### PR TITLE
fix(test): resolve @civitai/notifications in Vitest — unbreak unit+component suites on main

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,7 +7,19 @@ import path from 'path';
 // node_modules) resolves them the same way the app build does. `@civitai/auth` is omitted —
 // it IS symlinked in node_modules and resolves via its own exports map. Subpath regex must come
 // before the bare entry so `@civitai/redis/client` doesn't get caught by the bare `@civitai/redis`.
-const civitaiWorkspacePkgs = ['db-schema', 'db', 'redis', 'clickhouse', 'axiom', 'telemetry', 'brand'];
+const civitaiWorkspacePkgs = [
+  'db-schema',
+  'db',
+  'redis',
+  'clickhouse',
+  'axiom',
+  'telemetry',
+  'brand',
+  // `@civitai/notifications` (packages/civitai-notifications) is re-exported by
+  // src/server/common/enums.ts; without this alias Vitest can't resolve it and
+  // the whole server suite cascades (enums.ts → BlockRegistry undefined → …).
+  'notifications',
+];
 const civitaiAlias = civitaiWorkspacePkgs.flatMap((p) => {
   const src = path.resolve(__dirname, `packages/civitai-${p}/src`).replace(/\\/g, '/');
   return [


### PR DESCRIPTION
## Severity: the entire unit + component test suite is red on `main` right now

Fresh builds (#2890/#2893/#2894, 2026-07-02) all fail **both** suites identically:
```
unit:      103 failed | 187 passed (290 files) — 262 tests failed
component:  32 failed |  5 passed (37 files)  — 33 tests failed
```
Report-only checks, so it merged silently.

## Root cause — a missing Vitest alias, not 262 real failures

The common error across the ~103 failed files:
```
Error: Cannot find package '@civitai/notifications' imported from src/server/common/enums.ts
→ TypeError: Cannot read properties of undefined (reading 'getFeaturedBlocks' / 'listAvailable' / 'resolveBlockInstance' / …)
```
The notifications-domain migration (`927e31bfee`) made `enums.ts` re-export `NotificationCategory` from the new `@civitai/notifications` workspace package (`packages/civitai-notifications`) and wired it into **tsconfig paths** + **next.config transpilePackages** — but **not** the Vitest alias mirror in `vitest.config.mts`. Vitest doesn't read tsconfig paths and these `packages/civitai-*` packages aren't symlinked into root `node_modules`, so it couldn't resolve the package. `enums.ts` is foundational → `BlockRegistry` and every service imported as `undefined` → cascade. (The app build was fine — next transpiles it — which is why `deploy` stayed green.)

## Fix

Add `'notifications'` to `civitaiWorkspacePkgs` — identical treatment to the other 7 `packages/civitai-*` packages already in the list. One line (+ a comment). Aligns the test resolver with tsconfig + the app build.

## Verification
Confirming on the preview: `unit-tests` and `component-tests` go from the cascade back to green (≈ their real baselines) — should clear all 262 unit + 33 component cascade failures.

FYI to whoever owns the notifications migration: the package landed everywhere except the Vitest alias mirror — this closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)