### PR TITLE
fix(sysredis): STEP 7 — harden feature-scoped park holes

### DIFF
--- a/src/server/events/__tests__/base-event.sysredis-soft.test.ts
+++ b/src/server/events/__tests__/base-event.sysredis-soft.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createEvent } from '~/server/events/base.event';
+
+/**
+ * STEP-7 sysRedis soft-dependency (Group A) — base.event.ts holiday-event reads.
+ *
+ * Two already-fail-open reads gained the missing `withSysReadDeadline` wrap:
+ *   - getManualAssignments (hGetAll) — on the per-request cosmetic-resolution
+ *     path (getUserTeam → getUserCosmeticId) during active events. Fail-open →
+ *     {} → the user still gets a (deterministic-random) team.
+ *   - getDiscordRoles (hGetAll) — event role-grant path. Fail-open → {} → skip
+ *     the Discord role map for the outage window.
+ *
+ * Both were try/catch fail-open on a fast DOWN but PARKED ~11min on a silent
+ * half-open. The SLOW tests are fail-on-revert: the underlying hGetAll NEVER
+ * settles, so removing the wrap would hang the call → the test would TIME OUT.
+ */
+
+const { hGetAll, hSet, mockWithSysReadDeadline, mockLogSysRedisFailOpen, mockGetAllRoles } =
+  vi.hoisted(() => ({
+    hGetAll: vi.fn(),
+    hSet: vi.fn(async () => 1),
+    mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+    mockLogSysRedisFailOpen: vi.fn(),
+    mockGetAllRoles: vi.fn(async () => [] as { name: string; id: string }[]),
+  }));
+
+vi.mock('~/server/redis/client', () => ({
+  redis: { hGet: vi.fn(), hSet: vi.fn(), del: vi.fn(), hDel: vi.fn() },
+  sysRedis: { hGetAll, hSet },
+  REDIS_KEYS: { COSMETICS: { IDS: 'cosmetics:ids' }, EVENT: { CACHE: 'event:cache' } },
+  REDIS_SUB_KEYS: {
+    EVENT: { MANUAL_ASSIGNMENTS: 'manual-assignments', DISCORD_ROLES: 'discord-roles', COSMETICS: 'cosmetics' },
+  },
+  REDIS_SYS_KEYS: { EVENT: 'sys:event' },
+  withSysReadDeadline: mockWithSysReadDeadline,
+}));
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/integrations/discord', () => ({ discord: { getAllRoles: mockGetAllRoles } }));
+
+const definition = {
+  title: 'Test Event',
+  startDate: new Date('2020-01-01'),
+  endDate: new Date('2999-01-01'),
+  teams: ['Team1', 'Team2'],
+  bankIndex: 0,
+  cosmeticName: 'Test Cosmetic',
+  badgePrefix: 'Test:',
+} as unknown as Parameters<typeof createEvent>[1];
+
+const event = createEvent('event:test' as Parameters<typeof createEvent>[0], definition);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+  hGetAll.mockResolvedValue({});
+});
+
+describe('getUserTeam → getManualAssignments — sysRedis hGetAll (fail-open, park-bounded)', () => {
+  it('happy path: honors a manual assignment; read wrapped; no fail-open log', async () => {
+    hGetAll.mockResolvedValue({ '5': 'Team2' });
+    await expect(event.getUserTeam(5)).resolves.toBe('Team2');
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: hGetAll throws → fail-open to {} → still returns a team; logSysRedisFailOpen fired', async () => {
+    hGetAll.mockRejectedValue(new Error('sysRedis connection is down'));
+    const team = await event.getUserTeam(5);
+    expect(definition.teams).toContain(team);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledWith(
+      'read-degraded',
+      'getManualAssignments',
+      expect.any(Error),
+      expect.objectContaining({ event: 'event:test' })
+    );
+  });
+
+  it('SLOW/half-open: hGetAll NEVER settles + deadline REJECTS → fail-open team (fail-on-revert)', async () => {
+    hGetAll.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+    const team = await event.getUserTeam(5);
+    expect(definition.teams).toContain(team);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledWith(
+      'read-degraded',
+      'getManualAssignments',
+      expect.any(Error),
+      expect.objectContaining({ event: 'event:test' })
+    );
+  });
+});
+
+describe('getDiscordRoles — sysRedis hGetAll (fail-open, park-bounded)', () => {
+  it('happy path: cache hit → returns roles without hitting Discord; read wrapped; no log', async () => {
+    hGetAll.mockResolvedValue({ Team1: 'role-1' });
+    await expect(event.getDiscordRoles()).resolves.toEqual({ Team1: 'role-1' });
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockGetAllRoles).not.toHaveBeenCalled();
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: hGetAll throws → fail-open {} (Discord skipped); logSysRedisFailOpen fired', async () => {
+    hGetAll.mockRejectedValue(new Error('sysRedis connection is down'));
+    await expect(event.getDiscordRoles()).resolves.toEqual({});
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockGetAllRoles).not.toHaveBeenCalled();
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledWith(
+      'read-degraded',
+      'getDiscordRoles read',
+      expect.any(Error),
+      expect.objectContaining({ event: 'event:test' })
+    );
+  });
+
+  it('SLOW/half-open: hGetAll NEVER settles + deadline REJECTS → fail-open {} (fail-on-revert)', async () => {
+    hGetAll.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+    await expect(event.getDiscordRoles()).resolves.toEqual({});
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledWith(
+      'read-degraded',
+      'getDiscordRoles read',
+      expect.any(Error),
+      expect.objectContaining({ event: 'event:test' })
+    );
+  });
+});

