### PR TITLE
fix(signals): correct worker teardown on SharedWorker fallback (Android TypeError)

### DIFF
--- a/src/utils/signals/__tests__/teardownSignalWorker.test.ts
+++ b/src/utils/signals/__tests__/teardownSignalWorker.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { teardownSignalWorker } from '~/utils/signals/utils';
+
+// Regression coverage for the chronic Android-cohort crash:
+//   `TypeError: port.close is not a function` at useSignalsWorker cleanup.
+//
+// The `@okikio/sharedworker` wrapper backs onto a real SharedWorker when the
+// browser supports it, and falls back to a dedicated Worker when it does NOT
+// (Android Chrome / Samsung Internet). On the fallback path `worker.port` is the
+// dedicated Worker (which has `terminate()`, NOT `close()`), so the old
+// `worker.port.close()` teardown threw on every unmount for that cohort.
+//
+// These tests exercise BOTH runtime shapes the wrapper presents.
+
+describe('teardownSignalWorker', () => {
+  it('SharedWorker path: closes the MessagePort via the wrapper close() and sends beforeunload', () => {
+    // Shape a: SharedWorker-capable. wrapper.close() closes this tab's MessagePort.
+    const portClose = vi.fn();
+    const portPostMessage = vi.fn();
+    const wrapperClose = vi.fn();
+    const worker = {
+      port: { postMessage: portPostMessage, close: portClose },
+      close: wrapperClose,
+    };
+
+    expect(() => teardownSignalWorker(worker)).not.toThrow();
+
+    // best-effort unload notification is sent
+    expect(portPostMessage).toHaveBeenCalledWith({ type: 'beforeunload' });
+    // teardown goes through the wrapper's polymorphic close(), not the raw port
+    expect(wrapperClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('dedicated-Worker fallback: terminates the worker and NEVER throws (no port.close())', () => {
+    // Shape b: no SharedWorker. The wrapper's port getter returns the dedicated
+    // Worker, which has `postMessage`/`terminate` but NO `close`. Calling
+    // `port.close()` here is exactly the original TypeError. The wrapper's
+    // close() delegates to terminate() on this path.
+    const workerTerminate = vi.fn();
+    const portPostMessage = vi.fn();
+    // wrapper.close() delegates to the underlying Worker.terminate()
+    const wrapperClose = vi.fn(() => workerTerminate());
+    const worker = {
+      // port is the dedicated Worker: has postMessage + terminate, NO close
+      port: { postMessage: portPostMessage, terminate: workerTerminate },
+      close: wrapperClose,
+    };
+
+    expect(() => teardownSignalWorker(worker)).not.toThrow();
+
+    expect(portPostMessage).toHaveBeenCalledWith({ type: 'beforeunload' });
+    expect(wrapperClose).toHaveBeenCalledTimes(1);
+    // the underlying dedicated worker is actually terminated → no leak
+    expect(workerTerminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('defensive belt: no wrapper close() → falls back to raw MessagePort.close()', () => {
+    // If the wrapper contract ever changes and only exposes a raw port, teardown
+    // must still close a MessagePort-shaped port.
+    const portClose = vi.fn();
+    const portPostMessage = vi.fn();
+    const worker = {
+      port: { postMessage: portPostMessage, close: portClose },
+      // no wrapper-level close/terminate
+    };
+
+    expect(() => teardownSignalWorker(worker)).not.toThrow();
+    expect(portClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('defensive belt: no wrapper close() and a Worker-shaped port → terminate(), no throw', () => {
+    // The exact original crash shape with the defensive belt engaged: a raw
+    // Worker-shaped port (terminate, no close) and no wrapper close(). Must
+    // terminate the worker and NOT throw.
+    const portTerminate = vi.fn();
+    const portPostMessage = vi.fn();
+    const worker = {
+      port: { postMessage: portPostMessage, terminate: portTerminate },
+    };
+
+    expect(() => teardownSignalWorker(worker)).not.toThrow();
+    expect(portTerminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when the worker or port is missing', () => {
+    expect(() => teardownSignalWorker(null)).not.toThrow();
+    expect(() => teardownSignalWorker(undefined)).not.toThrow();
+    expect(() => teardownSignalWorker({})).not.toThrow();
+    expect(() => teardownSignalWorker({ port: null, close: vi.fn() })).not.toThrow();
+  });
+
+  it('teardown never throws even if beforeunload postMessage throws', () => {
+    // A dying port can throw on postMessage; teardown must still complete close().
+    const wrapperClose = vi.fn();
+    const worker = {
+      port: {
+        postMessage: vi.fn(() => {
+          throw new Error('port is closing');
+        }),
+        close: vi.fn(),
+      },
+      close: wrapperClose,
+    };
+
+    expect(() => teardownSignalWorker(worker)).not.toThrow();
+    expect(wrapperClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/signals/useSignalsWorker.ts
+++ b/src/utils/signals/useSignalsWorker.ts
@@ -14,7 +14,7 @@ import type {
 export type TopicStatusEvent = Omit<SignalTopicStatus, 'type'>;
 export type TopicStatusHandler = (event: TopicStatusEvent) => void;
 const TOPIC_STATUS_EVENT = '__topicStatus';
-import { Deferred, EventEmitter } from './utils';
+import { Deferred, EventEmitter, teardownSignalWorker } from './utils';
 
 export type SignalWorker = NonNullable<ReturnType<typeof useSignalsWorker>>;
 
@@ -58,8 +58,13 @@ export function useSignalsWorker(options?: {
     setWorker(newWorker);
 
     function cleanup() {
-      newWorker.port.postMessage({ type: 'beforeunload' });
-      newWorker.port.close();
+      // `teardownSignalWorker` sends `beforeunload` then uses the wrapper's
+      // polymorphic close() — closing the MessagePort on SharedWorker-capable
+      // browsers and terminating the dedicated Worker on the fallback path
+      // (Android Chrome / Samsung Internet). Calling `newWorker.port.close()`
+      // directly threw `TypeError: port.close is not a function` on the fallback
+      // cohort, where `port` is the Worker (no `.close()`).
+      teardownSignalWorker(newWorker);
       emitter.stop();
     }
 

--- a/src/utils/signals/utils.ts
+++ b/src/utils/signals/utils.ts
@@ -1,3 +1,73 @@
+/**
+ * The minimal surface of the `@okikio/sharedworker` wrapper that teardown needs.
+ *
+ * The wrapper transparently backs onto a real `SharedWorker` when the browser
+ * supports it, and falls back to a dedicated `Worker` when it does NOT (notably
+ * Android Chrome / Samsung Internet, where `SharedWorker` is unavailable).
+ *
+ * ⚠️ The wrapper's type declares `get port(): MessagePort`, but at runtime on the
+ * fallback path `port` is the dedicated `Worker` (which has `terminate()`, not
+ * `close()`). That type-vs-runtime mismatch is exactly why calling
+ * `worker.port.close()` typechecks yet throws `TypeError: port.close is not a
+ * function` on the fallback cohort. Always use the wrapper's polymorphic
+ * `close()` (below) instead of reaching into `.port`.
+ */
+export type TeardownableSignalWorker = {
+  port?: {
+    postMessage?: (message: unknown) => void;
+    close?: () => void;
+    terminate?: () => void;
+  } | null;
+  /** Wrapper method: closes the MessagePort (SharedWorker) or terminates the Worker (fallback). */
+  close?: () => void;
+  terminate?: () => void;
+};
+
+/**
+ * Correctly tears down a signals worker across BOTH the `SharedWorker` and the
+ * dedicated-`Worker` fallback paths.
+ *
+ * - Best-effort notifies the worker this tab is unloading (`beforeunload`).
+ * - Then calls the wrapper's polymorphic `close()`, which closes this tab's
+ *   MessagePort on SharedWorker-capable browsers and `terminate()`s the
+ *   dedicated Worker on the fallback path — so the worker never leaks and the
+ *   teardown never throws.
+ * - Falls back to closing/terminating the raw port directly if the wrapper's
+ *   `close()` is ever unavailable (defensive belt).
+ *
+ * Fixes the chronic `TypeError: port.close is not a function` that previously
+ * fired on every unmount for the Android Chromium cohort (no SharedWorker),
+ * where `worker.port` is the dedicated Worker (no `.close()`).
+ */
+export function teardownSignalWorker(worker: TeardownableSignalWorker | null | undefined) {
+  if (!worker) return;
+
+  // Best-effort: tell the (shared) worker this tab is going away. `postMessage`
+  // exists on both a MessagePort and a dedicated Worker, so this is safe on both
+  // paths; guard anyway in case the port is absent.
+  try {
+    worker.port?.postMessage?.({ type: 'beforeunload' });
+  } catch {
+    // ignore — teardown must not throw
+  }
+
+  // Preferred: the wrapper's polymorphic close() does the right thing per path.
+  if (typeof worker.close === 'function') {
+    worker.close();
+    return;
+  }
+  if (typeof worker.terminate === 'function') {
+    worker.terminate();
+    return;
+  }
+
+  // Defensive belt: no wrapper close/terminate — tear down the raw port by
+  // whichever method it actually supports (MessagePort → close, Worker → terminate).
+  const port = worker.port;
+  if (port && typeof port.close === 'function') port.close();
+  else if (port && typeof port.terminate === 'function') port.terminate();
+}
+
 export class Deferred<T = void, E = unknown> {
   promise: Promise<T>;
   resolve: (value: T | PromiseLike<T>) => void = () => null;


### PR DESCRIPTION
## The bug

`TypeError: port.close is not a function` at `src/utils/signals/useSignalsWorker.ts` cleanup — the **#1 client-side JS exception** in production Faro RUM this session:

- **~2,726 occurrences / 3h (~9.8% of ALL client exceptions)**, **chronic** (fires across app_versions 5.0.2012→2021 — not a deploy regression).
- **Android-heavy cohort**: Chrome (1,354) + Samsung Internet (638) + Edge.
- Fires on every route the signals worker mounts (`/models`, `/user`, `/images`, `/search`) — on unmount/`beforeunload`.

The signals worker powers live reactions/notifications/generation-status; the throwing teardown means the worker lifecycle cleanup fails on this cohort.

## Confirmed root cause

The hook imports `SharedWorker` from the **`@okikio/sharedworker`** polyfill wrapper, not the native class. That wrapper:

- Uses a real `SharedWorker` when `"SharedWorker" in globalThis` is true.
- **Falls back to a dedicated `Worker`** when it is not — which is the case on **Android Chrome / Samsung Internet** (no `SharedWorker` support).

On the fallback path, the wrapper's `get port()` returns **the dedicated `Worker` itself** — which has `terminate()`, **not** `close()`. The old teardown called `newWorker.port.close()`, so `.close` was `undefined` → **`TypeError: port.close is not a function`** on every unmount for that cohort.

Why TypeScript never caught it: the wrapper's `.d.ts` declares `get port(): MessagePort`, so `worker.port.close()` typechecks even though at runtime `.port` is a `Worker` on the fallback path. (Hypothesis from the task confirmed exactly — it is the SharedWorker→Worker fallback.)

## The fix (correct teardown, not a swallow)

New `teardownSignalWorker(worker)` helper in `src/utils/signals/utils.ts` routes cleanup through the **wrapper's polymorphic `close()`**, which does the right thing per path:

- SharedWorker-capable → closes this tab's **MessagePort** (`port.close()`).
- Fallback → **`terminate()`s the dedicated Worker** — so it does not leak.

It best-effort sends `beforeunload` first (guarded so a dying port can't throw), and includes a defensive belt that closes/terminates a raw port directly if the wrapper contract ever changes. The happy path (browsers with SharedWorker) still closes the port exactly as before.

## Test coverage

6 unit tests (`src/utils/signals/__tests__/teardownSignalWorker.test.ts`) exercising **both runtime shapes**:

- (a) SharedWorker-like port with `.close()` → wrapper `close()` called, `beforeunload` sent, no throw.
- (b) dedicated-Worker fallback (port has `terminate`, no `close`) → underlying worker **terminated**, **no `TypeError`**.
- Defensive-belt shapes (no wrapper `close()`), null/undefined/`{}` worker, and a throwing `postMessage` — teardown never throws.

`npx vitest run --project unit` → **6/6 pass**. Typecheck of touched files clean (repo-wide `tsc` only shows pre-existing TS2307 workspace-package module-resolution noise; zero signals errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)