### PR TITLE
fix(dev-tunnel): create the route in apps-dev-tunnel (same ns as sish)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -793,7 +793,9 @@ export const serverSchema = z
     //   P0 sish Service.
     APPS_DEV_TUNNEL_SISH_BACKEND: z
       .string()
-      .default('http://sish-http.apps-dev-tunnel.svc.cluster.local:8080'),
+      // Port 80 = the sish-http SERVICE port (targetPort 8080 on the pod). A Traefik
+      // IngressRoute service ref must match a Service port, not the pod targetPort.
+      .default('http://sish-http.apps-dev-tunnel.svc.cluster.local:80'),
     // APPS_DEV_TUNNEL_INGRESS_TARGET   the Traefik LB IP the ephemeral
     //   `dev-<hex>.<APPS_DOMAIN>` DNS record points at. Set PER-ENVIRONMENT (e.g. the
     //   dp-prod SOPS env) — intentionally NO default so the origin IP is not committed

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -802,6 +802,11 @@ export const serverSchema = z
     //   created (the tunnel host is NXDOMAIN). external-dns runs source=traefik-proxy,
     //   domain civit.ai.
     APPS_DEV_TUNNEL_INGRESS_TARGET: z.string().optional(),
+    // APPS_DEV_TUNNEL_ROUTE_NAMESPACE   the namespace the ephemeral dev-tunnel
+    //   IngressRoute + forwardAuth Middleware are created in. MUST match the sish
+    //   backend's namespace (apps-dev-tunnel) — Traefik rejects a cross-namespace
+    //   service reference. The apply Job still runs in APPS_KUBE_NAMESPACE.
+    APPS_DEV_TUNNEL_ROUTE_NAMESPACE: z.string().default('apps-dev-tunnel'),
     // APPS_DEV_TUNNEL_SSH_HOST_PUBKEY   the sish server's SSH HOST public key, as a
     //   NON-SECRET OpenSSH line (`ssh-ed25519 AAAA...`). Returned by
     //   startDevTunnel so the CLI can PIN it on the `ssh -R` hop (R1 — closes the

