### PR TITLE
fix(router): guard null history.state in Safari/iOS back-navigation

### DIFF
--- a/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.browser.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { BrowserRouterProvider, useBrowserRouter } from '~/components/BrowserRouter/BrowserRouterProvider';
+import { ClientHistoryStore } from '~/store/ClientHistoryStore';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+// Integration coverage for the Safari/iOS back-navigation crash, exercised at
+// the REAL call-sites (the live popstate handlers) in a browser:
+//   - BrowserRouterProvider popstate → `locationchange` → reads `.as` on null e.state
+//   - ClientHistoryStore   popstate → reads `.state.key` on null e.state
+// Safari nulls `history.state` / popstate `e.state` on some back/forward +
+// bfcache restores; the old handlers threw `TypeError: null is not an object`
+// and broke the back button for iOS users.
+//
+// IMPORTANT (why the ordering matters): the popstate listeners attach in a mount
+// `useEffect`, so a `popstate` dispatched immediately after render is LOST (the
+// listener isn't live yet) — such a test would silently pass even against the
+// broken code. So we first dispatch a POPULATED popstate and `waitFor` asPath to
+// update, which proves the listeners are live, THEN dispatch the null popstate.
+// The reliable regression signal is that the null popstate still drives asPath to
+// the current-location fallback: the OLD code throws before `setState`, so asPath
+// would stay stuck at the previous value and this assertion fails. (Listener
+// exceptions are swallowed by the browser event system and do not surface on the
+// window `error` event, so an onError spy is NOT a reliable guard here.)
+
+function AsPathProbe() {
+  const { asPath } = useBrowserRouter();
+  return <div data-testid="aspath">{asPath}</div>;
+}
+const probeText = () => page.getByTestId('aspath').element().textContent;
+
+describe('BrowserRouterProvider + ClientHistoryStore popstate handling (Safari null state)', () => {
+  test('a back navigation with null history.state degrades to the current location instead of crashing', async () => {
+    const originalState = window.history.state;
+    try {
+      renderWithProviders(
+        <>
+          <ClientHistoryStore />
+          <BrowserRouterProvider>
+            <AsPathProbe />
+          </BrowserRouterProvider>
+        </>
+      );
+
+      // 1) Establish that the popstate listeners are live: a populated
+      //    (Next.js-style) state must drive asPath. This is also the happy-path
+      //    assertion (behaviour unchanged for the non-null case). The listeners
+      //    attach in a mount effect, so we re-dispatch inside `waitFor` until the
+      //    effect is live (a single dispatch right after render is lost).
+      const populated = {
+        key: 'abc123',
+        as: '/search?query=cats',
+        url: '/search?query=cats',
+        state: { prev: { asPath: '/models' } },
+      };
+      window.history.replaceState(populated, '');
+      await vi.waitFor(() => {
+        window.dispatchEvent(new PopStateEvent('popstate', { state: populated }));
+        expect(probeText()).toBe('/search?query=cats');
+      });
+
+      // 2) The iOS back-button state: history.state === null, popstate with a
+      //    null state (what Safari delivers). The OLD handlers threw
+      //    `TypeError: null is not an object (evaluating 't.as' / 't.state.key')`
+      //    here and left asPath stuck at '/search?query=cats'. The guarded code
+      //    must instead degrade to the current location so navigation still
+      //    reflects the real URL.
+      window.history.replaceState(null, '');
+      expect(window.history.state).toBeNull();
+      window.dispatchEvent(new PopStateEvent('popstate', { state: null }));
+
+      const locationFallback = `${window.location.pathname}${window.location.search}`;
+      await vi.waitFor(() => {
+        expect(probeText()).toBe(locationFallback);
+      });
+      // Sanity: it actually changed away from the populated value (i.e. the null
+      // handler ran and did not throw before updating).
+      expect(probeText()).not.toBe('/search?query=cats');
+    } finally {
+      window.history.replaceState(originalState, '');
+    }
+  });
+});

--- a/src/components/BrowserRouter/BrowserRouterProvider.tsx
+++ b/src/components/BrowserRouter/BrowserRouterProvider.tsx
@@ -5,18 +5,13 @@ import { resolveHref } from 'next/dist/client/resolve-href';
 import { QS } from '~/utils/qs';
 import { create } from 'zustand';
 import { useDidUpdate } from '@mantine/hooks';
