### PR TITLE
feat(auth-hub): dual-write audit + error logs to Loki+Axiom via @civitai/axiom

### DIFF
--- a/apps/auth/package.json
+++ b/apps/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitai/auth-app",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/apps/auth/src/__tests__/hooks.server.test.ts
+++ b/apps/auth/src/__tests__/hooks.server.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HandleServerError } from '@sveltejs/kit';
+
+// Seam test for hooks.server.ts's HandleServerError. We spy the error logger, and stub the DB-pulling
+// session producer so importing hooks.server doesn't construct a pg Pool at module load (db/db.ts throws
+// without DATABASE_URL). This drives the real handleError export — proving it passes the EXACT alert
+// marker "unhandled server error" to logAxiomError, still bumps the counter, and returns a safe message.
+const h = vi.hoisted(() => ({ logAxiomError: vi.fn() }));
+vi.mock('$lib/server/axiom', () => ({ logAxiomError: h.logAxiomError, logToAxiom: vi.fn(async () => {}) }));
+vi.mock('$lib/server/auth/session-producer', () => ({ getOrProduceSessionUser: vi.fn() }));
+
+import { handleError } from '../hooks.server';
+import { register } from '$lib/server/metrics';
+
+async function unhandledCount(): Promise<number> {
+  const metric = (await register.getMetricsAsJSON()).find((m) => m.name === 'hub_unhandled_errors_total');
+  return metric?.values.find((v) => Object.keys(v.labels ?? {}).length === 0)?.value ?? 0;
+}
+
+beforeEach(() => h.logAxiomError.mockReset());
+
+describe('hooks.server handleError', () => {
+  it('logs the unhandled error with the exact alert marker, increments the counter, returns a safe message', async () => {
+    const before = await unhandledCount();
+    const error = new Error('kaboom');
+
+    const result = (handleError as HandleServerError)({
+      error,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      event: {} as any,
+      status: 500,
+      message: 'Internal Error',
+    });
+
+    expect(h.logAxiomError).toHaveBeenCalledTimes(1);
+    const [passedError, extra] = h.logAxiomError.mock.calls[0];
+    expect(passedError).toBe(error);
+    expect(extra).toEqual({ event: 'unhandled server error' });
+    // Alert-compat lock: the marker the Loki alert matches must be present.
+    expect(JSON.stringify(extra)).toContain('unhandled server error');
+
+    expect(await unhandledCount()).toBe(before + 1);
+    expect(result).toEqual({ message: 'Internal Error' });
+  });
+});

--- a/apps/auth/src/hooks.server.ts
+++ b/apps/auth/src/hooks.server.ts
@@ -4,6 +4,7 @@ import { verifier } from '$lib/server/auth/verifier';
 import { getOrProduceSessionUser } from '$lib/server/auth/session-producer';
 import { allowedCorsOrigin } from '$lib/server/cors';
 import { unhandledErrorsTotal } from '$lib/server/metrics';
