### PR TITLE
feat(app-blocks): W13 P2d — cut /apps over to the unified AppListing store (mod-only)

### DIFF
--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -1,6 +1,6 @@
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
-import { MarketplaceBody } from '~/components/Apps/MarketplaceBody';
+import { AppListingsMarketplaceBody } from '~/components/Apps/AppListingsMarketplaceBody';
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -25,11 +25,26 @@ export default function AppsPage() {
       <Meta title="Apps — Civitai" description="Civitai Apps marketplace" deIndex />
       {/* Outer chrome (Container + sticky sub-nav) is supplied by AppsPageLayout;
           the marketplace title/subtitle were removed for the page-apps-only
-          launch (the sub-nav supplies the wayfinding), so no header props. The
-          marketplace controls + grid live in MarketplaceBody (extracted so it's
-          component-testable without this page's server-side import chain). */}
+          launch (the sub-nav supplies the wayfinding), so no header props.
+
+          W13 P2d CUTOVER: the default `/apps` store now reads the unified
+          `AppListing` record (both on-site App Blocks AND off-site OAuth apps)
+          via `AppListingsMarketplaceBody` (the P2a `appListings.listAvailable`
+          read path). Still dark/mod-only — the page gate is UNCHANGED
+          (`resolveAppsPageAccess` → `features.appBlocks` Flipt mod segment,
+          `deIndex`), this only swaps WHICH grid renders.
+
+          ROLLBACK = one-line revert: the legacy AppBlock path
+          (`MarketplaceBody` → `AppBlockCard`) is intentionally retained in the
+          tree; swap this back to `<MarketplaceBody />` (re-import it) to fall
+          back to the AppBlock-backed grid.
+
+          The grid will be EMPTY until the mod-only backfills run on prod
+          (`blocks.backfillAppListings` → `appListings.backfillListingAssets`,
+          a separate post-deploy op step) — the empty state renders sanely
+          ("No apps yet"); expected + fine while dark. */}
       <AppsPageLayout size="xl">
-        <MarketplaceBody />
+        <AppListingsMarketplaceBody />
       </AppsPageLayout>
     </>
   );

--- a/src/pages/apps/store-preview.tsx
+++ b/src/pages/apps/store-preview.tsx
@@ -1,40 +1,32 @@
-import { NotFound } from '~/components/AppLayout/NotFound';
-import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
-import { AppListingsMarketplaceBody } from '~/components/Apps/AppListingsMarketplaceBody';
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
-import { Meta } from '~/components/Meta/Meta';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 
 /**
- * App Store Listings (W13) — P2b DARK preview mount.
+ * App Store Listings (W13) — P2d: `/apps/store-preview` REDIRECTS to `/apps`.
  *
- * A dedicated preview route that renders the NEW unified `AppListing`-backed
- * store (`AppListingsMarketplaceBody`) ALONGSIDE the live `/apps` surface. The
- * default `/apps` render (MarketplaceBody → AppBlockCard, off the AppBlock path)
- * is byte-unchanged — `pages/apps/index.tsx` is not touched. The default-swap /
- * cutover is a later PR (P2d).
+ * This was the DARK preview mount of the unified `AppListing`-backed store
+ * (`AppListingsMarketplaceBody`) that parallel-ran alongside the live `/apps`
+ * during P2b/P2c. As of the P2d cutover, `/apps` renders that same unified grid
+ * directly, so this standalone grid route is redundant — it 302-redirects to
+ * `/apps` (behind the SAME `resolveAppsPageAccess` mod gate: a non-mod still
+ * gets notFound, never a redirect that leaks the surface exists).
  *
- * Gating: reuses `resolveAppsPageAccess` — the SAME mod-segmented `appBlocks`
- * flag gate as `/apps` (the flag's Flipt segment is mod-only today, so this is
- * mod-only dark). `deIndex` stays on so the preview is never crawlable.
+ * NOTE: the listing DETAIL route `/apps/store-preview/[slug]` (P2c) is KEPT —
+ * the `AppListingCard` CTAs still link there. Reconciling the canonical detail
+ * URL (`/apps/[slug]`) vs the live `/apps/[appBlockId]` collision is a separate
+ * pre-GA follow-up, not this PR.
  */
 export const getServerSideProps = createServerSideProps({
   useSession: true,
-  resolver: async ({ features }) => resolveAppsPageAccess({ features }),
+  resolver: async ({ features }) => {
+    const access = resolveAppsPageAccess({ features });
+    if ('notFound' in access) return access;
+    return { redirect: { destination: '/apps', permanent: false } };
+  },
 });
 