--- a/src/server/events/base.event.ts
+++ b/src/server/events/base.event.ts
@@ -3,7 +3,14 @@ import Rand, { PRNG } from 'rand-seed';
 import { dbWrite } from '~/server/db/client';
 import { discord } from '~/server/integrations/discord';
 import type { RedisKeyTemplateCache } from '~/server/redis/client';
-import { redis, REDIS_KEYS, REDIS_SUB_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import {
+  redis,
+  REDIS_KEYS,
+  REDIS_SUB_KEYS,
+  REDIS_SYS_KEYS,
+  sysRedis,
+  withSysReadDeadline,
+} from '~/server/redis/client';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 
 // Disable pod memory keeping for now... We might not need it.
@@ -15,8 +22,13 @@ async function getManualAssignments(event: string) {
   // shouldn't 500 every cosmetic lookup — degrade to "no manual
   // assignments" for the outage window.
   try {
-    const assignments = await sysRedis.hGetAll(
-      `${REDIS_SYS_KEYS.EVENT}:${event}:${REDIS_SUB_KEYS.EVENT.MANUAL_ASSIGNMENTS}`
+    // Wall-clock deadline: this read is on the per-request cosmetic-resolution
+    // path during active events; the try/catch only covers a fast DOWN, so a
+    // silent half-open would park it ~11min.
+    const assignments = await withSysReadDeadline(
+      sysRedis.hGetAll(
+        `${REDIS_SYS_KEYS.EVENT}:${event}:${REDIS_SUB_KEYS.EVENT.MANUAL_ASSIGNMENTS}`
+      )
     );
     // manualAssignments[event] = assignments;
     return assignments;
@@ -108,7 +120,9 @@ export function createEvent<T>(name: RedisKeyTemplateCache, definition: HolidayE
     // missing map as no-op.
     let roleCache: Record<string, string>;
     try {
-      roleCache = await sysRedis.hGetAll(cacheKey);
+      // Wall-clock deadline so a silent half-open can't park this awaited read
+      // ~11min (the try/catch only covers a fast DOWN).
+      roleCache = await withSysReadDeadline(sysRedis.hGetAll(cacheKey));
     } catch (err) {
       logSysRedisFailOpen('read-degraded', 'getDiscordRoles read', err, { event: name });
       return {} as Record<string, string>;

--- a/src/server/games/daily-challenge/__tests__/daily-challenge-utils.sysredis-soft.test.ts
+++ b/src/server/games/daily-challenge/__tests__/daily-challenge-utils.sysredis-soft.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * STEP-7 sysRedis soft-dependency (Group A) — daily-challenge.utils.getChallengeConfig.
+ *
+ * getChallengeConfig reads the packed challenge-config blob (sysRedis.packed.get)
+ * and merges it over the in-code defaults. It was already try/catch fail-open
+ * (console.error → fall through to defaults) but PARKED ~11min on a silent
+ * half-open. STEP 7 adds `withSysReadDeadline` and the structured
+ * logSysRedisFailOpen('read-degraded', 'getChallengeConfig', ...) on the
+ * fail-open branch.
+ *
+ * The SLOW test is fail-on-revert: the underlying packed.get NEVER settles, so
+ * removing the wrap would hang the call → the test would TIME OUT.
+ */
+
+const { packedGet, packedSet, mockWithSysReadDeadline, mockLogSysRedisFailOpen, findUnique } =
+  vi.hoisted(() => ({
+    packedGet: vi.fn(),
+    packedSet: vi.fn(async () => undefined),
+    mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+    mockLogSysRedisFailOpen: vi.fn(),
+    findUnique: vi.fn(async () => null),
+  }));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { packed: { get: packedGet, set: packedSet } },
+  REDIS_SYS_KEYS: { DAILY_CHALLENGE: { CONFIG: 'daily-challenge:config' } },
+  withSysReadDeadline: mockWithSysReadDeadline,
+}));
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));
+// findUnique → null so fetchJudgingConfigFromDb returns null (no secondary packed.set).
+vi.mock('~/server/db/client', () => ({ dbRead: { challengeJudge: { findUnique } }, dbWrite: {} }));
+vi.mock('~/server/db/db-lag-helpers', () => ({ getDbWithoutLag: vi.fn(async () => ({})) }));
+
+import { getChallengeConfig } from '~/server/games/daily-challenge/daily-challenge.utils';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+  packedGet.mockResolvedValue({}); // empty redis config → pure defaults
+  findUnique.mockResolvedValue(null);
+});
+
+describe('getChallengeConfig — sysRedis packed.get (fail-open to defaults, park-bounded)', () => {
+  it('happy path: merges redis config over defaults; read wrapped once; no fail-open log', async () => {
+    packedGet.mockResolvedValue({ challengeType: 'world-morph' });
+    const config = await getChallengeConfig();
+    expect(config.challengeType).toBe('world-morph');
+    // Falls back to a default for an unset field.
+    expect(config.reviewAmount).toBeDefined();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: packed.get throws → fail-open to defaults; logSysRedisFailOpen fired', async () => {
+    packedGet.mockRejectedValue(new Error('sysRedis connection is down'));
+    const config = await getChallengeConfig();
+    // Still returns the in-code defaults.
+    expect(config.reviewAmount).toBeDefined();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledWith(
+      'read-degraded',
+      'getChallengeConfig',
+      expect.any(Error)
+    );
+  });
+
+  it('SLOW/half-open: packed.get NEVER settles + deadline REJECTS → defaults (fail-on-revert)', async () => {
+    packedGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+    const config = await getChallengeConfig();
+    expect(config.reviewAmount).toBeDefined();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledWith(
+      'read-degraded',
+      'getChallengeConfig',
+      expect.any(Error)
+    );
+  });
+});

