### PR TITLE
feat(app-blocks): W13 P3a PR-b — off-site approve/reject + assertListingAssetsComplete wiring (dark)

### DIFF
--- a/src/server/routers/__tests__/app-listings.router.offsite-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.offsite-authz.test.ts
@@ -31,6 +31,8 @@ const {
   mockListPending,
   mockListApproved,
   mockListRejected,
+  mockApprove,
+  mockReject,
   mockSetIcon,
   mockIsAppBlocksEnabled,
   mockIsAppBlocksAuthorEnabled,
@@ -41,6 +43,8 @@ const {
   mockListPending: vi.fn(async () => ({ items: [{ id: 'alpr_1' }], nextCursor: null })),
   mockListApproved: vi.fn(async () => ({ items: [], nextCursor: null })),
   mockListRejected: vi.fn(async () => ({ items: [], nextCursor: null })),
+  mockApprove: vi.fn(async () => ({ publishRequestId: 'alpr_1', listingId: 'apl_1', slug: 's' })),
+  mockReject: vi.fn(async () => undefined),
   // Faithful owner-check stand-in: throw FORBIDDEN when the caller doesn't own
   // the target listing (listingId encodes the owner: `own-<id>` / `other-<id>`).
   mockSetIcon: vi.fn(async (input: { listingId: string }, user: { id: number }) => {
@@ -59,6 +63,8 @@ vi.mock('~/server/services/blocks/offsite-listing.service', () => ({
   listPendingOffsiteRequests: mockListPending,
   listApprovedOffsiteRequests: mockListApproved,
   listRejectedOffsiteRequests: mockListRejected,
+  approveExternalRequest: mockApprove,
+  rejectExternalRequest: mockReject,
 }));
 vi.mock('~/server/services/blocks/app-listing-assets.service', () => ({
   setListingIcon: mockSetIcon,
@@ -215,6 +221,74 @@ describe('review-queue lists — moderatorProcedure', () => {
       await expect(caller[proc]({})).resolves.toBeDefined();
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// MOD approve / reject (moderatorProcedure) — PR-b.
+// ---------------------------------------------------------------------------
+
+const approveInput = { publishRequestId: 'alpr_1', approvalNotes: 'ok' };
+const rejectInput = { publishRequestId: 'alpr_1', rejectionReason: 'spam listing, not a real app' };
+
+describe('approveExternalRequest — moderatorProcedure', () => {
+  it('a non-mod AUTHOR (tester) is FORBIDDEN; service NOT called', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
+    await expect(caller.approveExternalRequest(approveInput)).rejects.toBeInstanceOf(TRPCError);
+    expect(mockApprove).not.toHaveBeenCalled();
+  });
+
+  it('a plain user is FORBIDDEN', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(nonAuthor) as never);
+    await expect(caller.approveExternalRequest(approveInput)).rejects.toBeInstanceOf(TRPCError);
+    expect(mockApprove).not.toHaveBeenCalled();
+  });
+
+  it('a moderator passes; service called with the reviewer id', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await caller.approveExternalRequest(approveInput);
+    expect(mockApprove).toHaveBeenCalledWith({
+      publishRequestId: 'alpr_1',
+      reviewerUserId: mod.id,
+      approvalNotes: 'ok',
+    });
+  });
+
+  it('a service failure (e.g. missing assets) maps to BAD_REQUEST with the message', async () => {
+    mockApprove.mockRejectedValueOnce(
+      new Error('Listing is missing required assets: screenshots')
+    );
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.approveExternalRequest(approveInput)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('missing required assets'),
+    });
+  });
+});
+
+describe('rejectExternalRequest — moderatorProcedure', () => {
+  it('a non-mod AUTHOR (tester) is FORBIDDEN; service NOT called', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
+    await expect(caller.rejectExternalRequest(rejectInput)).rejects.toBeInstanceOf(TRPCError);
+    expect(mockReject).not.toHaveBeenCalled();
+  });
+
+  it('a moderator passes; service called with the reviewer id + reason', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await caller.rejectExternalRequest(rejectInput);
+    expect(mockReject).toHaveBeenCalledWith({
+      publishRequestId: 'alpr_1',
+      reviewerUserId: mod.id,
+      rejectionReason: rejectInput.rejectionReason,
+    });
+  });
+
+  it('a short reason is rejected at the SCHEMA boundary (min 10)', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(
+      caller.rejectExternalRequest({ publishRequestId: 'alpr_1', rejectionReason: 'short' })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockReject).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/routers/__tests__/app-listings.router.offsite-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.offsite-authz.test.ts
@@ -116,6 +116,15 @@ function fakeCtx(user: unknown) {
   };
 }
 
+/**
+ * Fabricate a typed `OffsiteRequestError`-shaped throwable WITHOUT importing the
+ * (mocked) service module. The router duck-types on `name === 'OffsiteRequestError'`
+ * + a string `code`, so this exercises the real mapping path.
+ */
+function offsiteErr(code: string, message: string): Error {
+  return Object.assign(new Error(message), { name: 'OffsiteRequestError', code });
+}
+
 const mod = { id: 1, isModerator: true, tier: 'free', username: 'mod', onboarding: 0x1f };
 const tester = { id: 2, isModerator: false, tier: 'free', username: 'tester', onboarding: 0x1f };
 const nonAuthor = { id: 3, isModerator: false, tier: 'free', username: 'user', onboarding: 0x1f };
@@ -253,15 +262,59 @@ describe('approveExternalRequest — moderatorProcedure', () => {
     });
   });
 
-  it('a service failure (e.g. missing assets) maps to BAD_REQUEST with the message', async () => {
+  it('a typed BAD_REQUEST service failure (e.g. missing assets) passes THROUGH as BAD_REQUEST with the message', async () => {
+    // The real assets-incomplete failure is a TRPCError(BAD_REQUEST) from the
+    // service — it passes through unchanged so the mod sees the useful message.
     mockApprove.mockRejectedValueOnce(
-      new Error('Listing is missing required assets: screenshots')
+      new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Listing is missing required assets: screenshots',
+      })
     );
     const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
     await expect(caller.approveExternalRequest(approveInput)).rejects.toMatchObject({
       code: 'BAD_REQUEST',
       message: expect.stringContaining('missing required assets'),
     });
+  });
+
+  it('a typed OffsiteRequestError(NOT_FOUND) maps to TRPC NOT_FOUND (not BAD_REQUEST)', async () => {
+    mockApprove.mockRejectedValueOnce(offsiteErr('NOT_FOUND', 'publish request alpr_1 not found'));
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.approveExternalRequest(approveInput)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: expect.stringContaining('not found'),
+    });
+  });
+
+  it('a typed OffsiteRequestError(NOT_PENDING) maps to TRPC BAD_REQUEST', async () => {
+    mockApprove.mockRejectedValueOnce(
+      offsiteErr('NOT_PENDING', 'cannot approve — the request is no longer pending')
+    );
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.approveExternalRequest(approveInput)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('no longer pending'),
+    });
+  });
+
+  it('an UNEXPECTED/untyped service error maps to INTERNAL_SERVER_ERROR and does NOT leak the raw message', async () => {
+    const raw = 'connect ECONNREFUSED 10.0.0.5:5432 postgres://secret-dsn';
+    mockApprove.mockRejectedValueOnce(new Error(raw));
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    const err = await caller.approveExternalRequest(approveInput).then(
+      () => {
+        throw new Error('expected approve to reject');
+      },
+      (e) => e as TRPCError
+    );
+    expect(err).toBeInstanceOf(TRPCError);
+    expect(err.code).toBe('INTERNAL_SERVER_ERROR');
+    // The raw infra message must NOT reach the mod client (generic message only);
+    // the original is preserved on `cause` for server-side logging.
+    expect(err.message).not.toContain('ECONNREFUSED');
+    expect(err.message).not.toContain('secret-dsn');
+    expect((err.cause as Error | undefined)?.message).toBe(raw);
   });
 });
 
@@ -288,6 +341,29 @@ describe('rejectExternalRequest — moderatorProcedure', () => {
       caller.rejectExternalRequest({ publishRequestId: 'alpr_1', rejectionReason: 'short' })
     ).rejects.toBeInstanceOf(TRPCError);
     expect(mockReject).not.toHaveBeenCalled();
+  });
+
+  it('a typed OffsiteRequestError(NOT_FOUND) maps to TRPC NOT_FOUND', async () => {
+    mockReject.mockRejectedValueOnce(offsiteErr('NOT_FOUND', 'publish request alpr_1 not found'));
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.rejectExternalRequest(rejectInput)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('an UNEXPECTED/untyped service error maps to INTERNAL_SERVER_ERROR without leaking the message', async () => {
+    const raw = 'Prisma P1001: cannot reach database server at db:5432';
+    mockReject.mockRejectedValueOnce(new Error(raw));
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    const err = await caller.rejectExternalRequest(rejectInput).then(
+      () => {
+        throw new Error('expected reject to reject');
+      },
+      (e) => e as TRPCError
+    );
+    expect(err.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(err.message).not.toContain('P1001');
+    expect((err.cause as Error | undefined)?.message).toBe(raw);
   });
 });
 

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -15,8 +15,10 @@ import {
   listAppListingsSchema,
 } from '~/server/schema/blocks/app-listing-read.schema';
 import {
+  approveExternalRequestSchema,
   listMySubmissionsSchema,
   listOffsiteRequestsSchema,
+  rejectExternalRequestSchema,
   submitExternalListingSchema,
   withdrawExternalRequestSchema,
 } from '~/server/schema/blocks/offsite-listing.schema';
@@ -281,6 +283,64 @@ export const appListingsRouter = router({
         '~/server/services/blocks/offsite-listing.service'
       );
       return listRejectedOffsiteRequests(input);
+    }),
+
+  /**
+   * MOD: approve a pending off-site request (PR-b). Loads the request + its draft
+   * listing, enforces `assertListingAssetsComplete` (THE P3 activation — approve
+   * FAILS unless icon+cover+≥1 screenshot) + re-validates the stored externalUrl,
+   * then flips the listing draft→approved + the request→approved (status-guarded)
+   * and supersedes sibling pendings. v1 ALLOWS mod self-approve (reviewer ==
+   * submitter — trusted, enables single-mod dogfood; a reviewer≠submitter
+   * restriction is deferred to GA/P3b). All failure modes map to BAD_REQUEST with
+   * the service message (mirrors `blocks.approveRequest`).
+   */
+  approveExternalRequest: moderatorProcedure
+    .input(approveExternalRequestSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Approving off-site listings is restricted to civitai team');
+      }
+      const { approveExternalRequest } = await import(
+        '~/server/services/blocks/offsite-listing.service'
+      );
+      try {
+        return await approveExternalRequest({
+          publishRequestId: input.publishRequestId,
+          reviewerUserId: ctx.user.id,
+          approvalNotes: input.approvalNotes,
+        });
+      } catch (err) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
+      }
+    }),
+
+  /**
+   * MOD: reject a pending off-site request (PR-b). Requires `rejectionReason` ≥10
+   * chars; flips the request→rejected + sets `reviewedBy*` and DELETES the draft
+   * listing (status-guarded — releases the slug, never removes an approved
+   * listing). All failure modes map to BAD_REQUEST with the service message
+   * (mirrors `blocks.rejectRequest`).
+   */
+  rejectExternalRequest: moderatorProcedure
+    .input(rejectExternalRequestSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Rejecting off-site listings is restricted to civitai team');
+      }
+      const { rejectExternalRequest } = await import(
+        '~/server/services/blocks/offsite-listing.service'
+      );
+      try {
+        await rejectExternalRequest({
+          publishRequestId: input.publishRequestId,
+          reviewerUserId: ctx.user.id,
+          rejectionReason: input.rejectionReason,
+        });
+      } catch (err) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
+      }
+      return { ok: true };
     }),
 
   // -------------------------------------------------------------------------

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -123,7 +123,7 @@ function mapOffsiteError(err: unknown): TRPCError {
     err.name === 'OffsiteRequestError' &&
     typeof (err as { code?: unknown }).code === 'string'
   ) {
-    const code = (err as { code: string }).code;
+    const code = (err as { code?: unknown }).code as string;
     const trpcCode =
       code === 'NOT_FOUND' ? 'NOT_FOUND' : code === 'NOT_OWNED' ? 'FORBIDDEN' : 'BAD_REQUEST';
     return new TRPCError({ code: trpcCode, message: err.message });

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -99,6 +99,42 @@ function isRedCapableRequest(ctx: { req?: { headers?: { host?: string } } }): bo
   return host !== '' && isHostForColor(host, 'red');
 }
 
