### PR TITLE
perf(lcp): flag-gated fetchpriority/eager on above-the-fold homepage cards

### DIFF
--- a/src/components/CardTemplates/AspectRatioImageCard.tsx
+++ b/src/components/CardTemplates/AspectRatioImageCard.tsx
@@ -69,6 +69,14 @@ export type AspectRatioImageCardProps<T extends DialogKey> = {
   alwaysVisibleBadge?: boolean;
   /** Accessible fallback alt text when the image itself has no name (e.g. the card's title). */
   alt?: string;
+  /**
+   * Mark this card's media as the LCP / above-the-fold image so the browser
+   * fetches it eagerly at high priority (`loading="eager"` + `fetchpriority="high"`).
+   * Threaded into the underlying EdgeMedia. Reserve for the first N cards of the
+   * first above-the-fold row — priority on everything is priority on nothing.
+   * Off (default) is byte-identical to the previous render.
+   */
+  priority?: boolean;
 } & ContentTypeProps;
 
 const IMAGE_CARD_WIDTH = 450;
@@ -92,6 +100,7 @@ export function AspectRatioImageCard<T extends DialogKey>({
   explain,
   alwaysVisibleBadge,
   alt,
+  priority,
 }: AspectRatioImageCardProps<T>) {
   const originalAspectRatio = image && image.width && image.height ? image.width / image.height : 1;
 
@@ -176,6 +185,7 @@ export function AspectRatioImageCard<T extends DialogKey>({
                         })}
                         wrapperProps={{ className: 'flex-1 h-full' }}
                         width={IMAGE_CARD_WIDTH}
+                        priority={priority}
                         contain
                       />
                     )
