### PR TITLE
feat(notifications): add P2 Prometheus metrics (read-API RED, signals delivery, redis errors)

### DIFF
--- a/apps/notifications/src/__tests__/app.test.ts
+++ b/apps/notifications/src/__tests__/app.test.ts
@@ -75,11 +75,23 @@ describe('HTTP RED histogram', () => {
     expect(res.body).toContain('outcome="rejected"');
   });
 
-  it('does NOT record the ops routes (/health, /metrics) in the RED histogram', async () => {
+  it('does NOT record the ops routes (/health, /metrics, /pool-stats) in the RED histogram', async () => {
+    // Exercise EVERY ops route, including /pool-stats (which the old assertion skipped). All three have
+    // real route templates, so if the hook's `startsWith('/notifications')` scope guard were loosened or
+    // dropped they WOULD produce a histogram sample — these assertions fail in that case.
     await app.inject({ method: 'GET', url: '/health' });
+    await app.inject({ method: 'GET', url: '/pool-stats' });
     const res = await app.inject({ method: 'GET', url: '/metrics' });
     // The histogram label set must never carry an ops route.
     expect(res.body).not.toContain('route="/health"');
     expect(res.body).not.toContain('route="/metrics"');
+    expect(res.body).not.toContain('route="/pool-stats"');
+    // Belt-and-suspenders: no RED histogram sample may reference any non-/notifications route template.
+    // (Regex over the emitted series — every recorded series' `route=` label must start with /notifications.)
+    const redRouteLabels = [...res.body.matchAll(/notifications_http_request_duration_seconds\S*?route="([^"]*)"/g)];
+    expect(redRouteLabels.length).toBeGreaterThan(0); // sanity: the histogram is actually populated
+    for (const [, routeLabel] of redRouteLabels) {
+      expect(routeLabel.startsWith('/notifications')).toBe(true);
+    }
   });
 });

--- a/apps/notifications/src/__tests__/app.test.ts
+++ b/apps/notifications/src/__tests__/app.test.ts
@@ -39,6 +39,15 @@ describe('GET /metrics', () => {
     });
     expect(res.statusCode).toBe(404);
   });
