### PR TITLE
fix(sysredis): STEP 4 fail-closed sweep — browsing-addons + session-invalidation read + events full-file

### DIFF
--- a/src/server/auth/__tests__/session-invalidation.test.ts
+++ b/src/server/auth/__tests__/session-invalidation.test.ts
@@ -21,11 +21,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  *                 fail-open logger is touched.
  */
 
-const { mockHSetMultiWithTTL, mockLogSysRedisFailOpen, mockHGetAll } = vi.hoisted(() => ({
-  mockHSetMultiWithTTL: vi.fn(),
-  mockLogSysRedisFailOpen: vi.fn(),
-  mockHGetAll: vi.fn(),
-}));
+const { mockHSetMultiWithTTL, mockLogSysRedisFailOpen, mockHGetAll, mockWithSysReadDeadline } =
+  vi.hoisted(() => ({
+    mockHSetMultiWithTTL: vi.fn(),
+    mockLogSysRedisFailOpen: vi.fn(),
+    mockHGetAll: vi.fn(),
+    // STEP-4 soft-dependency: the hGetAll read is now wrapped in
+    // withSysReadDeadline so a SLOW/half-open sysRedis rejects (deadline)
+    // instead of parking ~11min. Transparent by default (returns the wrapped
+    // promise) — override per-test to reject to model the SLOW path.
+    mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  }));
 
 vi.mock('~/server/redis/atomic', () => ({
   hSetMultiWithTTL: mockHSetMultiWithTTL,
@@ -50,7 +56,7 @@ vi.mock('~/server/redis/client', () => ({
       ALL: 'sys:session:all',
     },
   },
-  withSysReadDeadline: <T>(p: Promise<T>) => p, // transparent in tests (matches rate-limiting.test.ts)
+  withSysReadDeadline: mockWithSysReadDeadline,
 }));
 
 vi.mock('~/server/utils/cache-helpers', () => ({
@@ -79,6 +85,7 @@ import { refreshSession, invalidateSession } from '../session-invalidation';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
   // Default: user has 2 tokens in the hash.
   mockHGetAll.mockResolvedValue({ 'token-a': 'active', 'token-b': 'active' });
 });
@@ -124,6 +131,54 @@ describe('updateSessionState fail-open wrapper (via refreshSession)', () => {
 
     expect(mockHSetMultiWithTTL).not.toHaveBeenCalled();
     expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe('updateSessionState READ fail-open wrapper (STEP-4 hGetAll)', () => {
+  it('happy path: reads the token hash through withSysReadDeadline and does not log fail-open', async () => {
+    mockHSetMultiWithTTL.mockResolvedValue(undefined);
+
+    await refreshSession(7, { sendSignal: false });
+
+    // The read is deadline-wrapped even on the happy path.
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockHGetAll).toHaveBeenCalledTimes(1);
+    // Tokens resolved → the write ran with them.
+    expect(mockHSetMultiWithTTL).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: hGetAll throws → fails open to an empty hash, does not throw, skips the write, logs read-degraded', async () => {
+    mockHGetAll.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    // Must NOT throw (would otherwise 500 the logout/ban request).
+    await expect(invalidateSession(99)).resolves.toBeUndefined();
+
+    // Empty token hash → no write attempted.
+    expect(mockHSetMultiWithTTL).not.toHaveBeenCalled();
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    const [subtype, fn, , extra] = mockLogSysRedisFailOpen.mock.calls[0];
+    expect(subtype).toBe('read-degraded');
+    expect(fn).toBe('session-invalidation.updateSessionState read');
+    expect(extra).toMatchObject({ userId: 99, type: 'invalid' });
+  });
+
+  it('SLOW/half-open: hGetAll NEVER settles + deadline REJECTS → fails open (fail-on-revert: a bare await would hang and time out)', async () => {
+    // Model a SLOW/half-open sysRedis: hGetAll never settles (would park
+    // ~11min in prod), so ONLY the withSysReadDeadline race can unblock the
+    // caller. This PINS the wrap — remove `withSysReadDeadline(...)` and the
+    // bare `await sysRedis.hGetAll` hangs forever → this test TIMES OUT. A
+    // resolved-hGetAll mock would pass even without the wrap.
+    mockHGetAll.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    await expect(refreshSession(123, { sendSignal: false })).resolves.toBeUndefined();
+
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockHSetMultiWithTTL).not.toHaveBeenCalled();
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+    expect(mockLogSysRedisFailOpen.mock.calls[0][3]).toMatchObject({ userId: 123, type: 'refresh' });
   });
 });
 

--- a/src/server/auth/session-invalidation.ts
+++ b/src/server/auth/session-invalidation.ts
@@ -1,5 +1,5 @@
 import { SignalMessages } from '~/server/common/enums';
-import { REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_KEYS, REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { hSetMultiWithTTL } from '~/server/redis/atomic';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import { createLogger } from '~/utils/logging';
@@ -14,7 +14,23 @@ async function updateSessionState(userId: number, type: 'refresh' | 'invalid') {
   const key = `${REDIS_KEYS.SESSION.USER_TOKENS}:${userId}`;
 
   // Get all tokens from hash (expired fields are automatically removed by Redis)
-  const tokenHash = await sysRedis.hGetAll(key as any);
+  let tokenHash: Record<string, string> = {};
+  try {
+    // Wall-clock deadline + fail-open: this read is on the user-facing
+    // logout / ban / session-refresh path. A fast sysRedis DOWN would 500
+    // the request; a silent half-open would park the awaited hGetAll ~11min.
+    // On DOWN/SLOW we fail open to an empty token hash — symmetric with the
+    // already-fail-open write below and the documented invalidateSession
+    // posture: the invalidation doesn't take effect during the outage (retry
+    // after recovery), but the request never 500s or parks.
+    tokenHash = await withSysReadDeadline(sysRedis.hGetAll(key as any));
+  } catch (err) {
+    logSysRedisFailOpen('read-degraded', 'session-invalidation.updateSessionState read', err, {
+      userId,
+      type,
+    });
+    tokenHash = {};
+  }
   const userTokens = Object.keys(tokenHash);
   const userTokensObj = userTokens.reduce<Record<string, string>>(
     (acc, token) => ({ ...acc, [token]: type }),
@@ -81,12 +97,16 @@ export async function refreshSession(userId: number, { sendSignal = true } = {})
  * to log out.
  *
  * SECURITY/IR NOTE: this path is fail-open on sysRedis unreachability
- * (PR #2332 round-3 audit fix). The write swallows the error and emits
- * a `sysredis-fail-open` Loki/Axiom event with subtype `write-degraded`
- * — see `updateSessionState` above. During a sysRedis outage the
- * invalidation does NOT take effect; callers that need guaranteed
- * invalidation (stolen-token reports, account-takeover response) MUST
- * retry after sysRedis recovery. This is symmetric with the read path:
+ * on BOTH the read and the write (PR #2332 round-3 audit fix for the
+ * write; STEP-4 soft-dependency sweep for the read). The read (hGetAll)
+ * is wrapped in `withSysReadDeadline` + try/catch and fails open to an
+ * empty token hash — subtype `read-degraded`; the write (hSetMultiWithTTL)
+ * swallows its error — subtype `write-degraded`. Both emit a
+ * `sysredis-fail-open` Loki/Axiom event; see `updateSessionState` above.
+ * During a sysRedis outage the invalidation does NOT take effect; callers
+ * that need guaranteed invalidation (stolen-token reports, account-takeover
+ * response) MUST retry after sysRedis recovery. This is symmetric with the
+ * downstream read path too:
  * the refreshToken pipeline in token-refresh.ts is already fail-open on
  * read errors, so `tokenState === 'invalid'` is never observed during
  * the outage window even if a prior successful call wrote it — the

--- a/src/server/events/__tests__/events.sysredis-soft.test.ts
+++ b/src/server/events/__tests__/events.sysredis-soft.test.ts
@@ -13,8 +13,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * *lPopCount is a DESTRUCTIVE atomic LPOP-with-count. On a fast DOWN the
  * command is never written (disableOfflineQueue + fast reject) so it pops
  * nothing and the queued items STAY on the list for next cycle (#2922
- * non-destructive lesson). On DOWN/SLOW we skip this event's queue this cycle
- * rather than dropping the drained-but-unprocessed items.
+ * non-destructive lesson). CAVEAT: on a slow-but-alive sysRedis the LPOP CAN
+ * execute server-side and pop items whose reply then lands after the deadline
+ * — those are dropped (a narrow, accepted loss window for best-effort Discord
+ * role grants; see the source comment). The SLOW test below models the
+ * never-popped sub-case (server never executes), which is what the wrap
+ * protects against; it does NOT assert the popped-then-late case is lossless.
  *
  * The SLOW tests are fail-on-revert: the sysRedis op NEVER settles, so if the
  * `withSysReadDeadline(...)` wrap were removed the caller would hang and the
@@ -211,7 +215,7 @@ describe('processAddRoleQueue — lLen + lPopCount READ soft-dependency', () => 
     expect(mockLogSysRedisFailOpen.mock.calls[0][1]).toBe('events.processAddRoleQueue lLen');
   });
 
-  it('SLOW/half-open (lPopCount NEVER settles + deadline REJECTS): skips cycle → items not lost (fail-on-revert)', async () => {
+  it('SLOW/half-open (lPopCount NEVER settles + deadline REJECTS): skips cycle, no items processed (fail-on-revert; never-popped sub-case)', async () => {
     mockLLen.mockResolvedValue(3);
     mockLPopCount.mockReturnValue(new Promise(() => undefined));
     // lLen resolves (transparent), only the lPopCount race rejects. Make the

--- a/src/server/events/__tests__/events.sysredis-soft.test.ts
+++ b/src/server/events/__tests__/events.sysredis-soft.test.ts
@@ -1,0 +1,230 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * STEP-4 sysRedis soft-dependency sweep — the full-file sweep of
+ * `src/server/events/index.ts`.
+ *
+ * sysRedis ops covered:
+ *   - getPartners           lRange     READ   → deadline + fail-open to []
+ *   - queueAddRole          lPush      WRITE  → try/catch fail-open (dropped)
+ *   - processAddRoleQueue   lLen       READ   → deadline + fail-open → skip
+ *   - processAddRoleQueue   lPopCount  READ*  → deadline + fail-open → skip
+ *
+ * *lPopCount is a DESTRUCTIVE atomic LPOP-with-count. On a fast DOWN the
+ * command is never written (disableOfflineQueue + fast reject) so it pops
+ * nothing and the queued items STAY on the list for next cycle (#2922
+ * non-destructive lesson). On DOWN/SLOW we skip this event's queue this cycle
+ * rather than dropping the drained-but-unprocessed items.
+ *
+ * The SLOW tests are fail-on-revert: the sysRedis op NEVER settles, so if the
+ * `withSysReadDeadline(...)` wrap were removed the caller would hang and the
+ * test would TIME OUT.
+ */
+
+const {
+  mockLRange,
+  mockLPush,
+  mockLLen,
+  mockLPopCount,
+  mockWithSysReadDeadline,
+  mockLogSysRedisFailOpen,
+  mockGetDiscordRoles,
+  mockGetDiscordIds,
+  mockAddRoleToUser,
+} = vi.hoisted(() => ({
+  mockLRange: vi.fn(),
+  mockLPush: vi.fn(),
+  mockLLen: vi.fn(),
+  mockLPopCount: vi.fn(),
+  mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  mockLogSysRedisFailOpen: vi.fn(),
+  mockGetDiscordRoles: vi.fn(async () => ({ Team1: 'role-1' } as Record<string, string>)),
+  mockGetDiscordIds: vi.fn(async () => new Map<number, string>()),
+  mockAddRoleToUser: vi.fn(async () => undefined),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { lRange: mockLRange, lPush: mockLPush, lLen: mockLLen, lPopCount: mockLPopCount },
+  redis: { get: vi.fn(), set: vi.fn(), del: vi.fn(), purgeTags: vi.fn() },
+  REDIS_KEYS: { EVENT: { EVENT_CLEANUP: 'event:cleanup', BASE: 'event' } },
+  REDIS_SUB_KEYS: { EVENT: { PARTNERS: 'partners', ADD_ROLE: 'add-role', CONTRIBUTORS: 'contributors' } },
+  REDIS_SYS_KEYS: { EVENT: 'sys:event' },
+  withSysReadDeadline: mockWithSysReadDeadline,
+}));
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));
+
+// Active event def so `events`/`activeEvents` (computed at module load) is
+// non-empty and `processAddRoleQueue` iterates it. Only the fields the three
+// functions under test touch are provided.
+vi.mock('~/server/events/holiday2024.event', () => ({
+  holiday2024: {
+    name: 'test-event',
+    startDate: new Date('2020-01-01'),
+    endDate: new Date('2999-01-01'), // future → active
+    getDiscordRoles: mockGetDiscordRoles,
+  },
+}));
+
+vi.mock('~/server/integrations/discord', () => ({
+  discord: {
+    getDiscordId: vi.fn(async () => undefined),
+    getDiscordIds: mockGetDiscordIds,
+    addRoleToUser: mockAddRoleToUser,
+  },
+}));
+
+// Heavy runtime deps in the module graph — stub so import doesn't pull DB /
+// clickhouse / buzz factories.
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  getAccountSummary: vi.fn(),
+  getTopContributors: vi.fn(),
+  getUserBuzzAccount: vi.fn(),
+}));
+vi.mock('~/server/services/user.service', () => ({ updateLeaderboardRank: vi.fn() }));
+
+import { eventEngine } from '~/server/events/index';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+  mockGetDiscordRoles.mockResolvedValue({ Team1: 'role-1' });
+  mockGetDiscordIds.mockResolvedValue(new Map<number, string>());
+});
+
+describe('getPartners — lRange READ soft-dependency', () => {
+  it('happy path: returns parsed partners sorted by amount, through withSysReadDeadline', async () => {
+    mockLRange.mockResolvedValue([
+      JSON.stringify({ title: 'A', amount: 10, image: '', url: '' }),
+      JSON.stringify({ title: 'B', amount: 50, image: '', url: '' }),
+    ]);
+
+    const result = await eventEngine.getPartners('test-event');
+
+    expect(result.map((x) => x.title)).toEqual(['B', 'A']); // sorted desc by amount
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: lRange throws → fails open to [], does not throw, logs read-degraded', async () => {
+    mockLRange.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await eventEngine.getPartners('test-event');
+
+    expect(result).toEqual([]);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    const [subtype, fn] = mockLogSysRedisFailOpen.mock.calls[0];
+    expect(subtype).toBe('read-degraded');
+    expect(fn).toBe('events.getPartners');
+  });
+
+  it('SLOW/half-open: lRange NEVER settles + deadline REJECTS → fails open to [] (fail-on-revert)', async () => {
+    mockLRange.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await eventEngine.getPartners('test-event');
+
+    expect(result).toEqual([]);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+  });
+});
+
+describe('queueAddRole — lPush WRITE soft-dependency', () => {
+  it('happy path: pushes to the queue, no fail-open', async () => {
+    mockLPush.mockResolvedValue(1);
+
+    await expect(
+      eventEngine.queueAddRole({ event: 'test-event', team: 'Team1', userId: 5 })
+    ).resolves.toBeUndefined();
+
+    expect(mockLPush).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: lPush throws → error swallowed (caller does not throw), logs write-degraded', async () => {
+    mockLPush.mockRejectedValue(new Error('sysRedis connection is down'));
+
+    await expect(
+      eventEngine.queueAddRole({ event: 'test-event', team: 'Team1', userId: 5 })
+    ).resolves.toBeUndefined();
+
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    const [subtype, fn, , extra] = mockLogSysRedisFailOpen.mock.calls[0];
+    expect(subtype).toBe('write-degraded');
+    expect(fn).toBe('events.queueAddRole');
+    expect(extra).toMatchObject({ event: 'test-event', team: 'Team1', userId: 5 });
+  });
+});
+
+describe('processAddRoleQueue — lLen + lPopCount READ soft-dependency', () => {
+  it('happy path: drains the queue and processes items, no fail-open', async () => {
+    mockLLen.mockResolvedValue(1);
+    mockLPopCount.mockResolvedValue([JSON.stringify({ team: 'Team1', userId: 7 })]);
+    mockGetDiscordIds.mockResolvedValue(new Map<number, string>([[7, 'discord-7']]));
+
+    await expect(eventEngine.processAddRoleQueue()).resolves.toBeUndefined();
+
+    expect(mockLPopCount).toHaveBeenCalledTimes(1);
+    expect(mockAddRoleToUser).toHaveBeenCalledWith('discord-7', 'role-1');
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN (lLen throws): skips this cycle without popping → items stay queued, logs read-degraded', async () => {
+    mockLLen.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(eventEngine.processAddRoleQueue()).resolves.toBeUndefined();
+
+    // lPopCount must NOT run — a failed lLen means we never destructively drain.
+    expect(mockLPopCount).not.toHaveBeenCalled();
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+    expect(mockLogSysRedisFailOpen.mock.calls[0][1]).toBe('events.processAddRoleQueue lLen');
+  });
+
+  it('DOWN (lPopCount throws): skips this cycle → queued items not lost, logs read-degraded', async () => {
+    mockLLen.mockResolvedValue(2);
+    mockLPopCount.mockRejectedValue(new Error('sysRedis connection is down'));
+
+    await expect(eventEngine.processAddRoleQueue()).resolves.toBeUndefined();
+
+    // No items processed (drain failed) — they remain on the list.
+    expect(mockAddRoleToUser).not.toHaveBeenCalled();
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+    expect(mockLogSysRedisFailOpen.mock.calls[0][1]).toBe('events.processAddRoleQueue lPopCount');
+  });
+
+  it('SLOW/half-open (lLen NEVER settles + deadline REJECTS): skips cycle, no pop (fail-on-revert)', async () => {
+    mockLLen.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    await expect(eventEngine.processAddRoleQueue()).resolves.toBeUndefined();
+
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLPopCount).not.toHaveBeenCalled();
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][1]).toBe('events.processAddRoleQueue lLen');
+  });
+
+  it('SLOW/half-open (lPopCount NEVER settles + deadline REJECTS): skips cycle → items not lost (fail-on-revert)', async () => {
+    mockLLen.mockResolvedValue(3);
+    mockLPopCount.mockReturnValue(new Promise(() => undefined));
+    // lLen resolves (transparent), only the lPopCount race rejects. Make the
+    // deadline reject only for the second (lPopCount) call.
+    mockWithSysReadDeadline
+      .mockImplementationOnce((p) => p) // lLen: transparent
+      .mockRejectedValueOnce(new Error('sysRedis read timed out after 2000ms')); // lPopCount
+
+    await expect(eventEngine.processAddRoleQueue()).resolves.toBeUndefined();
+
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(2);
+    expect(mockAddRoleToUser).not.toHaveBeenCalled();
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][1]).toBe('events.processAddRoleQueue lPopCount');
+  });
+});