@@ -198,6 +208,7 @@ export function AspectRatioImageCard<T extends DialogKey>({
                           ? IMAGE_CARD_WIDTH * originalAspectRatio
                           : IMAGE_CARD_WIDTH
                       }
+                      priority={priority}
                       skip={
                         image.type === 'video'
                           ? getSkipValue({

--- a/src/components/Cards/ArticleCard.tsx
+++ b/src/components/Cards/ArticleCard.tsx
@@ -24,11 +24,11 @@ const articleStatusBadge: Partial<Record<ArticleStatus, { label: string; color: 
   [ArticleStatus.UnpublishedViolation]: { label: 'Violation', color: 'red' },
 };
 
-export const ArticleCard = memo(function ArticleCard({ data, aspectRatio }: Props) {
-  return <ArticleCardContent data={data} aspectRatio={aspectRatio} />;
+export const ArticleCard = memo(function ArticleCard({ data, aspectRatio, priority }: Props) {
+  return <ArticleCardContent data={data} aspectRatio={aspectRatio} priority={priority} />;
 });
 
-function ArticleCardContent({ data, aspectRatio }: Props) {
+function ArticleCardContent({ data, aspectRatio, priority }: Props) {
   const { id, title, coverImage, publishedAt, user, tags, status, nsfwLevel } = data;
   // Show the article's aggregate nsfwLevel on the card (badge + blur), not just
   // the cover image's own level. Content images or a moderator/user override can
@@ -45,6 +45,7 @@ function ArticleCardContent({ data, aspectRatio }: Props) {
   return (
     <AspectRatioImageCard
       href={`/articles/${id}/${slugit(title)}`}
+      priority={priority}
       alt={title}
       aspectRatio={aspectRatio}
       contentType="article"
@@ -166,4 +167,5 @@ function ArticleStats({ data }: { data: ArticleGetAllRecord }) {
 type Props = {
   data: ArticleGetAllRecord;
   aspectRatio?: 'landscape' | 'portrait' | 'square';
+  priority?: boolean;
 };

--- a/src/components/Cards/ImageCard.tsx
+++ b/src/components/Cards/ImageCard.tsx
@@ -11,12 +11,13 @@ import { UserAvatarSimple } from '~/components/UserAvatar/UserAvatarSimple';
 import cardClasses from '~/components/Cards/Cards.module.css';
 import { ThemeIcon } from '@mantine/core';
 
-export function ImageCard({ data }: Props) {
+export function ImageCard({ data, priority }: Props) {
   const { getImages, ...context } = useImagesContext();
 
   return (
     <AspectRatioImageCard
       image={data}
+      priority={priority}
       cosmetic={data.cosmetic?.data}
       routedDialog={{
         name: 'imageDetail',
@@ -67,4 +68,4 @@ export function ImageCard({ data }: Props) {
   );
 }
 
-type Props = { data: ImagesInfiniteModel };
+type Props = { data: ImagesInfiniteModel; priority?: boolean };

--- a/src/components/Cards/ModelCard.tsx
+++ b/src/components/Cards/ModelCard.tsx
@@ -52,11 +52,11 @@ function ModFlagBadge({ labels }: { labels: string[] }) {
   );
 }
 
-export const ModelCard = memo(function ModelCard({ data }: Props) {
-  return <ModelCardContent data={data} />;
+export const ModelCard = memo(function ModelCard({ data, priority }: Props) {
+  return <ModelCardContent data={data} priority={priority} />;
 });
 
-function ModelCardContent({ data }: Props) {
+function ModelCardContent({ data, priority }: Props) {
   const theme = useMantineTheme();
   const colorScheme = useComputedColorScheme('dark');
 
@@ -119,6 +119,7 @@ function ModelCardContent({ data }: Props) {
   return (
     <AspectRatioImageCard
       href={href}
+      priority={priority}
       cosmetic={data.cosmetic?.data}
       contentType="model"
       contentId={data.id}
@@ -312,4 +313,4 @@ function ModelCardStats({ data }: { data: Props['data'] }) {
   );
 }
 
-type Props = { data: UseQueryModelReturn[number]; forceInView?: boolean };
+type Props = { data: UseQueryModelReturn[number]; forceInView?: boolean; priority?: boolean };

--- a/src/components/Cards/PostCard.tsx
+++ b/src/components/Cards/PostCard.tsx
@@ -12,7 +12,7 @@ import { CosmeticEntity } from '~/shared/utils/prisma/enums';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
 import { UserAvatarSimple } from '~/components/UserAvatar/UserAvatarSimple';
 
-export function PostCard({ data }: Props) {
+export function PostCard({ data, priority }: Props) {
   const currentUser = useCurrentUser();
 
   const image = data.images[0];
@@ -22,6 +22,7 @@ export function PostCard({ data }: Props) {
   return (
     <AspectRatioImageCard
       href={`/posts/${data.id}`}
+      priority={priority}
       alt={data.title || 'View post'}
       aspectRatio="square"
       cosmetic={data.cosmetic?.data}
@@ -73,4 +74,4 @@ export function PostCard({ data }: Props) {
   );
 }
 
-type Props = { data: PostsInfiniteModel };
+type Props = { data: PostsInfiniteModel; priority?: boolean };

--- a/src/components/EdgeMedia/EdgeImage.browser.test.tsx
+++ b/src/components/EdgeMedia/EdgeImage.browser.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { EdgeImage } from '~/components/EdgeMedia/EdgeImage';
+import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+// `useEdgeUrl` reads the CivitaiSession context (throws without a provider) and
+// builds a CF-resized URL. This test is about the LCP `priority` attributes, not
+// URL construction, so mock the hook to a fixed absolute URL. This also keeps the
+// leaf test network-free and provider-light (matches the scaffold's philosophy).
+const TEST_URL = 'https://example.com/lcp-test.jpg';
+vi.mock('~/client-utils/cf-images-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/client-utils/cf-images-utils')>();
+  return {
+    ...actual,
+    useEdgeUrl: () => ({ url: TEST_URL, type: 'image' as const }),
+  };
+});
+
+// The LCP fix renders the canonical lowercase HTML attributes. react-dom 18.3.1
+// has no `fetchPriority` in its known-attribute map, so we emit lowercase
+// `fetchpriority`, which the browser reads case-insensitively.
+//
+// NB: EdgeImage's props are `React.HTMLAttributes` (not `ImgHTMLAttributes`), so
+// `alt` is not one of its typed props — real callers pass `alt` via EdgeMedia's
+// img-prop spread. The EdgeImage renders below therefore omit `alt`; an <img>
+// with no alt attribute still has the implicit `img` role.
+async function getImg() {
+  const el = page.getByRole('img');
+  await expect.element(el).toBeInTheDocument();
+  return el.element() as HTMLImageElement;
+}
+
+describe('EdgeImage — LCP priority', () => {
+  test('priority renders fetchpriority="high" + loading="eager"', async () => {
+    renderWithProviders(<EdgeImage src={TEST_URL} options={{}} priority />);
+
+    const img = await getImg();
+    expect(img.getAttribute('fetchpriority')).toBe('high');
+    expect(img.getAttribute('loading')).toBe('eager');
+  });
+
+  test('no priority prop → no priority attributes (byte-identical / flag-off)', async () => {
+    renderWithProviders(<EdgeImage src={TEST_URL} options={{}} />);
+
+    const img = await getImg();
+    expect(img.hasAttribute('fetchpriority')).toBe(false);
+    expect(img.hasAttribute('loading')).toBe(false);
+  });
+
+  test('priority={false} → no priority attributes', async () => {
+    renderWithProviders(<EdgeImage src={TEST_URL} options={{}} priority={false} />);
+
+    const img = await getImg();
+    expect(img.hasAttribute('fetchpriority')).toBe(false);
+    expect(img.hasAttribute('loading')).toBe(false);
+  });
+});
+
+describe('EdgeMedia — LCP priority threading', () => {
+  test('image branch forwards priority to the underlying <img>', async () => {
+    renderWithProviders(<EdgeMedia type="image" src={TEST_URL} priority alt="test" />);
+
+    const img = await getImg();
+    expect(img.getAttribute('fetchpriority')).toBe('high');
+    expect(img.getAttribute('loading')).toBe('eager');
+  });
+
+  test('image branch without priority emits no priority attributes', async () => {
+    renderWithProviders(<EdgeMedia type="image" src={TEST_URL} alt="test" />);
+
+    const img = await getImg();
+    expect(img.hasAttribute('fetchpriority')).toBe(false);
+    expect(img.hasAttribute('loading')).toBe(false);
+  });
+});

--- a/src/components/EdgeMedia/EdgeImage.tsx
+++ b/src/components/EdgeMedia/EdgeImage.tsx
@@ -11,10 +11,34 @@ export type EdgeImageProps = React.HTMLAttributes<HTMLImageElement> & {
   options: Omit<EdgeUrlProps, 'src'>;
   /** Database image ID — included in drag data so drop targets can look up metadata server-side */
   imageId?: number;
+  /**
+   * Mark this image as the LCP / above-the-fold candidate. When set, emits
+   * `loading="eager"` + `fetchpriority="high"` so the browser fetches it ahead
+   * of the many sibling card images it would otherwise contend with. Off (the
+   * default) is byte-identical to the previous render (no attributes emitted).
+   * Reserve for the first N cards in a viewport — priority on everything is
+   * priority on nothing.
+   */
+  priority?: boolean;
 };
 
+// `@types/react@18.0.14` predates the `fetchPriority` img attribute (added
+// upstream in the 18.3 typings; the deployed react-dom is 18.3.1). react-dom
+// 18.3.1 has no `fetchPriority` in its known-attribute map either, so we emit
+// the canonical lowercase HTML attribute `fetchpriority` — React passes
+// lowercase custom attributes through to the DOM verbatim and browsers read the
+// attribute case-insensitively. The single controlled cast lives here so the
+// rest of the chain threads a clean typed `priority: boolean`.
+const priorityImgAttrs = {
+  loading: 'eager',
+  fetchpriority: 'high',
+} as unknown as React.ImgHTMLAttributes<HTMLImageElement>;
+
 export const EdgeImage = forwardRef<HTMLImageElement, EdgeImageProps>(
-  ({ className, fadeIn, src, options, style, onLoad, onError, imageId, ...props }, forwardedRef) => {
+  (
+    { className, fadeIn, src, options, style, onLoad, onError, imageId, priority, ...props },
+    forwardedRef
+  ) => {
     // const ref = useRef<HTMLImageElement>(null);
     // TODO - determine how we can animate cosmetics
     const { anim, ...rest } = options ?? {};
@@ -52,6 +76,7 @@ export const EdgeImage = forwardRef<HTMLImageElement, EdgeImageProps>(
           }
         }}
         {...props}
+        {...(priority ? priorityImgAttrs : undefined)}
       />
     );
   }

--- a/src/components/EdgeMedia/EdgeMedia.tsx
+++ b/src/components/EdgeMedia/EdgeMedia.tsx
@@ -34,6 +34,12 @@ export type EdgeMediaProps = EdgeUrlProps &
     imageProps?: React.HTMLAttributes<HTMLImageElement>;
     /** Database image ID — forwarded to EdgeImage for drag-and-drop metadata lookup */
     imageId?: number;
+    /**
+     * Mark this as the LCP / above-the-fold image. Forwarded to EdgeImage, which
+     * emits `loading="eager"` + `fetchpriority="high"`. Only applies to the image
+     * branch (no effect on video). Off (default) = byte-identical render.
+     */
+    priority?: boolean;
   };
 
 export function EdgeMedia({
@@ -71,6 +77,7 @@ export function EdgeMedia({
   imageProps,
   optimized,
   imageId,
+  priority,
   ...imgProps
 }: EdgeMediaProps) {
   const imgRef = useRef<HTMLImageElement>(null);
@@ -109,6 +116,7 @@ export function EdgeMedia({
           className={className}
           style={style}
           imageId={imageId}
+          priority={priority}
           {...imgProps}
           {...imageProps}
         />

--- a/src/components/HomeBlocks/CollectionHomeBlock.tsx
+++ b/src/components/HomeBlocks/CollectionHomeBlock.tsx
@@ -38,6 +38,7 @@ import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApp
 import { contestCollectionReactionsHidden } from '~/components/Collections/collection.utils';
 import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { shouldPrioritizeLcpImage } from '~/components/HomeBlocks/lcpImagePriority';
 import clsx from 'clsx';
 
 const icons = {
@@ -60,13 +61,16 @@ export const CollectionHomeBlock = ({ showAds, ...props }: Props) => {
 };
 
 const ITEMS_PER_ROW = 7;
-const CollectionHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
+const CollectionHomeBlockContent = ({ homeBlockId, metadata, index: blockIndex }: Props) => {
   const { data: homeBlock, isLoading } = trpc.homeBlock.getHomeBlock.useQuery(
     { id: homeBlockId },
     { trpc: { context: { skipBatch: true } } }
   );
 
   const rows = metadata.collection?.rows ?? 2;
+
+  const features = useFeatureFlags();
+  const isFirstBlock = blockIndex === 0;
 
   const currentUser = useCurrentUser();
 
@@ -261,14 +265,23 @@ const CollectionHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
               }}
             >
               {useGrid && <div className={classes.gridMeta}>{MetaDataGrid}</div>}
-              {items.map((item) => (
-                <div key={item.id} className="p-2">
-                  {type === 'model' && <ModelCard data={item as any} forceInView />}
-                  {type === 'image' && <ImageCard data={item as any} />}
-                  {type === 'post' && <PostCard data={item as any} />}
-                  {type === 'article' && <ArticleCard data={item as any} />}
-                </div>
-              ))}
+              {items.map((item, itemIndex) => {
+                const priority = shouldPrioritizeLcpImage({
+                  enabled: features.lcpImagePriority,
+                  isFirstBlock,
+                  index: itemIndex,
+                });
+                return (
+                  <div key={item.id} className="p-2">
+                    {type === 'model' && (
+                      <ModelCard data={item as any} forceInView priority={priority} />
+                    )}
+                    {type === 'image' && <ImageCard data={item as any} priority={priority} />}
+                    {type === 'post' && <PostCard data={item as any} priority={priority} />}
+                    {type === 'article' && <ArticleCard data={item as any} priority={priority} />}
+                  </div>
+                );
+              })}
             </ReactionSettingsProvider>
           </ImagesProvider>
         </div>
@@ -287,4 +300,10 @@ const CollectionHomeBlockContent = ({ homeBlockId, metadata }: Props) => {
   );
 };
 
-type Props = { homeBlockId: number; metadata: HomeBlockMetaSchema; showAds?: boolean };
+type Props = {
+  homeBlockId: number;
+  metadata: HomeBlockMetaSchema;
+  showAds?: boolean;
+  /** Position of this block in the homepage stack; block 0 holds the above-the-fold LCP image. */
+  index?: number;
+};

--- a/src/components/HomeBlocks/FeaturedCollectionsHomeBlock.tsx
+++ b/src/components/HomeBlocks/FeaturedCollectionsHomeBlock.tsx
@@ -16,12 +16,19 @@ import type { PickedFeaturedCollection } from '~/server/services/home-block.serv
 import { CollectionMode } from '~/shared/utils/prisma/enums';
 import { shuffle } from '~/utils/array-helpers';
 import { trpc } from '~/utils/trpc';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { shouldPrioritizeLcpImage } from '~/components/HomeBlocks/lcpImagePriority';
 
 const ITEMS_PER_ROW = 7;
 
-type Props = { homeBlockId: number; metadata: HomeBlockMetaSchema };
+type Props = {
+  homeBlockId: number;
+  metadata: HomeBlockMetaSchema;
+  /** Position of this block in the homepage stack; block 0 holds the above-the-fold LCP image. */
+  index?: number;
+};
 
-export const FeaturedCollectionsHomeBlock = ({ homeBlockId }: Props) => {
+export const FeaturedCollectionsHomeBlock = ({ homeBlockId, index }: Props) => {
   const { data: homeBlock, isLoading } = trpc.homeBlock.getHomeBlock.useQuery(
     { id: homeBlockId },
     { trpc: { context: { skipBatch: true } } }
@@ -44,10 +51,11 @@ export const FeaturedCollectionsHomeBlock = ({ homeBlockId }: Props) => {
 
   return (
     <>
-      {picks.map((pick) =>
+      {picks.map((pick, pickIndex) =>
         pick.collection ? (
           <HomeBlockWrapper key={pick.collection.id} py={32}>
-            <FeaturedCollectionSection pick={pick} />
+            {/* Only the first section of the first home block is above the fold. */}
+            <FeaturedCollectionSection pick={pick} aboveFold={index === 0 && pickIndex === 0} />
           </HomeBlockWrapper>
         ) : null
       )}
@@ -55,16 +63,18 @@ export const FeaturedCollectionsHomeBlock = ({ homeBlockId }: Props) => {
   );
 };
 
-type SectionProps =
+type SectionProps = { aboveFold?: boolean } & (
   | { pick: PickedFeaturedCollection; isLoading?: false }
   | {
       pick: { collection: null; items: []; rows: number; limit: number };
       isLoading: true;
-    };
+    }
+);
 
-function FeaturedCollectionSection({ pick, isLoading }: SectionProps) {
+function FeaturedCollectionSection({ pick, isLoading, aboveFold }: SectionProps) {
   const { collection, items: rawItems } = pick;
   const rows = pick.rows;
+  const features = useFeatureFlags();
 
   const shuffled = useMemo(() => shuffle(rawItems ?? []), [rawItems]);
   const shuffledData = useMemo(() => shuffled.map((x: { data: unknown }) => x.data), [shuffled]);
@@ -112,14 +122,23 @@ function FeaturedCollectionSection({ pick, isLoading }: SectionProps) {
                 hideReactions: collection ? contestCollectionReactionsHidden(collection) : false,
               }}
             >
-              {(items as any[]).map((item: any, idx: number) => (
-                <div key={item.id ?? idx} className="p-2">
-                  {type === 'model' && <ModelCard data={item} forceInView />}
-                  {type === 'image' && <ImageCard data={item} />}
-                  {type === 'post' && <PostCard data={item} />}
-                  {type === 'article' && <ArticleCard data={item} />}
-                </div>
-              ))}
+              {(items as any[]).map((item: any, idx: number) => {
+                const priority = shouldPrioritizeLcpImage({
+                  enabled: features.lcpImagePriority,
+                  isFirstBlock: !!aboveFold,
+                  index: idx,
+                });
+                return (
+                  <div key={item.id ?? idx} className="p-2">
+                    {type === 'model' && (
+                      <ModelCard data={item} forceInView priority={priority} />
+                    )}
+                    {type === 'image' && <ImageCard data={item} priority={priority} />}
+                    {type === 'post' && <PostCard data={item} priority={priority} />}
+                    {type === 'article' && <ArticleCard data={item} priority={priority} />}
+                  </div>
+                );
+              })}
             </ReactionSettingsProvider>
           </ImagesProvider>
         </div>

--- a/src/components/HomeBlocks/lcpImagePriority.test.ts
+++ b/src/components/HomeBlocks/lcpImagePriority.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  LCP_PRIORITY_ITEM_COUNT,
+  shouldPrioritizeLcpImage,
+} from '~/components/HomeBlocks/lcpImagePriority';
+
+// Deterministic gate for LCP-image prioritisation. This is the exact decision the
+// home blocks make per card: flag ON + first (top) block + one of the first N
+// items. Everything else must be false so below-the-fold / later-block images are
+// never marked high priority (priority on everything = priority on nothing), and
+// flag-OFF is always false (byte-identical render).
+describe('shouldPrioritizeLcpImage', () => {
+  it('prioritizes the first N items of the first block when enabled', () => {
+    for (let index = 0; index < LCP_PRIORITY_ITEM_COUNT; index++) {
+      expect(shouldPrioritizeLcpImage({ enabled: true, isFirstBlock: true, index })).toBe(true);
+    }
+  });
+
+  it('does NOT prioritize items at or beyond the count (below the fold)', () => {
+    expect(
+      shouldPrioritizeLcpImage({ enabled: true, isFirstBlock: true, index: LCP_PRIORITY_ITEM_COUNT })
+    ).toBe(false);
+    expect(shouldPrioritizeLcpImage({ enabled: true, isFirstBlock: true, index: 50 })).toBe(false);
+  });
+
+  it('does NOT prioritize any item in a non-first block', () => {
+    expect(shouldPrioritizeLcpImage({ enabled: true, isFirstBlock: false, index: 0 })).toBe(false);
+  });
+
+  it('is always false when the flag is disabled (byte-identical render)', () => {
+    expect(shouldPrioritizeLcpImage({ enabled: false, isFirstBlock: true, index: 0 })).toBe(false);
+  });
+
+  it('rejects negative indices defensively', () => {
+    expect(shouldPrioritizeLcpImage({ enabled: true, isFirstBlock: true, index: -1 })).toBe(false);
+  });
+
+  it('honors a custom count', () => {
+    expect(
+      shouldPrioritizeLcpImage({ enabled: true, isFirstBlock: true, index: 0, count: 1 })
+    ).toBe(true);
+    expect(
+      shouldPrioritizeLcpImage({ enabled: true, isFirstBlock: true, index: 1, count: 1 })
+    ).toBe(false);
+  });
+});

--- a/src/components/HomeBlocks/lcpImagePriority.ts
+++ b/src/components/HomeBlocks/lcpImagePriority.ts
@@ -1,0 +1,45 @@
+/**
+ * LCP (largest-contentful-paint) image prioritisation for the homepage home blocks.
+ *
+ * Production Faro RUM shows the homepage LCP element is the first home block's
+ * card image (`AspectRatioImageCard image`) and that its dominant LCP phase is
+ * `resource_load_delay` (~2.3s): the feed is client-rendered so the browser's
+ * preload scanner can't find the image in the initial HTML, and the plain `<img>`
+ * carries no `fetchpriority`. Marking the first above-the-fold cards with
+ * `fetchpriority="high"` + `loading="eager"` lets the LCP image jump ahead of the
+ * many sibling card images it otherwise contends with once it's in the DOM.
+ *
+ * IMPORTANT (honest scope): this only addresses the POST-render contention slice —
+ * once the image element exists, it stops waiting behind sibling requests. It does
+ * NOT address the PRE-render discovery delay (JS download → hydrate → tRPC feed
+ * fetch → render), which is the majority of the 2.3s and would require SSR-ing the
+ * first image URL / a server-emitted `<link rel="preload">` — deliberately out of
+ * scope here (that path was previously reverted).
+ */
+
+/**
+ * How many leading cards of the first home block to mark high-priority. Kept small
+ * on purpose: on mobile (1-column reflow) the LCP is the single first card; on
+ * desktop the first row is above the fold. Prioritising everything is priority on
+ * nothing, so cap at the leading cards that plausibly hold the LCP element.
+ */
+export const LCP_PRIORITY_ITEM_COUNT = 4;
+
+/**
+ * Decide whether a given home-block card should be fetched at high priority.
+ * Gated on the feature flag, on being the first (top) home block, and on the
+ * card being one of the first `LCP_PRIORITY_ITEM_COUNT` items in that block.
+ */
+export function shouldPrioritizeLcpImage({
+  enabled,
+  isFirstBlock,
+  index,
+  count = LCP_PRIORITY_ITEM_COUNT,
+}: {
+  enabled: boolean;
+  isFirstBlock: boolean;
+  index: number;
+  count?: number;
+}): boolean {
+  return enabled && isFirstBlock && index >= 0 && index < count;
+}

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -67,12 +67,17 @@ export function Home() {
               return (
                 <React.Fragment key={homeBlock.id}>
                   {homeBlock.type === HomeBlockType.Collection && (
-                    <CollectionHomeBlock homeBlockId={homeBlock.id} metadata={homeBlock.metadata} />
+                    <CollectionHomeBlock
+                      homeBlockId={homeBlock.id}
+                      metadata={homeBlock.metadata}
+                      index={i}
+                    />
                   )}
                   {homeBlock.type === HomeBlockType.FeaturedCollections && (
                     <FeaturedCollectionsHomeBlock
                       homeBlockId={homeBlock.id}
                       metadata={homeBlock.metadata}
+                      index={i}
                     />
                   )}
                   {/* {homeBlock.type === HomeBlockType.Announcement && (

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -83,6 +83,17 @@ const featureFlags = createFeatureFlags({
   // cosmetic space reservation (worst case = a little dead space, never a
   // functional break), so flipping the flag off is an instant, safe rollback.
   feedReserveCls: { availability: ['mod'], fliptKey: 'feed-reserve-cls' },
+  // LCP image prioritisation on the homepage home blocks. Marks the first N
+  // above-the-fold cards of the first home block with `fetchpriority="high"` +
+  // `loading="eager"` so the largest-contentful-paint image jumps ahead of the
+  // many sibling card images it contends with once rendered. Faro RUM attributes
+  // homepage poor-LCP (p75 ~3s; 30% of mobile "poor") to `AspectRatioImageCard
+  // image` with a ~2.3s `resource_load_delay`. Default OFF (mods only = the
+  // Flipt-DOWN fallback); ramp a % of ALL users via Flipt (`lcp-image-priority`)
+  // as a THRESHOLD rollout — LCP is an all-user route metric, so a mod-only
+  // cohort can't move the aggregate. Flag-OFF render is byte-identical (no img
+  // attributes emitted), so flipping it off is an instant, safe rollback.
+  lcpImagePriority: { availability: ['mod'], fliptKey: 'lcp-image-priority' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },


### PR DESCRIPTION
## Problem (production Faro RUM)

- Homepage **LCP p75 ~3006ms** (mobile 3040ms); **30% of mobile loads rate LCP "poor"** (>2500ms). Homepage is ~12% of traffic; all client-rendered feeds share the pattern.
- LCP phase attribution: dominant phase = **`resource_load_delay` ~2.3s** — the LCP image does not *start* fetching until ~2.3s after TTFB. TTFB is small (~270-560ms), the image download itself is small (95-251ms), `element_render_delay` is negligible (~19-25ms). So **JS is not blocking paint and the network is not slow — the image is discovered/started too late.**
- LCP element = the first home block's card image: **`AspectRatioImageCard image` = 65% of homepage poor-LCP.**
- Root (verified in code): `EdgeImage.tsx` renders a plain `<img>` with **no `loading` and no `fetchpriority`**, and the home-block feed is **client-rendered** (image URL is not in the initial HTML), so the browser preload scanner can't find the LCP image — it can only start loading after JS hydrates → fetches feed data (tRPC) → renders the cards.

## Fix

Thread an opt-in **`priority`** boolean through the shared card chain:

`AspectRatioImageCard` → `EdgeMedia2` → `EdgeMedia` → `EdgeImage` → `<img>`

When set, `EdgeImage` emits **`loading="eager"` + `fetchpriority="high"`**. Wired into the two home-block components that render the above-the-fold cards (`CollectionHomeBlock`, `FeaturedCollectionsHomeBlock`), marking only the **first N=4 cards of the FIRST home block** (`shouldPrioritizeLcpImage` gate) — priority on everything is priority on nothing.

- The 4 card types used by home blocks (`ImageCard`, `ModelCard`, `PostCard`, `ArticleCard`) forward `priority`.
- Below-the-fold cards and later home blocks get **no** priority attributes.
- Responsive `srcset`/sizing and aspect-ratio reservation are untouched (orthogonal to the CLS work).
- `react-dom@18.3.1` has no `fetchPriority` in its known-attribute map, so we emit the canonical **lowercase `fetchpriority`** (React passes lowercase attrs through verbatim; browsers read it case-insensitively). A single controlled cast lives in `EdgeImage`; the rest of the chain threads a clean typed `priority: boolean`.

## How much of the 2.3s does this remove? (honest)

**Partial — the post-render *contention* slice, not the pre-render *discovery* slice.**

- `fetchpriority="high"` + `loading="eager"` only help **after** the `<img>` is in the DOM: they let the LCP image jump ahead of the many sibling card images (and other in-flight requests) it would otherwise contend with, instead of waiting behind them at default priority.
- They do **not** fix the **pre-render discovery delay** (JS download/parse → hydrate → `useInView` → tRPC feed fetch → React renders the card → img enters DOM), which is the **majority** of the 2.3s. Given the phase split (download itself is only 95-251ms), the discovery slice is the dominant term.
- The **big** win (removing the bulk of the 2.3s) requires the LCP image URL to be discoverable early in the initial HTML — SSR-ing the first card's image URL or a server-emitted `<link rel="preload" as="image">`. On the homepage the first image URL is **not** knowable server-side without prefetching `image.getInfinite`/home-block cards on the server, i.e. **reintroducing the SSR-feed-prefetch that was deliberately reverted** (and fighting the intentional `IsClient`/`useInView` load sequencing in `pages/home/index.tsx`). This PR does **not** reintroduce that.

So: this is the clean, low-risk **partial** fix. If RUM shows the contention slice is meaningful, the next lever is a targeted server-emitted preload `<link>` for just the first home-block image — a separate, riskier change.

## Flag + measurement plan

- Flag: **`lcpImagePriority`** (Flipt key `lcp-image-priority`), `availability: ['mod']`, **default OFF**. Flag-OFF render is **byte-identical** (no attributes emitted) → instant, safe rollback.
- LCP is an all-user route metric, so a mod-only cohort can't move the aggregate — **ramp a % of ALL users via Flipt** as a threshold rollout.
- Measure via Faro RUM: LCP **`resource_load_delay`** and **p75 LCP by route** (homepage), flag-on vs flag-off cohorts. Expect a reduction in the contention tail, not the full 2.3s.

## Tests

- `EdgeImage.browser.test.tsx` (Vitest browser mode): `priority` → `fetchpriority="high"` + `loading="eager"`; no `priority` / `priority={false}` → **no attributes (byte-identical)**; `EdgeMedia` image branch forwards `priority` to the `<img>`. **5 passed.**
- `lcpImagePriority.test.ts` (unit): deterministic gate — first N of first block only; below-fold, later-block, and flag-off all false. **6 passed.**
- Typecheck: touched files clean (remaining `tsc --noEmit` errors are pre-existing baseline — missing `kysely`/`event-engine-common` external modules + untouched `image.service.ts` implicit-any).

## Does NOT

- Reintroduce the reverted broad SSR-feed-prefetch.
- Make below-the-fold images eager/high-priority.
- Change responsive sizing or aspect-ratio reservation (CLS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)