### PR TITLE
fix(post): guard undefined index in post.getInfinite (prod 500)

### DIFF
--- a/src/server/services/__tests__/post-getInfinite-collection-visibility.test.ts
+++ b/src/server/services/__tests__/post-getInfinite-collection-visibility.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CollectionContributorPermission,
+  CollectionReadConfiguration,
+} from '~/shared/utils/prisma/enums';
+import { canViewCollectionPost } from '~/server/services/post-collection-visibility';
+
+// Regression test for the prod 500 on `post.getInfinite`:
+//   INTERNAL_SERVER_ERROR "Cannot read properties of undefined (reading '0')"
+//   (22 occurrences / 3h on civitai-dp-prod).
+//
+// Root cause: the collection-permission filter in `getPostsInfinite` indexed
+// `collection.contributors[0]` unconditionally, but `contributors` is only
+// selected when the request has a logged-in user. For an anonymous viewer of a
+// NON-Public collection, `contributors` is `undefined`, so `contributors[0]`
+// threw `reading '0'`. `canViewCollectionPost` is the extracted predicate that
+// carries the guard; we exercise it directly (no DB) so the seam is cheap.
+
+describe('canViewCollectionPost (post.getInfinite collection filter)', () => {
+  it("does NOT throw and hides the post when an anonymous viewer hits a non-Public collection (contributors undefined) — the exact prod crash", () => {
+    // The precise value that reached the old code: a non-Public collection whose
+    // `contributors` field was never selected (anonymous request).
+    const collection = { read: CollectionReadConfiguration.Private } as {
+      read: CollectionReadConfiguration;
+      contributors?: { permissions: CollectionContributorPermission[] }[];
+    };
+    expect(collection.contributors).toBeUndefined();
+
+    // Sanity-anchor: the ORIGINAL unguarded access on this exact value throws the
+    // exact prod error signature. The guarded predicate must NOT.
+    expect(() => (collection.contributors as any)[0]).toThrowError(
+      /Cannot read properties of undefined \(reading '0'\)/
+    );
+
+    expect(() => canViewCollectionPost(collection)).not.toThrow();
+    expect(canViewCollectionPost(collection)).toBe(false);
+  });
+
+  it('hides the post for a non-Public collection with an empty contributors array', () => {
+    expect(
+      canViewCollectionPost({ read: CollectionReadConfiguration.Private, contributors: [] })
+    ).toBe(false);
+  });
+
+  it('shows the post for a non-Public collection where the viewer has VIEW permission', () => {
+    expect(
+      canViewCollectionPost({
+        read: CollectionReadConfiguration.Private,
+        contributors: [{ permissions: [CollectionContributorPermission.VIEW] }],
+      })
+    ).toBe(true);
+  });
+
+  it('hides the post for a non-Public collection where the contributor lacks VIEW permission', () => {
+    expect(
+      canViewCollectionPost({
+        read: CollectionReadConfiguration.Private,
+        contributors: [{ permissions: [CollectionContributorPermission.ADD] }],
+      })
+    ).toBe(false);
+  });
+
+  it('shows the post for a Public collection even when contributors is undefined (anonymous viewer)', () => {
+    expect(canViewCollectionPost({ read: CollectionReadConfiguration.Public })).toBe(true);
+  });
+});

