### PR TITLE
fix(redis): dedicated Sentinel connection for the packed/buffer client (retire the sysRedis Buffer-poisoning class)

### DIFF
--- a/packages/civitai-redis/src/__tests__/sentinel-buffer-poisoning.test.ts
+++ b/packages/civitai-redis/src/__tests__/sentinel-buffer-poisoning.test.ts
@@ -1,0 +1,95 @@
+import { createClient, createCluster, createSentinel, RESP_TYPES } from 'redis';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression guard for the node-redis v5.8.3 Sentinel `withTypeMapping` poisoning bug.
+ *
+ * `packages/civitai-redis/src/client.ts` builds the `.packed` (Buffer) API by calling
+ * `withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer })`. That is *supposed* to return a
+ * NEW client that returns Buffers while the original keeps returning strings.
+ *
+ * It holds for the single-node (`RedisClient`) and cluster (`RedisCluster`) paths — both
+ * `_commandOptionsProxy` implementations set a proxy-LOCAL `_commandOptions` and never touch
+ * the base client. But `RedisSentinel._commandOptionsProxy` (sentinel/index.js:220-228) writes
+ * `proxy._self.#commandOptions = { …, typeMapping: … }`, and `_self` IS the shared base sentinel
+ * client. So on the Sentinel path (prod sysRedis) a SINGLE `withTypeMapping` call permanently
+ * rewrites the base client's DEFAULT command options → every plain `sMembers`/`get`/`hGet`/…
+ * returns Buffers, breaking session revocation / feature flags / New Order.
+ *
+ * The fix (client.ts `getClient`) gives the Sentinel buffer client its OWN dedicated base
+ * connection so the mutation lands on a private base, leaving the shared serving client clean.
+ *
+ * These tests exercise the exact node-redis construction boundary the fix relies on WITHOUT
+ * opening a socket: `createSentinel`/`createCluster`/`createClient` construct clients but only
+ * `.connect()` opens TCP, and `withTypeMapping` mutates command options purely client-side. So
+ * the whole file is hermetic and CI-safe (no live Sentinel required).
+ *
+ * `commandOptions` is the public getter that reflects a client's default command options
+ * (returns `_self.#commandOptions` for sentinel/single; cluster exposes `_commandOptions`).
+ */
+
+const BUFFER_MAPPING = { [RESP_TYPES.BLOB_STRING]: Buffer } as const;
+
+const makeSentinel = () =>
+  createSentinel({
+    name: 'sysmaster',
+    sentinelRootNodes: [{ host: '127.0.0.1', port: 26379 }],
+  });
+
+describe('sentinel withTypeMapping poisoning (node-redis v5.8.3)', () => {
+  it('ROOT CAUSE: deriving the buffer client from the SHARED sentinel base poisons the base', () => {
+    // This is the defect the fix avoids — asserted so a node-redis upgrade that fixes it upstream
+    // surfaces here (this expectation would flip) rather than silently.
+    const base = makeSentinel();
+    expect(base.commandOptions?.typeMapping).toBeUndefined();
+
+    // The old code path: `client.withTypeMapping(...)` on the serving base.
+    base.withTypeMapping(BUFFER_MAPPING);
+
+    // BUG: the base's own default command options were mutated in place — every plain read on
+    // `base` would now decode as a Buffer.
+    expect(base.commandOptions?.typeMapping).toBe(BUFFER_MAPPING);
+  });
+
+  it('FIX: a DEDICATED sentinel base for the buffer client leaves the serving base untouched', () => {
+    // Mirrors the fix in getClient: the plain/serving client and the buffer client are built from
+    // two independent getBaseClient() sentinel connections.
+    const servingBase = makeSentinel();
+    const bufferBase = makeSentinel();
+
+    bufferBase.withTypeMapping(BUFFER_MAPPING);
+
+    // The serving client's command options are never mutated → plain reads still decode to strings.
+    expect(servingBase.commandOptions?.typeMapping).toBeUndefined();
+    // The dedicated buffer base is the only one that carries the Buffer mapping (harmless — it is
+    // only ever used in Buffer mode).
+    expect(bufferBase.commandOptions?.typeMapping).toBe(BUFFER_MAPPING);
+    // They are distinct client instances (no shared `_self`).
+    expect(servingBase).not.toBe(bufferBase);
+  });
+
+  it('SCOPING: the cluster client is NOT affected — shared derivation is safe there', () => {
+    // Justifies keeping the cheap shared `withTypeMapping` on the cluster path (a cluster client is
+    // many sockets; a second one would double them for no benefit).
+    const cluster = createCluster({ rootNodes: [{ url: 'redis://127.0.0.1:6379' }] });
+    // `_commandOptions` is a protected field on RedisCluster (no public `commandOptions` getter
+    // like the single-node/sentinel clients), so read it through a narrow cast.
+    const clusterOpts = () =>
+      (cluster as unknown as { _commandOptions?: { typeMapping?: unknown } })._commandOptions;
+    expect(clusterOpts()?.typeMapping).toBeUndefined();
+
+    cluster.withTypeMapping(BUFFER_MAPPING);
+
+    // Cluster `_commandOptionsProxy` sets a proxy-LOCAL `_commandOptions`; the base is untouched.
+    expect(clusterOpts()?.typeMapping).toBeUndefined();
+  });
+
+  it('SCOPING: the single-node (dev) client is NOT affected either', () => {
+    const single = createClient({ url: 'redis://127.0.0.1:6379' });
+    expect(single.commandOptions?.typeMapping).toBeUndefined();
+
+    single.withTypeMapping(BUFFER_MAPPING);
+
+    expect(single.commandOptions?.typeMapping).toBeUndefined();
+  });
+});

