### PR TITLE
feat(dev-tunnel): best-effort Cloudflare cleanup of orphan dev-tunnel DNS records

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -817,6 +817,18 @@ export const serverSchema = z
     //   an empty string and the CLI must fail closed (refuse to connect without a
     //   pin) rather than fall back to InsecureIgnoreHostKey.
     APPS_DEV_TUNNEL_SSH_HOST_PUBKEY: z.string().optional(),
+    // APPS_DEV_TUNNEL_CF_API_TOKEN   Cloudflare API token (DNS:Edit on the civit.ai
+    //   zone) used to DELETE the ephemeral `dev-<hex>.civit.ai` DNS records when a
+    //   dev-tunnel is torn down or reaped. external-dns runs `policy: upsert-only`, so
+    //   it NEVER removes a record on route deletion — the A record + its external-dns
+    //   ownership TXT records would otherwise accumulate forever (a CF zone record-cap
+    //   risk at scale). OPT-IN: unset ⇒ orphan-DNS GC is skipped (records linger exactly
+    //   as today). MUST be set on dp-prod for the cleanup to activate.
+    APPS_DEV_TUNNEL_CF_API_TOKEN: z.string().optional(),
+    // APPS_DEV_TUNNEL_CF_ZONE_ID   the civit.ai Cloudflare zone id. When set it is used
+    //   directly; when unset (but the token IS set) the zone is looked up by name
+    //   (GET /zones?name=civit.ai) and cached in-process. Optional.
+    APPS_DEV_TUNNEL_CF_ZONE_ID: z.string().optional(),
   })
   .superRefine((env, ctx) => {
     // Sentinel-mode for the system Redis client requires an explicit master group

--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -65,6 +65,8 @@ const {
       APPS_DEV_TUNNEL_SSH_HOST_PUBKEY: 'ssh-ed25519 AAAAC3NzaHostKeyExample sish-host' as
         | string
         | undefined,
+      APPS_DEV_TUNNEL_CF_API_TOKEN: undefined as string | undefined,
+      APPS_DEV_TUNNEL_CF_ZONE_ID: undefined as string | undefined,
     },
     mockNewId: vi.fn(() => 'bki_testsession'),
   };
@@ -92,6 +94,8 @@ import {
   buildDevTunnelApplyJob,
   buildDevTunnelIngressRoute,
   buildDevTunnelMiddleware,
+  deleteDevTunnelDns,
+  deleteDevTunnelRoute,
   getActiveDevTunnel,
   refundDevSessionBuzz,
   reserveDevSessionBuzz,
@@ -99,6 +103,7 @@ import {
   stopDevTunnel,
   reapExpiredDevTunnels,
   touchDevTunnelActivity,
+  __resetDevTunnelDnsCacheForTest,
   DEV_TUNNEL_IDLE_SECONDS,
   DEV_TUNNEL_HARD_SECONDS,
   DEV_TUNNEL_REAP_MIN_AGE_SECONDS,
@@ -118,8 +123,16 @@ beforeEach(() => {
   mockK8sFetch.mockResolvedValue(okRes());
   mockGetDp1Target.mockResolvedValue({ server: 'https://k8s', token: 't' });
   mockWaitForApplyJob.mockResolvedValue('succeeded');
+  mockEnv.APPS_DEV_TUNNEL_CF_API_TOKEN = undefined;
+  mockEnv.APPS_DEV_TUNNEL_CF_ZONE_ID = undefined;
+  __resetDevTunnelDnsCacheForTest();
 });
-afterEach(() => vi.clearAllMocks());
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+  mockEnv.APPS_DEV_TUNNEL_CF_API_TOKEN = undefined;
+  mockEnv.APPS_DEV_TUNNEL_CF_ZONE_ID = undefined;
+});
 
 describe('manifest builders (SSRF-safe, server-derived host)', () => {
   const opts = {
@@ -573,5 +586,234 @@ describe('reapExpiredDevTunnels (server-authoritative, idle + hardened)', () => 
       (c) => (c[2] as any)?.method === 'DELETE' && String(c[1]).includes('/middlewares/')
     );
     expect(mwDeletes.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cloudflare orphan-DNS cleanup (best-effort, opt-in, dev-<hex>-only guard)
+// ---------------------------------------------------------------------------
+
+const CF_DEV_HOST = 'dev-0123456789abcdef.civit.ai';
+
+/** A CF v4 envelope Response stub. */
+function cfEnvelope(result: unknown, ok = true, status = 200) {
+  return { ok, status, json: async () => ({ success: ok, result, errors: [] }) };
+}
+
+/** Route CF fetch by URL + method: zone lookup, per-name record list, deletes. */
+function routeCfFetch(recordsByName: Record<string, Array<{ id: string }>>, zoneResult = [{ id: 'zone-1' }]) {
+  return vi.fn(async (url: string, init?: any) => {
+    const method = init?.method ?? 'GET';
+    if (String(url).includes('/zones?name=')) return cfEnvelope(zoneResult);
+    const listMatch = String(url).match(/dns_records\?name=([^&]+)$/);
+    if (method === 'GET' && listMatch) {
+      const name = decodeURIComponent(listMatch[1]);
+      return cfEnvelope(recordsByName[name] ?? []);
+    }
+    if (method === 'DELETE') return cfEnvelope({ id: 'deleted' });
+    return cfEnvelope([]);
+  });
+}
+
+describe('deleteDevTunnelDns (best-effort orphan CF DNS cleanup)', () => {
+  beforeEach(() => {
+    mockEnv.APPS_DEV_TUNNEL_CF_API_TOKEN = 'cf-token';
+    mockEnv.APPS_DEV_TUNNEL_CF_ZONE_ID = undefined;
+    __resetDevTunnelDnsCacheForTest();
+  });
+
+  it('looks up the zone by name, queries BOTH host + a-host names, and DELETEs each returned record', async () => {
+    const fetchMock = routeCfFetch({
+      [CF_DEV_HOST]: [{ id: 'rec-a' }],
+      [`a-${CF_DEV_HOST}`]: [{ id: 'rec-txt' }],
+    });
+    await deleteDevTunnelDns(CF_DEV_HOST, fetchMock as unknown as typeof fetch);
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    // zone looked up by the registrable (last-two-label) domain of the host
+    expect(urls.some((u) => u.includes('/zones?name=civit.ai'))).toBe(true);
+    // both name forms queried (A record + external-dns TXT-registry forms)
+    expect(urls.some((u) => u.includes(`dns_records?name=${encodeURIComponent(CF_DEV_HOST)}`))).toBe(true);
+    expect(urls.some((u) => u.includes(`dns_records?name=${encodeURIComponent('a-' + CF_DEV_HOST)}`))).toBe(
+      true
+    );
+    // one DELETE per returned record id
+    const deletes = fetchMock.mock.calls
+      .filter((c) => (c[1] as any)?.method === 'DELETE')
+      .map((c) => String(c[0]));
+    expect(deletes.some((u) => u.endsWith('/zones/zone-1/dns_records/rec-a'))).toBe(true);
+    expect(deletes.some((u) => u.endsWith('/zones/zone-1/dns_records/rec-txt'))).toBe(true);
+  });
+
+  it('uses APPS_DEV_TUNNEL_CF_ZONE_ID directly when set (no zone lookup)', async () => {
+    mockEnv.APPS_DEV_TUNNEL_CF_ZONE_ID = 'zone-env';
+    const fetchMock = routeCfFetch({ [CF_DEV_HOST]: [{ id: 'r1' }], [`a-${CF_DEV_HOST}`]: [] });
+    await deleteDevTunnelDns(CF_DEV_HOST, fetchMock as unknown as typeof fetch);
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes('/zones?name='))).toBe(false);
+    expect(urls.some((u) => u.includes('/zones/zone-env/dns_records'))).toBe(true);
+  });
+
+  it('SAFETY: refuses any host that is not a well-formed dev-<16hex>.… (no CF calls)', async () => {
+    const fetchMock = vi.fn();
+    await deleteDevTunnelDns('civitai.com', fetchMock as unknown as typeof fetch);
+    await deleteDevTunnelDns('dev-notenoughhex.civit.ai', fetchMock as unknown as typeof fetch);
+    await deleteDevTunnelDns('evil-dev-0123456789abcdef.civit.ai', fetchMock as unknown as typeof fetch);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the CF token is unset (feature off — no fetch)', async () => {
+    mockEnv.APPS_DEV_TUNNEL_CF_API_TOKEN = undefined;
+    const fetchMock = vi.fn();
+    await deleteDevTunnelDns(CF_DEV_HOST, fetchMock as unknown as typeof fetch);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the CF call rejects (best-effort)', async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('cf down');
+    });
+    await expect(
+      deleteDevTunnelDns(CF_DEV_HOST, fetchMock as unknown as typeof fetch)
+    ).resolves.toBeUndefined();
+  });
+
+  it('never throws on a non-2xx CF response and issues no deletes', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes('/zones?name=')) return cfEnvelope([], false, 403);
+      return cfEnvelope([], false, 500);
+    });
+    await expect(
+      deleteDevTunnelDns(CF_DEV_HOST, fetchMock as unknown as typeof fetch)
+    ).resolves.toBeUndefined();
+    const deletes = fetchMock.mock.calls.filter((c) => (c[1] as any)?.method === 'DELETE');
+    expect(deletes.length).toBe(0);
+  });
+});
+
+describe('orphan-DNS GC wiring (teardown + reap call the CF deleter, best-effort)', () => {
+  /** LIST a route carrying the external-dns hostname annotation so
+   *  deleteDevTunnelRoute can discover the host for CF cleanup. */
+  function listRouteWithHost(sessionId: string, host: string) {
+    mockK8sFetch.mockImplementation(async (_t: unknown, path: string, init: any) => {
+      if (init?.method === 'GET' && path.includes('ingressroutes?labelSelector')) {
+        return okRes(
+          JSON.stringify({
+            items: [
+              {
+                metadata: {
+                  name: 'dev-tunnel-x',
+                  labels: { 'civitai.com/dev-tunnel-session': sessionId },
+                  annotations: { 'external-dns.alpha.kubernetes.io/hostname': host },
+                },
+              },
+            ],
+          })
+        );
+      }
+      return okRes();
+    });
+  }
+
+  it('deleteDevTunnelRoute deletes the orphan CF record for the route host', async () => {
+    mockEnv.APPS_DEV_TUNNEL_CF_API_TOKEN = 'cf-token';
+    mockEnv.APPS_DEV_TUNNEL_CF_ZONE_ID = 'zone-1';
+    listRouteWithHost('bki_wire', CF_DEV_HOST);
+    const cf: Array<[string, string]> = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string, init: any) => {
+        cf.push([init?.method ?? 'GET', String(url)]);
+        if (String(url).includes('dns_records?name=')) return cfEnvelope([{ id: 'rec-1' }]);
+        return cfEnvelope({});
+      })
+    );
+    await deleteDevTunnelRoute('bki_wire');
+    // the CF deleter was invoked with the route host and DELETEd its record
+    expect(cf.some(([m, u]) => m === 'DELETE' && u.endsWith('/zones/zone-1/dns_records/rec-1'))).toBe(true);
+  });
+
+  it('a CF failure does NOT break teardown (route + keys still deleted)', async () => {
+    mockEnv.APPS_DEV_TUNNEL_CF_API_TOKEN = 'cf-token';
+    mockEnv.APPS_DEV_TUNNEL_CF_ZONE_ID = 'zone-1';
+    sysRedis._store.set(
+      'system:blocks:dev-tunnel:session:bki_wire2',
+      JSON.stringify({
+        sessionId: 'bki_wire2',
+        userId: 42,
+        blockId: 'b',
+        host: CF_DEV_HOST,
+        fingerprint: 'fp',
+        createdAt: 1,
+        hardExpiresAt: 9999999999,
+        spendCapBuzz: 100,
+      })
+    );
+    listRouteWithHost('bki_wire2', CF_DEV_HOST);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('cf down');
+      })
+    );
+    // stopDevTunnel → teardownSession → deleteDevTunnelRoute (which GCs CF)
+    expect(await stopDevTunnel(42, 'bki_wire2')).toBe(true);
+    // teardown completed despite the CF failure — all keys gone
+    const remaining = [...sysRedis._store.keys()].filter((k) =>
+      k.startsWith('system:blocks:dev-tunnel')
+    );
+    expect(remaining).toEqual([]);
+  });
+
+  it('reapExpiredDevTunnels GCs CF DNS for a reaped session; a CF failure does not change counts', async () => {
+    mockEnv.APPS_DEV_TUNNEL_CF_API_TOKEN = 'cf-token';
+    mockEnv.APPS_DEV_TUNNEL_CF_ZONE_ID = 'zone-1';
+    const sessionId = 'bki_reapdns';
+    // hard-expired session record
+    sysRedis._store.set(
+      `system:blocks:dev-tunnel:session:${sessionId}`,
+      JSON.stringify({
+        sessionId,
+        userId: 7,
+        blockId: 'x',
+        host: CF_DEV_HOST,
+        fingerprint: 'fp',
+        createdAt: 1,
+        hardExpiresAt: 1,
+        spendCapBuzz: 100,
+        lastActivityAt: 1,
+      })
+    );
+    // LIST returns the route WITH the hostname annotation (discovery + host source)
+    mockK8sFetch.mockImplementation(async (_t: unknown, path: string, init: any) => {
+      if (init?.method === 'GET' && path.includes('ingressroutes?labelSelector')) {
+        return okRes(
+          JSON.stringify({
+            items: [
+              {
+                metadata: {
+                  name: 'dev-tunnel-x',
+                  labels: { 'civitai.com/dev-tunnel-session': sessionId },
+                  annotations: { 'external-dns.alpha.kubernetes.io/hostname': CF_DEV_HOST },
+                },
+              },
+            ],
+          })
+        );
+      }
+      return okRes();
+    });
+    const cfUrls: string[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url: string) => {
+        cfUrls.push(String(url));
+        throw new Error('cf down');
+      })
+    );
+    const result = await reapExpiredDevTunnels();
+    // reap counts are unaffected by the (failing) best-effort CF cleanup
+    expect(result).toEqual({ swept: 1, reaped: 1, skipped: 0, listOk: true });
+    // the CF deleter WAS invoked for the reaped host's zone
+    expect(cfUrls.some((u) => u.includes('/zones/zone-1/dns_records'))).toBe(true);
   });
 });

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -464,13 +464,185 @@ export async function renderDevTunnelRoute(host: string, sessionId: string): Pro
   }
 }
 
