### PR TITLE
docs(creator-studio): fold resolved review-pass decisions into specs

### DIFF
--- a/docs/creator-studio-plan.md
+++ b/docs/creator-studio-plan.md
@@ -22,8 +22,9 @@ Scope (from the ClickUp task), all creator-facing:
 main app; those stay put for now.
 
 **Access model (confirmed by Justin):** **any logged-in user can access Creator Studio.** Specific items/actions are
-restricted to **members**, gated on the user's subscription **`tier`**. The app is *not* CP-gated at the door — the
-gate is "authenticated," and member-only capabilities (e.g. setting a licensing fee) are enforced per-action.
+restricted to **Creator Program members** — a **single gate** for all gated actions. The app is *not* CP-gated at the
+door — the gate is "authenticated," and member-only capabilities (e.g. setting a licensing fee) are enforced per-action
+on Creator Program membership.
 
 **v1 build priority (from the designer meeting):** **model management** and **basic analytics** come first; the
 **Creator Shop is out of v1** — see the shop note below.
@@ -69,7 +70,7 @@ packages we import and wires each one's dependency, transpile entry, env vars, a
 | Framework | SvelteKit + `@sveltejs/adapter-node`, Svelte 5, Vite |
 | UI | `@civitai/ui` (shadcn-svelte / `bits-ui`) — reach for shadcn-svelte before hand-building; Civitai composites (EdgeMedia, ImageGuard, masonry) get built *on top of* the primitives, into `@civitai/ui` |
 | Styling | Tailwind v4 (`@tailwindcss/vite`), dark-only (`<html class="dark">`), `@import '@civitai/ui/theme.css'`, `@source` the package so classes aren't purged |
