### PR TITLE
feat(apps): dedicated appListings visibility flag — decouple App Store from app-blocks-enabled (dark, OR-fallback)

### DIFF
--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -105,7 +105,11 @@ export function AppListingsMarketplaceBody() {
       limit: 24,
     },
     {
-      enabled: !!features.appBlocks,
+      // W13 (PR-W1a/D8): store-visibility gate = dedicated `appListings`
+      // OR-falling-back to `appBlocks`. Mirrors the server read gate
+      // (`enforceAppListingsReadFlag` → `isAppListingsEnabled`). Zero behavior
+      // change today (the `app-listings` flag doesn't exist yet).
+      enabled: !!(features.appListings || features.appBlocks),
       getNextPageParam: (lastPage) => lastPage.nextCursor,
     }
   );

--- a/src/components/Apps/__tests__/resolveAppsPageAccess.test.ts
+++ b/src/components/Apps/__tests__/resolveAppsPageAccess.test.ts
@@ -2,26 +2,50 @@ import { describe, it, expect } from 'vitest';
 import { resolveAppsPageAccess } from '../resolveAppsPageAccess';
 
 /**
- * F-E E1 — SSR gate-ordering invariant for /apps.
+ * F-E E1 + W13 PR-W1a/D8 — SSR gate-ordering + decoupling invariant for /apps.
  *
- * The marketplace is anon-capable but stays DARK behind the mod-segmented flag.
- * These tests pin the GATING INVARIANT so it FAILS if the gate is reordered,
- * removed, or a session→login redirect is reintroduced:
- *   - No flag → notFound, REGARDLESS of session (gate is the only control,
+ * The marketplace is anon-capable but stays DARK behind the store-visibility
+ * flag. W13 repoints that gate onto the dedicated `appListings` flag WITH an
+ * OR-fallback to `appBlocks` (access = `appListings || appBlocks`). These tests
+ * pin the GATING INVARIANT so it FAILS if the gate is reordered, removed, the
+ * OR-fallback is dropped, or a session→login redirect is reintroduced:
+ *   - Neither flag → notFound, REGARDLESS of session (gate is the only control,
  *     and it's a hard notFound — never a login redirect).
+ *   - `appListings`-only true → renders (the new dedicated visibility flag).
+ *   - `appBlocks`-only true → renders (the OR-FALLBACK — keeps the current
+ *     mods+testers cohort in while `app-listings` doesn't exist yet).
  *   - Flag granted + NO session → renders (the dark anon read path).
- *   - Flag granted + session → renders.
  */
 
 describe('resolveAppsPageAccess — gating invariant', () => {
-  it('no appBlocks flag → notFound (gate intact, even with no session)', () => {
+  it('neither flag → notFound (gate intact, even with no session)', () => {
     expect(resolveAppsPageAccess({ features: { appBlocks: false } })).toEqual({ notFound: true });
+    expect(
+      resolveAppsPageAccess({ features: { appBlocks: false, appListings: false } })
+    ).toEqual({ notFound: true });
   });
 
   it('undefined/null features → notFound (fails closed)', () => {
     expect(resolveAppsPageAccess({ features: undefined })).toEqual({ notFound: true });
     expect(resolveAppsPageAccess({ features: null })).toEqual({ notFound: true });
     expect(resolveAppsPageAccess({ features: {} })).toEqual({ notFound: true });
+  });
+
+  it('appListings-only true → renders (dedicated visibility flag lit)', () => {
+    expect(
+      resolveAppsPageAccess({ features: { appListings: true, appBlocks: false } })
+    ).toEqual({ props: {} });
+    // and with appBlocks entirely absent from the object
+    expect(resolveAppsPageAccess({ features: { appListings: true } })).toEqual({ props: {} });
+  });
+
+  it('appBlocks-only true → renders (the OR-fallback preserves the current cohort)', () => {
+    // The load-bearing dark-decoupling case: `app-listings` doesn't exist yet, so
+    // `appListings` is false but `appBlocks` still grants today's mods+testers.
+    expect(
+      resolveAppsPageAccess({ features: { appBlocks: true, appListings: false } })
+    ).toEqual({ props: {} });
+    expect(resolveAppsPageAccess({ features: { appBlocks: true } })).toEqual({ props: {} });
   });
 
   it('flag granted + NO session → renders (the dark anon read path, no login redirect)', () => {
@@ -31,10 +55,6 @@ describe('resolveAppsPageAccess — gating invariant', () => {
     // /login; E1 removes that so the page renders behind the flag.
     expect(result).not.toHaveProperty('redirect');
     expect(result).not.toHaveProperty('notFound');
-  });
-
-  it('flag granted (mod path today) → renders', () => {
-    expect(resolveAppsPageAccess({ features: { appBlocks: true } })).toEqual({ props: {} });
   });
 });
 

--- a/src/components/Apps/resolveAppsPageAccess.ts
+++ b/src/components/Apps/resolveAppsPageAccess.ts
@@ -3,26 +3,36 @@
  * standalone so the GATING INVARIANT is unit-testable in the node-env unit
  * project without importing the page's React/Mantine module graph.
  *
- * 🔒 GATING INVARIANT (F-E E1 — do not violate):
- *   - The `features.appBlocks` flag gate is FIRST and is the ONLY access
- *     control. A logged-out / non-mod user does NOT satisfy the Flipt
- *     `app-blocks-enabled` mod segment, so `features.appBlocks` is false for
- *     them → notFound. The page stays dark for real anon/non-mod users until
- *     the segment is widened at launch (a separate, product-signed-off step).
+ * 🔒 GATING INVARIANT (F-E E1 + W13 PR-W1a/D8 — do not violate):
+ *   - The STORE-VISIBILITY flag gate is FIRST and is the ONLY access control.
+ *     W13 repoints it onto the dedicated `appListings` flag with an OR-fallback
+ *     to `appBlocks`: access = `features.appListings || features.appBlocks`. A
+ *     logged-out / non-mod user satisfies NEITHER (both are mod-segmented today),
+ *     so access is false for them → notFound. The store stays dark for real
+ *     anon/non-mod users until a segment is widened at launch.
+ *   - WHY the OR-fallback: `appListings` (Flipt `app-listings`) does not exist at
+ *     merge time, so `features.appListings` resolves via its `availability:['mod']`
+ *     Flipt-down fallback (mods only) while `appBlocks` still carries the
+ *     app-dev-testers cohort — the OR keeps the CURRENT mods+testers viewers in
+ *     verbatim (ZERO behavior change today). A future true-public flip widens
+ *     ONLY `app-listings` (this store gate) without flipping the held
+ *     block-runtime `app-blocks-enabled` gate.
  *   - There is intentionally NO separate `session→login` redirect: behind the
  *     flag gate, a session-less request RENDERS the marketplace read-only
  *     instead of bouncing to /login. This is the "anon-capable but dark" read
- *     path — reachable by a real anon user ONLY once the flag grants access
+ *     path — reachable by a real anon user ONLY once a flag grants access
  *     (mods-only today). (`deIndex` is kept ON in the page <Meta> so the page is
  *     not crawlable pre-launch.)
  */
 export type AppsPageAccessResult = { notFound: true } | { props: Record<string, never> };
 
 export function resolveAppsPageAccess(args: {
-  features?: { appBlocks?: boolean } | null;
+  features?: { appBlocks?: boolean; appListings?: boolean } | null;
 }): AppsPageAccessResult {
-  // Flag gate FIRST and ONLY. No session check — the dark anon path renders
-  // behind the flag; access is decided entirely by features.appBlocks.
-  if (!args.features?.appBlocks) return { notFound: true };
+  // Store-visibility gate FIRST and ONLY. No session check — the dark anon path
+  // renders behind the flag. W13: dedicated `appListings` flag OR-falling-back to
+  // `appBlocks` so the current mods+testers cohort keeps access while
+  // `app-listings` doesn't yet exist (zero behavior change today).
+  if (!(args.features?.appListings || args.features?.appBlocks)) return { notFound: true };
   return { props: {} };
 }

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -18,7 +18,11 @@ export const getServerSideProps = createServerSideProps({
 export default function AppsPage() {
   const features = useFeatureFlags();
 
-  if (!features.appBlocks) return <NotFound />;
+  // W13 (PR-W1a/D8): store-visibility gate = dedicated `appListings` OR-falling-
+  // back to `appBlocks` (mirrors the SSR `resolveAppsPageAccess` gate). Zero
+  // behavior change today — `app-listings` doesn't exist yet, so `appListings`
+  // resolves mods-only and `appBlocks` covers the app-dev-testers cohort.
+  if (!(features.appListings || features.appBlocks)) return <NotFound />;
 
   return (
     <>

--- a/src/pages/apps/store-preview/[slug].tsx
+++ b/src/pages/apps/store-preview/[slug].tsx
@@ -40,12 +40,16 @@ export default function AppStoreListingDetailPage() {
   // Anon-capable public read path — fires only behind the appBlocks flag (mods
   // today) with a slug. Returns ONLY the ListingDetail allowlist; a missing /
   // non-approved slug 404s server-side. retry:false so it settles into NotFound.
+  // W13 (PR-W1a/D8): store-visibility gate = dedicated `appListings` OR-falling-
+  // back to `appBlocks`. Zero behavior change today (the `app-listings` flag
+  // doesn't exist yet, so this resolves to today's mods+app-dev-testers cohort).
+  const canSeeStore = features.appListings || features.appBlocks;
   const { data, isLoading, error } = trpc.appListings.getAppDetail.useQuery(
     { slug },
-    { enabled: !!features.appBlocks && !!slug, retry: false }
+    { enabled: !!canSeeStore && !!slug, retry: false }
   );
 
-  if (!features.appBlocks) return <NotFound />;
+  if (!canSeeStore) return <NotFound />;
   if (error) return <NotFound />;
 
   const detail = data as ListingDetail | undefined;

--- a/src/server/routers/__tests__/app-listings.router.read-flag-gate.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.read-flag-gate.test.ts
@@ -5,29 +5,33 @@ import { TRPCError } from '@trpc/server';
  * W13 P2a — the DARK-POSTURE gate on the unified store read path.
  *
  * `appListings.listAvailable` / `getAppDetail` are `publicProcedure`s behind
- * `enforceAppListingsReadFlag` (the mod-segmented App Blocks flag). This is the
- * SINGLE control that keeps the whole store dark until the segment is widened at
- * cutover. `isAppBlocksEnabled` is mocked with a FAITHFUL per-user impl (ON only
- * when the caller is a moderator, matching the live `app-blocks-enabled` rule),
- * and the read service is mocked so importing the router doesn't drag in the
- * generated Prisma client (stale in a PR worktree). We then drive the REAL
- * router so the middleware's `{ user: ctx.user }` wiring is what decides:
+ * `enforceAppListingsReadFlag`. W13 (PR-W1a/D8) repointed that middleware onto
+ * the DEDICATED store-visibility flag `isAppListingsEnabled` (which itself
+ * OR-falls-back to `isAppBlocksEnabled`, so the current mods+testers cohort is
+ * unchanged today). This is the SINGLE control that keeps the whole store dark
+ * until the segment is widened at cutover. `isAppListingsEnabled` is mocked with
+ * a FAITHFUL per-user impl (ON only when the caller is a moderator — matching the
+ * live posture where the fallback grants mods), and the read service is mocked so
+ * importing the router doesn't drag in the generated Prisma client (stale in a PR
+ * worktree). We then drive the REAL router so the middleware's `{ user: ctx.user }`
+ * wiring is what decides:
  *   - list:   anon/non-mod → EMPTY page, service NOT consulted; mod → served.
  *   - detail: anon/non-mod → NOT_FOUND, service NOT consulted; mod → served.
  *   - flag lit for anon → served (proves the path is anon-CAPABLE, no leftover
  *     isModerator gate) — the deliberate cutover widen.
  */
 
-const { mockIsAppBlocksEnabled, mockListAvailableListings, mockGetListingDetail } = vi.hoisted(
+const { mockIsAppListingsEnabled, mockListAvailableListings, mockGetListingDetail } = vi.hoisted(
   () => ({
-    mockIsAppBlocksEnabled: vi.fn(),
+    mockIsAppListingsEnabled: vi.fn(),
     mockListAvailableListings: vi.fn(),
     mockGetListingDetail: vi.fn(),
   })
 );
 
+// W13: the read middleware now gates on the dedicated `isAppListingsEnabled`.
 vi.mock('~/server/services/app-blocks-flag', () => ({
-  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppListingsEnabled: mockIsAppListingsEnabled,
 }));
 // The read service is dynamically imported by the procs; mock it so the DB /
 // generated client is never loaded, and so we can assert "NOT consulted".
@@ -50,7 +54,11 @@ vi.mock('~/server/utils/server-domain', () => ({
 import { appListingsRouter } from '../app-listings.router';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 
-/** Faithful mod-segmented flag: ON iff the caller is a moderator (anon → false). */
+/**
+ * Faithful stand-in for the live `isAppListingsEnabled` posture today: ON iff the
+ * caller is a moderator (anon/non-mod → false). This matches the OR-fallback to
+ * `app-blocks-enabled` while the `app-listings` flag doesn't yet exist.
+ */
 function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
   return Promise.resolve(!!opts?.user?.isModerator);
 }
@@ -73,8 +81,8 @@ const modUser = { id: 1, isModerator: true, tier: 'free', username: 'mod' };
 const normalUser = { id: 2, isModerator: false, tier: 'free', username: 'user' };
 
 beforeEach(() => {
-  mockIsAppBlocksEnabled.mockReset();
-  mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+  mockIsAppListingsEnabled.mockReset();
+  mockIsAppListingsEnabled.mockImplementation(fakePerUserFlag);
   mockListAvailableListings.mockReset();
   mockListAvailableListings.mockResolvedValue({ items: [{ id: 'apl_1' }], nextCursor: undefined });
   mockGetListingDetail.mockReset();
@@ -87,7 +95,7 @@ describe('appListings.listAvailable — dark posture', () => {
     const result = await caller.listAvailable({ limit: 20 });
     expect(result).toEqual({ items: [], nextCursor: undefined });
     expect(mockListAvailableListings).not.toHaveBeenCalled();
-    expect(mockIsAppBlocksEnabled).toHaveBeenCalledWith({ user: undefined });
+    expect(mockIsAppListingsEnabled).toHaveBeenCalledWith({ user: undefined });
   });
 
   it('non-moderator (flag off): empty page, service NOT consulted', async () => {
@@ -105,7 +113,7 @@ describe('appListings.listAvailable — dark posture', () => {
   });
 
   it('anonymous WITH the flag widened (cutover): served — proves anon-capable', async () => {
-    mockIsAppBlocksEnabled.mockResolvedValue(true);
+    mockIsAppListingsEnabled.mockResolvedValue(true);
     const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
     const result = await caller.listAvailable({ limit: 20 });
     expect(result).toEqual({ items: [{ id: 'apl_1' }], nextCursor: undefined });

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -47,7 +47,11 @@ import {
   resolveReportSchema,
 } from '~/server/schema/blocks/offsite-moderation.schema';
 import { rateLimit } from '~/server/middleware.trpc';
-import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import {
+  isAppBlocksAuthorEnabled,
+  isAppBlocksEnabled,
+  isAppListingsEnabled,
+} from '~/server/services/app-blocks-flag';
 import {
   appDeveloperProcedure,
   middleware,
@@ -100,15 +104,21 @@ const enforceAppBlocksAuthorFlag = middleware(async ({ ctx, next }) => {
 
 /**
  * Flag gate for the P2a PUBLIC READ procs (unified store). Anon-CAPABLE but DARK
- * until launch: for a real anon / non-mod viewer the mod-segmented
- * `app-blocks-enabled` flag never matches → mark `_appBlocksDisabled` so the
- * query returns an EMPTY page / NOT_FOUND (never an error, mirroring
- * `blocks.router`'s read gate) rather than throwing. The surface only serves
- * real anon callers once the SEGMENT is widened at launch (a deliberate, separate
- * Flipt change — and, at the read-path cutover, its own `appListings` flag).
+ * until launch: for a real anon / non-mod viewer the flag never matches → mark
+ * `_appBlocksDisabled` so the query returns an EMPTY page / NOT_FOUND (never an
+ * error, mirroring `blocks.router`'s read gate) rather than throwing.
+ *
+ * W13 (PR-W1a / D8): repointed onto the DEDICATED store-visibility flag
+ * `isAppListingsEnabled` — which itself OR-falls-back to `isAppBlocksEnabled`, so
+ * the currently-visible cohort (mods + app-dev-testers via `app-blocks-enabled`)
+ * is UNCHANGED today while the `app-listings` flag does not yet exist. A future
+ * true-public flip widens ONLY `app-listings` (this store read path) WITHOUT
+ * touching the held block-runtime gate. The AUTHOR gate
+ * (`enforceAppBlocksAuthorFlag`) + the mod-only backfill (`enforceAppBlocksFlag`)
+ * intentionally stay on their existing flags.
  */
 const enforceAppListingsReadFlag = middleware(async ({ ctx, next }) => {
-  if (await isAppBlocksEnabled({ user: ctx.user })) return next();
+  if (await isAppListingsEnabled({ user: ctx.user })) return next();
   return next({ ctx: { _appBlocksDisabled: true } });
 });
 

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -78,8 +78,9 @@ import { isHostForColor } from '~/server/utils/server-domain';
  *     service-layer owner check still bounds every mutation to the caller.
  *   - `moderatorProcedure` (+ `enforceAppBlocksFlag` on backfill) — the mod-only
  *     backfill + the read-only off-site review-queue lists.
- *   - `enforceAppListingsReadFlag` (`app-blocks-enabled`) — the DARK public store
- *     read path (empty page / NOT_FOUND until the segment widens at cutover).
+ *   - `enforceAppListingsReadFlag` (`app-listings`, OR-falling-back to
+ *     `app-blocks-enabled`) — the DARK public store read path (empty page /
+ *     NOT_FOUND until the segment widens at cutover).
  */
 const enforceAppBlocksFlag = middleware(async ({ ctx, next }) => {
   if (await isAppBlocksEnabled({ user: ctx.user })) return next();

--- a/src/server/services/__tests__/app-blocks-flag.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.test.ts
@@ -26,7 +26,11 @@ vi.mock('~/server/flipt/client', () => ({
   isFlipt: mockIsFlipt,
 }));
 
-import { isAppBlocksEnabled, isAppBlocksAuthorEnabled } from '../app-blocks-flag';
+import {
+  isAppBlocksEnabled,
+  isAppBlocksAuthorEnabled,
+  isAppListingsEnabled,
+} from '../app-blocks-flag';
 
 // Faithful stand-in for the live `app-blocks-enabled` rule: base OFF, with a
 // `moderators` segment keyed on `context.isModerator === 'true'`. The no-arg
@@ -226,5 +230,114 @@ describe('isAppBlocksAuthorEnabled — author capability (developer soft-launch)
       expect.anything(),
       expect.anything()
     );
+  });
+});
+
+/**
+ * W13 (PR-W1a / D8) — dedicated App Store VISIBILITY flag with an OR-fallback.
+ *
+ * `isAppListingsEnabled` DECOUPLES store visibility from `app-blocks-enabled`
+ * (the block-runtime kill-switch): it evaluates the dedicated `app-listings`
+ * flag and, ONLY if that resolves false, FALLS BACK to `isAppBlocksEnabled`.
+ * That fallback is load-bearing — `app-listings` does not exist at merge time,
+ * so the fallback keeps the current mods+testers cohort in (zero behavior change
+ * today). A future true-public flip widens ONLY `app-listings`.
+ *
+ * The fake models BOTH flags: `app-blocks-enabled` = mod segment; `app-listings`
+ * = a configurable per-user grant set (empty = the dark window / flag absent).
+ */
+describe('isAppListingsEnabled — dedicated visibility flag + OR-fallback (W13)', () => {
+  let appListingsGrants: Set<string>;
+
+  function fakeVisibilityFlags(
+    flag: string,
+    entityId = 'global',
+    context: Record<string, string> = {}
+  ): boolean {
+    if (flag === 'app-blocks-enabled') return context.isModerator === 'true';
+    if (flag === 'app-listings') {
+      // Per-user segment grant. No-user / global eval never matches (dark window).
+      return typeof context.userId === 'string' && appListingsGrants.has(context.userId);
+    }
+    return false;
+  }
+
+  beforeEach(() => {
+    appListingsGrants = new Set();
+    mockIsFlipt.mockReset();
+    mockIsFlipt.mockImplementation(async (...args: Parameters<typeof fakeVisibilityFlags>) =>
+      fakeVisibilityFlags(...args)
+    );
+  });
+
+  it('app-listings granted for the user → true (dedicated flag lit, no fallback needed)', async () => {
+    appListingsGrants.add('888');
+    const user = makeUser({ id: 888, isModerator: false });
+    await expect(isAppListingsEnabled({ user })).resolves.toBe(true);
+    // Evaluated the dedicated visibility flag WITH the user's context...
+    expect(mockIsFlipt).toHaveBeenCalledWith(
+      'app-listings',
+      '888',
+      expect.objectContaining({ userId: '888' })
+    );
+    // ...and short-circuited: the fallback flag was never consulted.
+    expect(mockIsFlipt).not.toHaveBeenCalledWith(
+      'app-blocks-enabled',
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('app-listings false + app-blocks-enabled true (mod) → true via the OR-fallback', async () => {
+    // The dark-window case: `app-listings` grants nobody yet, but a mod still has
+    // store access through the `app-blocks-enabled` fallback.
+    const user = makeUser({ id: 123, isModerator: true });
+    await expect(isAppListingsEnabled({ user })).resolves.toBe(true);
+    // Read app-listings FIRST, then fell back to app-blocks-enabled.
+    expect(mockIsFlipt).toHaveBeenCalledWith(
+      'app-listings',
+      '123',
+      expect.objectContaining({ userId: '123' })
+    );
+    expect(mockIsFlipt).toHaveBeenCalledWith(
+      'app-blocks-enabled',
+      '123',
+      expect.objectContaining({ isModerator: 'true' })
+    );
+  });
+
+  it('both flags false (non-mod, no listings grant) → false', async () => {
+    const user = makeUser({ id: 555, isModerator: false });
+    await expect(isAppListingsEnabled({ user })).resolves.toBe(false);
+    // Fell through both the dedicated flag AND the fallback.
+    expect(mockIsFlipt).toHaveBeenCalledWith(
+      'app-listings',
+      '555',
+      expect.objectContaining({ userId: '555' })
+    );
+    expect(mockIsFlipt).toHaveBeenCalledWith(
+      'app-blocks-enabled',
+      '555',
+      expect.objectContaining({ isModerator: 'false' })
+    );
+  });
+
+  it('no user → global eval of BOTH flags, fail-closed false', async () => {
+    await expect(isAppListingsEnabled({ user: undefined })).resolves.toBe(false);
+    await expect(isAppListingsEnabled()).resolves.toBe(false);
+    // Both the dedicated flag and the fallback are evaluated globally (no context).
+    expect(mockIsFlipt).toHaveBeenCalledWith('app-listings');
+    expect(mockIsFlipt).toHaveBeenCalledWith('app-blocks-enabled');
+  });
+
+  it('reads ONLY app-listings + app-blocks-enabled (never the pipeline / runtime keys)', async () => {
+    const user = makeUser({ id: 555, isModerator: false });
+    await isAppListingsEnabled({ user });
+    for (const call of mockIsFlipt.mock.calls) {
+      expect(['app-listings', 'app-blocks-enabled']).toContain(call[0]);
+    }
+    expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-pipeline-enabled');
+    expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-runtime-enabled');
+    expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-author');
   });
 });

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -5,6 +5,24 @@ import { buildFliptContext } from '~/server/services/feature-flags.service';
 const APP_BLOCKS_FLAG = 'app-blocks-enabled';
 
 /**
+ * Dedicated App Store VISIBILITY flag (W13 — PR-W1a / D8).
+ *
+ * DECOUPLES the App Store *catalog visibility* from `app-blocks-enabled`, which
+ * doubles as the BLOCK-RUNTIME kill-switch. The store-visibility surfaces (the
+ * `/apps` store SSR gate + landing, the store DETAIL page, the store grid query,
+ * and the PUBLIC store read procs) key off THIS flag so the catalog can widen to
+ * `public` INDEPENDENTLY of the deliberately-held block-runtime GA — a future
+ * true-public flip widens ONLY `app-listings`, while `app-blocks-enabled` (the
+ * runtime gate) stays mod-segmented.
+ *
+ * Mirrors the `appListings` entry in feature-flags.service.ts
+ * (`availability: ['mod']`, `fliptKey: 'app-listings'`). The flag does NOT exist
+ * in Flipt at merge time — it is created AFTER (a companion `flipt-state` PR)
+ * with the SAME mods + `app-dev-testers` segment `app-blocks-enabled` uses.
+ */
+export const APP_LISTINGS_FLAG = 'app-listings';
+
+/**
  * Dedicated flag for the App Blocks AUTHOR capability (developer soft-launch,
  * Phase B). Grants the right to SUBMIT apps + use `dev:live` (mint a dev token,
  * generate/spend from your own block) to a curated cohort — INDEPENDENT of the
@@ -176,6 +194,59 @@ export async function isAppBlocksEnabled(opts?: { user?: SessionUser }): Promise
   // server-side `isModerator` that the `moderators` segment keys on.
   const user = opts.user;
   return isFlipt(APP_BLOCKS_FLAG, String(user.id), buildFliptContext(user));
+}
+
+/**
+ * Server-side check for the App Store VISIBILITY flag (W13 — PR-W1a / D8).
+ *
+ * Gates the STORE-VISIBILITY surfaces only — the public store read procs
+ * (`appListings.listAvailable` / `getAppDetail`), reached via the
+ * `enforceAppListingsReadFlag` middleware. This DECOUPLES store catalog
+ * visibility from `app-blocks-enabled`, which doubles as the block-runtime
+ * kill-switch, so the catalog can widen to public independently of the held
+ * block-runtime GA.
+ *
+ * ## Eval shape mirrors `isAppBlocksEnabled`, WITH an OR-fallback (load-bearing)
+ *
+ * Same per-user Flipt eval as `isAppBlocksEnabled` (entityId = user id, context
+ * from `buildFliptContext`) against the dedicated `app-listings` flag. The ONE
+ * difference: if `app-listings` resolves `false`, this FALLS BACK to
+ * `isAppBlocksEnabled(opts)`. That fallback is the whole point of the dark
+ * decoupling:
+ *   - The `app-listings` flag does NOT exist in Flipt at merge time (created
+ *     AFTER, as a companion `flipt-state` PR). A bare eval of an absent flag
+ *     resolves `false` for EVERYONE — which would REGRESS the currently-visible
+ *     cohort (mods + the `app-dev-testers` segment of `app-blocks-enabled`) the
+ *     instant this merges. The OR-fallback to `app-blocks-enabled` preserves
+ *     their store access verbatim through the transition window.
+ *   - Because `app-blocks-enabled` already grants the mods + app-dev-testers
+ *     cohort today, `isAppListingsEnabled` grants EXACTLY that same set until the
+ *     `app-listings` flag is created and later widened — so the as-merged change
+ *     is a NO-OP on visibility (zero behavior change today).
+ *
+ * Remove the `|| isAppBlocksEnabled` fallback ONLY after the store widens past
+ * the `app-blocks-enabled` cohort (i.e. once `app-listings` is the sole, wider
+ * source of truth); until then the fallback is what keeps existing viewers in.
+ *
+ * No user → preserve a global eval of `app-listings` that can never match a
+ * segment, then fall through to the no-arg `isAppBlocksEnabled()` global eval —
+ * fail-closed, identical to today's no-arg store-read behaviour.
+ */
+export async function isAppListingsEnabled(opts?: { user?: SessionUser }): Promise<boolean> {
+  const user = opts?.user;
+  // Per-user eval of the dedicated visibility flag — same entityId + context
+  // shape as isAppBlocksEnabled, so the `app-listings` segment resolves
+  // identically to the client/hasFeature gate. No user → global eval (never
+  // matches a segment).
+  const listingsOn = user
+    ? await isFlipt(APP_LISTINGS_FLAG, String(user.id), buildFliptContext(user))
+    : await isFlipt(APP_LISTINGS_FLAG);
+  if (listingsOn) return true;
+  // OR-fallback: the `app-listings` flag doesn't exist yet (dark window) / hasn't
+  // been widened, so defer to `app-blocks-enabled` to keep the existing
+  // mods + app-dev-testers cohort's store access intact. Same opts (per-user or
+  // no-user global) so the fallback eval matches the primary eval's shape.
+  return isAppBlocksEnabled(opts);
 }
 
 /**

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -262,6 +262,16 @@ const featureFlags = createFeatureFlags({
   // default until we ship publisher install UX + moderator approval workflow.
   // When off, BlockSlot renders nothing and no token-issuance traffic fires.
   appBlocks: { availability: ['mod'], fliptKey: 'app-blocks-enabled' },
+  // App Blocks W13 — dedicated App Store VISIBILITY flag, decoupled from
+  // `app-blocks-enabled` (which doubles as the block-runtime kill-switch) so the
+  // store catalog can widen to public INDEPENDENTLY of the held block-runtime GA.
+  // Store-visibility surfaces gate on `appListings || appBlocks` (client) /
+  // `isAppListingsEnabled()` which falls back to `isAppBlocksEnabled()` (server),
+  // so while the `app-listings` Flipt flag does not yet exist this resolves via
+  // the `availability: ['mod']` Flipt-down fallback (mods only) + the OR-fallback
+  // to `app-blocks-enabled` — i.e. ZERO behavior change today (the currently
+  // mod+app-dev-testers cohort keeps identical store access).
+  appListings: { availability: ['mod'], fliptKey: 'app-listings' },
   // App Blocks W10 — full-page apps (`/apps/run/<slug>`). A SEPARATE dark flag
   // so the page surface enables independently of the master `app-blocks-enabled`
   // gate. The page route + page-token mint require BOTH `appBlocks` AND


### PR DESCRIPTION
## What / Why (W13 "PR-W1a" / D8)

Introduces a dedicated **`appListings`** feature flag (capability `appListings`, fliptKey `app-listings`, `availability:['mod']`) + server helper `isAppListingsEnabled` and repoints **only the App Store VISIBILITY surfaces** onto it — decoupling store catalog visibility from **`app-blocks-enabled`**, which also serves as the **block-runtime kill-switch**.

**The invariant:** every repointed gate becomes `appListings || appBlocks` (client) / `isAppListingsEnabled()` which internally OR-falls-back to `isAppBlocksEnabled()` (server).

### DARK — zero behavior change today
The `app-listings` Flipt flag **does not exist yet**, so:
- `features.appListings` resolves via the `availability:['mod']` Flipt-down fallback → **mods only**.
- The server helper's OR-fallback to `app-blocks-enabled` covers the **app-dev-testers** cohort.

So the currently-visible cohort (mods + app-dev-testers, both in the live `app-blocks-enabled` segment) keeps **identical** store access. The only purpose of this change is to let a **future** true-public flip widen **only** `app-listings`→public while `app-blocks-enabled` (block runtime) stays mod-gated.

### Companion Flipt PR + ordering
A companion `civitai/flipt-state` PR creates the `app-listings` flag with the **same mods + app-dev-testers segment** `app-blocks-enabled` uses. **Order is safe either way** thanks to the OR-fallback: before the Flipt flag exists, the fallback holds visibility for the current cohort; after it exists (same segment), visibility is unchanged; a later public widen touches only `app-listings`.

## Classification table — every `features.appBlocks` / `isAppBlocksEnabled` consumer

STORE = store catalog visibility (repointed to the OR). RUNTIME/AUTHOR/INSTALL/LEGACY = left on `appBlocks` (fail-safe: store stays as-restrictive-as-today; a future public flip cannot leak block-runtime).

| File:line | Surface | Class | Repointed? |
|---|---|---|---|
| `src/components/Apps/resolveAppsPageAccess.ts` (gate + type + JSDoc) | `/apps` store SSR access gate | **STORE** | **Y** → `appListings \|\| appBlocks` |
| `src/pages/apps/index.tsx:21` | store landing client guard | **STORE** | **Y** |
| `src/pages/apps/store-preview/[slug].tsx:45,48` | store DETAIL page (query + guard) | **STORE** | **Y** |
| `src/components/Apps/AppListingsMarketplaceBody.tsx:108` | store grid `listAvailable` query | **STORE** | **Y** |
| `src/server/routers/app-listings.router.ts:110` `enforceAppListingsReadFlag` | PUBLIC store read procs (`listAvailable`/`getAppDetail`) | **STORE** | **Y** → `isAppListingsEnabled` |
| `src/server/routers/app-listings.router.ts:80` `enforceAppBlocksFlag` (mod backfill) | mod-only backfill | RUNTIME/mod | N (per spec) |
| `src/server/routers/app-listings.router.ts:96` `enforceAppBlocksAuthorFlag` | AUTHOR (submit/assets) | AUTHOR | N (per spec) |
| `src/pages/apps/[appBlockId]/index.tsx:100,108,125,135` | per-app runtime/install detail | RUNTIME | N |
| `src/pages/apps/[appBlockId]/edit-manifest.tsx:44,47` | author edit-manifest | AUTHOR | N |
| `src/pages/apps/[appBlockId]/revenue.tsx:83` | per-app revenue | RUNTIME | N |
| `src/pages/apps/run/[slug]/[[...path]].tsx` | full-page app RUNTIME | RUNTIME | N |
| `src/pages/apps/dev/[blockId].tsx` | dev tunnel author surface | AUTHOR | N |
| `src/pages/apps/installed.tsx:730,770` | installed-apps management | INSTALL | N |
| `src/pages/apps/revenue.tsx:263` | revenue dashboard | RUNTIME | N |
| `src/components/Apps/AppBlockReviews.tsx:92,95` | review write gate | RUNTIME | N |
| `src/components/Apps/MarketplaceBody.tsx:99,126,134,154,163,173` | legacy rollback grid body | LEGACY | N |
| `src/components/Apps/AppsSubNav.tsx:180,184` | author sub-nav | AUTHOR/nav | N |
| `src/components/Apps/AppDetailsModal.tsx:87,94` | in-context app details modal (runtime slot) | RUNTIME | N |
| `src/components/Apps/PublisherSubscriptionBanner.tsx:25,86` | publisher subscription banner | RUNTIME | N |
| `src/components/AppBlocks/BlockSlot.tsx:36` | model-page block mount | RUNTIME | N |
| `src/components/AppLayout/AppHeader/appsNavVisibility.ts:28` | apps nav marketplace visibility | nav | N |
| `src/server/routers/blocks.router.ts` (`enforceAppBlocksFlag`, `ctx.features.appBlocks` @ 816/1707/3142/3206/3505/3605/3717/3907, author gate) | block runtime/author/install/token-mint | RUNTIME/AUTHOR | N |
| `src/server/routers/apps.router.ts:44,72` | apps author/runtime gates | AUTHOR/RUNTIME | N |
| `src/pages/api/blocks/**`, `src/pages/api/v1/blocks/**`, `src/pages/api/v1/block-tokens/**`, `src/pages/api/v1/developer/block-manifests.ts` | block-token mint / submit / runtime | RUNTIME/AUTHOR | N |
| `src/server/trpc.ts:409` (`features.appBlocksAuthor`) | author trpc gate | AUTHOR | N |

## Flagged nuance — shared SSR resolver (`resolveAppsPageAccess`)

`resolveAppsPageAccess` is shared by the store index (`/apps`), the store detail (`/apps/store-preview/[slug]`), **and** the per-app RUNTIME detail (`/apps/[appBlockId]`). Repointing the resolver widens the **SSR access** decision for the runtime detail page too under a future `app-listings`→public flip. This does **NOT** leak runtime content: `/apps/[appBlockId]/index.tsx`'s own **client guard stays on `features.appBlocks`** (line 135) + all its queries gate on `appBlocks`, so the runtime detail 404s client-side for any non-`appBlocks` viewer. The SSR resolver only decides notFound-vs-render-shell; the client guard is the real gate for that page and is intentionally left on `appBlocks`. Today: zero change (the OR falls back to `appBlocks`).

## The un-repointed runtime surfaces stay on `app-blocks-enabled` intentionally
Everything classed RUNTIME/AUTHOR/INSTALL/LEGACY above keeps gating on `app-blocks-enabled` so a future `app-listings`→public flip widens **only** the store catalog, never the held block-runtime/author/mint surfaces.

## Tests
- `resolveAppsPageAccess.test.ts` — new cases: `appListings`-only → renders; `appBlocks`-only (OR-fallback) → renders; neither → notFound; null/undefined → notFound.
- `app-blocks-flag.test.ts` — new `isAppListingsEnabled` describe: dedicated-flag-lit → true (no fallback call); flag-false + mod-`app-blocks-enabled` → true via fallback; both-false → false; no-user → global fail-closed; reads only `app-listings` + `app-blocks-enabled` (never pipeline/runtime/author keys).
- `app-listings.router.read-flag-gate.test.ts` — updated mock to `isAppListingsEnabled` (the repointed middleware); dark-posture assertions unchanged (anon/non-mod dark, mod served, widened-flag anon served).

## Local checks
- `vitest --project unit`: 114 tests pass across the 6 affected specs.
- `tsc --noEmit`: **0 errors** (shared Prisma client was current in this worktree; no stale-Prisma pre-existing errors surfaced). Authoritative typecheck is the Tekton preview on this PR.

Do NOT merge yet — pairs with the companion `flipt-state` PR.
