### PR TITLE
feat(licensing): per-version licensing lineage (inherit fee from a root version)

### DIFF
--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -1048,6 +1048,13 @@ model ModelVersion {
   licensingFeeType               LicensingFeeType?               @default(PerImageBuzz)
   licensingFeeSettlementCurrency LicensingFeeSettlementCurrency? @default(Buzz)
 
+  // Licensing lineage: the root version whose fee this version inherits (e.g. a
+  // checkpoint built on Anima-Turbo points at the turbo version). Null falls
+  // back to the (baseModel, modelType) BaseModelLicensingFee rule. Decoupled
+  // from baseModel so it never affects gen-compat / leaderboards / filters.
+  licensingSourceVersionId Int?
+  licensingSource          ModelVersion?  @relation("licensingSource", fields: [licensingSourceVersionId], references: [id], onDelete: SetNull)
+
   monetization            ModelVersionMonetization?
   metrics                 ModelVersionMetric[]
   files                   ModelFile[]
@@ -1061,6 +1068,7 @@ model ModelVersion {
   metricsDaily            ModelMetricDaily[]
   modelVersionExploration ModelVersionExploration[]
   vaeFor                  ModelVersion[]            @relation("vae")
+  licensingDerivatives    ModelVersion[]            @relation("licensingSource")
   generationCoverage      GenerationCoverage?
   recommendedResources    RecommendedResource[]     @relation("recommendedResources")
   recommendedTo           RecommendedResource[]     @relation("recommendedTo")
@@ -1072,6 +1080,7 @@ model ModelVersion {
   baseModelLicensingFees  BaseModelLicensingFee[]
 
   @@index([modelId], type: Hash)
+  @@index([licensingSourceVersionId])
 }
 
 model BaseModelLicensingFee {

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -2575,6 +2575,7 @@ export type ModelVersion = {
   licensingFee: number | null;
   licensingFeeType: Generated<LicensingFeeType | null>;
   licensingFeeSettlementCurrency: Generated<LicensingFeeSettlementCurrency | null>;
+  licensingSourceVersionId: number | null;
 };
 export type ModelVersionEngagement = {
   userId: number;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -917,6 +917,8 @@ export interface ModelVersion {
   licensingFee: number | null;
   licensingFeeType: LicensingFeeType | null;
   licensingFeeSettlementCurrency: LicensingFeeSettlementCurrency | null;
+  licensingSourceVersionId: number | null;
+  licensingSource?: ModelVersion | null;
   monetization?: ModelVersionMonetization | null;
   metrics?: ModelVersionMetric[];
   files?: ModelFile[];
@@ -930,6 +932,7 @@ export interface ModelVersion {
   metricsDaily?: ModelMetricDaily[];
   modelVersionExploration?: ModelVersionExploration[];
   vaeFor?: ModelVersion[];
+  licensingDerivatives?: ModelVersion[];
   generationCoverage?: GenerationCoverage | null;
   recommendedResources?: RecommendedResource[];
   recommendedTo?: RecommendedResource[];

--- a/prisma/migrations/20260708120000_model_version_licensing_source/migration.sql
+++ b/prisma/migrations/20260708120000_model_version_licensing_source/migration.sql
@@ -1,0 +1,32 @@
+-- Licensing lineage: a ModelVersion can inherit another version's licensing fee
+-- via licensingSourceVersionId (e.g. a checkpoint built on Anima-Turbo points at
+-- the turbo version so it charges the turbo fee, not the base-model rule).
+-- Decoupled from baseModel so gen-compat / leaderboards / filters are unaffected.
+-- Resolution order per resource: own licensingFee -> licensingSource's fee ->
+-- (baseModel, modelType) BaseModelLicensingFee fallback.
+--
+-- NOTE: applied MANUALLY (this repo does NOT use `prisma migrate deploy`).
+
+-- a) Add the nullable column. Existing rows default NULL = current fallback
+--    behavior, so this is a no-op for everything until authors opt in.
+ALTER TABLE "ModelVersion" ADD COLUMN "licensingSourceVersionId" INTEGER;
+
+-- b) Self-referencing FK. NOT VALID first so we don't hold ACCESS EXCLUSIVE
+--    while scanning this large, hot table; VALIDATE then runs under SHARE
+--    UPDATE EXCLUSIVE (does not block concurrent reads/writes). All rows are
+--    NULL at add time so validation is effectively a no-op, but keep the
+--    two-step pattern for consistency with the rest of the repo.
+ALTER TABLE "ModelVersion"
+  ADD CONSTRAINT "ModelVersion_licensingSourceVersionId_fkey"
+  FOREIGN KEY ("licensingSourceVersionId") REFERENCES "ModelVersion"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE
+  NOT VALID;
+
+ALTER TABLE "ModelVersion"
+  VALIDATE CONSTRAINT "ModelVersion_licensingSourceVersionId_fkey";
+
+-- c) Index the referencing column. The FK is ON DELETE SET NULL, so without
+--    this every ModelVersion delete would seq-scan to find referencing rows.
+--    The column is all-NULL right now, so the build is instant.
+CREATE INDEX "ModelVersion_licensingSourceVersionId_idx"
+  ON "ModelVersion" ("licensingSourceVersionId");

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -18,7 +18,7 @@ import { IconAlertTriangle, IconInfoCircle } from '@tabler/icons-react';
 import { getQueryKey } from '@trpc/react-query';
 import { isEqual, uniq } from 'lodash-es';
 import { useRouter } from 'next/router';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import * as z from 'zod';
 
 import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
@@ -253,10 +253,25 @@ export function ModelVersionUpsertForm({
     !!currentUser?.isModerator;
 
   const licensingSourceVersionId = form.watch('licensingSourceVersionId') ?? null;
-  const { data: licensingRoots = [] } = trpc.modelVersion.getLicensingRoots.useQuery(
+  const { data: licensingRootsData = [] } = trpc.modelVersion.getLicensingRoots.useQuery(
     { baseModel },
     { enabled: !!baseModel }
   );
+  // Exclude the version being edited — a root defines its own fee and must not
+  // point at itself. The picker always carries an implicit "Default (base model
+  // standard fee)" option, so a single remaining root is still a real choice
+  // (default vs that lineage); we only hide it when there are no roots at all.
+  const licensingRoots = licensingRootsData.filter((r) => r.id !== version?.id);
+
+  // A licensing lineage root is scoped to a base model, so a base-model change
+  // invalidates any selected source. Skip the initial value (edit pre-fill).
+  const prevBaseModelRef = useRef(baseModel);
+  useEffect(() => {
+    if (prevBaseModelRef.current === baseModel) return;
+    prevBaseModelRef.current = baseModel;
+    if (form.getValues('licensingSourceVersionId') != null)
+      form.setValue('licensingSourceVersionId', null, { shouldDirty: true });
+  }, [baseModel]);
 
   // handle mismatched baseModels in training data
   useEffect(() => {
@@ -809,7 +824,7 @@ export function ModelVersionUpsertForm({
               <Divider my="md" />
             </Stack>
           )}
-          {licensingRoots.length > 0 && (
+          {(showLicensingFeeBlock || !!currentUser?.isModerator) && licensingRoots.length > 0 && (
             <Stack gap="xs">
               <Select
                 label="Licensing base"

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -7,6 +7,7 @@ import {
   Input,
   Popover,
   SegmentedControl,
+  Select,
   Stack,
   Switch,
   Text,
@@ -209,6 +210,7 @@ export function ModelVersionUpsertForm({
     licensingFee: version?.licensingFee ?? 0,
     licensingFeeType: version?.licensingFeeType ?? null,
     licensingFeeSettlementCurrency: version?.licensingFeeSettlementCurrency ?? null,
+    licensingSourceVersionId: version?.licensingSourceVersionId ?? null,
     requireAuth: version?.requireAuth ?? true,
     recommendedResources: version?.recommendedResources ?? [],
     // Being extra safe here and ensuring this value exists.
@@ -249,6 +251,12 @@ export function ModelVersionUpsertForm({
   const showLicensingFeeSettlementCurrency =
     existingSettlementCurrency === LicensingFeeSettlementCurrency.Cash ||
     !!currentUser?.isModerator;
+
+  const licensingSourceVersionId = form.watch('licensingSourceVersionId') ?? null;
+  const { data: licensingRoots = [] } = trpc.modelVersion.getLicensingRoots.useQuery(
+    { baseModel },
+    { enabled: !!baseModel }
+  );
 
   // handle mismatched baseModels in training data
   useEffect(() => {
@@ -799,6 +807,30 @@ export function ModelVersionUpsertForm({
                 </Text>
               )}
               <Divider my="md" />
+            </Stack>
+          )}
+          {licensingRoots.length > 0 && (
+            <Stack gap="xs">
+              <Select
+                label="Licensing base"
+                description="If this model is built on a specific base, pick it so generations inherit that base's licensing fee. Leave as default to use the base model's standard fee."
+                placeholder="Default (base model standard fee)"
+                clearable
+                value={licensingSourceVersionId ? String(licensingSourceVersionId) : null}
+                onChange={(val) =>
+                  form.setValue('licensingSourceVersionId', val ? Number(val) : null, {
+                    shouldDirty: true,
+                  })
+                }
+                data={licensingRoots.map((r) => ({
+                  value: String(r.id),
+                  label: `${r.modelName} — ${r.versionName} (${r.licensingFee} Buzz${
+                    r.licensingFeeSettlementCurrency === LicensingFeeSettlementCurrency.Cash
+                      ? ', cash'
+                      : ''
+                  })`,
+                }))}
+              />
             </Stack>
           )}
           {showLicensingFeeBlock && (

--- a/src/pages/api/v1/model-versions/mini/[id].ts
+++ b/src/pages/api/v1/model-versions/mini/[id].ts
@@ -63,6 +63,10 @@ type VersionRow = {
   baseLicensingFee: number | null;
   baseLicensingFeeType: LicensingFeeType | null;
   baseLicensingFeeSettlementCurrency: LicensingFeeSettlementCurrency | null;
+  licensingSourceVersionId: number | null;
+  sourceLicensingFee: number | null;
+  sourceLicensingFeeType: LicensingFeeType | null;
+  sourceLicensingFeeSettlementCurrency: LicensingFeeSettlementCurrency | null;
   versionFlags: number;
   userFlags: number;
 };
@@ -116,6 +120,10 @@ export default MixedAuthEndpoint(async function handler(
       rmv."licensingFee" AS "baseLicensingFee",
       rmv."licensingFeeType" AS "baseLicensingFeeType",
       rmv."licensingFeeSettlementCurrency" AS "baseLicensingFeeSettlementCurrency",
+      mv."licensingSourceVersionId",
+      lsv."licensingFee" AS "sourceLicensingFee",
+      lsv."licensingFeeType" AS "sourceLicensingFeeType",
+      lsv."licensingFeeSettlementCurrency" AS "sourceLicensingFeeSettlementCurrency",
       mv."flags" AS "versionFlags",
       u."flags" AS "userFlags",
       (
@@ -148,6 +156,7 @@ export default MixedAuthEndpoint(async function handler(
     LEFT JOIN "BaseModelLicensingFee" bmlf
       ON bmlf."baseModel" = mv."baseModel" AND bmlf."modelType" = m."type"
     LEFT JOIN "ModelVersion" rmv ON rmv.id = bmlf."modelVersionId"
+    LEFT JOIN "ModelVersion" lsv ON lsv.id = mv."licensingSourceVersionId"
     WHERE ${Prisma.join(where, ' AND ')}
   `;
   if (!modelVersion) return res.status(404).json({ error: 'Model not found' });
@@ -267,18 +276,39 @@ export default MixedAuthEndpoint(async function handler(
     .map((fm) => fm.modelId)
     .includes(modelVersion.modelId);
 
-  // A base-model rule and the version's own fee now stack: a derivative on a
-  // base model that charges a licensing fee can add its own fee on top, and each
-  // fee settles to its own recipient. `fees` carries the full breakdown; the
-  // orchestrator charges the sum and pays out each entry separately.
+  // Licensing-fee resolution (per resource). One "base/lineage" component — the
+  // fee owed to the licensor of whatever this version derives from — plus an
+  // optional "version" surcharge the creator stacks on top; each settles to its
+  // own recipient. `fees` carries the full breakdown; the orchestrator charges
+  // the sum and pays out each entry separately. The base/lineage component is
+  // resolved most-specific first:
+  //   1. this version is a LicensingRoot -> its own fee IS the lineage fee,
+  //      settled to itself, and it escapes the (baseModel, modelType) rule
+  //      (e.g. an ecosystem's Turbo checkpoint charges its rate, not the base's).
+  //   2. licensingSourceVersionId set -> the chosen root's fee, settled to it
+  //      (a checkpoint built on Turbo inherits the Turbo rate).
+  //   3. otherwise the (baseModel, modelType) BaseModelLicensingFee rule.
+  const isLicensingRoot =
+    Flags.hasFlag(modelVersion.versionFlags, ModelVersionFlag.LicensingRoot) &&
+    modelVersion.licensingFee != null &&
+    modelVersion.licensingFee > 0;
+  const hasSourceRule =
+    !isLicensingRoot &&
+    modelVersion.licensingSourceVersionId != null &&
+    modelVersion.sourceLicensingFee != null &&
+    modelVersion.sourceLicensingFee > 0;
   const hasBaseRule =
+    !isLicensingRoot &&
+    !hasSourceRule &&
     modelVersion.baseLicensingFeeRecipientId != null &&
     modelVersion.baseLicensingFee != null &&
     modelVersion.baseLicensingFee > 0;
-  // A base version resolves to its own row via the rule, so don't double-count
-  // its fee as both the base rule and an own fee.
+
+  // When the base/lineage component already settles to this version itself (it's
+  // the root), its own fee IS that component — don't double-count it as a surcharge.
   const isBaseRecipientItself =
-    hasBaseRule && modelVersion.baseLicensingFeeRecipientId === modelVersion.id;
+    isLicensingRoot ||
+    (hasBaseRule && modelVersion.baseLicensingFeeRecipientId === modelVersion.id);
   const hasOwnFee =
     modelVersion.licensingFee != null && modelVersion.licensingFee > 0 && !isBaseRecipientItself;
 
@@ -289,7 +319,23 @@ export default MixedAuthEndpoint(async function handler(
     settlementCurrency: string;
     recipientModelVersionId: number;
   }> = [];
-  if (hasBaseRule) {
+  if (isLicensingRoot) {
+    fees.push({
+      role: 'baseModel',
+      amount: modelVersion.licensingFee!,
+      type: lowerFirst(modelVersion.licensingFeeType ?? 'PerImageBuzz'),
+      settlementCurrency: lowerFirst(modelVersion.licensingFeeSettlementCurrency ?? 'Buzz'),
+      recipientModelVersionId: modelVersion.id,
+    });
+  } else if (hasSourceRule) {
+    fees.push({
+      role: 'baseModel',
+      amount: modelVersion.sourceLicensingFee!,
+      type: lowerFirst(modelVersion.sourceLicensingFeeType ?? 'PerImageBuzz'),
+      settlementCurrency: lowerFirst(modelVersion.sourceLicensingFeeSettlementCurrency ?? 'Buzz'),
+      recipientModelVersionId: modelVersion.licensingSourceVersionId!,
+    });
+  } else if (hasBaseRule) {
     fees.push({
       role: 'baseModel',
       amount: modelVersion.baseLicensingFee!,

--- a/src/server/controllers/model-version.controller.ts
+++ b/src/server/controllers/model-version.controller.ts
@@ -77,6 +77,8 @@ import { getWorkflow } from '~/server/services/orchestrator/workflows';
 import { updateTrainingWorkflowRecords } from '~/server/services/training.service';
 import { getAllowedAccountTypes } from '~/server/utils/buzz-helpers';
 import { isDefined } from '~/utils/type-guards';
+import { Flags } from '~/shared/utils/flags';
+import { ModelVersionFlag } from '~/shared/constants/model-version-flags.constants';
 
 export const getModelVersionRunStrategiesHandler = ({ input: { id } }: { input: GetByIdInput }) => {
   try {
@@ -129,6 +131,7 @@ const loadModelVersion = async ({
         licensingFee: true,
         licensingFeeType: true,
         licensingFeeSettlementCurrency: true,
+        licensingSourceVersionId: true,
         meta: true,
         model: {
           select: {
@@ -416,6 +419,20 @@ export const upsertModelVersionHandler = async ({
       if (!input.licensingFeeType) input.licensingFeeType = LicensingFeeType.PerImageBuzz;
       if (!input.licensingFeeSettlementCurrency)
         input.licensingFeeSettlementCurrency = LicensingFeeSettlementCurrency.Buzz;
+    }
+
+    // Licensing lineage: the chosen source must be a LicensingRoot for the same
+    // base model. Guards against pointing at an arbitrary (or zero-fee) version
+    // to dodge the base-model rule.
+    if (input.licensingSourceVersionId != null) {
+      const source = await dbRead.modelVersion.findUnique({
+        where: { id: input.licensingSourceVersionId },
+        select: { flags: true, baseModel: true },
+      });
+      if (!source || !Flags.hasFlag(source.flags, ModelVersionFlag.LicensingRoot))
+        throw throwBadRequestError('Invalid licensing source: not a licensing lineage root.');
+      if (source.baseModel !== input.baseModel)
+        throw throwBadRequestError('Licensing source must share the same base model.');
     }
 
     const version = await upsertModelVersion({

--- a/src/server/routers/model-version.router.ts
+++ b/src/server/routers/model-version.router.ts
@@ -24,6 +24,7 @@ import {
   mergeVersionsSchema,
   deleteExplorationPromptSchema,
   earlyAccessModelVersionsOnTimeframeSchema,
+  getLicensingRootsSchema,
   getModelVersionByModelTypeSchema,
   getModelVersionPopularityInput,
   getModelVersionSchema,
@@ -43,6 +44,7 @@ import {
   deleteExplorationPrompt,
   getExplorationPromptsById,
   getModelVersionPopularity,
+  getLicensingRoots,
   getModelVersionsByModelType,
   getModelVersionsPopularity,
   getVersionById,
@@ -123,6 +125,10 @@ export const modelVersionRouter = router({
     .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getModelVersionsByIdsInput)
     .query(({ input }) => getVersionsByIds(input)),
+  getLicensingRoots: publicProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getLicensingRootsSchema)
+    .query(({ input }) => getLicensingRoots(input)),
   getExplorationPromptsById: publicProcedure
     .meta({ requiredScope: TokenScope.ModelsRead })
     .input(getByIdSchema)

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -418,12 +418,20 @@ export const modelVersionUpsertSchema2 = z.object({
   licensingFee: z.number().int().min(0).max(MAX_LICENSING_FEE).nullish(),
   licensingFeeType: z.enum(LicensingFeeType).nullish(),
   licensingFeeSettlementCurrency: z.enum(LicensingFeeSettlementCurrency).nullish(),
+  // Inherit another version's licensing fee (a LicensingRoot for this baseModel).
+  // Null falls back to the (baseModel, modelType) rule.
+  licensingSourceVersionId: z.number().nullish(),
 });
 
 export type GetModelVersionSchema = z.infer<typeof getModelVersionSchema>;
 export const getModelVersionSchema = z.object({
   id: z.number(),
   withFiles: z.boolean().optional(),
+});
+
+export type GetLicensingRootsSchema = z.infer<typeof getLicensingRootsSchema>;
+export const getLicensingRootsSchema = z.object({
+  baseModel: z.string(),
 });
 
 export type UpsertExplorationPromptInput = z.infer<typeof upsertExplorationPromptSchema>;

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -90,7 +90,13 @@ import type {
   ModelVersionEngagementType,
   TrainingStatus,
 } from '~/shared/utils/prisma/enums';
-import { Availability, CommercialUse, ModelStatus } from '~/shared/utils/prisma/enums';
+import {
+  Availability,
+  CommercialUse,
+  LicensingFeeSettlementCurrency,
+  LicensingFeeType,
+  ModelStatus,
+} from '~/shared/utils/prisma/enums';
 import { isDefined } from '~/utils/type-guards';
 import { ingestModelById, updateModelLastVersionAt } from './model.service';
 import { filesForModelVersionCache } from './model-file.service';
@@ -257,6 +263,40 @@ export const getUserEarlyAccessModelVersions = async ({ userId }: { userId: numb
     },
     select: { id: true },
   });
+};
+
+// Licensing lineage roots selectable for a given base model — the versions
+// flagged LicensingRoot that define a fee others can inherit (e.g. an
+// ecosystem's Base / Turbo checkpoints). Feeds the version-form picker.
+export const getLicensingRoots = async ({ baseModel }: { baseModel: string }) => {
+  return dbRead.$queryRaw<
+    Array<{
+      id: number;
+      modelId: number;
+      modelName: string;
+      versionName: string;
+      licensingFee: number | null;
+      licensingFeeType: LicensingFeeType | null;
+      licensingFeeSettlementCurrency: LicensingFeeSettlementCurrency | null;
+    }>
+  >`
+    SELECT
+      mv.id,
+      mv."modelId",
+      m.name AS "modelName",
+      mv.name AS "versionName",
+      mv."licensingFee",
+      mv."licensingFeeType",
+      mv."licensingFeeSettlementCurrency"
+    FROM "ModelVersion" mv
+    JOIN "Model" m ON m.id = mv."modelId"
+    WHERE mv."baseModel" = ${baseModel}
+      AND (mv.flags & ${ModelVersionFlag.LicensingRoot}) = ${ModelVersionFlag.LicensingRoot}
+      AND mv.status = ${ModelStatus.Published}::"ModelStatus"
+      AND mv."licensingFee" IS NOT NULL
+      AND mv."licensingFee" > 0
+    ORDER BY m.name, mv.index
+  `;
 };
 
 export const upsertModelVersion = async ({

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -295,6 +295,9 @@ export const getLicensingRoots = async ({ baseModel }: { baseModel: string }) =>
       AND mv.status = ${ModelStatus.Published}::"ModelStatus"
       AND mv."licensingFee" IS NOT NULL
       AND mv."licensingFee" > 0
+      AND m.status = ${ModelStatus.Published}::"ModelStatus"
+      AND m.availability = ${Availability.Public}::"Availability"
+      AND m."deletedAt" IS NULL
     ORDER BY m.name, mv.index
   `;
 };

--- a/src/shared/constants/model-version-flags.constants.ts
+++ b/src/shared/constants/model-version-flags.constants.ts
@@ -9,10 +9,14 @@ export const ModelVersionFlag = {
 
   /** This version opts out of creator payouts — tips and creator compensation (e.g. licensed models earning via license fees instead). */
   DisablePayout: 1 << 0, // 1
+
+  /** This version defines a licensing-fee lineage that other versions can inherit via `licensingSourceVersionId` (e.g. an ecosystem's Base / Turbo checkpoint). Selectable as a "licensing base" in the version form. */
+  LicensingRoot: 1 << 1, // 2
 } as const;
 
 export type ModelVersionFlagValue = (typeof ModelVersionFlag)[keyof typeof ModelVersionFlag];
 
 export const modelVersionFlagLabels: Record<number, string> = {
   [ModelVersionFlag.DisablePayout]: 'Disable creator payouts',
+  [ModelVersionFlag.LicensingRoot]: 'Licensing lineage root',
 };


### PR DESCRIPTION
## What

Adds a **per-version licensing lineage** so a model version can inherit another version's licensing fee, decoupled from the `baseModel` string. This lets ecosystem variants (e.g. Anima **Turbo**) and checkpoints built on them charge their own licensing rate instead of the base-model rule — without splitting the base model (leaderboards, filters, generation compatibility all stay keyed on `baseModel` and are untouched).

Motivated by Anima-Turbo: it needs a 2-Buzz/image fee, and custom checkpoints built on Turbo should inherit the Turbo rate, not the Anima base rate.

## How it works

New nullable self-FK `ModelVersion.licensingSourceVersionId` + a `LicensingRoot` flag bit. Fee resolution in `mini/[id]` (per resource), most-specific first:

1. **LicensingRoot** (own fee > 0) → its own fee **is** the lineage fee, settled to itself; it escapes the `(baseModel, modelType)` rule. (Turbo checkpoint → its 2, not the Anima 5.)
2. **`licensingSourceVersionId` set** → the chosen root's fee, settled to that root. (A checkpoint built on Turbo → inherits 2, paid to Turbo.)
3. **fallback** → existing `BaseModelLicensingFee(baseModel, modelType)` rule.

The optional per-version "own fee" surcharge still **stacks** on top of the base/lineage component exactly as before, so existing third-party checkpoints (own fee + base rule) are unchanged.

Authors self-select via a **"Licensing base" dropdown** in the version form, populated by `modelVersion.getLicensingRoots({ baseModel })` (versions flagged `LicensingRoot` for that base model). Server-side guard: a chosen source must be a `LicensingRoot` sharing the same `baseModel`, so you can't point at an arbitrary/zero-fee version to underpay.

## Changes

- **Schema** (`schema.full.prisma`): `licensingSourceVersionId Int?` self-relation (`onDelete: SetNull`) + index; regenerated `models.ts` / `enums.ts` / kysely types.
- **Flag**: `ModelVersionFlag.LicensingRoot = 1 << 1`.
- **Resolver**: lineage-aware fee assembly in `src/pages/api/v1/model-versions/mini/[id].ts`.
- **Persistence + validation**: upsert input + controller guard.
- **Endpoint**: `modelVersion.getLicensingRoots`.
- **Form**: "Licensing base" picker in `ModelVersionUpsertForm`.
- **Migration**: `20260708120000_model_version_licensing_source` (adds column + FK via NOT VALID/VALIDATE + index).

## ⚠️ Manual steps (this repo does NOT use `prisma migrate deploy`)

1. Apply `prisma/migrations/20260708120000_model_version_licensing_source/migration.sql` manually to each env.
2. Flag the lineage roots + set their fees (data, post-deploy), e.g. Anima `base-v1.0` (fee 5, Cash) and `turbo-v1.0` (fee 2, Cash) as `LicensingRoot`. Then Turbo charges 2 and Turbo-derived checkpoints can select it.

Until roots are flagged, behavior is identical to today (all rows `licensingSourceVersionId = NULL` → existing fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
