### PR TITLE
fix(buzz): distinguish zero-earning month from never-earned on creator comp widget

### DIFF
--- a/src/components/Buzz/Rewards/DailyCreatorCompReward.tsx
+++ b/src/components/Buzz/Rewards/DailyCreatorCompReward.tsx
@@ -86,16 +86,18 @@ export function DailyCreatorCompReward({
   const [search, setSearch] = useState('');
   const [debouncedSearch] = useDebouncedValue(search, 300);
 
-  const { data: resources = [], isLoading } = trpc.buzz.getDailyBuzzCompensation.useQuery(
+  const { data, isLoading } = trpc.buzz.getDailyBuzzCompensation.useQuery(
     { date: selectedDate, accountType: buzzAccountType, source },
     { enabled: features.buzz }
   );
+  const resources = data?.resources ?? [];
+  const hasPublishedResources = data?.hasPublishedResources ?? false;
 
-  const { data: licenseProbe = [] } = trpc.buzz.getDailyBuzzCompensation.useQuery(
+  const { data: licenseProbe } = trpc.buzz.getDailyBuzzCompensation.useQuery(
     { date: selectedDate, source: 'licenseFee' },
     { enabled: features.buzz && source === 'compensation' }
   );
-  const hasLicenseEarnings = licenseProbe.length > 0 || source === 'licenseFee';
+  const hasLicenseEarnings = (licenseProbe?.resources.length ?? 0) > 0 || source === 'licenseFee';
   const theme = useMantineTheme();
   const colorScheme = useComputedColorScheme('dark');
   const labelColor = colorScheme === 'dark' ? theme.colors.gray[0] : theme.colors.dark[5];
@@ -280,6 +282,9 @@ export function DailyCreatorCompReward({
     { totalBuzz: 0, totalCashCents: 0 }
   );
   const showCashTotal = source === 'licenseFee' && totalCashCents > 0;
+  // Established creators (any published resource) keep the two-column layout even on a
+  // zero-earning month, so the month selector doesn't jump between months.
+  const useTwoColLayout = !isLoading && (resources.length > 0 || hasPublishedResources);
 
   return (
     <>
@@ -287,10 +292,7 @@ export function DailyCreatorCompReward({
         className={classes.dashboardGrid}
         style={
           {
-            '--grid-cols':
-              !isLoading && resources.length > 0
-                ? 'minmax(0, 8fr) minmax(0, 4fr)'
-                : 'minmax(0, 1fr)',
+            '--grid-cols': useTwoColLayout ? 'minmax(0, 8fr) minmax(0, 4fr)' : 'minmax(0, 1fr)',
           } as React.CSSProperties
         }
       >
@@ -385,10 +387,11 @@ export function DailyCreatorCompReward({
               buzzColor={buzzConfig.color}
               buzzLabel={getAccountTypeLabel(buzzAccountType)}
               loading={isLoading}
+              mode={hasPublishedResources ? 'noEarningsThisMonth' : 'onboarding'}
             />
           )}
         </Paper>
-        {!isLoading && resources.length > 0 && (
+        {useTwoColLayout && (
           <Paper
             className={classes.tileCard}
             h="100%"

--- a/src/components/Buzz/Rewards/GenerationBuzzEmptyState.tsx
+++ b/src/components/Buzz/Rewards/GenerationBuzzEmptyState.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react';
 import { Button, Divider, Loader, Stack, Text, ThemeIcon } from '@mantine/core';
-import { IconChartBar, IconRocket } from '@tabler/icons-react';
+import { IconCalendarStats, IconChartBar, IconRocket } from '@tabler/icons-react';
 import Link from 'next/link';
 
 export type EmptyStateProps = {
@@ -10,9 +10,20 @@ export type EmptyStateProps = {
   buzzLabel: string;
   /** Show loading state instead of empty state */
   loading?: boolean;
+  /**
+   * `onboarding` — user has never published a resource; show the full "start earning" pitch.
+   * `noEarningsThisMonth` — user has published resources but earned nothing in the selected month;
+   * show a light message that preserves the widget height so the month selector doesn't jump.
+   */
+  mode?: 'onboarding' | 'noEarningsThisMonth';
 };
 
-export function GenerationBuzzEmptyState({ buzzColor, loading }: EmptyStateProps) {
+export function GenerationBuzzEmptyState({
+  buzzColor,
+  buzzLabel,
+  loading,
+  mode = 'onboarding',
+}: EmptyStateProps) {
   // Spotlight effect — uses refs + direct DOM manipulation to avoid re-renders on mouse move
   const spotlightRef = useRef<HTMLDivElement>(null);
   const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
@@ -28,6 +39,29 @@ export function GenerationBuzzEmptyState({ buzzColor, loading }: EmptyStateProps
     const el = spotlightRef.current;
     if (el) el.style.opacity = '0';
   }, []);
+
+  if (!loading && mode === 'noEarningsThisMonth') {
+    return (
+      <div className="mt-2">
+        <Divider />
+        <Stack gap="sm" p="lg" justify="center" align="center" style={{ minHeight: 300 }}>
+          <ThemeIcon size={48} variant="light" color="gray" radius="xl">
+            <IconCalendarStats size={24} />
+          </ThemeIcon>
+          <Text fw={700} size="lg" ta="center">
+            No {buzzLabel} Buzz earned this month
+          </Text>
+          <Text size="sm" c="dimmed" ta="center" maw={360}>
+            You didn&apos;t earn any {buzzLabel} Buzz from generations in this period. Pick another
+            month with the selector above to see your earnings.
+          </Text>
+          <Text size="xs" c="dimmed" ta="center">
+            Earnings can take up to 24 hours to appear
+          </Text>
+        </Stack>
+      </div>
+    );
+  }
 
   return (
     <div className="mt-2">
@@ -79,18 +113,34 @@ export function GenerationBuzzEmptyState({ buzzColor, loading }: EmptyStateProps
 
           <Stack gap="md" p="lg" pl="xl" justify="center" className="relative z-[1] h-full">
             <Stack gap={4}>
-              <Text size="xs" c="dimmed" tt="uppercase" fw={600} style={{ letterSpacing: '0.08em' }}>
+              <Text
+                size="xs"
+                c="dimmed"
+                tt="uppercase"
+                fw={600}
+                style={{ letterSpacing: '0.08em' }}
+              >
                 Start earning
               </Text>
-              <Text fw={600}>
-                Train &amp; publish models to earn Buzz
-              </Text>
+              <Text fw={600}>Train &amp; publish models to earn Buzz</Text>
             </Stack>
 
             <Stack gap={10}>
-              <StepRow number={1} text="Train a custom model (LoRA, checkpoint, etc.)" buzzColor={buzzColor} />
-              <StepRow number={2} text="Publish it on Civitai for the community" buzzColor={buzzColor} />
-              <StepRow number={3} text="Earn Buzz every time someone generates with it" buzzColor={buzzColor} />
+              <StepRow
+                number={1}
+                text="Train a custom model (LoRA, checkpoint, etc.)"
+                buzzColor={buzzColor}
+              />
+              <StepRow
+                number={2}
+                text="Publish it on Civitai for the community"
+                buzzColor={buzzColor}
+              />
+              <StepRow
+                number={3}
+                text="Earn Buzz every time someone generates with it"
+                buzzColor={buzzColor}
+              />
             </Stack>
 
             <Button

--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -1061,7 +1061,8 @@ export const getDailyCompensationRewardByUser = async ({
     },
   });
 
-  if (!clickhouse || !modelVersions.length) return [];
+  const hasPublishedResources = modelVersions.length > 0;
+  if (!clickhouse || !modelVersions.length) return { resources: [], hasPublishedResources };
 
   const minDate = dayjs.utc(date).startOf('day').startOf('month').toDate();
   const maxDate = dayjs.utc(date).endOf('day').endOf('month').toDate();
@@ -1089,11 +1090,11 @@ export const getDailyCompensationRewardByUser = async ({
     ORDER BY date DESC, total DESC
   `;
 
-  if (!generationData.length) return [];
+  if (!generationData.length) return { resources: [], hasPublishedResources };
 
   // cashData totals are in pennies — CH stores cashSettled amounts in
   // tenths-of-a-penny, so divide by 10.
-  return modelVersions
+  const resources = modelVersions
     .map(({ model, ...version }) => {
       const versionRows = generationData.filter((x) => x.modelVersionId === version.id);
       const buzzByDate = new Map<string, number>();
@@ -1127,6 +1128,8 @@ export const getDailyCompensationRewardByUser = async ({
     })
     .filter((v) => v.data.length > 0 || v.cashCents > 0)
     .sort((a, b) => b.totalSum + b.cashCents - (a.totalSum + a.cashCents));
+
+  return { resources, hasPublishedResources };
 };
 
 export async function claimWatchedAdReward({


### PR DESCRIPTION
## Problem

The **Generation Buzz Earned** widget on the Buzz Dashboard rendered the full "You haven't earned anything yet / Train a model" onboarding empty state for **any** month with zero earnings — even for creators who have published resources and earn in other months. The empty state also collapsed the total-Buzz row, chart, and Top Earning Resources panel, shifting the month-selector's position and making month browsing awkward.

Source: Freshdesk #66282 (reporter: NanashiAnon).

## Fix

Distinguish **"no earnings this month"** from **"never earned / no published resources"** using a signal that costs **zero additional fetches**: the server handler already loads the user's published model versions before hitting ClickHouse, so it now returns `hasPublishedResources` alongside `resources`.

- **Established creator** (owns ≥1 published model), zero this month → light **"No {Buzz} earned this month"** message, keeps the two-column layout so the month selector stays put.
- **Truly-new creator** (no published resources) → unchanged onboarding pitch.

### Changes
- `buzz.service.ts` — `getDailyCompensationRewardByUser` returns `{ resources, hasPublishedResources }` instead of a bare array.
- `DailyCreatorCompReward.tsx` — consumes the new shape; `useTwoColLayout` keeps grid + Top Earning panel for established creators on dry months.
- `GenerationBuzzEmptyState.tsx` — new `mode: 'onboarding' | 'noEarningsThisMonth'`; light variant holds widget height (`minHeight: 300`).

## Notes
Deliberately keyed on *has published resource* rather than *has ever earned*. The latter would match the ticket's wording marginally better but requires an extra lifetime ClickHouse query to fix a rare, cosmetic edge (published a model, earned nothing ever). Not worth the cost.

## Test
- typecheck ✅ / lint ✅ / prettier ✅
- Established creator + dry month → light message, selector stable across months
- New user (no models) → onboarding unchanged
- Earning month → chart + Top Earning list unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)