### PR TITLE
fix(image-scan): ack deleted-image scan callbacks with 200

### DIFF
--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -126,6 +126,12 @@ export default WebhookEndpoint(async (req, res) => {
     try {
       await processImageScanResult(req);
     } catch (e: any) {
+      // Image was deleted between scan submit and callback — nothing to update.
+      // ACK with 200 so the orchestrator drops the workflow instead of retrying
+      // a result for a row that no longer exists.
+      if (e instanceof Error && e.message.startsWith('image not found')) {
+        return res.status(200).json({ ok: true, skipped: 'deleted' });
+      }
       if (e instanceof Error) {
         await logToAxiom({
           name: 'image-scan-result',
@@ -191,7 +197,10 @@ export default WebhookEndpoint(async (req, res) => {
 
     return res.status(200).json({ ok: true });
   } catch (e: any) {
-    if (e.message === 'Image not found') return res.status(404).send({ error: e.message });
+    // Image was deleted between scan submit and callback — there's nothing to
+    // update. ACK with 200 so the scanner drops the job instead of re-delivering
+    // the result for a row that no longer exists.
+    if (e.message === 'Image not found') return res.status(200).json({ ok: true, skipped: 'deleted' });
     return res.status(400).send({ error: e.message });
   }
 });


### PR DESCRIPTION
## Problem
When an image is deleted between scan submission and the scanner's callback, the `image-scan-result` webhook looks the row up on the primary DB, doesn't find it, and returns a **non-2xx** — `404` on the old Hangfire path, `400` on the new orchestrator (`workflowId`) path. The scanner treats that as a retryable failure and **re-delivers** the result, so deleted images churn in the ingestion queue.

### Evidence (Axiom, `civitai-prod`, last 7d)
- `image-scan-result` errors: **~4–5k/day**, 98% `"Image not found"`.
- **8,177 distinct** deleted images/week, each delivered ~2× across pods.
- Flat trend — a steady churn of scans for rows that no longer exist.
- Sampled IDs confirmed absent in Postgres (`Image` rows gone).

## Fix
A deleted image is terminal — nothing to update. Return **200** on both callback branches so the scanner drops the workflow instead of retrying. Also skip the noisy Axiom error log for this case on the orchestrator path.

## Scope / caveats
- Whether this shrinks the scanner's queue depends on the scanner treating non-2xx as retry — that logic lives in the ingestion service repo, not here. Worst case, this only removes the error-log noise + duplicate deliveries.
- Does **not** address backlog from inflow > drain (e.g. old Hangfire workers scaled down while `ingestImageBulk` still feeds them). Tracking that separately.

## Test
`pnpm typecheck` clean.