### PR TITLE
fix(trpc): retry:0 for the batched cohort (thundering-herd guard, dark-safe)

### DIFF
--- a/src/utils/__tests__/trpc-batching.test.ts
+++ b/src/utils/__tests__/trpc-batching.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   __getTrpcBatchingEnabled,
   CACHEABLE_PROCEDURES,
+  queryRetry,
   setTrpcBatchingEnabled,
   shouldBatch,
 } from '~/utils/trpc';
@@ -204,5 +205,31 @@ describe('CACHEABLE_PROCEDURES stays in sync with the routers (batch-skip guard)
     const stale = listed.filter((p) => !derived.has(p));
     expect({ notListed, stale }).toEqual({ notListed: [], stale: [] });
     expect(listed).toEqual(expected);
+  });
+});
+
+describe('queryRetry (batch-cohort thundering-herd guard)', () => {
+  const err = new Error('boom');
+  beforeEach(() => setTrpcBatchingEnabled(false));
+  afterEach(() => setTrpcBatchingEnabled(false));
+
+  it('flag OFF: identical to the prior retry:1 (exactly one retry)', () => {
+    setTrpcBatchingEnabled(false);
+    expect(queryRetry(0, err)).toBe(true); // 1st failure => retry once
+    expect(queryRetry(1, err)).toBe(false); // already retried once => stop
+    expect(queryRetry(2, err)).toBe(false);
+  });
+
+  it('flag ON: 0 retries (a batch failure must not fan out N retries)', () => {
+    setTrpcBatchingEnabled(true);
+    expect(queryRetry(0, err)).toBe(false);
+    expect(queryRetry(1, err)).toBe(false);
+  });
+
+  it('tracks live flips of the module flag', () => {
+    setTrpcBatchingEnabled(false);
+    expect(queryRetry(0, err)).toBe(true);
+    setTrpcBatchingEnabled(true);
+    expect(queryRetry(0, err)).toBe(false);
   });
 });

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -82,10 +82,16 @@ let trpcBatchingEnabled = false;
 export function setTrpcBatchingEnabled(enabled: boolean) {
   trpcBatchingEnabled = enabled;
 }
-// Test-only accessor: lets unit tests exercise the split condition deterministically.
-export function __getTrpcBatchingEnabled() {
+/**
+ * Whether tRPC request batching is active for THIS client (the `trpcBatching` flag
+ * resolved on for this user). Read by both `shouldBatch` (link routing) and the
+ * `QueryClient` `retry` policy, so retry behavior stays coupled to the batch cohort.
+ */
+export function getTrpcBatchingEnabled() {
   return trpcBatchingEnabled;
 }
+// Back-compat alias used by existing unit tests.
+export const __getTrpcBatchingEnabled = getTrpcBatchingEnabled;
 
 /**
  * True ONLY when we are definitively in an authenticated browser session.
@@ -206,11 +212,31 @@ const headers: RequestHeaders = {
  * browser `QueryClient` returned by `getQueryClient()` for callsites that
  * import `queryClient` directly.
  */
+/**
+ * Query retry policy.
+ *
+ * Dark path (batching flag OFF): `failureCount < 1` == exactly one retry — byte-for-byte
+ * the prior `retry: 1` behavior for every non-batched user.
+ *
+ * Batch cohort (flag ON): 0 retries. A batch transport failure (e.g. a 5xx on the single
+ * coalesced HTTP request) fails ALL N queries in that batch at once; with `retry: 1` that
+ * would fire N simultaneous retries — a thundering herd on the event-loop-bound api pool
+ * during the exact incident the retry was meant to smooth. Suppressing retries for the
+ * batch cohort keeps a batch failure to a single in-flight request. Reverts with the flag.
+ *
+ * Scope: `defaultOptions.queries` only — mutations (which never batch) keep React Query's
+ * own default (0 query-retries), so this does not change mutation behavior.
+ */
+export function queryRetry(failureCount: number, _error: unknown): boolean {
+  if (getTrpcBatchingEnabled()) return false;
+  return failureCount < 1;
+}
+
 const queryClientConfig: QueryClientConfig = {
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
-      retry: 1,
+      retry: queryRetry,
       staleTime: Infinity,
     },
   },


### PR DESCRIPTION
Ramp gate from the #2946 tRPC-batching audit (🟡). **Dark-safe, flag-gated, not merged.**

## Problem

With request batching on, N coalesced queries share **one** HTTP request. A batch transport failure (a 5xx on that request) fails **all N queries at once** — and today's `retry: 1` (`src/utils/trpc.ts`) would then fire **N simultaneous retries**, a thundering herd on the event-loop-bound api pool during the exact incident the retry was meant to smooth.

## Fix

Make the `QueryClient` `retry` a function that reads the **same module flag** `shouldBatch` uses (`getTrpcBatchingEnabled`):

```ts
export function queryRetry(failureCount, _error) {
  if (getTrpcBatchingEnabled()) return false;   // batch cohort: 0 retries
  return failureCount < 1;                        // dark path: == prior `retry: 1`
}
```

- **Flag OFF (dark):** `failureCount < 1` is byte-for-byte the prior `retry: 1` semantics (RQ retries while `failureCount < retry`) — every non-batched user is **unchanged**.
- **Flag ON (batch cohort):** 0 retries → a batch failure stays a single in-flight request instead of fanning out.
- **Reverts with the flag** (same `trpcBatching` flag, no separate toggle).

## Scope / non-regression

- Applied to `defaultOptions.queries` only. **Mutations never batch** and keep React Query's own default (0 query-retries) — mutation behavior is untouched.
- The retry policy is per-**client** (per authed user with the flag on), coupled to the batch cohort. When the flag is on, that client's few non-batched queries (anon-cacheable exclusions / large / `skipBatch`) also get 0 retries — acceptable and arguably safer during an incident (less load), and it reverts with the flag. Threading per-operation batch-ness into React Query's retry (which only gets `failureCount`/`error`) isn't worth the complexity for a ramp gate.

Adds `getTrpcBatchingEnabled` (public reader; `__getTrpcBatchingEnabled` retained as an alias).

## Tests

`src/utils/__tests__/trpc-batching.test.ts` — **16/16 pass** (`vitest run --project unit`): +3 for `queryRetry` (flag off → one retry then stop; flag on → zero; live flip).

> Local full `tsc` OOMs in this env (known caveat) — a 12GB-heap run completed with **0 errors in changed files** (17 pre-existing unrelated `Cannot find module` baseline). CI is source of truth.

Depends conceptually on #2946 (merged) — this reads the flag it introduced. Base is `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)