### PR TITLE
fix(cls): reserve above-feed announcement space to stop masonry-feed displacement

### DIFF
--- a/src/components/Announcements/Announcements.browser.test.tsx
+++ b/src/components/Announcements/Announcements.browser.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * Announcements CLS reserve — component tests for the flag-gated space
+ * reservation that stops the above-feed announcement banner from displacing the
+ * tall masonry feed on load (the shift production RUM mis-attributes to
+ * `MasonryContainer .queries`, the displaced victim).
+ *
+ * Load-bearing behaviours:
+ *   1. Flag OFF ⇒ current behaviour exactly (null when nothing to show; no
+ *      reserved space, ever).
+ *   2. Flag ON + a seeded announcement + PRE-hydration (isClient=false) ⇒ render
+ *      a reserve placeholder holding `minHeight` so the feed doesn't reflow when
+ *      the isClient-gated carousel mounts.
+ *   3. Flag ON + POST-hydration with everything dismissed (data empty, isClient
+ *      true) ⇒ release the reserve (no permanent dead space for a dismisser).
+ *   4. When a real announcement is visible, the carousel receives the same
+ *      `minHeight` floor (flag ON) / none (flag OFF).
+ */
+
+// Per-test-controllable hook outputs (vi.mock is hoisted above imports).
+const mocks = vi.hoisted(() => ({
+  feedReserveCls: false,
+  hook: {
+    data: [] as Array<{ id: number; dismissed: boolean }>,
+    seededCount: 0,
+    isClient: false,
+  },
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ feedReserveCls: mocks.feedReserveCls }),
+}));
+
+vi.mock('~/components/Announcements/announcements.utils', () => ({
+  useGetAnnouncements: () => mocks.hook,
+}));
+
+// Stub the dynamically-imported carousel so tests stay network/Embla-free and
+// can assert the `minHeight` floor it receives.
+vi.mock('~/components/Announcements/AnnouncementsCarousel', () => ({
+  default: (props: { minHeight?: number }) => (
+    <div data-testid="carousel" data-minheight={props.minHeight ?? 'none'} />
+  ),
+}));
+
+// Imported AFTER the mocks are registered.
+import { Announcements } from '~/components/Announcements/Announcements';
+
+beforeEach(() => {
+  mocks.feedReserveCls = false;
+  mocks.hook = { data: [], seededCount: 0, isClient: false };
+});
+
+describe('Announcements CLS reserve', () => {
+  test('flag OFF, pre-hydration, seeded announcement → renders nothing (no reserve)', async () => {
+    mocks.feedReserveCls = false;
+    mocks.hook = { data: [], seededCount: 1, isClient: false };
+    renderWithProviders(<Announcements className="mb-3" />);
+    // Give React a tick; then assert neither the reserve nor the carousel exist.
+    await expect.poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]')).toBe(
+      null
+    );
+    expect(document.querySelector('[data-testid="carousel"]')).toBe(null);
+  });
+
+  test('flag ON, pre-hydration, seeded announcement → renders reserve holding minHeight', async () => {
+    mocks.feedReserveCls = true;
+    mocks.hook = { data: [], seededCount: 1, isClient: false };
+    renderWithProviders(<Announcements className="mb-3" />);
+    const reserve = page.getByTestId('announcements-cls-reserve');
+    await expect.element(reserve).toBeInTheDocument();
+    const el = reserve.element() as HTMLElement;
+    // Space is actually reserved (a non-trivial min-height), and it's hidden from a11y.
+    expect(parseInt(el.style.minHeight, 10)).toBeGreaterThan(100);
+    expect(el.getAttribute('aria-hidden')).toBe('true');
+    // The pass-through className is preserved so spacing (mb-3) matches the banner.
+    expect(el.className).toContain('mb-3');
+  });
+
+  test('flag ON, post-hydration, all dismissed → releases reserve (no dead space)', async () => {
+    mocks.feedReserveCls = true;
+    mocks.hook = { data: [], seededCount: 1, isClient: true };
+    renderWithProviders(<Announcements className="mb-3" />);
+    await expect.poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]')).toBe(
+      null
+    );
+    expect(document.querySelector('[data-testid="carousel"]')).toBe(null);
+  });
+
+  test('flag ON, visible announcement → carousel gets the minHeight floor', async () => {
+    mocks.feedReserveCls = true;
+    mocks.hook = { data: [{ id: 1, dismissed: false }], seededCount: 1, isClient: true };
+    renderWithProviders(<Announcements className="mb-3" />);
+    const carousel = page.getByTestId('carousel');
+    await expect.element(carousel).toBeInTheDocument();
+    expect(Number((carousel.element() as HTMLElement).dataset.minheight)).toBeGreaterThan(100);
+  });
+
+  test('flag OFF, visible announcement → carousel renders WITHOUT a floor (unchanged)', async () => {
+    mocks.feedReserveCls = false;
+    mocks.hook = { data: [{ id: 1, dismissed: false }], seededCount: 1, isClient: true };
+    renderWithProviders(<Announcements className="mb-3" />);
+    const carousel = page.getByTestId('carousel');
+    await expect.element(carousel).toBeInTheDocument();
+    expect((carousel.element() as HTMLElement).dataset.minheight).toBe('none');
+  });
+});

