### PR TITLE
fix(orchestrator): bound the getWorkflow status-poll read with a timeout (cap park HOL-blocking)

### DIFF
--- a/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
+++ b/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
@@ -115,6 +115,29 @@ describe('getWorkflow error mapping', () => {
     expect((err as TRPCError).message).toMatch(/temporarily unavailable/i);
   });
 
+  it('maps a status-less TimeoutError RESOLVE (the real pre-response abort shape) to 503', async () => {
+    // LOAD-BEARING contract: createOrchestratorClient does NOT set `throwOnError`, so on a
+    // fetch abort BEFORE response headers (the common park shape) the @civitai/client
+    // RESOLVES with `{ data: undefined, error: <TimeoutError>, response: undefined }` — it
+    // does NOT reject. So the fired backstop lands in the `if(!data)` default branch, NOT
+    // the `.catch` above (which only the mid-body-read reject path hits). Assert that real
+    // runtime path maps to 503 and does NOT crash on the status-less error (undefined
+    // `error.status` → default → `error.detail?.startsWith` optional-chained →
+    // isUpstreamServerOrNetworkError matches `.name==='TimeoutError'`). This mirrors the
+    // resolve-shape lesson baked into submitWorkflow.timeout.test.ts.
+    mockGetWorkflow.mockResolvedValue({
+      data: undefined,
+      error: Object.assign(new Error('The operation was aborted due to timeout'), {
+        name: 'TimeoutError',
+      }),
+      response: undefined,
+    });
+    const err = await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch((e) => e);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+    expect((err as TRPCError).message).toMatch(/temporarily unavailable/i);
+  });
+
   it('passes an abort signal to the client so the read is bounded', async () => {
     // Guard the wiring: the backstop only works if getWorkflow actually hands the client
     // an AbortSignal. Without it a runaway read hangs unbounded (the pre-fix behavior).

--- a/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
+++ b/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
@@ -99,6 +99,32 @@ describe('getWorkflow error mapping', () => {
     expect(err).not.toBeInstanceOf(TRPCError);
   });
 
+  it('maps the read-backstop AbortSignal.timeout TimeoutError to 503 (statusUpdate poll)', async () => {
+    // The ORCHESTRATOR_GET_TIMEOUT_MS backstop aborts a runaway single-workflow read via
+    // AbortSignal.timeout(), which surfaces a DOMException named 'TimeoutError'.
+    // isUpstreamNetworkError matches `.name === 'TimeoutError'` → retry-able 503, so a
+    // parked getWorkflow poll can't pin an api-pool connection unbounded.
+    mockGetWorkflow.mockRejectedValue(
+      Object.assign(new Error('The operation was aborted due to timeout'), {
+        name: 'TimeoutError',
+      })
+    );
+    const err = await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch((e) => e);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+    expect((err as TRPCError).message).toMatch(/temporarily unavailable/i);
+  });
+
+  it('passes an abort signal to the client so the read is bounded', async () => {
+    // Guard the wiring: the backstop only works if getWorkflow actually hands the client
+    // an AbortSignal. Without it a runaway read hangs unbounded (the pre-fix behavior).
+    mockGetWorkflow.mockResolvedValue({ data: { id: 'wf-1', status: 'succeeded' } });
+    await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } });
+    expect(mockGetWorkflow).toHaveBeenCalledTimes(1);
+    const arg = mockGetWorkflow.mock.calls[0][0];
+    expect(arg.signal).toBeInstanceOf(AbortSignal);
+  });
+
   it('returns data on the success path untouched', async () => {
     mockGetWorkflow.mockResolvedValue({ data: { id: 'wf-1', status: 'succeeded' } });
     const data = await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } });

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -55,6 +55,21 @@ const ORCHESTRATOR_UNAVAILABLE_MESSAGE =
 // queryWorkflowsByTags, queue-status, admin) — every one a request-scoped read.
 const ORCHESTRATOR_QUERY_TIMEOUT_MS = 20_000;
 
+// Backstop deadline for the single-workflow orchestrator READ (getWorkflow). This is
+// the `orchestrator.statusUpdate` poll path (getWorkflowStatusUpdate → getWorkflow),
+// which the generation UI fires continuously while a workflow runs — so it is the most
+// re-fetchable read we have: a bounded poll simply re-polls on the next tick with no
+// lost state. Left unbounded, a single getWorkflow can park on an orchestrator hang and
+// pin an api-pool connection; because the pool is shared, enough parked polls
+// head-of-line-block every cheap endpoint (a 7ms buzz.getBuzzAccount was seen at 40s edge
+// during parks). Bounding it caps that park blast radius. Sized to match the sibling
+// query backstop (well above the healthy sub-second GET tail; the ~24s GET/status p99 is
+// the park itself), so it 503s essentially nothing today and fires only on the park tail;
+// tighten later once the healthy-tail p99 is confirmed via the latency dashboard. A fired
+// AbortSignal.timeout() surfaces a `TimeoutError`, which the existing getWorkflow catch /
+// default branch classifies via isUpstreamNetworkError → retry-able 503 (no new handling).
+const ORCHESTRATOR_GET_TIMEOUT_MS = 20_000;
+
 // Per-attempt backstop for the whatIf cost-estimate SUBMIT only (not generate). whatIf
 // (orchestrator.whatIfFromGraph) is a side-effect-free estimate that, on img2img inputs,
 // can hang ~30s on an orchestrator source-image-download step; with the default 3
