### PR TITLE
feat(orchestrator): observable READ path metrics (getWorkflow/queryWorkflows)

### DIFF
--- a/src/server/services/orchestrator/__tests__/orchestrator-read-metrics.test.ts
+++ b/src/server/services/orchestrator/__tests__/orchestrator-read-metrics.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import client from 'prom-client';
+
+// Use the REAL prom-client registry (via the telemetry package's register* helpers) instead of the global test
+// stub (src/__tests__/setup.ts), so we can READ BACK the actually-recorded histogram + counter values off the
+// shared `civitai_app_*` registry — the same registry /api/metrics exposes. This is the registry-introspection
+// analog of session-metrics.test.ts (which spies the register* returns). A file-level vi.mock overrides the
+// global stub for this module only.
+vi.mock('~/server/prom/client', async () => {
+  const pkg = await vi.importActual<typeof import('@civitai/telemetry/client')>(
+    '@civitai/telemetry/client'
+  );
+  return pkg;
+});
+
+import { observeOrchestratorRead } from '../orchestrator-read-metrics';
+// Importing session-metrics AGAINST THE SAME REAL REGISTRY proves the two modules register with NO
+// duplicate-metric-name collision (prom-client would otherwise conflict on a same-name re-register).
+import '~/server/auth/session-metrics';
+
+const DURATION = 'civitai_app_orchestrator_read_duration_seconds';
+const TIMEOUTS = 'civitai_app_orchestrator_read_timeouts_total';
+
+// The registry is a process-wide singleton and counters are monotonic, so every assertion reads a DELTA
+// (after − before) around the call rather than an absolute value.
+async function histCount(op: string, outcome: string): Promise<number> {
+  const metric = client.register.getSingleMetric(DURATION) as client.Histogram<string>;
+  const data = await metric.get();
+  const row = data.values.find(
+    (v) =>
+      v.metricName === `${DURATION}_count` && v.labels.op === op && v.labels.outcome === outcome
+  );
+  return (row?.value as number) ?? 0;
+}
+
+async function histSum(op: string, outcome: string): Promise<number> {
+  const metric = client.register.getSingleMetric(DURATION) as client.Histogram<string>;
+  const data = await metric.get();
+  const row = data.values.find(
+    (v) => v.metricName === `${DURATION}_sum` && v.labels.op === op && v.labels.outcome === outcome
+  );
+  return (row?.value as number) ?? 0;
+}
+
+async function timeoutCount(op: string): Promise<number> {
+  const metric = client.register.getSingleMetric(TIMEOUTS) as client.Counter<string>;
+  const data = await metric.get();
+  const row = data.values.find((v) => v.labels.op === op);
+  return (row?.value as number) ?? 0;
+}
+
+describe('observeOrchestratorRead — civitai_app_orchestrator_read_* wiring', () => {
+  it('registers both metrics on the shared registry (no name collision with session-metrics)', () => {
+    expect(client.register.getSingleMetric(DURATION)).toBeDefined();
+    expect(client.register.getSingleMetric(TIMEOUTS)).toBeDefined();
+    // The sibling module registered fine on the same registry.
+    expect(
+      client.register.getSingleMetric('civitai_app_session_resolution_duration_seconds')
+    ).toBeDefined();
+  });
+
+  it('observes the duration histogram on an ok outcome and does NOT touch the timeout counter', async () => {
+    const beforeCount = await histCount('getWorkflow', 'ok');
+    const beforeSum = await histSum('getWorkflow', 'ok');
+    const beforeTo = await timeoutCount('getWorkflow');
+
+    observeOrchestratorRead('getWorkflow', 'ok', 0.02);
+
+    expect(await histCount('getWorkflow', 'ok')).toBe(beforeCount + 1);
+    expect(await histSum('getWorkflow', 'ok')).toBeCloseTo(beforeSum + 0.02, 6);
+    // An ok read must not move the timeout counter.
+    expect(await timeoutCount('getWorkflow')).toBe(beforeTo);
+  });
+
+  it('increments the timeout counter ONLY on a timeout outcome (and still observes the histogram)', async () => {
+    const beforeCount = await histCount('getWorkflow', 'timeout');
+    const beforeTo = await timeoutCount('getWorkflow');
+
+    observeOrchestratorRead('getWorkflow', 'timeout', 20.1);
+
+    expect(await histCount('getWorkflow', 'timeout')).toBe(beforeCount + 1);
+    expect(await timeoutCount('getWorkflow')).toBe(beforeTo + 1);
+  });
+
+  it('does NOT increment the timeout counter on an error outcome', async () => {
+    const beforeCount = await histCount('queryWorkflows', 'error');
+    const beforeTo = await timeoutCount('queryWorkflows');
+
+    observeOrchestratorRead('queryWorkflows', 'error', 0.5);
+
+    expect(await histCount('queryWorkflows', 'error')).toBe(beforeCount + 1);
+    expect(await timeoutCount('queryWorkflows')).toBe(beforeTo);
+  });
+
+  it('increments the timeout counter per op (getWorkflow vs queryWorkflows are separate series)', async () => {
+    const beforeGet = await timeoutCount('getWorkflow');
+    const beforeQuery = await timeoutCount('queryWorkflows');
+
+    observeOrchestratorRead('queryWorkflows', 'timeout', 20.0);
+
+    expect(await timeoutCount('queryWorkflows')).toBe(beforeQuery + 1);
+    // The getWorkflow series is untouched by a queryWorkflows timeout.
+    expect(await timeoutCount('getWorkflow')).toBe(beforeGet);
+  });
+
+  it('never throws even if given odd input (total on the hot path)', () => {
+    expect(() =>
+      observeOrchestratorRead('getWorkflow', 'ok', Number.NaN)
+    ).not.toThrow();
+  });
+});

