### PR TITLE
fix(auth): route session resolution (cookie + bearer/API-key) to in-cluster hub + add timeouts (SPOF fix)

### DIFF
--- a/packages/civitai-auth/src/__tests__/session-client.test.ts
+++ b/packages/civitai-auth/src/__tests__/session-client.test.ts
@@ -228,6 +228,72 @@ describe('createSessionClient — identity-fetch timeout (fail-open + instrument
   });
 });
 
+// SPOF FIX pt.2 — the API-key/OAuth by-userId read + the hub write paths were the residual hairpin (they go
+// through hubFetch → the public AUTH_JWT_ISSUER with no timeout). hubFetch now prefers AUTH_HUB_INTERNAL_URL
+// and bounds the hop; these are the by-id-read tests. (hubBaseUrl / write-path routing exercised elsewhere.)
+describe('createSessionClient — getSessionUserById internal routing + timeout', () => {
+  it('routes the by-id read to AUTH_HUB_INTERNAL_URL when set', async () => {
+    h.loadAuthEnv.mockReturnValue({
+      AUTH_JWT_ISSUER: 'https://auth.test',
+      AUTH_INTERNAL_TOKEN: 'secret-123',
+      AUTH_HUB_INTERNAL_URL: 'http://civitai-auth.civitai-auth.svc.cluster.local:3000',
+    });
+    const fetch = stubFetch(async () => ({ ok: true, status: 200, json: async () => richUser(7) }));
+    await createSessionClient().getSessionUserById(7);
+    expect(fetch).toHaveBeenCalledWith(
+      'http://civitai-auth.civitai-auth.svc.cluster.local:3000/api/auth/identity?userId=7',
+      { headers: { authorization: 'Bearer secret-123' }, signal: expect.any(AbortSignal) }
+    );
+  });
+
+  it('fails safe (null) and reports "timeout" when the by-id hop aborts', async () => {
+    const onIdentityByIdLeg =
+      vi.fn<(outcome: 'hit' | 'miss' | 'timeout' | 'error', s: number) => void>();
+    // Simulate hubFetch's AbortSignal.timeout firing: fetch rejects with a TimeoutError-named error.
+    stubFetch(async () => {
+      throw Object.assign(new Error('The operation timed out.'), { name: 'TimeoutError' });
+    });
+    const user = await createSessionClient({ onIdentityByIdLeg }).getSessionUserById(7);
+    expect(user).toBeNull(); // unchanged unreachable→null behavior, just bounded
+    expect(onIdentityByIdLeg).toHaveBeenCalledWith('timeout', expect.any(Number));
+  });
+
+  it('reports "miss" on a 404 and "hit" on success', async () => {
+    const onIdentityByIdLeg =
+      vi.fn<(outcome: 'hit' | 'miss' | 'timeout' | 'error', s: number) => void>();
+    stubFetch(async () => ({ ok: false, status: 404, json: async () => null }));
+    await createSessionClient({ onIdentityByIdLeg }).getSessionUserById(7);
+    expect(onIdentityByIdLeg).toHaveBeenLastCalledWith('miss', expect.any(Number));
+    stubFetch(async () => ({ ok: true, status: 200, json: async () => richUser(8) }));
+    await createSessionClient({ onIdentityByIdLeg }).getSessionUserById(8);
+    expect(onIdentityByIdLeg).toHaveBeenLastCalledWith('hit', expect.any(Number));
+  });
+});
+
+// Item 2 — a THROWING metric callback must never corrupt the auth result (safeInvoke). Without the guard, a
+// throw right after a successful fetch would bubble to the surrounding catch → return null → a valid session
+// would appear unauthenticated.
+describe('createSessionClient — instrumentation is best-effort (throwing callback is swallowed)', () => {
+  it('still resolves the user when onIdentityLeg throws on "hit"', async () => {
+    stubFetch(async () => ({ ok: true, status: 200, json: async () => richUser(7, 'fresh') }));
+    const onIdentityLeg = vi.fn(() => {
+      throw new Error('metrics registry exploded');
+    });
+    const user = await createSessionClient({ onIdentityLeg }).getSessionUser('7');
+    expect(user).toMatchObject({ id: 7, username: 'fresh' }); // auth SUCCEEDS despite the throwing callback
+    expect(onIdentityLeg).toHaveBeenCalled();
+  });
+
+  it('still resolves the by-id user when onIdentityByIdLeg throws', async () => {
+    stubFetch(async () => ({ ok: true, status: 200, json: async () => richUser(7, 'byid') }));
+    const onIdentityByIdLeg = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const user = await createSessionClient({ onIdentityByIdLeg }).getSessionUserById(7);
+    expect(user).toMatchObject({ id: 7, username: 'byid' });
+  });
+});
+
 describe('createSessionClient — getSessionUserById (read by userId)', () => {
   it('returns the cached user without fetching', async () => {
     h.store.set(key(7), richUser(7, 'bob'));
@@ -247,6 +313,7 @@ describe('createSessionClient — getSessionUserById (read by userId)', () => {
     });
     expect(fetch).toHaveBeenCalledWith('https://auth.test/api/auth/identity?userId=7', {
       headers: { authorization: 'Bearer secret-123' },
+      signal: expect.any(AbortSignal), // hubFetch now bounds the hop
     });
     expect(h.store.has(key(7))).toBe(false); // consumer does NOT write — the hub producer does
   });
@@ -329,6 +396,7 @@ describe('createSessionClient — invalidate / refresh (write)', () => {
       method: 'POST',
       headers: { authorization: 'Bearer secret-123', 'content-type': 'application/json' },
       body: JSON.stringify({ userId: 7, refresh: false }),
+      signal: expect.any(AbortSignal), // hubFetch now bounds the write hop too
     });
   });
 
@@ -374,6 +442,7 @@ describe('createSessionClient — invalidateAll (mass cutoff)', () => {
       method: 'POST',
       headers: { authorization: 'Bearer secret-123', 'content-type': 'application/json' },
       body: JSON.stringify({ scope: 'all' }),
+      signal: expect.any(AbortSignal), // hubFetch now bounds the write hop too
     });
   });
 

--- a/packages/civitai-auth/src/__tests__/session-client.test.ts
+++ b/packages/civitai-auth/src/__tests__/session-client.test.ts
@@ -75,11 +75,12 @@ describe('createSessionClient — getSessionUser (read)', () => {
     expect(h.store.has(key(7))).toBe(false); // consumer does NOT write — the producer does
   });
 
-  it('fetches the verified token iss + /api/auth/identity with a Bearer', async () => {
+  it('fetches the verified token iss + /api/auth/identity with a Bearer (bounded by an AbortSignal)', async () => {
     const fetch = stubFetch(async () => ({ ok: true, status: 200, json: async () => richUser(7) }));
     await createSessionClient().getSessionUser('7');
     expect(fetch).toHaveBeenCalledWith('https://auth.test/api/auth/identity', {
       headers: { authorization: 'Bearer 7' },
+      signal: expect.any(AbortSignal), // the new identity-fetch timeout — armed on every read
     });
   });
 
@@ -150,6 +151,80 @@ describe('createSessionClient — getSessionUser (read)', () => {
     const fetch = stubFetch(async () => ({ ok: true, status: 200, json: async () => null }));
     expect(await createSessionClient().getSessionUser('7')).toBeNull();
     expect(fetch).not.toHaveBeenCalled();
+  });
+});
+
+// SPOF FIX — the identity read routes IN-CLUSTER via AUTH_HUB_INTERNAL_URL, but the anti-spoof
+// trustedHubBase(iss) guard is UNCHANGED: validate against the public trusted issuer, fetch from the internal
+// address. These tests pin both halves.
+describe('createSessionClient — internal identity routing (AUTH_HUB_INTERNAL_URL)', () => {
+  it('routes the identity fetch to AUTH_HUB_INTERNAL_URL when set + iss is trusted', async () => {
+    h.loadAuthEnv.mockReturnValue({
+      AUTH_JWT_ISSUER: 'https://auth.test',
+      AUTH_INTERNAL_TOKEN: 'secret-123',
+      AUTH_HUB_INTERNAL_URL: 'http://civitai-auth.civitai-auth.svc.cluster.local:3000',
+    });
+    const fetch = stubFetch(async () => ({ ok: true, status: 200, json: async () => richUser(7) }));
+    expect(await createSessionClient().getSessionUser('7')).toMatchObject({ id: 7 });
+    // FETCH target is the internal svc; the bearer is still the user's token.
+    expect(fetch).toHaveBeenCalledWith(
+      'http://civitai-auth.civitai-auth.svc.cluster.local:3000/api/auth/identity',
+      { headers: { authorization: 'Bearer 7' }, signal: expect.any(AbortSignal) }
+    );
+  });
+
+  it('falls back to the public iss base when AUTH_HUB_INTERNAL_URL is unset (backward-compatible)', async () => {
+    // beforeEach env has NO AUTH_HUB_INTERNAL_URL.
+    const fetch = stubFetch(async () => ({ ok: true, status: 200, json: async () => richUser(7) }));
+    await createSessionClient().getSessionUser('7');
+    expect(fetch).toHaveBeenCalledWith(
+      'https://auth.test/api/auth/identity',
+      expect.objectContaining({ headers: { authorization: 'Bearer 7' } })
+    );
+  });
+
+  it('STILL rejects a spoofed/untrusted iss even with AUTH_HUB_INTERNAL_URL set (no bypass, no fetch)', async () => {
+    // The internal override must NEVER let an untrusted issuer through — trustedHubBase(iss) runs first.
+    h.loadAuthEnv.mockReturnValue({
+      AUTH_JWT_ISSUER: 'https://auth.test',
+      AUTH_INTERNAL_TOKEN: 'secret-123',
+      AUTH_HUB_INTERNAL_URL: 'http://civitai-auth.civitai-auth.svc.cluster.local:3000',
+    });
+    h.verifyToken.mockImplementation(async (t: string) => ({ sub: t, iss: 'https://evil.example' }));
+    const fetch = stubFetch(async () => ({ ok: true, status: 200, json: async () => richUser(7) }));
+    expect(await createSessionClient().getSessionUser('7')).toBeNull(); // fail closed
+    expect(fetch).not.toHaveBeenCalled(); // bearer never left for the untrusted issuer
+  });
+});
+
+describe('createSessionClient — identity-fetch timeout (fail-open + instrumentation)', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('aborts a hung identity fetch at the timeout, resolves to the miss behavior (null), and reports timeout', async () => {
+    vi.useFakeTimers();
+    const onIdentityLeg =
+      vi.fn<(outcome: 'hit' | 'miss' | 'timeout' | 'error', s: number) => void>();
+    // A fetch that never settles on its own — it only rejects when its AbortSignal fires (like real fetch).
+    stubFetch(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          const signal = (init as { signal: AbortSignal }).signal;
+          if (signal.aborted) return reject(signal.reason);
+          signal.addEventListener('abort', () => reject(signal.reason));
+        }) as Promise<Res>
+    );
+    const p = createSessionClient({ onIdentityLeg }).getSessionUser('7');
+    await vi.advanceTimersByTimeAsync(1500); // trip AbortSignal.timeout(1500)
+    expect(await p).toBeNull(); // unchanged miss behavior — does NOT stall
+    expect(onIdentityLeg).toHaveBeenCalledWith('timeout', expect.any(Number));
+  });
+
+  it('reports outcome "hit" on a successful identity fetch', async () => {
+    const onIdentityLeg =
+      vi.fn<(outcome: 'hit' | 'miss' | 'timeout' | 'error', s: number) => void>();
+    stubFetch(async () => ({ ok: true, status: 200, json: async () => richUser(7) }));
+    await createSessionClient({ onIdentityLeg }).getSessionUser('7');
+    expect(onIdentityLeg).toHaveBeenCalledWith('hit', expect.any(Number));
   });
 });
 