+import { logAxiomError } from '$lib/server/axiom';
 
 // CORS preflight headers — credentialed, so Allow-Origin MUST echo the exact origin (never `*`).
 const preflightHeaders = (origin: string) => ({
@@ -56,6 +57,6 @@ export const handle: Handle = async ({ event, resolve }) => {
 // response so a metrics hiccup can't change what the client sees.
 export const handleError: HandleServerError = ({ error }) => {
   unhandledErrorsTotal.inc();
-  console.error('unhandled server error', error);
+  logAxiomError(error, { event: 'unhandled server error' });
   return { message: 'Internal Error' };
 };

--- a/apps/auth/src/hooks.server.ts
+++ b/apps/auth/src/hooks.server.ts
@@ -57,6 +57,6 @@ export const handle: Handle = async ({ event, resolve }) => {
 // response so a metrics hiccup can't change what the client sees.
 export const handleError: HandleServerError = ({ error }) => {
   unhandledErrorsTotal.inc();
-  logAxiomError(error, { event: 'unhandled server error' });
+  void logAxiomError(error, { event: 'unhandled server error' });
   return { message: 'Internal Error' };
 };

--- a/apps/auth/src/lib/server/__tests__/axiom.test.ts
+++ b/apps/auth/src/lib/server/__tests__/axiom.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Unit coverage for the hub's @civitai/axiom binding (src/lib/server/axiom.ts). We mock the PACKAGE so
+// `createAxiomLogger()` hands back a spy for the underlying `logToAxiom` — that lets us inspect the exact
+// payload + datastream our module forwards, without exercising the real stderr→Loki / Axiom dual-writer.
+//
+// The load-bearing assertions here are the ALERT-COMPAT LOCK: the three error seams (hooks handleError,
+// oauth/token handler, login email action) all funnel through `logAxiomError`, and the datapacket-talos
+// Loki alerts match auth logs by substring —
+//   {namespace="civitai-auth", app="civitai-auth"} |~ "(?i)(unhandled server error|handler error|action failed|…)" != "invalid_grant"
+// Because logToAxiom emits a JSON line, those alerts keep firing ONLY IF the literal keyword survives
+// serialization. Each seam passes `{ event: '<exact original label>' }`, so the serialized payload must
+// still contain e.g. "unhandled server error" / "handler error" / "action failed", and must still contain
+// "invalid_grant" when the error is one (so the `!= "invalid_grant"` exclusion keeps suppressing it).
+
+const h = vi.hoisted(() => ({
+  logToAxiom: vi.fn(async (_data: Record<string, unknown>, _datastream?: string) => {}),
+}));
+
+// A minimal safeError matching the package contract (name/message/stack for Errors). Function declarations
+// hoist, so it's defined when the (hoisted) vi.mock factory below runs.
+function safeError(e: unknown) {
+  if (e instanceof Error) return { name: e.name, message: e.message, stack: e.stack };
+  return { message: String(e) };
+}
+
+vi.mock('@civitai/axiom', () => ({
+  createAxiomLogger: () => ({ logToAxiom: h.logToAxiom, safeError }),
+  safeError,
+}));
+
+import { logAxiomError, logToAxiom } from '../axiom';
+
+beforeEach(() => h.logToAxiom.mockReset());
+
+describe('auth axiom binding', () => {
+  it('logToAxiom defaults to the civitai-prod datastream (preserves the existing captcha path)', async () => {
+    await logToAxiom({ name: 'captcha-reject' });
+    expect(h.logToAxiom).toHaveBeenCalledWith({ name: 'captcha-reject' }, 'civitai-prod');
+  });
+
+  it('logToAxiom honors an explicit datastream', async () => {
+    await logToAxiom({ event: 'oauth-audit' }, 'auth');
+    expect(h.logToAxiom).toHaveBeenCalledWith({ event: 'oauth-audit' }, 'auth');
+  });
+
+  it('logAxiomError routes to the auth datastream with type:error, the event marker, and safeError fields', async () => {
+    await logAxiomError(new Error('boom'), { event: 'unhandled server error', clientId: 'abc' });
+    expect(h.logToAxiom).toHaveBeenCalledTimes(1);
+    const [payload, datastream] = h.logToAxiom.mock.calls[0];
+    expect(datastream).toBe('auth');
+    expect(payload.type).toBe('error');
+    expect(payload.event).toBe('unhandled server error');
+    expect(payload.clientId).toBe('abc'); // extra context is merged
+    expect(payload.message).toBe('boom'); // safeError fields land
+  });
+
+  // ALERT-COMPAT LOCK — the serialized line must carry the exact substring each Loki alert keys on.
+  it.each([
+    ['unhandled server error', 'unhandled server error'],
+    ['[oauth/token] handler error', 'handler error'],
+    ['email login action failed', 'action failed'],
+  ])('seam marker %j keeps alert keyword %j in the serialized payload', async (marker, keyword) => {
+    await logAxiomError(new Error('boom'), { event: marker });
+    const [payload] = h.logToAxiom.mock.calls[0];
+    expect(payload.event).toBe(marker);
+    expect(JSON.stringify(payload)).toContain(keyword);
+  });
+
+  it('keeps "invalid_grant" in the line so the alert `!= "invalid_grant"` exclusion still suppresses it', async () => {
+    const err = Object.assign(new Error('Invalid grant: authorization code is invalid'), {
+      name: 'invalid_grant',
+    });
+    await logAxiomError(err, { event: '[oauth/token] handler error' });
+    const line = JSON.stringify(h.logToAxiom.mock.calls[0][0]);
+    expect(line).toContain('handler error');
+    expect(line).toContain('invalid_grant');
+  });
+
+  it('swallows a logToAxiom rejection — logging can never break the caller', async () => {
+    h.logToAxiom.mockRejectedValueOnce(new Error('axiom down'));
+    await expect(
+      logAxiomError(new Error('boom'), { event: 'unhandled server error' })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/auth/src/lib/server/__tests__/axiom.test.ts
+++ b/apps/auth/src/lib/server/__tests__/axiom.test.ts
@@ -44,11 +44,11 @@ describe('auth axiom binding', () => {
     expect(h.logToAxiom).toHaveBeenCalledWith({ event: 'oauth-audit' }, 'auth');
   });
 
-  it('logAxiomError routes to the auth datastream with type:error, the event marker, and safeError fields', async () => {
+  it('logAxiomError routes to the civitai-prod datastream with type:error, the event marker, and safeError fields', async () => {
     await logAxiomError(new Error('boom'), { event: 'unhandled server error', clientId: 'abc' });
     expect(h.logToAxiom).toHaveBeenCalledTimes(1);
     const [payload, datastream] = h.logToAxiom.mock.calls[0];
-    expect(datastream).toBe('auth');
+    expect(datastream).toBe('civitai-prod');
     expect(payload.type).toBe('error');
     expect(payload.event).toBe('unhandled server error');
     expect(payload.clientId).toBe('abc'); // extra context is merged

--- a/apps/auth/src/lib/server/axiom.ts
+++ b/apps/auth/src/lib/server/axiom.ts
@@ -11,15 +11,16 @@ export function logToAxiom(data: Record<string, unknown>, datastream = 'civitai-
   return logger.logToAxiom(data, datastream);
 }
 
-// Fire-and-forget error logger for the hub's catch paths. Mirrors apps/notifications' logAxiomError, but
-// routes to the `auth` datastream and accepts an optional `extra` object so callers can attach the exact
-// human label the Loki alerts match on (e.g. { event: 'unhandled server error' }). Order matters: `extra`
-// spreads BEFORE safeError so the marker survives, and safeError's name/message/stack land last. The
-// serialized JSON line (→ Alloy → Loki) MUST keep those literal substrings — the datapacket-talos alerts
+// Fire-and-forget error logger for the hub's catch paths. Mirrors apps/notifications' logAxiomError, and
+// routes to the default `civitai-prod` datastream (shared with the main app + the existing captcha path).
+// Accepts an optional `extra` object so callers can attach the exact human label the Loki alerts match on
+// (e.g. { event: 'unhandled server error' }). Order matters: `extra` spreads BEFORE safeError so the marker
+// survives, and safeError's name/message/stack land last. The serialized JSON line (→ Alloy → Loki) MUST
+// keep those literal substrings — the datapacket-talos alerts
 // `{namespace="civitai-auth"} |~ "(?i)(unhandled server error|handler error|action failed|…)" != "invalid_grant"`
 // key off them. Swallows its own failure so logging can never break the request.
 export function logAxiomError(error: unknown, extra?: Record<string, unknown>) {
-  return logToAxiom({ type: 'error', ...extra, ...safeError(error) }, 'auth').catch(() => {});
+  return logToAxiom({ type: 'error', ...extra, ...safeError(error) }).catch(() => {});
 }
 
 export { safeError };

--- a/apps/auth/src/lib/server/axiom.ts
+++ b/apps/auth/src/lib/server/axiom.ts
@@ -11,4 +11,15 @@ export function logToAxiom(data: Record<string, unknown>, datastream = 'civitai-
   return logger.logToAxiom(data, datastream);
 }
 
+// Fire-and-forget error logger for the hub's catch paths. Mirrors apps/notifications' logAxiomError, but
+// routes to the `auth` datastream and accepts an optional `extra` object so callers can attach the exact
+// human label the Loki alerts match on (e.g. { event: 'unhandled server error' }). Order matters: `extra`
+// spreads BEFORE safeError so the marker survives, and safeError's name/message/stack land last. The
+// serialized JSON line (→ Alloy → Loki) MUST keep those literal substrings — the datapacket-talos alerts
+// `{namespace="civitai-auth"} |~ "(?i)(unhandled server error|handler error|action failed|…)" != "invalid_grant"`
+// key off them. Swallows its own failure so logging can never break the request.
+export function logAxiomError(error: unknown, extra?: Record<string, unknown>) {
+  return logToAxiom({ type: 'error', ...extra, ...safeError(error) }, 'auth').catch(() => {});
+}
+
 export { safeError };

--- a/apps/auth/src/lib/server/oauth/__tests__/audit-log.test.ts
+++ b/apps/auth/src/lib/server/oauth/__tests__/audit-log.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirror the notifications axiom-mock pattern (create.behavioral.test.ts): replace the module the seam
+// imports so we capture the payload logOAuthEvent forwards, while the real Prometheus counter still runs.
+const h = vi.hoisted(() => ({
+  logToAxiom: vi.fn(async (_data: Record<string, unknown>, _datastream?: string) => {}),
+}));
+vi.mock('$lib/server/axiom', () => ({ logToAxiom: h.logToAxiom }));
+
+import { logOAuthEvent } from '../audit-log';
+import { register, oauthEventsTotal } from '$lib/server/metrics';
+
+// Pull a labeled counter sample straight from the registry JSON (same idiom as metrics.test.ts).
+async function counterValue(labels: Record<string, string>): Promise<number | undefined> {
+  const metric = (await register.getMetricsAsJSON()).find((m) => m.name === 'hub_oauth_events_total');
+  return metric?.values.find((v) =>
+    Object.entries(labels).every(([k, val]) => (v.labels ?? {})[k] === val)
+  )?.value;
+}
+
+beforeEach(() => h.logToAxiom.mockReset());
+
+describe('logOAuthEvent', () => {
+  it('dual-writes the audit event (event:"oauth-audit" + the event fields) to the auth datastream', () => {
+    logOAuthEvent({ type: 'token.issued', userId: 7, clientId: 'abc', ip: '1.2.3.4' });
+
+    expect(h.logToAxiom).toHaveBeenCalledTimes(1);
+    const [payload, datastream] = h.logToAxiom.mock.calls[0];
+    expect(datastream).toBe('auth');
+    expect(payload.event).toBe('oauth-audit');
+    expect(payload.type).toBe('token.issued');
+    expect(payload.userId).toBe(7);
+    expect(payload.clientId).toBe('abc');
+    expect(payload.ip).toBe('1.2.3.4');
+    expect(typeof payload.timestamp).toBe('string'); // ISO timestamp is added by the seam
+  });
+
+  it('still increments oauthEventsTotal with the dots→underscores label (metric preserved)', async () => {
+    // Reference the counter once so the label child is pre-declared even on a fresh registry.
+    oauthEventsTotal.inc({ type: 'token_refreshed' }, 0);
+    const before = (await counterValue({ type: 'token_refreshed' })) ?? 0;
+
+    logOAuthEvent({ type: 'token.refreshed', userId: 1 });
+
+    expect(await counterValue({ type: 'token_refreshed' })).toBe(before + 1);
+  });
+});

--- a/apps/auth/src/lib/server/oauth/__tests__/audit-log.test.ts
+++ b/apps/auth/src/lib/server/oauth/__tests__/audit-log.test.ts
@@ -21,12 +21,14 @@ async function counterValue(labels: Record<string, string>): Promise<number | un
 beforeEach(() => h.logToAxiom.mockReset());
 
 describe('logOAuthEvent', () => {
-  it('dual-writes the audit event (event:"oauth-audit" + the event fields) to the auth datastream', () => {
+  it('dual-writes the audit event (event:"oauth-audit" + the event fields), letting the wrapper civitai-prod default apply', () => {
     logOAuthEvent({ type: 'token.issued', userId: 7, clientId: 'abc', ip: '1.2.3.4' });
 
     expect(h.logToAxiom).toHaveBeenCalledTimes(1);
     const [payload, datastream] = h.logToAxiom.mock.calls[0];
-    expect(datastream).toBe('auth');
+    // The seam forwards no explicit datastream, so the real wrapper's `civitai-prod` default applies
+    // (asserted directly in axiom.test.ts). This test mocks the wrapper, so it sees the raw call args.
+    expect(datastream).toBeUndefined();
     expect(payload.event).toBe('oauth-audit');
     expect(payload.type).toBe('token.issued');
     expect(payload.userId).toBe(7);

--- a/apps/auth/src/lib/server/oauth/audit-log.ts
+++ b/apps/auth/src/lib/server/oauth/audit-log.ts
@@ -2,6 +2,7 @@
 // used it — dropped here.) Structured JSON to stdout for log aggregation (Axiom, etc.); fire-and-forget.
 
 import { oauthEventsTotal } from '../metrics';
+import { logToAxiom } from '$lib/server/axiom';
 
 export type OAuthEventType =
   | 'client.created'
@@ -38,8 +39,9 @@ export function logOAuthEvent(event: OAuthAuditEvent): void {
     ...event,
   };
 
-  // Log as structured JSON for log aggregation (Axiom, etc.)
-  console.log(`[oauth-audit] ${JSON.stringify(entry)}`);
+  // Dual-write to Loki (via the @civitai/axiom stderr line) + Axiom. Fire-and-forget — never blocks the
+  // request; a logging failure must not affect the audited operation.
+  void logToAxiom({ event: 'oauth-audit', ...entry }, 'auth').catch(() => {});
 
   // Mirror to a bounded-cardinality counter. The label is the event type with dots→underscores
   // (e.g. token.issued → token_issued) so it's a valid, stable Prometheus label value. This is the

--- a/apps/auth/src/lib/server/oauth/audit-log.ts
+++ b/apps/auth/src/lib/server/oauth/audit-log.ts
@@ -41,7 +41,7 @@ export function logOAuthEvent(event: OAuthAuditEvent): void {
 
   // Dual-write to Loki (via the @civitai/axiom stderr line) + Axiom. Fire-and-forget — never blocks the
   // request; a logging failure must not affect the audited operation.
-  void logToAxiom({ event: 'oauth-audit', ...entry }, 'auth').catch(() => {});
+  void logToAxiom({ event: 'oauth-audit', ...entry }).catch(() => {});
 
   // Mirror to a bounded-cardinality counter. The label is the event type with dots→underscores
   // (e.g. token.issued → token_issued) so it's a valid, stable Prometheus label value. This is the

--- a/apps/auth/src/routes/api/auth/oauth/token/+server.ts
+++ b/apps/auth/src/routes/api/auth/oauth/token/+server.ts
@@ -167,7 +167,7 @@ export const POST: RequestHandler = async ({ request }) => {
       // No CORS on a rejected origin — the browser surfaces a network error to the offending page.
       return json({ error: 'origin_not_allowed', error_description: err.message }, { status: 403 });
     }
-    logAxiomError(err, { event: '[oauth/token] handler error' });
+    void logAxiomError(err, { event: '[oauth/token] handler error' });
     setWildcardCors(respHeaders);
     const e = err as { code?: number; statusCode?: number; name?: string; message?: string };
     const status =

--- a/apps/auth/src/routes/api/auth/oauth/token/+server.ts
+++ b/apps/auth/src/routes/api/auth/oauth/token/+server.ts
@@ -5,6 +5,7 @@ import { db } from '$lib/server/db/db';
 import { oauthServer } from '$lib/server/oauth/server';
 import { checkOAuthRateLimit } from '$lib/server/oauth/rate-limit';
 import { logOAuthEvent } from '$lib/server/oauth/audit-log';
+import { logAxiomError } from '$lib/server/axiom';
 import { OriginNotAllowedError } from '$lib/server/oauth/errors';
 import { ACCESS_TOKEN_TTL } from '$lib/server/oauth/constants';
 import { consumeOidcContext } from '$lib/server/oauth/oidc-nonce';
@@ -166,7 +167,7 @@ export const POST: RequestHandler = async ({ request }) => {
       // No CORS on a rejected origin — the browser surfaces a network error to the offending page.
       return json({ error: 'origin_not_allowed', error_description: err.message }, { status: 403 });
     }
-    console.error('[oauth/token] handler error:', err);
+    logAxiomError(err, { event: '[oauth/token] handler error' });
     setWildcardCors(respHeaders);
     const e = err as { code?: number; statusCode?: number; name?: string; message?: string };
     const status =

--- a/apps/auth/src/routes/login/+page.server.ts
+++ b/apps/auth/src/routes/login/+page.server.ts
@@ -123,7 +123,7 @@ export const actions: Actions = {
     } catch (e) {
       // Don't let a token/email failure bubble up to SvelteKit's full-page 500.
       // Return it as form state so the page can show an inline error instead.
-      logAxiomError(e, { event: 'email login action failed' });
+      void logAxiomError(e, { event: 'email login action failed' });
       emailLoginFailuresTotal.inc();
       return fail(500, { email, serverError: true });
     }

--- a/apps/auth/src/routes/login/+page.server.ts
+++ b/apps/auth/src/routes/login/+page.server.ts
@@ -15,6 +15,7 @@ import { getClientIp } from '$lib/server/auth/request';
 import { trackLoginRedirect } from '$lib/server/tracking';
 import { userExistsByEmail } from '$lib/server/auth/users';
 import { emailLoginFailuresTotal } from '$lib/server/metrics';
+import { logAxiomError } from '$lib/server/axiom';
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -122,7 +123,7 @@ export const actions: Actions = {
     } catch (e) {
       // Don't let a token/email failure bubble up to SvelteKit's full-page 500.
       // Return it as form state so the page can show an inline error instead.
-      console.error('email login action failed', e);
+      logAxiomError(e, { event: 'email login action failed' });
       emailLoginFailuresTotal.inc();
       return fail(500, { email, serverError: true });
     }

--- a/packages/civitai-axiom/src/__tests__/safeError.test.ts
+++ b/packages/civitai-axiom/src/__tests__/safeError.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { safeError } from '../client';
+
+// Pins `safeError`'s contract: primitive-only extraction (no schema-blowup keys), and the two
+// nested-error shapes it unwraps — `.cause` (JS-native) and `.inner` (@node-oauth/oauth2-server's
+// ServerError wraps the real failure here, so the top-level name/message/stack are the generic
+// library frame). The `.inner` unwrap is load-bearing for triaging wrapped auth 500s.
+
+describe('safeError', () => {
+  it('returns undefined for null/undefined', () => {
+    expect(safeError(null)).toBeUndefined();
+    expect(safeError(undefined)).toBeUndefined();
+  });
+
+  it('stringifies non-Error values', () => {
+    expect(safeError('boom')).toEqual({ message: 'boom' });
+    expect(safeError(42)).toEqual({ message: '42' });
+  });
+
+  it('extracts only safe primitives from a plain Error', () => {
+    const e = Object.assign(new Error('bad'), { code: 'E_BAD' });
+    const out = safeError(e)!;
+    expect(out.name).toBe('Error');
+    expect(out.message).toBe('bad');
+    expect(out.code).toBe('E_BAD');
+    expect(typeof out.stack).toBe('string');
+    // no cause/inner present → those fields are undefined (dropped by JSON.stringify)
+    expect(out.causeMessage).toBeUndefined();
+    expect(out.innerName).toBeUndefined();
+    expect(out.innerMessage).toBeUndefined();
+    expect(out.innerStack).toBeUndefined();
+  });
+
+  it('captures the message of a JS-native .cause', () => {
+    const e = new Error('outer', { cause: new Error('the root cause') });
+    expect(safeError(e)!.causeMessage).toBe('the root cause');
+  });
+
+  it('unwraps oauth2-server-style .inner (name + message + stack)', () => {
+    // Shape of @node-oauth/oauth2-server ServerError: generic top-level, real failure in .inner.
+    const realFailure = new Error('column "foo" does not exist');
+    realFailure.name = 'DatabaseError';
+    const wrapped = Object.assign(new Error('Internal Server Error'), {
+      name: 'server_error',
+      code: 500,
+      inner: realFailure,
+    });
+
+    const out = safeError(wrapped)!;
+    // top-level stays the generic library frame...
+    expect(out.name).toBe('server_error');
+    expect(out.code).toBe(500);
+    // ...but the real cause is now recoverable for pager triage.
+    expect(out.innerName).toBe('DatabaseError');
+    expect(out.innerMessage).toBe('column "foo" does not exist');
+    expect(out.innerStack).toContain('column "foo" does not exist');
+  });
+
+  it('handles a non-Error .inner by stringifying its message', () => {
+    const wrapped = Object.assign(new Error('wrap'), { inner: 'raw string failure' });
+    const out = safeError(wrapped)!;
+    expect(out.innerMessage).toBe('raw string failure');
+    expect(out.innerName).toBeUndefined();
+    expect(out.innerStack).toBeUndefined();
+  });
+});

--- a/packages/civitai-axiom/src/client.ts
+++ b/packages/civitai-axiom/src/client.ts
@@ -12,8 +12,13 @@ import { loadAxiomEnv, type AxiomConfig } from './env';
 export function safeError(e: unknown): MixedObject | undefined {
   if (e == null) return undefined;
   if (e instanceof Error) {
-    const anyErr = e as { code?: unknown; cause?: unknown };
+    const anyErr = e as { code?: unknown; cause?: unknown; inner?: unknown };
     const cause = anyErr.cause;
+    // `@node-oauth/oauth2-server` nests the underlying failure in `.inner` (NOT `.cause`) — its
+    // `ServerError` wraps the real error, so the top-level name/message/stack are the generic library
+    // frame. Capture the inner name/message + its stack (the real failing line) so wrapped auth 500s
+    // stay triageable. Kept to primitives only, same as the rest of this helper.
+    const inner = anyErr.inner;
     return {
       name: e.name,
       message: e.message,
@@ -21,6 +26,10 @@ export function safeError(e: unknown): MixedObject | undefined {
       code: anyErr.code,
       causeMessage:
         cause instanceof Error ? cause.message : cause != null ? String(cause) : undefined,
+      innerName: inner instanceof Error ? inner.name : undefined,
+      innerMessage:
+        inner instanceof Error ? inner.message : inner != null ? String(inner) : undefined,
+      innerStack: inner instanceof Error ? inner.stack : undefined,
     };
   }
   return { message: String(e) };


### PR DESCRIPTION
## What

Wire the civitai auth hub (`apps/auth`, SvelteKit adapter-node) to ship its OAuth audit trail and its three server error seams to **both** Loki (stdout→Alloy, already working) **and** Axiom, by routing them through the shared `@civitai/axiom` dual-writer — mirroring how `apps/notifications` does it.

`createAxiomLogger().logToAxiom(data, datastream)` already dual-writes in prod: a structured `console.error(JSON.stringify({_axiom, ...}))` line (→ Alloy → Loki) **and** `axiom.ingestEvents(...)` (→ Axiom). Routing the log/error sites through it makes them go to both by construction.

**Datastream: `civitai-prod`** (the `logToAxiom` wrapper default — shared with the main app + the existing captcha path). The seams pass no explicit datastream, so the default applies.

## Changes (`apps/auth`)

- **`src/lib/server/axiom.ts`** — added `logAxiomError(error, extra?)` (`{ type: 'error', ...extra, ...safeError(error) }`, fire-and-forget) using the default `civitai-prod` datastream. `logToAxiom`'s existing `civitai-prod` default is unchanged, so the pre-existing captcha logging path is untouched.
- **`src/lib/server/oauth/audit-log.ts`** — `logOAuthEvent` now emits `logToAxiom({ event: 'oauth-audit', ...entry })` in place of the raw `console.log`. The `oauthEventsTotal` Prometheus counter is kept exactly as-is.
- **three error seams** now route through `logAxiomError` (raw `console.error` removed — one line per event, no double-emit):
  - `hooks.server.ts` `handleError` → `logAxiomError(error, { event: 'unhandled server error' })`
  - `routes/api/auth/oauth/token/+server.ts` catch → `logAxiomError(err, { event: '[oauth/token] handler error' })`
  - `routes/login/+page.server.ts` email action catch → `logAxiomError(e, { event: 'email login action failed' })`
  - surrounding metric increments / return values untouched.

### Alert compatibility (load-bearing)
The datapacket-talos Loki alerts match auth logs by substring:
`{namespace="civitai-auth", app="civitai-auth"} |~ "(?i)(unhandled server error|handler error|action failed|…)" != "invalid_grant"`. Because `logToAxiom` emits a JSON line, each error seam passes `{ event: '<the exact original label>' }` so the serialized line still contains those literal substrings, and still contains `invalid_grant` when the error is one (so the exclusion keeps firing). This is asserted in tests.

## Tests
- `src/lib/server/__tests__/axiom.test.ts` — datastream routing (`civitai-prod` for `logAxiomError`; default preserved for captcha), and the alert-keyword lock: each of the three seam markers keeps its Loki alert keyword after `JSON.stringify`, plus `invalid_grant` coexistence and the fire-and-forget swallow.
- `src/lib/server/oauth/__tests__/audit-log.test.ts` — `logOAuthEvent` calls `logToAxiom` once with `event: 'oauth-audit'` + fields (wrapper `civitai-prod` default applies), and still increments `oauthEventsTotal`.
- `src/__tests__/hooks.server.test.ts` — drives `handleError`: passes the exact `unhandled server error` marker to `logAxiomError`, bumps the counter, returns the safe message.

All 11 new tests pass (re-run locally). NOTE: the PR has no CI typecheck/vitest gate (only a submodule-pin guard); full typecheck happens at the release build.

## No lockfile / no deploy change here
`"@civitai/axiom": "workspace:*"` and its `pnpm-lock.yaml` link were **already present** on `main`, so no package.json / lockfile change was needed.

**Ops (separate, deploy-side):** for Axiom to actually receive data, the datapacket-talos `civitai-auth-env` secret must set **`AXIOM_TOKEN`** and **`AXIOM_ORG_ID`** (same values as civitai-dp-prod), then roll auth. Loki dual-write works with neither set. Note: `AXIOM_DATASTREAM` is **not** consulted here — the wrapper hardcodes the `civitai-prod` default — so don't rely on it to change the target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Also (shared package): `safeError` now unwraps `.inner`
`packages/civitai-axiom/src/client.ts` — `safeError` previously captured only `.cause`, but `@node-oauth/oauth2-server`'s `ServerError` nests the real failure in **`.inner`**. Without this, a wrapped auth 500 logs only the generic `server_error`/library-frame stack, losing the real failing line that the `civitai-auth-error-rate-critical` pager exists to triage. Now also captures `innerName`/`innerMessage`/`innerStack` (primitives only, same discipline as the rest of the helper) + adds the package's first `safeError` unit tests. Strict improvement; other consumers (notifications, main app) pick it up on their next build. (Surfaced by the /audit-pr review of this PR.)
