### PR TITLE
feat(app-blocks): dev-tunnel P1 control plane (dark)

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1429,6 +1429,16 @@ export const REDIS_SYS_KEYS = {
      * window than the submissions read since this is a write.
      */
     WITHDRAW_RATE_LIMIT: 'system:blocks:withdraw-rate-limit',
+    /**
+     * APP DEV TUNNEL — root prefix for the short-TTL dev-tunnel control-plane
+     * state (credential index, session record, host/user indexes, per-session
+     * spend counter). Sub-keyed as `${DEV_TUNNEL}:cred:<fp>` /
+     * `${DEV_TUNNEL}:session:<id>` / `${DEV_TUNNEL}:host:<host>` /
+     * `${DEV_TUNNEL}:user:<uid>:<blockId>` / `${DEV_TUNNEL}:spend:<id>`. All
+     * carry a hard-TTL EX so they self-expire (dev-tunnel.service.ts). On
+     * `sysRedis`, like the sibling BLOCKS caps/limiters.
+     */
+    DEV_TUNNEL: 'system:blocks:dev-tunnel',
   },
   DOWNLOAD: {
     LIMITS: 'download:limits',

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -757,6 +757,26 @@ export const serverSchema = z
     BUNDLE_S3_BUCKET: z.string().optional(),
     BUNDLE_S3_ACCESS_KEY_ID: z.string().optional(),
     BUNDLE_S3_SECRET_ACCESS_KEY: z.string().optional(),
+
+    // APP DEV TUNNEL (on-site dev via hardened sish tunnel — P1 control plane).
+    // ALL optional so envs without the feature still boot; the feature is dark
+    // behind the `app-blocks-dev-tunnel` Flipt flag regardless.
+    //
+    // APPS_DEV_TUNNEL_SISH_SECRET   shared secret the sish server presents on the
+    //   authz callback (`POST /api/apps/dev-tunnel/authz`) so random internet
+    //   cannot POST it. When UNSET the callback fail-closes (503) — the sish
+    //   integration is inert until it is provisioned (P3).
+    APPS_DEV_TUNNEL_SISH_SECRET: z.string().optional(),
+    // APPS_DEV_TUNNEL_FORWARDAUTH_URL   in-cluster address of the dev-tunnel-gate
+    //   forwardAuth endpoint the ephemeral Middleware points Traefik at. When
+    //   unset, derived from the civitai-web Service default.
+    APPS_DEV_TUNNEL_FORWARDAUTH_URL: z.string().url().optional(),
+    // APPS_DEV_TUNNEL_SISH_BACKEND   the sish HTTP backend the reverse tunnel is
+    //   bound behind, as `service.namespace:port` (or a full URL). Default is the
+    //   P0 sish Service.
+    APPS_DEV_TUNNEL_SISH_BACKEND: z
+      .string()
+      .default('http://sish-http.apps-dev-tunnel.svc.cluster.local:8080'),
   })
   .superRefine((env, ctx) => {
     // Sentinel-mode for the system Redis client requires an explicit master group

--- a/src/pages/api/apps/dev-tunnel/authz.ts
+++ b/src/pages/api/apps/dev-tunnel/authz.ts
@@ -104,9 +104,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // collision alone must never authorize).
   if (!pubKeysMatch(authKey, cred.sshPublicKey)) return deny('pubkey-mismatch');
 
-  // 3b. SINGLE-USE consume — delete the pubkey→credential index so a REPLAYED
-  // authz POST is denied (next lookup misses). Done BEFORE the 200 so a replay
-  // racing us still can't double-authorize past the delete.
+  // 3b. Best-effort single-use consume — delete the pubkey→credential index so a
+  // LATER replay of this POST misses the lookup and is denied.
+  //
+  // NOT ATOMIC (honest): this is GET (step 2) → DEL (here), a TOCTOU window — two
+  // POSTs racing on the same pubkey can BOTH pass step 2 before either DELs, so
+  // both authorize. That is ACCEPTABLE because replay is structurally inert: the
+  // `auth_key` is a PUBLIC key, and by the time sish calls this the SSH transport
+  // has ALREADY proven the client holds the matching PRIVATE key — so a replayer
+  // who lacks the private key can never actually bind the tunnel and gains
+  // nothing by re-authorizing the same userId's own binding. The consume is
+  // belt-and-suspenders (shuts a leaked pubkey out of a fresh authz), NOT the
+  // security boundary.
+  // TODO(P3): make truly single-use via a Lua GETDEL if single-use ever becomes
+  // load-bearing (GETDEL is not exposed on this redis client today).
   await consumeDevTunnelCredential(fingerprint).catch(() => {});
 
   // 4. Authorized. The tunnel⇆userId binding was recorded at mint; return the

--- a/src/pages/api/apps/dev-tunnel/authz.ts
+++ b/src/pages/api/apps/dev-tunnel/authz.ts
@@ -1,0 +1,127 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { env } from '~/env/server';
+import {
+  fingerprintSshPublicKey,
+  pubKeysMatch,
+  sharedSecretMatch,
+} from '~/server/services/blocks/dev-tunnel-session';
+import {
+  consumeDevTunnelCredential,
+  lookupCredentialByFingerprint,
+} from '~/server/services/blocks/dev-tunnel.service';
+
+/**
+ * POST /api/apps/dev-tunnel/authz  (APP DEV TUNNEL — sish authz callback)
+ *
+ * The sish tunnel server's `authentication-key-request-url` target. sish POSTs
+ * `{ auth_key, user, remote_addr }` for each `ssh -R` bind and authorizes the bind
+ * iff we return 200.
+ *
+ * ── THREAT POSTURE ──
+ * `user` and `remote_addr` are ATTACKER-CONTROLLED (they come off the SSH client)
+ * and are used for LOGGING ONLY — never for the authz decision. The decision rests
+ * entirely on the presented `auth_key` (the SSH PUBLIC key) matching a live,
+ * userId-bound tunnel credential minted by `startDevTunnel`:
+ *
+ *   1. SELF-AUTH (shared secret) — this endpoint is NOT session-authed (sish, a
+ *      machine, calls it), so it self-authenticates via a shared secret only sish
+ *      knows (`X-Dev-Tunnel-Secret` == APPS_DEV_TUNNEL_SISH_SECRET, constant-time).
+ *      Unset secret → 503 (the sish integration is inert until provisioned, P3).
+ *      Wrong/absent secret → 401 (random internet cannot POST this).
+ *   2. FINGERPRINT LOOKUP — index the credential by sha256(normalized pubkey).
+ *   3. CONSTANT-TIME PUBKEY COMPARE — the authoritative check: the full stored
+ *      pubkey must timing-safe-equal the presented `auth_key`. A fingerprint
+ *      collision alone can never authorize.
+ *   4. EXPIRY / REPLAY — the credential carries a hard-TTL EX in Redis, so it
+ *      self-expires; lookupCredentialByFingerprint additionally rejects a past
+ *      hardExpiresAt. Replay of this POST is inert: `auth_key` is a PUBLIC key, so
+ *      an attacker without the matching PRIVATE key cannot actually bind the
+ *      tunnel; a replay only re-authorizes the SAME userId's own binding.
+ *
+ * On success we return the sish-expected 200 (the tunnel⇆userId binding was
+ * already recorded at mint via the host index); on any failure a 403 `auth:false`.
+ */
+
+export const config = {
+  api: {
+    // Tiny JSON body ({ auth_key, user, remote_addr }).
+    bodyParser: { sizeLimit: '8kb' },
+  },
+};
+
+function firstHeader(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ auth: false, error: 'method not allowed' });
+    return;
+  }
+
+  // 1. Self-auth via the shared secret. Unset → the sish integration isn't
+  // provisioned yet (P3) → 503 (inert, fail-closed). Present but mismatched →
+  // 401 (random internet cannot POST this).
+  const configured = env.APPS_DEV_TUNNEL_SISH_SECRET;
+  if (!configured) {
+    res.status(503).json({ auth: false, error: 'dev tunnel not configured' });
+    return;
+  }
+  const presented = firstHeader(req.headers['x-dev-tunnel-secret']);
+  if (!sharedSecretMatch(presented, configured)) {
+    res.status(401).json({ auth: false, error: 'unauthorized' });
+    return;
+  }
+
+  const body = (req.body ?? {}) as { auth_key?: unknown; user?: unknown; remote_addr?: unknown };
+  const authKey = typeof body.auth_key === 'string' ? body.auth_key : '';
+  // user / remote_addr are ATTACKER-CONTROLLED — logged only, never authz'd on.
+  const claimedUser = typeof body.user === 'string' ? body.user.slice(0, 128) : '';
+  const remoteAddr = typeof body.remote_addr === 'string' ? body.remote_addr.slice(0, 64) : '';
+
+  const deny = (why: string) => {
+    // eslint-disable-next-line no-console
+    console.log(
+      JSON.stringify({
+        event: 'app-blocks.dev-tunnel.authz.deny',
+        reason: why,
+        claimedUser,
+        remoteAddr,
+      })
+    );
+    res.status(403).json({ auth: false });
+  };
+
+  // 2. Fingerprint the presented pubkey → index the credential.
+  const fingerprint = fingerprintSshPublicKey(authKey);
+  if (!fingerprint) return deny('malformed-pubkey');
+
+  const cred = await lookupCredentialByFingerprint(fingerprint).catch(() => null);
+  if (!cred) return deny('no-credential'); // absent or expired
+
+  // 3. AUTHORITATIVE constant-time compare of the FULL pubkey (a fingerprint
+  // collision alone must never authorize).
+  if (!pubKeysMatch(authKey, cred.sshPublicKey)) return deny('pubkey-mismatch');
+
+  // 3b. SINGLE-USE consume — delete the pubkey→credential index so a REPLAYED
+  // authz POST is denied (next lookup misses). Done BEFORE the 200 so a replay
+  // racing us still can't double-authorize past the delete.
+  await consumeDevTunnelCredential(fingerprint).catch(() => {});
+
+  // 4. Authorized. The tunnel⇆userId binding was recorded at mint; return the
+  // sish-expected 200. (The exact 200 body shape is confirmed against the sish
+  // image at P3; sish authorizes on the 2xx status, the JSON is advisory.)
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({
+      event: 'app-blocks.dev-tunnel.authz.allow',
+      sessionId: cred.sessionId,
+      userId: cred.userId,
+      blockId: cred.blockId,
+      host: cred.host,
+      remoteAddr,
+    })
+  );
+  res.status(200).json({ auth: true, host: cred.host });
+}

--- a/src/pages/api/internal/dev-tunnel-gate.ts
+++ b/src/pages/api/internal/dev-tunnel-gate.ts
@@ -12,18 +12,22 @@ import { verifyDevTunnelAccessToken } from '~/server/services/blocks/dev-tunnel-
  * authenticated parent mints a signed, short-TTL, AUTHOR-bound ENTRY token (see
  * `dev-tunnel-session.ts`) and injects it into the iframe `src` as `?dev=<token>`.
  *
- * ── LOAD-BEARING INVARIANT (T3) ──
- * A NAKED request to `dev-<host>.<APPS_DOMAIN>` with NO / expired / wrong-user /
- * host-mismatched token is DENIED (401) BEFORE it can reach the tunnel → the dev's
- * localhost is never exposed to an unauthenticated visitor. The `dev-<16hex>` host
- * is itself a ~64-bit secret on top of this gate (defence for T1).
+ * ── WHAT THE ENTRY TOKEN ACTUALLY GATES (T3, stated honestly) ──
+ * The entry token gates the ENTRY DOCUMENT ONLY. A NAKED ENTRY request (no /
+ * expired / wrong-user / host-mismatched token) is denied 401 — so a visitor who
+ * knows the host cannot LOAD the dev page. But NON-ENTRY subresources
+ * (Sec-Fetch-Dest empty/script/style/fetch/xhr/image/…) pass through with NO
+ * token. So anyone who LEARNS the `dev-<16hex>` host can reach the dev's
+ * localhost UNAUTHENTICATED for the session TTL by issuing subresource-shaped
+ * requests. Those subresources are protected by HOST-SECRECY only — the
+ * unguessable ~64-bit `dev-<16hex>` host — NOT by the token. This is the
+ * IDENTICAL accepted tradeoff as `mod-gate.ts` (Traefik does not forward a 2xx
+ * auth response's Set-Cookie, so a per-subresource cookie gate can't be set), and
+ * the victim of a leaked host is the AUTHOR'S OWN machine (author-only sessions).
  *
  * ── ENTRY-GATE-ONLY (mirrors mod-gate exactly) ──
  * Authorizes ONLY the ENTRY document/iframe request (the one that can carry the
- * `dev` token) and ALLOWS subresources through — Traefik does not forward a 2xx
- * auth response's Set-Cookie, so a per-subresource cookie gate can't be set (the
- * documented review-sandbox tradeoff). Residual risk is the same + accepted: the
- * token gates the ENTRY document, and the host is an unguessable ephemeral secret.
+ * `dev` token) and ALLOWS subresources through, per the tradeoff above.
  *
  *   - ENTRY (Sec-Fetch-Dest document/iframe/frame/nested-document, OR ABSENT →
  *     treated as entry, fail-safe): require a valid `dev` token bound to
@@ -64,9 +68,10 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     return;
   }
 
-  // SUBRESOURCE → allow (see the header comment: the 2xx Set-Cookie subresource
-  // gate can't be set, accepted tradeoff — the ENTRY `dev` token still keeps
-  // unauthenticated visitors out).
+  // SUBRESOURCE → allow with NO token (see the header comment). This means a
+  // caller who KNOWS the `dev-<16hex>` host reaches the tunnel unauthenticated via
+  // subresource-shaped requests — those are protected by HOST-SECRECY only, not
+  // the token. Accepted tradeoff, identical to mod-gate.ts.
   const isEntry = secFetchDest == null || ENTRY_DESTS.has(secFetchDest);
   if (!isEntry) {
     res.status(200).json({ ok: true, via: 'subresource' });
@@ -82,6 +87,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     return;
   }
 
-  // Naked / invalid / expired / wrong-user / host-mismatched token → 401. T3.
+  // Naked / invalid / expired / wrong-user / host-mismatched ENTRY request → 401.
+  // (Gates the ENTRY DOCUMENT only — see the header comment on subresources.)
   res.status(401).json({ error: 'Dev tunnel session required' });
 }

