### PR TITLE
fix(orchestrator): map transient submit failures to 503, preserve error cause, AIR-not-found→400

### DIFF
--- a/src/server/services/orchestrator/__tests__/orchestration-new.air-map.test.ts
+++ b/src/server/services/orchestrator/__tests__/orchestration-new.air-map.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * StrictAirMap.getOrThrow fault classification.
+ *
+ * A missing AIR means the submitted generation form references a resource that
+ * did NOT enrich (deleted/unavailable resource, or a form↔enrichment mismatch) —
+ * a CLIENT/DATA fault. It must throw a BAD_REQUEST TRPCError (so
+ * `classifyErrorFault` treats it as a client fault → HTTP 400 + info-level log),
+ * NOT a plain `Error` that tRPC wraps into a generic INTERNAL_SERVER_ERROR (500).
+ * This was ~10% of the orchestrator.whatIfFromGraph / generateFromGraph 500s.
+ *
+ * The mock preamble mirrors the sibling
+ * `orchestration-new.getGenerationStatus.sysredis-soft.test.ts`: it keeps the heavy
+ * DB / redis / generation.service module graph inert so the module imports cleanly
+ * (StrictAirMap only depends on the real `throwBadRequestError`).
+ */
+
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() }, get: vi.fn(), set: vi.fn() },
+    sysRedis: { hGet: vi.fn() },
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+    REDIS_SUB_KEYS: keyProxy,
+    withSysReadDeadline: vi.fn((p: Promise<unknown>) => p),
+  };
+});
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {} }));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  getDbWithoutLag: vi.fn(),
+  getDbWithoutLagBatch: vi.fn(),
+  preventReplicationLag: vi.fn(),
+}));
+vi.mock('~/server/db/datapacketDb', () => ({ datapacketDbRead: {}, datapacketDbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/search-index', () => ({}));
+vi.mock('@civitai/db', () => ({ createLagTracker: vi.fn(() => ({})), loadDbEnv: vi.fn(() => ({})) }));
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getGenerationEcosystemConfig: vi.fn(async () => ({
+    experimentalEcosystems: [],
+    hasTestingAccess: false,
+  })),
+  getGateRules: vi.fn(async () => []),
+  getSelfHostedDisabledEcosystems: vi.fn(() => [] as string[]),
+  getResourceData: vi.fn(async () => []),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  getAllImages: vi.fn(),
+  enqueueImageIngestion: vi.fn(),
+  imagesForModelVersionsCache: {},
+}));
+
+import { StrictAirMap } from '~/server/services/orchestrator/orchestration-new.service';
+
+describe('StrictAirMap.getOrThrow', () => {
+  it('returns the AIR for a present resource id', () => {
+    const map = new StrictAirMap([[123, 'urn:air:sdxl:model:civitai:123@456']]);
+    expect(map.getOrThrow(123)).toBe('urn:air:sdxl:model:civitai:123@456');
+  });
+
+  it('throws a BAD_REQUEST TRPCError (client fault) for a missing resource id — NOT a plain Error / 500', () => {
+    const map = new StrictAirMap();
+
+    const err = (() => {
+      try {
+        map.getOrThrow(3005242);
+        return undefined;
+      } catch (e) {
+        return e;
+      }
+    })();
+
+    expect(err).toBeInstanceOf(TRPCError);
+    expect(err).not.toBeInstanceOf(TypeError);
+    expect((err as TRPCError).code).toBe('BAD_REQUEST');
+    // Message preserved verbatim so moderators still see which resource + the cause.
+    expect((err as TRPCError).message).toBe(
+      'AIR not found for resource ID 3005242. ' +
+        'This indicates a mismatch between form data and enriched resources.'
+    );
+  });
+});

--- a/src/server/services/orchestrator/__tests__/submitWorkflow.error-mapping.test.ts
+++ b/src/server/services/orchestrator/__tests__/submitWorkflow.error-mapping.test.ts
@@ -179,6 +179,34 @@ describe('submitWorkflow — genuine app/validation faults are NOT converted to 
     expect((err as TRPCError).cause).toMatchObject({ status: 200, detail: 'no data' });
   });
 
