### PR TITLE
feat(faro): cohort-ramp gate for resource_timing via faro-resource-timing Flipt flag

### DIFF
--- a/src/components/Faro/FaroProvider.tsx
+++ b/src/components/Faro/FaroProvider.tsx
@@ -12,9 +12,8 @@ import {
 import { env } from '~/env/client';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { deepRedact } from '~/utils/faro/redact';
-import { resolveResourceTimingConfig } from '~/utils/faro/resourceTiming';
 import { resolveFaroSampling } from '~/utils/faro/traceSampler';
-import { ResourceTimingInstrumentation } from './ResourceTimingInstrumentation';
+import { buildResourceTimingInstrumentations } from './ResourceTimingInstrumentation';
 import { SampledTracingInstrumentation } from './SampledTracingInstrumentation';
 
 /**
@@ -34,16 +33,24 @@ import { SampledTracingInstrumentation } from './SampledTracingInstrumentation';
  *
  * Instrumentations (EXPLICIT allow-list — NOT the getWebInstrumentations() default set):
  * errors, web-vitals, session (required for sampling), view, navigation, tracing, and —
- * behind its own dark build-arg — a privacy-safe Resource Timing decomposition.
+ * behind its own build-arg + a cohort Flipt flag — a privacy-safe Resource Timing decomposition.
  * DELIBERATELY EXCLUDED for privacy on this adult/payments platform: the stock Performance
  * instrumentation (emits full resource URLs), UserAction (captures element datasets), CSP,
  * and Console (serialises arbitrary logged objects). NO session replay.
  *
- * The Resource Timing decomposition (`ResourceTimingInstrumentation`, gated on
- * `NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED`, default OFF) is the ONE resource-timing surface
- * we allow: unlike stock Performance it normalizes every URL to a coarse route BEFORE emit
- * (no URL/query ever leaves the browser), scopes to same-origin `/api` only, and is
- * volume-gated independently of trace sampling. See ResourceTimingInstrumentation.
+ * The Resource Timing decomposition (`ResourceTimingInstrumentation`) is the ONE resource-timing
+ * surface we allow: unlike stock Performance it normalizes every URL to a coarse route BEFORE
+ * emit (no URL/query ever leaves the browser), scopes to same-origin `/api` only, and is
+ * volume-gated independently of trace sampling. It is gated on BOTH (AND):
+ *   - the `NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED` build-arg (default OFF) = compiled-in
+ *     master enable/kill, AND
+ *   - the `faro-resource-timing` Flipt flag (`features.faroResourceTiming`, base `enabled:false`)
+ *     = which COHORT — so it ramps by % of users at RUNTIME, mirroring how the main `faro` flag
+ *     ramped. Never flip it 100%-at-once; bump the Flipt % rollout and watch the faro-rum stream
+ *     bytes stay under the 10 MB/s per-stream ceiling.
+ * The cohort boolean is read once at first-init (threaded in via `initFaro`, same model as the
+ * `features.faro` gate on the whole SDK) — a flag change applies on the next page load.
+ * See ResourceTimingInstrumentation.
  *
  * SAMPLING (two decoupled layers):
  *   - SESSION sampling (`NEXT_PUBLIC_FARO_SESSION_SAMPLE_RATE`, 1.0) gates ALL signals →
@@ -109,7 +116,19 @@ function scrubBeacon(item: TransportItem): TransportItem | null {
   }
 }
 
-function initFaro() {
+interface InitFaroOptions {
+  /**
+   * Whether THIS user is in the resource_timing cohort — the resolved value of the
+   * `faro-resource-timing` Flipt flag (`features.faroResourceTiming`), threaded in from the
+   * component so module-scope init never imports the hook. Combined (AND) with the build-arg
+   * `NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED` to decide whether to attach
+   * ResourceTimingInstrumentation. Read once at first-init (same model as the `features.faro`
+   * gate on the whole SDK) — ramping the flag % takes effect on the next page load.
+   */
+  resourceTimingCohort: boolean;
+}
+
+function initFaro({ resourceTimingCohort }: InitFaroOptions) {
   if (faroInitStarted) return;
   if (typeof window === 'undefined') return;
   if ((window as unknown as Record<string, unknown>)[WINDOW_GUARD_KEY]) return;
@@ -183,21 +202,19 @@ function initFaro() {
       // `/api` requests, emitted as custom measurements. This is NOT the stock
       // PerformanceInstrumentation (which stays excluded — it emits full URLs); it
       // normalizes every URL to a coarse route BEFORE emit and is volume-gated
-      // independently of trace sampling. Ships DARK behind its own build-arg so it can be
-      // ramped separately from the main RUM flag. The volume knobs (sample rate + per-client
-      // cap) are env-tunable so the ramp is dial-able WITHOUT a rebuild — resolved here with a
-      // safe fallback to the defaults (sample rate 0.05 keeps the shared faro-rum Loki stream
-      // under its 10 MB/s ceiling at 100k concurrent). See ResourceTimingInstrumentation.
-      ...(env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED
-        ? [
-            new ResourceTimingInstrumentation(
-              resolveResourceTimingConfig(
-                env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_SAMPLE_RATE,
-                env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_MAX_PER_WINDOW
-              )
-            ),
-          ]
-        : []),
+      // independently of trace sampling. TWO gates (AND): the build-arg
+      // NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED = compiled-in master enable/kill, and the
+      // `faro-resource-timing` Flipt flag (resourceTimingCohort) = which % of users — so ops
+      // ramps the cohort at runtime by bumping the flag %, no rebuild, mirroring how `faro`
+      // ramped. The volume knobs (sample rate + per-client cap) are env-tunable, resolved here
+      // with a safe fallback to the defaults (sample rate 0.05 keeps the shared faro-rum Loki
+      // stream under its 10 MB/s ceiling at 100k concurrent). See ResourceTimingInstrumentation.
+      ...buildResourceTimingInstrumentations({
+        buildArgEnabled: env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED,
+        cohortEnabled: resourceTimingCohort,
+        sampleRateEnv: env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_SAMPLE_RATE,
+        maxPerWindowEnv: env.NEXT_PUBLIC_FARO_RESOURCE_TIMING_MAX_PER_WINDOW,
+      }),
     ],
     // Defensive outer wrapper: scrubBeacon already fails closed, but guarantee that any
     // unexpected throw still drops the beacon (null) rather than emitting it unscrubbed.
@@ -218,7 +235,7 @@ export function FaroProvider() {
   useEffect(() => {
     try {
       if (enabled) {
-        initFaro();
+        initFaro({ resourceTimingCohort: !!features.faroResourceTiming });
         // If a prior transition paused an already-initialised instance, resume it.
         if (faroInitStarted) faro?.unpause?.();
       } else if (faroInitStarted) {

--- a/src/components/Faro/ResourceTimingInstrumentation.ts
+++ b/src/components/Faro/ResourceTimingInstrumentation.ts
@@ -5,6 +5,7 @@ import {
   type RateLimiter,
   RESOURCE_TIMING_DEFAULTS,
   type ResourceTimingLike,
+  resolveResourceTimingConfig,
 } from '~/utils/faro/resourceTiming';
 
 /**
@@ -112,4 +113,38 @@ export class ResourceTimingInstrumentation extends BaseInstrumentation {
       }
     }
   }
+}
+
+export interface ResourceTimingGate {
+  /** NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED — compiled-in master enable/kill. */
+  buildArgEnabled: boolean;
+  /** The `faro-resource-timing` Flipt flag for THIS user — the runtime % cohort. */
+  cohortEnabled: boolean;
+  /** NEXT_PUBLIC_FARO_RESOURCE_TIMING_SAMPLE_RATE (parsed with a safe fallback). */
+  sampleRateEnv?: string;
+  /** NEXT_PUBLIC_FARO_RESOURCE_TIMING_MAX_PER_WINDOW (parsed with a safe fallback). */
+  maxPerWindowEnv?: string;
+}
+
+/**
+ * The gating decision for whether to attach `ResourceTimingInstrumentation`, factored out of
+ * FaroProvider so it is unit-testable (and so the wiring test is load-bearing on the REAL
+ * production path, not a parallel copy that can drift). Returns a 0-or-1-element array to spread
+ * directly into the Faro `instrumentations` list.
+ *
+ * Attaches ONLY when BOTH gates are true (AND):
+ *   - `buildArgEnabled` = the build-arg (compiled-in master enable/kill), AND
+ *   - `cohortEnabled`   = the `faro-resource-timing` Flipt flag (runtime % cohort ramp).
+ * Either false ⇒ no instrumentation. This is what lets ops ramp resource_timing by % of users at
+ * runtime (bump the Flipt %) without a rebuild — mirroring how the main `faro` flag ramped.
+ */
+export function buildResourceTimingInstrumentations(
+  gate: ResourceTimingGate
+): ResourceTimingInstrumentation[] {
+  if (!gate.buildArgEnabled || !gate.cohortEnabled) return [];
+  return [
+    new ResourceTimingInstrumentation(
+      resolveResourceTimingConfig(gate.sampleRateEnv, gate.maxPerWindowEnv)
+    ),
+  ];
 }

--- a/src/components/Faro/__tests__/ResourceTimingInstrumentation.test.ts
+++ b/src/components/Faro/__tests__/ResourceTimingInstrumentation.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ResourceTimingInstrumentation } from '../ResourceTimingInstrumentation';
+import {
+  buildResourceTimingInstrumentations,
+  ResourceTimingInstrumentation,
+} from '../ResourceTimingInstrumentation';
 import type { ResourceTimingLike } from '~/utils/faro/resourceTiming';
 
 /**
@@ -133,5 +136,50 @@ describe('ResourceTimingInstrumentation', () => {
     const push = vi.fn();
     // Should not throw during initialize; nothing to observe.
     expect(() => makeInstrumentation(push).initialize()).not.toThrow();
+  });
+});
+
+describe('buildResourceTimingInstrumentations — the two-gate cohort ramp', () => {
+  // This is the EXACT decision FaroProvider spreads into the Faro `instrumentations` list, so
+  // these assertions are load-bearing on the production wiring. resource_timing attaches ONLY
+  // when BOTH the build-arg AND the `faro-resource-timing` Flipt cohort flag are true (AND).
+  it('attaches the instrumentation when BOTH build-arg and cohort flag are true', () => {
+    const list = buildResourceTimingInstrumentations({
+      buildArgEnabled: true,
+      cohortEnabled: true,
+    });
+    expect(list).toHaveLength(1);
+    expect(list[0]).toBeInstanceOf(ResourceTimingInstrumentation);
+  });
+
+  it('excludes it when the cohort flag is false even though the build-arg is on', () => {
+    expect(
+      buildResourceTimingInstrumentations({ buildArgEnabled: true, cohortEnabled: false })
+    ).toEqual([]);
+  });
+
+  it('excludes it when the build-arg is off even though the cohort flag is on', () => {
+    expect(
+      buildResourceTimingInstrumentations({ buildArgEnabled: false, cohortEnabled: true })
+    ).toEqual([]);
+  });
+
+  it('excludes it when both gates are false', () => {
+    expect(
+      buildResourceTimingInstrumentations({ buildArgEnabled: false, cohortEnabled: false })
+    ).toEqual([]);
+  });
+
+  it('passes the env-tunable volume knobs through to the instrumentation when attached', () => {
+    // A valid sample-rate/cap env resolves without throwing and yields exactly one instrumentation
+    // (the env-parse-with-fallback itself is covered in resourceTiming.test.ts).
+    const list = buildResourceTimingInstrumentations({
+      buildArgEnabled: true,
+      cohortEnabled: true,
+      sampleRateEnv: '0.2',
+      maxPerWindowEnv: '16',
+    });
+    expect(list).toHaveLength(1);
+    expect(list[0]).toBeInstanceOf(ResourceTimingInstrumentation);
   });
 });

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -56,6 +56,13 @@ const featureFlags = createFeatureFlags({
   // Flipt (`faro`). Runtime kill-switch for the Faro Web SDK — the FaroProvider only
   // initialises when this flag is on AND the NEXT_PUBLIC_FARO_* build-args are set.
   faro: { availability: ['mod'], fliptKey: 'faro' },
+  // Cohort-ramp gate for the Faro resource_timing decomposition. SEPARATE from `faro` so the
+  // network-phase measurements can be ramped by % of users at runtime (via Flipt) independently
+  // of the main RUM signals — the FaroProvider includes ResourceTimingInstrumentation only when
+  // this flag is on AND the NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED build-arg is set.
+  // availability ['mod'] is the Flipt-DOWN fallback (mirrors `faro`); Flipt is authoritative
+  // when the flag exists — ramp by bumping its % rollout, never all-at-once.
+  faroResourceTiming: { availability: ['mod'], fliptKey: 'faro-resource-timing' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },


### PR DESCRIPTION
## What

Adds a **cohort-ramp gate** for the Faro `resource_timing` decomposition so it can be ramped by
**% of users at runtime** (not 100%-at-once). Gates `ResourceTimingInstrumentation` on a
dedicated Flipt feature flag **`faro-resource-timing`** in **addition** to the existing
`NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED` build-arg.

- **Build-arg** (`NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED`) = compiled-in **master enable/kill**.
- **Flipt flag** (`faro-resource-timing`) = **which cohort** (the runtime % rollout).

Both must be true (**AND**) for the instrumentation to attach. This mirrors exactly how the main
`faro` RUM flag ramped: ops dials the cohort by bumping the Flipt % — **no rebuild**.

## Why

`resource_timing` was previously gated only on the build-arg, so turning it on was all-or-nothing
with no runtime cohort control. Given the volume/scale sensitivity (all RUM signals share one
Loki stream, `source="faro-rum"`, capped at 10 MB/s per-stream), the ramp needs to be a gradual
% rollout that ops can advance and instantly halt at runtime, watching the faro-rum stream bytes
stay under the ceiling — same operational model as the main flag. A dedicated flag (separate from
`faro`) lets the network-phase measurements ramp **independently** of the main RUM signals.

## Changes

- **`src/server/services/feature-flags.service.ts`** — new flag next to `faro`:
  `faroResourceTiming: { availability: ['mod'], fliptKey: 'faro-resource-timing' }`.
  `availability: ['mod']` is the **Flipt-DOWN fallback** (mirrors `faro`); Flipt is authoritative
  when the flag exists — ramp via its % rollout, base `enabled:false`, never all-at-once.
- **`src/components/Faro/FaroProvider.tsx`** — the module-scope `initFaro` now takes
  `initFaro({ resourceTimingCohort })`; the component threads in `!!features.faroResourceTiming`
  (no feature-flags hook imported into module scope). The condition to attach
  `ResourceTimingInstrumentation` now requires **both** the build-arg **and** the cohort boolean.
  StrictMode/HMR idempotency guards are untouched; the cohort is read once at first-init (same
  model as the existing `features.faro` gate on the whole SDK), so a flag change applies on the
  next page load. The build-arg gate, `sampleRate`, and the rate limiter are **unchanged**.
- **`src/components/Faro/ResourceTimingInstrumentation.ts`** — factored the two-gate decision into
  an exported `buildResourceTimingInstrumentations({ buildArgEnabled, cohortEnabled, sampleRateEnv,
  maxPerWindowEnv })` that returns a 0-or-1-element array to spread into the Faro `instrumentations`
  list. This is the **exact** path FaroProvider uses, so the unit test is load-bearing on the real
  wiring, not a parallel copy.
- **`src/components/Faro/__tests__/ResourceTimingInstrumentation.test.ts`** — new cases:
  attaches only when **both** gates are true; excluded when cohort-off / build-arg-off / both-off;
  and the env-knobs still flow through when attached.

## Testing

- **Unit:** `vitest run --project unit` on the two Faro test files → **41 passed** (30 + 11; the
  instrumentation-wiring file grew from 6 → 11 with the two-gate cases). Actually run, green.
- **Typecheck:** `tsc --noEmit` reports 17 pre-existing errors in this NixOS env, all in **untouched**
  files (generated kysely types, `image.service.ts`, `bitdex-stats.ts`, `flipt/client.ts`) — none
  reference my changed files. Notably there's **no** error on `FaroProvider.tsx`, which reads
  `features.faroResourceTiming`, confirming the new flag key is present in the derived feature-flags
  type. My change is additive and introduces zero type errors. CI is the source of truth.
- **Lint:** `pnpm run lint` remains broken repo-wide in this NixOS env at config-load
  (`eslint-config-next@16` flat-config vs the repo's legacy `.eslintrc.js` under `eslint@8.57`,
  crashes on untouched files too). Verified the changed files lint **clean** against the repo's
  substantive rules (`@typescript-eslint` + `prettier/prettier` at the repo's exact settings,
  `consistent-type-imports`) with the broken `next` extend dropped — the only flagged line is a
  **pre-existing** `typeof import()` in `feature-flags.service.ts:375` (identical on `origin/main`,
  outside my one-hunk diff at line 59). CI's working config is the source of truth.

## Rollout (follow-up, not this PR)

Create the `faro-resource-timing` Flipt flag (base `enabled:false`), set the build-arg
`NEXT_PUBLIC_FARO_RESOURCE_TIMING_ENABLED=true` (datapacket-talos build-arg), then ramp the flag %
gradually, watching the faro-rum Loki stream bytes stay under 10 MB/s at each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
