### PR TITLE
W13 P3b PR3 — off-site mod takedown loop: delist/relist/purge/resolve/dismiss [DARK]

### DIFF
--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -8,7 +8,9 @@ import {
   Divider,
   Group,
   List,
+  Loader,
   Modal,
+  SegmentedControl,
   Stack,
   Table,
   Text,
@@ -20,11 +22,24 @@ import {
   IconCheck,
   IconClock,
   IconExternalLink,
+  IconFlag,
+  IconHistory,
   IconQuestionMark,
   IconX,
 } from '@tabler/icons-react';
 import { useState } from 'react';
 import { getOffsiteReviewChecklist } from '~/components/Apps/offsiteReviewChecklist';
+import { getReportReasonLabel } from '~/components/Apps/appListingReportView';
+import {
+  isDestructiveAction,
+  listingStatusChip,
+  moderationActionChip,
+  reportActionLabel,
+  reportRowActions,
+  reportStatusChip,
+  type ReportRowAction,
+} from '~/components/Apps/appListingModerationView';
+import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -452,6 +467,437 @@ function OffsiteReviewModal({
           </Stack>
         )}
       </Stack>
+    </Modal>
+  );
+}
+
+// ===========================================================================
+// P3b PR3 — the mod REPORT QUEUE (Reports tab) + per-listing moderation history.
+//
+// Dark + mod-only (the whole /apps/review page requires isModerator, and every
+// proc here is `moderatorProcedure`). The report-row action set + status chips are
+// computed by the pure `appListingModerationView` view-model (unit-tested).
+// ===========================================================================
+
+type ReportReporter = { id: number; username: string | null; image: string | null };
+
+type ReportRow = {
+  id: string;
+  appListingId: string;
+  reason: string;
+  details: string | null;
+  status: string;
+  createdAt: string | Date;
+  resolvedAt: string | Date | null;
+  reporter: ReportReporter | null;
+  appListing: {
+    slug: string | null;
+    name: string | null;
+    kind: string | null;
+    status: string | null;
+  } | null;
+};
+
+type ReportList = { items: ReportRow[]; nextCursor: string | null };
+
+type ReportStatusFilter = 'pending' | 'resolved' | 'dismissed';
+
+export function OffsiteReportsQueue() {
+  const features = useFeatureFlags();
+  const [statusFilter, setStatusFilter] = useState<ReportStatusFilter>('pending');
+  const [pending, setPending] = useState<{ action: ReportRowAction; report: ReportRow } | null>(
+    null
+  );
+  const [historyFor, setHistoryFor] = useState<ReportRow | null>(null);
+
+  const queue = trpc.appListings.listListingReports.useQuery(
+    { status: statusFilter, limit: 50 },
+    { enabled: !!features?.appBlocks, retry: false }
+  );
+
+  // Flag off / not a mod → the query errors (moderatorProcedure); render nothing.
+  if (queue.error) return null;
+
+  const items = (queue.data?.items ?? []) as ReportRow[];
+
+  return (
+    <Stack gap="sm" mt="lg">
+      <Divider
+        label={
+          <Group gap={6}>
+            <IconFlag size={14} />
+            <Text size="sm" fw={600}>
+              Off-site listing reports
+            </Text>
+            <Badge size="sm" variant="light" color={items.length > 0 ? 'red' : 'gray'}>
+              {items.length}
+            </Badge>
+          </Group>
+        }
+        labelPosition="left"
+      />
+      <Group justify="space-between">
+        <Text size="xs" c="dimmed">
+          User reports of approved off-site apps. Verify ownership out-of-band, then delist / relist
+          / purge and resolve or dismiss the report.
+        </Text>
+        <SegmentedControl
+          size="xs"
+          value={statusFilter}
+          onChange={(v) => setStatusFilter(v as ReportStatusFilter)}
+          data={[
+            { label: 'Pending', value: 'pending' },
+            { label: 'Resolved', value: 'resolved' },
+            { label: 'Dismissed', value: 'dismissed' },
+          ]}
+        />
+      </Group>
+
+      {queue.isLoading ? (
+        <Group gap="xs">
+          <Loader size="xs" />
+          <Text size="sm" c="dimmed">
+            Loading…
+          </Text>
+        </Group>
+      ) : items.length === 0 ? (
+        <Card withBorder p="md">
+          <Group gap="xs">
+            <IconCheck color="var(--mantine-color-green-6)" size={18} />
+            <Text size="sm">No {statusFilter} reports.</Text>
+          </Group>
+        </Card>
+      ) : (
+        <Card withBorder p={0}>
+          <Table verticalSpacing="md" horizontalSpacing="md">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>App</Table.Th>
+                <Table.Th>Reason</Table.Th>
+                <Table.Th>Reporter</Table.Th>
+                <Table.Th>Reported</Table.Th>
+                <Table.Th>Status</Table.Th>
+                <Table.Th />
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {items.map((r) => {
+                const listingChip = listingStatusChip(r.appListing?.status);
+                const statusChip = reportStatusChip(r.status);
+                const actions = reportRowActions({
+                  reportStatus: r.status,
+                  listingStatus: r.appListing?.status,
+                });
+                return (
+                  <Table.Tr key={r.id}>
+                    <Table.Td>
+                      <Group gap={6}>
+                        <Code>{r.appListing?.slug ?? '—'}</Code>
+                        <Badge size="xs" color={listingChip.color} variant="light">
+                          {listingChip.label}
+                        </Badge>
+                      </Group>
+                      {r.appListing?.name && (
+                        <Text size="xs" c="dimmed">
+                          {r.appListing.name}
+                        </Text>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="xs">{getReportReasonLabel(r.reason)}</Text>
+                      {r.details && (
+                        <Text size="xs" c="dimmed" lineClamp={2} style={{ maxWidth: 260 }}>
+                          {r.details}
+                        </Text>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="xs">
+                        {r.reporter?.username ?? `#${r.reporter?.id ?? '?'}`}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Group gap={4}>
+                        <IconClock size={14} />
+                        <Text size="xs">{formatDate(r.createdAt)}</Text>
+                      </Group>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge size="sm" color={statusChip.color} variant="light">
+                        {statusChip.label}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      <Group gap={4} justify="flex-end" wrap="nowrap">
+                        {actions.map((action) => (
+                          <Button
+                            key={action}
+                            size="xs"
+                            variant={isDestructiveAction(action) ? 'filled' : 'default'}
+                            color={isDestructiveAction(action) ? 'red' : undefined}
+                            onClick={() => setPending({ action, report: r })}
+                            data-testid={`apps-report-${action}-${r.appListing?.slug ?? r.id}`}
+                          >
+                            {reportActionLabel(action)}
+                          </Button>
+                        ))}
+                        <Button
+                          size="xs"
+                          variant="subtle"
+                          leftSection={<IconHistory size={12} />}
+                          onClick={() => setHistoryFor(r)}
+                        >
+                          History
+                        </Button>
+                      </Group>
+                    </Table.Td>
+                  </Table.Tr>
+                );
+              })}
+            </Table.Tbody>
+          </Table>
+        </Card>
+      )}
+
+      <ReportActionModal pending={pending} onClose={() => setPending(null)} />
+      <ModerationHistoryModal report={historyFor} onClose={() => setHistoryFor(null)} />
+    </Stack>
+  );
+}
+
+/**
+ * The reason/note + confirm modal for a single report-row action. delist/relist/
+ * purge require a reason (≥{@link OFFSITE_MOD_REASON_MIN} chars); resolve/dismiss
+ * take an optional note. Purge is destructive → an extra warning + a permanent
+ * confirm label.
+ */
+function ReportActionModal({
+  pending,
+  onClose,
+}: {
+  pending: { action: ReportRowAction; report: ReportRow } | null;
+  onClose: () => void;
+}) {
+  const utils = trpc.useUtils();
+  const [text, setText] = useState('');
+
+  async function afterSuccess(message: string) {
+    showSuccessNotification({ message });
+    await utils.appListings.listListingReports.invalidate();
+    setText('');
+    onClose();
+  }
+  function onError(title: string) {
+    return (e: { message: string }) =>
+      showErrorNotification({ title, error: new Error(e.message) });
+  }
+
+  const delistMut = trpc.appListings.delistListing.useMutation({
+    onSuccess: () => afterSuccess('Listing delisted.'),
+    onError: onError('Delist failed'),
+  });
+  const relistMut = trpc.appListings.relistListing.useMutation({
+    onSuccess: () => afterSuccess('Listing relisted.'),
+    onError: onError('Relist failed'),
+  });
+  const purgeMut = trpc.appListings.purgeListing.useMutation({
+    onSuccess: () => afterSuccess('Listing purged.'),
+    onError: onError('Purge failed'),
+  });
+  const resolveMut = trpc.appListings.resolveReport.useMutation({
+    onSuccess: () => afterSuccess('Report resolved.'),
+    onError: onError('Resolve failed'),
+  });
+  const dismissMut = trpc.appListings.dismissReport.useMutation({
+    onSuccess: () => afterSuccess('Report dismissed.'),
+    onError: onError('Dismiss failed'),
+  });
+
+  const busy =
+    delistMut.isPending ||
+    relistMut.isPending ||
+    purgeMut.isPending ||
+    resolveMut.isPending ||
+    dismissMut.isPending;
+
+  if (!pending) return null;
+  const { action, report } = pending;
+  const reasonRequired = action === 'delist' || action === 'relist' || action === 'purge';
+  const trimmed = text.trim();
+  const canSubmit = !busy && (!reasonRequired || trimmed.length >= OFFSITE_MOD_REASON_MIN);
+
+  function submit() {
+    switch (action) {
+      case 'delist':
+        return delistMut.mutate({
+          appListingId: report.appListingId,
+          reason: trimmed,
+          reportId: report.id,
+        });
+      case 'relist':
+        return relistMut.mutate({ appListingId: report.appListingId, reason: trimmed });
+      case 'purge':
+        return purgeMut.mutate({ appListingId: report.appListingId, reason: trimmed });
+      case 'resolve':
+        return resolveMut.mutate({ reportId: report.id, note: trimmed || undefined });
+      case 'dismiss':
+        return dismissMut.mutate({ reportId: report.id, note: trimmed || undefined });
+    }
+  }
+
+  return (
+    <Modal
+      opened={!!pending}
+      onClose={() => {
+        if (busy) return;
+        setText('');
+        onClose();
+      }}
+      title={
+        <Group gap={6}>
+          <Text fw={600}>
+            {reportActionLabel(action)} — {report.appListing?.slug ?? report.appListingId}
+          </Text>
+        </Group>
+      }
+      centered
+    >
+      <Stack gap="md">
+        {isDestructiveAction(action) && (
+          <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
+            <Text size="sm">
+              Purge PERMANENTLY deletes this listing and its screenshots + reports. The audit event
+              (with the slug snapshot) is kept. This cannot be undone.
+            </Text>
+          </Alert>
+        )}
+        <Textarea
+          label={reasonRequired ? `Reason (≥${OFFSITE_MOD_REASON_MIN} chars, audited)` : 'Note (optional)'}
+          autosize
+          minRows={3}
+          maxRows={8}
+          placeholder={
+            reasonRequired
+              ? 'Why this action — recorded in the audit trail.'
+              : 'Optional resolution note (audited).'
+          }
+          value={text}
+          onChange={(e) => setText(e.currentTarget.value)}
+          disabled={busy}
+          data-testid="apps-report-action-reason"
+        />
+        <Group justify="flex-end" gap="xs">
+          <Button
+            variant="default"
+            onClick={() => {
+              setText('');
+              onClose();
+            }}
+            disabled={busy}
+          >
+            Cancel
+          </Button>
+          <Button
+            color={isDestructiveAction(action) ? 'red' : undefined}
+            onClick={submit}
+            disabled={!canSubmit}
+            loading={busy}
+            data-testid="apps-report-action-confirm"
+          >
+            {isDestructiveAction(action) ? 'Purge permanently' : reportActionLabel(action)}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}
+
+type ModEvent = {
+  id: string;
+  appListingId: string | null;
+  slug: string;
+  action: string;
+  reason: string | null;
+  detail: string | null;
+  before: unknown;
+  after: unknown;
+  reportId: string | null;
+  createdAt: string | Date;
+  actor: { id: number; username: string | null; image: string | null } | null;
+};
+
+type ModEventList = { items: ModEvent[]; nextCursor: string | null };
+
+/** Read-only per-listing moderation history (newest-first audit trail). */
+function ModerationHistoryModal({
+  report,
+  onClose,
+}: {
+  report: ReportRow | null;
+  onClose: () => void;
+}) {
+  const features = useFeatureFlags();
+  const query = trpc.appListings.listModerationEvents.useQuery(
+    { appListingId: report?.appListingId ?? '', limit: 50 },
+    { enabled: !!features?.appBlocks && !!report?.appListingId, retry: false }
+  );
+
+  if (!report) return null;
+  const events = (query.data?.items ?? []) as ModEvent[];
+
+  return (
+    <Modal
+      opened={!!report}
+      onClose={onClose}
+      title={
+        <Group gap={6}>
+          <IconHistory size={16} />
+          <Text fw={600}>Moderation history — {report.appListing?.slug ?? report.appListingId}</Text>
+        </Group>
+      }
+      size="lg"
+      centered
+    >
+      {query.isLoading ? (
+        <Group gap="xs">
+          <Loader size="xs" />
+          <Text size="sm" c="dimmed">
+            Loading…
+          </Text>
+        </Group>
+      ) : events.length === 0 ? (
+        <Text size="sm" c="dimmed">
+          No moderation events recorded for this listing yet.
+        </Text>
+      ) : (
+        <Stack gap="xs">
+          {events.map((e) => {
+            const chip = moderationActionChip(e.action);
+            return (
+              <Card key={e.id} withBorder p="sm">
+                <Group justify="space-between" gap="xs">
+                  <Group gap={6}>
+                    <Badge size="sm" color={chip.color} variant="light">
+                      {chip.label}
+                    </Badge>
+                    <Text size="xs" c="dimmed">
+                      by {e.actor?.username ?? `#${e.actor?.id ?? '?'}`}
+                    </Text>
+                  </Group>
+                  <Text size="xs" c="dimmed">
+                    {formatDate(e.createdAt)}
+                  </Text>
+                </Group>
+                {e.reason && (
+                  <Text size="sm" mt={4} style={{ whiteSpace: 'pre-wrap' }}>
+                    {e.reason}
+                  </Text>
+                )}
+              </Card>
+            );
+          })}
+        </Stack>
+      )}
     </Modal>
   );
 }

--- a/src/components/Apps/__tests__/appListingModerationView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationView.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isDestructiveAction,
+  listingStatusChip,
+  moderationActionChip,
+  reportActionLabel,
+  reportRowActions,
+  reportStatusChip,
+  type ReportRowAction,
+} from '~/components/Apps/appListingModerationView';
+import { APP_LISTING_MODERATION_ACTIONS } from '~/server/schema/blocks/offsite-moderation.schema';
+
+/**
+ * W13 P3b PR3 — pure moderation VIEW MODEL (the blocking gate for the report-row
+ * action set + the status/action chips; the browser-mode queue test is
+ * report-only). Pins the state→action-set matrix + that every chip has a label.
+ */
+
+describe('reportRowActions — the per-row action set', () => {
+  it('an APPROVED listing with a PENDING report offers delist + resolve + dismiss', () => {
+    expect(reportRowActions({ reportStatus: 'pending', listingStatus: 'approved' })).toEqual([
+      'delist',
+      'resolve',
+      'dismiss',
+    ]);
+  });
+
+  it('a REMOVED listing with a PENDING report offers relist + purge + resolve + dismiss', () => {
+    expect(reportRowActions({ reportStatus: 'pending', listingStatus: 'removed' })).toEqual([
+      'relist',
+      'purge',
+      'resolve',
+      'dismiss',
+    ]);
+  });
+
+  it('a resolved/dismissed report offers NO report actions (only listing actions remain)', () => {
+    expect(reportRowActions({ reportStatus: 'resolved', listingStatus: 'approved' })).toEqual([
+      'delist',
+    ]);
+    expect(reportRowActions({ reportStatus: 'dismissed', listingStatus: 'removed' })).toEqual([
+      'relist',
+      'purge',
+    ]);
+  });
+
+  it('purge is ONLY offered on a removed listing (never on an approved/live one)', () => {
+    expect(reportRowActions({ reportStatus: 'pending', listingStatus: 'approved' })).not.toContain(
+      'purge'
+    );
+    expect(reportRowActions({ reportStatus: 'pending', listingStatus: 'removed' })).toContain('purge');
+  });
+
+  it('a null/gone listing status yields no listing-level actions', () => {
+    expect(reportRowActions({ reportStatus: 'pending', listingStatus: null })).toEqual([
+      'resolve',
+      'dismiss',
+    ]);
+    expect(reportRowActions({ reportStatus: 'resolved', listingStatus: undefined })).toEqual([]);
+  });
+});
+
+describe('isDestructiveAction', () => {
+  it('only purge is destructive', () => {
+    expect(isDestructiveAction('purge')).toBe(true);
+    for (const a of ['delist', 'relist', 'resolve', 'dismiss'] as ReportRowAction[]) {
+      expect(isDestructiveAction(a)).toBe(false);
+    }
+  });
+});
+
+describe('chips', () => {
+  it('reportStatusChip covers every report status with a non-empty label', () => {
+    for (const s of ['pending', 'resolved', 'dismissed']) {
+      const chip = reportStatusChip(s);
+      expect(chip.label.trim().length).toBeGreaterThan(0);
+      expect(chip.color.trim().length).toBeGreaterThan(0);
+    }
+    // Unknown falls back to the raw value, never throws.
+    expect(reportStatusChip('weird').label).toBe('weird');
+  });
+
+  it('listingStatusChip maps removed→Delisted and a null status→Gone', () => {
+    expect(listingStatusChip('removed').label).toBe('Delisted');
+    expect(listingStatusChip('approved').label).toBe('Live');
+    expect(listingStatusChip(null).label).toBe('Gone');
+    expect(listingStatusChip(undefined).label).toBe('Gone');
+  });
+
+  it('moderationActionChip has a label for EVERY schema action (no unlabeled event)', () => {
+    for (const action of APP_LISTING_MODERATION_ACTIONS) {
+      const chip = moderationActionChip(action);
+      expect(chip.label.trim().length).toBeGreaterThan(0);
+      // A real label, not the raw action key.
+      expect(chip.label).not.toBe(action);
+    }
+  });
+});
+
+describe('reportActionLabel', () => {
+  it('gives a distinct human label for each action', () => {
+    const labels = (['delist', 'relist', 'purge', 'resolve', 'dismiss'] as ReportRowAction[]).map(
+      reportActionLabel
+    );
+    expect(new Set(labels).size).toBe(labels.length);
+    for (const l of labels) expect(l.trim().length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/Apps/appListingModerationView.ts
+++ b/src/components/Apps/appListingModerationView.ts
@@ -1,0 +1,115 @@
+/**
+ * App Store Listings (W13) — P3b PR3 MODERATION VIEW MODEL (pure, React-free).
+ *
+ * The report-row → action-set + status → chip logic for the mod report queue +
+ * the per-listing moderation-history view, extracted so the correctness gate lives
+ * in the node `unit` project (the civitai browser-mode component suites are
+ * REPORT-ONLY / non-blocking — so the real, blocking coverage for this logic lives
+ * here, mirroring `appListingReportView` / `appListingCardView`).
+ *
+ * No React, no Mantine imports — the color strings are plain Mantine color names
+ * the component maps onto <Badge color=…>. This keeps the module pure + trivially
+ * unit-testable.
+ */
+
+/** The mod actions a report row can offer (a subset renders per row). */
+export type ReportRowAction = 'delist' | 'relist' | 'purge' | 'resolve' | 'dismiss';
+
+/** A pill descriptor: a human label + a Mantine color name. */
+export type Chip = { label: string; color: string };
+
+/**
+ * The ordered set of actions to render for a report row, given the report's own
+ * status AND its target listing's status.
+ *
+ *   - resolve / dismiss: only while the report is `pending` (a closed report can't
+ *     be re-closed).
+ *   - delist: only while the listing is `approved` (delist is approved→removed).
+ *   - relist: only while the listing is `removed` (relist is removed→approved).
+ *   - purge: only once the listing is `removed` — a mod delists first, THEN purges;
+ *     this keeps the destructive hard-delete off a still-live approved listing in
+ *     the queue UI (the service itself allows purge on any status, but the queue
+ *     nudges the delist→purge order).
+ *
+ * `listingStatus` may be null (the listing was purged out from under an
+ * already-closed report — defensive; cascade normally removes the report) → no
+ * listing-level actions.
+ */
+export function reportRowActions(input: {
+  reportStatus: string;
+  listingStatus: string | null | undefined;
+}): ReportRowAction[] {
+  const actions: ReportRowAction[] = [];
+  const listingStatus = input.listingStatus ?? null;
+
+  if (listingStatus === 'approved') actions.push('delist');
+  if (listingStatus === 'removed') {
+    actions.push('relist');
+    actions.push('purge');
+  }
+  if (input.reportStatus === 'pending') {
+    actions.push('resolve');
+    actions.push('dismiss');
+  }
+  return actions;
+}
+
+/** Whether an action is the destructive one that must be confirmed before firing. */
+export function isDestructiveAction(action: ReportRowAction): boolean {
+  return action === 'purge';
+}
+
+const REPORT_STATUS_CHIPS: Record<string, Chip> = {
+  pending: { label: 'Pending', color: 'yellow' },
+  resolved: { label: 'Resolved', color: 'green' },
+  dismissed: { label: 'Dismissed', color: 'gray' },
+};
+
+/** Chip for a report's lifecycle status (falls back to the raw value / gray). */
+export function reportStatusChip(status: string): Chip {
+  return REPORT_STATUS_CHIPS[status] ?? { label: status, color: 'gray' };
+}
+
+const LISTING_STATUS_CHIPS: Record<string, Chip> = {
+  draft: { label: 'Draft', color: 'gray' },
+  pending: { label: 'Pending', color: 'yellow' },
+  approved: { label: 'Live', color: 'green' },
+  rejected: { label: 'Rejected', color: 'gray' },
+  removed: { label: 'Delisted', color: 'red' },
+};
+
+/** Chip for a listing's store status (falls back to the raw value / gray). */
+export function listingStatusChip(status: string | null | undefined): Chip {
+  if (!status) return { label: 'Gone', color: 'dark' };
+  return LISTING_STATUS_CHIPS[status] ?? { label: status, color: 'gray' };
+}
+
+const MOD_ACTION_CHIPS: Record<string, Chip> = {
+  delist: { label: 'Delisted', color: 'red' },
+  relist: { label: 'Relisted', color: 'green' },
+  purge: { label: 'Purged', color: 'dark' },
+  claim: { label: 'Ownership claimed', color: 'blue' },
+  'report-resolve': { label: 'Report resolved', color: 'green' },
+  'report-dismiss': { label: 'Report dismissed', color: 'gray' },
+};
+
+/** Chip for a moderation-event action, for the per-listing history view. */
+export function moderationActionChip(action: string): Chip {
+  return MOD_ACTION_CHIPS[action] ?? { label: action, color: 'gray' };
+}
+
+/** Human label for a report-row action button. */
+export function reportActionLabel(action: ReportRowAction): string {
+  switch (action) {
+    case 'delist':
+      return 'Delist';
+    case 'relist':
+      return 'Relist';
+    case 'purge':
+      return 'Purge';
+    case 'resolve':
+      return 'Resolve';
+    case 'dismiss':
+      return 'Dismiss';
+  }
+}

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -26,6 +26,7 @@ import {
   IconClock,
   IconCode,
   IconExternalLink,
+  IconFlag,
   IconKey,
   IconLayoutGrid,
   IconShieldLock,
@@ -36,7 +37,7 @@ import { useRouter } from 'next/router';
 import type { MouseEvent } from 'react';
 import { useMemo, useRef, useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
-import { OffsiteReviewQueue } from '~/components/Apps/OffsiteReviewQueue';
+import { OffsiteReportsQueue, OffsiteReviewQueue } from '~/components/Apps/OffsiteReviewQueue';
 import { pickReviewIframeSrc } from '~/components/Apps/reviewIframeSrc';
 import { Meta } from '~/components/Meta/Meta';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
@@ -144,10 +145,10 @@ type RejectedRequest = ReviewedRequestCommon & {
 
 type AnyRequest = PendingRequest | ApprovedRequest | RejectedRequest;
 
-type TabValue = 'pending' | 'approved' | 'rejected';
+type TabValue = 'pending' | 'approved' | 'rejected' | 'reports';
 
 function isTabValue(v: unknown): v is TabValue {
-  return v === 'pending' || v === 'approved' || v === 'rejected';
+  return v === 'pending' || v === 'approved' || v === 'rejected' || v === 'reports';
 }
 
 function formatBytes(s: string): string {
@@ -234,6 +235,9 @@ export default function ReviewQueuePage() {
             <Tabs.Tab value="rejected" leftSection={<IconX size={14} />}>
               Rejected
             </Tabs.Tab>
+            <Tabs.Tab value="reports" leftSection={<IconFlag size={14} />}>
+              Reports
+            </Tabs.Tab>
           </Tabs.List>
 
           <Tabs.Panel value="pending" pt="md">
@@ -252,6 +256,12 @@ export default function ReviewQueuePage() {
 
           <Tabs.Panel value="rejected" pt="md">
             <RejectedTab onSelect={(r) => setSelected({ request: r, mode: 'rejected' })} />
+          </Tabs.Panel>
+
+          <Tabs.Panel value="reports" pt="md">
+            {/* Off-site listing REPORT queue + mod takedown actions (W13 P3b PR3).
+                Dark + mod-only; read via appListings.listListingReports. */}
+            <OffsiteReportsQueue />
           </Tabs.Panel>
         </Tabs>
       </AppsPageLayout>

--- a/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * W13 P3b PR3 — off-site mod-ACTION router AUTHZ matrix + error mapping.
+ *
+ * Drives the REAL `appListingsRouter` via `createCaller` so the middleware wiring
+ * decides: delist / relist / purge / resolveReport / dismissReport /
+ * listModerationEvents are ALL `moderatorProcedure` (+ the inner `isModerator`
+ * recheck) → a tester (non-mod) is FORBIDDEN on every one, a mod passes with the
+ * reviewer bound to `ctx.user.id`, and typed `OffsiteModerationError`s map through
+ * `mapOffsiteError` (NOT_FOUND→NOT_FOUND, NOT_TRANSITIONABLE→BAD_REQUEST,
+ * unexpected infra→INTERNAL with no raw leak). The `claimListing` proc does NOT
+ * exist yet (PR4) — asserted by absence.
+ */
+
+const {
+  mockDelist,
+  mockRelist,
+  mockPurge,
+  mockResolve,
+  mockDismiss,
+  mockListEvents,
+  mockReport,
+  mockListReports,
+  mockIsAppBlocksEnabled,
+  mockIsAppBlocksAuthorEnabled,
+} = vi.hoisted(() => ({
+  mockDelist: vi.fn(async () => ({ appListingId: 'apl_1', status: 'removed' as const })),
+  mockRelist: vi.fn(async () => ({ appListingId: 'apl_1', status: 'approved' as const })),
+  mockPurge: vi.fn(async () => ({ appListingId: 'apl_1', purged: true as const })),
+  mockResolve: vi.fn(async () => undefined),
+  mockDismiss: vi.fn(async () => undefined),
+  mockListEvents: vi.fn(async () => ({ items: [], nextCursor: null })),
+  mockReport: vi.fn(async () => ({ reportId: 'alrp_1' })),
+  mockListReports: vi.fn(async () => ({ items: [], nextCursor: null })),
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockIsAppBlocksAuthorEnabled: vi.fn(),
+}));
+
+vi.mock('~/server/services/blocks/offsite-moderation.service', () => ({
+  reportListing: mockReport,
+  listListingReports: mockListReports,
+  delistListing: mockDelist,
+  relistListing: mockRelist,
+  purgeListing: mockPurge,
+  resolveReport: mockResolve,
+  dismissReport: mockDismiss,
+  listModerationEvents: mockListEvents,
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+vi.mock('~/server/utils/server-domain', () => ({ isHostForColor: () => false }));
+
+import { appListingsRouter } from '../app-listings.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function offsiteModErr(code: string, message: string): Error {
+  return Object.assign(new Error(message), { name: 'OffsiteModerationError', code });
+}
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+const mod = { id: 1, isModerator: true, tier: 'free', username: 'mod', onboarding: 0x1f };
+const tester = { id: 2, isModerator: false, tier: 'free', username: 'tester', onboarding: 0x1f };
+
+const REASON = 'confirmed impersonation of a real vendor';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAppBlocksEnabled.mockImplementation((opts?: { user?: { isModerator?: boolean } }) =>
+    Promise.resolve(!!opts?.user?.isModerator)
+  );
+  mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+});
+
+// Every mod action, keyed by a caller that invokes it with a VALID input so the
+// schema passes and the authz/middleware is what decides.
+const MOD_ACTIONS: Array<{
+  name: string;
+  mock: ReturnType<typeof vi.fn>;
+  call: (c: ReturnType<typeof appListingsRouter.createCaller>) => Promise<unknown>;
+}> = [
+  {
+    name: 'delistListing',
+    mock: mockDelist,
+    call: (c) => c.delistListing({ appListingId: 'apl_1', reason: REASON }),
+  },
+  {
+    name: 'relistListing',
+    mock: mockRelist,
+    call: (c) => c.relistListing({ appListingId: 'apl_1', reason: REASON }),
+  },
+  {
+    name: 'purgeListing',
+    mock: mockPurge,
+    call: (c) => c.purgeListing({ appListingId: 'apl_1', reason: REASON }),
+  },
+  {
+    name: 'resolveReport',
+    mock: mockResolve,
+    call: (c) => c.resolveReport({ reportId: 'alrp_1', note: 'ok' }),
+  },
+  {
+    name: 'dismissReport',
+    mock: mockDismiss,
+    call: (c) => c.dismissReport({ reportId: 'alrp_1' }),
+  },
+  {
+    name: 'listModerationEvents',
+    mock: mockListEvents,
+    call: (c) => c.listModerationEvents({ appListingId: 'apl_1' }),
+  },
+];
+
+describe('mod actions — every one is moderator-only', () => {
+  for (const action of MOD_ACTIONS) {
+    it(`${action.name}: a tester is FORBIDDEN; service NOT called`, async () => {
+      const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
+      await expect(action.call(caller)).rejects.toBeInstanceOf(TRPCError);
+      expect(action.mock).not.toHaveBeenCalled();
+    });
+
+    it(`${action.name}: anonymous is rejected; service NOT called`, async () => {
+      const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+      await expect(action.call(caller)).rejects.toBeInstanceOf(TRPCError);
+      expect(action.mock).not.toHaveBeenCalled();
+    });
+
+    it(`${action.name}: a moderator passes`, async () => {
+      const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+      await expect(action.call(caller)).resolves.toBeDefined();
+      expect(action.mock).toHaveBeenCalledTimes(1);
+    });
+  }
+});
+
+describe('mod actions — reviewer id is bound to ctx (never client-supplied)', () => {
+  it('delist/relist/purge pass reviewerUserId = ctx.user.id', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await caller.delistListing({ appListingId: 'apl_1', reason: REASON });
+    await caller.relistListing({ appListingId: 'apl_1', reason: REASON });
+    await caller.purgeListing({ appListingId: 'apl_1', reason: REASON });
+    expect(mockDelist.mock.calls[0][0]).toMatchObject({ reviewerUserId: mod.id });
+    expect(mockRelist.mock.calls[0][0]).toMatchObject({ reviewerUserId: mod.id });
+    expect(mockPurge.mock.calls[0][0]).toMatchObject({ reviewerUserId: mod.id });
+  });
+
+  it('resolve/dismiss pass reviewerUserId = ctx.user.id', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await caller.resolveReport({ reportId: 'alrp_1' });
+    await caller.dismissReport({ reportId: 'alrp_1' });
+    expect(mockResolve.mock.calls[0][0]).toMatchObject({ reviewerUserId: mod.id });
+    expect(mockDismiss.mock.calls[0][0]).toMatchObject({ reviewerUserId: mod.id });
+  });
+});
+
+describe('mod actions — error mapping via mapOffsiteError', () => {
+  it('a typed NOT_TRANSITIONABLE maps to BAD_REQUEST', async () => {
+    mockDelist.mockRejectedValueOnce(offsiteModErr('NOT_TRANSITIONABLE', 'This listing can no longer be delisted.'));
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.delistListing({ appListingId: 'apl_1', reason: REASON })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('no longer be delisted'),
+    });
+  });
+
+  it('a typed NOT_FOUND maps to NOT_FOUND', async () => {
+    mockRelist.mockRejectedValueOnce(offsiteModErr('NOT_FOUND', 'Off-site listing not found.'));
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.relistListing({ appListingId: 'apl_x', reason: REASON })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('a typed REPORT_NOT_PENDING maps to BAD_REQUEST', async () => {
+    mockResolve.mockRejectedValueOnce(offsiteModErr('REPORT_NOT_PENDING', 'This report has already been handled.'));
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.resolveReport({ reportId: 'alrp_1' })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('an unexpected infra error maps to INTERNAL without leaking the raw message', async () => {
+    const raw = 'connect ECONNREFUSED 10.0.0.5:5432 postgres://secret-dsn';
+    mockPurge.mockRejectedValueOnce(new Error(raw));
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    const err = await caller.purgeListing({ appListingId: 'apl_1', reason: REASON }).then(
+      () => {
+        throw new Error('expected purge to reject');
+      },
+      (e) => e as TRPCError
+    );
+    expect(err.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(err.message).not.toContain('ECONNREFUSED');
+    expect(err.message).not.toContain('secret-dsn');
+  });
+
+  it('rejects a too-short delist reason at the SCHEMA boundary (service NOT called)', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(
+      caller.delistListing({ appListingId: 'apl_1', reason: 'x' })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockDelist).not.toHaveBeenCalled();
+  });
+});
+
+describe('claimListing is NOT exposed in PR3 (it is PR4)', () => {
+  it('the router exposes the 5 PR3 mod actions but NOT claimListing', () => {
+    // The tRPC caller proxy fabricates a function for ANY path, so probe the router
+    // DEFINITION's procedure record (the source of truth) instead of the caller.
+    const procs = Object.keys(
+      (appListingsRouter as unknown as { _def: { procedures: Record<string, unknown> } })._def
+        .procedures
+    );
+    for (const p of [
+      'delistListing',
+      'relistListing',
+      'purgeListing',
+      'resolveReport',
+      'dismissReport',
+      'listModerationEvents',
+    ]) {
+      expect(procs).toContain(p);
+    }
+    expect(procs).not.toContain('claimListing');
+  });
+});

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -24,8 +24,14 @@ import {
   withdrawExternalRequestSchema,
 } from '~/server/schema/blocks/offsite-listing.schema';
 import {
+  delistListingSchema,
+  dismissReportSchema,
   listListingReportsSchema,
+  listModerationEventsSchema,
+  purgeListingSchema,
+  relistListingSchema,
   reportListingSchema,
+  resolveReportSchema,
 } from '~/server/schema/blocks/offsite-moderation.schema';
 import { rateLimit } from '~/server/middleware.trpc';
 import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
@@ -473,6 +479,113 @@ export const appListingsRouter = router({
         '~/server/services/blocks/offsite-moderation.service'
       );
       return listListingReports(input);
+    }),
+
+  // -------------------------------------------------------------------------
+  // P3b PR3 mod ACTIONS — delist / relist / purge / resolve / dismiss (DARK).
+  //
+  // Each is `moderatorProcedure` + the inner `isModerator` recheck (belt +
+  // braces, mirroring approve/reject) + `mapOffsiteError` (typed → TRPC code, no
+  // infra leak). The reviewer is bound to `ctx.user.id` — never client-supplied.
+  // Each writes exactly one `AppListingModerationEvent` in the same tx as its
+  // mutation. `claimListing` is a separate PR4. All offsite-only + dark.
+  // -------------------------------------------------------------------------
+
+  /**
+   * MOD delist an approved off-site listing (approved → removed). Drops out of the
+   * approved-only store read path automatically. Optionally resolves a linked
+   * `reportId` in the same tx. Typed failures map via `mapOffsiteError`
+   * (NOT_FOUND→NOT_FOUND, NOT_TRANSITIONABLE→BAD_REQUEST, infra→INTERNAL/no leak).
+   */
+  delistListing: moderatorProcedure
+    .input(delistListingSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Delisting off-site listings is restricted to civitai team');
+      }
+      const { delistListing } = await import('~/server/services/blocks/offsite-moderation.service');
+      try {
+        return await delistListing({ input, reviewerUserId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /** MOD relist a removed off-site listing (removed → approved). Reversibility. */
+  relistListing: moderatorProcedure
+    .input(relistListingSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Relisting off-site listings is restricted to civitai team');
+      }
+      const { relistListing } = await import('~/server/services/blocks/offsite-moderation.service');
+      try {
+        return await relistListing({ input, reviewerUserId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /**
+   * MOD hard-delete (purge) an off-site listing — the final expunge + the
+   * self-clean primitive. Writes the audit event BEFORE the delete so the event
+   * survives (SetNull FK + slug snapshot). Destructive — the UI gates it behind a
+   * confirm.
+   */
+  purgeListing: moderatorProcedure
+    .input(purgeListingSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Purging off-site listings is restricted to civitai team');
+      }
+      const { purgeListing } = await import('~/server/services/blocks/offsite-moderation.service');
+      try {
+        return await purgeListing({ input, reviewerUserId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /** MOD resolve a pending report (pending → resolved) + audit event. */
+  resolveReport: moderatorProcedure
+    .input(resolveReportSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Resolving reports is restricted to civitai team');
+      }
+      const { resolveReport } = await import('~/server/services/blocks/offsite-moderation.service');
+      try {
+        await resolveReport({ input, reviewerUserId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+      return { ok: true };
+    }),
+
+  /** MOD dismiss a pending report (pending → dismissed) + audit event. */
+  dismissReport: moderatorProcedure
+    .input(dismissReportSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Dismissing reports is restricted to civitai team');
+      }
+      const { dismissReport } = await import('~/server/services/blocks/offsite-moderation.service');
+      try {
+        await dismissReport({ input, reviewerUserId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+      return { ok: true };
+    }),
+
+  /** MOD per-listing moderation history (audit trail), newest-first, keyset. */
+  listModerationEvents: moderatorProcedure
+    .input(listModerationEventsSchema)
+    .query(async ({ input }) => {
+      const { listModerationEvents } = await import(
+        '~/server/services/blocks/offsite-moderation.service'
+      );
+      return listModerationEvents(input);
     }),
 
   // -------------------------------------------------------------------------

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -482,13 +482,17 @@ export const appListingsRouter = router({
     }),
 
   // -------------------------------------------------------------------------
-  // P3b PR3 mod ACTIONS — delist / relist / purge / resolve / dismiss (DARK).
+  // P3b PR3 mod ACTIONS — delist / relist / purge / resolve / dismiss.
   //
-  // Each is `moderatorProcedure` + the inner `isModerator` recheck (belt +
-  // braces, mirroring approve/reject) + `mapOffsiteError` (typed → TRPC code, no
-  // infra leak). The reviewer is bound to `ctx.user.id` — never client-supplied.
-  // Each writes exactly one `AppListingModerationEvent` in the same tx as its
-  // mutation. `claimListing` is a separate PR4. All offsite-only + dark.
+  // Posture: UI-dark (the mod takedown affordance renders only on the mod-only
+  // store-preview surface). The SERVER gate is `moderatorProcedure` + the inner
+  // `isModerator` recheck (belt + braces, mirroring approve/reject) — NOT the
+  // `app-blocks-enabled` flag: that flag darkens the UI only, and mods bypass it
+  // anyway, so `enforceAppBlocksFlag` here would be inert (deliberately omitted).
+  // Plus `mapOffsiteError` (typed → TRPC code, no infra leak). The reviewer is bound
+  // to `ctx.user.id` — never client-supplied. Each writes exactly one
+  // `AppListingModerationEvent` in the same tx as its mutation. `claimListing` is a
+  // separate PR4. All offsite-only.
   // -------------------------------------------------------------------------
 
   /**
@@ -528,9 +532,12 @@ export const appListingsRouter = router({
 
   /**
    * MOD hard-delete (purge) an off-site listing — the final expunge + the
-   * self-clean primitive. Writes the audit event BEFORE the delete so the event
-   * survives (SetNull FK + slug snapshot). Destructive — the UI gates it behind a
-   * confirm.
+   * self-clean primitive. Writes the audit event BEFORE the delete so the event row
+   * survives at the ROW level for audit/compliance (SetNull FK + slug snapshot). It
+   * is NOT retrievable via the per-listing history read (`listModerationEvents`)
+   * once purged — the FK is nulled, so post-purge it's reachable only via the actor
+   * index / raw SQL (a slug-keyed orphaned-events read path is deferred to pre-GA).
+   * Destructive — the UI gates it behind a confirm.
    */
   purgeListing: moderatorProcedure
     .input(purgeListingSchema)

--- a/src/server/schema/blocks/offsite-moderation.schema.ts
+++ b/src/server/schema/blocks/offsite-moderation.schema.ts
@@ -65,3 +65,95 @@ export const listListingReportsSchema = z.object({
   limit: z.number().int().min(1).max(50).optional(),
 });
 export type ListListingReportsInput = z.infer<typeof listListingReportsSchema>;
+
+// ---------------------------------------------------------------------------
+// P3b PR3 — mod ACTIONS (delist / relist / purge / resolve / dismiss) + the
+// per-listing moderation-history read.
+// ---------------------------------------------------------------------------
+
+/**
+ * Moderation-event action taxonomy — MUST equal the `app_listing_mod_events_action_check`
+ * CHECK set (migration `20260706120100_w13_p3b_app_listing_moderation_events`). A
+ * drift here would let a proc write an `action` the DB rejects (23514). The
+ * action-agreement unit test pins this tuple against the migration's IN-list.
+ *
+ * NOTE the hyphen form (`report-resolve`/`report-dismiss`) — it matches the
+ * shipped migration CHECK verbatim. `claim` is reserved for PR4 (not written by
+ * any PR3 proc), but stays in the tuple because the DB CHECK already allows it.
+ */
+export const APP_LISTING_MODERATION_ACTIONS = [
+  'delist',
+  'relist',
+  'claim',
+  'purge',
+  'report-resolve',
+  'report-dismiss',
+] as const;
+export type AppListingModerationAction = (typeof APP_LISTING_MODERATION_ACTIONS)[number];
+
+/**
+ * Bounds for the mod-supplied rationale (`reason`, REQUIRED on delist/relist/purge)
+ * and the optional resolution `note` (resolve/dismiss). The reason is the audit
+ * trail's human record of WHY a takedown happened, so a small non-empty floor is
+ * enforced (mirrors the reject-reason discipline, lighter).
+ */
+export const OFFSITE_MOD_REASON_MIN = 3;
+export const OFFSITE_MOD_REASON_MAX = 1000;
+export const OFFSITE_MOD_NOTE_MAX = 1000;
+
+const modReason = z.string().min(OFFSITE_MOD_REASON_MIN).max(OFFSITE_MOD_REASON_MAX);
+const modNote = z.string().max(OFFSITE_MOD_NOTE_MAX).optional();
+
+/**
+ * MOD delist an APPROVED off-site listing (approved → removed). `reason` is
+ * required (audit); `reportId` optionally links the report that triggered the
+ * takedown (resolved in the same tx). The reviewer is bound to `ctx.user.id` in
+ * the service — never supplied by the client.
+ */
+export const delistListingSchema = z.object({
+  appListingId: z.string().min(1).max(64),
+  reason: modReason,
+  reportId: z.string().min(1).max(64).optional(),
+});
+export type DelistListingInput = z.infer<typeof delistListingSchema>;
+
+/** MOD relist a REMOVED off-site listing (removed → approved). Reversibility. */
+export const relistListingSchema = z.object({
+  appListingId: z.string().min(1).max(64),
+  reason: modReason,
+});
+export type RelistListingInput = z.infer<typeof relistListingSchema>;
+
+/**
+ * MOD hard-delete (purge) an off-site listing — the final expunge that also makes
+ * the delist round-trip self-cleaning. Destructive: the UI gates it behind a
+ * confirm. `reason` required for the audit event (which SURVIVES the delete via
+ * the SetNull FK + the denormalized slug snapshot).
+ */
+export const purgeListingSchema = z.object({
+  appListingId: z.string().min(1).max(64),
+  reason: modReason,
+});
+export type PurgeListingInput = z.infer<typeof purgeListingSchema>;
+
+/** MOD resolve a PENDING report (pending → resolved). Optional resolution note. */
+export const resolveReportSchema = z.object({
+  reportId: z.string().min(1).max(64),
+  note: modNote,
+});
+export type ResolveReportInput = z.infer<typeof resolveReportSchema>;
+
+/** MOD dismiss a PENDING report (pending → dismissed; no action taken). */
+export const dismissReportSchema = z.object({
+  reportId: z.string().min(1).max(64),
+  note: modNote,
+});
+export type DismissReportInput = z.infer<typeof dismissReportSchema>;
+
+/** MOD per-listing moderation-history read (keyset, newest-first). */
+export const listModerationEventsSchema = z.object({
+  appListingId: z.string().min(1).max(64),
+  cursor: z.string().min(1).max(64).optional(),
+  limit: z.number().int().min(1).max(50).optional(),
+});
+export type ListModerationEventsInput = z.infer<typeof listModerationEventsSchema>;

--- a/src/server/services/blocks/__tests__/app-listing-mod-action.constants.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-mod-action.constants.test.ts
@@ -1,0 +1,57 @@
+import { readdirSync, readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { APP_LISTING_MODERATION_ACTIONS } from '~/server/schema/blocks/offsite-moderation.schema';
+
+/**
+ * Migration-agreement guard — P3b PR3.
+ *
+ * The `app_listing_moderation_events.action` allowed set lives in TWO places that
+ * MUST agree:
+ *   1. the code tuple `APP_LISTING_MODERATION_ACTIONS` (written by the delist/
+ *      relist/purge/resolve/dismiss procs), and
+ *   2. the DB `app_listing_mod_events_action_check` CHECK — MANUAL-APPLY per
+ *      CLAUDE.md rule #8.
+ *
+ * This parses the moderation-events migration `.sql` and asserts its action
+ * IN-list EQUALS the code tuple, so a drift ("a proc writes an action the CHECK
+ * forbids" → 23514/500) is caught in CI. It does NOT apply the DDL.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+const MIGRATIONS_DIR = path.join(REPO_ROOT, 'prisma/migrations');
+
+function modEventsMigration(): string {
+  const dirs = readdirSync(MIGRATIONS_DIR)
+    .filter((d) => /_app_listing_moderation_events$/.test(d))
+    .sort();
+  if (dirs.length === 0)
+    throw new Error('no *_app_listing_moderation_events migration dir found under prisma/migrations');
+  return path.join(MIGRATIONS_DIR, dirs[dirs.length - 1], 'migration.sql');
+}
+
+/** Extract the quoted tokens from the `... "action" IN ('a', 'b', ...)` list. */
+function parseActionCheckInList(sql: string): string[] {
+  const m = sql.match(/CHECK\s*\(\s*"action"\s+IN\s*\(([^)]*)\)/i);
+  if (!m) throw new Error('action CHECK IN-list not found in migration .sql');
+  return [...m[1].matchAll(/'([^']+)'/g)].map((mm) => mm[1]);
+}
+
+describe('AppListingModerationEvent action: code tuple ⟺ DB CHECK agreement', () => {
+  it('the action-CHECK IN-list equals APP_LISTING_MODERATION_ACTIONS (same members, no dup)', () => {
+    const sql = readFileSync(modEventsMigration(), 'utf8');
+    const fromSql = parseActionCheckInList(sql);
+    expect(new Set(fromSql)).toEqual(new Set(APP_LISTING_MODERATION_ACTIONS));
+    expect(fromSql.length).toBe(new Set(fromSql).size);
+  });
+
+  it('uses the HYPHEN form report-resolve / report-dismiss (matches the shipped CHECK)', () => {
+    expect(APP_LISTING_MODERATION_ACTIONS).toContain('report-resolve');
+    expect(APP_LISTING_MODERATION_ACTIONS).toContain('report-dismiss');
+    // The PR3 procs write these five; claim is reserved for PR4 but allowed by the CHECK.
+    for (const a of ['delist', 'relist', 'purge', 'report-resolve', 'report-dismiss']) {
+      expect(APP_LISTING_MODERATION_ACTIONS).toContain(a);
+    }
+  });
+});

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -1,0 +1,367 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+import {
+  OffsiteModerationError,
+  delistListing,
+  dismissReport,
+  listModerationEvents,
+  purgeListing,
+  relistListing,
+  resolveReport,
+} from '~/server/services/blocks/offsite-moderation.service';
+
+/**
+ * W13 P3b PR3 — off-site moderation ACTION service tests (delist / relist / purge
+ * / resolve / dismiss + the moderation-history read). All DB deps are mocked — no
+ * real Prisma. `dbWrite.$transaction` runs its callback against the SAME `dbWrite`
+ * mock (the tx client), so a test asserts the exact status-guarded writes + that a
+ * guarded 0-count throws BEFORE any audit event is written (zero events on a
+ * guarded mutation), and that purge writes its event BEFORE the delete.
+ */
+
+type WriteMock = {
+  $transaction: ReturnType<typeof vi.fn>;
+  appListing: { updateMany: ReturnType<typeof vi.fn>; deleteMany: ReturnType<typeof vi.fn> };
+  appListingModerationEvent: { create: ReturnType<typeof vi.fn> };
+  appListingReport: { updateMany: ReturnType<typeof vi.fn> };
+};
+type ReadMock = {
+  appListing: { findUnique: ReturnType<typeof vi.fn> };
+  appListingReport: { findUnique: ReturnType<typeof vi.fn> };
+  appListingModerationEvent: { findMany: ReturnType<typeof vi.fn> };
+};
+
+const { mockRead, mockWrite, ids } = vi.hoisted(() => {
+  const write: WriteMock = {
+    $transaction: vi.fn(),
+    appListing: {
+      updateMany: vi.fn(async () => ({ count: 1 })),
+      deleteMany: vi.fn(async () => ({ count: 1 })),
+    },
+    appListingModerationEvent: { create: vi.fn(async (a: { data: unknown }) => a.data) },
+    appListingReport: { updateMany: vi.fn(async () => ({ count: 1 })) },
+  };
+  // The tx client is the write mock itself, so tx.* calls land on the same spies.
+  write.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) => cb(write));
+  const read: ReadMock = {
+    appListing: { findUnique: vi.fn(async () => null) },
+    appListingReport: { findUnique: vi.fn(async () => null) },
+    appListingModerationEvent: { findMany: vi.fn(async () => []) },
+  };
+  return { mockRead: read, mockWrite: write, ids: { n: 0 } };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingReportId: () => `alrp_test_${++ids.n}`,
+  newAppListingModerationEventId: () => `alme_test_${++ids.n}`,
+}));
+
+const REVIEWER = 1001;
+const APP_ID = 'apl_target';
+const SLUG = 'cool-app';
+const REPORT_ID = 'alrp_r1';
+const GOOD_REASON = 'impersonates a real vendor';
+
+function offsiteListing(status: string, kind = 'offsite') {
+  return { id: APP_ID, kind, status, slug: SLUG };
+}
+
+beforeEach(() => {
+  ids.n = 0;
+  vi.clearAllMocks();
+  mockWrite.$transaction.mockImplementation(
+    async (cb: (tx: WriteMock) => Promise<unknown>) => cb(mockWrite)
+  );
+  mockWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
+  mockWrite.appListing.deleteMany.mockResolvedValue({ count: 1 });
+  mockWrite.appListingModerationEvent.create.mockImplementation(async (a: { data: unknown }) => a.data);
+  mockWrite.appListingReport.updateMany.mockResolvedValue({ count: 1 });
+  mockRead.appListing.findUnique.mockResolvedValue(null);
+  mockRead.appListingReport.findUnique.mockResolvedValue(null);
+  mockRead.appListingModerationEvent.findMany.mockResolvedValue([]);
+});
+
+// ---------------------------------------------------------------------------
+// delistListing
+// ---------------------------------------------------------------------------
+
+describe('delistListing', () => {
+  it('flips approved → removed (status+kind-guarded) and writes exactly ONE delist event', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    const res = await delistListing({
+      input: { appListingId: APP_ID, reason: GOOD_REASON },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'removed' });
+
+    // The mutate is status+kind-guarded (approved-only, offsite-only).
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'offsite', status: 'approved' },
+      data: { status: 'removed' },
+    });
+    // Exactly ONE audit event, with the correct action/actor/reason/slug/before/after.
+    expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    const data = mockWrite.appListingModerationEvent.create.mock.calls[0][0].data;
+    expect(data).toMatchObject({
+      appListingId: APP_ID,
+      slug: SLUG,
+      action: 'delist',
+      actorUserId: REVIEWER,
+      reason: GOOD_REASON,
+      before: { status: 'approved' },
+      after: { status: 'removed' },
+      reportId: null,
+    });
+    // No linked report → the report table is untouched.
+    expect(mockWrite.appListingReport.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('a status-guarded 0-count (already removed/draft) → NOT_TRANSITIONABLE and ZERO events', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    mockWrite.appListing.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(
+      delistListing({ input: { appListingId: APP_ID, reason: GOOD_REASON }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'NOT_TRANSITIONABLE' });
+    // Guard threw BEFORE the audit write — no event on a rolled-back mutation.
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('an ON-SITE listing is rejected by the kind guard (generic NOT_FOUND, no tx)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved', 'onsite'));
+    await expect(
+      delistListing({ input: { appListingId: APP_ID, reason: GOOD_REASON }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'NOT_FOUND' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('a missing listing → generic NOT_FOUND (indistinguishable from on-site)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      delistListing({ input: { appListingId: APP_ID, reason: GOOD_REASON }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('with a reportId, resolves that report in the SAME tx (status-guarded)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    await delistListing({
+      input: { appListingId: APP_ID, reason: GOOD_REASON, reportId: REPORT_ID },
+      reviewerUserId: REVIEWER,
+    });
+    expect(mockWrite.appListingReport.updateMany).toHaveBeenCalledWith({
+      where: { id: REPORT_ID, status: 'pending' },
+      data: { status: 'resolved', resolvedByUserId: REVIEWER, resolvedAt: expect.any(Date) },
+    });
+    // The event carries the reportId link.
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.reportId).toBe(REPORT_ID);
+  });
+
+  it('a too-short reason is a BAD_REQUEST (defense-in-depth) with no DB touch', async () => {
+    await expect(
+      delistListing({ input: { appListingId: APP_ID, reason: 'x' }, reviewerUserId: REVIEWER })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockRead.appListing.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// relistListing
+// ---------------------------------------------------------------------------
+
+describe('relistListing', () => {
+  it('flips removed → approved (guarded) + one relist event with swapped before/after', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    const res = await relistListing({
+      input: { appListingId: APP_ID, reason: 'appeal upheld' },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'offsite', status: 'removed' },
+      data: { status: 'approved' },
+    });
+    const data = mockWrite.appListingModerationEvent.create.mock.calls[0][0].data;
+    expect(data).toMatchObject({
+      action: 'relist',
+      before: { status: 'removed' },
+      after: { status: 'approved' },
+    });
+  });
+
+  it('relisting a non-removed row → NOT_TRANSITIONABLE, ZERO events', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    mockWrite.appListing.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(
+      relistListing({ input: { appListingId: APP_ID, reason: 'appeal upheld' }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// purgeListing
+// ---------------------------------------------------------------------------
+
+describe('purgeListing', () => {
+  it('writes the audit event BEFORE the hard delete (so the event captures the snapshot)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    const res = await purgeListing({
+      input: { appListingId: APP_ID, reason: 'confirmed impersonation' },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, purged: true });
+
+    // ORDER: event.create must be invoked before appListing.deleteMany.
+    const createOrder = mockWrite.appListingModerationEvent.create.mock.invocationCallOrder[0];
+    const deleteOrder = mockWrite.appListing.deleteMany.mock.invocationCallOrder[0];
+    expect(createOrder).toBeLessThan(deleteOrder);
+
+    // The event snapshots the pre-delete status + slug; the delete targets the id.
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'purge',
+      slug: SLUG,
+      before: { status: 'removed' },
+    });
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({ where: { id: APP_ID } });
+  });
+
+  it('purges regardless of the source status (approved allowed), snapshotting it', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    await purgeListing({
+      input: { appListingId: APP_ID, reason: 'spam expunge' },
+      reviewerUserId: REVIEWER,
+    });
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.before).toEqual({
+      status: 'approved',
+    });
+  });
+
+  it('the kind guard rejects an on-site listing (no tx)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed', 'onsite'));
+    await expect(
+      purgeListing({ input: { appListingId: APP_ID, reason: 'spam expunge' }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('a raced delete (0-count) → NOT_FOUND', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    mockWrite.appListing.deleteMany.mockResolvedValueOnce({ count: 0 });
+    await expect(
+      purgeListing({ input: { appListingId: APP_ID, reason: 'spam expunge' }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveReport / dismissReport
+// ---------------------------------------------------------------------------
+
+describe('resolveReport / dismissReport', () => {
+  const report = { id: REPORT_ID, status: 'pending', appListingId: APP_ID, appListing: { slug: SLUG } };
+
+  it('resolveReport flips pending → resolved (guarded) + a report-resolve event with the note', async () => {
+    mockRead.appListingReport.findUnique.mockResolvedValueOnce(report);
+    await resolveReport({ input: { reportId: REPORT_ID, note: '  handled  ' }, reviewerUserId: REVIEWER });
+    expect(mockWrite.appListingReport.updateMany).toHaveBeenCalledWith({
+      where: { id: REPORT_ID, status: 'pending' },
+      data: { status: 'resolved', resolvedByUserId: REVIEWER, resolvedAt: expect.any(Date) },
+    });
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'report-resolve',
+      reportId: REPORT_ID,
+      slug: SLUG,
+      reason: 'handled', // trimmed note
+      before: { status: 'pending' },
+      after: { status: 'resolved' },
+    });
+  });
+
+  it('dismissReport flips pending → dismissed + a report-dismiss event; empty note → null reason', async () => {
+    mockRead.appListingReport.findUnique.mockResolvedValueOnce(report);
+    await dismissReport({ input: { reportId: REPORT_ID }, reviewerUserId: REVIEWER });
+    expect(mockWrite.appListingReport.updateMany).toHaveBeenCalledWith({
+      where: { id: REPORT_ID, status: 'pending' },
+      data: { status: 'dismissed', resolvedByUserId: REVIEWER, resolvedAt: expect.any(Date) },
+    });
+    const data = mockWrite.appListingModerationEvent.create.mock.calls[0][0].data;
+    expect(data.action).toBe('report-dismiss');
+    expect(data.reason).toBeNull();
+  });
+
+  it('a non-pending report → REPORT_NOT_PENDING, ZERO events', async () => {
+    mockRead.appListingReport.findUnique.mockResolvedValueOnce({ ...report, status: 'resolved' });
+    mockWrite.appListingReport.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(
+      resolveReport({ input: { reportId: REPORT_ID }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'REPORT_NOT_PENDING' });
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('a missing report → NOT_FOUND (no tx)', async () => {
+    mockRead.appListingReport.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      dismissReport({ input: { reportId: REPORT_ID }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listModerationEvents
+// ---------------------------------------------------------------------------
+
+describe('listModerationEvents', () => {
+  const evt = (id: string) => ({
+    id,
+    appListingId: APP_ID,
+    slug: SLUG,
+    action: 'delist',
+    reason: 'r',
+    detail: null,
+    before: { status: 'approved' },
+    after: { status: 'removed' },
+    reportId: null,
+    createdAt: new Date(),
+    actor: { id: REVIEWER, username: 'mod', image: null },
+  });
+
+  it('is newest-first with an id tie-break, capped at 50, keyset-paginated', async () => {
+    mockRead.appListingModerationEvent.findMany.mockResolvedValueOnce([
+      evt('alme_3'),
+      evt('alme_2'),
+      evt('alme_1'),
+    ]);
+    const res = await listModerationEvents({ appListingId: APP_ID, limit: 2 });
+    expect(res.items).toHaveLength(2);
+    expect(res.nextCursor).toBe('alme_2');
+
+    const args = mockRead.appListingModerationEvent.findMany.mock.calls[0][0];
+    expect(args.where).toEqual({ appListingId: APP_ID });
+    expect(args.orderBy).toEqual([{ createdAt: 'desc' }, { id: 'desc' }]);
+    expect(args.take).toBe(3); // 2 + 1
+  });
+
+  it('caps limit at 50 and projects a PII-safe shape (actor chip, no raw actorUserId FK)', async () => {
+    mockRead.appListingModerationEvent.findMany.mockResolvedValueOnce([]);
+    await listModerationEvents({ appListingId: APP_ID, limit: 999 });
+    const args = mockRead.appListingModerationEvent.findMany.mock.calls[0][0];
+    expect(args.take).toBe(51);
+    expect(args.select.actor).toEqual({ select: { id: true, username: true, image: true } });
+    expect(args.select.actorUserId).toBeUndefined();
+  });
+
+  it('nextCursor is null on the last page', async () => {
+    mockRead.appListingModerationEvent.findMany.mockResolvedValueOnce([evt('alme_1')]);
+    const res = await listModerationEvents({ appListingId: APP_ID });
+    expect(res.nextCursor).toBeNull();
+  });
+});
+
+describe('OffsiteModerationError (PR3 codes)', () => {
+  it('carries the new NOT_TRANSITIONABLE / REPORT_NOT_PENDING codes', () => {
+    expect(new OffsiteModerationError('NOT_TRANSITIONABLE', 'x').code).toBe('NOT_TRANSITIONABLE');
+    expect(new OffsiteModerationError('REPORT_NOT_PENDING', 'x').code).toBe('REPORT_NOT_PENDING');
+  });
+});

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -22,7 +22,12 @@ import {
 
 type WriteMock = {
   $transaction: ReturnType<typeof vi.fn>;
-  appListing: { updateMany: ReturnType<typeof vi.fn>; deleteMany: ReturnType<typeof vi.fn> };
+  appListing: {
+    updateMany: ReturnType<typeof vi.fn>;
+    deleteMany: ReturnType<typeof vi.fn>;
+    // purge re-reads the pre-delete snapshot on the PRIMARY inside the tx.
+    findUnique: ReturnType<typeof vi.fn>;
+  };
   appListingModerationEvent: { create: ReturnType<typeof vi.fn> };
   appListingReport: { updateMany: ReturnType<typeof vi.fn> };
 };
@@ -38,6 +43,7 @@ const { mockRead, mockWrite, ids } = vi.hoisted(() => {
     appListing: {
       updateMany: vi.fn(async () => ({ count: 1 })),
       deleteMany: vi.fn(async () => ({ count: 1 })),
+      findUnique: vi.fn(async () => null),
     },
     appListingModerationEvent: { create: vi.fn(async (a: { data: unknown }) => a.data) },
     appListingReport: { updateMany: vi.fn(async () => ({ count: 1 })) },
@@ -76,6 +82,9 @@ beforeEach(() => {
   );
   mockWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
   mockWrite.appListing.deleteMany.mockResolvedValue({ count: 1 });
+  // Default the in-tx purge primary read to a valid offsite listing (overridden
+  // per-test where the snapshot status is load-bearing).
+  mockWrite.appListing.findUnique.mockResolvedValue(offsiteListing('removed'));
   mockWrite.appListingModerationEvent.create.mockImplementation(async (a: { data: unknown }) => a.data);
   mockWrite.appListingReport.updateMany.mockResolvedValue({ count: 1 });
   mockRead.appListing.findUnique.mockResolvedValue(null);
@@ -143,18 +152,40 @@ describe('delistListing', () => {
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
   });
 
-  it('with a reportId, resolves that report in the SAME tx (status-guarded)', async () => {
+  it('with a reportId, resolves that report in the SAME tx (status+listing-scoped)', async () => {
     mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
     await delistListing({
       input: { appListingId: APP_ID, reason: GOOD_REASON, reportId: REPORT_ID },
       reviewerUserId: REVIEWER,
     });
+    // The resolve is scoped to THIS listing (appListingId) AND the pending status —
+    // so a reportId for another listing can't be closed by this delist.
     expect(mockWrite.appListingReport.updateMany).toHaveBeenCalledWith({
-      where: { id: REPORT_ID, status: 'pending' },
+      where: { id: REPORT_ID, appListingId: APP_ID, status: 'pending' },
       data: { status: 'resolved', resolvedByUserId: REVIEWER, resolvedAt: expect.any(Date) },
     });
     // The event carries the reportId link.
     expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.reportId).toBe(REPORT_ID);
+  });
+
+  it('a reportId belonging to a DIFFERENT listing is NOT resolved (0-row no-op); the delist still succeeds', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    // The listing-scoped, status-guarded updateMany matches 0 rows (the report is
+    // for another listing) — the delist must still succeed (silent no-op).
+    mockWrite.appListingReport.updateMany.mockResolvedValueOnce({ count: 0 });
+    const res = await delistListing({
+      input: { appListingId: APP_ID, reason: GOOD_REASON, reportId: REPORT_ID },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'removed' });
+    // The WHERE is scoped to THIS listing, so a cross-listing report can never match.
+    expect(mockWrite.appListingReport.updateMany).toHaveBeenCalledWith({
+      where: { id: REPORT_ID, appListingId: APP_ID, status: 'pending' },
+      data: { status: 'resolved', resolvedByUserId: REVIEWER, resolvedAt: expect.any(Date) },
+    });
+    // The delist event still stands + still links the supplied reportId.
+    expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.action).toBe('delist');
   });
 
   it('a too-short reason is a BAD_REQUEST (defense-in-depth) with no DB touch', async () => {
@@ -206,6 +237,7 @@ describe('relistListing', () => {
 describe('purgeListing', () => {
   it('writes the audit event BEFORE the hard delete (so the event captures the snapshot)', async () => {
     mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
     const res = await purgeListing({
       input: { appListingId: APP_ID, reason: 'confirmed impersonation' },
       reviewerUserId: REVIEWER,
@@ -217,17 +249,21 @@ describe('purgeListing', () => {
     const deleteOrder = mockWrite.appListing.deleteMany.mock.invocationCallOrder[0];
     expect(createOrder).toBeLessThan(deleteOrder);
 
-    // The event snapshots the pre-delete status + slug; the delete targets the id.
+    // The event snapshots the pre-delete status + slug; the delete targets the id
+    // (kind-guarded — offsite-only, defense-in-depth on the destructive op).
     expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
       action: 'purge',
       slug: SLUG,
       before: { status: 'removed' },
     });
-    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({ where: { id: APP_ID } });
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'offsite' },
+    });
   });
 
   it('purges regardless of the source status (approved allowed), snapshotting it', async () => {
     mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
     await purgeListing({
       input: { appListingId: APP_ID, reason: 'spam expunge' },
       reviewerUserId: REVIEWER,
@@ -237,7 +273,35 @@ describe('purgeListing', () => {
     });
   });
 
-  it('the kind guard rejects an on-site listing (no tx)', async () => {
+  it('snapshots before.status + slug from the in-tx PRIMARY read, not the (lagging) replica classify', async () => {
+    // Replica classify sees a STALE `approved`/old-slug; the primary tx read sees the
+    // true current `removed`/new-slug. The audit `before` must reflect the PRIMARY.
+    mockRead.appListing.findUnique.mockResolvedValueOnce({
+      id: APP_ID,
+      kind: 'offsite',
+      status: 'approved',
+      slug: 'stale-slug',
+    });
+    mockWrite.appListing.findUnique.mockResolvedValueOnce({
+      status: 'removed',
+      slug: 'fresh-slug',
+      kind: 'offsite',
+    });
+    await purgeListing({
+      input: { appListingId: APP_ID, reason: 'confirmed impersonation' },
+      reviewerUserId: REVIEWER,
+    });
+    // The in-tx primary read is what feeds the snapshot.
+    expect(mockWrite.appListing.findUnique).toHaveBeenCalledWith({
+      where: { id: APP_ID },
+      select: { status: true, slug: true, kind: true },
+    });
+    const data = mockWrite.appListingModerationEvent.create.mock.calls[0][0].data;
+    expect(data.before).toEqual({ status: 'removed' });
+    expect(data.slug).toBe('fresh-slug');
+  });
+
+  it('the kind guard rejects an on-site listing at the replica classify (no tx)', async () => {
     mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed', 'onsite'));
     await expect(
       purgeListing({ input: { appListingId: APP_ID, reason: 'spam expunge' }, reviewerUserId: REVIEWER })
@@ -245,8 +309,21 @@ describe('purgeListing', () => {
     expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
+  it('a row that vanished/turned non-offsite between classify and the in-tx primary read → NOT_FOUND, ZERO events', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    // Passed the replica classify, but the primary tx read finds it gone.
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      purgeListing({ input: { appListingId: APP_ID, reason: 'spam expunge' }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    // Guard threw before the event write.
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
+  });
+
   it('a raced delete (0-count) → NOT_FOUND', async () => {
     mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
     mockWrite.appListing.deleteMany.mockResolvedValueOnce({ count: 0 });
     await expect(
       purgeListing({ input: { appListingId: APP_ID, reason: 'spam expunge' }, reviewerUserId: REVIEWER })

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.test.ts
@@ -300,8 +300,11 @@ describe('listListingReports — read-only mod queue', () => {
     // The reporter chip is the standard public {id,username,image} shape only.
     expect(select.reporter).toEqual({ select: { id: true, username: true, image: true } });
     expect(select.reporter.select.email).toBeUndefined();
-    // The target listing exposes only slug/name/kind.
-    expect(select.appListing).toEqual({ select: { slug: true, name: true, kind: true } });
+    // The target listing exposes only slug/name/kind/status (status drives the
+    // report-queue action set; still all public-safe listing fields).
+    expect(select.appListing).toEqual({
+      select: { slug: true, name: true, kind: true, status: true },
+    });
     // No reporterUserId (raw FK) / resolvedByUserId leaked in the projection.
     expect(select.reporterUserId).toBeUndefined();
     expect(select.resolvedByUserId).toBeUndefined();

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -316,11 +316,16 @@ export async function delistListing(opts: {
       },
     });
     if (input.reportId) {
-      // Resolve the triggering report in the same tx. Best-effort + status-guarded:
-      // a report a concurrent action already closed is left as-is (0 rows) — the
-      // delist still stands and the event still links the reportId.
+      // Resolve the triggering report in the same tx. Best-effort + status-guarded
+      // AND SCOPED to the delisted listing (`appListingId`): a caller passing a
+      // `reportId` that belongs to a DIFFERENT listing matches 0 rows (no
+      // cross-listing report closure) — the delist of THIS listing still stands and
+      // its event still links the supplied reportId; the mismatched report is just
+      // left untouched (silent no-op, not a hard failure — the delist is the primary
+      // action, a bad reportId must not fail it). A report a concurrent action
+      // already closed is likewise left as-is (0 rows).
       await tx.appListingReport.updateMany({
-        where: { id: input.reportId, status: 'pending' },
+        where: { id: input.reportId, appListingId: input.appListingId, status: 'pending' },
         data: { status: 'resolved', resolvedByUserId: reviewerUserId, resolvedAt: new Date() },
       });
     }
@@ -381,10 +386,22 @@ export type PurgeListingResult = { appListingId: string; purged: true };
  * 🔴 ORDER MATTERS: the audit event is written FIRST (capturing the slug snapshot +
  * the pre-delete status), THEN the `AppListing` row is deleted. The event's
  * `appListingId` FK is `ON DELETE SET NULL`, so the delete nulls the event's
- * `appListingId` but the event + its denormalized `slug` SURVIVE — an append-only
- * audit trail must outlive the row it references. `AppListingScreenshot` +
- * `AppListingReport` cascade-delete with the listing (intended). Both the event
- * write + the delete are in ONE tx; a 0-count delete (raced) rolls the event back.
+ * `appListingId` but the event row + its denormalized `slug` survive at the ROW
+ * level (compliance/forensics — an append-only audit trail must outlive the row it
+ * references). NOTE: because the FK is nulled on purge, a purged listing's events
+ * are NOT retrievable via `listModerationEvents({appListingId})` (the per-listing
+ * history read) — post-purge they're reachable only via the actor index or raw SQL
+ * (a slug-keyed orphaned-events read path is deferred to pre-GA).
+ * `AppListingScreenshot` + `AppListingReport` cascade-delete with the listing
+ * (intended). Both the event write + the delete are in ONE tx; a 0-count delete
+ * (raced) rolls the event back.
+ *
+ * The pre-delete snapshot (status/slug + the kind guard) is re-read INSIDE the tx
+ * from the PRIMARY (`tx.appListing.findUnique`), NOT from the replica classify —
+ * under replica lag the replica read could otherwise stamp a stale `before.status`
+ * (e.g. `approved` on a row already `removed`). The early replica `classify` is
+ * kept only as a fail-fast + info-leak-parity gate (missing/on-site → generic
+ * NOT_FOUND with no tx opened).
  */
 export async function purgeListing(opts: {
   input: PurgeListingInput;
@@ -392,26 +409,45 @@ export async function purgeListing(opts: {
 }): Promise<PurgeListingResult> {
   const { input, reviewerUserId } = opts;
   const reason = requireModReason(input.reason);
-  const listing = await classifyOffsiteListing(input.appListingId);
+  // Fail-fast + info-leak parity (replica): a missing OR on-site listing throws the
+  // same generic NOT_FOUND before any tx is opened. The authoritative snapshot is
+  // re-read on the primary inside the tx below.
+  await classifyOffsiteListing(input.appListingId);
 
   await dbWrite.$transaction(async (tx) => {
+    // Authoritative pre-delete snapshot from the PRIMARY (not the replica classify),
+    // so `before.status` + `slug` reflect the true current row and the kind guard is
+    // re-checked on the primary. A row that vanished (or turned non-offsite) between
+    // classify and here → generic NOT_FOUND, tx rolls back with no event written.
+    const current = await tx.appListing.findUnique({
+      where: { id: input.appListingId },
+      select: { status: true, slug: true, kind: true },
+    });
+    if (!current || current.kind !== 'offsite') {
+      throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+    }
     // Event FIRST (so the slug/state snapshot is captured before the row is gone).
     await tx.appListingModerationEvent.create({
       data: {
         id: newAppListingModerationEventId(),
         appListingId: input.appListingId,
-        slug: listing.slug,
+        slug: current.slug,
         action: 'purge',
         actorUserId: reviewerUserId,
         reason,
-        before: { status: listing.status },
+        before: { status: current.status },
       },
     });
     // THEN the hard delete (nulls the event's appListingId via SetNull; cascades
-    // screenshots + reports).
-    const deleted = await tx.appListing.deleteMany({ where: { id: input.appListingId } });
+    // screenshots + reports). The inline `kind: 'offsite'` guard mirrors delist/relist
+    // for defense-in-depth on a DESTRUCTIVE op — a 0-count delete (raced, or a
+    // non-offsite row slipping past classify) throws → the tx (incl. the event) rolls
+    // back.
+    const deleted = await tx.appListing.deleteMany({
+      where: { id: input.appListingId, kind: 'offsite' },
+    });
     if (deleted.count === 0) {
-      // Raced (concurrently purged between classify and here) → roll the event back.
+      // Raced (concurrently purged between the snapshot and here) → roll the event back.
       throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
     }
   });

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -1,10 +1,22 @@
+import { TRPCError } from '@trpc/server';
+
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
   APP_LISTING_REPORT_REASONS,
+  OFFSITE_MOD_REASON_MIN,
+  type DelistListingInput,
+  type DismissReportInput,
   type ListListingReportsInput,
+  type ListModerationEventsInput,
+  type PurgeListingInput,
+  type RelistListingInput,
   type ReportListingInput,
+  type ResolveReportInput,
 } from '~/server/schema/blocks/offsite-moderation.schema';
-import { newAppListingReportId } from '~/server/utils/app-block-ids';
+import {
+  newAppListingModerationEventId,
+  newAppListingReportId,
+} from '~/server/utils/app-block-ids';
 
 /**
  * App Store Listings (W13) — P3b OFF-SITE MODERATION service.
@@ -36,7 +48,15 @@ import { newAppListingReportId } from '~/server/utils/app-block-ids';
 export type OffsiteModerationErrorCode =
   | 'NOT_FOUND'
   | 'NOT_REPORTABLE'
-  | 'ALREADY_REPORTED';
+  | 'ALREADY_REPORTED'
+  // PR3 mod-action failure modes:
+  //   NOT_TRANSITIONABLE — a status-guarded delist/relist matched 0 rows (the
+  //     listing was already moved by a concurrent action) → BAD_REQUEST.
+  //   REPORT_NOT_PENDING — resolve/dismiss on an already-closed report → BAD_REQUEST.
+  // A kind mismatch (an on-site listing) reuses NOT_FOUND (generic — a mod caller
+  // must not be able to probe a listing's kind through this surface).
+  | 'NOT_TRANSITIONABLE'
+  | 'REPORT_NOT_PENDING';
 
 export class OffsiteModerationError extends Error {
   readonly code: OffsiteModerationErrorCode;
@@ -174,7 +194,10 @@ const reportQueueSelect = {
   createdAt: true,
   resolvedAt: true,
   reporter: { select: { id: true, username: true, image: true } },
-  appListing: { select: { slug: true, name: true, kind: true } },
+  // `status` is included so the report-queue UI can compute the per-row action set
+  // (delist only on an approved listing, relist/purge on a removed one) WITHOUT a
+  // second fetch. slug/name/kind/status are all public-safe listing fields.
+  appListing: { select: { slug: true, name: true, kind: true, status: true } },
 } as const;
 
 /**
@@ -194,6 +217,319 @@ export async function listListingReports(opts: ListListingReportsInput = {}) {
     take: limit + 1,
     ...(opts.cursor ? { cursor: { id: opts.cursor }, skip: 1 } : {}),
     select: reportQueueSelect,
+  });
+  const hasNext = rows.length > limit;
+  const items = hasNext ? rows.slice(0, limit) : rows;
+  return { items, nextCursor: hasNext ? items[items.length - 1].id : null };
+}
+
+// ---------------------------------------------------------------------------
+// PR3 — mod ACTIONS (delist / relist / purge / resolve / dismiss). Each writes
+// EXACTLY ONE `AppListingModerationEvent` in the SAME transaction as its mutation
+// (a crash can't split the mutation from its audit record). All mod-only at the
+// router (`moderatorProcedure` + `isModerator` recheck). `claim` is PR4.
+//
+// Discipline mirrored from the P3a offsite-listing approve/reject:
+//   - CLASSIFY on the replica (kind guard), then MUTATE with a status-guarded
+//     `updateMany`/`deleteMany` so a concurrent action can't double-act (TOCTOU);
+//     a 0-count rolls the whole tx back BEFORE the audit event is written.
+//   - A missing listing AND an on-site listing both raise the SAME generic
+//     NOT_FOUND — a mod caller can't probe a listing's kind/existence here.
+// ---------------------------------------------------------------------------
+
+/**
+ * Trim + re-assert the mod reason floor (defense-in-depth — these fns are exported
+ * and unit-tested directly, not only reached through the zod schema). A too-short
+ * reason is a plain BAD_REQUEST (passed through by `mapOffsiteError`).
+ */
+function requireModReason(raw: string): string {
+  const reason = raw.trim();
+  if (reason.length < OFFSITE_MOD_REASON_MIN) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `reason must be at least ${OFFSITE_MOD_REASON_MIN} characters`,
+    });
+  }
+  return reason;
+}
+
+/**
+ * Load + classify an off-site listing for a mod action. A missing listing AND an
+ * on-site (kind!=='offsite') listing BOTH raise the SAME generic NOT_FOUND — the
+ * kind guard (delist/relist/purge are offsite-only, §8 of the scope doc) must not
+ * let a mod caller probe a listing's kind or existence through this surface.
+ */
+async function classifyOffsiteListing(
+  appListingId: string
+): Promise<{ id: string; status: string; slug: string }> {
+  const listing = await dbRead.appListing.findUnique({
+    where: { id: appListingId },
+    select: { id: true, kind: true, status: true, slug: true },
+  });
+  if (!listing || listing.kind !== 'offsite') {
+    throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+  }
+  return { id: listing.id, status: listing.status, slug: listing.slug };
+}
+
+export type DelistListingResult = { appListingId: string; status: 'removed' };
+
+/**
+ * MOD delist an APPROVED off-site listing (approved → removed). The read path is
+ * approved-only, so a `removed` listing drops out of `listAvailableListings` +
+ * `getListingDetail` automatically (no read-path change). Status-guarded: the
+ * mutate is `updateMany({ id, kind:'offsite', status:'approved' })`; a 0-count
+ * means a concurrent action already moved the row → NOT_TRANSITIONABLE and the tx
+ * rolls back BEFORE the audit event is written (so a guarded failure emits ZERO
+ * events). Optionally resolves the triggering `reportId` in the same tx.
+ */
+export async function delistListing(opts: {
+  input: DelistListingInput;
+  reviewerUserId: number;
+}): Promise<DelistListingResult> {
+  const { input, reviewerUserId } = opts;
+  const reason = requireModReason(input.reason);
+  const listing = await classifyOffsiteListing(input.appListingId);
+
+  await dbWrite.$transaction(async (tx) => {
+    const flipped = await tx.appListing.updateMany({
+      where: { id: input.appListingId, kind: 'offsite', status: 'approved' },
+      data: { status: 'removed' },
+    });
+    if (flipped.count === 0) {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'This listing can no longer be delisted.'
+      );
+    }
+    await tx.appListingModerationEvent.create({
+      data: {
+        id: newAppListingModerationEventId(),
+        appListingId: input.appListingId,
+        slug: listing.slug,
+        action: 'delist',
+        actorUserId: reviewerUserId,
+        reason,
+        reportId: input.reportId ?? null,
+        before: { status: 'approved' },
+        after: { status: 'removed' },
+      },
+    });
+    if (input.reportId) {
+      // Resolve the triggering report in the same tx. Best-effort + status-guarded:
+      // a report a concurrent action already closed is left as-is (0 rows) — the
+      // delist still stands and the event still links the reportId.
+      await tx.appListingReport.updateMany({
+        where: { id: input.reportId, status: 'pending' },
+        data: { status: 'resolved', resolvedByUserId: reviewerUserId, resolvedAt: new Date() },
+      });
+    }
+  });
+
+  return { appListingId: input.appListingId, status: 'removed' };
+}
+
+export type RelistListingResult = { appListingId: string; status: 'approved' };
+
+/**
+ * MOD relist a REMOVED off-site listing (removed → approved) — reversibility for a
+ * mistaken/appealed takedown; restores store visibility instantly. Status-guarded
+ * (`status:'removed'`) + one audit event, same TOCTOU discipline as delist.
+ */
+export async function relistListing(opts: {
+  input: RelistListingInput;
+  reviewerUserId: number;
+}): Promise<RelistListingResult> {
+  const { input, reviewerUserId } = opts;
+  const reason = requireModReason(input.reason);
+  const listing = await classifyOffsiteListing(input.appListingId);
+
+  await dbWrite.$transaction(async (tx) => {
+    const flipped = await tx.appListing.updateMany({
+      where: { id: input.appListingId, kind: 'offsite', status: 'removed' },
+      data: { status: 'approved' },
+    });
+    if (flipped.count === 0) {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'This listing can no longer be relisted.'
+      );
+    }
+    await tx.appListingModerationEvent.create({
+      data: {
+        id: newAppListingModerationEventId(),
+        appListingId: input.appListingId,
+        slug: listing.slug,
+        action: 'relist',
+        actorUserId: reviewerUserId,
+        reason,
+        before: { status: 'removed' },
+        after: { status: 'approved' },
+      },
+    });
+  });
+
+  return { appListingId: input.appListingId, status: 'approved' };
+}
+
+export type PurgeListingResult = { appListingId: string; purged: true };
+
+/**
+ * MOD hard-delete (purge) an off-site listing — the genuine final expunge that
+ * also makes the delist round-trip self-cleaning.
+ *
+ * 🔴 ORDER MATTERS: the audit event is written FIRST (capturing the slug snapshot +
+ * the pre-delete status), THEN the `AppListing` row is deleted. The event's
+ * `appListingId` FK is `ON DELETE SET NULL`, so the delete nulls the event's
+ * `appListingId` but the event + its denormalized `slug` SURVIVE — an append-only
+ * audit trail must outlive the row it references. `AppListingScreenshot` +
+ * `AppListingReport` cascade-delete with the listing (intended). Both the event
+ * write + the delete are in ONE tx; a 0-count delete (raced) rolls the event back.
+ */
+export async function purgeListing(opts: {
+  input: PurgeListingInput;
+  reviewerUserId: number;
+}): Promise<PurgeListingResult> {
+  const { input, reviewerUserId } = opts;
+  const reason = requireModReason(input.reason);
+  const listing = await classifyOffsiteListing(input.appListingId);
+
+  await dbWrite.$transaction(async (tx) => {
+    // Event FIRST (so the slug/state snapshot is captured before the row is gone).
+    await tx.appListingModerationEvent.create({
+      data: {
+        id: newAppListingModerationEventId(),
+        appListingId: input.appListingId,
+        slug: listing.slug,
+        action: 'purge',
+        actorUserId: reviewerUserId,
+        reason,
+        before: { status: listing.status },
+      },
+    });
+    // THEN the hard delete (nulls the event's appListingId via SetNull; cascades
+    // screenshots + reports).
+    const deleted = await tx.appListing.deleteMany({ where: { id: input.appListingId } });
+    if (deleted.count === 0) {
+      // Raced (concurrently purged between classify and here) → roll the event back.
+      throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+    }
+  });
+
+  return { appListingId: input.appListingId, purged: true };
+}
+
+/**
+ * Shared close-a-report path for resolve/dismiss: status-guarded flip
+ * (pending → resolved|dismissed) + one audit event in the same tx. A non-pending
+ * report → REPORT_NOT_PENDING (rolls back before the event). The optional `note`
+ * lands on the event's `reason` (nullable — no note is fine).
+ */
+async function closeReport(opts: {
+  reportId: string;
+  reviewerUserId: number;
+  note?: string;
+  target: 'resolved' | 'dismissed';
+  action: 'report-resolve' | 'report-dismiss';
+}): Promise<void> {
+  const report = await dbRead.appListingReport.findUnique({
+    where: { id: opts.reportId },
+    select: { id: true, status: true, appListingId: true, appListing: { select: { slug: true } } },
+  });
+  if (!report) throw new OffsiteModerationError('NOT_FOUND', 'Report not found.');
+
+  const note = opts.note?.trim() ? opts.note.trim() : null;
+
+  await dbWrite.$transaction(async (tx) => {
+    const flipped = await tx.appListingReport.updateMany({
+      where: { id: opts.reportId, status: 'pending' },
+      data: { status: opts.target, resolvedByUserId: opts.reviewerUserId, resolvedAt: new Date() },
+    });
+    if (flipped.count === 0) {
+      throw new OffsiteModerationError(
+        'REPORT_NOT_PENDING',
+        'This report has already been handled.'
+      );
+    }
+    await tx.appListingModerationEvent.create({
+      data: {
+        id: newAppListingModerationEventId(),
+        appListingId: report.appListingId,
+        slug: report.appListing?.slug ?? '(unknown)',
+        action: opts.action,
+        actorUserId: opts.reviewerUserId,
+        reason: note,
+        reportId: opts.reportId,
+        before: { status: 'pending' },
+        after: { status: opts.target },
+      },
+    });
+  });
+}
+
+/** MOD resolve a pending report (pending → resolved). */
+export async function resolveReport(opts: {
+  input: ResolveReportInput;
+  reviewerUserId: number;
+}): Promise<void> {
+  await closeReport({
+    reportId: opts.input.reportId,
+    reviewerUserId: opts.reviewerUserId,
+    note: opts.input.note,
+    target: 'resolved',
+    action: 'report-resolve',
+  });
+}
+
+/** MOD dismiss a pending report (pending → dismissed; no action taken). */
+export async function dismissReport(opts: {
+  input: DismissReportInput;
+  reviewerUserId: number;
+}): Promise<void> {
+  await closeReport({
+    reportId: opts.input.reportId,
+    reviewerUserId: opts.reviewerUserId,
+    note: opts.input.note,
+    target: 'dismissed',
+    action: 'report-dismiss',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// listModerationEvents (moderator) — per-listing append-only audit history.
+// ---------------------------------------------------------------------------
+
+/**
+ * PII-safe moderation-event projection: the audit fields + the acting mod's public
+ * chip ({id,username,image}) + the denormalized slug. No raw actorUserId FK.
+ */
+const moderationEventSelect = {
+  id: true,
+  appListingId: true,
+  slug: true,
+  action: true,
+  reason: true,
+  detail: true,
+  before: true,
+  after: true,
+  reportId: true,
+  createdAt: true,
+  actor: { select: { id: true, username: true, image: true } },
+} as const;
+
+/**
+ * MOD per-listing moderation history, NEWEST-first, keyset-paginated. The cursor is
+ * the event id (`alme_<ULID>`, time-sortable so it tracks the `createdAt desc`
+ * order); the `id` tie-break makes same-millisecond ordering deterministic.
+ */
+export async function listModerationEvents(opts: ListModerationEventsInput) {
+  const limit = Math.min(opts.limit ?? 25, 50);
+  const rows = await dbRead.appListingModerationEvent.findMany({
+    where: { appListingId: opts.appListingId },
+    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+    take: limit + 1,
+    ...(opts.cursor ? { cursor: { id: opts.cursor }, skip: 1 } : {}),
+    select: moderationEventSelect,
   });
   const hasNext = rows.length > limit;
   const items = hasNext ? rows.slice(0, limit) : rows;

--- a/tests/preview-apps-external-delist.spec.ts
+++ b/tests/preview-apps-external-delist.spec.ts
@@ -1,0 +1,227 @@
+import { expect, test } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+import { storageStatePath } from './preview-fixtures';
+import { trpcMutation, trpcQuery } from './preview-trpc';
+
+/**
+ * Preview-e2e: App Blocks W13 P3b PR3 — OFF-SITE moderation ACTIONS (delist /
+ * relist / purge / resolve / dismiss), tRPC-driven, SELF-CLEANING.
+ *
+ * WHAT THIS COVERS (deterministically, in a preview) and WHY NOT the full
+ * approve-success → store-render → delist round-trip:
+ *
+ *   The full "approve an off-site listing, see it in the store, delist it, purge to
+ *   self-clean" round-trip requires a SUCCESSFUL approve, which the dark P1 asset
+ *   gate (`assertListingAssetsComplete`) blocks unless the draft has an icon+cover
+ *   +≥1 screenshot whose backing Image is `ingestion = Scanned`. In a PR preview
+ *   the external image scanner is UNREACHABLE, so uploaded images stay `Pending`
+ *   forever (see `tests/preview-post-images.spec.ts`: "image ingestion … is
+ *   unreachable in preview so the row stays Pending"). An attach of a Pending image
+ *   is rejected ("scan is not complete"), so an off-site listing can NOT reach
+ *   `approved` in preview — the approve→delist→store leg is therefore covered
+ *   EXHAUSTIVELY in the unit/integration tests instead
+ *   (`offsite-moderation.service.mod-actions.test.ts`), not here.
+ *
+ *   `purge` (the PR3 self-clean primitive) DOES solve the P3a "un-cleanable approved
+ *   row" problem the sibling approve spec deferred on — and it works on ANY off-site
+ *   status, so this spec exercises purge END-TO-END on a self-seeded DRAFT (the one
+ *   listing state reachable in preview), plus the report/delist GUARDS (a draft is
+ *   not reportable / not delistable) and the full mod-only AUTHZ matrix. All
+ *   self-cleaning via `purge` / `withdrawExternalRequest`.
+ *
+ * ROLE — `mod` for the action legs (every PR3 proc is `moderatorProcedure`; mod
+ * also authors via the app-blocks-author floor, so a single mod runs submit +
+ * purge), `tester` for the authz-denial matrix.
+ *
+ * GATES (Tekton `pr-smoke-test` is authoritative — do NOT run browser-mode locally
+ * on NixOS). SAFE + SELF-CLEANING: per-preview unique slugs; purge/withdraw in
+ * `finally` so a mid-test failure leaves nothing behind.
+ */
+
+const PREVIEW_URL = process.env.PREVIEW_URL ?? '';
+
+/** Per-preview + per-scenario slug so concurrent previews never collide. */
+function previewSlug(suffix: string): string {
+  let label = 'local';
+  try {
+    label = new URL(PREVIEW_URL).hostname.split('.')[0] || 'local';
+  } catch {
+    /* default */
+  }
+  const sanitized = label.toLowerCase().replace(/[^a-z0-9-]/g, '-');
+  const slug = `ci-del-${suffix}-${sanitized}`.slice(0, 40).replace(/-+$/, '');
+  return /[a-z0-9]$/.test(slug) ? slug : `${slug}0`;
+}
+
+const EXTERNAL_URL = 'https://example.com/ci-smoke-external-delist';
+
+type SubmitResult = { listingId: string; publishRequestId: string; slug: string };
+type ModEventList = { items: Array<{ id: string; action: string }>; nextCursor: string | null };
+
+function submitInput(slug: string) {
+  return {
+    slug,
+    name: 'CI Smoke — external delist/purge (P3b PR3)',
+    externalUrl: EXTERNAL_URL,
+    tagline: 'a pure external-link app',
+    category: 'utility',
+    contentRating: 'g',
+    changelog: 'ci-smoke delist/purge',
+  };
+}
+
+/** Best-effort: flip any leftover pending request for this preview's request id. */
+async function withdrawQuietly(request: APIRequestContext, publishRequestId: string | null) {
+  if (!publishRequestId) return;
+  await trpcMutation(request, 'appListings.withdrawExternalRequest', { publishRequestId }).catch(
+    () => {}
+  );
+}
+
+async function expectRejects(p: Promise<unknown>, why: string): Promise<Error> {
+  const err = await p.then(
+    () => {
+      throw new Error(`expected a rejection: ${why}`);
+    },
+    (e: Error) => e
+  );
+  return err;
+}
+
+test.describe('App Blocks P3b PR3: off-site moderation actions (mod, self-cleaning)', () => {
+  test.use({ storageState: storageStatePath('mod') });
+
+  test('GUARDS: a DRAFT is not reportable / not delistable, and writes ZERO audit events', async ({
+    page,
+  }) => {
+    const SLUG = previewSlug('guard');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    const request = page.request;
+
+    let publishRequestId: string | null = null;
+    try {
+      const result = await trpcMutation<SubmitResult>(
+        request,
+        'appListings.submitExternalListing',
+        submitInput(SLUG)
+      );
+      publishRequestId = result.publishRequestId;
+      const listingId = result.listingId;
+
+      // A draft (non-approved) listing is NOT reportable — the report-state gate
+      // fires (NOT_REPORTABLE → BAD_REQUEST → HTTP 400; trpcMutation throws).
+      await expectRejects(
+        trpcMutation(request, 'appListings.reportListing', { appListingId: listingId, reason: 'spam' }),
+        'reporting a draft listing must be rejected'
+      );
+
+      // A draft is NOT delistable — the status guard (approved-only) fires
+      // (NOT_TRANSITIONABLE → BAD_REQUEST). No event is written on the guarded fail.
+      await expectRejects(
+        trpcMutation(request, 'appListings.delistListing', {
+          appListingId: listingId,
+          reason: 'ci-smoke delist guard probe',
+        }),
+        'delisting a draft listing must be rejected'
+      );
+
+      // The guarded failures wrote NO moderation events (zero-event-on-guard).
+      const history = await trpcQuery<ModEventList>(request, 'appListings.listModerationEvents', {
+        appListingId: listingId,
+      });
+      expect(history.items, 'a guarded/rejected mutation writes no audit event').toHaveLength(0);
+    } finally {
+      await withdrawQuietly(request, publishRequestId);
+    }
+  });
+
+  test('PURGE hard-deletes a listing end-to-end (the self-clean primitive)', async ({ page }) => {
+    const SLUG = previewSlug('purge');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    const request = page.request;
+
+    let publishRequestId: string | null = null;
+    try {
+      const result = await trpcMutation<SubmitResult>(
+        request,
+        'appListings.submitExternalListing',
+        submitInput(SLUG)
+      );
+      publishRequestId = result.publishRequestId;
+      const listingId = result.listingId;
+
+      // PURGE succeeds on an off-site listing regardless of status (here: draft) —
+      // the mod final-expunge that also makes the delist round-trip self-cleaning.
+      const purged = await trpcMutation<{ appListingId: string; purged: boolean }>(
+        request,
+        'appListings.purgeListing',
+        { appListingId: listingId, reason: 'ci-smoke purge cleanup' }
+      );
+      expect(purged.purged, 'purge returns purged:true').toBe(true);
+
+      // The listing is GONE: a second purge → NOT_FOUND (→ HTTP 404; throws).
+      await expectRejects(
+        trpcMutation(request, 'appListings.purgeListing', {
+          appListingId: listingId,
+          reason: 'ci-smoke purge again',
+        }),
+        're-purging a deleted listing must 404'
+      );
+    } finally {
+      // The submit's publish request is now an orphan (appListingId SET NULL by the
+      // purge). Flip it out of the pending queue so nothing lingers.
+      await withdrawQuietly(request, publishRequestId);
+    }
+  });
+});
+
+test.describe('App Blocks P3b PR3: mod actions are moderator-only (tester denied)', () => {
+  test.use({ storageState: storageStatePath('tester') });
+
+  test('a non-mod is FORBIDDEN on every mod action + read', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    const request = page.request;
+
+    // Every mutating mod action → FORBIDDEN (moderatorProcedure; HTTP 403 → throws).
+    // Schema-valid throwaway ids: the middleware denies before the resolver runs.
+    await expectRejects(
+      trpcMutation(request, 'appListings.delistListing', {
+        appListingId: 'apl_ci_authz',
+        reason: 'ci authz probe reason',
+      }),
+      'tester delist must be forbidden'
+    );
+    await expectRejects(
+      trpcMutation(request, 'appListings.relistListing', {
+        appListingId: 'apl_ci_authz',
+        reason: 'ci authz probe reason',
+      }),
+      'tester relist must be forbidden'
+    );
+    await expectRejects(
+      trpcMutation(request, 'appListings.purgeListing', {
+        appListingId: 'apl_ci_authz',
+        reason: 'ci authz probe reason',
+      }),
+      'tester purge must be forbidden'
+    );
+    await expectRejects(
+      trpcMutation(request, 'appListings.resolveReport', { reportId: 'alrp_ci_authz' }),
+      'tester resolveReport must be forbidden'
+    );
+    await expectRejects(
+      trpcMutation(request, 'appListings.dismissReport', { reportId: 'alrp_ci_authz' }),
+      'tester dismissReport must be forbidden'
+    );
+
+    // The mod-only READS (report queue + moderation history) are likewise denied.
+    await expectRejects(
+      trpcQuery(request, 'appListings.listListingReports', {}),
+      'tester listListingReports must be forbidden'
+    );
+    await expectRejects(
+      trpcQuery(request, 'appListings.listModerationEvents', { appListingId: 'apl_ci_authz' }),
+      'tester listModerationEvents must be forbidden'
+    );
+  });
+});


### PR DESCRIPTION
## What

The moderator **takedown loop** for approved off-site `AppListing`s — **UI-dark** (mods only; the takedown affordance renders solely on the mod-only `/apps/review` page). Builds on **PR1** (data model + manual migrations, merged) and **PR2** (report backend `reportListing`/`listListingReports`, merged). `claimListing` is deliberately **OUT** — it lands in a separate **PR4**.

## Dark posture

**UI-dark, not flag-gated on the server.** Every new proc's server gate is `moderatorProcedure` + an inner `isModerator` recheck; the report-queue UI renders only on the mod-only `/apps/review` page. The `app-blocks-enabled` flag darkens the *UI* only — mods bypass it anyway, so an `enforceAppBlocksFlag` on these procs would be **inert** (deliberately omitted). No new Flipt flag; no store widening; `deIndex` untouched. Reviewer is always bound to `ctx.user.id` (never client-supplied).

## The 5 service procs (`offsite-moderation.service.ts`)

Each writes **exactly one** `AppListingModerationEvent` in the **same tx** as its mutation (a crash can't split the mutation from its audit record). Offsite-only (kind guard); a missing listing and an on-site listing both raise the same generic `NOT_FOUND` (no kind/existence probing).

- **`delistListing`** — `approved → removed`, status+kind-guarded `updateMany`; drops out of the approved-only store read path automatically (no read-path change). Optionally resolves a linked `reportId` in the same tx — **scoped to the delisted listing** (`{ id, appListingId, status:'pending' }`), so a mismatched `reportId` can't close another listing's report.
- **`relistListing`** — `removed → approved` (reversibility), status-guarded.
- **`purgeListing`** — hard delete. Re-reads the pre-delete status/slug/kind **inside the tx from the primary** (replica-lag-proof snapshot), writes the audit event **FIRST**, then deletes the row (inline `kind:'offsite'` guard). The event row survives at the **ROW level** for audit/compliance via the `ON DELETE SET NULL` FK + the denormalized `slug` snapshot (screenshots/reports cascade). See the forensic-retrievability caveat under **Post-audit fixes**. The self-clean primitive + a genuine spam-expunge.
- **`resolveReport` / `dismissReport`** — `pending → resolved/dismissed` + audit event; sets `resolvedBy*`.
- **`listModerationEvents`** — per-listing audit history (keyset, PII-safe projection).

A status-guarded 0-count rolls the whole tx back **before** the audit write → **zero events on a guarded/failed mutation**. Reuses PR2's `OffsiteModerationError` + `mapOffsiteError` generic-message discipline (typed→TRPC code, no infra leak).

## Post-audit fixes (latest commit)

An adversarial audit returned "safe to merge (as dark), no 🔴". These are the cheap correctness/integrity items it surfaced:

- **🟡 Delist report-resolve scoped to the listing** — the in-tx `updateMany` now filters on `appListingId` too, so `delistListing({appListingId:A, reportId:<pending report for B>})` matches 0 rows (silent no-op — the delist of A still succeeds; B's report is left untouched) instead of resolving an unrelated report and writing an A-event that links B's report.
- **🟡 Purge `before`-snapshot from the tx/primary** — the pre-delete `status/slug/kind` is re-read **inside the `$transaction` from the primary**, not the replica `classifyOffsiteListing`, so replica lag can't stamp a stale `before.status` (e.g. `approved` on a row already `removed`). The replica classify is kept only as a fail-fast + info-leak-parity gate.
- **🟢 Purge delete `kind:'offsite'` guard** — the `deleteMany` WHERE carries the inline offsite guard for defense-in-depth symmetry with delist/relist on the destructive op (a 0-count then rolls the tx, incl. the event, back).
- **🟢 Framing corrections** — (a) purge's "events survive" wording softened to **forensic/row-level only**: purged events survive at the row level for compliance but are **NOT retrievable via `listModerationEvents({appListingId})`** once the FK is `SetNull`'d — only via the actor index / raw SQL; (b) the dark-posture wording corrected to "UI-dark; server gate is `moderatorProcedure` + `isModerator`".

### Deferred to pre-GA (documented, not built here)

- **Slug-keyed / orphaned-events read path** for purged listings — post-purge a listing's moderation events are forensic-only (actor index / raw SQL). A per-slug read that re-surfaces them in the mod history is deferred to pre-GA.
- **Auto-clearing sibling pending reports on delist** — a delist resolves at most the one linked `reportId`; other pending reports against the same listing are left for the mod to clear individually (workflow decision, deferred).

## UI

A **"Reports" tab** on `/apps/review` (`OffsiteReportsQueue`): the report queue with per-row **Delist / Relist / Purge / Resolve / Dismiss** actions (+ a reason/note field; **Purge behind a destructive confirm**) and a per-listing **moderation-history** modal. The report-row→action-set + status/action→chip logic is extracted into a **pure, unit-tested view-model** (`appListingModerationView.ts`).

## Tests (61, all passing)

- **Service** (mod-actions, 23): delist/relist/purge/resolve/dismiss transitions + status/kind guards + zero-event-on-guard + purge **event-before-delete** ordering + audit-event correctness; **post-audit**: cross-listing `reportId` no-op (delist still succeeds), purge snapshot from the in-tx primary vs a stale replica, vanished-between-classify → NOT_FOUND, purge deleteMany `kind` guard; `listModerationEvents` keyset + PII-safe projection.
- **Router authz matrix**: every mod action FORBIDDEN for a tester; `mapOffsiteError` typed→code, no leak; `claimListing` **absent** (PR4).
- **Pure view-model** tests + a **migration-agreement** test (mod-events action CHECK ⟺ code tuple; hyphen form `report-resolve`/`report-dismiss`).
- **e2e** (`tests/preview-apps-external-delist.spec.ts`, tRPC-driven, self-cleaning): `purge` hard-delete **end-to-end** + report/delist **guards** on a draft + the mod-only **authz matrix**.
  - The approve-success → store-render → delist round-trip is covered **in the unit tests, not the preview**: the external image scanner is unreachable in a PR preview (uploaded images stay `Pending`, see `preview-post-images.spec.ts`), so the P1 asset gate can't pass → an off-site listing can't reach `approved` in preview. `purge` still self-cleans everything the preview *can* create.

## 🔴 Manual-migration gate — ALL THREE before activation (rule #8)

The whole loop is **MANUAL-APPLY** (rule #8: no auto-apply on the civitai DB). Apply to the **dev clone before this PR's preview runs** and to **prod nvme0 before `main → release`**:

1. **`AppListingReport`** table (PR1) — else `reportListing` 500s.
2. **`AppListingModerationEvent`** table (PR1) — else every mod action 500s (its in-tx audit `create` fails).
3. **`AppListing.status` CHECK ALTER** adding `removed` (PR3) — else the first `removed` write hits `23514` → 500.

The `.sql` for all three shipped in PR1/PR3; the migration-agreement unit tests catch code/DDL drift at CI. PR4 (`claimListing`) follows on `main` after this merges.

## Not merged

Opened for review; **do not merge**. Worktree left in place for inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
