### PR TITLE
feat(apps): AppListing review write path — thumbs review button + synchronous recommend-metric feed (both kinds, dark)

### DIFF
--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -34,6 +34,8 @@ import {
 } from '~/components/Apps/appListingCardView';
 import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
 import { ReportListingButton } from '~/components/Apps/ReportListingButton';
+import { ReviewListingButton } from '~/components/Apps/ReviewListingButton';
+import { AppListingReviews } from '~/components/Apps/AppListingReviews';
 import {
   CATEGORY_ICONS,
   FALLBACK_CATEGORY_ICON,
@@ -349,6 +351,10 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
         <Box style={{ flexShrink: 0 }}>
           <Stack gap="xs" align="flex-end">
             <PrimaryAction detail={detail} canOpenPage={canOpenPage} />
+            {/* Review affordance (thumbs/recommend) — hidden for the owner + signed-out
+                viewers; the write proc is protected + flag-gated + self-review-blocked
+                server-side. Feeds the recommend metric below SYNCHRONOUSLY. */}
+            <ReviewListingButton appListingId={detail.id} ownerUserId={detail.creator?.id ?? null} />
             {/* Report affordance — dark behind the mod-only store surface; the
                 proc is protected + rate-limited + reporter-bound server-side. */}
             <ReportListingButton appListingId={detail.id} />
@@ -371,6 +377,9 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
           </Text>
         )}
       </Group>
+
+      {/* Recent reviews — thumbs/recommend list (mod-filtered, escaped plain text). */}
+      <AppListingReviews appListingId={detail.id} />
 
       <ScreenshotGallery screenshots={detail.screenshots} name={detail.name} />
 

--- a/src/components/Apps/AppListingReviews.tsx
+++ b/src/components/Apps/AppListingReviews.tsx
@@ -1,0 +1,120 @@
+import { Badge, Button, Divider, Group, Loader, Stack, Text, ThemeIcon } from '@mantine/core';
+import { IconThumbDown, IconThumbUp } from '@tabler/icons-react';
+import { useMemo } from 'react';
+
+import { DaysFromNow } from '~/components/Dates/DaysFromNow';
+import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import type { AppListingReviewListItem } from '~/server/schema/blocks/app-listing-review.schema';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App Store Listings (W13) — the recent-reviews LIST for a store listing (thumbs
+ * / recommend). Keyset/infinite over `appListings.listReviews` (which already
+ * filters mod-excluded / tos-violation rows). Renders `details` as ESCAPED PLAIN
+ * TEXT via React's default escaping — NEVER dangerouslySetInnerHTML (`details` is
+ * only length-capped/trimmed server-side, so the escaping is the XSS control).
+ *
+ * DARK: mounted only under the mod-only store-preview detail body today.
+ */
+export function AppListingReviews({ appListingId }: { appListingId: string }) {
+  const currentUser = useCurrentUser();
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    trpc.appListings.listReviews.useInfiniteQuery(
+      { appListingId },
+      { getNextPageParam: (lastPage) => lastPage.nextCursor }
+    );
+
+  const items = useMemo(() => data?.pages.flatMap((p) => p.items) ?? [], [data]);
+
+  if (isLoading) {
+    return (
+      <Group justify="center" py="md">
+        <Loader size="sm" />
+      </Group>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <Text c="dimmed" size="sm">
+        Be the first to review this app.
+      </Text>
+    );
+  }
+
+  return (
+    <Stack gap="md">
+      {items.map((review) => (
+        <div key={review.id}>
+          <ReviewRow review={review} isViewer={review.user?.id === currentUser?.id} />
+          <Divider mt="md" />
+        </div>
+      ))}
+      {hasNextPage && (
+        <Group justify="center">
+          <Button variant="default" onClick={() => fetchNextPage()} loading={isFetchingNextPage}>
+            Load more
+          </Button>
+        </Group>
+      )}
+    </Stack>
+  );
+}
+
+function ReviewRow({
+  review,
+  isViewer,
+}: {
+  review: AppListingReviewListItem;
+  isViewer: boolean;
+}) {
+  return (
+    <Group align="flex-start" wrap="nowrap" gap="sm">
+      <Stack gap={4} style={{ flex: 1, minWidth: 0 }}>
+        <Group gap="xs" align="center" wrap="wrap">
+          {review.user ? (
+            <UserAvatar userId={review.user.id} size="sm" withUsername linkToProfile />
+          ) : (
+            <Text size="sm" c="dimmed">
+              [deleted]
+            </Text>
+          )}
+          {isViewer && (
+            <Badge size="xs" variant="light" color="blue">
+              Your review
+            </Badge>
+          )}
+          <Text c="dimmed" size="xs">
+            <DaysFromNow date={review.createdAt} />
+          </Text>
+        </Group>
+        {review.recommended ? (
+          <Group gap={4} align="center">
+            <ThemeIcon variant="light" color="green" size="sm" radius="xl">
+              <IconThumbUp size={12} />
+            </ThemeIcon>
+            <Text size="xs" c="green">
+              Recommends
+            </Text>
+          </Group>
+        ) : (
+          <Group gap={4} align="center">
+            <ThemeIcon variant="light" color="red" size="sm" radius="xl">
+              <IconThumbDown size={12} />
+            </ThemeIcon>
+            <Text size="xs" c="red">
+              Doesn&apos;t recommend
+            </Text>
+          </Group>
+        )}
+        {/* PLAIN TEXT ONLY — React escapes this. NEVER dangerouslySetInnerHTML. */}
+        {review.details && (
+          <Text size="sm" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {review.details}
+          </Text>
+        )}
+      </Stack>
+    </Group>
+  );
+}

