### PR TITLE
feat(app-blocks): W13 P1 — AppListing asset pipeline

### DIFF
--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -1,0 +1,117 @@
+import { TRPCError } from '@trpc/server';
+
+import {
+  addListingScreenshotSchema,
+  backfillListingAssetsSchema,
+  listingAssetsQuerySchema,
+  removeListingScreenshotSchema,
+  reorderListingScreenshotsSchema,
+  setListingCoverSchema,
+  setListingIconSchema,
+  updateListingScreenshotCaptionSchema,
+} from '~/server/schema/blocks/app-listing.schema';
+import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { middleware, moderatorProcedure, protectedProcedure, router } from '~/server/trpc';
+import { throwAuthorizationError } from '~/server/utils/errorHandling';
+
+/**
+ * App Store Listings (W13) — P1 asset pipeline router (NEW router, locked
+ * decision §5.1 — NOT an extension of `blocks.router`). All procs are DARK and
+ * additive: owner-scoped (mod override) creator asset management + a mod-only
+ * placeholder backfill. Nothing here is on a public read path (that is P2) or a
+ * live approval gate (P3).
+ *
+ * Flag gate: reuses the mod-segmented `app-blocks-enabled` flag (evaluated WITH
+ * the request user's context, like blocks.router's `enforceAppBlocksFlag`), so
+ * P1 ships dark-to-non-mods and immediately usable by the civitai team. A
+ * dedicated `app-listings-enabled` flag lands with the P2 read path when there
+ * is a user-facing surface to widen independently.
+ */
+const enforceAppBlocksFlag = middleware(async ({ ctx, next }) => {
+  if (await isAppBlocksEnabled({ user: ctx.user })) return next();
+  throw new TRPCError({ code: 'UNAUTHORIZED', message: 'App Blocks not enabled' });
+});
+
+export const appListingsRouter = router({
+  /** Owner/mod read of a listing's current assets (creator dashboard). */
+  getAssets: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(listingAssetsQuerySchema)
+    .query(async ({ ctx, input }) => {
+      const { getListingAssets } = await import('~/server/services/blocks/app-listing-assets.service');
+      return getListingAssets({ listingId: input.listingId }, ctx.user);
+    }),
+
+  setIcon: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(setListingIconSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { setListingIcon } = await import('~/server/services/blocks/app-listing-assets.service');
+      return setListingIcon(input, ctx.user);
+    }),
+
+  setCover: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(setListingCoverSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { setListingCover } = await import('~/server/services/blocks/app-listing-assets.service');
+      return setListingCover(input, ctx.user);
+    }),
+
+  addScreenshot: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(addListingScreenshotSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { addListingScreenshot } = await import(
+        '~/server/services/blocks/app-listing-assets.service'
+      );
+      return addListingScreenshot(input, ctx.user);
+    }),
+
+  reorderScreenshots: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(reorderListingScreenshotsSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { reorderListingScreenshots } = await import(
+        '~/server/services/blocks/app-listing-assets.service'
+      );
+      return reorderListingScreenshots(input, ctx.user);
+    }),
+
+  updateScreenshotCaption: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(updateListingScreenshotCaptionSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { updateListingScreenshotCaption } = await import(
+        '~/server/services/blocks/app-listing-assets.service'
+      );
+      return updateListingScreenshotCaption(input, ctx.user);
+    }),
+
+  removeScreenshot: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(removeListingScreenshotSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { removeListingScreenshot } = await import(
+        '~/server/services/blocks/app-listing-assets.service'
+      );
+      return removeListingScreenshot(input, ctx.user);
+    }),
+
+  /**
+   * Mod-only placeholder backfill for approved listings missing assets.
+   * Idempotent + dark + per-row isolated; `dryRun` previews without writing.
+   */
+  backfillAssets: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(backfillListingAssetsSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Listing asset backfill is restricted to civitai team');
+      }
+      const { backfillListingAssets } = await import(
+        '~/server/services/blocks/app-listing-assets.service'
+      );
+      return backfillListingAssets({ limit: input.limit, dryRun: input.dryRun });
+    }),
+});

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -7,6 +7,9 @@ import { router } from '~/server/trpc';
 export const appRouter = router({
   blocks: lazy(() => import('~/server/routers/blocks.router').then((m) => m.blocksRouter)),
   apps: lazy(() => import('~/server/routers/apps.router').then((m) => m.appsRouter)),
+  appListings: lazy(() =>
+    import('~/server/routers/app-listings.router').then((m) => m.appListingsRouter)
+  ),
   account: lazy(() => import('./account.router').then((m) => m.accountRouter)),
   announcement: lazy(() => import('./announcement.router').then((m) => m.announcementRouter)),
   answer: lazy(() => import('./answer.router').then((m) => m.answerRouter)),

--- a/src/server/schema/blocks/app-listing.schema.ts
+++ b/src/server/schema/blocks/app-listing.schema.ts
@@ -1,0 +1,175 @@
+import * as z from 'zod';
+
+/**
+ * App Store Listings (W13) — P1 asset pipeline schemas + validation.
+ *
+ * The creator asset-management procs (`app-listings.router`) attach ALREADY-
+ * ingested `Image` rows (uploaded through the site's standard media path) to an
+ * `AppListing` as its icon / cover / ordered screenshots. Validation mirrors the
+ * App Blocks E5 bundle-screenshot caps (count/size/type — see
+ * `publish-request.schema.ts` MAX_SCREENSHOTS / MAX_SCREENSHOT_SIZE_BYTES /
+ * SCREENSHOT_EXTENSIONS) and ADDS per-kind aspect + minimum-dimension caps a
+ * store card/detail needs (square-ish icon, landscape cover).
+ *
+ * DARK / additive: nothing here is wired to a live read path or UI in P1. The
+ * procs are owner/mod-gated behind the App Blocks flag.
+ */
+
+/** At most this many screenshots per listing (mirrors E5 MAX_SCREENSHOTS). */
+export const MAX_LISTING_SCREENSHOTS = 8;
+
+/** Per-asset byte caps. Screenshots mirror the E5 2 MiB cap; icon tighter, cover looser. */
+export const MAX_LISTING_SCREENSHOT_SIZE_BYTES = 2 * 1024 * 1024; // 2 MiB
+export const MAX_LISTING_ICON_SIZE_BYTES = 1 * 1024 * 1024; // 1 MiB
+export const MAX_LISTING_COVER_SIZE_BYTES = 4 * 1024 * 1024; // 4 MiB
+
+/**
+ * Aspect (= width / height) + minimum-dimension caps per asset kind:
+ *   - icon    — square-ish (a store avatar). Rejects wildly non-square images.
+ *   - cover   — landscape hero (roughly 4:3 → 21:9).
+ *   - screenshot — a real screen capture in either orientation, loosely bounded.
+ */
+export const LISTING_ICON_ASPECT_MIN = 0.9;
+export const LISTING_ICON_ASPECT_MAX = 1.1;
+export const LISTING_ICON_MIN_PX = 128;
+export const LISTING_ICON_MAX_PX = 4096;
+
+export const LISTING_COVER_ASPECT_MIN = 1.3; // ~4:3
+export const LISTING_COVER_ASPECT_MAX = 2.4; // ~21:9
+export const LISTING_COVER_MIN_WIDTH_PX = 640;
+
+export const LISTING_SCREENSHOT_ASPECT_MIN = 0.4;
+export const LISTING_SCREENSHOT_ASPECT_MAX = 2.6;
+export const LISTING_SCREENSHOT_MIN_PX = 320;
+
+/** Only real raster image MIME types (mirrors E5 SCREENSHOT_EXTENSIONS). */
+export const LISTING_ASSET_ALLOWED_MIME = ['image/png', 'image/jpeg', 'image/webp'] as const;
+
+/** Max caption length (a one-line gallery caption, not markdown). */
+export const LISTING_SCREENSHOT_CAPTION_MAX = 280;
+
+export type ListingAssetKind = 'icon' | 'cover' | 'screenshot';
+
+/** The subset of an `Image` row the validator inspects (kept pure + DB-free). */
+export type ListingImageMeta = {
+  /** MediaType — must be `image` (a video/audio asset is rejected). */
+  type: string;
+  width: number | null | undefined;
+  height: number | null | undefined;
+  /** Byte size (from `Image.metadata.size`) when known; unbounded when absent. */
+  sizeBytes?: number | null;
+  /** MIME type (from `Image.mimeType`) when known; unconstrained when absent. */
+  mimeType?: string | null;
+};
+
+export type ValidateListingImageResult = { ok: true } | { ok: false; reason: string };
+
+const KIND_SIZE_CAP: Record<ListingAssetKind, number> = {
+  icon: MAX_LISTING_ICON_SIZE_BYTES,
+  cover: MAX_LISTING_COVER_SIZE_BYTES,
+  screenshot: MAX_LISTING_SCREENSHOT_SIZE_BYTES,
+};
+
+/**
+ * Pure per-asset validation: a candidate `Image` must be a raster image of an
+ * accepted MIME type, within the byte cap, with known positive dimensions that
+ * satisfy the per-kind aspect + minimum-dimension bounds. Returns a structured
+ * result (the caller maps `!ok` → a 400) rather than throwing so it's trivially
+ * unit-testable. Size/MIME checks are SKIPPED only when the field is absent
+ * (an older Image row may not carry `metadata.size` / `mimeType`) — never faked.
+ */
+export function validateListingImage(
+  meta: ListingImageMeta,
+  kind: ListingAssetKind
+): ValidateListingImageResult {
+  if (meta.type !== 'image') {
+    return { ok: false, reason: `asset must be an image (got type "${meta.type}")` };
+  }
+  if (meta.mimeType != null && !LISTING_ASSET_ALLOWED_MIME.includes(meta.mimeType as never)) {
+    return {
+      ok: false,
+      reason: `unsupported image type "${meta.mimeType}" (allowed: ${LISTING_ASSET_ALLOWED_MIME.join(', ')})`,
+    };
+  }
+  const cap = KIND_SIZE_CAP[kind];
+  if (meta.sizeBytes != null && meta.sizeBytes > cap) {
+    return { ok: false, reason: `${kind} is ${meta.sizeBytes} bytes (max ${cap})` };
+  }
+  const { width, height } = meta;
+  if (!width || !height || width <= 0 || height <= 0) {
+    return { ok: false, reason: `${kind} has unknown or non-positive dimensions` };
+  }
+  const aspect = width / height;
+  if (kind === 'icon') {
+    const minSide = Math.min(width, height);
+    const maxSide = Math.max(width, height);
+    if (aspect < LISTING_ICON_ASPECT_MIN || aspect > LISTING_ICON_ASPECT_MAX) {
+      return { ok: false, reason: `icon must be square-ish (aspect ${aspect.toFixed(2)} outside ${LISTING_ICON_ASPECT_MIN}–${LISTING_ICON_ASPECT_MAX})` };
+    }
+    if (minSide < LISTING_ICON_MIN_PX) {
+      return { ok: false, reason: `icon must be at least ${LISTING_ICON_MIN_PX}px on its shorter side (got ${minSide}px)` };
+    }
+    if (maxSide > LISTING_ICON_MAX_PX) {
+      return { ok: false, reason: `icon must be at most ${LISTING_ICON_MAX_PX}px on its longer side (got ${maxSide}px)` };
+    }
+  } else if (kind === 'cover') {
+    if (aspect < LISTING_COVER_ASPECT_MIN || aspect > LISTING_COVER_ASPECT_MAX) {
+      return { ok: false, reason: `cover must be landscape (aspect ${aspect.toFixed(2)} outside ${LISTING_COVER_ASPECT_MIN}–${LISTING_COVER_ASPECT_MAX})` };
+    }
+    if (width < LISTING_COVER_MIN_WIDTH_PX) {
+      return { ok: false, reason: `cover must be at least ${LISTING_COVER_MIN_WIDTH_PX}px wide (got ${width}px)` };
+    }
+  } else {
+    if (aspect < LISTING_SCREENSHOT_ASPECT_MIN || aspect > LISTING_SCREENSHOT_ASPECT_MAX) {
+      return { ok: false, reason: `screenshot aspect ${aspect.toFixed(2)} is outside ${LISTING_SCREENSHOT_ASPECT_MIN}–${LISTING_SCREENSHOT_ASPECT_MAX}` };
+    }
+    if (Math.min(width, height) < LISTING_SCREENSHOT_MIN_PX) {
+      return { ok: false, reason: `screenshot must be at least ${LISTING_SCREENSHOT_MIN_PX}px on its shorter side` };
+    }
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// tRPC input schemas (owner/mod-gated creator asset management).
+// ---------------------------------------------------------------------------
+
+const listingId = z.string().min(1).max(64);
+const imageId = z.number().int().positive();
+const caption = z.string().max(LISTING_SCREENSHOT_CAPTION_MAX).nullish();
+
+export const listingAssetsQuerySchema = z.object({ listingId });
+export type ListingAssetsQueryInput = z.infer<typeof listingAssetsQuerySchema>;
+
+export const setListingIconSchema = z.object({ listingId, imageId });
+export type SetListingIconInput = z.infer<typeof setListingIconSchema>;
+
+export const setListingCoverSchema = z.object({ listingId, imageId });
+export type SetListingCoverInput = z.infer<typeof setListingCoverSchema>;
+
+export const addListingScreenshotSchema = z.object({ listingId, imageId, caption });
+export type AddListingScreenshotInput = z.infer<typeof addListingScreenshotSchema>;
+
+export const reorderListingScreenshotsSchema = z.object({
+  listingId,
+  // The full set of the listing's screenshot ids in the desired order.
+  orderedIds: z.array(z.string().min(1).max(64)).min(1).max(MAX_LISTING_SCREENSHOTS),
+});
+export type ReorderListingScreenshotsInput = z.infer<typeof reorderListingScreenshotsSchema>;
+
+export const updateListingScreenshotCaptionSchema = z.object({
+  screenshotId: z.string().min(1).max(64),
+  caption,
+});
+export type UpdateListingScreenshotCaptionInput = z.infer<
+  typeof updateListingScreenshotCaptionSchema
+>;
+
+export const removeListingScreenshotSchema = z.object({ screenshotId: z.string().min(1).max(64) });
+export type RemoveListingScreenshotInput = z.infer<typeof removeListingScreenshotSchema>;
+
+export const backfillListingAssetsSchema = z.object({
+  limit: z.number().int().min(1).max(1000).optional(),
+  dryRun: z.boolean().optional(),
+});
+export type BackfillListingAssetsInput = z.infer<typeof backfillListingAssetsSchema>;

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -1,0 +1,543 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  validateListingImage,
+  type ListingImageMeta,
+} from '~/server/schema/blocks/app-listing.schema';
+
+/**
+ * App Store Listings (W13 P1) — asset pipeline service tests.
+ *
+ * Covers: per-asset validation (type/size/aspect/count), the mandatory-asset
+ * gate, the screenshot CRUD (cap/reorder/caption/remove re-pack), and the
+ * placeholder backfill orchestration (migrate vs autogen vs placeholder,
+ * cover=first-screenshot, icon generation, idempotency, no-clobber, dryRun,
+ * per-row failed[] isolation). All DB/network/native deps are mocked or injected
+ * — no real Prisma/S3/sharp/verify-runner.
+ */
+
+const { mockDb, ids } = vi.hoisted(() => ({
+  mockDb: {
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      update: vi.fn(async (args: { data: unknown }) => ({ ...(args as object) })),
+    },
+    image: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+    appListingScreenshot: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      count: vi.fn(async (..._a: unknown[]): Promise<number> => 0),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+      createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+      update: vi.fn(async (args: { where: unknown; data: unknown }) => args.data),
+      delete: vi.fn(async (..._a: unknown[]) => ({})),
+    },
+    $transaction: vi.fn(async (ops: unknown[]) => Promise.all(ops as Promise<unknown>[])),
+  },
+  ids: { n: 0 },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingScreenshotId: () => `apls_test_${++ids.n}`,
+}));
+
+const owner = { id: 42, isModerator: false } as never;
+const otherUser = { id: 99, isModerator: false } as never;
+const mod = { id: 7, isModerator: true } as never;
+
+function resetDb() {
+  ids.n = 0;
+  mockDb.appListing.findUnique.mockReset().mockResolvedValue(null);
+  mockDb.appListing.findMany.mockReset().mockResolvedValue([]);
+  mockDb.appListing.update.mockReset().mockResolvedValue({});
+  mockDb.image.findUnique.mockReset().mockResolvedValue(null);
+  mockDb.appListingScreenshot.findUnique.mockReset().mockResolvedValue(null);
+  mockDb.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
+  mockDb.appListingScreenshot.count.mockReset().mockResolvedValue(0);
+  mockDb.appListingScreenshot.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+  mockDb.appListingScreenshot.createMany.mockReset().mockResolvedValue({ count: 0 });
+  mockDb.appListingScreenshot.update.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+  mockDb.appListingScreenshot.delete.mockReset().mockResolvedValue({});
+  mockDb.$transaction.mockReset().mockImplementation(async (ops: unknown[]) => Promise.all(ops as Promise<unknown>[]));
+}
+
+// ---------------------------------------------------------------------------
+// validateListingImage
+// ---------------------------------------------------------------------------
+
+describe('validateListingImage', () => {
+  const base: ListingImageMeta = { type: 'image', width: 512, height: 512, mimeType: 'image/png', sizeBytes: 100_000 };
+
+  it('accepts a square png icon', () => {
+    expect(validateListingImage(base, 'icon').ok).toBe(true);
+  });
+
+  it('rejects a non-image (video) asset for every kind', () => {
+    const video = { ...base, type: 'video' };
+    for (const kind of ['icon', 'cover', 'screenshot'] as const) {
+      const r = validateListingImage(video, kind);
+      expect(r.ok).toBe(false);
+    }
+  });
+
+  it('rejects an unsupported mime type', () => {
+    const r = validateListingImage({ ...base, mimeType: 'image/gif' }, 'icon');
+    expect(r).toEqual({ ok: false, reason: expect.stringContaining('unsupported image type') });
+  });
+
+  it('rejects an oversized icon (size cap)', () => {
+    const r = validateListingImage({ ...base, sizeBytes: 5 * 1024 * 1024 }, 'icon');
+    expect(r).toEqual({ ok: false, reason: expect.stringContaining('bytes') });
+  });
+
+  it('rejects a non-square icon (aspect)', () => {
+    const r = validateListingImage({ ...base, width: 512, height: 256 }, 'icon');
+    expect(r.ok).toBe(false);
+  });
+
+  it('rejects a too-small icon (min dimension)', () => {
+    const r = validateListingImage({ ...base, width: 64, height: 64 }, 'icon');
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts a 16:9 landscape cover, rejects a portrait cover', () => {
+    expect(validateListingImage({ ...base, width: 1280, height: 720 }, 'cover').ok).toBe(true);
+    expect(validateListingImage({ ...base, width: 720, height: 1280 }, 'cover').ok).toBe(false);
+  });
+
+  it('rejects a cover narrower than the min width', () => {
+    const r = validateListingImage({ ...base, width: 480, height: 320 }, 'cover');
+    expect(r.ok).toBe(false);
+  });
+
+  it('accepts a normal screenshot, rejects a tiny one and a too-wide one', () => {
+    expect(validateListingImage({ ...base, width: 1280, height: 720 }, 'screenshot').ok).toBe(true);
+    expect(validateListingImage({ ...base, width: 200, height: 200 }, 'screenshot').ok).toBe(false);
+    expect(validateListingImage({ ...base, width: 2600, height: 400 }, 'screenshot').ok).toBe(false);
+  });
+
+  it('rejects unknown/zero dimensions', () => {
+    expect(validateListingImage({ ...base, width: null, height: null }, 'icon').ok).toBe(false);
+    expect(validateListingImage({ ...base, width: 0, height: 0 }, 'cover').ok).toBe(false);
+  });
+
+  it('skips size/mime checks when those fields are absent (older Image rows)', () => {
+    const r = validateListingImage({ type: 'image', width: 512, height: 512 }, 'icon');
+    expect(r.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mandatory-asset gate
+// ---------------------------------------------------------------------------
+
+describe('checkListingAssetsComplete / assertListingAssetsComplete', () => {
+  it('is complete only with icon AND cover AND >=1 screenshot', async () => {
+    const { checkListingAssetsComplete } = await import('../app-listing-assets.service');
+    expect(checkListingAssetsComplete({ iconId: 1, coverId: 2, screenshotCount: 3 })).toEqual({
+      complete: true,
+    });
+  });
+
+  it('reports every missing combination', async () => {
+    const { checkListingAssetsComplete } = await import('../app-listing-assets.service');
+    expect(checkListingAssetsComplete({ iconId: null, coverId: 2, screenshotCount: 1 })).toEqual({
+      complete: false,
+      missing: ['icon'],
+    });
+    expect(checkListingAssetsComplete({ iconId: 1, coverId: null, screenshotCount: 1 })).toEqual({
+      complete: false,
+      missing: ['cover'],
+    });
+    expect(checkListingAssetsComplete({ iconId: 1, coverId: 2, screenshotCount: 0 })).toEqual({
+      complete: false,
+      missing: ['screenshots'],
+    });
+    expect(checkListingAssetsComplete({ iconId: null, coverId: null, screenshotCount: 0 })).toEqual({
+      complete: false,
+      missing: ['icon', 'cover', 'screenshots'],
+    });
+  });
+
+  it('assert throws with the missing list, passes when complete', async () => {
+    const { assertListingAssetsComplete } = await import('../app-listing-assets.service');
+    expect(() => assertListingAssetsComplete({ iconId: null, coverId: null, screenshotCount: 0 })).toThrow(
+      /icon, cover, screenshots/
+    );
+    expect(() => assertListingAssetsComplete({ iconId: 1, coverId: 2, screenshotCount: 1 })).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pure helpers
+// ---------------------------------------------------------------------------
+
+describe('pure helpers', () => {
+  it('seededHue is deterministic + in range', async () => {
+    const { seededHue } = await import('../app-listing-assets.service');
+    expect(seededHue('cool-app')).toBe(seededHue('cool-app'));
+    expect(seededHue('cool-app')).toBeGreaterThanOrEqual(0);
+    expect(seededHue('cool-app')).toBeLessThan(360);
+    expect(seededHue('a')).not.toBe(seededHue('b'));
+  });
+
+  it('appInitial picks first alphanumeric, uppercased, falls back to slug/?', async () => {
+    const { appInitial } = await import('../app-listing-assets.service');
+    expect(appInitial('Cool App', 'slug')).toBe('C');
+    expect(appInitial('  ', 'slug')).toBe('S');
+    expect(appInitial('', '')).toBe('?');
+    expect(appInitial('123abc', 'x')).toBe('1');
+  });
+
+  it('pickLogoPrefillUrl normalises http(s), rejects otherwise', async () => {
+    const { pickLogoPrefillUrl } = await import('../app-listing-assets.service');
+    expect(pickLogoPrefillUrl('  https://ex.com/a.png ')).toBe('https://ex.com/a.png');
+    expect(pickLogoPrefillUrl('ftp://ex.com/a')).toBeNull();
+    expect(pickLogoPrefillUrl('javascript:alert(1)')).toBeNull();
+    expect(pickLogoPrefillUrl(null)).toBeNull();
+    expect(pickLogoPrefillUrl(undefined)).toBeNull();
+  });
+
+  it('SVG builders emit valid-looking svg with the initial + escaped name', async () => {
+    const { buildPlaceholderIconSvg, buildPlaceholderCoverSvg } = await import(
+      '../app-listing-assets.service'
+    );
+    const icon = buildPlaceholderIconSvg({ slug: 'cool-app', category: 'games', name: 'Cool App' });
+    expect(icon).toContain('<svg');
+    expect(icon).toContain('>C<');
+    const cover = buildPlaceholderCoverSvg({ slug: 'x', category: null, name: 'A & B <x>' });
+    expect(cover).toContain('<svg');
+    expect(cover).toContain('A &amp; B &lt;x&gt;');
+    expect(cover).not.toContain('<x>');
+  });
+
+  it('chooseScreenshotSource: existing → migrate → autogen → placeholder', async () => {
+    const { chooseScreenshotSource } = await import('../app-listing-assets.service');
+    const base = {
+      id: 'apl_1', kind: 'onsite', slug: 's', name: 'n', category: null, userId: 1,
+      iconId: null, coverId: null, appBlockId: 'ab_1', appBlockScreenshots: null,
+      screenshots: [] as { imageId: number | null; order: number }[],
+    };
+    expect(chooseScreenshotSource({ ...base, screenshots: [{ imageId: 5, order: 0 }] })).toEqual({
+      mode: 'existing',
+    });
+    expect(
+      chooseScreenshotSource({ ...base, appBlockScreenshots: [{ key: 'k1' }, { key: 'k2' }] })
+    ).toEqual({ mode: 'migrate', count: 2 });
+    expect(chooseScreenshotSource({ ...base, appBlockScreenshots: [] })).toEqual({ mode: 'autogen' });
+    expect(
+      chooseScreenshotSource({ ...base, kind: 'offsite', appBlockId: null })
+    ).toEqual({ mode: 'placeholder' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// creator asset management (mocked DB)
+// ---------------------------------------------------------------------------
+
+describe('screenshot CRUD', () => {
+  beforeEach(resetDb);
+
+  const listingRow = {
+    id: 'apl_1', kind: 'onsite', slug: 's', name: 'n', category: null, userId: 42,
+    iconId: null, coverId: null,
+  };
+  const validScreenshotImage = {
+    id: 500, userId: 42, type: 'image', width: 1280, height: 720, mimeType: 'image/png',
+    metadata: { size: 100_000 },
+  };
+
+  it('addScreenshot appends at the next order and enforces owner + validation', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(listingRow);
+    mockDb.image.findUnique.mockResolvedValue(validScreenshotImage);
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([{ order: 2 }]);
+    mockDb.appListingScreenshot.count.mockResolvedValue(3);
+    const { addListingScreenshot } = await import('../app-listing-assets.service');
+    const res = await addListingScreenshot({ listingId: 'apl_1', imageId: 500 }, owner);
+    expect(res.order).toBe(3);
+    expect(mockDb.appListingScreenshot.create).toHaveBeenCalledTimes(1);
+    const arg = (mockDb.appListingScreenshot.create.mock.calls[0][0] as { data: { order: number } }).data;
+    expect(arg.order).toBe(3);
+  });
+
+  it('addScreenshot rejects a non-owner non-mod', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(listingRow);
+    const { addListingScreenshot } = await import('../app-listing-assets.service');
+    await expect(addListingScreenshot({ listingId: 'apl_1', imageId: 500 }, otherUser)).rejects.toThrow(
+      /do not own/
+    );
+  });
+
+  it('addScreenshot enforces the ≤8 cap (rejects the 9th)', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(listingRow);
+    mockDb.image.findUnique.mockResolvedValue(validScreenshotImage);
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([{ order: 7 }]);
+    mockDb.appListingScreenshot.count.mockResolvedValue(8);
+    const { addListingScreenshot } = await import('../app-listing-assets.service');
+    await expect(addListingScreenshot({ listingId: 'apl_1', imageId: 500 }, owner)).rejects.toThrow(
+      /at most 8/
+    );
+    expect(mockDb.appListingScreenshot.create).not.toHaveBeenCalled();
+  });
+
+  it('addScreenshot rejects an invalid image (aspect) before writing', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(listingRow);
+    mockDb.image.findUnique.mockResolvedValue({ ...validScreenshotImage, width: 100, height: 100 });
+    const { addListingScreenshot } = await import('../app-listing-assets.service');
+    await expect(addListingScreenshot({ listingId: 'apl_1', imageId: 500 }, owner)).rejects.toThrow();
+    expect(mockDb.appListingScreenshot.create).not.toHaveBeenCalled();
+  });
+
+  it('setIcon rejects a non-square image and accepts a square one', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(listingRow);
+    const { setListingIcon } = await import('../app-listing-assets.service');
+    mockDb.image.findUnique.mockResolvedValue({ id: 9, userId: 42, type: 'image', width: 512, height: 200, mimeType: 'image/png', metadata: {} });
+    await expect(setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner)).rejects.toThrow();
+    mockDb.image.findUnique.mockResolvedValue({ id: 9, userId: 42, type: 'image', width: 512, height: 512, mimeType: 'image/png', metadata: {} });
+    const res = await setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner);
+    expect(res.iconId).toBe(9);
+    expect(mockDb.appListing.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { iconId: 9 } })
+    );
+  });
+
+  it('reorderScreenshots requires an exact permutation and writes contiguous orders', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(listingRow);
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+    const { reorderListingScreenshots } = await import('../app-listing-assets.service');
+    // Wrong set → reject.
+    await expect(
+      reorderListingScreenshots({ listingId: 'apl_1', orderedIds: ['a', 'b'] }, owner)
+    ).rejects.toThrow(/exactly/);
+    // Correct permutation → 3 contiguous updates.
+    const res = await reorderListingScreenshots(
+      { listingId: 'apl_1', orderedIds: ['c', 'a', 'b'] },
+      owner
+    );
+    expect(res.reordered).toBe(3);
+    expect(mockDb.appListingScreenshot.update).toHaveBeenCalledTimes(3);
+    const orders = mockDb.appListingScreenshot.update.mock.calls.map(
+      (c) => (c[0] as { where: { id: string }; data: { order: number } })
+    );
+    expect(orders.map((o) => [o.where.id, o.data.order])).toEqual([
+      ['c', 0],
+      ['a', 1],
+      ['b', 2],
+    ]);
+  });
+
+  it('updateScreenshotCaption enforces ownership via the parent listing', async () => {
+    mockDb.appListingScreenshot.findUnique.mockResolvedValue({
+      id: 'a', appListing: { userId: 42 },
+    });
+    const { updateListingScreenshotCaption } = await import('../app-listing-assets.service');
+    await updateListingScreenshotCaption({ screenshotId: 'a', caption: 'hi' }, owner);
+    expect(mockDb.appListingScreenshot.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'a' }, data: { caption: 'hi' } })
+    );
+    // non-owner rejected
+    await expect(
+      updateListingScreenshotCaption({ screenshotId: 'a', caption: 'x' }, otherUser)
+    ).rejects.toThrow(/do not own/);
+  });
+
+  it('removeScreenshot deletes then re-packs remaining orders contiguously', async () => {
+    mockDb.appListingScreenshot.findUnique.mockResolvedValue({
+      id: 'b', appListingId: 'apl_1', appListing: { userId: 42 },
+    });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([{ id: 'a' }, { id: 'c' }]);
+    const { removeListingScreenshot } = await import('../app-listing-assets.service');
+    const res = await removeListingScreenshot({ screenshotId: 'b' }, owner);
+    expect(res.removed).toBe('b');
+    expect(mockDb.appListingScreenshot.delete).toHaveBeenCalledWith({ where: { id: 'b' } });
+    const orders = mockDb.appListingScreenshot.update.mock.calls.map(
+      (c) => c[0] as { where: { id: string }; data: { order: number } }
+    );
+    expect(orders.map((o) => [o.where.id, o.data.order])).toEqual([
+      ['a', 0],
+      ['c', 1],
+    ]);
+  });
+
+  it('getAssets returns assets + a completeness verdict (mod override reads any listing)', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ ...listingRow, userId: 111, iconId: 1, coverId: 2 });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([
+      { id: 's1', imageId: 10, order: 0, caption: null },
+    ]);
+    const { getListingAssets } = await import('../app-listing-assets.service');
+    const res = await getListingAssets({ listingId: 'apl_1' }, mod);
+    expect(res.completeness).toEqual({ complete: true });
+    expect(res.screenshots).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// placeholder backfill (injected deps + mocked DB)
+// ---------------------------------------------------------------------------
+
+describe('backfillListingAssets', () => {
+  beforeEach(resetDb);
+
+  function makeDeps() {
+    return {
+      migrateBlockScreenshots: vi.fn(async () => [201, 202]),
+      autogenScreenshot: vi.fn(async () => 301 as number | null),
+      generatePlaceholderScreenshot: vi.fn(async () => 401),
+      generateIcon: vi.fn(async () => 501),
+    };
+  }
+
+  function row(over: Partial<Record<string, unknown>> = {}) {
+    return {
+      id: 'apl_x', kind: 'onsite', slug: 's', name: 'n', category: 'games', userId: 42,
+      iconId: null, coverId: null, appBlockId: 'ab_x',
+      appBlock: { screenshots: null }, screenshots: [],
+      ...over,
+    };
+  }
+
+  it('migrates AppBlock.screenshots → Image rows, sets cover=first, generates icon', async () => {
+    mockDb.appListing.findMany.mockResolvedValue([
+      row({ appBlock: { screenshots: [{ key: 'k1' }, { key: 'k2' }] } }),
+    ]);
+    const deps = makeDeps();
+    const { backfillListingAssets } = await import('../app-listing-assets.service');
+    const res = await backfillListingAssets({}, deps);
+
+    expect(deps.migrateBlockScreenshots).toHaveBeenCalledTimes(1);
+    expect(deps.autogenScreenshot).not.toHaveBeenCalled();
+    expect(deps.generatePlaceholderScreenshot).not.toHaveBeenCalled();
+    expect(deps.generateIcon).toHaveBeenCalledTimes(1);
+    expect(res.screenshotsCreated).toBe(2);
+    expect(res.bySource.migrated).toBe(2);
+    expect(res.coversSet).toBe(1);
+    expect(res.iconsCreated).toBe(1);
+    // createMany got the 2 migrated image ids in order.
+    const createManyArg = mockDb.appListingScreenshot.createMany.mock.calls[0][0] as {
+      data: { imageId: number; order: number }[];
+    };
+    expect(createManyArg.data.map((d) => [d.imageId, d.order])).toEqual([
+      [201, 0],
+      [202, 1],
+    ]);
+    // cover set to first migrated image.
+    expect(mockDb.appListing.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { coverId: 201 } })
+    );
+    expect(mockDb.appListing.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { iconId: 501 } })
+    );
+  });
+
+  it('falls back to verify-runner autogen when there are no bundle screenshots', async () => {
+    mockDb.appListing.findMany.mockResolvedValue([row({ appBlock: { screenshots: [] } })]);
+    const deps = makeDeps();
+    const { backfillListingAssets } = await import('../app-listing-assets.service');
+    const res = await backfillListingAssets({}, deps);
+    expect(deps.autogenScreenshot).toHaveBeenCalledTimes(1);
+    expect(deps.generatePlaceholderScreenshot).not.toHaveBeenCalled();
+    expect(res.bySource.autogen).toBe(1);
+    expect(res.screenshotsCreated).toBe(1);
+  });
+
+  it('falls back to an SVG placeholder when autogen returns null', async () => {
+    mockDb.appListing.findMany.mockResolvedValue([row({ appBlock: { screenshots: [] } })]);
+    const deps = makeDeps();
+    deps.autogenScreenshot.mockResolvedValue(null);
+    const { backfillListingAssets } = await import('../app-listing-assets.service');
+    const res = await backfillListingAssets({}, deps);
+    expect(deps.generatePlaceholderScreenshot).toHaveBeenCalledTimes(1);
+    expect(res.bySource.placeholder).toBe(1);
+    expect(res.coversSet).toBe(1); // cover = the placeholder screenshot image
+  });
+
+  it('off-site listing (no appBlock) uses an SVG placeholder screenshot', async () => {
+    mockDb.appListing.findMany.mockResolvedValue([
+      row({ kind: 'offsite', appBlockId: null, appBlock: null }),
+    ]);
+    const deps = makeDeps();
+    const { backfillListingAssets } = await import('../app-listing-assets.service');
+    const res = await backfillListingAssets({}, deps);
+    expect(deps.migrateBlockScreenshots).not.toHaveBeenCalled();
+    expect(deps.autogenScreenshot).not.toHaveBeenCalled();
+    expect(deps.generatePlaceholderScreenshot).toHaveBeenCalledTimes(1);
+    expect(res.bySource.placeholder).toBe(1);
+  });
+
+  it('is idempotent — an already-complete listing is skipped, no deps called', async () => {
+    mockDb.appListing.findMany.mockResolvedValue([
+      row({ iconId: 1, coverId: 2, screenshots: [{ imageId: 10, order: 0 }] }),
+    ]);
+    const deps = makeDeps();
+    const { backfillListingAssets } = await import('../app-listing-assets.service');
+    const res = await backfillListingAssets({}, deps);
+    expect(res.skippedComplete).toBe(1);
+    expect(res.processed).toBe(0);
+    expect(deps.generateIcon).not.toHaveBeenCalled();
+    expect(mockDb.appListingScreenshot.createMany).not.toHaveBeenCalled();
+  });
+
+  it('does not clobber creator assets — only fills the missing ones', async () => {
+    // Has an icon + screenshots already, but no cover. Only the cover is filled.
+    mockDb.appListing.findMany.mockResolvedValue([
+      row({ iconId: 77, coverId: null, screenshots: [{ imageId: 88, order: 0 }] }),
+    ]);
+    const deps = makeDeps();
+    const { backfillListingAssets } = await import('../app-listing-assets.service');
+    const res = await backfillListingAssets({}, deps);
+    expect(deps.generateIcon).not.toHaveBeenCalled(); // icon untouched
+    expect(mockDb.appListingScreenshot.createMany).not.toHaveBeenCalled(); // screenshots untouched
+    expect(res.coversSet).toBe(1);
+    expect(mockDb.appListing.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { coverId: 88 } }) // cover = existing first screenshot
+    );
+    expect(res.iconsCreated).toBe(0);
+  });
+
+  it('dryRun computes counts and writes nothing / calls no deps', async () => {
+    mockDb.appListing.findMany.mockResolvedValue([
+      row({ appBlock: { screenshots: [{ key: 'k1' }] } }),
+    ]);
+    const deps = makeDeps();
+    const { backfillListingAssets } = await import('../app-listing-assets.service');
+    const res = await backfillListingAssets({ dryRun: true }, deps);
+    expect(res.dryRun).toBe(true);
+    expect(res.processed).toBe(1);
+    expect(res.screenshotsCreated).toBe(1);
+    expect(res.iconsCreated).toBe(1);
+    expect(res.coversSet).toBe(1);
+    expect(deps.migrateBlockScreenshots).not.toHaveBeenCalled();
+    expect(deps.generateIcon).not.toHaveBeenCalled();
+    expect(mockDb.appListingScreenshot.createMany).not.toHaveBeenCalled();
+    expect(mockDb.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('isolates a per-row failure into failed[] and continues the batch', async () => {
+    mockDb.appListing.findMany.mockResolvedValue([
+      row({ id: 'apl_bad', appBlock: { screenshots: [] } }),
+      row({ id: 'apl_ok', appBlock: { screenshots: [] } }),
+    ]);
+    const deps = makeDeps();
+    // First listing's autogen throws; second succeeds.
+    deps.autogenScreenshot
+      .mockRejectedValueOnce(new Error('runner exploded'))
+      .mockResolvedValue(301);
+    const { backfillListingAssets } = await import('../app-listing-assets.service');
+    const res = await backfillListingAssets({}, deps);
+    expect(res.failed).toEqual([{ listingId: 'apl_bad', error: 'runner exploded' }]);
+    expect(res.processed).toBe(1); // the second row still processed
+  });
+
+  it('forwards limit as take to findMany', async () => {
+    mockDb.appListing.findMany.mockResolvedValue([]);
+    const { backfillListingAssets } = await import('../app-listing-assets.service');
+    await backfillListingAssets({ limit: 5 }, makeDeps());
+    const arg = mockDb.appListing.findMany.mock.calls[0][0] as { take?: number; where: unknown };
+    expect(arg.take).toBe(5);
+    expect(arg.where).toEqual({ status: 'approved' });
+  });
+});

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -1,0 +1,915 @@
+import { TRPCError } from '@trpc/server';
+import { randomUUID } from 'crypto';
+
+import { dbRead, dbWrite } from '~/server/db/client';
+import { newAppListingScreenshotId } from '~/server/utils/app-block-ids';
+import {
+  MAX_LISTING_SCREENSHOTS,
+  validateListingImage,
+  type ListingAssetKind,
+} from '~/server/schema/blocks/app-listing.schema';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * App Store Listings (W13) — P1 asset pipeline service.
+ *
+ * Two halves, both DARK/additive (no live read path or UI in P1):
+ *
+ *   1. Creator asset management (owner/mod-gated): attach ALREADY-ingested
+ *      `Image` rows (uploaded via the site's standard media path) to an
+ *      `AppListing` as icon / cover / ordered screenshots, with per-kind
+ *      validation (see app-listing.schema `validateListingImage`) and a
+ *      contiguously-maintained `order` column + the ≤8 screenshot cap.
+ *
+ *   2. Mod-only placeholder backfill: for approved listings missing assets,
+ *      populate REAL stored `Image` rows so the mandatory-asset gate
+ *      (`assertListingAssetsComplete`) passes universally (locked decision §6.1
+ *      "auto-generate placeholders — no grandfather branch"). Screenshots prefer
+ *      migrating the backing `AppBlock.screenshots` (bundle MinIO) → Image rows,
+ *      else verify-runner autogen, else an SVG placeholder; cover = the first
+ *      screenshot's Image; icon = a deterministic category-glyph SVG→PNG.
+ *
+ * The gate helper is defined + exported here but NOT wired into any live approval
+ * path in P1 (that is P3) — it is pure and unit-tested only.
+ */
+
+// ---------------------------------------------------------------------------
+// Mandatory-asset gate (pure — defined + tested in P1, wired to approve in P3).
+// ---------------------------------------------------------------------------
+
+export type ListingAssetCompleteness = {
+  iconId: number | null;
+  coverId: number | null;
+  screenshotCount: number;
+};
+
+export type MissingAsset = 'icon' | 'cover' | 'screenshots';
+
+export type ListingAssetsCompleteResult =
+  | { complete: true }
+  | { complete: false; missing: MissingAsset[] };
+
+/**
+ * Pure completeness check: a listing is asset-complete when it has an icon AND a
+ * cover AND at least one screenshot. Returns the structured set of what's
+ * missing (never throws) so a caller can build a precise error. This is the gate
+ * P3 will enforce at approve; in P1 it is dark (exported + tested only).
+ */
+export function checkListingAssetsComplete(
+  listing: ListingAssetCompleteness
+): ListingAssetsCompleteResult {
+  const missing: MissingAsset[] = [];
+  if (listing.iconId == null) missing.push('icon');
+  if (listing.coverId == null) missing.push('cover');
+  if (!(listing.screenshotCount > 0)) missing.push('screenshots');
+  return missing.length === 0 ? { complete: true } : { complete: false, missing };
+}
+
+/**
+ * Throwing wrapper around {@link checkListingAssetsComplete} for the future
+ * approve gate. NOT called on any live path in P1.
+ */
+export function assertListingAssetsComplete(listing: ListingAssetCompleteness): void {
+  const result = checkListingAssetsComplete(listing);
+  if (!result.complete) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Listing is missing required assets: ${result.missing.join(', ')}`,
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Off-site icon prefill helper (tiny pure helper; the off-site CREATION flow is
+// P3 — this only normalises an OauthClient.logoUrl into a usable http(s) URL).
+// ---------------------------------------------------------------------------
+
+/**
+ * Pick a usable icon-prefill URL from an off-site app's `OauthClient.logoUrl`.
+ * Returns the trimmed https/http URL or null (a dev can replace it later). Pure;
+ * the actual ingest of the URL into an Image lands with the P3 off-site flow.
+ */
+export function pickLogoPrefillUrl(logoUrl: string | null | undefined): string | null {
+  if (typeof logoUrl !== 'string') return null;
+  const trimmed = logoUrl.trim();
+  if (!/^https?:\/\//i.test(trimmed)) return null;
+  return trimmed;
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic SVG placeholder builders (pure — unit-tested; rasterised to PNG
+// by the impure default deps below via sharp).
+// ---------------------------------------------------------------------------
+
+/** Category → glyph letter/emoji-free monogram seed (kept ASCII for the SVG). */
+const CATEGORY_GLYPH: Record<string, string> = {
+  generation: '✦',
+  games: '◆',
+  utility: '⚙',
+  discovery: '◈',
+  moderation: '⛨',
+  analytics: '▤',
+  other: '●',
+};
+
+/** FNV-1a → a stable 0..359 hue from a seed string (deterministic per slug). */
+export function seededHue(seed: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return Math.abs(h) % 360;
+}
+
+/** The app's display initial (first alphanumeric of name, else slug), uppercased. */
+export function appInitial(name: string, slug: string): string {
+  // A whitespace-only name must fall through to the slug (not resolve to '?').
+  const src = (name?.trim() || slug?.trim() || '?').trim();
+  const m = src.match(/[A-Za-z0-9]/);
+  return (m ? m[0] : '?').toUpperCase();
+}
+
+function gradientDefs(seed: string): { hue: number; hue2: number } {
+  const hue = seededHue(seed);
+  const hue2 = (hue + 40) % 360;
+  return { hue, hue2 };
+}
+
+/** Escape the few chars that are unsafe inside SVG text content. */
+function svgEscape(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Deterministic square icon SVG: a diagonal gradient (hue seeded by slug/
+ * category) with the app's initial centered. Mirrors the marketplace coverless-
+ * card look (gradient + glyph) so generated + real assets feel consistent.
+ */
+export function buildPlaceholderIconSvg(args: {
+  slug: string;
+  category: string | null;
+  name: string;
+  size?: number;
+}): string {
+  const size = args.size ?? 512;
+  const seed = `${args.category ?? 'other'}:${args.slug}`;
+  const { hue, hue2 } = gradientDefs(seed);
+  const initial = svgEscape(appInitial(args.name, args.slug));
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">`,
+    `<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">`,
+    `<stop offset="0%" stop-color="hsl(${hue} 55% 42%)"/>`,
+    `<stop offset="100%" stop-color="hsl(${hue2} 60% 22%)"/>`,
+    `</linearGradient></defs>`,
+    `<rect width="${size}" height="${size}" rx="${Math.round(size * 0.18)}" fill="url(#g)"/>`,
+    `<text x="50%" y="50%" dy="0.35em" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-weight="700" font-size="${Math.round(size * 0.5)}" fill="#ffffff" fill-opacity="0.92">${initial}</text>`,
+    `</svg>`,
+  ].join('');
+}
+
+/**
+ * Deterministic landscape cover/screenshot SVG placeholder: same seeded gradient
+ * with a category glyph + the app name. Used as the cover/screenshot fallback
+ * when no real screenshot can be produced (off-site rows, autogen failures).
+ */
+export function buildPlaceholderCoverSvg(args: {
+  slug: string;
+  category: string | null;
+  name: string;
+  width?: number;
+  height?: number;
+}): string {
+  const width = args.width ?? 1280;
+  const height = args.height ?? 720;
+  const seed = `${args.category ?? 'other'}:${args.slug}`;
+  const { hue, hue2 } = gradientDefs(seed);
+  const glyph = svgEscape(CATEGORY_GLYPH[args.category ?? 'other'] ?? CATEGORY_GLYPH.other);
+  const name = svgEscape((args.name || args.slug).slice(0, 48));
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
+    `<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">`,
+    `<stop offset="0%" stop-color="hsl(${hue} 45% 32%)"/>`,
+    `<stop offset="100%" stop-color="hsl(${hue2} 50% 16%)"/>`,
+    `</linearGradient></defs>`,
+    `<rect width="${width}" height="${height}" fill="url(#g)"/>`,
+    `<text x="50%" y="44%" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="${Math.round(height * 0.22)}" fill="#ffffff" fill-opacity="0.85">${glyph}</text>`,
+    `<text x="50%" y="66%" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-weight="600" font-size="${Math.round(height * 0.07)}" fill="#ffffff" fill-opacity="0.9">${name}</text>`,
+    `</svg>`,
+  ].join('');
+}
+
+// ---------------------------------------------------------------------------
+// Owner/mod authorization helpers.
+// ---------------------------------------------------------------------------
+
+type OwnedListing = {
+  id: string;
+  kind: string;
+  slug: string;
+  name: string;
+  category: string | null;
+  userId: number;
+  iconId: number | null;
+  coverId: number | null;
+};
+
+/**
+ * Load a listing and assert the caller owns it (or is a moderator). Throws
+ * NOT_FOUND for a missing listing, FORBIDDEN for a non-owner non-mod.
+ */
+async function loadOwnedListing(listingId: string, user: SessionUser): Promise<OwnedListing> {
+  const listing = await dbRead.appListing.findUnique({
+    where: { id: listingId },
+    select: {
+      id: true,
+      kind: true,
+      slug: true,
+      name: true,
+      category: true,
+      userId: true,
+      iconId: true,
+      coverId: true,
+    },
+  });
+  if (!listing) throw new TRPCError({ code: 'NOT_FOUND', message: 'Listing not found' });
+  if (listing.userId !== user.id && !user.isModerator) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
+  }
+  return listing;
+}
+
+/**
+ * Load an Image, assert the caller owns it (or is a mod), and validate it for
+ * the given asset kind. Returns the imageId once validated.
+ */
+async function loadValidatedImage(
+  imageId: number,
+  kind: ListingAssetKind,
+  user: SessionUser
+): Promise<number> {
+  const image = await dbRead.image.findUnique({
+    where: { id: imageId },
+    select: { id: true, userId: true, type: true, width: true, height: true, mimeType: true, metadata: true },
+  });
+  if (!image) throw new TRPCError({ code: 'NOT_FOUND', message: 'Image not found' });
+  if (image.userId !== user.id && !user.isModerator) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this image' });
+  }
+  const size = (image.metadata as { size?: unknown } | null)?.size;
+  const result = validateListingImage(
+    {
+      type: image.type,
+      width: image.width,
+      height: image.height,
+      mimeType: image.mimeType,
+      sizeBytes: typeof size === 'number' ? size : null,
+    },
+    kind
+  );
+  if (!result.ok) throw new TRPCError({ code: 'BAD_REQUEST', message: result.reason });
+  return image.id;
+}
+
+// ---------------------------------------------------------------------------
+// Creator asset management (owner/mod-gated).
+// ---------------------------------------------------------------------------
+
+export async function setListingIcon(
+  args: { listingId: string; imageId: number },
+  user: SessionUser
+): Promise<{ iconId: number }> {
+  await loadOwnedListing(args.listingId, user);
+  const iconId = await loadValidatedImage(args.imageId, 'icon', user);
+  await dbWrite.appListing.update({ where: { id: args.listingId }, data: { iconId } });
+  return { iconId };
+}
+
+export async function setListingCover(
+  args: { listingId: string; imageId: number },
+  user: SessionUser
+): Promise<{ coverId: number }> {
+  await loadOwnedListing(args.listingId, user);
+  const coverId = await loadValidatedImage(args.imageId, 'cover', user);
+  await dbWrite.appListing.update({ where: { id: args.listingId }, data: { coverId } });
+  return { coverId };
+}
+
+export async function addListingScreenshot(
+  args: { listingId: string; imageId: number; caption?: string | null },
+  user: SessionUser
+): Promise<{ id: string; order: number }> {
+  await loadOwnedListing(args.listingId, user);
+  const imageId = await loadValidatedImage(args.imageId, 'screenshot', user);
+
+  // COUNT cap — reject the (N+1)th (mirrors E5 MAX_SCREENSHOTS "reject, not truncate").
+  const existing = await dbRead.appListingScreenshot.findMany({
+    where: { appListingId: args.listingId },
+    select: { order: true },
+    orderBy: { order: 'desc' },
+    take: 1,
+  });
+  const count = await dbRead.appListingScreenshot.count({
+    where: { appListingId: args.listingId },
+  });
+  if (count >= MAX_LISTING_SCREENSHOTS) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `A listing may have at most ${MAX_LISTING_SCREENSHOTS} screenshots`,
+    });
+  }
+  const nextOrder = existing.length > 0 ? existing[0].order + 1 : 0;
+  const id = newAppListingScreenshotId();
+  await dbWrite.appListingScreenshot.create({
+    data: {
+      id,
+      appListingId: args.listingId,
+      imageId,
+      order: nextOrder,
+      caption: args.caption ?? null,
+    },
+  });
+  return { id, order: nextOrder };
+}
+
+/**
+ * Reorder a listing's screenshots. `orderedIds` MUST be exactly the current set
+ * of screenshot ids (a permutation) — otherwise BAD_REQUEST. Writes contiguous
+ * 0..n-1 orders in a single transaction.
+ */
+export async function reorderListingScreenshots(
+  args: { listingId: string; orderedIds: string[] },
+  user: SessionUser
+): Promise<{ reordered: number }> {
+  await loadOwnedListing(args.listingId, user);
+  const current = await dbRead.appListingScreenshot.findMany({
+    where: { appListingId: args.listingId },
+    select: { id: true },
+  });
+  const currentIds = new Set(current.map((s) => s.id));
+  const nextIds = new Set(args.orderedIds);
+  const samePermutation =
+    currentIds.size === nextIds.size &&
+    args.orderedIds.length === current.length &&
+    args.orderedIds.every((id) => currentIds.has(id));
+  if (!samePermutation) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'orderedIds must be exactly the listing’s current screenshot ids',
+    });
+  }
+  await dbWrite.$transaction(
+    args.orderedIds.map((id, index) =>
+      dbWrite.appListingScreenshot.update({ where: { id }, data: { order: index } })
+    )
+  );
+  return { reordered: args.orderedIds.length };
+}
+
+export async function updateListingScreenshotCaption(
+  args: { screenshotId: string; caption?: string | null },
+  user: SessionUser
+): Promise<{ id: string }> {
+  const shot = await dbRead.appListingScreenshot.findUnique({
+    where: { id: args.screenshotId },
+    select: { id: true, appListing: { select: { userId: true } } },
+  });
+  if (!shot) throw new TRPCError({ code: 'NOT_FOUND', message: 'Screenshot not found' });
+  if (shot.appListing.userId !== user.id && !user.isModerator) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
+  }
+  await dbWrite.appListingScreenshot.update({
+    where: { id: args.screenshotId },
+    data: { caption: args.caption ?? null },
+  });
+  return { id: args.screenshotId };
+}
+
+/**
+ * Remove a screenshot, then RE-PACK the remaining orders to a contiguous 0..n-1
+ * so no gaps accumulate (the read path can rely on dense ordering).
+ */
+export async function removeListingScreenshot(
+  args: { screenshotId: string },
+  user: SessionUser
+): Promise<{ removed: string }> {
+  const shot = await dbRead.appListingScreenshot.findUnique({
+    where: { id: args.screenshotId },
+    select: { id: true, appListingId: true, appListing: { select: { userId: true } } },
+  });
+  if (!shot) throw new TRPCError({ code: 'NOT_FOUND', message: 'Screenshot not found' });
+  if (shot.appListing.userId !== user.id && !user.isModerator) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
+  }
+  await dbWrite.appListingScreenshot.delete({ where: { id: args.screenshotId } });
+
+  // Re-pack: contiguous orders over the survivors (ordered by their old order).
+  const remaining = await dbRead.appListingScreenshot.findMany({
+    where: { appListingId: shot.appListingId },
+    select: { id: true },
+    orderBy: { order: 'asc' },
+  });
+  if (remaining.length > 0) {
+    await dbWrite.$transaction(
+      remaining.map((s, index) =>
+        dbWrite.appListingScreenshot.update({ where: { id: s.id }, data: { order: index } })
+      )
+    );
+  }
+  return { removed: args.screenshotId };
+}
+
+export type ListingAssetsView = {
+  listingId: string;
+  iconId: number | null;
+  coverId: number | null;
+  screenshots: { id: string; imageId: number | null; order: number; caption: string | null }[];
+  completeness: ListingAssetsCompleteResult;
+};
+
+/** Owner/mod read of a listing's current assets for the creator dashboard. */
+export async function getListingAssets(
+  args: { listingId: string },
+  user: SessionUser
+): Promise<ListingAssetsView> {
+  const listing = await loadOwnedListing(args.listingId, user);
+  const screenshots = await dbRead.appListingScreenshot.findMany({
+    where: { appListingId: args.listingId },
+    select: { id: true, imageId: true, order: true, caption: true },
+    orderBy: { order: 'asc' },
+  });
+  return {
+    listingId: listing.id,
+    iconId: listing.iconId,
+    coverId: listing.coverId,
+    screenshots,
+    completeness: checkListingAssetsComplete({
+      iconId: listing.iconId,
+      coverId: listing.coverId,
+      screenshotCount: screenshots.length,
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Placeholder / asset backfill (mod-only, idempotent, dark).
+// ---------------------------------------------------------------------------
+
+export type BackfillListingAssetsParams = {
+  limit?: number;
+  dryRun?: boolean;
+};
+
+export type BackfillListingAssetsResult = {
+  scanned: number;
+  /** Listings that were already asset-complete (idempotent skip). */
+  skippedComplete: number;
+  /** Listings we filled at least one asset on (or would, in dryRun). */
+  processed: number;
+  iconsCreated: number;
+  coversSet: number;
+  screenshotsCreated: number;
+  /** How the screenshots were sourced, for observability. */
+  bySource: { migrated: number; autogen: number; placeholder: number };
+  dryRun: boolean;
+  failed: { listingId: string; error: string }[];
+};
+
+/** A backfill-candidate listing (approved + its current asset state). */
+export type BackfillCandidate = {
+  id: string;
+  kind: string;
+  slug: string;
+  name: string;
+  category: string | null;
+  userId: number;
+  iconId: number | null;
+  coverId: number | null;
+  appBlockId: string | null;
+  /** The backing AppBlock's stored screenshots (bundle MinIO records), if any. */
+  appBlockScreenshots: unknown;
+  /** Existing AppListingScreenshot rows (imageId + order). */
+  screenshots: { imageId: number | null; order: number }[];
+};
+
+export type ScreenshotSourcePlan =
+  | { mode: 'existing' }
+  | { mode: 'migrate'; count: number }
+  | { mode: 'autogen' }
+  | { mode: 'placeholder' };
+
+/**
+ * Decide where a candidate's screenshots come from (pure):
+ *   - existing rows      → nothing to do,
+ *   - on-site with bundle screenshots → migrate them to Image rows,
+ *   - on-site without    → verify-runner autogen,
+ *   - anything else (off-site, no bundle) → an SVG placeholder screenshot.
+ * The impure backfill falls THROUGH autogen→placeholder if autogen returns null.
+ */
+export function chooseScreenshotSource(candidate: BackfillCandidate): ScreenshotSourcePlan {
+  if (candidate.screenshots.length > 0) return { mode: 'existing' };
+  const isOnsite = candidate.kind === 'onsite' && !!candidate.appBlockId;
+  if (isOnsite) {
+    const bundle = Array.isArray(candidate.appBlockScreenshots)
+      ? (candidate.appBlockScreenshots as { key?: unknown }[]).filter(
+          (s) => s && typeof s === 'object' && typeof s.key === 'string'
+        )
+      : [];
+    if (bundle.length > 0) return { mode: 'migrate', count: bundle.length };
+    return { mode: 'autogen' };
+  }
+  return { mode: 'placeholder' };
+}
+
+/**
+ * Impure operations the backfill needs (Image ingest, MinIO reads, verify-
+ * runner, sharp rasterize). Injectable so the orchestration is unit-testable
+ * with no network/DB/native deps; the default implementation is
+ * {@link defaultBackfillDeps}.
+ */
+export interface ListingAssetBackfillDeps {
+  /** Migrate the backing AppBlock's bundle screenshots → Image rows (in order). */
+  migrateBlockScreenshots(args: {
+    ownerId: number;
+    appBlockId: string;
+    blockScreenshots: { key?: unknown }[];
+  }): Promise<number[]>;
+  /** Autogenerate ONE screenshot via verify-runner, stored as an Image. Null on failure. */
+  autogenScreenshot(args: { ownerId: number; slug: string }): Promise<number | null>;
+  /** Render an SVG placeholder screenshot → PNG → Image row. */
+  generatePlaceholderScreenshot(args: {
+    ownerId: number;
+    slug: string;
+    category: string | null;
+    name: string;
+  }): Promise<number>;
+  /** Render the deterministic category-glyph icon → PNG → Image row. */
+  generateIcon(args: {
+    ownerId: number;
+    slug: string;
+    category: string | null;
+    name: string;
+  }): Promise<number>;
+}
+
+/**
+ * Backfill placeholder assets for approved listings missing any. Idempotent
+ * (fills only NULL/empty; never clobbers a creator-uploaded asset). Per-row
+ * isolation like the P0 backfill (a poison row → `failed[]`, batch continues).
+ * Verify-runner calls are serialised (single warm browser). DARK: writes only
+ * to the (unread-in-P1) `app_listings*` + `Image` tables.
+ */
+export async function backfillListingAssets(
+  params: BackfillListingAssetsParams = {},
+  deps: ListingAssetBackfillDeps = defaultBackfillDeps
+): Promise<BackfillListingAssetsResult> {
+  const { limit, dryRun = false } = params;
+
+  const listings = (await dbRead.appListing.findMany({
+    where: { status: 'approved' },
+    select: {
+      id: true,
+      kind: true,
+      slug: true,
+      name: true,
+      category: true,
+      userId: true,
+      iconId: true,
+      coverId: true,
+      appBlockId: true,
+      appBlock: { select: { screenshots: true } },
+      screenshots: { select: { imageId: true, order: true }, orderBy: { order: 'asc' } },
+    },
+    orderBy: { createdAt: 'desc' },
+    ...(typeof limit === 'number' ? { take: limit } : {}),
+  })) as unknown as Array<
+    Omit<BackfillCandidate, 'appBlockScreenshots'> & {
+      appBlock: { screenshots: unknown } | null;
+    }
+  >;
+
+  const result: BackfillListingAssetsResult = {
+    scanned: listings.length,
+    skippedComplete: 0,
+    processed: 0,
+    iconsCreated: 0,
+    coversSet: 0,
+    screenshotsCreated: 0,
+    bySource: { migrated: 0, autogen: 0, placeholder: 0 },
+    dryRun,
+    failed: [],
+  };
+
+  for (const row of listings) {
+    const candidate: BackfillCandidate = {
+      id: row.id,
+      kind: row.kind,
+      slug: row.slug,
+      name: row.name,
+      category: row.category,
+      userId: row.userId,
+      iconId: row.iconId,
+      coverId: row.coverId,
+      appBlockId: row.appBlockId,
+      appBlockScreenshots: row.appBlock?.screenshots ?? null,
+      screenshots: row.screenshots,
+    };
+
+    const hasScreenshots = candidate.screenshots.length > 0;
+    const complete =
+      candidate.iconId != null && candidate.coverId != null && hasScreenshots;
+    if (complete) {
+      result.skippedComplete += 1;
+      continue;
+    }
+
+    if (dryRun) {
+      // Count what WOULD change without touching storage/DB.
+      result.processed += 1;
+      const plan = chooseScreenshotSource(candidate);
+      if (plan.mode === 'migrate') {
+        result.screenshotsCreated += plan.count;
+        result.bySource.migrated += plan.count;
+      } else if (plan.mode === 'autogen') {
+        result.screenshotsCreated += 1;
+        result.bySource.autogen += 1;
+      } else if (plan.mode === 'placeholder') {
+        result.screenshotsCreated += 1;
+        result.bySource.placeholder += 1;
+      }
+      if (candidate.coverId == null) result.coversSet += 1;
+      if (candidate.iconId == null) result.iconsCreated += 1;
+      continue;
+    }
+
+    try {
+      let changed = false;
+
+      // 1) Ensure at least one screenshot exists.
+      let firstScreenshotImageId: number | null = hasScreenshots
+        ? candidate.screenshots[0].imageId
+        : null;
+      if (!hasScreenshots) {
+        const plan = chooseScreenshotSource(candidate);
+        let imageIds: number[] = [];
+        if (plan.mode === 'migrate' && candidate.appBlockId) {
+          imageIds = await deps.migrateBlockScreenshots({
+            ownerId: candidate.userId,
+            appBlockId: candidate.appBlockId,
+            blockScreenshots: (candidate.appBlockScreenshots as { key?: unknown }[]) ?? [],
+          });
+          result.bySource.migrated += imageIds.length;
+        } else if (plan.mode === 'autogen') {
+          const shot = await deps.autogenScreenshot({
+            ownerId: candidate.userId,
+            slug: candidate.slug,
+          });
+          if (shot != null) {
+            imageIds = [shot];
+            result.bySource.autogen += 1;
+          }
+        }
+        // Fallback: any path that produced nothing gets an SVG placeholder so
+        // the mandatory-asset gate is universal (locked decision §6.1).
+        if (imageIds.length === 0) {
+          const ph = await deps.generatePlaceholderScreenshot({
+            ownerId: candidate.userId,
+            slug: candidate.slug,
+            category: candidate.category,
+            name: candidate.name,
+          });
+          imageIds = [ph];
+          result.bySource.placeholder += 1;
+        }
+        await dbWrite.appListingScreenshot.createMany({
+          data: imageIds.map((imageId, index) => ({
+            id: newAppListingScreenshotId(),
+            appListingId: candidate.id,
+            imageId,
+            order: index,
+            caption: null,
+          })),
+        });
+        result.screenshotsCreated += imageIds.length;
+        firstScreenshotImageId = imageIds[0] ?? null;
+        changed = true;
+      }
+
+      // 2) Cover = the first screenshot's Image (mirrors #2838 coverUrl pattern).
+      if (candidate.coverId == null && firstScreenshotImageId != null) {
+        await dbWrite.appListing.update({
+          where: { id: candidate.id },
+          data: { coverId: firstScreenshotImageId },
+        });
+        result.coversSet += 1;
+        changed = true;
+      }
+
+      // 3) Icon = deterministic category-glyph SVG→PNG.
+      if (candidate.iconId == null) {
+        const iconId = await deps.generateIcon({
+          ownerId: candidate.userId,
+          slug: candidate.slug,
+          category: candidate.category,
+          name: candidate.name,
+        });
+        await dbWrite.appListing.update({
+          where: { id: candidate.id },
+          data: { iconId },
+        });
+        result.iconsCreated += 1;
+        changed = true;
+      }
+
+      if (changed) result.processed += 1;
+    } catch (err) {
+      // Per-row isolation: one poison listing (a MinIO fetch failure, an FK
+      // violation) must not abort the batch.
+      result.failed.push({
+        listingId: candidate.id,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Default (impure) backfill dependencies — dynamic imports so the pure helpers
+// above stay unit-testable without booting env/native modules.
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a REAL stored Image row from a server-side buffer, following the
+ * canonical site pattern (product-badge.service / uploadImageFromUrl):
+ * upload the bytes to the image backend, register the media location, then
+ * `image.create` with the storage key as `url`. Machine-generated/vetted assets
+ * are stored `Scanned` + safe (they bypass the user-content ingestion pipeline,
+ * exactly like the autogenerated marketplace screenshots do today).
+ */
+async function createStoredImage(args: {
+  ownerId: number;
+  buffer: Buffer;
+  contentType: string;
+  width: number;
+  height: number;
+  assetKind: ListingAssetKind;
+  autogenerated: boolean;
+}): Promise<number> {
+  const [{ PutObjectCommand }, s3utils, storageResolver, { ImageIngestionStatus, MediaType }, { NsfwLevel }] =
+    await Promise.all([
+      import('@aws-sdk/client-s3'),
+      import('~/utils/s3-utils'),
+      import('~/server/services/storage-resolver'),
+      import('~/shared/utils/prisma/enums'),
+      import('~/server/common/enums'),
+    ]);
+  const key = randomUUID();
+  const { s3, bucket, backend } = await s3utils.getImageUploadBackend();
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: args.buffer,
+      ContentType: args.contentType,
+    })
+  );
+  await storageResolver.registerMediaLocation(key, backend, args.buffer.length);
+
+  const created = await dbWrite.image.create({
+    data: {
+      url: key,
+      userId: args.ownerId,
+      type: MediaType.image,
+      width: args.width,
+      height: args.height,
+      mimeType: args.contentType,
+      nsfwLevel: NsfwLevel.PG,
+      ingestion: ImageIngestionStatus.Scanned,
+      metadata: {
+        size: args.buffer.length,
+        width: args.width,
+        height: args.height,
+        // Marker so a later creator upload can be preferred / these can be
+        // identified as generated placeholders (task §3). Stored on the EXISTING
+        // Image.metadata Json — no schema migration needed.
+        appListingAutogenerated: true,
+        appListingAssetKind: args.assetKind,
+      },
+    },
+    select: { id: true },
+  });
+  return created.id;
+}
+
+/** Rasterize an SVG string to a PNG buffer via sharp. */
+async function rasterizeSvg(svg: string, width: number, height: number): Promise<Buffer> {
+  const sharp = (await import('sharp')).default;
+  return sharp(Buffer.from(svg)).resize(width, height).png().toBuffer();
+}
+
+export const defaultBackfillDeps: ListingAssetBackfillDeps = {
+  async migrateBlockScreenshots({ ownerId, blockScreenshots }) {
+    const { getBundleBucket, getBundleS3Client } = await import('~/utils/bundle-s3');
+    const { GetObjectCommand } = await import('@aws-sdk/client-s3');
+    const client = getBundleS3Client();
+    const bucket = getBundleBucket();
+    const imageIds: number[] = [];
+    // Bound the migrate to the screenshot cap; ordered by the bundle index.
+    const records = blockScreenshots
+      .filter((s) => s && typeof s === 'object' && typeof s.key === 'string')
+      .slice(0, MAX_LISTING_SCREENSHOTS) as { key: string }[];
+    for (const rec of records) {
+      const obj = await client.send(new GetObjectCommand({ Bucket: bucket, Key: rec.key }));
+      const bytes = await obj.Body?.transformToByteArray();
+      if (!bytes || bytes.length === 0) continue;
+      const buffer = Buffer.from(bytes);
+      const contentType = (obj.ContentType as string) || 'image/png';
+      // Dimensions aren't stored on the bundle record; probe with sharp.
+      const sharp = (await import('sharp')).default;
+      const meta = await sharp(buffer).metadata();
+      const id = await createStoredImage({
+        ownerId,
+        buffer,
+        contentType,
+        width: meta.width ?? 1280,
+        height: meta.height ?? 720,
+        assetKind: 'screenshot',
+        autogenerated: true,
+      });
+      imageIds.push(id);
+    }
+    return imageIds;
+  },
+
+  async autogenScreenshot({ ownerId, slug }) {
+    // Reuse the verify-runner fetch from the App Blocks autogen path, but store
+    // the PNG as an Image row (not the bundle-MinIO screenshots path).
+    const { env } = await import('~/env/server');
+    const base = env.BLOCK_SCREENSHOT_RUNNER_URL;
+    if (!base) return null;
+    const url = `https://${slug}.${env.APPS_DOMAIN}/`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 45_000);
+    try {
+      const res = await fetch(`${base.replace(/\/$/, '')}/screenshot`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ url, width: 1280, height: 720, wait_until: 'networkidle' }),
+        signal: controller.signal,
+      });
+      if (!res.ok) return null;
+      const buffer = Buffer.from(await res.arrayBuffer());
+      if (buffer.length === 0) return null;
+      const { detectImageType } = await import('~/server/services/blocks/publish-request.service');
+      if (!detectImageType(buffer, 'png')) return null;
+      return createStoredImage({
+        ownerId,
+        buffer,
+        contentType: 'image/png',
+        width: 1280,
+        height: 720,
+        assetKind: 'screenshot',
+        autogenerated: true,
+      });
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  },
+
+  async generatePlaceholderScreenshot({ ownerId, slug, category, name }) {
+    const svg = buildPlaceholderCoverSvg({ slug, category, name, width: 1280, height: 720 });
+    const buffer = await rasterizeSvg(svg, 1280, 720);
+    return createStoredImage({
+      ownerId,
+      buffer,
+      contentType: 'image/png',
+      width: 1280,
+      height: 720,
+      assetKind: 'screenshot',
+      autogenerated: true,
+    });
+  },
+
+  async generateIcon({ ownerId, slug, category, name }) {
+    const svg = buildPlaceholderIconSvg({ slug, category, name, size: 512 });
+    const buffer = await rasterizeSvg(svg, 512, 512);
+    return createStoredImage({
+      ownerId,
+      buffer,
+      contentType: 'image/png',
+      width: 512,
+      height: 512,
+      assetKind: 'icon',
+      autogenerated: true,
+    });
+  },
+};


### PR DESCRIPTION
## W13 P1 — App Store Listings asset pipeline

Phase 1 of the App Store Listings workstream (W13). Builds the icon/cover/screenshot asset pipeline on top of the `AppListing` entity added in **P0 (#2862)**. **DARK / additive: no live read path or UI exposure; owner/mod-gated procs only; gated behind the mod-segmented App Blocks flag.** Needs an adversarial audit before merge.

Plan: `claudedocs/app-blocks-app-store-listings-plan-2026-07-01.md` (§5 assets, §6 locked clarifications).

### What lands

**New `appListings` tRPC router** (`src/server/routers/app-listings.router.ts`, registered in the root appRouter) — a NEW router per locked decision §5.1 (not an extension of `blocks.router`) + service `src/server/services/blocks/app-listing-assets.service.ts` + schema/validation `src/server/schema/blocks/app-listing.schema.ts`.

**Creator asset management** (owner-scoped, moderator override, flag-gated):
- `setIcon` / `setCover` / `addScreenshot` / `reorderScreenshots` / `updateScreenshotCaption` / `removeScreenshot` / `getAssets` (creator-dashboard read).
- Attaches already-ingested `Image` rows (the site's standard media path). Maintains the screenshot `order` column contiguously (append at next order; re-pack on remove). Enforces the ≤8 cap (rejects the 9th, mirroring E5).
- Per-asset validation `validateListingImage`: type (image only) / MIME / size caps (mirror E5's 2 MiB screenshot cap; icon 1 MiB / cover 4 MiB) + per-kind aspect & min-dimension bounds (square-ish icon, landscape cover, loosely-bounded screenshot).

**Mandatory-asset gate** `checkListingAssetsComplete` / `assertListingAssetsComplete` — pure, exported, unit-tested. Returns structured `missing: [icon|cover|screenshots]`. **NOT wired to any live approval path in P1** — that is P3 (dark).

**Mod-only placeholder backfill** `backfillListingAssets({ limit?, dryRun? })` — idempotent, `dryRun`, per-row `failed[]` isolation (mirrors the P0 backfill). For approved listings missing assets:
- **Screenshots:** migrate the backing `AppBlock.screenshots` (bundle MinIO objects) → real `Image` rows; else verify-runner autogen; else an SVG placeholder. Off-site rows fall straight to the placeholder.
- **Cover:** = the first screenshot's `Image` (mirrors #2838's coverUrl pattern).
- **Icon:** deterministic category-glyph gradient SVG → PNG (sharp), seeded by slug/category + app initial.
- Generated placeholders are **REAL stored Images** so the mandatory gate passes universally (locked decision §6.1 — no grandfather branch). Idempotent: fills only NULL/empty; never clobbers a creator-uploaded asset.

### Reuse (built on, not reinvented)
- `getImageUploadBackend` + `registerMediaLocation` + `image.create` — the server-side buffer→upload→Image row pattern from `product-badge.service.ts` / `uploadImageFromUrl`.
- `detectImageType` + the verify-runner `POST /screenshot` protocol (`BLOCK_SCREENSHOT_RUNNER_URL`) — from `autogenerate-screenshot.service.ts`.
- The bundle-MinIO `GetObjectCommand` + `Body.transformToByteArray()` read — from the screenshot serve route.
- The P0 backfill's `dryRun` + per-row `failed[]` isolation shape.

### Schema / migration
**None.** No new columns: `iconId`/`coverId`/`AppListingScreenshot` already exist from P0. The autogenerated marker rides on the existing `Image.metadata` Json (`appListingAutogenerated` / `appListingAssetKind`), per the plan's "prefer existing columns / metadata Json" preference.

### Flag
Reuses the mod-segmented `app-blocks-enabled` flag (evaluated with the request user's context, like `blocks.router`'s `enforceAppBlocksFlag`) so P1 ships dark-to-non-mods and is immediately usable by the team. A dedicated `app-listings-enabled` flag lands with the P2 read path when there's a user-facing surface to widen independently.

### Tests
**37 unit tests** (`app-listing-assets.service.test.ts`), all green; the full blocks suite (626 tests) stays green. Covers validation rejections (type/size/aspect/count per kind), gate combinations, screenshot CRUD/cap/reorder/caption/re-pack, and the backfill (migrate vs autogen vs placeholder; cover=first-screenshot; icon generation; idempotency; no-clobber; dryRun; `failed[]` isolation). Impure deps (sharp/S3/verify-runner) are injected so the suite needs no network/DB/native. Caught + fixed one real bug (whitespace-only name should fall back to slug for the icon initial).

> Local tsc is unreliable (gotcha #24) — the authoritative typecheck is the Tekton pr-preview. No non-route files under `src/pages` (gotcha #81); no `*/` in Prisma comments / no `$queryRaw` (gotchas #44/#48) — schema untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)