### PR TITLE
fix(app-blocks): dev-tunnel IngressRoute must listen on :80 (Cloudflare Flexible origin pull)

### DIFF
--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -147,6 +147,15 @@ describe('manifest builders (SSRF-safe, server-derived host)', () => {
   it('IngressRoute matches EXACTLY the assigned host (never a wildcard/user input)', () => {
     const ir = buildDevTunnelIngressRoute(opts);
     expect(ir.spec.routes[0].match).toBe('Host(`dev-0123456789abcdef.civit.ai`)');
+    // REGRESSION (dev-tunnel 404 via Cloudflare): CF pulls the civit.ai origin over
+    // HTTP :80 (Flexible SSL), so a websecure-only (443) route is invisible to CF's
+    // port-80 origin request → 404. Must listen on BOTH `web` (:80) and `websecure`
+    // (:443), mirroring the working app-block routes. Never revert to 443-only.
+    expect(ir.spec.entryPoints).toEqual(['web', 'websecure']);
+    expect(ir.spec.entryPoints).toContain('web');
+    // No explicit `tls` block — Traefik serves TLS on `websecure` via its default
+    // cert, matching the app-block IngressRoute shape (which carry no `tls` key).
+    expect('tls' in ir.spec).toBe(false);
     // routes to the sish backend service, parsed into name/namespace/port
     expect(ir.spec.routes[0].services[0]).toMatchObject({
       name: 'sish-http',

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -224,7 +224,13 @@ export function buildDevTunnelIngressRoute(opts: DevTunnelManifestOpts) {
       ...(externalDnsAnnotations ? { annotations: externalDnsAnnotations } : {}),
     },
     spec: {
-      entryPoints: ['websecure'],
+      // Cloudflare pulls the civit.ai origin over HTTP :80 (Flexible SSL); a
+      // websecure-only route is invisible to CF's port-80 origin request → 404.
+      // Mirror the app-block IngressRoutes (web+websecure). The forwardAuth gate
+      // middleware below is per-route, so naked-URL protection holds on both ports.
+      // Traefik still serves TLS on `websecure` via its default cert (no `tls` key
+      // needed — matches the proven-working app-block route shape).
+      entryPoints: ['web', 'websecure'],
       routes: [
         {
           match: `Host(\`${opts.host}\`)`,
@@ -239,7 +245,6 @@ export function buildDevTunnelIngressRoute(opts: DevTunnelManifestOpts) {
           ],
         },
       ],
-      tls: {},
     },
   } as const;
 }


### PR DESCRIPTION
## Bug
App Blocks **dev-tunnel** hosts (`dev-<16hex>.civit.ai`) returned **404 through Cloudflare** and never worked in a browser, while app-block hosts (`<slug>.civit.ai`) work.

## Root cause
Cloudflare pulls the `civit.ai` origin over **HTTP :80** (Flexible SSL). The dev-tunnel Traefik `IngressRoute` listened on `entryPoints: ['websecure']` (443 only) with a `tls: {}` block, so Cloudflare's port-80 origin request found no matching Traefik router → **404**. The working app-block `IngressRoute`s use `entryPoints: ['web', 'websecure']` with **no** `tls` block, so they serve on both ports.

Live proof: origin-direct `:80` → dev host 404, hello-world 200; via-Cloudflare matched the `:80` behavior (dev 404), not the `:443` behavior.

## Fix
In `buildDevTunnelIngressRoute` (`src/server/services/blocks/dev-tunnel.service.ts`):
- `entryPoints: ['websecure']` → `['web', 'websecure']`
- Remove the `tls: {}` block, mirroring the proven-working app-block route shape (Traefik still serves TLS on `websecure` via its default cert).

The `forwardAuth` gate middleware stays on the route (per-route, not per-entrypoint), so naked-URL protection is preserved on **both** :80 and :443. App-blocks already serve on :80 via CF, so exposing dev-tunnel on :80 is the established, gated posture — no new security exposure.

## Tests
`src/server/services/blocks/__tests__/dev-tunnel.service.test.ts` gains a regression assertion that the route lists both entrypoints (`['web','websecure']`) and carries **no** `tls` key, so it can never revert to 443-only. All existing assertions (middleware, service name/port, host match, annotations) are unchanged.

```
vitest run --project unit src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
→ 37 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)