### PR TITLE
test(blocks): inherit global env mock in the last 3 blocks-router tests (fix import crash)

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -87,6 +87,11 @@ const TEST_ENV_DEFAULTS: Record<string, unknown> = {
   // Same module-load pLimit() trap in signals/wrapper.ts (default 30).
   SIGNALS_CALL_CONCURRENCY: 30,
   LOGGING: '',
+  // App-blocks (git-push / forgejo / manifest) surfaces read these at module
+  // load. Live here so blocks-router tests don't each override the whole env
+  // mock (which drops the S3/MEILI defaults and crashes at import).
+  FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com',
+  APPS_DOMAIN: 'civit.ai',
   BLOCK_TOKEN_PRIVATE_KEY: TEST_BLOCK_TOKEN_PRIVATE_PEM,
   BLOCK_TOKEN_PUBLIC_KEY: TEST_BLOCK_TOKEN_PUBLIC_PEM,
   DATABASE_URL: 'postgres://user:pass@localhost:5432/db',

--- a/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppRepo.test.ts
@@ -27,13 +27,9 @@ const { mockIsAppBlocksEnabled, mockEnsureForgejoIdentity, mockAddCollaborator }
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
 }));
-vi.mock('~/env/server', () => ({
-  // LOGGING is read by cache-helpers' createLogger at module-eval (the router
-  // now statically imports appBlockReview.service, which imports cache-helpers).
-  // MEILI_CALL_CONCURRENCY is read by meilisearch/client at module-eval
-  // (reached via the router's transitive imports) — pLimit() throws on undefined.
-  env: { FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com', LOGGING: '', MEILI_CALL_CONCURRENCY: 50 },
-}));
+// env comes from the global ~/env/server mock in src/__tests__/setup.ts
+// (complete TEST_ENV_DEFAULTS incl. FORGEJO_PUBLIC_URL / MEILI / S3). Overriding
+// it locally drops those defaults and crashes the heavy import graph at load.
 vi.mock('~/server/services/blocks/dev-git-access.service', () => ({
   ensureForgejoIdentity: mockEnsureForgejoIdentity,
 }));

--- a/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
@@ -24,16 +24,9 @@ const { mockIsAppBlocksEnabled, mockEnsureForgejoIdentity, mockAddCollaborator }
 );
 
 vi.mock('~/server/services/app-blocks-flag', () => ({ isAppBlocksEnabled: mockIsAppBlocksEnabled }));
-vi.mock('~/env/server', () => ({
-  // MEILI_CALL_CONCURRENCY is read by meilisearch/client at module-eval
-  // (reached via the router's transitive imports) — pLimit() throws on undefined.
-  env: {
-    FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com',
-    APPS_DOMAIN: 'civit.ai',
-    LOGGING: '',
-    MEILI_CALL_CONCURRENCY: 50,
-  },
-}));
+// env comes from the global ~/env/server mock in src/__tests__/setup.ts
+// (complete TEST_ENV_DEFAULTS incl. FORGEJO_PUBLIC_URL / APPS_DOMAIN / MEILI /
+// S3). Overriding it locally drops those defaults and crashes at import.
 vi.mock('~/server/services/blocks/dev-git-access.service', () => ({
   ensureForgejoIdentity: mockEnsureForgejoIdentity,
 }));

--- a/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
+++ b/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
@@ -38,16 +38,9 @@ const {
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
 }));
-vi.mock('~/env/server', () => ({
-  // MEILI_CALL_CONCURRENCY is read by meilisearch/client at module-eval
-  // (reached via the router's transitive imports) — pLimit() throws on undefined.
-  env: {
-    FORGEJO_PUBLIC_URL: 'https://forgejo.civitai.com',
-    APPS_DOMAIN: 'civit.ai',
-    LOGGING: '',
-    MEILI_CALL_CONCURRENCY: 50,
-  },
-}));
+// env comes from the global ~/env/server mock in src/__tests__/setup.ts
+// (complete TEST_ENV_DEFAULTS incl. FORGEJO_PUBLIC_URL / APPS_DOMAIN / MEILI /
+// S3). Overriding it locally drops those defaults and crashes at import.
 vi.mock('~/server/services/blocks/forgejo.service', () => ({
   FORGEJO_ORG: 'civitai-apps',
   commitFiles: mockCommitFiles,


### PR DESCRIPTION
## What

The final 3 red unit files — `blocks.router.{getMyAppRepo,getMyForgejoCloneInfo,updateManifest}.test.ts` — fail to *load* (0 assertion failures) because each does `vi.mock('~/env/server', () => ({ env: {…few keys…} }))`, **fully replacing** the global env mock (`src/__tests__/setup.ts`) and discarding its complete `TEST_ENV_DEFAULTS`. Their heavy transitive import graph (`generation → model-file → s3-utils` / `meilisearch`) reads those vars at module load:
```
new URL(env.S3_UPLOAD_ENDPOINT)   // Invalid URL (undefined)
pLimit(env.MEILI_CALL_CONCURRENCY) // Expected concurrency to be a number
```
Adding one env var at a time was whack-a-mole (MEILI → S3 → next layer…).

## Root fix

The passing blocks tests (e.g. `getAppDetail`) **never override env** — they use the complete global mock. These 3 only override it to add `FORGEJO_PUBLIC_URL`/`APPS_DOMAIN` (which the global lacked). So:
- add `FORGEJO_PUBLIC_URL` + `APPS_DOMAIN` to the global `TEST_ENV_DEFAULTS`, and
- **delete** the 3 local `vi.mock('~/env/server')` overrides → they inherit the complete env (S3/MEILI/… included).

Values are identical to what the local mocks provided, so assertions are unchanged. Additive to the global env (app-blocks-specific vars that were previously `undefined`), so no impact on the other ~3900 unit tests — the preview `unit-tests` run confirms.

Completes #2910 (the `REDIS_SYS_KEYS` half). With this, the whole blocks-router suite + unit suite should be fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)