### PR TITLE
fix(civitai-redis): sysRedis Sentinel reserveClient:true — sidestep node-redis master lease-leak deadlock

### DIFF
--- a/packages/civitai-redis/src/__tests__/sentinel-reserve-client.test.ts
+++ b/packages/civitai-redis/src/__tests__/sentinel-reserve-client.test.ts
@@ -1,0 +1,98 @@
+import { createSentinel } from 'redis';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { createSysRedis } from '../client';
+
+/**
+ * Regression guard for the node-redis Sentinel `reserveClient` sidestep.
+ *
+ * node-redis's Sentinel `_execute` (sentinel/index.js, ~L242-267) reference-counts a SHARED
+ * master lease:
+ *
+ *     this.#masterClientInfo ??= await this.#internal.getClientLease();  // NOT atomic
+ *     clientInfo = this.#masterClientInfo; this.#masterClientCount++;
+ *     // finally: release iff clientInfo === this.#masterClientInfo && --count === 0
+ *
+ * `x ??= await f()` evaluates the nullish check BEFORE awaiting, so a COLD concurrent burst (when
+ * `#masterClientInfo` is undefined — no master command in flight) lets multiple callers all pass
+ * the check and each call `getClientLease()`. The extra leases get orphaned (the release guard's
+ * `===` only ever matches the LAST writer's lease) and pin pool slots → with `masterPoolSize: 2`
+ * the pool exhausts and any code needing a fresh master lease hangs (deadlock). This bug is present
+ * and UNFIXED upstream through at least node-redis 6.1.0 (verified byte-identical in 5.8.3 /
+ * 5.12.1 / 6.1.0) — it is version-independent.
+ *
+ * The sidestep: `reserveClient: true` pins ONE master lease at `connect()` (`#reservedClientInfo`)
+ * and routes every master command through it, fully bypassing the racy `??=` block (sentinel
+ * `_execute` short-circuits to the reserved client and never enters the shared-lease path). The
+ * reserved lease is just an integer index into the master pool, which `transform()` rebuilds
+ * IN PLACE (same ids) on a `switch-master`, so it repoints to the new master on failover — no
+ * failover regression — and it adds ZERO connections (the pool opens `masterPoolSize` master
+ * connections either way; the reserved client is one of them, pinned rather than acquired/released
+ * per burst).
+ *
+ * These tests guard the `client.ts` config so a future edit that flips `reserveClient` back to
+ * `false` (re-arming the cold-burst lease-leak) is caught in CI, without a live Sentinel.
+ */
+
+// Wrap the real `redis` module so `createSentinel` is captured (to inspect the options the factory
+// passes) AND neutralized (no `.connect()` → no TCP sockets / reconnect timers → no open handles).
+// Everything else stays REAL so `getClient`'s downstream wiring (event listeners, withTypeMapping,
+// instrumentation) runs exactly as in prod.
+const sentinelOptsCapture: Array<Record<string, unknown>> = [];
+
+vi.mock('redis', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('redis')>();
+  const noConnect = <T>(client: T): T => {
+    (client as { connect: () => Promise<T> }).connect = () => Promise.resolve(client);
+    return client;
+  };
+  return {
+    ...actual,
+    createSentinel: (opts: Parameters<typeof actual.createSentinel>[0]) => {
+      sentinelOptsCapture.push(opts as unknown as Record<string, unknown>);
+      return noConnect(actual.createSentinel(opts));
+    },
+    createClient: (opts: Parameters<typeof actual.createClient>[0]) =>
+      noConnect(actual.createClient(opts)),
+  };
+});
+
+describe('sysRedis Sentinel — reserveClient lease-leak sidestep', () => {
+  beforeAll(() => {
+    // loadRedisEnv() validates process.env (REDIS_URL / REDIS_SYS_URL are required z.url()).
+    process.env.REDIS_URL ??= 'redis://127.0.0.1:6379';
+    process.env.REDIS_SYS_URL ??= 'redis://127.0.0.1:6379';
+  });
+
+  it('constructs the Sentinel client(s) with reserveClient: true (bypasses the ??= cold-burst leak)', () => {
+    sentinelOptsCapture.length = 0;
+
+    createSysRedis({
+      sysSentinels: '127.0.0.1:26379',
+      sysSentinelName: 'sysmaster',
+      log: () => undefined,
+    });
+
+    // The Sentinel path builds TWO base clients: the serving client and the dedicated `.packed`
+    // buffer base (the withTypeMapping-poisoning fix). BOTH go through the same createSentinel
+    // block, so EVERY Sentinel client must carry the reserveClient sidestep.
+    expect(sentinelOptsCapture.length).toBeGreaterThanOrEqual(1);
+    for (const opts of sentinelOptsCapture) {
+      expect(opts.reserveClient).toBe(true);
+      // Guard the pool geometry the deadlock analysis depends on: masterPoolSize 2 (heartbeat on a
+      // separate TCP from in-flight writes), no replica pool. reserveClient pins one of these two
+      // master connections — it does NOT add a third.
+      expect(opts.masterPoolSize).toBe(2);
+      expect(opts.replicaPoolSize).toBe(0);
+    }
+  });
+
+  it('does NOT set reserveClient on the single-node (dev, no-Sentinel) path', () => {
+    // No sysSentinels → getBaseClient uses createClient (single-node), which has no lease pool and
+    // no reserveClient concept. Documents that the sidestep is scoped to the Sentinel path.
+    sentinelOptsCapture.length = 0;
+
+    const sysRedis = createSysRedis({ log: () => undefined });
+    expect(sysRedis).toBeDefined();
+    expect(sentinelOptsCapture.length).toBe(0);
+  });
+});

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -767,7 +767,21 @@ function getBaseClient(type: 'cache' | 'system') {
         scanInterval: 10_000,
         // Keep sub-client errors local; we surface them via the client-error listener instead.
         passthroughClientErrorEvents: false,
-        reserveClient: false,
+        // reserveClient: true pins ONE master lease at connect() (#reservedClientInfo) and routes
+        // every master command through it, fully bypassing node-redis's racy shared-lease path:
+        //   this.#masterClientInfo ??= await this.#internal.getClientLease();
+        // The `??=` checks nullish BEFORE awaiting, so a COLD concurrent burst (no master command
+        // in flight → #masterClientInfo undefined) lets multiple callers all pass the check and each
+        // call getClientLease(). Extra leases orphan (release guard uses `===`, so only the last
+        // writer's lease is ever returned) and pin pool slots → with masterPoolSize:2 the pool
+        // exhausts and any code needing a fresh master lease hangs (deadlock). This bug is present
+        // and UNFIXED upstream through at least node-redis 6.1.0 (verified byte-identical in
+        // 5.8.3 / 5.12.1 / 6.1.0) — it is version-independent, so pinning the reserved client is the
+        // durable sidestep. The reserved lease is just an integer index into the master pool, which
+        // transform() rebuilds IN PLACE (same ids) on a switch-master, so it repoints to the new
+        // master on failover — no failover regression, and zero net connection delta (the pool still
+        // opens masterPoolSize connections either way).
+        reserveClient: true,
       })
     : isCluster
     ? createCluster({


### PR DESCRIPTION
## The bug (node-redis Sentinel master lease-leak → deadlock)

`@redis/client` Sentinel `_execute` reference-counts a **shared** master lease:

```js
this.#masterClientInfo ??= await this.#internal.getClientLease();  // NOT atomic
clientInfo = this.#masterClientInfo; this.#masterClientCount++;
// finally: release iff clientInfo === this.#masterClientInfo && --count === 0
```

`x ??= await f()` evaluates the nullish check **before** awaiting. So a **cold concurrent burst** — when `#masterClientInfo` is `undefined` (no master command in flight) — lets multiple callers all pass the check and each call `getClientLease()`. The extra leases get **orphaned** (the release guard's `===` only ever matches the *last* writer's lease) and permanently pin pool slots. With our `masterPoolSize: 2` the master pool exhausts and any code needing a fresh master lease **hangs (deadlock)**.

This is present and **unfixed upstream** — verified byte-identical in node-redis **5.8.3 / 5.12.1 / 6.1.0** (`this.#masterClientInfo ??= await ...` still there in 6.1.0). It is version-independent, so a durable sidestep is warranted rather than waiting on an upstream release. (I'll file the upstream bug separately.)

## The fix — `reserveClient: true`

Sentinel `_execute` has an escape hatch: **if `reserveClient` is set, it uses a pre-reserved dedicated master client (`#reservedClientInfo`, leased once at `connect()`) and never touches the racy `??=` path.** Our sysRedis `createSentinel({...})` config had `reserveClient: false`; this flips it to `true` (single line + explanatory comment in `packages/civitai-redis/src/client.ts`).

## Verification against the node-redis source (evidence, not assumption)

1. **connect() reserves once** — `connect()` sets `#reservedClientInfo = await getClientLease()` when `reserveClient`, and `_execute` short-circuits to it for every master command, fully bypassing the `??=` block. ✅
2. **No replica-read change / no throughput regression** — the readonly path (`isReadonly && useReplicas`) is untouched. And under the shared-lease model concurrent master commands already funnel onto ONE memoized lease (`#masterClientInfo`), i.e. one connection — same as the reserved client. No throughput change. ✅
3. **FAILOVER-safe** (the check that could have blocked this) — the reserved lease is just an **integer index** into the master pool. On `switch-master`, `transform()` destroys the old master clients and rebuilds the pool **in place with the same ids** (`for i < masterPoolSize; #masterClients.push(...)`); the `#masterClientQueue` is untouched. `execute()` re-resolves `#masterClients[id]` **per call** and, on a not-ready/READONLY client, calls `#reset()` and retries. So the reserved lease **repoints to the new master** — it does **not** stick to a dead master. (node-redis's own 6.1.0 SCAN-iterator comment corroborates: *"a failover may have landed while waiting … in which case the lease now points to a fresh client on the new master."*) ✅
4. **Zero connection delta** — the pool opens `masterPoolSize` (2) master connections **either way**; `reserveClient` just pins one of them permanently instead of acquiring/releasing it per burst. Plus the 1 sentinel client connection. So flipping this flag adds **0 connections per pod**. It is orthogonal to #2908 (which added the dedicated `.packed` buffer *base* — a second sentinel client; that client also now carries `reserveClient:true`, still +0 vs its pre-existing pool). Given sysRedis's historically-fragile single master, a zero-delta fix is the right property. ✅

## Test

Connection-pool/failover behavior needs a live sentinel, so this adds a **hermetic config-guard** (`sentinel-reserve-client.test.ts`) mirroring the existing `sentinel-buffer-poisoning.test.ts` mock approach: it wraps the `redis` module to capture the options passed to `createSentinel`, drives the real `createSysRedis` factory with sentinel config, and asserts **every** constructed sentinel client carries `reserveClient: true` (+ `masterPoolSize: 2`, `replicaPoolSize: 0`). A second case asserts the single-node dev path sets no sentinel/reserveClient. So a future edit flipping it back is caught in CI.

- `pnpm --filter civitai-redis test` → **95/95 green** (includes the 2 new cases)
- Targeted `tsc --noEmit` on the two changed files → **clean**

## Risk

Reversible (one boolean). No schema/migration. Behavior-preserving per the source trace above; the only behavioral change is that the master lease is held for the client's lifetime instead of per-command — which is exactly the deadlock sidestep.