+/**
+ * Map a thrown off-site SERVICE error to the correct TRPC error for the mod client.
+ *
+ *   - A `TRPCError` the service already shaped (BAD_REQUEST: assets-incomplete /
+ *     invalid stored URL / reason-length) passes THROUGH unchanged.
+ *   - A typed `OffsiteRequestError` maps to its precise TRPC code
+ *     (`NOT_FOUND`→NOT_FOUND, `NOT_OWNED`→FORBIDDEN, `NOT_PENDING`/other→
+ *     BAD_REQUEST). It is DUCK-TYPED on `name` + `code` so the router never has to
+ *     eagerly `import` the service module (services are loaded via dynamic
+ *     `import()` to keep the Prisma client out of the router's import graph).
+ *   - Anything else is an UNEXPECTED infra/Prisma failure → INTERNAL_SERVER_ERROR
+ *     with a GENERIC message; the raw error is preserved only on `cause` (for the
+ *     central server-fault logger) and NEVER surfaced to the client.
+ *
+ * Replaces the previous blanket `BAD_REQUEST + (err as Error).message`, which both
+ * mis-coded typed failures and leaked raw infra messages to moderators.
+ */
+function mapOffsiteError(err: unknown): TRPCError {
+  if (err instanceof TRPCError) return err;
+  if (
+    err instanceof Error &&
+    err.name === 'OffsiteRequestError' &&
+    typeof (err as { code?: unknown }).code === 'string'
+  ) {
+    const code = (err as { code: string }).code;
+    const trpcCode =
+      code === 'NOT_FOUND' ? 'NOT_FOUND' : code === 'NOT_OWNED' ? 'FORBIDDEN' : 'BAD_REQUEST';
+    return new TRPCError({ code: trpcCode, message: err.message });
+  }
+  return new TRPCError({
+    code: 'INTERNAL_SERVER_ERROR',
+    message: 'An unexpected error occurred while processing the request. Please try again later.',
+    cause: err,
+  });
+}
+
 export const appListingsRouter = router({
   /** Owner/mod read of a listing's current assets (creator dashboard). */
   getAssets: protectedProcedure
@@ -292,8 +328,10 @@ export const appListingsRouter = router({
    * then flips the listing draft→approved + the request→approved (status-guarded)
    * and supersedes sibling pendings. v1 ALLOWS mod self-approve (reviewer ==
    * submitter — trusted, enables single-mod dogfood; a reviewer≠submitter
-   * restriction is deferred to GA/P3b). All failure modes map to BAD_REQUEST with
-   * the service message (mirrors `blocks.approveRequest`).
+   * restriction is deferred to GA/P3b). Failure modes are mapped by
+   * `mapOffsiteError`: typed NOT_FOUND→NOT_FOUND, NOT_PENDING/assets-incomplete/
+   * bad-URL→BAD_REQUEST, and any unexpected infra error→INTERNAL_SERVER_ERROR
+   * (generic message, no raw leak).
    */
   approveExternalRequest: moderatorProcedure
     .input(approveExternalRequestSchema)
@@ -311,16 +349,17 @@ export const appListingsRouter = router({
           approvalNotes: input.approvalNotes,
         });
       } catch (err) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
+        throw mapOffsiteError(err);
       }
     }),
 
   /**
    * MOD: reject a pending off-site request (PR-b). Requires `rejectionReason` ≥10
-   * chars; flips the request→rejected + sets `reviewedBy*` and DELETES the draft
-   * listing (status-guarded — releases the slug, never removes an approved
-   * listing). All failure modes map to BAD_REQUEST with the service message
-   * (mirrors `blocks.rejectRequest`).
+   * chars; in ONE tx flips the request→rejected + sets `reviewedBy*` and DELETES
+   * the draft listing (status-guarded — releases the slug, never removes an
+   * approved listing). Failure modes are mapped by `mapOffsiteError` (typed
+   * NOT_FOUND→NOT_FOUND, NOT_PENDING/reason-length→BAD_REQUEST, unexpected→
+   * INTERNAL_SERVER_ERROR with a generic message).
    */
   rejectExternalRequest: moderatorProcedure
     .input(rejectExternalRequestSchema)
@@ -338,7 +377,7 @@ export const appListingsRouter = router({
           rejectionReason: input.rejectionReason,
         });
       } catch (err) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
+        throw mapOffsiteError(err);
       }
       return { ok: true };
     }),

--- a/src/server/schema/blocks/__tests__/offsite-listing.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/offsite-listing.schema.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from 'vitest';
 import { MAX_EXTERNAL_URL_LENGTH } from '~/server/schema/blocks/external-app.schema';
 import {
   OFFSITE_DESCRIPTION_MAX,
+  approveExternalRequestSchema,
+  rejectExternalRequestSchema,
   submitExternalListingSchema,
 } from '~/server/schema/blocks/offsite-listing.schema';
 
