### PR TITLE
fix(sysredis): STEP 6 — bound the generation hot path + remaining park holes

### DIFF
--- a/src/server/orchestrator/__tests__/get-orchestrator-token.sysredis-soft.test.ts
+++ b/src/server/orchestrator/__tests__/get-orchestrator-token.sysredis-soft.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * STEP-6 sysRedis soft-dependency — the cross-pod orchestrator-token READ in
+ * getOrchestratorToken. It already try/catch fail-opens (a fast DOWN falls
+ * through to the getTemporaryUserApiKey mint path, logging
+ * token-mint-amplification); the gap STEP-6 closes is the missing wall-clock
+ * deadline. A silent half-open would otherwise park the awaited hGet ~11min on
+ * every authenticated generation call.
+ *
+ * The SLOW test is fail-on-revert: the underlying hGet NEVER settles, so if the
+ * `withSysReadDeadline(...)` wrap were removed the caller would hang → timeout.
+ */
+
+const {
+  mockHGet,
+  mockWithSysReadDeadline,
+  mockLogSysRedisFailOpen,
+  mockGetOrMint,
+  mockGetTempKey,
+  mockHSetWithTTL,
+} = vi.hoisted(() => ({
+  mockHGet: vi.fn(),
+  mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  mockLogSysRedisFailOpen: vi.fn(),
+  mockGetOrMint: vi.fn(),
+  mockGetTempKey: vi.fn(),
+  mockHSetWithTTL: vi.fn(async () => undefined),
+}));
+
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: {},
+    sysRedis: { hGet: mockHGet },
+    REDIS_KEYS: keyProxy,
+    withSysReadDeadline: mockWithSysReadDeadline,
+  };
+});
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));
+vi.mock('~/server/redis/atomic', () => ({ hSetWithTTL: mockHSetWithTTL }));
+vi.mock('~/server/orchestrator/orchestrator-token-cache', () => ({
+  getOrMintCachedToken: mockGetOrMint,
+}));
+vi.mock('~/server/services/api-key.service', () => ({ getTemporaryUserApiKey: mockGetTempKey }));
+vi.mock('~/server/utils/cookie-encryption', () => ({
+  getEncryptedCookie: vi.fn(),
+  setEncryptedCookie: vi.fn(),
+}));
+
+import { getOrchestratorToken } from '~/server/orchestrator/get-orchestrator-token';
+
+const ctx = { req: {} as any, res: {} as any };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+  // The mint path (used on DOWN/SLOW) — coalesced mint returns a fresh token.
+  mockGetOrMint.mockImplementation(async (_userId: number, mint: () => Promise<string>) => mint());
+  mockGetTempKey.mockResolvedValue('freshly-minted-token');
+  mockHSetWithTTL.mockResolvedValue(undefined);
+});
+
+describe('getOrchestratorToken — sysRedis read soft-dependency', () => {
+  it('happy path: returns the cached token through withSysReadDeadline, no mint', async () => {
+    mockHGet.mockResolvedValue('cached-token');
+
+    const token = await getOrchestratorToken(42, ctx);
+
+    expect(token).toBe('cached-token');
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockGetOrMint).not.toHaveBeenCalled();
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: hGet throws → fails open to the mint path, no throw, logs token-mint-amplification', async () => {
+    mockHGet.mockRejectedValue(new Error('sysRedis connection is down'));
+
+    const token = await getOrchestratorToken(42, ctx);
+
+    expect(token).toBe('freshly-minted-token'); // fell through to mint
+    expect(mockGetTempKey).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    const [subtype, fn] = mockLogSysRedisFailOpen.mock.calls[0];
+    expect(subtype).toBe('token-mint-amplification');
+    expect(fn).toBe('getOrchestratorToken hGet');
+  });
+
+  it('SLOW/half-open: hGet NEVER settles + deadline REJECTS → fails open to the mint path (fail-on-revert)', async () => {
+    mockHGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const token = await getOrchestratorToken(42, ctx);
+
+    expect(token).toBe('freshly-minted-token');
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockGetTempKey).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('token-mint-amplification');
+  });
+});

--- a/src/server/orchestrator/get-orchestrator-token.ts
+++ b/src/server/orchestrator/get-orchestrator-token.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { env } from '~/env/server';
 import { getOrMintCachedToken } from '~/server/orchestrator/orchestrator-token-cache';
