### PR TITLE
App Blocks Phase 2 — dev-tunnel scoped mint (real Buzz-spend generation pre-approval)

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260707120000_block_scope_invocation_nullable_appblock/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260707120000_block_scope_invocation_nullable_appblock/migration.sql
@@ -22,5 +22,6 @@ ALTER TABLE "block_scope_invocations"
 ALTER TABLE "block_scope_invocations"
   ADD COLUMN IF NOT EXISTS "synthetic_app_id" TEXT;
 
-CREATE INDEX IF NOT EXISTS "bsi_synthetic_app_invoked_idx"
-  ON "block_scope_invocations" ("synthetic_app_id", "invoked_at" DESC);
+-- Applied MANUALLY per civitai rule #8. Run this statement OUTSIDE a transaction (psql without --single-transaction): CONCURRENTLY cannot run in a txn. The two ALTERs above are metadata-only and safe in or out of a txn.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "bsi_synthetic_app_invoked_idx"
+  ON "block_scope_invocations" ("synthetic_app_id", "invoked_at" DESC) WHERE "synthetic_app_id" IS NOT NULL;

--- a/packages/civitai-db-schema/prisma/migrations/20260707120000_block_scope_invocation_nullable_appblock/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260707120000_block_scope_invocation_nullable_appblock/migration.sql
@@ -1,0 +1,26 @@
+-- App Dev Tunnel Phase 2 — durable per-spend audit for PRE-APPROVAL dev-tunnel spends.
+--
+-- A pre-approval app has NO AppBlock row (moderator approval is what creates it),
+-- so its scoped dev token carries a SYNTHETIC `ephemeral-<slug>` app_block_id that
+-- can never FK-resolve. Today recordScopeInvocation's INSERT FK-fails on that value
+-- and the error is swallowed, so a pre-approval Buzz spend leaves NO durable audit
+-- row (only a log line). This migration makes `app_block_id` NULLABLE and adds
+-- `synthetic_app_id` so the audit row PERSISTS for that case (app_block_id NULL,
+-- synthetic_app_id = the synthetic dev ref).
+--
+-- Additive + backward-compatible: every existing / approved-app row keeps its real
+-- app_block_id FK value and a NULL synthetic_app_id. The FK is preserved (ON DELETE
+-- CASCADE unchanged) — a nullable FK column simply skips the check for NULL rows.
+--
+-- MANUAL APPLY ONLY: the main civitai DB (CNPG nvme0) does NOT auto-apply Prisma
+-- migrations. Apply this SQL by hand to the target env; _prisma_migrations is not
+-- the source of truth here.
+
+ALTER TABLE "block_scope_invocations"
+  ALTER COLUMN "app_block_id" DROP NOT NULL;
+
+ALTER TABLE "block_scope_invocations"
+  ADD COLUMN IF NOT EXISTS "synthetic_app_id" TEXT;
+
+CREATE INDEX IF NOT EXISTS "bsi_synthetic_app_invoked_idx"
+  ON "block_scope_invocations" ("synthetic_app_id", "invoked_at" DESC);

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -3148,8 +3148,18 @@ model BlockScopeInvocation {
   id               BigInt   @id @default(autoincrement())
   userId           Int      @map("user_id")
   user             User     @relation(fields: [userId], references: [id], onDelete: Cascade)
-  appBlockId       String   @map("app_block_id")
-  appBlock         AppBlock @relation(fields: [appBlockId], references: [id], onDelete: Cascade)
+  /// NULLABLE (App Dev Tunnel Phase 2): a PRE-APPROVAL dev-tunnel spend has NO
+  /// AppBlock row (approval is what creates it), so the token carries a SYNTHETIC
+  /// `ephemeral-<slug>` appBlockId that can never FK-resolve. For that case this
+  /// column is NULL and the synthetic ref is captured in `syntheticAppId`, so the
+  /// durable per-spend audit row persists instead of FK-failing + being swallowed
+  /// (the "only a log line" gap). An APPROVED app still sets this (real FK).
+  appBlockId       String?  @map("app_block_id")
+  appBlock         AppBlock? @relation(fields: [appBlockId], references: [id], onDelete: Cascade)
+  /// The synthetic, non-resolving dev-app reference (`ephemeral-<slug>` /
+  /// `local-<slug>` / `pending-<pubreqId>`) for a PRE-APPROVAL dev-tunnel spend —
+  /// the forensic anchor when `appBlockId` is NULL. NULL for every approved-app row.
+  syntheticAppId   String?  @map("synthetic_app_id")
   blockInstanceId  String   @map("block_instance_id")
   scope            String
   endpoint         String
@@ -3158,6 +3168,7 @@ model BlockScopeInvocation {
 
   @@index([userId, invokedAt(sort: Desc), id(sort: Desc)], map: "bsi_user_invoked_idx")
   @@index([appBlockId, invokedAt(sort: Desc)], map: "bsi_app_block_invoked_idx")
+  @@index([syntheticAppId, invokedAt(sort: Desc)], map: "bsi_synthetic_app_invoked_idx")
   @@map("block_scope_invocations")
 }
 

--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -39,6 +39,14 @@ import {
   partitionByConsent,
   consentGatedScopes,
 } from '~/server/services/blocks/scope-grant.service';
+import {
+  clampDevScopes,
+  FORCED_SFW_CEILING,
+  resolveDevBuzzBudget,
+  signDevScopedPageToken,
+  TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+} from '~/server/services/blocks/dev-scoped-mint.service';
+import type { SessionUser } from '~/types/session';
 
 /**
  * POST /api/v1/block-tokens
@@ -98,11 +106,28 @@ const slotContextSchema = z.union([pageSlotContextSchema, modelSlotContextSchema
 const requestSchema = z.object({
   blockInstanceId: z.string().min(1).max(64),
   slotContext: slotContextSchema,
+  // PHASE 2 (App Dev Tunnel) — self-declared scopes for a BRAND-NEW (unsubmitted)
+  // ephemeral app the AUTHOR owns, sent by the dev host. IGNORED on every
+  // non-dev-tunnel path (an approved mint sources scopes from the approved
+  // manifest snapshot). When the app has an OWNED pending submission the server
+  // reads the pending manifest.scopes instead; these body scopes only ever
+  // NARROW / seed within the identical audited dev clamp belt (dev-scoped-mint
+  // .service), never widen past the tunnel allowlist.
+  devScopes: z.array(z.string().min(1).max(64)).max(32).optional(),
 });
 
 // W10 — synthetic block-instance id prefix for a stateless full-page app. The
 // id is `page_<appBlockId>`; there is no install row (Decision 2).
 const PAGE_INSTANCE_PREFIX = 'page_';
+
+// PHASE 2 (App Dev Tunnel) — the synthetic appBlockId namespace a PRE-APPROVAL
+// app carries (built by BlockRegistry.resolveEphemeralDevPageBlock as
+// `ephemeral-<slug>`). It can NEVER equal a real AppBlock.id (`apb_<ulid>`) nor an
+// OauthClient.id (UUIDv4 / `appblk-<slug>`), so recordSpendAttribution's
+// `oauthClient.findUnique` MISSES (no forged attribution) and the durable
+// per-spend audit row lands in the nullable-appBlockId path. The dev instance id
+// is therefore `page_ephemeral-<slug>`.
+const EPHEMERAL_APP_ID_PREFIX = 'ephemeral-';
 
 const BUZZ_BUDGET_DEFAULT = 10;
 const BUZZ_BUDGET_CAP = 1000;
@@ -288,6 +313,151 @@ function resolveBuzzBudget(
   return Math.min(candidate, BUZZ_BUDGET_CAP);
 }
 
+/**
+ * PHASE 2 — App Dev Tunnel author-own SCOPED mint.
+ *
+ * `resolvePageBlock` only resolves APPROVED page apps; a PRE-APPROVAL (ephemeral)
+ * app the AUTHOR is iterating on inside the dev tunnel (`/apps/dev/<blockId>`)
+ * misses it and would 404, so scoped features (real Buzz-spend generation) can
+ * never work pre-approval (Phase 1). This branch mints a SCOPED, forced-SFW,
+ * self-bound, budget-capped dev token for that case — reusing the SAME audited
+ * clamp+sign belt as `/api/v1/blocks/dev-token` (dev-scoped-mint.service), MINUS
+ * `apps:storage:*` (Decision 1: App Storage stays 403 until approval).
+ *
+ * CONTAINMENT (every gate server-side + fail-closed):
+ *   - COOKIE-authed author only: `isAppBlocksAuthorEnabled` on the SESSION user
+ *     PLUS the `app-blocks-dev-tunnel` kill-switch (defense-in-depth over the SSR
+ *     dev host, which already gates both). Banned/deleted account → refused.
+ *   - OWNERSHIP + ANTI-SHADOW: `resolveDevPageBlockForAuthor(slug, userId)` — a
+ *     foreign / already-claimed / structurally-invalid slug returns the SAME bare
+ *     null → the caller-facing 404 (no ownership/existence oracle beyond the
+ *     pre-existing, tolerated claimed-vs-unclaimed signal). Must resolve to
+ *     `status:'ephemeral'` (a just-approved app self-corrects on client reload via
+ *     the prod path).
+ *   - SPEND CONTAINMENT: the token is self-bound (`sub` = the session user), so at
+ *     RUNTIME `submitWorkflow` spends the AUTHOR's OWN Buzz, gated by
+ *     `assertViewerIsAppDeveloper(sub)` + the per-call (DEV_BUZZ_BUDGET_CAP) /
+ *     per-session / per-day caps. There is NO bearer credential here, so the
+ *     dev-token 7f AIServicesWrite ceiling doesn't map → `keyCanSpend: true`; the
+ *     runtime author-flag re-check is the substitute spend gate.
+ *   - SCOPE SOURCE (mirrors dev-token pending / no-row): the caller's OWN pending
+ *     submission's SERVER-READ `manifest.scopes`, else the SELF-DECLARED body
+ *     `devScopes`. Both pass the identical clamp (TUNNEL allowlist, no OAuth
+ *     ceiling — no client exists).
+ *
+ * Returns 'handled' iff it wrote a 200 token response; 'continue' on ANY
+ * non-match / refusal so the caller falls through to the uniform bare 404 (no
+ * oracle). An empty scope source mints a valid READ-only token (no spend) — a
+ * strict improvement over the Phase-1 404.
+ */
+async function tryDevTunnelScopedMint(args: {
+  res: NextApiResponse;
+  appBlockId: string;
+  blockInstanceId: string;
+  slotId: string;
+  sessionUser: SessionUser | undefined;
+  userId: number | null;
+  devScopes: string[] | undefined;
+}): Promise<'handled' | 'continue'> {
+  const { res, appBlockId, blockInstanceId, slotId, sessionUser, userId, devScopes } = args;
+
+  // Cookie-authed author only; only the ephemeral synthetic namespace is a
+  // pre-approval dev mint. Anything else → not our branch.
+  if (userId == null || !sessionUser) return 'continue';
+  if (!appBlockId.startsWith(EPHEMERAL_APP_ID_PREFIX)) return 'continue';
+  // The instance id is `page_<appBlockId>` by construction; a mismatch is not a
+  // legitimate dev mint.
+  if (blockInstanceId !== `${PAGE_INSTANCE_PREFIX}${appBlockId}`) return 'continue';
+  if (sessionUser.bannedAt) return 'continue';
+
+  // Author capability + dev-tunnel kill-switch (fail-closed, both must pass).
+  // Dynamic import so the flag module (Flipt/redis transitive deps) isn't eager-
+  // loaded on the prod-mint import path — mirrors blocks.router's startDevTunnel.
+  const { isAppBlocksAuthorEnabled, isAppBlocksDevTunnelEnabled } = await import(
+    '~/server/services/app-blocks-flag'
+  );
+  if (!(await isAppBlocksAuthorEnabled({ user: sessionUser }))) return 'continue';
+  if (!(await isAppBlocksDevTunnelEnabled({ user: sessionUser }))) return 'continue';
+
+  // Soft-delete gate (M1 parity with the prod path). A session that survived a
+  // soft-delete must not mint.
+  const userRow = await dbWrite.user.findUnique({
+    where: { id: userId },
+    select: { deletedAt: true, bannedAt: true },
+  });
+  if (!userRow || userRow.deletedAt || userRow.bannedAt) return 'continue';
+
+  // OWNERSHIP + ANTI-SHADOW resolve (any refusal → the same bare null → 404).
+  const slug = appBlockId.slice(EPHEMERAL_APP_ID_PREFIX.length);
+  const app = await BlockRegistry.resolveDevPageBlockForAuthor(slug, userId, { db: 'write' });
+  // Only a genuinely pre-approval (ephemeral) resolution mints here. A resolved
+  // approved/owned row (real appBlockId) would never carry an `ephemeral-` id, so
+  // this also fails closed if the app was approved mid-session.
+  if (!app || app.status !== 'ephemeral') return 'continue';
+
+  // Belt-and-suspenders: the page slot must be a real page slot (the caller
+  // already validated this, but the dev branch re-asserts before signing).
+  if (!isPageSlot(slotId)) return 'continue';
+
+  // SCOPE SOURCE: the caller's OWN pending submission's SERVER-READ manifest.scopes
+  // (the "submitted-pending" case), else the SELF-DECLARED body devScopes (the
+  // "brand-new" case). Ownership is enforced in the query (submittedByUserId).
+  const pending = await dbWrite.appBlockPublishRequest.findFirst({
+    where: { slug, status: 'pending', submittedByUserId: userId },
+    orderBy: { submittedAt: 'desc' },
+    select: { manifest: true },
+  });
+  let scopeSource: string[];
+  if (pending) {
+    const manifest = (pending.manifest ?? {}) as { scopes?: unknown };
+    scopeSource = Array.isArray(manifest.scopes)
+      ? manifest.scopes.filter((s): s is string => typeof s === 'string')
+      : [];
+  } else {
+    // Brand-new (no pending row): the client-supplied body scopes ARE the source.
+    scopeSource = devScopes ?? [];
+  }
+
+  // CLAMP — the IDENTICAL audited belt: TUNNEL allowlist (no apps:storage:*), no
+  // OAuth ceiling (`oauthAllowed: null` — a pre-approval app has no OauthClient),
+  // keyCanSpend=true (spend is gated at RUNTIME, not by a bearer here). devScopes
+  // narrows (pending) / is the source (brand-new) inside the same belt.
+  const granted = clampDevScopes({
+    scopeSource,
+    oauthAllowed: null,
+    requestedScopes: devScopes,
+    keyCanSpend: true,
+    allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+  });
+  const buzzBudget = resolveDevBuzzBudget(granted);
+
+  // SIGN — synthetic, non-resolving ids (`ephemeral-<slug>`), the client's page
+  // instance id, self-bound sub, forced-SFW, dev-capped budget, dev:true (4h).
+  const result = await signDevScopedPageToken({
+    userId,
+    signBlockId: app.blockId,
+    signAppId: app.appId,
+    signAppBlockId: app.appBlockId,
+    blockInstanceId,
+    granted,
+    buzzBudget,
+  });
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.status(200).json({
+    token: result.token,
+    expiresAt: result.expiresAt,
+    // Dev tokens are self-bound + mod/author-gated; there is no per-user consent
+    // ledger for a synthetic pre-approval app, so no consent signal is surfaced.
+    needsConsent: false,
+    missingScopes: [],
+    // Forced-SFW: the dev mint never reads the request host.
+    domain: null,
+    maxBrowsingLevel: FORCED_SFW_CEILING,
+  });
+  return 'handled';
+}
+
 export default withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   const cors = setSameOriginCors(req, res);
   if (cors === 'handled') return;
@@ -422,6 +592,19 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     const appBlockId = blockInstanceId.slice(PAGE_INSTANCE_PREFIX.length);
     const page = await BlockRegistry.resolvePageBlock(appBlockId, { db: 'write' });
     if (!page) {
+      // PHASE 2 — before the bare 404, try the App Dev Tunnel author-own SCOPED
+      // mint (pre-approval ephemeral app the caller OWNS). Any non-match / refusal
+      // returns 'continue' → the SAME bare 404 (no ownership/existence oracle).
+      const devMint = await tryDevTunnelScopedMint({
+        res,
+        appBlockId,
+        blockInstanceId,
+        slotId: slotContext.slotId,
+        sessionUser: session?.user,
+        userId,
+        devScopes: parsed.data.devScopes,
+      });
+      if (devMint === 'handled') return;
       // Missing / not-approved / not-a-page app → 404 (never leaks which).
       res.status(404).json({ error: 'Page app not found' });
       return;

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -8,13 +8,13 @@ import { dbWrite } from '~/server/db/client';
 import { sysRedis, REDIS_SYS_KEYS, withSysReadDeadline } from '~/server/redis/client';
 import { SLUG_REGEX } from '~/server/schema/blocks/publish-request.schema';
 import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
-import { BlockTokenService } from '~/server/services/block-token.service';
 import {
-  isKnownBlockScope,
-  validateBlockScopesAgainstOauthClient,
-} from '~/shared/constants/block-scope.constants';
-import { domainBrowsingCeiling } from '~/shared/constants/browsingLevel.constants';
-import { isPageSlot, PAGE_FORBIDDEN_SCOPES, PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
+  clampDevScopes,
+  DEV_TOKEN_SCOPE_ALLOWLIST,
+  FORCED_SFW_CEILING,
+  resolveDevBuzzBudget,
+  signDevScopedPageToken,
+} from '~/server/services/blocks/dev-scoped-mint.service';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { Flags } from '~/shared/utils/flags';
 
@@ -226,16 +226,10 @@ export const config = {
   },
 };
 
-// A LOWER dev budget cap than the prod 1000 (scope doc §4.1). The dev spends
-// their OWN Buzz and the per-user daily cumulative cap is untouched; this just
-// bounds a single submit's reservation.
-const DEV_BUZZ_BUDGET_CAP = 250;
-const DEV_BUZZ_BUDGET_DEFAULT = 50;
-
-// Forced SFW — the dev endpoint NEVER reads the request host. localhost has no
-// color domain, and even a color-localhost dev config must not widen maturity.
-const FORCED_SFW_CEILING = domainBrowsingCeiling(null);
-
+// The DEV budget caps, forced-SFW ceiling, and the DEV_TOKEN_SCOPE_ALLOWLIST
+// (read/catalog + page spend + per-app storage; EXCLUDES social:tip:self +
+// block:settings:*) now live in dev-scoped-mint.service so the Phase-2 cookie
+// host-mint reuses the identical belt. Imported above.
 const RATE_LIMIT = { max: 30, windowSeconds: 60 } as const;
 
 const PAGE_INSTANCE_PREFIX = 'page_';
@@ -246,28 +240,6 @@ const PAGE_INSTANCE_PREFIX = 'page_';
 // recordSpendAttribution's `oauthClient.findUnique({ id })` — guaranteeing the
 // attribution write is skipped (audit S1 parity with the pending path).
 const LOCAL_APP_ID_PREFIX = 'local-';
-
-/**
- * The DEV scope allowlist (scope doc §4.1): read/catalog scopes + the page
- * spend scope + per-app storage. DELIBERATELY EXCLUDES:
- *   - `social:tip:self` — real money OUT to third parties; no test value, real
- *     abuse value.
- *   - `block:settings:read` / `block:settings:write` — installer-only, and
- *     meaningless against a local instance with no real install row.
- *
- * A requested/approved scope outside this set is STRIPPED from the minted token
- * (defense-in-depth on top of the approved-snapshot pin). `social:tip:self` and
- * `buzz:read:self` are ALSO in PAGE_FORBIDDEN_SCOPES, so the page hard rule
- * below rejects them too — this allowlist is the explicit dev-side belt.
- */
-const DEV_TOKEN_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
-  'models:read:self',
-  'media:read:owned',
-  'user:read:self',
-  'ai:write:budgeted',
-  'apps:storage:read',
-  'apps:storage:write',
-]);
 
 const requestSchema = z
   .object({
@@ -714,107 +686,46 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     return;
   }
 
-  // 7. SCOPE CLAMP. Start from the resolved scope SOURCE — the app's APPROVED
+  // 7. SCOPE CLAMP + 8. BUDGET CAP — the AUDITED belt, now factored into the
+  // shared `dev-scoped-mint.service` so the Phase-2 cookie-authed host-mint branch
+  // (`/api/v1/block-tokens`) reuses the IDENTICAL logic instead of a parallel
+  // re-implementation. Start from the resolved scope SOURCE — the app's APPROVED
   // snapshot (existing-app) OR the OWNED pending request's un-reviewed
   // manifest.scopes (pending local-manifest, §4 R1) OR the CLIENT-SUPPLIED body
   // scopes (no-row local-manifest, §4 R1) — then apply the IDENTICAL belt:
   //   a) keep only KNOWN block scopes,
   //   b) keep only scopes within the DEV_TOKEN_SCOPE_ALLOWLIST (excludes
-  //      social:tip:self + block:settings:*),
+  //      social:tip:self + block:settings:*; INCLUDES apps:storage:* for THIS
+  //      bearer path — the tunnel path uses TUNNEL_HOST_MINT_SCOPE_ALLOWLIST which
+  //      strips storage, Decision 1),
   //   c) keep only scopes within the app's OAuth ceiling (allowedScopes) — ONLY
-  //      for the approved path. BOTH local-manifest paths (pending + no-row)
-  //      have NO OauthClient (`oauthAllowed === null`) → this step is OMITTED;
-  //      7f is the spend gate.
+  //      for the approved path (`oauthAllowed !== null`); OMITTED for both
+  //      local-manifest paths (no OauthClient),
   //   d) drop the PAGE_FORBIDDEN money/spend scopes (the page hard rule),
-  //   e) if the body requested a subset, intersect with it (on the no-row path
-  //      the source IS the body, so this is an identity no-op).
-  // Every step is a STRIP (no error) so a partially-disallowed request still
-  // mints a usable, safely-clamped token. The clamp belt is byte-identical
-  // across all three paths bar the OAuth-ceiling substitution — an un-reviewed
-  // manifest (server-side pending OR client-side local) can never escalate past
-  // the allowlist, the page-forbidden set, or the dev's own credential (7f).
-  const forbidden = new Set<string>(PAGE_FORBIDDEN_SCOPES);
-
-  let granted: string[] = resolved.scopeSource
-    .filter((s) => isKnownBlockScope(s))
-    .filter((s) => DEV_TOKEN_SCOPE_ALLOWLIST.has(s))
-    .filter((s) => !forbidden.has(s));
-
-  // OAuth-ceiling clamp (approved path ONLY) — drop any scope the app's
-  // OauthClient bitmask doesn't allow. validateBlockScopesAgainstOauthClient
-  // treats SKIP_OAUTH_CHECK scopes (apps:storage:*) as always-allowed, so
-  // per-scope re-validation keeps those. SKIPPED when oauthAllowed is null (the
-  // pending path — no client; passing 0 would wrongly strip every non-skip scope).
-  if (resolved.oauthAllowed !== null) {
-    const ceiling = resolved.oauthAllowed;
-    granted = granted.filter(
-      (s: string) => validateBlockScopesAgainstOauthClient([s], ceiling).valid
-    );
-  }
-
-  // Body narrowing — the dev may request a subset of the above.
-  if (requestedScopes && requestedScopes.length > 0) {
-    const want = new Set(requestedScopes);
-    granted = granted.filter((s: string) => want.has(s));
-  }
-
-  //   f) BEARER-CREDENTIAL SPEND CEILING (UNIFORM across personal key AND OAuth).
-  //      The minted block token's spend capability must be a SUBSET of what the
-  //      bearer credential itself authorizes — a credential lacking AIServicesWrite
-  //      (a read-only personal key, OR an OAuth consent that didn't grant
-  //      AIServicesWrite) cannot mint a Buzz-spending dev token. `session.tokenScope`
-  //      is the resolved bitmask for BOTH shapes (personal-key ApiKey.tokenScope,
-  //      or the OAuth-issued token's scope). Mirrors the /api/v1/me tokenScope
-  //      posture (me.ts:24). Read/catalog/storage scopes are unaffected; only the
-  //      budgeted-spend scope is gated. This is DELIBERATELY uniform —
-  //      `AppBlocksSubmit` is the MINT gate (step 1b), `AIServicesWrite` is the
-  //      SPEND gate, and the two are never conflated. Personal keys default to
-  //      Full (carries AIServicesWrite), so this is a no-op for a normal key and a
-  //      tightening only for a narrow key or an OAuth consent without AI Services.
-  //      Strip (no error), consistent with every other clamp step.
+  //   e) if the body requested a subset, intersect with it,
+  //   f) BEARER-CREDENTIAL SPEND CEILING (`keyCanSpend`): strip `ai:write:budgeted`
+  //      unless the bearer credential (personal key OR OAuth consent) carries
+  //      AIServicesWrite. `session.tokenScope` is the resolved bitmask for BOTH
+  //      shapes. `AppBlocksSubmit` is the MINT gate (step 1b), `AIServicesWrite`
+  //      the SPEND gate — never conflated.
+  //   g) force-grant `user:read:self` (self-bound read of the dev's OWN identity;
+  //      `/blocks/me` for the harness viewer). SAFE: the token `sub` is ALWAYS the
+  //      authenticated caller (never the body), so it can only return the caller's
+  //      own profile — no third-party data, no write, no spend.
+  // Every step is a STRIP (no error) so a partially-disallowed request still mints
+  // a usable, safely-clamped token. This bearer path is UNCHANGED by the
+  // extraction (a parity test locks it).
   const keyCanSpend = Flags.hasFlag(session.tokenScope ?? 0, TokenScope.AIServicesWrite);
-  if (!keyCanSpend) {
-    granted = granted.filter((s: string) => s !== 'ai:write:budgeted');
-  }
+  const granted = clampDevScopes({
+    scopeSource: resolved.scopeSource,
+    oauthAllowed: resolved.oauthAllowed,
+    requestedScopes,
+    keyCanSpend,
+    allowlist: DEV_TOKEN_SCOPE_ALLOWLIST,
+  });
 
-  //   g) FORCE-GRANT `user:read:self` (UNCONDITIONAL, post-clamp). The local
-  //      harness's `dev:live` mode resolves the dev's OWN viewer identity by
-  //      calling `GET /api/v1/blocks/me`, which is gated on `user:read:self`.
-  //      That scope is only minted if it survives the app-manifest/approved-
-  //      snapshot + OAuth-bitmask clamp above — and the page-money scaffold
-  //      manifest declares ONLY `ai:write:budgeted`, so `user:read:self` is
-  //      never in `approvedScopes` and never minted → /blocks/me 403s → the
-  //      harness falls back to an anonymous viewer. This bypasses that clamp
-  //      for this ONE read scope so `dev:live` can resolve the viewer.
-  //
-  //      SAFE because:
-  //        - `user:read:self` is a READ scope that returns ONLY the self-bound
-  //          caller's own profile — no third-party data, no write, no spend. The
-  //          `/blocks/me` handler resolves `userId` from `claims.sub` and reads
-  //          exactly that user (me.ts), and `enforceContextBinding` rejects
-  //          `user:read:self` on an `anon` sub (block-scope.middleware.ts). The
-  //          dev token's `sub` is ALWAYS `user:<callerId>` (self-bound, set from
-  //          the authenticated caller at sign time below — never from the body),
-  //          so this can only ever return the CALLER's own identity.
-  //        - it's already a member of `DEV_TOKEN_SCOPE_ALLOWLIST` — an intended,
-  //          vetted dev scope (it was simply being clamped OUT by the per-app
-  //          approved-scopes pin, which the page-money manifest doesn't list).
-  //        - this endpoint is mod-gated (step 2) and self-bound, so the net
-  //          effect is "a dev reads their OWN identity via their OWN token" —
-  //          zero escalation, no new data surface.
-  //      Post-clamp + uniform across BOTH the personal-key and OAuth paths (the
-  //      grant runs after every clamp belt, so neither path can suppress it).
-  //      This does NOT touch the prod mint (`/api/v1/block-tokens`).
-  granted.push('user:read:self');
-
-  // Dedup, deterministic order.
-  granted = Array.from(new Set(granted)).sort();
-
-  // 8. BUDGET CAP — only meaningful when ai:write:budgeted is granted. Clamp the
-  // dev-requested budget (or the default) to the LOWER dev cap.
-  const buzzBudget = granted.includes('ai:write:budgeted')
-    ? Math.min(requestedBudget ?? DEV_BUZZ_BUDGET_DEFAULT, DEV_BUZZ_BUDGET_CAP)
-    : undefined;
+  // 8. BUDGET CAP — only meaningful when ai:write:budgeted survived the clamp.
+  const buzzBudget = resolveDevBuzzBudget(granted, requestedBudget);
 
   // 8b. PENDING-PATH MINT AUDIT (FIX 🟡-1). The pending (local-manifest) path is
   // the ONLY mint without durable, queryable audit rows: recordSpendAttribution
@@ -860,54 +771,26 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   // All are BlockRevocation-checkable; the harness token-handling is identical.
   const blockInstanceId = resolved.blockInstanceId;
 
-  // 10. PAGE ctx (entity=none, no model binding) — byte-identical shape to the
-  // prod page mint, so a dev page token can NEVER satisfy a model-bound check.
-  const ctx: Record<string, unknown> = {
-    slotId: PAGE_SLOT_ID,
-    entityType: 'none',
-  };
-  // Defense-in-depth: PAGE_SLOT_ID is a page slot by construction; assert it.
-  if (!isPageSlot(PAGE_SLOT_ID)) {
-    res.status(500).json({ message: 'page slot misconfigured' });
-    return;
-  }
-
-  // 11. SIGN — reuse BlockTokenService.sign VERBATIM. Self-bound sub (userId),
-  // forced-SFW ceiling, dev-capped budget, page ctx. domain is null (no host
-  // read) — advisory only; the AUTHORITATIVE ceiling is maxBrowsingLevel.
+  // 10–11. SIGN — the shared belt builds the PAGE ctx (entity=none, no model
+  // binding — byte-identical to the prod page mint) and reuses
+  // BlockTokenService.sign VERBATIM: self-bound sub (userId), forced-SFW ceiling,
+  // dev-capped budget, `dev: true` (4h lifetime + `dev` claim; the verifier keys
+  // the 4h max-age cap off it, leaving every PRODUCTION token at 15min).
   //
-  // dev: true → a 4h lifetime + a `dev:true` claim (block-token.service.ts).
-  // The longer TTL lets a developer paste one token and iterate without
-  // re-minting every 15min; the verifier (block-scope.middleware.ts) keys the
-  // 4h max-age cap off the signed `dev` claim, leaving every PRODUCTION token
-  // at 15min.
-  //
-  // BLAST RADIUS of the 4h lifetime — the token carries NO mod claim, so step 2
-  // (the mint-TIME moderator check) does NOT bound it. What actually bounds the
+  // BLAST RADIUS of the 4h lifetime — the token carries NO mod claim, so the
+  // mint-TIME moderator check (step 2) does NOT bound it. What bounds the
   // money/settings paths is the LIVE per-request moderator re-check
   // (`assertViewerIsModerator` in apps.router / blocks.router): a demoted/banned
   // mod's 4h token is rejected there as soon as the demotion lands. The token is
-  // further self-bound (`sub` from the authenticated caller, never the body),
-  // per-call budget capped (step 8), and forced-SFW — all unchanged.
-  //
-  // ONE REAL RESIDUAL: the read-only catalog/`me` surfaces
-  // (`/api/v1/blocks/{models,images,me}`) authorize on token validity + the
-  // forced-SFW clamp, NOT a live mod re-check. So a demoted/banned mod holding a
-  // 4h dev token keeps read access to SFW-clamped PUBLIC catalog data for up to
-  // 4h. Low impact: public, SFW-clamped, self-bound `sub`, no money/settings
-  // scopes — accepted for the dev:live harness.
-  const result = await BlockTokenService.sign({
+  // further self-bound, per-call budget capped, and forced-SFW.
+  const result = await signDevScopedPageToken({
     userId: user.id,
-    blockId: resolved.signBlockId,
-    appId: resolved.signAppId,
-    appBlockId: resolved.signAppBlockId,
+    signBlockId: resolved.signBlockId,
+    signAppId: resolved.signAppId,
+    signAppBlockId: resolved.signAppBlockId,
     blockInstanceId,
-    scopes: granted,
-    ctx,
+    granted,
     buzzBudget,
-    domain: null,
-    maxBrowsingLevel: FORCED_SFW_CEILING,
-    dev: true,
   });
 
   // The body carries a bearer JWT — never let an intermediary cache it.

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -805,6 +805,10 @@ export function withBlockScope(
             scope: opts.requiredScope ?? '(any-token)',
               endpoint: endpointForLog,
               statusCode: res.statusCode,
+              // Phase 2: a dev token MAY carry a synthetic non-FK appBlockId (a
+              // pre-approval dev-tunnel app) — let the audit write persist it via
+              // the nullable-appBlockId path instead of FK-failing + swallowing.
+              dev: claims.dev === true,
             })
           )
           .catch(() => {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -2923,6 +2923,12 @@ export const blocksRouter = router({
           // Snapshot status is 'pending' / 'failed' / etc — map to an HTTP-
           // ish code so the existing UI badge colors are coherent.
           statusCode: snapshot.status === 'failed' ? 500 : 200,
+          // Phase 2 — App Dev Tunnel: a PRE-APPROVAL dev-tunnel spend carries a
+          // synthetic, non-FK appBlockId (`ephemeral-<slug>`). This is the durable
+          // per-spend audit row for that case (recordSpendAttribution below is
+          // inert for a synthetic appId, by design). `dev` routes it to the
+          // nullable-appBlockId path so the row persists instead of FK-failing.
+          dev: claims.dev === true,
         });
       })().catch(() => {
         /* swallowed inside helper */

--- a/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit coverage for the SHARED dev-scoped block-token mint belt
+ * (dev-scoped-mint.service) — the audited clamp + budget + sign logic BOTH the
+ * bearer dev-token mint and the Phase-2 cookie dev-tunnel host mint reuse.
+ *
+ * Locks the security-sensitive invariants that must NOT drift between callers:
+ *   - the TUNNEL allowlist STRIPS apps:storage:* (Decision 1); the DEV allowlist
+ *     KEEPS it,
+ *   - unknown + PAGE_FORBIDDEN + out-of-allowlist scopes are STRIPPED (no error),
+ *   - the OAuth ceiling is SKIPPED when oauthAllowed is null (pending/ephemeral —
+ *     no client), applied when a bitmask is passed,
+ *   - `keyCanSpend:false` strips the budgeted-spend scope,
+ *   - `user:read:self` is force-granted, output deduped + sorted,
+ *   - the budget clamps to the LOWER dev cap,
+ *   - the signed token is self-bound (userId), forced-SFW, dev:true, page ctx.
+ */
+
+const { mockSign } = vi.hoisted(() => ({
+  mockSign: vi.fn(async (input: unknown) => ({
+    token: 'jwt.signed',
+    expiresAt: '2099-01-01T00:00:00Z',
+    jti: 'j',
+    _input: input,
+  })),
+}));
+
+vi.mock('~/server/services/block-token.service', () => ({
+  BlockTokenService: { sign: mockSign },
+}));
+
+import {
+  clampDevScopes,
+  DEV_BUZZ_BUDGET_CAP,
+  DEV_BUZZ_BUDGET_DEFAULT,
+  DEV_TOKEN_SCOPE_ALLOWLIST,
+  FORCED_SFW_CEILING,
+  resolveDevBuzzBudget,
+  signDevScopedPageToken,
+  TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+} from '~/server/services/blocks/dev-scoped-mint.service';
+import { PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
+
+// AIServicesWrite OAuth bit — models:read:self carries a DIFFERENT bit, so a
+// ceiling of just this bit strips models:read:self but keeps ai:write:budgeted.
+const AI_WRITE_BIT = 1 << 15;
+
+const FULL_SOURCE = [
+  'models:read:self',
+  'media:read:owned',
+  'ai:write:budgeted',
+  'apps:storage:read',
+  'apps:storage:write',
+  'social:tip:self', // PAGE_FORBIDDEN
+  'buzz:read:self', // PAGE_FORBIDDEN
+  'block:settings:read', // not in either dev allowlist
+  'totally:fake:scope', // unknown
+];
+
+describe('clampDevScopes', () => {
+  it('TUNNEL allowlist STRIPS apps:storage:* (Decision 1) and every non-allowlisted / forbidden / unknown scope', () => {
+    const granted = clampDevScopes({
+      scopeSource: FULL_SOURCE,
+      oauthAllowed: null,
+      keyCanSpend: true,
+      allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(granted).toEqual([
+      'ai:write:budgeted',
+      'media:read:owned',
+      'models:read:self',
+      'user:read:self',
+    ]);
+    // App Storage never survives the tunnel clamp.
+    expect(granted).not.toContain('apps:storage:read');
+    expect(granted).not.toContain('apps:storage:write');
+  });
+
+  it('DEV (bearer) allowlist KEEPS apps:storage:* — the tunnel-vs-bearer difference is exactly storage', () => {
+    const granted = clampDevScopes({
+      scopeSource: FULL_SOURCE,
+      oauthAllowed: null,
+      keyCanSpend: true,
+      allowlist: DEV_TOKEN_SCOPE_ALLOWLIST,
+    });
+    expect(granted).toContain('apps:storage:read');
+    expect(granted).toContain('apps:storage:write');
+    // Still drops forbidden/unknown/out-of-allowlist.
+    expect(granted).not.toContain('social:tip:self');
+    expect(granted).not.toContain('buzz:read:self');
+    expect(granted).not.toContain('block:settings:read');
+    expect(granted).not.toContain('totally:fake:scope');
+  });
+
+  it('keyCanSpend:false STRIPS ai:write:budgeted (read/catalog scopes unaffected)', () => {
+    const granted = clampDevScopes({
+      scopeSource: ['models:read:self', 'ai:write:budgeted'],
+      oauthAllowed: null,
+      keyCanSpend: false,
+      allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(granted).not.toContain('ai:write:budgeted');
+    expect(granted).toEqual(['models:read:self', 'user:read:self']);
+  });
+
+  it('OAuth ceiling is SKIPPED when oauthAllowed is null but APPLIED for a bitmask (models:read:self stripped under an AI-only ceiling)', () => {
+    const withNull = clampDevScopes({
+      scopeSource: ['models:read:self', 'ai:write:budgeted'],
+      oauthAllowed: null,
+      keyCanSpend: true,
+      allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(withNull).toContain('models:read:self');
+
+    const withCeiling = clampDevScopes({
+      scopeSource: ['models:read:self', 'ai:write:budgeted'],
+      oauthAllowed: AI_WRITE_BIT, // allows ai:write:budgeted, NOT models:read:self
+      keyCanSpend: true,
+      allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(withCeiling).not.toContain('models:read:self');
+    expect(withCeiling).toContain('ai:write:budgeted');
+  });
+
+  it('body requestedScopes NARROWS the granted set (subset intersection)', () => {
+    const granted = clampDevScopes({
+      scopeSource: ['models:read:self', 'media:read:owned', 'ai:write:budgeted'],
+      oauthAllowed: null,
+      requestedScopes: ['ai:write:budgeted'],
+      keyCanSpend: true,
+      allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+    });
+    // Only the requested scope survives — plus the unconditional force-grant.
+    expect(granted).toEqual(['ai:write:budgeted', 'user:read:self']);
+  });
+
+  it('always force-grants user:read:self and dedups/sorts (even from an EMPTY source → read-only token)', () => {
+    const granted = clampDevScopes({
+      scopeSource: [],
+      oauthAllowed: null,
+      keyCanSpend: true,
+      allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(granted).toEqual(['user:read:self']);
+
+    // user:read:self present in source is not duplicated.
+    const dedup = clampDevScopes({
+      scopeSource: ['user:read:self', 'models:read:self'],
+      oauthAllowed: null,
+      keyCanSpend: true,
+      allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(dedup).toEqual(['models:read:self', 'user:read:self']);
+  });
+});
+
+describe('resolveDevBuzzBudget', () => {
+  it('returns undefined when ai:write:budgeted was not granted', () => {
+    expect(resolveDevBuzzBudget(['user:read:self'])).toBeUndefined();
+  });
+  it('clamps a requested budget to the LOWER dev cap', () => {
+    expect(resolveDevBuzzBudget(['ai:write:budgeted'], 100000)).toBe(DEV_BUZZ_BUDGET_CAP);
+    expect(resolveDevBuzzBudget(['ai:write:budgeted'], 10)).toBe(10);
+  });
+  it('defaults to DEV_BUZZ_BUDGET_DEFAULT when no budget is requested', () => {
+    expect(resolveDevBuzzBudget(['ai:write:budgeted'])).toBe(DEV_BUZZ_BUDGET_DEFAULT);
+  });
+});
+
+describe('signDevScopedPageToken', () => {
+  beforeEach(() => mockSign.mockClear());
+
+  it('signs a SELF-BOUND, forced-SFW, dev:true PAGE token with the synthetic ids verbatim', async () => {
+    const res = await signDevScopedPageToken({
+      userId: 777,
+      signBlockId: 'my-app',
+      signAppId: 'ephemeral-my-app',
+      signAppBlockId: 'ephemeral-my-app',
+      blockInstanceId: 'page_ephemeral-my-app',
+      granted: ['ai:write:budgeted', 'user:read:self'],
+      buzzBudget: 50,
+    });
+    expect(res.token).toBe('jwt.signed');
+    expect(mockSign).toHaveBeenCalledTimes(1);
+    const arg = mockSign.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.userId).toBe(777); // self-bound
+    expect(arg.dev).toBe(true); // 4h dev lifetime
+    expect(arg.domain).toBeNull(); // never reads a host
+    expect(arg.maxBrowsingLevel).toBe(FORCED_SFW_CEILING); // forced SFW
+    expect(arg.appId).toBe('ephemeral-my-app'); // synthetic, non-resolving
+    expect(arg.appBlockId).toBe('ephemeral-my-app');
+    expect(arg.blockInstanceId).toBe('page_ephemeral-my-app');
+    expect(arg.buzzBudget).toBe(50);
+    // PAGE ctx (entity=none, no modelId) — can never satisfy a model-bound check.
+    expect(arg.ctx).toEqual({ slotId: PAGE_SLOT_ID, entityType: 'none' });
+  });
+});

--- a/src/server/services/blocks/__tests__/record-scope-invocation-synthetic.test.ts
+++ b/src/server/services/blocks/__tests__/record-scope-invocation-synthetic.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * PHASE 2 — durable per-spend audit for PRE-APPROVAL dev-tunnel spends.
+ *
+ * recordScopeInvocation writes one BlockScopeInvocation row per scope-gated call.
+ * A pre-approval dev-tunnel token carries a SYNTHETIC, non-FK `appBlockId`
+ * (`ephemeral-<slug>`) that FK-fails the INSERT. With `dev:true` the write RETRIES
+ * with `appBlockId: null` + `syntheticAppId`, so the audit row PERSISTS instead of
+ * being swallowed. A non-dev FK orphan keeps the historical "log, no row" path.
+ */
+
+const { mockDbWrite, mockLog } = vi.hoisted(() => ({
+  mockDbWrite: {
+    blockScopeInvocation: { create: vi.fn<(...args: any[]) => Promise<any>>() },
+  },
+  mockLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: mockDbWrite }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLog }));
+
+import { recordScopeInvocation } from '~/server/services/blocks/user-app-surface.service';
+
+// Mimic a Prisma FK violation (P2003).
+function fkError() {
+  return Object.assign(new Error('FK violation'), { code: 'P2003' });
+}
+
+const BASE = {
+  userId: 99,
+  blockInstanceId: 'page_ephemeral-my-app',
+  scope: 'ai:write:budgeted',
+  endpoint: 'workflow:submit:wf_1',
+  statusCode: 200,
+};
+
+describe('recordScopeInvocation — synthetic pre-approval dev spend', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('a REAL appBlockId writes once with the FK value (no retry, no synthetic column)', async () => {
+    mockDbWrite.blockScopeInvocation.create.mockResolvedValueOnce({});
+    await recordScopeInvocation({ ...BASE, appBlockId: 'apb_real', dev: true });
+    expect(mockDbWrite.blockScopeInvocation.create).toHaveBeenCalledTimes(1);
+    const data = mockDbWrite.blockScopeInvocation.create.mock.calls[0][0].data;
+    expect(data.appBlockId).toBe('apb_real');
+    expect(data.syntheticAppId).toBeUndefined();
+  });
+
+  it('dev token + synthetic appBlockId FK-fails → RETRIES with appBlockId:null + syntheticAppId (row persists)', async () => {
+    mockDbWrite.blockScopeInvocation.create
+      .mockRejectedValueOnce(fkError()) // first attempt: FK violation on the synthetic id
+      .mockResolvedValueOnce({}); // retry: persists
+    await recordScopeInvocation({ ...BASE, appBlockId: 'ephemeral-my-app', dev: true });
+    expect(mockDbWrite.blockScopeInvocation.create).toHaveBeenCalledTimes(2);
+    const retry = mockDbWrite.blockScopeInvocation.create.mock.calls[1][0].data;
+    expect(retry.appBlockId).toBeNull();
+    expect(retry.syntheticAppId).toBe('ephemeral-my-app');
+    expect(retry.scope).toBe('ai:write:budgeted');
+    // The audit log is NOT fired — the retry succeeded.
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+
+  it('NON-dev FK orphan does NOT retry — historical "log, no row" behaviour is preserved', async () => {
+    mockDbWrite.blockScopeInvocation.create.mockRejectedValueOnce(fkError());
+    await recordScopeInvocation({ ...BASE, appBlockId: 'apb_deleted', dev: false });
+    expect(mockDbWrite.blockScopeInvocation.create).toHaveBeenCalledTimes(1);
+    expect(mockLog).toHaveBeenCalledTimes(1);
+  });
+
+  it('dev token whose synthetic RETRY also fails → best-effort log, never throws', async () => {
+    mockDbWrite.blockScopeInvocation.create
+      .mockRejectedValueOnce(fkError())
+      .mockRejectedValueOnce(new Error('db down'));
+    await expect(
+      recordScopeInvocation({ ...BASE, appBlockId: 'ephemeral-my-app', dev: true })
+    ).resolves.toBeUndefined();
+    expect(mockDbWrite.blockScopeInvocation.create).toHaveBeenCalledTimes(2);
+    expect(mockLog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/blocks/__tests__/record-scope-invocation-synthetic.test.ts
+++ b/src/server/services/blocks/__tests__/record-scope-invocation-synthetic.test.ts
@@ -70,6 +70,35 @@ describe('recordScopeInvocation — synthetic pre-approval dev spend', () => {
     expect(mockLog).toHaveBeenCalledTimes(1);
   });
 
+  it('DEV token + REAL apb_ id that FK-fails (app deleted between mint & spend) does NOT retry — never mislabelled synthetic', async () => {
+    // The prefix gate is load-bearing here: `dev && P2003` alone would wrongly
+    // relabel this real, deleted app as `synthetic_app_id = apb_...`. It must
+    // instead keep the historical "log, no row" path.
+    mockDbWrite.blockScopeInvocation.create.mockRejectedValueOnce(fkError());
+    await recordScopeInvocation({ ...BASE, appBlockId: 'apb_deleted_real', dev: true });
+    expect(mockDbWrite.blockScopeInvocation.create).toHaveBeenCalledTimes(1);
+    // No synthetic retry write happened.
+    expect(mockDbWrite.blockScopeInvocation.create.mock.calls[0][0].data.appBlockId).toBe(
+      'apb_deleted_real'
+    );
+    expect(mockLog).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['page_local_my-app', 'dev-token.ts no-row local-manifest path'],
+    ['pubreq_01HZY0000000000000000000', 'dev-token.ts pending path (AppBlockPublishRequest.id)'],
+  ])('dev token + synthetic %s FK-fails → RETRIES with syntheticAppId (row persists)', async (id) => {
+    mockDbWrite.blockScopeInvocation.create
+      .mockRejectedValueOnce(fkError())
+      .mockResolvedValueOnce({});
+    await recordScopeInvocation({ ...BASE, appBlockId: id, dev: true });
+    expect(mockDbWrite.blockScopeInvocation.create).toHaveBeenCalledTimes(2);
+    const retry = mockDbWrite.blockScopeInvocation.create.mock.calls[1][0].data;
+    expect(retry.appBlockId).toBeNull();
+    expect(retry.syntheticAppId).toBe(id);
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+
   it('dev token whose synthetic RETRY also fails → best-effort log, never throws', async () => {
     mockDbWrite.blockScopeInvocation.create
       .mockRejectedValueOnce(fkError())

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -1,0 +1,208 @@
+import {
+  isKnownBlockScope,
+  validateBlockScopesAgainstOauthClient,
+} from '~/shared/constants/block-scope.constants';
+import { domainBrowsingCeiling } from '~/shared/constants/browsingLevel.constants';
+import { isPageSlot, PAGE_FORBIDDEN_SCOPES, PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
+import { BlockTokenService } from '~/server/services/block-token.service';
+
+/**
+ * SHARED dev-scoped block-token mint belt (App Dev Tunnel).
+ *
+ * This is the AUDITED clamp + budget + sign belt extracted VERBATIM from the
+ * `POST /api/v1/blocks/dev-token` handler so BOTH mint entrypoints reuse the
+ * identical, adversarially-reviewed logic instead of a parallel re-implementation
+ * (where escalation defenses silently drift apart):
+ *
+ *   1. `/api/v1/blocks/dev-token`         — BEARER-authed (personal key / OAuth
+ *                                            civitai-cli) dev:live harness mint.
+ *                                            Uses `DEV_TOKEN_SCOPE_ALLOWLIST`
+ *                                            (WITH apps:storage:*) and gates the
+ *                                            spend scope on the bearer credential's
+ *                                            AIServicesWrite bit (`keyCanSpend`).
+ *   2. `/api/v1/block-tokens` (Phase 2)   — COOKIE-authed author-own dev-tunnel
+ *                                            branch, for the SSR dev host at
+ *                                            `/apps/dev/<blockId>`. Uses
+ *                                            `TUNNEL_HOST_MINT_SCOPE_ALLOWLIST`
+ *                                            (WITHOUT apps:storage:* — Decision 1:
+ *                                            App Storage stays 403 until approval)
+ *                                            and passes `keyCanSpend: true` because
+ *                                            there is no bearer ceiling; SPEND is
+ *                                            instead gated at RUNTIME by
+ *                                            `assertViewerIsAppDeveloper(sub)` on
+ *                                            the token subject (blocks.router
+ *                                            submitWorkflow) plus the per-call /
+ *                                            per-session / per-day Buzz caps.
+ *
+ * Every hard cap is IDENTICAL across both callers: forced-SFW ceiling, self-bound
+ * `sub`, `dev:true` short (4h) TTL, DEV_BUZZ_BUDGET_CAP per-call budget, page ctx.
+ * The synthetic, NON-RESOLVING appId/appBlockId (never an `appblk-<slug>` OauthClient
+ * id nor a UUIDv4) is the caller's responsibility to construct — it guarantees
+ * `recordSpendAttribution`'s `oauthClient.findUnique` MISSES (no forged attribution).
+ */
+
+// A LOWER dev budget cap than the prod 1000. The dev spends their OWN Buzz and the
+// per-user daily cumulative cap is untouched; this just bounds a single submit's
+// reservation.
+export const DEV_BUZZ_BUDGET_CAP = 250;
+export const DEV_BUZZ_BUDGET_DEFAULT = 50;
+
+// Forced SFW — the dev mint NEVER reads the request host. localhost / the dev
+// tunnel has no color domain, and even a color-localhost dev config must not widen
+// maturity.
+export const FORCED_SFW_CEILING = domainBrowsingCeiling(null);
+
+/**
+ * The BEARER dev-token allowlist (scope doc §4.1): read/catalog scopes + the page
+ * spend scope + per-app storage. Used by `/api/v1/blocks/dev-token` only.
+ * DELIBERATELY EXCLUDES `social:tip:self` (real money OUT) and
+ * `block:settings:read` / `block:settings:write` (installer-only). A requested /
+ * approved scope outside this set is STRIPPED (defense-in-depth).
+ */
+export const DEV_TOKEN_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
+  'models:read:self',
+  'media:read:owned',
+  'user:read:self',
+  'ai:write:budgeted',
+  'apps:storage:read',
+  'apps:storage:write',
+]);
+
+/**
+ * The COOKIE-authed dev-TUNNEL host-mint allowlist (Phase 2). IDENTICAL to
+ * `DEV_TOKEN_SCOPE_ALLOWLIST` MINUS `apps:storage:read` / `apps:storage:write`
+ * (Decision 1). App Storage is REFUSED pre-approval: a pre-approval app has a
+ * synthetic, non-resolving appId, so its storage namespace is undefined and could
+ * collide across the approve boundary — generation/Buzz work pre-approval, App
+ * Storage does not. Stripping the scope from the clamp is defense-in-depth ON TOP
+ * of the downstream `resolveStorageContext` 404 for a synthetic/non-approved appId
+ * (so a minted tunnel token can NEVER carry a storage scope in the first place).
+ */
+export const TUNNEL_HOST_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
+  'models:read:self',
+  'media:read:owned',
+  'user:read:self',
+  'ai:write:budgeted',
+]);
+
+/**
+ * The AUDITED scope clamp belt (dev-token.ts steps 7a–7g), extracted verbatim.
+ * Start from `scopeSource` (the app's approved snapshot, an owned pending request's
+ * un-reviewed `manifest.scopes`, or the caller's self-declared body scopes) and:
+ *   a) keep only KNOWN block scopes,
+ *   b) keep only scopes within `allowlist` (excludes social:tip:self +
+ *      block:settings:* always; for the tunnel allowlist also apps:storage:*),
+ *   c) keep only scopes within the app's OAuth ceiling (approved path only —
+ *      `oauthAllowed !== null`); OMITTED for a pending / no-row / ephemeral app
+ *      (no OauthClient — passing 0 would WRONGLY strip every non-skip scope),
+ *   d) drop the PAGE_FORBIDDEN money/spend scopes (the page hard rule),
+ *   e) if the body narrowed, intersect with the requested subset,
+ *   f) BEARER-credential spend ceiling — strip `ai:write:budgeted` unless
+ *      `keyCanSpend` (dev-token: the bearer's AIServicesWrite bit; host-mint:
+ *      `true`, since spend is gated at runtime by the author-flag re-check),
+ *   g) force-grant `user:read:self` (self-bound read of the caller's OWN identity).
+ * Every step is a STRIP (no error). The belt is byte-identical across all callers
+ * bar the allowlist + the OAuth-ceiling substitution.
+ */
+export function clampDevScopes(opts: {
+  scopeSource: string[];
+  oauthAllowed: number | null;
+  requestedScopes?: string[];
+  keyCanSpend: boolean;
+  allowlist: ReadonlySet<string>;
+}): string[] {
+  const { scopeSource, oauthAllowed, requestedScopes, keyCanSpend, allowlist } = opts;
+
+  const forbidden = new Set<string>(PAGE_FORBIDDEN_SCOPES);
+
+  let granted: string[] = scopeSource
+    .filter((s) => isKnownBlockScope(s))
+    .filter((s) => allowlist.has(s))
+    .filter((s) => !forbidden.has(s));
+
+  // OAuth-ceiling clamp (approved path ONLY). validateBlockScopesAgainstOauthClient
+  // treats SKIP_OAUTH_CHECK scopes as always-allowed. SKIPPED when oauthAllowed is
+  // null (pending / no-row / ephemeral — no client; passing 0 would wrongly strip
+  // every non-skip scope).
+  if (oauthAllowed !== null) {
+    const ceiling = oauthAllowed;
+    granted = granted.filter((s: string) => validateBlockScopesAgainstOauthClient([s], ceiling).valid);
+  }
+
+  // Body narrowing — the caller may request a subset of the above.
+  if (requestedScopes && requestedScopes.length > 0) {
+    const want = new Set(requestedScopes);
+    granted = granted.filter((s: string) => want.has(s));
+  }
+
+  // Bearer-credential (or runtime-author) spend ceiling: strip the budgeted-spend
+  // scope unless the caller can spend. Read/catalog scopes are unaffected.
+  if (!keyCanSpend) {
+    granted = granted.filter((s: string) => s !== 'ai:write:budgeted');
+  }
+
+  // Force-grant `user:read:self` (unconditional, post-clamp): a READ scope that
+  // returns ONLY the self-bound caller's own profile. The token's `sub` is always
+  // the authenticated caller (never the body), so this can only ever return the
+  // caller's own identity — zero escalation, no new data surface.
+  granted.push('user:read:self');
+
+  // Dedup, deterministic order.
+  return Array.from(new Set(granted)).sort();
+}
+
+/**
+ * BUDGET CAP (dev-token.ts step 8). Only meaningful when `ai:write:budgeted`
+ * survived the clamp. Clamp the requested budget (or the default) to the LOWER dev
+ * cap; `undefined` when no spend scope was granted.
+ */
+export function resolveDevBuzzBudget(
+  granted: string[],
+  requestedBudget?: number
+): number | undefined {
+  return granted.includes('ai:write:budgeted')
+    ? Math.min(requestedBudget ?? DEV_BUZZ_BUDGET_DEFAULT, DEV_BUZZ_BUDGET_CAP)
+    : undefined;
+}
+
+/**
+ * SIGN (dev-token.ts steps 10–11). Reuse BlockTokenService.sign VERBATIM with the
+ * PAGE ctx (entity=none, no model binding — byte-identical to the prod page mint so
+ * a dev page token can NEVER satisfy a model-bound check), the forced-SFW ceiling,
+ * a self-bound `userId`, the dev-capped budget, and `dev: true` (4h lifetime + the
+ * `dev` claim the verifier keys the 4h max-age cap off).
+ *
+ * The `isPageSlot(PAGE_SLOT_ID)` assertion is defense-in-depth on a compile-time
+ * constant (PAGE_SLOT_ID is always a page slot); it throws only on a build
+ * misconfiguration, which the callers translate into a 500.
+ */
+export async function signDevScopedPageToken(opts: {
+  userId: number;
+  signBlockId: string;
+  signAppId: string;
+  signAppBlockId: string;
+  blockInstanceId: string;
+  granted: string[];
+  buzzBudget: number | undefined;
+}): Promise<Awaited<ReturnType<typeof BlockTokenService.sign>>> {
+  const ctx: Record<string, unknown> = {
+    slotId: PAGE_SLOT_ID,
+    entityType: 'none',
+  };
+  if (!isPageSlot(PAGE_SLOT_ID)) {
+    throw new Error('page slot misconfigured');
+  }
+  return BlockTokenService.sign({
+    userId: opts.userId,
+    blockId: opts.signBlockId,
+    appId: opts.signAppId,
+    appBlockId: opts.signAppBlockId,
+    blockInstanceId: opts.blockInstanceId,
+    scopes: opts.granted,
+    ctx,
+    buzzBudget: opts.buzzBudget,
+    domain: null,
+    maxBrowsingLevel: FORCED_SFW_CEILING,
+    dev: true,
+  });
+}

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -409,6 +409,17 @@ export async function recordScopeInvocation(opts: {
   scope: string;
   endpoint: string;
   statusCode: number;
+  /**
+   * App Dev Tunnel Phase 2 — set when the token is a DEV token (`claims.dev`).
+   * A dev token MAY carry a SYNTHETIC, non-FK-resolving `appBlockId` (a
+   * PRE-APPROVAL app has no AppBlock row: `ephemeral-<slug>` / `local-<slug>` /
+   * `pubreq_<id>`). When the direct INSERT FK-fails for such a token we retry with
+   * `appBlockId: null` + `syntheticAppId` so the durable per-spend audit row
+   * PERSISTS instead of being swallowed. The APPROVED dev-token path carries a
+   * REAL appBlockId and writes on the first attempt (no retry). Absent/false →
+   * the historical behaviour (a real FK orphan just logs, no row).
+   */
+  dev?: boolean;
 }): Promise<void> {
   try {
     await dbWrite.blockScopeInvocation.create({
@@ -424,6 +435,41 @@ export async function recordScopeInvocation(opts: {
       },
     });
   } catch (err) {
+    // App Dev Tunnel Phase 2: a DEV token with a SYNTHETIC (non-resolving)
+    // appBlockId FK-fails here. Retry with `appBlockId: null` + `syntheticAppId`
+    // so the pre-approval per-spend audit row PERSISTS (the durable trail the
+    // synthetic-appId attribution path can't write). Scoped to `dev === true` +
+    // an FK violation so a deleted REAL app on the normal path keeps the historical
+    // "log, no row" behaviour (never mislabelled synthetic).
+    const isFkViolation =
+      typeof err === 'object' &&
+      err !== null &&
+      (err as { code?: unknown }).code === 'P2003';
+    if (opts.dev && isFkViolation) {
+      try {
+        // `appBlockId: null` + `syntheticAppId` require the schema change in this
+        // PR (BlockScopeInvocation.appBlockId → nullable, + synthetic_app_id).
+        // The generated Prisma client is regenerated from that schema at build
+        // time (postinstall → `pnpm db:generate`); this bridge cast keeps the
+        // source type-clean against a client generated BEFORE the migration lands
+        // (the NixOS dev env can't run `prisma generate`). Field names mirror the
+        // schema exactly — see schema.full.prisma model BlockScopeInvocation.
+        const retryData = {
+          userId: opts.userId,
+          appBlockId: null,
+          syntheticAppId: opts.appBlockId,
+          blockInstanceId: opts.blockInstanceId,
+          scope: opts.scope,
+          endpoint: opts.endpoint.slice(0, 512),
+          statusCode: opts.statusCode,
+        } as unknown as Parameters<typeof dbWrite.blockScopeInvocation.create>[0]['data'];
+        await dbWrite.blockScopeInvocation.create({ data: retryData });
+        return;
+      } catch (retryErr) {
+        // Fall through to the best-effort log below with the retry error.
+        err = retryErr;
+      }
+    }
     // Don't let an audit-write failure crash the request lifecycle. Most
     // common cause: app_block_id FK orphaned because the block was
     // deleted between token issuance and this scope call.

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -16,6 +16,28 @@
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 
+/**
+ * The SYNTHETIC (non-FK-resolving) `appBlockId` claim namespaces a PRE-APPROVAL
+ * dev-tunnel mint stamps on a `dev:live` token. A REAL AppBlock.id is ALWAYS
+ * `apb_<26 ULID>`, so none of these can ever collide with one — gating the
+ * synthetic-retry on this prefix set means a deleted REAL app (`apb_…`) whose
+ * FK-fails is NEVER relabelled `synthetic_app_id = <real id>`; it keeps the
+ * historical "log, no row" behaviour. Values verified against the mints:
+ *   - `ephemeral-<slug>`   block-tokens dev-tunnel scoped mint (Phase 2 — this PR)
+ *                          → `resolveDevPageBlockForAuthor` (status 'ephemeral')
+ *   - `page_local_<slug>`  dev-token.ts no-row local-manifest path (`signAppBlockId`)
+ *   - `pubreq_<ULID>`      dev-token.ts pending path (`signAppBlockId: pending.id`,
+ *                          AppBlockPublishRequest.id = `pubreq_<ULID>`)
+ * (NB: the conceptual *appId* names are `local-`/`pending-`; the *appBlockId*
+ * claim these paths actually carry — the value recordScopeInvocation sees — is
+ * `page_local_`/`pubreq_`.)
+ */
+const SYNTHETIC_APP_BLOCK_ID_PREFIXES = ['ephemeral-', 'page_local_', 'pubreq_'] as const;
+
+function isSyntheticAppBlockId(appBlockId: string): boolean {
+  return SYNTHETIC_APP_BLOCK_ID_PREFIXES.some((prefix) => appBlockId.startsWith(prefix));
+}
+
 export type ScopeGrantSurface = {
   appBlockId: string;
   slug: string;
@@ -412,12 +434,15 @@ export async function recordScopeInvocation(opts: {
   /**
    * App Dev Tunnel Phase 2 — set when the token is a DEV token (`claims.dev`).
    * A dev token MAY carry a SYNTHETIC, non-FK-resolving `appBlockId` (a
-   * PRE-APPROVAL app has no AppBlock row: `ephemeral-<slug>` / `local-<slug>` /
-   * `pubreq_<id>`). When the direct INSERT FK-fails for such a token we retry with
-   * `appBlockId: null` + `syntheticAppId` so the durable per-spend audit row
+   * PRE-APPROVAL app has no AppBlock row: `ephemeral-<slug>` / `page_local_<slug>`
+   * / `pubreq_<ULID>` — see SYNTHETIC_APP_BLOCK_ID_PREFIXES). When the direct
+   * INSERT FK-fails for such a token AND the id is synthetic-prefixed we retry
+   * with `appBlockId: null` + `syntheticAppId` so the durable per-spend audit row
    * PERSISTS instead of being swallowed. The APPROVED dev-token path carries a
-   * REAL appBlockId and writes on the first attempt (no retry). Absent/false →
-   * the historical behaviour (a real FK orphan just logs, no row).
+   * REAL `apb_<ulid>` appBlockId and writes on the first attempt (no retry); a
+   * REAL app deleted between mint and spend also FK-fails but is NOT synthetic —
+   * it keeps the historical "log, no row" behaviour. Absent/false `dev` → the
+   * historical behaviour (a real FK orphan just logs, no row).
    */
   dev?: boolean;
 }): Promise<void> {
@@ -445,7 +470,12 @@ export async function recordScopeInvocation(opts: {
       typeof err === 'object' &&
       err !== null &&
       (err as { code?: unknown }).code === 'P2003';
-    if (opts.dev && isFkViolation) {
+    // Gate the synthetic path on a SYNTHETIC-id PREFIX, not merely `dev && P2003`.
+    // A dev token can carry a REAL `apb_<ulid>` appBlockId whose AppBlock row was
+    // deleted between mint and spend — that FK-fails too, but it is NOT synthetic,
+    // so it must keep the historical "log, no row" behaviour (never mislabelled
+    // `synthetic_app_id = <real id>`). Only a genuine synthetic namespace retries.
+    if (opts.dev && isFkViolation && isSyntheticAppBlockId(opts.appBlockId)) {
       try {
         // `appBlockId: null` + `syntheticAppId` require the schema change in this
         // PR (BlockScopeInvocation.appBlockId → nullable, + synthetic_app_id).

--- a/src/tests/api/v1/block-tokens/dev-tunnel-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/dev-tunnel-mint.test.ts
@@ -173,6 +173,27 @@ async function invoke(body: unknown) {
   return res;
 }
 
+// A POST whose Origin header is `origin` (pass `null` to omit it entirely — a
+// `null`/absent Origin, e.g. a sandboxed-iframe or non-browser POST).
+function makeReqOrigin(body: unknown, origin: string | null): NextApiRequest {
+  const headers: Record<string, string> = {};
+  if (origin !== null) headers.origin = origin;
+  return {
+    method: 'POST',
+    headers,
+    body,
+    socket: { remoteAddress: '127.0.0.1' },
+    query: {},
+  } as unknown as NextApiRequest;
+}
+
+async function invokeOrigin(body: unknown, origin: string | null) {
+  const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+  const res = makeRes();
+  await handler(makeReqOrigin(body, origin), res);
+  return res;
+}
+
 describe('POST /api/v1/block-tokens — Phase 2 dev-tunnel author-own mint', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -278,6 +299,27 @@ describe('POST /api/v1/block-tokens — Phase 2 dev-tunnel author-own mint', () 
     mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: new Date(), bannedAt: null });
     const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted'] }));
     expect(res._status).toBe(404);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('CROSS-ORIGIN POST (Origin not in the allowlist) is 403 by setSameOriginCors BEFORE the dev mint', async () => {
+    // setSameOriginCors (handler entry) rejects the request before the dev-tunnel
+    // branch runs — the CSRF gate must fire ahead of any ownership/mint work, so a
+    // forged cross-origin POST can neither mint a token nor touch the resolver.
+    const res = await invokeOrigin(DEV_BODY({ devScopes: ['ai:write:budgeted'] }), 'https://evil.example');
+    expect(res._status).toBe(403);
+    expect(res._body).toEqual({ error: 'cross-origin POST rejected' });
+    // Never reached the dev branch: no resolve, no sign, no ACAO for the bad origin.
+    expect(mockBlockRegistry.resolveDevPageBlockForAuthor).not.toHaveBeenCalled();
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+    expect(res._headers['access-control-allow-origin']).toBeUndefined();
+  });
+
+  it('a null/absent-Origin POST is likewise 403 before the dev mint', async () => {
+    const res = await invokeOrigin(DEV_BODY({ devScopes: ['ai:write:budgeted'] }), null);
+    expect(res._status).toBe(403);
+    expect(res._body).toEqual({ error: 'cross-origin POST rejected' });
+    expect(mockBlockRegistry.resolveDevPageBlockForAuthor).not.toHaveBeenCalled();
     expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/api/v1/block-tokens/dev-tunnel-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/dev-tunnel-mint.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * PHASE 2 — App Dev Tunnel author-own SCOPED mint on POST /api/v1/block-tokens.
+ *
+ * When `resolvePageBlock` misses (a PRE-APPROVAL ephemeral app), the cookie-authed
+ * AUTHOR who OWNS the app mints a SCOPED, forced-SFW, self-bound, budget-capped dev
+ * token so real Buzz-spend generation works pre-approval. Asserts:
+ *   - OWN pending submission → scope source = server-read manifest.scopes,
+ *   - OWN brand-new (no pending) → scope source = self-declared body devScopes,
+ *   - App Storage scope is STRIPPED (Decision 1),
+ *   - the synthetic non-resolving ids + forced-SFW + dev:true are signed,
+ *   - foreign / approved-elsewhere (resolver → null) → the SAME bare 404, no token,
+ *   - the dev-tunnel kill-switch OFF → 404 (no mint),
+ *   - a resolved non-ephemeral status → 404 (fail-closed).
+ */
+
+const {
+  mockDbWrite,
+  mockRedis,
+  mockSession,
+  mockTokenService,
+  mockBlockRegistry,
+  mockFlags,
+  mockAppBlocksFlag,
+} = vi.hoisted(() => {
+  const dbWrite = {
+    user: {
+      findUnique: vi.fn<(...args: any[]) => Promise<any>>(async () => ({
+        deletedAt: null,
+        bannedAt: null,
+      })),
+    },
+    appBlockPublishRequest: {
+      findFirst: vi.fn<(...args: any[]) => Promise<any>>(async () => null),
+    },
+    appUserScopeGrant: { findUnique: vi.fn<(...args: any[]) => Promise<any>>(async () => null) },
+  };
+  const redis = {
+    incrBy: vi.fn(async () => 1),
+    expire: vi.fn(async () => true),
+    ttl: vi.fn(async () => 60),
+  };
+  const session = { value: null as any };
+  const tokenService = {
+    sign: vi.fn<(...args: any[]) => Promise<any>>(async () => ({
+      token: 'jwt.dev.signed',
+      expiresAt: '2099-01-01T00:00:00Z',
+      jti: 'j',
+    })),
+    checkRateLimit: vi.fn<(...args: any[]) => Promise<boolean>>(async () => true),
+  };
+  const blockRegistry = {
+    resolveBlockInstance: vi.fn<(...args: any[]) => Promise<any>>(),
+    resolvePageBlock: vi.fn<(...args: any[]) => Promise<any>>(async () => null),
+    resolveDevPageBlockForAuthor: vi.fn<(...args: any[]) => Promise<any>>(async () => null),
+  };
+  const flags = {
+    getFeatureFlags: vi.fn(({ user }: { user?: { isModerator?: boolean } }) => ({
+      appBlocks: !!user?.isModerator,
+      appBlocksPages: !!user?.isModerator,
+    })),
+  };
+  const appBlocksFlag = {
+    isAppBlocksAuthorEnabled: vi.fn(async () => true),
+    isAppBlocksDevTunnelEnabled: vi.fn(async () => true),
+  };
+  return {
+    mockDbWrite: dbWrite,
+    mockRedis: redis,
+    mockSession: session,
+    mockTokenService: tokenService,
+    mockBlockRegistry: blockRegistry,
+    mockFlags: flags,
+    mockAppBlocksFlag: appBlocksFlag,
+  };
+});
+
+vi.mock('~/env/server', () => ({
+  env: {
+    NEXTAUTH_URL: 'https://civitai.com',
+    TRPC_ORIGINS: [],
+    BLOCK_TOKEN_PRIVATE_KEY: 'fake-private',
+    BLOCK_TOKEN_PUBLIC_KEY: 'fake-public',
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
+vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: vi.fn(async () => mockSession.value),
+}));
+vi.mock('~/server/services/block-token.service', () => ({ BlockTokenService: mockTokenService }));
+vi.mock('~/server/services/block-registry.service', () => ({ BlockRegistry: mockBlockRegistry }));
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'rl' } },
+}));
+vi.mock('~/server/utils/server-domain', () => ({
+  getAllServerHosts: () => ['civitai.com'],
+  getRequestDomainColor: () => undefined,
+  isHostForColor: () => false,
+  isMatureContentRating: () => false,
+}));
+vi.mock('~/server/services/feature-flags.service', () => mockFlags);
+vi.mock('~/server/services/app-blocks-flag', () => mockAppBlocksFlag);
+
+function makeReq(body: unknown): NextApiRequest {
+  return {
+    method: 'POST',
+    headers: { origin: 'https://civitai.com' },
+    body,
+    socket: { remoteAddress: '127.0.0.1' },
+    query: {},
+  } as unknown as NextApiRequest;
+}
+
+function makeRes() {
+  const res = {
+    _status: 0,
+    _body: null as any,
+    _headers: {} as Record<string, string>,
+    setHeader: vi.fn(function (this: any, name: string, value: string) {
+      this._headers[name.toLowerCase()] = value;
+      return this;
+    }),
+    status: vi.fn(function (this: any, n: number) {
+      this._status = n;
+      return this;
+    }),
+    json: vi.fn(function (this: any, b: unknown) {
+      this._body = b;
+      return this;
+    }),
+    end: vi.fn(function (this: any) {
+      return this;
+    }),
+    send: vi.fn(function (this: any, b: unknown) {
+      this._body = b;
+      return this;
+    }),
+  };
+  return res as unknown as NextApiResponse & { _status: number; _body: any; _headers: Record<string, string> };
+}
+
+const MOD = { user: { id: 4242, isModerator: true, bannedAt: null } };
+
+// The ephemeral resolution BlockRegistry.resolveDevPageBlockForAuthor returns for
+// an OWNED pre-approval app (synthetic, non-resolving ids; empty display scopes).
+const EPHEMERAL_RESOLUTION = {
+  appBlockId: 'ephemeral-my-app',
+  appId: 'ephemeral-my-app',
+  blockId: 'my-app',
+  status: 'ephemeral',
+  trustTier: 'unverified',
+  name: 'my-app',
+  pageTitle: 'my-app',
+  sandbox: 'allow-scripts allow-forms',
+  scopes: [],
+  contentRating: null,
+};
+
+const DEV_BODY = (extra?: Record<string, unknown>) => ({
+  blockInstanceId: 'page_ephemeral-my-app',
+  slotContext: { entityType: 'none', slotId: 'app.page' },
+  ...extra,
+});
+
+async function invoke(body: unknown) {
+  const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+  const res = makeRes();
+  await handler(makeReq(body), res);
+  return res;
+}
+
+describe('POST /api/v1/block-tokens — Phase 2 dev-tunnel author-own mint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSession.value = MOD;
+    mockRedis.incrBy.mockResolvedValue(1);
+    mockRedis.ttl.mockResolvedValue(60);
+    mockTokenService.checkRateLimit.mockResolvedValue(true);
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(null); // pre-approval miss
+    mockBlockRegistry.resolveDevPageBlockForAuthor.mockResolvedValue(EPHEMERAL_RESOLUTION);
+    mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: null, bannedAt: null });
+    mockDbWrite.appBlockPublishRequest.findFirst.mockResolvedValue(null);
+    mockAppBlocksFlag.isAppBlocksAuthorEnabled.mockResolvedValue(true);
+    mockAppBlocksFlag.isAppBlocksDevTunnelEnabled.mockResolvedValue(true);
+  });
+
+  it('OWN pending submission → mints a scoped token from the SERVER-READ manifest scopes (App Storage STRIPPED)', async () => {
+    mockDbWrite.appBlockPublishRequest.findFirst.mockResolvedValue({
+      manifest: { scopes: ['ai:write:budgeted', 'apps:storage:read', 'apps:storage:write'] },
+    });
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(200);
+    expect(res._body.token).toBe('jwt.dev.signed');
+    expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
+    const arg = mockTokenService.sign.mock.calls[0][0] as any;
+    // spend scope granted + user:read:self force-grant; App Storage stripped.
+    expect(arg.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+    expect(arg.scopes).not.toContain('apps:storage:read');
+    expect(arg.scopes).not.toContain('apps:storage:write');
+    // self-bound, dev:true, forced-SFW, synthetic non-resolving ids.
+    expect(arg.userId).toBe(MOD.user.id);
+    expect(arg.dev).toBe(true);
+    expect(arg.domain).toBeNull();
+    expect(arg.appId).toBe('ephemeral-my-app');
+    expect(arg.appBlockId).toBe('ephemeral-my-app');
+    expect(arg.blockInstanceId).toBe('page_ephemeral-my-app');
+    expect(typeof arg.buzzBudget).toBe('number'); // budget set (spend granted)
+    // The pending lookup was ownership-scoped.
+    expect(mockDbWrite.appBlockPublishRequest.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { slug: 'my-app', status: 'pending', submittedByUserId: MOD.user.id },
+      })
+    );
+    // Ownership resolved on the slug (not the raw appBlockId).
+    expect(mockBlockRegistry.resolveDevPageBlockForAuthor).toHaveBeenCalledWith(
+      'my-app',
+      MOD.user.id,
+      { db: 'write' }
+    );
+  });
+
+  it('OWN brand-new (no pending) → mints from SELF-DECLARED body devScopes', async () => {
+    mockDbWrite.appBlockPublishRequest.findFirst.mockResolvedValue(null);
+    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted', 'social:tip:self'] }));
+    expect(res._status).toBe(200);
+    const arg = mockTokenService.sign.mock.calls[0][0] as any;
+    // social:tip:self is out-of-allowlist + forbidden → stripped; spend kept.
+    expect(arg.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+  });
+
+  it('OWN brand-new with NO scopes → a valid READ-ONLY token (no spend), still 200', async () => {
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(200);
+    const arg = mockTokenService.sign.mock.calls[0][0] as any;
+    expect(arg.scopes).toEqual(['user:read:self']);
+    expect(arg.buzzBudget).toBeUndefined();
+  });
+
+  it('foreign / already-claimed / absent app (resolver → null) → the SAME bare 404, NO token', async () => {
+    mockBlockRegistry.resolveDevPageBlockForAuthor.mockResolvedValue(null);
+    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted'] }));
+    expect(res._status).toBe(404);
+    expect(res._body).toEqual({ error: 'Page app not found' });
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('dev-tunnel kill-switch OFF → 404, NO token (defense-in-depth over the SSR gate)', async () => {
+    mockAppBlocksFlag.isAppBlocksDevTunnelEnabled.mockResolvedValue(false);
+    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted'] }));
+    expect(res._status).toBe(404);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('author capability OFF → 404, NO token', async () => {
+    mockAppBlocksFlag.isAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted'] }));
+    expect(res._status).toBe(404);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('resolved to a NON-ephemeral status (e.g. approved mid-session) → 404, fail-closed', async () => {
+    mockBlockRegistry.resolveDevPageBlockForAuthor.mockResolvedValue({
+      ...EPHEMERAL_RESOLUTION,
+      status: 'approved',
+      appBlockId: 'apb_real',
+      appId: 'appblk-my-app',
+    });
+    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted'] }));
+    expect(res._status).toBe(404);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('a soft-deleted account never mints (M1 parity)', async () => {
+    mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: new Date(), bannedAt: null });
+    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted'] }));
+    expect(res._status).toBe(404);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -48,6 +48,9 @@ const {
   const blockRegistry = {
     resolveBlockInstance: vi.fn<(...args: any[]) => Promise<any>>(),
     resolvePageBlock: vi.fn<(...args: any[]) => Promise<any>>(),
+    // Phase 2 dev-tunnel author-own mint resolver — default null (not owned), so
+    // the dev branch cleanly `continue`s to the bare 404 in this suite.
+    resolveDevPageBlockForAuthor: vi.fn<(...args: any[]) => Promise<any>>(async () => null),
   };
   // Flag mock that both the master + pages flag default ON for a mod.
   const flags = {
@@ -97,6 +100,14 @@ vi.mock('~/server/utils/server-domain', () => ({
   getRequestDomainColor: () => undefined,
 }));
 vi.mock('~/server/services/feature-flags.service', () => mockFlags);
+// Phase 2 dev-tunnel flag helpers (dynamically imported by the mint's dev branch).
+// Default OFF in this suite so the dev branch `continue`s → the bare 404 path the
+// W10 page-mint tests assert. The dev-mint behaviour has its own suite
+// (dev-tunnel-mint.test.ts).
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksAuthorEnabled: vi.fn(async () => false),
+  isAppBlocksDevTunnelEnabled: vi.fn(async () => false),
+}));
 
 function makeReq(opts: {
   method?: string;
@@ -351,12 +362,12 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
     expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
 
-  it('treats a synthetic ephemeral-<slug> page instance id as non-approved → 404, no token', async () => {
-    // The dev-tunnel ephemeral resolution mints synthetic `ephemeral-<slug>`
-    // ids (page instance `page_ephemeral-<slug>`). Those never name a real
-    // approved AppBlock.id, so the mint's resolvePageBlock(appBlockId) lookup
-    // yields null → 404. This locks that a pre-submit ephemeral app can never
-    // mint a scoped block token (Buzz / App Storage stay 403/404 until approval).
+  it('treats a synthetic ephemeral-<slug> page instance id as non-approved → 404 when the dev-tunnel gate does not apply', async () => {
+    // A synthetic `ephemeral-<slug>` id never names a real approved AppBlock.id,
+    // so `resolvePageBlock` yields null. Phase 2 then tries the author-own dev
+    // mint, but here the dev-tunnel flags are OFF (this suite) so that branch
+    // `continue`s → the SAME bare 404. (The author-own dev mint that DOES issue a
+    // scoped token for the OWNER is covered by dev-tunnel-mint.test.ts.)
     mockBlockRegistry.resolvePageBlock.mockResolvedValue(null);
     const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
     const res = makeRes();


### PR DESCRIPTION
## What

Phase 2 of the pre-submit App Blocks dev tunnel: an author can now mint a **scoped** block token for their **own unapproved** app inside the dev tunnel, so real Buzz-spend generation works pre-submit. Phase 1 (#2983/#2984) rendered local code but scoped features 403'd because the block-token mint required `status:'approved'`.

Security-sensitive (real Buzz spend on unreviewed apps + a DB migration) — built conservatively by **reusing the already-audited dev-token clamp+sign belt** rather than re-implementing it.

## Architecture (approach C)

- **NEW `src/server/services/blocks/dev-scoped-mint.service.ts`** — factors the audited clamp + budget + sign belt out of `/api/v1/blocks/dev-token` **verbatim** (`clampDevScopes`, `resolveDevBuzzBudget`, `signDevScopedPageToken` + `DEV_TOKEN_SCOPE_ALLOWLIST` / `TUNNEL_HOST_MINT_SCOPE_ALLOWLIST`). `dev-token.ts` now calls it — behaviour **unchanged** (76-test parity suite green).
- **`/api/v1/block-tokens`** gains a cookie-authed **author-own dev branch**: when `resolvePageBlock` misses a pre-approval (ephemeral) app the caller **owns** (`resolveDevPageBlockForAuthor` ownership + anti-shadow gate → same bare 404 for foreign/claimed/absent, no oracle), it mints a scoped, forced-SFW, self-bound, `dev:true` (4h), budget-capped page token.
  - **Scope source**: the owner's pending submission's **server-read `manifest.scopes`**, else self-declared body `devScopes` (brand-new). Both pass the identical clamp.
  - **App Storage refused (Decision 1)**: the tunnel allowlist **strips `apps:storage:*`** so a minted tunnel token can never carry it (defense-in-depth over the downstream `resolveStorageContext` 404).
  - **Spend containment**: no bearer here, so `keyCanSpend:true`; spend stays bounded by the **runtime** `assertViewerIsAppDeveloper(sub)` re-check on the self-bound author + the per-call (`DEV_BUZZ_BUDGET_CAP`) / per-session / per-day Buzz caps. Synthetic non-resolving `ephemeral-<slug>` ids → `recordSpendAttribution` misses (no forged attribution).

## Decision 2 — durable per-spend audit (schema + migration, MANUAL-APPLY)

- `BlockScopeInvocation.appBlockId` → **nullable** + new `synthetic_app_id` column, so a pre-approval spend (synthetic appBlockId) **persists a durable audit row** instead of FK-failing + being swallowed (the "only a log line" gap). `recordScopeInvocation` retries the synthetic path on P2003 for dev tokens; both the spend + middleware call sites pass `dev: claims.dev`.
- **Migration `20260707120000_block_scope_invocation_nullable_appblock` is WRITTEN, not applied.** Per civitai rule #8 a human applies it to **CNPG nvme0** (main civitai DB does not auto-apply). SQL is additive + backward-compatible.

## Tests

Shared-service unit (clamp / storage-strip / synthetic / SFW / budget / force-grant / oauth-ceiling-skip); host-mint dev branch (own-pending→manifest scopes, own-brand-new→body scopes, storage stripped, foreign/approved-elsewhere→404, kill-switch/author-off→404, non-ephemeral fail-closed, soft-delete gate); synthetic audit-row write; dev-token parity. Full `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)