--- a/src/server/events/index.ts
+++ b/src/server/events/index.ts
@@ -5,7 +5,15 @@ import type { DonationCosmeticData, EngagementEvent, TeamScore } from '~/server/
 import { holiday2024 } from '~/server/events/holiday2024.event';
 import { discord } from '~/server/integrations/discord';
 import { logToAxiom } from '~/server/logging/client';
-import { redis, REDIS_KEYS, REDIS_SUB_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import {
+  redis,
+  REDIS_KEYS,
+  REDIS_SUB_KEYS,
+  REDIS_SYS_KEYS,
+  sysRedis,
+  withSysReadDeadline,
+} from '~/server/redis/client';
+import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 import type { TeamScoreHistoryInput } from '~/server/schema/event.schema';
 import {
@@ -487,11 +495,18 @@ export const eventEngine = {
     const eventDef = events.find((x) => x.name === event);
     if (!eventDef) throw new Error("That event doesn't exist");
 
-    const partnersCache = await sysRedis.lRange(
-      `${REDIS_SYS_KEYS.EVENT}:${event}:${REDIS_SUB_KEYS.EVENT.PARTNERS}`,
-      0,
-      -1
-    );
+    let partnersCache: string[] = [];
+    try {
+      // Wall-clock deadline + fail-open: a fast sysRedis DOWN would 500 this
+      // read; a silent half-open would park the awaited lRange ~11min. On
+      // DOWN/SLOW fail open to an empty partners list.
+      partnersCache = await withSysReadDeadline(
+        sysRedis.lRange(`${REDIS_SYS_KEYS.EVENT}:${event}:${REDIS_SUB_KEYS.EVENT.PARTNERS}`, 0, -1)
+      );
+    } catch (err) {
+      logSysRedisFailOpen('read-degraded', 'events.getPartners', err, { event });
+      return [];
+    }
     const partners = partnersCache.map((x) => JSON.parse(x)) as EventPartner[];
 
     return partners.sort((a, b) => b.amount - a.amount);
@@ -500,10 +515,19 @@ export const eventEngine = {
     const eventDef = events.find((x) => x.name === event);
     if (!eventDef) throw new Error("That event doesn't exist");
 
-    await sysRedis.lPush(
-      `${REDIS_SYS_KEYS.EVENT}:${event}:${REDIS_SUB_KEYS.EVENT.ADD_ROLE}`,
-      JSON.stringify({ team, userId })
-    );
+    try {
+      // Best-effort write fail-open (NOT deadline-raced — writes are bounded
+      // by the sys client's commandsQueueMaxLength, not this helper). On a
+      // sysRedis DOWN/SLOW the queued role-add is dropped (acceptable feature
+      // degrade — the Discord team role just isn't granted this cycle) rather
+      // than 500ing the caller.
+      await sysRedis.lPush(
+        `${REDIS_SYS_KEYS.EVENT}:${event}:${REDIS_SUB_KEYS.EVENT.ADD_ROLE}`,
+        JSON.stringify({ team, userId })
+      );
+    } catch (err) {
+      logSysRedisFailOpen('write-degraded', 'events.queueAddRole', err, { event, team, userId });
+    }
   },
   async addRole({ event, team, userId }: { event: string; team: string; userId: number }) {
     const eventDef = events.find((x) => x.name === event);
@@ -526,8 +550,32 @@ export const eventEngine = {
     for (const eventDef of activeEvents) {
       const queueKey =
         `${REDIS_SYS_KEYS.EVENT}:${eventDef.name}:${REDIS_SUB_KEYS.EVENT.ADD_ROLE}` as const;
-      const queueLength = await sysRedis.lLen(queueKey);
-      const queueJson = await sysRedis.lPopCount(queueKey, queueLength);
+
+      // Both reads are deadline-raced + fail-open. On a sysRedis DOWN/SLOW we
+      // SKIP this event's queue this cycle so the queued role-adds STAY on the
+      // list and are drained next cycle — never lost (#2922 non-destructive
+      // lesson). lPopCount is an atomic LPOP-with-count: a fast DOWN reject
+      // never writes the command, so it pops nothing and the items remain.
+      let queueLength = 0;
+      try {
+        queueLength = await withSysReadDeadline(sysRedis.lLen(queueKey));
+      } catch (err) {
+        logSysRedisFailOpen('read-degraded', 'events.processAddRoleQueue lLen', err, {
+          event: eventDef.name,
+        });
+        continue;
+      }
+      if (!queueLength) continue;
+
+      let queueJson: string[] | null = null;
+      try {
+        queueJson = await withSysReadDeadline(sysRedis.lPopCount(queueKey, queueLength));
+      } catch (err) {
+        logSysRedisFailOpen('read-degraded', 'events.processAddRoleQueue lPopCount', err, {
+          event: eventDef.name,
+        });
+        continue;
+      }
       if (!queueJson) continue;
       const queue = queueJson.map((x) => JSON.parse(x)) as { team: string; userId: number }[];
 

--- a/src/server/events/index.ts
+++ b/src/server/events/index.ts
@@ -552,10 +552,15 @@ export const eventEngine = {
         `${REDIS_SYS_KEYS.EVENT}:${eventDef.name}:${REDIS_SUB_KEYS.EVENT.ADD_ROLE}` as const;
 
       // Both reads are deadline-raced + fail-open. On a sysRedis DOWN/SLOW we
-      // SKIP this event's queue this cycle so the queued role-adds STAY on the
-      // list and are drained next cycle — never lost (#2922 non-destructive
-      // lesson). lPopCount is an atomic LPOP-with-count: a fast DOWN reject
-      // never writes the command, so it pops nothing and the items remain.
+      // SKIP this event's queue this cycle and drain it next cycle.
+      // lPopCount is an atomic LPOP-with-count. On a fast DOWN the command is
+      // never written → nothing is popped → items stay queued (safe, #2922).
+      // CAVEAT (slow-but-alive): if the LPOP *does* execute server-side but its
+      // reply lands after the ~2s deadline, those items are popped-then-skipped
+      // and lost. That window is narrow and the payload is best-effort Discord
+      // team-role grants (no money/security/correctness) — an acceptable trade
+      // vs the ~11min park the deadline prevents. If loss ever mattered here,
+      // switch to a non-destructive lRange + conditional lTrim.
       let queueLength = 0;
       try {
         queueLength = await withSysReadDeadline(sysRedis.lLen(queueKey));

--- a/src/server/services/__tests__/system-cache.sysredis-soft.test.ts
+++ b/src/server/services/__tests__/system-cache.sysredis-soft.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * STEP-4 sysRedis soft-dependency sweep — the SSR/hot-path readers in
+ * system-cache.ts.
+ *
+ * Both `getBrowsingSettingAddons` (SSR every-render via _app.tsx) and
+ * `getCreationBlockedTags` (every model upsert) already try/catch fail-open;
+ * the gap this PR closes is the missing wall-clock deadline. A fast sysRedis
+ * DOWN rejects into the existing catch, but a silent SLOW/half-open parks the
+ * awaited `sysRedis.get` ~11min on every render/upsert. Wrapping the get in
+ * `withSysReadDeadline` makes the SLOW path reject (deadline) into the same
+ * catch → fail open.
+ *
+ * The SLOW tests are fail-on-revert: `sysRedis.get` NEVER settles, so if the
+ * `withSysReadDeadline(...)` wrap were removed the caller would hang and the
+ * test would TIME OUT. A resolved-get mock would pass even without the wrap,
+ * so it wouldn't guard the SLOW protection.
+ */
+
+const { mockGet, mockWithSysReadDeadline, mockLogSysRedisFailOpen } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  mockLogSysRedisFailOpen: vi.fn(),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { get: mockGet },
+  redis: { get: vi.fn(), set: vi.fn(), packed: { get: vi.fn(), set: vi.fn() } },
+  REDIS_KEYS: { SYSTEM: {}, LIVE_NOW: 'live-now' },
+  REDIS_SYS_KEYS: {
+    SYSTEM: {
+      BROWSING_SETTING_ADDONS: 'system:browsing-setting-addons',
+      CREATION_BLOCKED_TAGS: 'system:creation-blocked-tags',
+    },
+  },
+  withSysReadDeadline: mockWithSysReadDeadline,
+}));
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));
+
+// db/client pulls the Prisma factory graph — stub it (neither function under
+// test touches the DB on these paths).
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
+import {
+  getBrowsingSettingAddons,
+  getCreationBlockedTags,
+} from '~/server/services/system-cache';
+import { DEFAULT_BROWSING_SETTINGS_ADDONS } from '~/shared/constants/browsing-settings-addons';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+});
+
+describe('getBrowsingSettingAddons — sysRedis soft-dependency', () => {
+  it('happy path: returns the parsed cached value through withSysReadDeadline, no fail-open', async () => {
+    const addons = [{ type: 'setting', nsfwLevels: [1], excludedFromDefaultBrowsingLevel: false }];
+    mockGet.mockResolvedValue(JSON.stringify(addons));
+
+    const result = await getBrowsingSettingAddons();
+
+    expect(result).toEqual(addons);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: get throws → fails open to defaults, does not throw, logs read-degraded', async () => {
+    mockGet.mockRejectedValue(new Error('sysRedis connection is down'));
+
+    const result = await getBrowsingSettingAddons();
+
+    expect(result).toBe(DEFAULT_BROWSING_SETTINGS_ADDONS);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    const [subtype, fn] = mockLogSysRedisFailOpen.mock.calls[0];
+    expect(subtype).toBe('read-degraded');
+    expect(fn).toBe('getBrowsingSettingAddons');
+  });
+
+  it('SLOW/half-open: get NEVER settles + deadline REJECTS → fails open (fail-on-revert)', async () => {
+    mockGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await getBrowsingSettingAddons();
+
+    expect(result).toBe(DEFAULT_BROWSING_SETTINGS_ADDONS);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+  });
+});
+
+describe('getCreationBlockedTags — sysRedis soft-dependency (adjacent sibling)', () => {
+  it('happy path: returns the parsed+filtered blocked tags through withSysReadDeadline, no fail-open', async () => {
+    const tags = [
+      { id: 1, name: 'blocked-a' },
+      { id: 2, name: 'blocked-b' },
+    ];
+    mockGet.mockResolvedValue(JSON.stringify(tags));
+
+    const result = await getCreationBlockedTags();
+
+    expect(result).toEqual(tags);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: get throws → fails open to empty list, does not throw, logs defaults-firing', async () => {
+    mockGet.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await getCreationBlockedTags();
+
+    expect(result).toEqual([]);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    const [subtype, fn] = mockLogSysRedisFailOpen.mock.calls[0];
+    expect(subtype).toBe('defaults-firing');
+    expect(fn).toBe('getCreationBlockedTags');
+  });
+
+  it('SLOW/half-open: get NEVER settles + deadline REJECTS → fails open to empty (fail-on-revert)', async () => {
+    mockGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await getCreationBlockedTags();
+
+    expect(result).toEqual([]);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('defaults-firing');
+  });
+});

--- a/src/server/services/system-cache.ts
+++ b/src/server/services/system-cache.ts
@@ -265,9 +265,16 @@ export async function getLiveNow() {
 }
 
 export async function getBrowsingSettingAddons() {
-  let cached: string | null;
+  let cached: string | null = null;
   try {
-    cached = await sysRedis.get(REDIS_SYS_KEYS.SYSTEM.BROWSING_SETTING_ADDONS);
+    // Wall-clock deadline: this is an SSR every-render read (via _app.tsx
+    // getInitialProps). Without the race a silent sysRedis half-open parks
+    // the awaited get ~11min on EVERY page render; the try/catch below only
+    // covers a fast DOWN reject. On timeout the deadline rejects into the
+    // catch → fail open to defaults.
+    cached = await withSysReadDeadline(
+      sysRedis.get(REDIS_SYS_KEYS.SYSTEM.BROWSING_SETTING_ADDONS)
+    );
   } catch (err) {
     logSysRedisFailOpen('read-degraded', 'getBrowsingSettingAddons', err);
     return DEFAULT_BROWSING_SETTINGS_ADDONS;
@@ -302,9 +309,14 @@ export async function getCreationBlockedTags(): Promise<CreationBlockedTag[]> {
   // from model.controller.ts. A sysRedis outage would otherwise 500
   // every model upload. Empty list matches the unset-key behavior — no
   // tags blocked during the outage window.
-  let raw: string | null;
+  let raw: string | null = null;
   try {
-    raw = await sysRedis.get(REDIS_SYS_KEYS.SYSTEM.CREATION_BLOCKED_TAGS);
+    // Wall-clock deadline: called on every model upsert (ModelUpsertForm
+    // tRPC) + model.controller.ts, so a silent sysRedis half-open would park
+    // this awaited get ~11min on the upload path; the try/catch only covers a
+    // fast DOWN reject. On timeout the deadline rejects into the catch →
+    // fail open to the empty (no-tags-blocked) list.
+    raw = await withSysReadDeadline(sysRedis.get(REDIS_SYS_KEYS.SYSTEM.CREATION_BLOCKED_TAGS));
   } catch (err) {
     logSysRedisFailOpen('defaults-firing', 'getCreationBlockedTags', err);
     return [];


### PR DESCRIPTION
## STEP 4 — sysRedis soft-dependency: sitewide fail-closed sweep

Hardens three sysRedis touchpoints so a sysRedis **DOWN** or **SLOW/half-open** blip degrades gracefully instead of 500ing or parking ~11min.

### The mechanic
The `sysRedis` client has `socketTimeout:0` + `disableOfflineQueue:true`:
- **DOWN** → a command rejects **fast** (a `try/catch` fail-open survives).
- **SLOW/half-open** → an awaited command **PARKS ~11min** (until TCP keepalive errors the socket); only `withSysReadDeadline` (a ~2s wall-clock race that *rejects* on timeout) unblocks the caller.

So a **read** is fully soft only if it is BOTH `try/catch`'d AND wrapped in `withSysReadDeadline`. A **write** is bounded by `commandsQueueMaxLength` (not deadline-raced) → made soft with `try/catch` fail-open only. Every new fail-open branch emits `logSysRedisFailOpen` (Loki `sysredis-fail-open` visibility).

### SITE 1 — `system-cache.ts`
`getBrowsingSettingAddons` (SSR every-render via `_app.tsx`) + the adjacent sibling `getCreationBlockedTags` (every model upsert) already `try/catch` fail-open, but the `sysRedis.get` was **not deadline-raced** → SLOW parked ~11min per render/upsert. Wrapped both gets in `withSysReadDeadline`; the existing catch already handles the deadline rejection (fail-open + log). One-line change each.

Other un-hardened sysRedis read found in the file: `getLiveFeatureFlags` (same gap) — **left untouched** per scope (out of the STEP-4 remit; report only). `getSystemPermissions` is already deadline-wrapped.

### SITE 2 — `session-invalidation.ts` `updateSessionState`
The `hGetAll` **read** was neither `try/catch`'d nor deadline-wrapped → **DOWN 500'd** the logout/ban request, **SLOW parked ~11min**. Now `withSysReadDeadline` + `try/catch` → **fail-open to an empty token hash** (subtype `read-degraded`). Symmetric with the already-fail-open write (#2332) and the documented `invalidateSession` posture: during an outage the invalidation doesn't take effect (retry after recovery), but the request never 500s/parks. Updated the SECURITY/IR JSDoc to document the read fail-open too. The write (`hSetMultiWithTTL`, #2332) is unchanged. `clearSessionCache` is out of scope (cluster `redis` + hub `sessionClient`, already soft) — confirmed, untouched.

### SITE 3 — `events/index.ts` full-file sweep
| op | line | kind | handling |
|---|---|---|---|
| `getPartners` `lRange` | ~490 | READ | `withSysReadDeadline` + fail-open `[]` (empty partners), log `read-degraded` |
| `queueAddRole` `lPush` | ~503 | WRITE | `try/catch` fail-open (queued role-add dropped — feature degrade), log `write-degraded` |
| `processAddRoleQueue` `lLen` | ~529 | READ | `withSysReadDeadline` + fail-open → skip cycle, log `read-degraded` |
| `processAddRoleQueue` `lPopCount` | ~530 | READ (destructive) | `withSysReadDeadline` + fail-open → skip cycle so items **stay queued** (#2922 lesson), log `read-degraded` |

`lPopCount` is an **atomic** `LPOP key count` — a fast DOWN never writes the command (pops nothing), so on DOWN/SLOW we skip and the queued items remain for next cycle (not lost). Not a pipeline/Lua, so no partial-pop.

### Tests (fail-on-revert)
23 cases across the 3 sites: happy / DOWN (op throws → fail-open, caller doesn't throw, `logSysRedisFailOpen` fired) / SLOW (op **never settles** + `withSysReadDeadline` rejects → fail-open). The SLOW tests are **fail-on-revert**: removing the wrap leaves a bare `await` that hangs → the test TIMES OUT (verified by temporarily removing the `getPartners` wrap). Writes: DOWN swallowed + `write-degraded` logged. `lPopCount`: DOWN/SLOW skips without losing queued items.

Local: `vitest run --project unit` → **23 passed**. `tsc --noEmit` → no errors on touched files.