-import { REDIS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { hSetWithTTL } from '~/server/redis/atomic';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import { getTemporaryUserApiKey } from '~/server/services/api-key.service';
@@ -48,9 +48,12 @@ export async function getOrchestratorToken(
   let token: string | null;
   if (TOKEN_STORE === 'redis') {
     try {
-      token = await sysRedis
-        .hGet(REDIS_KEYS.GENERATION.TOKENS, redisKey)
-        .then((x) => x ?? null);
+      // Wall-clock deadline so a silent sysRedis half-open can't park this read
+      // ~11min on every authenticated generation call. A fast DOWN already
+      // rejects into the catch below; the SLOW half-open needs the race.
+      token = await withSysReadDeadline(
+        sysRedis.hGet(REDIS_KEYS.GENERATION.TOKENS, redisKey)
+      ).then((x) => x ?? null);
     } catch (err) {
       logSysRedisFailOpen(
         'token-mint-amplification',

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -70,7 +70,7 @@ import { enhanceComicPrompt } from '~/server/services/comics/prompt-enhance';
 import type { SessionUser } from '~/types/session';
 import { reviewConsumerStrikes } from '../http/orchestrator/flagged-consumers';
 import semver from 'semver';
-import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import { getAllowedAccountTypes } from '../utils/buzz-helpers';
@@ -134,7 +134,9 @@ const enforceGenerationVersion = middleware(async ({ ctx, next }) => {
   // the rest of the generation-path fail-open coverage in this PR.
   let genClient: Record<string, string>;
   try {
-    genClient = await sysRedis.hGetAll(REDIS_SYS_KEYS.GENERATION.CLIENT);
+    // Wall-clock deadline so a silent sysRedis half-open can't park every gen
+    // tRPC call ~11min (a fast DOWN already rejects into the catch below).
+    genClient = await withSysReadDeadline(sysRedis.hGetAll(REDIS_SYS_KEYS.GENERATION.CLIENT));
   } catch (err) {
     logSysRedisFailOpen('read-degraded', 'enforceGenerationVersion', err);
     return result;

--- a/src/server/services/__tests__/collection.service.sysredis-soft.test.ts
+++ b/src/server/services/__tests__/collection.service.sysredis-soft.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * STEP-6 sysRedis soft-dependency (Group B) — getCollectionRandomSeed.
+ *
+ * This was a RAW read (neither try/catch nor deadline): a sysRedis outage would
+ * 500 a Random-sorted collection view, and a silent half-open would park it
+ * ~11min. STEP-6 wraps it in try/catch + withSysReadDeadline and fails open to a
+ * locally-computed hourly seed (computeHourlySeed) — the same value the function
+ * writes to the shared cache on a cache miss, so a degraded read just skips the
+ * round-trip and the view stays deterministic-per-hour.
+ *
+ * The SLOW test is fail-on-revert: `sysRedis.get` NEVER settles, so if the
+ * `withSysReadDeadline(...)` wrap were removed the caller would hang → timeout.
+ */
+
+const { mockGet, mockSet, mockWithSysReadDeadline, mockLogSysRedisFailOpen } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSet: vi.fn(async () => 'OK'),
+  mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  mockLogSysRedisFailOpen: vi.fn(),
+}));
+
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { get: vi.fn(), set: vi.fn(), packed: { get: vi.fn(), set: vi.fn() } },
+    sysRedis: { get: mockGet, set: mockSet },
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+    REDIS_SUB_KEYS: keyProxy,
+    withSysReadDeadline: mockWithSysReadDeadline,
+  };
+});
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));
+
+// @civitai/db's index re-exports ./kysely, whose top-level `import 'kysely'` is
+// not installed in this worktree. Replacing the whole package short-circuits that
+// eval — none of it is needed by getCollectionRandomSeed.
+vi.mock('@civitai/db', () => ({
+  createLagTracker: vi.fn(() => ({})),
+  loadDbEnv: vi.fn(() => ({})),
+}));
+
+// Collapse the heavy sibling graph — getCollectionRandomSeed touches only
+// sysRedis + computeHourlySeed, so DB / cache / other service infra is inert.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {} }));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  getDbWithoutLag: vi.fn(),
+  preventReplicationLag: vi.fn(),
+}));
+vi.mock('~/server/search-index', () => ({}));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/caches', () => ({
+  tagIdsForImagesCache: {},
+  userCollectionCountCache: {},
+}));
+// Stub the sibling services collection.service pulls in — their graphs reach the
+// @civitai/db layer (kysely) which isn't needed by getCollectionRandomSeed.
+vi.mock('~/server/services/article.service', () => ({ getArticles: vi.fn() }));
+vi.mock('~/server/services/home-block-cache.service', () => ({ homeBlockCacheBust: vi.fn() }));
+vi.mock('~/server/services/image.service', () => ({
+  getAllImages: vi.fn(),
+  enqueueImageIngestion: vi.fn(),
+}));
+vi.mock('~/server/services/model.service', () => ({ getModelsWithVersions: vi.fn() }));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
+vi.mock('~/server/services/post.service', () => ({ getPostsInfinite: vi.fn() }));
+
+import { getCollectionRandomSeed } from '~/server/services/collection.service';
+
+// The function fails open to Math.floor(Date.now() / (1000*60*60)); compute the
+// same value here to assert the degraded return without pinning a literal.
+const currentHourSeed = () => Math.floor(Date.now() / (1000 * 60 * 60));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+  mockSet.mockResolvedValue('OK');
+});
+
+describe('getCollectionRandomSeed — sysRedis soft-dependency', () => {
+  it('happy path: returns the cached seed through withSysReadDeadline, no fail-open', async () => {
+    mockGet.mockResolvedValue('12345');
+
+    const result = await getCollectionRandomSeed();
+
+    expect(result).toBe(12345);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('cache miss (null): computes + writes back the hourly seed, no fail-open', async () => {
+    mockGet.mockResolvedValue(null);
+
+    const result = await getCollectionRandomSeed();
+
+    expect(result).toBe(currentHourSeed());
+    expect(mockSet).toHaveBeenCalledTimes(1); // writeback on cache miss
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: get throws → fails open to the locally-computed hourly seed, no throw, logs read-degraded', async () => {
+    mockGet.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await getCollectionRandomSeed();
+
+    expect(result).toBe(currentHourSeed());
+    expect(mockSet).not.toHaveBeenCalled(); // no writeback on a failed read
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    const [subtype, fn] = mockLogSysRedisFailOpen.mock.calls[0];
+    expect(subtype).toBe('read-degraded');
+    expect(fn).toBe('getCollectionRandomSeed');
+  });
+
+  it('SLOW/half-open: get NEVER settles + deadline REJECTS → fails open to the hourly seed (fail-on-revert)', async () => {
+    mockGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await getCollectionRandomSeed();
+
+    expect(result).toBe(currentHourSeed());
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+  });
+});

--- a/src/server/services/__tests__/system-cache.sysredis-soft.test.ts
+++ b/src/server/services/__tests__/system-cache.sysredis-soft.test.ts
@@ -32,6 +32,7 @@ vi.mock('~/server/redis/client', () => ({
     SYSTEM: {
       BROWSING_SETTING_ADDONS: 'system:browsing-setting-addons',
       CREATION_BLOCKED_TAGS: 'system:creation-blocked-tags',
+      LIVE_FEATURE_FLAGS: 'system:live-feature-flags',
     },
   },
   withSysReadDeadline: mockWithSysReadDeadline,
@@ -46,8 +47,10 @@ vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 import {
   getBrowsingSettingAddons,
   getCreationBlockedTags,
+  getLiveFeatureFlags,
 } from '~/server/services/system-cache';
 import { DEFAULT_BROWSING_SETTINGS_ADDONS } from '~/shared/constants/browsing-settings-addons';
+import { DEFAULT_LIVE_FEATURE_FLAGS } from '~/server/common/constants';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -128,5 +131,46 @@ describe('getCreationBlockedTags — sysRedis soft-dependency (adjacent sibling)
     expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
     expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
     expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('defaults-firing');
+  });
+});
+
+// STEP-6: getLiveFeatureFlags is evaluated on the generation/feature-flag hot
+// path. It already try/catch fail-opens to DEFAULT_LIVE_FEATURE_FLAGS; STEP-6
+// adds the missing wall-clock deadline so a silent half-open rejects instead of
+// parking ~11min.
+describe('getLiveFeatureFlags — sysRedis soft-dependency (STEP-6)', () => {
+  it('happy path: returns the parsed cached value through withSysReadDeadline, no fail-open', async () => {
+    const flags = { ...DEFAULT_LIVE_FEATURE_FLAGS };
+    mockGet.mockResolvedValue(JSON.stringify(flags));
+
+    const result = await getLiveFeatureFlags();
+
+    expect(result).toEqual(flags);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: get throws → fails open to defaults, does not throw, logs read-degraded', async () => {
+    mockGet.mockRejectedValue(new Error('sysRedis connection is down'));
+
+    const result = await getLiveFeatureFlags();
+
+    expect(result).toBe(DEFAULT_LIVE_FEATURE_FLAGS);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    const [subtype, fn] = mockLogSysRedisFailOpen.mock.calls[0];
+    expect(subtype).toBe('read-degraded');
+    expect(fn).toBe('getLiveFeatureFlags');
+  });
+
+  it('SLOW/half-open: get NEVER settles + deadline REJECTS → fails open to defaults (fail-on-revert)', async () => {
+    mockGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await getLiveFeatureFlags();
+
+    expect(result).toBe(DEFAULT_LIVE_FEATURE_FLAGS);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
   });
 });

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -18,7 +18,8 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { getDbWithoutLag, preventReplicationLag } from '~/server/db/db-lag-helpers';
 import { dbReadFallbackCounter } from '~/server/prom/client';
 import { tagIdsForImagesCache, userCollectionCountCache } from '~/server/redis/caches';
-import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
+import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import type { GetByIdInput, UserPreferencesInput } from '~/server/schema/base.schema';
 import { userPreferencesSchema } from '~/server/schema/base.schema';
 import type {
@@ -106,7 +107,17 @@ function computeHourlySeed(): number {
 
 // Get the current random seed from Redis, or compute a new one
 export async function getCollectionRandomSeed(): Promise<number> {
-  const cached = await sysRedis.get(REDIS_SYS_KEYS.COLLECTION.RANDOM_SEED);
+  // Fail open + wall-clock deadline: a Random-sorted collection view should
+  // degrade to a locally-computed hourly seed, not 500/park, on a sysRedis blip.
+  // computeHourlySeed() is the same value this function writes on a cache miss,
+  // so a degraded read just skips the shared-cache round-trip.
+  let cached: string | null;
+  try {
+    cached = await withSysReadDeadline(sysRedis.get(REDIS_SYS_KEYS.COLLECTION.RANDOM_SEED));
+  } catch (err) {
+    logSysRedisFailOpen('read-degraded', 'getCollectionRandomSeed', err);
+    return computeHourlySeed();
+  }
   if (cached) return Number(cached);
 
   const seed = computeHourlySeed();

--- a/src/server/services/generation/__tests__/generation.service.sysredis-soft.test.ts
+++ b/src/server/services/generation/__tests__/generation.service.sysredis-soft.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * STEP-6 sysRedis soft-dependency sweep — the generation hot-path readers in
+ * generation.service.ts. These five reads all run on the generation submit /
+ * config path (four together in getGenerationConfig's Promise.all), so a single
+ * un-deadlined member parking on a silent sysRedis half-open would park the whole
+ * gen submit ~11min on every request.
+ *
+ * Each already fail-opens (try/catch or a chained `.catch`); the gap this PR
+ * closes is the missing wall-clock deadline. The SLOW tests are fail-on-revert:
+ * the underlying sysRedis op NEVER settles, so if the `withSysReadDeadline(...)`
+ * wrap were removed the caller would hang and the test would TIME OUT.
+ */
+
+const { mockHGet, mockWithSysReadDeadline, mockLogSysRedisFailOpen } = vi.hoisted(() => ({
+  mockHGet: vi.fn(),
+  mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  mockLogSysRedisFailOpen: vi.fn(),
+}));
+
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn(), mGet: vi.fn() }, get: vi.fn(), set: vi.fn() },
+    sysRedis: { hGet: mockHGet },
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+    REDIS_SUB_KEYS: keyProxy,
+    withSysReadDeadline: mockWithSysReadDeadline,
+  };
+});
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));
+
+// Collapse the heavy sibling-service graph: these are only used at runtime by
+// code paths the five readers under test never reach, so empty/vi.fn stubs keep
+// the import light without touching DB / search-index / image feed infra.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  getDbWithoutLag: vi.fn(),
+  getDbWithoutLagBatch: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/ecosystems/wan.handler', () => ({
+  wanBaseModelGroupIdMap: {},
+}));
+vi.mock('~/server/search-index', () => ({ modelsSearchIndex: {} }));
+vi.mock('~/server/services/common.service', () => ({ hasEntityAccess: vi.fn() }));
+vi.mock('~/server/services/model-file.service', () => ({ getFilesForModelVersionCache: vi.fn() }));
+vi.mock('~/server/redis/resource-data.redis', () => ({ resourceDataCache: {} }));
+vi.mock('~/server/services/model.service', () => ({ getFeaturedModels: vi.fn() }));
+vi.mock('~/server/services/model-version.service', () => ({ getLinkedVaeIds: vi.fn() }));
+vi.mock('~/server/services/image.service', () => ({ imagesForModelVersionsCache: {} }));
+vi.mock('~/server/services/generation/version-generation-state.service', () => ({
+  getVisibleSystemWildcardSetIdsByVersionId: vi.fn(),
+}));
+vi.mock('~/server/utils/otel-helpers', () => ({
+  withSpan: (_name: string, fn: () => unknown) => fn(),
+}));
+// NB: leave ~/server/services/feature-flags.service REAL — it exports `userTiers`
+// (a constant consumed by user.schema at module load). resolveTestingAccess only
+// reaches its isFlipt at runtime for a NON-empty user; the tests pass `{}`, so the
+// flag call is short-circuited and never opens a connection.
+
+import {
+  getGenerationStatus,
+  getUnstableResources,
+  getGenerationEcosystemConfig,
+  getGateRules,
+  getUnavailableResources,
+} from '~/server/services/generation/generation.service';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+});
+
+describe('getGenerationStatus — sysRedis soft-dependency', () => {
+  it('happy path: returns the parsed status through withSysReadDeadline, no fail-open', async () => {
+    mockHGet.mockResolvedValue(JSON.stringify({ available: false }));
+
+    const result = await getGenerationStatus();
+
+    expect(result.available).toBe(false);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: hGet throws → fails open to schema defaults (available=true), no throw, logs defaults-firing', async () => {
+    mockHGet.mockRejectedValue(new Error('sysRedis connection is down'));
+
+    const result = await getGenerationStatus();
+
+    expect(result.available).toBe(true); // schema default — service appears enabled
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('defaults-firing');
+    expect(mockLogSysRedisFailOpen.mock.calls[0][1]).toBe('getGenerationStatus generation.service');
+  });
+
+  it('SLOW/half-open: hGet NEVER settles + deadline REJECTS → fails open to defaults (fail-on-revert)', async () => {
+    mockHGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await getGenerationStatus();
+
+    expect(result.available).toBe(true);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('defaults-firing');
+  });
+});
+
+describe('getUnstableResources — sysRedis soft-dependency', () => {
+  it('happy path: returns the parsed list through withSysReadDeadline, no fail-open', async () => {
+    mockHGet.mockResolvedValue(JSON.stringify([1, 2, 3]));
+
+    const result = await getUnstableResources();
+
+    expect(result).toEqual([1, 2, 3]);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: hGet throws → fails open to [], no throw, logs read-degraded', async () => {
+    mockHGet.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await getUnstableResources();
+
+    expect(result).toEqual([]);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+    expect(mockLogSysRedisFailOpen.mock.calls[0][1]).toBe('getUnstableResources');
+  });
+
+  it('SLOW/half-open: hGet NEVER settles + deadline REJECTS → fails open to [] (fail-on-revert)', async () => {
+    mockHGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await getUnstableResources();
+
+    expect(result).toEqual([]);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+  });
+});
+
+describe('getGenerationEcosystemConfig — sysRedis soft-dependency', () => {
+  it('happy path: returns the parsed config through withSysReadDeadline, no fail-open', async () => {
+    mockHGet.mockResolvedValue(JSON.stringify({ experimentalEcosystems: ['flux'] }));
+
+    const result = await getGenerationEcosystemConfig({});
+
+    expect(result.experimentalEcosystems).toEqual(['flux']);
+    expect(result.hasTestingAccess).toBe(false);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: hGet throws → fails open to defaults, no throw, logs read-degraded', async () => {
+    mockHGet.mockRejectedValue(new Error('sysRedis connection is down'));
+
+    const result = await getGenerationEcosystemConfig({});
+
+    expect(result.hasTestingAccess).toBe(false);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+    expect(mockLogSysRedisFailOpen.mock.calls[0][1]).toBe('getGenerationEcosystemConfig');
+  });
+
+  it('SLOW/half-open: hGet NEVER settles + deadline REJECTS → fails open to defaults (fail-on-revert)', async () => {
+    mockHGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await getGenerationEcosystemConfig({});
+
+    expect(result.hasTestingAccess).toBe(false);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+  });
+});
+
+describe('getGateRules — sysRedis soft-dependency', () => {
+  it('happy path: returns [] through withSysReadDeadline when no rules cached, no fail-open', async () => {
+    mockHGet.mockResolvedValue(JSON.stringify([]));
+
+    const result = await getGateRules();
+
+    expect(result).toEqual([]);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: hGet throws → fails open to [], no throw, logs read-degraded', async () => {
+    mockHGet.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    const result = await getGateRules();
+
+    expect(result).toEqual([]);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+    expect(mockLogSysRedisFailOpen.mock.calls[0][1]).toBe('getGateRules');
+  });
+
+  it('SLOW/half-open: hGet NEVER settles + deadline REJECTS → fails open to [] (fail-on-revert)', async () => {
+    mockHGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await getGateRules();
+
+    expect(result).toEqual([]);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+  });
+});
+
+describe('getUnavailableResources — sysRedis soft-dependency', () => {
+  it('happy path: returns the deduped list through withSysReadDeadline, no fail-open', async () => {
+    mockHGet.mockResolvedValue(JSON.stringify([1, 1, 2]));
+
+    const result = await getUnavailableResources();
+
+    expect(result).toEqual([1, 2]);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: hGet throws → fails open to [], no throw, logs read-degraded', async () => {
+    mockHGet.mockRejectedValue(new Error('sysRedis connection is down'));
+
+    const result = await getUnavailableResources();
+
+    expect(result).toEqual([]);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+    expect(mockLogSysRedisFailOpen.mock.calls[0][1]).toBe('getUnavailableResources');
+  });
+
+  it('SLOW/half-open: hGet NEVER settles + deadline REJECTS → fails open to [] (fail-on-revert)', async () => {
+    mockHGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await getUnavailableResources();
+
+    expect(result).toEqual([]);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
+  });
+});

