### PR TITLE
feat(app-blocks): W13 P2c — unified listing detail page

### DIFF
--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -77,7 +77,10 @@ describe('AppListingCard', () => {
     await expect.element(visit).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  test('off-site connect → Connect badge + inert (disabled) CTA', async () => {
+  test('off-site connect → Connect badge + View details → unified detail (P2c)', async () => {
+    // P2c: cards route to the unified detail; the Connect action itself lives on
+    // the detail page (the connect flow needs a P2a authorize-URL DTO addition),
+    // so the card's CTA is "View details", not an inert Connect button.
     renderWithProviders(
       <AppListingCard
         card={base({
@@ -88,13 +91,13 @@ describe('AppListingCard', () => {
       />
     );
     await expect.element(page.getByText('Connect app')).toBeInTheDocument();
-    const connect = page.getByRole('button', { name: 'Connect' });
-    await expect.element(connect).toBeDisabled();
+    const details = page.getByRole('link', { name: 'View details' });
+    await expect.element(details).toHaveAttribute('href', '/apps/store-preview/my-app');
   });
 
-  test('on-site page app WITHOUT canOpenPage → View details (no dead run link)', async () => {
+  test('on-site page app WITHOUT canOpenPage → View details → unified detail (P2c)', async () => {
     renderWithProviders(<AppListingCard card={base({})} canOpenPage={false} />);
     const details = page.getByRole('link', { name: 'View details' });
-    await expect.element(details).toHaveAttribute('href', '/apps/blk-1');
+    await expect.element(details).toHaveAttribute('href', '/apps/store-preview/my-app');
   });
 });

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -7,7 +7,7 @@ import {
 } from '@tabler/icons-react';
 import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
-import { useState } from 'react';
+import { type MouseEvent, useState } from 'react';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import {
   CATEGORY_ICONS,
@@ -136,7 +136,7 @@ function CreatorChip({ creator }: { creator: ListingCard['creator'] }) {
       href={`/user/${encodeURIComponent(creator.username)}`}
       underline="never"
       c="dimmed"
-      onClick={(e) => e.stopPropagation()}
+      onClick={(e: MouseEvent) => e.stopPropagation()}
     >
       <Group gap={6} wrap="nowrap">
         <Avatar src={avatarSrc} alt="" radius="xl" size={20}>

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Avatar, Badge, Box, Button, Card, Group, Image, Stack, Text, Title, Tooltip } from '@mantine/core';
+import { Anchor, Avatar, Badge, Box, Button, Card, Group, Image, Stack, Text, Title } from '@mantine/core';
 import {
   IconApps,
   IconExternalLink,
@@ -16,6 +16,7 @@ import {
 import {
   getListingBadge,
   getListingCta,
+  getListingDetailHref,
   getRecommendLabel,
   type ListingBadgeKind,
 } from '~/components/Apps/appListingCardView';
@@ -162,6 +163,7 @@ export interface AppListingCardProps {
 export function AppListingCard({ card, canOpenPage = false }: AppListingCardProps) {
   const badge = getListingBadge(card);
   const cta = getListingCta(card, { canOpenPage });
+  const detailHref = getListingDetailHref(card.slug);
   const recommendLabel = getRecommendLabel(card.recommend, card.reviewCount);
   const BadgeIcon = KIND_BADGE_ICON[badge.kind];
 
@@ -178,9 +180,20 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
               {card.name.charAt(0).toUpperCase()}
             </Avatar>
             <Stack gap={2} style={{ minWidth: 0 }}>
-              <Title order={4} className="line-clamp-2">
-                {card.name}
-              </Title>
+              {/* Title links to the unified detail so the detail is reachable
+                  from every card even when the primary CTA is a direct Open /
+                  Visit. underline:hover keeps it visibly a link. */}
+              <Anchor
+                component={Link}
+                href={detailHref}
+                underline="hover"
+                c="inherit"
+                style={{ minWidth: 0 }}
+              >
+                <Title order={4} className="line-clamp-2">
+                  {card.name}
+                </Title>
+              </Anchor>
               <CreatorChip creator={card.creator} />
             </Stack>
           </Group>
@@ -228,18 +241,10 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
             </Text>
           </Group>
 
-          {/* Kind-aware CTA. A disabled CTA (no working target in the dark phase)
-              renders inert with a tooltip so the card is never actionless. */}
-          {cta.disabled ? (
-            <Tooltip label="Available at launch" withArrow>
-              {/* Tooltip needs a non-disabled wrapper to receive hover events. */}
-              <span>
-                <Button size="xs" variant="light" disabled>
-                  {cta.label}
-                </Button>
-              </span>
-            </Tooltip>
-          ) : cta.external && cta.href ? (
+          {/* Kind-aware CTA — always has a working target (a direct Open / Visit,
+              or the unified detail). External Visit → new-tab anchor; everything
+              else → an internal Link. */}
+          {cta.external ? (
             <Button
               component="a"
               href={cta.href}
@@ -254,7 +259,7 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
           ) : (
             <Button
               component={Link}
-              href={cta.href ?? '#'}
+              href={cta.href}
               size="xs"
               variant={cta.action === 'open' ? 'filled' : 'light'}
             >

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -1,0 +1,395 @@
+import {
+  Alert,
+  Anchor,
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Divider,
+  Group,
+  Image,
+  SimpleGrid,
+  Stack,
+  Text,
+  ThemeIcon,
+  Title,
+} from '@mantine/core';
+import {
+  IconApps,
+  IconArrowLeft,
+  IconExternalLink,
+  IconInfoCircle,
+  IconPlugConnected,
+  IconThumbUp,
+} from '@tabler/icons-react';
+import type { Icon } from '@tabler/icons-react';
+import Link from 'next/link';
+import { useState } from 'react';
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import {
+  getListingBadge,
+  getRecommendLabel,
+  type ListingBadgeKind,
+} from '~/components/Apps/appListingCardView';
+import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
+import {
+  CATEGORY_ICONS,
+  FALLBACK_CATEGORY_ICON,
+} from '~/components/Apps/marketplaceCategoryIcons';
+import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
+import {
+  isMarketplaceCategory,
+  MARKETPLACE_CATEGORY_LABELS,
+} from '~/server/services/blocks/marketplace-categories.constants';
+import type {
+  ListingDetail,
+  ListingGalleryScreenshot,
+} from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * App Store Listings (W13) — P2c unified listing DETAIL body (over BOTH kinds).
+ *
+ * Renders one `ListingDetail` (from `appListings.getAppDetail`): a hero cover +
+ * app icon + name + tagline + creator chip + kind badge + Steam-style recommend
+ * breakdown + a screenshot gallery + a `CustomMarkdown` description + the
+ * kind-aware primary action (`getDetailPrimaryAction`). Mirrors the visual
+ * language of the LIVE per-app detail (`/apps/[appBlockId]` + `AppDetailsModal`)
+ * — same screenshot-grid + description + external-link discipline — so listings
+ * feel native.
+ *
+ * DARK / parallel-run: rendered only by the mod-only `/apps/store-preview/<slug>`
+ * surface. The live `/apps/[appBlockId]` detail + `AppDetailsModal` + default
+ * `/apps` are byte-unchanged; the canonical `/apps/[slug]` cutover is P2d.
+ *
+ * XSS / encoding discipline (mirrors P2b): external hrefs are https-guarded in
+ * the pure view-model (`safeExternalHref`) + rendered with rel="noopener
+ * noreferrer" target="_blank"; the markdown description goes through the shared
+ * `CustomMarkdown` (react-markdown, no `dangerouslySetInnerHTML`).
+ *
+ * Reuse tradeoffs (flagged in the PR, consistent with P2b):
+ *   - Creator: `UserAvatarSimple` wants a rich `ProfileImage` + cosmetics object;
+ *     the public DTO carries only a bare `{id,username,image}` string, so we
+ *     render the same lightweight avatar chip the P2b card uses.
+ *   - Cover: `AspectRatioImageCard` (cosmetic frames / per-image blur) needs a
+ *     full `Image` object; the allowlist DTO projects only a `coverUrl` string,
+ *     so we render a plain cover with the category-glyph placeholder fallback
+ *     (same as the card). Feeding those would be a P2a schema addition.
+ */
+
+const KIND_BADGE_ICON: Record<ListingBadgeKind, Icon> = {
+  onsite: IconApps,
+  connect: IconPlugConnected,
+  'external-link': IconExternalLink,
+};
+
+const KIND_BADGE_COLOR: Record<ListingBadgeKind, string> = {
+  onsite: 'blue',
+  connect: 'teal',
+  'external-link': 'blue',
+};
+
+function categoryLabel(category: string): string {
+  return isMarketplaceCategory(category) ? MARKETPLACE_CATEGORY_LABELS[category] : category;
+}
+
+function categoryIcon(category: string): Icon {
+  return isMarketplaceCategory(category) ? CATEGORY_ICONS[category] : FALLBACK_CATEGORY_ICON;
+}
+
+/**
+ * Hero cover — the listing cover (`coverUrl`, already a CDN URL). Falls back to a
+ * category-glyph placeholder over a neutral gradient when absent OR the image
+ * 404s (a coverUrl derived from a first-screenshot fallback can dangle) — never
+ * a broken `<img>`. Decorative (aria-hidden placeholder).
+ */
+function HeroCover({
+  coverUrl,
+  category,
+  name,
+}: {
+  coverUrl: string | null;
+  category: string | null;
+  name: string;
+}) {
+  const [broken, setBroken] = useState(false);
+  if (coverUrl && !broken) {
+    return (
+      <Image
+        src={coverUrl}
+        alt={`${name} cover image`}
+        h={260}
+        fit="cover"
+        radius="md"
+        onError={() => setBroken(true)}
+      />
+    );
+  }
+  const PlaceholderIcon = category ? categoryIcon(category) : IconApps;
+  return (
+    <Box
+      aria-hidden
+      h={260}
+      className="flex items-center justify-center"
+      style={{
+        borderRadius: 'var(--mantine-radius-md)',
+        background:
+          'linear-gradient(135deg, var(--mantine-color-dark-5) 0%, var(--mantine-color-dark-7) 100%)',
+      }}
+    >
+      <PlaceholderIcon size={72} className="opacity-40" />
+    </Box>
+  );
+}
+
+/**
+ * "by {creator}" chip — the public creator projection ({id,username,image}).
+ * Links to the creator profile. (UserAvatarSimple reuse tradeoff — see the file
+ * docstring.)
+ */
+function CreatorChip({ creator }: { creator: ListingDetail['creator'] }) {
+  if (!creator || !creator.username) return null;
+  const avatarSrc = creator.image ? getEdgeUrl(creator.image, { width: 64 }) : undefined;
+  return (
+    <Anchor
+      component={Link}
+      href={`/user/${encodeURIComponent(creator.username)}`}
+      underline="hover"
+      c="dimmed"
+    >
+      <Group gap={6} wrap="nowrap">
+        <Avatar src={avatarSrc} alt="" radius="xl" size={24}>
+          {creator.username.charAt(0).toUpperCase()}
+        </Avatar>
+        <Text size="sm" c="dimmed" lineClamp={1}>
+          by {creator.username}
+        </Text>
+      </Group>
+    </Anchor>
+  );
+}
+
+/**
+ * One screenshot tile — hides itself on load error (a dangling Image ref) rather
+ * than rendering a broken `<img>`. Plain `<img>` (mirrors AppDetailsModal / the
+ * live detail): the URL is a CDN edge URL, not a configured Next/Image domain.
+ */
+function ScreenshotTile({ shot, name, index }: { shot: ListingGalleryScreenshot; name: string; index: number }) {
+  const [broken, setBroken] = useState(false);
+  if (broken) return null;
+  return (
+    <Card withBorder padding={0} radius="md" style={{ overflow: 'hidden' }}>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={shot.url}
+        alt={shot.caption ? shot.caption : `${name} screenshot ${index + 1}`}
+        loading="lazy"
+        onError={() => setBroken(true)}
+        style={{ width: '100%', height: 'auto', display: 'block' }}
+      />
+      {shot.caption && (
+        <Text size="xs" c="dimmed" p="xs" lineClamp={2}>
+          {shot.caption}
+        </Text>
+      )}
+    </Card>
+  );
+}
+
+/** Screenshot gallery — reuses AppDetailsModal's SimpleGrid pattern. Empty/broken
+ *  URLs are skipped; the whole section is hidden when nothing remains. */
+function ScreenshotGallery({ screenshots, name }: { screenshots: ListingGalleryScreenshot[]; name: string }) {
+  const shots = screenshots.filter((s) => !!s.url);
+  if (shots.length === 0) return null;
+  return (
+    <>
+      <Divider />
+      <Stack gap="xs">
+        <Title order={4}>Screenshots</Title>
+        <SimpleGrid cols={{ base: 1, sm: 2 }} spacing="md">
+          {shots.map((shot, i) => (
+            <ScreenshotTile key={`${shot.url}-${i}`} shot={shot} name={name} index={i} />
+          ))}
+        </SimpleGrid>
+      </Stack>
+    </>
+  );
+}
+
+/** Kind-aware primary action button + (for info/connect stubs) an inline note. */
+function PrimaryAction({ detail, canOpenPage }: { detail: ListingDetail; canOpenPage: boolean }) {
+  const action = getDetailPrimaryAction(detail, { canOpenPage });
+
+  if (action.mode === 'open' && action.href) {
+    return (
+      <Button component={Link} href={action.href} leftSection={<IconExternalLink size={16} />}>
+        {action.label}
+      </Button>
+    );
+  }
+
+  if (action.mode === 'visit' && action.href) {
+    return (
+      <Button
+        component="a"
+        href={action.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        leftSection={<IconExternalLink size={16} />}
+      >
+        {action.label}
+      </Button>
+    );
+  }
+
+  if (action.mode === 'connect') {
+    // Honest stub — no derivable OAuth authorize URL from the public DTO. Inert
+    // button + a note so the affordance is never a dead 404 link.
+    return (
+      <Stack gap={4}>
+        <Button variant="default" leftSection={<IconPlugConnected size={16} />} disabled>
+          {action.label}
+        </Button>
+        {action.note && (
+          <Text size="xs" c="dimmed">
+            {action.note}
+          </Text>
+        )}
+      </Stack>
+    );
+  }
+
+  // Informational (`info`) — optional "learn more" internal link + a note.
+  return (
+    <Stack gap={4}>
+      {action.href ? (
+        <Button component={Link} href={action.href} variant="default" leftSection={<IconInfoCircle size={16} />}>
+          {action.label}
+        </Button>
+      ) : (
+        <Group gap={6} c="dimmed">
+          <IconInfoCircle size={16} />
+          <Text size="sm">{action.label}</Text>
+        </Group>
+      )}
+      {action.note && (
+        <Text size="xs" c="dimmed">
+          {action.note}
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
+export interface AppListingDetailBodyProps {
+  detail: ListingDetail;
+  /** Whether the viewer can launch an in-host page app (the `appBlocksPages` flag). */
+  canOpenPage?: boolean;
+}
+
+export function AppListingDetailBody({ detail, canOpenPage = false }: AppListingDetailBodyProps) {
+  const badge = getListingBadge(detail);
+  const BadgeIcon = KIND_BADGE_ICON[badge.kind];
+  const recommendLabel = getRecommendLabel(detail.recommend, detail.reviewCount);
+  const hasRecommend = detail.recommend.recommendPct != null;
+
+  return (
+    <Stack gap="lg">
+      <Anchor component={Link} href="/apps/store-preview" size="sm">
+        <Group gap={4}>
+          <IconArrowLeft size={14} />
+          Back to store
+        </Group>
+      </Anchor>
+
+      <HeroCover coverUrl={detail.coverUrl} category={detail.category} name={detail.name} />
+
+      {/* Header: icon + name + tagline + creator + kind/category badges + action. */}
+      <Group justify="space-between" align="flex-start" wrap="nowrap">
+        <Group gap="md" wrap="nowrap" align="flex-start" style={{ minWidth: 0 }}>
+          <Avatar src={detail.iconUrl ?? undefined} alt="" radius="md" size={64}>
+            {detail.name.charAt(0).toUpperCase()}
+          </Avatar>
+          <Stack gap={6} style={{ minWidth: 0 }}>
+            <Title order={2} className="line-clamp-2">
+              {detail.name}
+            </Title>
+            {detail.tagline && (
+              <Text c="dimmed" size="sm" className="line-clamp-2">
+                {detail.tagline}
+              </Text>
+            )}
+            <CreatorChip creator={detail.creator} />
+            <Group gap="xs" mt={2}>
+              <Badge
+                variant="light"
+                color={KIND_BADGE_COLOR[badge.kind]}
+                size="sm"
+                leftSection={<BadgeIcon size={12} />}
+              >
+                {badge.label}
+              </Badge>
+              {detail.category && (() => {
+                const CategoryIcon = categoryIcon(detail.category);
+                return (
+                  <Badge variant="light" color="grape" size="sm" leftSection={<CategoryIcon size={12} />}>
+                    {categoryLabel(detail.category)}
+                  </Badge>
+                );
+              })()}
+              {detail.contentRating && (
+                <Badge variant="light" color="gray" size="sm">
+                  {detail.contentRating}
+                </Badge>
+              )}
+            </Group>
+          </Stack>
+        </Group>
+        <Box style={{ flexShrink: 0 }}>
+          <PrimaryAction detail={detail} canOpenPage={canOpenPage} />
+        </Box>
+      </Group>
+
+      {/* Recommend rollup — Steam-style "N% recommend (M)" or "No reviews yet". */}
+      <Group gap="md" wrap="wrap">
+        <Group gap={6} wrap="nowrap">
+          <IconThumbUp size={16} className={hasRecommend ? 'text-green-500' : 'text-gray-500'} />
+          <Text size="sm" fw={500}>
+            {recommendLabel}
+          </Text>
+        </Group>
+        {hasRecommend && (
+          <Text size="xs" c="dimmed">
+            {detail.recommend.recommendedCount.toLocaleString()} recommend ·{' '}
+            {detail.recommend.notRecommendedCount.toLocaleString()} don&apos;t
+          </Text>
+        )}
+      </Group>
+
+      <ScreenshotGallery screenshots={detail.screenshots} name={detail.name} />
+
+      {/* Description — shared CustomMarkdown (no dangerouslySetInnerHTML). */}
+      {detail.description && (
+        <>
+          <Divider />
+          <Stack gap="xs">
+            <Title order={4}>About</Title>
+            <div className="markdown-content">
+              <CustomMarkdown>{detail.description}</CustomMarkdown>
+            </div>
+          </Stack>
+        </>
+      )}
+
+      {/* Off-site external destination disclosure (mirrors the live detail). */}
+      {detail.kindData.kind === 'offsite' &&
+        detail.kindData.subKind === 'external-link' &&
+        detail.kindData.externalUrl && (
+          <Alert variant="light" color="blue" icon={<IconInfoCircle size={16} />}>
+            This app runs entirely off-platform — no Civitai install, account access, or
+            permissions.
+          </Alert>
+        )}
+    </Stack>
+  );
+}

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   getListingBadge,
   getListingCta,
+  getListingDetailHref,
   getRecommendLabel,
   safeExternalHref,
 } from '~/components/Apps/appListingCardView';
@@ -111,79 +112,86 @@ describe('safeExternalHref', () => {
   });
 });
 
-describe('getListingCta — on-site', () => {
-  it('hasPage + canOpenPage → Open → /apps/run/<slug>', () => {
+describe('getListingDetailHref', () => {
+  it('routes to the unified store-preview detail by slug', () => {
+    expect(getListingDetailHref('my-app')).toBe('/apps/store-preview/my-app');
+  });
+  it('encodes an odd slug (defense in depth)', () => {
+    expect(getListingDetailHref('a b/c')).toBe('/apps/store-preview/a%20b%2Fc');
+  });
+});
+
+describe('getListingCta — on-site (P2c: View details → unified detail)', () => {
+  it('hasPage + canOpenPage → Open → /apps/run/<slug> (direct primary)', () => {
     expect(getListingCta(onsiteCard({ hasPage: true, slug: 'gen-matrix' }), { canOpenPage: true })).toEqual({
       label: 'Open',
       action: 'open',
       href: '/apps/run/gen-matrix',
       external: false,
-      disabled: false,
     });
   });
-  it('hasPage but NOT canOpenPage → View details → /apps/<appBlockId> (no dead run link)', () => {
-    expect(getListingCta(onsiteCard({ hasPage: true, appBlockId: 'blk-9' }), { canOpenPage: false })).toEqual({
+  it('hasPage but NOT canOpenPage → View details → unified detail (no dead run link)', () => {
+    expect(getListingCta(onsiteCard({ hasPage: true, slug: 'my-app' }), { canOpenPage: false })).toEqual({
       label: 'View details',
       action: 'detail',
-      href: '/apps/blk-9',
+      href: '/apps/store-preview/my-app',
       external: false,
-      disabled: false,
     });
   });
-  it('!hasPage → View details → /apps/<appBlockId>', () => {
-    expect(getListingCta(onsiteCard({ hasPage: false, appBlockId: 'blk-3' }), { canOpenPage: true })).toEqual({
+  it('!hasPage → View details → unified detail', () => {
+    expect(getListingCta(onsiteCard({ hasPage: false, slug: 'my-app' }), { canOpenPage: true })).toEqual({
       label: 'View details',
       action: 'detail',
-      href: '/apps/blk-3',
+      href: '/apps/store-preview/my-app',
       external: false,
-      disabled: false,
     });
   });
-  it('!hasPage + no appBlockId → disabled View details (no target)', () => {
-    expect(getListingCta(onsiteCard({ hasPage: false, appBlockId: null }), { canOpenPage: true })).toEqual({
+  it('!hasPage + no appBlockId → still reaches the unified detail (never actionless)', () => {
+    expect(getListingCta(onsiteCard({ hasPage: false, appBlockId: null, slug: 'my-app' }), { canOpenPage: true })).toEqual({
       label: 'View details',
       action: 'detail',
-      href: undefined,
+      href: '/apps/store-preview/my-app',
       external: false,
-      disabled: true,
     });
   });
-  it('encodes an odd slug', () => {
+  it('encodes an odd slug on the Open run link', () => {
     expect(
       getListingCta(onsiteCard({ hasPage: true, slug: 'a b/c' }), { canOpenPage: true }).href
     ).toBe('/apps/run/a%20b%2Fc');
   });
 });
 
-describe('getListingCta — off-site', () => {
-  it('external-link https → Visit ↗ (external)', () => {
+describe('getListingCta — off-site (P2c: View details → unified detail)', () => {
+  it('external-link https → Visit ↗ (direct external primary)', () => {
     expect(getListingCta(offsiteCard('external-link', 'https://foo.app'), { canOpenPage: true })).toEqual({
       label: 'Visit',
       action: 'visit',
       href: 'https://foo.app',
       external: true,
-      disabled: false,
     });
   });
-  it('external-link non-https → disabled View details (guard drops it)', () => {
+  it('external-link non-https → View details → unified detail (guard drops the href)', () => {
     expect(getListingCta(offsiteCard('external-link', 'http://foo.app'), { canOpenPage: true })).toEqual({
       label: 'View details',
       action: 'detail',
-      href: undefined,
+      href: '/apps/store-preview/ext-app',
       external: false,
-      disabled: true,
     });
   });
-  it('external-link null url → disabled View details', () => {
-    expect(getListingCta(offsiteCard('external-link', null), { canOpenPage: true }).disabled).toBe(true);
-  });
-  it('connect → disabled Connect (P2c flow)', () => {
-    expect(getListingCta(offsiteCard('connect', null), { canOpenPage: true })).toEqual({
-      label: 'Connect',
-      action: 'connect',
-      href: undefined,
+  it('external-link null url → View details → unified detail', () => {
+    expect(getListingCta(offsiteCard('external-link', null), { canOpenPage: true })).toEqual({
+      label: 'View details',
+      action: 'detail',
+      href: '/apps/store-preview/ext-app',
       external: false,
-      disabled: true,
+    });
+  });
+  it('connect → View details → unified detail (Connect affordance lives on the detail page)', () => {
+    expect(getListingCta(offsiteCard('connect', null), { canOpenPage: true })).toEqual({
+      label: 'View details',
+      action: 'detail',
+      href: '/apps/store-preview/ext-app',
+      external: false,
     });
   });
 });

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * App Store Listings (W13) — P2c detail view-model unit tests (node `unit`
+ * project → the BLOCKING correctness gate; the browser component suites are
+ * report-only). Pin the kind × hasPage × subKind primary-action matrix incl.
+ * the appBlocksPages gate, https guard, connect stub, and slug encoding, so a
+ * regression in the detail action routing FAILS here.
+ */
+
+function onsiteDetail(
+  over: Partial<ListingDetail> & { hasPage: boolean; appBlockId?: string | null; liveUrl?: string }
+): ListingDetail {
+  const { hasPage, appBlockId = 'blk-1', liveUrl = 'https://my-app.civit.ai', ...rest } = over;
+  return {
+    id: 'l1',
+    slug: 'my-app',
+    kind: 'onsite',
+    name: 'My App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    screenshots: [],
+    kindData: { kind: 'onsite', appBlockId, hasPage, liveUrl },
+    ...rest,
+  };
+}
+
+function offsiteDetail(
+  subKind: 'connect' | 'external-link',
+  over: { externalUrl?: string | null; connectClientId?: string | null; slug?: string } = {}
+): ListingDetail {
+  const { externalUrl = null, connectClientId = null, slug = 'ext-app' } = over;
+  return {
+    id: 'l2',
+    slug,
+    kind: 'offsite',
+    name: 'Ext App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    screenshots: [],
+    kindData: { kind: 'offsite', subKind, externalUrl, connectClientId },
+  };
+}
+
+describe('getDetailPrimaryAction — on-site', () => {
+  it('hasPage + canOpenPage → Open → /apps/run/<slug>', () => {
+    expect(getDetailPrimaryAction(onsiteDetail({ hasPage: true, slug: 'gen' }), { canOpenPage: true })).toEqual({
+      label: 'Open',
+      mode: 'open',
+      href: '/apps/run/gen',
+      external: false,
+    });
+  });
+  it('hasPage + !canOpenPage → Open live → the standalone liveUrl (no dead run link)', () => {
+    expect(
+      getDetailPrimaryAction(onsiteDetail({ hasPage: true, liveUrl: 'https://my-app.civit.ai' }), {
+        canOpenPage: false,
+      })
+    ).toEqual({ label: 'Open live', mode: 'visit', href: 'https://my-app.civit.ai', external: true });
+  });
+  it('hasPage + !canOpenPage + non-https liveUrl → info fallback (guard drops it)', () => {
+    const action = getDetailPrimaryAction(
+      onsiteDetail({ hasPage: true, liveUrl: 'http://insecure.example' }),
+      { canOpenPage: false }
+    );
+    expect(action.mode).toBe('info');
+    expect(action.label).toBe('Runs on model pages');
+  });
+  it('!hasPage (model-slot) → info "Runs on model pages" → link to live /apps/<appBlockId>', () => {
+    const action = getDetailPrimaryAction(onsiteDetail({ hasPage: false, appBlockId: 'blk-9' }), {
+      canOpenPage: true,
+    });
+    expect(action.mode).toBe('info');
+    expect(action.label).toBe('Runs on model pages');
+    expect(action.href).toBe('/apps/blk-9');
+    expect(action.note).toBeTruthy();
+  });
+  it('!hasPage + no appBlockId → info with no learn-more link (no dead nav)', () => {
+    const action = getDetailPrimaryAction(onsiteDetail({ hasPage: false, appBlockId: null }), {
+      canOpenPage: true,
+    });
+    expect(action.mode).toBe('info');
+    expect(action.href).toBeUndefined();
+  });
+  it('encodes an odd slug on the Open run link', () => {
+    expect(
+      getDetailPrimaryAction(onsiteDetail({ hasPage: true, slug: 'a b/c' }), { canOpenPage: true }).href
+    ).toBe('/apps/run/a%20b%2Fc');
+  });
+});
+
+describe('getDetailPrimaryAction — off-site', () => {
+  it('external-link https → Visit ↗ (external)', () => {
+    expect(
+      getDetailPrimaryAction(offsiteDetail('external-link', { externalUrl: 'https://foo.app' }), {
+        canOpenPage: true,
+      })
+    ).toEqual({ label: 'Visit', mode: 'visit', href: 'https://foo.app', external: true });
+  });
+  it('external-link non-https → info Unavailable (guard drops it, no target)', () => {
+    const action = getDetailPrimaryAction(
+      offsiteDetail('external-link', { externalUrl: 'http://foo.app' }),
+      { canOpenPage: true }
+    );
+    expect(action).toEqual({
+      label: 'Unavailable',
+      mode: 'info',
+      external: false,
+      note: 'This app has no valid external link.',
+    });
+  });
+  it('external-link null url → info Unavailable', () => {
+    expect(getDetailPrimaryAction(offsiteDetail('external-link', { externalUrl: null }), { canOpenPage: true }).mode).toBe(
+      'info'
+    );
+  });
+  it('connect → Connect stub (mode connect, no dead href, note set)', () => {
+    const action = getDetailPrimaryAction(offsiteDetail('connect', { connectClientId: 'client-123' }), {
+      canOpenPage: true,
+    });
+    expect(action.mode).toBe('connect');
+    expect(action.label).toBe('Connect');
+    expect(action.href).toBeUndefined();
+    expect(action.external).toBe(false);
+    expect(action.note).toBeTruthy();
+  });
+});

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -10,21 +10,24 @@
  * preview surface. The default `/apps` render (MarketplaceBody → AppBlockCard)
  * is untouched; the cutover is a later PR (P2d).
  *
- * CTA target policy (dark phase — no listing detail page exists yet, that's P2c):
+ * CTA target policy (P2c — the unified dark listing detail now exists at
+ * `/apps/store-preview/<slug>`, so every card can reach a real detail surface and
+ * NO CTA is ever inert/disabled):
  *   - on-site + hasPage + canOpenPage → **Open** → `/apps/run/<slug>` (the LIVE
  *     W10 page route; itself flag-gated on `appBlocksPages`, so we only route
- *     there when the viewer can actually open it).
+ *     there when the viewer can actually open it) — the direct primary action.
  *   - on-site otherwise (no page, or page but no `appBlocksPages`) → **View
- *     details** → the EXISTING per-AppBlock detail page `/apps/<appBlockId>`
- *     (a real, working page — the honest dark-phase stub; P2c adds the unified
- *     `/apps/<slug>` listing detail).
- *   - off-site external-link (https) → **Visit ↗** → external anchor.
- *   - off-site external-link (missing / non-https url) → disabled "View details"
- *     (no target yet; the DTO already null-guards non-https — we re-guard).
- *   - off-site connect → disabled **Connect** (the connect flow / listing detail
- *     is P2c; rendered but inert in the preview).
- * A CTA with `disabled: true` renders as a non-actionable button (component wraps
- * it in a tooltip). Every card always has a CTA (never actionless).
+ *     details** → `/apps/store-preview/<slug>` (the unified P2c detail).
+ *   - off-site external-link (https) → **Visit ↗** → external anchor (direct
+ *     primary action).
+ *   - off-site external-link (missing / non-https url) → **View details** →
+ *     the unified detail (the DTO already null-guards non-https — we re-guard;
+ *     the detail page shows the informational state).
+ *   - off-site connect → **View details** → the unified detail (the Connect
+ *     affordance lives on the detail page).
+ * Every CTA now has a working `href` (never actionless). The card ALSO links its
+ * title to the detail (via `getListingDetailHref`) so the detail is reachable
+ * even when the primary CTA is a direct Open / Visit.
  */
 
 import type {
@@ -79,60 +82,58 @@ export type ListingCta = {
   label: string;
   /** Semantic action (drives icon choice + analytics later). */
   action: ListingCtaAction;
-  /** Navigation target, or `undefined` when there is no working target yet. */
-  href?: string;
+  /** Navigation target — always present (the unified detail is always reachable). */
+  href: string;
   /** True → open in a new tab as an external anchor (rel=noopener noreferrer). */
   external: boolean;
-  /** True → render a non-actionable (inert) button; there's no target in the dark phase. */
-  disabled: boolean;
 };
 
-/** The per-AppBlock detail page that on-site listings stub to during the dark phase. */
-function onsiteDetailHref(appBlockId: string | null): string | undefined {
-  return appBlockId ? `/apps/${encodeURIComponent(appBlockId)}` : undefined;
+/**
+ * The unified P2c listing detail (`/apps/store-preview/<slug>`). Every card can
+ * reach it by slug — the honest, working detail surface that replaces the P2b
+ * per-AppBlock / disabled stubs. `deIndex`-ed + mod-gated (dark), parallel to
+ * the live `/apps` path; the default-`/apps` cutover is P2d.
+ */
+export function getListingDetailHref(slug: string): string {
+  return `/apps/store-preview/${encodeURIComponent(slug)}`;
 }
 
 /**
  * Kind-aware primary CTA. `canOpenPage` mirrors the `appBlocksPages` feature
  * flag: when false the live page route 404s, so an on-site page app falls back
- * to "View details" instead of a dead "Open" link.
+ * to "View details" (the unified detail) instead of a dead "Open" link. Every
+ * non-direct case routes to the unified detail — no CTA is ever inert.
  */
 export function getListingCta(
   card: Pick<ListingCard, 'slug' | 'kind' | 'kindData'>,
   opts: { canOpenPage: boolean }
 ): ListingCta {
+  const detailHref = getListingDetailHref(card.slug);
+
   if (card.kindData.kind === 'onsite') {
-    const { appBlockId, hasPage } = card.kindData;
+    const { hasPage } = card.kindData;
     if (hasPage && opts.canOpenPage) {
       return {
         label: 'Open',
         action: 'open',
         href: `/apps/run/${encodeURIComponent(card.slug)}`,
         external: false,
-        disabled: false,
       };
     }
-    // No page, or page but the viewer can't open it → the detail stub.
-    const href = onsiteDetailHref(appBlockId);
-    return {
-      label: 'View details',
-      action: 'detail',
-      href,
-      external: false,
-      disabled: !href,
-    };
+    // No page, or page but the viewer can't open it → the unified detail.
+    return { label: 'View details', action: 'detail', href: detailHref, external: false };
   }
 
   // Off-site.
   if (card.kindData.subKind === 'external-link') {
     const href = safeExternalHref(card.kindData.externalUrl);
     if (href) {
-      return { label: 'Visit', action: 'visit', href, external: true, disabled: false };
+      return { label: 'Visit', action: 'visit', href, external: true };
     }
-    // No usable external target (missing / non-https) — no detail page yet (P2c).
-    return { label: 'View details', action: 'detail', href: undefined, external: false, disabled: true };
+    // No usable external target (missing / non-https) → the unified detail.
+    return { label: 'View details', action: 'detail', href: detailHref, external: false };
   }
 
-  // Off-site connect (OAuth). The connect flow / listing detail is P2c — inert here.
-  return { label: 'Connect', action: 'connect', href: undefined, external: false, disabled: true };
+  // Off-site connect (OAuth) — the Connect affordance lives on the detail page.
+  return { label: 'View details', action: 'detail', href: detailHref, external: false };
 }

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -1,0 +1,117 @@
+/**
+ * App Store Listings (W13) — P2c detail VIEW MODEL (pure, React-free).
+ *
+ * The kind-aware PRIMARY-ACTION logic for the unified listing detail
+ * (`AppListingDetailBody`), extracted into a pure function so the correctness
+ * gate lives in the node `unit` project (the civitai browser-mode component
+ * suites are REPORT-ONLY / non-blocking — so the real, blocking coverage for the
+ * detail action matrix is here, mirroring `appListingCardView`).
+ *
+ * DARK / parallel-run: consumed only by the mod-only `/apps/store-preview/<slug>`
+ * detail surface. The live `/apps/[appBlockId]` detail + `AppDetailsModal` are
+ * untouched; the cutover to a canonical `/apps/[slug]` is a later PR (P2d).
+ *
+ * PRIMARY-ACTION policy (kind × hasPage × subKind), all with NO dead 404 nav:
+ *   - on-site + hasPage + canOpenPage → **Open** (`/apps/run/<slug>`, the LIVE
+ *     W10 in-host page route; flag-gated on `appBlocksPages`).
+ *   - on-site + hasPage + !canOpenPage → **Open live** → the already-public
+ *     standalone block origin (`liveUrl`, https-guarded) — no dead run link.
+ *   - on-site + !hasPage (model-slot app) → **informational** ("Runs on model
+ *     pages"): install happens on a model page, so there is no standalone
+ *     install here; link out to the live per-app detail (`/apps/<appBlockId>`)
+ *     where the install affordance lives. (Deeper install wiring = cutover.)
+ *   - off-site external-link (https) → **Visit ↗** → external anchor.
+ *   - off-site external-link (missing / non-https) → **informational** (guarded
+ *     out; no target).
+ *   - off-site connect (OAuth) → **Connect** STUB: a complete OAuth authorize
+ *     URL is NOT derivable from the public DTO (needs redirect_uri /
+ *     response_type / scope), so the connect flow is an honest stub with a note
+ *     until the cutover wires it — no dead 404 nav.
+ */
+
+import { safeExternalHref } from '~/components/Apps/appListingCardView';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * Primary-action mode:
+ *   - `open`    → internal nav to the in-host page runner.
+ *   - `visit`   → external new-tab anchor (Visit / Open live).
+ *   - `connect` → the OAuth connect affordance (stubbed until cutover; `note` set).
+ *   - `info`    → informational affordance, optional `href` "learn more" link.
+ */
+export type DetailActionMode = 'open' | 'visit' | 'connect' | 'info';
+
+export type DetailPrimaryAction = {
+  /** Button / affordance copy. */
+  label: string;
+  mode: DetailActionMode;
+  /** Nav target (internal for `open`/`info` link, external for `visit`), or undefined. */
+  href?: string;
+  /** True → open in a new tab as an external anchor (rel=noopener noreferrer). */
+  external: boolean;
+  /** Informational copy for the `info` / `connect`-stub modes. */
+  note?: string;
+};
+
+/** The live per-AppBlock detail page (where a model-slot on-site app installs). */
+function liveAppDetailHref(appBlockId: string | null): string | undefined {
+  return appBlockId ? `/apps/${encodeURIComponent(appBlockId)}` : undefined;
+}
+
+/**
+ * Kind-aware primary action for the unified detail. `canOpenPage` mirrors the
+ * `appBlocksPages` flag (dark/mod-only today) so an on-site page app never
+ * routes to a `/apps/run` link the viewer can't open.
+ */
+export function getDetailPrimaryAction(
+  detail: Pick<ListingDetail, 'slug' | 'kind' | 'kindData'>,
+  opts: { canOpenPage: boolean }
+): DetailPrimaryAction {
+  const kd = detail.kindData;
+
+  if (kd.kind === 'onsite') {
+    if (kd.hasPage && opts.canOpenPage) {
+      return {
+        label: 'Open',
+        mode: 'open',
+        href: `/apps/run/${encodeURIComponent(detail.slug)}`,
+        external: false,
+      };
+    }
+    if (kd.hasPage) {
+      // Page app, but this viewer can't launch the in-host page (appBlocksPages
+      // dark) — offer the already-public standalone origin instead of a dead
+      // /apps/run link.
+      const live = safeExternalHref(kd.liveUrl);
+      if (live) return { label: 'Open live', mode: 'visit', href: live, external: true };
+    }
+    // Model-slot app (no launch page): install happens on a model page.
+    return {
+      label: 'Runs on model pages',
+      mode: 'info',
+      href: liveAppDetailHref(kd.appBlockId),
+      external: false,
+      note: 'This app installs into a slot on model pages — open a model where it appears to add it.',
+    };
+  }
+
+  // Off-site.
+  if (kd.subKind === 'external-link') {
+    const href = safeExternalHref(kd.externalUrl);
+    if (href) return { label: 'Visit', mode: 'visit', href, external: true };
+    return {
+      label: 'Unavailable',
+      mode: 'info',
+      external: false,
+      note: 'This app has no valid external link.',
+    };
+  }
+
+  // Off-site connect (OAuth) — honest stub (see docstring: no derivable authorize URL).
+  return {
+    label: 'Connect',
+    mode: 'connect',
+    external: false,
+    note: 'Connecting this app will be available soon.',
+  };
+}

--- a/src/pages/apps/store-preview/[slug].tsx
+++ b/src/pages/apps/store-preview/[slug].tsx
@@ -1,0 +1,73 @@
+import { Center, Loader } from '@mantine/core';
+import { useRouter } from 'next/router';
+import { NotFound } from '~/components/AppLayout/NotFound';
+import { AppListingDetailBody } from '~/components/Apps/AppListingDetailBody';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
+import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
+import { Meta } from '~/components/Meta/Meta';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App Store Listings (W13) — P2c DARK unified listing DETAIL route
+ * (`/apps/store-preview/<slug>`).
+ *
+ * The per-listing detail for the NEW unified `AppListing`-backed store, rendered
+ * ALONGSIDE the live `/apps/[appBlockId]` detail (which is byte-unchanged). This
+ * folder route coexists with the sibling `pages/apps/store-preview.tsx` grid in
+ * the pages router. The default-`/apps` cutover to a canonical `/apps/[slug]` is
+ * a later PR (P2d).
+ *
+ * Gating (mirrors `store-preview.tsx`): `resolveAppsPageAccess` — the SAME
+ * mod-segmented `appBlocks` flag gate as `/apps` (mod-only dark today →
+ * `notFound` for non-mods/anon). NO SSR data leak: the listing is fetched
+ * CLIENT-SIDE via `appListings.getAppDetail` (itself dark behind the same flag +
+ * approved-only, public-allowlist DTO). `deIndex` stays on. A missing /
+ * non-approved slug 404s server-side → `NotFound`.
+ */
+export const getServerSideProps = createServerSideProps({
+  useSession: true,
+  resolver: async ({ features }) => resolveAppsPageAccess({ features }),
+});
+
+export default function AppStoreListingDetailPage() {
+  const features = useFeatureFlags();
+  const router = useRouter();
+  const slug = typeof router.query.slug === 'string' ? router.query.slug : '';
+
+  // Anon-capable public read path — fires only behind the appBlocks flag (mods
+  // today) with a slug. Returns ONLY the ListingDetail allowlist; a missing /
+  // non-approved slug 404s server-side. retry:false so it settles into NotFound.
+  const { data, isLoading, error } = trpc.appListings.getAppDetail.useQuery(
+    { slug },
+    { enabled: !!features.appBlocks && !!slug, retry: false }
+  );
+
+  if (!features.appBlocks) return <NotFound />;
+  if (error) return <NotFound />;
+
+  const detail = data as ListingDetail | undefined;
+
+  return (
+    <>
+      <Meta
+        title={detail ? `${detail.name} — App store preview` : 'App store preview — Civitai'}
+        description={detail?.tagline ?? 'Unified app store preview'}
+        deIndex
+      />
+      <AppsPageLayout size="lg">
+        {isLoading ? (
+          <Center py="xl">
+            <Loader />
+          </Center>
+        ) : !detail ? (
+          <NotFound />
+        ) : (
+          <AppListingDetailBody detail={detail} canOpenPage={!!features.appBlocksPages} />
+        )}
+      </AppsPageLayout>
+    </>
+  );
+}


### PR DESCRIPTION
## What

**Phase 2, PR 3 (P2c)** of the App Store Listings (W13) workstream: the per-listing **DETAIL** surface for the unified `/apps` store, consuming the P2a `appListings.getAppDetail` read path and resolving the P2b card-CTA stubs.

**DARK + PARALLEL-RUN:** the live `/apps/[appBlockId]` detail, `AppDetailsModal`, and default `/apps` are byte-unchanged. The new detail lives under the dark, mod-gated `store-preview` tree. Making `/apps/[slug]` canonical is a later PR (**P2d**).

## Route + dark gate

`src/pages/apps/store-preview/[slug].tsx` (a folder route coexisting with the sibling `store-preview.tsx` grid). Gating mirrors `store-preview.tsx`:
- `getServerSideProps` → `resolveAppsPageAccess` (mod-segmented `appBlocks` flag → `notFound` for anon/non-mods).
- `deIndex` on `<Meta>`; **no SSR data leak** — the listing is fetched client-side via `trpc.appListings.getAppDetail.useQuery({ slug }, { enabled: !!features.appBlocks })`.
- Missing / non-approved slug 404s server-side → `NotFound`.

## Detail body

`AppListingDetailBody` — hero cover (category-glyph placeholder + on-error fallback) · app icon · name · tagline · creator chip · kind / category / contentRating badges · Steam-style recommend breakdown (recommendPct + counts; "No reviews yet" when null, via the P2b recommend-label helper) · screenshot **gallery** (reuses `AppDetailsModal`'s `SimpleGrid` pattern; `screenshots[]{url,caption}`, skips empty/broken) · `CustomMarkdown` description · the kind-aware primary action.

## Kind-aware primary action (pure `getDetailPrimaryAction`)

| kind | condition | action |
|---|---|---|
| onsite | hasPage + canOpenPage | **Open** → `/apps/run/<slug>` |
| onsite | hasPage + !canOpenPage | **Open live** → standalone `liveUrl` (https-guarded; no dead run link) |
| onsite | !hasPage (model-slot) | **info** "Runs on model pages" → link to live `/apps/<appBlockId>` |
| offsite | external-link (https) | **Visit ↗** (rel=noopener noreferrer, new tab) |
| offsite | external-link (non-https/null) | **info** "Unavailable" (guard drops it) |
| offsite | connect | **Connect** honest stub (see below) |

## CTA wiring (resolves P2b stubs)

`getListingCta` "View details" (+ the onsite-!hasPage / offsite non-https / offsite-connect cases) now route to **`/apps/store-preview/<slug>`** (new `getListingDetailHref`) instead of the per-AppBlock / disabled stubs — **every CTA has a working href, no inert CTAs**. Direct **Open** (page apps → run) and **Visit** (offsite external) stay primary; the card **title links to the detail** so it's reachable from every card. Same XSS/encoding discipline as P2b (`encodeURIComponent`, https-only anchors, no `dangerouslySetInnerHTML`).

## Tests

Node `unit` project (the blocking gate — civitai browser-mode suites are report-only):
- **new** `appListingDetailView.test.ts` (10) — the detail action matrix incl. the `appBlocksPages` gate, https guard, connect stub, slug encoding.
- **updated** `appListingCardView.test.ts` (19) — new detail hrefs + `getListingDetailHref`.
- **29/29 pass.**

No non-route files under `src/pages` (#78/#81). Local tsc reports 0 errors in the new files (the repo's ~188 baseline tsc errors are environmental — a stale symlinked Prisma client + `civitai-ui` build — and unrelated; Tekton is the authoritative typecheck, #24).

## Stubbed → cutover
- **offsite-connect** OAuth flow — no complete authorize URL is derivable from the public DTO (needs `redirect_uri`/`response_type`/`scope`), so it's an honest disabled stub with a note (no dead 404 nav).
- **onsite model-slot** in-detail install (install happens on a model page; detail links out to the live per-app detail).
- The canonical `/apps/[slug]` **default-swap** (P2d).

**Do not merge** — pending an adversarial `/audit-pr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