--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -58,7 +58,7 @@ const {
       APPS_DOMAIN: 'civit.ai',
       APPS_KUBE_NAMESPACE: 'civitai-apps',
       NEXTAUTH_URL: 'https://civitai.com',
-      APPS_DEV_TUNNEL_SISH_BACKEND: 'http://sish-http.apps-dev-tunnel.svc.cluster.local:8080',
+      APPS_DEV_TUNNEL_SISH_BACKEND: 'http://sish-http.apps-dev-tunnel.svc.cluster.local:80',
       APPS_DEV_TUNNEL_ROUTE_NAMESPACE: 'apps-dev-tunnel',
       APPS_DEV_TUNNEL_INGRESS_TARGET: '192.0.2.1' as string | undefined,
       APPS_DEV_TUNNEL_FORWARDAUTH_URL: undefined as string | undefined,
@@ -229,6 +229,9 @@ describe('startDevTunnel', () => {
     expect(appliedMw.metadata.namespace).toBe('apps-dev-tunnel');
     // service + middleware refs are now SAME-namespace (the cross-ns 404 cause).
     expect(appliedIr.spec.routes[0].services[0].namespace).toBe('apps-dev-tunnel');
+    // PORT: reference the sish-http SERVICE port (80), not the pod targetPort (8080) —
+    // Traefik matches a service ref by Service port number. A revert to :8080 fails here.
+    expect(appliedIr.spec.routes[0].services[0].port).toBe(80);
     expect(appliedIr.spec.routes[0].middlewares[0].namespace).toBe('apps-dev-tunnel');
     expect(mockWaitForApplyJob).toHaveBeenCalledTimes(1);
     // persisted the 4 index keys (cred/session/host/user-block)

--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -59,6 +59,7 @@ const {
       APPS_KUBE_NAMESPACE: 'civitai-apps',
       NEXTAUTH_URL: 'https://civitai.com',
       APPS_DEV_TUNNEL_SISH_BACKEND: 'http://sish-http.apps-dev-tunnel.svc.cluster.local:8080',
+      APPS_DEV_TUNNEL_ROUTE_NAMESPACE: 'apps-dev-tunnel',
       APPS_DEV_TUNNEL_INGRESS_TARGET: '192.0.2.1' as string | undefined,
       APPS_DEV_TUNNEL_FORWARDAUTH_URL: undefined as string | undefined,
       APPS_DEV_TUNNEL_SSH_HOST_PUBKEY: 'ssh-ed25519 AAAAC3NzaHostKeyExample sish-host' as

--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -215,6 +215,21 @@ describe('startDevTunnel', () => {
     const posts = mockK8sFetch.mock.calls.filter((c) => (c[2] as any)?.method === 'POST');
     expect(posts.length).toBe(1);
     expect(posts[0][1]).toMatch(/\/jobs$/);
+    // NAMESPACE SPLIT (the fix): the apply Job is created in civitai-apps (APPS_KUBE_NAMESPACE,
+    // where apps-applier + the Job-create RBAC live), but the manifests it applies target the
+    // ROUTE namespace (apps-dev-tunnel = the sish backend's ns) so Traefik accepts the
+    // same-namespace service ref. Reverting manifestOpts to APPS_KUBE_NAMESPACE fails here.
+    expect(posts[0][1]).toContain('/namespaces/civitai-apps/jobs');
+    const job = JSON.parse((posts[0][2] as { body: string }).body);
+    const envVal = (name: string) =>
+      job.spec.template.spec.containers[0].env.find((e: { name: string }) => e.name === name)?.value;
+    const appliedIr = JSON.parse(envVal('INGRESSROUTE_JSON'));
+    const appliedMw = JSON.parse(envVal('MIDDLEWARE_JSON'));
+    expect(appliedIr.metadata.namespace).toBe('apps-dev-tunnel');
+    expect(appliedMw.metadata.namespace).toBe('apps-dev-tunnel');
+    // service + middleware refs are now SAME-namespace (the cross-ns 404 cause).
+    expect(appliedIr.spec.routes[0].services[0].namespace).toBe('apps-dev-tunnel');
+    expect(appliedIr.spec.routes[0].middlewares[0].namespace).toBe('apps-dev-tunnel');
     expect(mockWaitForApplyJob).toHaveBeenCalledTimes(1);
     // persisted the 4 index keys (cred/session/host/user-block)
     expect(sysRedis.set).toHaveBeenCalledTimes(4);

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -330,8 +330,11 @@ echo "dev-tunnel route applied"
  * functional blocker); it would ALSO be a security regression to broaden the
  * live web-pod SA to `create` (any civitai-web SSRF/RCE → arbitrary-IngressRoute
  * creation → hijack of live app hosts). The Job is the isolation boundary. The
- * web-pod SA only CREATES the Job (it has that) + DELETEs routes on teardown
- * (it has that) — it never itself creates a traefik CRD.
+ * web-pod SA (civitai-dp-prod `default`) CREATES the Job + LISTs/DELETEs routes on
+ * teardown (deleteDevTunnelRoute / reapExpiredDevTunnels). Its RoleBinding in
+ * apps-dev-tunnel currently grants the full CRD verb set (tracked hardening: narrow it
+ * to read+delete); but allowCrossNamespace=false confines any IngressRoute it could
+ * create there to apps-dev-tunnel services (sish only) — no live-app-host hijack.
  *
  * Pure + exported for a shape test.
  */

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -320,8 +320,11 @@ echo "dev-tunnel route applied"
 /**
  * Build the route-apply Job. CRITICAL (F1): runs as the narrowly-scoped
  * `apps-applier` ServiceAccount — the SAME SA the review sandbox renders through
- * (`triggerApplyReview`) — which HAS `create`/`patch` on traefik.io CRDs and
- * cannot escape the `civitai-apps` namespace. The web-pod SA
+ * (`triggerApplyReview`) — which HAS `create`/`patch` on traefik.io CRDs in
+ * `civitai-apps` (review sandbox) AND, via the dev-tunnel-route-applier RoleBinding,
+ * in `apps-dev-tunnel` (this feature's route namespace — same ns as the sish backend,
+ * so Traefik accepts the service ref). Scoped to those two CRDs in those two
+ * namespaces; it cannot touch anything else. The web-pod SA
  * (`civitai-web-apps-consumer`) grants only get/list/watch/delete on those CRDs,
  * so rendering the route DIRECTLY from the web pod 403'd (the untracked P3
  * functional blocker); it would ALSO be a security regression to broaden the

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -274,7 +274,7 @@ function manifestOpts(host: string, sessionId: string): DevTunnelManifestOpts {
   return {
     host,
     sessionId,
-    namespace: env.APPS_KUBE_NAMESPACE,
+    namespace: env.APPS_DEV_TUNNEL_ROUTE_NAMESPACE,
     forwardAuthUrl: forwardAuthUrl(),
     sishBackend: sishBackend(),
     ingressTarget: env.APPS_DEV_TUNNEL_INGRESS_TARGET,
@@ -463,7 +463,7 @@ export async function renderDevTunnelRoute(host: string, sessionId: string): Pro
  *  session's objects, never a live app. Best-effort + idempotent. */
 export async function deleteDevTunnelRoute(sessionId: string): Promise<void> {
   const target = await getDp1Target();
-  const ns = env.APPS_KUBE_NAMESPACE;
+  const ns = env.APPS_DEV_TUNNEL_ROUTE_NAMESPACE;
   const selector = encodeURIComponent(`${DEV_TUNNEL_SESSION_LABEL}=${sessionId}`);
   const kinds: Array<{ listPath: string; itemPath: (n: string) => string }> = [
     {
@@ -899,7 +899,7 @@ const LIST_UNREACHABLE_STATUS = 0;
  *   - apiserver-clock: the min-age + idle windows use the LIST response Date header.
  */
 export async function reapExpiredDevTunnels(): Promise<ReapResult> {
-  const ns = env.APPS_KUBE_NAMESPACE;
+  const ns = env.APPS_DEV_TUNNEL_ROUTE_NAMESPACE;
   const selector = encodeURIComponent(`${DEV_TUNNEL_LABEL}=true`);
   const listPaths = [
     `/apis/traefik.io/v1alpha1/namespaces/${ns}/ingressroutes?labelSelector=${selector}`,


### PR DESCRIPTION
## What
After DNS resolved (#2952), `dev-<hex>.civit.ai` still 404'd. Traefik was **rejecting the route**:
```
ERR error="service apps-dev-tunnel/sish-http not in the parent resource namespace civitai-apps"
```
The IngressRoute was created in `civitai-apps` (`APPS_KUBE_NAMESPACE`) but points at `sish-http` in `apps-dev-tunnel` — a **cross-namespace** service ref Traefik refuses unless `allowCrossNamespace` is enabled cluster-wide (we chose not to touch shared Traefik).

## Fix
Create the dev-tunnel IngressRoute + Middleware in a dedicated namespace (new env `APPS_DEV_TUNNEL_ROUTE_NAMESPACE`, default `apps-dev-tunnel`) = the sish backend's namespace → the service ref is same-namespace → Traefik serves it. The apply **Job** still runs in `APPS_KUBE_NAMESPACE` (civitai-apps, where `apps-applier` lives); only the applied manifests + the `deleteDevTunnelRoute`/`reapExpiredDevTunnels` paths use the route namespace.

## Companion RBAC (already applied on dp-prod, in datapacket)
`apps-dev-tunnel` now has a Role + RoleBinding granting ingressroutes/middlewares to both SAs that touch the routes: `apps-applier` (civitai-apps — the render Job) and `default` (civitai-dp-prod — the web/jobs pods that delete + reap directly via the k8s API).

## Tests
28 pass. Builder tests cover the manifests; the integration path uses the route-namespace env.

## Deploy
Server-side dp-prod web. The RBAC is already live. Default env is `apps-dev-tunnel` — no dp-prod env change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)