### PR TITLE
docs(app-blocks): correct stale postMessage-surface status

### DIFF
--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -146,8 +146,13 @@ JWT for workflows. The orchestrator validates via the JWKS endpoint and
 buckets buzz spend by the token's `buzzBudget` claim. This keeps the host
 out of the request path on every generation.
 
-Phase 2/3 postMessage surfaces (`PURCHASE_BUZZ`, `NAVIGATE`, `TRACK_EVENT`)
-are not implemented in v1. The SDK should detect their absence gracefully.
+Several later postMessage surfaces have since landed: `OPEN_BUZZ_PURCHASE` /
+`GET_BUZZ_BALANCE` (host-mediated Buzz purchase + per-account balance read) and
+`NAVIGATE` (page host only — the model slot intentionally does not bridge it).
+`TRACK_EVENT` is still not host-bridged (no analytics sink wired) and is dropped
+silently. See `src/components/AppBlocks/hostHandlerParity.ts` for the
+authoritative host↔SDK message inventory. The SDK should detect an unhandled
+surface gracefully.
 
 ## Publish / review / deploy lifecycle (no trust on push)
 


### PR DESCRIPTION
## Summary

Scanned the repo for STALE/DRIFTED user-facing copy, docs, and comments related to **Civitai Apps (App Blocks)** and fixed the one unambiguous, verified item. Prose/doc only — no code identifiers, message types, flags, or behavior touched.

**Headline finding: the App Blocks surface is well-maintained.** The user-facing rebrand ("App Blocks" → "Apps"/"Civitai Apps") is already complete in rendered UI, and the per-account-Buzz code comments already reflect current reality. The "App Blocks" name that remains everywhere is the platform's *internal* name (comments, error-JSON, tests, DB/entity names) — that is not drift and is out of scope by the guardrails.

## Fixed

| File:line | Before → After |
|---|---|
| `docs/features/app-blocks.md:149-150` | "Phase 2/3 postMessage surfaces (`PURCHASE_BUZZ`, `NAVIGATE`, `TRACK_EVENT`) are not implemented in v1." → corrected: `OPEN_BUZZ_PURCHASE`/`GET_BUZZ_BALANCE` and `NAVIGATE` (page host) **have landed**; only `TRACK_EVENT` remains un-bridged. Points readers at `hostHandlerParity.ts` as the SoT. |

Verified against `src/components/AppBlocks/hostHandlerParity.ts`: `OPEN_BUZZ_PURCHASE`/`GET_BUZZ_BALANCE` are `required` in both real hosts; `NAVIGATE` is `required` on `PageBlockHost` (model `IframeHost` intentionally does not bridge it); `TRACK_EVENT` is still not host-bridged (no sink wired).

## Deliberately NOT changed (out of scope / would break tests or behavior)

- **API error-JSON messages** (`'App Blocks not enabled'`, `'App Blocks is restricted to the civitai team'`, etc. across `src/pages/api/**` + routers). These are developer/SDK-facing, and many are asserted verbatim by tests — changing them is behavior/test churn, not user-facing copy.
- **Discord webhook titles/footers, JSON-schema titles, Forgejo repo names** (`'Civitai App Block Manifest'`, `'App Blocks publish-request queue'`, etc.) — ops/developer-facing, not product UI.
- **Internal comments** using "App Blocks" as the platform name across `src/server/**`, `src/components/AppBlocks/**` — accurate internal naming, not drift.

## Ambiguous — left for human review

1. **Token-scope consent label** `packages/civitai-auth/src/token-scope.ts:125` → `'Submit App Blocks for review'`. This *is* user-facing (OAuth consent + API-key UI), so arguably should read "Submit apps for review". Left because: it lives in the shared `@civitai/auth` package **also consumed by the auth hub** (can't verify that surface here), has a verbatim test assertion (`token-scope.constants.test.ts:51`), and mirrors the `AppBlocksSubmit` scope name developers grant via CLI — a rename has real blast radius. Product call needed.
2. **`docs/features/app-blocks.md:8`** describes hosting as `https://blocks.civitai.com/<name>`, which contradicts the doc's own normative section (line 213: the only valid iframe src is the per-app subdomain `https://<slug>.<APPS_DOMAIN>/`). Left because `blocks.civitai.com` is still referenced as a valid origin in the manifest-validator tests, so I couldn't confirm it is fully dead.
3. **`docs/features/app-blocks.md` overall** is a "Phase 1" design snapshot; its `BLOCK_INIT`/message-list section is outdated relative to the current SDK surface (now includes `SUBMIT_WORKFLOW`, `ESTIMATE_WORKFLOW`, `POLL_WORKFLOW`, `CANCEL_WORKFLOW`, `OPEN_CHECKPOINT_PICKER`, `REQUEST_SIGN_IN`/`REQUEST_CONSENT`, etc.). A faithful refresh is a deliberate rewrite needing product input, not a piecemeal drift-fix.
4. **`slot-registry.ts:176` `buzz:read:self` "no reason to read the viewer's balance"** — looked stale vs. `getMyBuzzBalance`, but the code (`blocks.router.ts:2861-2868`) already reconciles it: the scope stays forbidden; balance is exposed via a separate host-mediated proc. Comment is accurate — no change.

## Verification

Doc-only change; no source strings touched, so no typecheck needed. The corrected claim was checked against the live `hostHandlerParity.ts` inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
