### PR TITLE
feat(faro): privacy-safe Resource Timing decomposition for RUM

### DIFF
--- a/src/components/Faro/FaroProvider.tsx
+++ b/src/components/Faro/FaroProvider.tsx
@@ -13,6 +13,7 @@ import { env } from '~/env/client';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { deepRedact } from '~/utils/faro/redact';
 import { resolveFaroSampling } from '~/utils/faro/traceSampler';
+import { ResourceTimingInstrumentation } from './ResourceTimingInstrumentation';
 import { SampledTracingInstrumentation } from './SampledTracingInstrumentation';
 
 /**
@@ -31,10 +32,17 @@ import { SampledTracingInstrumentation } from './SampledTracingInstrumentation';
  * `faro.civitai.com` ingress (infra kill-switch).
  *
  * Instrumentations (EXPLICIT allow-list — NOT the getWebInstrumentations() default set):
- * errors, web-vitals, session (required for sampling), view, navigation, tracing.
- * DELIBERATELY EXCLUDED for privacy on this adult/payments platform: Performance
- * (emits full resource URLs), UserAction (captures element datasets), CSP, and Console
- * (serialises arbitrary logged objects). NO session replay.
+ * errors, web-vitals, session (required for sampling), view, navigation, tracing, and —
+ * behind its own dark build-arg — a privacy-safe Resource Timing decomposition.
+ * DELIBERATELY EXCLUDED for privacy on this adult/payments platform: the stock Performance
+ * instrumentation (emits full resource URLs), UserAction (captures element datasets), CSP,
+ * and Console (serialises arbitrary logged objects). NO session replay.
+ *
+ * The Resource Timing decomposition (`ResourceTimingInstrumentation`, gated on
+ * `NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED`, default OFF) is the ONE resource-timing surface
+ * we allow: unlike stock Performance it normalizes every URL to a coarse route BEFORE emit
+ * (no URL/query ever leaves the browser), scopes to same-origin `/api` only, and is
+ * volume-gated independently of trace sampling. See ResourceTimingInstrumentation.
  *
  * SAMPLING (two decoupled layers):
  *   - SESSION sampling (`NEXT_PUBLIC_FARO_SESSION_SAMPLE_RATE`, 1.0) gates ALL signals →
@@ -170,6 +178,15 @@ function initFaro() {
           propagateTraceHeaderCorsUrls: [sameOriginApiMatcher()],
         },
       }),
+      // Resource Timing phase decomposition (DNS/TCP/TLS/TTFB/download) for same-origin
+      // `/api` requests, emitted as custom measurements. This is NOT the stock
+      // PerformanceInstrumentation (which stays excluded — it emits full URLs); it
+      // normalizes every URL to a coarse route BEFORE emit and is volume-gated
+      // independently of trace sampling. Ships DARK behind its own build-arg so it can be
+      // ramped separately from the main RUM flag — see ResourceTimingInstrumentation.
+      ...(env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED
+        ? [new ResourceTimingInstrumentation()]
+        : []),
     ],
     // Defensive outer wrapper: scrubBeacon already fails closed, but guarantee that any
     // unexpected throw still drops the beacon (null) rather than emitting it unscrubbed.

--- a/src/components/Faro/FaroProvider.tsx
+++ b/src/components/Faro/FaroProvider.tsx
@@ -12,6 +12,7 @@ import {
 import { env } from '~/env/client';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { deepRedact } from '~/utils/faro/redact';
+import { resolveResourceTimingConfig } from '~/utils/faro/resourceTiming';
 import { resolveFaroSampling } from '~/utils/faro/traceSampler';
 import { ResourceTimingInstrumentation } from './ResourceTimingInstrumentation';
 import { SampledTracingInstrumentation } from './SampledTracingInstrumentation';
@@ -183,9 +184,19 @@ function initFaro() {
       // PerformanceInstrumentation (which stays excluded — it emits full URLs); it
       // normalizes every URL to a coarse route BEFORE emit and is volume-gated
       // independently of trace sampling. Ships DARK behind its own build-arg so it can be
-      // ramped separately from the main RUM flag — see ResourceTimingInstrumentation.
+      // ramped separately from the main RUM flag. The volume knobs (sample rate + per-client
+      // cap) are env-tunable so the ramp is dial-able WITHOUT a rebuild — resolved here with a
+      // safe fallback to the defaults (sample rate 0.05 keeps the shared faro-rum Loki stream
+      // under its 10 MB/s ceiling at 100k concurrent). See ResourceTimingInstrumentation.
       ...(env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED
-        ? [new ResourceTimingInstrumentation()]
+        ? [
+            new ResourceTimingInstrumentation(
+              resolveResourceTimingConfig(
+                env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_SAMPLE_RATE,
+                env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_MAX_PER_WINDOW
+              )
+            ),
+          ]
         : []),
     ],
     // Defensive outer wrapper: scrubBeacon already fails closed, but guarantee that any

--- a/src/components/Faro/ResourceTimingInstrumentation.ts
+++ b/src/components/Faro/ResourceTimingInstrumentation.ts
@@ -3,6 +3,7 @@ import {
   buildResourceMeasurement,
   createRateLimiter,
   type RateLimiter,
+  RESOURCE_TIMING_DEFAULTS,
   type ResourceTimingLike,
 } from '~/utils/faro/resourceTiming';
 
@@ -23,6 +24,13 @@ import {
  * rate limiter (sampling fraction + hard cap per rolling window), INDEPENDENT of trace/session
  * sampling. Ships behind `NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED` (default OFF) so it can be
  * ramped separately from the main RUM flag.
+ *
+ * The default `sampleRate` is 0.05 (not 0.25) to keep the aggregate under Loki's 10 MB/s
+ * per-stream ceiling on the shared `source="faro-rum"` stream at civitai's 100k-concurrent
+ * target — see `RESOURCE_TIMING_DEFAULTS`. Both `sampleRate` and `maxPerWindow` are
+ * DEPLOY-TUNABLE via env (`NEXT_PUBLIC_FARO_RESOURCE_TIMING_SAMPLE_RATE` /
+ * `..._MAX_PER_WINDOW`, resolved in FaroProvider) so the ramp can be dialed without a rebuild;
+ * the constructor options remain the override path that keeps this core unit-testable.
  */
 
 export interface ResourceTimingInstrumentationOptions {
@@ -30,7 +38,7 @@ export interface ResourceTimingInstrumentationOptions {
   maxPerWindow?: number;
   /** Rolling window length in ms. Default 15000. */
   windowMs?: number;
-  /** Per-candidate sampling fraction in [0, 1]. Default 0.25. */
+  /** Per-candidate sampling fraction in [0, 1]. Default 0.05 (Loki per-stream ceiling). */
   sampleRate?: number;
   /** Injectable RNG — for tests. */
   random?: () => number;
@@ -38,7 +46,7 @@ export interface ResourceTimingInstrumentationOptions {
   now?: () => number;
 }
 
-const DEFAULTS = { maxPerWindow: 8, windowMs: 15000, sampleRate: 0.25 } as const;
+const DEFAULTS = RESOURCE_TIMING_DEFAULTS;
 
 export class ResourceTimingInstrumentation extends BaseInstrumentation {
   readonly name = '@civitai/faro-instrumentation-resource-timing';

--- a/src/components/Faro/ResourceTimingInstrumentation.ts
+++ b/src/components/Faro/ResourceTimingInstrumentation.ts
@@ -1,0 +1,107 @@
+import { BaseInstrumentation } from '@grafana/faro-web-sdk';
+import {
+  buildResourceMeasurement,
+  createRateLimiter,
+  type RateLimiter,
+  type ResourceTimingLike,
+} from '~/utils/faro/resourceTiming';
+
+/**
+ * Faro instrumentation that decomposes same-origin `/api` `PerformanceResourceTiming`
+ * entries into phase durations (DNS / TCP-connect / TLS / TTFB / download) and emits them as
+ * custom Faro measurements (`type: 'resource_timing'`). It un-black-boxes the ~259ms
+ * "network" slice of user-perceived `/api` latency that trace stitching attributed to
+ * browser↔Cloudflare↔origin rather than the backend handler.
+ *
+ * 🔴 PRIVACY: this is the ONLY resource-timing surface we allow — the stock Faro
+ * `PerformanceInstrumentation` stays disabled because it emits full resource URLs. All URL
+ * normalization + same-origin/`/api` filtering happens in `~/utils/faro/resourceTiming`
+ * BEFORE emit; the payload carries only numeric phase values + a low-cardinality
+ * `{ route, protocol }` context. No URL/query ever leaves the browser. See that module.
+ *
+ * VOLUME: Resource Timing fires for every subresource, so emissions are gated by a per-client
+ * rate limiter (sampling fraction + hard cap per rolling window), INDEPENDENT of trace/session
+ * sampling. Ships behind `NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED` (default OFF) so it can be
+ * ramped separately from the main RUM flag.
+ */
+
+export interface ResourceTimingInstrumentationOptions {
+  /** Max emissions per rolling window (hard per-client cap). Default 8. */
+  maxPerWindow?: number;
+  /** Rolling window length in ms. Default 15000. */
+  windowMs?: number;
+  /** Per-candidate sampling fraction in [0, 1]. Default 0.25. */
+  sampleRate?: number;
+  /** Injectable RNG — for tests. */
+  random?: () => number;
+  /** Injectable clock — for tests. */
+  now?: () => number;
+}
+
+const DEFAULTS = { maxPerWindow: 8, windowMs: 15000, sampleRate: 0.25 } as const;
+
+export class ResourceTimingInstrumentation extends BaseInstrumentation {
+  readonly name = '@civitai/faro-instrumentation-resource-timing';
+  readonly version = '1.0.0';
+
+  private readonly options: ResourceTimingInstrumentationOptions;
+  private observer: PerformanceObserver | undefined;
+  private limiter: RateLimiter | undefined;
+  private origin = '';
+
+  constructor(options: ResourceTimingInstrumentationOptions = {}) {
+    super();
+    this.options = options;
+  }
+
+  initialize(): void {
+    if (typeof window === 'undefined' || typeof PerformanceObserver === 'undefined') return;
+
+    this.origin = window.location.origin;
+    this.limiter = createRateLimiter({
+      maxPerWindow: this.options.maxPerWindow ?? DEFAULTS.maxPerWindow,
+      windowMs: this.options.windowMs ?? DEFAULTS.windowMs,
+      sampleRate: this.options.sampleRate ?? DEFAULTS.sampleRate,
+      random: this.options.random,
+      now: this.options.now,
+    });
+
+    try {
+      this.observer = new PerformanceObserver((list) => {
+        this.handleEntries(list.getEntries() as unknown as ResourceTimingLike[]);
+      });
+      // `buffered: true` also drains resource entries recorded before the observer was wired
+      // (the SDK boots after some initial `/api` calls have already fired).
+      this.observer.observe({ type: 'resource', buffered: true });
+    } catch {
+      // PerformanceObserver unsupported / entryType rejected — degrade to no-op.
+      this.observer = undefined;
+    }
+  }
+
+  destroy(): void {
+    try {
+      this.observer?.disconnect();
+    } catch {
+      // ignore
+    }
+    this.observer = undefined;
+  }
+
+  private handleEntries(entries: ResourceTimingLike[]): void {
+    if (!this.limiter) return;
+    for (const entry of entries) {
+      try {
+        const measurement = buildResourceMeasurement(entry, this.origin);
+        if (!measurement) continue; // not a same-origin /api fetch/xhr resource
+        if (!this.limiter.allow()) continue; // volume gate
+        this.api.pushMeasurement(
+          { type: measurement.type, values: measurement.values },
+          { context: measurement.context }
+        );
+      } catch {
+        // Never let RUM instrumentation break the page.
+      }
+    }
+  }
+}

--- a/src/components/Faro/__tests__/ResourceTimingInstrumentation.test.ts
+++ b/src/components/Faro/__tests__/ResourceTimingInstrumentation.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ResourceTimingInstrumentation } from '../ResourceTimingInstrumentation';
+import type { ResourceTimingLike } from '~/utils/faro/resourceTiming';
+
+/**
+ * Wiring test for `ResourceTimingInstrumentation`: with a fake `PerformanceObserver` +
+ * `window` + Faro api, assert it observes `resource` (buffered), filters to same-origin
+ * `/api` fetch/xhr, emits the privacy-safe measurement shape, and honours the volume gate.
+ * The phase math / route normalization / privacy scrub are covered exhaustively in
+ * `~/utils/faro/__tests__/resourceTiming.test.ts`; this covers the SDK plumbing.
+ */
+
+const ORIGIN = 'https://civitai.com';
+
+type ObserverInit = { type: string; buffered?: boolean };
+let observerCallback: ((list: { getEntries: () => unknown[] }) => void) | undefined;
+let observeArgs: ObserverInit | undefined;
+
+class FakePerformanceObserver {
+  constructor(cb: (list: { getEntries: () => unknown[] }) => void) {
+    observerCallback = cb;
+  }
+  observe(init: ObserverInit) {
+    observeArgs = init;
+  }
+  disconnect() {
+    // no-op
+  }
+}
+
+function emitEntries(entries: ResourceTimingLike[]) {
+  observerCallback?.({ getEntries: () => entries });
+}
+
+function apiEntry(overrides: Partial<ResourceTimingLike> = {}): ResourceTimingLike {
+  return {
+    name: `${ORIGIN}/api/trpc/model.getById?batch=1`,
+    initiatorType: 'fetch',
+    nextHopProtocol: 'h2',
+    domainLookupStart: 10,
+    domainLookupEnd: 25,
+    connectStart: 25,
+    secureConnectionStart: 40,
+    connectEnd: 60,
+    requestStart: 60,
+    responseStart: 210,
+    responseEnd: 260,
+    duration: 250,
+    ...overrides,
+  };
+}
+
+/** Attach a mock Faro api + deterministic gate to an instrumentation instance. */
+function makeInstrumentation(pushMeasurement: ReturnType<typeof vi.fn>) {
+  const inst = new ResourceTimingInstrumentation({
+    maxPerWindow: 2,
+    windowMs: 1000,
+    sampleRate: 1, // no sampling in the plumbing test — assert exact emissions
+    now: () => 0,
+  });
+  (inst as unknown as { api: { pushMeasurement: unknown } }).api = { pushMeasurement };
+  return inst;
+}
+
+describe('ResourceTimingInstrumentation', () => {
+  beforeEach(() => {
+    observerCallback = undefined;
+    observeArgs = undefined;
+    (globalThis as unknown as { window: unknown }).window = { location: { origin: ORIGIN } };
+    (globalThis as unknown as { PerformanceObserver: unknown }).PerformanceObserver =
+      FakePerformanceObserver;
+  });
+
+  afterEach(() => {
+    delete (globalThis as unknown as { window?: unknown }).window;
+    delete (globalThis as unknown as { PerformanceObserver?: unknown }).PerformanceObserver;
+  });
+
+  it('observes the resource entry type with buffered:true', () => {
+    makeInstrumentation(vi.fn()).initialize();
+    expect(observeArgs).toEqual({ type: 'resource', buffered: true });
+  });
+
+  it('emits one privacy-safe measurement per same-origin /api entry', () => {
+    const push = vi.fn();
+    makeInstrumentation(push).initialize();
+
+    emitEntries([apiEntry()]);
+
+    expect(push).toHaveBeenCalledTimes(1);
+    const [payload, options] = push.mock.calls[0];
+    expect(payload.type).toBe('resource_timing');
+    expect(payload.values.rt_ttfb).toBe(150);
+    expect(payload.values.rt_dns).toBe(15);
+    expect(options.context).toEqual({ route: '/api/trpc', protocol: 'h2' });
+    // No URL/query anywhere in what we emit.
+    expect(JSON.stringify(push.mock.calls[0])).not.toContain('model.getById');
+    expect(JSON.stringify(push.mock.calls[0])).not.toContain('batch=1');
+  });
+
+  it('ignores third-party and non-/api resources (no emission)', () => {
+    const push = vi.fn();
+    makeInstrumentation(push).initialize();
+
+    emitEntries([
+      apiEntry({ name: 'https://api.stripe.com/v1/charges', initiatorType: 'fetch' }),
+      apiEntry({ name: `${ORIGIN}/models/123`, initiatorType: 'fetch' }),
+      apiEntry({ name: `${ORIGIN}/api/trpc/x`, initiatorType: 'img' }),
+    ]);
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('applies the per-window volume cap across a burst', () => {
+    const push = vi.fn();
+    makeInstrumentation(push).initialize(); // maxPerWindow: 2, frozen clock
+
+    emitEntries([apiEntry(), apiEntry(), apiEntry(), apiEntry()]);
+
+    expect(push).toHaveBeenCalledTimes(2);
+  });
+
+  it('never throws if the api push fails (RUM must not break the page)', () => {
+    const push = vi.fn(() => {
+      throw new Error('transport down');
+    });
+    makeInstrumentation(push).initialize();
+    expect(() => emitEntries([apiEntry()])).not.toThrow();
+  });
+
+  it('is a no-op when PerformanceObserver is unavailable', () => {
+    delete (globalThis as unknown as { PerformanceObserver?: unknown }).PerformanceObserver;
+    const push = vi.fn();
+    // Should not throw during initialize; nothing to observe.
+    expect(() => makeInstrumentation(push).initialize()).not.toThrow();
+  });
+});

--- a/src/env/client-schema.ts
+++ b/src/env/client-schema.ts
@@ -54,6 +54,11 @@ export const clientSchema = z.object({
   NEXT_PUBLIC_FARO_TRACES_SAMPLE_RATE: z.string().default('0.1'),
   // Session sampling ratio — gates ALL Faro signals (errors/web-vitals/events/sessions).
   NEXT_PUBLIC_FARO_SESSION_SAMPLE_RATE: z.string().default('1.0'),
+  // Resource Timing decomposition (DNS/TCP/TLS/TTFB/download splits for same-origin `/api`
+  // requests, emitted as custom Faro measurements). Ships DARK — default OFF — so it can be
+  // ramped INDEPENDENTLY of the main RUM flag once volume is confirmed on a small cohort.
+  // Only takes effect when NEXT_PUBLIC_FARO_ENABLED + the `faro` flag are also on.
+  NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED: z.stringbool().default(false),
 });
 
 /**
@@ -99,4 +104,5 @@ export const clientEnv = {
   NEXT_PUBLIC_FARO_COLLECTOR_URL: process.env.NEXT_PUBLIC_FARO_COLLECTOR_URL,
   NEXT_PUBLIC_FARO_TRACES_SAMPLE_RATE: process.env.NEXT_PUBLIC_FARO_TRACES_SAMPLE_RATE,
   NEXT_PUBLIC_FARO_SESSION_SAMPLE_RATE: process.env.NEXT_PUBLIC_FARO_SESSION_SAMPLE_RATE,
+  NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED: process.env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED,
 };

--- a/src/env/client-schema.ts
+++ b/src/env/client-schema.ts
@@ -59,6 +59,13 @@ export const clientSchema = z.object({
   // ramped INDEPENDENTLY of the main RUM flag once volume is confirmed on a small cohort.
   // Only takes effect when NEXT_PUBLIC_FARO_ENABLED + the `faro` flag are also on.
   NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED: z.stringbool().default(false),
+  // Deploy-tunable volume knobs for the resource-timing gate (dial the ramp WITHOUT a rebuild;
+  // parsed to numbers with a safe fallback in resolveResourceTimingConfig). Default sample rate
+  // is 0.05 — deliberately low so the aggregate stays under Loki's 10 MB/s per-stream ceiling on
+  // the shared `source="faro-rum"` stream at 100k concurrent (0.25 would breach it ~84.5k). The
+  // per-window cap is the pathological-single-client belt.
+  NEXT_PUBLIC_FARO_RESOURCE_TIMING_SAMPLE_RATE: z.string().default('0.05'),
+  NEXT_PUBLIC_FARO_RESOURCE_TIMING_MAX_PER_WINDOW: z.string().default('8'),
 });
 
 /**
@@ -105,4 +112,8 @@ export const clientEnv = {
   NEXT_PUBLIC_FARO_TRACES_SAMPLE_RATE: process.env.NEXT_PUBLIC_FARO_TRACES_SAMPLE_RATE,
   NEXT_PUBLIC_FARO_SESSION_SAMPLE_RATE: process.env.NEXT_PUBLIC_FARO_SESSION_SAMPLE_RATE,
   NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED: process.env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED,
+  NEXT_PUBLIC_FARO_RESOURCE_TIMING_SAMPLE_RATE:
+    process.env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_SAMPLE_RATE,
+  NEXT_PUBLIC_FARO_RESOURCE_TIMING_MAX_PER_WINDOW:
+    process.env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_MAX_PER_WINDOW,
 };

--- a/src/utils/faro/__tests__/resourceTiming.test.ts
+++ b/src/utils/faro/__tests__/resourceTiming.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildResourceMeasurement,
+  classifyApiEntry,
+  computeResourcePhases,
+  createRateLimiter,
+  normalizeApiRoute,
+  RESOURCE_TIMING_MEASUREMENT_TYPE,
+  type ResourceTimingLike,
+  sanitizeProtocol,
+} from '~/utils/faro/resourceTiming';
+
+const ORIGIN = 'https://civitai.com';
+
+/** Build a PerformanceResourceTiming-shaped object with sensible full-timing defaults. */
+function entry(overrides: Partial<ResourceTimingLike> = {}): ResourceTimingLike {
+  return {
+    name: `${ORIGIN}/api/trpc/model.getById?batch=1&input=%7B%7D`,
+    initiatorType: 'fetch',
+    nextHopProtocol: 'h2',
+    // A clean, non-reused connection: 0 → dns → connect(+tls) → request → response → end.
+    domainLookupStart: 10,
+    domainLookupEnd: 25, // DNS = 15
+    connectStart: 25,
+    secureConnectionStart: 40,
+    connectEnd: 60, // connect = 35, tls = 20
+    requestStart: 60,
+    responseStart: 210, // ttfb = 150
+    responseEnd: 260, // download = 50
+    duration: 250, // total
+    ...overrides,
+  };
+}
+
+describe('normalizeApiRoute', () => {
+  it('keeps only the first two path segments (coarse route)', () => {
+    expect(normalizeApiRoute('/api/trpc/model.getById')).toBe('/api/trpc');
+    expect(normalizeApiRoute('/api/v1/models/12345')).toBe('/api/v1');
+    expect(normalizeApiRoute('/api/auth/session')).toBe('/api/auth');
+    expect(normalizeApiRoute('/api/webhooks/stripe/abc')).toBe('/api/webhooks');
+  });
+
+  it('handles a bare /api and trailing/duplicate slashes', () => {
+    expect(normalizeApiRoute('/api')).toBe('/api');
+    expect(normalizeApiRoute('/api/')).toBe('/api');
+    expect(normalizeApiRoute('/api//trpc//x')).toBe('/api/trpc');
+  });
+});
+
+describe('sanitizeProtocol', () => {
+  it('passes known ALPN protocols through (lowercased)', () => {
+    expect(sanitizeProtocol('h2')).toBe('h2');
+    expect(sanitizeProtocol('h3')).toBe('h3');
+    expect(sanitizeProtocol('HTTP/1.1')).toBe('http/1.1');
+  });
+  it('collapses unknown/empty protocols to a low-cardinality bucket', () => {
+    expect(sanitizeProtocol('quic-v99')).toBe('other');
+    expect(sanitizeProtocol('')).toBe('unknown');
+    expect(sanitizeProtocol(undefined)).toBe('unknown');
+  });
+});
+
+describe('classifyApiEntry — same-origin /api filter', () => {
+  it('accepts a same-origin /api fetch and returns the coarse route', () => {
+    expect(classifyApiEntry(entry(), ORIGIN)).toBe('/api/trpc');
+  });
+
+  it('accepts xmlhttprequest initiator', () => {
+    expect(classifyApiEntry(entry({ initiatorType: 'xmlhttprequest' }), ORIGIN)).toBe('/api/trpc');
+  });
+
+  it('ignores non-/api same-origin resources (e.g. a page/data route)', () => {
+    expect(classifyApiEntry(entry({ name: `${ORIGIN}/models/123` }), ORIGIN)).toBeNull();
+    expect(classifyApiEntry(entry({ name: `${ORIGIN}/apixyz/thing` }), ORIGIN)).toBeNull();
+  });
+
+  it('ignores third-party (cross-origin) resources even on an /api path', () => {
+    expect(
+      classifyApiEntry(entry({ name: 'https://api.stripe.com/api/v1/charges' }), ORIGIN)
+    ).toBeNull();
+    expect(
+      classifyApiEntry(entry({ name: 'https://ga.google.com/api/collect' }), ORIGIN)
+    ).toBeNull();
+  });
+
+  it('ignores non fetch/xhr initiators (img/script/css/link)', () => {
+    for (const initiatorType of ['img', 'script', 'css', 'link', 'other', 'navigation']) {
+      expect(classifyApiEntry(entry({ initiatorType }), ORIGIN)).toBeNull();
+    }
+  });
+});
+
+describe('computeResourcePhases — phase math', () => {
+  it('computes DNS/connect/TLS/TTFB/download/total from a full-timing entry', () => {
+    expect(computeResourcePhases(entry())).toEqual({
+      rt_dns: 15,
+      rt_connect: 35,
+      rt_tls: 20,
+      rt_ttfb: 150,
+      rt_download: 50,
+      rt_total: 250,
+      rt_reused: 0,
+    });
+  });
+
+  it('rounds sub-millisecond jitter to integer ms', () => {
+    const values = computeResourcePhases(
+      entry({ domainLookupStart: 10.2, domainLookupEnd: 25.9 }) // 15.7 → 16
+    );
+    expect(values.rt_dns).toBe(16);
+  });
+
+  it('cache/keep-alive reuse: zero connect markers → dns/connect/tls all 0 and rt_reused=1', () => {
+    // Reused connection: DNS + connect skipped (all their markers 0); request/response still real.
+    const reused = entry({
+      domainLookupStart: 0,
+      domainLookupEnd: 0,
+      connectStart: 0,
+      connectEnd: 0,
+      secureConnectionStart: 0,
+      requestStart: 100,
+      responseStart: 180, // ttfb = 80
+      responseEnd: 200, // download = 20
+      duration: 100,
+    });
+    expect(computeResourcePhases(reused)).toEqual({
+      rt_dns: 0,
+      rt_connect: 0,
+      rt_tls: 0,
+      rt_ttfb: 80,
+      rt_download: 20,
+      rt_total: 100,
+      rt_reused: 1,
+    });
+  });
+
+  it('no-TLS (plain http / secureConnectionStart === 0): tls=0 but connect still measured', () => {
+    const noTls = entry({ secureConnectionStart: 0 }); // connectStart 25 → connectEnd 60 = 35
+    const values = computeResourcePhases(noTls);
+    expect(values.rt_tls).toBe(0);
+    expect(values.rt_connect).toBe(35);
+    expect(values.rt_reused).toBe(0);
+  });
+
+  it('never emits a negative phase (clamped to 0 on out-of-order markers)', () => {
+    const weird = entry({ responseStart: 60, requestStart: 210 }); // would be -150
+    expect(computeResourcePhases(weird).rt_ttfb).toBe(0);
+  });
+});
+
+describe('buildResourceMeasurement — the emitted payload', () => {
+  it('returns the stable measurement type + numeric values + low-cardinality context', () => {
+    const m = buildResourceMeasurement(entry(), ORIGIN);
+    expect(m).not.toBeNull();
+    expect(m!.type).toBe(RESOURCE_TIMING_MEASUREMENT_TYPE);
+    expect(m!.type).toBe('resource_timing');
+    expect(m!.context).toEqual({ route: '/api/trpc', protocol: 'h2' });
+    expect(m!.values.rt_ttfb).toBe(150);
+    // Every value is a number (unwrap-friendly for the dashboard).
+    for (const v of Object.values(m!.values)) expect(typeof v).toBe('number');
+  });
+
+  it('returns null for a resource that is not same-origin /api fetch/xhr', () => {
+    expect(buildResourceMeasurement(entry({ initiatorType: 'img' }), ORIGIN)).toBeNull();
+    expect(
+      buildResourceMeasurement(entry({ name: 'https://cdn.other.com/api/x' }), ORIGIN)
+    ).toBeNull();
+  });
+
+  // 🔴 PRIVACY GUARANTEE — the central assertion of this feature.
+  it('NEVER leaks the full URL, query string, or ids into the emitted payload', () => {
+    const sensitive = entry({
+      // A URL carrying an id, a slug, an oauth code and an email — none may escape.
+      name: `${ORIGIN}/api/auth/callback/credentials?code=SECRETCODE123&email=user%40example.com&modelId=99887766&slug=some-nsfw-model-name`,
+    });
+    const m = buildResourceMeasurement(sensitive, ORIGIN);
+    expect(m).not.toBeNull();
+
+    // The route is coarse and carries none of the sensitive tail.
+    expect(m!.context.route).toBe('/api/auth');
+
+    // Serialize the ENTIRE emitted payload and assert not one sensitive token survives.
+    const serialized = JSON.stringify(m);
+    expect(serialized).not.toContain('SECRETCODE123');
+    expect(serialized).not.toContain('example.com');
+    expect(serialized).not.toContain('99887766');
+    expect(serialized).not.toContain('some-nsfw-model-name');
+    expect(serialized).not.toContain('callback');
+    expect(serialized).not.toContain('credentials');
+    expect(serialized).not.toContain('?'); // no query string anywhere
+    expect(serialized).not.toContain('code=');
+    expect(serialized).not.toContain('=user'); // no email fragment
+    // The only path-shaped string in the payload is the coarse route.
+    expect(serialized).not.toContain(sensitive.name);
+  });
+});
+
+describe('createRateLimiter — the volume gate', () => {
+  it('allows up to maxPerWindow then drops within a window (sampleRate 1 = no sampling)', () => {
+    const limiter = createRateLimiter({
+      maxPerWindow: 3,
+      windowMs: 1000,
+      sampleRate: 1,
+      now: () => 0, // frozen clock → single window
+    });
+    expect(limiter.allow()).toBe(true);
+    expect(limiter.allow()).toBe(true);
+    expect(limiter.allow()).toBe(true);
+    expect(limiter.allow()).toBe(false); // cap reached
+    expect(limiter.allow()).toBe(false);
+  });
+
+  it('resets the cap after the rolling window elapses', () => {
+    let t = 0;
+    const limiter = createRateLimiter({
+      maxPerWindow: 1,
+      windowMs: 1000,
+      sampleRate: 1,
+      now: () => t,
+    });
+    expect(limiter.allow()).toBe(true);
+    expect(limiter.allow()).toBe(false);
+    t = 1000; // window elapsed
+    expect(limiter.allow()).toBe(true);
+  });
+
+  it('sampleRate drops candidates before the cap is consumed', () => {
+    // random() always returns 0.9; with sampleRate 0.25, 0.9 >= 0.25 → always dropped,
+    // and a dropped candidate must NOT consume a window slot.
+    const limiter = createRateLimiter({
+      maxPerWindow: 100,
+      windowMs: 1000,
+      sampleRate: 0.25,
+      random: () => 0.9,
+      now: () => 0,
+    });
+    for (let i = 0; i < 50; i++) expect(limiter.allow()).toBe(false);
+  });
+
+  it('sampleRate passes candidates when random() is below the fraction', () => {
+    const limiter = createRateLimiter({
+      maxPerWindow: 100,
+      windowMs: 1000,
+      sampleRate: 0.25,
+      random: () => 0.1, // 0.1 < 0.25 → passes the sample
+      now: () => 0,
+    });
+    expect(limiter.allow()).toBe(true);
+  });
+});

--- a/src/utils/faro/__tests__/resourceTiming.test.ts
+++ b/src/utils/faro/__tests__/resourceTiming.test.ts
@@ -5,7 +5,11 @@ import {
   computeResourcePhases,
   createRateLimiter,
   normalizeApiRoute,
+  parseMaxPerWindow,
+  parseSampleRate,
+  RESOURCE_TIMING_DEFAULTS,
   RESOURCE_TIMING_MEASUREMENT_TYPE,
+  resolveResourceTimingConfig,
   type ResourceTimingLike,
   sanitizeProtocol,
 } from '~/utils/faro/resourceTiming';
@@ -246,5 +250,78 @@ describe('createRateLimiter — the volume gate', () => {
       now: () => 0,
     });
     expect(limiter.allow()).toBe(true);
+  });
+});
+
+describe('RESOURCE_TIMING_DEFAULTS', () => {
+  // The default sample rate is 0.05 (NOT 0.25) so the aggregate resource-timing volume keeps the
+  // shared `source="faro-rum"` Loki stream under its 10 MB/s per-stream ceiling at civitai's
+  // 100k-concurrent target. This assertion guards that scale decision against a silent regression.
+  it('defaults sampleRate to 0.05 for the Loki per-stream ceiling', () => {
+    expect(RESOURCE_TIMING_DEFAULTS.sampleRate).toBe(0.05);
+  });
+
+  it('keeps the per-client belt at 8 emissions / 15s window', () => {
+    expect(RESOURCE_TIMING_DEFAULTS.maxPerWindow).toBe(8);
+    expect(RESOURCE_TIMING_DEFAULTS.windowMs).toBe(15000);
+  });
+});
+
+describe('parseSampleRate', () => {
+  it('parses a valid fraction and clamps into [0, 1]', () => {
+    expect(parseSampleRate('0.05', 0.05)).toBe(0.05);
+    expect(parseSampleRate('0.5', 0.05)).toBe(0.5);
+    expect(parseSampleRate('2', 0.05)).toBe(1);
+    expect(parseSampleRate('-1', 0.05)).toBe(0);
+  });
+
+  it('falls back on NaN / unset / non-numeric input', () => {
+    expect(parseSampleRate(undefined, 0.05)).toBe(0.05);
+    expect(parseSampleRate('', 0.05)).toBe(0.05);
+    expect(parseSampleRate('not-a-number', 0.05)).toBe(0.05);
+  });
+});
+
+describe('parseMaxPerWindow', () => {
+  it('parses a positive integer', () => {
+    expect(parseMaxPerWindow('8', 8)).toBe(8);
+    expect(parseMaxPerWindow('20', 8)).toBe(20);
+    expect(parseMaxPerWindow('12.9', 8)).toBe(12); // parseInt truncates
+  });
+
+  it('falls back on NaN / unset / invalid / non-positive input', () => {
+    expect(parseMaxPerWindow(undefined, 8)).toBe(8);
+    expect(parseMaxPerWindow('', 8)).toBe(8);
+    expect(parseMaxPerWindow('abc', 8)).toBe(8);
+    expect(parseMaxPerWindow('0', 8)).toBe(8);
+    expect(parseMaxPerWindow('-3', 8)).toBe(8);
+  });
+});
+
+describe('resolveResourceTimingConfig — the deploy-tunable knobs', () => {
+  it('reads sample rate + cap from their env strings', () => {
+    expect(resolveResourceTimingConfig('0.1', '20')).toEqual({ sampleRate: 0.1, maxPerWindow: 20 });
+  });
+
+  it('falls back to the defaults on invalid/NaN env (never zeroes the gate or crashes)', () => {
+    expect(resolveResourceTimingConfig('garbage', 'garbage')).toEqual({
+      sampleRate: RESOURCE_TIMING_DEFAULTS.sampleRate,
+      maxPerWindow: RESOURCE_TIMING_DEFAULTS.maxPerWindow,
+    });
+    expect(resolveResourceTimingConfig(undefined, undefined)).toEqual({
+      sampleRate: 0.05,
+      maxPerWindow: 8,
+    });
+  });
+
+  it('resolves each knob independently (one invalid does not taint the other)', () => {
+    expect(resolveResourceTimingConfig('0.2', 'nope')).toEqual({
+      sampleRate: 0.2,
+      maxPerWindow: 8,
+    });
+    expect(resolveResourceTimingConfig('nope', '16')).toEqual({
+      sampleRate: 0.05,
+      maxPerWindow: 16,
+    });
   });
 });