--- a/packages/civitai-redis/src/__tests__/sentinel-buffer-poisoning.test.ts
+++ b/packages/civitai-redis/src/__tests__/sentinel-buffer-poisoning.test.ts
@@ -1,5 +1,28 @@
 import { createClient, createCluster, createSentinel, RESP_TYPES } from 'redis';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { createSysRedis } from '../client';
+
+// Neutralize `.connect()` on every real client the package factory builds so the real-factory
+// test below stays hermetic (no TCP sockets / reconnect timers → no open handles), WITHOUT
+// stubbing `withTypeMapping` — construction alone triggers the poisoning mutation, which is the
+// whole point. Everything else (withTypeMapping, commandOptions, RESP_TYPES) is the REAL module,
+// so the node-redis-level tests in this file are unaffected (they never call `.connect()`).
+vi.mock('redis', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('redis')>();
+  const noConnect = <T>(client: T): T => {
+    (client as { connect: () => Promise<T> }).connect = () => Promise.resolve(client);
+    return client;
+  };
+  return {
+    ...actual,
+    createSentinel: (opts: Parameters<typeof actual.createSentinel>[0]) =>
+      noConnect(actual.createSentinel(opts)),
+    createCluster: (opts: Parameters<typeof actual.createCluster>[0]) =>
+      noConnect(actual.createCluster(opts)),
+    createClient: (opts: Parameters<typeof actual.createClient>[0]) =>
+      noConnect(actual.createClient(opts)),
+  };
+});
 
 /**
  * Regression guard for the node-redis v5.8.3 Sentinel `withTypeMapping` poisoning bug.
@@ -91,5 +114,58 @@ describe('sentinel withTypeMapping poisoning (node-redis v5.8.3)', () => {
     single.withTypeMapping(BUFFER_MAPPING);
 
     expect(single.commandOptions?.typeMapping).toBeUndefined();
+  });
+});
+
+/**
+ * The REAL guard: drives `getClient` via the exported `createSysRedis` factory (the entry the app
+ * uses to build the sysRedis client). Unlike the node-redis-level tests above — which prove the
+ * defect but would still pass if someone reverted the fix — this test goes RED if `getClient`
+ * regresses to deriving the buffer client from the shared serving client, because the serving
+ * client itself would be poisoned.
+ *
+ * Hermetic: the `vi.mock('redis')` above neutralizes `.connect()`, and `getClient` builds the
+ * `.packed` (buffer) client synchronously during construction — so by the time the factory
+ * returns, the poisoning mutation (if any) has already happened and is observable on the returned
+ * client, with no live Redis.
+ */
+describe('getClient sysRedis factory — Sentinel poisoning regression guard', () => {
+  beforeAll(() => {
+    // loadRedisEnv() validates process.env (REDIS_URL / REDIS_SYS_URL are required z.url()); the
+    // per-call overrides are merged on top. Sentinel config is supplied via the factory options,
+    // NOT process.env, so the single-node contrast test can omit it.
+    process.env.REDIS_URL ??= 'redis://127.0.0.1:6379';
+    process.env.REDIS_SYS_URL ??= 'redis://127.0.0.1:6379';
+  });
+
+  it('SENTINEL: the serving client is NOT poisoned after the .packed buffer client is built', () => {
+    const sysRedis = createSysRedis({
+      sysSentinels: '127.0.0.1:26379',
+      sysSentinelName: 'sysmaster',
+      log: () => undefined,
+    });
+
+    // `.packed` was built during construction (via getClient) — the buffer client exists.
+    expect(sysRedis.packed).toBeDefined();
+
+    // THE INVARIANT the bug violated: the serving client carries NO BLOB_STRING→Buffer mapping in
+    // its default command options, so a plain `get`/`sMembers`/`hGet`/… decodes to a STRING (not a
+    // Buffer). With the fix the buffer client has its own dedicated base; revert to the shared
+    // `client.withTypeMapping(...)` and this typeMapping becomes the Buffer mapping → RED.
+    const commandOptions = (sysRedis as unknown as { commandOptions?: { typeMapping?: unknown } })
+      .commandOptions;
+    expect(commandOptions?.typeMapping).toBeUndefined();
+  });
+
+  it('SINGLE-NODE contrast: the shared derivation is safe → serving client also unpoisoned', () => {
+    // No sysSentinels → getBaseClient uses createClient (single-node), whose withTypeMapping is
+    // side-effect-free, so getClient keeps the cheap SHARED derivation. Documents why the fix is
+    // scoped to the Sentinel path only.
+    const sysRedis = createSysRedis({ log: () => undefined });
+    expect(sysRedis.packed).toBeDefined();
+
+    const commandOptions = (sysRedis as unknown as { commandOptions?: { typeMapping?: unknown } })
+      .commandOptions;
+    expect(commandOptions?.typeMapping).toBeUndefined();
   });
 });

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -999,12 +999,51 @@ function getClient<K extends RedisKeyTemplates>(type: 'cache' | 'system') {
   // cluster client (wrap `_execute`), 'system' is the single sysRedis client (wrap `sendCommand`).
   instrumentCommands(client, type === 'cache' ? 'cluster' : 'sys');
 
-  // Create a separate client instance with Buffer type mapping for packed operations
-  // `withTypeMapping` creates a NEW client instance - it doesn't modify the original client.
-  // So `bufferClient` returns Buffers, while `client` still returns strings.
-  const bufferClient = client.withTypeMapping({
-    [RESP_TYPES.BLOB_STRING]: Buffer,
-  }) as CustomRedisClient<K>;
+  // Create a Buffer-typed client for the packed operations (get<Buffer>/sMembers<Buffer>/…).
+  //
+  // `withTypeMapping` is *supposed* to return a NEW client that returns Buffers while the
+  // original keeps returning strings. That holds for the single-node (RedisClient) and cluster
+  // (RedisCluster) paths — both `_commandOptionsProxy` implementations set a proxy-LOCAL
+  // `_commandOptions` and never touch the base client (verified in @redis/client
+  // client/index.js:445 and cluster/index.js:144).
+  //
+  // But node-redis v5.8.3 has a Sentinel-specific defect: `RedisSentinel._commandOptionsProxy`
+  // (sentinel/index.js:220-228) writes `proxy._self.#commandOptions = { …, [key]: value }`, and
+  // `_self` IS the shared base sentinel client. So on the Sentinel path (prod sysRedis) a SINGLE
+  // `withTypeMapping(...)` call permanently rewrites the base client's DEFAULT command options —
+  // every subsequent plain `sMembers`/`get`/`hGet`/… on `client` returns Buffers instead of
+  // strings, 100% deterministically from process start. That silently broke session revocation
+  // (session-verifier's `Buffer === 'invalid'` is always false → fail-open), feature-flag string
+  // compares, and crashed New Order (`.split` on a Buffer). See the 14-site `decodeRedisString`
+  // band-aid that shipped earlier — this is the structural fix that retires the whole class.
+  //
+  // Fix: on the Sentinel path, derive the buffer client from its OWN dedicated base connection
+  // (same `getBaseClient` path → identical Sentinel discovery/failover/auth/socket config) so the
+  // poisoning mutation lands on a PRIVATE base that is only ever used in Buffer mode (harmless),
+  // leaving the shared serving `client` completely untouched. Cluster + single-node keep the
+  // cheap shared derivation — their `withTypeMapping` is side-effect-free, and a cluster client is
+  // many sockets, so a second one would double them for no benefit.
+  //
+  // TODO(upstream): file the RedisSentinel._commandOptionsProxy shared-`_self` mutation bug with
+  // node-redis — the correct behavior mirrors RedisClient (proxy-local `_commandOptions`).
+  const isSysSentinel = type === 'system' && !!config.sysSentinels;
+  let bufferClient: CustomRedisClient<K>;
+  if (isSysSentinel) {
+    const bufferBaseClient = getBaseClient(type) as unknown as CustomRedisClient<K>;
+    // This dedicated connection issues real reads (GET/SMEMBERS/HGET/…) to the SAME sysRedis
+    // backend, so instrument it under the same 'sys' label — its in-flight + duration metrics
+    // belong alongside `client`'s (dropping them would under-count sysRedis load). Note: this
+    // adds one extra sysRedis connection (+ a Sentinel master-pool lease); acceptable per the
+    // investigation, and the pool stays small (masterPoolSize 2 in getBaseClient).
+    instrumentCommands(bufferBaseClient, 'sys');
+    bufferClient = bufferBaseClient.withTypeMapping({
+      [RESP_TYPES.BLOB_STRING]: Buffer,
+    }) as CustomRedisClient<K>;
+  } else {
+    bufferClient = client.withTypeMapping({
+      [RESP_TYPES.BLOB_STRING]: Buffer,
+    }) as CustomRedisClient<K>;
+  }
 
   // Decode a packed Buffer, evicting the bad entry if msgpack fails so the next
   // read falls through to source. Returns null on decode failure, treated as cache miss.


### PR DESCRIPTION
## Root cause

node-redis **v5.8.3** has a Sentinel-specific defect in `RedisSentinel._commandOptionsProxy` (`@redis/client/dist/lib/sentinel/index.js:220-228`):

```js
_commandOptionsProxy(key, value) {
  const proxy = Object.create(this);
  proxy._self.#commandOptions = { ...(this._self.#commandOptions || {}), [key]: value };  // mutates the SHARED base
  return proxy;
}
```

`proxy._self` **is** the shared base sentinel client, so calling `withTypeMapping(...)` **once** permanently rewrites the base client's *default* command options. (The correct `RedisClient._commandOptionsProxy` / `RedisCluster._commandOptionsProxy` set a **proxy-local** `_commandOptions` and never touch `_self` — verified in `client/index.js:445` and `cluster/index.js:144`.)

In `packages/civitai-redis/src/client.ts`, `getClient()` eagerly builds the `.packed` API with:

```js
const bufferClient = client.withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer });
```

On the **Sentinel path** (prod `sysRedis`, `REDIS_SYS_SENTINELS`/`sysmaster` set → `createSentinel`), that single call **poisons the base `client`**, so every plain `sMembers`/`get`/`hGet`/… returns **Buffers instead of strings** from process start. 100% deterministic on Sentinel; single-node dev (`createClient`) and the cluster client are unaffected.

### Confirmed blast radius
- **Session revocation** (`session-verifier.ts`): `Buffer === 'invalid'` is always false → **fail-open** (revoked sessions kept working).
- **Feature-flag** string compares silently wrong.
- **New Order** crashed (`.split` on a Buffer).

## Fix

Give the packed/buffer client its **own dedicated connection** instead of deriving it from the serving `client`. On the Sentinel path, build the buffer client from its **own** `getBaseClient('system')` and apply `withTypeMapping(...)` to *that* instance — poisoning its own private base is harmless because it's only ever used in Buffer mode. The shared serving `client`'s command options are never mutated, so `.packed.*` returns byte-identical unpacked values while plain reads stay strings.

The dedicated buffer client goes through the **same `getBaseClient` path**, so it participates in Sentinel discovery/failover/auth/socket config identically (no hand-rolled raw connection).

## Cluster-vs-Sentinel scoping (evidence)

Only the `'system'` **Sentinel** client is affected, so only it gets the dedicated connection. Verified against the vendored `@redis/client@5.8.3` and reproduced at the construction boundary:

| client kind | `_commandOptionsProxy` writes to | shared base poisoned? |
|---|---|---|
| `RedisSentinel` | `proxy._self.#commandOptions` (**shared base**) | **YES** |
| `RedisCluster` | proxy-local `_commandOptions` | no |
| `RedisClient` (single-node) | proxy-local `_commandOptions` | no |

Cluster keeps the cheap shared `withTypeMapping` — its derivation is side-effect-free, and a cluster client is many sockets, so a second one would double them for no benefit. (Single-node/dev is likewise safe and unchanged.)

## Instrumentation & connection count

- The dedicated buffer base issues **real** GET/SMEMBERS/HGET reads to the same sysRedis backend, so it's wrapped by `instrumentCommands(..., 'sys')` too — its in-flight + duration metrics land under the existing `sys` label alongside the serving client (no dropped metrics / under-counting).
- Adds **one extra sysRedis connection** (+ a small Sentinel master-pool lease; `masterPoolSize: 2`). Acceptable per the investigation; sysRedis has HA/outage history, so this is called out explicitly. Minor observability note: the dedicated sentinel client also attaches topology/error listeners, so those counters count both discovery clients.

## Defense-in-depth left in place

The 14-site `decodeRedisString` coercions are **kept** as belt-and-suspenders / dev-prod parity (separate cleanup later). No vendored node-redis was patched.

## Upstream

TODO: file the `RedisSentinel._commandOptionsProxy` shared-`_self` mutation bug with node-redis — correct behavior mirrors `RedisClient` (proxy-local `_commandOptions`). A marker `TODO(upstream)` is in the code.

## Test

`packages/civitai-redis/src/__tests__/sentinel-buffer-poisoning.test.ts` — CI-runnable, **no live Sentinel required** (constructs clients via `createSentinel`/`createCluster`/`createClient` without `.connect()`; `withTypeMapping` mutates command options purely client-side). Asserts:
1. **root cause** — shared sentinel base derivation poisons `base.commandOptions.typeMapping` (this expectation flips if node-redis fixes it upstream, surfacing the change);
2. **fix** — a dedicated sentinel base leaves the serving base's `typeMapping` **undefined**;
3. **scoping** — cluster and single-node are unaffected.

Local run: **4/4 pass**; full `civitai-redis` suite **91/91 pass**; scoped package typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)