### PR TITLE
W13 P3b PR2 — off-site report backend + user report affordance [DARK]

### DIFF
--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -33,6 +33,7 @@ import {
   type ListingBadgeKind,
 } from '~/components/Apps/appListingCardView';
 import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
+import { ReportListingButton } from '~/components/Apps/ReportListingButton';
 import {
   CATEGORY_ICONS,
   FALLBACK_CATEGORY_ICON,
@@ -346,7 +347,12 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
           </Stack>
         </Group>
         <Box style={{ flexShrink: 0 }}>
-          <PrimaryAction detail={detail} canOpenPage={canOpenPage} />
+          <Stack gap="xs" align="flex-end">
+            <PrimaryAction detail={detail} canOpenPage={canOpenPage} />
+            {/* Report affordance — dark behind the mod-only store surface; the
+                proc is protected + rate-limited + reporter-bound server-side. */}
+            <ReportListingButton appListingId={detail.id} />
+          </Stack>
         </Box>
       </Group>
 

--- a/src/components/Apps/ReportListingButton.browser.test.tsx
+++ b/src/components/Apps/ReportListingButton.browser.test.tsx
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * W13 P3b — the off-site listing REPORT modal. Browser-mode surface test
+ * (report-only in Tekton): the Report button opens a modal that renders the 6
+ * schema reasons + submits the picked reason via `appListings.reportListing`.
+ *
+ * Network-free: the reportListing mutation + useCurrentUser + notifications are
+ * mocked. The blocking correctness gate for the reason options lives in the node
+ * `unit` project (`appListingReportView.test.ts`).
+ */
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  isPending: false,
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    appListings: {
+      reportListing: {
+        useMutation: () => ({ mutate: mocks.mutate, isPending: mocks.isPending }),
+      },
+    },
+  },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 42, username: 'viewer' }),
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+const { ReportListingButton } = await import('./ReportListingButton');
+
+beforeEach(() => {
+  mocks.mutate.mockClear();
+  mocks.isPending = false;
+});
+
+describe('ReportListingButton', () => {
+  test('opens the modal and renders the 6 report reasons', async () => {
+    renderWithProviders(<ReportListingButton appListingId="apl_target" />);
+    await page.getByRole('button', { name: 'Report' }).click();
+
+    await expect
+      .element(page.getByText('Impersonation — not the real app or owner'))
+      .toBeInTheDocument();
+    await expect.element(page.getByText('Phishing or malware')).toBeInTheDocument();
+    await expect.element(page.getByText('Broken — does not work')).toBeInTheDocument();
+    await expect.element(page.getByText('Inappropriate content')).toBeInTheDocument();
+    await expect.element(page.getByText('Spam')).toBeInTheDocument();
+    await expect.element(page.getByText('Something else')).toBeInTheDocument();
+  });
+
+  test('submitting without a reason surfaces an inline error (mutation NOT called)', async () => {
+    renderWithProviders(<ReportListingButton appListingId="apl_target" />);
+    await page.getByRole('button', { name: 'Report' }).click();
+    await page.getByRole('button', { name: 'Submit report' }).click();
+    await expect.element(page.getByText('Please choose a reason.')).toBeInTheDocument();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  test('picking a reason + submitting calls reportListing with the listing id + reason', async () => {
+    renderWithProviders(<ReportListingButton appListingId="apl_target" />);
+    await page.getByRole('button', { name: 'Report' }).click();
+    await page.getByRole('radio', { name: 'Spam' }).click();
+    await page.getByRole('button', { name: 'Submit report' }).click();
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate.mock.calls[0][0]).toMatchObject({
+      appListingId: 'apl_target',
+      reason: 'spam',
+    });
+  });
+});

--- a/src/components/Apps/ReportListingButton.tsx
+++ b/src/components/Apps/ReportListingButton.tsx
@@ -1,0 +1,149 @@
+import { Alert, Button, Modal, Radio, Stack, Text, Textarea } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconAlertTriangle, IconFlag } from '@tabler/icons-react';
+import { type ChangeEvent, useState } from 'react';
+
+import {
+  APP_LISTING_REPORT_REASON_OPTIONS,
+  isReportReason,
+  reportErrorMessage,
+} from '~/components/Apps/appListingReportView';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import {
+  type AppListingReportReason,
+  OFFSITE_REPORT_DETAILS_MAX,
+} from '~/server/schema/blocks/offsite-moderation.schema';
+import { showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App Store Listings (W13) — P3b USER REPORT affordance for an off-site listing.
+ *
+ * A small "Report" button that opens a modal with a reason picker (the 6 schema
+ * reasons, human-labelled via the pure `appListingReportView` helper) + an
+ * optional details textarea → `trpc.appListings.reportListing`. The reporter is
+ * bound server-side to the authenticated caller (IDOR-safe); the DB partial-unique
+ * dedups a duplicate open report, surfaced inline as a friendly "already reported"
+ * message (mapped by `reportErrorMessage`).
+ *
+ * DARK: rendered only where the listing detail is visible — the mod-only
+ * `/apps/store-preview/<slug>` surface today — so reports are effectively mod-only
+ * until the store widens. Hidden entirely for a signed-out viewer (the proc is
+ * `protectedProcedure`).
+ */
+
+export function ReportListingButton({ appListingId }: { appListingId: string }) {
+  const currentUser = useCurrentUser();
+  const [opened, { open, close }] = useDisclosure(false);
+  const [reason, setReason] = useState<AppListingReportReason | null>(null);
+  const [details, setDetails] = useState('');
+  const [inlineError, setInlineError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const reportMutation = trpc.appListings.reportListing.useMutation({
+    onSuccess: () => {
+      setDone(true);
+      setInlineError(null);
+      showSuccessNotification({
+        title: 'Report submitted',
+        message: 'Thanks — a moderator will review this app.',
+      });
+      close();
+    },
+    onError: (error: { data?: { code?: string | null } | null; message?: string | null }) => {
+      setInlineError(reportErrorMessage(error));
+    },
+  });
+
+  // The report proc is protected — never offer it to a signed-out viewer.
+  if (!currentUser) return null;
+
+  const reset = () => {
+    setReason(null);
+    setDetails('');
+    setInlineError(null);
+  };
+
+  const handleClose = () => {
+    if (reportMutation.isPending) return;
+    close();
+    reset();
+  };
+
+  const handleSubmit = () => {
+    setInlineError(null);
+    if (!reason) {
+      setInlineError('Please choose a reason.');
+      return;
+    }
+    reportMutation.mutate({
+      appListingId,
+      reason,
+      details: details.trim() ? details.trim() : undefined,
+    });
+  };
+
+  return (
+    <>
+      <Button
+        variant="subtle"
+        color="gray"
+        size="xs"
+        leftSection={<IconFlag size={14} />}
+        onClick={() => {
+          reset();
+          open();
+        }}
+        disabled={done}
+      >
+        {done ? 'Reported' : 'Report'}
+      </Button>
+
+      <Modal opened={opened} onClose={handleClose} title="Report this app" size="md" centered>
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            Tell us what&apos;s wrong with this app. Reports go to the Civitai moderation team.
+          </Text>
+
+          <Radio.Group
+            label="Reason"
+            value={reason ?? ''}
+            onChange={(value: string) => setReason(isReportReason(value) ? value : null)}
+            withAsterisk
+          >
+            <Stack gap="xs" mt="xs">
+              {APP_LISTING_REPORT_REASON_OPTIONS.map((opt) => (
+                <Radio key={opt.value} value={opt.value} label={opt.label} />
+              ))}
+            </Stack>
+          </Radio.Group>
+
+          <Textarea
+            label="Details (optional)"
+            placeholder="Add any context that will help a moderator."
+            value={details}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setDetails(e.currentTarget.value)}
+            maxLength={OFFSITE_REPORT_DETAILS_MAX}
+            autosize
+            minRows={3}
+            maxRows={6}
+          />
+
+          {inlineError && (
+            <Alert variant="light" color="red" icon={<IconAlertTriangle size={16} />}>
+              {inlineError}
+            </Alert>
+          )}
+
+          <Button
+            onClick={handleSubmit}
+            loading={reportMutation.isPending}
+            leftSection={<IconFlag size={16} />}
+          >
+            Submit report
+          </Button>
+        </Stack>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/Apps/ReportListingButton.tsx
+++ b/src/components/Apps/ReportListingButton.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button, Modal, Radio, Stack, Text, Textarea } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { IconAlertTriangle, IconFlag } from '@tabler/icons-react';
-import { type ChangeEvent, useState } from 'react';
+import { useState } from 'react';
 
 import {
   APP_LISTING_REPORT_REASON_OPTIONS,

--- a/src/components/Apps/__tests__/appListingReportView.test.ts
+++ b/src/components/Apps/__tests__/appListingReportView.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  APP_LISTING_REPORT_REASON_OPTIONS,
+  getReportReasonLabel,
+  isReportReason,
+  reportErrorMessage,
+} from '~/components/Apps/appListingReportView';
+import { APP_LISTING_REPORT_REASONS } from '~/server/schema/blocks/offsite-moderation.schema';
+
+/**
+ * W13 P3b — pure report VIEW MODEL (the blocking gate for the reason picker; the
+ * browser-mode modal test is report-only). Pins: the option list matches the
+ * schema tuple exactly (no drift), every label is non-empty, and the error mapper
+ * gives the friendly duplicate-report copy on CONFLICT.
+ */
+
+describe('APP_LISTING_REPORT_REASON_OPTIONS', () => {
+  it('has exactly one option per schema reason, in the schema order', () => {
+    expect(APP_LISTING_REPORT_REASON_OPTIONS.map((o) => o.value)).toEqual([
+      ...APP_LISTING_REPORT_REASONS,
+    ]);
+  });
+
+  it('every option has a non-empty human label distinct from the raw value', () => {
+    for (const opt of APP_LISTING_REPORT_REASON_OPTIONS) {
+      expect(opt.label.trim().length).toBeGreaterThan(0);
+      expect(opt.label).not.toBe(opt.value);
+    }
+  });
+
+  it('has no duplicate values or labels', () => {
+    const values = APP_LISTING_REPORT_REASON_OPTIONS.map((o) => o.value);
+    const labels = APP_LISTING_REPORT_REASON_OPTIONS.map((o) => o.label);
+    expect(new Set(values).size).toBe(values.length);
+    expect(new Set(labels).size).toBe(labels.length);
+  });
+});
+
+describe('getReportReasonLabel', () => {
+  it('returns the human label for a known reason', () => {
+    expect(getReportReasonLabel('spam')).toBe('Spam');
+  });
+
+  it('falls back to the raw value for an unknown reason', () => {
+    expect(getReportReasonLabel('mystery')).toBe('mystery');
+  });
+});
+
+describe('isReportReason', () => {
+  it('accepts every schema reason and rejects anything else', () => {
+    for (const opt of APP_LISTING_REPORT_REASON_OPTIONS) {
+      expect(isReportReason(opt.value)).toBe(true);
+    }
+    expect(isReportReason('bogus')).toBe(false);
+    expect(isReportReason('')).toBe(false);
+  });
+});
+
+describe('reportErrorMessage', () => {
+  it('maps CONFLICT to the friendly "already reported" copy', () => {
+    expect(reportErrorMessage({ data: { code: 'CONFLICT' }, message: 'dup' })).toContain(
+      'already reported'
+    );
+  });
+
+  it('surfaces the server message for a BAD_REQUEST / NOT_FOUND', () => {
+    expect(
+      reportErrorMessage({ data: { code: 'BAD_REQUEST' }, message: 'only an approved listing can be reported' })
+    ).toContain('approved listing');
+    expect(reportErrorMessage({ data: { code: 'NOT_FOUND' }, message: 'listing not found' })).toContain(
+      'not found'
+    );
+  });
+
+  it('gives a generic fallback for an unknown / internal error (never a raw leak)', () => {
+    const msg = reportErrorMessage({ data: { code: 'INTERNAL_SERVER_ERROR' }, message: 'ECONNREFUSED' });
+    expect(msg).not.toContain('ECONNREFUSED');
+    expect(msg.length).toBeGreaterThan(0);
+  });
+
+  it('handles a null/undefined error', () => {
+    expect(reportErrorMessage(null).length).toBeGreaterThan(0);
+    expect(reportErrorMessage(undefined).length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/Apps/appListingReportView.ts
+++ b/src/components/Apps/appListingReportView.ts
@@ -1,0 +1,68 @@
+/**
+ * App Store Listings (W13) — P3b REPORT VIEW MODEL (pure, React-free).
+ *
+ * The reason-option list + inline-error copy for the off-site report affordance,
+ * extracted so the correctness gate lives in the node `unit` project (the civitai
+ * browser-mode component suites are REPORT-ONLY / non-blocking — so the real,
+ * blocking coverage for the report picker lives here, mirroring
+ * `appListingCardView` / `appListingDetailView`).
+ *
+ * The reason VALUES are the single-source tuple from the moderation schema (the
+ * same tuple the service re-validates + the migration CHECK enforces), so the
+ * picker can never drift from what the DB accepts.
+ */
+
+import {
+  APP_LISTING_REPORT_REASONS,
+  type AppListingReportReason,
+} from '~/server/schema/blocks/offsite-moderation.schema';
+
+export type ReportReasonOption = { value: AppListingReportReason; label: string };
+
+/** Human labels for each report reason (keyed by the schema tuple). */
+const REASON_LABELS: Record<AppListingReportReason, string> = {
+  impersonation: 'Impersonation — not the real app or owner',
+  'phishing-malware': 'Phishing or malware',
+  broken: 'Broken — does not work',
+  inappropriate: 'Inappropriate content',
+  spam: 'Spam',
+  other: 'Something else',
+};
+
+/**
+ * Reason options in the schema's declared order, for the modal's reason picker.
+ * Built from the schema tuple so adding a reason (schema + CHECK) surfaces it here
+ * automatically (the `Record` type makes a missing label a COMPILE error).
+ */
+export const APP_LISTING_REPORT_REASON_OPTIONS: ReportReasonOption[] =
+  APP_LISTING_REPORT_REASONS.map((value) => ({ value, label: REASON_LABELS[value] }));
+
+/** Human label for a stored reason value (falls back to the raw value). */
+export function getReportReasonLabel(reason: string): string {
+  return (REASON_LABELS as Record<string, string>)[reason] ?? reason;
+}
+
+/** Type-guard narrowing an arbitrary picker value to a valid report reason (no cast). */
+export function isReportReason(value: string): value is AppListingReportReason {
+  return (APP_LISTING_REPORT_REASONS as readonly string[]).includes(value);
+}
+
+/**
+ * Map a caught `reportListing` mutation error to inline modal copy. The duplicate-
+ * report case (DB partial-unique → CONFLICT) gets the friendly "already reported"
+ * message; a not-reportable / not-found case surfaces the server message; anything
+ * else is a generic fallback (the raw infra message is never surfaced — the router
+ * already collapses unknown errors to a generic INTERNAL message).
+ */
+export function reportErrorMessage(
+  err: { data?: { code?: string | null } | null; message?: string | null } | null | undefined
+): string {
+  const code = err?.data?.code ?? null;
+  if (code === 'CONFLICT') {
+    return 'You have already reported this app — a moderator is reviewing it.';
+  }
+  if (code === 'NOT_FOUND' || code === 'BAD_REQUEST') {
+    return err?.message ?? 'This app can no longer be reported.';
+  }
+  return 'Something went wrong submitting your report. Please try again later.';
+}

--- a/src/server/routers/__tests__/app-listings.router.report-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.report-authz.test.ts
@@ -137,18 +137,38 @@ describe('reportListing — protectedProcedure', () => {
     });
   });
 
-  it('a NOT_REPORTABLE listing maps to BAD_REQUEST', async () => {
-    mockReport.mockRejectedValueOnce(
-      offsiteModErr('NOT_REPORTABLE', 'only an approved listing can be reported (status draft)')
-    );
+  // Info-leak guard: the service now raises the SAME generic NOT_REPORTABLE for a
+  // missing AND a non-approved listing, so a caller can neither probe existence nor
+  // read the moderation status. Both map to BAD_REQUEST with the generic message.
+  it('a not-reportable listing (missing OR non-approved) maps to BAD_REQUEST with a generic message', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(user) as never);
-    await expect(caller.reportListing(reportInput)).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    mockReport.mockRejectedValueOnce(
+      offsiteModErr('NOT_REPORTABLE', 'This app can no longer be reported.')
+    );
+    await expect(caller.reportListing(reportInput)).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'This app can no longer be reported.',
+    });
   });
 
-  it('a NOT_FOUND listing maps to NOT_FOUND', async () => {
-    mockReport.mockRejectedValueOnce(offsiteModErr('NOT_FOUND', 'listing apl_x not found'));
+  it('the not-reportable client message never leaks the exact status or existence', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(user) as never);
-    await expect(caller.reportListing(reportInput)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    // Even though the service knows the real reason, the client-facing message is
+    // generic — no 'draft'/'not found'/status token reaches the caller.
+    mockReport.mockRejectedValueOnce(
+      offsiteModErr('NOT_REPORTABLE', 'This app can no longer be reported.')
+    );
+    const err = await caller.reportListing(reportInput).then(
+      () => {
+        throw new Error('expected reportListing to reject');
+      },
+      (e) => e as TRPCError
+    );
+    expect(err.code).toBe('BAD_REQUEST');
+    expect(err.message).not.toContain('draft');
+    expect(err.message).not.toContain('not found');
+    expect(err.message).not.toContain('status');
   });
 
   it('an UNEXPECTED/untyped error maps to INTERNAL_SERVER_ERROR without leaking the raw message', async () => {

--- a/src/server/routers/__tests__/app-listings.router.report-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.report-authz.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * W13 P3b — off-site REPORT router AUTHZ + error-mapping + rate-limit wiring.
+ *
+ * Drives the REAL `appListingsRouter` via `createCaller` so the middleware wiring
+ * (not a mock) decides:
+ *   - reportListing is `protectedProcedure`: anon → UNAUTHORIZED; any signed-in
+ *     user passes; the reporter id is forced from ctx (IDOR); a duplicate report
+ *     (service ALREADY_REPORTED) maps to CONFLICT; a not-reportable listing maps to
+ *     BAD_REQUEST; an unexpected infra error maps to INTERNAL (no raw leak).
+ *   - listListingReports is `moderatorProcedure`: a non-mod is FORBIDDEN, a mod
+ *     passes.
+ *   - reportListing carries a rateLimit(20/3600) middleware (report-spam guard).
+ */
+
+const { mockReport, mockListReports, mockIsAppBlocksEnabled, mockIsAppBlocksAuthorEnabled, rateLimitCalls } =
+  vi.hoisted(() => ({
+    mockReport: vi.fn(async () => ({ reportId: 'alrp_1' })),
+    mockListReports: vi.fn(async () => ({ items: [], nextCursor: null })),
+    mockIsAppBlocksEnabled: vi.fn(),
+    mockIsAppBlocksAuthorEnabled: vi.fn(),
+    rateLimitCalls: [] as Array<{ limit?: number; period?: number }>,
+  }));
+
+vi.mock('~/server/services/blocks/offsite-moderation.service', () => ({
+  reportListing: mockReport,
+  listListingReports: mockListReports,
+}));
+// The router also statically references the P3a service names via dynamic import
+// paths only, but the flag helpers are imported at module load — mock them.
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
+vi.mock('~/server/services/feature-flags.service', async () => {
+  const actual = await vi.importActual<typeof import('~/server/services/feature-flags.service')>(
+    '~/server/services/feature-flags.service'
+  );
+  return {
+    ...actual,
+    getFeatureFlags: (ctx: { user?: { id?: number; isModerator?: boolean } }) => ({
+      appBlocksAuthor: !!ctx.user?.isModerator,
+    }),
+  };
+});
+// Record the rateLimit config so the test can assert the report-spam guard is
+// WIRED (the middleware itself is a passthrough here).
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return {
+    rateLimit: (opts: { limit?: number; period?: number }) => {
+      rateLimitCalls.push(opts);
+      return middleware(async ({ next }) => next());
+    },
+  };
+});
+vi.mock('~/server/utils/server-domain', () => ({ isHostForColor: () => false }));
+
+import { appListingsRouter } from '../app-listings.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function offsiteModErr(code: string, message: string): Error {
+  return Object.assign(new Error(message), { name: 'OffsiteModerationError', code });
+}
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+const mod = { id: 1, isModerator: true, tier: 'free', username: 'mod', onboarding: 0x1f };
+const user = { id: 7, isModerator: false, tier: 'free', username: 'user', onboarding: 0x1f };
+
+const reportInput = { appListingId: 'apl_target', reason: 'spam' as const };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAppBlocksEnabled.mockImplementation((opts?: { user?: { isModerator?: boolean } }) =>
+    Promise.resolve(!!opts?.user?.isModerator)
+  );
+  mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+});
+
+describe('reportListing — protectedProcedure', () => {
+  it('anonymous → rejects, service NOT called', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.reportListing(reportInput)).rejects.toBeInstanceOf(TRPCError);
+    expect(mockReport).not.toHaveBeenCalled();
+  });
+
+  it('any signed-in user passes; service called with the caller id (no user-supplied reporter)', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(user) as never);
+    await caller.reportListing(reportInput);
+    expect(mockReport).toHaveBeenCalledTimes(1);
+    // The tRPC input middleware injects a `browsingLevel` — assert the id + the
+    // report fields, and that the reporter is bound to the caller (ctx), not input.
+    const call = mockReport.mock.calls[0][0] as {
+      userId: number;
+      input: { appListingId: string; reason: string };
+    };
+    expect(call.userId).toBe(user.id);
+    expect(call.input.appListingId).toBe('apl_target');
+    expect(call.input.reason).toBe('spam');
+  });
+
+  it('a mod passes too (any signed-in user)', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await caller.reportListing(reportInput);
+    const call = mockReport.mock.calls[0][0] as {
+      userId: number;
+      input: { appListingId: string; reason: string };
+    };
+    expect(call.userId).toBe(mod.id);
+    expect(call.input.appListingId).toBe('apl_target');
+    expect(call.input.reason).toBe('spam');
+  });
+
+  it('a duplicate report (ALREADY_REPORTED) maps to CONFLICT with the friendly message', async () => {
+    mockReport.mockRejectedValueOnce(
+      offsiteModErr('ALREADY_REPORTED', 'You have already reported this app — a moderator is reviewing it.')
+    );
+    const caller = appListingsRouter.createCaller(fakeCtx(user) as never);
+    await expect(caller.reportListing(reportInput)).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: expect.stringContaining('already reported'),
+    });
+  });
+
+  it('a NOT_REPORTABLE listing maps to BAD_REQUEST', async () => {
+    mockReport.mockRejectedValueOnce(
+      offsiteModErr('NOT_REPORTABLE', 'only an approved listing can be reported (status draft)')
+    );
+    const caller = appListingsRouter.createCaller(fakeCtx(user) as never);
+    await expect(caller.reportListing(reportInput)).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('a NOT_FOUND listing maps to NOT_FOUND', async () => {
+    mockReport.mockRejectedValueOnce(offsiteModErr('NOT_FOUND', 'listing apl_x not found'));
+    const caller = appListingsRouter.createCaller(fakeCtx(user) as never);
+    await expect(caller.reportListing(reportInput)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('an UNEXPECTED/untyped error maps to INTERNAL_SERVER_ERROR without leaking the raw message', async () => {
+    const raw = 'connect ECONNREFUSED 10.0.0.5:5432 postgres://secret-dsn';
+    mockReport.mockRejectedValueOnce(new Error(raw));
+    const caller = appListingsRouter.createCaller(fakeCtx(user) as never);
+    const err = await caller.reportListing(reportInput).then(
+      () => {
+        throw new Error('expected reportListing to reject');
+      },
+      (e) => e as TRPCError
+    );
+    expect(err.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(err.message).not.toContain('ECONNREFUSED');
+    expect(err.message).not.toContain('secret-dsn');
+    expect((err.cause as Error | undefined)?.message).toBe(raw);
+  });
+
+  it('rejects an invalid reason at the SCHEMA boundary (service NOT called)', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(user) as never);
+    await expect(
+      caller.reportListing({ appListingId: 'apl_target', reason: 'bogus' } as never)
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockReport).not.toHaveBeenCalled();
+  });
+});
+
+describe('reportListing — rate-limit wiring', () => {
+  it('is guarded by rateLimit(20/3600) (report-spam guard)', () => {
+    expect(rateLimitCalls).toContainEqual(expect.objectContaining({ limit: 20, period: 3600 }));
+  });
+});
+
+describe('listListingReports — moderatorProcedure', () => {
+  it('a plain user is FORBIDDEN; service NOT called', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(user) as never);
+    await expect(caller.listListingReports({})).rejects.toBeInstanceOf(TRPCError);
+    expect(mockListReports).not.toHaveBeenCalled();
+  });
+
+  it('anonymous is rejected', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.listListingReports({})).rejects.toBeInstanceOf(TRPCError);
+  });
+
+  it('a moderator passes', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.listListingReports({ status: 'pending' })).resolves.toBeDefined();
+    expect(mockListReports).toHaveBeenCalledWith({ status: 'pending' });
+  });
+});

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -23,6 +23,10 @@ import {
   submitExternalListingSchema,
   withdrawExternalRequestSchema,
 } from '~/server/schema/blocks/offsite-listing.schema';