--- a/src/utils/faro/resourceTiming.ts
+++ b/src/utils/faro/resourceTiming.ts
@@ -244,3 +244,57 @@ export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
     },
   };
 }
+
+/**
+ * Numeric defaults for the volume gate.
+ *
+ * WHY `sampleRate` IS 0.05 (NOT 0.25) — the 10 MB/s Loki per-stream ceiling:
+ * All RUM signals land on a SINGLE Loki stream (`source="faro-rum"`) which is capped at
+ * `per_stream_rate_limit` = 10 MB/s. At civitai's 100k-concurrent target a 0.25 sample rate
+ * would push the aggregate resource-timing volume so the shared stream breaches ~10 MB/s near
+ * ~84.5k sessions — and Loki sheds WHOLE BATCHES, dropping errors + web-vitals with it, not just
+ * these measurements. At 0.05 the aggregate is ~1,000 beacons/s (~0.74 MB/s), keeping the
+ * faro-rum stream ~8.9 MB/s — under the limit with headroom. It is deliberately conservative for
+ * the ramp; dial it UP via env once the observed stream rate at a cohort confirms headroom.
+ * `maxPerWindow`/`windowMs` are the pathological-single-client belt, not the aggregate control.
+ */
+export const RESOURCE_TIMING_DEFAULTS = {
+  maxPerWindow: 8,
+  windowMs: 15000,
+  sampleRate: 0.05,
+} as const;
+
+/** Parse a sampling fraction env string to [0, 1], falling back on NaN/unset/invalid. */
+export function parseSampleRate(raw: string | undefined, fallback: number): number {
+  const n = Number.parseFloat(raw ?? '');
+  if (!Number.isFinite(n)) return fallback;
+  return Math.min(1, Math.max(0, n));
+}
+
+/** Parse a positive-integer cap env string, falling back on NaN/unset/invalid/`< 1`. */
+export function parseMaxPerWindow(raw: string | undefined, fallback: number): number {
+  const n = Number.parseInt(raw ?? '', 10);
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return n;
+}
+
+export interface ResourceTimingConfig {
+  sampleRate: number;
+  maxPerWindow: number;
+}
+
+/**
+ * Resolve the deploy-tunable volume knobs from their env strings, each with a safe fallback to
+ * `RESOURCE_TIMING_DEFAULTS` (mirroring how `resolveFaroSampling` guards the trace/session
+ * rates). This makes the ramp dial-able (sample rate + per-client cap) WITHOUT a rebuild — an
+ * invalid/NaN env can never zero the gate or crash init; it degrades to the default.
+ */
+export function resolveResourceTimingConfig(
+  sampleRateRaw: string | undefined,
+  maxPerWindowRaw: string | undefined
+): ResourceTimingConfig {
+  return {
+    sampleRate: parseSampleRate(sampleRateRaw, RESOURCE_TIMING_DEFAULTS.sampleRate),
+    maxPerWindow: parseMaxPerWindow(maxPerWindowRaw, RESOURCE_TIMING_DEFAULTS.maxPerWindow),
+  };
+}

