### PR TITLE
fix(challenges): close duplicate judge-review / score re-roll exploit

### DIFF
--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -804,6 +804,15 @@ async function reviewEntriesForChallenge(currentChallenge: DailyChallengeDetails
   const scoredCountMap = new Map(userScoredCounts.map((r) => [r.userId, Number(r.count)]));
   log('Users with scored entries:', scoredCountMap.size);
 
+  // Durable "already reviewed" gate: the judged tag lives in the mutable
+  // CollectionItem.tagId, which resets when an entry is removed and re-added — letting
+  // users re-roll their score. The judge's comment survives that collection churn.
+  const notYetReviewedByJudge = Prisma.sql`NOT EXISTS (
+    SELECT 1 FROM "Thread" th
+    JOIN "CommentV2" cm ON cm."threadId" = th.id
+    WHERE th."imageId" = ci."imageId" AND cm."userId" = ${judgingConfig.userId}
+  )`;
+
   // Get entries approved since last reviewed
   const recentEntries = await dbWrite.$queryRaw<RecentEntry[]>`
     SELECT
@@ -818,6 +827,7 @@ async function reviewEntriesForChallenge(currentChallenge: DailyChallengeDetails
     AND ci.status = 'ACCEPTED'
     AND ci."tagId" IS NULL
     AND ci."reviewedAt" >= ${lastReviewedAt}
+    AND ${notYetReviewedByJudge}
   `;
   log('Recent entries:', recentEntries.length);
 
@@ -851,6 +861,7 @@ async function reviewEntriesForChallenge(currentChallenge: DailyChallengeDetails
     WHERE ci."collectionId" = ${currentChallenge.collectionId}
     AND ci.status = 'ACCEPTED'
     AND ci."tagId" = ${config.reviewMeTagId}
+    AND ${notYetReviewedByJudge}
   `;
   log('Requested review:', requestReview.length);
   // Paid review entries bypass per-user cap — users paid for guaranteed review
@@ -862,6 +873,23 @@ async function reviewEntriesForChallenge(currentChallenge: DailyChallengeDetails
   const tasks = toReview.map((entry) => async () => {
     try {
       log('Reviewing entry:', entry);
+
+      // Defense-in-depth for the selection-time gate: an overlapping job run (lock
+      // expires before the 10-min cron interval) could have selected this same entry.
+      // Re-check on dbWrite right before spending an LLM call so concurrent runs can't
+      // double-comment.
+      const [alreadyReviewed] = await dbWrite.$queryRaw<[{ exists: boolean }?]>`
+        SELECT EXISTS (
+          SELECT 1 FROM "Thread" th
+          JOIN "CommentV2" cm ON cm."threadId" = th.id
+          WHERE th."imageId" = ${entry.imageId} AND cm."userId" = ${judgingConfig.userId}
+        ) AS "exists"
+      `;
+      if (alreadyReviewed?.exists) {
+        log('Skipping already-reviewed entry', entry.imageId);
+        return;
+      }
+
       const review = await generateReview({
         theme: currentChallenge.theme,
         themeElements,

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -1921,6 +1921,34 @@ export const validateContestCollectionEntry = async ({
     throw throwBadRequestError('You are banned from participating in contests');
   }
 
+  // Block re-submitting an image a challenge judge has already scored. Removal
+  // hard-deletes the CollectionItem (erasing tag/score), so the judge's comment is the
+  // durable "already judged" signal — across this and every other challenge. Limited to
+  // challenge collections (target has a linked Challenge) so community contests are
+  // unaffected. Scoped to genuine re-adds: an image still present as an entry is excluded,
+  // so editing a post that re-saves its images doesn't fail.
+  if (imageIds.length > 0 && !isModerator) {
+    const alreadyJudged = await dbRead.$queryRaw<{ imageId: number }[]>`
+      SELECT DISTINCT th."imageId"
+      FROM "Thread" th
+      JOIN "CommentV2" cm ON cm."threadId" = th.id
+      JOIN "ChallengeJudge" cj ON cj."userId" = cm."userId"
+      WHERE th."imageId" IN (${Prisma.join(imageIds)})
+        AND EXISTS (SELECT 1 FROM "Challenge" ch WHERE ch."collectionId" = ${collectionId})
+        AND NOT EXISTS (
+          SELECT 1 FROM "CollectionItem" ci
+          WHERE ci."collectionId" = ${collectionId}
+            AND ci."imageId" = th."imageId"
+            AND ci.status IN ('ACCEPTED', 'REVIEW')
+        )
+    `;
+    if (alreadyJudged.length > 0) {
+      throw throwBadRequestError(
+        'This image has already been judged in a challenge and cannot be re-submitted. Please enter a new image.'
+      );
+    }
+  }
+
   if (!metadata) {
     return;
   }


### PR DESCRIPTION
## Problem

The daily-challenge judge bot ("CivBot") posts **multiple review comments** on the same challenge entry, and users exploit this to **re-roll their AI judge score**: they remove their image from the challenge collection and re-add it, get a fresh judge review + score, and keep only the best one.

Confirmed active in prod (ClickUp [868k81j9n](https://app.clickup.com/t/868k81j9n)) — duplicates as recent as this week, up to 6 reviews on a single image. Concentration is one user (~90% of duplicates), whose kept scores are uniformly top-tier (theme 9–10 / aesthetic 9 / wit+humor 6–8) vs. a scattered peer baseline — i.e. best-of-N score-shopping.

### Root cause

The review job's only "already reviewed" guard is the **mutable `CollectionItem.tagId = judgedTagId`**:

- `saveItemInCollections` / `bulkSaveItems` do `ON CONFLICT (...) DO UPDATE SET "tagId" = EXCLUDED."tagId"` — challenge entries carry `tagId = NULL`, so re-saving wipes the judged tag.
- Removing an entry **hard-deletes** the `CollectionItem`; re-adding inserts a fresh row (`tagId = NULL`, `status = REVIEW`).

Either way the entry re-enters the review pool. `upsertComment` is called with no `id`, so it **always creates a new comment** — no per-image dedup.

## Fix

Three layers, all keyed on the **durable signal** that an image was already judged: a review comment by a `ChallengeJudge`. That comment survives every collection churn (tag reset *and* delete+reinsert).

1. **Review selection gate** (`daily-challenge-processing.ts`) — both selection queries (`recentEntries` + `requestReview`) now exclude images the challenge judge has already commented on. No new score on re-add; also skips the wasted LLM call.
2. **Race guard** (`daily-challenge-processing.ts`) — a `dbWrite` re-check right before posting, so two overlapping job runs (the distributed lock, 300s, is shorter than the 10-min cron) can't double-comment.
3. **Submission block** (`collection.service.ts`, `validateContestCollectionEntry`) — reject re-adding an already-judged image to a **challenge** collection. Blocks reuse across *any* challenge (fairness), while:
   - allowing unlimited **new** images,
   - scoped to challenge-linked collections only (`EXISTS Challenge WHERE collectionId = target`) — community/user Contests unaffected,
   - excluding images still present as an entry, so **editing a post** (which re-saves its images) doesn't fail,
   - mods bypass.

## Validation

Ran the new predicates against the prod replica:

- Selection gate on an active challenge collection: blocks exactly the already-commented leak entries, spares all genuinely-fresh entries (no over-block).
- Submission guard: blocks a judged image that was removed (incl. from a *different* challenge), allows a judged image that is still a present entry (post-edit safe), and no-ops for non-challenge collections. Confirmed challenge collections resolve via `Challenge.collectionId`.
- Judge identity: keys on the exact `upsertComment` author (per-challenge judge or default); `Thread.imageId` is unique; both lookups hit hash indexes.

Editor diagnostics clean. Reviewed via a code-review pass (no Critical; the concurrent-run race it raised is addressed by layer 2).

## Not covered (follow-ups)

- **Re-uploading the identical image as a new post** (new `imageId`) bypasses all gates — there is no image perceptual-hash in the schema. Separate, larger effort. With this fix each distinct upload still gets exactly one honest score.
- **Backlog / mod action:** already-leaked entries keep whatever score they currently hold; the offending user(s) need a separate moderation review.
- **Optional hardening:** a DB unique constraint to fully eliminate the residual simultaneous-run race.

## Migrations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
