### PR TITLE
fix(sysredis): pipeline hardening — fail-open metric-flag + rewards-abuse config reads

### DIFF
--- a/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
+++ b/src/server/jobs/__tests__/rewards-abuse-prevention.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// STEP-3 sysRedis soft-dependency: the daily rewards-abuse-prevention job reads its
+// abuse thresholds from sysRedis. This job DISABLES user Buzz rewards (destructive),
+// so the fail-open policy here is to SKIP the run (not run on schema defaults) when the
+// config read fails — a sysRedis DOWN (hGet throws) or SLOW/half-open (withSysReadDeadline
+// rejects) must return early WITHOUT touching clickhouse/dbWrite.
+
+const { hGet, withSysReadDeadline, chQuery, dbQueryRawUnsafe, createNotification, refresh } =
+  vi.hoisted(() => ({
+    hGet: vi.fn(),
+    withSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+    chQuery: vi.fn(),
+    dbQueryRawUnsafe: vi.fn(),
+    createNotification: vi.fn(() => Promise.resolve(undefined)),
+    refresh: vi.fn(() => Promise.resolve(undefined)),
+  }));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { hGet },
+  REDIS_SYS_KEYS: { SYSTEM: { FEATURES: 'system:features' } },
+  withSysReadDeadline,
+}));
+
+vi.mock('~/server/clickhouse/client', () => ({
+  clickhouse: { $query: chQuery },
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbWrite: { $queryRawUnsafe: dbQueryRawUnsafe },
+}));
+
+vi.mock('~/server/redis/caches', () => ({
+  userMultipliersCache: { refresh },
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification,
+}));
+
+// The dynamic `import('~/server/prom/client')` inside the task loop.
+vi.mock('~/server/prom/client', () => ({
+  userUpdateCounter: { inc: vi.fn() },
+}));
+
+// Testable createJob: run().result invokes fn directly (mirrors process-strikes.test.ts).
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (_name: string, _cron: string, fn: any) => ({
+    name: _name,
+    cron: _cron,
+    run: (opts?: { req?: any }) => ({
+      result: fn({ status: 'running', on: vi.fn(), checkIfCanceled: vi.fn(), req: opts?.req }),
+      cancel: vi.fn(),
+    }),
+  }),
+}));
+
+import { rewardsAbusePrevention } from '~/server/jobs/rewards-abuse-prevention';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  withSysReadDeadline.mockImplementation((p) => p); // transparent by default
+  chQuery.mockResolvedValue([]); // no abusers by default
+  dbQueryRawUnsafe.mockResolvedValue([]);
+});
+
+describe('rewards-abuse-prevention — sysRedis config read (STEP-3 soft-dependency)', () => {
+  it('runs detection with a valid config (happy path)', async () => {
+    hGet.mockResolvedValue(
+      JSON.stringify({ awarded: 5000, user_count: 5, award_types: ['dailyBoost'] })
+    );
+
+    const result = await rewardsAbusePrevention.run().result;
+
+    expect(chQuery).toHaveBeenCalledTimes(1); // detection query ran
+    expect(result).toEqual({ usersDisabled: 0 });
+  });
+
+  it('treats a Buffer config reply (sentinel mode) as valid JSON', async () => {
+    hGet.mockResolvedValue(
+      Buffer.from(JSON.stringify({ awarded: 5000, user_count: 5 }), 'utf8')
+    );
+
+    const result = await rewardsAbusePrevention.run().result;
+
+    expect(chQuery).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ usersDisabled: 0 });
+  });
+
+  it('SKIPS the run (no destructive detection) when sysRedis is DOWN (hGet throws)', async () => {
+    hGet.mockRejectedValue(new Error('sysRedis connection is down'));
+
+    const result = await rewardsAbusePrevention.run().result;
+
+    expect(result).toEqual({ usersDisabled: 0, skipped: 'sysRedis-config-read-failed' });
+    expect(chQuery).not.toHaveBeenCalled(); // never queried abusers
+    expect(dbQueryRawUnsafe).not.toHaveBeenCalled(); // never ran the destructive UPDATE
+  });
+
+  it('SKIPS the run when the read-deadline REJECTS (SLOW/half-open)', async () => {
+    withSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await rewardsAbusePrevention.run().result;
+
+    expect(result).toEqual({ usersDisabled: 0, skipped: 'sysRedis-config-read-failed' });
+    expect(chQuery).not.toHaveBeenCalled();
+    expect(dbQueryRawUnsafe).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/jobs/rewards-abuse-prevention.ts
+++ b/src/server/jobs/rewards-abuse-prevention.ts
@@ -6,7 +6,7 @@ import { NotificationCategory } from '~/server/common/enums';
 import { dbWrite } from '~/server/db/client';
 import { createJob } from '~/server/jobs/job';
 import { userMultipliersCache } from '~/server/redis/caches';
-import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { createNotification } from '~/server/services/notification.service';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 
@@ -14,9 +14,22 @@ export const rewardsAbusePrevention = createJob(
   'rewards-abuse-prevention',
   '0 3 * * *',
   async () => {
+    let abuseLimitsRaw: string | Buffer | null = null;
+    try {
+      abuseLimitsRaw = await withSysReadDeadline(
+        sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, 'rewards:abuse-limits')
+      );
+    } catch {
+      // sysRedis DOWN/SLOW — we can't read the abuse thresholds. This job DISABLES
+      // user rewards (destructive), so skip this cycle rather than run on unknown
+      // config. The nightly cron retries tomorrow; a missed run is harmless.
+      return { usersDisabled: 0, skipped: 'sysRedis-config-read-failed' };
+    }
+    // Buffer-coerce (sentinel-mode sysRedis returns Buffer for BLOB_STRING replies;
+    // `?? '{}'` alone would mis-handle a Buffer — same root cause as base.metrics).
     const abuseLimits = abuseLimitsSchema.parse(
       JSON.parse(
-        (await sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, 'rewards:abuse-limits')) ?? '{}'
+        (Buffer.isBuffer(abuseLimitsRaw) ? abuseLimitsRaw.toString('utf8') : abuseLimitsRaw) ?? '{}'
       )
     );
     const abusers = await clickhouse?.$query<Abuser>(`

--- a/src/server/metrics/__tests__/base.metrics.test.ts
+++ b/src/server/metrics/__tests__/base.metrics.test.ts
@@ -11,16 +11,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // fixed in PR #2697. Both use the same hoisted-mock pattern to control the
 // hGet return type per-test — that's the exact axis of the bug.
 
-const { hGet, hSet, sAdd, sMembers, withSysReadDeadline } = vi.hoisted(() => ({
-  hGet: vi.fn(),
-  hSet: vi.fn(() => Promise.resolve(1)),
-  sAdd: vi.fn(() => Promise.resolve(1)),
-  sMembers: vi.fn(() => Promise.resolve([] as string[])),
-  // STEP-3 soft-dependency: the flag reads are now wrapped in withSysReadDeadline
-  // so a SLOW/half-open sysRedis rejects (deadline) instead of parking ~11min.
-  // Transparent by default (returns the wrapped promise) — override per-test to reject.
-  withSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
-}));
+const { hGet, hSet, sAdd, sMembers, withSysReadDeadline, logSysRedisFailOpen } = vi.hoisted(
+  () => ({
+    hGet: vi.fn(),
+    hSet: vi.fn(() => Promise.resolve(1)),
+    sAdd: vi.fn(() => Promise.resolve(1)),
+    sMembers: vi.fn(() => Promise.resolve([] as string[])),
+    // STEP-3 soft-dependency: the flag reads are now wrapped in withSysReadDeadline
+    // so a SLOW/half-open sysRedis rejects (deadline) instead of parking ~11min.
+    // Transparent by default (returns the wrapped promise) — override per-test to reject.
+    withSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+    // Spy the fail-open emitter so the fail-open path stays observable in the test
+    // (a blip that bypasses a kill-switch must leave a Loki `sysredis-fail-open` trace).
+    logSysRedisFailOpen: vi.fn(),
+  })
+);
 
 vi.mock('~/server/redis/client', () => ({
   sysRedis: { hGet, hSet, sAdd, sMembers, del: vi.fn(), exists: vi.fn() },
@@ -31,6 +36,8 @@ vi.mock('~/server/redis/client', () => ({
   REDIS_SUB_KEYS: { QUEUES: { MERGING: 'merging' } },
   withSysReadDeadline,
 }));
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen }));
 
 // Provide a non-null clickhouse so the early-return in update()/refreshRank()
 // doesn't fire (we want execution to reach the flag-read on the sysRedis mock).
@@ -126,15 +133,25 @@ describe('createMetricProcessor — update() metric flag (Buffer-vs-string)', ()
 
     await expect(proc.update(jobContext)).resolves.toBeUndefined(); // no throw escapes
     expect(update).toHaveBeenCalledTimes(1);
+    expect(logSysRedisFailOpen).toHaveBeenCalledTimes(1); // fail-open stays observable
   });
 
   it('FAILS OPEN and still runs the update when the read-deadline REJECTS (SLOW/half-open)', async () => {
+    // Model a SLOW/half-open sysRedis: the underlying hGet NEVER settles (it would
+    // park ~11min in prod), so ONLY the withSysReadDeadline race can unblock the
+    // caller. This PINS the wrap — if the `withSysReadDeadline(...)` wrap were
+    // removed (leaving a bare `await sysRedis.hGet`), update() would hang forever
+    // and this test would TIME OUT (fail-on-revert). A resolved-hGet mock would
+    // pass even without the wrap, so it wouldn't guard the SLOW-path protection.
+    hGet.mockReturnValue(new Promise(() => undefined));
     withSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
     const update = vi.fn(() => Promise.resolve(undefined));
     const proc = createMetricProcessor({ name: 'TestMetric', update });
 
     await expect(proc.update(jobContext)).resolves.toBeUndefined();
+    expect(withSysReadDeadline).toHaveBeenCalledTimes(1);
     expect(update).toHaveBeenCalledTimes(1);
+    expect(logSysRedisFailOpen).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -182,6 +199,10 @@ describe('createMetricProcessor — refreshRank() rank flag (Buffer-vs-string)',
   });
 
   it('FAILS OPEN and still runs the rank refresh when the read-deadline REJECTS (SLOW/half-open)', async () => {
+    // hGet never settles (SLOW/half-open park); only the withSysReadDeadline race
+    // unblocks. Pins the wrap — a bare `await sysRedis.hGet` would hang and time
+    // out this test on revert. See the update() SLOW test for the full rationale.
+    hGet.mockReturnValue(new Promise(() => undefined));
     withSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
     const refresh = vi.fn(() => Promise.resolve(undefined));
     const proc = createMetricProcessor({
@@ -191,6 +212,8 @@ describe('createMetricProcessor — refreshRank() rank flag (Buffer-vs-string)',
     });
 
     await expect(proc.refreshRank(jobContext)).resolves.toBeUndefined();
+    expect(withSysReadDeadline).toHaveBeenCalledTimes(1);
     expect(refresh).toHaveBeenCalledTimes(1);
+    expect(logSysRedisFailOpen).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/metrics/__tests__/base.metrics.test.ts
+++ b/src/server/metrics/__tests__/base.metrics.test.ts
@@ -11,11 +11,15 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // fixed in PR #2697. Both use the same hoisted-mock pattern to control the
 // hGet return type per-test — that's the exact axis of the bug.
 
-const { hGet, hSet, sAdd, sMembers } = vi.hoisted(() => ({
+const { hGet, hSet, sAdd, sMembers, withSysReadDeadline } = vi.hoisted(() => ({
   hGet: vi.fn(),
   hSet: vi.fn(() => Promise.resolve(1)),
   sAdd: vi.fn(() => Promise.resolve(1)),
   sMembers: vi.fn(() => Promise.resolve([] as string[])),
+  // STEP-3 soft-dependency: the flag reads are now wrapped in withSysReadDeadline
+  // so a SLOW/half-open sysRedis rejects (deadline) instead of parking ~11min.
+  // Transparent by default (returns the wrapped promise) — override per-test to reject.
+  withSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
 }));
 
 vi.mock('~/server/redis/client', () => ({
@@ -25,6 +29,7 @@ vi.mock('~/server/redis/client', () => ({
     QUEUES: { BUCKETS: 'queues:buckets' },
   },
   REDIS_SUB_KEYS: { QUEUES: { MERGING: 'merging' } },
+  withSysReadDeadline,
 }));
 
 // Provide a non-null clickhouse so the early-return in update()/refreshRank()
@@ -64,6 +69,7 @@ const jobContext = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  withSysReadDeadline.mockImplementation((p) => p); // transparent by default
 });
 
 describe('createMetricProcessor — update() metric flag (Buffer-vs-string)', () => {
@@ -109,6 +115,27 @@ describe('createMetricProcessor — update() metric flag (Buffer-vs-string)', ()
 
     expect(update).toHaveBeenCalledTimes(1);
   });
+
+  // STEP-3 soft-dependency: a sysRedis DOWN (hGet throws) or SLOW/half-open
+  // (withSysReadDeadline rejects) must FAIL OPEN to the absent default (allowed)
+  // and keep running the update — never park ~11min or skip on a blip.
+  it('FAILS OPEN and still runs the update when sysRedis is DOWN (hGet throws)', async () => {
+    hGet.mockRejectedValue(new Error('sysRedis connection is down'));
+    const update = vi.fn(() => Promise.resolve(undefined));
+    const proc = createMetricProcessor({ name: 'TestMetric', update });
+
+    await expect(proc.update(jobContext)).resolves.toBeUndefined(); // no throw escapes
+    expect(update).toHaveBeenCalledTimes(1);
+  });
+
+  it('FAILS OPEN and still runs the update when the read-deadline REJECTS (SLOW/half-open)', async () => {
+    withSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+    const update = vi.fn(() => Promise.resolve(undefined));
+    const proc = createMetricProcessor({ name: 'TestMetric', update });
+
+    await expect(proc.update(jobContext)).resolves.toBeUndefined();
+    expect(update).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('createMetricProcessor — refreshRank() rank flag (Buffer-vs-string)', () => {
@@ -138,5 +165,32 @@ describe('createMetricProcessor — refreshRank() rank flag (Buffer-vs-string)',
     await proc.refreshRank(jobContext);
 
     expect(refresh).not.toHaveBeenCalled();
+  });
+
+  // STEP-3 soft-dependency: same fail-open contract as the metric flag.
+  it('FAILS OPEN and still runs the rank refresh when sysRedis is DOWN (hGet throws)', async () => {
+    hGet.mockRejectedValue(new Error('sysRedis connection is down'));
+    const refresh = vi.fn(() => Promise.resolve(undefined));
+    const proc = createMetricProcessor({
+      name: 'TestMetric',
+      update: vi.fn(),
+      rank: { refresh } as any,
+    });
+
+    await expect(proc.refreshRank(jobContext)).resolves.toBeUndefined();
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('FAILS OPEN and still runs the rank refresh when the read-deadline REJECTS (SLOW/half-open)', async () => {
+    withSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+    const refresh = vi.fn(() => Promise.resolve(undefined));
+    const proc = createMetricProcessor({
+      name: 'TestMetric',
+      update: vi.fn(),
+      rank: { refresh } as any,
+    });
+
+    await expect(proc.refreshRank(jobContext)).resolves.toBeUndefined();
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/metrics/base.metrics.ts
+++ b/src/server/metrics/base.metrics.ts
@@ -8,7 +8,7 @@ import type { AugmentedPool } from '~/server/db/db-helpers';
 import { pgDbWrite } from '~/server/db/pgDb';
 import type { JobContext } from '~/server/jobs/job';
 import { getJobDate } from '~/server/jobs/job';
-import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { addToQueue, checkoutQueue } from '~/server/redis/queues';
 
 const DEFAULT_UPDATE_INTERVAL = 60 * 1000;
@@ -61,10 +61,18 @@ export function createMetricProcessor({
       // which silently flips this flag to disabled in sentinel mode. Coerce
       // to a utf8 string before comparing. See PR #2697 for the canonical
       // regression case (queues.ts getBucketNames).
-      const metricRaw = await sysRedis.hGet(
-        REDIS_SYS_KEYS.SYSTEM.FEATURES,
-        `metric:${name.toLowerCase()}`
-      );
+      let metricRaw: string | Buffer | null = null;
+      try {
+        metricRaw = await withSysReadDeadline(
+          sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, `metric:${name.toLowerCase()}`)
+        );
+      } catch {
+        // sysRedis DOWN (throw) or SLOW (deadline) — the metric kill-switch fails
+        // OPEN to its absent default ('true' = allowed) below. Metric/rank updates
+        // are DB/ClickHouse-driven and non-destructive, and the queue commit is
+        // already blip-hardened (#2922), so a sysRedis stall must not stop them.
+        metricRaw = null;
+      }
       const metricFlag = Buffer.isBuffer(metricRaw) ? metricRaw.toString('utf8') : metricRaw;
       const metricUpdateAllowed = (metricFlag ?? 'true') === 'true';
       if (!shouldUpdate || !metricUpdateAllowed) return;
@@ -89,10 +97,16 @@ export function createMetricProcessor({
       // Buffer-coerce mirror of the metric flag above. Same root cause —
       // sentinel-mode sysRedis returns Buffer, which silently fails the
       // === 'true' check. See PR #2697.
-      const rankRaw = await sysRedis.hGet(
-        REDIS_SYS_KEYS.SYSTEM.FEATURES,
-        `rank:${name.toLowerCase()}`
-      );
+      let rankRaw: string | Buffer | null = null;
+      try {
+        rankRaw = await withSysReadDeadline(
+          sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, `rank:${name.toLowerCase()}`)
+        );
+      } catch {
+        // sysRedis DOWN/SLOW — the rank kill-switch fails OPEN to its absent
+        // default ('true' = allowed) below, same rationale as the metric flag.
+        rankRaw = null;
+      }
       const rankFlag = Buffer.isBuffer(rankRaw) ? rankRaw.toString('utf8') : rankRaw;
       const rankUpdateAllowed = (rankFlag ?? 'true') === 'true';
       if (!shouldUpdateRank || !rankUpdateAllowed) return;

--- a/src/server/metrics/base.metrics.ts
+++ b/src/server/metrics/base.metrics.ts
@@ -9,6 +9,7 @@ import { pgDbWrite } from '~/server/db/pgDb';
 import type { JobContext } from '~/server/jobs/job';
 import { getJobDate } from '~/server/jobs/job';
 import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
+import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import { addToQueue, checkoutQueue } from '~/server/redis/queues';
 
 const DEFAULT_UPDATE_INTERVAL = 60 * 1000;
@@ -66,11 +67,15 @@ export function createMetricProcessor({
         metricRaw = await withSysReadDeadline(
           sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, `metric:${name.toLowerCase()}`)
         );
-      } catch {
+      } catch (err) {
         // sysRedis DOWN (throw) or SLOW (deadline) — the metric kill-switch fails
         // OPEN to its absent default ('true' = allowed) below. Metric/rank updates
         // are DB/ClickHouse-driven and non-destructive, and the queue commit is
         // already blip-hardened (#2922), so a sysRedis stall must not stop them.
+        // Emit the fail-open so a blip that silently bypasses a deliberately-set
+        // 'false' kill-switch is visible (Loki `sysredis-fail-open`), matching the
+        // queues.ts safeSysRead pattern.
+        logSysRedisFailOpen('read-degraded', 'base.metrics metric-flag', err, { metric: name });
         metricRaw = null;
       }
       const metricFlag = Buffer.isBuffer(metricRaw) ? metricRaw.toString('utf8') : metricRaw;
@@ -102,9 +107,10 @@ export function createMetricProcessor({
         rankRaw = await withSysReadDeadline(
           sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, `rank:${name.toLowerCase()}`)
         );
-      } catch {
+      } catch (err) {
         // sysRedis DOWN/SLOW — the rank kill-switch fails OPEN to its absent
         // default ('true' = allowed) below, same rationale as the metric flag.
+        logSysRedisFailOpen('read-degraded', 'base.metrics rank-flag', err, { metric: name });
         rankRaw = null;
       }
       const rankFlag = Buffer.isBuffer(rankRaw) ? rankRaw.toString('utf8') : rankRaw;


### PR DESCRIPTION
## sysRedis soft-dependency — STEP 3 (pipeline hardening)

Makes two sysRedis feature-flag/config reads fail-open so a sysRedis **DOWN** or **SLOW/half-open** blip degrades gracefully instead of throwing or parking ~11min.

### The DOWN/SLOW mechanic (governs the fix)
The `sysRedis` client is built with `socketTimeout:0` + `disableOfflineQueue:true`:
- **DOWN** → commands reject FAST (a plain try/catch fallback survives).
- **SLOW / half-open** → an awaited command PARKS ~11 min (OS TCP keepalive) on *every* request; only `withSysReadDeadline` (a ~2s wall-clock race) unblocks the caller. On timeout it rejects with `Error('sysRedis read timed out after Nms')`.

A read is fully soft **only** when it is BOTH (a) `try/catch`'d (survives DOWN) AND (b) wrapped in `withSysReadDeadline` (survives SLOW). Both reads here were neither.

### Fix 1 — `src/server/metrics/base.metrics.ts` (two reads)
The `metric:<name>` / `rank:<name>` kill-switch reads in `update()` and `refreshRank()` now wrap the `hGet` in `withSysReadDeadline` + `try/catch` and **FAIL OPEN to the absent default (`'true'` = allowed)**. Metric/rank updates are DB/ClickHouse-driven and non-destructive, so a sysRedis stall must not stop them. The existing Buffer-coercion and `?? 'true'` default are preserved exactly.

### Fix 2 — `src/server/jobs/rewards-abuse-prevention.ts` (config read)
This daily job **DISABLES users' Buzz rewards** (destructive: `rewardsEligibility='Ineligible'`). If the config read fails we don't know the real thresholds, and running on schema defaults could wrongly disable users. So the fail-open policy is the **opposite of Fix 1**: on a DOWN/SLOW read, LOG-via-return and **SKIP the cycle** (`return { usersDisabled: 0, skipped: 'sysRedis-config-read-failed' }`) instead of running the destructive detection. Reversibility-aware — a missed nightly run is harmless; wrongly disabling users is not. Also added the Buffer-coercion the original relied only on `?? '{}'` for (same Sentinel-Buffer root cause as base.metrics).

### Tests
- `base.metrics.test.ts` extended: DOWN (`hGet` throws) + SLOW (`withSysReadDeadline` rejects) now assert `update` / `rank.refresh` STILL RUN and no throw escapes; baseline `true`/absent/`false` cases retained.
- new `src/server/jobs/__tests__/rewards-abuse-prevention.test.ts`: DOWN + SLOW return early with `{ usersDisabled: 0, skipped }` and NEVER call clickhouse/`dbWrite` (no destructive UPDATE); plus happy-path + Buffer-config coverage.

All 14 tests pass locally (`vitest run --project unit`).