@@ -143,7 +158,16 @@ export async function getWorkflow({
   query,
 }: Options<GetWorkflowData> & { token: string }) {
   const client = createOrchestratorClient(token);
-  const { data, error } = await clientGetWorkflow({ client, path, query }).catch((thrown) => {
+  const { data, error } = await clientGetWorkflow({
+    client,
+    path,
+    query,
+    // Read backstop: abort a runaway single-workflow read (see constant above). Mirrors
+    // queryWorkflows — the statusUpdate poll simply re-fetches, so bounding is safe and
+    // caps an orchestrator park from HOL-blocking the shared api pool. The resulting
+    // TimeoutError is caught below and mapped to a retry-able 503.
+    signal: AbortSignal.timeout(ORCHESTRATOR_GET_TIMEOUT_MS),
+  }).catch((thrown) => {
     // The generated client REJECTS (no `{ data, error }` result) when the fetch
     // itself fails — e.g. orchestrator unreachable. The statusUpdate poll fires
     // continuously, so a brief blip here otherwise becomes a wave of raw 500s


### PR DESCRIPTION
## What

Adds an `AbortSignal.timeout` read backstop (`ORCHESTRATOR_GET_TIMEOUT_MS = 20s`) to the `getWorkflow` service function — the last orchestrator read with **no deadline**.

`getWorkflow` is the `orchestrator.statusUpdate` poll path (`getWorkflowStatusUpdate → getWorkflow`) that the generation UI fires continuously while a workflow runs. Its sibling `queryWorkflows` (the `queryGeneratedImages` feed) already carries this exact backstop, and #2848 bounded the `whatIf` submit — but a single-workflow GET could still park unbounded on an orchestrator hang and pin an api-pool connection.

## Why

Because the api pool is **shared**, enough parked polls head-of-line-block every cheap endpoint (a 7ms `buzz.getBuzzAccount` was observed at 40s edge during these parks), regressing `api-primary` p99 for **all** traffic. This is the recurring orchestrator-park HOL-blocking. This PR caps the park **blast radius** on the shared pool.

## How

- Mirror the `queryWorkflows` read backstop: a fresh `AbortSignal.timeout(20s)` on the `getWorkflow` client call.
- A status poll is the most re-fetchable read we have — a bounded poll simply re-polls next tick, no lost state — so bounding is safe.
- The fired `TimeoutError` flows through the **existing** `getWorkflow` catch / `if(!data)` default branch, which classifies it via `isUpstreamNetworkError` → a retry-able **503** (no new error handling). Verified against the real client contract: `createOrchestratorClient` does not set `throwOnError`, so a pre-response abort **resolves** with `{ error: <TimeoutError>, response: undefined }` (not a reject) and maps to 503 via the default branch without crashing on the status-less error. A mid-body abort rejects → `.catch` → 503. Both paths covered.

## Scope / risk

- Bounds `getWorkflow` **service-function** callers (statusUpdate poll, comics/blocks routers, training/model-version controllers, the training background job, `poll-iteration`). The scanner services import the **raw** `@civitai/client` `getWorkflow` directly and are **not** affected by this change.
- Universally safe for reads (re-fetchable); the one background-job caller already wraps getWorkflow in try/catch → log → continue, so a 20s throw is strictly better than hanging a concurrency slot.
- **Primary residual risk:** 20s sits *below* the current ~24s GET/status p99. The thesis is that that p99 tail **is** the park (healthy GET is sub-second), so it 503s ~nothing today — but that's unconfirmed until observed post-deploy. Low blast radius (re-fetchable poll; single-constant revert; shows as a 503 spike if wrong). Can be tightened *or* loosened once the healthy-tail p99 is confirmed on the latency dashboard.
- **Mitigation only.** Root fix = orch #261 (stamp source dims / bound the download); structural fix = isolating the generation API onto its own pool (orchestrator-gateway spin-out).

## Tests

Extend `workflows.error-mapping.test.ts` (15 pass; sibling `submitWorkflow.timeout.test.ts` 7 still green):
- `getWorkflow` maps the read-backstop `AbortSignal.timeout` `TimeoutError` → 503 via the **reject** (`.catch`) path.
- …and via the **resolve** (`if(!data)` default) path — the real pre-response abort shape (no `throwOnError`), the runtime contract that matters.
- Wiring guard: `getWorkflow` hands the client an `AbortSignal` (without it the read is unbounded).

## Audit

Adversarially audited (`/audit-pr 2883`) — verdict **safe to merge**, no blockers. Both abort→503 paths traced through the generated client, all affected callers confirmed to tolerate the new throw. The two 🟡 findings (resolve-path test gap; 20s-below-p99 sizing) are addressed above (added the resolve-path test; documented the sizing risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)