+// ---------------------------------------------------------------------------
+// Cloudflare orphan-DNS cleanup (best-effort — external-dns is upsert-only)
+// ---------------------------------------------------------------------------
+//
+// external-dns runs `policy: upsert-only` on the civit.ai zone, so deleting a
+// dev-tunnel IngressRoute leaves its `dev-<hex>.civit.ai` A record AND the
+// external-dns ownership TXT registry records behind — with no GC they accumulate
+// forever (a CF zone record-cap risk at scale). This best-effort deleter removes
+// them via the Cloudflare API when a tunnel is torn down or reaped. It is OPT-IN
+// (unset APPS_DEV_TUNNEL_CF_API_TOKEN ⇒ no-op, records linger as before) and NEVER
+// throws — it must not break teardown/reap.
+
+const CF_API_BASE = 'https://api.cloudflare.com/client/v4';
+/** Per-call HTTP timeout — the CF API is best-effort, keep it snappy. */
+const CF_CALL_TIMEOUT_MS = 5_000;
+/** External-dns annotation carrying the ephemeral dev host on the IngressRoute. */
+const EXTERNAL_DNS_HOSTNAME_ANNOTATION = 'external-dns.alpha.kubernetes.io/hostname';
+/** SAFETY guard: only ever act on a well-formed ephemeral dev host
+ *  `dev-<16hex>.<...>` — refuse anything else so a malformed/foreign host can
+ *  never delete an unrelated CF record. Extends DEV_HOST_LABEL_REGEX (the label)
+ *  to the full-host prefix; the queried names are `<host>` and `a-<host>`, both of
+ *  which then necessarily start with `dev-`/`a-dev-`. */
+const DEV_HOST_PREFIX_REGEX = /^dev-[a-f0-9]{16}\./;
+
+/** The CF v4 response envelope. */
+type CfEnvelope<T> = { success: boolean; result: T; errors?: unknown };
+
+/** In-process cache of the resolved civit.ai zone id (only used on the lookup
+ *  path — the env-provided id bypasses it). */
+let cfZoneIdCache: string | null = null;
+
+/** TEST-ONLY: reset the in-process zone-id cache between cases. */
+export function __resetDevTunnelDnsCacheForTest(): void {
+  cfZoneIdCache = null;
+}
+
+/** The registrable (last-two-label) domain of a host — the CF zone name. e.g.
+ *  `dev-abc.civit.ai` → `civit.ai`. */
+function registrableDomain(host: string): string {
+  return host.split('.').slice(-2).join('.');
+}
+
+async function cfFetch(
+  path: string,
+  token: string,
+  init: RequestInit,
+  fetchImpl: typeof fetch
+): Promise<Response> {
+  return fetchImpl(`${CF_API_BASE}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      ...(init.headers ?? {}),
+    },
+    signal: AbortSignal.timeout(CF_CALL_TIMEOUT_MS),
+  });
+}
+
+/** Resolve the CF zone id: prefer the env id; else look it up by name (once,
+ *  cached). Returns null when it can't be resolved (the deleter then no-ops). */
+async function resolveCfZoneId(
+  domain: string,
+  token: string,
+  fetchImpl: typeof fetch
+): Promise<string | null> {
+  if (env.APPS_DEV_TUNNEL_CF_ZONE_ID) return env.APPS_DEV_TUNNEL_CF_ZONE_ID;
+  if (cfZoneIdCache) return cfZoneIdCache;
+  const res = await cfFetch(
+    `/zones?name=${encodeURIComponent(domain)}`,
+    token,
+    { method: 'GET' },
+    fetchImpl
+  );
+  if (!res.ok) return null;
+  const body = (await res.json()) as CfEnvelope<Array<{ id?: string }>>;
+  const id = body?.success ? body.result?.[0]?.id : undefined;
+  if (typeof id === 'string' && id) {
+    cfZoneIdCache = id;
+    return id;
+  }
+  return null;
+}
+
+/** List the CF record ids (any type) whose name is exactly `name`. */
+async function listCfRecordIds(
+  zoneId: string,
+  name: string,
+  token: string,
+  fetchImpl: typeof fetch
+): Promise<string[]> {
+  const res = await cfFetch(
+    `/zones/${zoneId}/dns_records?name=${encodeURIComponent(name)}`,
+    token,
+    { method: 'GET' },
+    fetchImpl
+  );
+  if (!res.ok) return [];
+  const body = (await res.json()) as CfEnvelope<Array<{ id?: string }>>;
+  if (!body?.success || !Array.isArray(body.result)) return [];
+  return body.result
+    .map((r) => r?.id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+}
+
+/**
+ * Best-effort deletion of the orphan Cloudflare DNS records for a dev-tunnel
+ * host. Removes EVERY record named `<host>` OR `a-<host>` (external-dns's A record
+ * PLUS its TXT-registry ownership records — whose name is either the bare host or
+ * the type-prefixed `a-<host>` form depending on external-dns version — so
+ * deleting both names covers the A record + both TXT formats). No-op when
+ * unconfigured; refuses any host that isn't a well-formed `dev-<16hex>.…`; NEVER
+ * throws. `fetchImpl` is injected for testing (defaults to global fetch).
+ */
+export async function deleteDevTunnelDns(
+  host: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<void> {
+  try {
+    const token = env.APPS_DEV_TUNNEL_CF_API_TOKEN;
+    if (!token) return; // feature off — records linger as before
+    if (!host || typeof host !== 'string' || !DEV_HOST_PREFIX_REGEX.test(host)) {
+      // SAFETY: never touch a name that isn't a well-formed ephemeral dev host.
+      // eslint-disable-next-line no-console
+      console.warn(JSON.stringify({ event: 'app-blocks.dev-tunnel.dns-gc.refused', host }));
+      return;
+    }
+    const zoneId = await resolveCfZoneId(registrableDomain(host), token, fetchImpl);
+    if (!zoneId) return;
+    // The A record and BOTH external-dns TXT-registry name forms.
+    const ids = new Set<string>();
+    for (const name of [host, `a-${host}`]) {
+      for (const id of await listCfRecordIds(zoneId, name, token, fetchImpl)) ids.add(id);
+    }
+    for (const id of ids) {
+      await cfFetch(`/zones/${zoneId}/dns_records/${id}`, token, { method: 'DELETE' }, fetchImpl)
+        .then((r) => {
+          if (!r.ok) {
+            // eslint-disable-next-line no-console
+            console.warn(
+              JSON.stringify({
+                event: 'app-blocks.dev-tunnel.dns-gc.delete-failed',
+                host,
+                id,
+                status: r.status,
+              })
+            );
+          }
+        })
+        .catch(() => {
+          /* best-effort per-record delete */
+        });
+    }
+  } catch (e) {
+    // Best-effort — a CF hiccup must NEVER break teardown/reap.
+    // eslint-disable-next-line no-console
+    console.warn(
+      JSON.stringify({
+        event: 'app-blocks.dev-tunnel.dns-gc.error',
+        host,
+        error: (e as Error)?.message,
+      })
+    );
+  }
+}
+
 /** Delete the ephemeral Traefik route for ONE session by label selector. Scoped
  *  to `civitai.com/dev-tunnel-session=<id>` so it can only ever touch THAT
- *  session's objects, never a live app. Best-effort + idempotent. */
+ *  session's objects, never a live app. Best-effort + idempotent. Also best-effort
+ *  GCs the orphan CF DNS record for the route host (external-dns is upsert-only, so
+ *  it never removes the `dev-<hex>.civit.ai` record itself) — the host is read from
+ *  the IngressRoute's external-dns hostname annotation, so cleanup runs iff a record
+ *  was actually created (annotation present ⟺ ingressTarget was set at mint). */
 export async function deleteDevTunnelRoute(sessionId: string): Promise<void> {
   const target = await getDp1Target();
   const ns = env.APPS_DEV_TUNNEL_ROUTE_NAMESPACE;
   const selector = encodeURIComponent(`${DEV_TUNNEL_SESSION_LABEL}=${sessionId}`);
+  let devHost: string | undefined;
   const kinds: Array<{ listPath: string; itemPath: (n: string) => string }> = [
     {
       listPath: `/apis/traefik.io/v1alpha1/namespaces/${ns}/ingressroutes?labelSelector=${selector}`,
@@ -485,8 +657,17 @@ export async function deleteDevTunnelRoute(sessionId: string): Promise<void> {
     try {
       const listRes = await k8sFetch(target, k.listPath, { method: 'GET' });
       if (!listRes.ok) continue;
-      const list = await unwrap<{ items?: Array<{ metadata?: { name?: string } }> }>(listRes);
-      const names = (list?.items ?? [])
+      const list = await unwrap<{
+        items?: Array<{ metadata?: { name?: string; annotations?: Record<string, string> } }>;
+      }>(listRes);
+      const items = list?.items ?? [];
+      // Capture the ephemeral DNS host from the IngressRoute annotation (only the
+      // IngressRoute carries it) for the post-delete CF GC.
+      for (const it of items) {
+        const h = it?.metadata?.annotations?.[EXTERNAL_DNS_HOSTNAME_ANNOTATION];
+        if (!devHost && typeof h === 'string' && h) devHost = h;
+      }
+      const names = items
         .map((it) => it?.metadata?.name)
         .filter((n): n is string => typeof n === 'string' && n.length > 0);
       for (const name of names) {
@@ -500,6 +681,9 @@ export async function deleteDevTunnelRoute(sessionId: string): Promise<void> {
       /* a single kind failing must not abort the sweep */
     }
   }
+  // Best-effort orphan-DNS GC AFTER the k8s objects are gone — never blocks/fails
+  // teardown. No annotation ⇒ no record was created ⇒ nothing to clean.
+  if (devHost) await deleteDevTunnelDns(devHost).catch(() => {});
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds best-effort Cloudflare-API deletion of a dev-tunnel's ephemeral `dev-<16hex>.civit.ai` DNS record when the tunnel is torn down (`stopDevTunnel`) or reaped (`reapExpiredDevTunnels`).

## Why

The dev-tunnel creates the ephemeral host record via `external-dns` annotations on the IngressRoute. external-dns runs `policy: upsert-only`, so when the route is deleted the **DNS record is NOT removed** — the A record **and** external-dns's ownership TXT registry records accumulate forever. At scale this is a Cloudflare zone record-cap risk. There was previously no GC for these (it was a tracked follow-up noted in `buildDevTunnelIngressRoute`).

## How

- **`deleteDevTunnelDns(host)`** — resolves the CF zone, then deletes **every** record named `<host>` OR `a-<host>` (the A record + both external-dns TXT-registry name forms, so it's version-agnostic). Each HTTP call is 5s-bounded; parses the CF v4 `{success, result, errors}` envelope.
- Wired into **`deleteDevTunnelRoute`** — the single path that `stopDevTunnel` (via `teardownSession`) and **both** reaper branches (ok-expired via `teardownSession`, absent-orphan directly) funnel through. The host is read from the IngressRoute's `external-dns.alpha.kubernetes.io/hostname` annotation, so cleanup runs **iff** a record was actually created (annotation present ⟺ `ingressTarget` was set at mint).

## New envs (both OPTIONAL — opt-in)

Unset ⇒ CF cleanup is **skipped** and records linger exactly as today. **Must be set on dp-prod** for the cleanup to activate.

- `APPS_DEV_TUNNEL_CF_API_TOKEN` — a Cloudflare API token with `DNS:Edit` on the civit.ai zone.
- `APPS_DEV_TUNNEL_CF_ZONE_ID` — the civit.ai CF zone id; used directly if set, else the zone is looked up by name (`GET /zones?name=civit.ai`) and cached in-process.

## Safety

- **`dev-<hex>`-only guard:** refuses any host not matching `^dev-[a-f0-9]{16}\.` before any CF call, so a malformed/foreign host can never delete an unrelated record. It only ever operates on `dev-`/`a-dev-` names under the host's registrable (last-two-label) domain.
- **Best-effort / non-fatal:** never throws, logs a warning on failure. A CF hiccup must not break teardown or reap — verified by tests that a CF failure leaves teardown (route + keys) and reap counts unchanged.

## Tests

9 new tests (`npx vitest run src/server/services/blocks/__tests__/dev-tunnel.service.test.ts` → **37 passed**): deleter zone-lookup/env-id paths, both name queries, per-record deletes, the dev-only refusal, token-unset no-op, non-2xx/throw non-fatality, and the teardown + reap wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)