--- a/src/utils/faro/resourceTiming.ts
+++ b/src/utils/faro/resourceTiming.ts
@@ -1,0 +1,246 @@
+/**
+ * Privacy-safe Resource Timing decomposition for the Faro RUM pipeline.
+ *
+ * WHY THIS EXISTS: browser↔backend trace stitching proved ~83% of the ~275ms median
+ * user-perceived `/api` latency is browser↔Cloudflare↔origin NETWORK time, not backend
+ * (the handler is ~3.5%). That ~259ms "network" figure is a black box. This module reads
+ * the browser's `PerformanceResourceTiming` entries for same-origin `/api` requests and
+ * decomposes each into the standard phase durations (DNS / TCP-connect / TLS / TTFB /
+ * download) so the RUM dashboards can split the network cost.
+ *
+ * 🔴 PRIVACY (this is an adult-content + payments platform at 100% RUM):
+ *   - The stock Faro `PerformanceInstrumentation` is DELIBERATELY EXCLUDED (see
+ *     FaroProvider header) because it emits FULL resource URLs. This module must never
+ *     re-introduce that. For each entry we normalize the URL to a COARSE route
+ *     (`/api/trpc`, `/api/v1`, `/api/auth`, …) — first two path segments only, no query
+ *     string, no ids, no slugs — and emit that route as a low-cardinality label. The raw
+ *     `PerformanceResourceTiming.name` (a full URL with query) NEVER enters the payload.
+ *   - Scope is SAME-ORIGIN `/api` ONLY. Third-party resources (Stripe/Paddle/Meili/
+ *     Turnstile/GA/CDN/images) are ignored — both a privacy risk (third-party URLs) and
+ *     pure volume.
+ *   - This normalization is done HERE, before emit — it does NOT rely on the downstream
+ *     `deepRedact` scrub. Even if deepRedact changed, no raw URL is ever produced.
+ *
+ * Same-origin `/api` timings are always fully populated (a same-origin resource is exempt
+ * from the Timing-Allow-Origin gate), so DNS/connect/TLS are real numbers, not zeros
+ * masked by cross-origin opacity.
+ *
+ * Every function here is PURE and unit-tested (`__tests__/resourceTiming.test.ts`).
+ */
+
+/**
+ * The subset of `PerformanceResourceTiming` fields we read. Declared structurally (not as
+ * the DOM lib type) so the phase math can be unit-tested in a node env with plain objects.
+ * All time fields are `DOMHighResTimeStamp` (ms, relative to time-origin).
+ */
+export interface ResourceTimingLike {
+  name: string;
+  initiatorType: string;
+  nextHopProtocol?: string;
+  duration: number;
+  domainLookupStart: number;
+  domainLookupEnd: number;
+  connectStart: number;
+  connectEnd: number;
+  secureConnectionStart: number;
+  requestStart: number;
+  responseStart: number;
+  responseEnd: number;
+}
+
+/** Measurement `type` — stable, used as the Loki/dashboard selector. */
+export const RESOURCE_TIMING_MEASUREMENT_TYPE = 'resource_timing';
+
+/** Numeric value keys — stable + prefixed so a dashboard can `unwrap` them. */
+export interface ResourceTimingValues {
+  rt_dns: number;
+  rt_connect: number;
+  rt_tls: number;
+  rt_ttfb: number;
+  rt_download: number;
+  rt_total: number;
+  /** 1 when the connection was reused (keep-alive) or served from cache (connect phase 0). */
+  rt_reused: number;
+  [label: string]: number;
+}
+
+/** Low-cardinality context labels. NEVER a URL. */
+export interface ResourceTimingContext extends Record<string, string> {
+  route: string;
+  protocol: string;
+}
+
+export interface ResourceTimingMeasurement {
+  type: typeof RESOURCE_TIMING_MEASUREMENT_TYPE;
+  values: ResourceTimingValues;
+  context: ResourceTimingContext;
+}
+
+/** Only fetch/XHR resources (the `/api` traffic we care about); skip img/script/css/etc. */
+const API_INITIATOR_TYPES = new Set(['fetch', 'xmlhttprequest']);
+
+/** ALPN next-hop protocols we allow through as a label; anything else → `other`. */
+const KNOWN_PROTOCOLS = new Set(['h3', 'h2', 'http/1.1', 'http/1.0', 'http/0.9', 'spdy/3.1']);
+
+/**
+ * Normalize an `/api` pathname to a coarse, low-cardinality route: the first TWO path
+ * segments only (`/api/trpc`, `/api/v1`, `/api/auth`, `/api/webhooks`, …). Everything after
+ * the second segment — ids, slugs, trpc procedure names — is dropped. Matches the RUM
+ * dashboards' existing route normalization. Assumes `pathname` starts with `/api`.
+ */
+export function normalizeApiRoute(pathname: string): string {
+  // Split, drop empty segments (leading slash / trailing slash / dup slashes).
+  const segments = pathname.split('/').filter(Boolean);
+  // segments[0] === 'api'. Keep at most the first two segments.
+  return '/' + segments.slice(0, 2).join('/');
+}
+
+/** Constrain the next-hop protocol to a tiny known set so it stays low-cardinality. */
+export function sanitizeProtocol(nextHopProtocol: string | undefined): string {
+  if (!nextHopProtocol) return 'unknown';
+  const lower = nextHopProtocol.toLowerCase();
+  return KNOWN_PROTOCOLS.has(lower) ? lower : 'other';
+}
+
+/**
+ * If `entry` is a same-origin `/api` fetch/XHR resource, return its coarse route; else null.
+ * `origin` is `window.location.origin` (passed in so this is pure/testable).
+ *
+ * PRIVACY: the URL is parsed only to extract the origin (for the same-origin check) and the
+ * pathname (for `normalizeApiRoute`). The full URL / query string is never returned.
+ */
+export function classifyApiEntry(entry: ResourceTimingLike, origin: string): string | null {
+  if (!API_INITIATOR_TYPES.has(entry.initiatorType)) return null;
+  let url: URL;
+  try {
+    // `entry.name` is an absolute URL for network resources; `origin` base is a no-op then,
+    // and a safety net for any relative form.
+    url = new URL(entry.name, origin);
+  } catch {
+    return null;
+  }
+  if (url.origin !== origin) return null;
+  if (url.pathname !== '/api' && !url.pathname.startsWith('/api/')) return null;
+  return normalizeApiRoute(url.pathname);
+}
+
+/** Clamp a phase to a non-negative integer millisecond value (drops sub-ms jitter/noise). */
+function phase(ms: number): number {
+  return ms > 0 ? Math.round(ms) : 0;
+}
+
+/**
+ * Decompose one resource entry into the standard timing phases. Each phase is guarded on its
+ * own start marker being > 0 — a zero start marker means the phase did not occur / was not
+ * measured (cache hit, keep-alive reuse, no-TLS), which must read as 0, not a bogus delta.
+ *
+ *   DNS       = domainLookupEnd  - domainLookupStart
+ *   TCP conn  = connectEnd       - connectStart          (includes TLS)
+ *   TLS       = connectEnd       - secureConnectionStart  (only when secureConnectionStart > 0)
+ *   TTFB      = responseStart    - requestStart
+ *   Download  = responseEnd      - responseStart
+ *   Total     = duration
+ *   Reused    = 1 when connectStart === 0 (connection reused / served from cache)
+ */
+export function computeResourcePhases(entry: ResourceTimingLike): ResourceTimingValues {
+  const dns =
+    entry.domainLookupStart > 0 && entry.domainLookupEnd > 0
+      ? phase(entry.domainLookupEnd - entry.domainLookupStart)
+      : 0;
+  const connect =
+    entry.connectStart > 0 && entry.connectEnd > 0
+      ? phase(entry.connectEnd - entry.connectStart)
+      : 0;
+  const tls =
+    entry.secureConnectionStart > 0 && entry.connectEnd > 0
+      ? phase(entry.connectEnd - entry.secureConnectionStart)
+      : 0;
+  const ttfb =
+    entry.requestStart > 0 && entry.responseStart > 0
+      ? phase(entry.responseStart - entry.requestStart)
+      : 0;
+  const download =
+    entry.responseStart > 0 && entry.responseEnd > 0
+      ? phase(entry.responseEnd - entry.responseStart)
+      : 0;
+  const total = phase(entry.duration);
+  // A reused connection (keep-alive) or cache hit skips DNS+connect: connectStart is 0.
+  const reused = entry.connectStart > 0 ? 0 : 1;
+
+  return {
+    rt_dns: dns,
+    rt_connect: connect,
+    rt_tls: tls,
+    rt_ttfb: ttfb,
+    rt_download: download,
+    rt_total: total,
+    rt_reused: reused,
+  };
+}
+
+/**
+ * Build the privacy-safe measurement for one resource entry, or null if the entry is not a
+ * same-origin `/api` fetch/XHR resource. The returned object is exactly what gets pushed:
+ * numeric phase VALUES + a `{ route, protocol }` CONTEXT (both low-cardinality) — and NEVER
+ * the URL or query string.
+ */
+export function buildResourceMeasurement(
+  entry: ResourceTimingLike,
+  origin: string
+): ResourceTimingMeasurement | null {
+  const route = classifyApiEntry(entry, origin);
+  if (route === null) return null;
+  return {
+    type: RESOURCE_TIMING_MEASUREMENT_TYPE,
+    values: computeResourcePhases(entry),
+    context: { route, protocol: sanitizeProtocol(entry.nextHopProtocol) },
+  };
+}
+
+export interface RateLimiterOptions {
+  /** Max emissions allowed within one rolling window. */
+  maxPerWindow: number;
+  /** Rolling window length in ms. */
+  windowMs: number;
+  /** Per-candidate sampling fraction in [0, 1] applied BEFORE the window cap. */
+  sampleRate: number;
+  /** Injectable RNG (defaults to Math.random) — for deterministic tests. */
+  random?: () => number;
+  /** Injectable clock (defaults to Date.now) — for deterministic tests. */
+  now?: () => number;
+}
+
+export interface RateLimiter {
+  /** True if this candidate may be emitted (consumes a slot); false to drop it. */
+  allow: () => boolean;
+}
+
+/**
+ * Volume gate for resource-timing emissions. Resource Timing fires for EVERY subresource, so
+ * emitting one beacon per `/api` resource unbounded would flood Loki/Tempo. This bounds the
+ * per-client rate two ways: a sampling fraction (drops most candidates) AND a hard cap of
+ * `maxPerWindow` emissions per rolling `windowMs` (bounds the worst case regardless of how
+ * many `/api` calls a page fires). This is INDEPENDENT of trace/session sampling (the
+ * decoupled-sampling design) — it gates only this measurement signal.
+ */
+export function createRateLimiter(options: RateLimiterOptions): RateLimiter {
+  const random = options.random ?? Math.random;
+  const now = options.now ?? Date.now;
+  let windowStart = now();
+  let count = 0;
+
+  return {
+    allow(): boolean {
+      // Sample first (cheap short-circuit that drops the majority of candidates).
+      if (options.sampleRate < 1 && random() >= options.sampleRate) return false;
+      const t = now();
+      if (t - windowStart >= options.windowMs) {
+        windowStart = t;
+        count = 0;
+      }
+      if (count >= options.maxPerWindow) return false;
+      count += 1;
+      return true;
+    },
+  };
+}