--- a/src/components/Announcements/Announcements.browser.test.tsx
+++ b/src/components/Announcements/Announcements.browser.test.tsx
@@ -10,15 +10,19 @@ import { renderWithProviders } from '../../../test/component-setup';
  * `MasonryContainer .queries`, the displaced victim).
  *
  * Load-bearing behaviours:
- *   1. Flag OFF ⇒ current behaviour exactly (null when nothing to show; no
- *      reserved space, ever).
- *   2. Flag ON + a seeded announcement + PRE-hydration (isClient=false) ⇒ render
- *      a reserve placeholder holding `minHeight` so the feed doesn't reflow when
- *      the isClient-gated carousel mounts.
- *   3. Flag ON + POST-hydration with everything dismissed (data empty, isClient
- *      true) ⇒ release the reserve (no permanent dead space for a dismisser).
- *   4. When a real announcement is visible, the carousel receives the same
- *      `minHeight` floor (flag ON) / none (flag OFF).
+ *   1. Flag OFF ⇒ current behaviour exactly (null when nothing to show; the
+ *      carousel with no wrapper when there is — no reserved space, ever).
+ *   2. Flag ON + a seeded `site` announcement + PRE-hydration (isClient=false) ⇒
+ *      a PERSISTENT parent holding a responsive min-height (mobile 203 / desktop
+ *      162), spacer inside.
+ *   3. The SAME persistent parent (holding the min-height) is present once the
+ *      carousel mounts — so the space is held continuously across the
+ *      spacer→carousel swap (no collapse gap / double-shift while the dynamic
+ *      chunk resolves).
+ *   4. Flag ON + POST-hydration with everything dismissed ⇒ release the reserve
+ *      (no permanent dead space for a dismisser).
+ *   5. Reserve is scoped to `type === 'site'` — generator/training placements
+ *      (above a form/wizard, not the feed) never reserve.
  */
 
 // Per-test-controllable hook outputs (vi.mock is hoisted above imports).
@@ -39,16 +43,15 @@ vi.mock('~/components/Announcements/announcements.utils', () => ({
   useGetAnnouncements: () => mocks.hook,
 }));
 
-// Stub the dynamically-imported carousel so tests stay network/Embla-free and
-// can assert the `minHeight` floor it receives.
+// Stub the dynamically-imported carousel so tests stay network/Embla-free.
 vi.mock('~/components/Announcements/AnnouncementsCarousel', () => ({
-  default: (props: { minHeight?: number }) => (
-    <div data-testid="carousel" data-minheight={props.minHeight ?? 'none'} />
-  ),
+  default: () => <div data-testid="carousel" />,
 }));
 
 // Imported AFTER the mocks are registered.
 import { Announcements } from '~/components/Announcements/Announcements';
