### PR TITLE
fix(ssr-prefetch): limit app-shell prefetch to gate-(2)-clean queries

### DIFF
--- a/src/server/utils/__tests__/ssr-prefetch-app-shell.test.ts
+++ b/src/server/utils/__tests__/ssr-prefetch-app-shell.test.ts
@@ -9,12 +9,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * `trpcState` and hydrates on the client (which runs `staleTime: Infinity`, so
  * the hydrated value sticks and the ~188ms client→origin round-trip is saved)
  * instead of firing on mount. This pins the safety contract:
- *   - the SAFE session queries are prefetched on full SSR when the flag is on,
+ *   - the SAFE session query is prefetched on full SSR when the flag is on,
  *   - nothing is prefetched on a client-nav `/_next/data` fetch (no `ssg`),
  *   - the flag OFF prefetches nothing (but SSG/`trpcState` is unaffected),
  *   - anon sessions get no user-scoped prefetch,
  *   - `buzz.getUserMultipliers` is gated on the `buzz` flag,
  *   - a failing shell query degrades to client-fetch — it never 500s SSR.
+ *
+ * GATE (2) guard: the shell prefetch is intentionally limited to fast,
+ * read-only, local-store queries. `user.checkNotifications` (cross-service
+ * `@civitai/notifications` call) and `user.getBookmarkCollections` (WRITEs default
+ * bookmark collections via `dbWrite.collection.create`) were REMOVED for failing
+ * gate (2); these tests assert they are NO LONGER prefetched so nobody re-adds
+ * them to the SSR first-byte path.
  *
  * server-side-helpers.ts pulls the whole app router + clickhouse + auth graph at
  * module load; stub those so the module imports in isolation and the tRPC SSG
