### PR TITLE
feat(app-blocks): ephemeral pre-submit dev-tunnel resolution (Phase 1)

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1671,6 +1671,16 @@ export const REDIS_SYS_KEYS = {
      * `sysRedis`, like the sibling BLOCKS caps/limiters.
      */
     DEV_TUNNEL: 'system:blocks:dev-tunnel',
+    /**
+     * Per-user rate-limit counter for EPHEMERAL (pre-submit) dev-tunnel starts —
+     * `startDevTunnel` when the caller owns NO AppBlock row for the slug yet
+     * (block-registry.service.ts resolveEphemeralDevPageBlock). Keyed
+     * `${DEV_TUNNEL_EPHEMERAL_RATE_LIMIT}:<userId>`. Same `INCR` + first-hit `EX`
+     * shape as the sibling BLOCKS limiters, on `sysRedis`. Blunts host-pool
+     * enumeration / DoS via ephemeral tunnel starts across many unclaimed slugs;
+     * the approved/owned path is unaffected (only the ephemeral branch increments).
+     */
+    DEV_TUNNEL_EPHEMERAL_RATE_LIMIT: 'system:blocks:dev-tunnel-ephemeral-rate-limit',
   },
   DOWNLOAD: {
     LIMITS: 'download:limits',

--- a/src/server/routers/__tests__/blocks.router.devTunnel.test.ts
+++ b/src/server/routers/__tests__/blocks.router.devTunnel.test.ts
@@ -19,6 +19,7 @@ const {
   mockStop,
   mockStopForUserBlock,
   mockGetActive,
+  mockSysRedis,
 } = vi.hoisted(() => ({
   mockIsAppBlocksEnabled: vi.fn(async () => true),
   mockIsDevTunnelEnabled: vi.fn(async () => true),
@@ -27,6 +28,13 @@ const {
   mockStop: vi.fn(async () => true),
   mockStopForUserBlock: vi.fn(async () => true),
   mockGetActive: vi.fn(async () => null),
+  // Ephemeral dev-tunnel rate limiter (INCR + first-hit EX). Default counter = 1
+  // (under the limit). Only the ephemeral branch touches it.
+  mockSysRedis: {
+    incrBy: vi.fn(async () => 1),
+    expire: vi.fn(async () => 1),
+    ttl: vi.fn(async () => 3600),
+  },
 }));
 
 vi.mock('~/server/services/block-registry.service', () => ({
@@ -55,7 +63,11 @@ vi.mock('~/server/db/client', () => ({
 }));
 vi.mock('~/server/redis/client', async () => {
   const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
-  return { ...actual, redis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) } };
+  return {
+    ...actual,
+    redis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+    sysRedis: mockSysRedis,
+  };
 });
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
   verifyBlockToken: vi.fn(),
@@ -111,11 +123,29 @@ const OWN_APP = {
   contentRating: null,
 };
 
+// Ephemeral (pre-submit) resolution — the synthetic shape resolveEphemeralDevPageBlock
+// returns when the caller owns NO AppBlock row for an UNCLAIMED slug.
+const EPHEMERAL_APP = {
+  appBlockId: 'ephemeral-new-app',
+  blockId: 'new-app',
+  appId: 'ephemeral-new-app',
+  status: 'ephemeral',
+  trustTier: 'unverified',
+  name: 'new-app',
+  pageTitle: 'new-app',
+  sandbox: 'allow-scripts allow-forms',
+  scopes: [],
+  contentRating: null,
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockIsAppBlocksEnabled.mockResolvedValue(true);
   mockIsDevTunnelEnabled.mockResolvedValue(true);
   mockResolveDev.mockResolvedValue(OWN_APP);
+  mockSysRedis.incrBy.mockResolvedValue(1); // under the ephemeral rate limit
+  mockSysRedis.expire.mockResolvedValue(1);
+  mockSysRedis.ttl.mockResolvedValue(3600);
   mockStart.mockResolvedValue({
     sessionId: 'bki_s',
     host: 'dev-0123456789abcdef.civit.ai',
@@ -160,6 +190,52 @@ describe('startDevTunnel — authz matrix', () => {
     });
     // ownership resolve was scoped to the caller
     expect(mockResolveDev).toHaveBeenCalledWith('my-app', 100, { db: 'write' });
+  });
+});
+
+describe('startDevTunnel — EPHEMERAL pre-submit rate limit (Phase 1)', () => {
+  const ephemeralInput = { blockId: 'new-app', sshPublicKey: PUBKEY };
+
+  it('ephemeral start UNDER the limit → mints, and increments the per-user limiter', async () => {
+    mockResolveDev.mockResolvedValue(EPHEMERAL_APP);
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    const res = await caller.startDevTunnel(ephemeralInput);
+    expect(res.host).toMatch(/^dev-[a-f0-9]{16}\.civit\.ai$/);
+    // The ephemeral limiter was incremented on the caller's own key.
+    expect(mockSysRedis.incrBy).toHaveBeenCalledTimes(1);
+    expect(mockSysRedis.incrBy).toHaveBeenCalledWith(
+      expect.stringContaining('dev-tunnel-ephemeral-rate-limit:100'),
+      1
+    );
+    expect(mockStart).toHaveBeenCalledWith({ userId: 100, blockId: 'new-app', sshPublicKey: PUBKEY });
+  });
+
+  it('ephemeral start OVER the limit → TOO_MANY_REQUESTS, never mints', async () => {
+    mockResolveDev.mockResolvedValue(EPHEMERAL_APP);
+    mockSysRedis.incrBy.mockResolvedValue(21); // max is 20
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    await expect(caller.startDevTunnel(ephemeralInput)).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('ephemeral start with a Redis-DOWN limiter → fails CLOSED (TOO_MANY_REQUESTS), never mints', async () => {
+    mockResolveDev.mockResolvedValue(EPHEMERAL_APP);
+    mockSysRedis.incrBy.mockRejectedValue(new Error('redis down'));
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    await expect(caller.startDevTunnel(ephemeralInput)).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it('the OWNED (non-ephemeral) path NEVER touches the ephemeral limiter', async () => {
+    // OWN_APP has status:'pending' (an owned, real row) — not 'ephemeral'.
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    await caller.startDevTunnel(input);
+    expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    expect(mockStart).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -578,6 +578,38 @@ async function refundBlockBuzzSpend(
   });
 }
 
+// EPHEMERAL DEV-TUNNEL rate limit (Phase 1 pre-submit). Per-user fixed window,
+// bounding how many EPHEMERAL (no-owned-AppBlock) dev-tunnel starts a single
+// author can trigger — blunts host-pool enumeration / DoS across many unclaimed
+// slugs. Applies ONLY to the ephemeral branch; the approved/owned path never
+// increments this counter.
+const EPHEMERAL_DEV_TUNNEL_RATE_LIMIT = { max: 20, windowSeconds: 3600 } as const;
+
+/**
+ * Atomically counts one ephemeral dev-tunnel start against this user's fixed
+ * window and returns whether the call is ALLOWED. Same `INCR` + first-hit `EX`
+ * (with a ttl<0 self-heal) shape as reserveBlockBuzzSpend / the dev-token
+ * limiter. Fails CLOSED (returns false) on a Redis error — an ephemeral tunnel
+ * start is not latency-critical, and failing closed here can never block the
+ * approved/owned path (which does not call this).
+ */
+async function checkEphemeralDevTunnelRateLimit(userId: number): Promise<boolean> {
+  const key = `${REDIS_SYS_KEYS.BLOCKS.DEV_TUNNEL_EPHEMERAL_RATE_LIMIT}:${userId}` as const;
+  try {
+    const count = await sysRedis.incrBy(key, 1);
+    if (count === 1) {
+      await sysRedis.expire(key, EPHEMERAL_DEV_TUNNEL_RATE_LIMIT.windowSeconds);
+    } else {
+      const ttl = await sysRedis.ttl(key);
+      if (ttl < 0) await sysRedis.expire(key, EPHEMERAL_DEV_TUNNEL_RATE_LIMIT.windowSeconds);
+    }
+    return count <= EPHEMERAL_DEV_TUNNEL_RATE_LIMIT.max;
+  } catch {
+    // Fail closed — never silently bypass the ephemeral enumeration limiter.
+    return false;
+  }
+}
+
 // Free-form slot strings are a cache-busting surface for anon callers. Bound
 // to the explicit model-slot set; the canonical source is now the slot registry
 // (src/shared/constants/slot-registry.ts) — re-exported under the SAME name so
@@ -993,6 +1025,23 @@ export const blocksRouter = router({
         db: 'write',
       });
       if (!app) throw throwNotFoundError('App not found');
+      // EPHEMERAL PRE-SUBMIT PATH (Phase 1): the caller owns no AppBlock row for
+      // this slug yet (resolveEphemeralDevPageBlock returned a synthetic
+      // `status:'ephemeral'` resolution — already anti-shadow-guarded so the slug
+      // is unclaimed / the caller's own pending). Rate-limit these host-pool
+      // allocations per-user to blunt enumeration / DoS across unclaimed slugs.
+      // The approved/owned path skips this entirely. Same bare NOT_FOUND is NOT
+      // reused here — the caller already proved ownership intent (unclaimed slug),
+      // so a 429 is the honest signal (no existence oracle: it fires only on the
+      // caller's OWN allowed ephemeral starts, never as a probe result).
+      if (app.status === 'ephemeral') {
+        if (!(await checkEphemeralDevTunnelRateLimit(ctx.user.id))) {
+          throw new TRPCError({
+            code: 'TOO_MANY_REQUESTS',
+            message: 'Too many dev tunnel starts for unsubmitted apps; please retry shortly',
+          });
+        }
+      }
       const { startDevTunnel } = await import('~/server/services/blocks/dev-tunnel.service');
       try {
         return await startDevTunnel({

--- a/src/server/services/__tests__/block-registry.resolve-dev.test.ts
+++ b/src/server/services/__tests__/block-registry.resolve-dev.test.ts
@@ -15,9 +15,14 @@ const { mockDbRead, mockDbWrite, mockRedis, mockSysRedis } = vi.hoisted(() => {
     findUnique: vi.fn(async (): Promise<unknown> => null),
     findFirst: vi.fn(async (): Promise<unknown> => null),
   });
+  const pubreq = () => ({ findFirst: vi.fn(async (): Promise<unknown> => null) });
   return {
-    mockDbRead: { $queryRaw: vi.fn(async () => []), appBlock: ab() },
-    mockDbWrite: { appBlock: ab() },
+    mockDbRead: {
+      $queryRaw: vi.fn(async () => []),
+      appBlock: ab(),
+      appBlockPublishRequest: pubreq(),
+    },
+    mockDbWrite: { appBlock: ab(), appBlockPublishRequest: pubreq() },
     mockRedis: {
       packed: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
       get: vi.fn(async () => null),
@@ -73,10 +78,61 @@ describe('BlockRegistry.resolveDevPageBlockForAuthor', () => {
     }
   );
 
-  it('returns null for another author’s app (foreign/absent → the same null, no oracle)', async () => {
-    // The ownership predicate is in the WHERE, so a foreign app simply doesn't match.
+  // ── EPHEMERAL PRE-SUBMIT FALLBACK (Phase 1) ──────────────────────────────
+
+  it('(a) resolves an EPHEMERAL synthetic for an UNCLAIMED slug the caller owns no row for', async () => {
+    // No owned AppBlock row (owned findFirst → null), no foreign AppBlock row
+    // (findUnique → null), no pending request (pubreq findFirst → null).
     mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('brand-new', 555);
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe('ephemeral');
+    expect(res?.trustTier).toBe('unverified');
+    expect(res?.scopes).toEqual([]); // scoped mint stays 403 until approval
+    expect(res?.contentRating).toBeNull(); // SFW default
+    expect(res?.sandbox).toBe('allow-scripts allow-forms');
+    expect(res?.blockId).toBe('brand-new');
+    // Synthetic, non-resolving ids — never an `appblk-`/UUID that could FK-resolve.
+    expect(res?.appBlockId).toBe('ephemeral-brand-new');
+    expect(res?.appId).toBe('ephemeral-brand-new');
+    // No iframeSrc — the route derives the host from the tunnel only.
+    expect((res as Record<string, unknown>).iframeSrc).toBeUndefined();
+    // Anti-shadow guard queries: indexed unique lookup + pending lookup on the slug.
+    expect(mockDbRead.appBlock.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { blockId: 'brand-new' } })
+    );
+    expect(mockDbRead.appBlockPublishRequest.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { slug: 'brand-new', status: 'pending' } })
+    );
+  });
+
+  it('(b) REFUSES (→ null, no oracle) a slug with a FOREIGN AppBlock row (approved, other owner)', async () => {
+    // The owned findFirst returns null (not the caller's), but a row EXISTS for
+    // the slug globally (@@unique) — so it belongs to someone else. Bare null.
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue({ id: 'apb_someone_else' });
     expect(await BlockRegistry.resolveDevPageBlockForAuthor('their-app', 555)).toBeNull();
+    // Refused at guard (A) — never even reaches the pending lookup.
+    expect(mockDbRead.appBlockPublishRequest.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('(c) REFUSES (→ null, no oracle) a slug with a FOREIGN pending publish request', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({ submittedByUserId: 999 });
+    expect(await BlockRegistry.resolveDevPageBlockForAuthor('someone-pending', 555)).toBeNull();
+  });
+
+  it('(d) ALLOWS an ephemeral resolution when the caller OWNS the pending publish request', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({ submittedByUserId: 555 });
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('my-pending', 555);
+    expect(res).not.toBeNull();
+    expect(res?.status).toBe('ephemeral');
+    expect(res?.blockId).toBe('my-pending');
   });
 
   it('returns null on empty inputs (fail-closed)', async () => {

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -1846,6 +1846,16 @@ export class BlockRegistry {
    *
    * NOTE: this returns NO iframeSrc — the route derives the iframe host from the
    * assigned tunnel host ONLY (T6). It cannot be used to serve a deployed bundle.
+   *
+   * EPHEMERAL PRE-SUBMIT FALLBACK (Phase 1): when the caller owns NO AppBlock row
+   * for `blockId` at all (the app has not been submitted/approved — no row + no
+   * OauthClient are created until moderator APPROVE), we attempt an EPHEMERAL
+   * resolution so an author can iterate on local code in the real host BEFORE
+   * submitting. It writes NO DB row and returns a synthetic resolution with safe
+   * `unverified` defaults (see resolveEphemeralDevPageBlock). SCOPED features
+   * (Buzz / App Storage block-token mint) remain 403 until approval — the prod
+   * block-token mint (`/api/v1/block-tokens`) still gates on `status:'approved'`
+   * and is untouched here; this is UI / local-code rendering only.
    */
   static async resolveDevPageBlockForAuthor(
     blockId: string,
@@ -1856,7 +1866,8 @@ export class BlockRegistry {
     const db = opts?.db === 'write' ? dbWrite : dbRead;
     const ab = await db.appBlock.findFirst({
       // Ownership-scoped: the app's OauthClient.userId is the v1 ownership source
-      // of truth (same as getMyAppRepo). A foreign-owned or missing app → null.
+      // of truth (same as getMyAppRepo). A foreign-owned or missing app → null,
+      // in which case we fall through to the ephemeral pre-submit path below.
       where: { blockId, app: { userId } },
       select: {
         id: true,
@@ -1868,7 +1879,10 @@ export class BlockRegistry {
         contentRating: true,
       },
     });
-    if (!ab) return null;
+    // No OWNED AppBlock row → try the ephemeral pre-submit resolution (Phase 1).
+    // resolveEphemeralDevPageBlock returns null (→ same bare NOT_FOUND, no oracle)
+    // for a slug claimed by anyone else, so a foreign-owned app is never leaked.
+    if (!ab) return this.resolveEphemeralDevPageBlock(blockId, userId, db);
     const manifest = (ab.manifest ?? {}) as Record<string, unknown>;
     const iframe = (manifest.iframe ?? {}) as { sandbox?: unknown };
     const page = (manifest.page ?? {}) as { title?: unknown };
@@ -1890,6 +1904,86 @@ export class BlockRegistry {
       sandbox: typeof iframe.sandbox === 'string' ? iframe.sandbox : '',
       scopes: declaredScopes,
       contentRating: typeof ab.contentRating === 'string' ? ab.contentRating : null,
+    };
+  }
+
+  /**
+   * EPHEMERAL PRE-SUBMIT DEV RESOLUTION (Phase 1 — "ephemeral resolution", design
+   * approach C). Reached ONLY from resolveDevPageBlockForAuthor when the caller
+   * owns NO AppBlock row for `blockId`. Lets an author open a dev tunnel for a
+   * BRAND-NEW app they have not yet submitted (before any AppBlock/OauthClient row
+   * exists), so they can iterate on local code inside the real host. Writes NO DB
+   * row — the returned resolution is a purely synthetic, ownership/existence gate
+   * plus manifest DISPLAY defaults; the iframe host is still derived from the live
+   * tunnel only (the resolution carries no iframeSrc).
+   *
+   * SECURITY — ANTI-SHADOW GUARD (refuse any slug claimed by someone else, with NO
+   * existence oracle — every refusal returns the SAME bare null the "foreign /
+   * absent app" case returns):
+   *   (A) if ANY AppBlock row exists for `blockId` → REFUSE. The caller-owned row
+   *       was already checked (and returned) by the caller, so any row reaching
+   *       here is FOREIGN. `block_id` is GLOBALLY unique (`@@unique([blockId])`,
+   *       `app_blocks_block_id_unique`), so a single indexed lookup settles it: a
+   *       row (any status/owner) means the slug is claimed and can never become
+   *       the caller's — a superset of "an approved AppBlock exists (any owner)".
+   *   (B) if an AppBlockPublishRequest with `status:'pending'` exists for `blockId`
+   *       owned by a DIFFERENT user → REFUSE. The partial unique index
+   *       `UNIQUE(slug) WHERE status='pending'` guarantees ≤1 pending row per slug,
+   *       so this is a single indexed (`app_block_publish_requests_slug_idx`)
+   *       lookup. The caller's OWN pending request is ALLOWED (they are claiming
+   *       the slug), as is a truly-unclaimed slug.
+   * A user can therefore NEVER get an ephemeral resolution for a slug that belongs
+   * to — or is pending for — anyone else, and the refusal never reveals which case
+   * triggered it (no existence/ownership/state oracle).
+   *
+   * Safe DISPLAY defaults (no DB row, no reviewed manifest): `unverified` trust
+   * tier, EMPTY scopes (scoped block-token mint stays 403 until approval — Phase 2),
+   * SFW `contentRating`, and a minimal `allow-scripts allow-forms` sandbox that
+   * matches the unverified-tier allowed set (the client re-clamps via
+   * intersectSandbox, so this can only ever be as wide as the tier permits). The
+   * synthetic appBlockId/appId use an `ephemeral-<slug>` namespace that can never
+   * collide with a real AppBlock.id or an OauthClient.id (UUIDv4 / `appblk-<slug>`).
+   */
+  private static async resolveEphemeralDevPageBlock(
+    blockId: string,
+    userId: number,
+    db: typeof dbRead | typeof dbWrite
+  ): Promise<DevPageBlockResolution | null> {
+    // Guard (A): any FOREIGN AppBlock row for this slug → refuse (slug is claimed
+    // globally via @@unique([blockId])). Indexed on app_blocks_block_id_unique.
+    const claimed = await db.appBlock.findUnique({
+      where: { blockId },
+      select: { id: true },
+    });
+    if (claimed) return null;
+    // Guard (B): a FOREIGN pending publish request for this slug → refuse. ≤1
+    // pending row per slug (partial unique index). The caller's own pending is OK.
+    const pending = await db.appBlockPublishRequest.findFirst({
+      where: { slug: blockId, status: 'pending' },
+      select: { submittedByUserId: true },
+    });
+    if (pending && pending.submittedByUserId !== userId) return null;
+    // ALLOWED — truly-unclaimed slug, or the caller owns the pending request.
+    return {
+      // Synthetic, non-resolving ids (`ephemeral-<slug>`): the render path never
+      // FK-resolves these (the prod block-token mint 403s on the unapproved app
+      // before any appId/appBlockId lookup), and the prefix can never equal a real
+      // AppBlock.id nor an OauthClient.id (UUIDv4 / `appblk-<slug>`).
+      appBlockId: `ephemeral-${blockId}`,
+      blockId,
+      appId: `ephemeral-${blockId}`,
+      status: 'ephemeral',
+      trustTier: 'unverified',
+      name: blockId,
+      pageTitle: blockId,
+      // Minimal safe sandbox for an unverified tier (client intersectSandbox
+      // re-clamps to the allowlist ∪ MINIMAL_SANDBOX regardless).
+      sandbox: 'allow-scripts allow-forms',
+      // EMPTY — scoped features (Buzz / App Storage) require an approved,
+      // mod-reviewed scope grant; the block-token mint stays 403 until approval.
+      scopes: [],
+      // SFW default — no reviewed content rating exists pre-submit.
+      contentRating: null,
     };
   }
 


### PR DESCRIPTION
Let an author open a dev tunnel for an app that has no server-side AppBlock
row yet (before submit/approve), so they can iterate on local code inside the
real PageBlockHost. UI / local-code rendering only — scoped block-token mint
(Buzz / App Storage) stays 403 until approval (Phase 2, untouched).

resolveDevPageBlockForAuthor now falls back to a synthetic ephemeral resolution
(status:'ephemeral', unverified tier, empty scopes, SFW, allow-scripts
allow-forms sandbox, synthetic non-resolving ephemeral-<slug> ids) when the
caller owns no AppBlock row — writing NO DB row. Both call sites (the SSR dev
page + the startDevTunnel mint gate) share this path so they agree.

Anti-shadow guard (no existence oracle — every refusal returns the same bare
null): refuse any slug that already has ANY AppBlock row (foreign, globally
unique block_id) or a foreign pending publish request; allow only truly
unclaimed slugs or the caller's own pending. Per-user fixed-window rate limit
(20/hr, fail-closed) on ephemeral tunnel starts blunts host-pool enumeration /
DoS; the approved/owned path never increments it. Every existing gate
(AppBlocksDevTunnel scope, app-blocks-dev-tunnel kill-switch, author flag) is
preserved unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