--- a/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
+++ b/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
@@ -4,9 +4,10 @@ import { TRPCError } from '@trpc/server';
 // Mock ONLY the generated client + the orchestrator client factory + env so we can
 // drive `getWorkflow` / `queryWorkflows` through their error branches. The real
 // `~/server/utils/errorHandling` loads so the actual TRPCError mapping is exercised.
-const { mockGetWorkflow, mockQueryWorkflows } = vi.hoisted(() => ({
+const { mockGetWorkflow, mockQueryWorkflows, mockObserveRead } = vi.hoisted(() => ({
   mockGetWorkflow: vi.fn(),
   mockQueryWorkflows: vi.fn(),
+  mockObserveRead: vi.fn(),
 }));
 
 vi.mock('@civitai/client', () => ({
@@ -28,6 +29,12 @@ vi.mock('~/server/services/orchestrator/client', () => ({
 }));
 
 vi.mock('~/env/other', () => ({ isDev: false, isProd: true }));
+
+// Spy the additive read metric so we can assert the outcome classification wired into workflows.ts without
+// touching the real prom registry (the metric's own value-recording is covered in orchestrator-read-metrics.test.ts).
+vi.mock('~/server/services/orchestrator/orchestrator-read-metrics', () => ({
+  observeOrchestratorRead: mockObserveRead,
+}));
 
 import { getWorkflow, queryWorkflows } from '~/server/services/orchestrator/workflows';
 
@@ -203,5 +210,57 @@ describe('queryWorkflows error mapping (queryGeneratedImages path)', () => {
     mockQueryWorkflows.mockRejectedValue(bug);
     const err = await queryWorkflows(baseQueryArgs).catch((e) => e);
     expect(err).toBe(bug);
+  });
+});
+
+describe('read metric wiring (observeOrchestratorRead) — additive instrumentation', () => {
+  it('records op=getWorkflow outcome=ok exactly once on the success path', async () => {
+    mockGetWorkflow.mockResolvedValue({ data: { id: 'wf-1', status: 'succeeded' } });
+    await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } });
+    expect(mockObserveRead).toHaveBeenCalledTimes(1);
+    const [op, outcome, seconds] = mockObserveRead.mock.calls[0];
+    expect(op).toBe('getWorkflow');
+    expect(outcome).toBe('ok');
+    expect(typeof seconds).toBe('number');
+  });
+
+  it('records outcome=timeout on the REJECT path (mid-body abort) for getWorkflow', async () => {
+    mockGetWorkflow.mockRejectedValue(
+      Object.assign(new Error('The operation was aborted due to timeout'), { name: 'TimeoutError' })
+    );
+    await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch(() => {});
+    expect(mockObserveRead).toHaveBeenCalledTimes(1);
+    expect(mockObserveRead.mock.calls[0][0]).toBe('getWorkflow');
+    expect(mockObserveRead.mock.calls[0][1]).toBe('timeout');
+  });
+
+  it('records outcome=timeout on the RESOLVE path (pre-response abort, { error: TimeoutError }) for getWorkflow', async () => {
+    mockGetWorkflow.mockResolvedValue({
+      data: undefined,
+      error: Object.assign(new Error('The operation was aborted due to timeout'), {
+        name: 'TimeoutError',
+      }),
+      response: undefined,
+    });
+    await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch(() => {});
+    expect(mockObserveRead).toHaveBeenCalledTimes(1);
+    expect(mockObserveRead.mock.calls[0][1]).toBe('timeout');
+  });
+
+  it('records outcome=error on a non-timeout upstream 5xx for getWorkflow', async () => {
+    mockGetWorkflow.mockResolvedValue({ data: undefined, error: { status: 500, detail: 'boom' } });
+    await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch(() => {});
+    expect(mockObserveRead).toHaveBeenCalledTimes(1);
+    expect(mockObserveRead.mock.calls[0][1]).toBe('error');
+  });
+
+  it('records op=queryWorkflows outcome=timeout on the reject path', async () => {
+    mockQueryWorkflows.mockRejectedValue(
+      Object.assign(new Error('The operation was aborted due to timeout'), { name: 'TimeoutError' })
+    );
+    await queryWorkflows(baseQueryArgs).catch(() => {});
+    expect(mockObserveRead).toHaveBeenCalledTimes(1);
+    expect(mockObserveRead.mock.calls[0][0]).toBe('queryWorkflows');
+    expect(mockObserveRead.mock.calls[0][1]).toBe('timeout');
   });
 });

--- a/src/server/services/orchestrator/orchestrator-read-metrics.ts
+++ b/src/server/services/orchestrator/orchestrator-read-metrics.ts
@@ -1,0 +1,73 @@
+// Orchestrator READ observability — the LEADING INDICATOR for an orchestrator park HOL-blocking the shared api pool.
+//
+// WHY this exists: the two orchestrator READ funnels (getWorkflow → orchestrator.statusUpdate poll, and
+// queryWorkflows → queryGeneratedImages feed) had NO named span and NO metric. When a single getWorkflow parks
+// on an orchestrator hang it pins an api-pool connection; because the pool is shared, enough parked polls
+// head-of-line-block every cheap endpoint (a 7ms buzz.getBuzzAccount was observed at the 40s edge during
+// parks). The getWorkflow read-backstop shipped in #2883 (ORCHESTRATOR_GET_TIMEOUT_MS = 20s) added a deadline
+// so a park now 503s instead of hanging unbounded — but that fire was INVISIBLE: the ONLY signal a park/timeout
+// happened was an indirect 503 rate blended in with every other cause. These two metrics turn "generation is
+// mysteriously slow / 503ing" into a one-glance diagnosis: a spike in the read-duration tail by `op` + a
+// climbing `orchestrator_read_timeouts_total{op=...}` points straight at the parked read funnel, and the healthy
+// read-latency tail (the sub-cap buckets) tells us whether the 20s backstop is sized right.
+//
+// Registered on the shared `civitai_app_*` prom-client registry (`~/server/prom/client`, exposed by
+// /api/metrics), same as session_resolution_* / trpc_procedure_duration. Cardinality-safe: only the bounded
+// `op` / `outcome` labels, NEVER per-user or per-workflowId. This module owns the prom-client wiring; the
+// callers in workflows.ts time only the orchestrator client network call and hand the raw timing here.
+import { registerHistogram, registerCounterWithLabels } from '~/server/prom/client';
+
+// The two orchestrator READ funnels in workflows.ts. `getWorkflow` = the single-workflow read behind the
+// orchestrator.statusUpdate poll (fires continuously while a workflow runs — the most re-fetchable read we
+// have); `queryWorkflows` = the multi-workflow list behind queryGeneratedImages / queue-status / admin.
+export type OrchestratorReadOp = 'getWorkflow' | 'queryWorkflows';
+// `ok` = a successful data result; `error` = any non-timeout failure (rejected non-timeout, or a !data result
+// with a non-2xx status / status-less non-timeout error); `timeout` = the fired read-backstop AbortSignal.timeout
+// (ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS).
+export type OrchestratorReadOutcome = 'ok' | 'error' | 'timeout';
+
+// Sub-ms (cache/warm-hit read) → the 20s backstop cap → a >20s park in +Inf. Deliberately carries an EXTRA 20
+// bucket vs session_resolution_* so the p99 straddles the ORCHESTRATOR_*_TIMEOUT_MS cap cleanly: everything at
+// or under the cap lands ≤20, anything that beat the deadline (or a mid-body abort just past it) lands in +Inf.
+const ORCHESTRATOR_READ_BUCKETS = [0.005, 0.05, 0.5, 1, 2, 5, 10, 20, 30] as const;
+
+const durationHistogram = registerHistogram({
+  name: 'orchestrator_read_duration_seconds',
+  help:
+    'Duration (seconds) of the orchestrator client READ network call — the getWorkflow (statusUpdate poll) ' +
+    'and queryWorkflows (queryGeneratedImages feed) funnels. Times ONLY the awaited orchestrator client call, ' +
+    'not the surrounding handler. Labeled by op (getWorkflow|queryWorkflows) + outcome (ok|error|timeout). ' +
+    'The sub-20 buckets are the healthy read-latency tail (use to size the ORCHESTRATOR_*_TIMEOUT_MS backstop); ' +
+    '+Inf is a park that beat the 20s cap.',
+  labelNames: ['op', 'outcome'] as const,
+  buckets: [...ORCHESTRATOR_READ_BUCKETS],
+});
+
+const timeoutsCounter = registerCounterWithLabels({
+  name: 'orchestrator_read_timeouts_total',
+  help:
+    'Count of orchestrator READ calls that hit their read-backstop deadline (the fired ' +
+    'ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS AbortSignal.timeout, #2883). Labeled by op ' +
+    '(getWorkflow|queryWorkflows). The leading indicator for an orchestrator park HOL-blocking the shared api ' +
+    'pool — a nonzero rate means a read funnel is parking and getting cut at the backstop.',
+  labelNames: ['op'] as const,
+});
+
+/**
+ * Record one orchestrator READ. Always observes the duration histogram (labeled by op + outcome); additionally
+ * increments the timeout counter when the outcome is the fired read-backstop timeout. Cheap + TOTAL (never
+ * throws) — it runs on the generation hot path (the statusUpdate poll + the image feed), so callers wire it in
+ * directly around the client call. Wrapped so a metrics-layer hiccup can never take down a read.
+ */
+export function observeOrchestratorRead(
+  op: OrchestratorReadOp,
+  outcome: OrchestratorReadOutcome,
+  durationSeconds: number
+): void {
+  try {
+    durationHistogram.observe({ op, outcome }, durationSeconds);
+    if (outcome === 'timeout') timeoutsCounter.inc({ op });
+  } catch {
+    // Observability must never break the read path. Swallow any prom-client error.
+  }
+}

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -25,6 +25,7 @@ import type {
   workflowUpdateSchema,
 } from '~/server/schema/orchestrator/workflows.schema';
 import { createOrchestratorClient } from '~/server/services/orchestrator/client';
+import { observeOrchestratorRead } from '~/server/services/orchestrator/orchestrator-read-metrics';
 import {
   isUpstreamNetworkError,
   isUpstreamServerOrNetworkError,
@@ -87,6 +88,23 @@ const ORCHESTRATOR_GET_TIMEOUT_MS = 20_000;
 // orchestrator-side root fix (stamp source dims / bound the download) is orch #261.
 const WHATIF_SUBMIT_ATTEMPT_TIMEOUT_MS = 8_000;
 
+// Classify an orchestrator READ failure as the fired read-backstop deadline (#2883,
+// ORCHESTRATOR_GET_TIMEOUT_MS / ORCHESTRATOR_QUERY_TIMEOUT_MS) vs any other error — for the additive read
+// metric ONLY (does NOT touch control flow / error mapping). A fired `AbortSignal.timeout()` surfaces as an
+// Error/DOMException named `TimeoutError` (or `AbortError` for a composed/manual abort). Because
+// `createOrchestratorClient` does NOT set `throwOnError`, this shape appears on BOTH the `.catch` reject path
+// (a mid-body abort rejects) AND the `if (!data)` resolve path (a pre-response abort RESOLVES with
+// `{ error: TimeoutError, response: undefined }`) — so both call sites classify with this. Walks the `.cause`
+// chain briefly since tRPC/undici nest the original.
+function isOrchestratorReadTimeout(e: unknown): boolean {
+  let cur = e as { name?: string; cause?: unknown } | undefined;
+  for (let depth = 0; depth < 4 && cur && typeof cur === 'object'; depth++) {
+    if (cur.name === 'TimeoutError' || cur.name === 'AbortError') return true;
+    cur = cur.cause as typeof cur;
+  }
+  return false;
+}
+
 export async function queryWorkflows({
   token,
   fromDate,
@@ -95,6 +113,10 @@ export async function queryWorkflows({
 }: z.output<typeof workflowQuerySchema> & { token: string; hideMatureContent: boolean }) {
   const client = createOrchestratorClient(token);
 
+  // Additive read instrumentation: time ONLY the orchestrator client network call (not the whole handler) and
+  // record exactly one observation — in the `.catch` on a reject, else on the resolve path below. See
+  // orchestrator-read-metrics.ts for why. Purely observational; does NOT change any control flow / mapping.
+  const readStart = performance.now();
   const { data, error } = await clientQueryWorkflows({
     client,
     // Read backstop: abort a runaway orchestrator query (see constant above). The
@@ -111,10 +133,23 @@ export async function queryWorkflows({
     // (fetch failed / ECONNREFUSED / timeout) is a transient upstream outage →
     // retry-able 503, not an app 500. An unrecognized throw (a real bug in our
     // code) is left to bubble as a 500.
+    observeOrchestratorRead(
+      'queryWorkflows',
+      isOrchestratorReadTimeout(thrown) ? 'timeout' : 'error',
+      (performance.now() - readStart) / 1000
+    );
     if (isUpstreamNetworkError(thrown))
       throw throwServiceUnavailableError(ORCHESTRATOR_UNAVAILABLE_MESSAGE, thrown);
     throw thrown;
   });
+  // Resolve path (the `.catch` did NOT run). A `!data` result is either the pre-response backstop abort
+  // (`{ error: TimeoutError, response: undefined }` → timeout) or an upstream error; a `data` result is a
+  // success. Exactly one observation per call is recorded (here XOR in the catch above).
+  observeOrchestratorRead(
+    'queryWorkflows',
+    data ? 'ok' : isOrchestratorReadTimeout(error) ? 'timeout' : 'error',
+    (performance.now() - readStart) / 1000
+  );
   if (!data) {
     switch (error.status) {
       case 400:
@@ -158,6 +193,10 @@ export async function getWorkflow({
   query,
 }: Options<GetWorkflowData> & { token: string }) {
   const client = createOrchestratorClient(token);
+  // Additive read instrumentation: time ONLY the orchestrator client network call and record exactly one
+  // observation (in the `.catch` on a reject, else on the resolve path below). This is the statusUpdate poll
+  // hot path — the read the #2883 backstop targets. Purely observational; does NOT change control flow.
+  const readStart = performance.now();
   const { data, error } = await clientGetWorkflow({
     client,
     path,
@@ -173,10 +212,23 @@ export async function getWorkflow({
     // continuously, so a brief blip here otherwise becomes a wave of raw 500s
     // (TypeError: fetch failed). A recognized network failure → retry-able 503;
     // an unrecognized throw (a real bug) bubbles as a 500.
+    observeOrchestratorRead(
+      'getWorkflow',
+      isOrchestratorReadTimeout(thrown) ? 'timeout' : 'error',
+      (performance.now() - readStart) / 1000
+    );
     if (isUpstreamNetworkError(thrown))
       throw throwServiceUnavailableError(ORCHESTRATOR_UNAVAILABLE_MESSAGE, thrown);
     throw thrown;
   });
+  // Resolve path (the `.catch` did NOT run). A `!data` result is either the pre-response backstop abort
+  // (`{ error: TimeoutError, response: undefined }` → timeout, the LOAD-BEARING resolve shape) or an upstream
+  // error; a `data` result is a success. Exactly one observation per call (here XOR in the catch above).
+  observeOrchestratorRead(
+    'getWorkflow',
+    data ? 'ok' : isOrchestratorReadTimeout(error) ? 'timeout' : 'error',
+    (performance.now() - readStart) / 1000
+  );
   if (!data) {
     switch (error.status) {
       case 400:


### PR DESCRIPTION
## What
Adds a named, cardinality-safe metric for the two orchestrator **READ** funnels so we can observe them for the first time:

- Histogram `civitai_app_orchestrator_read_duration_seconds{op,outcome}`
- Counter `civitai_app_orchestrator_read_timeouts_total{op}`

`op` ∈ `{getWorkflow, queryWorkflows}`, `outcome` ∈ `{ok, error, timeout}`.

New module `src/server/services/orchestrator/orchestrator-read-metrics.ts` mirrors the `src/server/auth/session-metrics.ts` pattern (from #2882): `registerHistogram` + `registerCounterWithLabels` on the shared `civitai_app_*` prom-client registry (exposed by `/api/metrics`), bounded labels only (never per-user/per-workflowId).

## Why
The `getWorkflow` read-backstop shipped in #2883 (`ORCHESTRATOR_GET_TIMEOUT_MS = 20s`) added a deadline so an orchestrator park now 503s instead of hanging unbounded and HOL-blocking the shared api pool. But that fire was **invisible** — `getWorkflow` (the `statusUpdate` poll) and `queryWorkflows` (the `queryGeneratedImages` feed) had no span and no metric, so the only signal a park/timeout happened was an indirect, blended 503 rate. This PR makes the READ path observable so we can (a) **see when the backstop actually fires** and (b) **measure the healthy read-latency tail** to decide whether 20s is the right threshold. The buckets carry an extra `20` (`...,10,20,30`) so the p99 straddles the cap cleanly and a >20s park lands in `+Inf`.

## How
`getWorkflow` + `queryWorkflows` in `workflows.ts` now time **only** the awaited orchestrator client network call (`performance.now()`), classify the outcome, and record **exactly one** observation per call:
- `timeout` — the fired `AbortSignal.timeout`. Because `createOrchestratorClient` does **not** set `throwOnError`, a pre-response abort **resolves** with `{ error: TimeoutError, response: undefined }` while a mid-body abort **rejects** — so a timeout is detected (via a small `.name === 'TimeoutError' | 'AbortError'` cause-walk) and recorded on **both** the `.catch` path and the `if (!data)` resolve path.
- `error` — any other failure (non-timeout reject, or `!data` with non-2xx/status-less non-timeout).
- `ok` — a successful `data` result.

`observeOrchestratorRead()` is **total / never-throws** (it runs on the generation hot path). This change is **purely additive** — no existing control flow, error mapping, or thrown `TRPCError` is touched.

## Dashboards / PromQL
- Healthy read p99 by op:
  `histogram_quantile(0.99, sum by (op, le) (rate(civitai_app_orchestrator_read_duration_seconds_bucket[5m])))`
- Timeout fire rate by op:
  `sum by (op) (rate(civitai_app_orchestrator_read_timeouts_total[5m]))`

## Tests
- New `__tests__/orchestrator-read-metrics.test.ts` asserts against the **real** prom-client registry (delta reads of histogram `_count`/`_sum` + the counter; timeout counter moves only on `outcome=timeout`, per-op isolation), and imports `session-metrics` on the same registry to prove **no duplicate-metric-name collision**.
- `__tests__/workflows.error-mapping.test.ts` gains wiring assertions (outcome `ok` on success; `timeout` on both the reject and the resolve abort shapes; `error` on a non-timeout 5xx; `queryWorkflows` op label).
- Full affected suite green: `orchestrator-read-metrics` + `workflows.error-mapping` + `submitWorkflow.timeout` + `session-metrics` — **37 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)