### PR TITLE
docs(claude): point agents at pre-exported $CIVITAI / $KC_DPPROD handles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,9 @@ Occasionally, we comment back and forth as we make plans. Comments from us, are 
 @dev:* This is a new comment that needs attention
 ```
 
+## Shell env (agent shells)
+Non-interactive `zsh -c` doesn't persist state between calls, so don't re-`cd`/`export` each time — devrc's `.zshenv` pre-exports absolute, existence-guarded handles. Use them directly: `$CIVITAI` (this repo), `$DATAPACKET` (the k8s/deploy manifests repo), `$KC_DPPROD` (the dp-prod kubeconfig) — e.g. `git -C $DATAPACKET …`, `KUBECONFIG=$KC_DPPROD kubectl …`. There is no default `KUBECONFIG` — pick a cluster per command so a bare `kubectl` can't hit prod.
+
 ## Tech Stack Overview
 
 ### Core Technologies


### PR DESCRIPTION
## What

One-line pointer so agents in this repo use the **pre-exported shell handles** instead of re-typing `cd <repo>` / `export KUBECONFIG=…` on every Bash call.

## Why

Analysis of a week of Claude Code transcripts found ~50% of all Bash calls begin with `cd`/`export`, because non-interactive `zsh -c` (the agent Bash tool) does not persist shell state between calls — the same repo paths + kubeconfigs get re-set on nearly every turn (~3.8k avoidable turns/week). devrc now pre-exports absolute, existence-guarded handles in `.zshenv`.

## ⚠ Depends on

**devrc PR #48** (`feat/agent-shell-env`) must be **merged AND shipped to the host** (`ship.sh`) before these vars exist. Merge this one *after* that lands — until then the handles are unset (a bare `git -C $VAR` would operate on cwd). Docs-only; fully reversible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)