### PR TITLE
feat(faro): RUM experiment flag segmentation via session attributes

### DIFF
--- a/src/components/Faro/FaroProvider.tsx
+++ b/src/components/Faro/FaroProvider.tsx
@@ -11,6 +11,7 @@ import {
 } from '@grafana/faro-web-sdk';
 import { env } from '~/env/client';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { buildRumExperimentAttributes } from '~/utils/faro/experimentFlags';
 import { deepRedact } from '~/utils/faro/redact';
 import { resolveFaroSampling } from '~/utils/faro/traceSampler';
 import { buildResourceTimingInstrumentations } from './ResourceTimingInstrumentation';
@@ -126,9 +127,18 @@ interface InitFaroOptions {
    * gate on the whole SDK) — ramping the flag % takes effect on the next page load.
    */
   resourceTimingCohort: boolean;
+  /**
+   * Curated `exp_*` RUM-experiment session attributes (from `buildRumExperimentAttributes`),
+   * resolved from the SSR-seeded feature flags in the component so module-scope init never
+   * imports the flags hook. Set as `sessionTracking.session.attributes` so they ride on
+   * `meta.session.attributes` of EVERY beacon (→ Loki `session_attr_exp_*`) from session
+   * creation onward — before the first signal fires, so even LCP/CLS beacons carry them.
+   * Values are boolean-coerced strings (`"true"`/`"false"`); no PII. See experimentFlags.ts.
+   */
+  experimentAttributes: Record<string, string>;
 }
 
