### PR TITLE
fix(creator-program): pay creators for both banked buzz types

### DIFF
--- a/src/pages/api/testing/creator-program-backfill.ts
+++ b/src/pages/api/testing/creator-program-backfill.ts
@@ -1,0 +1,125 @@
+/*
+ * Creator Program payout backfill — one-off correction for the green+yellow double-count bug.
+ *
+ * Bug: getPoolParticipantsV2 returned one contributor row per (userId, source buzz type). The
+ * distribute job then wrote two cashPending grants sharing externalTransactionId
+ * `comp-pool-unified-<month>-<userId>`, and the buzz service deduped the second as a conflict —
+ * so each creator who banked BOTH green and yellow was paid for only one of the two types.
+ *
+ * This endpoint re-runs the (now-fixed) distribution for a settled month, compares each creator's
+ * correct share against what they were actually paid, and grants only the difference under a
+ * distinct `comp-pool-unified-<month>-<userId>-fix` externalTransactionId. Idempotent: re-running
+ * finds the -fix grant already present (its amount folds into "already paid") and computes a 0 top-up.
+ *
+ * Actions (POST JSON body):
+ *   { month?: 'YYYY-MM', dryRun?: boolean }
+ *     month  — settled month to backfill (default '2026-06')
+ *     dryRun — when true (default) compute and return the plan WITHOUT moving any buzz
+ *
+ * Always run dry first and eyeball totalTopUp. Set dryRun=false to actually grant the top-ups.
+ */
+import type { NextApiRequest, NextApiResponse } from 'next';
+import dayjs from '~/shared/utils/dayjs';
+import * as z from 'zod';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { SignalMessages, SignalTopic } from '~/server/common/enums';
+import {
+  getCompensationPool,
+  getPoolParticipantsV2,
+  userCashCache,
+} from '~/server/services/creator-program.service';
+import {
+  createBuzzTransactionMany,
+  getTransactionByExternalId,
+} from '~/server/services/buzz.service';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import { CAPPED_BUZZ_VALUE } from '~/shared/constants/creator-program.constants';
+import { TransactionType } from '~/shared/constants/buzz.constants';
+import { signalClient } from '~/utils/signal-client';
+
+const schema = z.object({
+  month: z
+    .string()
+    .regex(/^\d{4}-\d{2}$/)
+    .default('2026-06'),
+  // Default true, and treat the strings 'false'/'0' as false so a stray string body can't move money.
+  dryRun: z
+    .preprocess((v) => (v === 'false' || v === '0' || v === false ? false : true), z.boolean())
+    .default(true),
+});
+
+export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
+  const { month: monthStr, dryRun } = schema.parse(req.body ?? {});
+  const month = dayjs(`${monthStr}-15T12:00:00Z`).toDate();
+
+  const pool = await getCompensationPool({ month });
+  const participants = await getPoolParticipantsV2(month, false);
+
+  if (pool.size.current <= 0) {
+    return res.status(200).json({ month: monthStr, error: 'pool size is 0', participants: 0 });
+  }
+
+  // Recompute each participant's correct share exactly as creatorsProgramDistribute does, now that
+  // getPoolParticipantsV2 returns one summed row per creator (green + yellow combined).
+  let availablePoolValue = Math.floor(pool.value * 100);
+  const correctShares = new Map<number, number>();
+  for (const participant of participants) {
+    if (availablePoolValue <= 0) break;
+    const participantPortion = participant.amount / pool.size.current;
+    let participantShare = Math.floor(pool.value * participantPortion * 100);
+    const perBuzzValue = participantShare / participant.amount;
+    if (perBuzzValue > CAPPED_BUZZ_VALUE) participantShare = participant.amount * CAPPED_BUZZ_VALUE;
+    correctShares.set(participant.userId, participantShare);
+    availablePoolValue -= participantShare;
+  }
+
+  // For each creator, subtract what actually landed (original grant + any prior -fix grant).
+  const rows = await limitConcurrency(
+    Array.from(correctShares.entries()).map(([userId, correctShare]) => async () => {
+      const [original, priorFix] = await Promise.all([
+        getTransactionByExternalId(`comp-pool-unified-${monthStr}-${userId}`),
+        getTransactionByExternalId(`comp-pool-unified-${monthStr}-${userId}-fix`),
+      ]);
+      const alreadyPaid = (original?.amount ?? 0) + (priorFix?.amount ?? 0);
+      return { userId, correctShare, alreadyPaid, topUp: correctShare - alreadyPaid };
+    }),
+    10
+  );
+
+  const topUps = rows.filter((r) => r.topUp > 0);
+  const totalTopUp = topUps.reduce((sum, r) => sum + r.topUp, 0);
+
+  if (!dryRun && topUps.length > 0) {
+    await createBuzzTransactionMany(
+      topUps.map(({ userId, topUp }) => ({
+        type: TransactionType.Compensation,
+        toAccountType: 'cashPending',
+        toAccountId: userId,
+        fromAccountId: 0, // central bank
+        amount: topUp,
+        description: `Compensation Pool backfill for ${monthStr}`,
+        details: { month, backfill: 'green-yellow-double-count' },
+        externalTransactionId: `comp-pool-unified-${monthStr}-${userId}-fix`,
+      }))
+    );
+
+    await userCashCache.bust(topUps.map((r) => r.userId));
+    await signalClient.topicSend({
+      topic: SignalTopic.CreatorProgram,
+      target: SignalMessages.CashInvalidator,
+      data: {},
+    });
+  }
+
+  return res.status(200).json({
+    month: monthStr,
+    dryRun,
+    poolValueUsd: pool.value,
+    poolSize: pool.size.current,
+    participants: participants.length,
+    affectedCreators: topUps.length,
+    totalTopUpCents: totalTopUp,
+    totalTopUpUsd: totalTopUp / 100,
+    rows: topUps.sort((a, b) => b.topUp - a.topUp),
+  });
+});

