### PR TITLE
feat(generation): Anima ControlNet support + kill-switch flag

### DIFF
--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -97,6 +97,11 @@ const featureFlags = createFeatureFlags({
     availability: ['public'],
     fliptKey: 'enhanced-compatibility-sdcpp',
   },
+  // Anima ControlNet kill-switch. Default ON (public + fail-open when Flipt is
+  // down); the `anima-controlnet` Flipt flag is the lever — flip it OFF to hide
+  // the Anima ControlNet input (and strip controlNets server-side) without a
+  // deploy if the orchestrator side misbehaves.
+  animaControlnet: { availability: ['public'], fliptKey: 'anima-controlnet' },
   questions: ['dev', 'mod'],
   imageGeneration: ['public'],
   largerGenerationImages: {

--- a/src/server/services/orchestrator/ecosystems/anima.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/anima.handler.ts
@@ -8,13 +8,15 @@
 import type {
   AnimaCreateImageGenInput,
   ImageGenStepTemplate,
+  PreprocessImageStepTemplate,
   SdCppSampleMethod,
   SdCppSchedule,
 } from '@civitai/client';
 import { removeEmpty } from '~/utils/object-helpers';
 import type { GenerationGraphTypes } from '~/shared/data-graph/generation/generation-graph';
-import type { ResourceData } from '~/shared/data-graph/generation/common';
+import type { ControlNetsNodeValue, ResourceData } from '~/shared/data-graph/generation/common';
 import { defineHandler } from './handler-factory';
+import { buildControlNetSteps } from './controlnets.helper';
 
 // Types derived from generation graph
 type EcosystemGraphOutput = Extract<GenerationGraphTypes['Ctx'], { ecosystem: string }>;
@@ -23,7 +25,10 @@ type AnimaCtx = EcosystemGraphOutput & { ecosystem: 'Anima' };
 /**
  * Creates imageGen input for Anima ecosystem.
  */
-export const createAnimaInput = defineHandler<AnimaCtx, [ImageGenStepTemplate]>((data, ctx) => {
+export const createAnimaInput = defineHandler<
+  AnimaCtx,
+  (ImageGenStepTemplate | PreprocessImageStepTemplate)[]
+>((data, ctx) => {
   const loras: Record<string, number> = {};
   if ('resources' in data && Array.isArray(data.resources)) {
     for (const resource of data.resources as ResourceData[]) {
@@ -33,29 +38,36 @@ export const createAnimaInput = defineHandler<AnimaCtx, [ImageGenStepTemplate]>(
 
   const diffuserModel = data.model ? ctx.airs.getOrThrow(data.model.id) : undefined;
 
-  return [
-    {
-      $type: 'imageGen',
-      input: removeEmpty({
-        engine: 'comfy',
-        ecosystem: 'anima',
-        operation: 'createImage',
-        prompt: data.prompt,
-        negativePrompt: data.negativePrompt,
-        width: data.aspectRatio?.width,
-        height: data.aspectRatio?.height,
-        cfgScale: data.cfgScale,
-        steps: data.steps,
-        sampleMethod: data.sampler as SdCppSampleMethod,
-        schedule: data.scheduler as SdCppSchedule,
-        seed: data.seed,
-        quantity: data.quantity ?? 1,
-        outputFormat: data.outputFormat,
-        loras: Object.keys(loras).length > 0 ? loras : undefined,
-        diffuserModel,
-        // TODO: remove `as any` once @civitai/client ships updated AnimaCreateImageGenInput
-        // (current published type still declares engine: 'sdcpp', upstream switched to 'comfy').
-      }) as any as AnimaCreateImageGenInput,
-    },
-  ];
+  const { preprocessSteps, controlNets } = buildControlNetSteps(
+    (data as { controlNets?: ControlNetsNodeValue }).controlNets,
+    ctx.baseStepIndex
+  );
+
+  const genStep: ImageGenStepTemplate = {
+    $type: 'imageGen',
+    input: removeEmpty({
+      engine: 'comfy',
+      ecosystem: 'anima',
+      operation: 'createImage',
+      prompt: data.prompt,
+      negativePrompt: data.negativePrompt,
+      width: data.aspectRatio?.width,
+      height: data.aspectRatio?.height,
+      cfgScale: data.cfgScale,
+      steps: data.steps,
+      sampleMethod: data.sampler as SdCppSampleMethod,
+      schedule: data.scheduler as SdCppSchedule,
+      seed: data.seed,
+      quantity: data.quantity ?? 1,
+      outputFormat: data.outputFormat,
+      loras: Object.keys(loras).length > 0 ? loras : undefined,
+      diffuserModel,
+      ...(controlNets.length ? { controlNets } : {}),
+      // `as any`: (1) published AnimaCreateImageGenInput still declares engine
+      // 'sdcpp' (upstream switched to 'comfy'); (2) controlNets isn't declared on
+      // the type yet but is accepted by the orchestrator for the anima ecosystem.
+    }) as any as AnimaCreateImageGenInput,
+  };
+
+  return [...preprocessSteps, genStep];
 });

--- a/src/shared/constants/controlnets.constants.ts
+++ b/src/shared/constants/controlnets.constants.ts
@@ -766,3 +766,38 @@ export const zImageControlNetPreprocessors: ControlNetPreprocessorKey[] = [
   'openpose',
   'dwpose',
 ];
+
+/**
+ * Anima ControlNet support. Backed by 5 Anima-specific control models on the
+ * orchestrator (`engine: comfy`, `ecosystem: anima`); each preprocessor below
+ * maps to one of them upstream: an "any-test-like" model (canny, gray), a
+ * lineart model (lineart variants + anyline), a depth model (depth/zoe/midas/
+ * leres/metric3d depth), a pose model (openpose, dwpose), and a scribble model
+ * (scribble variants + fakeScribble + hed + softedgePidinet).
+ * Kinds with no Anima model (mlsd, tile, shuffle, teed, depthZoe, normals,
+ * segmentation) are intentionally omitted.
+ */
+export const animaControlNetPreprocessors: ControlNetPreprocessorKey[] = [
+  'canny',
+  'gray',
+  'lineartStandard',
+  'lineartRealistic',
+  'lineartAnime',
+  'lineartManga',
+  'anyline',
+  'depthAnything',
+  'depthAnythingV2',
+  'zoeDepth',
+  'zoeDepthAnything',
+  'midasDepth',
+  'leresDepth',
+  'metric3dDepth',
+  'openpose',
+  'dwpose',
+  'scribble',
+  'scribbleXdog',
+  'scribblePidinet',
+  'fakeScribble',
+  'hed',
+  'softedgePidinet',
+];

--- a/src/shared/data-graph/generation/anima-graph.ts
+++ b/src/shared/data-graph/generation/anima-graph.ts
@@ -83,14 +83,15 @@ export const animaGraph = new DataGraph<{ ecosystem: string; workflow: string },
     samplerNode({ options: animaSamplers, defaultValue: 'euler_a', presets: animaSamplerPresets })
   )
   .node('scheduler', schedulerNode({ options: animaSchedules, defaultValue: 'simple' }))
-  // ControlNets — only available for txt2img workflows.
+  // ControlNets — txt2img only, gated by the `animaControlnet` kill-switch flag
+  // (fail-open: shown unless the flag is explicitly false).
   .node(
     'controlNets',
-    (ctx) => ({
+    (ctx, ext) => ({
       ...controlNetsNode({ preprocessors: animaControlNetPreprocessors, limit: CONTROLNET_LIMIT }),
-      when: ctx.workflow === 'txt2img',
+      when: ctx.workflow === 'txt2img' && ext.flags?.animaControlnet !== false,
     }),
-    ['workflow']
+    ['workflow', 'ext:flags']
   )
   .merge(triggerWordsGraph)
   .merge(snippetsGraph)

--- a/src/shared/data-graph/generation/anima-graph.ts
+++ b/src/shared/data-graph/generation/anima-graph.ts
@@ -10,6 +10,8 @@ import { DataGraph } from '~/libs/data-graph/data-graph';
 import type { GenerationCtx } from './context';
 import {
   aspectRatioNode,
+  controlNetsNode,
+  CONTROLNET_LIMIT,
   createCheckpointGraph,
   createResourcesGraph,
   negativePromptGraph,
@@ -22,6 +24,7 @@ import {
   triggerWordsGraph,
 } from './common';
 import { sdxlAspectRatioBuckets } from '~/shared/constants/generation.constants';
+import { animaControlNetPreprocessors } from '~/shared/constants/controlnets.constants';
 
 // =============================================================================
 // Constants
@@ -80,6 +83,15 @@ export const animaGraph = new DataGraph<{ ecosystem: string; workflow: string },
     samplerNode({ options: animaSamplers, defaultValue: 'euler_a', presets: animaSamplerPresets })
   )
   .node('scheduler', schedulerNode({ options: animaSchedules, defaultValue: 'simple' }))
+  // ControlNets — only available for txt2img workflows.
+  .node(
+    'controlNets',
+    (ctx) => ({
+      ...controlNetsNode({ preprocessors: animaControlNetPreprocessors, limit: CONTROLNET_LIMIT }),
+      when: ctx.workflow === 'txt2img',
+    }),
+    ['workflow']
+  )
   .merge(triggerWordsGraph)
   .merge(snippetsGraph)
   .merge(promptGraph)


### PR DESCRIPTION
## What

Adds ControlNet support to the **Anima** base model in the generator (txt2img), mirroring the existing ZImage wiring. Requested via Freshdesk #67022 / ClickUp [868k869q0](https://app.clickup.com/t/8459928/868k869q0) — user switched from Illustrious (which has ControlNet) to Anima and wants parity.

Orchestrator side is already live — Koen confirmed `engine: comfy, ecosystem: anima` accepts `controlNets` and shipped the exact request spec + supported preprocessor→model map.

## Changes

- **`controlnets.constants.ts`** — new `animaControlNetPreprocessors` (22 keys) covering Anima's 5 control models (any-test-like / lineart / depth / pose / scribble). Kinds with no Anima model (mlsd, tile, shuffle, teed, depthZoe, normals, segmentation) are omitted.
- **`anima-graph.ts`** — adds the `controlNets` node, gated `when: workflow === 'txt2img'` **and** on the new kill-switch flag (fail-open).
- **`anima.handler.ts`** — reuses the shared `buildControlNetSteps` helper to prepend `preprocessImage` steps and attach `controlNets` to the imageGen input (same `as any` cast ZImage uses for the comfy/sdcpp type skew).
- **`feature-flags.service.ts`** — new `animaControlnet` flag (fliptKey `anima-controlnet`, `availability: ['public']` → default-on, fail-open when Flipt is down).

## Kill switch

Flipt flag **`anima-controlnet`** is live in `civitai/flipt-state` (`enabled: true`). Because the generation graph is shared client+server, flipping it **off** both hides the input and strips `controlNets` server-side — no deploy needed.

## Out of scope

Inpainting/outpainting from the same ticket is a net-new generation workflow (doesn't exist in gen-v2 for any ecosystem) — tracked separately.

## Checks

- `pnpm typecheck` ✅
- `pnpm prettier` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)