### PR TITLE
fix(app-blocks): dev-tunnel ephemeral resolver surfaces the pending app's declared scopes

### DIFF
--- a/src/server/services/__tests__/block-registry.resolve-dev.test.ts
+++ b/src/server/services/__tests__/block-registry.resolve-dev.test.ts
@@ -90,7 +90,7 @@ describe('BlockRegistry.resolveDevPageBlockForAuthor', () => {
     expect(res).not.toBeNull();
     expect(res?.status).toBe('ephemeral');
     expect(res?.trustTier).toBe('unverified');
-    expect(res?.scopes).toEqual([]); // scoped mint stays 403 until approval
+    expect(res?.scopes).toEqual([]); // brand-new (no pending row) declares scopes via the mint body
     expect(res?.contentRating).toBeNull(); // SFW default
     expect(res?.sandbox).toBe('allow-scripts allow-forms');
     expect(res?.blockId).toBe('brand-new');
@@ -128,11 +128,52 @@ describe('BlockRegistry.resolveDevPageBlockForAuthor', () => {
   it('(d) ALLOWS an ephemeral resolution when the caller OWNS the pending publish request', async () => {
     mockDbRead.appBlock.findFirst.mockResolvedValue(null);
     mockDbRead.appBlock.findUnique.mockResolvedValue(null);
-    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({ submittedByUserId: 555 });
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({
+      submittedByUserId: 555,
+      manifest: { scopes: ['ai:write:budgeted'] },
+    });
     const res = await BlockRegistry.resolveDevPageBlockForAuthor('my-pending', 555);
     expect(res).not.toBeNull();
     expect(res?.status).toBe('ephemeral');
     expect(res?.blockId).toBe('my-pending');
+    // The pending select must pull the manifest (the scope source).
+    expect(mockDbRead.appBlockPublishRequest.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ select: { submittedByUserId: true, manifest: true } })
+    );
+  });
+
+  it('(d2) THE FIX: an owned-pending money app surfaces its budgeted scope (not the stale []) so the dev-page Generate gate is not falsely empty', async () => {
+    // Regression guard for the "Grant access to generate" hang: pre-Phase-2 this
+    // resolver hardcoded scopes:[], so the dev-page host told the block it had NO
+    // scopes (declaredScopes → grantedScopes empty) and Generate hung — while the
+    // block-token mint's JWT already carried ai:write:budgeted. The resolver now
+    // mirrors the mint's clamp exactly, so the declared set matches the JWT.
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({
+      submittedByUserId: 555,
+      // Includes page-forbidden + non-allowlisted scopes — the clamp must strip them.
+      manifest: {
+        scopes: ['ai:write:budgeted', 'buzz:read:self', 'social:tip:self', 'not:a:scope'],
+      },
+    });
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('money-pending', 555);
+    // Clamp = TUNNEL allowlist − PAGE_FORBIDDEN, + force-granted user:read:self, sorted.
+    // buzz:read:self / social:tip:self are page-forbidden; not:a:scope is unknown.
+    expect(res?.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+  });
+
+  it('(d3) an owned-pending app that declares NO money scope stays read-only (no over-grant)', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({
+      submittedByUserId: 555,
+      manifest: { scopes: ['models:read:self'] },
+    });
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('read-pending', 555);
+    // No ai:write:budgeted (not declared) — only the declared read scope + self-read.
+    expect(res?.scopes).toEqual(['models:read:self', 'user:read:self']);
+    expect(res?.scopes).not.toContain('ai:write:budgeted');
   });
 
   it.each([

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -12,6 +12,10 @@ import {
 } from '~/server/services/blocks/checkpoint.service';
 import { validateBlockSettings } from '~/server/services/blocks/settings-validator.service';
 import {
+  clampDevScopes,
+  TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+} from '~/server/services/blocks/dev-scoped-mint.service';
+import {
   newBlockInstanceId,
   newBlockUserSubscriptionId,
 } from '~/server/utils/app-block-ids';
@@ -1989,9 +1993,34 @@ export class BlockRegistry {
     // pending row per slug (partial unique index). The caller's own pending is OK.
     const pending = await db.appBlockPublishRequest.findFirst({
       where: { slug: blockId, status: 'pending' },
-      select: { submittedByUserId: true },
+      select: { submittedByUserId: true, manifest: true },
     });
     if (pending && pending.submittedByUserId !== userId) return null;
+    // SCOPE SOURCE — the declared scopes the dev-page host surfaces to the block as
+    // `declaredScopes` (→ the block's `granted` UI state). For the SUBMITTED-PENDING
+    // case (the caller owns `pending`) mirror the block-token Phase-2 mint EXACTLY:
+    // clamp the pending submission's un-reviewed `manifest.scopes` through the SAME
+    // audited belt (`clampDevScopes` + `TUNNEL_HOST_MINT_SCOPE_ALLOWLIST`, no OAuth
+    // ceiling, keyCanSpend=true). This ALIGNS the host's declared set with the scopes
+    // the mint actually stamps on the JWT — without it (the pre-Phase-2 hardcoded
+    // `[]`) the block's Generate gate reads an empty granted set and hangs on
+    // "Grant access to generate" while the JWT it holds already carries the budgeted
+    // spend scope. NO new authority: the mint re-clamps + the runtime author-flag and
+    // per-call/session/day Buzz caps remain the actual spend gates. The BRAND-NEW
+    // (no-`pending`) case stays `[]` — those apps self-declare via the mint body.
+    let ephemeralScopes: string[] = [];
+    if (pending) {
+      const pendingManifest = (pending.manifest ?? {}) as { scopes?: unknown };
+      const declared = Array.isArray(pendingManifest.scopes)
+        ? pendingManifest.scopes.filter((s): s is string => typeof s === 'string')
+        : [];
+      ephemeralScopes = clampDevScopes({
+        scopeSource: declared,
+        oauthAllowed: null,
+        keyCanSpend: true,
+        allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+      });
+    }
     // ALLOWED — truly-unclaimed slug, or the caller owns the pending request.
     return {
       // Synthetic, non-resolving ids (`ephemeral-<slug>`): the render path never
@@ -2008,9 +2037,10 @@ export class BlockRegistry {
       // Minimal safe sandbox for an unverified tier (client intersectSandbox
       // re-clamps to the allowlist ∪ MINIMAL_SANDBOX regardless).
       sandbox: 'allow-scripts allow-forms',
-      // EMPTY — scoped features (Buzz / App Storage) require an approved,
-      // mod-reviewed scope grant; the block-token mint stays 403 until approval.
-      scopes: [],
+      // The caller's-own-pending declared scopes, clamped to the tunnel belt (see
+      // above); `[]` for a truly-unclaimed brand-new slug. Aligned with the Phase-2
+      // block-token mint so the dev-page block's Generate gate is not falsely empty.
+      scopes: ephemeralScopes,
       // SFW default — no reviewed content rating exists pre-submit.
       contentRating: null,
     };


### PR DESCRIPTION
## Problem

App Dev Tunnel **Phase-2 pre-approval generation** hung on **"Grant access to generate"** and never spent Buzz. Reproduced live on prod against a pending app (`/apps/dev/<pending-slug>` → Generate): the button showed "Grant access to generate", **0 rows** landed in `block_scope_invocations`, and the SSR `appBlockId` (`ephemeral-<slug>`) + the mint's JWT were both correct.

## Root cause

`BlockRegistry.resolveEphemeralDevPageBlock` hardcoded **`scopes: []`** — a stale pre-Phase-2 assumption ("the block-token mint stays 403 until approval"). But Phase-2's mint (`block-tokens/index.ts`) now **grants** `ai:write:budgeted` for a caller's own pending app (it reads the pending `manifest.scopes`). The two scope sources diverged:

| Source | Value | Drives |
|---|---|---|
| SSR `resolveEphemeralDevPageBlock.scopes` | `[]` ← stale | the block's `granted` UI state (`declaredScopes` → `grantedScopes`) |
| Mint JWT (`clampDevScopes(pending.manifest.scopes)`) | `[ai:write:budgeted]` ✓ | actual spend authority |

So the dev-page host told the block it had **no** scopes → the block's Generate gate was falsely empty → "Grant access to generate". The block then fired `REQUEST_CONSENT`, but the ephemeral mint returns `missingScopes: []`, so the host **dropped** the request (`requestConsentGate.ts`) — a permanent dead-end. The JWT it was holding already carried the budgeted spend scope; the block just never called generate.

## Fix

For the **caller's-own-pending** case, resolve the pending publish request's `manifest.scopes` through the **same audited clamp the mint uses** (`clampDevScopes` + `TUNNEL_HOST_MINT_SCOPE_ALLOWLIST`, `oauthAllowed: null`, `keyCanSpend: true`). This aligns the host's declared scope set with the JWT the mint issues.

- **No new authority.** `declaredScopes` only drives the block's UI `granted` state; the mint independently re-clamps, and the runtime author-flag re-check + per-call / per-session / per-day Buzz caps remain the real spend gates. This mirrors what the **owned-approved** path already does (it reads `manifest.scopes`).
- **Brand-new (no pending row) stays `[]`** — those apps self-declare via the mint body (the separate deferred follow-up).

## Tests

`block-registry.resolve-dev.test.ts` (20 pass):
- **(d2)** owned-pending money app → declared scopes `['ai:write:budgeted', 'user:read:self']` (page-forbidden `buzz:read:self`/`social:tip:self` + unknown scopes stripped; `user:read:self` force-granted).
- **(d3)** owned-pending app declaring no money scope → read-only, no `ai:write:budgeted` over-grant.
- **(d)** now asserts the pending select pulls `manifest`.
- **(a)** brand-new unclaimed slug still resolves `[]`.

Adjacent suites green: `dev-tunnel-page`, `block-tokens/{dev-tunnel-mint,page-mint}`, `slot-registry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)