+
+  it('exposes the signals-delivery + redis-error baseline series (zero before any event)', async () => {
+    const res = await app.inject({ method: 'GET', url: '/metrics' });
+    expect(res.body).toContain('notifications_signals_delivery_total');
+    expect(res.body).toContain('notifications_redis_errors_total');
+    // Pre-initialized outcome/operation series export a 0 baseline.
+    expect(res.body).toContain('notifications_signals_delivery_total{outcome="failure"} 0');
+    expect(res.body).toContain('notifications_redis_errors_total{operation="get"} 0');
+  });
 });
 
 describe('POST /notifications validation', () => {
@@ -49,5 +58,28 @@ describe('POST /notifications validation', () => {
       payload: { type: 'new-comment' }, // missing key/category/details
     });
     expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('HTTP RED histogram', () => {
+  it('records a request against the http_request_duration_seconds histogram, labeled by route+outcome', async () => {
+    // An invalid POST is rejected at the zod gate (no DB touched) → outcome="rejected".
+    await app.inject({
+      method: 'POST',
+      url: '/notifications',
+      payload: { type: 'new-comment' }, // missing key/category/details
+    });
+    const res = await app.inject({ method: 'GET', url: '/metrics' });
+    expect(res.body).toContain('notifications_http_request_duration_seconds');
+    expect(res.body).toContain('route="/notifications"');
+    expect(res.body).toContain('outcome="rejected"');
+  });
+
+  it('does NOT record the ops routes (/health, /metrics) in the RED histogram', async () => {
+    await app.inject({ method: 'GET', url: '/health' });
+    const res = await app.inject({ method: 'GET', url: '/metrics' });
+    // The histogram label set must never carry an ops route.
+    expect(res.body).not.toContain('route="/health"');
+    expect(res.body).not.toContain('route="/metrics"');
   });
 });

--- a/apps/notifications/src/app.ts
+++ b/apps/notifications/src/app.ts
@@ -9,7 +9,7 @@ import {
   notificationExistsInput,
   queryNotificationsInput,
 } from '@civitai/notifications';
-import { register, producerRequestsTotal } from './lib/server/metrics';
+import { register, producerRequestsTotal, httpRequestDurationSeconds } from './lib/server/metrics';
 import { isAuthorized } from './lib/server/auth';
 import { createNotification } from './lib/server/create';
 import {
@@ -45,6 +45,27 @@ export async function buildServer(): Promise<FastifyInstance> {
     // Raised from Fastify's 1MB default: a bulk-create batch (bounded to 1000 rows client-side) can still
     // carry large `users[]` arrays per row. The client chunks by row count; this bounds the worst case.
     bodyLimit: 25 * 1024 * 1024,
+  });
+
+  // RED for the authed API. One onResponse hook records duration+count+outcome for every /notifications*
+  // route uniformly (query/count/mark-read/bulk/exists/cleanup previously had NO metric). Scoped to the
+  // authed API paths so the ops routes (/health, /metrics, /pool-stats) don't pollute the RED view.
+  // `routeOptions.url` is the static route template (bounded label); skip when undefined (404s).
+  app.addHook('onResponse', async (req, reply) => {
+    const route = req.routeOptions.url;
+    if (!route || !route.startsWith('/notifications')) return;
+    const status = reply.statusCode;
+    const outcome =
+      status < 400
+        ? 'success'
+        : status === 401
+          ? 'unauthorized'
+          : status === 400
+            ? 'rejected'
+            : status >= 500
+              ? 'error'
+              : 'client_error';
+    httpRequestDurationSeconds.observe({ route, outcome }, reply.elapsedTime / 1000);
   });
 
   app.get('/health', async () => ({ status: 'ok', service: 'notifications' }));

--- a/apps/notifications/src/app.ts
+++ b/apps/notifications/src/app.ts
@@ -55,6 +55,9 @@ export async function buildServer(): Promise<FastifyInstance> {
     const route = req.routeOptions.url;
     if (!route || !route.startsWith('/notifications')) return;
     const status = reply.statusCode;
+    // outcome is derived purely from the HTTP status class, so a 2xx ⇒ "success" means the request was
+    // ACCEPTED, not that any downstream work completed. For fire-and-forget routes (e.g. mark-read's 202)
+    // "success" is the ACK; a later async write failure is invisible here (see the mark-read route note).
     const outcome =
       status < 400
         ? 'success'
@@ -153,6 +156,9 @@ export async function buildServer(): Promise<FastifyInstance> {
     const body = authedBody(markReadInput, req, reply);
     if (!body) return reply;
     // Fire-and-forget: enqueue the write and ack immediately (the caller's UI is already optimistic).
+    // NOTE: the 202 ACK means "accepted", not "written". The RED histogram therefore records this as
+    // outcome="success" for the ACK regardless of whether the async DB write later fails — a failed
+    // write does NOT surface here. This metric is request-acceptance RED, not delivery confirmation.
     markNotificationsRead(body);
     return reply.code(202).send({ status: 'accepted' });
   });

--- a/apps/notifications/src/lib/server/cache.test.ts
+++ b/apps/notifications/src/lib/server/cache.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock the redis client so cache ops run against a fake we can make throw. We assert the best-effort
+// counter (notifications_redis_errors_total) increments on a redis op error AND that the error still
+// propagates unchanged (behavior is non-behavioral except the counter).
+const { fakeRedis } = vi.hoisted(() => {
+  const fakeRedis = {
+    hGetAll: vi.fn(),
+    expire: vi.fn(),
+    exists: vi.fn(),
+    hSet: vi.fn(),
+    hIncrBy: vi.fn(),
+    hGet: vi.fn(),
+    hDel: vi.fn(),
+    del: vi.fn(),
+  };
+  return { fakeRedis };
+});
+
+vi.mock('./clients/redis', () => ({ getRedis: () => fakeRedis }));
+
+import { notificationCache } from './cache';
+import { redisErrorsTotal } from './metrics';
+
+async function opValue(operation: string): Promise<number> {
+  const metric = await redisErrorsTotal.get();
+  return metric.values.find((v) => v.labels.operation === operation)?.value ?? 0;
+}
+
+describe('notification cache redis-error counting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('increments redis_errors_total{operation="get"} and rethrows when a get op errors', async () => {
+    const before = await opValue('get');
+    fakeRedis.hGetAll.mockRejectedValueOnce(new Error('READONLY'));
+
+    await expect(notificationCache.getUser(42)).rejects.toThrow('READONLY');
+
+    expect(await opValue('get')).toBe(before + 1);
+  });
+
+  it('does NOT increment the counter on a successful op', async () => {
+    const before = await opValue('get');
+    fakeRedis.hGetAll.mockResolvedValueOnce({});
+
+    await expect(notificationCache.getUser(42)).resolves.toBeUndefined();
+
+    expect(await opValue('get')).toBe(before);
+  });
+
+  it('counts the increment op under operation="increment"', async () => {
+    const before = await opValue('increment');
+    fakeRedis.hIncrBy.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(notificationCache.incrementUser(7, 'Comment')).rejects.toThrow('boom');
+
+    expect(await opValue('increment')).toBe(before + 1);
+  });
+});