-export default function AppsStorePreviewPage() {
-  const features = useFeatureFlags();
-
-  if (!features.appBlocks) return <NotFound />;
-
-  return (
-    <>
-      <Meta title="App store preview — Civitai" description="Unified app store preview" deIndex />
-      <AppsPageLayout size="xl">
-        <AppListingsMarketplaceBody />
-      </AppsPageLayout>
-    </>
-  );
+// getServerSideProps always redirects (access) or notFounds (no access), so this
+// body never renders; a default export is still required for a pages/ route.
+export default function AppsStorePreviewRedirect() {
+  return null;
 }


### PR DESCRIPTION
## W13 P2d — the `/apps` cutover

First PR that touches the **live** (mod-gated) `/apps` default render. Small + trivially reversible.

### The swap (before → after)
`src/pages/apps/index.tsx` renders a different grid inside the **unchanged** page gate/layout:

- **Before:** `<AppsPageLayout><MarketplaceBody /></AppsPageLayout>` — the AppBlock path (`MarketplaceBody → AppBlockCard`).
- **After:** `<AppsPageLayout><AppListingsMarketplaceBody /></AppsPageLayout>` — the unified `AppListing` path (P2a `appListings.listAvailable`, both on-site App Blocks **and** off-site OAuth apps).

Page gate is **byte-identical**: `resolveAppsPageAccess({ features })` (getServerSideProps) + `if (!features.appBlocks) return <NotFound/>` + `deIndex`. Still **dark, mod-only** — this only changes *which grid renders*, not who can reach `/apps`. `AppListingsMarketplaceBody`'s query stays gated (`enabled: !!features.appBlocks`).

### Rollback
One-line revert. `MarketplaceBody.tsx` / `AppBlockCard.tsx` are **retained** in the tree (not deleted); swap `index.tsx` back to `<MarketplaceBody />` (re-import it) to fall back to the AppBlock-backed grid.

### Redundant store-preview grid route
`/apps/store-preview` (the dark standalone grid, now == `/apps`) **302-redirects to `/apps`** behind the same `resolveAppsPageAccess` gate (a non-mod still gets `notFound`, never a redirect that leaks the surface). The listing **detail** route `/apps/store-preview/[slug]` (P2c) is **kept** — the `AppListingCard` CTAs link there. Nothing in the tree linked to the standalone grid route.

### Empty until backfill (expected)
The listing grid is **EMPTY on prod** until the mod-only backfills run (`blocks.backfillAppListings` → `appListings.backfillListingAssets`, a separate post-deploy op step). The empty state renders sanely ("No apps yet") — not a crash/misleading error. Fine while dark/mod-only.

### Deferred to pre-GA (NOT this PR)
- Canonical `/apps/[slug]` detail-URL vs the live `/apps/[appBlockId]` collision (route surgery — flagged, not attempted).
- Dedicated `appListings` Flipt flag (still reusing `appBlocks`, mods-only).
- The two P1-audit prereqs: per-image NSFW rescan of creator imagery; mod-override attach-foreign-private-image gate.
- Any public exposure / Flipt widen.

### Tests
- App-Blocks unit suite (`src/components/Apps/__tests__/`, `unit` project): **66/66 pass** (8 files, incl. the 6-test `resolveAppsPageAccess` gate reused by the store-preview redirect). No regression.
- Diff = 2 existing route files only (no new non-route files under `src/pages`, gotcha #78/#81). No untyped inline handlers (gotcha #24). Authoritative gate = Tekton `preview / deploy` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)