### PR TITLE
feat(apps): edit external listing without withdraw (state-aware; approved edits staged as shadow-draft revisions)

### DIFF
--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -2557,7 +2557,13 @@ model AppListing {
   @@index([iconId], map: "app_listings_icon_idx")
   @@index([coverId], map: "app_listings_cover_idx")
   // Shadow-lookup (WHERE revisionOfId = parent) + the parent-delete cascade scan.
-  @@index([revisionOfId], map: "app_listings_revision_of_idx")
+  // NB: the migration creates this as a PARTIAL UNIQUE index (UNIQUE on
+  // revisionOfId WHERE revisionOfId IS NOT NULL) so a parent has at most ONE
+  // in-flight shadow at the DB level. Prisma can't express a partial-unique
+  // index, so this stays a plain @@index in the schema; the real one-shadow
+  // guard is the migration's partial-unique index + the app-level P2002 →
+  // idempotent-reuse handling in beginListingRevision.
+  @@index([revisionOfId], map: "app_listings_revision_of_id_key")
   @@map("app_listings")
 }
 

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -2517,6 +2517,19 @@ model AppListing {
   // Only a natively-created off-site listing (no backing AppBlock) leaves it NULL.
   appBlockId      String?      @unique @map("app_block_id")
   appBlock        AppBlock?    @relation(fields: [appBlockId], references: [id], onDelete: SetNull)
+  // Edit-without-withdraw (shadow-draft revision): a hidden DRAFT clone of an
+  // APPROVED parent listing points here at its parent. On mod re-approve the
+  // shadow's contents are copied onto the parent (which keeps its id/slug/
+  // app_block_id/metrics/reports) and the shadow is deleted; on reject/withdraw
+  // the shadow is deleted and the parent is untouched. NULL for a normal (top-
+  // level) listing. CASCADE so deleting a parent removes its in-flight shadow.
+  // A request is a REVISION iff its listing's revisionOfId != null (no extra
+  // column on the request — it is inferred). The read path filters
+  // revisionOfId != null out (shadows are draft, so already hidden — this is
+  // defense-in-depth).
+  revisionOfId    String?      @map("revision_of_id")
+  revisionOf      AppListing?  @relation("AppListingRevision", fields: [revisionOfId], references: [id], onDelete: Cascade)
+  revisions       AppListing[] @relation("AppListingRevision")
   // Curation rail (mirrors AppBlock.featured / featured_order).
   featured        Boolean      @default(false)
   featuredOrder   Int?         @map("featured_order")
@@ -2543,6 +2556,8 @@ model AppListing {
   // P1 populates icon/cover (Postgres does NOT auto-index a FK). Free now (empty).
   @@index([iconId], map: "app_listings_icon_idx")
   @@index([coverId], map: "app_listings_cover_idx")
+  // Shadow-lookup (WHERE revisionOfId = parent) + the parent-delete cascade scan.
+  @@index([revisionOfId], map: "app_listings_revision_of_idx")
   @@map("app_listings")
 }
 

--- a/prisma/migrations/20260707120000_w13_edit_listing_revision/migration.sql
+++ b/prisma/migrations/20260707120000_w13_edit_listing_revision/migration.sql
@@ -1,0 +1,56 @@
+-- ============================================================
+-- App Store Listings (W13) — edit-listing revision (shadow-draft) support
+-- ============================================================
+-- Adds a self-referential `revision_of_id` to app_listings so an author can EDIT
+-- an already-APPROVED (LIVE) listing without withdrawing it: a hidden DRAFT clone
+-- (the "shadow") of the live listing is created with revision_of_id = <parent id>,
+-- edited via the existing asset/field procs, and on mod re-approve its contents
+-- are copied onto the live parent (which keeps its id/slug/app_block_id/metrics/
+-- reports); the shadow is then deleted. On reject/withdraw the shadow is deleted
+-- and the live parent is untouched. See
+-- claudedocs/app-blocks-app-store-listings-plan-2026-07-01.md and the
+-- "edit external listing without withdraw" scope.
+--
+-- draft/pending listings are edited IN PLACE (no shadow); only an approved
+-- listing's MATERIAL edit (external_url / name / assets) routes through a shadow.
+--
+-- ON DELETE CASCADE: deleting a parent app_listing cascades its in-flight shadow
+-- (a shadow is meaningless without its parent). Screenshots of the shadow are in
+-- turn cascaded by the existing app_listing_screenshots FK.
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
+-- CNPG nvme0 DB does NOT auto-apply migrations (no prisma migrate deploy). This
+-- file is committed for HISTORY ONLY; a HUMAN applies the SQL below per
+-- environment (psql/retool). CI / deploy do NOT run it. Apply to BOTH, BEFORE the
+-- release that carries this code (a revision write hits the missing column
+-- otherwise):
+--   1. prod nvme0   (the live civitai DB)
+--   2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev, db civitai) — apply
+--      before the PR preview smoke runs, or the preview 500s on the missing column.
+--
+-- Additive + idempotent: IF NOT EXISTS on the column + index, and the FK is
+-- guarded by a DO block, so a manual re-run is a no-op. The column is NULLABLE
+-- (existing rows are all top-level listings, revision_of_id = NULL) so the ADD
+-- COLUMN is an instant metadata-only change (no table rewrite / no lock storm).
+
+ALTER TABLE "app_listings"
+  ADD COLUMN IF NOT EXISTS "revision_of_id" TEXT;
+
+-- Self-referential FK: a shadow points at its live parent. ON DELETE CASCADE so a
+-- parent delete removes its in-flight shadow. Guarded so a manual re-run is inert.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'app_listings_revision_of_id_fkey'
+  ) THEN
+    ALTER TABLE "app_listings"
+      ADD CONSTRAINT "app_listings_revision_of_id_fkey"
+      FOREIGN KEY ("revision_of_id") REFERENCES "app_listings"("id") ON DELETE CASCADE;
+  END IF;
+END $$;
+
+-- Index the FK: the shadow-lookup (WHERE revision_of_id = <parent>) + the read
+-- path's defense-in-depth `revision_of_id IS NULL` filter both scan on it, and
+-- Postgres does NOT auto-index a FK (so a parent DELETE would seq-scan otherwise).
+CREATE INDEX IF NOT EXISTS "app_listings_revision_of_idx"
+  ON "app_listings" ("revision_of_id");

--- a/prisma/migrations/20260707120000_w13_edit_listing_revision/migration.sql
+++ b/prisma/migrations/20260707120000_w13_edit_listing_revision/migration.sql
@@ -49,8 +49,15 @@ BEGIN
   END IF;
 END $$;
 
--- Index the FK: the shadow-lookup (WHERE revision_of_id = <parent>) + the read
--- path's defense-in-depth `revision_of_id IS NULL` filter both scan on it, and
--- Postgres does NOT auto-index a FK (so a parent DELETE would seq-scan otherwise).
-CREATE INDEX IF NOT EXISTS "app_listings_revision_of_idx"
-  ON "app_listings" ("revision_of_id");
+-- PARTIAL UNIQUE index on the FK: at most ONE in-flight shadow per parent (a
+-- second concurrent `beginListingRevision` that races past the read-check now
+-- hits this constraint → the app catches P2002 and collapses to idempotent
+-- reuse of the winning shadow instead of stranding a duplicate). The predicate
+-- (`revision_of_id IS NOT NULL`) excludes the many top-level listings (all NULL,
+-- which would otherwise collide) so uniqueness applies only to shadows. This
+-- index ALSO serves the shadow-lookup (WHERE revision_of_id = <parent>) + the
+-- read path's `revision_of_id IS NULL` filter that the FK would otherwise
+-- seq-scan (Postgres does NOT auto-index a FK). Idempotent (IF NOT EXISTS).
+CREATE UNIQUE INDEX IF NOT EXISTS "app_listings_revision_of_id_key"
+  ON "app_listings" ("revision_of_id")
+  WHERE "revision_of_id" IS NOT NULL;

--- a/src/components/Apps/OffsiteEditModal.tsx
+++ b/src/components/Apps/OffsiteEditModal.tsx
@@ -1,0 +1,220 @@
+import { Alert, Button, Group, Modal, Select, Stack, Text, TextInput } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconInfoCircle, IconPencil } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+
+import type { OffsiteSubmission } from '~/components/Apps/OffsiteSubmissionsList';
+import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
+import {
+  MARKETPLACE_CATEGORIES,
+  MARKETPLACE_CATEGORY_LABELS,
+  type MarketplaceCategory,
+} from '~/server/services/blocks/marketplace-categories.constants';
+import {
+  OFFSITE_CONTENT_RATINGS,
+  type OffsiteContentRating,
+  type UpdateListingPatch,
+} from '~/server/schema/blocks/offsite-listing.schema';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App Store Listings (W13) — EDIT-without-withdraw modal (author).
+ *
+ * A focused, minimal editor for the scalar display fields of an off-site listing
+ * the author still owns and can edit in place / stage for re-review:
+ *   - a PENDING request → the backing listing is a live DRAFT under review → edits
+ *     apply IN PLACE (no re-review),
+ *   - an APPROVED request → the listing is LIVE. A trivial edit (category /
+ *     contentRating) applies in place; a MATERIAL edit (name / externalUrl) is
+ *     staged as a shadow-draft revision and, because the shadow inherits the live
+ *     listing's already-complete assets, auto-submitted for re-review here — the
+ *     current version stays live until a moderator re-approves.
+ *
+ * SCOPE (deferred to a follow-up): tagline/description editing + a full
+ * asset-re-edit flow (reusing `ExternalSubmitForm` + the OG metadata auto-pull)
+ * for a material revision that also changes imagery. This modal changes only the
+ * fields whose current values the my-submissions payload already carries, so it
+ * never accidentally clears an un-prefilled field.
+ */
+
+const CATEGORY_OPTIONS = MARKETPLACE_CATEGORIES.map((c) => ({
+  value: c,
+  label: MARKETPLACE_CATEGORY_LABELS[c],
+}));
+const RATING_OPTIONS = OFFSITE_CONTENT_RATINGS.map((r) => ({ value: r, label: r.toUpperCase() }));
+
+export function OffsiteEditModal({ submission }: { submission: OffsiteSubmission }) {
+  const [opened, { open, close }] = useDisclosure(false);
+  const utils = trpc.useUtils();
+
+  const listingId = submission.appListingId;
+  const isApproved = submission.status === 'approved';
+  const orig = useMemo(
+    () => ({
+      name: submission.appListing?.name ?? '',
+      externalUrl: submission.appListing?.externalUrl ?? '',
+      category: submission.appListing?.category ?? null,
+      contentRating: submission.appListing?.contentRating ?? 'g',
+    }),
+    [submission]
+  );
+
+  const [name, setName] = useState(orig.name);
+  const [externalUrl, setExternalUrl] = useState(orig.externalUrl);
+  const [category, setCategory] = useState<string | null>(orig.category);
+  const [contentRating, setContentRating] = useState<string>(orig.contentRating);
+  const [inlineError, setInlineError] = useState<string | null>(null);
+
+  const reset = () => {
+    setName(orig.name);
+    setExternalUrl(orig.externalUrl);
+    setCategory(orig.category);
+    setContentRating(orig.contentRating);
+    setInlineError(null);
+  };
+
+  const done = (title: string, message: string) => {
+    showSuccessNotification({ title, message });
+    void utils.appListings.listMySubmissions.invalidate();
+    close();
+  };
+
+  const submitRevision = trpc.appListings.submitListingRevision.useMutation({
+    onSuccess: () =>
+      done('Sent for review', 'Your current version stays live until a moderator re-approves.'),
+    onError: (error: { message?: string | null }) => {
+      setInlineError(error.message ?? 'Failed to submit the revision for review.');
+      showErrorNotification({ error: new Error(error.message ?? 'Revision submit failed') });
+    },
+  });
+
+  const update = trpc.appListings.updateListing.useMutation({
+    onSuccess: (data: { requiresReview: boolean; shadowId: string | null }) => {
+      if (data.requiresReview && data.shadowId) {
+        // A material edit was staged on a shadow (assets inherited from the live
+        // listing) — submit it for re-review so it actually reaches the queue.
+        submitRevision.mutate({ shadowId: data.shadowId });
+        return;
+      }
+      done('Saved', 'Your changes are live.');
+    },
+    onError: (error: { message?: string | null }) => {
+      setInlineError(error.message ?? 'Failed to save your changes.');
+    },
+  });
+
+  const busy = update.isPending || submitRevision.isPending;
+
+  const buildPatch = (): UpdateListingPatch => {
+    const patch: UpdateListingPatch = {};
+    if (name !== orig.name) patch.name = name;
+    if (externalUrl !== orig.externalUrl) patch.externalUrl = externalUrl;
+    // The Select options are exactly MARKETPLACE_CATEGORIES (or cleared → null),
+    // and the RATING options are exactly OFFSITE_CONTENT_RATINGS, so these casts
+    // reflect the constrained option sets (the server re-validates regardless).
+    if (category !== orig.category) patch.category = category as MarketplaceCategory | null;
+    if (contentRating !== orig.contentRating)
+      patch.contentRating = contentRating as OffsiteContentRating;
+    return patch;
+  };
+
+  const onSubmit = () => {
+    setInlineError(null);
+    if (!listingId) {
+      setInlineError('This submission has no editable listing.');
+      return;
+    }
+    const patch = buildPatch();
+    if (Object.keys(patch).length === 0) {
+      close();
+      return;
+    }
+    if (patch.externalUrl !== undefined && !validateExternalUrl(patch.externalUrl).ok) {
+      setInlineError('The link must be a valid https:// URL.');
+      return;
+    }
+    if (name.trim().length === 0) {
+      setInlineError('Name is required.');
+      return;
+    }
+    update.mutate({ listingId, patch });
+  };
+
+  return (
+    <>
+      <Button
+        size="xs"
+        variant="default"
+        leftSection={<IconPencil size={12} />}
+        onClick={() => {
+          reset();
+          open();
+        }}
+        data-testid={`apps-offsite-edit-${submission.slug}`}
+      >
+        Edit
+      </Button>
+      <Modal opened={opened} onClose={close} title={`Edit ${orig.name || submission.slug}`} centered>
+        <Stack gap="sm">
+          {isApproved && (
+            <Alert
+              icon={<IconInfoCircle size={16} />}
+              color="blue"
+              variant="light"
+              data-testid="apps-offsite-edit-approved-notice"
+            >
+              <Text size="sm">
+                This app is live. Editing the <b>name</b> or <b>link</b> sends the change to
+                moderator review — your current version stays live until it&apos;s re-approved.
+                Category and rating changes apply immediately.
+              </Text>
+            </Alert>
+          )}
+          <TextInput
+            label="Name"
+            value={name}
+            onChange={(e) => setName(e.currentTarget.value)}
+            maxLength={120}
+            data-testid="apps-offsite-edit-name"
+          />
+          <TextInput
+            label="Link (https://)"
+            value={externalUrl}
+            onChange={(e) => setExternalUrl(e.currentTarget.value)}
+            data-testid="apps-offsite-edit-url"
+          />
+          <Select
+            label="Category"
+            data={CATEGORY_OPTIONS}
+            value={category}
+            onChange={setCategory}
+            clearable
+            data-testid="apps-offsite-edit-category"
+          />
+          <Select
+            label="Content rating"
+            data={RATING_OPTIONS}
+            value={contentRating}
+            onChange={(v) => setContentRating(v ?? 'g')}
+            allowDeselect={false}
+            data-testid="apps-offsite-edit-rating"
+          />
+          {inlineError && (
+            <Text size="sm" c="red" data-testid="apps-offsite-edit-error">
+              {inlineError}
+            </Text>
+          )}
+          <Group justify="flex-end" gap="xs">
+            <Button variant="default" onClick={close} disabled={busy}>
+              Cancel
+            </Button>
+            <Button onClick={onSubmit} loading={busy} data-testid="apps-offsite-edit-save">
+              {isApproved ? 'Save / submit for review' : 'Save'}
+            </Button>
+          </Group>
+        </Stack>
+      </Modal>
+    </>
+  );
+}

