### PR TITLE
perf(trpc): flag-gated authed-only request batching (httpBatchStreamLink)

### DIFF
--- a/src/providers/FeatureFlagsProvider.tsx
+++ b/src/providers/FeatureFlagsProvider.tsx
@@ -1,7 +1,7 @@
 import { useSession } from '~/providers/SessionProvider';
-import { createContext, useContext, useMemo, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import { type FeatureAccess } from '~/server/services/feature-flags.service';
-import { trpc } from '~/utils/trpc';
+import { setTrpcBatchingEnabled, trpc } from '~/utils/trpc';
 
 const FeatureFlagsCtx = createContext<FeatureAccess | null>(null);
 // Whether the per-user `getFeatureFlags` overlay has resolved. SSR seeds
@@ -71,6 +71,14 @@ export const FeatureFlagsProvider = ({
     }),
     [flags, userFeatures]
   );
+
+  // Bridge the resolved `trpcBatching` flag to the module-scope tRPC terminating
+  // link (which can't read a hook). Runs client-side only; until this fires the
+  // link stays unbatched (dark default), so anon + early-hydration queries never
+  // batch. See `shouldBatch` in `~/utils/trpc`.
+  useEffect(() => {
+    setTrpcBatchingEnabled(!!featureFlags.trpcBatching);
+  }, [featureFlags.trpcBatching]);
 
   return (
     <FeatureFlagsCtx.Provider value={featureFlags}>

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -63,6 +63,15 @@ const featureFlags = createFeatureFlags({
   // availability ['mod'] is the Flipt-DOWN fallback (mirrors `faro`); Flipt is authoritative
   // when the flag exists — ramp by bumping its % rollout, never all-at-once.
   faroResourceTiming: { availability: ['mod'], fliptKey: 'faro-resource-timing' },
+  // Cohort-ramp gate for tRPC request batching (httpBatchStreamLink). Default OFF
+  // (mods only) so batching is dark until ramped via Flipt (`trpc-batching`). Batching
+  // is applied ONLY to AUTHENTICATED-browser queries — anonymous tRPC GETs stay
+  // unbatched so they remain CF edge-cacheable (verified: anon `model.getAll` GET
+  // returns cf-cache-status HIT with s-maxage=60; authed requests have edgeTTL forced
+  // to 0 in createContext, so batching them loses no edge cache). availability ['mod']
+  // is the Flipt-DOWN fallback (mirrors `faro`); Flipt is authoritative when the flag
+  // exists — ramp by bumping its % rollout, never all-at-once. See `src/utils/trpc.ts`.
+  trpcBatching: { availability: ['mod'], fliptKey: 'trpc-batching' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },

--- a/src/utils/__tests__/trpc-batching.test.ts
+++ b/src/utils/__tests__/trpc-batching.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __getTrpcBatchingEnabled,
+  setTrpcBatchingEnabled,
+  shouldBatch,
+} from '~/utils/trpc';
+
+/**
+ * Unit coverage for the tRPC batching split decision (`shouldBatch`) that the
+ * `splitLink` terminating link uses to route a query to `httpBatchStreamLink`
+ * (batch) vs the unbatched large-query-aware link. The link objects themselves
+ * are tRPC internals; the branch SELECTION is the behaviour we own, so we test
+ * the predicate directly.
+ */
+
+// tRPC operations only need these fields for `shouldBatch`.
+type Op = { type: string; input: unknown; context: Record<string, unknown> };
+const op = (over: Partial<Op> = {}): Op => ({
+  type: 'query',
+  input: { limit: 5 },
+  context: {},
+  ...over,
+});
+
+const setWindowAuthed = (isAuthed: boolean | undefined) => {
+  (globalThis as any).window = isAuthed === undefined ? {} : { isAuthed };
+};
+const clearWindow = () => {
+  delete (globalThis as any).window;
+};
+
+beforeEach(() => {
+  setTrpcBatchingEnabled(false);
+  clearWindow();
+});
+afterEach(() => {
+  setTrpcBatchingEnabled(false);
+  clearWindow();
+});
+
+describe('setTrpcBatchingEnabled', () => {
+  it('defaults OFF and toggles the module flag', () => {
+    expect(__getTrpcBatchingEnabled()).toBe(false); // dark by default
+    setTrpcBatchingEnabled(true);
+    expect(__getTrpcBatchingEnabled()).toBe(true);
+    setTrpcBatchingEnabled(false);
+    expect(__getTrpcBatchingEnabled()).toBe(false);
+  });
+});
+
+describe('shouldBatch', () => {
+  it('batches an authed-browser small query when the flag is on', () => {
+    setTrpcBatchingEnabled(true);
+    setWindowAuthed(true);
+    expect(shouldBatch(op())).toBe(true);
+  });
+
+  it('does NOT batch when the flag is off (dark default), even if authed', () => {
+    setTrpcBatchingEnabled(false);
+    setWindowAuthed(true);
+    expect(shouldBatch(op())).toBe(false);
+  });
+
+  it('does NOT batch anonymous traffic (preserves CF edge-cache for anon GETs)', () => {
+    setTrpcBatchingEnabled(true);
+    setWindowAuthed(false);
+    expect(shouldBatch(op())).toBe(false);
+  });
+
+  it('does NOT batch when window.isAuthed is unknown/undefined (early hydration is safe)', () => {
+    setTrpcBatchingEnabled(true);
+    setWindowAuthed(undefined); // window exists but isAuthed not yet set
+    expect(shouldBatch(op())).toBe(false);
+  });
+
+  it('does NOT batch on the server (no window)', () => {
+    setTrpcBatchingEnabled(true);
+    clearWindow();
+    expect(shouldBatch(op())).toBe(false);
+  });
+
+  it('honors the skipBatch context escape hatch', () => {
+    setTrpcBatchingEnabled(true);
+    setWindowAuthed(true);
+    expect(shouldBatch(op({ context: { skipBatch: true } }))).toBe(false);
+  });
+
+  it('does NOT batch mutations (they stay standalone / keep the POST path)', () => {
+    setTrpcBatchingEnabled(true);
+    setWindowAuthed(true);
+    expect(shouldBatch(op({ type: 'mutation' }))).toBe(false);
+  });
+
+  it('does NOT batch large queries (they go out as POST methodOverride, body-carried)', () => {
+    setTrpcBatchingEnabled(true);
+    setWindowAuthed(true);
+    // input serializes to > MAX_QUERY_INPUT_LENGTH (2500 chars) => large => unbatched
+    expect(shouldBatch(op({ input: { q: 'x'.repeat(3000) } }))).toBe(false);
+  });
+
+  it('still batches a query whose input is just under the large-query threshold', () => {
+    setTrpcBatchingEnabled(true);
+    setWindowAuthed(true);
+    expect(shouldBatch(op({ input: { q: 'x'.repeat(100) } }))).toBe(true);
+  });
+});

--- a/src/utils/__tests__/trpc-batching.test.ts
+++ b/src/utils/__tests__/trpc-batching.test.ts
@@ -1,6 +1,9 @@
+import { readFileSync, readdirSync } from 'fs';
+import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   __getTrpcBatchingEnabled,
+  CACHEABLE_PROCEDURES,
   setTrpcBatchingEnabled,
   shouldBatch,
 } from '~/utils/trpc';
@@ -10,13 +13,15 @@ import {
  * `splitLink` terminating link uses to route a query to `httpBatchStreamLink`
  * (batch) vs the unbatched large-query-aware link. The link objects themselves
  * are tRPC internals; the branch SELECTION is the behaviour we own, so we test
- * the predicate directly.
+ * the predicate directly. Plus a durable guard keeping `CACHEABLE_PROCEDURES` in
+ * sync with the routers.
  */
 
 // tRPC operations only need these fields for `shouldBatch`.
-type Op = { type: string; input: unknown; context: Record<string, unknown> };
+type Op = { type: string; path: string; input: unknown; context: Record<string, unknown> };
 const op = (over: Partial<Op> = {}): Op => ({
   type: 'query',
+  path: 'model.getInfinite', // a non-edge-cacheable authed feed query (safe to batch)
   input: { limit: 5 },
   context: {},
   ...over,
@@ -79,6 +84,25 @@ describe('shouldBatch', () => {
     expect(shouldBatch(op())).toBe(false);
   });
 
+  it('does NOT batch a procedure that is edge-cacheable for authed sessions', () => {
+    setTrpcBatchingEnabled(true);
+    setWindowAuthed(true);
+    // `model.getAll` applies `edgeCacheIt` and does NOT opt out for authed, so it emits a
+    // cacheable response for logged-in users — batching would append `?batch=1` and lose
+    // the CF edge-hit. Must stay unbatched.
+    expect(CACHEABLE_PROCEDURES.has('model.getAll')).toBe(true);
+    expect(shouldBatch(op({ path: 'model.getAll' }))).toBe(false);
+  });
+
+  it('DOES batch a non-cacheable authed query on the same router', () => {
+    setTrpcBatchingEnabled(true);
+    setWindowAuthed(true);
+    // `model.getInfinite` is NOT edge-cached → safe to batch (sanity that the exclusion is
+    // path-scoped, not router-scoped).
+    expect(CACHEABLE_PROCEDURES.has('model.getInfinite')).toBe(false);
+    expect(shouldBatch(op({ path: 'model.getInfinite' }))).toBe(true);
+  });
+
   it('honors the skipBatch context escape hatch', () => {
     setTrpcBatchingEnabled(true);
     setWindowAuthed(true);
@@ -102,5 +126,83 @@ describe('shouldBatch', () => {
     setTrpcBatchingEnabled(true);
     setWindowAuthed(true);
     expect(shouldBatch(op({ input: { q: 'x'.repeat(100) } }))).toBe(true);
+  });
+});
+
+/**
+ * Durable guard: independently RE-DERIVE the set of procedures that are edge-cacheable for
+ * authenticated sessions (apply `edgeCacheIt` and do NOT opt out for authed via
+ * `noEdgeCache({ authedOnly })` / blanket `noEdgeCache()`) by statically parsing the router
+ * sources, and assert it equals `CACHEABLE_PROCEDURES`. This is what makes the exclusion
+ * durable: add a new `edgeCacheIt` procedure without excluding it from batching and THIS
+ * test fails — the batch link can't silently start de-caching authed feed queries.
+ */
+describe('CACHEABLE_PROCEDURES stays in sync with the routers (batch-skip guard)', () => {
+  const routersDir = join(process.cwd(), 'src/server/routers');
+
+  // Map `<basename>.router.ts` -> tRPC key prefix from the appRouter registration:
+  //   `key: lazy(() => import('.../x.router').then((m) => m.xRouter))`
+  const buildFileToKey = (): Record<string, string> => {
+    const index = readFileSync(join(routersDir, 'index.ts'), 'utf8');
+    const map: Record<string, string> = {};
+    const re = /(\w+):\s*lazy\(\(\)\s*=>\s*import\(['"]([^'"]+)['"]\)/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(index))) {
+      const [, key, importPath] = m;
+      const base = importPath.split('/').pop()!; // e.g. "model.router"
+      map[base.endsWith('.ts') ? base : `${base}.ts`] = key;
+    }
+    return map;
+  };
+
+  // Split a router file into top-level procedure blocks keyed by name (2-space indent).
+  const procedureBlocks = (content: string): Array<{ name: string; block: string }> => {
+    const lines = content.split('\n');
+    const starts: number[] = [];
+    lines.forEach((l, i) => {
+      if (/^ {2}[a-zA-Z_]\w*:\s/.test(l)) starts.push(i);
+    });
+    return starts.map((start, idx) => {
+      const end = idx + 1 < starts.length ? starts[idx + 1] : lines.length;
+      const name = /^ {2}([a-zA-Z_]\w*):/.exec(lines[start])![1];
+      return { name, block: lines.slice(start, end).join('\n') };
+    });
+  };
+
+  it('matches the statically-derived cacheable-for-authed set exactly', () => {
+    const fileToKey = buildFileToKey();
+    const derived = new Set<string>();
+    const missingKey: string[] = [];
+
+    for (const file of readdirSync(routersDir)) {
+      if (!file.endsWith('.router.ts')) continue;
+      const content = readFileSync(join(routersDir, file), 'utf8');
+      if (!content.includes('edgeCacheIt(')) continue;
+      const key = fileToKey[file];
+      if (!key) {
+        missingKey.push(file);
+        continue;
+      }
+      for (const { name, block } of procedureBlocks(content)) {
+        if (!block.includes('edgeCacheIt(')) continue;
+        // opts out of edge cache for authed (or everyone) => not cacheable-for-authed
+        if (/noEdgeCache\(\s*\{\s*authedOnly/.test(block) || /noEdgeCache\(\s*\)/.test(block)) {
+          continue;
+        }
+        derived.add(`${key}.${name}`);
+      }
+    }
+
+    // Every edgeCacheIt router must be resolvable to an appRouter key, or the guard is blind.
+    expect(missingKey).toEqual([]);
+    expect(derived.size).toBeGreaterThan(0);
+
+    const listed = [...CACHEABLE_PROCEDURES].sort();
+    const expected = [...derived].sort();
+    // Symmetric diff surfaces BOTH a new cached procedure not listed AND a stale listing.
+    const notListed = expected.filter((p) => !CACHEABLE_PROCEDURES.has(p));
+    const stale = listed.filter((p) => !derived.has(p));
+    expect({ notListed, stale }).toEqual({ notListed: [], stale: [] });
+    expect(listed).toEqual(expected);
   });
 });

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -92,12 +92,61 @@ export function __getTrpcBatchingEnabled() {
  * `window.isAuthed` is set by `CivitaiSessionProvider` AFTER hydration, so on the server
  * and during early hydration this is `false` — the SAFE direction: anonymous + unknown
  * ⇒ do NOT batch, so anonymous edge-cacheable tRPC GETs stay unbatched (no `?batch`
- * param) and remain CF-cacheable. Authenticated requests have `edgeTTL` forced to 0 in
- * `createContext`, so batching them loses no edge cache.
+ * param) and remain CF-cacheable.
  */
 function isAuthedBrowser() {
   return typeof window !== 'undefined' && window.isAuthed === true;
 }
+
+/**
+ * tRPC procedure paths (`<routerKey>.<procedure>`) that are EDGE-CACHEABLE for
+ * AUTHENTICATED sessions and therefore must NEVER be batched — batching appends
+ * `?batch=1`, which `edgeCacheIt` (`src/server/middleware.trpc.ts`) refuses to cache, so
+ * batching one of these would trade an authed CF edge-hit for extra api-pool load (the
+ * opposite of the goal).
+ *
+ * IMPORTANT — this is the FULL set of procedures that apply `edgeCacheIt` and do NOT opt
+ * back out for authed sessions via `noEdgeCache({ authedOnly: true })` (or a blanket
+ * `noEdgeCache()`). NB: `createContext` seeds `edgeTTL: 0` for logged-in users, but
+ * `edgeCacheIt` OVERWRITES it with a positive TTL (it only honors the `?batch` bail and
+ * `ctx.cache.canCache`), so these responses ARE cacheable for authed users today.
+ *
+ * 🔴 Keep this in sync with the routers. `trpc-batching.test.ts` re-derives this set by
+ * parsing every `*.router.ts` and FAILS if it drifts — so adding a new `edgeCacheIt`
+ * procedure without listing it here (or without an authed `noEdgeCache`) breaks CI rather
+ * than silently starting to batch (and de-cache) it.
+ */
+export const CACHEABLE_PROCEDURES: ReadonlySet<string> = new Set([
+  'article.getCivitaiNews',
+  'bug.getLatest',
+  'changelog.getLatest',
+  'event.getData',
+  'event.getDonors',
+  'event.getPartners',
+  'event.getRewards',
+  'event.getTeamScoreHistory',
+  'event.getTeamScores',
+  'generation.checkResourcesCoverage',
+  'generation.getStatus',
+  'homeBlock.getHomeBlock',
+  'image.get404Images',
+  'image.getGenerationData',
+  'image.getResources',
+  'model.getAll',
+  'modelFile.getOptions',
+  'nowPayments.getBuzzConversionRate',
+  'nowPayments.getMinAmount',
+  'nowPayments.getSupportedCurrencies',
+  'system.getCreationBlockedTags',
+  'system.getDbKV',
+  'system.getLiveNow',
+  'tag.getHomeExcluded',
+  'tag.getTagsForReview',
+  'technique.getAll',
+  'tool.getAll',
+  'training.getStatus',
+  'user.getCreator',
+]);
 
 /**
  * Route an operation to the streaming batch link only when ALL hold:
@@ -105,11 +154,13 @@ function isAuthedBrowser() {
  *    the large-mutation POST path intact),
  *  - the `trpcBatching` flag is on for this user,
  *  - we're in an authenticated browser (see `isAuthedBrowser` — anon stays cacheable),
+ *  - the procedure is NOT edge-cacheable for authed sessions (see `CACHEABLE_PROCEDURES`),
  *  - the caller didn't opt out via `context.skipBatch === true`,
  *  - it isn't a large query (those go out as POST `methodOverride`, body-carried).
  */
 export function shouldBatch(op: {
   type: string;
+  path: string;
   input: unknown;
   context: Record<string, unknown>;
 }) {
@@ -117,6 +168,7 @@ export function shouldBatch(op: {
     op.type === 'query' &&
     trpcBatchingEnabled &&
     isAuthedBrowser() &&
+    !CACHEABLE_PROCEDURES.has(op.path) &&
     op.context.skipBatch !== true &&
     !isLargeQuery(op)
   );

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -1,7 +1,13 @@
 // src/utils/trpc.ts
 import { QueryClient, type QueryClientConfig } from '@tanstack/react-query';
 import type { CreateTRPCClient, TRPCLink } from '@trpc/client';
-import { createTRPCClient, httpLink, loggerLink, splitLink } from '@trpc/client';
+import {
+  createTRPCClient,
+  httpBatchStreamLink,
+  httpLink,
+  loggerLink,
+  splitLink,
+} from '@trpc/client';
 import type { CreateTRPCNext } from '@trpc/next';
 import { createTRPCNext } from '@trpc/next';
 import type { NextPageContext } from 'next';
@@ -61,6 +67,79 @@ function httpLinkWithLargeQuerySupport({
     condition: isLargeQuery,
     true: httpLink({ transformer: superjson, url, methodOverride: 'POST', headers }),
     false: httpLink({ transformer: superjson, url, headers }),
+  });
+}
+
+/**
+ * Module-scoped, flag-driven batch toggle. Default OFF so batching is dark until the
+ * `trpcBatching` feature flag ramps. Set from `FeatureFlagsProvider` once the per-user
+ * flag overlay resolves in the browser. Kept as a mutable module flag (not React state)
+ * because the tRPC terminating link is built once at module init and cannot read a hook;
+ * the `splitLink` condition re-reads this per operation, so a later flip takes effect on
+ * subsequent queries without rebuilding the client.
+ */
+let trpcBatchingEnabled = false;
+export function setTrpcBatchingEnabled(enabled: boolean) {
+  trpcBatchingEnabled = enabled;
+}
+// Test-only accessor: lets unit tests exercise the split condition deterministically.
+export function __getTrpcBatchingEnabled() {
+  return trpcBatchingEnabled;
+}
+
+/**
+ * True ONLY when we are definitively in an authenticated browser session.
+ * `window.isAuthed` is set by `CivitaiSessionProvider` AFTER hydration, so on the server
+ * and during early hydration this is `false` — the SAFE direction: anonymous + unknown
+ * ⇒ do NOT batch, so anonymous edge-cacheable tRPC GETs stay unbatched (no `?batch`
+ * param) and remain CF-cacheable. Authenticated requests have `edgeTTL` forced to 0 in
+ * `createContext`, so batching them loses no edge cache.
+ */
+function isAuthedBrowser() {
+  return typeof window !== 'undefined' && window.isAuthed === true;
+}
+
+/**
+ * Route an operation to the streaming batch link only when ALL hold:
+ *  - it's a `query` (mutations stay standalone — matches the historical link, and keeps
+ *    the large-mutation POST path intact),
+ *  - the `trpcBatching` flag is on for this user,
+ *  - we're in an authenticated browser (see `isAuthedBrowser` — anon stays cacheable),
+ *  - the caller didn't opt out via `context.skipBatch === true`,
+ *  - it isn't a large query (those go out as POST `methodOverride`, body-carried).
+ */
+export function shouldBatch(op: {
+  type: string;
+  input: unknown;
+  context: Record<string, unknown>;
+}) {
+  return (
+    op.type === 'query' &&
+    trpcBatchingEnabled &&
+    isAuthedBrowser() &&
+    op.context.skipBatch !== true &&
+    !isLargeQuery(op)
+  );
+}
+
+/**
+ * Shared terminating link. Authenticated-browser queries (flag-gated) go out batched via
+ * `httpBatchStreamLink` (results stream as they resolve, so the fastest query in a batch
+ * isn't blocked by the slowest); everything else — anonymous traffic, mutations, large
+ * queries, and `skipBatch` opt-outs — falls through to the unbatched large-query-aware
+ * path, preserving CF edge-cache for anon GETs and the `methodOverride: 'POST'` route.
+ */
+function terminatingLink({
+  url,
+  headers,
+}: {
+  url: string;
+  headers: ReturnType<typeof getHeaders>;
+}): TRPCLink<AppRouter> {
+  return splitLink({
+    condition: shouldBatch,
+    true: httpBatchStreamLink({ transformer: superjson, url, headers, maxURLLength: 2083 }),
+    false: httpLinkWithLargeQuerySupport({ url, headers }),
   });
 }
 const headers: RequestHeaders = {
@@ -155,7 +234,7 @@ export const trpcVanilla: CreateTRPCClient<AppRouter> = createTRPCClient<AppRout
         (isDev && env.NEXT_PUBLIC_LOG_TRPC) ||
         (opts.direction === 'down' && opts.result instanceof Error),
     }),
-    httpLinkWithLargeQuerySupport({ url, headers: getHeaders() }),
+    terminatingLink({ url, headers: getHeaders() }),
   ],
 });
 
@@ -182,19 +261,10 @@ export const trpc: CreateTRPCNext<AppRouter, NextPageContext> = createTRPCNext<A
             (isDev && env.NEXT_PUBLIC_LOG_TRPC) ||
             (opts.direction === 'down' && opts.result instanceof Error),
         }),
