### PR TITLE
chore(moderator): use placeholder values in .env.example

### DIFF
--- a/apps/moderator/.env.example
+++ b/apps/moderator/.env.example
@@ -30,7 +30,7 @@ DATABASE_REPLICA_URL=postgresql://user:pass@localhost:5432/civitai
 # Cache cluster + sysRedis. The spoke guard reads the `session:data2` cache (and can inject real-time revocation)
 # instead of hitting the hub `/api/auth/identity` on every request. loadRedisEnv requires BOTH URLs.
 REDIS_URL=redis://:redis@localhost:6379
-REDIS_SYS_URL=redis://:UDN0Wlrp@79.127.232.233:6380
+REDIS_SYS_URL=redis://:redis@localhost:6380
 
 # --- ClickHouse (@civitai/clickhouse) ---
 # Required in prod, optional in dev. Backs moderator page-visit tracking (src/lib/server/page-visits.ts;


### PR DESCRIPTION
`.env.example` should carry local placeholder values, not environment-specific ones. Aligns `REDIS_SYS_URL` with the existing `REDIS_URL` placeholder style (`redis://:redis@localhost:…`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)