### PR TITLE
feat(metrics): B2 PUT Prometheus instrumentation (additive)

### DIFF
--- a/src/server/prom/__tests__/b2-put.metrics.test.ts
+++ b/src/server/prom/__tests__/b2-put.metrics.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import client from 'prom-client';
+import {
+  b2PutMetricsMiddleware,
+  opForCommand,
+  classifyErrorResult,
+  recordB2PresignIssued,
+  __resetB2PutMetricsForTest,
+} from '~/server/prom/b2-put.metrics';
+
+// Pure unit test: this module imports only prom-client (no env / Prisma / DB), so
+// nothing here boots the app graph. We drive the AWS-SDK-shaped middleware directly
+// with a mocked `next` handler and read counter values back off the default registry.
+
+type MetricJSON = { values: { value: number; labels: Record<string, string> }[] };
+
+async function readCounter(name: string): Promise<MetricJSON['values']> {
+  const metric = client.register.getSingleMetric(name) as unknown as {
+    get: () => Promise<MetricJSON>;
+  };
+  const data = await metric.get();
+  return data.values;
+}
+
+async function countFor(name: string, labels: Record<string, string>): Promise<number> {
+  const values = await readCounter(name);
+  const match = values.find((v) =>
+    Object.entries(labels).every(([k, val]) => v.labels[k] === val)
+  );
+  return match?.value ?? 0;
+}
+
+// An AWS-SDK error carries a $metadata bag; model just enough of it.
+function sdkError(opts: { httpStatusCode?: number; name?: string; attempts?: number }) {
+  const err = new Error(opts.name ?? 'SdkError') as Error & {
+    name: string;
+    $metadata?: { httpStatusCode?: number; attempts?: number };
+  };
+  if (opts.name) err.name = opts.name;
+  err.$metadata = { httpStatusCode: opts.httpStatusCode, attempts: opts.attempts };
+  return err;
+}
+
+beforeEach(() => {
+  __resetB2PutMetricsForTest();
+});
+
+describe('opForCommand', () => {
+  it('maps PutObject → upload, Copy → copy, multipart commands → multipart', () => {
+    expect(opForCommand('PutObjectCommand')).toBe('upload');
+    expect(opForCommand('CopyObjectCommand')).toBe('copy');
+    expect(opForCommand('CreateMultipartUploadCommand')).toBe('multipart');
+    expect(opForCommand('UploadPartCommand')).toBe('multipart');
+  });
+
+  it('returns null for non-PUT-class commands', () => {
+    expect(opForCommand('GetObjectCommand')).toBeNull();
+    expect(opForCommand('HeadObjectCommand')).toBeNull();
+    expect(opForCommand('DeleteObjectCommand')).toBeNull();
+    expect(opForCommand('CompleteMultipartUploadCommand')).toBeNull();
+    expect(opForCommand(undefined)).toBeNull();
+  });
+});
+
+describe('classifyErrorResult', () => {
+  it('classifies HTTP 429 as throttled', () => {
+    expect(classifyErrorResult(sdkError({ httpStatusCode: 429 }))).toBe('throttled');
+  });
+  it('classifies 503 SlowDown / TooManyRequests as throttled', () => {
+    expect(classifyErrorResult(sdkError({ httpStatusCode: 503, name: 'SlowDown' }))).toBe(
+      'throttled'
+    );
+    expect(classifyErrorResult(sdkError({ httpStatusCode: 503, name: 'TooManyRequests' }))).toBe(
+      'throttled'
+    );
+  });
+  it('classifies a generic 500 / unknown error as error', () => {
+    expect(classifyErrorResult(sdkError({ httpStatusCode: 500, name: 'InternalError' }))).toBe(
+      'error'
+    );
+    expect(classifyErrorResult(new Error('boom'))).toBe('error');
+  });
+});
+
+describe('b2PutMetricsMiddleware — send() outcome counting', () => {
+  it('(a) success → increments b2_put_requests_total with correct bucket/op/result', async () => {
+    const next = vi.fn(async () => ({ output: { $metadata: { attempts: 1 } } }));
+    const handler = b2PutMetricsMiddleware(next, { commandName: 'PutObjectCommand' });
+
+    const out = await handler({ input: { Bucket: 'civitai-media-uploads' } });
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(out).toEqual({ output: { $metadata: { attempts: 1 } } });
+    expect(
+      await countFor('b2_put_requests_total', {
+        service: 'civitai-web',
+        bucket: 'civitai-media-uploads',
+        op: 'upload',
+        result: 'success',
+      })
+    ).toBe(1);
+    // No retries on a single-attempt success.
+    expect(
+      await countFor('b2_put_retries_total', {
+        service: 'civitai-web',
+        bucket: 'civitai-media-uploads',
+      })
+    ).toBe(0);
+  });
+
+  it('(b) throttled: a 429 SlowDown throw → increments result="throttled" and re-throws', async () => {
+    const err = sdkError({ httpStatusCode: 429, name: 'SlowDown' });
+    const next = vi.fn(async () => {
+      throw err;
+    });
+    const handler = b2PutMetricsMiddleware(next, { commandName: 'CreateMultipartUploadCommand' });
+
+    await expect(handler({ input: { Bucket: 'civitai-modelfiles' } })).rejects.toBe(err);
+
+    expect(
+      await countFor('b2_put_requests_total', {
+        service: 'civitai-web',
+        bucket: 'civitai-modelfiles',
+        op: 'multipart',
+        result: 'throttled',
+      })
+    ).toBe(1);
+  });
+
+  it('(c) generic error throw → increments result="error" and re-throws', async () => {
+    const err = sdkError({ httpStatusCode: 500, name: 'InternalError' });
+    const next = vi.fn(async () => {
+      throw err;
+    });
+    const handler = b2PutMetricsMiddleware(next, { commandName: 'PutObjectCommand' });
+
+    await expect(handler({ input: { Bucket: 'civitai-media-uploads' } })).rejects.toBe(err);
+
+    expect(
+      await countFor('b2_put_requests_total', {
+        service: 'civitai-web',
+        bucket: 'civitai-media-uploads',
+        op: 'upload',
+        result: 'error',
+      })
+    ).toBe(1);
+  });
+
+  it('counts SDK retry attempts from $metadata.attempts (attempts=3 → retries+2)', async () => {
+    const next = vi.fn(async () => ({ output: { $metadata: { attempts: 3 } } }));
+    const handler = b2PutMetricsMiddleware(next, { commandName: 'UploadPartCommand' });
+
+    await handler({ input: { Bucket: 'civitai-modelfiles' } });
+
+    expect(
+      await countFor('b2_put_retries_total', {
+        service: 'civitai-web',
+        bucket: 'civitai-modelfiles',
+      })
+    ).toBe(2);
+    expect(
+      await countFor('b2_put_requests_total', {
+        service: 'civitai-web',
+        bucket: 'civitai-modelfiles',
+        op: 'multipart',
+        result: 'success',
+      })
+    ).toBe(1);
+  });
+
+  it('also counts retries when the final outcome is an error', async () => {
+    const err = sdkError({ httpStatusCode: 429, attempts: 4 });
+    const next = vi.fn(async () => {
+      throw err;
+    });
+    const handler = b2PutMetricsMiddleware(next, { commandName: 'PutObjectCommand' });
+
+    await expect(handler({ input: { Bucket: 'civitai-modelfiles' } })).rejects.toBe(err);
+
+    expect(
+      await countFor('b2_put_retries_total', {
+        service: 'civitai-web',
+        bucket: 'civitai-modelfiles',
+      })
+    ).toBe(3);
+  });
+
+  it('passes non-PUT-class commands straight through without counting', async () => {
+    const next = vi.fn(async () => ({ output: { $metadata: { attempts: 1 } } }));
+    const handler = b2PutMetricsMiddleware(next, { commandName: 'GetObjectCommand' });
+
+    await handler({ input: { Bucket: 'civitai-media-uploads' } });
+
+    expect(next).toHaveBeenCalledOnce();
+    const values = await readCounter('b2_put_requests_total');
+    expect(values).toHaveLength(0);
+  });
+
+  it('falls back to bucket="unknown" when the command input has no Bucket', async () => {
+    const next = vi.fn(async () => ({ output: { $metadata: { attempts: 1 } } }));
+    const handler = b2PutMetricsMiddleware(next, { commandName: 'PutObjectCommand' });
+
+    await handler({ input: {} });
+
+    expect(
+      await countFor('b2_put_requests_total', {
+        service: 'civitai-web',
+        bucket: 'unknown',
+        op: 'upload',
+        result: 'success',
+      })
+    ).toBe(1);
+  });
+});
+
+describe('recordB2PresignIssued', () => {
+  it('increments b2_presign_issued_total for the given bucket', async () => {
+    recordB2PresignIssued('civitai-modelfiles');
+    recordB2PresignIssued('civitai-modelfiles');
+    expect(
+      await countFor('b2_presign_issued_total', {
+        service: 'civitai-web',
+        bucket: 'civitai-modelfiles',
+      })
+    ).toBe(2);
+  });
+});

