### PR TITLE
fix(metrics): reconcile stale model generationCount

### DIFF
--- a/src/pages/api/admin/temp/backfill-generation-counts.ts
+++ b/src/pages/api/admin/temp/backfill-generation-counts.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import { chunk } from 'lodash-es';
 import * as z from 'zod';
 import { clickhouse } from '~/server/clickhouse/client';
+import { PG_INT4_MAX } from '~/server/common/constants';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { pgDbWrite } from '~/server/db/pgDb';
 import { modelsSearchIndex } from '~/server/search-index';
@@ -69,9 +70,9 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
       WHERE createdDate >= toDate('${sinceDate}') AND modelVersionId > 0
     )
       AND createdDate <= today()
-      AND count <= 2147483647
+      AND count <= ${PG_INT4_MAX}
     GROUP BY modelVersionId
-    HAVING generationCount BETWEEN 0 AND 2147483647
+    HAVING generationCount BETWEEN 0 AND ${PG_INT4_MAX}
   `);
 
   const affectedModelIds = new Set<number>();
@@ -162,7 +163,7 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
         FROM (
           -- LEAST guards the INT4 target: a model summing past 2^31-1 across its
           -- versions would otherwise error the whole batch.
-          SELECT mv."modelId", LEAST(SUM(mvm."generationCount"), 2147483647)::int AS total
+          SELECT mv."modelId", LEAST(SUM(mvm."generationCount"), ${PG_INT4_MAX})::int AS total
           FROM "ModelVersionMetric" mvm
           JOIN "ModelVersion" mv ON mv.id = mvm."modelVersionId"
           WHERE mv."modelId" = ANY($1::int[])

--- a/src/pages/api/admin/temp/backfill-generation-counts.ts
+++ b/src/pages/api/admin/temp/backfill-generation-counts.ts
@@ -1,0 +1,199 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { chunk } from 'lodash-es';
+import * as z from 'zod';
+import { clickhouse } from '~/server/clickhouse/client';
+import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
+import { pgDbWrite } from '~/server/db/pgDb';
+import { modelsSearchIndex } from '~/server/search-index';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+/**
+ * One-off reconcile for stale `ModelVersionMetric.generationCount` (and the
+ * `ModelMetric.generationCount` rollup shown on the model card).
+ *
+ * Regression c186546ad9 (2026-05-14) narrowed the metrics-job flag window to a
+ * 1-minute `orchestration.jobs` slice, so a version that goes quiet freezes at
+ * whatever partial all-time SUM was last written — an undercount (or 0 if the
+ * MV had not materialized yet). The going-forward fix only heals versions
+ * active today; already-frozen versions need this backfill.
+ *
+ * Source of truth: orchestration.daily_resource_generation_counts (ClickHouse).
+ * Scoped to versions with generation activity since `sinceDate` (pre-regression
+ * versions settled correctly under the old code).
+ *
+ * GET/POST /api/admin/temp/backfill-generation-counts?token=$WEBHOOK_TOKEN
+ *   sinceDate  ISO date, default 2026-05-14 (regression deploy). Only versions
+ *              active on/after this date are reconciled.
+ *   batchSize  versions per PG write batch (1-10000, default 2000)
+ *   dryRun     true = report mismatches + top gaps, write nothing (default false)
+ *   reindex    true = re-queue corrected models for search-index sync (default true)
+ */
+
+const schema = z.object({
+  sinceDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/)
+    .optional()
+    .default('2026-05-14'),
+  batchSize: z.coerce.number().min(1).max(10000).optional().default(2000),
+  // z.coerce.boolean() treats "false" as true — compare the raw string instead.
+  dryRun: z
+    .string()
+    .optional()
+    .default('false')
+    .transform((v) => v === 'true'),
+  reindex: z
+    .string()
+    .optional()
+    .default('true')
+    .transform((v) => v !== 'false'),
+});
+
+type TruthRow = { modelVersionId: number; generationCount: number };
+type GapRow = { modelId: number; modelVersionId: number; stored: number; truth: number };
+
+export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
+  const { sinceDate, batchSize, dryRun, reindex } = schema.parse(req.query);
+  if (!clickhouse) {
+    res.status(500).json({ error: 'ClickHouse client not available' });
+    return;
+  }
+
+  // 1. All-time generation SUM for every version active since sinceDate.
+  const truth = await clickhouse.$query<TruthRow>(`
+    SELECT modelVersionId, toInt64(SUM(count)) AS generationCount
+    FROM orchestration.daily_resource_generation_counts
+    WHERE modelVersionId GLOBAL IN (
+      SELECT DISTINCT modelVersionId
+      FROM orchestration.daily_resource_generation_counts
+      WHERE createdDate >= toDate('${sinceDate}') AND modelVersionId > 0
+    )
+      AND createdDate <= today()
+      AND count <= 2147483647
+    GROUP BY modelVersionId
+    HAVING generationCount BETWEEN 0 AND 2147483647
+  `);
+
+  const affectedModelIds = new Set<number>();
+  let versionsChanged = 0;
+  let modelsUpdated = 0;
+  let topGaps: Array<GapRow & { gap: number }> = [];
+
+  const trackGaps = (rows: GapRow[]) => {
+    for (const r of rows) topGaps.push({ ...r, gap: r.truth - Math.max(r.stored, 0) });
+    if (topGaps.length > 500) {
+      topGaps.sort((a, b) => b.gap - a.gap);
+      topGaps = topGaps.slice(0, 100);
+    }
+  };
+
+  // 2. Per batch: find/fix mismatched ModelVersionMetric rows.
+  for (const batch of chunk(truth, batchSize)) {
+    const payload = JSON.stringify(
+      batch.map((r) => ({ modelVersionId: r.modelVersionId, generationCount: Number(r.generationCount) }))
+    );
+
+    if (dryRun) {
+      const q = await pgDbWrite.cancellableQuery<GapRow>(
+        `
+        WITH data AS (
+          SELECT * FROM jsonb_to_recordset($1::jsonb) AS x("modelVersionId" INT, "generationCount" INT)
+        )
+        SELECT mv."modelId",
+               d."modelVersionId",
+               COALESCE(mvm."generationCount", -1) AS stored,
+               d."generationCount" AS truth
+        FROM data d
+        JOIN "ModelVersion" mv ON mv.id = d."modelVersionId"
+        LEFT JOIN "ModelVersionMetric" mvm ON mvm."modelVersionId" = d."modelVersionId"
+        WHERE COALESCE(mvm."generationCount", -1) <> d."generationCount"
+        `,
+        [payload]
+      );
+      const rows = await q.result();
+      versionsChanged += rows.length;
+      rows.forEach((r) => affectedModelIds.add(r.modelId));
+      trackGaps(rows);
+      continue;
+    }
+
+    // Mirror the metrics-job upsert: FK-guard on ModelVersion, conflict on the
+    // modelVersionId pkey, timeframe defaults to 'AllTime'. Only touch rows that
+    // actually change so updatedAt churn (and search-index re-queue) stays minimal.
+    const q = await pgDbWrite.cancellableQuery<{ modelVersionId: number }>(
+      `
+      WITH data AS (
+        SELECT * FROM jsonb_to_recordset($1::jsonb) AS x("modelVersionId" INT, "generationCount" INT)
+      )
+      INSERT INTO "ModelVersionMetric" ("modelVersionId", "updatedAt", "generationCount")
+      SELECT d."modelVersionId", NOW(), d."generationCount"
+      FROM data d
+      LEFT JOIN "ModelVersionMetric" im ON im."modelVersionId" = d."modelVersionId"
+      WHERE EXISTS (SELECT 1 FROM "ModelVersion" WHERE id = d."modelVersionId")
+        AND COALESCE(im."generationCount", -1) <> d."generationCount"
+      ON CONFLICT ("modelVersionId") DO UPDATE
+        SET "generationCount" = EXCLUDED."generationCount", "updatedAt" = NOW()
+      RETURNING "modelVersionId"
+      `,
+      [payload]
+    );
+    const updated = await q.result();
+    versionsChanged += updated.length;
+
+    if (updated.length) {
+      const midQ = await pgDbWrite.cancellableQuery<{ modelId: number }>(
+        `SELECT DISTINCT "modelId" FROM "ModelVersion" WHERE id = ANY($1::int[])`,
+        [updated.map((u) => u.modelVersionId)]
+      );
+      (await midQ.result()).forEach((m) => affectedModelIds.add(m.modelId));
+    }
+  }
+
+  const modelIds = [...affectedModelIds];
+
+  // 3. Roll the corrected version metrics up to ModelMetric.generationCount.
+  if (!dryRun && modelIds.length) {
+    for (const idBatch of chunk(modelIds, 1000)) {
+      const q = await pgDbWrite.cancellableQuery<{ modelId: number }>(
+        `
+        UPDATE "ModelMetric" mm
+        SET "generationCount" = agg.total, "updatedAt" = NOW()
+        FROM (
+          SELECT mv."modelId", SUM(mvm."generationCount")::int AS total
+          FROM "ModelVersionMetric" mvm
+          JOIN "ModelVersion" mv ON mv.id = mvm."modelVersionId"
+          WHERE mv."modelId" = ANY($1::int[])
+          GROUP BY mv."modelId"
+        ) agg
+        WHERE mm."modelId" = agg."modelId"
+          AND mm."generationCount" <> agg.total
+        RETURNING mm."modelId"
+        `,
+        [idBatch]
+      );
+      modelsUpdated += (await q.result()).length;
+    }
+
+    // 4. Re-queue corrected models so feed/search cards refresh.
+    if (reindex) {
+      for (const slice of chunk(modelIds, 5000)) {
+        await modelsSearchIndex.queueUpdate(
+          slice.map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update }))
+        );
+      }
+    }
+  }
+
+  topGaps.sort((a, b) => b.gap - a.gap);
+
+  res.status(200).json({
+    dryRun,
+    sinceDate,
+    versionsScanned: truth.length,
+    versionsChanged,
+    modelsAffected: modelIds.length,
+    modelsUpdated: dryRun ? undefined : modelsUpdated,
+    reindexed: !dryRun && reindex ? modelIds.length : 0,
+    topGaps: topGaps.slice(0, 25),
+  });
+});

--- a/src/pages/api/admin/temp/backfill-generation-counts.ts
+++ b/src/pages/api/admin/temp/backfill-generation-counts.ts
@@ -150,6 +150,7 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
   }
 
   const modelIds = [...affectedModelIds];
+  const updatedModelIds: number[] = [];
 
   // 3. Roll the corrected version metrics up to ModelMetric.generationCount.
   if (!dryRun && modelIds.length) {
@@ -159,7 +160,9 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
         UPDATE "ModelMetric" mm
         SET "generationCount" = agg.total, "updatedAt" = NOW()
         FROM (
-          SELECT mv."modelId", SUM(mvm."generationCount")::int AS total
+          -- LEAST guards the INT4 target: a model summing past 2^31-1 across its
+          -- versions would otherwise error the whole batch.
+          SELECT mv."modelId", LEAST(SUM(mvm."generationCount"), 2147483647)::int AS total
           FROM "ModelVersionMetric" mvm
           JOIN "ModelVersion" mv ON mv.id = mvm."modelVersionId"
           WHERE mv."modelId" = ANY($1::int[])
@@ -171,12 +174,13 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
         `,
         [idBatch]
       );
