### PR TITLE
fix(air): pass primary fileType when building popularity-cache AIR

### DIFF
--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -18,6 +18,7 @@ import type { EntityAccessDataType } from '~/server/services/common.service';
 import { getModelClient } from '~/server/services/orchestrator/models';
 import type { CachedObject } from '~/server/utils/cache-helpers';
 import { createCachedObject } from '~/server/utils/cache-helpers';
+import { getPrimaryFile } from '~/server/utils/model-helpers';
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
 import { stringifyAIR } from '~/shared/utils/air';
 import {
@@ -1555,12 +1556,20 @@ export const modelVersionResourceCache = createCachedObject<ModelVersionResource
     const db = fromWrite ? dbWrite : dbRead;
     const mvInfo = await db.modelVersion.findMany({
       where: { id: { in: ids } },
-      select: { id: true, baseModel: true, model: { select: { id: true, type: true } } },
+      select: {
+        id: true,
+        baseModel: true,
+        model: { select: { id: true, type: true } },
+        files: { select: { type: true, metadata: true } },
+      },
     });
 
     const versionInfo = await Promise.all(
       mvInfo.map(async (v) => {
         try {
+          const primaryFile = getPrimaryFile(
+            v.files as { type: string; metadata: BasicFileMetadata }[]
+          );
           const md = await getModelClient({
             token: env.ORCHESTRATOR_ACCESS_TOKEN,
             air: stringifyAIR({
@@ -1568,6 +1577,7 @@ export const modelVersionResourceCache = createCachedObject<ModelVersionResource
               type: v.model.type,
               modelId: v.model.id,
               id: v.id,
+              fileType: primaryFile?.type,
             }),
           });
           if (!md || !!md.error)


### PR DESCRIPTION
Follow-up to #2819 (ClickUp [868k6d1f6](https://app.clickup.com/t/868k6d1f6)).

## Problem
`modelVersionResourceCache` (`caches.ts`) builds the orchestrator lookup AIR from `model.type` only. After #2819, the live generation path registers a diffusion-model checkpoint under `...:diffusionmodel:...`, but this cache still queried `...:checkpoint:...`. The mismatch made `getModelClient` miss, so popularity/featured silently fell back to `popularityRank: 0 / isFeatured: false`.

## Fix
Select the version's `files`, resolve the primary file with `getPrimaryFile`, and forward its `type` into `stringifyAIR` so the cache AIR matches the generation AIR.

## Notes
- One extra `files` select on a `CacheTTL.day` batched lookup — negligible.
- Non-diffusion checkpoints are unaffected (primary file type falls back to the ModelType mapping).
- Typecheck clean for this file. (Pre-existing unrelated errors in `bitdex-stats`/`flipt/client`/`image.service` come from local `event-engine-common` submodule drift, not this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)