### PR TITLE
feat(app-blocks): W13 P2b — kind-aware store cards + listing marketplace grid

### DIFF
--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { AppListingCard } from '~/components/Apps/AppListingCard';
+import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * P2b AppListingCard component tests (REPORT-ONLY — the browser project is
+ * non-blocking; the blocking gate is appListingCardView.test.ts). These pin the
+ * rendered kind badge, recommend label, and kind-aware CTA affordance for a few
+ * representative cards.
+ */
+
+function base(over: Partial<ListingCard>): ListingCard {
+  return {
+    id: 'l1',
+    slug: 'my-app',
+    kind: 'onsite',
+    name: 'My App',
+    tagline: 'A handy app',
+    category: 'utility',
+    contentRating: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: { id: 5, username: 'alice', image: null },
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    kindData: { kind: 'onsite', appBlockId: 'blk-1', hasPage: true },
+    ...over,
+  };
+}
+
+describe('AppListingCard', () => {
+  test('on-site page app + canOpenPage → Open link to the run route', async () => {
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await expect.element(page.getByText('My App')).toBeInTheDocument();
+    await expect.element(page.getByText('App')).toBeInTheDocument();
+    await expect.element(page.getByText('by alice')).toBeInTheDocument();
+    const open = page.getByRole('link', { name: 'Open' });
+    await expect.element(open).toBeInTheDocument();
+    await expect.element(open).toHaveAttribute('href', '/apps/run/my-app');
+  });
+
+  test('no reviews → "No reviews yet"', async () => {
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await expect.element(page.getByText('No reviews yet')).toBeInTheDocument();
+  });
+
+  test('reviewed app → "N% recommend (M)"', async () => {
+    renderWithProviders(
+      <AppListingCard
+        card={base({
+          recommend: { recommendedCount: 9, notRecommendedCount: 1, recommendPct: 0.9 },
+          reviewCount: 10,
+        })}
+        canOpenPage
+      />
+    );
+    await expect.element(page.getByText('90% recommend (10)')).toBeInTheDocument();
+  });
+
+  test('off-site external-link https → Visit ↗ external anchor', async () => {
+    renderWithProviders(
+      <AppListingCard
+        card={base({
+          kind: 'offsite',
+          name: 'External App',
+          kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://ext.app' },
+        })}
+      />
+    );
+    await expect.element(page.getByText('Off-site')).toBeInTheDocument();
+    const visit = page.getByRole('link', { name: 'Visit' });
+    await expect.element(visit).toHaveAttribute('href', 'https://ext.app');
+    await expect.element(visit).toHaveAttribute('target', '_blank');
+    await expect.element(visit).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  test('off-site connect → Connect badge + inert (disabled) CTA', async () => {
+    renderWithProviders(
+      <AppListingCard
+        card={base({
+          kind: 'offsite',
+          name: 'Connect App',
+          kindData: { kind: 'offsite', subKind: 'connect', externalUrl: null },
+        })}
+      />
+    );
+    await expect.element(page.getByText('Connect app')).toBeInTheDocument();
+    const connect = page.getByRole('button', { name: 'Connect' });
+    await expect.element(connect).toBeDisabled();
+  });
+
+  test('on-site page app WITHOUT canOpenPage → View details (no dead run link)', async () => {
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage={false} />);
+    const details = page.getByRole('link', { name: 'View details' });
+    await expect.element(details).toHaveAttribute('href', '/apps/blk-1');
+  });
+});

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -1,0 +1,257 @@
+import { Anchor, Avatar, Badge, Box, Button, Card, Group, Image, Stack, Text, Title, Tooltip } from '@mantine/core';
+import {
+  IconApps,
+  IconExternalLink,
+  IconPlugConnected,
+  IconThumbUp,
+} from '@tabler/icons-react';
+import type { Icon } from '@tabler/icons-react';
+import Link from 'next/link';
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import {
+  CATEGORY_ICONS,
+  FALLBACK_CATEGORY_ICON,
+} from '~/components/Apps/marketplaceCategoryIcons';
+import {
+  getListingBadge,
+  getListingCta,
+  getRecommendLabel,
+  type ListingBadgeKind,
+} from '~/components/Apps/appListingCardView';
+import {
+  isMarketplaceCategory,
+  MARKETPLACE_CATEGORY_LABELS,
+} from '~/server/services/blocks/marketplace-categories.constants';
+import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * App Store Listings (W13) — P2b unified store CARD, over BOTH kinds.
+ *
+ * Renders one `ListingCard` (from `appListings.listAvailable`): cover + app icon
+ * + name + tagline + creator chip + a kind badge (App / Connect app / Off-site)
+ * + the Steam-style recommend rollup + a kind-aware CTA (Open / View details /
+ * Visit ↗ / Connect). Mirrors the visual language of the live `AppBlockCard`
+ * (Mantine Card + category-glyph cover placeholder) so listings feel native.
+ *
+ * DARK / parallel-run: used only by the mod-only `/apps/store-preview` surface —
+ * the default `/apps` render (MarketplaceBody → AppBlockCard) is untouched.
+ *
+ * Reuse note: the plan (§6.1) suggests rendering through `AspectRatioImageCard`
+ * for cosmetic frames + per-image maturity blur. That component's image slot
+ * needs a full `Image` object (id / nsfwLevel / hash / metadata / type), but the
+ * P2a public DTO deliberately projects only a bare `coverUrl`/`iconUrl` string
+ * (allowlist — no per-image internals). The listing read is already maturity-
+ * gated server-side (r/x hidden off a red-capable host), so we mirror
+ * AppBlockCard's proven Mantine-Card + placeholder pattern here. Feeding
+ * AspectRatioImageCard (cosmetic frames) would need the DTO to carry the Image
+ * object — a P2a schema addition, out of scope for P2b (flagged in the PR).
+ */
+
+const KIND_BADGE_ICON: Record<ListingBadgeKind, Icon> = {
+  onsite: IconApps,
+  connect: IconPlugConnected,
+  'external-link': IconExternalLink,
+};
+
+const KIND_BADGE_COLOR: Record<ListingBadgeKind, string> = {
+  onsite: 'blue',
+  connect: 'teal',
+  'external-link': 'blue',
+};
+
+function categoryLabel(category: string): string {
+  return isMarketplaceCategory(category) ? MARKETPLACE_CATEGORY_LABELS[category] : category;
+}
+
+function categoryIcon(category: string): Icon {
+  return isMarketplaceCategory(category) ? CATEGORY_ICONS[category] : FALLBACK_CATEGORY_ICON;
+}
+
+/**
+ * Card cover — the listing's cover image (`coverUrl`, already a CDN URL, with the
+ * first screenshot as a server-side fallback). When absent, a tasteful
+ * category-glyph placeholder over a neutral gradient (mirrors AppBlockCard) so a
+ * card is never a broken/empty `<img>`. Decorative (aria-hidden) — the placeholder
+ * carries no info the title/category chip don't.
+ */
+function ListingCover({
+  coverUrl,
+  category,
+  name,
+}: {
+  coverUrl: string | null;
+  category: string | null;
+  name: string;
+}) {
+  if (coverUrl) {
+    return (
+      <Card.Section>
+        <Image src={coverUrl} alt={`${name} cover image`} h={140} fit="cover" />
+      </Card.Section>
+    );
+  }
+  const PlaceholderIcon = category ? categoryIcon(category) : IconApps;
+  return (
+    <Card.Section>
+      <Box
+        aria-hidden
+        h={140}
+        className="flex items-center justify-center"
+        style={{
+          background:
+            'linear-gradient(135deg, var(--mantine-color-dark-5) 0%, var(--mantine-color-dark-7) 100%)',
+        }}
+      >
+        <PlaceholderIcon size={44} className="opacity-40" />
+      </Box>
+    </Card.Section>
+  );
+}
+
+/**
+ * "by {creator}" chip — restores the attribution line AppBlockCard dropped. Uses
+ * the public creator chip (id / username / image). Links to the creator profile.
+ * (UserAvatarSimple wants a rich `ProfileImage` + cosmetics object; the DTO only
+ * carries a bare `image` string, so we render a lightweight avatar here — noted
+ * as a reuse tradeoff in the PR.)
+ */
+function CreatorChip({ creator }: { creator: ListingCard['creator'] }) {
+  if (!creator || !creator.username) return null;
+  const avatarSrc = creator.image ? getEdgeUrl(creator.image, { width: 64 }) : undefined;
+  return (
+    <Anchor
+      component={Link}
+      href={`/user/${encodeURIComponent(creator.username)}`}
+      underline="never"
+      c="dimmed"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <Group gap={6} wrap="nowrap">
+        <Avatar src={avatarSrc} alt="" radius="xl" size={20}>
+          {creator.username.charAt(0).toUpperCase()}
+        </Avatar>
+        <Text size="xs" c="dimmed" lineClamp={1}>
+          by {creator.username}
+        </Text>
+      </Group>
+    </Anchor>
+  );
+}
+
+export interface AppListingCardProps {
+  card: ListingCard;
+  /**
+   * Whether the viewer can open a full-page app (the `appBlocksPages` flag). When
+   * false an on-site page app's CTA falls back to "View details" instead of a
+   * dead "Open" link (the `/apps/run/<slug>` route 404s without the flag).
+   */
+  canOpenPage?: boolean;
+}
+
+export function AppListingCard({ card, canOpenPage = false }: AppListingCardProps) {
+  const badge = getListingBadge(card);
+  const cta = getListingCta(card, { canOpenPage });
+  const recommendLabel = getRecommendLabel(card.recommend, card.reviewCount);
+  const BadgeIcon = KIND_BADGE_ICON[badge.kind];
+
+  return (
+    <Card shadow="sm" padding="md" radius="md" withBorder className="h-full">
+      <ListingCover coverUrl={card.coverUrl} category={card.category} name={card.name} />
+      <Stack gap="sm" h="100%" pt="sm">
+        <Group justify="space-between" align="flex-start" wrap="nowrap">
+          <Group gap="xs" wrap="nowrap" align="flex-start" style={{ minWidth: 0 }}>
+            {/* App icon (square, publisher-supplied). Decorative — the title
+                carries the accessible name; a missing icon falls back to the
+                app's initial. */}
+            <Avatar src={card.iconUrl ?? undefined} alt="" radius="md" size={40}>
+              {card.name.charAt(0).toUpperCase()}
+            </Avatar>
+            <Stack gap={2} style={{ minWidth: 0 }}>
+              <Title order={4} className="line-clamp-2">
+                {card.name}
+              </Title>
+              <CreatorChip creator={card.creator} />
+            </Stack>
+          </Group>
+          <Stack gap={4} align="flex-end">
+            {/* Kind badge — App (on-site) vs Connect app / Off-site (off-site). */}
+            <Badge
+              variant="light"
+              color={KIND_BADGE_COLOR[badge.kind]}
+              size="sm"
+              leftSection={<BadgeIcon size={12} />}
+            >
+              {badge.label}
+            </Badge>
+            {card.category && (() => {
+              const CategoryIcon = categoryIcon(card.category);
+              return (
+                <Badge
+                  variant="light"
+                  color="grape"
+                  size="sm"
+                  leftSection={<CategoryIcon size={12} />}
+                >
+                  {categoryLabel(card.category)}
+                </Badge>
+              );
+            })()}
+          </Stack>
+        </Group>
+
+        {card.tagline && (
+          <Text size="sm" c="dimmed" className="line-clamp-3">
+            {card.tagline}
+          </Text>
+        )}
+
+        <Group justify="space-between" mt="auto" pt="xs" wrap="nowrap">
+          {/* Recommend rollup — "N% recommend (M)" or "No reviews yet". */}
+          <Group gap={4} wrap="nowrap">
+            <IconThumbUp
+              size={13}
+              className={card.recommend.recommendPct == null ? 'text-gray-500' : 'text-green-500'}
+            />
+            <Text size="xs" c="dimmed">
+              {recommendLabel}
+            </Text>
+          </Group>
+
+          {/* Kind-aware CTA. A disabled CTA (no working target in the dark phase)
+              renders inert with a tooltip so the card is never actionless. */}
+          {cta.disabled ? (
+            <Tooltip label="Available at launch" withArrow>
+              {/* Tooltip needs a non-disabled wrapper to receive hover events. */}
+              <span>
+                <Button size="xs" variant="light" disabled>
+                  {cta.label}
+                </Button>
+              </span>
+            </Tooltip>
+          ) : cta.external && cta.href ? (
+            <Button
+              component="a"
+              href={cta.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              size="xs"
+              variant="light"
+              rightSection={<IconExternalLink size={14} />}
+            >
+              {cta.label}
+            </Button>
+          ) : (
+            <Button
+              component={Link}
+              href={cta.href ?? '#'}
+              size="xs"
+              variant={cta.action === 'open' ? 'filled' : 'light'}
+            >
+              {cta.label}
+            </Button>
+          )}
+        </Group>
+      </Stack>
+    </Card>
+  );
+}

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -7,6 +7,7 @@ import {
 } from '@tabler/icons-react';
 import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
+import { useState } from 'react';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import {
   CATEGORY_ICONS,
@@ -83,10 +84,20 @@ function ListingCover({
   category: string | null;
   name: string;
 }) {
-  if (coverUrl) {
+  // A non-null coverUrl can still 404 (the server derives it from a first-
+  // screenshot fallback, whose Image can dangle) — fall back to the category
+  // glyph placeholder on load error instead of a broken <img>.
+  const [broken, setBroken] = useState(false);
+  if (coverUrl && !broken) {
     return (
       <Card.Section>
-        <Image src={coverUrl} alt={`${name} cover image`} h={140} fit="cover" />
+        <Image
+          src={coverUrl}
+          alt={`${name} cover image`}
+          h={140}
+          fit="cover"
+          onError={() => setBroken(true)}
+        />
       </Card.Section>
     );
   }

--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * P2b AppListingsMarketplaceBody wiring tests (REPORT-ONLY). Network-free — the
+ * P2a `appListings.listAvailable` infinite query + feature flags are mocked.
+ * Covers the kind filter passing through to the query args, the sort/category
+ * controls rendering, and the card grid rendering the returned listings.
+ */
+
+function makeCard(id: string, name: string, kind: 'onsite' | 'offsite' = 'onsite'): ListingCard {
+  return {
+    id,
+    slug: `slug-${id}`,
+    kind,
+    name,
+    tagline: 'tag',
+    category: null,
+    contentRating: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    kindData:
+      kind === 'onsite'
+        ? { kind: 'onsite', appBlockId: `blk-${id}`, hasPage: false }
+        : { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://x.app' },
+  };
+}
+
+const mocks = vi.hoisted(() => ({
+  items: [] as ListingCard[],
+  lastArgs: null as null | Record<string, unknown>,
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    appListings: {
+      listAvailable: {
+        useInfiniteQuery: (input: Record<string, unknown>) => {
+          mocks.lastArgs = input;
+          return {
+            data: { pages: [{ items: mocks.items, nextCursor: undefined }] },
+            isLoading: false,
+            isFetchingNextPage: false,
+            fetchNextPage: vi.fn(),
+            hasNextPage: false,
+          };
+        },
+      },
+    },
+  },
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: false }),
+}));
+
+// Import AFTER mocks (vi.mock is hoisted, static imports are not).
+const { AppListingsMarketplaceBody } = await import('./AppListingsMarketplaceBody');
+
+beforeEach(() => {
+  mocks.items = [makeCard('a', 'Alpha App'), makeCard('b', 'Bravo App', 'offsite')];
+  mocks.lastArgs = null;
+});
+
+describe('AppListingsMarketplaceBody', () => {
+  test('renders the returned listings as cards + the kind/sort controls', async () => {
+    renderWithProviders(<AppListingsMarketplaceBody />);
+    await expect.element(page.getByText('Alpha App')).toBeInTheDocument();
+    await expect.element(page.getByText('Bravo App')).toBeInTheDocument();
+    // Kind filter present, defaulting to All.
+    await expect.element(page.getByRole('button', { name: 'All apps' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    // Query fired with kind=all default.
+    expect(mocks.lastArgs).toMatchObject({ kind: 'all', sort: 'top-rated', limit: 24 });
+  });
+
+  test('clicking a kind toggle passes kind through to the query', async () => {
+    renderWithProviders(<AppListingsMarketplaceBody />);
+    await userEvent.click(page.getByRole('button', { name: 'Off-site' }));
+    expect(mocks.lastArgs).toMatchObject({ kind: 'offsite' });
+  });
+
+  test('empty result → "No apps yet"', async () => {
+    mocks.items = [];
+    renderWithProviders(<AppListingsMarketplaceBody />);
+    await expect.element(page.getByText('No apps yet')).toBeInTheDocument();
+  });
+});

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -1,0 +1,215 @@
+import { Button, Center, Grid, Group, Loader, Select, Stack, Text, TextInput } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { IconApps, IconExternalLink, IconLayoutGrid, IconSearch } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+import { AppListingCard } from '~/components/Apps/AppListingCard';
+import { CategoryFilterButtons } from '~/components/Apps/CategoryFilterButtons';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { type MarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
+import type {
+  ListingCard,
+  ListingKindFilter,
+  ListingSort,
+} from '~/server/schema/blocks/app-listing-read.schema';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App Store Listings (W13) — P2b unified store BODY (grid over BOTH kinds).
+ *
+ * Consumes `appListings.listAvailable` (the P2a read path) and renders the
+ * kind-aware `AppListingCard` grid with a kind filter (all / on-site / off-site),
+ * the category icon toggles, the 4 store sorts, cursor pagination, and
+ * empty/loading states. Mirrors the structure of the live `MarketplaceBody` so
+ * the two feel identical.
+ *
+ * DARK / parallel-run: mounted only by the mod-only `/apps/store-preview`
+ * surface. The default `/apps` render (MarketplaceBody → AppBlockCard) is
+ * untouched; the cutover is a later PR (P2d).
+ *
+ * ⚠️ Search gap: the P2a `listAvailable` input has NO `query` field (kind /
+ * category / sort / cursor / limit only). Server-side search would need a P2a
+ * addition — out of scope here (don't add a proc). The search box below filters
+ * client-side over the LOADED pages (name + tagline). With today's small catalog
+ * (~1 page) that's complete; once listings exceed one page it becomes lossy
+ * (unloaded matches are missed) — flagged as the P2a follow-up.
+ */
+
+const SORT_OPTIONS: { value: ListingSort; label: string }[] = [
+  { value: 'top-rated', label: 'Top rated' },
+  { value: 'popular', label: 'Most popular' },
+  { value: 'newest', label: 'Newest' },
+  { value: 'name', label: 'Name (A–Z)' },
+];
+
+const KIND_OPTIONS: { value: ListingKindFilter; label: string; icon: typeof IconApps }[] = [
+  { value: 'all', label: 'All apps', icon: IconLayoutGrid },
+  { value: 'onsite', label: 'On-site', icon: IconApps },
+  { value: 'offsite', label: 'Off-site', icon: IconExternalLink },
+];
+
+/**
+ * Kind filter — a small row of single-select toggle buttons (all / on-site /
+ * off-site), matching the CategoryFilterButtons toggle idiom (Mantine `variant`
+ * filled/subtle for active + `aria-pressed` so the state isn't colour-only).
+ */
+function KindFilterButtons({
+  value,
+  onChange,
+}: {
+  value: ListingKindFilter;
+  onChange: (next: ListingKindFilter) => void;
+}) {
+  return (
+    <Group gap="xs" role="group" aria-label="Filter by app kind">
+      {KIND_OPTIONS.map(({ value: v, label, icon: Icon }) => {
+        const active = value === v;
+        return (
+          <Button
+            key={v}
+            size="xs"
+            variant={active ? 'filled' : 'subtle'}
+            color="blue"
+            aria-pressed={active}
+            leftSection={<Icon size={14} />}
+            onClick={() => onChange(v)}
+          >
+            {label}
+          </Button>
+        );
+      })}
+    </Group>
+  );
+}
+
+export function AppListingsMarketplaceBody() {
+  const features = useFeatureFlags();
+  const [kind, setKind] = useState<ListingKindFilter>('all');
+  const [category, setCategory] = useState<MarketplaceCategory | null>(null);
+  const [sort, setSort] = useState<ListingSort>('top-rated');
+  const [searchInput, setSearchInput] = useState('');
+  const [debouncedSearch] = useDebouncedValue(searchInput, 300);
+
+  const {
+    data,
+    isLoading,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+  } = trpc.appListings.listAvailable.useInfiniteQuery(
+    {
+      kind,
+      category: category ?? undefined,
+      sort,
+      limit: 24,
+    },
+    {
+      enabled: !!features.appBlocks,
+      getNextPageParam: (lastPage) => lastPage.nextCursor,
+    }
+  );
+
+  const items = useMemo(
+    () => (data?.pages ?? []).flatMap((p) => p.items as ListingCard[]),
+    [data]
+  );
+
+  // Client-side search over loaded pages (name + tagline). See the ⚠️ gap note:
+  // this is complete only while the catalog fits in the loaded pages.
+  const filteredItems = useMemo(() => {
+    const q = debouncedSearch.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter(
+      (c) =>
+        c.name.toLowerCase().includes(q) ||
+        (c.tagline ? c.tagline.toLowerCase().includes(q) : false)
+    );
+  }, [items, debouncedSearch]);
+
+  const hasActiveFilters =
+    searchInput.trim().length > 0 || category != null || kind !== 'all';
+
+  function clearFilters() {
+    setKind('all');
+    setCategory(null);
+    setSearchInput('');
+  }
+
+  const showingEmpty = !isLoading && filteredItems.length === 0;
+
+  return (
+    <Stack gap="md">
+      <Group gap="md" align="end">
+        <TextInput
+          label="Search"
+          placeholder="Search by name"
+          leftSection={<IconSearch size={16} />}
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.currentTarget.value)}
+          style={{ flex: 1, minWidth: 240 }}
+        />
+        <Select
+          label="Sort"
+          data={SORT_OPTIONS}
+          value={sort}
+          onChange={(v) => setSort((v as ListingSort) ?? 'top-rated')}
+          allowDeselect={false}
+          w={180}
+        />
+      </Group>
+
+      {/* Kind filter (all / on-site / off-site). */}
+      <KindFilterButtons value={kind} onChange={setKind} />
+
+      {/* Category icon toggles — reuses the live marketplace component + taxonomy. */}
+      <CategoryFilterButtons value={category} onChange={setCategory} />
+
+      {isLoading ? (
+        <Center py="xl">
+          <Loader />
+        </Center>
+      ) : showingEmpty ? (
+        <Center py="xl">
+          <Stack align="center" gap={8}>
+            <Text size="lg" fw={500}>
+              {hasActiveFilters ? 'No apps match' : 'No apps yet'}
+            </Text>
+            <Text size="sm" c="dimmed" ta="center" maw={420}>
+              {hasActiveFilters
+                ? 'Try clearing your filters or search query.'
+                : 'Approved app listings will appear here.'}
+            </Text>
+            {hasActiveFilters && (
+              <Button variant="light" size="xs" onClick={clearFilters}>
+                Clear filters
+              </Button>
+            )}
+          </Stack>
+        </Center>
+      ) : (
+        <>
+          <Grid gutter="md">
+            {filteredItems.map((card) => (
+              <Grid.Col key={card.id} span={{ base: 12, sm: 6, md: 4, lg: 3 }}>
+                <AppListingCard card={card} canOpenPage={!!features.appBlocksPages} />
+              </Grid.Col>
+            ))}
+          </Grid>
+          {/* Load-more is hidden while a client-side search is active (it would
+              page in more UN-searched items — the searched view is over loaded
+              pages only; see the ⚠️ gap note). */}
+          {hasNextPage && !debouncedSearch.trim() && (
+            <Center py="md">
+              <Button
+                variant="default"
+                loading={isFetchingNextPage}
+                onClick={() => fetchNextPage()}
+              >
+                Load more
+              </Button>
+            </Center>
+          )}
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -92,6 +92,8 @@ export function AppListingsMarketplaceBody() {
   const {
     data,
     isLoading,
+    isError,
+    refetch,
     isFetchingNextPage,
     fetchNextPage,
     hasNextPage,
@@ -166,6 +168,20 @@ export function AppListingsMarketplaceBody() {
       {isLoading ? (
         <Center py="xl">
           <Loader />
+        </Center>
+      ) : isError ? (
+        <Center py="xl">
+          <Stack align="center" gap={8}>
+            <Text size="lg" fw={500}>
+              Couldn&apos;t load apps
+            </Text>
+            <Text size="sm" c="dimmed" ta="center" maw={420}>
+              Something went wrong loading the app store. Please try again.
+            </Text>
+            <Button variant="light" size="xs" onClick={() => refetch()}>
+              Retry
+            </Button>
+          </Stack>
         </Center>
       ) : showingEmpty ? (
         <Center py="xl">

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getListingBadge,
+  getListingCta,
+  getRecommendLabel,
+  safeExternalHref,
+} from '~/components/Apps/appListingCardView';
+import type {
+  ListingCard,
+  ListingRecommendRollup,
+} from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * App Store Listings (W13) — P2b card view-model unit tests (node `unit`
+ * project → the BLOCKING correctness gate; the browser component suites are
+ * report-only). Pin the kind matrix, the recommend label (incl. null pct), the
+ * https guard, and the CTA target policy so a regression in the kind-aware
+ * routing/badging FAILS here.
+ */
+
+const roll = (
+  recommendedCount: number,
+  notRecommendedCount: number,
+  recommendPct: number | null
+): ListingRecommendRollup => ({ recommendedCount, notRecommendedCount, recommendPct });
+
+function onsiteCard(over: Partial<ListingCard> & { hasPage: boolean; appBlockId?: string | null }): ListingCard {
+  const { hasPage, appBlockId = 'blk-1', ...rest } = over;
+  return {
+    id: 'l1',
+    slug: 'my-app',
+    kind: 'onsite',
+    name: 'My App',
+    tagline: null,
+    category: null,
+    contentRating: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: roll(0, 0, null),
+    reviewCount: 0,
+    kindData: { kind: 'onsite', appBlockId, hasPage },
+    ...rest,
+  };
+}
+
+function offsiteCard(
+  subKind: 'connect' | 'external-link',
+  externalUrl: string | null
+): ListingCard {
+  return {
+    id: 'l2',
+    slug: 'ext-app',
+    kind: 'offsite',
+    name: 'Ext App',
+    tagline: null,
+    category: null,
+    contentRating: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: roll(0, 0, null),
+    reviewCount: 0,
+    kindData: { kind: 'offsite', subKind, externalUrl },
+  };
+}
+
+describe('getListingBadge', () => {
+  it('on-site → "App"', () => {
+    expect(getListingBadge(onsiteCard({ hasPage: true }))).toEqual({ label: 'App', kind: 'onsite' });
+  });
+  it('off-site connect → "Connect app"', () => {
+    expect(getListingBadge(offsiteCard('connect', null))).toEqual({
+      label: 'Connect app',
+      kind: 'connect',
+    });
+  });
+  it('off-site external-link → "Off-site"', () => {
+    expect(getListingBadge(offsiteCard('external-link', 'https://x.com'))).toEqual({
+      label: 'Off-site',
+      kind: 'external-link',
+    });
+  });
+});
+
+describe('getRecommendLabel', () => {
+  it('null pct → "No reviews yet"', () => {
+    expect(getRecommendLabel(roll(0, 0, null), 0)).toBe('No reviews yet');
+  });
+  it('pct present → "N% recommend (M)" with rounding + count', () => {
+    expect(getRecommendLabel(roll(9, 1, 0.9), 10)).toBe('90% recommend (10)');
+    expect(getRecommendLabel(roll(2, 1, 0.6666), 3)).toBe('67% recommend (3)');
+    expect(getRecommendLabel(roll(1, 0, 1), 1)).toBe('100% recommend (1)');
+  });
+  it('formats large counts with locale separators', () => {
+    expect(getRecommendLabel(roll(1200, 300, 0.8), 1500)).toBe('80% recommend (1,500)');
+  });
+});
+
+describe('safeExternalHref', () => {
+  it('passes https', () => {
+    expect(safeExternalHref('https://example.com')).toBe('https://example.com');
+  });
+  it('rejects http / non-https / dangerous / empty', () => {
+    expect(safeExternalHref('http://example.com')).toBeNull();
+    expect(safeExternalHref('javascript:alert(1)')).toBeNull();
+    expect(safeExternalHref('ftp://x')).toBeNull();
+    expect(safeExternalHref('')).toBeNull();
+    expect(safeExternalHref(null)).toBeNull();
+    expect(safeExternalHref(undefined)).toBeNull();
+  });
+});
+
+describe('getListingCta — on-site', () => {
+  it('hasPage + canOpenPage → Open → /apps/run/<slug>', () => {
+    expect(getListingCta(onsiteCard({ hasPage: true, slug: 'gen-matrix' }), { canOpenPage: true })).toEqual({
+      label: 'Open',
+      action: 'open',
+      href: '/apps/run/gen-matrix',
+      external: false,
+      disabled: false,
+    });
+  });
+  it('hasPage but NOT canOpenPage → View details → /apps/<appBlockId> (no dead run link)', () => {
+    expect(getListingCta(onsiteCard({ hasPage: true, appBlockId: 'blk-9' }), { canOpenPage: false })).toEqual({
+      label: 'View details',
+      action: 'detail',
+      href: '/apps/blk-9',
+      external: false,
+      disabled: false,
+    });
+  });
+  it('!hasPage → View details → /apps/<appBlockId>', () => {
+    expect(getListingCta(onsiteCard({ hasPage: false, appBlockId: 'blk-3' }), { canOpenPage: true })).toEqual({
+      label: 'View details',
+      action: 'detail',
+      href: '/apps/blk-3',
+      external: false,
+      disabled: false,
+    });
+  });
+  it('!hasPage + no appBlockId → disabled View details (no target)', () => {
+    expect(getListingCta(onsiteCard({ hasPage: false, appBlockId: null }), { canOpenPage: true })).toEqual({
+      label: 'View details',
+      action: 'detail',
+      href: undefined,
+      external: false,
+      disabled: true,
+    });
+  });
+  it('encodes an odd slug', () => {
+    expect(
+      getListingCta(onsiteCard({ hasPage: true, slug: 'a b/c' }), { canOpenPage: true }).href
+    ).toBe('/apps/run/a%20b%2Fc');
+  });
+});
+
+describe('getListingCta — off-site', () => {
+  it('external-link https → Visit ↗ (external)', () => {
+    expect(getListingCta(offsiteCard('external-link', 'https://foo.app'), { canOpenPage: true })).toEqual({
+      label: 'Visit',
+      action: 'visit',
+      href: 'https://foo.app',
+      external: true,
+      disabled: false,
+    });
+  });
+  it('external-link non-https → disabled View details (guard drops it)', () => {
+    expect(getListingCta(offsiteCard('external-link', 'http://foo.app'), { canOpenPage: true })).toEqual({
+      label: 'View details',
+      action: 'detail',
+      href: undefined,
+      external: false,
+      disabled: true,
+    });
+  });
+  it('external-link null url → disabled View details', () => {
+    expect(getListingCta(offsiteCard('external-link', null), { canOpenPage: true }).disabled).toBe(true);
+  });
+  it('connect → disabled Connect (P2c flow)', () => {
+    expect(getListingCta(offsiteCard('connect', null), { canOpenPage: true })).toEqual({
+      label: 'Connect',
+      action: 'connect',
+      href: undefined,
+      external: false,
+      disabled: true,
+    });
+  });
+});

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -1,0 +1,138 @@
+/**
+ * App Store Listings (W13) — P2b card VIEW MODEL (pure, React-free).
+ *
+ * The kind-aware badge / CTA / recommend-label logic for `AppListingCard`,
+ * extracted into pure functions so the correctness gate lives in the node `unit`
+ * project (the civitai browser-mode component suites are REPORT-ONLY / non-
+ * blocking — so the real, blocking test coverage for this behaviour is here).
+ *
+ * DARK / parallel-run: consumed only by the mod-only `/apps/store-preview`
+ * preview surface. The default `/apps` render (MarketplaceBody → AppBlockCard)
+ * is untouched; the cutover is a later PR (P2d).
+ *
+ * CTA target policy (dark phase — no listing detail page exists yet, that's P2c):
+ *   - on-site + hasPage + canOpenPage → **Open** → `/apps/run/<slug>` (the LIVE
+ *     W10 page route; itself flag-gated on `appBlocksPages`, so we only route
+ *     there when the viewer can actually open it).
+ *   - on-site otherwise (no page, or page but no `appBlocksPages`) → **View
+ *     details** → the EXISTING per-AppBlock detail page `/apps/<appBlockId>`
+ *     (a real, working page — the honest dark-phase stub; P2c adds the unified
+ *     `/apps/<slug>` listing detail).
+ *   - off-site external-link (https) → **Visit ↗** → external anchor.
+ *   - off-site external-link (missing / non-https url) → disabled "View details"
+ *     (no target yet; the DTO already null-guards non-https — we re-guard).
+ *   - off-site connect → disabled **Connect** (the connect flow / listing detail
+ *     is P2c; rendered but inert in the preview).
+ * A CTA with `disabled: true` renders as a non-actionable button (component wraps
+ * it in a tooltip). Every card always has a CTA (never actionless).
+ */
+
+import type {
+  ListingCard,
+  ListingRecommendRollup,
+} from '~/server/schema/blocks/app-listing-read.schema';
+
+/** Kind badge shown on the card face. */
+export type ListingBadgeKind = 'onsite' | 'connect' | 'external-link';
+export type ListingBadge = { label: string; kind: ListingBadgeKind };
+
+/**
+ * The kind badge: on-site apps read "App"; off-site splits into the two
+ * sub-kinds — an OAuth "Connect app" vs a plain "Off-site" external link.
+ */
+export function getListingBadge(card: Pick<ListingCard, 'kind' | 'kindData'>): ListingBadge {
+  if (card.kindData.kind === 'onsite') return { label: 'App', kind: 'onsite' };
+  return card.kindData.subKind === 'connect'
+    ? { label: 'Connect app', kind: 'connect' }
+    : { label: 'Off-site', kind: 'external-link' };
+}
+
+/**
+ * Recommend rollup → display label. `recommendPct` is `null` when there are no
+ * reviews yet (metric row absent OR zero counts) — render "No reviews yet"
+ * rather than a misleading "0% recommend". Otherwise a Steam-style
+ * "N% recommend (M)" with the review count.
+ */
+export function getRecommendLabel(
+  recommend: ListingRecommendRollup,
+  reviewCount: number
+): string {
+  if (recommend.recommendPct == null) return 'No reviews yet';
+  const pct = Math.round(recommend.recommendPct * 100);
+  return `${pct}% recommend (${reviewCount.toLocaleString()})`;
+}
+
+/**
+ * https-only external-link guard. The public DTO already null-guards a non-https
+ * `externalUrl`, but re-guard at the render boundary so a malformed/`javascript:`
+ * value can never become an anchor `href` (defense in depth).
+ */
+export function safeExternalHref(url: string | null | undefined): string | null {
+  if (!url) return null;
+  return url.startsWith('https://') ? url : null;
+}
+
+export type ListingCtaAction = 'open' | 'detail' | 'visit' | 'connect';
+
+export type ListingCta = {
+  /** Button copy. */
+  label: string;
+  /** Semantic action (drives icon choice + analytics later). */
+  action: ListingCtaAction;
+  /** Navigation target, or `undefined` when there is no working target yet. */
+  href?: string;
+  /** True → open in a new tab as an external anchor (rel=noopener noreferrer). */
+  external: boolean;
+  /** True → render a non-actionable (inert) button; there's no target in the dark phase. */
+  disabled: boolean;
+};
+
+/** The per-AppBlock detail page that on-site listings stub to during the dark phase. */
+function onsiteDetailHref(appBlockId: string | null): string | undefined {
+  return appBlockId ? `/apps/${encodeURIComponent(appBlockId)}` : undefined;
+}
+
+/**
+ * Kind-aware primary CTA. `canOpenPage` mirrors the `appBlocksPages` feature
+ * flag: when false the live page route 404s, so an on-site page app falls back
+ * to "View details" instead of a dead "Open" link.
+ */
+export function getListingCta(
+  card: Pick<ListingCard, 'slug' | 'kind' | 'kindData'>,
+  opts: { canOpenPage: boolean }
+): ListingCta {
+  if (card.kindData.kind === 'onsite') {
+    const { appBlockId, hasPage } = card.kindData;
+    if (hasPage && opts.canOpenPage) {
+      return {
+        label: 'Open',
+        action: 'open',
+        href: `/apps/run/${encodeURIComponent(card.slug)}`,
+        external: false,
+        disabled: false,
+      };
+    }
+    // No page, or page but the viewer can't open it → the detail stub.
+    const href = onsiteDetailHref(appBlockId);
+    return {
+      label: 'View details',
+      action: 'detail',
+      href,
+      external: false,
+      disabled: !href,
+    };
+  }
+
+  // Off-site.
+  if (card.kindData.subKind === 'external-link') {
+    const href = safeExternalHref(card.kindData.externalUrl);
+    if (href) {
+      return { label: 'Visit', action: 'visit', href, external: true, disabled: false };
+    }
+    // No usable external target (missing / non-https) — no detail page yet (P2c).
+    return { label: 'View details', action: 'detail', href: undefined, external: false, disabled: true };
+  }
+
+  // Off-site connect (OAuth). The connect flow / listing detail is P2c — inert here.
+  return { label: 'Connect', action: 'connect', href: undefined, external: false, disabled: true };
+}

--- a/src/pages/apps/store-preview.tsx
+++ b/src/pages/apps/store-preview.tsx
@@ -1,0 +1,40 @@
+import { NotFound } from '~/components/AppLayout/NotFound';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
+import { AppListingsMarketplaceBody } from '~/components/Apps/AppListingsMarketplaceBody';
+import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
+import { Meta } from '~/components/Meta/Meta';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+
+/**
+ * App Store Listings (W13) — P2b DARK preview mount.
+ *
+ * A dedicated preview route that renders the NEW unified `AppListing`-backed
+ * store (`AppListingsMarketplaceBody`) ALONGSIDE the live `/apps` surface. The
+ * default `/apps` render (MarketplaceBody → AppBlockCard, off the AppBlock path)
+ * is byte-unchanged — `pages/apps/index.tsx` is not touched. The default-swap /
+ * cutover is a later PR (P2d).
+ *
+ * Gating: reuses `resolveAppsPageAccess` — the SAME mod-segmented `appBlocks`
+ * flag gate as `/apps` (the flag's Flipt segment is mod-only today, so this is
+ * mod-only dark). `deIndex` stays on so the preview is never crawlable.
+ */
+export const getServerSideProps = createServerSideProps({
+  useSession: true,
+  resolver: async ({ features }) => resolveAppsPageAccess({ features }),
+});
+
+export default function AppsStorePreviewPage() {
+  const features = useFeatureFlags();
+
+  if (!features.appBlocks) return <NotFound />;
+
+  return (
+    <>
+      <Meta title="App store preview — Civitai" description="Unified app store preview" deIndex />
+      <AppsPageLayout size="xl">
+        <AppListingsMarketplaceBody />
+      </AppsPageLayout>
+    </>
+  );
+}


### PR DESCRIPTION
## What

**App Store Listings (W13) — Phase 2, PR 2b.** Builds the UI that consumes the already-merged **P2a** unified read path (`appListings.listAvailable` → `ListingCard` DTOs) into a **kind-aware store card + marketplace grid**.

**DARK + PARALLEL-RUN:** the default `/apps` render (`MarketplaceBody` → `AppBlockCard`, off the AppBlock path) is **byte-unchanged** — `pages/apps/index.tsx` is not touched. The new UI lives on a dedicated mod-only preview route. The default-swap / cutover is a later PR (**P2d**).

## Components (new)

| File | Purpose |
|---|---|
| `src/components/Apps/appListingCardView.ts` | Pure, React-free **view model** — kind badge, recommend label, https guard, kind-aware CTA target policy. **The blocking correctness gate** (browser suites are report-only). |
| `src/components/Apps/AppListingCard.tsx` | Unified store card over BOTH kinds. |
| `src/components/Apps/AppListingsMarketplaceBody.tsx` | Grid surface: search + sorts + kind filter + category filter + pagination. |
| `src/pages/apps/store-preview.tsx` | **Dark preview mount** (route). |

## Dark-mount mechanism

A **dedicated preview route `/apps/store-preview`** (chosen over a `?store=` branch on `/apps` so `index.tsx` stays completely untouched). It reuses `resolveAppsPageAccess` — the **same mod-segmented `appBlocks` flag gate** as `/apps` (the Flipt segment is mod-only today → mod-only dark) — plus `deIndex`. No new Flipt flag (reuses `appBlocks`, per scope).

## Reuse map

- **`CategoryFilterButtons`** — reused verbatim (icon toggles + taxonomy).
- **`AppBlockCard` visual language** — the card mirrors its Mantine `Card` + `Card.Section` cover + category-glyph placeholder pattern, plus the review-rollup row idiom.
- **`marketplaceCategoryIcons` / `MARKETPLACE_CATEGORY_LABELS` / `isMarketplaceCategory`** — shared category icon + label helpers.
- **`getEdgeUrl`** — for the creator-avatar image (the DTO's `creator.image` is a raw key; `coverUrl`/`iconUrl` are already CDN URLs).
- **Kind filter** — new `KindFilterButtons` (all/on-site/off-site) matching the `CategoryFilterButtons` toggle idiom (`variant` filled/subtle + `aria-pressed`).

### Reuse decision that diverged from the plan (flag for audit)
Plan §6.1 suggests rendering the card **through `AspectRatioImageCard`** (cosmetic frames + per-image maturity blur). That component's `image` slot needs a full **`Image` object** (`id`/`nsfwLevel`/`hash`/`metadata`/`type`), but the **P2a public DTO deliberately projects only a bare `coverUrl`/`iconUrl` string** (allowlist — no per-image internals), and the listing read is already **maturity-gated server-side** (r/x hidden off a red-capable host). So the card mirrors the proven `AppBlockCard` Mantine-Card pattern instead. Feeding `AspectRatioImageCard` would require the DTO to carry the Image object — a **P2a schema addition, out of scope** here.

## Kind badge / CTA matrix

| Kind | Badge | CTA |
|---|---|---|
| on-site, `hasPage` + `appBlocksPages` | **App** | **Open** → `/apps/run/<slug>` |
| on-site, page but no `appBlocksPages` | App | **View details** → `/apps/<appBlockId>` (no dead run link) |
| on-site, `!hasPage` | App | **View details** → `/apps/<appBlockId>` |
| off-site external-link (https) | **Off-site** | **Visit ↗** (`target=_blank`, `rel=noopener noreferrer`) |
| off-site external-link (missing/non-https) | Off-site | inert **View details** (guard drops it) |
| off-site connect | **Connect app** | inert **Connect** |

Recommend rollup: `recommendPct == null` → **"No reviews yet"**; else **"N% recommend (M)"**.

## Stubbed to P2c (explicitly noted)
- **onsite `!hasPage` / no-page-flag** → routes to the **existing per-AppBlock detail page** `/apps/<appBlockId>` (a real, working page — the honest dark-phase stub; deeper install wiring is P2c/cutover).
- **offsite connect** and **offsite external with missing/non-https url** → the CTA renders **inert** (tooltip "Available at launch") since there is no unified listing detail page yet — **P2c** adds `/apps/<slug>`.

## Search gap (P2a follow-up, noted — not fixed here)
`appListings.listAvailable` has **no `query` input** (kind/category/sort/cursor/limit only). The search box filters **client-side over loaded pages** (name + tagline). Complete for today's ~1-page catalog; **lossy once listings exceed one page** — needs a P2a `query` addition (out of scope; no proc change in this PR). Load-more is hidden while a search is active.

## Tests
- **17/17 pure-helper unit tests PASS** (node `unit` project — the blocking gate): kind matrix, null `recommendPct`, https guard (rejects http/`javascript:`/empty), CTA target policy incl. `hasPage`/`canOpenPage`/no-`appBlockId` variants + slug encoding.
- **Report-only component tests** (`AppListingCard.browser.test.tsx`, `AppListingsMarketplaceBody.browser.test.tsx`) — the civitai browser project is non-blocking; not run locally (NixOS `sharp`/optimizeDeps limitation), authoritative gate is Tekton pr-preview.
- No non-route files under `src/pages` (only the route `store-preview.tsx`); tests co-located under `src/components/Apps/`.

**Do NOT merge — needs an adversarial audit.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
