### PR TITLE
feat(app-blocks): W13 P2a — unified AppListing read path (backend)

### DIFF
--- a/src/server/routers/__tests__/app-listings.router.read-flag-gate.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.read-flag-gate.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * W13 P2a — the DARK-POSTURE gate on the unified store read path.
+ *
+ * `appListings.listAvailable` / `getAppDetail` are `publicProcedure`s behind
+ * `enforceAppListingsReadFlag` (the mod-segmented App Blocks flag). This is the
+ * SINGLE control that keeps the whole store dark until the segment is widened at
+ * cutover. `isAppBlocksEnabled` is mocked with a FAITHFUL per-user impl (ON only
+ * when the caller is a moderator, matching the live `app-blocks-enabled` rule),
+ * and the read service is mocked so importing the router doesn't drag in the
+ * generated Prisma client (stale in a PR worktree). We then drive the REAL
+ * router so the middleware's `{ user: ctx.user }` wiring is what decides:
+ *   - list:   anon/non-mod → EMPTY page, service NOT consulted; mod → served.
+ *   - detail: anon/non-mod → NOT_FOUND, service NOT consulted; mod → served.
+ *   - flag lit for anon → served (proves the path is anon-CAPABLE, no leftover
+ *     isModerator gate) — the deliberate cutover widen.
+ */
+
+const { mockIsAppBlocksEnabled, mockListAvailableListings, mockGetListingDetail } = vi.hoisted(
+  () => ({
+    mockIsAppBlocksEnabled: vi.fn(),
+    mockListAvailableListings: vi.fn(),
+    mockGetListingDetail: vi.fn(),
+  })
+);
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+}));
+// The read service is dynamically imported by the procs; mock it so the DB /
+// generated client is never loaded, and so we can assert "NOT consulted".
+vi.mock('~/server/services/blocks/app-listing.service', () => ({
+  listAvailableListings: (...a: unknown[]) => mockListAvailableListings(...a),
+  getListingDetail: (...a: unknown[]) => mockGetListingDetail(...a),
+}));
+// rateLimit pulls in redis; the gate under test is the flag middleware, so stub
+// it to a pass-through (mirrors blocks.router.flag-gate.test.ts).
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+// server-domain pulls in env/host helpers; the maturity host-check is not the
+// unit under test (default SFW / non-red).
+vi.mock('~/server/utils/server-domain', () => ({
+  isHostForColor: () => false,
+}));
+
+import { appListingsRouter } from '../app-listings.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/** Faithful mod-segmented flag: ON iff the caller is a moderator (anon → false). */
+function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
+  return Promise.resolve(!!opts?.user?.isModerator);
+}
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+const modUser = { id: 1, isModerator: true, tier: 'free', username: 'mod' };
+const normalUser = { id: 2, isModerator: false, tier: 'free', username: 'user' };
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset();
+  mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+  mockListAvailableListings.mockReset();
+  mockListAvailableListings.mockResolvedValue({ items: [{ id: 'apl_1' }], nextCursor: undefined });
+  mockGetListingDetail.mockReset();
+  mockGetListingDetail.mockResolvedValue({ id: 'apl_1', slug: 'x', kind: 'onsite' });
+});
+
+describe('appListings.listAvailable — dark posture', () => {
+  it('anonymous (flag off): empty page, service NOT consulted', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    const result = await caller.listAvailable({ limit: 20 });
+    expect(result).toEqual({ items: [], nextCursor: undefined });
+    expect(mockListAvailableListings).not.toHaveBeenCalled();
+    expect(mockIsAppBlocksEnabled).toHaveBeenCalledWith({ user: undefined });
+  });
+
+  it('non-moderator (flag off): empty page, service NOT consulted', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(normalUser) as never);
+    const result = await caller.listAvailable({ limit: 20 });
+    expect(result).toEqual({ items: [], nextCursor: undefined });
+    expect(mockListAvailableListings).not.toHaveBeenCalled();
+  });
+
+  it('moderator: gate passes, service IS consulted (mods-only is the live state)', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.listAvailable({ limit: 20 });
+    expect(result).toEqual({ items: [{ id: 'apl_1' }], nextCursor: undefined });
+    expect(mockListAvailableListings).toHaveBeenCalledTimes(1);
+  });
+
+  it('anonymous WITH the flag widened (cutover): served — proves anon-capable', async () => {
+    mockIsAppBlocksEnabled.mockResolvedValue(true);
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    const result = await caller.listAvailable({ limit: 20 });
+    expect(result).toEqual({ items: [{ id: 'apl_1' }], nextCursor: undefined });
+    expect(mockListAvailableListings).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('appListings.getAppDetail — dark posture', () => {
+  it('anonymous (flag off): NOT_FOUND, service NOT consulted', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.getAppDetail({ slug: 'foo' })).rejects.toBeInstanceOf(TRPCError);
+    expect(mockGetListingDetail).not.toHaveBeenCalled();
+  });
+
+  it('non-moderator (flag off): NOT_FOUND, service NOT consulted', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.getAppDetail({ slug: 'foo' })).rejects.toBeInstanceOf(TRPCError);
+    expect(mockGetListingDetail).not.toHaveBeenCalled();
+  });
+
+  it('moderator: gate passes, detail served', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.getAppDetail({ slug: 'foo' });
+    expect(result).toMatchObject({ id: 'apl_1' });
+    expect(mockGetListingDetail).toHaveBeenCalledTimes(1);
+  });
+
+  it('moderator, listing not approved/found (service → null): NOT_FOUND', async () => {
+    mockGetListingDetail.mockResolvedValue(null);
+    const caller = appListingsRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(caller.getAppDetail({ id: 'apl_missing' })).rejects.toBeInstanceOf(TRPCError);
+  });
+});

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -10,9 +10,20 @@ import {
   setListingIconSchema,
   updateListingScreenshotCaptionSchema,
 } from '~/server/schema/blocks/app-listing.schema';
+import {
+  getAppListingDetailSchema,
+  listAppListingsSchema,
+} from '~/server/schema/blocks/app-listing-read.schema';
 import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
-import { middleware, moderatorProcedure, protectedProcedure, router } from '~/server/trpc';
-import { throwAuthorizationError } from '~/server/utils/errorHandling';
+import {
+  middleware,
+  moderatorProcedure,
+  protectedProcedure,
+  publicProcedure,
+  router,
+} from '~/server/trpc';
+import { throwAuthorizationError, throwNotFoundError } from '~/server/utils/errorHandling';
+import { isHostForColor } from '~/server/utils/server-domain';
 
 /**
  * App Store Listings (W13) — P1 asset pipeline router (NEW router, locked
@@ -31,6 +42,31 @@ const enforceAppBlocksFlag = middleware(async ({ ctx, next }) => {
   if (await isAppBlocksEnabled({ user: ctx.user })) return next();
   throw new TRPCError({ code: 'UNAUTHORIZED', message: 'App Blocks not enabled' });
 });
+
+/**
+ * Flag gate for the P2a PUBLIC READ procs (unified store). Anon-CAPABLE but DARK
+ * until launch: for a real anon / non-mod viewer the mod-segmented
+ * `app-blocks-enabled` flag never matches → mark `_appBlocksDisabled` so the
+ * query returns an EMPTY page / NOT_FOUND (never an error, mirroring
+ * `blocks.router`'s read gate) rather than throwing. The surface only serves
+ * real anon callers once the SEGMENT is widened at launch (a deliberate, separate
+ * Flipt change — and, at the read-path cutover, its own `appListings` flag).
+ */
+const enforceAppListingsReadFlag = middleware(async ({ ctx, next }) => {
+  if (await isAppBlocksEnabled({ user: ctx.user })) return next();
+  return next({ ctx: { _appBlocksDisabled: true } });
+});
+
+/**
+ * Red-capable host check — maturity is a HOST property (independent of moderator
+ * status), so even a mod on civitai.com does not see mature (r/x) listings in
+ * these viewer-facing reads. Fail-closed: a missing host → false (SFW only).
+ * Mirrors `blocks.router`'s `isRedCapableRequest`.
+ */
+function isRedCapableRequest(ctx: { req?: { headers?: { host?: string } } }): boolean {
+  const host = ctx.req?.headers?.host ?? '';
+  return host !== '' && isHostForColor(host, 'red');
+}
 
 export const appListingsRouter = router({
   /** Owner/mod read of a listing's current assets (creator dashboard). */
@@ -113,5 +149,48 @@ export const appListingsRouter = router({
         '~/server/services/blocks/app-listing-assets.service'
       );
       return backfillListingAssets({ limit: input.limit, dryRun: input.dryRun });
+    }),
+
+  // -------------------------------------------------------------------------
+  // P2a UNIFIED STORE READ PATH (over BOTH kinds) — publicProcedure, DARK.
+  //
+  // Parallel-run: these serve the unified `/apps` store from `AppListing` and
+  // live ALONGSIDE the existing AppBlock-backed `blocks.listAvailable` /
+  // `blocks.getAppDetail`. The UI switch + cutover are LATER PRs — this PR wires
+  // no UI and does NOT touch the AppBlock read path.
+  //
+  // EXPOSURE / SECURITY: approved-only, PUBLIC-ALLOWLIST projections only
+  // (see app-listing-read.schema DTOs — no trustTier / raw iframe.src / OAuth
+  // secrets / owner PII beyond the public creator chip / DB status). No per-user
+  // data. Maturity-gated (r/x hidden off a red-capable host). Dark behind the
+  // mod-segmented App Blocks flag (empty page / NOT_FOUND when off).
+  // -------------------------------------------------------------------------
+
+  /** Unified store listing over BOTH kinds — approved rows, keyset-paginated. */
+  listAvailable: publicProcedure
+    .use(enforceAppListingsReadFlag)
+    .input(listAppListingsSchema)
+    .query(async ({ ctx, input }) => {
+      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+        return { items: [], nextCursor: undefined };
+      }
+      const { listAvailableListings } = await import(
+        '~/server/services/blocks/app-listing.service'
+      );
+      return listAvailableListings(input, { redCapable: isRedCapableRequest(ctx) });
+    }),
+
+  /** Per-listing public detail, by EXACTLY ONE of slug or id (approved only). */
+  getAppDetail: publicProcedure
+    .use(enforceAppListingsReadFlag)
+    .input(getAppListingDetailSchema)
+    .query(async ({ ctx, input }) => {
+      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+        throw throwNotFoundError('Listing not found');
+      }
+      const { getListingDetail } = await import('~/server/services/blocks/app-listing.service');
+      const detail = await getListingDetail(input, { redCapable: isRedCapableRequest(ctx) });
+      if (!detail) throw throwNotFoundError('Listing not found');
+      return detail;
     }),
 });

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -14,6 +14,7 @@ import {
   getAppListingDetailSchema,
   listAppListingsSchema,
 } from '~/server/schema/blocks/app-listing-read.schema';
