### PR TITLE
copy(app-blocks): get-started page — Beta badge, "Build on Civitai" title, drop em-dashes

### DIFF
--- a/src/components/Apps/GetStartedBody.tsx
+++ b/src/components/Apps/GetStartedBody.tsx
@@ -101,12 +101,12 @@ export function GetStartedBody() {
       <Stack gap="xs">
         <Group gap="xs">
           <Badge color="blue" variant="light" radius="sm">
-            For app builders
+            Beta
           </Badge>
         </Group>
-        <Title order={1}>Build apps on Civitai</Title>
+        <Title order={1}>Build on Civitai</Title>
         <Text size="lg" c="dimmed">
-          Build on Civitai&apos;s web + AI infrastructure — tap a catalog of hundreds of thousands of
+          Build on Civitai&apos;s web + AI infrastructure. Tap a catalog of hundreds of thousands of
           models and generate with Buzz. You focus on creating; we handle the rest.
         </Text>
       </Stack>
@@ -139,7 +139,7 @@ export function GetStartedBody() {
               <IconPhoto size={16} />
             </ThemeIcon>
             <Text size="sm">
-              <b>A huge model catalog</b> — search hundreds of thousands of models &amp; images from
+              <b>A huge model catalog</b>: search hundreds of thousands of models &amp; images from
               your app.
             </Text>
           </Group>
@@ -148,7 +148,7 @@ export function GetStartedBody() {
               <IconSparkles size={16} />
             </ThemeIcon>
             <Text size="sm">
-              <b>AI generation, no GPUs</b> — run generations on Civitai&apos;s infrastructure, paid
+              <b>AI generation, no GPUs</b>: run generations on Civitai&apos;s infrastructure, paid
               in Buzz.
             </Text>
           </Group>
@@ -157,7 +157,7 @@ export function GetStartedBody() {
               <IconServer size={16} />
             </ThemeIcon>
             <Text size="sm">
-              <b>Hosting handled</b> — we build and host your app; no Docker, no servers.
+              <b>Hosting handled</b>: we build and host your app; no Docker, no servers.
             </Text>
           </Group>
           <Group gap="xs" align="flex-start" wrap="nowrap">
@@ -165,7 +165,7 @@ export function GetStartedBody() {
               <IconUser size={16} />
             </ThemeIcon>
             <Text size="sm">
-              <b>Built-in identity</b> — your app knows who&apos;s viewing; no auth to wire up.
+              <b>Built-in identity</b>: your app knows who&apos;s viewing; no auth to wire up.
             </Text>
           </Group>
           <Group gap="xs" align="flex-start" wrap="nowrap">
@@ -173,7 +173,7 @@ export function GetStartedBody() {
               <IconDatabase size={16} />
             </ThemeIcon>
             <Text size="sm">
-              <b>Private storage</b> — a per-app key-value store for your data.
+              <b>Private storage</b>: a per-app key-value store for your data.
             </Text>
           </Group>
           <Group gap="xs" align="flex-start" wrap="nowrap">
@@ -181,7 +181,7 @@ export function GetStartedBody() {
               <IconPalette size={16} />
             </ThemeIcon>
             <Text size="sm">
-              <b>Themed UI kit</b> — drop-in components that match Civitai automatically.
+              <b>Themed UI kit</b>: drop-in components that match Civitai automatically.
             </Text>
           </Group>
         </SimpleGrid>

--- a/src/pages/apps/get-started.tsx
+++ b/src/pages/apps/get-started.tsx
@@ -47,7 +47,7 @@ export default function AppsGetStartedPage() {
       {/* deIndexed initially — private-beta funnel, not for organic search yet.
           TODO(launch): drop `deIndex` to make indexable when comms is ready. */}
       <Meta
-        title="Build apps on Civitai"
+        title="Build on Civitai"
         description="Build small web apps that run inside Civitai. Install the Civitai CLI and runtime SDK, scaffold an app, and test it locally."
         deIndex
       />


### PR DESCRIPTION
Small copy pass on the `/apps/get-started` page (`GetStartedBody.tsx` + `get-started.tsx`).

- **Badge:** "For app builders" → **"Beta"**.
- **Title:** H1 + Meta/tab title "Build apps on Civitai" → **"Build on Civitai"**.
- **Em-dashes:** replaced all *rendered* em-dashes — the hero sentence (`— tap` → `. Tap`) and the "What you get" feature list (`<b>Label</b> — desc` → `<b>Label</b>: desc`). No rendered em-dashes remain.

Notes:
- Code-comment em-dashes were left untouched (internal, not page copy) — easy to sweep too if wanted.
- Heads-up: the H1 "Build on Civitai" now slightly echoes the hero subtitle ("Build on Civitai's web + AI infrastructure…") — left the subtitle as-is per scope; happy to reword if you'd prefer.
- Copy-only; the page stays `appBlocksGetStarted`-gated + `deIndex`ed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)