### PR TITLE
fix(dev-tunnel-gate): allow websocket upgrades so App Blocks dev-tunnel HMR flows

### DIFF
--- a/src/pages/api/internal/dev-tunnel-gate.ts
+++ b/src/pages/api/internal/dev-tunnel-gate.ts
@@ -29,6 +29,14 @@ import { verifyDevTunnelAccessToken } from '~/server/services/blocks/dev-tunnel-
  * Authorizes ONLY the ENTRY document/iframe request (the one that can carry the
  * `dev` token) and ALLOWS subresources through, per the tradeoff above.
  *
+ *   - WEBSOCKET UPGRADE (`Upgrade: websocket`, e.g. the Vite HMR socket
+ *     `wss://dev-<hex>/?token=…`): 200 (allow). A ws handshake is structurally a
+ *     subresource — it can NEVER be a top-level document navigation — so allowing
+ *     it does not weaken the naked-entry-document 401 property. Keyed on the
+ *     DEFINITIONAL `Upgrade` handshake header (RFC 6455), not on the browser
+ *     emitting `Sec-Fetch-Dest: websocket` (which the subresource branch would
+ *     also allow, but which some browsers/proxies omit → the request would fall
+ *     into the ENTRY branch and 401 the HMR socket). Deterministic, not heuristic.
  *   - ENTRY (Sec-Fetch-Dest document/iframe/frame/nested-document, OR ABSENT →
  *     treated as entry, fail-safe): require a valid `dev` token bound to
  *     X-Forwarded-Host → 200 + X-Dev-User-Id, else 401.
@@ -65,6 +73,21 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // Fail-closed: without the dev host we can't bind/verify anything.
   if (!forwardedHost) {
     res.status(401).json({ error: 'Missing dev host' });
+    return;
+  }
+
+  // WEBSOCKET UPGRADE → allow (e.g. the Vite HMR socket `wss://dev-<hex>/?token=…`
+  // so live-reload flows over the tunnel). A ws handshake is structurally a
+  // subresource and can never be a top-level document navigation, so this does
+  // NOT weaken the naked-entry-document 401 property (and the ws still only
+  // reaches the AUTHOR'S OWN localhost, host-secrecy protected — same tradeoff as
+  // every other subresource). Keyed on the DEFINITIONAL `Upgrade` handshake
+  // header (RFC 6455) rather than `Sec-Fetch-Dest: websocket`, which some
+  // browsers/proxies omit → the request would otherwise fall into the ENTRY
+  // branch below and 401 the HMR socket. Deterministic + structural.
+  const upgrade = firstHeader(req.headers['upgrade']);
+  if (upgrade && upgrade.toLowerCase() === 'websocket') {
+    res.status(200).json({ ok: true, via: 'websocket' });
     return;
   }
 

--- a/src/tests/api/internal/blocks/dev-tunnel-gate.test.ts
+++ b/src/tests/api/internal/blocks/dev-tunnel-gate.test.ts
@@ -52,11 +52,17 @@ function makeRes() {
   };
 }
 
