### PR TITLE
test(orchestrator): cover reject-path error outcome + cause-chain timeout (audit follow-up to #2884)

### DIFF
--- a/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
+++ b/src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts
@@ -263,4 +263,37 @@ describe('read metric wiring (observeOrchestratorRead) — additive instrumentat
     expect(mockObserveRead.mock.calls[0][0]).toBe('queryWorkflows');
     expect(mockObserveRead.mock.calls[0][1]).toBe('timeout');
   });
+
+  it('records outcome=error (NOT timeout) on a non-timeout network REJECT for getWorkflow', async () => {
+    // The reject `.catch` path with a NETWORK error that is not a timeout: a fetch-failed
+    // TypeError whose cause is an ECONNREFUSED — this maps to a retry-able 503 downstream,
+    // but the metric outcome must be classified `error`, NOT `timeout` (no TimeoutError/
+    // AbortError anywhere in the cause chain) and NOT `ok`. This closes the reject-path
+    // non-timeout `error` gap the depth-0 resolve-path 5xx test above doesn't cover.
+    mockGetWorkflow.mockRejectedValue(
+      Object.assign(new TypeError('fetch failed'), {
+        cause: Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+      })
+    );
+    await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch(() => {});
+    expect(mockObserveRead).toHaveBeenCalledTimes(1);
+    expect(mockObserveRead.mock.calls[0][0]).toBe('getWorkflow');
+    expect(mockObserveRead.mock.calls[0][1]).toBe('error');
+  });
+
+  it('classifies as timeout via the .cause chain at depth>0 (outer error is generic) for getWorkflow', async () => {
+    // isOrchestratorReadTimeout walks the `.cause` chain (depth ≤ 4), not just the top-level
+    // `.name`. Prove the walk works past depth 0: the OUTER error is a generic Error, but a
+    // nested cause carries `name: 'TimeoutError'` — this must still classify `timeout`, not
+    // `error`. The existing timeout tests only exercise depth-0 (`name` on the thrown error).
+    mockGetWorkflow.mockRejectedValue(
+      Object.assign(new Error('wrapped'), {
+        cause: Object.assign(new Error('inner'), { name: 'TimeoutError' }),
+      })
+    );
+    await getWorkflow({ token: 'tok', path: { workflowId: 'wf-1' } }).catch(() => {});
+    expect(mockObserveRead).toHaveBeenCalledTimes(1);
+    expect(mockObserveRead.mock.calls[0][0]).toBe('getWorkflow');
+    expect(mockObserveRead.mock.calls[0][1]).toBe('timeout');
+  });
 });


### PR DESCRIPTION
## What

Adds two Vitest cases to `src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts`, closing the two 🟡 test-coverage gaps flagged by the audit of the now-merged #2884 (orchestrator READ-path metrics).

**Tests only — no source changes.** #2884's `observeOrchestratorRead` / `isOrchestratorReadTimeout` code is unchanged and already correct; this is purely additive coverage of two previously-unasserted branches.

## The two gaps

1. **Reject-path non-timeout `error` outcome was unasserted.** The existing `outcome=error` test only exercised the depth-0 *resolve*-path 5xx (`{ error: { status: 500 } }`). The reject `.catch` branch's non-timeout classification had no coverage. New test drives a NETWORK reject (`fetch failed` `TypeError` with an `ECONNREFUSED` cause) through `getWorkflow` and asserts `observeOrchestratorRead('getWorkflow', 'error', …)` — not `'timeout'`, not `'ok'`.

2. **`.cause`-chain timeout detection at depth>0 was untested.** Every prior timeout test set `name: 'TimeoutError'` directly on the thrown error (depth 0). `isOrchestratorReadTimeout` walks the `.cause` chain (depth ≤ 4). New test throws a generic outer `Error` whose nested `.cause` carries `name: 'TimeoutError'` and asserts the outcome is still classified `'timeout'`, proving the cause-walk works past depth 0.

## Why

#2884 ships the metric that distinguishes orchestrator read `ok` / `error` / `timeout` outcomes on the statusUpdate poll hot path. The audit noted these two classification branches were the ones a regression would silently mis-label; locking them in with tests keeps the metric trustworthy.

## Verification

`vitest run` over `workflows.error-mapping.test.ts` + `orchestrator-read-metrics.test.ts`: **28 tests pass** (22 + 6; +2 new). Both new tests mirror the existing spy setup (`mockObserveRead` + `vi.mock` of `orchestrator-read-metrics`) exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)