### PR TITLE
feat(blocks): add AppBlocksDevTunnel OAuth scope for civitai app dev-tunnel

### DIFF
--- a/apps/auth/src/routes/api/auth/oauth/device-token/__tests__/server.test.ts
+++ b/apps/auth/src/routes/api/auth/oauth/device-token/__tests__/server.test.ts
@@ -147,4 +147,49 @@ describe('device-token +server — AppBlocksSubmit scope survives into the minte
     expect(((await res.json()) as { error: string }).error).toBe('invalid_grant');
     expect(h.createPair).not.toHaveBeenCalled();
   });
+
+  // The opt-in AppBlocksDevTunnel bit (1<<26, EXCLUDED from Full) must survive the
+  // ALL_SCOPES bound + per-client allowedScopes intersection when the widened
+  // civitai-cli client requests it — the migration that widens allowedScopes is what
+  // makes this pass in prod. Mirrors the AppBlocksSubmit coverage above.
+  const WIDENED_CLI_SCOPE =
+    TokenScope.UserRead | TokenScope.AppBlocksSubmit | TokenScope.AppBlocksDevTunnel; // 100663297
+
+  it('mints a token carrying AppBlocksDevTunnel when the widened client allows it', async () => {
+    h.hGet.mockResolvedValueOnce({ ...approvedCode, scope: WIDENED_CLI_SCOPE.toString() });
+    h.clientRow = { allowedScopes: WIDENED_CLI_SCOPE }; // civitai-cli AFTER the widen migration
+
+    const res = await POST(
+      makeEvent({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'devcode',
+        client_id: 'civitai-cli',
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.scope).toBe(WIDENED_CLI_SCOPE.toString());
+    // bit 26 survived the bound + intersection into the minted token pair.
+    expect(h.createPair).toHaveBeenCalledWith(7, 'civitai-cli', WIDENED_CLI_SCOPE);
+  });
+
+  it('rejects with invalid_scope when the client allowedScopes does NOT include AppBlocksDevTunnel', async () => {
+    h.hGet.mockResolvedValueOnce({ ...approvedCode, scope: WIDENED_CLI_SCOPE.toString() });
+    // Pre-widen client: allows UserRead|AppBlocksSubmit but NOT the DevTunnel bit —
+    // this is exactly the state that 400s `civitai login` if the CLI ships before the migration.
+    h.clientRow = { allowedScopes: CLI_SCOPE };
+
+    const res = await POST(
+      makeEvent({
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code: 'devcode',
+        client_id: 'civitai-cli',
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as { error: string }).error).toBe('invalid_scope');
+    expect(h.createPair).not.toHaveBeenCalled();
+  });
 });

--- a/packages/civitai-auth/src/__tests__/token-scope.test.ts
+++ b/packages/civitai-auth/src/__tests__/token-scope.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
+  ALL_SCOPES,
   TokenScope,
   TokenScopePresets,
   tokenScopeLabels,
@@ -26,5 +27,40 @@ describe('TokenScope bitmask (shared contract — must not drift)', () => {
   it('every read/write scope has a UI label', () => {
     expect(tokenScopeLabels[TokenScope.UserRead]).toBeTruthy();
     expect(tokenScopeLabels[TokenScope.AIServicesWrite]).toBeTruthy();
+  });
+});
+
+describe('AppBlocksDevTunnel (opt-in scope — NOT part of Full)', () => {
+  it('is bit 26 = 67108864', () => {
+    expect(TokenScope.AppBlocksDevTunnel).toBe(1 << 26);
+    expect(TokenScope.AppBlocksDevTunnel).toBe(67108864);
+  });
+
+  it('is EXCLUDED from Full (Full stays frozen at (1<<25)-1)', () => {
+    expect(TokenScope.Full).toBe(33554431);
+    // hasFlag-style subset test: the bit must NOT be present in Full.
+    expect(TokenScope.Full & TokenScope.AppBlocksDevTunnel).toBe(0);
+  });
+
+  it('IS included in ALL_SCOPES (the computed upper bound)', () => {
+    expect(ALL_SCOPES & TokenScope.AppBlocksDevTunnel).toBe(TokenScope.AppBlocksDevTunnel);
+    // Full is exactly ALL_SCOPES minus the two opt-in bits.
+    expect(ALL_SCOPES).toBe(
+      TokenScope.Full | TokenScope.AppBlocksSubmit | TokenScope.AppBlocksDevTunnel
+    );
+  });
+
+  it('has a consent-screen label', () => {
+    expect(tokenScopeLabels[TokenScope.AppBlocksDevTunnel]).toBeTruthy();
+  });
+
+  it('is NOT folded into any TokenScopePreset (opt-in, like AppBlocksSubmit)', () => {
+    for (const [name, preset] of Object.entries(TokenScopePresets)) {
+      // Full is a preset alias for TokenScope.Full, which itself excludes the bit.
+      expect(
+        (preset & TokenScope.AppBlocksDevTunnel) === 0,
+        `preset ${name} must not carry AppBlocksDevTunnel`
+      ).toBe(true);
+    }
   });
 });

--- a/packages/civitai-auth/src/token-scope.ts
+++ b/packages/civitai-auth/src/token-scope.ts
@@ -70,6 +70,16 @@ export const TokenScope = {
   // carries this bit AND the user is a moderator. See AppBlocksSubmit gate.
   AppBlocksSubmit: 1 << 25, // 33554432
 
+  // App Blocks — open an on-site dev tunnel for an App Block you author.
+  // Opt-in, off-by-default (NOT part of `Full`): granted only to OAuth clients
+  // that explicitly list it in `allowedScopes` and request it (currently only
+  // the first-party `civitai-cli` client, so `civitai app dev-tunnel` works over
+  // the OAuth `civitai login` token instead of a Full personal API key). The
+  // dev-tunnel tRPC procedures (blocks.router: startDevTunnel / stopDevTunnel /
+  // devTunnelStatus) gate on this bit via `.meta({ requiredScope })`. Like
+  // AppBlocksSubmit it is EXCLUDED from `Full` so it never widens an existing key.
+  AppBlocksDevTunnel: 1 << 26, // 67108864
+
   // All scopes
   //
   // NOTE: `Full` is INTENTIONALLY frozen at (1 << 25) - 1 = 33554431 — it is the
@@ -86,7 +96,7 @@ export type TokenScopeValue = (typeof TokenScope)[keyof typeof TokenScope];
 
 /**
  * Mask of EVERY defined scope bit, including opt-in scopes that are NOT part of
- * `Full` (currently `AppBlocksSubmit`). Use this as the upper bound when
+ * `Full` (currently `AppBlocksSubmit` and `AppBlocksDevTunnel`). Use this as the upper bound when
  * validating a requested/stored scope value in the OAuth flow — bounding against
  * `Full` would reject any value carrying an opt-in bit. Computed from the enum so
  * it can never drift behind a newly-added bit.
@@ -123,6 +133,7 @@ export const tokenScopeLabels: Record<number, string> = {
   [TokenScope.VaultRead]: 'View vault',
   [TokenScope.VaultWrite]: 'Manage vault',
   [TokenScope.AppBlocksSubmit]: 'Submit Apps for review',
+  [TokenScope.AppBlocksDevTunnel]: 'Open on-site dev tunnels',
 };
 
 /** Convenience presets for the API key creation UI */

--- a/packages/civitai-auth/src/token-scope.ts
+++ b/packages/civitai-auth/src/token-scope.ts
@@ -96,10 +96,10 @@ export type TokenScopeValue = (typeof TokenScope)[keyof typeof TokenScope];
 
 /**
  * Mask of EVERY defined scope bit, including opt-in scopes that are NOT part of
- * `Full` (currently `AppBlocksSubmit` and `AppBlocksDevTunnel`). Use this as the upper bound when
- * validating a requested/stored scope value in the OAuth flow — bounding against
- * `Full` would reject any value carrying an opt-in bit. Computed from the enum so
- * it can never drift behind a newly-added bit.
+ * `Full` (currently `AppBlocksSubmit` and `AppBlocksDevTunnel`). Use this as the
+ * upper bound when validating a requested/stored scope value in the OAuth flow —
+ * bounding against `Full` would reject any value carrying an opt-in bit. Computed
+ * from the enum so it can never drift behind a newly-added bit.
  */
 export const ALL_SCOPES: number = Object.entries(TokenScope)
   .filter(([key]) => key !== 'None' && key !== 'Full')

--- a/prisma/migrations/20260706120000_widen_civitai_cli_oauth_client_dev_tunnel_scope/migration.sql
+++ b/prisma/migrations/20260706120000_widen_civitai_cli_oauth_client_dev_tunnel_scope/migration.sql
@@ -1,0 +1,36 @@
+-- Widen the first-party `civitai-cli` OAuth client's allowedScopes to permit the
+-- new opt-in `TokenScope.AppBlocksDevTunnel` bit, so the OAuth `civitai login`
+-- token can open on-site App Block dev tunnels (blocks.router: startDevTunnel /
+-- stopDevTunnel / devTunnelStatus). Prior to this the CLI token carried only
+-- `UserRead | AppBlocksSubmit`, so those procedures (now gated on the DevTunnel
+-- bit) rejected it and users had to fall back to a Full-scope personal API key.
+--
+-- allowedScopes: 33554433 -> 100663297
+--   old = TokenScope.UserRead | TokenScope.AppBlocksSubmit
+--       = 1 | 33554432
+--       = 33554433
+--   new = old | TokenScope.AppBlocksDevTunnel
+--       = 33554433 | (1<<26)
+--       = 33554433 | 67108864
+--       = 100663297
+-- (AppBlocksDevTunnel, bit 26 = 1<<26 = 67108864, is opt-in and INTENTIONALLY
+--  excluded from TokenScope.Full = 33554431 — like AppBlocksSubmit. This client is
+--  the only first-party consumer that requests it.)
+--
+-- IDEMPOTENT: the OR-in of the bit is a no-op on re-apply (re-ORing the same bit
+-- leaves the value unchanged); scoped to the single `civitai-cli` row so it can
+-- never touch another client's grant.
+--
+-- 🔴 DEPLOY ORDERING: apply this migration (and merge/deploy the server change
+-- that gates the dev-tunnel procs on AppBlocksDevTunnel) BEFORE releasing a
+-- civitai CLI that REQUESTS the wider scope. If the CLI requests the bit before
+-- this widens allowedScopes, the hub's per-client allowedScopes intersection
+-- rejects the device request with `invalid_scope` and `civitai login` 400s.
+--
+-- ⚠️ MANUAL-APPLY: per the cluster ops rule, civitai DB migrations are NOT
+-- auto-applied. A human applies this to prod (CNPG nvme0) and the dev clone.
+UPDATE "OauthClient"
+SET "allowedScopes" = "allowedScopes" | 67108864, -- TokenScope.AppBlocksDevTunnel (1<<26)
+    "updatedAt" = CURRENT_TIMESTAMP
+WHERE "id" = 'civitai-cli'
+  AND ("allowedScopes" & 67108864) = 0; -- no-op once the bit is already set

--- a/src/server/routers/__tests__/blocks.router.devTunnel.test.ts
+++ b/src/server/routers/__tests__/blocks.router.devTunnel.test.ts
@@ -198,3 +198,108 @@ describe('stopDevTunnel / devTunnelStatus', () => {
     expect(res).toMatchObject({ active: true, host: 'dev-0123456789abcdef.civit.ai' });
   });
 });
