### PR TITLE
feat(app-blocks): appBlocksAuthor capability — open authoring to a non-mod cohort

### DIFF
--- a/src/components/Apps/MarketplaceBody.tsx
+++ b/src/components/Apps/MarketplaceBody.tsx
@@ -166,10 +166,11 @@ export function MarketplaceBody() {
   // marketplace cards owned by the viewer. Visible only to the owner;
   // the trPC procedure is guarded so other users get nothing back.
   const { data: myAppsRaw } = trpc.blocks.getMyApps.useQuery(undefined, {
-    // getMyApps is a moderatorProcedure — gate on the same developer predicate as
-    // the rest of the funnel so a non-developer never fires it (today: mod-only;
-    // post-W11-widen: only app developers, not every logged-in marketplace viewer).
-    enabled: !!features.appBlocks && isAppDeveloper(currentUser),
+    // getMyApps is an appDeveloperProcedure — gate on the same developer predicate
+    // as the rest of the funnel so a non-developer never fires it. Threads the
+    // `appBlocksAuthor` capability so the curated non-mod author cohort (not every
+    // logged-in marketplace viewer) fires it too.
+    enabled: !!features.appBlocks && isAppDeveloper(currentUser, { appBlocksAuthor: features.appBlocksAuthor }),
   });
   const earningsByAppBlockId = useMemo(() => {
     type AppRow = { id: string; lifetimeShareCents: number };
@@ -325,7 +326,7 @@ export function MarketplaceBody() {
           probeLoading={probeLoading && hasActiveFilters}
           hasActiveFilters={hasActiveFilters}
           onClearFilters={clearFilters}
-          canSubmit={isAppDeveloper(currentUser)}
+          canSubmit={isAppDeveloper(currentUser, { appBlocksAuthor: features.appBlocksAuthor })}
         />
       ) : (
         <>

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -7,7 +7,7 @@ import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
 import { dbWrite } from '~/server/db/client';
 import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
 import { SLUG_REGEX } from '~/server/schema/blocks/publish-request.schema';
-import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { BlockTokenService } from '~/server/services/block-token.service';
 import {
   isKnownBlockScope,
@@ -380,9 +380,16 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     }
   }
 
-  // 2. MOD gate — App Blocks is mod-only pre-GA. The runtime spend belt already
-  // asserts moderator, but we keep the MINT mod-gated too (scope doc §4 / §6 R2).
-  if (!user.isModerator || user.bannedAt) {
+  // 2. Author gate — App Blocks authoring is capability-gated on the dedicated
+  // `app-blocks-author` flag (static fallback mod-only), so a curated non-mod
+  // cohort can mint a dev token for `dev:live`. A BANNED account is always
+  // rejected. The runtime spend belt re-checks the author capability against the
+  // token SUBJECT; we keep the MINT author-gated too (scope doc §4 / §6 R2).
+  if (user.bannedAt) {
+    res.status(403).json({ message: 'App Blocks is restricted to the civitai team' });
+    return;
+  }
+  if (!(await isAppBlocksAuthorEnabled({ user }))) {
     res.status(403).json({ message: 'App Blocks is restricted to the civitai team' });
     return;
   }

--- a/src/pages/api/v1/blocks/submissions.ts
+++ b/src/pages/api/v1/blocks/submissions.ts
@@ -6,7 +6,7 @@ import * as z from 'zod';
 import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
 import { dbRead } from '~/server/db/client';
 import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
-import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { Flags } from '~/shared/utils/flags';
 
@@ -202,9 +202,14 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     }
   }
 
-  // 2. Moderator gate — App Blocks is mod-only pre-GA (parity with
-  // submit-version + dev-token).
-  if (!user.isModerator || user.bannedAt) {
+  // 2. Author gate — App Blocks AUTHORING is mod OR the app-dev-testers cohort
+  // (parity with submit-version + withdraw + dev-token). AUTHZ; the
+  // isAppBlocksEnabled kill-switch below is separate.
+  if (user.bannedAt) {
+    res.status(403).json({ message: 'App Blocks is restricted to the civitai team' });
+    return;
+  }
+  if (!(await isAppBlocksAuthorEnabled({ user }))) {
     res.status(403).json({ message: 'App Blocks is restricted to the civitai team' });
     return;
   }

--- a/src/pages/api/v1/blocks/submit-version.ts
+++ b/src/pages/api/v1/blocks/submit-version.ts
@@ -5,7 +5,7 @@ import type { SessionUser } from '~/types/session';
 import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
 import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
 import { submitVersionSchema } from '~/server/schema/blocks/publish-request.schema';
-import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { Flags } from '~/shared/utils/flags';
 
@@ -141,10 +141,17 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     }
   }
 
-  // 2. Moderator gate — App Blocks is mod-only pre-GA (parity with the session
-  // route's ModEndpoint). Resolve before touching the heavy body so a non-mod
-  // key never costs a decode.
-  if (!user.isModerator || user.bannedAt) {
+  // 2. Author gate — App Blocks authoring is capability-gated on the dedicated
+  // `app-blocks-author` flag (static fallback mod-only), so a curated non-mod
+  // cohort can submit. A BANNED account is always rejected regardless of the
+  // capability. Resolve before touching the heavy body so a non-author key never
+  // costs a decode. (This is AUTHZ; the `isAppBlocksEnabled` kill-switch below
+  // is a separate gate.)
+  if (user.bannedAt) {
+    res.status(403).json({ message: 'App Blocks is restricted to the civitai team' });
+    return;
+  }
+  if (!(await isAppBlocksAuthorEnabled({ user }))) {
     res.status(403).json({ message: 'App Blocks is restricted to the civitai team' });
     return;
   }

--- a/src/pages/api/v1/blocks/withdraw.ts
+++ b/src/pages/api/v1/blocks/withdraw.ts
@@ -5,7 +5,7 @@ import type { SessionUser } from '~/types/session';
 import * as z from 'zod';
 import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
 import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
-import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { withdrawRequest, WithdrawRequestError } from '~/server/services/blocks/publish-request.service';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { Flags } from '~/shared/utils/flags';
@@ -131,9 +131,14 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     }
   }
 
