### PR TITLE
feat(apps): OG-image/metadata auto-pull for external listings + SSRF-safe fetch (+ userinfo hardening)

### DIFF
--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -16,6 +16,9 @@ import { renderWithProviders } from '../../../test/component-setup';
 const mocks = vi.hoisted(() => ({
   submit: vi.fn(),
   mutate: vi.fn(),
+  // The metadata auto-pull query result the mocked `fetchListingMetaFromUrl`
+  // returns — tests mutate this to simulate a suggestion set / empty result.
+  meta: { data: undefined as unknown, isFetching: false, isSuccess: false },
 }));
 
 vi.mock('~/utils/trpc', () => {
@@ -29,7 +32,13 @@ vi.mock('~/utils/trpc', () => {
             return { mutate: mocks.mutate, mutateAsync: vi.fn(), isPending: false };
           },
         },
+        // The auto-pull query — driven by the mutable `mocks.meta` result so a test
+        // can assert prefill (mock a suggestion) or the empty state (default).
+        fetchListingMetaFromUrl: {
+          useQuery: () => mocks.meta,
+        },
         persistAssetImage: { useMutation: mutation },
+        ingestAssetFromUrl: { useMutation: mutation },
         setIcon: { useMutation: mutation },
         setCover: { useMutation: mutation },
         addScreenshot: { useMutation: mutation },
@@ -57,6 +66,8 @@ const { ExternalSubmitForm } = await import('./ExternalSubmitForm');
 beforeEach(() => {
   mocks.submit.mockClear();
   mocks.mutate.mockClear();
+  // Reset the auto-pull query result to "found nothing" between tests.
+  mocks.meta = { data: undefined, isFetching: false, isSuccess: false };
 });
 
 describe('ExternalSubmitForm — wizard', () => {
@@ -94,7 +105,11 @@ describe('ExternalSubmitForm — wizard', () => {
     await page.getByRole('textbox', { name: /Link URL/ }).fill('http://example.com');
     await page.getByRole('button', { name: 'Next' }).click();
     // The "Use https://" fix-it error surfaces inline; we stay on the URL step.
-    await expect.element(page.getByText(/https/i)).toBeInTheDocument();
+    // Assert the EXACT validator string — `/https/i` matches 3 elements (the field
+    // description + the alert copy + the error), a strict-mode violation.
+    await expect
+      .element(page.getByText('Use https:// (or omit the scheme)'))
+      .toBeInTheDocument();
     expect(page.getByRole('button', { name: 'Create draft' }).elements()).toHaveLength(0);
   });
 
@@ -106,6 +121,41 @@ describe('ExternalSubmitForm — wizard', () => {
       .element()
       .dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
     await expect.element(page.getByRole('button', { name: 'Create draft' })).toBeInTheDocument();
+  });
+
+  test('a fetched suggestion prefills the (blank) tagline on the Details step', async () => {
+    // Simulate the SSRF-safe auto-pull returning og:description + image suggestions.
+    mocks.meta = {
+      data: {
+        name: 'Og Title App',
+        tagline: 'The best off-site app around',
+        coverImageUrl: 'https://cdn.example.com/og.png',
+        iconImageUrl: 'https://cdn.example.com/icon.png',
+      },
+      isFetching: false,
+      isSuccess: true,
+    };
+    renderWithProviders(<ExternalSubmitForm />);
+    await page.getByRole('textbox', { name: /Link URL/ }).fill('https://vitrine.civitai.com');
+    await page.getByRole('button', { name: 'Next' }).click();
+
+    // Tagline was blank → prefilled from og:description. (Name is already
+    // host-derived to "Vitrine" on advance, so it is not clobbered — the
+    // non-destructive prefill only fills blank fields.)
+    await expect
+      .element(page.getByRole('textbox', { name: /Tagline/ }))
+      .toHaveValue('The best off-site app around');
+    await expect.element(page.getByRole('textbox', { name: /^Name/ })).toHaveValue('Vitrine');
+  });
+
+  test('the empty-suggestions state renders when the auto-pull finds nothing', async () => {
+    mocks.meta = { data: {}, isFetching: false, isSuccess: true };
+    renderWithProviders(<ExternalSubmitForm />);
+    await page.getByRole('textbox', { name: /Link URL/ }).fill('https://vitrine.civitai.com');
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect
+      .element(page.getByText(/No suggestions found/i))
+      .toBeInTheDocument();
   });
 
   test('submitting valid details calls submitExternalListing (server owns the draft)', async () => {

--- a/src/components/Apps/ExternalSubmitForm.tsx
+++ b/src/components/Apps/ExternalSubmitForm.tsx
@@ -6,6 +6,7 @@ import {
   Code,
   FileInput,
   Group,
+  Image,
   Loader,
   Select,
   Stack,
@@ -70,6 +71,9 @@ import { trpc } from '~/utils/trpc';
 
 type Submitted = { listingId: string; publishRequestId: string; slug: string };
 
+/** Server-suggested image URLs from the URL's page metadata (cover = og:image, icon = favicon/apple-touch). */
+type MetaSuggestions = { coverImageUrl?: string; iconImageUrl?: string };
+
 type AssetKind = 'icon' | 'cover' | 'screenshot';
 
 /**
@@ -131,6 +135,35 @@ export function ExternalSubmitForm() {
   const [errors, setErrors] = useState<OffsiteSubmitFormErrors>({});
   const [serverError, setServerError] = useState<string | null>(null);
   const [submitted, setSubmitted] = useState<Submitted | null>(null);
+
+  // Metadata auto-pull: once a valid URL advances to Details, fetch the target
+  // page's OG metadata SERVER-side (SSRF-safe) and surface suggestions. The query
+  // is keyed on `metaUrl` (set when advancing) so it fires once per URL; failures
+  // are non-blocking (the form still works with manual entry).
+  const [metaUrl, setMetaUrl] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<MetaSuggestions>({});
+  const appliedMetaRef = useRef<string | null>(null);
+
+  const metaQuery = trpc.appListings.fetchListingMetaFromUrl.useQuery(
+    { url: metaUrl ?? '' },
+    { enabled: !!metaUrl, retry: false, refetchOnWindowFocus: false, staleTime: Infinity }
+  );
+
+  // Apply a fetched suggestion set ONCE per URL: non-destructively prefill any
+  // still-blank name/tagline (never clobber what the author typed or the
+  // host-derived name), and stash the cover/icon image suggestions for the Assets
+  // step (they can only be attached after the draft listing exists).
+  useEffect(() => {
+    if (!metaQuery.data || appliedMetaRef.current === metaUrl) return;
+    appliedMetaRef.current = metaUrl;
+    const data = metaQuery.data;
+    setValues((v) => ({
+      ...v,
+      name: v.name.trim().length === 0 && data.name ? data.name : v.name,
+      tagline: v.tagline.trim().length === 0 && data.tagline ? data.tagline : v.tagline,
+    }));
+    setSuggestions({ coverImageUrl: data.coverImageUrl, iconImageUrl: data.iconImageUrl });
+  }, [metaQuery.data, metaUrl]);
 
   const submitMutation = trpc.appListings.submitExternalListing.useMutation({
     onSuccess: (res: Submitted) => {
@@ -197,6 +230,7 @@ export function ExternalSubmitForm() {
     }
     applyNormalizedUrl(result.url);
     setErrors((prev) => ({ ...prev, externalUrl: undefined }));
+    setMetaUrl(result.url); // kick off the (SSRF-safe) metadata auto-pull
     setActive(STEP_DETAILS);
   }
 
@@ -251,6 +285,7 @@ export function ExternalSubmitForm() {
       const result = normalizeLinkUrl(values.externalUrl);
       if (result.error) return; // can't reach Details with an invalid URL
       applyNormalizedUrl(result.url);
+      setMetaUrl(result.url);
       setActive(STEP_DETAILS);
     }
   }
@@ -334,6 +369,24 @@ export function ExternalSubmitForm() {
           data-testid="apps-offsite-wizard-step-details"
         >
           <Stack gap="md" mt="md">
+            {metaQuery.isFetching && (
+              <Group gap={6} data-testid="apps-offsite-meta-loading">
+                <Loader size={12} />
+                <Text size="xs" c="dimmed">
+                  Looking for a name, description and images from your link…
+                </Text>
+              </Group>
+            )}
+            {!metaQuery.isFetching &&
+              metaQuery.isSuccess &&
+              !metaQuery.data.name &&
+              !metaQuery.data.tagline &&
+              !metaQuery.data.coverImageUrl &&
+              !metaQuery.data.iconImageUrl && (
+                <Text size="xs" c="dimmed" data-testid="apps-offsite-meta-empty">
+                  No suggestions found — fill in the details and upload assets manually.
+                </Text>
+              )}
             <TextInput
               label="Name"
               description="Prefilled from your URL — edit as needed."
@@ -460,7 +513,11 @@ export function ExternalSubmitForm() {
         >
           <div data-testid="apps-offsite-wizard-assets-panel">
             {submitted ? (
-              <AssetStep submitted={submitted} contentRating={values.contentRating} />
+              <AssetStep
+                submitted={submitted}
+                contentRating={values.contentRating}
+                suggestions={suggestions}
+              />
             ) : (
               <Alert color="gray" variant="light" mt="md">
                 <Text size="sm">Create the draft on the previous step to add assets.</Text>
@@ -483,9 +540,11 @@ export function ExternalSubmitForm() {
 function AssetStep({
   submitted,
   contentRating,
+  suggestions,
 }: {
   submitted: Submitted;
   contentRating: OffsiteContentRating;
+  suggestions: MetaSuggestions;
 }) {
   const { uploadToCF } = useCFImageUpload();
   const [icon, setIcon] = useState<AssetState>(emptyAsset);
@@ -494,6 +553,7 @@ function AssetStep({
   const screenshotIdRef = useRef(0);
 
   const persistMutation = trpc.appListings.persistAssetImage.useMutation();
+  const ingestMutation = trpc.appListings.ingestAssetFromUrl.useMutation();
   const setIconMutation = trpc.appListings.setIcon.useMutation();
   const setCoverMutation = trpc.appListings.setCover.useMutation();
   const addScreenshotMutation = trpc.appListings.addScreenshot.useMutation();
@@ -638,6 +698,34 @@ function AssetStep({
     }
   }
 
+  /**
+   * Accept a server-suggested image URL (og:image cover / favicon icon): the
+   * SERVER re-fetches the remote URL (SSRF-safe) → uploads to CF → ingests through
+   * the STANDARD scan pipeline, returning a scannable imageId; we then run the SAME
+   * attach/poll cycle as an uploaded file (drive → scanning → attached). No scan
+   * bypass — the attach proc still requires `ingestion === Scanned`.
+   */
+  async function acceptSuggestion(
+    key: string,
+    kind: 'icon' | 'cover',
+    url: string,
+    apply: (s: AssetState) => void
+  ) {
+    clearTimer(key);
+    const epoch = bumpEpoch(key);
+    apply({ status: 'working', imageId: null, message: null });
+    try {
+      const { imageId } = await ingestMutation.mutateAsync({ url, kind });
+      if (!isCurrentEpoch(key, epoch)) return; // a newer upload/accept superseded this
+      await drive(key, kind, imageId, 0, epoch, apply);
+    } catch (err) {
+      if (!isCurrentEpoch(key, epoch)) return;
+      clearTimer(key);
+      apply({ status: 'error', imageId: null, message: (err as Error).message });
+      showErrorNotification({ title: `Could not import ${kind}`, error: err as Error });
+    }
+  }
+
   /** Manual Retry: reset the poll (new epoch, cleared timer) and re-drive from the
    *  already-persisted imageId. */
   async function retryAttach(
@@ -697,6 +785,11 @@ function AssetStep({
         onRetry={() => {
           if (icon.imageId != null) void retryAttach('icon', 'icon', icon.imageId, setIcon);
         }}
+        suggestionUrl={suggestions.iconImageUrl}
+        onAcceptSuggestion={() => {
+          if (suggestions.iconImageUrl)
+            void acceptSuggestion('icon', 'icon', suggestions.iconImageUrl, setIcon);
+        }}
       />
       <AssetRow
         kind="cover"
@@ -706,6 +799,11 @@ function AssetStep({
         onFile={(f) => void startAttach('cover', 'cover', f, setCover)}
         onRetry={() => {
           if (cover.imageId != null) void retryAttach('cover', 'cover', cover.imageId, setCover);
+        }}
+        suggestionUrl={suggestions.coverImageUrl}
+        onAcceptSuggestion={() => {
+          if (suggestions.coverImageUrl)
+            void acceptSuggestion('cover', 'cover', suggestions.coverImageUrl, setCover);
         }}
       />
 
@@ -787,6 +885,8 @@ function AssetRow({
   state,
   onFile,
   onRetry,
+  suggestionUrl,
+  onAcceptSuggestion,
 }: {
   kind: AssetKind;
   label: string;
@@ -794,7 +894,12 @@ function AssetRow({
   state: AssetState;
   onFile: (file: File | null) => void;
   onRetry: () => void;
+  suggestionUrl?: string;
+  onAcceptSuggestion?: () => void;
 }) {
+  // Offer the server-suggested image (og:image / favicon) only while the asset is
+  // idle — once the author uploads or accepts, the suggestion preview steps aside.
+  const showSuggestion = state.status === 'idle' && !!suggestionUrl && !!onAcceptSuggestion;
   return (
     <Card withBorder p="sm">
       <Stack gap="xs">
@@ -819,8 +924,40 @@ function AssetRow({
             )}
           </Group>
         </Group>
+        {showSuggestion && (
+          <Card withBorder p="xs" bg="var(--mantine-color-blue-light)">
+            <Group gap="sm" wrap="nowrap">
+              <Image
+                src={suggestionUrl}
+                w={48}
+                h={48}
+                radius="sm"
+                fit="contain"
+                alt={`suggested ${kind}`}
+                data-testid={`apps-offsite-suggested-${kind}-preview`}
+              />
+              <Stack gap={2} style={{ flex: 1 }}>
+                <Text size="xs" fw={600}>
+                  Suggested from your link
+                </Text>
+                <Text size="xs" c="dimmed">
+                  We&apos;ll re-scan it just like an upload.
+                </Text>
+              </Stack>
+              <Button
+                size="compact-xs"
+                variant="light"
+                leftSection={<IconCheck size={12} />}
+                onClick={onAcceptSuggestion}
+                data-testid={`apps-offsite-accept-${kind}`}
+              >
+                Use this
+              </Button>
+            </Group>
+          </Card>
+        )}
         <FileInput
-          label={`Upload ${kind}`}
+          label={showSuggestion ? `Or upload your own ${kind}` : `Upload ${kind}`}
           description={description}
           placeholder="Select an image"
           accept="image/png,image/jpeg,image/webp"

--- a/src/components/Apps/__tests__/deriveListingFromUrl.test.ts
+++ b/src/components/Apps/__tests__/deriveListingFromUrl.test.ts
@@ -141,10 +141,16 @@ describe('deriveListingFromUrl — hostile / edge hosts never throw', () => {
     expect(deriveListingFromUrl('https://[::1]')).toEqual({ name: '[::1]', slug: '' });
   });
 
-  it('userinfo is stripped — derivation uses the host only', () => {
+  it('userinfo is rejected — no derivation (credentials in URL are invalid)', () => {
+    // validateExternalUrl now rejects any userinfo (user:pass@host) as a
+    // phishing/display-spoof vector, so derivation yields nothing.
     expect(deriveListingFromUrl('https://user:pass@example.com')).toEqual({
-      name: 'Example',
-      slug: 'example',
+      name: '',
+      slug: '',
+    });
+    expect(deriveListingFromUrl('https://example.com@evil.com')).toEqual({
+      name: '',
+      slug: '',
     });
   });
 

--- a/src/components/Apps/__tests__/normalizeLinkUrl.test.ts
+++ b/src/components/Apps/__tests__/normalizeLinkUrl.test.ts
@@ -85,11 +85,27 @@ describe('normalizeLinkUrl — hostile schemes are rejected', () => {
     expect(result.error).toBeDefined();
   });
 
-  // NOTE: a scheme-LIKE prefix with no `://` and an `@` (e.g. `mailto:x@host`)
-  // is, under the locked `://` policy, prepended to `https://mailto:x@host` — which
-  // parses as a valid https URL (`mailto:x` becomes userinfo). It is NOT rejected.
-  // That's a harmless consequence of the policy (the result is still https) and was
-  // not a spec-required reject case, so it is intentionally not asserted here.
+  // NOTE: a scheme-LIKE prefix with no `://` and an `@` (e.g. `mailto:x@host`) is,
+  // under the locked `://` policy, prepended to `https://mailto:x@host` — which
+  // WHATWG-parses `mailto:x` as USERINFO. Since `validateExternalUrl` now rejects
+  // any URL carrying userinfo (the phishing-vector fold-in), this is rejected.
+  it('a scheme-like prefix that parses as userinfo is now rejected', () => {
+    const result = normalizeLinkUrl('mailto:x@host.com');
+    expect(result.url).toBe('');
+    expect(result.error).toBeDefined();
+  });
+});
+
+describe('normalizeLinkUrl — embedded credentials (userinfo) are rejected (mirrors the server)', () => {
+  it.each([
+    ['host-confusion', 'https://example.com@evil.com'],
+    ['user:pass', 'https://user:pass@evil.com'],
+    ['bare-domain host-confusion (no scheme)', 'example.com@evil.com'],
+  ])('%s → error (credentials rejected)', (_label, input) => {
+    const result = normalizeLinkUrl(input);
+    expect(result.url).toBe('');
+    expect(result.error).toMatch(/credential/i);
+  });
 });
 
 describe('normalizeLinkUrl — empty / whitespace', () => {

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -24,6 +24,10 @@ import {
   withdrawExternalRequestSchema,
 } from '~/server/schema/blocks/offsite-listing.schema';
 import {
+  fetchListingMetaSchema,
+  ingestListingAssetFromUrlSchema,
+} from '~/server/schema/blocks/listing-meta.schema';
+import {
   claimListingSchema,
   delistListingSchema,
   dismissReportSchema,
@@ -322,6 +326,57 @@ export const appListingsRouter = router({
         '~/server/services/blocks/offsite-listing.service'
       );
       return persistListingAssetImage({ input, userId: ctx.user.id });
+    }),
+
+  /**
+   * AUTHOR: SSRF-safe metadata auto-pull for the submit form. Given an external
+   * listing URL, server-side fetches the target page (hardened `safeFetch`:
+   * https-only + DNS-resolved-public + manual-redirect-revalidate + timeout + size
+   * cap + text/html allowlist) and returns SUGGESTIONS (name / tagline + cover/icon
+   * image URLs). Nothing is persisted — the author accepts or overrides. Never
+   * throws on "nothing found" (returns empty fields); SSRF/timeout/size failures
+   * map to a friendly BAD_REQUEST with no internal detail leaked. Rate-limited
+   * (~30/hr) — it triggers an outbound fetch per call.
+   */
+  fetchListingMetaFromUrl: appDeveloperProcedure
+    .use(
+      rateLimit({
+        limit: 30,
+        period: 3600,
+        errorMessage: 'Too many preview lookups — slow down.',
+      })
+    )
+    .input(fetchListingMetaSchema)
+    .query(async ({ input }) => {
+      const { fetchListingMeta } = await import('~/server/services/blocks/listing-meta.service');
+      return fetchListingMeta(input);
+    }),
+
+  /**
+   * AUTHOR: ingest an ACCEPTED suggested image URL into a scannable `Image` row.
+   * The remote URL is attacker-influenced + cross-origin, so the SERVER pulls the
+   * bytes (SSRF-safe) → uploads to CF → `createImage` through the STANDARD scan
+   * pipeline (default ingestion, NO skipIngestion / NO scan bypass) and returns the
+   * numeric `imageId`. The client then attaches it via `setIcon`/`setCover` (which
+   * enforce `ingestion === Scanned` + per-kind validation), polling until Scanned —
+   * exactly like an author-uploaded asset. Rate-limited (~30/hr, outbound fetch +
+   * CF upload per call). Ownership is bound to the caller.
+   */
+  ingestAssetFromUrl: appDeveloperProcedure
+    .use(
+      rateLimit({
+        limit: 30,
+        period: 3600,
+        errorMessage: 'Too many image imports — slow down.',
+      })
+    )
+    .input(ingestListingAssetFromUrlSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { ingestListingAssetFromUrl } = await import(
+        '~/server/services/blocks/listing-meta.service'
+      );
+      return ingestListingAssetFromUrl({ input, userId: ctx.user.id });
     }),
 
   /** AUTHOR: the caller's OWN off-site submissions (my-submissions page, PR-c). */

--- a/src/server/schema/blocks/__tests__/external-app.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/external-app.schema.test.ts
@@ -82,6 +82,26 @@ describe('validateExternalUrl', () => {
     const long = 'https://example.com/' + 'a'.repeat(MAX_EXTERNAL_URL_LENGTH);
     expect(validateExternalUrl(long).ok).toBe(false);
   });
+
+  it('REJECTS a URL with embedded credentials (userinfo phishing vector)', () => {
+    // `https://example.com@evil.com` DISPLAYS as example.com but the real host is
+    // evil.com — a display-vs-real-host phishing vector; reject it outright.
+    for (const url of [
+      'https://example.com@evil.com',
+      'https://user:pass@evil.com',
+      'https://user@example.com/app',
+      'https://:pass@example.com',
+    ]) {
+      const r = validateExternalUrl(url);
+      expect(r.ok, `"${url}" must be rejected`).toBe(false);
+      if (!r.ok) expect(r.error).toMatch(/credential/i);
+    }
+  });
+
+  it('accepts a normal https URL that merely CONTAINS an @ in the path/query (not userinfo)', () => {
+    const r = validateExternalUrl('https://example.com/u/@handle?to=a@b.com');
+    expect(r.ok).toBe(true);
+  });
 });
 
 describe('assertNoOnPlatformSurface (external ⟂ on-platform)', () => {

--- a/src/server/schema/blocks/app-listing.schema.ts
+++ b/src/server/schema/blocks/app-listing.schema.ts
@@ -42,6 +42,15 @@ export const LISTING_SCREENSHOT_ASPECT_MIN = 0.4;
 export const LISTING_SCREENSHOT_ASPECT_MAX = 2.6;
 export const LISTING_SCREENSHOT_MIN_PX = 320;
 
+/**
+ * Absolute upper bound on either side of ANY ingested listing asset. A ceiling
+ * (the per-kind checks above only enforce MINIMUMS / aspect) that stops a
+ * decompression-bomb / absurd-dimension image (e.g. 100000×100000) from reaching
+ * the CF upload + `createImage` scan pipeline on the OG-pull path. 8192px is
+ * comfortably above any real store icon/cover/screenshot.
+ */
+export const LISTING_ASSET_MAX_DIMENSION_PX = 8192;
+
 /** Only real raster image MIME types (mirrors E5 SCREENSHOT_EXTENSIONS). */
 export const LISTING_ASSET_ALLOWED_MIME = ['image/png', 'image/jpeg', 'image/webp'] as const;
 

--- a/src/server/schema/blocks/external-app.schema.ts
+++ b/src/server/schema/blocks/external-app.schema.ts
@@ -24,8 +24,13 @@ export type ExternalUrlValidation =
   | { ok: false; error: string };
 
 /**
- * Validate a candidate external-link URL. Returns the canonical (parsed, no
- * trailing whitespace) https:// URL on success, or a human-readable error.
+ * Validate a candidate external-link URL. Returns the parsed (whitespace-trimmed)
+ * https:// URL string on success, or a human-readable error.
+ *
+ * NOTE: the returned `url` is the WHATWG-parsed serialization of the input, NOT a
+ * sanitized/canonicalized safe URL — it is only guaranteed to be an https URL with
+ * a host and NO embedded credentials. It is NOT DNS-resolved and NOT SSRF-checked;
+ * a server-side fetch of it must still go through the hardened `safeFetch`.
  *
  * Rules (deterministic, no heuristics):
  *   - parses as an absolute URL,
@@ -33,6 +38,9 @@ export type ExternalUrlValidation =
  *     rejected — a marketplace card link opens in the user's browser, so a
  *     non-https or non-http scheme is a phishing / XSS vector),
  *   - has a host,
+ *   - carries NO userinfo (`user:pass@host`) — `https://example.com@evil.com`
+ *     displays as `example.com` but resolves to `evil.com`, a display-vs-real-host
+ *     phishing vector; reject it outright,
  *   - within the length bound.
  */
 export function validateExternalUrl(raw: unknown): ExternalUrlValidation {
@@ -54,6 +62,11 @@ export function validateExternalUrl(raw: unknown): ExternalUrlValidation {
   }
   if (!parsed.host) {
     return { ok: false, error: 'externalUrl must include a host' };
+  }
+  // Reject embedded credentials — `https://example.com@evil.com` renders the
+  // trusted-looking `example.com` but the REAL host is `evil.com`.
+  if (parsed.username || parsed.password) {
+    return { ok: false, error: 'externalUrl must not contain credentials (user:pass@host)' };
   }
   return { ok: true, url: parsed.toString() };
 }

--- a/src/server/schema/blocks/listing-meta.schema.ts
+++ b/src/server/schema/blocks/listing-meta.schema.ts
@@ -1,0 +1,39 @@
+import * as z from 'zod';
+
+import { MAX_EXTERNAL_URL_LENGTH } from '~/server/schema/blocks/external-app.schema';
+
+/**
+ * App Store Listings (W13) — external-listing METADATA AUTO-PULL schemas.
+ *
+ * Two author-gated procs back the submit-form auto-pull:
+ *   - `fetchListingMetaFromUrl` — SSRF-safe server fetch of the target page →
+ *     suggested name/tagline + cover/icon image URLs (SUGGESTIONS only, not
+ *     persisted).
+ *   - `ingestListingAssetFromUrl` — on ACCEPT, SSRF-safe server fetch of a
+ *     suggested image URL → CF upload → `Image` row via the STANDARD scan
+ *     pipeline (createImage default ingestion). Returns the numeric `imageId`
+ *     the client then attaches via `setIcon`/`setCover` (polling until Scanned).
+ *
+ * Both `url` inputs are bound loose here (length only); the https-only /
+ * DNS-resolved-public SSRF validation is enforced in the SERVICE via `safeFetch`,
+ * NOT the schema — a lexically-valid https URL can still resolve to a private
+ * address, so validation must happen at fetch time.
+ */
+
+/** Fetch page metadata for the submit form's URL step. */
+export const fetchListingMetaSchema = z.object({
+  url: z.string().min(1).max(MAX_EXTERNAL_URL_LENGTH),
+});
+export type FetchListingMetaInput = z.infer<typeof fetchListingMetaSchema>;
+
+/** Ingest an accepted suggested image URL into a scannable Image row. */
+export const ingestListingAssetFromUrlSchema = z.object({
+  url: z.string().min(1).max(MAX_EXTERNAL_URL_LENGTH),
+  /**
+   * Which asset the author is accepting this image for. Advisory only — it is
+   * recorded in the CF metadata; the per-kind dimension/mime/aspect validation is
+   * enforced authoritatively by the `setIcon`/`setCover` attach procs, not here.
+   */
+  kind: z.enum(['icon', 'cover']),
+});
+export type IngestListingAssetFromUrlInput = z.infer<typeof ingestListingAssetFromUrlSchema>;

--- a/src/server/services/block-manifest-validator.service.ts
+++ b/src/server/services/block-manifest-validator.service.ts
@@ -3,6 +3,11 @@ import {
   validateBlockScopesAgainstOauthClient,
 } from '~/shared/constants/block-scope.constants';
 import { isKnownSlotId, isPageSlot } from '~/shared/constants/slot-registry';
+// The lexical SSRF hostname guards were EXTRACTED to a shared, dependency-free
+// module (no `node:dns`, so this validator stays client-bundle-safe — it is
+// imported by `ManifestEditForm.tsx`). `safe-fetch.ts` imports the same helpers,
+// so the manifest validator and the fetch-time guard share ONE source of truth.
+import { isPublicHttpsUrl } from '~/server/utils/ssrf-hostname';
 
 type ValidationResult = { valid: true } | { valid: false; errors: string[] };
 
@@ -114,89 +119,12 @@ const SHELL_METACHAR_RE = /[;|&$`<>(){}\\!*?\[\]'"\n\r]/;
 const HEIGHT_MIN_FLOOR = 40;
 const HEIGHT_MAX_CEILING = 4000;
 
-// SSRF gate for iframe.src and assetBundleUrl. The migrate-once-fix-forever
-// move is to reject hostnames that resolve to private/loopback ranges. We
-// can't DNS-resolve at validation time, so we use a hostname allowlist of
-// shapes we know are public: must have a dot, can't be an IP, can't be a
-// reserved hostname (localhost / metadata service endpoints).
-const PRIVATE_HOSTNAME_PATTERNS = [
-  /^localhost$/i,
-  /^127\./,
-  /^10\./,
-  /^172\.(1[6-9]|2\d|3[01])\./,
-  /^192\.168\./,
-  /^169\.254\./,
-  /^0\./,
-  /^::1$/,
-  // Full IPv6 ULA range fc00::/7 — the spec is fc00::/7, not fc00::/8.
-  // Previously only fc00: matched; widen to fc00-fdff.
-  /^f[cd][0-9a-f]{2}:/i,
-  /^fe80:/i,
-  // IPv6 with a zone identifier (RFC 6874 `%`-encoded) — sometimes accepted
-  // by URL parsers and lets an attacker pin a literal zone like %eth0.
-  /%/,
-  // Reserved internal infrastructure names commonly used internally.
-  /\.internal$/i,
-  /\.local$/i,
-  /^metadata\.google\.internal$/i,
-  // Note: punycode/IDN homograph attacks (e.g. `xn--...` registered as a
-  // look-alike) and DNS-rebinding (public name flipped to 127.0.0.1 at
-  // fetch time) are NOT caught by lexical validation. Phase 2's
-  // assetBundleUrl fetch must re-validate at fetch time and disable
-  // redirect-follow. v1 doesn't fetch either URL server-side so the
-  // exposure is bounded.
-];
-
-function isPublicHttpsUrl(raw: string): { ok: true } | { ok: false; reason: string } {
-  let url: URL;
-  try {
-    url = new URL(raw);
-  } catch {
-    return { ok: false, reason: 'malformed URL' };
-  }
-  if (url.protocol !== 'https:') return { ok: false, reason: 'must be https' };
-  const hostname = url.hostname;
-
-  // Single-string IPv4 literals (audit B4): WHATWG URL accepts dot-less
-  // forms like `0x7f000001` and `2130706433` (the integer form of 127.0.0.1)
-  // and parses them to the corresponding IPv4 address. Reject these BEFORE
-  // the dotted-name check below, because they don't contain dots.
-  if (/^0x[0-9a-f]+$/i.test(hostname)) {
-    return { ok: false, reason: 'hex IPv4 literal not permitted' };
-  }
-  if (/^[0-9]+$/.test(hostname)) {
-    // Pure-integer form. Includes `2130706433` (= 127.0.0.1) and similar.
-    return { ok: false, reason: 'integer IPv4 literal not permitted' };
-  }
-
-  // IPv4-mapped IPv6 ([::ffff:127.0.0.1] and similar) — WHATWG URL surfaces
-  // these as `[::ffff:7f00:1]` style in `hostname` (lowercased, square
-  // brackets kept when URL.host includes them — URL.hostname strips them).
-  // Reject anything containing `::ffff:` (the IPv4-mapped prefix).
-  if (/::ffff:/i.test(hostname)) {
-    return { ok: false, reason: 'IPv4-mapped IPv6 not permitted' };
-  }
-
-  if (!hostname.includes('.') || hostname.endsWith('.')) {
-    return { ok: false, reason: 'hostname must be a public dotted name' };
-  }
-  for (const re of PRIVATE_HOSTNAME_PATTERNS) {
-    if (re.test(hostname)) return { ok: false, reason: 'private/internal hostname' };
-  }
-  // Pure-decimal-dotted IPv4 literals — keep the surface narrow even for
-  // public addresses; manifests should always load by DNS name.
-  if (/^[0-9.]+$/.test(hostname)) {
-    return { ok: false, reason: 'literal IPv4 addresses are not permitted' };
-  }
-  // Dotted hex/octal IPv4 literals (e.g. 0x7f.0x0.0x0.0x1, 0177.0.0.1).
-  if (/^0x[0-9a-f]+(\.0x[0-9a-f]+)+$/i.test(hostname)) {
-    return { ok: false, reason: 'hex IPv4 literals are not permitted' };
-  }
-  if (/^0[0-7]+(\.[0-7]+)+$/.test(hostname)) {
-    return { ok: false, reason: 'octal IPv4 literals are not permitted' };
-  }
-  return { ok: true };
-}
+// SSRF gate for iframe.src and assetBundleUrl. `isPublicHttpsUrl` (and the
+// `PRIVATE_HOSTNAME_PATTERNS` it uses) live in `~/server/utils/ssrf-hostname` (a
+// shared, dependency-free module) so this validator, the read-path anchors, and
+// the fetch-time guard in `safe-fetch.ts` can't drift. It is PURELY LEXICAL — a
+// server-side fetch of one of these URLs must additionally DNS-resolve + check
+// every address at fetch time (see safe-fetch.ts).
 
 // Sandbox is a positive allowlist gated by trust tier. Anything not listed
 // is rejected even if HTML's iframe sandbox accepts it. This stops the

--- a/src/server/services/blocks/__tests__/listing-meta.service.test.ts
+++ b/src/server/services/blocks/__tests__/listing-meta.service.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * External-listing metadata AUTO-PULL service. Covers `fetchListingMeta` (page →
+ * suggestions; non-https reject; SafeFetchError → friendly BAD_REQUEST; empty page
+ * → {}) and `ingestListingAssetFromUrl` (SSRF-safe image fetch → sharp decode → CF
+ * upload → `createImage` through the STANDARD scan pipeline; the scan-invariant
+ * that `createImage` is called WITHOUT `skipIngestion`; unsupported format reject).
+ * All I/O deps (safeFetch, sharp, CF upload, createImage) are mocked.
+ */
+
+// A real SafeFetchError class shared with the mocked module so `instanceof` holds
+// in the service under test.
+const { mockSafeFetch, SafeFetchError } = vi.hoisted(() => {
+  class SafeFetchError extends Error {
+    readonly code: string;
+    constructor(code: string, message: string) {
+      super(message);
+      this.name = 'SafeFetchError';
+      this.code = code;
+    }
+  }
+  return { mockSafeFetch: vi.fn(), SafeFetchError };
+});
+vi.mock('~/server/utils/safe-fetch', () => ({ safeFetch: mockSafeFetch, SafeFetchError }));
+
+const { mockMetadata, mockSharp } = vi.hoisted(() => {
+  const mockMetadata = vi.fn();
+  const mockSharp = vi.fn(() => ({ metadata: mockMetadata }));
+  return { mockMetadata, mockSharp };
+});
+vi.mock('sharp', () => ({ default: mockSharp }));
+
+const { mockUploadBufferToCF } = vi.hoisted(() => ({ mockUploadBufferToCF: vi.fn() }));
+vi.mock('~/utils/cf-images-utils', () => ({ uploadBufferToCF: mockUploadBufferToCF }));
+
+const { mockCreateImage } = vi.hoisted(() => ({ mockCreateImage: vi.fn() }));
+vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage }));
+
+import {
+  fetchListingMeta,
+  ingestListingAssetFromUrl,
+} from '~/server/services/blocks/listing-meta.service';
+
+beforeEach(() => {
+  mockSafeFetch.mockReset();
+  mockMetadata.mockReset();
+  mockSharp.mockClear();
+  mockUploadBufferToCF.mockReset();
+  mockCreateImage.mockReset();
+});
+
+describe('fetchListingMeta', () => {
+  it('returns parsed suggestions from the fetched page', async () => {
+    mockSafeFetch.mockResolvedValue({
+      finalUrl: 'https://vendor.example.com/app',
+      contentType: 'text/html',
+      bytes: Buffer.from(
+        '<meta property="og:title" content="Cool App">' +
+          '<meta property="og:description" content="Neat">' +
+          '<meta property="og:image" content="https://cdn.example.com/og.png">'
+      ),
+    });
+    const r = await fetchListingMeta({ url: 'https://vendor.example.com/app' });
+    expect(r).toEqual({
+      name: 'Cool App',
+      tagline: 'Neat',
+      coverImageUrl: 'https://cdn.example.com/og.png',
+    });
+  });
+
+  it('rejects a non-https URL BEFORE any fetch', async () => {
+    await expect(fetchListingMeta({ url: 'http://vendor.example.com' })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockSafeFetch).not.toHaveBeenCalled();
+  });
+
+  it('maps a SafeFetchError to a friendly BAD_REQUEST (no leak)', async () => {
+    mockSafeFetch.mockRejectedValue(new SafeFetchError('blocked_host', 'host resolves to private'));
+    await expect(
+      fetchListingMeta({ url: 'https://vendor.example.com' })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringMatching(/preview info/i) });
+  });
+
+  it('returns {} when the page has no usable tags (graceful)', async () => {
+    mockSafeFetch.mockResolvedValue({
+      finalUrl: 'https://vendor.example.com',
+      contentType: 'text/html',
+      bytes: Buffer.from('<html><body>nothing</body></html>'),
+    });
+    expect(await fetchListingMeta({ url: 'https://vendor.example.com' })).toEqual({});
+  });
+});
+
+describe('ingestListingAssetFromUrl', () => {
+  const imageBytes = Buffer.from('fake-image-bytes');
+
+  function primeHappyPath() {
+    mockSafeFetch.mockResolvedValue({
+      finalUrl: 'https://cdn.example.com/og.png',
+      contentType: 'image/jpeg',
+      bytes: imageBytes,
+    });
+    mockMetadata.mockResolvedValue({ width: 640, height: 480, format: 'jpeg' });
+    mockUploadBufferToCF.mockResolvedValue({ id: 'cf-image-uuid' });
+    mockCreateImage.mockResolvedValue({ id: 999 });
+  }
+
+  it('safe-fetches → decodes → uploads → createImage (default scan pipeline) → imageId', async () => {
+    primeHappyPath();
+    const res = await ingestListingAssetFromUrl({
+      input: { url: 'https://cdn.example.com/og.png', kind: 'cover' },
+      userId: 7,
+    });
+    expect(res).toEqual({ imageId: 999 });
+
+    // Bytes uploaded to CF are the ones safeFetch returned (never a re-fetch).
+    expect(mockUploadBufferToCF).toHaveBeenCalledWith(
+      imageBytes,
+      expect.stringContaining('listing-asset'),
+      expect.objectContaining({ userId: 7, kind: 'cover' })
+    );
+
+    // SCAN INVARIANT: createImage is called with default ingestion — NO
+    // skipIngestion — so the image flows through the standard scan-gate.
+    expect(mockCreateImage).toHaveBeenCalledTimes(1);
+    const arg = mockCreateImage.mock.calls[0][0];
+    expect(arg).toMatchObject({
+      url: 'cf-image-uuid',
+      type: 'image',
+      width: 640,
+      height: 480,
+      mimeType: 'image/jpeg',
+      userId: 7,
+      metadata: { size: imageBytes.byteLength },
+    });
+    expect(arg.skipIngestion).toBeUndefined();
+  });
+
+  it('maps a SafeFetchError to a friendly BAD_REQUEST', async () => {
+    mockSafeFetch.mockRejectedValue(new SafeFetchError('too_large', 'oversize'));
+    await expect(
+      ingestListingAssetFromUrl({ input: { url: 'https://cdn.example.com/x', kind: 'icon' }, userId: 1 })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported decoded format (e.g. gif) without ingesting', async () => {
+    mockSafeFetch.mockResolvedValue({
+      finalUrl: 'https://cdn.example.com/x.gif',
+      contentType: 'image/gif',
+      bytes: imageBytes,
+    });
+    mockMetadata.mockResolvedValue({ width: 100, height: 100, format: 'gif' });
+    await expect(
+      ingestListingAssetFromUrl({ input: { url: 'https://cdn.example.com/x.gif', kind: 'icon' }, userId: 1 })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockUploadBufferToCF).not.toHaveBeenCalled();
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the bytes cannot be decoded as an image', async () => {
+    mockSafeFetch.mockResolvedValue({
+      finalUrl: 'https://cdn.example.com/x',
+      contentType: 'image/png',
+      bytes: imageBytes,
+    });
+    mockMetadata.mockRejectedValue(new Error('unsupported image format'));
+    await expect(
+      ingestListingAssetFromUrl({ input: { url: 'https://cdn.example.com/x', kind: 'icon' }, userId: 1 })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/listing-meta.service.test.ts
+++ b/src/server/services/blocks/__tests__/listing-meta.service.test.ts
@@ -161,6 +161,25 @@ describe('ingestListingAssetFromUrl', () => {
     expect(mockCreateImage).not.toHaveBeenCalled();
   });
 
+  it('rejects an image whose decoded dimensions exceed the max-side cap (decompression-bomb guard)', async () => {
+    mockSafeFetch.mockResolvedValue({
+      finalUrl: 'https://cdn.example.com/huge.png',
+      contentType: 'image/png',
+      bytes: imageBytes,
+    });
+    // Tiny file, but decodes to an absurd 100000×100000 canvas — must be rejected
+    // BEFORE the CF upload + createImage scan pipeline.
+    mockMetadata.mockResolvedValue({ width: 100_000, height: 100_000, format: 'png' });
+    await expect(
+      ingestListingAssetFromUrl({
+        input: { url: 'https://cdn.example.com/huge.png', kind: 'cover' },
+        userId: 1,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockUploadBufferToCF).not.toHaveBeenCalled();
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
   it('rejects when the bytes cannot be decoded as an image', async () => {
     mockSafeFetch.mockResolvedValue({
       finalUrl: 'https://cdn.example.com/x',

--- a/src/server/services/blocks/listing-meta.service.ts
+++ b/src/server/services/blocks/listing-meta.service.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server';
 
+import { LISTING_ASSET_MAX_DIMENSION_PX } from '~/server/schema/blocks/app-listing.schema';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
 import type {
   FetchListingMetaInput,
@@ -144,6 +145,16 @@ export async function ingestListingAssetFromUrl(opts: {
     throw new TRPCError({
       code: 'BAD_REQUEST',
       message: 'Unsupported image type — upload a PNG, JPEG or WebP manually.',
+    });
+  }
+
+  // Ceiling on either side — the byte cap alone doesn't bound decoded dimensions
+  // (a tiny highly-compressed file can decode to an enormous canvas / bomb). Reject
+  // before the CF upload + createImage scan pipeline.
+  if (width > LISTING_ASSET_MAX_DIMENSION_PX || height > LISTING_ASSET_MAX_DIMENSION_PX) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `That image is too large (max ${LISTING_ASSET_MAX_DIMENSION_PX}px per side). Try uploading a smaller one manually.`,
     });
   }
 

--- a/src/server/services/blocks/listing-meta.service.ts
+++ b/src/server/services/blocks/listing-meta.service.ts
@@ -1,0 +1,176 @@
+import { TRPCError } from '@trpc/server';
+
+import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
+import type {
+  FetchListingMetaInput,
+  IngestListingAssetFromUrlInput,
+} from '~/server/schema/blocks/listing-meta.schema';
+import { extractListingMeta, type ListingMetaSuggestion } from '~/server/utils/og-metadata';
+import { SafeFetchError, safeFetch } from '~/server/utils/safe-fetch';
+
+/**
+ * App Store Listings (W13) — external-listing METADATA AUTO-PULL service.
+ *
+ * `fetchListingMeta` SSRF-safe-fetches the target page and returns SUGGESTIONS
+ * (name / tagline / cover+icon image URLs) the author can accept or override;
+ * nothing is persisted. `ingestListingAssetFromUrl` runs on ACCEPT: it
+ * SSRF-safe-fetches the suggested image, uploads the bytes to Cloudflare, and
+ * materialises an `Image` row through the STANDARD ingestion/scan pipeline
+ * (`createImage` with default ingestion — NO `skipIngestion`, NO scan bypass),
+ * returning the numeric `imageId` the client then attaches via `setIcon`/`setCover`
+ * (which enforce `ingestion === Scanned` + per-kind validation).
+ *
+ * All outbound fetches go through `safeFetch` (lexical + DNS-resolve-public +
+ * manual-redirect-revalidate + timeout + size cap + content-type allowlist). The
+ * heavy deps (`createImage`, `sharp`, CF utils) are dynamically imported to keep
+ * this module's static graph light (mirrors the router/offsite-service discipline).
+ */
+
+// ---------------------------------------------------------------------------
+// Fetch budgets (SSRF controls). Mirror the bounded og-image-helpers pattern.
+// ---------------------------------------------------------------------------
+
+/** Page fetch: text/html only, ~1.5MB cap (plenty for a <head> full of OG tags), ~5s. */
+export const META_HTML_TIMEOUT_MS = 5000;
+export const META_HTML_MAX_BYTES = 1_500_000;
+
+/** Image fetch: image/* only, 6MB cap (matches OG_IMAGE_MAX_BYTES), ~2.5s. */
+export const META_IMAGE_TIMEOUT_MS = 2500;
+export const META_IMAGE_MAX_BYTES = 6 * 1024 * 1024;
+
+/** Allowed decoded image formats → their canonical listing-asset MIME types. */
+const FORMAT_TO_MIME: Record<string, string> = {
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+};
+
+/** Generic, non-leaky message for any safe-fetch-layer failure. */
+function friendlyFetchError(): TRPCError {
+  return new TRPCError({
+    code: 'BAD_REQUEST',
+    message:
+      "We couldn't read that link's preview info. Check the URL, or add your name and images manually.",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// fetchListingMeta (author) — page → suggestions.
+// ---------------------------------------------------------------------------
+
+/**
+ * SSRF-safe-fetch the target page and extract suggested listing metadata. NEVER
+ * throws on "nothing found" — a page with no usable tags returns `{}` (the UI
+ * falls back to manual entry). SSRF / timeout / size / content-type / transport
+ * failures map to a friendly `BAD_REQUEST` with no internal detail leaked.
+ */
+export async function fetchListingMeta(
+  input: FetchListingMetaInput
+): Promise<ListingMetaSuggestion> {
+  // Lexical https-only gate first (the same single-source validator the submit
+  // form uses) — a non-https / malformed URL is a user error, not a fetch failure.
+  const url = validateExternalUrl(input.url);
+  if (!url.ok) throw new TRPCError({ code: 'BAD_REQUEST', message: url.error });
+
+  let result;
+  try {
+    result = await safeFetch(url.url, {
+      timeoutMs: META_HTML_TIMEOUT_MS,
+      maxBytes: META_HTML_MAX_BYTES,
+      allowedContentTypes: ['text/html', 'application/xhtml+xml'],
+    });
+  } catch (err) {
+    if (err instanceof SafeFetchError) throw friendlyFetchError();
+    throw err;
+  }
+
+  const html = result.bytes.toString('utf8');
+  // Best-effort parse; an unparseable/empty page yields `{}` (not an error).
+  return extractListingMeta(html, result.finalUrl);
+}
+
+// ---------------------------------------------------------------------------
+// ingestListingAssetFromUrl (author) — accepted image URL → scannable Image row.
+// ---------------------------------------------------------------------------
+
+/**
+ * Ingest an ACCEPTED suggested image URL into a scannable `Image` row. The remote
+ * URL is attacker-influenced + cross-origin, so the SERVER pulls the bytes
+ * (SSRF-safe) rather than the browser (CORS/SSRF-trust). Flow: safeFetch (image/*,
+ * 6MB cap, 2.5s) → decode dimensions/format with sharp → upload the bytes to CF →
+ * `createImage` (DEFAULT ingestion — the standard scan pipeline, NO bypass) →
+ * return `{ imageId }`. The client then attaches via `setIcon`/`setCover` and polls
+ * until the scan lands (reusing the existing asset-polling), exactly like an
+ * author-uploaded asset. No listing binding here; ownership is the caller.
+ */
+export async function ingestListingAssetFromUrl(opts: {
+  input: IngestListingAssetFromUrlInput;
+  userId: number;
+}): Promise<{ imageId: number }> {
+  const { input, userId } = opts;
+
+  let fetched;
+  try {
+    fetched = await safeFetch(input.url, {
+      timeoutMs: META_IMAGE_TIMEOUT_MS,
+      maxBytes: META_IMAGE_MAX_BYTES,
+      allowedContentTypes: ['image/'],
+    });
+  } catch (err) {
+    if (err instanceof SafeFetchError) throw friendlyFetchError();
+    throw err;
+  }
+
+  // Decode the bytes to get authoritative dimensions + format (the Content-Type
+  // header is untrusted). sharp is a heavy native dep → dynamic import.
+  const { default: sharp } = await import('sharp');
+  let width: number | undefined;
+  let height: number | undefined;
+  let format: string | undefined;
+  try {
+    const meta = await sharp(fetched.bytes).metadata();
+    width = meta.width;
+    height = meta.height;
+    format = meta.format;
+  } catch {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: "That image couldn't be read. Try uploading it manually.",
+    });
+  }
+
+  const mimeType = format ? FORMAT_TO_MIME[format] : undefined;
+  if (!mimeType || !width || !height || width <= 0 || height <= 0) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Unsupported image type — upload a PNG, JPEG or WebP manually.',
+    });
+  }
+
+  // Upload the ALREADY-FETCHED bytes to Cloudflare (never re-fetch the remote URL).
+  const { uploadBufferToCF } = await import('~/utils/cf-images-utils');
+  const ext = mimeType.split('/')[1] ?? 'img';
+  const uploaded = await uploadBufferToCF(fetched.bytes, `listing-asset.${ext}`, {
+    userId,
+    source: 'app-listing-og-pull',
+    kind: input.kind,
+  });
+
+  // Materialise the Image row through the STANDARD scan pipeline (default
+  // ingestion — no skipIngestion). Dynamic import keeps the heavy image.service
+  // graph out of this module's static imports.
+  const { createImage } = await import('~/server/services/image.service');
+  const image = await createImage({
+    url: uploaded.id,
+    name: `listing-${input.kind}`,
+    type: 'image',
+    width,
+    height,
+    mimeType,
+    // The P1 image validator reads the byte size from `Image.metadata.size`.
+    metadata: { size: fetched.bytes.byteLength },
+    userId,
+  });
+
+  return { imageId: image.id };
+}

--- a/src/server/utils/__tests__/og-metadata.test.ts
+++ b/src/server/utils/__tests__/og-metadata.test.ts
@@ -67,6 +67,20 @@ describe('extractListingMeta', () => {
     expect(extractListingMeta(html, BASE).coverImageUrl).toBeUndefined();
   });
 
+  it('drops a non-https (http:) suggested image/icon so the preview matches the https-only accept path', () => {
+    const html = `
+      <meta property="og:image" content="http://cdn.example.com/og.png">
+      <link rel="apple-touch-icon" href="http://cdn.example.com/touch.png">`;
+    const r = extractListingMeta(html, BASE);
+    expect(r.coverImageUrl).toBeUndefined();
+    expect(r.iconImageUrl).toBeUndefined();
+  });
+
+  it('keeps a protocol-relative asset (//host/x) since it resolves to https against an https page', () => {
+    const html = `<meta property="og:image" content="//cdn.example.com/og.png">`;
+    expect(extractListingMeta(html, BASE).coverImageUrl).toBe('https://cdn.example.com/og.png');
+  });
+
   it('clamps an over-long name to the listing name bound', () => {
     const long = 'x'.repeat(300);
     const r = extractListingMeta(`<meta property="og:title" content="${long}">`, BASE);

--- a/src/server/utils/__tests__/og-metadata.test.ts
+++ b/src/server/utils/__tests__/og-metadata.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractListingMeta } from '~/server/utils/og-metadata';
+
+/**
+ * PURE OG/HTML metadata extraction — og:title/description/image + favicon/
+ * apple-touch-icon + <title>, relative-URL resolution, and the missing-tags →
+ * empty-object graceful case.
+ */
+
+const BASE = 'https://vendor.example.com/apps/cool';
+
+describe('extractListingMeta', () => {
+  it('pulls og:title / og:description / og:image + apple-touch-icon (absolute)', () => {
+    const html = `
+      <head>
+        <meta property="og:title" content="Cool App" />
+        <meta property="og:description" content="Does cool things" />
+        <meta property="og:image" content="https://cdn.example.com/og.png" />
+        <link rel="apple-touch-icon" sizes="180x180" href="https://cdn.example.com/touch.png" />
+      </head>`;
+    expect(extractListingMeta(html, BASE)).toEqual({
+      name: 'Cool App',
+      tagline: 'Does cool things',
+      coverImageUrl: 'https://cdn.example.com/og.png',
+      iconImageUrl: 'https://cdn.example.com/touch.png',
+    });
+  });
+
+  it('resolves RELATIVE asset URLs against the final page URL', () => {
+    const html = `
+      <meta property="og:image" content="/img/og.jpg">
+      <link rel="icon" href="favicon.ico">`;
+    const r = extractListingMeta(html, BASE);
+    expect(r.coverImageUrl).toBe('https://vendor.example.com/img/og.jpg');
+    // Relative to the page path (…/apps/cool) → …/apps/favicon.ico
+    expect(r.iconImageUrl).toBe('https://vendor.example.com/apps/favicon.ico');
+  });
+
+  it('falls back to <title> for the name and meta[name=description] for the tagline', () => {
+    const html = `<title>  Plain &amp; Simple  </title>
+      <meta name="description" content="Fallback &quot;desc&quot;">`;
+    const r = extractListingMeta(html, BASE);
+    expect(r.name).toBe('Plain & Simple');
+    expect(r.tagline).toBe('Fallback "desc"');
+  });
+
+  it('prefers apple-touch-icon, else the largest declared rel=icon', () => {
+    const html = `
+      <link rel="icon" sizes="16x16" href="/small.png">
+      <link rel="icon" sizes="64x64" href="/big.png">`;
+    expect(extractListingMeta(html, BASE).iconImageUrl).toBe('https://vendor.example.com/big.png');
+  });
+
+  it('uses twitter:image as a cover fallback when og:image is absent', () => {
+    const html = `<meta name="twitter:image" content="https://cdn.example.com/tw.png">`;
+    expect(extractListingMeta(html, BASE).coverImageUrl).toBe('https://cdn.example.com/tw.png');
+  });
+
+  it('returns {} for a page with no usable tags (graceful fallback)', () => {
+    expect(extractListingMeta('<html><body><p>hi</p></body></html>', BASE)).toEqual({});
+    expect(extractListingMeta('', BASE)).toEqual({});
+  });
+
+  it('drops a data: URI image (non-fetchable) rather than suggesting it', () => {
+    const html = `<meta property="og:image" content="data:image/png;base64,AAAA">`;
+    expect(extractListingMeta(html, BASE).coverImageUrl).toBeUndefined();
+  });
+
+  it('clamps an over-long name to the listing name bound', () => {
+    const long = 'x'.repeat(300);
+    const r = extractListingMeta(`<meta property="og:title" content="${long}">`, BASE);
+    expect(r.name?.length).toBe(120);
+  });
+});

--- a/src/server/utils/__tests__/safe-fetch.test.ts
+++ b/src/server/utils/__tests__/safe-fetch.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the DNS resolver the fetch-time guard uses; each test drives it.
+vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
+
+import { lookup } from 'node:dns/promises';
+import { SafeFetchError, safeFetch } from '~/server/utils/safe-fetch';
+
+/**
+ * SSRF-hardened fetch. Proves EVERY control: lexical (non-https, userinfo, IP
+ * literal) reject, DNS-resolves-to-private reject, redirect-to-private reject,
+ * redirect cap, size cap (header + mid-stream), content-type allowlist, non-2xx,
+ * and timeout. `fetch` + `node:dns` are mocked so the tests are pure + fast.
+ */
+
+const lookupMock = vi.mocked(lookup);
+
+type FakeInit = { status?: number; headers?: Record<string, string>; chunks?: string[] };
+/** A minimal Response stand-in exposing only what safeFetch touches. */
+function fakeResponse({ status = 200, headers = {}, chunks = [] as string[] }: FakeInit) {
+  const h = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  let i = 0;
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: { get: (k: string) => h.get(k.toLowerCase()) ?? null },
+    body: {
+      getReader() {
+        return {
+          read: async () =>
+            i < chunks.length
+              ? { done: false, value: new TextEncoder().encode(chunks[i++]) }
+              : { done: true, value: undefined },
+          cancel: async () => undefined,
+          releaseLock: () => undefined,
+        };
+      },
+      cancel: async () => undefined,
+    },
+    arrayBuffer: async () => new TextEncoder().encode(chunks.join('')).buffer,
+  } as unknown as Response;
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  fetchMock.mockReset();
+  lookupMock.mockReset();
+  // Default: every host resolves to a single public address.
+  lookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const HTML = { timeoutMs: 5000, maxBytes: 1000, allowedContentTypes: ['text/html'] } as const;
+
+async function code(p: Promise<unknown>): Promise<string> {
+  try {
+    await p;
+    return '<<no-throw>>';
+  } catch (e) {
+    if (e instanceof SafeFetchError) return e.code;
+    throw e;
+  }
+}
+
+describe('safeFetch — lexical rejects (no DNS / no fetch)', () => {
+  it('rejects a non-https URL', async () => {
+    expect(await code(safeFetch('http://example.com', HTML))).toBe('invalid_url');
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(lookupMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects userinfo (user:pass@host)', async () => {
+    expect(await code(safeFetch('https://user:pass@example.com', HTML))).toBe('invalid_url');
+    expect(await code(safeFetch('https://example.com@evil.com', HTML))).toBe('invalid_url');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an IP-literal host lexically', async () => {
+    expect(await code(safeFetch('https://127.0.0.1', HTML))).toBe('invalid_url');
+    expect(await code(safeFetch('https://2130706433', HTML))).toBe('invalid_url');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('safeFetch — DNS-resolve guard', () => {
+  it('rejects when the host resolves to a private address (DNS-rebinding)', async () => {
+    lookupMock.mockResolvedValue([{ address: '10.0.0.5', family: 4 }] as never);
+    expect(await code(safeFetch('https://rebind.example.com', HTML))).toBe('blocked_host');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects if ANY resolved address is private (mixed A records)', async () => {
+    lookupMock.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '169.254.169.254', family: 4 },
+    ] as never);
+    expect(await code(safeFetch('https://mixed.example.com', HTML))).toBe('blocked_host');
+  });
+
+  it('maps a DNS failure to dns_failure', async () => {
+    lookupMock.mockRejectedValue(new Error('ENOTFOUND'));
+    expect(await code(safeFetch('https://nxdomain.example.com', HTML))).toBe('dns_failure');
+  });
+});
+
+describe('safeFetch — response controls', () => {
+  it('returns bytes + content-type + finalUrl on a good response, using redirect:manual', async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({ headers: { 'content-type': 'text/html; charset=utf-8' }, chunks: ['<html>hi'] })
+    );
+    const r = await safeFetch('https://example.com/page', HTML);
+    expect(r.contentType).toBe('text/html');
+    expect(r.bytes.toString('utf8')).toBe('<html>hi');
+    expect(r.finalUrl).toBe('https://example.com/page');
+    expect(fetchMock.mock.calls[0]?.[1]?.redirect).toBe('manual');
+  });
+
+  it('rejects a disallowed content-type', async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({ headers: { 'content-type': 'application/json' }, chunks: ['{}'] })
+    );
+    expect(await code(safeFetch('https://example.com', HTML))).toBe('content_type');
+  });
+
+  it('rejects a non-2xx status', async () => {
+    fetchMock.mockResolvedValue(fakeResponse({ status: 404 }));
+    expect(await code(safeFetch('https://example.com', HTML))).toBe('bad_status');
+  });
+
+  it('rejects an oversize body via the Content-Length header (pre-buffer)', async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({ headers: { 'content-type': 'text/html', 'content-length': '999999' } })
+    );
+    expect(await code(safeFetch('https://example.com', { ...HTML, maxBytes: 100 }))).toBe(
+      'too_large'
+    );
+  });
+
+  it('aborts mid-stream once the body exceeds maxBytes (lying/absent Content-Length)', async () => {
+    // No content-length; body is 12 bytes but the cap is 5.
+    fetchMock.mockResolvedValue(
+      fakeResponse({ headers: { 'content-type': 'text/html' }, chunks: ['abcd', 'efgh', 'ijkl'] })
+    );
+    expect(await code(safeFetch('https://example.com', { ...HTML, maxBytes: 5 }))).toBe('too_large');
+  });
+
+  it('maps a fetch TimeoutError to timeout', async () => {
+    fetchMock.mockRejectedValue(new DOMException('timed out', 'TimeoutError'));
+    expect(await code(safeFetch('https://example.com', HTML))).toBe('timeout');
+  });
+});
+
+describe('safeFetch — redirects (re-validated per hop)', () => {
+  it('re-validates a redirect Location and rejects one pointing at a private host', async () => {
+    lookupMock.mockImplementation(async (host: string) =>
+      host === 'internal.example.com'
+        ? ([{ address: '10.1.2.3', family: 4 }] as never)
+        : ([{ address: '93.184.216.34', family: 4 }] as never)
+    );
+    fetchMock.mockResolvedValueOnce(
+      fakeResponse({ status: 302, headers: { location: 'https://internal.example.com/x' } })
+    );
+    expect(await code(safeFetch('https://example.com', HTML))).toBe('blocked_host');
+    // Only the FIRST hop was fetched; the private redirect target never was.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows a redirect to a public host and returns the final body', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        fakeResponse({ status: 301, headers: { location: 'https://www.example.com/final' } })
+      )
+      .mockResolvedValueOnce(
+        fakeResponse({ headers: { 'content-type': 'text/html' }, chunks: ['final'] })
+      );
+    const r = await safeFetch('https://example.com', HTML);
+    expect(r.finalUrl).toBe('https://www.example.com/final');
+    expect(r.bytes.toString('utf8')).toBe('final');
+  });
+
+  it('caps the redirect chain', async () => {
+    fetchMock.mockResolvedValue(
+      fakeResponse({ status: 302, headers: { location: 'https://example.com/loop' } })
+    );
+    expect(await code(safeFetch('https://example.com', HTML))).toBe('too_many_redirects');
+  });
+});

--- a/src/server/utils/__tests__/safe-fetch.test.ts
+++ b/src/server/utils/__tests__/safe-fetch.test.ts
@@ -1,7 +1,14 @@
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mock the DNS resolver the fetch-time guard uses; each test drives it.
+// Mock the DNS resolver AND the node:https transport the fetch-time guard uses;
+// each test drives them. `node:https` is a default-import (`https.request`) in the
+// module under test, so the mock exposes a `default`. `requestMock` is `vi.hoisted`
+// so it exists when the hoisted `vi.mock` factory runs.
+const { requestMock } = vi.hoisted(() => ({ requestMock: vi.fn() }));
 vi.mock('node:dns/promises', () => ({ lookup: vi.fn() }));
+vi.mock('node:https', () => ({ default: { request: requestMock } }));
 
 import { lookup } from 'node:dns/promises';
 import { SafeFetchError, safeFetch } from '~/server/utils/safe-fetch';
@@ -10,49 +17,69 @@ import { SafeFetchError, safeFetch } from '~/server/utils/safe-fetch';
  * SSRF-hardened fetch. Proves EVERY control: lexical (non-https, userinfo, IP
  * literal) reject, DNS-resolves-to-private reject, redirect-to-private reject,
  * redirect cap, size cap (header + mid-stream), content-type allowlist, non-2xx,
- * and timeout. `fetch` + `node:dns` are mocked so the tests are pure + fast.
+ * timeout — AND, critically, that the outbound SOCKET is PINNED to the validated
+ * IP (the DNS-rebinding TOCTOU fix): the `lookup` override handed to
+ * `https.request` yields the address `resolveAndValidateHost` validated, so a
+ * public-then-private rebind can never land the connect on the private IP.
+ * `https.request` + `node:dns` are mocked so the tests are pure + fast.
  */
 
 const lookupMock = vi.mocked(lookup);
 
 type FakeInit = { status?: number; headers?: Record<string, string>; chunks?: string[] };
-/** A minimal Response stand-in exposing only what safeFetch touches. */
+
+/** A minimal IncomingMessage stand-in: a real Readable + statusCode/headers. */
 function fakeResponse({ status = 200, headers = {}, chunks = [] as string[] }: FakeInit) {
-  const h = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
-  let i = 0;
-  return {
-    status,
-    ok: status >= 200 && status < 300,
-    headers: { get: (k: string) => h.get(k.toLowerCase()) ?? null },
-    body: {
-      getReader() {
-        return {
-          read: async () =>
-            i < chunks.length
-              ? { done: false, value: new TextEncoder().encode(chunks[i++]) }
-              : { done: true, value: undefined },
-          cancel: async () => undefined,
-          releaseLock: () => undefined,
-        };
-      },
-      cancel: async () => undefined,
-    },
-    arrayBuffer: async () => new TextEncoder().encode(chunks.join('')).buffer,
-  } as unknown as Response;
+  const lower = Object.fromEntries(
+    Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v])
+  );
+  const stream = Readable.from(chunks.map((c) => Buffer.from(c)));
+  return Object.assign(stream, { statusCode: status, headers: lower });
 }
 
-const fetchMock = vi.fn();
+/** The options passed to each `https.request` call (assert pinning on these). */
+let capturedOptions: any[] = [];
+
+/**
+ * Drive the transport. `responses` is consumed one-per-hop; a value of `'hang'`
+ * makes the request never respond (so the abort deadline fires — timeout test);
+ * an `Error` is emitted on the request.
+ */
+function primeTransport(...responses: Array<ReturnType<typeof fakeResponse> | Error | 'hang'>) {
+  let i = 0;
+  requestMock.mockImplementation((options: any, cb: (res: unknown) => void) => {
+    capturedOptions.push(options);
+    const req = new EventEmitter() as EventEmitter & { end: () => void };
+    req.end = () => {
+      const r = responses[i++];
+      if (r === 'hang') {
+        options.signal?.addEventListener('abort', () => {
+          const e = new Error('aborted');
+          e.name = 'AbortError';
+          req.emit('error', e);
+        });
+        return;
+      }
+      if (r instanceof Error) {
+        queueMicrotask(() => req.emit('error', r));
+        return;
+      }
+      queueMicrotask(() => cb(r));
+    };
+    return req;
+  });
+}
 
 beforeEach(() => {
-  vi.stubGlobal('fetch', fetchMock);
-  fetchMock.mockReset();
+  requestMock.mockReset();
+  capturedOptions = [];
   lookupMock.mockReset();
   // Default: every host resolves to a single public address.
   lookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }] as never);
 });
 
 afterEach(() => {
-  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 const HTML = { timeoutMs: 5000, maxBytes: 1000, allowedContentTypes: ['text/html'] } as const;
@@ -67,23 +94,35 @@ async function code(p: Promise<unknown>): Promise<string> {
   }
 }
 
-describe('safeFetch — lexical rejects (no DNS / no fetch)', () => {
+/** Invoke a captured `lookup` override and return the address(es) it yields. */
+function invokeLookup(
+  lookupFn: any,
+  all: boolean
+): { address: string; family: number } | Array<{ address: string; family: number }> {
+  let out: any;
+  lookupFn('ignored.example.com', { all }, (_err: unknown, a: unknown, family?: number) => {
+    out = all ? a : { address: a, family };
+  });
+  return out;
+}
+
+describe('safeFetch — lexical rejects (no DNS / no request)', () => {
   it('rejects a non-https URL', async () => {
     expect(await code(safeFetch('http://example.com', HTML))).toBe('invalid_url');
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(requestMock).not.toHaveBeenCalled();
     expect(lookupMock).not.toHaveBeenCalled();
   });
 
   it('rejects userinfo (user:pass@host)', async () => {
     expect(await code(safeFetch('https://user:pass@example.com', HTML))).toBe('invalid_url');
     expect(await code(safeFetch('https://example.com@evil.com', HTML))).toBe('invalid_url');
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(requestMock).not.toHaveBeenCalled();
   });
 
   it('rejects an IP-literal host lexically', async () => {
     expect(await code(safeFetch('https://127.0.0.1', HTML))).toBe('invalid_url');
     expect(await code(safeFetch('https://2130706433', HTML))).toBe('invalid_url');
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(requestMock).not.toHaveBeenCalled();
   });
 });
 
@@ -91,7 +130,7 @@ describe('safeFetch — DNS-resolve guard', () => {
   it('rejects when the host resolves to a private address (DNS-rebinding)', async () => {
     lookupMock.mockResolvedValue([{ address: '10.0.0.5', family: 4 }] as never);
     expect(await code(safeFetch('https://rebind.example.com', HTML))).toBe('blocked_host');
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(requestMock).not.toHaveBeenCalled();
   });
 
   it('rejects if ANY resolved address is private (mixed A records)', async () => {
@@ -100,6 +139,7 @@ describe('safeFetch — DNS-resolve guard', () => {
       { address: '169.254.169.254', family: 4 },
     ] as never);
     expect(await code(safeFetch('https://mixed.example.com', HTML))).toBe('blocked_host');
+    expect(requestMock).not.toHaveBeenCalled();
   });
 
   it('maps a DNS failure to dns_failure', async () => {
@@ -108,32 +148,64 @@ describe('safeFetch — DNS-resolve guard', () => {
   });
 });
 
+describe('safeFetch — connection pinning (DNS-rebinding TOCTOU fix)', () => {
+  it('pins the outbound socket to the validated IP; SNI/Host keep the hostname', async () => {
+    lookupMock.mockResolvedValue([{ address: '203.0.113.7', family: 4 }] as never);
+    primeTransport(
+      fakeResponse({ headers: { 'content-type': 'text/html' }, chunks: ['ok'] })
+    );
+    await safeFetch('https://vendor.example.com/app', HTML);
+
+    const opts = capturedOptions[0];
+    // Host header + SNI + cert identity ride the real hostname, NOT the pinned IP.
+    expect(opts.hostname).toBe('vendor.example.com');
+    // The lookup override is what pins the socket — it yields ONLY the validated IP.
+    expect(typeof opts.lookup).toBe('function');
+    expect(invokeLookup(opts.lookup, true)).toEqual([{ address: '203.0.113.7', family: 4 }]);
+    expect(invokeLookup(opts.lookup, false)).toEqual({ address: '203.0.113.7', family: 4 });
+  });
+
+  it('a public-then-private rebind cannot make the connect target the private IP', async () => {
+    // Validation time: the authoritative server answers PUBLIC.
+    lookupMock.mockResolvedValue([{ address: '198.51.100.9', family: 4 }] as never);
+    primeTransport(
+      fakeResponse({ headers: { 'content-type': 'text/html' }, chunks: ['ok'] })
+    );
+    await safeFetch('https://rebind.example.com', HTML);
+
+    const opts = capturedOptions[0];
+    // Connect time: even if DNS now flips to a private IP, Node calls OUR pinned
+    // lookup, which returns ONLY the validated public IP — never 169.254.169.254.
+    const all = invokeLookup(opts.lookup, true) as Array<{ address: string }>;
+    expect(all.map((a) => a.address)).toEqual(['198.51.100.9']);
+    expect(all.some((a) => a.address === '169.254.169.254')).toBe(false);
+    expect(invokeLookup(opts.lookup, false)).toEqual({ address: '198.51.100.9', family: 4 });
+  });
+});
+
 describe('safeFetch — response controls', () => {
-  it('returns bytes + content-type + finalUrl on a good response, using redirect:manual', async () => {
-    fetchMock.mockResolvedValue(
+  it('returns bytes + content-type + finalUrl on a good response', async () => {
+    primeTransport(
       fakeResponse({ headers: { 'content-type': 'text/html; charset=utf-8' }, chunks: ['<html>hi'] })
     );
     const r = await safeFetch('https://example.com/page', HTML);
     expect(r.contentType).toBe('text/html');
     expect(r.bytes.toString('utf8')).toBe('<html>hi');
     expect(r.finalUrl).toBe('https://example.com/page');
-    expect(fetchMock.mock.calls[0]?.[1]?.redirect).toBe('manual');
   });
 
   it('rejects a disallowed content-type', async () => {
-    fetchMock.mockResolvedValue(
-      fakeResponse({ headers: { 'content-type': 'application/json' }, chunks: ['{}'] })
-    );
+    primeTransport(fakeResponse({ headers: { 'content-type': 'application/json' }, chunks: ['{}'] }));
     expect(await code(safeFetch('https://example.com', HTML))).toBe('content_type');
   });
 
   it('rejects a non-2xx status', async () => {
-    fetchMock.mockResolvedValue(fakeResponse({ status: 404 }));
+    primeTransport(fakeResponse({ status: 404 }));
     expect(await code(safeFetch('https://example.com', HTML))).toBe('bad_status');
   });
 
   it('rejects an oversize body via the Content-Length header (pre-buffer)', async () => {
-    fetchMock.mockResolvedValue(
+    primeTransport(
       fakeResponse({ headers: { 'content-type': 'text/html', 'content-length': '999999' } })
     );
     expect(await code(safeFetch('https://example.com', { ...HTML, maxBytes: 100 }))).toBe(
@@ -143,48 +215,63 @@ describe('safeFetch — response controls', () => {
 
   it('aborts mid-stream once the body exceeds maxBytes (lying/absent Content-Length)', async () => {
     // No content-length; body is 12 bytes but the cap is 5.
-    fetchMock.mockResolvedValue(
+    primeTransport(
       fakeResponse({ headers: { 'content-type': 'text/html' }, chunks: ['abcd', 'efgh', 'ijkl'] })
     );
     expect(await code(safeFetch('https://example.com', { ...HTML, maxBytes: 5 }))).toBe('too_large');
   });
 
-  it('maps a fetch TimeoutError to timeout', async () => {
-    fetchMock.mockRejectedValue(new DOMException('timed out', 'TimeoutError'));
-    expect(await code(safeFetch('https://example.com', HTML))).toBe('timeout');
+  it('maps a request timeout (abort deadline) to timeout', async () => {
+    primeTransport('hang');
+    expect(await code(safeFetch('https://example.com', { ...HTML, timeoutMs: 20 }))).toBe('timeout');
+  });
+
+  it('maps a transport error to network', async () => {
+    primeTransport(new Error('ECONNRESET'));
+    expect(await code(safeFetch('https://example.com', HTML))).toBe('network');
   });
 });
 
-describe('safeFetch — redirects (re-validated per hop)', () => {
+describe('safeFetch — redirects (re-validated + re-pinned per hop)', () => {
   it('re-validates a redirect Location and rejects one pointing at a private host', async () => {
     lookupMock.mockImplementation(async (host: string) =>
       host === 'internal.example.com'
         ? ([{ address: '10.1.2.3', family: 4 }] as never)
         : ([{ address: '93.184.216.34', family: 4 }] as never)
     );
-    fetchMock.mockResolvedValueOnce(
+    primeTransport(
       fakeResponse({ status: 302, headers: { location: 'https://internal.example.com/x' } })
     );
     expect(await code(safeFetch('https://example.com', HTML))).toBe('blocked_host');
-    // Only the FIRST hop was fetched; the private redirect target never was.
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Only the FIRST hop opened a socket; the private redirect target never did.
+    expect(requestMock).toHaveBeenCalledTimes(1);
   });
 
-  it('follows a redirect to a public host and returns the final body', async () => {
-    fetchMock
-      .mockResolvedValueOnce(
-        fakeResponse({ status: 301, headers: { location: 'https://www.example.com/final' } })
-      )
-      .mockResolvedValueOnce(
-        fakeResponse({ headers: { 'content-type': 'text/html' }, chunks: ['final'] })
-      );
+  it('follows a redirect to a public host, re-pinning to the new host IP', async () => {
+    lookupMock.mockImplementation(async (host: string) =>
+      host === 'www.example.com'
+        ? ([{ address: '198.51.100.20', family: 4 }] as never)
+        : ([{ address: '203.0.113.5', family: 4 }] as never)
+    );
+    primeTransport(
+      fakeResponse({ status: 301, headers: { location: 'https://www.example.com/final' } }),
+      fakeResponse({ headers: { 'content-type': 'text/html' }, chunks: ['final'] })
+    );
     const r = await safeFetch('https://example.com', HTML);
     expect(r.finalUrl).toBe('https://www.example.com/final');
     expect(r.bytes.toString('utf8')).toBe('final');
+    // Hop 1 pinned the origin IP; hop 2 re-pinned to the redirect target's IP.
+    expect(capturedOptions[0].hostname).toBe('example.com');
+    expect(invokeLookup(capturedOptions[0].lookup, false)).toEqual({ address: '203.0.113.5', family: 4 });
+    expect(capturedOptions[1].hostname).toBe('www.example.com');
+    expect(invokeLookup(capturedOptions[1].lookup, false)).toEqual({ address: '198.51.100.20', family: 4 });
   });
 
   it('caps the redirect chain', async () => {
-    fetchMock.mockResolvedValue(
+    primeTransport(
+      fakeResponse({ status: 302, headers: { location: 'https://example.com/loop' } }),
+      fakeResponse({ status: 302, headers: { location: 'https://example.com/loop' } }),
+      fakeResponse({ status: 302, headers: { location: 'https://example.com/loop' } }),
       fakeResponse({ status: 302, headers: { location: 'https://example.com/loop' } })
     );
     expect(await code(safeFetch('https://example.com', HTML))).toBe('too_many_redirects');

--- a/src/server/utils/__tests__/ssrf-hostname.test.ts
+++ b/src/server/utils/__tests__/ssrf-hostname.test.ts
@@ -110,6 +110,22 @@ describe('isPrivateIp (DNS-resolved-address guard)', () => {
     expect(isPrivateIp('2001:4860:4860::8888')).toBe(false); // Google DNS
   });
 
+  it('flags NAT64 (64:ff9b::/96) with a private/metadata embedded IPv4', () => {
+    expect(isPrivateIp('64:ff9b::a9fe:a9fe')).toBe(true); // embeds 169.254.169.254 (metadata)
+    expect(isPrivateIp('64:ff9b::7f00:1')).toBe(true); // embeds 127.0.0.1 (loopback)
+    expect(isPrivateIp('64:ff9b::a00:1')).toBe(true); // embeds 10.0.0.1 (RFC1918)
+    // A NAT64-wrapped PUBLIC IPv4 stays public (8.8.8.8 = 0808:0808).
+    expect(isPrivateIp('64:ff9b::808:808')).toBe(false);
+  });
+
+  it('flags 6to4 (2002::/16) with a private/metadata embedded IPv4', () => {
+    expect(isPrivateIp('2002:a9fe:a9fe::1')).toBe(true); // embeds 169.254.169.254 (metadata)
+    expect(isPrivateIp('2002:a00:1::')).toBe(true); // embeds 10.0.0.1 (RFC1918)
+    expect(isPrivateIp('2002:7f00:1::')).toBe(true); // embeds 127.0.0.1 (loopback)
+    // A 6to4-wrapped PUBLIC IPv4 stays public (8.8.8.8 = 0808:0808).
+    expect(isPrivateIp('2002:808:808::1')).toBe(false);
+  });
+
   it('flags an IPv6 with a zone id and fails closed on garbage', () => {
     expect(isPrivateIp('fe80::1%eth0')).toBe(true);
     expect(isPrivateIp('not-an-ip')).toBe(true); // unparseable → fail closed

--- a/src/server/utils/__tests__/ssrf-hostname.test.ts
+++ b/src/server/utils/__tests__/ssrf-hostname.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPrivateIp, isPublicHttpsUrl } from '~/server/utils/ssrf-hostname';
+
+/**
+ * The PURE lexical + IP SSRF guards shared by the manifest validator and the
+ * fetch-time `safeFetch`. `isPublicHttpsUrl` gates the URL SHAPE (https-only,
+ * no literal/encoded-IP hosts); `isPrivateIp` gates a DNS-RESOLVED address (the
+ * DNS-rebinding complement). Both fail CLOSED.
+ */
+
+describe('isPublicHttpsUrl (lexical URL-shape guard)', () => {
+  it('accepts a normal public https URL', () => {
+    expect(isPublicHttpsUrl('https://example.com/app').ok).toBe(true);
+    expect(isPublicHttpsUrl('https://sub.example.co.uk:8443/x?y=1').ok).toBe(true);
+  });
+
+  it('REJECTS non-https schemes', () => {
+    for (const u of ['http://example.com', 'ftp://example.com', 'file:///etc/passwd']) {
+      expect(isPublicHttpsUrl(u).ok, u).toBe(false);
+    }
+  });
+
+  it('REJECTS localhost / reserved internal names', () => {
+    for (const u of [
+      'https://localhost',
+      'https://foo.internal',
+      'https://bar.local',
+      'https://metadata.google.internal',
+    ]) {
+      expect(isPublicHttpsUrl(u).ok, u).toBe(false);
+    }
+  });
+
+  it('REJECTS dotted private/loopback/link-local IPv4 literals', () => {
+    for (const u of [
+      'https://127.0.0.1',
+      'https://10.0.0.5',
+      'https://172.16.0.1',
+      'https://192.168.1.1',
+      'https://169.254.169.254', // cloud metadata
+      'https://0.0.0.0',
+    ]) {
+      expect(isPublicHttpsUrl(u).ok, u).toBe(false);
+    }
+  });
+
+  it('REJECTS obfuscated IPv4 (hex / integer / octal / dotless) and IPv4-mapped IPv6', () => {
+    for (const u of [
+      'https://0x7f000001', // hex int 127.0.0.1
+      'https://2130706433', // decimal int 127.0.0.1
+      'https://0177.0.0.1', // octal
+      'https://[::ffff:127.0.0.1]', // IPv4-mapped IPv6
+    ]) {
+      expect(isPublicHttpsUrl(u).ok, u).toBe(false);
+    }
+  });
+
+  it('REJECTS a dot-less hostname', () => {
+    expect(isPublicHttpsUrl('https://intranet').ok).toBe(false);
+  });
+});
+
+describe('isPrivateIp (DNS-resolved-address guard)', () => {
+  it('treats public IPv4 as public', () => {
+    for (const ip of ['8.8.8.8', '1.1.1.1', '93.184.216.34']) {
+      expect(isPrivateIp(ip), ip).toBe(false);
+    }
+  });
+
+  it('flags private / loopback / link-local / CGNAT / reserved IPv4', () => {
+    for (const ip of [
+      '127.0.0.1',
+      '10.1.2.3',
+      '172.16.0.1',
+      '172.31.255.255',
+      '192.168.0.1',
+      '169.254.169.254',
+      '100.64.0.1', // CGNAT
+      '0.0.0.0',
+      '224.0.0.1', // multicast
+      '255.255.255.255',
+    ]) {
+      expect(isPrivateIp(ip), ip).toBe(true);
+    }
+  });
+
+  it('does NOT over-flag 172.15/172.32 (outside the /12)', () => {
+    expect(isPrivateIp('172.15.0.1')).toBe(false);
+    expect(isPrivateIp('172.32.0.1')).toBe(false);
+  });
+
+  it('flags loopback / ULA / link-local / mapped IPv6', () => {
+    for (const ip of [
+      '::1', // loopback
+      '::', // unspecified
+      'fc00::1', // ULA
+      'fd12:3456:789a::1', // ULA
+      'fe80::1', // link-local
+      'ff02::1', // multicast
+      '::ffff:127.0.0.1', // IPv4-mapped loopback
+      '::ffff:10.0.0.1', // IPv4-mapped private
+    ]) {
+      expect(isPrivateIp(ip), ip).toBe(true);
+    }
+  });
+
+  it('treats a public IPv6 as public', () => {
+    expect(isPrivateIp('2606:4700:4700::1111')).toBe(false); // Cloudflare DNS
+    expect(isPrivateIp('2001:4860:4860::8888')).toBe(false); // Google DNS
+  });
+
+  it('flags an IPv6 with a zone id and fails closed on garbage', () => {
+    expect(isPrivateIp('fe80::1%eth0')).toBe(true);
+    expect(isPrivateIp('not-an-ip')).toBe(true); // unparseable → fail closed
+    expect(isPrivateIp('999.999.999.999')).toBe(true);
+  });
+});

--- a/src/server/utils/og-metadata.ts
+++ b/src/server/utils/og-metadata.ts
@@ -128,7 +128,13 @@ function pickIconHref(candidates: IconCandidate[]): string | undefined {
   return icons[0]?.href;
 }
 
-/** Resolve a possibly-relative asset URL against the final page URL; drop unparseable. */
+/**
+ * Resolve a possibly-relative asset URL against the final page URL; drop
+ * unparseable OR non-https results. https-only mirrors the accept-side `safeFetch`
+ * (which is https-only): a suggested `http://` image would render as a
+ * mixed-content preview client-side but then FAIL ingestion on accept — so we
+ * never suggest one (the UI falls back to manual upload instead).
+ */
 function resolveUrl(href: string | undefined, baseUrl: string): string | undefined {
   if (!href) return undefined;
   const trimmed = href.trim();
@@ -136,11 +142,16 @@ function resolveUrl(href: string | undefined, baseUrl: string): string | undefin
   // Skip data: URIs and other non-fetchable schemes early — the accept-side
   // safeFetch would reject them anyway, but there's no point suggesting them.
   if (/^data:/i.test(trimmed)) return undefined;
+  let resolved: URL;
   try {
-    return new URL(trimmed, baseUrl).toString();
+    resolved = new URL(trimmed, baseUrl);
   } catch {
     return undefined;
   }
+  // Only https suggestions — matches what safeFetch can actually ingest, so the
+  // preview never shows an asset the accept step will reject.
+  if (resolved.protocol !== 'https:') return undefined;
+  return resolved.toString();
 }
 
 function clamp(s: string | undefined, max: number): string | undefined {

--- a/src/server/utils/og-metadata.ts
+++ b/src/server/utils/og-metadata.ts
@@ -1,0 +1,184 @@
+/**
+ * PURE (no network) OpenGraph / HTML metadata extraction for the App Blocks
+ * external-listing auto-pull. Given a page's HTML + its final (post-redirect) URL,
+ * pull the best-effort SUGGESTIONS an author can accept or override:
+ *
+ *   og:title  / <title>               → suggested NAME
+ *   og:description / meta description  → suggested TAGLINE/description
+ *   og:image  / twitter:image          → suggested COVER image URL
+ *   apple-touch-icon / rel=icon        → suggested ICON image URL
+ *
+ * There is no HTML-parser dependency in this repo (no cheerio / node-html-parser),
+ * and `unfurl.js` does its OWN unguarded outbound fetch — so this is a small,
+ * dependency-free regex extractor. It is best-effort ONLY: the output is a set of
+ * SUGGESTIONS, never persisted directly, and any image URL is re-fetched through
+ * the SSRF-hardened `safeFetch` on accept — so a fragile parse can under-suggest
+ * (→ the UI falls back to manual upload) but can never bypass a security control.
+ *
+ * Relative asset URLs (`/favicon.ico`, `og.png`) are resolved against the final
+ * page URL. Missing tags yield `undefined` fields (never throws).
+ */
+
+const MAX_NAME_LEN = 120; // mirrors OFFSITE_NAME_MAX
+const MAX_TAGLINE_LEN = 140; // mirrors OFFSITE_TAGLINE_MAX
+
+export type ListingMetaSuggestion = {
+  name?: string;
+  tagline?: string;
+  coverImageUrl?: string;
+  iconImageUrl?: string;
+};
+
+/** Read one attribute value from a single tag string (double, single, or unquoted). */
+function getAttr(tag: string, attr: string): string | undefined {
+  // Negative lookbehind for a word-char or hyphen so `name` doesn't match inside
+  // `data-name` / `itemname`, and `content` doesn't match `data-content`.
+  const re = new RegExp(`(?<![\\w-])${attr}\\s*=\\s*("([^"]*)"|'([^']*)'|([^\\s"'>]+))`, 'i');
+  const m = re.exec(tag);
+  if (!m) return undefined;
+  const raw = m[2] ?? m[3] ?? m[4];
+  return raw !== undefined ? decodeEntities(raw).trim() : undefined;
+}
+
+/** Minimal HTML-entity decoder for the handful that appear in titles/descriptions. */
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => safeFromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => safeFromCodePoint(parseInt(dec, 10)))
+    .replace(/&quot;/gi, '"')
+    .replace(/&apos;/gi, "'")
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&nbsp;/gi, ' ')
+    // &amp; LAST so an entity like `&amp;lt;` isn't double-decoded.
+    .replace(/&amp;/gi, '&');
+}
+
+function safeFromCodePoint(cp: number): string {
+  if (!Number.isFinite(cp) || cp < 0 || cp > 0x10ffff) return '';
+  try {
+    return String.fromCodePoint(cp);
+  } catch {
+    return '';
+  }
+}
+
+/** All `<meta ...>` tags → a map keyed by lowercased `property`/`name` → `content`. */
+function extractMetaMap(html: string): Map<string, string> {
+  const map = new Map<string, string>();
+  const metaRe = /<meta\b[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = metaRe.exec(html)) !== null) {
+    const tag = m[0];
+    const key = getAttr(tag, 'property') ?? getAttr(tag, 'name');
+    if (!key) continue;
+    const content = getAttr(tag, 'content');
+    if (content === undefined) continue;
+    const lower = key.toLowerCase();
+    // First occurrence wins (OG tags are usually in <head> order; don't let a
+    // later duplicate override the canonical one).
+    if (!map.has(lower)) map.set(lower, content);
+  }
+  return map;
+}
+
+type IconCandidate = { rel: string; href: string; sizePx: number };
+
+/** All `<link rel=... href=...>` icon candidates (rel contains "icon"). */
+function extractIconCandidates(html: string): IconCandidate[] {
+  const out: IconCandidate[] = [];
+  const linkRe = /<link\b[^>]*>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = linkRe.exec(html)) !== null) {
+    const tag = m[0];
+    const rel = getAttr(tag, 'rel')?.toLowerCase();
+    if (!rel || !rel.includes('icon')) continue;
+    const href = getAttr(tag, 'href');
+    if (!href) continue;
+    const sizes = getAttr(tag, 'sizes') ?? '';
+    const sizeMatch = /(\d+)x(\d+)/i.exec(sizes);
+    const sizePx = sizeMatch ? Number(sizeMatch[1]) : 0;
+    out.push({ rel, href, sizePx });
+  }
+  return out;
+}
+
+/** The `<title>` text (first occurrence), decoded + trimmed. */
+function extractTitle(html: string): string | undefined {
+  const m = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html);
+  if (!m) return undefined;
+  const text = decodeEntities(m[1]).replace(/\s+/g, ' ').trim();
+  return text.length > 0 ? text : undefined;
+}
+
+/**
+ * Pick the best icon href from the candidates: prefer `apple-touch-icon` (large,
+ * high-quality), then the largest declared `rel=icon`, then any icon. Returns the
+ * raw (possibly relative) href.
+ */
+function pickIconHref(candidates: IconCandidate[]): string | undefined {
+  if (candidates.length === 0) return undefined;
+  const apple = candidates
+    .filter((c) => c.rel.includes('apple-touch-icon'))
+    .sort((a, b) => b.sizePx - a.sizePx);
+  if (apple.length > 0) return apple[0].href;
+  const icons = candidates
+    .filter((c) => c.rel.includes('icon'))
+    .sort((a, b) => b.sizePx - a.sizePx);
+  return icons[0]?.href;
+}
+
+/** Resolve a possibly-relative asset URL against the final page URL; drop unparseable. */
+function resolveUrl(href: string | undefined, baseUrl: string): string | undefined {
+  if (!href) return undefined;
+  const trimmed = href.trim();
+  if (trimmed.length === 0) return undefined;
+  // Skip data: URIs and other non-fetchable schemes early — the accept-side
+  // safeFetch would reject them anyway, but there's no point suggesting them.
+  if (/^data:/i.test(trimmed)) return undefined;
+  try {
+    return new URL(trimmed, baseUrl).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function clamp(s: string | undefined, max: number): string | undefined {
+  if (s === undefined) return undefined;
+  const t = s.trim();
+  if (t.length === 0) return undefined;
+  return t.length > max ? t.slice(0, max).trim() : t;
+}
+
+/**
+ * Extract the listing-metadata suggestions from a page's HTML. Resolves relative
+ * asset URLs against `finalUrl` (the post-redirect page URL). Every field is
+ * optional — a page with no usable tags returns `{}` (the UI then falls back to
+ * manual entry / upload). Never throws.
+ */
+export function extractListingMeta(html: string, finalUrl: string): ListingMetaSuggestion {
+  const meta = extractMetaMap(html);
+
+  const name = clamp(meta.get('og:title') ?? extractTitle(html), MAX_NAME_LEN);
+  const tagline = clamp(
+    meta.get('og:description') ?? meta.get('twitter:description') ?? meta.get('description'),
+    MAX_TAGLINE_LEN
+  );
+
+  const coverHref =
+    meta.get('og:image') ??
+    meta.get('og:image:url') ??
+    meta.get('og:image:secure_url') ??
+    meta.get('twitter:image') ??
+    meta.get('twitter:image:src');
+  const coverImageUrl = resolveUrl(coverHref, finalUrl);
+
+  const iconImageUrl = resolveUrl(pickIconHref(extractIconCandidates(html)), finalUrl);
+
+  const result: ListingMetaSuggestion = {};
+  if (name) result.name = name;
+  if (tagline) result.tagline = tagline;
+  if (coverImageUrl) result.coverImageUrl = coverImageUrl;
+  if (iconImageUrl) result.iconImageUrl = iconImageUrl;
+  return result;
+}

--- a/src/server/utils/safe-fetch.ts
+++ b/src/server/utils/safe-fetch.ts
@@ -1,0 +1,232 @@
+import { lookup } from 'node:dns/promises';
+
+import { isPrivateIp, isPublicHttpsUrl } from '~/server/utils/ssrf-hostname';
+
+/**
+ * SSRF-hardened server-side fetch — the ONE guarded outbound-fetch primitive for
+ * pulling an attacker-influenced URL (an App Blocks external-listing page or its
+ * og:image). There is NO existing safeFetch/isPrivateIp util in the repo; this is
+ * it. `unfurl.js` and `cf-images-utils.uploadViaBuffer` both do UNGUARDED outbound
+ * fetches — do NOT use them to reach a user-supplied URL; use this instead.
+ *
+ * Controls (all enforced on every hop):
+ *   1. LEXICAL — https-only + `isPublicHttpsUrl` (rejects hex/int/octal IPv4,
+ *      IPv4-mapped IPv6, dot-less/reserved hosts) AND reject URL userinfo
+ *      (`user:pass@host`).
+ *   2. DNS — resolve the host to ALL A/AAAA addresses and reject if ANY resolves
+ *      to a private/loopback/link-local/unique-local/metadata range. This closes
+ *      the DNS-rebinding hole the lexical guard can't see.
+ *   3. REDIRECTS — `redirect: 'manual'`; a 3xx `Location` is followed at most
+ *      `maxRedirects` (default 2) hops, and EACH hop's host is re-validated
+ *      (lexical + DNS) before it is fetched.
+ *   4. TIMEOUT — a hard `AbortSignal.timeout` per request.
+ *   5. SIZE — a hard `maxBytes` cap, enforced by the `Content-Length` header
+ *      (pre-buffer) AND by aborting mid-stream once the cumulative body exceeds it.
+ *   6. CONTENT-TYPE — a per-call allowlist (text/html for the page; image/* for
+ *      the image), matched by prefix on the final response.
+ */
+
+export type SafeFetchErrorCode =
+  | 'invalid_url' // lexical reject (non-https, bad host shape, userinfo)
+  | 'blocked_host' // DNS resolved to a private/reserved address
+  | 'dns_failure' // host didn't resolve
+  | 'too_many_redirects'
+  | 'bad_status' // non-2xx (and non-followed-3xx) response
+  | 'content_type' // response content-type not in the allowlist
+  | 'too_large' // body exceeded maxBytes
+  | 'timeout' // aborted by the per-request timeout
+  | 'network'; // any other transport error
+
+/** A typed, NON-leaky failure. `message` is safe to log; never surface it raw to a client. */
+export class SafeFetchError extends Error {
+  readonly code: SafeFetchErrorCode;
+  constructor(code: SafeFetchErrorCode, message: string) {
+    super(message);
+    this.name = 'SafeFetchError';
+    this.code = code;
+  }
+}
+
+export type SafeFetchOptions = {
+  /** Per-request timeout in ms (also the whole-chain budget per hop). */
+  timeoutMs: number;
+  /** Hard cap on the response body; the stream is aborted once it is exceeded. */
+  maxBytes: number;
+  /**
+   * Allowed response content-type PREFIXES (matched on the `type/subtype` part,
+   * lowercased, before any `;` params). e.g. `['text/html']` or `['image/']`.
+   */
+  allowedContentTypes: readonly string[];
+  /** Max redirect hops to follow (each re-validated). Default 2. */
+  maxRedirects?: number;
+};
+
+export type SafeFetchResult = {
+  /** The FINAL URL fetched (after any followed redirects) — resolve relative assets against this. */
+  finalUrl: string;
+  /** The response content-type's `type/subtype` (lowercased, no params). */
+  contentType: string;
+  /** The fetched body bytes (≤ maxBytes). */
+  bytes: Buffer;
+};
+
+/** Lexical + userinfo validation of a single URL. Throws SafeFetchError on reject. */
+function assertLexicallySafe(raw: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    throw new SafeFetchError('invalid_url', `unparseable URL`);
+  }
+  // Reject credentials in the URL (`https://example.com@evil.com`,
+  // `https://user:pass@host`) — a display-vs-real-host phishing/SSRF vector.
+  if (parsed.username || parsed.password) {
+    throw new SafeFetchError('invalid_url', 'URL must not contain credentials (user:pass@host)');
+  }
+  const lexical = isPublicHttpsUrl(raw);
+  if (!lexical.ok) throw new SafeFetchError('invalid_url', lexical.reason);
+  return parsed;
+}
+
+/** DNS-resolve a host to all A/AAAA addresses and reject if ANY is private. */
+async function assertHostResolvesPublic(hostname: string): Promise<void> {
+  let addresses: { address: string; family: number }[];
+  try {
+    addresses = await lookup(hostname, { all: true });
+  } catch {
+    throw new SafeFetchError('dns_failure', `could not resolve host`);
+  }
+  if (addresses.length === 0) {
+    throw new SafeFetchError('dns_failure', `host resolved to no addresses`);
+  }
+  for (const { address } of addresses) {
+    if (isPrivateIp(address)) {
+      throw new SafeFetchError('blocked_host', `host resolves to a non-public address`);
+    }
+  }
+}
+
+/** Parse a `Content-Type` header down to its lowercased `type/subtype`. */
+function normalizeContentType(raw: string | null): string {
+  return (raw ?? '').split(';')[0]?.trim().toLowerCase() ?? '';
+}
+
+function contentTypeAllowed(ct: string, allowed: readonly string[]): boolean {
+  return allowed.some((prefix) => ct.startsWith(prefix.toLowerCase()));
+}
+
+/** Read a response body into a Buffer, aborting once `maxBytes` is exceeded. */
+async function readCappedBody(res: Response, maxBytes: number): Promise<Buffer> {
+  // Pre-buffer guard: an advertised oversize body is rejected before reading.
+  const declared = Number(res.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new SafeFetchError('too_large', `Content-Length ${declared} exceeds cap ${maxBytes}`);
+  }
+
+  const body = res.body;
+  if (!body) {
+    // No stream (e.g. a mocked/empty body) — fall back to arrayBuffer with a
+    // post-read cap.
+    const buf = Buffer.from(await res.arrayBuffer());
+    if (buf.byteLength > maxBytes) {
+      throw new SafeFetchError('too_large', `body exceeds cap ${maxBytes}`);
+    }
+    return buf;
+  }
+
+  const reader = body.getReader();
+  const chunks: Buffer[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        total += value.byteLength;
+        if (total > maxBytes) {
+          await reader.cancel();
+          throw new SafeFetchError('too_large', `body exceeds cap ${maxBytes}`);
+        }
+        chunks.push(Buffer.from(value));
+      }
+    }
+  } finally {
+    reader.releaseLock?.();
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Perform an SSRF-hardened GET. Validates (lexical + DNS) the URL and every
+ * redirect hop, enforces the timeout / size / content-type controls, and returns
+ * the final URL + content-type + capped body bytes. Throws {@link SafeFetchError}
+ * (a typed, non-leaky failure) on any control violation or transport error.
+ */
+export async function safeFetch(url: string, opts: SafeFetchOptions): Promise<SafeFetchResult> {
+  const maxRedirects = opts.maxRedirects ?? 2;
+  let currentUrl = url;
+
+  for (let hop = 0; ; hop++) {
+    const parsed = assertLexicallySafe(currentUrl);
+    await assertHostResolvesPublic(parsed.hostname);
+
+    let res: Response;
+    try {
+      res = await fetch(parsed.toString(), {
+        method: 'GET',
+        redirect: 'manual',
+        signal: AbortSignal.timeout(opts.timeoutMs),
+        headers: {
+          // A neutral UA + explicit Accept keeps some origins from serving a
+          // login/redirect wall; harmless if ignored.
+          'user-agent': 'CivitaiBot/1.0 (+https://civitai.com)',
+          accept: opts.allowedContentTypes.join(', ') || '*/*',
+        },
+      });
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'TimeoutError') {
+        throw new SafeFetchError('timeout', 'request timed out');
+      }
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new SafeFetchError('timeout', 'request aborted');
+      }
+      throw new SafeFetchError('network', 'transport error');
+    }
+
+    // Manual redirect handling: re-validate the Location host on the next hop.
+    if (res.status >= 300 && res.status < 400) {
+      // Free the redirect response's socket before following.
+      await res.body?.cancel().catch(() => undefined);
+      const location = res.headers.get('location');
+      if (!location) throw new SafeFetchError('bad_status', `redirect without a Location`);
+      if (hop >= maxRedirects) {
+        throw new SafeFetchError('too_many_redirects', `exceeded ${maxRedirects} redirects`);
+      }
+      // Resolve a possibly-relative Location against the current URL, then loop
+      // (the top of the loop re-runs the lexical + DNS guard on it).
+      let next: string;
+      try {
+        next = new URL(location, parsed).toString();
+      } catch {
+        throw new SafeFetchError('invalid_url', 'malformed redirect Location');
+      }
+      currentUrl = next;
+      continue;
+    }
+
+    if (!res.ok) {
+      // Drain to free the socket, then reject.
+      await res.body?.cancel().catch(() => undefined);
+      throw new SafeFetchError('bad_status', `non-2xx status ${res.status}`);
+    }
+
+    const contentType = normalizeContentType(res.headers.get('content-type'));
+    if (!contentTypeAllowed(contentType, opts.allowedContentTypes)) {
+      await res.body?.cancel().catch(() => undefined);
+      throw new SafeFetchError('content_type', `disallowed content-type "${contentType}"`);
+    }
+
+    const bytes = await readCappedBody(res, opts.maxBytes);
+    return { finalUrl: parsed.toString(), contentType, bytes };
+  }
+}

--- a/src/server/utils/safe-fetch.ts
+++ b/src/server/utils/safe-fetch.ts
@@ -1,4 +1,7 @@
 import { lookup } from 'node:dns/promises';
+import type { IncomingHttpHeaders, IncomingMessage } from 'node:http';
+import https from 'node:https';
+import type { LookupFunction } from 'node:net';
 
 import { isPrivateIp, isPublicHttpsUrl } from '~/server/utils/ssrf-hostname';
 
@@ -14,16 +17,31 @@ import { isPrivateIp, isPublicHttpsUrl } from '~/server/utils/ssrf-hostname';
  *      IPv4-mapped IPv6, dot-less/reserved hosts) AND reject URL userinfo
  *      (`user:pass@host`).
  *   2. DNS — resolve the host to ALL A/AAAA addresses and reject if ANY resolves
- *      to a private/loopback/link-local/unique-local/metadata range. This closes
- *      the DNS-rebinding hole the lexical guard can't see.
- *   3. REDIRECTS — `redirect: 'manual'`; a 3xx `Location` is followed at most
- *      `maxRedirects` (default 2) hops, and EACH hop's host is re-validated
- *      (lexical + DNS) before it is fetched.
- *   4. TIMEOUT — a hard `AbortSignal.timeout` per request.
- *   5. SIZE — a hard `maxBytes` cap, enforced by the `Content-Length` header
- *      (pre-buffer) AND by aborting mid-stream once the cumulative body exceeds it.
- *   6. CONTENT-TYPE — a per-call allowlist (text/html for the page; image/* for
+ *      to a private/loopback/link-local/unique-local/metadata range.
+ *   3. CONNECTION PINNING (closes the DNS-rebinding TOCTOU) — the outbound socket
+ *      is pinned to the EXACT validated IP via a per-request `lookup` override on
+ *      `https.request`. Node's own connect path calls our `lookup`, which returns
+ *      the address we validated in step 2 — so the byte we validated IS the byte
+ *      we connect to. There is NO second, undici/OS resolution of the
+ *      attacker-controlled name at connect time to race (the classic
+ *      validate-then-`fetch(url)` TOCTOU, where an authoritative TTL-0 server can
+ *      answer PUBLIC to the check and PRIVATE to the connect). SNI + the `Host`
+ *      header still carry the real hostname (Node derives both from `hostname`,
+ *      not from the pinned IP), so TLS cert validation is against the hostname.
+ *   4. REDIRECTS — followed MANUALLY at most `maxRedirects` (default 2) hops; each
+ *      hop re-runs the FULL lexical + DNS guard AND re-pins to that hop's freshly
+ *      validated IP before any socket is opened to it (a redirect to a private
+ *      host is rejected before it is ever connected).
+ *   5. TIMEOUT — a hard per-request deadline (an AbortController fired by a timer)
+ *      covering connect + headers + the whole body read.
+ *   6. SIZE — a hard `maxBytes` cap, enforced by the `Content-Length` header
+ *      (pre-buffer) AND by destroying the response stream once the cumulative body
+ *      exceeds it.
+ *   7. CONTENT-TYPE — a per-call allowlist (text/html for the page; image/* for
  *      the image), matched by prefix on the final response.
+ *
+ * No cookies, credentials, or auth headers are ever sent (no cookie jar; only a
+ * neutral UA + Accept), so a redirect can't be used to exfiltrate ambient creds.
  */
 
 export type SafeFetchErrorCode =
@@ -50,7 +68,7 @@ export class SafeFetchError extends Error {
 export type SafeFetchOptions = {
   /** Per-request timeout in ms (also the whole-chain budget per hop). */
   timeoutMs: number;
-  /** Hard cap on the response body; the stream is aborted once it is exceeded. */
+  /** Hard cap on the response body; the stream is destroyed once it is exceeded. */
   maxBytes: number;
   /**
    * Allowed response content-type PREFIXES (matched on the `type/subtype` part,
@@ -70,6 +88,9 @@ export type SafeFetchResult = {
   bytes: Buffer;
 };
 
+/** A DNS-resolved, SSRF-validated address the socket is pinned to. */
+type ValidatedAddress = { address: string; family: number };
+
 /** Lexical + userinfo validation of a single URL. Throws SafeFetchError on reject. */
 function assertLexicallySafe(raw: string): URL {
   let parsed: URL;
@@ -88,9 +109,14 @@ function assertLexicallySafe(raw: string): URL {
   return parsed;
 }
 
-/** DNS-resolve a host to all A/AAAA addresses and reject if ANY is private. */
-async function assertHostResolvesPublic(hostname: string): Promise<void> {
-  let addresses: { address: string; family: number }[];
+/**
+ * DNS-resolve a host to all A/AAAA addresses, reject if ANY is private, and return
+ * the FIRST validated address to pin the outbound socket to. Every returned
+ * address has been checked, so pinning to any one of them is safe; pinning is what
+ * closes the rebinding TOCTOU (the connect path can't re-resolve to a private IP).
+ */
+async function resolveAndValidateHost(hostname: string): Promise<ValidatedAddress> {
+  let addresses: ValidatedAddress[];
   try {
     addresses = await lookup(hostname, { all: true });
   } catch {
@@ -104,10 +130,27 @@ async function assertHostResolvesPublic(hostname: string): Promise<void> {
       throw new SafeFetchError('blocked_host', `host resolves to a non-public address`);
     }
   }
+  return addresses[0];
+}
+
+/**
+ * A `lookup` override that ALWAYS yields the pre-validated address, so Node's
+ * connect path can never re-resolve the attacker-controlled name to a private IP.
+ * Handles both callback conventions: `all: true` (array — Node ≥18 happy-eyeballs)
+ * and the single-address form.
+ */
+function pinnedLookup(validated: ValidatedAddress): LookupFunction {
+  return (_hostname, options, callback) => {
+    if (options.all) {
+      callback(null, [{ address: validated.address, family: validated.family }]);
+    } else {
+      callback(null, validated.address, validated.family);
+    }
+  };
 }
 
 /** Parse a `Content-Type` header down to its lowercased `type/subtype`. */
-function normalizeContentType(raw: string | null): string {
+function normalizeContentType(raw: string | undefined): string {
   return (raw ?? '').split(';')[0]?.trim().toLowerCase() ?? '';
 }
 
@@ -115,52 +158,152 @@ function contentTypeAllowed(ct: string, allowed: readonly string[]): boolean {
   return allowed.some((prefix) => ct.startsWith(prefix.toLowerCase()));
 }
 
-/** Read a response body into a Buffer, aborting once `maxBytes` is exceeded. */
-async function readCappedBody(res: Response, maxBytes: number): Promise<Buffer> {
-  // Pre-buffer guard: an advertised oversize body is rejected before reading.
-  const declared = Number(res.headers.get('content-length'));
-  if (Number.isFinite(declared) && declared > maxBytes) {
-    throw new SafeFetchError('too_large', `Content-Length ${declared} exceeds cap ${maxBytes}`);
-  }
+/** Read a single header value (first, if a multi-value array). */
+function headerValue(headers: IncomingHttpHeaders, name: string): string | undefined {
+  const v = headers[name];
+  return Array.isArray(v) ? v[0] : v;
+}
 
-  const body = res.body;
-  if (!body) {
-    // No stream (e.g. a mocked/empty body) — fall back to arrayBuffer with a
-    // post-read cap.
-    const buf = Buffer.from(await res.arrayBuffer());
-    if (buf.byteLength > maxBytes) {
-      throw new SafeFetchError('too_large', `body exceeds cap ${maxBytes}`);
-    }
-    return buf;
-  }
+type Hop = {
+  statusCode: number;
+  headers: IncomingHttpHeaders;
+  stream: IncomingMessage;
+};
 
-  const reader = body.getReader();
-  const chunks: Buffer[] = [];
-  let total = 0;
-  try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      if (value) {
-        total += value.byteLength;
-        if (total > maxBytes) {
-          await reader.cancel();
-          throw new SafeFetchError('too_large', `body exceeds cap ${maxBytes}`);
-        }
-        chunks.push(Buffer.from(value));
+/**
+ * Open ONE https GET to `parsed`, pinned to `validated`. Resolves once the
+ * response headers are in (the body stream is returned unread). The `signal`
+ * (a timeout deadline) aborts the request at any stage.
+ */
+function requestHop(
+  parsed: URL,
+  validated: ValidatedAddress,
+  opts: SafeFetchOptions,
+  signal: AbortSignal
+): Promise<Hop> {
+  return new Promise<Hop>((resolve, reject) => {
+    const req = https.request(
+      {
+        protocol: 'https:',
+        // Real hostname → drives the Host header, SNI, and cert identity check.
+        hostname: parsed.hostname,
+        port: parsed.port || 443,
+        path: `${parsed.pathname}${parsed.search}`,
+        method: 'GET',
+        // Pin the socket to the validated IP — the crux of the TOCTOU fix.
+        lookup: pinnedLookup(validated),
+        signal,
+        headers: {
+          // A neutral UA + explicit Accept keeps some origins from serving a
+          // login/redirect wall; harmless if ignored. NO cookie / auth headers.
+          'user-agent': 'CivitaiBot/1.0 (+https://civitai.com)',
+          accept: opts.allowedContentTypes.join(', ') || '*/*',
+        },
+      },
+      (res) => {
+        resolve({ statusCode: res.statusCode ?? 0, headers: res.headers, stream: res });
       }
+    );
+    req.on('error', (err) => reject(err));
+    req.end();
+  });
+}
+
+/** Map a raw transport error to a typed, non-leaky SafeFetchError. */
+function mapTransportError(err: unknown): SafeFetchError {
+  if (err instanceof SafeFetchError) return err;
+  if (err instanceof Error) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (err.name === 'AbortError' || err.name === 'TimeoutError' || code === 'ABORT_ERR') {
+      return new SafeFetchError('timeout', 'request timed out');
     }
-  } finally {
-    reader.releaseLock?.();
   }
-  return Buffer.concat(chunks);
+  return new SafeFetchError('network', 'transport error');
+}
+
+/**
+ * Read a response stream into a Buffer, destroying it once `maxBytes` is exceeded
+ * or the deadline `signal` fires. The `Content-Length` header (when present +
+ * oversize) short-circuits before a byte is read.
+ */
+function readCappedBody(
+  stream: IncomingMessage,
+  contentLength: string | undefined,
+  maxBytes: number,
+  signal: AbortSignal
+): Promise<Buffer> {
+  const declared = Number(contentLength);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    stream.destroy();
+    return Promise.reject(
+      new SafeFetchError('too_large', `Content-Length ${declared} exceeds cap ${maxBytes}`)
+    );
+  }
+
+  return new Promise<Buffer>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let settled = false;
+
+    const cleanup = () => {
+      signal.removeEventListener('abort', onAbort);
+      stream.removeListener('data', onData);
+      stream.removeListener('end', onEnd);
+      stream.removeListener('error', onError);
+    };
+    const fail = (e: SafeFetchError) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      stream.destroy();
+      reject(e);
+    };
+    const onAbort = () => fail(new SafeFetchError('timeout', 'request timed out'));
+    const onData = (chunk: Buffer) => {
+      if (settled) return;
+      total += chunk.byteLength;
+      if (total > maxBytes) {
+        fail(new SafeFetchError('too_large', `body exceeds cap ${maxBytes}`));
+        return;
+      }
+      chunks.push(chunk);
+    };
+    const onEnd = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(Buffer.concat(chunks));
+    };
+    const onError = (err: unknown) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(mapTransportError(err));
+    };
+
+    if (signal.aborted) {
+      fail(new SafeFetchError('timeout', 'request timed out'));
+      return;
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+    stream.on('data', onData);
+    stream.on('end', onEnd);
+    stream.on('error', onError);
+  });
+}
+
+/** Discard a response body (free the socket) without reading it into memory. */
+function drain(stream: IncomingMessage): void {
+  stream.destroy();
 }
 
 /**
  * Perform an SSRF-hardened GET. Validates (lexical + DNS) the URL and every
- * redirect hop, enforces the timeout / size / content-type controls, and returns
- * the final URL + content-type + capped body bytes. Throws {@link SafeFetchError}
- * (a typed, non-leaky failure) on any control violation or transport error.
+ * redirect hop, PINS the outbound socket to the validated IP (closing the
+ * DNS-rebinding TOCTOU), enforces the timeout / size / content-type controls, and
+ * returns the final URL + content-type + capped body bytes. Throws
+ * {@link SafeFetchError} (a typed, non-leaky failure) on any control violation or
+ * transport error.
  */
 export async function safeFetch(url: string, opts: SafeFetchOptions): Promise<SafeFetchResult> {
   const maxRedirects = opts.maxRedirects ?? 2;
@@ -168,65 +311,58 @@ export async function safeFetch(url: string, opts: SafeFetchOptions): Promise<Sa
 
   for (let hop = 0; ; hop++) {
     const parsed = assertLexicallySafe(currentUrl);
-    await assertHostResolvesPublic(parsed.hostname);
+    const validated = await resolveAndValidateHost(parsed.hostname);
 
-    let res: Response;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), opts.timeoutMs);
     try {
-      res = await fetch(parsed.toString(), {
-        method: 'GET',
-        redirect: 'manual',
-        signal: AbortSignal.timeout(opts.timeoutMs),
-        headers: {
-          // A neutral UA + explicit Accept keeps some origins from serving a
-          // login/redirect wall; harmless if ignored.
-          'user-agent': 'CivitaiBot/1.0 (+https://civitai.com)',
-          accept: opts.allowedContentTypes.join(', ') || '*/*',
-        },
-      });
-    } catch (err) {
-      if (err instanceof DOMException && err.name === 'TimeoutError') {
-        throw new SafeFetchError('timeout', 'request timed out');
-      }
-      if (err instanceof Error && err.name === 'AbortError') {
-        throw new SafeFetchError('timeout', 'request aborted');
-      }
-      throw new SafeFetchError('network', 'transport error');
-    }
-
-    // Manual redirect handling: re-validate the Location host on the next hop.
-    if (res.status >= 300 && res.status < 400) {
-      // Free the redirect response's socket before following.
-      await res.body?.cancel().catch(() => undefined);
-      const location = res.headers.get('location');
-      if (!location) throw new SafeFetchError('bad_status', `redirect without a Location`);
-      if (hop >= maxRedirects) {
-        throw new SafeFetchError('too_many_redirects', `exceeded ${maxRedirects} redirects`);
-      }
-      // Resolve a possibly-relative Location against the current URL, then loop
-      // (the top of the loop re-runs the lexical + DNS guard on it).
-      let next: string;
+      let res: Hop;
       try {
-        next = new URL(location, parsed).toString();
-      } catch {
-        throw new SafeFetchError('invalid_url', 'malformed redirect Location');
+        res = await requestHop(parsed, validated, opts, controller.signal);
+      } catch (err) {
+        throw mapTransportError(err);
       }
-      currentUrl = next;
-      continue;
-    }
 
-    if (!res.ok) {
-      // Drain to free the socket, then reject.
-      await res.body?.cancel().catch(() => undefined);
-      throw new SafeFetchError('bad_status', `non-2xx status ${res.status}`);
-    }
+      // Manual redirect handling: re-validate + re-pin the Location host next hop.
+      if (res.statusCode >= 300 && res.statusCode < 400) {
+        drain(res.stream); // free the redirect response's socket before following.
+        const location = headerValue(res.headers, 'location');
+        if (!location) throw new SafeFetchError('bad_status', `redirect without a Location`);
+        if (hop >= maxRedirects) {
+          throw new SafeFetchError('too_many_redirects', `exceeded ${maxRedirects} redirects`);
+        }
+        // Resolve a possibly-relative Location against the current URL, then loop
+        // (the top of the loop re-runs the lexical + DNS + pin guard on it).
+        let next: string;
+        try {
+          next = new URL(location, parsed).toString();
+        } catch {
+          throw new SafeFetchError('invalid_url', 'malformed redirect Location');
+        }
+        currentUrl = next;
+        continue;
+      }
 
-    const contentType = normalizeContentType(res.headers.get('content-type'));
-    if (!contentTypeAllowed(contentType, opts.allowedContentTypes)) {
-      await res.body?.cancel().catch(() => undefined);
-      throw new SafeFetchError('content_type', `disallowed content-type "${contentType}"`);
-    }
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        drain(res.stream);
+        throw new SafeFetchError('bad_status', `non-2xx status ${res.statusCode}`);
+      }
 
-    const bytes = await readCappedBody(res, opts.maxBytes);
-    return { finalUrl: parsed.toString(), contentType, bytes };
+      const contentType = normalizeContentType(headerValue(res.headers, 'content-type'));
+      if (!contentTypeAllowed(contentType, opts.allowedContentTypes)) {
+        drain(res.stream);
+        throw new SafeFetchError('content_type', `disallowed content-type "${contentType}"`);
+      }
+
+      const bytes = await readCappedBody(
+        res.stream,
+        headerValue(res.headers, 'content-length'),
+        opts.maxBytes,
+        controller.signal
+      );
+      return { finalUrl: parsed.toString(), contentType, bytes };
+    } finally {
+      clearTimeout(timer);
+    }
   }
 }

--- a/src/server/utils/ssrf-hostname.ts
+++ b/src/server/utils/ssrf-hostname.ts
@@ -1,0 +1,204 @@
+/**
+ * SSRF lexical hostname/IP guards — the PURE, dependency-free half of the SSRF
+ * defense. NO `node:dns`, NO `fetch`, NO env: safe to pull into a client bundle
+ * (e.g. `block-manifest-validator.service` is imported by `ManifestEditForm.tsx`).
+ *
+ * `PRIVATE_HOSTNAME_PATTERNS` + `isPublicHttpsUrl` were EXTRACTED verbatim from
+ * `block-manifest-validator.service.ts` (which now imports them from here) so the
+ * manifest validator, the read-path anchors, and the fetch-time guard in
+ * `safe-fetch.ts` all share ONE source of truth and can't drift.
+ *
+ * ⚠️ These are PURELY LEXICAL — they do NOT DNS-resolve, so they do NOT catch
+ * DNS-rebinding (a public name that resolves to 127.0.0.1 at fetch time). Any
+ * server-side FETCH of a user-supplied URL MUST additionally resolve the host and
+ * run every resolved address through {@link isPrivateIp} at fetch time — that is
+ * exactly what `safe-fetch.ts` does. `isPrivateIp` lives here (pure) so both the
+ * fetch guard and its unit tests can import it without the `node:dns` graph.
+ */
+
+// SSRF gate for a user-supplied URL host. The migrate-once-fix-forward move is to
+// reject hostnames that resolve to private/loopback ranges. We can't DNS-resolve
+// at LEXICAL validation time, so we use a hostname denylist of shapes we know are
+// non-public (localhost / RFC1918 / link-local / metadata service endpoints).
+export const PRIVATE_HOSTNAME_PATTERNS = [
+  /^localhost$/i,
+  /^127\./,
+  /^10\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^0\./,
+  /^::1$/,
+  // Full IPv6 ULA range fc00::/7 — the spec is fc00::/7, not fc00::/8.
+  // Previously only fc00: matched; widen to fc00-fdff.
+  /^f[cd][0-9a-f]{2}:/i,
+  /^fe80:/i,
+  // IPv6 with a zone identifier (RFC 6874 `%`-encoded) — sometimes accepted
+  // by URL parsers and lets an attacker pin a literal zone like %eth0.
+  /%/,
+  // Reserved internal infrastructure names commonly used internally.
+  /\.internal$/i,
+  /\.local$/i,
+  /^metadata\.google\.internal$/i,
+  // Note: punycode/IDN homograph attacks (e.g. `xn--...` registered as a
+  // look-alike) and DNS-rebinding (public name flipped to 127.0.0.1 at
+  // fetch time) are NOT caught by lexical validation. A server-side fetch of
+  // this URL MUST re-validate at fetch time (DNS-resolve + isPrivateIp) and
+  // disable redirect-follow — see safe-fetch.ts.
+];
+
+export function isPublicHttpsUrl(raw: string): { ok: true } | { ok: false; reason: string } {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return { ok: false, reason: 'malformed URL' };
+  }
+  if (url.protocol !== 'https:') return { ok: false, reason: 'must be https' };
+  const hostname = url.hostname;
+
+  // Single-string IPv4 literals (audit B4): WHATWG URL accepts dot-less
+  // forms like `0x7f000001` and `2130706433` (the integer form of 127.0.0.1)
+  // and parses them to the corresponding IPv4 address. Reject these BEFORE
+  // the dotted-name check below, because they don't contain dots.
+  if (/^0x[0-9a-f]+$/i.test(hostname)) {
+    return { ok: false, reason: 'hex IPv4 literal not permitted' };
+  }
+  if (/^[0-9]+$/.test(hostname)) {
+    // Pure-integer form. Includes `2130706433` (= 127.0.0.1) and similar.
+    return { ok: false, reason: 'integer IPv4 literal not permitted' };
+  }
+
+  // IPv4-mapped IPv6 ([::ffff:127.0.0.1] and similar) — WHATWG URL surfaces
+  // these as `[::ffff:7f00:1]` style in `hostname` (lowercased, square
+  // brackets kept when URL.host includes them — URL.hostname strips them).
+  // Reject anything containing `::ffff:` (the IPv4-mapped prefix).
+  if (/::ffff:/i.test(hostname)) {
+    return { ok: false, reason: 'IPv4-mapped IPv6 not permitted' };
+  }
+
+  if (!hostname.includes('.') || hostname.endsWith('.')) {
+    return { ok: false, reason: 'hostname must be a public dotted name' };
+  }
+  for (const re of PRIVATE_HOSTNAME_PATTERNS) {
+    if (re.test(hostname)) return { ok: false, reason: 'private/internal hostname' };
+  }
+  // Pure-decimal-dotted IPv4 literals — keep the surface narrow even for
+  // public addresses; manifests should always load by DNS name.
+  if (/^[0-9.]+$/.test(hostname)) {
+    return { ok: false, reason: 'literal IPv4 addresses are not permitted' };
+  }
+  // Dotted hex/octal IPv4 literals (e.g. 0x7f.0x0.0x0.0x1, 0177.0.0.1).
+  if (/^0x[0-9a-f]+(\.0x[0-9a-f]+)+$/i.test(hostname)) {
+    return { ok: false, reason: 'hex IPv4 literals are not permitted' };
+  }
+  if (/^0[0-7]+(\.[0-7]+)+$/.test(hostname)) {
+    return { ok: false, reason: 'octal IPv4 literals are not permitted' };
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// isPrivateIp — the FETCH-TIME guard applied to every DNS-resolved address.
+// Pure (no I/O) so both safe-fetch.ts and its unit tests can import it.
+// Fail CLOSED: an unparseable address is treated as private (unsafe).
+// ---------------------------------------------------------------------------
+
+/** True if a dotted-quad IPv4 string is in a private / loopback / reserved range. */
+function isPrivateIpv4(addr: string): boolean {
+  const parts = addr.split('.');
+  if (parts.length !== 4) return true; // not a dotted-quad → fail closed
+  const octets = parts.map((p) => Number(p));
+  if (octets.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return true;
+  const [a, b] = octets;
+  if (a === 0) return true; // 0.0.0.0/8 "this host"
+  if (a === 10) return true; // 10.0.0.0/8 private
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link-local (incl. 169.254.169.254 metadata)
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  if (a === 192 && b === 0 && octets[2] === 0) return true; // 192.0.0.0/24 IETF protocol
+  if (a === 192 && b === 0 && octets[2] === 2) return true; // 192.0.2.0/24 TEST-NET-1
+  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmarking
+  if (a >= 224) return true; // 224/4 multicast + 240/4 reserved + 255.255.255.255 broadcast
+  return false;
+}
+
+/**
+ * Expand an IPv6 textual address into its 8 hextet numbers, or null if it can't
+ * be parsed. Handles `::` compression and an IPv4-mapped/embedded dotted tail
+ * (`::ffff:127.0.0.1`, `::127.0.0.1`).
+ */
+function expandIpv6(input: string): number[] | null {
+  let a = input;
+
+  // Fold a trailing dotted-quad (IPv4-mapped / -embedded) into two hextets.
+  const v4 = a.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (v4 && v4.index !== undefined) {
+    const octs = v4[1].split('.').map(Number);
+    if (octs.length !== 4 || octs.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+      return null;
+    }
+    const hi = ((octs[0] << 8) | octs[1]).toString(16);
+    const lo = ((octs[2] << 8) | octs[3]).toString(16);
+    a = a.slice(0, v4.index) + hi + ':' + lo;
+  }
+
+  const halves = a.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] === '' ? [] : halves[0].split(':');
+  let groups: string[];
+  if (halves.length === 2) {
+    const tail = halves[1] === '' ? [] : halves[1].split(':');
+    const missing = 8 - head.length - tail.length;
+    if (missing < 0) return null;
+    groups = [...head, ...Array<string>(missing).fill('0'), ...tail];
+  } else {
+    groups = head;
+  }
+  if (groups.length !== 8) return null;
+  const nums = groups.map((g) => (g === '' ? NaN : parseInt(g, 16)));
+  if (nums.some((n) => Number.isNaN(n) || n < 0 || n > 0xffff)) return null;
+  return nums;
+}
+
+/** True if an IPv6 string is loopback / ULA / link-local / multicast / mapped-private. */
+function isPrivateIpv6(addr: string): boolean {
+  if (addr.includes('%')) return true; // zone id (link-local) → reject
+  const g = expandIpv6(addr.toLowerCase());
+  if (!g) return true; // unparseable → fail closed
+  // ::1 loopback / :: unspecified
+  if (g.slice(0, 7).every((h) => h === 0) && (g[7] === 0 || g[7] === 1)) return true;
+  const firstByte = g[0] >> 8;
+  if ((firstByte & 0xfe) === 0xfc) return true; // fc00::/7 unique-local
+  if (g[0] >= 0xfe80 && g[0] <= 0xfebf) return true; // fe80::/10 link-local
+  if (firstByte === 0xff) return true; // ff00::/8 multicast
+  // ::ffff:a.b.c.d IPv4-mapped → check the embedded IPv4.
+  if (
+    g[0] === 0 &&
+    g[1] === 0 &&
+    g[2] === 0 &&
+    g[3] === 0 &&
+    g[4] === 0 &&
+    g[5] === 0xffff
+  ) {
+    return isPrivateIpv4(`${g[6] >> 8}.${g[6] & 0xff}.${g[7] >> 8}.${g[7] & 0xff}`);
+  }
+  // ::a.b.c.d IPv4-compatible (deprecated) → check the embedded IPv4.
+  if (g.slice(0, 6).every((h) => h === 0) && (g[6] !== 0 || g[7] !== 0)) {
+    return isPrivateIpv4(`${g[6] >> 8}.${g[6] & 0xff}.${g[7] >> 8}.${g[7] & 0xff}`);
+  }
+  return false;
+}
+
+/**
+ * True if `addr` (a DNS-resolved IPv4 or IPv6 literal) is in a
+ * private / loopback / link-local / unique-local / metadata / reserved range and
+ * must NOT be fetched. Fail CLOSED — an address we can't parse is treated as
+ * private. This is the fetch-time complement to the lexical hostname guard that
+ * closes the DNS-rebinding hole.
+ */
+export function isPrivateIp(addr: string): boolean {
+  return addr.includes(':') ? isPrivateIpv6(addr) : isPrivateIpv4(addr);
+}

--- a/src/server/utils/ssrf-hostname.ts
+++ b/src/server/utils/ssrf-hostname.ts
@@ -189,6 +189,24 @@ function isPrivateIpv6(addr: string): boolean {
   if (g.slice(0, 6).every((h) => h === 0) && (g[6] !== 0 || g[7] !== 0)) {
     return isPrivateIpv4(`${g[6] >> 8}.${g[6] & 0xff}.${g[7] >> 8}.${g[7] & 0xff}`);
   }
+  // NAT64 well-known prefix 64:ff9b::/96 (RFC 6052) — the low 32 bits embed an
+  // IPv4 dest a NAT64 translator will reach. `64:ff9b::a9fe:a9fe` embeds
+  // 169.254.169.254, so the embedded v4 MUST be run through the v4 guard.
+  if (
+    g[0] === 0x0064 &&
+    g[1] === 0xff9b &&
+    g[2] === 0 &&
+    g[3] === 0 &&
+    g[4] === 0 &&
+    g[5] === 0
+  ) {
+    return isPrivateIpv4(`${g[6] >> 8}.${g[6] & 0xff}.${g[7] >> 8}.${g[7] & 0xff}`);
+  }
+  // 6to4 2002::/16 (RFC 3056) — the next 32 bits after the 2002 prefix embed the
+  // IPv4 of the 6to4 relay/host; reject if that embedded v4 is private/reserved.
+  if (g[0] === 0x2002) {
+    return isPrivateIpv4(`${g[1] >> 8}.${g[1] & 0xff}.${g[2] >> 8}.${g[2] & 0xff}`);
+  }
   return false;
 }
 

--- a/src/shared/constants/__tests__/token-scope.constants.test.ts
+++ b/src/shared/constants/__tests__/token-scope.constants.test.ts
@@ -21,13 +21,18 @@ describe('TokenScope constants', () => {
     expect(Flags.hasFlag(TokenScope.Full, TokenScope.AppBlocksSubmit)).toBe(false);
   });
 
-  it('ALL_SCOPES includes every defined bit, including AppBlocksSubmit', () => {
+  it('ALL_SCOPES includes every defined bit, including the opt-in App Blocks scopes', () => {
     expect(Flags.hasFlag(ALL_SCOPES, TokenScope.AppBlocksSubmit)).toBe(true);
+    expect(Flags.hasFlag(ALL_SCOPES, TokenScope.AppBlocksDevTunnel)).toBe(true);
     expect(Flags.hasFlag(ALL_SCOPES, TokenScope.UserRead)).toBe(true);
     expect(Flags.hasFlag(ALL_SCOPES, TokenScope.VaultWrite)).toBe(true);
-    // ALL_SCOPES = Full | AppBlocksSubmit (the only opt-in bit today).
-    expect(ALL_SCOPES).toBe(TokenScope.Full | TokenScope.AppBlocksSubmit);
-    expect(ALL_SCOPES).toBe(67108863); // (1 << 26) - 1
+    // ALL_SCOPES = Full | the opt-in bits NOT folded into Full. AppBlocksDevTunnel
+    // (bit 26, 67108864) was added beyond AppBlocksSubmit (bit 25), so ALL_SCOPES
+    // is now the OR of bits 0..26 = (1 << 27) - 1.
+    expect(ALL_SCOPES).toBe(
+      TokenScope.Full | TokenScope.AppBlocksSubmit | TokenScope.AppBlocksDevTunnel
+    );
+    expect(ALL_SCOPES).toBe(134217727); // (1 << 27) - 1
   });
 
   it('a UserRead|AppBlocksSubmit token (the civitai-cli scope) is within ALL_SCOPES but exceeds Full', () => {

--- a/src/utils/cf-images-utils.ts
+++ b/src/utils/cf-images-utils.ts
@@ -113,6 +113,48 @@ type UploadViaUrlResponse = {
 };
 
 /**
+ * Upload ALREADY-FETCHED image bytes to Cloudflare Images. Unlike `uploadViaBuffer`
+ * (which downloads the URL itself, UNGUARDED) this takes bytes the caller has
+ * already pulled through the SSRF-hardened `safeFetch`, so it never performs an
+ * outbound fetch to an attacker-influenced URL. Used by the App Blocks
+ * external-listing OG-image ingest path. Returns the CF image id.
+ */
+export async function uploadBufferToCF(
+  data: Uint8Array | Buffer,
+  filename: string,
+  metadata: Record<string, unknown> | null = null
+) {
+  const missing = missingEnvs();
+  if (missing.length > 0)
+    throw new Error(`CloudFlare Image Upload: Missing ENVs ${missing.join(', ')}`);
+
+  metadata ??= {};
+  const body = new FormData();
+  // Copy into a fresh Uint8Array so the Blob owns a plain ArrayBuffer (a Node
+  // Buffer's underlying pool ArrayBuffer can be larger than the view).
+  const bytes = new Uint8Array(data);
+  body.append('file', new Blob([bytes]), filename);
+  body.append('requireSignedURLs', 'false');
+  body.append('metadata', JSON.stringify(metadata));
+
+  const response = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/images/v1`,
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${env.CF_IMAGES_TOKEN}`,
+      },
+      body,
+    }
+  );
+
+  const result = (await response.json()) as UploadViaUrlResponse;
+  if (!result.success) throw new Error(result.errors.join('\n'));
+
+  return result.result;
+}
+
+/**
  * Download an image from a URL and upload it to Cloudflare Images as binary data.
  * Useful as a fallback when `uploadViaUrl` fails because CF can't reach the source URL.
  */


### PR DESCRIPTION
## What this does

When an App Blocks author enters an external-listing URL in the submit form, a **server-side, SSRF-hardened** fetch pulls the target page's metadata and returns **suggestions** the author can accept or override:

| Source | Suggests |
|---|---|
| `og:title` / `<title>` | listing **name** |
| `og:description` / meta description / `twitter:description` | **tagline** |
| `og:image` / `twitter:image` | **cover** image |
| `apple-touch-icon` / `rel=icon` | **icon** image |

Graceful throughout: nothing found → empty fields → the UI falls back to manual entry/upload. Suggestions are **not auto-persisted**.

When the author **accepts** an image suggestion, the server ingests the remote image through the **standard scan pipeline** (`createImage` default ingestion → `ingestImage` scan → scan-gate) exactly like an author-uploaded asset — the client then attaches it via the existing `setIcon`/`setCover` procs and polls until `Scanned` (reusing `assetPolling`). **No `skipIngestion`, no scan bypass.**

## SSRF controls (`src/server/utils/safe-fetch.ts`)

The one guarded outbound-fetch primitive for an attacker-influenced URL (page + og:image). Every hop enforces:

1. **Lexical** — https-only + `isPublicHttpsUrl` (rejects hex/int/octal IPv4, IPv4-mapped IPv6, dot-less/reserved hosts) **and rejects URL userinfo** (`user:pass@host`).
2. **DNS** — resolves the host to **all** A/AAAA addresses and rejects if **any** is private/loopback/link-local/unique-local/metadata (`isPrivateIp`, new). Closes the DNS-rebinding hole the lexical guard can't see.
3. **Redirects** — `redirect: 'manual'`; follows ≤2 hops and **re-validates (lexical + DNS) each hop's host**.
4. **Timeout** — hard `AbortSignal.timeout` per request.
5. **Size** — hard `maxBytes` cap via `Content-Length` (pre-buffer) **and** mid-stream abort.
6. **Content-type** — per-call allowlist (`text/html` page fetch ~1.5MB/5s; `image/*` image fetch 6MB/2.5s).

The lexical guards (`PRIVATE_HOSTNAME_PATTERNS` + `isPublicHttpsUrl`) were **extracted verbatim** into a shared, dependency-free module (`ssrf-hostname.ts`) that both `block-manifest-validator` (kept **client-bundle-safe** — it's imported by `ManifestEditForm.tsx`, so no `node:dns`) and `safe-fetch` import — one source of truth, behavior unchanged.

## New tRPC procs (author-gated `appDeveloperProcedure`, rate-limited 30/hr)

- `fetchListingMetaFromUrl({ url })` → `{ name?, tagline?, coverImageUrl?, iconImageUrl? }`. Never throws on "nothing found"; SSRF/timeout/size failures → friendly `BAD_REQUEST` (no internal leak).
- `ingestAssetFromUrl({ url, kind })` → `safeFetch` image → `sharp` decode (authoritative dims/format) → `uploadBufferToCF` (new bytes-based CF helper — the existing `uploadViaBuffer` does its own **unguarded** fetch) → `createImage` (default ingestion) → `{ imageId }`.

## Fold-ins

1. **`validateExternalUrl` userinfo hardening** — rejects any URL with userinfo (`https://example.com@evil.com` displays `example.com` but resolves `evil.com`). The client `normalizeLinkUrl` mirror inherits it via delegation; doc-comment corrected (the returned URL is parsed, not "sanitized/canonical").
2. **token-scope test** — `ALL_SCOPES` is now `(1<<27)-1 = 134217727`: a new `AppBlocksDevTunnel` bit (`1<<26`) was added in `@civitai/auth` beyond `AppBlocksSubmit`. Test updated to reality (auth package unchanged).
3. **ExternalSubmitForm browser test** — assert the exact validator string `'Use https:// (or omit the scheme)'` instead of `/https/i` (matched 3 elements → strict-mode violation); restores the fix lost in the #2974 squash.

## Tests

- `safe-fetch` — private/loopback/link-local/metadata rejected (lexical), DNS-resolves-to-private rejected (mocked dns), userinfo rejected, non-https rejected, redirect-to-private rejected + re-validated, redirect cap, oversize (header + mid-stream), content-type mismatch, timeout.
- `ssrf-hostname` — `isPrivateIp` (v4/v6, CGNAT, ULA, mapped, zone-id, fail-closed) + `isPublicHttpsUrl`.
- `og-metadata` — og:image/title/description/favicon/apple-touch extraction, relative-URL resolution, twitter fallback, data-URI drop, missing-tags → `{}`.
- `validateExternalUrl` + `normalizeLinkUrl` userinfo rejection.
- `listing-meta` service — fetch (parse/reject-non-https/friendly-error/empty) + ingest (**scan invariant: `createImage` called without `skipIngestion`**, unsupported-format reject, undecodable reject).
- Browser test — tRPC-mocked form prefill + empty-suggestions state.

## Not verified locally

No `node_modules` in the worktree (NixOS) — `tsc`/`vitest` were **not** run here. Types were written carefully (no `any`); the PR preview pipeline is the reliable typecheck/test gate. The end-to-end accept→ingest→scan→attach flow needs the preview/prod environment to exercise (the scanner is unreachable on PR previews, so an accepted image will poll → `timeout` there, as the existing asset flow already documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)