--- a/src/server/prom/__tests__/b2-put.metrics.test.ts
+++ b/src/server/prom/__tests__/b2-put.metrics.test.ts
@@ -213,6 +213,67 @@ describe('b2PutMetricsMiddleware — send() outcome counting', () => {
   });
 });
 
+describe('b2PutMetricsMiddleware — telemetry can never throw into an upload', () => {
+  // The middleware evaluates classifyErrorResult / retriesFromMetadata as arguments
+  // to the guarded recordB2PutSend. These helpers only do optional-chaining reads and
+  // realistically can't throw — but the guard must be STRUCTURAL, not empirical. We
+  // force the telemetry argument-evaluation to throw (a metadata object whose accessed
+  // property throws) and assert the middleware still behaves as if telemetry is a no-op:
+  // the ORIGINAL SDK error is re-thrown on the error path, and the SDK result is still
+  // returned on the success path — never a telemetry error, and the upload never crashes.
+
+  it('error path: re-throws the ORIGINAL SDK error even if classifyErrorResult/retriesFromMetadata throw', async () => {
+    const err = new Error('original sdk failure') as Error & { $metadata?: unknown };
+    // Reading $metadata (done by both classifyErrorResult and retriesFromMetadata)
+    // throws — simulating a telemetry helper blowing up on a hostile metadata bag.
+    Object.defineProperty(err, '$metadata', {
+      get() {
+        throw new Error('telemetry classify boom — must NOT surface');
+      },
+    });
+    const next = vi.fn(async () => {
+      throw err;
+    });
+    const handler = b2PutMetricsMiddleware(next, { commandName: 'PutObjectCommand' });
+
+    // Rejects with the ORIGINAL err (not the telemetry error) and does not crash.
+    await expect(handler({ input: { Bucket: 'civitai-modelfiles' } })).rejects.toBe(err);
+    // Telemetry swallowed the throw, so nothing was counted for this send.
+    expect(
+      await countFor('b2_put_requests_total', {
+        service: 'civitai-web',
+        bucket: 'civitai-modelfiles',
+        op: 'upload',
+        result: 'error',
+      })
+    ).toBe(0);
+  });
+
+  it('success path: returns the SDK result even if retriesFromMetadata arg-eval throws', async () => {
+    const result = { output: {} as { $metadata?: unknown } };
+    // Reading result.output.$metadata (the retriesFromMetadata argument) throws.
+    Object.defineProperty(result.output, '$metadata', {
+      get() {
+        throw new Error('telemetry retries boom — must NOT surface');
+      },
+    });
+    const next = vi.fn(async () => result);
+    const handler = b2PutMetricsMiddleware(next, { commandName: 'PutObjectCommand' });
+
+    // Resolves to the original SDK result — the successful upload is untouched.
+    await expect(handler({ input: { Bucket: 'civitai-modelfiles' } })).resolves.toBe(result);
+    // Telemetry swallowed the throw, so no success row was recorded either.
+    expect(
+      await countFor('b2_put_requests_total', {
+        service: 'civitai-web',
+        bucket: 'civitai-modelfiles',
+        op: 'upload',
+        result: 'success',
+      })
+    ).toBe(0);
+  });
+});
+
 describe('recordB2PresignIssued', () => {
   it('increments b2_presign_issued_total for the given bucket', async () => {
     recordB2PresignIssued('civitai-modelfiles');

--- a/src/server/prom/b2-put.metrics.ts
+++ b/src/server/prom/b2-put.metrics.ts
@@ -1,0 +1,231 @@
+import client from 'prom-client';
+// Type-only: erased at compile time, so this module stays a runtime-pure prom-client
+// leaf (the unit test never loads the AWS SDK).
+import type { S3Client } from '@aws-sdk/client-s3';
+
+/**
+ * BACKBLAZE B2 PUT observability (additive telemetry only — no behavior change).
+ *
+ * Civitai's B2 account is contracted for a 3,000 PUT-RPS ceiling and the main app
+ * is the dominant, previously-uninstrumented source. This module emits the
+ * CROSS-SERVICE CANONICAL counters (shared verbatim with image-cacher +
+ * orchestration + the DR-mirror Pushgateway jobs and read by the `B2 PUT Load`
+ * Grafana dashboard / alerts), so the metric NAMES here are intentionally NOT
+ * `PROM_PREFIX`-prefixed — they must match the identical names on every service:
+ *
+ *   b2_put_requests_total{service="civitai-web", bucket, op, result}
+ *       op     ∈ {upload, copy, multipart}
+ *       result ∈ {success, throttled, error}
+ *   b2_put_retries_total{service="civitai-web", bucket}
+ *   b2_presign_issued_total{service="civitai-web", bucket}   (civitai-web-only proxy — see below)
+ *
+ * SERVER-side coverage is via an AWS-SDK v3 client middleware installed on the two
+ * B2 S3 client factories (`getB2S3Client` / `getB2ImageS3Client` in s3-utils.ts).
+ * Because the middleware runs at the `initialize` step it fires once per `.send()`
+ * with the FINAL outcome (post-retry), and it NEVER runs for presigned URLs —
+ * `getSignedUrl` does not call `.send()`. This gives us exactly the server-side /
+ * browser-direct split we want. Retry attempts are read from `$metadata.attempts`
+ * on the resolved output (or the thrown error), so retries ARE observable without a
+ * per-attempt middleware.
+ *
+ * BROWSER-DIRECT uploads (presigned model-file / media PUTs) upload from the user's
+ * browser IP, so the actual PUT is invisible pod-side. We count ISSUANCE of the
+ * presigned URL as a proxy via `b2_presign_issued_total` — a DEDICATED counter, not
+ * a `b2_put_requests_total{op="presign"}` row, deliberately: the dashboard's
+ * headline sums `b2_put_requests_total` as real PUT RPS against the 3,000 ceiling,
+ * and folding non-PUT issuance into that name would inflate the ceiling gauge.
+ *
+ * Registered on the DEFAULT prom-client registry (scraped at /api/metrics) and
+ * pinned on globalThis so HMR / a second webpack-graph eval reuse the one instance
+ * instead of tripping prom-client's duplicate-registration throw (same pattern as
+ * dev-tunnel.metrics.ts / the http-error counter).
+ */
+
+export const B2_PUT_SERVICE = 'civitai-web';
+
+export type B2PutOp = 'upload' | 'copy' | 'multipart';
+export type B2PutResult = 'success' | 'throttled' | 'error';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __civitaiB2PutMetrics:
+    | {
+        requests: client.Counter<string>;
+        retries: client.Counter<string>;
+        presignIssued: client.Counter<string>;
+      }
+    | undefined;
+}
+
+const metrics =
+  globalThis.__civitaiB2PutMetrics ??
+  (globalThis.__civitaiB2PutMetrics = {
+    requests: new client.Counter({
+      name: 'b2_put_requests_total',
+      help:
+        'Server-side Backblaze B2 PUT-class transactions issued by this pod, by op ' +
+        '(upload|copy|multipart) and result (success|throttled|error). Counts once per ' +
+        '.send() (final post-retry outcome). Excludes browser-direct presigned uploads.',
+      labelNames: ['service', 'bucket', 'op', 'result'],
+    }),
+    retries: new client.Counter({
+      name: 'b2_put_retries_total',
+      help:
+        'SDK retry attempts made on server-side B2 PUT-class sends (attempts-1, from ' +
+        '$metadata.attempts). Monotonic; use rate().',
+      labelNames: ['service', 'bucket'],
+    }),
+    presignIssued: new client.Counter({
+      name: 'b2_presign_issued_total',
+      help:
+        'Presigned B2 PUT/UploadPart URLs ISSUED to browsers (proxy for browser-direct ' +
+        'upload load — the actual PUT happens from the user IP and is invisible pod-side). ' +
+        'NOT a real PUT; kept out of b2_put_requests_total on purpose.',
+      labelNames: ['service', 'bucket'],
+    }),
+  });
+
+/** Map an AWS-SDK command name to the canonical `op`, or null for commands we do
+ *  not count (Get/Head/Delete/Complete/Abort — not PUT-class transactions). */
+export function opForCommand(commandName: string | undefined): B2PutOp | null {
+  switch (commandName) {
+    case 'PutObjectCommand':
+      return 'upload';
+    case 'CopyObjectCommand':
+      return 'copy';
+    case 'CreateMultipartUploadCommand':
+    case 'UploadPartCommand':
+      return 'multipart';
+    default:
+      return null;
+  }
+}
+
+const THROTTLE_ERROR_NAMES = new Set([
+  'SlowDown',
+  'TooManyRequests',
+  'TooManyRequestsException',
+  'ThrottlingException',
+  'Throttling',
+  'RequestThrottled',
+  'RequestThrottledException',
+  'ProvisionedThroughputExceededException',
+]);
+
+/** Classify a thrown SDK error as `throttled` (HTTP 429, or 503 SlowDown/
+ *  TooManyRequests / other throttle codes) vs a generic `error`. */
+export function classifyErrorResult(error: unknown): Extract<B2PutResult, 'throttled' | 'error'> {
+  const e = error as
+    | { name?: string; Code?: string; $metadata?: { httpStatusCode?: number } }
+    | undefined;
+  const status = e?.$metadata?.httpStatusCode;
+  if (status === 429) return 'throttled';
+  const code = e?.name ?? e?.Code;
+  if (code && THROTTLE_ERROR_NAMES.has(code)) return 'throttled';
+  return 'error';
+}
+
+function retriesFromMetadata(metadata: { attempts?: number } | undefined): number {
+  const attempts = metadata?.attempts;
+  if (typeof attempts === 'number' && attempts > 1) return attempts - 1;
+  return 0;
+}
+
+/** Record one server-side B2 PUT-class send outcome. Never throws — a telemetry
+ *  failure must not break an upload. Exported for direct unit testing. */
+export function recordB2PutSend(args: {
+  bucket: string | undefined;
+  op: B2PutOp;
+  result: B2PutResult;
+  retries?: number;
+}): void {
+  try {
+    const bucket = args.bucket ?? 'unknown';
+    metrics.requests.inc({ service: B2_PUT_SERVICE, bucket, op: args.op, result: args.result });
+    if (args.retries && args.retries > 0) {
+      metrics.retries.inc({ service: B2_PUT_SERVICE, bucket }, args.retries);
+    }
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+/** Record issuance of a presigned browser-direct B2 PUT URL. Never throws. */
+export function recordB2PresignIssued(bucket: string | undefined): void {
+  try {
+    metrics.presignIssued.inc({ service: B2_PUT_SERVICE, bucket: bucket ?? 'unknown' });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+// Minimal structural shapes so this module needs no @aws-sdk/@smithy type deps.
+type B2Metadata = { attempts?: number; httpStatusCode?: number };
+type B2MiddlewareArgs = { input?: { Bucket?: string } };
+type B2MiddlewareOutput = { output?: { $metadata?: B2Metadata } };
+type B2NextHandler = (args: B2MiddlewareArgs) => Promise<B2MiddlewareOutput>;
+type B2MiddlewareContext = { commandName?: string };
+
+/**
+ * AWS-SDK v3 `initialize`-step middleware that counts B2 PUT-class sends. Exported
+ * raw (curried `(next, context) => handler`) so unit tests can drive it directly.
+ * Passes non-PUT-class commands straight through untouched.
+ */
+export const b2PutMetricsMiddleware =
+  (next: B2NextHandler, context: B2MiddlewareContext) => async (args: B2MiddlewareArgs) => {
+    const op = opForCommand(context?.commandName);
+    if (!op) return next(args);
+    const bucket = args?.input?.Bucket;
+    try {
+      const result = await next(args);
+      recordB2PutSend({
+        bucket,
+        op,
+        result: 'success',
+        retries: retriesFromMetadata(result?.output?.$metadata),
+      });
+      return result;
+    } catch (error) {
+      recordB2PutSend({
+        bucket,
+        op,
+        result: classifyErrorResult(error),
+        retries: retriesFromMetadata((error as { $metadata?: B2Metadata })?.$metadata),
+      });
+      throw error;
+    }
+  };
+
+// Track instrumented clients so re-wrapping a memoized client is a no-op.
+const instrumentedClients = new WeakSet<object>();
+
+/**
+ * Install the B2 PUT metrics middleware on an AWS-SDK v3 S3Client and return it.
+ * Idempotent per client instance. Typed loosely (`middlewareStack.add` is heavily
+ * overloaded on the S3 service union) — the middleware itself is fully structural.
+ */
+export function instrumentB2Client(s3: S3Client): S3Client {
+  try {
+    if (instrumentedClients.has(s3)) return s3;
+    // `middlewareStack.add` is overloaded per step; the `step: 'initialize'` option
+    // selects the initialize overload. The middleware is structurally typed (no SDK
+    // deps), so cast it past the overload's strict generic signature.
+    s3.middlewareStack.add(b2PutMetricsMiddleware as never, {
+      step: 'initialize',
+      name: 'civitaiB2PutMetrics',
+      tags: ['B2_PUT_METRICS'],
+      override: true,
+    });
+    instrumentedClients.add(s3);
+  } catch {
+    /* never let instrumentation break client construction */
+  }
+  return s3;
+}
+
+/** Test-only: reset all B2 PUT counters between cases. */
+export function __resetB2PutMetricsForTest(): void {
+  metrics.requests.reset();
+  metrics.retries.reset();
+  metrics.presignIssued.reset();
+}

--- a/src/server/prom/b2-put.metrics.ts
+++ b/src/server/prom/b2-put.metrics.ts
@@ -178,20 +178,35 @@ export const b2PutMetricsMiddleware =
     const bucket = args?.input?.Bucket;
     try {
       const result = await next(args);
-      recordB2PutSend({
-        bucket,
-        op,
-        result: 'success',
-        retries: retriesFromMetadata(result?.output?.$metadata),
-      });
+      // Guard the WHOLE telemetry expression — including the retriesFromMetadata
+      // argument evaluation — so no telemetry helper can throw into a successful
+      // upload's return path. (recordB2PutSend also self-guards; this makes the
+      // "telemetry never throws into an upload" guarantee structural, not just
+      // empirical about which helpers currently can throw.)
+      try {
+        recordB2PutSend({
+          bucket,
+          op,
+          result: 'success',
+          retries: retriesFromMetadata(result?.output?.$metadata),
+        });
+      } catch {
+        /* never throw from telemetry */
+      }
       return result;
     } catch (error) {
-      recordB2PutSend({
-        bucket,
-        op,
-        result: classifyErrorResult(error),
-        retries: retriesFromMetadata((error as { $metadata?: B2Metadata })?.$metadata),
-      });
+      // Guard telemetry (classifyErrorResult + retriesFromMetadata arg evaluation)
+      // so the ORIGINAL SDK error is always the one re-thrown, never a telemetry error.
+      try {
+        recordB2PutSend({
+          bucket,
+          op,
+          result: classifyErrorResult(error),
+          retries: retriesFromMetadata((error as { $metadata?: B2Metadata })?.$metadata),
+        });
+      } catch {
+        /* never throw from telemetry */
+      }
       throw error;
     }
   };

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -17,6 +17,7 @@ import { dbWrite } from '~/server/db/client';
 import { env } from '~/env/server';
 
 import { logToAxiom } from '~/server/logging/client';
+import { instrumentB2Client, recordB2PresignIssued } from '~/server/prom/b2-put.metrics';
 
 const missingEnvs = (): string[] => {
   const keys = [];
@@ -29,19 +30,33 @@ const missingEnvs = (): string[] => {
 
 export type UploadBackend = 'default' | 'b2';
 
+// B2 bucket names — used to gate browser-direct presign issuance counting so the
+// generic presign helpers (which also serve the R2 default backend) only bump
+// `b2_presign_issued_total` when the target is actually B2.
+const B2_BUCKET_NAMES: ReadonlySet<string> = new Set(
+  [
+    env.S3_UPLOAD_B2_BUCKET ?? 'civitai-modelfiles',
+    env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads',
+  ].filter((b): b is string => typeof b === 'string' && b.length > 0)
+);
+
 export function getB2S3Client() {
   if (!env.S3_UPLOAD_B2_ACCESS_KEY || !env.S3_UPLOAD_B2_SECRET_KEY || !env.S3_UPLOAD_B2_ENDPOINT) {
     throw new Error('B2 upload credentials not configured');
   }
-  return new S3Client({
-    credentials: {
-      accessKeyId: env.S3_UPLOAD_B2_ACCESS_KEY,
-      secretAccessKey: env.S3_UPLOAD_B2_SECRET_KEY,
-    },
-    region: env.S3_UPLOAD_B2_REGION ?? 'us-west-004',
-    endpoint: env.S3_UPLOAD_B2_ENDPOINT,
-    forcePathStyle: true,
-  });
+  // Wrap with the additive B2 PUT-metrics middleware (counts server-side .send()s;
+  // presigned uploads never hit this path). Behavior-neutral.
+  return instrumentB2Client(
+    new S3Client({
+      credentials: {
+        accessKeyId: env.S3_UPLOAD_B2_ACCESS_KEY,
+        secretAccessKey: env.S3_UPLOAD_B2_SECRET_KEY,
+      },
+      region: env.S3_UPLOAD_B2_REGION ?? 'us-west-004',
+      endpoint: env.S3_UPLOAD_B2_ENDPOINT,
+      forcePathStyle: true,
+    })
+  );
 }
 
 export function getUploadS3Client(backend: UploadBackend = 'default') {
@@ -62,15 +77,18 @@ export function getB2ImageS3Client(): S3Client {
     throw new Error('B2 image upload credentials not configured');
   }
   if (!_b2ImageS3Client) {
-    _b2ImageS3Client = new S3Client({
-      credentials: {
-        accessKeyId: env.S3_IMAGE_B2_ACCESS_KEY,
-        secretAccessKey: env.S3_IMAGE_B2_SECRET_KEY,
-      },
-      region: env.S3_IMAGE_B2_REGION ?? 'us-west-004',
-      endpoint: env.S3_IMAGE_B2_ENDPOINT,
-      forcePathStyle: true,
-    });
+    // Additive B2 PUT-metrics middleware (server-side .send()s only). Behavior-neutral.
+    _b2ImageS3Client = instrumentB2Client(
+      new S3Client({
+        credentials: {
+          accessKeyId: env.S3_IMAGE_B2_ACCESS_KEY,
+          secretAccessKey: env.S3_IMAGE_B2_SECRET_KEY,
+        },
+        region: env.S3_IMAGE_B2_REGION ?? 'us-west-004',
+        endpoint: env.S3_IMAGE_B2_ENDPOINT,
+        forcePathStyle: true,
+      })
+    );
   }
   return _b2ImageS3Client;
 }
@@ -115,6 +133,8 @@ export async function getCustomPutUrl(bucket: string, key: string, s3: S3Client 
   const url = await getSignedUrl(s3, new PutObjectCommand({ Bucket: bucket, Key: key }), {
     expiresIn: UPLOAD_EXPIRATION,
   });
+  // Browser-direct B2 upload proxy: count issuance (the actual PUT is invisible pod-side).
+  if (B2_BUCKET_NAMES.has(bucket)) recordB2PresignIssued(bucket);
   return { url, bucket, key };
 }
 
@@ -424,6 +444,12 @@ export async function getMultipartPutUrl(
     );
   }
   const urls = await Promise.all(promises);
+
+  // Browser-direct B2 upload proxy: count ONE issuance per multipart upload (not
+  // per part). The CreateMultipartUpload above is a real pod-side send already
+  // counted by the client middleware (op=multipart); the UploadPart URLs here are
+  // browser-direct and invisible pod-side.
+  if (bucket && B2_BUCKET_NAMES.has(bucket)) recordB2PresignIssued(bucket);
 
   return { urls, bucket, key, uploadId: UploadId };
 }


### PR DESCRIPTION
## What

Adds per-source **Backblaze B2 PUT observability** to the civitai app — additive Prometheus telemetry only, **no upload/storage behavior change**. The app is the dominant, previously-uninstrumented source against B2's contracted **3,000 PUT-RPS** ceiling; this gives us per-op/per-bucket counters to attribute the load.

Design context: `datapacket-talos/claudedocs/b2-put-observability-plan-2026-07-06.md` (Part 3, civitai-app section).

## Canonical schema (matches image-cacher / orchestration verbatim — a cross-service dashboard reads these names)

```
b2_put_requests_total{service="civitai-web", bucket, op, result}   # op ∈ {upload,copy,multipart}; result ∈ {success,throttled,error}
b2_put_retries_total{service="civitai-web", bucket}
b2_presign_issued_total{service="civitai-web", bucket}             # browser-direct issuance proxy (see below)
```

Names are intentionally **NOT** `civitai_app_`-prefixed — they must be identical across services.

## How

**Server-side coverage** — an AWS-SDK v3 `initialize`-step middleware installed on the two B2 S3 client factories (`getB2S3Client()` / `getB2ImageS3Client()` in `s3-utils.ts`). It fires once per `.send()` of `PutObject` / `CopyObject` / `CreateMultipartUpload` / `UploadPart` with the final (post-retry) outcome:
- `op` from `context.commandName` (upload / copy / multipart)
- `bucket` from the command input
- `result` = `success` | `throttled` (HTTP 429, or 503 `SlowDown` / `TooManyRequests` / other throttle codes) | `error`
- retries from `$metadata.attempts` (`attempts - 1`) → **retries are observable**, no per-attempt middleware needed

Because `getSignedUrl` never calls `.send()`, the middleware naturally **excludes** presigned/browser-direct uploads — exactly the server-side vs browser-direct split we want.

**Browser-direct coverage** — the 3 presigned-B2-PUT issuance flows (`getCustomPutUrl` / `getMultipartPutUrl`, gated to B2 buckets) bump a **dedicated** `b2_presign_issued_total`. Chose a dedicated counter over `b2_put_requests_total{op="presign"}` so the dashboard's "actual PUT RPS vs 3,000 ceiling" sum over `b2_put_requests_total` stays clean (issuance is a proxy, not a real PUT). One increment per multipart *upload*, not per part; the `CreateMultipartUpload` server send is separately counted by the middleware (`op=multipart`).

Registered on the default `prom-client` registry (scraped at `/api/metrics`), `globalThis`-pinned for HMR safety — same pattern as `dev-tunnel.metrics.ts`. All record helpers are try/catch-wrapped so telemetry can never break an upload.

## Call sites changed
- `src/utils/s3-utils.ts` — wrap both B2 client factories with `instrumentB2Client(...)`; add B2-bucket-gated `recordB2PresignIssued(...)` in `getCustomPutUrl` + `getMultipartPutUrl`.
- `src/server/prom/b2-put.metrics.ts` (new) — counters, middleware, classification, presign helper.
- `src/server/prom/__tests__/b2-put.metrics.test.ts` (new) — unit test.

## Tests

Pure vitest unit test (no Prisma/DB), 13 cases — all green. Drives the middleware directly with a mocked `next`:
- **(a) success** → asserts `b2_put_requests_total{op=upload,result=success,bucket}` increments
- **(b) throttled** → a real **429 `SlowDown`** throw asserts `result=throttled` (+ re-throws)
- **(c) error** → generic 500 throw asserts `result=error` (+ re-throws)
- op mapping, retry counting (`attempts=3` → `+2`, incl. on the error path), pass-through of non-PUT commands, `bucket=unknown` fallback, and presign issuance.

`tsc --noEmit`: zero type errors in app `src/` (preexisting `packages/` errors are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)