-function initFaro({ resourceTimingCohort }: InitFaroOptions) {
+function initFaro({ resourceTimingCohort, experimentAttributes }: InitFaroOptions) {
   if (faroInitStarted) return;
   if (typeof window === 'undefined') return;
   if ((window as unknown as Record<string, unknown>)[WINDOW_GUARD_KEY]) return;
@@ -167,7 +177,19 @@ function initFaro({ resourceTimingCohort }: InitFaroOptions) {
     // Session sampling gates ALL signals in Faro; keep at 1.0 so errors + web-vitals +
     // events + sessions stay at 100%. Browser traces are sub-sampled SEPARATELY by the OTel
     // sampler on SampledTracingInstrumentation below — this rate does NOT gate them.
-    sessionTracking: { samplingRate: sessionSamplingRate },
+    //
+    // `session.attributes` seeds the curated RUM-experiment flags (`exp_*`) onto the session
+    // meta at session CREATION — the Faro session manager merges them with the generated
+    // session id, so they ride on `meta.session.attributes` of every beacon (→ Loki
+    // `session_attr_exp_*`) from the first signal onward. Only set when non-empty. See
+    // experimentFlags.ts for the mechanism, the exact Loki field, the timing guarantee, and
+    // the PII rationale (boolean values only).
+    sessionTracking: {
+      samplingRate: sessionSamplingRate,
+      ...(Object.keys(experimentAttributes).length
+        ? { session: { attributes: experimentAttributes } }
+        : {}),
+    },
     // Error-storm guard: drop known browser noise so a broken deploy can't turn every
     // session into a flood.
     ignoreErrors: [
@@ -235,7 +257,10 @@ export function FaroProvider() {
   useEffect(() => {
     try {
       if (enabled) {
-        initFaro({ resourceTimingCohort: !!features.faroResourceTiming });
+        initFaro({
+          resourceTimingCohort: !!features.faroResourceTiming,
+          experimentAttributes: buildRumExperimentAttributes(features),
+        });
         // If a prior transition paused an already-initialised instance, resume it.
         if (faroInitStarted) faro?.unpause?.();
       } else if (faroInitStarted) {

--- a/src/utils/faro/__tests__/experimentFlags.test.ts
+++ b/src/utils/faro/__tests__/experimentFlags.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { FeatureAccess } from '~/server/services/feature-flags.service';
+import {
+  buildRumExperimentAttributes,
+  RUM_EXPERIMENT_ATTR_PREFIX,
+  RUM_EXPERIMENT_FLAGS,
+} from '~/utils/faro/experimentFlags';
+
+/**
+ * Tests the RUM experiment-segmentation mechanism. `buildRumExperimentAttributes` is the
+ * load-bearing pure function: FaroProvider calls it with the resolved feature flags and spreads
+ * its output VERBATIM into `initializeFaro`'s `sessionTracking.session.attributes` — so testing
+ * this output IS testing the attributes that get set on the session at init (which then ride on
+ * `meta.session.attributes` → Loki `session_attr_exp_*` of every beacon).
+ */
+
+describe('RUM_EXPERIMENT_FLAGS (curated allowlist)', () => {
+  it('includes the feedReserveCls experiment with its explicit exp_ attribute name', () => {
+    const entry = RUM_EXPERIMENT_FLAGS.find((f) => f.flag === 'feedReserveCls');
+    expect(entry).toBeDefined();
+    expect(entry?.attr).toBe('exp_feed_reserve_cls');
+  });
+
+  it('every curated attribute uses the exp_ prefix (greppable Loki field contract)', () => {
+    for (const { attr } of RUM_EXPERIMENT_FLAGS) {
+      expect(attr.startsWith(RUM_EXPERIMENT_ATTR_PREFIX)).toBe(true);
+    }
+  });
+
+  it('has no duplicate attribute names (each maps to a distinct Loki field)', () => {
+    const attrs = RUM_EXPERIMENT_FLAGS.map((f) => f.attr);
+    expect(new Set(attrs).size).toBe(attrs.length);
+  });
+});
+
+describe('buildRumExperimentAttributes', () => {
+  it('emits "true" for an enabled curated flag', () => {
+    const attrs = buildRumExperimentAttributes({ feedReserveCls: true });
+    expect(attrs.exp_feed_reserve_cls).toBe('true');
+  });
+
+  it('emits "false" for a disabled curated flag (the off cohort must be queryable too)', () => {
+    const attrs = buildRumExperimentAttributes({ feedReserveCls: false });
+    expect(attrs.exp_feed_reserve_cls).toBe('false');
+  });
+
+  it('treats a missing flag as off ("false"), never undefined/absent', () => {
+    const attrs = buildRumExperimentAttributes({});
+    expect(attrs.exp_feed_reserve_cls).toBe('false');
+  });
+
+  it('coerces every value to a string (MetaAttributes must be strings)', () => {
+    const attrs = buildRumExperimentAttributes({ feedReserveCls: true });
+    for (const value of Object.values(attrs)) {
+      expect(typeof value).toBe('string');
+    }
+  });
+
+  it('only emits allowlisted flags — never leaks a non-curated flag onto beacons', () => {
+    // A truthy flag that is NOT in the curated allowlist must not appear as any attribute.
+    const features = {
+      feedReserveCls: true,
+      // Not in RUM_EXPERIMENT_FLAGS — must be dropped (cardinality/PII/noise guard).
+      isModerator: true,
+      redBrowsingLevel: true,
+    } as unknown as Partial<FeatureAccess>;
+    const attrs = buildRumExperimentAttributes(features);
+
+    const emittedKeys = Object.keys(attrs);
+    // Exactly the curated set, nothing else.
+    expect(emittedKeys.sort()).toEqual(RUM_EXPERIMENT_FLAGS.map((f) => f.attr).sort());
+    expect(emittedKeys).not.toContain('isModerator');
+    expect(emittedKeys).not.toContain('redBrowsingLevel');
+    // No emitted key escapes the exp_ prefix.
+    for (const key of emittedKeys) {
+      expect(key.startsWith(RUM_EXPERIMENT_ATTR_PREFIX)).toBe(true);
+    }
+  });
+
+  it('emits exactly one attribute per curated flag', () => {
+    const attrs = buildRumExperimentAttributes({ feedReserveCls: true });
+    expect(Object.keys(attrs).length).toBe(RUM_EXPERIMENT_FLAGS.length);
+  });
+});

--- a/src/utils/faro/experimentFlags.ts
+++ b/src/utils/faro/experimentFlags.ts
@@ -1,0 +1,77 @@
+import type { FeatureAccess, FeatureFlagKey } from '~/server/services/feature-flags.service';
+
+/**
+ * RUM experiment segmentation — carry the value of a CURATED set of feature flags on every
+ * Faro RUM beacon so flag-on vs flag-off cohorts are separable in Loki.
+ *
+ * WHY THIS EXISTS: Faro RUM is at 100% of users, but the beacons carry NO feature-flag
+ * dimension. So a flag-gated A/B experiment (e.g. `feedReserveCls`, the announcement-CLS-reserve
+ * flag ramped to 25% via Flipt) is UNMEASURABLE from RUM — CLS/LCP/exception beacons land in
+ * Loki with no way to split the flag-on cohort from flag-off. This module produces a small,
+ * curated set of `exp_*` session attributes from the resolved feature flags, which FaroProvider
+ * sets as Faro session metadata at init.
+ *
+ * MECHANISM + THE LOKI FIELD IT PRODUCES (verified against the Alloy `faro.receiver` source):
+ *   - These attributes are passed to `initializeFaro` as `sessionTracking.session.attributes`.
+ *     The Faro session manager merges them onto the session meta at session creation (alongside
+ *     the generated session id + `isSampled`) — so they are present BEFORE the first beacon and
+ *     ride on `meta.session.attributes` of EVERY beacon type (exceptions, web-vitals
+ *     measurements, events, resource_timing).
+ *   - Alloy's `faro.receiver` maps `Meta.Session` with prefix `session_` and the session's
+ *     `attributes` map with prefix `attr_` (see `Meta.KeyVal` / `Session.KeyVal` in
+ *     grafana/alloy `.../faro/receiver/internal/payload/payload.go`). So attribute
+ *     `exp_feed_reserve_cls` lands in Loki as the logfmt field **`session_attr_exp_feed_reserve_cls`**.
+ *     NOTE: this is `session_attr_*`, NOT `context_*`. The `context_*` prefix is reserved for a
+ *     BEACON's OWN payload context (e.g. resource_timing's `context_route`, web-vitals'
+ *     `context_largest_shift_target`) — those are set per-push by the instrumentation that emits
+ *     them and cannot be set globally. Session meta is the only surface that reliably lands on
+ *     web-vitals + exception beacons, which is exactly the measurement need here.
+ *
+ * TIMING: because the attributes are baked into the session at creation (during
+ * `initializeFaro`, before any signal is sent), ALL beacon types carry them — including LCP
+ * (early) and CLS/INP (finalized at page-hide/unload). There is no early-beacon gap: session
+ * meta is snapshotted at beacon-emit time, and emit always happens after session creation.
+ *
+ * PII/SAFETY: only curated flags, only boolean values coerced to the strings `"true"`/`"false"`.
+ * Nothing user-identifying. (MetaAttributes must be strings.) These values match none of the
+ * `deepRedact` PII patterns, so they pass through the `beforeSend` scrub untouched. Adding a
+ * flag here does NOT bypass redaction — but keep this list to non-identifying experiment gates
+ * only.
+ *
+ * REUSABILITY: to add a future RUM experiment, add ONE entry to `RUM_EXPERIMENT_FLAGS` — the
+ * feature-flag key + the explicit `exp_*` attribute name. Explicit (not derived) attribute
+ * names keep the Loki field greppable and stable, and avoid a camelCase→snake_case heuristic.
+ */
+
+/** Prefix on every RUM-experiment session attribute, so the Loki field is greppable. */
+export const RUM_EXPERIMENT_ATTR_PREFIX = 'exp_';
+
+/**
+ * CURATED allowlist of feature flags whose value is carried on RUM beacons. This is
+ * DELIBERATELY a small hand-picked set — do NOT dump all feature flags onto beacons
+ * (cardinality, PII, noise). Add one entry per active experiment.
+ *
+ * `flag` — the FeatureAccess key to read.
+ * `attr` — the session-attribute name (`exp_*`) → Loki field `session_attr_<attr>`.
+ */
+export const RUM_EXPERIMENT_FLAGS = [
+  { flag: 'feedReserveCls', attr: 'exp_feed_reserve_cls' },
+] as const satisfies ReadonlyArray<{ flag: FeatureFlagKey; attr: string }>;
+
+/**
+ * Build the `exp_*` session attributes from the resolved feature flags. Emits BOTH cohorts
+ * (`"true"` and `"false"`) for every curated flag so the flag-OFF cohort is queryable too (an
+ * absent field can't be distinguished from "no data"). Only allowlisted flags are emitted; a
+ * flag missing from `features` is treated as off (`"false"`).
+ *
+ * PURE + unit-tested (`__tests__/experimentFlags.test.ts`).
+ */
+export function buildRumExperimentAttributes(
+  features: Partial<FeatureAccess>
+): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  for (const { flag, attr } of RUM_EXPERIMENT_FLAGS) {
+    attributes[attr] = String(!!features[flag]);
+  }
+  return attributes;
+}


### PR DESCRIPTION
## The need

Faro RUM is at 100% of users, but beacons carry **no feature-flag dimension**. So a flag-gated A/B experiment is unmeasurable from RUM — CLS/LCP/exception beacons land in Loki with no way to split the flag-on cohort from flag-off.

Immediate driver: **`feedReserveCls`** (the announcement-CLS-reserve fix, now ramped to **25%** via Flipt). We currently **cannot read its A/B** because the beacon has no flag attribute.

## The mechanism (reusable)

A curated **`RUM_EXPERIMENT_FLAGS`** allowlist (`src/utils/faro/experimentFlags.ts`) maps each experiment flag to an explicit `exp_*` attribute name:

```ts
export const RUM_EXPERIMENT_FLAGS = [
  { flag: 'feedReserveCls', attr: 'exp_feed_reserve_cls' },
] as const;
```

`buildRumExperimentAttributes(features)` coerces the resolved flags to `"true"`/`"false"` strings (both cohorts, so the OFF cohort is queryable too — an absent field can't be told apart from "no data"). `FaroProvider` passes the result into `initializeFaro` as **`sessionTracking.session.attributes`**. The Faro session manager merges them onto the session meta at **session creation** (with the generated session id + `isSampled`), so they ride on `meta.session.attributes` of **every** beacon type.

**Adding a future experiment is one line** in `RUM_EXPERIMENT_FLAGS`. Only the curated set is emitted — feature flags are never dumped wholesale onto beacons (cardinality/PII/noise guard).

## The Loki field it produces

Verified against the Alloy `faro.receiver` source (`Meta.KeyVal` prefixes `Session` with `session_`; `Session.KeyVal` prefixes its `attributes` with `attr_`). So attribute `exp_feed_reserve_cls` lands as the logfmt field:

```
session_attr_exp_feed_reserve_cls = "true" | "false"
```

Note this is **`session_attr_*`, not `context_*`**. The `context_*` prefix is reserved for a beacon's **own payload context** (e.g. resource_timing's `context_route`, web-vitals' `context_largest_shift_target`), which is set per-push by the emitting instrumentation and can't be set globally. Session meta is the only surface that reliably reaches web-vitals + exception beacons — which is exactly the measurement need.

## Timing (which beacons carry it)

Because the attributes are baked into the session **at creation** (during `initializeFaro`, before the first signal), session meta is snapshotted at every beacon's emit time — which is always after creation. So **all** web-vitals carry it:

| Beacon | Finalizes | Carries `session_attr_exp_*`? |
|---|---|---|
| CLS, INP | page-hide / unload | ✅ yes |
| LCP, FCP, TTFB | load / interaction / hide | ✅ yes (not borderline — set before first beacon) |
| exceptions | on throw | ✅ yes |
| resource_timing, events | per-event | ✅ yes |

There is no early-beacon gap: setting attributes at session creation avoids the "set-late, LCP misses it" hazard entirely.

## Safety

- Only **curated** flags, only **boolean** values → `"true"`/`"false"` strings. Nothing user-identifying.
- Values match none of the `deepRedact` PII patterns, so they pass the existing `beforeSend` scrub untouched. **The redaction/sampling path is not modified.**
- Gated behind the existing `faro` flag (init only runs when RUM is on). No new flag introduced.

## Measurement plan (after deploy)

Once live, segment CLS by route and cohort in Loki:

```logql
quantile_over_time(0.75,
  {service_name="civitai-dp-prod", source="faro-rum"}
  |= `kind=measurement` | logfmt | kind=`measurement`
  | value_cls!=`` | unwrap value_cls [$__auto])
by (session_attr_exp_feed_reserve_cls)
```

→ clean flag-on vs flag-off CLS p75 A/B — finally readable. (Group by the label per the faro-rum query-pattern rules: unqualified `| logfmt` + trailing `by()` keeps it OOM-safe.)

## Tests

`src/utils/faro/__tests__/experimentFlags.test.ts` (9 tests, node unit project): on/off/missing → correct `exp_*` values; values are always strings; **non-allowlisted flags are never emitted**; every attribute uses the `exp_` prefix; no duplicate attributes; one attribute per curated flag. All 96 Faro unit tests pass; touched files are typecheck-clean (baseline TS errors are all in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