--- a/src/server/services/generation/generation.service.ts
+++ b/src/server/services/generation/generation.service.ts
@@ -6,7 +6,7 @@ import { EntityAccessPermission, SearchIndexUpdateQueueAction } from '~/server/c
 import { dbRead } from '~/server/db/client';
 import { getDbWithoutLag, getDbWithoutLagBatch } from '~/server/db/db-lag-helpers';
 import { wanBaseModelGroupIdMap } from '~/server/services/orchestrator/ecosystems/wan.handler';
-import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import type { GetByIdInput } from '~/server/schema/base.schema';
 import type {
@@ -275,7 +275,11 @@ export async function getGenerationStatus() {
   // Fail open: a sysRedis outage shouldn't crash generation API calls.
   let raw: string | null | undefined;
   try {
-    raw = await sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, REDIS_SYS_KEYS.GENERATION.STATUS);
+    // Wall-clock deadline so a silent sysRedis half-open can't park this read
+    // (runs in getGenerationConfig's Promise.all on every gen submit) ~11min.
+    raw = await withSysReadDeadline(
+      sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, REDIS_SYS_KEYS.GENERATION.STATUS)
+    );
   } catch (err) {
     logSysRedisFailOpen('defaults-firing', 'getGenerationStatus generation.service', err);
     raw = undefined;
@@ -785,10 +789,17 @@ const getModelVersionGenerationData = async ({
 };
 
 export async function getUnstableResources() {
-  const cachedData = await sysRedis
-    .hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, 'generation:unstable-resources')
+  // Wall-clock deadline: this runs in getGenerationConfig's Promise.all on
+  // every gen submit, so a silent sysRedis half-open would park the whole submit.
+  const cachedData = await withSysReadDeadline(
+    sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, 'generation:unstable-resources')
+  )
     .then((data) => (data ? fromJson<number[]>(data) : ([] as number[])))
-    .catch(() => [] as number[]); // fallback to empty array if redis fails
+    .catch((err) => {
+      // fallback to empty array if redis fails (DOWN or SLOW/deadline)
+      logSysRedisFailOpen('read-degraded', 'getUnstableResources', err);
+      return [] as number[];
+    });
 
   return cachedData ?? [];
 }
