### PR TITLE
chore(image-scan): log every ingest submit to Axiom for diagnosis

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -856,6 +856,17 @@ export const ingestImage = async ({
   tx?: Prisma.TransactionClient;
   userId?: number;
 }): Promise<boolean> => {
+  // TEMP diagnostic: trace who submits to image ingestion and at what priority.
+  // Grouping by `stack` buckets callers even in minified prod builds. Remove
+  // once the low-priority scanner-queue growth is traced.
+  logToAxiom({
+    name: 'ingest-submit',
+    type: 'info',
+    imageId: image.id,
+    message: `ingestImage priority=${lowPriority ? 'low' : 'normal'} userId=${userId ?? ''}`,
+    stack: new Error('ingest-submit').stack,
+  }).catch(() => undefined);
+
   const scanRequestedAt = new Date();
   const dbClient = tx ?? dbWrite;
 
@@ -1001,6 +1012,17 @@ export const ingestImageBulk = async ({
   const dbClient = tx ?? dbWrite;
 
   if (!imageIds.length) return false;
+
+  // TEMP diagnostic: trace who bulk-submits to image ingestion and at what
+  // priority. Grouping by `stack` buckets callers even in minified prod builds.
+  // Remove once the low-priority scanner-queue growth is traced.
+  logToAxiom({
+    name: 'ingest-submit-bulk',
+    type: 'info',
+    imageId: imageIds[0],
+    message: `ingestImageBulk priority=${lowPriority ? 'low' : 'normal'} count=${imageIds.length}`,
+    stack: new Error('ingest-submit-bulk').stack,
+  }).catch(() => undefined);
 
   // TODO.articleImageScan: uncomment when ready to enable image scanning for articles
   // if (!isProd || !callbackUrl) {


### PR DESCRIPTION
## Why
Tracing continuous growth of the **low-priority** queue in the image-ingestion (Hangfire) service. `Image.scanRequestedAt` only stores the *last* submit time, so repeat-submits of the same image are invisible from the DB. We need per-call submit data.

## What
`ingestImage` and `ingestImageBulk` are the two funnels into the ingestion service. Log every call to Axiom:
- `ingest-submit` / `ingest-submit-bulk` (`name`)
- `message`: `priority=low|normal` (+ `count=` for bulk)
- `stack`: `new Error().stack` — grouping by stack buckets callers even in minified prod builds, revealing which path drives low-pri submissions and how often the same images are re-sent.

Only existing Axiom columns used (`name`/`type`/`message`/`imageId`/`stack`) — the `civitai-prod` dataset is at its column cap.

## Temporary
Diagnostic only — revert once the source is traced. Fire-and-forget (`.catch()`), no behavior change.

## Test
`pnpm typecheck` clean.