### PR DESCRIPTION
## What

Adds a **privacy-safe Resource Timing decomposition** to the Faro RUM pipeline. It reads
same-origin `/api` `PerformanceResourceTiming` entries in the browser and emits the standard
network-phase splits (DNS / TCP-connect / TLS / TTFB / download) as custom Faro measurements
(`type: 'resource_timing'`), keyed only by a **coarse route** + protocol.

## Why

Browser↔backend trace stitching showed ~83% of the ~275ms median user-perceived `/api`
latency is browser↔Cloudflare↔origin **network** time, not backend (the handler is ~3.5%).
That ~259ms "network" figure is currently a black box. This un-black-boxes it so the RUM
dashboards can see DNS vs TCP-connect vs TLS vs TTFB vs download splits per route.

## 🔴 Privacy (adult-content + payments platform, 100% RUM)

This is **not** the stock Faro `PerformanceInstrumentation` — that stays deliberately disabled
because it emits full resource URLs. Instead:

- **Coarse route only.** Every URL is normalized to its first two path segments
  (`/api/trpc`, `/api/v1`, `/api/auth`, `/api/webhooks`, …) **before emit** — no query string,
  no ids, no slugs. The raw `PerformanceResourceTiming.name` (a full URL) never enters the
  payload. This is enforced in `~/utils/faro/resourceTiming.ts` independently of the downstream
  `deepRedact` scrub, so even if `deepRedact` changed, no raw URL is ever produced.