--- a/src/server/services/post-collection-visibility.ts
+++ b/src/server/services/post-collection-visibility.ts
@@ -1,0 +1,30 @@
+import {
+  CollectionContributorPermission,
+  CollectionReadConfiguration,
+} from '~/shared/utils/prisma/enums';
+
+/**
+ * Whether a viewer may see a post that belongs to `collection`, based on the
+ * collection's read setting and the viewer's contributor permissions.
+ *
+ * `contributors` is only selected when the `post.getInfinite` request has a
+ * logged-in user (see the `collection.findMany` select in post.service.ts) — for
+ * anonymous viewers the field is absent (`undefined`). Indexing `contributors[0]`
+ * without guarding that threw `Cannot read properties of undefined (reading '0')`
+ * for every logged-out viewer of a non-Public collection (prod 500s on
+ * post.getInfinite). The `?.` before `[0]` is the guard; the result then means
+ * "no VIEW permission" → hide the post, which is the correct behaviour for an
+ * anonymous viewer of a private/unlisted collection.
+ *
+ * Kept in a standalone (import-light) module so it is unit-testable without the
+ * full post.service dependency graph.
+ */
+export const canViewCollectionPost = (collection: {
+  read: CollectionReadConfiguration;
+  contributors?: { permissions: CollectionContributorPermission[] }[];
+}) => {
+  if (collection.read === CollectionReadConfiguration.Public) return true;
+  return !!collection.contributors?.[0]?.permissions.includes(
+    CollectionContributorPermission.VIEW
+  );
+};

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -39,6 +39,7 @@ import {
 } from '~/server/services/collection.service';
 import { Limiter } from '~/server/utils/concurrency-helpers';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
+import { canViewCollectionPost } from '~/server/services/post-collection-visibility';
 import {
   createImage,
   createImageResources,
@@ -550,12 +551,7 @@ export const getPostsInfinite = async ({
             const collection = collections.find((x) => x.id === p.collectionId);
             if (!collection) return false;
 
-            if (
-              collection.read !== CollectionReadConfiguration.Public &&
-              !collection?.contributors[0]?.permissions.includes(
-                CollectionContributorPermission.VIEW
-              )
-            ) {
+            if (!canViewCollectionPost(collection)) {
               return false;
             }
           }

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -73,7 +73,6 @@ import {
   Availability,
   CollectionContributorPermission,
   CollectionMode,
-  CollectionReadConfiguration,
   CollectionType,
   MediaType,
   Model3DStatus,


### PR DESCRIPTION
## Root cause

`post.getInfinite` (→ `getPostsInfinite` in `src/server/services/post.service.ts`) throws when an **anonymous** viewer browses a post that belongs to a **non-Public** collection.

The collection-permission filter did:

```ts
if (
  collection.read !== CollectionReadConfiguration.Public &&
  !collection?.contributors[0]?.permissions.includes(CollectionContributorPermission.VIEW)
) { return false; }
```

`contributors` is only fetched when the request has a logged-in user — the `collection.findMany` select sets `contributors: user?.id ? {...} : undefined`. For a logged-out viewer the field is **absent (`undefined`)**, so `collection.contributors[0]` throws `TypeError: Cannot read properties of undefined (reading '0')`. The `?.` in `collection?.contributors[0]` only guards `collection`, not `contributors`.

The handler wraps this via `throwDbError`, which turns the plain `TypeError` into a tRPC `INTERNAL_SERVER_ERROR` carrying the original message verbatim.

## Prod evidence

- **22 × `INTERNAL_SERVER_ERROR` on `post.getInfinite` in 3h** on civitai-dp-prod
- message exactly: `Cannot read properties of undefined (reading '0')`

## Fix

Extract the predicate into an import-light module `src/server/services/post-collection-visibility.ts` and add the missing guard (`collection.contributors?.[0]`). Semantics are preserved and correct: an anonymous viewer of a private/unlisted collection has no `VIEW` permission → the post is hidden (filtered out) instead of 500-ing the whole page. Public collections still short-circuit to visible.

## Test

`src/server/services/__tests__/post-getInfinite-collection-visibility.test.ts` (vitest, unit project) exercises `canViewCollectionPost` directly (pure, no DB):

- reproduces the exact crash input (non-Public collection, `contributors` undefined) and asserts the guarded predicate does **not** throw and returns `false`
- asserts the raw unguarded access on that same value throws the exact prod signature (documents the bug)
- covers empty-`contributors`, VIEW-present, VIEW-absent, and Public cases

Verified **fail-before / pass-after**: with the `?.` guard removed the repro test fails with `TypeError: Cannot read properties of undefined (reading '0')`; with the guard it passes (5/5). `tsc --noEmit` reports zero errors in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
