### PR TITLE
fix(api/download): return 404 (not 500) on unresolvable download key

### DIFF
--- a/src/pages/api/download/[...key].ts
+++ b/src/pages/api/download/[...key].ts
@@ -1,8 +1,9 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { getDownloadUrl } from '~/utils/delivery-worker';
+import { DeliveryWorkerError, getDownloadUrl } from '~/utils/delivery-worker';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { dbWrite, dbRead } from '~/server/db/client';
 import requestIp from 'request-ip';
+import { isClientAbortError } from '~/server/utils/errorHandling';
 
 export default async function downloadTrainingData(req: NextApiRequest, res: NextApiResponse) {
   // Get ip so that we can block exploits we catch
@@ -24,7 +25,55 @@ export default async function downloadTrainingData(req: NextApiRequest, res: Nex
     else return res.redirect(`/login?returnUrl=/api/download/${key}`);
   }
 
-  const { url } = await getDownloadUrl(key);
+  // This is a catch-all `/api/download/[...key]` route. Clients that hit a
+  // non-existent sub-path (e.g. `/api/download/images/:id`, which is NOT a real
+  // download endpoint) fall through here: the segments are joined into a key
+  // like `images/127209598` that the delivery worker cannot resolve. That was
+  // the dominant dp-prod raw-500 source — the throw below was unguarded. A key
+  // the delivery worker cannot resolve is a CLIENT error (404 / 400), not a 500.
+  let url: string | undefined;
+  try {
+    ({ url } = await getDownloadUrl(key));
+  } catch (err: unknown) {
+    if (isClientAbortError(err)) {
+      if (!res.headersSent) res.status(499).end();
+      return;
+    }
+
+    if (err instanceof DeliveryWorkerError) {
+      // 404/410 → the key doesn't resolve to a stored file (not found).
+      // 400     → the delivery worker rejected the key as malformed.
+      // Anything else the worker returned (403/429/5xx) is NOT a clean
+      // "this key is bad" signal — treat it as a transient backend problem and
+      // KEEP it 5xx so a real storage/worker outage is never masked as a 404.
+      if (err.statusCode === 404 || err.statusCode === 410)
+        return res.status(404).json({ error: 'Not found' });
+      if (err.statusCode === 400)
+        return res.status(400).json({ error: 'Invalid download key' });
+
+      console.error(
+        `Delivery worker error resolving key "${key}" (status ${err.statusCode}): ${err.message}`
+      );
+      res.setHeader('Retry-After', '2');
+      return res.status(503).json({ error: 'Download temporarily unavailable' });
+    }
+
+    // Not a DeliveryWorkerError → a fetch transport reject / JSON-parse / other
+    // unexpected failure. Cause is unknown, so keep it a hard 500 (do not claim
+    // not-found and do not claim retryable).
+    console.error(
+      `Unexpected error resolving download key "${key}": ${(err as Error)?.message ?? String(err)}`
+    );
+    return res.status(500).json({ error: 'Error resolving download' });
+  }
+
+  if (!url) {
+    // Delivery worker returned OK but no URL — a backend contract violation, not
+    // a client error. Surface as 5xx rather than redirecting to `undefined`
+    // (which would itself throw a raw 500).
+    console.error(`Delivery worker returned no url for key "${key}"`);
+    return res.status(502).json({ error: 'Download temporarily unavailable' });
+  }
 
   res.redirect(url);
 }

--- a/src/pages/api/download/[...key].ts
+++ b/src/pages/api/download/[...key].ts
@@ -4,6 +4,7 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { dbWrite, dbRead } from '~/server/db/client';
 import requestIp from 'request-ip';
 import { isClientAbortError } from '~/server/utils/errorHandling';
