### PR TITLE
fix(dev-tunnel): external-dns annotations so dev-<hex>.civit.ai resolves

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -794,6 +794,14 @@ export const serverSchema = z
     APPS_DEV_TUNNEL_SISH_BACKEND: z
       .string()
       .default('http://sish-http.apps-dev-tunnel.svc.cluster.local:8080'),
+    // APPS_DEV_TUNNEL_INGRESS_TARGET   the Traefik LB IP the ephemeral
+    //   `dev-<hex>.<APPS_DOMAIN>` DNS record points at. Set PER-ENVIRONMENT (e.g. the
+    //   dp-prod SOPS env) — intentionally NO default so the origin IP is not committed
+    //   to the repo. When set, the dev-tunnel IngressRoute carries external-dns
+    //   annotations and the host resolves (CF-proxied); when unset, no record is
+    //   created (the tunnel host is NXDOMAIN). external-dns runs source=traefik-proxy,
+    //   domain civit.ai.
+    APPS_DEV_TUNNEL_INGRESS_TARGET: z.string().optional(),
     // APPS_DEV_TUNNEL_SSH_HOST_PUBKEY   the sish server's SSH HOST public key, as a
     //   NON-SECRET OpenSSH line (`ssh-ed25519 AAAA...`). Returned by
     //   startDevTunnel so the CLI can PIN it on the `ssh -R` hop (R1 — closes the