--- a/apps/notifications/src/lib/server/cache.ts
+++ b/apps/notifications/src/lib/server/cache.ts
@@ -6,6 +6,7 @@
 import { REDIS_KEYS, type RedisKeyTemplateCache } from '@civitai/redis';
 import type { NotificationCategory } from '@civitai/notifications';
 import { getRedis } from './clients/redis';
+import { redisErrorsTotal } from './metrics';
 
 const NOTIFICATION_CACHE_TIME = 60 * 60 * 24 * 7; // one week
 
@@ -15,22 +16,36 @@ function userKey(userId: number) {
   return `${REDIS_KEYS.SYSTEM.NOTIFICATION_COUNTS}:${userId}` as RedisKeyTemplateCache;
 }
 
+/**
+ * Count-and-rethrow wrapper for redis cache ops. Behavior is unchanged — an error still propagates to the
+ * caller exactly as before (callers that already `.catch()` keep degrading to no-op) — this only makes an
+ * otherwise-silent redis failure scrapeable via `notifications_redis_errors_total{operation}`.
+ */
+async function withRedisErrorCount<T>(operation: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    redisErrorsTotal.inc({ operation });
+    throw err;
+  }
+}
+
 async function slideExpiration(userId: number) {
   const redis = getRedis();
   if (!redis) return;
-  await redis.expire(userKey(userId), NOTIFICATION_CACHE_TIME);
+  await withRedisErrorCount('set', () => redis.expire(userKey(userId), NOTIFICATION_CACHE_TIME));
 }
 
 async function hasUser(userId: number) {
   const redis = getRedis();
   if (!redis) return false;
-  return await redis.exists(userKey(userId));
+  return await withRedisErrorCount('has', () => redis.exists(userKey(userId)));
 }
 
 async function getUser(userId: number): Promise<NotificationCategoryCount[] | undefined> {
   const redis = getRedis();
   if (!redis) return undefined;
-  const counts = await redis.hGetAll(userKey(userId));
+  const counts = await withRedisErrorCount('get', () => redis.hGetAll(userKey(userId)));
   if (!Object.keys(counts).length) return undefined;
   return Object.entries(counts).map(([category, count]) => {
     const casted = Number(count);
@@ -42,7 +57,9 @@ async function setUser(userId: number, counts: NotificationCategoryCount[]) {
   const redis = getRedis();
   if (!redis) return;
   const key = userKey(userId);
-  for (const { category, count } of counts) await redis.hSet(key, category, count.toString());
+  await withRedisErrorCount('set', async () => {
+    for (const { category, count } of counts) await redis.hSet(key, category, count.toString());
+  });
   await slideExpiration(userId);
 }
 
@@ -50,11 +67,13 @@ async function incrementUser(userId: number, category: NotificationCategory, by 
   const redis = getRedis();
   if (!redis) return;
   const key = userKey(userId);
-  await redis.hIncrBy(key, category, by);
-  if (by < 0) {
-    const value = await redis.hGet(key, category);
-    if (Number(value) <= 0) await redis.hDel(key, category);
-  }
+  await withRedisErrorCount('increment', async () => {
+    await redis.hIncrBy(key, category, by);
+    if (by < 0) {
+      const value = await redis.hGet(key, category);
+      if (Number(value) <= 0) await redis.hDel(key, category);
+    }
+  });
 }
 
 async function decrementUser(userId: number, category: NotificationCategory, by = 1) {
@@ -66,14 +85,14 @@ async function decrementUser(userId: number, category: NotificationCategory, by 
 async function bustUser(userId: number) {
   const redis = getRedis();
   if (!redis) return;
-  await redis.del(userKey(userId));
+  await withRedisErrorCount('bustUser', () => redis.del(userKey(userId)));
 }
 
 async function clearCategory(userId: number, category: NotificationCategory) {
   const redis = getRedis();
   if (!redis) return;
   if (!(await hasUser(userId))) return;
-  await redis.hDel(userKey(userId), category);
+  await withRedisErrorCount('clearCategory', () => redis.hDel(userKey(userId), category));
   await slideExpiration(userId);
 }
 

--- a/apps/notifications/src/lib/server/metrics.ts
+++ b/apps/notifications/src/lib/server/metrics.ts
@@ -46,3 +46,48 @@ export const writePoolActive = new Gauge({
   help: 'Active (non-idle) connections in the notif write pool, sampled per worker tick.',
   registers: [register],
 });
+
+/**
+ * Read/mutation API RED — request duration (and, via `_count`, rate) for the authed POST routes, labeled
+ * by `route` (the static route template, low cardinality) and `outcome` (derived from the status class:
+ * success / rejected / unauthorized / error / client_error). Covers ALL authed routes uniformly — the
+ * create path's finer-grained outcome breakdown stays on `notifications_producer_requests_total`; this
+ * metric is the RED-across-routes view (query/count/mark-read/bulk/exists/cleanup had NO metric before).
+ */
+export const httpRequestDurationSeconds = new Histogram({
+  name: 'notifications_http_request_duration_seconds',
+  help: 'Authed API request duration in seconds, labeled by route and outcome.',
+  labelNames: ['route', 'outcome'] as const,
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [register],
+});
+
+/**
+ * Realtime-signal delivery outcome per affected user (the fan-out worker's per-user POST to
+ * `${SIGNALS_ENDPOINT}/users/{id}/signals/...`). `failure` counts a non-2xx response OR a thrown/rejected
+ * fetch — the exact silent-drop mode the OLD external notification-server had (POSTing to a non-existent
+ * endpoint), previously visible only in Axiom. Delivery stays fire-and-forget; this only observes it.
+ */
+export const signalsDeliveryTotal = new Counter({
+  name: 'notifications_signals_delivery_total',
+  help: 'Realtime signal POSTs to the signals service, labeled by outcome (success/failure).',
+  labelNames: ['outcome'] as const,
+  registers: [register],
+});
+
+/**
+ * Redis cache operation errors (the per-user unread-counter cache). The cache is best-effort — an error
+ * on a counter op is logged/propagated as before; this counter just makes otherwise-silent redis failures
+ * scrapeable/alertable. Labeled by `operation` (bounded enum of the cache ops).
+ */
+export const redisErrorsTotal = new Counter({
+  name: 'notifications_redis_errors_total',
+  help: 'Redis cache operation errors, labeled by operation.',
+  labelNames: ['operation'] as const,
+  registers: [register],
+});
+
+// Baseline series at load so they export a 0 before the first event (see the cardinality note above).
+for (const outcome of ['success', 'failure'] as const) signalsDeliveryTotal.inc({ outcome }, 0);
+for (const operation of ['get', 'set', 'increment', 'has', 'clearCategory', 'bustUser'] as const)
+  redisErrorsTotal.inc({ operation }, 0);

--- a/apps/notifications/src/lib/server/metrics.ts
+++ b/apps/notifications/src/lib/server/metrics.ts
@@ -1,8 +1,12 @@
 // Prometheus metrics for the notifications app (mirrors apps/orchestrator-gateway/src/lib/server/metrics.ts).
 //
 // Cardinality discipline: labels are bounded, low-cardinality enums ONLY. NEVER put userId (or any
-// unbounded value) in a label. All series are registered at module load with their full label sets so
-// they export a baseline before the first event.
+// unbounded value) in a label. Counters/gauges are registered at module load with their full label sets
+// so they export a baseline before the first event. The one exception is
+// `notifications_http_request_duration_seconds`: its route×outcome cross-product is verbose and every
+// series is bounded to a known route template anyway, so it uses standard first-observation series
+// creation (a route×outcome series appears the first time that combination is served) rather than a
+// pre-seeded baseline.
 
 import { Registry, collectDefaultMetrics, Counter, Histogram, Gauge } from 'prom-client';
 

--- a/apps/notifications/src/worker/poll-loop.ts
+++ b/apps/notifications/src/worker/poll-loop.ts
@@ -15,6 +15,7 @@ import { notificationCache } from '../lib/server/cache';
 import { signalsEndpoint } from '../env';
 import {
   notificationsFannedOutTotal,
+  signalsDeliveryTotal,
   workerPendingProcessedTotal,
   workerTickSeconds,
   writePoolActive,
@@ -232,11 +233,21 @@ const run = async () => {
     for (let i = 0; i < affectBatches.length; i++) {
       for (const { userId, id, createdAt } of affectBatches[i]!) {
         await notificationCache.incrementUser(userId, row.category);
+        // Fire-and-forget (resilience unchanged): a signals failure must NOT break fan-out. We only add
+        // outcome counting — non-2xx AND network/throw both count as `failure` (the old server silently
+        // POSTed to a non-existent endpoint; that drop is now scrapeable).
         fetch(`${signalsEndpoint}/users/${userId}/signals/${newNotificationSignal}`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ ...signalData, id, createdAt, read: false }),
-        }).catch((e) => logAxiomError(e as Error));
+        })
+          .then((res) => {
+            signalsDeliveryTotal.inc({ outcome: res.ok ? 'success' : 'failure' });
+          })
+          .catch((e) => {
+            signalsDeliveryTotal.inc({ outcome: 'failure' });
+            logAxiomError(e as Error);
+          });
       }
       if (i < affectBatches.length - 1) await sleep(signalDelay);
     }


### PR DESCRIPTION
## What

Adds the **P2 observability metrics** to the notifications app (`apps/notifications`), extending its existing prom-client registry (`src/lib/server/metrics.ts`) — same registry, `notifications_` prefix, bounded low-cardinality labels.

### Metrics added (exact names + labels — for the Grafana dashboard PR)

| Metric | Type | Labels | Meaning |
|---|---|---|---|
| `notifications_http_request_duration_seconds` | Histogram | `route`, `outcome` | Read/mutation API RED. `route` = static route template (`/notifications`, `/notifications/query`, `/notifications/count`, `/notifications/mark-read`, `/notifications/bulk`, `/notifications/exists`, `/notifications/cleanup`). `outcome` ∈ `success` \| `rejected` \| `unauthorized` \| `error` \| `client_error`. `_count` gives request rate. Buckets: `0.005,0.01,0.025,0.05,0.1,0.25,0.5,1,2.5,5,10`. |
| `notifications_signals_delivery_total` | Counter | `outcome` | Fan-out worker's per-user realtime signal POST result. `outcome` ∈ `success` \| `failure`. |
| `notifications_redis_errors_total` | Counter | `operation` | Unread-counter cache op errors. `operation` ∈ `get` \| `set` \| `increment` \| `has` \| `clearCategory` \| `bustUser`. |

### Design notes
- **RED via one `onResponse` hook**, scoped to `/notifications*` routes (ops routes `/health`, `/metrics`, `/pool-stats` are excluded so they don't pollute the RED view). Uniform coverage across all authed routes — `query`/`count`/`mark-read`/`bulk`/`exists`/`cleanup` previously had **no** metric. The create path's finer-grained outcome breakdown stays on the existing `notifications_producer_requests_total`; this histogram is the RED-across-routes view, not a double count (different metric names).
- **Signals-delivery** counts non-2xx **and** thrown/rejected fetch as `failure` — the exact silent-drop mode the OLD external notification-server had (POSTing to a non-existent endpoint, previously Axiom-only). Delivery stays **fire-and-forget**; fan-out resilience is unchanged, we only observe the outcome.
- **Redis errors** use a count-and-rethrow wrapper in `cache.ts` — behavior is **unchanged** (errors propagate exactly as before; callers that already `.catch()` still degrade to no-op); the counter just makes silent redis failures scrapeable.
- Signals/redis series are **zero-initialized at load** so they export a `0` baseline before the first event (matches the file's cardinality-discipline comment).

### Scraping
Picked up automatically by the existing ServiceMonitor at `/metrics` — no infra change.

## Tests
- New `cache.test.ts` (3 tests): redis-op error increments `notifications_redis_errors_total{operation}` and still rethrows; success path doesn't increment.
- Extended `app.test.ts` (4 new tests): RED histogram records `route`+`outcome`, ops routes excluded, signals/redis baseline series present.
- `pnpm --filter @civitai/notifications-app typecheck` ✅ and `test` ✅ (20 tests pass). Local Prisma client was reused from the main checkout (NixOS can't fetch the Prisma query engine — `prisma generate` fails locally); CI is the authoritative gate.

## Deploy
No effect on the running deployment until a **`notifications-v*` release build + deploy** (`pnpm release:notifications`). This PR is code only — not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)