### PR TITLE
fix(app-blocks): harden dev-tunnel control plane (P4 audit F1/F3/F4 + R1)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -781,6 +781,13 @@ export const serverSchema = z
     APPS_DEV_TUNNEL_SISH_BACKEND: z
       .string()
       .default('http://sish-http.apps-dev-tunnel.svc.cluster.local:8080'),
+    // APPS_DEV_TUNNEL_SSH_HOST_PUBKEY   the sish server's SSH HOST public key, as a
+    //   NON-SECRET OpenSSH line (`ssh-ed25519 AAAA...`). Returned by
+    //   startDevTunnel so the CLI can PIN it on the `ssh -R` hop (R1 — closes the
+    //   MITM window; see design Revision-2 gate #6). Unset → startDevTunnel returns
+    //   an empty string and the CLI must fail closed (refuse to connect without a
+    //   pin) rather than fall back to InsecureIgnoreHostKey.
+    APPS_DEV_TUNNEL_SSH_HOST_PUBKEY: z.string().optional(),
   })
   .superRefine((env, ctx) => {
     // Sentinel-mode for the system Redis client requires an explicit master group

--- a/src/pages/api/internal/dev-tunnel-gate.ts
+++ b/src/pages/api/internal/dev-tunnel-gate.ts
@@ -57,7 +57,7 @@ function extractDevToken(forwardedUri: string | undefined): string | undefined {
   }
 }
 
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const forwardedHost = firstHeader(req.headers['x-forwarded-host']);
   const forwardedUri = firstHeader(req.headers['x-forwarded-uri']);
   const secFetchDest = firstHeader(req.headers['sec-fetch-dest']);
@@ -84,6 +84,19 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   if (result.ok && result.userId != null) {
     res.setHeader('X-Dev-User-Id', String(result.userId));
     res.status(200).json({ ok: true, via: 'token' });
+    // F3 — refresh the session's idle marker on this (successful, browser-driven)
+    // ENTRY hit so the server-side idle-reaper measures real activity, not just
+    // the 8h hard-TTL. Runs AFTER the auth response is flushed above so a Redis
+    // hiccup can NEVER change the gate decision or add user-facing latency
+    // (touchDevTunnelActivity swallows all errors; awaited only so tests settle).
+    try {
+      const { touchDevTunnelActivity } = await import(
+        '~/server/services/blocks/dev-tunnel.service'
+      );
+      await touchDevTunnelActivity(forwardedHost);
+    } catch {
+      /* idle-refresh is best-effort — the auth decision already stands */
+    }
     return;
   }
 

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -103,6 +103,22 @@ const {
   mockRecordSpendAttribution: vi.fn(),
 }));
 
+// F4: submitWorkflow dynamically imports the dev-tunnel spend backstop. Mock the
+// module so the default (no active tunnel → getActiveDevTunnel null) leaves every
+// existing test unchanged, and the F4 tests can drive an active dev session.
+const { mockGetActiveDevTunnel, mockReserveDevSessionBuzz, mockRefundDevSessionBuzz } = vi.hoisted(
+  () => ({
+    mockGetActiveDevTunnel: vi.fn(async () => null as unknown),
+    mockReserveDevSessionBuzz: vi.fn(async () => ({ allowed: true, total: 0 })),
+    mockRefundDevSessionBuzz: vi.fn(async () => undefined),
+  })
+);
+vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
+  getActiveDevTunnel: (...a: unknown[]) => mockGetActiveDevTunnel(...(a as [])),
+  reserveDevSessionBuzz: (...a: unknown[]) => mockReserveDevSessionBuzz(...(a as [])),
+  refundDevSessionBuzz: (...a: unknown[]) => mockRefundDevSessionBuzz(...(a as [])),
+}));
+
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
   verifyBlockToken: mockVerifyBlockToken,
   parseSubjectUserId: (...args: unknown[]) => mockParseSubjectUserId(...args),
@@ -341,9 +357,17 @@ beforeEach(() => {
     mockResolveCanGenerateForVersions,
     mockRecordSpendAttribution,
     mockIsAppBlocksAuthorEnabled,
+    mockGetActiveDevTunnel,
+    mockReserveDevSessionBuzz,
+    mockRefundDevSessionBuzz,
   ]) {
     fn.mockReset();
   }
+  // F4 defaults: no active dev tunnel (getActiveDevTunnel → null) so the dev
+  // spend backstop is inert for every non-dev test. The F4 tests override these.
+  mockGetActiveDevTunnel.mockResolvedValue(null);
+  mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 0 });
+  mockRefundDevSessionBuzz.mockResolvedValue(undefined);
   // W3 flow A default: the spend-attribution write resolves successfully.
   // Tests that exercise best-effort override it to reject.
   mockRecordSpendAttribution.mockResolvedValue({
@@ -616,6 +640,79 @@ describe('blocks.submitWorkflow', () => {
     expect(mockAuditPromptServer).toHaveBeenCalledWith(
       expect.objectContaining({ prompt: 'a cat', userId: 42 })
     );
+  });
+
+  // ---- F4: dev-tunnel per-session spend backstop --------------------------
+  describe('dev-tunnel session spend cap (F4)', () => {
+    function setupSubmit() {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+    }
+
+    it('rejects (fail-closed) when the dev session ceiling is exceeded — no real submit', async () => {
+      setupSubmit();
+      // Active dev tunnel for this (user, block); the reserve DENIES.
+      mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 5000 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: false, total: 5000 });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      expect(result.snapshot.status).toBe('failed');
+      expect(result.snapshot.error).toMatch(/dev tunnel session Buzz cap reached/);
+      // Only the whatIf cost-check submit ran; the REAL submit was never reached.
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+      // The reserve was checked against the session's own ceiling.
+      expect(mockReserveDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 25, 5000);
+      // The daily-cap reservation was refunded (DECRBY) on the reject.
+      expect(mockSysRedis.decrBy).toHaveBeenCalled();
+    });
+
+    it('passes through when the dev session is UNDER the ceiling (real submit proceeds)', async () => {
+      setupSubmit();
+      mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 5000 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 25 });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(2);
+      expect(mockRefundDevSessionBuzz).not.toHaveBeenCalled();
+    });
+
+    it('refunds the dev-session reservation when the real submit THROWS', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
+      happyVersionLookup();
+      happyUser();
+      mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 5000 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 25 });
+      // whatIf ok, then the REAL submit throws.
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockRejectedValueOnce(new Error('orchestrator down'));
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
+      ).rejects.toThrow(/orchestrator down/);
+      // both the daily cap AND the dev session reservation were refunded.
+      expect(mockSysRedis.decrBy).toHaveBeenCalled();
+      expect(mockRefundDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 25);
+    });
+
+    it('is INERT for a normal submit (no active dev tunnel → reserve never called)', async () => {
+      setupSubmit();
+      // default mockGetActiveDevTunnel → null
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      expect(mockReserveDevSessionBuzz).not.toHaveBeenCalled();
+    });
   });
 
   // ---- workflow metadata parity (queue/remix view) ------------------------

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -2739,6 +2739,57 @@ export const blocksRouter = router({
         };
       }
 
+      // APP DEV TUNNEL per-session spend backstop (F4). When the caller has an
+      // ACTIVE dev tunnel for THIS block, bound cumulative spend within that ONE
+      // dev session (a backstop OVER the per-call budget + the per-user daily cap
+      // above) so a runaway LOCAL submit loop can't drain Buzz. The block token
+      // carries no dev-session id (see the P4 audit / handoff note), so the
+      // session is resolved SERVER-SIDE from (userId, blockId) — a single Redis
+      // GET that misses (and no-ops) for every non-dev submit.
+      //
+      // Posture: the LOOKUP fails OPEN (a getActiveDevTunnel error → treat as
+      // non-dev, so a Redis blip can't break ALL generation — the daily cap still
+      // applies), but the ENFORCEMENT fails CLOSED (reserveDevSessionBuzz denies
+      // on a Redis error once we know it IS a dev session). Mirrors the daily
+      // cap's refund-on-throw so a failed submit doesn't permanently burn the
+      // session ceiling. Why the fail-open is SAFE: the fail-CLOSED per-user daily
+      // cap (reserveBlockBuzzSpend above, whose incrBy is NOT wrapped in a catch)
+      // has ALREADY run and throws on any Redis error — so a real Redis outage
+      // rejects the submit BEFORE this lookup even executes. The fail-open here
+      // can therefore only degrade the finer session cap while the daily cap is
+      // healthy, i.e. within an already-daily-capped bound — never an uncapped one.
+      let devSessionReserve: { sessionId: string; cost: number } | null = null;
+      {
+        const { getActiveDevTunnel, reserveDevSessionBuzz } = await import(
+          '~/server/services/blocks/dev-tunnel.service'
+        );
+        const devTunnel = await getActiveDevTunnel(userId, claims.blockId).catch(() => null);
+        if (devTunnel) {
+          const reserved = await reserveDevSessionBuzz(
+            devTunnel.sessionId,
+            cost,
+            devTunnel.spendCapBuzz
+          );
+          if (!reserved.allowed) {
+            // Over the session ceiling → refund the daily reservation made above
+            // (the session reserve rolled ITSELF back on deny) and reject.
+            await refundBlockBuzzSpend(buzzCapKey, cost);
+            return {
+              snapshot: {
+                workflowId: 'failed',
+                status: 'failed' as const,
+                cost: { total: cost },
+                error:
+                  `dev tunnel session Buzz cap reached: ${reserved.total} already spent ` +
+                  `this dev session, this generation costs ${Math.ceil(cost)}, ` +
+                  `session cap is ${devTunnel.spendCapBuzz}`,
+              },
+            };
+          }
+          devSessionReserve = { sessionId: devTunnel.sessionId, cost: Math.ceil(cost) };
+        }
+      }
+
       // From here the reservation is live. If ANYTHING throws before a resolved
       // submitWorkflow, refund the reservation and re-throw — this matches the
       // original semantics exactly (the old code recorded the spend only after
