### PR TITLE
feat(app-blocks): let unsubmitted apps test Buzz-spend generation in the dev tunnel

### DIFF
--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -40,13 +40,13 @@ import {
   consentGatedScopes,
 } from '~/server/services/blocks/scope-grant.service';
 import {
-  clampDevScopes,
+  clampTunnelDeclaredScopes,
   FORCED_SFW_CEILING,
   resolveDevBuzzBudget,
   signDevScopedPageToken,
-  TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
 } from '~/server/services/blocks/dev-scoped-mint.service';
 import type { SessionUser } from '~/types/session';
+import type { Logger } from '@civitai/next-axiom';
 
 /**
  * POST /api/v1/block-tokens
@@ -106,14 +106,12 @@ const slotContextSchema = z.union([pageSlotContextSchema, modelSlotContextSchema
 const requestSchema = z.object({
   blockInstanceId: z.string().min(1).max(64),
   slotContext: slotContextSchema,
-  // PHASE 2 (App Dev Tunnel) — self-declared scopes for a BRAND-NEW (unsubmitted)
-  // ephemeral app the AUTHOR owns, sent by the dev host. IGNORED on every
-  // non-dev-tunnel path (an approved mint sources scopes from the approved
-  // manifest snapshot). When the app has an OWNED pending submission the server
-  // reads the pending manifest.scopes instead; these body scopes only ever
-  // NARROW / seed within the identical audited dev clamp belt (dev-scoped-mint
-  // .service), never widen past the tunnel allowlist.
-  devScopes: z.array(z.string().min(1).max(64)).max(32).optional(),
+  // NB: the on-site tunnel mint NEVER sources scopes from the request body. A
+  // BRAND-NEW (unsubmitted) ephemeral app's scopes come from the AUTHENTICATED CLI's
+  // dev-tunnel session (server-stored, clamped) — see `tryDevTunnelScopedMint` — so
+  // a block's iframe JS can never self-declare/widen its own scopes. (The bearer
+  // `/api/v1/blocks/dev-token` localhost path legitimately body-sources; this
+  // cookie-authed page-host path does not.)
 });
 
 // W10 — synthetic block-instance id prefix for a stateless full-page app. The
@@ -340,10 +338,13 @@ function resolveBuzzBudget(
  *     per-session / per-day caps. There is NO bearer credential here, so the
  *     dev-token 7f AIServicesWrite ceiling doesn't map → `keyCanSpend: true`; the
  *     runtime author-flag re-check is the substitute spend gate.
- *   - SCOPE SOURCE (mirrors dev-token pending / no-row): the caller's OWN pending
- *     submission's SERVER-READ `manifest.scopes`, else the SELF-DECLARED body
- *     `devScopes`. Both pass the identical clamp (TUNNEL allowlist, no OAuth
- *     ceiling — no client exists).
+ *   - SCOPE SOURCE (the resolver is the single authority — `app.scopes`): the
+ *     caller's OWN pending submission's SERVER-READ `manifest.scopes` (pending), else
+ *     the AUTHENTICATED CLI's dev-tunnel SESSION `grantedScopes` (brand-new — NEVER a
+ *     browser body, so a block can't self-widen). Both pass the identical
+ *     `clampTunnelDeclaredScopes` belt (TUNNEL allowlist, no OAuth ceiling). Real
+ *     spend on a brand-new (never-reviewed) app is additionally gated by the
+ *     dedicated `app-blocks-dev-tunnel-unsubmitted-spend` flag (else read-only).
  *
  * Returns 'handled' iff it wrote a 200 token response; 'continue' on ANY
  * non-match / refusal so the caller falls through to the uniform bare 404 (no
@@ -351,15 +352,15 @@ function resolveBuzzBudget(
  * strict improvement over the Phase-1 404.
  */
 async function tryDevTunnelScopedMint(args: {
+  req: NextApiRequest & { log?: Logger };
   res: NextApiResponse;
   appBlockId: string;
   blockInstanceId: string;
   slotId: string;
   sessionUser: SessionUser | undefined;
   userId: number | null;
-  devScopes: string[] | undefined;
 }): Promise<'handled' | 'continue'> {
-  const { res, appBlockId, blockInstanceId, slotId, sessionUser, userId, devScopes } = args;
+  const { req, res, appBlockId, blockInstanceId, slotId, sessionUser, userId } = args;
 
   // Cookie-authed author only; only the ephemeral synthetic namespace is a
   // pre-approval dev mint. Anything else → not our branch.
@@ -370,12 +371,14 @@ async function tryDevTunnelScopedMint(args: {
   if (blockInstanceId !== `${PAGE_INSTANCE_PREFIX}${appBlockId}`) return 'continue';
   if (sessionUser.bannedAt) return 'continue';
 
-  // Author capability + dev-tunnel kill-switch (fail-closed, both must pass).
-  // Dynamic import so the flag module (Flipt/redis transitive deps) isn't eager-
-  // loaded on the prod-mint import path — mirrors blocks.router's startDevTunnel.
-  const { isAppBlocksAuthorEnabled, isAppBlocksDevTunnelEnabled } = await import(
-    '~/server/services/app-blocks-flag'
-  );
+  // Author capability + dev-tunnel kill-switch + the DEDICATED unsubmitted-spend
+  // gate (all fail-closed). Dynamic import so the flag module (Flipt/redis
+  // transitive deps) isn't eager-loaded on the prod-mint import path.
+  const {
+    isAppBlocksAuthorEnabled,
+    isAppBlocksDevTunnelEnabled,
+    isAppBlocksDevTunnelUnsubmittedSpendEnabled,
+  } = await import('~/server/services/app-blocks-flag');
   if (!(await isAppBlocksAuthorEnabled({ user: sessionUser }))) return 'continue';
   if (!(await isAppBlocksDevTunnelEnabled({ user: sessionUser }))) return 'continue';
 
@@ -387,48 +390,41 @@ async function tryDevTunnelScopedMint(args: {
   });
   if (!userRow || userRow.deletedAt || userRow.bannedAt) return 'continue';
 
-  // OWNERSHIP + ANTI-SHADOW resolve (any refusal → the same bare null → 404).
   const slug = appBlockId.slice(EPHEMERAL_APP_ID_PREFIX.length);
-  const app = await BlockRegistry.resolveDevPageBlockForAuthor(slug, userId, { db: 'write' });
-  // Only a genuinely pre-approval (ephemeral) resolution mints here. A resolved
-  // approved/owned row (real appBlockId) would never carry an `ephemeral-` id, so
-  // this also fails closed if the app was approved mid-session.
+
+  // SCOPE SOURCE for the BRAND-NEW (no-pending-row) case = the caller's dev-tunnel
+  // SESSION's clamped `grantedScopes` (set by the AUTHENTICATED CLI from the local
+  // manifest at tunnel start) — NEVER a browser body, so a block's iframe JS can
+  // never widen. Real spend on a never-reviewed app is gated by the DEDICATED
+  // `app-blocks-dev-tunnel-unsubmitted-spend` flag. Both reads only on the rare
+  // dev-mint path. (Pending apps ignore the session — see the resolver.)
+  const { getActiveDevTunnel } = await import('~/server/services/blocks/dev-tunnel.service');
+  const tunnel = await getActiveDevTunnel(userId, slug);
+  const unsubmittedSpendAllowed = await isAppBlocksDevTunnelUnsubmittedSpendEnabled({
+    user: sessionUser,
+  });
+
+  // OWNERSHIP + ANTI-SHADOW resolve (any refusal → the same bare null → 404). The
+  // resolver is the SINGLE scope authority: `app.scopes` is the clamped granted set
+  // for BOTH the pending (own submission → server-read manifest) and brand-new
+  // (session-declared, flag-gated) cases — so this JWT and the SSR `declaredScopes`
+  // derive from the same function and can NEVER diverge. A resolved approved/owned
+  // row (real appBlockId, status !== 'ephemeral') fails closed here.
+  const app = await BlockRegistry.resolveDevPageBlockForAuthor(slug, userId, {
+    db: 'write',
+    sessionGrantedScopes: tunnel?.grantedScopes,
+    unsubmittedSpendAllowed,
+  });
   if (!app || app.status !== 'ephemeral') return 'continue';
 
   // Belt-and-suspenders: the page slot must be a real page slot (the caller
   // already validated this, but the dev branch re-asserts before signing).
   if (!isPageSlot(slotId)) return 'continue';
 
-  // SCOPE SOURCE: the caller's OWN pending submission's SERVER-READ manifest.scopes
-  // (the "submitted-pending" case), else the SELF-DECLARED body devScopes (the
-  // "brand-new" case). Ownership is enforced in the query (submittedByUserId).
-  const pending = await dbWrite.appBlockPublishRequest.findFirst({
-    where: { slug, status: 'pending', submittedByUserId: userId },
-    orderBy: { submittedAt: 'desc' },
-    select: { manifest: true },
-  });
-  let scopeSource: string[];
-  if (pending) {
-    const manifest = (pending.manifest ?? {}) as { scopes?: unknown };
-    scopeSource = Array.isArray(manifest.scopes)
-      ? manifest.scopes.filter((s): s is string => typeof s === 'string')
-      : [];
-  } else {
-    // Brand-new (no pending row): the client-supplied body scopes ARE the source.
-    scopeSource = devScopes ?? [];
-  }
-
-  // CLAMP — the IDENTICAL audited belt: TUNNEL allowlist (no apps:storage:*), no
-  // OAuth ceiling (`oauthAllowed: null` — a pre-approval app has no OauthClient),
-  // keyCanSpend=true (spend is gated at RUNTIME, not by a bearer here). devScopes
-  // narrows (pending) / is the source (brand-new) inside the same belt.
-  const granted = clampDevScopes({
-    scopeSource,
-    oauthAllowed: null,
-    requestedScopes: devScopes,
-    keyCanSpend: true,
-    allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
-  });
+  // Re-clamp idempotently as defense-in-depth over the resolver's output (the
+  // authority boundary re-enforces the tunnel allowlist even if the stored/returned
+  // set were ever tampered). Never re-adds a stripped scope — the source lacks it.
+  const granted = clampTunnelDeclaredScopes(app.scopes);
   const buzzBudget = resolveDevBuzzBudget(granted);
 
   // SIGN — synthetic, non-resolving ids (`ephemeral-<slug>`), the client's page
@@ -441,6 +437,20 @@ async function tryDevTunnelScopedMint(args: {
     blockInstanceId,
     granted,
     buzzBudget,
+  });
+
+  // MINT-TIME AUDIT (dev-token.ts `blocks.dev-token.*-mint` parity): a synthetic
+  // `ephemeral-<slug>` app has NO durable AppBlock-backed row, so this structured
+  // event (Axiom/Loki-queryable, NEVER the token) is the forensic record of granting
+  // a (possibly spend-capable) dev token to an un-approved app. The runtime `bsi`
+  // row records the later SPEND invocation — this records the GRANT decision.
+  req.log?.info('app-blocks.dev-tunnel.mint', {
+    mode: app.ephemeralSource,
+    userId,
+    slug,
+    sessionId: tunnel?.sessionId,
+    scopes: granted,
+    spendGranted: granted.includes('ai:write:budgeted'),
   });
 
   res.setHeader('Cache-Control', 'no-store');
@@ -596,13 +606,13 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       // mint (pre-approval ephemeral app the caller OWNS). Any non-match / refusal
       // returns 'continue' → the SAME bare 404 (no ownership/existence oracle).
       const devMint = await tryDevTunnelScopedMint({
+        req,
         res,
         appBlockId,
         blockInstanceId,
         slotId: slotContext.slotId,
         sessionUser: session?.user,
         userId,
-        devScopes: parsed.data.devScopes,
       });
       if (devMint === 'handled') return;
       // Missing / not-approved / not-a-page app → 404 (never leaks which).

--- a/src/pages/apps/dev/[blockId].tsx
+++ b/src/pages/apps/dev/[blockId].tsx
@@ -63,7 +63,9 @@ export const getServerSideProps = createServerSideProps<DevTunnelProps>({
         },
       };
     }
-    const { isAppBlocksDevTunnelEnabled } = await import('~/server/services/app-blocks-flag');
+    const { isAppBlocksDevTunnelEnabled, isAppBlocksDevTunnelUnsubmittedSpendEnabled } = await import(
+      '~/server/services/app-blocks-flag'
+    );
     if (!(await isAppBlocksDevTunnelEnabled({ user }))) {
       return { notFound: true };
     }
@@ -73,12 +75,11 @@ export const getServerSideProps = createServerSideProps<DevTunnelProps>({
       typeof rawBlockId === 'string' ? rawBlockId : Array.isArray(rawBlockId) ? rawBlockId[0] : '';
     if (!blockId) return { notFound: true };
 
-    // Ownership-scoped resolve (any status). null for a foreign/absent app → the
-    // SAME notFound (no oracle). This can NEVER resolve a deployed bundle host.
-    const app = await BlockRegistry.resolveDevPageBlockForAuthor(blockId, user.id);
-    if (!app) return { notFound: true };
-
-    // Resolve the caller's active tunnel for this block (started by the CLI).
+    // Resolve the caller's active tunnel FIRST — a BRAND-NEW (unsubmitted) app's
+    // `declaredScopes` come from the session's CLI-declared `grantedScopes`, gated by
+    // the dedicated unsubmitted-spend flag. Passing both into the resolver keeps the
+    // block's advertised `declaredScopes` byte-identical to what the block-token mint
+    // will grant (both derive from `resolveDevPageBlockForAuthor`).
     const { getActiveDevTunnel } = await import('~/server/services/blocks/dev-tunnel.service');
     const { signDevTunnelAccessToken, isValidDevHost } = await import(
       '~/server/services/blocks/dev-tunnel-session'
@@ -86,6 +87,15 @@ export const getServerSideProps = createServerSideProps<DevTunnelProps>({
     const { env } = await import('~/env/server');
 
     const tunnel = await getActiveDevTunnel(user.id, blockId);
+    const unsubmittedSpendAllowed = await isAppBlocksDevTunnelUnsubmittedSpendEnabled({ user });
+
+    // Ownership-scoped resolve (any status). null for a foreign/absent app → the
+    // SAME notFound (no oracle). This can NEVER resolve a deployed bundle host.
+    const app = await BlockRegistry.resolveDevPageBlockForAuthor(blockId, user.id, {
+      sessionGrantedScopes: tunnel?.grantedScopes,
+      unsubmittedSpendAllowed,
+    });
+    if (!app) return { notFound: true };
 
     let iframeSrc: string | null = null;
     let host: string | null = null;

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1011,6 +1011,13 @@ export const blocksRouter = router({
         // determined caller can't push parse pressure; a real ed25519/rsa pubkey
         // is well under 2kb.
         sshPublicKey: z.string().min(1).max(4096),
+        // App Dev Tunnel — the caller's local `block.manifest.json` scopes, sent by
+        // the CLI. Stored (clamped) on the session so an UNSUBMITTED (no-pending-row)
+        // app can mint a dev token carrying them. NOT an authz input: the proc has
+        // already gated author + ownership + flags; these are clamped to the tunnel
+        // allowlist at write + re-gated (incl. the dedicated unsubmitted-spend flag)
+        // at the mint. Bounded to blunt parse pressure; absent → read-only.
+        declaredScopes: z.array(z.string().min(1).max(64)).max(32).optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -1064,6 +1071,10 @@ export const blocksRouter = router({
           // value makes that independent of input normalization.
           blockId: app.blockId,
           sshPublicKey: input.sshPublicKey,
+          // Self-declared local-manifest scopes (bounded above). Clamped to the
+          // tunnel allowlist at write; the mint re-gates spend behind the dedicated
+          // unsubmitted-spend flag. An old CLI omits this → read-only session.
+          declaredScopes: input.declaredScopes,
         });
       } catch (err) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });

--- a/src/server/services/__tests__/block-registry.resolve-dev.test.ts
+++ b/src/server/services/__tests__/block-registry.resolve-dev.test.ts
@@ -90,7 +90,10 @@ describe('BlockRegistry.resolveDevPageBlockForAuthor', () => {
     expect(res).not.toBeNull();
     expect(res?.status).toBe('ephemeral');
     expect(res?.trustTier).toBe('unverified');
-    expect(res?.scopes).toEqual([]); // brand-new (no pending row) declares scopes via the mint body
+    // Brand-new with NO tunnel session (opts omitted) → clampTunnelDeclaredScopes([])
+    // force-adds only the self-bound read scope; no spend without a declared session.
+    expect(res?.scopes).toEqual(['user:read:self']);
+    expect(res?.ephemeralSource).toBe('brand-new');
     expect(res?.contentRating).toBeNull(); // SFW default
     expect(res?.sandbox).toBe('allow-scripts allow-forms');
     expect(res?.blockId).toBe('brand-new');
@@ -161,6 +164,86 @@ describe('BlockRegistry.resolveDevPageBlockForAuthor', () => {
     // Clamp = TUNNEL allowlist − PAGE_FORBIDDEN, + force-granted user:read:self, sorted.
     // buzz:read:self / social:tip:self are page-forbidden; not:a:scope is unknown.
     expect(res?.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+    expect(res?.ephemeralSource).toBe('pending');
+  });
+
+  it('(f) BRAND-NEW + session grantedScopes + unsubmittedSpendAllowed → surfaces the budgeted scope', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('brand-new', 555, {
+      sessionGrantedScopes: ['ai:write:budgeted'],
+      unsubmittedSpendAllowed: true,
+    });
+    expect(res?.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+    expect(res?.ephemeralSource).toBe('brand-new');
+  });
+
+  it('(g) BRAND-NEW + session scopes but the unsubmitted-spend FLAG OFF → strips ai:write:budgeted (read-only)', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('brand-new', 555, {
+      sessionGrantedScopes: ['ai:write:budgeted'],
+      unsubmittedSpendAllowed: false,
+    });
+    expect(res?.scopes).toEqual(['user:read:self']);
+    expect(res?.scopes).not.toContain('ai:write:budgeted');
+    expect(res?.ephemeralSource).toBe('brand-new');
+  });
+
+  it('(h) BRAND-NEW clamps forbidden / non-allowlisted / unknown scopes out of the session set', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('brand-new', 555, {
+      sessionGrantedScopes: ['ai:write:budgeted', 'apps:storage:write', 'social:tip:self', 'not:a:scope'],
+      unsubmittedSpendAllowed: true,
+    });
+    // apps:storage:* not in the tunnel allowlist; social:tip:self page-forbidden;
+    // not:a:scope unknown — all stripped, self-read force-added.
+    expect(res?.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+  });
+
+  it('(i) SECURITY: a FOREIGN CLAIMED slug returns null EVEN WITH session spend scopes (ownership precedes scopes)', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue({ id: 'apb_someone_else' });
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('their-app', 555, {
+      sessionGrantedScopes: ['ai:write:budgeted'],
+      unsubmittedSpendAllowed: true,
+    });
+    expect(res).toBeNull();
+    // Refused at guard (A) — session scopes can NEVER cause a foreign slug to resolve.
+    expect(mockDbRead.appBlockPublishRequest.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('(j) SECURITY: a FOREIGN PENDING slug returns null even with session spend scopes', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({ submittedByUserId: 999 });
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('someone-pending', 555, {
+      sessionGrantedScopes: ['ai:write:budgeted'],
+      unsubmittedSpendAllowed: true,
+    });
+    expect(res).toBeNull();
+  });
+
+  it('(k) a PENDING app IGNORES the session scopes AND the unsubmitted-spend flag (grants from its OWN manifest)', async () => {
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockDbRead.appBlock.findUnique.mockResolvedValue(null);
+    mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({
+      submittedByUserId: 555,
+      manifest: { scopes: ['ai:write:budgeted'] },
+    });
+    const res = await BlockRegistry.resolveDevPageBlockForAuthor('my-pending', 555, {
+      // Both IGNORED for the pending path — an app that IS submitted is not gated by
+      // the unsubmitted-spend flag, and its scope source is the pending manifest.
+      sessionGrantedScopes: ['models:read:self'],
+      unsubmittedSpendAllowed: false,
+    });
+    expect(res?.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+    expect(res?.scopes).not.toContain('models:read:self');
+    expect(res?.ephemeralSource).toBe('pending');
   });
 
   it('(d3) an owned-pending app that declares NO money scope stays read-only (no over-grant)', async () => {

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -419,6 +419,18 @@ export async function isAppBlocksDevTunnelEnabled(opts?: {
  * to `isAppBlocksDevTunnelEnabled`. Fail-closed: absent flag / Flipt-down → `false`
  * → no unsubmitted spend for anyone (mods included), so the as-merged posture is
  * dark until the flag is created in Flipt.
+ *
+ * SCOPE OF THE KILL (by design — kills NEW grants, not in-flight tokens): this is
+ * checked at MINT time (block-token mint + `/apps/dev` SSR), NOT re-checked per
+ * spend at `submitWorkflow`. A dev token minted while this flag was ON therefore
+ * retains `ai:write:budgeted` for its ≤4h `dev` TTL after a flip to OFF. That window
+ * is bounded by the self-bound spend (author's OWN Buzz only) + the per-call
+ * (DEV_BUZZ_BUDGET_CAP) / per-session (DEV_TUNNEL_SESSION_BUZZ_CAP) / per-user-daily
+ * caps, and `app-blocks-author` provides a RUNTIME full-kill for a bad actor (its
+ * re-check runs at submit). If instant SURGICAL revocation of just this surface is
+ * ever needed, add a per-spend re-check here in the `claims.dev` branch of
+ * `submitWorkflow` (gated on a brand-new discriminator so pending/approved spend is
+ * untouched). Accepted trade at ship: the caps + 4h TTL + author-flag kill suffice.
  */
 export const APP_BLOCKS_DEV_TUNNEL_UNSUBMITTED_SPEND_FLAG =
   'app-blocks-dev-tunnel-unsubmitted-spend';

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -406,6 +406,36 @@ export async function isAppBlocksDevTunnelEnabled(opts?: {
 }
 
 /**
+ * DEDICATED kill-switch for the HIGHEST-risk dev-tunnel surface: granting REAL
+ * (self-capped) Buzz-spend (`ai:write:budgeted`) to an UNSUBMITTED app — one that
+ * has NEVER been through review (no publish request). Deliberately SEPARATE from
+ * `app-blocks-dev-tunnel` so ops can kill "real Buzz on an unreviewed app" WITHOUT
+ * disabling all tunnel dev (render/HMR/pending-app testing stay up). When OFF, the
+ * brand-new (no-pending-row) dev-tunnel mint + SSR strip `ai:write:budgeted` from
+ * the granted set → the app resolves READ-ONLY (still renders, just can't spend).
+ * The PENDING (submitted-but-unapproved) and APPROVED tunnel paths are unaffected.
+ *
+ * Evaluated WITH the caller's context (mod/cohort segments), identical eval shape
+ * to `isAppBlocksDevTunnelEnabled`. Fail-closed: absent flag / Flipt-down → `false`
+ * → no unsubmitted spend for anyone (mods included), so the as-merged posture is
+ * dark until the flag is created in Flipt.
+ */
+export const APP_BLOCKS_DEV_TUNNEL_UNSUBMITTED_SPEND_FLAG =
+  'app-blocks-dev-tunnel-unsubmitted-spend';
+
+export async function isAppBlocksDevTunnelUnsubmittedSpendEnabled(opts?: {
+  user?: SessionUser;
+}): Promise<boolean> {
+  if (!opts?.user) return isFlipt(APP_BLOCKS_DEV_TUNNEL_UNSUBMITTED_SPEND_FLAG);
+  const user = opts.user;
+  return isFlipt(
+    APP_BLOCKS_DEV_TUNNEL_UNSUBMITTED_SPEND_FLAG,
+    String(user.id),
+    buildFliptContext(user)
+  );
+}
+
+/**
  * Dedicated GLOBAL fail-closed flag for the attribution BACKPAY reader
  * (W3 attribution back-half — Slice 4 read leg, see backpay.service.ts).
  *

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -11,10 +11,7 @@ import {
   validateBlockCheckpoint,
 } from '~/server/services/blocks/checkpoint.service';
 import { validateBlockSettings } from '~/server/services/blocks/settings-validator.service';
-import {
-  clampDevScopes,
-  TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
-} from '~/server/services/blocks/dev-scoped-mint.service';
+import { clampTunnelDeclaredScopes } from '~/server/services/blocks/dev-scoped-mint.service';
 import {
   newBlockInstanceId,
   newBlockUserSubscriptionId,
@@ -453,6 +450,11 @@ export interface DevPageBlockResolution {
   sandbox: string;
   scopes: string[];
   contentRating: string | null;
+  /** For an `ephemeral` resolution only: which scope source produced `scopes` —
+   *  `'pending'` (the caller's own submitted-but-unapproved manifest) or
+   *  `'brand-new'` (a truly-unclaimed slug, scopes from the dev-tunnel session).
+   *  Undefined for the owned-approved path. Used for the mint-time audit log. */
+  ephemeralSource?: 'pending' | 'brand-new';
 }
 
 interface UninstallOpts {
@@ -1865,7 +1867,18 @@ export class BlockRegistry {
   static async resolveDevPageBlockForAuthor(
     blockId: string,
     userId: number,
-    opts?: { db?: 'read' | 'write' }
+    opts?: {
+      db?: 'read' | 'write';
+      /** BRAND-NEW (no pending row) scope source: the caller's dev-tunnel session's
+       *  clamped `grantedScopes` (from their local `block.manifest.json`, sent by the
+       *  CLI at tunnel start). Ignored for the pending (own submission → server-read
+       *  manifest) and owned-approved paths. Absent → brand-new resolves read-only. */
+      sessionGrantedScopes?: string[];
+      /** Whether the dedicated `app-blocks-dev-tunnel-unsubmitted-spend` flag is ON
+       *  for the caller. When false, the BRAND-NEW branch strips `ai:write:budgeted`
+       *  (renders read-only). Fail-closed default (false). No effect on pending. */
+      unsubmittedSpendAllowed?: boolean;
+    }
   ): Promise<DevPageBlockResolution | null> {
     if (!blockId || !userId) return null;
     const db = opts?.db === 'write' ? dbWrite : dbRead;
@@ -1887,7 +1900,11 @@ export class BlockRegistry {
     // No OWNED AppBlock row → try the ephemeral pre-submit resolution (Phase 1).
     // resolveEphemeralDevPageBlock returns null (→ same bare NOT_FOUND, no oracle)
     // for a slug claimed by anyone else, so a foreign-owned app is never leaked.
-    if (!ab) return this.resolveEphemeralDevPageBlock(blockId, userId, db);
+    if (!ab)
+      return this.resolveEphemeralDevPageBlock(blockId, userId, db, {
+        sessionGrantedScopes: opts?.sessionGrantedScopes,
+        unsubmittedSpendAllowed: opts?.unsubmittedSpendAllowed,
+      });
     const manifest = (ab.manifest ?? {}) as Record<string, unknown>;
     const iframe = (manifest.iframe ?? {}) as { sandbox?: unknown };
     const page = (manifest.page ?? {}) as { title?: unknown };
@@ -1969,7 +1986,8 @@ export class BlockRegistry {
   private static async resolveEphemeralDevPageBlock(
     blockId: string,
     userId: number,
-    db: typeof dbRead | typeof dbWrite
+    db: typeof dbRead | typeof dbWrite,
+    opts?: { sessionGrantedScopes?: string[]; unsubmittedSpendAllowed?: boolean }
   ): Promise<DevPageBlockResolution | null> {
     // Guard (C): reject a non-CANONICAL slug BEFORE any DB read (same bare null,
     // no oracle). Canonical = the exact constraint submit enforces on
@@ -1997,29 +2015,37 @@ export class BlockRegistry {
     });
     if (pending && pending.submittedByUserId !== userId) return null;
     // SCOPE SOURCE — the declared scopes the dev-page host surfaces to the block as
-    // `declaredScopes` (→ the block's `granted` UI state). For the SUBMITTED-PENDING
-    // case (the caller owns `pending`) mirror the block-token Phase-2 mint EXACTLY:
-    // clamp the pending submission's un-reviewed `manifest.scopes` through the SAME
-    // audited belt (`clampDevScopes` + `TUNNEL_HOST_MINT_SCOPE_ALLOWLIST`, no OAuth
-    // ceiling, keyCanSpend=true). This ALIGNS the host's declared set with the scopes
-    // the mint actually stamps on the JWT — without it (the pre-Phase-2 hardcoded
-    // `[]`) the block's Generate gate reads an empty granted set and hangs on
-    // "Grant access to generate" while the JWT it holds already carries the budgeted
-    // spend scope. NO new authority: the mint re-clamps + the runtime author-flag and
-    // per-call/session/day Buzz caps remain the actual spend gates. The BRAND-NEW
-    // (no-`pending`) case stays `[]` — those apps self-declare via the mint body.
+    // `declaredScopes` (→ the block's `granted` UI state) AND the block-token mint
+    // uses as the JWT's granted set (both consume the SAME `clampTunnelDeclaredScopes`
+    // so they can NEVER diverge). Two ephemeral cases:
+    //
+    //   • SUBMITTED-PENDING (the caller owns `pending`): clamp the pending
+    //     submission's SERVER-READ, un-reviewed `manifest.scopes`. Without this the
+    //     block's Generate gate reads empty and hangs on "Grant access" while the JWT
+    //     already carries the budgeted scope (the pre-#2992 bug). NOT gated by the
+    //     unsubmitted-spend flag — the app IS submitted.
+    //   • BRAND-NEW (no pending row, truly-unclaimed slug the caller owns): the scope
+    //     source is the AUTHENTICATED CLI's dev-tunnel session (`sessionGrantedScopes`,
+    //     already clamped at write) — NEVER a browser body. When the dedicated
+    //     `app-blocks-dev-tunnel-unsubmitted-spend` flag is OFF for the caller, strip
+    //     `ai:write:budgeted` so a never-reviewed app renders READ-ONLY (fail-closed).
+    //
+    // NO new authority either way: the belt (TUNNEL allowlist, no OAuth ceiling,
+    // keyCanSpend=true) is identical; the runtime author-flag re-check + per-call /
+    // per-session / per-day Buzz caps remain the actual spend gates.
     let ephemeralScopes: string[] = [];
+    const ephemeralSource: 'pending' | 'brand-new' = pending ? 'pending' : 'brand-new';
     if (pending) {
       const pendingManifest = (pending.manifest ?? {}) as { scopes?: unknown };
       const declared = Array.isArray(pendingManifest.scopes)
         ? pendingManifest.scopes.filter((s): s is string => typeof s === 'string')
         : [];
-      ephemeralScopes = clampDevScopes({
-        scopeSource: declared,
-        oauthAllowed: null,
-        keyCanSpend: true,
-        allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
-      });
+      ephemeralScopes = clampTunnelDeclaredScopes(declared);
+    } else {
+      ephemeralScopes = clampTunnelDeclaredScopes(opts?.sessionGrantedScopes ?? []);
+      if (!opts?.unsubmittedSpendAllowed) {
+        ephemeralScopes = ephemeralScopes.filter((s) => s !== 'ai:write:budgeted');
+      }
     }
     // ALLOWED — truly-unclaimed slug, or the caller owns the pending request.
     return {
@@ -2037,10 +2063,11 @@ export class BlockRegistry {
       // Minimal safe sandbox for an unverified tier (client intersectSandbox
       // re-clamps to the allowlist ∪ MINIMAL_SANDBOX regardless).
       sandbox: 'allow-scripts allow-forms',
-      // The caller's-own-pending declared scopes, clamped to the tunnel belt (see
-      // above); `[]` for a truly-unclaimed brand-new slug. Aligned with the Phase-2
+      // Clamped tunnel scopes: the own-pending server-read manifest (pending) or the
+      // CLI-declared session scopes (brand-new, flag-gated). Aligned with the
       // block-token mint so the dev-page block's Generate gate is not falsely empty.
       scopes: ephemeralScopes,
+      ephemeralSource,
       // SFW default — no reviewed content rating exists pre-submit.
       contentRating: null,
     };

--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -293,6 +293,67 @@ describe('startDevTunnel', () => {
     expect(mockK8sFetch).not.toHaveBeenCalled();
     expect(sysRedis.set).not.toHaveBeenCalled();
   });
+
+  const readSession = () =>
+    JSON.parse(sysRedis._store.get('system:blocks:dev-tunnel:session:bki_testsession')!);
+
+  it('stores the CLI-declared scopes RAW (forensics) + a CLAMPED grantedScopes on the session', async () => {
+    await startDevTunnel({
+      userId: 555,
+      blockId: 'my-app',
+      sshPublicKey: PUBKEY,
+      // apps:storage:* is NOT in the tunnel allowlist — the clamp must strip it from
+      // grantedScopes, but the raw declaredScopes keeps it for "what did the dev ask".
+      declaredScopes: ['ai:write:budgeted', 'apps:storage:write'],
+    });
+    const s = readSession();
+    expect(s.declaredScopes).toEqual(['ai:write:budgeted', 'apps:storage:write']);
+    // grantedScopes = clampTunnelDeclaredScopes → storage stripped, self-read added, sorted.
+    expect(s.grantedScopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+  });
+
+  it('absent declaredScopes → empty raw declared + read-only granted (user:read:self)', async () => {
+    await startDevTunnel({ userId: 555, blockId: 'my-app', sshPublicKey: PUBKEY });
+    const s = readSession();
+    expect(s.declaredScopes).toEqual([]);
+    expect(s.grantedScopes).toEqual(['user:read:self']);
+  });
+
+  it('SANITIZES declaredScopes: drops non-strings + empties + over-64-char, trims, dedupes', async () => {
+    await startDevTunnel({
+      userId: 555,
+      blockId: 'my-app',
+      sshPublicKey: PUBKEY,
+      declaredScopes: [
+        '  ai:write:budgeted  ', // trimmed
+        'ai:write:budgeted', // duplicate → collapsed
+        '', // empty → dropped
+        'x'.repeat(80), // over 64 chars → dropped
+        123 as unknown as string, // non-string → dropped
+        null as unknown as string, // non-string → dropped
+      ],
+    });
+    const s = readSession();
+    expect(s.declaredScopes).toEqual(['ai:write:budgeted']); // trimmed, deduped, junk removed
+    expect(s.declaredScopes.every((x: unknown) => typeof x === 'string' && (x as string).length <= 64)).toBe(
+      true
+    );
+    expect(s.grantedScopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+  });
+
+  it('CAPS declaredScopes at 32 distinct entries', async () => {
+    const forty = Array.from({ length: 40 }, (_, i) => `zz-scope-${i}`);
+    await startDevTunnel({
+      userId: 555,
+      blockId: 'my-app',
+      sshPublicKey: PUBKEY,
+      declaredScopes: forty,
+    });
+    const s = readSession();
+    expect(s.declaredScopes.length).toBe(32);
+    // All are unknown scopes → clamp strips them → only the force-added self-read.
+    expect(s.grantedScopes).toEqual(['user:read:self']);
+  });
 });
 
 describe('buildDevTunnelApplyJob (F1 — renders via the scoped apps-applier SA)', () => {

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -152,6 +152,28 @@ export function clampDevScopes(opts: {
 }
 
 /**
+ * App Dev Tunnel — the SINGLE clamp for a dev-tunnel session's self-declared
+ * (`block.manifest.json`) scopes: the fixed TUNNEL belt (no OAuth ceiling — a
+ * pre-approval app has no OauthClient; `keyCanSpend: true` — spend is gated at
+ * RUNTIME by the author-flag re-check + the dev/session/day Buzz caps, not a bearer
+ * here). Used by BOTH the SSR `declaredScopes` surface (block-registry) AND the
+ * on-site block-token mint, so the block's advertised `granted` set and the JWT's
+ * actual scopes derive from ONE function and can NEVER drift apart. Idempotent —
+ * safe to re-apply to an already-clamped stored set (defense-in-depth over the
+ * clamp-at-write in `startDevTunnel`). NO `requestedScopes` narrowing: the tunnel
+ * scope source is the AUTHENTICATED CLI's session, never a browser body, so there
+ * is no legitimate browser-side narrowing input (and thus no body→source foot-gun).
+ */
+export function clampTunnelDeclaredScopes(scopeSource: string[]): string[] {
+  return clampDevScopes({
+    scopeSource,
+    oauthAllowed: null,
+    keyCanSpend: true,
+    allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+  });
+}
+
+/**
  * BUDGET CAP (dev-token.ts step 8). Only meaningful when `ai:write:budgeted`
  * survived the clamp. Clamp the requested budget (or the default) to the LOWER dev
  * cap; `undefined` when no spend scope was granted.

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -18,6 +18,13 @@ import {
   recordDevTunnelTeardown,
   type DevTunnelTeardownReason,
 } from '~/server/prom/dev-tunnel.metrics';
+import { clampTunnelDeclaredScopes } from '~/server/services/blocks/dev-scoped-mint.service';
+
+/** App Dev Tunnel — bounds on the self-declared scope list stored on a session
+ *  (defense-in-depth over the tRPC zod input bound; mirrors `block-tokens`'
+ *  `z.array(z.string().min(1).max(64)).max(32)`). */
+const DEV_TUNNEL_SCOPE_MAX_LEN = 64;
+const DEV_TUNNEL_SCOPE_MAX_COUNT = 32;
 
 /**
  * APP DEV TUNNEL — control-plane state + ephemeral Traefik route lifecycle.
@@ -85,6 +92,18 @@ export type DevTunnelSessionRecord = {
   createdAt: number; // unix seconds
   hardExpiresAt: number; // unix seconds
   spendCapBuzz: number;
+  /** App Dev Tunnel — the self-declared scopes the CLI sent from the local
+   *  `block.manifest.json` at tunnel start (raw-but-bounded; kept for forensics /
+   *  "what did the dev declare"). NOT authoritative on its own — readers consume
+   *  `grantedScopes`. ABSENT on an old-CLI session → treated as `[]`. */
+  declaredScopes?: string[];
+  /** App Dev Tunnel — `clampTunnelDeclaredScopes(declaredScopes)`, clamped ONCE at
+   *  WRITE so an allowlist change can never retroactively widen a live session.
+   *  The AUTHORITATIVE scope source for an UNSUBMITTED (no-pending-row) app's dev
+   *  SSR `declaredScopes` + on-site mint. Readers re-clamp idempotently as
+   *  defense-in-depth. ABSENT on an old-CLI session → treated as `[]` (read-only,
+   *  no spend). */
+  grantedScopes?: string[];
   /** Last browser-activity marker (unix seconds), refreshed by the forwardAuth
    *  gate on each successful ENTRY-document hit (F3). The reaper reaps a session
    *  idle past DEV_TUNNEL_IDLE_SECONDS. ABSENT on a never-visited tunnel → the
@@ -700,6 +719,13 @@ export type StartDevTunnelParams = {
   blockId: string;
   /** The CLI's ephemeral SSH public key (raw OpenSSH line). */
   sshPublicKey: string;
+  /** App Dev Tunnel — the self-declared scopes from the caller's local
+   *  `block.manifest.json` (already zod-bounded by the tRPC input; sanitized again
+   *  here). Stored raw + clamped on the session so an UNSUBMITTED app can mint a
+   *  dev token carrying them. The caller (tRPC proc) has ALREADY gated author +
+   *  ownership + flags; these scopes are NOT an authz input — they are clamped to
+   *  the tunnel allowlist and re-gated at the mint. Omitted/absent → read-only. */
+  declaredScopes?: string[];
 };
 
 export type StartDevTunnelResult = {
@@ -739,6 +765,23 @@ export async function startDevTunnel(params: StartDevTunnelParams): Promise<Star
   const created = nowSec();
   const hardExpiresAt = created + DEV_TUNNEL_HARD_SECONDS;
 
+  // App Dev Tunnel — sanitize the self-declared scopes (defense-in-depth over the
+  // tRPC zod bound): strings only, trimmed, deduped, capped. Then clamp ONCE at
+  // WRITE (`clampTunnelDeclaredScopes`) so the stored `grantedScopes` is what every
+  // reader grants — an allowlist change can never retroactively widen a live
+  // session, and a reader that forgets to re-clamp still gets an already-safe set.
+  const declaredScopes = Array.isArray(params.declaredScopes)
+    ? Array.from(
+        new Set(
+          params.declaredScopes
+            .filter((s): s is string => typeof s === 'string')
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0 && s.length <= DEV_TUNNEL_SCOPE_MAX_LEN)
+        )
+      ).slice(0, DEV_TUNNEL_SCOPE_MAX_COUNT)
+    : [];
+  const grantedScopes = clampTunnelDeclaredScopes(declaredScopes);
+
   const session: DevTunnelSessionRecord = {
     sessionId,
     userId: params.userId,
@@ -748,6 +791,8 @@ export async function startDevTunnel(params: StartDevTunnelParams): Promise<Star
     createdAt: created,
     hardExpiresAt,
     spendCapBuzz: DEV_TUNNEL_SESSION_BUZZ_CAP,
+    declaredScopes,
+    grantedScopes,
     // Seed the idle marker at mint so a never-visited tunnel still idle-reaps
     // (createdAt fallback in the reaper covers an absent field too).
     lastActivityAt: created,
@@ -938,11 +983,13 @@ export type ReserveDevSessionBuzzResult = { allowed: boolean; total: number };
  * DEV_BUZZ_BUDGET_CAP + the per-user daily cap; the author still spends only
  * their OWN Buzz.
  *
- * ⚠️ NOT WIRED in P1 — dev-session Buzz is NOT capped yet. This tested primitive
- * has NO live call site: it is enforced at workflow-submit in P3 once the block
- * token carries a dev-session id. Real dev spend TODAY rides the existing
- * `/api/v1/blocks/dev-token` real-Buzz clamp (DEV_BUZZ_BUDGET_CAP + the per-user
- * daily cap), NOT this per-session ceiling. Do NOT assume this backstop is active.
+ * WIRED (P3): enforced at workflow-submit in `blocks.router.ts` — the submit path
+ * resolves the caller's active tunnel via `getActiveDevTunnel(userId, blockId)` and
+ * calls this with the session's `spendCapBuzz` (no dev-session id needs to ride the
+ * JWT — the server re-derives it from (userId, blockId)). So this per-session
+ * ceiling IS active for on-site dev-tunnel spend, stacking under the block-token
+ * `DEV_BUZZ_BUDGET_CAP` (per call) + the per-user daily cap. The author still spends
+ * only their OWN Buzz.
  */
 export async function reserveDevSessionBuzz(
   sessionId: string,

--- a/src/tests/api/v1/block-tokens/dev-tunnel-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/dev-tunnel-mint.test.ts
@@ -6,13 +6,16 @@ import type { NextApiRequest, NextApiResponse } from 'next';
  *
  * When `resolvePageBlock` misses (a PRE-APPROVAL ephemeral app), the cookie-authed
  * AUTHOR who OWNS the app mints a SCOPED, forced-SFW, self-bound, budget-capped dev
- * token so real Buzz-spend generation works pre-approval. Asserts:
- *   - OWN pending submission → scope source = server-read manifest.scopes,
- *   - OWN brand-new (no pending) → scope source = self-declared body devScopes,
- *   - App Storage scope is STRIPPED (Decision 1),
+ * token so real Buzz-spend generation works pre-approval. The RESOLVER is the single
+ * scope authority (`app.scopes`); the mint re-clamps + signs it. Asserts:
+ *   - grant = clampTunnelDeclaredScopes(resolver scopes); App Storage STRIPPED,
+ *   - the BRAND-NEW scope decision comes from the SESSION + the unsubmitted-spend
+ *     flag (passed to the resolver) — NEVER a request body,
+ *   - the unsubmitted-spend flag OFF → read-only (no spend),
+ *   - the app-blocks.dev-tunnel.mint audit event fires (never the token),
  *   - the synthetic non-resolving ids + forced-SFW + dev:true are signed,
  *   - foreign / approved-elsewhere (resolver → null) → the SAME bare 404, no token,
- *   - the dev-tunnel kill-switch OFF → 404 (no mint),
+ *   - the dev-tunnel kill-switch OFF → 404 (no mint, before any session/scope read),
  *   - a resolved non-ephemeral status → 404 (fail-closed).
  */
 
@@ -24,6 +27,7 @@ const {
   mockBlockRegistry,
   mockFlags,
   mockAppBlocksFlag,
+  mockDevTunnelService,
 } = vi.hoisted(() => {
   const dbWrite = {
     user: {
@@ -65,6 +69,15 @@ const {
   const appBlocksFlag = {
     isAppBlocksAuthorEnabled: vi.fn(async () => true),
     isAppBlocksDevTunnelEnabled: vi.fn(async () => true),
+    isAppBlocksDevTunnelUnsubmittedSpendEnabled: vi.fn(async () => true),
+  };
+  // The mint reads the caller's dev-tunnel session (server-stored, CLI-declared) as
+  // the BRAND-NEW scope source — never a browser body.
+  const devTunnelService = {
+    getActiveDevTunnel: vi.fn<(...args: any[]) => Promise<any>>(async () => ({
+      sessionId: 'bki_testsession',
+      grantedScopes: ['ai:write:budgeted', 'user:read:self'],
+    })),
   };
   return {
     mockDbWrite: dbWrite,
@@ -74,6 +87,7 @@ const {
     mockBlockRegistry: blockRegistry,
     mockFlags: flags,
     mockAppBlocksFlag: appBlocksFlag,
+    mockDevTunnelService: devTunnelService,
   };
 });
 
@@ -104,6 +118,7 @@ vi.mock('~/server/utils/server-domain', () => ({
 }));
 vi.mock('~/server/services/feature-flags.service', () => mockFlags);
 vi.mock('~/server/services/app-blocks-flag', () => mockAppBlocksFlag);
+vi.mock('~/server/services/blocks/dev-tunnel.service', () => mockDevTunnelService);
 
 function makeReq(body: unknown): NextApiRequest {
   return {
@@ -146,7 +161,9 @@ function makeRes() {
 const MOD = { user: { id: 4242, isModerator: true, bannedAt: null } };
 
 // The ephemeral resolution BlockRegistry.resolveDevPageBlockForAuthor returns for
-// an OWNED pre-approval app (synthetic, non-resolving ids; empty display scopes).
+// an OWNED pre-approval app. The resolver is the SINGLE scope authority — `scopes`
+// is the clamped granted set (pending manifest OR session-declared). The mint
+// re-clamps `app.scopes` and signs it; there is NO body scope source.
 const EPHEMERAL_RESOLUTION = {
   appBlockId: 'ephemeral-my-app',
   appId: 'ephemeral-my-app',
@@ -156,7 +173,8 @@ const EPHEMERAL_RESOLUTION = {
   name: 'my-app',
   pageTitle: 'my-app',
   sandbox: 'allow-scripts allow-forms',
-  scopes: [],
+  scopes: ['ai:write:budgeted', 'user:read:self'],
+  ephemeralSource: 'brand-new',
   contentRating: null,
 };
 
@@ -204,21 +222,28 @@ describe('POST /api/v1/block-tokens — Phase 2 dev-tunnel author-own mint', () 
     mockBlockRegistry.resolvePageBlock.mockResolvedValue(null); // pre-approval miss
     mockBlockRegistry.resolveDevPageBlockForAuthor.mockResolvedValue(EPHEMERAL_RESOLUTION);
     mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: null, bannedAt: null });
-    mockDbWrite.appBlockPublishRequest.findFirst.mockResolvedValue(null);
     mockAppBlocksFlag.isAppBlocksAuthorEnabled.mockResolvedValue(true);
     mockAppBlocksFlag.isAppBlocksDevTunnelEnabled.mockResolvedValue(true);
+    mockAppBlocksFlag.isAppBlocksDevTunnelUnsubmittedSpendEnabled.mockResolvedValue(true);
+    mockDevTunnelService.getActiveDevTunnel.mockResolvedValue({
+      sessionId: 'bki_testsession',
+      grantedScopes: ['ai:write:budgeted', 'user:read:self'],
+    });
   });
 
-  it('OWN pending submission → mints a scoped token from the SERVER-READ manifest scopes (App Storage STRIPPED)', async () => {
-    mockDbWrite.appBlockPublishRequest.findFirst.mockResolvedValue({
-      manifest: { scopes: ['ai:write:budgeted', 'apps:storage:read', 'apps:storage:write'] },
+  it('mints a scoped token by RE-CLAMPING the resolver-supplied scopes (App Storage stripped, self-read added)', async () => {
+    // The resolver is the single scope authority; the mint re-clamps `app.scopes`
+    // as defense-in-depth. A resolution carrying storage/junk → clamp strips it.
+    mockBlockRegistry.resolveDevPageBlockForAuthor.mockResolvedValue({
+      ...EPHEMERAL_RESOLUTION,
+      scopes: ['ai:write:budgeted', 'apps:storage:read', 'apps:storage:write'],
+      ephemeralSource: 'pending',
     });
     const res = await invoke(DEV_BODY());
     expect(res._status).toBe(200);
     expect(res._body.token).toBe('jwt.dev.signed');
     expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
     const arg = mockTokenService.sign.mock.calls[0][0] as any;
-    // spend scope granted + user:read:self force-grant; App Storage stripped.
     expect(arg.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
     expect(arg.scopes).not.toContain('apps:storage:read');
     expect(arg.scopes).not.toContain('apps:storage:write');
@@ -230,55 +255,118 @@ describe('POST /api/v1/block-tokens — Phase 2 dev-tunnel author-own mint', () 
     expect(arg.appBlockId).toBe('ephemeral-my-app');
     expect(arg.blockInstanceId).toBe('page_ephemeral-my-app');
     expect(typeof arg.buzzBudget).toBe('number'); // budget set (spend granted)
-    // The pending lookup was ownership-scoped.
-    expect(mockDbWrite.appBlockPublishRequest.findFirst).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { slug: 'my-app', status: 'pending', submittedByUserId: MOD.user.id },
-      })
-    );
-    // Ownership resolved on the slug (not the raw appBlockId).
+  });
+
+  it('sources the BRAND-NEW scope decision from the SESSION + the flag (never the body): passes both to the resolver', async () => {
+    mockDevTunnelService.getActiveDevTunnel.mockResolvedValue({
+      sessionId: 'bki_testsession',
+      grantedScopes: ['ai:write:budgeted', 'user:read:self'],
+    });
+    mockAppBlocksFlag.isAppBlocksDevTunnelUnsubmittedSpendEnabled.mockResolvedValue(true);
+    // Junk body scopes MUST be ignored — there is no body scope source anymore.
+    const res = await invoke(DEV_BODY({ devScopes: ['apps:storage:write', 'social:tip:self'] }));
+    expect(res._status).toBe(200);
+    // The resolver was called with the SESSION's grantedScopes + the flag result —
+    // NOT anything from the request body.
     expect(mockBlockRegistry.resolveDevPageBlockForAuthor).toHaveBeenCalledWith(
       'my-app',
       MOD.user.id,
-      { db: 'write' }
+      expect.objectContaining({
+        db: 'write',
+        sessionGrantedScopes: ['ai:write:budgeted', 'user:read:self'],
+        unsubmittedSpendAllowed: true,
+      })
     );
-  });
-
-  it('OWN brand-new (no pending) → mints from SELF-DECLARED body devScopes', async () => {
-    mockDbWrite.appBlockPublishRequest.findFirst.mockResolvedValue(null);
-    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted', 'social:tip:self'] }));
-    expect(res._status).toBe(200);
+    // Grant == clamp(resolver scopes); the body's storage/tip never appear.
     const arg = mockTokenService.sign.mock.calls[0][0] as any;
-    // social:tip:self is out-of-allowlist + forbidden → stripped; spend kept.
     expect(arg.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+    expect(arg.scopes).not.toContain('apps:storage:write');
+    expect(arg.scopes).not.toContain('social:tip:self');
   });
 
-  it('OWN brand-new with NO scopes → a valid READ-ONLY token (no spend), still 200', async () => {
+  it('unsubmitted-spend FLAG OFF → the mint passes unsubmittedSpendAllowed:false; a read-only resolution mints no spend', async () => {
+    mockAppBlocksFlag.isAppBlocksDevTunnelUnsubmittedSpendEnabled.mockResolvedValue(false);
+    // With the flag off the resolver returns the stripped (read-only) set.
+    mockBlockRegistry.resolveDevPageBlockForAuthor.mockResolvedValue({
+      ...EPHEMERAL_RESOLUTION,
+      scopes: ['user:read:self'],
+      ephemeralSource: 'brand-new',
+    });
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(200);
+    expect(mockBlockRegistry.resolveDevPageBlockForAuthor).toHaveBeenCalledWith(
+      'my-app',
+      MOD.user.id,
+      expect.objectContaining({ unsubmittedSpendAllowed: false })
+    );
+    const arg = mockTokenService.sign.mock.calls[0][0] as any;
+    expect(arg.scopes).toEqual(['user:read:self']);
+    expect(arg.scopes).not.toContain('ai:write:budgeted');
+    expect(arg.buzzBudget).toBeUndefined(); // no spend granted → no budget
+  });
+
+  it('a resolver with NO scopes → a valid READ-ONLY token (no spend), still 200', async () => {
+    mockBlockRegistry.resolveDevPageBlockForAuthor.mockResolvedValue({
+      ...EPHEMERAL_RESOLUTION,
+      scopes: [],
+    });
     const res = await invoke(DEV_BODY());
     expect(res._status).toBe(200);
     const arg = mockTokenService.sign.mock.calls[0][0] as any;
-    expect(arg.scopes).toEqual(['user:read:self']);
+    expect(arg.scopes).toEqual(['user:read:self']); // clamp force-adds self-read
     expect(arg.buzzBudget).toBeUndefined();
+  });
+
+  it('emits the app-blocks.dev-tunnel.mint audit event (spendGranted reflects the grant), NEVER the token', async () => {
+    mockBlockRegistry.resolveDevPageBlockForAuthor.mockResolvedValue({
+      ...EPHEMERAL_RESOLUTION,
+      scopes: ['ai:write:budgeted', 'user:read:self'],
+      ephemeralSource: 'brand-new',
+    });
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const req = makeReq(DEV_BODY()) as any;
+    req.log = log;
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(200);
+    expect(log.info).toHaveBeenCalledWith(
+      'app-blocks.dev-tunnel.mint',
+      expect.objectContaining({
+        mode: 'brand-new',
+        userId: MOD.user.id,
+        slug: 'my-app',
+        sessionId: 'bki_testsession',
+        scopes: ['ai:write:budgeted', 'user:read:self'],
+        spendGranted: true,
+      })
+    );
+    // The audit payload must NOT carry the signed token/secret.
+    const payload = log.info.mock.calls.find((c: any[]) => c[0] === 'app-blocks.dev-tunnel.mint')![1];
+    expect(JSON.stringify(payload)).not.toContain('jwt.dev.signed');
   });
 
   it('foreign / already-claimed / absent app (resolver → null) → the SAME bare 404, NO token', async () => {
     mockBlockRegistry.resolveDevPageBlockForAuthor.mockResolvedValue(null);
-    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted'] }));
+    const res = await invoke(DEV_BODY());
     expect(res._status).toBe(404);
     expect(res._body).toEqual({ error: 'Page app not found' });
     expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
 
-  it('dev-tunnel kill-switch OFF → 404, NO token (defense-in-depth over the SSR gate)', async () => {
+  it('dev-tunnel kill-switch OFF → 404, NO token (before any session/scope read)', async () => {
     mockAppBlocksFlag.isAppBlocksDevTunnelEnabled.mockResolvedValue(false);
-    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted'] }));
+    const res = await invoke(DEV_BODY());
     expect(res._status).toBe(404);
     expect(mockTokenService.sign).not.toHaveBeenCalled();
+    // fail-closed BEFORE reading the tunnel session / resolving.
+    expect(mockDevTunnelService.getActiveDevTunnel).not.toHaveBeenCalled();
+    expect(mockBlockRegistry.resolveDevPageBlockForAuthor).not.toHaveBeenCalled();
   });
 
   it('author capability OFF → 404, NO token', async () => {
     mockAppBlocksFlag.isAppBlocksAuthorEnabled.mockResolvedValue(false);
-    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted'] }));
+    const res = await invoke(DEV_BODY());
     expect(res._status).toBe(404);
     expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
@@ -290,14 +378,14 @@ describe('POST /api/v1/block-tokens — Phase 2 dev-tunnel author-own mint', () 
       appBlockId: 'apb_real',
       appId: 'appblk-my-app',
     });
-    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted'] }));
+    const res = await invoke(DEV_BODY());
     expect(res._status).toBe(404);
     expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
 
   it('a soft-deleted account never mints (M1 parity)', async () => {
     mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: new Date(), bannedAt: null });
-    const res = await invoke(DEV_BODY({ devScopes: ['ai:write:budgeted'] }));
+    const res = await invoke(DEV_BODY());
     expect(res._status).toBe(404);
     expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
@@ -306,7 +394,7 @@ describe('POST /api/v1/block-tokens — Phase 2 dev-tunnel author-own mint', () 
     // setSameOriginCors (handler entry) rejects the request before the dev-tunnel
     // branch runs — the CSRF gate must fire ahead of any ownership/mint work, so a
     // forged cross-origin POST can neither mint a token nor touch the resolver.
-    const res = await invokeOrigin(DEV_BODY({ devScopes: ['ai:write:budgeted'] }), 'https://evil.example');
+    const res = await invokeOrigin(DEV_BODY(), 'https://evil.example');
     expect(res._status).toBe(403);
     expect(res._body).toEqual({ error: 'cross-origin POST rejected' });
     // Never reached the dev branch: no resolve, no sign, no ACAO for the bad origin.
@@ -316,7 +404,7 @@ describe('POST /api/v1/block-tokens — Phase 2 dev-tunnel author-own mint', () 
   });
 
   it('a null/absent-Origin POST is likewise 403 before the dev mint', async () => {
-    const res = await invokeOrigin(DEV_BODY({ devScopes: ['ai:write:budgeted'] }), null);
+    const res = await invokeOrigin(DEV_BODY(), null);
     expect(res._status).toBe(403);
     expect(res._body).toEqual({ error: 'cross-origin POST rejected' });
     expect(mockBlockRegistry.resolveDevPageBlockForAuthor).not.toHaveBeenCalled();

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -107,6 +107,7 @@ vi.mock('~/server/services/feature-flags.service', () => mockFlags);
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksAuthorEnabled: vi.fn(async () => false),
   isAppBlocksDevTunnelEnabled: vi.fn(async () => false),
+  isAppBlocksDevTunnelUnsubmittedSpendEnabled: vi.fn(async () => false),
 }));
 
 function makeReq(opts: {

--- a/src/tests/pages/apps/dev/dev-tunnel-page.test.ts
+++ b/src/tests/pages/apps/dev/dev-tunnel-page.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * APP DEV TUNNEL — `/apps/dev/[blockId]` SSR resolver.
@@ -30,11 +30,13 @@ vi.mock('~/server/utils/server-side-helpers', () => ({
   },
 }));
 
-const { mockResolveDev, mockResolvePageBySlug, mockGetActiveTunnel } = vi.hoisted(() => ({
-  mockResolveDev: vi.fn<(...a: any[]) => Promise<any>>(),
-  mockResolvePageBySlug: vi.fn<(...a: any[]) => Promise<any>>(),
-  mockGetActiveTunnel: vi.fn<(...a: any[]) => Promise<any>>(),
-}));
+const { mockResolveDev, mockResolvePageBySlug, mockGetActiveTunnel, mockUnsubmittedSpend } =
+  vi.hoisted(() => ({
+    mockResolveDev: vi.fn<(...a: any[]) => Promise<any>>(),
+    mockResolvePageBySlug: vi.fn<(...a: any[]) => Promise<any>>(),
+    mockGetActiveTunnel: vi.fn<(...a: any[]) => Promise<any>>(),
+    mockUnsubmittedSpend: vi.fn<(...a: any[]) => Promise<boolean>>(async () => true),
+  }));
 vi.mock('~/server/services/block-registry.service', () => ({
   BlockRegistry: {
     resolveDevPageBlockForAuthor: mockResolveDev,
@@ -43,6 +45,8 @@ vi.mock('~/server/services/block-registry.service', () => ({
 }));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksDevTunnelEnabled: vi.fn(async () => true),
+  isAppBlocksDevTunnelUnsubmittedSpendEnabled: (...a: unknown[]) =>
+    mockUnsubmittedSpend(...(a as [])),
 }));
 vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
   getActiveDevTunnel: (...a: unknown[]) => mockGetActiveTunnel(...(a as [])),
@@ -112,6 +116,11 @@ describe('/apps/dev/[blockId] SSR resolver', () => {
     process.env.NEXTAUTH_SECRET = SECRET;
     mockResolveDev.mockReset();
     mockGetActiveTunnel.mockReset();
+    mockUnsubmittedSpend.mockReset();
+    mockUnsubmittedSpend.mockResolvedValue(true);
+  });
+  afterAll(() => {
+    process.env.NEXTAUTH_SECRET = prev;
   });
 
   it('author + owner + active tunnel → iframeSrc set (server-derived host) + route-scoped CSP', async () => {
@@ -165,6 +174,68 @@ describe('/apps/dev/[blockId] SSR resolver', () => {
     const res = await resolver(makeCtx({ user: AUTHOR, setHeader: (k, v) => (headers[k] = v) }));
     expect(res.props.iframeSrc).toBeNull();
     expect(headers['Content-Security-Policy']).toBeUndefined();
+  });
+
+  it('BRAND-NEW: passes the session grantedScopes + unsubmitted-spend flag into the resolver, and surfaces its scopes as declaredScopes', async () => {
+    const resolver = await loadDevResolver();
+    // The resolver (mocked) is the single scope authority — SSR just forwards the
+    // session scopes + flag and reflects the returned `scopes` into the prop.
+    mockResolveDev.mockResolvedValue({
+      ...DEV_APP,
+      status: 'ephemeral',
+      scopes: ['ai:write:budgeted', 'user:read:self'],
+      ephemeralSource: 'brand-new',
+    });
+    mockGetActiveTunnel.mockResolvedValue({
+      sessionId: 'bki_s',
+      userId: 555,
+      blockId: 'my-app',
+      host: 'dev-0123456789abcdef.civit.ai',
+      hardExpiresAt: 9e9,
+      spendCapBuzz: 5000,
+      grantedScopes: ['ai:write:budgeted', 'user:read:self'],
+    });
+    mockUnsubmittedSpend.mockResolvedValue(true);
+    const res = await resolver(makeCtx({ user: AUTHOR, setHeader: () => {} }));
+    // Resolver received the SESSION scopes (never a browser body) + the flag result.
+    expect(mockResolveDev).toHaveBeenCalledWith(
+      'my-app',
+      555,
+      expect.objectContaining({
+        sessionGrantedScopes: ['ai:write:budgeted', 'user:read:self'],
+        unsubmittedSpendAllowed: true,
+      })
+    );
+    // The advertised declaredScopes prop == the resolver's returned scopes (so the
+    // block's Generate gate matches what the mint will grant).
+    expect(res.props.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+  });
+
+  it('BRAND-NEW with the unsubmitted-spend flag OFF → forwards unsubmittedSpendAllowed:false', async () => {
+    const resolver = await loadDevResolver();
+    mockUnsubmittedSpend.mockResolvedValue(false);
+    mockResolveDev.mockResolvedValue({
+      ...DEV_APP,
+      status: 'ephemeral',
+      scopes: ['user:read:self'],
+      ephemeralSource: 'brand-new',
+    });
+    mockGetActiveTunnel.mockResolvedValue({
+      sessionId: 'bki_s',
+      userId: 555,
+      blockId: 'my-app',
+      host: 'dev-0123456789abcdef.civit.ai',
+      hardExpiresAt: 9e9,
+      spendCapBuzz: 5000,
+      grantedScopes: ['ai:write:budgeted', 'user:read:self'],
+    });
+    const res = await resolver(makeCtx({ user: AUTHOR, setHeader: () => {} }));
+    expect(mockResolveDev).toHaveBeenCalledWith(
+      'my-app',
+      555,
+      expect.objectContaining({ unsubmittedSpendAllowed: false })
+    );
+    expect(res.props.scopes).toEqual(['user:read:self']);
   });
 
   it('unauthenticated → redirect to login', async () => {


### PR DESCRIPTION
## What
App Dev Tunnel Phase-2 follow-up: a developer can now test **real (self-capped) Buzz-spend generation** for an app that has **never been submitted** (no publish request row), not just a submitted-pending one. Previously the ephemeral resolver returned `scopes: []` for a brand-new slug, so the block's Generate gate hung. Scopes are self-declared by the dev's local `block.manifest.json`, carried **CLI → tunnel session (Redis) → server**.

Companion PRs (feature is inert until all three land + the flag is enabled):
- **civitai/cli#110** — the CLI forwards manifest scopes as `declaredScopes`.
- **flipt-state#30** — the dedicated `app-blocks-dev-tunnel-unsubmitted-spend` flag.

## Security model (a design-stage security audit shaped this)
- **Scope source = the authenticated CLI's tunnel session** (server-stored, clamped at **write**), **never a browser body**. The block's iframe JS can only *use* the granted set — never widen it. The `block-tokens` `devScopes` body field is **removed** (it was the only body→source foot-gun on this path).
- **Single clamp**: new `clampTunnelDeclaredScopes` is the one belt both the SSR `declaredScopes` surface and the mint's JWT consume → they can't diverge. `resolveDevPageBlockForAuthor` is the single scope authority; the mint uses `app.scopes` (re-clamped idempotently as defense-in-depth).
- **Dedicated kill-switch** `app-blocks-dev-tunnel-unsubmitted-spend` (Flipt, **fail-closed**) gates *only* brand-new spend — when off, `ai:write:budgeted` is stripped and the app renders read-only. **Pending/approved paths unaffected.** Ops can kill "real Buzz on an unreviewed app" without disabling all tunnel dev.
- **Mint-time audit**: `app-blocks.dev-tunnel.mint` structured event (never the token) records the grant decision (a synthetic `ephemeral-<slug>` app has no durable AppBlock row).
- **Containment unchanged**: self-bound token (author's own Buzz), forced-SFW, no `apps:storage`, dev per-call + per-session + per-user-daily Buzz caps, author + dev-tunnel dual-flag gated. **Ownership/anti-shadow still precede scope application** (a foreign/claimed slug returns the same bare null even with session spend scopes).

## Also
- Session stores `declaredScopes` (raw-bounded, forensics) + `grantedScopes` (clamped). `startDevTunnel` sanitizes/bounds the input (≤32 × ≤64, deduped, strings-only).
- Fixed the stale `reserveDevSessionBuzz` "NOT WIRED" comment (it *is* wired at workflow-submit).

## Backward-compat
An old CLI omitting `declaredScopes` → read-only session. No behavior change for pending/approved apps.

## Tests — 112 pass
Resolver (ownership-precedes-scopes, flag-gate, forbidden/storage/unknown clamp, `ephemeralSource`), mint (session-sourced, **body-ignored**, flag-off → read-only, audit event never carries the token), SSR (`declaredScopes` == mint grant), and `startDevTunnel` storage/bounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)