- **Same-origin `/api` only.** Third-party resources (Stripe/Paddle/Meili/Turnstile/GA/CDN/
  images) are ignored — both a privacy risk (third-party URLs) and pure volume.
- **Low-cardinality context.** The emitted payload is numeric phase values + `{ route, protocol }`.
  `protocol` is constrained to a known ALPN allow-list (else `other`).

A unit test serializes the entire emitted payload for a URL carrying an oauth `code`, an email,
a model id and a slug, and asserts none of them (nor any `?`/query) survive.

## Volume / aggregation decision

One measurement **per same-origin `/api` resource**, but gated by a per-client rate limiter:
a **sampling fraction** (default **0.05**) **and** a hard cap (default 8 emissions per rolling
15s window). Per-resource (vs per-view aggregate) is chosen because the goal is the
*distribution* of the network split (p50/p95 of each phase), which a per-route average would
lose. The gate is **independent of trace/session sampling** (respecting the existing
decoupled-sampling design).

### Why `sampleRate = 0.05` (the 10 MB/s Loki per-stream ceiling)

All RUM signals land on a **single Loki stream** (`source="faro-rum"`) capped at
`per_stream_rate_limit` = **10 MB/s**. A scale audit at civitai's **100k-concurrent** target
found that at `sampleRate = 0.25` the aggregate resource-timing volume pushes that shared stream
past ~10 MB/s near **~84.5k sessions** — at which point Loki sheds **whole batches**, dropping
`errors` + `web-vitals` along with these measurements, not just the new signal. At **0.05** the
aggregate is **~1,000 beacons/s (~0.74 MB/s)**, keeping the faro-rum stream **~8.9 MB/s** — under
the limit with headroom. Fine at today's ~4.3k concurrent either way, but 0.05 is the safe
default for the ramp. The per-window cap (8 / 15s ⇒ ≤ ~0.53/s/client) is the
pathological-single-client belt, not the aggregate control.