+  it('a 2xx/empty-body anomaly with `error: undefined` → clean INTERNAL_SERVER_ERROR (500), NOT a TypeError', async () => {
+    // Reachable shape: `!data` + truthy `response` + status < 400 + NO `error`
+    // (e.g. a 204/empty body). `throwInternalServerError` reads
+    // `(error as any).message`, so an undefined `error` would itself throw a
+    // spurious `TypeError: Cannot read properties of undefined (reading 'message')`
+    // — ironic for a causeless-500 fix. The site synthesizes a defined Error instead.
+    mockSubmitWorkflow.mockResolvedValue({
+      data: undefined,
+      error: undefined,
+      response: { status: 204 },
+    });
+
+    const err = await submitWorkflow({
+      token: 'tok',
+      body: {} as any,
+      query: {} as any,
+    }).catch((e) => e);
+
+    expect(err).toBeInstanceOf(TRPCError);
+    expect(err).not.toBeInstanceOf(TypeError);
+    expect((err as TRPCError).code).toBe('INTERNAL_SERVER_ERROR');
+    // Clean, defined message — not the spurious undefined-read TypeError.
+    expect((err as TRPCError).message).toBeTruthy();
+    expect((err as TRPCError).message).not.toMatch(/Cannot read properties of undefined/i);
+    // Not retryable (status < 500) → single attempt, no backoff.
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+  });
+
   it('returns data untouched on the success path', async () => {
     mockSubmitWorkflow.mockResolvedValue({ data: { id: 'wf-1' }, response: { status: 200 } });
 

--- a/src/server/services/orchestrator/__tests__/submitWorkflow.error-mapping.test.ts
+++ b/src/server/services/orchestrator/__tests__/submitWorkflow.error-mapping.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * Submit-path error mapping for orchestrator.whatIfFromGraph / generateFromGraph.
+ *
+ * These drive the REAL `submitWorkflow` (workflows.ts) through its
+ * `if (!result.data)` → `switch (response.status)` branches, mocking ONLY the
+ * generated `@civitai/client` + the client factory + env so the real
+ * `~/server/utils/errorHandling` TRPCError mapping runs end-to-end.
+ *
+ * The bug this covers (bursty causeless generic 500s on whatIf/generate):
+ *  - Item C: the submit switch had NO 503 branch — an upstream HTTP 5xx (or an
+ *    HTML gateway/LB error page, a 5xx body starting with `<!DOCTYPE`) surfaced as
+ *    a generic INTERNAL_SERVER_ERROR (500), unlike the READ paths (getWorkflow /
+ *    queryWorkflows) which map upstream 5xx → retry-able 503 via
+ *    `isUpstreamServerOrNetworkError`. We now mirror that mapping on submit.
+ *  - Item B: those 5xx sites threw `throwInternalServerError(<string>)`, dropping
+ *    the structured client error — only a STRING survived as `cause`, which the
+ *    un-masking logger (`buildServerFaultErrorLog`) renders EMPTY, hiding the
+ *    trigger. The original client error is now preserved as `cause`.
+ */
+
+const { mockSubmitWorkflow } = vi.hoisted(() => ({
+  mockSubmitWorkflow: vi.fn(),
+}));
+
+vi.mock('@civitai/client', () => ({
+  submitWorkflow: mockSubmitWorkflow,
+  // unused-by-these-tests named exports referenced at module load
+  addWorkflowTag: vi.fn(),
+  deleteWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  patchWorkflow: vi.fn(),
+  queryWorkflows: vi.fn(),
+  removeWorkflowTag: vi.fn(),
+  updateWorkflow: vi.fn(),
+  // handleError derives the fallback user-facing message from the client error.
+  handleError: vi.fn((e: unknown) => (typeof e === 'string' ? e : 'err')),
+}));
+
+vi.mock('~/server/services/orchestrator/client', () => ({
+  createOrchestratorClient: vi.fn(() => ({})),
+  internalOrchestratorClient: {},
+}));
+
+vi.mock('~/env/other', () => ({ isDev: false, isProd: true }));
+
+import { submitWorkflow } from '~/server/services/orchestrator/workflows';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Upstream 5xx responses are `retryable` in submitWorkflowWithRetry, so the wrapper
+// backs off (real setTimeout) between its 3 attempts. Skip that wait deterministically
+// with fake timers so the suite stays fast.
+const runWithFakeTimers = async <T>(fn: () => Promise<T>): Promise<T> => {
+  vi.useFakeTimers();
+  const p = fn();
+  await vi.runAllTimersAsync();
+  return p;
+};
+
+// A resolve shape (NOT a reject): the @civitai/client with no `throwOnError` RESOLVES
+// `{ data: undefined, error, response }` on an upstream error response.
+const errorResolve = (status: number, error: Record<string, unknown>) => ({
+  data: undefined,
+  error,
+  response: { status },
+});
+
+describe('submitWorkflow — upstream 5xx → retry-able 503 (Item C) + cause preserved (Item B)', () => {
+  it('maps an orchestrator HTTP 500 to SERVICE_UNAVAILABLE (503), NOT a generic 500', async () => {
+    const upstreamError = { status: 500, detail: 'boom' };
+    mockSubmitWorkflow.mockResolvedValue(errorResolve(500, upstreamError));
+
+    const err = await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as any, query: {} as any }).catch((e) => e)
+    );
+
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+    expect((err as TRPCError).message).toMatch(/temporarily unavailable/i);
+    // upstream 5xx is retryable → all 3 attempts ran before the final 503.
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(3);
+  });
+
+  it('preserves the ORIGINAL client error on `.cause` so the un-masking log is non-empty (Item B)', async () => {
+    const upstreamError = { status: 500, detail: 'orchestrator exploded' };
+    mockSubmitWorkflow.mockResolvedValue(errorResolve(500, upstreamError));
+
+    const err = await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as any, query: {} as any }).catch((e) => e)
+    );
+
+    // Before the fix `.cause` was a bare string ('err') → empty in
+    // buildServerFaultErrorLog. Now it carries the structured client error.
+    const cause = (err as TRPCError).cause as unknown;
+    expect(cause).toBeDefined();
+    expect(cause).toMatchObject({ status: 500, detail: 'orchestrator exploded' });
+  });
+
+  it('maps an upstream 503/504-class status (via `default`) to 503', async () => {
+    mockSubmitWorkflow.mockResolvedValue(errorResolve(503, { status: 503, detail: '' }));
+
+    const err = await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as any, query: { whatif: true } as any }).catch(
+        (e) => e
+      )
+    );
+
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+  });
+
+  it('maps an HTML gateway error page (5xx body starting with <!DOCTYPE) to 503', async () => {
+    // A gateway/LB returns an HTML error page; the client surfaces it as the 5xx
+    // response `messages`. status 502 → transient upstream → 503 (was 500 before).
+    const htmlError = {
+      status: 502,
+      errors: { messages: ['<!DOCTYPE html><html><body>502 Bad Gateway</body></html>'] },
+    };
+    mockSubmitWorkflow.mockResolvedValue(errorResolve(502, htmlError));
+
+    const err = await runWithFakeTimers(() =>
+      submitWorkflow({ token: 'tok', body: {} as any, query: {} as any }).catch((e) => e)
+    );
+
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+    expect((err as TRPCError).cause).toMatchObject({ status: 502 });
+  });
+});
+
+describe('submitWorkflow — genuine app/validation faults are NOT converted to 503', () => {
+  it('keeps an orchestrator 400 as BAD_REQUEST (client fault), not 503', async () => {
+    mockSubmitWorkflow.mockResolvedValue(errorResolve(400, { status: 400, detail: 'bad input' }));
+
+    // 4xx is not retryable → returns on the first attempt (no backoff, no fake timers).
+    const err = await submitWorkflow({
+      token: 'tok',
+      body: {} as any,
+      query: {} as any,
+    }).catch((e) => e);
+
+    expect((err as TRPCError).code).toBe('BAD_REQUEST');
+    expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps an unhandled 4xx (422) as BAD_REQUEST, not 503', async () => {
+    mockSubmitWorkflow.mockResolvedValue(errorResolve(422, { status: 422, detail: 'unprocessable' }));
+
+    const err = await submitWorkflow({
+      token: 'tok',
+      body: {} as any,
+      query: {} as any,
+    }).catch((e) => e);
+
+    expect((err as TRPCError).code).toBe('BAD_REQUEST');
+  });
+
+  it('a non-4xx/5xx anomaly with no data stays INTERNAL_SERVER_ERROR (500), cause preserved', async () => {
+    // A malformed "success" (2xx status but no `data`) is NOT a recognized transient
+    // upstream failure, so it must stay a visible 500 — but carry the original error
+    // as `cause` (Item B), never a bare string.
+    const anomaly = { status: 200, detail: 'no data' };
+    mockSubmitWorkflow.mockResolvedValue(errorResolve(200, anomaly));
+
+    const err = await submitWorkflow({
+      token: 'tok',
+      body: {} as any,
+      query: {} as any,
+    }).catch((e) => e);
+
+    expect((err as TRPCError).code).toBe('INTERNAL_SERVER_ERROR');
+    expect((err as TRPCError).cause).toMatchObject({ status: 200, detail: 'no data' });
+  });
+
+  it('returns data untouched on the success path', async () => {
+    mockSubmitWorkflow.mockResolvedValue({ data: { id: 'wf-1' }, response: { status: 200 } });
+
+    const data = await submitWorkflow({ token: 'tok', body: {} as any, query: {} as any });
+    expect(data).toEqual({ id: 'wf-1' });
+  });
+});

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -175,7 +175,7 @@ type EcosystemGraphOutput = Extract<GenerationGraphOutput, { ecosystem: string }
  * A Map that throws an error when getting a value that doesn't exist.
  * Used for AIR lookups where a missing value indicates a data problem.
  */
