### PR TITLE
fix(dev-tunnel-gate): allow HMR WebSocket via Sec-WebSocket-Key (Upgrade is stripped by Traefik)

### DIFF
--- a/src/pages/api/internal/dev-tunnel-gate.ts
+++ b/src/pages/api/internal/dev-tunnel-gate.ts
@@ -29,14 +29,26 @@ import { verifyDevTunnelAccessToken } from '~/server/services/blocks/dev-tunnel-
  * Authorizes ONLY the ENTRY document/iframe request (the one that can carry the
  * `dev` token) and ALLOWS subresources through, per the tradeoff above.
  *
- *   - WEBSOCKET UPGRADE (`Upgrade: websocket`, e.g. the Vite HMR socket
- *     `wss://dev-<hex>/?token=…`): 200 (allow). A ws handshake is structurally a
- *     subresource — it can NEVER be a top-level document navigation — so allowing
- *     it does not weaken the naked-entry-document 401 property. Keyed on the
- *     DEFINITIONAL `Upgrade` handshake header (RFC 6455), not on the browser
- *     emitting `Sec-Fetch-Dest: websocket` (which the subresource branch would
- *     also allow, but which some browsers/proxies omit → the request would fall
- *     into the ENTRY branch and 401 the HMR socket). Deterministic, not heuristic.
+ *   - WEBSOCKET HANDSHAKE (e.g. the Vite HMR socket `wss://dev-<hex>/?token=…`):
+ *     200 (allow). A ws handshake is structurally a subresource — it can NEVER be
+ *     a top-level document navigation — so allowing it does not weaken the naked-
+ *     entry-document 401 property (the ws still only reaches the AUTHOR'S OWN
+ *     localhost, host-secrecy protected — same tradeoff as every other
+ *     subresource, no token required). Keyed PRIMARILY on `Sec-WebSocket-Key`, the
+ *     RFC-6455-MANDATORY handshake request header: the browser ALWAYS sends it on
+ *     a ws upgrade AND Traefik FORWARDS it to the forwardAuth subrequest (it is
+ *     NOT hop-by-hop, and this middleware sets no `authRequestHeaders` allowlist,
+ *     so every non-hop-by-hop header passes). `Upgrade` — the other definitional
+ *     handshake header (RFC 6455) — is a hop-by-hop header (RFC 7230 §6.1) that
+ *     Traefik STRIPS from the auth subrequest, so it can NOT be the sole signal
+ *     and the `upgrade === 'websocket'` branch never fires in production; it is
+ *     kept only as belt-and-suspenders for any path that DOES preserve it. We do
+ *     NOT rely on `Sec-Fetch-Dest: websocket` either — a real Chrome HMR handshake
+ *     arrives with NO usable `Sec-Fetch-Dest`, so it would fall into the ENTRY
+ *     branch and 401 the socket. A request bearing `Sec-WebSocket-Key` can never
+ *     be a top-level document navigation, so allowing it keeps the IDENTICAL
+ *     security posture (host-secrecy, no token) as every other subresource.
+ *     Deterministic + structural, not heuristic.
  *   - ENTRY (Sec-Fetch-Dest document/iframe/frame/nested-document, OR ABSENT →
  *     treated as entry, fail-safe): require a valid `dev` token bound to
  *     X-Forwarded-Host → 200 + X-Dev-User-Id, else 401.
@@ -76,17 +88,22 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return;
   }
 
-  // WEBSOCKET UPGRADE → allow (e.g. the Vite HMR socket `wss://dev-<hex>/?token=…`
+  // WEBSOCKET HANDSHAKE → allow (e.g. the Vite HMR socket `wss://dev-<hex>/?token=…`
   // so live-reload flows over the tunnel). A ws handshake is structurally a
   // subresource and can never be a top-level document navigation, so this does
   // NOT weaken the naked-entry-document 401 property (and the ws still only
   // reaches the AUTHOR'S OWN localhost, host-secrecy protected — same tradeoff as
-  // every other subresource). Keyed on the DEFINITIONAL `Upgrade` handshake
-  // header (RFC 6455) rather than `Sec-Fetch-Dest: websocket`, which some
-  // browsers/proxies omit → the request would otherwise fall into the ENTRY
-  // branch below and 401 the HMR socket. Deterministic + structural.
+  // every other subresource). Keyed PRIMARILY on `Sec-WebSocket-Key`, the RFC-
+  // 6455-MANDATORY handshake header the browser ALWAYS sends and — unlike the
+  // hop-by-hop `Upgrade` header (RFC 7230 §6.1) which Traefik STRIPS from the auth
+  // subrequest — Traefik FORWARDS it (no `authRequestHeaders` allowlist on this
+  // middleware). The `Upgrade` check is kept only as belt-and-suspenders for any
+  // path that DOES preserve it; in production it never fires. Deterministic +
+  // structural (a request bearing `Sec-WebSocket-Key` is definitionally a ws
+  // handshake, never a document navigation).
+  const wsKey = firstHeader(req.headers['sec-websocket-key']);
   const upgrade = firstHeader(req.headers['upgrade']);