--- a/src/pages/api/testing/creator-program-backfill.ts
+++ b/src/pages/api/testing/creator-program-backfill.ts
@@ -74,19 +74,36 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
   }
 
   // For each creator, subtract what actually landed (original grant + any prior -fix grant).
-  const rows = await limitConcurrency(
+  const rows: {
+    userId: number;
+    correctShare: number;
+    alreadyPaid: number;
+    topUp: number;
+    hasOriginal: boolean;
+  }[] = [];
+  await limitConcurrency(
     Array.from(correctShares.entries()).map(([userId, correctShare]) => async () => {
       const [original, priorFix] = await Promise.all([
         getTransactionByExternalId(`comp-pool-unified-${monthStr}-${userId}`),
         getTransactionByExternalId(`comp-pool-unified-${monthStr}-${userId}-fix`),
       ]);
       const alreadyPaid = (original?.amount ?? 0) + (priorFix?.amount ?? 0);
-      return { userId, correctShare, alreadyPaid, topUp: correctShare - alreadyPaid };
+      rows.push({
+        userId,
+        correctShare,
+        alreadyPaid,
+        topUp: correctShare - alreadyPaid,
+        // Only ever correct an existing distribution. A creator with no original grant was never
+        // paid for this month (unaffected / never-distributed month), so paying a full corrected
+        // share here would mint money that the distribute job never intended.
+        hasOriginal: !!original,
+      });
     }),
     10
   );
 
-  const topUps = rows.filter((r) => r.topUp > 0);
+  const skippedNoOriginal = rows.filter((r) => r.topUp > 0 && !r.hasOriginal);
+  const topUps = rows.filter((r) => r.topUp > 0 && r.hasOriginal);
   const totalTopUp = topUps.reduce((sum, r) => sum + r.topUp, 0);
 
   if (!dryRun && topUps.length > 0) {
@@ -120,6 +137,7 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
     affectedCreators: topUps.length,
     totalTopUpCents: totalTopUp,
     totalTopUpUsd: totalTopUp / 100,
+    skippedNoOriginal: skippedNoOriginal.length,
     rows: topUps.sort((a, b) => b.topUp - a.topUp),
   });
 });

