### PR TITLE
W13 P3b PR4 — off-site claimListing (mod-arbitrated ownership reassignment) [DARK]

### DIFF
--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -10,6 +10,7 @@ import {
   List,
   Loader,
   Modal,
+  NumberInput,
   SegmentedControl,
   Stack,
   Table,
@@ -680,11 +681,15 @@ function ReportActionModal({
 }) {
   const utils = trpc.useUtils();
   const [text, setText] = useState('');
+  // The claim target-owner id (a numeric userId; a mod may reassign to any real
+  // user). Empty until the mod types one — claim submit is gated on a positive int.
+  const [targetUserId, setTargetUserId] = useState<number | ''>('');
 
   async function afterSuccess(message: string) {
     showSuccessNotification({ message });
     await utils.appListings.listListingReports.invalidate();
     setText('');
+    setTargetUserId('');
     onClose();
   }
   function onError(title: string) {
@@ -699,6 +704,10 @@ function ReportActionModal({
   const relistMut = trpc.appListings.relistListing.useMutation({
     onSuccess: () => afterSuccess('Listing relisted.'),
     onError: onError('Relist failed'),
+  });
+  const claimMut = trpc.appListings.claimListing.useMutation({
+    onSuccess: () => afterSuccess('Ownership reassigned.'),
+    onError: onError('Claim failed'),
   });
   const purgeMut = trpc.appListings.purgeListing.useMutation({
     onSuccess: () => afterSuccess('Listing purged.'),
@@ -716,15 +725,22 @@ function ReportActionModal({
   const busy =
     delistMut.isPending ||
     relistMut.isPending ||
+    claimMut.isPending ||
     purgeMut.isPending ||
     resolveMut.isPending ||
     dismissMut.isPending;
 
   if (!pending) return null;
   const { action, report } = pending;
-  const reasonRequired = action === 'delist' || action === 'relist' || action === 'purge';
+  const reasonRequired =
+    action === 'delist' || action === 'relist' || action === 'claim' || action === 'purge';
+  const isClaim = action === 'claim';
   const trimmed = text.trim();
-  const canSubmit = !busy && (!reasonRequired || trimmed.length >= OFFSITE_MOD_REASON_MIN);
+  const validTarget = typeof targetUserId === 'number' && Number.isInteger(targetUserId) && targetUserId > 0;
+  const canSubmit =
+    !busy &&
+    (!reasonRequired || trimmed.length >= OFFSITE_MOD_REASON_MIN) &&
+    (!isClaim || validTarget);
 
   function submit() {
     switch (action) {
@@ -736,6 +752,14 @@ function ReportActionModal({
         });
       case 'relist':
         return relistMut.mutate({ appListingId: report.appListingId, reason: trimmed });
+      case 'claim':
+        // Narrow to a concrete number (validTarget alone doesn't narrow the union).
+        if (typeof targetUserId !== 'number' || !validTarget) return;
+        return claimMut.mutate({
+          appListingId: report.appListingId,
+          targetUserId,
+          reason: trimmed,
+        });
       case 'purge':
         return purgeMut.mutate({ appListingId: report.appListingId, reason: trimmed });
       case 'resolve':
@@ -751,6 +775,7 @@ function ReportActionModal({
       onClose={() => {
         if (busy) return;
         setText('');
+        setTargetUserId('');
         onClose();
       }}
       title={
@@ -770,6 +795,27 @@ function ReportActionModal({
               (with the slug snapshot) is kept. This cannot be undone.
             </Text>
           </Alert>
+        )}
+        {isClaim && (
+          <>
+            <Alert color="blue" variant="light" icon={<IconAlertTriangle size={16} />}>
+              <Text size="sm">
+                Reassigns the listing OWNER to the user id below (verify ownership out-of-band
+                first). The original submission record is preserved. Reversible via a later claim.
+              </Text>
+            </Alert>
+            <NumberInput
+              label="New owner user id"
+              placeholder="e.g. 12345"
+              value={targetUserId}
+              onChange={(v) => setTargetUserId(typeof v === 'number' ? v : '')}
+              min={1}
+              allowNegative={false}
+              allowDecimal={false}
+              disabled={busy}
+              data-testid="apps-report-claim-target"
+            />
+          </>
         )}
         <Textarea
           label={reasonRequired ? `Reason (≥${OFFSITE_MOD_REASON_MIN} chars, audited)` : 'Note (optional)'}
@@ -791,6 +837,7 @@ function ReportActionModal({
             variant="default"
             onClick={() => {
               setText('');
+              setTargetUserId('');
               onClose();
             }}
             disabled={busy}

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -759,6 +759,10 @@ function ReportActionModal({
           appListingId: report.appListingId,
           targetUserId,
           reason: trimmed,
+          // The claim here is always initiated from a report row (the impersonation
+          // report → delist → claim flow), so link + resolve that report in the same
+          // tx — exactly like the delist action above.
+          reportId: report.id,
         });
       case 'purge':
         return purgeMut.mutate({ appListingId: report.appListingId, reason: trimmed });
@@ -875,6 +879,23 @@ type ModEvent = {
 
 type ModEventList = { items: ModEvent[]; nextCursor: string | null };
 
+/**
+ * The ownership transfer carried by a `claim` event's `{userId}`-shaped before/after.
+ * Returns null for any non-claim event (delist/relist/purge/report-* carry a
+ * `{status}`-shaped before/after instead), so the history row only renders the
+ * transfer for claims — it never mis-reads a status event's payload. before/after are
+ * typed `unknown` (JSON columns), so each userId is narrowed to a number defensively.
+ */
+function claimOwnerTransfer(e: ModEvent): { from: number | null; to: number | null } | null {
+  if (e.action !== 'claim') return null;
+  const before = (e.before ?? null) as { userId?: unknown } | null;
+  const after = (e.after ?? null) as { userId?: unknown } | null;
+  const from = typeof before?.userId === 'number' ? before.userId : null;
+  const to = typeof after?.userId === 'number' ? after.userId : null;
+  if (from === null && to === null) return null;
+  return { from, to };
+}
+
 /** Read-only per-listing moderation history (newest-first audit trail). */
 function ModerationHistoryModal({
   report,
@@ -920,6 +941,7 @@ function ModerationHistoryModal({
         <Stack gap="xs">
           {events.map((e) => {
             const chip = moderationActionChip(e.action);
+            const transfer = claimOwnerTransfer(e);
             return (
               <Card key={e.id} withBorder p="sm">
                 <Group justify="space-between" gap="xs">
@@ -935,6 +957,11 @@ function ModerationHistoryModal({
                     {formatDate(e.createdAt)}
                   </Text>
                 </Group>
+                {transfer && (
+                  <Text size="xs" c="dimmed" mt={4} data-testid={`apps-mod-event-owner-${e.id}`}>
+                    owner: {transfer.from ?? '?'} → {transfer.to ?? '?'}
+                  </Text>
+                )}
                 {e.reason && (
                   <Text size="sm" mt={4} style={{ whiteSpace: 'pre-wrap' }}>
                     {e.reason}

--- a/src/components/Apps/__tests__/appListingModerationView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationView.test.ts
@@ -18,17 +18,19 @@ import { APP_LISTING_MODERATION_ACTIONS } from '~/server/schema/blocks/offsite-m
  */
 
 describe('reportRowActions — the per-row action set', () => {
-  it('an APPROVED listing with a PENDING report offers delist + resolve + dismiss', () => {
+  it('an APPROVED listing with a PENDING report offers delist + claim + resolve + dismiss', () => {
     expect(reportRowActions({ reportStatus: 'pending', listingStatus: 'approved' })).toEqual([
       'delist',
+      'claim',
       'resolve',
       'dismiss',
     ]);
   });
 
-  it('a REMOVED listing with a PENDING report offers relist + purge + resolve + dismiss', () => {
+  it('a REMOVED listing with a PENDING report offers relist + claim + purge + resolve + dismiss', () => {
     expect(reportRowActions({ reportStatus: 'pending', listingStatus: 'removed' })).toEqual([
       'relist',
+      'claim',
       'purge',
       'resolve',
       'dismiss',
@@ -38,11 +40,26 @@ describe('reportRowActions — the per-row action set', () => {
   it('a resolved/dismissed report offers NO report actions (only listing actions remain)', () => {
     expect(reportRowActions({ reportStatus: 'resolved', listingStatus: 'approved' })).toEqual([
       'delist',
+      'claim',
     ]);
     expect(reportRowActions({ reportStatus: 'dismissed', listingStatus: 'removed' })).toEqual([
       'relist',
+      'claim',
       'purge',
     ]);
+  });
+
+  it('claim is offered on BOTH an approved and a removed listing (a mod may reclaim either)', () => {
+    expect(reportRowActions({ reportStatus: 'pending', listingStatus: 'approved' })).toContain(
+      'claim'
+    );
+    expect(reportRowActions({ reportStatus: 'pending', listingStatus: 'removed' })).toContain(
+      'claim'
+    );
+    // …but NOT on a gone/unknown-status listing (no listing-level actions at all).
+    expect(reportRowActions({ reportStatus: 'pending', listingStatus: null })).not.toContain(
+      'claim'
+    );
   });
 
   it('purge is ONLY offered on a removed listing (never on an approved/live one)', () => {
@@ -64,7 +81,7 @@ describe('reportRowActions — the per-row action set', () => {
 describe('isDestructiveAction', () => {
   it('only purge is destructive', () => {
     expect(isDestructiveAction('purge')).toBe(true);
-    for (const a of ['delist', 'relist', 'resolve', 'dismiss'] as ReportRowAction[]) {
+    for (const a of ['delist', 'relist', 'claim', 'resolve', 'dismiss'] as ReportRowAction[]) {
       expect(isDestructiveAction(a)).toBe(false);
     }
   });
@@ -100,9 +117,9 @@ describe('chips', () => {
 
 describe('reportActionLabel', () => {
   it('gives a distinct human label for each action', () => {
-    const labels = (['delist', 'relist', 'purge', 'resolve', 'dismiss'] as ReportRowAction[]).map(
-      reportActionLabel
-    );
+    const labels = (
+      ['delist', 'relist', 'claim', 'purge', 'resolve', 'dismiss'] as ReportRowAction[]
+    ).map(reportActionLabel);
     expect(new Set(labels).size).toBe(labels.length);
     for (const l of labels) expect(l.trim().length).toBeGreaterThan(0);
   });

--- a/src/components/Apps/appListingModerationView.ts
+++ b/src/components/Apps/appListingModerationView.ts
@@ -13,7 +13,7 @@
  */
 
 /** The mod actions a report row can offer (a subset renders per row). */
-export type ReportRowAction = 'delist' | 'relist' | 'purge' | 'resolve' | 'dismiss';
+export type ReportRowAction = 'delist' | 'relist' | 'claim' | 'purge' | 'resolve' | 'dismiss';
 
 /** A pill descriptor: a human label + a Mantine color name. */
 export type Chip = { label: string; color: string };
@@ -26,6 +26,10 @@ export type Chip = { label: string; color: string };
  *     be re-closed).
  *   - delist: only while the listing is `approved` (delist is approved→removed).
  *   - relist: only while the listing is `removed` (relist is removed→approved).
+ *   - claim: on either a live (`approved`) OR a delisted (`removed`) listing — a
+ *     mod-verified owner may reclaim either. The report queue only lists OFF-SITE
+ *     reports (the report table is offsite-only), so the service's kind guard is
+ *     implicitly satisfied here (no kind input needed at the view-model layer).
  *   - purge: only once the listing is `removed` — a mod delists first, THEN purges;
  *     this keeps the destructive hard-delete off a still-live approved listing in
  *     the queue UI (the service itself allows purge on any status, but the queue
@@ -42,9 +46,13 @@ export function reportRowActions(input: {
   const actions: ReportRowAction[] = [];
   const listingStatus = input.listingStatus ?? null;
 
-  if (listingStatus === 'approved') actions.push('delist');
+  if (listingStatus === 'approved') {
+    actions.push('delist');
+    actions.push('claim');
+  }
   if (listingStatus === 'removed') {
     actions.push('relist');
+    actions.push('claim');
     actions.push('purge');
   }
   if (input.reportStatus === 'pending') {
@@ -105,6 +113,8 @@ export function reportActionLabel(action: ReportRowAction): string {
       return 'Delist';
     case 'relist':
       return 'Relist';
+    case 'claim':
+      return 'Claim';
     case 'purge':
       return 'Purge';
     case 'resolve':

--- a/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
@@ -5,18 +5,20 @@ import { TRPCError } from '@trpc/server';
  * W13 P3b PR3 — off-site mod-ACTION router AUTHZ matrix + error mapping.
  *
  * Drives the REAL `appListingsRouter` via `createCaller` so the middleware wiring
- * decides: delist / relist / purge / resolveReport / dismissReport /
+ * decides: delist / relist / claim / purge / resolveReport / dismissReport /
  * listModerationEvents are ALL `moderatorProcedure` (+ the inner `isModerator`
  * recheck) → a tester (non-mod) is FORBIDDEN on every one, a mod passes with the
  * reviewer bound to `ctx.user.id`, and typed `OffsiteModerationError`s map through
- * `mapOffsiteError` (NOT_FOUND→NOT_FOUND, NOT_TRANSITIONABLE→BAD_REQUEST,
- * unexpected infra→INTERNAL with no raw leak). The `claimListing` proc does NOT
- * exist yet (PR4) — asserted by absence.
+ * `mapOffsiteError` (NOT_FOUND→NOT_FOUND, NOT_TRANSITIONABLE/INVALID_TARGET_USER→
+ * BAD_REQUEST, unexpected infra→INTERNAL with no raw leak). `claimListing` (PR4) is
+ * `moderatorProcedure` — there is deliberately NO `protectedProcedure` self-claim
+ * endpoint (mod-only is the whole boundary), asserted by the caller-proc probe.
  */
 
 const {
   mockDelist,
   mockRelist,
+  mockClaim,
   mockPurge,
   mockResolve,
   mockDismiss,
@@ -28,6 +30,7 @@ const {
 } = vi.hoisted(() => ({
   mockDelist: vi.fn(async () => ({ appListingId: 'apl_1', status: 'removed' as const })),
   mockRelist: vi.fn(async () => ({ appListingId: 'apl_1', status: 'approved' as const })),
+  mockClaim: vi.fn(async () => ({ appListingId: 'apl_1', userId: 42 })),
   mockPurge: vi.fn(async () => ({ appListingId: 'apl_1', purged: true as const })),
   mockResolve: vi.fn(async () => undefined),
   mockDismiss: vi.fn(async () => undefined),
@@ -43,6 +46,7 @@ vi.mock('~/server/services/blocks/offsite-moderation.service', () => ({
   listListingReports: mockListReports,
   delistListing: mockDelist,
   relistListing: mockRelist,
+  claimListing: mockClaim,
   purgeListing: mockPurge,
   resolveReport: mockResolve,
   dismissReport: mockDismiss,
@@ -110,6 +114,11 @@ const MOD_ACTIONS: Array<{
     call: (c) => c.relistListing({ appListingId: 'apl_1', reason: REASON }),
   },
   {
+    name: 'claimListing',
+    mock: mockClaim,
+    call: (c) => c.claimListing({ appListingId: 'apl_1', targetUserId: 42, reason: REASON }),
+  },
+  {
     name: 'purgeListing',
     mock: mockPurge,
     call: (c) => c.purgeListing({ appListingId: 'apl_1', reason: REASON }),
@@ -154,13 +163,19 @@ describe('mod actions — every one is moderator-only', () => {
 });
 
 describe('mod actions — reviewer id is bound to ctx (never client-supplied)', () => {
-  it('delist/relist/purge pass reviewerUserId = ctx.user.id', async () => {
+  it('delist/relist/claim/purge pass reviewerUserId = ctx.user.id', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
     await caller.delistListing({ appListingId: 'apl_1', reason: REASON });
     await caller.relistListing({ appListingId: 'apl_1', reason: REASON });
+    await caller.claimListing({ appListingId: 'apl_1', targetUserId: 42, reason: REASON });
     await caller.purgeListing({ appListingId: 'apl_1', reason: REASON });
     expect(mockDelist.mock.calls[0][0]).toMatchObject({ reviewerUserId: mod.id });
     expect(mockRelist.mock.calls[0][0]).toMatchObject({ reviewerUserId: mod.id });
+    // claim forwards the whole input (targetUserId) + the ctx-bound reviewer.
+    expect(mockClaim.mock.calls[0][0]).toMatchObject({
+      reviewerUserId: mod.id,
+      input: { appListingId: 'apl_1', targetUserId: 42, reason: REASON },
+    });
     expect(mockPurge.mock.calls[0][0]).toMatchObject({ reviewerUserId: mod.id });
   });
 
@@ -199,6 +214,19 @@ describe('mod actions — error mapping via mapOffsiteError', () => {
     });
   });
 
+  it('a typed INVALID_TARGET_USER (claim) maps to BAD_REQUEST with the friendly message', async () => {
+    mockClaim.mockRejectedValueOnce(
+      offsiteModErr('INVALID_TARGET_USER', 'The target user could not be found.')
+    );
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(
+      caller.claimListing({ appListingId: 'apl_1', targetUserId: 999999, reason: REASON })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('target user'),
+    });
+  });
+
   it('an unexpected infra error maps to INTERNAL without leaking the raw message', async () => {
     const raw = 'connect ECONNREFUSED 10.0.0.5:5432 postgres://secret-dsn';
     mockPurge.mockRejectedValueOnce(new Error(raw));
@@ -221,10 +249,24 @@ describe('mod actions — error mapping via mapOffsiteError', () => {
     ).rejects.toBeInstanceOf(TRPCError);
     expect(mockDelist).not.toHaveBeenCalled();
   });
+
+  it('rejects a too-short claim reason + a non-positive targetUserId at the SCHEMA boundary', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(
+      caller.claimListing({ appListingId: 'apl_1', targetUserId: 42, reason: 'x' })
+    ).rejects.toBeInstanceOf(TRPCError);
+    await expect(
+      caller.claimListing({ appListingId: 'apl_1', targetUserId: 0, reason: REASON })
+    ).rejects.toBeInstanceOf(TRPCError);
+    await expect(
+      caller.claimListing({ appListingId: 'apl_1', targetUserId: -5, reason: REASON })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockClaim).not.toHaveBeenCalled();
+  });
 });
 
-describe('claimListing is NOT exposed in PR3 (it is PR4)', () => {
-  it('the router exposes the 5 PR3 mod actions but NOT claimListing', () => {
+describe('claimListing (PR4) is exposed as moderator-only — NO self-service endpoint', () => {
+  it('the router exposes claimListing alongside the other mod actions', () => {
     // The tRPC caller proxy fabricates a function for ANY path, so probe the router
     // DEFINITION's procedure record (the source of truth) instead of the caller.
     const procs = Object.keys(
@@ -234,6 +276,7 @@ describe('claimListing is NOT exposed in PR3 (it is PR4)', () => {
     for (const p of [
       'delistListing',
       'relistListing',
+      'claimListing',
       'purgeListing',
       'resolveReport',
       'dismissReport',
@@ -241,6 +284,16 @@ describe('claimListing is NOT exposed in PR3 (it is PR4)', () => {
     ]) {
       expect(procs).toContain(p);
     }
-    expect(procs).not.toContain('claimListing');
+  });
+
+  it('there is EXACTLY ONE claim endpoint (no separate protectedProcedure self-claim)', () => {
+    // The mod-only gate is the whole boundary: a user cannot claim their own listing.
+    // Assert by absence — no `claimMyListing`/`requestClaim`/`selfClaim`-style proc.
+    const procs = Object.keys(
+      (appListingsRouter as unknown as { _def: { procedures: Record<string, unknown> } })._def
+        .procedures
+    );
+    const claimProcs = procs.filter((p) => /claim/i.test(p));
+    expect(claimProcs).toEqual(['claimListing']);
   });
 });

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -24,6 +24,7 @@ import {
   withdrawExternalRequestSchema,
 } from '~/server/schema/blocks/offsite-listing.schema';
 import {
+  claimListingSchema,
   delistListingSchema,
   dismissReportSchema,
   listListingReportsSchema,
@@ -482,7 +483,7 @@ export const appListingsRouter = router({
     }),
 
   // -------------------------------------------------------------------------
-  // P3b PR3 mod ACTIONS — delist / relist / purge / resolve / dismiss.
+  // P3b PR3/PR4 mod ACTIONS — delist / relist / claim / purge / resolve / dismiss.
   //
   // Posture: UI-dark (the mod takedown affordance renders only on the mod-only
   // store-preview surface). The SERVER gate is `moderatorProcedure` + the inner
@@ -491,8 +492,9 @@ export const appListingsRouter = router({
   // anyway, so `enforceAppBlocksFlag` here would be inert (deliberately omitted).
   // Plus `mapOffsiteError` (typed → TRPC code, no infra leak). The reviewer is bound
   // to `ctx.user.id` — never client-supplied. Each writes exactly one
-  // `AppListingModerationEvent` in the same tx as its mutation. `claimListing` is a
-  // separate PR4. All offsite-only.
+  // `AppListingModerationEvent` in the same tx as its mutation. `claimListing` (PR4)
+  // reassigns ownership — there is NO self-service claim endpoint (mod-only is the
+  // whole boundary). All offsite-only.
   // -------------------------------------------------------------------------
 
   /**
@@ -525,6 +527,32 @@ export const appListingsRouter = router({
       const { relistListing } = await import('~/server/services/blocks/offsite-moderation.service');
       try {
         return await relistListing({ input, reviewerUserId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /**
+   * MOD claim (reassign ownership of) an approved/removed off-site listing (PR4) —
+   * the mod-arbitrated ownership transfer. Reassigns `AppListing.userId` to a
+   * mod-verified `targetUserId`; the historical `AppListingPublishRequest`
+   * submitter is left INTACT. `moderatorProcedure` + `isModerator` recheck is the
+   * WHOLE trust boundary — there is deliberately NO `protectedProcedure` self-claim
+   * endpoint (a user cannot claim their own listing). Typed failures map via
+   * `mapOffsiteError` (NOT_FOUND→NOT_FOUND, NOT_TRANSITIONABLE/INVALID_TARGET_USER→
+   * BAD_REQUEST, infra→INTERNAL with no leak).
+   */
+  claimListing: moderatorProcedure
+    .input(claimListingSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError(
+          'Reassigning off-site listings is restricted to civitai team'
+        );
+      }
+      const { claimListing } = await import('~/server/services/blocks/offsite-moderation.service');
+      try {
+        return await claimListing({ input, reviewerUserId: ctx.user.id });
       } catch (err) {
         throw mapOffsiteError(err);
       }

--- a/src/server/schema/blocks/offsite-moderation.schema.ts
+++ b/src/server/schema/blocks/offsite-moderation.schema.ts
@@ -133,11 +133,16 @@ export type RelistListingInput = z.infer<typeof relistListingSchema>;
  * — never client-supplied. There is NO self-service / `protectedProcedure` claim
  * endpoint: a mod is the whole trust boundary (a mod MAY reassign to any real user,
  * including resolving an impersonation by re-pointing to the verified owner).
+ *
+ * `reportId` optionally links the report that triggered the claim (the substantive
+ * resolution of an impersonation report → delist → claim → ban flow) — resolved in
+ * the same tx, listing-scoped, exactly like `delistListingSchema.reportId`.
  */
 export const claimListingSchema = z.object({
   appListingId: z.string().min(1).max(64),
   targetUserId: z.number().int().positive(),
   reason: modReason,
+  reportId: z.string().min(1).max(64).optional(),
 });
 export type ClaimListingInput = z.infer<typeof claimListingSchema>;
 

--- a/src/server/schema/blocks/offsite-moderation.schema.ts
+++ b/src/server/schema/blocks/offsite-moderation.schema.ts
@@ -125,6 +125,23 @@ export const relistListingSchema = z.object({
 export type RelistListingInput = z.infer<typeof relistListingSchema>;
 
 /**
+ * MOD claim (reassign ownership of) an off-site listing (PR4) — mod-arbitrated
+ * ownership transfer of an `approved` OR `removed` off-site listing to a
+ * mod-verified owner. `targetUserId` is the numeric id of the NEW owner (a real
+ * `User`, validated in the service); `reason` is the required ownership-verification
+ * audit note. The reviewer (the acting mod) is bound to `ctx.user.id` in the service
+ * — never client-supplied. There is NO self-service / `protectedProcedure` claim
+ * endpoint: a mod is the whole trust boundary (a mod MAY reassign to any real user,
+ * including resolving an impersonation by re-pointing to the verified owner).
+ */
+export const claimListingSchema = z.object({
+  appListingId: z.string().min(1).max(64),
+  targetUserId: z.number().int().positive(),
+  reason: modReason,
+});
+export type ClaimListingInput = z.infer<typeof claimListingSchema>;
+
+/**
  * MOD hard-delete (purge) an off-site listing — the final expunge that also makes
  * the delist round-trip self-cleaning. Destructive: the UI gates it behind a
  * confirm. `reason` required for the audit event (which SURVIVES the delete via

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -278,7 +278,48 @@ describe('claimListing', () => {
       reason: GOOD_REASON,
       before: { userId: OLD_OWNER },
       after: { userId: TARGET },
+      reportId: null,
     });
+    // No linked report → the report table is untouched.
+    expect(mockWrite.appListingReport.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('with a reportId, resolves that report in the SAME tx (status+listing-scoped) + links it on the event', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('approved'));
+    await claimListing({
+      input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON, reportId: REPORT_ID },
+      reviewerUserId: REVIEWER,
+    });
+    // Scoped to THIS listing (appListingId) AND pending — a reportId for another
+    // listing can't be closed by this claim (mirrors delist EXACTLY).
+    expect(mockWrite.appListingReport.updateMany).toHaveBeenCalledWith({
+      where: { id: REPORT_ID, appListingId: APP_ID, status: 'pending' },
+      data: { status: 'resolved', resolvedByUserId: REVIEWER, resolvedAt: expect.any(Date) },
+    });
+    // The claim event carries the reportId link.
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.reportId).toBe(REPORT_ID);
+  });
+
+  it('a reportId belonging to a DIFFERENT listing is NOT resolved (0-row no-op); the claim still succeeds', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('approved'));
+    // The listing-scoped, status-guarded updateMany matches 0 rows (report is for
+    // another listing) — the claim must still succeed (silent no-op).
+    mockWrite.appListingReport.updateMany.mockResolvedValueOnce({ count: 0 });
+    const res = await claimListing({
+      input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON, reportId: REPORT_ID },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, userId: TARGET });
+    // The WHERE is scoped to THIS listing, so a cross-listing report can never match.
+    expect(mockWrite.appListingReport.updateMany).toHaveBeenCalledWith({
+      where: { id: REPORT_ID, appListingId: APP_ID, status: 'pending' },
+      data: { status: 'resolved', resolvedByUserId: REVIEWER, resolvedAt: expect.any(Date) },
+    });
+    // The claim event still stands + still links the supplied reportId.
+    expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.action).toBe('claim');
   });
 
   it('reassigns userId on a REMOVED (delisted) listing too', async () => {

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -3,6 +3,7 @@ import { TRPCError } from '@trpc/server';
 
 import {
   OffsiteModerationError,
+  claimListing,
   delistListing,
   dismissReport,
   listModerationEvents,
@@ -25,11 +26,15 @@ type WriteMock = {
   appListing: {
     updateMany: ReturnType<typeof vi.fn>;
     deleteMany: ReturnType<typeof vi.fn>;
-    // purge re-reads the pre-delete snapshot on the PRIMARY inside the tx.
+    // purge + claim re-read the pre-mutation snapshot on the PRIMARY inside the tx.
     findUnique: ReturnType<typeof vi.fn>;
   };
   appListingModerationEvent: { create: ReturnType<typeof vi.fn> };
   appListingReport: { updateMany: ReturnType<typeof vi.fn> };
+  // claim validates the target owner on the primary inside the tx.
+  user: { findUnique: ReturnType<typeof vi.fn> };
+  // NEVER touched by claim (the submitter record is preserved) — asserted by absence.
+  appListingPublishRequest: { updateMany: ReturnType<typeof vi.fn> };
 };
 type ReadMock = {
   appListing: { findUnique: ReturnType<typeof vi.fn> };
@@ -47,6 +52,8 @@ const { mockRead, mockWrite, ids } = vi.hoisted(() => {
     },
     appListingModerationEvent: { create: vi.fn(async (a: { data: unknown }) => a.data) },
     appListingReport: { updateMany: vi.fn(async () => ({ count: 1 })) },
+    user: { findUnique: vi.fn(async () => ({ id: 1 })) },
+    appListingPublishRequest: { updateMany: vi.fn(async () => ({ count: 1 })) },
   };
   // The tx client is the write mock itself, so tx.* calls land on the same spies.
   write.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) => cb(write));
@@ -87,6 +94,9 @@ beforeEach(() => {
   mockWrite.appListing.findUnique.mockResolvedValue(offsiteListing('removed'));
   mockWrite.appListingModerationEvent.create.mockImplementation(async (a: { data: unknown }) => a.data);
   mockWrite.appListingReport.updateMany.mockResolvedValue({ count: 1 });
+  // claim: default the target-owner lookup to a real user + the reassign to 1 row.
+  mockWrite.user.findUnique.mockResolvedValue({ id: 42 });
+  mockWrite.appListingPublishRequest.updateMany.mockResolvedValue({ count: 1 });
   mockRead.appListing.findUnique.mockResolvedValue(null);
   mockRead.appListingReport.findUnique.mockResolvedValue(null);
   mockRead.appListingModerationEvent.findMany.mockResolvedValue([]);
@@ -227,6 +237,160 @@ describe('relistListing', () => {
       relistListing({ input: { appListingId: APP_ID, reason: 'appeal upheld' }, reviewerUserId: REVIEWER })
     ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claimListing
+// ---------------------------------------------------------------------------
+
+describe('claimListing', () => {
+  const OLD_OWNER = 500;
+  const TARGET = 42;
+
+  /** The in-tx PRIMARY snapshot shape claim reads (userId + status + slug + kind). */
+  function primarySnapshot(status: string, kind = 'offsite', userId = OLD_OWNER) {
+    return { userId, status, slug: SLUG, kind };
+  }
+
+  it('reassigns userId on an APPROVED listing + writes exactly ONE claim event (before/after userId)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('approved'));
+    const res = await claimListing({
+      input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, userId: TARGET });
+
+    // The reassign is status+kind-guarded (approved|removed, offsite-only).
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'offsite', status: { in: ['approved', 'removed'] } },
+      data: { userId: TARGET },
+    });
+    // Exactly ONE audit event, capturing the ownership transfer.
+    expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    const data = mockWrite.appListingModerationEvent.create.mock.calls[0][0].data;
+    expect(data).toMatchObject({
+      appListingId: APP_ID,
+      slug: SLUG,
+      action: 'claim',
+      actorUserId: REVIEWER,
+      reason: GOOD_REASON,
+      before: { userId: OLD_OWNER },
+      after: { userId: TARGET },
+    });
+  });
+
+  it('reassigns userId on a REMOVED (delisted) listing too', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('removed'));
+    const res = await claimListing({
+      input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, userId: TARGET });
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.after).toEqual({
+      userId: TARGET,
+    });
+  });
+
+  it('leaves AppListingPublishRequest.submittedByUserId INTACT (never touches the publish request)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('approved'));
+    await claimListing({
+      input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+      reviewerUserId: REVIEWER,
+    });
+    // The locked decision: claim reassigns AppListing.userId only — the historical
+    // submission record is preserved. The publish-request table is NEVER written.
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('a draft/pending/rejected status → NOT_TRANSITIONABLE, ZERO events, no reassign', async () => {
+    for (const status of ['draft', 'pending', 'rejected']) {
+      vi.clearAllMocks();
+      mockWrite.$transaction.mockImplementation(
+        async (cb: (tx: WriteMock) => Promise<unknown>) => cb(mockWrite)
+      );
+      mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing(status));
+      mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot(status));
+      await expect(
+        claimListing({
+          input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+          reviewerUserId: REVIEWER,
+        })
+      ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'NOT_TRANSITIONABLE' });
+      expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+      expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    }
+  });
+
+  it('an ON-SITE listing is rejected by the kind guard (generic NOT_FOUND, no tx)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved', 'onsite'));
+    await expect(
+      claimListing({
+        input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+        reviewerUserId: REVIEWER,
+      })
+    ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'NOT_FOUND' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('a nonexistent targetUserId → friendly INVALID_TARGET_USER, no reassign, ZERO events', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('approved'));
+    // The target-owner lookup finds no user.
+    mockWrite.user.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      claimListing({
+        input: { appListingId: APP_ID, targetUserId: 999999, reason: GOOD_REASON },
+        reviewerUserId: REVIEWER,
+      })
+    ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'INVALID_TARGET_USER' });
+    // Guarded before the reassign + the event write.
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('a status-guarded updateMany 0-count (TOCTOU) → NOT_TRANSITIONABLE, ZERO events', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('approved'));
+    // The row was moved out of {approved,removed} between the snapshot and the write.
+    mockWrite.appListing.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(
+      claimListing({
+        input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+        reviewerUserId: REVIEWER,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('snapshots before.userId from the in-tx PRIMARY read, not the (lagging) replica classify', async () => {
+    // The replica classify sees a stale row; the primary tx read sees the TRUE owner.
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(primarySnapshot('approved', 'offsite', 777));
+    await claimListing({
+      input: { appListingId: APP_ID, targetUserId: TARGET, reason: GOOD_REASON },
+      reviewerUserId: REVIEWER,
+    });
+    expect(mockWrite.appListing.findUnique).toHaveBeenCalledWith({
+      where: { id: APP_ID },
+      select: { userId: true, status: true, slug: true, kind: true },
+    });
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.before).toEqual({
+      userId: 777,
+    });
+  });
+
+  it('a too-short reason is a BAD_REQUEST (defense-in-depth) with no DB touch', async () => {
+    await expect(
+      claimListing({
+        input: { appListingId: APP_ID, targetUserId: TARGET, reason: 'x' },
+        reviewerUserId: REVIEWER,
+      })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockRead.appListing.findUnique).not.toHaveBeenCalled();
   });
 });
 
@@ -436,9 +600,10 @@ describe('listModerationEvents', () => {
   });
 });
 
-describe('OffsiteModerationError (PR3 codes)', () => {
-  it('carries the new NOT_TRANSITIONABLE / REPORT_NOT_PENDING codes', () => {
+describe('OffsiteModerationError (PR3/PR4 codes)', () => {
+  it('carries the NOT_TRANSITIONABLE / REPORT_NOT_PENDING / INVALID_TARGET_USER codes', () => {
     expect(new OffsiteModerationError('NOT_TRANSITIONABLE', 'x').code).toBe('NOT_TRANSITIONABLE');
     expect(new OffsiteModerationError('REPORT_NOT_PENDING', 'x').code).toBe('REPORT_NOT_PENDING');
+    expect(new OffsiteModerationError('INVALID_TARGET_USER', 'x').code).toBe('INVALID_TARGET_USER');
   });
 });

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -4,6 +4,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import {
   APP_LISTING_REPORT_REASONS,
   OFFSITE_MOD_REASON_MIN,
+  type ClaimListingInput,
   type DelistListingInput,
   type DismissReportInput,
   type ListListingReportsInput,
@@ -50,13 +51,17 @@ export type OffsiteModerationErrorCode =
   | 'NOT_REPORTABLE'
   | 'ALREADY_REPORTED'
   // PR3 mod-action failure modes:
-  //   NOT_TRANSITIONABLE — a status-guarded delist/relist matched 0 rows (the
-  //     listing was already moved by a concurrent action) → BAD_REQUEST.
+  //   NOT_TRANSITIONABLE — a status-guarded delist/relist/claim matched 0 rows (the
+  //     listing was already moved by a concurrent action, or is not in a claimable
+  //     status) → BAD_REQUEST.
   //   REPORT_NOT_PENDING — resolve/dismiss on an already-closed report → BAD_REQUEST.
+  //   INVALID_TARGET_USER — claim targeted a userId that is not a real User (a
+  //     friendly BAD_REQUEST instead of a raw FK 23503 leaking as INTERNAL).
   // A kind mismatch (an on-site listing) reuses NOT_FOUND (generic — a mod caller
   // must not be able to probe a listing's kind through this surface).
   | 'NOT_TRANSITIONABLE'
-  | 'REPORT_NOT_PENDING';
+  | 'REPORT_NOT_PENDING'
+  | 'INVALID_TARGET_USER';
 
 export class OffsiteModerationError extends Error {
   readonly code: OffsiteModerationErrorCode;
@@ -224,10 +229,12 @@ export async function listListingReports(opts: ListListingReportsInput = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// PR3 — mod ACTIONS (delist / relist / purge / resolve / dismiss). Each writes
-// EXACTLY ONE `AppListingModerationEvent` in the SAME transaction as its mutation
-// (a crash can't split the mutation from its audit record). All mod-only at the
-// router (`moderatorProcedure` + `isModerator` recheck). `claim` is PR4.
+// PR3/PR4 — mod ACTIONS (delist / relist / claim / purge / resolve / dismiss). Each
+// writes EXACTLY ONE `AppListingModerationEvent` in the SAME transaction as its
+// mutation (a crash can't split the mutation from its audit record). All mod-only at
+// the router (`moderatorProcedure` + `isModerator` recheck). `claim` (PR4) reassigns
+// the listing OWNER (`AppListing.userId`) — the historical
+// `AppListingPublishRequest.submittedByUserId` is left INTACT.
 //
 // Discipline mirrored from the P3a offsite-listing approve/reject:
 //   - CLASSIFY on the replica (kind guard), then MUTATE with a status-guarded
@@ -375,6 +382,117 @@ export async function relistListing(opts: {
   });
 
   return { appListingId: input.appListingId, status: 'approved' };
+}
+
+export type ClaimListingResult = { appListingId: string; userId: number };
+
+/**
+ * MOD claim (reassign ownership of) an off-site listing (PR4) — the mod-arbitrated
+ * ownership transfer that resolves an impersonation / verified-owner dispute. A mod
+ * verifies ownership OUT-OF-BAND, then re-points `AppListing.userId` from the current
+ * owner to `targetUserId`; the mod IS the whole trust boundary (there is NO
+ * self-service `protectedProcedure` claim endpoint — a user cannot claim their own
+ * listing).
+ *
+ * Guards (mirror delist/relist/purge):
+ *   - KIND: offsite-only. An on-site `AppListing` is 1:1 with an owned `AppBlock`, so
+ *     reassigning its `userId` would desync it from the backing block's real owner —
+ *     rejected via the shared `classifyOffsiteListing` (missing/on-site → generic
+ *     NOT_FOUND, no tx; info-leak parity with the other actions).
+ *   - STATUS: only `approved` OR `removed` (a mod-verified owner may reclaim a live
+ *     OR a delisted listing). A draft/pending/rejected listing → NOT_TRANSITIONABLE,
+ *     no event.
+ *   - TARGET USER: `targetUserId` must be a REAL `User` — validated on the PRIMARY
+ *     inside the tx so a bad id is a friendly INVALID_TARGET_USER (BAD_REQUEST), NOT
+ *     a raw FK 23503 leaking as an INTERNAL error.
+ *
+ * The pre-state (`before.userId` + `slug` + the status/kind re-check) is snapshotted
+ * from the PRIMARY inside the tx (mirroring purge's in-tx-snapshot fix) — a replica
+ * read could otherwise stamp a stale owner under replica lag. The reassign is a
+ * status-guarded `updateMany` (`status IN (approved,removed)`); a 0-count means a
+ * concurrent action moved the row → NOT_TRANSITIONABLE, and the tx rolls back BEFORE
+ * the audit event is written (ZERO events on a guarded/rolled-back claim).
+ *
+ * 🔴 `AppListingPublishRequest.submittedByUserId` is left INTACT (the locked
+ * decision): claim reassigns the listing OWNER only; the historical submission record
+ * is preserved for audit fidelity (who actually submitted it). This fn NEVER touches
+ * the publish request. The audit event's before/after userId captures the transfer.
+ */
+export async function claimListing(opts: {
+  input: ClaimListingInput;
+  reviewerUserId: number;
+}): Promise<ClaimListingResult> {
+  const { input, reviewerUserId } = opts;
+  const reason = requireModReason(input.reason);
+  // Fail-fast + info-leak parity (replica): a missing OR on-site listing throws the
+  // same generic NOT_FOUND before any tx is opened. The authoritative snapshot is
+  // re-read on the primary inside the tx below.
+  await classifyOffsiteListing(input.appListingId);
+
+  await dbWrite.$transaction(async (tx) => {
+    // Authoritative pre-state snapshot from the PRIMARY (not the replica classify),
+    // so `before.userId` + `slug` reflect the TRUE current row and the kind/status
+    // guards are re-checked on the primary. A row that vanished (or turned
+    // non-offsite) between classify and here → generic NOT_FOUND, tx rolls back with
+    // no event written.
+    const current = await tx.appListing.findUnique({
+      where: { id: input.appListingId },
+      select: { userId: true, status: true, slug: true, kind: true },
+    });
+    if (!current || current.kind !== 'offsite') {
+      throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+    }
+    // Status guard: claim is allowed only on an approved OR removed listing (a
+    // mod-verified owner may reclaim a live OR a delisted listing). draft/pending/
+    // rejected → NOT_TRANSITIONABLE, no event.
+    if (current.status !== 'approved' && current.status !== 'removed') {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'Only an approved or delisted listing can be reassigned.'
+      );
+    }
+    // Validate the target is a REAL user — a friendly error rather than relying on
+    // the FK to 23503-fail (which would surface as a generic INTERNAL). Read on the
+    // primary (inside the tx) so the check is consistent with the write below.
+    const target = await tx.user.findUnique({
+      where: { id: input.targetUserId },
+      select: { id: true },
+    });
+    if (!target) {
+      throw new OffsiteModerationError(
+        'INVALID_TARGET_USER',
+        'The target user could not be found.'
+      );
+    }
+    // Status-guarded reassign (TOCTOU): a 0-count means a concurrent action moved the
+    // row out of {approved,removed} → NOT_TRANSITIONABLE, rolls the tx (incl. the
+    // event) back. `AppListingPublishRequest.submittedByUserId` is deliberately NOT
+    // touched (locked decision — the submission record is historical).
+    const flipped = await tx.appListing.updateMany({
+      where: { id: input.appListingId, kind: 'offsite', status: { in: ['approved', 'removed'] } },
+      data: { userId: input.targetUserId },
+    });
+    if (flipped.count === 0) {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'This listing can no longer be reassigned.'
+      );
+    }
+    await tx.appListingModerationEvent.create({
+      data: {
+        id: newAppListingModerationEventId(),
+        appListingId: input.appListingId,
+        slug: current.slug,
+        action: 'claim',
+        actorUserId: reviewerUserId,
+        reason,
+        before: { userId: current.userId },
+        after: { userId: input.targetUserId },
+      },
+    });
+  });
+
+  return { appListingId: input.appListingId, userId: input.targetUserId };
 }
 
 export type PurgeListingResult = { appListingId: string; purged: true };

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -417,6 +417,12 @@ export type ClaimListingResult = { appListingId: string; userId: number };
  * decision): claim reassigns the listing OWNER only; the historical submission record
  * is preserved for audit fidelity (who actually submitted it). This fn NEVER touches
  * the publish request. The audit event's before/after userId captures the transfer.
+ *
+ * Optionally links + resolves the triggering `reportId` in the SAME tx (mirrors
+ * delist EXACTLY, listing-scoped): in the impersonation workflow (report → delist →
+ * claim → ban) the claim is the substantive resolution, so it ties to and closes the
+ * report just like delist. A mismatched/already-closed reportId is a silent no-op —
+ * the claim still succeeds.
  */
 export async function claimListing(opts: {
   input: ClaimListingInput;
@@ -486,10 +492,26 @@ export async function claimListing(opts: {
         action: 'claim',
         actorUserId: reviewerUserId,
         reason,
+        reportId: input.reportId ?? null,
         before: { userId: current.userId },
         after: { userId: input.targetUserId },
       },
     });
+    if (input.reportId) {
+      // Resolve the triggering report in the same tx — mirrors delist EXACTLY. In the
+      // impersonation flow (report → delist → claim → ban) the claim is the substantive
+      // resolution, so it ties to + closes the report just like delist. Best-effort +
+      // status-guarded AND SCOPED to THIS listing (`appListingId`): a `reportId` that
+      // belongs to a DIFFERENT listing matches 0 rows (no cross-listing report closure)
+      // — the claim of THIS listing still stands and its event still links the supplied
+      // reportId; the mismatched (or already-closed) report is left untouched (silent
+      // no-op, not a hard failure — the claim is the primary action, a bad reportId
+      // must not fail it).
+      await tx.appListingReport.updateMany({
+        where: { id: input.reportId, appListingId: input.appListingId, status: 'pending' },
+        data: { status: 'resolved', resolvedByUserId: reviewerUserId, resolvedAt: new Date() },
+      });
+    }
   });
 
   return { appListingId: input.appListingId, userId: input.targetUserId };

--- a/tests/preview-apps-external-delist.spec.ts
+++ b/tests/preview-apps-external-delist.spec.ts
@@ -4,32 +4,36 @@ import { storageStatePath } from './preview-fixtures';
 import { trpcMutation, trpcQuery } from './preview-trpc';
 
 /**
- * Preview-e2e: App Blocks W13 P3b PR3 — OFF-SITE moderation ACTIONS (delist /
- * relist / purge / resolve / dismiss), tRPC-driven, SELF-CLEANING.
+ * Preview-e2e: App Blocks W13 P3b PR3/PR4 — OFF-SITE moderation ACTIONS (delist /
+ * relist / claim / purge / resolve / dismiss), tRPC-driven, SELF-CLEANING.
  *
  * WHAT THIS COVERS (deterministically, in a preview) and WHY NOT the full
- * approve-success → store-render → delist round-trip:
+ * approve-success → store-render → delist/claim round-trip:
  *
- *   The full "approve an off-site listing, see it in the store, delist it, purge to
- *   self-clean" round-trip requires a SUCCESSFUL approve, which the dark P1 asset
- *   gate (`assertListingAssetsComplete`) blocks unless the draft has an icon+cover
- *   +≥1 screenshot whose backing Image is `ingestion = Scanned`. In a PR preview
- *   the external image scanner is UNREACHABLE, so uploaded images stay `Pending`
- *   forever (see `tests/preview-post-images.spec.ts`: "image ingestion … is
- *   unreachable in preview so the row stays Pending"). An attach of a Pending image
- *   is rejected ("scan is not complete"), so an off-site listing can NOT reach
- *   `approved` in preview — the approve→delist→store leg is therefore covered
- *   EXHAUSTIVELY in the unit/integration tests instead
- *   (`offsite-moderation.service.mod-actions.test.ts`), not here.
+ *   The full "approve an off-site listing, see it in the store, delist/claim it,
+ *   purge to self-clean" round-trip requires a SUCCESSFUL approve, which the dark P1
+ *   asset gate (`assertListingAssetsComplete`) blocks unless the draft has an
+ *   icon+cover+≥1 screenshot whose backing Image is `ingestion = Scanned`. In a PR
+ *   preview the external image scanner is UNREACHABLE, so uploaded images stay
+ *   `Pending` forever (see `tests/preview-post-images.spec.ts`: "image ingestion …
+ *   is unreachable in preview so the row stays Pending"). An attach of a Pending
+ *   image is rejected ("scan is not complete"), so an off-site listing can NOT reach
+ *   `approved`/`removed` in preview — i.e. a CLAIMABLE-state listing is not
+ *   constructible here. So the claim HAPPY-PATH (approved/removed → reassigned +
+ *   audit event) is covered EXHAUSTIVELY in the unit tests instead
+ *   (`offsite-moderation.service.mod-actions.test.ts`), NOT here. This preview spec
+ *   exercises only what is reachable: the claim GUARD rejections (claiming a draft /
+ *   a nonexistent listing → typed error, zero events) + the mod-only AUTHZ (a tester
+ *   is FORBIDDEN). Same rationale as the delist/purge legs below.
  *
  *   `purge` (the PR3 self-clean primitive) DOES solve the P3a "un-cleanable approved
  *   row" problem the sibling approve spec deferred on — and it works on ANY off-site
  *   status, so this spec exercises purge END-TO-END on a self-seeded DRAFT (the one
- *   listing state reachable in preview), plus the report/delist GUARDS (a draft is
- *   not reportable / not delistable) and the full mod-only AUTHZ matrix. All
- *   self-cleaning via `purge` / `withdrawExternalRequest`.
+ *   listing state reachable in preview), plus the report/delist/claim GUARDS (a draft
+ *   is not reportable / not delistable / not claimable) and the full mod-only AUTHZ
+ *   matrix. All self-cleaning via `purge` / `withdrawExternalRequest`.
  *
- * ROLE — `mod` for the action legs (every PR3 proc is `moderatorProcedure`; mod
+ * ROLE — `mod` for the action legs (every PR3/PR4 proc is `moderatorProcedure`; mod
  * also authors via the app-blocks-author floor, so a single mod runs submit +
  * purge), `tester` for the authz-denial matrix.
  *
@@ -125,6 +129,29 @@ test.describe('App Blocks P3b PR3: off-site moderation actions (mod, self-cleani
         'delisting a draft listing must be rejected'
       );
 
+      // A draft is NOT claimable — the status guard (approved|removed-only) fires
+      // (NOT_TRANSITIONABLE → BAD_REQUEST) BEFORE the target-user validation, so this
+      // rejects regardless of targetUserId. No event on the guarded fail.
+      await expectRejects(
+        trpcMutation(request, 'appListings.claimListing', {
+          appListingId: listingId,
+          targetUserId: 1,
+          reason: 'ci-smoke claim guard probe',
+        }),
+        'claiming a draft listing must be rejected'
+      );
+
+      // Claiming a NONEXISTENT listing → the kind/existence guard (generic NOT_FOUND
+      // → 404). Also zero events (no such listing to record against).
+      await expectRejects(
+        trpcMutation(request, 'appListings.claimListing', {
+          appListingId: 'apl_ci_nonexistent',
+          targetUserId: 1,
+          reason: 'ci-smoke claim missing probe',
+        }),
+        'claiming a nonexistent listing must 404'
+      );
+
       // The guarded failures wrote NO moderation events (zero-event-on-guard).
       const history = await trpcQuery<ModEventList>(request, 'appListings.listModerationEvents', {
         appListingId: listingId,
@@ -197,6 +224,14 @@ test.describe('App Blocks P3b PR3: mod actions are moderator-only (tester denied
         reason: 'ci authz probe reason',
       }),
       'tester relist must be forbidden'
+    );
+    await expectRejects(
+      trpcMutation(request, 'appListings.claimListing', {
+        appListingId: 'apl_ci_authz',
+        targetUserId: 1,
+        reason: 'ci authz probe reason',
+      }),
+      'tester claim must be forbidden (mod-only is the whole boundary; no self-claim)'
     );
     await expectRejects(
       trpcMutation(request, 'appListings.purgeListing', {


### PR DESCRIPTION
## What

The **final P3b piece** — `claimListing`, deliberately split out of PR3 (#2969). A **moderator-only, arbitrated ownership transfer** for an off-site `AppListing`: a mod verifies ownership out-of-band, then reassigns `AppListing.userId` to the verified owner, fully audited. **Closes P3b.**

**Posture: DARK.** Behind `app-blocks-enabled` (the mod takedown UI renders only on the mod-only store-preview surface); the server gate is `moderatorProcedure` + an inner `isModerator` recheck. No behaviour change for real users.

## The mod-only, no-self-service boundary

There is deliberately **NO `protectedProcedure` self-claim endpoint** — a user cannot claim their own listing. The mod is the whole trust boundary (a mod MAY reassign to any real user, including resolving an impersonation by re-pointing to the verified owner). Asserted by absence in the router authz test (exactly one `claim` proc, moderator-only).

## Service (`offsite-moderation.service.ts`) — mirrors delist/relist/purge exactly

One tx, `claimListing({ appListingId, targetUserId, reason, reviewerUserId })`:
- **Kind guard**: offsite-only (an on-site listing is 1:1 with an owned `AppBlock`; reassigning its owner would desync it) → generic `NOT_FOUND` (info-leak parity), no tx.
- **Status guard**: allow claim only on `{approved, removed}` (a mod-verified owner may reclaim a live OR a delisted listing). `draft`/`pending`/`rejected` → `NOT_TRANSITIONABLE`, **zero events**.
- **Target-user validation** on the PRIMARY inside the tx → friendly `INVALID_TARGET_USER` (BAD_REQUEST) instead of a raw FK `23503` leaking as INTERNAL.
- **Pre-state snapshot** (`before.userId` + `slug`) read from the **in-tx PRIMARY** (mirrors PR3's purge in-tx-snapshot fix) so replica lag can't stamp a stale owner.
- **Status-guarded `updateMany`** (`status IN (approved,removed)`); a 0-count (TOCTOU) → `NOT_TRANSITIONABLE`, tx rolls back **before** the audit event (zero events on a guarded/raced claim).
- **Audit**: exactly ONE `AppListingModerationEvent(action='claim', actorUserId=reviewer, reason, slug=<snapshot>, before={userId:<old>}, after={userId:<target>})`.

### Kept-`submittedByUserId` decision (locked)
Claim reassigns `AppListing.userId` **only**. `AppListingPublishRequest.submittedByUserId` is left **INTACT** — the historical submission record is preserved for audit fidelity (who actually submitted it); `AppListing.userId` is the sole ownership source of truth. The service never touches the publish request (pinned by a unit test).

## Router + schema + UI
- Router: `claimListing` = `moderatorProcedure` + inner `isModerator` recheck + `mapOffsiteError` (typed→code, unknown→INTERNAL no-leak). Reviewer bound to `ctx.user.id`.
- Schema: `claimListingSchema` (`appListingId`, positive-int `targetUserId`, bounded `reason`).
- **No schema/migration change** — service-only; the `claim` action value already exists in the merged migration CHECK.
- UI (dark, mods only): a **Claim** action on the Reports-tab action set + a modal with a **numeric target-user id** field + reason. The pure view-model (`appListingModerationView`) offers claim on both `approved` and `removed` rows (unit-tested).

## Tests (all pass locally with symlinked deps)
- **Unit — service**: happy-path (approved→reassigned + one `claim` event with before/after userId; removed→reassigned too); status guard (draft/pending/rejected → typed error, zero event); kind guard (on-site → NOT_FOUND, no tx); nonexistent `targetUserId` → friendly `INVALID_TARGET_USER`, no reassign, zero event; TOCTOU 0-count → NOT_TRANSITIONABLE; `submittedByUserId` untouched; in-tx-PRIMARY `before.userId` snapshot; reason floor.
- **Unit — router authz**: claim is moderator-only (tester/anon FORBIDDEN, service not called); reviewer bound to ctx; `INVALID_TARGET_USER`→BAD_REQUEST no-leak; schema-boundary rejections (short reason, non-positive targetUserId); **exactly one claim proc / no self-claim endpoint**.
- **Unit — view-model**: claim action-set on approved+removed, not on gone; labels.
- **e2e (Playwright preview, self-cleaning)**: claim **guard rejections** (draft → typed error; nonexistent → 404) + **mod-only authz** (tester FORBIDDEN). The claim **happy-path is unit-covered** — a claimable-state listing (approved/removed) is **not constructible in preview** (the image scanner is unreachable → the P1 asset gate can't pass → can't reach `approved`, and `removed` needs a prior approve). Scope documented in the spec header, same rationale as PR3.

## Activation gate (unchanged)
🔴 All **three** P3b migrations (reports table, moderation-events table, `app_listings.status` CHECK adding `removed`) must be applied to the dev clone (done — previews work) **and to prod nvme0 before `main`→`release`**, per CLAUDE.md DB rule #8. This PR adds no new migration.

## Post-audit fixes (2026-07-07)
Cheap coherence items surfaced by a second independent audit (which returned "safe to merge, no 🔴"):
- 🟡 **Thread + resolve `reportId` on `claimListing`, mirroring `delistListing` exactly.** Claim now accepts an optional `reportId`, links it on the `AppListingModerationEvent`, and resolves that report in the **same tx** — listing-scoped (`appListingId`) + `status='pending'`-guarded, so a `reportId` for a different listing (or an already-closed one) is a **silent no-op** and the claim still succeeds. In the impersonation workflow (report → delist → claim → ban) the claim is the substantive resolution, so it now closes the triggering report instead of leaving it `pending`. **No migration** — `AppListingModerationEvent.reportId` already exists (PR1). The Claim modal (always initiated from a report row) passes `report.id`. Tests: +2 (matching `reportId` resolves + links; cross-listing `reportId` scoped no-op) and the no-report case now pins `event.reportId=null` + report untouched.
- 🟢 **Render the ownership transfer in the moderation-history modal** — a `claim` row now shows `owner: <before.userId> → <after.userId>`, guarded to the `{userId}`-shaped claim payload so it never mis-reads the `{status}`-shaped delist/relist/purge/report-* events.

### Deferred to pre-GA (documented, not built)
- Reject a banned / soft-deleted `targetUserId` (accepted as mod out-of-band verification for now).
- Re-own the inherited `Image` rows to the new owner / the old-owner-delete-blanks-the-listing durability trap (guidance / re-upload).
- `listMySubmissions` coherence for the new owner.

## Not merged
Left for review + Tekton green (unit + `pr-smoke-test` at the smoke-LOG level).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

