### PR TITLE
feat(apps): submit external-link UX + my-submissions filter/sort/collapse (client-only)

### DIFF
--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -5,11 +5,12 @@ import { renderWithProviders } from '../../../test/component-setup';
 
 /**
  * W13 — /apps/submit "External link" mode WIZARD. Browser-mode surface test
- * (report-only in Tekton): the stepper starts on the URL step, advancing from a
- * valid URL prefills name + slug on the Details step (derived from the URL), and
- * an invalid URL blocks the advance with the shared inline https error. The pure
- * derivation + step-gating are unit-tested separately in
- * `__tests__/deriveListingFromUrl.test.ts`.
+ * (report-only in Tekton): the stepper starts on the URL step (field renamed to
+ * "Link URL"), advancing from a valid URL prefills name + slug on the Details step
+ * (derived from the URL), a bare domain is accepted (normalized to https), an
+ * explicit http:// blocks the advance with an inline error, and Enter advances the
+ * step. The pure derivation / normalization / step-gating are unit-tested in
+ * `__tests__/deriveListingFromUrl.test.ts` + `__tests__/normalizeLinkUrl.test.ts`.
  */
 
 const mocks = vi.hoisted(() => ({
@@ -38,7 +39,12 @@ vi.mock('~/utils/trpc', () => {
 });
 
 vi.mock('~/hooks/useCFImageUpload', () => ({
-  useCFImageUpload: () => ({ uploadToCF: vi.fn(), files: [], resetFiles: vi.fn(), removeImage: vi.fn() }),
+  useCFImageUpload: () => ({
+    uploadToCF: vi.fn(),
+    files: [],
+    resetFiles: vi.fn(),
+    removeImage: vi.fn(),
+  }),
 }));
 
 vi.mock('~/utils/notifications', () => ({
@@ -54,11 +60,11 @@ beforeEach(() => {
 });
 
 describe('ExternalSubmitForm — wizard', () => {
-  test('starts on the URL step (details/create not yet shown)', async () => {
+  test('starts on the URL step with the renamed "Link URL" field', async () => {
     renderWithProviders(<ExternalSubmitForm />);
-    await expect
-      .element(page.getByRole('textbox', { name: /External URL/ }))
-      .toBeInTheDocument();
+    await expect.element(page.getByRole('textbox', { name: /Link URL/ })).toBeInTheDocument();
+    // The renamed field carries its "where users will land" description.
+    await expect.element(page.getByText(/where users will land/i)).toBeInTheDocument();
     await expect.element(page.getByRole('button', { name: 'Next' })).toBeInTheDocument();
     // The Create-draft button lives on the Details step and is not rendered yet.
     expect(page.getByRole('button', { name: 'Create draft' }).elements()).toHaveLength(0);
@@ -66,7 +72,7 @@ describe('ExternalSubmitForm — wizard', () => {
 
   test('a valid URL advances to Details and prefills name + slug', async () => {
     renderWithProviders(<ExternalSubmitForm />);
-    await page.getByRole('textbox', { name: /External URL/ }).fill('https://vitrine.civitai.com');
+    await page.getByRole('textbox', { name: /Link URL/ }).fill('https://vitrine.civitai.com');
     await page.getByRole('button', { name: 'Next' }).click();
 
     // Details step is now active with the prefilled name + slug.
@@ -75,18 +81,36 @@ describe('ExternalSubmitForm — wizard', () => {
     await expect.element(page.getByRole('button', { name: 'Create draft' })).toBeInTheDocument();
   });
 
-  test('an invalid (http) URL blocks the advance with an inline error', async () => {
+  test('a bare domain (no scheme) is accepted and normalized to https', async () => {
     renderWithProviders(<ExternalSubmitForm />);
-    await page.getByRole('textbox', { name: /External URL/ }).fill('http://example.com');
+    await page.getByRole('textbox', { name: /Link URL/ }).fill('vitrine.civitai.com');
     await page.getByRole('button', { name: 'Next' }).click();
-    // Shared https validation surfaces inline; we stay on the URL step.
+    // Bare domain no longer errors — it advances and prefills from the https form.
+    await expect.element(page.getByRole('textbox', { name: /^Slug/ })).toHaveValue('vitrine');
+  });
+
+  test('an explicit http:// URL blocks the advance with an inline error', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    await page.getByRole('textbox', { name: /Link URL/ }).fill('http://example.com');
+    await page.getByRole('button', { name: 'Next' }).click();
+    // The "Use https://" fix-it error surfaces inline; we stay on the URL step.
     await expect.element(page.getByText(/https/i)).toBeInTheDocument();
     expect(page.getByRole('button', { name: 'Create draft' }).elements()).toHaveLength(0);
   });
 
+  test('Enter on the URL field advances to Details', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    const url = page.getByRole('textbox', { name: /Link URL/ });
+    await url.fill('https://vitrine.civitai.com');
+    await url
+      .element()
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await expect.element(page.getByRole('button', { name: 'Create draft' })).toBeInTheDocument();
+  });
+
   test('submitting valid details calls submitExternalListing (server owns the draft)', async () => {
     renderWithProviders(<ExternalSubmitForm />);
-    await page.getByRole('textbox', { name: /External URL/ }).fill('https://vitrine.civitai.com');
+    await page.getByRole('textbox', { name: /Link URL/ }).fill('https://vitrine.civitai.com');
     await page.getByRole('button', { name: 'Next' }).click();
     await page.getByRole('button', { name: 'Create draft' }).click();
     expect(mocks.mutate).toHaveBeenCalledTimes(1);

--- a/src/components/Apps/ExternalSubmitForm.tsx
+++ b/src/components/Apps/ExternalSubmitForm.tsx
@@ -6,6 +6,7 @@ import {
   Code,
   FileInput,
   Group,
+  Loader,
   Select,
   Stack,
   Stepper,
@@ -22,7 +23,7 @@ import {
   IconUpload,
 } from '@tabler/icons-react';
 import Link from 'next/link';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
 import {
   OFFSITE_CATEGORY_OPTIONS,
@@ -32,11 +33,16 @@ import {
   emptyOffsiteSubmitForm,
   isDetailsStepComplete,
   isUrlStepComplete,
+  normalizeLinkUrl,
   validateOffsiteSubmitForm,
   type OffsiteSubmitFormErrors,
   type OffsiteSubmitFormValues,
 } from '~/components/Apps/offsiteSubmitFormConfig';
-import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
+import {
+  classifyAttachResult,
+  shouldKeepPolling,
+  type AttachOutcome,
+} from '~/components/Apps/assetPolling';
 import {
   appendScreenshotSlot,
   makeScreenshotSlotId,
@@ -67,13 +73,26 @@ type Submitted = { listingId: string; publishRequestId: string; slug: string };
 type AssetKind = 'icon' | 'cover' | 'screenshot';
 
 /**
- * Per-asset attach lifecycle. `processing` = the image was persisted but the async
- * scan is not complete yet, so the P1 attach proc rejected with "scan is not
- * complete" — the author can Retry once the scan lands (a listing asset is publicly
- * rendered, so the P1 gate requires a scan-complete image).
+ * Per-asset attach lifecycle:
+ *   idle      — nothing uploaded yet.
+ *   working   — uploading + persisting, or the very first attach attempt.
+ *   scanning  — the persisted image is still being virus/NSFW-scanned, so the P1
+ *               attach proc rejected with "scan is not complete"; we AUTO-POLL the
+ *               attach on a backoff (see `assetPolling.ts`) and flip to `attached`
+ *               the moment the scan lands — no manual Retry needed.
+ *   attached  — the attach succeeded (terminal).
+ *   error     — the attach failed for a NON-scan reason (blocked / NSFW / bad
+ *               dimensions); polling stops and the reason is shown (terminal).
+ *   timeout   — the scan didn't complete within the ~3-min poll budget; polling
+ *               stops but the manual Retry stays as a fallback.
+ *
+ * NOTE: on a PR PREVIEW the scanner is unreachable, so a real image will poll →
+ * `timeout` (expected). The auto-poll is validated on PROD, where the scan
+ * actually completes and the asset transitions scanning → attached on its own.
  */
+type AssetStatus = 'idle' | 'working' | 'scanning' | 'attached' | 'timeout' | 'error';
 type AssetState = {
-  status: 'idle' | 'working' | 'attached' | 'processing' | 'error';
+  status: AssetStatus;
   imageId: number | null;
   message: string | null;
 };
@@ -89,8 +108,6 @@ const emptyAsset: AssetState = { status: 'idle', imageId: null, message: null };
  * `screenshotSlots.ts` so it is unit-testable without mounting the form.
  */
 type ScreenshotState = ScreenshotSlot;
-
-const SCAN_INCOMPLETE = /scan is not complete/i;
 
 /** Read the intrinsic pixel dimensions of an image File (the P1 attach proc
  *  rejects unknown/zero dimensions, so they must accompany the persisted row). */
@@ -138,29 +155,67 @@ export function ExternalSubmitForm() {
   }
 
   /**
-   * Step 1 → Step 2 prefill: derive name + slug from the URL. NON-DESTRUCTIVE —
-   * only fills a currently-blank field, so a name/slug the author already typed
-   * (or edited on the details step) is never clobbered. Fires on URL blur and on
-   * advancing out of the URL step.
+   * Store the canonical https URL and derive name + slug from it. The prefill is
+   * NON-DESTRUCTIVE — only fills a currently-blank field, so a name/slug the author
+   * already typed (or edited on the Details step) is never clobbered. `normalized`
+   * is the already-validated https URL from `normalizeLinkUrl`, so the STORED /
+   * submitted `externalUrl` is guaranteed https and the derivation runs on it.
    */
-  function prefillFromUrl() {
-    const derived = deriveListingFromUrl(values.externalUrl);
+  function applyNormalizedUrl(normalized: string) {
+    const derived = deriveListingFromUrl(normalized);
     setValues((v) => ({
       ...v,
+      externalUrl: normalized,
       name: v.name.trim().length === 0 && derived.name ? derived.name : v.name,
       slug: v.slug.trim().length === 0 && derived.slug ? derived.slug : v.slug,
     }));
   }
 
+  /**
+   * URL-field blur: normalize (bare domain → https, host:port → https) and store
+   * the canonical https value + prefill. GENTLE — an invalid URL (empty, explicit
+   * `http://`, non-https scheme) is left as-is with NO inline error on blur; the
+   * error only surfaces when the author tries to advance.
+   */
+  function handleUrlBlur() {
+    const result = normalizeLinkUrl(values.externalUrl);
+    if (result.error) return;
+    applyNormalizedUrl(result.url);
+    setErrors((prev) => ({ ...prev, externalUrl: undefined }));
+  }
+
+  /**
+   * Advance URL → Details. Normalize + validate first: a bare domain is accepted
+   * (upgraded to https and stored) so it no longer shows an error, but an explicit
+   * `http://` (or any non-https scheme) is REJECTED inline and blocks the advance.
+   */
   function handleAdvanceFromUrl() {
-    prefillFromUrl();
-    const urlResult = validateExternalUrl(values.externalUrl);
-    if (!urlResult.ok) {
-      setErrors((prev) => ({ ...prev, externalUrl: urlResult.error }));
+    const result = normalizeLinkUrl(values.externalUrl);
+    if (result.error) {
+      setErrors((prev) => ({ ...prev, externalUrl: result.error }));
       return;
     }
+    applyNormalizedUrl(result.url);
     setErrors((prev) => ({ ...prev, externalUrl: undefined }));
     setActive(STEP_DETAILS);
+  }
+
+  /** Enter on the URL field advances the step (same normalize+validate as Next). */
+  function handleUrlKeyDown(e: ReactKeyboardEvent<HTMLInputElement>) {
+    if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
+    e.preventDefault();
+    handleAdvanceFromUrl();
+  }
+
+  /**
+   * Enter on a Details text field creates the draft — but ONLY when the whole
+   * Details step validates, guarding against an accidental empty submit. The
+   * authoritative `validateOffsiteSubmitForm` still runs inside `handleCreateDraft`.
+   */
+  function handleDetailsKeyDown(e: ReactKeyboardEvent<HTMLInputElement>) {
+    if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
+    e.preventDefault();
+    if (isDetailsStepComplete(values)) handleCreateDraft();
   }
 
   function handleCreateDraft() {
@@ -192,8 +247,10 @@ export function ExternalSubmitForm() {
       setActive(STEP_URL);
       return;
     }
-    if (step === STEP_DETAILS && isUrlStepComplete(values)) {
-      prefillFromUrl();
+    if (step === STEP_DETAILS) {
+      const result = normalizeLinkUrl(values.externalUrl);
+      if (result.error) return; // can't reach Details with an invalid URL
+      applyNormalizedUrl(result.url);
       setActive(STEP_DETAILS);
     }
   }
@@ -227,12 +284,7 @@ export function ExternalSubmitForm() {
         </Alert>
       )}
 
-      <Stepper
-        active={active}
-        onStepClick={handleStepClick}
-        allowNextStepsSelect={false}
-        size="sm"
-      >
+      <Stepper active={active} onStepClick={handleStepClick} allowNextStepsSelect={false} size="sm">
         <Stepper.Step
           label="URL"
           description="The link"
@@ -241,12 +293,13 @@ export function ExternalSubmitForm() {
         >
           <Stack gap="md" mt="md">
             <TextInput
-              label="External URL"
-              description="An https:// link. Opens in a new tab with rel=noopener. We'll suggest a name + slug from it."
-              placeholder="https://example.com/app"
+              label="Link URL"
+              description="Where users will land when they click your app. Just type the domain — we'll add https:// and suggest a name + slug from it."
+              placeholder="example.com/app"
               value={values.externalUrl}
               onChange={(e) => setField('externalUrl', e.currentTarget.value)}
-              onBlur={prefillFromUrl}
+              onBlur={handleUrlBlur}
+              onKeyDown={handleUrlKeyDown}
               error={errors.externalUrl}
               maxLength={OFFSITE_SUBMIT_LIMITS.urlMax}
               required
@@ -255,7 +308,12 @@ export function ExternalSubmitForm() {
               data-testid="apps-offsite-submit-url"
             />
             <Group justify="space-between">
-              <Button variant="default" component={Link} href="/apps/my-submissions" disabled={busy}>
+              <Button
+                variant="default"
+                component={Link}
+                href="/apps/my-submissions"
+                disabled={busy}
+              >
                 Cancel
               </Button>
               <Button
@@ -282,6 +340,7 @@ export function ExternalSubmitForm() {
               placeholder="My External App"
               value={values.name}
               onChange={(e) => setField('name', e.currentTarget.value)}
+              onKeyDown={handleDetailsKeyDown}
               error={errors.name}
               maxLength={OFFSITE_SUBMIT_LIMITS.nameMax}
               required
@@ -296,6 +355,7 @@ export function ExternalSubmitForm() {
               placeholder="my-external-app"
               value={values.slug}
               onChange={(e) => setField('slug', e.currentTarget.value)}
+              onKeyDown={handleDetailsKeyDown}
               error={errors.slug}
               maxLength={OFFSITE_SUBMIT_LIMITS.slugMax}
               required
@@ -308,6 +368,7 @@ export function ExternalSubmitForm() {
               description="A short one-liner (optional)."
               value={values.tagline}
               onChange={(e) => setField('tagline', e.currentTarget.value)}
+              onKeyDown={handleDetailsKeyDown}
               error={errors.tagline}
               maxLength={OFFSITE_SUBMIT_LIMITS.taglineMax}
               disabled={busy}
@@ -437,6 +498,46 @@ function AssetStep({
   const setCoverMutation = trpc.appListings.setCover.useMutation();
   const addScreenshotMutation = trpc.appListings.addScreenshot.useMutation();
 
+  /**
+   * Poll bookkeeping, keyed by asset ('icon' / 'cover' / a screenshot slot id):
+   *   - `timers`  holds the ONE pending re-try timeout per asset (so a poll never
+   *               stacks), cleared on success / error / timeout / retry / unmount.
+   *   - `epochs`  is a per-asset generation counter; a new upload or manual Retry
+   *               bumps it, and an in-flight poll cycle bails when its captured
+   *               epoch is stale — so a Retry can't be raced by an older cycle.
+   */
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+  const epochsRef = useRef<Map<string, number>>(new Map());
+
+  function clearTimer(key: string) {
+    const t = timersRef.current.get(key);
+    if (t !== undefined) {
+      clearTimeout(t);
+      timersRef.current.delete(key);
+    }
+  }
+
+  function bumpEpoch(key: string): number {
+    const next = (epochsRef.current.get(key) ?? 0) + 1;
+    epochsRef.current.set(key, next);
+    return next;
+  }
+
+  function isCurrentEpoch(key: string, epoch: number): boolean {
+    return (epochsRef.current.get(key) ?? 0) === epoch;
+  }
+
+  // Cancel every pending poll when the step unmounts (navigating away). This
+  // covers "clear the timer on unmount / when leaving the step" — the earlier
+  // wizard steps are locked once submitted, so unmount is the only exit.
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      for (const t of timers.values()) clearTimeout(t);
+      timers.clear();
+    };
+  }, []);
+
   /** Upload → persist → return the persisted numeric imageId (throws on failure). */
   async function uploadAndPersist(file: File): Promise<number> {
     const { width, height } = await readImageDimensions(file);
@@ -453,8 +554,9 @@ function AssetStep({
     return imageId;
   }
 
-  /** Run the attach proc for an already-persisted imageId; classify the result. */
-  async function attach(kind: AssetKind, imageId: number): Promise<AssetState> {
+  /** Run the attach proc once for an already-persisted imageId; classify the
+   *  outcome (attached / scanning / non-scan error) with the pure helper. */
+  async function attachOnce(kind: AssetKind, imageId: number): Promise<AttachOutcome> {
     try {
       if (kind === 'icon') {
         await setIconMutation.mutateAsync({ listingId: submitted.listingId, imageId });
@@ -463,40 +565,91 @@ function AssetStep({
       } else {
         await addScreenshotMutation.mutateAsync({ listingId: submitted.listingId, imageId });
       }
-      return { status: 'attached', imageId, message: null };
+      return classifyAttachResult(null);
     } catch (err) {
-      const message = (err as Error).message;
-      if (SCAN_INCOMPLETE.test(message)) {
-        return {
-          status: 'processing',
-          imageId,
-          message: 'Image is still processing (virus/NSFW scan). Retry in a moment.',
-        };
-      }
-      return { status: 'error', imageId, message };
+      return classifyAttachResult((err as Error).message);
     }
   }
 
-  async function handleSingle(
+  /**
+   * Drive one attach cycle for `key`: run the attach, then on
+   *   attached → terminal 'attached';
+   *   error    → terminal 'error' (show the reason, stop);
+   *   scanning → if the backoff still has budget, show the spinner and schedule the
+   *              next cycle; else terminal 'timeout' (manual Retry stays).
+   * `attempt` is the 0-indexed re-try number (attempt 0 = the first attach). The
+   * captured `epoch` guards against a superseding upload/Retry. On PR PREVIEW the
+   * scanner is unreachable, so this cycles scanning → timeout (expected); on PROD
+   * it lands scanning → attached.
+   */
+  async function drive(
+    key: string,
+    kind: AssetKind,
+    imageId: number,
+    attempt: number,
+    epoch: number,
+    apply: (s: AssetState) => void
+  ) {
+    const outcome = await attachOnce(kind, imageId);
+    if (!isCurrentEpoch(key, epoch)) return; // superseded by a newer cycle
+    if (outcome.kind === 'attached') {
+      clearTimer(key);
+      apply({ status: 'attached', imageId, message: null });
+      return;
+    }
+    if (outcome.kind === 'error') {
+      clearTimer(key);
+      apply({ status: 'error', imageId, message: outcome.message });
+      return;
+    }
+    const decision = shouldKeepPolling(outcome, attempt);
+    if (!decision.keep) {
+      clearTimer(key);
+      apply({ status: 'timeout', imageId, message: 'Still scanning — Retry in a moment.' });
+      return;
+    }
+    apply({ status: 'scanning', imageId, message: null });
+    const timer = setTimeout(() => {
+      void drive(key, kind, imageId, attempt + 1, epoch, apply);
+    }, decision.delayMs);
+    timersRef.current.set(key, timer);
+  }
+
+  /** Upload a fresh file then start the attach/poll cycle for `key`. */
+  async function startAttach(
+    key: string,
+    kind: AssetKind,
     file: File | null,
-    kind: 'icon' | 'cover',
-    set: (s: AssetState) => void
+    apply: (s: AssetState) => void
   ) {
     if (!file) return;
-    set({ status: 'working', imageId: null, message: null });
+    clearTimer(key);
+    const epoch = bumpEpoch(key);
+    apply({ status: 'working', imageId: null, message: null });
     try {
       const imageId = await uploadAndPersist(file);
-      set(await attach(kind, imageId));
+      if (!isCurrentEpoch(key, epoch)) return; // a newer upload/Retry superseded this
+      await drive(key, kind, imageId, 0, epoch, apply);
     } catch (err) {
-      set({ status: 'error', imageId: null, message: (err as Error).message });
+      if (!isCurrentEpoch(key, epoch)) return;
+      clearTimer(key);
+      apply({ status: 'error', imageId: null, message: (err as Error).message });
       showErrorNotification({ title: `Could not add ${kind}`, error: err as Error });
     }
   }
 
-  async function retrySingle(kind: 'icon' | 'cover', state: AssetState, set: (s: AssetState) => void) {
-    if (state.imageId == null) return;
-    set({ ...state, status: 'working' });
-    set(await attach(kind, state.imageId));
+  /** Manual Retry: reset the poll (new epoch, cleared timer) and re-drive from the
+   *  already-persisted imageId. */
+  async function retryAttach(
+    key: string,
+    kind: AssetKind,
+    imageId: number,
+    apply: (s: AssetState) => void
+  ) {
+    clearTimer(key);
+    const epoch = bumpEpoch(key);
+    apply({ status: 'working', imageId, message: null });
+    await drive(key, kind, imageId, 0, epoch, apply);
   }
 
   async function handleScreenshots(files: File[]) {
@@ -507,27 +660,18 @@ function AssetStep({
       // `screenshotSlots.ts` for the pure append/patch-by-id logic.
       const id = makeScreenshotSlotId(screenshotIdRef.current++);
       setScreenshots((prev: ScreenshotState[]) => appendScreenshotSlot(prev, id));
-      try {
-        const imageId = await uploadAndPersist(file);
-        const result = await attach('screenshot', imageId);
-        setScreenshots((prev: ScreenshotState[]) => patchScreenshotSlot(prev, id, result));
-      } catch (err) {
-        const message = (err as Error).message;
-        setScreenshots((prev: ScreenshotState[]) =>
-          patchScreenshotSlot(prev, id, { status: 'error', imageId: null, message })
-        );
-        showErrorNotification({ title: 'Could not add screenshot', error: err as Error });
-      }
+      await startAttach(id, 'screenshot', file, (s: AssetState) =>
+        setScreenshots((prev: ScreenshotState[]) => patchScreenshotSlot(prev, id, s))
+      );
     }
   }
 
-  async function retryScreenshot(id: string) {
+  function retryScreenshot(id: string) {
     const state = screenshots.find((s: ScreenshotState) => s.id === id);
     if (!state || state.imageId == null) return;
-    const imageId = state.imageId;
-    setScreenshots((prev: ScreenshotState[]) => patchScreenshotSlot(prev, id, { status: 'working' }));
-    const result = await attach('screenshot', imageId);
-    setScreenshots((prev: ScreenshotState[]) => patchScreenshotSlot(prev, id, result));
+    void retryAttach(id, 'screenshot', state.imageId, (s: AssetState) =>
+      setScreenshots((prev: ScreenshotState[]) => patchScreenshotSlot(prev, id, s))
+    );
   }
 
   const attachedScreenshots = screenshots.filter((s) => s.status === 'attached').length;
@@ -538,9 +682,9 @@ function AssetStep({
     <Stack gap="md" data-testid="apps-offsite-submit-success">
       <Alert color="green" variant="light" icon={<IconCheck size={16} />} title="Draft created">
         <Text size="sm">
-          <Code>{submitted.slug}</Code> is a pending off-site submission. Attach an icon, a cover and
-          at least one screenshot below — a moderator can only approve an asset-complete listing.
-          Content rating: <Badge size="xs">{contentRating}</Badge>
+          <Code>{submitted.slug}</Code> is a pending off-site submission. Attach an icon, a cover
+          and at least one screenshot below — a moderator can only approve an asset-complete
+          listing. Content rating: <Badge size="xs">{contentRating}</Badge>
         </Text>
       </Alert>
 
@@ -549,16 +693,20 @@ function AssetStep({
         label="Icon"
         description="Square-ish, ≥128px, png/jpeg/webp."
         state={icon}
-        onFile={(f) => void handleSingle(f, 'icon', setIcon)}
-        onRetry={() => void retrySingle('icon', icon, setIcon)}
+        onFile={(f) => void startAttach('icon', 'icon', f, setIcon)}
+        onRetry={() => {
+          if (icon.imageId != null) void retryAttach('icon', 'icon', icon.imageId, setIcon);
+        }}
       />
       <AssetRow
         kind="cover"
         label="Cover"
         description="Landscape, ≥640px wide, png/jpeg/webp."
         state={cover}
-        onFile={(f) => void handleSingle(f, 'cover', setCover)}
-        onRetry={() => void retrySingle('cover', cover, setCover)}
+        onFile={(f) => void startAttach('cover', 'cover', f, setCover)}
+        onRetry={() => {
+          if (cover.imageId != null) void retryAttach('cover', 'cover', cover.imageId, setCover);
+        }}
       />
 
       <Card withBorder p="sm">
@@ -589,12 +737,12 @@ function AssetStep({
                   <Text size="xs">Screenshot {i + 1}</Text>
                   <Group gap={6}>
                     <AssetStatusBadge state={s} />
-                    {(s.status === 'processing' || s.status === 'error') && s.imageId != null && (
+                    {(s.status === 'error' || s.status === 'timeout') && s.imageId != null && (
                       <Button
                         size="compact-xs"
                         variant="subtle"
                         leftSection={<IconRefresh size={12} />}
-                        onClick={() => void retryScreenshot(s.id)}
+                        onClick={() => retryScreenshot(s.id)}
                       >
                         Retry
                       </Button>
@@ -620,7 +768,11 @@ function AssetStep({
       </Alert>
 
       <Group justify="flex-end">
-        <Button component={Link} href="/apps/my-submissions" rightSection={<IconExternalLink size={16} />}>
+        <Button
+          component={Link}
+          href="/apps/my-submissions"
+          rightSection={<IconExternalLink size={16} />}
+        >
           View my submissions
         </Button>
       </Group>
@@ -655,7 +807,7 @@ function AssetRow({
           </Group>
           <Group gap={6}>
             <AssetStatusBadge state={state} />
-            {(state.status === 'processing' || state.status === 'error') && state.imageId != null && (
+            {(state.status === 'error' || state.status === 'timeout') && state.imageId != null && (
               <Button
                 size="compact-xs"
                 variant="subtle"
@@ -676,7 +828,7 @@ function AssetRow({
           leftSection={<IconUpload size={16} />}
           value={null}
           onChange={onFile}
-          disabled={state.status === 'working'}
+          disabled={state.status === 'working' || state.status === 'scanning'}
         />
         {state.message && (
           <Text size="xs" c={state.status === 'error' ? 'red' : 'dimmed'}>
@@ -688,20 +840,51 @@ function AssetRow({
   );
 }
 
-function AssetStatusBadge({ state }: { state: AssetState }) {
+// Accepts either an AssetState (icon/cover) or a ScreenshotSlot (screenshots) via
+// the minimal shared shape — AssetStatus ⊆ ScreenshotSlotStatus, and no `id` is
+// required so both structurally satisfy it. The legacy `processing` value is
+// rendered like `scanning` (the component no longer produces it, but the shared
+// ScreenshotSlot type still permits it).
+type BadgeState = {
+  status: ScreenshotSlot['status'];
+  imageId: number | null;
+  message: string | null;
+};
+function AssetStatusBadge({ state }: { state: BadgeState }) {
   switch (state.status) {
     case 'working':
-      return <Badge size="xs" color="blue">uploading…</Badge>;
+      return (
+        <Badge size="xs" color="blue" leftSection={<Loader size={10} color="blue" />}>
+          uploading…
+        </Badge>
+      );
+    case 'scanning':
+    case 'processing':
+      // Auto-poll in progress: spinner + "Scanning image…" (no Retry — it retries
+      // itself on a backoff until the scan lands or the budget is spent).
+      return (
+        <Badge size="xs" color="yellow" leftSection={<Loader size={10} color="yellow" />}>
+          Scanning image…
+        </Badge>
+      );
     case 'attached':
       return (
         <Badge size="xs" color="green" leftSection={<IconCheck size={10} />}>
           attached
         </Badge>
       );
-    case 'processing':
-      return <Badge size="xs" color="yellow">processing</Badge>;
+    case 'timeout':
+      return (
+        <Badge size="xs" color="orange" leftSection={<IconAlertTriangle size={10} />}>
+          still scanning
+        </Badge>
+      );
     case 'error':
-      return <Badge size="xs" color="red">error</Badge>;
+      return (
+        <Badge size="xs" color="red">
+          error
+        </Badge>
+      );
     default:
       return (
         <Text size="xs" c="dimmed">

--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -190,25 +190,40 @@ describe('MySubmissionsList', () => {
   });
 
   test('the inline analytics `from` is floored to start-of-day, so same-app rows share one query key (per-row dedup)', async () => {
-    // Two APPROVED versions of the SAME app block. Pre-fix, each AppAnalyticsInline
-    // computed `from = dayjs().subtract(30,'day').toISOString()` at ms precision per
-    // instance → two distinct query inputs → no React-Query dedup → 2 heavy queries.
-    // The floor (.startOf('day')) makes both rows pass the IDENTICAL input.
+    // Two APPROVED versions of the SAME app block. They now COLLAPSE into one group
+    // (latest shown; older behind a "2 versions" toggle), so expand to mount BOTH
+    // inline stats. Pre-fix, each AppAnalyticsInline computed `from` at ms precision
+    // per instance → two distinct query inputs → no React-Query dedup. The floor
+    // (.startOf('day')) makes both rows pass the IDENTICAL input.
     const appBlockId = 'block-dedup';
     renderWithProviders(
       <MySubmissionsList
         submissions={[
-          makeSubmission({ id: 'v1', version: '1.0.0', appBlockId }),
-          makeSubmission({ id: 'v2', version: '2.0.0', appBlockId }),
+          makeSubmission({
+            id: 'v1',
+            version: '1.0.0',
+            appBlockId,
+            submittedAt: new Date('2026-01-01T00:00:00Z'),
+          }),
+          makeSubmission({
+            id: 'v2',
+            version: '2.0.0',
+            appBlockId,
+            submittedAt: new Date('2026-02-01T00:00:00Z'),
+          }),
         ]}
         onWithdraw={vi.fn()}
         withdrawing={false}
       />
     );
     await expect.element(page.getByText('my-app', { exact: false }).first()).toBeInTheDocument();
+    // Expand the collapsed versions so the OLDER version's inline stat also mounts.
+    await page.getByRole('button', { name: /versions/i }).click();
 
     // Every call carried the same app id.
-    const inputs = mocks.analyticsUseQuery.mock.calls.map((c) => c[0] as { appBlockId: string; from: string });
+    const inputs = mocks.analyticsUseQuery.mock.calls.map(
+      (c) => c[0] as { appBlockId: string; from: string }
+    );
     const appInputs = inputs.filter((i) => i?.appBlockId === appBlockId);
     expect(appInputs.length).toBeGreaterThanOrEqual(2); // both rows mounted an inline stat
 
@@ -273,5 +288,78 @@ describe('MySubmissionsList', () => {
     await expect.element(advanced).toBeInTheDocument();
     await advanced.click();
     await expect.element(page.getByTestId('author-via-git')).toBeInTheDocument();
+  });
+});
+
+describe('MySubmissionsList — UX pass: filter / sort / version-collapse', () => {
+  test('the text filter narrows rows by app slug', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[
+          makeSubmission({ id: 'a', slug: 'alpha-app', appBlockId: 'block-a' }),
+          makeSubmission({ id: 'b', slug: 'bravo-app', appBlockId: 'block-b' }),
+        ]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    await expect.element(page.getByText('alpha-app', { exact: false })).toBeInTheDocument();
+    await expect.element(page.getByText('bravo-app', { exact: false })).toBeInTheDocument();
+
+    await page.getByTestId('apps-submissions-filter').fill('bravo');
+    // Only the matching app remains.
+    await expect.element(page.getByText('bravo-app', { exact: false })).toBeInTheDocument();
+    expect(page.getByText('alpha-app', { exact: false }).elements()).toHaveLength(0);
+  });
+
+  test('clicking the App header sorts and exposes aria-sort', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[
+          makeSubmission({ id: 'b', slug: 'bravo-app', appBlockId: 'block-b' }),
+          makeSubmission({ id: 'a', slug: 'alpha-app', appBlockId: 'block-a' }),
+        ]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    const appHeader = page.getByRole('button', { name: /sort by app/i });
+    await appHeader.click();
+    // The header's <th> reflects the active sort for screen readers.
+    const th = appHeader.element().closest('th');
+    expect(th?.getAttribute('aria-sort')).toBe('ascending');
+  });
+
+  test('multiple versions of one app collapse; the toggle reveals older versions', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[
+          makeSubmission({
+            id: 'v1',
+            version: '1.0.0',
+            appBlockId: 'block-x',
+            submittedAt: new Date('2026-01-01T00:00:00Z'),
+          }),
+          makeSubmission({
+            id: 'v2',
+            version: '2.0.0',
+            appBlockId: 'block-x',
+            submittedAt: new Date('2026-02-01T00:00:00Z'),
+          }),
+        ]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    // Collapsed: only the newest version (2.0.0) is shown; 1.0.0 is hidden.
+    await expect.element(page.getByText('2.0.0', { exact: true })).toBeInTheDocument();
+    expect(page.getByText('1.0.0', { exact: true }).elements()).toHaveLength(0);
+
+    // The "2 versions" toggle carries aria-expanded and reveals the older row.
+    const toggle = page.getByRole('button', { name: /2 versions/i });
+    expect(toggle.element().getAttribute('aria-expanded')).toBe('false');
+    await toggle.click();
+    await expect.element(page.getByText('1.0.0', { exact: true })).toBeInTheDocument();
+    expect(toggle.element().getAttribute('aria-expanded')).toBe('true');
   });
 });

--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -28,10 +28,21 @@ import {
   IconX,
 } from '@tabler/icons-react';
 import Link from 'next/link';
-import { Fragment, useState } from 'react';
+import { Fragment, useMemo, useState, type ReactNode } from 'react';
 import { AppAnalyticsInline } from '~/components/Apps/AppAnalyticsInline';
 import { AuthorViaGit } from '~/components/Apps/AuthorViaGit';
 import { isStaleDeploy } from '~/components/Apps/deploy-status';
+import {
+  filterGroups,
+  groupSubmissionsByApp,
+  nextSortState,
+  sortGroups,
+  toDate,
+  type SortColumn,
+  type SortState,
+  type SubmissionAccessors,
+} from '~/components/Apps/submissionsTable';
+import { SortableTh, SubmissionSearch, VersionToggle } from '~/components/Apps/submissionsTableUi';
 
 /** Civitai CLI repo — the recommended author + submit path (replaces the raw
  *  git-clone affordance as the PRIMARY way to author/update an app). */
@@ -210,17 +221,140 @@ export function ReviewerNotesButton({
 function StatusCell({ submission }: { submission: Submission }) {
   const { status, rejectionReason, approvalNotes } = submission;
   const notes =
-    status === 'rejected'
-      ? rejectionReason
-      : status === 'approved'
-      ? approvalNotes
-      : null;
+    status === 'rejected' ? rejectionReason : status === 'approved' ? approvalNotes : null;
   const variant = status === 'rejected' ? 'rejected' : 'approved';
   return (
     <Stack gap={6} align="flex-start">
       {statusBadge(submission)}
       {notes && <ReviewerNotesButton notes={notes} variant={variant} />}
     </Stack>
+  );
+}
+
+/** Field adapters for the shared filter/sort/group helpers. Collapse identity =
+ *  the app block id when present (set on first approval), else the slug — so an
+ *  app's pre-approval versions (null block id) still group by their shared slug.
+ *  Onsite has no display name, so the app label is the slug. */
+const ONSITE_ACCESSORS: SubmissionAccessors<Submission> = {
+  identity: (s) => s.appBlockId ?? s.slug,
+  name: (s) => s.slug,
+  slug: (s) => s.slug,
+  status: (s) => s.status,
+  submittedAt: (s) => toDate(s.submittedAt),
+  reviewedAt: (s) => toDate(s.reviewedAt),
+};
+
+/** One submission's rows: the main row + (approved) a deploy-failed alert and the
+ *  authoring affordance. `nested` demotes an older (expanded) version row;
+ *  `showAuthor` renders the app-level authoring affordance only on the latest. */
+function OnsiteRow({
+  s,
+  nested,
+  showAuthor,
+  onWithdraw,
+  withdrawing,
+  toggle,
+}: {
+  s: Submission;
+  nested: boolean;
+  showAuthor: boolean;
+  onWithdraw: (id: string) => void;
+  withdrawing: boolean;
+  toggle?: ReactNode;
+}) {
+  const mds = (s.manifestDiffSummary ?? {}) as ManifestDiffSummary;
+  const isFirst = mds.kind === 'first-version';
+  const isApproved = s.status === 'approved';
+  return (
+    <>
+      <Table.Tr>
+        <Table.Td>
+          <Group gap={6} pl={nested ? 'lg' : undefined}>
+            {nested && (
+              <Text size="xs" c="dimmed">
+                ·
+              </Text>
+            )}
+            <Code>{s.slug}</Code>
+            {isFirst && (
+              <Badge color="violet" size="xs">
+                first version
+              </Badge>
+            )}
+            {toggle}
+          </Group>
+        </Table.Td>
+        <Table.Td>
+          <Code>{s.version}</Code>
+        </Table.Td>
+        <Table.Td>
+          <StatusCell submission={s} />
+        </Table.Td>
+        <Table.Td>
+          <Text size="xs">{formatDate(s.submittedAt)}</Text>
+        </Table.Td>
+        <Table.Td>
+          {s.reviewedAt ? (
+            <Text size="xs">{formatDate(s.reviewedAt)}</Text>
+          ) : (
+            <Text size="xs" c="dimmed">
+              —
+            </Text>
+          )}
+        </Table.Td>
+        <Table.Td>
+          <InstallCountCell
+            modelInstalls={s.modelInstallCount}
+            subscriptions={s.userSubscriptionCount}
+          />
+        </Table.Td>
+        <Table.Td>
+          {isApproved && s.appBlockId ? (
+            <AppAnalyticsInline appBlockId={s.appBlockId} appLabel={s.slug} />
+          ) : (
+            <Text size="xs" c="dimmed">
+              —
+            </Text>
+          )}
+        </Table.Td>
+        <Table.Td>
+          <SubmissionActions
+            submission={s}
+            isFirstVersion={isFirst}
+            onWithdraw={() => onWithdraw(s.id)}
+            busy={withdrawing}
+          />
+        </Table.Td>
+      </Table.Tr>
+      {s.status === 'approved' && s.deployState === 'failed' && (
+        <Table.Tr>
+          <Table.Td colSpan={8} p={0}>
+            <Alert
+              color="red"
+              variant="light"
+              radius={0}
+              icon={<IconAlertTriangle size={16} />}
+              title="Build / deploy failed"
+            >
+              <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+                {s.deployDetail ??
+                  'The build or deploy failed. Fix the issue and resubmit a new version.'}
+              </Text>
+            </Alert>
+          </Table.Td>
+        </Table.Tr>
+      )}
+      {/* Authoring updates: the CLI is the recommended path; git is a collapsed
+          advanced footnote. Only approved rows with an app block (FK set on
+          approve) can author updates; app-level, so only on the latest version. */}
+      {showAuthor && s.status === 'approved' && s.appBlockId && (
+        <Table.Tr>
+          <Table.Td colSpan={8}>
+            <AuthorAffordance appBlockId={s.appBlockId} />
+          </Table.Td>
+        </Table.Tr>
+      )}
+    </>
   );
 }
 
@@ -233,115 +367,95 @@ export function MySubmissionsList({
   onWithdraw: (id: string) => void;
   withdrawing: boolean;
 }) {
+  const [query, setQuery] = useState('');
+  const [sort, setSort] = useState<SortState>({ column: 'submitted', direction: 'desc' });
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const groups = useMemo(() => {
+    const grouped = groupSubmissionsByApp(
+      submissions,
+      ONSITE_ACCESSORS.identity,
+      ONSITE_ACCESSORS.submittedAt
+    );
+    return sortGroups(filterGroups(grouped, query, ONSITE_ACCESSORS), sort, ONSITE_ACCESSORS);
+  }, [submissions, query, sort]);
+
+  const onSort = (column: SortColumn) => setSort((prev) => nextSortState(prev, column));
+  const toggle = (identity: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(identity)) next.delete(identity);
+      else next.add(identity);
+      return next;
+    });
+
   return (
-    <Card withBorder p={0}>
-      <Table verticalSpacing="md" horizontalSpacing="md">
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>App</Table.Th>
-            <Table.Th>Version</Table.Th>
-            <Table.Th>Status</Table.Th>
-            <Table.Th>Submitted</Table.Th>
-            <Table.Th>Reviewed</Table.Th>
-            <Table.Th>Installs</Table.Th>
-            <Table.Th>Usage (30d)</Table.Th>
-            <Table.Th />
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {submissions.map((s) => {
-            const mds = (s.manifestDiffSummary ?? {}) as ManifestDiffSummary;
-            const isFirst = mds.kind === 'first-version';
-            const isApproved = s.status === 'approved';
-            return (
-              <Fragment key={s.id}>
-                <Table.Tr>
-                  <Table.Td>
-                    <Group gap={6}>
-                      <Code>{s.slug}</Code>
-                      {isFirst && (
-                        <Badge color="violet" size="xs">
-                          first version
-                        </Badge>
-                      )}
-                    </Group>
-                  </Table.Td>
-                  <Table.Td>
-                    <Code>{s.version}</Code>
-                  </Table.Td>
-                  <Table.Td>
-                    <StatusCell submission={s} />
-                  </Table.Td>
-                  <Table.Td>
-                    <Text size="xs">{formatDate(s.submittedAt)}</Text>
-                  </Table.Td>
-                  <Table.Td>
-                    {s.reviewedAt ? (
-                      <Text size="xs">{formatDate(s.reviewedAt)}</Text>
-                    ) : (
-                      <Text size="xs" c="dimmed">
-                        —
-                      </Text>
-                    )}
-                  </Table.Td>
-                  <Table.Td>
-                    <InstallCountCell
-                      modelInstalls={s.modelInstallCount}
-                      subscriptions={s.userSubscriptionCount}
+    <Stack gap="xs">
+      <SubmissionSearch value={query} onChange={setQuery} testId="apps-submissions-filter" />
+      <Card withBorder p={0}>
+        <Table verticalSpacing="md" horizontalSpacing="md">
+          <Table.Thead>
+            <Table.Tr>
+              <SortableTh label="App" column="app" sort={sort} onSort={onSort} />
+              <Table.Th>Version</Table.Th>
+              <SortableTh label="Status" column="status" sort={sort} onSort={onSort} />
+              <SortableTh label="Submitted" column="submitted" sort={sort} onSort={onSort} />
+              <SortableTh label="Reviewed" column="reviewed" sort={sort} onSort={onSort} />
+              <Table.Th>Installs</Table.Th>
+              <Table.Th>Usage (30d)</Table.Th>
+              <Table.Th />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {groups.length === 0 ? (
+              <Table.Tr>
+                <Table.Td colSpan={8}>
+                  <Text size="sm" c="dimmed" ta="center" py="sm">
+                    No submissions match “{query}”.
+                  </Text>
+                </Table.Td>
+              </Table.Tr>
+            ) : (
+              groups.map((g) => {
+                const isExpanded = expanded.has(g.identity);
+                return (
+                  <Fragment key={g.identity}>
+                    <OnsiteRow
+                      s={g.latest}
+                      nested={false}
+                      showAuthor
+                      onWithdraw={onWithdraw}
+                      withdrawing={withdrawing}
+                      toggle={
+                        g.older.length > 0 ? (
+                          <VersionToggle
+                            expanded={isExpanded}
+                            count={g.versionCount}
+                            onToggle={() => toggle(g.identity)}
+                            testId={`apps-submissions-versions-${g.identity}`}
+                          />
+                        ) : undefined
+                      }
                     />
-                  </Table.Td>
-                  <Table.Td>
-                    {isApproved && s.appBlockId ? (
-                      <AppAnalyticsInline appBlockId={s.appBlockId} appLabel={s.slug} />
-                    ) : (
-                      <Text size="xs" c="dimmed">
-                        —
-                      </Text>
-                    )}
-                  </Table.Td>
-                  <Table.Td>
-                    <SubmissionActions
-                      submission={s}
-                      isFirstVersion={isFirst}
-                      onWithdraw={() => onWithdraw(s.id)}
-                      busy={withdrawing}
-                    />
-                  </Table.Td>
-                </Table.Tr>
-                {s.status === 'approved' && s.deployState === 'failed' && (
-                  <Table.Tr>
-                    <Table.Td colSpan={8} p={0}>
-                      <Alert
-                        color="red"
-                        variant="light"
-                        radius={0}
-                        icon={<IconAlertTriangle size={16} />}
-                        title="Build / deploy failed"
-                      >
-                        <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
-                          {s.deployDetail ??
-                            'The build or deploy failed. Fix the issue and resubmit a new version.'}
-                        </Text>
-                      </Alert>
-                    </Table.Td>
-                  </Table.Tr>
-                )}
-                {/* Authoring updates: the CLI is the recommended path; git is a
-                    collapsed advanced footnote. Only approved rows with an app
-                    block (FK set on approve) can author updates. */}
-                {s.status === 'approved' && s.appBlockId && (
-                  <Table.Tr>
-                    <Table.Td colSpan={8}>
-                      <AuthorAffordance appBlockId={s.appBlockId} />
-                    </Table.Td>
-                  </Table.Tr>
-                )}
-              </Fragment>
-            );
-          })}
-        </Table.Tbody>
-      </Table>
-    </Card>
+                    {isExpanded &&
+                      g.older.map((older) => (
+                        <OnsiteRow
+                          key={older.id}
+                          s={older}
+                          nested
+                          showAuthor={false}
+                          onWithdraw={onWithdraw}
+                          withdrawing={withdrawing}
+                        />
+                      ))}
+                  </Fragment>
+                );
+              })
+            )}
+          </Table.Tbody>
+        </Table>
+      </Card>
+    </Stack>
   );
 }
 
@@ -363,8 +477,8 @@ export function AuthorAffordance({ appBlockId }: { appBlockId: string }) {
           <Anchor href={CIVITAI_CLI_URL} target="_blank" rel="noopener noreferrer">
             <Code>civitai</Code> CLI
           </Anchor>
-          . Install it, then run <Code>civitai app submit</Code> to publish a new
-          version for review.
+          . Install it, then run <Code>civitai app submit</Code> to publish a new version for
+          review.
         </Text>
       </Group>
       <Group>
@@ -372,9 +486,7 @@ export function AuthorAffordance({ appBlockId }: { appBlockId: string }) {
           size="compact-xs"
           variant="subtle"
           color="gray"
-          leftSection={
-            showGit ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />
-          }
+          leftSection={showGit ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
           onClick={() => setShowGit((v) => !v)}
         >
           <Group gap={4}>

--- a/src/components/Apps/OffsiteSubmissionsList.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.tsx
@@ -1,11 +1,23 @@
 import { Anchor, Badge, Button, Card, Code, Group, Stack, Table, Text } from '@mantine/core';
 import { IconExternalLink } from '@tabler/icons-react';
+import { Fragment, useMemo, useState, type ReactNode } from 'react';
 import {
   isWithdrawableOffsiteStatus,
   offsiteStatusChip,
 } from '~/components/Apps/offsiteSubmissionStatus';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
 import { ReviewerNotesButton } from '~/components/Apps/MySubmissionsList';
+import {
+  filterGroups,
+  groupSubmissionsByApp,
+  nextSortState,
+  sortGroups,
+  toDate,
+  type SortColumn,
+  type SortState,
+  type SubmissionAccessors,
+} from '~/components/Apps/submissionsTable';
+import { SortableTh, SubmissionSearch, VersionToggle } from '~/components/Apps/submissionsTableUi';
 
 /**
  * /apps/my-submissions — the author's OFF-SITE (external-link) submissions, shown
@@ -13,6 +25,11 @@ import { ReviewerNotesButton } from '~/components/Apps/MySubmissionsList';
  * (pending/approved/rejected/withdrawn), the reviewer-notes modal, an external-URL
  * link, and a Withdraw action for pending rows. Data is
  * `appListings.listMySubmissions` (scoped to the caller server-side).
+ *
+ * UX pass: a client-side text filter (name/slug), sortable column headers
+ * (App/Status/Submitted/Reviewed), and per-app version-collapse (grouped by
+ * `slug`, newest shown, older versions expandable). The filter/sort/group logic is
+ * the shared pure `submissionsTable.ts` (identical to the onsite list).
  */
 
 export type OffsiteSubmission = {
@@ -31,6 +48,18 @@ export type OffsiteSubmission = {
     category: string | null;
     contentRating: string | null;
   } | null;
+};
+
+/** Field adapters for the shared filter/sort/group helpers. Collapse identity =
+ *  `slug` (the app's unique off-site handle); the filterable/sortable app label
+ *  falls back to the slug when a listing has no name. */
+const OFFSITE_ACCESSORS: SubmissionAccessors<OffsiteSubmission> = {
+  identity: (s) => s.slug,
+  name: (s) => s.appListing?.name ?? s.slug,
+  slug: (s) => s.slug,
+  status: (s) => s.status,
+  submittedAt: (s) => toDate(s.submittedAt),
+  reviewedAt: (s) => toDate(s.reviewedAt),
 };
 
 function formatDate(d: string | Date | null | undefined): string {
@@ -60,6 +89,111 @@ function StatusCell({ submission }: { submission: OffsiteSubmission }) {
   );
 }
 
+function LinkCell({ submission }: { submission: OffsiteSubmission }) {
+  const url = submission.appListing?.externalUrl;
+  if (validateExternalUrl(url).ok) {
+    return (
+      <Anchor href={url ?? undefined} target="_blank" rel="noopener noreferrer" size="xs">
+        <Group gap={4} wrap="nowrap">
+          <Text size="xs" lineClamp={1} style={{ maxWidth: 220 }}>
+            {url}
+          </Text>
+          <IconExternalLink size={12} />
+        </Group>
+      </Anchor>
+    );
+  }
+  if (url) {
+    // Present but non-https (defense-in-depth) → INERT text, no anchor.
+    return (
+      <Text size="xs" c="red" lineClamp={1} style={{ maxWidth: 220 }}>
+        {url}
+      </Text>
+    );
+  }
+  return (
+    <Text size="xs" c="dimmed">
+      —
+    </Text>
+  );
+}
+
+function OffsiteRow({
+  submission,
+  nested,
+  onWithdraw,
+  withdrawing,
+  toggle,
+}: {
+  submission: OffsiteSubmission;
+  /** True for an older (expanded) version row — visually demoted. */
+  nested: boolean;
+  onWithdraw: (publishRequestId: string) => void;
+  withdrawing: boolean;
+  /** The "N versions" expand/collapse control (only on a collapsible latest row). */
+  toggle?: ReactNode;
+}) {
+  const s = submission;
+  return (
+    <Table.Tr data-testid={`apps-offsite-submission-row-${s.slug}`}>
+      <Table.Td>
+        <Group gap={6} pl={nested ? 'lg' : undefined}>
+          {nested && (
+            <Text size="xs" c="dimmed">
+              ·
+            </Text>
+          )}
+          <Code>{s.slug}</Code>
+          {!nested && (
+            <Badge size="xs" color="grape" variant="light">
+              external
+            </Badge>
+          )}
+          {toggle}
+        </Group>
+        {!nested && s.appListing?.name && (
+          <Text size="xs" c="dimmed">
+            {s.appListing.name}
+          </Text>
+        )}
+      </Table.Td>
+      <Table.Td>
+        <LinkCell submission={s} />
+      </Table.Td>
+      <Table.Td>
+        <StatusCell submission={s} />
+      </Table.Td>
+      <Table.Td>
+        <Text size="xs">{formatDate(s.submittedAt)}</Text>
+      </Table.Td>
+      <Table.Td>
+        <Text size="xs" c={s.reviewedAt ? undefined : 'dimmed'}>
+          {formatDate(s.reviewedAt)}
+        </Text>
+      </Table.Td>
+      <Table.Td>
+        {isWithdrawableOffsiteStatus(s.status) ? (
+          <Button
+            size="xs"
+            variant="default"
+            color="red"
+            onClick={() => onWithdraw(s.id)}
+            disabled={withdrawing}
+            loading={withdrawing}
+            data-testid={`apps-offsite-withdraw-${s.slug}`}
+          >
+            Withdraw
+          </Button>
+        ) : (
+          <Text size="xs" c="dimmed">
+            —
+          </Text>
+        )}
+      </Table.Td>
+    </Table.Tr>
+  );
+}
+
 export function OffsiteSubmissionsList({
   submissions,
   onWithdraw,
@@ -69,95 +203,94 @@ export function OffsiteSubmissionsList({
   onWithdraw: (publishRequestId: string) => void;
   withdrawing: boolean;
 }) {
+  const [query, setQuery] = useState('');
+  const [sort, setSort] = useState<SortState>({ column: 'submitted', direction: 'desc' });
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const groups = useMemo(() => {
+    const grouped = groupSubmissionsByApp(
+      submissions,
+      OFFSITE_ACCESSORS.identity,
+      OFFSITE_ACCESSORS.submittedAt
+    );
+    return sortGroups(filterGroups(grouped, query, OFFSITE_ACCESSORS), sort, OFFSITE_ACCESSORS);
+  }, [submissions, query, sort]);
+
+  const onSort = (column: SortColumn) => setSort((prev) => nextSortState(prev, column));
+  const toggle = (identity: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(identity)) next.delete(identity);
+      else next.add(identity);
+      return next;
+    });
+
   return (
-    <Card withBorder p={0}>
-      <Table verticalSpacing="md" horizontalSpacing="md">
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>App</Table.Th>
-            <Table.Th>Link</Table.Th>
-            <Table.Th>Status</Table.Th>
-            <Table.Th>Submitted</Table.Th>
-            <Table.Th>Reviewed</Table.Th>
-            <Table.Th />
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {submissions.map((s) => (
-            <Table.Tr key={s.id} data-testid={`apps-offsite-submission-row-${s.slug}`}>
-              <Table.Td>
-                <Group gap={6}>
-                  <Code>{s.slug}</Code>
-                  <Badge size="xs" color="grape" variant="light">
-                    external
-                  </Badge>
-                </Group>
-                {s.appListing?.name && (
-                  <Text size="xs" c="dimmed">
-                    {s.appListing.name}
-                  </Text>
-                )}
-              </Table.Td>
-              <Table.Td>
-                {validateExternalUrl(s.appListing?.externalUrl).ok ? (
-                  <Anchor
-                    href={s.appListing?.externalUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    size="xs"
-                  >
-                    <Group gap={4} wrap="nowrap">
-                      <Text size="xs" lineClamp={1} style={{ maxWidth: 220 }}>
-                        {s.appListing?.externalUrl}
-                      </Text>
-                      <IconExternalLink size={12} />
-                    </Group>
-                  </Anchor>
-                ) : s.appListing?.externalUrl ? (
-                  // Present but non-https (defense-in-depth) → INERT text, no anchor.
-                  <Text size="xs" c="red" lineClamp={1} style={{ maxWidth: 220 }}>
-                    {s.appListing.externalUrl}
-                  </Text>
-                ) : (
-                  <Text size="xs" c="dimmed">
-                    —
-                  </Text>
-                )}
-              </Table.Td>
-              <Table.Td>
-                <StatusCell submission={s} />
-              </Table.Td>
-              <Table.Td>
-                <Text size="xs">{formatDate(s.submittedAt)}</Text>
-              </Table.Td>
-              <Table.Td>
-                <Text size="xs" c={s.reviewedAt ? undefined : 'dimmed'}>
-                  {formatDate(s.reviewedAt)}
-                </Text>
-              </Table.Td>
-              <Table.Td>
-                {isWithdrawableOffsiteStatus(s.status) ? (
-                  <Button
-                    size="xs"
-                    variant="default"
-                    color="red"
-                    onClick={() => onWithdraw(s.id)}
-                    disabled={withdrawing}
-                    loading={withdrawing}
-                    data-testid={`apps-offsite-withdraw-${s.slug}`}
-                  >
-                    Withdraw
-                  </Button>
-                ) : (
-                  <Text size="xs" c="dimmed">
-                    —
-                  </Text>
-                )}
-              </Table.Td>
+    <Stack gap="xs">
+      <SubmissionSearch
+        value={query}
+        onChange={setQuery}
+        testId="apps-offsite-submissions-filter"
+      />
+      <Card withBorder p={0}>
+        <Table verticalSpacing="md" horizontalSpacing="md">
+          <Table.Thead>
+            <Table.Tr>
+              <SortableTh label="App" column="app" sort={sort} onSort={onSort} />
+              <Table.Th>Link</Table.Th>
+              <SortableTh label="Status" column="status" sort={sort} onSort={onSort} />
+              <SortableTh label="Submitted" column="submitted" sort={sort} onSort={onSort} />
+              <SortableTh label="Reviewed" column="reviewed" sort={sort} onSort={onSort} />
+              <Table.Th />
             </Table.Tr>
-          ))}
-        </Table.Tbody>
-      </Table>
-    </Card>
+          </Table.Thead>
+          <Table.Tbody>
+            {groups.length === 0 ? (
+              <Table.Tr>
+                <Table.Td colSpan={6}>
+                  <Text size="sm" c="dimmed" ta="center" py="sm">
+                    No submissions match “{query}”.
+                  </Text>
+                </Table.Td>
+              </Table.Tr>
+            ) : (
+              groups.map((g) => {
+                const isExpanded = expanded.has(g.identity);
+                return (
+                  <Fragment key={g.identity}>
+                    <OffsiteRow
+                      submission={g.latest}
+                      nested={false}
+                      onWithdraw={onWithdraw}
+                      withdrawing={withdrawing}
+                      toggle={
+                        g.older.length > 0 ? (
+                          <VersionToggle
+                            expanded={isExpanded}
+                            count={g.versionCount}
+                            onToggle={() => toggle(g.identity)}
+                            testId={`apps-offsite-versions-${g.identity}`}
+                          />
+                        ) : undefined
+                      }
+                    />
+                    {isExpanded &&
+                      g.older.map((older) => (
+                        <OffsiteRow
+                          key={older.id}
+                          submission={older}
+                          nested
+                          onWithdraw={onWithdraw}
+                          withdrawing={withdrawing}
+                        />
+                      ))}
+                  </Fragment>
+                );
+              })
+            )}
+          </Table.Tbody>
+        </Table>
+      </Card>
+    </Stack>
   );
 }

--- a/src/components/Apps/__tests__/assetPolling.test.ts
+++ b/src/components/Apps/__tests__/assetPolling.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import {
+  POLL_BUDGET_MS,
+  POLL_SCHEDULE_MS,
+  classifyAttachResult,
+  nextPollDelay,
+  shouldKeepPolling,
+} from '~/components/Apps/assetPolling';
+
+/**
+ * W13 P3a — off-site asset-attach AUTO-POLL decision logic. Pins the backoff
+ * schedule, the terminal-on-error / terminal-on-success classification, and the
+ * timeout-after-budget behaviour so the poll loop is provable WITHOUT mounting the
+ * component or faking timers.
+ */
+
+describe('classifyAttachResult', () => {
+  it('null message (resolved) → attached (terminal)', () => {
+    expect(classifyAttachResult(null)).toEqual({ kind: 'attached' });
+  });
+
+  it('"scan is not complete" → scanning (retriable)', () => {
+    expect(classifyAttachResult('Image scan is not complete yet')).toEqual({ kind: 'scanning' });
+  });
+
+  it('matches the scan message case-insensitively', () => {
+    expect(classifyAttachResult('SCAN IS NOT COMPLETE').kind).toBe('scanning');
+  });
+
+  it('any other message → error (terminal) carrying the reason', () => {
+    expect(classifyAttachResult('Image was blocked (NSFW)')).toEqual({
+      kind: 'error',
+      message: 'Image was blocked (NSFW)',
+    });
+  });
+});
+
+describe('nextPollDelay — backoff schedule', () => {
+  it('returns each scheduled delay in order for early attempts', () => {
+    expect(nextPollDelay(0)).toBe(POLL_SCHEDULE_MS[0]);
+    expect(nextPollDelay(1)).toBe(POLL_SCHEDULE_MS[1]);
+    expect(nextPollDelay(2)).toBe(POLL_SCHEDULE_MS[2]);
+  });
+
+  it('reuses the LAST schedule entry for attempts past the array (until budget)', () => {
+    const last = POLL_SCHEDULE_MS[POLL_SCHEDULE_MS.length - 1];
+    // Just past the array end, still within budget → the last (repeated) value.
+    expect(nextPollDelay(POLL_SCHEDULE_MS.length)).toBe(last);
+  });
+
+  it('is front-loaded then eased out (non-decreasing early delays)', () => {
+    for (let i = 1; i < POLL_SCHEDULE_MS.length; i++) {
+      expect(POLL_SCHEDULE_MS[i]).toBeGreaterThanOrEqual(POLL_SCHEDULE_MS[i - 1]);
+    }
+  });
+
+  it('returns null once the cumulative budget would be exceeded (timeout)', () => {
+    // Walk attempts until it gives up; the sum of granted delays must not exceed budget.
+    let attempt = 0;
+    let total = 0;
+    let delay = nextPollDelay(attempt);
+    while (delay !== null) {
+      total += delay;
+      attempt++;
+      delay = nextPollDelay(attempt);
+      // Safety valve so a bug can't infinite-loop the test.
+      if (attempt > 10000) break;
+    }
+    expect(delay).toBeNull();
+    expect(total).toBeLessThanOrEqual(POLL_BUDGET_MS);
+    // And the whole window is in the intended ~2–3 min ballpark.
+    expect(total).toBeGreaterThanOrEqual(120000);
+  });
+
+  it('rejects a negative / non-finite attempt with null', () => {
+    expect(nextPollDelay(-1)).toBeNull();
+    expect(nextPollDelay(Number.NaN)).toBeNull();
+  });
+
+  it('honours a custom schedule + budget (pure, injectable)', () => {
+    const schedule = [10, 20];
+    const budget = 45;
+    expect(nextPollDelay(0, schedule, budget)).toBe(10); // cum 0 + 10 ≤ 45
+    expect(nextPollDelay(1, schedule, budget)).toBe(20); // cum 10 + 20 ≤ 45
+    // attempt 2 reuses last (20); cum 10+20=30, +20=50 > 45 → give up.
+    expect(nextPollDelay(2, schedule, budget)).toBeNull();
+  });
+
+  it('an empty schedule gives up immediately', () => {
+    expect(nextPollDelay(0, [], 1000)).toBeNull();
+  });
+});
+
+describe('shouldKeepPolling', () => {
+  it('keeps polling on a scanning outcome within budget, returning the delay', () => {
+    expect(shouldKeepPolling({ kind: 'scanning' }, 0)).toEqual({
+      keep: true,
+      delayMs: POLL_SCHEDULE_MS[0],
+    });
+  });
+
+  it('STOPS on an attached outcome (terminal, no delay)', () => {
+    expect(shouldKeepPolling({ kind: 'attached' }, 0)).toEqual({ keep: false });
+  });
+
+  it('STOPS on an error outcome (terminal — blocked/NSFW)', () => {
+    expect(shouldKeepPolling({ kind: 'error', message: 'blocked' }, 0)).toEqual({ keep: false });
+  });
+
+  it('STOPS on a scanning outcome once the budget is exhausted (→ timeout)', () => {
+    const schedule = [10];
+    const budget = 15;
+    // attempt 0 fits (10 ≤ 15); attempt 1 would be 10+10=20 > 15 → stop.
+    expect(shouldKeepPolling({ kind: 'scanning' }, 0, schedule, budget)).toEqual({
+      keep: true,
+      delayMs: 10,
+    });
+    expect(shouldKeepPolling({ kind: 'scanning' }, 1, schedule, budget)).toEqual({ keep: false });
+  });
+});

--- a/src/components/Apps/__tests__/normalizeLinkUrl.test.ts
+++ b/src/components/Apps/__tests__/normalizeLinkUrl.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeLinkUrl } from '~/components/Apps/offsiteSubmitFormConfig';
+import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
+
+/**
+ * W13 — External-link "Link URL" NORMALIZER. Locked policy: prepend https:// when
+ * the scheme is missing, but REJECT an explicit http:// (no silent upgrade). Pins
+ * every branch so the stored/submitted value is always a canonical https URL (or a
+ * surfaced error) and can't drift from the shared `validateExternalUrl` contract.
+ */
+
+describe('normalizeLinkUrl — bare domain → https (prepend)', () => {
+  it('prepends https:// to a bare host', () => {
+    expect(normalizeLinkUrl('example.com')).toEqual({ url: 'https://example.com/' });
+  });
+
+  it('prepends https:// to a bare host + path', () => {
+    expect(normalizeLinkUrl('example.com/app')).toEqual({ url: 'https://example.com/app' });
+  });
+
+  it('prepends https:// to a host:port (colon is a port, not a scheme)', () => {
+    expect(normalizeLinkUrl('example.com:8443/app')).toEqual({
+      url: 'https://example.com:8443/app',
+    });
+  });
+
+  it('prepends https:// to a subdomain host', () => {
+    expect(normalizeLinkUrl('vitrine.civitai.com')).toEqual({
+      url: 'https://vitrine.civitai.com/',
+    });
+  });
+});
+
+describe('normalizeLinkUrl — explicit http:// is REJECTED (not upgraded)', () => {
+  it('rejects http:// with the fix-it message', () => {
+    expect(normalizeLinkUrl('http://example.com')).toEqual({
+      url: '',
+      error: 'Use https:// (or omit the scheme)',
+    });
+  });
+
+  it('rejects HTTP:// case-insensitively', () => {
+    expect(normalizeLinkUrl('HTTP://Example.com')).toEqual({
+      url: '',
+      error: 'Use https:// (or omit the scheme)',
+    });
+  });
+
+  it('does NOT silently upgrade http:// to https:// (stays an error)', () => {
+    const result = normalizeLinkUrl('http://example.com/app');
+    expect(result.url).toBe('');
+    expect(result.error).toBeDefined();
+  });
+});
+
+describe('normalizeLinkUrl — valid https passthrough (canonicalized)', () => {
+  it('keeps an https URL and canonicalizes it', () => {
+    expect(normalizeLinkUrl('https://example.com/app')).toEqual({
+      url: 'https://example.com/app',
+    });
+  });
+
+  it('trims surrounding whitespace before parsing', () => {
+    expect(normalizeLinkUrl('  https://example.com/app  ')).toEqual({
+      url: 'https://example.com/app',
+    });
+  });
+
+  it('a bare host that normalizes then passes validateExternalUrl round-trips', () => {
+    const result = normalizeLinkUrl('example.com/app');
+    expect(result.error).toBeUndefined();
+    // The normalized value is itself a valid external URL (server contract).
+    expect(validateExternalUrl(result.url).ok).toBe(true);
+  });
+});
+
+describe('normalizeLinkUrl — hostile schemes are rejected', () => {
+  it.each([
+    ['javascript pseudo-scheme', 'javascript:alert(1)'],
+    ['data URI', 'data:text/html,<script>'],
+    ['ftp scheme (has ://, not upgraded)', 'ftp://example.com'],
+  ])('%s → error, empty url', (_label, input) => {
+    const result = normalizeLinkUrl(input);
+    expect(result.url).toBe('');
+    expect(result.error).toBeDefined();
+  });
+
+  // NOTE: a scheme-LIKE prefix with no `://` and an `@` (e.g. `mailto:x@host`)
+  // is, under the locked `://` policy, prepended to `https://mailto:x@host` — which
+  // parses as a valid https URL (`mailto:x` becomes userinfo). It is NOT rejected.
+  // That's a harmless consequence of the policy (the result is still https) and was
+  // not a spec-required reject case, so it is intentionally not asserted here.
+});
+
+describe('normalizeLinkUrl — empty / whitespace', () => {
+  it('empty string → error', () => {
+    const result = normalizeLinkUrl('');
+    expect(result.url).toBe('');
+    expect(result.error).toBe('externalUrl must not be empty');
+  });
+
+  it('whitespace-only → error', () => {
+    const result = normalizeLinkUrl('   ');
+    expect(result.url).toBe('');
+    expect(result.error).toBe('externalUrl must not be empty');
+  });
+});

--- a/src/components/Apps/__tests__/submissionsTable.test.ts
+++ b/src/components/Apps/__tests__/submissionsTable.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ariaSortFor,
+  compareDate,
+  compareStatus,
+  compareText,
+  filterGroups,
+  groupSubmissionsByApp,
+  matchesQuery,
+  nextSortState,
+  sortGroups,
+  statusRank,
+  toDate,
+  type SortState,
+  type SubmissionAccessors,
+} from '~/components/Apps/submissionsTable';
+
+/**
+ * W13 — /apps/my-submissions table view-model logic (shared by the onsite +
+ * offsite lists). Pins the column comparators, the case-insensitive name/slug
+ * filter, and the per-app version-collapse so filter/sort/group can't drift and
+ * are provable without mounting a table.
+ */
+
+// A minimal row shape covering both lists' needs for these pure helpers.
+type Row = {
+  id: string;
+  identity: string;
+  name: string;
+  slug: string;
+  status: string;
+  submittedAt: string | Date | null;
+  reviewedAt: string | Date | null;
+};
+
+const A: SubmissionAccessors<Row> = {
+  identity: (r) => r.identity,
+  name: (r) => r.name,
+  slug: (r) => r.slug,
+  status: (r) => r.status,
+  submittedAt: (r) => toDate(r.submittedAt),
+  reviewedAt: (r) => toDate(r.reviewedAt),
+};
+
+function row(overrides: Partial<Row>): Row {
+  return {
+    id: 'r',
+    identity: 'app',
+    name: 'App',
+    slug: 'app',
+    status: 'pending',
+    submittedAt: '2026-01-01T00:00:00Z',
+    reviewedAt: null,
+    ...overrides,
+  };
+}
+
+describe('statusRank / compareStatus — pending → approved → rejected → withdrawn', () => {
+  it('ranks the known statuses in the intended order', () => {
+    expect(statusRank('pending')).toBeLessThan(statusRank('approved'));
+    expect(statusRank('approved')).toBeLessThan(statusRank('rejected'));
+    expect(statusRank('rejected')).toBeLessThan(statusRank('withdrawn'));
+  });
+
+  it('an unknown status ranks after all known ones', () => {
+    expect(statusRank('weird')).toBeGreaterThan(statusRank('withdrawn'));
+  });
+
+  it('compareStatus orders by rank', () => {
+    expect(compareStatus('pending', 'approved')).toBeLessThan(0);
+    expect(compareStatus('withdrawn', 'pending')).toBeGreaterThan(0);
+    expect(compareStatus('approved', 'approved')).toBe(0);
+  });
+});
+
+describe('compareText — case-insensitive', () => {
+  it('sorts alphabetically ignoring case', () => {
+    expect(compareText('alpha', 'Beta')).toBeLessThan(0);
+    expect(compareText('Zed', 'apple')).toBeGreaterThan(0);
+    expect(compareText('Same', 'same')).toBe(0);
+  });
+});
+
+describe('compareDate — nulls sort as oldest', () => {
+  it('orders older before newer', () => {
+    expect(compareDate(new Date('2026-01-01'), new Date('2026-02-01'))).toBeLessThan(0);
+    expect(compareDate(new Date('2026-03-01'), new Date('2026-02-01'))).toBeGreaterThan(0);
+  });
+
+  it('a null date sorts as the oldest (before any real date)', () => {
+    expect(compareDate(null, new Date('2026-01-01'))).toBeLessThan(0);
+    expect(compareDate(new Date('2026-01-01'), null)).toBeGreaterThan(0);
+    expect(compareDate(null, null)).toBe(0);
+  });
+});
+
+describe('matchesQuery — name OR slug, case-insensitive substring', () => {
+  it('matches on the name', () => {
+    expect(matchesQuery('My Cool App', 'other-slug', 'cool')).toBe(true);
+  });
+
+  it('matches on the slug', () => {
+    expect(matchesQuery('Name', 'vitrine-tool', 'VITRINE')).toBe(true);
+  });
+
+  it('is case-insensitive on both sides', () => {
+    expect(matchesQuery('ALPHA', 'beta', 'alp')).toBe(true);
+  });
+
+  it('does not match when neither contains the query', () => {
+    expect(matchesQuery('Alpha', 'beta', 'zzz')).toBe(false);
+  });
+
+  it('an empty/whitespace query matches everything', () => {
+    expect(matchesQuery('x', 'y', '')).toBe(true);
+    expect(matchesQuery('x', 'y', '   ')).toBe(true);
+  });
+});
+
+describe('groupSubmissionsByApp — version collapse', () => {
+  it('collapses multiple versions of one app; latest = newest by submittedAt', () => {
+    const rows = [
+      row({ id: 'v1', identity: 'app', submittedAt: '2026-01-01T00:00:00Z' }),
+      row({ id: 'v3', identity: 'app', submittedAt: '2026-03-01T00:00:00Z' }),
+      row({ id: 'v2', identity: 'app', submittedAt: '2026-02-01T00:00:00Z' }),
+    ];
+    const groups = groupSubmissionsByApp(rows, A.identity, A.submittedAt);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].versionCount).toBe(3);
+    expect(groups[0].latest.id).toBe('v3'); // newest
+    expect(groups[0].older.map((r) => r.id)).toEqual(['v2', 'v1']); // newest-first
+  });
+
+  it('a single-version app yields one group with no older versions', () => {
+    const groups = groupSubmissionsByApp(
+      [row({ id: 'only', identity: 'solo' })],
+      A.identity,
+      A.submittedAt
+    );
+    expect(groups).toHaveLength(1);
+    expect(groups[0].versionCount).toBe(1);
+    expect(groups[0].older).toEqual([]);
+  });
+
+  it('groups distinct apps separately, preserving first-seen order', () => {
+    const rows = [
+      row({ id: 'b1', identity: 'bravo' }),
+      row({ id: 'a1', identity: 'alpha' }),
+      row({ id: 'a2', identity: 'alpha', submittedAt: '2026-05-01T00:00:00Z' }),
+    ];
+    const groups = groupSubmissionsByApp(rows, A.identity, A.submittedAt);
+    expect(groups.map((g) => g.identity)).toEqual(['bravo', 'alpha']);
+    expect(groups[1].versionCount).toBe(2);
+    expect(groups[1].latest.id).toBe('a2');
+  });
+
+  it('supports mixed onsite (block id) + offsite (slug) identity keys', () => {
+    // Onsite rows key by an app-block id, offsite by slug — both are just strings
+    // here, so distinct keys never collide across the two lists.
+    const rows = [
+      row({ id: 'onsite-1', identity: 'block-123' }),
+      row({ id: 'offsite-1', identity: 'my-slug' }),
+      row({ id: 'onsite-2', identity: 'block-123', submittedAt: '2026-06-01T00:00:00Z' }),
+    ];
+    const groups = groupSubmissionsByApp(rows, A.identity, A.submittedAt);
+    expect(groups).toHaveLength(2);
+    const block = groups.find((g) => g.identity === 'block-123');
+    expect(block?.versionCount).toBe(2);
+    expect(block?.latest.id).toBe('onsite-2');
+    expect(groups.find((g) => g.identity === 'my-slug')?.versionCount).toBe(1);
+  });
+
+  it('does not mutate the input array', () => {
+    const rows = [row({ id: 'a' }), row({ id: 'b', identity: 'app', submittedAt: '2026-09-01' })];
+    const snapshot = rows.map((r) => r.id);
+    groupSubmissionsByApp(rows, A.identity, A.submittedAt);
+    expect(rows.map((r) => r.id)).toEqual(snapshot);
+  });
+});
+
+describe('filterGroups — matches if ANY version matches', () => {
+  const groups = groupSubmissionsByApp(
+    [
+      row({ id: 'v1', identity: 'app', name: 'Old Name', slug: 'app', submittedAt: '2026-01-01' }),
+      row({ id: 'v2', identity: 'app', name: 'New Name', slug: 'app', submittedAt: '2026-02-01' }),
+      row({ id: 'other', identity: 'other', name: 'Other', slug: 'other-slug' }),
+    ],
+    A.identity,
+    A.submittedAt
+  );
+
+  it('keeps a group when an OLDER version matches (not just the latest)', () => {
+    const result = filterGroups(groups, 'Old Name', A);
+    expect(result).toHaveLength(1);
+    expect(result[0].identity).toBe('app');
+  });
+
+  it('filters out a group when no version matches', () => {
+    expect(filterGroups(groups, 'Other', A).map((g) => g.identity)).toEqual(['other']);
+  });
+
+  it('an empty query returns all groups', () => {
+    expect(filterGroups(groups, '', A)).toHaveLength(2);
+  });
+});
+
+describe('sortGroups — by the latest version of each group', () => {
+  const groups = groupSubmissionsByApp(
+    [
+      row({
+        id: 'a',
+        identity: 'alpha',
+        name: 'Alpha',
+        status: 'approved',
+        submittedAt: '2026-02-01',
+        reviewedAt: '2026-02-05',
+      }),
+      row({
+        id: 'b',
+        identity: 'bravo',
+        name: 'Bravo',
+        status: 'pending',
+        submittedAt: '2026-01-01',
+        reviewedAt: null,
+      }),
+    ],
+    A.identity,
+    A.submittedAt
+  );
+
+  const ids = (s: SortState) => sortGroups(groups, s, A).map((g) => g.identity);
+
+  it('sorts by App text asc/desc', () => {
+    expect(ids({ column: 'app', direction: 'asc' })).toEqual(['alpha', 'bravo']);
+    expect(ids({ column: 'app', direction: 'desc' })).toEqual(['bravo', 'alpha']);
+  });
+
+  it('sorts by Status enum order asc/desc (pending before approved)', () => {
+    expect(ids({ column: 'status', direction: 'asc' })).toEqual(['bravo', 'alpha']);
+    expect(ids({ column: 'status', direction: 'desc' })).toEqual(['alpha', 'bravo']);
+  });
+
+  it('sorts by Submitted date asc/desc', () => {
+    expect(ids({ column: 'submitted', direction: 'asc' })).toEqual(['bravo', 'alpha']);
+    expect(ids({ column: 'submitted', direction: 'desc' })).toEqual(['alpha', 'bravo']);
+  });
+
+  it('sorts by Reviewed date, unreviewed (null) as oldest', () => {
+    // bravo has null reviewedAt (sorts oldest); alpha has a real date.
+    expect(ids({ column: 'reviewed', direction: 'asc' })).toEqual(['bravo', 'alpha']);
+    expect(ids({ column: 'reviewed', direction: 'desc' })).toEqual(['alpha', 'bravo']);
+  });
+
+  it('does not mutate the input group array', () => {
+    const before = groups.map((g) => g.identity);
+    sortGroups(groups, { column: 'app', direction: 'desc' }, A);
+    expect(groups.map((g) => g.identity)).toEqual(before);
+  });
+});
+
+describe('nextSortState — header-click toggle', () => {
+  it('toggles direction when the same column is clicked', () => {
+    expect(nextSortState({ column: 'app', direction: 'asc' }, 'app')).toEqual({
+      column: 'app',
+      direction: 'desc',
+    });
+    expect(nextSortState({ column: 'app', direction: 'desc' }, 'app')).toEqual({
+      column: 'app',
+      direction: 'asc',
+    });
+  });
+
+  it('switches column with a sensible default direction (text asc, date desc)', () => {
+    expect(nextSortState({ column: 'app', direction: 'asc' }, 'status')).toEqual({
+      column: 'status',
+      direction: 'asc',
+    });
+    expect(nextSortState({ column: 'app', direction: 'asc' }, 'submitted')).toEqual({
+      column: 'submitted',
+      direction: 'desc',
+    });
+    expect(nextSortState({ column: 'app', direction: 'asc' }, 'reviewed')).toEqual({
+      column: 'reviewed',
+      direction: 'desc',
+    });
+  });
+});
+
+describe('ariaSortFor', () => {
+  it('reports the direction for the active column, none otherwise', () => {
+    const s: SortState = { column: 'submitted', direction: 'asc' };
+    expect(ariaSortFor(s, 'submitted')).toBe('ascending');
+    expect(ariaSortFor({ column: 'submitted', direction: 'desc' }, 'submitted')).toBe('descending');
+    expect(ariaSortFor(s, 'app')).toBe('none');
+  });
+});
+
+describe('toDate', () => {
+  it('parses ISO strings, passes Date through, and maps null/invalid to null', () => {
+    expect(toDate('2026-01-01T00:00:00Z')?.getTime()).toBe(Date.parse('2026-01-01T00:00:00Z'));
+    const d = new Date('2026-05-05');
+    expect(toDate(d)).toBe(d);
+    expect(toDate(null)).toBeNull();
+    expect(toDate(undefined)).toBeNull();
+    expect(toDate('not-a-date')).toBeNull();
+  });
+});

--- a/src/components/Apps/assetPolling.ts
+++ b/src/components/Apps/assetPolling.ts
@@ -1,0 +1,106 @@
+/**
+ * App Store Listings (W13) — P3a off-site asset-attach POLL decision logic
+ * (PURE, no React, no timers). Extracted from `ExternalSubmitForm`'s asset step
+ * so the backoff schedule + the keep-polling / terminal decision are unit-testable
+ * WITHOUT mounting the component or faking timers.
+ *
+ * Context: an attach (setIcon / setCover / addScreenshot) requires a
+ * scan-complete image. A freshly-persisted image is still scanning, so the attach
+ * first rejects with "scan is not complete". Previously the asset then sat in
+ * `processing` forever until the author clicked Retry — there was NO polling. The
+ * component now auto-re-runs the attach on the schedule below, transitioning to
+ * `attached` the moment the scan lands, to `error` on a NON-scan failure (blocked
+ * / NSFW → stop), or to `timeout` once the budget is exhausted (keep the manual
+ * Retry).
+ */
+
+/** The classification of a single attach() outcome, independent of React state. */
+export type AttachOutcome =
+  /** The attach succeeded — the asset is scan-complete and attached. Terminal. */
+  | { kind: 'attached' }
+  /** The attach rejected because the scan isn't complete yet — keep polling. */
+  | { kind: 'scanning' }
+  /** The attach rejected for a non-scan reason (blocked / NSFW / bad dims). Terminal. */
+  | { kind: 'error'; message: string };
+
+/** Matches the server's "scan is not complete" rejection (the only retriable one). */
+export const SCAN_INCOMPLETE = /scan is not complete/i;
+
+/**
+ * Backoff schedule (ms) between successive attach re-tries while an image is
+ * scanning. Front-loaded (a scan usually lands within a few seconds) then eased
+ * out; the FINAL entry repeats until the cumulative budget is spent. Chosen so
+ * the total polling window is ~2–3 min — long enough for a real scan, bounded so
+ * a stuck scan surfaces a timeout instead of polling forever.
+ *
+ * attempt 0 = the delay BEFORE the 1st re-try (the initial attach already ran),
+ * attempt 1 = before the 2nd re-try, … Indices past the array reuse the last value.
+ */
+export const POLL_SCHEDULE_MS: readonly number[] = [
+  2000, 3000, 3000, 5000, 5000, 8000, 8000, 10000, 10000, 12000, 12000, 15000,
+];
+
+/**
+ * Total polling budget (ms). Once the CUMULATIVE delay of the re-tries reaches
+ * this, `nextPollDelay` returns null (give up → timeout state). Sized to admit
+ * the whole `POLL_SCHEDULE_MS` sequence plus a couple of trailing 15s repeats,
+ * i.e. ~3 min of real-world scan wait.
+ */
+export const POLL_BUDGET_MS = 180000;
+
+/**
+ * The delay (ms) to wait before re-try number `attempt` (0-indexed), or `null`
+ * when the cumulative budget is exhausted (→ stop polling, show a timeout). PURE:
+ * the schedule + budget are the only inputs, so the whole backoff is testable
+ * without timers.
+ *
+ * `attempt` must be ≥ 0. The cumulative wait BEFORE this attempt is summed from
+ * the schedule (clamping out-of-range indices to the last entry); if adding this
+ * attempt's delay would exceed `POLL_BUDGET_MS`, we give up.
+ */
+export function nextPollDelay(
+  attempt: number,
+  schedule: readonly number[] = POLL_SCHEDULE_MS,
+  budgetMs: number = POLL_BUDGET_MS
+): number | null {
+  if (!Number.isFinite(attempt) || attempt < 0) return null;
+  if (schedule.length === 0) return null;
+  const delayAt = (i: number): number =>
+    schedule[Math.min(i, schedule.length - 1)] ?? schedule[schedule.length - 1] ?? 0;
+  let cumulative = 0;
+  for (let i = 0; i < attempt; i++) cumulative += delayAt(i);
+  const thisDelay = delayAt(attempt);
+  if (cumulative + thisDelay > budgetMs) return null;
+  return thisDelay;
+}
+
+/**
+ * Classify an attach() result — either a resolved success or a caught error's
+ * message — into an {@link AttachOutcome}. PURE. `errorMessage === null` means the
+ * attach resolved (success). A "scan is not complete" message is retriable
+ * (`scanning`); any other message is a terminal `error`.
+ */
+export function classifyAttachResult(errorMessage: string | null): AttachOutcome {
+  if (errorMessage === null) return { kind: 'attached' };
+  if (SCAN_INCOMPLETE.test(errorMessage)) return { kind: 'scanning' };
+  return { kind: 'error', message: errorMessage };
+}
+
+/**
+ * Whether to schedule ANOTHER poll given the latest outcome and the number of
+ * re-tries already made. PURE. Keep polling only while the outcome is `scanning`
+ * AND the schedule still has budget for the next attempt. Returns the delay to
+ * use (so the caller doesn't re-derive it) or `null` to STOP (terminal outcome or
+ * budget exhausted → the caller shows attached / error / timeout accordingly).
+ */
+export function shouldKeepPolling(
+  outcome: AttachOutcome,
+  attempt: number,
+  schedule: readonly number[] = POLL_SCHEDULE_MS,
+  budgetMs: number = POLL_BUDGET_MS
+): { keep: true; delayMs: number } | { keep: false } {
+  if (outcome.kind !== 'scanning') return { keep: false };
+  const delayMs = nextPollDelay(attempt, schedule, budgetMs);
+  if (delayMs === null) return { keep: false };
+  return { keep: true, delayMs };
+}

--- a/src/components/Apps/offsiteSubmitFormConfig.ts
+++ b/src/components/Apps/offsiteSubmitFormConfig.ts
@@ -55,9 +55,7 @@ export type OffsiteSubmitFormValues = {
   changelog: string;
 };
 
-export type OffsiteSubmitFormErrors = Partial<
-  Record<keyof OffsiteSubmitFormValues, string>
->;
+export type OffsiteSubmitFormErrors = Partial<Record<keyof OffsiteSubmitFormValues, string>>;
 
 /** Category `<Select>` data (value + human label). */
 export const OFFSITE_CATEGORY_OPTIONS: Array<{ value: MarketplaceCategory; label: string }> =
@@ -197,6 +195,46 @@ export function deriveListingFromUrl(url: string): { name: string; slug: string 
       : '';
 
   return { name, slug };
+}
+
+/**
+ * Normalize a raw "Link URL" input into the canonical https URL that will be
+ * STORED / submitted. PURE + unit-tested. Locked policy: *prepend https if the
+ * scheme is missing, but REJECT an explicit `http://`* (don't silently upgrade —
+ * make the user fix it so they're never surprised their http link became https).
+ *
+ * Rules (deterministic, pinned by the unit tests):
+ *   - trim; empty → `{ url: '', error }` (as `validateExternalUrl` would).
+ *   - starts with `http://` (case-insensitive) → `{ url: '', error }` with a
+ *     "Use https://" message — NOT a silent upgrade.
+ *   - contains NO scheme separator (`://`) → prepend `https://` (a bare domain
+ *     `example.com/app`, or a `host:port` like `example.com:8443/app`, becomes
+ *     `https://…`). A pseudo-scheme with no `://` (`javascript:…`, `data:…`) is
+ *     also prepended, then rejected by `validateExternalUrl` when the resulting
+ *     string fails to parse — the reject outcome is what matters.
+ *   - already has a scheme (`https://…`, `ftp://…`, …) → passed through unchanged
+ *     to `validateExternalUrl`, which accepts only https and rejects the rest.
+ *   - then run the shared `validateExternalUrl` on the result → `{ url }` (the
+ *     canonical https URL) on ok, else `{ url: '', error }`.
+ *
+ * The SERVER validation (`validateExternalUrl`, https-only) is unchanged; the
+ * client just normalizes so the submitted `externalUrl` is already https.
+ */
+export function normalizeLinkUrl(raw: string): { url: string; error?: string } {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return { url: '', error: 'externalUrl must not be empty' };
+  }
+  // Explicit http:// → reject (do NOT silently upgrade to https).
+  if (/^http:\/\//i.test(trimmed)) {
+    return { url: '', error: 'Use https:// (or omit the scheme)' };
+  }
+  // No scheme separator → prepend https://. A scheme present (`ftp://`, `data:…`
+  // once it parses, etc.) is left for `validateExternalUrl` to reject.
+  const candidate = trimmed.includes('://') ? trimmed : `https://${trimmed}`;
+  const result = validateExternalUrl(candidate);
+  if (!result.ok) return { url: '', error: result.error };
+  return { url: result.url };
 }
 
 /**

--- a/src/components/Apps/screenshotSlots.ts
+++ b/src/components/Apps/screenshotSlots.ts
@@ -11,7 +11,17 @@
  * id removes the index/closure dependency entirely.
  */
 
-export type ScreenshotSlotStatus = 'idle' | 'working' | 'attached' | 'processing' | 'error';
+export type ScreenshotSlotStatus =
+  | 'idle'
+  | 'working'
+  /** actively auto-polling the attach while the async scan completes */
+  | 'scanning'
+  | 'attached'
+  /** @deprecated superseded by the auto-poll `scanning`/`timeout` states */
+  | 'processing'
+  /** the scan didn't complete within the poll budget — manual Retry offered */
+  | 'timeout'
+  | 'error';
 
 export type ScreenshotSlot = {
   /** Stable per-file id — the ONLY key used to address a slot after creation. */

--- a/src/components/Apps/submissionsTable.ts
+++ b/src/components/Apps/submissionsTable.ts
@@ -1,0 +1,193 @@
+/**
+ * App Store Listings (W13) — /apps/my-submissions table view-model logic (PURE,
+ * no React). Shared by BOTH lists (onsite `MySubmissionsList` + offsite
+ * `OffsiteSubmissionsList`) so the text filter, the column comparators, and the
+ * per-app version-collapse behave IDENTICALLY across them. Extracted so each piece
+ * is unit-testable without mounting a table.
+ *
+ * The two row shapes differ (onsite has a block id + version; offsite has a slug +
+ * external URL), so every helper here is GENERIC over the row type `T` and reads
+ * the sortable / filterable / identity fields through a small `SubmissionAccessors`
+ * adapter the caller supplies. That keeps this module free of any dependency on the
+ * concrete `Submission` / `OffsiteSubmission` types.
+ */
+
+/** Sortable columns shared by both tables. */
+export type SortColumn = 'app' | 'status' | 'submitted' | 'reviewed';
+export type SortDirection = 'asc' | 'desc';
+export type SortState = { column: SortColumn; direction: SortDirection };
+
+/**
+ * Status sort order (pending → approved → rejected → withdrawn): active/actionable
+ * first, terminal last. An unknown status sorts after all known ones (kept stable
+ * by an alphabetical tiebreak) so a future status degrades gracefully.
+ */
+export const STATUS_SORT_ORDER: Readonly<Record<string, number>> = {
+  pending: 0,
+  approved: 1,
+  rejected: 2,
+  withdrawn: 3,
+};
+
+export function statusRank(status: string): number {
+  return STATUS_SORT_ORDER[status] ?? Number.MAX_SAFE_INTEGER;
+}
+
+/** Coerce a `string | Date | null | undefined` timestamp to a `Date | null`. */
+export function toDate(d: string | Date | null | undefined): Date | null {
+  if (d == null) return null;
+  const date = typeof d === 'string' ? new Date(d) : d;
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Field adapters for a concrete row type. `name` is the human app name (fall back
+ * to the slug when a row has none), `slug` the URL slug, `identity` the
+ * version-collapse key (offsite = slug, onsite = the block/app id).
+ */
+export type SubmissionAccessors<T> = {
+  identity: (row: T) => string;
+  name: (row: T) => string;
+  slug: (row: T) => string;
+  status: (row: T) => string;
+  submittedAt: (row: T) => Date | null;
+  reviewedAt: (row: T) => Date | null;
+};
+
+/** A collapsed per-app group: the newest request + the older ones (newest-first). */
+export type SubmissionGroup<T> = {
+  identity: string;
+  latest: T;
+  older: T[];
+  versionCount: number;
+};
+
+// ── comparators (pure, primitive-typed — unit-tested independently) ────────────
+
+/** Case-insensitive text compare (App column). */
+export function compareText(a: string, b: string): number {
+  return a.localeCompare(b, undefined, { sensitivity: 'base' });
+}
+
+/** Status compare by {@link statusRank}, alphabetical tiebreak for equal ranks. */
+export function compareStatus(a: string, b: string): number {
+  const ra = statusRank(a);
+  const rb = statusRank(b);
+  if (ra !== rb) return ra < rb ? -1 : 1;
+  return a.localeCompare(b);
+}
+
+/** Date compare; a null date sorts as the OLDEST (so direction flips it cleanly). */
+export function compareDate(a: Date | null, b: Date | null): number {
+  const ta = a ? a.getTime() : -Infinity;
+  const tb = b ? b.getTime() : -Infinity;
+  if (ta === tb) return 0;
+  return ta < tb ? -1 : 1;
+}
+
+// ── filter ─────────────────────────────────────────────────────────────────────
+
+/** Case-insensitive substring match of a query against a row's name OR slug. */
+export function matchesQuery(name: string, slug: string, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return true;
+  return name.toLowerCase().includes(q) || slug.toLowerCase().includes(q);
+}
+
+// ── group / collapse ─────────────────────────────────────────────────────────
+
+/**
+ * Collapse rows by app identity. Groups preserve first-seen order; within a group
+ * the rows are sorted newest-first by `submittedAt`, so `latest` is the newest
+ * request and `older` the rest (newest-first). PURE — never mutates the input.
+ */
+export function groupSubmissionsByApp<T>(
+  rows: readonly T[],
+  identityOf: (row: T) => string,
+  submittedAtOf: (row: T) => Date | null
+): SubmissionGroup<T>[] {
+  const buckets = new Map<string, T[]>();
+  for (const row of rows) {
+    const id = identityOf(row);
+    const bucket = buckets.get(id);
+    if (bucket) bucket.push(row);
+    else buckets.set(id, [row]);
+  }
+  const result: SubmissionGroup<T>[] = [];
+  for (const [identity, members] of buckets) {
+    const sorted = [...members].sort(
+      (a: T, b: T) =>
+        (submittedAtOf(b)?.getTime() ?? -Infinity) - (submittedAtOf(a)?.getTime() ?? -Infinity)
+    );
+    const latest = sorted[0];
+    if (latest === undefined) continue; // unreachable (buckets never empty) — type guard
+    result.push({ identity, latest, older: sorted.slice(1), versionCount: sorted.length });
+  }
+  return result;
+}
+
+// ── filter + sort over the grouped view ────────────────────────────────────────
+
+/** Keep a group if ANY of its versions matches the query (name or slug). */
+export function filterGroups<T>(
+  groups: readonly SubmissionGroup<T>[],
+  query: string,
+  accessors: SubmissionAccessors<T>
+): SubmissionGroup<T>[] {
+  const q = query.trim();
+  if (q.length === 0) return [...groups];
+  return groups.filter((g: SubmissionGroup<T>) =>
+    [g.latest, ...g.older].some((row: T) =>
+      matchesQuery(accessors.name(row), accessors.slug(row), q)
+    )
+  );
+}
+
+/**
+ * Sort groups by the chosen column's value on each group's `latest` request.
+ * Stable (Array.prototype.sort is stable), non-mutating. `direction` flips the
+ * base comparator.
+ */
+export function sortGroups<T>(
+  groups: readonly SubmissionGroup<T>[],
+  sort: SortState,
+  accessors: SubmissionAccessors<T>
+): SubmissionGroup<T>[] {
+  const factor = sort.direction === 'asc' ? 1 : -1;
+  const base = (a: SubmissionGroup<T>, b: SubmissionGroup<T>): number => {
+    const la = a.latest;
+    const lb = b.latest;
+    switch (sort.column) {
+      case 'app':
+        return compareText(accessors.name(la), accessors.name(lb));
+      case 'status':
+        return compareStatus(accessors.status(la), accessors.status(lb));
+      case 'submitted':
+        return compareDate(accessors.submittedAt(la), accessors.submittedAt(lb));
+      case 'reviewed':
+        return compareDate(accessors.reviewedAt(la), accessors.reviewedAt(lb));
+    }
+  };
+  return [...groups].sort((a: SubmissionGroup<T>, b: SubmissionGroup<T>) => factor * base(a, b));
+}
+
+/** The next sort state when a column header is clicked: toggle direction on the
+ *  same column, else switch to the new column with a sensible default direction
+ *  (text/status default asc, dates default desc = newest first). */
+export function nextSortState(current: SortState, column: SortColumn): SortState {
+  if (current.column === column) {
+    return { column, direction: current.direction === 'asc' ? 'desc' : 'asc' };
+  }
+  const defaultDirection: SortDirection =
+    column === 'submitted' || column === 'reviewed' ? 'desc' : 'asc';
+  return { column, direction: defaultDirection };
+}
+
+/** `aria-sort` value for a header, given the active sort state. */
+export function ariaSortFor(
+  sort: SortState,
+  column: SortColumn
+): 'ascending' | 'descending' | 'none' {
+  if (sort.column !== column) return 'none';
+  return sort.direction === 'asc' ? 'ascending' : 'descending';
+}

--- a/src/components/Apps/submissionsTableUi.tsx
+++ b/src/components/Apps/submissionsTableUi.tsx
@@ -1,0 +1,118 @@
+import { Badge, Button, Table, Text, TextInput, UnstyledButton } from '@mantine/core';
+import {
+  IconArrowsSort,
+  IconChevronDown,
+  IconChevronRight,
+  IconSearch,
+  IconSortAscending,
+  IconSortDescending,
+} from '@tabler/icons-react';
+import { ariaSortFor, type SortColumn, type SortState } from '~/components/Apps/submissionsTable';
+
+/**
+ * App Store Listings (W13) — shared /apps/my-submissions table UI atoms, used by
+ * BOTH the onsite (`MySubmissionsList`) and offsite (`OffsiteSubmissionsList`)
+ * tables so the filter box, the sortable headers, and the version-collapse toggle
+ * look + behave identically. Pure presentational — all state lives in the parent
+ * list; the pure filter/sort/group logic lives in `submissionsTable.ts`.
+ *
+ * Accessibility: the sortable header is a real <button> inside a <th> carrying
+ * `aria-sort`; the version toggle is a <button> carrying `aria-expanded`.
+ */
+
+/** A sortable column header: a `<th aria-sort>` wrapping a real sort <button>. */
+export function SortableTh({
+  label,
+  column,
+  sort,
+  onSort,
+}: {
+  label: string;
+  column: SortColumn;
+  sort: SortState;
+  onSort: (column: SortColumn) => void;
+}) {
+  const active = sort.column === column;
+  const DirectionIcon = !active
+    ? IconArrowsSort
+    : sort.direction === 'asc'
+    ? IconSortAscending
+    : IconSortDescending;
+  return (
+    <Table.Th aria-sort={ariaSortFor(sort, column)}>
+      <UnstyledButton
+        onClick={() => onSort(column)}
+        aria-label={`Sort by ${label}`}
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+      >
+        <Text size="sm" fw={600} span>
+          {label}
+        </Text>
+        <DirectionIcon size={14} style={{ opacity: active ? 1 : 0.45 }} />
+      </UnstyledButton>
+    </Table.Th>
+  );
+}
+
+/** The client-side text filter box shown above a submissions table. */
+export function SubmissionSearch({
+  value,
+  onChange,
+  testId,
+  placeholder = 'Filter by app name or slug…',
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  testId?: string;
+  placeholder?: string;
+}) {
+  return (
+    <TextInput
+      value={value}
+      onChange={(e) => onChange(e.currentTarget.value)}
+      placeholder={placeholder}
+      aria-label="Filter submissions"
+      leftSection={<IconSearch size={16} />}
+      size="sm"
+      maw={360}
+      data-testid={testId}
+    />
+  );
+}
+
+/** The "N versions" expand/collapse affordance on a collapsed app group row. */
+export function VersionToggle({
+  expanded,
+  count,
+  onToggle,
+  testId,
+}: {
+  expanded: boolean;
+  count: number;
+  onToggle: () => void;
+  testId?: string;
+}) {
+  return (
+    <Button
+      size="compact-xs"
+      variant="light"
+      color="gray"
+      aria-expanded={expanded}
+      leftSection={expanded ? <IconChevronDown size={14} /> : <IconChevronRight size={14} />}
+      onClick={onToggle}
+      data-testid={testId}
+    >
+      {count} {count === 1 ? 'version' : 'versions'}
+    </Button>
+  );
+}
+
+/** A small inert "N versions" badge for a group with older versions (non-toggle). */
+export function VersionCountBadge({ count }: { count: number }) {
+  if (count <= 1) return null;
+  return (
+    <Badge size="xs" variant="light" color="gray">
+      {count} versions
+    </Badge>
+  );
+}


### PR DESCRIPTION
Client-only UX pass on the App-Blocks author flow. **No backend / schema / proc change** — the server stays the source of truth (same `validateExternalUrl`, same procs). **Dark**: these pages are `app-blocks-author` / `app-blocks-enabled` gated; nothing renders to real users. Branched off current `main` (includes the merged submit redesign #2971).

## 3 areas / 7 changes

### A. External-link wizard (`ExternalSubmitForm.tsx`, `offsiteSubmitFormConfig.ts`)
1. **Renamed field** "External URL" → **"Link URL"** + description *"Where users will land when they click your app."*
2. **`normalizeLinkUrl(raw)`** (new pure helper) so the stored/submitted `externalUrl` is always canonical https:
   - trim; empty → error.
   - starts with `http://` (case-insensitive) → **error** "Use https:// (or omit the scheme)" (no silent upgrade).
   - no `://` → **prepend `https://`** (bare domain `example.com/app`, `host:port` `example.com:8443/app`).
   - has a scheme (`ftp://`, `javascript:`, `data:`…) → passed to the shared `validateExternalUrl`, which accepts only https and rejects the rest.
   - normalizes on blur, on Next, and on step-click; `deriveListingFromUrl` runs on the normalized URL. A bare domain no longer shows an error; explicit `http://` does. Server validation unchanged.
3. **Enter advances the step** — URL step: normalize+validate → Details; Details step: Create draft only when `isDetailsStepComplete` (guards an accidental empty submit). Textareas keep newline behavior.

### B. Asset step — fix the stuck "processing" (auto-poll)
4. After an attach returns *"scan is not complete"*, the asset now **auto-polls** the attach on a backoff and flips to **attached** the moment the scan lands — no more waiting on a manual Retry.
   - **Backoff:** `2s, 3s, 3s, 5s, 5s, 8s, 8s, 10s, 10s, 12s, 12s, 15s…` (last value repeats) within a **~180s budget** (grants ~168s of retries). Spinner + "Scanning image…" while polling.
   - **Terminal states:** `attached` (done), `error` (non-scan reason: blocked/NSFW → show reason, stop), `timeout` (budget spent → keep the manual **Retry** fallback). Applies to **icon, cover, and each screenshot**.
   - Pure decision logic extracted to **`assetPolling.ts`** (`nextPollDelay` / `classifyAttachResult` / `shouldKeepPolling`) — unit-tested without timers or mounting.
   - Timers cleared on success / error / timeout / manual Retry / unmount; a per-asset **epoch guard** prevents overlapping polls. On a **PR preview the scanner is unreachable**, so a real image polls → `timeout` (expected — validated on prod).

### C. `/apps/my-submissions` — filter + sort + version-collapse (BOTH lists)
5. **Text filter** — case-insensitive substring over app name + slug, client-side.
6. **Sortable headers** — App (text) / Status (pending→approved→rejected→withdrawn) / Submitted / Reviewed, toggling asc/desc with a direction indicator + `aria-sort`. Comparators are pure unit-tested helpers.
7. **Version-collapse** — group by app identity (**offsite = `slug`**, **onsite = block id `?? slug`**), show the newest request + an **"N versions"** toggle (`aria-expanded`) that expands the older ones. Filter matches if any version matches; sort sorts groups by the latest's value. Pure `groupSubmissionsByApp` → `{ latest, older[] }[]`. Shared pure logic in **`submissionsTable.ts`**, shared UI atoms in **`submissionsTableUi.tsx`** so both tables behave identically.

## Tests
- **+58 unit tests** (the gate): `normalizeLinkUrl` (bare→https, http→error, javascript/data/ftp→reject, https passthrough, empty/whitespace), `assetPolling` (backoff schedule, terminal-on-error/success, timeout-after-budget), `submissionsTable` (each comparator asc/desc, name+slug filter, version-collapse incl. mixed onsite/offsite keys). Existing `deriveListingFromUrl` / `offsiteSubmitFormConfig` / `screenshotSlots` suites kept green — **203 Apps unit tests pass**.
- Component/browser tests updated (renamed field, Enter-advance, filter/sort/expand) — report-only (Tekton).
- `tsc --noEmit` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)