### PR TITLE
test(app-blocks): fix stale GetStartedBody hero-heading assertion (#2878 copy change)

### DIFF
--- a/src/components/Apps/GetStartedBody.browser.test.tsx
+++ b/src/components/Apps/GetStartedBody.browser.test.tsx
@@ -22,7 +22,7 @@ describe('GetStartedBody (public App builders landing)', () => {
   test('renders the hero heading', async () => {
     renderWithProviders(<GetStartedBody />);
     await expect
-      .element(page.getByRole('heading', { name: 'Build apps on Civitai', level: 1 }))
+      .element(page.getByRole('heading', { name: 'Build on Civitai', level: 1 }))
       .toBeInTheDocument();
   });
 


### PR DESCRIPTION
## What

The last remaining `component-tests` failure (after #2871/#2876 + #2903): `GetStartedBody.browser.test.tsx > renders the hero heading` fails with `Cannot find element: getByRole('heading', { name: 'Build apps on Civitai', level: 1 })`.

#2878 (`copy(app-blocks): get-started page — Beta badge, 'Build on Civitai' title`) changed the H1 from **'Build apps on Civitai'** → **'Build on Civitai'** (`GetStartedBody.tsx:107`) but didn't update the test. One-line assertion fix to match the shipped copy. Test-only; no product change.

Part of un-breaking today's `main` test suites (alongside #2903 notifications-alias + the blocks.router redis-mock fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)