--- a/packages/civitai-auth/src/__tests__/timing.test.ts
+++ b/packages/civitai-auth/src/__tests__/timing.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { now, elapsed, isTimeoutError } from '../timing';
+
+describe('timing helpers', () => {
+  it('now() is monotonic and elapsed() returns non-negative seconds', () => {
+    const start = now();
+    expect(elapsed(start)).toBeGreaterThanOrEqual(0);
+    expect(elapsed(start)).toBeLessThan(5); // this test does not take 5s
+  });
+
+  describe('isTimeoutError', () => {
+    it('classifies the identity-fetch AbortSignal.timeout DOMException (name TimeoutError)', () => {
+      // What AbortSignal.timeout(...) throws through fetch.
+      const err = Object.assign(new Error('The operation timed out.'), { name: 'TimeoutError' });
+      expect(isTimeoutError(err)).toBe(true);
+    });
+
+    it('classifies the jose JWKS refetch timeout (name JWKSTimeout)', () => {
+      expect(isTimeoutError(Object.assign(new Error('x'), { name: 'JWKSTimeout' }))).toBe(true);
+    });
+
+    it('classifies the jose JWKS timeout by code ERR_JWKS_TIMEOUT', () => {
+      expect(isTimeoutError(Object.assign(new Error('x'), { code: 'ERR_JWKS_TIMEOUT' }))).toBe(true);
+    });
+
+    it('does NOT classify ordinary errors (bad signature, network reset, undefined) as timeouts', () => {
+      expect(isTimeoutError(new Error('bad signature'))).toBe(false);
+      expect(isTimeoutError(Object.assign(new Error('reset'), { name: 'TypeError' }))).toBe(false);
+      expect(isTimeoutError(undefined)).toBe(false);
+      expect(isTimeoutError('nope')).toBe(false);
+    });
+  });
+});

--- a/packages/civitai-auth/src/__tests__/verify.test.ts
+++ b/packages/civitai-auth/src/__tests__/verify.test.ts
@@ -52,6 +52,37 @@ describe('createAuthVerifier', () => {
     expect(claims?.jti).toBe('t7');
   });
 