-      modelsUpdated += (await q.result()).length;
+      updatedModelIds.push(...(await q.result()).map((r) => r.modelId));
     }
+    modelsUpdated = updatedModelIds.length;
 
-    // 4. Re-queue corrected models so feed/search cards refresh.
+    // 4. Re-queue only the models whose rollup actually changed.
     if (reindex) {
-      for (const slice of chunk(modelIds, 5000)) {
+      for (const slice of chunk(updatedModelIds, 5000)) {
         await modelsSearchIndex.queueUpdate(
           slice.map((id) => ({ id, action: SearchIndexUpdateQueueAction.Update }))
         );
@@ -193,7 +197,7 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
     versionsChanged,
     modelsAffected: modelIds.length,
     modelsUpdated: dryRun ? undefined : modelsUpdated,
-    reindexed: !dryRun && reindex ? modelIds.length : 0,
+    reindexed: !dryRun && reindex ? updatedModelIds.length : 0,
     topGaps: topGaps.slice(0, 25),
   });
 });

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -1450,6 +1450,10 @@ export const generation = {
   },
 } as const;
 export const maxRandomSeed = 2147483647;
+// Postgres INT4 (integer) column bounds — the ceiling any value written to an
+// `integer` column (e.g. metric counts) must fit under.
+export const PG_INT4_MAX = 2_147_483_647;
+export const PG_INT4_MIN = -2_147_483_648;
 export const maxUpscaleSize = 3840;
 export const minDownscaleSize = 320;
 export const minUploadSize = 300;