--- a/src/server/games/daily-challenge/daily-challenge.utils.ts
+++ b/src/server/games/daily-challenge/daily-challenge.utils.ts
@@ -7,7 +7,8 @@ import { parseChallengeMetadata } from '~/server/schema/challenge.schema';
 import { Flags } from '~/shared/utils/flags';
 
 import { getDbWithoutLag } from '~/server/db/db-lag-helpers';
-import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
+import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import {
   type ChallengeDetails,
   closeChallengeCollection,
@@ -97,11 +98,15 @@ export const dailyChallengeConfig: ChallengeConfig = {
 export async function getChallengeConfig() {
   let config: Partial<ChallengeConfig> = {};
   try {
-    const redisConfig = await sysRedis.packed.get<Partial<ChallengeConfig>>(
-      REDIS_SYS_KEYS.DAILY_CHALLENGE.CONFIG
+    // Wall-clock deadline so a silent sysRedis half-open can't park this read
+    // ~11min (the try/catch only covers a fast DOWN / a parse error). On timeout
+    // the deadline rejects into the catch → fall through to schema defaults.
+    const redisConfig = await withSysReadDeadline(
+      sysRedis.packed.get<Partial<ChallengeConfig>>(REDIS_SYS_KEYS.DAILY_CHALLENGE.CONFIG)
     );
     if (redisConfig) config = challengeConfigSchema.partial().parse(redisConfig);
   } catch (e) {
+    logSysRedisFailOpen('read-degraded', 'getChallengeConfig', e);
     console.error('Invalid daily challenge config in redis:', e);
   }
 

--- a/src/server/services/__tests__/content-markdown.sysredis-soft.test.ts
+++ b/src/server/services/__tests__/content-markdown.sysredis-soft.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * STEP-7 sysRedis soft-dependency (Group A) — content.service.getMarkdownContent.
+ *
+ * getMarkdownContent reads the region-warning content blob (sysRedis.hGet) on a
+ * user-facing content query. It was already wrapped in try/catch, but the catch
+ * collapses ANY read error to a 404 (`throwNotFoundError`) — so on a fast DOWN
+ * it already fails to 404. The park hole was the SLOW/half-open case: the awaited
+ * hGet would park ~11min before the OS keepalive errored the socket. STEP 7 adds
+ * `withSysReadDeadline` to BOUND that park — the fail direction is UNCHANGED
+ * (still 404), the SLOW case now rejects at the deadline and 404s in ~2s.
+ *
+ * The SLOW test is fail-on-revert: the underlying hGet NEVER settles, so removing
+ * the wrap would hang the call → the test would TIME OUT.
+ */
+
+const { hGet, hSet, mockWithSysReadDeadline } = vi.hoisted(() => ({
+  hGet: vi.fn(),
+  hSet: vi.fn(async () => 1),
+  mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { hGet, hSet },
+  REDIS_SYS_KEYS: { CONTENT: { REGION_WARNING: 'content:region-warning' } },
+  withSysReadDeadline: mockWithSysReadDeadline,
+}));
+
+import { getMarkdownContent } from '~/server/services/content.service';
+
+const VALID = `---
+title: Region Warning
+description: A warning
+---
+Body text here.`;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+  hGet.mockResolvedValue(VALID);
+});
+
+describe('getMarkdownContent — sysRedis read (park-bounded, fail direction unchanged)', () => {
+  it('happy path: returns parsed frontmatter + markdown; read went through withSysReadDeadline', async () => {
+    const result = await getMarkdownContent({ key: 'us' });
+    expect(result.title).toBe('Region Warning');
+    expect(result.description).toBe('A warning');
+    expect(result.content.trim()).toBe('Body text here.');
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+  });
+
+  it('genuine not-found (key unset → hGet null): throws NOT_FOUND (behavior preserved)', async () => {
+    hGet.mockResolvedValue(null);
+    await expect(getMarkdownContent({ key: 'us' })).rejects.toThrow();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+  });
+
+  it('DOWN: hGet throws → caught → 404 (throwNotFoundError), never hangs', async () => {
+    hGet.mockRejectedValue(new Error('sysRedis connection is down'));
+    await expect(getMarkdownContent({ key: 'us' })).rejects.toThrow();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+  });
+
+  it('SLOW/half-open: hGet NEVER settles + deadline REJECTS → 404 (fail-on-revert)', async () => {
+    hGet.mockReturnValue(new Promise(() => undefined)); // never settles
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+    // Without the wrap the bare `await sysRedis.hGet` would hang and this test
+    // would TIME OUT. With the wrap the deadline rejects → caught → 404.
+    await expect(getMarkdownContent({ key: 'us' })).rejects.toThrow();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/__tests__/daily-challenge-service.sysredis-soft.test.ts
+++ b/src/server/services/__tests__/daily-challenge-service.sysredis-soft.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * STEP-7 sysRedis soft-dependency (Group A) — daily-challenge.service.getCustomChallenge.
+ *
+ * getCustomChallenge is a RAW read (sysRedis.get, no try/catch) feeding the
+ * still-live getCurrentDailyChallenge query. STEP 7 wraps it in try/catch +
+ * withSysReadDeadline and fails OPEN to `null` ("no custom challenge" → the
+ * regular challenge is shown). A sysRedis outage shouldn't 500 the challenge
+ * view; and the awaited get would otherwise park ~11min on a silent half-open.
+ *
+ * The SLOW test is fail-on-revert: the underlying get NEVER settles, so removing
+ * the wrap would hang the call → the test would TIME OUT.
+ */
+
+const { get, mockWithSysReadDeadline, mockLogSysRedisFailOpen } = vi.hoisted(() => ({
+  get: vi.fn(),
+  mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  mockLogSysRedisFailOpen: vi.fn(),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { get },
+  REDIS_SYS_KEYS: { GENERATION: { CUSTOM_CHALLENGE: 'generation:custom-challenge' } },
+  withSysReadDeadline: mockWithSysReadDeadline,
+}));
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));
+vi.mock('~/server/db/client', () => ({ dbRead: {} }));
+// Heavy sibling modules pulled in by the service's import graph — stub so the
+// import doesn't pull DB / article service.
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getCurrentChallenge: vi.fn(),
+  dailyChallengeConfig: {},
+}));
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({ getChallengeById: vi.fn() }));
+vi.mock('~/server/services/article.service', () => ({ getArticles: vi.fn() }));
+
+import { getCustomChallenge } from '~/server/services/daily-challenge.service';
+
+const VALID = JSON.stringify({
+  articleId: 1,
+  endsAtDate: '2999-01-01',
+  collectionId: 2,
+  title: 'Custom',
+  invitation: 'Join',
+  coverUrl: 'guid',
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+  get.mockResolvedValue(VALID);
+});
+
+describe('getCustomChallenge — sysRedis get (RAW → fail-open null, park-bounded)', () => {
+  it('happy path: parses + returns the challenge; read wrapped once; no fail-open log', async () => {
+    const result = await getCustomChallenge();
+    expect(result?.title).toBe('Custom');
+    expect(result?.collectionId).toBe(2);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('unset key (get → null): returns null (behavior preserved), no fail-open log', async () => {
+    get.mockResolvedValue(null);
+    await expect(getCustomChallenge()).resolves.toBeNull();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: get throws → fail-open to null; logSysRedisFailOpen fired', async () => {
+    get.mockRejectedValue(new Error('sysRedis connection is down'));
+    await expect(getCustomChallenge()).resolves.toBeNull();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledWith(
+      'read-degraded',
+      'getCustomChallenge',
+      expect.any(Error)
+    );
+  });
+
+  it('SLOW/half-open: get NEVER settles + deadline REJECTS → null (fail-on-revert)', async () => {
+    get.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+    await expect(getCustomChallenge()).resolves.toBeNull();
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledWith(
+      'read-degraded',
+      'getCustomChallenge',
+      expect.any(Error)
+    );
+  });
+});

--- a/src/server/services/__tests__/training-status.sysredis-soft.test.ts
+++ b/src/server/services/__tests__/training-status.sysredis-soft.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as z from 'zod';
+
+/**
+ * STEP-7 sysRedis soft-dependency (Group A) — training.service.getTrainingServiceStatus.
+ *
+ * Symmetric with the getGenerationStatus wrap from STEP 6. The status read
+ * (sysRedis.hGet of SYSTEM.FEATURES) was already try/catch fail-open (logs
+ * 'defaults-firing', falls back to the schema '{}' default = available:true) but
+ * PARKED ~11min on a silent half-open. STEP 7 adds `withSysReadDeadline` to
+ * bound that park — the fail direction is unchanged (already fail-open).
+ *
+ * The SLOW test is fail-on-revert: the underlying hGet NEVER settles, so
+ * removing the wrap would hang the call → the test would TIME OUT.
+ *
+ * The heavy training.service import graph (@aws-sdk, @civitai/client,
+ * orchestrator caller, s3) + the client-coupled training.schema are stubbed;
+ * trainingServiceStatusSchema is replaced with an equivalent local zod schema so
+ * the parse still exercises the real default (available:true).
+ */
+
+const { hGet, mockWithSysReadDeadline, mockLogSysRedisFailOpen } = vi.hoisted(() => ({
+  hGet: vi.fn(),
+  mockWithSysReadDeadline: vi.fn<(p: Promise<unknown>) => Promise<unknown>>(),
+  mockLogSysRedisFailOpen: vi.fn(),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: { hGet },
+  REDIS_SYS_KEYS: { SYSTEM: { FEATURES: 'system:features' }, TRAINING: { STATUS: 'training:status' } },
+  withSysReadDeadline: mockWithSysReadDeadline,
+}));
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSysRedisFailOpen }));
+
+// Replace the client-coupled schema module with an equivalent local schema so
+// getTrainingServiceStatus' safeParse/parse still exercises the real defaulting
+// (available:true) without pulling ~/components / ~/store into the node graph.
+vi.mock('~/server/schema/training.schema', () => ({
+  trainingServiceStatusSchema: z.object({
+    available: z.boolean().default(true),
+    message: z.string().nullish(),
+    blockedModels: z.array(z.string()).optional().default([]),
+  }),
+}));
+
+// Heavy import-graph deps — trivial stubs so the module imports in node.
+vi.mock('@aws-sdk/lib-storage', () => ({ Upload: class {} }));
+vi.mock('@civitai/client', () => ({}));
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/db/db-lag-helpers', () => ({ preventModelVersionLag: vi.fn() }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+vi.mock('~/server/redis/caches', () => ({ dataForModelsCache: {} }));
+vi.mock('~/server/services/orchestrator/client', () => ({ internalOrchestratorClient: {} }));
+vi.mock('~/utils/s3-utils', () => ({ getS3Client: vi.fn(), deleteObject: vi.fn() }));
+vi.mock('~/server/http/orchestrator/orchestrator.caller', () => ({ getOrchestratorCaller: vi.fn() }));
+
+import { getTrainingServiceStatus } from '~/server/services/training.service';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWithSysReadDeadline.mockImplementation((p) => p); // transparent by default
+  hGet.mockResolvedValue('{}');
+});
+
+describe('getTrainingServiceStatus — sysRedis hGet (fail-open to defaults, park-bounded)', () => {
+  it('happy path: honors the stored status; read wrapped once; no fail-open log', async () => {
+    hGet.mockResolvedValue(JSON.stringify({ available: false, message: 'paused' }));
+    const status = await getTrainingServiceStatus();
+    expect(status.available).toBe(false);
+    expect(status.message).toBe('paused');
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).not.toHaveBeenCalled();
+  });
+
+  it('DOWN: hGet throws → fail-open to schema default (available:true); logSysRedisFailOpen fired', async () => {
+    hGet.mockRejectedValue(new Error('sysRedis connection is down'));
+    const status = await getTrainingServiceStatus();
+    expect(status.available).toBe(true);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledWith(
+      'defaults-firing',
+      'getTrainingServiceStatus',
+      expect.any(Error)
+    );
+  });
+
+  it('SLOW/half-open: hGet NEVER settles + deadline REJECTS → defaults (fail-on-revert)', async () => {
+    hGet.mockReturnValue(new Promise(() => undefined));
+    mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
+    const status = await getTrainingServiceStatus();
+    expect(status.available).toBe(true);
+    expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
+    expect(mockLogSysRedisFailOpen).toHaveBeenCalledWith(
+      'defaults-firing',
+      'getTrainingServiceStatus',
+      expect.any(Error)
+    );
+  });
+});

