### PR TITLE
fix(a11y): /models filter Popover.Target on button not Indicator div (aria-allowed-attr)

### DIFF
--- a/src/components/Model/Infinite/ModelFiltersDropdown.tsx
+++ b/src/components/Model/Infinite/ModelFiltersDropdown.tsx
@@ -157,20 +157,27 @@ export function DumbModelFiltersDropdown({
     (isModerator && mergedFilters.disablePoi ? 1 : 0) +
     (isModerator && mergedFilters.disableMinor ? 1 : 0);
 
-  const target = (
-    <Indicator
-      offset={4}
-      label={filterLength ? filterLength : undefined}
-      size={14}
-      zIndex={10}
-      disabled={!filterLength}
-      inline
-    >
-      <FilterButton icon={IconFilter} onClick={toggle} active={opened}>
-        Filters
-      </FilterButton>
-    </Indicator>
+  const filterButton = (
+    <FilterButton icon={IconFilter} onClick={toggle} active={opened}>
+      Filters
+    </FilterButton>
   );
+
+  // Active-filter count badge. Keep the Indicator as a purely visual wrapper:
+  // in the desktop path Popover.Target must clone the inner <button> (which
+  // forwards the aria-haspopup/expanded/controls it injects), NOT the
+  // Indicator's role-less <div> — putting aria-expanded on a <div> trips the
+  // aria-allowed-attr a11y rule.
+  const indicatorProps = {
+    offset: 4,
+    label: filterLength ? filterLength : undefined,
+    size: 14,
+    zIndex: 10,
+    disabled: !filterLength,
+    inline: true,
+  };
+
+  const target = <Indicator {...indicatorProps}>{filterButton}</Indicator>;
 
   const dropdownBody = (
     <Stack gap={8} p="md">
@@ -424,7 +431,9 @@ export function DumbModelFiltersDropdown({
         withinPortal
         withArrow
       >
-        <Popover.Target>{target}</Popover.Target>
+        <Indicator {...indicatorProps}>
+          <Popover.Target>{filterButton}</Popover.Target>
+        </Indicator>
         <Popover.Dropdown maw={576} p={0} w="100%">
           <ScrollArea.Autosize
             mah={maxPopoverHeight ?? 'calc(90vh - var(--header-height) - 156px)'}


### PR DESCRIPTION
## What

`/models` last non-design a11y residual: **`aria-allowed-attr`** (w10). The **Filters** control (`ModelFiltersDropdown`) wrapped the entire `<Indicator>` in `Popover.Target`, so Mantine injected `aria-haspopup`/`aria-expanded`/`aria-controls` onto the Indicator's **role-less `<div>`** — `aria-expanded` is not allowed there.

**Fix:** `Popover.Target` now clones the inner `FilterButton` (a `forwardRef` real `<button>` that spreads the injected aria-* + ref), with the `Indicator` as a purely visual wrapper around it. `Popover.Target` is context-based (`usePopoverContext` + `cloneElement`), so nesting it inside the `Indicator` is fine — the popover anchors to the button. The mobile drawer path (uses the Indicator standalone, no `Popover.Target`) is unchanged.

Expected `/models` a11y **87 → ~91**. Remaining after this: `target-size` + `color-contrast` (both design calls).

## Verification
Report-only. I'm verifying on the preview: (1) `lhci-bot` `aria-allowed-attr` → pass / a11y ~91, and (2) Playwright — open the Filters dropdown, confirm it opens, the active-count badge still renders, and `aria-expanded` is now on the `<button>` (structural change → functional check required).

## Follow-up (not this PR)
The same Indicator-as-Popover.Target pattern is in the shared `FiltersDropdown` / `AdaptiveFiltersDropdown` (used by image/article/etc. feeds, not in LHCI) — worth the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)