### PR TITLE
chore(deps): drop unused @civitai/blocks-react dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "@axiomhq/axiom-node": "^0.12.0",
     "@civitai/app-sdk": "^0.14.0",
     "@civitai/auth": "workspace:*",
-    "@civitai/blocks-react": "^0.16.0",
     "@civitai/buzz": "workspace:*",
     "@civitai/client": "0.2.0-beta.78",
     "@civitai/cybertipline-tools": "^0.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,9 +34,6 @@ importers:
       '@civitai/auth':
         specifier: workspace:*
         version: link:packages/civitai-auth
-      '@civitai/blocks-react':
-        specifier: ^0.16.0
-        version: 0.16.0(@civitai/app-sdk@0.14.0)(react@18.3.1)
       '@civitai/buzz':
         specifier: workspace:*
         version: link:packages/civitai-buzz
@@ -1639,13 +1636,6 @@ packages:
   '@civitai/app-sdk@0.14.0':
     resolution: {integrity: sha512-YdXRZzBQe48+eJJSQXmKTP9SLKC6a97UBbcUDOPxzuH3UbWbyVL3Hh/jMK5Q4TrmDtYkkSs/RZbuF4ykIVtNBA==}
     engines: {node: '>=20'}
-
-  '@civitai/blocks-react@0.16.0':
-    resolution: {integrity: sha512-Y3UqrqyEf2piyPyNWTvBJuL3PVDDtAwMLNxojbODhmSqQBN2mj1xAL69+zXTORtftNFUrjyg5ko5IT+3E4edmA==}
-    engines: {node: '>=20'}
-    peerDependencies:
-      '@civitai/app-sdk': '>=0.13.0'
-      react: ^18.0.0 || ^19.0.0
 
   '@civitai/client@0.2.0-beta.78':
     resolution: {integrity: sha512-dSXkI8hVoozzlPS9DymzoyncWz8eapH3wkSDzDVGWjjqamXn8Dbcq1hWu5xUZkZmqCaR76F7BS9BQNqvOJ++Sw==}
@@ -12595,11 +12585,6 @@ snapshots:
   '@chevrotain/utils@10.5.0': {}
 
   '@civitai/app-sdk@0.14.0': {}
-
-  '@civitai/blocks-react@0.16.0(@civitai/app-sdk@0.14.0)(react@18.3.1)':
-    dependencies:
-      '@civitai/app-sdk': 0.14.0
-      react: 18.3.1
 
   '@civitai/client@0.2.0-beta.78':
     dependencies:


### PR DESCRIPTION
`@civitai/blocks-react` is declared in `dependencies` but **never imported anywhere** in the repo.

civitai is the App Blocks **host**; `@civitai/blocks-react` is the **author/block-side** package (the hooks a block author uses). Verified repo-wide: **0 import/require/dynamic-import sites**. Every textual reference is a comment, doc-string, or the get-started page's `BLOCKS_REACT_NPM_URL` string constant (a hardcoded npm link — needs no dependency). The host's only code-level SDK consumption is a single `import type { BlockToParentMessageType } from '@civitai/app-sdk/blocks'` in `hostHandlerParity.ts`.

Removing it trims the install tree with **zero code impact**. `@civitai/app-sdk` stays (the type import). Lockfile diff is `blocks-react`-only (0 added / 15 removed), no unrelated churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)