@@ -807,10 +818,17 @@ export async function getGenerationEcosystemConfig(
   user: { id?: number; isModerator?: boolean } = {}
 ): Promise<GenerationEcosystemContext> {
   const [cached, hasTestingAccess] = await Promise.all([
-    sysRedis
-      .hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, 'generation:ecosystem-config')
+    // Wall-clock deadline: runs in getGenerationConfig's Promise.all on every
+    // gen submit — a silent sysRedis half-open would park the whole submit.
+    withSysReadDeadline(
+      sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, 'generation:ecosystem-config')
+    )
       .then((data) => (data ? fromJson<Partial<GenerationEcosystemConfig>>(data) : null))
-      .catch(() => null), // fallback to default if redis fails
+      .catch((err) => {
+        // fallback to default if redis fails (DOWN or SLOW/deadline)
+        logSysRedisFailOpen('read-degraded', 'getGenerationEcosystemConfig', err);
+        return null;
+      }),
     resolveTestingAccess(user),
   ]);
 
@@ -855,10 +873,16 @@ const gateRulesArraySchema = z.array(gateRuleSchema);
  * Fail-open to `[]` so a bad/missing value never blocks generation.
  */
 export async function getGateRules(): Promise<GateRule[]> {
-  const cached = await sysRedis
-    .hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, 'generation:gate-rules')
+  // Wall-clock deadline: getGateRules runs in getGenerationConfig's
+  // Promise.all on every gen submit — a silent sysRedis half-open would park it.
+  const cached = await withSysReadDeadline(
+    sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, 'generation:gate-rules')
+  )
     .then((data) => (data ? fromJson<GateRule[]>(data) : null))
