### PR TITLE
fix(notifications): gate the count cache to the unread/no-category variant it actually represents

### DIFF
--- a/apps/notifications/src/lib/server/operations.countNotifications.test.ts
+++ b/apps/notifications/src/lib/server/operations.countNotifications.test.ts
@@ -40,7 +40,10 @@ vi.mock('./lag', () => ({
 vi.mock('./clients/db', () => ({ notifDbWrite: () => h.readPool, notifDbRead: () => h.readPool }));
 vi.mock('./cache', () => ({
   notificationCache: {
-    getUser: (userId: number) => h.state.getUser(userId),
+    // vi.fn wrapper (delegating to the swappable state impl) so tests can assert getUser's call COUNT —
+    // e.g. that a non-cacheable variant never consults the cache. vi.clearAllMocks() clears call history
+    // but preserves this implementation, so the delegation survives across tests.
+    getUser: vi.fn((userId: number) => h.state.getUser(userId)),
     setUser: vi.fn(async () => {}),
     bustUser: vi.fn(async () => {}),
   },
@@ -249,6 +252,123 @@ describe('recent-writer (lag/primary) path under coalescing', () => {
     d.resolve(rows);
     const [r1, r2] = await Promise.all([p1, p2]);
     expect(r1).toEqual(rows); // fresh primary read, not the stale cached [System,99]
+    expect(r2).toEqual(rows);
+    expect(h.calls).toHaveLength(1);
+  });
+});
+
+// =========================================================================================================
+// The cacheability GATE. The count cache is a single per-user hash of per-category UNREAD counts, so it can
+// only represent the `unread:true`, no-category variant. countNotificationsImpl must therefore consult /
+// bust / populate the cache ONLY for that variant; every other variant (unread:false totals, or a
+// category-scoped subset) must run the DB query WITHOUT touching the cache — otherwise a stale/wrong-variant
+// hit is served, and (worse) writing an unread:false total into the hash corrupts the worker's unread
+// counters. These tests pin every branch of `cacheable = unread === true && category == null`.
+describe('cacheability gate (unread:true + no category only)', () => {
+  it('cacheable variant: consults the cache; a HIT short-circuits with no DB query', async () => {
+    const cached = [{ category: 'System', count: 5 }];
+    h.state.getUser = async () => cached;
+
+    const result = await countNotifications({ userId: 20, unread: true });
+
+    expect(result).toBe(cached);
+    expect(notificationCache.getUser).toHaveBeenCalledTimes(1); // cache WAS consulted
+    expect(notificationCache.getUser).toHaveBeenCalledWith(20);
+    expect(h.calls).toHaveLength(0); // hit → no DB query
+    expect(notificationCache.setUser).not.toHaveBeenCalled(); // nothing to populate on a hit
+  });
+
+  it('cacheable variant: a MISS runs the DB query and populates the cache via setUser', async () => {
+    h.state.getUser = async () => undefined; // miss
+    const rows = [{ category: 'Comment', count: 4 }];
+    h.state.resultImpl = async () => rows;
+
+    const result = await countNotifications({ userId: 21, unread: true });
+
+    expect(notificationCache.getUser).toHaveBeenCalledTimes(1);
+    expect(h.calls).toHaveLength(1); // DB query ran
+    expect(notificationCache.setUser).toHaveBeenCalledTimes(1);
+    expect(notificationCache.setUser).toHaveBeenCalledWith(21, rows); // populated with the fresh result
+    expect(result).toEqual(rows);
+  });
+
+  it('unread:false variant: NEVER touches the cache (no getUser/setUser/bustUser), runs DB, returns uncached', async () => {
+    // A cache value is present but MUST be ignored — an unread:false total is not what the unread hash holds.
+    h.state.getUser = async () => [{ category: 'System', count: 99 }];
+    const rows = [{ category: 'Comment', count: 8 }];
+    h.state.resultImpl = async () => rows;
+
+    const result = await countNotifications({ userId: 22, unread: false });
+
+    expect(notificationCache.getUser).not.toHaveBeenCalled();
+    expect(notificationCache.setUser).not.toHaveBeenCalled();
+    expect(notificationCache.bustUser).not.toHaveBeenCalled();
+    expect(h.calls).toHaveLength(1); // DB query ran
+    expect(result).toEqual(rows); // fresh DB result, NOT the [System,99] cache
+  });
+
+  it('category-scoped variant (unread:true + category): same cache bypass, DB runs, no populate', async () => {
+    h.state.getUser = async () => [{ category: 'System', count: 99 }]; // would be wrong subset if used
+    const rows = [{ category: 'System', count: 2 }];
+    h.state.resultImpl = async () => rows;
+
+    const result = await countNotifications({ userId: 23, unread: true, category: 'System' });
+
+    expect(notificationCache.getUser).not.toHaveBeenCalled();
+    expect(notificationCache.setUser).not.toHaveBeenCalled();
+    expect(notificationCache.bustUser).not.toHaveBeenCalled();
+    expect(h.calls).toHaveLength(1);
+    // The DB WHERE carries the category param — proves the scoped query, not the all-category hash, was used.
+    expect(h.calls[0].params).toEqual([23, 'System']);
+    expect(result).toEqual(rows);
+  });
+
+  it('recent-writer + cacheable variant: busts the cache exactly once', async () => {
+    h.state.isWritePool = true;
+    h.state.getUser = async () => [{ category: 'System', count: 99 }]; // ignored on the write-pool branch
+    const rows = [{ category: 'Comment', count: 1 }];
+    h.state.resultImpl = async () => rows;
+
+    const result = await countNotifications({ userId: 24, unread: true });
+
+    expect(notificationCache.bustUser).toHaveBeenCalledTimes(1);
+    expect(notificationCache.bustUser).toHaveBeenCalledWith(24);
+    expect(notificationCache.getUser).not.toHaveBeenCalled(); // write-pool branch skips the cache read
+    expect(h.calls).toHaveLength(1); // primary read
+    expect(result).toEqual(rows);
+  });
+
+  it('recent-writer + NON-cacheable variant: no cache interaction at all (bustUser NOT called)', async () => {
+    h.state.isWritePool = true; // recent writer, but the variant is uncacheable → still zero cache ops
+    const rows = [{ category: 'Comment', count: 6 }];
+    h.state.resultImpl = async () => rows;
+
+    const result = await countNotifications({ userId: 25, unread: false });
+
+    expect(notificationCache.bustUser).not.toHaveBeenCalled();
+    expect(notificationCache.getUser).not.toHaveBeenCalled();
+    expect(notificationCache.setUser).not.toHaveBeenCalled();
+    expect(h.calls).toHaveLength(1); // still routed to the primary via getNotifDbWithoutLag
+    expect(result).toEqual(rows);
+  });
+
+  it('single-flight still coalesces a NON-cacheable variant (gate is inside the impl, key unchanged)', async () => {
+    const d = deferred<unknown[]>();
+    h.state.resultImpl = () => d.promise;
+
+    const p1 = countNotifications({ userId: 26, unread: false });
+    const p2 = countNotifications({ userId: 26, unread: false });
+
+    await tick();
+    expect(h.calls).toHaveLength(1); // two same-key uncacheable calls collapse to ONE DB query
+    expect(p2).toBe(p1);
+    expect(countInFlight.has('26:false:all')).toBe(true);
+    expect(notificationCache.getUser).not.toHaveBeenCalled(); // still no cache interaction
+
+    const rows = [{ category: 'Comment', count: 3 }];
+    d.resolve(rows);
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toEqual(rows);
     expect(r2).toEqual(rows);
     expect(h.calls).toHaveLength(1);
   });

--- a/apps/notifications/src/lib/server/operations.ts
+++ b/apps/notifications/src/lib/server/operations.ts
@@ -157,14 +157,29 @@ async function countNotificationsImpl(input: {
 }): Promise<NotificationCategoryCount[]> {
   const { userId, unread, category } = input;
 
+  // The count cache (cache.ts) is a SINGLE per-user redis hash of per-category UNREAD counts, maintained
+  // incrementally by the worker's incrementUser (fan-out) / decrementUser (mark-read). It is keyed on
+  // `userId` ONLY — it does not distinguish the `unread` flag or a `category` filter. So it can correctly
+  // represent EXACTLY ONE variant of this query: `unread:true` with no category. For any other variant:
+  //   - `unread:false` (totals incl. read): there is no worker-maintained "total" counter, so this is
+  //     fundamentally uncacheable in this structure — and writing a total into the hash would CORRUPT the
+  //     worker's unread counters for every subsequent read.
+  //   - a `category`-scoped call: getUser returns the ALL-category hash, not the requested subset.
+  // Therefore gate the ENTIRE cache interaction (read + recent-writer bust + populate) on the cacheable
+  // variant. Non-cacheable variants touch the cache NOT AT ALL and just run the DB query uncached —
+  // getNotifDbWithoutLag still routes recent-writers to the primary, so freshness is preserved.
+  const cacheable = unread === true && category == null;
+
   // Check the lag flag BEFORE the cache — if a recent write flagged this user, bust the cache and read
-  // the primary to avoid a stale count.
+  // the primary to avoid a stale count. Only the cacheable variant interacts with the cache at all.
   const db = await getNotifDbWithoutLag(userId);
-  if (isWritePool(db)) {
-    await notificationCache.bustUser(userId);
-  } else {
-    const cached = await notificationCache.getUser(userId);
-    if (cached) return cached;
+  if (cacheable) {
+    if (isWritePool(db)) {
+      await notificationCache.bustUser(userId);
+    } else {
+      const cached = await notificationCache.getUser(userId);
+      if (cached) return cached;
+    }
   }
 
   const where: string[] = ['un."userId" = $1'];
@@ -183,7 +198,7 @@ async function countNotificationsImpl(input: {
     params
   );
   const result = await query.result();
-  await notificationCache.setUser(userId, result);
+  if (cacheable) await notificationCache.setUser(userId, result);
   return result;
 }
 


### PR DESCRIPTION
## The bug

The notification count cache (`apps/notifications/src/lib/server/cache.ts`) is a **single per-user redis hash of per-category UNREAD counts** (`system:notification-counts:{userId}`, field = category), maintained incrementally by the worker's `incrementUser` (fan-out) / `decrementUser` (mark-read). It is keyed on **`userId` only** — it does not distinguish the `unread` flag or a `category` filter.

But `countNotifications` is parameterized by **`(userId, unread, category)`**, and `countNotificationsImpl`'s cache read/write ignored both `unread` and `category`:

- An **`unread:false`** (total, incl. read) call read/wrote the **same hash** as the `unread:true` (unread-only) call → whichever ran last won, so a later cache **HIT returned the wrong variant's numbers**, AND `setUser` writing a total into the hash **corrupts the worker's unread counters** for every subsequent read (the more serious risk — it poisons the incrementally-maintained state).
- A **`category`-scoped** call got `getUser`'s ALL-category hash back, not the requested subset.

This was latent, masked only because the bell badge usually sends `unread:true` with no category.

## The fix

The hash can only correctly represent the **`unread:true`, no-category** variant — there is no worker-maintained "total" counter, so `unread:false` is fundamentally uncacheable in this structure. Gate the **entire** cache interaction on `cacheable = unread === true && category == null`:

- `getUser` (read + early return), the recent-writer `bustUser`, and `setUser` (populate) all run **only when `cacheable`**.
- Non-cacheable variants touch the cache **not at all** — they just run the DB query and return it uncached. `getNotifDbWithoutLag` still routes recent-writers to the primary, so read-your-writes freshness is preserved.
- The worker's `incrementUser`/`decrementUser` and the `cache.ts` key structure are **unchanged** — they're correct for the unread hash.
- The single-flight coalescing wrapper (#2937) is **unchanged**; the gate lives inside `countNotificationsImpl`, the coalescing key stays `userId:unread:category`.

## Caller-usage finding

The only live caller — `checkUserNotificationsHandler` → `getUserNotificationCount({ userId, unread: true })` — always passes `unread:true` with **no category**. (`getUserNotifications`'s `count` branch is not exercised by any current caller.) The `unread:false` / category variants are reachable only via the raw `/notifications/count` HTTP endpoint with an arbitrary body. So gating them to the DB is **behavior-preserving** (correctness-improving) with effectively **zero added DB load** — these variants aren't currently hot. Default gate applied; no separate per-variant counters needed.

## Tests

Extended `operations.countNotifications.test.ts` with a `cacheability gate` block covering **every branch**:

1. cacheable (`unread:true`, no category): cache consulted; HIT short-circuits (no DB); MISS → DB query + `setUser`.
2. `unread:false`: `getUser`/`setUser`/`bustUser` all **not** called; DB runs; result returned uncached (present-but-wrong cache ignored).
3. `category` set: same cache bypass; DB `WHERE` carries the category param.
4. recent-writer (`isWritePool=true`) + cacheable: `bustUser` called exactly once, no `getUser`.
5. recent-writer + non-cacheable: **no** cache interaction at all (`bustUser` not called), still primary-routed.
6. single-flight still coalesces a non-cacheable variant (gate is inside the impl; coalescing key unchanged).

Whole notifications suite green (85 tests), typecheck clean.

## Mutation check

Broke the source one mutation at a time and confirmed each turns a test **red**, then reverted:

- invert `cacheable` (cache the wrong variants) → 10 failed
- drop the `bustUser` gate (always bust) → 4 failed
- drop the `setUser` gate (always populate) → 3 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)