--- a/src/components/Apps/OffsiteSubmissionsList.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.tsx
@@ -2,9 +2,11 @@ import { Anchor, Badge, Button, Card, Code, Group, Stack, Table, Text } from '@m
 import { IconExternalLink } from '@tabler/icons-react';
 import { Fragment, useMemo, useState, type ReactNode } from 'react';
 import {
+  isEditableOffsiteStatus,
   isWithdrawableOffsiteStatus,
   offsiteStatusChip,
 } from '~/components/Apps/offsiteSubmissionStatus';
+import { OffsiteEditModal } from '~/components/Apps/OffsiteEditModal';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
 import { ReviewerNotesButton } from '~/components/Apps/MySubmissionsList';
 import {
@@ -47,7 +49,11 @@ export type OffsiteSubmission = {
     externalUrl: string | null;
     category: string | null;
     contentRating: string | null;
+    /** Non-null only for a shadow revision draft (never surfaced here — inferred). */
+    revisionOfId?: string | null;
   } | null;
+  /** True when this parent listing has an in-flight shadow revision under review. */
+  hasPendingRevision?: boolean;
 };
 
 /** Field adapters for the shared filter/sort/group helpers. Collapse identity =
@@ -134,6 +140,47 @@ function OffsiteRow({
   toggle?: ReactNode;
 }) {
   const s = submission;
+  // Edit only on the latest (non-nested) row of an editable request; older
+  // versions are historical. Withdraw stays available per-row where applicable.
+  const canEdit = !nested && isEditableOffsiteStatus(s.status) && !!s.appListingId;
+  const canWithdraw = isWithdrawableOffsiteStatus(s.status);
+  const renderActions = () => {
+    if (!canEdit && !canWithdraw && !s.hasPendingRevision) {
+      return (
+        <Text size="xs" c="dimmed">
+          —
+        </Text>
+      );
+    }
+    return (
+      <Group gap={6} wrap="nowrap">
+        {canEdit && <OffsiteEditModal submission={s} />}
+        {canWithdraw && (
+          <Button
+            size="xs"
+            variant="default"
+            color="red"
+            onClick={() => onWithdraw(s.id)}
+            disabled={withdrawing}
+            loading={withdrawing}
+            data-testid={`apps-offsite-withdraw-${s.slug}`}
+          >
+            Withdraw
+          </Button>
+        )}
+        {s.hasPendingRevision && (
+          <Badge
+            size="xs"
+            color="orange"
+            variant="light"
+            data-testid={`apps-offsite-revision-pending-${s.slug}`}
+          >
+            revision in review
+          </Badge>
+        )}
+      </Group>
+    );
+  };
   return (
     <Table.Tr data-testid={`apps-offsite-submission-row-${s.slug}`}>
       <Table.Td>
@@ -171,25 +218,7 @@ function OffsiteRow({
           {formatDate(s.reviewedAt)}
         </Text>
       </Table.Td>
-      <Table.Td>
-        {isWithdrawableOffsiteStatus(s.status) ? (
-          <Button
-            size="xs"
-            variant="default"
-            color="red"
-            onClick={() => onWithdraw(s.id)}
-            disabled={withdrawing}
-            loading={withdrawing}
-            data-testid={`apps-offsite-withdraw-${s.slug}`}
-          >
-            Withdraw
-          </Button>
-        ) : (
-          <Text size="xs" c="dimmed">
-            —
-          </Text>
-        )}
-      </Table.Td>
+      <Table.Td>{renderActions()}</Table.Td>
     </Table.Tr>
   );
 }

--- a/src/components/Apps/__tests__/offsiteSubmissionStatus.test.ts
+++ b/src/components/Apps/__tests__/offsiteSubmissionStatus.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  isEditableOffsiteStatus,
   isWithdrawableOffsiteStatus,
   offsiteStatusChip,
 } from '../offsiteSubmissionStatus';
@@ -27,6 +28,18 @@ describe('isWithdrawableOffsiteStatus', () => {
     expect(isWithdrawableOffsiteStatus('pending')).toBe(true);
     for (const s of ['approved', 'rejected', 'withdrawn', 'weird']) {
       expect(isWithdrawableOffsiteStatus(s)).toBe(false);
+    }
+  });
+});
+
+describe('isEditableOffsiteStatus', () => {
+  it('pending (live draft under review) and approved (live) are editable without withdrawing', () => {
+    expect(isEditableOffsiteStatus('pending')).toBe(true);
+    expect(isEditableOffsiteStatus('approved')).toBe(true);
+  });
+  it('rejected/withdrawn (listing deleted) and unknown are NOT editable', () => {
+    for (const s of ['rejected', 'withdrawn', 'weird']) {
+      expect(isEditableOffsiteStatus(s)).toBe(false);
     }
   });
 });

--- a/src/components/Apps/offsiteSubmissionStatus.ts
+++ b/src/components/Apps/offsiteSubmissionStatus.ts
@@ -35,3 +35,14 @@ export function offsiteStatusChip(status: string): OffsiteStatusChip {
 export function isWithdrawableOffsiteStatus(status: string): boolean {
   return status === 'pending';
 }
+
+/**
+ * True for a REQUEST status whose backing listing is still editable WITHOUT
+ * withdrawing it. `pending` (the listing is a live draft under review — edited in
+ * place) and `approved` (the listing is live — a trivial edit applies in place, a
+ * material edit is staged as a shadow revision). `rejected`/`withdrawn` deleted
+ * their listing (→ resubmit), so they are NOT editable here.
+ */
+export function isEditableOffsiteStatus(status: string): boolean {
+  return status === 'pending' || status === 'approved';
+}

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -21,11 +21,14 @@ import {
 } from '~/server/schema/blocks/app-listing-review.schema';
 import {
   approveExternalRequestSchema,
+  beginListingRevisionSchema,
   listMySubmissionsSchema,
   listOffsiteRequestsSchema,
   persistListingAssetImageSchema,
   rejectExternalRequestSchema,
   submitExternalListingSchema,
+  submitListingRevisionSchema,
+  updateListingSchema,
   withdrawExternalRequestSchema,
 } from '~/server/schema/blocks/offsite-listing.schema';
 import {
@@ -150,7 +153,7 @@ function mapOffsiteError(err: unknown): TRPCError {
     const trpcCode =
       code === 'NOT_FOUND'
         ? 'NOT_FOUND'
-        : code === 'NOT_OWNED'
+        : code === 'NOT_OWNED' || code === 'FORBIDDEN'
         ? 'FORBIDDEN'
         : code === 'ALREADY_REPORTED'
         ? 'CONFLICT'
@@ -307,6 +310,90 @@ export const appListingsRouter = router({
         throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
       }
       return { ok: true };
+    }),
+
+  /**
+   * AUTHOR: edit an existing off-site listing WITHOUT withdrawing it (state-aware).
+   * draft/pending → in place; approved-trivial (tagline/description/category/
+   * contentRating) → in place; approved-material (externalUrl/name) → staged on a
+   * shadow-draft revision (`requiresReview:true` + the `shadowId` to edit assets
+   * against, then `submitListingRevision`). Owner-bound in the service. Rejected →
+   * MUST_RESUBMIT; removed → FORBIDDEN. Typed failures map via `mapOffsiteError`.
+   */
+  updateListing: appDeveloperProcedure
+    .use(
+      rateLimit({
+        limit: 30,
+        period: 3600,
+        errorMessage: 'Too many edits — slow down.',
+      })
+    )
+    .input(updateListingSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { updateListing } = await import('~/server/services/blocks/offsite-listing.service');
+      try {
+        return await updateListing({
+          listingId: input.listingId,
+          patch: input.patch,
+          userId: ctx.user.id,
+        });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /**
+   * AUTHOR: open (or re-open) a shadow-draft revision of an APPROVED listing so its
+   * MATERIAL fields / assets can be edited while the current version stays live.
+   * Idempotent (re-opening returns the existing shadow). Returns the shadow id;
+   * the author then edits its assets via `setIcon`/`setCover`/`addScreenshot`
+   * (passing the shadow id) and calls `submitListingRevision`.
+   */
+  beginListingRevision: appDeveloperProcedure
+    .input(beginListingRevisionSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { beginListingRevision } = await import(
+        '~/server/services/blocks/offsite-listing.service'
+      );
+      try {
+        return await beginListingRevision({ listingId: input.listingId, userId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /**
+   * AUTHOR: submit a prepared shadow-draft revision for mod re-approval. Asserts
+   * the shadow is a draft revision, asset-complete + URL-valid, then creates a
+   * pending publish request pointing at the shadow but carrying the PUBLIC PARENT
+   * slug. Guards a second concurrent pending revision. Typed failures map via
+   * `mapOffsiteError`.
+   */
+  submitListingRevision: appDeveloperProcedure
+    .use(
+      rateLimit({
+        limit: 20,
+        period: 3600,
+        errorMessage: 'Too many revision submissions — slow down.',
+      })
+    )
+    .input(submitListingRevisionSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { submitListingRevision } = await import(
+        '~/server/services/blocks/offsite-listing.service'
+      );
+      try {
+        return await submitListingRevision({
+          shadowId: input.shadowId,
+          userId: ctx.user.id,
+          changelog: input.changelog,
+        });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
     }),
 
   /**

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -102,6 +102,62 @@ export const withdrawExternalRequestSchema = z.object({
 export type WithdrawExternalRequestInput = z.infer<typeof withdrawExternalRequestSchema>;
 
 /**
+ * AUTHOR: edit an existing off-site listing WITHOUT withdrawing it (state-aware).
+ *
+ * `patch` carries ONLY the editable display fields — never `slug` or `kind`
+ * (those are immutable for a live listing; a slug change would break its public
+ * URL + squat protection). `externalUrl` is bounded loose here and re-validated
+ * for the https-only shape by the shared `validateExternalUrl` in the service
+ * (single source of truth; this fn is exported + unit-tested directly). Category
+ * / contentRating are re-checked against their taxonomies in the service too.
+ *
+ * At least one field must be present (an empty patch is a no-op the schema
+ * rejects, so the client can't accidentally fire a meaningless mutation). The
+ * SERVICE routes the patch by the listing's status: draft/pending → in place;
+ * approved-trivial → in place; approved-material → staged on a shadow revision.
+ */
+export const updateListingPatchSchema = z
+  .object({
+    externalUrl: z.string().min(1).max(MAX_EXTERNAL_URL_LENGTH).optional(),
+    name: z.string().min(1).max(OFFSITE_NAME_MAX).optional(),
+    tagline: z.string().max(OFFSITE_TAGLINE_MAX).nullable().optional(),
+    description: z.string().max(OFFSITE_DESCRIPTION_MAX).nullable().optional(),
+    category: z.enum(MARKETPLACE_CATEGORIES).nullable().optional(),
+    contentRating: z.enum(OFFSITE_CONTENT_RATINGS).optional(),
+  })
+  .refine((p) => Object.values(p).some((v) => v !== undefined), {
+    message: 'patch must change at least one field',
+  });
+export type UpdateListingPatch = z.infer<typeof updateListingPatchSchema>;
+
+export const updateListingSchema = z.object({
+  listingId: z.string().min(1).max(64),
+  patch: updateListingPatchSchema,
+});
+export type UpdateListingInput = z.infer<typeof updateListingSchema>;
+
+/**
+ * AUTHOR: begin (or re-open) a shadow-draft revision of an APPROVED listing so
+ * its MATERIAL fields / assets can be edited while the current version stays
+ * live. Idempotent in the service (re-opening returns the existing shadow).
+ */
+export const beginListingRevisionSchema = z.object({
+  listingId: z.string().min(1).max(64),
+});
+export type BeginListingRevisionInput = z.infer<typeof beginListingRevisionSchema>;
+
+/**
+ * AUTHOR: submit a prepared shadow-draft revision for mod re-approval. `shadowId`
+ * is the id returned by `beginListingRevision` (the hidden draft clone). The
+ * optional changelog is denormalized onto the pending publish request.
+ */
+export const submitListingRevisionSchema = z.object({
+  shadowId: z.string().min(1).max(64),
+  changelog: z.string().max(OFFSITE_CHANGELOG_MAX).optional(),
+});
+export type SubmitListingRevisionInput = z.infer<typeof submitListingRevisionSchema>;
+
+/**
  * MOD approve of a pending off-site request (PR-b). Mirrors the on-site
  * `approveRequestSchema` shape: the request id + an optional `approvalNotes`.
  * The asset-completeness gate + the external-URL re-validation are enforced in

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -400,6 +400,11 @@ describe('listAvailableListings — query building + pagination', () => {
     expect(capturedSql()).toMatch(/al\.status\s*=\s*'approved'/);
   });
 
+  it('SQL excludes SHADOW revision drafts (revision_of_id IS NULL) — defense in depth', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
+    expect(capturedSql()).toMatch(/al\.revision_of_id\s+IS\s+NULL/i);
+  });
+
   it('kind filter binds the requested kind (onsite)', async () => {
     await listAvailableListings({ kind: 'onsite', sort: 'newest', limit: 20 });
     expect(capturedSql()).toMatch(/al\.kind\s*=/);
@@ -642,7 +647,8 @@ describe('getListingDetail — approved-only + maturity gate', () => {
     // Looked up by slug.
     const where = (mockDbRead.appListing.findFirst.mock.calls.at(-1)?.[0] as { where?: unknown })
       ?.where;
-    expect(where).toEqual({ slug: 'cool-app' });
+    // Includes the shadow-exclusion guard (defense-in-depth).
+    expect(where).toEqual({ slug: 'cool-app', revisionOfId: null });
   });
 
   it('looks up by id when id is provided', async () => {
@@ -650,7 +656,14 @@ describe('getListingDetail — approved-only + maturity gate', () => {
     await getListingDetail({ id: 'apl_1' });
     const where = (mockDbRead.appListing.findFirst.mock.calls.at(-1)?.[0] as { where?: unknown })
       ?.where;
-    expect(where).toEqual({ id: 'apl_1' });
+    expect(where).toEqual({ id: 'apl_1', revisionOfId: null });
+  });
+
+  it('the WHERE excludes SHADOW revision drafts (revisionOfId: null) for BOTH selectors', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...hydratedRow(), status: 'approved' });
+    await getListingDetail({ slug: 'cool-app' });
+    const bySlug = (mockDbRead.appListing.findFirst.mock.calls.at(-1)?.[0] as { where?: { revisionOfId?: unknown } })?.where;
+    expect(bySlug?.revisionOfId).toBeNull();
   });
 
   it('returns null for a missing listing', async () => {

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -1,0 +1,698 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+import {
+  OffsiteRequestError,
+  approveExternalRequest,
+  beginListingRevision,
+  listMySubmissions,
+  rejectExternalRequest,
+  submitListingRevision,
+  updateListing,
+  withdrawExternalRequest,
+} from '~/server/services/blocks/offsite-listing.service';
+import type { UpdateListingPatch } from '~/server/schema/blocks/offsite-listing.schema';
+
+/**
+ * App Store Listings (W13) — EDIT-without-withdraw (shadow-draft revision) tests.
+ *
+ * Covers the state machine (updateListing: draft/pending in-place; approved-trivial
+ * in-place; approved-material → shadow; rejected → MUST_RESUBMIT; removed →
+ * FORBIDDEN; non-owner → NOT_OWNED; invalid URL), the shadow lifecycle
+ * (beginListingRevision clone + idempotent reuse; submitListingRevision request w/
+ * PARENT slug + concurrent-guard + asset gate), the REVISION-AWARE approve (copy
+ * shadow → parent, preserve parent id/slug, delete shadow, re-point + approve the
+ * request) and the reject/withdraw revision paths (delete shadow only; parent
+ * untouched), plus listMySubmissions shadow exclusion + the hasPendingRevision flag.
+ *
+ * All DB deps are mocked — no real Prisma. `dbRead` (replica) and `dbWrite`
+ * (primary, owns `$transaction`) are DISTINCT mocks; the interactive tx runs the
+ * callback with `mockWrite` itself as `tx`.
+ */
+
+// ---------------------------------------------------------------------------
+// Mock harness
+// ---------------------------------------------------------------------------
+
+type Row = Record<string, unknown> & { id: string };
+
+const { mockRead, mockWrite, seq } = vi.hoisted(() => {
+  const makeClient = () => ({
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+      update: vi.fn(async (args: { data: unknown }) => args.data),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appListingScreenshot: {
+      count: vi.fn(async (..._a: unknown[]) => 0),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+    },
+    appListingPublishRequest: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      count: vi.fn(async (..._a: unknown[]) => 0),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+  });
+  const mockRead = makeClient();
+  const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
+    $transaction: ReturnType<typeof vi.fn>;
+  };
+  mockWrite.$transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  return { mockRead, mockWrite, seq: { n: 0 } };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingId: () => `apl_new_${++seq.n}`,
+  newAppListingPublishRequestId: () => `alpr_new_${++seq.n}`,
+  newAppListingScreenshotId: () => `apls_new_${++seq.n}`,
+  newUlid: () => `ULID${++seq.n}`,
+}));
+
+const OWNER = 42;
+const OTHER = 99;
+const MOD = 7;
+
+/** Build a findUnique impl that routes by `where.id` against a row map. */
+function findUniqueById(rows: Record<string, Row | null>) {
+  return async (args: { where: { id: string } }) => rows[args.where.id] ?? null;
+}
+
+function resetAll() {
+  for (const client of [mockRead, mockWrite]) {
+    client.appListing.findUnique.mockReset().mockResolvedValue(null);
+    client.appListing.findFirst.mockReset().mockResolvedValue(null);
+    client.appListing.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    client.appListing.update.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    client.appListing.updateMany.mockReset().mockResolvedValue({ count: 1 });
+    client.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
+    client.appListingScreenshot.count.mockReset().mockResolvedValue(0);
+    client.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
+    client.appListingScreenshot.createMany.mockReset().mockResolvedValue({ count: 0 });
+    client.appListingScreenshot.updateMany.mockReset().mockResolvedValue({ count: 0 });
+    client.appListingScreenshot.deleteMany.mockReset().mockResolvedValue({ count: 0 });
+    client.appListingPublishRequest.findUnique.mockReset().mockResolvedValue(null);
+    client.appListingPublishRequest.findFirst.mockReset().mockResolvedValue(null);
+    client.appListingPublishRequest.count.mockReset().mockResolvedValue(0);
+    client.appListingPublishRequest.create
+      .mockReset()
+      .mockImplementation(async (a: { data: unknown }) => a.data);
+    client.appListingPublishRequest.updateMany.mockReset().mockResolvedValue({ count: 1 });
+    client.appListingPublishRequest.findMany.mockReset().mockResolvedValue([]);
+  }
+  mockWrite.$transaction
+    .mockReset()
+    .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  seq.n = 0;
+}
+
+beforeEach(resetAll);
+
+/** A fully-populated approved parent listing row (as the editableListingSelect returns). */
+function approvedParent(overrides: Partial<Row> = {}): Row {
+  return {
+    id: 'apl_parent',
+    kind: 'offsite',
+    slug: 'cool-app',
+    status: 'approved',
+    userId: OWNER,
+    revisionOfId: null,
+    name: 'Cool App',
+    tagline: 'the tagline',
+    description: 'the description',
+    category: 'utility',
+    contentRating: 'g',
+    externalUrl: 'https://cool.example.com/app',
+    connectClientId: null,
+    iconId: 1,
+    coverId: 2,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// updateListing
+// ---------------------------------------------------------------------------
+
+describe('updateListing', () => {
+  it('draft → edits IN PLACE (no shadow, no re-review)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent({ status: 'draft' }));
+    const patch: UpdateListingPatch = { name: 'Renamed', tagline: 'new tagline' };
+    const res = await updateListing({ listingId: 'apl_parent', patch, userId: OWNER });
+
+    expect(res).toEqual({
+      listingId: 'apl_parent',
+      status: 'draft',
+      requiresReview: false,
+      shadowId: null,
+    });
+    expect(mockWrite.appListing.update).toHaveBeenCalledWith({
+      where: { id: 'apl_parent' },
+      data: { name: 'Renamed', tagline: 'new tagline' },
+    });
+    // No shadow was opened.
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('pending → edits IN PLACE (the existing pending request keeps reviewing the row)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent({ status: 'pending' }));
+    const res = await updateListing({
+      listingId: 'apl_parent',
+      patch: { description: 'updated' },
+      userId: OWNER,
+    });
+    expect(res.requiresReview).toBe(false);
+    expect(res.shadowId).toBeNull();
+    expect(mockWrite.appListing.update).toHaveBeenCalledWith({
+      where: { id: 'apl_parent' },
+      data: { description: 'updated' },
+    });
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('approved + TRIVIAL-only edit → applied IN PLACE on the live row (no re-review)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent());
+    const res = await updateListing({
+      listingId: 'apl_parent',
+      patch: { tagline: 'fresh tagline', category: 'games', contentRating: 'pg' },
+      userId: OWNER,
+    });
+    expect(res).toEqual({
+      listingId: 'apl_parent',
+      status: 'approved',
+      requiresReview: false,
+      shadowId: null,
+    });
+    expect(mockWrite.appListing.update).toHaveBeenCalledWith({
+      where: { id: 'apl_parent' },
+      data: { tagline: 'fresh tagline', category: 'games', contentRating: 'pg' },
+    });
+    // No shadow — a trivial edit does not stage a revision.
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('approved + a MATERIAL name change → staged on a shadow (requiresReview), live row untouched', async () => {
+    // loadOwnedEditableListing (dbRead) + beginListingRevision's owner load (dbRead)
+    // both read the parent; the idempotent shadow lookup (dbRead.findFirst) → none.
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent());
+    mockRead.appListing.findFirst.mockResolvedValue(null); // no existing shadow
+    // beginListingRevision: in-tx race check → null (no race), then the post-tx
+    // winning-shadow re-read → the row we minted.
+    mockWrite.appListing.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'apl_new_1' });
+
+    const res = await updateListing({
+      listingId: 'apl_parent',
+      patch: { name: 'Brand New Name', tagline: 'also this' },
+      userId: OWNER,
+    });
+
+    expect(res.requiresReview).toBe(true);
+    expect(res.listingId).toBe('apl_parent');
+    expect(res.shadowId).toBe('apl_new_1');
+    // The shadow was created as a draft revision of the parent.
+    const shadowData = mockWrite.appListing.create.mock.calls[0][0].data as Row;
+    expect(shadowData).toMatchObject({ status: 'draft', revisionOfId: 'apl_parent', appBlockId: null });
+    // The FULL patch was written to the SHADOW, never the live parent.
+    const updateCalls = mockWrite.appListing.update.mock.calls.map((c) => c[0]);
+    expect(updateCalls).toContainEqual({
+      where: { id: 'apl_new_1' },
+      data: { name: 'Brand New Name', tagline: 'also this' },
+    });
+    expect(updateCalls.every((c) => (c as { where: { id: string } }).where.id !== 'apl_parent')).toBe(
+      true
+    );
+  });
+
+  it('approved + externalUrl change → treated as MATERIAL → shadow path', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent());
+    mockRead.appListing.findFirst.mockResolvedValue(null);
+    mockWrite.appListing.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'apl_new_1' });
+    const res = await updateListing({
+      listingId: 'apl_parent',
+      patch: { externalUrl: 'https://cool.example.com/new-path' },
+      userId: OWNER,
+    });
+    expect(res.requiresReview).toBe(true);
+    expect(res.shadowId).toBe('apl_new_1');
+  });
+
+  it('approved + a material field set to the SAME value → NOT material → in place (no shadow)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent());
+    const res = await updateListing({
+      listingId: 'apl_parent',
+      // name identical to the live value; only the tagline actually changes.
+      patch: { name: 'Cool App', tagline: 'tweaked' },
+      userId: OWNER,
+    });
+    expect(res.requiresReview).toBe(false);
+    expect(res.shadowId).toBeNull();
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('rejected → MUST_RESUBMIT (no row usually exists; steer to resubmit)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent({ status: 'rejected' }));
+    await expect(
+      updateListing({ listingId: 'apl_parent', patch: { name: 'x' }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'MUST_RESUBMIT' });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('removed → FORBIDDEN (mod-only takedown)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent({ status: 'removed' }));
+    await expect(
+      updateListing({ listingId: 'apl_parent', patch: { name: 'x' }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('non-owner → NOT_OWNED (no write)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent());
+    await expect(
+      updateListing({ listingId: 'apl_parent', patch: { name: 'x' }, userId: OTHER })
+    ).rejects.toMatchObject({ code: 'NOT_OWNED' });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('missing listing → NOT_FOUND', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(null);
+    await expect(
+      updateListing({ listingId: 'nope', patch: { name: 'x' }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('editing a SHADOW directly → INVALID_REVISION', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(
+      approvedParent({ id: 'apl_shadow', status: 'draft', revisionOfId: 'apl_parent' })
+    );
+    await expect(
+      updateListing({ listingId: 'apl_shadow', patch: { name: 'x' }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'INVALID_REVISION' });
+  });
+
+  it('invalid externalUrl → BAD_REQUEST (no write)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent({ status: 'draft' }));
+    await expect(
+      updateListing({
+        listingId: 'apl_parent',
+        patch: { externalUrl: 'http://insecure.example.com' },
+        userId: OWNER,
+      })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// beginListingRevision
+// ---------------------------------------------------------------------------
+
+describe('beginListingRevision', () => {
+  it('clones scalars + screenshots into a hidden draft shadow (synthetic slug, null appBlockId, revisionOfId set)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent());
+    mockRead.appListing.findFirst.mockResolvedValue(null); // no existing shadow
+    mockWrite.appListing.findFirst.mockResolvedValue(null); // no in-tx race
+    mockWrite.appListingScreenshot.findMany.mockResolvedValue([
+      { imageId: 10, order: 0, caption: 'a' },
+      { imageId: 11, order: 1, caption: null },
+    ]);
+    // After the tx, the winning-shadow re-read returns the row we just minted.
+    mockWrite.appListing.findFirst
+      .mockResolvedValueOnce(null) // in-tx race check
+      .mockResolvedValueOnce({ id: 'apl_new_1' }); // post-tx winner
+
+    const res = await beginListingRevision({ listingId: 'apl_parent', userId: OWNER });
+    expect(res.created).toBe(true);
+    expect(res.shadowId).toBe('apl_new_1');
+
+    const shadow = mockWrite.appListing.create.mock.calls[0][0].data as Row;
+    expect(shadow).toMatchObject({
+      status: 'draft',
+      revisionOfId: 'apl_parent',
+      appBlockId: null,
+      name: 'Cool App',
+      externalUrl: 'https://cool.example.com/app',
+      iconId: 1,
+      coverId: 2,
+      userId: OWNER,
+    });
+    // Synthetic, non-public slug — NOT the parent's public slug.
+    expect(shadow.slug).toMatch(/^rev-/);
+    expect(shadow.slug).not.toBe('cool-app');
+
+    // Screenshots were copied (imageId/order/caption preserved) onto the shadow.
+    const shots = mockWrite.appListingScreenshot.createMany.mock.calls[0][0].data as Row[];
+    expect(shots).toHaveLength(2);
+    expect(shots[0]).toMatchObject({ appListingId: 'apl_new_1', imageId: 10, order: 0, caption: 'a' });
+    expect(shots[1]).toMatchObject({ appListingId: 'apl_new_1', imageId: 11, order: 1, caption: null });
+  });
+
+  it('idempotent: an existing shadow is returned as-is (no second clone)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent());
+    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_existing_shadow' });
+    const res = await beginListingRevision({ listingId: 'apl_parent', userId: OWNER });
+    expect(res).toEqual({ shadowId: 'apl_existing_shadow', created: false });
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('non-approved parent → INVALID_REVISION', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent({ status: 'pending' }));
+    await expect(
+      beginListingRevision({ listingId: 'apl_parent', userId: OWNER })
+    ).rejects.toMatchObject({ code: 'INVALID_REVISION' });
+  });
+
+  it('non-owner → NOT_OWNED', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent());
+    await expect(
+      beginListingRevision({ listingId: 'apl_parent', userId: OTHER })
+    ).rejects.toMatchObject({ code: 'NOT_OWNED' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// submitListingRevision
+// ---------------------------------------------------------------------------
+
+function shadowRow(overrides: Partial<Row> = {}): Row {
+  return {
+    id: 'apl_shadow',
+    kind: 'offsite',
+    status: 'draft',
+    userId: OWNER,
+    revisionOfId: 'apl_parent',
+    externalUrl: 'https://cool.example.com/app',
+    iconId: 1,
+    coverId: 2,
+    revisionOf: { slug: 'cool-app', status: 'approved' },
+    ...overrides,
+  };
+}
+
+describe('submitListingRevision', () => {
+  it('asset-complete shadow → creates a pending request pointing at the shadow with the PARENT slug', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(shadowRow());
+    mockWrite.appListingScreenshot.count.mockResolvedValue(1);
+    mockRead.appListingPublishRequest.findFirst.mockResolvedValue(null); // no open request
+
+    const res = await submitListingRevision({
+      shadowId: 'apl_shadow',
+      userId: OWNER,
+      changelog: 'fixed the URL typo',
+    });
+    expect(res.shadowId).toBe('apl_shadow');
+    expect(res.slug).toBe('cool-app');
+
+    const reqData = mockWrite.appListingPublishRequest.create.mock.calls[0][0].data as Row;
+    expect(reqData).toMatchObject({
+      appListingId: 'apl_shadow',
+      status: 'pending',
+      slug: 'cool-app', // the PUBLIC parent slug, not the synthetic rev-* slug
+      submittedByUserId: OWNER,
+      changelog: 'fixed the URL typo',
+      kind: 'offsite',
+    });
+  });
+
+  it('blocks a SECOND concurrent pending revision (returns the existing open request)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(shadowRow());
+    mockWrite.appListingScreenshot.count.mockResolvedValue(1);
+    mockRead.appListingPublishRequest.findFirst.mockResolvedValue({
+      id: 'alpr_open',
+      slug: 'cool-app',
+    });
+    const res = await submitListingRevision({ shadowId: 'apl_shadow', userId: OWNER });
+    expect(res.publishRequestId).toBe('alpr_open');
+    // No new request created — the existing pending one stands.
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+  });
+
+  it('asset-incomplete shadow (no screenshot) → BAD_REQUEST, no request', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(shadowRow());
+    mockWrite.appListingScreenshot.count.mockResolvedValue(0); // no real screenshot
+    await expect(
+      submitListingRevision({ shadowId: 'apl_shadow', userId: OWNER })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('screenshots') });
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+  });
+
+  it('a non-shadow listing (revisionOfId null) → INVALID_REVISION', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(
+      shadowRow({ revisionOfId: null, revisionOf: null })
+    );
+    await expect(
+      submitListingRevision({ shadowId: 'apl_shadow', userId: OWNER })
+    ).rejects.toMatchObject({ code: 'INVALID_REVISION' });
+  });
+
+  it('a non-draft shadow → INVALID_REVISION', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(shadowRow({ status: 'approved' }));
+    await expect(
+      submitListingRevision({ shadowId: 'apl_shadow', userId: OWNER })
+    ).rejects.toMatchObject({ code: 'INVALID_REVISION' });
+  });
+
+  it('non-owner → NOT_OWNED', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(shadowRow({ userId: OTHER }));
+    await expect(
+      submitListingRevision({ shadowId: 'apl_shadow', userId: OWNER })
+    ).rejects.toMatchObject({ code: 'NOT_OWNED' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// approveExternalRequest — REVISION APPLY
+// ---------------------------------------------------------------------------
+
+describe('approveExternalRequest (revision apply)', () => {
+  /** Stage a pending revision request → shadow (revisionOfId set) → live parent. */
+  function stageRevisionApprove(shadow: Partial<Row> = {}) {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_rev',
+      status: 'pending',
+      kind: 'offsite',
+      slug: 'cool-app',
+      appListingId: 'apl_shadow',
+    });
+    // Step-2 listing load (dbRead) — the SHADOW, with revisionOfId set.
+    const shadowListing = {
+      id: 'apl_shadow',
+      status: 'draft',
+      externalUrl: 'https://cool.example.com/edited',
+      iconId: 5,
+      coverId: 6,
+      revisionOfId: 'apl_parent',
+    };
+    // Parent load (dbRead) inside applyApprovedRevision.
+    mockRead.appListing.findUnique.mockImplementation(
+      findUniqueById({
+        apl_shadow: shadowListing as Row,
+        apl_parent: { id: 'apl_parent', slug: 'cool-app' } as Row,
+      })
+    );
+    // In-tx authoritative shadow re-read (dbWrite) — full scalars to copy.
+    mockWrite.appListing.findUnique.mockImplementation(
+      findUniqueById({
+        apl_shadow: {
+          id: 'apl_shadow',
+          status: 'draft',
+          revisionOfId: 'apl_parent',
+          name: 'Edited Name',
+          tagline: 'edited tagline',
+          description: 'edited desc',
+          category: 'games',
+          contentRating: 'pg',
+          externalUrl: 'https://cool.example.com/edited',
+          connectClientId: null,
+          iconId: 5,
+          coverId: 6,
+          ...shadow,
+        } as Row,
+      })
+    );
+    mockWrite.appListingScreenshot.count.mockResolvedValue(2);
+  }
+
+  it('copies shadow scalars onto the PARENT (id/slug preserved), deletes the shadow, approves + re-points the request', async () => {
+    stageRevisionApprove();
+    const res = await approveExternalRequest({
+      publishRequestId: 'alpr_rev',
+      reviewerUserId: MOD,
+      approvalNotes: 'nice edit',
+    });
+    // Returns the LIVE parent id + slug (not the shadow).
+    expect(res).toEqual({ publishRequestId: 'alpr_rev', listingId: 'apl_parent', slug: 'cool-app' });
+
+    // The request flip re-points appListingId at the PARENT + marks approved.
+    const reqCall = mockWrite.appListingPublishRequest.updateMany.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    };
+    expect(reqCall.where).toEqual({ id: 'alpr_rev', status: 'pending' });
+    expect(reqCall.data).toMatchObject({
+      status: 'approved',
+      reviewedByUserId: MOD,
+      approvalNotes: 'nice edit',
+      appListingId: 'apl_parent',
+    });
+
+    // Scalars copied onto the PARENT (never the shadow), status/slug/id untouched.
+    const parentUpdate = mockWrite.appListing.update.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    };
+    expect(parentUpdate.where).toEqual({ id: 'apl_parent' });
+    expect(parentUpdate.data).toEqual({
+      name: 'Edited Name',
+      tagline: 'edited tagline',
+      description: 'edited desc',
+      category: 'games',
+      contentRating: 'pg',
+      externalUrl: 'https://cool.example.com/edited',
+      connectClientId: null,
+      iconId: 5,
+      coverId: 6,
+    });
+    expect(parentUpdate.data).not.toHaveProperty('status');
+    expect(parentUpdate.data).not.toHaveProperty('slug');
+
+    // Screenshots reparented BEFORE the shadow delete (cascade-safe): delete parent's
+    // rows, move the shadow's rows onto the parent.
+    expect(mockWrite.appListingScreenshot.deleteMany).toHaveBeenCalledWith({
+      where: { appListingId: 'apl_parent' },
+    });
+    expect(mockWrite.appListingScreenshot.updateMany).toHaveBeenCalledWith({
+      where: { appListingId: 'apl_shadow' },
+      data: { appListingId: 'apl_parent' },
+    });
+    // The shadow is retired (guarded to a revision row).
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
+      where: { id: 'apl_shadow', revisionOfId: { not: null } },
+    });
+  });
+
+  it('revision approve is BLOCKED if the shadow is asset-incomplete (primary re-assert)', async () => {
+    stageRevisionApprove();
+    mockWrite.appListingScreenshot.count.mockResolvedValue(0); // no real screenshot on the shadow
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_rev', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('screenshots') });
+    // Neither the request nor the parent were mutated.
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('revision approve TOCTOU: the request flip matches 0 rows → NOT_PENDING, parent NOT copied', async () => {
+    stageRevisionApprove();
+    mockWrite.appListingPublishRequest.updateMany.mockResolvedValue({ count: 0 });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_rev', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'NOT_PENDING' });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reject / withdraw — REVISION path (delete shadow only; parent untouched)
+// ---------------------------------------------------------------------------
+
+describe('reject/withdraw a pending REVISION', () => {
+  it('rejectExternalRequest deletes ONLY the shadow (status-guarded draft); the parent is a separate row, untouched', async () => {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_rev',
+      status: 'pending',
+      kind: 'offsite',
+      appListingId: 'apl_shadow', // the shadow, a draft
+    });
+    await rejectExternalRequest({
+      publishRequestId: 'alpr_rev',
+      reviewerUserId: MOD,
+      rejectionReason: 'the edit is not acceptable',
+    });
+    // The status-guarded delete targets ONLY a draft row → the shadow. The live
+    // approved parent (apl_parent) is never referenced, so it stays live.
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
+      where: { id: 'apl_shadow', status: 'draft' },
+    });
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ id: 'apl_parent' }) })
+    );
+  });
+
+  it('withdrawExternalRequest on a revision deletes ONLY the shadow (draft); the parent is untouched', async () => {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_rev',
+      status: 'pending',
+      submittedByUserId: OWNER,
+      appListingId: 'apl_shadow',
+    });
+    await withdrawExternalRequest({ publishRequestId: 'alpr_rev', userId: OWNER });
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
+      where: { id: 'apl_shadow', status: 'draft' },
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listMySubmissions — shadow exclusion + hasPendingRevision flag
+// ---------------------------------------------------------------------------
+
+describe('listMySubmissions (shadow handling)', () => {
+  it('excludes shadow-targeting requests from the query and flags parents with a pending revision', async () => {
+    // The query returns only the parent's own (non-shadow) request; assert the WHERE
+    // excludes shadow-targeting requests.
+    mockRead.appListingPublishRequest.findMany.mockResolvedValue([
+      {
+        id: 'alpr_parent',
+        appListingId: 'apl_parent',
+        slug: 'cool-app',
+        status: 'approved',
+        appListing: { name: 'Cool App', revisionOfId: null },
+      },
+    ]);
+    // A shadow exists for apl_parent → hasPendingRevision should be true.
+    mockRead.appListing.findMany.mockResolvedValue([{ revisionOfId: 'apl_parent' }]);
+
+    const res = await listMySubmissions({ userId: OWNER });
+
+    const where = mockRead.appListingPublishRequest.findMany.mock.calls[0][0].where as Record<
+      string,
+      unknown
+    >;
+    expect(where).toMatchObject({ submittedByUserId: OWNER, kind: 'offsite' });
+    // Shadow-targeting requests are excluded (OR: appListingId null OR parent listing).
+    expect(where.OR).toEqual([{ appListingId: null }, { appListing: { revisionOfId: null } }]);
+
+    expect(res.items).toHaveLength(1);
+    expect(res.items[0]).toMatchObject({ id: 'alpr_parent', hasPendingRevision: true });
+  });
+
+  it('a parent with NO in-flight shadow → hasPendingRevision false', async () => {
+    mockRead.appListingPublishRequest.findMany.mockResolvedValue([
+      {
+        id: 'alpr_parent',
+        appListingId: 'apl_parent',
+        slug: 'cool-app',
+        status: 'approved',
+        appListing: { name: 'Cool App', revisionOfId: null },
+      },
+    ]);
+    mockRead.appListing.findMany.mockResolvedValue([]); // no shadows
+    const res = await listMySubmissions({ userId: OWNER });
+    expect(res.items[0]).toMatchObject({ hasPendingRevision: false });
+  });
+});

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -183,7 +183,9 @@ describe('updateListing', () => {
     mockRead.appListing.findUnique.mockResolvedValue(approvedParent());
     const res = await updateListing({
       listingId: 'apl_parent',
-      patch: { tagline: 'fresh tagline', category: 'games', contentRating: 'pg' },
+      // tagline/description/category are trivial; contentRating is MATERIAL (see
+      // its own test below) so it is deliberately NOT in this trivial patch.
+      patch: { tagline: 'fresh tagline', category: 'games', description: 'new desc' },
       userId: OWNER,
     });
     expect(res).toEqual({
@@ -194,9 +196,54 @@ describe('updateListing', () => {
     });
     expect(mockWrite.appListing.update).toHaveBeenCalledWith({
       where: { id: 'apl_parent' },
-      data: { tagline: 'fresh tagline', category: 'games', contentRating: 'pg' },
+      data: { tagline: 'fresh tagline', category: 'games', description: 'new desc' },
     });
     // No shadow — a trivial edit does not stage a revision.
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('approved + contentRating change → treated as MATERIAL → shadow path (maturity re-review)', async () => {
+    // Regression guard for the maturity-gate bypass: an approved author lowering
+    // contentRating ('x'→'g') must NOT apply in place (the public SFW filter would
+    // then show a still-mature listing to SFW users). It routes through a shadow.
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent({ contentRating: 'x' }));
+    mockRead.appListing.findFirst.mockResolvedValue(null); // no existing shadow
+    mockWrite.appListing.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: 'apl_new_1' });
+    const res = await updateListing({
+      listingId: 'apl_parent',
+      patch: { contentRating: 'g' },
+      userId: OWNER,
+    });
+    expect(res.requiresReview).toBe(true);
+    expect(res.shadowId).toBe('apl_new_1');
+    // The contentRating change landed on the SHADOW, never the live parent.
+    const updateCalls = mockWrite.appListing.update.mock.calls.map((c) => c[0]);
+    expect(updateCalls).toContainEqual({
+      where: { id: 'apl_new_1' },
+      data: { contentRating: 'g' },
+    });
+    expect(updateCalls.every((c) => (c as { where: { id: string } }).where.id !== 'apl_parent')).toBe(
+      true
+    );
+  });
+
+  it('DRAFT + contentRating change → edits IN PLACE (no shadow — pre-approval, no gate to bypass)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(
+      approvedParent({ status: 'draft', contentRating: 'x' })
+    );
+    const res = await updateListing({
+      listingId: 'apl_parent',
+      patch: { contentRating: 'g' },
+      userId: OWNER,
+    });
+    expect(res.requiresReview).toBe(false);
+    expect(res.shadowId).toBeNull();
+    expect(mockWrite.appListing.update).toHaveBeenCalledWith({
+      where: { id: 'apl_parent' },
+      data: { contentRating: 'g' },
+    });
     expect(mockWrite.appListing.create).not.toHaveBeenCalled();
   });
 
@@ -368,6 +415,36 @@ describe('beginListingRevision', () => {
     expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
+  it('P2002 on insert (a concurrent creator won the partial-UNIQUE) → idempotent reuse of the winning shadow', async () => {
+    // Two creators race past the pre-tx + in-tx read-checks (neither sees the
+    // other's uncommitted row); the loser's INSERT hits the partial-UNIQUE index
+    // on revision_of_id → P2002. It must collapse to the winner, not throw.
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent());
+    mockRead.appListing.findFirst.mockResolvedValue(null); // pre-tx idempotent check → none
+    mockWrite.appListing.findFirst
+      .mockResolvedValueOnce(null) // in-tx race check → none
+      .mockResolvedValueOnce({ id: 'apl_winner_shadow' }); // post-tx winner re-read
+    mockWrite.appListing.create.mockRejectedValueOnce(
+      Object.assign(new Error('Unique constraint failed'), { code: 'P2002' })
+    );
+
+    const res = await beginListingRevision({ listingId: 'apl_parent', userId: OWNER });
+    // Reused the concurrent winner (created: false — we did not mint it).
+    expect(res).toEqual({ shadowId: 'apl_winner_shadow', created: false });
+  });
+
+  it('a NON-P2002 insert error is re-thrown (not swallowed as idempotent reuse)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedParent());
+    mockRead.appListing.findFirst.mockResolvedValue(null);
+    mockWrite.appListing.findFirst.mockResolvedValueOnce(null); // in-tx race check
+    mockWrite.appListing.create.mockRejectedValueOnce(
+      Object.assign(new Error('deadlock detected'), { code: 'P2034' })
+    );
+    await expect(
+      beginListingRevision({ listingId: 'apl_parent', userId: OWNER })
+    ).rejects.toThrow('deadlock detected');
+  });
+
   it('non-approved parent → INVALID_REVISION', async () => {
     mockRead.appListing.findUnique.mockResolvedValue(approvedParent({ status: 'pending' }));
     await expect(
@@ -496,11 +573,11 @@ describe('approveExternalRequest (revision apply)', () => {
       coverId: 6,
       revisionOfId: 'apl_parent',
     };
-    // Parent load (dbRead) inside applyApprovedRevision.
+    // Parent load (dbRead) inside applyApprovedRevision — must still be approved.
     mockRead.appListing.findUnique.mockImplementation(
       findUniqueById({
         apl_shadow: shadowListing as Row,
-        apl_parent: { id: 'apl_parent', slug: 'cool-app' } as Row,
+        apl_parent: { id: 'apl_parent', slug: 'cool-app', status: 'approved' } as Row,
       })
     );
     // In-tx authoritative shadow re-read (dbWrite) — full scalars to copy.
@@ -604,6 +681,34 @@ describe('approveExternalRequest (revision apply)', () => {
     expect(mockWrite.appListing.update).not.toHaveBeenCalled();
     expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
   });
+
+  it('parent no longer approved (mod REMOVED it after submit) → INVALID_REVISION, nothing copied', async () => {
+    // Guards the confusing "approved request → still-hidden listing" state: applying
+    // the shadow's scalars onto a removed parent would not flip its status back to
+    // approved. Refuse before touching the request/parent.
+    stageRevisionApprove();
+    mockRead.appListing.findUnique.mockImplementation(
+      findUniqueById({
+        apl_shadow: {
+          id: 'apl_shadow',
+          status: 'draft',
+          externalUrl: 'https://cool.example.com/edited',
+          iconId: 5,
+          coverId: 6,
+          revisionOfId: 'apl_parent',
+        } as Row,
+        apl_parent: { id: 'apl_parent', slug: 'cool-app', status: 'removed' } as Row,
+      })
+    );
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_rev', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'INVALID_REVISION' });
+    // No re-point, no scalar copy, no shadow delete — the whole apply is refused
+    // before the transaction.
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -652,20 +757,22 @@ describe('reject/withdraw a pending REVISION', () => {
 // ---------------------------------------------------------------------------
 
 describe('listMySubmissions (shadow handling)', () => {
-  it('excludes shadow-targeting requests from the query and flags parents with a pending revision', async () => {
-    // The query returns only the parent's own (non-shadow) request; assert the WHERE
-    // excludes shadow-targeting requests.
-    mockRead.appListingPublishRequest.findMany.mockResolvedValue([
-      {
-        id: 'alpr_parent',
-        appListingId: 'apl_parent',
-        slug: 'cool-app',
-        status: 'approved',
-        appListing: { name: 'Cool App', revisionOfId: null },
-      },
-    ]);
-    // A shadow exists for apl_parent → hasPendingRevision should be true.
-    mockRead.appListing.findMany.mockResolvedValue([{ revisionOfId: 'apl_parent' }]);
+  /** The parent's own (non-shadow) request row as the main query returns it. */
+  const parentRequestRow = {
+    id: 'alpr_parent',
+    appListingId: 'apl_parent',
+    slug: 'cool-app',
+    status: 'approved',
+    appListing: { name: 'Cool App', revisionOfId: null },
+  };
+
+  it('excludes shadow-targeting requests from the main query and flags a parent with a PENDING revision request', async () => {
+    // findMany is called TWICE: (1) the main rows query, (2) the pending-revision
+    // detection. Chain the two responses.
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([parentRequestRow])
+      // (2) a PENDING request targets a shadow of apl_parent → hasPendingRevision.
+      .mockResolvedValueOnce([{ appListing: { revisionOfId: 'apl_parent' } }]);
 
     const res = await listMySubmissions({ userId: OWNER });
 
@@ -677,21 +784,37 @@ describe('listMySubmissions (shadow handling)', () => {
     // Shadow-targeting requests are excluded (OR: appListingId null OR parent listing).
     expect(where.OR).toEqual([{ appListingId: null }, { appListing: { revisionOfId: null } }]);
 
+    // The detection query filters on a PENDING request targeting a shadow — NOT on
+    // shadow existence (an abandoned shadow has no such request).
+    const revWhere = mockRead.appListingPublishRequest.findMany.mock.calls[1][0].where as Record<
+      string,
+      unknown
+    >;
+    expect(revWhere).toMatchObject({
+      status: 'pending',
+      kind: 'offsite',
+      appListing: { revisionOfId: { in: ['apl_parent'] } },
+    });
+
     expect(res.items).toHaveLength(1);
     expect(res.items[0]).toMatchObject({ id: 'alpr_parent', hasPendingRevision: true });
   });
 
-  it('a parent with NO in-flight shadow → hasPendingRevision false', async () => {
-    mockRead.appListingPublishRequest.findMany.mockResolvedValue([
-      {
-        id: 'alpr_parent',
-        appListingId: 'apl_parent',
-        slug: 'cool-app',
-        status: 'approved',
-        appListing: { name: 'Cool App', revisionOfId: null },
-      },
-    ]);
-    mockRead.appListing.findMany.mockResolvedValue([]); // no shadows
+  it('a parent with NO pending revision request → hasPendingRevision false', async () => {
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([parentRequestRow])
+      .mockResolvedValueOnce([]); // no pending revision requests
+    const res = await listMySubmissions({ userId: OWNER });
+    expect(res.items[0]).toMatchObject({ hasPendingRevision: false });
+  });
+
+  it('an ABANDONED shadow (opened but never submitted → no pending request) does NOT badge the parent', async () => {
+    // Regression guard for the 🟢 fix: hasPendingRevision is derived from a PENDING
+    // publish request, not from shadow existence. A shadow that was created but
+    // never submitted produces no pending request → the detection query returns [].
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([parentRequestRow])
+      .mockResolvedValueOnce([]); // shadow exists in the DB, but no PENDING request targets it
     const res = await listMySubmissions({ userId: OWNER });
     expect(res.items[0]).toMatchObject({ hasPendingRevision: false });
   });

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -454,6 +454,9 @@ export async function listAvailableListings(
     FROM app_listings al
     LEFT JOIN app_listing_metrics m ON m.app_listing_id = al.id
     WHERE al.status = 'approved'
+      -- Never surface a SHADOW revision draft. Shadows are status='draft' so the
+      -- approved-only filter already hides them; this is defense-in-depth.
+      AND al.revision_of_id IS NULL
       AND (${kindParam}::text IS NULL OR al.kind = ${kindParam}::text)
       AND (${categoryParam}::text IS NULL OR al.category = ${categoryParam}::text)
       AND ${listingMatureFilter(redCapable)}
@@ -507,9 +510,12 @@ export async function getListingDetail(
   // undefined })` would return an ARBITRARY approved row (enumeration footgun);
   // both → ambiguous. Fail closed to null in either case.
   if (!input.id === !input.slug) return null;
+  // `revisionOfId: null` is defense-in-depth: a shadow is status='draft' (already
+  // excluded by the approved-only check below), but never let a crafted id reach a
+  // shadow's data through this public read.
   const where: Prisma.AppListingWhereInput = input.id
-    ? { id: input.id }
-    : { slug: input.slug };
+    ? { id: input.id, revisionOfId: null }
+    : { slug: input.slug, revisionOfId: null };
 
   const row = await dbRead.appListing.findFirst({
     where,

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -348,8 +348,18 @@ async function deleteDraftListing(
 //   removed          → mod-only takedown → FORBIDDEN for an author edit.
 // ---------------------------------------------------------------------------
 
-/** MATERIAL scalar fields — a change to any of these on an approved listing forces re-review. */
-const MATERIAL_PATCH_FIELDS = ['externalUrl', 'name'] as const;
+/**
+ * MATERIAL scalar fields — a change to ANY of these on an approved listing forces
+ * re-review (routes through a shadow revision, not an in-place edit).
+ *
+ * `contentRating` is material because it drives the public SFW filter
+ * (`content_rating NOT IN ('r','x')`): letting an approved author lower an 'x'/'r'
+ * listing to 'g' in place with no mod re-review would surface a still-mature
+ * listing to SFW users. `externalUrl`/`name` are the listing's identity/destination.
+ * `tagline`/`description`/`category` stay trivial — quick copy edits are intended
+ * and are delistable if abused.
+ */
+const MATERIAL_PATCH_FIELDS = ['externalUrl', 'name', 'contentRating'] as const;
 
 /**
  * Validate + normalize an update patch (shared by the in-place + shadow paths).
@@ -387,18 +397,29 @@ function buildListingPatchData(patch: UpdateListingPatch): Prisma.AppListingUpda
   return data;
 }
 
-/** True iff the patch changes a MATERIAL field to a value DIFFERENT from the live listing. */
+/**
+ * True iff the patch changes a MATERIAL field (see MATERIAL_PATCH_FIELDS) to a
+ * value DIFFERENT from the live listing. Iterates the material-field list so the
+ * set is edited in ONE place; `externalUrl` compares against the validator's
+ * canonical form, the rest are plain scalar inequality.
+ */
 function patchHasMaterialChange(
   patch: UpdateListingPatch,
-  live: { externalUrl: string | null; name: string }
+  live: { externalUrl: string | null; name: string; contentRating: string | null }
 ): boolean {
-  if (patch.externalUrl !== undefined) {
-    const url = validateExternalUrl(patch.externalUrl);
-    // An invalid URL is a material change (it will be rejected downstream, but it
-    // is not "unchanged").
-    if (!url.ok || url.url !== live.externalUrl) return true;
+  for (const field of MATERIAL_PATCH_FIELDS) {
+    const patched = patch[field];
+    if (patched === undefined) continue;
+    if (field === 'externalUrl') {
+      const url = validateExternalUrl(patched);
+      // An invalid URL is a material change (it will be rejected downstream, but
+      // it is not "unchanged").
+      if (!url.ok || url.url !== live.externalUrl) return true;
+      continue;
+    }
+    // name / contentRating: plain scalar inequality vs the live value.
+    if (patched !== live[field]) return true;
   }
-  if (patch.name !== undefined && patch.name !== live.name) return true;
   return false;
 }
 
@@ -517,6 +538,7 @@ export async function updateListing(opts: {
       const material = patchHasMaterialChange(patch, {
         externalUrl: listing.externalUrl,
         name: listing.name,
+        contentRating: listing.contentRating,
       });
       if (!material) {
         // TRIVIAL-only edit → apply to the LIVE row in place (no re-review). Any
@@ -588,55 +610,68 @@ export async function beginListingRevision(opts: {
   // @unique, so it must not collide with the parent or any other listing.
   const shadowSlug = `rev-${newUlid()}`;
 
-  await dbWrite.$transaction(async (tx) => {
-    // Re-check inside the tx (primary) that no shadow was created concurrently.
-    const race = await tx.appListing.findFirst({
-      where: { revisionOfId: listingId },
-      select: { id: true },
-    });
-    if (race) return; // lost the race — the other caller's shadow stands.
-    await tx.appListing.create({
-      data: {
-        id: shadowId,
-        kind: parent.kind,
-        status: 'draft',
-        slug: shadowSlug,
-        revisionOfId: listingId,
-        name: parent.name,
-        tagline: parent.tagline,
-        description: parent.description,
-        category: parent.category,
-        contentRating: parent.contentRating,
-        externalUrl: parent.externalUrl,
-        connectClientId: parent.connectClientId,
-        iconId: parent.iconId,
-        coverId: parent.coverId,
-        // A shadow has NO backing AppBlock (appBlockId is @unique — it stays on
-        // the parent) and no publish request yet (submitListingRevision adds it).
-        appBlockId: null,
-        userId: parent.userId,
-      },
-    });
-    const shots = await tx.appListingScreenshot.findMany({
-      where: { appListingId: listingId },
-      select: { imageId: true, order: true, caption: true },
-      orderBy: { order: 'asc' },
-    });
-    if (shots.length > 0) {
-      await tx.appListingScreenshot.createMany({
-        data: shots.map((s: { imageId: number | null; order: number; caption: string | null }) => ({
-          id: newAppListingScreenshotId(),
-          appListingId: shadowId,
-          imageId: s.imageId,
-          order: s.order,
-          caption: s.caption,
-        })),
+  try {
+    await dbWrite.$transaction(async (tx) => {
+      // Re-check inside the tx (primary) that no shadow was created concurrently.
+      const race = await tx.appListing.findFirst({
+        where: { revisionOfId: listingId },
+        select: { id: true },
       });
-    }
-  });
+      if (race) return; // lost the race — the other caller's shadow stands.
+      await tx.appListing.create({
+        data: {
+          id: shadowId,
+          kind: parent.kind,
+          status: 'draft',
+          slug: shadowSlug,
+          revisionOfId: listingId,
+          name: parent.name,
+          tagline: parent.tagline,
+          description: parent.description,
+          category: parent.category,
+          contentRating: parent.contentRating,
+          externalUrl: parent.externalUrl,
+          connectClientId: parent.connectClientId,
+          iconId: parent.iconId,
+          coverId: parent.coverId,
+          // A shadow has NO backing AppBlock (appBlockId is @unique — it stays on
+          // the parent) and no publish request yet (submitListingRevision adds it).
+          appBlockId: null,
+          userId: parent.userId,
+        },
+      });
+      const shots = await tx.appListingScreenshot.findMany({
+        where: { appListingId: listingId },
+        select: { imageId: true, order: true, caption: true },
+        orderBy: { order: 'asc' },
+      });
+      if (shots.length > 0) {
+        await tx.appListingScreenshot.createMany({
+          data: shots.map((s: { imageId: number | null; order: number; caption: string | null }) => ({
+            id: newAppListingScreenshotId(),
+            appListingId: shadowId,
+            imageId: s.imageId,
+            order: s.order,
+            caption: s.caption,
+          })),
+        });
+      }
+    });
+  } catch (err) {
+    // A concurrent creator committed its shadow between our in-tx read-check and
+    // our INSERT → the partial-UNIQUE index on revision_of_id (WHERE NOT NULL)
+    // rejects the duplicate with P2002. Collapse to the idempotent-reuse path
+    // (the winner re-read below returns the standing shadow) instead of
+    // surfacing the race as an error. Duck-type on `code` (the Prisma error
+    // class isn't reliably constructible with a stale client). Re-throw anything
+    // else.
+    const code = (err as { code?: unknown })?.code;
+    if (code !== 'P2002') throw err;
+  }
 
-  // If we lost the concurrent-create race the row we minted was never written;
-  // re-read the winning shadow so the caller always gets a live shadow id.
+  // If we lost the concurrent-create race (in-tx read-check OR a P2002 on
+  // insert) the row we minted was never written; re-read the winning shadow so
+  // the caller always gets a live shadow id.
   const winner = await dbWrite.appListing.findFirst({
     where: { revisionOfId: listingId },
     select: { id: true },
@@ -1015,10 +1050,20 @@ async function applyApprovedRevision(opts: {
   // Parent must still exist (defense — its delete would CASCADE the shadow away).
   const parent = await dbRead.appListing.findUnique({
     where: { id: parentId },
-    select: { id: true, slug: true },
+    select: { id: true, slug: true, status: true },
   });
   if (!parent) {
     throw new OffsiteRequestError('NOT_FOUND', `parent listing ${parentId} not found`);
+  }
+  // The live parent must still be APPROVED. If a mod REMOVED (took down) or
+  // otherwise un-approved it after this revision was submitted, applying the
+  // shadow's scalars would leave a confusing "approved request → still-hidden
+  // listing" state (the copy doesn't flip status). Refuse instead.
+  if (parent.status !== 'approved') {
+    throw new OffsiteRequestError(
+      'INVALID_REVISION',
+      `the live listing is no longer approved (status is ${parent.status}); cannot apply this revision`
+    );
   }
 
   await dbWrite.$transaction(async (tx) => {
@@ -1300,19 +1345,30 @@ export async function listMySubmissions(
   const hasNext = rows.length > limit;
   const page = hasNext ? rows.slice(0, limit) : rows;
 
-  // Flag which parent listings on this page have an in-flight shadow revision.
+  // Flag which parent listings on this page have a revision UNDER REVIEW. This is
+  // derived from the existence of a PENDING publish request that targets a shadow
+  // (a `revisionOfId`-bearing listing) for the parent — NOT from mere shadow
+  // existence. An abandoned shadow (opened via beginListingRevision but never
+  // submitListingRevision-ed → no pending request) must NOT falsely badge the
+  // parent "revision in review".
   const parentIds = page
     .map((r) => r.appListingId)
     .filter((id): id is string => id != null);
-  const shadows =
+  const pendingRevisionReqs =
     parentIds.length > 0
-      ? await dbRead.appListing.findMany({
-          where: { revisionOfId: { in: parentIds } },
-          select: { revisionOfId: true },
+      ? await dbRead.appListingPublishRequest.findMany({
+          where: {
+            status: 'pending',
+            kind: 'offsite',
+            appListing: { revisionOfId: { in: parentIds } },
+          },
+          select: { appListing: { select: { revisionOfId: true } } },
         })
       : [];
   const parentsWithRevision = new Set(
-    shadows.map((s) => s.revisionOfId).filter((id): id is string => id != null)
+    pendingRevisionReqs
+      .map((r) => r.appListing?.revisionOfId)
+      .filter((id): id is string => id != null)
   );
   const items = page.map((r) => ({
     ...r,

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from '@trpc/server';
+import type { Prisma } from '@prisma/client';
 
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
@@ -14,7 +15,13 @@ import {
 } from '~/server/schema/blocks/offsite-listing.schema';
 import { assertListingAssetsComplete } from '~/server/services/blocks/app-listing-assets.service';
 import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
-import { newAppListingId, newAppListingPublishRequestId } from '~/server/utils/app-block-ids';
+import {
+  newAppListingId,
+  newAppListingPublishRequestId,
+  newAppListingScreenshotId,
+  newUlid,
+} from '~/server/utils/app-block-ids';
+import type { UpdateListingPatch } from '~/server/schema/blocks/offsite-listing.schema';
 
 /**
  * App Store Listings (W13) — P3a OFF-SITE submission service (Design B1).
@@ -45,7 +52,17 @@ import { newAppListingId, newAppListingPublishRequestId } from '~/server/utils/a
 // Typed failure modes for withdrawExternalRequest (mirror WithdrawRequestError).
 // ---------------------------------------------------------------------------
 
-export type OffsiteRequestErrorCode = 'NOT_FOUND' | 'NOT_OWNED' | 'NOT_PENDING';
+export type OffsiteRequestErrorCode =
+  | 'NOT_FOUND'
+  | 'NOT_OWNED'
+  | 'NOT_PENDING'
+  // Author tried to edit a `removed` (mod-taken-down) listing — mod-only.
+  | 'FORBIDDEN'
+  // Author tried to edit a `rejected` listing (no row exists) — resubmit instead.
+  | 'MUST_RESUBMIT'
+  // A shadow-draft revision precondition failed (not a shadow / not a draft /
+  // a concurrent revision is already pending / the parent isn't approved).
+  | 'INVALID_REVISION';
 
 export class OffsiteRequestError extends Error {
   readonly code: OffsiteRequestErrorCode;
@@ -231,6 +248,13 @@ export async function submitExternalListing(opts: {
  * orphan draft accrues; the delete is status-guarded (`status:'draft'`) so it can
  * never remove an approved listing.
  *
+ * REVISION-AWARE (no branch needed): a pending REVISION request points at a SHADOW
+ * `AppListing`, which is itself `status:'draft'`. So the same status-guarded
+ * `deleteDraftListing` deletes ONLY the shadow — the LIVE parent (a separate,
+ * `approved` row, never referenced by this request's `appListingId`) is untouched
+ * and stays live. Withdrawing a revision therefore behaves exactly like withdrawing
+ * a first-time submission, by construction.
+ *
  * CONCURRENCY (TOCTOU): the `findUnique` only CLASSIFIES; the mutation is a
  * status-guarded `updateMany({ id, status:'pending' })`, so a withdraw that read
  * `pending` can't clobber a row a concurrent approve flipped. If the guarded
@@ -306,6 +330,431 @@ async function deleteDraftListing(
 ): Promise<void> {
   if (!appListingId) return;
   await client.appListing.deleteMany({ where: { id: appListingId, status: 'draft' } });
+}
+
+// ---------------------------------------------------------------------------
+// updateListing / beginListingRevision / submitListingRevision (author) —
+// edit an off-site listing WITHOUT withdrawing it (shadow-draft revision).
+//
+// State machine (on the LIVE listing's status):
+//   draft | pending  → edit IN PLACE (no re-review). A pending listing's existing
+//                      pending request keeps reviewing the now-updated row.
+//   approved         → the live version STAYS LIVE. A TRIVIAL-only edit (tagline/
+//                      description/category/contentRating) applies in place; any
+//                      MATERIAL change (externalUrl/name — or assets, edited
+//                      separately) is staged on a hidden DRAFT clone (the shadow)
+//                      and applied to the parent only on mod re-approve.
+//   rejected         → no row exists (reject deletes it) → MUST_RESUBMIT.
+//   removed          → mod-only takedown → FORBIDDEN for an author edit.
+// ---------------------------------------------------------------------------
+
+/** MATERIAL scalar fields — a change to any of these on an approved listing forces re-review. */
+const MATERIAL_PATCH_FIELDS = ['externalUrl', 'name'] as const;
+
+/**
+ * Validate + normalize an update patch (shared by the in-place + shadow paths).
+ * Re-runs the shared URL / category / contentRating validators (this fn is
+ * exported + unit-tested directly, so it can't trust the schema boundary) and
+ * returns a Prisma `data` object carrying ONLY the fields the patch actually set
+ * (an omitted field is left untouched; an explicit `null` clears a nullable one).
+ * `externalUrl` is normalized to the validator's canonical form.
+ */
+function buildListingPatchData(patch: UpdateListingPatch): Prisma.AppListingUpdateInput {
+  const data: Prisma.AppListingUpdateInput = {};
+  if (patch.externalUrl !== undefined) {
+    const url = validateExternalUrl(patch.externalUrl);
+    if (!url.ok) throw new TRPCError({ code: 'BAD_REQUEST', message: url.error });
+    data.externalUrl = url.url;
+  }
+  if (patch.name !== undefined) data.name = patch.name;
+  if (patch.tagline !== undefined) data.tagline = patch.tagline;
+  if (patch.description !== undefined) data.description = patch.description;
+  if (patch.category !== undefined) {
+    if (patch.category != null && !isMarketplaceCategory(patch.category)) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: `unknown category "${patch.category}"` });
+    }
+    data.category = patch.category;
+  }
+  if (patch.contentRating !== undefined) {
+    if (!(OFFSITE_CONTENT_RATINGS as readonly string[]).includes(patch.contentRating)) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `unknown content rating "${patch.contentRating}"`,
+      });
+    }
+    data.contentRating = patch.contentRating;
+  }
+  return data;
+}
+
+/** True iff the patch changes a MATERIAL field to a value DIFFERENT from the live listing. */
+function patchHasMaterialChange(
+  patch: UpdateListingPatch,
+  live: { externalUrl: string | null; name: string }
+): boolean {
+  if (patch.externalUrl !== undefined) {
+    const url = validateExternalUrl(patch.externalUrl);
+    // An invalid URL is a material change (it will be rejected downstream, but it
+    // is not "unchanged").
+    if (!url.ok || url.url !== live.externalUrl) return true;
+  }
+  if (patch.name !== undefined && patch.name !== live.name) return true;
+  return false;
+}
+
+export type UpdateListingResult = {
+  /** The LIVE listing id (unchanged — a shadow never surfaces its own id here). */
+  listingId: string;
+  /** The listing's status after the edit (unchanged for a live listing). */
+  status: string;
+  /** True when the edit was staged for mod re-review (approved-material path). */
+  requiresReview: boolean;
+  /** The shadow id created/reused for a staged revision, else null. */
+  shadowId: string | null;
+};
+
+/**
+ * A minimal listing projection used by the author edit paths (owner-check + state).
+ */
+type EditableListing = {
+  id: string;
+  kind: string;
+  slug: string;
+  status: string;
+  userId: number;
+  revisionOfId: string | null;
+  name: string;
+  tagline: string | null;
+  description: string | null;
+  category: string | null;
+  contentRating: string | null;
+  externalUrl: string | null;
+  connectClientId: string | null;
+  iconId: number | null;
+  coverId: number | null;
+};
+
+const editableListingSelect = {
+  id: true,
+  kind: true,
+  slug: true,
+  status: true,
+  userId: true,
+  revisionOfId: true,
+  name: true,
+  tagline: true,
+  description: true,
+  category: true,
+  contentRating: true,
+  externalUrl: true,
+  connectClientId: true,
+  iconId: true,
+  coverId: true,
+} as const;
+
+/** Load a listing and assert the caller is its OWNER (strict — no mod override on the author edit path). */
+async function loadOwnedEditableListing(
+  listingId: string,
+  userId: number
+): Promise<EditableListing> {
+  const listing = (await dbRead.appListing.findUnique({
+    where: { id: listingId },
+    select: editableListingSelect,
+  })) as EditableListing | null;
+  if (!listing) {
+    throw new OffsiteRequestError('NOT_FOUND', `listing ${listingId} not found`);
+  }
+  if (listing.userId !== userId) {
+    throw new OffsiteRequestError('NOT_OWNED', 'you can only edit your own listings');
+  }
+  return listing;
+}
+
+/**
+ * AUTHOR: edit an off-site listing without withdrawing it. State-aware (see the
+ * section header). Owner-bound (non-owner → NOT_OWNED/FORBIDDEN). Returns the
+ * LIVE listing id + whether the edit was staged for re-review.
+ */
+export async function updateListing(opts: {
+  listingId: string;
+  patch: UpdateListingPatch;
+  userId: number;
+}): Promise<UpdateListingResult> {
+  const { listingId, patch, userId } = opts;
+  const listing = await loadOwnedEditableListing(listingId, userId);
+
+  // A shadow is an internal draft — never editable via this top-level path (its
+  // scalars are edited by updateListing's approved-material branch / asset procs).
+  if (listing.revisionOfId != null) {
+    throw new OffsiteRequestError(
+      'INVALID_REVISION',
+      'this listing is an internal revision draft and cannot be edited directly'
+    );
+  }
+
+  switch (listing.status) {
+    case 'removed':
+      throw new OffsiteRequestError(
+        'FORBIDDEN',
+        'this listing has been removed by a moderator and can no longer be edited'
+      );
+    case 'rejected':
+      // reject() deletes the draft, so this row usually doesn't exist (→ NOT_FOUND
+      // above). If a rejected row somehow persists, steer the caller to resubmit.
+      throw new OffsiteRequestError(
+        'MUST_RESUBMIT',
+        'this listing was rejected; submit a new listing instead of editing it'
+      );
+    case 'draft':
+    case 'pending': {
+      // Edit IN PLACE — no re-review. A pending listing's existing pending request
+      // keeps reviewing the now-updated row (it references the row, not a snapshot).
+      const data = buildListingPatchData(patch);
+      await dbWrite.appListing.update({ where: { id: listingId }, data });
+      return { listingId, status: listing.status, requiresReview: false, shadowId: null };
+    }
+    case 'approved': {
+      const material = patchHasMaterialChange(patch, {
+        externalUrl: listing.externalUrl,
+        name: listing.name,
+      });
+      if (!material) {
+        // TRIVIAL-only edit → apply to the LIVE row in place (no re-review). Any
+        // material key present is byte-identical to the live value (material ===
+        // false), so writing it is a harmless no-op.
+        const data = buildListingPatchData(patch);
+        await dbWrite.appListing.update({ where: { id: listingId }, data });
+        return { listingId, status: listing.status, requiresReview: false, shadowId: null };
+      }
+      // MATERIAL change → stage on a shadow. The parent stays LIVE untouched; the
+      // FULL patch (material + trivial) is written to the shadow. Assets are edited
+      // separately against the shadow id, then submitListingRevision re-reviews it.
+      const { shadowId } = await beginListingRevision({ listingId, userId });
+      const data = buildListingPatchData(patch);
+      await dbWrite.appListing.update({ where: { id: shadowId }, data });
+      return { listingId, status: listing.status, requiresReview: true, shadowId };
+    }
+    default:
+      throw new OffsiteRequestError(
+        'INVALID_REVISION',
+        `cannot edit a listing in status ${listing.status}`
+      );
+  }
+}
+
+export type BeginListingRevisionResult = { shadowId: string; created: boolean };
+
+/**
+ * AUTHOR: create (or re-open) a shadow-draft revision of an APPROVED listing.
+ *
+ * Idempotent: if a shadow (an AppListing with revisionOfId === parentId) already
+ * exists it is returned as-is (so re-entering the edit flow doesn't clone a second
+ * shadow). Otherwise the approved parent is cloned into a hidden DRAFT AppListing
+ * — scalars copied, appBlockId NULL, a synthetic unique slug (`rev-<ulid>`, never
+ * public), revisionOfId = parentId, owned by the parent's owner — and each of the
+ * parent's screenshots is copied (imageId/order/caption). The author then edits
+ * the shadow's ASSETS via the EXISTING setIcon/setCover/addScreenshot procs by
+ * passing the shadow id (no new asset procs).
+ */
+export async function beginListingRevision(opts: {
+  listingId: string;
+  userId: number;
+}): Promise<BeginListingRevisionResult> {
+  const { listingId, userId } = opts;
+  const parent = await loadOwnedEditableListing(listingId, userId);
+
+  if (parent.revisionOfId != null) {
+    throw new OffsiteRequestError(
+      'INVALID_REVISION',
+      'cannot open a revision of a revision draft'
+    );
+  }
+  if (parent.status !== 'approved') {
+    throw new OffsiteRequestError(
+      'INVALID_REVISION',
+      `only an approved listing can be revised (status is ${parent.status})`
+    );
+  }
+
+  // Idempotent reuse: a parent has at most one in-flight shadow.
+  const existing = await dbRead.appListing.findFirst({
+    where: { revisionOfId: listingId },
+    select: { id: true },
+  });
+  if (existing) return { shadowId: existing.id, created: false };
+
+  const shadowId = newAppListingId();
+  // Synthetic, globally-unique slug: the shadow is never public, but slug is
+  // @unique, so it must not collide with the parent or any other listing.
+  const shadowSlug = `rev-${newUlid()}`;
+
+  await dbWrite.$transaction(async (tx) => {
+    // Re-check inside the tx (primary) that no shadow was created concurrently.
+    const race = await tx.appListing.findFirst({
+      where: { revisionOfId: listingId },
+      select: { id: true },
+    });
+    if (race) return; // lost the race — the other caller's shadow stands.
+    await tx.appListing.create({
+      data: {
+        id: shadowId,
+        kind: parent.kind,
+        status: 'draft',
+        slug: shadowSlug,
+        revisionOfId: listingId,
+        name: parent.name,
+        tagline: parent.tagline,
+        description: parent.description,
+        category: parent.category,
+        contentRating: parent.contentRating,
+        externalUrl: parent.externalUrl,
+        connectClientId: parent.connectClientId,
+        iconId: parent.iconId,
+        coverId: parent.coverId,
+        // A shadow has NO backing AppBlock (appBlockId is @unique — it stays on
+        // the parent) and no publish request yet (submitListingRevision adds it).
+        appBlockId: null,
+        userId: parent.userId,
+      },
+    });
+    const shots = await tx.appListingScreenshot.findMany({
+      where: { appListingId: listingId },
+      select: { imageId: true, order: true, caption: true },
+      orderBy: { order: 'asc' },
+    });
+    if (shots.length > 0) {
+      await tx.appListingScreenshot.createMany({
+        data: shots.map((s: { imageId: number | null; order: number; caption: string | null }) => ({
+          id: newAppListingScreenshotId(),
+          appListingId: shadowId,
+          imageId: s.imageId,
+          order: s.order,
+          caption: s.caption,
+        })),
+      });
+    }
+  });
+
+  // If we lost the concurrent-create race the row we minted was never written;
+  // re-read the winning shadow so the caller always gets a live shadow id.
+  const winner = await dbWrite.appListing.findFirst({
+    where: { revisionOfId: listingId },
+    select: { id: true },
+  });
+  if (!winner) {
+    throw new OffsiteRequestError('INVALID_REVISION', 'failed to open a revision draft');
+  }
+  return { shadowId: winner.id, created: winner.id === shadowId };
+}
+
+export type SubmitListingRevisionResult = {
+  publishRequestId: string;
+  shadowId: string;
+  /** The PUBLIC parent slug denormalized onto the review-queue request. */
+  slug: string;
+};
+
+/**
+ * AUTHOR: submit a prepared shadow-draft revision for mod re-approval. Asserts the
+ * shadow is a draft revision (revisionOfId set), asset-complete, and URL-valid,
+ * then creates a pending AppListingPublishRequest pointing at the SHADOW but
+ * carrying the PUBLIC PARENT slug (so the queue reads the live slug). Idempotent /
+ * concurrency-guarded: a shadow that already has a pending request returns it
+ * rather than creating a second concurrent pending revision.
+ */
+export async function submitListingRevision(opts: {
+  shadowId: string;
+  userId: number;
+  changelog?: string | null;
+}): Promise<SubmitListingRevisionResult> {
+  const { shadowId, userId } = opts;
+  const changelog = opts.changelog ?? null;
+
+  const shadow = (await dbRead.appListing.findUnique({
+    where: { id: shadowId },
+    select: {
+      id: true,
+      kind: true,
+      status: true,
+      userId: true,
+      revisionOfId: true,
+      externalUrl: true,
+      iconId: true,
+      coverId: true,
+      revisionOf: { select: { slug: true, status: true } },
+    },
+  })) as
+    | {
+        id: string;
+        kind: string;
+        status: string;
+        userId: number;
+        revisionOfId: string | null;
+        externalUrl: string | null;
+        iconId: number | null;
+        coverId: number | null;
+        revisionOf: { slug: string; status: string } | null;
+      }
+    | null;
+
+  if (!shadow) {
+    throw new OffsiteRequestError('NOT_FOUND', `revision draft ${shadowId} not found`);
+  }
+  if (shadow.userId !== userId) {
+    throw new OffsiteRequestError('NOT_OWNED', 'you can only submit your own revision');
+  }
+  if (shadow.revisionOfId == null || !shadow.revisionOf) {
+    throw new OffsiteRequestError('INVALID_REVISION', 'this listing is not a revision draft');
+  }
+  if (shadow.status !== 'draft') {
+    throw new OffsiteRequestError(
+      'INVALID_REVISION',
+      `a revision can only be submitted from draft (status is ${shadow.status})`
+    );
+  }
+
+  // Asset-completeness (authoritative on the primary — the asset mutators write to
+  // dbWrite, so a replica count could be stale-complete under lag) + URL re-validate.
+  const screenshotCount = await dbWrite.appListingScreenshot.count({
+    where: { appListingId: shadowId, imageId: { not: null } },
+  });
+  assertListingAssetsComplete({
+    iconId: shadow.iconId,
+    coverId: shadow.coverId,
+    screenshotCount,
+  });
+  const url = validateExternalUrl(shadow.externalUrl);
+  if (!url.ok) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `stored externalUrl is invalid and cannot be submitted: ${url.error}`,
+    });
+  }
+
+  // Guard a second concurrent pending revision: one open request per shadow.
+  const openRequest = await dbRead.appListingPublishRequest.findFirst({
+    where: { appListingId: shadowId, status: 'pending' },
+    select: { id: true, slug: true },
+  });
+  if (openRequest) {
+    return { publishRequestId: openRequest.id, shadowId, slug: openRequest.slug };
+  }
+
+  const publishRequestId = newAppListingPublishRequestId();
+  await dbWrite.appListingPublishRequest.create({
+    data: {
+      id: publishRequestId,
+      appListingId: shadowId,
+      kind: shadow.kind,
+      // Denormalize the PUBLIC parent slug so the mod queue reads the live slug,
+      // not the synthetic rev-<ulid>.
+      slug: shadow.revisionOf.slug,
+      submittedByUserId: userId,
+      status: 'pending',
+      changelog,
+    },
+  });
+  return { publishRequestId, shadowId, slug: shadow.revisionOf.slug };
 }
 
 // ---------------------------------------------------------------------------
@@ -399,11 +848,33 @@ export async function approveExternalRequest(opts: {
   // stale-complete). See step (5).
   const listing = await dbRead.appListing.findUnique({
     where: { id: appListingId },
-    select: { id: true, status: true, externalUrl: true, iconId: true, coverId: true },
+    select: {
+      id: true,
+      status: true,
+      externalUrl: true,
+      iconId: true,
+      coverId: true,
+      revisionOfId: true,
+    },
   });
   if (!listing) {
     throw new OffsiteRequestError('NOT_FOUND', `draft listing ${appListingId} not found`);
   }
+
+  // REVISION branch: the request points at a SHADOW (an edit of an approved
+  // parent), not a first-time draft. Apply the shadow onto its live parent instead
+  // of the first-time draft→approved flip. The NON-revision path below is
+  // deliberately left byte-for-behavior UNCHANGED.
+  if (listing.revisionOfId != null) {
+    return applyApprovedRevision({
+      request,
+      shadowId: appListingId,
+      parentId: listing.revisionOfId,
+      reviewerUserId,
+      approvalNotes,
+    });
+  }
+
   const screenshotCount = await dbRead.appListingScreenshot.count({
     where: { appListingId, imageId: { not: null } },
   });
@@ -509,6 +980,145 @@ export async function approveExternalRequest(opts: {
 }
 
 /**
+ * REVISION APPLY (shadow-draft): copy an approved shadow's contents onto its live
+ * parent, preserving the parent's id / slug / appBlockId / metric / reports, then
+ * retire the shadow. Called by {@link approveExternalRequest} when the request's
+ * listing has `revisionOfId` set.
+ *
+ * In ONE transaction (authoritative on the primary):
+ *   1. Re-load the shadow from the primary; re-assert it is still a draft revision,
+ *      asset-complete, and URL-valid (any failure rolls the whole tx back before
+ *      any mutation — the parent stays exactly as it was).
+ *   2. Flip the request pending→approved (status-guarded TOCTOU) AND re-point it at
+ *      the PARENT (so the approved request documents the live listing, and deleting
+ *      the shadow can't SetNull it — the FK is `onDelete: SetNull`).
+ *   3. Copy the shadow's scalars (name/tagline/description/category/contentRating/
+ *      externalUrl/iconId/coverId/connectClientId) onto the parent. NOT status /
+ *      slug / appBlockId / id — the live identity + placement are preserved.
+ *   4. REPARENT the shadow's screenshots onto the parent: delete the parent's
+ *      existing screenshot rows, then UPDATE the shadow's screenshots'
+ *      appListingId → parent BEFORE deleting the shadow, so the CASCADE on the
+ *      shadow delete drops nothing (the rows have already left the shadow).
+ *   5. Delete the shadow (guarded to a revision row so it can never remove a real
+ *      listing). Its screenshots are gone (moved) and its only request is re-pointed
+ *      at the parent, so the cascade is a no-op.
+ */
+async function applyApprovedRevision(opts: {
+  request: { id: string; slug: string; appListingId: string | null };
+  shadowId: string;
+  parentId: string;
+  reviewerUserId: number;
+  approvalNotes: string | null;
+}): Promise<ApproveExternalRequestResult> {
+  const { request, shadowId, parentId, reviewerUserId, approvalNotes } = opts;
+
+  // Parent must still exist (defense — its delete would CASCADE the shadow away).
+  const parent = await dbRead.appListing.findUnique({
+    where: { id: parentId },
+    select: { id: true, slug: true },
+  });
+  if (!parent) {
+    throw new OffsiteRequestError('NOT_FOUND', `parent listing ${parentId} not found`);
+  }
+
+  await dbWrite.$transaction(async (tx) => {
+    // (1) AUTHORITATIVE re-read of the shadow on the PRIMARY (row-consistent with
+    // the copy). The sibling asset mutators write to dbWrite, so a pre-tx replica
+    // gate could pass on stale-complete state — re-assert here.
+    const shadow = await tx.appListing.findUnique({
+      where: { id: shadowId },
+      select: {
+        id: true,
+        status: true,
+        revisionOfId: true,
+        name: true,
+        tagline: true,
+        description: true,
+        category: true,
+        contentRating: true,
+        externalUrl: true,
+        connectClientId: true,
+        iconId: true,
+        coverId: true,
+      },
+    });
+    if (!shadow || shadow.revisionOfId !== parentId || shadow.status !== 'draft') {
+      throw new OffsiteRequestError(
+        'NOT_PENDING',
+        'cannot approve — the revision draft is no longer available'
+      );
+    }
+    const screenshotCount = await tx.appListingScreenshot.count({
+      where: { appListingId: shadowId, imageId: { not: null } },
+    });
+    assertListingAssetsComplete({
+      iconId: shadow.iconId,
+      coverId: shadow.coverId,
+      screenshotCount,
+    });
+    const url = validateExternalUrl(shadow.externalUrl);
+    if (!url.ok) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `stored externalUrl is invalid and cannot be approved: ${url.error}`,
+      });
+    }
+
+    // (2) Flip the request pending→approved AND re-point it at the PARENT.
+    const req = await tx.appListingPublishRequest.updateMany({
+      where: { id: request.id, status: 'pending' },
+      data: {
+        status: 'approved',
+        reviewedByUserId: reviewerUserId,
+        reviewedAt: new Date(),
+        approvalNotes,
+        // Re-point at the live parent so (a) the approved request documents the
+        // live listing and (b) the shadow delete below can't SetNull this row.
+        appListingId: parentId,
+      },
+    });
+    if (req.count === 0) {
+      throw new OffsiteRequestError(
+        'NOT_PENDING',
+        'cannot approve — the request is no longer pending'
+      );
+    }
+
+    // (3) Copy scalars onto the parent (id / slug / appBlockId / status untouched).
+    await tx.appListing.update({
+      where: { id: parentId },
+      data: {
+        name: shadow.name,
+        tagline: shadow.tagline,
+        description: shadow.description,
+        category: shadow.category,
+        contentRating: shadow.contentRating,
+        externalUrl: shadow.externalUrl,
+        connectClientId: shadow.connectClientId,
+        iconId: shadow.iconId,
+        coverId: shadow.coverId,
+      },
+    });
+
+    // (4) Reparent screenshots BEFORE deleting the shadow (cascade-safe): drop the
+    // parent's current rows, then move the shadow's rows onto the parent.
+    await tx.appListingScreenshot.deleteMany({ where: { appListingId: parentId } });
+    await tx.appListingScreenshot.updateMany({
+      where: { appListingId: shadowId },
+      data: { appListingId: parentId },
+    });
+
+    // (5) Retire the shadow (guarded to a revision row). Screenshots already moved;
+    // the request already re-pointed — the cascade drops nothing.
+    await tx.appListing.deleteMany({
+      where: { id: shadowId, revisionOfId: { not: null } },
+    });
+  });
+
+  return { publishRequestId: request.id, listingId: parentId, slug: parent.slug };
+}
+
+/**
  * MOD reject of a pending off-site request. Requires a `rejectionReason` of ≥10
  * (trimmed) chars, then — in ONE transaction — flips the request
  * `pending → rejected` + sets `reviewedBy*` / `rejectionReason` and DELETES the
@@ -519,6 +1129,12 @@ export async function approveExternalRequest(opts: {
  * `updateMany` so a concurrent approve/withdraw that already flipped the row yields
  * NOT_PENDING (and, having matched 0, the tx rolls back before the delete).
  * Non-pending → NOT_PENDING.
+ *
+ * REVISION-AWARE (no branch needed): a pending REVISION request points at a SHADOW
+ * `AppListing`, which is `status:'draft'`, so the status-guarded `deleteDraftListing`
+ * deletes ONLY the shadow — the LIVE parent (a separate `approved` row) is untouched
+ * and stays live. Rejecting a revision therefore behaves exactly like rejecting a
+ * first-time submission, by construction.
  */
 export async function rejectExternalRequest(opts: {
   publishRequestId: string;
@@ -636,7 +1252,15 @@ const submissionSelect = {
   approvalNotes: true,
   changelog: true,
   appListing: {
-    select: { name: true, externalUrl: true, category: true, contentRating: true },
+    // `revisionOfId` lets a caller INFER whether a request targets a shadow (a
+    // revision) vs a top-level listing — no dedicated column on the request.
+    select: {
+      name: true,
+      externalUrl: true,
+      category: true,
+      contentRating: true,
+      revisionOfId: true,
+    },
   },
 } as const;
 
@@ -647,20 +1271,54 @@ export type ListOffsiteRequestsOptions = { limit?: number; cursor?: string };
 /**
  * The caller's OWN off-site submissions, newest-first, keyset-paginated. Scoped
  * to `submittedByUserId` — never another user's rows.
+ *
+ * SHADOW handling: a pending REVISION request targets a hidden SHADOW listing
+ * (`appListing.revisionOfId != null`) — it must NOT surface as its own top-level
+ * submission. Those requests are excluded here; instead each PARENT row carries a
+ * `hasPendingRevision` flag so the my-submissions UI can badge "a revision is
+ * under review". (A request whose listing was deleted — `appListingId` null, e.g.
+ * a rejected/withdrawn submission — is still shown.) The shape is otherwise
+ * backward-compatible: `hasPendingRevision` is purely additive.
  */
 export async function listMySubmissions(
   opts: { userId: number } & ListOffsiteRequestsOptions
 ) {
   const limit = Math.min(opts.limit ?? 25, 100);
   const rows = await dbRead.appListingPublishRequest.findMany({
-    where: { submittedByUserId: opts.userId, kind: 'offsite' },
+    where: {
+      submittedByUserId: opts.userId,
+      kind: 'offsite',
+      // Exclude requests targeting a SHADOW (revision) listing — surfaced as a
+      // flag on the parent, not as their own row. Keep requests with no listing.
+      OR: [{ appListingId: null }, { appListing: { revisionOfId: null } }],
+    },
     orderBy: { submittedAt: 'desc' },
     take: limit + 1,
     ...(opts.cursor ? { cursor: { id: opts.cursor }, skip: 1 } : {}),
     select: submissionSelect,
   });
   const hasNext = rows.length > limit;
-  const items = hasNext ? rows.slice(0, limit) : rows;
+  const page = hasNext ? rows.slice(0, limit) : rows;
+
+  // Flag which parent listings on this page have an in-flight shadow revision.
+  const parentIds = page
+    .map((r) => r.appListingId)
+    .filter((id): id is string => id != null);
+  const shadows =
+    parentIds.length > 0
+      ? await dbRead.appListing.findMany({
+          where: { revisionOfId: { in: parentIds } },
+          select: { revisionOfId: true },
+        })
+      : [];
+  const parentsWithRevision = new Set(
+    shadows.map((s) => s.revisionOfId).filter((id): id is string => id != null)
+  );
+  const items = page.map((r) => ({
+    ...r,
+    hasPendingRevision: r.appListingId != null && parentsWithRevision.has(r.appListingId),
+  }));
+
   return { items, nextCursor: hasNext ? items[items.length - 1].id : null };
 }
 


### PR DESCRIPTION
## What

Authors can now **edit an existing off-site App Store listing without withdrawing it**. This fixes the "I have a live listing with a URL typo and my only option is to withdraw (going dark) and resubmit" gap.

### State machine (on the LIVE listing's status)

| Status | Behaviour |
|---|---|
| `draft` / `pending` | edit **IN PLACE** (no re-review). A pending listing's existing pending request keeps reviewing the now-updated row. |
| `approved` (LIVE) | the current version **STAYS LIVE**. A **TRIVIAL** edit (`tagline`/`description`/`category`/`contentRating`) applies **in place**. A **MATERIAL** edit (`externalUrl`/`name`, or the icon/cover/screenshot assets) is staged as a **shadow-draft revision** and applied to the live parent **only on mod re-approve**. |
| `rejected` | no row exists (reject deletes it) → typed `MUST_RESUBMIT` (out of `updateListing`'s scope — resubmit via the existing submit flow). |
| `removed` | mod-only takedown → `FORBIDDEN` for an author edit. |

### Chosen mechanism — SHADOW-DRAFT

An approved-listing material edit creates a hidden **DRAFT clone** ("the shadow") of the live listing:

- `beginListingRevision(listingId)` — idempotent; clones the approved parent's scalars into a draft `AppListing` (`revisionOfId = parentId`, synthetic unique `rev-<ulid>` slug, `appBlockId: null`, owner = parent owner) and copies each parent screenshot (imageId/order/caption). The author then edits the shadow's **assets** via the **existing** `setIcon`/`setCover`/`addScreenshot`/… procs by passing the shadow id — no new asset procs.
- `submitListingRevision(shadowId)` — asserts the shadow is a draft revision, asset-complete, URL-valid, then opens a pending `AppListingPublishRequest` pointing at the **shadow** but denormalizing the **PUBLIC parent slug** so the mod queue reads the live slug. Guards a second concurrent pending revision (returns the existing one).
- On **approve**, `applyApprovedRevision` (in one tx): copies the shadow's scalars onto the **live parent** (parent `id`/`slug`/`appBlockId`/`metric`/`reports` preserved — status/slug/id untouched), **reparents** the shadow's screenshots onto the parent **before** deleting the shadow (cascade-safe), flips the request `pending→approved` **and re-points its `appListingId` at the parent**, then retires the shadow.
- On **reject / withdraw**, the shadow (itself a `draft`) is deleted and the live parent is untouched — **no branch needed**, the existing status-guarded `deleteDraftListing({ status:'draft' })` already does exactly this.

`A request is a REVISION iff its listing's revisionOfId != null` — inferred, no new column on the request.

## Migration (rule #8 — MANUAL APPLY)

**`prisma/migrations/20260707120000_w13_edit_listing_revision/migration.sql`** — must be applied by a human to **prod nvme0 AND the dev clone BEFORE the release that carries this code** (a revision write hits the missing column otherwise; apply to the dev clone before the PR preview smoke runs). Additive + idempotent; the column is nullable so ADD COLUMN is a metadata-only change.

```sql
ALTER TABLE "app_listings"
  ADD COLUMN IF NOT EXISTS "revision_of_id" TEXT;

DO $$
BEGIN
  IF NOT EXISTS (
    SELECT 1 FROM pg_constraint WHERE conname = 'app_listings_revision_of_id_fkey'
  ) THEN
    ALTER TABLE "app_listings"
      ADD CONSTRAINT "app_listings_revision_of_id_fkey"
      FOREIGN KEY ("revision_of_id") REFERENCES "app_listings"("id") ON DELETE CASCADE;
  END IF;
END $$;

CREATE INDEX IF NOT EXISTS "app_listings_revision_of_idx"
  ON "app_listings" ("revision_of_id");
```

`schema.full.prisma` gains `revisionOfId` + the `revisionOf`/`revisions` self-relation (`onDelete: Cascade`) + `@@index([revisionOfId])`.

## Server (complete + tested)

- **NEW** `updateListing`, `beginListingRevision`, `submitListingRevision` (author-gated `appDeveloperProcedure`, owner-checked in the service, rate-limited).
- `approveExternalRequest` is now **revision-aware**: it branches on `revisionOfId`. The first-time `draft→approved` path is **byte-for-behavior unchanged** (the branch happens before the existing gate/tx). A locked test proves a non-revision approval behaves exactly as before.
- `reject`/`withdraw` unchanged (documented why they already handle the shadow correctly).
- `listMySubmissions` excludes shadow-targeting requests and adds a `hasPendingRevision` flag per parent (backward-compatible, additive).
- Public read path (`listAvailableListings` raw SQL + `getListingDetail` where) gains a defense-in-depth `revisionOfId IS NULL` guard (shadows are already `draft`, so already hidden).

## UI (functional-but-minimal; polish deferred)

`OffsiteEditModal` on the author's my-submissions off-site rows (`Edit` on pending/approved rows): edits name/link/category/rating. Draft/pending → in place; approved-material → auto-stages **and submits** the revision (the shadow inherits the live listing's complete assets, so it re-reviews without an asset editor) — the modal tells the author the current version stays live. A `revision in review` badge shows on parents with a pending revision.

**Deferred follow-up:** tagline/description editing + a full asset-re-edit flow (reusing `ExternalSubmitForm` + the OG metadata auto-pull) for a material revision that also changes imagery. This modal only changes fields whose current values the my-submissions payload already carries, so it never clears an un-prefilled field.

## Tests

`offsite-listing.edit.service.test.ts` (new) + additions to `app-listing.service.test.ts` and `offsiteSubmissionStatus.test.ts`:
- `updateListing`: draft/pending in place, approved-trivial in place, approved-material → shadow, material-same-value → in place, rejected → MUST_RESUBMIT, removed → FORBIDDEN, non-owner → NOT_OWNED, invalid URL, editing a shadow → INVALID_REVISION.
- `beginListingRevision`: clones scalars + screenshots, synthetic slug + null appBlockId + revisionOfId, idempotent reuse, non-approved/non-owner guards.
- `submitListingRevision`: pending request with PARENT slug, concurrent-guard, asset-incomplete blocked, non-shadow/non-draft/non-owner guards.
- `approveExternalRequest`: revision apply copies scalars+screenshots onto the parent, preserves parent id/slug, deletes the shadow, approves + re-points the request; asset-incomplete + TOCTOU blocked. Existing suite already locks the non-revision path unchanged.
- reject/withdraw revision: delete only the shadow, parent untouched.
- `listMySubmissions`: shadows excluded from the query, parent flagged `hasPendingRevision`.
- Public read: `revision_of_id IS NULL` in the list SQL; `revisionOfId: null` in the detail where.

## Only the preview can confirm

Local `tsc`/`vitest` can't run here (NixOS, no `node_modules`) — the PR preview is the authoritative typecheck/test gate. In particular, the new Prisma fields (`revisionOfId`/`revisionOf`/`revisions`) require `prisma generate` from `schema.full.prisma` (CI runs it) before the service typechecks.

## Honest risk notes

- The only shipped-code path with regression surface is `approveExternalRequest`. The revision branch is placed **after** the request-load + listing-load and **before** the existing gate/tx, so the non-revision path is untouched; a dedicated test locks it.
- `beginListingRevision` uses find-then-create with an in-tx race re-check for the single-shadow-per-parent invariant (no DB unique on `revisionOfId`); a lost race reuses the winning shadow. A DB partial-unique could harden this later if needed.
- After a revision reject, the request's `appListingId` becomes NULL via the existing `SetNull` FK (same as a first-time reject) — consistent existing behaviour, surfaced in my-submissions with the parent slug on the request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
