### PR TITLE
fix(api/v1/users): return 503 (not 500) on transient user-search failure

### DIFF
--- a/src/pages/api/v1/users/index.ts
+++ b/src/pages/api/v1/users/index.ts
@@ -7,6 +7,7 @@ import { publicApiContext2 } from '~/server/createContext';
 import { getAllUsersInput } from '~/server/schema/user.schema';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 import { isClientAbortError } from '~/server/utils/errorHandling';
+import { isTransientMeiliError } from '~/server/meilisearch/client';
 
 const schema = getAllUsersInput.extend({
   email: z.never().optional(),
@@ -31,6 +32,30 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
     if (isClientAbortError(error)) {
       // Client disconnected mid-request — not a server fault. 499, not 500.
       if (!res.headersSent) res.status(499).end();
+      return;
+    }
+    // Transient user-search backend failure → retryable 503 (mirrors
+    // /api/v1/images + #2759/#2765). The ?query= path runs getUsersWithSearch
+    // (Meilisearch), which now wraps a transient upstream error as TRPCError
+    // SERVICE_UNAVAILABLE (status 503). We match BOTH that wrapped 503 AND a raw
+    // SDK Meili error that escaped the service wrap (isTransientMeiliError) as
+    // defense-in-depth. no-store so an edge layer can't cache the error; a
+    // Retry-After so clients/CF retry the (typically seconds-long) flap. This
+    // MUST run before the generic TRPCError branch below, whose
+    // JSON.parse(error.message) would otherwise throw on the plain-text
+    // SERVICE_UNAVAILABLE message and bubble a raw 500 — the exact leak this
+    // fixes (transient search error was surfacing as an unhandled 500). A
+    // non-transient error (real app bug / auth / NOT_FOUND) is NOT matched and
+    // still surfaces as its real status.
+    const trpcStatus = error instanceof TRPCError ? getHTTPStatusCodeFromError(error) : undefined;
+    if (isTransientMeiliError(error) || trpcStatus === 503) {
+      if (!res.headersSent) {
+        res.setHeader('Cache-Control', 'no-store');
+        res.setHeader('Retry-After', '2');
+        res
+          .status(503)
+          .json({ error: 'User search is temporarily overloaded — please retry.' });
+      }
       return;
     }
     if (error instanceof TRPCError) {

--- a/src/pages/api/v1/users/index.ts
+++ b/src/pages/api/v1/users/index.ts
@@ -60,9 +60,22 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
     }
     if (error instanceof TRPCError) {
       const status = getHTTPStatusCodeFromError(error);
-      const parsedError = JSON.parse(error.message);
-
-      res.status(status).json(parsedError);
+      // Some tRPC errors carry a JSON-stringified message (e.g. zod/validation
+      // issues serialized as a JSON array) — preserve that shape. But a
+      // throwDbError-wrapped INTERNAL_SERVER_ERROR carries a PLAIN-STRING message
+      // (`message: e.message` — Prisma errors / generic app bugs), so a blind
+      // JSON.parse would THROW and escape this catch → a raw unhandled 500 (the
+      // exact failure mode this PR fixes, previously still live for the
+      // non-transient subset). Fall back to the /api/v1/images error shape
+      // ({ error, code }) on a non-JSON message so NO input path can produce a
+      // raw unhandled 500.
+      let body: unknown;
+      try {
+        body = JSON.parse(error.message);
+      } catch {
+        body = { error: error.message, code: error.code };
+      }
+      res.status(status).json(body);
     } else {
       const err = error as Error;
       res.status(500).json({ message: 'An unexpected error occurred', error: err.message });

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -23,7 +23,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { preventReplicationLag } from '~/server/db/db-lag-helpers';
 import { withSpan } from '~/server/utils/otel-helpers';
 import { logToAxiom } from '~/server/logging/client';
-import { MeiliCallTimeoutError, searchClient, withMeili } from '~/server/meilisearch/client';
+import { isTransientMeiliError, searchClient, withMeili } from '~/server/meilisearch/client';
 import { dbReadFallbackCounter, userUpdateCounter } from '~/server/prom/client';
 import { articleMetrics, modelMetrics, postMetrics, userMetrics } from '~/server/metrics';
 import type { NotifDetailsFollowedBy } from '~/server/notifications/follow.notifications';
@@ -270,11 +270,24 @@ export async function getUsersWithSearch({
       })
     );
   } catch (err) {
-    // Mirror image.getInfinite's handling: surface a fast, retryable 503 via
+    // Mirror /api/v1/images (#2759/#2765): surface a fast, retryable 503 via
     // TRPCError SERVICE_UNAVAILABLE so the client can retry instead of waiting
     // on Traefik's 30s router timeout. (Was TIMEOUT/408 under tRPC v10, which
     // lacked SERVICE_UNAVAILABLE; v11 has it.)
-    if (err instanceof MeiliCallTimeoutError) {
+    //
+    // Widened from `instanceof MeiliCallTimeoutError` to isTransientMeiliError:
+    // the timeout-wrapper only covers civitai's own MeiliCallTimeoutError, but a
+    // Meilisearch brownout also throws the SDK's OWN transient error types
+    // (MeiliSearchCommunicationError with statusCode=408/503, MeiliSearchApiError
+    // with a gateway httpStatus, MeiliSearchTimeOutError, network ECONNRESET, …).
+    // Those fell through this branch as raw Errors → throwDbError wrapped them as
+    // TRPCError INTERNAL_SERVER_ERROR → the handler emitted a raw 500 (the top
+    // REST 500 source on the ?query= path). Converting them here preserves the
+    // "transient" signal as SERVICE_UNAVAILABLE through throwDbError (which
+    // re-throws an existing TRPCError unchanged) so the handler maps it to 503.
+    // Non-transient errors (malformed filter / auth / real app bug) are NOT
+    // matched and continue to surface as their real status (500).
+    if (isTransientMeiliError(err)) {
       throw new TRPCError({
         code: 'SERVICE_UNAVAILABLE',
         message: 'User search is temporarily overloaded — please retry.',

--- a/src/tests/api/v1/users/index.test.ts
+++ b/src/tests/api/v1/users/index.test.ts
@@ -184,6 +184,33 @@ describe('/api/v1/users transient-upstream 503 reclassification', () => {
     expect(res._getHeader('Retry-After')).toBeUndefined();
   });
 
+  it('returns a clean 500 (no throw, no 503) for the REAL prod non-transient shape: a throwDbError-wrapped TRPCError INTERNAL_SERVER_ERROR with a PLAIN-STRING (non-JSON) message', async () => {
+    // This is what a non-transient user.getAll failure (Prisma error / generic
+    // app bug) actually looks like after throwDbError: TRPCError
+    // INTERNAL_SERVER_ERROR whose `message` is a bare string, NOT JSON. Against
+    // the UN-hardened handler this hits `JSON.parse('Database connection lost')`
+    // → SyntaxError → the throw escapes the catch → a raw unhandled Next 500 (the
+    // original failure mode, still live for the non-transient subset). The
+    // hardened handler falls back to the { error, code } shape with the correct
+    // HTTP status — a clean 500, never a throw, never a 503.
+    const dbError = new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Database connection lost',
+    });
+    mockGetAll.mockRejectedValue(dbError);
+    const { req, res } = createMocks({ query: { query: 'heidi' } });
+
+    // Must NOT throw (the pre-hardening crash).
+    await expect(handler(req, res)).resolves.toBeUndefined();
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getJSONData()).toEqual({
+      error: 'Database connection lost',
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
   it('does NOT mask a generic app error (null deref) as 503 — bubbles to 500', async () => {
     // A non-transient, non-TRPCError failure must still surface as a hard 500 —
     // only transient search errors become 503.

--- a/src/tests/api/v1/users/index.test.ts
+++ b/src/tests/api/v1/users/index.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// 1. Hoisted mocks. The handler builds a tRPC caller via publicApiContext2 and
+// calls `apiCaller.user.getAll(...)`. We mock publicApiContext2 to return a
+// caller whose `user.getAll` is a vi.fn we can resolve/reject — this drives the
+// handler's success + error classification in isolation (mirrors the images
+// handler test mocking the search service).
+const { mockPublicApiContext2, mockGetAll } = vi.hoisted(() => ({
+  mockPublicApiContext2: vi.fn(),
+  mockGetAll: vi.fn(),
+}));
+
+vi.mock('~/server/createContext', () => ({
+  publicApiContext2: mockPublicApiContext2,
+}));
+
+// Mock PublicEndpoint to be a simple passthrough wrapper (same as the images test).
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: any) => handler,
+}));
+
+// NOTE: isTransientMeiliError (~/server/meilisearch/client), isClientAbortError
+// (~/server/utils/errorHandling) and the getAllUsersInput zod schema are kept
+// REAL so the handler's production classification logic runs. env/prom at their
+// module load are tolerated (no real connection opens in test).
+
+// 2. Import the handler after the mocks are defined.
+import handler from '~/pages/api/v1/users/index';
+
+// 3. Helper to mock NextApiRequest/Response (mirrors the images handler test).
+function createMocks({ query = {} }: { query?: Record<string, string | string[]> }) {
+  const req = {
+    method: 'GET',
+    headers: {},
+    query,
+  } as unknown as NextApiRequest;
+
+  let statusCode = 200;
+  let payload: any = undefined;
+  let ended = false;
+  const headers: Record<string, string> = {};
+
+  const res = {
+    headersSent: false,
+    setHeader(name: string, value: string) {
+      headers[name.toLowerCase()] = value;
+      return res;
+    },
+    getHeader(name: string) {
+      return headers[name.toLowerCase()];
+    },
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(body: any) {
+      payload = body;
+      return res;
+    },
+    end() {
+      ended = true;
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+    _getHeader: (name: string) => headers[name.toLowerCase()],
+    _ended: () => ended,
+  } as unknown as NextApiResponse & {
+    _getStatusCode: () => number;
+    _getJSONData: () => any;
+    _getHeader: (name: string) => string | undefined;
+    _ended: () => boolean;
+  };
+
+  return { req, res };
+}
+
+// Faithful meilisearch-js 0.33 SDK transient error shapes (see
+// client.ts isTransientMeiliError). Used for the defense-in-depth branch:
+// a raw SDK error that escaped the getUsersWithSearch service wrap.
+const makeCommunicationError = (statusCode: number) => {
+  const e = new Error(statusCode === 408 ? 'Request Timeout' : 'Service Unavailable') as Error & {
+    name: string;
+    statusCode: number;
+  };
+  e.name = 'MeiliSearchCommunicationError';
+  e.statusCode = statusCode;
+  return e;
+};
+
+// The post-service-fix prod shape: getUsersWithSearch converts a transient Meili
+// error to a TRPCError SERVICE_UNAVAILABLE, and the controller's throwDbError
+// re-throws an existing TRPCError unchanged — so this is exactly what reaches
+// the handler in production for a transient upstream.
+const makeServiceUnavailableTrpcError = () =>
+  new TRPCError({
+    code: 'SERVICE_UNAVAILABLE',
+    message: 'User search is temporarily overloaded — please retry.',
+  });
+
+// 4. Test Suite
+describe('/api/v1/users transient-upstream 503 reclassification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Every request builds a caller whose user.getAll is our controllable mock.
+    mockPublicApiContext2.mockResolvedValue({ user: { getAll: mockGetAll } });
+  });
+
+  it('happy path is unchanged (200) with no Retry-After header', async () => {
+    const items = [{ id: 1, username: 'alice' }];
+    mockGetAll.mockResolvedValue(items);
+    const { req, res } = createMocks({ query: { query: 'ali' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getJSONData()).toEqual({ items });
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
+  it('maps a TRPCError SERVICE_UNAVAILABLE (the service-wrapped transient path) to a retryable 503', async () => {
+    // This is the exact error shape the fixed getUsersWithSearch raises for a
+    // transient Meili brownout, preserved unchanged through throwDbError. Against
+    // the UNFIXED handler this hits `error instanceof TRPCError` → status 503 →
+    // JSON.parse('User search is temporarily overloaded — please retry.') THROWS
+    // → the throw escapes the catch → raw 500. The fix short-circuits to a clean
+    // 503 before that JSON.parse landmine.
+    mockGetAll.mockRejectedValue(makeServiceUnavailableTrpcError());
+    const { req, res } = createMocks({ query: { query: 'bob' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(503);
+    expect(res._getJSONData()).toEqual({
+      error: 'User search is temporarily overloaded — please retry.',
+    });
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+    expect(res._getHeader('Retry-After')).toBe('2');
+  });
+
+  it.each([408, 429, 502, 503, 504])(
+    'maps a raw SDK MeiliSearchCommunicationError(statusCode=%i) that escaped the service wrap to a retryable 503 (defense-in-depth)',
+    async (status) => {
+      mockGetAll.mockRejectedValue(makeCommunicationError(status));
+      const { req, res } = createMocks({ query: { query: 'carol' } });
+
+      await handler(req, res);
+
+      expect(res._getStatusCode()).toBe(503);
+      expect(res._getJSONData()).toEqual({
+        error: 'User search is temporarily overloaded — please retry.',
+      });
+      expect(res._getHeader('Cache-Control')).toBe('no-store');
+      expect(res._getHeader('Retry-After')).toBe('2');
+    }
+  );
+
+  it('DOES map a transport-layer MeiliSearchCommunicationError(statusCode=500) (empty body) to a retryable 503', async () => {
+    mockGetAll.mockRejectedValue(makeCommunicationError(500));
+    const { req, res } = createMocks({ query: { query: 'dave' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(503);
+    expect(res._getHeader('Retry-After')).toBe('2');
+  });
+
+  it('does NOT mask a genuine (non-transient) TRPCError NOT_FOUND as 503 — keeps its real 404, no Retry-After', async () => {
+    // Message is JSON so the handler's existing JSON.parse(error.message) branch
+    // resolves cleanly (that pre-existing branch is how this endpoint formats
+    // real tRPC errors). The key assertions: NOT 503, no Retry-After.
+    const notFound = new TRPCError({
+      code: 'NOT_FOUND',
+      message: JSON.stringify({ message: 'User not found' }),
+    });
+    mockGetAll.mockRejectedValue(notFound);
+    const { req, res } = createMocks({ query: { query: 'eve' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
+  it('does NOT mask a generic app error (null deref) as 503 — bubbles to 500', async () => {
+    // A non-transient, non-TRPCError failure must still surface as a hard 500 —
+    // only transient search errors become 503.
+    mockGetAll.mockRejectedValue(new Error('cannot read properties of undefined'));
+    const { req, res } = createMocks({ query: { query: 'frank' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getJSONData()).toEqual({
+      message: 'An unexpected error occurred',
+      error: 'cannot read properties of undefined',
+    });
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
+  it('does NOT mask a non-transient upstream 400 (malformed filter) as 503', async () => {
+    // A 4xx-other from the SDK (malformed filter / auth) is a real client/app
+    // error, not a retryable brownout. It is not a TRPCError, so it falls to the
+    // generic mapping → 500. The key assertion: it is NOT 503, no Retry-After.
+    mockGetAll.mockRejectedValue(makeCommunicationError(400));
+    const { req, res } = createMocks({ query: { query: 'grace' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).not.toBe(503);
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Root cause

`GET /api/v1/users?query=<username>` returns a raw **HTTP 500** when the user-search backend has a transient failure. On dp-prod this was the **single largest REST 500 source — 51 occurrences in 3h**; the same queries retried immediately return 200, so these are transient search-backend errors leaking as a non-retryable 500.

The `?query=` path routes non-moderator callers to `getUsersWithSearch` (Meilisearch — `searchClient.index(USERS_SEARCH_INDEX).search()`). Its `catch` only converted civitai's own `MeiliCallTimeoutError` into a retryable `TRPCError SERVICE_UNAVAILABLE`. But a Meilisearch brownout **also** throws the SDK's own transient error types — `MeiliSearchCommunicationError` (`statusCode` 408/503), `MeiliSearchApiError` (gateway `httpStatus`), `MeiliSearchTimeOutError`, network `ECONNRESET`. Those fell through as raw `Error`s →

1. the controller's `throwDbError(error)` wrapped them into `TRPCError INTERNAL_SERVER_ERROR` (message = the HTTP statustext, e.g. `"Service Unavailable"`),
2. the handler hit `error instanceof TRPCError` → status 500 → `JSON.parse("Service Unavailable")` **threw** → the throw escaped the catch → a raw Next.js 500.

This mirrors the images-endpoint fix (#2759/#2765): a transient upstream Meili error should surface as a retryable **503**, not a hard 500.

## Fix (two parts — the images service-wrap + handler defense-in-depth pattern)

- **`getUsersWithSearch`** (`src/server/services/user.service.ts`): widen the catch from `instanceof MeiliCallTimeoutError` → `isTransientMeiliError(err)`, so **all** genuinely-transient Meili errors become `TRPCError SERVICE_UNAVAILABLE`. `throwDbError` re-throws an existing `TRPCError` unchanged, so the 503 signal is preserved all the way to the handler. Non-transient errors (malformed filter / auth / real app bug) are **not** matched and still surface as their real status.
- **`/api/v1/users` handler** (`src/pages/api/v1/users/index.ts`): add a transient → **503** branch (`Cache-Control: no-store` + `Retry-After: 2`) **before** the generic `TRPCError` branch, exactly like `/api/v1/images`. It matches both the wrapped `SERVICE_UNAVAILABLE` (`trpcStatus === 503`) and a raw SDK Meili error that escaped the wrap (`isTransientMeiliError`). Running before the pre-existing `JSON.parse(error.message)` also removes the crash on the plain-text `SERVICE_UNAVAILABLE` message.

## Test

`src/tests/api/v1/users/index.test.ts` mirrors the images handler test (vitest):
- **transient → 503** with `no-store` + `Retry-After`: the wrapped `TRPCError SERVICE_UNAVAILABLE` (post-service-fix prod shape) **and** raw `MeiliSearchCommunicationError` (408/429/500/502/503/504, defense-in-depth).
- **non-transient still surfaces**: `TRPCError NOT_FOUND` → 404, generic `Error` → 500, SDK 400 (malformed filter) → not 503. Only transient errors become 503.
- **happy path** → 200, no `Retry-After`.

Verified fail-before / pass-after: the 7 transient cases **fail** against the unfixed handler (raw 500 / `JSON.parse` crash) and **pass** with the fix — **11/11** green. The 4 negative/happy cases pass in both states (no false-positive masking). Changed files typecheck clean via `tsc-files --noEmit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)