--- a/src/components/Apps/ReviewListingButton.browser.test.tsx
+++ b/src/components/Apps/ReviewListingButton.browser.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * W13 — AppListing REVIEW button (thumbs/recommend) component tests.
+ *
+ * Load-bearing behaviours, network-free (tRPC mocked via the scaffold's documented
+ * `vi.mock('~/utils/trpc')` pattern):
+ *   1. ELIGIBILITY GATING — hidden for a signed-out viewer AND for the listing
+ *      owner (the self-review CTA never renders); shown for any other signed-in
+ *      user (no install gate).
+ *   2. WRITE WIRING — picking a thumbs value + typing details + submit calls
+ *      `appListings.upsertReview` with exactly `{appListingId, recommended, details}`.
+ */
+
+const mocks = vi.hoisted(() => ({
+  upsert: vi.fn(),
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  myReview: null as null | { id: number; recommended: boolean; details: string | null; createdAt: Date },
+  currentUser: { id: 42, username: 'viewer' } as null | { id: number; username: string },
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    appListings: {
+      getMyReview: {
+        useQuery: () => ({ data: mocks.myReview, isLoading: false }),
+      },
+      upsertReview: {
+        useMutation: ({ onSuccess }: { onSuccess?: (r: unknown) => void } = {}) => ({
+          mutate: (input: unknown) => {
+            mocks.upsert(input);
+            onSuccess?.({ isNewReview: true });
+          },
+          isPending: false,
+        }),
+      },
+      listReviews: { invalidate: mocks.invalidate },
+    },
+    useUtils: () => ({
+      appListings: {
+        getMyReview: { invalidate: mocks.invalidate },
+        listReviews: { invalidate: mocks.invalidate },
+        getAppDetail: { invalidate: mocks.invalidate },
+      },
+    }),
+  },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.currentUser,
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+// Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
+const { ReviewListingButton } = await import('./ReviewListingButton');
+
+beforeEach(() => {
+  mocks.upsert.mockClear();
+  mocks.invalidate.mockClear();
+  mocks.myReview = null;
+  mocks.currentUser = { id: 42, username: 'viewer' };
+});
+
+describe('ReviewListingButton', () => {
+  test('signed-in non-owner sees the review CTA', async () => {
+    renderWithProviders(<ReviewListingButton appListingId="apl_1" ownerUserId={99} />);
+    await expect.element(page.getByRole('button', { name: /leave a review/i })).toBeInTheDocument();
+  });
+
+  test('the listing owner does NOT see the CTA (no self-review)', async () => {
+    mocks.currentUser = { id: 99, username: 'owner' };
+    renderWithProviders(<ReviewListingButton appListingId="apl_1" ownerUserId={99} />);
+    await expect
+      .element(page.getByRole('button', { name: /leave a review/i }))
+      .not.toBeInTheDocument();
+  });
+
+  test('a signed-out viewer does NOT see the CTA', async () => {
+    mocks.currentUser = null;
+    renderWithProviders(<ReviewListingButton appListingId="apl_1" ownerUserId={99} />);
+    await expect
+      .element(page.getByRole('button', { name: /leave a review/i }))
+      .not.toBeInTheDocument();
+  });
+
+  test('picking Recommend + typing details submits upsertReview with the entered values', async () => {
+    renderWithProviders(<ReviewListingButton appListingId="apl_1" ownerUserId={99} />);
+
+    await page.getByRole('button', { name: /leave a review/i }).click();
+
+    // Modal is open — choose the thumbs value, type a blurb, submit.
+    await page.getByRole('button', { name: /^recommend$/i }).click();
+    await page.getByRole('textbox').fill('Great app, very useful');
+    await page.getByRole('button', { name: /post review/i }).click();
+
+    expect(mocks.upsert).toHaveBeenCalledTimes(1);
+    expect(mocks.upsert).toHaveBeenCalledWith({
+      appListingId: 'apl_1',
+      recommended: true,
+      details: 'Great app, very useful',
+    });
+  });
+});

--- a/src/components/Apps/ReviewListingButton.tsx
+++ b/src/components/Apps/ReviewListingButton.tsx
@@ -1,0 +1,174 @@
+import { Button, Group, Modal, Stack, Text, Textarea } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconThumbDown, IconThumbUp } from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
+
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { LISTING_REVIEW_DETAILS_MAX } from '~/server/schema/blocks/app-listing-review.schema';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App Store Listings (W13) — the USER "leave a review" affordance (thumbs /
+ * recommend + optional blurb) for a store listing. A compact button in the
+ * detail action column that opens a modal with the thumbs toggle + a textarea →
+ * `appListings.upsertReview`.
+ *
+ * ELIGIBILITY (mirrors the server gate; the server is the source of truth):
+ *   - HIDDEN for a signed-out viewer (`upsertReview` is protected).
+ *   - HIDDEN for the listing OWNER — unlike the legacy 5-star path, the public
+ *     detail DTO carries the creator id, so we can hide the self-review CTA
+ *     client-side (the server still 403s a self-review as defense-in-depth).
+ *   - NO install/usage gate (locked W13 decision) — any other signed-in user may
+ *     review, for BOTH on-site + off-site kinds.
+ *
+ * Prefills from `getMyReview` so the SAME modal EDITS an existing review (the
+ * backend upserts on (listing, user)); the current recommend state is shown +
+ * changeable. DARK: reachable only on the mod-only store-preview surface today.
+ */
+export function ReviewListingButton({
+  appListingId,
+  ownerUserId,
+}: {
+  appListingId: string;
+  /** The listing owner's user id — the CTA is hidden for them (no self-review). */
+  ownerUserId: number | null;
+}) {
+  const currentUser = useCurrentUser();
+  const queryUtils = trpc.useUtils();
+  const [opened, { open, close }] = useDisclosure(false);
+  const [recommended, setRecommended] = useState<boolean | null>(null);
+  const [details, setDetails] = useState('');
+
+  const enabled = !!currentUser && opened;
+  const { data: myReview } = trpc.appListings.getMyReview.useQuery(
+    { appListingId },
+    { enabled }
+  );
+
+  // Seed the form from the viewer's existing review once it loads (keyed on the
+  // review id so a fresh load reseeds without clobbering in-progress typing).
+  useEffect(() => {
+    if (myReview) {
+      setRecommended(myReview.recommended);
+      setDetails(myReview.details ?? '');
+    }
+  }, [myReview?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const upsert = trpc.appListings.upsertReview.useMutation({
+    onSuccess: async (res) => {
+      showSuccessNotification({
+        message: res.isNewReview ? 'Thanks for your review!' : 'Review updated',
+      });
+      close();
+      await Promise.all([
+        queryUtils.appListings.getMyReview.invalidate({ appListingId }),
+        queryUtils.appListings.listReviews.invalidate({ appListingId }),
+        // The recommend rollup lives on getAppDetail — refresh so the "N% recommend"
+        // block reflects the new/changed review.
+        queryUtils.appListings.getAppDetail.invalidate(),
+      ]);
+    },
+    onError: (error: { message?: string | null }) => {
+      showErrorNotification({
+        title: 'Could not post review',
+        error: new Error(error.message ?? 'Please try again later.'),
+      });
+    },
+  });
+
+  // Signed-out → no CTA (the proc is protected). Owner → no self-review CTA.
+  if (!currentUser) return null;
+  if (ownerUserId != null && ownerUserId === currentUser.id) return null;
+
+  const isEditing = !!myReview;
+  const overLimit = details.length > LISTING_REVIEW_DETAILS_MAX;
+
+  const handleSubmit = () => {
+    if (recommended == null) {
+      showErrorNotification({
+        title: 'Pick a rating',
+        error: new Error('Choose 👍 or 👎 before posting.'),
+      });
+      return;
+    }
+    upsert.mutate({
+      appListingId,
+      recommended,
+      details: details.trim() ? details.trim() : undefined,
+    });
+  };
+
+  return (
+    <>
+      <Button
+        variant="light"
+        size="xs"
+        leftSection={<IconThumbUp size={14} />}
+        onClick={open}
+      >
+        {isEditing ? 'Edit review' : 'Leave a review'}
+      </Button>
+
+      <Modal
+        opened={opened}
+        onClose={() => (upsert.isPending ? undefined : close())}
+        title={isEditing ? 'Edit your review' : 'Review this app'}
+        size="md"
+        centered
+      >
+        <Stack gap="md">
+          <Text size="sm" c="dimmed">
+            Would you recommend this app to others?
+          </Text>
+
+          <Group gap="sm">
+            <Button
+              variant={recommended === true ? 'filled' : 'default'}
+              color="green"
+              leftSection={<IconThumbUp size={16} />}
+              onClick={() => setRecommended(true)}
+            >
+              Recommend
+            </Button>
+            <Button
+              variant={recommended === false ? 'filled' : 'default'}
+              color="red"
+              leftSection={<IconThumbDown size={16} />}
+              onClick={() => setRecommended(false)}
+            >
+              Don&apos;t recommend
+            </Button>
+          </Group>
+
+          <Textarea
+            label="Details (optional)"
+            placeholder="What did you think of this app?"
+            value={details}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              setDetails(e.currentTarget.value)
+            }
+            maxLength={LISTING_REVIEW_DETAILS_MAX}
+            autosize
+            minRows={3}
+            maxRows={8}
+            error={
+              overLimit
+                ? `Max ${LISTING_REVIEW_DETAILS_MAX.toLocaleString()} characters`
+                : undefined
+            }
+          />
+
+          <Button
+            onClick={handleSubmit}
+            loading={upsert.isPending}
+            disabled={recommended == null || overLimit}
+            leftSection={<IconThumbUp size={16} />}
+          >
+            {isEditing ? 'Update review' : 'Post review'}
+          </Button>
+        </Stack>
+      </Modal>
+    </>
+  );
+}

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -15,6 +15,11 @@ import {
   listAppListingsSchema,
 } from '~/server/schema/blocks/app-listing-read.schema';
 import {
+  getMyAppListingReviewSchema,
+  listAppListingReviewsSchema,
+  upsertAppListingReviewSchema,
+} from '~/server/schema/blocks/app-listing-review.schema';
+import {
   approveExternalRequestSchema,
   listMySubmissionsSchema,
   listOffsiteRequestsSchema,
@@ -733,5 +738,82 @@ export const appListingsRouter = router({
       const detail = await getListingDetail(input, { redCapable: isRedCapableRequest(ctx) });
       if (!detail) throw throwNotFoundError('Listing not found');
       return detail;
+    }),
+
+  // -------------------------------------------------------------------------
+  // REVIEW (thumbs/recommend) WRITE + READ — the write half of AppListingReview
+  // (the model + the "N% recommend (M)" DISPLAY already existed; only the write
+  // path + read procs + the SYNCHRONOUS metric feed were missing).
+  //
+  // ELIGIBILITY (locked W13 decision, enforced in the service): any signed-in
+  // user EXCEPT the listing owner, for BOTH kinds, NO install/usage gate.
+  //
+  // FLAG GATING: the WRITEs (`upsertReview`/`getMyReview`) are `protectedProcedure`
+  // (auth REQUIRED) + `enforceAppBlocksFlag` — the "store enabled for this viewer"
+  // gate that THROWS UNAUTHORIZED when off (a real anon/non-mod caller can't write
+  // until the segment widens at GA). `listReviews` is `publicProcedure` +
+  // `enforceAppListingsReadFlag` (empty page when off, same posture as
+  // listAvailable). The review affordance renders only on the mod-only
+  // store-preview surface today (the public `/apps/[slug]` cutover is P2d).
+  //
+  // FOLLOW-UP (deferred): a MOD exclude/report path for individual reviews.
+  // `listReviews` ALREADY filters `exclude`/`tosViolation`, so a future mod action
+  // takes effect on the visible list with no read-path change.
+  // -------------------------------------------------------------------------
+
+  /**
+   * USER: create-or-update the caller's review for a listing (thumbs/recommend),
+   * feeding the recommend metric SYNCHRONOUSLY in the same tx. Self-review /
+   * non-approved-listing gates are enforced in the service (FORBIDDEN / BAD_REQUEST).
+   */
+  upsertReview: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .use(
+      rateLimit({
+        limit: 30,
+        period: 60,
+        errorMessage: 'Too many review submissions — slow down.',
+      })
+    )
+    .input(upsertAppListingReviewSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { upsertAppListingReview } = await import(
+        '~/server/services/blocks/app-listing-review.service'
+      );
+      return upsertAppListingReview({ userId: ctx.user.id, input });
+    }),
+
+  /** USER: the caller's OWN review for a listing (form prefill), or null. */
+  getMyReview: protectedProcedure
+    .use(enforceAppBlocksFlag)
+    .input(getMyAppListingReviewSchema)
+    .query(async ({ ctx, input }) => {
+      if (!ctx.user) return null;
+      const { getMyAppListingReview } = await import(
+        '~/server/services/blocks/app-listing-review.service'
+      );
+      return getMyAppListingReview(input.appListingId, ctx.user.id);
+    }),
+
+  /** PUBLIC: keyset-paginated reviews for a listing (newest-first, mod-filtered). */
+  listReviews: publicProcedure
+    .use(enforceAppListingsReadFlag)
+    .use(
+      rateLimit({
+        limit: 60,
+        period: 60,
+        errorMessage: 'Too many review requests — slow down.',
+      })
+    )
+    .input(listAppListingReviewsSchema)
+    .query(async ({ ctx, input }) => {
+      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+        return { items: [], nextCursor: undefined };
+      }
+      const { listAppListingReviews } = await import(
+        '~/server/services/blocks/app-listing-review.service'
+      );
+      return listAppListingReviews(input);
     }),
 });

