### PR TITLE
fix(blocks): bound sysRedis rate-limiter waits with withSysReadDeadline (cli#28)

### DIFF
--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -5,7 +5,7 @@ import type { SessionUser } from '~/types/session';
 import * as z from 'zod';
 import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
 import { dbWrite } from '~/server/db/client';
-import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
+import { sysRedis, REDIS_SYS_KEYS, withSysReadDeadline } from '~/server/redis/client';
 import { SLUG_REGEX } from '~/server/schema/blocks/publish-request.schema';
 import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { BlockTokenService } from '~/server/services/block-token.service';
@@ -416,14 +416,23 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   const rateKey = `${REDIS_SYS_KEYS.BLOCKS.DEV_TOKEN_RATE_LIMIT}:${rateSubject}` as const;
   let count: number;
   try {
-    const multiResult = await sysRedis
-      .multi()
-      .set(rateKey, '0', { NX: true, EX: RATE_LIMIT.windowSeconds })
-      .incr(rateKey)
-      .exec();
+    // withSysReadDeadline (#28): the raw sysRedis MULTI runs on the request's
+    // critical path. On a SILENT half-open the written command parks in node-redis's
+    // reply queue until OS TCP keepalive (~11min) — a HANG, not a throw, so the
+    // try/catch alone can't unpark it. Racing the `.exec()` against the sys read
+    // deadline (default REDIS_SYS_READ_TIMEOUT_MS=2000) turns that open-ended hang
+    // into a clean rejection caught here → fail closed (503) instead of parking.
+    const multiResult = await withSysReadDeadline(
+      sysRedis
+        .multi()
+        .set(rateKey, '0', { NX: true, EX: RATE_LIMIT.windowSeconds })
+        .incr(rateKey)
+        .exec()
+    );
     count = Number(multiResult?.[1]);
   } catch (err) {
-    // A Redis incident must NEVER silently bypass the mint — fail closed.
+    // A Redis incident (a throw OR a deadline-bounded hang) must NEVER silently
+    // bypass the mint — fail closed.
     req.log?.warn('blocks/dev-token: rate limiter threw; failing closed', { rateSubject });
     res.status(503).json({ message: 'Rate limiter unavailable; please retry' });
     return;
@@ -441,11 +450,18 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   // footgun). Re-arm only when the TTL is actually missing, so we never extend an
   // active window. Best-effort — mirrors block-token.service.ts:274-275.
   if (count > 1) {
-    const ttl = await sysRedis.ttl(rateKey).catch(() => -1);
+    // Bound the self-heal TTL read too (#28): a hung sysRedis.ttl would park the
+    // mint just past the limiter. The deadline reject folds into the existing -1
+    // fallback (treat as "no TTL" → best-effort re-arm), never a hang.
+    const ttl = await withSysReadDeadline(sysRedis.ttl(rateKey)).catch(() => -1);
     if (ttl < 0) await sysRedis.expire(rateKey, RATE_LIMIT.windowSeconds).catch(() => {});
   }
   if (count > RATE_LIMIT.max) {
-    const retryAfter = await sysRedis.ttl(rateKey);
+    // Bound the 429-path TTL read (#28) so a hung sysRedis.ttl can't park the
+    // over-limit response. On a deadline/throw fall back to the full window.
+    const retryAfter = await withSysReadDeadline(sysRedis.ttl(rateKey)).catch(
+      () => RATE_LIMIT.windowSeconds
+    );
     res.setHeader('Retry-After', String(Math.max(retryAfter, 1)));
     res.status(429).json({
       message: 'Rate limit exceeded',

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -454,7 +454,13 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     // mint just past the limiter. The deadline reject folds into the existing -1
     // fallback (treat as "no TTL" → best-effort re-arm), never a hang.
     const ttl = await withSysReadDeadline(sysRedis.ttl(rateKey)).catch(() => -1);
-    if (ttl < 0) await sysRedis.expire(rateKey, RATE_LIMIT.windowSeconds).catch(() => {});
+    // Fire-and-forget the self-heal re-arm (#28 audit 🟡): this is a best-effort
+    // sysRedis WRITE and withSysReadDeadline deliberately does NOT race sys writes
+    // (the #2556/#2586 wedge). Awaiting it would re-open the exact park this PR
+    // closes — on a client that half-opens AFTER exec() resolved, the awaited
+    // expire on the dead socket parks the mint ~11min. `void` lets the response
+    // proceed; the .catch keeps the orphaned promise from surfacing as unhandled.
+    if (ttl < 0) void sysRedis.expire(rateKey, RATE_LIMIT.windowSeconds).catch(() => {});
   }
   if (count > RATE_LIMIT.max) {
     // Bound the 429-path TTL read (#28) so a hung sysRedis.ttl can't park the

--- a/src/pages/api/v1/blocks/submit-version.ts
+++ b/src/pages/api/v1/blocks/submit-version.ts
@@ -3,7 +3,7 @@ import { withAxiom } from '@civitai/next-axiom';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { SessionUser } from '~/types/session';
 import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
-import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
+import { sysRedis, REDIS_SYS_KEYS, withSysReadDeadline } from '~/server/redis/client';
 import { submitVersionSchema } from '~/server/schema/blocks/publish-request.schema';
 import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
@@ -185,18 +185,35 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   // left as a deliberate follow-up to keep this PR's auth change focused.
   const rateSubject = session.apiKeyId ? `key:${session.apiKeyId}` : `ip:${clientIp(req)}`;
   const rateKey = `${REDIS_SYS_KEYS.BLOCKS.SUBMIT_RATE_LIMIT}:${rateSubject}` as const;
-  const multiResult = await sysRedis
-    .multi()
-    .set(rateKey, '0', { NX: true, EX: RATE_LIMIT.windowSeconds })
-    .incr(rateKey)
-    .exec();
-  // F3 — fail CLOSED, not open, on a malformed limiter result. If `exec()`
-  // returns null/short (Redis hiccup, MULTI aborted), `Number(undefined)` is
-  // `NaN` and `NaN > max` is `false`, which would let the request slip through
-  // un-limited. Treat a non-finite counter as "limiter unavailable" and reject
-  // (503) rather than silently bypass — this is a heavy, mod-gated bundle upload,
-  // so erring toward refusal is correct.
-  const count = Number(multiResult?.[1]);
+  // F3 — fail CLOSED, not open. If `exec()` returns null/short (Redis hiccup, MULTI
+  // aborted), `Number(undefined)` is `NaN` and `NaN > max` is `false`, which would
+  // let the request slip through un-limited. Treat a non-finite counter as "limiter
+  // unavailable" and reject (503) rather than silently bypass — this is a heavy,
+  // mod-gated bundle upload, so erring toward refusal is correct.
+  //
+  // withSysReadDeadline (#28): the raw sysRedis MULTI runs on the request's critical
+  // path. On a SILENT half-open the written command parks in node-redis's reply queue
+  // until OS TCP keepalive (~11min) — a HANG, not a throw. Racing the `.exec()` against
+  // the sys read deadline (default REDIS_SYS_READ_TIMEOUT_MS=2000) turns that open-ended
+  // hang into a clean rejection; the surrounding try/catch (mirrors dev-token) then fails
+  // closed (503) instead of parking the submit indefinitely.
+  let count: number;
+  try {
+    const multiResult = await withSysReadDeadline(
+      sysRedis
+        .multi()
+        .set(rateKey, '0', { NX: true, EX: RATE_LIMIT.windowSeconds })
+        .incr(rateKey)
+        .exec()
+    );
+    count = Number(multiResult?.[1]);
+  } catch (err) {
+    // A Redis incident (a throw OR a deadline-bounded hang) must NEVER silently
+    // bypass the mint — fail closed.
+    req.log?.warn('blocks/submit-version: rate limiter threw; failing closed', { rateSubject });
+    res.status(503).json({ message: 'Rate limiter unavailable; please retry' });
+    return;
+  }
   if (!Number.isFinite(count)) {
     req.log?.warn('blocks/submit-version: rate-limit counter malformed; failing closed', {
       rateSubject,
@@ -205,7 +222,11 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     return;
   }
   if (count > RATE_LIMIT.max) {
-    const retryAfter = await sysRedis.ttl(rateKey);
+    // Bound the 429-path TTL read (#28) so a hung sysRedis.ttl can't park the
+    // over-limit response. On a deadline/throw fall back to the full window.
+    const retryAfter = await withSysReadDeadline(sysRedis.ttl(rateKey)).catch(
+      () => RATE_LIMIT.windowSeconds
+    );
     res.setHeader('Retry-After', String(Math.max(retryAfter, 1)));
     res.status(429).json({
       message: 'Rate limit exceeded',

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -65,22 +65,42 @@ const {
   mockPublishRequestFindFirst,
   mockSysRedis,
   mockMultiIncr,
+  mockWithSysReadDeadline,
+  sysDeadline,
 } = vi.hoisted(() => {
   const mockMultiIncr = {
     value: 1,
     malformedExec: false as unknown[] | null | false,
     throwExec: false,
+    // #28: simulate a SILENT half-open where `.exec()` never settles (parks the
+    // handler). withSysReadDeadline must reject it within the deadline → 503.
+    hangExec: false,
   };
   const multiFactory = () => ({
     set: vi.fn().mockReturnThis(),
     incr: vi.fn().mockReturnThis(),
     exec: vi.fn().mockImplementation(async () => {
+      if (mockMultiIncr.hangExec) return new Promise(() => {}); // never settles
       if (mockMultiIncr.throwExec) throw new Error('redis down');
       return mockMultiIncr.malformedExec !== false
         ? mockMultiIncr.malformedExec
         : ['OK', mockMultiIncr.value];
     }),
   });
+  // Faithful stand-in for the real withSysReadDeadline (sys-read-deadline.ts): race
+  // the wrapped promise against a rejecting timer; `<= 0` disables (no-op). A tiny
+  // default ms keeps the never-settles tests fast without fake timers.
+  const sysDeadline = { ms: 50 };
+  const mockWithSysReadDeadline = <T>(p: Promise<T>, ms = sysDeadline.ms): Promise<T> => {
+    if (!ms || ms <= 0) return p;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`sysRedis read timed out after ${ms}ms`)), ms);
+    });
+    return Promise.race([p, deadline]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+  };
   return {
     mockGetSession: vi.fn(),
     mockIsAppBlocksEnabled: vi.fn(),
@@ -94,6 +114,8 @@ const {
       expire: vi.fn().mockResolvedValue(1),
     },
     mockMultiIncr,
+    mockWithSysReadDeadline,
+    sysDeadline,
   };
 });
 
@@ -115,6 +137,7 @@ vi.mock('~/server/db/client', () => ({
 vi.mock('~/server/redis/client', () => ({
   sysRedis: mockSysRedis,
   REDIS_SYS_KEYS: { BLOCKS: { DEV_TOKEN_RATE_LIMIT: 'system:blocks:dev-token-rate-limit' } },
+  withSysReadDeadline: mockWithSysReadDeadline,
 }));
 vi.mock('~/env/server', () => ({
   env: { BLOCK_TOKEN_PRIVATE_KEY: 'priv', BLOCK_TOKEN_PUBLIC_KEY: 'pub' },
@@ -213,6 +236,8 @@ beforeEach(() => {
   mockMultiIncr.value = 1;
   mockMultiIncr.malformedExec = false;
   mockMultiIncr.throwExec = false;
+  mockMultiIncr.hangExec = false;
+  sysDeadline.ms = 50;
   mockSysRedis.ttl.mockResolvedValue(60);
   mockSysRedis.expire.mockResolvedValue(1);
   mockIsAppBlocksEnabled.mockResolvedValue(true);
@@ -453,6 +478,35 @@ describe('POST /api/v1/blocks/dev-token', () => {
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(503);
     // A Redis incident must never silently bypass the mint.
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('503 (fail closed) when the rate-limit exec() HANGS (#28: silent half-open never settles) — deadline-bounded, no park', async () => {
+    // The #28 root cause: a raw sysRedis MULTI on the critical path parks the
+    // handler on a silent half-open (no throw). withSysReadDeadline races the
+    // never-settling exec() against the deadline → rejects → the existing catch
+    // fails closed (503) instead of hanging ~11min to TCP keepalive.
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.hangExec = true;
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never); // must RESOLVE (not hang)
+    expect(res._getStatusCode()).toBe(503);
+    // A hung limiter must never silently bypass the mint.
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('429 path does not park when the retry-after sysRedis.ttl HANGS (#28) — falls back to the window', async () => {
+    // Over the limit → the 429 path reads ttl for Retry-After. A hung ttl must not
+    // park the over-limit response: the deadline reject folds into the windowSeconds
+    // fallback so a 429 is still returned promptly.
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.value = 31; // > RATE_LIMIT.max (30)
+    mockSysRedis.ttl.mockReturnValueOnce(new Promise(() => {})); // never settles
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never); // must RESOLVE
+    expect(res._getStatusCode()).toBe(429);
+    // Fallback Retry-After = RATE_LIMIT.windowSeconds (60).
+    expect(res._getHeaders()['Retry-After']).toBe('60');
     expect(mockSign).not.toHaveBeenCalled();
   });
 

--- a/src/tests/api/v1/blocks/submit-version.test.ts
+++ b/src/tests/api/v1/blocks/submit-version.test.ts
@@ -49,19 +49,42 @@ const {
   mockSubmitVersion,
   mockRedis,
   mockMultiIncr,
+  mockWithSysReadDeadline,
+  sysDeadline,
 } = vi.hoisted(() => {
   // `exec()` normally returns ['OK', <count>]. `malformedExec` simulates a Redis
   // hiccup / aborted MULTI where the result is null or short (F3 fail-closed).
-  const mockMultiIncr = { value: 1, malformedExec: null as unknown[] | null | false };
+  // `hangExec` (#28) simulates a SILENT half-open where `.exec()` never settles —
+  // withSysReadDeadline must reject it within the deadline → fail closed (503).
+  const mockMultiIncr = {
+    value: 1,
+    malformedExec: null as unknown[] | null | false,
+    hangExec: false,
+  };
   const multiFactory = () => ({
     set: vi.fn().mockReturnThis(),
     incr: vi.fn().mockReturnThis(),
-    exec: vi.fn().mockImplementation(async () =>
-      mockMultiIncr.malformedExec !== false
+    exec: vi.fn().mockImplementation(async () => {
+      if (mockMultiIncr.hangExec) return new Promise(() => {}); // never settles
+      return mockMultiIncr.malformedExec !== false
         ? mockMultiIncr.malformedExec
-        : ['OK', mockMultiIncr.value]
-    ),
+        : ['OK', mockMultiIncr.value];
+    }),
   });
+  // Faithful stand-in for the real withSysReadDeadline (sys-read-deadline.ts): race
+  // the wrapped promise against a rejecting timer; `<= 0` disables (no-op). A tiny
+  // default ms keeps the never-settles tests fast without fake timers.
+  const sysDeadline = { ms: 50 };
+  const mockWithSysReadDeadline = <T>(p: Promise<T>, ms = sysDeadline.ms): Promise<T> => {
+    if (!ms || ms <= 0) return p;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`sysRedis read timed out after ${ms}ms`)), ms);
+    });
+    return Promise.race([p, deadline]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+  };
   return {
     mockGetSession: vi.fn(),
     mockIsAppBlocksEnabled: vi.fn(),
@@ -69,6 +92,8 @@ const {
     mockSubmitVersion: vi.fn(),
     mockRedis: { multi: vi.fn(multiFactory), ttl: vi.fn().mockResolvedValue(60) },
     mockMultiIncr,
+    mockWithSysReadDeadline,
+    sysDeadline,
   };
 });
 
@@ -83,6 +108,7 @@ vi.mock('~/server/services/app-blocks-flag', () => ({
 vi.mock('~/server/redis/client', () => ({
   sysRedis: mockRedis,
   REDIS_SYS_KEYS: { BLOCKS: { SUBMIT_RATE_LIMIT: 'blocks:submit-rate-limit' } },
+  withSysReadDeadline: mockWithSysReadDeadline,
 }));
 // The route dynamically imports env + the service; mock both so the heavy
 // dependency tree never loads in the unit test.
@@ -145,6 +171,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockMultiIncr.value = 1;
   mockMultiIncr.malformedExec = false;
+  mockMultiIncr.hangExec = false;
+  sysDeadline.ms = 50;
   mockRedis.ttl.mockResolvedValue(60);
   mockIsAppBlocksEnabled.mockResolvedValue(true);
   // Author gate mirrors the mod floor by default; the widening test overrides it.
@@ -329,6 +357,38 @@ describe('POST /api/v1/blocks/submit-version (token auth)', () => {
     });
     await handler(req as never, res as never);
     expect(res._getStatusCode()).toBe(503);
+    expect(mockSubmitVersion).not.toHaveBeenCalled();
+  });
+
+  it('#28: 503 (fail closed) when the rate-limit exec() HANGS (silent half-open never settles) — deadline-bounded, no park', async () => {
+    // The #28 root cause: this route's raw sysRedis MULTI runs on the critical path
+    // with NO try/catch. On a silent half-open the written command parks the handler
+    // (no throw). withSysReadDeadline races the never-settling exec() → rejects → the
+    // new try/catch fails closed (503) instead of hanging ~11min to TCP keepalive.
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.hangExec = true;
+    const { req, res } = createMocks({
+      headers: { authorization: 'Bearer key' },
+      body: goodBody,
+    });
+    await handler(req as never, res as never); // must RESOLVE (not hang)
+    expect(res._getStatusCode()).toBe(503);
+    // A hung limiter must never silently bypass the heavy publish path.
+    expect(mockSubmitVersion).not.toHaveBeenCalled();
+  });
+
+  it('#28: 429 path does not park when the retry-after sysRedis.ttl HANGS — falls back to the window', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockMultiIncr.value = 11; // > RATE_LIMIT.max (10)
+    mockRedis.ttl.mockReturnValueOnce(new Promise(() => {})); // never settles
+    const { req, res } = createMocks({
+      headers: { authorization: 'Bearer key' },
+      body: goodBody,
+    });
+    await handler(req as never, res as never); // must RESOLVE
+    expect(res._getStatusCode()).toBe(429);
+    // Fallback Retry-After = RATE_LIMIT.windowSeconds (60).
+    expect(res._getHeaders()['Retry-After']).toBe('60');
     expect(mockSubmitVersion).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Root cause (civitai/cli#28)

`POST /api/v1/blocks/dev-token` intermittently **hangs** (HTTP 000, 8–40s+, ~2 of 3 calls) then the client gives up; the rest respond ~0.17s.

The per-request rate limiter runs a **raw, unwrapped `sysRedis` MULTI** (`SET NX EX` + `INCR`) on the request's critical path. The single-replica sys client carries no per-command socket timeout (deliberately, to avoid the #2556/#2586 reconnect-storm wedge). When it goes **silently half-open** (still believes it's connected), node-redis parks the written command in its reply queue until OS TCP keepalive errors the socket (~11 min on Linux defaults) — **parking the request handler**. Because this is a *hang*, not a *throw*, the existing `try/catch` (which only catches rejections) does not help.

## Fix

Bound every per-request **sysRedis** wait with the purpose-built `withSysReadDeadline(promise, ms?)` (`src/server/redis/sys-read-deadline.ts`, default `REDIS_SYS_READ_TIMEOUT_MS` = **2000ms**, live/unset in dp-prod). It races the promise against a timer and **rejects** on timeout, converting an open-ended hang into a deterministic reject that each site's existing fail policy then handles.

### The 3 sites

1. **`src/pages/api/v1/blocks/dev-token.ts`** (sysRedis) — wrap the `.exec()` (folds into the existing **fail-CLOSED 503** catch: `"Rate limiter unavailable; please retry"`), the self-heal `ttl` (folds into the existing `-1` fallback), and the 429-path `ttl` (safe `RATE_LIMIT.windowSeconds` fallback so a hang can't park the 429 response).

2. **`src/pages/api/v1/blocks/submit-version.ts`** (sysRedis) — same raw MULTI, but it had **no `try/catch` at all**. Wrap the `.exec()` **and add** a fail-CLOSED 503 `try/catch` mirroring dev-token's shape exactly (including the `req.log?.warn(...)` line); keep the existing `Number.isFinite` fail-closed check; wrap the 429-path `ttl` with the `windowSeconds` fallback.

3. **`src/server/services/block-token.service.ts` `checkRateLimit`** — **LEFT UNCHANGED (verified).** This site uses the **cluster** `redis` client (`redis.incrBy` / `expire` / `ttl`). Cluster commands route through `_execute`, which `instrumentCommands` (packages/civitai-redis/src/client.ts) **already auto-wraps with `withCommandDeadline`** (`wrapWithDeadline = isClusterClient && clientLabel === 'cluster'`) at the client layer. So a stuck cluster command already rejects within `REDIS_CLUSTER_COMMAND_TIMEOUT_MS` and hits the site's existing **fail-open** `catch { return true }` — the #28 hang cannot occur here, and no change is needed (fail-open semantics preserved).

## Why each fix is safe

- **Deterministic / structural**, not a prose or threshold tweak. No rate-limit thresholds, keys, budgets, scopes, or auth logic changed — byte-for-byte identical otherwise.
- **No-op on a healthy redis**: the wrapped read resolves well within 2000ms, the timer is cleared in `finally`, `Promise.race` reaps any late rejection.
- **Preserves each site's posture**: dev-token + submit-version limiter stay **fail-CLOSED** (503); the ttl fallbacks degrade to a sane Retry-After; block-token.service stays **fail-OPEN**.

## Tests

Added focused coverage proving the new behavior (mock `sysRedis`/`withSysReadDeadline` so `.exec()` / `ttl` return never-settling promises; a faithful in-test `withSysReadDeadline` stand-in with a tiny default ms):

- **dev-token**: `.exec()` that never settles → **503** within the deadline (not a hang); 429-path `ttl` that never settles → still **429** with `Retry-After: 60`.
- **submit-version**: `.exec()` that never settles → **503** (via the newly-added catch); 429-path `ttl` that never settles → still **429** with `Retry-After: 60`.

```
Test Files  2 passed (2)
     Tests  95 passed (95)
```
(dev-token 74→76, submit-version 17→19.) Full `tsc --noEmit` shows no errors in any touched file (remaining baseline errors are pre-existing sibling-repo / kysely module-resolution noise unrelated to this change).

Refs civitai/cli#28

🤖 Generated with [Claude Code](https://claude.com/claude-code)