### PR TITLE
fix(app-blocks): F5 dev-tunnel sish authz — carry shared secret in URL path

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -763,9 +763,13 @@ export const serverSchema = z
     // behind the `app-blocks-dev-tunnel` Flipt flag regardless.
     //
     // APPS_DEV_TUNNEL_SISH_SECRET   shared secret the sish server presents on the
-    //   authz callback (`POST /api/apps/dev-tunnel/authz`) so random internet
-    //   cannot POST it. When UNSET the callback fail-closes (503) — the sish
-    //   integration is inert until it is provisioned (P3).
+    //   authz callback so random internet cannot POST it. Carried as the trailing
+    //   PATH segment of the callback URL
+    //   (`POST /api/apps/dev-tunnel/authz/<secret>`) because sish v2.23.0's
+    //   `authentication-key-request-url` does a bare POST and CANNOT attach a
+    //   custom header (F5). MUST be a URL-PATH-SAFE token (no `/`, no whitespace,
+    //   no reserved chars) — generate as hex/base64url. When UNSET the callback
+    //   fail-closes (503) — the sish integration is inert until provisioned (P3).
     APPS_DEV_TUNNEL_SISH_SECRET: z.string().optional(),
     // APPS_DEV_TUNNEL_FORWARDAUTH_URL   in-cluster address of the dev-tunnel-gate
     //   forwardAuth endpoint the ephemeral Middleware points Traefik at. When

