### PR TITLE
feat(blocks): per-account buzz spend + host-mediated balance read (Phase 1 backend)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -3357,4 +3357,156 @@ describe('blocks workflow — buzz-type parity + spend-attribution currency', ()
       });
     });
   });
+
+  // ---- viewer-picked accountType (money page blocks) ----------------------
+  // The exact reordered orchestrator currency VALUES can't be asserted here
+  // (the global @civitai/client mock nulls out BuzzClientAccount, so
+  // toOrchestratorType yields non-comparable values — the ORDERING is asserted
+  // on the pure BuzzSpendType strings in buzz-helpers.test.ts). Here we pin the
+  // ROUTER-level behavior: an ALLOWED / ABSENT pick submits normally, and a
+  // DISALLOWED pick is REJECTED before any orchestrator spend.
+  describe('honors body.accountType (preferred-first, domain-clamped)', () => {
+    it('absent accountType → submits normally (Auto, both submit sites fire)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 1000, maxBrowsingLevel: SFW_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      happySubmit();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(2);
+      // Auto still derives the 2-element parity currency set at both sites.
+      expect((bodyOf(0).currencies as unknown[]).length).toBe(2);
+      expect((bodyOf(1).currencies as unknown[]).length).toBe(2);
+    });
+
+    it('ALLOWED accountType (green on a SFW block) → submits normally', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 1000, maxBrowsingLevel: SFW_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      happySubmit();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: validBody({ accountType: 'green' }),
+      });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(2);
+      // whatIf + real still carry the same currency set (estimate matches drain).
+      expect((bodyOf(1).currencies as unknown[]).length).toBe(2);
+    });
+
+    it('DISALLOWED accountType (yellow on a SFW block) → BAD_REQUEST, no spend', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 1000, maxBrowsingLevel: SFW_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody({ accountType: 'yellow' }) })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      // The domain clamp must fire BEFORE any orchestrator interaction.
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('DISALLOWED accountType (green on a mature .red block) → BAD_REQUEST, no spend', async () => {
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 1000, maxBrowsingLevel: ALL_CEILING })
+      );
+      happyVersionLookup();
+      happyUser();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody({ accountType: 'green' }) })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('rejects an out-of-enum accountType at the schema boundary (zod)', async () => {
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({
+          blockToken: 'tok',
+          // `red` is disabled and not in the spendable enum → zod rejects.
+          body: validBody({ accountType: 'red' }) as never,
+        })
+      ).rejects.toThrow();
+    });
+  });
+});
+
+// ---- getMyBuzzBalance (host-mediated, token-bound balance read) ------------
+// Money page blocks read the VIEWER's OWN spendable balances via the block
+// token WITHOUT holding buzz:read:self. userId is derived from the self-bound
+// token sub, never client input — a page can only read its own session's user.
+describe('blocks.getMyBuzzBalance', () => {
+  it('returns the three spendable balances for a valid token (from getUserBuzzAccounts)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    happyUser();
+    // getUserBuzzAccounts returns every spend type; the proc projects to three.
+    mockGetUserBuzzAccounts.mockResolvedValue({ blue: 100, green: 20, yellow: 5, red: 999 });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.getMyBuzzBalance({ blockToken: 'tok' });
+    expect(result).toEqual({ blue: 100, green: 20, yellow: 5 });
+    // Never returns internal types (red / creatorProgram / cash).
+    expect(result).not.toHaveProperty('red');
+    // The balance is read for the TOKEN subject (42), not any client input.
+    expect(mockGetUserBuzzAccounts).toHaveBeenCalledWith({ userId: 42 });
+  });
+
+  it('defaults missing account values to 0', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    happyUser();
+    mockGetUserBuzzAccounts.mockResolvedValue({ blue: 50 } as never);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.getMyBuzzBalance({ blockToken: 'tok' });
+    expect(result).toEqual({ blue: 50, green: 0, yellow: 0 });
+  });
+
+  it('rejects an invalid block token with UNAUTHORIZED (never reads a balance)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyBuzzBalance({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockGetUserBuzzAccounts).not.toHaveBeenCalled();
+  });
+
+  it('rejects an anon subject with UNAUTHORIZED (no balance to read)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ sub: 'anon' }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyBuzzBalance({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockGetUserBuzzAccounts).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the App Blocks flag is disabled (kill-switch)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    happyUser();
+    mockIsAppBlocksEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyBuzzBalance({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+      message: 'App Blocks not enabled',
+    });
+    expect(mockGetUserBuzzAccounts).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-author subject with FORBIDDEN (author gate, no balance read)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    // Enabled kill-switch passes, but the subject is not an app author.
+    mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: false, tier: 'free' });
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyBuzzBalance({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockGetUserBuzzAccounts).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -53,7 +53,6 @@ import { registerExternalAppSchema } from '~/server/schema/blocks/external-app.s
 import { blockWorkflowBodySchema } from '~/server/schema/blocks/workflow.schema';
 import {
   allowMatureContentForCeiling,
-  domainBrowsingCeiling,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -2876,8 +2876,15 @@ export const blocksRouter = router({
   getMyBuzzBalance: publicProcedure
     // Block-JWT-authed (no session for dev:live) — flag evaluated against the
     // TOKEN subject below, not the `enforceAppBlocksFlag` middleware's ctx.user.
+    //
+    // MUTATION (not query) DELIBERATELY: the block JWT is a bearer credential
+    // that ALSO authorizes submitWorkflow (spend). A tRPC .query sends small
+    // inputs as HTTP GET with the input in the URL (?input=...), leaking the
+    // token into CF/nginx/Traefik logs, browser history, and Referer where it
+    // is replayable within its TTL. Every block-token-authed proc in this router
+    // is a mutation for exactly this reason (token in the POST body). Keep it so.
     .input(z.object({ blockToken: z.string().min(1) }))
-    .query(async ({ input }) => {
+    .mutation(async ({ input }) => {
       const claims = await verifyBlockToken(input.blockToken);
       if (!claims) throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid block token' });
       // Derive the user from the SELF-BOUND token subject, never client input.

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -93,7 +93,11 @@ import { getResourceGenerationSupport } from '~/shared/constants/basemodel.const
 import type { ModelType } from '~/shared/utils/prisma/enums';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { BuzzTypes } from '~/shared/constants/buzz.constants';
-import { getBlockAllowedAccountTypes, isPayoutEligibleBuzz } from '~/server/utils/buzz-helpers';
+import {
+  getBlockAllowedAccountTypes,
+  isPayoutEligibleBuzz,
+  orderBlockCurrencyTypes,
+} from '~/server/utils/buzz-helpers';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { getBaseModelSetType, WORKFLOW_TAGS } from '~/shared/constants/generation.constants';
 import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
@@ -2518,7 +2522,12 @@ export const blocksRouter = router({
       // output clamp. SFW → blue/green; mature → blue/yellow. Used by BOTH the
       // whatIf cost-check and the real submit below so the estimate matches what
       // the real submit will actually drain.
-      const currencies = resolveBlockCurrencies(isGreen);
+      //
+      // Money page blocks may pick a preferred `accountType` — honor it
+      // PREFERRED-FIRST while keeping the maturity policy clamp: an in-set pick
+      // is moved to the front (with the rest as fallback); an out-of-set pick is
+      // rejected; absent → Auto (unchanged). See resolveBlockCurrenciesForAccount.
+      const currencies = resolveBlockCurrenciesForAccount(isGreen, input.body.accountType);
 
       if (isPage) {
         const loraGates = await resolvePageLoraGates({
@@ -2842,6 +2851,56 @@ export const blocksRouter = router({
       }
 
       return { snapshot: autoClaim ? { ...snapshot, autoClaim } : snapshot };
+    }),
+
+  /**
+   * HOST-MEDIATED balance read for the token-bound viewer (money page blocks).
+   * Returns the viewer's OWN spendable buzz balances so a page can render an
+   * account picker + "you have N buzz" without the page ever holding the
+   * `buzz:read:self` scope.
+   *
+   * POLICY REVERSAL (intentional, scoped): App Blocks pages are deliberately
+   * FORBIDDEN the `buzz:read:self` scope — a page has no business reading the
+   * viewer's balance directly. This procedure is the FIRST-PARTY host exposing
+   * the viewer's OWN balance to their OWN page session, mediated by the
+   * proof-of-session block token: userId is derived from the token `sub`
+   * (self-bound), NEVER from client input, so a page can only ever read the
+   * balance of the exact user whose session minted the token. This does NOT
+   * lift the scope forbid; `buzz:read:self` stays denied for pages.
+   *
+   * Auth model is IDENTICAL to submitWorkflow's block-token gate: verify the
+   * token, require an authenticated (non-anon) subject, then the App-Blocks
+   * enabled kill-switch + author gate evaluated against the TOKEN subject. Only
+   * the three spendable types the UI needs are returned (blue/green/yellow) —
+   * internal types (red / creatorProgram / cash) are omitted.
+   */
+  getMyBuzzBalance: publicProcedure
+    // Block-JWT-authed (no session for dev:live) — flag evaluated against the
+    // TOKEN subject below, not the `enforceAppBlocksFlag` middleware's ctx.user.
+    .input(z.object({ blockToken: z.string().min(1) }))
+    .query(async ({ input }) => {
+      const claims = await verifyBlockToken(input.blockToken);
+      if (!claims) throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid block token' });
+      // Derive the user from the SELF-BOUND token subject, never client input.
+      const userId = parseSubjectUserId(claims.sub);
+      if (userId == null) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'buzz balance requires an authenticated viewer',
+        });
+      }
+      // Same gates as the other block-token procs, evaluated against the TOKEN
+      // subject: the enabled kill-switch AND the author capability.
+      await assertAppBlocksEnabledForTokenUser(userId);
+      await assertViewerIsAppDeveloper(userId);
+      // getUserBuzzAccounts returns every spend type; project to just the three
+      // spendable types the UI needs (omit red / creator-program / cash).
+      const accounts = await getUserBuzzAccounts({ userId });
+      return {
+        blue: accounts.blue ?? 0,
+        green: accounts.green ?? 0,
+        yellow: accounts.yellow ?? 0,
+      };
     }),
 
   /**
@@ -3741,6 +3800,36 @@ function compareSemver(a: string, b: string): number {
 // See buzz-helpers.ts.
 function resolveBlockCurrencies(isGreen: boolean) {
   return BuzzTypes.toOrchestratorType(getBlockAllowedAccountTypes(isGreen));
+}
+
+// PREFERRED-FIRST + DOMAIN-CLAMPED currency selection for a viewer-picked
+// account (money page blocks). The domain-allowed set is derived from the
+// token's AUTHORITATIVE maturity ceiling (`getBlockAllowedAccountTypes`) — the
+// maturity policy gate — and is NEVER widened here.
+//
+//   - accountType absent          → return the allowed set unchanged (Auto).
+//     Byte-identical to `resolveBlockCurrencies(isGreen)`, so the no-pick path
+//     preserves today's behavior exactly.
+//   - accountType NOT in the set  → REJECT (BAD_REQUEST). A SFW block can't
+//     spend yellow, a mature block can't spend green. We never silently spend a
+//     different account than requested, and never add a disallowed account.
+//   - accountType in the set      → move it to the FRONT, keeping the remaining
+//     allowed currencies as FALLBACK. The orchestrator drains in array order,
+//     so the picked account pays first but a generation still succeeds when the
+//     preferred account alone can't cover it (total across the allowed accounts
+//     is enough) — preferred-first, then fall back.
+function resolveBlockCurrenciesForAccount(
+  isGreen: boolean,
+  accountType: BuzzSpendType | undefined
+): ReturnType<typeof resolveBlockCurrencies> {
+  const { ordered, disallowed } = orderBlockCurrencyTypes(isGreen, accountType);
+  if (disallowed) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `buzz account '${accountType}' is not spendable for this app's content rating`,
+    });
+  }
+  return BuzzTypes.toOrchestratorType(ordered);
 }
 
 /**

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -1,4 +1,15 @@
 import * as z from 'zod';
+import { buzzSpendTypes } from '~/shared/constants/buzz.constants';
+import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
+
+// The spendable buzz account types a viewer may pick for a (money) page block.
+// Reuse the authoritative `buzzSpendTypes` (blue/green/yellow — `red` is
+// disabled and filtered out) rather than a fresh literal so this stays in sync
+// with the buzz-constants source of truth. The domain-maturity policy still
+// CLAMPS which of these is actually spendable per-request in blocks.router
+// (SFW → blue/green, mature → blue/yellow) — this enum only bounds the wire
+// surface; it never widens the allowed set.
+const blockAccountTypeSchema = z.enum(buzzSpendTypes as [BuzzSpendType, ...BuzzSpendType[]]);
 
 // v1: textToImage is the only block-supported kind. Adding a new kind here
 // must also (a) extend the discriminator in blocks.router workflow procedures,
@@ -48,6 +59,13 @@ const blockTextToImageBodySchema = z.object({
   // base-model-family-matches against the checkpoint before any spend. Capped
   // at MAX_ADDITIONAL_RESOURCES for the iframe posture above.
   additionalResources: z.array(blockAdditionalResourceSchema).max(MAX_ADDITIONAL_RESOURCES).optional(),
+  // Optional viewer-picked buzz account to spend (money page blocks). Absent →
+  // unchanged Auto behavior (domain-allowed currencies drained blue-first). When
+  // present, blocks.router moves it to the FRONT of the domain-allowed currency
+  // order (preferred-first, then fall back) and REJECTS it if it's outside the
+  // domain-allowed set — the maturity policy is never widened here. See
+  // `resolveBlockCurrenciesForAccount`.
+  accountType: blockAccountTypeSchema.optional(),
   params: z.object({
     prompt: z.string().max(PROMPT_MAX).default(''),
     negativePrompt: z.string().max(NEG_PROMPT_MAX).optional(),
@@ -80,6 +98,12 @@ export type BlockWorkflowSnapshot = {
   cost?: { total: number };
   imageUrls?: string[];
   error?: string;
+  // The buzz account that primarily funded this generation (the accountType of
+  // the largest realized debit). OPTIONAL + additive: existing consumers that
+  // don't read it are unaffected. Only the account TYPE is surfaced — nothing
+  // beyond what `cost.total` already implies. Absent on estimates, cache-hits,
+  // or any snapshot the orchestrator returned without transactions.
+  spentAccountType?: BuzzSpendType;
   autoClaim?: {
     type: 'dailyBoost';
     amount: number;

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -141,6 +141,75 @@ describe('snapshotFromWorkflow', () => {
     const snap = snapshotFromWorkflow(wf as never);
     expect(snap.imageUrls).toBeUndefined();
   });
+
+  // ---- spentAccountType (money page blocks) --------------------------------
+  // The snapshot surfaces the account that PRIMARILY funded the generation:
+  // the accountType of the LARGEST realized debit on transactions.list.
+  describe('spentAccountType (realized spent account)', () => {
+    it('omits spentAccountType when there are no transactions (backward compatible)', () => {
+      const snap = snapshotFromWorkflow(fakeWorkflow() as never);
+      expect(snap.spentAccountType).toBeUndefined();
+    });
+
+    it('omits spentAccountType when the transactions list is empty', () => {
+      const snap = snapshotFromWorkflow(
+        fakeWorkflow({ transactions: { list: [] } }) as never
+      );
+      expect(snap.spentAccountType).toBeUndefined();
+    });
+
+    it('surfaces the accountType of the largest debit (split blue+green → green when green is larger)', () => {
+      const snap = snapshotFromWorkflow(
+        fakeWorkflow({
+          transactions: {
+            list: [
+              { type: 'debit', amount: 10, accountType: 'blue' },
+              { type: 'debit', amount: 90, accountType: 'green' },
+            ],
+          },
+        }) as never
+      );
+      expect(snap.spentAccountType).toBe('green');
+    });
+
+    it('reports blue when blue is the largest debit (free-funded generation)', () => {
+      const snap = snapshotFromWorkflow(
+        fakeWorkflow({
+          transactions: {
+            list: [
+              { type: 'debit', amount: 80, accountType: 'blue' },
+              { type: 'debit', amount: 5, accountType: 'yellow' },
+            ],
+          },
+        }) as never
+      );
+      expect(snap.spentAccountType).toBe('blue');
+    });
+
+    it('ignores credits when picking the largest debit', () => {
+      const snap = snapshotFromWorkflow(
+        fakeWorkflow({
+          transactions: {
+            list: [
+              { type: 'debit', amount: 20, accountType: 'yellow' },
+              // A larger CREDIT (refund/correction) must not be treated as a spend.
+              { type: 'credit', amount: 100, accountType: 'green' },
+            ],
+          },
+        }) as never
+      );
+      expect(snap.spentAccountType).toBe('yellow');
+    });
+
+    it('omits spentAccountType when the largest debit is an internal-only account (fakeRed)', () => {
+      const snap = snapshotFromWorkflow(
+        fakeWorkflow({
+          transactions: { list: [{ type: 'debit', amount: 50, accountType: 'fakeRed' }] },
+        }) as never
+      );
+      expect(snap.spentAccountType).toBeUndefined();
+    });
+  });
 });
 
 describe('resolveBlockVersionContext', () => {

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import type { Workflow, WorkflowStatus } from '@civitai/client';
+import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { dbRead } from '~/server/db/client';
 import { getBaseModelSetType } from '~/shared/constants/generation.constants';
 import { getEcosystem } from '~/shared/constants/basemodel.constants';
@@ -48,6 +49,7 @@ export function snapshotFromWorkflow(workflow: Workflow): BlockWorkflowSnapshot 
     }
   }
   const total = workflow.cost?.total;
+  const spentAccountType = primaryDebitedAccountType(workflow.transactions);
   return {
     // A whatif/estimate workflow has no orchestrator id. The block SDK's
     // inbound validator (isValidWorkflowSnapshot) DROPS any snapshot whose
@@ -61,7 +63,42 @@ export function snapshotFromWorkflow(workflow: Workflow): BlockWorkflowSnapshot 
     status,
     ...(typeof total === 'number' ? { cost: { total } } : {}),
     ...(imageUrls.length > 0 ? { imageUrls } : {}),
+    // Surface the realized spent account (money page blocks). Additive +
+    // optional — omitted when there's no debit to report so every existing
+    // snapshot stays byte-identical to before.
+    ...(spentAccountType ? { spentAccountType } : {}),
   };
+}
+
+// The three spendable buzz accounts a snapshot surfaces. `fakeRed` is
+// disabled/internal and never a real spend; credits and any other account type
+// are not reported.
+const SNAPSHOT_SPENDABLE_ACCOUNTS: ReadonlySet<string> = new Set<BuzzSpendType>([
+  'blue',
+  'green',
+  'yellow',
+]);
+
+/**
+ * The buzz account that PRIMARILY funded a generation — the accountType of the
+ * largest realized `debit` on the orchestrator's `transactions.list`. A single
+ * generation can split across free (blue) and paid (green/yellow) buzz; we
+ * report the account with the biggest debit as the primary funder. Returns
+ * `undefined` when there are no debits (estimate / cache-hit / no-transactions
+ * snapshot) or the largest debit is an internal-only account (fakeRed), so the
+ * field is simply omitted rather than leaking a non-spendable type.
+ */
+function primaryDebitedAccountType(
+  transactions: Workflow['transactions']
+): BuzzSpendType | undefined {
+  const debits = (transactions?.list ?? []).filter((t) => t.type === 'debit');
+  if (debits.length === 0) return undefined;
+  const largest = debits.reduce((a, b) =>
+    Math.abs(b.amount ?? 0) > Math.abs(a.amount ?? 0) ? b : a
+  );
+  return SNAPSHOT_SPENDABLE_ACCOUNTS.has(largest.accountType)
+    ? (largest.accountType as BuzzSpendType)
+    : undefined;
 }
 
 /**

--- a/src/server/utils/__tests__/buzz-helpers.test.ts
+++ b/src/server/utils/__tests__/buzz-helpers.test.ts
@@ -3,6 +3,7 @@ import {
   getAllowedAccountTypes,
   getBlockAllowedAccountTypes,
   isPayoutEligibleBuzz,
+  orderBlockCurrencyTypes,
   PAYOUT_ELIGIBLE_BUZZ_TYPES,
 } from '~/server/utils/buzz-helpers';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
@@ -84,5 +85,55 @@ describe('isPayoutEligibleBuzz — payout-safety allowlist', () => {
     expect(sfwSpendable.filter(isPayoutEligibleBuzz)).toEqual(['green']);
     // Mature block: the paid domain currency (yellow) is eligible; blue is not.
     expect(matureSpendable.filter(isPayoutEligibleBuzz)).toEqual(['yellow']);
+  });
+});
+
+describe('orderBlockCurrencyTypes — preferred-first + domain clamp', () => {
+  it('no pick → the allowed set UNCHANGED (byte-identical to Auto), both domains', () => {
+    // SFW.
+    expect(orderBlockCurrencyTypes(true, undefined)).toEqual({
+      ordered: getBlockAllowedAccountTypes(true),
+      disallowed: false,
+    });
+    expect(orderBlockCurrencyTypes(true, undefined).ordered).toEqual(['blue', 'green']);
+    // Mature.
+    expect(orderBlockCurrencyTypes(false, undefined)).toEqual({
+      ordered: getBlockAllowedAccountTypes(false),
+      disallowed: false,
+    });
+    expect(orderBlockCurrencyTypes(false, undefined).ordered).toEqual(['blue', 'yellow']);
+  });
+
+  it('allowed pick → moved to the FRONT with the rest as fallback (SFW green)', () => {
+    // allowed ['blue','green'] + pick green → ['green','blue'].
+    expect(orderBlockCurrencyTypes(true, 'green')).toEqual({
+      ordered: ['green', 'blue'],
+      disallowed: false,
+    });
+  });
+
+  it('allowed pick → moved to the FRONT with the rest as fallback (mature yellow)', () => {
+    // allowed ['blue','yellow'] + pick yellow → ['yellow','blue'].
+    expect(orderBlockCurrencyTypes(false, 'yellow')).toEqual({
+      ordered: ['yellow', 'blue'],
+      disallowed: false,
+    });
+  });
+
+  it('picking blue (already first) keeps blue-first + fallback intact', () => {
+    expect(orderBlockCurrencyTypes(true, 'blue')).toEqual({
+      ordered: ['blue', 'green'],
+      disallowed: false,
+    });
+  });
+
+  it('disallowed pick → flagged disallowed, allowed set returned UNCHANGED (no widening)', () => {
+    // yellow is NOT spendable on a SFW block; green is NOT spendable on a mature block.
+    const sfw = orderBlockCurrencyTypes(true, 'yellow');
+    expect(sfw.disallowed).toBe(true);
+    expect(sfw.ordered).toEqual(['blue', 'green']); // set never widened to include yellow
+    const mature = orderBlockCurrencyTypes(false, 'green');
+    expect(mature.disallowed).toBe(true);
+    expect(mature.ordered).toEqual(['blue', 'yellow']); // never widened to include green
   });
 });

--- a/src/server/utils/buzz-helpers.ts
+++ b/src/server/utils/buzz-helpers.ts
@@ -99,6 +99,40 @@ export function getBlockAllowedAccountTypes(isGreen: boolean): BuzzSpendType[] {
 }
 
 /**
+ * PREFERRED-FIRST + DOMAIN-CLAMPED currency ordering for a viewer-picked buzz
+ * account (App Blocks money page blocks). The domain-allowed set
+ * (`getBlockAllowedAccountTypes`) is the maturity policy gate and is NEVER
+ * widened here — a pick can only REORDER within that set:
+ *
+ *   - no pick               → the allowed set unchanged (`disallowed: false`).
+ *     Byte-identical to `getBlockAllowedAccountTypes(isGreen)`, so the Auto path
+ *     preserves today's blue-first drain order exactly.
+ *   - pick NOT in the set   → `disallowed: true`, allowed set returned unchanged.
+ *     The caller REJECTS (never silently spend a different account than asked).
+ *   - pick in the set       → the pick moved to the FRONT, the remaining allowed
+ *     currencies kept as FALLBACK. The orchestrator drains in array order, so
+ *     the picked account pays first but the generation still succeeds when the
+ *     total across the allowed accounts covers the cost (preferred-first, then
+ *     fall back — a single-account clamp would fail an otherwise-affordable gen).
+ *
+ * Pure (no throw / no orchestrator-type mapping) so it's unit-testable on the
+ * plain `BuzzSpendType` strings; the router wraps it (throws BAD_REQUEST on
+ * `disallowed`, then maps to orchestrator currency types).
+ */
+export function orderBlockCurrencyTypes(
+  isGreen: boolean,
+  accountType?: BuzzSpendType
+): { ordered: BuzzSpendType[]; disallowed: boolean } {
+  const allowed = getBlockAllowedAccountTypes(isGreen);
+  if (!accountType) return { ordered: allowed, disallowed: false };
+  if (!allowed.includes(accountType)) return { ordered: allowed, disallowed: true };
+  return {
+    ordered: [accountType, ...allowed.filter((type) => type !== accountType)],
+    disallowed: false,
+  };
+}
+
+/**
  * PAYOUT-SAFETY GATE (App Blocks Sybil / payout review).
  *
  * Which Buzz account types are eligible to accrue an app-author payout


### PR DESCRIPTION
## Phase 1 (backend) — App Blocks per-account buzz spend + balance read

Server-side only. Enables a **money** page block to (a) let the viewer pick which buzz account type to spend, and (b) read their own per-type balance — **without lifting the page's `buzz:read:self` forbid**. The SDK/host/scaffold pieces are later phases; this PR touches nothing under `src/components/AppBlocks/*`, the SDK, `hostHandlerParity.ts`, or the scaffold.

### What changed
1. **`accountType` on the submit body (schema).** Optional `accountType?: 'blue'|'green'|'yellow'` on `blockWorkflowBodySchema`, reusing the authoritative `buzzSpendTypes` enum (`red` is disabled → excluded). Absent → byte-identical to today.
2. **Preferred-first + domain-clamped currency selection.** In `submitWorkflow`, when `accountType` is present:
   - **Domain clamp (security):** if it's not in the domain-allowed set (`getBlockAllowedAccountTypes` — the maturity policy: SFW → blue/green, mature → blue/yellow), **reject** with `BAD_REQUEST`. The allowed set is **never widened**; a different account is never silently spent.
   - If allowed: **reorder** so the pick is FIRST with the remaining allowed currencies kept as **fallback** (so a generation still succeeds when the total across the allowed accounts covers the cost — preferred-first, then fall back).
   - Absent → Auto (unchanged). The pure ordering lives in `orderBlockCurrencyTypes` (buzz-helpers) so it's unit-testable on plain `BuzzSpendType` strings.
3. **`spentAccountType` on the snapshot.** `snapshotFromWorkflow` surfaces the account that primarily funded the generation (the `accountType` of the largest realized `debit` on the orchestrator's `transactions.list`). Optional + additive; omitted on estimates / cache-hits / no-transaction snapshots or an internal-only account. Nothing beyond account type + the already-present `cost.total` is leaked.
4. **`blocks.getMyBuzzBalance` query (host-mediated, NO new scope).** Takes `{ blockToken }`, verifies it with the **same** block-token verification `submitWorkflow` uses (self-bound; `userId` derived from the token `sub`, **never** client input), and returns `{ blue, green, yellow }` from `getUserBuzzAccounts`. Gated on the App Blocks enabled kill-switch + author gate, consistent with the other block-token procedures.
   - **Policy reversal (intentional, scoped):** pages remain **forbidden** `buzz:read:self`. This is the first-party host deliberately exposing the viewer's **own** balance to their **own** page session via the proof-of-session block token — bounded to the token-bound user only. It reverses the old "pages have no reason to read balance" stance without lifting the scope forbid.

### Preserving existing behavior
When `accountType` is absent the currency derivation is byte-identical to `resolveBlockCurrencies(isGreen)`. `resolveBlockCurrencies` and the maturity policy are unchanged. No SDK/host/scaffold changes.

### Tests
- `buzz-helpers.test.ts` — `orderBlockCurrencyTypes`: absent → unchanged; allowed → reordered preferred-first with fallback; disallowed → flagged, set not widened.
- `workflow.service.test.ts` — `spentAccountType`: surfaced from the largest debit, ignores credits, omitted when absent/fakeRed.
- `blocks.router.workflow.test.ts` — router reorder (absent/allowed submit normally; disallowed → BAD_REQUEST, no spend; out-of-enum → zod reject) + `getMyBuzzBalance` (returns three balances for a valid token, defaults missing to 0, rejects invalid/anon token, kill-switch, non-author).

Typecheck clean on all touched files (the only `tsc` errors in the worktree are pre-existing `kysely` module-resolution noise in `packages/civitai-db*`). Relevant vitest suites: **228 tests pass** (buzz-helpers 17, workflow.service 39, blocks.router.workflow 133 + others in-file).

SDK/host/scaffold phases follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)