### PR TITLE
feat(apps): my-submissions status sections + external-review modal UX

### DIFF
--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -156,6 +156,8 @@ describe('MySubmissionsList', () => {
         withdrawing={false}
       />
     );
+    // A rejected row now lives in the default-collapsed Rejected section — expand it.
+    await page.getByTestId('apps-submissions-section-rejected-toggle').click();
     const btn = page.getByRole('button', { name: /see reviewer notes/i });
     await expect.element(btn).toBeInTheDocument();
     // Reason not inline.
@@ -305,24 +307,6 @@ describe('MySubmissionsList — UX pass: filter / sort / version-collapse', () =
     expect(page.getByText('alpha-app', { exact: false }).elements()).toHaveLength(0);
   });
 
-  test('clicking the App header sorts and exposes aria-sort', async () => {
-    renderWithProviders(
-      <MySubmissionsList
-        submissions={[
-          makeSubmission({ id: 'b', slug: 'bravo-app', appBlockId: 'block-b' }),
-          makeSubmission({ id: 'a', slug: 'alpha-app', appBlockId: 'block-a' }),
-        ]}
-        onWithdraw={vi.fn()}
-        withdrawing={false}
-      />
-    );
-    const appHeader = page.getByRole('button', { name: /sort by app/i });
-    await appHeader.click();
-    // The header's <th> reflects the active sort for screen readers.
-    const th = appHeader.element().closest('th');
-    expect(th?.getAttribute('aria-sort')).toBe('ascending');
-  });
-
   test('multiple versions of one app collapse; the toggle reveals older versions', async () => {
     renderWithProviders(
       <MySubmissionsList
@@ -389,6 +373,94 @@ describe('MySubmissionsList — UX pass: filter / sort / version-collapse', () =
     expect(page.getByText('1.0.0', { exact: true }).elements()).toHaveLength(0);
     await toggle.click();
     await expect.element(page.getByText('1.0.0', { exact: true })).toBeInTheDocument();
+  });
+});
+
+describe('MySubmissionsList — status sections', () => {
+  const oneOfEach = () => [
+    makeSubmission({ id: 'a', slug: 'live-app', appBlockId: 'block-a', status: 'approved' }),
+    makeSubmission({
+      id: 'b',
+      slug: 'pending-app',
+      appBlockId: 'block-b',
+      status: 'pending',
+      deployState: null,
+      reviewedAt: null,
+    }),
+    makeSubmission({
+      id: 'c',
+      slug: 'rejected-app',
+      appBlockId: 'block-c',
+      status: 'rejected',
+      deployState: null,
+      rejectionReason: null,
+    }),
+    makeSubmission({
+      id: 'd',
+      slug: 'withdrawn-app',
+      appBlockId: 'block-d',
+      status: 'withdrawn',
+      deployState: null,
+    }),
+  ];
+
+  test('groups submissions into Live/Pending/Rejected/Withdrawn sections', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={oneOfEach()} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await expect.element(page.getByTestId('apps-submissions-section-live')).toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-submissions-section-pending'))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-submissions-section-rejected'))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-submissions-section-withdrawn'))
+      .toBeInTheDocument();
+
+    // Live + Pending are expanded → their rows are visible up-front.
+    await expect.element(page.getByText('live-app', { exact: false })).toBeInTheDocument();
+    await expect.element(page.getByText('pending-app', { exact: false })).toBeInTheDocument();
+  });
+
+  test('Live + Pending render expanded; Rejected + Withdrawn are collapsed by default', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={oneOfEach()} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    // Expanded sections: rows present.
+    await expect.element(page.getByText('live-app', { exact: false })).toBeInTheDocument();
+    await expect.element(page.getByText('pending-app', { exact: false })).toBeInTheDocument();
+    // Collapsed sections: their rows are NOT in the DOM until toggled.
+    expect(page.getByText('rejected-app', { exact: false }).elements()).toHaveLength(0);
+    expect(page.getByText('withdrawn-app', { exact: false }).elements()).toHaveLength(0);
+
+    // The collapse toggles carry aria-expanded=false initially.
+    const rejectedToggle = page.getByTestId('apps-submissions-section-rejected-toggle');
+    expect(rejectedToggle.element().getAttribute('aria-expanded')).toBe('false');
+
+    // Clicking a collapsed section's toggle reveals its rows.
+    await rejectedToggle.click();
+    await expect.element(page.getByText('rejected-app', { exact: false })).toBeInTheDocument();
+    expect(rejectedToggle.element().getAttribute('aria-expanded')).toBe('true');
+    // The Withdrawn section is still collapsed (independent toggle).
+    expect(page.getByText('withdrawn-app', { exact: false }).elements()).toHaveLength(0);
+  });
+
+  test('empty sections are not rendered (only-approved submissions → no other sections)', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[
+          makeSubmission({ id: 'a', slug: 'live-app', appBlockId: 'block-a', status: 'approved' }),
+        ]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    await expect.element(page.getByTestId('apps-submissions-section-live')).toBeInTheDocument();
+    expect(page.getByTestId('apps-submissions-section-pending').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-submissions-section-rejected').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-submissions-section-withdrawn').elements()).toHaveLength(0);
   });
 });
 

--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -16,17 +16,16 @@ import { Fragment, useMemo, useState, type ReactNode } from 'react';
 import { AppAnalyticsInline } from '~/components/Apps/AppAnalyticsInline';
 import { isStaleDeploy } from '~/components/Apps/deploy-status';
 import {
+  bucketGroupsByStatus,
   currentlyPublishedVersionId,
   filterGroups,
   groupSubmissionsByApp,
-  nextSortState,
   sortGroups,
   toDate,
-  type SortColumn,
-  type SortState,
   type SubmissionAccessors,
+  type SubmissionGroup,
 } from '~/components/Apps/submissionsTable';
