### PR TITLE
fix(notifications): FOR UPDATE SKIP LOCKED on the worker batch-claim query

### DIFF
--- a/apps/notifications/src/worker/poll-loop.test.ts
+++ b/apps/notifications/src/worker/poll-loop.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+// The batch-claim query is exported so its structure can be asserted directly (no DB/mock needed), the
+// same "assert the SQL string" approach as operations.test.ts. The single load-bearing invariant here is
+// `FOR UPDATE SKIP LOCKED`: dropping it silently reintroduces the two-worker double-claim race (see the
+// comment on PENDING_CLAIM_QUERY). This test is the regression guard against that edit.
+import { PENDING_CLAIM_QUERY } from './poll-loop';
+
+// Collapse all runs of whitespace so assertions are insensitive to indentation/line-wrapping.
+const sql = PENDING_CLAIM_QUERY.replace(/\s+/g, ' ').trim();
+
+describe('PENDING_CLAIM_QUERY', () => {
+  it('locks claimed rows with FOR UPDATE SKIP LOCKED in the inner SELECT', () => {
+    expect(sql).toContain('FOR UPDATE SKIP LOCKED');
+  });
+
+  it('applies the row lock to the LIMITed inner SELECT, not the outer UPDATE', () => {
+    // FOR UPDATE SKIP LOCKED must sit after LIMIT (inside the CTE) so only the claimed batch is locked.
+    // Order matters: `... LIMIT <n> FOR UPDATE SKIP LOCKED )` then the outer UPDATE.
+    expect(sql).toMatch(/LIMIT \d+ FOR UPDATE SKIP LOCKED \)/);
+    expect(sql.indexOf('FOR UPDATE SKIP LOCKED')).toBeLessThan(sql.indexOf('UPDATE "PendingNotification" pn'));
+  });
+
+  it('claims by stamping claimedAt and reclaims rows stuck past the too-old window', () => {
+    expect(sql).toContain('SET "claimedAt" = NOW()');
+    // Stale-claim reclaim guard — a row whose worker died stays claimable after the interval.
+    expect(sql).toMatch(/"claimedAt" IS NULL OR "claimedAt" < NOW\(\) - INTERVAL '30min'/);
+  });
+
+  it('processes oldest-first and bounds the batch size', () => {
+    expect(sql).toContain('ORDER BY id');
+    expect(sql).toMatch(/LIMIT 3000/);
+  });
+
+  it('returns the claimed rows so the worker can fan them out', () => {
+    expect(sql).toMatch(/RETURNING \*$/);
+  });
+});

