### PR TITLE
test(blocks): importActual real REDIS keys in redis mocks — unbreak 14 unit files

### DIFF
--- a/src/server/routers/__tests__/blocks.router.flag-gate-hydrate.test.ts
+++ b/src/server/routers/__tests__/blocks.router.flag-gate-hydrate.test.ts
@@ -99,12 +99,10 @@ vi.mock('~/server/db/client', () => ({
   dbRead: mockDbRead,
   dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: mockRedis,
-  sysRedis: mockSysRedis,
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return { ...actual, redis: mockRedis, sysRedis: mockSysRedis };
+});
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
 }));

--- a/src/server/routers/__tests__/blocks.router.flag-gate.test.ts
+++ b/src/server/routers/__tests__/blocks.router.flag-gate.test.ts
@@ -82,12 +82,10 @@ vi.mock('~/server/db/client', () => ({
   dbRead: mockDbRead,
   dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: mockRedis,
-  sysRedis: mockSysRedis,
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return { ...actual, redis: mockRedis, sysRedis: mockSysRedis };
+});
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
 }));

--- a/src/server/routers/__tests__/blocks.router.getAppDetail.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getAppDetail.test.ts
@@ -66,12 +66,14 @@ vi.mock('~/server/db/client', () => ({
   dbRead: { appBlock: { findUnique: vi.fn() } },
   dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: { get: vi.fn(), set: vi.fn() },
-  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return {
+    ...actual,
+    redis: { get: vi.fn(), set: vi.fn() },
+    sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  };
+});
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
 }));

--- a/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getInstallConfig.test.ts
@@ -53,10 +53,10 @@ vi.mock('~/server/db/client', () => ({
   dbRead: { appBlock: { findUnique: mockDbReadAppBlockFindUnique } },
   dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
-  REDIS_KEYS: { BLOCKS: {} },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return { ...actual, redis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) } };
+});
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
   verifyBlockToken: vi.fn(),
   parseSubjectUserId: vi.fn(),

--- a/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
@@ -106,12 +106,10 @@ vi.mock('~/server/db/client', () => ({
   dbRead: mockDbRead,
   dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: mockRedis,
-  sysRedis: mockSysRedis,
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return { ...actual, redis: mockRedis, sysRedis: mockSysRedis };
+});
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
 }));