--- a/src/server/schema/blocks/app-listing-review.schema.ts
+++ b/src/server/schema/blocks/app-listing-review.schema.ts
@@ -1,0 +1,82 @@
+import * as z from 'zod';
+
+/**
+ * App Store Listings (W13) — REVIEW (thumbs/recommend) write + read schemas.
+ *
+ * Backs the NEW `appListings.upsertReview` / `appListings.getMyReview` /
+ * `appListings.listReviews` procs against the durable `AppListingReview` table
+ * (Steam-style RECOMMEND — a boolean thumbs-up/down, NOT the legacy AppBlock
+ * 5-star). Eligibility (enforced in the service): any signed-in user EXCEPT the
+ * listing owner, for BOTH `onsite` and `offsite` kinds, with NO install/usage
+ * gate (the locked W13 decision). One review per (listing, user) via the DB
+ * unique `app_listing_reviews_listing_user_uniq` (an upsert, not a 2nd row).
+ *
+ * Imports ONLY zod, so this module is safe to pull into the client bundle (the
+ * review form reuses `LISTING_REVIEW_DETAILS_MAX` as the single source of truth
+ * for the textarea cap).
+ *
+ * The write path SYNCHRONOUSLY feeds `AppListingMetric.thumbsUp/DownCount` in the
+ * same tx (delta vs the prior review) so the existing "N% recommend (M)" rollup
+ * on the store card/detail goes live — there is no batch rollup job.
+ */
+
+/**
+ * Free-text `details` cap. Matches the off-site report/description bound
+ * (`OFFSITE_REPORT_DETAILS_MAX` = 2000) — a sane sibling limit for a short
+ * review body (the legacy AppBlock 10k cap is a full write-up; a recommend blurb
+ * is shorter). The column is `text` (no DB length), so this zod cap + the
+ * service re-trim/re-assert are the only bounds.
+ */
+export const LISTING_REVIEW_DETAILS_MAX = 2000;
+
+/** Shared listing-id shape (an `apl_<ULID>`), mirroring the other listing schemas. */
+const appListingId = z.string().min(1).max(64);
+
+/**
+ * USER upsert of their review for a listing. `recommended` is the thumbs value
+ * (true = recommend); `details` is an OPTIONAL bounded blurb. The reviewer is
+ * ALWAYS bound to `ctx.user.id` in the service (no user field here); the owner /
+ * approved-state / one-per-(listing,user) gates are all enforced server-side.
+ */
+export const upsertAppListingReviewSchema = z.object({
+  appListingId,
+  recommended: z.boolean(),
+  details: z.string().max(LISTING_REVIEW_DETAILS_MAX).optional(),
+});
+export type UpsertAppListingReviewInput = z.infer<typeof upsertAppListingReviewSchema>;
+
+/** USER read of their OWN review for a listing (form prefill), or null. */
+export const getMyAppListingReviewSchema = z.object({ appListingId });
+export type GetMyAppListingReviewInput = z.infer<typeof getMyAppListingReviewSchema>;
+
+/**
+ * PUBLIC keyset-paginate a listing's reviews, NEWEST-first. Excludes mod-excluded
+ * / tos-violation rows (a future mod action takes effect immediately). `limit`
+ * capped at 50; `cursor` is the last row's numeric id (autoincrement, monotonic).
+ */
+export const listAppListingReviewsSchema = z.object({
+  appListingId,
+  cursor: z.number().int().positive().optional(),
+  limit: z.number().int().min(1).max(50).optional(),
+});
+export type ListAppListingReviewsInput = z.infer<typeof listAppListingReviewsSchema>;
+
+/**
+ * Public-safe review projection (the reviewer's public chip + the review body).
+ * No moderation flags, no email/PII beyond the standard `{id,username,image}`.
+ */
+export type AppListingReviewListItem = {
+  id: number;
+  recommended: boolean;
+  details: string | null;
+  createdAt: Date;
+  user: { id: number; username: string | null; image: string | null } | null;
+};
+
+/** The viewer's own review (form-prefill shape), or null. */
+export type MyAppListingReview = {
+  id: number;
+  recommended: boolean;
+  details: string | null;
+  createdAt: Date;
+} | null;