+
+const RESERVE_CLASSES = ['min-h-[203px]', 'md:min-h-[162px]'];
 
 beforeEach(() => {
   mocks.feedReserveCls = false;
@@ -56,56 +59,71 @@ beforeEach(() => {
 });
 
 describe('Announcements CLS reserve', () => {
-  test('flag OFF, pre-hydration, seeded announcement → renders nothing (no reserve)', async () => {
+  test('flag OFF, pre-hydration, seeded announcement → renders nothing (no reserve, no wrapper)', async () => {
     mocks.feedReserveCls = false;
     mocks.hook = { data: [], seededCount: 1, isClient: false };
     renderWithProviders(<Announcements className="mb-3" />);
-    // Give React a tick; then assert neither the reserve nor the carousel exist.
-    await expect.poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]')).toBe(
-      null
-    );
+    await expect
+      .poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]'))
+      .toBe(null);
     expect(document.querySelector('[data-testid="carousel"]')).toBe(null);
   });
 
-  test('flag ON, pre-hydration, seeded announcement → renders reserve holding minHeight', async () => {
+  test('flag ON, pre-hydration, seeded site announcement → persistent parent holds responsive min-height (spacer inside)', async () => {
     mocks.feedReserveCls = true;
     mocks.hook = { data: [], seededCount: 1, isClient: false };
     renderWithProviders(<Announcements className="mb-3" />);
     const reserve = page.getByTestId('announcements-cls-reserve');
     await expect.element(reserve).toBeInTheDocument();
     const el = reserve.element() as HTMLElement;
-    // Space is actually reserved (a non-trivial min-height), and it's hidden from a11y.
-    expect(parseInt(el.style.minHeight, 10)).toBeGreaterThan(100);
+    // Reserves the LARGER (mobile) height, with a desktop override — never under-reserves.
+    for (const cls of RESERVE_CLASSES) expect(el.className).toContain(cls);
+    // Spacer state: hidden from a11y, no carousel inside yet, pass-through spacing preserved.
     expect(el.getAttribute('aria-hidden')).toBe('true');
-    // The pass-through className is preserved so spacing (mb-3) matches the banner.
+    expect(el.querySelector('[data-testid="carousel"]')).toBe(null);
     expect(el.className).toContain('mb-3');
+  });
+
+  test('flag ON, visible announcement → SAME persistent parent still holds min-height, now wrapping the carousel', async () => {
+    mocks.feedReserveCls = true;
+    mocks.hook = { data: [{ id: 1, dismissed: false }], seededCount: 1, isClient: true };
+    renderWithProviders(<Announcements className="mb-3" />);
+    const reserve = page.getByTestId('announcements-cls-reserve');
+    await expect.element(reserve).toBeInTheDocument();
+    const el = reserve.element() as HTMLElement;
+    // The min-height is held by the SAME parent across the swap → no collapse gap.
+    for (const cls of RESERVE_CLASSES) expect(el.className).toContain(cls);
+    // Carousel is now nested INSIDE the persistent parent, and content is not aria-hidden.
+    expect(el.querySelector('[data-testid="carousel"]')).not.toBe(null);
+    expect(el.getAttribute('aria-hidden')).toBe(null);
   });
 
   test('flag ON, post-hydration, all dismissed → releases reserve (no dead space)', async () => {
     mocks.feedReserveCls = true;
     mocks.hook = { data: [], seededCount: 1, isClient: true };
     renderWithProviders(<Announcements className="mb-3" />);
-    await expect.poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]')).toBe(
-      null
-    );
+    await expect
+      .poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]'))
+      .toBe(null);
     expect(document.querySelector('[data-testid="carousel"]')).toBe(null);
   });
 
-  test('flag ON, visible announcement → carousel gets the minHeight floor', async () => {
+  test('flag ON but type !== "site" (generator) → no reserve (scoped to the feed placement)', async () => {
     mocks.feedReserveCls = true;
-    mocks.hook = { data: [{ id: 1, dismissed: false }], seededCount: 1, isClient: true };
-    renderWithProviders(<Announcements className="mb-3" />);
-    const carousel = page.getByTestId('carousel');
-    await expect.element(carousel).toBeInTheDocument();
-    expect(Number((carousel.element() as HTMLElement).dataset.minheight)).toBeGreaterThan(100);
+    mocks.hook = { data: [], seededCount: 1, isClient: false };
+    renderWithProviders(<Announcements type="generator" />);
+    await expect
+      .poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]'))
+      .toBe(null);
   });
 
-  test('flag OFF, visible announcement → carousel renders WITHOUT a floor (unchanged)', async () => {
+  test('flag OFF, visible announcement → carousel renders directly, WITHOUT the reserve wrapper (unchanged)', async () => {
     mocks.feedReserveCls = false;
     mocks.hook = { data: [{ id: 1, dismissed: false }], seededCount: 1, isClient: true };
     renderWithProviders(<Announcements className="mb-3" />);
     const carousel = page.getByTestId('carousel');
     await expect.element(carousel).toBeInTheDocument();
-    expect((carousel.element() as HTMLElement).dataset.minheight).toBe('none');
+    // No persistent reserve parent in the flag-off path.
+    expect(document.querySelector('[data-testid="announcements-cls-reserve"]')).toBe(null);
   });
 });

--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -1,6 +1,7 @@
 import { useGetAnnouncements } from '~/components/Announcements/announcements.utils';
 import React from 'react';
 import dynamic from 'next/dynamic';
+import clsx from 'clsx';
 import type { AnnouncementType } from '~/server/schema/announcement.schema';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 
@@ -8,14 +9,15 @@ const AnnouncementsCarousel = dynamic(
   () => import('~/components/Announcements/AnnouncementsCarousel')
 );
 
-// Approximate rendered height (px) of one announcement carousel slide (title +
-// a short markdown body + action button row), measured from production. Used as
-// the pre-hydration space reserve + a floor once the carousel mounts, so the
-// tall masonry feed below doesn't reflow when the isClient-gated carousel
-// appears. Variable markdown makes it approximate: a taller announcement leaves
-// a small residual shift (still far less than the full un-reserved push), a
-// shorter one leaves a little dead space (never a functional break). Tune here.
-const ANNOUNCEMENT_RESERVE_PX = 162;
+// Responsive reserved height for one announcement carousel slide, measured from
+// production: ~162px on desktop, ~203px on mobile (title/markdown/button-row wrap
+// taller in a narrow column). Reserve the LARGER per-viewport so neither
+// under-reserves (an under-reserve leaves a residual downshift; an over-reserve
+// is only cosmetic dead space, never a shift). Variable markdown still makes it
+// approximate — a longer announcement leaves a small residual shift, far less
+// than the full un-reserved push. Written as literal Tailwind classes so JIT
+// emits them; tune here.
+const ANNOUNCEMENT_RESERVE_CLASS = 'min-h-[203px] md:min-h-[162px]';
 
 export function Announcements({
   className,
@@ -29,37 +31,43 @@ export function Announcements({
 
   const announcements = data.filter((x) => !x.dismissed);
 
-  // CLS reserve (flag-gated). The SSR seed tells us (dismissed-independently)
-  // whether an announcement of this type exists — `seededCount`. Hold its space
-  // so the feed doesn't shift when the carousel mounts. Active while the seed has
-  // an announcement AND we haven't resolved to "nothing to show" (post-hydration
-  // with everything dismissed) — that last case releases the reserve so a heavy
-  // dismisser isn't left with permanent dead space.
+  // CLS reserve (flag-gated). The SSR seed tells us — dismissed-independently, via
+  // `seededCount` — whether a `site` announcement exists, so we can hold its space
+  // from first paint so the tall masonry feed below doesn't reflow when the
+  // isClient-gated / dynamically-imported carousel mounts. Scoped to `type ===
+  // 'site'` (the above-feed placement in AppLayout): the `generator`/`training`
+  // placements sit above a form/wizard, not a huge feed, so they aren't the CLS
+  // problem and don't need the reserve. Released post-hydration if everything is
+  // dismissed (see the fall-through below) so a heavy dismisser keeps no dead space.
   const reserveActive =
-    features.feedReserveCls && seededCount > 0 && (!isClient || announcements.length > 0);
+    features.feedReserveCls &&
+    type === 'site' &&
+    seededCount > 0 &&
+    (!isClient || announcements.length > 0);
 
-  if (!announcements.length) {
-    // Nothing surfaced yet. Pre-hydration with a seeded announcement → hold the
-    // space (server + first client render agree: both have announcements=[] via
-    // the isClient gate and the same seededCount, so no hydration mismatch).
-    if (reserveActive) {
-      return (
-        <div
-          className={className}
-          style={{ minHeight: ANNOUNCEMENT_RESERVE_PX }}
-          aria-hidden="true"
-          data-testid="announcements-cls-reserve"
-        />
-      );
-    }
-    return null;
+  if (reserveActive) {
+    // PERSISTENT parent: this same <div> renders in the SSR HTML and stays mounted
+    // (no key, same element type + tree position) from server → hydration → the
+    // carousel's dynamic-import load. Only the INNER content swaps (spacer → the
+    // real carousel), and the min-height lives on THIS parent, so the reserved
+    // space is held CONTINUOUSLY across the handoff — no 162→0→162 collapse gap
+    // (and therefore no double-shift) while the carousel chunk resolves. Server +
+    // first client render agree (both: announcements=[] via the isClient gate,
+    // same seededCount), so there's no hydration mismatch.
+    return (
+      <div
+        className={clsx(className, ANNOUNCEMENT_RESERVE_CLASS)}
+        data-testid="announcements-cls-reserve"
+        aria-hidden={announcements.length ? undefined : true}
+      >
+        {announcements.length ? <AnnouncementsCarousel type={type} /> : null}
+      </div>
+    );
   }
 
-  return (
-    <AnnouncementsCarousel
-      className={className}
-      type={type}
-      minHeight={reserveActive ? ANNOUNCEMENT_RESERVE_PX : undefined}
-    />
-  );
+  // Flag OFF / non-site type / seed empty / post-hydration all-dismissed:
+  // byte-identical to the original behavior.
+  if (!announcements.length) return null;
+
+  return <AnnouncementsCarousel className={className} type={type} />;
 }

--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -2,10 +2,20 @@ import { useGetAnnouncements } from '~/components/Announcements/announcements.ut
 import React from 'react';
 import dynamic from 'next/dynamic';
 import type { AnnouncementType } from '~/server/schema/announcement.schema';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 
 const AnnouncementsCarousel = dynamic(
   () => import('~/components/Announcements/AnnouncementsCarousel')
 );
+
+// Approximate rendered height (px) of one announcement carousel slide (title +
+// a short markdown body + action button row), measured from production. Used as
+// the pre-hydration space reserve + a floor once the carousel mounts, so the
+// tall masonry feed below doesn't reflow when the isClient-gated carousel
+// appears. Variable markdown makes it approximate: a taller announcement leaves
+// a small residual shift (still far less than the full un-reserved push), a
+// shorter one leaves a little dead space (never a functional break). Tune here.
+const ANNOUNCEMENT_RESERVE_PX = 162;
 
 export function Announcements({
   className,
@@ -14,11 +24,42 @@ export function Announcements({
   className?: string;
   type?: AnnouncementType;
 }) {
-  const { data } = useGetAnnouncements(type);
+  const features = useFeatureFlags();
+  const { data, seededCount, isClient } = useGetAnnouncements(type);
 
   const announcements = data.filter((x) => !x.dismissed);
 
-  if (!announcements.length) return null;
+  // CLS reserve (flag-gated). The SSR seed tells us (dismissed-independently)
+  // whether an announcement of this type exists — `seededCount`. Hold its space
+  // so the feed doesn't shift when the carousel mounts. Active while the seed has
+  // an announcement AND we haven't resolved to "nothing to show" (post-hydration
+  // with everything dismissed) — that last case releases the reserve so a heavy
+  // dismisser isn't left with permanent dead space.
+  const reserveActive =
+    features.feedReserveCls && seededCount > 0 && (!isClient || announcements.length > 0);
 
-  return <AnnouncementsCarousel className={className} type={type} />;
+  if (!announcements.length) {
+    // Nothing surfaced yet. Pre-hydration with a seeded announcement → hold the
+    // space (server + first client render agree: both have announcements=[] via
+    // the isClient gate and the same seededCount, so no hydration mismatch).
+    if (reserveActive) {
+      return (
+        <div
+          className={className}
+          style={{ minHeight: ANNOUNCEMENT_RESERVE_PX }}
+          aria-hidden="true"
+          data-testid="announcements-cls-reserve"
+        />
+      );
+    }
+    return null;
+  }
+
+  return (
+    <AnnouncementsCarousel
+      className={className}
+      type={type}
+      minHeight={reserveActive ? ANNOUNCEMENT_RESERVE_PX : undefined}
+    />
+  );
 }

--- a/src/components/Announcements/AnnouncementsCarousel.tsx
+++ b/src/components/Announcements/AnnouncementsCarousel.tsx
@@ -9,14 +9,9 @@ import type { AnnouncementType } from '~/server/schema/announcement.schema';
 export default function AnnouncementsCarousel({
   className,
   type = 'site',
-  minHeight,
 }: {
   className?: string;
   type?: AnnouncementType;
-  // Optional floor (px) so the carousel holds the space previously reserved by
-  // the pre-hydration placeholder (feed-CLS reserve) — keeps the swap from the
-  // placeholder to the real carousel from reflowing the feed below it.
-  minHeight?: number;
 }) {
   const autoplayRef = useRef(autoplay({ delay: 10000 }));
   const { data } = useGetAnnouncements(type);
@@ -28,7 +23,7 @@ export default function AnnouncementsCarousel({
   return (
     // Required custom class to apply certain styles based on peer elements
     // eslint-disable-next-line tailwindcss/no-custom-classname
-    <div className={clsx('announcements peer container', className)} style={{ minHeight }}>
+    <div className={clsx('announcements peer container', className)}>
       <Embla plugins={[autoplayRef.current]} loop withIndicators={announcements.length > 1}>
         <Embla.Viewport>
           <Embla.Container className="-ml-4 flex">

--- a/src/components/Announcements/AnnouncementsCarousel.tsx
+++ b/src/components/Announcements/AnnouncementsCarousel.tsx
@@ -9,9 +9,14 @@ import type { AnnouncementType } from '~/server/schema/announcement.schema';
 export default function AnnouncementsCarousel({
   className,
   type = 'site',
+  minHeight,
 }: {
   className?: string;
   type?: AnnouncementType;
+  // Optional floor (px) so the carousel holds the space previously reserved by
+  // the pre-hydration placeholder (feed-CLS reserve) — keeps the swap from the
+  // placeholder to the real carousel from reflowing the feed below it.
+  minHeight?: number;
 }) {
   const autoplayRef = useRef(autoplay({ delay: 10000 }));
   const { data } = useGetAnnouncements(type);
@@ -23,7 +28,7 @@ export default function AnnouncementsCarousel({
   return (
     // Required custom class to apply certain styles based on peer elements
     // eslint-disable-next-line tailwindcss/no-custom-classname
-    <div className={clsx('announcements peer container', className)}>
+    <div className={clsx('announcements peer container', className)} style={{ minHeight }}>
       <Embla plugins={[autoplayRef.current]} loop withIndicators={announcements.length > 1}>
         <Embla.Viewport>
           <Embla.Container className="-ml-4 flex">

--- a/src/components/Announcements/announcements.utils.ts
+++ b/src/components/Announcements/announcements.utils.ts
@@ -116,5 +116,11 @@ export function useGetAnnouncements(type: AnnouncementType = 'site') {
     [typed, dismissed, isClient]
   );
 
-  return { data: announcements, ...rest };
+  // `seededCount` is the SSR-seeded, dismissed-independent count of this type's
+  // announcements. Unlike `data` (which the `isClient` gate zeroes on the server
+  // + first client render to avoid a dismissed-flash), it is stable across the
+  // SSR→hydration boundary, so a consumer can reserve layout space at first paint
+  // when the seed indicates an announcement WILL surface post-hydration. `isClient`
+  // lets the consumer scope that reserve to the pre-hydration window only.
+  return { data: announcements, seededCount: typed.length, isClient, ...rest };
 }

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -101,6 +101,17 @@ const featureFlags = createFeatureFlags({
   // prefetch degrades to client fetch, never breaks the generator SSR), so
   // flipping the flag off is an instant, safe rollback.
   ssrPrefetchGenerator: { availability: ['mod'], fliptKey: 'ssr-prefetch-generator' },
+  // Feed-page CLS fix. Reserves vertical space for the above-feed announcements
+  // banner during the pre-hydration window so the isClient-gated / dynamically
+  // imported carousel mount doesn't shove the (very tall) masonry feed down — the
+  // shift production RUM attributes to `MasonryContainer .queries`, which is the
+  // DISPLACED VICTIM (largest moved element), not the cause. Default OFF (mods
+  // only = the Flipt-DOWN fallback, mirrors `ssrPrefetchShell`); ramp a % of ALL
+  // users via Flipt (`feed-reserve-cls`) as a THRESHOLD rollout — CLS is an
+  // all-user route metric, so a mod cohort can't move the aggregate. Purely
+  // cosmetic space reservation (worst case = a little dead space, never a
+  // functional break), so flipping the flag off is an instant, safe rollback.
+  feedReserveCls: { availability: ['mod'], fliptKey: 'feed-reserve-cls' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },


### PR DESCRIPTION
## Problem — the RUM blames the wrong component

Production Faro RUM (100% of users) reports feed-route CLS p75 **0.27–0.73 (POOR)**, with **~66% of significant layout shifts attributed to `div.MasonryContainer…__queries`**, firing ~1.5–2.4s into load.

Real-browser `PerformanceObserver('layout-shift')` attribution (against production, throttled to reproduce the RUM timing) shows **`.queries` is the DISPLACED VICTIM, not the cause**:

- `.queries` is the tallest element on every feed page. Its width is stable at first paint (CSS container-query `320/16/7` == JS `combinedWidth`) and item heights are reserved — it does **not** reflow internally.
- On `/images` and `/models` the feed's document-Y jumps **116px → 290px (a rigid +174px)**. The element that appears directly above it is the **Announcements banner** (measured **162px** desktop / **203px** mobile + `mb-3`).
- Root chain: `AppLayout.tsx:134` renders `{announcements && <Announcements/>}` directly above the feed. `announcements.utils.ts` gates the SSR-seeded data behind `useIsClient()` (returns `[]` on server + first client render to avoid a dismissed-flash), and `AnnouncementsCarousel` is a `dynamic()` import — so the banner is `null` (0px) until post-hydration, then mounts and shoves the tall feed down. `.queries`, being huge, dominates the shift attribution → RUM names it.

## Fix — persistent-parent above-feed space reserve (flag-gated)

Hold the announcement's vertical space **continuously from first paint** so the feed lays out at its final position:

- `useGetAnnouncements` now also returns `seededCount` (the SSR-seeded, **dismissed-independent** count — stable across the SSR→hydration boundary) and `isClient`.
- **Persistent parent (Fix A, essential):** the reserved `min-height` lives on a SINGLE `<div>` that renders in the SSR HTML and stays mounted (same element, no key) from server → hydration → the carousel's dynamic-import load. Only the INNER content swaps (spacer → carousel), so the space is held **continuously** across the handoff. This closes a real double-shift the audit caught: with a *separate* spacer div that unmounts when the carousel mounts, the dynamic chunk gap collapses `162→0→162` — see the deterministic fixture below (separate-div CLS **0.252 = 2× baseline** vs persistent-parent **0**).
- **Responsive height (Fix B):** measured **162px desktop / 203px mobile** (narrow column wraps taller). Reserve the LARGER per-viewport via `min-h-[203px] md:min-h-[162px]` so neither under-reserves. An under-reserve leaves a residual downshift; an over-reserve is only cosmetic dead space.
- **Scope:** gated to `type === 'site'` (the above-feed AppLayout placement). The `generator` / `training` `<Announcements>` placements sit above a form/wizard, not a feed, so they're deliberately untouched — the flag has no collateral there.
- Releases the reserve post-hydration if everything is dismissed (see limitation below).
- Hydration-safe: server + first client render agree (both `announcements=[]` via the `isClient` gate, same `seededCount`); the feature flag is SSR-seeded synchronously.

### Flag

`feedReserveCls` → Flipt `feed-reserve-cls`, `availability: ['mod']` (Flipt-DOWN fallback, mirrors `ssrPrefetchShell`), **default OFF**. 🔴 **Must be ramped as a Flipt % THRESHOLD rollout to ALL users**, not a mod cohort — CLS is an all-user route metric. Default-OFF = the control arm. Purely cosmetic reserve → flipping off is an instant safe rollback. *(The Flipt flag itself still needs creating + ramping in flipt-state.)*

## ⚠️ Not an unconditional win — ramp must be gated on the RUM A/B

For a user who has **dismissed all** current announcements, SSR still reserves 162/203px (dismiss state is client-only localStorage, unknown at SSR) → post-hydration the spacer collapses → a **162/203px UPWARD shift** that `main` doesn't have. So aggregate CLS **improves for fresh announcements** (few dismissers) but **can regress for stale ones** (many dismissers).

**Therefore: ramp gated on the RUM A/B — flag-on cohort CLS p75 by route vs flag-off (Loki `{source="faro-rum"}`, plus the frequency of `context_largest_shift_target` matching the `.queries` selector). If it doesn't improve (or regresses), the dismisser/stale-announcement case is dominating → do the cookie fix before widening.** The proper fix = move dismiss-state localStorage→cookie so SSR reserves exactly (0 when all dismissed) — deferred (bigger change).

## Verification

- **Deterministic fixture** (models header → announcement slot → tall feed, with the dynamic-import gap):
  - flag OFF: CLS **0.126**
  - old separate-div design (the audit-caught double-shift): CLS **0.252**
  - **persistent-parent (this PR): CLS 0**
- **Production baseline** (the problem, reproduced): feed displaced +174px; announcement height 162px desktop / 203px mobile.
- **Component test** (`Announcements.browser.test.tsx`, 6/6): persistent parent holds the responsive min-height in BOTH the spacer state and the carousel-mounted state (same element across the swap); releases when all dismissed; scoped out for non-`site` types; **byte-identical no-op when flag OFF**.
- Honest caveat: a full flag-ON app build wasn't runnable here (needs DB/redis/meili) and a production DOM-injection sim can't reproduce React's SSR-present atomic swap — hence the controlled fixture for the deterministic proof + the production run for the baseline magnitude.

## Scope / honesty

- **This addresses only the ~0.16 announcement push.** Programmatic **ad units** are the dominant unaddressed stacked above-feed contributor (separate, revenue-sensitive work) — so feed routes won't necessarily reach CLS < 0.1 from this change alone. Expected and honest.
- **RewardsBonusBanner is intentionally NOT touched.** Client-data-gated (`getUserMultipliers`, logged-in only) with **no SSR seed on feed pages** — a client-only reserve merely relocates its shift to hydration. The correct fix needs seeding the global bonus through the `/api/user/settings` bootstrap (high-blast-radius per-request path) for a rare ~32px banner — deferred.

## Test / typecheck

- `vitest --project component Announcements.browser.test.tsx` → **6/6 pass**. Existing `announcements-seed` unit test → 6/6.
- `tsc --noEmit`: **0 errors in touched files.** Repo baseline = 17 pre-existing errors, all in unrelated files (`image.service.ts` ×10, kysely, `bitdex-stats`, `flipt/client`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