--- a/src/pages/api/apps/dev-tunnel/authz/[secret].ts
+++ b/src/pages/api/apps/dev-tunnel/authz/[secret].ts
@@ -11,11 +11,28 @@ import {
 } from '~/server/services/blocks/dev-tunnel.service';
 
 /**
- * POST /api/apps/dev-tunnel/authz  (APP DEV TUNNEL — sish authz callback)
+ * POST /api/apps/dev-tunnel/authz/<secret>  (APP DEV TUNNEL — sish authz callback)
  *
  * The sish tunnel server's `authentication-key-request-url` target. sish POSTs
  * `{ auth_key, user, remote_addr }` for each `ssh -R` bind and authorizes the bind
  * iff we return 200.
+ *
+ * ── WHY THE SHARED SECRET IS IN THE PATH, NOT A HEADER (F5) ──
+ * sish v2.23.0's `authentication-key-request-url` does a BARE POST with a
+ * hardcoded `{ auth_key, user, remote_addr }` body — it CANNOT attach a custom
+ * request header. An `X-Dev-Tunnel-Secret` header self-auth would therefore 401
+ * every real bind. So the shared secret is carried as the LAST PATH SEGMENT of the
+ * callback URL sish is configured with:
+ *
+ *   authentication-key-request-url: https://civitai.com/api/apps/dev-tunnel/authz/<APPS_DEV_TUNNEL_SISH_SECRET>
+ *
+ * Path (not query) keeps the secret out of most access-log query-string capture,
+ * mirroring the review-sandbox mr-token-in-path choice. Because that URL contains
+ * the secret it is SOPS-managed on the infra side and only wired at P3.
+ *
+ * ⚠️ `APPS_DEV_TUNNEL_SISH_SECRET` MUST be a URL-PATH-SAFE token (no `/`, no
+ * whitespace, no reserved chars) — it is compared against the decoded path
+ * segment. Generate it as a hex/base64url string.
  *
  * ── THREAT POSTURE ──
  * `user` and `remote_addr` are ATTACKER-CONTROLLED (they come off the SSH client)
@@ -23,11 +40,13 @@ import {
  * entirely on the presented `auth_key` (the SSH PUBLIC key) matching a live,
  * userId-bound tunnel credential minted by `startDevTunnel`:
  *
- *   1. SELF-AUTH (shared secret) — this endpoint is NOT session-authed (sish, a
- *      machine, calls it), so it self-authenticates via a shared secret only sish
- *      knows (`X-Dev-Tunnel-Secret` == APPS_DEV_TUNNEL_SISH_SECRET, constant-time).
- *      Unset secret → 503 (the sish integration is inert until provisioned, P3).
- *      Wrong/absent secret → 401 (random internet cannot POST this).
+ *   1. SELF-AUTH (shared secret in the path) — this endpoint is NOT session-authed
+ *      (sish, a machine, calls it), so it self-authenticates via a shared secret
+ *      only sish knows (the trailing path segment == APPS_DEV_TUNNEL_SISH_SECRET,
+ *      constant-time). Unset secret → 503 (the sish integration is inert until
+ *      provisioned, P3). Wrong/absent path secret → 401 (random internet cannot
+ *      POST this). This compare runs BEFORE any Redis work — a DoS-safe ordering
+ *      so an unauthenticated flood never touches the credential store.
  *   2. FINGERPRINT LOOKUP — index the credential by sha256(normalized pubkey).
  *   3. CONSTANT-TIME PUBKEY COMPARE — the authoritative check: the full stored
  *      pubkey must timing-safe-equal the presented `auth_key`. A fingerprint
@@ -49,7 +68,9 @@ export const config = {
   },
 };
 
-function firstHeader(v: string | string[] | undefined): string | undefined {
+function pathSecret(v: string | string[] | undefined): string | undefined {
+  // Next decodes the [secret] path param; a catch-all would be an array, a single
+  // dynamic segment is a string. Take the first if somehow an array.
   return Array.isArray(v) ? v[0] : v;
 }
 
@@ -60,15 +81,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  // 1. Self-auth via the shared secret. Unset → the sish integration isn't
-  // provisioned yet (P3) → 503 (inert, fail-closed). Present but mismatched →
-  // 401 (random internet cannot POST this).
+  // 1. Self-auth via the shared secret carried in the URL PATH. Ordering is
+  // deliberate + DoS-safe: env-unset → 503, then a constant-time path-secret
+  // compare → 401, BOTH before any fingerprint/Redis work.
+  //
+  // Unset → the sish integration isn't provisioned yet (P3) → 503 (inert,
+  // fail-closed). Present but mismatched/absent → 401 (random internet cannot
+  // POST this).
   const configured = env.APPS_DEV_TUNNEL_SISH_SECRET;
   if (!configured) {
     res.status(503).json({ auth: false, error: 'dev tunnel not configured' });
     return;
   }
-  const presented = firstHeader(req.headers['x-dev-tunnel-secret']);
+  const presented = pathSecret(req.query.secret);
   if (!sharedSecretMatch(presented, configured)) {
     res.status(401).json({ auth: false, error: 'unauthorized' });
     return;

--- a/src/tests/api/apps/dev-tunnel-authz.test.ts
+++ b/src/tests/api/apps/dev-tunnel-authz.test.ts
@@ -171,4 +171,31 @@ describe('POST /api/apps/dev-tunnel/authz/<secret>', () => {
     await handler(makeReq({ secret: 'sish-shared-secret', method: 'GET' }), res);
     expect(res.statusCode).toBe(405);
   });
+
+  // F-4: a `?secret=` query param merged into the dynamic [secret] path segment
+  // yields a Next.js `string[]`. Lock the pathSecret()→sharedSecretMatch()
+  // type-guard contract so this can never become a bypass under a future
+  // refactor. pathSecret() takes index [0]; sharedSecretMatch() rejects
+  // non-strings — the correct secret is only accepted at index 0.
+  it('ARRAY path secret, correct at index 0 → 200 (first element wins)', async () => {
+    mockLookup.mockResolvedValue(validCred);
+    const res = makeRes();
+    await handler(makeReq({ secret: ['sish-shared-secret', 'injected'], authKey: PUBKEY }), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.auth).toBe(true);
+  });
+
+  it('ARRAY path secret, real secret at index 1 → 401 (index-1 must NOT rescue)', async () => {
+    const res = makeRes();
+    await handler(makeReq({ secret: ['injected', 'sish-shared-secret'], authKey: PUBKEY }), res);
+    expect(res.statusCode).toBe(401);
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('EMPTY array path secret → 401 (no lookup) — defense-in-depth', async () => {
+    const res = makeRes();
+    await handler(makeReq({ secret: [], authKey: PUBKEY }), res);
+    expect(res.statusCode).toBe(401);
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
 });

--- a/src/tests/api/apps/dev-tunnel-authz.test.ts
+++ b/src/tests/api/apps/dev-tunnel-authz.test.ts
@@ -4,10 +4,11 @@ import { fingerprintSshPublicKey, normalizeSshPublicKey } from '~/server/service
 
 /**
  * APP DEV TUNNEL — coverage for the sish authz callback
- * `POST /api/apps/dev-tunnel/authz`. `user` / `remote_addr` are attacker-
- * controlled → never authz'd on; the decision is the presented `auth_key`
- * matching a live userId-bound credential (constant-time), gated by the shared
- * secret. Single-use → replay denied.
+ * `POST /api/apps/dev-tunnel/authz/<secret>`. The shared secret is carried in the
+ * URL PATH (F5: sish v2.23.0 cannot attach a custom header), not a header.
+ * `user` / `remote_addr` are attacker-controlled → never authz'd on; the decision
+ * is the presented `auth_key` matching a live userId-bound credential
+ * (constant-time), gated by the path secret. Single-use → replay denied.
  */
 
 const { mockLookup, mockConsume, mockEnv } = vi.hoisted(() => ({
@@ -22,7 +23,7 @@ vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
   consumeDevTunnelCredential: (...a: unknown[]) => mockConsume(...a),
 }));
 