+import { logToAxiom, safeError } from '~/server/logging/client';
 
 export default async function downloadTrainingData(req: NextApiRequest, res: NextApiResponse) {
   // Get ip so that we can block exploits we catch
@@ -51,27 +52,46 @@ export default async function downloadTrainingData(req: NextApiRequest, res: Nex
       if (err.statusCode === 400)
         return res.status(400).json({ error: 'Invalid download key' });
 
-      console.error(
-        `Delivery worker error resolving key "${key}" (status ${err.statusCode}): ${err.message}`
-      );
+      // Server-fault: a real delivery-worker/storage failure. Error-log to Axiom
+      // (mirrors file.service.ts `resolve-download-url-failed`) — safeError sets
+      // `name: 'Error'`, so spread it BEFORE our literal `name`. Client-fault
+      // 404/410/400 above are intentionally NOT logged (expected, would be noise).
+      logToAxiom({
+        type: 'error',
+        ...safeError(err),
+        name: 'resolve-download-url-failed',
+        key,
+        status: 503,
+        workerStatus: err.statusCode,
+      }).catch(() => undefined);
       res.setHeader('Retry-After', '2');
       return res.status(503).json({ error: 'Download temporarily unavailable' });
     }
 
     // Not a DeliveryWorkerError → a fetch transport reject / JSON-parse / other
     // unexpected failure. Cause is unknown, so keep it a hard 500 (do not claim
-    // not-found and do not claim retryable).
-    console.error(
-      `Unexpected error resolving download key "${key}": ${(err as Error)?.message ?? String(err)}`
-    );
+    // not-found and do not claim retryable). Server-fault → Axiom.
+    logToAxiom({
+      type: 'error',
+      ...safeError(err),
+      name: 'resolve-download-url-failed',
+      key,
+      status: 500,
+    }).catch(() => undefined);
     return res.status(500).json({ error: 'Error resolving download' });
   }
 
   if (!url) {
     // Delivery worker returned OK but no URL — a backend contract violation, not
     // a client error. Surface as 5xx rather than redirecting to `undefined`
-    // (which would itself throw a raw 500).
-    console.error(`Delivery worker returned no url for key "${key}"`);
+    // (which would itself throw a raw 500). Server-fault → Axiom.
+    logToAxiom({
+      type: 'error',
+      name: 'resolve-download-url-failed',
+      message: 'delivery worker returned no url',
+      key,
+      status: 502,
+    }).catch(() => undefined);
     return res.status(502).json({ error: 'Download temporarily unavailable' });
   }
 

--- a/src/tests/api/download/key-endpoint.test.ts
+++ b/src/tests/api/download/key-endpoint.test.ts
@@ -39,6 +39,18 @@ vi.mock('~/server/db/client', () => ({
 const { mockGetClientIp } = vi.hoisted(() => ({ mockGetClientIp: vi.fn() }));
 vi.mock('request-ip', () => ({ default: { getClientIp: mockGetClientIp } }));
 
+// Mock the Axiom logger. `safeError` mirrors the real @civitai/axiom shape
+// (spreads `name: <errClass>` which the handler overrides). We assert server-fault
+// branches log and client-fault branches do NOT.
+const { mockLogToAxiom } = vi.hoisted(() => ({
+  mockLogToAxiom: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: mockLogToAxiom,
+  safeError: (e: unknown) =>
+    e instanceof Error ? { name: e.name, message: e.message } : { message: String(e) },
+}));
+
 // isClientAbortError (~/server/utils/errorHandling) is kept REAL so the handler's
 // real abort classification runs.
 
@@ -124,6 +136,7 @@ describe('/api/download/[...key] — unresolvable key returns 4xx, not 500', () 
     expect(mockGetDownloadUrl).toHaveBeenCalledWith('modelVersion/123/file.safetensors');
     expect(res._getRedirect()).toBe('https://cdn.example.com/signed-url');
     expect(res._getStatusCode()).toBe(200); // status() never called on the redirect path
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
   });
 
   it('unresolvable key (delivery worker 404) → clean 404, does NOT throw / 500', async () => {
@@ -137,6 +150,8 @@ describe('/api/download/[...key] — unresolvable key returns 4xx, not 500', () 
     expect(res._getJSONData()).toEqual({ error: 'Not found' });
     expect(res._getRedirect()).toBeUndefined();
     expect(res._getHeader('retry-after')).toBeUndefined();
+    // Client-fault: MUST NOT error-log to Axiom (an unresolvable key is expected).
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
   });
 
   it('delivery worker 410 (gone) → 404', async () => {
@@ -146,6 +161,7 @@ describe('/api/download/[...key] — unresolvable key returns 4xx, not 500', () 
     await handler(req, res);
 
     expect(res._getStatusCode()).toBe(404);
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
   });
 
   it('delivery worker 400 (malformed key) → 400', async () => {
@@ -156,6 +172,8 @@ describe('/api/download/[...key] — unresolvable key returns 4xx, not 500', () 
 
     expect(res._getStatusCode()).toBe(400);
     expect(res._getJSONData()).toEqual({ error: 'Invalid download key' });
+    // Client-fault: no Axiom error log.
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
   });
 
   it.each([500, 502, 503, 504])(
@@ -169,6 +187,16 @@ describe('/api/download/[...key] — unresolvable key returns 4xx, not 500', () 
       expect(res._getStatusCode()).not.toBe(404);
       expect(res._getJSONData()).toEqual({ error: 'Download temporarily unavailable' });
       expect(res._getHeader('retry-after')).toBe('2');
+      // Server-fault: error-logged to Axiom with the stable name + classified status.
+      expect(mockLogToAxiom).toHaveBeenCalledTimes(1);
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          name: 'resolve-download-url-failed',
+          status: 503,
+          workerStatus: status,
+        })
+      );
     }
   );
 
@@ -179,6 +207,10 @@ describe('/api/download/[...key] — unresolvable key returns 4xx, not 500', () 
       await handler(req, res);
       expect(res._getStatusCode()).toBe(503);
       expect(res._getStatusCode()).not.toBe(404);
+      // Server-fault: error-logged to Axiom.
+      expect(mockLogToAxiom).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'resolve-download-url-failed', status: 503 })
+      );
     }
   });
 