+
+/**
+ * OAuth token-scope gate on the 3 dev-tunnel procs. enforceTokenScope (trpc.ts)
+ * runs in the publicProcedure base chain, BEFORE the appDeveloperProcedure author
+ * gate, so a token lacking AppBlocksDevTunnel is rejected at the scope gate with a
+ * message mentioning "scope" (distinguishing it from the author-capability
+ * FORBIDDEN). Bitmask values are hard-coded so a drift in the enum trips the test.
+ *
+ *   - Full personal API key (33554431)           → passes gate (no regression;
+ *                                                    enforceTokenScope early-returns on Full).
+ *   - New CLI OAuth token (UserRead|AppBlocksSubmit|AppBlocksDevTunnel = 100663297)
+ *                                                 → passes gate.
+ *   - Old CLI OAuth token (UserRead|AppBlocksSubmit = 33554433, NO DevTunnel bit)
+ *                                                 → FORBIDDEN at the scope gate.
+ */
+describe('dev-tunnel procs — AppBlocksDevTunnel scope gate', () => {
+  const FULL = 33554431; // TokenScope.Full
+  const NEW_CLI = 1 | (1 << 25) | (1 << 26); // UserRead|AppBlocksSubmit|AppBlocksDevTunnel = 100663297
+  const OLD_CLI = 1 | (1 << 25); // UserRead|AppBlocksSubmit = 33554433 (pre-widen CLI token)
+
+  // Ctx for a token-authenticated caller (apiKeyId set) carrying `scope`. isModerator
+  // stays true so the author gate is satisfied and the ONLY thing under test is the scope gate.
+  function tokenCtx(userId: number, scope: number) {
+    return { ...authedCtx(userId, true), apiKeyId: 999, tokenScope: scope };
+  }
+
+  it('sanity: the hard-coded bitmasks match the enum', () => {
+    expect(TokenScope.Full).toBe(FULL);
+    expect(TokenScope.UserRead | TokenScope.AppBlocksSubmit | TokenScope.AppBlocksDevTunnel).toBe(
+      NEW_CLI
+    );
+    expect(TokenScope.UserRead | TokenScope.AppBlocksSubmit).toBe(OLD_CLI);
+  });
+
+  describe('startDevTunnel', () => {
+    it('Full personal key passes the scope gate and mints (no regression)', async () => {
+      const caller = blocksRouter.createCaller(tokenCtx(100, FULL) as never);
+      const res = await caller.startDevTunnel(input);
+      expect(res.host).toMatch(/^dev-[a-f0-9]{16}\.civit\.ai$/);
+      expect(mockStart).toHaveBeenCalledTimes(1);
+    });
+
+    it('new CLI OAuth token (with DevTunnel bit) passes the scope gate and mints', async () => {
+      const caller = blocksRouter.createCaller(tokenCtx(100, NEW_CLI) as never);
+      const res = await caller.startDevTunnel(input);
+      expect(res.host).toMatch(/^dev-[a-f0-9]{16}\.civit\.ai$/);
+      expect(mockStart).toHaveBeenCalledWith({ userId: 100, blockId: 'my-app', sshPublicKey: PUBKEY });
+    });
+
+    it('old CLI OAuth token (no DevTunnel bit) → FORBIDDEN at the scope gate, never mints', async () => {
+      const caller = blocksRouter.createCaller(tokenCtx(100, OLD_CLI) as never);
+      await expect(caller.startDevTunnel(input)).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: expect.stringContaining('scope'),
+      });
+      expect(mockStart).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('stopDevTunnel', () => {
+    it('Full personal key passes the scope gate (no regression)', async () => {
+      const caller = blocksRouter.createCaller(tokenCtx(100, FULL) as never);
+      expect(await caller.stopDevTunnel({ sessionId: 'bki_s' })).toEqual({ ok: true, stopped: true });
+    });
+
+    it('new CLI OAuth token (with DevTunnel bit) passes the scope gate', async () => {
+      const caller = blocksRouter.createCaller(tokenCtx(100, NEW_CLI) as never);
+      expect(await caller.stopDevTunnel({ sessionId: 'bki_s' })).toEqual({ ok: true, stopped: true });
+      expect(mockStop).toHaveBeenCalledWith(100, 'bki_s');
+    });
+
+    it('old CLI OAuth token (no DevTunnel bit) → FORBIDDEN at the scope gate', async () => {
+      const caller = blocksRouter.createCaller(tokenCtx(100, OLD_CLI) as never);
+      await expect(caller.stopDevTunnel({ sessionId: 'bki_s' })).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: expect.stringContaining('scope'),
+      });
+      expect(mockStop).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('devTunnelStatus', () => {
+    it('Full personal key passes the scope gate (no regression)', async () => {
+      mockGetActive.mockResolvedValue(null);
+      const caller = blocksRouter.createCaller(tokenCtx(100, FULL) as never);
+      expect(await caller.devTunnelStatus({ blockId: 'my-app' })).toEqual({ active: false });
+    });
+
+    it('new CLI OAuth token (with DevTunnel bit) passes the scope gate', async () => {
+      mockGetActive.mockResolvedValue(null);
+      const caller = blocksRouter.createCaller(tokenCtx(100, NEW_CLI) as never);
+      expect(await caller.devTunnelStatus({ blockId: 'my-app' })).toEqual({ active: false });
+      expect(mockGetActive).toHaveBeenCalledWith(100, 'my-app');
+    });
+
+    it('old CLI OAuth token (no DevTunnel bit) → FORBIDDEN at the scope gate', async () => {
+      const caller = blocksRouter.createCaller(tokenCtx(100, OLD_CLI) as never);
+      await expect(caller.devTunnelStatus({ blockId: 'my-app' })).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: expect.stringContaining('scope'),
+      });
+      expect(mockGetActive).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -92,6 +92,7 @@ import { getResourceGenerationSupport } from '~/shared/constants/basemodel.const
 import type { ModelType } from '~/shared/utils/prisma/enums';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { BuzzTypes } from '~/shared/constants/buzz.constants';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 import {
   getBlockAllowedAccountTypes,
   isPayoutEligibleBuzz,
@@ -965,6 +966,12 @@ export const blocksRouter = router({
    * SAME bare NOT_FOUND, no ownership oracle). DARK until the flag is on.
    */
   startDevTunnel: appDeveloperProcedure
+    // Scope gate: an OAuth token (the `civitai login` token the civitai-cli mints)
+    // may open a dev tunnel ONLY if it carries the opt-in AppBlocksDevTunnel bit.
+    // NOTE: enforceTokenScope (trpc.ts) EARLY-RETURNS for `ctx.tokenScope === TokenScope.Full`,
+    // so a Full-scope PERSONAL API key still passes regardless of this meta — this is the
+    // no-regression guarantee. Do NOT "tighten" enforceTokenScope to also gate Full keys here.
+    .meta({ requiredScope: TokenScope.AppBlocksDevTunnel })
     .use(enforceAppBlocksFlag)
     .input(
       z.object({
@@ -1010,6 +1017,9 @@ export const blocksRouter = router({
    * can never tear down another author's tunnel. Same gates as startDevTunnel.
    */
   stopDevTunnel: appDeveloperProcedure
+    // Same AppBlocksDevTunnel scope gate as startDevTunnel. A Full personal API key
+    // still passes (enforceTokenScope early-returns on TokenScope.Full) — no regression.
+    .meta({ requiredScope: TokenScope.AppBlocksDevTunnel })
     .use(enforceAppBlocksFlag)
     .input(
       z
@@ -1041,6 +1051,9 @@ export const blocksRouter = router({
    * expiry, spend ceiling), or null when none is active. Same gates.
    */
   devTunnelStatus: appDeveloperProcedure
+    // Same AppBlocksDevTunnel scope gate as startDevTunnel. A Full personal API key
+    // still passes (enforceTokenScope early-returns on TokenScope.Full) — no regression.
+    .meta({ requiredScope: TokenScope.AppBlocksDevTunnel })
     .use(enforceAppBlocksFlag)
     .input(z.object({ blockId: z.string().min(1).max(64) }))
     .query(async ({ ctx, input }) => {


### PR DESCRIPTION
## What

Adds a dedicated opt-in **`AppBlocksDevTunnel`** OAuth token scope (bit 26 = `1<<26` = **67108864**) so the OAuth `civitai login` token minted by the `civitai-cli` client can open on-site App Block dev tunnels — without regressing Full-scope personal-API-key access.

Today the dev-tunnel tRPC procs (`startDevTunnel` / `stopDevTunnel` / `devTunnelStatus` in `blocks.router.ts`) carry no `requiredScope` meta, so `enforceTokenScope` implicitly requires `TokenScope.Full`. The CLI's OAuth token (`UserRead|AppBlocksSubmit`) is rejected, forcing users onto a Full-scope personal key. This mirrors the existing `AppBlocksSubmit` opt-in-scope pattern.

## Changes

- **`packages/civitai-auth/src/token-scope.ts`** — new `AppBlocksDevTunnel: 1 << 26`. EXCLUDED from `Full` (frozen at `(1<<25)-1 = 33554431`); auto-included in the computed `ALL_SCOPES`; consent label `"Open on-site dev tunnels"`; NOT folded into any `TokenScopePreset`.
- **`src/server/routers/blocks.router.ts`** — `.meta({ requiredScope: TokenScope.AppBlocksDevTunnel })` on all 3 dev-tunnel procs (import added). Code comment records that `enforceTokenScope` early-returns on `TokenScope.Full`, so a **Full personal API key still passes** regardless of `requiredScope` — the no-regression guarantee. `enforceTokenScope` itself is unchanged.
- **`prisma/migrations/20260706120000_widen_civitai_cli_oauth_client_dev_tunnel_scope/migration.sql`** — widens the `civitai-cli` OAuth client's `allowedScopes` from **33554433** (`UserRead|AppBlocksSubmit`) to **100663297** (`| 1<<26`). Idempotent, single-row `UPDATE ... WHERE "id" = 'civitai-cli'`, no-op once the bit is set.
- **OAuth hub (`apps/auth`)** — **no code change needed**. The device/authorize flow bounds requested scope against `ALL_SCOPES` (which auto-grew) and intersects with the client's `allowedScopes` via `hasScope`; the consent screen renders labels from `tokenScopeLabels` (new label already covers it). Verified `device-token/+server.ts`, `authorize/+server.ts`, `device/+server.ts`, `lib/server/oauth/scope.ts` — none hardcode a scope list or bound against `Full`.

## Tests (all green locally)

- `packages/civitai-auth/.../token-scope.test.ts` — bit == `1<<26`, excluded from `Full`, in `ALL_SCOPES`, has a label, absent from every preset. **8 passed.**
- `src/server/routers/__tests__/blocks.router.devTunnel.test.ts` — per proc: Full key passes the gate, new CLI token (`100663297`) passes, old CLI token (`33554433`, no DevTunnel bit) → **403 FORBIDDEN at the scope gate**; existing author/flag/ownership assertions intact. **18 passed.**
- `apps/auth/.../device-token/__tests__/server.test.ts` — widened `civitai-cli` mints a token carrying the bit; a client without it in `allowedScopes` → `invalid_scope`. **5 passed.**
- Repo typecheck (`tsc --noEmit`, root config) — **0 errors**.

## 🔴 DEPLOY ORDERING (must follow in order)

1. **Merge + deploy this server PR AND apply the new migration to prod (CNPG nvme0) + the dev clone FIRST.** (Migrations are MANUAL-APPLY per repo policy — this PR only authors the `.sql`.)
2. **ONLY THEN release the civitai CLI** that requests the wider scope. If the CLI ships first, its device request exceeds the client's `allowedScopes` and the hub rejects it with `invalid_scope` → **`civitai login` 400s for everyone**.

Also: after both are live, **users must re-run `civitai login`** to obtain a token carrying the new `AppBlocksDevTunnel` bit (existing tokens won't have it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
