### PR TITLE
chore(image-scan): revert temp ingest-submit Axiom logging

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -856,17 +856,6 @@ export const ingestImage = async ({
   tx?: Prisma.TransactionClient;
   userId?: number;
 }): Promise<boolean> => {
-  // TEMP diagnostic: trace who submits to image ingestion and at what priority.
-  // Grouping by `stack` buckets callers even in minified prod builds. Remove
-  // once the low-priority scanner-queue growth is traced.
-  logToAxiom({
-    name: 'ingest-submit',
-    type: 'info',
-    imageId: image.id,
-    message: `ingestImage priority=${lowPriority ? 'low' : 'normal'} userId=${userId ?? ''}`,
-    stack: new Error('ingest-submit').stack,
-  }).catch(() => undefined);
-
   const scanRequestedAt = new Date();
   const dbClient = tx ?? dbWrite;
 
@@ -1012,17 +1001,6 @@ export const ingestImageBulk = async ({
   const dbClient = tx ?? dbWrite;
 
   if (!imageIds.length) return false;
-
-  // TEMP diagnostic: trace who bulk-submits to image ingestion and at what
-  // priority. Grouping by `stack` buckets callers even in minified prod builds.
-  // Remove once the low-priority scanner-queue growth is traced.
-  logToAxiom({
-    name: 'ingest-submit-bulk',
-    type: 'info',
-    imageId: imageIds[0],
-    message: `ingestImageBulk priority=${lowPriority ? 'low' : 'normal'} count=${imageIds.length}`,
-    stack: new Error('ingest-submit-bulk').stack,
-  }).catch(() => undefined);
 
   // TODO.articleImageScan: uncomment when ready to enable image scanning for articles
   // if (!isProd || !callbackUrl) {


### PR DESCRIPTION
Reverts the temporary per-call logging from #2899. It served its purpose: traced the low-pri scanner-queue growth to two legacy k8s CronJobs (`civitai-dp-prod` + `civitai-next`) hitting `run-jobs/ingest-images` hourly, bypassing the disabled Hangfire scheduler. Those cronjobs were removed at the Flux source (talos-infra PR #384), so the high-volume logging is no longer needed. Pure removal of the two `logToAxiom` blocks — restores the pre-#2899 code.