### Env-tunable knobs (dial the ramp without a rebuild)

The numeric knobs are now deploy-tunable (previously only the on/off boolean was), so the ramp
can be dialed via build-arg without a code change:

- `NEXT_PUBLIC_FARO_RESOURCE_TIMING_SAMPLE_RATE` (default `'0.05'`)
- `NEXT_PUBLIC_FARO_RESOURCE_TIMING_MAX_PER_WINDOW` (default `'8'`)

`resolveResourceTimingConfig` parses each with a **safe fallback to the defaults** (NaN / unset /
invalid / `< 1` → default), mirroring how `resolveFaroSampling` guards the trace/session rates —
an invalid env can never zero the gate or crash init. The constructor options remain the override
path so the pure core stays unit-testable. Intended rollout mirrors traces: enable for a small
cohort, read the actual `count_over_time({kind="measurement"} ...)` / stream `bytes` rate, then
dial `SAMPLE_RATE` up via env.

## Gating / rollout

Behind a dedicated build-arg `NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED` (default **false**,
`z.stringbool()` mirroring the existing `NEXT_PUBLIC_FARO_*` flags). Only takes effect when
`NEXT_PUBLIC_FARO_ENABLED` + the `faro` runtime flag are also on. Flipping it on in prod (and
setting the sample-rate/cap build-args) is a follow-up datapacket-talos change, **not** part of
this PR.