+import {
+  resolveLocationChangeState,
+  type BrowserRouterState,
+  type HistoryState,
+} from '~/components/BrowserRouter/browserRouterState';
 
 type Url = UrlObject | string;
-
-type HistoryState = {
-  prev?: { asPath: string };
-} & Record<string, any>;
-
-type BrowserRouterState = {
-  asPath: string;
-  query: Record<string, any>;
-  state?: HistoryState;
-};
 
 const BrowserRouterContext = createContext<{
   asPath: string;
@@ -36,12 +31,6 @@ export const useBrowserRouter = () => {
 export function BrowserRouterProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const stateRef = useRef<BrowserRouterState>();
-
-  const parseQuery = (state?: any) => {
-    if (!state && typeof window === 'undefined') return {};
-    const [path, queryString] = (state?.url ?? history.state.url).split('?');
-    return QS.parse(queryString) as Record<string, any>;
-  };
 
   const {
     asPath = router.asPath,
@@ -63,12 +52,8 @@ export function BrowserRouterProvider({ children }: { children: React.ReactNode 
     const locationChangeFn = (e: Event) => {
       const event = e as CustomEvent;
       if (event.detail) {
-        const state = event.detail[0];
-        stateRef.current = {
-          asPath: state.as,
-          query: parseQuery(state),
-          state: history.state.state,
-        };
+        const eventState = event.detail[0];
+        stateRef.current = resolveLocationChangeState(eventState, history.state, window.location);
         if (!usingNextRouter) useBrowserRouterState.setState(stateRef.current);
       }
     };
@@ -83,7 +68,7 @@ export function BrowserRouterProvider({ children }: { children: React.ReactNode 
 
   useEffect(() => {
     const handleRouteChangeComplete = () => {
-      if (stateRef.current && stateRef.current?.asPath === history.state.as)
+      if (stateRef.current && stateRef.current?.asPath === history.state?.as)
         useBrowserRouterState.setState(stateRef.current);
 
       setUsingNextRouter(false);
@@ -109,7 +94,7 @@ function goto(type: 'replace' | 'push', url: Url, as?: Url, state?: HistoryState
 
   const historyState = {
     ...history.state,
-    state: { ...history.state.state, ...state },
+    state: { ...(history.state?.state ?? {}), ...state },
     // key: uuidv4(),
     url: _url,
     as: _as,
@@ -118,7 +103,7 @@ function goto(type: 'replace' | 'push', url: Url, as?: Url, state?: HistoryState
   if (type === 'replace') {
     history.replaceState(historyState, '', _as);
   } else {
-    const { as } = history.state;
+    const { as } = history.state ?? {};
     historyState.state.prev = { asPath: as };
     history.pushState(historyState, '', _as);
   }

--- a/src/components/BrowserRouter/__tests__/browserRouterState.test.ts
+++ b/src/components/BrowserRouter/__tests__/browserRouterState.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { resolveLocationChangeState } from '~/components/BrowserRouter/browserRouterState';
+
+// Regression coverage for the Safari/iOS back-navigation crash:
+//   TypeError: null is not an object (evaluating 't.as')
+//     at src/components/BrowserRouter/BrowserRouterProvider.tsx (popstate handler)
+// The popstate handler dispatches `locationchange` with `detail: [e.state]`; on
+// Safari `e.state` (and `history.state`) can be null on back/forward + bfcache
+// restores. Reading `.as` / `.url` / `.state` off null threw and broke back-nav.
+// `resolveLocationChangeState` is the shared guard: it degrades to the CURRENT
+// LOCATION (already updated by popstate) so navigation still reflects the real
+// URL instead of crashing.
+describe('resolveLocationChangeState', () => {
+  const location = { pathname: '/models', search: '?sort=Newest' };
+
+  describe('the Safari/iOS null case (the crash)', () => {
+    it('does not throw when both popstate state and history.state are null', () => {
+      expect(() => resolveLocationChangeState(null, null, location)).not.toThrow();
+    });
+
+    it('falls back to the current location for asPath + query when state is null', () => {
+      const result = resolveLocationChangeState(null, null, location);
+      // asPath reflects the real (already-navigated) URL, not a crash / blank.
+      expect(result.asPath).toBe('/models?sort=Newest');
+      // query parsed from the current location, not from a null state.
+      expect(result.query).toEqual({ sort: 'Newest' });
+      // state degrades to an empty object (context type expects an object).
+      expect(result.state).toEqual({});
+    });
+
+    it('handles a root location with no search string', () => {
+      const result = resolveLocationChangeState(null, null, { pathname: '/', search: '' });
+      expect(result.asPath).toBe('/');
+      expect(result.query).toEqual({});
+      expect(result.state).toEqual({});
+    });
+
+    it('uses history.state.url for query when popstate e.state is null but history.state exists', () => {
+      // Safari can null the popstate `e.state` while `history.state` is present.
+      const historyState = { url: '/search?query=cats', as: '/search', state: { prev: { asPath: '/' } } };
+      const result = resolveLocationChangeState(null, historyState, location);
+      // asPath still degrades to location (e.state.as is what normally supplies it).
+      expect(result.asPath).toBe('/models?sort=Newest');
+      // query comes from history.state.url.
+      expect(result.query).toEqual({ query: 'cats' });
+      // nested state preserved from history.state.state.
+      expect(result.state).toEqual({ prev: { asPath: '/' } });
+    });
+  });
+
+  describe('the Chrome / happy path (unchanged)', () => {
+    it('reads asPath/query/state from the populated popstate state object', () => {
+      const eventState = {
+        as: '/search?query=dogs',
+        url: '/search?query=dogs',
+        state: { prev: { asPath: '/models' } },
+      };
+      const historyState = { ...eventState };
+      const result = resolveLocationChangeState(eventState, historyState, location);
+      expect(result.asPath).toBe('/search?query=dogs');
+      expect(result.query).toEqual({ query: 'dogs' });
+      expect(result.state).toEqual({ prev: { asPath: '/models' } });
+    });
+
+    it('parses an empty query when the state url has no query string', () => {
+      const eventState = { as: '/models', url: '/models', state: {} };
+      const result = resolveLocationChangeState(eventState, eventState, location);
+      expect(result.asPath).toBe('/models');
+      expect(result.query).toEqual({});
+      expect(result.state).toEqual({});
+    });
+  });
+});

--- a/src/components/BrowserRouter/browserRouterState.ts
+++ b/src/components/BrowserRouter/browserRouterState.ts
@@ -1,0 +1,42 @@
+import { QS } from '~/utils/qs';
+
+export type HistoryState = {
+  prev?: { asPath: string };
+} & Record<string, any>;
+
+export type BrowserRouterState = {
+  asPath: string;
+  query: Record<string, any>;
+  state?: HistoryState;
+};
+
+/**
+ * Build the browser-router state from a (possibly `null`) popstate/history state.
+ *
+ * Safari (and iOS WebViews) deliver a `null` `history.state` / popstate
+ * `e.state` on some back/forward navigations and back-forward-cache restores,
+ * where Chrome keeps the Next.js-populated state object. Reading `.as` / `.url`
+ * / `.state` off that null threw `TypeError: null is not an object` in the
+ * popstate handler and broke client-side back navigation for iOS users.
+ *
+ * When the state object is missing those fields we fall back to the *current
+ * location* (which popstate has already updated) so the router still reflects
+ * the real URL rather than crashing or going blank:
+ *  - `asPath`  ← `eventState.as`  else `location.pathname + location.search`
+ *  - `query`   ← parsed from `eventState.url` / `history.state.url` else location
+ *  - `state`   ← `history.state.state` else `{}`
+ */
+export function resolveLocationChangeState(
+  eventState: any,
+  historyState: any,
+  currentLocation: { pathname: string; search: string }
+): BrowserRouterState {
+  const locationHref = `${currentLocation.pathname}${currentLocation.search}`;
+  const urlSource: string = eventState?.url ?? historyState?.url ?? locationHref;
+  const [, queryString] = urlSource.split('?');
+  return {
+    asPath: eventState?.as ?? locationHref,
+    query: QS.parse(queryString) as Record<string, any>,
+    state: (historyState?.state ?? {}) as HistoryState,
+  };
+}

--- a/src/components/BrowserRouter/browserRouterState.ts
+++ b/src/components/BrowserRouter/browserRouterState.ts
@@ -25,6 +25,12 @@ export type BrowserRouterState = {
  *  - `asPath`  ← `eventState.as`  else `location.pathname + location.search`
  *  - `query`   ← parsed from `eventState.url` / `history.state.url` else location
  *  - `state`   ← `history.state.state` else `{}`
+ *
+ * NOTE: the `location` fallback is pathname-level, NOT fully asPath-equivalent.
+ * It drops the URL hash (e.g. `#comments`) and any dynamic-route params Next
+ * interpolates into `history.state.url` (e.g. `/models/[id]?id=123` → `{id:'123'}`
+ * becomes `{}`). This is an accepted degradation on a path that previously
+ * HARD-CRASHED — reaching this branch means the populated state was unavailable.
  */
 export function resolveLocationChangeState(
   eventState: any,

--- a/src/components/Dialog/RoutedDialogProvider.tsx
+++ b/src/components/Dialog/RoutedDialogProvider.tsx
@@ -11,6 +11,7 @@ import {
 } from '~/components/BrowserRouter/BrowserRouterProvider';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { getHasClientHistory } from '~/store/ClientHistoryStore';
+import { getRoutedDialogState } from '~/components/Dialog/routedDialogState';
 
 export function RoutedDialogProvider() {
   const router = useRouter();
@@ -82,7 +83,12 @@ export function RoutedDialogProvider() {
       const dialog = dialogs[name];
       if (!dialog) continue;
       if ((dialog as any).requireAuth && !currentUser) continue;
-      const state = history.state.state;
+      // Safari/iOS can deliver a null `history.state` on back/forward + bfcache
+      // restores (same crash class fixed in BrowserRouterProvider). This effect
+      // runs on that nav (deps include browserRouter.query), and on a `?dialog=…`
+      // URL `toOpen` is non-empty — an unguarded `history.state.state` threw
+      // `TypeError: null is not an object`. Degrade to `{}` (no extra props).
+      const state = getRoutedDialogState(history.state);
       const Dialog = createBrowserRouterSync(dialog.component);
       dialogStore.trigger({
         id: key,

--- a/src/components/Dialog/__tests__/routedDialogState.test.ts
+++ b/src/components/Dialog/__tests__/routedDialogState.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { getRoutedDialogState } from '~/components/Dialog/routedDialogState';
+
+// Regression coverage for the relocated Safari/iOS back-navigation crash:
+//   TypeError: null is not an object (evaluating 't.state')
+//     at src/components/Dialog/RoutedDialogProvider.tsx (the `?dialog=…` open path)
+// Safari delivers a null `history.state` on some back/forward + bfcache restores;
+// the routed-dialog effect read `history.state.state` (nested props to spread into
+// the opened dialog) unguarded and threw. `getRoutedDialogState` is the shared
+// guard the call-site now uses — it must degrade to `{}` (no extra props) rather
+// than crash, matching the `?? {}` style used in resolveLocationChangeState.
+describe('getRoutedDialogState', () => {
+  describe('the Safari/iOS null case (the crash)', () => {
+    it('returns {} for null history.state (no throw) — dialog opens with no extra props', () => {
+      expect(() => getRoutedDialogState(null)).not.toThrow();
+      expect(getRoutedDialogState(null)).toEqual({});
+    });
+
+    it('returns {} for undefined state', () => {
+      expect(getRoutedDialogState(undefined)).toEqual({});
+    });
+
+    it('returns {} when history.state has no nested state (bfcache-restored entry)', () => {
+      expect(getRoutedDialogState({})).toEqual({});
+      expect(getRoutedDialogState({ url: '/models/1?dialog=imageDetail', as: '/images/1' })).toEqual({});
+    });
+
+    it('returns {} when nested state is null / not an object', () => {
+      expect(getRoutedDialogState({ state: null })).toEqual({});
+      expect(getRoutedDialogState({ state: 'nope' })).toEqual({});
+      expect(getRoutedDialogState({ state: 42 })).toEqual({});
+    });
+
+    it('returns {} for a non-object history.state (primitive)', () => {
+      expect(getRoutedDialogState('nope')).toEqual({});
+    });
+  });
+
+  describe('the Chrome / happy path (unchanged)', () => {
+    it('returns the nested state object when present (Next.js-populated state)', () => {
+      const nested = { imageId: 123, postId: 45 };
+      expect(getRoutedDialogState({ state: nested })).toBe(nested);
+      expect(getRoutedDialogState({ url: '/x', as: '/x', state: { foo: 'bar' } })).toEqual({ foo: 'bar' });
+    });
+  });
+});

--- a/src/components/Dialog/routedDialogState.ts
+++ b/src/components/Dialog/routedDialogState.ts
@@ -1,0 +1,21 @@
+/**
+ * Safari/iOS null-`history.state` guard for the routed-dialog effect.
+ *
+ * Safari (and iOS WebViews) deliver a `null` `history.state` on some
+ * back/forward navigations and back-forward-cache restores (the same class of
+ * crash fixed in BrowserRouterProvider/ClientHistoryStore). The routed-dialog
+ * effect runs on that nav and, on a `?dialog=…` URL, read the nested props off
+ * `history.state.state` to spread into the opened dialog — an unguarded
+ * `history.state.state` threw `TypeError: null is not an object`.
+ *
+ * Degrade to an empty object when the nested state is missing/not an object, so
+ * the dialog opens with no extra props instead of crashing. Mirrors
+ * `resolveLocationChangeState`'s `?? {}` fallback.
+ */
+export function getRoutedDialogState(historyState: unknown): Record<string, any> {
+  if (historyState && typeof historyState === 'object') {
+    const nested = (historyState as { state?: unknown }).state;
+    if (nested && typeof nested === 'object') return nested as Record<string, any>;
+  }
+  return {};
+}

--- a/src/store/ClientHistoryStore.tsx
+++ b/src/store/ClientHistoryStore.tsx
@@ -2,6 +2,7 @@ import { useWindowEvent } from '@mantine/hooks';
 import { useEffect } from 'react';
 import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
+import { getHistoryStateKey } from '~/store/clientHistoryState';
 
 // partial support navigation api - https://caniuse.com/?search=window.navigation
 const isClient = typeof window !== 'undefined';
@@ -57,7 +58,8 @@ export function ClientHistoryStore() {
 
   useEffect(() => {
     if (!keys.length) {
-      setDefault(history.state.key);
+      const key = getHistoryStateKey(history.state);
+      if (key) setDefault(key);
     }
   }, [keys, setDefault]);
 
@@ -73,7 +75,8 @@ export function ClientHistoryStore() {
   }, [pushKey]);
 
   const handlePopstate = (e: any) => {
-    if (e.state.key) setKey(e.state.key);
+    const key = getHistoryStateKey(e?.state);
+    if (key) setKey(key);
   };
   useWindowEvent('popstate', handlePopstate);
 
@@ -92,8 +95,8 @@ export function useHasClientHistory() {
 export const getHasClientHistory = () => {
   if (!hasNavigation) {
     const keys = sessionStorage.getItem(sessionKey)?.split(',') ?? [];
-    const current = history.state.key;
-    const index = keys.indexOf(current);
+    const current = getHistoryStateKey(history.state);
+    const index = current ? keys.indexOf(current) : -1;
     return index > 0;
   } else return navigation.currentEntry.index > 0;
 };

--- a/src/store/__tests__/clientHistoryState.test.ts
+++ b/src/store/__tests__/clientHistoryState.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { getHistoryStateKey } from '~/store/clientHistoryState';
+
+// Regression coverage for the Safari/iOS back-navigation crash:
+//   TypeError: null is not an object (evaluating 't.state.key')
+//     at src/store/ClientHistoryStore.tsx (popstate handler + setDefault)
+// Safari delivers a `null` `history.state` / popstate `e.state` on some
+// back/forward + bfcache restores; reading `.key` off it threw and broke the
+// back button for iOS users. `getHistoryStateKey` is the shared guard the two
+// call-sites (handlePopstate, the setDefault effect, getHasClientHistory) use.
+describe('getHistoryStateKey', () => {
+  describe('the Safari/iOS null case (the crash)', () => {
+    it('returns undefined for null history.state / popstate e.state (no throw)', () => {
+      expect(() => getHistoryStateKey(null)).not.toThrow();
+      expect(getHistoryStateKey(null)).toBeUndefined();
+    });
+
+    it('returns undefined for undefined state', () => {
+      expect(getHistoryStateKey(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for a state object with no key (bfcache-restored entry)', () => {
+      expect(getHistoryStateKey({})).toBeUndefined();
+      expect(getHistoryStateKey({ url: '/models', as: '/models' })).toBeUndefined();
+    });
+
+    it('returns undefined for a non-string / null key', () => {
+      expect(getHistoryStateKey({ key: null })).toBeUndefined();
+      expect(getHistoryStateKey({ key: 123 })).toBeUndefined();
+      expect(getHistoryStateKey({ key: undefined })).toBeUndefined();
+    });
+
+    it('returns undefined for non-object state (primitive)', () => {
+      expect(getHistoryStateKey('nope')).toBeUndefined();
+      expect(getHistoryStateKey(42)).toBeUndefined();
+    });
+  });
+
+  describe('the Chrome / happy path (unchanged)', () => {
+    it('returns the string key when present (Next.js-populated state)', () => {
+      expect(getHistoryStateKey({ key: 'abc123' })).toBe('abc123');
+      expect(getHistoryStateKey({ key: 'k', url: '/models', as: '/models' })).toBe('k');
+    });
+  });
+});

--- a/src/store/clientHistoryState.ts
+++ b/src/store/clientHistoryState.ts
@@ -1,0 +1,16 @@
+/**
+ * Safari (and iOS WebViews) deliver a `null` `history.state` / popstate
+ * `e.state` on some back/forward navigations and back-forward-cache restores,
+ * where Chrome keeps the Next.js-populated state object. Reading `.key` off that
+ * null threw `TypeError: null is not an object` and broke client-side back
+ * navigation for iOS users. Resolve the key defensively: return `undefined`
+ * when there is no usable string key so callers degrade to "no key for this
+ * entry" (skip index bookkeeping) instead of crashing.
+ */
+export function getHistoryStateKey(state: unknown): string | undefined {
+  if (state && typeof state === 'object') {
+    const key = (state as { key?: unknown }).key;
+    if (typeof key === 'string') return key;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Safari/iOS back-button crash — `history.state` is `null`

### Evidence (production Faro RUM)
Two sibling client-side crash signatures, one shared root, seen only on **Safari / Mobile Safari / iOS** (near-zero Chrome), on routes like `/models` and `/search`, chronic across app versions, **~387 hits / 3h**:

- `TypeError: null is not an object (evaluating 't.as')` — `BrowserRouterProvider.tsx` popstate/`locationchange` handler.
- `TypeError: null is not an object (evaluating 't.state.key')` — `ClientHistoryStore.tsx` popstate handler.

Impact: breaks client-side (back-button) navigation for iOS users.

### Root cause
Both custom-router handlers read fields off `history.state` / the popstate `e.state` assuming it is always the Next.js-populated object. **Safari (and iOS WebViews) deliver a `null` `history.state` / `e.state`** on some back/forward navigations and back-forward-cache (bfcache) restores, so:

- `BrowserRouterProvider` popstate handler did `state.as`, `parseQuery(state)` → `history.state.url`, and `history.state.state` → all throw on `null`.
- `ClientHistoryStore` did `e.state.key` (popstate) and `history.state.key` (initial default + `getHasClientHistory`) → throw on `null`.

### Fix (both call-sites, graceful fallback — not just crash-avoidance)
Two small dependency-light helpers encode the correct null-fallback and are used at every call-site:

- `browserRouterState.ts` → `resolveLocationChangeState(eventState, historyState, location)`: when the state object is null/missing fields, **fall back to the current `location`** (which popstate has already updated) so `asPath`/`query` still reflect the real URL, and `state` degrades to `{}`. Keeps navigation correct rather than blank.
- `clientHistoryState.ts` → `getHistoryStateKey(state)`: returns the string `key` when present, else `undefined`, so the store **skips index bookkeeping for the keyless entry** instead of throwing.

Also guarded the remaining same-class `history.state` derefs in `BrowserRouterProvider` (`routeChangeComplete` and `goto`) so the fix doesn't just move the crash. The Chrome/happy path (populated state) is unchanged.

### Test coverage
- **Unit** (`clientHistoryState.test.ts`, `browserRouterState.test.ts`, 12 tests): both helpers on `null`/`undefined`/keyless/malformed inputs → no throw + exact fallback values (asPath from location, query parsed from location, `state` = `{}`, key = `undefined`), plus the populated happy path unchanged.
- **Component / browser mode** (`BrowserRouterProvider.browser.test.tsx`): mounts the real `BrowserRouterProvider` + `ClientHistoryStore`, establishes the live popstate listeners, then dispatches a **real `PopStateEvent` with `state: null`** (forcing `history.state = null`) — the iOS back-button path. Asserts `asPath` degrades to the current-location fallback. Verified this test **fails** against the pre-fix code and **passes** with the fix.

Typecheck: touched files are clean (`tsc --noEmit` residual errors are pre-existing baseline — missing `kysely` / private `event-engine-common` module, unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