-        httpLinkWithLargeQuerySupport({
+        terminatingLink({
           url: isClient ? url : `${env.NEXT_PUBLIC_BASE_URL as string}${url}`,
           headers: getHeaders(ctx),
         }),
-        // splitLink({
-        //   // do not batch post requests
-        //   condition: (op) => (op.type === 'query' ? op.context.skipBatch === true : true),
-        //   // when condition is true, use normal request
-        //   true: httpLink({ url, headers: getHeaders }),
-        //   // when condition is false, use batching
-        //   // false: unstable_httpBatchStreamLink({ url, maxURLLength: 2083 }),
-        //   false: httpLink({ url, headers: getHeaders }), // Let's disable batching for now
-        // }),
       ],
     };
   },


### PR DESCRIPTION
## What

Re-enables tRPC request batching, **scoped to authenticated-browser queries that are NOT edge-cacheable**, gated behind a dark-by-default `trpcBatching` feature flag, to cut user-perceived `/api/trpc` latency. Merge-safe: **no behavior change until the Flipt flag is created and ramped.**

## Why (data-backed)

Browser Resource-Timing RUM decomposed the ~275ms perceived `/api` latency: the network portion is ~100% TTFB on a **warm keep-alive H2 connection**. `/api/trpc` is the worst route at **1266ms p95 TTFB** and highest volume. An authenticated page load fires ~**10-13 concurrent** authed app-shell queries. The honest win is **server-side**: `createContext` runs `getServerAuthSession` (**JWE decrypt**) once *per HTTP request*, so batching the shell cluster amortizes that auth/context work ~10×→1× on the **event-loop-bound** api pool (dp-prod's documented bottleneck), plus tail collapse via streaming. (Over H2 the concurrent queries already parallelize, so this is not an N× round-trip collapse — magnitude is to be measured by the ramp.)

## The edge-cache tradeoff — and the audit fix

Batching appends `?batch=1`, and `edgeCacheIt` (`middleware.trpc.ts`) **refuses to cache any `?batch` request**. Two populations of cacheable traffic must be protected:

1. **Anonymous** tRPC GETs — verified cached against prod: anon `model.getAll` GET returns `cf-cache-status: HIT`, `Cache-Control: public, s-maxage=60`. → **anon stays unbatched** (the `isAuthedBrowser` gate; server/early-hydration/anon all read `false`).
2. **🟡 Audit finding (now closed):** authed sessions are ALSO edge-cached for feed queries. The original premise ("`createContext` forces `edgeTTL:0` for authed") was **imprecise** — `edgeCacheIt` **overwrites** that seed with a positive TTL (it only honors the `?batch` bail + `ctx.cache.canCache`). So authed `model.getAll` (ttl 60), image/article/tag/event feeds, etc. currently emit CF-cacheable responses; batching them would have traded authed edge-hits for api-pool load. **Fixed** by excluding them centrally.

### How it's closed (central skip-set + durable guard)
- **`CACHEABLE_PROCEDURES`** — the **29** `<router>.<proc>` paths that apply `edgeCacheIt` and do NOT opt out for authed (`noEdgeCache({ authedOnly })` / blanket `noEdgeCache()`). `shouldBatch` returns `false` for any `CACHEABLE_PROCEDURES.has(op.path)`. Central + fail-safe, not scattered per-callsite `skipBatch`.
- **Guard test** — `trpc-batching.test.ts` independently **re-derives** that set by statically parsing every `*.router.ts` (+ the appRouter key map) and asserts it equals `CACHEABLE_PROCEDURES`. Adding a new `edgeCacheIt` procedure without listing it (or without an authed `noEdgeCache`) now **FAILS CI** — verified it fails on drift (`notListed: ['model.getAll']`) and passes when in sync. This is what makes the exclusion durable, not just correct today.

The set: `article.getCivitaiNews, bug.getLatest, changelog.getLatest, event.{getData,getDonors,getPartners,getRewards,getTeamScoreHistory,getTeamScores}, generation.{checkResourcesCoverage,getStatus}, homeBlock.getHomeBlock, image.{get404Images,getGenerationData,getResources}, model.getAll, modelFile.getOptions, nowPayments.{getBuzzConversionRate,getMinAmount,getSupportedCurrencies}, system.{getCreationBlockedTags,getDbKV,getLiveNow}, tag.{getHomeExcluded,getTagsForReview}, technique.getAll, tool.getAll, training.getStatus, user.getCreator`. (`homeBlock.getHomeBlocks` — plural — carries `noEdgeCache({authedOnly:true})` and is correctly NOT in the set.)

## Design

- `terminatingLink` = `splitLink(shouldBatch)`: **batch** → `httpBatchStreamLink({ transformer: superjson, url, headers, maxURLLength: 2083 })` (streams results, so the fastest query in a batch isn't blocked by the slowest); **else** → existing `httpLinkWithLargeQuerySupport` (anon edge-cache + large-query `methodOverride: 'POST'` path preserved).
- `shouldBatch(op)` requires **all**: `type === 'query'` · flag on · authed browser · **not in `CACHEABLE_PROCEDURES`** · `context.skipBatch !== true` · not a large query.
- `skipBatch` context escape hatch retained. Flag bridged to the module-scope link via `setTrpcBatchingEnabled` from `FeatureFlagsProvider` (dark until ramp).
- Removes the long-dead commented-out batching block.

## Rollout (mirror the Faro ramp)

Flag `trpcBatching` (`availability: ['mod']`, `fliptKey: 'trpc-batching'`), base `enabled:false`. Ship the Flipt-state flag, then ramp 1% → 10% → 50% → 100% watching `/d/civitai-dp-prod-perceived-api-latency` + Faro `{source="faro-rum"}` `/api/trpc` TTFB p95, event-loop lag, api CPU, 5xx, and the anon+authed `cf-cache-status: HIT` ratio.

## Risks to watch during ramp

1. **Batch error entanglement** — a transport 5xx fails the whole batch; `httpBatchStreamLink` isolates per-item results + shell keeps `retry:1`. Confirm graceful degradation.
2. **Streaming through the Next pages API adapter** — verify `application/jsonl` streams end-to-end (not buffered) on dp-prod.
3. **Cache-hit ratio unchanged** — both anon (never batches) AND authed feed queries (now in `CACHEABLE_PROCEDURES`) should retain their HIT ratio after ramp.

## Tests

`src/utils/__tests__/trpc-batching.test.ts` — **13/13 pass**: split decision (authed+flag→batch; flag-off/anon/unknown/server→unbatched; `skipBatch`; mutation + large-query→unbatched) + the cacheable-procedure exclusion + the router-sync guard. Adjacent trpc suites green (39/39 total).

> Local full `tsc` OOMs in this env (known caveat) — on a 12GB-heap run it completed with **0 errors in changed files** (the 17 reported are pre-existing `Cannot find module` in unrelated workspace stubs). CI is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)