### PR TITLE
fix(dev-tunnel): DNS-1123-sanitize Middleware/IngressRoute names (mint was hanging)

### DIFF
--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -137,9 +137,11 @@ describe('manifest builders (SSRF-safe, server-derived host)', () => {
       namespace: 'apps-dev-tunnel',
       port: 8080,
     });
-    // gated by the forwardAuth middleware
-    expect(ir.spec.routes[0].middlewares[0].name).toBe('dev-tunnel-gate-bki_s');
-    // labelled for the reaper + teardown sweep
+    // gated by the forwardAuth middleware — the ref uses the DNS-1123-sanitized
+    // suffix (`bki_s` → `bki-s`), matching the Middleware's actual resource name.
+    expect(ir.spec.routes[0].middlewares[0].name).toBe('dev-tunnel-gate-bki-s');
+    // labelled for the reaper + teardown sweep — the LABEL keeps the RAW sessionId
+    // (label values permit `_`; the reaper deletes by this label, not by name).
     expect(ir.metadata.labels['civitai.com/dev-tunnel']).toBe('true');
     expect(ir.metadata.labels['civitai.com/dev-tunnel-session']).toBe('bki_s');
   });
@@ -148,6 +150,33 @@ describe('manifest builders (SSRF-safe, server-derived host)', () => {
     const mw = buildDevTunnelMiddleware(opts);
     expect(mw.spec.forwardAuth.address).toBe('http://civitai-web/api/internal/dev-tunnel-gate');
     expect(mw.spec.forwardAuth.authResponseHeaders).toContain('X-Dev-User-Id');
+  });
+
+  // REGRESSION: the real sessionId is `bki_<ULID>` — Crockford base32 (UPPERCASE)
+  // with a `_`. Interpolating it raw into a k8s RESOURCE name produces an invalid
+  // name ("must be a lowercase RFC 1123 subdomain"), so the route-apply Job fails,
+  // the mint hangs, and the CLI times out. The Middleware/IngressRoute names (and
+  // the route→middleware ref) MUST be DNS-1123-sanitized; the session LABEL keeps
+  // the raw id for the reaper.
+  it('derives DNS-1123-valid resource names from a real bki_<ULID> sessionId', () => {
+    const RFC1123 = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/;
+    const realId = 'bki_01KWW3E1GT3JZW1XNBA9XA06ZM'; // uppercase + underscore
+    const realOpts = { ...opts, sessionId: realId };
+
+    const mw = buildDevTunnelMiddleware(realOpts);
+    const ir = buildDevTunnelIngressRoute(realOpts);
+    const expectedSuffix = 'bki-01kww3e1gt3jzw1xnba9xa06zm';
+
+    // Names are valid k8s resource names (no uppercase / underscore).
+    expect(mw.metadata.name).toBe(`dev-tunnel-gate-${expectedSuffix}`);
+    expect(ir.metadata.name).toBe(`dev-tunnel-${expectedSuffix}`);
+    expect(mw.metadata.name).toMatch(RFC1123);
+    expect(ir.metadata.name).toMatch(RFC1123);
+    // The route's middleware ref must equal the Middleware's actual name.
+    expect(ir.spec.routes[0].middlewares[0].name).toBe(mw.metadata.name);
+    // Labels retain the RAW sessionId so the reaper's label-selector delete matches.
+    expect(mw.metadata.labels['civitai.com/dev-tunnel-session']).toBe(realId);
+    expect(ir.metadata.labels['civitai.com/dev-tunnel-session']).toBe(realId);
   });
 });
 

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -148,7 +148,10 @@ export type DevTunnelManifestOpts = {
  *  Middleware points Traefik at the dev-tunnel-gate endpoint, which requires the
  *  parent-minted author-bound entry token on the ENTRY document (T3). */
 export function buildDevTunnelMiddleware(opts: DevTunnelManifestOpts) {
-  const name = `dev-tunnel-gate-${opts.sessionId}`;
+  // Name is a k8s RESOURCE name → must be DNS-1123 (no uppercase/`_` from the raw
+  // bki_<ULID> sessionId). Labels below keep the raw sessionId (label values allow
+  // them, and the reaper matches on the label).
+  const name = `dev-tunnel-gate-${sessionResourceSuffix(opts.sessionId)}`;
   return {
     apiVersion: 'traefik.io/v1alpha1',
     kind: 'Middleware',
@@ -176,8 +179,12 @@ export function buildDevTunnelMiddleware(opts: DevTunnelManifestOpts) {
  *  Middleware, and routes to the sish HTTP backend. TLS via the existing
  *  `*.civit.ai` wildcard cert (default TLS store — no per-host cert). */
 export function buildDevTunnelIngressRoute(opts: DevTunnelManifestOpts) {
-  const name = `dev-tunnel-${opts.sessionId}`;
-  const middlewareName = `dev-tunnel-gate-${opts.sessionId}`;
+  // k8s RESOURCE names → DNS-1123 (see sessionResourceSuffix). middlewareName MUST
+  // derive identically to buildDevTunnelMiddleware's name so the route references the
+  // Middleware that actually gets created. Labels keep the raw sessionId.
+  const suffix = sessionResourceSuffix(opts.sessionId);
+  const name = `dev-tunnel-${suffix}`;
+  const middlewareName = `dev-tunnel-gate-${suffix}`;
   // Split the backend into host:port for the Traefik ExternalName-style service
   // reference is not needed — Traefik IngressRoute services reference an in-ns
   // Service by name+port. The sish backend is a Service in the sish namespace, so
@@ -255,11 +262,20 @@ function manifestOpts(host: string, sessionId: string): DevTunnelManifestOpts {
 // k8s apply / delete (thin, reuses apps-pipeline helpers)
 // ---------------------------------------------------------------------------
 
-/** DNS-1123 Job name for a session's route-apply Job. `sessionId` is opaque
- *  (`bki_<ulid>`); sanitize + bound it so the Job name is always valid. */
+/** DNS-1123-safe suffix from an opaque sessionId for use in k8s RESOURCE NAMES.
+ *  `sessionId` is `bki_<ulid>` — Crockford base32 (UPPERCASE) with a `_` separator;
+ *  k8s resource names forbid uppercase and `_` (RFC 1123 subdomain), so we lowercase
+ *  + replace any non-`[a-z0-9-]` char and bound the length. Label VALUES, by
+ *  contrast, DO permit uppercase/`_`, so labels keep the RAW sessionId (the reaper
+ *  deletes routes by label selector, not by name). Used by the Job, Middleware, and
+ *  IngressRoute names so they all agree. */
+export function sessionResourceSuffix(sessionId: string): string {
+  return sessionId.replace(/[^a-z0-9-]/gi, '-').toLowerCase().slice(0, 40);
+}
+
+/** DNS-1123 Job name for a session's route-apply Job. */
 export function devTunnelApplyJobName(sessionId: string): string {
-  const suffix = sessionId.replace(/[^a-z0-9-]/gi, '-').toLowerCase().slice(0, 40);
-  return `dev-tunnel-apply-${suffix}`;
+  return `dev-tunnel-apply-${sessionResourceSuffix(sessionId)}`;
 }
 
 /**


### PR DESCRIPTION
## What
`civitai app dev-tunnel` hangs and the CLI times out (`context deadline exceeded` on `blocks.startDevTunnel`). Root cause: the mint's `renderDevTunnelRoute` fires a k8s Job that creates a Traefik **Middleware + IngressRoute named after the session id**, and the session id is `bki_<ULID>` — Crockford base32 (**UPPERCASE**) with a `_`. That's an **invalid k8s resource name** (RFC 1123 subdomain = lowercase alnum + `-`), so the Job fails:

```
The Middleware "dev-tunnel-gate-bki_01KWW3E1GT3JZW1XNBA9XA06ZM" is invalid:
metadata.name: Invalid value: … must be a lowercase RFC 1123 subdomain
```

→ Middleware/IngressRoute never created → the mint hangs on `waitForApplyJob` (180s) → the CLI (120s) times out. **The feature never worked end-to-end** — the Job *name* was already sanitized (`devTunnelApplyJobName`), but the resource names it *applies* were not. The Stage-2 harness missed it by seeding sysRedis directly and never exercising the route-apply path; this surfaced on the first real end-to-end dogfood.

## Fix
Extract `sessionResourceSuffix` (the existing DNS-1123 sanitizer) and use it for the **Middleware name**, the **IngressRoute name**, and the **route→middleware ref** (which must derive identically so the route points at the Middleware that's actually created). **Labels keep the raw session id** — label *values* permit uppercase/`_`, and `deleteDevTunnelRoute` deletes by **label selector** (not by name), so teardown/the reaper are unaffected.

## Tests
New regression case builds both manifests from a real `bki_<ULID>` and asserts the names are RFC-1123-valid, the middleware ref equals the Middleware's name, and the session label retains the raw id. Fixed the pre-existing test that enshrined the bug (asserted `dev-tunnel-gate-bki_s` with an underscore). `vitest run dev-tunnel.service.test.ts` → 27 passed.

## Deploy
Server-side, dp-prod web (`civitai-prod` image) — no migration, no hub change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)