### PR TITLE
test(model3d): fix stale PostingToModel3DCard href assertions (slugged URLs)

### DIFF
--- a/src/components/Model3D/Posting/PostingToModel3DCard.browser.test.tsx
+++ b/src/components/Model3D/Posting/PostingToModel3DCard.browser.test.tsx
@@ -88,7 +88,7 @@ describe('PostingToModel3DCard — durable data-gate', () => {
 
     // Chip rendered the model name + links to the 3D model.
     await expect.element(page.getByText('My Cube')).toBeInTheDocument();
-    const link = document.querySelector('a[href="/3d-models/555"]');
+    const link = document.querySelector('a[href="/3d-models/555/my-cube"]');
     expect(link).not.toBeNull();
 
     // getById ran enabled; getByPostId was NOT enabled even though postId was passed.
@@ -119,7 +119,7 @@ describe('PostingToModel3DCard — durable data-gate', () => {
     renderWithProviders(<PostingToModel3DCard postId={123} />);
 
     await expect.element(page.getByText('Linked From Post')).toBeInTheDocument();
-    const link = document.querySelector('a[href="/3d-models/777"]');
+    const link = document.querySelector('a[href="/3d-models/777/linked-from-post"]');
     expect(link).not.toBeNull();
 
     // The fallback path: getByPostId enabled, getById not.
@@ -150,7 +150,7 @@ describe('PostingToModel3DCard — durable data-gate', () => {
     );
 
     await expect.element(page.getByText('Feed Cube')).toBeInTheDocument();
-    expect(document.querySelector('a[href="/3d-models/4242"]')).not.toBeNull();
+    expect(document.querySelector('a[href="/3d-models/4242/feed-cube"]')).not.toBeNull();
     expect(document.body.textContent).not.toContain('LEAKED');
 
     // getByPostId never enabled even though postId was passed → the ambient call


### PR DESCRIPTION
## What

The only failing component-tests file — `PostingToModel3DCard.browser.test.tsx` (3 tests). #03b11d9b80 (`feat(model3d): add name slugs to 3D model URLs`) changed the card href from `/3d-models/:id` to `getModel3DUrl({id,name})` = `/3d-models/:id/:slug`, but didn't update this test's href assertions:
```
expect(document.querySelector('a[href="/3d-models/555"]')).not.toBeNull()  // → null now
```
(The reported `expected null not to be null` was the querySelector line, not the `getByText` — the model name renders fine; only the href selectors were stale.)

**Fix:** update the 3 href assertions to the slugged URLs (`slugit`: 'My Cube'→`my-cube`, 'Linked From Post'→`linked-from-post`, 'Feed Cube'→`feed-cube`). Test-only.

With this, the component suite returns to green. (Unit suite is already fully green after #2914 — 293 files / 4040 tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)