--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -59,6 +59,7 @@ const {
       APPS_KUBE_NAMESPACE: 'civitai-apps',
       NEXTAUTH_URL: 'https://civitai.com',
       APPS_DEV_TUNNEL_SISH_BACKEND: 'http://sish-http.apps-dev-tunnel.svc.cluster.local:8080',
+      APPS_DEV_TUNNEL_INGRESS_TARGET: '192.0.2.1' as string | undefined,
       APPS_DEV_TUNNEL_FORWARDAUTH_URL: undefined as string | undefined,
       APPS_DEV_TUNNEL_SSH_HOST_PUBKEY: 'ssh-ed25519 AAAAC3NzaHostKeyExample sish-host' as
         | string
@@ -126,6 +127,7 @@ describe('manifest builders (SSRF-safe, server-derived host)', () => {
     namespace: 'civitai-apps',
     forwardAuthUrl: 'http://civitai-web/api/internal/dev-tunnel-gate',
     sishBackend: 'http://sish-http.apps-dev-tunnel.svc.cluster.local:8080',
+    ingressTarget: '192.0.2.1', // RFC-5737 doc placeholder; the real LB IP is a per-env secret
   };
 
   it('IngressRoute matches EXACTLY the assigned host (never a wildcard/user input)', () => {
@@ -144,6 +146,23 @@ describe('manifest builders (SSRF-safe, server-derived host)', () => {
     // (label values permit `_`; the reaper deletes by this label, not by name).
     expect(ir.metadata.labels['civitai.com/dev-tunnel']).toBe('true');
     expect(ir.metadata.labels['civitai.com/dev-tunnel-session']).toBe('bki_s');
+    // external-dns annotations present when ingressTarget is set — without them the
+    // ephemeral host is NXDOMAIN and the browser can't load the tunnel.
+    expect(ir.metadata.annotations['external-dns.alpha.kubernetes.io/hostname']).toBe(
+      'dev-0123456789abcdef.civit.ai'
+    );
+    expect(ir.metadata.annotations['external-dns.alpha.kubernetes.io/target']).toBe('192.0.2.1');
+    expect(ir.metadata.annotations['external-dns.alpha.kubernetes.io/cloudflare-proxied']).toBe(
+      'true'
+    );
+  });
+
+  it('omits external-dns annotations when no ingressTarget is configured (no DNS record)', () => {
+    const { ingressTarget: _drop, ...noTarget } = opts;
+    const ir = buildDevTunnelIngressRoute(noTarget);
+    // No target → no annotations → external-dns creates no record. The route still
+    // renders (routing is correct); the host just won't resolve until the env is set.
+    expect(ir.metadata.annotations).toBeUndefined();
   });
 
   it('Middleware points forwardAuth at the dev-tunnel-gate endpoint', () => {

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -142,6 +142,13 @@ export type DevTunnelManifestOpts = {
   forwardAuthUrl: string;
   /** sish HTTP backend the reverse tunnel is bound behind. */
   sishBackend: string;
+  /** Traefik LB IP the ephemeral `dev-<hex>.<APPS_DOMAIN>` DNS record targets.
+   *  When set, the IngressRoute carries external-dns annotations so external-dns
+   *  (source=traefik-proxy, domain civit.ai) creates the CF-proxied record — WITHOUT
+   *  it the host is NXDOMAIN and the browser can't load the tunnel. Sourced from env
+   *  (APPS_DEV_TUNNEL_INGRESS_TARGET, set per-environment) rather than hardcoded, so
+   *  the origin IP is not committed here; unset ⇒ annotations omitted (no record). */
+  ingressTarget?: string;
 };
 
 /** Build the ephemeral forwardAuth Middleware for a dev-tunnel host. The
@@ -190,6 +197,20 @@ export function buildDevTunnelIngressRoute(opts: DevTunnelManifestOpts) {
   // Service by name+port. The sish backend is a Service in the sish namespace, so
   // we use a Traefik `services[].name` + `namespace`. Parse host/port defensively.
   const backend = parseBackend(opts.sishBackend);
+  // external-dns (source=traefik-proxy, domain civit.ai) creates the CF-proxied DNS
+  // record for the ephemeral host from THESE annotations — mirroring the per-app-block
+  // routes (`<slug>.civit.ai`). Without them the host is NXDOMAIN and the browser can't
+  // load the tunnel. Gated on ingressTarget (the Traefik LB IP, from env) so the origin
+  // IP is not committed here; unset ⇒ no annotations ⇒ no record.
+  // ⚠️ NOT auto-cleaned: the civit.ai external-dns is `policy: upsert-only`, so deleting
+  // the route does NOT remove the record (orphan-DNS GC is a tracked follow-up).
+  const externalDnsAnnotations = opts.ingressTarget
+    ? {
+        'external-dns.alpha.kubernetes.io/hostname': opts.host,
+        'external-dns.alpha.kubernetes.io/target': opts.ingressTarget,
+        'external-dns.alpha.kubernetes.io/cloudflare-proxied': 'true',
+      }
+    : undefined;
   return {
     apiVersion: 'traefik.io/v1alpha1',
     kind: 'IngressRoute',
@@ -200,6 +221,7 @@ export function buildDevTunnelIngressRoute(opts: DevTunnelManifestOpts) {
         [DEV_TUNNEL_LABEL]: 'true',
         [DEV_TUNNEL_SESSION_LABEL]: opts.sessionId,
       },
+      ...(externalDnsAnnotations ? { annotations: externalDnsAnnotations } : {}),
     },
     spec: {
       entryPoints: ['websecure'],
@@ -255,6 +277,7 @@ function manifestOpts(host: string, sessionId: string): DevTunnelManifestOpts {
     namespace: env.APPS_KUBE_NAMESPACE,
     forwardAuthUrl: forwardAuthUrl(),
     sishBackend: sishBackend(),
+    ingressTarget: env.APPS_DEV_TUNNEL_INGRESS_TARGET,
   };
 }
 


### PR DESCRIPTION
## What
`civitai app dev-tunnel` mints + routes correctly, but the ephemeral host `dev-<hex>.civit.ai` was **NXDOMAIN** — the iframe couldn't load. external-dns (`--source=traefik-proxy --domain-filter=civit.ai`) creates the CF-proxied record from an IngressRoute's external-dns annotations; `buildDevTunnelIngressRoute` set none (the per-app-block `<slug>.civit.ai` routes DO).

## Fix
Add the `hostname`/`target`/`cloudflare-proxied` annotations to the dev-tunnel IngressRoute, gated on a new **optional** env `APPS_DEV_TUNNEL_INGRESS_TARGET` (the Traefik LB IP). The IP is set **per-environment (dp-prod SOPS env), not hardcoded here**, so the origin IP isn't committed to this public repo; unset ⇒ annotations omitted ⇒ no record (graceful, no crash). Tests use the `192.0.2.1` (RFC-5737) documentation placeholder.

Note: the `civit.ai` external-dns is `policy: upsert-only`, so records aren't auto-deleted on teardown — orphan-DNS GC is a tracked follow-up.

## Tests
28 pass — asserts annotations present when the target is set, and omitted when unset.

## Deploy
Server-side dp-prod web + the dp-prod SOPS env must carry `APPS_DEV_TUNNEL_INGRESS_TARGET`. (Replaces the closed #2949, which hardcoded the IP.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)