+  it('reports the JWKS leg outcome "hit" on a successful JWKS verify (SPOF-fix instrumentation)', async () => {
+    stubJwks();
+    const onJwksLeg = vi.fn<(o: 'hit' | 'timeout', s: number) => void>();
+    const token = await signer.mintSessionToken({ user: { id: 7 }, signedAt: 1 }, { jti: 't7' });
+    await createAuthVerifier({ ...cfg, onJwksLeg }).verifyToken(token);
+    expect(onJwksLeg).toHaveBeenCalledWith('hit', expect.any(Number));
+  });
+
+  it('does NOT fire the JWKS leg on the LOCAL public-key (hub) path — no network to instrument', async () => {
+    const onJwksLeg = vi.fn<(o: 'hit' | 'timeout', s: number) => void>();
+    const token = await signer.mintSessionToken({ user: { id: 7 }, signedAt: 1 }, { jti: 't7' });
+    await createAuthVerifier({ issuer, audience, publicKeyPem, onJwksLeg }).verifyToken(token);
+    expect(onJwksLeg).not.toHaveBeenCalled();
+  });
+
+  it('does NOT report a JWKS timeout on an ordinary bad-token verify failure', async () => {
+    stubJwks();
+    const onJwksLeg = vi.fn<(o: 'hit' | 'timeout', s: number) => void>();
+    // Wrong issuer → jwtVerify throws a claim-validation error (NOT a timeout) → verifyToken returns null,
+    // and the JWKS leg must not be recorded as a timeout.
+    const token = await signer.mintSessionToken({ user: { id: 7 }, signedAt: 1 }, { jti: 't7' });
+    const claims = await createAuthVerifier({
+      jwksUri,
+      issuer: 'https://nope.test',
+      audience,
+      onJwksLeg,
+    }).verifyToken(token);
+    expect(claims).toBeNull();
+    expect(onJwksLeg).not.toHaveBeenCalledWith('timeout', expect.any(Number));
+  });
+
   it('verifies an ES256 token with a LOCAL public key (no JWKS fetch)', async () => {
     // No stubJwks() here: a local public key must verify WITHOUT any network. If it fell through to
     // JWKS, global fetch is unstubbed and this would reject.

--- a/packages/civitai-auth/src/__tests__/verify.test.ts
+++ b/packages/civitai-auth/src/__tests__/verify.test.ts
@@ -60,6 +60,18 @@ describe('createAuthVerifier', () => {
     expect(onJwksLeg).toHaveBeenCalledWith('hit', expect.any(Number));
   });
 
+  it('still verifies when a throwing onJwksLeg callback fires (instrumentation is best-effort)', async () => {
+    stubJwks();
+    const token = await signer.mintSessionToken({ user: { id: 7 }, signedAt: 1 }, { jti: 't7' });
+    const onJwksLeg = vi.fn(() => {
+      throw new Error('metrics exploded');
+    });
+    // Without safeInvoke this would re-throw → verifyToken returns null → a valid token becomes a logout.
+    const claims = await createAuthVerifier({ ...cfg, onJwksLeg }).verifyToken(token);
+    expect(claims?.user).toMatchObject({ id: 7 }); // verify SUCCEEDS despite the throwing callback
+    expect(onJwksLeg).toHaveBeenCalled();
+  });
+
   it('does NOT fire the JWKS leg on the LOCAL public-key (hub) path — no network to instrument', async () => {
     const onJwksLeg = vi.fn<(o: 'hit' | 'timeout', s: number) => void>();
     const token = await signer.mintSessionToken({ user: { id: 7 }, signedAt: 1 }, { jti: 't7' });

--- a/packages/civitai-auth/src/env.ts
+++ b/packages/civitai-auth/src/env.ts
@@ -13,6 +13,14 @@ const schema = z.object({
   // --- spoke: verify side ---
   AUTH_JWKS_URI: z.url().optional(), // e.g. https://auth.civitai.com/.well-known/jwks.json
   AUTH_JWT_ISSUER: z.string().optional(), // e.g. https://auth.civitai.com
+  // SERVER-ONLY internal-routing override for the session-identity read (session-client.ts fetchIdentity).
+  // When set, the identity fetch is sent to THIS base (the in-cluster hub svc, e.g.
+  // http://civitai-auth.civitai-auth.svc.cluster.local:3000) instead of hairpinning out to the public
+  // AUTH_JWT_ISSUER origin (CF edge → Traefik → back to the same cluster). It ONLY changes the FETCH target —
+  // the token's `iss` is STILL validated against the public trusted origin(s) first (trustedHubBase), so the
+  // override can never be used to send a bearer to an untrusted issuer. Deliberately NOT a `NEXT_PUBLIC_*`
+  // var: it is read on the server only and must never reach the client bundle.
+  AUTH_HUB_INTERNAL_URL: z.url().optional(), // e.g. http://civitai-auth.civitai-auth.svc.cluster.local:3000
   // Legacy symmetric secret — kept ONLY for the migration window so spokes can still
   // decode pre-cutover next-auth JWE cookies. Drop after the max old-token TTL.
   NEXTAUTH_SECRET: z.string().optional(),

--- a/packages/civitai-auth/src/hub.ts
+++ b/packages/civitai-auth/src/hub.ts
@@ -1,9 +1,14 @@
 import { loadAuthEnv } from './env';
 
+// Bound every hub hop so a stalled hub / edge fails fast instead of hanging the authed request (matches the
+// token identity leg). A caller that arms its own signal (e.g. session-token-client) is respected.
+const HUB_FETCH_TIMEOUT_MS = 1500;
+
 /**
  * The hub origin (the token issuer, `AUTH_JWT_ISSUER`), trailing slashes stripped. Returns null when
- * unconfigured so callers can no-op a request path instead of throwing. Single source for the spoke→hub
- * clients (device / session-token / impersonation) + the session-client write path.
+ * unconfigured so callers can no-op a request path instead of throwing. This is the PUBLIC origin used for
+ * URL/redirect BUILDING (spoke-guard, first-party-bridge) — NOT the fetch target (see hubFetch). Single source
+ * for the spoke→hub clients (device / session-token / impersonation) + the session-client write path.
  */
 export function hubBaseUrl(): string | null {
   const url = loadAuthEnv().AUTH_JWT_ISSUER;
@@ -11,12 +16,29 @@ export function hubBaseUrl(): string | null {
 }
 
 /**
+ * The base hubFetch actually TARGETS: the in-cluster hub svc (`AUTH_HUB_INTERNAL_URL`) when set, else the
+ * public `AUTH_JWT_ISSUER` (today's behavior). Unlike the token identity leg there is NO spoof concern here —
+ * hubFetch always targets the operator-configured trusted issuer, never an attacker-controlled `claims.iss` —
+ * so we prefer the internal address unconditionally. This removes the CF-edge hairpin for the API-key/OAuth
+ * by-id read (getSessionUserById) + the write paths + the device/session-token/impersonation clients. It is
+ * cookie-safe: the hub derives its cookie `Domain` from `AUTH_JWT_ISSUER` (unchanged), never the request Host.
+ */
+function hubFetchBase(): string | null {
+  const env = loadAuthEnv();
+  const base = env.AUTH_HUB_INTERNAL_URL ?? env.AUTH_JWT_ISSUER;
+  return base ? base.replace(/\/+$/, '') : null;
+}
+
+/**
  * STRICT hub fetch — the server-side primitive every spoke→hub client routes through, so the package provably
- * only ever talks to the hub (`AUTH_JWT_ISSUER`), never a relative/spoke path. Throws if the hub isn't
- * configured; callers wrap in try/catch and fall back to their own empty/null result.
+ * only ever talks to the hub, never a relative/spoke path. Routes in-cluster via `AUTH_HUB_INTERNAL_URL` when
+ * set (else the public issuer) and bounds the hop with a timeout. Throws if the hub isn't configured; callers
+ * wrap in try/catch and fall back to their own empty/null result.
  */
 export function hubFetch(path: string, init?: RequestInit): Promise<Response> {
-  const base = hubBaseUrl();
+  const base = hubFetchBase();
   if (!base) throw new Error('[@civitai/auth] hub not configured (AUTH_JWT_ISSUER)');
-  return fetch(`${base}${path}`, init);
+  // Respect a caller-armed signal (session-token-client sets its own 2500ms), else arm the default timeout.
+  const signal = init?.signal ?? AbortSignal.timeout(HUB_FETCH_TIMEOUT_MS);
+  return fetch(`${base}${path}`, { ...init, signal });
 }

--- a/packages/civitai-auth/src/session-client.ts
+++ b/packages/civitai-auth/src/session-client.ts
@@ -2,6 +2,7 @@ import { createAuthVerifier, type AuthVerifier } from './verify';
 import { loadAuthEnv } from './env';
 import { hubFetch } from './hub';
 import { getCacheRedis, sessionCacheKey } from './redis';
+import { now, elapsed, isTimeoutError } from './timing';
 import type { SessionUser, SessionClaims } from './types';
 
 // SESSION CLIENT — the consumer-side interface to the auth hub's session-user data (thin-session model;
@@ -52,6 +53,19 @@ export interface SessionClientConfig {
    * token before the cache read. Fail-open inside (a redis blip must not log everyone out).
    */
   isRevoked?: (claims: SessionClaims) => Promise<boolean> | boolean;
+  /**
+   * Optional instrumentation for the identity read-through leg — the app→hub `fetchIdentity` hop that this
+   * SPOF fix routes in-cluster. Called once per hub fetch with the outcome and its wall-clock duration so the
+   * CALLING app can emit metrics (the hub can't see this hop — a stalled app→CF→hub hairpin is invisible to
+   * the hub's own metrics). Kept as an INJECTED callback so the package stays infra-dep-free (no prom-client):
+   * the app wires it to its registry. Must never throw / must be cheap (it runs on the authed hot path).
+   */
+  onIdentityLeg?: (outcome: 'hit' | 'miss' | 'timeout' | 'error', durationSeconds: number) => void;
+  /**
+   * Optional instrumentation for the JWKS verify leg used by THIS client's hot-path verifier (getSessionUser
+   * verifies inline). Forwarded straight to the internal `createAuthVerifier` — see AuthVerifierConfig.onJwksLeg.
+   */
+  onJwksLeg?: (outcome: 'hit' | 'timeout', durationSeconds: number) => void;
 }
 
 export function createSessionClient(config: SessionClientConfig = {}): SessionClient {
@@ -59,7 +73,10 @@ export function createSessionClient(config: SessionClientConfig = {}): SessionCl
   // injected `isRevoked` after signature/expiry, so revocation is enforced on the cache-hit read path too.
   let _verifier: AuthVerifier | undefined;
   const verify = (token: string) =>
-    (_verifier ??= createAuthVerifier({ isRevoked: config.isRevoked })).verifyToken(token);
+    (_verifier ??= createAuthVerifier({
+      isRevoked: config.isRevoked,
+      onJwksLeg: config.onJwksLeg,
+    })).verifyToken(token);
 
   // Per-pod single-flight: collapse concurrent read-misses for the same user into ONE hub fetch, so a cache
   // bust / cold cache doesn't fan out into N identical HTTP hops to the hub (stampede protection). One map per
@@ -95,13 +112,28 @@ export function createSessionClient(config: SessionClientConfig = {}): SessionCl
     // mismatched issuer. Mismatch / unconfigured → null (fail closed), no fetch.
     const existing = inflight.get(userId);
     if (existing) return existing;
+    // VALIDATE the token's issuer against the configured trusted origin(s) — unchanged. This is the anti-spoof
+    // guard: the bearer only leaves for an origin the operator configured, never one an attacker's `iss` names.
     const baseUrl = trustedHubBase(claims.iss);
+    // DECOUPLE the fetch target from the validation target: the issuer is validated above (public origin), but
+    // the actual identity hop is routed to AUTH_HUB_INTERNAL_URL (the in-cluster hub svc) when set — so the
+    // authed hot path stops hairpinning out through the public edge (CF → Traefik → back to the same cluster),
+    // the SPOF a transient CF-edge blip turned into a fleet-wide auth stall. Falls back to the public iss base
+    // when the override is unset (backward-compatible default). The bearer now travels over in-cluster http
+    // (no public edge) — acceptable, and the trustedHubBase(iss) check still gates whether we fetch at all.
+    const fetchBase = baseUrl ? loadAuthEnv().AUTH_HUB_INTERNAL_URL ?? baseUrl : null;
     const p = (async () => {
-      if (!baseUrl) return null; // no trusted issuer to resolve against
+      if (!fetchBase) return null; // no trusted issuer to resolve against
+      const start = now();
       try {
-        return await fetchIdentity(baseUrl, token);
-      } catch {
-        return null; // hub unreachable — appear unauthenticated (the warm cache covers the normal path)
+        const user = await fetchIdentity(fetchBase, token);
+        config.onIdentityLeg?.(user ? 'hit' : 'miss', elapsed(start));
+        return user;
+      } catch (err) {
+        // hub unreachable / aborted — appear unauthenticated (the warm cache covers the normal path). A
+        // fetch aborted by the AbortSignal.timeout throws a TimeoutError (name === 'TimeoutError').
+        config.onIdentityLeg?.(isTimeoutError(err) ? 'timeout' : 'error', elapsed(start));
+        return null;
       }
     })().finally(() => inflight.delete(userId));
     inflight.set(userId, p);
@@ -204,11 +236,24 @@ function trustedHubBase(iss: string | undefined): string | null {
   return iss.replace(/\/+$/, '');
 }
 
-/** Read source: GET `{iss}/api/auth/identity` with the session token as a Bearer. */
+// Bound the identity read so even an in-cluster hiccup fails fast (→ null, the existing miss behavior) rather
+// than stalling the authed request. Defense-in-depth on top of the internal routing: the fetch never had a
+// timeout before, so a half-open connection could park the whole request until OS TCP keepalive (~min).
+const IDENTITY_FETCH_TIMEOUT_MS = 1500;
+
+/** Read source: GET `{base}/api/auth/identity` with the session token as a Bearer, bounded by a timeout. */
 async function fetchIdentity(baseUrl: string, token: string): Promise<SessionUser | null> {
   const url = `${baseUrl.replace(/\/+$/, '')}/api/auth/identity`;
-  const res = await fetch(url, { headers: { authorization: `Bearer ${token}` } });
+  // AbortSignal.timeout throws a DOMException `TimeoutError` on expiry — surfaced to the caller's catch, which
+  // records the 'timeout' outcome and returns null (unchanged miss semantics — we never throw a new error
+  // shape upward). No Host header is needed: the hub's identity handler authenticates by the bearer token /
+  // AUTH_INTERNAL_TOKEN and does NOT gate on the Host header (apps/auth .../identity/+server.ts).
+  const res = await fetch(url, {
+    headers: { authorization: `Bearer ${token}` },
+    signal: AbortSignal.timeout(IDENTITY_FETCH_TIMEOUT_MS),
+  });
   if (res.status === 401 || res.status === 404) return null; // not authenticated / no such user
   if (!res.ok) throw new Error(`[@civitai/auth] identity fetch failed: ${res.status}`);
   return (await res.json()) as SessionUser;
 }
+

--- a/packages/civitai-auth/src/session-client.ts
+++ b/packages/civitai-auth/src/session-client.ts
@@ -2,7 +2,7 @@ import { createAuthVerifier, type AuthVerifier } from './verify';
 import { loadAuthEnv } from './env';
 import { hubFetch } from './hub';
 import { getCacheRedis, sessionCacheKey } from './redis';
-import { now, elapsed, isTimeoutError } from './timing';
+import { now, elapsed, isTimeoutError, safeInvoke } from './timing';
 import type { SessionUser, SessionClaims } from './types';
 
 // SESSION CLIENT — the consumer-side interface to the auth hub's session-user data (thin-session model;
@@ -66,6 +66,18 @@ export interface SessionClientConfig {
    * verifies inline). Forwarded straight to the internal `createAuthVerifier` — see AuthVerifierConfig.onJwksLeg.
    */
   onJwksLeg?: (outcome: 'hit' | 'timeout', durationSeconds: number) => void;
+  /**
+   * Optional instrumentation for the BY-USERID read-through hub hop (getSessionUserById) — the hot read for
+   * API-key / OAuth / legacy-cookie auth. Same shape as onIdentityLeg. `miss` = the hub reported no user
+   * (401/404/5xx). Now routed in-cluster + bounded like the token identity leg.
+   */
+  onIdentityByIdLeg?: (outcome: 'hit' | 'miss' | 'timeout' | 'error', durationSeconds: number) => void;
+  /**
+   * Optional instrumentation for the hub WRITE hops (invalidate / refresh / invalidateAll). `hit` = the write
+   * completed (2xx); `timeout` = the bounded hub fetch aborted; `error` = a non-ok status or network error
+   * (the write still throws, per its contract — the callback is fire-and-forget observability only).
+   */
+  onHubWriteLeg?: (outcome: 'hit' | 'timeout' | 'error', durationSeconds: number) => void;
 }
 
 export function createSessionClient(config: SessionClientConfig = {}): SessionClient {
@@ -127,12 +139,13 @@ export function createSessionClient(config: SessionClientConfig = {}): SessionCl
       const start = now();
       try {
         const user = await fetchIdentity(fetchBase, token);
-        config.onIdentityLeg?.(user ? 'hit' : 'miss', elapsed(start));
+        // safeInvoke: a throwing metric callback here must NOT flip a valid session to null via the catch.
+        safeInvoke(config.onIdentityLeg, user ? 'hit' : 'miss', elapsed(start));
         return user;
       } catch (err) {
         // hub unreachable / aborted — appear unauthenticated (the warm cache covers the normal path). A
         // fetch aborted by the AbortSignal.timeout throws a TimeoutError (name === 'TimeoutError').
-        config.onIdentityLeg?.(isTimeoutError(err) ? 'timeout' : 'error', elapsed(start));
+        safeInvoke(config.onIdentityLeg, isTimeoutError(err) ? 'timeout' : 'error', elapsed(start));
         return null;
       }
     })().finally(() => inflight.delete(userId));
@@ -142,7 +155,8 @@ export function createSessionClient(config: SessionClientConfig = {}): SessionCl
 
   // READ-THROUGH by userId — for consumer paths with no session token (API-key/bearer auth, legacy cookie).
   // Shared-cache read → single-flight the miss to the INTERNAL-authed GET identity?userId= (read-through, NOT
-  // a bust — refresh() is the bust path). The hub URL is AUTH_JWT_ISSUER (no token whose `iss` to read).
+  // a bust — refresh() is the bust path). Routed in-cluster + bounded by hubFetch (AUTH_HUB_INTERNAL_URL) —
+  // this is the hot read for EVERY API-key / OAuth request, so it's the same hairpin SPOF as the token path.
   async function getSessionUserById(userId: number): Promise<SessionUser | null> {
     if (!Number.isFinite(userId)) return null;
     const cached = await readCachedUser(userId);
@@ -153,14 +167,23 @@ export function createSessionClient(config: SessionClientConfig = {}): SessionCl
     const p = (async () => {
       const internal = loadAuthEnv().AUTH_INTERNAL_TOKEN; // by-userId read is service-authed (no user token)
       if (!internal) return null;
+      const start = now();
       try {
         const res = await hubFetch(`/api/auth/identity?userId=${userId}`, {
           headers: { authorization: `Bearer ${internal}` },
         });
-        if (!res.ok) return null; // 401 (bad secret) / 404 (no such user) / 5xx → treat as unauthenticated
-        return (await res.json()) as SessionUser;
-      } catch {
-        return null; // hub unreachable / not configured
+        if (!res.ok) {
+          // 401 (bad secret) / 404 (no such user) / 5xx → treat as unauthenticated
+          safeInvoke(config.onIdentityByIdLeg, 'miss', elapsed(start));
+          return null;
+        }
+        const user = (await res.json()) as SessionUser;
+        safeInvoke(config.onIdentityByIdLeg, 'hit', elapsed(start));
+        return user;
+      } catch (err) {
+        // hub unreachable / aborted (bounded by hubFetch's AbortSignal.timeout) / not configured
+        safeInvoke(config.onIdentityByIdLeg, isTimeoutError(err) ? 'timeout' : 'error', elapsed(start));
+        return null;
       }
     })().finally(() => inflightById.delete(userId));
     inflightById.set(userId, p);
@@ -174,12 +197,23 @@ export function createSessionClient(config: SessionClientConfig = {}): SessionCl
     if (!token)
       throw new Error('[@civitai/auth] createSessionClient: AUTH_INTERNAL_TOKEN is not set');
 
-    const res = await hubFetch('/api/auth/identity', {
-      method: 'POST',
-      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
-      body: JSON.stringify({ userId, refresh: reproduce }), // `refresh` is the hub's wire field
-    });
-    if (!res.ok) throw new Error(`[@civitai/auth] session invalidate failed: ${res.status}`);
+    const start = now();
+    let res: Response;
+    try {
+      res = await hubFetch('/api/auth/identity', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({ userId, refresh: reproduce }), // `refresh` is the hub's wire field
+      });
+    } catch (err) {
+      safeInvoke(config.onHubWriteLeg, isTimeoutError(err) ? 'timeout' : 'error', elapsed(start));
+      throw err; // write contract unchanged — the caller sees the (now-bounded) failure
+    }
+    if (!res.ok) {
+      safeInvoke(config.onHubWriteLeg, 'error', elapsed(start));
+      throw new Error(`[@civitai/auth] session invalidate failed: ${res.status}`);
+    }
+    safeInvoke(config.onHubWriteLeg, 'hit', elapsed(start));
     if (!reproduce) return null;
     return ((await res.json()) ?? null) as SessionUser | null;
   }
@@ -190,12 +224,23 @@ export function createSessionClient(config: SessionClientConfig = {}): SessionCl
     const token = loadAuthEnv().AUTH_INTERNAL_TOKEN;
     if (!token)
       throw new Error('[@civitai/auth] createSessionClient: AUTH_INTERNAL_TOKEN is not set');
-    const res = await hubFetch('/api/auth/identity', {
-      method: 'POST',
-      headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
-      body: JSON.stringify({ scope: 'all' }),
-    });
-    if (!res.ok) throw new Error(`[@civitai/auth] session invalidateAll failed: ${res.status}`);
+    const start = now();
+    let res: Response;
+    try {
+      res = await hubFetch('/api/auth/identity', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: JSON.stringify({ scope: 'all' }),
+      });
+    } catch (err) {
+      safeInvoke(config.onHubWriteLeg, isTimeoutError(err) ? 'timeout' : 'error', elapsed(start));
+      throw err;
+    }
+    if (!res.ok) {
+      safeInvoke(config.onHubWriteLeg, 'error', elapsed(start));
+      throw new Error(`[@civitai/auth] session invalidateAll failed: ${res.status}`);
+    }
+    safeInvoke(config.onHubWriteLeg, 'hit', elapsed(start));
   }
 
   return {

--- a/packages/civitai-auth/src/timing.ts
+++ b/packages/civitai-auth/src/timing.ts
@@ -24,3 +24,22 @@ export const isTimeoutError = (err: unknown): boolean => {
   const { name, code } = err as { name?: string; code?: string };
   return name === 'TimeoutError' || name === 'JWKSTimeout' || code === 'ERR_JWKS_TIMEOUT';
 };
+
+/**
+ * Invoke an optional instrumentation callback WITHOUT letting it affect the auth result. A throwing metric
+ * callback on the hot path would otherwise corrupt auth: a throw right after a successful identity fetch would
+ * bubble to the surrounding catch → return null → a valid session appears unauthenticated; in verify it would
+ * re-throw → fail-closed logout. `observeSessionLeg` never throws today, but this makes the guarantee
+ * STRUCTURAL — instrumentation is strictly best-effort.
+ */
+export function safeInvoke<A extends unknown[]>(
+  fn: ((...args: A) => void) | undefined,
+  ...args: A
+): void {
+  if (!fn) return;
+  try {
+    fn(...args);
+  } catch {
+    /* instrumentation must never affect the auth result */
+  }
+}

--- a/packages/civitai-auth/src/timing.ts
+++ b/packages/civitai-auth/src/timing.ts
@@ -1,0 +1,26 @@
+// Tiny, infra-free timing helpers shared by the session-resolution legs (session-client fetchIdentity + the
+// verify JWKS refetch). Kept in the package (no prom-client / no infra dep — base-package rules); the CALLING
+// app injects the actual metric emission via the `onIdentityLeg` / `onJwksLeg` callbacks and these helpers just
+// produce the numbers.
+
+/** High-resolution monotonic clock in ms, falling back to Date.now where `performance` is unavailable. */
+export const now = (): number =>
+  typeof performance !== 'undefined' && typeof performance.now === 'function'
+    ? performance.now()
+    : Date.now();
+
+/** Elapsed seconds since a `now()` start mark — the unit prom histograms expect. */
+export const elapsed = (startMs: number): number => (now() - startMs) / 1000;
+
+/**
+ * True when an error is a bounded-wait TIMEOUT from one of the two mechanisms this fix adds:
+ *  - `AbortSignal.timeout(...)` on the identity fetch → DOMException `TimeoutError`.
+ *  - jose `createRemoteJWKSet(..., { timeoutDuration })` on the JWKS refetch → `JWKSTimeout`
+ *    (code `ERR_JWKS_TIMEOUT`).
+ * Everything else (bad signature, 5xx, network reset) is NOT a timeout.
+ */
+export const isTimeoutError = (err: unknown): boolean => {
+  if (!err || typeof err !== 'object') return false;
+  const { name, code } = err as { name?: string; code?: string };
+  return name === 'TimeoutError' || name === 'JWKSTimeout' || code === 'ERR_JWKS_TIMEOUT';
+};

--- a/packages/civitai-auth/src/verify.ts
+++ b/packages/civitai-auth/src/verify.ts
@@ -11,9 +11,11 @@ import { createRemoteJWKSet, decodeProtectedHeader, importSPKI, jwtVerify } from
 import { sessionCookieName } from './cookies';
 import { decodeLegacySessionCookie } from './legacy-cookie';
 import { loadAuthEnv } from './env';
+import { now, elapsed, isTimeoutError } from './timing';
 import type { SessionClaims } from './types';
 
 const ALG = 'ES256'; // matches the signer (sign.ts) — EC P-256 keys, smaller signatures than RS256
+const JWKS_TIMEOUT_MS = 2500; // bound the on-rotation JWKS refetch (jose default is 5000ms) — see below
 // Accept a multiline PEM or a single-line value with literal `\n` escapes (matches sign.ts).
 const normalizePem = (pem: string) => pem.replace(/\\n/g, '\n');
 
@@ -43,6 +45,16 @@ export interface AuthVerifierConfig {
   legacyEnabled?: boolean;
   /** Injected revocation check (e.g. the sysRedis TOKEN_STATE marker). Fail-open inside. */
   isRevoked?: (claims: SessionClaims) => Promise<boolean> | boolean;
+  /**
+   * Optional instrumentation for the JWKS verify leg — fires once per ES256-via-JWKS verify with its
+   * wall-clock duration. Injected (not imported) so the package stays infra-dep-free; the CALLING app wires
+   * it to prom-client. `hit` = verify succeeded (keys were cached → sub-ms crypto, OR a refetch on an unknown
+   * kid succeeded → the network cost shows up here); `timeout` = the bounded JWKS refetch (timeoutDuration)
+   * aborted. Ordinary bad-token failures (bad signature / expiry / issuer) are NOT emitted — they aren't a
+   * JWKS-leg event. Must be cheap + never throw (authed hot path). Only fires on the JWKS path, never the
+   * local-public-key (hub) path.
+   */
+  onJwksLeg?: (outcome: 'hit' | 'timeout', durationSeconds: number) => void;
 }
 
 export interface AuthVerifier {
@@ -75,6 +87,7 @@ export function createAuthVerifier(config: AuthVerifierConfig = {}): AuthVerifie
     // (preserves migration-window behavior); pass `legacyEnabled: false` to force it off at cutover.
     legacyEnabled: config.legacyEnabled ?? true,
     isRevoked: config.isRevoked,
+    onJwksLeg: config.onJwksLeg,
   };
 
   // Verification key. Prefer a LOCAL public key (no network) when configured — the hub verifying its
@@ -82,7 +95,14 @@ export function createAuthVerifier(config: AuthVerifierConfig = {}): AuthVerifie
   // rotation) — the spoke path. At least one must be present to verify ES256.
   let _localKey: ReturnType<typeof importSPKI> | undefined;
   const localKey = () => (_localKey ??= importSPKI(normalizePem(cfg.publicKeyPem!), ALG));
-  const jwks = !cfg.publicKeyPem && cfg.jwksUri ? createRemoteJWKSet(new URL(cfg.jwksUri)) : undefined;
+  // Bound the JWKS refetch (triggered only on an unknown `kid`, i.e. key rotation) so it can't hang the verify
+  // path. jose defaults timeoutDuration to 5000ms; we tighten it to 2500ms as defense-in-depth (on the authed
+  // hot path a hung JWKS fetch would otherwise stall every request whose kid isn't cached). The internal
+  // AUTH_JWKS_URI (see env change) also removes the CF-edge hairpin for this fetch.
+  const jwks =
+    !cfg.publicKeyPem && cfg.jwksUri
+      ? createRemoteJWKSet(new URL(cfg.jwksUri), { timeoutDuration: JWKS_TIMEOUT_MS })
+      : undefined;
   const canVerify = () => !!cfg.publicKeyPem || !!jwks;
 
   // Branch so each jwtVerify call matches a single jose overload (KeyLike vs JWKS-getter).
@@ -91,7 +111,19 @@ export function createAuthVerifier(config: AuthVerifierConfig = {}): AuthVerifie
     // must NOT be inferred from the verification key (alg-confusion guard) — jose only ever accepts
     // an ES256 signature here, never anything the header asks for.
     const opts = { issuer: cfg.issuer, audience: cfg.audience, algorithms: [ALG] };
-    return cfg.publicKeyPem ? jwtVerify(token, await localKey(), opts) : jwtVerify(token, jwks!, opts);
+    if (cfg.publicKeyPem) return jwtVerify(token, await localKey(), opts);
+    // JWKS path (spoke): time it so a stalled key-refetch is VISIBLE to the calling app. Emit `timeout` on the
+    // bounded JWKS-refetch abort, `hit` on success; a plain bad-token failure re-throws WITHOUT emitting (not a
+    // JWKS-leg event). Instrumentation must never mask the verify result → we always re-throw on failure.
+    const start = now();
+    try {
+      const res = await jwtVerify(token, jwks!, opts);
+      cfg.onJwksLeg?.('hit', elapsed(start));
+      return res;
+    } catch (err) {
+      if (isTimeoutError(err)) cfg.onJwksLeg?.('timeout', elapsed(start));
+      throw err;
+    }
   }
 
   async function verifyToken(token: string): Promise<SessionClaims | null> {

--- a/packages/civitai-auth/src/verify.ts
+++ b/packages/civitai-auth/src/verify.ts
@@ -11,7 +11,7 @@ import { createRemoteJWKSet, decodeProtectedHeader, importSPKI, jwtVerify } from
 import { sessionCookieName } from './cookies';
 import { decodeLegacySessionCookie } from './legacy-cookie';
 import { loadAuthEnv } from './env';
-import { now, elapsed, isTimeoutError } from './timing';
+import { now, elapsed, isTimeoutError, safeInvoke } from './timing';
 import type { SessionClaims } from './types';
 
 const ALG = 'ES256'; // matches the signer (sign.ts) — EC P-256 keys, smaller signatures than RS256
@@ -118,10 +118,11 @@ export function createAuthVerifier(config: AuthVerifierConfig = {}): AuthVerifie
     const start = now();
     try {
       const res = await jwtVerify(token, jwks!, opts);
-      cfg.onJwksLeg?.('hit', elapsed(start));
+      // safeInvoke: a throwing metric callback must NOT turn a valid verify into a re-thrown fail-closed logout.
+      safeInvoke(cfg.onJwksLeg, 'hit', elapsed(start));
       return res;
     } catch (err) {
-      if (isTimeoutError(err)) cfg.onJwksLeg?.('timeout', elapsed(start));
+      if (isTimeoutError(err)) safeInvoke(cfg.onJwksLeg, 'timeout', elapsed(start));
       throw err;
     }
   }

--- a/src/server/auth/__tests__/ban-session-revocation.test.ts
+++ b/src/server/auth/__tests__/ban-session-revocation.test.ts
@@ -37,7 +37,11 @@ const h = vi.hoisted(() => {
   return { hashes, strings, KEYS, sysRedis };
 });
 
-vi.mock('~/server/redis/client', () => ({ sysRedis: h.sysRedis, ...h.KEYS }));
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: h.sysRedis,
+  ...h.KEYS,
+  withSysReadDeadline: <T>(p: Promise<T>) => p, // transparent in tests (matches rate-limiting.test.ts)
+}));
 // session-invalidation marks TOKEN_STATE via the atomic eval helper (hSetMultiWithTTL); the
 // fake sysRedis above has no `eval`, so stub the helper to write straight to the in-memory hash.
 vi.mock('~/server/redis/atomic', () => ({

--- a/src/server/auth/__tests__/session-invalidation.test.ts
+++ b/src/server/auth/__tests__/session-invalidation.test.ts
@@ -50,6 +50,7 @@ vi.mock('~/server/redis/client', () => ({
       ALL: 'sys:session:all',
     },
   },
+  withSysReadDeadline: <T>(p: Promise<T>) => p, // transparent in tests (matches rate-limiting.test.ts)
 }));
 
 vi.mock('~/server/utils/cache-helpers', () => ({

--- a/src/server/auth/__tests__/session-metrics.test.ts
+++ b/src/server/auth/__tests__/session-metrics.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Stable metric spies so we can assert the histogram + counter wiring. A file-level vi.mock overrides the
+// global prom/client stub (src/__tests__/setup.ts) for this module.
+const h = vi.hoisted(() => ({
+  histogram: { observe: vi.fn() },
+  counter: { inc: vi.fn() },
+}));
+
+vi.mock('~/server/prom/client', () => ({
+  registerHistogram: vi.fn(() => h.histogram),
+  registerCounterWithLabels: vi.fn(() => h.counter),
+}));
+
+import { observeSessionLeg } from '../session-metrics';
+
+beforeEach(() => {
+  h.histogram.observe.mockClear();
+  h.counter.inc.mockClear();
+});
+
+describe('observeSessionLeg — civitai_app_session_resolution_* wiring', () => {
+  it('observes the duration histogram on every outcome (labeled leg + outcome)', () => {
+    observeSessionLeg('identity', 'hit', 0.02);
+    expect(h.histogram.observe).toHaveBeenCalledWith({ leg: 'identity', outcome: 'hit' }, 0.02);
+    expect(h.counter.inc).not.toHaveBeenCalled(); // a hit is not a timeout
+  });
+
+  // The coordinator-required assertion: the timeout PATH increments session_resolution_timeouts_total.
+  it('increments the timeouts counter ONLY on a timeout outcome (labeled by leg)', () => {
+    observeSessionLeg('identity', 'timeout', 1.5);
+    expect(h.histogram.observe).toHaveBeenCalledWith(
+      { leg: 'identity', outcome: 'timeout' },
+      1.5
+    );
+    expect(h.counter.inc).toHaveBeenCalledWith({ leg: 'identity' });
+    expect(h.counter.inc).toHaveBeenCalledTimes(1);
+  });
+
+  it('increments the timeouts counter per leg (identity / jwks / revocation)', () => {
+    observeSessionLeg('jwks', 'timeout', 2.5);
+    observeSessionLeg('revocation', 'timeout', 2.0);
+    expect(h.counter.inc).toHaveBeenCalledWith({ leg: 'jwks' });
+    expect(h.counter.inc).toHaveBeenCalledWith({ leg: 'revocation' });
+    expect(h.counter.inc).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT increment the counter on error / miss outcomes (only real timeouts)', () => {
+    observeSessionLeg('identity', 'error', 0.5);
+    observeSessionLeg('revocation', 'error', 0.1);
+    observeSessionLeg('identity', 'miss', 0.03);
+    expect(h.counter.inc).not.toHaveBeenCalled();
+    expect(h.histogram.observe).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/server/auth/__tests__/session-metrics.test.ts
+++ b/src/server/auth/__tests__/session-metrics.test.ts
@@ -37,12 +37,16 @@ describe('observeSessionLeg — civitai_app_session_resolution_* wiring', () => 
     expect(h.counter.inc).toHaveBeenCalledTimes(1);
   });
 
-  it('increments the timeouts counter per leg (identity / jwks / revocation)', () => {
+  it('increments the timeouts counter per leg (all five legs)', () => {
     observeSessionLeg('jwks', 'timeout', 2.5);
     observeSessionLeg('revocation', 'timeout', 2.0);
+    observeSessionLeg('identity-by-id', 'timeout', 1.5);
+    observeSessionLeg('hub-write', 'timeout', 1.5);
     expect(h.counter.inc).toHaveBeenCalledWith({ leg: 'jwks' });
     expect(h.counter.inc).toHaveBeenCalledWith({ leg: 'revocation' });
-    expect(h.counter.inc).toHaveBeenCalledTimes(2);
+    expect(h.counter.inc).toHaveBeenCalledWith({ leg: 'identity-by-id' });
+    expect(h.counter.inc).toHaveBeenCalledWith({ leg: 'hub-write' });
+    expect(h.counter.inc).toHaveBeenCalledTimes(4);
   });
 
   it('does NOT increment the counter on error / miss outcomes (only real timeouts)', () => {

--- a/src/server/auth/__tests__/session-verifier.test.ts
+++ b/src/server/auth/__tests__/session-verifier.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SessionClaims } from '@civitai/auth';
+
+// Leg 3 of the SPOF fix: the sysRedis revocation read is now bounded by withSysReadDeadline and FAILS OPEN on
+// a timeout (a revocation-check stall must never block login), while emitting the revocation-leg metric.
+const h = vi.hoisted(() => ({
+  observeSessionLeg: vi.fn(),
+  hGet: vi.fn(),
+  get: vi.fn(),
+  withSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  logSysRedisFailOpen: vi.fn(),
+}));
+
+// session-verifier constructs an AuthVerifier at module load — stub the package (we only exercise isRevoked).
+vi.mock('@civitai/auth', () => ({ createAuthVerifier: () => ({}) }));
+vi.mock('~/server/auth/session-metrics', () => ({ observeSessionLeg: h.observeSessionLeg }));
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: h.logSysRedisFailOpen }));
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { hGet: h.hGet, get: h.get },
+  REDIS_SYS_KEYS: { SESSION: { TOKEN_STATE: 'sys:token-state', ALL: 'sys:all' } },
+  withSysReadDeadline: h.withSysReadDeadline,
+}));
+
+import { isRevoked } from '../session-verifier';
+
+const claims = (over: Partial<SessionClaims> = {}): SessionClaims =>
+  ({ jti: 't7', signedAt: 1000, ...over } as SessionClaims);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.withSysReadDeadline.mockImplementation((p) => p); // transparent by default
+  h.hGet.mockResolvedValue(null);
+  h.get.mockResolvedValue(null);
+});
+
+describe('isRevoked — bounded revocation read (leg 3)', () => {
+  it('returns false and records outcome "hit" when the token is not revoked', async () => {
+    expect(await isRevoked(claims())).toBe(false);
+    expect(h.observeSessionLeg).toHaveBeenCalledWith('revocation', 'hit', expect.any(Number));
+  });
+
+  it('returns true when TOKEN_STATE is "invalid" (explicit logout/ban)', async () => {
+    h.hGet.mockResolvedValue('invalid');
+    expect(await isRevoked(claims())).toBe(true);
+    expect(h.observeSessionLeg).toHaveBeenCalledWith('revocation', 'hit', expect.any(Number));
+  });
+
+  it('returns true when a global SESSION.ALL cutoff is newer than the token', async () => {
+    h.get.mockResolvedValue(new Date(5000).toISOString()); // cutoff 5000 > signedAt 1000
+    expect(await isRevoked(claims({ signedAt: 1000 }))).toBe(true);
+  });
+
+  it('FAILS OPEN (false) on a read-deadline timeout and records outcome "timeout"', async () => {
+    // withSysReadDeadline rejects with a "…read timed out after Nms" Error when the deadline trips.
+    h.withSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+    expect(await isRevoked(claims())).toBe(false); // a stalled revocation check must NOT block login
+    expect(h.observeSessionLeg).toHaveBeenCalledWith('revocation', 'timeout', expect.any(Number));
+    expect(h.logSysRedisFailOpen).toHaveBeenCalled();
+  });
+
+  it('FAILS OPEN (false) on a generic read error and records outcome "error"', async () => {
+    h.withSysReadDeadline.mockRejectedValue(new Error('ECONNRESET'));
+    expect(await isRevoked(claims())).toBe(false);
+    expect(h.observeSessionLeg).toHaveBeenCalledWith('revocation', 'error', expect.any(Number));
+  });
+
+  it('returns false without reading when the token has no jti', async () => {
+    expect(await isRevoked(claims({ jti: undefined }))).toBe(false);
+    expect(h.withSysReadDeadline).not.toHaveBeenCalled();
+    expect(h.observeSessionLeg).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/auth/session-client.ts
+++ b/src/server/auth/session-client.ts
@@ -18,6 +18,11 @@ export const sessionClient = createSessionClient({
   isRevoked,
   onIdentityLeg: (outcome, durationSeconds) => observeSessionLeg('identity', outcome, durationSeconds),
   onJwksLeg: (outcome, durationSeconds) => observeSessionLeg('jwks', outcome, durationSeconds),
+  // The API-key/OAuth by-id read + the hub write paths hairpin too (bearer-token.ts, App Blocks, ban/logout) —
+  // now internally routed + bounded by hubFetch; instrument them under their own leg labels.
+  onIdentityByIdLeg: (outcome, durationSeconds) =>
+    observeSessionLeg('identity-by-id', outcome, durationSeconds),
+  onHubWriteLeg: (outcome, durationSeconds) => observeSessionLeg('hub-write', outcome, durationSeconds),
 });
 // Session-token lifecycle (rolling refresh / revoke) — the hub contract lives in the package, not inline here.
 const sessionTokenClient = createSessionTokenClient();

--- a/src/server/auth/session-client.ts
+++ b/src/server/auth/session-client.ts
@@ -3,6 +3,7 @@ import { createSessionClient, createSessionTokenClient, sessionCookieName } from
 import { setSessionCookie, clearLegacyCookies, type CookieWritable } from './civ-cookie';
 import { isRevoked } from './session-verifier';
 import { decodeTokenClaim } from './token-claims';
+import { observeSessionLeg } from './session-metrics';
 
 // The main app's handle to the centralized auth hub (thin-session model — docs/main-app-auth-cutover.md).
 // Validation routes through this client (getHubSession) instead of next-auth's jwt()/session(); refresh +
@@ -10,7 +11,14 @@ import { decodeTokenClaim } from './token-claims';
 
 // Inject the shared revocation check so the read path rejects a logged-out/banned token even on a cache hit
 // (otherwise a revoked civ-token resolves until the session:data2 entry is re-warmed). See session-verifier.ts.
-export const sessionClient = createSessionClient({ isRevoked });
+// Also inject the leg-instrumentation callbacks so the identity fetch + JWKS verify are timed on the CALLING
+// app (the hub can't see this hairpin) — see session-metrics.ts. The package emits the raw timings; we record
+// them to prom-client here.
+export const sessionClient = createSessionClient({
+  isRevoked,
+  onIdentityLeg: (outcome, durationSeconds) => observeSessionLeg('identity', outcome, durationSeconds),
+  onJwksLeg: (outcome, durationSeconds) => observeSessionLeg('jwks', outcome, durationSeconds),
+});
 // Session-token lifecycle (rolling refresh / revoke) — the hub contract lives in the package, not inline here.
 const sessionTokenClient = createSessionTokenClient();
 

--- a/src/server/auth/session-metrics.ts
+++ b/src/server/auth/session-metrics.ts
@@ -1,0 +1,53 @@
+// Session-resolution observability — the LEADING INDICATOR for the app→hub hairpin SPOF class.
+//
+// WHY this lives in the calling app (not civitai-auth): a transient CF-edge blip stalled every authed request
+// 40-90s while the hub itself was healthy — so the stall was INVISIBLE to the hub's own metrics. Only the app
+// making the app→CF→hub identity/JWKS hops (and the sysRedis revocation read) can see this. These two metrics
+// turn "authed traffic is mysteriously slow" into a one-glance diagnosis: a spike in the `identity`/`jwks` leg
+// duration + a climbing `session_resolution_timeouts_total{leg=...}` points straight at the hop.
+//
+// Registered on the shared `civitai_app_*` prom-client registry (`~/server/prom/client`, exposed by
+// /api/metrics), same as trpc_procedure_duration etc. Cardinality-safe: only bounded `leg` / `outcome` labels,
+// NEVER per-user. The package emits the raw timings via injected callbacks (it stays infra-dep-free); this
+// module owns the prom-client wiring.
+import { registerHistogram, registerCounterWithLabels } from '~/server/prom/client';
+
+export type SessionLeg = 'identity' | 'jwks' | 'revocation';
+export type SessionLegOutcome = 'hit' | 'miss' | 'timeout' | 'error';
+
+// Sub-ms (cache/crypto) → ~30s (a fully-stalled hairpin, the incident tail). Covers the whole span so a
+// 40-90s stall lands in the +Inf bucket and the p99 is unmistakable.
+const SESSION_RESOLUTION_BUCKETS = [0.005, 0.05, 0.5, 1, 2, 5, 10, 30] as const;
+
+const durationHistogram = registerHistogram({
+  name: 'session_resolution_duration_seconds',
+  help:
+    'Duration (seconds) of each session-resolution leg as seen by the CALLING app — the app→hub identity ' +
+    'fetch, the JWKS verify/refetch, and the sysRedis revocation read. The hub cannot observe these hops. ' +
+    'Labeled by leg (identity|jwks|revocation) + outcome (hit|miss|timeout|error).',
+  labelNames: ['leg', 'outcome'] as const,
+  buckets: [...SESSION_RESOLUTION_BUCKETS],
+});
+
+const timeoutsCounter = registerCounterWithLabels({
+  name: 'session_resolution_timeouts_total',
+  help:
+    'Count of session-resolution legs that hit their bounded-wait timeout (identity AbortSignal.timeout, ' +
+    'JWKS timeoutDuration, or the sysRedis read deadline). Labeled by leg. The leading indicator for the ' +
+    'app→hub hairpin SPOF — a nonzero rate means a leg is stalling.',
+  labelNames: ['leg'] as const,
+});
+
+/**
+ * Record one session-resolution leg. Always observes the duration histogram; additionally increments the
+ * timeout counter when the outcome is a bounded-wait timeout. Cheap + total (never throws) — it runs on the
+ * authed hot path, so callers wire it directly into the package's injected leg callbacks.
+ */
+export function observeSessionLeg(
+  leg: SessionLeg,
+  outcome: SessionLegOutcome,
+  durationSeconds: number
+): void {
+  durationHistogram.observe({ leg, outcome }, durationSeconds);
+  if (outcome === 'timeout') timeoutsCounter.inc({ leg });
+}

--- a/src/server/auth/session-metrics.ts
+++ b/src/server/auth/session-metrics.ts
@@ -12,7 +12,10 @@
 // module owns the prom-client wiring.
 import { registerHistogram, registerCounterWithLabels } from '~/server/prom/client';
 
-export type SessionLeg = 'identity' | 'jwks' | 'revocation';
+// `identity` = token cookie path (getSessionUser); `identity-by-id` = API-key/OAuth/legacy by-userId read
+// (getSessionUserById); `hub-write` = the invalidate/refresh/invalidateAll hub writes; `jwks` = ES256 verify
+// key fetch; `revocation` = sysRedis TOKEN_STATE/ALL read.
+export type SessionLeg = 'identity' | 'identity-by-id' | 'hub-write' | 'jwks' | 'revocation';
 export type SessionLegOutcome = 'hit' | 'miss' | 'timeout' | 'error';
 
 // Sub-ms (cache/crypto) → ~30s (a fully-stalled hairpin, the incident tail). Covers the whole span so a
@@ -23,8 +26,9 @@ const durationHistogram = registerHistogram({
   name: 'session_resolution_duration_seconds',
   help:
     'Duration (seconds) of each session-resolution leg as seen by the CALLING app — the app→hub identity ' +
-    'fetch, the JWKS verify/refetch, and the sysRedis revocation read. The hub cannot observe these hops. ' +
-    'Labeled by leg (identity|jwks|revocation) + outcome (hit|miss|timeout|error).',
+    'fetch (cookie + by-userId API-key/OAuth), the hub invalidate/refresh writes, the JWKS verify/refetch, ' +
+    'and the sysRedis revocation read. The hub cannot observe these hops. Labeled by leg ' +
+    '(identity|identity-by-id|hub-write|jwks|revocation) + outcome (hit|miss|timeout|error).',
   labelNames: ['leg', 'outcome'] as const,
   buckets: [...SESSION_RESOLUTION_BUCKETS],
 });

--- a/src/server/auth/session-verifier.ts
+++ b/src/server/auth/session-verifier.ts
@@ -7,21 +7,35 @@
 // fail OPEN — a sysRedis blip must not 500 every authed request.
 import { createAuthVerifier } from '@civitai/auth';
 import type { SessionClaims } from '@civitai/auth';
-import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
+import { observeSessionLeg } from './session-metrics';
 
 export async function isRevoked(claims: SessionClaims): Promise<boolean> {
   const tokenId = claims.jti;
   if (!tokenId) return false; // can't check — fail open
+  // Bound the revocation read with the shared wall-clock deadline (REDIS_SYS_READ_TIMEOUT_MS, default 2000ms):
+  // the sys client carries NO socketTimeout (0, to dodge the reconnect-storm wedge on the single-replica
+  // backend), so on a silent half-open these two reads could park the whole authed request until OS TCP
+  // keepalive (~minutes). withSysReadDeadline races them so a stall FAILS OPEN fast — a revocation-check
+  // timeout must never block login (matches the existing catch → return false posture, just bounded now).
+  const start = performance.now();
   try {
-    const [state, allStr] = await Promise.all([
-      sysRedis.hGet(REDIS_SYS_KEYS.SESSION.TOKEN_STATE, tokenId),
-      sysRedis.get(REDIS_SYS_KEYS.SESSION.ALL),
-    ]);
+    const [state, allStr] = await withSysReadDeadline(
+      Promise.all([
+        sysRedis.hGet(REDIS_SYS_KEYS.SESSION.TOKEN_STATE, tokenId),
+        sysRedis.get(REDIS_SYS_KEYS.SESSION.ALL),
+      ])
+    );
+    observeSessionLeg('revocation', 'hit', (performance.now() - start) / 1000);
     if (state === 'invalid') return true;
     if (allStr && claims.signedAt && new Date(allStr).getTime() > claims.signedAt) return true;
     return false;
   } catch (err) {
+    // withSysReadDeadline rejects with a "…read timed out after Nms" Error on the deadline; anything else is a
+    // real read error. Both fail OPEN (return false) — the timeout is just the bounded, observable variant.
+    const timedOut = err instanceof Error && /timed out/.test(err.message);
+    observeSessionLeg('revocation', timedOut ? 'timeout' : 'error', (performance.now() - start) / 1000);
     logSysRedisFailOpen('read-degraded', 'session-verifier isRevoked', err, {
       tokenId,
       userId: claims.user?.id,


### PR DESCRIPTION
## Incident (2026-07-01)
A transient Cloudflare-edge blip stalled **all authenticated traffic 40-90s**. Root cause: the authed session-resolution path hairpins out through Cloudflare to reach the **in-cluster** `civitai-auth` hub, and has **no timeouts**.

On a session-cache miss, resolution does a **JWKS verify** (`AUTH_JWKS_URI`) + an **identity fetch** to `trustedHubBase(claims.iss)`. Both `AUTH_JWKS_URI` and `claims.iss` are the **public** `https://auth.civitai.com`, so each call leaves the cluster → CF → back through Traefik to the same-cluster `civitai-auth` svc (`civitai-auth.civitai-auth.svc.cluster.local:3000`). None were bounded; the sysRedis revocation reads carry socket timeout `0`. Every *other* dp-prod dependency already uses an internal `*.svc.cluster.local` URL — auth was the only hairpin, on the hot path for **all** authed traffic.

This PR closes the incident class for **both** auth paths: the **cookie** session path (`getSessionUser`) **and** the **bearer/API-key/OAuth** path (`getSessionUserById` + the hub write paths), which go through `hubFetch` and had the same unbounded public hairpin.

**Hard constraint honored:** `AUTH_JWT_ISSUER` is **unchanged** — it's client-facing (browser redirect URLs + the token `iss` claim). Only the server-side fetches are re-pointed.

## The fix — route server-side fetches in-cluster + bound every leg

### Leg 1 — JWKS (env-only + explicit timeout)
`AUTH_JWKS_URI` is server-only (read only in `verify.ts`, non-`NEXT_PUBLIC`); the deploy re-points it to the internal svc. Code adds explicit jose `timeoutDuration: 2500ms` on `createRemoteJWKSet` (jose default 5000ms) so an unknown-kid refetch can't hang.

### Leg 2 — Cookie identity (new `AUTH_HUB_INTERNAL_URL`, anti-spoof guard PRESERVED)
New server-only env `AUTH_HUB_INTERNAL_URL` (non-`NEXT_PUBLIC`). In `session-client.ts` the `trustedHubBase(claims.iss)` validation is kept **exactly as-is** — it still rejects a spoofed/untrusted issuer, so the bearer only ever leaves for an operator-configured origin. **Only after** that passes (iss trusted) **and** `AUTH_HUB_INTERNAL_URL` is set do we use it as the **fetch** base: *validate against public iss → fetch from internal svc*. Backward-compatible (unset → public iss base). Bounded by `AbortSignal.timeout(1500ms)` → null on timeout (unchanged miss behavior).

### Leg 2b — Bearer/API-key/OAuth path (`hubFetch` internal routing + timeout) — NEW
`getSessionUserById` (the hot read for **every** API-key/OAuth request — `bearer-token.ts:33` — and App Blocks) plus the write paths (`invalidate`/`refresh`/`invalidateAll`) route through `hubFetch` → the public `AUTH_JWT_ISSUER`, with no timeout: the same unbounded hairpin, unfixed by the cookie-leg change. `hubFetch` (`hub.ts`) now:
- **Routes in-cluster** via `AUTH_HUB_INTERNAL_URL` when set (else the public issuer). **No spoof concern** — `hubFetch` always targets the operator-configured trusted issuer, never an attacker-controlled `claims.iss` — so it prefers the internal address unconditionally. `hubBaseUrl()` (used for URL/redirect *building* in spoke-guard / first-party-bridge) stays the **public** origin, untouched.
- **Bounds the hop** with `AbortSignal.timeout(1500ms)`, respecting a caller-armed signal (`session-token-client` keeps its own 2500ms). This also closes the device/session-token/impersonation/first-party-bridge hairpins for free.
- **Cookie-safe:** verified the hub derives its cookie `Domain` from `AUTH_JWT_ISSUER` (unchanged) + `AUTH_COOKIE_DOMAIN`, never the request `Host` (`apps/auth/.../cookie.ts`), and token-bearing responses (`/switch`, `/refresh`) return the token in the JSON **body** (the app sets the cookie), not via the hub's Set-Cookie. So the internal `Host` is accepted.

**`Host` header:** not needed for `/api/auth/identity` — it authenticates by bearer / `AUTH_INTERNAL_TOKEN` and does not gate on `Host` (`isInternalRequest`, and an explicit no-CORS server-to-server path); `/api/auth/jwks` is public keys.

### Leg 3 — Revocation read (bounded, fail-open) — behavior CHANGE, stated honestly
The sysRedis reads in `isRevoked` are now wrapped in the existing shared `withSysReadDeadline` (`REDIS_SYS_READ_TIMEOUT_MS`, **default 2000ms, confirmed active in prod**) and fail **open** (return `false`).

**This is a deliberate availability tradeoff, not a no-op:** on a sysRedis half-open, base `main` **hung** the whole authed request (until OS TCP keepalive, ~minutes); this PR instead **times out at ~2s and fail-open GRANTS** — so for that ~2s window a just-banned / just-logged-out token could still resolve on a cache hit until the read recovers. That is the same fail-open posture the existing `catch` already had for a *thrown* redis error (a revocation-check outage must not 500/lock out every authed request); we are bounding the *stall* variant to match it. The exposure is bounded (≤ the read deadline, and only while sysRedis is degraded); the alternative (fail-closed) would turn a redis blip into a fleet-wide logout. Flagging explicitly because it widens the ban/logout race very slightly under sysRedis degradation.

## Observability (added — the leading indicator this incident class lacked)
The hub was healthy; the stall lived in the app→CF→hub hop, visible **only** to the calling app. Two cardinality-safe metrics on the `civitai_app_*` registry (`/api/metrics`):
- `civitai_app_session_resolution_duration_seconds` — histogram, labels `leg="identity|identity-by-id|hub-write|jwks|revocation"`, `outcome="hit|miss|timeout|error"`.
- `civitai_app_session_resolution_timeouts_total` — counter, label `leg`, incremented on a leg timeout.

Emitted from the app via **injected callbacks** so `@civitai/auth` stays infra-dep-free; no per-user labels. The callback invocations are wrapped in `safeInvoke` (try/catch) so a throwing metric callback can **never** corrupt the auth result (a throw after a successful fetch would otherwise bubble → return null → a valid session appears unauthenticated; in verify → re-throw → fail-closed logout). `observeSessionLeg` never throws today; this makes the guarantee structural.

> Note: the metrics + defensive-wrap were requested by the review coordinator (not the original brief). They directly serve the reliability goal and are self-contained. JWKS-leg duration is the ES256-via-JWKS verify time (sub-ms crypto normally; network cost surfaces only on an unknown-kid refetch) — the clean signals are the `timeout` counter and the `hit` duration tail.

## Security guards preserved
- **iss-spoof still rejected** even with `AUTH_HUB_INTERNAL_URL` set — the override never bypasses `trustedHubBase` (test: fail-closed, no fetch). The `hubFetch` internal routing has no spoof surface (fixed trusted issuer, never `claims.iss`).
- ES256 alg-pinning + issuer/audience in `verify.ts` untouched; JWKS instrumentation re-throws the verify error unchanged.
- Throwing-callback tests prove auth still succeeds (cookie, by-id, and verify paths).

## Client-bundle safety proof
- `AUTH_JWKS_URI` / `AUTH_HUB_INTERNAL_URL` are **not** `NEXT_PUBLIC_*`, read only in server modules via lazy `loadAuthEnv()`. No file references `process.env.AUTH_HUB_INTERNAL_URL`/`AUTH_JWKS_URI` directly (nothing inline-able).
- Browser entry `@civitai/auth/client` is explicitly env/jose/redis-free (re-exports only pure contracts); the main `@civitai/auth` entry is structurally server-only (`@civitai/redis` → `node:net`).
- **Full `next build` + `grep svc.cluster.local .next/static/` not run** (heavy on this host) — recommend adding that grep as a CI gate. Static analysis is conclusive.

## Verification (honest)
- `@civitai/auth` package: **60 passed** (`session-client` 38, `verify` 17, `timing` 5) — includes a real-`AbortSignal.timeout` fail-open test, internal-routing (cookie + by-id), iss-spoof-rejected, and throwing-callback-safe tests.
- App auth (`src/server/auth`): **74 passed** across 10 files (incl. `session-metrics`, `session-verifier` revocation fail-open/timeout, `ban-session-revocation`, `session-client`).
- `tsc --noEmit` (full program, after `prisma generate`): **zero errors in any file this PR touches**. The tree has pre-existing baseline errors in untouched `webhooks/*` + `types/router.ts` (`@prisma/client` slim-schema artifact) — not introduced here.
- Not deployed. Not verified against a live prod click-path (code + tests only).

## Behavior deltas active on merge (before the env change)
The code ships with the timeouts **active** regardless of the env change:
- The identity `AbortSignal.timeout(1500ms)` + `hubFetch` 1500ms + JWKS 2500ms + revocation 2000ms deadline all apply to the **still-public hairpin** the moment this releases. That is **strictly safer** than base (a stall now fails fast instead of hanging) but is **not byte-identical to base** — a hub/edge slower than these bounds will now time out (→ null / fail-open) where base would have waited. Intended.
- Internal *routing* only activates once `AUTH_HUB_INTERNAL_URL` / `AUTH_JWKS_URI` are set (below).

## Deploy step (SEPARATE — do NOT apply before this code releases)
Sequencing: **code must merge + release BEFORE `AUTH_HUB_INTERNAL_URL` is set** (the code must exist to honor it). `AUTH_JWKS_URI` can change independently but coordinate.

SOPS env change in **datapacket-talos** `clusters/production/apps/civitai-dp-prod/secrets/prod-env.enc.yaml` (`sops` CLI only):
```
AUTH_JWKS_URI:         http://civitai-auth.civitai-auth.svc.cluster.local:3000/api/auth/jwks   # was https://auth.civitai.com/api/auth/jwks
AUTH_HUB_INTERNAL_URL: http://civitai-auth.civitai-auth.svc.cluster.local:3000                 # new
# AUTH_JWT_ISSUER: https://auth.civitai.com  <- UNCHANGED (client-facing)
```
Confirmed civitai-auth serves `/api/auth/jwks` + `/api/auth/identity` on the internal svc `:3000` (SvelteKit adapter-node; svc `civitai-auth` port 3000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