--- a/src/server/metrics/model.metrics.ts
+++ b/src/server/metrics/model.metrics.ts
@@ -372,8 +372,10 @@ async function getDownloadTasks(ctx: ModelMetricContext) {
 const injectedVersionIds = allInjectableResourceIds;
 
 async function getGenerationTasks(ctx: ModelMetricContext) {
-  // Flag every version generated so far today (createdDate >= toDate(lastUpdate),
-  // i.e. since 00:00 UTC), then re-SUM its all-time count from the MV below.
+  // Flag every version generated since the start of the day containing
+  // lastUpdate (createdDate >= toDate(lastUpdate)) — normally today, but wider
+  // on the first run past UTC midnight or after an outage, which usefully
+  // re-reconciles the prior day's tail. Then re-SUM its all-time count below.
   // `daily_resource_generation_counts` is built asynchronously from
   // `orchestration.jobs`, so a job's contribution lands in the MV after the job
   // row exists. Flagging by `jobs.createdAt >= lastUpdate` (a 1-minute window)

--- a/src/server/metrics/model.metrics.ts
+++ b/src/server/metrics/model.metrics.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import dayjs from '~/shared/utils/dayjs';
 import { chunk } from 'lodash-es';
+import { PG_INT4_MAX, PG_INT4_MIN } from '~/server/common/constants';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { templateHandler } from '~/server/db/db-helpers';
 import type { MetricProcessorRunContext } from '~/server/metrics/base.metrics';
@@ -228,9 +229,6 @@ async function bulkInsertMetrics<T extends readonly string[]>(
   const targetTuple = metrics.map((key) => `"${table}"."${key}"`).join(', ');
   const excludedTuple = metrics.map((key) => `EXCLUDED."${key}"`).join(', ');
 
-  const PG_INT_MAX = 2147483647;
-  const PG_INT_MIN = -2147483648;
-
   const tasks = chunk(updates, 100).map((batch, i) => async () => {
     ctx.jobContext.checkIfCanceled();
     log(`insert ${options.logName}`, i + 1, 'of', tasks.length);
@@ -243,8 +241,8 @@ async function bulkInsertMetrics<T extends readonly string[]>(
         if (
           typeof value !== 'number' ||
           !Number.isFinite(value) ||
-          value > PG_INT_MAX ||
-          value < PG_INT_MIN
+          value > PG_INT4_MAX ||
+          value < PG_INT4_MIN
         ) {
           offenders.push({ id: row[idColumn], key, value });
         }
@@ -391,7 +389,7 @@ async function getGenerationTasks(ctx: ModelMetricContext) {
     WHERE createdDate >= toDate(${ctx.lastUpdate})
       AND createdDate <= today()
       AND modelVersionId > 0
-      AND count <= 2147483647
+      AND count <= ${PG_INT4_MAX}
   `;
   const affected = generated
     .map((x) => x.modelVersionId)
@@ -407,7 +405,7 @@ async function getGenerationTasks(ctx: ModelMetricContext) {
       FROM orchestration.daily_resource_generation_counts
       WHERE modelVersionId IN (${ids})
         AND createdDate <= today()
-        AND count <= 2147483647
+        AND count <= ${PG_INT4_MAX}
       GROUP BY modelVersionId;
     `;
 

--- a/src/server/metrics/model.metrics.ts
+++ b/src/server/metrics/model.metrics.ts
@@ -220,6 +220,13 @@ async function bulkInsertMetrics<T extends readonly string[]>(
     .map((key) => `COALESCE(d."${key}", im."${key}", 0) as "${key}"`)
     .join(',\n');
   const metricOverrides = metrics.map((key) => `"${key}" = EXCLUDED."${key}"`).join(',\n');
+  // Only bump the row when a value actually moved. `updatedAt` gates the
+  // search-index enqueue (getVersionAggregationTasks → ctx.affected), so a
+  // re-SUM that returns the same count must stay a no-op — otherwise every
+  // still-active-today version re-queues to Meili each run and the write
+  // volume ramps through the UTC day.
+  const targetTuple = metrics.map((key) => `"${table}"."${key}"`).join(', ');
+  const excludedTuple = metrics.map((key) => `EXCLUDED."${key}"`).join(', ');
 
   const PG_INT_MAX = 2147483647;
   const PG_INT_MIN = -2147483648;
@@ -266,6 +273,7 @@ async function bulkInsertMetrics<T extends readonly string[]>(
           SET
             ${metricOverrides},
             "updatedAt" = NOW()
+          WHERE (${targetTuple}) IS DISTINCT FROM (${excludedTuple})
       `;
     } catch (err) {
       const ids = (batch as any[]).map((r) => r[idColumn]);
@@ -364,20 +372,24 @@ async function getDownloadTasks(ctx: ModelMetricContext) {
 const injectedVersionIds = allInjectableResourceIds;
 
 async function getGenerationTasks(ctx: ModelMetricContext) {
-  // Pull versions touched since lastUpdate from `orchestration.jobs` directly.
-  // The `daily_resource_generation_counts` MV is bucketed by Date, so filtering
-  // it by `toDate(lastUpdate)` returned every version generated since 00:00 UTC
-  // — growing linearly through the day and resetting at midnight UTC. That
-  // produced a daily ramp of search-index update volume into Meili.
+  // Flag every version generated so far today (createdDate >= toDate(lastUpdate),
+  // i.e. since 00:00 UTC), then re-SUM its all-time count from the MV below.
+  // `daily_resource_generation_counts` is built asynchronously from
+  // `orchestration.jobs`, so a job's contribution lands in the MV after the job
+  // row exists. Flagging by `jobs.createdAt >= lastUpdate` (a 1-minute window)
+  // therefore re-SUMs before the new counts settle and never revisits the
+  // version once it goes quiet, freezing the metric at an undercount. Re-summing
+  // all of today's active versions every minute reconciles that tail. The Meili
+  // write-volume ramp this breadth used to cause no longer forms: bulkInsertMetrics
+  // only bumps updatedAt on an actual value change, so a re-SUM returning the same
+  // count is a no-op and never re-queues the version to the search index.
   const generated = await ctx.ch.$query<{ modelVersionId: number }>`
     SELECT DISTINCT modelVersionId
-    FROM (
-      SELECT arrayJoin(resourcesUsed) AS modelVersionId
-      FROM orchestration.jobs
-      WHERE createdAt >= ${ctx.lastUpdate}
-        AND length(resourcesUsed) > 0
-    )
-    WHERE modelVersionId > 0
+    FROM orchestration.daily_resource_generation_counts
+    WHERE createdDate >= toDate(${ctx.lastUpdate})
+      AND createdDate <= today()
+      AND modelVersionId > 0
+      AND count <= 2147483647
   `;
   const affected = generated
     .map((x) => x.modelVersionId)


### PR DESCRIPTION
## Problem
Model card generation counts read stale/zero for recently-published or still-generating versions (`ModelVersionMetric.generationCount` → `ModelMetric.generationCount`). Reported by creator RisingV (Freshdesk 67772, ClickUp 868k9txq8).

## Root cause
Regression `c186546ad9` (2026-05-14) narrowed `getGenerationTasks`'s flag window to a 1-minute `orchestration.jobs` slice. `daily_resource_generation_counts` (ClickHouse) settles asynchronously, so a version's last jobs land in the MV *after* the recompute — and once the version goes quiet it's never re-flagged, freezing the metric at an undercount (or 0). Confirmed against ClickHouse: e.g. v3073048 stored 54 vs truth 64, v3092917 stored 50 vs truth 56.

## Fix
- **Revert the flag query** to the daily MV window so every version active today is re-summed and the async-MV tail reconciles.
- **Change-gate `bulkInsertMetrics`** — the upsert now only bumps `updatedAt` when a value actually changes (`row IS DISTINCT FROM excluded`). `updatedAt` drives the search-index enqueue, so restoring the broad flag no longer re-floods Meili (the ramp `c186546ad9` was avoiding). Verified no other `updatedAt` consumer depends on the old bump-every-run behavior.
- **Backfill endpoint** (`api/admin/temp/backfill-generation-counts.ts`) to heal versions frozen since the regression; `dryRun` first, then rolls up to `ModelMetric` and re-queues corrected models to search.

No DB migration.