-  if (upgrade && upgrade.toLowerCase() === 'websocket') {
+  if (wsKey || (upgrade && upgrade.toLowerCase() === 'websocket')) {
     res.status(200).json({ ok: true, via: 'websocket' });
     return;
   }

--- a/src/tests/api/internal/blocks/dev-tunnel-gate.test.ts
+++ b/src/tests/api/internal/blocks/dev-tunnel-gate.test.ts
@@ -57,12 +57,14 @@ function makeReq(opts: {
   uri?: string;
   secFetchDest?: string;
   upgrade?: string;
+  wsKey?: string;
 }): NextApiRequest {
   const headers: Record<string, string> = {};
   if (opts.host !== undefined) headers['x-forwarded-host'] = opts.host;
   if (opts.uri !== undefined) headers['x-forwarded-uri'] = opts.uri;
   if (opts.secFetchDest !== undefined) headers['sec-fetch-dest'] = opts.secFetchDest;
   if (opts.upgrade !== undefined) headers['upgrade'] = opts.upgrade;
+  if (opts.wsKey !== undefined) headers['sec-websocket-key'] = opts.wsKey;
   return { method: 'GET', headers } as unknown as NextApiRequest;
 }
 
@@ -168,6 +170,35 @@ describe('/api/internal/dev-tunnel-gate', () => {
     handler(makeReq({ host: HOST, uri: '/?token=abc', upgrade: 'websocket' }), res);
     expect(res.statusCode).toBe(200);
     expect((res.body as { via?: string }).via).toBe('websocket');
+  });
+
+  // ── Sec-WebSocket-Key: the PROD path (Traefik strips Upgrade, Chrome omits
+  //    Sec-Fetch-Dest). This is the exact scenario the Upgrade-only allow misses. ──
+  it('Sec-WebSocket-Key present, NO Upgrade, NO Sec-Fetch-Dest → 200 (prod HMR handshake)', () => {
+    const res = makeRes();
+    handler(makeReq({ host: HOST, uri: '/?token=abc', wsKey: 'dGhlIHNhbXBsZSBub25jZQ==' }), res);
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { via?: string }).via).toBe('websocket');
+  });
+
+  it('Sec-WebSocket-Key + vite `?token=` (not `?dev=`) in X-Forwarded-Uri → still 200 (not routed into entry/token branch)', () => {
+    const res = makeRes();
+    handler(
+      makeReq({
+        host: HOST,
+        uri: '/?token=zzz-vite-hmr-token',
+        wsKey: 'dGhlIHNhbXBsZSBub25jZQ==',
+      }),
+      res
+    );
+    expect(res.statusCode).toBe(200);
+    expect((res.body as { via?: string }).via).toBe('websocket');
+  });
+
+  it('Sec-WebSocket-Key without X-Forwarded-Host → 401 (fail-closed still wins)', () => {
+    const res = makeRes();
+    handler(makeReq({ uri: '/?token=abc', wsKey: 'dGhlIHNhbXBsZSBub25jZQ==' }), res);
+    expect(res.statusCode).toBe(401);
   });
 
   it('WEBSOCKET UPGRADE is case-insensitive (Upgrade: WebSocket) → 200', () => {


### PR DESCRIPTION
The Traefik forwardAuth subrequest never sees the Upgrade header (RFC 7230
hop-by-hop), so the existing `upgrade === 'websocket'` allow is inert in
production, and a real Chrome HMR handshake arrives with no usable
Sec-Fetch-Dest → it falls into the ENTRY branch, finds vite's `?token=`
(not `?dev=`), and 401s → HMR breaks.

Add a WS-handshake allow keyed on Sec-WebSocket-Key: the RFC-6455-mandatory
handshake header the browser always sends AND Traefik forwards (not
hop-by-hop; this middleware sets no authRequestHeaders allowlist). A request
bearing it can never be a top-level document navigation, so allowing it keeps
the identical security posture (host-secrecy, no token) as every other
subresource — the naked-entry 401 is unchanged. The Upgrade check is kept as
belt-and-suspenders.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
