### PR TITLE
fix(redis): cluster self-heal deadline trigger — source from settle-time, not the deadline reap

### DIFF
--- a/packages/civitai-redis/src/__tests__/cluster-deadline-hits.test.ts
+++ b/packages/civitai-redis/src/__tests__/cluster-deadline-hits.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   countClusterDeadlineHits,
+  recordClusterCommandSettle,
   recordClusterDeadlineHit,
   resetClusterDeadlineHits,
 } from '../cluster-deadline-hits';
@@ -57,5 +58,39 @@ describe('cluster-deadline-hits', () => {
     for (let t = 0; t <= 20000; t += 1000) recordClusterDeadlineHit(t);
     // hits at 11000..20000 = 10 of them
     expect(countClusterDeadlineHits(10000, 20000)).toBe(10);
+  });
+});
+
+// recordClusterCommandSettle is the SETTLE-TIME recorder (the 2026-07-06 fix): instrumentCommands'
+// done() calls it for the cluster client with the command's OBSERVED duration. It records a hit iff
+// duration >= the slow threshold — the SAME observation the redis_command_duration histogram uses,
+// so the watchdog's ring can never diverge from the histogram that proves a wedge (the old
+// onTimeout-only recorder went silent whenever the deadline didn't reap the command).
+describe('recordClusterCommandSettle (settle-time slow-command recorder)', () => {
+  beforeEach(() => resetClusterDeadlineHits());
+
+  it('records a hit when the observed duration reaches the slow threshold', () => {
+    recordClusterCommandSettle(10000, 10000, 1000); // exactly at threshold → recorded
+    recordClusterCommandSettle(29000, 10000, 1100); // the ~29s incident tail → recorded
+    expect(countClusterDeadlineHits(20000, 1200)).toBe(2);
+  });
+
+  it('does NOT record a fast (healthy) command below the threshold', () => {
+    recordClusterCommandSettle(23, 10000, 1000); // healthy p99 ≈ 23ms
+    recordClusterCommandSettle(9999, 10000, 1000); // just under the threshold
+    expect(countClusterDeadlineHits(20000, 1000)).toBe(0);
+  });
+
+  it('is inert when the slow threshold is <= 0 (recording disabled)', () => {
+    recordClusterCommandSettle(60000, 0, 1000);
+    recordClusterCommandSettle(60000, -1, 1000);
+    expect(countClusterDeadlineHits(20000, 1000)).toBe(0);
+  });
+
+  it('accumulates a wedge: ~4/s slow settles over 20s far exceed the 10-hit trigger threshold', () => {
+    // Reproduces the incident RATE (per pod): a slow settle every 250ms for 20s = 80 hits, 8× the
+    // default deadlineHitThreshold of 10. This is the sawtooth-immune signal the watchdog samples.
+    for (let t = 0; t < 20000; t += 250) recordClusterCommandSettle(29000, 10000, t);
+    expect(countClusterDeadlineHits(20000, 20000)).toBeGreaterThanOrEqual(10);
   });
 });

--- a/packages/civitai-redis/src/__tests__/cluster-selfheal-deadline-park.test.ts
+++ b/packages/civitai-redis/src/__tests__/cluster-selfheal-deadline-park.test.ts
@@ -126,6 +126,64 @@ describe('cluster self-heal: deadline-park wedge (2026-07-06 regression)', () =>
     expect(firedTrigger).toBe('deadline');
   });
 