-  // 2. Moderator gate — App Blocks is mod-only pre-GA (parity with
-  // submit-version + submissions + dev-token).
-  if (!user.isModerator || user.bannedAt) {
+  // 2. Author gate — App Blocks AUTHORING is mod OR the app-dev-testers cohort
+  // (parity with submit-version + submissions + dev-token). AUTHZ; the
+  // isAppBlocksEnabled kill-switch below is separate.
+  if (user.bannedAt) {
+    res.status(403).json({ message: 'App Blocks is restricted to the civitai team' });
+    return;
+  }
+  if (!(await isAppBlocksAuthorEnabled({ user }))) {
     res.status(403).json({ message: 'App Blocks is restricted to the civitai team' });
     return;
   }

--- a/src/pages/apps/[appBlockId]/revenue.tsx
+++ b/src/pages/apps/[appBlockId]/revenue.tsx
@@ -26,7 +26,10 @@ import { trpc } from '~/utils/trpc';
 export const getServerSideProps = createServerSideProps({
   useSession: true,
   resolver: async ({ features, session, ctx }) => {
-    if (!features?.appBlocks) return { notFound: true };
+    // Author-capability gate (Phase B): the dedicated `appBlocksAuthor` flag
+    // (Flipt `app-blocks-author`, static fallback mod-only), INDEPENDENT of the
+    // marketplace-visibility `appBlocks` flag (which widens to public at GA).
+    if (!features?.appBlocksAuthor) return { notFound: true };
     if (!session?.user) {
       return {
         redirect: {
@@ -35,7 +38,7 @@ export const getServerSideProps = createServerSideProps({
         },
       };
     }
-    if (!isAppDeveloper(session.user)) {
+    if (!isAppDeveloper(session.user, { appBlocksAuthor: features?.appBlocksAuthor })) {
       return { notFound: true };
     }
     return { props: {} };

--- a/src/pages/apps/my-submissions.tsx
+++ b/src/pages/apps/my-submissions.tsx
@@ -28,7 +28,10 @@ import { trpc } from '~/utils/trpc';
 export const getServerSideProps = createServerSideProps({
   useSession: true,
   resolver: async ({ features, session, ctx }) => {
-    if (!features?.appBlocks) return { notFound: true };
+    // Author-capability gate (Phase B): the dedicated `appBlocksAuthor` flag
+    // (Flipt `app-blocks-author`, static fallback mod-only), INDEPENDENT of the
+    // marketplace-visibility `appBlocks` flag (which widens to public at GA).
+    if (!features?.appBlocksAuthor) return { notFound: true };
     if (!session?.user) {
       return {
         redirect: {
@@ -37,7 +40,7 @@ export const getServerSideProps = createServerSideProps({
         },
       };
     }
-    if (!isAppDeveloper(session.user)) {
+    if (!isAppDeveloper(session.user, { appBlocksAuthor: features?.appBlocksAuthor })) {
       return { notFound: true };
     }
     return { props: {} };

--- a/src/pages/apps/revenue.tsx
+++ b/src/pages/apps/revenue.tsx
@@ -27,7 +27,10 @@ import { trpc } from '~/utils/trpc';
 export const getServerSideProps = createServerSideProps({
   useSession: true,
   resolver: async ({ features, session, ctx }) => {
-    if (!features?.appBlocks) return { notFound: true };
+    // Author-capability gate (Phase B): the dedicated `appBlocksAuthor` flag
+    // (Flipt `app-blocks-author`, static fallback mod-only), INDEPENDENT of the
+    // marketplace-visibility `appBlocks` flag (which widens to public at GA).
+    if (!features?.appBlocksAuthor) return { notFound: true };
     if (!session?.user) {
       return {
         redirect: {
@@ -36,7 +39,7 @@ export const getServerSideProps = createServerSideProps({
         },
       };
     }
-    if (!isAppDeveloper(session.user)) {
+    if (!isAppDeveloper(session.user, { appBlocksAuthor: features?.appBlocksAuthor })) {
       return { notFound: true };
     }
     return { props: {} };

--- a/src/pages/apps/submit.tsx
+++ b/src/pages/apps/submit.tsx
@@ -54,7 +54,10 @@ import { trpc } from '~/utils/trpc';
 export const getServerSideProps = createServerSideProps({
   useSession: true,
   resolver: async ({ features, session, ctx }) => {
-    if (!features?.appBlocks) return { notFound: true };
+    // Author-capability gate (Phase B): the dedicated `appBlocksAuthor` flag
+    // (Flipt `app-blocks-author`, static fallback mod-only), INDEPENDENT of the
+    // marketplace-visibility `appBlocks` flag (which widens to public at GA).
+    if (!features?.appBlocksAuthor) return { notFound: true };
     if (!session?.user) {
       return {
         redirect: {
@@ -63,7 +66,7 @@ export const getServerSideProps = createServerSideProps({
         },
       };
     }
-    if (!isAppDeveloper(session.user)) {
+    if (!isAppDeveloper(session.user, { appBlocksAuthor: features?.appBlocksAuthor })) {
       return { notFound: true };
     }
     return { props: {} };

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -17,6 +17,8 @@ const {
   mockGetQuota,
   mockLogToAxiom,
   mockGetUserById,
+  mockGetSessionUser,
+  mockIsAppBlocksAuthorEnabled,
 } = vi.hoisted(() => {
   const mockClient = {
     query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
@@ -38,6 +40,8 @@ const {
     mockGetQuota: vi.fn(),
     mockLogToAxiom: vi.fn(async () => undefined),
     mockGetUserById: vi.fn(),
+    mockGetSessionUser: vi.fn(),
+    mockIsAppBlocksAuthorEnabled: vi.fn(),
   };
 });
 
@@ -51,6 +55,10 @@ vi.mock('~/server/db/client', () => ({
 }));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
+vi.mock('~/server/auth/session-client', () => ({
+  sessionClient: { getSessionUserById: (...args: unknown[]) => mockGetSessionUser(...args) },
 }));
 vi.mock('~/server/db/appsDb', () => ({
   requireAppsDb: () => mockPool,
@@ -116,13 +124,21 @@ beforeEach(() => {
   mockGetQuota.mockReset();
   mockLogToAxiom.mockReset();
   mockGetUserById.mockReset();
+  mockGetSessionUser.mockReset();
+  mockIsAppBlocksAuthorEnabled.mockReset();
 
   // Sane defaults the happy-path tests inherit.
   mockIsAppBlocksEnabled.mockImplementation(async () => true);
   mockParseSubjectUserId.mockImplementation((sub: string) => (sub === 'anon' ? null : 42));
-  // Phase 2: App Blocks is moderator-only; the storage resolver re-asserts the
-  // resolved viewer is a mod. Default the happy path to a moderator subject.
+  // The storage resolver re-asserts the resolved viewer is an app AUTHOR
+  // (assertViewerIsAppDeveloper → getSessionUserById + isAppBlocksAuthorEnabled).
+  // Default the happy path to a moderator subject; the author capability defaults
+  // to the mod-floor (mirrors the flag absent → mods pass, non-mods don't).
   mockGetUserById.mockResolvedValue({ id: 42, isModerator: true });
+  mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: true });
+  mockIsAppBlocksAuthorEnabled.mockImplementation(
+    async (opts?: { user?: { isModerator?: boolean } }) => !!opts?.user?.isModerator
+  );
   mockDbRead.appBlock.findUnique.mockResolvedValue({
     id: 'apb_test',
     status: 'approved',
@@ -182,12 +198,12 @@ describe('apps.storage shared gates', () => {
     ).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
   });
 
-  // Phase 2: App Blocks is moderator-only until GA. A block token whose
-  // subject resolves to a non-mod user is rejected with FORBIDDEN by the
-  // shared resolveStorageContext gate — across every storage op.
+  // App Blocks authoring is mod OR the app-dev-testers cohort. A block token
+  // whose subject resolves to a non-author (non-mod, no cohort grant) is rejected
+  // with FORBIDDEN by the shared resolveStorageContext gate — across every op.
   it('rejects a non-mod resolved viewer with FORBIDDEN (get)', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
-    mockGetUserById.mockResolvedValueOnce({ id: 42, isModerator: false });
+    mockGetSessionUser.mockResolvedValueOnce({ id: 42, isModerator: false });
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
       caller.storage.get({ blockToken: 't', key: 'k' })
@@ -198,7 +214,7 @@ describe('apps.storage shared gates', () => {
 
   it('rejects a non-mod resolved viewer with FORBIDDEN (set)', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
-    mockGetUserById.mockResolvedValueOnce({ id: 42, isModerator: false });
+    mockGetSessionUser.mockResolvedValueOnce({ id: 42, isModerator: false });
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
       caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
@@ -206,13 +222,24 @@ describe('apps.storage shared gates', () => {
     expect(mockClient.query).not.toHaveBeenCalled();
   });
 
-  it('rejects a vanished resolved viewer with FORBIDDEN (getUserById → null)', async () => {
+  it('rejects a vanished resolved viewer with FORBIDDEN (getSessionUserById → null)', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
-    mockGetUserById.mockResolvedValueOnce(null);
+    mockGetSessionUser.mockResolvedValueOnce(null);
     const caller = appsRouter.createCaller(fakeCtx() as never);
     await expect(
       caller.storage.get({ blockToken: 't', key: 'k' })
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('accepts an author-capable NON-MOD subject (cohort widening): reaches the data pool', async () => {
+    // A curated non-mod author (granted app-blocks-author) whose block declares
+    // apps:storage:* must NOT be blocked at the storage gate — the KV op proceeds.
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockGetSessionUser.mockResolvedValueOnce({ id: 42, isModerator: false });
+    mockIsAppBlocksAuthorEnabled.mockResolvedValueOnce(true);
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await caller.storage.get({ blockToken: 't', key: 'k' });
+    expect(mockPool.query).toHaveBeenCalled();
   });
 
   // Fix 3 / audit A5 (design-gaps H4): storage is a DECLARED, approved scope —

--- a/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
+++ b/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
@@ -446,32 +446,38 @@ describe('blocks.deleteSubscription (guarded)', () => {
  * upsertSubscription/deleteSubscription/installOnModel were previously asserted
  * as FORBIDDEN-for-non-mod here (the old Phase-2 mod gate). That belt is gone by
  * design for these own-data procs; the coverage now lives in the
- * 'Layer 1 — install procs widened to protectedProcedure' describe below. The
- * procedures kept in THIS block (mod-review queue + revenue/apps developer reads)
- * remain mod-gated.
+ * 'Layer 1 — install procs widened to protectedProcedure' describe below.
+ *
+ * Developer soft-launch (Phase B): the own-data DEVELOPER reads getMyRevenue /
+ * getMyApps moved `moderatorProcedure → appDeveloperProcedure` (the
+ * `appBlocksAuthor` capability). A plain non-mod with no cohort grant still
+ * resolves the capability OFF (static mod-only fallback) → FORBIDDEN, so the
+ * assertions below are unchanged. The mod-REVIEW queue procs
+ * (listPendingRequests / approveRequest) STAY `moderatorProcedure` — the guard
+ * that a non-mod can never review/curate others' apps.
  */
-describe('Phase 2 — mod-only procedures reject non-mod verified users (FORBIDDEN)', () => {
+describe('soft-launch — developer + mod-review procs reject a plain non-mod (FORBIDDEN)', () => {
   function nonMod() {
     return blocksRouter.createCaller(authedCtx(42, false) as never);
   }
 
-  it('listPendingRequests (mod queue) → FORBIDDEN', async () => {
+  it('listPendingRequests (mod queue, stays mod-only) → FORBIDDEN', async () => {
     await expect(nonMod().listPendingRequests({ limit: 20 })).rejects.toMatchObject({
       code: 'FORBIDDEN',
     });
   });
 
-  it('approveRequest → FORBIDDEN', async () => {
+  it('approveRequest (mod-only review/curation, unchanged) → FORBIDDEN', async () => {
     await expect(
       nonMod().approveRequest({ publishRequestId: 'pubreq_x' })
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 
-  it('getMyRevenue → FORBIDDEN', async () => {
+  it('getMyRevenue (author-gated) → FORBIDDEN for a non-cohort non-mod', async () => {
     await expect(nonMod().getMyRevenue({})).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 
-  it('getMyApps → FORBIDDEN', async () => {
+  it('getMyApps (author-gated) → FORBIDDEN for a non-cohort non-mod', async () => {
     await expect(nonMod().getMyApps()).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 });

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -27,6 +27,7 @@ const {
   mockDbRead,
   mockRedis,
   mockIsAppBlocksEnabled,
+  mockIsAppBlocksAuthorEnabled,
   mockDailyBoostApply,
   mockDailyBoostGetDetails,
   mockGetUserBuzzAccounts,
@@ -71,6 +72,12 @@ const {
     ttl: vi.fn(async () => -1),
   },
   mockIsAppBlocksEnabled: vi.fn(async () => true),
+  // Developer soft-launch (Phase B): the runtime AUTHZ gate now checks the
+  // `appBlocksAuthor` capability against the token subject (was: isModerator).
+  // Default mirrors the mod floor so existing mod-subject happy paths pass.
+  mockIsAppBlocksAuthorEnabled: vi.fn(
+    async (opts?: { user?: { isModerator?: boolean } }) => !!opts?.user?.isModerator
+  ),
   mockDailyBoostApply: vi.fn(async () => undefined),
   mockDailyBoostGetDetails: vi.fn(async () => ({
     awarded: 0,
@@ -158,6 +165,7 @@ vi.mock('~/server/redis/client', () => ({
 }));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
 }));
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: {
@@ -332,6 +340,7 @@ beforeEach(() => {
     mockSysRedis.ttl,
     mockResolveCanGenerateForVersions,
     mockRecordSpendAttribution,
+    mockIsAppBlocksAuthorEnabled,
   ]) {
     fn.mockReset();
   }
@@ -363,9 +372,15 @@ beforeEach(() => {
   // gate they're exercising. NB: mockReset wipes the implementation, so the
   // default has to be re-set every beforeEach (not just at hoisted-init time).
   mockIsAppBlocksEnabled.mockImplementation(async () => true);
-  // Phase 2: default the resolved viewer to a moderator so every happy-path
-  // test passes the new assertViewerIsModerator gate. FORBIDDEN tests override
-  // this to a non-mod (or vanished) user.
+  // Developer soft-launch (Phase B): default the AUTHOR gate to the mod floor —
+  // the default subject is a mod, so every happy-path test passes
+  // assertViewerIsAppDeveloper. FORBIDDEN tests drive a non-author subject.
+  mockIsAppBlocksAuthorEnabled.mockImplementation(
+    async (opts?: { user?: { isModerator?: boolean } }) => !!opts?.user?.isModerator
+  );
+  // Phase 2 → soft-launch: default the resolved viewer to a moderator so every
+  // happy-path test passes the runtime AUTHZ gate. FORBIDDEN tests override this
+  // to a non-author (or vanished) subject.
   mockGetUserById.mockResolvedValue({
     id: 42,
     isModerator: true,
@@ -373,10 +388,10 @@ beforeEach(() => {
     email: 'u@example.com',
     username: 'u',
   });
-  // assertAppBlocksEnabledForTokenUser resolves the full SessionUser for the flag
-  // gate; default to a moderator so the (mocked) flag gate passes. The vanished
-  // -viewer test sets getUserById→null to make the SECOND gate
-  // (assertViewerIsModerator) reject; this default keeps the first gate green.
+  // BOTH runtime gates (assertAppBlocksEnabledForTokenUser for the enabled
+  // kill-switch AND assertViewerIsAppDeveloper for authz) resolve the subject via
+  // sessionClient.getSessionUserById — default to a moderator so both pass. The
+  // FORBIDDEN / vanished-viewer tests override THIS resolver (not getUserById).
   mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: true, tier: 'free' });
   mockParseSubjectUserId.mockImplementation((sub: string) => (sub === 'anon' ? null : 42));
   mockGetOrchestratorToken.mockResolvedValue('orch_token');
@@ -1994,25 +2009,33 @@ describe('blocks.submitWorkflow — LoRA install precedence', () => {
 });
 
 /**
- * Phase 2 — App Blocks is moderator-only until GA. Every block-token-authed
- * runtime procedure re-asserts that the RESOLVED viewer (from the token
- * subject, NOT ctx.user) is a moderator. A token whose subject resolves to a
- * non-mod verified user must be rejected with FORBIDDEN even though the token
- * itself is otherwise valid (valid signature, correct scopes, matching ctx).
+ * Developer soft-launch (Phase B) — the block-token-authed runtime procedures
+ * re-assert the AUTHOR capability against the RESOLVED viewer (from the token
+ * subject, NOT ctx.user). A token whose subject resolves to a NON-author
+ * (non-mod, not in the `app-blocks-author` cohort) must be rejected with
+ * FORBIDDEN even though the token is otherwise valid (valid signature, correct
+ * scopes, matching ctx).
  *
- * This is the defense-in-depth layer beneath the mod-gated token minting
- * endpoint: even if a token were somehow minted for a non-mod, the runtime
- * refuses it.
+ * This is the defense-in-depth layer beneath the gated token-minting endpoint:
+ * even if a token were somehow minted for a non-author, the runtime refuses it.
+ *
+ * NB: the AUTHZ gate resolves the subject via sessionClient.getSessionUserById
+ * (mockGetSessionUser) and evaluates isAppBlocksAuthorEnabled against it — a
+ * non-mod with no cohort grant → the default mock returns false → FORBIDDEN.
  */
-describe('Phase 2 — block-token runtime procedures reject non-mod viewers', () => {
+describe('soft-launch — block-token runtime procedures reject non-author viewers', () => {
   function nonModViewer() {
-    mockGetUserById.mockResolvedValue({
+    const nonMod = {
       id: 42,
       isModerator: false,
       tier: 'free',
       email: 'u@example.com',
       username: 'u',
-    });
+    };
+    // Both runtime gates resolve the subject via getSessionUserById; a non-author
+    // subject (default author mock = mod-floor only) fails assertViewerIsAppDeveloper.
+    mockGetUserById.mockResolvedValue(nonMod);
+    mockGetSessionUser.mockResolvedValue(nonMod);
   }
 
   it('pollWorkflow → FORBIDDEN for a non-mod resolved viewer', async () => {
@@ -2059,13 +2082,34 @@ describe('Phase 2 — block-token runtime procedures reject non-mod viewers', ()
     expect(mockSubmitWorkflow).not.toHaveBeenCalled();
   });
 
-  it('FORBIDDEN when the resolved viewer has vanished (getUserById → null)', async () => {
+  it('FORBIDDEN when the resolved viewer has vanished (getSessionUserById → null)', async () => {
     mockVerifyBlockToken.mockResolvedValue(validClaims());
+    // The enabled kill-switch is mocked ON (default), so the FORBIDDEN comes from
+    // the authz gate: a vanished subject → undefined user → no mod floor + the
+    // author mock's `!!undefined?.isModerator` → false → FORBIDDEN.
     mockGetUserById.mockResolvedValue(null);
+    mockGetSessionUser.mockResolvedValue(null);
     const caller = blocksRouter.createCaller(fakeCtx() as never);
     await expect(
       caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('author-capable NON-MOD subject passes the authz gate (cohort widening)', async () => {
+    // A curated non-mod author: the enabled kill-switch is ON and the
+    // `appBlocksAuthor` capability resolves true for this subject → the runtime
+    // proc gets PAST the authz gate (reaches the orchestrator read).
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    const cohortAuthor = { id: 42, isModerator: false, tier: 'free', username: 'u' };
+    mockGetSessionUser.mockResolvedValue(cohortAuthor);
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(true);
+    mockGetWorkflow.mockResolvedValue({ id: 'wf_1', status: 'succeeded', cost: { total: 0 }, steps: [] });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const ok = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+    expect(ok.snapshot.workflowId).toBe('wf_1');
+    expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({
+      user: expect.objectContaining({ id: 42, isModerator: false }),
+    });
   });
 });
 

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -15,7 +15,9 @@ import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
 import { dbRead } from '~/server/db/client';
 import { parseSubjectUserId, verifyBlockToken } from '~/server/middleware/block-scope.middleware';
-import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { sessionClient } from '~/server/auth/session-client';
+import type { SessionUser } from '~/types/session';
 import { AppStorageProvisioner } from '~/server/services/apps/storage-provision.service';
 import {
   appStorageLatencyHistogram,
@@ -25,22 +27,24 @@ import {
 import { logToAxiom } from '~/server/logging/client';
 import { requireAppsDb } from '~/server/db/appsDb';
 import { appSchemaIdent, sanitizeAppSlug } from '~/server/utils/apps-slug';
-import { getUserById } from '~/server/services/user.service';
 import { middleware, publicProcedure, router } from '~/server/trpc';
 
 /**
- * Phase 2 (internal-only graduation gate): App Blocks is moderator-only until
- * GA. Storage procedures are `publicProcedure` + block-token authed — the
- * viewer is resolved from the JWT subject, not `ctx.user`. Re-assert the
- * resolved viewer is a moderator here (block-token minting is also mod-gated,
- * but defense-in-depth re-checks per call). Throws FORBIDDEN otherwise.
+ * App Blocks authoring gate: storage procedures are `publicProcedure` +
+ * block-token authed — the viewer is resolved from the JWT subject, not
+ * `ctx.user`. Re-assert the resolved viewer is an app AUTHOR here (mod OR the
+ * app-dev-testers cohort, via the appBlocksAuthor capability) — defense-in-depth
+ * per call (mint is also author-gated). Mirrors blocks.router's
+ * assertViewerIsAppDeveloper so a KV-using block works for the whole author
+ * loop. Fail-closed: an unhydratable subject → undefined → mod-floor misses +
+ * Flipt eval can't match → FORBIDDEN. Throws FORBIDDEN otherwise.
  */
-async function assertViewerIsModerator(userId: number): Promise<void> {
-  const row = await getUserById({ id: userId, select: { id: true, isModerator: true } });
-  if (!row?.isModerator) {
+async function assertViewerIsAppDeveloper(userId: number): Promise<void> {
+  const user = (await sessionClient.getSessionUserById(userId)) as SessionUser | null;
+  if (!(await isAppBlocksAuthorEnabled({ user: user ?? undefined }))) {
     throw new TRPCError({
       code: 'FORBIDDEN',
-      message: 'App Blocks is restricted to the civitai team',
+      message: 'App Blocks authoring is not enabled for this account',
     });
   }
 }
@@ -143,7 +147,7 @@ async function resolveStorageContext(blockToken: string, op: StorageOp): Promise
   // anon-handling (clean-null for reads, UNAUTHORIZED for writes) — block-token
   // minting is itself mod-gated so an anon mod token can't be minted anyway.
   if (userId != null) {
-    await assertViewerIsModerator(userId);
+    await assertViewerIsAppDeveloper(userId);
   }
   return {
     userId,

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -56,7 +56,7 @@ import {
   domainBrowsingCeiling,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
-import { isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { rateLimit } from '~/server/middleware.trpc';
 import { BlockRegistry } from '~/server/services/block-registry.service';
 import {
@@ -105,6 +105,7 @@ import {
 import { getUserById } from '~/server/services/user.service';
 import { sessionClient } from '~/server/auth/session-client';
 import {
+  appDeveloperProcedure,
   guardedProcedure,
   moderatorProcedure,
   protectedProcedure,
@@ -141,26 +142,37 @@ const enforceAppBlocksFlag = middleware(async ({ ctx, next, type }) => {
 });
 
 /**
- * Phase 2 (internal-only graduation gate): App Blocks is moderator-only until
- * GA. The management procedures use `moderatorProcedure` so the tRPC session
- * user is checked at the procedure layer. But the runtime/read procedures are
- * `publicProcedure` — they authenticate a block JWT that resolves to a viewer
- * userId rather than `ctx.user`. For those, we re-assert that the RESOLVED
- * viewer is a moderator (don't trust "only mods get block tokens" — block-token
- * minting is also gated, but defense-in-depth means each call re-checks).
+ * AUTHZ gate for the BLOCK-TOKEN-authed runtime procs (estimate/submit/poll/
+ * cancelWorkflow, updateUserSettings). These are `publicProcedure` authenticated
+ * by a block JWT that resolves to a viewer userId rather than `ctx.user`, so the
+ * `appDeveloperProcedure` middleware can't gate them — we re-assert the AUTHOR
+ * capability against the RESOLVED subject here (defense-in-depth: don't trust
+ * "only authors get block tokens" — the mint is gated too, but each call
+ * re-checks).
  *
- * Factored into one helper so the check can't drift across the ~14 call sites.
- * Throws FORBIDDEN for a non-mod (or vanished) user.
+ * Developer soft-launch (Phase B): this replaced the old
+ * `assertViewerIsModerator` — the subject must hold the `appBlocksAuthor`
+ * capability (Flipt `app-blocks-author`, static fallback mod-only), so a curated
+ * non-mod cohort can generate + spend Buzz from their OWN block while a random
+ * non-author subject is still FORBIDDEN.
  *
- * (Internal-only graduation gate — remove/relax at GA alongside the feature
- * flag's `availability` widening.)
+ * Hydrates the subject IDENTICALLY to `assertAppBlocksEnabledForTokenUser` (the
+ * enabled kill-switch that runs right before this) — `sessionClient
+ * .getSessionUserById`, the authoritative hub-backed resolver, never a
+ * client-supplied value — so `buildFliptContext` sees the subject's real
+ * isModerator/tier and the mod floor / segment match can't be spoofed. A
+ * vanished user → undefined → no mod floor + global eval (never matches a
+ * segment) → FORBIDDEN (fail-closed).
+ *
+ * This is the AUTHZ half only; the `isAppBlocksEnabled` kill-switch
+ * (`assertAppBlocksEnabledForTokenUser`) still runs first and is unchanged.
  */
-async function assertViewerIsModerator(userId: number): Promise<void> {
-  const row = await getUserById({ id: userId, select: { id: true, isModerator: true } });
-  if (!row?.isModerator) {
+async function assertViewerIsAppDeveloper(userId: number): Promise<void> {
+  const user = (await sessionClient.getSessionUserById(userId)) as SessionUser | null;
+  if (!(await isAppBlocksAuthorEnabled({ user: user ?? undefined }))) {
     throw new TRPCError({
       code: 'FORBIDDEN',
-      message: 'App Blocks is restricted to the civitai team',
+      message: 'App Blocks authoring is not enabled for this account',
     });
   }
 }
@@ -185,7 +197,7 @@ async function assertViewerIsModerator(userId: number): Promise<void> {
  * mod-segmented flag resolves `true` only for a moderator subject; a non-mod or
  * anon (`sub:'anon'` → no resolvable user) subject still resolves `false` →
  * blocked. `verifyBlockToken` (caller) already rejected invalid/expired/revoked
- * tokens before this runs, and `assertViewerIsModerator` + every other belt
+ * tokens before this runs, and `assertViewerIsAppDeveloper` + every other belt
  * (budget cap, daily Buzz cap, reserveBlockBuzzSpend, getOrchestratorToken,
  * forced-SFW) are unchanged — this only swaps which identity the FLAG sees.
  *
@@ -212,7 +224,7 @@ async function assertAppBlocksEnabledForTokenUser(userId: number): Promise<void>
   // Full, authoritative SessionUser (cached; tier derived from active
   // subscriptions) so buildFliptContext sees the user's REAL tier/isMember,
   // not type-defaults. A vanished user → undefined → global eval → flag false
-  // → blocked (fail-closed; the subsequent assertViewerIsModerator would also
+  // → blocked (fail-closed; the subsequent assertViewerIsAppDeveloper would also
   // reject).
   // getSessionUserById returns the package SessionUser (loosely typed at this boundary — cast as bearer-token.ts
   // does) or null for a vanished user. null → undefined → isAppBlocksEnabled's global eval → flag false → blocked.
@@ -295,9 +307,9 @@ function resolveBlockMaturity(claims: { maxBrowsingLevel?: number }): {
 //
 // Pass the REAL viewer context (their id + real isModerator + the request's
 // sfwOnly/wildcards flags) — never an elevated context. Today the viewer is
-// always a mod (assertViewerIsModerator), so they see mod-level access, which
-// is correct platform behaviour; when GA opens to non-mods the same gate bounds
-// them properly. Fail-closed: a version missing from the result Map → FORBIDDEN.
+// always an author (assertViewerIsAppDeveloper), so they see the appropriate
+// access; when GA opens further the same gate bounds them properly. Fail-closed:
+// a version missing from the result Map → FORBIDDEN.
 //
 // Page-LoRA (Increment 1): generalized from 1→N versions. The checkpoint AND
 // every picked LoRA are gated in ONE `resolveCanGenerateForVersions` call (it
@@ -894,7 +906,7 @@ export const blocksRouter = router({
    * Idempotent. Allows resubmitting against the same slug without
    * accumulating dead pending rows.
    */
-  withdrawPublishRequest: moderatorProcedure
+  withdrawPublishRequest: appDeveloperProcedure
     .use(enforceAppBlocksFlag)
     .input(withdrawRequestSchema)
     .mutation(async ({ ctx, input }) => {
@@ -923,7 +935,7 @@ export const blocksRouter = router({
    * instead of letting the user hit the same-slug error on submit.
    * Scoped to the caller's own rows by design.
    */
-  getMyPendingForSlug: moderatorProcedure
+  getMyPendingForSlug: appDeveloperProcedure
     .use(enforceAppBlocksFlag)
     .input(getMyPendingForSlugSchema)
     .query(async ({ ctx, input }) => {
@@ -1343,7 +1355,7 @@ export const blocksRouter = router({
    * Returns the rejection reason inline so the dev sees mod feedback
    * without a second round-trip.
    */
-  listMyPublishRequests: moderatorProcedure
+  listMyPublishRequests: appDeveloperProcedure
     .use(enforceAppBlocksFlag)
     .query(async ({ ctx }) => {
       if (!ctx.user) return [];
@@ -2194,7 +2206,7 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsModerator(userId);
+      await assertViewerIsAppDeveloper(userId);
       const token = await getOrchestratorToken(userId, ctx);
       const workflow = await getWorkflow({ token, path: { workflowId: input.workflowId } });
       return { snapshot: snapshotFromWorkflow(workflow) };
@@ -2237,7 +2249,7 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsModerator(userId);
+      await assertViewerIsAppDeveloper(userId);
       const token = await getOrchestratorToken(userId, ctx);
       await cancelWorkflow({ workflowId: input.workflowId, token });
       const workflow = await getWorkflow({ token, path: { workflowId: input.workflowId } });
@@ -2299,7 +2311,7 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsModerator(userId);
+      await assertViewerIsAppDeveloper(userId);
       const ctxSlotId = (claims.ctx as { slotId?: unknown } | undefined)?.slotId;
       if (typeof ctxSlotId !== 'string' || ctxSlotId.length === 0) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'block token lacks slotId context' });
@@ -2450,7 +2462,7 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsModerator(userId);
+      await assertViewerIsAppDeveloper(userId);
       const ctxSlotId = (claims.ctx as { slotId?: unknown } | undefined)?.slotId;
       if (typeof ctxSlotId !== 'string' || ctxSlotId.length === 0) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'block token lacks slotId context' });
@@ -2963,7 +2975,7 @@ export const blocksRouter = router({
       }
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
-      await assertViewerIsModerator(userId);
+      await assertViewerIsAppDeveloper(userId);
       const ctxModelId = Number((claims.ctx as { modelId?: unknown } | undefined)?.modelId ?? NaN);
       if (!Number.isInteger(ctxModelId)) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'block token lacks modelId context' });
@@ -3051,10 +3063,11 @@ export const blocksRouter = router({
    * Publisher revenue summary. Caller must be the app owner — the
    * service filters by `app_owner_user_id` so even if the request
    * carries a different appBlockId, the rows are scoped to the caller.
-   * Auth check is enforced by moderatorProcedure; no need to also assert
-   * ownership of the requested appBlockId (the join filter does it).
+   * Auth is enforced by appDeveloperProcedure (the `appBlocksAuthor`
+   * capability); no need to also assert ownership of the requested appBlockId
+   * (the join filter does it).
    */
-  getMyRevenue: moderatorProcedure
+  getMyRevenue: appDeveloperProcedure
     .use(enforceAppBlocksFlag)
     .input(
       z.object({
@@ -3089,13 +3102,13 @@ export const blocksRouter = router({
    * and engagement for the caller's OWN app(s), derived entirely from
    * existing App Blocks tables (no new instrumentation). Read-only.
    *
-   * Same audience gate as getMyRevenue (moderatorProcedure +
+   * Same audience gate as getMyRevenue (appDeveloperProcedure +
    * enforceAppBlocksFlag — dark behind the appBlocks flag). Ownership is
    * enforced inside the service: it resolves the caller's owned app_block
    * ids via AppBlock.app.userId and returns zeroed/empty analytics for a
    * non-owned id, so an author can never read another author's metrics.
    */
-  getMyAppAnalytics: moderatorProcedure
+  getMyAppAnalytics: appDeveloperProcedure
     .use(enforceAppBlocksFlag)
     .input(
       z.object({
@@ -3127,7 +3140,7 @@ export const blocksRouter = router({
    * the per-app dropdown on /apps/revenue. OauthClient.userId is the
    * single source of truth for app ownership in v1.
    */
-  getMyApps: moderatorProcedure
+  getMyApps: appDeveloperProcedure
     .use(enforceAppBlocksFlag)
     .query(async ({ ctx }) => {
       const user = ctx.user as SessionUser;

--- a/src/server/services/__tests__/app-blocks-flag.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.test.ts
@@ -26,7 +26,7 @@ vi.mock('~/server/flipt/client', () => ({
   isFlipt: mockIsFlipt,
 }));
 
-import { isAppBlocksEnabled } from '../app-blocks-flag';
+import { isAppBlocksEnabled, isAppBlocksAuthorEnabled } from '../app-blocks-flag';
 
 // Faithful stand-in for the live `app-blocks-enabled` rule: base OFF, with a
 // `moderators` segment keyed on `context.isModerator === 'true'`. The no-arg
@@ -139,5 +139,92 @@ describe('isAppBlocksEnabled — no accidental repoint to the pipeline flag (Dec
     expect(mockIsFlipt).toHaveBeenCalledWith('app-blocks-enabled');
     expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-pipeline-enabled');
     expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-runtime-enabled');
+  });
+});
+
+/**
+ * Developer soft-launch (Phase B) — the AUTHOR capability helper.
+ *
+ * `isAppBlocksAuthorEnabled` reads the dedicated `app-blocks-author` Flipt flag
+ * (created AFTER merge as base OFF + `moderators` segment + a curated author
+ * cohort segment), WITH a static moderator floor so mods never lose their
+ * existing author access while the flag is absent / Flipt is down.
+ */
+// Faithful stand-in for the `app-blocks-author` flag once created: base OFF,
+// with a `moderators` segment (isModerator === 'true') AND an author-cohort
+// segment (a userId allowlist — here { '777' }).
+const AUTHOR_COHORT = new Set(['777']);
+function fakeAppBlocksAuthorFlag(
+  flag: string,
+  _entityId = 'global',
+  context: Record<string, string> = {}
+): boolean {
+  if (flag !== 'app-blocks-author') return false;
+  if (context.isModerator === 'true') return true;
+  return typeof context.userId === 'string' && AUTHOR_COHORT.has(context.userId);
+}
+
+describe('isAppBlocksAuthorEnabled — author capability (developer soft-launch)', () => {
+  beforeEach(() => {
+    mockIsFlipt.mockReset();
+    mockIsFlipt.mockImplementation(async (...args: Parameters<typeof fakeAppBlocksAuthorFlag>) =>
+      fakeAppBlocksAuthorFlag(...args)
+    );
+  });
+
+  it('resolves ON for a moderator via the static floor WITHOUT calling Flipt', async () => {
+    const user = makeUser({ isModerator: true });
+    await expect(isAppBlocksAuthorEnabled({ user })).resolves.toBe(true);
+    // Mod floor short-circuits: the flag is never evaluated (so an absent /
+    // mis-segmented flag can't regress mods).
+    expect(mockIsFlipt).not.toHaveBeenCalled();
+  });
+
+  it('resolves ON for a flag-granted cohort user (non-mod)', async () => {
+    const user = makeUser({ id: 777, isModerator: false });
+    await expect(isAppBlocksAuthorEnabled({ user })).resolves.toBe(true);
+    expect(mockIsFlipt).toHaveBeenCalledWith(
+      'app-blocks-author',
+      '777',
+      expect.objectContaining({ userId: '777', isModerator: 'false' })
+    );
+  });
+
+  it('resolves OFF for a random non-mod not in the cohort (fail-closed authz)', async () => {
+    const user = makeUser({ id: 555, isModerator: false });
+    await expect(isAppBlocksAuthorEnabled({ user })).resolves.toBe(false);
+  });
+
+  it('resolves OFF for an anonymous / vanished user (no floor, global eval never matches)', async () => {
+    await expect(isAppBlocksAuthorEnabled({ user: undefined })).resolves.toBe(false);
+    await expect(isAppBlocksAuthorEnabled()).resolves.toBe(false);
+    expect(mockIsFlipt).toHaveBeenCalledWith('app-blocks-author');
+  });
+
+  it('Flipt-down / flag absent → mods only (static fallback), non-mods denied', async () => {
+    // isFlipt returns false for everything (flag absent or Flipt unreachable).
+    mockIsFlipt.mockImplementation(async () => false);
+    await expect(
+      isAppBlocksAuthorEnabled({ user: makeUser({ isModerator: true }) })
+    ).resolves.toBe(true); // mod floor
+    await expect(
+      isAppBlocksAuthorEnabled({ user: makeUser({ id: 777, isModerator: false }) })
+    ).resolves.toBe(false); // cohort denied when flag absent
+    await expect(
+      isAppBlocksAuthorEnabled({ user: makeUser({ id: 555, isModerator: false }) })
+    ).resolves.toBe(false);
+  });
+
+  it('reads ONLY the app-blocks-author key (never the enabled/pipeline/runtime keys)', async () => {
+    await isAppBlocksAuthorEnabled({ user: makeUser({ id: 777, isModerator: false }) });
+    for (const call of mockIsFlipt.mock.calls) {
+      expect(call[0]).toBe('app-blocks-author');
+    }
+    expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-enabled');
+    expect(mockIsFlipt).not.toHaveBeenCalledWith(
+      'app-blocks-enabled',
+      expect.anything(),
+      expect.anything()
+    );
   });
 });

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -5,6 +5,25 @@ import { buildFliptContext } from '~/server/services/feature-flags.service';
 const APP_BLOCKS_FLAG = 'app-blocks-enabled';
 
 /**
+ * Dedicated flag for the App Blocks AUTHOR capability (developer soft-launch,
+ * Phase B). Grants the right to SUBMIT apps + use `dev:live` (mint a dev token,
+ * generate/spend from your own block) to a curated cohort — INDEPENDENT of the
+ * mod-only marketplace-visibility flag (`app-blocks-enabled`).
+ *
+ * WHY A SEPARATE FLAG: `app-blocks-enabled` gates marketplace VISIBILITY and
+ * widens to `public` at GA. Authoring must stay independently gated (we do NOT
+ * want every user able to author when the marketplace goes public), so the
+ * author authz decision keys off THIS flag, never `app-blocks-enabled`.
+ *
+ * Mirrors the `appBlocksAuthor` entry in feature-flags.service.ts
+ * (`availability: ['mod']`, `fliptKey: 'app-blocks-author'`). Create it in Flipt
+ * as base `enabled: false` with the `moderators` segment PLUS the author cohort
+ * segment (e.g. `app-dev-testers`), exactly like `app-blocks-enabled`, so mods +
+ * the cohort resolve `true` and everyone else `false`.
+ */
+export const APP_BLOCKS_AUTHOR_FLAG = 'app-blocks-author';
+
+/**
  * Dedicated GLOBAL flag for the build/publish/deploy PIPELINE (Decision 1).
  *
  * The user-facing `app-blocks-enabled` flag is base `enabled: false` with a
@@ -157,6 +176,50 @@ export async function isAppBlocksEnabled(opts?: { user?: SessionUser }): Promise
   // server-side `isModerator` that the `moderators` segment keys on.
   const user = opts.user;
   return isFlipt(APP_BLOCKS_FLAG, String(user.id), buildFliptContext(user));
+}
+
+/**
+ * AUTHZ check for the App Blocks AUTHOR capability (developer soft-launch).
+ *
+ * Governs who may SUBMIT apps + use `dev:live` (mint a dev token, generate +
+ * spend Buzz from their own block). Used by the REST author endpoints
+ * (submit-version, dev-token) and the block-token-authed runtime procs, which
+ * evaluate it against the TOKEN's hydrated subject user (NOT a request session).
+ *
+ * ## Eval shape mirrors `isAppBlocksEnabled`, WITH a moderator floor
+ *
+ * Same per-user Flipt eval as `isAppBlocksEnabled` (entityId = user id, context
+ * from `buildFliptContext`), so the `app-blocks-author` flag's segments match
+ * exactly as the client/`hasFeature` gate sees them.
+ *
+ * The ONE difference: moderators are a STATIC floor (short-circuit `true`). This
+ * is deliberate and load-bearing:
+ *   - The `app-blocks-author` flag does NOT exist in Flipt at merge time (it is
+ *     created AFTER, as the rollout). With a bare `isFlipt` eval, an absent flag
+ *     resolves `false` for EVERYONE — mods included — which would REGRESS mods'
+ *     existing author access the instant this merges. `isAppBlocksEnabled` has
+ *     no such problem only because its flag already exists in prod.
+ *   - The mod floor makes this helper consistent with the `appBlocksAuthor`
+ *     entry's `availability: ['mod']`, which is what `hasFeature` falls back to
+ *     when Flipt returns null (flag absent / Flipt down). So SSR/`ctx.features`
+ *     gates and this helper agree in the fail-closed direction: mods only.
+ *
+ * Fail-CLOSED: a non-mod with no `app-blocks-author` grant (flag absent, Flipt
+ * down, or segment miss) → `isFlipt` false → denied. Only mods (floor) and the
+ * flag-granted cohort pass. A vanished/undefined user → no floor + global eval
+ * (can never match a segment) → denied.
+ */
+export async function isAppBlocksAuthorEnabled(opts?: { user?: SessionUser }): Promise<boolean> {
+  const user = opts?.user;
+  // Moderator floor — the `availability: ['mod']` static fallback. Keeps mods'
+  // existing author access intact while the Flipt flag is absent (dark window)
+  // and regardless of how the flag's segments are later configured.
+  if (user?.isModerator) return true;
+  // No user → preserve a global eval that can never match a segment (fail-closed).
+  if (!user) return isFlipt(APP_BLOCKS_AUTHOR_FLAG);
+  // Per-user eval — same entityId + context shape as isAppBlocksEnabled, so the
+  // author cohort segment resolves identically to the client/hasFeature gate.
+  return isFlipt(APP_BLOCKS_AUTHOR_FLAG, String(user.id), buildFliptContext(user));
 }
 
 /**

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -253,6 +253,16 @@ const featureFlags = createFeatureFlags({
   // land. The Flipt key stays the kill-switch / future-widen lever (flip it off
   // to drop the page + nav entry without a deploy).
   appBlocksGetStarted: { availability: ['mod'], fliptKey: 'app-blocks-get-started' },
+  // App Blocks — AUTHOR capability (developer soft-launch, Phase B). Grants the
+  // right to SUBMIT apps + use `dev:live` (the author surfaces + the runtime
+  // spend gate on a block-token subject). INDEPENDENT of the mod-only
+  // marketplace-visibility `appBlocks` flag ON PURPOSE: `appBlocks` widens to
+  // `public` at GA, but authoring must stay gated, so the author authz decision
+  // keys off THIS flag, never `appBlocks`. Mirrors `appBlocks` shape — staged
+  // mod-only today (`['mod']` = the Flipt-down / flag-absent fallback), widened
+  // to mods + a curated cohort via the Flipt `app-blocks-author` flag (created
+  // AFTER this merges: absent → static mod-only, identical to today).
+  appBlocksAuthor: { availability: ['mod'], fliptKey: 'app-blocks-author' },
 });
 
 export const featureFlagKeys = Object.keys(featureFlags) as FeatureFlagKey[];

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -392,6 +392,28 @@ export const protectedProcedure = publicProcedure.use(isAuthed);
 export const moderatorProcedure = protectedProcedure.use(isMod);
 
 /**
+ * App developer procedure — authenticated + the `appBlocksAuthor` capability
+ * (Flipt `app-blocks-author`, static fallback mod-only). Gates the App Blocks
+ * AUTHOR surfaces (own submissions / revenue / analytics, withdraw, dev:live)
+ * for a curated non-mod cohort WITHOUT granting the mod REVIEW/curation powers
+ * (those stay on `moderatorProcedure`).
+ *
+ * Fail-CLOSED: `getFeatureFlags` resolves `appBlocksAuthor` from Flipt when the
+ * flag exists, else falls back to the static `availability: ['mod']` — so an
+ * absent flag / Flipt-down yields mods only, never open-to-all.
+ */
+const hasAppBlocksAuthor = t.middleware(({ ctx, next }) => {
+  const features = getFeatureFlags(ctx);
+  if (!features.appBlocksAuthor)
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'You do not have access to App Blocks authoring',
+    });
+  return next();
+});
+export const appDeveloperProcedure = protectedProcedure.use(hasAppBlocksAuthor);
+
+/**
  * Verified procedure to prevent users from making actions
  * if they haven't completed the onboarding process
  */

--- a/src/shared/utils/__tests__/app-blocks-access.test.ts
+++ b/src/shared/utils/__tests__/app-blocks-access.test.ts
@@ -25,6 +25,25 @@ describe('isAppDeveloper', () => {
   it('returns false for undefined user', () => {
     expect(isAppDeveloper(undefined)).toBe(false);
   });
+
+  // Developer soft-launch (Phase B): the optional `appBlocksAuthor` capability
+  // widens the predicate to a curated non-mod cohort without touching mods.
+  it('returns true for a non-mod when the appBlocksAuthor capability is granted', () => {
+    expect(isAppDeveloper({ isModerator: false }, { appBlocksAuthor: true })).toBe(true);
+  });
+
+  it('stays false for a non-mod when the capability is not granted', () => {
+    expect(isAppDeveloper({ isModerator: false }, { appBlocksAuthor: false })).toBe(false);
+    expect(isAppDeveloper({ isModerator: false }, {})).toBe(false);
+  });
+
+  it('keeps moderators in as a floor even when the capability flag is false', () => {
+    expect(isAppDeveloper({ isModerator: true }, { appBlocksAuthor: false })).toBe(true);
+  });
+
+  it('preserves the mod-only meaning when called with no opts (no silent widening)', () => {
+    expect(isAppDeveloper({ isModerator: false })).toBe(false);
+  });
 });
 
 describe('isAppReviewer', () => {

--- a/src/shared/utils/app-blocks-access.ts
+++ b/src/shared/utils/app-blocks-access.ts
@@ -36,8 +36,18 @@
  * Pure (no server/client-only imports) so it's usable from both the
  * `getServerSideProps` resolvers and the client-side nav hook.
  */
-export function isAppDeveloper(user: { isModerator?: boolean | null } | null | undefined): boolean {
-  return !!user?.isModerator;
+export function isAppDeveloper(
+  user: { isModerator?: boolean | null } | null | undefined,
+  // Developer soft-launch (Phase B): the `appBlocksAuthor` capability (Flipt
+  // `app-blocks-author`, static fallback mod-only) widens the developer surfaces
+  // to a curated non-mod cohort. Callers thread the resolved flag from
+  // `features.appBlocksAuthor` (SSR resolver) / `useFeatureFlags()` (client).
+  // OPTIONAL + defaulting undefined so pre-existing callers keep the mod-only
+  // meaning unchanged (no silent widening); moderators stay a hard floor via the
+  // `isModerator ||` so they never lose access regardless of Flipt config.
+  opts?: { appBlocksAuthor?: boolean }
+): boolean {
+  return !!user?.isModerator || !!opts?.appBlocksAuthor;
 }
 
 /**

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -59,6 +59,7 @@ function createMocks({
 const {
   mockGetSession,
   mockIsAppBlocksEnabled,
+  mockIsAppBlocksAuthorEnabled,
   mockSign,
   mockAppBlockFindUnique,
   mockPublishRequestFindFirst,
@@ -83,6 +84,7 @@ const {
   return {
     mockGetSession: vi.fn(),
     mockIsAppBlocksEnabled: vi.fn(),
+    mockIsAppBlocksAuthorEnabled: vi.fn(),
     mockSign: vi.fn(),
     mockAppBlockFindUnique: vi.fn(),
     mockPublishRequestFindFirst: vi.fn(),
@@ -97,7 +99,10 @@ const {
 
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (fn: unknown) => fn }));
 vi.mock('~/server/auth/bearer-token', () => ({ getSessionFromBearerToken: mockGetSession }));
-vi.mock('~/server/services/app-blocks-flag', () => ({ isAppBlocksEnabled: mockIsAppBlocksEnabled }));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
 vi.mock('~/server/services/block-token.service', () => ({
   BlockTokenService: { sign: mockSign },
 }));
@@ -211,6 +216,9 @@ beforeEach(() => {
   mockSysRedis.ttl.mockResolvedValue(60);
   mockSysRedis.expire.mockResolvedValue(1);
   mockIsAppBlocksEnabled.mockResolvedValue(true);
+  mockIsAppBlocksAuthorEnabled.mockImplementation(
+    async (opts) => !!opts?.user?.isModerator
+  );
   mockAppBlockFindUnique.mockResolvedValue(pageApp());
   // Default: no pending request. The local-manifest path tests set this per-case.
   mockPublishRequestFindFirst.mockResolvedValue(null);
@@ -299,12 +307,25 @@ describe('POST /api/v1/blocks/dev-token', () => {
     expect(out.buzzBudget).toBeUndefined();
   });
 
-  it('403 when the resolved user is NOT a moderator', async () => {
+  it('403 when the resolved user is NOT an app author (non-mod, no cohort grant)', async () => {
     mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
     const { req, res } = authPost({ appBlockId: 'apb_abc' });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(403);
     expect(mockSign).not.toHaveBeenCalled();
+    // Denied on the authz line — never reached the enabled-flag check.
+    expect(mockIsAppBlocksEnabled).not.toHaveBeenCalled();
+  });
+
+  it('author-capable NON-MOD (cohort widening): passes the authz line into the flag check', async () => {
+    mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
+    mockIsAppBlocksAuthorEnabled.mockResolvedValueOnce(true);
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    // Got PAST the authz gate — not a 403 on the author line, and the enabled
+    // kill-switch flag was consulted next.
+    expect(res._getStatusCode()).not.toBe(403);
+    expect(mockIsAppBlocksEnabled).toHaveBeenCalled();
   });
 
   it('403 when the mod is banned', async () => {

--- a/src/tests/api/v1/blocks/submissions.test.ts
+++ b/src/tests/api/v1/blocks/submissions.test.ts
@@ -61,6 +61,7 @@ function createMocks({
 const {
   mockGetSession,
   mockIsAppBlocksEnabled,
+  mockIsAppBlocksAuthorEnabled,
   mockFindMany,
   mockFindFirst,
   mockSysRedis,
@@ -84,6 +85,7 @@ const {
   return {
     mockGetSession: vi.fn(),
     mockIsAppBlocksEnabled: vi.fn(),
+    mockIsAppBlocksAuthorEnabled: vi.fn(),
     mockFindMany: vi.fn(),
     mockFindFirst: vi.fn(),
     mockSysRedis: {
@@ -97,7 +99,10 @@ const {
 
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (fn: unknown) => fn }));
 vi.mock('~/server/auth/bearer-token', () => ({ getSessionFromBearerToken: mockGetSession }));
-vi.mock('~/server/services/app-blocks-flag', () => ({ isAppBlocksEnabled: mockIsAppBlocksEnabled }));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
 vi.mock('~/server/db/client', () => ({
   dbRead: { appBlockPublishRequest: { findMany: mockFindMany, findFirst: mockFindFirst } },
 }));
@@ -168,6 +173,9 @@ beforeEach(() => {
   mockSysRedis.ttl.mockResolvedValue(60);
   mockSysRedis.expire.mockResolvedValue(1);
   mockIsAppBlocksEnabled.mockResolvedValue(true);
+  // Author capability defaults to the mod-floor (mirrors isAppBlocksAuthorEnabled
+  // when the app-blocks-author Flipt flag is absent): mods pass, non-mods don't.
+  mockIsAppBlocksAuthorEnabled.mockImplementation(async (opts?: { user?: { isModerator?: boolean } }) => !!opts?.user?.isModerator);
   mockFindMany.mockResolvedValue([dbRow()]);
   mockFindFirst.mockResolvedValue(dbRow());
 });
@@ -219,12 +227,21 @@ describe('GET /api/v1/blocks/submissions', () => {
     );
   });
 
-  it('403 when the resolved user is NOT a moderator', async () => {
+  it('403 when the resolved user is NOT a moderator (and not a cohort author)', async () => {
     mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
     const { req, res } = authGet();
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(403);
     expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('accepts an author-capable NON-MOD (cohort widening): passes the authz line to the query', async () => {
+    mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
+    mockIsAppBlocksAuthorEnabled.mockResolvedValueOnce(true);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).not.toBe(403);
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
   });
 
   it('403 when the mod is banned', async () => {

--- a/src/tests/api/v1/blocks/submit-version.test.ts
+++ b/src/tests/api/v1/blocks/submit-version.test.ts
@@ -45,6 +45,7 @@ function createMocks({
 const {
   mockGetSession,
   mockIsAppBlocksEnabled,
+  mockIsAppBlocksAuthorEnabled,
   mockSubmitVersion,
   mockRedis,
   mockMultiIncr,
@@ -64,6 +65,7 @@ const {
   return {
     mockGetSession: vi.fn(),
     mockIsAppBlocksEnabled: vi.fn(),
+    mockIsAppBlocksAuthorEnabled: vi.fn(),
     mockSubmitVersion: vi.fn(),
     mockRedis: { multi: vi.fn(multiFactory), ttl: vi.fn().mockResolvedValue(60) },
     mockMultiIncr,
@@ -76,6 +78,7 @@ vi.mock('~/server/auth/bearer-token', () => ({
 }));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
 }));
 vi.mock('~/server/redis/client', () => ({
   sysRedis: mockRedis,
@@ -144,6 +147,10 @@ beforeEach(() => {
   mockMultiIncr.malformedExec = false;
   mockRedis.ttl.mockResolvedValue(60);
   mockIsAppBlocksEnabled.mockResolvedValue(true);
+  // Author gate mirrors the mod floor by default; the widening test overrides it.
+  mockIsAppBlocksAuthorEnabled.mockImplementation(
+    async (opts) => !!opts?.user?.isModerator
+  );
   mockSubmitVersion.mockResolvedValue({
     publishRequestId: 'pubreq_abc',
     slug: 'my-block',
@@ -179,7 +186,9 @@ describe('POST /api/v1/blocks/submit-version (token auth)', () => {
     expect(mockSubmitVersion).not.toHaveBeenCalled();
   });
 
-  it('403 when the resolved user is NOT a moderator', async () => {
+  it('403 when the resolved user is NOT an app author (non-mod, no cohort grant)', async () => {
+    // Default author mock = mod floor only → a random non-mod is denied on the
+    // authz line (developer soft-launch: authoring stays gated).
     mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
     const { req, res } = createMocks({
       headers: { authorization: 'Bearer key' },
@@ -188,6 +197,21 @@ describe('POST /api/v1/blocks/submit-version (token auth)', () => {
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(403);
     expect(mockSubmitVersion).not.toHaveBeenCalled();
+  });
+
+  it('accepts an author-capable NON-MOD (cohort widening): passes the authz line', async () => {
+    // A curated non-mod author granted the `app-blocks-author` capability is NOT
+    // rejected on the authz line — the submit proceeds through the flag +
+    // rate-limit gates to the real service.
+    mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
+    mockIsAppBlocksAuthorEnabled.mockResolvedValueOnce(true);
+    const { req, res } = createMocks({
+      headers: { authorization: 'Bearer key' },
+      body: goodBody,
+    });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSubmitVersion).toHaveBeenCalledTimes(1);
   });
 
   it('403 when the resolved user is banned even if isModerator', async () => {

--- a/src/tests/api/v1/blocks/withdraw.test.ts
+++ b/src/tests/api/v1/blocks/withdraw.test.ts
@@ -64,6 +64,7 @@ function createMocks({
 const {
   mockGetSession,
   mockIsAppBlocksEnabled,
+  mockIsAppBlocksAuthorEnabled,
   mockWithdrawRequest,
   mockSysRedis,
   mockMultiIncr,
@@ -99,6 +100,7 @@ const {
   return {
     mockGetSession: vi.fn(),
     mockIsAppBlocksEnabled: vi.fn(),
+    mockIsAppBlocksAuthorEnabled: vi.fn(),
     mockWithdrawRequest: vi.fn(),
     mockSysRedis: {
       multi: vi.fn(multiFactory),
@@ -112,7 +114,10 @@ const {
 
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (fn: unknown) => fn }));
 vi.mock('~/server/auth/bearer-token', () => ({ getSessionFromBearerToken: mockGetSession }));
-vi.mock('~/server/services/app-blocks-flag', () => ({ isAppBlocksEnabled: mockIsAppBlocksEnabled }));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
 vi.mock('~/server/services/blocks/publish-request.service', () => ({
   withdrawRequest: mockWithdrawRequest,
   WithdrawRequestError,
@@ -165,6 +170,9 @@ beforeEach(() => {
   mockSysRedis.ttl.mockResolvedValue(60);
   mockSysRedis.expire.mockResolvedValue(1);
   mockIsAppBlocksEnabled.mockResolvedValue(true);
+  // Author capability defaults to the mod-floor (mirrors isAppBlocksAuthorEnabled
+  // when the app-blocks-author Flipt flag is absent): mods pass, non-mods don't.
+  mockIsAppBlocksAuthorEnabled.mockImplementation(async (opts?: { user?: { isModerator?: boolean } }) => !!opts?.user?.isModerator);
   mockWithdrawRequest.mockResolvedValue(undefined);
 });
 
@@ -217,12 +225,21 @@ describe('POST /api/v1/blocks/withdraw', () => {
     });
   });
 
-  it('403 when the resolved user is NOT a moderator', async () => {
+  it('403 when the resolved user is NOT a moderator (and not a cohort author)', async () => {
     mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
     const { req, res } = authPost();
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(403);
     expect(mockWithdrawRequest).not.toHaveBeenCalled();
+  });
+
+  it('accepts an author-capable NON-MOD (cohort widening): passes the authz line to the service', async () => {
+    mockGetSession.mockResolvedValueOnce(NONMOD_SESSION);
+    mockIsAppBlocksAuthorEnabled.mockResolvedValueOnce(true);
+    const { req, res } = authPost();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).not.toBe(403);
+    expect(mockWithdrawRequest).toHaveBeenCalledTimes(1);
   });
 
   it('403 when the mod is banned', async () => {


### PR DESCRIPTION
Phase B of the App Blocks developer soft-launch: a dedicated **`appBlocksAuthor`** capability so a curated **non-mod** cohort (granted via the Flipt segment `app-dev-testers`) can author / submit / dev:live App Blocks — **without** being moderators. Deliberately kept separate from `appBlocks` (marketplace visibility) so that at GA, widening `appBlocks`→public does NOT silently make everyone an author.

**Dark until the `app-blocks-author` Flipt flag is created** — the flag is absent today, so the mod-floor makes every gate mod-only, identical to current behavior. Safe to merge dark.

### New primitives
- Feature flag `appBlocksAuthor: { availability: ['mod'], fliptKey: 'app-blocks-author' }`
- `isAppBlocksAuthorEnabled({ user })` (mod-floor + per-user Flipt eval; fail-closed to mod-only)
- tRPC `appDeveloperProcedure` + runtime `assertViewerIsAppDeveloper(subjectUserId)`

### Gates changed (widened → author) vs left mod-only
| Widened to author capability | Left mod-only (unchanged) |
|---|---|
| REST: `submit-version`, `dev-token`, `withdraw`, `submissions` | `approveRequest`, `rejectRequest`, `list{Pending,Approved,Rejected}Requests` |
| tRPC: `getMyApps`, `getMyRevenue`, `getMyAppAnalytics`, `listMyPublishRequests`, `withdrawPublishRequest`, `getMyPendingForSlug` | `getPublishRequest{Diff,Screenshots}`, `set/getMarketplaceMeta`, `setReviewExcluded` |
| Runtime: `submitWorkflow`/`estimateWorkflow`/`pollWorkflow`/`cancelWorkflow`/`updateUserSettings` (subject-gated) | `registerExternalApp`, all `backfill*`, all review-sandbox procs |
| Runtime: `apps.storage.*` (W4 KV) | `isAppReviewer` (still = isModerator) |
| SSR: submit / my-submissions / revenue / [appBlockId]/revenue |  |

**Safety:** approve stays mod-only (the safety valve — testers *submit*, a mod still approves→deploys). Money caps unchanged (self-bound token, per-mint + per-user-daily Buzz caps, AIServicesWrite ceiling, forced-SFW); payout untouched (track-only, `spendSharePct=0`).

### Adversarial audit — no 🔴
Every widened gate verified **fail-closed** (flag absent / Flipt-down → mod-only); the runtime subject is the **signed token `sub`** (not client-controlled); spend is gated before money moves; all mod-review/approve/curation/sandbox gates provably unchanged. Findings addressed: the App Storage straggler (🟡) is widened here; branch rebased onto current main (🟡). Left: 🟢 cosmetic stale `assertViewerIsModerator` doc-comment references in `dev-token.ts`/`block-tokens/index.ts`.

### ⚠️ Rollout requirement (dual flag)
A cohort member needs to be in **BOTH** Flipt segments: `app-blocks-author` (authz) **and** `app-blocks-enabled` (the kill-switch the REST/runtime paths still enforce). The `app-blocks-author` flag's `moderators` rollout is mandatory (Flipt overrides the code fallback). Handled in the Flipt setup after this deploys.

### Tests
349 across the touched suites green (flag helper, access util, appDeveloperProcedure, workflow runtime, storage, submit-version/dev-token/withdraw/submissions) — each asserts: cohort non-mod passes, random non-mod denied, mods pass, Flipt-down → mod-only, and mod-only procs still deny non-mods. The PR-preview typecheck/build is the authoritative TS gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)