### PR TITLE
fix(apps): restore AppBlocks PageBlockHost browser-test imports (7 files silently not running)

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -14,6 +14,12 @@ import { renderWithProviders } from '../../../test/component-setup';
 // PageBlockHostWorkflow / PageBlockHostStorage.browser.test.tsx; here they're
 // inert stubs.
 vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider (pulled into PageBlockHost's real render graph) statically
+  // imports `setTrpcBatchingEnabled` from this module (added in #2946). Because
+  // `vi.mock` replaces the module wholesale, the factory MUST re-declare that named
+  // export or the ESM link fails ("does not provide an export named …") and the whole
+  // test file fails to import — silently, since this suite is report-only.
+  setTrpcBatchingEnabled: vi.fn(),
   trpc: {
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -39,6 +39,11 @@ import { renderWithProviders } from '../../../test/component-setup';
 // network-free (the checkpoint picker itself makes NO tRPC call — it reuses the
 // native modal which talks to Meili in the parent context).
 vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider (in PageBlockHost's real render graph) statically imports
+  // `setTrpcBatchingEnabled` from this module (#2946). vi.mock replaces the module
+  // wholesale, so the factory must re-declare it or the ESM link fails and the whole
+  // test file fails to import.
+  setTrpcBatchingEnabled: vi.fn(),
   trpc: {
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -40,6 +40,11 @@ import { renderWithProviders } from '../../../test/component-setup';
 // network-free (the resource picker itself makes NO tRPC call — it reuses the
 // native modal which talks to Meili in the parent context).
 vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider (in PageBlockHost's real render graph) statically imports
+  // `setTrpcBatchingEnabled` from this module (#2946). vi.mock replaces the module
+  // wholesale, so the factory must re-declare it or the ESM link fails and the whole
+  // test file fails to import.
+  setTrpcBatchingEnabled: vi.fn(),
   trpc: {
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -34,6 +34,11 @@ import { renderWithProviders } from '../../../test/component-setup';
  */
 
 vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider (in PageBlockHost's real render graph) statically imports
+  // `setTrpcBatchingEnabled` from this module (#2946). vi.mock replaces the module
+  // wholesale, so the factory must re-declare it or the ESM link fails and the whole
+  // test file fails to import.
+  setTrpcBatchingEnabled: vi.fn(),
   trpc: {
     // PageBlockHost wires the workflow + storage bridges at render; stub so it
     // mounts network-free. SET_USER_CHECKPOINT makes NO tRPC call on a page (it

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -26,6 +26,11 @@ import { renderWithProviders } from '../../../test/component-setup';
 // trpc is mocked so PageBlockHost's workflow + storage bridges mount network-free
 // (inert stubs here — exercised in their own suites).
 vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider (in PageBlockHost's real render graph) statically imports
+  // `setTrpcBatchingEnabled` from this module (#2946). vi.mock replaces the module
+  // wholesale, so the factory must re-declare it or the ESM link fails and the whole
+  // test file fails to import.
+  setTrpcBatchingEnabled: vi.fn(),
   trpc: {
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
@@ -43,6 +43,11 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider (in PageBlockHost's real render graph) statically imports
+  // `setTrpcBatchingEnabled` from this module (#2946). vi.mock replaces the module
+  // wholesale, so the factory must re-declare it or the ESM link fails and the whole
+  // test file fails to import.
+  setTrpcBatchingEnabled: vi.fn(),
   trpc: {
     // PageBlockHost also wires the workflow bridge at render (inert here —
     // exercised in PageBlockHostWorkflow.browser.test.tsx); stub so it mounts.

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -41,6 +41,11 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider (in PageBlockHost's real render graph) statically imports
+  // `setTrpcBatchingEnabled` from this module (#2946). vi.mock replaces the module
+  // wholesale, so the factory must re-declare it or the ESM link fails and the whole
+  // test file fails to import.
+  setTrpcBatchingEnabled: vi.fn(),
   trpc: {
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: mocks.submit }) },


### PR DESCRIPTION
## Problem

In the `preview / component-tests` (vitest browser-mode) suite, seven test files under `src/components/AppBlocks/` were failing identically with vitest's wrapper error:

```
Error: Failed to import test file .../PageBlockHost*.browser.test.tsx
```

Because the suite is report-only (non-blocking), it has been silently red on `main`: the report showed `7 failed | 33 passed` **files** but `303 passed` **tests** — i.e. these 7 files never imported, so their tests (74 of them) **never ran at all**. That's a chunk of App Blocks page-host coverage that wasn't executing.

The seven: `PageBlockHost`, `PageBlockHostCheckpointPicker`, `PageBlockHostResourcePicker`, `PageBlockHostSetUserCheckpoint`, `PageBlockHostSignIn`, `PageBlockHostStorage`, `PageBlockHostWorkflow`.

## Real error (behind the wrapper)

```
SyntaxError: The requested module '/src/utils/trpc.ts'
does not provide an export named 'setTrpcBatchingEnabled'
```

A static ESM link failure — thrown before any test runs.

## Root cause

- #2946 (`perf(trpc): flag-gated authed-only request batching`) added `setTrpcBatchingEnabled` to `src/utils/trpc.ts` and made `src/providers/FeatureFlagsProvider.tsx` statically `import { setTrpcBatchingEnabled, trpc } from '~/utils/trpc'`.
- `FeatureFlagsProvider` sits in `PageBlockHost`'s **real** render graph. All 7 suites mount the real `PageBlockHost` and `vi.mock('~/utils/trpc', () => ({ trpc: {…} }))` — a factory that replaces the module **wholesale** and only re-declares `trpc`.
- Once `FeatureFlagsProvider` began importing `setTrpcBatchingEnabled`, the mocked module no longer provided it → ESM link error → the whole file fails to import.

**Why these 7 and not the other 33:** the two sibling AppBlocks browser tests (`AppBlockChrome`, `IframeHost`) either don't mock `~/utils/trpc` or their (model-slot) graph doesn't reach `FeatureFlagsProvider`, so their mocks weren't missing anything. Only the `PageBlockHost*` graph pulls `FeatureFlagsProvider`, the sole importer of `setTrpcBatchingEnabled`.

## Fix

Add `setTrpcBatchingEnabled: vi.fn()` to each of the 7 `vi.mock('~/utils/trpc', …)` factories so the mocked module re-declares the named export the graph links against. Smallest correct fix — no test disabled, skipped, or deleted; the point is to make the coverage **run**.

## Verification

Reproduced and verified locally with vitest browser-mode (real Chromium via Playwright):

- **Before:** `PageBlockHost.browser.test.tsx` → `SyntaxError: … does not provide an export named 'setTrpcBatchingEnabled'`, `0 tests`.
- **After:** all 7 files import and run — **7 passed (7), 74 tests passed** (were 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)