--- a/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
@@ -1,0 +1,302 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+import {
+  getMyAppListingReview,
+  listAppListingReviews,
+  upsertAppListingReview,
+} from '~/server/services/blocks/app-listing-review.service';
+import { LISTING_REVIEW_DETAILS_MAX } from '~/server/schema/blocks/app-listing-review.schema';
+
+/**
+ * W13 — AppListing REVIEW (thumbs/recommend) service tests.
+ *
+ * Covers upsertReview (the SYNCHRONOUS metric-delta feed: new / details-only edit
+ * / recommend flip; the non-negative clamp; the self-review + approved-only +
+ * details-cap gates), getMyReview, and listReviews (mod-filter + keyset). All DB
+ * deps are mocked — no real Prisma. `dbWrite.$transaction` runs its callback
+ * against the SAME `dbWrite` mock (the tx client) so a test asserts the exact
+ * metric writes made inside the tx. `dbRead`/`dbWrite` are DISTINCT mocks so a
+ * test proves the listing load went to the replica and the writes to the primary.
+ */
+
+type WriteMock = {
+  $transaction: ReturnType<typeof vi.fn>;
+  appListingReview: { findUnique: ReturnType<typeof vi.fn>; upsert: ReturnType<typeof vi.fn> };
+  appListingMetric: { upsert: ReturnType<typeof vi.fn>; updateMany: ReturnType<typeof vi.fn> };
+};
+type ReadMock = {
+  appListing: { findUnique: ReturnType<typeof vi.fn> };
+  appListingReview: { findUnique: ReturnType<typeof vi.fn>; findMany: ReturnType<typeof vi.fn> };
+};
+
+const SAVED_REVIEW = {
+  id: 7,
+  appListingId: 'apl_target',
+  userId: 42,
+  recommended: true,
+  details: null,
+  createdAt: new Date('2026-07-07T00:00:00Z'),
+  updatedAt: new Date('2026-07-07T00:00:00Z'),
+};
+
+const { mockRead, mockWrite } = vi.hoisted(() => {
+  const write: WriteMock = {
+    $transaction: vi.fn(),
+    appListingReview: {
+      findUnique: vi.fn(async () => null),
+      upsert: vi.fn(async () => SAVED_REVIEW),
+    },
+    appListingMetric: {
+      upsert: vi.fn(async () => ({})),
+      updateMany: vi.fn(async () => ({ count: 0 })),
+    },
+  };
+  write.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) => cb(write));
+  const read: ReadMock = {
+    appListing: { findUnique: vi.fn(async () => null) },
+    appListingReview: { findUnique: vi.fn(async () => null), findMany: vi.fn(async () => []) },
+  };
+  return { mockRead: read, mockWrite: write };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/utils/cache-helpers', () => ({ bustCacheTag: vi.fn(async () => undefined) }));
+
+const CALLER = 42;
+const OWNER = 99;
+const APP_ID = 'apl_target';
+
+/** Approved listing owned by someone OTHER than the caller (reviewable). */
+function reviewableListing() {
+  return { id: APP_ID, userId: OWNER, status: 'approved' };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWrite.$transaction.mockImplementation(
+    async (cb: (tx: WriteMock) => Promise<unknown>) => cb(mockWrite)
+  );
+  mockWrite.appListingReview.findUnique.mockResolvedValue(null);
+  mockWrite.appListingReview.upsert.mockResolvedValue(SAVED_REVIEW);
+  mockWrite.appListingMetric.upsert.mockResolvedValue({});
+  mockWrite.appListingMetric.updateMany.mockResolvedValue({ count: 0 });
+  mockRead.appListing.findUnique.mockResolvedValue(reviewableListing());
+  mockRead.appListingReview.findUnique.mockResolvedValue(null);
+  mockRead.appListingReview.findMany.mockResolvedValue([]);
+});
+
+function metricUpsertArgs() {
+  return mockWrite.appListingMetric.upsert.mock.calls[0][0] as {
+    where: { appListingId: string };
+    create: { thumbsUpCount: number; thumbsDownCount: number };
+    update: {
+      thumbsUpCount?: { increment: number };
+      thumbsDownCount?: { increment: number };
+    };
+  };
+}
+
+describe('upsertAppListingReview — new review (no prior)', () => {
+  it('recommend=true → +1 thumbsUp; creates the metric row (zeros) if absent; isNewReview', async () => {
+    const res = await upsertAppListingReview({
+      userId: CALLER,
+      input: { appListingId: APP_ID, recommended: true },
+    });
+
+    expect(res.isNewReview).toBe(true);
+    // Review written to the PRIMARY, keyed on (appListingId, userId), userId FORCED.
+    const upsertArgs = mockWrite.appListingReview.upsert.mock.calls[0][0];
+    expect(upsertArgs.where).toEqual({ appListingId_userId: { appListingId: APP_ID, userId: CALLER } });
+    expect(upsertArgs.create).toMatchObject({ appListingId: APP_ID, userId: CALLER, recommended: true });
+
+    // Metric: create ensures the row exists with +1; update path increments +1.
+    const m = metricUpsertArgs();
+    expect(m.where).toEqual({ appListingId: APP_ID });
+    expect(m.create).toEqual({ appListingId: APP_ID, thumbsUpCount: 1, thumbsDownCount: 0 });
+    expect(m.update).toEqual({ thumbsUpCount: { increment: 1 } });
+    // No decrement → no clamp.
+    expect(mockWrite.appListingMetric.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('recommend=false → +1 thumbsDown', async () => {
+    await upsertAppListingReview({
+      userId: CALLER,
+      input: { appListingId: APP_ID, recommended: false },
+    });
+    const m = metricUpsertArgs();
+    expect(m.create).toEqual({ appListingId: APP_ID, thumbsUpCount: 0, thumbsDownCount: 1 });
+    expect(m.update).toEqual({ thumbsDownCount: { increment: 1 } });
+  });
+});
+
+describe('upsertAppListingReview — editing an existing review', () => {
+  it('details-only edit (same recommend) does NOT touch the metric (no double-count)', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue({
+      id: 7,
+      recommended: true,
+      exclude: false,
+    });
+    const res = await upsertAppListingReview({
+      userId: CALLER,
+      input: { appListingId: APP_ID, recommended: true, details: 'nice app' },
+    });
+    expect(res.isNewReview).toBe(false);
+    expect(mockWrite.appListingReview.upsert).toHaveBeenCalledTimes(1);
+    // Zero delta → no metric write at all.
+    expect(mockWrite.appListingMetric.upsert).not.toHaveBeenCalled();
+  });
+
+  it('flipping recommend true→false moves the count (−1 up, +1 down) and clamps up ≥0', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue({
+      id: 7,
+      recommended: true,
+      exclude: false,
+    });
+    await upsertAppListingReview({
+      userId: CALLER,
+      input: { appListingId: APP_ID, recommended: false },
+    });
+    const m = metricUpsertArgs();
+    // create clamps the down bucket to ≥0 (only reached if the row were absent).
+    expect(m.create).toEqual({ appListingId: APP_ID, thumbsUpCount: 0, thumbsDownCount: 1 });
+    expect(m.update).toEqual({
+      thumbsUpCount: { increment: -1 },
+      thumbsDownCount: { increment: 1 },
+    });
+    // A decrement fired → the defensive non-negative clamp runs for the up bucket.
+    expect(mockWrite.appListingMetric.updateMany).toHaveBeenCalledWith({
+      where: { appListingId: APP_ID, thumbsUpCount: { lt: 0 } },
+      data: { thumbsUpCount: 0 },
+    });
+  });
+
+  it('a mod-EXCLUDED prior review is treated as un-counted → editing it makes no delta', async () => {
+    mockWrite.appListingReview.findUnique.mockResolvedValue({
+      id: 7,
+      recommended: true,
+      exclude: true,
+    });
+    await upsertAppListingReview({
+      userId: CALLER,
+      input: { appListingId: APP_ID, recommended: false },
+    });
+    // Prior didn't count (excluded) and the edit stays excluded → no counter change.
+    expect(mockWrite.appListingMetric.upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe('upsertAppListingReview — eligibility + input gates', () => {
+  it('self-review is rejected (owner) with no write', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue({ id: APP_ID, userId: CALLER, status: 'approved' });
+    await expect(
+      upsertAppListingReview({ userId: CALLER, input: { appListingId: APP_ID, recommended: true } })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('a missing listing → NOT_FOUND', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(null);
+    await expect(
+      upsertAppListingReview({ userId: CALLER, input: { appListingId: APP_ID, recommended: true } })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('a non-approved (draft/removed/rejected) listing is not reviewable → BAD_REQUEST', async () => {
+    for (const status of ['draft', 'pending', 'rejected', 'removed']) {
+      mockRead.appListing.findUnique.mockResolvedValue({ id: APP_ID, userId: OWNER, status });
+      await expect(
+        upsertAppListingReview({ userId: CALLER, input: { appListingId: APP_ID, recommended: true } })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    }
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('details over the cap → BAD_REQUEST before any listing load', async () => {
+    await expect(
+      upsertAppListingReview({
+        userId: CALLER,
+        input: {
+          appListingId: APP_ID,
+          recommended: true,
+          details: 'x'.repeat(LISTING_REVIEW_DETAILS_MAX + 1),
+        },
+      })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockRead.appListing.findUnique).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('trims details and stores null for whitespace-only', async () => {
+    await upsertAppListingReview({
+      userId: CALLER,
+      input: { appListingId: APP_ID, recommended: true, details: '  loved it  ' },
+    });
+    expect(mockWrite.appListingReview.upsert.mock.calls[0][0].create.details).toBe('loved it');
+
+    await upsertAppListingReview({
+      userId: CALLER,
+      input: { appListingId: APP_ID, recommended: true, details: '   ' },
+    });
+    expect(mockWrite.appListingReview.upsert.mock.calls[1][0].create.details).toBeNull();
+  });
+});
+
+describe('getMyAppListingReview', () => {
+  it('returns the caller review from the replica', async () => {
+    mockRead.appListingReview.findUnique.mockResolvedValue({
+      id: 7,
+      recommended: true,
+      details: 'ok',
+      createdAt: new Date(),
+    });
+    const res = await getMyAppListingReview(APP_ID, CALLER);
+    expect(res).toMatchObject({ id: 7, recommended: true });
+    expect(mockRead.appListingReview.findUnique.mock.calls[0][0].where).toEqual({
+      appListingId_userId: { appListingId: APP_ID, userId: CALLER },
+    });
+  });
+
+  it('returns null when the caller has no review', async () => {
+    mockRead.appListingReview.findUnique.mockResolvedValue(null);
+    expect(await getMyAppListingReview(APP_ID, CALLER)).toBeNull();
+  });
+});
+
+describe('listAppListingReviews', () => {
+  function row(id: number) {
+    return {
+      id,
+      recommended: true,
+      details: null,
+      createdAt: new Date(),
+      user: { id: 1, username: 'u', image: null },
+    };
+  }
+
+  it('filters exclude + tosViolation, newest-first, off the replica', async () => {
+    mockRead.appListingReview.findMany.mockResolvedValue([row(3), row(2), row(1)]);
+    await listAppListingReviews({ appListingId: APP_ID, limit: 20 });
+    const args = mockRead.appListingReview.findMany.mock.calls[0][0];
+    expect(args.where).toMatchObject({ appListingId: APP_ID, exclude: false, tosViolation: false });
+    expect(args.orderBy).toEqual({ id: 'desc' });
+  });
+
+  it('emits a nextCursor when a full page + 1 comes back (keyset)', async () => {
+    // limit 2 → take 3; return 3 rows → hasNext, cursor = last VISIBLE row id.
+    mockRead.appListingReview.findMany.mockResolvedValue([row(5), row(4), row(3)]);
+    const res = await listAppListingReviews({ appListingId: APP_ID, limit: 2 });
+    expect(res.items.map((i) => i.id)).toEqual([5, 4]);
+    expect(res.nextCursor).toBe(4);
+  });
+
+  it('no nextCursor on a short page; applies the cursor as id < cursor', async () => {
+    mockRead.appListingReview.findMany.mockResolvedValue([row(2), row(1)]);
+    const res = await listAppListingReviews({ appListingId: APP_ID, limit: 20, cursor: 3 });
+    expect(res.nextCursor).toBeUndefined();
+    expect(mockRead.appListingReview.findMany.mock.calls[0][0].where).toMatchObject({
+      id: { lt: 3 },
+    });
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
@@ -283,6 +283,15 @@ describe('listAppListingReviews', () => {
     expect(args.orderBy).toEqual({ id: 'desc' });
   });
 
+  it('gates on the listing being approved (reviews of a removed/rejected listing are not enumerable)', async () => {
+    mockRead.appListingReview.findMany.mockResolvedValue([]);
+    await listAppListingReviews({ appListingId: APP_ID, limit: 20 });
+    const args = mockRead.appListingReview.findMany.mock.calls[0][0];
+    // The relation filter is what makes a later-removed listing's reviews vanish (and a
+    // missing listing return empty) — critical before the P2d public read cutover.
+    expect(args.where).toMatchObject({ appListing: { is: { status: 'approved' } } });
+  });
+
   it('emits a nextCursor when a full page + 1 comes back (keyset)', async () => {
     // limit 2 → take 3; return 3 rows → hasNext, cursor = last VISIBLE row id.
     mockRead.appListingReview.findMany.mockResolvedValue([row(5), row(4), row(3)]);

--- a/src/server/services/blocks/app-listing-review.service.ts
+++ b/src/server/services/blocks/app-listing-review.service.ts
@@ -166,6 +166,12 @@ export async function upsertAppListingReview(opts: {
     // Feed the metric in the SAME tx. Only touch it when there's a real delta (a
     // details-only edit leaves the counters untouched). The upsert CREATES the row
     // (clamped ≥0) when absent, else applies the atomic per-counter increments.
+    // Concurrency note: two users filing the first-ever reviews on a listing with no
+    // metric row both take the create branch; this is safe ONLY because Prisma emits a
+    // native INSERT … ON CONFLICT DO UPDATE for a single-PK upsert (the loser's insert
+    // converts to the increment). If Prisma ever falls back to select-then-insert, the
+    // loser's tx would 500 once (retriable — the row then exists). Single writer today
+    // (no P5 rollup job); a future job MUST NOT also write thumbsUp/DownCount here.
     if (upDelta !== 0 || downDelta !== 0) {
       await tx.appListingMetric.upsert({
         where: { appListingId },
@@ -229,6 +235,11 @@ export async function listAppListingReviews(
   const rows = await dbRead.appListingReview.findMany({
     where: {
       appListingId: input.appListingId,
+      // Only surface reviews for a currently-approved listing: reviews accrue while
+      // approved, but a listing can later be removed/rejected — its reviews must not
+      // stay publicly enumerable by id once the read flag widens to anon at the P2d
+      // cutover. Filtering on the relation also makes a missing listing return empty.
+      appListing: { is: { status: 'approved' } },
       exclude: false,
       tosViolation: false,
       ...(input.cursor ? { id: { lt: input.cursor } } : {}),

--- a/src/server/services/blocks/app-listing-review.service.ts
+++ b/src/server/services/blocks/app-listing-review.service.ts
@@ -1,0 +1,249 @@
+import { dbRead, dbWrite } from '~/server/db/client';
+import {
+  LISTING_REVIEW_DETAILS_MAX,
+  type AppListingReviewListItem,
+  type ListAppListingReviewsInput,
+  type MyAppListingReview,
+  type UpsertAppListingReviewInput,
+} from '~/server/schema/blocks/app-listing-review.schema';
+import { bustCacheTag } from '~/server/utils/cache-helpers';
+import {
+  throwAuthorizationError,
+  throwBadRequestError,
+  throwNotFoundError,
+} from '~/server/utils/errorHandling';
+
+/**
+ * App Store Listings (W13) — REVIEW (thumbs/recommend) write + read service.
+ *
+ * The write half of `AppListingReview` (the read/DISPLAY of the recommend
+ * rollup + the model already existed — see `app-listing.service.recommendRollup`
+ * + the P0 `AppListingMetric` table). Steam-style RECOMMEND: a boolean
+ * thumbs-up/down (NOT the legacy AppBlock 5-star `appBlockReview.service`).
+ *
+ * ELIGIBILITY (locked W13 decision — enforced here; the router adds the flag +
+ * auth gates): any signed-in user EXCEPT the listing OWNER, for BOTH `onsite`
+ * and `offsite` kinds, with NO install/usage gate (the legacy 5-star path's
+ * enabled-install gate deliberately does NOT apply). One review per
+ * (listing, user) via the DB unique (an upsert, not a 2nd row).
+ *
+ * SYNCHRONOUS METRIC FEED (locked decision — no batch rollup job): the write
+ * adjusts `AppListingMetric.thumbsUp/DownCount` by the DELTA vs the user's PRIOR
+ * review IN THE SAME TX, so the existing "N% recommend (M)" rollup on the store
+ * card/detail goes live the instant a review lands. The metric row is CREATED
+ * (zeros) if absent — most listings have no row today (no writer before this).
+ *
+ * DARK: all surfaces are gated at the router (the mod-segmented App Blocks flag);
+ * this service does no auth of its own beyond the owner / approved-state gates.
+ */
+
+// The only review-derived cached value feeding a visible surface is the
+// store-wide Bayesian-prior recommend MEAN (`app-listing.service`'s
+// getGlobalRecommendMean, tag below, 1h). The per-listing card/detail counts are
+// read straight off the AppListingMetric rollup (uncached), so only the global
+// mean needs busting when a review shifts the counters.
+const GLOBAL_RECOMMEND_MEAN_TAG = 'app-listing:recommend-global-mean';
+
+/**
+ * Bust the store-wide recommend-mean cache after a review write. Fire-and-forget
+ * (a cache-bus outage must never fail the review).
+ */
+async function bustRecommendMeanCache(): Promise<void> {
+  await bustCacheTag([GLOBAL_RECOMMEND_MEAN_TAG]);
+}
+
+/** The compound-unique lookup key for `AppListingReview(appListingId, userId)`. */
+function reviewKey(appListingId: string, userId: number) {
+  return { appListingId_userId: { appListingId, userId } };
+}
+
+export type UpsertAppListingReviewResult = {
+  review: {
+    id: number;
+    appListingId: string;
+    userId: number;
+    recommended: boolean;
+    details: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+  };
+  /** True only on the CREATE branch (no prior review for this (listing, user)). */
+  isNewReview: boolean;
+};
+
+/**
+ * Create-or-update the caller's review for a listing, keyed on the unique
+ * (app_listing_id, user_id), and feed the recommend metric SYNCHRONOUSLY.
+ *
+ * Gates (all enforced here):
+ *   1. Listing must EXIST and be `approved` — a missing / draft / pending /
+ *      rejected / removed listing is not reviewable (BAD_REQUEST / NOT_FOUND).
+ *   2. NO SELF-REVIEW — the listing owner cannot review their own listing
+ *      (FORBIDDEN), for both kinds.
+ *   3. `details` is trimmed + length-capped (defense-in-depth on top of the zod
+ *      cap — this fn is exported + unit-tested directly); whitespace-only → null.
+ *
+ * Metric DELTA (in the SAME tx as the review upsert): adjust thumbsUp/Down vs the
+ * user's PRIOR NON-EXCLUDED review —
+ *   - no prior (or prior was mod-excluded) → +1 to the chosen bucket.
+ *   - prior, same `recommended` → no counter change (details-only edit).
+ *   - prior, flipped `recommended` → −1 old bucket, +1 new bucket.
+ * The metric row is created (zeros) if absent; a decrement can never drive a
+ * counter negative (a −1 only happens when a prior counted review existed, which
+ * itself added +1 — and a defensive clamp back-stops any inconsistency).
+ */
+export async function upsertAppListingReview(opts: {
+  userId: number;
+  input: UpsertAppListingReviewInput;
+}): Promise<UpsertAppListingReviewResult> {
+  const { userId, input } = opts;
+  const { appListingId, recommended } = input;
+
+  // Gate 3: trim + re-assert the cap (defense-in-depth). Whitespace-only → null.
+  const trimmed = input.details?.trim() ?? '';
+  if (trimmed.length > LISTING_REVIEW_DETAILS_MAX) {
+    throw throwBadRequestError(
+      `Review is too long (max ${LISTING_REVIEW_DETAILS_MAX.toLocaleString()} characters)`
+    );
+  }
+  const details = trimmed.length > 0 ? trimmed : null;
+
+  // Gate 1+2: the listing must exist, be approved, and NOT be owned by the caller.
+  const listing = await dbRead.appListing.findUnique({
+    where: { id: appListingId },
+    select: { id: true, userId: true, status: true },
+  });
+  if (!listing) throw throwNotFoundError('Listing not found');
+  if (listing.userId === userId) {
+    throw throwAuthorizationError('You cannot review your own app');
+  }
+  if (listing.status !== 'approved') {
+    throw throwBadRequestError('This app is not available for review');
+  }
+
+  const review = await dbWrite.$transaction(async (tx) => {
+    // Read the prior review (if any) to compute the metric delta. The DB unique
+    // makes the upsert itself atomic; a concurrent first-review by the SAME user
+    // is impossible (they're one user) so the read-then-upsert is race-safe here.
+    const prior = await tx.appListingReview.findUnique({
+      where: reviewKey(appListingId, userId),
+      select: { id: true, recommended: true, exclude: true },
+    });
+
+    // A prior review contributes to a bucket ONLY when it is non-excluded. The
+    // freshly written review keeps the prior `exclude` (create → false); we never
+    // flip `exclude` on the write path (that's the deferred mod control), so
+    // "will count" == "prior wasn't excluded" (or a brand-new, non-excluded row).
+    const priorCounted = prior != null && !prior.exclude;
+    const willCount = prior != null ? !prior.exclude : true;
+
+    let upDelta = 0;
+    let downDelta = 0;
+    if (priorCounted) {
+      if (prior!.recommended) upDelta -= 1;
+      else downDelta -= 1;
+    }
+    if (willCount) {
+      if (recommended) upDelta += 1;
+      else downDelta += 1;
+    }
+
+    const saved = await tx.appListingReview.upsert({
+      where: reviewKey(appListingId, userId),
+      create: { appListingId, userId, recommended, details },
+      update: { recommended, details },
+      select: {
+        id: true,
+        appListingId: true,
+        userId: true,
+        recommended: true,
+        details: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    // Feed the metric in the SAME tx. Only touch it when there's a real delta (a
+    // details-only edit leaves the counters untouched). The upsert CREATES the row
+    // (clamped ≥0) when absent, else applies the atomic per-counter increments.
+    if (upDelta !== 0 || downDelta !== 0) {
+      await tx.appListingMetric.upsert({
+        where: { appListingId },
+        create: {
+          appListingId,
+          thumbsUpCount: Math.max(0, upDelta),
+          thumbsDownCount: Math.max(0, downDelta),
+        },
+        update: {
+          ...(upDelta !== 0 ? { thumbsUpCount: { increment: upDelta } } : {}),
+          ...(downDelta !== 0 ? { thumbsDownCount: { increment: downDelta } } : {}),
+        },
+      });
+      // Defensive clamp — a counter must NEVER go negative even if the metric row
+      // drifted out of sync with the review rows (e.g. a future mod re-count). Each
+      // updateMany is atomic; it's a no-op in the normal (consistent) case.
+      if (upDelta < 0) {
+        await tx.appListingMetric.updateMany({
+          where: { appListingId, thumbsUpCount: { lt: 0 } },
+          data: { thumbsUpCount: 0 },
+        });
+      }
+      if (downDelta < 0) {
+        await tx.appListingMetric.updateMany({
+          where: { appListingId, thumbsDownCount: { lt: 0 } },
+          data: { thumbsDownCount: 0 },
+        });
+      }
+    }
+
+    return { saved, isNewReview: prior == null };
+  });
+
+  await bustRecommendMeanCache().catch(() => undefined);
+  return { review: review.saved, isNewReview: review.isNewReview };
+}
+
+/** The caller's OWN review for a listing (form prefill), or null. */
+export async function getMyAppListingReview(
+  appListingId: string,
+  userId: number
+): Promise<MyAppListingReview> {
+  const row = await dbRead.appListingReview.findUnique({
+    where: reviewKey(appListingId, userId),
+    select: { id: true, recommended: true, details: true, createdAt: true },
+  });
+  return row ?? null;
+}
+
+/**
+ * Keyset-paginated list of a listing's reviews, NEWEST-first. Excludes
+ * mod-excluded (`exclude`) AND `tosViolation` rows, so a future mod action takes
+ * effect on the visible list immediately. Keyset on `id DESC` (autoincrement,
+ * monotonic — `createdAt` can tie). Returns the page + `nextCursor` (last row's
+ * id) when more rows exist.
+ */
+export async function listAppListingReviews(
+  input: ListAppListingReviewsInput
+): Promise<{ items: AppListingReviewListItem[]; nextCursor?: number }> {
+  const take = Math.min(Math.max(input.limit ?? 20, 1), 50);
+  const rows = await dbRead.appListingReview.findMany({
+    where: {
+      appListingId: input.appListingId,
+      exclude: false,
+      tosViolation: false,
+      ...(input.cursor ? { id: { lt: input.cursor } } : {}),
+    },
+    orderBy: { id: 'desc' },
+    take: take + 1,
+    select: {
+      id: true,
+      recommended: true,
+      details: true,
+      createdAt: true,
+      user: { select: { id: true, username: true, image: true } },
+    },
+  });
+  const items = rows.slice(0, take);
+  const nextCursor = rows.length > take ? items[items.length - 1]?.id : undefined;
+  return { items, nextCursor };
+}


### PR DESCRIPTION
## What

The W13 unified store had the recommend-% **DISPLAY** and the `AppListingReview` / `AppListingMetric` tables (P0 migration), but the **write half was never built** — so there was no way to leave a review and the "N% recommend (M)" block was always empty. This adds the write path + read procs + the synchronous metric feed + the write UI. No migration (tables already exist).

## Server (`app-listings.router.ts` + new `app-listing-review.service.ts`)

- **`upsertReview`** (`protectedProcedure` + `enforceAppBlocksFlag`, rate-limited 30/60) — create-or-update the caller's thumbs/recommend review, keyed on the DB unique `(appListingId, userId)` (an upsert, not a 2nd row). Gates: **no self-review** (owner → `UNAUTHORIZED`), **approved-only** listing (missing → `NOT_FOUND`; draft/pending/rejected/removed → `BAD_REQUEST`), `details` trimmed + capped at 2000 (defense-in-depth on top of the zod cap; whitespace-only → null).
- **`getMyReview`** (`protectedProcedure` + flag) — the caller's own review for form prefill, or null.
- **`listReviews`** (`publicProcedure` + `enforceAppListingsReadFlag`, rate-limited 60/60) — keyset-paginated, newest-first; **already filters `exclude` + `tosViolation`** so a future mod action takes effect on the visible list with no read-path change.

### Synchronous recommend-metric feed (locked decision — no batch rollup job)

Inside the **same tx** as the review upsert, `AppListingMetric.thumbsUp/DownCount` is adjusted by the **delta vs the user's prior review**:
- no prior (or prior was mod-`exclude`d) → **+1** to the chosen bucket;
- prior, same `recommended` → **no change** (details-only edit);
- prior, flipped `recommended` → **−1** old bucket, **+1** new bucket.

**Row existence:** the counter write is a Prisma `upsert` whose `create` seeds the row (clamped ≥0) — most listings have no `AppListingMetric` row today (no writer before this), so the first review creates it. **Non-negative:** the `update` uses atomic per-counter `increment`; a −1 only occurs when a prior *counted* review existed (which itself added +1, so the counter is ≥1), and a defensive guarded `updateMany` (`thumbsXCount < 0 → 0`) back-stops any drift. Once the counters are populated the existing `recommendRollup(row.metric)` display goes live automatically.

## Eligibility / flag gating

Any **signed-in user except the listing owner**, for **BOTH `onsite` and `offsite`** kinds, **no install/usage gate** (the locked W13 decision — the legacy 5-star path's enabled-install gate deliberately does **not** apply here). Writes throw when the store flag is off (`enforceAppBlocksFlag`); `listReviews` returns an empty page (mirrors `listAvailable`). **Dark** — reachable only on the mod-only `/apps/store-preview/[slug]` surface until the public `/apps/[slug]` **P2d** cutover.

## Client

- **`ReviewListingButton`** — a compact modal (thumbs Recommend / Don't + optional blurb), mounted next to `ReportListingButton` in the detail action column. **Hidden for the owner** (via the public DTO's `creator.id`) and signed-out viewers; prefills from `getMyReview`; on success invalidates `getAppDetail` so the recommend rollup refreshes.
- **`AppListingReviews`** — recent-reviews list below the recommend block; renders `details` as **escaped plain text** (React default escaping — never `dangerouslySetInnerHTML`), mod-filtered.

## Tests

- **Service** (`app-listing-review.service.test.ts`, DB mocked, `$transaction` runs against the write mock): metric delta for new / details-only edit / recommend flip; the non-negative clamp; mod-excluded prior treated as un-counted; self-review `UNAUTHORIZED`; approved-only `BAD_REQUEST`; details-over-cap rejected before any listing load; trim/whitespace→null; `getMyReview` returns/null; `listReviews` mod-filter + keyset + newest-first.
- **Browser** (`ReviewListingButton.browser.test.tsx`): owner + signed-out hiding; write wiring (pick Recommend + type details + submit → `upsertReview` called with exactly `{appListingId, recommended, details}`).

## Deferred follow-ups

- A **mod exclude/report path for individual reviews** (`listReviews` already filters `exclude`/`tosViolation`, so the read side is ready).
- Nothing else blocking — the reviews-list UI **is** included here.

## Merge note

Touches `app-listings.router.ts`, which the in-flight **edit-listing** PR also extends — the change here is purely **additive procs** (three new entries + one import block), trivial merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