## Files

- `src/utils/faro/resourceTiming.ts` — pure, unit-tested helpers: route normalization, protocol
  sanitization, same-origin `/api` classification, phase math, the measurement builder, and the
  volume rate-limiter.
- `src/components/Faro/ResourceTimingInstrumentation.ts` — `BaseInstrumentation` subclass wiring
  a `PerformanceObserver('resource', { buffered: true })` → filter → gate → `pushMeasurement`.
- `src/components/Faro/FaroProvider.tsx` — conditionally adds the instrumentation to the
  allow-list behind the new flag; header comment updated.
- `src/env/client-schema.ts` — the `NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED` build-arg plus the
  two deploy-tunable knobs (`..._SAMPLE_RATE` default `'0.05'`, `..._MAX_PER_WINDOW` default `'8'`).
- `src/utils/faro/__tests__/resourceTiming.test.ts` — phase math (incl. cache-reuse zero-duration
  and no-TLS `secureConnectionStart===0` cases), route normalization, same-origin filter, the
  privacy assertion, the rate-limiter, the `0.05` default, and the env-parse-with-fallback
  (invalid/NaN/`<1` → default).
- `src/components/Faro/__tests__/ResourceTimingInstrumentation.test.ts` — SDK wiring (observes
  `resource` buffered, filters, emit shape, volume cap, error containment, no-`PerformanceObserver`
  no-op).