--- a/src/pages/api/internal/dev-tunnel-gate.ts
+++ b/src/pages/api/internal/dev-tunnel-gate.ts
@@ -1,0 +1,87 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { verifyDevTunnelAccessToken } from '~/server/services/blocks/dev-tunnel-session';
+
+/**
+ * GET/ANY /api/internal/dev-tunnel-gate  (APP DEV TUNNEL — edge forwardAuth)
+ *
+ * A Traefik `forwardAuth` target guarding the ephemeral dev-tunnel hosts
+ * (`dev-<16hex>.<APPS_DOMAIN>`). This is the author-bound sibling of the mod
+ * review-sandbox gate (`/api/internal/mod-gate`): the dev-tunnel host is a
+ * CROSS-ORIGIN iframe embedded inside the authenticated `civitai.com/apps/dev`
+ * page, so the civitai session cookie is NOT sent to `*.civit.ai`. The already-
+ * authenticated parent mints a signed, short-TTL, AUTHOR-bound ENTRY token (see
+ * `dev-tunnel-session.ts`) and injects it into the iframe `src` as `?dev=<token>`.
+ *
+ * ── LOAD-BEARING INVARIANT (T3) ──
+ * A NAKED request to `dev-<host>.<APPS_DOMAIN>` with NO / expired / wrong-user /
+ * host-mismatched token is DENIED (401) BEFORE it can reach the tunnel → the dev's
+ * localhost is never exposed to an unauthenticated visitor. The `dev-<16hex>` host
+ * is itself a ~64-bit secret on top of this gate (defence for T1).
+ *
+ * ── ENTRY-GATE-ONLY (mirrors mod-gate exactly) ──
+ * Authorizes ONLY the ENTRY document/iframe request (the one that can carry the
+ * `dev` token) and ALLOWS subresources through — Traefik does not forward a 2xx
+ * auth response's Set-Cookie, so a per-subresource cookie gate can't be set (the
+ * documented review-sandbox tradeoff). Residual risk is the same + accepted: the
+ * token gates the ENTRY document, and the host is an unguessable ephemeral secret.
+ *
+ *   - ENTRY (Sec-Fetch-Dest document/iframe/frame/nested-document, OR ABSENT →
+ *     treated as entry, fail-safe): require a valid `dev` token bound to
+ *     X-Forwarded-Host → 200 + X-Dev-User-Id, else 401.
+ *   - SUBRESOURCE (any other Sec-Fetch-Dest): 200 (allow).
+ *   - Missing X-Forwarded-Host → 401 (fail-closed).
+ */
+
+/** Sec-Fetch-Dest values that mean "top-level document / iframe being LOADED". An
+ *  ABSENT header is treated as entry (fail-safe). */
+const ENTRY_DESTS = new Set(['document', 'iframe', 'frame', 'nested-document']);
+
+function firstHeader(v: string | string[] | undefined): string | undefined {
+  return Array.isArray(v) ? v[0] : v;
+}
+
+/** Extract the `dev` query param from the forwarded original URI. */
+function extractDevToken(forwardedUri: string | undefined): string | undefined {
+  if (!forwardedUri) return undefined;
+  const q = forwardedUri.indexOf('?');
+  if (q < 0) return undefined;
+  try {
+    const params = new URLSearchParams(forwardedUri.slice(q + 1));
+    return params.get('dev') ?? undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const forwardedHost = firstHeader(req.headers['x-forwarded-host']);
+  const forwardedUri = firstHeader(req.headers['x-forwarded-uri']);
+  const secFetchDest = firstHeader(req.headers['sec-fetch-dest']);
+
+  // Fail-closed: without the dev host we can't bind/verify anything.
+  if (!forwardedHost) {
+    res.status(401).json({ error: 'Missing dev host' });
+    return;
+  }
+
+  // SUBRESOURCE → allow (see the header comment: the 2xx Set-Cookie subresource
+  // gate can't be set, accepted tradeoff — the ENTRY `dev` token still keeps
+  // unauthenticated visitors out).
+  const isEntry = secFetchDest == null || ENTRY_DESTS.has(secFetchDest);
+  if (!isEntry) {
+    res.status(200).json({ ok: true, via: 'subresource' });
+    return;
+  }
+
+  // ENTRY → require a valid `dev` token bound to this host.
+  const token = extractDevToken(forwardedUri);
+  const result = verifyDevTunnelAccessToken(token, forwardedHost);
+  if (result.ok && result.userId != null) {
+    res.setHeader('X-Dev-User-Id', String(result.userId));
+    res.status(200).json({ ok: true, via: 'token' });
+    return;
+  }
+
+  // Naked / invalid / expired / wrong-user / host-mismatched token → 401. T3.
+  res.status(401).json({ error: 'Dev tunnel session required' });
+}

--- a/src/pages/apps/dev/[blockId].tsx
+++ b/src/pages/apps/dev/[blockId].tsx
@@ -1,0 +1,227 @@
+import { Alert, Box, Code, Stack, Text, Title, useComputedColorScheme } from '@mantine/core';
+import { useMemo } from 'react';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { Meta } from '~/components/Meta/Meta';
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+import { useBlockToken } from '~/components/AppBlocks/useBlockToken';
+import type { BlockInstall, PageContext } from '~/components/AppBlocks/types';
+import { BlockRegistry } from '~/server/services/block-registry.service';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+
+/**
+ * APP DEV TUNNEL — dedicated author-only dev route: `/apps/dev/<blockId>`.
+ *
+ * NEVER the public `/apps/run/<slug>` path. Renders the caller's OWN app (at ANY
+ * status) inside the REAL production `PageBlockHost`, but with the iframe pointing
+ * at their LOCAL dev server via the ephemeral `dev-<16hex>.<APPS_DOMAIN>` tunnel
+ * host — a prod-fidelity inner-dev-loop.
+ *
+ * DARK / FLAG-GATED: requires `features.appBlocks` AND `features.appBlocksAuthor`
+ * AND the `app-blocks-dev-tunnel` kill-switch (base off). When any is missing the
+ * SSR returns notFound (fail-closed) — the route is invisible/un-enumerable until
+ * the flag widens.
+ *
+ * SECURITY:
+ *   - unauthenticated → redirect to login.
+ *   - non-owner of `blockId` → notFound (no ownership/existence oracle).
+ *   - `iframeSrc` is SERVER-DERIVED from the assigned tunnel host ONLY, validated
+ *     against `^dev-[a-f0-9]{16}\.<APPS_DOMAIN>$` — never reflected from client
+ *     input (T6). It can never be a `<slug>.civit.ai` deployed bundle host.
+ *   - a ROUTE-SCOPED CSP (`frame-src https://<dev-host>`) is set on THIS response
+ *     only — it never widens the global CSP (T7).
+ */
+
+interface DevTunnelProps {
+  appBlockId: string;
+  blockId: string;
+  appId: string;
+  appName: string;
+  pageTitle: string;
+  status: string;
+  trustTier: 'unverified' | 'verified' | 'internal';
+  sandbox: string;
+  scopes: string[];
+  /** Set ONLY when an active tunnel exists — `https://<dev-host>/?dev=<token>`. */
+  iframeSrc: string | null;
+  /** The assigned dev host (for the "no active tunnel" copy). */
+  host: string | null;
+}
+
+export const getServerSideProps = createServerSideProps<DevTunnelProps>({
+  useSession: true,
+  resolver: async ({ features, ctx, session }) => {
+    // GATE FIRST, fail-closed. Author capability + the dev-tunnel kill-switch.
+    if (!features?.appBlocks || !features?.appBlocksAuthor) {
+      return { notFound: true };
+    }
+    const user = session?.user;
+    if (!user) {
+      return {
+        redirect: {
+          destination: `/login?returnUrl=${encodeURIComponent(ctx.resolvedUrl)}`,
+          permanent: false,
+        },
+      };
+    }
+    const { isAppBlocksDevTunnelEnabled } = await import('~/server/services/app-blocks-flag');
+    if (!(await isAppBlocksDevTunnelEnabled({ user }))) {
+      return { notFound: true };
+    }
+
+    const rawBlockId = ctx.params?.blockId;
+    const blockId =
+      typeof rawBlockId === 'string' ? rawBlockId : Array.isArray(rawBlockId) ? rawBlockId[0] : '';
+    if (!blockId) return { notFound: true };
+
+    // Ownership-scoped resolve (any status). null for a foreign/absent app → the
+    // SAME notFound (no oracle). This can NEVER resolve a deployed bundle host.
+    const app = await BlockRegistry.resolveDevPageBlockForAuthor(blockId, user.id);
+    if (!app) return { notFound: true };
+
+    // Resolve the caller's active tunnel for this block (started by the CLI).
+    const { getActiveDevTunnel } = await import('~/server/services/blocks/dev-tunnel.service');
+    const { signDevTunnelAccessToken, isValidDevHost } = await import(
+      '~/server/services/blocks/dev-tunnel-session'
+    );
+    const { env } = await import('~/env/server');
+
+    const tunnel = await getActiveDevTunnel(user.id, blockId);
+
+    let iframeSrc: string | null = null;
+    let host: string | null = null;
+    if (tunnel && isValidDevHost(tunnel.host, env.APPS_DOMAIN)) {
+      host = tunnel.host;
+      // Mint a FRESH short-TTL, author-bound entry token and inject it into the
+      // iframe src. The `*.civit.ai` edge forwardAuth verifies it on the ENTRY
+      // document (T3). A fresh token is minted on every SSR render so the live
+      // iframe never serves a stale one.
+      const token = signDevTunnelAccessToken({ userId: user.id, host });
+      iframeSrc = `https://${host}/?dev=${encodeURIComponent(token)}`;
+
+      // ROUTE-SCOPED CSP (T7). Constrain THIS response's frame-src to exactly the
+      // assigned dev host — a tightening scoped to this route only; it does NOT
+      // touch the global CSP (set in next.config headers()). CSP host-sources do
+      // not support a `dev-*` LABEL wildcard (only full `*.civit.ai` subdomain
+      // wildcards, which would be far broader), so the EXACT host is used — the
+      // tightest valid form.
+      ctx.res.setHeader('Content-Security-Policy', `frame-src https://${host}`);
+    }
+
+    return {
+      props: {
+        appBlockId: app.appBlockId,
+        blockId: app.blockId,
+        appId: app.appId,
+        appName: app.name,
+        pageTitle: app.pageTitle,
+        status: app.status,
+        trustTier: app.trustTier,
+        sandbox: app.sandbox,
+        scopes: app.scopes,
+        iframeSrc,
+        host,
+      },
+    };
+  },
+});
+
+export default function DevTunnelPage(props: DevTunnelProps) {
+  const { appBlockId, blockId, appId, appName, iframeSrc, sandbox, trustTier, scopes, host } = props;
+  const currentUser = useCurrentUser();
+  const colorScheme = useComputedColorScheme('dark');
+  const theme: 'light' | 'dark' = colorScheme === 'dark' ? 'dark' : 'light';
+
+  // Synthetic page instance id — same shape as the prod page mint path.
+  const blockInstanceId = `page_${appBlockId}`;
+
+  const install = useMemo<BlockInstall>(
+    () => ({
+      blockInstanceId,
+      blockId,
+      appId,
+      appBlockId,
+      manifest: {
+        name: appName,
+        scopes,
+        iframe: {
+          src: iframeSrc ?? '',
+          minHeight: 200,
+          maxHeight: null,
+          resizable: true,
+          sandbox,
+        },
+      },
+      publisherSettings: {},
+      enabled: true,
+      renderMode: 'iframe',
+      trustTier,
+    }),
+    [appBlockId, appId, appName, blockId, blockInstanceId, iframeSrc, sandbox, scopes, trustTier]
+  );
+
+  const context = useMemo<PageContext>(
+    () => ({
+      slotId: 'app.page',
+      entityType: 'none',
+      slug: blockId,
+      subPath: '',
+      viewerUserId: currentUser?.id ?? null,
+      viewerUsername: currentUser?.username ?? null,
+      theme,
+    }),
+    [blockId, currentUser, theme]
+  );
+
+  const { token, expiresAt, needsConsent, missingScopes, domain, maxBrowsingLevel, error, refresh } =
+    useBlockToken(install, context);
+
+  const viewer = currentUser
+    ? { id: currentUser.id, username: currentUser.username ?? null }
+    : null;
+
+  return (
+    <>
+      <Meta title={`${appName} — Dev tunnel — Civitai Apps`} deIndex />
+      <Box style={{ width: '100%' }}>
+        {!iframeSrc ? (
+          <Stack p="md" gap="sm" style={{ maxWidth: 720, margin: '0 auto' }}>
+            <Title order={3}>No active dev tunnel</Title>
+            <Text size="sm">
+              Start your local dev server and open a tunnel for <Code>{blockId}</Code>, then reload
+              this page:
+            </Text>
+            <Code block>civitai app dev:tunnel</Code>
+            <Alert color="yellow" variant="light">
+              This page renders your LOCAL app inside the real Civitai host. Only you can see it —
+              the tunnel is bound to your account.
+            </Alert>
+          </Stack>
+        ) : (
+          <PageBlockHost
+            appBlockId={appBlockId}
+            blockId={blockId}
+            appId={appId}
+            blockInstanceId={blockInstanceId}
+            appName={appName}
+            iframeSrc={iframeSrc}
+            sandbox={sandbox}
+            trustTier={trustTier}
+            slug={blockId}
+            token={token}
+            expiresAt={expiresAt}
+            declaredScopes={scopes}
+            missingScopes={missingScopes}
+            needsConsent={needsConsent}
+            domain={domain}
+            maxBrowsingLevel={maxBrowsingLevel}
+            tokenError={error != null}
+            viewer={viewer}
+            theme={theme}
+            onConsentGranted={refresh}
+            onRetryToken={refresh}
+          />
+        )}
+      </Box>
+    </>
+  );
+}

--- a/src/server/prom/dev-tunnel.metrics.ts
+++ b/src/server/prom/dev-tunnel.metrics.ts
@@ -1,0 +1,82 @@
+import client from 'prom-client';
+import { PROM_PREFIX } from '@civitai/telemetry/client';
+
+/**
+ * APP DEV TUNNEL metrics (in-cluster Prometheus, per the design's Revision #3 —
+ * Grafana stack, not ClickHouse/Axiom). Registered on the DEFAULT prom-client
+ * registry (the request webpack graph) so `/api/metrics` scrapes them — the
+ * tunnel lifecycle runs inside the tRPC request handlers, which live in that
+ * graph (same as `civitai_app_http_errors_total`).
+ *
+ * Pinned on globalThis so an HMR re-eval / second request-graph eval reuse the
+ * one instance instead of throwing prom-client's duplicate-registration error
+ * (same trap documented for the http-error counter + instrumentationRegistry).
+ *
+ * Signals:
+ *   - `civitai_app_dev_tunnels_active` (Gauge) — currently-live dev tunnels. inc
+ *     on a successful mint, dec on teardown/reap. Per-pod; sum across pods for the
+ *     fleet count. A non-negative floor is enforced so an over-decrement (double
+ *     teardown) can't drive it below 0.
+ *   - `civitai_app_dev_tunnel_mints_total` (Counter) — cumulative mints.
+ *   - `civitai_app_dev_tunnel_teardowns_total{reason}` (Counter) — cumulative
+ *     teardowns, labelled `stop` (explicit) | `reap-idle` | `reap-maxttl`.
+ */
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __civitaiDevTunnelMetrics:
+    | {
+        active: client.Gauge<string>;
+        mints: client.Counter<string>;
+        teardowns: client.Counter<string>;
+      }
+    | undefined;
+}
+
+const metrics =
+  globalThis.__civitaiDevTunnelMetrics ??
+  (globalThis.__civitaiDevTunnelMetrics = {
+    active: new client.Gauge({
+      name: PROM_PREFIX + 'dev_tunnels_active',
+      help: 'Currently-live App Blocks dev tunnels (per pod). inc on mint, dec on teardown/reap.',
+    }),
+    mints: new client.Counter({
+      name: PROM_PREFIX + 'dev_tunnel_mints_total',
+      help: 'Cumulative App Blocks dev-tunnel mints (startDevTunnel). Monotonic; use rate().',
+    }),
+    teardowns: new client.Counter({
+      name: PROM_PREFIX + 'dev_tunnel_teardowns_total',
+      help: 'Cumulative App Blocks dev-tunnel teardowns by reason (stop|reap-idle|reap-maxttl).',
+      labelNames: ['reason'],
+    }),
+  });
+
+export type DevTunnelTeardownReason = 'stop' | 'reap-idle' | 'reap-maxttl';
+
+/** Record a successful mint: bump the active gauge + the mint counter. Never
+ *  throws — a telemetry failure must not break the mint. */
+export function recordDevTunnelMint(): void {
+  try {
+    metrics.active.inc();
+    metrics.mints.inc();
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+/** Record a teardown: decrement the active gauge (floored at 0) + bump the
+ *  teardown counter with the reason label. Never throws. */
+export function recordDevTunnelTeardown(reason: DevTunnelTeardownReason): void {
+  try {
+    metrics.teardowns.inc({ reason });
+    metrics.active.dec();
+    // prom-client Gauge has no hard floor; guard against a double-teardown driving
+    // the gauge negative by reading it back — cheap + per-teardown only.
+    // (get() returns the sync snapshot for a plain Gauge with no labels.)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const val = (metrics.active as any).hashMap?.['']?.value;
+    if (typeof val === 'number' && val < 0) metrics.active.set(0);
+  } catch {
+    /* never throw from telemetry */
+  }
+}

--- a/src/server/routers/__tests__/blocks.router.devTunnel.test.ts
+++ b/src/server/routers/__tests__/blocks.router.devTunnel.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * APP DEV TUNNEL — router authz matrix for startDevTunnel / stopDevTunnel /
+ * devTunnelStatus (appDeveloperProcedure + enforceAppBlocksFlag + the
+ * `app-blocks-dev-tunnel` kill-switch + ownership):
+ *
+ *   - non-author (plain non-mod, no cohort) → FORBIDDEN (author capability off).
+ *   - author + dev-tunnel flag OFF → FORBIDDEN.
+ *   - author + flag ON + NON-owner of blockId → NOT_FOUND (no oracle).
+ *   - author + flag ON + owner → mints (service called with the caller's userId).
+ */
+
+const {
+  mockIsAppBlocksEnabled,
+  mockIsDevTunnelEnabled,
+  mockResolveDev,
+  mockStart,
+  mockStop,
+  mockStopForUserBlock,
+  mockGetActive,
+} = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(async () => true),
+  mockIsDevTunnelEnabled: vi.fn(async () => true),
+  mockResolveDev: vi.fn(),
+  mockStart: vi.fn(),
+  mockStop: vi.fn(async () => true),
+  mockStopForUserBlock: vi.fn(async () => true),
+  mockGetActive: vi.fn(async () => null),
+}));
+
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    resolveDevPageBlockForAuthor: mockResolveDev,
+  },
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksDevTunnelEnabled: mockIsDevTunnelEnabled,
+}));
+vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
+  startDevTunnel: mockStart,
+  stopDevTunnel: mockStop,
+  stopDevTunnelForUserBlock: mockStopForUserBlock,
+  getActiveDevTunnel: mockGetActive,
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlock: { findUnique: vi.fn() } },
+  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return { ...actual, redis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) } };
+});
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: vi.fn(),
+  parseSubjectUserId: vi.fn(),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({ getOrchestratorToken: vi.fn() }));
+vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
+  buildGenerationContext: vi.fn(),
+  createWorkflowStepsFromGraphInput: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({ auditPromptServer: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function authedCtx(userId: number, isModerator = true) {
+  return {
+    acceptableOrigin: true,
+    user: { id: userId, isModerator, onboarding: 0x1f } as never,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+const OWN_APP = {
+  appBlockId: 'apb_dev',
+  blockId: 'my-app',
+  appId: 'appblk-my-app',
+  status: 'pending',
+  trustTier: 'unverified',
+  name: 'My App',
+  pageTitle: 'My App',
+  sandbox: '',
+  scopes: [],
+  contentRating: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAppBlocksEnabled.mockResolvedValue(true);
+  mockIsDevTunnelEnabled.mockResolvedValue(true);
+  mockResolveDev.mockResolvedValue(OWN_APP);
+  mockStart.mockResolvedValue({
+    sessionId: 'bki_s',
+    host: 'dev-0123456789abcdef.civit.ai',
+    url: 'https://civitai.com/apps/dev/my-app',
+    expiresAt: 9e9,
+    spendCapBuzz: 5000,
+  });
+});
+
+const PUBKEY = 'ssh-ed25519 AAAAExampleKey dev@laptop';
+const input = { blockId: 'my-app', sshPublicKey: PUBKEY };
+
+describe('startDevTunnel — authz matrix', () => {
+  it('non-author (plain non-mod, capability off) → FORBIDDEN, never mints', async () => {
+    const caller = blocksRouter.createCaller(authedCtx(42, false) as never);
+    await expect(caller.startDevTunnel(input)).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('author + dev-tunnel flag OFF → FORBIDDEN, never mints', async () => {
+    mockIsDevTunnelEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    await expect(caller.startDevTunnel(input)).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('author + flag ON + NON-owner of blockId → NOT_FOUND (no oracle), never mints', async () => {
+    mockResolveDev.mockResolvedValue(null); // foreign/absent app
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    await expect(caller.startDevTunnel(input)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('author + flag ON + OWNER → mints, bound to the CALLER’s userId', async () => {
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    const res = await caller.startDevTunnel(input);
+    expect(res.host).toMatch(/^dev-[a-f0-9]{16}\.civit\.ai$/);
+    expect(mockStart).toHaveBeenCalledWith({
+      userId: 100,
+      blockId: 'my-app',
+      sshPublicKey: PUBKEY,
+    });
+    // ownership resolve was scoped to the caller
+    expect(mockResolveDev).toHaveBeenCalledWith('my-app', 100, { db: 'write' });
+  });
+});
+
+describe('stopDevTunnel / devTunnelStatus', () => {
+  it('stopDevTunnel by sessionId → ownership-checked service call', async () => {
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    const res = await caller.stopDevTunnel({ sessionId: 'bki_s' });
+    expect(res).toEqual({ ok: true, stopped: true });
+    expect(mockStop).toHaveBeenCalledWith(100, 'bki_s');
+  });
+
+  it('stopDevTunnel flag OFF → FORBIDDEN', async () => {
+    mockIsDevTunnelEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    await expect(caller.stopDevTunnel({ blockId: 'my-app' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+  });
+
+  it('devTunnelStatus returns active:false when no tunnel', async () => {
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    expect(await caller.devTunnelStatus({ blockId: 'my-app' })).toEqual({ active: false });
+  });
+
+  it('devTunnelStatus returns the live session for the owner', async () => {
+    mockGetActive.mockResolvedValue({
+      sessionId: 'bki_s',
+      userId: 100,
+      blockId: 'my-app',
+      host: 'dev-0123456789abcdef.civit.ai',
+      hardExpiresAt: 9e9,
+      spendCapBuzz: 5000,
+    });
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    const res = await caller.devTunnelStatus({ blockId: 'my-app' });
+    expect(res).toMatchObject({ active: true, host: 'dev-0123456789abcdef.civit.ai' });
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -991,7 +991,11 @@ export const blocksRouter = router({
       try {
         return await startDevTunnel({
           userId: ctx.user.id,
-          blockId: input.blockId,
+          // Belt-and-suspenders: key the tunnel state off the RESOLVED, canonical
+          // block_id (app.blockId), never the raw client input. Safe today only
+          // because the ownership resolve above ran first — using the resolved
+          // value makes that independent of input normalization.
+          blockId: app.blockId,
           sshPublicKey: input.sshPublicKey,
         });
       } catch (err) {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -954,6 +954,110 @@ export const blocksRouter = router({
     }),
 
   /**
+   * APP DEV TUNNEL — start an on-site dev tunnel for one of the caller's OWN
+   * apps. Mints a pubkey-bound tunnel credential + an unguessable
+   * `dev-<16hex>.<APPS_DOMAIN>` host, and renders the ephemeral Traefik route.
+   *
+   * GATES (all server-side, fail-closed): `appDeveloperProcedure` (author cap) +
+   * `enforceAppBlocksFlag` (app-blocks-enabled) — the dual-flag — PLUS the
+   * `app-blocks-dev-tunnel` kill-switch (base off → dark) PLUS the caller must OWN
+   * `blockId` (resolveDevPageBlockForAuthor → null for a foreign/absent app → the
+   * SAME bare NOT_FOUND, no ownership oracle). DARK until the flag is on.
+   */
+  startDevTunnel: appDeveloperProcedure
+    .use(enforceAppBlocksFlag)
+    .input(
+      z.object({
+        blockId: z.string().min(1).max(64),
+        // The CLI's ephemeral SSH public key (raw OpenSSH line). Bounded so a
+        // determined caller can't push parse pressure; a real ed25519/rsa pubkey
+        // is well under 2kb.
+        sshPublicKey: z.string().min(1).max(4096),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { isAppBlocksDevTunnelEnabled } = await import('~/server/services/app-blocks-flag');
+      if (!(await isAppBlocksDevTunnelEnabled({ user: ctx.user }))) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Dev tunnels are not available' });
+      }
+      // Ownership gate — resolve the caller's OWN app at any status. null → the
+      // bare NOT_FOUND (no existence/ownership oracle, mirrors dev-token).
+      const app = await BlockRegistry.resolveDevPageBlockForAuthor(input.blockId, ctx.user.id, {
+        db: 'write',
+      });
+      if (!app) throw throwNotFoundError('App not found');
+      const { startDevTunnel } = await import('~/server/services/blocks/dev-tunnel.service');
+      try {
+        return await startDevTunnel({
+          userId: ctx.user.id,
+          blockId: input.blockId,
+          sshPublicKey: input.sshPublicKey,
+        });
+      } catch (err) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
+      }
+    }),
+
+  /**
+   * APP DEV TUNNEL — stop the caller's dev tunnel (revokes the credential +
+   * entry-token binding + deletes the Traefik route). Idempotent. By `sessionId`
+   * (from startDevTunnel) OR `blockId`. Ownership-checked server-side: a caller
+   * can never tear down another author's tunnel. Same gates as startDevTunnel.
+   */
+  stopDevTunnel: appDeveloperProcedure
+    .use(enforceAppBlocksFlag)
+    .input(
+      z
+        .object({
+          sessionId: z.string().min(1).max(128).optional(),
+          blockId: z.string().min(1).max(64).optional(),
+        })
+        .refine((v) => !!v.sessionId || !!v.blockId, {
+          message: 'one of sessionId or blockId is required',
+        })
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { isAppBlocksDevTunnelEnabled } = await import('~/server/services/app-blocks-flag');
+      if (!(await isAppBlocksDevTunnelEnabled({ user: ctx.user }))) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Dev tunnels are not available' });
+      }
+      const { stopDevTunnel, stopDevTunnelForUserBlock } = await import(
+        '~/server/services/blocks/dev-tunnel.service'
+      );
+      const stopped = input.sessionId
+        ? await stopDevTunnel(ctx.user.id, input.sessionId)
+        : await stopDevTunnelForUserBlock(ctx.user.id, input.blockId!);
+      return { ok: true, stopped };
+    }),
+
+  /**
+   * APP DEV TUNNEL — status of the caller's active tunnel for a block (host,
+   * expiry, spend ceiling), or null when none is active. Same gates.
+   */
+  devTunnelStatus: appDeveloperProcedure
+    .use(enforceAppBlocksFlag)
+    .input(z.object({ blockId: z.string().min(1).max(64) }))
+    .query(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { isAppBlocksDevTunnelEnabled } = await import('~/server/services/app-blocks-flag');
+      if (!(await isAppBlocksDevTunnelEnabled({ user: ctx.user }))) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'Dev tunnels are not available' });
+      }
+      const { getActiveDevTunnel } = await import('~/server/services/blocks/dev-tunnel.service');
+      const session = await getActiveDevTunnel(ctx.user.id, input.blockId);
+      if (!session) return { active: false as const };
+      return {
+        active: true as const,
+        sessionId: session.sessionId,
+        host: session.host,
+        expiresAt: session.hardExpiresAt,
+        spendCapBuzz: session.spendCapBuzz,
+      };
+    }),
+
+  /**
    * Mod queue: paginated list of publish requests waiting for review,
    * oldest first. Powers /apps/review.
    */

--- a/src/server/services/__tests__/block-registry.resolve-dev.test.ts
+++ b/src/server/services/__tests__/block-registry.resolve-dev.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * APP DEV TUNNEL — BlockRegistry.resolveDevPageBlockForAuthor.
+ *
+ * The dev route resolver: resolves the caller's OWN app by blockId at ANY status,
+ * ownership-scoped. Foreign / absent → null (no oracle). Pins the two invariants
+ * that keep the dev path disjoint from the public run path:
+ *   - it never requires status:approved (a draft/pending own app resolves), and
+ *   - it carries NO iframeSrc (the route derives the host from the tunnel only).
+ */
+
+const { mockDbRead, mockDbWrite, mockRedis, mockSysRedis } = vi.hoisted(() => {
+  const ab = () => ({
+    findUnique: vi.fn(async (): Promise<unknown> => null),
+    findFirst: vi.fn(async (): Promise<unknown> => null),
+  });
+  return {
+    mockDbRead: { $queryRaw: vi.fn(async () => []), appBlock: ab() },
+    mockDbWrite: { appBlock: ab() },
+    mockRedis: {
+      packed: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => undefined),
+      del: vi.fn(async () => 0),
+      scanIterator: async function* () {},
+    },
+    mockSysRedis: { sMembers: vi.fn(async () => []) },
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  sysRedis: mockSysRedis,
+  REDIS_KEYS: { BLOCKS: { REGISTRY: 'r', TOKEN_RATE_LIMIT: 'rl', REVOKED_INSTANCE: 'rev' } },
+  REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
+}));
+
+import { BlockRegistry } from '~/server/services/block-registry.service';
+
+function ownRow(status: string) {
+  return {
+    id: 'apb_dev',
+    blockId: 'my-app',
+    appId: 'appblk-my-app',
+    status,
+    manifest: { name: 'My App', scopes: ['ai:write:budgeted'], iframe: { sandbox: 'allow-scripts' } },
+    trustTier: 'unverified',
+    contentRating: null,
+  };
+}
+
+describe('BlockRegistry.resolveDevPageBlockForAuthor', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each(['draft', 'pending', 'approved', 'rejected'])(
+    'resolves the caller’s OWN app at status=%s (status-agnostic)',
+    async (status) => {
+      mockDbRead.appBlock.findFirst.mockResolvedValue(ownRow(status));
+      const res = await BlockRegistry.resolveDevPageBlockForAuthor('my-app', 555);
+      expect(res).not.toBeNull();
+      expect(res?.status).toBe(status);
+      expect(res?.appBlockId).toBe('apb_dev');
+      expect(res?.scopes).toEqual(['ai:write:budgeted']);
+      // The query is OWNERSHIP-scoped: blockId + app.userId.
+      expect(mockDbRead.appBlock.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { blockId: 'my-app', app: { userId: 555 } } })
+      );
+      // NO iframeSrc field exists on the dev resolution — it can never serve a
+      // deployed <slug>.civit.ai bundle.
+      expect((res as Record<string, unknown>).iframeSrc).toBeUndefined();
+    }
+  );
+
+  it('returns null for another author’s app (foreign/absent → the same null, no oracle)', async () => {
+    // The ownership predicate is in the WHERE, so a foreign app simply doesn't match.
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    expect(await BlockRegistry.resolveDevPageBlockForAuthor('their-app', 555)).toBeNull();
+  });
+
+  it('returns null on empty inputs (fail-closed)', async () => {
+    expect(await BlockRegistry.resolveDevPageBlockForAuthor('', 555)).toBeNull();
+    expect(await BlockRegistry.resolveDevPageBlockForAuthor('my-app', 0)).toBeNull();
+    expect(mockDbRead.appBlock.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('INVARIANT: the public resolvePageBlockBySlug requires status:approved (never a dev/draft app)', async () => {
+    // The public run path only ever resolves an APPROVED app (its WHERE pins
+    // status:'approved') — so a draft/pending dev app is invisible to it, keeping
+    // the two paths disjoint. A non-approved row → the findFirst below returns null.
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null); // no approved row for a draft slug
+    expect(await BlockRegistry.resolvePageBlockBySlug('my-app', { db: 'read' })).toBeNull();
+    expect(mockDbRead.appBlock.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { blockId: 'my-app', status: 'approved' } })
+    );
+  });
+});

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -280,6 +280,61 @@ export async function isAppBlocksRuntimeEnabled(): Promise<boolean> {
 }
 
 /**
+ * Dedicated mod+cohort-segmented flag for the APP DEV TUNNEL (on-site dev via a
+ * hardened sish tunnel — the `dev-<random16>.<APPS_DOMAIN>` generalization of the
+ * mod review sandbox).
+ *
+ * When ON for the caller, an approved app developer may mint a tunnel credential
+ * (`blocks.startDevTunnel`), get an ephemeral `dev-<random16>.<APPS_DOMAIN>` host
+ * wired to their LOCAL dev server, and open `civitai.com/apps/dev/<blockId>` to
+ * see their local code rendered inside the real production `PageBlockHost`. The
+ * whole feature is DORMANT until this flag is on for the caller, so it ships dark
+ * and enables per-cohort without touching the user-facing `app-blocks-enabled`
+ * rollout or the build pipeline.
+ *
+ * This is a USER-VISIBILITY / capability gate (the `startDevTunnel` / `stop` /
+ * `status` tRPC procedures + the `/apps/dev` SSR route + the entry-token mint), so
+ * — exactly like `app-blocks-review-sandbox-enabled` — it is segment-gated and
+ * MUST be evaluated WITH the caller's context. Create it in Flipt as base
+ * `enabled: false` with the `moderators` segment PLUS the `app-dev-testers` cohort
+ * segment (mirror `app-blocks-pages-enabled` / `app-blocks-review-sandbox-enabled`
+ * exactly) so mods + the dev-testers cohort resolve `true` and everyone else
+ * `false`.
+ *
+ * NB: this flag gates only the CONTROL PLANE (mint / route / entry-token). The
+ * public SSH exposure of the sish tunnel is a separate, deliberately-windowed
+ * infra change (P3) — enabling this flag alone can never expose a dev's machine,
+ * because with no public `ssh -R` reachability there is no tunnel to serve.
+ *
+ * Fail-safe: the flag does NOT exist in Flipt yet (created only AFTER this merges)
+ * → `isFlipt` returns `false` → `startDevTunnel` throws FORBIDDEN and the
+ * `/apps/dev` route 404s. So the as-merged behaviour is fully dark and cannot
+ * regress the gate open.
+ */
+export const APP_BLOCKS_DEV_TUNNEL_FLAG = 'app-blocks-dev-tunnel';
+
+/**
+ * Segment-gated gate for the APP DEV TUNNEL. Evaluated WITH the caller's context
+ * (entityId = user id, context carries server-side `isModerator`) so the
+ * `moderators` / `app-dev-testers` segments can match — identical eval shape to
+ * `isAppBlocksReviewSandboxEnabled`. No user → preserves a global eval that can
+ * never match a segment (fail-closed). See APP_BLOCKS_DEV_TUNNEL_FLAG.
+ *
+ * NOTE: unlike `isAppBlocksAuthorEnabled`, there is NO moderator static floor —
+ * the flag is created as the rollout, so an absent flag resolves `false` for
+ * EVERYONE (mods included). That is intentional and load-bearing: the dev tunnel
+ * is a brand-new surface (no existing mod access to preserve), so fail-closed for
+ * all until the flag exists is the safe posture.
+ */
+export async function isAppBlocksDevTunnelEnabled(opts?: {
+  user?: SessionUser;
+}): Promise<boolean> {
+  if (!opts?.user) return isFlipt(APP_BLOCKS_DEV_TUNNEL_FLAG);
+  const user = opts.user;
+  return isFlipt(APP_BLOCKS_DEV_TUNNEL_FLAG, String(user.id), buildFliptContext(user));
+}
+
+/**
  * Dedicated GLOBAL fail-closed flag for the attribution BACKPAY reader
  * (W3 attribution back-half — Slice 4 read leg, see backpay.service.ts).
  *

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -427,6 +427,29 @@ export interface PageBlockSsr {
   contentRating: string | null;
 }
 
+/**
+ * APP DEV TUNNEL — the caller's OWN app resolved for the `/apps/dev/<blockId>`
+ * route, at ANY status (pending/draft/approved/rejected). DISTINCT from
+ * PageBlockSsr in TWO load-bearing ways:
+ *   - it is OWNERSHIP-SCOPED (resolves only the caller's own app; null for
+ *     another author's app — see resolveDevPageBlockForAuthor), and
+ *   - it carries NO iframeSrc: the dev route's iframe points at the ephemeral
+ *     tunnel host (server-derived), NEVER the manifest's stored iframe.src. This
+ *     is why it can never resolve or serve a deployed `<slug>.civit.ai` bundle.
+ */
+export interface DevPageBlockResolution {
+  appBlockId: string;
+  blockId: string;
+  appId: string;
+  status: string;
+  trustTier: 'unverified' | 'verified' | 'internal';
+  name: string;
+  pageTitle: string;
+  sandbox: string;
+  scopes: string[];
+  contentRating: string | null;
+}
+
 interface UninstallOpts {
   modelId: number;
   appBlockId: string;
@@ -1806,6 +1829,66 @@ export class BlockRegistry {
       scopes: declaredScopes,
       // NSFW-APP-RED-ONLY: NULL-safe (column is non-null on approve, but defend
       // against a pre-feature / partial row → treated as SFW by the gate).
+      contentRating: typeof ab.contentRating === 'string' ? ab.contentRating : null,
+    };
+  }
+
+  /**
+   * APP DEV TUNNEL — resolve the caller's OWN app by `blockId` (== AppBlock
+   * `block_id`, GLOBALLY unique via `@@unique([blockId])`) at ANY status, for the
+   * `/apps/dev/<blockId>` SSR route + the startDevTunnel gate. Ownership is
+   * enforced IN the query (`app.userId === userId`), so a `blockId` owned by a
+   * DIFFERENT author — or no such app — returns null (no ownership/existence
+   * oracle). Unlike resolvePageBlockBySlug this does NOT require `status:approved`
+   * NOR `manifestDeclaresPage`: a developer iterating locally may have a
+   * draft/pending app whose manifest has no page block yet. The dev host renders
+   * the LOCAL code via the tunnel, so the manifest iframe/page is irrelevant here.
+   *
+   * NOTE: this returns NO iframeSrc — the route derives the iframe host from the
+   * assigned tunnel host ONLY (T6). It cannot be used to serve a deployed bundle.
+   */
+  static async resolveDevPageBlockForAuthor(
+    blockId: string,
+    userId: number,
+    opts?: { db?: 'read' | 'write' }
+  ): Promise<DevPageBlockResolution | null> {
+    if (!blockId || !userId) return null;
+    const db = opts?.db === 'write' ? dbWrite : dbRead;
+    const ab = await db.appBlock.findFirst({
+      // Ownership-scoped: the app's OauthClient.userId is the v1 ownership source
+      // of truth (same as getMyAppRepo). A foreign-owned or missing app → null.
+      where: { blockId, app: { userId } },
+      select: {
+        id: true,
+        blockId: true,
+        appId: true,
+        status: true,
+        manifest: true,
+        trustTier: true,
+        contentRating: true,
+      },
+    });
+    if (!ab) return null;
+    const manifest = (ab.manifest ?? {}) as Record<string, unknown>;
+    const iframe = (manifest.iframe ?? {}) as { sandbox?: unknown };
+    const page = (manifest.page ?? {}) as { title?: unknown };
+    const name = typeof manifest.name === 'string' ? manifest.name : ab.blockId;
+    const declaredScopes = Array.isArray((manifest as { scopes?: unknown }).scopes)
+      ? (manifest as { scopes: unknown[] }).scopes.filter((s): s is string => typeof s === 'string')
+      : [];
+    return {
+      appBlockId: ab.id,
+      blockId: ab.blockId,
+      appId: ab.appId,
+      status: ab.status,
+      trustTier:
+        ab.trustTier === 'verified' || ab.trustTier === 'internal'
+          ? (ab.trustTier as 'verified' | 'internal')
+          : 'unverified',
+      name,
+      pageTitle: typeof page.title === 'string' ? page.title : name,
+      sandbox: typeof iframe.sandbox === 'string' ? iframe.sandbox : '',
+      scopes: declaredScopes,
       contentRating: typeof ab.contentRating === 'string' ? ab.contentRating : null,
     };
   }

--- a/src/server/services/blocks/__tests__/dev-tunnel-session.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel-session.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEV_HOST_LABEL_REGEX,
+  devHostRegexForDomain,
+  fingerprintSshPublicKey,
+  generateDevHostLabel,
+  isValidDevHost,
+  normalizeSshPublicKey,
+  pubKeysMatch,
+  sharedSecretMatch,
+  signDevTunnelAccessToken,
+  verifyDevTunnelAccessToken,
+} from '~/server/services/blocks/dev-tunnel-session';
+
+/**
+ * APP DEV TUNNEL — pure-crypto coverage for the entry token (author-bound) + the
+ * sish tunnel-credential pubkey helpers.
+ */
+
+const SECRET = 'test-nextauth-secret-aaaaaaaaaaaaaaaaaaaa';
+const HOST = 'dev-0123456789abcdef.civit.ai';
+const USER = 4242;
+const PUBKEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBytesHere0123456789abc dev@laptop';
+
+describe('signDevTunnelAccessToken / verifyDevTunnelAccessToken (entry token)', () => {
+  it('roundtrips: a fresh token verifies for the bound host + returns the author userId', () => {
+    const token = signDevTunnelAccessToken({ userId: USER, host: HOST, secret: SECRET });
+    expect(token).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    expect(verifyDevTunnelAccessToken(token, HOST, { secret: SECRET })).toEqual({
+      ok: true,
+      userId: USER,
+    });
+  });
+
+  it('rejects a token verified against a DIFFERENT host (host binding, T6/T3)', () => {
+    const token = signDevTunnelAccessToken({ userId: USER, host: HOST, secret: SECRET });
+    expect(
+      verifyDevTunnelAccessToken(token, 'dev-deadbeefdeadbeef.civit.ai', { secret: SECRET })
+    ).toEqual({ ok: false });
+  });
+
+  it('rejects a token signed with a different secret (sig mismatch, constant-time path)', () => {
+    const token = signDevTunnelAccessToken({ userId: USER, host: HOST, secret: 'other-secret-xx' });
+    expect(verifyDevTunnelAccessToken(token, HOST, { secret: SECRET })).toEqual({ ok: false });
+  });
+
+  it('rejects an expired token (exp in the past)', () => {
+    const token = signDevTunnelAccessToken({
+      userId: USER,
+      host: HOST,
+      secret: SECRET,
+      ttlSeconds: -1,
+    });
+    expect(verifyDevTunnelAccessToken(token, HOST, { secret: SECRET })).toEqual({ ok: false });
+  });
+
+  it('rejects a tampered payload (different userId) — recomputed signing string diverges', () => {
+    const token = signDevTunnelAccessToken({ userId: USER, host: HOST, secret: SECRET });
+    const [payloadB64, sig] = token.split('.');
+    const payload = JSON.parse(Buffer.from(payloadB64, 'base64url').toString('utf8'));
+    payload.u = 9999; // escalate to another user
+    const forged = `${Buffer.from(JSON.stringify(payload)).toString('base64url')}.${sig}`;
+    expect(verifyDevTunnelAccessToken(forged, HOST, { secret: SECRET })).toEqual({ ok: false });
+  });
+
+  it('NEVER throws on malformed input → { ok:false }', () => {
+    for (const bad of [null, undefined, '', 'nodot', '.', 'a.', '.b', '💥.💥', 'x'.repeat(5000)]) {
+      expect(verifyDevTunnelAccessToken(bad as never, HOST, { secret: SECRET })).toEqual({
+        ok: false,
+      });
+    }
+  });
+
+  it('is domain-separated from the review-sandbox mr token (cannot be cross-verified)', () => {
+    // A review token over the SAME secret must NOT verify as a dev token, and
+    // vice versa — the domain prefixes differ.
+    const dev = signDevTunnelAccessToken({ userId: USER, host: HOST, secret: SECRET });
+    // Hand-craft a review-shaped payload {m,h,exp} and confirm the dev verifier
+    // rejects it (different field names + signing string).
+    const reviewPayload = Buffer.from(JSON.stringify({ m: USER, h: HOST, exp: 9e9 })).toString(
+      'base64url'
+    );
+    expect(verifyDevTunnelAccessToken(`${reviewPayload}.${dev.split('.')[1]}`, HOST, { secret: SECRET })).toEqual({
+      ok: false,
+    });
+  });
+});
+
+describe('dev host generation + validation (T6 SSRF surface)', () => {
+  it('generateDevHostLabel yields dev-<16hex>', () => {
+    for (let i = 0; i < 20; i++) {
+      expect(generateDevHostLabel()).toMatch(DEV_HOST_LABEL_REGEX);
+    }
+  });
+
+  it('isValidDevHost accepts a well-formed host and rejects everything else', () => {
+    expect(isValidDevHost('dev-0123456789abcdef.civit.ai', 'civit.ai')).toBe(true);
+    // rejects: wrong prefix, wrong length, uppercase hex, wrong domain, path/query
+    // injection, a deployed <slug>.civit.ai bundle host, review host.
+    for (const bad of [
+      'review-0123456789abcdef.civit.ai',
+      'dev-0123456789abcde.civit.ai', // 15 hex
+      'dev-0123456789ABCDEF.civit.ai', // uppercase
+      'dev-0123456789abcdef.evil.com',
+      'dev-0123456789abcdef.civit.ai.evil.com',
+      'myapp.civit.ai',
+      'dev-0123456789abcdef.civit.ai/../../etc',
+      'dev-0123456789abcdef.civit.ai?x=1',
+      '',
+      null,
+      undefined,
+    ]) {
+      expect(isValidDevHost(bad as never, 'civit.ai')).toBe(false);
+    }
+  });
+
+  it('devHostRegexForDomain escapes the domain dots (no wildcard match)', () => {
+    const re = devHostRegexForDomain('civit.ai');
+    expect(re.test('dev-0123456789abcdef.civitXai')).toBe(false); // '.' is literal
+  });
+});
+
+describe('SSH pubkey credential helpers (sish authz core)', () => {
+  it('normalizeSshPublicKey drops the comment but keeps type+key stable', () => {
+    const a = normalizeSshPublicKey('ssh-ed25519 AAAAC3Nza dev@laptop');
+    const b = normalizeSshPublicKey('  ssh-ed25519   AAAAC3Nza   other@host  ');
+    expect(a).toBe('ssh-ed25519 AAAAC3Nza');
+    expect(a).toBe(b); // comment/whitespace-insensitive → a reconnect matches
+  });
+
+  it('normalizeSshPublicKey rejects junk', () => {
+    for (const bad of ['', 'notakey', 'ssh-ed25519', null, undefined]) {
+      expect(normalizeSshPublicKey(bad as never)).toBe('');
+    }
+  });
+
+  it('fingerprint is stable across comment changes + null on junk', () => {
+    const f1 = fingerprintSshPublicKey('ssh-ed25519 AAAAC3Nza a@x');
+    const f2 = fingerprintSshPublicKey('ssh-ed25519 AAAAC3Nza b@y');
+    expect(f1).toBe(f2);
+    expect(f1).toMatch(/^[a-f0-9]{64}$/);
+    expect(fingerprintSshPublicKey('junk')).toBeNull();
+  });
+
+  it('pubKeysMatch: constant-time equality on normalized keys', () => {
+    expect(pubKeysMatch(PUBKEY, `${PUBKEY} different-comment`)).toBe(true);
+    expect(pubKeysMatch(PUBKEY, 'ssh-ed25519 DIFFERENTKEYBYTES x@y')).toBe(false);
+    // WRONG-PUBKEY (the sish authz deny case) + malformed → false, never throws.
+    expect(pubKeysMatch(PUBKEY, null)).toBe(false);
+    expect(pubKeysMatch(null, PUBKEY)).toBe(false);
+    expect(pubKeysMatch('junk', 'junk')).toBe(false);
+  });
+
+  it('sharedSecretMatch: constant-time; empty/mismatch/length-diff → false', () => {
+    expect(sharedSecretMatch('s3cr3t', 's3cr3t')).toBe(true);
+    expect(sharedSecretMatch('s3cr3t', 's3cr3T')).toBe(false);
+    expect(sharedSecretMatch('short', 'longer-secret')).toBe(false);
+    expect(sharedSecretMatch('', 'x')).toBe(false);
+    expect(sharedSecretMatch(undefined, 'x')).toBe(false);
+    expect(sharedSecretMatch('x', undefined)).toBe(false);
+  });
+});

--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * APP DEV TUNNEL — service coverage: manifest shape (SSRF-safe host match),
+ * startDevTunnel mint+render+persist, stop (ownership-checked), getActiveDevTunnel,
+ * the per-session spend-cap backstop, and the reaper.
+ */
+
+const { mockK8sFetch, mockGetDp1Target, mockUnwrap, sysRedis, mockEnv, mockNewId } = vi.hoisted(
+  () => {
+    const store = new Map<string, string>();
+    return {
+      store,
+      mockK8sFetch: vi.fn(),
+      mockGetDp1Target: vi.fn(async () => ({ server: 'https://k8s', token: 't' })),
+      mockUnwrap: vi.fn(async (res: any) => {
+        const t = await res.text();
+        return t ? JSON.parse(t) : {};
+      }),
+      sysRedis: {
+        _store: store,
+        get: vi.fn(async (k: string) => store.get(k) ?? null),
+        set: vi.fn(async (k: string, v: string) => {
+          store.set(k, v);
+          return 'OK';
+        }),
+        del: vi.fn(async (k: string) => {
+          store.delete(k);
+          return 1;
+        }),
+        incrBy: vi.fn(async (k: string, n: number) => {
+          const cur = Number(store.get(k) ?? '0') + n;
+          store.set(k, String(cur));
+          return cur;
+        }),
+        decrBy: vi.fn(async (k: string, n: number) => {
+          const cur = Number(store.get(k) ?? '0') - n;
+          store.set(k, String(cur));
+          return cur;
+        }),
+        expire: vi.fn(async () => 1),
+        ttl: vi.fn(async () => 100),
+      },
+      mockEnv: {
+        APPS_DOMAIN: 'civit.ai',
+        APPS_KUBE_NAMESPACE: 'civitai-apps',
+        NEXTAUTH_URL: 'https://civitai.com',
+        APPS_DEV_TUNNEL_SISH_BACKEND: 'http://sish-http.apps-dev-tunnel.svc.cluster.local:8080',
+        APPS_DEV_TUNNEL_FORWARDAUTH_URL: undefined as string | undefined,
+      },
+      mockNewId: vi.fn(() => 'bki_testsession'),
+    };
+  }
+);
+
+vi.mock('~/env/server', () => ({ env: mockEnv }));
+vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
+  getDp1Target: (...a: unknown[]) => mockGetDp1Target(...(a as [])),
+  k8sFetch: (...a: unknown[]) => mockK8sFetch(...(a as [])),
+  unwrap: (...a: unknown[]) => mockUnwrap(...(a as [any])),
+}));
+vi.mock('~/server/redis/client', () => ({
+  sysRedis,
+  withSysReadDeadline: <T>(p: Promise<T>) => p,
+  REDIS_SYS_KEYS: { BLOCKS: { DEV_TUNNEL: 'system:blocks:dev-tunnel' } },
+}));
+vi.mock('~/server/utils/app-block-ids', () => ({ newBlockInstanceId: () => mockNewId() }));
+vi.mock('~/server/prom/dev-tunnel.metrics', () => ({
+  recordDevTunnelMint: vi.fn(),
+  recordDevTunnelTeardown: vi.fn(),
+}));
+
+import {
+  buildDevTunnelIngressRoute,
+  buildDevTunnelMiddleware,
+  getActiveDevTunnel,
+  reserveDevSessionBuzz,
+  startDevTunnel,
+  stopDevTunnel,
+  reapExpiredDevTunnels,
+  DEV_TUNNEL_SESSION_BUZZ_CAP,
+} from '~/server/services/blocks/dev-tunnel.service';
+import { DEV_HOST_LABEL_REGEX } from '~/server/services/blocks/dev-tunnel-session';
+
+const PUBKEY = 'ssh-ed25519 AAAAC3NzaExampleBytes0123456789abcdef dev@laptop';
+
+function okRes(body = '{}') {
+  return { ok: true, status: 200, text: async () => body };
+}
+
+beforeEach(() => {
+  sysRedis._store.clear();
+  vi.clearAllMocks();
+  mockK8sFetch.mockResolvedValue(okRes());
+  mockGetDp1Target.mockResolvedValue({ server: 'https://k8s', token: 't' });
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('manifest builders (SSRF-safe, server-derived host)', () => {
+  const opts = {
+    host: 'dev-0123456789abcdef.civit.ai',
+    sessionId: 'bki_s',
+    namespace: 'civitai-apps',
+    forwardAuthUrl: 'http://civitai-web/api/internal/dev-tunnel-gate',
+    sishBackend: 'http://sish-http.apps-dev-tunnel.svc.cluster.local:8080',
+  };
+
+  it('IngressRoute matches EXACTLY the assigned host (never a wildcard/user input)', () => {
+    const ir = buildDevTunnelIngressRoute(opts);
+    expect(ir.spec.routes[0].match).toBe('Host(`dev-0123456789abcdef.civit.ai`)');
+    // routes to the sish backend service, parsed into name/namespace/port
+    expect(ir.spec.routes[0].services[0]).toMatchObject({
+      name: 'sish-http',
+      namespace: 'apps-dev-tunnel',
+      port: 8080,
+    });
+    // gated by the forwardAuth middleware
+    expect(ir.spec.routes[0].middlewares[0].name).toBe('dev-tunnel-gate-bki_s');
+    // labelled for the reaper + teardown sweep
+    expect(ir.metadata.labels['civitai.com/dev-tunnel']).toBe('true');
+    expect(ir.metadata.labels['civitai.com/dev-tunnel-session']).toBe('bki_s');
+  });
+
+  it('Middleware points forwardAuth at the dev-tunnel-gate endpoint', () => {
+    const mw = buildDevTunnelMiddleware(opts);
+    expect(mw.spec.forwardAuth.address).toBe('http://civitai-web/api/internal/dev-tunnel-gate');
+    expect(mw.spec.forwardAuth.authResponseHeaders).toContain('X-Dev-User-Id');
+  });
+});
+
+describe('startDevTunnel', () => {
+  it('mints an unguessable host, renders the route, persists state, returns the URL', async () => {
+    const result = await startDevTunnel({ userId: 555, blockId: 'my-app', sshPublicKey: PUBKEY });
+    // host = dev-<16hex>.civit.ai
+    expect(result.host).toMatch(/^dev-[a-f0-9]{16}\.civit\.ai$/);
+    expect(result.host.split('.')[0]).toMatch(DEV_HOST_LABEL_REGEX);
+    expect(result.url).toBe('https://civitai.com/apps/dev/my-app');
+    expect(result.spendCapBuzz).toBe(DEV_TUNNEL_SESSION_BUZZ_CAP);
+    // rendered: middleware + ingressroute each pre-deleted (DELETE) + POSTed
+    const posts = mockK8sFetch.mock.calls.filter((c) => (c[2] as any)?.method === 'POST');
+    expect(posts.length).toBe(2);
+    // persisted the 4 index keys (cred/session/host/user-block)
+    expect(sysRedis.set).toHaveBeenCalledTimes(4);
+    // the credential is keyed by pubkey fingerprint (sish authz lookup index)
+    const credKeys = [...sysRedis._store.keys()].filter((k) => k.includes(':cred:'));
+    expect(credKeys.length).toBe(1);
+  });
+
+  it('rejects an invalid SSH public key before touching k8s/redis', async () => {
+    await expect(
+      startDevTunnel({ userId: 1, blockId: 'a', sshPublicKey: 'junk' })
+    ).rejects.toThrow(/invalid SSH public key/);
+    expect(mockK8sFetch).not.toHaveBeenCalled();
+    expect(sysRedis.set).not.toHaveBeenCalled();
+  });
+});
+
+describe('stopDevTunnel (ownership-checked)', () => {
+  it('a caller can NEVER tear down another author’s tunnel', async () => {
+    await startDevTunnel({ userId: 555, blockId: 'my-app', sshPublicKey: PUBKEY });
+    // wrong user → no-op false, session survives
+    expect(await stopDevTunnel(999, 'bki_testsession')).toBe(false);
+    expect(sysRedis._store.has('system:blocks:dev-tunnel:session:bki_testsession')).toBe(true);
+  });
+
+  it('the owner tears down: deletes route + all keys', async () => {
+    await startDevTunnel({ userId: 555, blockId: 'my-app', sshPublicKey: PUBKEY });
+    expect(await stopDevTunnel(555, 'bki_testsession')).toBe(true);
+    const remaining = [...sysRedis._store.keys()].filter((k) => k.startsWith('system:blocks:dev-tunnel'));
+    expect(remaining).toEqual([]);
+  });
+});
+
+describe('getActiveDevTunnel', () => {
+  it('returns the active session for the owner; null for a foreign/absent index', async () => {
+    await startDevTunnel({ userId: 555, blockId: 'my-app', sshPublicKey: PUBKEY });
+    const s = await getActiveDevTunnel(555, 'my-app');
+    expect(s?.userId).toBe(555);
+    expect(s?.host).toMatch(/^dev-[a-f0-9]{16}\.civit\.ai$/);
+    // wrong user / wrong block → null (no cross-tenant leak)
+    expect(await getActiveDevTunnel(999, 'my-app')).toBeNull();
+    expect(await getActiveDevTunnel(555, 'other-app')).toBeNull();
+  });
+});
+
+describe('reserveDevSessionBuzz (spend-cap backstop)', () => {
+  it('allows spend under the ceiling and DENIES + rolls back once it would exceed', async () => {
+    const cap = 100;
+    expect(await reserveDevSessionBuzz('sess', 60, cap)).toEqual({ allowed: true, total: 60 });
+    // 60 + 60 = 120 > 100 → denied, rolled back to 60
+    expect(await reserveDevSessionBuzz('sess', 60, cap)).toEqual({ allowed: false, total: 60 });
+    // a smaller top-up that fits still passes
+    expect(await reserveDevSessionBuzz('sess', 40, cap)).toEqual({ allowed: true, total: 100 });
+    // now full → any further spend denied
+    expect(await reserveDevSessionBuzz('sess', 1, cap)).toEqual({ allowed: false, total: 100 });
+  });
+
+  it('fails CLOSED (denied) on a redis error — never silently uncaps', async () => {
+    sysRedis.incrBy.mockRejectedValueOnce(new Error('redis down'));
+    const r = await reserveDevSessionBuzz('sess', 10, 100);
+    expect(r.allowed).toBe(false);
+  });
+});
+
+describe('reapExpiredDevTunnels (server-authoritative)', () => {
+  it('tears down a route whose backing session has expired', async () => {
+    // Seed an EXPIRED session + a k8s route labelled with it.
+    const sessionId = 'bki_expired';
+    sysRedis._store.set(
+      `system:blocks:dev-tunnel:session:${sessionId}`,
+      JSON.stringify({
+        sessionId,
+        userId: 7,
+        blockId: 'x',
+        host: 'dev-aaaaaaaaaaaaaaaa.civit.ai',
+        fingerprint: 'fp',
+        createdAt: 1,
+        hardExpiresAt: 1, // long past
+        spendCapBuzz: 100,
+      })
+    );
+    // First k8sFetch (the LIST) returns the labelled route; subsequent DELETEs ok.
+    mockK8sFetch.mockImplementation(async (_t: unknown, path: string, init: any) => {
+      if (init?.method === 'GET' && path.includes('ingressroutes?labelSelector')) {
+        return okRes(
+          JSON.stringify({
+            items: [{ metadata: { labels: { 'civitai.com/dev-tunnel-session': sessionId } } }],
+          })
+        );
+      }
+      return okRes();
+    });
+    const result = await reapExpiredDevTunnels();
+    expect(result.swept).toBe(1);
+    expect(result.reaped).toBe(1);
+    // the session record was removed during teardown
+    expect(sysRedis._store.has(`system:blocks:dev-tunnel:session:${sessionId}`)).toBe(false);
+  });
+});

--- a/src/server/services/blocks/apps-pipeline.service.ts
+++ b/src/server/services/blocks/apps-pipeline.service.ts
@@ -36,12 +36,15 @@ import { env } from '~/env/server';
 
 // ---------- shared HTTP helpers --------------------------------------------
 
-type K8sTarget = {
+export type K8sTarget = {
   server: string;
   token: string;
 };
 
-async function k8sFetch(target: K8sTarget, path: string, init?: RequestInit): Promise<Response> {
+// Exported for reuse by the sibling dev-tunnel service (renders/deletes the
+// ephemeral dev-tunnel Traefik route via the SAME in-pod SA k8s API surface as
+// the review render). Kept thin + dependency-free on purpose.
+export async function k8sFetch(target: K8sTarget, path: string, init?: RequestInit): Promise<Response> {
   const url = `${target.server.replace(/\/$/, '')}${path}`;
   const headers: HeadersInit = {
     Authorization: `Bearer ${target.token}`,
@@ -56,7 +59,7 @@ async function k8sFetch(target: K8sTarget, path: string, init?: RequestInit): Pr
   });
 }
 
-async function unwrap<T>(res: Response, allowStatuses: number[] = []): Promise<T> {
+export async function unwrap<T>(res: Response, allowStatuses: number[] = []): Promise<T> {
   if (res.ok || allowStatuses.includes(res.status)) {
     const text = await res.text();
     return text ? (JSON.parse(text) as T) : (null as unknown as T);
@@ -68,7 +71,7 @@ async function unwrap<T>(res: Response, allowStatuses: number[] = []): Promise<T
 // ---------- in-cluster (dp-1) target ---------------------------------------
 
 let dp1Target: K8sTarget | null = null;
-async function getDp1Target(): Promise<K8sTarget> {
+export async function getDp1Target(): Promise<K8sTarget> {
   if (dp1Target) return dp1Target;
   // Standard in-pod paths.
   const token = await readFile('/var/run/secrets/kubernetes.io/serviceaccount/token', 'utf8');

--- a/src/server/services/blocks/dev-tunnel-session.ts
+++ b/src/server/services/blocks/dev-tunnel-session.ts
@@ -1,0 +1,268 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from 'crypto';
+
+/**
+ * APP DEV TUNNEL — pure crypto primitives (no DB / Redis / k8s), so they are
+ * unit-testable in isolation. This is the direct sibling of `review-session.ts`
+ * (the mod review sandbox), with the "mod-bound" binding swapped for
+ * "author-bound", and adds the tunnel-credential (sish `ssh -R` pubkey) helpers.
+ *
+ * Two distinct tokens live here — do not conflate them:
+ *
+ *   1. ENTRY TOKEN (author-bound, host-bound, ~120s) — the BROWSER-side
+ *      cross-origin access token the authenticated `civitai.com/apps/dev/<id>`
+ *      parent mints and injects into the iframe `src` as `?dev=<token>`. The
+ *      `*.civit.ai` edge forwardAuth (`/api/internal/dev-tunnel-gate`) verifies it
+ *      on the ENTRY document request. This is the exact review-sandbox `mr`-token
+ *      pattern, re-keyed to the author's userId. It gates who may LOAD the tunnel.
+ *
+ *   2. TUNNEL CREDENTIAL (pubkey-bound) — the SERVER-side authorization for the
+ *      CLI's `ssh -R` bind. The CLI generates an ephemeral SSH keypair and sends
+ *      its PUBLIC key to `startDevTunnel`; the mint records it. When sish receives
+ *      the reverse-tunnel bind it POSTs the presented pubkey (`auth_key`) to the
+ *      sish authz callback, which looks the credential up BY FINGERPRINT and
+ *      constant-time compares the full stored pubkey. This module owns the
+ *      fingerprint + constant-time-compare helpers; the Redis-backed credential
+ *      lifecycle lives in `dev-tunnel.service.ts`.
+ *
+ * SECURITY NOTE (why the pubkey is the boundary, and replay is inert): the
+ * `auth_key` sish forwards is a PUBLIC key. Possessing it does NOT let an attacker
+ * bind the tunnel — the SSH transport still requires the matching PRIVATE key
+ * (standard pubkey auth), which never leaves the dev's machine. So an attacker who
+ * replays the authz POST only re-authorizes the SAME userId's own tunnel binding
+ * and gains nothing. Defense-in-depth on the callback is nonetheless: a shared
+ * secret (only sish knows), a short-TTL credential, and a constant-time compare.
+ */
+
+// ---------------------------------------------------------------------------
+// ENTRY token (author-bound, short-TTL, carried as `?dev=` on the iframe src)
+// ---------------------------------------------------------------------------
+
+/** ENTRY-token TTL in seconds. Intentionally short: mint (getServerSideProps /
+ *  status poll) → iframe document load. A fresh URL is minted on every render so
+ *  the live iframe never serves a stale token. */
+export const DEV_TUNNEL_ACCESS_TOKEN_TTL_SECONDS = 120;
+
+/** Domain-separation prefix for the short-TTL ENTRY token. Ensures this HMAC can
+ *  never collide with the review-sandbox `mr` token or any other the app signs
+ *  over the same NEXTAUTH_SECRET. Bump `v1` if the payload shape changes. */
+const ENTRY_DOMAIN_PREFIX = 'dev-tunnel-mr:v1';
+
+/** The unguessable dev host label: `dev-<16 hex>`. Exported so the mint, the
+ *  route iframeSrc derivation, and the gate all validate the SAME shape. The
+ *  16-hex (64-bit) random makes the host itself an unguessable secret on top of
+ *  the entry-token gate (defence for T1). */
+export const DEV_HOST_LABEL_REGEX = /^dev-[a-f0-9]{16}$/;
+
+/** Full-host regex `^dev-<16hex>\.<escaped-domain>$`. Server-derives + validates
+ *  the iframeSrc host (T6: never reflect a client-supplied URL). */
+export function devHostRegexForDomain(appsDomain: string): RegExp {
+  const escaped = appsDomain.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^dev-[a-f0-9]{16}\\.${escaped}$`);
+}
+
+/** True iff `host` is a well-formed `dev-<16hex>.<appsDomain>` host. */
+export function isValidDevHost(host: string | null | undefined, appsDomain: string): boolean {
+  if (!host || typeof host !== 'string') return false;
+  return devHostRegexForDomain(appsDomain).test(host);
+}
+
+/** Generate a fresh unguessable dev host label `dev-<16hex>` (8 random bytes). */
+export function generateDevHostLabel(): string {
+  return `dev-${randomBytes(8).toString('hex')}`;
+}
+
+type DevAccessPayload = {
+  /** Author (app developer) user id the token is bound to. */
+  u: number;
+  /** dev host the token authorizes (`dev-<16hex>.<APPS_DOMAIN>`). */
+  h: string;
+  /** Absolute expiry, unix seconds. */
+  exp: number;
+};
+
+function base64url(input: Buffer | string): string {
+  const buf = typeof input === 'string' ? Buffer.from(input, 'utf8') : input;
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlToBuffer(input: string): Buffer {
+  const pad = input.length % 4 === 0 ? '' : '='.repeat(4 - (input.length % 4));
+  return Buffer.from(input.replace(/-/g, '+').replace(/_/g, '/') + pad, 'base64');
+}
+
+function entrySigningString(p: DevAccessPayload): string {
+  return `${ENTRY_DOMAIN_PREFIX}:${p.u}:${p.h}:${p.exp}`;
+}
+
+function hmac(secret: string, signingStr: string): Buffer {
+  return createHmac('sha256', secret).update(signingStr).digest();
+}
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+export type SignDevAccessTokenParams = {
+  userId: number;
+  host: string;
+  /** Injected for testability; defaults to env.NEXTAUTH_SECRET. */
+  secret?: string;
+  /** Injected for testability; defaults to DEV_TUNNEL_ACCESS_TOKEN_TTL_SECONDS. */
+  ttlSeconds?: number;
+};
+
+/**
+ * Mint a compact `base64url(payload).base64url(sig)` dev-tunnel entry token bound
+ * to (userId, host), valid for `ttlSeconds` (default 120s).
+ */
+export function signDevTunnelAccessToken(params: SignDevAccessTokenParams): string {
+  const secret = params.secret ?? resolveSecret();
+  const ttl = params.ttlSeconds ?? DEV_TUNNEL_ACCESS_TOKEN_TTL_SECONDS;
+  const payload: DevAccessPayload = {
+    u: params.userId,
+    h: params.host,
+    exp: nowSec() + ttl,
+  };
+  const payloadB64 = base64url(JSON.stringify(payload));
+  const sigB64 = base64url(hmac(secret, entrySigningString(payload)));
+  return `${payloadB64}.${sigB64}`;
+}
+
+export type VerifyDevAccessTokenResult = {
+  ok: boolean;
+  userId?: number;
+};
+
+/**
+ * Verify a dev-tunnel entry token against the expected host. NEVER throws on
+ * malformed input — returns `{ ok:false }`. Checks: structurally parseable
+ * payload + signature, constant-time HMAC match, not expired, bound host equals
+ * `expectedHost`.
+ */
+export function verifyDevTunnelAccessToken(
+  token: string | null | undefined,
+  expectedHost: string,
+  opts?: { secret?: string }
+): VerifyDevAccessTokenResult {
+  const fail: VerifyDevAccessTokenResult = { ok: false };
+  if (!token || typeof token !== 'string') return fail;
+
+  const dot = token.indexOf('.');
+  if (dot <= 0 || dot === token.length - 1) return fail;
+  const payloadB64 = token.slice(0, dot);
+  const sigB64 = token.slice(dot + 1);
+
+  let payload: DevAccessPayload;
+  try {
+    const parsed = JSON.parse(base64urlToBuffer(payloadB64).toString('utf8'));
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      typeof parsed.u !== 'number' ||
+      typeof parsed.h !== 'string' ||
+      typeof parsed.exp !== 'number'
+    ) {
+      return fail;
+    }
+    payload = parsed as DevAccessPayload;
+  } catch {
+    return fail;
+  }
+
+  let secret: string;
+  try {
+    secret = opts?.secret ?? resolveSecret();
+  } catch {
+    return fail;
+  }
+
+  const expectedSig = hmac(secret, entrySigningString(payload));
+  let providedSig: Buffer;
+  try {
+    providedSig = base64urlToBuffer(sigB64);
+  } catch {
+    return fail;
+  }
+  if (providedSig.length !== expectedSig.length) return fail;
+  if (!timingSafeEqual(providedSig, expectedSig)) return fail;
+
+  if (payload.exp <= nowSec()) return fail;
+  if (payload.h !== expectedHost) return fail;
+
+  return { ok: true, userId: payload.u };
+}
+
+// ---------------------------------------------------------------------------
+// TUNNEL credential (sish `ssh -R` pubkey binding)
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize an SSH public key to its stable comparison form: `<type> <base64>`
+ * (drop any trailing comment + surrounding whitespace, collapse inner runs). An
+ * OpenSSH pubkey line is `ssh-ed25519 AAAA... user@host` — the comment is
+ * cosmetic and must NOT participate in the identity, or a reconnect that drops it
+ * would fail to match. Returns '' for anything not shaped like a pubkey.
+ */
+export function normalizeSshPublicKey(raw: string | null | undefined): string {
+  if (!raw || typeof raw !== 'string') return '';
+  const parts = raw.trim().split(/\s+/);
+  if (parts.length < 2) return '';
+  const [type, key] = parts;
+  // A base64 body is required; be strict so junk can't produce a stable
+  // fingerprint that later collides.
+  if (!/^[A-Za-z0-9+/=@.\-]+$/.test(type) || !/^[A-Za-z0-9+/=]+$/.test(key)) return '';
+  return `${type} ${key}`;
+}
+
+/**
+ * Stable fingerprint (sha256 hex of the normalized pubkey) used as the Redis
+ * lookup key for the credential. This is only an INDEX — the authorization
+ * decision is a constant-time compare of the full stored pubkey vs the presented
+ * one (see `pubKeysMatch`), so a fingerprint collision alone can never authorize.
+ */
+export function fingerprintSshPublicKey(raw: string | null | undefined): string | null {
+  const normalized = normalizeSshPublicKey(raw);
+  if (!normalized) return null;
+  return createHash('sha256').update(normalized).digest('hex');
+}
+
+/**
+ * Constant-time equality of two SSH public keys (compared in normalized form).
+ * Returns false (never throws) on malformed input or a length mismatch. This is
+ * the authoritative authz check in the sish callback.
+ */
+export function pubKeysMatch(a: string | null | undefined, b: string | null | undefined): boolean {
+  const na = normalizeSshPublicKey(a);
+  const nb = normalizeSshPublicKey(b);
+  if (!na || !nb) return false;
+  const ba = Buffer.from(na, 'utf8');
+  const bb = Buffer.from(nb, 'utf8');
+  if (ba.length !== bb.length) return false;
+  return timingSafeEqual(ba, bb);
+}
+
+/**
+ * Constant-time equality for the sish shared secret (self-authenticating the
+ * callback so random internet cannot POST it). Never throws; a missing/empty
+ * configured secret or a length mismatch is a definitive non-match.
+ */
+export function sharedSecretMatch(
+  presented: string | null | undefined,
+  configured: string | null | undefined
+): boolean {
+  if (!presented || !configured || typeof presented !== 'string' || typeof configured !== 'string') {
+    return false;
+  }
+  const bp = Buffer.from(presented, 'utf8');
+  const bc = Buffer.from(configured, 'utf8');
+  if (bp.length !== bc.length) return false;
+  return timingSafeEqual(bp, bc);
+}
+
+/** Resolve NEXTAUTH_SECRET lazily so the module stays import-cheap + testable
+ *  (callers can inject `secret` directly to avoid env resolution). */
+function resolveSecret(): string {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) throw new Error('NEXTAUTH_SECRET is not set');
+  return secret;
+}

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -1,0 +1,598 @@
+import { env } from '~/env/server';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
+import { newBlockInstanceId } from '~/server/utils/app-block-ids';
+import {
+  getDp1Target,
+  k8sFetch,
+  unwrap,
+  type K8sTarget,
+} from '~/server/services/blocks/apps-pipeline.service';
+import {
+  fingerprintSshPublicKey,
+  generateDevHostLabel,
+  isValidDevHost,
+  normalizeSshPublicKey,
+} from '~/server/services/blocks/dev-tunnel-session';
+import {
+  recordDevTunnelMint,
+  recordDevTunnelTeardown,
+  type DevTunnelTeardownReason,
+} from '~/server/prom/dev-tunnel.metrics';
+
+/**
+ * APP DEV TUNNEL — control-plane state + ephemeral Traefik route lifecycle.
+ *
+ * Generalizes the mod review sandbox (`apps-pipeline.service.ts` render +
+ * `publish-request.service.ts` teardown) from "mod-bound, pending build" to
+ * "author-bound, live sish tunnel". No DB migration: the credential/session state
+ * is short-TTL and lives entirely in `sysRedis` (like the dev-token rate limiter +
+ * the block Buzz cap), keyed under `system:blocks:dev-tunnel:*`.
+ *
+ * DARK: every caller is gated by `app-blocks-dev-tunnel` (base off) upstream, so
+ * none of this runs in prod until P3 flips the flag. The public `ssh -R` exposure
+ * (sish listener on the shared proxy) is a separate P3 infra change — the
+ * BROWSER-facing Traefik route render here is inert without it.
+ */
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/** Idle timeout (no browser activity) before the reaper tears a tunnel down. */
+export const DEV_TUNNEL_IDLE_SECONDS = 30 * 60; // 30m (design §9)
+/** Hard max lifetime — the credential Redis keys carry this as their EX, so an
+ *  orphaned tunnel self-expires from the authz path even if the reaper never
+ *  runs; the reaper additionally deletes the k8s route. */
+export const DEV_TUNNEL_HARD_SECONDS = 8 * 60 * 60; // 8h (design §9)
+
+/** Per-dev-session cumulative Buzz ceiling (backstop over the block-token
+ *  DEV_BUZZ_BUDGET_CAP + the untouched per-user daily cap). Bounds a runaway
+ *  local submit loop within ONE dev session. Conservative default. */
+export const DEV_TUNNEL_SESSION_BUZZ_CAP = 5000;
+
+const SYS_PREFIX = REDIS_SYS_KEYS.BLOCKS.DEV_TUNNEL;
+const credKey = (fingerprint: string) => `${SYS_PREFIX}:cred:${fingerprint}` as const;
+const sessionKey = (sessionId: string) => `${SYS_PREFIX}:session:${sessionId}` as const;
+const hostKey = (host: string) => `${SYS_PREFIX}:host:${host}` as const;
+const userBlockKey = (userId: number, blockId: string) =>
+  `${SYS_PREFIX}:user:${userId}:${blockId}` as const;
+const spendKey = (sessionId: string) => `${SYS_PREFIX}:spend:${sessionId}` as const;
+
+/** Label every rendered k8s object carries so the reaper + teardown can sweep by
+ *  selector and never touch a live app (live apps carry no dev-tunnel label). */
+const DEV_TUNNEL_LABEL = 'civitai.com/dev-tunnel';
+const DEV_TUNNEL_SESSION_LABEL = 'civitai.com/dev-tunnel-session';
+
+// ---------------------------------------------------------------------------
+// Record shapes
+// ---------------------------------------------------------------------------
+
+export type DevTunnelSessionRecord = {
+  sessionId: string;
+  userId: number;
+  blockId: string;
+  host: string;
+  fingerprint: string;
+  createdAt: number; // unix seconds
+  hardExpiresAt: number; // unix seconds
+  spendCapBuzz: number;
+};
+
+/** The subset of the credential the sish authz callback needs. Stored separately
+ *  keyed by pubkey fingerprint (the callback's lookup index). */
+type DevTunnelCredentialRecord = {
+  sessionId: string;
+  userId: number;
+  blockId: string;
+  host: string;
+  /** Full normalized SSH public key — the authz decision constant-time compares
+   *  this against the presented `auth_key`. The fingerprint is only the index. */
+  sshPublicKey: string;
+  hardExpiresAt: number;
+};
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/** All dev-tunnel sub-keys share this template — a subtype of the branded
+ *  sysRedis key union, so `sysRedis.get(key)` type-checks. */
+type DevTunnelKey = `${typeof SYS_PREFIX}:${string}`;
+
+async function readJson<T>(key: DevTunnelKey): Promise<T | null> {
+  try {
+    const raw = await withSysReadDeadline(sysRedis.get(key));
+    if (!raw || typeof raw !== 'string') return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Manifest builders (PURE — exported for shape tests)
+// ---------------------------------------------------------------------------
+
+export type DevTunnelManifestOpts = {
+  host: string;
+  sessionId: string;
+  namespace: string;
+  /** in-cluster forwardAuth address (the dev-tunnel-gate endpoint). */
+  forwardAuthUrl: string;
+  /** sish HTTP backend the reverse tunnel is bound behind. */
+  sishBackend: string;
+};
+
+/** Build the ephemeral forwardAuth Middleware for a dev-tunnel host. The
+ *  Middleware points Traefik at the dev-tunnel-gate endpoint, which requires the
+ *  parent-minted author-bound entry token on the ENTRY document (T3). */
+export function buildDevTunnelMiddleware(opts: DevTunnelManifestOpts) {
+  const name = `dev-tunnel-gate-${opts.sessionId}`;
+  return {
+    apiVersion: 'traefik.io/v1alpha1',
+    kind: 'Middleware',
+    metadata: {
+      name,
+      namespace: opts.namespace,
+      labels: {
+        [DEV_TUNNEL_LABEL]: 'true',
+        [DEV_TUNNEL_SESSION_LABEL]: opts.sessionId,
+      },
+    },
+    spec: {
+      forwardAuth: {
+        address: opts.forwardAuthUrl,
+        // Forward the headers the gate reasons over. Traefik always forwards
+        // X-Forwarded-* + the ENTRY request's own Sec-Fetch-Dest.
+        authResponseHeaders: ['X-Dev-User-Id'],
+      },
+    },
+  } as const;
+}
+
+/** Build the ephemeral IngressRoute for a dev-tunnel host. Matches the exact
+ *  `dev-<16hex>.<APPS_DOMAIN>` host (server-derived), gates with the forwardAuth
+ *  Middleware, and routes to the sish HTTP backend. TLS via the existing
+ *  `*.civit.ai` wildcard cert (default TLS store — no per-host cert). */
+export function buildDevTunnelIngressRoute(opts: DevTunnelManifestOpts) {
+  const name = `dev-tunnel-${opts.sessionId}`;
+  const middlewareName = `dev-tunnel-gate-${opts.sessionId}`;
+  // Split the backend into host:port for the Traefik ExternalName-style service
+  // reference is not needed — Traefik IngressRoute services reference an in-ns
+  // Service by name+port. The sish backend is a Service in the sish namespace, so
+  // we use a Traefik `services[].name` + `namespace`. Parse host/port defensively.
+  const backend = parseBackend(opts.sishBackend);
+  return {
+    apiVersion: 'traefik.io/v1alpha1',
+    kind: 'IngressRoute',
+    metadata: {
+      name,
+      namespace: opts.namespace,
+      labels: {
+        [DEV_TUNNEL_LABEL]: 'true',
+        [DEV_TUNNEL_SESSION_LABEL]: opts.sessionId,
+      },
+    },
+    spec: {
+      entryPoints: ['websecure'],
+      routes: [
+        {
+          match: `Host(\`${opts.host}\`)`,
+          kind: 'Rule',
+          middlewares: [{ name: middlewareName, namespace: opts.namespace }],
+          services: [
+            {
+              name: backend.service,
+              namespace: backend.namespace,
+              port: backend.port,
+            },
+          ],
+        },
+      ],
+      tls: {},
+    },
+  } as const;
+}
+
+/** Parse `http://sish-http.apps-dev-tunnel.svc.cluster.local:8080` (or a bare
+ *  `service.namespace:port`) into the Traefik service reference parts. Defensive
+ *  defaults keep a shape valid even for a terse backend string. */
+function parseBackend(raw: string): { service: string; namespace: string; port: number } {
+  const stripped = raw.replace(/^https?:\/\//, '');
+  const [hostPart, portPart] = stripped.split(':');
+  const port = Number(portPart ?? '8080') || 8080;
+  const segs = hostPart.split('.');
+  const service = segs[0] || 'sish-http';
+  const namespace = segs[1] || 'apps-dev-tunnel';
+  return { service, namespace, port };
+}
+
+function forwardAuthUrl(): string {
+  // In-cluster address of the dev-tunnel-gate endpoint. Defaults to the civitai-web
+  // internal Service; overridable via env for the real cluster wiring (P3).
+  return (
+    env.APPS_DEV_TUNNEL_FORWARDAUTH_URL ??
+    'http://civitai-web.civitai.svc.cluster.local/api/internal/dev-tunnel-gate'
+  );
+}
+
+function sishBackend(): string {
+  return env.APPS_DEV_TUNNEL_SISH_BACKEND;
+}
+
+function manifestOpts(host: string, sessionId: string): DevTunnelManifestOpts {
+  return {
+    host,
+    sessionId,
+    namespace: env.APPS_KUBE_NAMESPACE,
+    forwardAuthUrl: forwardAuthUrl(),
+    sishBackend: sishBackend(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// k8s apply / delete (thin, reuses apps-pipeline helpers)
+// ---------------------------------------------------------------------------
+
+async function applyManifest(target: K8sTarget, ns: string, kindPath: string, obj: unknown, name: string) {
+  // Delete-then-create so a re-render of the same session name is idempotent
+  // (mirrors the review apply Job's pre-delete). 404 on delete is fine.
+  await k8sFetch(target, `${kindPath}/${name}?propagationPolicy=Background`, {
+    method: 'DELETE',
+  }).then(async (r) => {
+    if (!r.ok && r.status !== 404) {
+      const body = await r.text().catch(() => '');
+      throw new Error(`dev-tunnel pre-delete ${name} ${r.status}: ${body.slice(0, 200)}`);
+    }
+  });
+  const res = await k8sFetch(target, kindPath, { method: 'POST', body: JSON.stringify(obj) });
+  await unwrap<{ metadata: { name: string } }>(res);
+}
+
+/** Render the ephemeral Traefik IngressRoute + forwardAuth Middleware for a
+ *  dev-tunnel host by POSTing them directly to the k8s API (the same in-pod SA
+ *  surface + create/delete RBAC the review teardown uses — no bash render Job, no
+ *  template ConfigMap dependency). */
+export async function renderDevTunnelRoute(host: string, sessionId: string): Promise<void> {
+  const target = await getDp1Target();
+  const ns = env.APPS_KUBE_NAMESPACE;
+  const opts = manifestOpts(host, sessionId);
+  const mw = buildDevTunnelMiddleware(opts);
+  const ir = buildDevTunnelIngressRoute(opts);
+  await applyManifest(
+    target,
+    ns,
+    `/apis/traefik.io/v1alpha1/namespaces/${ns}/middlewares`,
+    mw,
+    mw.metadata.name
+  );
+  await applyManifest(
+    target,
+    ns,
+    `/apis/traefik.io/v1alpha1/namespaces/${ns}/ingressroutes`,
+    ir,
+    ir.metadata.name
+  );
+}
+
+/** Delete the ephemeral Traefik route for ONE session by label selector. Scoped
+ *  to `civitai.com/dev-tunnel-session=<id>` so it can only ever touch THAT
+ *  session's objects, never a live app. Best-effort + idempotent. */
+export async function deleteDevTunnelRoute(sessionId: string): Promise<void> {
+  const target = await getDp1Target();
+  const ns = env.APPS_KUBE_NAMESPACE;
+  const selector = encodeURIComponent(`${DEV_TUNNEL_SESSION_LABEL}=${sessionId}`);
+  const kinds: Array<{ listPath: string; itemPath: (n: string) => string }> = [
+    {
+      listPath: `/apis/traefik.io/v1alpha1/namespaces/${ns}/ingressroutes?labelSelector=${selector}`,
+      itemPath: (n) => `/apis/traefik.io/v1alpha1/namespaces/${ns}/ingressroutes/${n}`,
+    },
+    {
+      listPath: `/apis/traefik.io/v1alpha1/namespaces/${ns}/middlewares?labelSelector=${selector}`,
+      itemPath: (n) => `/apis/traefik.io/v1alpha1/namespaces/${ns}/middlewares/${n}`,
+    },
+  ];
+  for (const k of kinds) {
+    try {
+      const listRes = await k8sFetch(target, k.listPath, { method: 'GET' });
+      if (!listRes.ok) continue;
+      const list = await unwrap<{ items?: Array<{ metadata?: { name?: string } }> }>(listRes);
+      const names = (list?.items ?? [])
+        .map((it) => it?.metadata?.name)
+        .filter((n): n is string => typeof n === 'string' && n.length > 0);
+      for (const name of names) {
+        await k8sFetch(target, `${k.itemPath(name)}?propagationPolicy=Background`, {
+          method: 'DELETE',
+        }).catch(() => {
+          /* best-effort */
+        });
+      }
+    } catch {
+      /* a single kind failing must not abort the sweep */
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+export type StartDevTunnelParams = {
+  userId: number;
+  blockId: string;
+  /** The CLI's ephemeral SSH public key (raw OpenSSH line). */
+  sshPublicKey: string;
+};
+
+export type StartDevTunnelResult = {
+  sessionId: string;
+  host: string;
+  /** The URL the dev opens in their own browser. */
+  url: string;
+  expiresAt: number;
+  spendCapBuzz: number;
+};
+
+/**
+ * Mint a dev-tunnel credential + host, render the ephemeral Traefik route, and
+ * persist the session state in Redis. Enforces ONE active tunnel per (user,
+ * blockId): a prior session for the same pair is torn down first (route + keys).
+ *
+ * The caller (the tRPC procedure) has ALREADY gated author + ownership + all
+ * flags — this function trusts `userId`/`blockId` as authorized and never
+ * re-derives authz from client input.
+ */
+export async function startDevTunnel(params: StartDevTunnelParams): Promise<StartDevTunnelResult> {
+  const normalizedKey = normalizeSshPublicKey(params.sshPublicKey);
+  if (!normalizedKey) throw new Error('invalid SSH public key');
+  const fingerprint = fingerprintSshPublicKey(normalizedKey);
+  if (!fingerprint) throw new Error('invalid SSH public key');
+
+  // Tear down any existing tunnel for this (user, block) so a re-run doesn't
+  // orphan a route/credential.
+  await stopDevTunnelForUserBlock(params.userId, params.blockId).catch(() => {});
+
+  const sessionId = newBlockInstanceId(); // `bki_<ulid>` — opaque, unique
+  const host = `${generateDevHostLabel()}.${env.APPS_DOMAIN}`;
+  const created = nowSec();
+  const hardExpiresAt = created + DEV_TUNNEL_HARD_SECONDS;
+
+  const session: DevTunnelSessionRecord = {
+    sessionId,
+    userId: params.userId,
+    blockId: params.blockId,
+    host,
+    fingerprint,
+    createdAt: created,
+    hardExpiresAt,
+    spendCapBuzz: DEV_TUNNEL_SESSION_BUZZ_CAP,
+  };
+  const credential: DevTunnelCredentialRecord = {
+    sessionId,
+    userId: params.userId,
+    blockId: params.blockId,
+    host,
+    sshPublicKey: normalizedKey,
+    hardExpiresAt,
+  };
+
+  // Render the Traefik route FIRST — if it fails we never persist state, so a
+  // failed mint leaves nothing behind.
+  await renderDevTunnelRoute(host, sessionId);
+
+  // Persist the index + records, all with the hard-TTL EX so they self-expire.
+  await Promise.all([
+    sysRedis.set(credKey(fingerprint), JSON.stringify(credential), { EX: DEV_TUNNEL_HARD_SECONDS }),
+    sysRedis.set(sessionKey(sessionId), JSON.stringify(session), { EX: DEV_TUNNEL_HARD_SECONDS }),
+    sysRedis.set(hostKey(host), sessionId, { EX: DEV_TUNNEL_HARD_SECONDS }),
+    sysRedis.set(userBlockKey(params.userId, params.blockId), sessionId, {
+      EX: DEV_TUNNEL_HARD_SECONDS,
+    }),
+  ]);
+
+  recordDevTunnelMint();
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({
+      event: 'app-blocks.dev-tunnel.start',
+      sessionId,
+      userId: params.userId,
+      blockId: params.blockId,
+      host,
+      expiresAt: hardExpiresAt,
+    })
+  );
+
+  return {
+    sessionId,
+    host,
+    url: `${(env.NEXTAUTH_URL ?? 'https://civitai.com').replace(/\/$/, '')}/apps/dev/${params.blockId}`,
+    expiresAt: hardExpiresAt,
+    spendCapBuzz: DEV_TUNNEL_SESSION_BUZZ_CAP,
+  };
+}
+
+/** Delete all state + the route for a session (used by stop + reap). Best-effort;
+ *  never throws. `reason` labels the teardown metric. */
+async function teardownSession(
+  session: DevTunnelSessionRecord,
+  reason: DevTunnelTeardownReason
+): Promise<void> {
+  await deleteDevTunnelRoute(session.sessionId).catch(() => {});
+  await Promise.all([
+    sysRedis.del(credKey(session.fingerprint)).catch(() => {}),
+    sysRedis.del(sessionKey(session.sessionId)).catch(() => {}),
+    sysRedis.del(hostKey(session.host)).catch(() => {}),
+    sysRedis.del(userBlockKey(session.userId, session.blockId)).catch(() => {}),
+    sysRedis.del(spendKey(session.sessionId)).catch(() => {}),
+  ]);
+  recordDevTunnelTeardown(reason);
+  // eslint-disable-next-line no-console
+  console.log(
+    JSON.stringify({
+      event: 'app-blocks.dev-tunnel.stop',
+      sessionId: session.sessionId,
+      userId: session.userId,
+      blockId: session.blockId,
+      host: session.host,
+      reason,
+    })
+  );
+}
+
+/** Stop a dev tunnel by sessionId, but ONLY if it belongs to `userId` (defence:
+ *  a caller can never tear down another author's tunnel). Returns true if a
+ *  session was found + torn down. */
+export async function stopDevTunnel(userId: number, sessionId: string): Promise<boolean> {
+  const session = await readJson<DevTunnelSessionRecord>(sessionKey(sessionId));
+  if (!session || session.userId !== userId) return false;
+  await teardownSession(session, 'stop');
+  return true;
+}
+
+/** Stop whatever active tunnel exists for a (user, block) pair (used by
+ *  startDevTunnel to reclaim the single active slot, and by stopDevTunnel by
+ *  blockId). */
+export async function stopDevTunnelForUserBlock(userId: number, blockId: string): Promise<boolean> {
+  // The user-block index stores a BARE sessionId string (not JSON).
+  const sessionId = await withSysReadDeadline(
+    sysRedis.get(userBlockKey(userId, blockId))
+  ).catch(() => null);
+  if (!sessionId || typeof sessionId !== 'string') return false;
+  return stopDevTunnel(userId, sessionId);
+}
+
+/** Resolve the active dev-tunnel session for a (user, block), for the SSR route +
+ *  the status procedure. Returns null when none is active. */
+export async function getActiveDevTunnel(
+  userId: number,
+  blockId: string
+): Promise<DevTunnelSessionRecord | null> {
+  const sessionId = await withSysReadDeadline(
+    sysRedis.get(userBlockKey(userId, blockId))
+  ).catch(() => null);
+  if (!sessionId || typeof sessionId !== 'string') return null;
+  const session = await readJson<DevTunnelSessionRecord>(sessionKey(sessionId));
+  // Cross-check ownership + freshness (fail-closed on a stale/foreign index).
+  if (!session || session.userId !== userId || session.blockId !== blockId) return null;
+  if (session.host && !isValidDevHost(session.host, env.APPS_DOMAIN)) return null;
+  if (session.hardExpiresAt <= nowSec()) return null;
+  return session;
+}
+
+// ---------------------------------------------------------------------------
+// sish authz callback support
+// ---------------------------------------------------------------------------
+
+/** Look up the credential the sish authz callback presents (by pubkey
+ *  fingerprint). Returns null when absent/expired. The CALLER does the
+ *  constant-time full-pubkey compare — this is only the index read. */
+export async function lookupCredentialByFingerprint(
+  fingerprint: string
+): Promise<DevTunnelCredentialRecord | null> {
+  const cred = await readJson<DevTunnelCredentialRecord>(credKey(fingerprint));
+  if (!cred) return null;
+  if (cred.hardExpiresAt <= nowSec()) return null;
+  return cred;
+}
+
+/**
+ * SINGLE-USE consume: delete the credential index after a successful sish authz
+ * so a REPLAYED authz POST is denied (the next lookup misses → deny). The
+ * tunnel⇆userId binding (host / session records) persists for the session; only
+ * the pubkey→credential authz index is one-time. Best-effort (a failed delete
+ * leaves the credential, which the hard-TTL still expires) — never throws.
+ */
+export async function consumeDevTunnelCredential(fingerprint: string): Promise<void> {
+  await sysRedis.del(credKey(fingerprint)).catch(() => {});
+}
+
+// ---------------------------------------------------------------------------
+// Spend-cap backstop
+// ---------------------------------------------------------------------------
+
+export type ReserveDevSessionBuzzResult = { allowed: boolean; total: number };
+
+/**
+ * Reserve `costBuzz` against a dev SESSION's cumulative ceiling. Atomic INCRBY;
+ * if the reservation would exceed `capBuzz` it is rolled back (DECRBY) and denied
+ * — the safe direction for an abuse backstop. Fails CLOSED (denied) on any Redis
+ * error, never silently bypasses. This is a BACKSTOP over the block-token
+ * DEV_BUZZ_BUDGET_CAP + the per-user daily cap; the author still spends only
+ * their OWN Buzz.
+ */
+export async function reserveDevSessionBuzz(
+  sessionId: string,
+  costBuzz: number,
+  capBuzz: number = DEV_TUNNEL_SESSION_BUZZ_CAP
+): Promise<ReserveDevSessionBuzzResult> {
+  const cost = Math.max(0, Math.ceil(costBuzz));
+  const key = spendKey(sessionId);
+  try {
+    const total = await sysRedis.incrBy(key, cost);
+    if (total <= cost) {
+      // first write in this window — arm the TTL so it self-expires with the tunnel
+      await sysRedis.expire(key, DEV_TUNNEL_HARD_SECONDS);
+    }
+    if (total > capBuzz) {
+      await sysRedis.decrBy(key, cost).catch(() => {});
+      return { allowed: false, total: total - cost };
+    }
+    return { allowed: true, total };
+  } catch {
+    // Fail closed — a Redis incident must never silently uncap dev spend.
+    return { allowed: false, total: capBuzz };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reaper (server-authoritative — NOT CLI-dependent)
+// ---------------------------------------------------------------------------
+
+/**
+ * Sweep the ephemeral dev-tunnel routes and tear down any whose backing session
+ * record has expired (hard-TTL) or vanished from Redis. Bounded by the number of
+ * live routes (label-scoped LIST). Server-authoritative: even if the CLI crashes
+ * without calling stopDevTunnel, the hard-TTL Redis expiry + this sweep reclaim
+ * the route. Intended to be driven by a periodic job (P3 infra); the primitive is
+ * complete + unit-tested here.
+ *
+ * Idle handling: a session whose Redis record is gone (its keys carry a hard-TTL
+ * EX) is reaped as `reap-maxttl`. A finer idle-timeout (`reap-idle`) is enforced
+ * by refreshing the session key's TTL on browser activity and reaping the route
+ * when the key is absent — same code path (absent key → reap). The `reason` here
+ * is `reap-maxttl` for an expired/absent record.
+ */
+export async function reapExpiredDevTunnels(): Promise<{ swept: number; reaped: number }> {
+  const target = await getDp1Target();
+  const ns = env.APPS_KUBE_NAMESPACE;
+  const selector = encodeURIComponent(`${DEV_TUNNEL_LABEL}=true`);
+  const listRes = await k8sFetch(
+    target,
+    `/apis/traefik.io/v1alpha1/namespaces/${ns}/ingressroutes?labelSelector=${selector}`,
+    { method: 'GET' }
+  );
+  if (!listRes.ok) return { swept: 0, reaped: 0 };
+  const list = await unwrap<{
+    items?: Array<{ metadata?: { labels?: Record<string, string> } }>;
+  }>(listRes);
+  const items = list?.items ?? [];
+  let reaped = 0;
+  for (const it of items) {
+    const sessionId = it?.metadata?.labels?.[DEV_TUNNEL_SESSION_LABEL];
+    if (!sessionId) continue;
+    const session = await readJson<DevTunnelSessionRecord>(sessionKey(sessionId));
+    const expired = !session || session.hardExpiresAt <= nowSec();
+    if (expired) {
+      if (session) {
+        await teardownSession(session, 'reap-maxttl').catch(() => {});
+      } else {
+        // Redis record gone but route survives — delete the route directly.
+        await deleteDevTunnelRoute(sessionId).catch(() => {});
+        recordDevTunnelTeardown('reap-maxttl');
+      }
+      reaped += 1;
+    }
+  }
+  return { swept: items.length, reaped };
+}

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -520,6 +520,12 @@ export type ReserveDevSessionBuzzResult = { allowed: boolean; total: number };
  * error, never silently bypasses. This is a BACKSTOP over the block-token
  * DEV_BUZZ_BUDGET_CAP + the per-user daily cap; the author still spends only
  * their OWN Buzz.
+ *
+ * ⚠️ NOT WIRED in P1 — dev-session Buzz is NOT capped yet. This tested primitive
+ * has NO live call site: it is enforced at workflow-submit in P3 once the block
+ * token carries a dev-session id. Real dev spend TODAY rides the existing
+ * `/api/v1/blocks/dev-token` real-Buzz clamp (DEV_BUZZ_BUDGET_CAP + the per-user
+ * daily cap), NOT this per-session ceiling. Do NOT assume this backstop is active.
  */
 export async function reserveDevSessionBuzz(
   sessionId: string,

--- a/src/tests/api/apps/dev-tunnel-authz.test.ts
+++ b/src/tests/api/apps/dev-tunnel-authz.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { fingerprintSshPublicKey, normalizeSshPublicKey } from '~/server/services/blocks/dev-tunnel-session';
+
+/**
+ * APP DEV TUNNEL — coverage for the sish authz callback
+ * `POST /api/apps/dev-tunnel/authz`. `user` / `remote_addr` are attacker-
+ * controlled → never authz'd on; the decision is the presented `auth_key`
+ * matching a live userId-bound credential (constant-time), gated by the shared
+ * secret. Single-use → replay denied.
+ */
+
+const { mockLookup, mockConsume, mockEnv } = vi.hoisted(() => ({
+  mockLookup: vi.fn(),
+  mockConsume: vi.fn(async (..._a: unknown[]) => undefined),
+  mockEnv: { APPS_DEV_TUNNEL_SISH_SECRET: 'sish-shared-secret' as string | undefined },
+}));
+
+vi.mock('~/env/server', () => ({ env: mockEnv }));
+vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
+  lookupCredentialByFingerprint: (...a: unknown[]) => mockLookup(...a),
+  consumeDevTunnelCredential: (...a: unknown[]) => mockConsume(...a),
+}));
+
+import handler from '~/pages/api/apps/dev-tunnel/authz';
+
+const PUBKEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBytes0123456789abcdefg dev@laptop';
+const NORMALIZED = normalizeSshPublicKey(PUBKEY);
+const FP = fingerprintSshPublicKey(PUBKEY)!;
+const NOW = Math.floor(Date.now() / 1000);
+
+const validCred = {
+  sessionId: 'bki_abc',
+  userId: 555,
+  blockId: 'my-app',
+  host: 'dev-0123456789abcdef.civit.ai',
+  sshPublicKey: NORMALIZED,
+  hardExpiresAt: NOW + 3600,
+};
+
+function makeRes() {
+  const headers: Record<string, string> = {};
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    status(c: number) {
+      this.statusCode = c;
+      return this;
+    },
+    json(p: unknown) {
+      this.body = p;
+      return this;
+    },
+    _headers: headers,
+  };
+  return res as unknown as NextApiResponse & { statusCode: number; body: any };
+}
+
+function makeReq(opts: {
+  secret?: string;
+  authKey?: string;
+  user?: string;
+  remoteAddr?: string;
+  method?: string;
+}): NextApiRequest {
+  const headers: Record<string, string> = {};
+  if (opts.secret !== undefined) headers['x-dev-tunnel-secret'] = opts.secret;
+  return {
+    method: opts.method ?? 'POST',
+    headers,
+    body: { auth_key: opts.authKey, user: opts.user, remote_addr: opts.remoteAddr },
+  } as unknown as NextApiRequest;
+}
+
+describe('POST /api/apps/dev-tunnel/authz', () => {
+  beforeEach(() => {
+    mockLookup.mockReset();
+    mockConsume.mockClear();
+    mockEnv.APPS_DEV_TUNNEL_SISH_SECRET = 'sish-shared-secret';
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('valid secret + matching pubkey → 200 (and consumes the credential)', async () => {
+    mockLookup.mockResolvedValue(validCred);
+    const res = makeRes();
+    await handler(makeReq({ secret: 'sish-shared-secret', authKey: PUBKEY, user: 'anything' }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.auth).toBe(true);
+    expect(mockConsume).toHaveBeenCalledWith(FP);
+  });
+
+  it('FORGED user field is IGNORED — authz rests on the pubkey only', async () => {
+    // A malicious client claims to be another user; the pubkey still matches its
+    // own credential → authorized as the credential's userId, not the claim.
+    mockLookup.mockResolvedValue(validCred);
+    const res = makeRes();
+    await handler(
+      makeReq({ secret: 'sish-shared-secret', authKey: PUBKEY, user: 'root; DROP TABLE' }),
+      res
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('REPLAYED key → deny (single-use consume: second lookup misses)', async () => {
+    // First bind consumes; the replay's lookup returns null → 403.
+    mockLookup.mockResolvedValueOnce(validCred).mockResolvedValueOnce(null);
+    const res1 = makeRes();
+    await handler(makeReq({ secret: 'sish-shared-secret', authKey: PUBKEY }), res1);
+    expect(res1.statusCode).toBe(200);
+    const res2 = makeRes();
+    await handler(makeReq({ secret: 'sish-shared-secret', authKey: PUBKEY }), res2);
+    expect(res2.statusCode).toBe(403);
+  });
+
+  it('EXPIRED credential (lookup returns null) → 403', async () => {
+    mockLookup.mockResolvedValue(null); // lookup already filters expired
+    const res = makeRes();
+    await handler(makeReq({ secret: 'sish-shared-secret', authKey: PUBKEY }), res);
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('WRONG pubkey (fingerprint hits a different credential) → 403 (constant-time compare fails)', async () => {
+    mockLookup.mockResolvedValue({
+      ...validCred,
+      sshPublicKey: normalizeSshPublicKey('ssh-ed25519 DIFFERENTKEYBYTES someoneelse@host'),
+    });
+    const res = makeRes();
+    await handler(makeReq({ secret: 'sish-shared-secret', authKey: PUBKEY }), res);
+    expect(res.statusCode).toBe(403);
+    expect(mockConsume).not.toHaveBeenCalled();
+  });
+
+  it('malformed pubkey → 403 (no lookup)', async () => {
+    const res = makeRes();
+    await handler(makeReq({ secret: 'sish-shared-secret', authKey: 'junk' }), res);
+    expect(res.statusCode).toBe(403);
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('WRONG shared secret → 401 (random internet cannot POST)', async () => {
+    const res = makeRes();
+    await handler(makeReq({ secret: 'nope', authKey: PUBKEY }), res);
+    expect(res.statusCode).toBe(401);
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('MISSING shared secret header → 401', async () => {
+    const res = makeRes();
+    await handler(makeReq({ authKey: PUBKEY }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('UNCONFIGURED sish secret (env unset) → 503 (inert until provisioned)', async () => {
+    mockEnv.APPS_DEV_TUNNEL_SISH_SECRET = undefined;
+    const res = makeRes();
+    await handler(makeReq({ secret: 'anything', authKey: PUBKEY }), res);
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('non-POST → 405', async () => {
+    const res = makeRes();
+    await handler(makeReq({ secret: 'sish-shared-secret', method: 'GET' }), res);
+    expect(res.statusCode).toBe(405);
+  });
+});

--- a/src/tests/api/internal/blocks/dev-tunnel-gate.test.ts
+++ b/src/tests/api/internal/blocks/dev-tunnel-gate.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { signDevTunnelAccessToken } from '~/server/services/blocks/dev-tunnel-session';
+
+/**
+ * APP DEV TUNNEL — coverage for the Traefik forwardAuth entry gate
+ * `/api/internal/dev-tunnel-gate`. The LOAD-BEARING invariant (T3): a NAKED /
+ * expired / wrong-user / host-mismatched request is DENIED before it can reach
+ * the tunnel → the dev's localhost is never exposed.
+ */
+
+import handler from '~/pages/api/internal/dev-tunnel-gate';
+
+const SECRET = 'test-nextauth-secret-cccccccccccccccccccc';
+const HOST = 'dev-0123456789abcdef.civit.ai';
+const USER = 99;
+
+function makeRes() {
+  const headers: Record<string, string> = {};
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    _headers: headers,
+  };
+  return res as unknown as NextApiResponse & {
+    statusCode: number;
+    body: unknown;
+    _headers: Record<string, string>;
+  };
+}
+
+function makeReq(opts: { host?: string; uri?: string; secFetchDest?: string }): NextApiRequest {
+  const headers: Record<string, string> = {};
+  if (opts.host !== undefined) headers['x-forwarded-host'] = opts.host;
+  if (opts.uri !== undefined) headers['x-forwarded-uri'] = opts.uri;
+  if (opts.secFetchDest !== undefined) headers['sec-fetch-dest'] = opts.secFetchDest;
+  return { method: 'GET', headers } as unknown as NextApiRequest;
+}
+
+const entryUri = (token: string) => `/?dev=${encodeURIComponent(token)}`;
+
+describe('/api/internal/dev-tunnel-gate', () => {
+  const prev = process.env.NEXTAUTH_SECRET;
+  beforeEach(() => {
+    process.env.NEXTAUTH_SECRET = SECRET;
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.NEXTAUTH_SECRET;
+    else process.env.NEXTAUTH_SECRET = prev;
+  });
+
+  it('ENTRY (document) + valid dev token + matching host → 200 + X-Dev-User-Id', () => {
+    const token = signDevTunnelAccessToken({ userId: USER, host: HOST, secret: SECRET });
+    const res = makeRes();
+    handler(makeReq({ host: HOST, uri: entryUri(token), secFetchDest: 'document' }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res._headers['X-Dev-User-Id']).toBe(String(USER));
+  });
+
+  it('ENTRY (iframe) + valid token → 200', () => {
+    const token = signDevTunnelAccessToken({ userId: USER, host: HOST, secret: SECRET });
+    const res = makeRes();
+    handler(makeReq({ host: HOST, uri: entryUri(token), secFetchDest: 'iframe' }), res);
+    expect(res.statusCode).toBe(200);
+  });
+
+  // ── THE LOAD-BEARING TEST (T3): naked URL denied ──────────────────────────
+  it('NAKED entry request (no dev token) → 401 (T3 — localhost never exposed)', () => {
+    const res = makeRes();
+    handler(makeReq({ host: HOST, uri: '/', secFetchDest: 'document' }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('ABSENT Sec-Fetch-Dest is treated as ENTRY → still needs a token (naked → 401)', () => {
+    const res = makeRes();
+    handler(makeReq({ host: HOST, uri: '/' }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('expired token → 401', () => {
+    const token = signDevTunnelAccessToken({
+      userId: USER,
+      host: HOST,
+      secret: SECRET,
+      ttlSeconds: -1,
+    });
+    const res = makeRes();
+    handler(makeReq({ host: HOST, uri: entryUri(token), secFetchDest: 'document' }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('token bound to a DIFFERENT host (host mismatch) → 401', () => {
+    const token = signDevTunnelAccessToken({
+      userId: USER,
+      host: 'dev-ffffffffffffffff.civit.ai',
+      secret: SECRET,
+    });
+    const res = makeRes();
+    handler(makeReq({ host: HOST, uri: entryUri(token), secFetchDest: 'document' }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('token signed with a wrong secret (forged) → 401', () => {
+    const token = signDevTunnelAccessToken({ userId: USER, host: HOST, secret: 'wrong-secret' });
+    const res = makeRes();
+    handler(makeReq({ host: HOST, uri: entryUri(token), secFetchDest: 'document' }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('missing X-Forwarded-Host → 401 (fail-closed)', () => {
+    const token = signDevTunnelAccessToken({ userId: USER, host: HOST, secret: SECRET });
+    const res = makeRes();
+    handler(makeReq({ uri: entryUri(token), secFetchDest: 'document' }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('SUBRESOURCE (Sec-Fetch-Dest: script) → 200 (no token needed — accepted tradeoff)', () => {
+    const res = makeRes();
+    handler(makeReq({ host: HOST, uri: '/app.js', secFetchDest: 'script' }), res);
+    expect(res.statusCode).toBe(200);
+  });
+});

--- a/src/tests/api/internal/blocks/dev-tunnel-gate.test.ts
+++ b/src/tests/api/internal/blocks/dev-tunnel-gate.test.ts
@@ -4,9 +4,11 @@ import { signDevTunnelAccessToken } from '~/server/services/blocks/dev-tunnel-se
 
 /**
  * APP DEV TUNNEL — coverage for the Traefik forwardAuth entry gate
- * `/api/internal/dev-tunnel-gate`. The LOAD-BEARING invariant (T3): a NAKED /
- * expired / wrong-user / host-mismatched request is DENIED before it can reach
- * the tunnel → the dev's localhost is never exposed.
+ * `/api/internal/dev-tunnel-gate`. The gate protects the ENTRY DOCUMENT only: a
+ * NAKED / expired / wrong-user / host-mismatched ENTRY request is DENIED (401),
+ * so a visitor who knows the host cannot LOAD the dev page. Non-entry
+ * subresources pass with no token (host-secrecy only — the accepted mod-gate.ts
+ * tradeoff), so this suite pins the ENTRY-gate behaviour, not full protection.
  */
 
 import handler from '~/pages/api/internal/dev-tunnel-gate';
@@ -75,8 +77,8 @@ describe('/api/internal/dev-tunnel-gate', () => {
     expect(res.statusCode).toBe(200);
   });
 
-  // ── THE LOAD-BEARING TEST (T3): naked URL denied ──────────────────────────
-  it('NAKED entry request (no dev token) → 401 (T3 — localhost never exposed)', () => {
+  // ── ENTRY-document gate: naked ENTRY denied (visitor can't LOAD the page) ──
+  it('NAKED entry request (no dev token) → 401 (entry document gated)', () => {
     const res = makeRes();
     handler(makeReq({ host: HOST, uri: '/', secFetchDest: 'document' }), res);
     expect(res.statusCode).toBe(401);

--- a/src/tests/pages/apps/dev/dev-tunnel-page.test.ts
+++ b/src/tests/pages/apps/dev/dev-tunnel-page.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * APP DEV TUNNEL — `/apps/dev/[blockId]` SSR resolver.
+ *
+ *   - author + owner + flags + active tunnel → iframeSrc = https://<dev-host>/?dev=<token>
+ *     (server-derived host ONLY; strict `dev-<16hex>` shape) + a ROUTE-SCOPED CSP
+ *     header (frame-src the exact dev host).
+ *   - unauthenticated → redirect to login.
+ *   - non-owner (resolver null) → notFound.
+ *   - flag off / author cap off → notFound.
+ *   - a foreign/invalid tunnel host is NEVER reflected into iframeSrc (T6).
+ *   - the GLOBAL CSP is unchanged: a DIFFERENT route's resolver sets no CSP.
+ */
+
+const { capturedDev, capturedRun } = vi.hoisted(() => ({
+  capturedDev: { fn: null as null | ((c: any) => Promise<any>) },
+  capturedRun: { fn: null as null | ((c: any) => Promise<any>) },
+}));
+
+// Capture BOTH resolvers from the two page modules. The dev page is imported
+// first, the run page second, so route to the right capture by call order.
+let sspCallCount = 0;
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: (opts: { resolver: (c: any) => Promise<any> }) => {
+    const target = sspCallCount === 0 ? capturedDev : capturedRun;
+    target.fn = opts.resolver;
+    sspCallCount += 1;
+    return async () => ({ props: {} });
+  },
+}));
+
+const { mockResolveDev, mockResolvePageBySlug, mockGetActiveTunnel } = vi.hoisted(() => ({
+  mockResolveDev: vi.fn<(...a: any[]) => Promise<any>>(),
+  mockResolvePageBySlug: vi.fn<(...a: any[]) => Promise<any>>(),
+  mockGetActiveTunnel: vi.fn<(...a: any[]) => Promise<any>>(),
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    resolveDevPageBlockForAuthor: mockResolveDev,
+    resolvePageBlockBySlug: mockResolvePageBySlug,
+  },
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksDevTunnelEnabled: vi.fn(async () => true),
+}));
+vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
+  getActiveDevTunnel: (...a: unknown[]) => mockGetActiveTunnel(...(a as [])),
+}));
+// Real dev-tunnel-session (pure) — signs a real token + validates the host.
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+vi.mock('~/server/utils/server-domain', () => ({ ratingAllowedOnHost: () => true }));
+
+// Heavy component deps stubbed so importing the page modules doesn't pull a DOM.
+vi.mock('@mantine/core', () => ({
+  Alert: () => null,
+  Box: () => null,
+  Code: () => null,
+  Stack: () => null,
+  Text: () => null,
+  Title: () => null,
+  useComputedColorScheme: () => 'dark',
+}));
+vi.mock('~/components/AppBlocks/PageBlockHost', () => ({ PageBlockHost: () => null }));
+vi.mock('~/components/AppBlocks/useBlockToken', () => ({ useBlockToken: () => ({}) }));
+vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+const SECRET = 'test-nextauth-secret-dddddddddddddddddddd';
+const DEV_APP = {
+  appBlockId: 'apb_dev',
+  blockId: 'my-app',
+  appId: 'appblk-my-app',
+  status: 'pending',
+  trustTier: 'unverified' as const,
+  name: 'My App',
+  pageTitle: 'My App',
+  sandbox: 'allow-scripts',
+  scopes: [] as string[],
+  contentRating: null,
+};
+
+function makeCtx(opts: { user?: any; blockId?: string; setHeader: (k: string, v: string) => void }) {
+  return {
+    features: { appBlocks: true, appBlocksAuthor: true },
+    session: opts.user ? { user: opts.user } : null,
+    ctx: {
+      params: { blockId: opts.blockId ?? 'my-app' },
+      resolvedUrl: '/apps/dev/my-app',
+      req: { headers: { host: 'civitai.com' } },
+      res: { setHeader: opts.setHeader },
+    },
+  };
+}
+
+async function loadDevResolver() {
+  await import('~/pages/apps/dev/[blockId]');
+  if (!capturedDev.fn) throw new Error('dev resolver not captured');
+  return capturedDev.fn;
+}
+async function loadRunResolver() {
+  await import('~/pages/apps/run/[slug]/[[...path]]');
+  if (!capturedRun.fn) throw new Error('run resolver not captured');
+  return capturedRun.fn;
+}
+
+const AUTHOR = { id: 555, username: 'dev', isModerator: false };
+
+describe('/apps/dev/[blockId] SSR resolver', () => {
+  const prev = process.env.NEXTAUTH_SECRET;
+  beforeEach(() => {
+    process.env.NEXTAUTH_SECRET = SECRET;
+    mockResolveDev.mockReset();
+    mockGetActiveTunnel.mockReset();
+  });
+
+  it('author + owner + active tunnel → iframeSrc set (server-derived host) + route-scoped CSP', async () => {
+    const resolver = await loadDevResolver();
+    mockResolveDev.mockResolvedValue(DEV_APP);
+    mockGetActiveTunnel.mockResolvedValue({
+      sessionId: 'bki_s',
+      userId: 555,
+      blockId: 'my-app',
+      host: 'dev-0123456789abcdef.civit.ai',
+      hardExpiresAt: 9e9,
+      spendCapBuzz: 5000,
+    });
+    const headers: Record<string, string> = {};
+    const res = await resolver(
+      makeCtx({ user: AUTHOR, setHeader: (k, v) => (headers[k] = v) })
+    );
+    expect(res.props.iframeSrc).toMatch(
+      /^https:\/\/dev-0123456789abcdef\.civit\.ai\/\?dev=[^&]+$/
+    );
+    // ROUTE-SCOPED CSP: frame-src pinned to the exact dev host, on THIS response.
+    expect(headers['Content-Security-Policy']).toBe(
+      'frame-src https://dev-0123456789abcdef.civit.ai'
+    );
+    expect(headers['Content-Security-Policy']).toContain('dev-');
+  });
+
+  it('no active tunnel → props with iframeSrc:null (renders "start your tunnel"), no CSP', async () => {
+    const resolver = await loadDevResolver();
+    mockResolveDev.mockResolvedValue(DEV_APP);
+    mockGetActiveTunnel.mockResolvedValue(null);
+    const headers: Record<string, string> = {};
+    const res = await resolver(makeCtx({ user: AUTHOR, setHeader: (k, v) => (headers[k] = v) }));
+    expect(res.props.iframeSrc).toBeNull();
+    expect(headers['Content-Security-Policy']).toBeUndefined();
+  });
+
+  it('T6: a FOREIGN/invalid tunnel host is never reflected into iframeSrc', async () => {
+    const resolver = await loadDevResolver();
+    mockResolveDev.mockResolvedValue(DEV_APP);
+    // A poisoned session host (attacker-shaped) must fail isValidDevHost → no src.
+    mockGetActiveTunnel.mockResolvedValue({
+      sessionId: 'bki_s',
+      userId: 555,
+      blockId: 'my-app',
+      host: 'evil.com/../dev-0123456789abcdef.civit.ai',
+      hardExpiresAt: 9e9,
+      spendCapBuzz: 5000,
+    });
+    const headers: Record<string, string> = {};
+    const res = await resolver(makeCtx({ user: AUTHOR, setHeader: (k, v) => (headers[k] = v) }));
+    expect(res.props.iframeSrc).toBeNull();
+    expect(headers['Content-Security-Policy']).toBeUndefined();
+  });
+
+  it('unauthenticated → redirect to login', async () => {
+    const resolver = await loadDevResolver();
+    const res = await resolver(makeCtx({ user: undefined, setHeader: () => {} }));
+    expect(res.redirect?.destination).toContain('/login');
+  });
+
+  it('non-owner (resolver returns null) → notFound', async () => {
+    const resolver = await loadDevResolver();
+    mockResolveDev.mockResolvedValue(null);
+    const res = await resolver(makeCtx({ user: AUTHOR, setHeader: () => {} }));
+    expect(res.notFound).toBe(true);
+  });
+
+  it('author capability missing → notFound (fail-closed)', async () => {
+    const resolver = await loadDevResolver();
+    const res = await resolver({
+      features: { appBlocks: true, appBlocksAuthor: false },
+      session: { user: AUTHOR },
+      ctx: {
+        params: { blockId: 'my-app' },
+        resolvedUrl: '/apps/dev/my-app',
+        req: { headers: { host: 'civitai.com' } },
+        res: { setHeader: () => {} },
+      },
+    });
+    expect(res.notFound).toBe(true);
+  });
+
+  it('GLOBAL CSP unchanged: the /apps/run resolver sets NO Content-Security-Policy', async () => {
+    const runResolver = await loadRunResolver();
+    mockResolvePageBySlug.mockResolvedValue({
+      appBlockId: 'ab',
+      blockId: 'cool',
+      appId: 'app',
+      iframeSrc: 'https://cool.civit.ai',
+      sandbox: 'allow-scripts',
+      trustTier: 'unverified',
+      name: 'Cool',
+      pageTitle: 'Cool',
+      scopes: [],
+      contentRating: 'g',
+    });
+    const headers: Record<string, string> = {};
+    await runResolver({
+      features: { appBlocks: true, appBlocksPages: true },
+      ctx: {
+        params: { slug: 'cool' },
+        req: { headers: { host: 'civitai.com' } },
+        res: { setHeader: (k: string, v: string) => (headers[k] = v) },
+      },
+    });
+    // The dev route sets a frame-src CSP; the run route must NOT — proving the
+    // dev route's CSP is route-scoped and never widens the global CSP.
+    expect(headers['Content-Security-Policy']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Civitai Apps on-site dev tunnel — **P1 control plane** (DARK)

Phase P1 of "Civitai Apps on-site dev via hardened tunnel". The civitai control
plane for the sish tunnel P0 deployed. **Everything ships DARK** behind the new
`app-blocks-dev-tunnel` Flipt flag (base off) → inert in prod until P3 flips it.
A generalization of the mod review sandbox ("mod-bound, pending build" →
"author-bound, live tunnel").

Design: `datapacket-talos/claudedocs/app-blocks-dev-tunnel-design-2026-07-03.md` (§8 = P1).
**Flag PR (separate repo, not stacked):** civitai/flipt-state#10.

### What's here
- **Flag reader** `isAppBlocksDevTunnelEnabled()` — mirrors review-sandbox; fail-safe absent/Flipt-down ⇒ OFF (no mod static floor — brand-new surface).
- **tRPC** `blocks.startDevTunnel` / `stopDevTunnel` / `devTunnelStatus` on `appDeveloperProcedure` + `enforceAppBlocksFlag` + the dev-tunnel flag + **block ownership**. Mints a **pubkey-bound tunnel credential**, assigns `dev-<random16>.<APPS_DOMAIN>`, renders the ephemeral Traefik IngressRoute + forwardAuth Middleware via the in-pod SA k8s API (reuses the apps-pipeline helpers). One active tunnel per (user, block); server-authoritative reaper.
- **sish authz callback** `POST /api/apps/dev-tunnel/authz` — the `authentication-key-request-url` target. Shared-secret self-auth (constant-time), **constant-time pubkey compare**, **single-use** consume (replay → deny), expiry. `user`/`remote_addr` treated as attacker-controlled (logged only).
- **Route** `/apps/dev/[blockId]` + `BlockRegistry.resolveDevPageBlockForAuthor` (own app, ANY status; null for others). `iframeSrc` **server-derived from the tunnel host only** (strict `^dev-[a-f0-9]{16}\.` regex, T6) + a **route-scoped CSP** `frame-src https://<dev-host>` that never widens the global CSP (T7). Renders the real `PageBlockHost`.
- **Entry-token forwardAuth** `/api/internal/dev-tunnel-gate` — author-bound sibling of `mod-gate`. Gates the **ENTRY DOCUMENT only**: a naked / expired / wrong-user / host-mismatched ENTRY request ⇒ **401**, so a visitor who knows the host cannot *load* the dev page. Non-entry subresources pass with **no token** — they are protected by **host-secrecy only** (the unguessable ~64-bit `dev-<16hex>` host), the identical accepted tradeoff as `mod-gate.ts`; the victim of a leaked host is the **author's own machine**.
- **Spend-cap backstop** — per-dev-session cumulative Buzz ceiling, atomic + fail-closed.
- **Telemetry** — Prometheus `civitai_app_dev_tunnels_active` + mint/teardown counters + stdout lifecycle logs (→ Loki). (No Faro RUM wiring exists in this app; none added — see below.)

### Credential / auth-callback design
The CLI generates an **ephemeral SSH keypair** and sends its **public** key to `startDevTunnel`; the mint stores it keyed by `sha256(normalized pubkey)`. sish forwards the presented `auth_key` (pubkey) to the callback → fingerprint lookup → **constant-time compare of the full stored pubkey**. Replay is defended by (a) a **shared secret** only sish knows, (b) a short-TTL credential, and (c) a **best-effort single-use consume** (first authz deletes the index → a later replay misses → deny). The consume is **NOT atomic** (GET-then-DEL TOCTOU) and is belt-and-suspenders, not the boundary: replay is structurally inert because `auth_key` is a *public* key and the SSH transport has already proven private-key possession, so a replayer can't bind the tunnel and gains nothing.

### Route-scoped CSP
Set via `ctx.res.setHeader('Content-Security-Policy', 'frame-src https://<dev-host>')` in `getServerSideProps` — a per-response header, so it only affects `/apps/dev`. The global CSP (next.config `headers()`) is untouched; a test asserts the `/apps/run` resolver sets **no** CSP.

### Deferred to P3 (honest scope)
- The **public `ssh -R` exposure** (shared-proxy nginx stream, port 2224) — out of P1 by design.
- The **block-token bridge** that lights up real per-account Buzz/pickers/storage inside `PageBlockHost` needs the real tunnel to actually serve (not testable in P1) and reuses the existing audited `/api/v1/blocks/dev-token` real-Buzz clamp — a P3 runtime integration. The route renders `PageBlockHost` with the tunnel iframeSrc + entry token today.
- **Faro RUM**: this app has **no** Faro wiring (grep-confirmed); per "do NOT stand up new Faro infra" none was added — browser-side dev-route telemetry lands with the P3 wiring.
- **Reaper scheduler** + the exact sish 200-body shape are confirmed against the sish image at P3.

### Tests / checks (actually run)
- `tsc --noEmit`: **0 errors**.
- **66 unit/integration tests pass** across 7 files: entry/pubkey crypto; gate (naked-URL-denied); authz matrix (forged user / replay / expired / wrong pubkey); service (mint / stop / reaper / spend-cap / SSRF-safe manifests); resolver (own-any-status vs null + the run-path-can't-resolve-dev invariant); route SSR (iframeSrc / redirect / notFound / route-CSP + **global-CSP-unchanged** / SSRF-reject); router authz matrix. No regressions in the 107 sibling app-blocks tests.
- **NOT verified**: the true end-to-end tunnel path (deferred to P3 — requires the public SSH exposure + a live sish bind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
