### PR TITLE
test(app-blocks): fix AppListingCard getByText strict-mode failures (#2874 follow-up)

### DIFF
--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -35,7 +35,9 @@ describe('AppListingCard', () => {
   test('on-site page app + canOpenPage → Open link to the run route', async () => {
     renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
     await expect.element(page.getByText('My App')).toBeInTheDocument();
-    await expect.element(page.getByText('App')).toBeInTheDocument();
+    // exact: the "App" kind badge, else the substring also matches the title
+    // ("My App") and description ("A handy app") — strict-mode violation.
+    await expect.element(page.getByText('App', { exact: true })).toBeInTheDocument();
     await expect.element(page.getByText('by alice')).toBeInTheDocument();
     const open = page.getByRole('link', { name: 'Open' });
     await expect.element(open).toBeInTheDocument();
@@ -90,7 +92,9 @@ describe('AppListingCard', () => {
         })}
       />
     );
-    await expect.element(page.getByText('Connect app')).toBeInTheDocument();
+    // exact: the "Connect app" badge, else the substring also matches the title
+    // ("Connect App", case-insensitive) — strict-mode violation.
+    await expect.element(page.getByText('Connect app', { exact: true })).toBeInTheDocument();
     const details = page.getByRole('link', { name: 'View details' });
     await expect.element(details).toHaveAttribute('href', '/apps/store-preview/my-app');
   });


### PR DESCRIPTION
## What

Follow-up to #2874. Two of its new `AppListingCard.browser.test.tsx` tests fail — **test bugs, not product bugs**. Playwright's `page.getByText` is case-insensitive **substring** by default, so the assertions collided with the card title:

| Line | Query | Also matched |
|---|---|---|
| L38 | `getByText('App')` | title `My App`, badge `App`, desc `A handy app` (3 → strict-mode violation) |
| L93 | `getByText('Connect app')` | title `Connect App`, badge `Connect app` (2 → strict-mode violation) |

**Fix:** add `{ exact: true }` (case-sensitive, whole text node) so each resolves to only the kind badge it's asserting (`"My App"`/`"A handy app"` ≠ exact `"App"`; `"Connect App"` ≠ case-exact `"Connect app"`).

## Verification
The `component-tests` suite builds again after #2871, so these two now run green. Confirming on the preview `component-tests` check (fail→pass on `AppListingCard.browser.test.tsx`).

Note: `#2874`'s `unit-tests` failure was **separate + pre-existing** (`block-registry.marketplace-meta`, unrelated to that PR) — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)