+import { rateLimit } from '~/server/middleware.trpc';
 import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import {
   middleware,
@@ -169,6 +170,13 @@ export const appListingsRouter = router({
   /** Unified store listing over BOTH kinds — approved rows, keyset-paginated. */
   listAvailable: publicProcedure
     .use(enforceAppListingsReadFlag)
+    .use(
+      rateLimit({
+        limit: 60,
+        period: 60,
+        errorMessage: 'Too many marketplace requests — slow down.',
+      })
+    )
     .input(listAppListingsSchema)
     .query(async ({ ctx, input }) => {
       if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
@@ -183,6 +191,13 @@ export const appListingsRouter = router({
   /** Per-listing public detail, by EXACTLY ONE of slug or id (approved only). */
   getAppDetail: publicProcedure
     .use(enforceAppListingsReadFlag)
+    .use(
+      rateLimit({
+        limit: 60,
+        period: 60,
+        errorMessage: 'Too many marketplace requests — slow down.',
+      })
+    )
     .input(getAppListingDetailSchema)
     .query(async ({ ctx, input }) => {
       if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -1,0 +1,177 @@
+import * as z from 'zod';
+
+import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
+
+/**
+ * App Store Listings (W13) — P2a UNIFIED STORE READ PATH schemas + public DTOs.
+ *
+ * These back the NEW `appListings.listAvailable` / `appListings.getAppDetail`
+ * read procs that serve the unified `/apps` store over BOTH kinds (`onsite`
+ * AppBlocks + `offsite` external/connect apps) from the durable `AppListing`
+ * record. They MIRROR the existing AppBlock read path
+ * (`blocks.listAvailable` / `blocks.getAppDetail` +
+ * `subscription.schema.ts::AvailableBlock` / `PublicAppDetail`) so the two can't
+ * drift, but read `AppListing` rather than `AppBlock`.
+ *
+ * DARK / parallel-run: nothing here is on the LIVE `/apps` surface yet (that
+ * still reads the AppBlock path). The new procs live ALONGSIDE it behind the
+ * SAME mod-segmented App Blocks flag; the UI switch + cutover are later PRs.
+ *
+ * SECURITY: every DTO below is a PUBLIC-FIELD ALLOWLIST (like `AvailableBlock` /
+ * `PublicBlockManifest`). Internal fields (trustTier, raw iframe.src, OAuth
+ * secrets, owner PII beyond the public creator chip, DB status) are NEVER shaped
+ * in — a field can only leak if it is added here on purpose.
+ */
+
+// ---------------------------------------------------------------------------
+// Inputs.
+// ---------------------------------------------------------------------------
+
+/** Kind filter for the unified store: everything, on-site only, or off-site only. */
+export const listingKindFilterSchema = z.enum(['all', 'onsite', 'offsite']);
+export type ListingKindFilter = z.infer<typeof listingKindFilterSchema>;
+
+/**
+ * Store sort options:
+ *   - `top-rated` (DEFAULT) — Bayesian-shrinkage on the recommend proportion
+ *     (up / (up+down)) DESC; a few-review 100%-recommend app can't outrank a
+ *     many-review 90% app, and 0-review apps sit mid-pack at the global mean
+ *     recommend rate (mirrors the AppBlock `rating` sort, on a proportion
+ *     instead of a 1..5 average). Ties fall back to install_count then id.
+ *   - `popular`  — install_count DESC (from the AppListingMetric rollup).
+ *   - `newest`   — created_at DESC.
+ *   - `name`     — name ASC (case-insensitive).
+ */
+export const listingSortSchema = z.enum(['top-rated', 'popular', 'newest', 'name']);
+export type ListingSort = z.infer<typeof listingSortSchema>;
+
+export const listAppListingsSchema = z.object({
+  kind: listingKindFilterSchema.default('all'),
+  // Category filter validated against the single-source taxonomy const (shared
+  // with the AppBlock path) so adding a category needs no schema migration.
+  category: z.enum(MARKETPLACE_CATEGORIES).optional(),
+  sort: listingSortSchema.default('top-rated'),
+  // Opaque keyset cursor (base64url) — see app-listing.service encode/decode.
+  cursor: z.string().max(128).optional(),
+  limit: z.number().int().min(1).max(50).default(20),
+});
+export type ListAppListingsInput = z.infer<typeof listAppListingsSchema>;
+
+/** Detail lookup by EXACTLY ONE of slug or id (approved listings only). */
+export const getAppListingDetailSchema = z
+  .object({
+    slug: z.string().min(1).max(64).optional(),
+    id: z.string().min(1).max(64).optional(),
+  })
+  .refine((d) => (d.slug ? 1 : 0) + (d.id ? 1 : 0) === 1, {
+    message: 'Provide exactly one of `slug` or `id`',
+  });
+export type GetAppListingDetailInput = z.infer<typeof getAppListingDetailSchema>;
+
+// ---------------------------------------------------------------------------
+// Public DTOs (allowlist projections).
+// ---------------------------------------------------------------------------
+
+export type ListingKind = 'onsite' | 'offsite';
+
+/** Off-site apps come in two shapes (locked decision §6.4). */
+export type OffsiteSubKind = 'connect' | 'external-link';
+
+/**
+ * Public creator chip — id/username/image ONLY (the standard public-user
+ * projection subset). No email/PII. `null` only if the owner row vanished.
+ */
+export type ListingCreatorChip = {
+  id: number;
+  username: string | null;
+  image: string | null;
+};
+
+/**
+ * Recommend rollup, read from the `AppListingMetric` rollup (P5-populated).
+ * `recommendPct` is `null` when there are no reviews yet (metric row absent OR
+ * zero counts) so the UI can render "no reviews yet" instead of "0%".
+ */
+export type ListingRecommendRollup = {
+  recommendedCount: number;
+  notRecommendedCount: number;
+  /** up / (up+down) in [0,1], or null when there are no reviews yet. */
+  recommendPct: number | null;
+};
+
+/** Kind-specific card fields (discriminated by the card's `kind`). */
+export type ListingCardKindData =
+  | {
+      kind: 'onsite';
+      /** Backing AppBlock id (the runtime), or null for a native off-site row. */
+      appBlockId: string | null;
+      /** True when the app declares a launch page (Open CTA) vs a model-slot install (Install CTA). */
+      hasPage: boolean;
+    }
+  | {
+      kind: 'offsite';
+      subKind: OffsiteSubKind;
+      /** External-link target (Visit CTA). Null for a connect-only listing. */
+      externalUrl: string | null;
+    };
+
+/** One store card over EITHER kind (the unified `/apps` grid). */
+export type ListingCard = {
+  id: string;
+  slug: string;
+  kind: ListingKind;
+  name: string;
+  tagline: string | null;
+  category: string | null;
+  contentRating: string | null;
+  iconUrl: string | null;
+  /** Cover image, or the first screenshot as a fallback, or null. */
+  coverUrl: string | null;
+  creator: ListingCreatorChip | null;
+  recommend: ListingRecommendRollup;
+  /** Total reviews reflected in the recommend rollup (recommended + not). */
+  reviewCount: number;
+  kindData: ListingCardKindData;
+};
+
+export type ListingGalleryScreenshot = {
+  url: string;
+  caption: string | null;
+};
+
+/** Kind-specific action data on the detail page. */
+export type ListingDetailKindData =
+  | {
+      kind: 'onsite';
+      appBlockId: string | null;
+      hasPage: boolean;
+      /** Already-public standalone block origin (no token/scope). */
+      liveUrl: string;
+    }
+  | {
+      kind: 'offsite';
+      subKind: OffsiteSubKind;
+      externalUrl: string | null;
+      /** Public OAuth client_id for a connect-kind listing (NOT a secret); null otherwise. */
+      connectClientId: string | null;
+    };
+
+/** Full public detail for one approved listing (card fields + gallery + body). */
+export type ListingDetail = {
+  id: string;
+  slug: string;
+  kind: ListingKind;
+  name: string;
+  tagline: string | null;
+  description: string | null;
+  category: string | null;
+  contentRating: string | null;
+  iconUrl: string | null;
+  coverUrl: string | null;
+  creator: ListingCreatorChip | null;
+  recommend: ListingRecommendRollup;
+  reviewCount: number;
+  /** Ordered gallery — screenshots whose backing Image still exists (null-image rows dropped). */
+  screenshots: ListingGalleryScreenshot[];
+  kindData: ListingDetailKindData;
+};

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -45,6 +45,7 @@ import {
   recommendRollup,
   resolveOffsiteSubKind,
 } from '../app-listing.service';
+import { listAppListingsSchema } from '~/server/schema/blocks/app-listing-read.schema';
 
 const SEP = String.fromCharCode(31);
 
@@ -161,6 +162,24 @@ describe('cursor encode/decode', () => {
       cursorId: null,
       cursorMean: null,
     });
+  });
+
+  it('drops an out-of-[0,1] mean (crafted overflow guard) but keeps the keyset', () => {
+    // A mean like 1e300 would flow into `round(score * SCALE)::bigint` and
+    // overflow int8 (→ Postgres "bigint out of range" → 500). It is dropped to
+    // null so the caller falls back to the freshly-computed global mean.
+    const huge = encodeListingCursor('000000900', 'apl_2', 1e300);
+    expect(decodeListingCursor(huge)).toEqual({
+      cursorSortKey: '000000900',
+      cursorId: 'apl_2',
+      cursorMean: null,
+    });
+    // Large-negative mean, encoded raw (also out of range → dropped).
+    const neg = Buffer.from(`000000900${SEP}apl_2${SEP}-1e300`, 'utf8').toString('base64url');
+    expect(decodeListingCursor(neg).cursorMean).toBeNull();
+    // A boundary in-range mean (0 and 1) is KEPT.
+    expect(decodeListingCursor(encodeListingCursor('k', 'id', 0)).cursorMean).toBe(0);
+    expect(decodeListingCursor(encodeListingCursor('k', 'id', 1)).cursorMean).toBe(1);
   });
 });
 
@@ -526,6 +545,68 @@ describe('listAvailableListings — query building + pagination', () => {
     expect(capturedValues()).toContain(0.25);
   });
 
+  it('sort=top-rated with a crafted out-of-range mean cursor does NOT 500', async () => {
+    // The mean is dropped by decode (clamp), so the service re-reads the global
+    // mean (call 1) then runs the id page (call 2) — nothing overflows the bigint
+    // sort key. Assert the call resolves rather than throws.
+    const crafted = encodeListingCursor('000000900', 'apl_2', 1e300);
+    mockDbRead.$queryRaw.mockResolvedValueOnce([{ mean: 0.8 }]); // global mean re-read
+    mockDbRead.$queryRaw.mockResolvedValueOnce([]); // empty id page
+    await expect(
+      listAvailableListings({ kind: 'all', sort: 'top-rated', cursor: crafted, limit: 20 })
+    ).resolves.toEqual({ items: [], nextCursor: undefined });
+    // The huge mean never reached the SQL params (it was dropped); the safe 0.8
+    // fallback is what got bound into the Bayesian key.
+    expect(capturedValues()).not.toContain(1e300);
+    expect(capturedValues()).toContain(0.8);
+
+    // Also large-negative, via a raw-built cursor.
+    const neg = Buffer.from(`000000900${SEP}apl_2${SEP}-1e300`, 'utf8').toString('base64url');
+    mockDbRead.$queryRaw.mockResolvedValueOnce([{ mean: 0.5 }]);
+    mockDbRead.$queryRaw.mockResolvedValueOnce([]);
+    await expect(
+      listAvailableListings({ kind: 'all', sort: 'top-rated', cursor: neg, limit: 20 })
+    ).resolves.toEqual({ items: [], nextCursor: undefined });
+    expect(capturedValues()).not.toContain(-1e300);
+  });
+
+  it('sort=name bounds the sort key so a long-name nextCursor stays paginable (≤128)', async () => {
+    // The name sort key is `left(LOWER(al.name), 64)` — proven in the SQL — so the
+    // key encoded into the cursor is ≤64 chars and the cursor stays under the
+    // `cursor: z.string().max(128)` cap even for very long names.
+    await listAvailableListings({ kind: 'all', sort: 'name', limit: 20 });
+    expect(capturedSql()).toMatch(/left\(LOWER\(al\.name\),\s*64\)/i);
+
+    // A page whose last row carries the MAX (64-char) truncated key + a realistic
+    // id: the emitted nextCursor must be ≤128 and round-trip, and a follow-up call
+    // with it must succeed (pagination survives a >65-char name).
+    const key64 = 'z'.repeat(64); // what left(lower(name),64) yields for a long name
+    const longId = 'apl_' + 'c'.repeat(24); // cuid-length id
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      { id: 'apl_prev', sort_key: 'a'.repeat(64) },
+      { id: longId, sort_key: key64 },
+      { id: 'apl_plus1', sort_key: 'z'.repeat(64) }, // the +1 (dropped → nextCursor)
+    ]);
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([
+      hydratedRow({ id: 'apl_prev', slug: 's-prev' }),
+      hydratedRow({ id: longId, slug: 's-long' }),
+    ]);
+    const { nextCursor } = await listAvailableListings({ kind: 'all', sort: 'name', limit: 2 });
+    expect(nextCursor).toBeDefined();
+    expect((nextCursor as string).length).toBeLessThanOrEqual(128);
+    // The schema cap must accept it (proves pagination doesn't halt).
+    expect(listAppListingsSchema.shape.cursor.parse(nextCursor)).toBe(nextCursor);
+    const decoded = decodeListingCursor(nextCursor);
+    expect(decoded.cursorSortKey).toBe(key64);
+    expect(decoded.cursorId).toBe(longId);
+
+    // Follow-up page 2 with that cursor resolves (keyset accepted).
+    mockDbRead.$queryRaw.mockResolvedValueOnce([]);
+    await expect(
+      listAvailableListings({ kind: 'all', sort: 'name', cursor: nextCursor, limit: 2 })
+    ).resolves.toEqual({ items: [], nextCursor: undefined });
+  });
+
   it('returns an empty page (no hydration) when the keyset query is empty', async () => {
     mockDbRead.$queryRaw.mockResolvedValueOnce([]);
     const { items, nextCursor } = await listAvailableListings({
@@ -575,6 +656,18 @@ describe('getListingDetail — approved-only + maturity gate', () => {
   it('returns null for a missing listing', async () => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce(null);
     expect(await getListingDetail({ slug: 'nope' })).toBeNull();
+  });
+
+  it('returns null (no query) when NEITHER slug nor id is provided (enumeration guard)', async () => {
+    // The zod .refine guards the tRPC boundary, but the service is exported —
+    // `findFirst({ slug: undefined })` would return an arbitrary approved row.
+    expect(await getListingDetail({} as never)).toBeNull();
+    expect(mockDbRead.appListing.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('returns null (no query) when BOTH slug and id are provided (ambiguous)', async () => {
+    expect(await getListingDetail({ slug: 'cool-app', id: 'apl_1' } as never)).toBeNull();
+    expect(mockDbRead.appListing.findFirst).not.toHaveBeenCalled();
   });
 
   it.each(['draft', 'pending', 'rejected'])('returns null for a %s listing', async (status) => {

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -1,0 +1,601 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * App Store Listings (W13) — P2a unified store READ PATH tests.
+ *
+ * Covers the public-allowlist projections + query building for
+ * `app-listing.service` (the `AppListing`-backed twin of the AppBlock
+ * marketplace read path). We do NOT hit a DB — `dbRead.$queryRaw` (the keyset
+ * id page) and `dbRead.appListing.findMany/findFirst` (the hydration) are mocked
+ * so we can assert both the projected wire SHAPE (no internal-field leaks) and
+ * the SQL the service builds (approved-only, kind/category filters, sort +
+ * keyset). `getEdgeUrl` is mocked to identity so URL fields echo the stored key.
+ */
+
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    appListing: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+// getEdgeUrl → identity so URL fields assert against the stored key.
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (src: string) => src }));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+// queryCache → passthrough to the mocked $queryRaw (no Redis in unit tests).
+vi.mock('~/server/utils/cache-helpers', () => ({
+  queryCache:
+    () =>
+    async (sql: unknown): Promise<unknown[]> =>
+      mockDbRead.$queryRaw(sql),
+}));
+
+import {
+  decodeListingCursor,
+  encodeListingCursor,
+  getListingDetail,
+  listAvailableListings,
+  projectListingCard,
+  projectListingDetail,
+  recommendRollup,
+  resolveOffsiteSubKind,
+} from '../app-listing.service';
+
+const SEP = String.fromCharCode(31);
+
+/** Reconstruct the SQL string Prisma received (single Prisma.Sql arg). */
+function capturedSql(): string {
+  const last = mockDbRead.$queryRaw.mock.calls.at(-1);
+  const first = last?.[0] as { sql?: unknown } | undefined;
+  return first && typeof first.sql === 'string' ? first.sql : '';
+}
+
+/** The bound parameter values of the last $queryRaw call. */
+function capturedValues(): unknown[] {
+  const last = mockDbRead.$queryRaw.mock.calls.at(-1);
+  const first = last?.[0] as { values?: unknown[] } | undefined;
+  return first?.values ?? [];
+}
+
+/** A fully-hydrated onsite listing row (as `listingHydrateSelect` returns). */
+function hydratedRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 'apl_1',
+    kind: 'onsite',
+    slug: 'cool-app',
+    name: 'Cool App',
+    tagline: 'Does cool things',
+    description: '# Cool app\n\nbody',
+    category: 'utility',
+    contentRating: 'pg',
+    externalUrl: null,
+    connectClientId: null,
+    appBlockId: 'ab_1',
+    icon: { url: 'icon-key' },
+    cover: { url: 'cover-key' },
+    user: { id: 7, username: 'dev', image: 'avatar-key' },
+    metric: { thumbsUpCount: 9, thumbsDownCount: 1 },
+    appBlock: {
+      manifest: {
+        name: 'Cool App',
+        page: { path: '/run' },
+        // internal fields that must NEVER reach a public DTO:
+        trustTier: 'internal',
+        iframe: { src: 'https://cool.internal.example/', sandbox: 'allow-scripts' },
+        scopes: ['ai:write:budgeted'],
+        settings: { apiKey: 'super-secret' },
+      },
+    },
+    screenshots: [{ caption: 'first shot', image: { url: 'shot-0' } }],
+    ...over,
+  };
+}
+
+describe('recommendRollup', () => {
+  it('computes counts + pct from the metric rollup', () => {
+    expect(recommendRollup({ thumbsUpCount: 9, thumbsDownCount: 1 })).toEqual({
+      recommendedCount: 9,
+      notRecommendedCount: 1,
+      recommendPct: 0.9,
+    });
+  });
+
+  it('returns 0/0/null when the metric row is absent (P5-populated)', () => {
+    expect(recommendRollup(null)).toEqual({
+      recommendedCount: 0,
+      notRecommendedCount: 0,
+      recommendPct: null,
+    });
+    expect(recommendRollup(undefined)).toEqual({
+      recommendedCount: 0,
+      notRecommendedCount: 0,
+      recommendPct: null,
+    });
+  });
+
+  it('recommendPct is null (not 0) when there are zero reviews', () => {
+    expect(recommendRollup({ thumbsUpCount: 0, thumbsDownCount: 0 }).recommendPct).toBeNull();
+  });
+});
+
+describe('resolveOffsiteSubKind', () => {
+  it('connect when a connect client is set, external-link otherwise', () => {
+    expect(resolveOffsiteSubKind('oauth_123')).toBe('connect');
+    expect(resolveOffsiteSubKind(null)).toBe('external-link');
+    expect(resolveOffsiteSubKind(undefined)).toBe('external-link');
+  });
+});
+
+describe('cursor encode/decode', () => {
+  it('round-trips a 2-field cursor (non-top-rated sorts)', () => {
+    const c = encodeListingCursor('0000000005', 'apl_9');
+    expect(decodeListingCursor(c)).toEqual({
+      cursorSortKey: '0000000005',
+      cursorId: 'apl_9',
+      cursorMean: null,
+    });
+  });
+
+  it('round-trips a 3-field cursor with a pinned mean (top-rated)', () => {
+    const c = encodeListingCursor('000000900', 'apl_2', 0.72);
+    expect(decodeListingCursor(c)).toEqual({
+      cursorSortKey: '000000900',
+      cursorId: 'apl_2',
+      cursorMean: 0.72,
+    });
+  });
+
+  it('a malformed / empty cursor decodes to first-page (fail-open)', () => {
+    expect(decodeListingCursor(undefined)).toEqual({
+      cursorSortKey: null,
+      cursorId: null,
+      cursorMean: null,
+    });
+    expect(decodeListingCursor('not a real cursor!!!')).toEqual({
+      cursorSortKey: null,
+      cursorId: null,
+      cursorMean: null,
+    });
+  });
+});
+
+describe('projectListingCard — public allowlist (no internal leaks)', () => {
+  it('projects the exact public card allowlist', () => {
+    const card = projectListingCard(hydratedRow() as never);
+    expect(Object.keys(card).sort()).toEqual(
+      [
+        'category',
+        'contentRating',
+        'coverUrl',
+        'creator',
+        'iconUrl',
+        'id',
+        'kind',
+        'kindData',
+        'name',
+        'recommend',
+        'reviewCount',
+        'slug',
+        'tagline',
+      ].sort()
+    );
+    expect(card).not.toHaveProperty('status');
+    expect(card).not.toHaveProperty('description'); // detail-only
+  });
+
+  it('never leaks internal AppBlock manifest fields onto the card', () => {
+    const card = projectListingCard(hydratedRow() as never);
+    const serialized = JSON.stringify(card);
+    for (const secret of ['trustTier', 'internal.example', 'super-secret', 'allow-scripts']) {
+      expect(serialized, `card leaked "${secret}"`).not.toContain(secret);
+    }
+  });
+
+  it('projects icon/cover URLs, creator chip, recommend rollup + reviewCount', () => {
+    const card = projectListingCard(hydratedRow() as never);
+    expect(card.iconUrl).toBe('icon-key');
+    expect(card.coverUrl).toBe('cover-key');
+    expect(card.creator).toEqual({ id: 7, username: 'dev', image: 'avatar-key' });
+    expect(card.recommend).toEqual({
+      recommendedCount: 9,
+      notRecommendedCount: 1,
+      recommendPct: 0.9,
+    });
+    expect(card.reviewCount).toBe(10);
+  });
+
+  it('onsite kindData carries appBlockId + hasPage (Open) when the manifest declares a page', () => {
+    const card = projectListingCard(hydratedRow() as never);
+    expect(card.kindData).toEqual({ kind: 'onsite', appBlockId: 'ab_1', hasPage: true });
+  });
+
+  it('onsite hasPage=false (Install) when the manifest declares no page', () => {
+    const row = hydratedRow({ appBlock: { manifest: { name: 'X', targets: [] } } });
+    const card = projectListingCard(row as never);
+    expect(card.kindData).toEqual({ kind: 'onsite', appBlockId: 'ab_1', hasPage: false });
+  });
+
+  it('coverUrl falls back to the first screenshot when there is no cover', () => {
+    const row = hydratedRow({ cover: null });
+    expect(projectListingCard(row as never).coverUrl).toBe('shot-0');
+  });
+
+  it('coverUrl is null when there is no cover and no screenshot', () => {
+    const row = hydratedRow({ cover: null, screenshots: [] });
+    expect(projectListingCard(row as never).coverUrl).toBeNull();
+  });
+
+  it('recommend rollup is 0/0/null when the metric row is absent', () => {
+    const row = hydratedRow({ metric: null });
+    const card = projectListingCard(row as never);
+    expect(card.recommend).toEqual({
+      recommendedCount: 0,
+      notRecommendedCount: 0,
+      recommendPct: null,
+    });
+    expect(card.reviewCount).toBe(0);
+  });
+
+  it('offsite connect card: subKind=connect + externalUrl passthrough', () => {
+    const row = hydratedRow({
+      kind: 'offsite',
+      appBlockId: null,
+      appBlock: null,
+      connectClientId: 'oauth_abc',
+      externalUrl: null,
+    });
+    const card = projectListingCard(row as never);
+    expect(card.kind).toBe('offsite');
+    expect(card.kindData).toEqual({ kind: 'offsite', subKind: 'connect', externalUrl: null });
+  });
+
+  it('offsite external-link card: subKind=external-link + externalUrl', () => {
+    const row = hydratedRow({
+      kind: 'offsite',
+      appBlockId: null,
+      appBlock: null,
+      connectClientId: null,
+      externalUrl: 'https://ext.example/app',
+    });
+    const card = projectListingCard(row as never);
+    expect(card.kindData).toEqual({
+      kind: 'offsite',
+      subKind: 'external-link',
+      externalUrl: 'https://ext.example/app',
+    });
+  });
+
+  it('a vanished owner yields a null creator chip (no crash)', () => {
+    const row = hydratedRow({ user: null });
+    expect(projectListingCard(row as never).creator).toBeNull();
+  });
+});
+
+describe('projectListingDetail — public allowlist + gallery', () => {
+  it('projects the detail allowlist incl. description + screenshots', () => {
+    const detail = projectListingDetail(hydratedRow() as never);
+    expect(Object.keys(detail).sort()).toEqual(
+      [
+        'category',
+        'contentRating',
+        'coverUrl',
+        'creator',
+        'description',
+        'iconUrl',
+        'id',
+        'kind',
+        'kindData',
+        'name',
+        'recommend',
+        'reviewCount',
+        'screenshots',
+        'slug',
+        'tagline',
+      ].sort()
+    );
+    expect(detail).not.toHaveProperty('status');
+    expect(detail.description).toBe('# Cool app\n\nbody');
+  });
+
+  it('onsite detail kindData carries appBlockId, hasPage + the computed liveUrl', () => {
+    const detail = projectListingDetail(hydratedRow() as never);
+    expect(detail.kindData).toEqual({
+      kind: 'onsite',
+      appBlockId: 'ab_1',
+      hasPage: true,
+      liveUrl: 'https://cool-app.civit.ai',
+    });
+  });
+
+  it('offsite connect detail exposes the PUBLIC connectClientId (never a secret)', () => {
+    const row = hydratedRow({
+      kind: 'offsite',
+      appBlockId: null,
+      appBlock: null,
+      connectClientId: 'oauth_abc',
+      externalUrl: null,
+    });
+    const detail = projectListingDetail(row as never);
+    expect(detail.kindData).toEqual({
+      kind: 'offsite',
+      subKind: 'connect',
+      externalUrl: null,
+      connectClientId: 'oauth_abc',
+    });
+  });
+
+  it('offsite external-link detail has a null connectClientId', () => {
+    const row = hydratedRow({
+      kind: 'offsite',
+      appBlockId: null,
+      appBlock: null,
+      connectClientId: null,
+      externalUrl: 'https://ext.example/app',
+    });
+    const detail = projectListingDetail(row as never);
+    expect(detail.kindData).toMatchObject({
+      kind: 'offsite',
+      subKind: 'external-link',
+      connectClientId: null,
+    });
+  });
+
+  it('the gallery excludes screenshots whose backing Image is gone (null image)', () => {
+    const row = hydratedRow({
+      screenshots: [
+        { caption: 'a', image: { url: 's0' } },
+        { caption: 'b', image: null },
+        { caption: 'c', image: { url: 's2' } },
+      ],
+    });
+    const detail = projectListingDetail(row as never);
+    expect(detail.screenshots).toEqual([
+      { url: 's0', caption: 'a' },
+      { url: 's2', caption: 'c' },
+    ]);
+  });
+
+  it('never leaks internal manifest fields onto the detail', () => {
+    const serialized = JSON.stringify(projectListingDetail(hydratedRow() as never));
+    for (const secret of ['trustTier', 'internal.example', 'super-secret']) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+});
+
+describe('listAvailableListings — query building + pagination', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockClear();
+    mockDbRead.appListing.findMany.mockClear();
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+    mockDbRead.appListing.findMany.mockResolvedValue([]);
+  });
+
+  it('SQL hard-filters status = approved (draft/pending/rejected never returned)', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
+    expect(capturedSql()).toMatch(/al\.status\s*=\s*'approved'/);
+  });
+
+  it('kind filter binds the requested kind (onsite)', async () => {
+    await listAvailableListings({ kind: 'onsite', sort: 'newest', limit: 20 });
+    expect(capturedSql()).toMatch(/al\.kind\s*=/);
+    expect(capturedValues()).toContain('onsite');
+  });
+
+  it("kind='all' does not bind a kind (the filter is a no-op)", async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
+    expect(capturedValues()).not.toContain('onsite');
+    expect(capturedValues()).not.toContain('offsite');
+  });
+
+  it('category filter binds the requested category', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', category: 'games', limit: 20 });
+    expect(capturedSql()).toMatch(/al\.category\s*=/);
+    expect(capturedValues()).toContain('games');
+  });
+
+  it('maturity gate hides r/x when not red-capable', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 }, { redCapable: false });
+    expect(capturedSql()).toMatch(/content_rating.*NOT IN \('r', 'x'\)/i);
+  });
+
+  it('maturity gate is a no-op (TRUE) on a red-capable host', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 }, { redCapable: true });
+    expect(capturedSql()).not.toMatch(/content_rating.*NOT IN/i);
+  });
+
+  it('sort=popular orders by install count DESC (no Bayesian fragment)', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'popular', limit: 20 });
+    const sql = capturedSql();
+    expect(sql).toMatch(/lpad\(COALESCE\(m\.install_count/i);
+    expect(sql).toMatch(/ORDER BY\s+sort_key\s+DESC/i);
+    expect(sql).not.toMatch(/lpad\(round\(/i);
+  });
+
+  it('sort=newest orders by created_at DESC', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
+    const sql = capturedSql();
+    expect(sql).toMatch(/to_char\(al\.created_at/i);
+    expect(sql).toMatch(/ORDER BY\s+sort_key\s+DESC/i);
+  });
+
+  it('sort=name orders by LOWER(name) ASC and resumes the keyset with `>`', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'name', limit: 20 });
+    const sql = capturedSql();
+    expect(sql).toMatch(/LOWER\(al\.name\)/i);
+    expect(sql).toMatch(/ORDER BY\s+sort_key\s+ASC/i);
+    expect(sql).toMatch(/,\s*al\.id\)\s*>\s*\(/);
+  });
+
+  it('sort=top-rated emits the Bayesian recommend key in SELECT + keyset WHERE (no drift)', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'top-rated', limit: 20 });
+    const sql = capturedSql();
+    // The Bayesian fragment appears in the SELECT (AS sort_key) AND the keyset.
+    const occurrences = sql.match(/lpad\(round\(/gi)?.length ?? 0;
+    expect(occurrences).toBeGreaterThanOrEqual(2);
+    expect(sql).toMatch(/ORDER BY\s+sort_key\s+DESC/i);
+    expect(sql).toMatch(/,\s*al\.id\)\s*<\s*\(/); // DESC keyset resumes with `<`
+    // Regression guard: lpad length args MUST be cast to ::int (bigint has no overload).
+    expect(sql).toMatch(/lpad\(round\([\s\S]*?::int,\s*'0'\)/i);
+  });
+
+  it('returns both kinds and preserves the keyset order across hydration', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      { id: 'apl_a', sort_key: 'k2' },
+      { id: 'apl_b', sort_key: 'k1' },
+    ]);
+    // findMany returns the rows OUT OF ORDER — the service must re-apply the id order.
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([
+      hydratedRow({ id: 'apl_b', kind: 'offsite', appBlockId: null, appBlock: null, connectClientId: 'oc_1', slug: 'b-app' }),
+      hydratedRow({ id: 'apl_a', kind: 'onsite', slug: 'a-app' }),
+    ]);
+    const { items } = await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
+    expect(items.map((i) => i.id)).toEqual(['apl_a', 'apl_b']);
+    expect(items.map((i) => i.kind)).toEqual(['onsite', 'offsite']);
+  });
+
+  it('emits nextCursor only when a full page+1 is returned (pagination contract)', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      { id: 'apl_0', sort_key: '20260101000000000000' },
+      { id: 'apl_1', sort_key: '20260101000000000001' },
+      { id: 'apl_2', sort_key: '20260101000000000002' }, // the +1 (dropped)
+    ]);
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([
+      hydratedRow({ id: 'apl_0', slug: 's0' }),
+      hydratedRow({ id: 'apl_1', slug: 's1' }),
+    ]);
+    const { items, nextCursor } = await listAvailableListings({
+      kind: 'all',
+      sort: 'newest',
+      limit: 2,
+    });
+    expect(items).toHaveLength(2);
+    expect(nextCursor).toBeDefined();
+    // The cursor is the LAST returned row's (sortKey, id) — carries the sort key,
+    // not just the id, so a paged scan over tied sort values is stable.
+    const decoded = Buffer.from(nextCursor as string, 'base64url').toString('utf8');
+    expect(decoded).toBe(`20260101000000000001${SEP}apl_1`);
+  });
+
+  it('no nextCursor when the result fits in one page', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([{ id: 'apl_0', sort_key: 'k0' }]);
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([hydratedRow({ id: 'apl_0' })]);
+    const { nextCursor } = await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
+    expect(nextCursor).toBeUndefined();
+  });
+
+  it('sort=top-rated page 1 reads + PINS the global recommend mean into nextCursor', async () => {
+    // Call 1 = getGlobalRecommendMean (via queryCache → $queryRaw): mean 0.8.
+    mockDbRead.$queryRaw.mockResolvedValueOnce([{ mean: 0.8 }]);
+    // Call 2 = the id page (limit+1 so nextCursor is emitted).
+    mockDbRead.$queryRaw.mockResolvedValueOnce([
+      { id: 'apl_0', sort_key: '000000800' },
+      { id: 'apl_1', sort_key: '000000790' },
+      { id: 'apl_2', sort_key: '000000780' },
+    ]);
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([
+      hydratedRow({ id: 'apl_0' }),
+      hydratedRow({ id: 'apl_1' }),
+    ]);
+    const { nextCursor } = await listAvailableListings({ kind: 'all', sort: 'top-rated', limit: 2 });
+    const decoded = Buffer.from(nextCursor as string, 'base64url').toString('utf8');
+    expect(decoded).toBe(`000000790${SEP}apl_1${SEP}0.8`);
+  });
+
+  it('sort=top-rated with a pinned-mean cursor REUSES it (no global-mean re-read)', async () => {
+    const cursor = Buffer.from(`000000250${SEP}apl_5${SEP}0.25`, 'utf8').toString('base64url');
+    // ONLY the id-page query is queued — if the service re-read the mean it would
+    // consume this and the id page would get [].
+    mockDbRead.$queryRaw.mockResolvedValueOnce([{ id: 'apl_9', sort_key: '000000240' }]);
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([hydratedRow({ id: 'apl_9' })]);
+    const { items } = await listAvailableListings({
+      kind: 'all',
+      sort: 'top-rated',
+      cursor,
+      limit: 20,
+    });
+    expect(items).toHaveLength(1);
+    // Exactly ONE $queryRaw (the id page) — the mean re-read was skipped.
+    expect(mockDbRead.$queryRaw).toHaveBeenCalledTimes(1);
+    // The pinned mean 0.25 is bound into the Bayesian key (C*m term).
+    expect(capturedValues()).toContain(0.25);
+  });
+
+  it('returns an empty page (no hydration) when the keyset query is empty', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([]);
+    const { items, nextCursor } = await listAvailableListings({
+      kind: 'all',
+      sort: 'newest',
+      limit: 20,
+    });
+    expect(items).toEqual([]);
+    expect(nextCursor).toBeUndefined();
+    expect(mockDbRead.appListing.findMany).not.toHaveBeenCalled();
+  });
+
+  it('the list projection carries no internal-field leaks end-to-end', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([{ id: 'apl_0', sort_key: 'k0' }]);
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([hydratedRow({ id: 'apl_0' })]);
+    const { items } = await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
+    const serialized = JSON.stringify(items);
+    for (const secret of ['trustTier', 'internal.example', 'super-secret', 'status']) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+});
+
+describe('getListingDetail — approved-only + maturity gate', () => {
+  beforeEach(() => {
+    mockDbRead.appListing.findFirst.mockReset();
+  });
+
+  it('returns the projected detail for an approved listing (by slug)', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...hydratedRow(), status: 'approved' });
+    const detail = await getListingDetail({ slug: 'cool-app' });
+    expect(detail?.id).toBe('apl_1');
+    // Looked up by slug.
+    const where = (mockDbRead.appListing.findFirst.mock.calls.at(-1)?.[0] as { where?: unknown })
+      ?.where;
+    expect(where).toEqual({ slug: 'cool-app' });
+  });
+
+  it('looks up by id when id is provided', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...hydratedRow(), status: 'approved' });
+    await getListingDetail({ id: 'apl_1' });
+    const where = (mockDbRead.appListing.findFirst.mock.calls.at(-1)?.[0] as { where?: unknown })
+      ?.where;
+    expect(where).toEqual({ id: 'apl_1' });
+  });
+
+  it('returns null for a missing listing', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce(null);
+    expect(await getListingDetail({ slug: 'nope' })).toBeNull();
+  });
+
+  it.each(['draft', 'pending', 'rejected'])('returns null for a %s listing', async (status) => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...hydratedRow(), status });
+    expect(await getListingDetail({ slug: 'cool-app' })).toBeNull();
+  });
+
+  it('hides a mature (x) listing off a non-red host', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({
+      ...hydratedRow({ contentRating: 'x' }),
+      status: 'approved',
+    });
+    expect(await getListingDetail({ slug: 'cool-app' }, { redCapable: false })).toBeNull();
+  });
+
+  it('shows a mature (x) listing on a red-capable host', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({
+      ...hydratedRow({ contentRating: 'x' }),
+      status: 'approved',
+    });
+    const detail = await getListingDetail({ slug: 'cool-app' }, { redCapable: true });
+    expect(detail?.contentRating).toBe('x');
+  });
+});

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -1,0 +1,497 @@
+import { Prisma } from '@prisma/client';
+
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { env } from '~/env/server';
+import { CacheTTL } from '~/server/common/constants';
+import { dbRead } from '~/server/db/client';
+import { toPublicBlockManifest } from '~/server/schema/blocks/subscription.schema';
+import { isMatureContentRating } from '~/server/utils/server-domain';
+import type {
+  GetAppListingDetailInput,
+  ListAppListingsInput,
+  ListingCard,
+  ListingCardKindData,
+  ListingCreatorChip,
+  ListingDetail,
+  ListingDetailKindData,
+  ListingGalleryScreenshot,
+  ListingKind,
+  ListingRecommendRollup,
+  ListingSort,
+  OffsiteSubKind,
+} from '~/server/schema/blocks/app-listing-read.schema';
+import { queryCache } from '~/server/utils/cache-helpers';
+
+/**
+ * App Store Listings (W13) — P2a UNIFIED STORE READ PATH service.
+ *
+ * Serves the unified `/apps` store over BOTH kinds (`onsite` AppBlocks +
+ * `offsite` external/connect apps) from the durable `AppListing` record. This is
+ * the `AppListing`-backed twin of `block-registry.service`'s
+ * `listAvailable` / `getAppDetail`; it MIRRORS that path's shape (approved-only
+ * WHERE, public-allowlist projection, keyset cursor pagination, Bayesian sort,
+ * red-only maturity gate) but reads the new tables.
+ *
+ * DARK / parallel-run: nothing here is on the LIVE `/apps` surface — the UI
+ * still reads the AppBlock path. These procs are wired ALONGSIDE it behind the
+ * SAME mod-segmented App Blocks flag (see the router). The read-path CUTOVER +
+ * its dedicated `appListings` flag are later PRs.
+ *
+ * TODO(W13 cutover): introduce a dedicated `appListings` Flipt flag at the
+ * read-path cutover so listings can widen independently of the block runtime GA
+ * (which is separately HELD). Reusing `app-blocks-enabled` here keeps P2a dark
+ * without needing flipt-state creation before mods can even test.
+ *
+ * TODO(W13 pre-cutover): the icon/cover/screenshot URLs returned below render
+ * creator-supplied imagery publicly. Two P1-audit prerequisites MUST land before
+ * the flag widens to non-mods: (1) route MIGRATED bundle + AUTOGEN live-app
+ * creator imagery through the real per-image NSFW ingestion scan (P1 stamped
+ * them `Scanned` with an interim per-app contentRating level, which is per-app
+ * not per-image); (2) decide/gate the mod-override attach-foreign-image path
+ * (a private-image-exposure vector once rendered). Neither is fixed here — this
+ * PR is dark and mod-only.
+ */
+
+// ---------------------------------------------------------------------------
+// Sort-key encoding constants (mirror block-registry's Bayesian rating sort).
+// ---------------------------------------------------------------------------
+
+/**
+ * Bayesian prior COUNT for the `top-rated` recommend sort — how many "average"
+ * reviews a 0-review app is seeded with so a 1-review 100% app can't outrank a
+ * many-review 95% app. Mirrors the AppBlock rating sort's `BAYES_MIN_REVIEWS`.
+ */
+export const LISTING_BAYES_PRIOR = 10;
+
+// The recommend proportion is in [0,1]; scale to a zero-padded sortable integer.
+// 1 * SCALE = 1_000_000 → 7 digits; pad to 9 for headroom (matches AppBlock).
+const BAYES_SCORE_SCALE = 1_000_000;
+const BAYES_SCORE_PAD = 9;
+const INSTALL_PAD = 20; // matches the `popular` sort's install-count padding
+
+/** Neutral fallback recommend rate when the store has no reviews yet (dark/empty). */
+const DEFAULT_RECOMMEND_MEAN = 0.5;
+
+// ---------------------------------------------------------------------------
+// Keyset cursor (opaque base64url of `sortKey␟id[␟mean]`). Mirrors block-registry.
+// ---------------------------------------------------------------------------
+
+const CURSOR_SEPARATOR = String.fromCharCode(31); // unit separator (\x1f)
+
+/**
+ * Encode a keyset cursor. The `top-rated` sort PINS the global recommend mean
+ * into the cursor (as the AppBlock rating sort pins its mean) so every page of a
+ * paging session reuses page 1's mean — otherwise the 1h-cached mean could shift
+ * mid-pagination and the keyset boundary would silently skip/duplicate a row.
+ */
+export function encodeListingCursor(sortKey: string, id: string, pinnedMean?: number): string {
+  const body =
+    pinnedMean == null
+      ? `${sortKey}${CURSOR_SEPARATOR}${id}`
+      : `${sortKey}${CURSOR_SEPARATOR}${id}${CURSOR_SEPARATOR}${pinnedMean}`;
+  return Buffer.from(body, 'utf8').toString('base64url');
+}
+
+export function decodeListingCursor(cursor: string | undefined): {
+  cursorSortKey: string | null;
+  cursorId: string | null;
+  cursorMean: number | null;
+} {
+  const empty = { cursorSortKey: null, cursorId: null, cursorMean: null };
+  if (!cursor) return empty;
+  let decoded: string;
+  try {
+    decoded = Buffer.from(cursor, 'base64url').toString('utf8');
+  } catch {
+    return empty; // malformed → treat as first page (fail-open to a safe default)
+  }
+  const sep1 = decoded.indexOf(CURSOR_SEPARATOR);
+  if (sep1 < 0) return empty;
+  const sep2 = decoded.indexOf(CURSOR_SEPARATOR, sep1 + 1);
+  const cursorId = sep2 < 0 ? decoded.slice(sep1 + 1) : decoded.slice(sep1 + 1, sep2);
+  const meanField = sep2 < 0 ? '' : decoded.slice(sep2 + 1);
+  const meanNum = meanField === '' ? NaN : Number(meanField);
+  return {
+    cursorSortKey: decoded.slice(0, sep1),
+    cursorId,
+    cursorMean: Number.isFinite(meanNum) ? meanNum : null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure projection helpers (exported for unit tests — no DB / env / network).
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the recommend rollup from an `AppListingMetric` row (or null when the
+ * P5 rollup job hasn't populated one yet — every count reads 0, pct null).
+ */
+export function recommendRollup(
+  metric: { thumbsUpCount: number; thumbsDownCount: number } | null | undefined
+): ListingRecommendRollup {
+  const up = metric?.thumbsUpCount ?? 0;
+  const down = metric?.thumbsDownCount ?? 0;
+  const total = up + down;
+  return {
+    recommendedCount: up,
+    notRecommendedCount: down,
+    recommendPct: total > 0 ? up / total : null,
+  };
+}
+
+/** Off-site sub-kind: OAuth-connect when a connect client is set, else external-link. */
+export function resolveOffsiteSubKind(connectClientId: string | null | undefined): OffsiteSubKind {
+  return connectClientId ? 'connect' : 'external-link';
+}
+
+/** Build a CDN icon URL from an icon Image row (or null). */
+function iconUrl(icon: { url: string | null } | null | undefined): string | null {
+  return icon?.url ? getEdgeUrl(icon.url, { width: 256 }) : null;
+}
+
+/** Cover URL = the cover Image, else the first screenshot's Image, else null. */
+function coverUrl(
+  cover: { url: string | null } | null | undefined,
+  firstScreenshotUrl: string | null
+): string | null {
+  if (cover?.url) return getEdgeUrl(cover.url, { width: 1200 });
+  return firstScreenshotUrl;
+}
+
+function creatorChip(
+  user: { id: number; username: string | null; image: string | null } | null | undefined
+): ListingCreatorChip | null {
+  if (!user) return null;
+  return { id: user.id, username: user.username ?? null, image: user.image ?? null };
+}
+
+/** True when the backing AppBlock manifest declares a launch page (Open vs Install). */
+function manifestHasPage(manifest: unknown): boolean {
+  return !!toPublicBlockManifest(manifest).hasPage;
+}
+
+/**
+ * The Prisma `select` for a hydrated listing row (shared by card + detail). Only
+ * fields the public projection uses — the internal columns (status, ownership
+ * beyond the chip, raw manifest internals) are never selected into a public DTO.
+ */
+export const listingHydrateSelect = {
+  id: true,
+  kind: true,
+  slug: true,
+  name: true,
+  tagline: true,
+  description: true,
+  category: true,
+  contentRating: true,
+  externalUrl: true,
+  connectClientId: true,
+  appBlockId: true,
+  icon: { select: { url: true } },
+  cover: { select: { url: true } },
+  user: { select: { id: true, username: true, image: true } },
+  metric: { select: { thumbsUpCount: true, thumbsDownCount: true } },
+  appBlock: { select: { manifest: true } },
+  screenshots: {
+    where: { imageId: { not: null } },
+    orderBy: { order: 'asc' },
+    select: { caption: true, image: { select: { url: true } } },
+  },
+} satisfies Prisma.AppListingSelect;
+
+export type HydratedListing = Prisma.AppListingGetPayload<{ select: typeof listingHydrateSelect }>;
+
+/** First screenshot's CDN URL (used as the cover fallback), or null. */
+function firstScreenshotUrl(row: HydratedListing): string | null {
+  for (const s of row.screenshots) {
+    if (s.image?.url) return getEdgeUrl(s.image.url, { width: 1200 });
+  }
+  return null;
+}
+
+function cardKindData(row: HydratedListing): ListingCardKindData {
+  if (row.kind === 'offsite') {
+    return {
+      kind: 'offsite',
+      subKind: resolveOffsiteSubKind(row.connectClientId),
+      externalUrl: row.externalUrl ?? null,
+    };
+  }
+  return {
+    kind: 'onsite',
+    appBlockId: row.appBlockId ?? null,
+    hasPage: manifestHasPage(row.appBlock?.manifest),
+  };
+}
+
+/** Project a hydrated listing row → the PUBLIC card DTO (allowlist). */
+export function projectListingCard(row: HydratedListing): ListingCard {
+  const recommend = recommendRollup(row.metric);
+  return {
+    id: row.id,
+    slug: row.slug,
+    kind: row.kind as ListingKind,
+    name: row.name,
+    tagline: row.tagline ?? null,
+    category: row.category ?? null,
+    contentRating: row.contentRating ?? null,
+    iconUrl: iconUrl(row.icon),
+    coverUrl: coverUrl(row.cover, firstScreenshotUrl(row)),
+    creator: creatorChip(row.user),
+    recommend,
+    reviewCount: recommend.recommendedCount + recommend.notRecommendedCount,
+    kindData: cardKindData(row),
+  };
+}
+
+function detailKindData(row: HydratedListing): ListingDetailKindData {
+  if (row.kind === 'offsite') {
+    const subKind = resolveOffsiteSubKind(row.connectClientId);
+    return {
+      kind: 'offsite',
+      subKind,
+      externalUrl: row.externalUrl ?? null,
+      // The OAuth client_id is public (it's sent in the connect URL); the secret
+      // is never selected here. Null for an external-link listing.
+      connectClientId: subKind === 'connect' ? row.connectClientId ?? null : null,
+    };
+  }
+  return {
+    kind: 'onsite',
+    appBlockId: row.appBlockId ?? null,
+    hasPage: manifestHasPage(row.appBlock?.manifest),
+    // Already-public standalone origin (no token/scope) — same host the webhook
+    // validates the bundle's iframe against. Built from slug + APPS_DOMAIN.
+    liveUrl: `https://${row.slug}.${env.APPS_DOMAIN}`,
+  };
+}
+
+/** Ordered gallery — screenshots whose backing Image still exists. */
+function galleryScreenshots(row: HydratedListing): ListingGalleryScreenshot[] {
+  const out: ListingGalleryScreenshot[] = [];
+  for (const s of row.screenshots) {
+    // A row whose Image was deleted (imageId → null via onDelete: SetNull) must
+    // NOT render as a blank tile. The select already filters imageId != null, but
+    // guard defensively so a null-image row can never reach the wire.
+    if (!s.image?.url) continue;
+    out.push({ url: getEdgeUrl(s.image.url, { width: 1200 }), caption: s.caption ?? null });
+  }
+  return out;
+}
+
+/** Project a hydrated listing row → the PUBLIC detail DTO (allowlist). */
+export function projectListingDetail(row: HydratedListing): ListingDetail {
+  const recommend = recommendRollup(row.metric);
+  return {
+    id: row.id,
+    slug: row.slug,
+    kind: row.kind as ListingKind,
+    name: row.name,
+    tagline: row.tagline ?? null,
+    description: row.description ?? null,
+    category: row.category ?? null,
+    contentRating: row.contentRating ?? null,
+    iconUrl: iconUrl(row.icon),
+    coverUrl: coverUrl(row.cover, firstScreenshotUrl(row)),
+    creator: creatorChip(row.user),
+    recommend,
+    reviewCount: recommend.recommendedCount + recommend.notRecommendedCount,
+    screenshots: galleryScreenshots(row),
+    kindData: detailKindData(row),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SQL fragment builders (exported for the SQL drift-guard unit tests).
+// ---------------------------------------------------------------------------
+
+/**
+ * The `top-rated` Bayesian recommend sort key, as a single zero-padded sortable
+ * TEXT. Reused IDENTICALLY in SELECT (AS sort_key) + the keyset WHERE — if it
+ * drifts, keyset pagination silently skips rows.
+ *
+ *   score = (C*m + up) / (C + up + down)
+ *     C = prior (LISTING_BAYES_PRIOR), m = global recommend mean, up/down =
+ *     thumbsUp/Down from the AppListingMetric rollup (0 when absent).
+ *   0-review apps → score = m (mid-pack). Ties break on install_count then id.
+ */
+export function listingBayesianSortKey(globalMean: number): Prisma.Sql {
+  const score = Prisma.sql`(
+    (${LISTING_BAYES_PRIOR}::float * ${globalMean}::float + COALESCE(m.thumbs_up_count, 0))
+    / (${LISTING_BAYES_PRIOR}::float + COALESCE(m.thumbs_up_count, 0) + COALESCE(m.thumbs_down_count, 0))
+  )`;
+  // NB: lpad length args cast to ::int — Prisma binds JS number constants as
+  // bigint, and `lpad(text, bigint, unknown)` has no overload (signature is
+  // `lpad(text, integer, text)`) → the query 500s at runtime otherwise. (Same
+  // trap the AppBlock rating sort hit; see block-registry.service.)
+  return Prisma.sql`(
+    lpad(round(${score} * ${BAYES_SCORE_SCALE})::bigint::text, ${BAYES_SCORE_PAD}::int, '0')
+    || lpad(COALESCE(m.install_count, 0)::text, ${INSTALL_PAD}::int, '0')
+  )`;
+}
+
+/** The sort-key TEXT expression for a given sort (+ whether it sorts DESC). */
+export function listingSortKeyExpr(
+  sort: ListingSort,
+  globalMean: number
+): { expr: Prisma.Sql; descending: boolean } {
+  switch (sort) {
+    case 'top-rated':
+      return { expr: listingBayesianSortKey(globalMean), descending: true };
+    case 'popular':
+      return {
+        expr: Prisma.sql`lpad(COALESCE(m.install_count, 0)::text, ${INSTALL_PAD}::int, '0')`,
+        descending: true,
+      };
+    case 'newest':
+      return {
+        expr: Prisma.sql`to_char(al.created_at AT TIME ZONE 'UTC', 'YYYYMMDDHH24MISSUS')`,
+        descending: true,
+      };
+    case 'name':
+    default:
+      return { expr: Prisma.sql`LOWER(al.name)`, descending: false };
+  }
+}
+
+/**
+ * Maturity gate — hide mature (r/x) listings off a red-capable host. Mirrors the
+ * AppBlock `matureHostSqlFilter`. Fail-closed: a null/unknown rating is treated
+ * as SFW (kept); the direction is fail-closed for the MATURE rows we must hide.
+ */
+export function listingMatureFilter(redCapable: boolean): Prisma.Sql {
+  if (redCapable) return Prisma.sql`TRUE`;
+  return Prisma.sql`COALESCE(LOWER(al.content_rating), '') NOT IN ('r', 'x')`;
+}
+
+// ---------------------------------------------------------------------------
+// Global recommend mean (the Bayesian prior mean `m`, 1h-cached scalar).
+// ---------------------------------------------------------------------------
+
+/**
+ * The store-wide mean recommend rate `m` across listings that have reviews
+ * (up/(up+down) from the metric rollup), cached 1h. Falls back to the neutral
+ * 0.5 when the store has no reviews yet (dark/empty) so a 0-review world still
+ * produces a sane, stable `top-rated` sort.
+ */
+export async function getGlobalRecommendMean(): Promise<number> {
+  const cacheable = queryCache(dbRead, 'getGlobalListingRecommendMean', 'v1');
+  const rows = await cacheable<{ mean: number | null }[]>(
+    Prisma.sql`
+      SELECT AVG(m.thumbs_up_count::float / (m.thumbs_up_count + m.thumbs_down_count)) AS mean
+      FROM app_listing_metrics m
+      JOIN app_listings al ON al.id = m.app_listing_id
+      WHERE al.status = 'approved'
+        AND (m.thumbs_up_count + m.thumbs_down_count) > 0
+    `,
+    { ttl: CacheTTL.hour, tag: ['app-listing:recommend-global-mean'] }
+  );
+  return rows[0]?.mean ?? DEFAULT_RECOMMEND_MEAN;
+}
+
+// ---------------------------------------------------------------------------
+// Read procs (over BOTH kinds, approved-only, public allowlist).
+// ---------------------------------------------------------------------------
+
+/**
+ * List approved listings of BOTH kinds for the unified store. Keyset-paginated
+ * over a computed `sort_key`; the row-value tuple `(sort_key, id)` is a total
+ * keyset so a paged scan stays stable even across tied sort values.
+ *
+ * Two-step: a raw keyset query resolves the ORDERED, filtered page of ids
+ * (joining the metric rollup for the sort), then a single Prisma hydration
+ * fetches the public projection fields and we re-apply the raw order. This keeps
+ * the projection type-safe + testable while the sort/keyset stays exact.
+ */
+export async function listAvailableListings(
+  input: ListAppListingsInput,
+  opts: { redCapable?: boolean } = {}
+): Promise<{ items: ListingCard[]; nextCursor?: string }> {
+  const { kind, category, sort, cursor, limit } = input;
+  const redCapable = opts.redCapable ?? false;
+
+  const { cursorSortKey, cursorId, cursorMean } = decodeListingCursor(cursor);
+
+  // Only `top-rated` needs the global mean. PIN it into the cursor across a
+  // paging session (page 1 reads the 1h cache + encodes it; pages 2..N reuse
+  // the pinned value, NOT a fresh read) so the sort key can't shift mid-scan.
+  const globalMean =
+    sort === 'top-rated' ? cursorMean ?? (await getGlobalRecommendMean()) : 0;
+
+  const { expr: sortKeyExpr, descending } = listingSortKeyExpr(sort, globalMean);
+  const dir = descending ? Prisma.sql`DESC` : Prisma.sql`ASC`;
+  const keysetCmp = descending ? Prisma.sql`<` : Prisma.sql`>`;
+  const kindParam = kind === 'all' ? null : kind;
+  const categoryParam = category ?? null;
+
+  const idRows = await dbRead.$queryRaw<{ id: string; sort_key: string }[]>(Prisma.sql`
+    SELECT al.id, ${sortKeyExpr} AS sort_key
+    FROM app_listings al
+    LEFT JOIN app_listing_metrics m ON m.app_listing_id = al.id
+    WHERE al.status = 'approved'
+      AND (${kindParam}::text IS NULL OR al.kind = ${kindParam}::text)
+      AND (${categoryParam}::text IS NULL OR al.category = ${categoryParam}::text)
+      AND ${listingMatureFilter(redCapable)}
+      AND (
+        ${cursorSortKey}::text IS NULL
+        OR (${sortKeyExpr}, al.id) ${keysetCmp} (${cursorSortKey}::text, ${cursorId}::text)
+      )
+    ORDER BY sort_key ${dir}, al.id ${dir}
+    LIMIT ${limit + 1}
+  `);
+
+  const trimmed = idRows.slice(0, limit);
+  const last = trimmed[trimmed.length - 1];
+  const pinnedMean = sort === 'top-rated' ? globalMean : undefined;
+  const nextCursor =
+    idRows.length > limit && last
+      ? encodeListingCursor(last.sort_key, last.id, pinnedMean)
+      : undefined;
+
+  if (trimmed.length === 0) return { items: [], nextCursor: undefined };
+
+  // Hydrate the public projection for the page, then re-apply the keyset order
+  // (findMany does not preserve the `IN (...)` order).
+  const pageIds = trimmed.map((r) => r.id);
+  const hydrated = await dbRead.appListing.findMany({
+    where: { id: { in: pageIds } },
+    select: listingHydrateSelect,
+  });
+  const byId = new Map(hydrated.map((r) => [r.id, r]));
+  const items = pageIds
+    .map((id) => byId.get(id))
+    .filter((r): r is HydratedListing => r != null)
+    .map(projectListingCard);
+
+  return { items, nextCursor };
+}
+
+/**
+ * Per-listing public detail, by EXACTLY ONE of slug or id. Approved-only: a
+ * missing OR non-approved (draft/pending/rejected) listing returns null — the
+ * router maps that to NOT_FOUND so an unapproved listing can't be enumerated.
+ * Off a red-capable host a mature (r/x) listing also returns null (→ NOT_FOUND).
+ */
+export async function getListingDetail(
+  input: GetAppListingDetailInput,
+  opts: { redCapable?: boolean } = {}
+): Promise<ListingDetail | null> {
+  const redCapable = opts.redCapable ?? false;
+  const where: Prisma.AppListingWhereInput = input.id
+    ? { id: input.id }
+    : { slug: input.slug };
+
+  const row = await dbRead.appListing.findFirst({
+    where,
+    select: { ...listingHydrateSelect, status: true },
+  });
+  // Status check in the app layer (like the AppBlock path) so a future caller
+  // can't reuse this for a non-public path: a non-approved row returns null
+  // exactly like a missing one — never its data.
+  if (!row || row.status !== 'approved') return null;
+  // Maturity gate off a non-red host: a mature listing is indistinguishable from
+  // a missing one (mirrors the AppBlock detail's red-only 404).
+  if (!redCapable && isMatureContentRating(row.contentRating)) return null;
+
+  return projectListingDetail(row);
+}

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -111,10 +111,17 @@ export function decodeListingCursor(cursor: string | undefined): {
   const cursorId = sep2 < 0 ? decoded.slice(sep1 + 1) : decoded.slice(sep1 + 1, sep2);
   const meanField = sep2 < 0 ? '' : decoded.slice(sep2 + 1);
   const meanNum = meanField === '' ? NaN : Number(meanField);
+  // The mean is a recommend PROPORTION in [0,1]; a crafted cursor could encode a
+  // huge/negative value that flows unclamped into `round(score * SCALE)::bigint`
+  // (int8 overflow → Postgres "bigint out of range" → 500). Only accept an
+  // in-range proportion; anything else is treated as an invalid mean component
+  // (dropped → the caller falls back to the freshly-computed global mean /
+  // first-page behavior, matching the malformed-cursor fail-open).
+  const cursorMean = Number.isFinite(meanNum) && meanNum >= 0 && meanNum <= 1 ? meanNum : null;
   return {
     cursorSortKey: decoded.slice(0, sep1),
     cursorId,
-    cursorMean: Number.isFinite(meanNum) ? meanNum : null,
+    cursorMean,
   };
 }
 
@@ -142,6 +149,16 @@ export function recommendRollup(
 /** Off-site sub-kind: OAuth-connect when a connect client is set, else external-link. */
 export function resolveOffsiteSubKind(connectClientId: string | null | undefined): OffsiteSubKind {
   return connectClientId ? 'connect' : 'external-link';
+}
+
+/**
+ * Re-assert (defense-in-depth) that an off-site `externalUrl` is an https URL
+ * before it reaches the wire — so a bad row can never surface a `javascript:` /
+ * `http:` Visit target to the P2b UI, even if a write-path validation regresses.
+ * NB: the P2b UI must STILL render this link with `rel="noopener noreferrer"`.
+ */
+function safeExternalUrl(url: string | null | undefined): string | null {
+  return url && /^https:\/\//i.test(url) ? url : null;
 }
 
 /** Build a CDN icon URL from an icon Image row (or null). */
@@ -194,7 +211,9 @@ export const listingHydrateSelect = {
   appBlock: { select: { manifest: true } },
   screenshots: {
     where: { imageId: { not: null } },
-    orderBy: { order: 'asc' },
+    // Stable order: `id` tiebreaks rows with a tied `order` (default 0), which
+    // would otherwise sort nondeterministically across requests.
+    orderBy: [{ order: 'asc' }, { id: 'asc' }],
     select: { caption: true, image: { select: { url: true } } },
   },
 } satisfies Prisma.AppListingSelect;
@@ -214,7 +233,7 @@ function cardKindData(row: HydratedListing): ListingCardKindData {
     return {
       kind: 'offsite',
       subKind: resolveOffsiteSubKind(row.connectClientId),
-      externalUrl: row.externalUrl ?? null,
+      externalUrl: safeExternalUrl(row.externalUrl),
     };
   }
   return {
@@ -250,7 +269,7 @@ function detailKindData(row: HydratedListing): ListingDetailKindData {
     return {
       kind: 'offsite',
       subKind,
-      externalUrl: row.externalUrl ?? null,
+      externalUrl: safeExternalUrl(row.externalUrl),
       // The OAuth client_id is public (it's sent in the connect URL); the secret
       // is never selected here. Null for an external-link listing.
       connectClientId: subKind === 'connect' ? row.connectClientId ?? null : null,
@@ -350,7 +369,13 @@ export function listingSortKeyExpr(
       };
     case 'name':
     default:
-      return { expr: Prisma.sql`LOWER(al.name)`, descending: false };
+      // `name` is unbounded `text`; the RAW sort key is encoded into the base64
+      // cursor, so a long name would overflow `cursor: z.string().max(128)` and
+      // halt pagination (BAD_REQUEST). Bound the key to 64 chars — IDENTICAL in
+      // SELECT + the keyset WHERE (same `expr`), so paging stays exact; `al.id`
+      // remains the total-order tiebreak, so a 64-char-truncation collision
+      // still paginates correctly.
+      return { expr: Prisma.sql`left(LOWER(al.name), 64)`, descending: false };
   }
 }
 
@@ -477,6 +502,11 @@ export async function getListingDetail(
   opts: { redCapable?: boolean } = {}
 ): Promise<ListingDetail | null> {
   const redCapable = opts.redCapable ?? false;
+  // Assert exactly-one selector in the SERVICE (the zod `.refine` only guards the
+  // tRPC boundary, but this fn is exported). Neither → `findFirst({ slug:
+  // undefined })` would return an ARBITRARY approved row (enumeration footgun);
+  // both → ambiguous. Fail closed to null in either case.
+  if (!input.id === !input.slug) return null;
   const where: Prisma.AppListingWhereInput = input.id
     ? { id: input.id }
     : { slug: input.slug };


### PR DESCRIPTION
## What

Backend-only PR for **App Store Listings (W13) Phase 2, PR 1 (P2a)**: the tRPC read procs that serve the unified `/apps` store over **BOTH kinds** (`onsite` AppBlocks + `offsite` external/connect apps) from the durable `AppListing` record (P0/P1 already merged).

**Dark / parallel-run / no-UI.** Nothing here is on the live `/apps` surface — the UI still reads the AppBlock path. These procs live **alongside** `blocks.listAvailable` / `blocks.getAppDetail`; the UI switch + cutover are later PRs. This PR does **not** touch the existing AppBlock read path.

## Procs (both on the existing `appListings` router, registered in P1)

- **`appListings.listAvailable`** (`publicProcedure`) — approved rows of both kinds, keyset-paginated over a computed `sort_key`.
  - Inputs: `kind` (all|onsite|offsite), `category?`, `sort` (top-rated|popular|newest|name), `cursor`, `limit`.
  - `top-rated` = Bayesian shrinkage on the **recommend proportion** (up/(up+down)), mirroring the AppBlock `rating` sort on a [0,1] rate; 0-review apps sit mid-pack at the global mean; the mean is pinned into the cursor across a paging session (as the AppBlock sort does).
- **`appListings.getAppDetail`** (`publicProcedure`) — approved-only, by **exactly one** of `slug` or `id`. Card fields + `description` + ordered screenshot gallery + kind-aware action data.

## Allowlist projection (exact fields exposed)

Public DTOs in `app-listing-read.schema.ts` — a field can only leak if added on purpose. **Card:** `id, slug, kind, name, tagline, category, contentRating, iconUrl, coverUrl, creator{id,username,image}, recommend{recommendedCount,notRecommendedCount,recommendPct}, reviewCount, kindData`. **kindData** — onsite: `{appBlockId, hasPage}` (hasPage → Open vs Install); offsite: `{subKind: connect|external-link, externalUrl}`. **Detail** adds `description`, `screenshots[]{url,caption}`, and kindData → onsite `{appBlockId, hasPage, liveUrl}`, offsite `{subKind, externalUrl, connectClientId}` (the connect `client_id` is public, never a secret).

Never exposed: `trustTier`, raw `iframe.src`, OAuth secrets, owner PII beyond the chip, DB `status`. Recommend rollup reads `AppListingMetric.thumbsUp/DownCount` (P5-populated → gracefully 0/null when the metric row is absent). Icon/cover/screenshot URLs via the standard `getEdgeUrl` path; cover falls back to the first screenshot.

## Reuse decisions

- Mirrors `block-registry.service`'s `listAvailable`/`getAppDetail`: approved-only WHERE, public-allowlist projection, keyset cursor (opaque base64url `sortKey␟id[␟mean]`), `lpad`-encoded Bayesian sort key (incl. the `::int` cast trap), red-only maturity gate (`isMatureContentRating`), the `_appBlocksDisabled` empty-page/NOT_FOUND dark posture.
- Reuses `getEdgeUrl` (edge URL), `simpleUserSelect`-style `{id,username,image}` creator chip, `MARKETPLACE_CATEGORIES` (category taxonomy), `toPublicBlockManifest().hasPage` (page detection), `queryCache` (1h global-mean scalar).

## Flag

Reuses `app-blocks-enabled` (no dead Flipt flag). `TODO(W13 cutover)` marks where the dedicated `appListings` flag lands so listings can widen independently of the HELD block-runtime GA. `TODO(W13 pre-cutover)` marks the two deferred P1-audit prerequisites (per-image NSFW rescan of creator imagery; mod-override attach-foreign-image gate) that MUST land before the flag widens to non-mods.

## Schema / migrations

None. The P0 indexes (`status,kind` / `featured,order` / `category` / `userId` / FK indexes) cover the read path.

## Tests

`app-listing.service.test.ts` — **49 unit tests, all passing** (DB mocked). Covers: public allowlist (asserts no `trustTier`/`iframe.src`/secret leaks), both kinds + kind filter, all sort variants incl. top-rated Bayesian shrinkage + pinned-mean cursor reuse, category filter, keyset pagination (>page-size, cursor decode), recommend% math incl. the metric-absent (0/null) case, null-image screenshots excluded from the gallery, approved-only (draft/pending/rejected excluded) + red-only maturity gate. Full blocks-services suite (684 tests) green.

**Do not merge — needs an adversarial audit.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)