-import { SortableTh, SubmissionSearch, VersionToggle } from '~/components/Apps/submissionsTableUi';
+import { StatusSections, SubmissionSearch, VersionToggle } from '~/components/Apps/submissionsTableUi';
 import { formatDate } from '~/utils/date-helpers';
 
 export type FileSummary = {
@@ -350,19 +349,33 @@ export function MySubmissionsList({
   withdrawing: boolean;
 }) {
   const [query, setQuery] = useState('');
-  const [sort, setSort] = useState<SortState>({ column: 'submitted', direction: 'desc' });
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
-  const groups = useMemo(() => {
+  // Group by app, apply the text filter, sort newest-first, then partition into
+  // status SECTIONS (Live / Pending / Rejected / Withdrawn). Status is now the
+  // section, so the column header is no longer sortable — a plain submittedAt-desc
+  // sort within each section keeps the newest request on top.
+  const buckets = useMemo(() => {
     const grouped = groupSubmissionsByApp(
       submissions,
       ONSITE_ACCESSORS.identity,
       ONSITE_ACCESSORS.submittedAt
     );
-    return sortGroups(filterGroups(grouped, query, ONSITE_ACCESSORS), sort, ONSITE_ACCESSORS);
-  }, [submissions, query, sort]);
+    const filtered = filterGroups(grouped, query, ONSITE_ACCESSORS);
+    const sorted = sortGroups(
+      filtered,
+      { column: 'submitted', direction: 'desc' },
+      ONSITE_ACCESSORS
+    );
+    return bucketGroupsByStatus(sorted, ONSITE_ACCESSORS.status);
+  }, [submissions, query]);
 
-  const onSort = (column: SortColumn) => setSort((prev) => nextSortState(prev, column));
+  const totalGroups =
+    buckets.live.length +
+    buckets.pending.length +
+    buckets.rejected.length +
+    buckets.withdrawn.length;
+
   const toggle = (identity: string) =>
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -371,76 +384,82 @@ export function MySubmissionsList({
       return next;
     });
 
-  return (
-    <Stack gap="xs">
-      <SubmissionSearch value={query} onChange={setQuery} testId="apps-submissions-filter" />
-      <Card withBorder p={0}>
-        <Table verticalSpacing="md" horizontalSpacing="md">
-          <Table.Thead>
-            <Table.Tr>
-              <SortableTh label="App" column="app" sort={sort} onSort={onSort} />
-              <Table.Th>Version</Table.Th>
-              <SortableTh label="Status" column="status" sort={sort} onSort={onSort} />
-              <SortableTh label="Submitted" column="submitted" sort={sort} onSort={onSort} />
-              <SortableTh label="Reviewed" column="reviewed" sort={sort} onSort={onSort} />
-              <Table.Th>Installs</Table.Th>
-              <Table.Th>Usage (30d)</Table.Th>
-              <Table.Th />
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
-            {groups.length === 0 ? (
-              <Table.Tr>
-                <Table.Td colSpan={8}>
-                  <Text size="sm" c="dimmed" ta="center" py="sm">
-                    No submissions match “{query}”.
-                  </Text>
-                </Table.Td>
-              </Table.Tr>
-            ) : (
-              groups.map((g) => {
-                const isExpanded = expanded.has(g.identity);
-                // Single source of truth for the "live" badge + "Open live" button:
-                // the newest approved version across this listing's history.
-                const publishedId = currentlyPublishedVersionId([g.latest, ...g.older]);
-                return (
-                  <Fragment key={g.identity}>
+  const renderTable = (groups: SubmissionGroup<Submission>[]) => (
+    <Card withBorder p={0}>
+      <Table verticalSpacing="md" horizontalSpacing="md">
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>App</Table.Th>
+            <Table.Th>Version</Table.Th>
+            <Table.Th>Status</Table.Th>
+            <Table.Th>Submitted</Table.Th>
+            <Table.Th>Reviewed</Table.Th>
+            <Table.Th>Installs</Table.Th>
+            <Table.Th>Usage (30d)</Table.Th>
+            <Table.Th />
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {groups.map((g) => {
+            const isExpanded = expanded.has(g.identity);
+            // Single source of truth for the "live" badge + "Open live" button:
+            // the newest approved version across this listing's history.
+            const publishedId = currentlyPublishedVersionId([g.latest, ...g.older]);
+            return (
+              <Fragment key={g.identity}>
+                <OnsiteRow
+                  s={g.latest}
+                  nested={false}
+                  isCurrentlyPublished={g.latest.id === publishedId}
+                  onWithdraw={onWithdraw}
+                  withdrawing={withdrawing}
+                  toggle={
+                    g.older.length > 0 ? (
+                      <VersionToggle
+                        expanded={isExpanded}
+                        count={g.versionCount}
+                        onToggle={() => toggle(g.identity)}
+                        variant="subtle"
+                        testId={`apps-submissions-versions-${g.identity}`}
+                      />
+                    ) : undefined
+                  }
+                />
+                {isExpanded &&
+                  g.older.map((older) => (
                     <OnsiteRow
-                      s={g.latest}
-                      nested={false}
-                      isCurrentlyPublished={g.latest.id === publishedId}
+                      key={older.id}
+                      s={older}
+                      nested
+                      isCurrentlyPublished={older.id === publishedId}
                       onWithdraw={onWithdraw}
                       withdrawing={withdrawing}
-                      toggle={
-                        g.older.length > 0 ? (
-                          <VersionToggle
-                            expanded={isExpanded}
-                            count={g.versionCount}
-                            onToggle={() => toggle(g.identity)}
-                            variant="subtle"
-                            testId={`apps-submissions-versions-${g.identity}`}
-                          />
-                        ) : undefined
-                      }
                     />
-                    {isExpanded &&
-                      g.older.map((older) => (
-                        <OnsiteRow
-                          key={older.id}
-                          s={older}
-                          nested
-                          isCurrentlyPublished={older.id === publishedId}
-                          onWithdraw={onWithdraw}
-                          withdrawing={withdrawing}
-                        />
-                      ))}
-                  </Fragment>
-                );
-              })
-            )}
-          </Table.Tbody>
-        </Table>
-      </Card>
+                  ))}
+              </Fragment>
+            );
+          })}
+        </Table.Tbody>
+      </Table>
+    </Card>
+  );
+
+  return (
+    <Stack gap="md">
+      <SubmissionSearch value={query} onChange={setQuery} testId="apps-submissions-filter" />
+      {totalGroups === 0 ? (
+        <Card withBorder p="md">
+          <Text size="sm" c="dimmed" ta="center" py="sm">
+            No submissions match “{query}”.
+          </Text>
+        </Card>
+      ) : (
+        <StatusSections
+          buckets={buckets}
+          testIdPrefix="apps-submissions-section"
+          renderTable={renderTable}
+        />
+      )}
     </Stack>
   );
 }

--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
+import { formatDate } from '~/utils/date-helpers';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -96,8 +97,57 @@ describe('OffsiteReviewQueue — kind-aware review row', () => {
     await expect.element(page.getByText('Icon present')).toBeInTheDocument();
     // NO on-site code items.
     expect(page.getByText('Code diff reviewed').elements()).toHaveLength(0);
-    // Approve + Reject actions present.
-    await expect.element(page.getByRole('button', { name: 'Approve' })).toBeInTheDocument();
-    await expect.element(page.getByRole('button', { name: 'Reject…' })).toBeInTheDocument();
+    // The two ENTRY actions present (approve is now gated behind its own click).
+    await expect.element(page.getByTestId('apps-offsite-approve-open')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-reject-open')).toBeInTheDocument();
+  });
+});
+
+describe('OffsiteReviewModal — approve-notes gating, friendly date, field labels', () => {
+  test('the approval-notes textarea is NOT shown until "Approve…" is clicked, then a confirm Approve appears', async () => {
+    renderWithProviders(<OffsiteReviewQueue />);
+    await page.getByRole('button', { name: 'Review' }).click();
+
+    // View mode: only the two entry buttons — NO approval-notes textarea yet.
+    await expect.element(page.getByTestId('apps-offsite-approve-open')).toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-approve-notes').elements()).toHaveLength(0);
+
+    // Clicking "Approve…" reveals the notes textarea + a confirm Approve button.
+    await page.getByTestId('apps-offsite-approve-open').click();
+    await expect.element(page.getByTestId('apps-offsite-approve-notes')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-approve-confirm')).toBeInTheDocument();
+    // The entry buttons are gone (replaced by Cancel / Approve).
+    expect(page.getByTestId('apps-offsite-approve-open').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-offsite-reject-open').elements()).toHaveLength(0);
+  });
+
+  test('the Reject… flow still reveals the rejection-reason textarea + confirm', async () => {
+    renderWithProviders(<OffsiteReviewQueue />);
+    await page.getByRole('button', { name: 'Review' }).click();
+    // No rejection textarea until Reject… is clicked.
+    expect(page.getByTestId('apps-offsite-reject-reason').elements()).toHaveLength(0);
+    await page.getByTestId('apps-offsite-reject-open').click();
+    await expect.element(page.getByTestId('apps-offsite-reject-reason')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-reject-confirm')).toBeInTheDocument();
+  });
+
+  test('the submitted timestamp renders as "Month D, YYYY" (no time-of-day)', async () => {
+    renderWithProviders(<OffsiteReviewQueue />);
+    // Self-consistent with the component (same helper) → TZ-agnostic.
+    const expected = formatDate(OFFSITE_ROW.submittedAt, 'MMMM D, YYYY');
+    // Present in the queue row's "Submitted" column (and again in the modal once open).
+    await expect.element(page.getByText(expected, { exact: false }).first()).toBeInTheDocument();
+    // The old toLocaleString form carried a clock time — none should remain.
+    expect(page.getByText(/\d{1,2}:\d\d/).elements()).toHaveLength(0);
+  });
+
+  test('the modal labels the Category and Content-rating fields', async () => {
+    renderWithProviders(<OffsiteReviewQueue />);
+    await page.getByRole('button', { name: 'Review' }).click();
+    await expect.element(page.getByText('Category', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText('Content rating', { exact: true })).toBeInTheDocument();
+    // The badge values they label are still rendered.
+    await expect.element(page.getByText('utility', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText('g', { exact: true })).toBeInTheDocument();
   });
 });

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -43,6 +43,7 @@ import {
 import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { formatDate as formatDateHelper } from '~/utils/date-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -78,6 +79,19 @@ function formatDate(d: string | Date | null | undefined): string {
   if (!d) return '—';
   const date = typeof d === 'string' ? new Date(d) : d;
   return date.toLocaleString();
+}
+
+/**
+ * Friendly whole-day "Month D, YYYY" form (e.g. "June 7, 2026") for the external-
+ * review SUBMITTED timestamps — the modal's submitted line + the review queue's
+ * "Submitted" column. A mod deciding on a submission cares about the calendar day,
+ * not the minute. Audit-trail timestamps (report "Reported", moderation history)
+ * keep the full local formatter above where time-of-day matters. Matches
+ * `MySubmissionsList.formatSubmissionDate`.
+ */
+function formatSubmittedDate(d: string | Date | null | undefined): string {
+  if (!d) return '—';
+  return formatDateHelper(d, 'MMMM D, YYYY');
 }
 
 export function OffsiteReviewQueue() {
@@ -163,7 +177,7 @@ export function OffsiteReviewQueue() {
                   <Table.Td onClick={() => setSelected(r)}>
                     <Group gap={4}>
                       <IconClock size={14} />
-                      <Text size="xs">{formatDate(r.submittedAt)}</Text>
+                      <Text size="xs">{formatSubmittedDate(r.submittedAt)}</Text>
                     </Group>
                   </Table.Td>
                   <Table.Td>
@@ -200,7 +214,10 @@ function OffsiteReviewModal({
   const features = useFeatureFlags();
   const [rejectionReason, setRejectionReason] = useState('');
   const [approvalNotes, setApprovalNotes] = useState('');
-  const [actionMode, setActionMode] = useState<'view' | 'reject'>('view');
+  // 'view' shows only the two entry buttons; 'reject' / 'approve' each reveal their
+  // own notes textarea + confirm (approve gated behind an explicit "Approve…" click,
+  // mirroring reject — so a stray click can't approve with un-reviewed notes).
+  const [actionMode, setActionMode] = useState<'view' | 'reject' | 'approve'>('view');
 
   // Asset presence for the content checklist (author/mod-gated; a mod passes the
   // author floor). Only enabled once a row with a draft listing is open.
@@ -286,7 +303,7 @@ function OffsiteReviewModal({
           </Text>
           <Text size="xs">{request.submittedBy?.username ?? `#${request.submittedBy?.id ?? '?'}`}</Text>
           <Text size="xs" c="dimmed">
-            · {formatDate(request.submittedAt)}
+            · {formatSubmittedDate(request.submittedAt)}
           </Text>
         </Group>
 
@@ -323,16 +340,26 @@ function OffsiteReviewModal({
                 )}
               </Group>
             )}
-            <Group gap={12}>
+            <Group gap={24}>
               {request.appListing?.category && (
-                <Badge size="sm" variant="light">
-                  {request.appListing.category}
-                </Badge>
+                <Group gap={6}>
+                  <Text size="xs" c="dimmed">
+                    Category
+                  </Text>
+                  <Badge size="sm" variant="light">
+                    {request.appListing.category}
+                  </Badge>
+                </Group>
               )}
               {request.appListing?.contentRating && (
-                <Badge size="sm" color="gray" variant="light">
-                  {request.appListing.contentRating}
-                </Badge>
+                <Group gap={6}>
+                  <Text size="xs" c="dimmed">
+                    Content rating
+                  </Text>
+                  <Badge size="sm" color="gray" variant="light">
+                    {request.appListing.contentRating}
+                  </Badge>
+                </Group>
               )}
             </Group>
             {request.changelog && (
@@ -427,10 +454,12 @@ function OffsiteReviewModal({
               </Button>
             </Group>
           </Stack>
-        ) : (
+        ) : actionMode === 'approve' ? (
           <Stack gap="xs">
+            <Text size="sm" fw={600}>
+              Approval notes (optional)
+            </Text>
             <Textarea
-              label="Approval notes (optional)"
               autosize
               minRows={2}
               maxRows={6}
@@ -438,17 +467,11 @@ function OffsiteReviewModal({
               value={approvalNotes}
               onChange={(e) => setApprovalNotes(e.currentTarget.value)}
               disabled={busy}
+              data-testid="apps-offsite-approve-notes"
             />
             <Group justify="flex-end" gap="xs">
-              <Button
-                color="red"
-                variant="default"
-                leftSection={<IconX size={14} />}
-                onClick={() => setActionMode('reject')}
-                disabled={busy}
-                data-testid="apps-offsite-reject-open"
-              >
-                Reject…
+              <Button variant="default" onClick={() => setActionMode('view')} disabled={busy}>
+                Cancel
               </Button>
               <Button
                 color="green"
@@ -461,11 +484,34 @@ function OffsiteReviewModal({
                 }
                 disabled={busy}
                 loading={approveMut.isPending}
+                data-testid="apps-offsite-approve-confirm"
               >
                 Approve
               </Button>
             </Group>
           </Stack>
+        ) : (
+          <Group justify="flex-end" gap="xs">
+            <Button
+              color="red"
+              variant="default"
+              leftSection={<IconX size={14} />}
+              onClick={() => setActionMode('reject')}
+              disabled={busy}
+              data-testid="apps-offsite-reject-open"
+            >
+              Reject…
+            </Button>
+            <Button
+              color="green"
+              leftSection={<IconCheck size={14} />}
+              onClick={() => setActionMode('approve')}
+              disabled={busy}
+              data-testid="apps-offsite-approve-open"
+            >
+              Approve…
+            </Button>
+          </Group>
         )}
       </Stack>
     </Modal>

--- a/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
@@ -1,0 +1,147 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * /apps/my-submissions OFF-SITE list — status-section restructure (UX pass).
+ * The offsite (external-link) list now renders as the same four status SECTIONS as
+ * the onsite list: Live + Pending (always expanded) and Rejected + Withdrawn
+ * (default-collapsed `Collapse`, revealed by their toggle). Asserted via the stable
+ * `apps-offsite-submissions-section-*` testids.
+ *
+ * The list transitively imports `MySubmissionsList` (for `ReviewerNotesButton`),
+ * which pulls in the analytics inline stat → `~/utils/trpc`; and the editable rows
+ * mount `OffsiteEditModal`. Both are mocked so this stays network-free. Per the
+ * documented gotcha, the wholesale `~/utils/trpc` mock includes
+ * `setTrpcBatchingEnabled` (a graph-reachable module imports it).
+ */
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    blocks: {
+      getMyAppAnalytics: {
+        useQuery: () => ({ data: { runs: { count: 0 }, engagement: { activeUsers: 0 } }, isLoading: false }),
+      },
+    },
+  },
+  setTrpcBatchingEnabled: vi.fn(),
+}));
+
+// The edit affordance pulls trpc mutations + category constants we don't exercise
+// here; stub it so an editable (pending/approved) row renders without that surface.
+vi.mock('~/components/Apps/OffsiteEditModal', () => ({
+  OffsiteEditModal: () => <div data-testid="offsite-edit-modal-stub" />,
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+import type { OffsiteSubmission } from './OffsiteSubmissionsList';
+const { OffsiteSubmissionsList } = await import('./OffsiteSubmissionsList');
+
+function makeOffsite(overrides: Partial<OffsiteSubmission>): OffsiteSubmission {
+  return {
+    id: 'o1',
+    appListingId: 'listing-1',
+    slug: 'off-app',
+    status: 'approved',
+    submittedAt: new Date('2026-01-01T00:00:00Z'),
+    reviewedAt: new Date('2026-01-02T00:00:00Z'),
+    rejectionReason: null,
+    approvalNotes: null,
+    changelog: null,
+    appListing: {
+      name: 'Off App',
+      externalUrl: 'https://example.com/app',
+      category: 'utility',
+      contentRating: 'g',
+    },
+    ...overrides,
+  };
+}
+
+const oneOfEach = (): OffsiteSubmission[] => [
+  makeOffsite({ id: 'a', slug: 'live-off', appListingId: 'l-a', status: 'approved' }),
+  makeOffsite({ id: 'b', slug: 'pending-off', appListingId: 'l-b', status: 'pending', reviewedAt: null }),
+  makeOffsite({ id: 'c', slug: 'rejected-off', appListingId: null, status: 'rejected' }),
+  makeOffsite({ id: 'd', slug: 'withdrawn-off', appListingId: null, status: 'withdrawn' }),
+];
+
+describe('OffsiteSubmissionsList — status sections', () => {
+  test('groups off-site submissions into the four status sections', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList submissions={oneOfEach()} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await expect
+      .element(page.getByTestId('apps-offsite-submissions-section-live'))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-offsite-submissions-section-pending'))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-offsite-submissions-section-rejected'))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-offsite-submissions-section-withdrawn'))
+      .toBeInTheDocument();
+  });
+
+  test('Live + Pending render expanded; Rejected + Withdrawn are collapsed by default', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList submissions={oneOfEach()} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    // Expanded sections show their rows.
+    await expect.element(page.getByText('live-off', { exact: false })).toBeInTheDocument();
+    await expect.element(page.getByText('pending-off', { exact: false })).toBeInTheDocument();
+    // Collapsed sections hide their rows until toggled.
+    expect(page.getByText('rejected-off', { exact: false }).elements()).toHaveLength(0);
+    expect(page.getByText('withdrawn-off', { exact: false }).elements()).toHaveLength(0);
+
+    const withdrawnToggle = page.getByTestId('apps-offsite-submissions-section-withdrawn-toggle');
+    expect(withdrawnToggle.element().getAttribute('aria-expanded')).toBe('false');
+    await withdrawnToggle.click();
+    await expect.element(page.getByText('withdrawn-off', { exact: false })).toBeInTheDocument();
+    expect(withdrawnToggle.element().getAttribute('aria-expanded')).toBe('true');
+    // The Rejected section stays collapsed (independent toggle).
+    expect(page.getByText('rejected-off', { exact: false }).elements()).toHaveLength(0);
+  });
+
+  test('empty sections are not rendered (only-pending → no other sections)', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList
+        submissions={[
+          makeOffsite({ id: 'b', slug: 'pending-off', appListingId: 'l-b', status: 'pending', reviewedAt: null }),
+        ]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    await expect
+      .element(page.getByTestId('apps-offsite-submissions-section-pending'))
+      .toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-submissions-section-live').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-offsite-submissions-section-rejected').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-offsite-submissions-section-withdrawn').elements()).toHaveLength(0);
+  });
+
+  test('the text filter narrows rows within their sections', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList
+        submissions={[
+          makeOffsite({ id: 'a', slug: 'alpha-off', appListingId: 'l-a', status: 'approved' }),
+          makeOffsite({ id: 'b', slug: 'bravo-off', appListingId: 'l-b', status: 'approved' }),
+        ]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    await expect.element(page.getByText('alpha-off', { exact: false })).toBeInTheDocument();
+    await expect.element(page.getByText('bravo-off', { exact: false })).toBeInTheDocument();
+    await page.getByTestId('apps-offsite-submissions-filter').fill('bravo');
+    await expect.element(page.getByText('bravo-off', { exact: false })).toBeInTheDocument();
+    expect(page.getByText('alpha-off', { exact: false }).elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Apps/OffsiteSubmissionsList.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.tsx
@@ -10,16 +10,15 @@ import { OffsiteEditModal } from '~/components/Apps/OffsiteEditModal';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
 import { ReviewerNotesButton } from '~/components/Apps/MySubmissionsList';
 import {
+  bucketGroupsByStatus,
   filterGroups,
   groupSubmissionsByApp,
-  nextSortState,
   sortGroups,
   toDate,
-  type SortColumn,
-  type SortState,
   type SubmissionAccessors,
+  type SubmissionGroup,
 } from '~/components/Apps/submissionsTable';
-import { SortableTh, SubmissionSearch, VersionToggle } from '~/components/Apps/submissionsTableUi';
+import { StatusSections, SubmissionSearch, VersionToggle } from '~/components/Apps/submissionsTableUi';
 
 /**
  * /apps/my-submissions — the author's OFF-SITE (external-link) submissions, shown
@@ -233,19 +232,32 @@ export function OffsiteSubmissionsList({
   withdrawing: boolean;
 }) {
   const [query, setQuery] = useState('');
-  const [sort, setSort] = useState<SortState>({ column: 'submitted', direction: 'desc' });
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
-  const groups = useMemo(() => {
+  // Group → filter → sort newest-first → partition into status SECTIONS. Status is
+  // now the section (Live / Pending / Rejected / Withdrawn), so the header column is
+  // no longer sortable; a plain submittedAt-desc sort orders rows within a section.
+  const buckets = useMemo(() => {
     const grouped = groupSubmissionsByApp(
       submissions,
       OFFSITE_ACCESSORS.identity,
       OFFSITE_ACCESSORS.submittedAt
     );
-    return sortGroups(filterGroups(grouped, query, OFFSITE_ACCESSORS), sort, OFFSITE_ACCESSORS);
-  }, [submissions, query, sort]);
+    const filtered = filterGroups(grouped, query, OFFSITE_ACCESSORS);
+    const sorted = sortGroups(
+      filtered,
+      { column: 'submitted', direction: 'desc' },
+      OFFSITE_ACCESSORS
+    );
+    return bucketGroupsByStatus(sorted, OFFSITE_ACCESSORS.status);
+  }, [submissions, query]);
 
-  const onSort = (column: SortColumn) => setSort((prev) => nextSortState(prev, column));
+  const totalGroups =
+    buckets.live.length +
+    buckets.pending.length +
+    buckets.rejected.length +
+    buckets.withdrawn.length;
+
   const toggle = (identity: string) =>
     setExpanded((prev) => {
       const next = new Set(prev);
@@ -254,72 +266,78 @@ export function OffsiteSubmissionsList({
       return next;
     });
 
+  const renderTable = (groups: SubmissionGroup<OffsiteSubmission>[]) => (
+    <Card withBorder p={0}>
+      <Table verticalSpacing="md" horizontalSpacing="md">
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>App</Table.Th>
+            <Table.Th>Link</Table.Th>
+            <Table.Th>Status</Table.Th>
+            <Table.Th>Submitted</Table.Th>
+            <Table.Th>Reviewed</Table.Th>
+            <Table.Th />
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {groups.map((g) => {
+            const isExpanded = expanded.has(g.identity);
+            return (
+              <Fragment key={g.identity}>
+                <OffsiteRow
+                  submission={g.latest}
+                  nested={false}
+                  onWithdraw={onWithdraw}
+                  withdrawing={withdrawing}
+                  toggle={
+                    g.older.length > 0 ? (
+                      <VersionToggle
+                        expanded={isExpanded}
+                        count={g.versionCount}
+                        onToggle={() => toggle(g.identity)}
+                        testId={`apps-offsite-versions-${g.identity}`}
+                      />
+                    ) : undefined
+                  }
+                />
+                {isExpanded &&
+                  g.older.map((older) => (
+                    <OffsiteRow
+                      key={older.id}
+                      submission={older}
+                      nested
+                      onWithdraw={onWithdraw}
+                      withdrawing={withdrawing}
+                    />
+                  ))}
+              </Fragment>
+            );
+          })}
+        </Table.Tbody>
+      </Table>
+    </Card>
+  );
+
   return (
-    <Stack gap="xs">
+    <Stack gap="md">
       <SubmissionSearch
         value={query}
         onChange={setQuery}
         testId="apps-offsite-submissions-filter"
       />
-      <Card withBorder p={0}>
-        <Table verticalSpacing="md" horizontalSpacing="md">
-          <Table.Thead>
-            <Table.Tr>
-              <SortableTh label="App" column="app" sort={sort} onSort={onSort} />
-              <Table.Th>Link</Table.Th>
-              <SortableTh label="Status" column="status" sort={sort} onSort={onSort} />
-              <SortableTh label="Submitted" column="submitted" sort={sort} onSort={onSort} />
-              <SortableTh label="Reviewed" column="reviewed" sort={sort} onSort={onSort} />
-              <Table.Th />
-            </Table.Tr>
-          </Table.Thead>
-          <Table.Tbody>
-            {groups.length === 0 ? (
-              <Table.Tr>
-                <Table.Td colSpan={6}>
-                  <Text size="sm" c="dimmed" ta="center" py="sm">
-                    No submissions match “{query}”.
-                  </Text>
-                </Table.Td>
-              </Table.Tr>
-            ) : (
-              groups.map((g) => {
-                const isExpanded = expanded.has(g.identity);
-                return (
-                  <Fragment key={g.identity}>
-                    <OffsiteRow
-                      submission={g.latest}
-                      nested={false}
-                      onWithdraw={onWithdraw}
-                      withdrawing={withdrawing}
-                      toggle={
-                        g.older.length > 0 ? (
-                          <VersionToggle
-                            expanded={isExpanded}
-                            count={g.versionCount}
-                            onToggle={() => toggle(g.identity)}
-                            testId={`apps-offsite-versions-${g.identity}`}
-                          />
-                        ) : undefined
-                      }
-                    />
-                    {isExpanded &&
-                      g.older.map((older) => (
-                        <OffsiteRow
-                          key={older.id}
-                          submission={older}
-                          nested
-                          onWithdraw={onWithdraw}
-                          withdrawing={withdrawing}
-                        />
-                      ))}
-                  </Fragment>
-                );
-              })
-            )}
-          </Table.Tbody>
-        </Table>
-      </Card>
+      {totalGroups === 0 ? (
+        <Card withBorder p="md">
+          <Text size="sm" c="dimmed" ta="center" py="sm">
+            No submissions match “{query}”.
+          </Text>
+        </Card>
+      ) : (
+        <StatusSections
+          buckets={buckets}
+          testIdPrefix="apps-offsite-submissions-section"
+          renderTable={renderTable}
+        />
+      )}
     </Stack>
   );
 }

--- a/src/components/Apps/__tests__/submissionsTable.test.ts
+++ b/src/components/Apps/__tests__/submissionsTable.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   ariaSortFor,
+  bucketGroupsByStatus,
   compareDate,
   compareStatus,
   compareText,
@@ -10,7 +11,9 @@ import {
   matchesQuery,
   nextSortState,
   sortGroups,
+  statusBucket,
   statusRank,
+  STATUS_SECTION_ORDER,
   toDate,
   type SortState,
   type SubmissionAccessors,
@@ -338,6 +341,80 @@ describe('currentlyPublishedVersionId — newest approved version is the live on
 
   it('an empty list → null', () => {
     expect(currentlyPublishedVersionId([])).toBeNull();
+  });
+});
+
+describe('statusBucket / bucketGroupsByStatus — status sections', () => {
+  it('maps each known status to its section', () => {
+    expect(statusBucket('approved')).toBe('live');
+    expect(statusBucket('pending')).toBe('pending');
+    expect(statusBucket('rejected')).toBe('rejected');
+    expect(statusBucket('withdrawn')).toBe('withdrawn');
+  });
+
+  it('maps an unknown/other status to the (closed) withdrawn section as a safe default', () => {
+    expect(statusBucket('archived')).toBe('withdrawn');
+    expect(statusBucket('')).toBe('withdrawn');
+  });
+
+  it('the section order is Live → Pending → Rejected → Withdrawn', () => {
+    expect(STATUS_SECTION_ORDER).toEqual(['live', 'pending', 'rejected', 'withdrawn']);
+  });
+
+  it("buckets a group by its LATEST submission's status (not older versions)", () => {
+    // One app whose newest version is approved but has an older rejected version →
+    // the WHOLE group lands in Live (the section follows the current version).
+    const groups = groupSubmissionsByApp(
+      [
+        row({ id: 'v1', identity: 'app', status: 'rejected', submittedAt: '2026-01-01' }),
+        row({ id: 'v2', identity: 'app', status: 'approved', submittedAt: '2026-02-01' }),
+      ],
+      A.identity,
+      A.submittedAt
+    );
+    const buckets = bucketGroupsByStatus(groups, A.status);
+    expect(buckets.live.map((g) => g.identity)).toEqual(['app']);
+    expect(buckets.pending).toEqual([]);
+    expect(buckets.rejected).toEqual([]);
+    expect(buckets.withdrawn).toEqual([]);
+  });
+
+  it('partitions distinct apps into their four sections', () => {
+    const groups = groupSubmissionsByApp(
+      [
+        row({ id: 'a', identity: 'live-app', status: 'approved' }),
+        row({ id: 'b', identity: 'pending-app', status: 'pending' }),
+        row({ id: 'c', identity: 'rejected-app', status: 'rejected' }),
+        row({ id: 'd', identity: 'withdrawn-app', status: 'withdrawn' }),
+        row({ id: 'e', identity: 'weird-app', status: 'archived' }),
+      ],
+      A.identity,
+      A.submittedAt
+    );
+    const buckets = bucketGroupsByStatus(groups, A.status);
+    expect(buckets.live.map((g) => g.identity)).toEqual(['live-app']);
+    expect(buckets.pending.map((g) => g.identity)).toEqual(['pending-app']);
+    expect(buckets.rejected.map((g) => g.identity)).toEqual(['rejected-app']);
+    // Unknown status ('archived') falls back into the closed Withdrawn section.
+    expect(buckets.withdrawn.map((g) => g.identity)).toEqual(['withdrawn-app', 'weird-app']);
+  });
+
+  it('preserves the incoming group order within a bucket (a pre-applied sort is kept)', () => {
+    const groups = groupSubmissionsByApp(
+      [
+        row({ id: 'p1', identity: 'p1', status: 'pending', submittedAt: '2026-03-01' }),
+        row({ id: 'p2', identity: 'p2', status: 'pending', submittedAt: '2026-01-01' }),
+      ],
+      A.identity,
+      A.submittedAt
+    );
+    const buckets = bucketGroupsByStatus(groups, A.status);
+    expect(buckets.pending.map((g) => g.identity)).toEqual(['p1', 'p2']);
+  });
+
+  it('yields four empty buckets for no groups', () => {
+    const buckets = bucketGroupsByStatus([], A.status);
+    expect(buckets).toEqual({ live: [], pending: [], rejected: [], withdrawn: [] });
   });
 });
 

--- a/src/components/Apps/__tests__/submissionsTable.test.ts
+++ b/src/components/Apps/__tests__/submissionsTable.test.ts
@@ -361,22 +361,40 @@ describe('statusBucket / bucketGroupsByStatus — status sections', () => {
     expect(STATUS_SECTION_ORDER).toEqual(['live', 'pending', 'rejected', 'withdrawn']);
   });
 
-  it("buckets a group by its LATEST submission's status (not older versions)", () => {
-    // One app whose newest version is approved but has an older rejected version →
-    // the WHOLE group lands in Live (the section follows the current version).
+  it('buckets a never-approved group by its LATEST submission status', () => {
+    // No approved version anywhere → the section follows the current (latest) version.
     const groups = groupSubmissionsByApp(
       [
-        row({ id: 'v1', identity: 'app', status: 'rejected', submittedAt: '2026-01-01' }),
-        row({ id: 'v2', identity: 'app', status: 'approved', submittedAt: '2026-02-01' }),
+        row({ id: 'v1', identity: 'app', status: 'pending', submittedAt: '2026-01-01' }),
+        row({ id: 'v2', identity: 'app', status: 'rejected', submittedAt: '2026-02-01' }),
       ],
       A.identity,
       A.submittedAt
     );
     const buckets = bucketGroupsByStatus(groups, A.status);
-    expect(buckets.live.map((g) => g.identity)).toEqual(['app']);
-    expect(buckets.pending).toEqual([]);
-    expect(buckets.rejected).toEqual([]);
-    expect(buckets.withdrawn).toEqual([]);
+    expect(buckets.rejected.map((g) => g.identity)).toEqual(['app']);
+    expect(buckets.live).toEqual([]);
+  });
+
+  it('keeps a currently-LIVE app in Live even when its latest update is rejected/withdrawn/pending', () => {
+    // 🟡#1 regression guard: an app with an approved (published) version whose NEWEST
+    // submission is an in-flight update must stay in the always-expanded Live section,
+    // never buried in the default-collapsed Rejected/Withdrawn section.
+    for (const latestStatus of ['rejected', 'withdrawn', 'pending'] as const) {
+      const groups = groupSubmissionsByApp(
+        [
+          row({ id: 'v1', identity: 'app', status: 'approved', submittedAt: '2026-01-01' }),
+          row({ id: 'v2', identity: 'app', status: latestStatus, submittedAt: '2026-02-01' }),
+        ],
+        A.identity,
+        A.submittedAt
+      );
+      const buckets = bucketGroupsByStatus(groups, A.status);
+      expect(buckets.live.map((g) => g.identity)).toEqual(['app']);
+      expect(buckets.pending).toEqual([]);
+      expect(buckets.rejected).toEqual([]);
+      expect(buckets.withdrawn).toEqual([]);
+    }
   });
 
   it('partitions distinct apps into their four sections', () => {

--- a/src/components/Apps/submissionsTable.ts
+++ b/src/components/Apps/submissionsTable.ts
@@ -258,10 +258,17 @@ export function statusBucket(status: string): StatusBucket {
 export type BucketedGroups<T> = Record<StatusBucket, SubmissionGroup<T>[]>;
 
 /**
- * Partition already-grouped submissions into the four status sections by each
- * group's `latest` submission status (see {@link statusBucket}). Preserves the
- * incoming group order within each bucket (so a pre-applied sort is retained).
+ * Partition already-grouped submissions into the four status sections. Preserves
+ * the incoming group order within each bucket (so a pre-applied sort is retained).
  * PURE — never mutates the input.
+ *
+ * A group that has ANY approved (currently-published) version buckets to **live**,
+ * EVEN IF its `latest` submission is an in-flight pending/rejected/withdrawn UPDATE.
+ * This keeps a live app in the always-expanded Live section (its "live" badge lives
+ * on the published version within the group) instead of burying it in the
+ * default-collapsed Rejected/Withdrawn section — reachable normally when a live app
+ * gets an update that's then rejected or withdrawn. Only groups that have NEVER been
+ * approved bucket by their `latest` submission's status (see {@link statusBucket}).
  */
 export function bucketGroupsByStatus<T>(
   groups: readonly SubmissionGroup<T>[],
@@ -269,7 +276,11 @@ export function bucketGroupsByStatus<T>(
 ): BucketedGroups<T> {
   const result: BucketedGroups<T> = { live: [], pending: [], rejected: [], withdrawn: [] };
   for (const group of groups) {
-    result[statusBucket(statusOf(group.latest))].push(group);
+    const hasPublishedVersion = [group.latest, ...group.older].some(
+      (v) => statusOf(v) === 'approved'
+    );
+    const bucket = hasPublishedVersion ? 'live' : statusBucket(statusOf(group.latest));
+    result[bucket].push(group);
   }
   return result;
 }

--- a/src/components/Apps/submissionsTable.ts
+++ b/src/components/Apps/submissionsTable.ts
@@ -214,3 +214,62 @@ export function ariaSortFor(
   if (sort.column !== column) return 'none';
   return sort.direction === 'asc' ? 'ascending' : 'descending';
 }
+
+// ── status sections (UX pass) ──────────────────────────────────────────────────
+
+/**
+ * The four status SECTIONS the /apps/my-submissions lists render, in display order.
+ * A group is bucketed by its `latest` submission's status:
+ *   - `approved` → **Live** (the row badge still distinguishes the onsite deploy
+ *     sub-state building/deploying/live/failed — we DON'T split approved by it),
+ *   - `pending` → **Pending**,
+ *   - `rejected` → **Rejected** (its own default-collapsed section),
+ *   - `withdrawn` → **Withdrawn** (default-collapsed),
+ *   - any other/unknown status → **Withdrawn** (a safe closed default so a future
+ *     status degrades gracefully rather than vanishing).
+ */
+export type StatusBucket = 'live' | 'pending' | 'rejected' | 'withdrawn';
+
+/** The section render order (Live → Pending → Rejected → Withdrawn). */
+export const STATUS_SECTION_ORDER: readonly StatusBucket[] = [
+  'live',
+  'pending',
+  'rejected',
+  'withdrawn',
+];
+
+/** Map a raw submission status → its display section. Unknown → `withdrawn`. */
+export function statusBucket(status: string): StatusBucket {
+  switch (status) {
+    case 'approved':
+      return 'live';
+    case 'pending':
+      return 'pending';
+    case 'rejected':
+      return 'rejected';
+    case 'withdrawn':
+      return 'withdrawn';
+    default:
+      return 'withdrawn';
+  }
+}
+
+/** Groups partitioned into the four status sections (by each group's `latest`). */
+export type BucketedGroups<T> = Record<StatusBucket, SubmissionGroup<T>[]>;
+
+/**
+ * Partition already-grouped submissions into the four status sections by each
+ * group's `latest` submission status (see {@link statusBucket}). Preserves the
+ * incoming group order within each bucket (so a pre-applied sort is retained).
+ * PURE — never mutates the input.
+ */
+export function bucketGroupsByStatus<T>(
+  groups: readonly SubmissionGroup<T>[],
+  statusOf: (row: T) => string
+): BucketedGroups<T> {
+  const result: BucketedGroups<T> = { live: [], pending: [], rejected: [], withdrawn: [] };
+  for (const group of groups) {
+    result[statusBucket(statusOf(group.latest))].push(group);
+  }
+  return result;
+}

--- a/src/components/Apps/submissionsTableUi.tsx
+++ b/src/components/Apps/submissionsTableUi.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, Table, Text, TextInput, UnstyledButton } from '@mantine/core';
+import { Badge, Button, Collapse, Group, Stack, Table, Text, TextInput, UnstyledButton } from '@mantine/core';
 import {
   IconArrowsSort,
   IconChevronDown,
@@ -7,7 +7,16 @@ import {
   IconSortAscending,
   IconSortDescending,
 } from '@tabler/icons-react';
-import { ariaSortFor, type SortColumn, type SortState } from '~/components/Apps/submissionsTable';
+import { useState, type ReactNode } from 'react';
+import {
+  ariaSortFor,
+  STATUS_SECTION_ORDER,
+  type BucketedGroups,
+  type SortColumn,
+  type SortState,
+  type StatusBucket,
+  type SubmissionGroup,
+} from '~/components/Apps/submissionsTable';
 
 /**
  * App Store Listings (W13) — shared /apps/my-submissions table UI atoms, used by
@@ -118,5 +127,125 @@ export function VersionCountBadge({ count }: { count: number }) {
     <Badge size="xs" variant="light" color="gray">
       {count} versions
     </Badge>
+  );
+}
+
+// ── status sections (UX pass) ──────────────────────────────────────────────────
+
+/**
+ * Per-section presentation: label, count-badge color, and whether the section is a
+ * default-collapsed `Collapse`. Live + Pending are always-expanded (actionable);
+ * Rejected + Withdrawn are terminal, so they collapse by default to keep the page
+ * focused on what still needs attention.
+ */
+export const STATUS_SECTION_META: Record<
+  StatusBucket,
+  { label: string; color: string; collapsible: boolean }
+> = {
+  live: { label: 'Live', color: 'green', collapsible: false },
+  pending: { label: 'Pending', color: 'blue', collapsible: false },
+  rejected: { label: 'Rejected', color: 'red', collapsible: true },
+  withdrawn: { label: 'Withdrawn', color: 'gray', collapsible: true },
+};
+
+/**
+ * One status section: a header (label + count badge) and its body (a table).
+ * When `collapsible`, the header is a toggle button (chevron + label + count) and
+ * the body is a `Collapse` that starts CLOSED — its content isn't rendered until
+ * the section is opened, so a collapsed section leaves no rows in the DOM.
+ */
+function StatusSection({
+  label,
+  color,
+  count,
+  collapsible,
+  testId,
+  children,
+}: {
+  label: string;
+  color: string;
+  count: number;
+  collapsible: boolean;
+  testId: string;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const countBadge = (
+    <Badge size="sm" variant="light" color={color}>
+      {count}
+    </Badge>
+  );
+
+  if (!collapsible) {
+    return (
+      <Stack gap="xs" data-testid={testId}>
+        <Group gap={6}>
+          <Text size="sm" fw={700}>
+            {label}
+          </Text>
+          {countBadge}
+        </Group>
+        {children}
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap="xs" data-testid={testId}>
+      <UnstyledButton
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        data-testid={`${testId}-toggle`}
+        style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}
+      >
+        {open ? <IconChevronDown size={16} /> : <IconChevronRight size={16} />}
+        <Text size="sm" fw={700}>
+          {label}
+        </Text>
+        {countBadge}
+      </UnstyledButton>
+      <Collapse in={open}>{open ? children : null}</Collapse>
+    </Stack>
+  );
+}
+
+/**
+ * Render a submissions list as status SECTIONS (Live → Pending → Rejected →
+ * Withdrawn). Each non-empty bucket gets its own section + table (built by
+ * `renderTable` from that bucket's groups); empty buckets render nothing. Shared by
+ * both the onsite (`MySubmissionsList`) and offsite (`OffsiteSubmissionsList`)
+ * lists so the section layout + collapse behavior are identical.
+ */
+export function StatusSections<T>({
+  buckets,
+  testIdPrefix,
+  renderTable,
+}: {
+  buckets: BucketedGroups<T>;
+  /** e.g. `apps-submissions-section` → section testids `${prefix}-live` etc. */
+  testIdPrefix: string;
+  renderTable: (groups: SubmissionGroup<T>[]) => ReactNode;
+}) {
+  return (
+    <Stack gap="lg">
+      {STATUS_SECTION_ORDER.map((bucket) => {
+        const groups = buckets[bucket];
+        if (groups.length === 0) return null;
+        const meta = STATUS_SECTION_META[bucket];
+        return (
+          <StatusSection
+            key={bucket}
+            label={meta.label}
+            color={meta.color}
+            count={groups.length}
+            collapsible={meta.collapsible}
+            testId={`${testIdPrefix}-${bucket}`}
+          >
+            {renderTable(groups)}
+          </StatusSection>
+        );
+      })}
+    </Stack>
   );
 }


### PR DESCRIPTION
UX polish on two App Blocks surfaces. All changes are **dark** — behind `features.appBlocks` / `appBlocksAuthor`, mod/author-gated.

## Part A — /apps/my-submissions: status-grouped sections (both lists)
Both the onsite `MySubmissionsList` and offsite `OffsiteSubmissionsList` are restructured from a single sortable table into status **SECTIONS**, in a fixed order:

**Live → Pending → Rejected (collapsed) → Withdrawn (collapsed)**

- Live + Pending are always expanded; Rejected + Withdrawn are wrapped in a default-**collapsed** `Collapse` whose header (chevron + label + count) toggles it.
- Each app **group** is bucketed by its `latest` submission's status: `approved` → Live (all deploy sub-states building/deploying/live/failed stay in Live — the row badge still distinguishes them), `pending` → Pending, `rejected` → Rejected, `withdrawn`/unknown → Withdrawn (safe closed default).
- Existing per-app version-collapse, the client text filter, and the row components (`OnsiteRow`/`OffsiteRow`) are reused unchanged — only the partitioning is new.
- Empty sections don't render (no "Rejected 0"). Section containers + collapse toggles carry stable `data-testid`s (`apps-submissions-section-*`, `apps-offsite-submissions-section-*`, `-toggle`).
- The pure bucketing (`bucketGroupsByStatus` / `statusBucket`) lives in `submissionsTable.ts` and is unit-tested; the shared section UI (`StatusSections`) lives in `submissionsTableUi.tsx`.
- Status is now the section, so the sortable column headers were dropped in favor of a plain `submittedAt desc` sort within each section.

## Part B — OffsiteReviewModal (mod external-review): 3 fixes
1. **Approve-notes gating** — approval is now behind an explicit `Approve…` click (mirrors Reject). `actionMode: 'view' | 'reject' | 'approve'`: view shows only `[Reject…] [Approve…]`; the "Approval notes (optional)" textarea + confirm Approve appear only in approve mode. `approvalNotes` cleared on close.
2. **Friendly dates** — the external-review submitted timestamps (the modal's submitted line + the review-queue "Submitted" column) now render `MMMM D, YYYY` (e.g. "June 7, 2026") via the shared date util. Audit-trail timestamps (report "Reported", moderation history) keep the full time-of-day formatter.
3. **Labeled card fields** — the Category and Content-rating badges get "Category" / "Content rating" labels, matching the existing URL labeled-row style.

## Tests
- Unit: `bucketGroupsByStatus` / `statusBucket` (bucketing, unknown→withdrawn, order, empty).
- Browser: onsite + offsite section membership, Live/Pending expanded, Rejected/Withdrawn collapsed-by-default (content absent until toggled), empty sections absent; modal approve-notes gating, reject flow intact, friendly submitted date, Category/Content-rating labels.
- `vitest` (unit + component) green locally; `tsc --noEmit` clean for all touched files (remaining errors are pre-existing stale-Prisma noise in unrelated files). Authoritative typecheck = the Tekton preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)