### PR TITLE
fix(api/v1): guard JSON.parse(error.message) in creators + tags handlers (prod raw-500 sweep)

### DIFF
--- a/src/pages/api/v1/creators.ts
+++ b/src/pages/api/v1/creators.ts
@@ -52,7 +52,17 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
     }
     if (error instanceof TRPCError) {
       const status = getHTTPStatusCodeFromError(error);
-      const parsedError = JSON.parse(error.message);
+      // Some TRPCErrors carry a JSON-stringified body (zod/validation); others
+      // (throwDbError-wrapped INTERNAL_SERVER_ERRORs) carry a plain string. A
+      // blind JSON.parse on the plain-string case throws, escapes this catch,
+      // and surfaces a raw unhandled 500 — so guard it with a fallback.
+      const parsedError = (() => {
+        try {
+          return JSON.parse(error.message);
+        } catch {
+          return { message: error.message };
+        }
+      })();
 
       res.status(status).json(parsedError);
     } else {

--- a/src/pages/api/v1/tags.ts
+++ b/src/pages/api/v1/tags.ts
@@ -42,7 +42,17 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
     }
     if (error instanceof TRPCError) {
       const status = getHTTPStatusCodeFromError(error);
-      const parsedError = JSON.parse(error.message);
+      // Some TRPCErrors carry a JSON-stringified body (zod/validation); others
+      // (throwDbError-wrapped INTERNAL_SERVER_ERRORs) carry a plain string. A
+      // blind JSON.parse on the plain-string case throws, escapes this catch,
+      // and surfaces a raw unhandled 500 — so guard it with a fallback.
+      const parsedError = (() => {
+        try {
+          return JSON.parse(error.message);
+        } catch {
+          return { message: error.message };
+        }
+      })();
 
       res.status(status).json(parsedError);
     } else {

--- a/src/tests/api/v1/creators.test.ts
+++ b/src/tests/api/v1/creators.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// The handler builds a tRPC caller via publicApiContext2 and calls
+// `apiCaller.user.getCreators(req.query)`. Mock publicApiContext2 to return a
+// caller whose `user.getCreators` is a vi.fn we control — this drives the
+// handler's success + error-classification paths in isolation (mirrors the
+// users/index handler test).
+const { mockPublicApiContext2, mockGetCreators } = vi.hoisted(() => ({
+  mockPublicApiContext2: vi.fn(),
+  mockGetCreators: vi.fn(),
+}));
+
+vi.mock('~/server/createContext', () => ({
+  publicApiContext2: mockPublicApiContext2,
+}));
+
+// PublicEndpoint is a simple passthrough wrapper in tests.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: any) => handler,
+}));
+
+// NOTE: isClientAbortError (~/server/utils/errorHandling), getPaginationLinks
+// and mapCreatorItem (getEdgeUrl) are kept REAL so the handler's production
+// classification + mapping logic runs unmodified.
+
+import handler from '~/pages/api/v1/creators';
+
+function createMocks({ query = {} }: { query?: Record<string, string | string[]> }) {
+  const req = {
+    method: 'GET',
+    url: '/api/v1/creators',
+    headers: { host: 'civitai.com' },
+    query,
+  } as unknown as NextApiRequest;
+
+  let statusCode = 200;
+  let payload: any = undefined;
+  let ended = false;
+
+  const res = {
+    headersSent: false,
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(body: any) {
+      payload = body;
+      return res;
+    },
+    end() {
+      ended = true;
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+    _ended: () => ended,
+  } as unknown as NextApiResponse & {
+    _getStatusCode: () => number;
+    _getJSONData: () => any;
+    _ended: () => boolean;
+  };
+
+  return { req, res };
+}
+
+describe('/api/v1/creators error-body JSON.parse guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPublicApiContext2.mockResolvedValue({ user: { getCreators: mockGetCreators } });
+  });
+
+  it('happy path is unchanged (200) with mapped items + metadata', async () => {
+    mockGetCreators.mockResolvedValue({
+      items: [{ username: 'alice', _count: { models: 3 } }],
+      currentPage: 1,
+      totalPages: 1,
+    });
+    const { req, res } = createMocks({ query: {} });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const body = res._getJSONData();
+    expect(body.items).toEqual([
+      {
+        username: 'alice',
+        modelCount: 3,
+        link: 'http://localhost:3000/api/v1/models?username=alice',
+        image: undefined,
+      },
+    ]);
+    expect(body.metadata.currentPage).toBe(1);
+  });
+
+  it('a TRPCError with a JSON-stringified message is parsed and returned as before (no regression)', async () => {
+    // Some errors legitimately carry a JSON-stringified body (zod/validation).
+    // The pre-existing success path must keep parsing them.
+    const jsonError = new TRPCError({
+      code: 'BAD_REQUEST',
+      message: JSON.stringify([{ path: ['limit'], message: 'must be a number' }]),
+    });
+    mockGetCreators.mockRejectedValue(jsonError);
+    const { req, res } = createMocks({ query: {} });
+
+    await expect(handler(req, res)).resolves.toBeUndefined();
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual([{ path: ['limit'], message: 'must be a number' }]);
+  });
+
+  it('returns a clean 500 (no throw) for a throwDbError-wrapped TRPCError INTERNAL_SERVER_ERROR with a PLAIN-STRING message', async () => {
+    // The real prod non-transient shape: a Prisma/app failure becomes a TRPCError
+    // INTERNAL_SERVER_ERROR whose `message` is a bare string, NOT JSON. Against the
+    // UN-hardened handler `JSON.parse('Database connection lost')` throws a
+    // SyntaxError that escapes the catch → raw unhandled Next 500. The hardened
+    // handler falls back to { message } with the correct HTTP status.
+    const dbError = new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Database connection lost',
+    });
+    mockGetCreators.mockRejectedValue(dbError);
+    const { req, res } = createMocks({ query: {} });
+
+    await expect(handler(req, res)).resolves.toBeUndefined();
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getJSONData()).toEqual({ message: 'Database connection lost' });
+  });
+
+  it('client abort (499) branch is unchanged — ends without a body', async () => {
+    // isClientAbortError (kept real) recognizes the aborted-operation message.
+    const abort = new Error('The operation was aborted');
+    mockGetCreators.mockRejectedValue(abort);
+    const { req, res } = createMocks({ query: {} });
+
+    await expect(handler(req, res)).resolves.toBeUndefined();
+
+    expect(res._getStatusCode()).toBe(499);
+    expect(res._ended()).toBe(true);
+    expect(res._getJSONData()).toBeUndefined();
+  });
+
+  it('a non-TRPCError failure still surfaces as a generic 500', async () => {
+    mockGetCreators.mockRejectedValue(new Error('cannot read properties of undefined'));
+    const { req, res } = createMocks({ query: {} });
+
+    await expect(handler(req, res)).resolves.toBeUndefined();
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getJSONData().message).toBe('An unexpected error occurred');
+  });
+});