--- a/apps/notifications/src/worker/poll-loop.ts
+++ b/apps/notifications/src/worker/poll-loop.ts
@@ -50,30 +50,42 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+// Batch-claim query for due PendingNotification rows. `FOR UPDATE SKIP LOCKED` on the inner SELECT is the
+// load-bearing concurrency guard: without it, two workers' CTE SELECTs can pick the SAME rows (the SELECT
+// takes no locks), and the outer UPDATE's `WHERE r.id = pn.id` does NOT re-check `claimedAt IS NULL` — so
+// the second UPDATE, once it unblocks on the first's row lock, re-stamps `claimedAt` and RETURNS the same
+// rows → both workers fan the batch out (double signals + debounce rows resurrected via the ON CONFLICT
+// DO UPDATE ... viewed=FALSE path). The worker Deployment is replicas:1 + strategy:Recreate today, so no
+// two workers run concurrently in normal operation; SKIP LOCKED makes the claim correct regardless of
+// replica count (an accidental scale-up or a future HA change can't cause double fan-out). With a single
+// worker there is zero contention, so this clause is a no-op on the happy path.
+export const PENDING_CLAIM_QUERY = `
+  WITH
+    return_data AS (
+      SELECT
+        id, type, category, key, users, details,
+        "debounceSeconds", "lastTriggered", "nextSendAt"
+      FROM "PendingNotification"
+      WHERE
+        ("claimedAt" IS NULL OR "claimedAt" < NOW() - INTERVAL '${tooOld}')
+        AND (
+          "debounceSeconds" IS NULL
+          OR ("debounceSeconds" IS NOT NULL AND NOW() >= "nextSendAt")
+        )
+      ORDER BY id
+      LIMIT ${rowsToFetch}
+      FOR UPDATE SKIP LOCKED
+    )
+  UPDATE "PendingNotification" pn
+  SET "claimedAt" = NOW()
+  FROM return_data r
+  WHERE r.id = pn.id
+  RETURNING *
+`;
+
 const getPending = async (): Promise<PendingReturnRow[]> => {
   try {
-    const query = await notifDbWrite().cancellableQuery<PendingReturnRow>(`
-      WITH
-        return_data AS (
-          SELECT
-            id, type, category, key, users, details,
-            "debounceSeconds", "lastTriggered", "nextSendAt"
-          FROM "PendingNotification"
-          WHERE
-            ("claimedAt" IS NULL OR "claimedAt" < NOW() - INTERVAL '${tooOld}')
-            AND (
-              "debounceSeconds" IS NULL
-              OR ("debounceSeconds" IS NOT NULL AND NOW() >= "nextSendAt")
-            )
-          ORDER BY id
-          LIMIT ${rowsToFetch}
-        )
-      UPDATE "PendingNotification" pn
-      SET "claimedAt" = NOW()
-      FROM return_data r
-      WHERE r.id = pn.id
-      RETURNING *
-    `);
+    const query = await notifDbWrite().cancellableQuery<PendingReturnRow>(PENDING_CLAIM_QUERY);
     return await query.result();
   } catch (e) {
     logAxiomError(e as Error);


### PR DESCRIPTION
## What

Add `FOR UPDATE SKIP LOCKED` to the fan-out worker's `PendingNotification` batch-claim query (`apps/notifications/src/worker/poll-loop.ts`).

## Why

The claim query is a `WITH return_data AS (SELECT ... LIMIT n) UPDATE "PendingNotification" ... FROM return_data WHERE r.id = pn.id RETURNING *`. The inner `SELECT` took **no row locks**, and the outer `UPDATE`'s join condition is only `r.id = pn.id` — it never re-checks `claimedAt IS NULL`.

Concurrency consequence: if two workers run at once, both CTE `SELECT`s can select the **same** rows. The second `UPDATE` blocks on the first's row lock, then unblocks *after* the first commits, re-stamps `claimedAt = NOW()`, and `RETURNING *` hands the **same batch** back. Both workers fan it out →

- duplicate realtime signals per user, and
- debounced notifications resurrected as unread via the `ON CONFLICT ("notificationId","userId") DO UPDATE SET "createdAt"=now(), viewed=FALSE` path.

`FOR UPDATE SKIP LOCKED` on the inner SELECT is the canonical Postgres claim-queue fix: a second worker **skips** rows locked by the first instead of double-claiming.

## Risk / scope

Defensive, not a live-bug fix. The worker Deployment is `replicas: 1` + `strategy: Recreate`, so no two workers run concurrently in normal operation (single-worker correctness was previously enforced *only* by that config + a comment). This makes the claim query correct **regardless of replica count** — an accidental scale-up or a future HA change can no longer cause double fan-out. With one worker there is zero lock contention, so the clause is a **no-op on the happy path**.

## Verification

- `EXPLAIN` of the exact query against the live `notification_prod` DB plans a `LockRows` node inside the CTE (SKIP LOCKED is accepted + applied).
- Query extracted to an exported `PENDING_CLAIM_QUERY` constant + a structural regression test (asserts the locking clause, its placement after `LIMIT`, claim/reclaim semantics) — mirrors the existing `operations.test.ts` "assert the SQL" pattern.
- Full notifications suite: **25/25 pass**; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)