--- a/src/server/services/__tests__/creator-program.service.test.ts
+++ b/src/server/services/__tests__/creator-program.service.test.ts
@@ -586,6 +586,8 @@ describe('getPoolParticipantsV2', () => {
     expect(alex).toHaveLength(1);
     expect(alex[0].amount).toBe(252280);
     expect(participants).toHaveLength(2);
+    // Upstream contributor order is preserved (the distribute pool-depletion cutoff depends on it).
+    expect(participants.map((p) => p.userId)).toEqual([4944, 999]);
   });
 
   it('drops banned participants after summing', async () => {

--- a/src/server/services/__tests__/creator-program.service.test.ts
+++ b/src/server/services/__tests__/creator-program.service.test.ts
@@ -121,6 +121,7 @@ import {
   getBanked,
   getCompensationPool,
   getCreatorRequirements,
+  getPoolParticipantsV2,
   joinCreatorsProgram,
   withdrawCash,
 } from '~/server/services/creator-program.service';
@@ -167,9 +168,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockSysRedis.get.mockResolvedValue(null);
   // Default fetchThroughCache: just call the function
-  mockFetchThroughCache.mockImplementation(
-    async (_key: string, fn: () => Promise<any>) => fn()
-  );
+  mockFetchThroughCache.mockImplementation(async (_key: string, fn: () => Promise<any>) => fn());
 });
 
 // ─── getCreatorRequirements ────────────────────────────────────────────────────
@@ -562,6 +561,50 @@ describe('withdrawCash', () => {
   });
 });
 