@@ -193,6 +225,15 @@ describe('/api/download/[...key] — unresolvable key returns 4xx, not 500', () 
     expect(res._getStatusCode()).toBe(500);
     expect(res._getJSONData()).toEqual({ error: 'Error resolving download' });
     expect(res._getStatusCode()).not.toBe(404);
+    // Server-fault: error-logged to Axiom with the transport error's details.
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        name: 'resolve-download-url-failed',
+        status: 500,
+        message: 'fetch failed',
+      })
+    );
   });
 
   it('delivery worker returns OK but no url → 5xx (502), never redirects to undefined', async () => {
@@ -203,6 +244,10 @@ describe('/api/download/[...key] — unresolvable key returns 4xx, not 500', () 
 
     expect(res._getStatusCode()).toBe(502);
     expect(res._getRedirect()).toBeUndefined();
+    // Server-fault (backend contract violation): error-logged to Axiom.
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'resolve-download-url-failed', status: 502 })
+    );
   });
 
   it('blacklisted ip → 403 (unchanged), never calls the delivery worker', async () => {

--- a/src/tests/api/download/key-endpoint.test.ts
+++ b/src/tests/api/download/key-endpoint.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// The catch-all `/api/download/[...key]` handler resolves a download key via the
+// delivery worker and 302-redirects to the signed URL. We drive its branches in
+// isolation by mocking the delivery worker, auth, the ip-blacklist db read, and
+// request-ip. `DeliveryWorkerError` is defined INSIDE the mock so the handler's
+// `err instanceof DeliveryWorkerError` sees the same class we throw here
+// (faithful: in prod getDownloadUrl throws exactly this typed error — see
+// src/utils/__tests__/delivery-worker.test.ts for the real error-shape proof).
+const { mockGetDownloadUrl, MockDeliveryWorkerError } = vi.hoisted(() => {
+  class MockDeliveryWorkerError extends Error {
+    readonly statusCode: number;
+    constructor(statusCode: number, statusText: string) {
+      super(`Delivery worker error: ${statusText}`);
+      this.name = 'DeliveryWorkerError';
+      this.statusCode = statusCode;
+    }
+  }
+  return { mockGetDownloadUrl: vi.fn(), MockDeliveryWorkerError };
+});
+
+vi.mock('~/utils/delivery-worker', () => ({
+  getDownloadUrl: mockGetDownloadUrl,
+  DeliveryWorkerError: MockDeliveryWorkerError,
+}));
+
+const { mockGetServerAuthSession } = vi.hoisted(() => ({ mockGetServerAuthSession: vi.fn() }));
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: mockGetServerAuthSession,
+}));
+
+const { mockFindUnique } = vi.hoisted(() => ({ mockFindUnique: vi.fn() }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { keyValue: { findUnique: mockFindUnique } },
+  dbWrite: {},
+}));
+
+const { mockGetClientIp } = vi.hoisted(() => ({ mockGetClientIp: vi.fn() }));
+vi.mock('request-ip', () => ({ default: { getClientIp: mockGetClientIp } }));
+
+// isClientAbortError (~/server/utils/errorHandling) is kept REAL so the handler's
+// real abort classification runs.
+
+import handler from '~/pages/api/download/[...key]';
+
+function createMocks({
+  key = ['images', '127209598'],
+  headers = {},
+}: {
+  key?: string[];
+  headers?: Record<string, string>;
+} = {}) {
+  const req = {
+    method: 'GET',
+    headers,
+    query: { key },
+  } as unknown as NextApiRequest;
+
+  let statusCode = 200;
+  let payload: any = undefined;
+  let redirectedTo: string | undefined;
+  let ended = false;
+  const resHeaders: Record<string, string> = {};
+
+  const res = {
+    headersSent: false,
+    setHeader(name: string, value: string) {
+      resHeaders[name.toLowerCase()] = value;
+      return res;
+    },
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(body: any) {
+      payload = body;
+      return res;
+    },
+    redirect(url: string) {
+      redirectedTo = url;
+      return res;
+    },
+    end() {
+      ended = true;
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+    _getRedirect: () => redirectedTo,
+    _getHeader: (name: string) => resHeaders[name.toLowerCase()],
+    _ended: () => ended,
+  } as unknown as NextApiResponse & {
+    _getStatusCode: () => number;
+    _getJSONData: () => any;
+    _getRedirect: () => string | undefined;
+    _getHeader: (name: string) => string | undefined;
+    _ended: () => boolean;
+  };
+
+  return { req, res };
+}
+
+const authedSession = { user: { id: 42 } };
+
+describe('/api/download/[...key] — unresolvable key returns 4xx, not 500', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Defaults: no blacklist, no ip, authed user. Individual tests override.
+    mockFindUnique.mockResolvedValue({ value: '' });
+    mockGetClientIp.mockReturnValue(null);
+    mockGetServerAuthSession.mockResolvedValue(authedSession);
+  });
+
+  it('happy path: a resolvable key 302-redirects to the signed url (unchanged)', async () => {
+    mockGetDownloadUrl.mockResolvedValue({
+      url: 'https://cdn.example.com/signed-url',
+      urlExpiryDate: new Date(),
+    });
+    const { req, res } = createMocks({ key: ['modelVersion', '123', 'file.safetensors'] });
+
+    await handler(req, res);
+
+    expect(mockGetDownloadUrl).toHaveBeenCalledWith('modelVersion/123/file.safetensors');
+    expect(res._getRedirect()).toBe('https://cdn.example.com/signed-url');
+    expect(res._getStatusCode()).toBe(200); // status() never called on the redirect path
+  });
+
+  it('unresolvable key (delivery worker 404) → clean 404, does NOT throw / 500', async () => {
+    // The dominant dp-prod 500: `/api/download/images/127209598` → key
+    // "images/127209598" → worker 404. Pre-fix this threw an unguarded 500.
+    mockGetDownloadUrl.mockRejectedValue(new MockDeliveryWorkerError(404, 'Not Found'));
+    const { req, res } = createMocks({ key: ['images', '127209598'] });
+
+    await expect(handler(req, res)).resolves.toBe(res); // resolves (no throw)
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(res._getRedirect()).toBeUndefined();
+    expect(res._getHeader('retry-after')).toBeUndefined();
+  });
+
+  it('delivery worker 410 (gone) → 404', async () => {
+    mockGetDownloadUrl.mockRejectedValue(new MockDeliveryWorkerError(410, 'Gone'));
+    const { req, res } = createMocks();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it('delivery worker 400 (malformed key) → 400', async () => {
+    mockGetDownloadUrl.mockRejectedValue(new MockDeliveryWorkerError(400, 'Bad Request'));
+    const { req, res } = createMocks();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: 'Invalid download key' });
+  });
+
+  it.each([500, 502, 503, 504])(
+    'genuine transient backend error (delivery worker %i) → 5xx (503, retryable) — NOT masked as 404',
+    async (status) => {
+      mockGetDownloadUrl.mockRejectedValue(new MockDeliveryWorkerError(status, 'backend down'));
+      const { req, res } = createMocks();
+
+      await expect(handler(req, res)).resolves.toBe(res);
+      expect(res._getStatusCode()).toBe(503);
+      expect(res._getStatusCode()).not.toBe(404);
+      expect(res._getJSONData()).toEqual({ error: 'Download temporarily unavailable' });
+      expect(res._getHeader('retry-after')).toBe('2');
+    }
+  );
+
+  it('worker 403 / 429 (ambiguous, not a clean not-found) → kept 5xx, never 404', async () => {
+    for (const status of [403, 429]) {
+      mockGetDownloadUrl.mockRejectedValue(new MockDeliveryWorkerError(status, 'nope'));
+      const { req, res } = createMocks();
+      await handler(req, res);
+      expect(res._getStatusCode()).toBe(503);
+      expect(res._getStatusCode()).not.toBe(404);
+    }
+  });
+
+  it('network/transport reject (plain Error, not a DeliveryWorkerError) → hard 500 (unknown cause)', async () => {
+    // A fetch transport reject (S3/worker unreachable) surfaces as a non-typed
+    // error. We keep it a hard 500 — not a 404 (don't claim not-found) and not a
+    // 503 (don't claim retryable for an unknown failure).
+    mockGetDownloadUrl.mockRejectedValue(new TypeError('fetch failed'));
+    const { req, res } = createMocks();
+
+    await expect(handler(req, res)).resolves.toBe(res);
+    expect(res._getStatusCode()).toBe(500);
+    expect(res._getJSONData()).toEqual({ error: 'Error resolving download' });
+    expect(res._getStatusCode()).not.toBe(404);
+  });
+
+  it('delivery worker returns OK but no url → 5xx (502), never redirects to undefined', async () => {
+    mockGetDownloadUrl.mockResolvedValue({ url: undefined, urlExpiryDate: new Date() });
+    const { req, res } = createMocks();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(502);
+    expect(res._getRedirect()).toBeUndefined();
+  });
+
+  it('blacklisted ip → 403 (unchanged), never calls the delivery worker', async () => {
+    mockGetClientIp.mockReturnValue('1.2.3.4');
+    mockFindUnique.mockResolvedValue({ value: '9.9.9.9,1.2.3.4' });
+    const { req, res } = createMocks();
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({ error: 'Forbidden' });
+    expect(mockGetDownloadUrl).not.toHaveBeenCalled();
+  });
+
+  it('missing key → 400 (unchanged)', async () => {
+    const { req, res } = createMocks({ key: [] });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(res._getJSONData()).toEqual({ error: 'Missing key' });
+    expect(mockGetDownloadUrl).not.toHaveBeenCalled();
+  });
+
+  it('unauthenticated + JSON content-type → 401 (unchanged)', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null);
+    const { req, res } = createMocks({ headers: { 'content-type': 'application/json' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(res._getJSONData()).toEqual({ error: 'Unauthorized' });
+    expect(mockGetDownloadUrl).not.toHaveBeenCalled();
+  });
+
+  it('unauthenticated + browser (non-JSON) → redirect to /login (unchanged)', async () => {
+    mockGetServerAuthSession.mockResolvedValue(null);
+    const { req, res } = createMocks({ key: ['modelVersion', '5', 'a.bin'] });
+
+    await handler(req, res);
+
+    expect(res._getRedirect()).toBe('/login?returnUrl=/api/download/modelVersion/5/a.bin');
+    expect(mockGetDownloadUrl).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/__tests__/delivery-worker.test.ts
+++ b/src/utils/__tests__/delivery-worker.test.ts
@@ -34,7 +34,12 @@ vi.mock('~/server/db/client', () => ({
   dbWrite: {},
 }));
 
-import { getDownloadUrl, resolveDownloadUrl, safeDecodeURIComponent } from '../delivery-worker';
+import {
+  DeliveryWorkerError,
+  getDownloadUrl,
+  resolveDownloadUrl,
+  safeDecodeURIComponent,
+} from '../delivery-worker';
 
 describe('safeDecodeURIComponent', () => {
   it('decodes a well-formed encoded value', () => {
@@ -94,11 +99,55 @@ describe('getDownloadUrl — malformed file.url / filename no longer 500s', () =
   });
 
   it('throws (→ caller treats as not-found) when the delivery worker rejects every key', async () => {
-    fetchMock.mockResolvedValue({ ok: false, statusText: 'Not Found' } as unknown as Response);
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as unknown as Response);
 
     await expect(
       getDownloadUrl('https://abcd1234.r2.cloudflarestorage.com/civitai/files/x.safetensors')
     ).rejects.toThrow(/Delivery worker error/);
+  });
+
+  it('throws a DeliveryWorkerError carrying the upstream 404 status (not-found → caller can 404)', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as unknown as Response);
+
+    await getDownloadUrl(
+      'https://abcd1234.r2.cloudflarestorage.com/civitai/files/x.safetensors'
+    ).then(
+      () => {
+        throw new Error('expected getDownloadUrl to reject');
+      },
+      (err) => {
+        expect(err).toBeInstanceOf(DeliveryWorkerError);
+        expect((err as DeliveryWorkerError).statusCode).toBe(404);
+      }
+    );
+  });
+
+  it('throws a DeliveryWorkerError carrying an upstream 5xx status (transient → caller keeps 5xx)', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+    } as unknown as Response);
+
+    await getDownloadUrl(
+      'https://abcd1234.r2.cloudflarestorage.com/civitai/files/x.safetensors'
+    ).then(
+      () => {
+        throw new Error('expected getDownloadUrl to reject');
+      },
+      (err) => {
+        expect(err).toBeInstanceOf(DeliveryWorkerError);
+        expect((err as DeliveryWorkerError).statusCode).toBe(503);
+      }
+    );
   });
 });
 