--- a/src/tests/api/v1/tags.test.ts
+++ b/src/tests/api/v1/tags.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// The handler builds a tRPC caller via publicApiContext2 and calls
+// `apiCaller.tag.getAll(...)`. Mock publicApiContext2 to return a caller whose
+// `tag.getAll` is a vi.fn we control — drives the handler's success + error
+// classification paths in isolation (mirrors the users/index handler test).
+const { mockPublicApiContext2, mockGetAll } = vi.hoisted(() => ({
+  mockPublicApiContext2: vi.fn(),
+  mockGetAll: vi.fn(),
+}));
+
+vi.mock('~/server/createContext', () => ({
+  publicApiContext2: mockPublicApiContext2,
+}));
+
+// PublicEndpoint is a simple passthrough wrapper in tests.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: any) => handler,
+}));
+
+// The handler imports the full appRouter; stub it so importing the handler does
+// not pull the entire server graph. Only publicApiContext2 (mocked above) is
+// used at runtime to build the caller.
+vi.mock('~/server/routers', () => ({ appRouter: {} }));
+
+// NOTE: isClientAbortError (~/server/utils/errorHandling) and getPaginationLinks
+// are kept REAL so the handler's production classification logic runs unmodified.
+
+import handler from '~/pages/api/v1/tags';
+
+function createMocks({ query = {} }: { query?: Record<string, string | string[]> }) {
+  const req = {
+    method: 'GET',
+    url: '/api/v1/tags',
+    headers: { host: 'civitai.com' },
+    query,
+  } as unknown as NextApiRequest;
+
+  let statusCode = 200;
+  let payload: any = undefined;
+  let ended = false;
+
+  const res = {
+    headersSent: false,
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(body: any) {
+      payload = body;
+      return res;
+    },
+    end() {
+      ended = true;
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+    _ended: () => ended,
+  } as unknown as NextApiResponse & {
+    _getStatusCode: () => number;
+    _getJSONData: () => any;
+    _ended: () => boolean;
+  };
+
+  return { req, res };
+}
+
+describe('/api/v1/tags error-body JSON.parse guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPublicApiContext2.mockResolvedValue({ tag: { getAll: mockGetAll } });
+  });
+
+  it('happy path is unchanged (200) with mapped items + metadata', async () => {
+    mockGetAll.mockResolvedValue({
+      items: [{ name: 'anime', models: [] }],
+      currentPage: 1,
+      totalPages: 1,
+    });
+    const { req, res } = createMocks({ query: {} });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const body = res._getJSONData();
+    expect(body.items).toEqual([
+      { name: 'anime', link: 'http://localhost:3000/api/v1/models?tag=anime' },
+    ]);
+    expect(body.metadata.currentPage).toBe(1);
+  });
+
+  it('a TRPCError with a JSON-stringified message is parsed and returned as before (no regression)', async () => {
+    const jsonError = new TRPCError({
+      code: 'BAD_REQUEST',
+      message: JSON.stringify([{ path: ['limit'], message: 'must be a number' }]),
+    });
+    mockGetAll.mockRejectedValue(jsonError);
+    const { req, res } = createMocks({ query: {} });
+
+    await expect(handler(req, res)).resolves.toBeUndefined();
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual([{ path: ['limit'], message: 'must be a number' }]);
+  });
+
+  it('returns a clean 500 (no throw) for a throwDbError-wrapped TRPCError INTERNAL_SERVER_ERROR with a PLAIN-STRING message', async () => {
+    // The real prod non-transient shape: a Prisma/app failure becomes a TRPCError
+    // INTERNAL_SERVER_ERROR whose `message` is a bare string, NOT JSON. Against the
+    // UN-hardened handler `JSON.parse('Database connection lost')` throws a
+    // SyntaxError that escapes the catch → raw unhandled Next 500. The hardened
+    // handler falls back to { message } with the correct HTTP status.
+    const dbError = new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Database connection lost',
+    });
+    mockGetAll.mockRejectedValue(dbError);
+    const { req, res } = createMocks({ query: {} });
+
+    await expect(handler(req, res)).resolves.toBeUndefined();
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getJSONData()).toEqual({ message: 'Database connection lost' });
+  });
+
+  it('client abort (499) branch is unchanged — ends without a body', async () => {
+    // isClientAbortError (kept real) recognizes the aborted-operation message.
+    const abort = new Error('The operation was aborted');
+    mockGetAll.mockRejectedValue(abort);
+    const { req, res } = createMocks({ query: {} });
+
+    await expect(handler(req, res)).resolves.toBeUndefined();
+
+    expect(res._getStatusCode()).toBe(499);
+    expect(res._ended()).toBe(true);
+    expect(res._getJSONData()).toBeUndefined();
+  });
+
+  it('a non-TRPCError failure still surfaces as a generic 500', async () => {
+    mockGetAll.mockRejectedValue(new Error('cannot read properties of undefined'));
+    const { req, res } = createMocks({ query: {} });
+
+    await expect(handler(req, res)).resolves.toBeUndefined();
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getJSONData().message).toBe('An unexpected error occurred');
+  });
+});