+// ─── getPoolParticipantsV2 ───────────────────────────────────────────────────────
+describe('getPoolParticipantsV2', () => {
+  const month = new Date('2026-06-15T12:00:00Z');
+  const monthAccount = 202606;
+
+  it('sums duplicate per-buzz-type contributor rows into a single participant', async () => {
+    // A creator who banked both green and yellow is returned as two rows with the same userId.
+    // These must collapse to one participant so the distribute job emits a single grant covering
+    // both types (regression: duplicate rows produced two grants sharing an externalTransactionId
+    // and the second was dropped, paying the creator for only one buzz type).
+    mockGetTopContributors.mockResolvedValueOnce({
+      [monthAccount]: [
+        { userId: 4944, amount: 151798 }, // yellow
+        { userId: 4944, amount: 100482 }, // green
+        { userId: 999, amount: 50000 },
+      ],
+    });
+    mockDbWrite.$queryRaw.mockResolvedValueOnce([]); // no banned participants
+
+    const participants = await getPoolParticipantsV2(month, false);
+
+    const alex = participants.filter((p) => p.userId === 4944);
+    expect(alex).toHaveLength(1);
+    expect(alex[0].amount).toBe(252280);
+    expect(participants).toHaveLength(2);
+  });
+
+  it('drops banned participants after summing', async () => {
+    mockGetTopContributors.mockResolvedValueOnce({
+      [monthAccount]: [
+        { userId: 4944, amount: 100000 },
+        { userId: 4944, amount: 50000 },
+        { userId: 999, amount: 50000 },
+      ],
+    });
+    mockDbWrite.$queryRaw.mockResolvedValueOnce([{ userId: 4944 }]); // 4944 banned
+
+    const participants = await getPoolParticipantsV2(month, false);
+
+    expect(participants).toHaveLength(1);
+    expect(participants[0].userId).toBe(999);
+  });
+});
+
 // ─── Unified pool invariants ───────────────────────────────────────────────────
 describe('unified pool invariants', () => {
   beforeEach(() => {
@@ -632,9 +675,7 @@ describe('unified pool invariants', () => {
     await extractBuzz(userId);
 
     const allCalls = mockCreateBuzzTransaction.mock.calls;
-    const extractCalls = allCalls.filter(
-      (call: any[]) => call[0].type === TransactionType.Extract
-    );
+    const extractCalls = allCalls.filter((call: any[]) => call[0].type === TransactionType.Extract);
 
     expect(extractCalls).toHaveLength(2);
     const greenRefund = extractCalls.find((c: any[]) => c[0].toAccountType === 'green');

--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -887,17 +887,15 @@ export async function getPoolParticipantsV2(month?: Date, includeNegativeAmounts
   // as one contributor row per source type. Sum them per userId so each creator is a single
   // participant and receives a single compensation grant — otherwise the distribute loop emits two
   // grants sharing one externalTransactionId and the second is silently dropped as a conflict,
-  // paying the creator for only one buzz type.
-  const participants = Object.values(
-    (data[`${monthAccount}`] ?? []).reduce<Record<number, { userId: number; amount: number }>>(
-      (acc, p) => {
-        acc[p.userId] ??= { userId: p.userId, amount: 0 };
-        acc[p.userId].amount += p.amount;
-        return acc;
-      },
-      {}
-    )
-  );
+  // paying the creator for only one buzz type. A Map preserves the upstream contributor order that
+  // the distribute loop's pool-depletion cutoff depends on (Object.values would reorder by userId).
+  const summed = new Map<number, { userId: number; amount: number }>();
+  for (const p of data[`${monthAccount}`] ?? []) {
+    const existing = summed.get(p.userId);
+    if (existing) existing.amount += p.amount;
+    else summed.set(p.userId, { userId: p.userId, amount: p.amount });
+  }
+  const participants = [...summed.values()];
   let bannedParticipants: { userId: number }[] = [];
 
   if (participants.length > 0) {

--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -883,7 +883,21 @@ export async function getPoolParticipantsV2(month?: Date, includeNegativeAmounts
     limit: 10000,
     all: true,
   });
-  const participants = data[`${monthAccount}`];
+  // A creator who banked from more than one source account type (e.g. green + yellow) is returned
+  // as one contributor row per source type. Sum them per userId so each creator is a single
+  // participant and receives a single compensation grant — otherwise the distribute loop emits two
+  // grants sharing one externalTransactionId and the second is silently dropped as a conflict,
+  // paying the creator for only one buzz type.
+  const participants = Object.values(
+    (data[`${monthAccount}`] ?? []).reduce<Record<number, { userId: number; amount: number }>>(
+      (acc, p) => {
+        acc[p.userId] ??= { userId: p.userId, amount: 0 };
+        acc[p.userId].amount += p.amount;
+        return acc;
+      },
+      {}
+    )
+  );
   let bannedParticipants: { userId: number }[] = [];
 
   if (participants.length > 0) {


### PR DESCRIPTION
## Problem

Creator Program monthly payout underpaid every creator who banked **both** green and yellow buzz — each was paid for only **one** buzz type.

**Root cause:** creators bank green + yellow into a single `creatorProgramBank` account (`getBankAccountType` ignores `buzzType`). `getPoolParticipantsV2` → `getTopContributors('creatorProgramBank')` returns **one contributor row per (userId, source buzz type)**, and the app wrapper drops `accountType` without summing. The distribute job then wrote **two** `cashPending` grants sharing one `externalTransactionId` (`comp-pool-unified-<month>-<userId>`); the buzz service deduplicates the second as a benign `conflict`, so only one type's share landed. (`getPoolParticipants` V1 — raw ClickHouse `GROUP BY userId` — was correct; V2 was the regression.)

## Fix A — payout

`getPoolParticipantsV2` now sums contributor rows by `userId`, so each creator is a single participant and receives a single combined grant. Regression test added (`getPoolParticipantsV2` had no prior coverage).

## Backfill

`POST /api/testing/creator-program-backfill` (WEBHOOK_TOKEN-gated, **dry-run by default**):
- Re-runs the corrected distribution for a settled month with the real pool value/size/cap logic.
- Subtracts what each creator already received (original grant + any prior `-fix`) and grants only the delta under `comp-pool-unified-<month>-<userId>-fix`.
- Idempotent (re-run → 0 top-ups).

```bash
# dry-run first, eyeball totalTopUpUsd, then re-run with "dryRun":false
curl -s -X POST "https://civitai.com/api/testing/creator-program-backfill?token=$WEBHOOK_TOKEN"   -H 'content-type: application/json' -d '{"month":"2026-06","dryRun":true}' | jq
```

## Blast radius (ClickHouse audit)

Green banking began 2026-04; the bug hit only the green-banking era:

| month | affected creators | shortfall |
|---|---|---|
| 2026-04 | 17 | $379.11 |
| 2026-05 | 26 | $642.91 |
| 2026-06 | 39 | $1,398.54 |
| **total** | **82** | **~$2,410.56** |

2025-03 → 2026-03: clean ($0 — no green banked).

## Verification

- `pnpm run typecheck` ✅
- `pnpm exec prettier` ✅
- Vitest `creator-program.service.test.ts`: 34/34 ✅
- (`pnpm run lint` fails repo-wide locally on a pre-existing eslintrc circular-config error, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)