--- a/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
@@ -30,7 +30,9 @@ vi.mock('~/server/services/app-blocks-flag', () => ({
 vi.mock('~/env/server', () => ({
   // LOGGING is read by cache-helpers' createLogger at module-eval (the router
   // now statically imports appBlockReview.service, which imports cache-helpers).
-  env: { FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com', LOGGING: '' },
+  // MEILI_CALL_CONCURRENCY is read by meilisearch/client at module-eval
+  // (reached via the router's transitive imports) — pLimit() throws on undefined.
+  env: { FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com', LOGGING: '', MEILI_CALL_CONCURRENCY: 50 },
 }));
 vi.mock('~/server/services/blocks/dev-git-access.service', () => ({
   ensureForgejoIdentity: mockEnsureForgejoIdentity,

--- a/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
@@ -79,12 +79,14 @@ vi.mock('~/server/db/client', () => ({
   dbRead: { appBlock: { findUnique: vi.fn() } },
   dbWrite: {},
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: { get: vi.fn(), set: vi.fn() },
-  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return {
+    ...actual,
+    redis: { get: vi.fn(), set: vi.fn() },
+    sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  };
+});
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
 }));

--- a/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
@@ -68,12 +68,14 @@ vi.mock('~/server/db/client', () => ({
   dbRead: { appBlock: { findUnique: vi.fn(), findFirst: vi.fn() } },
   dbWrite: {},
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: { get: vi.fn(), set: vi.fn() },
-  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return {
+    ...actual,
+    redis: { get: vi.fn(), set: vi.fn() },
+    sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  };
+});
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
 }));

--- a/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
@@ -25,7 +25,14 @@ const { mockIsAppBlocksEnabled, mockEnsureForgejoIdentity, mockAddCollaborator }
 
 vi.mock('~/server/services/app-blocks-flag', () => ({ isAppBlocksEnabled: mockIsAppBlocksEnabled }));
 vi.mock('~/env/server', () => ({
-  env: { FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com', APPS_DOMAIN: 'civit.ai', LOGGING: '' },
+  // MEILI_CALL_CONCURRENCY is read by meilisearch/client at module-eval
+  // (reached via the router's transitive imports) — pLimit() throws on undefined.
+  env: {
+    FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com',
+    APPS_DOMAIN: 'civit.ai',
+    LOGGING: '',
+    MEILI_CALL_CONCURRENCY: 50,
+  },
 }));
 vi.mock('~/server/services/blocks/dev-git-access.service', () => ({
   ensureForgejoIdentity: mockEnsureForgejoIdentity,

--- a/src/server/routers/__tests__/blocks.router.getNavSummary.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getNavSummary.test.ts
@@ -86,12 +86,10 @@ vi.mock('~/server/db/client', () => ({
   dbRead: mockDbRead,
   dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: mockRedis,
-  sysRedis: mockSysRedis,
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return { ...actual, redis: mockRedis, sysRedis: mockSysRedis };
+});
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
 }));

--- a/src/server/routers/__tests__/blocks.router.reviewSandbox.test.ts
+++ b/src/server/routers/__tests__/blocks.router.reviewSandbox.test.ts
@@ -91,12 +91,10 @@ vi.mock('~/server/db/client', () => ({
   dbRead: mockDbRead,
   dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: mockRedis,
-  sysRedis: mockSysRedis,
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return { ...actual, redis: mockRedis, sysRedis: mockSysRedis };
+});
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
 }));

--- a/src/server/routers/__tests__/blocks.router.setMarketplaceMeta.test.ts
+++ b/src/server/routers/__tests__/blocks.router.setMarketplaceMeta.test.ts
@@ -73,12 +73,14 @@ vi.mock('~/server/db/client', () => ({
   dbRead: { appBlock: { findUnique: vi.fn() } },
   dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: { get: vi.fn(), set: vi.fn() },
-  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return {
+    ...actual,
+    redis: { get: vi.fn(), set: vi.fn() },
+    sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  };
+});
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
 }));

--- a/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
+++ b/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
@@ -71,29 +71,16 @@ vi.mock('~/server/db/client', () => ({
 // Mock the heavy peer modules the router imports so the import graph
 // stays cheap and we don't accidentally hit live deps.
 // blocks.router transitively pulls in many redis-cache modules (resource-data.redis,
-// caches.ts, ...) that each read `REDIS_KEYS.<GROUP>.<KEY>` AT IMPORT TIME. The
-// real keys live in redis/client (which connects on import, so we can't
-// importActual it). A hand-trimmed REDIS_KEYS is whack-a-mole: it flakily threw on
-// whichever key the current load order happened to reach first (RESOURCE_DATA, then
-// CACHES.TAG_IDS_FOR_IMAGES, ...). `completeKeys` wraps the few values the tests
-// assert on with an auto-vivifying Proxy so ANY other key resolves to a
-// deterministic placeholder string instead of `undefined.X` — ending the flake.
-const { completeKeys } = vi.hoisted(() => {
-  const group = (explicit: Record<string, string>, name: string): Record<string, string> =>
-    new Proxy(explicit, {
-      get: (t, k) => (k in t ? (t as any)[k] : typeof k === 'string' ? `mock:${name}:${k}` : (t as any)[k]),
-    });
-  const completeKeys = (explicit: Record<string, Record<string, string>>) =>
-    new Proxy(explicit, {
-      get: (t, g) => (g in t ? group((t as any)[g], g as string) : typeof g === 'string' ? group({}, g) : (t as any)[g]),
-    });
-  return { completeKeys };
+// caches.ts, ...) that read REDIS_KEYS/REDIS_SYS_KEYS.<GROUP>.<KEY> AT IMPORT TIME.
+// importActual the @civitai/redis PACKAGE — it's side-effect-free (only exports the
+// key constants + factory; connections happen when createRedisClients() is CALLED,
+// which only the ~/server/redis/client shim does at import) → the COMPLETE real key
+// tree, so no hand-trimmed subset can go stale. (Replaces the old completeKeys Proxy,
+// which covered REDIS_KEYS but not REDIS_SYS_KEYS.)
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return { ...actual, redis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) } };
 });
-
-vi.mock('~/server/redis/client', () => ({
-  redis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
-  REDIS_KEYS: completeKeys({ BLOCKS: {} }),
-}));
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
   verifyBlockToken: vi.fn(),
   parseSubjectUserId: vi.fn(),

--- a/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
+++ b/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
@@ -39,7 +39,14 @@ vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
 }));
 vi.mock('~/env/server', () => ({
-  env: { FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com', APPS_DOMAIN: 'civit.ai', LOGGING: '' },
+  // MEILI_CALL_CONCURRENCY is read by meilisearch/client at module-eval
+  // (reached via the router's transitive imports) — pLimit() throws on undefined.
+  env: {
+    FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com',
+    APPS_DOMAIN: 'civit.ai',
+    LOGGING: '',
+    MEILI_CALL_CONCURRENCY: 50,
+  },
 }));
 vi.mock('~/server/services/blocks/forgejo.service', () => ({
   FORGEJO_ORG: 'civitai-apps',

--- a/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
+++ b/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
@@ -94,12 +94,14 @@ vi.mock('~/server/db/client', () => ({
   dbRead: { appBlock: { findUnique: vi.fn() } },
   dbWrite: {},
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: { get: vi.fn(), set: vi.fn() },
-  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return {
+    ...actual,
+    redis: { get: vi.fn(), set: vi.fn() },
+    sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  };
+});
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
 }));

--- a/src/server/routers/__tests__/blocks.router.upsertReview.test.ts
+++ b/src/server/routers/__tests__/blocks.router.upsertReview.test.ts
@@ -70,12 +70,14 @@ vi.mock('~/server/db/client', () => ({
   dbRead: { appBlock: { findUnique: vi.fn() } },
   dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
 }));
-vi.mock('~/server/redis/client', () => ({
-  redis: { get: vi.fn(), set: vi.fn() },
-  sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
-  REDIS_KEYS: { BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } },
-  REDIS_SYS_KEYS: { BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } },
-}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return {
+    ...actual,
+    redis: { get: vi.fn(), set: vi.fn() },
+    sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  };
+});
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
 }));