-function makeReq(opts: { host?: string; uri?: string; secFetchDest?: string }): NextApiRequest {
+function makeReq(opts: {
+  host?: string;
+  uri?: string;
+  secFetchDest?: string;
+  upgrade?: string;
+}): NextApiRequest {
   const headers: Record<string, string> = {};
   if (opts.host !== undefined) headers['x-forwarded-host'] = opts.host;
   if (opts.uri !== undefined) headers['x-forwarded-uri'] = opts.uri;
   if (opts.secFetchDest !== undefined) headers['sec-fetch-dest'] = opts.secFetchDest;
+  if (opts.upgrade !== undefined) headers['upgrade'] = opts.upgrade;
   return { method: 'GET', headers } as unknown as NextApiRequest;
 }
 
@@ -142,6 +148,45 @@ describe('/api/internal/dev-tunnel-gate', () => {
     const res = makeRes();
     handler(makeReq({ host: HOST, uri: '/app.js', secFetchDest: 'script' }), res);
     expect(res.statusCode).toBe(200);
+  });
+
+  // ── WEBSOCKET UPGRADE (Vite HMR socket) → allowed deterministically ──
+  it('WEBSOCKET UPGRADE (Upgrade: websocket) with NO token → 200 (HMR socket allowed)', () => {
+    const res = makeRes();
+    handler(
+      makeReq({ host: HOST, uri: '/?token=abc', upgrade: 'websocket', secFetchDest: 'websocket' }),
+      res
+    );
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { via?: string }).via).toBe('websocket');
+  });
+
+  it('WEBSOCKET UPGRADE with ABSENT Sec-Fetch-Dest → still 200 (not treated as ENTRY)', () => {
+    // The load-bearing case: without the explicit Upgrade allow, an absent
+    // Sec-Fetch-Dest would route a ws handshake into the ENTRY branch → 401.
+    const res = makeRes();
+    handler(makeReq({ host: HOST, uri: '/?token=abc', upgrade: 'websocket' }), res);
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { via?: string }).via).toBe('websocket');
+  });
+
+  it('WEBSOCKET UPGRADE is case-insensitive (Upgrade: WebSocket) → 200', () => {
+    const res = makeRes();
+    handler(makeReq({ host: HOST, uri: '/?token=abc', upgrade: 'WebSocket' }), res);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('WEBSOCKET UPGRADE without X-Forwarded-Host → 401 (fail-closed still wins)', () => {
+    const res = makeRes();
+    handler(makeReq({ uri: '/?token=abc', upgrade: 'websocket' }), res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('does NOT refresh the idle marker on a ws upgrade (no ENTRY auth decision)', async () => {
+    const res = makeRes();
+    await handler(makeReq({ host: HOST, uri: '/?token=abc', upgrade: 'websocket' }), res);
+    expect(res.statusCode).toBe(200);
+    expect(mockTouchDevTunnelActivity).not.toHaveBeenCalled();
   });
 
   // ── F3: idle-marker refresh fires ONLY on a successful ENTRY hit ──


### PR DESCRIPTION
## Context

Companion to civitai/cli#105. App Blocks authors run their block locally and `civitai app dev-tunnel <id>` exposes it at `dev-<16hex>.civit.ai`, iframed by `civitai.com/apps/dev/<id>`. The app renders, but **HMR (live-reload) doesn't flow** over the tunnel. The CLI PR routes Vite's HMR socket over `wss://<tunnel-host>:443/`; this PR ensures that ws upgrade passes the edge forwardAuth gate deterministically.

## Gate analysis

`/api/internal/dev-tunnel-gate` authorizes the ENTRY document (token-gated) and allows subresources through by `Sec-Fetch-Dest`. A browser HMR ws normally sends `Sec-Fetch-Dest: websocket`, which is not in `ENTRY_DESTS` → it already passes via the subresource branch. **But** when that header is absent (some browsers/proxies omit it on the ws handshake), the request falls into the ENTRY branch → 401, blocking HMR. (A naked curl probe — no `Sec-Fetch-Dest` — 401s for exactly this reason.)

## Fix

Add a deterministic, structural allow keyed on the **definitional `Upgrade: websocket` handshake header** (RFC 6455), placed after the fail-closed `X-Forwarded-Host` check and before the ENTRY logic.

**Security property preserved:** a ws handshake can never be a top-level document navigation, so this does not weaken the naked-entry-document 401 property. The ws still only reaches the author's own localhost (host-secrecy protected — the same accepted tradeoff as every other subresource). Missing `X-Forwarded-Host` still 401s. Keying on `Upgrade` rather than `Sec-Fetch-Dest` is deterministic, not a heuristic.

## Coverage

5 new tests: ws upgrade with and without `Sec-Fetch-Dest` (the load-bearing absent-header case → 200), case-insensitive `Upgrade`, fail-closed on missing host (still 401), and no idle-marker refresh on a ws upgrade. **All 17 gate tests pass** (ran locally). `tsc --noEmit`: no new errors in the changed files (17 pre-existing errors are all in unrelated files: kysely generated types, bitdex-stats, flipt client, image.service).

## Not verified

Actual live-reload requires a real moderator browser walk on the author's laptop (invisible Turnstile blocks headless automation). Verified: the gate allows the upgrade at the code level, tests pass, typecheck clean for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)