-    .catch(() => null);
+    .catch((err) => {
+      logSysRedisFailOpen('read-degraded', 'getGateRules', err);
+      return null;
+    });
   const parsed = gateRulesArraySchema.safeParse(cached ?? []);
   return parsed.success ? parsed.data : [];
 }
@@ -957,10 +981,17 @@ export async function getGenerationConfig(
 }
 
 export async function getUnavailableResources() {
-  const cachedData = await sysRedis
-    .hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, 'generation:unavailable-resources')
+  // Wall-clock deadline: getUnavailableResources gates the gen submit path — a
+  // silent sysRedis half-open would park generation ~11min instead of failing open.
+  const cachedData = await withSysReadDeadline(
+    sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, 'generation:unavailable-resources')
+  )
     .then((data) => (data ? fromJson<number[]>(data) : ([] as number[])))
-    .catch(() => [] as number[]); // fallback to empty array if redis fails
+    .catch((err) => {
+      // fallback to empty array if redis fails (DOWN or SLOW/deadline)
+      logSysRedisFailOpen('read-degraded', 'getUnavailableResources', err);
+      return [] as number[];
+    });
 
   return [...new Set(cachedData ?? [])];
 }

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -81,7 +81,13 @@ import {
   userImageVideoCountCache,
 } from '~/server/redis/caches';
 import type { RedisKeyTemplateSys } from '~/server/redis/client';
-import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import {
+  redis,
+  REDIS_KEYS,
+  REDIS_SYS_KEYS,
+  sysRedis,
+  withSysReadDeadline,
+} from '~/server/redis/client';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import { createCachedObject, queryCacheRaw } from '~/server/utils/cache-helpers';
 import { createLruCache } from '~/server/utils/lru-cache';
@@ -3501,7 +3507,9 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
       // to DB — slower but correct).
       let cachedResults: (string | null)[];
       try {
-        cachedResults = await sysRedis.packed.mGet(cacheKeys);
+        // Wall-clock deadline so a silent sysRedis half-open can't park this
+        // highest-traffic read ~11min (a fast DOWN already rejects into catch).
+        cachedResults = await withSysReadDeadline(sysRedis.packed.mGet(cacheKeys));
       } catch (err) {
         logSysRedisFailOpen('read-degraded', 'checkImageExistence mGet', err);
         cachedResults = new Array(uniqueIds.length).fill(null);
@@ -4548,7 +4556,10 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
       // sibling checkImageExistence call site above for the same pattern.
       let cachedResults: (string | null)[];
       try {
-        cachedResults = cacheKeys.length > 0 ? await sysRedis.packed.mGet(cacheKeys) : [];
+        // Wall-clock deadline — see the sibling checkImageExistence call site
+        // above; bounds a silent sysRedis half-open on this hot read.
+        cachedResults =
+          cacheKeys.length > 0 ? await withSysReadDeadline(sysRedis.packed.mGet(cacheKeys)) : [];
       } catch (err) {
         logSysRedisFailOpen('read-degraded', 'checkImageExistence mGet', err);
         cachedResults = new Array(uniqueIds.length).fill(null);

--- a/src/server/services/orchestrator/__tests__/orchestration-new.getGenerationStatus.sysredis-soft.test.ts
+++ b/src/server/services/orchestrator/__tests__/orchestration-new.getGenerationStatus.sysredis-soft.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * STEP-6 sysRedis soft-dependency — the LOCAL getGenerationStatus dup in
+ * orchestration-new.service.ts, exercised through its exported caller
+ * buildGenerationContext. Same contract as the generation.service reader: it
+ * already try/catch fail-opens to schema defaults; STEP-6 adds the wall-clock
+ * deadline so a silent half-open rejects instead of parking ~11min while the
+ * generation context is built.
+ *
+ * getGenerationEcosystemConfig + getGateRules are imported from generation.service
+ * and mocked here, so the ONLY withSysReadDeadline call is the local status read
+ * under test. The SLOW test is fail-on-revert (hGet never settles).
+ */
+
+const { mockHGet, mockWithSysReadDeadline, mockLogSysRedisFailOpen } = vi.hoisted(() => ({
+  mockHGet: vi.fn(),
+  mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  mockLogSysRedisFailOpen: vi.fn(),
+}));
+
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() }, get: vi.fn(), set: vi.fn() },
+    sysRedis: { hGet: mockHGet },
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+    REDIS_SUB_KEYS: keyProxy,
+    withSysReadDeadline: mockWithSysReadDeadline,
+  };
+});
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));
+
+// Keep the DB / infra layer inert (avoids booting Prisma / kysely / pools at
+// import — buildGenerationContext never touches them on the status path).
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {} }));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  getDbWithoutLag: vi.fn(),
+  getDbWithoutLagBatch: vi.fn(),
+  preventReplicationLag: vi.fn(),
+}));
+vi.mock('~/server/db/datapacketDb', () => ({ datapacketDbRead: {}, datapacketDbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/search-index', () => ({}));
+vi.mock('@civitai/db', () => ({ createLagTracker: vi.fn(() => ({})), loadDbEnv: vi.fn(() => ({})) }));
+
+// The two sibling readers buildGenerationContext composes — mock so the only
+// deadline-wrapped read is the local getGenerationStatus under test, and so the
+// heavy generation.service graph doesn't load.
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getGenerationEcosystemConfig: vi.fn(async () => ({
+    experimentalEcosystems: [],
+    hasTestingAccess: false,
+  })),
+  getGateRules: vi.fn(async () => []),
+  getSelfHostedDisabledEcosystems: vi.fn(() => [] as string[]),
+}));
+
+// image.service (pulled transitively via cosmetic.service) imports the private
+// `event-engine-common` submodule that isn't checked out here + boots DB pools;
+// buildGenerationContext never uses it, so stub it out.
+vi.mock('~/server/services/image.service', () => ({
+  getAllImages: vi.fn(),
+  enqueueImageIngestion: vi.fn(),
+  imagesForModelVersionsCache: {},
+}));
+
+import { buildGenerationContext } from '~/server/services/orchestrator/orchestration-new.service';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+});
+
+describe('buildGenerationContext → local getGenerationStatus — sysRedis soft-dependency', () => {
+  it('happy path: reads status through withSysReadDeadline, resolves, no fail-open', async () => {
+    mockHGet.mockResolvedValue(JSON.stringify({ available: true }));
+
+    const result = await buildGenerationContext('free', {}, {});
+
+    expect(result).toBeDefined();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: hGet throws → local status fails open to defaults, resolves, logs defaults-firing', async () => {
+    mockHGet.mockRejectedValue(new Error('sysRedis connection is down'));
+
+    const result = await buildGenerationContext('free', {}, {});
+
+    expect(result).toBeDefined(); // did NOT throw
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    const [subtype, fn] = mockLogSysRedisFailOpen.mock.calls[0];
+    expect(subtype).toBe('defaults-firing');
+    expect(fn).toBe('getGenerationStatus orchestration-new');
+  });
+
+  it('SLOW/half-open: hGet NEVER settles + deadline REJECTS → fails open to defaults (fail-on-revert)', async () => {
+    mockHGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    const result = await buildGenerationContext('free', {}, {});
+
+    expect(result).toBeDefined();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('defaults-firing');
+  });
+});