@@ -149,5 +151,66 @@ describe('submitExternalListingSchema — external ⟂ on-platform mutual exclus
 
   it('an EMPTY targets array declares nothing → accepted', () => {
     expect(submitExternalListingSchema.safeParse({ ...base, targets: [] }).success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// approve / reject input schemas (PR-b) — mirror the on-site shapes.
+// ---------------------------------------------------------------------------
+
+describe('approveExternalRequestSchema', () => {
+  it('accepts a bare publishRequestId', () => {
+    expect(approveExternalRequestSchema.safeParse({ publishRequestId: 'alpr_1' }).success).toBe(true);
+  });
+
+  it('accepts an optional approvalNotes', () => {
+    expect(
+      approveExternalRequestSchema.safeParse({ publishRequestId: 'alpr_1', approvalNotes: 'ok' })
+        .success
+    ).toBe(true);
+  });
+
+  it('rejects an empty publishRequestId', () => {
+    expect(approveExternalRequestSchema.safeParse({ publishRequestId: '' }).success).toBe(false);
+  });
+
+  it('rejects over-long approvalNotes (>2000)', () => {
+    expect(
+      approveExternalRequestSchema.safeParse({
+        publishRequestId: 'alpr_1',
+        approvalNotes: 'x'.repeat(2001),
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('rejectExternalRequestSchema', () => {
+  it('accepts a reason ≥10 chars', () => {
+    expect(
+      rejectExternalRequestSchema.safeParse({
+        publishRequestId: 'alpr_1',
+        rejectionReason: 'spam listing, not a real app',
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects a reason <10 chars', () => {
+    expect(
+      rejectExternalRequestSchema.safeParse({ publishRequestId: 'alpr_1', rejectionReason: 'short' })
+        .success
+    ).toBe(false);
+  });
+
+  it('rejects a missing reason', () => {
+    expect(rejectExternalRequestSchema.safeParse({ publishRequestId: 'alpr_1' }).success).toBe(false);
+  });
+
+  it('rejects an over-long reason (>2000)', () => {
+    expect(
+      rejectExternalRequestSchema.safeParse({
+        publishRequestId: 'alpr_1',
+        rejectionReason: 'x'.repeat(2001),
+      }).success
+    ).toBe(false);
   });
 });

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -41,6 +41,11 @@ export const OFFSITE_TAGLINE_MAX = 140;
 export const OFFSITE_DESCRIPTION_MAX = 2000;
 export const OFFSITE_CHANGELOG_MAX = 2000;
 
+/** Mod-review note bounds (mirror the on-site approve/reject shapes). */
+export const OFFSITE_APPROVAL_NOTES_MAX = 2000;
+export const OFFSITE_REJECTION_REASON_MIN = 10;
+export const OFFSITE_REJECTION_REASON_MAX = 2000;
+
 /**
  * Author submit input for a pure external-link off-site listing.
  *
@@ -95,6 +100,30 @@ export const withdrawExternalRequestSchema = z.object({
   publishRequestId: z.string().min(1).max(64),
 });
 export type WithdrawExternalRequestInput = z.infer<typeof withdrawExternalRequestSchema>;
+
+/**
+ * MOD approve of a pending off-site request (PR-b). Mirrors the on-site
+ * `approveRequestSchema` shape: the request id + an optional `approvalNotes`.
+ * The asset-completeness gate + the external-URL re-validation are enforced in
+ * the SERVICE (not the schema — they read the stored draft listing).
+ */
+export const approveExternalRequestSchema = z.object({
+  publishRequestId: z.string().min(1).max(64),
+  approvalNotes: z.string().max(OFFSITE_APPROVAL_NOTES_MAX).optional(),
+});
+export type ApproveExternalRequestInput = z.infer<typeof approveExternalRequestSchema>;
+
+/**
+ * MOD reject of a pending off-site request (PR-b). Mirrors the on-site
+ * `rejectRequestSchema` shape: the request id + a `rejectionReason` of at least
+ * 10 chars (the service re-checks the trimmed length as defense-in-depth, since
+ * the service is exported + unit-tested directly).
+ */
+export const rejectExternalRequestSchema = z.object({
+  publishRequestId: z.string().min(1).max(64),
+  rejectionReason: z.string().min(OFFSITE_REJECTION_REASON_MIN).max(OFFSITE_REJECTION_REASON_MAX),
+});
+export type RejectExternalRequestInput = z.infer<typeof rejectExternalRequestSchema>;
 
 /** Keyset-paginate the caller's own off-site submissions (my-submissions page, PR-c). */
 export const listMySubmissionsSchema = z.object({

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -16,13 +16,37 @@ import type { SubmitExternalListingInput } from '~/server/schema/blocks/offsite-
  *
  * Covers submit (draft AppListing + pending request in one tx; owner-binding;
  * slug-collision pre-check AND P2002-race branch; cross-kind block-id collision;
- * URL re-validation; unknown category) and withdraw (own-pending → withdrawn +
- * draft deletion; NOT_OWNED / NOT_PENDING / idempotent-withdrawn; the
- * status-guarded TOCTOU re-read). All DB deps are mocked — no real Prisma.
+ * URL re-validation; unknown category), withdraw (own-pending → withdrawn + draft
+ * deletion; NOT_OWNED / NOT_PENDING / idempotent-withdrawn; the status-guarded
+ * TOCTOU re-read), approve (mandatory-asset gate re-asserted on the PRIMARY inside
+ * the tx; TOCTOU; self-approve) and reject (atomic flip+delete in one tx). All DB
+ * deps are mocked — no real Prisma.
+ *
+ * REPLICA vs PRIMARY: `dbRead` and `dbWrite` are DISTINCT mocks (`mockRead` /
+ * `mockWrite`) so a test can prove which client a read went through — notably that
+ * the approve asset gate re-reads the PRIMARY (`mockWrite`/`tx`), not the replica
+ * (`mockRead`), so it can't pass on stale-complete replica state under lag.
  */
 
-const { mockDb, ids } = vi.hoisted(() => ({
-  mockDb: {
+type Client = {
+  appListing: {
+    findUnique: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    updateMany: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+  };
+  appListingScreenshot: { count: ReturnType<typeof vi.fn> };
+  appBlock: { findFirst: ReturnType<typeof vi.fn> };
+  appListingPublishRequest: {
+    findUnique: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    updateMany: ReturnType<typeof vi.fn>;
+  };
+};
+
+const { mockRead, mockWrite, ids } = vi.hoisted(() => {
+  const makeClient = () => ({
     appListing: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       create: vi.fn(async (args: { data: unknown }) => args.data),
@@ -41,13 +65,19 @@ const { mockDb, ids } = vi.hoisted(() => ({
       create: vi.fn(async (args: { data: unknown }) => args.data),
       updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
     },
-    // Interactive transaction: run the callback with the same mock as `tx`.
-    $transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockDb)),
-  },
-  ids: { n: 0 },
-}));
+  });
+  const mockRead = makeClient();
+  // The PRIMARY client also owns `$transaction`; the interactive tx runs the
+  // callback with `mockWrite` itself as `tx` (so tx-scoped reads/writes hit the
+  // primary mock, exactly like a real interactive transaction).
+  const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
+    $transaction: ReturnType<typeof vi.fn>;
+  };
+  mockWrite.$transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  return { mockRead, mockWrite, ids: { n: 0 } };
+});
 
-vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingId: () => `apl_test_${++ids.n}`,
   newAppListingPublishRequestId: () => `alpr_test_${++ids.n}`,
@@ -63,23 +93,28 @@ const validInput: SubmitExternalListingInput = {
   contentRating: 'g',
 };
 
-beforeEach(() => {
-  ids.n = 0;
-  mockDb.appListing.findUnique.mockReset().mockResolvedValue(null);
-  mockDb.appListing.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
-  mockDb.appListing.updateMany.mockReset().mockResolvedValue({ count: 1 });
-  mockDb.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
-  mockDb.appListingScreenshot.count.mockReset().mockResolvedValue(0);
-  mockDb.appBlock.findFirst.mockReset().mockResolvedValue(null);
-  mockDb.appListingPublishRequest.findUnique.mockReset().mockResolvedValue(null);
-  mockDb.appListingPublishRequest.count.mockReset().mockResolvedValue(0);
-  mockDb.appListingPublishRequest.create
+function resetClient(c: Client) {
+  c.appListing.findUnique.mockReset().mockResolvedValue(null);
+  c.appListing.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+  c.appListing.updateMany.mockReset().mockResolvedValue({ count: 1 });
+  c.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
+  c.appListingScreenshot.count.mockReset().mockResolvedValue(0);
+  c.appBlock.findFirst.mockReset().mockResolvedValue(null);
+  c.appListingPublishRequest.findUnique.mockReset().mockResolvedValue(null);
+  c.appListingPublishRequest.count.mockReset().mockResolvedValue(0);
+  c.appListingPublishRequest.create
     .mockReset()
     .mockImplementation(async (a: { data: unknown }) => a.data);
-  mockDb.appListingPublishRequest.updateMany.mockReset().mockResolvedValue({ count: 1 });
-  mockDb.$transaction
+  c.appListingPublishRequest.updateMany.mockReset().mockResolvedValue({ count: 1 });
+}
+
+beforeEach(() => {
+  ids.n = 0;
+  resetClient(mockRead as unknown as Client);
+  resetClient(mockWrite as unknown as Client);
+  mockWrite.$transaction
     .mockReset()
-    .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockDb));
+    .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
 });
 
 // ---------------------------------------------------------------------------
@@ -94,7 +129,8 @@ describe('submitExternalListing', () => {
     expect(res.listingId).toMatch(/^apl_test_/);
     expect(res.publishRequestId).toMatch(/^alpr_test_/);
 
-    const listingData = mockDb.appListing.create.mock.calls[0][0].data as Record<string, unknown>;
+    // Rows are created on the PRIMARY (inside the tx).
+    const listingData = mockWrite.appListing.create.mock.calls[0][0].data as Record<string, unknown>;
     expect(listingData).toMatchObject({
       kind: 'offsite',
       status: 'draft',
@@ -106,7 +142,7 @@ describe('submitExternalListing', () => {
       userId: CALLER,
     });
 
-    const reqData = mockDb.appListingPublishRequest.create.mock.calls[0][0]
+    const reqData = mockWrite.appListingPublishRequest.create.mock.calls[0][0]
       .data as Record<string, unknown>;
     expect(reqData).toMatchObject({
       kind: 'offsite',
@@ -115,85 +151,84 @@ describe('submitExternalListing', () => {
       appListingId: res.listingId,
       submittedByUserId: CALLER,
     });
-    // Both writes happened inside the transaction.
-    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    // Both writes happened inside the transaction on the primary.
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
   });
 
   it('IDOR: the created rows always carry the AUTHENTICATED caller as owner/submitter', async () => {
     // Even if the input somehow carried a foreign userId-like field, the service
     // reads only `userId` (the authenticated caller) — there is no owner input.
     await submitExternalListing({ input: validInput, userId: OTHER });
-    const listingData = mockDb.appListing.create.mock.calls[0][0].data as { userId: number };
-    const reqData = mockDb.appListingPublishRequest.create.mock.calls[0][0]
+    const listingData = mockWrite.appListing.create.mock.calls[0][0].data as { userId: number };
+    const reqData = mockWrite.appListingPublishRequest.create.mock.calls[0][0]
       .data as { submittedByUserId: number };
     expect(listingData.userId).toBe(OTHER);
     expect(reqData.submittedByUserId).toBe(OTHER);
   });
 
-  it('slug already taken (existing AppListing pre-check) → friendly BAD_REQUEST, no write', async () => {
-    mockDb.appListing.findUnique.mockResolvedValue({ id: 'apl_existing' });
+  it('slug already taken (existing AppListing pre-check on the replica) → friendly BAD_REQUEST, no write', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue({ id: 'apl_existing' });
     await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toMatchObject(
       { code: 'BAD_REQUEST', message: expect.stringContaining('already taken') }
     );
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
   it('slug taken via the P2002 create RACE → same friendly error', async () => {
     // Pre-checks pass (null), but the unique constraint fires inside the tx.
-    mockDb.$transaction.mockRejectedValue({ code: 'P2002' });
+    mockWrite.$transaction.mockRejectedValue({ code: 'P2002' });
     await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toMatchObject(
       { code: 'BAD_REQUEST', message: expect.stringContaining('already taken') }
     );
   });
 
   it('a non-P2002 tx error is NOT masked as a slug collision', async () => {
-    mockDb.$transaction.mockRejectedValue(new Error('db down'));
+    mockWrite.$transaction.mockRejectedValue(new Error('db down'));
     await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toThrow(
       'db down'
     );
   });
 
-  it('cross-kind: a slug equal to an existing AppBlock.block_id is rejected', async () => {
-    mockDb.appBlock.findFirst.mockResolvedValue({ id: 'block_x' });
+  it('cross-kind: a slug equal to an existing AppBlock.block_id (replica pre-check) is rejected', async () => {
+    mockRead.appBlock.findFirst.mockResolvedValue({ id: 'block_x' });
     await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toMatchObject(
       { code: 'BAD_REQUEST', message: expect.stringContaining('already taken') }
     );
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
   it('cross-kind: block_id collision missed by the replica pre-check is caught by the PRIMARY re-check inside the tx (no draft created)', async () => {
-    // Replica pre-check (1st findFirst) is lag-stale → null; the PRIMARY re-read
-    // inside the tx (2nd findFirst) sees the block → same friendly error, and the
-    // draft AppListing is never created.
-    mockDb.appBlock.findFirst
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({ id: 'block_lagged' });
+    // Replica pre-check (mockRead) is lag-stale → null; the PRIMARY re-read inside
+    // the tx (mockWrite) sees the block → same friendly error, and the draft
+    // AppListing is never created.
+    mockRead.appBlock.findFirst.mockResolvedValue(null);
+    mockWrite.appBlock.findFirst.mockResolvedValue({ id: 'block_lagged' });
     await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toMatchObject(
       { code: 'BAD_REQUEST', message: expect.stringContaining('already taken') }
     );
     // The tx opened (primary re-check runs inside it) but no rows were created.
-    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
-    expect(mockDb.appListing.create).not.toHaveBeenCalled();
-    expect(mockDb.appListingPublishRequest.create).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
   });
 
   it('per-user pending cap: AT the cap → TOO_MANY_REQUESTS, no write', async () => {
-    mockDb.appListingPublishRequest.count.mockResolvedValue(MAX_PENDING_OFFSITE_SUBMISSIONS);
+    mockRead.appListingPublishRequest.count.mockResolvedValue(MAX_PENDING_OFFSITE_SUBMISSIONS);
     await expect(submitExternalListing({ input: validInput, userId: CALLER })).rejects.toMatchObject(
       { code: 'TOO_MANY_REQUESTS', message: expect.stringContaining('pending') }
     );
-    // The count is scoped to the caller's pending offsite requests.
-    expect(mockDb.appListingPublishRequest.count).toHaveBeenCalledWith({
+    // The count is scoped to the caller's pending offsite requests (on the replica).
+    expect(mockRead.appListingPublishRequest.count).toHaveBeenCalledWith({
       where: { submittedByUserId: CALLER, kind: 'offsite', status: 'pending' },
     });
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
   it('per-user pending cap: UNDER the cap → allowed (draft created)', async () => {
-    mockDb.appListingPublishRequest.count.mockResolvedValue(MAX_PENDING_OFFSITE_SUBMISSIONS - 1);
+    mockRead.appListingPublishRequest.count.mockResolvedValue(MAX_PENDING_OFFSITE_SUBMISSIONS - 1);
     const res = await submitExternalListing({ input: validInput, userId: CALLER });
     expect(res.slug).toBe('cool-app');
-    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
   });
 
   it('re-asserts contentRating against the offsite enum (an out-of-set value is rejected before any write)', async () => {
@@ -206,7 +241,7 @@ describe('submitExternalListing', () => {
       code: 'BAD_REQUEST',
       message: expect.stringContaining('content rating'),
     });
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
   it('re-validates externalUrl (a non-https URL is rejected before any write)', async () => {
@@ -216,7 +251,7 @@ describe('submitExternalListing', () => {
         userId: CALLER,
       })
     ).rejects.toBeInstanceOf(TRPCError);
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
   it('rejects an unknown category (service re-checks the taxonomy)', async () => {
@@ -226,7 +261,7 @@ describe('submitExternalListing', () => {
         userId: CALLER,
       })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('category') });
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
   it('rejects a submission declaring an on-platform surface (defense-in-depth)', async () => {
@@ -236,7 +271,7 @@ describe('submitExternalListing', () => {
         userId: CALLER,
       })
     ).rejects.toBeInstanceOf(TRPCError);
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 });
 
@@ -246,7 +281,8 @@ describe('submitExternalListing', () => {
 
 describe('withdrawExternalRequest', () => {
   it('own pending → withdrawn + the draft listing is deleted (slug released)', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+    // Classify read is on the replica; the guarded flip + delete are on the primary.
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'pending',
       submittedByUserId: CALLER,
@@ -254,18 +290,18 @@ describe('withdrawExternalRequest', () => {
     });
     await withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER });
 
-    expect(mockDb.appListingPublishRequest.updateMany).toHaveBeenCalledWith({
+    expect(mockWrite.appListingPublishRequest.updateMany).toHaveBeenCalledWith({
       where: { id: 'alpr_1', status: 'pending' },
       data: { status: 'withdrawn' },
     });
     // Draft deletion is status-guarded (never removes an approved listing).
-    expect(mockDb.appListing.deleteMany).toHaveBeenCalledWith({
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
       where: { id: 'apl_1', status: 'draft' },
     });
   });
 
   it('NOT_OWNED when the request belongs to another user (no write)', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'pending',
       submittedByUserId: OTHER,
@@ -274,19 +310,19 @@ describe('withdrawExternalRequest', () => {
     await expect(
       withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER })
     ).rejects.toMatchObject({ code: 'NOT_OWNED' });
-    expect(mockDb.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
-    expect(mockDb.appListing.deleteMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
   });
 
   it('NOT_FOUND when the request does not exist', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue(null);
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue(null);
     await expect(
       withdrawExternalRequest({ publishRequestId: 'nope', userId: CALLER })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
   it('NOT_PENDING when the request is already approved (no write)', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'approved',
       submittedByUserId: CALLER,
@@ -295,11 +331,11 @@ describe('withdrawExternalRequest', () => {
     await expect(
       withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER })
     ).rejects.toMatchObject({ code: 'NOT_PENDING' });
-    expect(mockDb.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
   });
 
   it('idempotent: an already-withdrawn request is a no-op success (no delete)', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'withdrawn',
       submittedByUserId: CALLER,
@@ -308,49 +344,47 @@ describe('withdrawExternalRequest', () => {
     await expect(
       withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER })
     ).resolves.toBeUndefined();
-    expect(mockDb.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
-    expect(mockDb.appListing.deleteMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
   });
 
-  it('TOCTOU: guarded write matches 0 rows, re-read shows withdrawn → idempotent success', async () => {
-    mockDb.appListingPublishRequest.findUnique
-      // classify read: pending
-      .mockResolvedValueOnce({
-        id: 'alpr_1',
-        status: 'pending',
-        submittedByUserId: CALLER,
-        appListingId: 'apl_1',
-      })
-      // re-read from primary after count 0: raced into withdrawn
-      .mockResolvedValueOnce({ status: 'withdrawn' });
-    mockDb.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+  it('TOCTOU: guarded write matches 0 rows, PRIMARY re-read shows withdrawn → idempotent success', async () => {
+    // Classify (replica) = pending; the guarded flip (primary) matches 0; the
+    // re-read is done on the PRIMARY (mockWrite) and shows withdrawn.
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'pending',
+      submittedByUserId: CALLER,
+      appListingId: 'apl_1',
+    });
+    mockWrite.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+    mockWrite.appListingPublishRequest.findUnique.mockResolvedValue({ status: 'withdrawn' });
 
     await expect(
       withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER })
     ).resolves.toBeUndefined();
     // We did not perform the withdraw → we do NOT re-delete the draft.
-    expect(mockDb.appListing.deleteMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
   });
 
-  it('TOCTOU: guarded write matches 0 rows, re-read shows approved → NOT_PENDING', async () => {
-    mockDb.appListingPublishRequest.findUnique
-      .mockResolvedValueOnce({
-        id: 'alpr_1',
-        status: 'pending',
-        submittedByUserId: CALLER,
-        appListingId: 'apl_1',
-      })
-      .mockResolvedValueOnce({ status: 'approved' });
-    mockDb.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+  it('TOCTOU: guarded write matches 0 rows, PRIMARY re-read shows approved → NOT_PENDING', async () => {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'pending',
+      submittedByUserId: CALLER,
+      appListingId: 'apl_1',
+    });
+    mockWrite.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+    mockWrite.appListingPublishRequest.findUnique.mockResolvedValue({ status: 'approved' });
 
     await expect(
       withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER })
     ).rejects.toMatchObject({ code: 'NOT_PENDING' });
-    expect(mockDb.appListing.deleteMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
   });
 
   it('the thrown error is an OffsiteRequestError with a typed code', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'pending',
       submittedByUserId: OTHER,
@@ -368,31 +402,41 @@ describe('withdrawExternalRequest', () => {
 
 const MOD = 7; // reviewer
 
-/** Stage a pending offsite request + a draft listing with the given asset state. */
+/**
+ * Stage a pending offsite request + a draft listing with the given asset state.
+ * Sets the state on BOTH the replica (mockRead — the pre-tx fail-fast reads) and
+ * the primary (mockWrite — the authoritative in-tx gate reads) so a normal
+ * (non-lagged) scenario passes both. A replica-vs-primary DIVERGENCE test overrides
+ * one client afterwards.
+ */
 function stageApproveScenario(listing: {
   iconId?: number | null;
   coverId?: number | null;
   screenshotCount?: number;
   externalUrl?: string;
   status?: string;
+  submittedByUserId?: number;
 }) {
-  mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+  mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
     id: 'alpr_1',
     status: 'pending',
     kind: 'offsite',
     slug: 'cool-app',
     appListingId: 'apl_1',
+    submittedByUserId: listing.submittedByUserId ?? CALLER,
   });
-  mockDb.appListing.findUnique.mockResolvedValue({
+  const listingRow = {
     id: 'apl_1',
     status: listing.status ?? 'draft',
     externalUrl: listing.externalUrl ?? 'https://cool.example.com/app',
     iconId: listing.iconId === undefined ? 1 : listing.iconId,
     coverId: listing.coverId === undefined ? 2 : listing.coverId,
-  });
-  mockDb.appListingScreenshot.count.mockResolvedValue(
-    listing.screenshotCount === undefined ? 1 : listing.screenshotCount
-  );
+  };
+  const count = listing.screenshotCount === undefined ? 1 : listing.screenshotCount;
+  mockRead.appListing.findUnique.mockResolvedValue(listingRow);
+  mockRead.appListingScreenshot.count.mockResolvedValue(count);
+  mockWrite.appListing.findUnique.mockResolvedValue(listingRow);
+  mockWrite.appListingScreenshot.count.mockResolvedValue(count);
 }
 
 describe('approveExternalRequest', () => {
@@ -405,8 +449,8 @@ describe('approveExternalRequest', () => {
     });
     expect(res).toEqual({ publishRequestId: 'alpr_1', listingId: 'apl_1', slug: 'cool-app' });
 
-    // Request flip (status-guarded) is the FIRST updateMany call.
-    const reqCall = mockDb.appListingPublishRequest.updateMany.mock.calls[0][0] as {
+    // Request flip (status-guarded) is the FIRST updateMany call on the primary.
+    const reqCall = mockWrite.appListingPublishRequest.updateMany.mock.calls[0][0] as {
       where: Record<string, unknown>;
       data: Record<string, unknown>;
     };
@@ -419,18 +463,66 @@ describe('approveExternalRequest', () => {
     expect(reqCall.data.reviewedAt).toBeInstanceOf(Date);
 
     // Listing flip (status-guarded so an approved listing is never re-flipped).
-    expect(mockDb.appListing.updateMany).toHaveBeenCalledWith({
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
       where: { id: 'apl_1', status: 'draft' },
       data: { status: 'approved' },
     });
-    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('the AUTHORITATIVE asset gate reads the PRIMARY (tx), not the replica', async () => {
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
+    await approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD });
+    // The gate's icon/cover read + the imageId-bearing screenshot count both go
+    // through the PRIMARY client (`tx` === mockWrite) inside the transaction.
+    expect(mockWrite.appListing.findUnique).toHaveBeenCalledWith({
+      where: { id: 'apl_1' },
+      select: { externalUrl: true, iconId: true, coverId: true },
+    });
+    expect(mockWrite.appListingScreenshot.count).toHaveBeenCalledWith({
+      where: { appListingId: 'apl_1', imageId: { not: null } },
+    });
+  });
+
+  it('REPLICA-LAG: replica reports COMPLETE but the PRIMARY is INCOMPLETE → approve BLOCKED (no flip)', async () => {
+    // The pre-tx fail-fast reads the (lag-stale) replica, which still shows a cover
+    // — so it passes. The AUTHORITATIVE in-tx gate reads the primary, where a
+    // concurrent owner edit removed the cover → the gate must FAIL and roll back.
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
+    mockWrite.appListing.findUnique.mockResolvedValue({
+      id: 'apl_1',
+      status: 'draft',
+      externalUrl: 'https://cool.example.com/app',
+      iconId: 1,
+      coverId: null, // primary: cover was concurrently removed
+    });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('cover') });
+    // We DID open the tx (the authoritative gate runs inside it) but bailed BEFORE
+    // any flip — neither the request nor the listing status changed.
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('REPLICA-LAG: replica shows a screenshot but the PRIMARY count is 0 → approve BLOCKED', async () => {
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
+    mockWrite.appListingScreenshot.count.mockResolvedValue(0); // primary: no real screenshot
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('screenshots'),
+    });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
   });
 
   it('supersedes any SIBLING pending request for the same slug (parity with on-site)', async () => {
     stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
     await approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD });
     // The 2nd request updateMany is the supersede: same slug, pending, NOT this row.
-    const supersede = mockDb.appListingPublishRequest.updateMany.mock.calls[1][0] as {
+    const supersede = mockWrite.appListingPublishRequest.updateMany.mock.calls[1][0] as {
       where: Record<string, unknown>;
       data: Record<string, unknown>;
     };
@@ -448,8 +540,9 @@ describe('approveExternalRequest', () => {
     await expect(
       approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('icon') });
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
-    expect(mockDb.appListing.updateMany).not.toHaveBeenCalled();
+    // Missing on the replica too → fail-fast before the tx even opens.
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
   });
 
   it('BLOCKED by assertListingAssetsComplete — missing COVER → BAD_REQUEST, no mutation', async () => {
@@ -457,7 +550,7 @@ describe('approveExternalRequest', () => {
     await expect(
       approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('cover') });
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
   it('BLOCKED by assertListingAssetsComplete — missing SCREENSHOT → BAD_REQUEST, no mutation', async () => {
@@ -468,23 +561,23 @@ describe('approveExternalRequest', () => {
       code: 'BAD_REQUEST',
       message: expect.stringContaining('screenshots'),
     });
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
-  it('all assets present → the gate PASSES (approve proceeds)', async () => {
+  it('all assets present → the gate PASSES (approve proceeds); the count query excludes imageId-null rows', async () => {
     stageApproveScenario({ iconId: 9, coverId: 8, screenshotCount: 3 });
     await expect(
       approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
     ).resolves.toMatchObject({ listingId: 'apl_1' });
     // A screenshot whose Image was deleted (imageId null) is excluded by the count
-    // query — assert we filter on imageId != null.
-    expect(mockDb.appListingScreenshot.count).toHaveBeenCalledWith({
+    // query — assert we filter on imageId != null on the primary.
+    expect(mockWrite.appListingScreenshot.count).toHaveBeenCalledWith({
       where: { appListingId: 'apl_1', imageId: { not: null } },
     });
   });
 
   it('rejects a NON-PENDING request (already approved) → NOT_PENDING, no listing load', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'approved',
       kind: 'offsite',
@@ -494,12 +587,12 @@ describe('approveExternalRequest', () => {
     await expect(
       approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
     ).rejects.toMatchObject({ code: 'NOT_PENDING' });
-    expect(mockDb.appListing.findUnique).not.toHaveBeenCalled();
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockRead.appListing.findUnique).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
   it('NOT_FOUND when the request does not exist', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue(null);
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue(null);
     await expect(
       approveExternalRequest({ publishRequestId: 'nope', reviewerUserId: MOD })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
@@ -518,40 +611,25 @@ describe('approveExternalRequest', () => {
       code: 'BAD_REQUEST',
       message: expect.stringContaining('externalUrl'),
     });
-    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
   it('TOCTOU: the guarded request flip matches 0 rows (concurrent withdraw) → NOT_PENDING, listing NOT flipped', async () => {
     stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
     // Inside the tx, the request updateMany loses the race → count 0.
-    mockDb.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+    mockWrite.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
     await expect(
       approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
     ).rejects.toMatchObject({ code: 'NOT_PENDING' });
     // The tx opened + the request flip ran, but we bailed BEFORE the listing flip.
-    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
-    expect(mockDb.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
   });
 
   it('mod SELF-APPROVE is ALLOWED (v1): reviewer == submitter succeeds (no self-approve block)', async () => {
     // The request was submitted by the SAME mod who now approves it. The service
     // does not compare reviewer to submitter, so this is allowed by design.
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
-      id: 'alpr_1',
-      status: 'pending',
-      kind: 'offsite',
-      slug: 'cool-app',
-      appListingId: 'apl_1',
-      submittedByUserId: MOD, // == reviewerUserId below
-    });
-    mockDb.appListing.findUnique.mockResolvedValue({
-      id: 'apl_1',
-      status: 'draft',
-      externalUrl: 'https://cool.example.com/app',
-      iconId: 1,
-      coverId: 2,
-    });
-    mockDb.appListingScreenshot.count.mockResolvedValue(1);
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1, submittedByUserId: MOD });
     await expect(
       approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
     ).resolves.toMatchObject({ publishRequestId: 'alpr_1', listingId: 'apl_1' });
@@ -569,12 +647,12 @@ describe('rejectExternalRequest', () => {
     await expect(
       rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: 'too short' })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('at least') });
-    expect(mockDb.appListingPublishRequest.findUnique).not.toHaveBeenCalled();
-    expect(mockDb.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockRead.appListingPublishRequest.findUnique).not.toHaveBeenCalled();
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
   });
 
-  it('pending → rejected + reviewedBy*/rejectionReason set + draft listing DELETED', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+  it('pending → rejected + reviewedBy*/rejectionReason set + draft listing DELETED, ATOMICALLY in one tx', async () => {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'pending',
       kind: 'offsite',
@@ -582,7 +660,9 @@ describe('rejectExternalRequest', () => {
     });
     await rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON });
 
-    const call = mockDb.appListingPublishRequest.updateMany.mock.calls[0][0] as {
+    // The flip + delete run inside ONE transaction on the primary (tx client).
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
+    const call = mockWrite.appListingPublishRequest.updateMany.mock.calls[0][0] as {
       where: Record<string, unknown>;
       data: Record<string, unknown>;
     };
@@ -594,13 +674,13 @@ describe('rejectExternalRequest', () => {
     });
     expect(call.data.reviewedAt).toBeInstanceOf(Date);
     // The draft listing is deleted (status-guarded — never removes an approved one).
-    expect(mockDb.appListing.deleteMany).toHaveBeenCalledWith({
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
       where: { id: 'apl_1', status: 'draft' },
     });
   });
 
   it('a NON-PENDING request → NOT_PENDING, no write', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'approved',
       kind: 'offsite',
@@ -609,29 +689,29 @@ describe('rejectExternalRequest', () => {
     await expect(
       rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON })
     ).rejects.toMatchObject({ code: 'NOT_PENDING' });
-    expect(mockDb.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
-    expect(mockDb.appListing.deleteMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
   });
 
   it('NOT_FOUND when the request does not exist', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue(null);
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue(null);
     await expect(
       rejectExternalRequest({ publishRequestId: 'nope', reviewerUserId: MOD, rejectionReason: REASON })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
   it('TOCTOU: the guarded flip matches 0 rows (concurrent approve) → NOT_PENDING, draft NOT deleted', async () => {
-    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'pending',
       kind: 'offsite',
       appListingId: 'apl_1',
     });
-    mockDb.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+    mockWrite.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
     await expect(
       rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON })
     ).rejects.toMatchObject({ code: 'NOT_PENDING' });
-    // Lost the flip → we never delete the draft (the winner owns cleanup).
-    expect(mockDb.appListing.deleteMany).not.toHaveBeenCalled();
+    // Lost the flip → the tx rolls back and we never delete the draft.
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -4,6 +4,8 @@ import { TRPCError } from '@trpc/server';
 import {
   MAX_PENDING_OFFSITE_SUBMISSIONS,
   OffsiteRequestError,
+  approveExternalRequest,
+  rejectExternalRequest,
   submitExternalListing,
   withdrawExternalRequest,
 } from '~/server/services/blocks/offsite-listing.service';
@@ -24,7 +26,11 @@ const { mockDb, ids } = vi.hoisted(() => ({
     appListing: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       create: vi.fn(async (args: { data: unknown }) => args.data),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
       deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appListingScreenshot: {
+      count: vi.fn(async (..._a: unknown[]) => 0),
     },
     appBlock: {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
@@ -61,7 +67,9 @@ beforeEach(() => {
   ids.n = 0;
   mockDb.appListing.findUnique.mockReset().mockResolvedValue(null);
   mockDb.appListing.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+  mockDb.appListing.updateMany.mockReset().mockResolvedValue({ count: 1 });
   mockDb.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
+  mockDb.appListingScreenshot.count.mockReset().mockResolvedValue(0);
   mockDb.appBlock.findFirst.mockReset().mockResolvedValue(null);
   mockDb.appListingPublishRequest.findUnique.mockReset().mockResolvedValue(null);
   mockDb.appListingPublishRequest.count.mockReset().mockResolvedValue(0);
@@ -351,5 +359,279 @@ describe('withdrawExternalRequest', () => {
     await expect(
       withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER })
     ).rejects.toBeInstanceOf(OffsiteRequestError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// approveExternalRequest
+// ---------------------------------------------------------------------------
+
+const MOD = 7; // reviewer
+
+/** Stage a pending offsite request + a draft listing with the given asset state. */
+function stageApproveScenario(listing: {
+  iconId?: number | null;
+  coverId?: number | null;
+  screenshotCount?: number;
+  externalUrl?: string;
+  status?: string;
+}) {
+  mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+    id: 'alpr_1',
+    status: 'pending',
+    kind: 'offsite',
+    slug: 'cool-app',
+    appListingId: 'apl_1',
+  });
+  mockDb.appListing.findUnique.mockResolvedValue({
+    id: 'apl_1',
+    status: listing.status ?? 'draft',
+    externalUrl: listing.externalUrl ?? 'https://cool.example.com/app',
+    iconId: listing.iconId === undefined ? 1 : listing.iconId,
+    coverId: listing.coverId === undefined ? 2 : listing.coverId,
+  });
+  mockDb.appListingScreenshot.count.mockResolvedValue(
+    listing.screenshotCount === undefined ? 1 : listing.screenshotCount
+  );
+}
+
+describe('approveExternalRequest', () => {
+  it('happy path: pending + assets-complete → listing draft→approved + request approved w/ reviewedBy*/approvalNotes', async () => {
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
+    const res = await approveExternalRequest({
+      publishRequestId: 'alpr_1',
+      reviewerUserId: MOD,
+      approvalNotes: 'looks good',
+    });
+    expect(res).toEqual({ publishRequestId: 'alpr_1', listingId: 'apl_1', slug: 'cool-app' });
+
+    // Request flip (status-guarded) is the FIRST updateMany call.
+    const reqCall = mockDb.appListingPublishRequest.updateMany.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    };
+    expect(reqCall.where).toEqual({ id: 'alpr_1', status: 'pending' });
+    expect(reqCall.data).toMatchObject({
+      status: 'approved',
+      reviewedByUserId: MOD,
+      approvalNotes: 'looks good',
+    });
+    expect(reqCall.data.reviewedAt).toBeInstanceOf(Date);
+
+    // Listing flip (status-guarded so an approved listing is never re-flipped).
+    expect(mockDb.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apl_1', status: 'draft' },
+      data: { status: 'approved' },
+    });
+    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('supersedes any SIBLING pending request for the same slug (parity with on-site)', async () => {
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
+    await approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD });
+    // The 2nd request updateMany is the supersede: same slug, pending, NOT this row.
+    const supersede = mockDb.appListingPublishRequest.updateMany.mock.calls[1][0] as {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    };
+    expect(supersede.where).toMatchObject({
+      slug: 'cool-app',
+      status: 'pending',
+      kind: 'offsite',
+      NOT: { id: 'alpr_1' },
+    });
+    expect(supersede.data).toEqual({ status: 'withdrawn' });
+  });
+
+  it('BLOCKED by assertListingAssetsComplete — missing ICON → BAD_REQUEST, no mutation', async () => {
+    stageApproveScenario({ iconId: null, coverId: 2, screenshotCount: 1 });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('icon') });
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
+    expect(mockDb.appListing.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('BLOCKED by assertListingAssetsComplete — missing COVER → BAD_REQUEST, no mutation', async () => {
+    stageApproveScenario({ iconId: 1, coverId: null, screenshotCount: 1 });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('cover') });
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('BLOCKED by assertListingAssetsComplete — missing SCREENSHOT → BAD_REQUEST, no mutation', async () => {
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 0 });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('screenshots'),
+    });
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('all assets present → the gate PASSES (approve proceeds)', async () => {
+    stageApproveScenario({ iconId: 9, coverId: 8, screenshotCount: 3 });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).resolves.toMatchObject({ listingId: 'apl_1' });
+    // A screenshot whose Image was deleted (imageId null) is excluded by the count
+    // query — assert we filter on imageId != null.
+    expect(mockDb.appListingScreenshot.count).toHaveBeenCalledWith({
+      where: { appListingId: 'apl_1', imageId: { not: null } },
+    });
+  });
+
+  it('rejects a NON-PENDING request (already approved) → NOT_PENDING, no listing load', async () => {
+    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'approved',
+      kind: 'offsite',
+      slug: 'cool-app',
+      appListingId: 'apl_1',
+    });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'NOT_PENDING' });
+    expect(mockDb.appListing.findUnique).not.toHaveBeenCalled();
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('NOT_FOUND when the request does not exist', async () => {
+    mockDb.appListingPublishRequest.findUnique.mockResolvedValue(null);
+    await expect(
+      approveExternalRequest({ publishRequestId: 'nope', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('re-validates the STORED externalUrl — a non-https stored value BLOCKS approve', async () => {
+    stageApproveScenario({
+      iconId: 1,
+      coverId: 2,
+      screenshotCount: 1,
+      externalUrl: 'http://insecure.example.com',
+    });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('externalUrl'),
+    });
+    expect(mockDb.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('TOCTOU: the guarded request flip matches 0 rows (concurrent withdraw) → NOT_PENDING, listing NOT flipped', async () => {
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
+    // Inside the tx, the request updateMany loses the race → count 0.
+    mockDb.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'NOT_PENDING' });
+    // The tx opened + the request flip ran, but we bailed BEFORE the listing flip.
+    expect(mockDb.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockDb.appListing.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('mod SELF-APPROVE is ALLOWED (v1): reviewer == submitter succeeds (no self-approve block)', async () => {
+    // The request was submitted by the SAME mod who now approves it. The service
+    // does not compare reviewer to submitter, so this is allowed by design.
+    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'pending',
+      kind: 'offsite',
+      slug: 'cool-app',
+      appListingId: 'apl_1',
+      submittedByUserId: MOD, // == reviewerUserId below
+    });
+    mockDb.appListing.findUnique.mockResolvedValue({
+      id: 'apl_1',
+      status: 'draft',
+      externalUrl: 'https://cool.example.com/app',
+      iconId: 1,
+      coverId: 2,
+    });
+    mockDb.appListingScreenshot.count.mockResolvedValue(1);
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).resolves.toMatchObject({ publishRequestId: 'alpr_1', listingId: 'apl_1' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rejectExternalRequest
+// ---------------------------------------------------------------------------
+
+describe('rejectExternalRequest', () => {
+  const REASON = 'not a real app, looks like spam';
+
+  it('reason < 10 chars → BAD_REQUEST, no DB read/write', async () => {
+    await expect(
+      rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: 'too short' })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('at least') });
+    expect(mockDb.appListingPublishRequest.findUnique).not.toHaveBeenCalled();
+    expect(mockDb.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('pending → rejected + reviewedBy*/rejectionReason set + draft listing DELETED', async () => {
+    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'pending',
+      kind: 'offsite',
+      appListingId: 'apl_1',
+    });
+    await rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON });
+
+    const call = mockDb.appListingPublishRequest.updateMany.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    };
+    expect(call.where).toEqual({ id: 'alpr_1', status: 'pending' });
+    expect(call.data).toMatchObject({
+      status: 'rejected',
+      reviewedByUserId: MOD,
+      rejectionReason: REASON,
+    });
+    expect(call.data.reviewedAt).toBeInstanceOf(Date);
+    // The draft listing is deleted (status-guarded — never removes an approved one).
+    expect(mockDb.appListing.deleteMany).toHaveBeenCalledWith({
+      where: { id: 'apl_1', status: 'draft' },
+    });
+  });
+
+  it('a NON-PENDING request → NOT_PENDING, no write', async () => {
+    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'approved',
+      kind: 'offsite',
+      appListingId: 'apl_1',
+    });
+    await expect(
+      rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON })
+    ).rejects.toMatchObject({ code: 'NOT_PENDING' });
+    expect(mockDb.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockDb.appListing.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it('NOT_FOUND when the request does not exist', async () => {
+    mockDb.appListingPublishRequest.findUnique.mockResolvedValue(null);
+    await expect(
+      rejectExternalRequest({ publishRequestId: 'nope', reviewerUserId: MOD, rejectionReason: REASON })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('TOCTOU: the guarded flip matches 0 rows (concurrent approve) → NOT_PENDING, draft NOT deleted', async () => {
+    mockDb.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'pending',
+      kind: 'offsite',
+      appListingId: 'apl_1',
+    });
+    mockDb.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON })
+    ).rejects.toMatchObject({ code: 'NOT_PENDING' });
+    // Lost the flip → we never delete the draft (the winner owns cleanup).
+    expect(mockDb.appListing.deleteMany).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -295,11 +295,16 @@ export async function withdrawExternalRequest(opts: {
 /**
  * Delete a still-DRAFT off-site listing (releases the slug; cascades its
  * screenshots via `onDelete: Cascade`). Status-guarded so an approved listing is
- * never removed; no-op when the request had no linked listing.
+ * never removed; no-op when the request had no linked listing. Accepts an optional
+ * transaction client so the caller can make the flip + delete atomic (reject);
+ * defaults to `dbWrite` (autocommit) for withdraw.
  */
-async function deleteDraftListing(appListingId: string | null): Promise<void> {
+async function deleteDraftListing(
+  appListingId: string | null,
+  client: Pick<typeof dbWrite, 'appListing'> = dbWrite
+): Promise<void> {
   if (!appListingId) return;
-  await dbWrite.appListing.deleteMany({ where: { id: appListingId, status: 'draft' } });
+  await client.appListing.deleteMany({ where: { id: appListingId, status: 'draft' } });
 }
 
 // ---------------------------------------------------------------------------
@@ -332,9 +337,15 @@ export type ApproveExternalRequestResult = {
  *      somehow-bad stored value blocks approve; the card link opens in the user's
  *      browser, so a non-https stored URL must never reach the store).
  *
- * Then, in ONE transaction: flip the request `pending → approved` (status-guarded
- * TOCTOU), flip the listing `draft → approved` (status-guarded), and supersede any
- * sibling pending request for the same slug (parity with the on-site approve).
+ * The asset gate is a CHEAP FAIL-FAST on the replica; it is RE-ASSERTED
+ * authoritatively on the PRIMARY inside the tx (row-consistent with the flip) —
+ * the sibling asset mutators write to `dbWrite`, so under replica lag the replica
+ * gate could otherwise pass on stale-complete state.
+ *
+ * Then, in ONE transaction: re-assert the asset+URL gate on the primary, flip the
+ * request `pending → approved` (status-guarded TOCTOU), flip the listing
+ * `draft → approved` (status-guarded), and supersede any sibling pending request
+ * for the same slug (parity with the on-site approve).
  *
  * NOTE (self-approve): v1 deliberately ALLOWS a moderator to approve their OWN
  * submission (reviewer == submitter) — this enables single-mod dogfooding + the
@@ -376,20 +387,28 @@ export async function approveExternalRequest(opts: {
       `publish request ${publishRequestId} has no draft listing`
     );
   }
+  // Narrow once for the tx closures below (findUnique needs a non-null id).
+  const appListingId = request.appListingId;
 
-  // (2) Load the draft listing + count its REAL (imageId-bearing) screenshots.
+  // (2) CHEAP PRE-TX FAIL-FAST on the replica: load the draft listing + count its
+  // REAL (imageId-bearing) screenshots so an obviously-incomplete listing is
+  // rejected before we open a transaction. This is NOT authoritative — the
+  // AUTHORITATIVE gate re-reads the PRIMARY inside the tx below (the sibling asset
+  // mutators write to dbWrite, so under replica lag this replica read can be
+  // stale-complete). See step (5).
   const listing = await dbRead.appListing.findUnique({
-    where: { id: request.appListingId },
+    where: { id: appListingId },
     select: { id: true, status: true, externalUrl: true, iconId: true, coverId: true },
   });
   if (!listing) {
-    throw new OffsiteRequestError('NOT_FOUND', `draft listing ${request.appListingId} not found`);
+    throw new OffsiteRequestError('NOT_FOUND', `draft listing ${appListingId} not found`);
   }
   const screenshotCount = await dbRead.appListingScreenshot.count({
-    where: { appListingId: request.appListingId, imageId: { not: null } },
+    where: { appListingId, imageId: { not: null } },
   });
 
   // (3) THE P3 ACTIVATION — mandatory-asset gate (throws BAD_REQUEST { missing }).
+  // Fail-fast copy on the replica; re-asserted authoritatively on the primary in (5).
   assertListingAssetsComplete({
     iconId: listing.iconId,
     coverId: listing.coverId,
@@ -397,7 +416,8 @@ export async function approveExternalRequest(opts: {
   });
 
   // (4) Defense-in-depth: re-validate the STORED externalUrl before it can reach
-  // the store (mirrors submit + the read-path `safeExternalUrl`).
+  // the store (mirrors submit + the read-path `safeExternalUrl`). Also re-checked
+  // on the primary inside the tx.
   const url = validateExternalUrl(listing.externalUrl);
   if (!url.ok) {
     throw new TRPCError({
@@ -406,8 +426,40 @@ export async function approveExternalRequest(opts: {
     });
   }
 
-  // (5) One transaction: guarded request flip + guarded listing flip + supersede.
+  // (5) One transaction: RE-ASSERT the asset gate on the PRIMARY (row-consistent
+  // with the flip) + guarded request flip + guarded listing flip + supersede.
   await dbWrite.$transaction(async (tx) => {
+    // AUTHORITATIVE asset gate — re-read from the PRIMARY (`tx`), not the replica.
+    // The sibling asset mutators (add/reorder/removeListingScreenshot,
+    // setListingIcon/Cover) deliberately read+write dbWrite to avoid replica-lag
+    // races, so under lag + a concurrent owner asset-edit the pre-tx replica gate
+    // in (3) can pass on stale-complete state. Re-reading iconId/coverId + the
+    // imageId-bearing screenshot count via `tx` (and re-validating the stored URL)
+    // makes the security-relevant gate row-consistent with the status flip below;
+    // any failure rolls the whole tx back BEFORE anything is flipped.
+    const primaryListing = await tx.appListing.findUnique({
+      where: { id: appListingId },
+      select: { externalUrl: true, iconId: true, coverId: true },
+    });
+    if (!primaryListing) {
+      throw new OffsiteRequestError('NOT_FOUND', `draft listing ${appListingId} not found`);
+    }
+    const primaryScreenshotCount = await tx.appListingScreenshot.count({
+      where: { appListingId, imageId: { not: null } },
+    });
+    assertListingAssetsComplete({
+      iconId: primaryListing.iconId,
+      coverId: primaryListing.coverId,
+      screenshotCount: primaryScreenshotCount,
+    });
+    const primaryUrl = validateExternalUrl(primaryListing.externalUrl);
+    if (!primaryUrl.ok) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `stored externalUrl is invalid and cannot be approved: ${primaryUrl.error}`,
+      });
+    }
+
     const req = await tx.appListingPublishRequest.updateMany({
       where: { id: publishRequestId, status: 'pending' },
       data: {
@@ -426,7 +478,7 @@ export async function approveExternalRequest(opts: {
       );
     }
     const flipped = await tx.appListing.updateMany({
-      where: { id: request.appListingId, status: 'draft' },
+      where: { id: appListingId, status: 'draft' },
       data: { status: 'approved' },
     });
     if (flipped.count === 0) {
@@ -452,17 +504,20 @@ export async function approveExternalRequest(opts: {
     });
   });
 
-  return { publishRequestId, listingId: request.appListingId, slug: request.slug };
+  return { publishRequestId, listingId: appListingId, slug: request.slug };
 }
 
 /**
  * MOD reject of a pending off-site request. Requires a `rejectionReason` of ≥10
- * (trimmed) chars, flips the request `pending → rejected` + sets `reviewedBy*` /
- * `rejectionReason`, and DELETES the draft `AppListing` (status-guarded
- * `deleteMany({ id, status:'draft' })` so it can never remove an approved listing
- * — releases the slug). The request flip is a status-guarded `updateMany` so a
- * concurrent approve/withdraw that already flipped the row yields NOT_PENDING here
- * (and, having matched 0, we never reach the delete). Non-pending → NOT_PENDING.
+ * (trimmed) chars, then — in ONE transaction — flips the request
+ * `pending → rejected` + sets `reviewedBy*` / `rejectionReason` and DELETES the
+ * draft `AppListing` (status-guarded `deleteMany({ id, status:'draft' })` so it can
+ * never remove an approved listing — releases the slug). Wrapping the flip + delete
+ * in a single tx means a crash between them can't orphan a hidden `draft` listing
+ * that keeps squatting the slug (parity with approve). The flip is a status-guarded
+ * `updateMany` so a concurrent approve/withdraw that already flipped the row yields
+ * NOT_PENDING (and, having matched 0, the tx rolls back before the delete).
+ * Non-pending → NOT_PENDING.
  */
 export async function rejectExternalRequest(opts: {
   publishRequestId: string;
@@ -504,21 +559,30 @@ export async function rejectExternalRequest(opts: {
     );
   }
 
-  // Status-guarded flip (TOCTOU): a concurrent approve/withdraw that already
-  // flipped the row matches 0 here → NOT_PENDING; only the winner deletes.
-  const { count } = await dbWrite.appListingPublishRequest.updateMany({
-    where: { id: publishRequestId, status: 'pending' },
-    data: {
-      status: 'rejected',
-      reviewedByUserId: reviewerUserId,
-      reviewedAt: new Date(),
-      rejectionReason: reason,
-    },
+  // ONE transaction: status-guarded flip + draft delete, so a crash between them
+  // can't orphan a hidden `draft` listing that keeps squatting the slug. The flip
+  // is TOCTOU-guarded (`status:'pending'`): a concurrent approve/withdraw that
+  // already flipped the row matches 0 → NOT_PENDING (throwing rolls the tx back
+  // before any delete); only the winner deletes. The delete is status-guarded
+  // (`status:'draft'`) so it can never remove an approved listing.
+  await dbWrite.$transaction(async (tx) => {
+    const { count } = await tx.appListingPublishRequest.updateMany({
+      where: { id: publishRequestId, status: 'pending' },
+      data: {
+        status: 'rejected',
+        reviewedByUserId: reviewerUserId,
+        reviewedAt: new Date(),
+        rejectionReason: reason,
+      },
+    });
+    if (count === 0) {
+      throw new OffsiteRequestError(
+        'NOT_PENDING',
+        `cannot reject — the request is no longer pending`
+      );
+    }
+    await deleteDraftListing(request.appListingId, tx);
   });
-  if (count === 0) {
-    throw new OffsiteRequestError('NOT_PENDING', `cannot reject — the request is no longer pending`);
-  }
-  await deleteDraftListing(request.appListingId);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -7,8 +7,11 @@ import {
 } from '~/server/schema/blocks/external-app.schema';
 import {
   OFFSITE_CONTENT_RATINGS,
+  OFFSITE_REJECTION_REASON_MAX,
+  OFFSITE_REJECTION_REASON_MIN,
   type SubmitExternalListingInput,
 } from '~/server/schema/blocks/offsite-listing.schema';
+import { assertListingAssetsComplete } from '~/server/services/blocks/app-listing-assets.service';
 import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 import { newAppListingId, newAppListingPublishRequestId } from '~/server/utils/app-block-ids';
 
@@ -297,6 +300,225 @@ export async function withdrawExternalRequest(opts: {
 async function deleteDraftListing(appListingId: string | null): Promise<void> {
   if (!appListingId) return;
   await dbWrite.appListing.deleteMany({ where: { id: appListingId, status: 'draft' } });
+}
+
+// ---------------------------------------------------------------------------
+// approveExternalRequest / rejectExternalRequest (moderator) — PR-b.
+//
+// Mirror the on-site `publish-request.service` approve/reject state machine over
+// the `AppListingPublishRequest` + `AppListing` tables (no bundle / build /
+// deploy). Approve flips the DRAFT listing → approved (the read path then
+// surfaces it in the store); reject DELETES the draft (releases the slug). Both
+// writes are status-guarded `updateMany`/`deleteMany` so a concurrent
+// approve/reject/withdraw can never double-act (TOCTOU).
+// ---------------------------------------------------------------------------
+
+export type ApproveExternalRequestResult = {
+  publishRequestId: string;
+  listingId: string;
+  slug: string;
+};
+
+/**
+ * MOD approve of a pending off-site request. Loads the request + its draft
+ * `AppListing`, asserts `pending`, and enforces two gates BEFORE any mutation:
+ *
+ *   1. {@link assertListingAssetsComplete} — **THE P3 ACTIVATION.** Approve FAILS
+ *      `BAD_REQUEST { missing }` unless the draft has an icon AND a cover AND ≥1
+ *      screenshot (a screenshot whose backing Image was deleted — `imageId` null
+ *      — does NOT count, mirroring `getListingAssets`' completeness math). This is
+ *      the intended live wiring of the dark P1 gate.
+ *   2. `validateExternalUrl` on the STORED `externalUrl` (defense-in-depth — a
+ *      somehow-bad stored value blocks approve; the card link opens in the user's
+ *      browser, so a non-https stored URL must never reach the store).
+ *
+ * Then, in ONE transaction: flip the request `pending → approved` (status-guarded
+ * TOCTOU), flip the listing `draft → approved` (status-guarded), and supersede any
+ * sibling pending request for the same slug (parity with the on-site approve).
+ *
+ * NOTE (self-approve): v1 deliberately ALLOWS a moderator to approve their OWN
+ * submission (reviewer == submitter) — this enables single-mod dogfooding + the
+ * approve e2e, and mods are trusted. A reviewer≠submitter restriction is DEFERRED
+ * to GA / P3b hardening (alongside report → verify-ownership → delist/claim). Do
+ * NOT add a self-approve block here without that product decision.
+ */
+export async function approveExternalRequest(opts: {
+  publishRequestId: string;
+  reviewerUserId: number;
+  approvalNotes?: string | null;
+}): Promise<ApproveExternalRequestResult> {
+  const { publishRequestId, reviewerUserId } = opts;
+  const approvalNotes = opts.approvalNotes ?? null;
+
+  // (1) Classify: an off-site + pending request pointing at a draft listing.
+  const request = await dbRead.appListingPublishRequest.findUnique({
+    where: { id: publishRequestId },
+    select: { id: true, status: true, kind: true, slug: true, appListingId: true },
+  });
+  if (!request) {
+    throw new OffsiteRequestError('NOT_FOUND', `publish request ${publishRequestId} not found`);
+  }
+  if (request.kind !== 'offsite') {
+    throw new OffsiteRequestError(
+      'NOT_FOUND',
+      `publish request ${publishRequestId} is not an off-site request`
+    );
+  }
+  if (request.status !== 'pending') {
+    throw new OffsiteRequestError(
+      'NOT_PENDING',
+      `cannot approve a request in status ${request.status}`
+    );
+  }
+  if (!request.appListingId) {
+    throw new OffsiteRequestError(
+      'NOT_FOUND',
+      `publish request ${publishRequestId} has no draft listing`
+    );
+  }
+
+  // (2) Load the draft listing + count its REAL (imageId-bearing) screenshots.
+  const listing = await dbRead.appListing.findUnique({
+    where: { id: request.appListingId },
+    select: { id: true, status: true, externalUrl: true, iconId: true, coverId: true },
+  });
+  if (!listing) {
+    throw new OffsiteRequestError('NOT_FOUND', `draft listing ${request.appListingId} not found`);
+  }
+  const screenshotCount = await dbRead.appListingScreenshot.count({
+    where: { appListingId: request.appListingId, imageId: { not: null } },
+  });
+
+  // (3) THE P3 ACTIVATION — mandatory-asset gate (throws BAD_REQUEST { missing }).
+  assertListingAssetsComplete({
+    iconId: listing.iconId,
+    coverId: listing.coverId,
+    screenshotCount,
+  });
+
+  // (4) Defense-in-depth: re-validate the STORED externalUrl before it can reach
+  // the store (mirrors submit + the read-path `safeExternalUrl`).
+  const url = validateExternalUrl(listing.externalUrl);
+  if (!url.ok) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `stored externalUrl is invalid and cannot be approved: ${url.error}`,
+    });
+  }
+
+  // (5) One transaction: guarded request flip + guarded listing flip + supersede.
+  await dbWrite.$transaction(async (tx) => {
+    const req = await tx.appListingPublishRequest.updateMany({
+      where: { id: publishRequestId, status: 'pending' },
+      data: {
+        status: 'approved',
+        reviewedByUserId: reviewerUserId,
+        reviewedAt: new Date(),
+        approvalNotes,
+      },
+    });
+    if (req.count === 0) {
+      // Lost the TOCTOU race to a concurrent withdraw/reject/approve — the whole
+      // tx rolls back.
+      throw new OffsiteRequestError(
+        'NOT_PENDING',
+        `cannot approve — the request is no longer pending`
+      );
+    }
+    const flipped = await tx.appListing.updateMany({
+      where: { id: request.appListingId, status: 'draft' },
+      data: { status: 'approved' },
+    });
+    if (flipped.count === 0) {
+      // The draft was concurrently deleted / already flipped — abort (rolls back
+      // the request flip) rather than approve a request whose listing is gone.
+      throw new OffsiteRequestError(
+        'NOT_PENDING',
+        `cannot approve — the draft listing is no longer available`
+      );
+    }
+    // Supersede any OTHER pending off-site request for this slug (parity with the
+    // on-site approve). With `AppListing.slug @unique` a sibling draft can't exist,
+    // so this is a rarely-non-empty safety net; scoped to NOT touch the approved
+    // row.
+    await tx.appListingPublishRequest.updateMany({
+      where: {
+        slug: request.slug,
+        status: 'pending',
+        kind: 'offsite',
+        NOT: { id: publishRequestId },
+      },
+      data: { status: 'withdrawn' },
+    });
+  });
+
+  return { publishRequestId, listingId: request.appListingId, slug: request.slug };
+}
+
+/**
+ * MOD reject of a pending off-site request. Requires a `rejectionReason` of ≥10
+ * (trimmed) chars, flips the request `pending → rejected` + sets `reviewedBy*` /
+ * `rejectionReason`, and DELETES the draft `AppListing` (status-guarded
+ * `deleteMany({ id, status:'draft' })` so it can never remove an approved listing
+ * — releases the slug). The request flip is a status-guarded `updateMany` so a
+ * concurrent approve/withdraw that already flipped the row yields NOT_PENDING here
+ * (and, having matched 0, we never reach the delete). Non-pending → NOT_PENDING.
+ */
+export async function rejectExternalRequest(opts: {
+  publishRequestId: string;
+  reviewerUserId: number;
+  rejectionReason: string;
+}): Promise<void> {
+  const { publishRequestId, reviewerUserId } = opts;
+  const reason = opts.rejectionReason.trim();
+  if (reason.length < OFFSITE_REJECTION_REASON_MIN) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `rejection reason must be at least ${OFFSITE_REJECTION_REASON_MIN} characters`,
+    });
+  }
+  if (reason.length > OFFSITE_REJECTION_REASON_MAX) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `rejection reason must be at most ${OFFSITE_REJECTION_REASON_MAX} characters`,
+    });
+  }
+
+  const request = await dbRead.appListingPublishRequest.findUnique({
+    where: { id: publishRequestId },
+    select: { id: true, status: true, kind: true, appListingId: true },
+  });
+  if (!request) {
+    throw new OffsiteRequestError('NOT_FOUND', `publish request ${publishRequestId} not found`);
+  }
+  if (request.kind !== 'offsite') {
+    throw new OffsiteRequestError(
+      'NOT_FOUND',
+      `publish request ${publishRequestId} is not an off-site request`
+    );
+  }
+  if (request.status !== 'pending') {
+    throw new OffsiteRequestError(
+      'NOT_PENDING',
+      `cannot reject a request in status ${request.status}`
+    );
+  }
+
+  // Status-guarded flip (TOCTOU): a concurrent approve/withdraw that already
+  // flipped the row matches 0 here → NOT_PENDING; only the winner deletes.
+  const { count } = await dbWrite.appListingPublishRequest.updateMany({
+    where: { id: publishRequestId, status: 'pending' },
+    data: {
+      status: 'rejected',
+      reviewedByUserId: reviewerUserId,
+      reviewedAt: new Date(),
+      rejectionReason: reason,
+    },
+  });
+  if (count === 0) {
+    throw new OffsiteRequestError('NOT_PENDING', `cannot reject — the request is no longer pending`);
+  }
+  await deleteDraftListing(request.appListingId);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/preview-apps-external-approve.spec.ts
+++ b/tests/preview-apps-external-approve.spec.ts
@@ -1,0 +1,214 @@
+import { expect, test } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+import { storageStatePath } from './preview-fixtures';
+import { trpcMutation, trpcQuery } from './preview-trpc';
+
+/**
+ * Preview-e2e: App Blocks W13 P3a — OFF-SITE (external-link) APPROVE/REJECT leg
+ * (PR-b), run as `mod`. Exercises the two SAFE + SELF-CLEANING moderation paths:
+ *
+ *   (1) REJECT: submit (mod, per-preview slug) → `rejectExternalRequest(reason)`
+ *       → the request leaves the pending queue and its DRAFT listing is deleted
+ *       (reject is terminal + releases the slug → self-cleaning, no leftover row).
+ *
+ *   (2) APPROVE-GATE: submit (mod, NO assets — no icon/cover/screenshot) →
+ *       `approveExternalRequest` → asserts a BAD_REQUEST (the dark P1
+ *       `assertListingAssetsComplete` gate fires: "missing required assets"),
+ *       proving approve is BLOCKED without assets. Then `withdrawExternalRequest`
+ *       cleans the still-pending draft.
+ *
+ * WHY NOT an approve-SUCCESS → store-render spec here: a successful approve leaves
+ * an APPROVED listing with NO delete path in P3a (approve is one-way; there is no
+ * un-approve / delete-approved proc yet), which would POLLUTE the shared dev store
+ * across concurrent previews. That path (approve success + the store Visit-anchor
+ * invariant) is DEFERRED to PR-c (the UI + a listing-management surface). This spec
+ * deliberately only drives the two self-cleaning paths.
+ *
+ * ROLE — why `mod`: `submit/withdrawExternalRequest` are `appDeveloperProcedure`
+ * (`app-blocks-author`) and `approve/rejectExternalRequest`/`listPendingRequests`
+ * are `moderatorProcedure`. The `mod` fixture satisfies BOTH (mods author via the
+ * app-blocks-author floor), and v1 ALLOWS mod self-approve (reviewer==submitter),
+ * so the whole leg runs as a single mod — like every sibling apps smoke spec.
+ *
+ * GATES (Tekton `pr-smoke-test` is authoritative — do NOT run browser-mode locally
+ * on NixOS).
+ *
+ * SAFE + SELF-CLEANING (the dev DB is shared across concurrent previews):
+ *   - Each scenario uses its OWN per-preview slug so two previews never collide on
+ *     `AppListing.slug @unique`. A same-preview re-run pre-withdraws any leftover
+ *     pending row before submitting.
+ *   - No asset upload / no successful approve → NO Image rows, NO Tekton build, NO
+ *     CF DNS, NO approved store row.
+ *   - We withdraw in `finally` (deletes the draft + releases the slug) so a
+ *     mid-test failure leaves nothing behind.
+ */
+
+const ROLE = 'mod' as const;
+const PREVIEW_URL = process.env.PREVIEW_URL ?? '';
+
+/** Per-preview + per-scenario slug so concurrent previews never collide. */
+function previewSlug(suffix: string): string {
+  let label = 'local';
+  try {
+    label = new URL(PREVIEW_URL).hostname.split('.')[0] || 'local';
+  } catch {
+    /* fall through to default */
+  }
+  const sanitized = label.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+  const slug = `ci-ext-${suffix}-${sanitized}`.slice(0, 40).replace(/-+$/, '');
+  return /[a-z0-9]$/.test(slug) ? slug : `${slug}0`;
+}
+
+const EXTERNAL_URL = 'https://example.com/ci-smoke-external-approve';
+
+type SubmitResult = { listingId: string; publishRequestId: string; slug: string };
+type PendingItem = { id: string; slug: string; appListingId: string | null };
+type PendingList = { items: PendingItem[]; nextCursor: string | null };
+
+function submitInput(slug: string) {
+  return {
+    slug,
+    name: 'CI Smoke — external approve/reject (P3a PR-b)',
+    externalUrl: EXTERNAL_URL,
+    tagline: 'a pure external-link app',
+    category: 'utility',
+    contentRating: 'g',
+    changelog: 'ci-smoke approve/reject',
+  };
+}
+
+/** Page the oldest-first pending queue to find our row by slug. */
+async function findPendingBySlug(
+  request: APIRequestContext,
+  slug: string
+): Promise<PendingItem | null> {
+  let cursor: string | null = null;
+  for (let page = 0; page < 25; page++) {
+    const input: { limit: number; cursor?: string } = { limit: 100 };
+    if (cursor) input.cursor = cursor;
+    const list = await trpcQuery<PendingList>(request, 'appListings.listPendingRequests', input);
+    const hit = list.items.find((i) => i.slug === slug);
+    if (hit) return hit;
+    if (!list.nextCursor) break;
+    cursor = list.nextCursor;
+  }
+  return null;
+}
+
+/** Best-effort: withdraw any leftover pending row for this slug (self-clean). */
+async function withdrawPendingForSlug(
+  request: APIRequestContext,
+  slug: string
+): Promise<void> {
+  const row = await findPendingBySlug(request, slug).catch(() => null);
+  if (row?.id) {
+    await trpcMutation(request, 'appListings.withdrawExternalRequest', {
+      publishRequestId: row.id,
+    }).catch(() => {});
+  }
+}
+
+test.describe('App Blocks P3a PR-b: off-site approve/reject (mod, self-cleaning)', () => {
+  test.use({ storageState: storageStatePath(ROLE) });
+
+  test('REJECT: submit → reject(reason) → request leaves the pending queue (draft deleted)', async ({
+    page,
+  }) => {
+    const SLUG = previewSlug('rej');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    const request = page.request;
+
+    let publishRequestId: string | null = null;
+    try {
+      await withdrawPendingForSlug(request, SLUG);
+
+      const result = await trpcMutation<SubmitResult>(
+        request,
+        'appListings.submitExternalListing',
+        submitInput(SLUG)
+      );
+      publishRequestId = result.publishRequestId;
+      expect(result.slug, 'slug echoes the submission').toBe(SLUG);
+
+      // It's in the pending queue before review.
+      const pending = await findPendingBySlug(request, SLUG);
+      expect(pending, 'the submitted request is pending before review').not.toBeNull();
+
+      // REJECT (reason ≥10) — terminal; deletes the draft listing.
+      await trpcMutation(request, 'appListings.rejectExternalRequest', {
+        publishRequestId,
+        rejectionReason: 'ci-smoke reject: not a real app, rejecting',
+      });
+      publishRequestId = null; // rejected + draft deleted — nothing to clean
+
+      // Gone from the pending queue.
+      const afterReject = await findPendingBySlug(request, SLUG);
+      expect(afterReject, 'the rejected request no longer appears in the pending queue').toBeNull();
+    } finally {
+      if (publishRequestId) {
+        await trpcMutation(request, 'appListings.withdrawExternalRequest', {
+          publishRequestId,
+        }).catch(() => {});
+      } else {
+        await withdrawPendingForSlug(request, SLUG);
+      }
+    }
+  });
+
+  test('APPROVE-GATE: submit with NO assets → approve is BLOCKED (missing assets) → withdraw cleans', async ({
+    page,
+  }) => {
+    const SLUG = previewSlug('gate');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    const request = page.request;
+
+    let publishRequestId: string | null = null;
+    try {
+      await withdrawPendingForSlug(request, SLUG);
+
+      const result = await trpcMutation<SubmitResult>(
+        request,
+        'appListings.submitExternalListing',
+        submitInput(SLUG)
+      );
+      publishRequestId = result.publishRequestId;
+
+      // APPROVE with NO icon/cover/screenshot attached → the assertListingAssetsComplete
+      // gate MUST fire (the router maps it to a BAD_REQUEST / HTTP 400 whose message
+      // names the missing assets). trpcMutation throws on a non-2xx response.
+      let approveError: Error | null = null;
+      try {
+        await trpcMutation(request, 'appListings.approveExternalRequest', {
+          publishRequestId,
+          approvalNotes: 'ci-smoke approve (expected to be gate-blocked)',
+        });
+      } catch (err) {
+        approveError = err as Error;
+      }
+      expect(approveError, 'approve without assets must be rejected by the gate').not.toBeNull();
+      expect(
+        approveError?.message ?? '',
+        'the gate error names the missing required assets'
+      ).toMatch(/missing required assets/i);
+
+      // The gate fired BEFORE any mutation → the request is still pending.
+      const stillPending = await findPendingBySlug(request, SLUG);
+      expect(stillPending, 'the gate-blocked request is still pending (no mutation)').not.toBeNull();
+
+      // WITHDRAW to clean (deletes the draft + releases the slug).
+      await trpcMutation(request, 'appListings.withdrawExternalRequest', { publishRequestId });
+      publishRequestId = null;
+
+      const afterWithdraw = await findPendingBySlug(request, SLUG);
+      expect(afterWithdraw, 'the withdrawn request no longer appears in the queue').toBeNull();
+    } finally {
+      if (publishRequestId) {
+        await trpcMutation(request, 'appListings.withdrawExternalRequest', {
+          publishRequestId,
+        }).catch(() => {});
+      } else {
+        await withdrawPendingForSlug(request, SLUG);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## W13 P3a — PR-b: off-site listing approve/reject + `assertListingAssetsComplete` wiring (dark)

PR-b of the App Store **off-site (external-link)** listing flow. PR-a (the submission backend — `offsite-listing.service`, the submit/withdraw/queue procs, the widened asset-CRUD gate) is already on `main` (#2950). This PR adds the **moderator approve/reject state machine** and — the headline — **activates the dark P1 mandatory-asset gate (`assertListingAssetsComplete`) at approve**. Everything stays **dark**: no UI, gated by `moderatorProcedure`; a draft/pending/rejected listing never surfaces in the (approved-only, mod-segmented) store read path.

### What this adds

- **`approveExternalRequest`** (`moderatorProcedure`): loads the request + its draft `AppListing`, asserts `pending`, then enforces two gates **before any mutation**:
  1. **`assertListingAssetsComplete(listing)` — THE P3 activation.** Approve FAILS `BAD_REQUEST { missing }` unless the draft has an **icon + cover + ≥1 screenshot**. A screenshot whose backing `Image` was deleted (`imageId` null) does **not** count — mirrors `getListingAssets`' completeness math (`imageId: { not: null }`).
  2. **Re-validates the STORED `externalUrl`** (`validateExternalUrl`, defense-in-depth) — a somehow-bad stored value blocks approve (the card link opens in the user's browser).

  Then, in **one transaction**: flip request `pending→approved` (status-guarded TOCTOU), flip listing `draft→approved` (status-guarded), set `reviewedByUserId`/`reviewedAt`/`approvalNotes`, and **supersede** any sibling pending request for the slug (parity with the on-site `publish-request.service` approve; with `AppListing.slug @unique` a sibling draft can't actually exist, so it's a safety net).

- **`rejectExternalRequest`** (`moderatorProcedure`): requires `rejectionReason` ≥10 (trimmed); flips request `pending→rejected` + `reviewedBy*`, and **deletes the draft `AppListing`** (status-guarded `deleteMany({ id, status:'draft' })` — releases the slug, can never remove an approved listing).

- **Router**: both procs wired on the `appListings` router as `moderatorProcedure` (`+ isModerator` guard, service errors → `BAD_REQUEST` with the message — mirrors `blocks.approveRequest`/`rejectRequest`). New `approveExternalRequestSchema` / `rejectExternalRequestSchema` in `offsite-listing.schema.ts` mirror the on-site approve/reject shapes.

### Locked decisions honored

- **Reject deletes the draft** (releases the slug). **Approve flips draft→approved** so the approved-only read path surfaces it in the store.
- **v1 ALLOWS mod self-approve** (reviewer == submitter) — mods are trusted; this enables single-mod dogfood + the approve e2e. The service never compares reviewer to submitter. A `reviewer≠submitter` restriction is **deferred to GA / P3b** hardening (documented in an in-code `NOTE:`). Self-approve is **not** blocked.
- **No schema/DDL change, no migration** (all fields exist). No `...input` spread — update data is built explicitly.
- **Status-guarded `updateMany`/`deleteMany`** on every write so a concurrent approve / reject / withdraw can't double-act; exactly one op wins the `pending` flip.

### Tests

- **Unit** (all green via symlinked deps; 92 in the three changed files):
  - `offsite-listing.schema.test.ts` (+8): approve/reject shape validation.
  - `offsite-listing.service.test.ts` (+17): approve happy-path (listing draft→approved + request approved w/ `reviewedBy*`/`approvalNotes` + supersede); **gate-blocked — one case each for missing icon / cover / screenshot → `BAD_REQUEST` naming the missing set, + an all-present pass** (asserts the `imageId != null` screenshot filter); non-pending → `NOT_PENDING`; stored-URL re-validation blocks approve; TOCTOU (guarded flip matches 0 → `NOT_PENDING`, listing not flipped); **mod self-approve allowed**; reject reason<10 → `BAD_REQUEST`; reject pending→rejected + draft deleted; reject non-pending → error; reject TOCTOU.
  - `app-listings.router.offsite-authz.test.ts` (+7): both procs are `moderatorProcedure` — non-mod author / plain user FORBIDDEN, mod passes with the reviewer id; a service gate error maps to `BAD_REQUEST`; schema-boundary short-reason rejection.
- **e2e** (new `tests/preview-apps-external-approve.spec.ts`, run as `mod`, **self-cleaning**): (1) **reject path** — submit → reject(reason) → request leaves the pending queue (draft deleted); (2) **approve-gate path** — submit with **no assets** → approve → asserts `BAD_REQUEST` (gate fires, "missing required assets") → withdraw to clean. **Approve-SUCCESS → store-render is deliberately NOT here** (a successful approve leaves an approved listing with no delete path in P3a → would pollute the shared dev store); deferred to PR-c. Runs in Tekton `pr-smoke-test`, not locally (NixOS browser-mode limitation).

### Rollout / follow-ups

Dark + additive → rollback = revert. **PR-c** (UI: submit form + my-submissions + kind-aware review queue) and **PR-d** (#2821 `registerExternalApp` retirement + conditional row migration) follow as separate PRs off `main` (no stacked PRs).

Spec: `datapacket-talos/claudedocs/app-blocks-p3a-external-listing-submission-scope-2026-07-06.md` (§8 PR-b, §4 state machine, §9.1 approve/reject tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Post-audit fixes (commit `0f4c05dd53`)

An adversarial audit returned "safe to merge, no 🔴". Applied the two 🟡 + one 🟢 integrity item; the rest are documented pre-GA deferrals (below).

1. **🟡 Asset gate on the PRIMARY, inside the approve tx.** The gate read `iconId`/`coverId` + the screenshot count via `dbRead` (replica), but the sibling asset mutators (`add`/`reorder`/`removeListingScreenshot`, `setListingIcon`/`Cover`) deliberately read+write `dbWrite` to dodge replica-lag races — so under lag + a concurrent owner asset-edit the gate could pass on **stale-complete** state, weakening the security-relevant gate. The **authoritative** `assertListingAssetsComplete` now re-reads `iconId`/`coverId` + the `imageId != null` screenshot count via the **transaction client (`tx`/primary)**, row-consistent with the status flip; the cheap replica check is kept as a pre-tx fail-fast.
2. **🟡 Proper error-code mapping in the router approve/reject `catch`.** A new `mapOffsiteError` passes service-shaped `TRPCError`s through (assets-incomplete / bad-URL / reason-length stay `BAD_REQUEST` with their message), maps typed `OffsiteRequestError` codes (`NOT_FOUND`→`NOT_FOUND`, `NOT_OWNED`→`FORBIDDEN`, `NOT_PENDING`→`BAD_REQUEST`), and turns any **unexpected** infra/Prisma throw into `INTERNAL_SERVER_ERROR` with a **generic message** (the raw error is preserved only on `cause` for server-side logging, never surfaced to the mod). Replaces the blanket `BAD_REQUEST + raw (err as Error).message` that both mis-coded typed failures and leaked infra messages.
3. **🟢 Atomic reject.** The request flip + draft delete are now wrapped in **one `$transaction`** (parity with approve) so a crash between them can't orphan a hidden `draft` listing squatting the slug.

**Test deltas:** `dbRead`/`dbWrite` split into **distinct** mocks so the gate's primary reads are asserted — including a **replica-lag divergence** test (replica reads complete, primary is incomplete → approve **BLOCKED**, no flip) and an assertion the gate reads go through `tx`. Added router tests: typed→proper-code (`NOT_FOUND`→`NOT_FOUND`, `NOT_PENDING`→`BAD_REQUEST`) and **untyped→`INTERNAL_SERVER_ERROR` with no raw-message leak** (raw preserved on `cause`), plus a reject-atomicity test. **147 related unit tests green** (offsite service 40 + authz router 34 + schema 26 + asset service 47).

### Pre-GA deferrals (NOT built — documented)

- **Reviewer≠submitter self-approve restriction** — v1 deliberately allows mod self-approve (trusted; enables single-mod dogfood). Deferred to GA/P3b alongside report→verify-ownership→delist/claim.
- **Delete-approved path** — approve currently has no reverse/delete path (one-way); a delist/takedown flow is a pre-GA gate.
- **`externalUrl` denormalization onto the request** for abuse-tracking — needs a column (→ a later P3b migration).