## Testing

- **Unit:** `vitest run --project unit` on both test files → **36 passed** (30 + 6), including the
  hardening additions (default `0.05`, env-parse-with-fallback). Re-run after the scale hardening.
- **Lint:** `pnpm run lint` is **broken repo-wide in my local NixOS env** at config-load —
  `eslint-config-next@16.2.7` (flat-config-only) is incompatible with the repo's legacy
  `.eslintrc.js` under `eslint@8.57` (crashes on every file, including untouched ones). I verified
  the new/changed files lint clean against the repo's **substantive** rules (`@typescript-eslint`
  + `prettier/prettier` at the repo's exact settings, `consistent-type-imports`) with the broken
  `next` extend dropped — 0 problems after a prettier autofix. CI's working config should be the
  source of truth.
- **Typecheck:** `tsc --noEmit` reports **1392 pre-existing errors** in my env, all cascading from
  an un-regeneratable Prisma client (repo pins `prisma@6.13`; the only nix-available engine is
  `7.8.0`, and the checked-in generated client is stale vs the schema — e.g. missing `wildcardSet`
  models). **Baseline (origin/main, my change reverted) = 1392; with my change = 1392 → delta 0.**
  None of the errors reference my files. My change is additive (a new env var + one array entry)
  and introduces zero type errors; CI, which regenerates the client, should be clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