@@ -2800,6 +2851,14 @@ export const blocksRouter = router({
         // "only record after a resolved submit" behavior) and propagate. Refund
         // against the pinned key, not a re-derived one (midnight-UTC race).
         await refundBlockBuzzSpend(buzzCapKey, cost);
+        // F4 — mirror the daily refund for the dev-session reservation so a failed
+        // submit doesn't permanently burn the session ceiling. Best-effort.
+        if (devSessionReserve) {
+          const { refundDevSessionBuzz } = await import(
+            '~/server/services/blocks/dev-tunnel.service'
+          );
+          await refundDevSessionBuzz(devSessionReserve.sessionId, devSessionReserve.cost);
+        }
         throw e;
       }
 

--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -6,17 +6,30 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
  * the per-session spend-cap backstop, and the reaper.
  */
 
-const { mockK8sFetch, mockGetDp1Target, mockUnwrap, sysRedis, mockEnv, mockNewId } = vi.hoisted(
-  () => {
-    const store = new Map<string, string>();
-    return {
-      store,
-      mockK8sFetch: vi.fn(),
-      mockGetDp1Target: vi.fn(async () => ({ server: 'https://k8s', token: 't' })),
-      mockUnwrap: vi.fn(async (res: any) => {
-        const t = await res.text();
-        return t ? JSON.parse(t) : {};
-      }),
+const {
+  mockK8sFetch,
+  mockGetDp1Target,
+  mockUnwrap,
+  mockWaitForApplyJob,
+  mockRecordTeardown,
+  sysRedis,
+  mockEnv,
+  mockNewId,
+} = vi.hoisted(() => {
+  const store = new Map<string, string>();
+  return {
+    store,
+    mockK8sFetch: vi.fn(),
+    mockGetDp1Target: vi.fn(async () => ({ server: 'https://k8s', token: 't' })),
+    mockUnwrap: vi.fn(async (res: any) => {
+      const t = await res.text();
+      return t ? JSON.parse(t) : {};
+    }),
+    // F1: the route now renders via an apps-applier Job that renderDevTunnelRoute
+    // awaits to Succeeded. Default the wait to 'succeeded' so start/render tests
+    // don't poll; the failure test overrides it.
+    mockWaitForApplyJob: vi.fn(async () => 'succeeded' as const),
+    mockRecordTeardown: vi.fn(),
       sysRedis: {
         _store: store,
         get: vi.fn(async (k: string) => store.get(k) ?? null),
@@ -41,23 +54,26 @@ const { mockK8sFetch, mockGetDp1Target, mockUnwrap, sysRedis, mockEnv, mockNewId
         expire: vi.fn(async () => 1),
         ttl: vi.fn(async () => 100),
       },
-      mockEnv: {
-        APPS_DOMAIN: 'civit.ai',
-        APPS_KUBE_NAMESPACE: 'civitai-apps',
-        NEXTAUTH_URL: 'https://civitai.com',
-        APPS_DEV_TUNNEL_SISH_BACKEND: 'http://sish-http.apps-dev-tunnel.svc.cluster.local:8080',
-        APPS_DEV_TUNNEL_FORWARDAUTH_URL: undefined as string | undefined,
-      },
-      mockNewId: vi.fn(() => 'bki_testsession'),
-    };
-  }
-);
+    mockEnv: {
+      APPS_DOMAIN: 'civit.ai',
+      APPS_KUBE_NAMESPACE: 'civitai-apps',
+      NEXTAUTH_URL: 'https://civitai.com',
+      APPS_DEV_TUNNEL_SISH_BACKEND: 'http://sish-http.apps-dev-tunnel.svc.cluster.local:8080',
+      APPS_DEV_TUNNEL_FORWARDAUTH_URL: undefined as string | undefined,
+      APPS_DEV_TUNNEL_SSH_HOST_PUBKEY: 'ssh-ed25519 AAAAC3NzaHostKeyExample sish-host' as
+        | string
+        | undefined,
+    },
+    mockNewId: vi.fn(() => 'bki_testsession'),
+  };
+});
 
 vi.mock('~/env/server', () => ({ env: mockEnv }));
 vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
   getDp1Target: (...a: unknown[]) => mockGetDp1Target(...(a as [])),
   k8sFetch: (...a: unknown[]) => mockK8sFetch(...(a as [])),
   unwrap: (...a: unknown[]) => mockUnwrap(...(a as [any])),
+  waitForApplyJob: (...a: unknown[]) => mockWaitForApplyJob(...(a as [])),
 }));
 vi.mock('~/server/redis/client', () => ({
   sysRedis,
@@ -67,17 +83,23 @@ vi.mock('~/server/redis/client', () => ({
 vi.mock('~/server/utils/app-block-ids', () => ({ newBlockInstanceId: () => mockNewId() }));
 vi.mock('~/server/prom/dev-tunnel.metrics', () => ({
   recordDevTunnelMint: vi.fn(),
-  recordDevTunnelTeardown: vi.fn(),
+  recordDevTunnelTeardown: (...a: unknown[]) => mockRecordTeardown(...(a as [])),
 }));
 
 import {
+  buildDevTunnelApplyJob,
   buildDevTunnelIngressRoute,
   buildDevTunnelMiddleware,
   getActiveDevTunnel,
+  refundDevSessionBuzz,
   reserveDevSessionBuzz,
   startDevTunnel,
   stopDevTunnel,
   reapExpiredDevTunnels,
+  touchDevTunnelActivity,
+  DEV_TUNNEL_IDLE_SECONDS,
+  DEV_TUNNEL_HARD_SECONDS,
+  DEV_TUNNEL_REAP_MIN_AGE_SECONDS,
   DEV_TUNNEL_SESSION_BUZZ_CAP,
 } from '~/server/services/blocks/dev-tunnel.service';
 import { DEV_HOST_LABEL_REGEX } from '~/server/services/blocks/dev-tunnel-session';
@@ -93,6 +115,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockK8sFetch.mockResolvedValue(okRes());
   mockGetDp1Target.mockResolvedValue({ server: 'https://k8s', token: 't' });
+  mockWaitForApplyJob.mockResolvedValue('succeeded');
 });
 afterEach(() => vi.clearAllMocks());
 
@@ -129,21 +152,49 @@ describe('manifest builders (SSRF-safe, server-derived host)', () => {
 });
 
 describe('startDevTunnel', () => {
-  it('mints an unguessable host, renders the route, persists state, returns the URL', async () => {
+  it('mints an unguessable host, renders the route (via the apply Job), persists state, returns the URL + host pubkey', async () => {
     const result = await startDevTunnel({ userId: 555, blockId: 'my-app', sshPublicKey: PUBKEY });
     // host = dev-<16hex>.civit.ai
     expect(result.host).toMatch(/^dev-[a-f0-9]{16}\.civit\.ai$/);
     expect(result.host.split('.')[0]).toMatch(DEV_HOST_LABEL_REGEX);
     expect(result.url).toBe('https://civitai.com/apps/dev/my-app');
     expect(result.spendCapBuzz).toBe(DEV_TUNNEL_SESSION_BUZZ_CAP);
-    // rendered: middleware + ingressroute each pre-deleted (DELETE) + POSTed
+    // R1: returns the sish host pubkey (from env) for the CLI to pin.
+    expect(result.sshHostPublicKey).toBe('ssh-ed25519 AAAAC3NzaHostKeyExample sish-host');
+    // F1: the route renders via ONE apply Job POST (NOT direct CRD POSTs from the
+    // web-pod SA), pre-deleted first, then awaited to Succeeded.
     const posts = mockK8sFetch.mock.calls.filter((c) => (c[2] as any)?.method === 'POST');
-    expect(posts.length).toBe(2);
+    expect(posts.length).toBe(1);
+    expect(posts[0][1]).toMatch(/\/jobs$/);
+    expect(mockWaitForApplyJob).toHaveBeenCalledTimes(1);
     // persisted the 4 index keys (cred/session/host/user-block)
     expect(sysRedis.set).toHaveBeenCalledTimes(4);
     // the credential is keyed by pubkey fingerprint (sish authz lookup index)
     const credKeys = [...sysRedis._store.keys()].filter((k) => k.includes(':cred:'));
     expect(credKeys.length).toBe(1);
+    // the session record carries the initial idle marker
+    const sessionRaw = sysRedis._store.get('system:blocks:dev-tunnel:session:bki_testsession')!;
+    expect(JSON.parse(sessionRaw).lastActivityAt).toBeTypeOf('number');
+  });
+
+  it('R1: returns an EMPTY host pubkey when the env is unset (CLI fails closed)', async () => {
+    mockEnv.APPS_DEV_TUNNEL_SSH_HOST_PUBKEY = undefined;
+    try {
+      const result = await startDevTunnel({ userId: 5, blockId: 'a', sshPublicKey: PUBKEY });
+      expect(result.sshHostPublicKey).toBe('');
+    } finally {
+      mockEnv.APPS_DEV_TUNNEL_SSH_HOST_PUBKEY = 'ssh-ed25519 AAAAC3NzaHostKeyExample sish-host';
+    }
+  });
+
+  it('F1: a FAILED route-apply Job aborts the mint — nothing is persisted', async () => {
+    mockWaitForApplyJob.mockResolvedValueOnce('failed');
+    await expect(
+      startDevTunnel({ userId: 9, blockId: 'b', sshPublicKey: PUBKEY })
+    ).rejects.toThrow(/apply Job failed/);
+    // render threw before persist → no dev-tunnel keys left behind
+    const keys = [...sysRedis._store.keys()].filter((k) => k.startsWith('system:blocks:dev-tunnel'));
+    expect(keys).toEqual([]);
   });
 
   it('rejects an invalid SSH public key before touching k8s/redis', async () => {
@@ -152,6 +203,50 @@ describe('startDevTunnel', () => {
     ).rejects.toThrow(/invalid SSH public key/);
     expect(mockK8sFetch).not.toHaveBeenCalled();
     expect(sysRedis.set).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildDevTunnelApplyJob (F1 — renders via the scoped apps-applier SA)', () => {
+  it('runs as the apps-applier SA and injects both manifests (never the web-pod SA)', () => {
+    const mw = buildDevTunnelMiddleware({
+      host: 'dev-0123456789abcdef.civit.ai',
+      sessionId: 'bki_s',
+      namespace: 'civitai-apps',
+      forwardAuthUrl: 'http://civitai-web/api/internal/dev-tunnel-gate',
+      sishBackend: 'http://sish-http.apps-dev-tunnel.svc.cluster.local:8080',
+    });
+    const ir = buildDevTunnelIngressRoute({
+      host: 'dev-0123456789abcdef.civit.ai',
+      sessionId: 'bki_s',
+      namespace: 'civitai-apps',
+      forwardAuthUrl: 'http://civitai-web/api/internal/dev-tunnel-gate',
+      sishBackend: 'http://sish-http.apps-dev-tunnel.svc.cluster.local:8080',
+    });
+    const job = buildDevTunnelApplyJob({
+      ns: 'civitai-apps',
+      jobName: 'dev-tunnel-apply-bki_s',
+      sessionId: 'bki_s',
+      middleware: mw,
+      ingressRoute: ir,
+    });
+    // THE F1 SECURITY INVARIANT: the create runs as the narrowly-scoped applier SA.
+    expect(job.spec.template.spec.serviceAccountName).toBe('apps-applier');
+    // F1-1: a bounded deadline guarantees a hung apply pod becomes terminal → GC'd,
+    // and it must be >= the 180s render wait so a slow-succeeding pull isn't killed.
+    expect(job.spec.activeDeadlineSeconds).toBe(200);
+    expect(job.spec.activeDeadlineSeconds).toBeGreaterThanOrEqual(180);
+    // Both manifests are injected into the Job (kubectl apply -f -), not POSTed
+    // by the web pod.
+    const env = job.spec.template.spec.containers[0].env;
+    const mwEnv = env.find((e) => e.name === 'MIDDLEWARE_JSON')!;
+    const irEnv = env.find((e) => e.name === 'INGRESSROUTE_JSON')!;
+    expect(JSON.parse(mwEnv.value).kind).toBe('Middleware');
+    expect(JSON.parse(irEnv.value).kind).toBe('IngressRoute');
+    // labelled for the reaper/teardown sweep
+    expect(job.metadata.labels['civitai.com/dev-tunnel-session']).toBe('bki_s');
+    // hardened pod spec (non-root, RO fs, drop ALL)
+    expect(job.spec.template.spec.securityContext.runAsNonRoot).toBe(true);
+    expect(job.spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem).toBe(true);
   });
 });
 
@@ -202,10 +297,57 @@ describe('reserveDevSessionBuzz (spend-cap backstop)', () => {
   });
 });
 
-describe('reapExpiredDevTunnels (server-authoritative)', () => {
-  it('tears down a route whose backing session has expired', async () => {
-    // Seed an EXPIRED session + a k8s route labelled with it.
-    const sessionId = 'bki_expired';
+describe('touchDevTunnelActivity (F3 — idle refresh on gate entry)', () => {
+  it('stamps lastActivityAt without extending the hard-TTL', async () => {
+    await startDevTunnel({ userId: 555, blockId: 'my-app', sshPublicKey: PUBKEY });
+    const host = JSON.parse(
+      sysRedis._store.get('system:blocks:dev-tunnel:session:bki_testsession')!
+    ).host as string;
+    // move the marker back so a refresh is observable
+    const before = JSON.parse(
+      sysRedis._store.get('system:blocks:dev-tunnel:session:bki_testsession')!
+    );
+    before.lastActivityAt = 1000;
+    sysRedis._store.set(
+      'system:blocks:dev-tunnel:session:bki_testsession',
+      JSON.stringify(before)
+    );
+
+    await touchDevTunnelActivity(host);
+
+    const after = JSON.parse(
+      sysRedis._store.get('system:blocks:dev-tunnel:session:bki_testsession')!
+    );
+    expect(after.lastActivityAt).toBeGreaterThan(1000);
+    // the re-persist used EX = remaining-until-hard-expiry, NOT a fresh 8h reset
+    const setCall = sysRedis.set.mock.calls.find(
+      (c) => c[0] === 'system:blocks:dev-tunnel:session:bki_testsession' && c[2]
+    );
+    expect((setCall![2] as { EX: number }).EX).toBeLessThanOrEqual(DEV_TUNNEL_HARD_SECONDS);
+  });
+
+  it('is a no-op for an unknown host (never throws)', async () => {
+    await expect(touchDevTunnelActivity('dev-ffffffffffffffff.civit.ai')).resolves.toBeUndefined();
+  });
+});
+
+describe('reserveDevSessionBuzz / refundDevSessionBuzz (F4 support)', () => {
+  it('refund reverses a reservation (best-effort DECRBY)', async () => {
+    const cap = 100;
+    await reserveDevSessionBuzz('sess', 60, cap);
+    await refundDevSessionBuzz('sess', 60);
+    // back under the cap → a fresh 60 fits again
+    expect(await reserveDevSessionBuzz('sess', 60, cap)).toEqual({ allowed: true, total: 60 });
+  });
+});
+
+describe('reapExpiredDevTunnels (server-authoritative, idle + hardened)', () => {
+  const NOW = Math.floor(Date.now() / 1000);
+
+  function seedSession(
+    sessionId: string,
+    over: Partial<Record<string, unknown>> = {}
+  ) {
     sysRedis._store.set(
       `system:blocks:dev-tunnel:session:${sessionId}`,
       JSON.stringify({
@@ -214,192 +356,155 @@ describe('reapExpiredDevTunnels (server-authoritative)', () => {
         blockId: 'x',
         host: 'dev-aaaaaaaaaaaaaaaa.civit.ai',
         fingerprint: 'fp',
-        createdAt: 1,
-        hardExpiresAt: 1, // long past
+        createdAt: NOW - 60,
+        hardExpiresAt: NOW + DEV_TUNNEL_HARD_SECONDS, // NOT hard-expired
         spendCapBuzz: 100,
+        lastActivityAt: NOW,
+        ...over,
       })
     );
-    // First k8sFetch (the LIST) returns the labelled route; subsequent DELETEs ok.
+  }
+
+  /** Make the LIST return a single route labelled `sessionId`, with an optional
+   *  creationTimestamp; every other call (DELETE) is a plain OK. */
+  function listOneRoute(sessionId: string, creationTimestamp?: string) {
     mockK8sFetch.mockImplementation(async (_t: unknown, path: string, init: any) => {
       if (init?.method === 'GET' && path.includes('ingressroutes?labelSelector')) {
         return okRes(
           JSON.stringify({
-            items: [{ metadata: { labels: { 'civitai.com/dev-tunnel-session': sessionId } } }],
+            items: [
+              {
+                metadata: {
+                  labels: { 'civitai.com/dev-tunnel-session': sessionId },
+                  ...(creationTimestamp ? { creationTimestamp } : {}),
+                },
+              },
+            ],
+          })
+        );
+      }
+      return okRes();
+    });
+  }
+
+  it('tears down a route whose backing session is HARD-expired (reap-maxttl)', async () => {
+    const sessionId = 'bki_expired';
+    seedSession(sessionId, { hardExpiresAt: 1, createdAt: 1, lastActivityAt: 1 });
+    listOneRoute(sessionId);
+    const result = await reapExpiredDevTunnels();
+    expect(result).toEqual({ swept: 1, reaped: 1, skipped: 0, listOk: true });
+    expect(sysRedis._store.has(`system:blocks:dev-tunnel:session:${sessionId}`)).toBe(false);
+    expect(mockRecordTeardown).toHaveBeenCalledWith('reap-maxttl');
+  });
+
+  it('F3: reaps an IDLE-expired session (activity older than the idle window) as reap-idle', async () => {
+    const sessionId = 'bki_idle';
+    seedSession(sessionId, { lastActivityAt: NOW - DEV_TUNNEL_IDLE_SECONDS - 60 });
+    listOneRoute(sessionId);
+    const result = await reapExpiredDevTunnels();
+    expect(result).toMatchObject({ reaped: 1, skipped: 0, listOk: true });
+    expect(mockRecordTeardown).toHaveBeenCalledWith('reap-idle');
+    expect(sysRedis._store.has(`system:blocks:dev-tunnel:session:${sessionId}`)).toBe(false);
+  });
+
+  it('F3: does NOT reap a recently-ACTIVE session (survives, not counted as skipped)', async () => {
+    const sessionId = 'bki_active';
+    seedSession(sessionId, { lastActivityAt: NOW - 5 }); // just active
+    listOneRoute(sessionId);
+    const result = await reapExpiredDevTunnels();
+    // a live session is kept: reaped 0 AND skipped 0 (skipped = read-error/guarded-absent only)
+    expect(result).toEqual({ swept: 1, reaped: 0, skipped: 0, listOk: true });
+    expect(sysRedis._store.has(`system:blocks:dev-tunnel:session:${sessionId}`)).toBe(true);
+  });
+
+  it('read-error skip: a Redis read error leaves a LIVE route alone (counted in skipped)', async () => {
+    const sessionId = 'bki_blip';
+    seedSession(sessionId);
+    listOneRoute(sessionId);
+    sysRedis.get.mockRejectedValueOnce(new Error('redis blip'));
+    const result = await reapExpiredDevTunnels();
+    expect(result).toEqual({ swept: 1, reaped: 0, skipped: 1, listOk: true });
+    // route + record untouched
+    expect(sysRedis._store.has(`system:blocks:dev-tunnel:session:${sessionId}`)).toBe(true);
+  });
+
+  it('min-age guard: an absent-record route that is TOO YOUNG (mid-mint) is skipped, not reaped', async () => {
+    const sessionId = 'bki_young';
+    // no session record seeded → absent; route created just now
+    listOneRoute(sessionId, new Date().toISOString());
+    const result = await reapExpiredDevTunnels();
+    expect(result).toEqual({ swept: 1, reaped: 0, skipped: 1, listOk: true });
+  });
+
+  it('min-age guard: an absent-record route with UNKNOWN age (no creationTimestamp) is skipped', async () => {
+    const sessionId = 'bki_noage';
+    listOneRoute(sessionId); // no creationTimestamp → age indeterminable → skip (never reap)
+    const result = await reapExpiredDevTunnels();
+    expect(result).toEqual({ swept: 1, reaped: 0, skipped: 1, listOk: true });
+  });
+
+  it('orphan reap: an absent-record route OLDER than the min-age is deleted', async () => {
+    const sessionId = 'bki_orphan';
+    const old = new Date((NOW - DEV_TUNNEL_REAP_MIN_AGE_SECONDS - 60) * 1000).toISOString();
+    listOneRoute(sessionId, old);
+    const result = await reapExpiredDevTunnels();
+    expect(result).toEqual({ swept: 1, reaped: 1, skipped: 0, listOk: true });
+    expect(mockRecordTeardown).toHaveBeenCalledWith('reap-maxttl');
+  });
+
+  it('listOk: a NON-2xx LIST surfaces listOk:false + the HTTP status (not a silent empty sweep)', async () => {
+    mockK8sFetch.mockResolvedValue({ ok: false, status: 403, text: async () => 'forbidden' });
+    const result = await reapExpiredDevTunnels();
+    expect(result).toEqual({ swept: 0, reaped: 0, skipped: 0, listOk: false, status: 403 });
+  });
+
+  it('listOk: a THROWN LIST (apiserver unreachable) surfaces listOk:false + status 0 sentinel', async () => {
+    mockK8sFetch.mockRejectedValue(new Error('connection refused'));
+    const result = await reapExpiredDevTunnels();
+    expect(result).toEqual({ swept: 0, reaped: 0, skipped: 0, listOk: false, status: 0 });
+  });
+
+  it('listOk: getDp1Target throwing (no SA token) surfaces listOk:false + status 0', async () => {
+    mockGetDp1Target.mockRejectedValueOnce(new Error('not in-cluster'));
+    const result = await reapExpiredDevTunnels();
+    expect(result).toEqual({ swept: 0, reaped: 0, skipped: 0, listOk: false, status: 0 });
+  });
+
+  it('F1-2: discovers + reaps an ORPHAN MIDDLEWARE (no IngressRoute) for an absent session', async () => {
+    const sessionId = 'bki_mw_orphan';
+    const old = new Date((NOW - DEV_TUNNEL_REAP_MIN_AGE_SECONDS - 60) * 1000).toISOString();
+    // ingressroutes LIST → EMPTY (the IngressRoute apply failed); middlewares LIST
+    // → the orphan Middleware. No session record seeded → absent.
+    mockK8sFetch.mockImplementation(async (_t: unknown, path: string, init: any) => {
+      if (init?.method === 'GET' && path.includes('ingressroutes?labelSelector')) {
+        return okRes(JSON.stringify({ items: [] }));
+      }
+      if (init?.method === 'GET' && path.includes('middlewares?labelSelector')) {
+        return okRes(
+          JSON.stringify({
+            items: [
+              {
+                metadata: {
+                  name: `dev-tunnel-gate-${sessionId}`,
+                  labels: { 'civitai.com/dev-tunnel-session': sessionId },
+                  creationTimestamp: old,
+                },
+              },
+            ],
           })
         );
       }
       return okRes();
     });
     const result = await reapExpiredDevTunnels();
+    // the Middleware-only session was discovered (swept) + reaped (both-kind delete)
     expect(result.swept).toBe(1);
     expect(result.reaped).toBe(1);
-    // the session record was removed during teardown
-    expect(sysRedis._store.has(`system:blocks:dev-tunnel:session:${sessionId}`)).toBe(false);
-  });
-
-  /** Helper: make the main label-scoped LIST return `items`, everything else ok. */
-  function listReturns(items: unknown[], listStatus?: { ok: boolean; status: number }) {
-    mockK8sFetch.mockImplementation(async (_t: unknown, path: string, init: any) => {
-      if (init?.method === 'GET' && path.includes('ingressroutes?labelSelector')) {
-        if (listStatus && !listStatus.ok) {
-          return { ok: false, status: listStatus.status, text: async () => 'forbidden' };
-        }
-        return okRes(JSON.stringify({ items }));
-      }
-      return okRes();
-    });
-  }
-  const deleteCalls = () =>
-    mockK8sFetch.mock.calls.filter((c: unknown[]) => (c[2] as any)?.method === 'DELETE');
-
-  it('(a) LEAVES an ACTIVE session ALONE — the delete blast-radius stays tight', async () => {
-    // Present session with a FUTURE hardExpiresAt = a live tunnel. Must survive.
-    const sessionId = 'bki_active';
-    const key = `system:blocks:dev-tunnel:session:${sessionId}`;
-    sysRedis._store.set(
-      key,
-      JSON.stringify({
-        sessionId,
-        userId: 7,
-        blockId: 'x',
-        host: 'dev-bbbbbbbbbbbbbbbb.civit.ai',
-        fingerprint: 'fp',
-        createdAt: 1,
-        hardExpiresAt: Math.floor(Date.now() / 1000) + 3600, // 1h in the future
-        spendCapBuzz: 100,
-      })
+    expect(mockRecordTeardown).toHaveBeenCalledWith('reap-maxttl');
+    // deleteDevTunnelRoute issued a DELETE against the orphan middleware
+    const mwDeletes = mockK8sFetch.mock.calls.filter(
+      (c) => (c[2] as any)?.method === 'DELETE' && String(c[1]).includes('/middlewares/')
     );
-    listReturns([{ metadata: { labels: { 'civitai.com/dev-tunnel-session': sessionId } } }]);
-
-    const result = await reapExpiredDevTunnels();
-
-    expect(result).toMatchObject({ swept: 1, reaped: 0, skipped: 0, listOk: true });
-    // the live session record is untouched + no route delete issued
-    expect(sysRedis._store.has(key)).toBe(true);
-    expect(deleteCalls().length).toBe(0);
-  });
-
-  it('(b) a non-2xx LIST surfaces listOk:false (NOT a silent empty sweep)', async () => {
-    listReturns([], { ok: false, status: 403 });
-
-    const result = await reapExpiredDevTunnels();
-
-    expect(result).toMatchObject({ swept: 0, reaped: 0, skipped: 0, listOk: false, status: 403 });
-    // nothing was deleted on a failed list
-    expect(deleteCalls().length).toBe(0);
-  });
-
-  it('(c) a Redis READ ERROR during the sweep does NOT delete the route (skip, not reap)', async () => {
-    const sessionId = 'bki_readerr';
-    // Old route (would clear the min-age guard) — proving the SKIP is due to the
-    // read FAILURE, not the age guard.
-    listReturns([
-      {
-        metadata: {
-          labels: { 'civitai.com/dev-tunnel-session': sessionId },
-          creationTimestamp: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
-        },
-      },
-    ]);
-    // The session read throws (Redis timeout) — must be treated as "unknown", not "gone".
-    sysRedis.get.mockImplementation(async (k: string) => {
-      if (k.includes(`:session:${sessionId}`)) throw new Error('redis timeout');
-      return sysRedis._store.get(k) ?? null;
-    });
-
-    const result = await reapExpiredDevTunnels();
-
-    expect(result).toMatchObject({ swept: 1, reaped: 0, skipped: 1, listOk: true });
-    expect(deleteCalls().length).toBe(0);
-  });
-
-  it('(d) the min-age guard LEAVES a just-created route (create-before-persist race)', async () => {
-    const sessionId = 'bki_young';
-    // Route created just now, session record NOT yet written (clean miss).
-    listReturns([
-      {
-        metadata: {
-          labels: { 'civitai.com/dev-tunnel-session': sessionId },
-          creationTimestamp: new Date().toISOString(),
-        },
-      },
-    ]);
-
-    const result = await reapExpiredDevTunnels();
-
-    expect(result).toMatchObject({ swept: 1, reaped: 0, skipped: 1, listOk: true });
-    expect(deleteCalls().length).toBe(0);
-  });
-
-  it('(e) an OLD absent-record route IS reaped — proving the guard is age-gated, not blanket-skip', async () => {
-    const sessionId = 'bki_old_orphan';
-    // Route older than the min-age guard, session record confirmed-absent.
-    listReturns([
-      {
-        metadata: {
-          labels: { 'civitai.com/dev-tunnel-session': sessionId },
-          creationTimestamp: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
-        },
-      },
-    ]);
-
-    const result = await reapExpiredDevTunnels();
-
-    expect(result).toMatchObject({ swept: 1, reaped: 1, skipped: 0, listOk: true });
-  });
-
-  it('(f) a THROWN LIST (TLS/network) is list_failed (status 0), NOT a generic error — and deletes nothing', async () => {
-    // Simulate a TLS-verify reject / connection failure on the LIST call itself.
-    mockK8sFetch.mockImplementation(async (_t: unknown, path: string, init: any) => {
-      if (init?.method === 'GET' && path.includes('ingressroutes?labelSelector')) {
-        throw new Error('unable to verify the first certificate'); // TLS handshake reject
-      }
-      return okRes();
-    });
-
-    // MUST NOT throw — the reaper converts an unreachable API into a discriminated
-    // list_failed (sentinel status 0) so the job records `list_failed`, not `error`.
-    const result = await reapExpiredDevTunnels();
-
-    expect(result).toMatchObject({ swept: 0, reaped: 0, skipped: 0, listOk: false, status: 0 });
-    expect(deleteCalls().length).toBe(0);
-  });
-
-  it('(g) route age uses the apiserver Date header — young-per-apiserver route is SKIPPED despite a pod clock running ~1h ahead', async () => {
-    const sessionId = 'bki_skewguard';
-    // Fixed base ~1h in the PAST of the real pod clock: under Date.now() the route
-    // would look ~1h old → reaped. Session record confirmed-absent.
-    const base = Date.now() - 60 * 60 * 1000;
-    const creationTimestamp = new Date(base).toISOString();
-    // apiserver "now" = 5s after creation → YOUNG in the apiserver's own clock domain.
-    const apiserverDate = new Date(base + 5000).toUTCString();
-    mockK8sFetch.mockImplementation(async (_t: unknown, path: string, init: any) => {
-      if (init?.method === 'GET' && path.includes('ingressroutes?labelSelector')) {
-        return {
-          ok: true,
-          status: 200,
-          headers: { get: (h: string) => (h.toLowerCase() === 'date' ? apiserverDate : null) },
-          text: async () =>
-            JSON.stringify({
-              items: [
-                {
-                  metadata: {
-                    labels: { 'civitai.com/dev-tunnel-session': sessionId },
-                    creationTimestamp,
-                  },
-                },
-              ],
-            }),
-        };
-      }
-      return okRes();
-    });
-
-    const result = await reapExpiredDevTunnels();
-
-    // Age computed from the apiserver Date (~5s) < guard → SKIPPED. If the code used
-    // the pod clock (~1h ahead) it would have reaped a route mid-creation.
-    expect(result).toMatchObject({ swept: 1, reaped: 0, skipped: 1, listOk: true });
-    expect(deleteCalls().length).toBe(0);
+    expect(mwDeletes.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -5,7 +5,7 @@ import {
   getDp1Target,
   k8sFetch,
   unwrap,
-  type K8sTarget,
+  waitForApplyJob,
 } from '~/server/services/blocks/apps-pipeline.service';
 import {
   fingerprintSshPublicKey,
@@ -85,6 +85,12 @@ export type DevTunnelSessionRecord = {
   createdAt: number; // unix seconds
   hardExpiresAt: number; // unix seconds
   spendCapBuzz: number;
+  /** Last browser-activity marker (unix seconds), refreshed by the forwardAuth
+   *  gate on each successful ENTRY-document hit (F3). The reaper reaps a session
+   *  idle past DEV_TUNNEL_IDLE_SECONDS. ABSENT on a never-visited tunnel → the
+   *  reaper falls back to `createdAt` so a CLI that dies before the browser ever
+   *  loads still idle-reaps. */
+  lastActivityAt?: number;
 };
 
 /** The subset of the credential the sish authz callback needs. Stored separately
@@ -118,83 +124,11 @@ async function readJson<T>(key: DevTunnelKey): Promise<T | null> {
   }
 }
 
-/**
- * Read outcome that distinguishes a CONFIRMED-ABSENT key (`ok:true, value:null`)
- * from a Redis READ FAILURE (`ok:false`). The reaper MUST use this — not the
- * error→null `readJson` — for its reap decision: collapsing a read failure to
- * null would let a transient Redis blip mid-sweep be read as "session gone →
- * delete route" and tear down ALL active tunnels whose read happened to error.
- */
-type SessionReadOutcome =
-  | { ok: true; value: DevTunnelSessionRecord | null }
-  | { ok: false };
-
-async function readSessionChecked(sessionId: string): Promise<SessionReadOutcome> {
-  try {
-    const raw = await withSysReadDeadline(sysRedis.get(sessionKey(sessionId)));
-    // A clean miss: the key is genuinely absent (the read SUCCEEDED and returned
-    // nothing) — reap-eligible, subject to the min-age guard.
-    if (!raw || typeof raw !== 'string') return { ok: true, value: null };
-    try {
-      return { ok: true, value: JSON.parse(raw) as DevTunnelSessionRecord };
-    } catch {
-      // Present-but-corrupt value — a confirmed-bad record, not a read failure.
-      // Treat as absent (still min-age guarded before any delete).
-      return { ok: true, value: null };
-    }
-  } catch {
-    // Redis READ FAILURE (timeout / connection error). NOT a confirmed absence —
-    // the route may back a live session. The caller must SKIP, never reap.
-    return { ok: false };
-  }
-}
-
-/** Parse an HTTP `Date` header (apiserver-stamped) to epoch ms, or null if it's
- *  missing/unparseable. */
-function parseHttpDate(dateHeader: string | null | undefined): number | null {
-  if (!dateHeader) return null;
-  const t = Date.parse(dateHeader);
-  return Number.isNaN(t) ? null : t;
-}
-
-/** Elapsed seconds between `nowMs` and a k8s object's `creationTimestamp`, or
- *  null if `creationTimestamp` is missing/unparseable (in which case the reaper
- *  conservatively skips a confirmed-absent route rather than risk the
- *  create-before-persist race).
- *
- *  `nowMs` MUST be the apiserver's own clock (its LIST-response `Date` header) —
- *  same clock domain as `creationTimestamp` — so the min-age guard is immune to
- *  pod↔apiserver clock skew. A pod clock running ahead of the apiserver would
- *  otherwise make a just-created route look ≥guard-old and reap a live tunnel
- *  mid-creation. */
-function routeAgeSeconds(creationTimestamp: string | undefined, nowMs: number): number | null {
-  if (!creationTimestamp) return null;
-  const created = Date.parse(creationTimestamp);
-  if (Number.isNaN(created)) return null;
-  return Math.floor((nowMs - created) / 1000);
-}
-
-/** Discriminated result of one reaper sweep. `listOk:false` (with the HTTP
- *  `status`) is the SILENT-FAILURE fix: a non-2xx LIST is surfaced distinctly
- *  instead of masquerading as a healthy empty sweep. */
-export type ReapResult = {
-  swept: number;
-  reaped: number;
-  /** Routes intentionally left this sweep (young/absent-guarded, or their session
-   *  read errored) — retried next tick. */
-  skipped: number;
-  /** false ⇒ the label-scoped LIST failed (non-2xx, OR the call THREW: TLS-verify
-   *  reject / DNS / connection-refused / timeout / missing SA token); the sweep
-   *  did nothing and the reaper could not reclaim routes. */
-  listOk: boolean;
-  /** When listOk is false: the HTTP status of a non-2xx LIST, or the sentinel `0`
-   *  when the LIST call THREW (API server unreachable — no HTTP status exists). */
-  status?: number;
-};
-
-/** Sentinel `status` for a LIST that threw (API unreachable — no real HTTP
- *  status). Distinguishes "couldn't reach the apiserver" from a genuine non-2xx. */
-const LIST_UNREACHABLE_STATUS = 0;
+// NOTE (rebase resolution): the reaper's `ReapResult` contract + the reap
+// session-read / apiserver-clock / idle helpers are defined together in the
+// Reaper section below (this PR's superset version — idle-reap + ingressroute∪
+// middleware union). #2928's parallel helpers here were dropped to keep a SINGLE
+// canonical copy; the shared `readJson` above stays.
 
 // ---------------------------------------------------------------------------
 // Manifest builders (PURE — exported for shape tests)
@@ -321,45 +255,168 @@ function manifestOpts(host: string, sessionId: string): DevTunnelManifestOpts {
 // k8s apply / delete (thin, reuses apps-pipeline helpers)
 // ---------------------------------------------------------------------------
 
-async function applyManifest(target: K8sTarget, ns: string, kindPath: string, obj: unknown, name: string) {
-  // Delete-then-create so a re-render of the same session name is idempotent
-  // (mirrors the review apply Job's pre-delete). 404 on delete is fine.
-  await k8sFetch(target, `${kindPath}/${name}?propagationPolicy=Background`, {
-    method: 'DELETE',
-  }).then(async (r) => {
-    if (!r.ok && r.status !== 404) {
-      const body = await r.text().catch(() => '');
-      throw new Error(`dev-tunnel pre-delete ${name} ${r.status}: ${body.slice(0, 200)}`);
-    }
-  });
-  const res = await k8sFetch(target, kindPath, { method: 'POST', body: JSON.stringify(obj) });
-  await unwrap<{ metadata: { name: string } }>(res);
+/** DNS-1123 Job name for a session's route-apply Job. `sessionId` is opaque
+ *  (`bki_<ulid>`); sanitize + bound it so the Job name is always valid. */
+export function devTunnelApplyJobName(sessionId: string): string {
+  const suffix = sessionId.replace(/[^a-z0-9-]/gi, '-').toLowerCase().slice(0, 40);
+  return `dev-tunnel-apply-${suffix}`;
 }
 
-/** Render the ephemeral Traefik IngressRoute + forwardAuth Middleware for a
- *  dev-tunnel host by POSTing them directly to the k8s API (the same in-pod SA
- *  surface + create/delete RBAC the review teardown uses — no bash render Job, no
- *  template ConfigMap dependency). */
+/**
+ * The bash script the route-apply Job runs. `kubectl apply`s the (fully
+ * server-rendered) Middleware then IngressRoute from env-injected JSON — no
+ * template ConfigMap, no envsubst. `kubectl apply` is create-or-update, so a
+ * re-render of the same session is naturally idempotent. Pure + exported so the
+ * shape stays locked in a unit test.
+ */
+export function buildDevTunnelApplyScript(): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s' "\${MIDDLEWARE_JSON}" | kubectl apply -f -
+printf '%s' "\${INGRESSROUTE_JSON}" | kubectl apply -f -
+echo "dev-tunnel route applied"
+`;
+}
+
+/**
+ * Build the route-apply Job. CRITICAL (F1): runs as the narrowly-scoped
+ * `apps-applier` ServiceAccount — the SAME SA the review sandbox renders through
+ * (`triggerApplyReview`) — which HAS `create`/`patch` on traefik.io CRDs and
+ * cannot escape the `civitai-apps` namespace. The web-pod SA
+ * (`civitai-web-apps-consumer`) grants only get/list/watch/delete on those CRDs,
+ * so rendering the route DIRECTLY from the web pod 403'd (the untracked P3
+ * functional blocker); it would ALSO be a security regression to broaden the
+ * live web-pod SA to `create` (any civitai-web SSRF/RCE → arbitrary-IngressRoute
+ * creation → hijack of live app hosts). The Job is the isolation boundary. The
+ * web-pod SA only CREATES the Job (it has that) + DELETEs routes on teardown
+ * (it has that) — it never itself creates a traefik CRD.
+ *
+ * Pure + exported for a shape test.
+ */
+export function buildDevTunnelApplyJob(opts: {
+  ns: string;
+  jobName: string;
+  sessionId: string;
+  middleware: unknown;
+  ingressRoute: unknown;
+}) {
+  return {
+    apiVersion: 'batch/v1',
+    kind: 'Job',
+    metadata: {
+      name: opts.jobName,
+      namespace: opts.ns,
+      labels: {
+        app: opts.jobName,
+        'civitai.com/role': 'apply-job',
+        [DEV_TUNNEL_LABEL]: 'true',
+        [DEV_TUNNEL_SESSION_LABEL]: opts.sessionId,
+      },
+    },
+    spec: {
+      backoffLimit: 2,
+      // F1-1: a hung apply pod (restartPolicy:Never, stuck image pull / API
+      // throttle) would never become terminal → never TTL-GC'd, and since each
+      // re-mint uses a fresh sessionId→jobName the pre-delete-by-name can't reclaim
+      // it → hung Jobs would accumulate. activeDeadlineSeconds guarantees the Job
+      // becomes terminal (DeadlineExceeded) so ttlSecondsAfterFinished GCs it.
+      // MUST be >= renderDevTunnelRoute's waitForApplyJob timeout (180s) so a
+      // slow-but-succeeding cold image pull isn't killed before the wait observes
+      // success (which would orphan a route the pod may have already applied).
+      activeDeadlineSeconds: 200,
+      // Short TTL after the Job reaches a terminal state (Complete/DeadlineExceeded).
+      ttlSecondsAfterFinished: 300,
+      template: {
+        metadata: {
+          labels: {
+            'civitai.com/role': 'apply-job',
+            [DEV_TUNNEL_LABEL]: 'true',
+            [DEV_TUNNEL_SESSION_LABEL]: opts.sessionId,
+          },
+        },
+        spec: {
+          // The narrowly-scoped apply SA (has create on traefik CRDs; ns-locked).
+          serviceAccountName: 'apps-applier',
+          restartPolicy: 'Never',
+          securityContext: {
+            runAsNonRoot: true,
+            runAsUser: 65532,
+            runAsGroup: 65532,
+            seccompProfile: { type: 'RuntimeDefault' },
+          },
+          containers: [
+            {
+              name: 'apply',
+              image: 'alpine/k8s:1.34.0',
+              imagePullPolicy: 'IfNotPresent',
+              env: [
+                { name: 'MIDDLEWARE_JSON', value: JSON.stringify(opts.middleware) },
+                { name: 'INGRESSROUTE_JSON', value: JSON.stringify(opts.ingressRoute) },
+              ],
+              securityContext: {
+                allowPrivilegeEscalation: false,
+                readOnlyRootFilesystem: true,
+                capabilities: { drop: ['ALL'] },
+              },
+              volumeMounts: [{ name: 'tmp', mountPath: '/tmp' }],
+              command: ['/bin/bash', '-c'],
+              args: [buildDevTunnelApplyScript()],
+              resources: {
+                requests: { cpu: '50m', memory: '64Mi' },
+                limits: { cpu: '250m', memory: '128Mi' },
+              },
+            },
+          ],
+          volumes: [{ name: 'tmp', emptyDir: { sizeLimit: '8Mi' } }],
+        },
+      },
+    },
+  };
+}
+
+/**
+ * Render the ephemeral Traefik IngressRoute + forwardAuth Middleware for a
+ * dev-tunnel host by dispatching a render-and-apply Job that runs as the scoped
+ * `apps-applier` SA — the SAME mechanism the review sandbox uses (F1). The
+ * web-pod SA only creates the Job + waits for it; the Job (apps-applier) is what
+ * `kubectl apply`s the CRDs. Awaits the Job to Succeeded so `startDevTunnel` can
+ * keep its "render FIRST → persist state only on success" contract (a failed
+ * render throws → nothing is persisted → no orphan).
+ */
 export async function renderDevTunnelRoute(host: string, sessionId: string): Promise<void> {
   const target = await getDp1Target();
   const ns = env.APPS_KUBE_NAMESPACE;
   const opts = manifestOpts(host, sessionId);
   const mw = buildDevTunnelMiddleware(opts);
   const ir = buildDevTunnelIngressRoute(opts);
-  await applyManifest(
-    target,
-    ns,
-    `/apis/traefik.io/v1alpha1/namespaces/${ns}/middlewares`,
-    mw,
-    mw.metadata.name
-  );
-  await applyManifest(
-    target,
-    ns,
-    `/apis/traefik.io/v1alpha1/namespaces/${ns}/ingressroutes`,
-    ir,
-    ir.metadata.name
-  );
+  const jobName = devTunnelApplyJobName(sessionId);
+  const job = buildDevTunnelApplyJob({ ns, jobName, sessionId, middleware: mw, ingressRoute: ir });
+
+  // Re-rendering the same session must restart the apply — delete a same-name Job
+  // first (404 is fine). This is a Job DELETE, which the web-pod SA CAN do.
+  await k8sFetch(target, `/apis/batch/v1/namespaces/${ns}/jobs/${jobName}?propagationPolicy=Background`, {
+    method: 'DELETE',
+  }).then(async (r) => {
+    if (!r.ok && r.status !== 404) {
+      const body = await r.text().catch(() => '');
+      throw new Error(`dev-tunnel pre-delete apply Job ${r.status}: ${body.slice(0, 200)}`);
+    }
+  });
+
+  const res = await k8sFetch(target, `/apis/batch/v1/namespaces/${ns}/jobs`, {
+    method: 'POST',
+    body: JSON.stringify(job),
+  });
+  await unwrap<{ metadata: { name: string } }>(res);
+
+  // F1-3: 180s tolerates a cold `alpine/k8s` image pull (the review-sandbox
+  // reference waits ~6min). Kept < the Job's activeDeadlineSeconds (200s) so a
+  // slow-but-succeeding pull is observed as success here before the Job's own
+  // deadline fires — see buildDevTunnelApplyJob for the reconciliation.
+  const outcome = await waitForApplyJob(jobName, { timeoutMs: 180_000, pollMs: 2_000 });
+  if (outcome !== 'succeeded') {
+    throw new Error(`dev-tunnel route apply Job ${outcome} (session ${sessionId})`);
+  }
 }
 
 /** Delete the ephemeral Traefik route for ONE session by label selector. Scoped
@@ -418,6 +475,10 @@ export type StartDevTunnelResult = {
   url: string;
   expiresAt: number;
   spendCapBuzz: number;
+  /** The sish server's SSH HOST public key (non-secret OpenSSH line) so the CLI
+   *  can PIN it on the `ssh -R` hop (R1). Empty string when unconfigured — the
+   *  CLI MUST fail closed (refuse to connect) rather than ignore the host key. */
+  sshHostPublicKey: string;
 };
 
 /**
@@ -453,6 +514,9 @@ export async function startDevTunnel(params: StartDevTunnelParams): Promise<Star
     createdAt: created,
     hardExpiresAt,
     spendCapBuzz: DEV_TUNNEL_SESSION_BUZZ_CAP,
+    // Seed the idle marker at mint so a never-visited tunnel still idle-reaps
+    // (createdAt fallback in the reaper covers an absent field too).
+    lastActivityAt: created,
   };
   const credential: DevTunnelCredentialRecord = {
     sessionId,
@@ -496,6 +560,9 @@ export async function startDevTunnel(params: StartDevTunnelParams): Promise<Star
     url: `${(env.NEXTAUTH_URL ?? 'https://civitai.com').replace(/\/$/, '')}/apps/dev/${params.blockId}`,
     expiresAt: hardExpiresAt,
     spendCapBuzz: DEV_TUNNEL_SESSION_BUZZ_CAP,
+    // R1: hand the CLI the sish host pubkey to pin. Empty when unconfigured (the
+    // CLI fails closed). Non-secret, so it rides the mint response directly.
+    sshHostPublicKey: env.APPS_DEV_TUNNEL_SSH_HOST_PUBKEY ?? '',
   };
 }
 
@@ -565,6 +632,35 @@ export async function getActiveDevTunnel(
   if (session.host && !isValidDevHost(session.host, env.APPS_DOMAIN)) return null;
   if (session.hardExpiresAt <= nowSec()) return null;
   return session;
+}
+
+/**
+ * Refresh a session's idle marker on browser activity (F3). Called by the
+ * forwardAuth gate on each successful ENTRY-document hit. Resolves the session
+ * from the dev host, stamps `lastActivityAt = now`, and re-persists the session
+ * key WITHOUT extending the hard-TTL: the EX is recomputed as the REMAINING time
+ * until `hardExpiresAt`, so activity can never push a tunnel past its 8h hard
+ * cap. Best-effort — a Redis hiccup here must never fail the gate decision (the
+ * auth response is already sent), so it swallows all errors and is a no-op past
+ * the hard expiry (the reaper then collects the route).
+ */
+export async function touchDevTunnelActivity(host: string): Promise<void> {
+  if (!host || typeof host !== 'string') return;
+  try {
+    const sessionId = await withSysReadDeadline(sysRedis.get(hostKey(host)));
+    if (!sessionId || typeof sessionId !== 'string') return;
+    const session = await readJson<DevTunnelSessionRecord>(sessionKey(sessionId));
+    if (!session) return;
+    const now = nowSec();
+    const remaining = session.hardExpiresAt - now;
+    // Past the hard cap → do NOT re-persist (would resurrect an expired session /
+    // set a non-positive EX). Let the reaper + hard-TTL collect it.
+    if (remaining <= 0) return;
+    const updated: DevTunnelSessionRecord = { ...session, lastActivityAt: now };
+    await sysRedis.set(sessionKey(sessionId), JSON.stringify(updated), { EX: remaining });
+  } catch {
+    /* best-effort idle refresh — never throw into the gate */
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -638,106 +734,224 @@ export async function reserveDevSessionBuzz(
   }
 }
 
+/**
+ * Refund a previously-reserved dev-session `costBuzz` (best-effort DECRBY). Used
+ * by the submit path when the workflow submit throws AFTER a successful
+ * reservation, mirroring the per-user daily cap's refund-on-throw so a failed
+ * submit doesn't permanently burn the session ceiling. Best-effort: a lost
+ * refund only OVER-counts (a STRICTER backstop) and never throws into the caller.
+ */
+export async function refundDevSessionBuzz(sessionId: string, costBuzz: number): Promise<void> {
+  const cost = Math.max(0, Math.ceil(costBuzz));
+  if (cost === 0) return;
+  await sysRedis.decrBy(spendKey(sessionId), cost).catch(() => {
+    /* best-effort — a lost refund over-counts (stricter cap) */
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Reaper (server-authoritative — NOT CLI-dependent)
 // ---------------------------------------------------------------------------
 
+/** A reaper session read that distinguishes a genuine ABSENCE (reap) from a
+ *  transient read ERROR (skip) — `readJson` collapses both to null, which would
+ *  let a Redis blip reap a LIVE route. */
+type ReaperRead =
+  | { status: 'ok'; session: DevTunnelSessionRecord }
+  | { status: 'absent' }
+  | { status: 'error' };
+
+async function readSessionForReap(sessionId: string): Promise<ReaperRead> {
+  let raw: string | null;
+  try {
+    raw = await withSysReadDeadline(sysRedis.get(sessionKey(sessionId)));
+  } catch {
+    return { status: 'error' };
+  }
+  if (raw == null) return { status: 'absent' };
+  if (typeof raw !== 'string') return { status: 'error' };
+  try {
+    return { status: 'ok', session: JSON.parse(raw) as DevTunnelSessionRecord };
+  } catch {
+    // Corrupt JSON — ambiguous, don't reap on it.
+    return { status: 'error' };
+  }
+}
+
+/** Prefer the apiserver's clock (the LIST response `Date` header) over the pod's
+ *  local clock for the min-age / idle windows, so a skewed pod can't over- or
+ *  under-reap. Falls back to the local clock when the header is unavailable. */
+function apiServerNowSec(res: Response): number {
+  try {
+    const d = (res as { headers?: { get?: (k: string) => string | null } }).headers?.get?.('date');
+    if (typeof d === 'string' && d) {
+      const t = Date.parse(d);
+      if (Number.isFinite(t)) return Math.floor(t / 1000);
+    }
+  } catch {
+    /* fall through */
+  }
+  return nowSec();
+}
+
+/** True iff the session has been idle longer than DEV_TUNNEL_IDLE_SECONDS.
+ *  Falls back to `createdAt` when `lastActivityAt` is absent (never-visited). */
+function isIdleExpired(session: DevTunnelSessionRecord, now: number): boolean {
+  const activity =
+    typeof session.lastActivityAt === 'number' ? session.lastActivityAt : session.createdAt;
+  return now - activity > DEV_TUNNEL_IDLE_SECONDS;
+}
+
+/**
+ * Discriminated result of one reaper sweep — matches the sibling reaper-schedule
+ * contract (civitai #2928) BYTE-FOR-BYTE so its `reap-dev-tunnels` job + the
+ * `dev_tunnel_reaper_runs_total{result}` metric compile + work unchanged against
+ * this (superset) reaper. `listOk:false` (with the HTTP `status`) is the
+ * SILENT-FAILURE fix: a non-2xx / unreachable LIST is surfaced DISTINCTLY instead
+ * of masquerading as a healthy empty sweep (which would let the job record `ok`
+ * on a permanent no-op). Do NOT return a bare `{swept,reaped}` — the job hard-reads
+ * `result.listOk` (undefined ⇒ every healthy run mis-records `list_failed`).
+ */
+export type ReapResult = {
+  swept: number;
+  reaped: number;
+  /** Sessions intentionally left this sweep (young/absent-guarded, or their
+   *  session read errored) — retried next tick. */
+  skipped: number;
+  /** false ⇒ a label-scoped LIST failed (non-2xx, OR the call THREW: TLS-verify
+   *  reject / DNS / connection-refused / timeout / missing SA token); the sweep
+   *  did nothing and could not reclaim routes. */
+  listOk: boolean;
+  /** When listOk is false: the HTTP status of a non-2xx LIST, or the sentinel `0`
+   *  when the LIST call THREW (API server unreachable — no HTTP status exists). */
+  status?: number;
+};
+
+/** Sentinel `status` for a LIST that threw (API unreachable — no real HTTP
+ *  status). Distinguishes "couldn't reach the apiserver" from a genuine non-2xx.
+ *  Matches #2928's constant of the same name + value. */
+const LIST_UNREACHABLE_STATUS = 0;
+
 /**
  * Sweep the ephemeral dev-tunnel routes and tear down any whose backing session
- * record has genuinely expired (hard-TTL) or is confirmed-absent. Bounded by the
+ * is HARD-expired (8h max-TTL), IDLE-expired (no browser activity for
+ * DEV_TUNNEL_IDLE_SECONDS — F3), or genuinely GONE from Redis. Bounded by the
  * number of live routes (label-scoped LIST). Server-authoritative: even if the
- * CLI crashes without calling stopDevTunnel, the hard-TTL Redis expiry + this
- * sweep reclaim the route. Driven by the `reap-dev-tunnels` periodic job.
+ * CLI crashes without calling stopDevTunnel, this sweep + the hard-TTL Redis
+ * expiry reclaim the route. Driven by the `reap-dev-tunnels` periodic job (#2928).
  *
- * SAFETY (the delete blast-radius is the whole point of a reaper — it must be
- * tight):
- *  - **LIST failure is NOT an empty sweep.** A non-2xx LIST returns
- *    `{ listOk:false, status }` (not a benign zero) so a persistent RBAC/ns/5xx
- *    failure is detectable + alertable rather than a silent permanent no-op.
- *  - **Never reap on a Redis READ FAILURE.** The reap decision uses
- *    `readSessionChecked` (error vs absent), not the error→null `readJson`. On a
- *    read error the route is SKIPPED — a transient Redis blip can never be read
- *    as "session gone → delete" and tear down live tunnels.
- *  - **Confirmed-absent record → min-age guarded.** A route whose session read
- *    cleanly missed is only reaped once it's older than
- *    DEV_TUNNEL_REAP_MIN_AGE_SECONDS, closing the create-before-persist race
- *    (route rendered before the session key is written).
- *
- * A present record is reaped only when `hardExpiresAt <= now` (`reap-maxttl`).
- * (A finer idle-timeout would refresh the session key's TTL on browser activity;
- * the absent-key path then reaps it — same code path, min-age guarded.)
+ * Hardening (preserved + extended — this is the SUPERSET of #2928's reaper,
+ * returning #2928's EXACT {@link ReapResult} contract):
+ *   - CONTRACT (non-regressing): an errored or unreachable LIST is
+ *     `{listOk:false, status}`, NEVER a silent `{swept:0,reaped:0}` that the
+ *     `reap-dev-tunnels` job would mis-record as a healthy `ok` run.
+ *   - BOTH KINDS (F1-2): discover ingressroutes AND middlewares, then reap over the
+ *     UNION of session ids. buildDevTunnelApplyScript applies the Middleware BEFORE
+ *     the IngressRoute under `set -e`, so a failed IngressRoute apply can leave an
+ *     orphan Middleware (session-labelled) while the mint aborts. LISTing routes
+ *     only would never discover it → an unbounded (inert) leak. deleteDevTunnelRoute
+ *     already deletes both kinds, so a middleware-only orphan gets fully cleaned.
+ *   - read-error skip: a transient Redis read error SKIPS the session (counted in
+ *     `skipped`) — reap only on a CONFIRMED absent/expired/idle record, never a blip.
+ *   - min-age guard: an absent-record session whose EARLIEST discovered object is
+ *     younger than DEV_TUNNEL_REAP_MIN_AGE_SECONDS — OR whose age can't be
+ *     determined (mirrors #2928) — is SKIPPED (counted), not reaped: it may be
+ *     mid-mint (render precedes persist).
+ *   - apiserver-clock: the min-age + idle windows use the LIST response Date header.
  */
 export async function reapExpiredDevTunnels(): Promise<ReapResult> {
   const ns = env.APPS_KUBE_NAMESPACE;
   const selector = encodeURIComponent(`${DEV_TUNNEL_LABEL}=true`);
-  let listRes: Response;
+  const listPaths = [
+    `/apis/traefik.io/v1alpha1/namespaces/${ns}/ingressroutes?labelSelector=${selector}`,
+    `/apis/traefik.io/v1alpha1/namespaces/${ns}/middlewares?labelSelector=${selector}`,
+  ];
+
+  // Resolve the in-pod target once. A getDp1Target throw (missing SA token / not
+  // in-cluster) is "can't reach the apiserver" — surface as listOk:false with the
+  // unreachable sentinel, NOT a propagated exception (which the job would
+  // mis-attribute to `error` rather than `list_failed`).
+  let target: Awaited<ReturnType<typeof getDp1Target>>;
   try {
-    const target = await getDp1Target();
-    listRes = await k8sFetch(
-      target,
-      `/apis/traefik.io/v1alpha1/namespaces/${ns}/ingressroutes?labelSelector=${selector}`,
-      { method: 'GET' }
-    );
+    target = await getDp1Target();
   } catch {
-    // Couldn't even REACH the API server: TLS-verify reject (a pool without
-    // NODE_EXTRA_CA_CERTS), DNS, connection-refused, timeout, or a missing SA
-    // token. That's "can't reclaim routes" — a list_failed, NOT a code bug — so
-    // surface it as listOk:false (sentinel status 0), not a thrown exception that
-    // the job would misattribute to `error`. Recording `ok`/no-op here would
-    // re-open the silent-failure hole.
     return { swept: 0, reaped: 0, skipped: 0, listOk: false, status: LIST_UNREACHABLE_STATUS };
   }
-  // A non-2xx LIST is a FAILURE, not an empty sweep — surface it distinctly so
-  // the job logs `level:error` + increments the `list_failed` metric. Returning a
-  // benign zero here would make an RBAC/ns/5xx break a permanent silent no-op.
-  if (!listRes.ok) {
-    return { swept: 0, reaped: 0, skipped: 0, listOk: false, status: listRes.status };
+
+  // Discover sessions across BOTH kinds. Map sessionId → EARLIEST discovered
+  // object creationTimestamp (seconds), used by the min-age guard (a session with
+  // even one old object is not mid-mint; a freshly-created pair stays young).
+  const discovered = new Map<string, number | undefined>();
+  let apiNow = nowSec();
+  for (const listPath of listPaths) {
+    let listRes: Response;
+    try {
+      listRes = await k8sFetch(target, listPath, { method: 'GET' });
+    } catch {
+      // Couldn't even REACH the apiserver for this LIST — list_failed (unreachable),
+      // never a silent empty sweep.
+      return { swept: 0, reaped: 0, skipped: 0, listOk: false, status: LIST_UNREACHABLE_STATUS };
+    }
+    // A non-2xx LIST is a FAILURE (RBAC/ns/5xx), NOT an empty cluster — surface it
+    // distinctly so the job records `list_failed` instead of a healthy `ok` no-op.
+    if (!listRes.ok) {
+      return { swept: 0, reaped: 0, skipped: 0, listOk: false, status: listRes.status };
+    }
+    apiNow = apiServerNowSec(listRes);
+    const list = await unwrap<{
+      items?: Array<{ metadata?: { labels?: Record<string, string>; creationTimestamp?: string } }>;
+    }>(listRes);
+    for (const it of list?.items ?? []) {
+      const sessionId = it?.metadata?.labels?.[DEV_TUNNEL_SESSION_LABEL];
+      if (!sessionId) continue;
+      const parsed = Date.parse(it?.metadata?.creationTimestamp ?? '');
+      const createdSec = Number.isFinite(parsed) ? Math.floor(parsed / 1000) : undefined;
+      if (!discovered.has(sessionId)) {
+        discovered.set(sessionId, createdSec);
+      } else {
+        const prev = discovered.get(sessionId);
+        if (createdSec != null && (prev == null || createdSec < prev)) {
+          discovered.set(sessionId, createdSec);
+        }
+      }
+    }
   }
-  const list = await unwrap<{
-    items?: Array<{
-      metadata?: { labels?: Record<string, string>; creationTimestamp?: string };
-    }>;
-  }>(listRes);
-  const items = list?.items ?? [];
-  // Use the APISERVER's clock (the LIST response `Date` header) as "now" for the
-  // min-age guard — same clock domain as each object's creationTimestamp, so the
-  // guard is immune to pod↔apiserver skew. Fall back to the pod clock only if the
-  // header is missing/unparseable (then the guard assumes bounded NTP skew).
-  const nowMs = parseHttpDate(listRes.headers?.get?.('date')) ?? Date.now();
+
   let reaped = 0;
   let skipped = 0;
-  for (const it of items) {
-    const sessionId = it?.metadata?.labels?.[DEV_TUNNEL_SESSION_LABEL];
-    if (!sessionId) continue;
-    const outcome = await readSessionChecked(sessionId);
-    if (!outcome.ok) {
-      // Redis READ FAILED — this route may back a LIVE session. Never reap on a
-      // read failure; skip and let the next sweep retry.
+  for (const [sessionId, createdSec] of discovered) {
+    const read = await readSessionForReap(sessionId);
+
+    // read-error skip: a Redis blip must never reap a LIVE session.
+    if (read.status === 'error') {
       skipped += 1;
       continue;
     }
-    const session = outcome.value;
-    if (session) {
-      // Record present: reap ONLY if genuinely past its hard-TTL.
-      if (session.hardExpiresAt <= nowSec()) {
-        await teardownSession(session, 'reap-maxttl').catch(() => {});
-        reaped += 1;
+
+    if (read.status === 'absent') {
+      // min-age guard: a just-created object (or one whose age can't be
+      // determined — createdSec undefined) may be mid-mint → skip, never reap.
+      if (createdSec == null || apiNow - createdSec < DEV_TUNNEL_REAP_MIN_AGE_SECONDS) {
+        skipped += 1;
+        continue;
       }
+      // Orphan (record genuinely gone, object old enough) — delete BOTH kinds.
+      await deleteDevTunnelRoute(sessionId).catch(() => {});
+      recordDevTunnelTeardown('reap-maxttl');
+      reaped += 1;
       continue;
     }
-    // Record CONFIRMED-ABSENT (clean miss or corrupt value). Guard the
-    // create-before-persist race: only reap a route demonstrably older than the
-    // min-age guard. A young route (or one whose age can't be determined) is left
-    // for the next sweep.
-    const ageSec = routeAgeSeconds(it?.metadata?.creationTimestamp, nowMs);
-    if (ageSec === null || ageSec < DEV_TUNNEL_REAP_MIN_AGE_SECONDS) {
-      skipped += 1;
-      continue;
+
+    // status === 'ok': reap on hard-TTL OR idle expiry. A healthy non-expired
+    // session is neither reaped nor `skipped` — it's a live route intentionally
+    // kept (matches #2928: skipped counts read-error + guarded-absent only).
+    const session = read.session;
+    const hardExpired = session.hardExpiresAt <= apiNow;
+    const idleExpired = isIdleExpired(session, apiNow);
+    if (hardExpired || idleExpired) {
+      await teardownSession(session, hardExpired ? 'reap-maxttl' : 'reap-idle').catch(() => {});
+      reaped += 1;
     }
-    // Redis record gone but route survives past the guard — delete it directly.
-    await deleteDevTunnelRoute(sessionId).catch(() => {});
-    recordDevTunnelTeardown('reap-maxttl');
-    reaped += 1;
   }
-  return { swept: items.length, reaped, skipped, listOk: true };
+  return { swept: discovered.size, reaped, skipped, listOk: true };
 }

--- a/src/tests/api/internal/blocks/dev-tunnel-gate.test.ts
+++ b/src/tests/api/internal/blocks/dev-tunnel-gate.test.ts
@@ -1,6 +1,16 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { signDevTunnelAccessToken } from '~/server/services/blocks/dev-tunnel-session';
+
+// F3: the gate refreshes the session idle marker on a successful ENTRY hit via a
+// dynamic import of dev-tunnel.service. Mock it so the gate suite stays lean (no
+// Redis/k8s) and we can assert WHEN the refresh fires.
+const { mockTouchDevTunnelActivity } = vi.hoisted(() => ({
+  mockTouchDevTunnelActivity: vi.fn(async (_host: string): Promise<void> => undefined),
+}));
+vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
+  touchDevTunnelActivity: (...a: unknown[]) => mockTouchDevTunnelActivity(...(a as [string])),
+}));
 
 /**
  * APP DEV TUNNEL — coverage for the Traefik forwardAuth entry gate
@@ -56,6 +66,7 @@ describe('/api/internal/dev-tunnel-gate', () => {
   const prev = process.env.NEXTAUTH_SECRET;
   beforeEach(() => {
     process.env.NEXTAUTH_SECRET = SECRET;
+    mockTouchDevTunnelActivity.mockClear();
   });
   afterEach(() => {
     if (prev === undefined) delete process.env.NEXTAUTH_SECRET;
@@ -131,5 +142,28 @@ describe('/api/internal/dev-tunnel-gate', () => {
     const res = makeRes();
     handler(makeReq({ host: HOST, uri: '/app.js', secFetchDest: 'script' }), res);
     expect(res.statusCode).toBe(200);
+  });
+
+  // ── F3: idle-marker refresh fires ONLY on a successful ENTRY hit ──
+  it('refreshes the session idle marker on a successful ENTRY hit', async () => {
+    const token = signDevTunnelAccessToken({ userId: USER, host: HOST, secret: SECRET });
+    const res = makeRes();
+    await handler(makeReq({ host: HOST, uri: entryUri(token), secFetchDest: 'document' }), res);
+    expect(res.statusCode).toBe(200);
+    expect(mockTouchDevTunnelActivity).toHaveBeenCalledWith(HOST);
+  });
+
+  it('does NOT refresh on a denied (naked) ENTRY request', async () => {
+    const res = makeRes();
+    await handler(makeReq({ host: HOST, uri: '/', secFetchDest: 'document' }), res);
+    expect(res.statusCode).toBe(401);
+    expect(mockTouchDevTunnelActivity).not.toHaveBeenCalled();
+  });
+
+  it('does NOT refresh on a SUBRESOURCE (no auth decision to bind activity to)', async () => {
+    const res = makeRes();
+    await handler(makeReq({ host: HOST, uri: '/app.js', secFetchDest: 'script' }), res);
+    expect(res.statusCode).toBe(200);
+    expect(mockTouchDevTunnelActivity).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Addresses four P4-security-audit findings on the App Blocks **dev-tunnel P1 control plane** (design Revision 3, `claudedocs/app-blocks-dev-tunnel-design-2026-07-03.md`), plus the CLI host-key pin (R1). Base off `main` (P1 #2920 merged), not stacked.

The feature is **dark** behind `app-blocks-dev-tunnel` (base off) — these are pre-P3-flag-flip hardening + the untracked functional blocker.

## F1 — render via the scoped `apps-applier` Job SA, not the web-pod SA
`renderDevTunnelRoute` POSTed the IngressRoute/Middleware **directly from the web pod**, but `civitai-web-apps-consumer` grants only `get/list/watch/delete` on traefik.io CRDs (no `create`) → `startDevTunnel` 403'd (silent P3 blocker). Broadening the live web-pod SA to `create` would turn any civitai-web SSRF/RCE into arbitrary-IngressRoute creation → hijack of live app hosts.

Now renders through the **same render-and-apply Job mechanism the review sandbox uses** (`serviceAccountName: apps-applier`, ns-locked, HAS create) — the Job `kubectl apply`s the server-rendered manifests. `renderDevTunnelRoute` awaits it to Succeeded so the "render first → persist state only on success" contract holds. The reaper's DELETE stays on the web-pod SA (it has delete).
- `dev-tunnel.service.ts`: `buildDevTunnelApplyJob` / `buildDevTunnelApplyScript` / `devTunnelApplyJobName`; `renderDevTunnelRoute` rewritten (removed the direct web-pod-SA `applyManifest`).

## F3 — server-side idle-reap (`DEV_TUNNEL_IDLE_SECONDS` was defined but unused)
- `dev-tunnel-gate.ts`: the forwardAuth gate refreshes a `lastActivityAt` marker on each successful **ENTRY** hit, **after** the auth response is flushed (a Redis hiccup can't change the gate decision or add latency).
- `touchDevTunnelActivity` re-persists the session with `EX = remaining-until-hardExpiresAt` — activity **never extends** the 8h hard cap.
- `reapExpiredDevTunnels` now reaps **idle-expired** sessions (`reap-idle`) in addition to hard-TTL, and gains the hardening the design calls for: **read-error skip** (a Redis blip never reaps a live route), **min-age guard** on absent-record orphans (never reap mid-mint, since render precedes persist), **apiserver-clock** for the windows, plus the existing **listOk**.

## F4 — wire the per-session Buzz spend cap (`reserveDevSessionBuzz` had no call site)
`submitWorkflow` resolves the caller's active dev tunnel for `(userId, blockId)` server-side and enforces `reserveDevSessionBuzz` before the real submit; over-cap → **fail-closed** reject (failed snapshot + daily-cap refund); a throw after reserve refunds the session reservation too (mirrors the daily cap).

**Deviation (reported honestly):** implemented via **submit-time `getActiveDevTunnel`**, not token-carriage. The block token carries **no dev-session id**, and the standard mint's *approved-only* gate wouldn't issue a token for the dev-tunnel's own-app-**any-status** premise — so stamping the token would be a larger, more fragile change that still wouldn't cover the unapproved-app dev case. The submit-time lookup is **strictly more bounded** (single file), **token-provenance-independent**, and ties enforcement to the session's own `spendCapBuzz`. `claims.blockId` == the `AppBlock.blockId` used as the session key (verified). One extra Redis GET on the block-submit path (misses/no-ops for every non-dev submit). Lookup fails **open** (a getActiveDevTunnel error → treat as non-dev, so a blip can't break all generation — the daily cap still applies); enforcement fails **closed** (reserveDevSessionBuzz denies on Redis error).

## R1 — return the sish host pubkey for the CLI to pin
`startDevTunnel` now returns `sshHostPublicKey` from the new (non-secret) `APPS_DEV_TUNNEL_SSH_HOST_PUBKEY` env (added to the schema). Empty string when unset → the CLI must fail closed (refuse to connect rather than `InsecureIgnoreHostKey`).

## F5 — reported, NO code change (sish cannot attach the shared-secret header)
Confirmed against **sish v2.23.0 source** (`utils/utils.go::checkAuthenticationKeyRequest` uses a bare `http.Client.Post` with a hardcoded `{auth_key,user,remote_addr}` body; the only flags are `authentication-key-request-url` + `-timeout` — **no header flag**). So sish **cannot** send the `X-Dev-Tunnel-Secret` header that `authz.ts` requires → every real bind would 401 → the tunnel never authorizes. **P3 blocker.** Alternative (per sish's single-URL config): carry the shared secret in the **URL path/query** and have `authz.ts` read it there instead of the header (prefer a path segment to keep it out of query-string access logs).

## Tests
Full unit coverage; `tsc --noEmit` (8GB heap) clean.
- `dev-tunnel.service.test.ts` (22): apply-Job renders via `apps-applier` (not web-pod SA) + carries both manifests; failed Job aborts the mint (nothing persisted); `sshHostPublicKey` returned / empty-when-unset; `touchDevTunnelActivity` refreshes without extending hard-TTL; reaper idle-reap / recently-active-survives / read-error-skip / min-age-guard / orphan-reap / listOk; `refundDevSessionBuzz`.
- `dev-tunnel-gate.test.ts` (12): idle refresh fires only on a successful ENTRY (not on 401/subresource).
- `blocks.router.workflow.test.ts` (137, +4 F4): over-cap fail-closed reject (no real submit) / pass-through / refund-on-throw / inert for a normal submit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)