### PR TITLE
fix(nowpayments): send stuck-deposit email from hello@civitai.com

### DIFF
--- a/src/server/email/templates/stuckCryptoDeposit.email.ts
+++ b/src/server/email/templates/stuckCryptoDeposit.email.ts
@@ -23,6 +23,7 @@ export const stuckCryptoDepositEmail = createEmail({
     subject: `Unprocessed crypto deposit ${paymentId} - wrong token / network`,
     to: supportEmail,
     cc: userEmail,
+    from: 'Civitai Support <hello@civitai.com>',
   }),
   html(data: StuckCryptoDepositData) {
     const { username, paymentId, payAddress, payinHash } = data;


### PR DESCRIPTION
Follow-up to #2956. Sets the `stuckCryptoDeposit` email `from` to `Civitai Support <hello@civitai.com>` so NowPayments replies land in our support inbox instead of the unmonitored `noreply@` default.

- `hello@civitai.com` is on the SES-verified `civitai.com` domain, so it sends cleanly.
- User stays CC'd, so a reply-all still reaches them too.
- One-line change to the template header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)