### PR TITLE
feat(image-feed): graceful stale-serve on Meili failure

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1686,6 +1686,15 @@ export const REDIS_KEYS = {
     ANNOUNCEMENTS: 'packed:caches:announcement',
     THUMBNAILS: 'packed:caches:thumbnails',
     IMAGE_METRICS: 'packed:caches:image-metrics',
+    // Last-good (stale) image-feed search results, keyed on a strong hash of the
+    // FULLY-COMPOSED Meili request (filter string + sort + limit + offset). The
+    // filter string encodes every visibility dimension (browsingLevel, own/mod
+    // carve-outs, hidden/followed id-lists, excluded tags/users, period, …), so a
+    // stale entry is only ever served back to a request whose visibility semantics
+    // are byte-identical. Written on every successful search (short TTL) and read
+    // ONLY on a recognized transient Meili failure to degrade "stale-but-fast"
+    // instead of erroring. See src/server/meilisearch/image-search-stale-cache.ts.
+    IMAGE_SEARCH_STALE: 'packed:caches:image-search-stale',
     ARTICLE_STATS: 'packed:caches:article-stats',
     POST_STATS: 'packed:caches:post-stats',
     USER_FOLLOWS: 'packed:caches:user-follows',

--- a/src/server/meilisearch/__tests__/image-search-stale-cache.test.ts
+++ b/src/server/meilisearch/__tests__/image-search-stale-cache.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { StalePackedClient } from '~/server/meilisearch/image-search-stale-cache';
+import {
+  MEILI_STALE_MAX_AGE_MS,
+  MEILI_STALE_MAX_AGE_SECONDS,
+  buildImageSearchStaleKey,
+  readImageSearchStale,
+  staleServeOnError,
+  writeImageSearchStale,
+} from '~/server/meilisearch/image-search-stale-cache';
+
+// A minimal in-memory fake of the packed redis surface the module uses. Stores
+// the exact { value, cachedAt } envelope writeImageSearchStale produces so read
+// and write can be exercised end-to-end without a real redis.
+function makeFakeRedis() {
+  const store = new Map<string, unknown>();
+  const client: StalePackedClient & { store: Map<string, unknown> } = {
+    store,
+    packed: {
+      get: vi.fn(async <T>(key: string) => (store.has(key) ? (store.get(key) as T) : null)),
+      set: vi.fn(async <T>(key: string, value: T) => {
+        store.set(key, value);
+      }),
+    },
+  };
+  return client;
+}
+
+// Two Meili filter strings that differ ONLY in the nsfwLevel IN [...] clause —
+// i.e. two different browsing levels. Everything else identical. This is the
+// exact vector the cache key must keep separate to avoid an NSFW leak.
+const FILTER_PG = 'postId IS NOT NULL AND (nsfwLevel IN [1] OR (nsfwLevel = 0))';
+const FILTER_NSFW = 'postId IS NOT NULL AND (nsfwLevel IN [1,2,4,8,16] OR (nsfwLevel = 0))';
+const BASE_PARTS = {
+  index: 'metrics_images_v1',
+  filter: FILTER_PG,
+  sort: ['sortAt:desc'] as string[],
+  limit: 101,
+  offset: 0,
+};
+
+describe('buildImageSearchStaleKey', () => {
+  it('is deterministic for identical request parts', () => {
+    expect(buildImageSearchStaleKey(BASE_PARTS)).toBe(buildImageSearchStaleKey({ ...BASE_PARTS }));
+  });
+
+  it('is prefixed with the dedicated cache namespace', () => {
+    expect(buildImageSearchStaleKey(BASE_PARTS)).toMatch(/^packed:caches:image-search-stale:/);
+  });
+
+  it('SECURITY: a different browsingLevel (nsfwLevel filter) yields a different key', () => {
+    const pgKey = buildImageSearchStaleKey({ ...BASE_PARTS, filter: FILTER_PG });
+    const nsfwKey = buildImageSearchStaleKey({ ...BASE_PARTS, filter: FILTER_NSFW });
+    expect(pgKey).not.toBe(nsfwKey);
+  });
+
+  it('SECURITY: an added per-user own-carve-out clause yields a different key', () => {
+    // The logged-in own-carve-out appends `OR "userId" = <id>` into the filter.
+    // Two different users (or anon vs user) must never share a stale entry.
+    const anon = buildImageSearchStaleKey({ ...BASE_PARTS, filter: FILTER_PG });
+    const user123 = buildImageSearchStaleKey({
+      ...BASE_PARTS,
+      filter: `${FILTER_PG} AND ((NOT availability = Private) OR "userId" = 123)`,
+    });
+    const user456 = buildImageSearchStaleKey({
+      ...BASE_PARTS,
+      filter: `${FILTER_PG} AND ((NOT availability = Private) OR "userId" = 456)`,
+    });
+    expect(new Set([anon, user123, user456]).size).toBe(3);
+  });
+
+  it('differs on sort, limit, offset, and index', () => {
+    const base = buildImageSearchStaleKey(BASE_PARTS);
+    expect(buildImageSearchStaleKey({ ...BASE_PARTS, sort: ['reactionCount:desc'] })).not.toBe(base);
+    expect(buildImageSearchStaleKey({ ...BASE_PARTS, limit: 51 })).not.toBe(base);
+    expect(buildImageSearchStaleKey({ ...BASE_PARTS, offset: 100 })).not.toBe(base);
+    expect(buildImageSearchStaleKey({ ...BASE_PARTS, index: 'other_index' })).not.toBe(base);
+  });
+});
+
+describe('readImageSearchStale / writeImageSearchStale', () => {
+  const key = buildImageSearchStaleKey(BASE_PARTS);
+  const value = { data: [{ id: 1 }], nextCursor: 42 };
+
+  it('round-trips a written value that is within the stale bound', async () => {
+    const redis = makeFakeRedis();
+    const now = 1_000_000;
+    writeImageSearchStale(redis, key, value, now);
+    await Promise.resolve(); // let the fire-and-forget set settle
+    const read = await readImageSearchStale<typeof value>(redis, key, now + 1000);
+    expect(read).toEqual(value);
+    // stored with the EX bound
+    expect(redis.packed.set).toHaveBeenCalledWith(
+      key,
+      { value, cachedAt: now },
+      { EX: MEILI_STALE_MAX_AGE_SECONDS }
+    );
+  });
+
+  it('returns null when the entry is older than the stale bound', async () => {
+    const redis = makeFakeRedis();
+    const now = 1_000_000;
+    writeImageSearchStale(redis, key, value, now);
+    await Promise.resolve();
+    const read = await readImageSearchStale<typeof value>(
+      redis,
+      key,
+      now + MEILI_STALE_MAX_AGE_MS + 1
+    );
+    expect(read).toBeNull();
+  });
+
+  it('serves right up to the bound but not past it', async () => {
+    const redis = makeFakeRedis();
+    const now = 5_000_000;
+    writeImageSearchStale(redis, key, value, now);
+    await Promise.resolve();
+    expect(await readImageSearchStale(redis, key, now + MEILI_STALE_MAX_AGE_MS)).toEqual(value);
+    expect(await readImageSearchStale(redis, key, now + MEILI_STALE_MAX_AGE_MS + 1)).toBeNull();
+  });
+
+  it('returns null when nothing is cached', async () => {
+    const redis = makeFakeRedis();
+    expect(await readImageSearchStale(redis, key)).toBeNull();
+  });
+
+  it('returns null (never throws) when the redis read fails', async () => {
+    const redis = makeFakeRedis();
+    redis.packed.get = vi.fn(async () => {
+      throw new Error('redis down');
+    });
+    await expect(readImageSearchStale(redis, key)).resolves.toBeNull();
+  });
+
+  it('write never rejects even if the underlying set throws', async () => {
+    const redis = makeFakeRedis();
+    redis.packed.set = vi.fn(async () => {
+      throw new Error('redis down');
+    });
+    // Must not throw synchronously nor create an unhandled rejection.
+    expect(() => writeImageSearchStale(redis, key, value)).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});
+
+describe('staleServeOnError', () => {
+  const liveValue = { data: [{ id: 1 }], nextCursor: 1 };
+  const staleValue = { data: [{ id: 2 }], nextCursor: 2 };
+
+  it('happy path: returns the LIVE value byte-identically, writes it, never reads stale', async () => {
+    const read = vi.fn(async () => staleValue);
+    const write = vi.fn();
+    const onStaleServed = vi.fn();
+    const result = await staleServeOnError({
+      run: async () => liveValue,
+      read,
+      write,
+      isRecoverable: () => true,
+      onStaleServed,
+    });
+    expect(result).toBe(liveValue);
+    expect(write).toHaveBeenCalledWith(liveValue);
+    expect(read).not.toHaveBeenCalled();
+    expect(onStaleServed).not.toHaveBeenCalled();
+  });
+
+  it('genuine empty result is returned as-is (not treated as a failure / not stale-served)', async () => {
+    const empty = { data: [], nextCursor: undefined };
+    const read = vi.fn(async () => staleValue);
+    const onStaleServed = vi.fn();
+    const result = await staleServeOnError({
+      run: async () => empty,
+      read,
+      write: vi.fn(),
+      isRecoverable: () => true,
+      onStaleServed,
+    });
+    expect(result).toBe(empty);
+    expect(read).not.toHaveBeenCalled();
+    expect(onStaleServed).not.toHaveBeenCalled();
+  });
+
+  it('transient failure + fresh stale present → serves stale and increments the metric', async () => {
+    const onStaleServed = vi.fn();
+    const write = vi.fn();
+    const result = await staleServeOnError({
+      run: async () => {
+        throw new Error('meili timeout');
+      },
+      read: async () => staleValue,
+      write,
+      isRecoverable: () => true,
+      onStaleServed,
+    });
+    expect(result).toBe(staleValue);
+    expect(onStaleServed).toHaveBeenCalledTimes(1);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('transient failure + stale absent/too old (read → null) → rethrows, no metric', async () => {
+    const onStaleServed = vi.fn();
+    const err = new Error('meili timeout');
+    await expect(
+      staleServeOnError({
+        run: async () => {
+          throw err;
+        },
+        read: async () => null,
+        write: vi.fn(),
+        isRecoverable: () => true,
+        onStaleServed,
+      })
+    ).rejects.toBe(err);
+    expect(onStaleServed).not.toHaveBeenCalled();
+  });
+
+  it('non-recoverable error rethrows WITHOUT consulting the stale cache', async () => {
+    const read = vi.fn(async () => staleValue);
+    const onStaleServed = vi.fn();
+    const err = new Error('validation error');
+    await expect(
+      staleServeOnError({
+        run: async () => {
+          throw err;
+        },
+        read,
+        write: vi.fn(),
+        isRecoverable: () => false,
+        onStaleServed,
+      })
+    ).rejects.toBe(err);
+    expect(read).not.toHaveBeenCalled();
+    expect(onStaleServed).not.toHaveBeenCalled();
+  });
+
+  it('rethrows the ORIGINAL error (not the read error) if the stale read itself throws', async () => {
+    const err = new Error('meili timeout');
+    const onStaleServed = vi.fn();
+    await expect(
+      staleServeOnError({
+        run: async () => {
+          throw err;
+        },
+        read: async () => {
+          throw new Error('redis down');
+        },
+        write: vi.fn(),
+        isRecoverable: () => true,
+        onStaleServed,
+      })
+    ).rejects.toBe(err);
+    expect(onStaleServed).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/meilisearch/client.ts
+++ b/src/server/meilisearch/client.ts
@@ -413,6 +413,29 @@ export function failfastReasonForTransientError(error: unknown): MeiliFetchFailf
  * Naming follows the prom-client wrapper's PROM_PREFIX convention — exposed
  * to Prometheus as `civitai_app_meili_fetch_failfast_total`.
  */
+/**
+ * Counter incremented every time a Meili-backed read serves a LAST-GOOD (stale)
+ * cached result because the live call failed with a recognized transient error
+ * (MeiliCallTimeoutError / circuit-open / transient SDK error). This is the
+ * "graceful stale-serve" degradation: instead of throwing a 503 on the image
+ * feed when Meili browns out, we serve the most recent successful result for the
+ * SAME visibility query (see image-search-stale-cache.ts) as long as it's within
+ * the bounded stale age.
+ *
+ * A rising rate here means the feed is being kept usable by masking a real
+ * Meili degradation — alert-worthy as a leading indicator even though users see
+ * no error. Exposed to Prometheus as `civitai_app_meili_stale_served_total`.
+ * `backend` mirrors the other meili counters; `route` identifies the caller.
+ */
+export const meiliStaleServedTotal = registerCounterWithLabels({
+  name: 'meili_stale_served_total',
+  help:
+    'Meili-backed reads served from the last-good (stale) cache because the live ' +
+    'call hit a transient failure — the graceful "stale-but-fast" degradation. ' +
+    'A nonzero rate masks a real Meili brownout; alert on it as a leading signal.',
+  labelNames: ['backend', 'route'] as const,
+});
+
 export const meiliFetchFailfastTotal = registerCounterWithLabels({
   name: 'meili_fetch_failfast_total',
   help:

--- a/src/server/meilisearch/image-search-stale-cache.ts
+++ b/src/server/meilisearch/image-search-stale-cache.ts
@@ -1,0 +1,195 @@
+import { createHash } from 'crypto';
+import type { RedisKeyTemplateCache } from '~/server/redis/client';
+import { REDIS_KEYS } from '~/server/redis/client';
+
+/**
+ * Graceful stale-serve ("stale-but-fast") for the Meili-backed image feed.
+ *
+ * WHY: civitai-dp-prod's metricsSearch Meilisearch backend (index > node RAM)
+ * chronically browns out during waves — p99 3–6s, timeouts, circuit trips. When
+ * that happens the feed's Meili read throws `MeiliCallTimeoutError` (wrapper
+ * timeout / circuit-open) or a transient SDK error, and `getAllImagesIndex`
+ * maps it to a hard 503 — the feed goes UNUSABLE exactly when traffic is
+ * highest. This module lets the feed serve the LAST-GOOD result fast instead.
+ *
+ * ── NSFW / visibility SAFETY (the load-bearing property) ────────────────────
+ * The cache key is a strong (sha256) hash of the FULLY-COMPOSED Meili request:
+ * the `filter` string, the `sort`, `limit`, and `offset`. In
+ * getImagesFromSearchPreFilter that filter string is the SOLE determinant of
+ * which documents Meili is allowed to return, and it encodes EVERY visibility
+ * dimension:
+ *   - browsingLevel        → `nsfwLevel IN [...]` / `combinedNsfwLevel IN [...]`
+ *   - moderator status     → the mod-only carve-outs (poi/minor/blockedFor, 0-level)
+ *   - the viewer's own id   → `OR "userId" = <id>` own-carve-outs on the
+ *                             availability / blocked / nsfw / published clauses
+ *   - hidden / followed     → resolved to explicit id-lists baked into the filter
+ *   - excluded tags / users → `tagIds NOT IN [...]` / `userId NOT IN [...]`
+ *   - tags/tools/types/baseModels/period/postId/modelVersionId/etc.
+ *
+ * Therefore two requests that hash to the same key have BYTE-IDENTICAL
+ * visibility semantics, and serving one's stored result for the other cannot
+ * leak content across browsing levels or across per-user visibility scopes. A
+ * different browsingLevel → a different `nsfwLevel IN [...]` clause → a different
+ * filter string → a different key (asserted in the unit tests). Because the own-
+ * carve-out embeds `currentUserId`, any personalized query is automatically
+ * scoped to that user; anonymous / browsing-level-only queries (the dominant,
+ * shared traffic) share a key safely.
+ *
+ * sha256 (not the app's 32-bit hashifyObject) is used DELIBERATELY: a 32-bit
+ * hash collides at ~65k distinct keys, and a collision here would serve one
+ * visibility scope's content under another — an NSFW leak. A 256-bit digest
+ * makes that collision probability negligible.
+ *
+ * ── RESIDUAL RISK (documented, bounded) ─────────────────────────────────────
+ * A cached doc carries the `nsfwLevel` it had at cache time. If an image is
+ * re-rated (e.g. PG → X) AFTER being cached, a stale serve could show it under
+ * the old level for up to the stale bound. This is the SAME eventual-consistency
+ * window that already exists in the live Meili index (re-rate → reindex lag is
+ * minutes) and in BitDex; the stale bound merely adds at most `MEILI_STALE_MAX_AGE`
+ * on top. Keep the bound tight to keep that additive window small.
+ *
+ * ── BOUND ───────────────────────────────────────────────────────────────────
+ * Stale is served ONLY if the entry is within `MEILI_STALE_MAX_AGE_MS`. The
+ * bound is enforced two ways: Redis `EX` expiry AND an explicit `cachedAt` check
+ * on read (belt-and-suspenders + unit-testable). Past the bound we fall through
+ * to today's behavior (throw → 503).
+ */
+
+/**
+ * Maximum age a last-good entry may be served at. 5 minutes: long enough to ride
+ * out a typical brownout / circuit-cooldown cycle, short enough that the additive
+ * nsfwLevel-drift window (see RESIDUAL RISK) stays small. The feed's `sortAt` is
+ * already minute-snapped so content granularity below this is moot.
+ */
+export const MEILI_STALE_MAX_AGE_MS = 5 * 60 * 1000;
+export const MEILI_STALE_MAX_AGE_SECONDS = Math.floor(MEILI_STALE_MAX_AGE_MS / 1000);
+
+/** Stored shape: the cached value plus the wall-clock time it was written. */
+export type StaleEntry<T> = { value: T; cachedAt: number };
+
+/**
+ * Minimal surface of the packed redis client this module needs. Declared here
+ * (rather than importing the concrete client) so callers inject the real client
+ * and tests inject a fake — keeping the module free of the redis singleton.
+ */
+export interface StalePackedClient {
+  packed: {
+    get<T>(key: RedisKeyTemplateCache): Promise<T | null>;
+    set<T>(key: RedisKeyTemplateCache, value: T, options?: { EX?: number }): Promise<void>;
+  };
+}
+
+/**
+ * Build the stale-cache key from the fully-composed Meili request. See the
+ * module header for why hashing the composed request (filter+sort+limit+offset)
+ * is the NSFW-safe key: the filter string is the exact visibility query.
+ */
+export function buildImageSearchStaleKey(parts: {
+  index: string;
+  filter: string;
+  sort: readonly string[];
+  limit: number;
+  offset: number;
+}): RedisKeyTemplateCache {
+  // Canonical, order-stable serialization of the discriminating fields.
+  const canonical = JSON.stringify([
+    parts.index,
+    parts.filter,
+    parts.sort,
+    parts.limit,
+    parts.offset,
+  ]);
+  const digest = createHash('sha256').update(canonical).digest('hex');
+  return `${REDIS_KEYS.CACHES.IMAGE_SEARCH_STALE}:${digest}` as RedisKeyTemplateCache;
+}
+
+/**
+ * Write the last-good result. Fire-and-forget by design: the happy-path return
+ * value is NOT altered and the caller does not await this, so a slow/failed
+ * cache write never adds latency to (nor can it fail) a successful search. The
+ * `EX` bound means keys self-expire at the stale ceiling.
+ */
+export function writeImageSearchStale<T>(
+  client: StalePackedClient,
+  key: RedisKeyTemplateCache,
+  value: T,
+  now: number = Date.now()
+): void {
+  const entry: StaleEntry<T> = { value, cachedAt: now };
+  void Promise.resolve()
+    .then(() => client.packed.set(key, entry, { EX: MEILI_STALE_MAX_AGE_SECONDS }))
+    .catch(() => {
+      // Best-effort: a stale-cache write failure must never surface on the feed.
+    });
+}
+
+/**
+ * Read the last-good result, enforcing the stale bound. Returns the cached VALUE
+ * only when an entry exists AND is within `MEILI_STALE_MAX_AGE_MS`; otherwise
+ * null (so the caller falls through to today's throw). Never throws — a redis
+ * read failure resolves to null.
+ */
+export async function readImageSearchStale<T>(
+  client: StalePackedClient,
+  key: RedisKeyTemplateCache,
+  now: number = Date.now()
+): Promise<T | null> {
+  let entry: StaleEntry<T> | null;
+  try {
+    entry = await client.packed.get<StaleEntry<T>>(key);
+  } catch {
+    return null;
+  }
+  if (!entry || typeof entry.cachedAt !== 'number') return null;
+  if (now - entry.cachedAt > MEILI_STALE_MAX_AGE_MS) return null;
+  return entry.value;
+}
+
+/**
+ * Run a live Meili-backed read with graceful stale-serve on a recognized
+ * transient failure.
+ *
+ * Semantics (all asserted in the unit tests):
+ *   - Healthy: run() resolves → write last-good (fire-and-forget) → return the
+ *     LIVE value byte-identically. No stale read. (Happy path unchanged.)
+ *   - Transient failure + fresh last-good present → return the stale value and
+ *     call onStaleServed() (the metric). The original error is NOT thrown.
+ *   - Transient failure + no last-good / last-good past the bound → rethrow the
+ *     original error (today's behavior → 503).
+ *   - Non-recoverable failure (validation / auth / real bug) → rethrow WITHOUT
+ *     consulting the cache. A genuine failure is never masked.
+ *
+ * A genuine empty result (run() resolves to `{ data: [], ... }`) returns via the
+ * healthy path and is honored as-is — stale-serve only ever triggers inside the
+ * catch, so "0 results" stays 0 results.
+ */
+export async function staleServeOnError<T>(opts: {
+  run: () => Promise<T>;
+  read: () => Promise<T | null>;
+  write: (value: T) => void;
+  isRecoverable: (err: unknown) => boolean;
+  onStaleServed: () => void;
+}): Promise<T> {
+  try {
+    const value = await opts.run();
+    opts.write(value);
+    return value;
+  } catch (err) {
+    if (opts.isRecoverable(err)) {
+      // A stale read must never mask the original failure: if it throws, fall
+      // through to rethrowing `err` (today's behavior). readImageSearchStale
+      // already resolves to null on redis error, so this is belt-and-suspenders.
+      let stale: T | null = null;
+      try {
+        stale = await opts.read();
+      } catch {
+        stale = null;
+      }
+      if (stale != null) {
+        opts.onStaleServed();
+        return stale;
+      }
+    }
+    throw err;
+  }
+}

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -56,10 +56,17 @@ import {
   isFailfastStatus,
   isTransientMeiliError,
   meiliFetchFailfastTotal,
+  meiliStaleServedTotal,
   metricsSearchClient,
   withMeili,
   wrapMeilisearchClientWithLimiter,
 } from '~/server/meilisearch/client';
+import {
+  buildImageSearchStaleKey,
+  readImageSearchStale,
+  staleServeOnError,
+  writeImageSearchStale,
+} from '~/server/meilisearch/image-search-stale-cache';
 import { postMetrics } from '~/server/metrics';
 import {
   clickhouseFailSoftCounter,
@@ -3387,229 +3394,268 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
   const endTimer = requestDurationSeconds.startTimer({ route });
   requestTotal.inc({ route }); // count every request up front
 
+  // Graceful stale-serve key: a strong hash of the FULLY-COMPOSED Meili request.
+  // The `filter` string is the exact visibility query (browsingLevel + own/mod
+  // carve-outs + hidden/followed id-lists + excluded tags/users + all other
+  // clauses), so an entry is only ever served back to a byte-identical-visibility
+  // request — no cross-browsing-level / cross-user leak. See image-search-stale-cache.ts.
+  const staleKey = buildImageSearchStaleKey({
+    index: METRICS_SEARCH_INDEX,
+    // request.filter is Meili's `Filter` type (string | (string|string[])[]); our
+    // code always sets it to filters.join(' AND ') (a string), but coerce for the
+    // type — the key builder hashes it verbatim either way.
+    filter: typeof request.filter === 'string' ? request.filter : JSON.stringify(request.filter ?? ''),
+    sort: (request.sort as string[] | undefined) ?? [],
+    limit: request.limit ?? 0,
+    offset: request.offset ?? 0,
+  });
+
   try {
-    const actor = input.actor;
+    // On a recognized TRANSIENT Meili failure (MeiliCallTimeoutError / circuit-open
+    // / transient SDK error), serve the last-good result for THIS EXACT request if
+    // it's within the stale bound — "stale-but-fast" instead of a hard 503. The
+    // happy path is unchanged: run()'s live value is returned byte-identically and
+    // the last-good cache is refreshed fire-and-forget. A genuine 0-result returns
+    // via run() and is honored (stale-serve only triggers inside the catch); a
+    // non-transient error rethrows without consulting the cache.
+    const result = await staleServeOnError({
+      read: () => readImageSearchStale(redis, staleKey),
+      write: (value) => writeImageSearchStale(redis, staleKey, value),
+      isRecoverable: isTransientMeiliError,
+      onStaleServed: () => {
+        // Stale-serve short-circuits run() before it reaches its own endTimer(),
+        // so close the request-duration timer here (the success returns close it
+        // inline; the catch closes it on the fall-through throw).
+        endTimer();
+        meiliStaleServedTotal.inc({ backend: 'metricsSearch', route });
+      },
+      run: async () => {
+        const actor = input.actor;
 
-    // Always use the abortable raw fetch path. Two reasons:
-    //   1. Client disconnect: a caller-supplied `input.signal` still cancels
-    //      the underlying request as before.
-    //   2. Hard local deadline: fetchDocumentsAbortable() now races against a
-    //      5s default timer (FETCH_DOCUMENTS_DEFAULT_TIMEOUT_MS). Before this,
-    //      the non-signal branch fell through to the SDK getDocuments, which
-    //      meilisearch-js 0.33/0.34 does NOT cancel — the only protection was
-    //      withMeili()'s 2.5s wrapper timer, with the orphan SDK promise still
-    //      running. Routing everything through fetchDocumentsAbortable gives
-    //      us one code path with a real abort, regardless of whether the
-    //      caller passed a signal.
-    //
-    // This is the hot tRPC path
-    // (image.getInfinite → getInfiniteImagesHandler → getAllImagesIndex →
-    //  this prefilter). Verification on 2026-05-29 showed this is where the
-    // 374-error/15min Meili bleed lives, NOT in getImagesFromFeedSearch.
-    const mainResult = await withSpan('image:meili:getDocuments', () =>
-      fetchDocumentsAbortable<ImageMetricsSearchIndexRecord>(METRICS_SEARCH_INDEX, request, {
-        host: env.METRICS_SEARCH_HOST as string,
-        apiKey: env.METRICS_SEARCH_API_KEY,
-        signal: input.signal,
-        actor,
-      })
-    );
-    let results = mainResult.results;
+        // Always use the abortable raw fetch path. Two reasons:
+        //   1. Client disconnect: a caller-supplied `input.signal` still cancels
+        //      the underlying request as before.
+        //   2. Hard local deadline: fetchDocumentsAbortable() now races against a
+        //      5s default timer (FETCH_DOCUMENTS_DEFAULT_TIMEOUT_MS). Before this,
+        //      the non-signal branch fell through to the SDK getDocuments, which
+        //      meilisearch-js 0.33/0.34 does NOT cancel — the only protection was
+        //      withMeili()'s 2.5s wrapper timer, with the orphan SDK promise still
+        //      running. Routing everything through fetchDocumentsAbortable gives
+        //      us one code path with a real abort, regardless of whether the
+        //      caller passed a signal.
+        //
+        // This is the hot tRPC path
+        // (image.getInfinite → getInfiniteImagesHandler → getAllImagesIndex →
+        //  this prefilter). Verification on 2026-05-29 showed this is where the
+        // 374-error/15min Meili bleed lives, NOT in getImagesFromFeedSearch.
+        const mainResult = await withSpan('image:meili:getDocuments', () =>
+          fetchDocumentsAbortable<ImageMetricsSearchIndexRecord>(METRICS_SEARCH_INDEX, request, {
+            host: env.METRICS_SEARCH_HOST as string,
+            apiKey: env.METRICS_SEARCH_API_KEY,
+            signal: input.signal,
+            actor,
+          })
+        );
+        let results = mainResult.results;
 
-    let nextCursor: number | undefined;
-    if (results.length > limit) {
-      results.pop();
-      // - if we have no entrypoint, it's the first request, and set one for the future
-      //   else keep it the same
-      nextCursor = !entry ? results[0]?.sortAtUnix : entry;
-    }
+        let nextCursor: number | undefined;
+        if (results.length > limit) {
+          results.pop();
+          // - if we have no entrypoint, it's the first request, and set one for the future
+          //   else keep it the same
+          nextCursor = !entry ? results[0]?.sortAtUnix : entry;
+        }
 
-    const filteredHits = results.filter((hit) => {
-      if (!hit.url)
-        // check for good data
-        return false;
-      // filter out items flagged with minor unless it's the owner or moderator
-      if (hit.acceptableMinor) return hit.userId === currentUserId || isModerator;
-      // filter out non-scanned unless it's the owner or moderator
-      if (![0, NsfwLevel.Blocked].includes(hit.nsfwLevel) && !hit.needsReview) return true;
+        const filteredHits = results.filter((hit) => {
+          if (!hit.url)
+            // check for good data
+            return false;
+          // filter out items flagged with minor unless it's the owner or moderator
+          if (hit.acceptableMinor) return hit.userId === currentUserId || isModerator;
+          // filter out non-scanned unless it's the owner or moderator
+          if (![0, NsfwLevel.Blocked].includes(hit.nsfwLevel) && !hit.needsReview) return true;
 
-      return hit.userId === currentUserId || (isModerator && includesNsfwContent);
-    });
+          return hit.userId === currentUserId || (isModerator && includesNsfwContent);
+        });
 
-    // Get all image IDs from search results
-    const searchImageIds = filteredHits.map((hit) => hit.id);
-    const filteredHitIds = [...new Set(searchImageIds)];
+        // Get all image IDs from search results
+        const searchImageIds = filteredHits.map((hit) => hit.id);
+        const filteredHitIds = [...new Set(searchImageIds)];
 
-    // Routed through getFliptBoolean (memoized once PR #2394's eval cache lands)
-    // instead of a direct per-request wasm eval; returns false on a missing/
-    // uninitialized client (existence check off), matching the prior default.
-    const cacheExistenceEnabled = await getFliptBoolean(
-      FLIPT_FEATURE_FLAGS.FEED_IMAGE_EXISTENCE,
-      currentUserId?.toString() || 'anonymous'
-    );
-    ffRequestsTotal.inc({ route, enabled: String(cacheExistenceEnabled) });
+        // Routed through getFliptBoolean (memoized once PR #2394's eval cache lands)
+        // instead of a direct per-request wasm eval; returns false on a missing/
+        // uninitialized client (existence check off), matching the prior default.
+        const cacheExistenceEnabled = await getFliptBoolean(
+          FLIPT_FEATURE_FLAGS.FEED_IMAGE_EXISTENCE,
+          currentUserId?.toString() || 'anonymous'
+        );
+        ffRequestsTotal.inc({ route, enabled: String(cacheExistenceEnabled) });
 
-    if (!cacheExistenceEnabled) {
-      cacheHitRequestsTotal.inc({ route, hit_type: 'miss' });
+        if (!cacheExistenceEnabled) {
+          cacheHitRequestsTotal.inc({ route, hit_type: 'miss' });
 
-      // BASIC DB CHECK (default)
-      const dbIdResp = await dbRead.image.findMany({
-        where: { id: { in: filteredHitIds } },
-        select: { id: true },
-      });
+          // BASIC DB CHECK (default)
+          const dbIdResp = await dbRead.image.findMany({
+            where: { id: { in: filteredHitIds } },
+            select: { id: true },
+          });
 
-      const idSet = new Set(dbIdResp.map((r) => r.id));
-      const filtered = results.filter((h) => idSet.has(h.id));
+          const idSet = new Set(dbIdResp.map((r) => r.id));
+          const filtered = results.filter((h) => idSet.has(h.id));
 
-      const droppedCount = results.length - filtered.length;
-      droppedIdsTotal.inc({ route, hit_type: 'miss' }, droppedCount);
+          const droppedCount = results.length - filtered.length;
+          droppedIdsTotal.inc({ route, hit_type: 'miss' }, droppedCount);
 
-      const imageMetrics = await getImageMetricsObject(filtered);
-      const fullData = filtered.map((h) => {
-        const match = imageMetrics[h.id];
-        return {
-          ...h,
-          stats: {
-            likeCountAllTime: match?.reactionLike ?? 0,
-            laughCountAllTime: match?.reactionLaugh ?? 0,
-            heartCountAllTime: match?.reactionHeart ?? 0,
-            cryCountAllTime: match?.reactionCry ?? 0,
-            commentCountAllTime: match?.comment ?? 0,
-            collectedCountAllTime: match?.collection ?? 0,
-            tippedAmountCountAllTime: match?.buzz ?? 0,
-            dislikeCountAllTime: 0,
-            viewCountAllTime: 0,
-          },
+          const imageMetrics = await getImageMetricsObject(filtered);
+          const fullData = filtered.map((h) => {
+            const match = imageMetrics[h.id];
+            return {
+              ...h,
+              stats: {
+                likeCountAllTime: match?.reactionLike ?? 0,
+                laughCountAllTime: match?.reactionLaugh ?? 0,
+                heartCountAllTime: match?.reactionHeart ?? 0,
+                cryCountAllTime: match?.reactionCry ?? 0,
+                commentCountAllTime: match?.comment ?? 0,
+                collectedCountAllTime: match?.collection ?? 0,
+                tippedAmountCountAllTime: match?.buzz ?? 0,
+                dislikeCountAllTime: 0,
+                viewCountAllTime: 0,
+              },
+            };
+          });
+
+          endTimer();
+
+          return { data: fullData, nextCursor };
+        }
+
+        // ===== SMART CACHE EXISTENCE CHECK (feature-flagged) =====
+        const checkImageExistence = async (imageIds: number[]) => {
+          // Preserve original order and remove duplicates
+          const uniqueIds = [...new Set(imageIds)];
+          const cachePrefix = `${REDIS_SYS_KEYS.CACHES.IMAGE_EXISTS}:`;
+          const cacheKeys = uniqueIds.map((id) => `${cachePrefix}${id}` as RedisKeyTemplateSys);
+
+          // Check cached results first (10 minute TTL — see EX: 600 below). Fail open: image feed
+          // is the highest-traffic endpoint, a sysRedis outage shouldn't 500
+          // it. Treat a throw as full cache miss (everything falls through
+          // to DB — slower but correct).
+          let cachedResults: (string | null)[];
+          try {
+            cachedResults = await sysRedis.packed.mGet(cacheKeys);
+          } catch (err) {
+            logSysRedisFailOpen('read-degraded', 'checkImageExistence mGet', err);
+            cachedResults = new Array(uniqueIds.length).fill(null);
+          }
+
+          // Separate cached and uncached IDs
+          const uncachedIds: number[] = [];
+          const cachedMap = new Map<number, boolean>();
+          let cacheMiss = 0;
+
+          for (let i = 0; i < uniqueIds.length; i++) {
+            const id = uniqueIds[i];
+            const cachedResult = cachedResults[i];
+
+            if (cachedResult === 'true') {
+              cachedMap.set(id, true);
+            } else if (cachedResult === 'false') {
+              cachedMap.set(id, false);
+            } else {
+              uncachedIds.push(id);
+              cacheMiss++;
+            }
+          }
+
+          let hitType: 'full' | 'partial' | 'miss';
+          if (cacheMiss === 0) {
+            hitType = 'full';
+          } else if (cacheMiss === uniqueIds.length) {
+            hitType = 'miss';
+          } else {
+            hitType = 'partial';
+          }
+
+          cacheHitRequestsTotal.inc({ route, hit_type: hitType });
+
+          // Query DB for uncached IDs
+          if (uncachedIds.length > 0) {
+            const dbResults = await dbRead.image.findMany({
+              where: { id: { in: uncachedIds } },
+              select: { id: true },
+            });
+
+            const dbIdSet = new Set(dbResults.map((r) => r.id));
+
+            // Update cache with DB results (10-minute TTL, EX: 600)
+            const cacheUpdates: Record<string, string> = {};
+            for (const id of uncachedIds) {
+              const exists = dbIdSet.has(id);
+              cacheUpdates[`${cachePrefix}${id}`] = exists ? 'true' : 'false';
+              cachedMap.set(id, exists);
+            }
+
+            // Best-effort cache populate. Without this catch, the read-side
+            // fail-open above is defeated: every partial-cache-miss request
+            // during a sysRedis outage would still 500 here.
+            await Promise.all(
+              Object.entries(cacheUpdates).map(([key, value]) =>
+                sysRedis.packed.set(key as RedisKeyTemplateSys, value, { EX: 600 })
+              )
+            ).catch((err) => {
+              logSysRedisFailOpen('write-degraded', 'checkImageExistence cache populate', err);
+            });
+          }
+
+          // Filter hits based on existence check while preserving order
+          let dropped = 0;
+          const filteredHits = results.filter((hit) => {
+            const exists = cachedMap.get(hit.id);
+            const keep = exists !== false; // treat undefined as exists=true
+            if (!keep) dropped++;
+
+            return keep;
+          });
+
+          droppedIdsTotal.inc({ route, hit_type: hitType }, dropped);
+
+          return filteredHits.filter((x) => imageIds.includes(x.id));
         };
-      });
 
-      endTimer();
+        // Apply the (flagged) existence check
+        const filtered = await checkImageExistence(filteredHitIds);
 
-      return { data: fullData, nextCursor };
-    }
+        const imageMetrics = await getImageMetricsObject(filtered);
 
-    // ===== SMART CACHE EXISTENCE CHECK (feature-flagged) =====
-    const checkImageExistence = async (imageIds: number[]) => {
-      // Preserve original order and remove duplicates
-      const uniqueIds = [...new Set(imageIds)];
-      const cachePrefix = `${REDIS_SYS_KEYS.CACHES.IMAGE_EXISTS}:`;
-      const cacheKeys = uniqueIds.map((id) => `${cachePrefix}${id}` as RedisKeyTemplateSys);
-
-      // Check cached results first (10 minute TTL — see EX: 600 below). Fail open: image feed
-      // is the highest-traffic endpoint, a sysRedis outage shouldn't 500
-      // it. Treat a throw as full cache miss (everything falls through
-      // to DB — slower but correct).
-      let cachedResults: (string | null)[];
-      try {
-        cachedResults = await sysRedis.packed.mGet(cacheKeys);
-      } catch (err) {
-        logSysRedisFailOpen('read-degraded', 'checkImageExistence mGet', err);
-        cachedResults = new Array(uniqueIds.length).fill(null);
-      }
-
-      // Separate cached and uncached IDs
-      const uncachedIds: number[] = [];
-      const cachedMap = new Map<number, boolean>();
-      let cacheMiss = 0;
-
-      for (let i = 0; i < uniqueIds.length; i++) {
-        const id = uniqueIds[i];
-        const cachedResult = cachedResults[i];
-
-        if (cachedResult === 'true') {
-          cachedMap.set(id, true);
-        } else if (cachedResult === 'false') {
-          cachedMap.set(id, false);
-        } else {
-          uncachedIds.push(id);
-          cacheMiss++;
-        }
-      }
-
-      let hitType: 'full' | 'partial' | 'miss';
-      if (cacheMiss === 0) {
-        hitType = 'full';
-      } else if (cacheMiss === uniqueIds.length) {
-        hitType = 'miss';
-      } else {
-        hitType = 'partial';
-      }
-
-      cacheHitRequestsTotal.inc({ route, hit_type: hitType });
-
-      // Query DB for uncached IDs
-      if (uncachedIds.length > 0) {
-        const dbResults = await dbRead.image.findMany({
-          where: { id: { in: uncachedIds } },
-          select: { id: true },
+        const fullData = filtered.map((h) => {
+          const match = imageMetrics[h.id];
+          return {
+            ...h,
+            stats: {
+              likeCountAllTime: match?.reactionLike ?? 0,
+              laughCountAllTime: match?.reactionLaugh ?? 0,
+              heartCountAllTime: match?.reactionHeart ?? 0,
+              cryCountAllTime: match?.reactionCry ?? 0,
+              commentCountAllTime: match?.comment ?? 0,
+              collectedCountAllTime: match?.collection ?? 0,
+              tippedAmountCountAllTime: match?.buzz ?? 0,
+              dislikeCountAllTime: 0,
+              viewCountAllTime: 0,
+            },
+          };
         });
 
-        const dbIdSet = new Set(dbResults.map((r) => r.id));
+        endTimer();
 
-        // Update cache with DB results (10-minute TTL, EX: 600)
-        const cacheUpdates: Record<string, string> = {};
-        for (const id of uncachedIds) {
-          const exists = dbIdSet.has(id);
-          cacheUpdates[`${cachePrefix}${id}`] = exists ? 'true' : 'false';
-          cachedMap.set(id, exists);
-        }
-
-        // Best-effort cache populate. Without this catch, the read-side
-        // fail-open above is defeated: every partial-cache-miss request
-        // during a sysRedis outage would still 500 here.
-        await Promise.all(
-          Object.entries(cacheUpdates).map(([key, value]) =>
-            sysRedis.packed.set(key as RedisKeyTemplateSys, value, { EX: 600 })
-          )
-        ).catch((err) => {
-          logSysRedisFailOpen('write-degraded', 'checkImageExistence cache populate', err);
-        });
-      }
-
-      // Filter hits based on existence check while preserving order
-      let dropped = 0;
-      const filteredHits = results.filter((hit) => {
-        const exists = cachedMap.get(hit.id);
-        const keep = exists !== false; // treat undefined as exists=true
-        if (!keep) dropped++;
-
-        return keep;
-      });
-
-      droppedIdsTotal.inc({ route, hit_type: hitType }, dropped);
-
-      return filteredHits.filter((x) => imageIds.includes(x.id));
-    };
-
-    // Apply the (flagged) existence check
-    const filtered = await checkImageExistence(filteredHitIds);
-
-    const imageMetrics = await getImageMetricsObject(filtered);
-
-    const fullData = filtered.map((h) => {
-      const match = imageMetrics[h.id];
-      return {
-        ...h,
-        stats: {
-          likeCountAllTime: match?.reactionLike ?? 0,
-          laughCountAllTime: match?.reactionLaugh ?? 0,
-          heartCountAllTime: match?.reactionHeart ?? 0,
-          cryCountAllTime: match?.reactionCry ?? 0,
-          commentCountAllTime: match?.comment ?? 0,
-          collectedCountAllTime: match?.collection ?? 0,
-          tippedAmountCountAllTime: match?.buzz ?? 0,
-          dislikeCountAllTime: 0,
-          viewCountAllTime: 0,
-        },
-      };
+        return {
+          data: fullData,
+          nextCursor,
+        };
+      },
     });
 
-    endTimer();
-
-    return {
-      data: fullData,
-      nextCursor,
-    };
+    return result;
   } catch (error) {
     const err = error as Error;
     logToAxiom(


### PR DESCRIPTION
## Graceful stale-serve on Meili failure (image feed)

civitai-dp-prod's `metricsSearch` Meilisearch backend (index > node RAM) chronically browns out during waves — p99 3–6s, timeouts, circuit trips. Today, when it degrades the image feed's Meili read throws and the feed goes **unusable** (hard 503) exactly when traffic is highest. This PR makes the feed degrade **"stale-but-fast"**: on a recognized transient Meili failure, serve the **last-good** result for the *same visibility query* instead of erroring.

Scoped to the **confirmed dominant hot path**: `getImagesFromSearchPreFilter` (the `image.getInfinite → getInfiniteImagesHandler → getAllImagesIndex` metricsSearch feed — the code itself notes "this is where the 374-error/15min Meili bleed lives"). The post-filter variant (behind the `FEED_POST_FILTER` flag) and `getImagesFromFeedSearch` (REST, "0 errors/15min") are intentionally **out of scope** for a minimal first cut — see Follow-ups.

### Behavior: today vs after
| | Meili healthy | Meili transient failure (timeout / circuit-open / transient SDK error) | Genuine 0 results | Non-transient error (validation/auth/app bug) |
|---|---|---|---|---|
| **Today** | live result | `getAllImagesIndex` maps to **503** → feed unusable | `[]` | bubbles as its real status (500) |
| **After** | **live result, byte-identical** (+ last-good cache refreshed, fire-and-forget) | serve **last-good** if within the stale bound, else **503** (unchanged) | `[]` (unchanged) | bubbles unchanged — cache is **not** consulted |

The happy path is unchanged: `run()`'s live value is returned byte-for-byte and the cache write is fire-and-forget (`.catch()`, not awaited), so a slow/failed write never adds latency to nor can fail a successful search.

### Cache-key composition + why it's NSFW-safe (the load-bearing property)
The stale entry is keyed on a **sha256** of the **fully-composed Meili request**: `[index, filter, sort, limit, offset]`. In `getImagesFromSearchPreFilter` the `filter` string is the **sole determinant of which documents Meili may return**, and it encodes **every** visibility dimension:

- **browsingLevel** → `nsfwLevel IN […]` / `combinedNsfwLevel IN […]`
- **moderator status** → the mod-only carve-outs (poi/minor/blockedFor, level-0)
- **the viewer's own id** → `OR "userId" = <id>` own-carve-outs on the availability / blocked / nsfw / published clauses
- **hidden / followed** → resolved to explicit id-lists baked into the filter
- **excluded tags / users** → `tagIds NOT IN […]` / `userId NOT IN […]`
- tags / tools / types / baseModels / period / postId / modelVersionId / remix / etc.

Therefore two requests that hash to the same key have **byte-identical visibility semantics**, so serving one's stored result for the other **cannot leak content across browsing levels or across per-user visibility scopes**. A different browsingLevel → a different `nsfwLevel IN […]` clause → a different filter string → a different key (asserted in tests). Because the own-carve-out embeds `currentUserId`, any personalized query is automatically scoped to that user; anonymous / browsing-level-only queries (the dominant, shared wave traffic — and the safest) share a key.

- **Why sha256, not the app's 32-bit `hashifyObject`:** a 32-bit hash collides at ~65k distinct keys, and a collision here would serve one visibility scope's content under another — an NSFW leak. A 256-bit digest makes that negligible.
- **Enrichment stays fresh:** we cache only the raw search output (`{ data, nextCursor }`). Downstream `getAllImagesIndex` re-runs *all* per-user enrichment on the (stale) ids — user data, metrics, tagIds (client-side hidden-tag filtering), and the `model3dId` visibility resolution — so only "which image ids, in what order" is stale.

### Stale-age bound
Served **only** if the entry is within `MEILI_STALE_MAX_AGE_MS` (**5 min**). Enforced twice: Redis `EX` expiry **and** an explicit `cachedAt` check on read (belt-and-suspenders + unit-testable). Past the bound → fall through to today's behavior (throw → 503). 5 min rides out a typical brownout/circuit-cooldown cycle while keeping the additive nsfwLevel-drift window (below) small; the feed's `sortAt` is already minute-snapped.

### Documented residual risk (bounded)
A cached doc carries the `nsfwLevel` it had at cache time. If an image is **re-rated** (e.g. PG→X) *after* caching, a stale serve could show it under the old level for ≤ the stale bound. This is the **same eventual-consistency window that already exists in the live Meili index** (re-rate → reindex lag is minutes) and in BitDex; stale-serve adds at most `MEILI_STALE_MAX_AGE` on top. Kept tight (5 min) to keep that additive window small. (Also: a doc deleted after caching could appear briefly — deleted ≠ NSFW, bounded, acceptable.)

### Observability
New counter `civitai_app_meili_stale_served_total{backend,route}` (registered alongside the other `civitai_app_meili_*` metrics), incremented each time a stale result is served. A nonzero rate **masks a real Meili brownout** users don't see — alert on it as a leading indicator.

### Files changed
- `packages/civitai-redis/src/client.ts` — new key `REDIS_KEYS.CACHES.IMAGE_SEARCH_STALE`.
- `src/server/meilisearch/client.ts` — register + export `meiliStaleServedTotal`.
- `src/server/meilisearch/image-search-stale-cache.ts` — **new** helper: `buildImageSearchStaleKey` (sha256), `readImageSearchStale` (bound-enforcing, never throws), `writeImageSearchStale` (fire-and-forget + `EX`), `staleServeOnError` (the SWR-on-error orchestrator), `MEILI_STALE_MAX_AGE_MS`.
- `src/server/services/image.service.ts` — wire `getImagesFromSearchPreFilter` through `staleServeOnError`; only transient (`isTransientMeiliError`) failures consult the cache.
- `src/server/meilisearch/__tests__/image-search-stale-cache.test.ts` — **new**, 17 tests.

### Tests (17, all green)
- **Key (security):** identical parts → identical key; **different browsingLevel (nsfwLevel filter) → different key**; different own-carve-out per user → 3 distinct keys; differs on sort/limit/offset/index; namespace prefix.
- **Bound:** round-trips within bound; **null past bound**; serves right up to the bound, not one ms past; null when absent; read never throws on redis error; write never rejects.
- **Orchestrator:** healthy → live value byte-identically + writes + **no stale read**; **genuine empty → returned as-is, not stale-served**; transient + fresh stale → serve + metric; transient + stale null → rethrow, no metric; **non-recoverable → rethrow without reading cache**; read-throws → rethrow the **original** error.

Full `tsc --noEmit` clean (with the `event-engine-common` submodule present).

### Risks / decisions for review
1. **Write amplification / keyspace:** the last-good cache is written on **every** successful prefilter search (fire-and-forget, `EX=300s`). Anonymous/browsing-level keys are few and highly shared; logged-in own-carve-out keys are per-user (low reuse, self-expiring in 5 min). Payload is ~100 msgpack'd search docs. Reviewable: gate writes to first-page / small-offset only, or to anonymous requests, if Redis pressure is a concern.
2. **Scope:** prefilter only. If `FEED_POST_FILTER` or the REST feed path is meaningfully live, extend `staleServeOnError` there too (same helper).
3. **Stale bound (5 min):** could be made a `MEILI_STALE_MAX_AGE_MS` env for runtime ops-tuning (mirrors the other `MEILI_*` envs) — left as a module const to keep surface minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