-import handler from '~/pages/api/apps/dev-tunnel/authz';
+import handler from '~/pages/api/apps/dev-tunnel/authz/[secret]';
 
 const PUBKEY = 'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBytes0123456789abcdefg dev@laptop';
 const NORMALIZED = normalizeSshPublicKey(PUBKEY);
@@ -60,22 +61,25 @@ function makeRes() {
 }
 
 function makeReq(opts: {
-  secret?: string;
+  /** The trailing path segment (the shared secret). `undefined` ⇒ no path param
+   *  at all (e.g. a request that somehow reached the handler with no [secret]). */
+  secret?: string | string[];
   authKey?: string;
   user?: string;
   remoteAddr?: string;
   method?: string;
 }): NextApiRequest {
-  const headers: Record<string, string> = {};
-  if (opts.secret !== undefined) headers['x-dev-tunnel-secret'] = opts.secret;
+  const query: Record<string, string | string[]> = {};
+  if (opts.secret !== undefined) query.secret = opts.secret;
   return {
     method: opts.method ?? 'POST',
-    headers,
+    headers: {},
+    query,
     body: { auth_key: opts.authKey, user: opts.user, remote_addr: opts.remoteAddr },
   } as unknown as NextApiRequest;
 }
 
-describe('POST /api/apps/dev-tunnel/authz', () => {
+describe('POST /api/apps/dev-tunnel/authz/<secret>', () => {
   beforeEach(() => {
     mockLookup.mockReset();
     mockConsume.mockClear();
@@ -83,7 +87,7 @@ describe('POST /api/apps/dev-tunnel/authz', () => {
   });
   afterEach(() => vi.clearAllMocks());
 
-  it('valid secret + matching pubkey → 200 (and consumes the credential)', async () => {
+  it('valid PATH secret + matching pubkey → 200 (and consumes the credential)', async () => {
     mockLookup.mockResolvedValue(validCred);
     const res = makeRes();
     await handler(makeReq({ secret: 'sish-shared-secret', authKey: PUBKEY, user: 'anything' }), res);
@@ -140,24 +144,26 @@ describe('POST /api/apps/dev-tunnel/authz', () => {
     expect(mockLookup).not.toHaveBeenCalled();
   });
 
-  it('WRONG shared secret → 401 (random internet cannot POST)', async () => {
+  it('WRONG path secret → 401 (random internet cannot POST) — no Redis lookup (DoS-safe ordering)', async () => {
     const res = makeRes();
     await handler(makeReq({ secret: 'nope', authKey: PUBKEY }), res);
     expect(res.statusCode).toBe(401);
     expect(mockLookup).not.toHaveBeenCalled();
   });
 
-  it('MISSING shared secret header → 401', async () => {
+  it('MISSING path secret → 401 (no lookup)', async () => {
     const res = makeRes();
     await handler(makeReq({ authKey: PUBKEY }), res);
     expect(res.statusCode).toBe(401);
+    expect(mockLookup).not.toHaveBeenCalled();
   });
 
-  it('UNCONFIGURED sish secret (env unset) → 503 (inert until provisioned)', async () => {
+  it('UNCONFIGURED sish secret (env unset) → 503 (inert until provisioned), even with a path secret', async () => {
     mockEnv.APPS_DEV_TUNNEL_SISH_SECRET = undefined;
     const res = makeRes();
     await handler(makeReq({ secret: 'anything', authKey: PUBKEY }), res);
     expect(res.statusCode).toBe(503);
+    expect(mockLookup).not.toHaveBeenCalled();
   });
 
   it('non-POST → 405', async () => {


### PR DESCRIPTION
## Why (F5 — confirmed P3 blocker)

The App Blocks dev-tunnel sish authz callback (`authz.ts`) self-authenticated on an `X-Dev-Tunnel-Secret` **header**. But sish v2.23.0's `authentication-key-request-url` does a **bare POST with a hardcoded `{auth_key,user,remote_addr}` body and CANNOT attach a custom request header** — so every real `ssh -R` bind would 401. The callback is unusable end-to-end until this lands.

## Fix

Move the shared secret from the header into the callback URL **path**:

- `src/pages/api/apps/dev-tunnel/authz.ts` → dynamic route **`src/pages/api/apps/dev-tunnel/authz/[secret].ts`**, reading `req.query.secret` and constant-time comparing it (`sharedSecretMatch`) against `env.APPS_DEV_TUNNEL_SISH_SECRET`. Header check removed (path is the sole self-auth).
- **Path, not query** — keeps the secret out of most access-log query-string capture, mirroring the review-sandbox mr-token-in-path choice.
- **Fail-closed + DoS-safe ordering preserved** (the property the prior audit praised): env unset → **503**; missing/mismatched path secret → **401**, both **before any fingerprint/Redis work**. Everything after is unchanged — fingerprint lookup, authoritative full-pubkey `timingSafeEqual`, best-effort single-use consume, and the `user`/`remote_addr` = log-only (attacker-controlled) posture.
- **`APPS_DEV_TUNNEL_SISH_SECRET` must now be a URL-path-safe token** (hex/base64url, no `/`, no whitespace/reserved chars) — it is compared against the decoded path segment. Noted in the env schema doc.

## New callback URL

`https://civitai.com/api/apps/dev-tunnel/authz/<secret>`

The sish config side (`authentication-key-request-url`) is wired at **P3** in datapacket-talos, SOPS-managed because the URL embeds the secret — see talos-infra #442.

## Tests

Existing `dev-tunnel-authz` suite re-pointed from the header to `query.secret`; added no-Redis-lookup assertions on the 401/503 paths to lock the DoS-safe ordering. Valid path secret → 200 + consume; wrong/missing path secret → 401 (no lookup); env unset → 503 (no lookup); fingerprint / replay / wrong-pubkey / malformed / non-POST matrix intact.

- `npx vitest run` dev-tunnel-authz + dev-tunnel-session: **25/25 pass**.
- `tsc --noEmit` (8GB heap): no errors in the changed files. (The only tsc output was pre-existing worktree noise — the uninitialized `event-engine-common` submodule + `kysely` resolution — unrelated to this change.)

## Honesty

Unit-tested + typechecked here. F5's true end-to-end (sish actually POSTing the path URL and the bind succeeding) can only be validated against the live sish v2.23.0 image at **P3**. Dark until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)