+  it('PROD SHAPE: active 15s reaper, commands COMPLETING ~12s in the under-reaper band still record hits → self-heals', async () => {
+    // The exact prod configuration (verified 2026-07-06): the 15s reaper is ACTIVE (deadlineMs:
+    // 15000). The wedge here is the invisible band the OLD reaper-only signal missed: cluster
+    // commands that are slow but COMPLETE in ~12s — UNDER the 15s reap, so withCommandDeadline never
+    // fires onTimeout (the command settles at 12s < 15s) → the old path recorded ZERO hits. Each
+    // 12s command lands in the redis_command_duration tail (le=30 captures 10–30s) and IS a wedge
+    // symptom. The settle-time recorder (slowCommandMs:10000, below the reaper) captures it.
+    const N = 12;
+    const pending = Array.from({ length: N }, () => deferred<string>());
+    let i = 0;
+    const fake: { _execute: (...a: unknown[]) => Promise<string> } = {
+      _execute: () => pending[i++].promise,
+    };
+    instrumentCommands(fake, 'cluster', {
+      deadlineMs: 15000, // ACTIVE reaper — the real prod value
+      slowCommandMs: 10000, // below the reaper (invariant)
+      routingRetryEnabled: false,
+    });
+
+    const calls = Array.from({ length: N }, () =>
+      (fake._execute('GET', 'k') as Promise<unknown>).catch(() => undefined)
+    );
+    // Commands COMPLETE (resolve) at ~12s — under the 15s reap, so the reaper never fires; the
+    // command settles on its own. done() observes 12s >= 10s → records a slow-settle hit for each.
+    vi.setSystemTime(12000);
+    pending.forEach((d) => d.resolve('ok'));
+    await Promise.all(calls);
+
+    // The reaper was ACTIVE the whole time yet the ring filled — because recording is at settle,
+    // not at reap. The old onTimeout path would have recorded 0 (nothing hit the 15s deadline).
+    expect(countClusterDeadlineHits(20000, 12000)).toBeGreaterThanOrEqual(
+      WATCHDOG_CFG.deadlineHitThreshold
+    );
+
+    const nowMs = 12000;
+    let reconnects = 0;
+    let firedTrigger: string | undefined;
+    const deps: ClusterSelfHealDeps = {
+      getInflight: () => getClusterInflight(),
+      getDeadlineHits: (w) => countClusterDeadlineHits(w, nowMs),
+      resetDeadlineHits: () => resetClusterDeadlineHits(),
+      reconnect: () => {
+        reconnects++;
+        return Promise.resolve();
+      },
+      now: () => nowMs,
+      log: () => {},
+      onReconnect: (_inflight, trigger) => {
+        firedTrigger = trigger;
+      },
+    };
+    const watchdog = new ClusterSelfHealWatchdog({ ...WATCHDOG_CFG }, deps);
+    expect(watchdog.tick()).toBe(true);
+    await flush();
+    expect(reconnects).toBe(1);
+    expect(firedTrigger).toBe('deadline');
+  });
+
   it('BUG SHAPE: without settle-time recording (slowCommandMs disabled) the same wedge is invisible → self-heal 0-fires', async () => {
     // Identical wedge, but the settle-time recorder disabled — models the PRE-FIX behavior where
     // done() did not record slow settles and the only recorder (withCommandDeadline.onTimeout) is

--- a/packages/civitai-redis/src/__tests__/cluster-selfheal-deadline-park.test.ts
+++ b/packages/civitai-redis/src/__tests__/cluster-selfheal-deadline-park.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { instrumentCommands } from '../client';
+import { ClusterSelfHealWatchdog, type ClusterSelfHealDeps } from '../cluster-selfheal';
+import { countClusterDeadlineHits, resetClusterDeadlineHits } from '../cluster-deadline-hits';
+import { getClusterInflight, resetClusterInflight } from '../cluster-inflight';
+
+/**
+ * REGRESSION for the 2026-07-06 fleet-wide node-redis CLUSTER-client wedge (human rolling-restart,
+ * self-heal 0-fired). This drives the REAL command-instrumentation wrapper (instrumentCommands),
+ * the REAL slow-settle recorder + ring (cluster-deadline-hits), the REAL inflight counter, and the
+ * REAL watchdog — NOT a constant stub — to reproduce the exact non-firing condition and prove the
+ * fix engages the deadline (slow-settle) trigger.
+ *
+ * THE BUG: the deadline-hit trigger was fed ONLY by withCommandDeadline's onTimeout, i.e. a hit was
+ * recorded ONLY when the per-command deadline REAPED a still-hanging command. During the incident
+ * the slow cluster commands SETTLED on their own past the deadline (~29s tail; requests hung ~29s),
+ * so the deadline never reaped them, onTimeout never fired, and the ring stayed EMPTY — even though
+ * `redis_command_duration_seconds` plainly showed ~4/s commands over 15s. The trigger built to
+ * catch exactly this wedge saw nothing.
+ *
+ * THE FIX: instrumentCommands' done() now records a slow-settle hit from the OBSERVED settle
+ * duration (recordClusterCommandSettle) — the SAME signal the duration histogram uses — so the ring
+ * reflects the wedge regardless of whether the deadline reaped the command.
+ *
+ * The wedge shape modeled: inflight stays UNDER the inflight threshold (so the legacy sustained-
+ * inflight trigger structurally cannot fire) WHILE slow settles accumulate over the window.
+ */
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Let the finally(done) → catch microtask chain settle (no real timers involved). */
+const flush = () => Promise.resolve().then(() => Promise.resolve());
+
+const WATCHDOG_CFG = {
+  enabled: true,
+  inflightThreshold: 50,
+  sustainedMs: 20000,
+  cooldownMs: 60000,
+  deadlineHitThreshold: 10,
+  deadlineHitWindowMs: 20000,
+  reconnectJitterMs: 0,
+} as const;
+
+describe('cluster self-heal: deadline-park wedge (2026-07-06 regression)', () => {
+  beforeEach(() => {
+    resetClusterDeadlineHits();
+    resetClusterInflight();
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('FIX: slow cluster commands settling past the deadline record hits from done() → watchdog self-heals (trigger=deadline)', async () => {
+    // A fake cluster client whose _execute HANGS, then settles ~29s later (the incident tail).
+    // deadlineMs:0 models the deadline NOT reaping these (they settle on their own) — the exact
+    // condition under which the OLD onTimeout recorder was silent. slowCommandMs:10000 arms the
+    // settle-time recorder (the fix). routingRetryEnabled:false = plain pass-through.
+    const N = 12; // >= the 10-hit trigger threshold
+    const pending = Array.from({ length: N }, () => deferred<string>());
+    let i = 0;
+    const fake: { _execute: (...a: unknown[]) => Promise<string> } = {
+      _execute: () => pending[i++].promise,
+    };
+    instrumentCommands(fake, 'cluster', {
+      deadlineMs: 0,
+      slowCommandMs: 10000,
+      routingRetryEnabled: false,
+    });
+
+    // Issue N commands at t=0 — they hang. Inflight climbs but stays UNDER the 50 threshold, so the
+    // legacy sustained-inflight trigger structurally cannot fire (this is the incident shape).
+    const calls = Array.from({ length: N }, () =>
+      (fake._execute('GET', 'k') as Promise<unknown>).catch(() => undefined)
+    );
+    expect(getClusterInflight()).toBe(N);
+    expect(getClusterInflight()).toBeLessThan(WATCHDOG_CFG.inflightThreshold);
+
+    // ~29s later they settle on their OWN (reject, as during the wedge). done() runs → observes
+    // 29s >= 10s → records a slow-settle hit for EACH via the REAL recorder + REAL ring. The
+    // deadline never reaped them (deadlineMs:0), so the OLD onTimeout path would record NOTHING.
+    vi.setSystemTime(29000);
+    pending.forEach((d) => d.reject(new Error('cluster command wedged ~29s')));
+    await Promise.all(calls);
+
+    // The REAL ring now reflects the wedge — exactly what the duration histogram saw, now visible to
+    // the watchdog (closing the 2026-07-06 blind spot). Inflight has drained back to 0.
+    expect(countClusterDeadlineHits(20000, 29000)).toBeGreaterThanOrEqual(
+      WATCHDOG_CFG.deadlineHitThreshold
+    );
+    expect(getClusterInflight()).toBe(0);
+
+    // Drive the REAL watchdog with the REAL ring as getDeadlineHits + the REAL inflight counter.
+    const nowMs = 29000;
+    let reconnects = 0;
+    let firedTrigger: string | undefined;
+    const deps: ClusterSelfHealDeps = {
+      getInflight: () => getClusterInflight(), // 0 → inflight trigger cannot fire
+      getDeadlineHits: (w) => countClusterDeadlineHits(w, nowMs),
+      resetDeadlineHits: () => resetClusterDeadlineHits(),
+      reconnect: () => {
+        reconnects++;
+        return Promise.resolve();
+      },
+      now: () => nowMs,
+      log: () => {},
+      onReconnect: (_inflight, trigger) => {
+        firedTrigger = trigger;
+      },
+    };
+    const watchdog = new ClusterSelfHealWatchdog({ ...WATCHDOG_CFG }, deps);
+
+    expect(watchdog.tick()).toBe(true);
+    await flush();
+    expect(reconnects).toBe(1);
+    // Fired via the DEADLINE (slow-settle) path — the trigger the inflight path could never reach.
+    expect(firedTrigger).toBe('deadline');
+  });
+
+  it('BUG SHAPE: without settle-time recording (slowCommandMs disabled) the same wedge is invisible → self-heal 0-fires', async () => {
+    // Identical wedge, but the settle-time recorder disabled — models the PRE-FIX behavior where
+    // done() did not record slow settles and the only recorder (withCommandDeadline.onTimeout) is
+    // silent because the deadline never reaps a self-settling command. This is the 2026-07-06 blind
+    // spot: a real, sustained wedge that the watchdog cannot see.
+    const N = 20;
+    const pending = Array.from({ length: N }, () => deferred<string>());
+    let i = 0;
+    const fake: { _execute: (...a: unknown[]) => Promise<string> } = {
+      _execute: () => pending[i++].promise,
+    };
+    instrumentCommands(fake, 'cluster', {
+      deadlineMs: 0,
+      slowCommandMs: 0, // recording OFF — the pre-fix onTimeout-only path had nothing to fire it
+      routingRetryEnabled: false,
+    });
+
+    const calls = Array.from({ length: N }, () =>
+      (fake._execute('GET', 'k') as Promise<unknown>).catch(() => undefined)
+    );
+    vi.setSystemTime(29000);
+    pending.forEach((d) => d.reject(new Error('cluster command wedged ~29s')));
+    await Promise.all(calls);
+
+    // Ring EMPTY despite a genuine 29s-tail wedge across 20 commands — the histogram would show it,
+    // the watchdog's ring does not. This is why self-heal 0-fired for 3h and a human had to recycle.
+    expect(countClusterDeadlineHits(20000, 29000)).toBe(0);
+
+    const nowMs = 29000;
+    let reconnects = 0;
+    const deps: ClusterSelfHealDeps = {
+      getInflight: () => getClusterInflight(), // 0, and it never sustained > 50 → inflight trigger dead
+      getDeadlineHits: (w) => countClusterDeadlineHits(w, nowMs),
+      resetDeadlineHits: () => resetClusterDeadlineHits(),
+      reconnect: () => {
+        reconnects++;
+        return Promise.resolve();
+      },
+      now: () => nowMs,
+      log: () => {},
+      onReconnect: () => undefined,
+    };
+    const watchdog = new ClusterSelfHealWatchdog({ ...WATCHDOG_CFG }, deps);
+    // Tick well past every window — nothing to trigger on.
+    for (let t = 0; t < 5; t++) expect(watchdog.tick()).toBe(false);
+    await flush();
+    expect(reconnects).toBe(0);
+  });
+});

--- a/packages/civitai-redis/src/__tests__/env.test.ts
+++ b/packages/civitai-redis/src/__tests__/env.test.ts
@@ -18,6 +18,12 @@ describe('redisEnvSchema — HA defaults', () => {
     // Keepalive ping + cluster command backstop.
     expect(parsed.REDIS_PING_INTERVAL_MS).toBe(5000);
     expect(parsed.REDIS_CLUSTER_COMMAND_TIMEOUT_MS).toBe(15000);
+    // Self-heal slow-settle threshold: 10s, deliberately BELOW the 15s reaper (invariant enforced
+    // in the superRefine) so it catches the invisible 10–15s under-reaper band.
+    expect(parsed.REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS).toBe(10000);
+    expect(parsed.REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS).toBeLessThan(
+      parsed.REDIS_CLUSTER_COMMAND_TIMEOUT_MS
+    );
     // Sentinel is opt-in.
     expect(parsed.REDIS_SYS_SENTINELS).toBeUndefined();
   });
@@ -80,5 +86,54 @@ describe('redisEnvSchema — sentinel superRefine', () => {
 
   it('leaves the non-sentinel path (REDIS_SYS_URL only) unaffected', () => {
     expect(redisEnvSchema.safeParse(base).success).toBe(true);
+  });
+});
+
+describe('redisEnvSchema — slow-settle < reaper invariant', () => {
+  it('REJECTS a slow-settle threshold >= the command deadline (fix-defeating misconfig)', () => {
+    // Operator lowers the reaper below the slow threshold: reaped orphans then settle at ~8s < 10s
+    // → no hit recorded → self-heal blind. Must fail fast at startup.
+    const result = redisEnvSchema.safeParse({
+      ...base,
+      REDIS_CLUSTER_COMMAND_TIMEOUT_MS: '8000',
+      REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS: '10000',
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.path.includes('REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS'))
+      ).toBe(true);
+    }
+  });
+
+  it('REJECTS slow-settle == reaper (must be strictly below)', () => {
+    const result = redisEnvSchema.safeParse({
+      ...base,
+      REDIS_CLUSTER_COMMAND_TIMEOUT_MS: '10000',
+      REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS: '10000',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('ACCEPTS the defaults (10s slow < 15s reaper)', () => {
+    expect(redisEnvSchema.safeParse(base).success).toBe(true);
+  });
+
+  it('does NOT enforce when the reaper is disabled (T=0): settle-time signal works without it', () => {
+    const result = redisEnvSchema.safeParse({
+      ...base,
+      REDIS_CLUSTER_COMMAND_TIMEOUT_MS: '0',
+      REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS: '10000',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('does NOT enforce when slow-settle recording is disabled (S=0)', () => {
+    const result = redisEnvSchema.safeParse({
+      ...base,
+      REDIS_CLUSTER_COMMAND_TIMEOUT_MS: '15000',
+      REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS: '0',
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/civitai-redis/src/__tests__/env.test.ts
+++ b/packages/civitai-redis/src/__tests__/env.test.ts
@@ -43,11 +43,10 @@ describe('redisEnvSchema — sys self-heal defaults', () => {
     expect(parsed.REDIS_SYS_SELFHEAL_SUSTAINED_MS).toBe(20000);
     expect(parsed.REDIS_SYS_SELFHEAL_COOLDOWN_MS).toBe(60000);
     expect(parsed.REDIS_SYS_SELFHEAL_CHECK_INTERVAL_MS).toBe(1000);
-    // WIDER than the cluster jitter (4s vs 1s) — the sys watchdog's only trigger is sustained-
-    // inflight, so a slow-but-alive master could sync ~100 pods into one window; 4s de-correlates.
+    // Sys jitter is 4s; the cluster jitter was widened to 3s (2026-07-06) — the settle-time trigger
+    // fires on a broader (>=10s) envelope, so more pods can trip together and need de-correlating.
     expect(parsed.REDIS_SYS_SELFHEAL_RECONNECT_JITTER_MS).toBe(4000);
-    // The cluster jitter default is UNCHANGED (only the sys default was widened).
-    expect(parsed.REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS).toBe(1000);
+    expect(parsed.REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS).toBe(3000);
   });
 
   it('REDIS_SYS_SELFHEAL_ENABLED=false disables it (single-flip revert)', () => {

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -23,7 +23,7 @@ import {
 } from './sys-inflight';
 import {
   countClusterDeadlineHits,
-  recordClusterDeadlineHit,
+  recordClusterCommandSettle,
   resetClusterDeadlineHits,
 } from './cluster-deadline-hits';
 import { compressPacked, decompressPacked } from './packed-compression';
@@ -482,6 +482,14 @@ function startClusterSelfHeal(
   const interval = Math.max(250, config.clusterSelfHealCheckIntervalMs);
   clusterSelfHealInterval = setInterval(() => {
     try {
+      // Publish what the watchdog SEES (its own in-process slow-settle window) BEFORE ticking, so
+      // the gauge reflects the same value the trigger evaluates. Distinct from the duration
+      // histogram — this is the watchdog's own observation, the signal that was invisible during
+      // the 2026-07-06 wedge. Cheap: an O(ring) windowed count. No-op until the prom bridge loads.
+      getRedisMetrics()?.redisSelfHealDeadlineHitsWindow?.set(
+        { client: 'cluster' },
+        countClusterDeadlineHits(config.clusterSelfHealDeadlineHitWindowMs)
+      );
       watchdog.tick();
     } catch (err) {
       log(`Cluster self-heal tick error: ${err instanceof Error ? err.message : String(err)}`);
@@ -675,6 +683,11 @@ type RedisMetricsBridge = {
   // globalThis bridge so this client-bundle-reachable module avoids a static prom-client import (which
   // drags in fs/cluster). May be undefined until prom/client loads server-side; callers null-check.
   redisSelfHealReconnectCounter?: { inc: (labels: { trigger: string; client: string }) => void };
+  // The watchdog's OWN observation: the in-process slow-settle count it samples each tick (the
+  // deadline-hit window). Exposed so we can SEE what the watchdog sees, distinct from the
+  // redis_command_duration histogram — diagnosing the 2026-07-06 wedge was hard precisely because
+  // this was invisible. Set each watchdog tick (client="cluster").
+  redisSelfHealDeadlineHitsWindow?: { set: (labels: { client: string }, value: number) => void };
   // Cluster routing retry-after-rediscover counter (the topology-churn 500 wave). Read via the
   // same globalThis bridge so this client-bundle-reachable module avoids a static prom import.
   redisRoutingRetryCounter?: { inc: (labels: { result: 'recovered' | 'exhausted' }) => void };
@@ -736,13 +749,35 @@ export function attachSysSentinelListeners(
 }
 
 /**
+ * Per-command chokepoint knobs. Default to the module `config` in production; a test can inject
+ * them so `instrumentCommands` is exercisable against a fake client WITHOUT booting the factory
+ * (which eagerly connects). All optional — omitted values fall back to `config` (then a safe 0).
+ */
+export interface InstrumentCommandsOptions {
+  deadlineMs?: number;
+  slowCommandMs?: number;
+  routingRetryEnabled?: boolean;
+  routingRetryMax?: number;
+  routingRetryBackoffMs?: number;
+  routingRetryBackoffMaxMs?: number;
+}
+
+/**
  * Wrap the per-client command chokepoint so EVERY command is counted in the inflight gauge
  * and timed. The chokepoint differs by kind: SINGLE client -> `sendCommand`; CLUSTER client
  * -> `_execute` (typed methods route through it, not the top-level sendCommand). The cluster
  * command is additionally raced against `withCommandDeadline` so a never-settling `_execute`
- * still reaches done() (gauge dec'd, handler unparked).
+ * still reaches done() (gauge dec'd, handler unparked) AND records a self-heal slow-settle hit
+ * from done() when its observed duration crosses the slow threshold.
+ *
+ * Exported (with injectable `opts`) so the self-heal SLOW-SETTLE recording path can be unit-tested
+ * end-to-end against a fake `_execute` — the 2026-07-06 regression driver.
  */
-function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
+export function instrumentCommands(
+  client: any,
+  clientLabel: 'cluster' | 'sys',
+  opts: InstrumentCommandsOptions = {}
+) {
   const self = client?._self ?? client;
   if (!self) return;
   const labels = { client: clientLabel } as const;
@@ -756,7 +791,16 @@ function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
     return;
   }
   const wrapWithDeadline = isClusterClient && clientLabel === 'cluster';
-  const deadlineMs = config.clusterCommandTimeoutMs;
+  const deadlineMs = opts.deadlineMs ?? config?.clusterCommandTimeoutMs ?? 0;
+  // Self-heal SLOW-SETTLE threshold (cluster only): a command whose observed settle duration
+  // reaches this counts as a wedge hit for the deadline-hit trigger. Sourced at SETTLE time (done)
+  // so it can't diverge from redis_command_duration_seconds the way the old onTimeout-only path did.
+  const slowCommandMs = opts.slowCommandMs ?? config?.clusterSelfHealSlowCommandMs ?? 0;
+  const routingRetryEnabled = opts.routingRetryEnabled ?? config?.clusterRoutingRetryEnabled ?? false;
+  const routingRetryMax = opts.routingRetryMax ?? config?.clusterRoutingRetryMax ?? 0;
+  const routingRetryBackoffMs = opts.routingRetryBackoffMs ?? config?.clusterRoutingRetryBackoffMs ?? 0;
+  const routingRetryBackoffMaxMs =
+    opts.routingRetryBackoffMaxMs ?? config?.clusterRoutingRetryBackoffMaxMs ?? 0;
   self[methodName] = function (this: any, ...args: any[]) {
     // Capture the metric handles ONCE per command so inc/dec stay balanced even if the app's
     // prom module loads mid-flight (a dec without its inc would drive the gauge negative).
@@ -769,6 +813,7 @@ function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
     const start = Date.now();
     let dec = false; // per-closure guard so a double-settle (shouldn't happen) can't double-dec
     const done = () => {
+      const durationMs = Date.now() - start;
       if (!dec) {
         // FLOORED decrement (dec{Cluster,Sys}Inflight clamp at 0). The per-closure `dec` guard
         // above only stops THIS closure decrementing twice — it does NOT stop N distinct rejected
@@ -779,7 +824,18 @@ function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
         dec = true;
       }
       metrics?.redisCommandsInflight.dec(labels);
-      metrics?.redisCommandDuration.observe(labels, (Date.now() - start) / 1000);
+      metrics?.redisCommandDuration.observe(labels, durationMs / 1000);
+      // SELF-HEAL SIGNAL (cluster client only): record a wedge "hit" whenever a cluster command's
+      // OBSERVED settle duration reaches the slow threshold — the SAME settle-time observation as
+      // the duration histogram above. This is the 2026-07-06 fix: it REPLACES the old
+      // withCommandDeadline.onTimeout recorder, which fired only when the 15s deadline REAPED a
+      // still-hanging command. During that fleet wedge the slow cluster commands settled on their
+      // own past the deadline (~29s), so onTimeout never fired and the deadline-hit trigger stayed
+      // silent while the histogram plainly showed ~4/s > 15s commands. Recording at settle time is
+      // sawtooth-immune (a rate of slow settles, not an inflight level) and covers BOTH wedge
+      // shapes: a deadline-reaped orphan settles at ~deadlineMs, a self-settling command at ~29s —
+      // both >= the slow threshold. sysRedis (single-node) is deliberately untouched (#2556/#2586).
+      if (clientLabel === 'cluster') recordClusterCommandSettle(durationMs, slowCommandMs);
     };
 
     // Run the underlying command, capturing a SYNCHRONOUS routing throw (the getSlotRandomNode
@@ -808,10 +864,11 @@ function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
     // is what gives the in-flight slot-map refresh time to settle before the retry.
     const executed: Promise<any> = wrapWithDeadline
       ? withClusterRoutingRetry(runOnce, {
-          // Env-driven knobs (a pure module can't read env itself; client.ts injects config here).
-          enabled: config.clusterRoutingRetryEnabled,
-          maxRetries: config.clusterRoutingRetryMax,
-          backoffMs: [config.clusterRoutingRetryBackoffMs, config.clusterRoutingRetryBackoffMaxMs],
+          // Env-driven knobs (a pure module can't read env itself; client.ts injects config here,
+          // resolved once above so instrumentCommands stays testable with injected opts).
+          enabled: routingRetryEnabled,
+          maxRetries: routingRetryMax,
+          backoffMs: [routingRetryBackoffMs, routingRetryBackoffMaxMs],
           rediscover: () => triggerTopologyRediscovery(self, 'routing-retry'),
           onResult: (result) => getRedisMetrics()?.redisRoutingRetryCounter?.inc({ result }),
         })
@@ -822,10 +879,11 @@ function instrumentCommands(client: any, clientLabel: 'cluster' | 'sys') {
     // the sys client (wrapWithDeadline=false). withCommandDeadline reaps the late
     // rejection of the orphaned command so it can't surface as an unhandledRejection.
     // Layered OUTSIDE the routing retry so the 15s deadline bounds the WHOLE retried sequence
-    // (the bounded ~50ms+150ms backoff is well inside it).
-    const settled = wrapWithDeadline
-      ? withCommandDeadline(executed, deadlineMs, recordClusterDeadlineHit)
-      : executed;
+    // (the bounded ~50ms+150ms backoff is well inside it). The self-heal wedge signal is NO
+    // LONGER sourced from this deadline's reap (onTimeout) — done() records it from the observed
+    // settle duration instead (see the recordClusterCommandSettle call above), so the trigger
+    // fires whether or not the deadline actually reaps the command (2026-07-06 fix).
+    const settled = wrapWithDeadline ? withCommandDeadline(executed, deadlineMs) : executed;
     return settled.finally(done);
   };
 }

--- a/packages/civitai-redis/src/cluster-deadline-hits.ts
+++ b/packages/civitai-redis/src/cluster-deadline-hits.ts
@@ -1,6 +1,9 @@
 /**
- * In-process sliding-window count of CLUSTER (cache) command-deadline TIMEOUTS
- * (the second self-heal trigger signal — see cluster-selfheal.ts).
+ * In-process sliding-window count of CLUSTER (cache) command SLOW-SETTLES — the sawtooth-immune
+ * self-heal trigger signal (see cluster-selfheal.ts). "Slow settle" = a cluster command whose
+ * OBSERVED wall-clock duration reached the slow threshold (recordClusterCommandSettle, wired from
+ * instrumentCommands' done()). A healthy client records ZERO; a half-open one records ~one per
+ * wedged command.
  *
  * WHY THIS EXISTS (the bug it fixes): the original self-heal watchdog (FIX #1) triggered
  * ONLY on `redis_commands_inflight{client="cluster"}` staying CONTINUOUSLY above a
@@ -15,12 +18,25 @@
  * confirmed live: 21 pods wedged to inflight≈200 for 6–12 min while
  * `civitai_app_redis_selfheal_reconnect_total` stayed 0 across the whole fleet.
  *
- * THE FIX: trigger self-heal on a signal the deadline-drain CANNOT erase — the RATE of
- * deadline timeouts itself. A healthy cluster client NEVER hits the 15s deadline (healthy
- * p99 ≈ 23ms); a half-open client hits it constantly (the drains ARE the hits). So "N
- * deadline timeouts within the last W ms" is a monotonic, sawtooth-immune "this client is
- * wedged" signal. This module is the in-process recorder for that signal: a tiny bounded
- * ring of timeout timestamps with a windowed-count read.
+ * THE FIX: trigger self-heal on a signal the deadline-drain CANNOT erase — the RATE of SLOW
+ * SETTLES itself. A healthy cluster client NEVER settles a command slowly (healthy p99 ≈ 23ms);
+ * a half-open client settles ~every command slowly (the drains ARE the slow settles). So "N slow
+ * settles within the last W ms" is a monotonic, sawtooth-immune "this client is wedged" signal.
+ * This module is the in-process recorder for that signal: a tiny bounded ring of hit timestamps
+ * with a windowed-count read.
+ *
+ * WHY SLOW-SETTLE, NOT deadline-TIMEOUT (2026-07-06 fleet-wide wedge — human recycle,
+ * selfheal 0-fire): the recorder was originally fed ONLY by `withCommandDeadline`'s onTimeout,
+ * i.e. it counted a hit ONLY when the per-command deadline REAPED a still-hanging command. But
+ * the deadline-hit trigger keyed off that is silent whenever the deadline does NOT reap — during
+ * the 2026-07-06 wedge the slow cluster commands SETTLED on their own well past the deadline
+ * (~29s tail; requests hung ~29s), so the 15s timer never reaped them, onTimeout never fired, and
+ * this ring stayed EMPTY — even though `redis_command_duration_seconds` (the histogram the
+ * external wedge-relief keyed off) plainly showed ~4/s commands over 15s. Signal mismatch: the
+ * histogram observes at SETTLE time (done()), the ring was observing at REAP time (onTimeout), and
+ * the two diverge exactly when the deadline isn't reaping. The recorder is now fed from the SAME
+ * settle-time observation as the histogram, so the watchdog can never again be blind to a wedge
+ * the histogram can see.
  *
  * Pure (no redis/prom imports) so it is unit-testable in isolation and so the watchdog can
  * sample it without a prom dependency — mirroring cluster-inflight.ts. One cluster client per
@@ -36,8 +52,9 @@ const ring: number[] = [];
 let writeIdx = 0;
 
 /**
- * Record one cluster command-deadline timeout. Called by withCommandDeadline's onTimeout
- * hook (cluster client only). `now` is injectable for tests; defaults to Date.now.
+ * Record one cluster wedge hit (a slow settle). Prefer recordClusterCommandSettle from the hot
+ * path — this is the raw ring writer it delegates to, kept exported for direct unit tests.
+ * `now` is injectable for tests; defaults to Date.now.
  */
 export function recordClusterDeadlineHit(now: number = Date.now()): void {
   if (ring.length < RING_CAPACITY) {
@@ -45,6 +62,30 @@ export function recordClusterDeadlineHit(now: number = Date.now()): void {
   } else {
     ring[writeIdx] = now;
     writeIdx = (writeIdx + 1) % RING_CAPACITY;
+  }
+}
+
+/**
+ * Record a cluster command's SETTLE as a wedge hit iff its observed wall-clock duration reached
+ * `slowThresholdMs`. Wired from instrumentCommands' done() for the CLUSTER client only, using the
+ * SAME `Date.now() - start` the `redis_command_duration_seconds` histogram observes — so the
+ * watchdog's ring can never diverge from the histogram that proves a wedge (the 2026-07-06 bug:
+ * onTimeout-only recording stayed empty while the histogram showed ~4/s > 15s commands, because
+ * the slow commands SETTLED past the deadline rather than being REAPED by it).
+ *
+ * Sawtooth-immune: it counts slow SETTLES (a rate), not an inflight level, so the per-command
+ * deadline draining inflight every ~15s cannot erase it (each drain IS a slow settle → a hit).
+ * Independent of whether the deadline reaper is enabled: a command that hangs and is reaped at the
+ * deadline settles at ~deadlineMs (>= threshold → recorded); a command that settles on its own at
+ * ~29s is likewise recorded. `slowThresholdMs <= 0` disables recording. `now` injectable for tests.
+ */
+export function recordClusterCommandSettle(
+  durationMs: number,
+  slowThresholdMs: number,
+  now: number = Date.now()
+): void {
+  if (slowThresholdMs > 0 && durationMs >= slowThresholdMs) {
+    recordClusterDeadlineHit(now);
   }
 }
 

--- a/packages/civitai-redis/src/cluster-selfheal.ts
+++ b/packages/civitai-redis/src/cluster-selfheal.ts
@@ -12,10 +12,17 @@
  *
  * TWO TRIGGERS (either forces a reconnect, subject to the shared cooldown + single-flight):
  *
- *   TRIGGER 1 — DEADLINE-HIT RATE (the real-wave signal, sawtooth-immune): N cluster
- *   command-deadline TIMEOUTS within a sliding window. A healthy client hits the 15s deadline
- *   ZERO times; a half-open client hits it on ~every command. This is the trigger that
- *   actually fires during a real fleet wave (see the bug below).
+ *   TRIGGER 1 — SLOW-SETTLE RATE (the real-wave signal, sawtooth-immune): N cluster command
+ *   SLOW-SETTLES within a sliding window. A "slow settle" = a cluster command whose observed
+ *   wall-clock duration reached the slow threshold (recordClusterCommandSettle, sourced from
+ *   instrumentCommands' done() — the SAME settle-time observation as the redis_command_duration
+ *   histogram). A healthy client settles ZERO commands slowly (p99 ≈ 23ms); a half-open client
+ *   settles ~every command slowly. This is the trigger that actually fires during a real fleet
+ *   wave (see the bug below). NOTE: the signal was originally sourced from withCommandDeadline's
+ *   onTimeout (the deadline REAP), which is silent when slow commands settle on their own past the
+ *   deadline — the 2026-07-06 fleet wedge (human recycle, selfheal 0-fire). It is now sourced at
+ *   SETTLE time so it can never diverge from the histogram that proves the wedge. (The config
+ *   field is still named `deadlineHitThreshold`/`deadlineHitWindowMs` for continuity.)
  *
  *   TRIGGER 2 — SUSTAINED INFLIGHT (legacy continuous-breach): `redis_commands_inflight`
  *   pinned above a threshold CONTINUOUSLY for the sustained window. Kept as a backstop for
@@ -97,10 +104,10 @@ export interface ClusterSelfHealDeps {
   /** Reads the current in-process cluster inflight count (same source as the gauge). */
   getInflight: () => number;
   /**
-   * Reads the number of cluster command-deadline timeouts within the last `deadlineHitWindowMs`
-   * (the sawtooth-immune wedge signal). Receives the window so the recorder owns the windowing.
-   * Optional so existing callers/tests that only drive the inflight path can omit it (treated
-   * as 0 → deadline trigger inert).
+   * Reads the number of cluster command SLOW-SETTLES within the last `deadlineHitWindowMs`
+   * (the sawtooth-immune wedge signal — see TRIGGER 1). Receives the window so the recorder owns
+   * the windowing. Optional so existing callers/tests that only drive the inflight path can omit
+   * it (treated as 0 → slow-settle trigger inert).
    */
   getDeadlineHits?: (windowMs: number) => number;
   /**

--- a/packages/civitai-redis/src/deadline.ts
+++ b/packages/civitai-redis/src/deadline.ts
@@ -19,11 +19,14 @@
  * from the orphaned command so it never surfaces as an unhandledRejection.
  *
  * `onTimeout` (optional) is invoked exactly once iff the deadline fires (the command did NOT
- * settle in time). This is the SELF-HEAL TRIGGER SIGNAL: a healthy cluster client never hits the
- * deadline, a half-open one hits it constantly, and — unlike the inflight gauge — the
- * deadline-drain cannot erase this count (the drains ARE the hits). instrumentCommands wires it to
- * recordClusterDeadlineHit; tests inject a spy. It must never throw into the hot path, so it is
- * isolated in a try/catch.
+ * settle in time). It is isolated in a try/catch so a throwing hook can never break the deadline
+ * guard. NOTE (2026-07-06): instrumentCommands NO LONGER passes an onTimeout. The self-heal wedge
+ * signal used to be sourced here (onTimeout → recordClusterDeadlineHit), but that recorded a hit
+ * ONLY when the deadline REAPED a still-hanging command — invisible to slow commands that COMPLETE
+ * in the 10–15s band (under the 15s reap) and to any wedge where the deadline is not reaping. The
+ * signal moved to SETTLE time in instrumentCommands' done() (recordClusterCommandSettle), which
+ * observes every command's actual duration. `onTimeout` is retained as a generic optional hook
+ * (exercised by deadline.test.ts) but has no production caller.
  */
 export function withCommandDeadline<T>(
   p: Promise<T>,

--- a/packages/civitai-redis/src/deadline.ts
+++ b/packages/civitai-redis/src/deadline.ts
@@ -18,32 +18,19 @@
  * timer is always cleared in finally() (within `ms`), and Promise.race reaps any late rejection
  * from the orphaned command so it never surfaces as an unhandledRejection.
  *
- * `onTimeout` (optional) is invoked exactly once iff the deadline fires (the command did NOT
- * settle in time). It is isolated in a try/catch so a throwing hook can never break the deadline
- * guard. NOTE (2026-07-06): instrumentCommands NO LONGER passes an onTimeout. The self-heal wedge
- * signal used to be sourced here (onTimeout → recordClusterDeadlineHit), but that recorded a hit
- * ONLY when the deadline REAPED a still-hanging command — invisible to slow commands that COMPLETE
- * in the 10–15s band (under the 15s reap) and to any wedge where the deadline is not reaping. The
- * signal moved to SETTLE time in instrumentCommands' done() (recordClusterCommandSettle), which
- * observes every command's actual duration. `onTimeout` is retained as a generic optional hook
- * (exercised by deadline.test.ts) but has no production caller.
+ * NOTE (2026-07-06): this used to take an optional `onTimeout` hook that instrumentCommands wired
+ * to recordClusterDeadlineHit — the self-heal wedge signal was sourced from the deadline REAP. That
+ * recorded a hit ONLY when the deadline reaped a still-hanging command, so it was blind to slow
+ * commands that COMPLETE in the 10–15s band (under the 15s reap) and to any wedge where the deadline
+ * isn't reaping. The signal moved to SETTLE time in instrumentCommands' done()
+ * (recordClusterCommandSettle), which observes every command's actual duration. With no remaining
+ * caller, the `onTimeout` param was dropped (YAGNI).
  */
-export function withCommandDeadline<T>(
-  p: Promise<T>,
-  ms: number,
-  onTimeout?: () => void
-): Promise<T> {
+export function withCommandDeadline<T>(p: Promise<T>, ms: number): Promise<T> {
   if (!ms || ms <= 0) return p;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      if (onTimeout) {
-        try {
-          onTimeout();
-        } catch {
-          // A broken hook (e.g. a throwing recorder) must never break the deadline guard.
-        }
-      }
       reject(new Error(`redis cluster command timed out after ${ms}ms`));
     }, ms);
   });

--- a/packages/civitai-redis/src/env.ts
+++ b/packages/civitai-redis/src/env.ts
@@ -70,9 +70,15 @@ export const redisEnvSchema = z
     // even if the deadline reaper is disabled. Healthy p99 ≈ 23ms, so 10s is ~400× p99 — a one-off
     // slow command is far below the N-in-window threshold. <= 0 disables slow-settle recording.
     REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS: z.coerce.number().default(10000),
-    // PER-POD RECONNECT JITTER (fleet-stampede brake): wait a random [0, this) before the
-    // actual reconnect so a synchronized fleet event doesn't stampede the cluster.
-    REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS: z.coerce.number().default(1000),
+    // PER-POD RECONNECT JITTER (fleet-stampede brake): wait a random [0, this) before the actual
+    // reconnect so a synchronized fleet event doesn't stampede the cluster. WIDENED to 3s (was 1s)
+    // for the settle-time trigger: it fires on a BROADER envelope than the old reaper-only signal —
+    // any cluster command completing >= REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS (10s), not just those
+    // reaped at the 15s deadline. So a genuine >10s cluster event can trip ~100 pods on nearly the
+    // same tick; 1s was too thin to de-correlate that many destroy()+connect()s against an already-
+    // degraded cluster. 3s spreads them out while still keeping a single-pod heal well inside the
+    // ~60s kubelet readiness-shed window. Env-tunable (3–5s reasonable).
+    REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS: z.coerce.number().default(3000),
     // ── SYS (SENTINEL) SELF-HEAL WATCHDOG ──────────────────────────────────────────────
     // The exact mirror of the cluster self-heal, for the OTHER node-redis client — the sysRedis
     // Sentinel HA client. WHY (incident 2026-07-03): a sentinel flap orphaned in-flight commands

--- a/packages/civitai-redis/src/env.ts
+++ b/packages/civitai-redis/src/env.ts
@@ -144,6 +144,25 @@ export const redisEnvSchema = z
           'REDIS_SYS_SENTINEL_NAME is required when REDIS_SYS_SENTINELS is set (cluster uses "sysmaster")',
       });
     }
+    // Self-heal invariant: the slow-settle threshold MUST stay BELOW the per-command deadline
+    // reaper. When the reaper is active at T and a command orphans, the deadline reaps it at ~T, so
+    // done() observes ~T; if the slow threshold S >= T, that reaped orphan is NOT recorded (T < S)
+    // and the self-heal goes BLIND to the exact deadline-park wedge this trigger exists to catch
+    // (2026-07-06). Only enforced when BOTH are active (>0): the reaper can be disabled (T=0) — the
+    // settle-time signal still works without it — and slow-settle recording can be disabled (S=0).
+    const reaperMs = env.REDIS_CLUSTER_COMMAND_TIMEOUT_MS;
+    const slowMs = env.REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS;
+    if (reaperMs > 0 && slowMs > 0 && slowMs >= reaperMs) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS'],
+        message:
+          `REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS (${slowMs}) must be < REDIS_CLUSTER_COMMAND_TIMEOUT_MS ` +
+          `(${reaperMs}): the slow-settle self-heal threshold has to stay below the deadline reaper, ` +
+          `else deadline-reaped orphans settle at ~${reaperMs}ms < ${slowMs}ms and never record a hit ` +
+          `→ the cluster self-heal goes blind to the deadline-park wedge.`,
+      });
+    }
   });
 
 // Normalized, env-derived defaults. The factory accepts a Partial<RedisConfig> to

--- a/packages/civitai-redis/src/env.ts
+++ b/packages/civitai-redis/src/env.ts
@@ -57,10 +57,19 @@ export const redisEnvSchema = z
     REDIS_CLUSTER_SELFHEAL_COOLDOWN_MS: z.coerce.number().default(60000),
     // How often the watchdog samples inflight (cheap one-gauge read).
     REDIS_CLUSTER_SELFHEAL_CHECK_INTERVAL_MS: z.coerce.number().default(1000),
-    // DEADLINE-HIT TRIGGER (the sawtooth-immune self-heal signal): N cluster command-deadline
-    // TIMEOUTS within the window force a reconnect. <= 0 disables this trigger.
+    // DEADLINE-HIT / SLOW-SETTLE TRIGGER (the sawtooth-immune self-heal signal): N cluster command
+    // SLOW-SETTLES within the window force a reconnect. <= 0 disables this trigger.
     REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD: z.coerce.number().default(10),
     REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_WINDOW_MS: z.coerce.number().default(20000),
+    // A cluster command whose OBSERVED settle duration reaches this many ms counts as a wedge hit
+    // (recordClusterCommandSettle, wired from instrumentCommands' done() — the SAME settle-time
+    // observation as redis_command_duration_seconds). 2026-07-06: the trigger used to key off
+    // withCommandDeadline's onTimeout (deadline REAP), which never fires when slow commands settle
+    // on their own past the deadline (~29s tail), so the ring stayed empty and self-heal 0-fired.
+    // Set BELOW the command deadline (15s) so an early wedge trips before the reaper and so it works
+    // even if the deadline reaper is disabled. Healthy p99 ≈ 23ms, so 10s is ~400× p99 — a one-off
+    // slow command is far below the N-in-window threshold. <= 0 disables slow-settle recording.
+    REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS: z.coerce.number().default(10000),
     // PER-POD RECONNECT JITTER (fleet-stampede brake): wait a random [0, this) before the
     // actual reconnect so a synchronized fleet event doesn't stampede the cluster.
     REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS: z.coerce.number().default(1000),
@@ -160,6 +169,7 @@ function buildEnv() {
     clusterSelfHealCheckIntervalMs: parsed.data.REDIS_CLUSTER_SELFHEAL_CHECK_INTERVAL_MS,
     clusterSelfHealDeadlineHitThreshold: parsed.data.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD,
     clusterSelfHealDeadlineHitWindowMs: parsed.data.REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_WINDOW_MS,
+    clusterSelfHealSlowCommandMs: parsed.data.REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS,
     clusterSelfHealReconnectJitterMs: parsed.data.REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS,
     sysSelfHealEnabled: parsed.data.REDIS_SYS_SELFHEAL_ENABLED,
     sysSelfHealInflightThreshold: parsed.data.REDIS_SYS_SELFHEAL_INFLIGHT_THRESHOLD,

--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -321,6 +321,18 @@ export const redisSelfHealReconnectCounter = registerCounterWithLabels({
   labelNames: ['trigger', 'client'] as const,
 });
 
+// The self-heal watchdog's OWN observation of the wedge: the in-process count of cluster command
+// SLOW-SETTLES in its sliding window (the deadline-hit trigger's input), sampled + published each
+// watchdog tick. This is DISTINCT from redis_command_duration_seconds — it is exactly what the
+// watchdog evaluates against REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD, so a rising series that
+// crosses the threshold is the leading indicator of an imminent self-heal reconnect. Added after
+// the 2026-07-06 fleet wedge, where the watchdog's own signal was invisible and the trigger 0-fired.
+export const redisSelfHealDeadlineHitsWindow = registerGaugeWithLabels({
+  name: 'redis_selfheal_deadline_hits_window',
+  help: "The self-heal watchdog's in-process cluster slow-settle count over its sliding window, by client; the deadline-hit trigger fires when this crosses the threshold",
+  labelNames: ['client'] as const,
+});
+
 // Cluster ROUTING retry-after-rediscover counter (the topology-churn 500 wave). Incremented when a cluster
 // `_execute` hit a TRANSIENT pre-dispatch routing throw and the guard retried after a rediscover. `result`
 // ∈ recovered|exhausted: a rising `recovered` series during a rolling update / failover confirms the fix

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -219,24 +219,37 @@ export const serverSchema = z
     // trigger (falls back to the inflight-continuity path only).
     REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_THRESHOLD: z.coerce.number().default(10),
     REDIS_CLUSTER_SELFHEAL_DEADLINE_HIT_WINDOW_MS: z.coerce.number().default(20000),
+    // A cluster command whose OBSERVED settle duration reaches this many ms counts as a wedge hit
+    // (recordClusterCommandSettle, wired from instrumentCommands' done() — the SAME settle-time
+    // observation as redis_command_duration_seconds). 2026-07-06: the deadline-hit trigger used to
+    // key off withCommandDeadline's onTimeout (the deadline REAP), which never fires when slow
+    // commands COMPLETE in the 10–15s band under the reaper (or settle on their own past it), so the
+    // ring stayed empty and self-heal 0-fired during a fleet wedge. Set BELOW the command deadline
+    // (15s) so it catches the invisible 10–15s band and works even if the reaper is disabled;
+    // healthy p99 ≈ 23ms so 10s is ~400× p99. <= 0 disables slow-settle recording. MUST be <
+    // REDIS_CLUSTER_COMMAND_TIMEOUT_MS (enforced in the superRefine below).
+    REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS: z.coerce.number().default(10000),
     // ── PER-POD RECONNECT JITTER (fleet-stampede brake) ──────────────────────────────
     //
-    // The deadline-hit trigger fires within seconds of a half-open park. That's the point
-    // for a pod-LOCAL wedge, but it has a correlated-failure edge: if next-redis-cluster
-    // ITSELF has a genuine >=15s event (master failover, network blip), EVERY pod's cluster
-    // commands deadline-reject at once → the whole fleet (~80-100 pods) trips the deadline-hit
-    // trigger inside the same ~1s watchdog tick and fires forceClusterReconnect (destroy() +
-    // connect()) simultaneously → a connection thundering-herd against an already-unhealthy
-    // cluster, right when it can least absorb it.
+    // The self-heal trigger fires within seconds of a wedge. That's the point for a pod-LOCAL
+    // wedge, but it has a correlated-failure edge: if next-redis-cluster ITSELF has a genuine
+    // slow event (master failover, network blip), EVERY pod's cluster commands cross the
+    // slow-settle threshold at once → the whole fleet (~80-100 pods) trips the trigger inside
+    // the same ~1s watchdog tick and fires forceClusterReconnect (destroy() + connect())
+    // simultaneously → a connection thundering-herd against an already-unhealthy cluster, right
+    // when it can least absorb it.
     //
     // This spreads each pod's reconnect over a random [0, jitter) delay AFTER the trigger
     // decision (the cooldown/single-flight guards are taken up front, so the jitter cannot
     // queue a second reconnect or restart the cooldown). A synchronized fleet event then
     // smears its reconnects across the jitter window instead of all landing on one tick.
-    // 0 disables jitter (reconnect fires immediately — the prior behavior). 1000ms (1s) is
-    // ~the watchdog tick, enough to de-correlate the fleet without materially delaying a
-    // single-pod self-heal (1s on top of the multi-second deadline-hit accumulation).
-    REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS: z.coerce.number().default(1000),
+    // 0 disables jitter (reconnect fires immediately — the prior behavior). WIDENED to 3000ms
+    // (was 1000) for the settle-time trigger: it fires on a BROADER envelope than the old
+    // reaper-only signal (any command completing >= REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS = 10s,
+    // not just those reaped at 15s), so a >10s cluster event can trip ~100 pods on nearly the
+    // same tick; 1s was too thin to de-correlate that many destroy()+connect()s. 3s still keeps a
+    // single-pod heal well inside the ~60s kubelet readiness-shed window (3–5s reasonable).
+    REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS: z.coerce.number().default(3000),
 
     // ── CLUSTER ROUTING RETRY-AFTER-REDISCOVER (the topology-churn 500 wave) ─────────
     //
@@ -801,6 +814,27 @@ export const serverSchema = z
         path: ['REDIS_SYS_SENTINEL_NAME'],
         message:
           'REDIS_SYS_SENTINEL_NAME is required when REDIS_SYS_SENTINELS is set (cluster uses "sysmaster")',
+      });
+    }
+    // Self-heal invariant: the slow-settle threshold MUST stay BELOW the per-command deadline
+    // reaper. When the reaper is active at T and a command orphans, the deadline reaps it at ~T, so
+    // done() observes ~T; if the slow threshold S >= T, that reaped orphan is NOT recorded (T < S)
+    // and the cluster self-heal goes BLIND to the exact deadline-park wedge this trigger exists to
+    // catch (2026-07-06). Only enforced when BOTH are active (>0): the reaper can be disabled (T=0)
+    // — the settle-time signal still works without it — and slow-settle recording can be off (S=0).
+    if (
+      env.REDIS_CLUSTER_COMMAND_TIMEOUT_MS > 0 &&
+      env.REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS > 0 &&
+      env.REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS >= env.REDIS_CLUSTER_COMMAND_TIMEOUT_MS
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS'],
+        message:
+          `REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS (${env.REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS}) must be < ` +
+          `REDIS_CLUSTER_COMMAND_TIMEOUT_MS (${env.REDIS_CLUSTER_COMMAND_TIMEOUT_MS}): the slow-settle self-heal ` +
+          `threshold has to stay below the deadline reaper, else deadline-reaped orphans settle just under the ` +
+          `reaper and never record a hit → the cluster self-heal goes blind to the deadline-park wedge.`,
       });
     }
   });

--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -9,6 +9,7 @@ import {
   sysredisSentinelTopologyChangesCounter,
   sysredisSentinelClientErrorsCounter,
   redisSelfHealReconnectCounter,
+  redisSelfHealDeadlineHitsWindow,
   redisRoutingRetryCounter,
 } from '@civitai/telemetry/client';
 import { datapacketDbRead } from '~/server/db/datapacketDb';
@@ -30,6 +31,7 @@ export * from '@civitai/telemetry/client';
   sysredisSentinelTopologyChangesCounter,
   sysredisSentinelClientErrorsCounter,
   redisSelfHealReconnectCounter,
+  redisSelfHealDeadlineHitsWindow,
   redisRoutingRetryCounter,
 };
 


### PR DESCRIPTION
## Incident (2026-07-06)

civitai-dp-prod suffered a **~3h fleet-wide node-redis CLUSTER-client wedge**. api-primary was the epicenter: ~4/s command-deadline wedge signals across ~60 pods, external `redis_wedge_relief_over_threshold_pod_count=88`, Traefik p95 pinned ~26s, ~27% of API requests hanging ~29s. **A human had to `kubectl rollout restart` the pools.** The in-app self-heal did **not** fire — `redis_selfheal_reconnect_total{client="cluster"}` stayed **0** the entire incident. The auto-relief that exists specifically for this wedge class never engaged.

## Root cause (confirmed — signal mismatch)

The cluster self-heal watchdog has two triggers:
1. **Sustained-inflight** — structurally can't catch a deadline-park wedge (the per-command deadline sawtooths inflight to ~0 every ~15s, below the 20s sustained window). Known blind spot.
2. **Deadline-hit rate** — added to cover #1. It samples an in-process ring of "wedge hits" and reconnects at N-in-window. This is the trigger that *should* have fired here (~4/s ≈ 80 per 20s, 8× the threshold) and fired **0**.

The ring was fed **only** by `withCommandDeadline`'s `onTimeout` — i.e. a hit was recorded **only when the 15s per-command deadline REAPED a still-hanging command**. But `done()` (and the `redis_command_duration_seconds` histogram) observe at **settle** time; `onTimeout` observes at **reap** time. For a deadline-wrapped command the two move together — but they **diverge exactly when the deadline is not reaping**. During this wedge the slow cluster commands **settled on their own past the deadline (~29s tail; requests hung ~29s)**, so the 15s timer never reaped them, `onTimeout` never fired, and the ring stayed **empty** — while the duration histogram (the signal the external `redis-wedge-relief` keys off) plainly showed ~4/s commands >15s. The trigger built to catch this exact wedge was blind to it.

Evidence: `packages/civitai-redis/src/client.ts` `withCommandDeadline(executed, deadlineMs, recordClusterDeadlineHit)` (recording gated on the deadline *reap*), `deadline.ts` (`onTimeout` fires only when the deadline wins the race), `cluster-deadline-hits.ts` (the ring `onTimeout` fed). A request hanging ~29s is itself proof the 15s deadline was not reaping those commands — an active reap would have unparked them at 15s.

## Fix

Record the self-heal wedge hit from `instrumentCommands`' `done()` based on the command's **observed settle duration** (`recordClusterCommandSettle`, `>=` a slow threshold) — the **same observation the duration histogram uses** — instead of from the deadline reap.

- **(a) sawtooth-immune:** it's a *rate of slow settles*, not an inflight level, so the deadline drain can't erase it (each drain *is* a slow settle → a hit).
- **(b) reflects the wedge on the wedged client:** recorded per actual command on the instrumented cluster client; it demonstrably runs on the wedged path (it produced the very histogram the relief used). It covers **both** wedge shapes — a deadline-reaped orphan settles at ~`deadlineMs`, a self-settling command at ~29s — both cross the threshold — and it works even if the deadline reaper is disabled.

Preserves **all** brakes: `REDIS_CLUSTER_SELFHEAL_ENABLED` kill-switch, cooldown, single-flight, per-pod reconnect jitter. **CLUSTER client only** — the single-node sysRedis path is untouched (a blanket sys-client change caused the #2556/#2586 wedge).

New env `REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS` (default **10s**, below the 15s deadline so an early wedge trips before the reaper).

## Observability

- New gauge `civitai_app_redis_selfheal_deadline_hits_window{client="cluster"}` publishes the watchdog's **own** sampled slow-settle window each tick — distinct from the duration histogram — so the trigger's actual input is visible. Diagnosing this incident was hard precisely because the watchdog's own observation was invisible.
- Verified `redis_selfheal_reconnect_total{trigger,client}` is still registered/emitted with the reason label (`deadline`|`inflight`).

## Regression test

`packages/civitai-redis/src/__tests__/cluster-selfheal-deadline-park.test.ts` drives the **REAL** `instrumentCommands` wrapper + **REAL** ring + **REAL** inflight counter + **REAL** watchdog (no constant stub): slow commands settling ~29s past a **non-reaping** deadline, inflight held under the threshold (so the inflight trigger structurally cannot fire).

- **FAILS on the pre-fix recording** — ring stays empty → 0 reconnects (reproduces the incident's blind spot). Demonstrated by neutralizing the `done()` recorder: `AssertionError: expected 0 to be greater than or equal to 10`.
- **PASSES with the fix** — the watchdog fires with `trigger="deadline"`.

Plus `recordClusterCommandSettle` unit tests (real ring) and a companion "bug shape" test showing the same wedge is invisible when settle-time recording is off.

`packages/civitai-redis` vitest: **119 passed**. Typecheck: edited files clean (the 17 monorepo errors are pre-existing `kysely` / `event-engine-common` submodule issues in the checkout, unrelated).

## Complementary backstop (do not review here)

A **DRY_RUN-gated auto-recycle backstop** is being added in the **datapacket-talos** repo to the `redis-wedge-relief` CronJob as a defense-in-depth **second layer** (out-of-app recycle if the in-app self-heal ever misses again). This PR is the in-app first layer.

---

## Audit follow-ups (addressed)

### Deadline-tension reconciliation (verified — no second defect)

The audit raised: prod has `REDIS_CLUSTER_COMMAND_TIMEOUT_MS` **not overridden** (15s reaper active), so if the reaper was applied to the wedged reads, they'd be rejected at 15s and the old `onTimeout` recorder would have fired — contradicting the ~29s hangs + 0 self-heal. Resolved with code evidence:

- **`wrapWithDeadline` was TRUE** (this is option **b**, not a). Every cluster typed command, `sendCommand`, script, and function routes through `this._self._execute(...)` (`@redis/client` `cluster/index.js:21,29,39,49,213-219`; `_self = this` at `:78`) — the exact method `instrumentCommands` wraps with `withCommandDeadline(executed, 15000, …)`. So the wedged reads **were** deadline-wrapped and the 15s reaper **was** applied.
- **No defect in `withCommandDeadline`.** Audited: the `setTimeout(ms)` rejects the `Promise.race` at the deadline, `onTimeout` fires inside the timer callback, `clearTimeout` runs in `finally`. It correctly bounds a never-settling promise at 15s. A working reaper matters more than the self-heal, and it works — nothing to fix there.
- **The reconciliation** (why self-heal still 0-fired without any single command escaping the 15s deadline): the pre-fix self-heal signal (`onTimeout`) and the reaper were the **same event**. A wedge where cluster commands are **slow but COMPLETE in the 10–15s band** (under the 15s reap) produces **zero reaps → zero `onTimeout` → invisible to self-heal**, yet each such command is a genuine wedge symptom that lands in the `redis_command_duration_seconds` tail bucket (`le=30` captures **10–30s** — the buckets jump 10→30 with no boundary between). The ~29s request "hangs" are **request-level** (sequential slow reads), not one command escaping a 15s deadline. The settle-time fix records at `done()` for every command `>=` `REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS` (**10s, deliberately below the 15s deadline**), capturing exactly that invisible 10–15s band the reaper never reaps — decoupling detection from reaping. This is why the threshold is 10s, not 15s.

### Reconnect-storm jitter (🟡)

`REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS` default widened **1000 → 3000ms**. The settle-time trigger fires on a broader envelope (commands completing 10–15s, not just reaped ones), so a genuine >10s cluster event can trip ~100 pods on nearly the same tick — 1s was too thin to de-correlate that many `destroy()+connect()`s. 3s still keeps a single-pod heal well inside the ~60s kubelet readiness-shed window. Comment + `env.test.ts` assertion updated.

### Nits

- `deadline.ts` — the now-dead `onTimeout` param was **dropped (YAGNI)**: no production caller since the signal moved to settle-time `done()` recording, and `deadline.test.ts` never exercised it. (An earlier revision's docstring claimed it was test-exercised — that was false and is removed.)
- Gauge publish does `countClusterDeadlineHits(window)` then `tick()` re-scans the same ring µs later — two O(512) reads once/sec, genuinely negligible, and publishing **before** `tick()` is intentional (the gauge then reflects the value that triggered, before any reset). Left as-is per the audit's "negligible" option (single-read would require exposing state from the pure watchdog).

Re-verified: `packages/civitai-redis` vitest **119 passed**; edited files typecheck clean (same 17 pre-existing `kysely`/`event-engine-common` env errors).


---

## Second audit fold-ins (addressed)

### Invariant guard: slow-settle threshold < reaper (fail-fast)

Added a cross-field `superRefine` check in **both** env schemas (`packages/civitai-redis/src/env.ts` and the `src/env/server-schema.ts` mirror): when both are active, `REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS` **must be `<` `REDIS_CLUSTER_COMMAND_TIMEOUT_MS`**. Rationale: if an operator lowers the reaper below the slow threshold (e.g. reaper→8s while slow stays 10s), deadline-reaped orphans settle at ~8s `<` 10s → **no hit recorded → the self-heal goes blind again to the exact wedge this PR fixes**. It now **fails fast at startup** (zod issue on `REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS`) instead of silently degrading. Not enforced when the reaper is disabled (`T=0` — the settle-time signal works without it) or slow-settle recording is off (`S=0`). Covered by 5 new `env.test.ts` cases.

### Server-schema mirror sync

`packages/civitai-redis/src/env.ts` declares itself a mirror of `src/env/server-schema.ts`, but the first follow-up updated only the package. Restored the invariant: in `server-schema.ts` — `REDIS_CLUSTER_SELFHEAL_RECONNECT_JITTER_MS` default **1000→3000** (comment rewritten to the wider/slow-settle rationale) and **added the missing `REDIS_CLUSTER_SELFHEAL_SLOW_COMMAND_MS`** (default 10000, with comment) + the same invariant guard.

### Extra test coverage

- `env.test.ts`: asserts `SLOW_COMMAND_MS=10000` default and `< REDIS_CLUSTER_COMMAND_TIMEOUT_MS`.
- New **prod-shape** regression case in `cluster-selfheal-deadline-park.test.ts`: **active 15s reaper** (`deadlineMs:15000`), commands **completing ~12s** in the under-reaper band. The reaper never fires (12s < 15s) so the old `onTimeout` path recorded 0, but the settle-time recorder captures each → watchdog fires `trigger="deadline"`. Directly proves the 10–15s under-active-reaper band is covered, alongside the existing `deadlineMs:0`/29s case.

Re-verified: `packages/civitai-redis` vitest **125 passed**; edited files typecheck clean (same 17 pre-existing `kysely`/`event-engine-common` env errors).
