### PR TITLE
feat(notifications): single Axiom event for notification-server request failures

### DIFF
--- a/packages/civitai-notifications/src/client.test.ts
+++ b/packages/civitai-notifications/src/client.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   countNotifications,
   createNotification,
   createNotificationsBulk,
   NotificationsClientError,
   queryNotifications,
+  setNotificationsFailureLogger,
 } from './client';
 import { createNotificationPendingRow } from './schema';
 
@@ -131,6 +132,55 @@ describe('read wrappers', () => {
       { endpoint: 'http://notif.internal', fetch: fetchMock }
     );
     expect(counts).toEqual([{ category: 'Comment', count: 3 }]);
+  });
+});
+
+describe('setNotificationsFailureLogger', () => {
+  afterEach(() => setNotificationsFailureLogger(undefined));
+
+  it('reports ONCE on the final failure (after retries), with path/status/attempts', async () => {
+    const failures: any[] = [];
+    setNotificationsFailureLogger((f) => failures.push(f));
+    const fetchMock = vi.fn().mockResolvedValue(new Response('busy', { status: 503 }));
+
+    await expect(
+      createNotification(validRow, {
+        endpoint: 'http://notif.internal',
+        fetch: fetchMock,
+        retries: 2,
+        retryBaseMs: 0,
+      })
+    ).rejects.toBeInstanceOf(NotificationsClientError);
+
+    expect(failures).toHaveLength(1); // one event, not one-per-attempt
+    expect(failures[0]).toMatchObject({
+      path: '/notifications',
+      status: 503,
+      retryable: true,
+      attempts: 3,
+    });
+  });
+
+  it('reports a 4xx immediately (attempts=1, retryable=false)', async () => {
+    const failures: any[] = [];
+    setNotificationsFailureLogger((f) => failures.push(f));
+    const fetchMock = vi.fn().mockResolvedValue(new Response('bad', { status: 400 }));
+
+    await expect(
+      createNotification(validRow, { endpoint: 'http://notif.internal', fetch: fetchMock, retryBaseMs: 0 })
+    ).rejects.toBeInstanceOf(NotificationsClientError);
+
+    expect(failures).toEqual([
+      expect.objectContaining({ path: '/notifications', status: 400, retryable: false, attempts: 1 }),
+    ]);
+  });
+
+  it('does NOT report on success', async () => {
+    const failures: any[] = [];
+    setNotificationsFailureLogger((f) => failures.push(f));
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 202 }));
+    await createNotification(validRow, { endpoint: 'http://notif.internal', fetch: fetchMock });
+    expect(failures).toHaveLength(0);
   });
 });
 

--- a/packages/civitai-notifications/src/client.ts
+++ b/packages/civitai-notifications/src/client.ts
@@ -42,6 +42,41 @@ export class NotificationsClientError extends Error {
   }
 }
 