+import {
+  listListingReportsSchema,
+  reportListingSchema,
+} from '~/server/schema/blocks/offsite-moderation.schema';
 import { rateLimit } from '~/server/middleware.trpc';
 import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import {
@@ -105,11 +109,13 @@ function isRedCapableRequest(ctx: { req?: { headers?: { host?: string } } }): bo
  *
  *   - A `TRPCError` the service already shaped (BAD_REQUEST: assets-incomplete /
  *     invalid stored URL / reason-length) passes THROUGH unchanged.
- *   - A typed `OffsiteRequestError` maps to its precise TRPC code
- *     (`NOT_FOUND`→NOT_FOUND, `NOT_OWNED`→FORBIDDEN, `NOT_PENDING`/other→
- *     BAD_REQUEST). It is DUCK-TYPED on `name` + `code` so the router never has to
- *     eagerly `import` the service module (services are loaded via dynamic
- *     `import()` to keep the Prisma client out of the router's import graph).
+ *   - A typed `OffsiteRequestError` (P3a) OR `OffsiteModerationError` (P3b report/
+ *     delist/claim) maps to its precise TRPC code (`NOT_FOUND`→NOT_FOUND,
+ *     `NOT_OWNED`→FORBIDDEN, `ALREADY_REPORTED`→CONFLICT, `NOT_PENDING`/
+ *     `NOT_REPORTABLE`/other→BAD_REQUEST). It is DUCK-TYPED on `name` + `code` so
+ *     the router never has to eagerly `import` the service module (services are
+ *     loaded via dynamic `import()` to keep the Prisma client out of the router's
+ *     import graph).
  *   - Anything else is an UNEXPECTED infra/Prisma failure → INTERNAL_SERVER_ERROR
  *     with a GENERIC message; the raw error is preserved only on `cause` (for the
  *     central server-fault logger) and NEVER surfaced to the client.
@@ -121,12 +127,18 @@ function mapOffsiteError(err: unknown): TRPCError {
   if (err instanceof TRPCError) return err;
   if (
     err instanceof Error &&
-    err.name === 'OffsiteRequestError' &&
+    (err.name === 'OffsiteRequestError' || err.name === 'OffsiteModerationError') &&
     typeof (err as { code?: unknown }).code === 'string'
   ) {
     const code = (err as { code?: unknown }).code as string;
     const trpcCode =
-      code === 'NOT_FOUND' ? 'NOT_FOUND' : code === 'NOT_OWNED' ? 'FORBIDDEN' : 'BAD_REQUEST';
+      code === 'NOT_FOUND'
+        ? 'NOT_FOUND'
+        : code === 'NOT_OWNED'
+        ? 'FORBIDDEN'
+        : code === 'ALREADY_REPORTED'
+        ? 'CONFLICT'
+        : 'BAD_REQUEST';
     return new TRPCError({ code: trpcCode, message: err.message });
   }
   return new TRPCError({
@@ -405,6 +417,62 @@ export const appListingsRouter = router({
         throw mapOffsiteError(err);
       }
       return { ok: true };
+    }),
+
+  // -------------------------------------------------------------------------
+  // P3b OFF-SITE MODERATION — report affordance + mod report-queue read (DARK).
+  //
+  // `reportListing` is any-signed-in-user (`protectedProcedure`) + rate-limited
+  // (report-spam guard) — the reporter is bound to `ctx.user.id` in the service
+  // (IDOR-safe) and the DB partial-unique dedups a duplicate open report.
+  // `listListingReports` is a read-only `moderatorProcedure`. The mod ACTIONS
+  // (delist / relist / claim / resolve / dismiss + the audit writes) land in PR3.
+  // -------------------------------------------------------------------------
+
+  /**
+   * USER: report an approved off-site listing. The reporter is bound to the
+   * caller (no user-supplied reporter — IDOR guard); the DB partial-unique
+   * (`one_open_per_reporter`) dedups a duplicate open report → a friendly
+   * CONFLICT via `mapOffsiteError`. Reporting a non-approved / missing listing →
+   * NOT_REPORTABLE(BAD_REQUEST) / NOT_FOUND. Unexpected infra → INTERNAL (no leak).
+   */
+  reportListing: protectedProcedure
+    .use(
+      rateLimit({
+        // Report-spam guard (mirrors the submit rate-limit idiom). The DB
+        // one-open-report-per-(listing,reporter) partial-unique bounds duplicate
+        // reports; this bounds the report RATE across listings.
+        limit: 20,
+        period: 3600,
+        errorMessage: 'Too many reports — slow down.',
+      })
+    )
+    .input(reportListingSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { reportListing } = await import(
+        '~/server/services/blocks/offsite-moderation.service'
+      );
+      try {
+        return await reportListing({ input, userId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /**
+   * MOD: the off-site report queue (read-only in PR2; the delist/claim/resolve
+   * actions land in PR3). Oldest-first (FIFO), keyset-paginated, optional `status`
+   * filter; a public-safe projection (reporter chip + target listing slug/name/
+   * kind — no PII/secret).
+   */
+  listListingReports: moderatorProcedure
+    .input(listListingReportsSchema)
+    .query(async ({ input }) => {
+      const { listListingReports } = await import(
+        '~/server/services/blocks/offsite-moderation.service'
+      );
+      return listListingReports(input);
     }),
 
   // -------------------------------------------------------------------------

--- a/src/server/schema/blocks/__tests__/offsite-moderation.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/offsite-moderation.schema.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  APP_LISTING_REPORT_REASONS,
+  APP_LISTING_REPORT_STATUSES,
+  OFFSITE_REPORT_DETAILS_MAX,
+  listListingReportsSchema,
+  reportListingSchema,
+} from '~/server/schema/blocks/offsite-moderation.schema';
+
+/**
+ * W13 P3b — off-site moderation INPUT validation + the reason/status tuples.
+ *
+ * Pins: the reason enum, the details bound, the mod-queue limit cap (≤50), AND
+ * that the schema tuples equal the migration CHECK sets (a drift would let the
+ * proc write a value the DB's `app_listing_reports_*_check` CHECK rejects — 23514).
+ */
+
+describe('APP_LISTING_REPORT_REASONS — matches the migration CHECK set', () => {
+  it('is exactly the 6 documented reasons, in order', () => {
+    expect([...APP_LISTING_REPORT_REASONS]).toEqual([
+      'impersonation',
+      'phishing-malware',
+      'broken',
+      'inappropriate',
+      'spam',
+      'other',
+    ]);
+  });
+});
+
+describe('APP_LISTING_REPORT_STATUSES — matches the migration CHECK set', () => {
+  it('is exactly pending|resolved|dismissed', () => {
+    expect([...APP_LISTING_REPORT_STATUSES]).toEqual(['pending', 'resolved', 'dismissed']);
+  });
+});
+
+describe('reportListingSchema', () => {
+  const base = { appListingId: 'apl_01HZZ', reason: 'spam' as const };
+
+  it('accepts a minimal valid report (no details)', () => {
+    const parsed = reportListingSchema.safeParse(base);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('accepts every enum reason', () => {
+    for (const reason of APP_LISTING_REPORT_REASONS) {
+      expect(reportListingSchema.safeParse({ ...base, reason }).success).toBe(true);
+    }
+  });
+
+  it('rejects a reason not in the enum', () => {
+    expect(reportListingSchema.safeParse({ ...base, reason: 'nonsense' }).success).toBe(false);
+  });
+
+  it('requires a non-empty appListingId', () => {
+    expect(reportListingSchema.safeParse({ ...base, appListingId: '' }).success).toBe(false);
+  });
+
+  it('accepts details up to the bound and rejects over it', () => {
+    const ok = { ...base, details: 'x'.repeat(OFFSITE_REPORT_DETAILS_MAX) };
+    const tooLong = { ...base, details: 'x'.repeat(OFFSITE_REPORT_DETAILS_MAX + 1) };
+    expect(reportListingSchema.safeParse(ok).success).toBe(true);
+    expect(reportListingSchema.safeParse(tooLong).success).toBe(false);
+  });
+
+  it('has NO reporter field — the reporter is caller-forced (mass-assignment guard)', () => {
+    const parsed = reportListingSchema.parse({
+      ...base,
+      // A malicious extra field is stripped by zod's default object parse.
+      reporterUserId: 999,
+    } as unknown as { appListingId: string; reason: 'spam' });
+    expect((parsed as Record<string, unknown>).reporterUserId).toBeUndefined();
+  });
+});
+
+describe('listListingReportsSchema', () => {
+  it('accepts an empty query (defaults handled in the service)', () => {
+    expect(listListingReportsSchema.safeParse({}).success).toBe(true);
+  });
+
+  it('accepts an optional status filter', () => {
+    expect(listListingReportsSchema.safeParse({ status: 'pending' }).success).toBe(true);
+    expect(listListingReportsSchema.safeParse({ status: 'resolved' }).success).toBe(true);
+  });
+
+  it('rejects a status not in the enum', () => {
+    expect(listListingReportsSchema.safeParse({ status: 'open' }).success).toBe(false);
+  });
+
+  it('caps limit at 50', () => {
+    expect(listListingReportsSchema.safeParse({ limit: 50 }).success).toBe(true);
+    expect(listListingReportsSchema.safeParse({ limit: 51 }).success).toBe(false);
+    expect(listListingReportsSchema.safeParse({ limit: 0 }).success).toBe(false);
+  });
+});

--- a/src/server/schema/blocks/offsite-moderation.schema.ts
+++ b/src/server/schema/blocks/offsite-moderation.schema.ts
@@ -1,0 +1,67 @@
+import * as z from 'zod';
+
+/**
+ * App Store Listings (W13) — P3b OFF-SITE MODERATION schemas.
+ *
+ * The user-facing REPORT affordance + the mod-facing report-queue read. Kept in a
+ * DEDICATED schema module (parallel to the P3a `offsite-listing.schema`) so the
+ * post-approval moderation surface (report now; delist / relist / claim in PR3)
+ * stays cleanly separated from the submission lifecycle.
+ *
+ * Imports ONLY zod, so this module is safe to pull into the client bundle (the
+ * report modal + its pure view-model reuse the reason tuple as the single source
+ * of truth — the CHECK constraint in the migration `.sql` is the DB-layer mirror).
+ *
+ * The reason / status tuples MUST match the CHECK constraints applied in
+ * `prisma/migrations/20260706120050_w13_p3b_app_listing_reports/migration.sql`:
+ *   reason IN (impersonation, phishing-malware, broken, inappropriate, spam, other)
+ *   status IN (pending, resolved, dismissed)
+ * A drift here would let the proc write a value the DB rejects (23514). A unit
+ * test pins the tuple against those documented values.
+ */
+
+/** Report reasons — MUST equal the `app_listing_reports_reason_check` CHECK set. */
+export const APP_LISTING_REPORT_REASONS = [
+  'impersonation',
+  'phishing-malware',
+  'broken',
+  'inappropriate',
+  'spam',
+  'other',
+] as const;
+export type AppListingReportReason = (typeof APP_LISTING_REPORT_REASONS)[number];
+
+/** Report lifecycle — MUST equal the `app_listing_reports_status_check` CHECK set. */
+export const APP_LISTING_REPORT_STATUSES = ['pending', 'resolved', 'dismissed'] as const;
+export type AppListingReportStatus = (typeof APP_LISTING_REPORT_STATUSES)[number];
+
+/** Free-text elaboration bound (mirrors the off-site description/changelog bound). */
+export const OFFSITE_REPORT_DETAILS_MAX = 2000;
+
+/**
+ * USER report of an approved off-site listing.
+ *
+ * `appListingId` is the target listing id (`apl_<ULID>`); the reporter is ALWAYS
+ * bound to `ctx.user.id` in the service (there is NO reporter field here — a
+ * caller can never file a report as someone else). `reason` is validated against
+ * the shared tuple (the CHECK mirror); `details` is optional + bounded.
+ */
+export const reportListingSchema = z.object({
+  appListingId: z.string().min(1).max(64),
+  reason: z.enum(APP_LISTING_REPORT_REASONS),
+  details: z.string().max(OFFSITE_REPORT_DETAILS_MAX).optional(),
+});
+export type ReportListingInput = z.infer<typeof reportListingSchema>;
+
+/**
+ * MOD keyset-paginate the report queue. Optional `status` filter (default: the
+ * whole queue; the queue UI passes `pending`); FIFO oldest-first in the service.
+ * `limit` is capped at 50 (a smaller page than the submission queues — a report
+ * row carries the reporter chip + target listing projection).
+ */
+export const listListingReportsSchema = z.object({
+  status: z.enum(APP_LISTING_REPORT_STATUSES).optional(),
+  cursor: z.string().min(1).max(64).optional(),
+  limit: z.number().int().min(1).max(50).optional(),
+});
+export type ListListingReportsInput = z.infer<typeof listListingReportsSchema>;

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   OffsiteModerationError,
+  REPORT_UNAVAILABLE_MESSAGE,
   listListingReports,
   reportListing,
 } from '~/server/services/blocks/offsite-moderation.service';
@@ -117,29 +118,81 @@ describe('reportListing — happy path', () => {
 });
 
 describe('reportListing — reportable-state gate', () => {
-  it('rejects a nonexistent listing with NOT_FOUND', async () => {
+  // Info-leak guard: a caller holding an arbitrary listing id must NOT be able to
+  // probe existence or read the exact moderation status. Both the missing-listing
+  // and the non-approved-listing cases surface the SAME client-visible code
+  // (`NOT_REPORTABLE`) + `REPORT_UNAVAILABLE_MESSAGE`; the real reason/status is
+  // carried only on `cause` (server-only, for logs/tests).
+  it('rejects a nonexistent listing generically (NOT_REPORTABLE + generic message; NOT_FOUND only on cause)', async () => {
     (mockRead as unknown as Client).appListing.findUnique.mockResolvedValueOnce(null);
-    await expect(reportListing({ input: validInput, userId: CALLER })).rejects.toMatchObject({
-      name: 'OffsiteModerationError',
-      code: 'NOT_FOUND',
-    });
+    const err: OffsiteModerationError = await reportListing({
+      input: validInput,
+      userId: CALLER,
+    }).then(
+      () => {
+        throw new Error('expected reportListing to reject');
+      },
+      (e: OffsiteModerationError) => e
+    );
+    expect(err.name).toBe('OffsiteModerationError');
+    expect(err.code).toBe('NOT_REPORTABLE');
+    // Client-visible message reveals NOTHING about existence.
+    expect(err.message).toBe(REPORT_UNAVAILABLE_MESSAGE);
+    // The real reason is server-only (on cause) — not in the client-facing message.
+    expect(err.cause).toMatchObject({ reason: 'NOT_FOUND', appListingId: APP_ID });
     expect((mockWrite as unknown as Client).appListingReport.create).not.toHaveBeenCalled();
   });
 
   it.each(['draft', 'pending', 'rejected', 'removed'])(
-    'rejects a %s listing with NOT_REPORTABLE (only approved is reportable)',
+    'rejects a %s listing generically (status is NOT client-visible — only on cause)',
     async (status) => {
       (mockRead as unknown as Client).appListing.findUnique.mockResolvedValueOnce({
         id: APP_ID,
         status,
       });
-      await expect(reportListing({ input: validInput, userId: CALLER })).rejects.toMatchObject({
-        name: 'OffsiteModerationError',
-        code: 'NOT_REPORTABLE',
-      });
+      const err: OffsiteModerationError = await reportListing({
+        input: validInput,
+        userId: CALLER,
+      }).then(
+        () => {
+          throw new Error('expected reportListing to reject');
+        },
+        (e: OffsiteModerationError) => e
+      );
+      expect(err.name).toBe('OffsiteModerationError');
+      expect(err.code).toBe('NOT_REPORTABLE');
+      expect(err.message).toBe(REPORT_UNAVAILABLE_MESSAGE);
+      // The exact status must NEVER leak into the client-facing message.
+      expect(err.message).not.toContain(status);
+      // …but it IS preserved server-side on cause for logs/mod tooling.
+      expect(err.cause).toMatchObject({ reason: 'NOT_APPROVED', status });
       expect((mockWrite as unknown as Client).appListingReport.create).not.toHaveBeenCalled();
     }
   );
+
+  it('missing vs non-approved are INDISTINGUISHABLE client-side (same code + same message)', async () => {
+    (mockRead as unknown as Client).appListing.findUnique.mockResolvedValueOnce(null);
+    const missing: OffsiteModerationError = await reportListing({
+      input: validInput,
+      userId: CALLER,
+    }).catch((e: OffsiteModerationError) => e);
+
+    (mockRead as unknown as Client).appListing.findUnique.mockResolvedValueOnce({
+      id: APP_ID,
+      status: 'draft',
+    });
+    const notApproved: OffsiteModerationError = await reportListing({
+      input: validInput,
+      userId: CALLER,
+    }).catch((e: OffsiteModerationError) => e);
+
+    // A caller cannot tell "doesn't exist" from "exists but not approvable".
+    expect(missing.code).toBe(notApproved.code);
+    expect(missing.message).toBe(notApproved.message);
+    expect(missing.message).toBe(REPORT_UNAVAILABLE_MESSAGE);
+    // Only the server-side cause differs.
+    expect(missing.cause).not.toEqual(notApproved.cause);
+  });
 
   it('rejects an unknown reason (defense-in-depth) BEFORE touching the DB', async () => {
     await expect(
@@ -217,11 +270,13 @@ describe('listListingReports — read-only mod queue', () => {
     expect(res.nextCursor).toBeNull();
   });
 
-  it('is FIFO (oldest-first) and caps limit at 50', async () => {
+  it('is FIFO (oldest-first) with an id tie-break for a total order, and caps limit at 50', async () => {
     (mockRead as unknown as Client).appListingReport.findMany.mockResolvedValueOnce([]);
     await listListingReports({ limit: 999 });
     const args = (mockRead as unknown as Client).appListingReport.findMany.mock.calls[0][0];
-    expect(args.orderBy).toEqual({ createdAt: 'asc' });
+    // `createdAt` alone is non-unique (default now()) → keyset tie-break on `id`
+    // so same-millisecond inserts can't skip/duplicate across a page boundary.
+    expect(args.orderBy).toEqual([{ createdAt: 'asc' }, { id: 'asc' }]);
     expect(args.take).toBe(51); // 50 (cap) + 1
   });
 

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  OffsiteModerationError,
+  listListingReports,
+  reportListing,
+} from '~/server/services/blocks/offsite-moderation.service';
+import type { ReportListingInput } from '~/server/schema/blocks/offsite-moderation.schema';
+
+/**
+ * W13 P3b — off-site moderation SERVICE tests (report + report-queue read).
+ *
+ * Covers reportListing (happy path + caller-forced reporterUserId; DB-layer dedup
+ * via P2002; approved-only reportable gate; reason re-validation; IDOR guard) and
+ * listListingReports (keyset shape + FIFO order + public-safe projection). All DB
+ * deps are mocked — no real Prisma. `dbRead`/`dbWrite` are DISTINCT mocks so a
+ * test can prove the read went to the replica and the insert to the primary.
+ */
+
+type Client = {
+  appListing: { findUnique: ReturnType<typeof vi.fn> };
+  appListingReport: {
+    create: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+};
+
+const { mockRead, mockWrite, ids } = vi.hoisted(() => {
+  const makeClient = () => ({
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+    appListingReport: {
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+  });
+  return { mockRead: makeClient(), mockWrite: makeClient(), ids: { n: 0 } };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingReportId: () => `alrp_test_${++ids.n}`,
+}));
+
+const CALLER = 42;
+const OTHER = 99;
+const APP_ID = 'apl_target';
+
+const validInput: ReportListingInput = { appListingId: APP_ID, reason: 'spam' };
+
+function resetClient(c: Client) {
+  c.appListing.findUnique.mockReset().mockResolvedValue(null);
+  c.appListingReport.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+  c.appListingReport.findMany.mockReset().mockResolvedValue([]);
+}
+
+beforeEach(() => {
+  ids.n = 0;
+  resetClient(mockRead as unknown as Client);
+  resetClient(mockWrite as unknown as Client);
+});
+
+describe('reportListing — happy path', () => {
+  it('creates a PENDING report with reporterUserId forced from the caller', async () => {
+    (mockRead as unknown as Client).appListing.findUnique.mockResolvedValueOnce({
+      id: APP_ID,
+      status: 'approved',
+    });
+    const res = await reportListing({ input: validInput, userId: CALLER });
+
+    expect(res.reportId).toMatch(/^alrp_test_/);
+    // The row is written to the PRIMARY (dbWrite), not the replica.
+    expect((mockWrite as unknown as Client).appListingReport.create).toHaveBeenCalledTimes(1);
+    expect((mockRead as unknown as Client).appListingReport.create).not.toHaveBeenCalled();
+    const data = (mockWrite as unknown as Client).appListingReport.create.mock.calls[0][0].data;
+    expect(data).toMatchObject({
+      appListingId: APP_ID,
+      reporterUserId: CALLER,
+      reason: 'spam',
+      status: 'pending',
+      details: null,
+    });
+  });
+
+  it('trims details and stores non-empty text (null when whitespace-only)', async () => {
+    (mockRead as unknown as Client).appListing.findUnique.mockResolvedValue({
+      id: APP_ID,
+      status: 'approved',
+    });
+
+    await reportListing({ input: { ...validInput, details: '  hi there  ' }, userId: CALLER });
+    expect(
+      (mockWrite as unknown as Client).appListingReport.create.mock.calls[0][0].data.details
+    ).toBe('hi there');
+
+    await reportListing({ input: { ...validInput, details: '   ' }, userId: CALLER });
+    expect(
+      (mockWrite as unknown as Client).appListingReport.create.mock.calls[1][0].data.details
+    ).toBeNull();
+  });
+
+  it('IDOR: a user-supplied reporter field can never override the caller id', async () => {
+    (mockRead as unknown as Client).appListing.findUnique.mockResolvedValueOnce({
+      id: APP_ID,
+      status: 'approved',
+    });
+    // Even if a caller smuggles a reporterUserId through, the service reads only
+    // `userId` (from ctx) — the written row is bound to the caller.
+    await reportListing({
+      input: { ...validInput, reporterUserId: OTHER } as unknown as ReportListingInput,
+      userId: CALLER,
+    });
+    const data = (mockWrite as unknown as Client).appListingReport.create.mock.calls[0][0].data;
+    expect(data.reporterUserId).toBe(CALLER);
+  });
+});
+
+describe('reportListing — reportable-state gate', () => {
+  it('rejects a nonexistent listing with NOT_FOUND', async () => {
+    (mockRead as unknown as Client).appListing.findUnique.mockResolvedValueOnce(null);
+    await expect(reportListing({ input: validInput, userId: CALLER })).rejects.toMatchObject({
+      name: 'OffsiteModerationError',
+      code: 'NOT_FOUND',
+    });
+    expect((mockWrite as unknown as Client).appListingReport.create).not.toHaveBeenCalled();
+  });
+
+  it.each(['draft', 'pending', 'rejected', 'removed'])(
+    'rejects a %s listing with NOT_REPORTABLE (only approved is reportable)',
+    async (status) => {
+      (mockRead as unknown as Client).appListing.findUnique.mockResolvedValueOnce({
+        id: APP_ID,
+        status,
+      });
+      await expect(reportListing({ input: validInput, userId: CALLER })).rejects.toMatchObject({
+        name: 'OffsiteModerationError',
+        code: 'NOT_REPORTABLE',
+      });
+      expect((mockWrite as unknown as Client).appListingReport.create).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects an unknown reason (defense-in-depth) BEFORE touching the DB', async () => {
+    await expect(
+      reportListing({
+        input: { ...validInput, reason: 'nonsense' as unknown as ReportListingInput['reason'] },
+        userId: CALLER,
+      })
+    ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'NOT_REPORTABLE' });
+    expect((mockRead as unknown as Client).appListing.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+describe('reportListing — DB-layer dedup', () => {
+  it('collapses the partial-unique P2002 to a friendly ALREADY_REPORTED', async () => {
+    (mockRead as unknown as Client).appListing.findUnique.mockResolvedValueOnce({
+      id: APP_ID,
+      status: 'approved',
+    });
+    (mockWrite as unknown as Client).appListingReport.create.mockRejectedValueOnce(
+      Object.assign(new Error('Unique constraint failed'), { code: 'P2002' })
+    );
+    await expect(reportListing({ input: validInput, userId: CALLER })).rejects.toMatchObject({
+      name: 'OffsiteModerationError',
+      code: 'ALREADY_REPORTED',
+    });
+  });
+
+  it('re-throws a non-P2002 DB error unchanged (mapped to INTERNAL at the router)', async () => {
+    (mockRead as unknown as Client).appListing.findUnique.mockResolvedValueOnce({
+      id: APP_ID,
+      status: 'approved',
+    });
+    const raw = new Error('connect ECONNREFUSED');
+    (mockWrite as unknown as Client).appListingReport.create.mockRejectedValueOnce(raw);
+    await expect(reportListing({ input: validInput, userId: CALLER })).rejects.toBe(raw);
+  });
+
+  it('a resolved/dismissed prior report does NOT block a new one (P2002 only fires on a pending dup)', async () => {
+    // The partial-unique covers WHERE status='pending', so with no live pending
+    // dup the insert succeeds — modelled by create resolving normally.
+    (mockRead as unknown as Client).appListing.findUnique.mockResolvedValueOnce({
+      id: APP_ID,
+      status: 'approved',
+    });
+    const res = await reportListing({ input: validInput, userId: CALLER });
+    expect(res.reportId).toMatch(/^alrp_test_/);
+  });
+});
+
+describe('listListingReports — read-only mod queue', () => {
+  const row = (id: string) => ({
+    id,
+    appListingId: APP_ID,
+    reason: 'spam',
+    details: null,
+    status: 'pending',
+    createdAt: new Date(),
+    resolvedAt: null,
+    reporter: { id: CALLER, username: 'rep', image: null },
+    appListing: { slug: 's', name: 'n', kind: 'offsite' },
+  });
+
+  it('returns the page + a nextCursor when there is another page (limit+1 keyset)', async () => {
+    const rows = [row('alrp_1'), row('alrp_2'), row('alrp_3')];
+    (mockRead as unknown as Client).appListingReport.findMany.mockResolvedValueOnce(rows);
+    const res = await listListingReports({ limit: 2 });
+    expect(res.items).toHaveLength(2);
+    expect(res.nextCursor).toBe('alrp_2');
+  });
+
+  it('nextCursor is null on the last page', async () => {
+    (mockRead as unknown as Client).appListingReport.findMany.mockResolvedValueOnce([row('alrp_1')]);
+    const res = await listListingReports({ limit: 25 });
+    expect(res.items).toHaveLength(1);
+    expect(res.nextCursor).toBeNull();
+  });
+
+  it('is FIFO (oldest-first) and caps limit at 50', async () => {
+    (mockRead as unknown as Client).appListingReport.findMany.mockResolvedValueOnce([]);
+    await listListingReports({ limit: 999 });
+    const args = (mockRead as unknown as Client).appListingReport.findMany.mock.calls[0][0];
+    expect(args.orderBy).toEqual({ createdAt: 'asc' });
+    expect(args.take).toBe(51); // 50 (cap) + 1
+  });
+
+  it('applies the status filter when given, and no filter otherwise', async () => {
+    (mockRead as unknown as Client).appListingReport.findMany.mockResolvedValue([]);
+    await listListingReports({ status: 'pending' });
+    expect(
+      (mockRead as unknown as Client).appListingReport.findMany.mock.calls[0][0].where
+    ).toEqual({ status: 'pending' });
+
+    await listListingReports({});
+    expect(
+      (mockRead as unknown as Client).appListingReport.findMany.mock.calls[1][0].where
+    ).toEqual({});
+  });
+
+  it('projection is public-safe: no reporter email / infra fields selected', async () => {
+    (mockRead as unknown as Client).appListingReport.findMany.mockResolvedValueOnce([]);
+    await listListingReports({});
+    const select = (mockRead as unknown as Client).appListingReport.findMany.mock.calls[0][0].select;
+    // The reporter chip is the standard public {id,username,image} shape only.
+    expect(select.reporter).toEqual({ select: { id: true, username: true, image: true } });
+    expect(select.reporter.select.email).toBeUndefined();
+    // The target listing exposes only slug/name/kind.
+    expect(select.appListing).toEqual({ select: { slug: true, name: true, kind: true } });
+    // No reporterUserId (raw FK) / resolvedByUserId leaked in the projection.
+    expect(select.reporterUserId).toBeUndefined();
+    expect(select.resolvedByUserId).toBeUndefined();
+  });
+});
+
+describe('OffsiteModerationError', () => {
+  it('carries the name + code the router duck-types on', () => {
+    const err = new OffsiteModerationError('ALREADY_REPORTED', 'dup');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe('OffsiteModerationError');
+    expect(err.code).toBe('ALREADY_REPORTED');
+  });
+});

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -40,12 +40,30 @@ export type OffsiteModerationErrorCode =
 
 export class OffsiteModerationError extends Error {
   readonly code: OffsiteModerationErrorCode;
-  constructor(code: OffsiteModerationErrorCode, message: string) {
-    super(message);
+  constructor(code: OffsiteModerationErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'OffsiteModerationError';
     this.code = code;
   }
 }
+
+/**
+ * Generic client-facing message for the not-reportable failure mode.
+ *
+ * Info-leak guard: the router's `mapOffsiteError` forwards `err.message` straight
+ * to the client, so a caller holding an arbitrary listing id must NOT be able to
+ * probe (a) whether the id EXISTS and (b) its exact moderation status. Both the
+ * missing-listing and the non-approved-listing cases therefore throw the SAME
+ * code (`NOT_REPORTABLE` → BAD_REQUEST) with this SAME generic message; the real
+ * distinction (not-found vs the actual status) is carried only on `cause`, which
+ * `mapOffsiteError` keeps server-side (central fault logger) and never surfaces.
+ */
+export const REPORT_UNAVAILABLE_MESSAGE = 'This app can no longer be reported.';
+
+/** Server-only (on `cause`) reason for a not-reportable throw — for logs/tests. */
+export type NotReportableCause =
+  | { reason: 'NOT_FOUND'; appListingId: string }
+  | { reason: 'NOT_APPROVED'; status: string };
 
 // ---------------------------------------------------------------------------
 // reportListing (any signed-in user).
@@ -61,10 +79,13 @@ export type ReportListingResult = { reportId: string };
  * caller can never file a report as another user.
  *
  * Reportable-state gate: the target listing must EXIST and be `approved`. A
- * missing listing → NOT_FOUND; a draft / pending / rejected / removed listing →
- * NOT_REPORTABLE (a non-approved listing is not in the store — nothing to report).
- * `reason` is re-validated against the shared tuple (defense-in-depth: this fn is
- * exported + unit-tested directly, not only reached through the zod schema).
+ * missing listing AND a non-approved (draft / pending / rejected / removed)
+ * listing BOTH raise `NOT_REPORTABLE` with the SAME generic client message
+ * (`REPORT_UNAVAILABLE_MESSAGE`) — the caller cannot tell existence apart from
+ * non-approvability, nor read the exact status (info-leak guard; the real reason
+ * rides on `cause`, server-only). `reason` is re-validated against the shared
+ * tuple (defense-in-depth: this fn is exported + unit-tested directly, not only
+ * reached through the zod schema).
  *
  * Dedup / anti-spam: the insert relies on the DB partial-unique
  * `app_listing_reports_one_open_per_reporter` (one PENDING report per
@@ -86,18 +107,23 @@ export async function reportListing(opts: {
   }
 
   // Reportable-state gate: must be an existing, APPROVED listing.
+  //
+  // Info-leak guard: a missing listing and a non-approved listing are BOTH
+  // surfaced to the client as the same code + `REPORT_UNAVAILABLE_MESSAGE`, so a
+  // caller cannot distinguish "id doesn't exist" from "exists but not approvable"
+  // nor read the exact moderation status. The real reason (and the raw status)
+  // rides on `cause` — server-only (logs/tests), never client-visible.
   const listing = await dbRead.appListing.findUnique({
     where: { id: input.appListingId },
     select: { id: true, status: true },
   });
   if (!listing) {
-    throw new OffsiteModerationError('NOT_FOUND', `listing ${input.appListingId} not found`);
+    const cause: NotReportableCause = { reason: 'NOT_FOUND', appListingId: input.appListingId };
+    throw new OffsiteModerationError('NOT_REPORTABLE', REPORT_UNAVAILABLE_MESSAGE, { cause });
   }
   if (listing.status !== 'approved') {
-    throw new OffsiteModerationError(
-      'NOT_REPORTABLE',
-      `only an approved listing can be reported (status ${listing.status})`
-    );
+    const cause: NotReportableCause = { reason: 'NOT_APPROVED', status: listing.status };
+    throw new OffsiteModerationError('NOT_REPORTABLE', REPORT_UNAVAILABLE_MESSAGE, { cause });
   }
 
   const details = input.details?.trim() ? input.details.trim() : null;
@@ -160,7 +186,11 @@ export async function listListingReports(opts: ListListingReportsInput = {}) {
   const limit = Math.min(opts.limit ?? 25, 50);
   const rows = await dbRead.appListingReport.findMany({
     where: opts.status ? { status: opts.status } : {},
-    orderBy: { createdAt: 'asc' },
+    // Total order: `createdAt` alone is non-unique (default now()), so
+    // same-millisecond inserts could skip/duplicate a row across a page boundary.
+    // The `id` tie-break makes the ordering deterministic; the native cursor
+    // (cursor:{id}, skip:1) still paginates on the unique id.
+    orderBy: [{ createdAt: 'asc' }, { id: 'asc' }],
     take: limit + 1,
     ...(opts.cursor ? { cursor: { id: opts.cursor }, skip: 1 } : {}),
     select: reportQueueSelect,

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -1,0 +1,171 @@
+import { dbRead, dbWrite } from '~/server/db/client';
+import {
+  APP_LISTING_REPORT_REASONS,
+  type ListListingReportsInput,
+  type ReportListingInput,
+} from '~/server/schema/blocks/offsite-moderation.schema';
+import { newAppListingReportId } from '~/server/utils/app-block-ids';
+
+/**
+ * App Store Listings (W13) — P3b OFF-SITE MODERATION service.
+ *
+ * The post-approval moderation surface for off-site listings. PR2 ships the
+ * user-facing REPORT path + the mod-facing report-queue read; PR3 adds the mod
+ * actions (delist / relist / claim / resolve / dismiss + the
+ * `AppListingModerationEvent` audit writes) in THIS file.
+ *
+ * Mirrors the P3a `offsite-listing.service` discipline: a typed error class
+ * (duck-typed by the router's `mapOffsiteError`, so the router never eagerly
+ * imports this module — services are loaded via dynamic `import()` to keep the
+ * generated Prisma client out of the router's static graph), DB-layer dedup (the
+ * partial-unique `app_listing_reports_one_open_per_reporter` — one PENDING report
+ * per (listing, reporter) — caught as P2002, NOT a check-then-insert race), and a
+ * caller-forced owner id (mass-assignment / IDOR guard).
+ *
+ * DARK: `reportListing` is `protectedProcedure` (+ router rate-limit) and
+ * `listListingReports` is `moderatorProcedure`; the report affordance renders only
+ * on the mod-only store-preview surface, so reports are mod-only until the store
+ * widens. The dedup + rate-limit are in from day one regardless, so widening is
+ * safe with no service change.
+ */
+
+// ---------------------------------------------------------------------------
+// Typed failure modes (mirror OffsiteRequestError; duck-typed by mapOffsiteError).
+// ---------------------------------------------------------------------------
+
+export type OffsiteModerationErrorCode =
+  | 'NOT_FOUND'
+  | 'NOT_REPORTABLE'
+  | 'ALREADY_REPORTED';
+
+export class OffsiteModerationError extends Error {
+  readonly code: OffsiteModerationErrorCode;
+  constructor(code: OffsiteModerationErrorCode, message: string) {
+    super(message);
+    this.name = 'OffsiteModerationError';
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// reportListing (any signed-in user).
+// ---------------------------------------------------------------------------
+
+export type ReportListingResult = { reportId: string };
+
+/**
+ * File a report against an APPROVED off-site listing.
+ *
+ * Owner-binding (IDOR / mass-assignment): `reporterUserId` is ALWAYS the
+ * authenticated caller (`userId`) — the input carries NO reporter field, so a
+ * caller can never file a report as another user.
+ *
+ * Reportable-state gate: the target listing must EXIST and be `approved`. A
+ * missing listing → NOT_FOUND; a draft / pending / rejected / removed listing →
+ * NOT_REPORTABLE (a non-approved listing is not in the store — nothing to report).
+ * `reason` is re-validated against the shared tuple (defense-in-depth: this fn is
+ * exported + unit-tested directly, not only reached through the zod schema).
+ *
+ * Dedup / anti-spam: the insert relies on the DB partial-unique
+ * `app_listing_reports_one_open_per_reporter` (one PENDING report per
+ * (listing, reporter)) — a duplicate open report fires P2002, collapsed to a
+ * friendly ALREADY_REPORTED. This is DB-layer dedup, NOT a check-then-insert
+ * pre-check (which would race). A prior report that a mod later resolved /
+ * dismissed does NOT block a new one (the partial index only covers `pending`).
+ */
+export async function reportListing(opts: {
+  input: ReportListingInput;
+  userId: number;
+}): Promise<ReportListingResult> {
+  const { input, userId } = opts;
+
+  // Defense-in-depth reason re-validation (mirrors the offsite submit service's
+  // re-checks of URL/surface/category/rating — the fn is exported + unit-tested).
+  if (!(APP_LISTING_REPORT_REASONS as readonly string[]).includes(input.reason)) {
+    throw new OffsiteModerationError('NOT_REPORTABLE', `unknown report reason "${input.reason}"`);
+  }
+
+  // Reportable-state gate: must be an existing, APPROVED listing.
+  const listing = await dbRead.appListing.findUnique({
+    where: { id: input.appListingId },
+    select: { id: true, status: true },
+  });
+  if (!listing) {
+    throw new OffsiteModerationError('NOT_FOUND', `listing ${input.appListingId} not found`);
+  }
+  if (listing.status !== 'approved') {
+    throw new OffsiteModerationError(
+      'NOT_REPORTABLE',
+      `only an approved listing can be reported (status ${listing.status})`
+    );
+  }
+
+  const details = input.details?.trim() ? input.details.trim() : null;
+  const reportId = newAppListingReportId();
+
+  try {
+    await dbWrite.appListingReport.create({
+      data: {
+        id: reportId,
+        appListingId: input.appListingId,
+        // FORCED from the authenticated caller — never from input (IDOR guard).
+        reporterUserId: userId,
+        reason: input.reason,
+        details,
+        status: 'pending',
+      },
+    });
+  } catch (err) {
+    // Lost the dedup race (or a duplicate open report): the partial-unique
+    // `one_open_per_reporter` fires P2002. Collapse to a friendly message.
+    if ((err as { code?: unknown })?.code === 'P2002') {
+      throw new OffsiteModerationError(
+        'ALREADY_REPORTED',
+        'You have already reported this app — a moderator is reviewing it.'
+      );
+    }
+    throw err;
+  }
+
+  return { reportId };
+}
+
+// ---------------------------------------------------------------------------
+// listListingReports (moderator) — read-only report queue.
+// ---------------------------------------------------------------------------
+
+/**
+ * Public-safe report-queue projection: the report fields + the reporter's public
+ * chip ({id,username,image}) + the target listing's slug/name/kind. NO PII beyond
+ * the public creator-chip shape, no infra / secret fields.
+ */
+const reportQueueSelect = {
+  id: true,
+  appListingId: true,
+  reason: true,
+  details: true,
+  status: true,
+  createdAt: true,
+  resolvedAt: true,
+  reporter: { select: { id: true, username: true, image: true } },
+  appListing: { select: { slug: true, name: true, kind: true } },
+} as const;
+
+/**
+ * MOD report queue, oldest-first (FIFO), keyset-paginated. Optional `status`
+ * filter (the queue UI passes `pending`). The cursor is the report id (an
+ * `alrp_<ULID>`, time-sortable so it tracks the `createdAt asc` order).
+ */
+export async function listListingReports(opts: ListListingReportsInput = {}) {
+  const limit = Math.min(opts.limit ?? 25, 50);
+  const rows = await dbRead.appListingReport.findMany({
+    where: opts.status ? { status: opts.status } : {},
+    orderBy: { createdAt: 'asc' },
+    take: limit + 1,
+    ...(opts.cursor ? { cursor: { id: opts.cursor }, skip: 1 } : {}),
+    select: reportQueueSelect,
+  });
+  const hasNext = rows.length > limit;
+  const items = hasNext ? rows.slice(0, limit) : rows;
+  return { items, nextCursor: hasNext ? items[items.length - 1].id : null };
+}


### PR DESCRIPTION
## What

W13 P3b **PR2** (dark) — the user-facing **report** path + the mod **report-queue read** for approved off-site `AppListing`s. Builds directly on `main` on top of **PR1** (the dark/inert moderation data model — `AppListingReport` + `AppListingModerationEvent` + the 3 manual migrations, merged in #2967). Base `main`, not stacked.

Closes the P3a interim gap only partway on purpose: **PR2 CREATES reports + lets mods LIST them; PR3 adds the mod actions** (delist / relist / claim / resolve / dismiss + the `AppListingModerationEvent` audit writes + the queue UI).

## Delivered

**Service** — new `src/server/services/blocks/offsite-moderation.service.ts` (clean separation; PR3's delist/claim also land here):
- `reportListing({ appListingId, reason, details?, userId })` — approved-only reportable gate: a **missing** listing AND a **non-approved** (draft/pending/rejected/removed) listing BOTH raise the **same generic `NOT_REPORTABLE`** (see Post-audit fixes — info-leak guard), reason re-validated against the shared tuple, **`reporterUserId` forced from the authenticated caller** (IDOR / mass-assignment guard). Dedup is the DB partial-unique `app_listing_reports_one_open_per_reporter` — a duplicate open report fires **P2002 → friendly `ALREADY_REPORTED`** (no check-then-insert race). A prior *resolved/dismissed* report does not block a new one (the partial index only covers `pending`).
- `listListingReports({ status?, cursor?, limit≤50 })` — `moderatorProcedure`-only, **FIFO keyset** queue with an **`id` tie-break** for a total order (see Post-audit fixes), **public-safe projection** (reporter `{id,username,image}` + target listing `slug/name/kind` — no PII/secret).

**Schema** — new `offsite-moderation.schema.ts`: `reportListingSchema`, `listListingReportsSchema`, plus the reason/status tuples pinned to the migration CHECK sets (`impersonation|phishing-malware|broken|inappropriate|spam|other`, `pending|resolved|dismissed`) — a unit test guards drift so the proc can't write a value the DB rejects (23514).

**Router** — `reportListing` = `protectedProcedure` + `rateLimit({limit:20,period:3600})` (report-spam guard); `listListingReports` = `moderatorProcedure`. `mapOffsiteError` duck-types `OffsiteModerationError` (`ALREADY_REPORTED`→CONFLICT, `NOT_REPORTABLE`→BAD_REQUEST; the generic mapper still maps `NOT_FOUND`→NOT_FOUND for the P3a/PR3 procs); unknown infra → INTERNAL, no leak.

**UI** — `ReportListingButton` (reason picker over the 6 reasons + optional details → `trpc.appListings.reportListing`; inline *"already reported"* on CONFLICT), wired into `AppListingDetailBody`. The reason-option list + error copy + a reason type-guard are extracted into the **pure, unit-tested** `appListingReportView` helper. Added to the **detail** surface only (card affordance deferred — keeps scope tight).

## Post-audit fixes

An adversarial audit returned merge-after-fixes (no 🔴). The cheap fixes are applied in `52d0676`:

- **🟡 Close the status/existence info-leak in `reportListing`.** `mapOffsiteError` forwards `err.message` to the client, so the old `NOT_FOUND` ("listing X not found") vs `NOT_REPORTABLE` ("…status draft") split let a caller holding any listing id probe BOTH existence and the exact moderation status of arbitrary listings. Both cases now raise the **same** code (`NOT_REPORTABLE` → BAD_REQUEST) with the **same generic message** (`"This app can no longer be reported."`), so existence/status is indistinguishable client-side; the real reason/status is kept server-side on the error's `cause` (logs) only. Inert while dark (unguessable ids + mod-only read path) but permanent.
- **🟢 Keyset tie-break on `listListingReports`.** `orderBy: { createdAt: 'asc' }` is non-unique (`createdAt default now()`), so same-millisecond inserts could skip/duplicate a row across a page boundary → `orderBy: [{ createdAt: 'asc' }, { id: 'asc' }]` for a total order (the native `cursor:{id}, skip:1` is unchanged).
- **🟢 Dead import.** Dropped the unused `type ChangeEvent` in `ReportListingButton.tsx`.

Tests updated to assert the generic message + client-side indistinguishability of existence/status, and the stable ordering.

## Pre-GA deferral (deliberately NOT built here)

- **Cross-account (sybil) per-listing report cap.** The DB partial-unique dedups one open report *per (listing, reporter)* but does not bound the number of *distinct* accounts reporting one listing — a sybil ring could inflate a report count. A genuine build, only reachable once the store widens past mods, so it is **deferred**. This cap **plus the store-widen gate** are a **pre-GA prerequisite**, tracked alongside **PR3** (which lands the mod-side resolution/dismissal that the cap complements).

## Dark posture

Report = `protectedProcedure`, list = `moderatorProcedure`, both behind the existing `app-blocks-enabled`/`app-blocks-author` flags. The report button renders only where the listing detail is visible — the **mod-only** `/apps/store-preview/<slug>` surface today — and is hidden for signed-out viewers. The rate-limit + DB dedup are in from day one, so widening the store later is safe with no service change. No new Flipt flag.

## Tests

- **Unit (primary gate, 53 passing with symlinked deps):** service (19) — happy-path + caller-forced reporter, IDOR, approved-only (draft/pending/rejected/removed/nonexistent rejected **generically**, existence/status indistinguishable client-side), reason validation, P2002→ALREADY_REPORTED dedup, keyset shape + FIFO + **`id` tie-break** + public-safe projection; schema (12) — reason enum, details bound, limit≤50, CHECK-set agreement; router authz (12) — `reportListing` protected (anon rejected, signed-in passes, reporter bound to ctx), error mapping (CONFLICT / BAD_REQUEST generic-message-no-leak / INTERNAL-no-leak), **rate-limit-wiring assertion**, `listListingReports` moderator-only; pure view (10). No regressions in the existing app-listings suites.
- **Browser component test** (report-only in Tekton): the report modal renders the 6 reasons + submits the picked reason. Unaffected by the post-audit fixes (the dead-import removal is inert at runtime).
- **e2e DEFERRED to PR3 (intentional):** filing a report needs an APPROVED listing and there is **no cleanup verb** (resolve/dismiss/delist) until PR3, so a PR2 report e2e would accrue **un-cleanable rows** on the shared dev clone (the P3a-arc lesson — don't leave un-cleanable test data). PR3's e2e (report→resolve / approve→delist) is self-cleaning.

## Not in PR2 (→ PR3)

Mod actions (delist/relist/claim/purge), report resolution (resolve/dismiss), `AppListingModerationEvent` writes, the queue UI beyond this read proc, and the `AppListing.status` CHECK ALTER (adds `removed`) — that migration is timing-sharp and applied per rule #8 before PR3 deploys. PR1's `app_listing_reports` table is already applied to the dev clone (preview builds have it); the prod apply is a tracked human step before `release`.

## Notes

- **TS re-check:** re-scanned all changed lines (incl. the post-audit fixes) — every handler/callback param is typed (`options?: ErrorOptions`, `cause: NotReportableCause`, typed `catch` callbacks), no unsafe casts (the reason narrowing uses a `value is AppListingReportReason` **type-guard**, not a cast; the `.ok`/P2002 duck-types mirror the P3a idiom). Language-server diagnostics are clean on all changed files; the only local errors are `dbWrite.appListingReport` "does not exist" — the **stale pre-PR1 generated Prisma client**. Tekton's `db:generate` regenerates from `schema.full.prisma`, so `preview`/`deploy` is authoritative.
- No Playwright run locally (NixOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