-class StrictAirMap extends Map<number, string> {
+export class StrictAirMap extends Map<number, string> {
   /**
    * Gets the AIR string for a resource ID.
    * @throws Error if the resource ID is not found in the map.
@@ -183,7 +183,15 @@ class StrictAirMap extends Map<number, string> {
   getOrThrow(resourceId: number): string {
     const air = this.get(resourceId);
     if (!air) {
-      throw new Error(
+      // A missing AIR means the submitted form data references a resource that did
+      // NOT enrich (a deleted/unavailable resource, or a form↔enrichment mismatch)
+      // — a CLIENT/DATA fault, not a server failure. Throw a BAD_REQUEST TRPCError
+      // (via throwBadRequestError) so `classifyErrorFault` treats it as a client
+      // fault → logged at info, surfaced as HTTP 400 — instead of a plain Error that
+      // tRPC wraps into a generic INTERNAL_SERVER_ERROR (500). This was ~10% of the
+      // orchestrator.whatIfFromGraph / generateFromGraph 500s (the loudest single
+      // instance being the dead resource 3005242). Message preserved verbatim.
+      throw throwBadRequestError(
         `AIR not found for resource ID ${resourceId}. ` +
           `This indicates a mismatch between form data and enriched resources.`
       );

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -329,7 +329,13 @@ export async function submitWorkflow({
   // `result.data` to defined for the `return` below.
   if (!result.data) {
     const { error, response } = result;
-    const { messages } = (typeof error !== 'string' ? error.errors ?? {} : {}) as {
+    // Null-guard `error`: on a status-less resolve the client can hand back
+    // `{ data: undefined, error: undefined, response: undefined }`, and a bare
+    // `error.errors` would then throw a TypeError ("Cannot read properties of
+    // undefined") BEFORE the `!response` 503 guard below — surfacing as a raw 500
+    // (the exact metric this targets). The `&& error` lets that shape fall through
+    // to the 503 mapping instead of crashing.
+    const { messages } = (typeof error !== 'string' && error ? error.errors ?? {} : {}) as {
       messages?: string[];
     };
     let message = messages?.length ? messages.join(',\n') : handleError(error);
@@ -376,20 +382,36 @@ export async function submitWorkflow({
         // BAD_REQUEST), so the client can back off AND the tRPC onError Axiom-skip
         // for TOO_MANY_REQUESTS keeps a 429 storm off the event loop.
         throw throwRateLimitError(message);
-      case 500:
-        throw throwInternalServerError(message);
       default:
-        if (message?.startsWith('<!DOCTYPE'))
-          throw throwInternalServerError('Generation services down');
         // An unhandled 4xx from the orchestrator is a client/validation fault
         // (e.g. "<resource> is not enabled for generation. Please contact …"),
         // not a server error. Surface it as a 4xx instead of re-throwing a raw
         // error that tRPC maps to INTERNAL_SERVER_ERROR (500) — that misclassified
-        // generate/whatIf validation rejections as the app's own 500s. Genuine
-        // upstream 5xx / status-less failures still fall through to a server error.
+        // generate/whatIf validation rejections as the app's own 500s.
         if (typeof response.status === 'number' && response.status >= 400 && response.status < 500)
           throw throwBadRequestError(message);
-        throw error;
+        // A genuine upstream 5xx — an orchestrator HTTP 500, or a gateway/LB HTML
+        // error page (which arrives as a 5xx body starting with `<!DOCTYPE`) — is a
+        // TRANSIENT dependency outage, NOT this app's own fault. Mirror the read
+        // paths (queryWorkflows/getWorkflow, above): map it to a retry-able 503
+        // SERVICE_UNAVAILABLE, guarded on the SAME `isUpstreamServerOrNetworkError`
+        // predicate, with the ORIGINAL client error preserved as `cause`.
+        //
+        // Before this the submit switch had NO 503 branch: the old `case 500` and
+        // the 5xx `default` both threw `throwInternalServerError(<string>)`, which
+        // (a) counted a transient orchestrator blip against our 500 SLO and (b)
+        // dropped the structured client error — only a derived STRING survived as
+        // `cause`, which `buildServerFaultErrorLog` renders EMPTY. That is the
+        // causeless-generic-500 signature seen on orchestrator.whatIfFromGraph /
+        // generateFromGraph; this is its submit-path fix and the read-path analogue.
+        if (isUpstreamServerOrNetworkError({ clientError: { status: response.status }, thrown: error }))
+          throw throwServiceUnavailableError(ORCHESTRATOR_UNAVAILABLE_MESSAGE, error);
+        // Anything else (a non-4xx/5xx anomaly with no `data` — e.g. a malformed
+        // "success", a genuine bug) stays a 500 so real problems remain visible, but
+        // carry the ORIGINAL client error as `cause` (not a bare string) so
+        // `buildServerFaultErrorLog` can un-mask the real message/stack. We do NOT
+        // blanket-convert to 503 — only recognized transient upstream failures above.
+        throw throwInternalServerError(error);
     }
   }
 

--- a/src/server/services/orchestrator/workflows.ts
+++ b/src/server/services/orchestrator/workflows.ts
@@ -411,7 +411,15 @@ export async function submitWorkflow({
         // carry the ORIGINAL client error as `cause` (not a bare string) so
         // `buildServerFaultErrorLog` can un-mask the real message/stack. We do NOT
         // blanket-convert to 503 — only recognized transient upstream failures above.
-        throw throwInternalServerError(error);
+        // When `error` is nullish here (a 2xx/empty-body anomaly: `!data` +
+        // truthy `response` + `status < 400` + no `error`), synthesize a defined
+        // Error so `throwInternalServerError`'s `(error as any).message` read
+        // (errorHandling.ts) can't itself throw a spurious TypeError — the very
+        // causeless-500 shape this PR exists to kill. A non-nullish `error` flows
+        // through unchanged, cause preserved (Item B).
+        throw throwInternalServerError(
+          error ?? new Error('orchestrator returned no data', { cause: error })
+        );
     }
   }
 


### PR DESCRIPTION
## Investigation evidence

`orchestrator.whatIfFromGraph` (~495/3h) and `orchestrator.generateFromGraph` (~222/3h) return **bursty HTTP 500 `INTERNAL_SERVER_ERROR`** with the generic "An unexpected error ocurred, please try again later".

- The orchestrator itself is **healthy on submit**: `orchestration-api` POST returns 200/201/202; POST 500 ≈ 0.033/s, POST 502 = 0. These are **transient upstream blips** surfacing wrong on the civitai side, not the orchestrator rejecting.
- Failures are **bursty** (100–210 in a 10-min window, then near-zero) and **predate today's deploy**.
- The un-masking logger (`buildServerFaultErrorLog`, which walks `.cause`) showed the cause chain **terminating at a bare generic TRPCError with NO `.cause`** for ~90% of them — the real trigger was never captured.
- The remaining ~10% are `AIR not found for resource ID <n>` (125/130 = the single dead resource `3005242`), a user/data fault thrown as a plain `Error` → wrapped as 500.

Root cause is the `@civitai/client` **resolve-not-reject** gotcha (`createOrchestratorClient` sets no `throwOnError`): the read paths already map `!data`/`!response` → retry-able **503** via `isUpstreamServerOrNetworkError`, but the whatIf/generate submit path had gaps.

## What each item does (all three shipped)

**A — AIR-not-found → 400, not 500.** `StrictAirMap.getOrThrow` (`orchestration-new.service.ts`) threw a plain `Error`. A missing AIR means the form references a resource that didn't enrich — a **client/data fault** — so it now throws `throwBadRequestError(...)` (a `BAD_REQUEST` TRPCError). `classifyErrorFault` then treats it as a client fault (HTTP 400, info-level log). Message preserved verbatim. (`BAD_REQUEST` is in `CLIENT_FAULT_TRPC_CODES`.)

**B — preserve the real `.cause` on the generic throw.** `submitWorkflow` (`workflows.ts`) previously threw `throwInternalServerError(<string>)` at its 5xx sites, so only a derived **string** survived as `.cause` — which `buildServerFaultErrorLog` renders **empty** (the causeless-500 signature). The switch now carries the **original structured client error** (`{ status, detail, … }`) as `cause`, so the trigger is diagnosable. Also null-guards `error.errors` so a status-less resolve (`{ error: undefined, response: undefined }`) reaches the 503 mapping instead of crashing into a raw 500 on `undefined.errors`.

**C — transient submit failure → 503.** `submitWorkflow`'s `switch(response.status)` had **no 503 branch**: an upstream 5xx (orchestrator HTTP 500, or a gateway/LB HTML error page arriving as a 5xx `<!DOCTYPE` body) surfaced as a generic **500**, unlike the READ paths (`getWorkflow`/`queryWorkflows`) which map upstream 5xx → retry-able **503** via `isUpstreamServerOrNetworkError`. This PR mirrors that mapping onto the submit path, **guarded on the SAME `isUpstreamServerOrNetworkError` predicate** — so genuine app/validation faults still 500, 4xx still map to 400, and only recognized transient upstream failures become 503 (with the original error as `cause`). A 503 is retry-able and is already skipped from the 500 SLO + Axiom ingest in the tRPC `onError`.

> Scope note on C: the literal `{ error, response: undefined }` resolve case was *already* mapped to 503 (the pre-existing `!response` guard). The concrete unmapped divergence this PR fixes is the **with-response upstream 5xx** (`case 500` + the 5xx `default`) — the submit switch was simply missing the read paths' `isUpstreamServerOrNetworkError → 503` branch. This is a direct mirror of a proven read-path mapping, not a speculative new one. The exact per-request attribution of the ~90% empty-cause 500s becomes fully visible once B lands (causes populated in prod), but the mapping itself stands on the read/submit divergence, not on that pending data.

## Test evidence

New: `__tests__/orchestration-new.air-map.test.ts` (Item A), `__tests__/submitWorkflow.error-mapping.test.ts` (Items B+C). Both mirror the existing `workflows.error-mapping.test.ts` / `submitWorkflow.timeout.test.ts` harnesses and mock the `@civitai/client` **resolve** shape (`{ error, response }`), not `mockRejectedValue`.

```
npx vitest run \
  src/server/services/orchestrator/__tests__/submitWorkflow.error-mapping.test.ts \
  src/server/services/orchestrator/__tests__/orchestration-new.air-map.test.ts \
  src/server/services/orchestrator/__tests__/submitWorkflow.timeout.test.ts \
  src/server/services/orchestrator/__tests__/workflows.error-mapping.test.ts \
  src/server/logging/whatif-error-logging.test.ts
# → 5 files, 54 tests, all passed
```

**Fail-before/pass-after** (verified by `git stash`-ing the two source files and re-running — tests are untracked so they stayed):
- With the source reverted: **7 behavioral tests failed** — `getOrThrow` BAD_REQUEST + present-id return; upstream 500/503/HTML-5xx → 503; `.cause` carries the original error; anomaly-stays-500-with-cause. The 4xx-stays-400 and happy-path tests correctly stayed green (unchanged behavior).
- With the source restored: **all 54 pass.**

Typecheck: `tsc --noEmit` — 0 errors project-wide, none referencing the changed files.

## Shipped vs deferred

Shipped: **A, B, C** (one PR). Nothing deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)