+/** A single notification-server request failure (after any retries), for the injected failure sink. */
+export type NotificationsRequestFailure = {
+  /** The request path, e.g. `/notifications`, `/notifications/query`. */
+  path: string;
+  /** HTTP status when the app responded; absent for transport/timeout/config failures. */
+  status?: number;
+  /** True when the failure was transient (5xx/429/transport) and retries were exhausted. */
+  retryable: boolean;
+  /** Attempts made (0 = failed before the first request, e.g. no endpoint configured). */
+  attempts: number;
+  message: string;
+};
+
+let failureLogger: ((failure: NotificationsRequestFailure) => void) | undefined;
+
+/**
+ * Register a SINGLE sink for EVERY notification-server request failure (create/bulk/read/count/mark/
+ * exists/cleanup), fired once per failed call after retries are exhausted. The consumer wires this once
+ * at startup so all failures surface as one queryable event — this package stays dependency-free and
+ * doesn't know about Axiom/logging. Pass `undefined` to clear.
+ */
+export function setNotificationsFailureLogger(
+  fn: ((failure: NotificationsRequestFailure) => void) | undefined
+) {
+  failureLogger = fn;
+}
+
+function reportFailure(failure: NotificationsRequestFailure) {
+  try {
+    failureLogger?.(failure);
+  } catch {
+    // A logger error must never affect the caller or mask the original request failure.
+  }
+}
+
 function resolveConfig(config: NotificationsClientConfig) {
   const endpoint = config.endpoint ?? process.env.NOTIFICATIONS_ENDPOINT;
   if (!endpoint) {
@@ -103,16 +138,35 @@ async function postAttempt(
   }
 }
 
-/** POST with bounded exponential backoff on transient failures. Returns the parsed JSON response. */
+/** POST with bounded exponential backoff on transient failures. Returns the parsed JSON response. On the
+ * FINAL failure (retries exhausted / non-retryable / config error) it reports once to the injected sink
+ * before throwing — the single choke point every request flows through, so every failure logs uniformly. */
 async function post(path: string, body: unknown, config: NotificationsClientConfig): Promise<unknown> {
-  const { endpoint, token, fetch: fetchImpl, timeoutMs, retries, retryBaseMs } = resolveConfig(config);
+  let resolved: ReturnType<typeof resolveConfig>;
+  try {
+    resolved = resolveConfig(config);
+  } catch (err) {
+    const e = err as NotificationsClientError;
+    reportFailure({ path, status: e.status, retryable: false, attempts: 0, message: e.message });
+    throw e;
+  }
+  const { endpoint, token, fetch: fetchImpl, timeoutMs, retries, retryBaseMs } = resolved;
   const url = `${endpoint}${path}`;
   for (let attempt = 0; ; attempt++) {
     try {
       return await postAttempt(url, body, token, fetchImpl, timeoutMs);
     } catch (err) {
       const e = err as NotificationsClientError;
-      if (!e.retryable || attempt >= retries) throw e;
+      if (!e.retryable || attempt >= retries) {
+        reportFailure({
+          path,
+          status: e.status,
+          retryable: e.retryable,
+          attempts: attempt + 1,
+          message: e.message,
+        });
+        throw e;
+      }
       const backoff = Math.min(retryBaseMs * 2 ** attempt, 2000) + Math.random() * retryBaseMs;
       await new Promise((resolve) => setTimeout(resolve, backoff));
     }

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -17,6 +17,7 @@ import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
 import { registerCpuProfiler, registerEventLoopStallProfiler } from '~/server/cpu-profiler';
 import { registerEventLoopLongTaskDetector } from '~/server/eventloop-longtask';
 import { registerLivenessHeartbeat } from '~/server/liveness-heartbeat';
+import { registerNotificationsFailureLogging } from '~/server/notifications/register-failure-logging';
 
 // Arm the on-demand, signal-triggered V8 CPU profiler. Zero steady-state
 // overhead; only does work when signalled. Independent of OTEL so it is
@@ -50,6 +51,11 @@ registerEventLoopLongTaskDetector();
 // because it's served by the same saturated loop. See liveness-heartbeat.ts and
 // the liveness history in datapacket-talos deployment-api.yaml.
 registerLivenessHeartbeat();
+
+// Route ALL notification-server request failures to one Axiom event
+// (name 'notifications-request-failed', datastream 'notifications'), so a
+// failed create/read/mark/bulk anywhere is a single thing to alert on.
+registerNotificationsFailureLogging();
 
 // Kick the in-process route warmer (fire-and-forget). Next standalone
 // lazy-require()s each route on first hit; the dependency-only readiness probe

--- a/src/server/jobs/send-notifications.ts
+++ b/src/server/jobs/send-notifications.ts
@@ -1,7 +1,7 @@
 import { isEmpty } from 'lodash-es';
 import { isPromise } from 'util/types';
 import { clickhouse } from '~/server/clickhouse/client';
-import { createNotificationsBulk } from '@civitai/notifications';
+import { createNotificationsBulk, NotificationsClientError } from '@civitai/notifications';
 import { pgDbRead } from '~/server/db/pgDb';
 import { logToAxiom } from '~/server/logging/client';
 import { notificationBatches } from '~/server/notifications/utils.notifications';
@@ -107,6 +107,10 @@ export const sendNotificationsJob = createJob('send-notifications', '*/1 * * * *
             log('sent', key, 'notifications in', (Date.now() - start) / 1000, 's');
           }
         } catch (e) {
+          // A bulk send failure is logged centrally by the client (notifications-request-failed) — skip
+          // it here to avoid a double log; still log genuine query/build failures (the try also wraps the
+          // main-DB query + pendingData build). The failed key isn't marked sent, so it retries next run.
+          if (e instanceof NotificationsClientError) return;
           const error = e as Error;
           logToAxiom(
             {

--- a/src/server/notifications/register-failure-logging.ts
+++ b/src/server/notifications/register-failure-logging.ts
@@ -1,0 +1,26 @@
+import { setNotificationsFailureLogger } from '@civitai/notifications';
+import { logToAxiom } from '~/server/logging/client';
+
+/**
+ * Wire EVERY notification-server request failure — across create / bulk / read / count / mark / exists /
+ * cleanup — to a SINGLE Axiom event: `name: 'notifications-request-failed'` on the `notifications`
+ * datastream. Because the @civitai/notifications client reports through one choke point, this is the one
+ * thing to alert/dashboard on when notifications fail to send. Registered once at server startup (see
+ * src/instrumentation.node.ts). Idempotent — re-registering just replaces the sink.
+ */
+export function registerNotificationsFailureLogging() {
+  setNotificationsFailureLogger((failure) => {
+    logToAxiom(
+      {
+        type: 'error',
+        name: 'notifications-request-failed',
+        path: failure.path,
+        status: failure.status,
+        retryable: failure.retryable,
+        attempts: failure.attempts,
+        message: failure.message,
+      },
+      'notifications'
+    ).catch(() => {});
+  });
+}

--- a/src/server/services/club.service.ts
+++ b/src/server/services/club.service.ts
@@ -272,15 +272,21 @@ export const updateClub = async ({
 
     if (reqData) {
       const reqUsers = reqList.map((r) => r.userId);
-      await createNotificationsBulk([
-        {
-          key: reqData.key,
-          type: reqData.type,
-          category: NotificationCategory.Update,
-          users: reqUsers,
-          details: reqData.details,
-        },
-      ]);
+      // Best-effort: a notification-server failure (logged centrally as notifications-request-failed)
+      // must not fail the club update.
+      try {
+        await createNotificationsBulk([
+          {
+            key: reqData.key,
+            type: reqData.type,
+            category: NotificationCategory.Update,
+            users: reqUsers,
+            details: reqData.details,
+          },
+        ]);
+      } catch {
+        // swallowed — see above
+      }
     }
   }
 

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -4,6 +4,7 @@ import {
   countNotifications,
   createNotification as createNotificationRequest,
   markNotificationsRead as markNotificationsReadRequest,
+  NotificationsClientError,
   queryNotifications,
 } from '@civitai/notifications';
 import type { NotificationCategory } from '~/server/common/enums';
@@ -37,6 +38,10 @@ export const createNotification = async (data: CreateNotificationPendingRow) => 
   try {
     await createNotificationRequest(data);
   } catch (e) {
+    // Send failures are logged centrally by the client (notifications-request-failed) — swallow them
+    // here (best-effort). Only surface a non-request error, e.g. a producer whose payload fails schema
+    // validation before it ever leaves the monolith.
+    if (e instanceof NotificationsClientError) return;
     const error = e as Error;
     logToAxiom(
       {
@@ -91,8 +96,9 @@ export const markNotificationsRead = async ({
   category,
 }: MarkReadNotificationInput & { userId: number }) => {
   // Best-effort, like the original: the UI already optimistically marked read, so a transient app
-  // failure (after the client's backoff retries) must NOT surface as a tRPC error — swallow + log.
-  // The input id is a bigint (UserNotification.id is int4-sized) — narrow to a JSON-safe number.
+  // failure (after the client's backoff retries) must NOT surface as a tRPC error — swallow it. Send
+  // failures are logged centrally by the client (notifications-request-failed); only log a non-request
+  // error here. The input id is a bigint (UserNotification.id is int4-sized) — narrow to a JSON number.
   try {
     await markNotificationsReadRequest({
       userId,
@@ -101,6 +107,7 @@ export const markNotificationsRead = async ({
       category,
     });
   } catch (e) {
+    if (e instanceof NotificationsClientError) return;
     const error = e as Error;
     logToAxiom(
       {


### PR DESCRIPTION
Every notification-server request (create/bulk/read/count/mark/exists/cleanup) now surfaces one queryable failure event instead of scattered per-caller logs.

- @civitai/notifications: the client reports each final failure (after retries) through one injectable sink (setNotificationsFailureLogger) at its single post() choke point — path/status/retryable/attempts/message. Package stays dependency-free.
- Monolith: register-failure-logging wires that sink to logToAxiom(name 'notifications-request-failed', datastream 'notifications'), registered once at startup in instrumentation.node.ts.
- Trim now-redundant per-caller send-failure logs: notification.service create + mark-read only log non-request errors; send-notifications job skips the send-failure log (keeps its query/generation-failure log + per-type isolation); club.service bulk is best-effort (swallow) so a blip can't fail a club update.
- +3 client tests (reports once on final failure, 4xx immediate, none on success).