--- a/src/server/services/__tests__/model-version.idempotent.service.test.ts
+++ b/src/server/services/__tests__/model-version.idempotent.service.test.ts
@@ -59,7 +59,10 @@ vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
 vi.mock('~/server/redis/caches', () => ({}));
 vi.mock('~/server/redis/client', async () => {
   const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
-  return { ...actual };
+  // The `redis`/`sysRedis` client instances live on the app shim, NOT the
+  // package (`...actual` only has the key consts + factory) — stub them so
+  // importers like db-lag-helpers resolve the named export.
+  return { ...actual, redis: { get: vi.fn(), set: vi.fn() }, sysRedis: { get: vi.fn() } };
 });
 vi.mock('~/server/redis/resource-data.redis', () => ({ resourceDataCache: {} }));
 vi.mock('~/server/search-index', () => ({}));

--- a/src/server/services/__tests__/model-version.idempotent.service.test.ts
+++ b/src/server/services/__tests__/model-version.idempotent.service.test.ts
@@ -57,7 +57,10 @@ vi.mock('~/server/prom/client', async (importOriginal) => {
 // Keep the heavy service/search-index graph out of the test module graph.
 vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
 vi.mock('~/server/redis/caches', () => ({}));
-vi.mock('~/server/redis/client', () => ({ REDIS_KEYS: {} }));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return { ...actual };
+});
 vi.mock('~/server/redis/resource-data.redis', () => ({ resourceDataCache: {} }));
 vi.mock('~/server/search-index', () => ({}));
 vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));


### PR DESCRIPTION
## What

14 unit files fail on `main` (report-only, silent): 13× `blocks.router.*.test.ts` + `model-version.idempotent.service.test.ts`.
```
TypeError: Cannot read properties of undefined (reading 'JUDGEMENTS')
  new-order.service.ts:  REDIS_SYS_KEYS.NEW_ORDER.JUDGEMENTS.CORRECT
```

**Root cause:** these tests `vi.mock('~/server/redis/client')` with a **hand-rolled, partial** `REDIS_SYS_KEYS`/`REDIS_KEYS`. `REDIS_SYS_KEYS` grew `NEW_ORDER.JUDGEMENTS` (part of today's migration wave); the router's transitively-imported redis-cache modules read those keys **at import time**, so the partial mock crashes. `subscriptions.test.ts` already tried an auto-vivifying `completeKeys` Proxy — but only for `REDIS_KEYS`, not `REDIS_SYS_KEYS`, so it still crashed.

**Fix:** mock only the `redis`/`sysRedis` client instances and spread the **real** key constants via `vi.importActual('@civitai/redis/client')`. The **package** (`packages/civitai-redis/src/client.ts`) is side-effect-free — it exports the key consts + the `createRedisClients` factory, and connections only happen when the factory is *called* (which only the `~/server/redis/client` shim does at import). So this gives the **complete real key tree** that can't go stale on the next key addition. Removes the now-redundant `completeKeys` Proxy.

## Verification
⚠️ Honest note: a local vitest run wasn't feasible this session (heavy NixOS/prisma setup + a permission-blocked helper), so the authoritative check is the preview **`unit-tests`** taskrun — the 14 files should go from failing → passing. The `importActual`-the-package approach is standard + statically verified side-effect-free; if a hidden transitive import side-effect surfaces, CI will show it and I'll iterate (fallback: extend the proven auto-vivify Proxy to `REDIS_SYS_KEYS`).

Companion to #2903 (the `@civitai/notifications` Vitest alias). Together with #2907 (GetStartedBody copy) this clears today's three test-suite regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)