### PR TITLE
feat(perf): SSR-prefetch the /images feed initial query (anon, dark, mod-gated)

### DIFF
--- a/src/pages/images/index.tsx
+++ b/src/pages/images/index.tsx
@@ -24,12 +24,15 @@ import {
 // (the same cost the homepage already pays). Flux/CDN cache-control is unchanged.
 export const getServerSideProps = createServerSideProps({
   useSSG: true,
-  resolver: async ({ ssg, session, features }) => {
+  resolver: async ({ ssg, session, features, ctx, ssgAbortController }) => {
     // `ssg` exists only on full SSR (never a client-nav `/_next/data` fetch), and
     // the prefetch is gated on the dark, independently-ramped flag. Flag OFF (the
     // default) → zero added backend work; the page render / props are unaffected.
+    // `ctx.query` gates out filtered feeds (`?period=…` etc.) whose client key
+    // differs; `ssgAbortController` lets the prefetch release its heavy bulkhead
+    // slot on the deadline.
     if (ssg && features?.ssrPrefetchImagesFeed) {
-      await prefetchImagesFeedQueries(ssg, session ?? null);
+      await prefetchImagesFeedQueries(ssg, session ?? null, ctx.query, ssgAbortController);
     }
   },
 });

--- a/src/pages/images/index.tsx
+++ b/src/pages/images/index.tsx
@@ -6,6 +6,33 @@ import { useImageQueryParams } from '~/components/Image/image.utils';
 import ImagesInfinite from '~/components/Image/Infinite/ImagesInfinite';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { Meta } from '~/components/Meta/Meta';
+import {
+  createServerSideProps,
+  prefetchImagesFeedQueries,
+} from '~/server/utils/server-side-helpers';
+
+// SSR-prefetch the INITIAL anon `image.getInfinite` feed query so it hydrates
+// from the page HTML instead of firing a client→CF→origin round-trip on mount
+// (flag-gated, anon-only, best-effort — see `prefetchImagesFeedQueries`).
+//
+// NOTE ON RENDERING MODEL: `/images` previously had NO data method. It was NOT
+// statically CDN-cached, though — `MyApp.getInitialProps` (src/pages/_app.tsx)
+// disables Next.js Automatic Static Optimization app-wide, so this page already
+// rendered per-request on the SSR pod (like the homepage `/`, which likewise
+// uses `createServerSideProps`). Adding GSSP therefore strips NO edge caching;
+// it adds only the resolver's `getServerAuthSession` + `getFeatureFlagsAsync`
+// (the same cost the homepage already pays). Flux/CDN cache-control is unchanged.
+export const getServerSideProps = createServerSideProps({
+  useSSG: true,
+  resolver: async ({ ssg, session, features }) => {
+    // `ssg` exists only on full SSR (never a client-nav `/_next/data` fetch), and
+    // the prefetch is gated on the dark, independently-ramped flag. Flag OFF (the
+    // default) → zero added backend work; the page render / props are unaffected.
+    if (ssg && features?.ssrPrefetchImagesFeed) {
+      await prefetchImagesFeedQueries(ssg, session ?? null);
+    }
+  },
+});
 
 export default Page(
   function () {

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -101,6 +101,35 @@ const featureFlags = createFeatureFlags({
   // prefetch degrades to client fetch, never breaks the generator SSR), so
   // flipping the flag off is an instant, safe rollback.
   ssrPrefetchGenerator: { availability: ['mod'], fliptKey: 'ssr-prefetch-generator' },
+  // High-traffic-feed variant: when on, the `/images` page SSR-prefetches the
+  // INITIAL `image.getInfinite` feed query (the page's first, heaviest client
+  // fetch) so it hydrates from the page HTML instead of firing a
+  // client→CF→origin round-trip on mount (client `staleTime: Infinity` makes the
+  // hydrated value stick, so the round-trip is truly saved). SEPARATE flag so it
+  // ramps / rolls back independently of the shell/generator prefetches.
+  //
+  // 🔴 SCOPE — ANONYMOUS ONLY. The initial feed input is a large derived object
+  // (localStorage filters + a 3-provider browsingLevel chain + DB-resolved
+  // browsing-settings-addons). Only the ANON path is deterministically
+  // reproducible server-side (browsingLevel is forced to `publicBrowsingLevelsFlag`
+  // on every domain, filters are the FiltersProvider schema defaults), so the
+  // react-query key matches with 100% confidence and no client-code drift risk.
+  // Authed users get NO prefetch here (their localStorage filters + saved
+  // browsing level can diverge from any server guess → a WASTED heavy query),
+  // so they fall through to the unchanged client fetch. `image.getInfinite` is a
+  // `heavyProcedure` (bulkhead-slotted) — a mismatched prefetch is not just
+  // wasted work, it consumes a scarce slot, so the anon-only + exact-key scoping
+  // is load-bearing, not conservatism.
+  //
+  // Default OFF (mods only via the availability fallback) so the added per-SSR
+  // heavy backend call is dark until ramped via Flipt (`ssr-prefetch-images-feed`).
+  // NOTE: mods are always authed, so the dark (mod-only) phase never fires the
+  // anon-scoped prefetch — MEASUREMENT requires ramping Flipt to PUBLIC traffic
+  // (watch `/d/civitai-dp-prod-api-net-phases` + SSR-pool/Meili load). The whole
+  // behavior is best-effort (a failing / >300ms-slow prefetch degrades to the
+  // client fetch, never breaks or slows the `/images` SSR), so flipping the flag
+  // off is an instant, safe rollback.
+  ssrPrefetchImagesFeed: { availability: ['mod'], fliptKey: 'ssr-prefetch-images-feed' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },

--- a/src/server/utils/__tests__/ssr-prefetch-images-feed.test.ts
+++ b/src/server/utils/__tests__/ssr-prefetch-images-feed.test.ts
@@ -84,7 +84,11 @@ vi.mock('~/server/services/system-cache', () => ({
   getBrowsingSettingAddons: h.getBrowsingSettingAddons,
 }));
 
-import { createServerSideProps, prefetchImagesFeedQueries } from '../server-side-helpers';
+import {
+  createServerSideProps,
+  hasImagesFeedQueryParams,
+  prefetchImagesFeedQueries,
+} from '../server-side-helpers';
 
 type AnyContext = Parameters<ReturnType<typeof createServerSideProps>>[0];
 
@@ -128,21 +132,21 @@ function expectedAnonInput(addons: BrowsingSettingsAddon[]) {
   };
 }
 
-function makeContext(url: string): AnyContext {
+function makeContext(url: string, query: Record<string, unknown> = {}): AnyContext {
   return {
     req: { url, headers: { host: 'civitai.com' } },
     res: { setHeader: vi.fn() },
     resolvedUrl: url,
-    query: {},
+    query,
   } as any;
 }
 
-// Mirrors the `/images` GSSP wiring: flag-gated, anon-only, runs only when the
-// SSG helper exists (full SSR), never on client-nav.
+// Mirrors the `/images` GSSP wiring: flag-gated, anon-only, gates on feed query
+// params, runs only when the SSG helper exists (full SSR), never on client-nav.
 function imagesResolver() {
-  return async ({ session, features, ssg }: any) => {
+  return async ({ session, features, ssg, ctx, ssgAbortController }: any) => {
     if (ssg && features?.ssrPrefetchImagesFeed) {
-      await prefetchImagesFeedQueries(ssg, session ?? null);
+      await prefetchImagesFeedQueries(ssg, session ?? null, ctx.query, ssgAbortController);
     }
     return { props: {} } as any;
   };
@@ -217,17 +221,41 @@ describe('createServerSideProps — images feed SSR prefetch (integration)', () 
     expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
     expect(h.getInfinitePrefetch).toHaveBeenCalledTimes(1);
   });
+
+  it('does NOT prefetch a FILTERED feed (?period=Month) — client key differs, no burned heavy slot', async () => {
+    const gssp = createServerSideProps({ useSSG: true, resolver: imagesResolver() });
+    const res: any = await gssp(makeContext('/images?period=Month', { period: 'Month' }));
+
+    // A feed-affecting query param → the client builds a different key → skip.
+    expect(h.getInfinitePrefetch).not.toHaveBeenCalled();
+    expect(h.getBrowsingSettingAddons).not.toHaveBeenCalled();
+    // The page still renders / dehydrates normally.
+    expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
+  });
+
+  it('still prefetches the bare default feed when only non-feed params are present (utm_*)', async () => {
+    const gssp = createServerSideProps({ useSSG: true, resolver: imagesResolver() });
+    // utm_source is stripped by the client zod parse → the key is unchanged, so a
+    // referral-link default feed still hydrates.
+    const res: any = await gssp(
+      makeContext('/images?utm_source=twitter', { utm_source: 'twitter' })
+    );
+
+    expect(h.getInfinitePrefetch).toHaveBeenCalledTimes(1);
+    expect(h.getInfinitePrefetch).toHaveBeenCalledWith(expectedAnonInput(ADDONS));
+    expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
+  });
 });
 
 describe('prefetchImagesFeedQueries — unit', () => {
   it('prefetches the initial feed query for an anon session with the exact reproduced input', async () => {
-    await prefetchImagesFeedQueries(h.fakeSsg as any, null);
+    await prefetchImagesFeedQueries(h.fakeSsg as any, null, {});
     expect(h.getInfinitePrefetch).toHaveBeenCalledTimes(1);
     expect(h.getInfinitePrefetch).toHaveBeenCalledWith(expectedAnonInput(ADDONS));
   });
 
   it('resolves the addon-derived fields (non-empty excludedTagIds + disablePoi) at the anon PG level', async () => {
-    await prefetchImagesFeedQueries(h.fakeSsg as any, null);
+    await prefetchImagesFeedQueries(h.fakeSsg as any, null, {});
     const input = h.getInfinitePrefetch.mock.calls[0][0] as any;
     // Only the PG-applicable addon contributes; order is preserved for the hash.
     expect(input.excludedTagIds).toEqual([5161, 5162, 5188]);
@@ -238,20 +266,20 @@ describe('prefetchImagesFeedQueries — unit', () => {
   });
 
   it('prefetches nothing for an authed session (anon-only scope)', async () => {
-    await prefetchImagesFeedQueries(h.fakeSsg as any, authedSession);
+    await prefetchImagesFeedQueries(h.fakeSsg as any, authedSession, {});
     expect(h.getInfinitePrefetch).not.toHaveBeenCalled();
     expect(h.getBrowsingSettingAddons).not.toHaveBeenCalled();
   });
 
   it('skips the prefetch (never fires a wrong-key heavy query) when the addon fetch fails', async () => {
     h.getBrowsingSettingAddons.mockRejectedValueOnce(new Error('redis down'));
-    await expect(prefetchImagesFeedQueries(h.fakeSsg as any, null)).resolves.toBeUndefined();
+    await expect(prefetchImagesFeedQueries(h.fakeSsg as any, null, {})).resolves.toBeUndefined();
     expect(h.getInfinitePrefetch).not.toHaveBeenCalled();
   });
 
   it('resolves (never throws) when the feed prefetch rejects', async () => {
     h.getInfinitePrefetch.mockRejectedValueOnce(new Error('meili down'));
-    await expect(prefetchImagesFeedQueries(h.fakeSsg as any, null)).resolves.toBeUndefined();
+    await expect(prefetchImagesFeedQueries(h.fakeSsg as any, null, {})).resolves.toBeUndefined();
   });
 
   it('resolves via the deadline (never hangs SSR) when the feed prefetch never settles', async () => {
@@ -259,7 +287,7 @@ describe('prefetchImagesFeedQueries — unit', () => {
     try {
       h.getInfinitePrefetch.mockImplementationOnce(() => new Promise<undefined>(() => {}));
 
-      const pending = prefetchImagesFeedQueries(h.fakeSsg as any, null);
+      const pending = prefetchImagesFeedQueries(h.fakeSsg as any, null, {});
       let settled = false;
       const tracked = pending.then(() => {
         settled = true;
@@ -278,6 +306,76 @@ describe('prefetchImagesFeedQueries — unit', () => {
       expect(settled).toBe(true);
     } finally {
       vi.useRealTimers();
+    }
+  });
+
+  it('aborts the SSG signal on the deadline so the heavy bulkhead slot frees early', async () => {
+    vi.useFakeTimers();
+    try {
+      h.getInfinitePrefetch.mockImplementationOnce(() => new Promise<undefined>(() => {}));
+      const abortController = new AbortController();
+
+      const pending = prefetchImagesFeedQueries(h.fakeSsg as any, null, {}, abortController);
+      let settled = false;
+      const tracked = pending.then(() => {
+        settled = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(0); // flush the addon-fetch microtask
+      await vi.advanceTimersByTimeAsync(299);
+      // Before the deadline: not aborted, not settled.
+      expect(abortController.signal.aborted).toBe(false);
+      expect(settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await tracked;
+      // The deadline fired abort() → cancels the in-flight query → releases the slot.
+      expect(abortController.signal.aborted).toBe(true);
+      expect(settled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT abort when the prefetch settles before the deadline', async () => {
+    const abortController = new AbortController();
+    await prefetchImagesFeedQueries(h.fakeSsg as any, null, {}, abortController);
+    expect(h.getInfinitePrefetch).toHaveBeenCalledTimes(1);
+    // Fast happy path → the deadline never fires → the signal is untouched.
+    expect(abortController.signal.aborted).toBe(false);
+  });
+
+  it('skips the prefetch when a feed-affecting query param is present', async () => {
+    await prefetchImagesFeedQueries(h.fakeSsg as any, null, { sort: 'Newest' });
+    expect(h.getInfinitePrefetch).not.toHaveBeenCalled();
+    expect(h.getBrowsingSettingAddons).not.toHaveBeenCalled();
+  });
+});
+
+describe('hasImagesFeedQueryParams', () => {
+  it('is false for the bare default feed (no query) and for only non-feed params', () => {
+    expect(hasImagesFeedQueryParams(undefined)).toBe(false);
+    expect(hasImagesFeedQueryParams({})).toBe(false);
+    // Params the client zod-strips (don't change the key) do not block the prefetch.
+    expect(hasImagesFeedQueryParams({ utm_source: 'x', fbclid: 'y', ref: 'z' })).toBe(false);
+  });
+
+  it('is true for each feed-affecting param the client merges into the input', () => {
+    for (const key of [
+      'period',
+      'sort',
+      'types',
+      'tags',
+      'withMeta',
+      'baseModels',
+      'view',
+      'section',
+      'tools',
+      'techniques',
+      'followed',
+      'hidden',
+    ]) {
+      expect(hasImagesFeedQueryParams({ [key]: 'anything' })).toBe(true);
     }
   });
 });

--- a/src/server/utils/__tests__/ssr-prefetch-images-feed.test.ts
+++ b/src/server/utils/__tests__/ssr-prefetch-images-feed.test.ts
@@ -1,0 +1,283 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MediaType, MetricTimeframe } from '~/shared/utils/prisma/enums';
+import { ImageSort, NsfwLevel } from '~/server/common/enums';
+import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+import {
+  resolveBrowsingSettingsAddons,
+  type BrowsingSettingsAddon,
+} from '~/shared/constants/browsing-settings-addons';
+
+/**
+ * SSR-prefetch of the `/images` feed page's INITIAL `image.getInfinite` query
+ * (see `prefetchImagesFeedQueries` in `src/server/utils/server-side-helpers.ts`,
+ * wired flag-gated into the `/images` GSSP resolver in `src/pages/images/index.tsx`).
+ *
+ * The lever: the initial feed query — the page's first, HEAVIEST client fetch
+ * (`heavyProcedure`, bulkhead-slotted) — rides down in the page's dehydrated
+ * `trpcState` and hydrates on the client (`staleTime: Infinity`, so the hydrated
+ * value sticks and the ~188ms client→origin round-trip is saved) instead of
+ * firing on mount. Because a mismatched heavy prefetch is pure cost (wasted work
+ * + a burned bulkhead slot), this pins the safety + key-match contract:
+ *   - ANON-ONLY: the exact client input is only server-reproducible for anon
+ *     (deterministic browsingLevel + default filters + resolved addons); authed
+ *     requests are never prefetched (their localStorage/browsing state diverges),
+ *   - the prefetched input reproduces the client `useInfiniteQuery` key EXACTLY
+ *     (default filters + `publicBrowsingLevelsFlag` + `include:['cosmetics']` +
+ *     the addon-resolved `excludedTagIds`/`disablePoi`/`disableMinor`),
+ *   - `prefetchInfinite` (not `.prefetch`) is used so the dehydrated shape matches
+ *     the client `useInfiniteQuery`,
+ *   - nothing is prefetched on a client-nav `/_next/data` fetch (no `ssg`),
+ *   - the flag OFF prefetches nothing (SSG/`trpcState` unaffected),
+ *   - a failing addon fetch skips the prefetch (never fire a wrong-key heavy query),
+ *   - a failing / never-settling feed query degrades to client-fetch — it never
+ *     500s or hangs the `/images` SSR (bounded by the 300ms shared deadline).
+ *
+ * server-side-helpers.ts pulls the whole app router + clickhouse + auth graph at
+ * module load; stub those so it imports in isolation and the tRPC SSG helper is a
+ * spy. `~/server/services/system-cache` (redis) is lazy-imported by the helper,
+ * so it is mocked here too.
+ */
+
+const h = vi.hoisted(() => {
+  const getInfinitePrefetch = vi.fn(async () => undefined);
+  // shell-prefetch procedures (createServerSideProps also calls the shell
+  // prefetch; stubbed inert — driven OFF via the flag / anon session).
+  const checkNotifications = vi.fn(async () => undefined);
+  const getBookmarkCollections = vi.fn(async () => undefined);
+  const getUserMultipliers = vi.fn(async () => undefined);
+  const dehydrate = vi.fn(() => ({ mock: 'trpcState' }));
+  const fakeSsg = {
+    image: {
+      getInfinite: { prefetchInfinite: getInfinitePrefetch },
+    },
+    user: {
+      checkNotifications: { prefetch: checkNotifications },
+      getBookmarkCollections: { prefetch: getBookmarkCollections },
+    },
+    buzz: {
+      getUserMultipliers: { prefetch: getUserMultipliers },
+    },
+    dehydrate,
+  };
+  return {
+    getInfinitePrefetch,
+    dehydrate,
+    fakeSsg,
+    createServerSideHelpers: vi.fn(() => fakeSsg),
+    getServerAuthSession: vi.fn(),
+    getFeatureFlagsAsync: vi.fn(),
+    getBrowsingSettingAddons: vi.fn(),
+  };
+});
+
+vi.mock('@trpc/react-query/server', () => ({ createServerSideHelpers: h.createServerSideHelpers }));
+vi.mock('~/server/routers', () => ({ appRouter: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ Tracker: class {} }));
+vi.mock('~/server/services/feature-flags.service', () => ({
+  getFeatureFlagsAsync: h.getFeatureFlagsAsync,
+}));
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: h.getServerAuthSession,
+}));
+vi.mock('~/server/utils/server-domain', () => ({ getRequestDomainColor: vi.fn(() => 'blue') }));
+vi.mock('~/server/services/system-cache', () => ({
+  getBrowsingSettingAddons: h.getBrowsingSettingAddons,
+}));
+
+import { createServerSideProps, prefetchImagesFeedQueries } from '../server-side-helpers';
+
+type AnyContext = Parameters<ReturnType<typeof createServerSideProps>>[0];
+
+const authedSession = { user: { id: 1 } } as any;
+
+// A representative addon list (mirrors the real-person rule in
+// DEFAULT_BROWSING_SETTINGS_ADDONS) so the resolver injects a NON-empty,
+// order-sensitive excludedTagIds + disablePoi at the anon PG level.
+const ADDONS: BrowsingSettingsAddon[] = [
+  {
+    type: 'some',
+    nsfwLevels: [NsfwLevel.PG, NsfwLevel.PG13, NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX],
+    disablePoi: true,
+    excludedTagIds: [5161, 5162, 5188],
+  },
+  {
+    type: 'some',
+    nsfwLevels: [NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX], // does NOT apply at PG
+    disableMinor: true,
+    excludedTagIds: [5351],
+  },
+];
+
+// The EXACT input `useQueryImages` builds for a default anonymous `/images` load,
+// reproduced here from the SAME public functions the client uses, so this asserts
+// the server prefetch key == the client `useInfiniteQuery` key.
+function expectedAnonInput(addons: BrowsingSettingsAddon[]) {
+  const resolved = resolveBrowsingSettingsAddons(addons, publicBrowsingLevelsFlag, {
+    isModerator: false,
+  });
+  return {
+    period: MetricTimeframe.Week,
+    sort: ImageSort.MostReactions,
+    types: [MediaType.image],
+    withMeta: false,
+    browsingLevel: publicBrowsingLevelsFlag,
+    include: ['cosmetics'],
+    excludedTagIds: resolved.excludedTagIds,
+    disablePoi: resolved.disablePoi,
+    disableMinor: resolved.disableMinor,
+  };
+}
+
+function makeContext(url: string): AnyContext {
+  return {
+    req: { url, headers: { host: 'civitai.com' } },
+    res: { setHeader: vi.fn() },
+    resolvedUrl: url,
+    query: {},
+  } as any;
+}
+
+// Mirrors the `/images` GSSP wiring: flag-gated, anon-only, runs only when the
+// SSG helper exists (full SSR), never on client-nav.
+function imagesResolver() {
+  return async ({ session, features, ssg }: any) => {
+    if (ssg && features?.ssrPrefetchImagesFeed) {
+      await prefetchImagesFeedQueries(ssg, session ?? null);
+    }
+    return { props: {} } as any;
+  };
+}
+
+function features(overrides: Record<string, boolean> = {}) {
+  return {
+    ssrPrefetchImagesFeed: true,
+    ssrPrefetchShell: false, // keep the shell prefetch inert in these tests
+    ...overrides,
+  } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: anonymous request.
+  h.getServerAuthSession.mockResolvedValue(null);
+  h.getFeatureFlagsAsync.mockResolvedValue(features());
+  h.getBrowsingSettingAddons.mockResolvedValue(ADDONS);
+});
+
+describe('createServerSideProps — images feed SSR prefetch (integration)', () => {
+  it('prefetches the initial anon feed query with the EXACT client key on full SSR when the flag is on', async () => {
+    const gssp = createServerSideProps({ useSSG: true, resolver: imagesResolver() });
+    const res: any = await gssp(makeContext('/images'));
+
+    expect(h.getInfinitePrefetch).toHaveBeenCalledTimes(1);
+    // The reproduced input deep-equals the client `useInfiniteQuery` input.
+    expect(h.getInfinitePrefetch).toHaveBeenCalledWith(expectedAnonInput(ADDONS));
+    // hydrated cache rides down in trpcState.
+    expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
+  });
+
+  it('does NOT prefetch (or build an SSG helper) on a client-nav /_next/data fetch', async () => {
+    const gssp = createServerSideProps({ useSSG: true, resolver: imagesResolver() });
+    const res: any = await gssp(makeContext('/_next/data/build-id/images.json'));
+
+    expect(h.createServerSideHelpers).not.toHaveBeenCalled();
+    expect(h.getInfinitePrefetch).not.toHaveBeenCalled();
+    expect(res.props.trpcState).toBeUndefined();
+  });
+
+  it('prefetches nothing when the flag is OFF, but still dehydrates SSG state', async () => {
+    h.getFeatureFlagsAsync.mockResolvedValue(features({ ssrPrefetchImagesFeed: false }));
+    const gssp = createServerSideProps({ useSSG: true, resolver: imagesResolver() });
+    const res: any = await gssp(makeContext('/images'));
+
+    expect(h.getInfinitePrefetch).not.toHaveBeenCalled();
+    // useSSG still builds the helper — the flag gates only the feed prefetch.
+    expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
+  });
+
+  it('does NOT prefetch for an authed session (anon-only), but still dehydrates SSG state', async () => {
+    h.getServerAuthSession.mockResolvedValue(authedSession);
+    const gssp = createServerSideProps({ useSSG: true, resolver: imagesResolver() });
+    const res: any = await gssp(makeContext('/images'));
+
+    expect(h.getInfinitePrefetch).not.toHaveBeenCalled();
+    expect(h.getBrowsingSettingAddons).not.toHaveBeenCalled();
+    // The authed render path is entirely unchanged — props/session still returned.
+    expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
+    expect(res.props.session).toEqual(authedSession);
+  });
+
+  it('degrades gracefully — a failing feed prefetch never rejects out of SSR', async () => {
+    h.getInfinitePrefetch.mockRejectedValueOnce(new Error('backend 500'));
+    const gssp = createServerSideProps({ useSSG: true, resolver: imagesResolver() });
+
+    const res: any = await gssp(makeContext('/images'));
+
+    // SSR still resolves with a normal props payload (no throw / 500).
+    expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
+    expect(h.getInfinitePrefetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('prefetchImagesFeedQueries — unit', () => {
+  it('prefetches the initial feed query for an anon session with the exact reproduced input', async () => {
+    await prefetchImagesFeedQueries(h.fakeSsg as any, null);
+    expect(h.getInfinitePrefetch).toHaveBeenCalledTimes(1);
+    expect(h.getInfinitePrefetch).toHaveBeenCalledWith(expectedAnonInput(ADDONS));
+  });
+
+  it('resolves the addon-derived fields (non-empty excludedTagIds + disablePoi) at the anon PG level', async () => {
+    await prefetchImagesFeedQueries(h.fakeSsg as any, null);
+    const input = h.getInfinitePrefetch.mock.calls[0][0] as any;
+    // Only the PG-applicable addon contributes; order is preserved for the hash.
+    expect(input.excludedTagIds).toEqual([5161, 5162, 5188]);
+    expect(input.disablePoi).toBe(true);
+    expect(input.disableMinor).toBe(false); // R+ rule does not apply at PG
+    expect(input.browsingLevel).toBe(publicBrowsingLevelsFlag);
+    expect(input.include).toEqual(['cosmetics']);
+  });
+
+  it('prefetches nothing for an authed session (anon-only scope)', async () => {
+    await prefetchImagesFeedQueries(h.fakeSsg as any, authedSession);
+    expect(h.getInfinitePrefetch).not.toHaveBeenCalled();
+    expect(h.getBrowsingSettingAddons).not.toHaveBeenCalled();
+  });
+
+  it('skips the prefetch (never fires a wrong-key heavy query) when the addon fetch fails', async () => {
+    h.getBrowsingSettingAddons.mockRejectedValueOnce(new Error('redis down'));
+    await expect(prefetchImagesFeedQueries(h.fakeSsg as any, null)).resolves.toBeUndefined();
+    expect(h.getInfinitePrefetch).not.toHaveBeenCalled();
+  });
+
+  it('resolves (never throws) when the feed prefetch rejects', async () => {
+    h.getInfinitePrefetch.mockRejectedValueOnce(new Error('meili down'));
+    await expect(prefetchImagesFeedQueries(h.fakeSsg as any, null)).resolves.toBeUndefined();
+  });
+
+  it('resolves via the deadline (never hangs SSR) when the feed prefetch never settles', async () => {
+    vi.useFakeTimers();
+    try {
+      h.getInfinitePrefetch.mockImplementationOnce(() => new Promise<undefined>(() => {}));
+
+      const pending = prefetchImagesFeedQueries(h.fakeSsg as any, null);
+      let settled = false;
+      const tracked = pending.then(() => {
+        settled = true;
+      });
+
+      // The addon fetch is an awaited microtask before the deadline race starts;
+      // flush it so the timers below drive the hung prefetch, not the addon await.
+      await vi.advanceTimersByTimeAsync(0);
+      // Not resolved before the deadline elapses…
+      await vi.advanceTimersByTimeAsync(299);
+      expect(settled).toBe(false);
+
+      // …but the 300ms deadline resolves it (never throws) with the task still hung.
+      await vi.advanceTimersByTimeAsync(1);
+      await tracked;
+      expect(settled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -435,6 +435,18 @@ export function createServerSideProps<P>({
     // Real controller backing the SSG procedure `ctx.signal`, so a page prefetch
     // can cancel its in-flight query on a deadline (see the images-feed prefetch).
     // Created only when we build an SSG helper; exposed to the resolver below.
+    //
+    // ⚠️ SHARED signal: this ONE controller backs `ctx.signal` for EVERY prefetch
+    // on this `ssg` helper (the app-shell batch below AND any page-scoped prefetch,
+    // e.g. images). So a page prefetch that fires `.abort()` on its deadline also
+    // aborts the shell queries' signal. Benign today: `shellPrefetch` starts before
+    // the resolver and the only aborting caller (images) awaits an addon fetch
+    // first, so its abort fires strictly AFTER the shell's own 300ms dehydration
+    // window — any shell query still in flight has already missed hydration, so
+    // cancelling it only frees resources (graceful client-refetch, never an error).
+    // If a future page pairs a heavy `onDeadline` abort with the shell on the same
+    // signal, or shell queries gain longer deadlines, give each prefetch its OWN
+    // controller to fully decouple them.
     const ssgAbortController = new AbortController();
     const ssg =
       useSSG && (prefetch === 'always' || !isClient)

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -24,7 +24,14 @@ import type { ImageInclude } from '~/server/schema/image.schema';
 export const getServerProxySSGHelpers = async (
   ctx: GetServerSidePropsContext,
   session: Session | null,
-  features: FeatureAccess
+  features: FeatureAccess,
+  // Optional real AbortController whose `.signal` becomes the SSG procedure ctx
+  // signal. Threaded in so a prefetch can be cancelled on a deadline (see the
+  // images-feed prefetch, which fires `abort()` on timeout to release the heavy
+  // bulkhead slot early). When omitted, a fresh never-fired controller is used —
+  // byte-compatible with the prior behavior for the shell/generator callers,
+  // which never abort.
+  abortController: AbortController = new AbortController()
 ) => {
   const domain = getRequestDomainColor(ctx.req) ?? 'blue';
   const ssg = createServerSideHelpers({
@@ -39,7 +46,7 @@ export const getServerProxySSGHelpers = async (
       cache: null as any,
       req: ctx.req as any,
       domain,
-      signal: new AbortController().signal,
+      signal: abortController.signal,
       tokenScope: TokenScope.Full,
       apiKeyId: undefined,
       subject: undefined,
@@ -100,21 +107,40 @@ const APP_SHELL_PREFETCH_TIMEOUT_MS = 300;
  * slow backend can't drag SSR past the cap — on timeout we resolve (never throw)
  * and the un-prefetched queries fall back to their normal client fetch, the same
  * graceful-degradation contract as a failed prefetch. This is the single shared
- * safety primitive behind every SSR prefetch batch (app-shell + generator).
+ * safety primitive behind every SSR prefetch batch (app-shell + generator + images).
+ *
+ * `onDeadline` (optional): fired ONCE if — and only if — the deadline wins the
+ * race (the tasks had not all settled in time). Omitted by the shell/generator
+ * callers (their tasks are cheap in-process reads that need no cancellation), so
+ * their behavior is unchanged. The images-feed caller passes it to `abort()` the
+ * SSG signal on timeout, which cancels the in-flight heavy `image.getInfinite`
+ * Meili query and releases its per-pod bulkhead slot early (the handler honors
+ * `ctx.signal`; the `withBulkhead` middleware releases the slot in a `finally`
+ * on handler settle) instead of holding the slot for the query's full duration.
+ * `allSettled` still captures the resulting late rejection, so no unhandled
+ * rejection escapes.
  */
 async function settlePrefetchWithDeadline(
   tasks: Promise<unknown>[],
-  timeoutMs: number
+  timeoutMs: number,
+  onDeadline?: () => void
 ): Promise<void> {
   if (!tasks.length) return;
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
   const deadline = new Promise<void>((resolve) => {
-    timer = setTimeout(resolve, timeoutMs);
+    timer = setTimeout(() => {
+      timedOut = true;
+      resolve();
+    }, timeoutMs);
   });
   try {
     await Promise.race([Promise.allSettled(tasks), deadline]);
   } finally {
     if (timer) clearTimeout(timer);
+    // Fire the cancellation hook only when the deadline actually elapsed (tasks
+    // still pending) — never when the tasks settled first.
+    if (timedOut) onDeadline?.();
   }
 }
 
@@ -255,11 +281,24 @@ export async function prefetchGeneratorQueries(
  * (`src/utils/trpc.ts`) and this call-site sets no lower `staleTime`, so once the
  * dehydrated infinite entry hydrates it is never stale → no refetch on mount.
  *
+ * QUERY-PARAM GUARD — the reproduced input above is ONLY the client's key for
+ * the BARE default feed. `/images?period=Month` / `?tags=…` / `?sort=…` / etc.
+ * make the client's `useImageFilters('images')` merge those URL params into the
+ * feed input → a DIFFERENT infinite-query key → a guaranteed key miss + a burned
+ * heavy slot. So we skip the prefetch when the request carries ANY feed-affecting
+ * query param (the `imagesQueryParamSchema` set). Unrecognized params (utm_*,
+ * fbclid, …) are stripped by the client's zod parse and don't change the key, so
+ * they do NOT block the prefetch — a default feed opened from a shared/referral
+ * link (a high-value anon cohort) still hydrates.
+ *
  * ROBUSTNESS + DEADLINE — best-effort via `settlePrefetchWithDeadline`: a failing
  * or >300ms-slow feed query degrades to the normal client fetch and can NEVER
- * reject out of SSR or drag it past the cap. If the addon fetch fails we skip the
- * prefetch entirely (prefetching with the wrong `excludedTagIds` would miss the
- * key AND waste a heavy slot — worse than not prefetching).
+ * reject out of SSR or drag it past the cap. On the deadline we `abort()` the SSG
+ * signal (Fix, wired via the `abortController`), which cancels the in-flight heavy
+ * `image.getInfinite` Meili query and releases its per-pod bulkhead slot early
+ * rather than holding it for the full query duration. If the addon fetch fails we
+ * skip the prefetch entirely (prefetching with the wrong `excludedTagIds` would
+ * miss the key AND waste a heavy slot — worse than not prefetching).
  */
 // Reproduces the FiltersProvider `imageFilterSchema` defaults (client storeFilters
 // for a default anon) verbatim — the values `useImageFilters('images')` yields
@@ -272,16 +311,56 @@ const IMAGES_FEED_DEFAULT_FILTERS = {
   withMeta: false,
 };
 
+// The URL query params the images feed reads into its infinite-query input.
+// MUST mirror `imagesQueryParamSchema` in `src/components/Image/image.utils.ts`
+// (that module is client-heavy — mantine/trpc/react — so we enumerate the keys
+// here rather than import it into this server module). If a key is added to that
+// schema, add it here too; over-listing is safe (skipping is free), under-listing
+// risks a wasted heavy prefetch on a non-default feed. `view`/`section` are
+// UI-ish but still flow into the client's raw feed input, so they gate too.
+const IMAGES_FEED_QUERY_PARAM_KEYS = new Set<string>([
+  'baseModels', 'collectionId', 'collectionTagId', 'hideAutoResources',
+  'hideManualResources', 'followed', 'fromPlatform', 'hidden', 'includeBaseModel',
+  'limit', 'modelId', 'modelVersionId', 'notPublished', 'publishedOnly',
+  'pendingReviewOnly', 'period', 'periodMode', 'postId', 'prioritizedUserIds',
+  'reactions', 'scheduled', 'section', 'sort', 'tags', 'techniques', 'tools',
+  'types', 'userId', 'username', 'view', 'withMeta', 'requiringMeta', 'remixOfId',
+  'includePG13', 'poiOnly', 'minorOnly', 'disablePoi', 'disableMinor',
+  'remixesOnly', 'nonRemixesOnly',
+]);
+
+/** True when the request URL carries any feed-affecting param (→ a non-default key). */
+export function hasImagesFeedQueryParams(query: Record<string, unknown> | undefined): boolean {
+  if (!query) return false;
+  for (const key of Object.keys(query)) {
+    if (IMAGES_FEED_QUERY_PARAM_KEYS.has(key)) return true;
+  }
+  return false;
+}
+
 const IMAGES_FEED_PREFETCH_TIMEOUT_MS = 300;
 
 export async function prefetchImagesFeedQueries(
   ssg: SSGHelpers,
-  session: Session | null
+  session: Session | null,
+  query: Record<string, unknown> | undefined,
+  // Real controller backing the SSG `ctx.signal` (from `getServerProxySSGHelpers`
+  // via `createServerSideProps`). Aborted on the deadline to release the heavy
+  // bulkhead slot early. Optional so the helper is unit-testable in isolation.
+  abortController?: AbortController
 ): Promise<void> {
   // ANON-ONLY: authed inputs are not server-reproducible (see doc above).
   if (session?.user) return;
+  // Only the BARE default feed's key is reproducible — skip any filtered variant.
+  if (hasImagesFeedQueryParams(query)) return;
 
-  // Deterministic anon browsing level on every domain.
+  // Deterministic anon browsing level on every domain. This MIRRORS
+  // `BrowsingLevelProvider`'s anon path (src/components/BrowsingLevel/…): with no
+  // `currentUser`, `domainForcedLevel` forces `publicBrowsingLevelsFlag` on green
+  // AND blue/red, and the green `capToPublic` intersection with the same flag is
+  // idempotent — so it is domain-independent. 🔴 If that anon rule ever becomes
+  // domain-dependent, this constant silently breaks the key match; re-derive it
+  // from the request domain here at that point.
   const browsingLevel = publicBrowsingLevelsFlag;
 
   // Resolve the browsing-settings addons against the SAME data the client sees.
@@ -314,7 +393,11 @@ export async function prefetchImagesFeedQueries(
 
   await settlePrefetchWithDeadline(
     [ssg.image.getInfinite.prefetchInfinite(input as any)],
-    IMAGES_FEED_PREFETCH_TIMEOUT_MS
+    IMAGES_FEED_PREFETCH_TIMEOUT_MS,
+    // On timeout, cancel the in-flight heavy query so its bulkhead slot frees now
+    // instead of at the query's natural completion (the deadline already gave up
+    // on hydrating it, so aborting loses nothing hydratable — pure slot savings).
+    () => abortController?.abort()
   );
 }
 
@@ -349,9 +432,13 @@ export function createServerSideProps<P>({
 
     const features = await getFeatureFlagsAsync({ user: session?.user, req: context.req });
 
+    // Real controller backing the SSG procedure `ctx.signal`, so a page prefetch
+    // can cancel its in-flight query on a deadline (see the images-feed prefetch).
+    // Created only when we build an SSG helper; exposed to the resolver below.
+    const ssgAbortController = new AbortController();
     const ssg =
       useSSG && (prefetch === 'always' || !isClient)
-        ? await getServerProxySSGHelpers(context, session, features)
+        ? await getServerProxySSGHelpers(context, session, features, ssgAbortController)
         : undefined;
 
     // Flag-gated SSR-prefetch of the universal app-shell queries into the shared
@@ -379,6 +466,9 @@ export function createServerSideProps<P>({
       ssg,
       session,
       features,
+      // Only meaningful when `ssg` exists; a page prefetch fires `.abort()` on its
+      // deadline to release a heavy bulkhead slot early.
+      ssgAbortController: ssg ? ssgAbortController : undefined,
     })) ?? { props: {} }) as GetPropsFnResult<NonNullable<P>>;
 
     if (result.redirect) return { redirect: result.redirect };
@@ -429,5 +519,7 @@ type CustomGetServerSidePropsContext = {
   ssg?: AsyncReturnType<typeof getServerProxySSGHelpers>;
   session?: Session | null;
   features?: FeatureAccess;
+  /** Backs the SSG `ctx.signal`; a page prefetch aborts it on its deadline to free a heavy slot early. */
+  ssgAbortController?: AbortController;
   // browsingLevel: number;
 };

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -10,7 +10,16 @@ import { getFeatureFlagsAsync } from '~/server/services/feature-flags.service';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { getRequestDomainColor } from '~/server/utils/server-domain';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
-import { ChallengeSource, ChallengeStatus } from '~/shared/utils/prisma/enums';
+import {
+  ChallengeSource,
+  ChallengeStatus,
+  MediaType,
+  MetricTimeframe,
+} from '~/shared/utils/prisma/enums';
+import { ImageSort } from '~/server/common/enums';
+import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+import { resolveBrowsingSettingsAddons } from '~/shared/constants/browsing-settings-addons';
+import type { ImageInclude } from '~/server/schema/image.schema';
 
 export const getServerProxySSGHelpers = async (
   ctx: GetServerSidePropsContext,
@@ -204,6 +213,109 @@ export async function prefetchGeneratorQueries(
     tasks.push(ssg.challenge.getInfinite.prefetch({ ...GENERATOR_ACTIVE_CHALLENGES_INPUT }));
 
   await settlePrefetchWithDeadline(tasks, GENERATOR_PREFETCH_TIMEOUT_MS);
+}
+
+/**
+ * SSR-prefetch the `/images` feed page's INITIAL `image.getInfinite` query so it
+ * hydrates from the dehydrated `trpcState` instead of firing a client→CF→origin
+ * round-trip on mount (~188ms network floor). Unlike the shell/generator
+ * prefetches (cheap, input-less reads), this targets a `heavyProcedure`
+ * (bulkhead-slotted) feed query — the page's first and most expensive fetch — so
+ * a mismatched prefetch is not just wasted, it burns a scarce heavy slot. That
+ * makes the EXACT react-query key match the whole game.
+ *
+ * 🔴 ANON-ONLY. The client's initial input (`ImagesInfinite` → `useQueryImages`)
+ * is derived from three client-only sources: (1) the FiltersProvider store
+ * (localStorage, NOT server-readable), (2) a 3-provider `browsingLevel` chain,
+ * and (3) DB-resolved browsing-settings-addons. For an ANONYMOUS request all of
+ * these collapse to deterministic, server-reproducible values:
+ *   - `browsingLevel` → `publicBrowsingLevelsFlag` on EVERY domain: anon has no
+ *     user, so `BrowsingLevelProvider`'s `domainForcedLevel` forces public, and
+ *     the green-domain `capToPublic` intersection with the same flag is
+ *     idempotent. (`useBrowsingLevelDebounced` returns it verbatim, non-zero.)
+ *   - filters → the FiltersProvider `imageFilterSchema` defaults (empty anon
+ *     localStorage parses to these): `{ period: Week, sort: MostReactions,
+ *     types: [image], withMeta: false }`. `removeEmpty` keeps `withMeta: false`
+ *     (not nil) and the non-empty `types` array, so both are in the key.
+ *   - `excludedTagIds` / `disablePoi` / `disableMinor` → `resolveBrowsingSettingsAddons`
+ *     run against the SAME addon data the client sees (its provider `initialData`
+ *     comes from `getBrowsingSettingAddons()` in `_app.getInitialProps`), at
+ *     `publicBrowsingLevelsFlag`, `isModerator: false`. At PG this yields
+ *     `disablePoi: true`, `disableMinor: false`, and the real-person tag list —
+ *     reproduced verbatim (array ORDER matters for the react-query hash).
+ * `include: ['cosmetics']` is the constant `ImagesInfinite` passes. `limit`/`cursor`
+ * are NOT in the client's raw infinite-query key (server zod defaults them for the
+ * handler only), so they are omitted here — `prefetchInfinite` builds the same key.
+ *
+ * Authed requests are intentionally NOT prefetched: their localStorage filters +
+ * saved browsing level can diverge from any server guess, and a mismatch on a
+ * heavy query is pure cost. They fall through to the unchanged client fetch.
+ *
+ * WHY THE WIN LANDS: the shared QueryClient runs `staleTime: Infinity`
+ * (`src/utils/trpc.ts`) and this call-site sets no lower `staleTime`, so once the
+ * dehydrated infinite entry hydrates it is never stale → no refetch on mount.
+ *
+ * ROBUSTNESS + DEADLINE — best-effort via `settlePrefetchWithDeadline`: a failing
+ * or >300ms-slow feed query degrades to the normal client fetch and can NEVER
+ * reject out of SSR or drag it past the cap. If the addon fetch fails we skip the
+ * prefetch entirely (prefetching with the wrong `excludedTagIds` would miss the
+ * key AND waste a heavy slot — worse than not prefetching).
+ */
+// Reproduces the FiltersProvider `imageFilterSchema` defaults (client storeFilters
+// for a default anon) verbatim — the values `useImageFilters('images')` yields
+// before merge. Kept as an explicit literal (the schema isn't exported) so the
+// react-query key match is auditable against `src/providers/FiltersProvider.tsx`.
+const IMAGES_FEED_DEFAULT_FILTERS = {
+  period: MetricTimeframe.Week,
+  sort: ImageSort.MostReactions,
+  types: [MediaType.image],
+  withMeta: false,
+};
+
+const IMAGES_FEED_PREFETCH_TIMEOUT_MS = 300;
+
+export async function prefetchImagesFeedQueries(
+  ssg: SSGHelpers,
+  session: Session | null
+): Promise<void> {
+  // ANON-ONLY: authed inputs are not server-reproducible (see doc above).
+  if (session?.user) return;
+
+  // Deterministic anon browsing level on every domain.
+  const browsingLevel = publicBrowsingLevelsFlag;
+
+  // Resolve the browsing-settings addons against the SAME data the client sees.
+  // Lazy import so the server-only system-cache (redis) module isn't pulled at
+  // top-level (keeps the module importable in isolation / other prefetch tests).
+  // Best-effort: on any failure, skip the prefetch rather than fire it with a
+  // wrong `excludedTagIds` that would miss the key and waste a heavy slot.
+  let addons;
+  try {
+    const { getBrowsingSettingAddons } = await import('~/server/services/system-cache');
+    const data = await getBrowsingSettingAddons();
+    addons = resolveBrowsingSettingsAddons(data, browsingLevel, { isModerator: false });
+  } catch {
+    return;
+  }
+
+  // Reproduce EXACTLY the input `useQueryImages` builds for a default anon:
+  //   { ...filters, browsingLevel, include: ['cosmetics'], excludedTagIds,
+  //     disablePoi, disableMinor }
+  // (anon: filters.excludedTagIds/disablePoi/disableMinor are unset, so they come
+  //  solely from the resolved addons; isOwnImages is false so addon tags apply.)
+  const input = {
+    ...IMAGES_FEED_DEFAULT_FILTERS,
+    browsingLevel,
+    include: ['cosmetics'] as ImageInclude[],
+    excludedTagIds: addons.excludedTagIds,
+    disablePoi: addons.disablePoi,
+    disableMinor: addons.disableMinor,
+  };
+
+  await settlePrefetchWithDeadline(
+    [ssg.image.getInfinite.prefetchInfinite(input as any)],
+    IMAGES_FEED_PREFETCH_TIMEOUT_MS
+  );
 }
 
 export function createServerSideProps<P>({


### PR DESCRIPTION
## The lever

Third increment of the perceived-latency SSR-prefetch arc (after app-shell #2990 and generator #2993). The `/images` feed's **first and heaviest** client fetch — the initial `image.getInfinite` infinite query — currently fires a client→CF→origin round-trip on mount (~188ms network floor). This prefetches it server-side so it hydrates from the page's dehydrated `trpcState` instead.

**Why hydration lands:** the shared QueryClient runs `staleTime: Infinity` (`src/utils/trpc.ts`) and this call-site sets no lower `staleTime`, so once the dehydrated infinite entry hydrates it is never stale → no refetch on mount. Uses `prefetchInfinite` (not `.prefetch`) so the dehydrated shape matches the client `useInfiniteQuery`.

## 🔴 Edge-caching trade-off — analyzed, NO regression

`MyApp.getInitialProps` (`src/pages/_app.tsx:347`) is active → Next.js **Automatic Static Optimization is already disabled app-wide**. `/images` (which had no data method) already rendered **per-request on the SSR pod**, not as a static CDN asset (it sends the standard SSR `Cache-Control: private, no-store`). The homepage `/` already uses `createServerSideProps`. Adding GSSP therefore strips **no** edge caching; it adds only the resolver's `getServerAuthSession` + `getFeatureFlagsAsync` — the cost the homepage already pays. Flag-OFF (the default) adds **zero** prefetch work.

## 🔴 Key-match reproduction — why ANON-ONLY + default-feed-only

`image.getInfinite` is a **`heavyProcedure`** (bulkhead-slotted). A key-mismatched prefetch is not just wasted work — it **burns a scarce heavy slot** and the client refetches anyway. So the exact react-query key match is load-bearing.

The client's initial input (`ImagesInfinite` → `useQueryImages`) is derived from client-only sources. Only the **anonymous, bare-default-feed** request is deterministically reproducible server-side:
- **browsingLevel → `publicBrowsingLevelsFlag` on every domain** (anon has no user → `domainForcedLevel` forces public; the green `capToPublic` intersection is idempotent).
- **filters → FiltersProvider `imageFilterSchema` defaults** (empty anon localStorage parses to these): `{ period: Week, sort: MostReactions, types: [image], withMeta: false }`.
- **excludedTagIds / disablePoi / disableMinor →** the shared isomorphic `resolveBrowsingSettingsAddons` over the **same** addon data the client sees (`getBrowsingSettingAddons()` in `_app.getInitialProps`), at `publicBrowsingLevelsFlag`, `isModerator: false`. Array **order** matters for the hash and is reproduced verbatim (asserted in tests).

**Authed users are never prefetched** (localStorage filters + saved browsing level diverge). **Filtered feeds are never prefetched** (see Fix 1). Both fall through to the unchanged client fetch — zero regression, zero wasted heavy work.

## Adversarial-audit fixes folded in (commit `a5439bd`)

**Fix 1 — skip non-default feeds.** The reproduced key is only correct for the bare default feed. `/images?period=Month` / `?sort=…` / `?tags=…` etc. make the client merge those URL params into the feed input → a different key → a guaranteed miss + burned slot. The resolver now skips the prefetch when the request carries **any** feed-affecting query param (the `imagesQueryParamSchema` set, enumerated in `IMAGES_FEED_QUERY_PARAM_KEYS` + guarded by the exported `hasImagesFeedQueryParams`). Unrecognized params (`utm_*`, `fbclid`) are zod-stripped client-side and don't change the key, so a default feed from a **referral/shared link** (a high-value anon cohort) still hydrates.

**Fix 2 — release the heavy bulkhead slot on the deadline.** Previously, on the 300ms timeout `settlePrefetchWithDeadline` left the heavy `prefetchInfinite` running, holding its per-pod bulkhead slot for the query's **full** duration while the client refetched (double heavy execution). Investigation confirmed the fix is real: `image.getInfinite` **honors `ctx.signal`** (`image.controller.ts:281,337` → `image.service.ts:3419,4320` thread it into the Meili `getDocuments`), and `withBulkhead` (`trpc.ts:298`) releases the slot in a `finally` on handler settle. So on the deadline we now `abort()` the SSG signal → the in-flight Meili query cancels → the slot frees **at 300ms** instead of at natural completion. Wired a real `AbortController` through `getServerProxySSGHelpers` → `createServerSideProps` → resolver ctx; `settlePrefetchWithDeadline` gained an optional `onDeadline` hook that fires **only** on timeout. **Shell/generator callers pass no hook → byte-behavior unchanged** (verified: their suites still green). Aborting loses nothing hydratable (the deadline already gave up on that result), so it is pure slot savings.

**Fix 3 — hardened the `browsingLevel` invariant** with a comment tying the hardcoded `publicBrowsingLevelsFlag` to `BrowsingLevelProvider`'s anon path, so a future domain-rule change can't silently break the key match.

## The flag

`ssrPrefetchImagesFeed` (Flipt `ssr-prefetch-images-feed`, `availability: ['mod']`), **default OFF**, independent ramp/rollback. `['mod']` is the Flipt-DOWN fallback (mirrors `ssrPrefetchShell`); when Flipt is up and ramped it applies to all targeted traffic including anon.

## 🔴 Dark vs. ramp — the honest story (read before ramping)

**Safe to merge dark. NOT incrementally rampable across anon as-is.**

1. **The feature is all-or-nothing across anon traffic.** The flag path uses a **constant** Flipt entityId for anonymous users — `feature-flags.service.ts:90`: `user ? String(user.id) : 'anonymous'`. Flipt's percentage rollout hashes the entityId, so every anon request evaluates identically → any % threshold flips **0%→100% of anon at once**. A true anon canary needs either a **stable per-device anon bucketing token** as the entityId, or a **`deploymentId`/segment**-based rollout — that is separate flag-infra work and is **NOT in this PR**. Since mods are always authed and the prefetch is anon-only, the dark (mod-only) phase fires **nothing** — the win can only be observed by turning it on for anon, which is all-or-nothing.
2. **Pre-gate any ramp on these signals** (roll back = flag OFF, an instant, safe revert): SSR-pod **CPU + event-loop lag**; **`BulkheadFull` reject rate** on SSR pods (the `heavy-image` key — Fix 2 mitigates but does not eliminate the added slot pressure); **`image.getInfinite` p95 vs the 300ms deadline** (if p95 > 300ms, most prefetches abort → cost without hydration); **hydration hit-rate**; **Meili load**; and **`/d/civitai-dp-prod-api-net-phases`** for the perceived/network-phase win. Given (1), do a brief timed on/off comparison rather than a gradual ramp.
3. **Known miss classes** (degrade to client fetch, never wasted-heavy after Fix 1): NSFW-toggled anons on blue/red domains (browsingLevel diverges); and — **now mitigated by Fix 1** — any filtered/query-param feed variant.

Honest bottom line: mechanism correct + safe dark; the audit's "not safe to ramp as described" is addressed by Fix 1/Fix 2 (no wasted-heavy on filtered feeds; slot freed on deadline) **and** by stating plainly that the anon ramp is all-or-nothing and must be a metric-gated on/off test, not a %. The win is real for the default anon cohort but remains **unproven until measured** on anon public traffic.

## Tests

`src/server/utils/__tests__/ssr-prefetch-images-feed.test.ts` — **18 passing** (`vitest run`): exact client-key reproduction incl. resolved `excludedTagIds` ordering; anon-only; **filtered-feed skip** + **utm-only still-prefetches** + `hasImagesFeedQueryParams` unit matrix (Fix 1); client-nav `/_next/data` skip; flag-OFF no-op; addon-fetch-fail skip; failing prefetch degrades without throwing; never-settling prefetch resolves via the 300ms deadline; **deadline fires `abort()` / fast path does not** (Fix 2). Sibling `ssr-prefetch-generator` (10) + `ssr-prefetch-app-shell` (13) suites **still green** — no regression to the merged PRs. Total **41 passing**.

**Typecheck:** full-project `tsc` (raised heap) → 17 pre-existing errors, all in unrelated files (db-schema/kysely, flipt client, image.service, bitdex-stats), all TS2307/TS7006 noise; **zero in the touched files**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)