-| Auth | `createSpokeGuard` in `hooks.server.ts`; gate is **any authenticated user** (`require: (u) => !!u`). Member-only actions are enforced per-action on the `tier` (see [§5](#5-apiservice-plan)) |
+| Auth | `createSpokeGuard` in `hooks.server.ts`; gate is **any authenticated user** (`require: (u) => !!u`). Member-only actions are enforced per-action on **Creator Program membership** (see [§5](#5-apiservice-plan)) |
 | Data | `@civitai/db/kysely` (env-free, no Prisma engine) for domain reads/writes; monetization **mutations run in-process** via a creator-studio **module** (kysely + `@civitai/buzz`) — **no main-app tRPC hop**. See [§5](#5-apiservice-plan) |
 | Buzz | `@civitai/buzz` — a **server-side-only** client for the buzz service (transactions + earnings reads). All buzz comms are server-side; never imported into browser code |
 | Env | app-local `.env` (+ committed `.env.example`); `process.env` shim in `vite.config.ts` |
@@ -92,9 +93,9 @@ Routes under `apps/creator-studio/src/routes/`. Grouped, minimal, one screen per
 | `/earnings` | **Earnings** | Breakdown by source: license fees, tips, model-access sales, cosmetic sales. Time-series + totals. Links to CP cash/withdrawal. |
 | `/earnings/analytics` | **Basic analytics** ⭐ | Model usage that drives fees (generations per resource, downloads, engagement over time). **v1 priority — keep "basic" for v1; richer analytics is post-v1.** |
 | `/licensing` | **Licensing fees (bulk editor)** | Table of the creator's models/versions; multi-select; set/clear fee; apply model-type default suggestions (LoRA ~0.1, base ~1 buzz/image); fractional pricing. *(Bulk editor may trail the per-version editor on `/models` — [§8](#8-phasing).)* |
-| `/models` | **Model management** ⭐ | Grouped by model (versions nested, **drafts included**). Per-version: **full** early/paid-access config, licensing-fee on/off + amount (members only), "sell access indefinitely" for **CP members**, and (2nd-priority) **publish/schedule**. **v1 priority.** See [models.md](creator-studio/models.md). |
-| `/settings` | **Payout & settings** | Payment config (Tipalti) status, membership/`tier` status, per-account default fee suggestions. |
-| `/join` | **Membership upsell** | Shown to non-members (any logged-in user can reach the Studio): what the member tier unlocks + link to subscribe. *(Tier vs CP gate to confirm — [§5.2](#52-reuse-existing-main-app-endpointsservices).)* |
+| `/models` | **Model management** ⭐ | Grouped by model (versions nested, **drafts included**). Per-version: **full** early/paid-access config, licensing-fee on/off + amount (**CP members**), "sell access indefinitely" (**CP members**), and **publish/schedule**. **v1 priority.** See [models.md](creator-studio/models.md). |
+| `/settings` | **Payout & settings** | Payment config (Tipalti) status, Creator Program membership status, per-account default fee suggestions. |
+| `/join` | **Membership upsell** | Shown to non-members (any logged-in user can reach the Studio): what Creator Program membership unlocks + link to join. |
 
 Public/allowlisted (pre-gate): `/favicon.svg`, health check.
 
@@ -106,7 +107,7 @@ Public/allowlisted (pre-gate): `/favicon.svg`, health check.
 constant** (`apps/creator-studio/src/lib/nav.ts` — `{ href, label, icon, memberOnly? }[]`) that mirrors this table, so
 the two can't drift and adding a page is a one-line change. It's app-local config (one app → a module, not a package).
 Notes: match **active state** carefully for nested routes (`/earnings` vs `/earnings/analytics`); `memberOnly` lets
-both navs conditionally show/disable member-gated items off the user's `tier` (ties into the [§5.2](#52-reuse-existing-main-app-endpointsservices) gate).
+both navs conditionally show/disable member-gated items off the user's **Creator Program membership** (ties into the [§5.2](#52-reuse-existing-main-app-endpointsservices) gate).
 
 ---
 
@@ -115,7 +116,7 @@ both navs conditionally show/disable member-gated items off the user's `tier` (t
 | # | Workstream | Built today? | v1 work |
 |---|---|---|---|
 | 1 | Retire 25% comp | Live (to sunset) | **Post-v1 cutover track** (not this app's v1): stop minting `Compensation` rows; remove comp UI; keep tips + license-fee payout paths |
-| 2 | Creator-controlled licensing fees | **Mostly built** | Fractional pricing, member-`tier` gating, **bulk edit** (new), default suggestions |
+| 2 | Creator-controlled licensing fees | **Mostly built** | Fractional pricing, Creator Program membership gating, **bulk edit** (new), default suggestions |
 | 3 | Sell model access (no time cap) | Partially (score-capped EA) | Remove time/qty caps for members; expose toggle in Studio |
 | 4 | Creator Shops | **Being built in the main app** (by another dev) | Not this app's v1 — transferred into Creator Studio later; cosmetics 70/30; Shopify merch is fast-follow |
 | 5 | Creator Studio | **Net-new** | This whole app |
@@ -145,7 +146,7 @@ One new *package* (`@civitai/buzz`); monetization writes are a creator-studio *m
                      already uses it broadly AND creator-studio needs it. Lifted out of buzz.service.ts.
                      SERVER-ONLY — no browser entry; all buzz comms stay server-side.
 monetization module  (creator-studio MODULE — apps/creator-studio/src/lib/server/monetization/, NOT a package yet)
-                     the creator ops: setLicensingFee, bulkSetLicensingFee, setUnlimitedAccess + member-tier gate.
+                     the creator ops: setLicensingFee, bulkSetLicensingFee, setUnlimitedAccess + CP-membership gate.
                      Deps: @civitai/db (kysely) + @civitai/buzz. NO ClickHouse. NO stacking (backend handles it).
 ```
 
@@ -186,7 +187,7 @@ are **not** the analytics path.)*
 
 | Need | Existing surface |
 |---|---|
-| Is user a paying member (by `tier`)? | Active **subscription tier**: `CustomerSubscription` → `Product.metadata.tier` (bronze/silver/gold). ⚠️ `creatorProgram.getCreatorRequirements` *also* gates on creator score ≥40k (full **CP** membership) — a stricter bar; use it only if the gate is meant to be CP-membership, not tier alone. **Confirm which** (Justin said "tier," HackMD said "CP members" — see [§9](#9-decisions--open-questions) "to confirm"). `creator-program.service.ts:205` |
+| Is the user a Creator Program member? | **Creator Program membership** is the single gate (resolved 2026-07-02): `creatorProgram.getCreatorRequirements` (`creator-program.service.ts:205`) — CP membership = subscription tier **+** creator score ≥40k. Used for every gated action (fee-set, indefinite-sale, default-fee pref). |
 | Earnings + analytics (all) | **ClickHouse** via `@civitai/clickhouse` — buzz earnings + `resourceCompensations` aggregates live here; the buzz service is too slow for this. Work from materialized views / daily records ([§7.6](#76-clickhouse-analytics--materialized-views)) |
 | CP cash / banked / pool | `creatorProgram.getCash` / `getBanked` / `getCompensationPool` (`creator-program.router.ts`) |
 | Set a licensing fee (single) | `modelVersion` upsert — `licensingFee*` fields (`model-version.schema.ts:418`), flag `licensing-fee` |
@@ -204,8 +205,8 @@ implementation only at the consolidation ([§9](#9-decisions--open-questions) "f
 | `setLicensingFee` / `bulkSetLicensingFee` | Per-version fee set (member-only) + bulk edit across many versions — no bulk path exists today. |
 | `getDefaultFeeSuggestions` | Model-type default suggestions (LoRA ~0.1, base ~1 buzz/image). |
 | `setUnlimitedAccess` | Remove EA time/quantity caps for members. |
-| fee validation (member gate + fractional) | Enforce member `tier` + fractional bounds when setting a fee. **Stacking/split is NOT here** — the backend already handles it ([§7.3](#73-fee-stacking--already-handled-no-new-work)). |
-| member-`tier` gate | Authorization asserted **inside the module** on member-only operations (and reused when the main app adopts it at consolidation). |
+| fee validation (member gate + fractional) | Enforce **Creator Program membership** + fractional bounds when setting a fee. **Stacking/split is NOT here** — the backend already handles it ([§7.3](#73-fee-stacking--already-handled-no-new-work)). |
+| Creator Program membership gate | Authorization asserted **inside the module** on member-only operations (and reused when the main app adopts it at consolidation). |
 
 Earnings reads are **not** package operations — all analytics come from **ClickHouse** via `@civitai/clickhouse`
 ([§5.2](#52-reuse-existing-main-app-endpointsservices), [§7.6](#76-clickhouse-analytics--materialized-views)).
@@ -342,10 +343,10 @@ ships **~1 week before** it (Justin), so comp-retirement is **not** a v1 item.
 
 ### v1 — MVP (designer-prioritised)
 
-1. **App shell** — scaffold `apps/creator-studio`, auth spoke gate (**any authenticated user**) + member-`tier` action
-   gating, `@civitai/ui`, dashboard.
+1. **App shell** — scaffold `apps/creator-studio`, auth spoke gate (**any authenticated user**) + Creator Program
+   membership action gating, `@civitai/ui`, dashboard.
 2. **Buzz package + monetization module** — `@civitai/buzz` (client, **built**) + a creator-studio **monetization
-   module** (creator ops: `setLicensingFee` / `bulkSetLicensingFee` / `setUnlimitedAccess` + member-`tier` gate; **no
+   module** (creator ops: `setLicensingFee` / `bulkSetLicensingFee` / `setUnlimitedAccess` + Creator Program membership gate; **no
    stacking** — backend handles it) built on `@civitai/db` + `@civitai/buzz` ([§7.2](#72-new-package--creator-studio-modules)).
    No main-app repoint in v1 — that's the consolidation (post-v1).
 3. **Model management** ⭐ — `/models`: per-version early/paid-access toggles, per-version **licensing-fee on/off +
@@ -377,8 +378,9 @@ ships **~1 week before** it (Justin), so comp-retirement is **not** a v1 item.
 
 ### Decided (Justin, 2026-07-01)
 
-- **Access model.** Any logged-in user can access Creator Studio; member-only items/actions are gated on the user's
-  subscription **`tier`**. → app gate is "authenticated," not CP-only ([§1](#1-what-this-app-is), [§2](#2-architecture--tooling)).
+- **Access model.** Any logged-in user can access Creator Studio; member-only items/actions are gated on **Creator
+  Program membership** — a **single bar** for all gated actions (fee-set, indefinite-sale, default-fee pref), resolved
+  2026-07-02. → app gate is "authenticated," not CP-only at the door ([§1](#1-what-this-app-is), [§2](#2-architecture--tooling)).
 - **Timeline.** Launch by **end of month (~2026-07-31)**; Justin is working the orchestrator side with **Koen**.
 - **Fractional pricing.** Fees as small as **1 buzz per 100 images = 0.01 buzz/image**. → migrate `licensingFee` to
   decimal (0.01 precision), settle at the daily payout boundary ([§7.1](#71-schema--data-main-app-db)).
@@ -407,49 +409,46 @@ ships **~1 week before** it (Justin), so comp-retirement is **not** a v1 item.
 ### Decided — Q1: minimal monetization scope for v1
 
 The creator-studio **monetization module** ships the **minimal creator-side writes only** — `setLicensingFee` /
-`bulkSetLicensingFee` with a member-`tier` gate and the `active` flag ([§7.1](#71-schema--data-main-app-db)), plus
+`bulkSetLicensingFee` with a Creator Program membership gate and the `active` flag ([§7.1](#71-schema--data-main-app-db)), plus
 `setUnlimitedAccess` (same shape). These are plain `ModelVersion` writes — no buzz call, no domain co-write. The risky
 buyer-side paths (`earlyAccessPurchase`, cosmetic purchase) **stay in the main app**; they don't move for v1. It's a
 **module, not a package** (single caller in v1 — [§2](#2-architecture--tooling)); with the cutover decoupled (Q5) the
 extraction is off the critical path, so the dependency-map (§7.5) is no longer a blocker.
 
-### To confirm (surfaced in review)
+### Resolved — review pass (2026-07-02)
 
-- **Member gate: subscription `tier` vs full Creator Program membership — possibly feature-specific.** Justin said the
-  fee gate is **`tier`** (any active bronze/silver/gold subscription); the HackMD said "active **Creator Program**
-  members" (tier **+** creator score ≥40k). And Justin scoped **indefinite-sale specifically to CP members** — which
-  suggests the gates may **differ by feature** (licensing fee = `tier`; indefinite-sale = CP membership) rather than one
-  bar. Confirm both — it changes who can set a fee, who can sell indefinitely, and the `/join` upsell copy
-  ([§5.2](#52-reuse-existing-main-app-endpointsservices)).
+Product/business calls resolved from the Q&A roundup. (Eng/design-owned items — charting lib, `/licensing`
+separate-vs-mode, owner-keyed rollup, etc. — are resolved in [creator-studio/README.md](creator-studio/README.md#cross-cutting-decisions-resolved-2026-07-02).)
 
-### Questions for Justin — review pass (2026-07-02)
-
-Consolidated **product/business** calls for Justin's doc review. (Eng/design-owned items — charting lib, `/licensing`
-separate-vs-mode, owner-keyed rollup, etc. — are in [creator-studio/README.md](creator-studio/README.md#cross-cutting-decisions-needed-answer-once--they-recur-across-pages).)
-
-1. **Feature-specific gates?** Confirm the two bars differ: licensing fee gates on subscription **`tier`**;
-   indefinite-sale gates on **CP membership** (see the "To confirm" item above).
-2. **Indefinite-sale mechanics.** How does "available for sale indefinitely" actually work — a one-time purchase at a
-   **creator-set price**? How does it relate to early-access pricing (replaces / stacks / separate)? New and
-   underspecified; needs main-app support ([§7.1](#71-schema--data-main-app-db)).
-3. **v1 earnings sources.** Show **all** sources (incl. model-access + cosmetic sales — need a new buzz rollup,
-   [§7.6 gap #2](#76-clickhouse-analytics--materialized-views)), or ship **comp / license / tip only** in v1 and add the
-   rest later? ([earnings.md](creator-studio/earnings.md))
-4. **"Basic analytics" scope.** Lock the v1 metric/chart list (proposed: generations-over-time, downloads-over-time, a
-   top-models table, a few stat tiles) so it doesn't balloon ([analytics.md](creator-studio/analytics.md)).
-5. **Fee auto-pause → notify?** When a fee **silently pauses** because membership lapsed ([§7.1](#71-schema--data-main-app-db)),
-   is the creator **notified** (in-app / email)? A silent pause = lost income = support tickets. Do we need
-   notifications in v1 (fee paused, payout ready)?
-6. **Cutover creator comms / grandfathering.** When 25% comp retires (~1 week after v1), what's the creator-facing
-   story, and is there any **grandfathering / transition** for creators mid-accrual?
-7. **Max licensing fee.** Floor is **0.01 buzz/image** (confirmed). Is the **cap** still 100 buzz/image
-   (`MAX_LICENSING_FEE`) with fractional pricing, or does it change?
-8. **Studio discoverability.** How do creators find `creator.civitai.com` — a nav link from the main app for
-   **everyone**, only users **with models**, or a launch announcement? (Shapes the non-member / `/join` experience.)
-9. **Publish/schedule + bulk fee editor — v1 or fast-follow?** Both are flagged "2nd priority" / "may trail"
-   ([models.md](creator-studio/models.md), [licensing.md](creator-studio/licensing.md)) — confirm which land in v1.
-10. **Currency display.** Buzz-only in v1, or show **USD equivalents** for cash earnings (dashboard / earnings)?
-11. **Default fee suggestions.** Confirm the values (LoRA ~0.1, base ~1 buzz/image) and which model types get one.
+- **PLAN-TC / PLAN-1 — Member gate.** **Creator Program membership is the single bar** for every gated action (fee-set,
+  indefinite-sale, default-fee pref). No feature-specific split and no subscription-tier-only gate. Higher-tier-only
+  features may come eventually, but v1 gates everything on CP membership.
+- **PLAN-2 — Indefinite-sale mechanics.** It is an **extension of early-access pricing using the same mechanism** — one
+  simply has **no early-access end date**. (Early access becomes the switch you flip when selling a model.) Needs the
+  main-app no-end-date representation ([§7.1](#71-schema--data-main-app-db)).
+- **PLAN-3 — v1 earnings sources.** **All sources day 1** ideally, with a **source filter** (model access, cosmetic,
+  comp, licenses, tips; merch later). **Comp + licenses can share a chart** (comp is being retired). Access-sale +
+  cosmetic-sale need the [§7.6 gap #2](#76-clickhouse-analytics--materialized-views) MV.
+- **PLAN-4 / PLAN-11 — Analytics scope + defaults.** v1 charts: generations-over-time (weekly option + split by buzz
+  color blue/yellow/green), earnings-over-time by source (weekly, week-over-week delta), a top-models table (per-week
+  earnings + generations + fee set), stat tiles, and a pricing-reference metric (avg buzz cost/image by base model +
+  type). Confirm the final list with Alex DS before locking.
+- **PLAN-5 — Fee auto-pause → notify.** **Yes** — notify via **in-app + email**; the email **lists the affected models**
+  no longer collecting fees. **Notifications are needed in v1** (fee paused, payout ready), eased by the new
+  notifications app/SDK.
+- **PLAN-6 — Cutover comms / grandfathering.** Comms story lives in the dedicated article
+  ([civitai.com/articles/32087](https://civitai.com/articles/32087)). Creators get a **1-week window** to set licensing
+  fees, then Creator Comp is gone — **no grandfathering**. (Recommendation on the table: settle comp already accrued up
+  to the cutover, then stop all new accrual — kinder than a clean zero.)
+- **PLAN-7 — Max licensing fee.** Floor **0.01 buzz/image**, cap stays **100 buzz/image** (`MAX_LICENSING_FEE`).
+- **PLAN-8 — Discoverability.** A **nav item in the main-site user menu** linking to the Studio + a **launch
+  announcement** + a **nice notice on the Buzz dashboard** (where banking/creator controls live) pointing to the Studio.
+- **PLAN-9 — Publish/schedule + bulk fee editor.** **v1 — critical.** Managing your models is the whole point of v1.
+- **PLAN-10 — Currency display.** Display earnings **in the currency received** (buzz or USD); **no conversion/mapping**
+  (no rate exists). USD is available only for select users; most creators are buzz-only and don't set a currency.
+- **PLAN-11 — Default fee suggestions + eligible types.** Values LoRA ~0.1, base ~1 buzz/image. Model types are handled
+  as an **exclude set** — every type gets a fee **except**: **Poses, Wildcards, Workflows, Other, Detection,
+  VisionLanguage, LLM, CLIP, CLIPVision, TextEncoder**. **UNet IS eligible** (increasingly used like a checkpoint).
 
 ### For the full cutover (post-v1 notes)
 

--- a/docs/creator-studio/README.md
+++ b/docs/creator-studio/README.md
@@ -17,8 +17,8 @@ Actions (writes) → States → Gating → Shared/cross-refs → Open questions.
 | Model management | [models.md](models.md) | ⭐ | access toggles, per-version licensing fee, sell-indefinitely |
 | Analytics | [analytics.md](analytics.md) | ⭐ | `/earnings/analytics` — ClickHouse usage/earnings charts |
 | Earnings | [earnings.md](earnings.md) | ✓ | `/earnings` — earnings by source (ClickHouse) |
-| Licensing fees (bulk) | [licensing.md](licensing.md) | ~ | bulk fee editor; may trail the per-version editor |
-| Settings | [settings.md](settings.md) | ✓ | Tipalti/tier status, default fee suggestions |
+| Licensing fees (bulk) | [licensing.md](licensing.md) | ✓ | bulk fee editor — a mode of `/models`, not a separate page (v1-critical) |
+| Settings | [settings.md](settings.md) | ✓ | Tipalti/membership status, default fee suggestions |
 | Membership upsell | [join.md](join.md) | ✓ | `/join` — for non-members |
 
 ⭐ designer-prioritised · ✓ in v1 · ~ v1 if it lands, else fast-follow
@@ -26,24 +26,23 @@ Actions (writes) → States → Gating → Shared/cross-refs → Open questions.
 ## Cross-cutting (not a page — referenced by several)
 
 - **Nav** — one app-local `nav.ts` constant drives the desktop sidebar + mobile header ([plan §3](../creator-studio-plan.md#3-page-list-v1)).
-- **Member gate** — most write actions are member-`tier` gated; the exact bar (tier vs full CP membership) is a
-  [pending confirm](../creator-studio-plan.md#9-decisions--open-questions).
+- **Member gate** — all gated write actions are gated on **Creator Program membership** (one bar for everything;
+  resolved 2026-07-02).
 - **Monetization module** — `setLicensingFee` / `bulkSetLicensingFee` / `setUnlimitedAccess`
   ([plan §5.3](../creator-studio-plan.md#53-new-monetization-operations-creator-studio-module-extract-to-a-package-at-consolidation)).
 - **Analytics reads** — ClickHouse via `@civitai/clickhouse`, daily aggregates ([plan §7.6](../creator-studio-plan.md#76-clickhouse-analytics--materialized-views)).
 
-## Cross-cutting decisions needed (answer once — they recur across pages)
+## Cross-cutting decisions (resolved 2026-07-02)
 
-These surfaced in ≥2 page docs; deciding them once keeps the specs from drifting. **Justin's product/business review
-questions** are consolidated in [plan §9](../creator-studio-plan.md#questions-for-justin--review-pass-2026-07-02).
+These surfaced in ≥2 page docs; deciding them once keeps the specs from drifting. All resolved from the Q&A roundup.
 
-| # | Decision | Affects | Owner |
+| # | Question | Affects | Decision |
 |---|---|---|---|
-| 1 | **`/licensing`: separate page vs a mode/tab of `/models`** (they share rows + the fee action) | [licensing](licensing.md), [models](models.md) | eng/design |
-| 2 | **Owner-keyed earnings rollup** (§7.6 gap #1) — earnings tables key on `modelVersionId`, not the creator's `userId`; needed to scope "my" earnings/usage at scale | [dashboard](dashboard.md), [analytics](analytics.md), [earnings](earnings.md) | **backend / Koen** |
-| 3 | **Charting library** (no chart primitive in `@civitai/ui`; Chart.js is React-only) + **date-range/calendar** control (no calendar primitive) | [analytics](analytics.md), [earnings](earnings.md), [dashboard](dashboard.md) | eng |
-| 4 | **CP cash + withdrawal home** — dashboard vs `/earnings` vs `/settings` (pick one entry point) | [dashboard](dashboard.md), [earnings](earnings.md), [settings](settings.md) | design |
-| 5 | **`/earnings` vs `/earnings/analytics` vs dashboard boundary** — what's unique to each so the same numbers don't appear (and drift) in three places | [dashboard](dashboard.md), [earnings](earnings.md), [analytics](analytics.md) | design |
-| 6 | **Member gate: subscription `tier` vs full CP membership** (score ≥40k) — changes gating + `/join` CTA. Justin scoped **indefinite-sale to CP members**, so gates may be **feature-specific** (fee = `tier`, indefinite-sale = CP) | [join](join.md), [models](models.md), [licensing](licensing.md), [settings](settings.md) | **Justin** ([plan §9](../creator-studio-plan.md#9-decisions--open-questions)) |
-| 7 | **Access-sale + cosmetic-sale earnings** (§7.6 gap #2, a per-`toAccountId` buzz rollup) — in v1 or defer? | [earnings](earnings.md), [dashboard](dashboard.md) | design + backend |
-| 8 | **Default fee suggestion — per-account vs per-version** *(settlement currency resolved: not a creator choice — Civitai-only, special cases)* | [settings](settings.md), [models](models.md) | design |
+| 1 | **`/licensing`: separate page vs a mode/tab of `/models`** (they share rows + the fee action) | [licensing](licensing.md), [models](models.md) | **Mode of `/models`** — a bulk-edit column/mode; no separate page. |
+| 2 | **Owner-keyed earnings rollup** (§7.6 gap #1) — earnings tables key on `modelVersionId`, not the creator's `userId` | [dashboard](dashboard.md), [analytics](analytics.md), [earnings](earnings.md) | **ClickPipe/CDC → `modelVersion → ownerUserId` CH dictionary → owner-keyed AggregatingMergeTree MV.** Build handoff at [../plans/creator-studio-owner-rollup-handoff.md](../plans/creator-studio-owner-rollup-handoff.md); version-ID query is the fallback. |
+| 3 | **Charting library** + **date-range/calendar** control (none in `@civitai/ui`) | [analytics](analytics.md), [earnings](earnings.md), [dashboard](dashboard.md) | **LayerChart** (via shadcn-svelte, primitives in `@civitai/ui`; LayerChart 2.0) + **adopt a date picker**. |
+| 4 | **CP cash + withdrawal home** — dashboard vs `/earnings` vs `/settings` | [dashboard](dashboard.md), [earnings](earnings.md), [settings](settings.md) | **`/earnings`** — single entry point (dashboard shows a condensed preview + links out). |
+| 5 | **`/earnings` vs `/earnings/analytics` vs dashboard boundary** | [dashboard](dashboard.md), [earnings](earnings.md), [analytics](analytics.md) | **Analytics = non-buzz usage** (generations, downloads); **earnings = buzz + real-dollar cash**; dashboard = condensed preview. |
+| 6 | **Member gate: subscription `tier` vs full CP membership** | [join](join.md), [models](models.md), [licensing](licensing.md), [settings](settings.md) | **Creator Program membership — a single bar for all gated actions** (no feature-specific / tier hedging). |
+| 7 | **Access-sale + cosmetic-sale earnings** (§7.6 gap #2, a per-`toAccountId` buzz rollup) — in v1 or defer? | [earnings](earnings.md), [dashboard](dashboard.md) | **In v1** (all sources day 1 ideally); needs the gap #2 per-`toAccountId` MV. |
+| 8 | **Default fee suggestion — per-account vs per-version** *(settlement currency: not a creator choice — Civitai-only)* | [settings](settings.md), [models](models.md) | **Per-account baseline in Settings**, overridable per version in `/models`. |

--- a/docs/creator-studio/analytics.md
+++ b/docs/creator-studio/analytics.md
@@ -17,15 +17,18 @@ the money I see on [earnings.md](./earnings.md). I can change the date range and
 `@civitai/ui` (shadcn-svelte) primitives — don't hand-build:
 
 - **`card`** — headline stat tiles (total generations, total downloads, engagement) for the selected range.
-- **charts** — generations-over-time + downloads-over-time line/area, per-resource. ⚠️ **`@civitai/ui` has NO chart
-  primitive**, and the main app's Chart.js is React-only — a **Svelte charting library must be chosen** (see open
-  questions). This is a real v1 dependency, not a detail.
-- **`table`** — **top models / versions** breakdown (generations · downloads · engagement, sortable). Depends on the
-  owner-keyed rollup (see Data) — may be deferred if that rollup slips.
+- **charts** — **generations-over-time** (with a **weekly** option, **split by buzz color** blue/yellow/green) and
+  downloads-over-time line/area, per-resource. Charting lib is **LayerChart** (via shadcn-svelte, primitives in
+  `@civitai/ui`; LayerChart 2.0). A real v1 dependency, not a detail.
+- **`table`** — **top models / versions** breakdown (per-week earnings · generations · **the fee currently set**,
+  sortable). Depends on the owner-keyed rollup (see Data) — may be deferred if that rollup slips.
+- **Pricing-reference metric** — avg buzz cost per image by **base model + type**, so creators know what to price at
+  (the same reference surfaced inline in the [licensing.md](./licensing.md) bulk editor).
 - **`tabs`** (optional) — switch metric views (usage vs. downloads vs. engagement) to keep each view basic.
-- **`badge`** for deltas vs. prior period; **`skeleton`** while loading; **`popover`** for metric definitions.
-- **Date-range control** — ⚠️ `@civitai/ui` has **no calendar** primitive; a preset range control (7d/30d/90d) or a
-  chosen date-picker is needed (see open questions).
+- **`badge`** for deltas vs. prior period (week-over-week); **`skeleton`** while loading; **`popover`** for metric
+  definitions.
+- **Date-range control** — adopt a **date-picker** plus a **granularity switcher** (daily / weekly / monthly),
+  default **last 30 days**, with a custom range.
 
 ## Data (reads) — `+page.server.ts`
 
@@ -70,8 +73,8 @@ all keyed by **`modelVersionId, date`**:
 ## Gating
 
 **Any logged-in user can access** — this is a read, so gating is light
-([plan §1](../creator-studio-plan.md#1-what-this-app-is)). No member-`tier` action gate here (that's a per-*action*
-concern, and this page has no actions). **Member vs non-member is a data-visibility nuance**: usage is only interesting
+([plan §1](../creator-studio-plan.md#1-what-this-app-is)). No Creator Program membership action gate here (that's a
+per-*action* concern, and this page has no actions). **Member vs non-member is a data-visibility nuance**: usage is only interesting
 where a fee is *active* (member) — a non-member's usage doesn't drive fees, so copy should frame usage as potential and
 point to [join.md](./join.md). Nav item is not `memberOnly`.
 
@@ -84,17 +87,19 @@ point to [join.md](./join.md). Nav item is not `memberOnly`.
 - **ClickHouse client** `@civitai/clickhouse` is shared; the creator-usage **query logic is new** here
   ([plan §7.6](../creator-studio-plan.md#76-clickhouse-analytics--materialized-views)).
 
-## Open questions
+## Decisions (resolved 2026-07-02)
 
-- **What counts as "basic" for v1?** Lock the metric/chart list (generations-over-time, downloads-over-time, top-models
-  table + a few stat tiles?) to guard against scope-balloon — richer analytics (cohorts, per-model funnels) is
-  **post-v1** ([plan §8](../creator-studio-plan.md#8-phasing)).
-- **Per-model breakdown table** depends on the **owner-keyed rollup**
-  ([plan §7.6 gap #1](../creator-studio-plan.md#76-clickhouse-analytics--materialized-views)) — is it **v1** (needs the MV
-  from backend) or **fast-follow** (v1 ships headline usage only)?
-- **Which Svelte charting library?** No chart primitive in `@civitai/ui`; Chart.js is React-only. Pick one
-  (LayerChart / LayerCake / d3-based) and decide whether it lands **in `@civitai/ui`** (shared) or app-local.
-- **Date-range picker** — `@civitai/ui` has no calendar; ship **presets** (7d/30d/90d) for v1 or adopt a date-picker?
-- **Default range + granularity** — proposed **last 30 days, daily** (matches the daily aggregates); confirm.
-- **Earnings-over-time boundary** — does the money time-series live **here** or on [earnings.md](./earnings.md)? Proposed:
-  usage here, money there, cross-linked — confirm so we don't double-build the same chart.
+- **ANALYTICS-1 — v1 metric/chart list.** Lock to: **generations-over-time** (weekly option + split by buzz color
+  blue/yellow/green), **earnings-over-time by source** (weekly, week-over-week delta), a **top-models table** (per-week
+  earnings + generations + the fee set), **stat tiles**, and a **pricing-reference metric** (avg buzz cost/image by
+  base model + type). Richer analytics (cohorts, per-model funnels) is post-v1.
+- **ANALYTICS-2 — Per-model breakdown.** Depends on the **owner-keyed rollup** (EARN-2). v1 if the rollup lands, else
+  fast-follow with the version-ID fallback.
+- **ANALYTICS-3 — Date control + charting lib.** **Adopt a date picker** (not just presets). Charting lib is
+  **LayerChart** (via shadcn-svelte, primitives added to `@civitai/ui`; LayerChart 2.0 approved).
+- **ANALYTICS-4 — Default range + granularity.** Default **last 30 days** with a **granularity switcher** (daily /
+  weekly / monthly) and a custom range.
+- **ANALYTICS-5 — Earnings-over-time boundary.** **Usage time-series (non-buzz: generations, downloads) lives here** in
+  analytics; the **money time-series lives on [earnings.md](./earnings.md)**. Split on buzz vs non-buzz.
+
+**Still open / deferred:** the per-model breakdown table (ANALYTICS-2) hinges on the owner-keyed rollup (EARN-2) landing.

--- a/docs/creator-studio/dashboard.md
+++ b/docs/creator-studio/dashboard.md
@@ -15,14 +15,14 @@ into `/models` to manage monetization, `/earnings` for the full breakdown, `/lic
 
 `@civitai/ui` (shadcn-svelte) primitives — don't hand-build:
 
-- **`card`** — one per headline stat (earned this period, CP cash pending, CP cash settled, top-earning model) and one
-  "earnings by source" summary card. **`separator`** between groups.
+- **`card`** — one per headline stat (~3-4: **generation count · buzz earned · downloads · access spend**; later
+  cosmetic/merch sales once the shop lands) and one "earnings by source" summary card. **`separator`** between groups.
 - **`badge`** for source labels (comp / license fee / tip) and member/non-member state; **`tooltip`** for metric
   definitions and the pending/settled distinction.
 - **Section link cards** (`card` + `button`) as entry points into `/models`, `/earnings`, `/licensing`, `/settings`.
 - **`skeleton`** for each card while server data resolves.
-- **No chart component exists in `@civitai/ui`** — a trend sparkline on the summary card would need a new primitive or
-  a raw SVG; flag this and default v1 to numbers-only. See [analytics.md](analytics.md) for the charted view.
+- **Sparkline** — a trend sparkline on the summary card is worth a **shared chart primitive** (LayerChart, added to
+  `@civitai/ui`; see [analytics.md](analytics.md)). Include it in v1 rather than numbers-only.
 
 ## Data (reads) — `+page.server.ts`
 
@@ -37,8 +37,8 @@ All scoped to `locals.user.id`. **No monetization writes on this page.**
   dashboard either app-side `WHERE modelVersionId IN (…)` (doesn't scale for prolific creators) or drops top-earners.
 - **CP cash** — `creatorProgram.getCash` / `getBanked` / `getCompensationPool` ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices))
   for pending/settled figures. Not ClickHouse.
-- **Member `tier`** — `CustomerSubscription → Product.metadata.tier` (via `@civitai/db` kysely) to decide member vs
-  upsell rendering. *(Tier vs full-CP gate is a pending confirm — [plan §9](../creator-studio-plan.md#9-decisions--open-questions).)*
+- **Creator Program membership** — via `creatorProgram.getCreatorRequirements` (the single gate) to decide member vs
+  upsell rendering.
 - **Headline counts** — model/version count from `@civitai/db` kysely; period earnings from the rollup above.
 
 ## Actions (writes)
@@ -60,8 +60,8 @@ CTA here would only **link** to `/earnings` or `/settings`, not perform the acti
 ## Gating
 
 Any logged-in user can access `/`. Nothing on this page is member-gated to *view* — earnings and CP cash show for
-everyone who has them. The member vs non-member split only changes whether the upsell card renders. Exact member bar
-pending ([plan §9](../creator-studio-plan.md#9-decisions--open-questions)).
+everyone who has them. The member vs non-member split only changes whether the upsell card renders. The member bar is
+**Creator Program membership**.
 
 ## Shared / cross-refs
 
@@ -69,17 +69,23 @@ pending ([plan §9](../creator-studio-plan.md#9-decisions--open-questions)).
   is [analytics.md](analytics.md) (`/earnings/analytics`).
 - The creator-earnings ClickHouse query logic is **shared with `/earnings`** — build it once as a server-side read
   module, not duplicated here ([plan §7.6](../creator-studio-plan.md#76-clickhouse-analytics--materialized-views)).
-- CP cash reads (`getCash`/`getBanked`) are the same as [settings.md](settings.md)'s Tipalti/tier surface.
+- CP cash reads (`getCash`/`getBanked`) are the same as [settings.md](settings.md)'s Tipalti/membership surface.
 - Nav lives in the shared app-local `nav.ts` ([plan §3](../creator-studio-plan.md#3-page-list-v1)).
 
-## Open questions
+## Decisions (resolved 2026-07-02)
 
-- **Headline metrics + default window** — which 3–4 stats, and this-month vs last-30-days as the default period?
-- **CP cash here or defer?** — surface pending/settled + a withdrawal CTA on the dashboard, or keep cash entirely on
-  [/earnings](earnings.md) and just link out?
-- **"Top-earning models" widget** — depends on the owner-keyed rollup ([plan §7.6 gap #1](../creator-studio-plan.md#76-clickhouse-analytics--materialized-views));
-  v1 or fast-follow? Fallback if the MV isn't ready at launch.
-- **Overlap with `/earnings`** — what is *unique* to the dashboard vs a condensed preview of earnings? Risk of two
-  places showing the same numbers that can drift.
-- **Sparkline** — worth adding a chart primitive to `@civitai/ui` for a trend line, or numbers-only in v1?
-- **New-creator empty state** — copy + which CTA (upload on main app vs set a fee on `/models`).
+- **DASH-1 — Headline metrics + window.** Default **last 30 days**. ~3-4 stats: **generation count, buzz earned,
+  downloads, access spend** (the amount others spent to access their models); add cosmetic/merch sales later once the
+  shop lands. Stats shown depend on what the creator actually does.
+- **DASH-2 — CP cash.** Cash lives on [/earnings](earnings.md). The dashboard shows a **condensed preview + links out**;
+  no full withdraw flow here.
+- **DASH-3 — "Top-earning models" widget.** Depends on the owner-keyed rollup (EARN-2). **v1 if the rollup lands, else
+  fast-follow** with the version-ID fallback.
+- **DASH-4 — Overlap with `/earnings`.** Dashboard = **condensed preview**; `/earnings` = full buzz + cash detail.
+  Boundary is buzz vs non-buzz per EARN-3.
+- **DASH-5 — Sparkline.** **Yes** — worth a **shared chart primitive** (LayerChart in `@civitai/ui`); there will be many
+  charts in this app.
+- **DASH-6 — New-creator empty state.** Stats render empty; the CTA is a **dual action**: **Train** (primary, → the
+  training experience where they pick a dataset) + **Upload** (secondary, → upload their first model).
+
+**Still open / deferred:** the "top-earning models" widget (DASH-3) hinges on the owner-keyed rollup (EARN-2) landing.

--- a/docs/creator-studio/earnings.md
+++ b/docs/creator-studio/earnings.md
@@ -18,13 +18,17 @@ it"* view (generations, downloads, per-model funnels) lives on [analytics.md](an
 `@civitai/ui` (shadcn-svelte) primitives — don't hand-build:
 
 - **Totals `card`s** — one per source (License fees · Tips · Compensation · Access sales · Cosmetic sales) + a grand
-  total, each with the window's sum and a `badge` for delta vs. prior window.
-- **`table`** — earnings by source × period (or a breakdown table under the chart); `tabs` to switch window
-  (7d / 30d / all) or granularity (daily / monthly).
-- **Time-series chart** — daily/stacked-by-source earnings. ⚠️ **No chart primitive in `@civitai/ui`** — the charting
-  lib is a shared decision with [analytics.md](analytics.md) (flag, don't pick here).
-- **CP cash panel** — pending + settled cash and a **Withdraw** button that **links out** to the existing CP flow
-  (don't rebuild payout); see Shared.
+  total, each with the window's sum and a `badge` for delta vs. prior window. A **source filter** lets creators focus a
+  single source; **compensation + licenses can share a chart** (comp is being retired).
+- **`table`** — earnings by source × period (or a breakdown table under the chart); a **granularity switcher**
+  (daily / weekly / monthly) and a **date-range picker** (last 7 / last 30 / last month / custom), default **last 30 days**.
+- **Time-series chart** — earnings-over-time stacked by source. Charting lib is **LayerChart** (via shadcn-svelte,
+  primitives in `@civitai/ui`) — the shared decision with [analytics.md](analytics.md).
+- **Currency** — display earnings **in the currency they were received in** (buzz or USD); **no conversion/mapping**
+  (there is no rate). USD is only relevant for select users.
+- **CP cash panel** — pending + settled cash. This is the **single home for cash + withdrawal**; for v1 the **Withdraw**
+  button **links out** to the existing CP cash flow (`/user/buzz-dashboard`) and setup links to `/tipalti/setup` —
+  copy the withdrawal gate as **"$50 Ready to Withdraw"** (settled cash, not pending); see Shared.
 - **`skeleton`** for load; **`sonner`** only for the (rare) refresh/error toast.
 
 ## Data (reads) — `+page.server.ts`
@@ -39,7 +43,10 @@ service is too slow) ([plan §5.1](../creator-studio-plan.md#51-the-core-archite
   ([§7.6](../creator-studio-plan.md#76-clickhouse-analytics--materialized-views) **gap #2**) — see Open questions.
 - **Owner-keyed rollup dependency** — every earnings table is keyed by `modelVersionId`, **not** the creator's
   `userId`; "creator X's earnings" needs the `(ownerUserId, date, source)` MV + `modelVersion → ownerUserId` dictionary
-  ([§7.6](../creator-studio-plan.md#76-clickhouse-analytics--materialized-views) **gap #1**). Blocks this page.
+  ([§7.6](../creator-studio-plan.md#76-clickhouse-analytics--materialized-views) **gap #1**). Resolved approach: build it
+  via **ClickPipe/CDC → a `modelVersion → ownerUserId` ClickHouse dictionary → an owner-keyed AggregatingMergeTree MV**
+  (build handoff: [docs/plans/creator-studio-owner-rollup-handoff.md](../plans/creator-studio-owner-rollup-handoff.md)).
+  The per-owner version-ID query stays as a fallback for small creators until the MV lands.
 - **CP cash / banked** — `creatorProgram.getCash` / `getBanked`
   ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices)) for the pending/settled panel.
 - **Not** the buzz service; **no** per-version monetization writes here (those are [models.md](models.md)).
@@ -61,9 +68,8 @@ flow ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpoint
 
 ## Gating
 
-**Any logged-in user can access** — this is a read, and member-`tier` gating is per-*action* (fee-setting on
-[models.md](models.md)), not per-view ([plan §9](../creator-studio-plan.md#9-decisions--open-questions)). Non-members
-see their own earnings normally.
+**Any logged-in user can access** — this is a read, and Creator Program membership gating is per-*action* (fee-setting on
+[models.md](models.md)), not per-view. Non-members see their own earnings normally.
 
 ## Shared / cross-refs
 
@@ -76,16 +82,23 @@ see their own earnings normally.
 - Legacy `getDailyCompensationRewardByUser` (main app) is being redirected; both converge on one CH read module at the
   full cutover ([§7.6](../creator-studio-plan.md#76-clickhouse-analytics--materialized-views)).
 
-## Open questions
+## Decisions (resolved 2026-07-02)
 
-- **Which sources ship in v1?** comp / license / tip are ready today; **access-sale + cosmetic-sale** need the gap #2
-  per-`toAccountId` buzz-earnings MV ([§7.6](../creator-studio-plan.md#76-clickhouse-analytics--materialized-views)) —
-  include in v1 or defer to fast-follow?
-- **Owner-keyed rollup (gap #1)** is a hard dependency — is the `(ownerUserId, date, source)` MV + `modelVersion →
-  ownerUserId` dictionary scheduled before v1?
-- **`/earnings` vs `/earnings/analytics` vs dashboard boundary** — what is *unique* to `/earnings` (by-source totals +
-  cash) so it doesn't duplicate the other two?
-- **CP cash + withdrawal — inline or link-out?** Surface pending/settled + Withdraw here, or send fully to the existing
-  CP flow?
-- **Time granularity + default window** — daily vs monthly; default 30d? Shared with [analytics.md](analytics.md).
-- **Charting lib** — none in `@civitai/ui`; pick jointly with [analytics.md](analytics.md).
+- **EARN-1 — v1 sources.** **All sources day 1** ideally, with a **source filter** (model access, cosmetic, comp,
+  licenses, tips; merch later). **Comp + licenses can share a chart** (comp is being retired). This means access-sale +
+  cosmetic-sale are in v1 and need the **gap #2** per-`toAccountId` buzz-earnings MV.
+- **EARN-2 — Owner-keyed rollup.** Build via **ClickPipe/CDC → a `modelVersion → ownerUserId` ClickHouse dictionary →
+  an owner-keyed AggregatingMergeTree MV** (reusing the existing Buzz ClickPipe pattern; CH can't reach the
+  Bastion-gated prod DB directly). Build handoff:
+  [docs/plans/creator-studio-owner-rollup-handoff.md](../plans/creator-studio-owner-rollup-handoff.md). The per-owner
+  version-ID query is the launch fallback.
+- **EARN-3 — Boundary.** **Analytics = non-buzz usage** (generations, downloads); **earnings = everything buzz +
+  real-dollar cash/banking/withdrawal**. `/earnings` owns the by-source money detail and the cash surface.
+- **EARN-4 — Cash + withdrawal home.** Lives here on `/earnings` as the **single entry point** — surfaced inline. For
+  v1 the actual withdrawal **links out** to the existing CP cash flow (`/user/buzz-dashboard`); the dashboard only shows
+  a condensed preview and links here.
+- **EARN-5 — Granularity + window.** A **switcher (daily / weekly / monthly)**, default **last 30 days**, plus a custom
+  range (last 7 / last 30 / last month / custom). Shared with [analytics.md](analytics.md).
+
+**Still open / deferred:** access-sale + cosmetic-sale earnings depend on the **gap #2** MV being built; the owner-keyed
+rollup (EARN-2) lands v1 if it's ready, else fast-follow with the version-ID fallback.

--- a/docs/creator-studio/join.md
+++ b/docs/creator-studio/join.md
@@ -8,28 +8,29 @@
 ## User story
 
 As a logged-in **non-member**, I open the Studio and can look around, but the money-making controls are disabled. When
-I hit `/join` (or click a disabled control on [models.md](models.md) / [licensing.md](licensing.md)), I see **what the
-member tier unlocks** and a single CTA to **subscribe / join** — which takes me to the existing main-app flow.
+I hit `/join` (or click a disabled control on [models.md](models.md) / [licensing.md](licensing.md)), I see **what
+Creator Program membership unlocks** and a single CTA to **join the Creator Program** — which takes me to the existing
+main-app flow.
 
 ## Layout & components
 
 `@civitai/ui` (shadcn-svelte) primitives — don't hand-build:
 
 - **`card`** — one value-prop card per unlocked capability (set licensing fees · sell access indefinitely) and a
-  **tier-comparison** card (member vs non-member: what each can do).
-- **`button`** — the single primary **subscribe / join** CTA (links out — see Actions); **`badge`** for the tier name
-  (bronze/silver/gold) or "Creator Program"; **`separator`** between prop groups.
-- Copy is **gate-dependent**: "subscribe to a plan" vs "join the Creator Program" hinges on the pending confirm below —
-  the CTA target and headline change with it.
+  **member-vs-non-member comparison** card (what each can do).
+- **`button`** — the single primary **join the Creator Program** CTA (links out — see Actions); **`badge`** for
+  "Creator Program" membership state; **`separator`** between prop groups.
+- Copy is fixed: the gate is **Creator Program membership**, so the CTA reads "join the Creator Program" (not
+  "subscribe to a plan").
 
 ## Data (reads) — `+page.server.ts`
 
 Read-only, from `locals.user` (kysely via `@civitai/db`), scoped to the current user:
 
-- **Confirm the user is a non-member** — the member `tier` via `CustomerSubscription → Product.metadata.tier`
-  ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices)); if they're already a member,
-  `/join` redirects to `/` (nothing to upsell).
-- **Which tiers / plans to show** — the value props and tier-comparison content (static config or the same tier source).
+- **Confirm the user is not a Creator Program member** — via `creatorProgram.getCreatorRequirements` (CP membership is
+  the single gate) ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices)); if they're
+  already a member, `/join` redirects to `/` (nothing to upsell).
+- **What to show** — the value props and member-vs-non-member comparison content (static config).
 - **No writes, no ClickHouse, no buzz call** — this page only reads current-user membership state.
 
 ## Actions (writes) — none (CTA links out)
@@ -40,7 +41,7 @@ Whether that's an in-app redirect or an out-to-main-app link is an open question
 
 ## States
 
-- **Non-member** — the default and only meaningful state: value props + tier comparison + CTA.
+- **Non-member** — the default and only meaningful state: value props + member-vs-non-member comparison + CTA.
 - **Already a member** — redirect to `/` (or the section they came from); `/join` has nothing to say to members.
 - **Inline upsell** — when reused as a card/tooltip/modal on a gated control, it renders the same value prop + CTA in a
   compact form (see Shared/cross-refs).
@@ -49,7 +50,7 @@ Whether that's an in-app redirect or an out-to-main-app link is an open question
 
 Inverse of the rest of the Studio: `/join` is the surface **for** non-members. The nav item is member-aware — hidden or
 de-emphasised for members via the shared `nav.ts` `memberOnly` mechanism ([plan §3](../creator-studio-plan.md#3-page-list-v1)).
-The capabilities it sells (fee-setting, sell-indefinitely) are the member-`tier`-gated ones enforced on
+The capabilities it sells (fee-setting, sell-indefinitely) are the Creator Program membership-gated ones enforced on
 [models.md](models.md) / [licensing.md](licensing.md) and re-checked server-side in the monetization module.
 
 ## Shared / cross-refs
@@ -58,20 +59,23 @@ The capabilities it sells (fee-setting, sell-indefinitely) are the member-`tier`
   [models.md](models.md) (§Gating) and [licensing.md](licensing.md) get an **upsell tooltip / link to `/join`**. `/join`
   is likely **both** a standalone page **and** an inline surface (card/tooltip/modal) reused across those pages — the
   value-prop + CTA block should be one shared component so the message can't drift.
-- **Settings** — membership / `tier` status also lives on [settings.md](settings.md); `/join` is the *acquisition*
-  surface, settings is the *status* surface.
+- **Settings** — Creator Program membership status also lives on [settings.md](settings.md); `/join` is the
+  *acquisition* surface, settings is the *status* surface.
 - **Nav** — member-aware item via app-local `nav.ts` ([plan §3](../creator-studio-plan.md#3-page-list-v1)).
 
-## Open questions
+## Decisions (resolved 2026-07-02)
 
-- **⚠️ Tier vs full-CP gate (headline).** Is "member" an **active subscription `tier`** (bronze/silver/gold) or **full
-  Creator Program membership** (tier **+** creator score ≥40k)? This directly changes the CTA and copy — "subscribe to a
-  plan" vs "join the Creator Program" (the latter needs score ≥40k, a stricter bar). Pending confirm
-  ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices), [plan §9](../creator-studio-plan.md#9-decisions--open-questions)).
-- **In-app vs redirect.** Does subscribe / enroll happen in-app or redirect to the main app's billing / CP flow (and do
-  we deep-link back to the Studio afterward)?
-- **Which tiers + value props to display** — all three subscription tiers with a comparison, or just the minimum bar
-  that unlocks the gated controls?
-- **Standalone page, interstitial, or both** — is `/join` a full page, an interstitial shown when a gated action is
-  attempted, or both — and how is the shared gating/upsell surface reused across [models.md](models.md) and
-  [licensing.md](licensing.md) without drift?
+- **JOIN-1 — Gate.** The gate is **Creator Program membership** (one bar for all gated actions). Copy reads "join the
+  Creator Program," not "subscribe to a plan."
+- **JOIN-2 — In-app vs redirect.** CP enrollment is lightweight, so users who **already have a membership** join
+  **in-app** (no bounce to the main site). Users **without a membership** can't join CP yet, so upsell them to buy a
+  membership first (link out — see JOIN-3).
+- **JOIN-3 — What to show.** Don't sell memberships on-site. For membership purchase, point users to the **main-app
+  pricing page**; they pick a plan and come back. On-site join is only for users who already hold a membership.
+- **JOIN-4 — Surface shape.** Both an **interstitial** and inline **alerts**. Gated charts get an overlay ("you have to
+  be a program member for this"); attempting a gated action (e.g. setting a licensing fee) throws a **modal** that
+  explains the gate and points to the `/join` interstitial. Keep the value-prop + CTA block as one shared component so
+  the message can't drift.
+
+**Still open / deferred:** the main-app pricing page + purchase flow needs a **return-URL / message control** so users
+land back in the Studio after buying a membership (JOIN-2/JOIN-3).

--- a/docs/creator-studio/licensing.md
+++ b/docs/creator-studio/licensing.md
@@ -1,27 +1,21 @@
-# `/licensing` — Licensing fees (bulk editor)
+# Licensing fees (bulk editor) — a mode of `/models`
 
-> **v1 if it lands, else fast-follow** ([plan §8](../creator-studio-plan.md#8-phasing) — "bulk editing / default
-> suggestions can trail the per-version editor"). The multi-version companion to [models.md](./models.md): set, clear,
-> and default a **licensing fee** across MANY of the creator's versions in one pass. Ops in
+> **v1 — critical** (managing your models is the point of v1). The bulk fee editor is **not a separate `/licensing`
+> page** — it lives **inside [`/models`](./models.md)** as a bulk-edit column/mode: set, clear, and default a
+> **licensing fee** across MANY of the creator's versions in one pass. Ops in
 > [plan §5.3](../creator-studio-plan.md#53-new-monetization-operations-creator-studio-module-extract-to-a-package-at-consolidation).
+> This doc specs the *bulk* behaviour that renders inside `/models`.
 
-## ⚠️ Open fork — separate page, or a mode of `/models`?
+## Where it lives — a bulk-edit mode of `/models` (resolved)
 
 `/licensing` and [`/models`](./models.md) overlap almost completely: **same rows** (model versions), **same field**
-(the per-version fee), **same write** (`setLicensingFee`). The plan lists them as separate pages but explicitly flags
-this as unresolved ([plan §8](../creator-studio-plan.md#8-phasing), post-v1 "bulk … if not landed"). **Resolve before
-building.** Options:
+(the per-version fee), **same write** (`setLicensingFee`). **Decision (LIC-1 / README-1):** there is **no separate
+`/licensing` page** — the bulk editor is a **bulk-edit column/mode inside `/models`** (multi-select + a fee column you
+can set across the selection). Zero divergence, and it's discoverable from where creators already manage models.
 
-- **A — separate `/licensing` page** (as listed). Clean nav entry; a dedicated "bulk money" surface. Cost: two pages
-  to keep in sync.
-- **B — `?mode=bulk` on `/models`** — same route, the table swaps into a multi-select + bulk-bar mode via searchParam.
-  Zero divergence; discoverable from where creators already are.
-- **C — a tab within `/models`** ("Manage" / "Bulk fees") — one route, two view states, own tab.
-
-**Whatever we pick, this is not a second implementation.** Both surfaces share the same **row component** and call
-`setLicensingFee` (single) / `bulkSetLicensingFee` (many) from the one **monetization module** — see
-[models.md § Actions](./models.md#actions-writes--form-actions--monetization-module). This doc specs the *bulk*
-behaviour regardless of where it renders.
+Both the single and bulk paths share the same **row component** and call `setLicensingFee` (single) /
+`bulkSetLicensingFee` (many) from the one **monetization module** — see
+[models.md § Actions](./models.md#actions-writes--form-actions--monetization-module).
 
 ## User story
 
@@ -35,12 +29,15 @@ default suggestion**. I confirm the change in a dialog (it's money) before it ap
 
 - **`table`** (data-table) with a leading **`checkbox`** column — one row per version (the shared row from
   [models.md](./models.md)), plus a header select-all. Columns: version · base model · **model type** · current fee
-  (`badge` for `Active` / `Paused` / `Off`).
+  (`badge` for `Active` / `Paused` / `Off`) · **reference price** (the ecosystem's base generation cost) · **end-user
+  price** (base cost + the licensing fee). The reference/end-user columns are **hardcoded for v1** (pulled from the
+  orchestrator in v2 — Koen follow-up); when the ecosystem isn't defined, show **no reference price**.
 - **Bulk action bar** — appears when ≥1 row selected: **`input`** (fee amount) + **`button`** *Apply fee*, *Clear
-  fees*, and *Apply default by type*; a live count ("42 versions selected").
-- **`dialog`** — confirm-before-apply summarizing the change ("Set 0.1 buzz/image on 42 versions — 8 already have a fee,
-  overwrite?"); **`sonner`** toast for result; **`badge`** for per-row fee state.
-- **`input`**/search + filter controls bound to URL searchParams (see reads).
+  fees*, and *Apply default by type*; a live count ("42 versions selected"). Applies to the **selected rows only**.
+- **`dialog`** — mandatory confirm-before-apply on every bulk op, summarizing the change with an affected-count ("Set
+  0.1 buzz/image on 42 versions — 8 already have a fee, overwrite?"); **`sonner`** toast for result; **`badge`** for
+  per-row fee state. **No undo**, but changes are captured in an **audit log**.
+- **`input`**/search + **filter controls** (base model · model type · date) bound to URL searchParams (see reads).
 
 ## Data (reads) — `+page.server.ts`
 
@@ -50,14 +47,16 @@ Loaded server-side (kysely via `@civitai/db`), scoped to `locals.user.id` — sa
 - The creator's **models + versions** with current fee fields (`licensingFee`, `licensingFeeType`, the **`active`
   flag** — [plan §7.1](../creator-studio-plan.md#71-schema--data-main-app-db)) and each version's **model type** (drives
   the default suggestion).
-- The user's member **`tier`** (gates whether any fee write is enabled) —
+- The user's **Creator Program membership** (gates whether any fee write is enabled) —
   [plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices).
 - **`getDefaultFeeSuggestions`** — model-type defaults (LoRA ~0.1, base ~1 buzz/image;
   [plan §5.3](../creator-studio-plan.md#53-new-monetization-operations-creator-studio-module-extract-to-a-package-at-consolidation)).
 - **Not** an analytics page — no ClickHouse. Table state (search / filters / sort / pagination) lives in **URL
   searchParams**.
 
-Paginate/virtualize — the bulk case *is* the many-versions case.
+Paginate/virtualize (cursor-based, matching [models.md](./models.md)) — the bulk case *is* the many-versions case.
+**Select-all-matching** spans every page: it fires a **server-side request that returns the matching version IDs** so the
+selection stays consistent as the creator scrolls through pages.
 
 ## Actions (writes) — form actions → monetization module
 
@@ -67,13 +66,13 @@ The one bulk mutation goes through the creator-studio **monetization module** (`
 
 | Action | Op | Notes |
 |---|---|---|
-| Apply fee to selected | `bulkSetLicensingFee(versionIds, fee)` | **member-only**; fractional (0.01 precision); validate bounds. Value kept even when paused. |
+| Apply fee to selected | `bulkSetLicensingFee(versionIds, fee)` | **Creator Program members only**; fractional (0.01 precision); floor 0.01, cap 100 buzz/image; validate bounds. Value kept even when paused. |
 | Clear fees on selected | `bulkSetLicensingFee(versionIds, null)` | sets fee off across the selection. |
 | Apply default by type | `bulkSetLicensingFee` per resolved default | resolve each version's default via `getDefaultFeeSuggestions`, then set. |
 
-- **Authorization asserted inside the module** (member `tier`) for the whole batch — the disabled UI is UX, the server
-  re-checks — and **ownership is checked per version**: the batch must confirm `locals.user.id` owns *every* id
-  ([models.md § Actions](./models.md#actions-writes--form-actions--monetization-module)).
+- **Authorization asserted inside the module** (Creator Program membership) for the whole batch — the disabled UI is UX,
+  the server re-checks — and **ownership is checked per version**: the batch must confirm `locals.user.id` owns *every*
+  id ([models.md § Actions](./models.md#actions-writes--form-actions--monetization-module)).
 - **Stacking is not handled here** — the backend does it
   ([plan §7.3](../creator-studio-plan.md#73-fee-stacking--already-handled-no-new-work)).
 - Optimistic money updates are OK with **rollback** on failure; a partial failure reports which ids failed.
@@ -83,17 +82,16 @@ The one bulk mutation goes through the creator-studio **monetization module** (`
 - **Loading** — skeleton rows.
 - **Empty** — no models → empty state + link to upload on the main app (same as [models.md](./models.md)).
 - **Nothing selected** — bulk bar hidden; table read-only.
-- **Non-member** — page loads; the fee/apply/clear controls **disabled** with an upsell to `/join` (a fee is
-  member-gated).
+- **Non-member** — page loads; the fee/apply/clear controls **disabled** with an upsell to `/join` (a fee is gated on
+  Creator Program membership).
 - **Fee paused** — versions whose owner's membership lapsed show `Paused`, value retained, not charged
   ([plan §7.1](../creator-studio-plan.md#71-schema--data-main-app-db)).
 - **Error / partial** — toast + inline row errors for the ids that failed; optimistic changes roll back.
 
 ## Gating
 
-Member-`tier` gates **every** fee write here (there is no non-gated bulk action). Enforced in UI (disabled + tooltip)
-and re-checked in the module for the whole batch. Exact bar (tier vs full-CP membership) pending
-([plan §9](../creator-studio-plan.md#9-decisions--open-questions)).
+**Creator Program membership** gates **every** fee write here (there is no non-gated bulk action). Enforced in UI
+(disabled + tooltip) and re-checked in the module for the whole batch.
 
 ## Shared / cross-refs
 
@@ -102,14 +100,23 @@ and re-checked in the module for the whole batch. Exact bar (tier vs full-CP mem
 - Per-account default fee suggestions / settlement-currency default live in [settings.md](./settings.md).
 - Nav item is member-aware (`memberOnly`) via the shared `nav.ts`.
 
-## Open questions
+## Decisions (resolved 2026-07-02)
 
-- **Separate page vs mode of `/models`** — the fork above; decide before building (A / B / C).
-- **Default-apply semantics** — apply to *selected only* or to *all of a chosen model type*? And **overwrite existing
-  fees or only fill empty ones**? (Lean: selected-only + a confirm that names how many already have a fee.)
-- **Selection across pages** — does a multi-select persist across paginated pages, or is "select all matching" a
-  server-side filter apply (safer, no giant id list)? Should selection survive in URL state?
-- **Scope of bulk** — fees only, or also bulk **access toggles** / sell-indefinitely? (Lean: fees-only for v1 — access
-  is per-version on [models.md](./models.md).)
-- **Guardrails against a mistaken overwrite** — mandatory confirm dialog with an affected-count + before/after summary;
-  is an undo / recent-change surface warranted for a money field?
+- **LIC-1 — Where it lives.** No separate `/licensing` page. The bulk editor is a **bulk-edit column/mode inside
+  `/models`** (see the resolved section above).
+- **LIC-2 — Apply semantics + filters.** Apply to the **selected rows only** (creators filter + multi-select to target
+  a set). Filters mirror the main site: **base model, model type, and a date filter** (e.g. "everything released in the
+  last 30 days"). Show a **reference price** (ecosystem base cost) and an **end-user price** column (base cost + fee) so
+  creators see how their pricing fits; the reference is **hardcoded for v1**, pulled from the orchestrator in v2
+  (backend follow-up, tracked internally); **no reference shown when the ecosystem is
+  undefined**.
+- **LIC-3 — Selection across pages.** "Select all matching" spans every page via a **server-side request that returns
+  the matching version IDs**, so the selection stays consistent as the creator pages through.
+- **LIC-4 — Scope of bulk.** **Fees only for v1**, but design so other bulk ops (access permissions, sell rates) can be
+  added later — creators will want "all my old models at rate X, new ones at rate Y."
+- **LIC-5 — Guardrails.** Every bulk op requires a **confirm dialog with an affected-count**. **No undo**, but keep an
+  **audit log** of the changes made and when.
+
+**Still open / deferred:** **per-account default pricing settings** (a saved default licensing/access price for new
+models) is **post-v1**, not v1. Pulling the reference price from the orchestrator (rather than hardcoding) is a v2
+backend follow-up (tracked internally).

--- a/docs/creator-studio/models.md
+++ b/docs/creator-studio/models.md
@@ -9,8 +9,8 @@
 As a creator, I open `/models` and see **my** models as rows with their **versions nested underneath** (drafts
 included). Per version I manage **all monetization**: set/clear a **licensing fee** (members only), edit **early/paid
 access** config, and — as a **Creator Program member** — make a version **available for sale indefinitely** (beyond
-early access). Secondarily I can **publish or schedule a version's publish date** from here (a management convenience,
-lower priority than fees). Changes save inline; I see immediately whether a fee is *active* or paused.
+early access). I can also **publish or schedule a version's publish date** from here (v1 — managing your models is the
+point). Changes save inline; I see immediately whether a fee is *active* or paused.
 
 ## Layout & components
 
@@ -32,10 +32,9 @@ Loaded server-side (kysely via `@civitai/db`), scoped to `locals.user.id`:
   `licensingFeeType` + the new **`active` flag** ([plan §7.1](../creator-studio-plan.md#71-schema--data-main-app-db)),
   `earlyAccessConfig` / `earlyAccessEndsAt`, and the "unlimited access / indefinite-sale" flag.
   `licensingFeeSettlementCurrency` is read **for display only** — creators can't set it (see Actions).
-- The user's **member `tier`** and **CP-membership** status — the fee gate keys on `tier`; **indefinite-sale keys on
-  Creator Program membership** (per Justin) — `CustomerSubscription → Product.metadata.tier` +
-  `creatorProgram.getCreatorRequirements` ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices)).
-  *(The exact fee gate — tier vs full CP — is still a [pending confirm](../creator-studio-plan.md#9-decisions--open-questions).)*
+- The user's **Creator Program membership** status — the single gate for **all** monetization actions (both the fee and
+  indefinite-sale) — via `creatorProgram.getCreatorRequirements`
+  ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices)).
 - **Not** an analytics page — no ClickHouse here. Per-model earnings/usage live on [analytics.md](analytics.md).
 
 ## Actions (writes) — form actions → monetization module
@@ -45,13 +44,13 @@ All mutations go through the creator-studio **monetization module** (`src/lib/se
 
 | Action | Op | Notes |
 |---|---|---|
-| Set / adjust / clear licensing fee | `setLicensingFee(versionId, fee)` | **member-only**; fractional (0.01 precision); validate bounds. Value kept even when paused. |
-| Edit early/paid access config | (access config write) | **Full** `earlyAccessConfig` (not just a toggle) — Justin wants *all monetization in the studio*. Field-by-field scope in Open questions. |
-| Sell access indefinitely | `setUnlimitedAccess(versionId)` | **Creator Program members only** (per Justin) — indefinite availability beyond early access; needs main-app support ([plan §7.1](../creator-studio-plan.md#71-schema--data-main-app-db)). |
-| Publish / schedule publish | (publish write) | **Management convenience — 2nd priority to fees.** Publish a version or set its publish date from the studio. |
+| Set / adjust / clear licensing fee | `setLicensingFee(versionId, fee)` | **Creator Program members only**; fractional (0.01 precision); floor 0.01, cap 100 buzz/image; validate bounds. Value kept even when paused. |
+| Edit early/paid access config | (access config write) | **Full** `earlyAccessConfig` brought over (not just a toggle) — Justin wants *all monetization in the studio*. Only the **generation price** field is a candidate for retirement (licensing fees now cover it). |
+| Sell access indefinitely | `setUnlimitedAccess(versionId)` | **Creator Program members only** — early-access pricing with **no end date** (same mechanism, one just has no early-access end); needs main-app support ([plan §7.1](../creator-studio-plan.md#71-schema--data-main-app-db)). |
+| Publish / schedule publish | (publish write) | **v1 — critical.** Publish a version or set its publish date from the studio; managing your models is the point of v1. |
 
-- **Authorization asserted inside the module** (disabled control is UX; the server re-checks): fee writes gate on member
-  `tier`; **indefinite-sale gates on CP membership**.
+- **Authorization asserted inside the module** (disabled control is UX; the server re-checks): **all** monetization
+  writes (fee, indefinite-sale) gate on **Creator Program membership** — one bar.
 - **Ownership check**: every action confirms `locals.user.id` owns the version.
 - **Settlement currency is not a creator choice** — cash settlement is done by Civitai only, in special circumstances,
   on the creator's behalf (Justin). No per-version or per-account control.
@@ -61,8 +60,8 @@ All mutations go through the creator-studio **monetization module** (`src/lib/se
 
 - **Loading** — skeleton rows (`skeleton`).
 - **Empty** — creator has no models → friendly empty state + link to upload on the main app.
-- **Non-member / non-CP** — page loads; **fee** controls disabled (member gate) and **sell-indefinitely** disabled (CP
-  gate) with an upsell to `/join`; access-config editing stays available (early access isn't member-gated). Drafts are
+- **Non-member** — page loads; **fee** and **sell-indefinitely** controls disabled (Creator Program membership gate)
+  with an upsell to `/join`; access-config editing stays available (early access isn't member-gated). Drafts are
   listed with a draft badge.
 - **Fee paused** — member set a fee then membership lapsed → fee shows `Paused`, value retained, not charged
   ([plan §7.1](../creator-studio-plan.md#71-schema--data-main-app-db)). Pre-cutover fees show a "not-yet-payable" state.
@@ -70,11 +69,9 @@ All mutations go through the creator-studio **monetization module** (`src/lib/se
 
 ## Gating
 
-Gating is **feature-specific**: **setting a fee** keys on member `tier`; **sell-indefinitely** keys on **Creator
-Program membership** (per Justin). Everything else (access config, publish) is open to any authenticated owner. Enforced
-in UI (disabled + tooltip) and re-checked in the module. The exact *fee* bar (tier vs full CP) is still
-[pending](../creator-studio-plan.md#9-decisions--open-questions) — Justin's CP answer for indefinite-sale hints the two
-gates may genuinely differ.
+Gating is a **single bar**: **Creator Program membership** gates every monetization action (setting a fee,
+sell-indefinitely). Everything else (access config, publish) is open to any authenticated owner. Enforced in UI
+(disabled + tooltip) and re-checked in the module.
 
 ## Shared / cross-refs
 
@@ -85,26 +82,33 @@ gates may genuinely differ.
 
 ## Routing & URL state
 
-- **Table state in the URL** — search (`?q=`), filters (`?status=`, `?fee=active|paused|off`, `?access=`), sort, page —
+- **Table state in the URL** — search (`?q=`), filters (`?status=`, `?fee=active|paused|off`, `?access=`), sort, cursor —
   read in `+page.server.ts` `load`, updated via `goto('?…', { keepFocus, noScroll })`; deep-linkable, refetches fresh.
 - **Grouped rows** — which models are expanded is view state; keep ephemeral (or `?open=<modelId>` for linkable expansion).
 - **Edit surfaces** — richer per-version editors (full access config, publish scheduling) open as a **URL-addressable
   drawer** (`?version=<id>`) via **shallow routing** (`pushState`) — linkable, back-button closes it, no page reload.
   Inline fee/on-off stays in the row.
 - **Optimistic** money updates with rollback on failure (confirmed OK — the fee is a stored value, not a live charge).
-- **Pagination** — offset vs cursor **undecided** (Justin: "not sure yet"); revisit for creators with many versions.
+- **Pagination** — **cursor-based virtualized infinite scroll** (load-more) with a total count shown, plus
+  filters/sort/search; **not** numbered pages (see Decisions).
 
-## Open questions
+## Decisions (resolved 2026-07-02)
 
-- **Fee gate — tier vs full CP membership** (still pending — [plan §9](../creator-studio-plan.md#9-decisions--open-questions)).
-  Justin scoped **indefinite-sale to CP members**, so the gates may genuinely differ (fee = `tier`, indefinite = CP).
-- **Access-config depth** — "all monetization in the studio" ⇒ expose the **full** `earlyAccessConfig` (download vs
-  generation price, trial limits, donation goals) here; confirm the field-by-field v1 scope vs. what trails.
-- **Indefinite-sale needs main-app work** — "available for sale indefinitely" (beyond early access, CP-gated) needs a
-  main-app representation + backend ([plan §7.1](../creator-studio-plan.md#71-schema--data-main-app-db)) before the
-  studio control is real. Scope/own with backend.
-- **Publish / schedule from the studio** — confirmed wanted but **2nd priority to fees**; v1 or fast-follow?
-- **Pagination** — offset vs cursor (undecided).
+- **MODELS-1 — Fee gate.** **Creator Program membership** — one bar for all gated actions (fee-setting and
+  indefinite-sale). No separate tier gate.
+- **MODELS-2 — Access-config depth.** Bring over the **full** `earlyAccessConfig` (download vs generation price, trial
+  limits, donation goals). Only the **generation price** is a candidate for retirement, since licensing fees now cover
+  that.
+- **MODELS-3 — Indefinite-sale.** It is **early-access pricing with no end date** (same mechanism). The main-app backend
+  needs the no-end-date representation; scope/own with backend.
+- **MODELS-4 — Publish / schedule.** **v1 — critical.** Managing your models (publish/schedule + bulk fee editing) is
+  the whole point of v1.
+- **MODELS-5 — Pagination.** **Cursor-based virtualized infinite scroll** (load-more) with strong filters/sort/search
+  and a total count shown — **not** numbered pages. Numbered/offset paging can be added later only if page-jumps are
+  explicitly requested.
 
-**Resolved (Justin):** table **grouped by model, versions nested** · **drafts shown** · **settlement currency is not a
-creator choice** (Civitai-only, special cases) · optimistic updates OK.
+**Also resolved (Justin):** table **grouped by model, versions nested** · **drafts shown** · **settlement currency is not
+a creator choice** (Civitai-only, special cases) · optimistic updates OK.
+
+**Still open / deferred:** indefinite-sale's main-app no-end-date backend representation must land before the studio
+control is real (MODELS-3, coordinate with backend).

--- a/docs/creator-studio/settings.md
+++ b/docs/creator-studio/settings.md
@@ -1,23 +1,25 @@
 # `/settings` — Payout & settings
 
-> **v1.** The creator's account-level control surface: **payment config (Tipalti) status**, **membership/`tier`
-> status**, and a **default fee-suggestion** preference.
+> **v1.** The creator's account-level control surface: **payment config (Tipalti) status**, **Creator Program
+> membership status**, and a **default fee-suggestion** preference.
 > Umbrella: [plan §3](../creator-studio-plan.md#3-page-list-v1). Mostly **read + link-out**; a few small preference
 > writes go through the creator-studio module ([plan §5.3](../creator-studio-plan.md#53-new-monetization-operations-creator-studio-module-extract-to-a-package-at-consolidation)).
 
 ## User story
 
 As a creator, I open `/settings` and see at a glance whether I'm **set up to get paid** (Tipalti onboarding done or
-not) and whether my **membership** is active and at what `tier`. I don't re-do onboarding or billing here — I click out
-to the existing flows. I *do* set my **default fee suggestion** here, so `/models` and `/licensing` start from my baseline instead of the
-global default. (**Settlement currency isn't a creator choice** — Civitai handles cash settlement in special cases.)
+not) and whether my **Creator Program membership** is active. I don't re-do onboarding or billing here — I click out
+to the existing flows. I *do* set my **default fee suggestion** here (the per-account baseline), so `/models` starts from
+my baseline instead of the global default. (**Settlement currency isn't a creator choice** — Civitai handles cash
+settlement in special cases.)
 
 ## Layout & components
 
 `@civitai/ui` (shadcn-svelte) primitives — don't hand-build:
 
-- **`card`** — one status card per concern: **Payout** (Tipalti), **Membership** (`tier`), each with a **`badge`**
-  (`Set up` / `Not set up` / `Active` / `Lapsed`) and a **`button`** linking out.
+- **`card`** — one status card per concern: **Payout** (Tipalti), **Membership** (Creator Program), each with a
+  **`badge`** (`Set up` / `Not set up` / `Active` / `Lapsed`) and a **`button`** linking out (Membership → the main-app
+  pricing page; Payout → `/tipalti/setup`).
 - **`separator`** between the read-only status block and the editable prefs block.
 - **`input`** + **`label`** for the **default fee suggestion**; **`button`** to save.
 - **`sonner`** (toast) for save success/failure; **`tooltip`** for the gated/lapsed explanations.
@@ -28,9 +30,10 @@ global default. (**Settlement currency isn't a creator choice** — Civitai hand
 Loaded server-side (kysely via `@civitai/db`), scoped to `locals.user.id`:
 
 - **Payout config** — `UserPaymentConfiguration` (Tipalti onboarding / payout-method status)
-  ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices)). Read-only here.
-- **Membership `tier`** — `CustomerSubscription → Product.metadata.tier` (bronze/silver/gold); drives whether the fee
-  prefs are enabled and what the Membership card shows ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices)).
+  ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices)). Read-only here. The Tipalti
+  setup gate is **settled cash ("Ready to Withdraw") >= $50** (not pending), so copy reads **"$50 Ready to Withdraw."**
+- **Creator Program membership** — via `creatorProgram.getCreatorRequirements`; drives whether the fee prefs are enabled
+  and what the Membership card shows ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices)).
 - **CP cash / banked** (if the withdrawal entry lives here) — `creatorProgram.getCash` / `getBanked`
   ([plan §5.2](../creator-studio-plan.md#52-reuse-existing-main-app-endpointsservices)).
 - **Current defaults** — the creator's saved fee-suggestion pref (see writes).
@@ -43,29 +46,29 @@ through the creator-studio **monetization module** ([plan §5.3](../creator-stud
 
 | Action | Op | Notes |
 |---|---|---|
-| Set default fee suggestion | (account-pref write) | member-only; overrides the model-type default (`getDefaultFeeSuggestions`) as the creator's baseline. |
+| Set default fee suggestion | (account-pref write) | Creator Program members only; overrides the model-type default (`getDefaultFeeSuggestions`) as the creator's per-account baseline. |
 
 - **Authorization asserted inside the module** on member-gated prefs — the disabled control is UX, the server
-  re-checks the `tier`.
+  re-checks Creator Program membership.
 - **Ownership** is implicit (`locals.user.id`), but every write is scoped to it explicitly.
 - **No buzz call, no ClickHouse** — these are plain account-pref writes.
 
 ## States
 
 - **Loading** — `skeleton` cards.
-- **Payout not set up** — Payout card shows `Not set up` + a prominent "Set up payouts" button → main-app / CP Tipalti
-  onboarding.
+- **Payout not set up** — Payout card shows `Not set up` + a prominent "Set up payouts" button → the embedded Tipalti
+  setup at `/tipalti/setup` (creators are invited once settled cash is **>= $50 Ready to Withdraw**).
 - **Non-member** — Membership card shows the upsell → [./join.md](./join.md); the fee-suggestion pref is **disabled**
   with an upsell tooltip.
-- **Membership lapsed** — `tier` inactive: Membership card shows `Lapsed`; note that any set fees are **paused** (value
-  retained) per [plan §7.1](../creator-studio-plan.md#71-schema--data-main-app-db), with a link to [./models.md](./models.md).
+- **Membership lapsed** — Creator Program membership inactive: Membership card shows `Lapsed`; note that any set fees are
+  **paused** (value retained) per [plan §7.1](../creator-studio-plan.md#71-schema--data-main-app-db), with a link to [./models.md](./models.md).
 - **Error** — inline field error + toast; optimistic pref update rolls back on failure.
 
 ## Gating
 
-Member-`tier` gates the **default fee suggestion** pref (it's a fee action). Payout/membership status and settlement
-currency are visible/editable to any authenticated user. Enforced both in UI (disabled + tooltip) and in the module
-(server re-check). Exact bar (tier vs full CP) pending ([plan §9](../creator-studio-plan.md#9-decisions--open-questions)).
+**Creator Program membership** gates the **default fee suggestion** pref (it's a fee action). Payout/membership status
+and settlement currency are visible to any authenticated user. Enforced both in UI (disabled + tooltip) and in the
+module (server re-check).
 
 ## Shared / cross-refs
 
@@ -73,18 +76,23 @@ currency are visible/editable to any authenticated user. Enforced both in UI (di
   flows ([plan §6.2](../creator-studio-plan.md#62-redirect-superseded-management-surfaces)).
 - **Settlement currency is not a creator setting** (Justin) — Civitai does cash settlement only in special cases, on the
   creator's behalf; there's no per-account or per-version control on [./models.md](./models.md).
-- **Cash withdrawal** may surface here or on [./earnings.md](./earnings.md); either way the flow itself is the CP
-  withdrawal path, not rebuilt here.
+- **Cash withdrawal home is [./earnings.md](./earnings.md)** (single entry point) — settings only shows payout-setup
+  status. For v1 the withdrawal flow links out to the existing CP path, not rebuilt here.
 - Nav item is not member-gated (settings is reachable by any authenticated user) via the shared `nav.ts`.
 
-## Open questions
+## Decisions (resolved 2026-07-02)
 
-- **Editable here vs link-out** — is Tipalti setup *initiated* here (embedded/deep-link) or purely a status card that
-  links to the main-app onboarding? Default assumption: status + link-out.
-- **Default fee suggestion — per-account vs per-version** — confirm this page owns the per-account baseline and
-  [./models.md](./models.md) inherits/overrides per version. *(Settlement currency is resolved — not a creator choice.)*
-- **Membership upgrade/cancel** — done here or link out to billing? Default: link out; show status only.
-- **Cash withdrawal home** — here, on [./earnings.md](./earnings.md), or purely the CP flow? Pick one to avoid two
-  entry points.
-- **Tier-vs-CP gate** ([plan §9](../creator-studio-plan.md#9-decisions--open-questions)) — changes what the Membership
-  card reports (subscription `tier` alone vs tier + creator-score CP membership) and the fee-pref gate.
+- **SET-1 — Tipalti: editable here vs link-out.** **v1 = link out.** A creator is invited to set up Tipalti (embedded
+  iframe at `/tipalti/setup`) once their **settled** cash is **>= $50 "Ready to Withdraw"** (not pending). Copy must say
+  **"$50 Ready to Withdraw."** v1 link-out targets: `/tipalti/setup` (set up payouts), `/user/buzz-dashboard` (withdraw),
+  `/user/account#payments` (account status), `/creator-program` (FAQ/join) — link only the Creator Program V2 cash flow.
+  If CP banking is ported later, bring the Tipalti setup into the Studio.
+- **SET-2 — Default fee: per-account vs per-version.** **Settings owns the per-account baseline**; [./models.md](./models.md)
+  overrides per version. Values LoRA ~0.1, base ~1 buzz/image (see PLAN-11 for the model-type exclusion set).
+- **SET-3 — Membership upgrade/cancel.** **Link out** to the main-app pricing page (return control brings them back to
+  the Studio); status shown here only.
+- **SET-4 — Cash withdrawal home.** **[./earnings.md](./earnings.md)** — single entry point.
+- **SET-5 — Gate.** **Creator Program membership.** The Membership card reports CP status; the fee-pref gate is CP.
+
+**Still open / deferred:** porting the full CP banking/withdrawal experience into the Studio (Tipalti setup + withdraw
+inline) is a **later** upgrade; v1 links out.

--- a/docs/plans/creator-studio-owner-rollup-handoff.md
+++ b/docs/plans/creator-studio-owner-rollup-handoff.md
@@ -1,0 +1,227 @@
+# Handoff — Owner-keyed earnings/usage rollup in ClickHouse (Creator Studio)
+
+**Status:** design handoff, NOT built. Build when the Creator Studio analytics/earnings pages need real
+owner-scoped data at scale.
+**Owner of the decision:** Justin. **Executing agent:** TBD.
+**Source questions:** [creator-studio/QUESTIONS-ROUNDUP.md](../creator-studio/QUESTIONS-ROUNDUP.md) EARN-2 (+ ANALYTICS-2,
+DASH-3). **Plan context:** [creator-studio-plan.md §7.6](../creator-studio-plan.md#76-clickhouse-analytics--materialized-views).
+
+---
+
+## 1. Why
+
+Creator Studio needs to answer "**how much has creator X earned / how much is X's catalog being used**", scoped to a
+single creator, fast, at any catalog size.
+
+Every earnings + usage aggregate in ClickHouse is keyed by **`modelVersionId`**, never the creator's **`userId`**.
+The `userId` columns that exist (`daily_user_resource`, `userModelDownloads`) are the *generator/downloader*, not the
+*creator*. So there is no owner dimension to group on.
+
+Today's workaround (used elsewhere): when an owner reviews their data, the app knows all of their `modelVersionId`s
+and queries `WHERE modelVersionId IN (…)`. This balloons and gets slow for prolific creators (hundreds/thousands of
+versions). We want a point lookup by `ownerUserId` instead.
+
+The missing piece is a **`modelVersion → ownerUserId` mapping inside ClickHouse**, plus rollups that use it.
+
+---
+
+## 2. Decision already made (Justin)
+
+- Get the mapping into ClickHouse via **ClickPipe / CDC**, same pattern as the **existing ClickPipes connected to the
+  Buzz database**. The prod app DB is not publicly exposed and reaches CH over **Bastion**, so a direct
+  ClickHouse→Postgres connection isn't viable — **CDC is the path**.
+- Use a **dictionary** for the lookup (not a runtime JOIN — CH joins are weak for this; a dictionary is an O(1) hash
+  lookup).
+- Build an **owner-keyed aggregating MV** so owner review is a point lookup.
+
+This doc turns that into a concrete build plan.
+
+---
+
+## 3. Source data (Postgres → ClickHouse)
+
+The mapping is a 2-table join in the app DB:
+
+- `Model (id, "userId")` — `userId` is the creator/owner.
+- `ModelVersion (id, "modelId")` — `modelId → Model.id`.
+
+So `modelVersionId → ownerUserId` = `ModelVersion.modelId = Model.id`, take `Model.userId`.
+
+**CDC scope:** replicate **`Model`** and **`ModelVersion`** (id/modelId/userId columns are enough; replicate full
+rows if simpler) into CH as **`ReplacingMergeTree`** mirrors, e.g. `default.pg_model` and `default.pg_model_version`,
+`ORDER BY id`, with a version/`_peerdb`/`updatedAt` column as the ReplacingMergeTree version so updates + deletes
+collapse correctly. Match whatever convention the existing Buzz ClickPipe uses (soft-delete handling, `_peerdb_*`
+metadata columns, etc.) — **inspect an existing pipe first and mirror its conventions.**
+
+> ⚠️ Ownership can change (model transfers, merges). CDC keeps the mirror current; the dictionary reload (below) then
+> picks it up. If a downstream MV resolved owner **at insert time**, historical rows keep the owner as-of-insert —
+> see §4 option A vs B for whether that matters to you.
+
+---
+
+## 4. The mapping: dictionary
+
+Create a CH **dictionary** keyed on `modelVersionId`, returning `ownerUserId`.
+
+Source = a query over the two mirror tables (final/collapsed):
+
+```sql
+-- conceptual dictionary source query
+SELECT mv.id AS modelVersionId, m.userId AS ownerUserId
+FROM default.pg_model_version FINAL AS mv
+INNER JOIN default.pg_model FINAL AS m ON m.id = mv.modelId
+```
+
+Dictionary definition (adjust names/creds to our CH conventions):
+
+```sql
+CREATE DICTIONARY default.mv_owner_dict (
+  modelVersionId UInt32,
+  ownerUserId    UInt32
+)
+PRIMARY KEY modelVersionId
+SOURCE(CLICKHOUSE(QUERY '<the SELECT above>'))
+LAYOUT(HASHED())
+LIFETIME(MIN 300 MAX 600);   -- reload every 5-10 min; CDC keeps the source fresh
+```
+
+Lookup in any query/MV: `dictGet('default.mv_owner_dict', 'ownerUserId', toUInt32(modelVersionId))`.
+
+New model versions appear in the dict within one `LIFETIME` window after CDC lands them. That lag is fine for
+analytics; it only matters for the resolve-at-insert option below.
+
+---
+
+## 5. The rollups — two options
+
+### Source of truth for earnings
+
+`orchestration.resourceCompensations` (SummingMergeTree, keyed `modelVersionId, date`, with `accountType`, `source`
+where source ∈ comp / licenseFee / tip). Mirror: `default.buzz_resource_compensation`. Generations:
+`default.daily_resource_generation_counts`. Downloads: `default.daily_downloads*`.
+
+### Option A (recommended) — owner-keyed aggregating MV (point lookup)
+
+Target table:
+
+```sql
+CREATE TABLE default.owner_earnings_daily (
+  ownerUserId UInt32,
+  date        Date,
+  source      LowCardinality(String),
+  amount      AggregateFunction(sum, Int64)   -- or SummingMergeTree with a plain sum column
+)
+ENGINE = AggregatingMergeTree
+ORDER BY (ownerUserId, date, source);
+```
+
+MV that populates it, resolving owner via the dictionary **on insert**:
+
+```sql
+CREATE MATERIALIZED VIEW default.owner_earnings_daily_mv TO default.owner_earnings_daily AS
+SELECT
+  dictGet('default.mv_owner_dict','ownerUserId', toUInt32(modelVersionId)) AS ownerUserId,
+  date,
+  source,
+  sumState(amount) AS amount
+FROM <the raw insert source that feeds resourceCompensations>
+GROUP BY ownerUserId, date, source;
+```
+
+Owner review query = a point lookup:
+
+```sql
+SELECT date, source, sumMerge(amount) AS earned
+FROM default.owner_earnings_daily
+WHERE ownerUserId = {ownerId:UInt32} AND date BETWEEN {from:Date} AND {to:Date}
+GROUP BY date, source ORDER BY date;
+```
+
+> ⚠️ **Critical confirm:** a ClickHouse MV fires on **INSERTs to its FROM table**, not on background merges. If
+> `resourceCompensations` is itself the target of an MV fed by some raw table, hang `owner_earnings_daily_mv` off that
+> **same raw source**, not off `resourceCompensations`. Trace the insert path before writing the MV
+> ([§7 confirm list](#7-confirm-before-building)).
+
+Trade-off: owner is resolved as-of-insert. If a model transfers later, past earnings stay with the old owner unless
+you also re-key history (a one-off backfill). For creator earnings that's usually the correct behavior (you earned it
+while you owned it), but confirm with Justin.
+
+### Option B (simpler v1 fallback) — resolve at query time
+
+Keep earnings keyed by `modelVersionId` (as today) and resolve owner in the **query**:
+
+```sql
+SELECT date, source, sum(amount) AS earned
+FROM orchestration.resourceCompensations
+WHERE dictGet('default.mv_owner_dict','ownerUserId', toUInt32(modelVersionId)) = {ownerId:UInt32}
+  AND date BETWEEN {from:Date} AND {to:Date}
+GROUP BY date, source;
+```
+
+Better than app-side `IN (…)` (no giant id list, always current owner), but it still scans the resourceCompensations
+partitions for the window rather than a point lookup. Fine for launch / low traffic; graduate to Option A when it
+gets slow. **Recommendation:** ship B if the MV insert-path wiring in A is uncertain at build time, then move to A.
+
+### Per-model breakdown (ANALYTICS-2 / DASH-3)
+
+For the per-model table and "top-earning models" widget, add `modelVersionId` to the Option A key:
+
+```sql
+ORDER BY (ownerUserId, modelVersionId, date, source)
+```
+
+Then top-models = `WHERE ownerUserId = ? GROUP BY modelVersionId ORDER BY sum DESC LIMIT N`.
+
+---
+
+## 6. Gap #2 — access-sale + cosmetic-sale earnings (only if v1 needs them)
+
+EARN-1 / PLAN-3 want **all** earnings sources day 1, including model-access purchases and cosmetic sales. Those are
+buzz **transactions**, not in `resourceCompensations`. `buzz.transactions_daily_stats` is platform-wide (no account
+dimension). This needs a **per-`toAccountId` daily buzz-earnings-by-type MV** off the buzz-transactions stream:
+
+```sql
+-- target: (toAccountId, date, type) -> sum(amount)
+ORDER BY (toAccountId, date, type)
+```
+
+`toAccountId` for a creator's earnings *is* their `userId` (buzz account), so this one does **not** need the
+dictionary — it's already owner-keyed. Confirm the buzz-transactions source table/stream in CH and the `type` values
+that correspond to access-sale vs cosmetic-sale vs tip.
+
+---
+
+## 7. Confirm before building
+
+1. **Existing Buzz ClickPipe config** — find it, copy its conventions (soft-delete/`_peerdb_is_deleted`, version
+   column, naming, Bastion/network setup). Don't invent a new pattern.
+2. **Insert path into `resourceCompensations`** — is it written directly, or via an MV from a raw table? Option A's MV
+   must hang off the actual insert source. (Blocker for Option A.)
+3. **ID types** — confirm `modelVersionId` / `userId` widths in CH (UInt32 vs UInt64) so the dictionary + dictGet
+   casts match.
+4. **Owner-as-of-insert vs current-owner** for historical earnings after a model transfer (§5 Option A trade-off) —
+   Justin's call.
+5. **buzz-transactions source in CH** + the `type` enum values for gap #2 (§6).
+6. **Refresh lag tolerance** — is a 5-10 min dictionary `LIFETIME` acceptable for brand-new versions showing earnings?
+   (Almost certainly yes.)
+7. **Does v1 actually need gap #2 and the per-model breakdown**, or do those trail? (Drives how much of this ships
+   first — see EARN-1 / ANALYTICS-2 / DASH-3.)
+
+---
+
+## 8. Suggested build order
+
+1. Stand up the CDC ClickPipe for `Model` + `ModelVersion` → CH mirrors (reuse Buzz pipe pattern).
+2. Create `mv_owner_dict`; validate `dictGet` returns correct owners on a sample of known versions.
+3. Ship **Option B** query path so the earnings/analytics pages have real owner-scoped data immediately.
+4. Trace the `resourceCompensations` insert path; build **Option A** (`owner_earnings_daily` + MV) and cut the app
+   read over to it; backfill from history.
+5. Add the per-model key variant (ANALYTICS-2 / DASH-3) if in scope.
+6. Add gap #2 buzz-transactions MV (§6) if access/cosmetic sales are v1.
+
+## 9. Validation
+
+- Pick 3-5 creators (one tiny, one huge catalog). Compare owner-keyed totals vs the legacy app-side
+  `modelVersionId IN (…)` sum (`getDailyCompensationRewardByUser`) for the same window — they must match.
+- Check a just-created model version earns correctly once CDC + dict reload land it (measure the actual lag).
+- Confirm a transferred model behaves per the §7.4 decision.


### PR DESCRIPTION
Folds the completed Creator Studio spec review pass back into the source docs.

## What changed
- Each page doc's **Open questions** section replaced with a dated **Decisions (resolved 2026-07-02)** section; genuinely-deferred items kept under "Still open / deferred".
- **Member gate** corrected everywhere to **Creator Program membership** (single bar for all gated actions); dropped the earlier tier-vs-CP / feature-specific hedging (plan §1/§2/§3/§5/§9 + all page docs).
- **Tipalti copy** fixed to **"$50 Ready to Withdraw"** (settled cash, not pending) with correct v1 link-out targets.
- **Analytics** chart set locked (weekly granularity, buzz-color split, week-over-week, pricing reference); **LayerChart** via shadcn-svelte into `@civitai/ui`.
- **Licensing fee** eligibility (model-type exclusion set), floor/cap, notify-on-pause, currency display, discoverability, pagination, bulk-editor behavior all recorded.
- Adds **`docs/plans/creator-studio-owner-rollup-handoff.md`** — build handoff for the owner-keyed ClickHouse rollup (ClickPipe/CDC → dictionary → owner-keyed MV).

## Notes
- Docs-only. Nothing built.
- The raw decision-log sheet (with private DM feedback + casual answers) is kept out of the repo intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)