--- a/src/server/services/orchestrator/__tests__/promptAuditing.sysredis-soft.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing.sysredis-soft.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * STEP-6 sysRedis soft-dependency (Group C) — promptAuditing.
+ *
+ * SAFETY-SENSITIVE. The sysRedis reads in `addBlockedPrompt` (exists / lRange /
+ * lLen) run AFTER a prompt has already been flagged, on the way to the
+ * violation-count → auto-mute accounting inside `auditPromptServer`. They must
+ * keep FAILING CLOSED: a sysRedis error propagates out of auditPromptServer so
+ * the generation request errors rather than silently proceeding. STEP-6 only
+ * adds the wall-clock deadline to BOUND a silent half-open (it would otherwise
+ * park each awaited read ~11min) — it deliberately does NOT add a fail-open
+ * catch. This suite locks in "park bounded, but still fails closed":
+ *   - the deadline wrap is applied (SLOW → rejects at the deadline rather than
+ *     hanging → fail-on-revert), AND
+ *   - the error still propagates (no silent success), AND
+ *   - no fail-open is logged (there is no fail-open here by design).
+ */
+
+const {
+  mockExists,
+  mockLPush,
+  mockLRange,
+  mockLRem,
+  mockLLen,
+  mockWithSysReadDeadline,
+  mockLogSysRedisFailOpen,
+  mockAuditPromptEnriched,
+  mockModeratePrompt,
+} = vi.hoisted(() => ({
+  mockExists: vi.fn(),
+  mockLPush: vi.fn(async () => 1),
+  mockLRange: vi.fn(async () => [] as string[]),
+  mockLRem: vi.fn(async () => 1),
+  mockLLen: vi.fn(async () => 1),
+  mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  mockLogSysRedisFailOpen: vi.fn(),
+  mockAuditPromptEnriched: vi.fn(),
+  mockModeratePrompt: vi.fn(async () => ({ flagged: false, categories: [] as string[] })),
+}));
+
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: {},
+    sysRedis: {
+      exists: mockExists,
+      lPush: mockLPush,
+      lRange: mockLRange,
+      lRem: mockLRem,
+      lLen: mockLLen,
+      del: vi.fn(),
+      expire: vi.fn(),
+      rPush: vi.fn(),
+    },
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+    withSysReadDeadline: mockWithSysReadDeadline,
+  };
+});
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));
+
+// Force the regex audit to flag the prompt so auditPromptServer enters its catch
+// and reaches addBlockedPrompt (the reads under test).
+vi.mock('~/utils/metadata/audit', () => ({
+  auditPromptEnriched: mockAuditPromptEnriched,
+}));
+vi.mock('~/server/integrations/moderation', () => ({
+  extModeration: { moderatePrompt: mockModeratePrompt },
+}));
+
+// Collapse the heavy graph — none of these are reached on the counting path with
+// a below-threshold count.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({ updateUserById: vi.fn() }));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  fetchThroughCache: vi.fn(),
+  bustFetchThroughCache: vi.fn(),
+}));
+
+import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
+
+const blockingOptions = {
+  prompt: 'a flagged prompt',
+  userId: 5,
+  isGreen: false,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+  // Regex audit flags the prompt → drives the block path.
+  mockAuditPromptEnriched.mockReturnValue({
+    triggers: [{ message: 'blocked term', category: 'regex', matchedWord: 'x' }],
+    success: false,
+  });
+  mockExists.mockResolvedValue(1);
+  mockLRange.mockResolvedValue([]);
+  mockLLen.mockResolvedValue(1); // below the mute threshold — no auto-mute
+});
+
+describe('auditPromptServer → addBlockedPrompt — sysRedis reads (fail-CLOSED, park-bounded)', () => {
+  it('happy path: flagged prompt → throws the block error, reads wrapped in withSysReadDeadline, no fail-open log', async () => {
+    // A flagged prompt always throws a BAD_REQUEST (the user-facing block). The
+    // point here is that the counting reads went THROUGH the deadline wrap.
+    await expect(auditPromptServer(blockingOptions)).rejects.toThrow();
+
+    // exists + lRange + lLen each wrapped.
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(3);
+    // No fail-open here by design — this path fails closed, never fails open.
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: sysRedis.exists throws → the error PROPAGATES (fails closed), no silent success, no fail-open log', async () => {
+    mockExists.mockRejectedValue(new Error('sysRedis connection is down'));
+
+    // Must reject with the underlying sysRedis error — NOT resolve. A resolve
+    // would mean the counting path swallowed the outage (a moderation weakening).
+    await expect(auditPromptServer(blockingOptions)).rejects.toThrow(/down/i);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('SLOW/half-open: exists NEVER settles + deadline REJECTS → the error propagates (fail-on-revert), no fail-open log', async () => {
+    mockExists.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+
+    await expect(auditPromptServer(blockingOptions)).rejects.toThrow(/timed out/i);
+    // The wrap was applied to the first read (exists). Without it, the bare
+    // `await sysRedis.exists` would hang and this test would TIME OUT.
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/orchestrator/__tests__/promptAuditing.sysredis-soft.test.ts
+++ b/src/server/services/orchestrator/__tests__/promptAuditing.sysredis-soft.test.ts
@@ -80,6 +80,9 @@ vi.mock('~/server/utils/cache-helpers', () => ({
   fetchThroughCache: vi.fn(),
   bustFetchThroughCache: vi.fn(),
 }));
+// The mute path's banError catch logs via logToAxiom — stub it so the test
+// doesn't attempt a real network call.
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
 
 import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
 
@@ -131,6 +134,46 @@ describe('auditPromptServer → addBlockedPrompt — sysRedis reads (fail-CLOSED
     // The wrap was applied to the first read (exists). Without it, the bare
     // `await sysRedis.exists` would hang and this test would TIME OUT.
     expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+});
+
+describe('auditPromptServer → reportProhibitedRequest → getBlockedPrompts (mute path, fail-CAUGHT)', () => {
+  // Drive count > muted (constants.imageGeneration.requestBlocking.muted = 8) so
+  // reportProhibitedRequest enters the auto-mute branch and calls getBlockedPrompts.
+  // The downstream dbWrite.userRestriction.create throws (dbWrite is mocked {}),
+  // absorbed by the existing `catch (banError)` — so no heavy mute-path scaffolding
+  // is needed. Unlike addBlockedPrompt (fail-PROPAGATED), a sysRedis error in
+  // getBlockedPrompts is fail-CAUGHT: the auto-mute is skipped, and the current
+  // prompt is still blocked upstream via throwBadRequestError.
+  it('mute path: getBlockedPrompts lRange goes through withSysReadDeadline (4th wrapped read); prompt still blocked', async () => {
+    mockLLen.mockResolvedValue(9); // > muted (8) → enters the mute branch
+
+    await expect(auditPromptServer(blockingOptions)).rejects.toThrow();
+
+    // exists + lRange + lLen (addBlockedPrompt) + lRange (getBlockedPrompts) = 4.
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(4);
+    // No fail-open branch here — getBlockedPrompts' outcome is handled by banError.
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('SLOW/half-open on getBlockedPrompts: its lRange never settles + deadline REJECTS → caught by banError (mute skipped), prompt still blocked (fail-on-revert)', async () => {
+    mockLLen.mockResolvedValue(9); // enter the mute branch
+    // addBlockedPrompt's lRange (1st) resolves; getBlockedPrompts' lRange (2nd) never settles.
+    mockLRange.mockResolvedValueOnce([]).mockReturnValueOnce(new Promise(() => undefined));
+    // Transparent for the three addBlockedPrompt reads; reject the 4th call
+    // (getBlockedPrompts lRange) to model the half-open deadline trip.
+    mockWithSysReadDeadline
+      .mockImplementationOnce((p) => p)
+      .mockImplementationOnce((p) => p)
+      .mockImplementationOnce((p) => p)
+      .mockRejectedValueOnce(new Error('sysRedis read timed out after 2000ms'));
+
+    // The deadline-reject is absorbed by reportProhibitedRequest's banError catch;
+    // auditPromptServer still throws the user-facing block. Without the wrap on
+    // getBlockedPrompts, the bare `await sysRedis.lRange` would HANG → test times out.
+    await expect(auditPromptServer(blockingOptions)).rejects.toThrow();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(4);
     expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -46,7 +46,13 @@ import {
 } from '~/server/services/generation/generation.service';
 import { applicableRulesFor } from '~/shared/data-graph/generation/gates';
 import type { GenerationResource } from '~/shared/types/generation.types';
-import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import {
+  redis,
+  REDIS_KEYS,
+  REDIS_SYS_KEYS,
+  sysRedis,
+  withSysReadDeadline,
+} from '~/server/redis/client';
 import type { RedisKeyTemplateCache } from '~/server/redis/client';
 import { fetchThroughCache } from '~/server/utils/cache-helpers';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
@@ -230,7 +236,11 @@ async function getGenerationStatus(): Promise<GenerationStatus> {
   // Fail open: a sysRedis outage shouldn't crash generation context build.
   let raw: string | null | undefined;
   try {
-    raw = await sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, REDIS_SYS_KEYS.GENERATION.STATUS);
+    // Wall-clock deadline so a silent sysRedis half-open can't park this read
+    // (runs while building the generation context) ~11min.
+    raw = await withSysReadDeadline(
+      sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, REDIS_SYS_KEYS.GENERATION.STATUS)
+    );
   } catch (err) {
     logSysRedisFailOpen('defaults-firing', 'getGenerationStatus orchestration-new', err);
     raw = undefined;

--- a/src/server/services/orchestrator/promptAuditing.ts
+++ b/src/server/services/orchestrator/promptAuditing.ts
@@ -3,7 +3,7 @@ import { NotificationCategory } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { extModeration } from '~/server/integrations/moderation';
 import { logToAxiom } from '~/server/logging/client';
-import { REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_KEYS, REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import { createNotification } from '~/server/services/notification.service';
 import { updateUserById } from '~/server/services/user.service';
@@ -112,7 +112,14 @@ async function getBlockedPromptCount(userId: number): Promise<number> {
 /** Add a blocked prompt and return the new count */
 async function addBlockedPrompt(userId: number, entry: BlockedPromptEntry): Promise<number> {
   const key = getBlockedPromptsKey(userId);
-  const exists = await sysRedis.exists(key);
+  // SAFETY-SENSITIVE: this runs only AFTER a prompt is flagged (inside
+  // auditPromptServer's catch), on the way to auto-mute accounting. A sysRedis
+  // error MUST keep propagating so auditPromptServer fails CLOSED (the generation
+  // request aborts) rather than silently proceeding — do NOT add a fail-open catch.
+  // The deadline only BOUNDS a silent half-open (which would otherwise park each
+  // awaited read ~11min): it rejects at ~2s, preserving the same fail-closed
+  // direction. See STEP-6 report's promptAuditing note.
+  const exists = await withSysReadDeadline(sysRedis.exists(key));
 
   if (!exists) {
     await seedBlockedPromptsFromClickHouse(userId);
@@ -124,13 +131,15 @@ async function addBlockedPrompt(userId: number, entry: BlockedPromptEntry): Prom
 
   // If the seeded list was just a reset marker, drop the marker now that we
   // have a real entry. Using lRem (not del) preserves the TTL set by the seed.
-  const currentEntries = (await sysRedis.lRange(key, 0, -1)).map((e) => decodeRedisString(e));
+  const currentEntries = (await withSysReadDeadline(sysRedis.lRange(key, 0, -1))).map((e) =>
+    decodeRedisString(e)
+  );
   if (currentEntries.includes(RESET_MARKER)) {
     await sysRedis.lRem(key, 0, RESET_MARKER);
   }
 
   // Marker has been removed above, so lLen now equals the real violation count.
-  return await sysRedis.lLen(key);
+  return await withSysReadDeadline(sysRedis.lLen(key));
 }
 
 /** Get all blocked prompts (excludes reset marker) */

--- a/src/server/services/orchestrator/promptAuditing.ts
+++ b/src/server/services/orchestrator/promptAuditing.ts
@@ -145,7 +145,16 @@ async function addBlockedPrompt(userId: number, entry: BlockedPromptEntry): Prom
 /** Get all blocked prompts (excludes reset marker) */
 async function getBlockedPrompts(userId: number): Promise<BlockedPromptEntry[]> {
   const key = getBlockedPromptsKey(userId);
-  const entries = (await sysRedis.lRange(key, 0, -1)).map((e) => decodeRedisString(e));
+  // Park-bounding only. This read is on the auto-mute sub-path — called from
+  // reportProhibitedRequest INSIDE its `try { … } catch (banError)` block, so a
+  // throw here is caught there (auto-mute is skipped + logged as
+  // `user-ban-creation-error`; the current prompt is still blocked upstream).
+  // Deadline the read so a silent half-open rejects at ~2s instead of parking
+  // ~11min; we add no fail-open catch of our own — the existing banError handler
+  // already bounds the blast to "mute skipped this once."
+  const entries = (await withSysReadDeadline(sysRedis.lRange(key, 0, -1))).map((e) =>
+    decodeRedisString(e)
+  );
   return entries
     .filter((e) => e !== RESET_MARKER)
     .map((entry) => JSON.parse(entry) as BlockedPromptEntry);

--- a/src/server/services/system-cache.ts
+++ b/src/server/services/system-cache.ts
@@ -381,7 +381,9 @@ export async function removeCreationBlockedTags(tagIds: number[]): Promise<Creat
 export async function getLiveFeatureFlags() {
   let cached: string | null;
   try {
-    cached = await sysRedis.get(REDIS_SYS_KEYS.SYSTEM.LIVE_FEATURE_FLAGS);
+    // Wall-clock deadline so a silent sysRedis half-open can't park this read
+    // (evaluated on the generation/feature-flag hot path) ~11min.
+    cached = await withSysReadDeadline(sysRedis.get(REDIS_SYS_KEYS.SYSTEM.LIVE_FEATURE_FLAGS));
   } catch (err) {
     logSysRedisFailOpen('read-degraded', 'getLiveFeatureFlags', err);
     return DEFAULT_LIVE_FEATURE_FLAGS;


### PR DESCRIPTION
## STEP 6 — bound the generation hot path + remaining park holes

A completeness sweep found the four prior sysRedis soft-dependency PRs never covered the **generation submit/config path**. This closes those holes.

### The mechanic
`sysRedis` (Sentinel client, `socketTimeout:0` + `disableOfflineQueue:true`) rejects **FAST** on DOWN (try/catch survives) but **PARKS ~11min** on a silent SLOW/half-open unless the awaited read is wrapped in `withSysReadDeadline(...)` (a ~2s race that REJECTS on timeout). A read is fully soft only when **both** try/catch'd **and** deadline-wrapped. Only `sysRedis` parks; the cluster `redis` client is out of scope.

### Group A — already fail-open; add the missing deadline wrap
| File | Function | read |
|---|---|---|
| generation.service.ts | `getGenerationStatus`, `getUnstableResources`, `getGenerationEcosystemConfig`, `getGateRules`, `getUnavailableResources` | hGet |
| orchestration-new.service.ts | local `getGenerationStatus` dup | hGet |
| orchestrator.router.ts | `enforceGenerationVersion` middleware | hGetAll |
| get-orchestrator-token.ts | cross-pod token read | hGet |
| system-cache.ts | `getLiveFeatureFlags` | get |
| image.service.ts | two image-feed `checkImageExistence` | packed.mGet |

The first four generation.service reads run together in `getGenerationConfig`'s `Promise.all`, so a single un-deadlined member parked the whole gen submit. The three chained-`.catch` readers (`getUnstableResources`/`getGenerationEcosystemConfig`/`getGateRules`/`getUnavailableResources`) also gained the previously-**missing** `logSysRedisFailOpen`. Fail-open **values/subtypes are unchanged** — `getGenerationStatus` still fails open to `available=true` (`defaults-firing`); the deadline just extends that same posture from DOWN to SLOW (symmetric, no new semantic).

### Group B — raw read; add try/catch + deadline
- `collection.service.getCollectionRandomSeed` fails open to `computeHourlySeed()` (the same value it writes on a cache miss), so Random-sorted collection views degrade instead of 500/park. Logs `read-degraded`.

### Group C — safety-sensitive (promptAuditing) — deadline-only, NO fail-open
`addBlockedPrompt` (`exists`/`lRange`/`lLen`) runs on the **blocked-prompt / auto-mute accounting** path. Applied **only** the deadline wrap to bound the ~11min park; **preserved error propagation** so the reads still **FAIL CLOSED** — a sysRedis error propagates out of `auditPromptServer` and the generation request errors, rather than silently proceeding. The fail *direction* of a safety gate is a product decision, left to a human (see the safety note below).

### Tests
DOWN + SLOW + happy for every hardened read (co-located `__tests__/`, none under `src/pages/**`). SLOW cases are **fail-on-revert**: the underlying sysRedis op never settles, so removing the `withSysReadDeadline(...)` wrap makes the bare `await` hang → the test times out. Verified empirically (removed one wrap → SLOW test hung). Group A/B assert `withSysReadDeadline` was called + `logSysRedisFailOpen` fired; Group C asserts the deadline is applied AND the error still propagates (no silent success, no fail-open log). **37 tests across 6 files, all green.**

### promptAuditing safety note (for the human)
- **What the reads gate:** they run *after* a prompt is already flagged (inside `auditPromptServer`'s catch), tallying the user's violation count toward the auto-mute threshold and building the `UserRestriction` record. The blocklist decision itself (regex `auditPromptEnriched` + external `extModeration.moderatePrompt`) does **not** touch sysRedis.
- **Today on DOWN:** `addBlockedPrompt`'s `sysRedis.exists` throws → propagates out of `auditPromptServer` → the generation request errors (**fails closed** — the flagged prompt does not generate).
- **This PR:** the deadline bounds the SLOW park from ~11min to ~2s, **same fail-closed direction**. No moderation bypass is introduced.
- **A future fail-open catch here would NOT bypass the blocklist** (the `throwBadRequestError` block still fires) but WOULD under-count toward auto-mute — a moderation-accounting weakening. That direction change is intentionally **not** made here.

### Not unit-tested (hardened in source; isolation impractical)
- `orchestrator.router.enforceGenerationVersion` — a non-exported tRPC middleware; the router's import graph is prohibitively large to boot in a unit test.
- The two `image.service` `checkImageExistence` mGet reads — inner closures deep inside `getImagesFromSearchPreFilter`/`PostFilter`; reaching the mGet branch needs a full search-backend + DB harness.

Both share the exact one-line wrap shape as the 9 covered functions, inside pre-existing try/catch fail-open blocks that already log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
