### PR TITLE
fix(dev-tunnel): validate ephemeral slug + honest oracle comment + tests

### DIFF
--- a/src/server/routers/__tests__/blocks.router.devTunnel.test.ts
+++ b/src/server/routers/__tests__/blocks.router.devTunnel.test.ts
@@ -237,6 +237,22 @@ describe('startDevTunnel — EPHEMERAL pre-submit rate limit (Phase 1)', () => {
     expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
     expect(mockStart).toHaveBeenCalledTimes(1);
   });
+
+  it('a FOREIGN/absent slug (resolve → null) → NOT_FOUND WITHOUT touching the ephemeral limiter', async () => {
+    // The resolver already refused (foreign-claimed OR non-canonical slug → the
+    // same bare null). The router must NOT_FOUND at the ownership gate BEFORE the
+    // ephemeral branch — so a probe for someone else's slug can never even
+    // consume the caller's rate-limit budget (the claimed-vs-unclaimed budget
+    // asymmetry the honest-oracle comment documents). Distinct from the "OWNED
+    // path" test above: that resolves to a real row, this resolves to null.
+    mockResolveDev.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(authedCtx(100, true) as never);
+    await expect(caller.startDevTunnel({ blockId: 'their-app', sshPublicKey: PUBKEY })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+    expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
 });
 
 describe('stopDevTunnel / devTunnelStatus', () => {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1028,12 +1028,24 @@ export const blocksRouter = router({
       // EPHEMERAL PRE-SUBMIT PATH (Phase 1): the caller owns no AppBlock row for
       // this slug yet (resolveEphemeralDevPageBlock returned a synthetic
       // `status:'ephemeral'` resolution — already anti-shadow-guarded so the slug
-      // is unclaimed / the caller's own pending). Rate-limit these host-pool
-      // allocations per-user to blunt enumeration / DoS across unclaimed slugs.
-      // The approved/owned path skips this entirely. Same bare NOT_FOUND is NOT
-      // reused here — the caller already proved ownership intent (unclaimed slug),
-      // so a 429 is the honest signal (no existence oracle: it fires only on the
-      // caller's OWN allowed ephemeral starts, never as a probe result).
+      // is unclaimed / the caller's own pending / canonical). Rate-limit these
+      // host-pool allocations per-user to blunt enumeration / DoS across unclaimed
+      // slugs. The approved/owned path skips this entirely.
+      //
+      // HONEST SECURITY NOTE (not a full "no existence oracle"): a claimed slug
+      // returns the bare NOT_FOUND above (consuming NO rate-limit budget) while an
+      // unclaimed slug reaches this branch (consuming budget / allocating a host),
+      // so a claimed-vs-unclaimed signal is INHERENT — and once a caller exhausts
+      // their 20/hr budget, claimed→NOT_FOUND vs unclaimed→429 becomes freely
+      // distinguishable. What the guard DOES guarantee: it never distinguishes
+      // AMONG the claimed cases (foreign-approved / foreign-pending / foreign-
+      // suspended all return the identical bare NOT_FOUND). Approved slugs are
+      // already public (they render at `<slug>.civit.ai`), so the only residual
+      // leak is the existence of a PENDING/SUSPENDED slug — and only to another
+      // author-flagged (trusted-cohort) caller. The 429 message is kept (not
+      // suppressed to NOT_FOUND): actionable rate-limit feedback is better UX for
+      // that trusted cohort, and it exposes nothing an exhausted-budget probe
+      // couldn't already infer.
       if (app.status === 'ephemeral') {
         if (!(await checkEphemeralDevTunnelRateLimit(ctx.user.id))) {
           throw new TRPCError({

--- a/src/server/services/__tests__/block-registry.resolve-dev.test.ts
+++ b/src/server/services/__tests__/block-registry.resolve-dev.test.ts
@@ -135,6 +135,31 @@ describe('BlockRegistry.resolveDevPageBlockForAuthor', () => {
     expect(res?.blockId).toBe('my-pending');
   });
 
+  it.each([
+    ['UpperCase', 'uppercase letters'],
+    ['my.app', 'a dot'],
+    ['my:app', 'a colon'],
+    ['1leading', 'a leading digit'],
+    ['-leading', 'a leading hyphen'],
+    ['trailing-', 'a trailing hyphen'],
+    ['ab', 'under the 3-char minimum'],
+    ['a'.repeat(41), 'over the 40-char maximum'],
+  ])(
+    '(e) REFUSES (→ null, no oracle) a NON-CANONICAL slug %s (%s) WITHOUT any ephemeral DB lookup',
+    async (badSlug) => {
+      // No owned row for the (non-canonical) slug → falls into the ephemeral path,
+      // where guard (C) rejects it BEFORE the anti-shadow DB reads. Same bare null
+      // a claimed slug returns — a non-canonical slug can never match a real row
+      // (every stored blockId/pending slug is canonical), so this only burns a
+      // rate-limited host-pool allocation if allowed through.
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      expect(await BlockRegistry.resolveDevPageBlockForAuthor(badSlug, 555)).toBeNull();
+      // Rejected up-front — neither anti-shadow lookup runs.
+      expect(mockDbRead.appBlock.findUnique).not.toHaveBeenCalled();
+      expect(mockDbRead.appBlockPublishRequest.findFirst).not.toHaveBeenCalled();
+    }
+  );
+
   it('returns null on empty inputs (fail-closed)', async () => {
     expect(await BlockRegistry.resolveDevPageBlockForAuthor('', 555)).toBeNull();
     expect(await BlockRegistry.resolveDevPageBlockForAuthor('my-app', 0)).toBeNull();

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -3,6 +3,7 @@ import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { manifestSettingsSchema } from '~/server/schema/blocks/manifest-settings.meta.schema';
+import { SLUG_REGEX } from '~/server/schema/blocks/publish-request.schema';
 import { BlockRevocation } from '~/server/services/block-revocation.service';
 import {
   getPopularCheckpointForEcosystem,
@@ -1917,9 +1918,18 @@ export class BlockRegistry {
    * plus manifest DISPLAY defaults; the iframe host is still derived from the live
    * tunnel only (the resolution carries no iframeSrc).
    *
-   * SECURITY — ANTI-SHADOW GUARD (refuse any slug claimed by someone else, with NO
-   * existence oracle — every refusal returns the SAME bare null the "foreign /
-   * absent app" case returns):
+   * SECURITY — ANTI-SHADOW GUARD (refuse any slug claimed by someone else). Every
+   * refusal returns the SAME bare null the "foreign / absent app" case returns, so
+   * the guard NEVER distinguishes AMONG the claimed cases: foreign-approved,
+   * foreign-pending, and foreign-suspended all yield an identical bare null. It is
+   * NOT a full "no existence oracle" (see the caller comment in blocks.router.ts):
+   * a claimed slug returns null (consuming no host-pool / rate-limit budget) while
+   * an unclaimed slug returns a synthetic resolution (which downstream may allocate
+   * a rate-limited host), so a claimed-vs-unclaimed signal is inherent. Approved
+   * slugs are already PUBLIC (they render at `<slug>.civit.ai`), so the only
+   * residual signal this leaks is the EXISTENCE of a pending/suspended slug — and
+   * only to another author-flagged (trusted-cohort) caller, gated behind the
+   * per-user rate limit. That residual is the accepted trade for the pre-submit UX.
    *   (A) if ANY AppBlock row exists for `blockId` → REFUSE. The caller-owned row
    *       was already checked (and returned) by the caller, so any row reaching
    *       here is FOREIGN. `block_id` is GLOBALLY unique (`@@unique([blockId])`,
@@ -1932,9 +1942,17 @@ export class BlockRegistry {
    *       so this is a single indexed (`app_block_publish_requests_slug_idx`)
    *       lookup. The caller's OWN pending request is ALLOWED (they are claiming
    *       the slug), as is a truly-unclaimed slug.
+   *   (C) if `blockId` is not a CANONICAL slug (the same `SLUG_REGEX` + 3–40-char
+   *       bounds submit enforces on `manifest.blockId`) → REFUSE, returning the
+   *       same bare null BEFORE any DB read. Every stored AppBlock.blockId / pending
+   *       slug is canonical, so a non-canonical `blockId` can never match a real row
+   *       — without this guard an uppercase / dotted / over-length / leading-digit
+   *       string would sail past guards (A)/(B) as "unclaimed" and burn a
+   *       rate-limited host-pool allocation. The owned path is unaffected (its rows
+   *       are always canonical, so it never reaches here).
    * A user can therefore NEVER get an ephemeral resolution for a slug that belongs
-   * to — or is pending for — anyone else, and the refusal never reveals which case
-   * triggered it (no existence/ownership/state oracle).
+   * to — or is pending for — anyone else, nor for a structurally-invalid slug, and
+   * the refusal never reveals WHICH of these cases triggered it.
    *
    * Safe DISPLAY defaults (no DB row, no reviewed manifest): `unverified` trust
    * tier, EMPTY scopes (scoped block-token mint stays 403 until approval — Phase 2),
@@ -1949,6 +1967,17 @@ export class BlockRegistry {
     userId: number,
     db: typeof dbRead | typeof dbWrite
   ): Promise<DevPageBlockResolution | null> {
+    // Guard (C): reject a non-CANONICAL slug BEFORE any DB read (same bare null,
+    // no oracle). Canonical = the exact constraint submit enforces on
+    // manifest.blockId (SLUG_REGEX + 3–40 chars). Every stored blockId/pending
+    // slug is canonical, so a non-canonical string can never match a real row —
+    // rejecting it here stops an uppercase / dotted (`a.b`) / over-length /
+    // leading-digit slug from being treated as "unclaimed" and burning a
+    // rate-limited host-pool allocation. The owned path never reaches this
+    // (its rows are always canonical, so guard-A/B and this are moot for it).
+    if (blockId.length < 3 || blockId.length > 40 || !SLUG_REGEX.test(blockId)) {
+      return null;
+    }
     // Guard (A): any FOREIGN AppBlock row for this slug → refuse (slug is claimed
     // globally via @@unique([blockId])). Indexed on app_blocks_block_id_unique.
     const claimed = await db.appBlock.findUnique({

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -351,6 +351,33 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
     expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
 
+  it('treats a synthetic ephemeral-<slug> page instance id as non-approved → 404, no token', async () => {
+    // The dev-tunnel ephemeral resolution mints synthetic `ephemeral-<slug>`
+    // ids (page instance `page_ephemeral-<slug>`). Those never name a real
+    // approved AppBlock.id, so the mint's resolvePageBlock(appBlockId) lookup
+    // yields null → 404. This locks that a pre-submit ephemeral app can never
+    // mint a scoped block token (Buzz / App Storage stay 403/404 until approval).
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(null);
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(
+      makeReq({
+        origin: 'https://civitai.com',
+        body: {
+          blockInstanceId: 'page_ephemeral-my-app',
+          slotContext: { entityType: 'none', slotId: 'app.page' },
+        },
+      }),
+      res
+    );
+    expect(res._status).toBe(404);
+    // The synthetic id is passed through verbatim to the (null-yielding) lookup.
+    expect(mockBlockRegistry.resolvePageBlock).toHaveBeenCalledWith('ephemeral-my-app', {
+      db: 'write',
+    });
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
   it('rejects a page request whose instance id is not page_<appBlockId>', async () => {
     const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
     const res = makeRes();


### PR DESCRIPTION
Fast-follow security-audit fixes to #2983 (ephemeral pre-submit dev-tunnel resolution). No Prisma migration; behavior of the approved/owned path is unchanged.

## Fix 1 — validate the ephemeral blockId against the canonical slug format
The ephemeral fallback used the RAW client `blockId` (router input is only `z.string().min(1).max(64)`), so an uppercase / dotted (`a.b`) / colon / over-length (41–64) / leading-digit slug sailed past the anti-shadow guards as "unclaimed" and burned a rate-limited host-pool allocation.

**Placement chosen: (b) — a guard at the top of `resolveEphemeralDevPageBlock`** (returns the same bare `null`, no oracle), NOT the zod-input variant (a). Reasoning:
- The resolver is the **shared chokepoint**: both `startDevTunnel` *and* the SSR dev page (`/apps/dev/[blockId].tsx`) reach it with a raw user-controlled slug. Tightening only the `startDevTunnel` zod input (a) would leave the SSR page granting ephemeral resolutions for non-canonical slugs. (b) closes both with one guard.
- It preserves the exact "same bare null" contract the design leans on — a non-canonical slug returns `null` → `NOT_FOUND` / `notFound`, identical to a claimed slug, leaking nothing (a non-canonical slug can never name a real row, so it carries zero existence info).
- No regression risk: every stored `AppBlock.blockId` / pending slug is canonical — submit enforces exactly `length 3–40 && SLUG_REGEX` on `manifest.blockId` (`publish-request.service.ts:992`) — so the owned path (checked first) never reaches the guard.
- The guard runs **before** the two anti-shadow DB reads, so garbage input costs no query.

## Fix 2 — correct the overstated "no existence oracle" comments
The router comment and the resolver docstring claimed the design has "no existence oracle" / the 429 "never fires as a probe result." That's inaccurate: a claimed slug returns `NOT_FOUND` consuming **no** rate-limit budget while an unclaimed slug consumes budget / allocates a host, so a claimed-vs-unclaimed signal is **inherent** — and once a caller exhausts the 20/hr budget, `claimed→NOT_FOUND` vs `unclaimed→429` is freely distinguishable. Rewrote both to state the **actual** guarantee: the guard does not distinguish AMONG the claimed cases (foreign-approved / foreign-pending / foreign-suspended all return the identical bare null); approved slugs are already public (`<slug>.civit.ai`); so the only residual leak is the existence of a **pending/suspended** slug, and only to another author-flagged (trusted-cohort) caller. **429 behavior is unchanged** — the actionable rate-limit message is better UX for the trusted cohort and exposes nothing an exhausted-budget probe couldn't already infer.

## Fix 3 — tests
- `block-registry.resolve-dev.test.ts`: 8 non-canonical slugs (uppercase, dot, colon, leading-digit, leading/trailing hyphen, under-3, over-40) each get **no** ephemeral resolution and trigger **no** anti-shadow DB lookup.
- `blocks.router.devTunnel.test.ts`: a foreign/absent slug (`resolve → null`) returns `NOT_FOUND` **without** incrementing the ephemeral rate limiter (distinct from the existing owned-path test, which resolves to a real row).
- `page-mint.test.ts`: a synthetic `page_ephemeral-<slug>` instance id resolves to a non-approved app → **404**, no token (locks that a pre-submit ephemeral app can't mint a scoped block token).

**Not touched:** block-token mint state machine, approve/submit flow, `resolvePageBlockBySlug`, `dev-tunnel.service.ts`.

**Deliberately skipped (noted in audit):** equalizing the two anti-shadow lookups to run unconditionally to erase the sub-ms timing gap between "foreign AppBlock exists" (1 query) and "pending-only" (2 queries). The side-channel is sub-millisecond — dwarfed by DB/network jitter and capped by the 20/hr per-user rate limit — and making both queries unconditional would add a wasted DB round-trip to every *allowed* start (the common case) for negligible gain.

## Verification
- `vitest run` the 3 files: **65 passed** (resolve-dev 18, devTunnel 23, page-mint 24).
- `tsc --noEmit` (full project, 12 GB heap): exit 0, **0 errors**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)