### PR TITLE
fix(apps): OG-pull ingest — register imported images for real scanning so they reach Scanned (were terminally NotFound)

### DIFF
--- a/src/components/Apps/ListingAssetStep.browser.test.tsx
+++ b/src/components/Apps/ListingAssetStep.browser.test.tsx
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * W13 — the shared listing ASSET step, focused on the OG-image AUTO-FILL path
+ * (Accept a server-suggested icon/cover → ingest → poll the attach proc until the
+ * scan lands). Browser-mode surface test (report-only in Tekton).
+ *
+ * Two behaviours are asserted (the client half of the OG-pull-ingest fix):
+ *  1. A freshly-ingested image is NOT attached eagerly — the row shows a
+ *     "Scanning image…" state while the attach proc keeps rejecting with the
+ *     retriable "scan is not complete", and flips to "attached" only once the
+ *     attach resolves (scan complete). (Poll logic proven pure in
+ *     `__tests__/assetPolling.test.ts`; this proves the component wiring.)
+ *  2. A TERMINAL ingest failure — the attach proc rejecting with the distinct,
+ *     non-retriable "couldn't be imported — upload it manually" message the server
+ *     now returns for a `NotFound` image — surfaces a CLEAR error and leaves the
+ *     manual-upload FileInput usable (never an eternal "still scanning" dead-end).
+ */
+
+const mocks = vi.hoisted(() => ({
+  ingestAsync: vi.fn(),
+  setIconAsync: vi.fn(),
+  setCoverAsync: vi.fn(),
+  addScreenshotAsync: vi.fn(),
+}));
+
+vi.mock('~/utils/trpc', () => {
+  const passthrough = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
+  return {
+    trpc: {
+      appListings: {
+        persistAssetImage: { useMutation: passthrough },
+        ingestAssetFromUrl: {
+          useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.ingestAsync, isPending: false }),
+        },
+        setIcon: {
+          useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.setIconAsync, isPending: false }),
+        },
+        setCover: {
+          useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.setCoverAsync, isPending: false }),
+        },
+        addScreenshot: {
+          useMutation: () => ({
+            mutate: vi.fn(),
+            mutateAsync: mocks.addScreenshotAsync,
+            isPending: false,
+          }),
+        },
+        removeScreenshot: { useMutation: passthrough },
+      },
+    },
+  };
+});
+
+vi.mock('~/hooks/useCFImageUpload', () => ({
+  useCFImageUpload: () => ({
+    uploadToCF: vi.fn(),
+    files: [],
+    resetFiles: vi.fn(),
+    removeImage: vi.fn(),
+  }),
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+const { ListingAssetStep } = await import('./ListingAssetStep');
+
+const suggestions = {
+  iconImageUrl: 'https://cdn.example.com/icon.png',
+  coverImageUrl: 'https://cdn.example.com/cover.png',
+};
+
+function renderStep() {
+  return renderWithProviders(
+    <ListingAssetStep listingId="listing-1" contentRating="g" suggestions={suggestions} />
+  );
+}
+
+beforeEach(() => {
+  mocks.ingestAsync.mockReset();
+  mocks.setIconAsync.mockReset();
+  mocks.setCoverAsync.mockReset();
+  mocks.addScreenshotAsync.mockReset();
+});
+
+describe('ListingAssetStep — OG-image auto-fill', () => {
+  test('renders the suggested-icon accept affordance from the server suggestion', async () => {
+    renderStep();
+    await expect.element(page.getByTestId('apps-offsite-accept-icon')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-suggested-icon-preview')).toBeInTheDocument();
+    // The "re-scan it just like an upload" reassurance is shown (icon + cover
+    // both render it → scope with .first()).
+    await expect
+      .element(page.getByText(/re-scan it just like an upload/i).first())
+      .toBeInTheDocument();
+  });
+
+  test('accepting a suggestion shows a scanning state, then attaches once the scan lands', async () => {
+    mocks.ingestAsync.mockResolvedValue({ imageId: 777 });
+    // The attach proc rejects "scan is not complete" while the image is still
+    // scanning, then resolves once the scan lands — the polling drives to attached.
+    mocks.setIconAsync
+      .mockRejectedValueOnce(
+        new Error('image is not approved for publishing (scan is not complete)')
+      )
+      .mockResolvedValue({ ok: true });
+
+    renderStep();
+    await page.getByTestId('apps-offsite-accept-icon').click();
+
+    // The ingest ran and the row is in the scanning state (NOT eagerly attached).
+    expect(mocks.ingestAsync).toHaveBeenCalledWith({
+      url: suggestions.iconImageUrl,
+      kind: 'icon',
+    });
+    await expect.element(page.getByText(/Scanning image/i)).toBeInTheDocument();
+
+    // Once the scan lands (2nd attach resolves after the poll delay), the icon
+    // badge flips to "attached" (exact match → the badge, not "0 attached" / the
+    // completeness copy).
+    await expect
+      .element(page.getByText('attached', { exact: true }))
+      .toBeInTheDocument();
+    expect(mocks.setIconAsync).toHaveBeenCalledWith({ listingId: 'listing-1', imageId: 777 });
+  });
+
+  test('a terminal ingest (NotFound) surfaces a clear error and keeps manual upload usable', async () => {
+    mocks.ingestAsync.mockResolvedValue({ imageId: 888 });
+    // The server now returns a DISTINCT, non-retriable message for a NotFound
+    // image (not the retriable "scan is not complete") — the client classifies it
+    // as a terminal error instead of polling forever.
+    mocks.setIconAsync.mockRejectedValue(
+      new Error("that image couldn't be imported — upload it manually instead")
+    );
+
+    renderStep();
+    await page.getByTestId('apps-offsite-accept-icon').click();
+
+    // The clear, actionable error is shown (not an eternal "still scanning").
+    await expect.element(page.getByText(/upload it manually/i)).toBeInTheDocument();
+
+    // The failed auto-fill transitioned OUT of idle (the suggestion accept button
+    // is gone) and the row now offers the plain manual "Upload icon" file input —
+    // the author is never stuck on the failed auto-fill.
+    await expect.element(page.getByText('Upload icon', { exact: true })).toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-accept-icon').elements()).toHaveLength(0);
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -495,6 +495,41 @@ describe('screenshot CRUD', () => {
     expect(mockDb.appListing.update).not.toHaveBeenCalled();
   });
 
+  // A TERMINAL ingestion failure must throw a DISTINCT, non-retriable message
+  // (NOT the retriable "scan is not complete"), so the client stops polling and
+  // shows a clear "upload it manually" error instead of an eternal scanning
+  // spinner. This is the client-resilience half of the OG-pull-ingest fix — a
+  // NotFound image (e.g. the old CF-Images-store bug) is the canonical trigger.
+  it('setIcon surfaces a DISTINCT terminal message for a NotFound image (not "scan is not complete")', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(listingRow);
+    mockDb.image.findUnique.mockResolvedValue({
+      id: 9, userId: 42, type: 'image', width: 512, height: 512, mimeType: 'image/png',
+      metadata: {}, ingestion: 'NotFound', nsfwLevel: 1,
+    });
+    const { setListingIcon } = await import('../app-listing-assets.service');
+    await expect(setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner)).rejects.toThrow(
+      /couldn't be imported — upload it manually/
+    );
+    // Must NOT be the retriable message the client polls on.
+    await expect(setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner)).rejects.not.toThrow(
+      /scan is not complete/
+    );
+    expect(mockDb.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('setIcon surfaces a DISTINCT terminal message for a Blocked image', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(listingRow);
+    mockDb.image.findUnique.mockResolvedValue({
+      id: 9, userId: 42, type: 'image', width: 512, height: 512, mimeType: 'image/png',
+      metadata: {}, ingestion: 'Blocked', nsfwLevel: 1,
+    });
+    const { setListingIcon } = await import('../app-listing-assets.service');
+    await expect(setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner)).rejects.toThrow(
+      /rejected during scanning/
+    );
+    expect(mockDb.appListing.update).not.toHaveBeenCalled();
+  });
+
   it('addScreenshot rejects an Image above the listing content rating (null rating → SFW)', async () => {
     // Listing has no contentRating → fail-closed PG ceiling; image is R (NsfwLevel.R === 4).
     mockDb.appListing.findUnique.mockResolvedValue(listingRow);

--- a/src/server/services/blocks/__tests__/listing-meta.service.test.ts
+++ b/src/server/services/blocks/__tests__/listing-meta.service.test.ts
@@ -154,7 +154,11 @@ describe('ingestListingAssetFromUrl', () => {
       height: 480,
       mimeType: 'image/jpeg',
       userId: 7,
-      metadata: { size: imageBytes.byteLength },
+      metadata: {
+        size: imageBytes.byteLength,
+        source: 'app-listing-og-pull',
+        appListingAssetKind: 'cover',
+      },
     });
     expect(arg.skipIngestion).toBeUndefined();
   });

--- a/src/server/services/blocks/__tests__/listing-meta.service.test.ts
+++ b/src/server/services/blocks/__tests__/listing-meta.service.test.ts
@@ -4,10 +4,21 @@ import { TRPCError } from '@trpc/server';
 /**
  * External-listing metadata AUTO-PULL service. Covers `fetchListingMeta` (page →
  * suggestions; non-https reject; SafeFetchError → friendly BAD_REQUEST; empty page
- * → {}) and `ingestListingAssetFromUrl` (SSRF-safe image fetch → sharp decode → CF
- * upload → `createImage` through the STANDARD scan pipeline; the scan-invariant
- * that `createImage` is called WITHOUT `skipIngestion`; unsupported format reject).
- * All I/O deps (safeFetch, sharp, CF upload, createImage) are mocked.
+ * → {}) and `ingestListingAssetFromUrl` (SSRF-safe image fetch → sharp decode →
+ * upload the bytes into the SCANNABLE image store → `createImage` through the
+ * STANDARD scan pipeline; the scan-invariant that `createImage` is called WITHOUT
+ * `skipIngestion`; unsupported format reject).
+ *
+ * 🔴 STORE-CONVERGENCE REGRESSION GUARD: the original bug uploaded the bytes to
+ * Cloudflare Images (`uploadBufferToCF`) and stored the CF Images id as
+ * `Image.url`. The scanner's edge URL (`getEdgeUrl` → `NEXT_PUBLIC_IMAGE_LOCATION`)
+ * never resolves a CF Images id, so it 404'd at scan time and every OG-pull image
+ * went terminally `ImageIngestionStatus.NotFound`. The fix routes the bytes
+ * through `uploadImageBufferToStore` — the SAME B2 image bucket + storage-resolver
+ * registration the working browser-direct upload path uses — and stores its UUID
+ * key. These tests assert that convergence (and would FAIL on the old CF path).
+ *
+ * All I/O deps (safeFetch, sharp, the store upload, createImage) are mocked.
  */
 
 // A real SafeFetchError class shared with the mocked module so `instanceof` holds
@@ -32,8 +43,12 @@ const { mockMetadata, mockSharp } = vi.hoisted(() => {
 });
 vi.mock('sharp', () => ({ default: mockSharp }));
 
-const { mockUploadBufferToCF } = vi.hoisted(() => ({ mockUploadBufferToCF: vi.fn() }));
-vi.mock('~/utils/cf-images-utils', () => ({ uploadBufferToCF: mockUploadBufferToCF }));
+const { mockUploadImageBufferToStore } = vi.hoisted(() => ({
+  mockUploadImageBufferToStore: vi.fn(),
+}));
+vi.mock('~/utils/s3-utils', () => ({
+  uploadImageBufferToStore: mockUploadImageBufferToStore,
+}));
 
 const { mockCreateImage } = vi.hoisted(() => ({ mockCreateImage: vi.fn() }));
 vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage }));
@@ -47,7 +62,7 @@ beforeEach(() => {
   mockSafeFetch.mockReset();
   mockMetadata.mockReset();
   mockSharp.mockClear();
-  mockUploadBufferToCF.mockReset();
+  mockUploadImageBufferToStore.mockReset();
   mockCreateImage.mockReset();
 });
 
@@ -104,11 +119,11 @@ describe('ingestListingAssetFromUrl', () => {
       bytes: imageBytes,
     });
     mockMetadata.mockResolvedValue({ width: 640, height: 480, format: 'jpeg' });
-    mockUploadBufferToCF.mockResolvedValue({ id: 'cf-image-uuid' });
+    mockUploadImageBufferToStore.mockResolvedValue({ key: 'store-uuid-key', backend: 'backblaze' });
     mockCreateImage.mockResolvedValue({ id: 999 });
   }
 
-  it('safe-fetches → decodes → uploads → createImage (default scan pipeline) → imageId', async () => {
+  it('safe-fetches → decodes → uploads to the scannable store → createImage (default scan pipeline) → imageId', async () => {
     primeHappyPath();
     const res = await ingestListingAssetFromUrl({
       input: { url: 'https://cdn.example.com/og.png', kind: 'cover' },
@@ -116,19 +131,24 @@ describe('ingestListingAssetFromUrl', () => {
     });
     expect(res).toEqual({ imageId: 999 });
 
-    // Bytes uploaded to CF are the ones safeFetch returned (never a re-fetch).
-    expect(mockUploadBufferToCF).toHaveBeenCalledWith(
+    // STORE CONVERGENCE (regression guard): the bytes go to the SAME scannable
+    // image store the working manual-upload path uses — NOT Cloudflare Images.
+    // The bytes uploaded are the ones safeFetch returned (never a re-fetch), and
+    // the decoded mime is passed as the object Content-Type.
+    expect(mockUploadImageBufferToStore).toHaveBeenCalledTimes(1);
+    expect(mockUploadImageBufferToStore).toHaveBeenCalledWith(
       imageBytes,
-      expect.stringContaining('listing-asset'),
-      expect.objectContaining({ userId: 7, kind: 'cover' })
+      expect.objectContaining({ contentType: 'image/jpeg' })
     );
 
-    // SCAN INVARIANT: createImage is called with default ingestion — NO
-    // skipIngestion — so the image flows through the standard scan-gate.
+    // SCAN INVARIANT: createImage is called with the STORE's UUID key as
+    // `Image.url` (what the edge URL + scanner resolve) and default ingestion —
+    // NO skipIngestion — so the image flows through the standard scan-gate and can
+    // reach `Scanned`. (On the old CF path this url was a CF Images id → NotFound.)
     expect(mockCreateImage).toHaveBeenCalledTimes(1);
     const arg = mockCreateImage.mock.calls[0][0];
     expect(arg).toMatchObject({
-      url: 'cf-image-uuid',
+      url: 'store-uuid-key',
       type: 'image',
       width: 640,
       height: 480,
@@ -157,7 +177,7 @@ describe('ingestListingAssetFromUrl', () => {
     await expect(
       ingestListingAssetFromUrl({ input: { url: 'https://cdn.example.com/x.gif', kind: 'icon' }, userId: 1 })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
-    expect(mockUploadBufferToCF).not.toHaveBeenCalled();
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
     expect(mockCreateImage).not.toHaveBeenCalled();
   });
 
@@ -176,7 +196,7 @@ describe('ingestListingAssetFromUrl', () => {
         userId: 1,
       })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
-    expect(mockUploadBufferToCF).not.toHaveBeenCalled();
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
     expect(mockCreateImage).not.toHaveBeenCalled();
   });
 

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -344,6 +344,27 @@ async function loadValidatedImage(
   // Content-status gate: a listing asset is publicly rendered (P2), so the Image
   // must be scan-complete AND within the listing's maturity ceiling. This mirrors
   // the site-wide "don't publish un-scanned / over-rated media" invariant.
+  //
+  // Distinguish a TERMINAL ingestion failure (NotFound = the scanner couldn't
+  // fetch the bytes; Blocked = the image was rejected) from the TRANSIENT
+  // scanning states (Pending / Error-retry / PendingManualAssignment). The client
+  // polls this proc until the scan lands and treats "scan is not complete" as
+  // retriable — so a terminal failure MUST carry a DIFFERENT, non-retriable
+  // message, otherwise the author is stuck watching an eternal "still scanning"
+  // spinner with a useless Retry (that was the OG-image-import dead-end). The
+  // distinct message routes the client to a clear error + the manual-upload path.
+  if (image.ingestion === ImageIngestionStatus.NotFound) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: "that image couldn't be imported — upload it manually instead",
+    });
+  }
+  if (image.ingestion === ImageIngestionStatus.Blocked) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'that image was rejected during scanning — choose a different image',
+    });
+  }
   if (image.ingestion !== ImageIngestionStatus.Scanned) {
     throw new TRPCError({
       code: 'BAD_REQUEST',

--- a/src/server/services/blocks/listing-meta.service.ts
+++ b/src/server/services/blocks/listing-meta.service.ts
@@ -15,11 +15,14 @@ import { SafeFetchError, safeFetch } from '~/server/utils/safe-fetch';
  * `fetchListingMeta` SSRF-safe-fetches the target page and returns SUGGESTIONS
  * (name / tagline / cover+icon image URLs) the author can accept or override;
  * nothing is persisted. `ingestListingAssetFromUrl` runs on ACCEPT: it
- * SSRF-safe-fetches the suggested image, uploads the bytes to Cloudflare, and
- * materialises an `Image` row through the STANDARD ingestion/scan pipeline
- * (`createImage` with default ingestion — NO `skipIngestion`, NO scan bypass),
- * returning the numeric `imageId` the client then attaches via `setIcon`/`setCover`
- * (which enforce `ingestion === Scanned` + per-kind validation).
+ * SSRF-safe-fetches the suggested image, uploads the bytes into the SAME image
+ * store the browser-direct client upload path uses (the B2 image bucket +
+ * storage-resolver registration, via `uploadImageBufferToStore` — NOT Cloudflare
+ * Images, whose ids the scanner's edge URL never resolves), and materialises an
+ * `Image` row through the STANDARD ingestion/scan pipeline (`createImage` with
+ * default ingestion — NO `skipIngestion`, NO scan bypass), returning the numeric
+ * `imageId` the client then attaches via `setIcon`/`setCover` (which enforce
+ * `ingestion === Scanned` + per-kind validation).
  *
  * All outbound fetches go through `safeFetch` (lexical + DNS-resolve-public +
  * manual-redirect-revalidate + timeout + size cap + content-type allowlist). The
@@ -158,21 +161,22 @@ export async function ingestListingAssetFromUrl(opts: {
     });
   }
 
-  // Upload the ALREADY-FETCHED bytes to Cloudflare (never re-fetch the remote URL).
-  const { uploadBufferToCF } = await import('~/utils/cf-images-utils');
-  const ext = mimeType.split('/')[1] ?? 'img';
-  const uploaded = await uploadBufferToCF(fetched.bytes, `listing-asset.${ext}`, {
-    userId,
-    source: 'app-listing-og-pull',
-    kind: input.kind,
-  });
+  // Upload the ALREADY-FETCHED bytes into the SAME store the browser-direct client
+  // upload path uses (the B2 image bucket, registered in storage-resolver) — NOT
+  // Cloudflare Images. This is the load-bearing convergence: the edge URL
+  // (`getEdgeUrl` → `NEXT_PUBLIC_IMAGE_LOCATION`) and the image scanner read from
+  // this store, so the `Image.url` key below resolves at scan time and the row
+  // reaches `Scanned`. (Uploading to CF Images instead — the original bug — left
+  // these rows terminally `NotFound` because that store is never resolved here.)
+  const { uploadImageBufferToStore } = await import('~/utils/s3-utils');
+  const { key } = await uploadImageBufferToStore(fetched.bytes, { contentType: mimeType });
 
   // Materialise the Image row through the STANDARD scan pipeline (default
   // ingestion — no skipIngestion). Dynamic import keeps the heavy image.service
   // graph out of this module's static imports.
   const { createImage } = await import('~/server/services/image.service');
   const image = await createImage({
-    url: uploaded.id,
+    url: key,
     name: `listing-${input.kind}`,
     type: 'image',
     width,

--- a/src/server/services/blocks/listing-meta.service.ts
+++ b/src/server/services/blocks/listing-meta.service.ts
@@ -183,7 +183,14 @@ export async function ingestListingAssetFromUrl(opts: {
     height,
     mimeType,
     // The P1 image validator reads the byte size from `Image.metadata.size`.
-    metadata: { size: fetched.bytes.byteLength },
+    // `source`/`appListingAssetKind` stamp provenance so an OG-pulled asset is
+    // auditable + query-able (e.g. the prod scan-verification check) — mirrors
+    // `createStoredImage`.
+    metadata: {
+      size: fetched.bytes.byteLength,
+      source: 'app-listing-og-pull',
+      appListingAssetKind: input.kind,
+    },
     userId,
   });
 

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -13,11 +13,13 @@ import {
 } from '@aws-sdk/client-s3';
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { randomUUID } from 'crypto';
 import { dbWrite } from '~/server/db/client';
 import { env } from '~/env/server';
 
 import { logToAxiom } from '~/server/logging/client';
 import { instrumentB2Client, recordB2PresignIssued } from '~/server/prom/b2-put.metrics';
+import { registerMediaLocation } from '~/server/services/storage-resolver';
 
 const missingEnvs = (): string[] => {
   const keys = [];
@@ -103,6 +105,46 @@ export async function getImageUploadBackend(): Promise<{
     bucket: env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads',
     backend: 'backblaze',
   };
+}
+
+/**
+ * Server-side: upload ALREADY-FETCHED image bytes into the SAME store the
+ * browser-direct client upload path uses (the B2 image bucket resolved by
+ * `getImageUploadBackend`, registered in storage-resolver) and return the UUID
+ * key to store as `Image.url`.
+ *
+ * This is the server analogue of `/api/v1/image-upload` + the client's presigned
+ * PUT (`useCFImageUpload`): the bytes land where the edge URL (`getEdgeUrl` →
+ * `NEXT_PUBLIC_IMAGE_LOCATION`) and the image SCANNER actually read from, so a
+ * subsequent `createImage({ url: key })` reaches `Scanned`.
+ *
+ * 🔴 DO NOT reach for Cloudflare Images (`uploadBufferToCF`) to make a SCANNABLE
+ * image. CF Images is a DIFFERENT store the edge URL + scanner never resolve — a
+ * CF Images id used as `Image.url` yields an edge URL that 404s at scan time, so
+ * the row goes terminally `ImageIngestionStatus.NotFound`. (That bug shipped in
+ * the App Blocks OG-image auto-pull path.)
+ */
+export async function uploadImageBufferToStore(
+  data: Uint8Array | Buffer,
+  opts?: { contentType?: string }
+): Promise<{ key: string; backend: ImageUploadBackend }> {
+  const { s3, bucket, backend } = await getImageUploadBackend();
+  const key = randomUUID();
+  const bytes = Buffer.isBuffer(data) ? data : Buffer.from(data);
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: bytes,
+      ...(opts?.contentType ? { ContentType: opts.contentType } : {}),
+    })
+  );
+  // Mirror the upload endpoint: register the uuid→backend mapping so the
+  // storage-resolver / edge (and thus the scanner) can locate the object. Awaited
+  // (unlike the endpoint's fire-and-forget) to close the register-vs-scan race —
+  // `registerMediaLocation` swallows its own errors, so this can't throw.
+  await registerMediaLocation(key, backend, bytes.byteLength);
+  return { key, backend };
 }
 
 export function getS3Client() {


### PR DESCRIPTION
## Root cause

The App Blocks external-listing OG-image auto-fill (`ingestListingAssetFromUrl`, `src/server/services/blocks/listing-meta.service.ts`) uploaded the fetched image bytes to **Cloudflare Images** (`uploadBufferToCF` → `api.cloudflare.com/.../images/v1`) and stored the returned **CF Images id** as `Image.url`, then called `createImage` with default ingestion.

But the entire image read/scan pipeline resolves `Image.url` through `getEdgeUrl` → `NEXT_PUBLIC_IMAGE_LOCATION` — the **B2 image origin** fronted by storage-resolver / the image-cacher — **not** Cloudflare Images. The scan request (`createImageIngestionRequest` in `orchestrator.service.ts`) sends the scanner `mediaUrl = getEdgeUrl(Image.url)`. A CF Images id is not a key in that B2 store, so the scanner's fetch **404'd**, and the scan-result webhook (`src/pages/api/webhooks/image-scan-result.ts`, `case Status.NotFound` → line ~164) wrote `ImageIngestionStatus.NotFound`:

```ts
case Status.NotFound: // "image not found at url"
  await dbWrite.image.updateMany({
    where: { id: data.id, ingestion: { in: pendingStates } },
    data: { ingestion: ImageIngestionStatus.NotFound },
  });
```

Every OG-pull icon/cover/screenshot then failed to attach with `400 "image is not approved for publishing (scan is not complete)"` (`loadValidatedImage` in `app-listing-assets.service.ts`, which requires `ingestion === Scanned`).

### The divergence from the working path

The working browser-direct/manual upload path — `useCFImageUpload` → `POST /api/v1/image-upload` → presigned PUT — does **not** use Cloudflare Images at all:

```ts
// src/pages/api/v1/image-upload/index.ts
const { s3, bucket, backend } = await getImageUploadBackend(); // B2 civitai-media-uploads
const result = await getCustomPutUrl(bucket, imageKey, s3);    // presigned PUT
registerMediaLocation(imageKey, backend, 0);                   // storage-resolver
res.json({ id: result.key, uploadURL: result.url });           // Image.url = the UUID key
```

It lands the bytes in the **B2 `civitai-media-uploads`** bucket and registers the UUID→backend mapping in storage-resolver — exactly the store the edge URL + scanner read. The og-pull path diverged onto CF Images, a store nothing in the scan/read path resolves, so those rows could never reach `Scanned`.

**Evidence (prod, userId 8753561):** Image ids `136145606` / `136145608` (`metadata.source='app-listing-og-pull'`) sat terminally `NotFound` while the general scanner was healthy (1066 images `Scanned` in a 15-min window). This is code, not infra.

## Fix

- New server helper `uploadImageBufferToStore` (`src/utils/s3-utils.ts`) — the server analogue of `/api/v1/image-upload` + the client's presigned PUT: it PUTs the already-fetched, SSRF-validated bytes into the B2 image bucket from `getImageUploadBackend`, registers them in storage-resolver, and returns the UUID key.
- `ingestListingAssetFromUrl` now uses it instead of `uploadBufferToCF` and stores the UUID key as `Image.url`, so the image is scanned from the store the scanner actually reads → reaches `Scanned` → `setIcon`/`setCover`/`addScreenshot` attach succeeds. Applies to all asset kinds (they share `ingestAssetFromUrl`). The existing SSRF-safe fetch + sharp validation + dimension/type caps are unchanged.

## Client resilience (deterministic, at the attach gate)

`loadValidatedImage` now distinguishes **terminal** ingestion failures (`NotFound` = scanner couldn't fetch; `Blocked` = rejected) from the **transient** scanning states, throwing a **distinct, non-retriable** message ("that image couldn't be imported — upload it manually instead" / "…rejected during scanning…") instead of the retriable "scan is not complete".

The client (`ListingAssetStep.tsx`) already polls the attach proc and treats only "scan is not complete" as retriable (`classifyAttachResult` / `assetPolling.ts`). Before this, a `NotFound` image made it poll to a misleading "still scanning" timeout with a useless Retry — a dead-end. Now the distinct message is classified as a terminal error, so the author immediately sees a clear, actionable error and the manual-upload FileInput stays usable. The client already waits for scan-complete before attaching (it re-runs the attach proc, transitioning to `attached` only when it resolves) — no eager-attach bug.

## Dark / mod-gated

Behind `app-blocks-author` (mod-gated) — no impact on general users.

## Tests

- `listing-meta.service.test.ts` — **store-convergence regression guard**: asserts the OG-pull path uploads via `uploadImageBufferToStore` and stores its UUID key as `Image.url` (not a CF Images id). **Fails on the old CF path.**
- `app-listing-assets.service.test.ts` — terminal-state gate: `NotFound` / `Blocked` images throw the distinct, non-retriable message (and NOT "scan is not complete").
- `ListingAssetStep.browser.test.tsx` (new) — accept-suggestion shows a "Scanning image…" state then flips to "attached" only once the attach resolves; a terminal ingest surfaces the clear "upload it manually" error and leaves the manual "Upload icon" input usable.

Local: `tsc --noEmit` clean; unit (listing-meta 9, app-listing-assets 53, offsite-listing 42, router offsite-authz 36, assetPolling) + the 3 browser tests all pass.

## Preview-verified vs prod-only (honest scope)

The image scanner is **unreachable on PR previews** (uploads stay `Pending` there), so a true ingest→`Scanned`→attach E2E can only be verified on **prod**. The deterministic unit/component coverage above is preview-safe and proves the store-convergence contract + the client resilience, but the actual scan success is **not** preview-verified.

### Prod-verification checklist (run post-deploy, as a mod)

1. As an `app-blocks-author` mod, open `/apps/submit` (external mode), enter a URL whose page has an `og:image`, and **Accept** the suggested cover (and icon).
2. Grab the created Image id and confirm it reaches `Scanned` (not `NotFound`):
   ```sql
   SELECT id, ingestion, url, metadata
   FROM "Image"
   WHERE metadata->>'source' = 'app-listing-og-pull'
   ORDER BY id DESC LIMIT 5;
   -- expect ingestion = 'Scanned' within ~1 min; url is a UUID key (not a CF Images id)
   ```
   (CNPG nvme0 primary: `kubectl exec -n cnpg-database cnpg-cluster-nvme0-5 -c postgres -- psql -U postgres -d civitai -c "…"`.)
3. Confirm the asset attaches — the icon/cover row flips to **attached** (no 400), i.e. `setCover`/`setIcon` succeeded once the scan landed.
4. Negative-path sanity: if an ingest ever yields a terminal `NotFound`/`Blocked`, the row shows the clear "upload it manually" error and the manual FileInput still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