--- a/src/utils/delivery-worker.ts
+++ b/src/utils/delivery-worker.ts
@@ -11,6 +11,31 @@ export type DownloadInfo = {
 };
 
 /**
+ * Thrown by `getDownloadUrl` when the delivery worker responds non-OK for every
+ * key candidate. Carries the upstream HTTP `statusCode` so callers can tell a
+ * client error (404 not-found / 400 malformed key → the key doesn't resolve to a
+ * stored file) apart from a transient backend/storage failure (5xx, or a
+ * network-layer failure that never produces a status). Without this distinction
+ * a caller can only see a generic thrown Error and would have to guess — masking
+ * a real storage outage as "not found" (or a bad key as a 500).
+ *
+ * `statusCode` is the delivery worker's HTTP status. It is `undefined` only when
+ * the failure happened before a response existed (a `fetch` transport reject),
+ * in which case this error is never thrown — the transport error propagates
+ * as-is — so in practice `statusCode` is always set on a `DeliveryWorkerError`.
+ */
+export class DeliveryWorkerError extends Error {
+  readonly statusCode: number;
+  constructor(statusCode: number, statusText: string) {
+    // Keep the historical "Delivery worker error: …" message so existing
+    // callers/log-matchers that key off it are unaffected.
+    super(`Delivery worker error: ${statusText}`);
+    this.name = 'DeliveryWorkerError';
+    this.statusCode = statusCode;
+  }
+}
+
+/**
  * `decodeURIComponent` throws `URIError: URI malformed` on a value with a
  * broken/truncated percent-sequence (e.g. a lone `%`, `%E0%A4%A`). Some stored
  * `file.url` / filename values are already-encoded or contain raw `%` literals,
@@ -142,7 +167,7 @@ export async function getDownloadUrl(fileUrl: string, fileName?: string) {
   }
 
   if (!response.ok) {
-    throw new Error(`Delivery worker error: ${response.statusText}`);
+    throw new DeliveryWorkerError(response.status, response.statusText);
   }
   const result = await response.json();
   return result as DownloadInfo;


### PR DESCRIPTION
## Root cause

`GET /api/download/images/{id}?token=…` returns a raw **HTTP 500** — the dominant dp-prod 500 source (~0.4/s, ~185/h; one client retrying a fixed set of ~20 image IDs).

`/api/download/images/:id` is **not** a real download route. The request falls through to the catch-all `src/pages/api/download/[...key].ts` (`downloadTrainingData`), which joins the segments into `key = "images/127209598"` and calls `const { url } = await getDownloadUrl(key)` **unguarded**. The delivery worker can't resolve that as a stored file → `getDownloadUrl` throws → no try/catch → **raw unhandled 500**. A malformed/unresolvable download key is a **client error (404 / 400), not a 500**.

## The not-found vs. transient distinction (the load-bearing nuance)

Pre-fix, `getDownloadUrl` threw a plain `Error("Delivery worker error: <statusText>")` for **any** non-OK delivery-worker response — the HTTP status was discarded, so a caller could not tell a 404 (key doesn't resolve) apart from a 5xx (storage/worker outage). Blanket-converting every failure to 404 would **mask a real storage incident** as "not found".

Fix: `getDownloadUrl` now throws a typed **`DeliveryWorkerError`** carrying the upstream `statusCode` (message prefix `Delivery worker error: …` preserved, so existing callers / log matchers and the `resolveDownloadUrl` bare-catch fallback are unaffected). The handler maps by class:

| From delivery worker | Handler returns | Why |
|---|---|---|
| **404 / 410** | **404** `{ error: 'Not found' }` | key doesn't resolve to a stored file |
| **400** | **400** `{ error: 'Invalid download key' }` | malformed key |
| **5xx / 403 / 429** | **503** + `Retry-After: 2` | genuine/ambiguous backend problem — **kept 5xx so a real outage is never masked as not-found** |
| fetch transport reject / other non-typed error | **500** | unknown cause — don't claim not-found, don't claim retryable |
| OK but no `url` | **502** | backend contract violation; avoids `res.redirect(undefined)` (itself a raw 500) |

Everything else is unchanged: the ip-blacklist 403, the `Missing key` 400, the auth check (401 / redirect to `/login?returnUrl=…`), and the **happy path** (valid key → `getDownloadUrl` → `res.redirect(url)`).

## Files

- `src/utils/delivery-worker.ts` — add `DeliveryWorkerError { statusCode }`; `getDownloadUrl` throws it on the non-OK path (was a plain `Error`).
- `src/pages/api/download/[...key].ts` — guard `getDownloadUrl` + the subsequent redirect; classify by upstream status.

## Tests

- **`src/tests/api/download/key-endpoint.test.ts`** (new, 15 cases): unresolvable-key 404, 410→404, 400→400, transient 500/502/503/504→503 (not 404), 403/429→503, transport-reject→500, no-url→502, happy-path redirect, and the unchanged blacklist-403 / missing-key-400 / 401 / login-redirect branches. `getDownloadUrl` + auth + db + `request-ip` mocked — no live S3/DB.
- **`src/utils/__tests__/delivery-worker.test.ts`**: added assertions that `getDownloadUrl` throws a `DeliveryWorkerError` carrying the upstream status (404 and 503) — proves the error-shape contract the handler relies on.

**Fail-before / pass-after** verified for the not-found→404 case: with the guard reverted the handler **rejects** with the unhandled `DeliveryWorkerError` (= the raw 500 in prod); with the fix it resolves to a clean 404. Full run: **23/23 pass**. `pnpm typecheck` clean on all changed files (remaining errors are pre-existing in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)