@@ -88,16 +95,17 @@ beforeEach(() => {
 });
 
 describe('createServerSideProps — SSR app-shell prefetch', () => {
-  it('prefetches the SAFE session shell queries on full SSR when the flag is on', async () => {
+  it('prefetches the SAFE session shell query on full SSR when the flag is on', async () => {
     const gssp = createServerSideProps({ useSSG: true, resolver: okResolver });
     const res: any = await gssp(makeContext('/models'));
 
-    expect(h.checkNotifications).toHaveBeenCalledTimes(1);
-    expect(h.getBookmarkCollections).toHaveBeenCalledTimes(1);
     expect(h.getUserMultipliers).toHaveBeenCalledTimes(1);
     // input-less: prefetch called with no argument so the dehydrated key matches
     // the client `useQuery(undefined)` exactly.
-    expect(h.checkNotifications).toHaveBeenCalledWith();
+    expect(h.getUserMultipliers).toHaveBeenCalledWith();
+    // GATE (2) guard: the two gate-failing targets are NOT prefetched.
+    expect(h.checkNotifications).not.toHaveBeenCalled();
+    expect(h.getBookmarkCollections).not.toHaveBeenCalled();
     // hydrated cache rides down in trpcState.
     expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
   });
@@ -140,21 +148,21 @@ describe('createServerSideProps — SSR app-shell prefetch', () => {
     const gssp = createServerSideProps({ useSSG: true, resolver: okResolver });
     await gssp(makeContext('/models'));
 
-    expect(h.checkNotifications).toHaveBeenCalledTimes(1);
-    expect(h.getBookmarkCollections).toHaveBeenCalledTimes(1);
+    // buzz off → the single shell target is skipped, so nothing is prefetched.
     expect(h.getUserMultipliers).not.toHaveBeenCalled();
+    expect(h.checkNotifications).not.toHaveBeenCalled();
+    expect(h.getBookmarkCollections).not.toHaveBeenCalled();
   });
 
   it('degrades gracefully — a failing shell prefetch never rejects out of SSR', async () => {
-    h.checkNotifications.mockRejectedValueOnce(new Error('backend 500'));
+    h.getUserMultipliers.mockRejectedValueOnce(new Error('backend 500'));
     const gssp = createServerSideProps({ useSSG: true, resolver: okResolver });
 
     const res: any = await gssp(makeContext('/models'));
 
-    // SSR still resolves with a normal props payload (no throw / 500).
+    // SSR still resolves with a normal props payload (no throw / 500) even though
+    // the sole shell prefetch rejected — it degrades to the client fetch.
     expect(res.props.trpcState).toEqual({ mock: 'trpcState' });
-    // the other shell queries were still attempted (allSettled, not fail-fast).
-    expect(h.getBookmarkCollections).toHaveBeenCalledTimes(1);
     expect(h.getUserMultipliers).toHaveBeenCalledTimes(1);
   });
 
@@ -176,7 +184,7 @@ describe('createServerSideProps — SSR app-shell prefetch', () => {
     try {
       // A shell task that never settles → the batch can only complete via its
       // 300ms deadline. In serial code the resolver could not run until then.
-      h.checkNotifications.mockImplementationOnce(() => new Promise<undefined>(() => {}));
+      h.getUserMultipliers.mockImplementationOnce(() => new Promise<undefined>(() => {}));
       const resolver = vi.fn(async () => ({ props: {} } as any));
       const gssp = createServerSideProps({ useSSG: true, resolver });
       const pending = gssp(makeContext('/models'));
@@ -187,7 +195,7 @@ describe('createServerSideProps — SSR app-shell prefetch', () => {
       // blocked on its (un-elapsed) deadline. Serial code would not have run it.
       expect(resolver).toHaveBeenCalledTimes(1);
       // …the shell task WAS kicked off (it's in-flight, just not awaited yet).
-      expect(h.checkNotifications).toHaveBeenCalledTimes(1);
+      expect(h.getUserMultipliers).toHaveBeenCalledTimes(1);
 
       // The render path still awaits the shell prefetch before dehydrate; it
       // resolves at the 300ms deadline.
@@ -203,7 +211,7 @@ describe('createServerSideProps — SSR app-shell prefetch', () => {
     vi.useFakeTimers();
     try {
       // Shell task hangs forever; if the redirect path awaited it, this would hang.
-      h.checkNotifications.mockImplementationOnce(() => new Promise<undefined>(() => {}));
+      h.getUserMultipliers.mockImplementationOnce(() => new Promise<undefined>(() => {}));
       const resolver = vi.fn(async () => ({
         redirect: { destination: '/login', permanent: false },
       } as any));
@@ -222,11 +230,12 @@ describe('createServerSideProps — SSR app-shell prefetch', () => {
 });
 
 describe('prefetchAppShellQueries — unit', () => {
-  it('prefetches all three SAFE queries for an authed session with buzz on', async () => {
+  it('prefetches only the SAFE gate-(2) query for an authed session with buzz on', async () => {
     await prefetchAppShellQueries(h.fakeSsg as any, authedSession, features());
-    expect(h.checkNotifications).toHaveBeenCalledTimes(1);
-    expect(h.getBookmarkCollections).toHaveBeenCalledTimes(1);
     expect(h.getUserMultipliers).toHaveBeenCalledTimes(1);
+    // GATE (2) guard: the cross-service / render-path-write targets stay OUT.
+    expect(h.checkNotifications).not.toHaveBeenCalled();
+    expect(h.getBookmarkCollections).not.toHaveBeenCalled();
   });
 
   it('prefetches nothing for an anonymous session', async () => {
@@ -237,7 +246,7 @@ describe('prefetchAppShellQueries — unit', () => {
   });
 
   it('resolves (never throws) when a prefetch rejects', async () => {
-    h.getBookmarkCollections.mockRejectedValueOnce(new Error('db down'));
+    h.getUserMultipliers.mockRejectedValueOnce(new Error('db down'));
     await expect(
       prefetchAppShellQueries(h.fakeSsg as any, authedSession, features())
     ).resolves.toBeUndefined();
@@ -247,7 +256,7 @@ describe('prefetchAppShellQueries — unit', () => {
     vi.useFakeTimers();
     try {
       // A prefetch that hangs forever — without the deadline this would block SSR.
-      h.checkNotifications.mockImplementationOnce(() => new Promise<undefined>(() => {}));
+      h.getUserMultipliers.mockImplementationOnce(() => new Promise<undefined>(() => {}));
 
       const pending = prefetchAppShellQueries(h.fakeSsg as any, authedSession, features());
       let settled = false;

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -62,6 +62,23 @@ type SSGHelpers = Awaited<ReturnType<typeof getServerProxySSGHelpers>>;
  * `chat.getUserSettings` are already seeded there; re-prefetching them would be
  * a duplicate backend call for no gain.
  *
+ * GATE (2) — an SSR-prefetch target MUST be FAST + READ-ONLY + local-store,
+ * because this runs on the `getServerSideProps` first-byte critical path. A
+ * target that writes, or that fans out to another service, adds its failure mode
+ * and latency to TTFB for every authed render. The ONLY remaining target,
+ * `buzz.getUserMultipliers`, is Redis-cached parallel reads with no writes and no
+ * cross-service call — gate-(2) clean. Two earlier targets were REMOVED for
+ * failing gate (2) — DO NOT re-add them here:
+ *   - `user.checkNotifications` → `getUserNotificationCount` →
+ *     `notifications.countNotifications` (the `@civitai/notifications` client) is
+ *     a CROSS-SERVICE call to the separate notifications service with its own
+ *     failure mode — a flaky external dependency on the SSR first-byte path.
+ *   - `user.getBookmarkCollections` → `getUserBookmarkCollections`
+ *     (`src/server/services/user.service.ts`) does `dbWrite.collection.create` to
+ *     lazily create default bookmark collections — a WRITE on the SSR render path.
+ * Both now fall back to their normal async client fetch (the pre-#2990
+ * behavior), which is correct and cheap.
+ *
  * All targets are input-less protected reads (session-gated on the client), so
  * they are prefetched ONLY for authenticated sessions. `buzz.getUserMultipliers`
  * additionally requires the `buzz` feature flag (its `buzzProcedure` throws
@@ -118,9 +135,8 @@ export async function prefetchAppShellQueries(
 
   if (session?.user) {
     // Input-less, protected, static-at-load; `staleTime: Infinity` on the client
-    // so the hydrated value sticks (round-trip truly saved).
-    tasks.push(ssg.user.checkNotifications.prefetch());
-    tasks.push(ssg.user.getBookmarkCollections.prefetch());
+    // so the hydrated value sticks (round-trip truly saved). Gate (2): the only
+    // shell target is this Redis-cached, read-only, no-cross-service query.
     // buzzProcedure = protected + `isFlagProtected('buzz')`: throws unless the
     // `buzz` flag is on, so only prefetch when it is (allSettled would swallow
     // the throw anyway, but skipping avoids a guaranteed-failed backend call).


### PR DESCRIPTION
## What

Correctness hygiene on the merged, deployed SSR app-shell prefetch (**#2990**). **Not a revert** — the `ssrPrefetchShell` Flipt flag, the best-effort/deadline machinery, and the generator prefetch path (#2993) all stay. This just trims the shell prefetch from three tRPC targets down to the one that belongs on the SSR first-byte path.

## Gate (2)

An SSR-prefetch target must be **FAST + READ-ONLY + local-store**, because `getServerSideProps` blocks the first byte — a target that writes or fans out to another service adds its latency and failure mode to TTFB on every authed render. Two of the three shell targets fail gate (2) (source-verified):

- 🔴 **`user.checkNotifications`** → `getUserNotificationCount` → `notifications.countNotifications` — the `@civitai/notifications` client (`src/server/services/notification.service.ts:7,83`). A **cross-service call** to the separate notifications service with its own failure mode, on the SSR first-byte path.
- 🔴 **`user.getBookmarkCollections`** → `getUserBookmarkCollections` (`src/server/services/user.service.ts:2297`) does `dbRead.collection.findMany` **and `dbWrite.collection.create`** (`:2304`) to lazily create default bookmark collections — a **WRITE on the SSR render path**.
- ✅ **`buzz.getUserMultipliers`** — Redis-cached parallel reads, no writes, no cross-service. Gate-(2) clean → **kept** (with its existing session + `features.buzz` gates).

## The change

- `prefetchAppShellQueries` (`src/server/utils/server-side-helpers.ts`): remove the `checkNotifications` and `getBookmarkCollections` prefetches; keep only `getUserMultipliers`. Everything else is unchanged — the `ssrPrefetchShell` flag gate, `settlePrefetchWithDeadline` (300ms best-effort), the concurrency wiring, and the dehydrate path. It just prefetches one query now instead of three.
- Doc comment updated to state gate (2) and **why** the two were removed (cross-service call / render-path write), so they aren't re-added.
- `prefetchGeneratorQueries` (#2993) is **untouched** — its three targets (`challenge.getInfinite` DB read, `generationPreset.getOwn` DB read, `user.userRewardDetails` Redis) are all gate-(2)-clean.

## Behavior change

Mods (the only segment the flag is on for) no longer get notifications/bookmarks pre-seeded on GSSP pages — those fall back to the normal async client fetch, which is the **pre-#2990 behavior (no regression)**, and it removes the render-path write + the cross-service SSR dependency. Buzz multipliers still pre-seed. No flag change.

## Tests — no regression

Updated `ssr-prefetch-app-shell.test.ts`: the shell path asserts only `getUserMultipliers` is prefetched, and adds **re-add guards** asserting `checkNotifications`/`getBookmarkCollections` are NO LONGER prefetched (on SSR, on the unit path, and on the buzz-off path). Degradation / deadline / concurrency / redirect cases rewired onto the surviving query. Generator suite left as-is.

```
npx vitest run src/server/utils/__tests__/ssr-prefetch-app-shell.test.ts \
               src/server/utils/__tests__/ssr-prefetch-generator.test.ts
# 2 files, 23 passed (13 app-shell + 10 generator — generator green = no regression)
```

Typecheck (`tsc --noEmit`): 0 errors on the touched files (0 project-wide in this run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
