### PR TITLE
fix(image-scan): Rescan cooldown + retry cap in ingest-images job

### DIFF
--- a/src/server/jobs/image-ingestion.ts
+++ b/src/server/jobs/image-ingestion.ts
@@ -82,7 +82,16 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
   const pendingBackfill = pendingImages.filter((img) => img.isBackfill);
   const pendingUserUploads = pendingImages.filter((img) => !img.isBackfill);
 
-  const rescanImages = images.filter((img) => img.ingestion === 'Rescan');
+  // Rescan mirrors Pending/Error: only re-send once the retry delay has elapsed
+  // (cooldown via scanRequestedAt) and while still under the retry cap. Without
+  // the cooldown, every Rescan image was re-submitted on every run — the
+  // low-priority scanner-queue flood.
+  const rescanImages = images.filter(
+    (img) =>
+      img.ingestion === 'Rescan' &&
+      (!img.scanRequestedAt || img.scanRequestedAt <= rescanDate) &&
+      Number(img.retryCount ?? 0) < IMAGE_SCANNING_RETRY_LIMIT
+  );
 
   const errorImages = images.filter(
     (img) =>
@@ -111,6 +120,14 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
           img.scanRequestedAt > rescanDate
         ) {
           return true;
+        }
+        // Rescan waiting for the retry delay (and still under the retry cap) - KEEP.
+        // Must mirror the rescanImages cooldown above, otherwise a cooled-down
+        // Rescan image is neither processed nor waiting and gets wrongly pruned.
+        if (img.ingestion === 'Rescan') {
+          const waitingForDelay = !!img.scanRequestedAt && img.scanRequestedAt > rescanDate;
+          const underRetryLimit = Number(img.retryCount ?? 0) < IMAGE_SCANNING_RETRY_LIMIT;
+          return waitingForDelay && underRetryLimit;
         }
         // Error but waiting for retry delay or under retry limit
         if (img.ingestion === 'Error') {


### PR DESCRIPTION
## Problem
The `ingest-images` job re-sent **every** `Rescan` image to the scanner on **every run** — `rescanImages` had no `scanRequestedAt` cooldown and no retry cap (unlike `Pending`/`Error`, which gate on the retry delay). Any Rescan that never resolved cycled forever. Combined with the (now-removed) hourly cron double-trigger, this was the low-priority scanner-queue backlog growth.

## Fix
- Gate `rescanImages` on `scanRequestedAt <= rescanDate` (same cooldown as Pending) and cap at `IMAGE_SCANNING_RETRY_LIMIT` (same as Error).
- Add cooled-down Rescan to `waitingForRetryIds` so queue cleanup keeps them. Without this, a cooled-down Rescan would be neither processed nor waiting and get **wrongly pruned** from JobQueue.

Turns Rescan from *every run* into *once per retry-delay, capped* — same contract as Pending/Error. Single file.

## Note
Bigger-picture follow-up (not here): the "items live in JobQueue and get re-swept until terminal" model is fragile; a cleaner design removes on successful submit and re-enqueues only on scan failure/timeout.

## Test
Worktree typecheck showed no errors in the changed file (other errors are workspace-package resolution artifacts of the isolated worktree). Change mirrors the existing Error-branch pattern with in-scope typed vars.