### PR DESCRIPTION
## The landmine

Several `/api/v1/*` REST handlers catch a `TRPCError` and build the response body with a blind `JSON.parse(error.message)`. In production, non-transient failures reach these handlers as a `TRPCError INTERNAL_SERVER_ERROR` whose `message` is a **plain string** — `throwDbError` (`src/server/utils/errorHandling.ts`) wraps Prisma/app errors as `message: e.message`, **not** JSON. A blind `JSON.parse` of a plain string throws a `SyntaxError` that **escapes the catch block → raw unhandled Next 500**.

This is the **same class of bug fixed for `/api/v1/users` in #2972**.

## Files swept (the two that still had the unguarded pattern)

- `src/pages/api/v1/creators.ts`
- `src/pages/api/v1/tags.ts`

Both now wrap the `JSON.parse` in the same **try/catch-with-fallback house-style** already used by the sibling `src/pages/api/v1/bugs.ts` (they live in the same dir): on a parse failure they fall back to `{ message: error.message }` and still respond with the correct HTTP status via `getHTTPStatusCodeFromError`. Unchanged: the JSON-message success path (zod/validation errors that legitimately carry a JSON-stringified body), the `499` client-abort branch, and the generic-`else` 500 branch. **Net: no input can make these two handlers emit a raw unhandled 500.**

## Tests

Adds `src/tests/api/v1/creators.test.ts` + `src/tests/api/v1/tags.test.ts`, mirroring the #2972 `users/index.test.ts` harness (mock `publicApiContext2`, passthrough `PublicEndpoint`, real `isClientAbortError` / `getPaginationLinks`). Each asserts:

- **(a)** a `TRPCError INTERNAL_SERVER_ERROR` with a **plain-string** message → handler **resolves** (no throw), clean **500** with a well-formed body. This case **fails-before / passes-after** the fix (verified by temporarily reverting the handler edits: both throw `SyntaxError: Unexpected token 'D', "Database c"... is not valid JSON`, promise rejects instead of resolving).
- **(b)** a `TRPCError` with a **JSON-stringified** message → still parsed and returned as before (no regression).
- **(c)** the happy path is unaffected; plus the `499` abort branch and the generic-`500` branch.

`vitest run --project unit` on both files: **10 passed**. The four changed files typecheck clean.

## Out of scope

- `bugs.ts`, `bugs/[id].ts` and `users/index.ts` already guard this pattern — untouched.
- `/api/v1/models` and the upload handlers do **not** use this pattern — out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)