--- a/src/server/services/content.service.ts
+++ b/src/server/services/content.service.ts
@@ -3,7 +3,7 @@ import { readFile } from 'fs/promises';
 import { access } from 'fs/promises';
 import matter from 'gray-matter';
 import { join, resolve } from 'path';
-import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
+import { sysRedis, REDIS_SYS_KEYS, withSysReadDeadline } from '~/server/redis/client';
 import { throwBadRequestError, throwNotFoundError } from '~/server/utils/errorHandling';
 import type { Context } from '~/server/createContext';
 
@@ -168,7 +168,13 @@ export async function getTosMeta({
 
 export async function getMarkdownContent({ key }: { key: string }) {
   try {
-    const content = await sysRedis.hGet(REDIS_SYS_KEYS.CONTENT.REGION_WARNING, key);
+    // Wall-clock deadline: bounds a silent sysRedis half-open (this awaited hGet
+    // would otherwise park ~11min on the region-warning content query). The fail
+    // direction is UNCHANGED — a timeout rejects into the catch below, which
+    // already collapses any read error to a 404 (same as a fast DOWN).
+    const content = await withSysReadDeadline(
+      sysRedis.hGet(REDIS_SYS_KEYS.CONTENT.REGION_WARNING, key)
+    );
     if (!content) throw throwNotFoundError('Content not found');
 
     const { data: frontmatter, content: markdown } = matter(content);

--- a/src/server/services/daily-challenge.service.ts
+++ b/src/server/services/daily-challenge.service.ts
@@ -12,7 +12,8 @@ import {
 import { articleWhereSchema } from '~/server/schema/article.schema';
 import { getArticles } from '~/server/services/article.service';
 import { throwNotFoundError } from '~/server/utils/errorHandling';
-import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
+import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import { ChallengeStatus } from '~/shared/utils/prisma/enums';
 import * as z from 'zod';
 import { isFutureDate, startOfDay } from '~/utils/date-helpers';
@@ -116,7 +117,18 @@ const customChallengeSchema = z.object({
 });
 
 export async function getCustomChallenge() {
-  const data = await sysRedis.get(REDIS_SYS_KEYS.GENERATION.CUSTOM_CHALLENGE);
+  // Fail-open read: this feeds the (deprecated but still live) getCurrentDailyChallenge
+  // query. A sysRedis outage shouldn't 500 the challenge view — degrade to "no
+  // custom challenge" (null) so the regular challenge is shown. Wall-clock deadline
+  // bounds a silent half-open (this awaited get would otherwise park ~11min); on
+  // DOWN or timeout we fail open to null.
+  let data: string | null;
+  try {
+    data = await withSysReadDeadline(sysRedis.get(REDIS_SYS_KEYS.GENERATION.CUSTOM_CHALLENGE));
+  } catch (err) {
+    logSysRedisFailOpen('read-degraded', 'getCustomChallenge', err);
+    return null;
+  }
   if (!data) return null;
   const challenge = customChallengeSchema.parse(JSON.parse(data));
   const date = new Date(challenge.endsAtDate).toISOString().split('T')[0];

--- a/src/server/services/training.service.ts
+++ b/src/server/services/training.service.ts
@@ -21,7 +21,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { preventModelVersionLag } from '~/server/db/db-lag-helpers';
 import { logToAxiom } from '~/server/logging/client';
 import { dataForModelsCache } from '~/server/redis/caches';
-import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import type { TrainingResultsV2 } from '~/server/schema/model-file.schema';
 import type { TrainingDetailsObj } from '~/server/schema/model-version.schema';
@@ -271,7 +271,12 @@ export async function getTrainingServiceStatus() {
   // touched the sites that did string-typed ops (=== 'true', .split, etc.).
   let raw: string | null | undefined;
   try {
-    raw = await sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, REDIS_SYS_KEYS.TRAINING.STATUS);
+    // Wall-clock deadline: symmetric with the getGenerationStatus wrap in STEP 6.
+    // The try/catch only covers a fast DOWN reject — a silent sysRedis half-open
+    // would park this awaited hGet ~11min on the training status/submit path.
+    raw = await withSysReadDeadline(
+      sysRedis.hGet(REDIS_SYS_KEYS.SYSTEM.FEATURES, REDIS_SYS_KEYS.TRAINING.STATUS)
+    );
   } catch (err) {
     logSysRedisFailOpen('defaults-firing', 'getTrainingServiceStatus', err);
     raw = undefined;


### PR DESCRIPTION
## The mechanic

`sysRedis` (the Sentinel client, `socketTimeout:0`) rejects **FAST on DOWN** but **PARKS ~11min on a silent SLOW/half-open** unless the awaited read is wrapped in `withSysReadDeadline(...)` (a ~2s race that rejects; default `REDIS_SYS_READ_TIMEOUT_MS=2000`). A read is only fully soft when **BOTH** try/catch'd **AND** deadline-wrapped. This PR closes the feature-scoped park holes the prior five sysRedis PRs (#2921/#2922/#2934/#2938/#2939) left.

## Group A — hardened here (the safe set)

Each site either was already fail-open (fail direction pre-decided) or keeps its existing fail direction; the wrap only bounds the ~11min park. Fail-open degrades exactly one feature — no money-cap bypass, no moderation bypass, no fail-closed→fail-open flip.

| Site | Class | Change |
|---|---|---|
| `training.service.getTrainingServiceStatus` | READ | TRYCATCH-ONLY (defaults-firing, symmetric w/ STEP 6 getGenerationStatus) → add wrap |
| `content.service.getMarkdownContent` | READ | catch already collapses any error → 404; add wrap (fail direction UNCHANGED, park bounded) |
| `events/base.event.getManualAssignments` | READ | TRYCATCH-ONLY fail-open `{}` (per-request cosmetic path) → add wrap |
| `events/base.event.getDiscordRoles` | READ | TRYCATCH-ONLY fail-open `{}` → add wrap |
| `daily-challenge.utils.getChallengeConfig` | READ | TRYCATCH-ONLY fail-open to defaults (console.error) → add wrap + structured `logSysRedisFailOpen` |
| `daily-challenge.service.getCustomChallenge` | READ | RAW → add try/catch + wrap + log, fail-open to `null` |

**Tests** (co-located `__tests__/`, 20 cases, 5 files): happy + DOWN + SLOW per read. SLOW cases are **fail-on-revert** (never-settling underlying mock → removing the wrap hangs → timeout) and assert `withSysReadDeadline` was called + `logSysRedisFailOpen` fired.

## Deferred — Group B (fail-direction is a human money/moderation judgment)

Not touched — each needs a human decision on whether infra outage should fail open or closed:

- **Money caps** (currently fail-CLOSED): `blocks.router.reserveBlockBuzzSpend` (per-user daily Buzz cap), `app-bounty-cap.reserveAppBountyAccrual`, `buzz-withdrawal-request` controller `maxAmount` limit + its `getServiceStatus`.
- **Earnings gate**: `creator-program.getFlippedPhaseStatus` (banking-phase gate).
- **Moderation / safety**: `moderation-utils` word/url lists, `image.service.isImageScannerNewEnabled` (scanner-select, also writes on read), `nsfwLevels.updateModelVersionNsfwLevels` kill-switch, `system-cache.getCreationBlockedTagsRaw` (intentionally fail-closed to avoid wiping the list), the **New Order** moderation game (`new-order.service` / `new-order/utils` — money + moderation, many per-vote reads), `research.router.getSanityIds` (rater sanity gate).

## Deferred — Group C (job/cron/admin/webhook — a park delays a worker, not a user request)

`scanner-policies.service` (~20 sites), `model.metrics`, `meilisearch/util` content-removal drain, `update-user-score`, `entity-moderation`, `cache-cleanup`, `audit-remix-sources`, `user-restriction.router` mod reads, `retool-endpoint` rate-limit ttl, `events/index` getDiscordRoles caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)