### PR TITLE
feat(ssr): flag-gated SSR-prefetch of app-shell tRPC queries

### DIFF
--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -72,6 +72,22 @@ const featureFlags = createFeatureFlags({
   // is the Flipt-DOWN fallback (mirrors `faro`); Flipt is authoritative when the flag
   // exists — ramp by bumping its % rollout, never all-at-once. See `src/utils/trpc.ts`.
   trpcBatching: { availability: ['mod'], fliptKey: 'trpc-batching' },
+  // Cohort-ramp gate for SSR-prefetch of the universal app-shell tRPC queries
+  // (see `createServerSideProps` / `prefetchAppShellQueries` in
+  // `src/server/utils/server-side-helpers.ts`). When ON, pages that use
+  // `createServerSideProps({ useSSG: true })` also prefetch the session's
+  // input-less shell queries (`user.checkNotifications`,
+  // `user.getBookmarkCollections`, and — when `buzz` is on — `buzz.getUserMultipliers`)
+  // server-side, so they hydrate from the page HTML instead of each firing a
+  // client→CF→origin round-trip on mount (client `staleTime: Infinity` makes the
+  // hydrated value stick, so the round-trip is truly saved, not just deferred).
+  // Default OFF (mods only) so the added per-SSR backend calls are dark until
+  // ramped via Flipt (`ssr-prefetch-shell`); availability ['mod'] is the
+  // Flipt-DOWN fallback (mirrors `trpc-batching`). This is a per-request server
+  // behavior gate — `features` is already resolved in that path — and the whole
+  // behavior is best-effort (a failing shell prefetch degrades to client fetch,
+  // never breaks SSR), so flipping the flag off is an instant, safe rollback.
+  ssrPrefetchShell: { availability: ['mod'], fliptKey: 'ssr-prefetch-shell' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },

--- a/src/server/utils/__tests__/ssr-prefetch-app-shell.test.ts
+++ b/src/server/utils/__tests__/ssr-prefetch-app-shell.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * SSR-prefetch of the universal app-shell tRPC queries (see
+ * `prefetchAppShellQueries` + the flag-gated call in `createServerSideProps`,
+ * `src/server/utils/server-side-helpers.ts`).
+ *
+ * The lever: each prefetched shell query rides down in the page's dehydrated
+ * `trpcState` and hydrates on the client (which runs `staleTime: Infinity`, so
+ * the hydrated value sticks and the ~188ms client→origin round-trip is saved)
+ * instead of firing on mount. This pins the safety contract:
+ *   - the SAFE session queries are prefetched on full SSR when the flag is on,
+ *   - nothing is prefetched on a client-nav `/_next/data` fetch (no `ssg`),
+ *   - the flag OFF prefetches nothing (but SSG/`trpcState` is unaffected),
+ *   - anon sessions get no user-scoped prefetch,
+ *   - `buzz.getUserMultipliers` is gated on the `buzz` flag,
+ *   - a failing shell query degrades to client-fetch — it never 500s SSR.
+ *
+ * server-side-helpers.ts pulls the whole app router + clickhouse + auth graph at
+ * module load; stub those so the module imports in isolation and the tRPC SSG
+ * helper is a spy we can assert `.prefetch()` calls against.
+ */
+
+const h = vi.hoisted(() => {
+  const checkNotifications = vi.fn(async () => undefined);
+  const getBookmarkCollections = vi.fn(async () => undefined);
+  const getUserMultipliers = vi.fn(async () => undefined);
+  const dehydrate = vi.fn(() => ({ mock: 'trpcState' }));
+  // Shape mirrors the real tRPC SSG proxy for exactly the procedures we prefetch.
+  const fakeSsg = {
+    user: {
+      checkNotifications: { prefetch: checkNotifications },
+      getBookmarkCollections: { prefetch: getBookmarkCollections },
+    },
+    buzz: {
+      getUserMultipliers: { prefetch: getUserMultipliers },
+    },
+    dehydrate,
+  };
+  return {
+    checkNotifications,
+    getBookmarkCollections,
+    getUserMultipliers,
+    dehydrate,
+    fakeSsg,
+    createServerSideHelpers: vi.fn(() => fakeSsg),
+    getServerAuthSession: vi.fn(),
+    getFeatureFlagsAsync: vi.fn(),
+  };
+});
+
+vi.mock('@trpc/react-query/server', () => ({ createServerSideHelpers: h.createServerSideHelpers }));
+vi.mock('~/server/routers', () => ({ appRouter: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ Tracker: class {} }));
+vi.mock('~/server/services/feature-flags.service', () => ({
+  getFeatureFlagsAsync: h.getFeatureFlagsAsync,
+}));
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: h.getServerAuthSession,
+}));
+vi.mock('~/server/utils/server-domain', () => ({ getRequestDomainColor: vi.fn(() => 'blue') }));
+
+import { createServerSideProps, prefetchAppShellQueries } from '../server-side-helpers';
+
+type AnyContext = Parameters<ReturnType<typeof createServerSideProps>>[0];
+
+const authedSession = { user: { id: 1 } } as any;
+
+function makeContext(url: string): AnyContext {
+  return {
+    req: { url, headers: { host: 'civitai.com' } },
+    res: { setHeader: vi.fn() },
+    resolvedUrl: url,
+    query: {},
+  } as any;
+}
+
+function features(overrides: Record<string, boolean> = {}) {
+  return { ssrPrefetchShell: true, buzz: true, ...overrides } as any;
+}
+
+const okResolver = async () => ({ props: {} } as any);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  h.getServerAuthSession.mockResolvedValue(authedSession);
+  h.getFeatureFlagsAsync.mockResolvedValue(features());
+});
+
+describe('createServerSideProps — SSR app-shell prefetch', () => {
+  it('prefetches the SAFE session shell queries on full SSR when the flag is on', async () => {
+    const gssp = createServerSideProps({ useSSG: true, resolver: okResolver });
+    const res: any = await gssp(makeContext('/models'));
+
+    expect(h.checkNotifications).toHaveBeenCalledTimes(1);
+    expect(h.getBookmarkCollections).toHaveBeenCalledTimes(1);
+    expect(h.getUserMultipliers).toHaveBeenCalledTimes(1);
+    // input-less: prefetch called with no argument so the dehydrated key matches
+    // the client `useQuery(undefined)` exactly.
+    expect(h.checkNotifications).toHaveBeenCalledWith();
+    // hydrated cache rides down in trpcState.
+    expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
+  });
+
+  it('does NOT prefetch (or build an SSG helper) on a client-nav /_next/data fetch', async () => {
+    const gssp = createServerSideProps({ useSSG: true, resolver: okResolver });
+    const res: any = await gssp(makeContext('/_next/data/build-id/models.json'));
+
+    expect(h.createServerSideHelpers).not.toHaveBeenCalled();
+    expect(h.checkNotifications).not.toHaveBeenCalled();
+    expect(h.getBookmarkCollections).not.toHaveBeenCalled();
+    expect(h.getUserMultipliers).not.toHaveBeenCalled();
+    expect(res.props.trpcState).toBeUndefined();
+  });
+
+  it('prefetches nothing when the flag is OFF, but still dehydrates SSG state', async () => {
+    h.getFeatureFlagsAsync.mockResolvedValue(features({ ssrPrefetchShell: false }));
+    const gssp = createServerSideProps({ useSSG: true, resolver: okResolver });
+    const res: any = await gssp(makeContext('/models'));
+
+    expect(h.checkNotifications).not.toHaveBeenCalled();
+    expect(h.getBookmarkCollections).not.toHaveBeenCalled();
+    expect(h.getUserMultipliers).not.toHaveBeenCalled();
+    // useSSG still builds the helper — the flag gates only the shell prefetch.
+    expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
+  });
+
+  it('does not prefetch user-scoped queries for an anonymous session', async () => {
+    h.getServerAuthSession.mockResolvedValue(null);
+    const gssp = createServerSideProps({ useSSG: true, resolver: okResolver });
+    await gssp(makeContext('/models'));
+
+    expect(h.checkNotifications).not.toHaveBeenCalled();
+    expect(h.getBookmarkCollections).not.toHaveBeenCalled();
+    expect(h.getUserMultipliers).not.toHaveBeenCalled();
+  });
+
+  it('gates buzz.getUserMultipliers on the buzz feature flag', async () => {
+    h.getFeatureFlagsAsync.mockResolvedValue(features({ buzz: false }));
+    const gssp = createServerSideProps({ useSSG: true, resolver: okResolver });
+    await gssp(makeContext('/models'));
+
+    expect(h.checkNotifications).toHaveBeenCalledTimes(1);
+    expect(h.getBookmarkCollections).toHaveBeenCalledTimes(1);
+    expect(h.getUserMultipliers).not.toHaveBeenCalled();
+  });
+
+  it('degrades gracefully — a failing shell prefetch never rejects out of SSR', async () => {
+    h.checkNotifications.mockRejectedValueOnce(new Error('backend 500'));
+    const gssp = createServerSideProps({ useSSG: true, resolver: okResolver });
+
+    const res: any = await gssp(makeContext('/models'));
+
+    // SSR still resolves with a normal props payload (no throw / 500).
+    expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
+    // the other shell queries were still attempted (allSettled, not fail-fast).
+    expect(h.getBookmarkCollections).toHaveBeenCalledTimes(1);
+    expect(h.getUserMultipliers).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not prefetch when useSSG is not set (no SSG helper at all)', async () => {
+    const gssp = createServerSideProps({ resolver: okResolver });
+    const res: any = await gssp(makeContext('/models'));
+
+    expect(h.createServerSideHelpers).not.toHaveBeenCalled();
+    expect(h.checkNotifications).not.toHaveBeenCalled();
+    expect(res.props.trpcState).toBeUndefined();
+  });
+});
+
+describe('prefetchAppShellQueries — unit', () => {
+  it('prefetches all three SAFE queries for an authed session with buzz on', async () => {
+    await prefetchAppShellQueries(h.fakeSsg as any, authedSession, features());
+    expect(h.checkNotifications).toHaveBeenCalledTimes(1);
+    expect(h.getBookmarkCollections).toHaveBeenCalledTimes(1);
+    expect(h.getUserMultipliers).toHaveBeenCalledTimes(1);
+  });
+
+  it('prefetches nothing for an anonymous session', async () => {
+    await prefetchAppShellQueries(h.fakeSsg as any, null, features());
+    expect(h.checkNotifications).not.toHaveBeenCalled();
+    expect(h.getBookmarkCollections).not.toHaveBeenCalled();
+    expect(h.getUserMultipliers).not.toHaveBeenCalled();
+  });
+
+  it('resolves (never throws) when a prefetch rejects', async () => {
+    h.getBookmarkCollections.mockRejectedValueOnce(new Error('db down'));
+    await expect(
+      prefetchAppShellQueries(h.fakeSsg as any, authedSession, features())
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/server/utils/__tests__/ssr-prefetch-app-shell.test.ts
+++ b/src/server/utils/__tests__/ssr-prefetch-app-shell.test.ts
@@ -189,4 +189,29 @@ describe('prefetchAppShellQueries — unit', () => {
       prefetchAppShellQueries(h.fakeSsg as any, authedSession, features())
     ).resolves.toBeUndefined();
   });
+
+  it('resolves via the deadline (never hangs SSR) when a prefetch never settles', async () => {
+    vi.useFakeTimers();
+    try {
+      // A prefetch that hangs forever — without the deadline this would block SSR.
+      h.checkNotifications.mockImplementationOnce(() => new Promise<undefined>(() => {}));
+
+      const pending = prefetchAppShellQueries(h.fakeSsg as any, authedSession, features());
+      let settled = false;
+      const tracked = pending.then(() => {
+        settled = true;
+      });
+
+      // Not resolved before the deadline elapses…
+      await vi.advanceTimersByTimeAsync(299);
+      expect(settled).toBe(false);
+
+      // …but the 300ms deadline resolves it (never throws) even with a task still hung.
+      await vi.advanceTimersByTimeAsync(1);
+      await tracked;
+      expect(settled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -39,6 +39,58 @@ export const getServerProxySSGHelpers = async (
   return ssg;
 };
 
+type SSGHelpers = Awaited<ReturnType<typeof getServerProxySSGHelpers>>;
+
+/**
+ * SSR-prefetch the universal app-shell tRPC queries so they hydrate from the
+ * dehydrated `trpcState` in the page HTML instead of each firing a
+ * client→CF→origin round-trip on mount (~188ms network floor per query).
+ *
+ * WHY THE WIN LANDS (hydration mechanics): the shared QueryClient runs with
+ * `defaultOptions.queries.staleTime: Infinity` (`src/utils/trpc.ts`), and these
+ * queries carry no lower per-call `staleTime`, so once React Query hydrates the
+ * dehydrated entry it is never stale → NO background refetch on mount. The
+ * client `useQuery(undefined)` key (path + `superjson`-serialized input) matches
+ * the input-less `.prefetch()` here exactly, so hydration hits. (The
+ * `authedCacheBypassLink` mutates the WIRE input, not the react-query key, so
+ * keys still match.)
+ *
+ * SCOPE — only queries NOT already SSR-seeded via `initialData` in
+ * `_app.getInitialProps` are prefetched here. `user.getFeatureFlags`,
+ * `user.getSettings`, `user.getFollowingUsers`, `system.getLiveNow`, and
+ * `chat.getUserSettings` are already seeded there; re-prefetching them would be
+ * a duplicate backend call for no gain.
+ *
+ * All targets are input-less protected reads (session-gated on the client), so
+ * they are prefetched ONLY for authenticated sessions. `buzz.getUserMultipliers`
+ * additionally requires the `buzz` feature flag (its `buzzProcedure` throws
+ * without it), so it is gated on `features.buzz`.
+ *
+ * ROBUSTNESS — best-effort via `Promise.allSettled`: a failing shell query
+ * degrades to the normal client fetch, it MUST NEVER reject out of SSR and 500
+ * the page.
+ */
+export async function prefetchAppShellQueries(
+  ssg: SSGHelpers,
+  session: Session | null,
+  features: FeatureAccess
+): Promise<void> {
+  const tasks: Promise<unknown>[] = [];
+
+  if (session?.user) {
+    // Input-less, protected, static-at-load; `staleTime: Infinity` on the client
+    // so the hydrated value sticks (round-trip truly saved).
+    tasks.push(ssg.user.checkNotifications.prefetch());
+    tasks.push(ssg.user.getBookmarkCollections.prefetch());
+    // buzzProcedure = protected + `isFlagProtected('buzz')`: throws unless the
+    // `buzz` flag is on, so only prefetch when it is (allSettled would swallow
+    // the throw anyway, but skipping avoids a guaranteed-failed backend call).
+    if (features.buzz) tasks.push(ssg.buzz.getUserMultipliers.prefetch());
+  }
+
+  await Promise.allSettled(tasks);
+}
+
 export function createServerSideProps<P>({
   resolver,
   useSSG,
@@ -74,6 +126,16 @@ export function createServerSideProps<P>({
       useSSG && (prefetch === 'always' || !isClient)
         ? await getServerProxySSGHelpers(context, session, features)
         : undefined;
+
+    // Flag-gated SSR-prefetch of the universal app-shell queries into the shared
+    // `ssg` cache so they ride down in `trpcState` (dehydrated below) and hydrate
+    // instead of round-tripping on mount. Runs only when the `ssg` helper exists
+    // (i.e. full SSR, or `prefetch: 'always'` — never a bare client-nav
+    // `/_next/data` fetch) and the `ssrPrefetchShell` flag is on for this user.
+    // Best-effort: never throws (see `prefetchAppShellQueries`).
+    if (ssg && features.ssrPrefetchShell) {
+      await prefetchAppShellQueries(ssg, session, features);
+    }
 
     const result = ((await resolver?.({
       ctx: context,

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -50,10 +50,10 @@ type SSGHelpers = Awaited<ReturnType<typeof getServerProxySSGHelpers>>;
  * `defaultOptions.queries.staleTime: Infinity` (`src/utils/trpc.ts`), and these
  * queries carry no lower per-call `staleTime`, so once React Query hydrates the
  * dehydrated entry it is never stale → NO background refetch on mount. The
- * client `useQuery(undefined)` key (path + `superjson`-serialized input) matches
- * the input-less `.prefetch()` here exactly, so hydration hits. (The
- * `authedCacheBypassLink` mutates the WIRE input, not the react-query key, so
- * keys still match.)
+ * client `useQuery(undefined)` key (path + the RAW input in the key array,
+ * `[path, { input, type }]` — not a superjson string) matches the input-less
+ * `.prefetch()` here exactly, so hydration hits. (The `authedCacheBypassLink`
+ * mutates the WIRE input, not the react-query key, so keys still match.)
  *
  * SCOPE — only queries NOT already SSR-seeded via `initialData` in
  * `_app.getInitialProps` are prefetched here. `user.getFeatureFlags`,
@@ -69,7 +69,18 @@ type SSGHelpers = Awaited<ReturnType<typeof getServerProxySSGHelpers>>;
  * ROBUSTNESS — best-effort via `Promise.allSettled`: a failing shell query
  * degrades to the normal client fetch, it MUST NEVER reject out of SSR and 500
  * the page.
+ *
+ * DEADLINE — the whole batch is `await`ed on the SSR critical path, so it is
+ * bounded by `APP_SHELL_PREFETCH_TIMEOUT_MS`: on timeout we resolve (never throw)
+ * and the un-prefetched queries fall back to their normal client fetch — same
+ * graceful-degradation contract as a failed prefetch. Without this a slow
+ * postgres/redis would add directly to TTFB on every authed full-SSR render.
  */
+// Tight cap: these are input-less in-process reads that return in single-digit
+// ms on the happy path, so 300ms costs nothing normally but stops a backend
+// slowdown from becoming a fleet-wide authed-SSR TTFB regression.
+const APP_SHELL_PREFETCH_TIMEOUT_MS = 300;
+
 export async function prefetchAppShellQueries(
   ssg: SSGHelpers,
   session: Session | null,
@@ -88,7 +99,21 @@ export async function prefetchAppShellQueries(
     if (features.buzz) tasks.push(ssg.buzz.getUserMultipliers.prefetch());
   }
 
-  await Promise.allSettled(tasks);
+  if (!tasks.length) return;
+
+  // `allSettled` never rejects and keeps handling each task even after the race
+  // resolves on timeout, so a late rejection can't surface as an unhandled
+  // rejection. We race it against a resolving deadline (not a rejecting one) so
+  // a slow backend can't drag SSR past the cap.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, APP_SHELL_PREFETCH_TIMEOUT_MS);
+  });
+  try {
+    await Promise.race([Promise.allSettled(tasks), deadline]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 export function createServerSideProps<P>({


### PR DESCRIPTION
## What & why

`createTRPCNext({ ssr: false })` means tRPC does **no** automatic SSR-prefetch — every query fires client-side on mount, and each client→CF→origin tRPC round-trip has a ~188ms network floor (Faro RUM: ~83% of perceived API latency is network/CF, not handler time). The universal **app-shell** queries (notification bell, header bookmark menu, header buzz multiplier) fire on essentially every authenticated page.

This PR adds a **flag-gated** SSR-prefetch of those shell queries into the shared `createServerSideProps` path. When on, the queries are prefetched server-side, ride down in the page's dehydrated `trpcState`, and **hydrate** on the client instead of round-tripping — removing one ~188ms round-trip per query on first paint.

This is a focused first step; see **Follow-up scope** below.

## Why the win actually lands (hydration mechanics)

React Query only *uses* dehydrated data without an immediate background refetch when the query is not stale on mount **and** the query key matches exactly:

- **staleTime** — the shared `QueryClient` runs `defaultOptions.queries.staleTime: Infinity` (`src/utils/trpc.ts`), and none of the prefetched shell queries set a lower per-call `staleTime`. So on hydration the entry is never stale → **no on-mount refetch** → the round-trip is truly saved, not merely deferred. (If global `staleTime` were `0`, hydration would give instant first paint but still fire the round-trip = zero latency win. It is `Infinity`, so the win lands.)
- **key match** — all three targets are called client-side as `useQuery(undefined)` (input-less), and we prefetch them input-less via `ssg.<proc>.prefetch()`, so the tRPC key (`path` + `superjson`-serialized input) matches exactly. The `authedCacheBypassLink` mutates the **wire** input, not the react-query key, so keys still match.

`user.checkNotifications` additionally carries `gcTime: Infinity, staleTime: Infinity` at its call-site, so the hydrated unread state persists until an explicit invalidation (the count is already treated as cache-until-mutated, with optimistic updates on read). Minor accepted trade-off: a notification arriving in the sub-second SSR→hydrate window shows one paint late — already true of today's fetch-on-mount.

## SAFE-to-prefetch (what this PR prefetches)

All are input-less, `protectedProcedure`-family, pure reads, static-at-load, session-gated on the client. Prefetched **only when a session is present**:

| Query | Router | Gate | Reason SAFE |
|---|---|---|---|
| `user.checkNotifications` | protectedProcedure, input-less | session | Unread-notification state; `staleTime: Infinity` client-side; tolerates sub-second staleness at first paint. |
| `user.getBookmarkCollections` | protectedProcedure, input-less | session | User's system/bookmark collections; only changes on the user's own mutation (which patches the cache). |
| `buzz.getUserMultipliers` | buzzProcedure, input-less | session **and** `buzz` flag | Header buzz multipliers; static-at-load. `buzzProcedure` throws unless the `buzz` flag is on, so gated on `features.buzz` to avoid a guaranteed-failed call. |

## NOT prefetched (and why)

- **Already SSR-seeded via `initialData` in `_app.getInitialProps`** — `user.getFeatureFlags`, `user.getSettings`, `user.getFollowingUsers`, `system.getLiveNow`, `chat.getUserSettings`. These are already primed on every SSR render through the provider-tree `initialData` path; re-prefetching them here would be a **duplicate backend call for no gain**. Left alone deliberately.
- **`buzz.getDailyBuzzCompensation`** — page-only (buzz dashboard), and its input requires a client-selected `date` (no stable server-resolvable input). Not shell-wide.
- **`user.userRewardDetails`** — input-less/protected but mounts only in the buzz dashboard / daily-boost / generation UI, **not** the universal shell tree. Prefetching it on every SSR page would add a call most pages never consume.
- **`blocks.*`** — confined to `/apps/**` and the model-page slot; not shell-wide.

## The flag + how to ramp

- New feature flag **`ssrPrefetchShell`** (Flipt key `ssr-prefetch-shell`), `availability: ['mod']` — **default OFF** (mods only) with Flipt authoritative, mirroring `trpcBatching`.
- Gate is **server-side**: `features` is already resolved in `createServerSideProps`, so the whole behavior keys off `features.ssrPrefetchShell` — a clean per-request, per-user gate. Ramp by bumping the Flipt `ssr-prefetch-shell` % rollout; **instant rollback** by flipping it off (no deploy).

## Robustness

- Prefetches run under `Promise.allSettled` — a failing shell query **degrades to the normal client fetch and never rejects out of SSR** (never 500s the page).
- Only runs when the `ssg` helper exists (full SSR or `prefetch: 'always'`), never on a bare client-nav `/_next/data` fetch — reuses the existing `useSSG && (prefetch === 'always' || !isClient)` guard.

## Coverage caveat (honest scope)

`createServerSideProps` runs only on pages that opt into it via `getServerSideProps`. Pages that render the shell but use only `_app.getInitialProps`/`getStaticProps` won't hit this path — their shell queries still fire client-side. A fuller-coverage follow-up is to extend the existing `initialData` seeding in `_app.getInitialProps` (which already covers the 5 queries above) to include these three. Kept out of this PR to keep it focused and low-blast-radius.

## Trade-offs

- **+N backend calls per full-SSR page** (≤3, session-gated) — bounded and flag-ramped so it can be measured A/B.
- **+dehydrated-HTML payload** for the prefetched results (small, input-less reads).
- vs. **one ~188ms client round-trip saved per prefetched query** on first paint.

## Measurement plan

After a soak at a small Flipt %, compare `/api/trpc` + the three shell-query route TTFB p95 on Grafana `/d/civitai-dp-prod-api-net-phases` between the flagged cohort and control; watch api-primary CPU / request-rate for the added SSR calls. Roll forward only if net perceived-latency improves without an api-pool regression.

## Follow-up scope (NOT in this PR)

- Generator-init prefetchable queries (the safe subset — **not** `orchestrator.whatIfFromGraph`).
- The images feed prefetch.
- Fuller shell coverage via `_app.getInitialProps` `initialData` (see coverage caveat).

## Tests

`src/server/utils/__tests__/ssr-prefetch-app-shell.test.ts` (10 cases): SAFE-list prefetched on SSR with the flag on; skipped on client-nav `/_next/data`; flag OFF prefetches nothing (but SSG/`trpcState` unaffected); anon gets no user-scoped prefetch; `buzz.getUserMultipliers` gated on the `buzz` flag; a failing prefetch degrades gracefully (no throw); plus direct unit tests of `prefetchAppShellQueries`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
