### PR TITLE
feat(app-blocks): shared/cross-user storage — Phase 1 server core (dark, fail-closed)

### DIFF
--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -614,6 +614,24 @@ export function enforceContextBinding(
         }
         break;
       }
+      case 'apps:storage:shared:read': {
+        // SHARED (app-global) READS are allowed for anon — the shared list +
+        // counts are public within the app (the real per-op authorization + the
+        // min-trust gate live in `resolveSharedContext`, apps-shared.router). No
+        // extra request-shape binding here; presence of the scope is the check.
+        break;
+      }
+      case 'apps:storage:shared:write': {
+        // SHARED WRITES (append / vote / withdraw / report) are NEVER anonymous —
+        // they are attributed to the subject and pass the min-trust gate. Reject an
+        // anon subject here so wiring this scope can't silently fail open (mirrors
+        // the apps:storage:write case). The trust gate itself is enforced in
+        // `resolveSharedContext`.
+        if (claims.sub === 'anon') {
+          throw forbidden(`${scope} requires authenticated subject`);
+        }
+        break;
+      }
       default:
         // Fail closed (L-M6). Reaching here means a scope passed the
         // `isKnownBlockScope` gate above (it's in BLOCK_SCOPE_TO_OAUTH_BIT)

--- a/src/server/routers/__tests__/apps-shared.router.test.ts
+++ b/src/server/routers/__tests__/apps-shared.router.test.ts
@@ -1,0 +1,483 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * Coverage for `apps.shared.*` (block-token authed cross-user storage) +
+ * `apps.mod.purgeSharedRow` (session moderatorProcedure). Mocks the pg pool, the
+ * block-token verifier, the dedicated Flipt flag, the rate limiters, and the
+ * subject hydration so each auth / counter / trust / safety gate is pinned
+ * independently. The content-safety belt runs FOR REAL (real includesMinor /
+ * includesPoi / HTML-escape) with only its redis-backed deps (blocklist,
+ * promptAuditing) mocked — so the C3 tests exercise the genuine audit path.
+ */
+
+const {
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockDbRead,
+  mockIsSharedEnabled,
+  mockPool,
+  mockClient,
+  mockGetSessionUser,
+  mockCheckAppendRl,
+  mockCheckVoteRl,
+  mockThrowOnBlockedLinkDomain,
+  mockAuditPromptServer,
+} = vi.hoisted(() => {
+  const mockClient = {
+    query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+    release: vi.fn(),
+  };
+  const mockPool = {
+    connect: vi.fn(async () => mockClient),
+    query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+  };
+  return {
+    mockVerifyBlockToken: vi.fn(),
+    mockParseSubjectUserId: vi.fn(),
+    mockDbRead: { appBlock: { findUnique: vi.fn() } },
+    mockIsSharedEnabled: vi.fn(async () => true),
+    mockPool,
+    mockClient,
+    mockGetSessionUser: vi.fn(),
+    mockCheckAppendRl: vi.fn(async () => ({ allowed: true })),
+    mockCheckVoteRl: vi.fn(async () => ({ allowed: true })),
+    mockThrowOnBlockedLinkDomain: vi.fn(async () => undefined),
+    mockAuditPromptServer: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...args: unknown[]) => mockParseSubjectUserId(...args),
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksSharedStorageEnabled: mockIsSharedEnabled,
+}));
+vi.mock('~/server/auth/session-client', () => ({
+  sessionClient: { getSessionUserById: (...a: unknown[]) => mockGetSessionUser(...a) },
+}));
+vi.mock('~/server/db/appsDb', () => ({ requireAppsDb: () => mockPool }));
+vi.mock('~/server/utils/shared-storage-rate-limit', () => ({
+  checkSharedAppendRateLimit: (...a: unknown[]) => mockCheckAppendRl(...a),
+  checkSharedVoteRateLimit: (...a: unknown[]) => mockCheckVoteRl(...a),
+}));
+// Keep the content-safety belt REAL; mock only its redis-backed deps.
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: (...a: unknown[]) => mockThrowOnBlockedLinkDomain(...a),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: (...a: unknown[]) => mockAuditPromptServer(...a),
+}));
+
+import { appsSharedRouter, appsModRouter } from '../apps-shared.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { OnboardingSteps } from '~/server/common/enums';
+
+const READ = 'apps:storage:shared:read';
+const WRITE = 'apps:storage:shared:write';
+
+function validClaims(over: Record<string, unknown> = {}) {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'jti_test',
+    blockId: 'app-voting',
+    appId: 'app_test',
+    appBlockId: 'apb_test',
+    blockInstanceId: 'bki_inst',
+    ctx: {},
+    scopes: [READ, WRITE],
+    ...over,
+  };
+}
+
+// A subject that PASSES the min-trust gate (H3): verified, onboarded, >7d old.
+function trustedUser(over: Record<string, unknown> = {}) {
+  return {
+    id: 42,
+    isModerator: false,
+    bannedAt: null,
+    muted: false,
+    onboarding: OnboardingSteps.Buzz, // Flags.hasFlag(Buzz, Buzz) === true
+    emailVerified: new Date('2020-01-01'),
+    createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    ...over,
+  };
+}
+
+function fakeCtx(user?: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+const caller = () => appsSharedRouter.createCaller(fakeCtx() as never);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsSharedEnabled.mockImplementation(async () => true);
+  mockParseSubjectUserId.mockImplementation((sub: string) =>
+    sub === 'anon' ? null : Number(sub.split(':')[1])
+  );
+  mockGetSessionUser.mockResolvedValue(trustedUser());
+  mockDbRead.appBlock.findUnique.mockResolvedValue({ id: 'apb_test', status: 'approved' });
+  mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
+  mockClient.query.mockResolvedValue({ rows: [], rowCount: 0 });
+  mockCheckAppendRl.mockResolvedValue({ allowed: true });
+  mockCheckVoteRl.mockResolvedValue({ allowed: true });
+  mockThrowOnBlockedLinkDomain.mockResolvedValue(undefined);
+  mockAuditPromptServer.mockResolvedValue(undefined);
+});
+
+describe('resolver gates', () => {
+  it('rejects an invalid token (UNAUTHORIZED)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(null);
+    await expect(caller().getCount({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('rejects a missing AppBlock (NOT_FOUND)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockDbRead.appBlock.findUnique.mockResolvedValueOnce(null);
+    await expect(caller().getCount({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('rejects a non-approved AppBlock (FORBIDDEN)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockDbRead.appBlock.findUnique.mockResolvedValueOnce({ id: 'apb_x', status: 'pending' });
+    await expect(caller().getCount({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+  });
+
+  it('rejects a token missing the read scope (FORBIDDEN)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ scopes: [WRITE] }));
+    await expect(caller().getCount({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it('rejects a token missing the write scope on append (FORBIDDEN)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ scopes: [READ] }));
+    await expect(
+      caller().append({ blockToken: 't', value: { title: 'hi' } })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('FLAG DARK → every op refuses (FORBIDDEN)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockIsSharedEnabled.mockResolvedValue(false);
+    await expect(caller().list({ blockToken: 't' })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    await expect(
+      caller().append({ blockToken: 't', value: { title: 'hi' } })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+});
+
+describe('H3 min-trust gate (write + vote)', () => {
+  const cases: Array<[string, Record<string, unknown> | null]> = [
+    ['vanished subject (null)', null],
+    ['muted', { muted: true }],
+    ['banned', { bannedAt: new Date() }],
+    ['unverified email', { emailVerified: undefined }],
+    ['onboarding incomplete', { onboarding: 0 }],
+    ['too-new account', { createdAt: new Date() }],
+  ];
+  for (const [name, over] of cases) {
+    it(`DENIES an untrusted writer: ${name} (FORBIDDEN)`, async () => {
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+      mockGetSessionUser.mockResolvedValueOnce(over === null ? null : trustedUser(over));
+      await expect(
+        caller().append({ blockToken: 't', value: { title: 'idea' } })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockPool.connect).not.toHaveBeenCalled();
+    });
+  }
+
+  it('ALLOWS a trusted writer (reaches the data path)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('author_user_id') && sql.includes('count(*)'))
+        return { rows: [{ n: '0' }], rowCount: 1 };
+      if (sql.includes('.quota'))
+        return { rows: [{ used_bytes: '0', row_count: '0' }], rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    });
+    const out = await caller().append({ blockToken: 't', value: { title: 'idea' } });
+    expect(out.key).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(mockPool.connect).toHaveBeenCalled();
+  });
+
+  it('anon may READ list/counts', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ sub: 'anon' }));
+    const out = await caller().list({ blockToken: 't' });
+    expect(out.items).toEqual([]);
+  });
+
+  it('anon NEVER writes (UNAUTHORIZED)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'anon' }));
+    await expect(
+      caller().append({ blockToken: 't', value: { title: 'x' } })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    await expect(caller().vote({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+  });
+});
+
+describe('C1 cross-user overwrite', () => {
+  it('append SERVER-generates the key (client key never used)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('author_user_id') && sql.includes('count(*)'))
+        return { rows: [{ n: '0' }], rowCount: 1 };
+      if (sql.includes('.quota'))
+        return { rows: [{ used_bytes: '0', row_count: '0' }], rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    });
+    // Even if a caller smuggles `key`, zod strips it and the server ULID is used.
+    const out = await caller().append({
+      blockToken: 't',
+      value: { title: 'idea' },
+      key: 'victim-key',
+    } as never);
+    const insert = (mockClient.query.mock.calls as Array<[string, unknown[]?]>).find((c) =>
+      c[0].includes('INSERT INTO "app_app_voting".shared_kv')
+    );
+    expect(insert).toBeTruthy();
+    expect((insert![1] as unknown[])[0]).toBe(out.key); // param[0] is the server ULID
+    expect((insert![1] as unknown[])[0]).not.toBe('victim-key');
+  });
+
+  it('withdraw only deletes the author’s OWN row (WHERE author_user_id)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockClient.query.mockImplementation(async (sql: string) => {
+      if (sql.startsWith('DELETE')) return { rows: [], rowCount: 0 }; // not the author → 0
+      return { rows: [], rowCount: 0 };
+    });
+    const out = await caller().withdraw({ blockToken: 't', key: 'someone-elses-key' });
+    expect(out.deleted).toBe(false);
+    const del = (mockClient.query.mock.calls as Array<[string, unknown[]?]>).find((c) =>
+      c[0].startsWith('DELETE')
+    );
+    expect(del![0]).toContain('author_user_id = $2');
+    expect((del![1] as unknown[])[1]).toBe(42);
+  });
+});
+
+describe('H1/H2 vote counter integrity (SQL shape + FK)', () => {
+  it('vote is FK/visibility-gated and uses the insert-gated counter CTE', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('hidden_at IS NULL') && sql.trim().startsWith('SELECT 1'))
+        return { rows: [{ '?column?': 1 }], rowCount: 1 };
+      if (sql.includes('WITH ins AS')) return { rows: [{ count: '1' }], rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    });
+    const out = await caller().vote({ blockToken: 't', key: 'req1' });
+    expect(out.count).toBe(1);
+    const cte = (mockPool.query.mock.calls as Array<[string]>).find((c) =>
+      c[0].includes('WITH ins AS')
+    );
+    // insert-gated increment (H1): ON CONFLICT DO NOTHING + count + EXCLUDED.count
+    expect(cte![0]).toContain('ON CONFLICT (key, user_id) DO NOTHING');
+    expect(cte![0]).toContain('EXCLUDED.count');
+  });
+
+  it('H2: vote on a missing/hidden request rejects NOT_FOUND (pre-check)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 }); // pre-check finds nothing
+    await expect(caller().vote({ blockToken: 't', key: 'ghost' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('H2: FK violation (23503) surfaces NOT_FOUND', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.trim().startsWith('SELECT 1')) return { rows: [{ x: 1 }], rowCount: 1 };
+      if (sql.includes('WITH ins AS')) throw { code: '23503' };
+      return { rows: [], rowCount: 0 };
+    });
+    await expect(caller().vote({ blockToken: 't', key: 'race' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('unvote decrements by exactly the rows deleted (symmetric CTE)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('WITH del AS')) return { rows: [{ count: '0' }], rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    });
+    const out = await caller().unvote({ blockToken: 't', key: 'req1' });
+    expect(out.count).toBe(0);
+    const cte = (mockPool.query.mock.calls as Array<[string]>).find((c) =>
+      c[0].includes('WITH del AS')
+    );
+    expect(cte![0]).toContain('count - (SELECT count(*) FROM del)');
+  });
+});
+
+describe('C3 content safety (blocking on append)', () => {
+  it('rejects minor content + files a Report', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    await expect(
+      caller().append({ blockToken: 't', value: { title: '13 year old girl' } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    // a shared_kv_reports row was filed (auto:minor)
+    const report = (mockPool.query.mock.calls as Array<[string, unknown[]?]>).find((c) =>
+      c[0].includes('shared_kv_reports')
+    );
+    expect(report).toBeTruthy();
+    expect(String((report![1] as unknown[])[3])).toContain('auto:');
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('rejects a blocked link domain (BAD_REQUEST)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockThrowOnBlockedLinkDomain.mockRejectedValueOnce(new Error('invalid urls'));
+    await expect(
+      caller().append({ blockToken: 't', value: { title: 'visit http://bad.example' } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('HTML in text is stored ESCAPED (C2 stored-XSS)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('author_user_id') && sql.includes('count(*)'))
+        return { rows: [{ n: '0' }], rowCount: 1 };
+      if (sql.includes('.quota'))
+        return { rows: [{ used_bytes: '0', row_count: '0' }], rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    });
+    await caller().append({
+      blockToken: 't',
+      value: { title: 'hi <script>alert(1)</script>' },
+    });
+    const insert = (mockClient.query.mock.calls as Array<[string, unknown[]?]>).find((c) =>
+      c[0].includes('INSERT INTO "app_app_voting".shared_kv')
+    );
+    const stored = String((insert![1] as unknown[])[2]);
+    expect(stored).toContain('&lt;script&gt;');
+    expect(stored).not.toContain('<script>');
+  });
+
+  it('audit rejection (auto-mute path) surfaces BAD_REQUEST', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockAuditPromptServer.mockRejectedValueOnce(new Error('Your prompt was flagged'));
+    await expect(
+      caller().append({ blockToken: 't', value: { title: 'flagged text' } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+});
+
+describe('H4 rate limits', () => {
+  it('append over the daily cap → TOO_MANY_REQUESTS', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockCheckAppendRl.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 60 });
+    await expect(
+      caller().append({ blockToken: 't', value: { title: 'idea' } })
+    ).rejects.toMatchObject({ code: 'TOO_MANY_REQUESTS' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('vote over the per-minute cap → TOO_MANY_REQUESTS', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockCheckVoteRl.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 30 });
+    await expect(caller().vote({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+  });
+});
+
+describe('isolation + read invariants', () => {
+  it('list reads ONLY shared_kv/counters (never kv/votes), excludes hidden', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await caller().list({ blockToken: 't' });
+    const sql = (mockPool.query.mock.calls[0] as [string])[0];
+    expect(sql).toContain('.shared_kv');
+    expect(sql).toContain('.counters');
+    expect(sql).toContain('hidden_at IS NULL');
+    expect(sql).not.toMatch(/\.kv\b/);
+    expect(sql).not.toMatch(/\.votes\b/);
+  });
+
+  it('per-app isolation: schema derives from claims.blockId (app A ≠ app B)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ blockId: 'app-beta' }));
+    await caller().list({ blockToken: 't' });
+    const sql = (mockPool.query.mock.calls[0] as [string])[0];
+    expect(sql).toContain('"app_app_beta".shared_kv');
+    expect(sql).not.toContain('app_app_voting');
+  });
+});
+
+describe('M4 mod-purge (session moderatorProcedure)', () => {
+  const modCtx = () =>
+    fakeCtx({ id: 9, isModerator: true, bannedAt: null, deletedAt: null, muted: false });
+  const modCaller = () => appsModRouter.createCaller(modCtx() as never);
+
+  it('DELETE cascades the row (+ files a report)', async () => {
+    mockDbRead.appBlock.findUnique.mockResolvedValueOnce({ id: 'apb_x', blockId: 'app-voting' });
+    mockClient.query.mockImplementation(async (sql: string) => {
+      if (sql.startsWith('DELETE')) return { rows: [], rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    });
+    const out = await modCaller().purgeSharedRow({
+      appBlockId: 'apb_x',
+      key: 'bad',
+      action: 'delete',
+    });
+    expect(out).toMatchObject({ ok: true, action: 'delete', affected: 1 });
+    const del = (mockClient.query.mock.calls as Array<[string]>).find((c) =>
+      c[0].startsWith('DELETE')
+    );
+    expect(del![0]).toContain('"app_app_voting".shared_kv');
+    const report = (mockPool.query.mock.calls as Array<[string, unknown[]?]>).find((c) =>
+      c[0].includes('shared_kv_reports')
+    );
+    expect(String((report![1] as unknown[])[3])).toContain('mod:delete');
+  });
+
+  it('HIDE soft-hides (UPDATE hidden_at) without deleting', async () => {
+    mockDbRead.appBlock.findUnique.mockResolvedValueOnce({ id: 'apb_x', blockId: 'app-voting' });
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.trim().startsWith('UPDATE')) return { rows: [], rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    });
+    const out = await modCaller().purgeSharedRow({
+      appBlockId: 'apb_x',
+      key: 'bad',
+      action: 'hide',
+    });
+    expect(out).toMatchObject({ ok: true, action: 'hide', affected: 1 });
+    const upd = (mockPool.query.mock.calls as Array<[string]>).find((c) =>
+      c[0].trim().startsWith('UPDATE')
+    );
+    expect(upd![0]).toContain('hidden_at = now()');
+  });
+
+  it('is NOT reachable by a non-moderator session (FORBIDDEN)', async () => {
+    const nonMod = appsModRouter.createCaller(fakeCtx({ id: 1, isModerator: false }) as never);
+    await expect(
+      nonMod.purgeSharedRow({ appBlockId: 'apb_x', key: 'k', action: 'hide' })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+});

--- a/src/server/routers/__tests__/apps-shared.router.test.ts
+++ b/src/server/routers/__tests__/apps-shared.router.test.ts
@@ -23,6 +23,7 @@ const {
   mockCheckVoteRl,
   mockThrowOnBlockedLinkDomain,
   mockAuditPromptServer,
+  mockIsRevoked,
 } = vi.hoisted(() => {
   const mockClient = {
     query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
@@ -44,6 +45,7 @@ const {
     mockCheckVoteRl: vi.fn(async () => ({ allowed: true })),
     mockThrowOnBlockedLinkDomain: vi.fn(async () => undefined),
     mockAuditPromptServer: vi.fn(async () => undefined),
+    mockIsRevoked: vi.fn(async () => false),
   };
 });
 
@@ -70,6 +72,10 @@ vi.mock('~/server/services/blocklist.service', () => ({
 vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
   auditPromptServer: (...a: unknown[]) => mockAuditPromptServer(...a),
 }));
+vi.mock('~/server/services/block-revocation.service', () => ({
+  BlockRevocation: { isRevoked: (...a: unknown[]) => mockIsRevoked(...a) },
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: async () => undefined }));
 
 import { appsSharedRouter, appsModRouter } from '../apps-shared.router';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
@@ -163,6 +169,15 @@ describe('resolver gates', () => {
     await expect(caller().getCount({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
       code: 'FORBIDDEN',
     });
+  });
+
+  it('rejects a revoked block instance (FORBIDDEN) — audit M-1', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockIsRevoked.mockResolvedValueOnce(true);
+    await expect(caller().getCount({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockPool.query).not.toHaveBeenCalled();
   });
 
   it('rejects a token missing the read scope (FORBIDDEN)', async () => {

--- a/src/server/routers/apps-shared.router.ts
+++ b/src/server/routers/apps-shared.router.ts
@@ -27,6 +27,8 @@ import { requireAppsDb } from '~/server/db/appsDb';
 import { appSchemaIdent, sanitizeAppSlug } from '~/server/utils/apps-slug';
 import { newUlid } from '~/server/utils/app-block-ids';
 import { parseSubjectUserId, verifyBlockToken } from '~/server/middleware/block-scope.middleware';
+import { BlockRevocation } from '~/server/services/block-revocation.service';
+import { logToAxiom } from '~/server/logging/client';
 import { isAppBlocksSharedStorageEnabled } from '~/server/services/app-blocks-flag';
 import { sessionClient } from '~/server/auth/session-client';
 import type { SessionUser } from '~/types/session';
@@ -139,6 +141,14 @@ async function resolveSharedContext(blockToken: string, op: SharedOp): Promise<S
   if (!block) throw new TRPCError({ code: 'NOT_FOUND', message: 'app block not found' });
   if (block.status !== 'approved') {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'app block is not approved' });
+  }
+
+  // Per-instance revocation — the missing containment leg (audit M-1). The REST
+  // `withBlockScope` path enforces this; the tRPC shared path must too, so an
+  // uninstalled / toggled-off / publisher-banned instance can't keep writing
+  // until token expiry. Mirrors block-scope.middleware's check.
+  if (await BlockRevocation.isRevoked(claims.blockInstanceId)) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'block instance revoked' });
   }
 
   // Per-op scope assertion (re-checks the issuance contract at point of use).
@@ -320,7 +330,7 @@ export const appsSharedRouter = router({
   append: publicProcedure
     .input(blockTokenInput.extend({ value: appendValueInput }))
     .mutation(async ({ input }) => {
-      const { userId, subjectUser, schema, appBlockId } = await resolveSharedContext(
+      const { userId, subjectUser, slug, schema, appBlockId } = await resolveSharedContext(
         input.blockToken,
         'append'
       );
@@ -356,6 +366,23 @@ export const appsSharedRouter = router({
               reporterUserId: uid,
               reason: `auto:${e.category}`,
             }).catch(() => {});
+          }
+          // H-1 (audit): the `shared_kv_reports` table has no reader yet, so the
+          // LEGAL-escalation signal (minor/POI) would otherwise be silent. Emit a
+          // structured, alertable event (NEVER the content) so a CSAM/minor attempt
+          // is observable even before the mod-queue wiring lands (a pre-GA gate).
+          if (e.category === 'minor' || e.category === 'poi') {
+            logToAxiom(
+              {
+                name: 'app-blocks-shared-storage-legal-block',
+                type: 'error',
+                category: e.category,
+                userId: uid,
+                slug,
+                appBlockId,
+              },
+              'block-audit'
+            ).catch(() => {});
           }
           throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
         }

--- a/src/server/routers/apps-shared.router.ts
+++ b/src/server/routers/apps-shared.router.ts
@@ -1,0 +1,676 @@
+// App Blocks SHARED (app-global / cross-user) storage tRPC router.
+//
+// Mounted at `trpc.apps.shared.*` (block-token authed) + `trpc.apps.mod.*`
+// (session moderatorProcedure). This is the FIRST App Blocks surface that opens
+// the per-app datastore to PUBLIC cross-user writes — today per-user KV is
+// reachable only by mods + app-dev-testers (apps.router `assertViewerIsAppDeveloper`).
+// Every control here exists because a community app serves GENERAL users; see the
+// hardened design (`shared-storage-design.md`, "HARDENED per design security
+// review"). Read that before touching auth/counter/trust logic.
+//
+// Data model (per-app schema `app_<slug>`, provisioned by AppStorageProvisioner):
+//   - shared_kv(key ULID PK [SERVER-generated], author_user_id, value jsonb, …)
+//   - votes(key→shared_kv ON DELETE CASCADE, user_id, PK(key,user_id))
+//   - counters(key→shared_kv ON DELETE CASCADE, count>=0)  ← reconstructable cache
+//   - shared_kv_reports(id, key, reporter_user_id, reason, …)
+//
+// Invariants (design "Isolation confirmed SAFE"):
+//   - schema derived from sanitizeAppSlug(claims.blockId) → app A can't reach app B
+//   - shared:read touches ONLY shared_kv/counters, NEVER the per-user `kv`
+//   - `votes` is NEVER listable — only the aggregate `count` is returned
+//   - votes/counters are OUT of the byte-quota; a per-user shared_kv row cap applies
+
+import { TRPCError } from '@trpc/server';
+import * as z from 'zod';
+import { dbRead } from '~/server/db/client';
+import { requireAppsDb } from '~/server/db/appsDb';
+import { appSchemaIdent, sanitizeAppSlug } from '~/server/utils/apps-slug';
+import { newUlid } from '~/server/utils/app-block-ids';
+import { parseSubjectUserId, verifyBlockToken } from '~/server/middleware/block-scope.middleware';
+import { isAppBlocksSharedStorageEnabled } from '~/server/services/app-blocks-flag';
+import { sessionClient } from '~/server/auth/session-client';
+import type { SessionUser } from '~/types/session';
+import { Flags } from '~/shared/utils/flags';
+import { OnboardingSteps } from '~/server/common/enums';
+import {
+  assertSharedTextSafe,
+  SharedContentBlockedError,
+  SHARED_TITLE_MAX,
+  SHARED_BODY_MAX,
+} from '~/server/services/apps/shared-content-safety';
+import {
+  checkSharedAppendRateLimit,
+  checkSharedVoteRateLimit,
+} from '~/server/utils/shared-storage-rate-limit';
+import { moderatorProcedure, publicProcedure, router } from '~/server/trpc';
+
+// ── Limits (design M2/M3) ─────────────────────────────────────────────────────
+// The app quota row is SHARED with the per-user kv path; these mirror the
+// apps.router ceilings so shared writes and per-user writes share one 50MB / 1M
+// budget. Votes/counters/reports carry NO quota trigger → excluded from bytes.
+const APP_QUOTA_BYTES = 50 * 1024 * 1024;
+const APP_ROW_LIMIT = 1_000_000;
+// Per individual shared value (title+body already capped; this bounds the jsonb).
+const SHARED_VALUE_BYTE_CAP = 8 * 1024;
+// Per-USER row cap on shared_kv (design M2): one hostile-but-trusted account can't
+// exhaust the app row budget on its own.
+const SHARED_KV_PER_USER_ROW_CAP = 50;
+
+// ── Min-trust gate (design H3 / MIN-TRUST GATE) ───────────────────────────────
+// Account must be older than this to write/vote (anti-sybil). Starts at 7d.
+const MIN_ACCOUNT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+// Flag-toggleable STRONG anti-sybil lever (design H5): require a paid tier to
+// write/vote. OFF by default — flip to true (or wire to a flag) if sybil pressure
+// materializes. `free`/absent tier fails when on.
+const REQUIRE_PAID_TIER = false;
+
+type SharedOp = 'list' | 'getCount' | 'append' | 'vote' | 'unvote' | 'withdraw' | 'report';
+const READ_OPS: ReadonlySet<SharedOp> = new Set<SharedOp>(['list', 'getCount']);
+
+const SHARED_READ_SCOPE = 'apps:storage:shared:read';
+const SHARED_WRITE_SCOPE = 'apps:storage:shared:write';
+
+/**
+ * The min-trust gate (design H3). Reuses EXISTING civitai trust signals hydrated
+ * from `SessionUser` — no new trust score. FAIL-CLOSED: a vanished subject (null),
+ * banned, muted, onboarding-incomplete, unverified email, or too-new account is
+ * DENIED. `asserts` narrows `user` to non-null for the caller.
+ *
+ * Signals (all AND-ed):
+ *   sub!=anon (caller passes non-null) · !bannedAt · !muted ·
+ *   onboarding-complete (Flags.hasFlag(onboarding, Buzz)) · emailVerified present ·
+ *   account age ≥ MIN_ACCOUNT_AGE_MS · [optional] paid tier.
+ */
+export function assertSharedWriteTrust(user: SessionUser | null): asserts user is SessionUser {
+  const deny = (message: string): never => {
+    throw new TRPCError({ code: 'FORBIDDEN', message });
+  };
+  if (!user) return deny('Your account is not eligible for this action');
+  if (user.bannedAt) return deny('Your account is not eligible for this action');
+  if (user.muted) return deny('Your account has been restricted');
+  if (!Flags.hasFlag(user.onboarding ?? 0, OnboardingSteps.Buzz)) {
+    return deny('Complete onboarding before contributing');
+  }
+  if (!user.emailVerified) return deny('Verify your email before contributing');
+  const createdAt = user.createdAt ? new Date(user.createdAt).getTime() : NaN;
+  if (!Number.isFinite(createdAt) || Date.now() - createdAt < MIN_ACCOUNT_AGE_MS) {
+    return deny('Your account is too new to contribute');
+  }
+  if (REQUIRE_PAID_TIER && (!user.tier || user.tier === 'free')) {
+    return deny('A membership is required to contribute');
+  }
+}
+
+interface SharedContext {
+  userId: number | null;
+  subjectUser: SessionUser | null;
+  slug: string;
+  schema: string;
+  appBlockId: string;
+  blockInstanceId: string;
+}
+
+/**
+ * NEW resolver for the shared surface — does NOT reuse resolveStorageContext /
+ * assertViewerIsAppDeveloper (that gates to app-authors only; copying it would
+ * FORBID all general users). Asserts, per op:
+ *   1. valid block token → approved AppBlock (isolation via sanitizeAppSlug)
+ *   2. the shared read/write scope is present on claims.scopes
+ *   3. the dedicated fail-closed Flipt flag (kill-switch) is on
+ *   4. for WRITE ops: authenticated subject + the min-trust gate
+ * Anon may READ list/counts; anon NEVER writes/votes.
+ */
+async function resolveSharedContext(blockToken: string, op: SharedOp): Promise<SharedContext> {
+  const claims = await verifyBlockToken(blockToken);
+  if (!claims) throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid block token' });
+
+  const slug = sanitizeAppSlug(claims.blockId);
+  if (!slug) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'block id is not a valid storage slug',
+    });
+  }
+
+  const block = await dbRead.appBlock.findUnique({
+    where: { appId_blockId: { appId: claims.appId, blockId: claims.blockId } },
+    select: { id: true, status: true },
+  });
+  if (!block) throw new TRPCError({ code: 'NOT_FOUND', message: 'app block not found' });
+  if (block.status !== 'approved') {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'app block is not approved' });
+  }
+
+  // Per-op scope assertion (re-checks the issuance contract at point of use).
+  const requiredScope = READ_OPS.has(op) ? SHARED_READ_SCOPE : SHARED_WRITE_SCOPE;
+  if (!Array.isArray(claims.scopes) || !claims.scopes.includes(requiredScope)) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: `shared storage ${op} requires the ${requiredScope} scope`,
+    });
+  }
+
+  const userId = parseSubjectUserId(claims.sub);
+  // Hydrate the TOKEN SUBJECT (block-token path has no ctx.user) — needed for both
+  // the flag segment eval and the trust gate. Fail-closed on a vanished subject.
+  const subjectUser =
+    userId != null
+      ? ((await sessionClient.getSessionUserById(userId)) as SessionUser | null)
+      : null;
+
+  // Dedicated fail-closed kill-switch (evaluated with the subject's context so the
+  // flag's mod/cohort segments resolve identically to the client gate; anon read →
+  // global eval → fail-closed until a base-enabled GA flip).
+  if (!(await isAppBlocksSharedStorageEnabled({ user: subjectUser ?? undefined }))) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'shared storage is not enabled' });
+  }
+
+  if (!READ_OPS.has(op)) {
+    // WRITE — anon never writes; authenticated subject must pass the trust gate.
+    if (userId == null) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'shared storage writes require an authenticated viewer',
+      });
+    }
+    assertSharedWriteTrust(subjectUser);
+  }
+
+  return {
+    userId,
+    subjectUser,
+    slug,
+    schema: appSchemaIdent(slug),
+    appBlockId: block.id,
+    blockInstanceId: claims.blockInstanceId,
+  };
+}
+
+// Postgres literal quoting for the SET LOCAL GUC (no $1 form). appBlockId is the
+// server-issued `apb_<ulid>` PK from the AppBlock lookup — never client input.
+function pgQuoteLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+const blockTokenInput = z.object({ blockToken: z.string().min(1) });
+const sharedKeyInput = z.string().min(1).max(64);
+
+// Structured, moderatable append payload (design M3: title ≤200, body ≤ few KB).
+const appendValueInput = z.object({
+  title: z.string().min(1).max(SHARED_TITLE_MAX),
+  body: z.string().max(SHARED_BODY_MAX).optional(),
+});
+
+export const appsSharedRouter = router({
+  /**
+   * Cursor-paginated list of shared_kv rows (the "requests" feed). shared_kv +
+   * counter aggregate ONLY — NEVER the per-user kv, NEVER the raw vote rows.
+   * Hidden rows are excluded. Anon may read. Keyset cursor on the ULID key
+   * (newest-first, DESC).
+   */
+  list: publicProcedure
+    .input(
+      blockTokenInput.extend({
+        prefix: z.string().max(64).optional(),
+        limit: z.number().int().min(1).max(100).default(50),
+        cursor: z.string().max(200).optional(),
+      })
+    )
+    .query(async ({ input }) => {
+      const { schema } = await resolveSharedContext(input.blockToken, 'list');
+      const pool = requireAppsDb();
+
+      const afterKey = input.cursor
+        ? Buffer.from(input.cursor, 'base64').toString('utf8')
+        : null;
+      const escapedPrefix = (input.prefix ?? '').replace(/([\\%_])/g, '\\$1');
+      const prefixPattern = `${escapedPrefix}%`;
+
+      const rows = (
+        await pool.query<{
+          key: string;
+          author_user_id: number;
+          value: unknown;
+          count: string;
+          created_at: Date;
+          updated_at: Date;
+        }>(
+          `SELECT s.key, s.author_user_id, s.value, COALESCE(c.count, 0)::text AS count,
+                  s.created_at, s.updated_at
+             FROM ${schema}.shared_kv s
+             LEFT JOIN ${schema}.counters c ON c.key = s.key
+            WHERE s.hidden_at IS NULL
+              AND s.key LIKE $1 ESCAPE '\\'
+              AND ($2::text IS NULL OR s.key < $2)
+            ORDER BY s.key DESC
+            LIMIT $3`,
+          [prefixPattern, afterKey, input.limit]
+        )
+      ).rows;
+
+      const nextCursor =
+        rows.length === input.limit
+          ? Buffer.from(rows[rows.length - 1].key, 'utf8').toString('base64')
+          : undefined;
+
+      return {
+        items: rows.map((r) => ({
+          key: r.key,
+          authorUserId: r.author_user_id,
+          value: r.value,
+          count: Number(r.count),
+          createdAt: r.created_at,
+          updatedAt: r.updated_at,
+        })),
+        nextCursor,
+      };
+    }),
+
+  /**
+   * Aggregate vote count for a single key. counters only (never the vote rows).
+   * Returns 0 for a missing/hidden key.
+   */
+  getCount: publicProcedure
+    .input(blockTokenInput.extend({ key: sharedKeyInput }))
+    .query(async ({ input }) => {
+      const { schema } = await resolveSharedContext(input.blockToken, 'getCount');
+      const pool = requireAppsDb();
+      const rows = (
+        await pool.query<{ count: string }>(
+          `SELECT COALESCE(c.count, 0)::text AS count
+             FROM ${schema}.shared_kv s
+             LEFT JOIN ${schema}.counters c ON c.key = s.key
+            WHERE s.key = $1 AND s.hidden_at IS NULL`,
+          [input.key]
+        )
+      ).rows;
+      return { count: Number(rows[0]?.count ?? '0') };
+    }),
+
+  /**
+   * Batch aggregate counts. counters only. Unknown/hidden keys resolve to 0.
+   */
+  getCounts: publicProcedure
+    .input(blockTokenInput.extend({ keys: z.array(sharedKeyInput).min(1).max(100) }))
+    .query(async ({ input }) => {
+      const { schema } = await resolveSharedContext(input.blockToken, 'getCount');
+      const pool = requireAppsDb();
+      const rows = (
+        await pool.query<{ key: string; count: string }>(
+          `SELECT s.key, COALESCE(c.count, 0)::text AS count
+             FROM ${schema}.shared_kv s
+             LEFT JOIN ${schema}.counters c ON c.key = s.key
+            WHERE s.key = ANY($1) AND s.hidden_at IS NULL`,
+          [input.keys]
+        )
+      ).rows;
+      const counts: Record<string, number> = {};
+      for (const k of input.keys) counts[k] = 0;
+      for (const r of rows) counts[r.key] = Number(r.count);
+      return { counts };
+    }),
+
+  /**
+   * Create a shared row (a "request"). The server GENERATES a ULID key (C1: never
+   * accept a client key on create → user B can't overwrite user A's row).
+   * INSERT-only; author = the token subject. Runs the BLOCKING content-safety belt
+   * (C2/C3/M1) synchronously, the per-user + per-app row caps + byte quota, and the
+   * per-(user,app) daily rate limit — all before the row lands.
+   */
+  append: publicProcedure
+    .input(blockTokenInput.extend({ value: appendValueInput }))
+    .mutation(async ({ input }) => {
+      const { userId, subjectUser, schema, appBlockId } = await resolveSharedContext(
+        input.blockToken,
+        'append'
+      );
+      // userId is non-null (trust gate ran in the resolver).
+      const uid = userId as number;
+
+      // Rate limit FIRST — bounds a flood AND the external-moderation cost the
+      // safety belt would otherwise incur per attempt.
+      const rl = await checkSharedAppendRateLimit(uid, appBlockId);
+      if (!rl.allowed) {
+        throw new TRPCError({
+          code: 'TOO_MANY_REQUESTS',
+          message: `Too many submissions — retry in ${rl.retryAfterSeconds}s`,
+        });
+      }
+
+      // BLOCKING content safety → HTML-escaped, store-ready text.
+      let safe: { title: string; body?: string };
+      try {
+        safe = await assertSharedTextSafe({
+          title: input.value.title,
+          body: input.value.body,
+          userId: uid,
+          isModerator: subjectUser?.isModerator,
+        });
+      } catch (e) {
+        if (e instanceof SharedContentBlockedError) {
+          // C3/M5: minor/POI/audit hits file a Report row for mod review. (link/size
+          // are user error, not reportable abuse.)
+          if (e.category === 'minor' || e.category === 'poi' || e.category === 'audit') {
+            await insertSharedReport(schema, {
+              key: null,
+              reporterUserId: uid,
+              reason: `auto:${e.category}`,
+            }).catch(() => {});
+          }
+          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
+        }
+        throw e;
+      }
+
+      const storedValue = { title: safe.title, ...(safe.body != null ? { body: safe.body } : {}) };
+      const serialized = JSON.stringify(storedValue);
+      const byteSize = Buffer.byteLength(serialized, 'utf8');
+      if (byteSize > SHARED_VALUE_BYTE_CAP) {
+        throw new TRPCError({ code: 'PAYLOAD_TOO_LARGE', message: 'value exceeds size cap' });
+      }
+
+      const pool = requireAppsDb();
+
+      // Per-USER row cap (design M2).
+      const userRowCount = Number(
+        (
+          await pool.query<{ n: string }>(
+            `SELECT count(*)::text AS n FROM ${schema}.shared_kv WHERE author_user_id = $1`,
+            [uid]
+          )
+        ).rows[0]?.n ?? '0'
+      );
+      if (userRowCount + 1 > SHARED_KV_PER_USER_ROW_CAP) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'you have reached the maximum number of submissions for this app',
+        });
+      }
+
+      // Per-app byte + row quota (shared with the per-user kv path).
+      const quota = (
+        await pool.query<{ used_bytes: string; row_count: string }>(
+          `SELECT used_bytes::text, row_count::text FROM ${schema}.quota WHERE app_block_id = $1`,
+          [appBlockId]
+        )
+      ).rows[0];
+      const usedBytes = Number(quota?.used_bytes ?? '0');
+      const rowCount = Number(quota?.row_count ?? '0');
+      if (usedBytes + byteSize > APP_QUOTA_BYTES) {
+        throw new TRPCError({ code: 'PAYLOAD_TOO_LARGE', message: 'app quota exceeded' });
+      }
+      if (rowCount + 1 > APP_ROW_LIMIT) {
+        throw new TRPCError({ code: 'PAYLOAD_TOO_LARGE', message: 'app row limit exceeded' });
+      }
+
+      const key = newUlid();
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        // GUC drives the shared_kv quota trigger (byte/row accounting).
+        await client.query(`SET LOCAL app.current_app_block_id = ${pgQuoteLiteral(appBlockId)}`);
+        await client.query(
+          `INSERT INTO ${schema}.shared_kv (key, author_user_id, value)
+           VALUES ($1, $2, $3::jsonb)`,
+          [key, uid, serialized]
+        );
+        // Seed the counter cache (votes are the source of truth).
+        await client.query(
+          `INSERT INTO ${schema}.counters (key, count) VALUES ($1, 0)
+           ON CONFLICT (key) DO NOTHING`,
+          [key]
+        );
+        await client.query('COMMIT');
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {});
+        throw err;
+      } finally {
+        client.release();
+      }
+
+      return { key };
+    }),
+
+  /**
+   * Up-vote a request. FK-checked (H2: a vote on a non-existent request rejects
+   * NOT_FOUND) + visibility-checked (hidden rows can't be voted). The counter
+   * increment is ATOMICALLY gated on the vote row actually inserting (H1: a double
+   * vote is a no-op, the counter never inflates). Rate-limited per (user, app).
+   */
+  vote: publicProcedure
+    .input(blockTokenInput.extend({ key: sharedKeyInput }))
+    .mutation(async ({ input }) => {
+      const { userId, schema, appBlockId } = await resolveSharedContext(input.blockToken, 'vote');
+      const uid = userId as number;
+
+      const rl = await checkSharedVoteRateLimit(uid, appBlockId);
+      if (!rl.allowed) {
+        throw new TRPCError({
+          code: 'TOO_MANY_REQUESTS',
+          message: `Too many votes — retry in ${rl.retryAfterSeconds}s`,
+        });
+      }
+
+      const pool = requireAppsDb();
+      // Visibility/existence pre-check → NOT_FOUND for hidden OR missing (H2). The
+      // FK on votes.key is the belt for a race between this and the insert.
+      const exists = (
+        await pool.query(
+          `SELECT 1 FROM ${schema}.shared_kv WHERE key = $1 AND hidden_at IS NULL`,
+          [input.key]
+        )
+      ).rowCount;
+      if (!exists) throw new TRPCError({ code: 'NOT_FOUND', message: 'request not found' });
+
+      try {
+        // Atomic insert-gated counter (design H1). EXCLUDED.count = |ins| ∈ {0,1}.
+        const rows = (
+          await pool.query<{ count: string }>(
+            `WITH ins AS (
+               INSERT INTO ${schema}.votes (key, user_id) VALUES ($1, $2)
+               ON CONFLICT (key, user_id) DO NOTHING
+               RETURNING 1
+             )
+             INSERT INTO ${schema}.counters AS c (key, count)
+             VALUES ($1, (SELECT count(*) FROM ins))
+             ON CONFLICT (key) DO UPDATE
+               SET count = c.count + EXCLUDED.count
+             RETURNING c.count::text AS count`,
+            [input.key, uid]
+          )
+        ).rows;
+        return { count: Number(rows[0]?.count ?? '0') };
+      } catch (err) {
+        // FK violation (key vanished mid-op) → NOT_FOUND (H2).
+        if (isForeignKeyViolation(err)) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'request not found' });
+        }
+        throw err;
+      }
+    }),
+
+  /**
+   * Withdraw an up-vote. Symmetric to vote: the counter decrements by exactly the
+   * number of vote rows deleted (0 or 1); the `CHECK(count >= 0)` constraint blocks
+   * any underflow (H1). Rate-limited on the same per (user, app) vote bucket.
+   */
+  unvote: publicProcedure
+    .input(blockTokenInput.extend({ key: sharedKeyInput }))
+    .mutation(async ({ input }) => {
+      const { userId, schema, appBlockId } = await resolveSharedContext(input.blockToken, 'unvote');
+      const uid = userId as number;
+
+      const rl = await checkSharedVoteRateLimit(uid, appBlockId);
+      if (!rl.allowed) {
+        throw new TRPCError({
+          code: 'TOO_MANY_REQUESTS',
+          message: `Too many votes — retry in ${rl.retryAfterSeconds}s`,
+        });
+      }
+
+      const pool = requireAppsDb();
+      const rows = (
+        await pool.query<{ count: string }>(
+          `WITH del AS (
+             DELETE FROM ${schema}.votes WHERE key = $1 AND user_id = $2 RETURNING 1
+           )
+           UPDATE ${schema}.counters
+              SET count = count - (SELECT count(*) FROM del)
+            WHERE key = $1
+           RETURNING count::text AS count`,
+          [input.key, uid]
+        )
+      ).rows;
+      return { count: Number(rows[0]?.count ?? '0') };
+    }),
+
+  /**
+   * Author withdraws their OWN request (design LOCKED #4). Deletes the shared_kv
+   * row ONLY when author_user_id = subject; the FK cascade drops its votes +
+   * counter. SET LOCAL GUC so the quota trigger reclaims the bytes/row.
+   */
+  withdraw: publicProcedure
+    .input(blockTokenInput.extend({ key: sharedKeyInput }))
+    .mutation(async ({ input }) => {
+      const { userId, schema, appBlockId } = await resolveSharedContext(
+        input.blockToken,
+        'withdraw'
+      );
+      const uid = userId as number;
+      const pool = requireAppsDb();
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+        await client.query(`SET LOCAL app.current_app_block_id = ${pgQuoteLiteral(appBlockId)}`);
+        const result = await client.query(
+          `DELETE FROM ${schema}.shared_kv WHERE key = $1 AND author_user_id = $2`,
+          [input.key, uid]
+        );
+        await client.query('COMMIT');
+        return { ok: true as const, deleted: (result.rowCount ?? 0) > 0 };
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {});
+        throw err;
+      } finally {
+        client.release();
+      }
+    }),
+
+  /**
+   * User report (design M5). Files a shared_kv_reports row for mod review. Requires
+   * the write scope + trust gate (only eligible users can report, to bound report
+   * spam). Does not hide the row — a moderator decides via `apps.mod.purgeSharedRow`.
+   */
+  report: publicProcedure
+    .input(
+      blockTokenInput.extend({ key: sharedKeyInput, reason: z.string().max(500).optional() })
+    )
+    .mutation(async ({ input }) => {
+      const { userId, schema } = await resolveSharedContext(input.blockToken, 'report');
+      const uid = userId as number;
+      const pool = requireAppsDb();
+      const exists = (
+        await pool.query(`SELECT 1 FROM ${schema}.shared_kv WHERE key = $1`, [input.key])
+      ).rowCount;
+      if (!exists) throw new TRPCError({ code: 'NOT_FOUND', message: 'request not found' });
+      await insertSharedReport(schema, {
+        key: input.key,
+        reporterUserId: uid,
+        reason: input.reason ?? 'user-report',
+      });
+      return { ok: true as const };
+    }),
+});
+
+/**
+ * Cross-app moderator surface (design M4). SESSION-authed (moderatorProcedure) —
+ * NOT reachable by a block token. Hides OR hard-deletes any (appBlockId, key)
+ * shared row across ANY app, cascades its votes/counter (hard-delete), and files a
+ * Report row. The app slug is derived server-side from the AppBlock row, never
+ * from client input.
+ */
+export const appsModRouter = router({
+  purgeSharedRow: moderatorProcedure
+    .input(
+      z.object({
+        appBlockId: z.string().min(1).max(64),
+        key: sharedKeyInput,
+        action: z.enum(['hide', 'delete']),
+        reason: z.string().max(500).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const block = await dbRead.appBlock.findUnique({
+        where: { id: input.appBlockId },
+        select: { id: true, blockId: true },
+      });
+      if (!block) throw new TRPCError({ code: 'NOT_FOUND', message: 'app block not found' });
+      const slug = sanitizeAppSlug(block.blockId);
+      if (!slug) {
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'invalid app slug' });
+      }
+      const schema = appSchemaIdent(slug);
+      const pool = requireAppsDb();
+
+      let affected = 0;
+      if (input.action === 'hide') {
+        const result = await pool.query(
+          `UPDATE ${schema}.shared_kv
+              SET hidden_at = now(), hidden_by = $2
+            WHERE key = $1 AND hidden_at IS NULL`,
+          [input.key, ctx.user.id]
+        );
+        affected = result.rowCount ?? 0;
+      } else {
+        const client = await pool.connect();
+        try {
+          await client.query('BEGIN');
+          await client.query(
+            `SET LOCAL app.current_app_block_id = ${pgQuoteLiteral(input.appBlockId)}`
+          );
+          const result = await client.query(`DELETE FROM ${schema}.shared_kv WHERE key = $1`, [
+            input.key,
+          ]);
+          await client.query('COMMIT');
+          affected = result.rowCount ?? 0;
+        } catch (err) {
+          await client.query('ROLLBACK').catch(() => {});
+          throw err;
+        } finally {
+          client.release();
+        }
+      }
+
+      // File the Report row (kept even after a hard delete — key is not FK'd here).
+      await insertSharedReport(schema, {
+        key: input.key,
+        reporterUserId: ctx.user.id,
+        reason: `mod:${input.action}${input.reason ? `:${input.reason}` : ''}`,
+      }).catch(() => {});
+
+      return { ok: true as const, action: input.action, affected };
+    }),
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+async function insertSharedReport(
+  schema: string,
+  args: { key: string | null; reporterUserId: number | null; reason: string }
+): Promise<void> {
+  const pool = requireAppsDb();
+  await pool.query(
+    `INSERT INTO ${schema}.shared_kv_reports (id, key, reporter_user_id, reason)
+     VALUES ($1, $2, $3, $4)`,
+    [`skr_${newUlid()}`, args.key, args.reporterUserId, args.reason]
+  );
+}
+
+function isForeignKeyViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err != null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === '23503'
+  );
+}

--- a/src/server/routers/apps-shared.router.ts
+++ b/src/server/routers/apps-shared.router.ts
@@ -160,7 +160,14 @@ async function resolveSharedContext(blockToken: string, op: SharedOp): Promise<S
     });
   }
 
-  const userId = parseSubjectUserId(claims.sub);
+  // parseSubjectUserId throws a plain ForbiddenError on a malformed `sub`; surface
+  // it as a clean FORBIDDEN (not an uncaught 500). Fail-closed either way. (audit 🟢-4)
+  let userId: number | null;
+  try {
+    userId = parseSubjectUserId(claims.sub);
+  } catch {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'invalid token subject' });
+  }
   // Hydrate the TOKEN SUBJECT (block-token path has no ctx.user) — needed for both
   // the flag segment eval and the trust gate. Fail-closed on a vanished subject.
   const subjectUser =

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -28,6 +28,7 @@ import { logToAxiom } from '~/server/logging/client';
 import { requireAppsDb } from '~/server/db/appsDb';
 import { appSchemaIdent, sanitizeAppSlug } from '~/server/utils/apps-slug';
 import { middleware, publicProcedure, router } from '~/server/trpc';
+import { appsSharedRouter, appsModRouter } from '~/server/routers/apps-shared.router';
 
 /**
  * App Blocks authoring gate: storage procedures are `publicProcedure` +
@@ -522,6 +523,14 @@ export const appsStorageRouter = router({
 
 export const appsRouter = router({
   storage: appsStorageRouter,
+  // SHARED (app-global / cross-user) storage — the public-write surface (voting +
+  // community lists). Block-token authed with its OWN resolver (resolveSharedContext:
+  // trust gate, NOT the app-author gate) + dedicated fail-closed flag. See
+  // apps-shared.router.ts.
+  shared: appsSharedRouter,
+  // Cross-app moderator surface for shared storage (session moderatorProcedure —
+  // NOT block-token reachable). Purge/hide any shared row + file a report.
+  mod: appsModRouter,
 });
 
 // Postgres literal quoting — used ONLY for the regex-validated appBlockId

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -531,3 +531,36 @@ export async function isAppBlocksReviewSandboxEnabled(opts?: {
   const user = opts.user;
   return isFlipt(APP_BLOCKS_REVIEW_SANDBOX_FLAG, String(user.id), buildFliptContext(user));
 }
+
+/**
+ * Dedicated fail-closed flag for App Blocks SHARED (app-global / cross-user)
+ * storage — the FIRST surface that opens the per-app datastore to PUBLIC
+ * cross-user writes (previously mod + app-dev-tester only). Mirrors
+ * `app-blocks-dev-tunnel`: a brand-new surface with NO existing access to
+ * preserve, so there is deliberately NO moderator static floor — an absent flag
+ * resolves `false` for EVERYONE (mods included). This is the cluster-wide
+ * kill-switch: flip it off and every shared read/write/vote refuses immediately
+ * (the `resolveSharedContext` gate), independent of the block-runtime rollout.
+ *
+ * Evaluated WITH the caller's context (entityId = user id, context carries
+ * server-side `isModerator`) so the `moderators` / community segments can match.
+ * On the block-token path the "caller" is the HYDRATED TOKEN SUBJECT
+ * (`getSessionUserById`), not a session — anon reads pass no user → global eval
+ * that can never match a segment → fail-closed (anon shared access is a GA-only
+ * widening, safe to stay dark until a base-`enabled` flip).
+ *
+ * Create it in Flipt as base `enabled: false` with the `moderators` segment (+
+ * any community-cohort segment) exactly like `app-blocks-dev-tunnel`. The flag
+ * does NOT exist in Flipt at merge time — the companion `flipt-state` entry is a
+ * SEPARATE follow-up PR — so the as-merged posture is fully dark and cannot
+ * regress the gate open.
+ */
+export const APP_BLOCKS_SHARED_STORAGE_FLAG = 'app-blocks-shared-storage';
+
+export async function isAppBlocksSharedStorageEnabled(opts?: {
+  user?: SessionUser;
+}): Promise<boolean> {
+  if (!opts?.user) return isFlipt(APP_BLOCKS_SHARED_STORAGE_FLAG);
+  const user = opts.user;
+  return isFlipt(APP_BLOCKS_SHARED_STORAGE_FLAG, String(user.id), buildFliptContext(user));
+}

--- a/src/server/services/apps/__tests__/storage-provision.service.test.ts
+++ b/src/server/services/apps/__tests__/storage-provision.service.test.ts
@@ -80,6 +80,32 @@ describe('AppStorageProvisioner.provision', () => {
     expect(joined).toContain('CREATE TRIGGER kv_quota_trg');
   });
 
+  it('provisions the SHARED storage tables + trigger (shared_kv/votes/counters/reports)', async () => {
+    await AppStorageProvisioner.provision({
+      appBlockId: 'apb_test',
+      slug: 'generate_from_model',
+    });
+    const joined = capturedQueries.map((q) => q.sql).join('\n');
+    const S = '"app_generate_from_model"';
+    // shared_kv: server-key PK, author, generated size_bytes, hidden columns.
+    expect(joined).toContain(`CREATE TABLE IF NOT EXISTS ${S}.shared_kv`);
+    expect(joined).toContain('key text PRIMARY KEY');
+    expect(joined).toContain('author_user_id integer NOT NULL');
+    expect(joined).toContain('hidden_at timestamptz');
+    // votes: composite PK (one-vote-per-user) + FK cascade.
+    expect(joined).toContain(`CREATE TABLE IF NOT EXISTS ${S}.votes`);
+    expect(joined).toContain(`REFERENCES ${S}.shared_kv(key) ON DELETE CASCADE`);
+    expect(joined).toContain('PRIMARY KEY (key, user_id)');
+    // counters: CHECK(count>=0) blocks underflow (H1) + FK cascade.
+    expect(joined).toContain(`CREATE TABLE IF NOT EXISTS ${S}.counters`);
+    expect(joined).toContain('CHECK (count >= 0)');
+    // reports table (M4/M5).
+    expect(joined).toContain(`CREATE TABLE IF NOT EXISTS ${S}.shared_kv_reports`);
+    // shared_kv reuses the quota trigger fn → shared bytes/rows fold into the quota.
+    expect(joined).toContain('CREATE TRIGGER shared_kv_quota_trg');
+    expect(joined).toContain(`EXECUTE FUNCTION ${S}.kv_quota_trigger()`);
+  });
+
   it('seeds the quota row with the provided appBlockId via a parameterized insert', async () => {
     await AppStorageProvisioner.provision({
       appBlockId: 'apb_seed_value',

--- a/src/server/services/apps/migrations/20260708120000_app_blocks_shared_storage.sql
+++ b/src/server/services/apps/migrations/20260708120000_app_blocks_shared_storage.sql
@@ -1,0 +1,99 @@
+-- App Blocks SHARED (app-global / cross-user) storage — manual-apply migration.
+--
+-- TARGET DATABASE: the App Blocks datastore  (appsDb / cnpg-cluster-apps), NOT
+--   the main civitai CNPG nvme0 DB. This DB holds the per-app `app_<slug>`
+--   schemas provisioned by AppStorageProvisioner. Apply to:
+--     - prod  appsDb  (cnpg-cluster-apps)
+--     - the writable weekly dev clone of appsDb (if one exists for this DB)
+--   Per datapacket-talos rule #8: this is written for history + is applied
+--   MANUALLY by a human (psql), never auto-run by CI/deploy.
+--
+-- WHAT IT DOES: idempotent BACKFILL of the shared_kv / votes / counters /
+--   shared_kv_reports tables + the shared_kv quota trigger + role grants onto
+--   EVERY already-provisioned `app_<slug>` schema. NEW apps get these tables
+--   automatically the next time AppStorageProvisioner.provision() runs (webhook
+--   on approved version push, or the P7 backfill job) — this script covers apps
+--   provisioned BEFORE the code shipped so they don't wait for a re-provision.
+--
+-- IDEMPOTENT: every statement is IF NOT EXISTS / OR REPLACE, safe to re-run.
+--
+-- The DDL below MUST stay byte-equivalent to the shared-table DDL in
+--   src/server/services/apps/storage-provision.service.ts — that service is the
+--   source of truth for new apps; this script only backfills existing ones.
+
+DO $migrate$
+DECLARE
+  r record;
+  s text;      -- quoted schema ident, e.g. "app_myslug"
+  role_ident text;
+BEGIN
+  FOR r IN
+    SELECT schema_name
+      FROM information_schema.schemata
+     WHERE schema_name LIKE 'app\_%'
+       -- only schemas that already have the per-user kv table (a real app schema)
+       AND EXISTS (
+         SELECT 1 FROM information_schema.tables t
+          WHERE t.table_schema = schemata.schema_name AND t.table_name = 'kv'
+       )
+  LOOP
+    s := quote_ident(r.schema_name);
+    role_ident := quote_ident(r.schema_name || '_role');
+
+    EXECUTE format($ddl$
+      CREATE TABLE IF NOT EXISTS %s.shared_kv (
+        key text PRIMARY KEY,
+        author_user_id integer NOT NULL,
+        value jsonb NOT NULL,
+        size_bytes integer GENERATED ALWAYS AS (octet_length(value::text)) STORED,
+        hidden_at timestamptz,
+        hidden_by integer,
+        created_at timestamptz DEFAULT now() NOT NULL,
+        updated_at timestamptz DEFAULT now() NOT NULL
+      )$ddl$, s);
+
+    EXECUTE format(
+      'CREATE INDEX IF NOT EXISTS shared_kv_author_idx ON %s.shared_kv (author_user_id)', s);
+    EXECUTE format(
+      'CREATE INDEX IF NOT EXISTS shared_kv_created_idx ON %s.shared_kv (created_at)', s);
+
+    EXECUTE format($ddl$
+      CREATE TABLE IF NOT EXISTS %s.votes (
+        key text NOT NULL REFERENCES %s.shared_kv(key) ON DELETE CASCADE,
+        user_id integer NOT NULL,
+        created_at timestamptz DEFAULT now() NOT NULL,
+        PRIMARY KEY (key, user_id)
+      )$ddl$, s, s);
+
+    EXECUTE format($ddl$
+      CREATE TABLE IF NOT EXISTS %s.counters (
+        key text PRIMARY KEY REFERENCES %s.shared_kv(key) ON DELETE CASCADE,
+        count bigint NOT NULL DEFAULT 0 CHECK (count >= 0)
+      )$ddl$, s, s);
+
+    EXECUTE format($ddl$
+      CREATE TABLE IF NOT EXISTS %s.shared_kv_reports (
+        id text PRIMARY KEY,
+        key text,
+        reporter_user_id integer,
+        reason text,
+        created_at timestamptz DEFAULT now() NOT NULL
+      )$ddl$, s);
+
+    -- Reuse the existing per-schema kv_quota_trigger() on shared_kv so shared
+    -- bytes/rows fold into the same app quota row (created with the schema).
+    EXECUTE format('DROP TRIGGER IF EXISTS shared_kv_quota_trg ON %s.shared_kv', s);
+    EXECUTE format($ddl$
+      CREATE TRIGGER shared_kv_quota_trg
+      AFTER INSERT OR UPDATE OR DELETE ON %s.shared_kv
+      FOR EACH ROW EXECUTE FUNCTION %s.kv_quota_trigger()$ddl$, s, s);
+
+    -- Re-grant on the new tables to the per-app NOLOGIN role (ALTER DEFAULT
+    -- PRIVILEGES already covers future tables, but a re-grant is safe + covers
+    -- schemas whose defaults predate the shared tables).
+    EXECUTE format(
+      'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA %s TO %s',
+      s, role_ident);
+  END LOOP;
+END
+$migrate$;

--- a/src/server/services/apps/shared-content-safety.ts
+++ b/src/server/services/apps/shared-content-safety.ts
@@ -1,0 +1,132 @@
+import { includesMinor, includesPoi } from '~/utils/metadata/audit';
+import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
+import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
+
+/**
+ * BLOCKING content-safety belt for App Blocks SHARED storage writes (hardened
+ * design C2 / C3 / M1 / M3).
+ *
+ * Shared rows are cross-user PUBLIC user-generated text rendered in OTHER users'
+ * browsers + host-side surfaces (mod queue, activity feed, notifications). This is
+ * the entire new abuse surface, so every `append` runs this SYNCHRONOUSLY before a
+ * row can land:
+ *   - C2 (stored XSS): shared text is PLAIN TEXT. We HTML-escape on write (store
+ *     escaped) so a stored `<script>` can never execute even if a
+ *     featured/verified app is later granted `allow-same-origin`. The block still
+ *     treats it as untrusted on read; escape-at-rest is the belt.
+ *   - C3 (illegal content): `includesMinor` / `includesPoi` are a HARD legal fail
+ *     (minor/POI/CSAM signals) — reject + the caller files a Report. Then
+ *     `auditPromptServer` runs the full platform audit (regex + external
+ *     moderation) and routes repeat abuse into the EXISTING auto-mute machinery,
+ *     closing the loop with the trust gate.
+ *   - M1 (link abuse): `throwOnBlockedLinkDomain` rejects blocked link domains; no
+ *     server-side unfurl is ever performed.
+ *   - M3 (size): tight caps (title ≤ 200 chars, body ≤ a few KB) — enforced by the
+ *     router's zod schema AND re-asserted here as defence-in-depth.
+ *
+ * FORCED-SFW: shared community text is audited with `isGreen: true` (the stricter
+ * SFW + profanity ceiling), mirroring the dev-tunnel forced-SFW posture — a
+ * community app must not become an NSFW-text channel.
+ */
+
+// M3 — tight caps. Also enforced by the router zod schema; duplicated here so a
+// future caller can't skip the schema and bypass the ceiling.
+export const SHARED_TITLE_MAX = 200;
+export const SHARED_BODY_MAX = 4096;
+
+export type SharedBlockedCategory = 'minor' | 'poi' | 'link' | 'audit' | 'size';
+
+/**
+ * Thrown by `assertSharedTextSafe` when the text is rejected. Carries the
+ * `category` so the caller can decide whether to file a Report (minor/poi/audit)
+ * before converting to a user-facing TRPCError. NEVER leak the raw matched word to
+ * the client beyond the audit machinery's own message.
+ */
+export class SharedContentBlockedError extends Error {
+  readonly category: SharedBlockedCategory;
+  constructor(category: SharedBlockedCategory, message: string) {
+    super(message);
+    this.name = 'SharedContentBlockedError';
+    this.category = category;
+  }
+}
+
+/**
+ * HTML-escape a plain-text field for storage-at-rest (C2). We STORE the escaped
+ * form so the value is inert on every render path. `&` first so we don't
+ * double-escape the entities we introduce.
+ */
+export function escapeSharedText(input: string): string {
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#x27;');
+}
+
+export interface SharedTextSafetyInput {
+  title: string;
+  body?: string;
+  /** Token subject — the abuse principal for auto-mute accounting. */
+  userId: number;
+  /** From the hydrated subject; moderators skip the auto-mute side effect. */
+  isModerator?: boolean;
+}
+
+/**
+ * Runs the full BLOCKING safety belt on shared write text. Throws
+ * `SharedContentBlockedError` on any block. Returns the HTML-escaped, store-ready
+ * `{ title, body }` on success.
+ */
+export async function assertSharedTextSafe(
+  input: SharedTextSafetyInput
+): Promise<{ title: string; body?: string }> {
+  const { title, body, userId, isModerator } = input;
+
+  // M3 — belt re-check (the schema is the primary gate).
+  if (title.length > SHARED_TITLE_MAX) {
+    throw new SharedContentBlockedError('size', 'Title exceeds the maximum length');
+  }
+  if (body != null && body.length > SHARED_BODY_MAX) {
+    throw new SharedContentBlockedError('size', 'Body exceeds the maximum length');
+  }
+
+  const combined = body ? `${title}\n${body}` : title;
+
+  // C3 — HARD legal fail FIRST. These signals (minor age / POI / CSAM composites)
+  // must reject + Report regardless of the account's mute state. Kept ahead of the
+  // general audit so a minor/POI hit is unambiguously classified for the caller's
+  // Report filing.
+  if (includesMinor(combined)) {
+    throw new SharedContentBlockedError('minor', 'Content flagged for review');
+  }
+  if (includesPoi(combined)) {
+    throw new SharedContentBlockedError('poi', 'Content flagged for review');
+  }
+
+  // M1 — blocked link domains. `throwOnBlockedLinkDomain` throws a plain Error.
+  try {
+    await throwOnBlockedLinkDomain(combined);
+  } catch {
+    throw new SharedContentBlockedError('link', 'Content contains a blocked link');
+  }
+
+  // C3 — full platform audit (regex + external moderation) + the EXISTING
+  // auto-mute machinery (repeat blocked-prompt accounting → mute). isGreen:true
+  // forces the SFW + profanity ceiling for community text. `track` omitted (the
+  // block-token path has no request Tracker); auditPromptServer guards on it.
+  try {
+    await auditPromptServer({
+      prompt: combined,
+      userId,
+      isGreen: true,
+      isModerator,
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : 'Content was flagged';
+    throw new SharedContentBlockedError('audit', message);
+  }
+
+  return { title: escapeSharedText(title), body: body != null ? escapeSharedText(body) : undefined };
+}

--- a/src/server/services/apps/storage-provision.service.ts
+++ b/src/server/services/apps/storage-provision.service.ts
@@ -83,6 +83,72 @@ export const AppStorageProvisioner = {
         )
       `);
 
+      // ── SHARED (app-global / cross-user) storage tables ────────────────────
+      // The public-write surface (voting + community lists). Distinct from the
+      // per-user `kv` table above: rows are app-global, readable by all users of
+      // the app, written per the shared write policy (apps-shared.router).
+      //
+      // shared_kv.key is a SERVER-generated ULID (never a client key — C1: a
+      // client-chosen key would let user B overwrite user A's row). INSERT-only
+      // create; author_user_id is attribution + rate-limit + moderation.
+      // size_bytes mirrors `kv` so the SAME quota trigger folds shared bytes/rows
+      // into the app's 50MB / 1M budget. hidden_at/hidden_by back the mod soft-hide.
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${schema}.shared_kv (
+          key text PRIMARY KEY,
+          author_user_id integer NOT NULL,
+          value jsonb NOT NULL,
+          size_bytes integer GENERATED ALWAYS AS (octet_length(value::text)) STORED,
+          hidden_at timestamptz,
+          hidden_by integer,
+          created_at timestamptz DEFAULT now() NOT NULL,
+          updated_at timestamptz DEFAULT now() NOT NULL
+        )
+      `);
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS shared_kv_author_idx ON ${schema}.shared_kv (author_user_id)`
+      );
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS shared_kv_created_idx ON ${schema}.shared_kv (created_at)`
+      );
+
+      // votes — one row per (key, user). The UNIQUE (composite PK) guarantees
+      // one-vote-per-user (H1). FK ON DELETE CASCADE ties a vote's lifetime to its
+      // request so withdraw/purge reclaim cleanly. This table is NEVER listable —
+      // only the aggregate `count` is ever returned (design isolation invariant).
+      // votes carry NO size_bytes / NO quota trigger → excluded from the byte quota.
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${schema}.votes (
+          key text NOT NULL REFERENCES ${schema}.shared_kv(key) ON DELETE CASCADE,
+          user_id integer NOT NULL,
+          created_at timestamptz DEFAULT now() NOT NULL,
+          PRIMARY KEY (key, user_id)
+        )
+      `);
+
+      // counters — the monotonic vote-tally CACHE (votes are the source of truth,
+      // this is reconstructable). CHECK(count >= 0) blocks any unvote underflow
+      // (H1). FK ON DELETE CASCADE. Excluded from the byte quota.
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${schema}.counters (
+          key text PRIMARY KEY REFERENCES ${schema}.shared_kv(key) ON DELETE CASCADE,
+          count bigint NOT NULL DEFAULT 0 CHECK (count >= 0)
+        )
+      `);
+
+      // shared_kv_reports — user + moderator reports on a shared row (M4/M5). The
+      // `key` is intentionally NOT an FK: a report must survive a hard-delete/purge
+      // of the row it concerns (audit trail). Excluded from the byte quota.
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${schema}.shared_kv_reports (
+          id text PRIMARY KEY,
+          key text,
+          reporter_user_id integer,
+          reason text,
+          created_at timestamptz DEFAULT now() NOT NULL
+        )
+      `);
+
       // Trigger function — quota row is keyed on app_block_id pulled from
       // session-local `app.current_app_block_id`. tRPC procedures must
       // `SET LOCAL app.current_app_block_id = ...` in the same txn as the
@@ -127,6 +193,18 @@ export const AppStorageProvisioner = {
       await client.query(`
         CREATE TRIGGER kv_quota_trg
         AFTER INSERT OR UPDATE OR DELETE ON ${schema}.kv
+        FOR EACH ROW EXECUTE FUNCTION ${schema}.kv_quota_trigger()
+      `);
+
+      // Reuse the SAME quota-trigger function on shared_kv (it only touches
+      // ${schema}.quota + NEW/OLD.size_bytes + row_count — all present on
+      // shared_kv). Shared writes SET LOCAL app.current_app_block_id in-txn just
+      // like the per-user path, so shared bytes/rows fold into the same 50MB / 1M
+      // app budget. votes/counters/reports have no trigger → excluded from quota.
+      await client.query(`DROP TRIGGER IF EXISTS shared_kv_quota_trg ON ${schema}.shared_kv`);
+      await client.query(`
+        CREATE TRIGGER shared_kv_quota_trg
+        AFTER INSERT OR UPDATE OR DELETE ON ${schema}.shared_kv
         FOR EACH ROW EXECUTE FUNCTION ${schema}.kv_quota_trigger()
       `);
 

--- a/src/server/utils/shared-storage-rate-limit.ts
+++ b/src/server/utils/shared-storage-rate-limit.ts
@@ -1,0 +1,99 @@
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+
+/**
+ * Server-side fixed-window rate limits for App Blocks SHARED storage writes
+ * (`apps.shared.append` / `apps.shared.vote` / `apps.shared.unvote`).
+ *
+ * WHY (hardened design H4 — "weaponized users"): shared storage opens the app
+ * datastore to cross-user PUBLIC writes for the first time. A trusted-but-hostile
+ * (or compromised) account could flood requests or brigade votes. These caps are
+ * the second leg of the containment triad (trust-gate + rate-limit + mod-approval):
+ * they bound the write volume a SINGLE user can push through a SINGLE app,
+ * independent of the per-app quota (which bounds bytes, not per-user velocity).
+ *
+ * KEYING (design H4): keyed on `(user_id, appBlockId)` — NOT the block instance,
+ * NOT the token `jti`. The token subject (`user_id`) is the abuse principal, and
+ * `appBlockId` scopes the budget per app, so one user hammering app A does not eat
+ * their budget for app B, and churning fresh tokens can't reset the window (the
+ * subject is stable). Sub-namespaced under the shared blocks rate-limit key so
+ * these buckets never contend with the mint (`TOKEN_RATE_LIMIT:<subject>:...`) or
+ * catalog (`:catalog:`) buckets.
+ *
+ * PATTERN: the established blocks fixed-window limiter — INCR + EXPIRE on the
+ * `redis` cache client, byte-identical shape to `checkBlockCatalogRateLimit` and
+ * `BlockTokenService.checkRateLimit`. FAIL-OPEN on any redis error: a limiter-redis
+ * incident must never break legitimate writes (the trust-gate + content-moderation
+ * + mod-approval remain as the durable controls). We NEVER fail-closed here because
+ * the abuse ceiling is a defence-in-depth layer, not the authorization boundary.
+ */
+
+// APPEND: N requests/day/app/user. A real community member files a handful of
+// requests a day at most; 20 bounds a flood without touching normal use. Window
+// is a rolling 24h fixed bucket (resets on first hit + TTL).
+export const SHARED_APPEND_RATE_LIMIT_MAX = 20;
+export const SHARED_APPEND_RATE_LIMIT_WINDOW_SECONDS = 24 * 60 * 60;
+
+// VOTE: M votes/min/app/user. Covers a user rapidly up-voting a browsed list
+// while bounding a scripted brigade. Symmetric bucket covers vote + unvote so a
+// toggle-spam loop is also capped.
+export const SHARED_VOTE_RATE_LIMIT_MAX = 30;
+export const SHARED_VOTE_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+export type SharedStorageRateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number };
+
+async function checkFixedWindow(
+  key: string,
+  max: number,
+  windowSeconds: number
+): Promise<SharedStorageRateLimitResult> {
+  try {
+    const count = await redis.incrBy(key as never, 1);
+    if (count === 1) {
+      await redis.expire(key as never, windowSeconds);
+    } else {
+      // Re-assert a lost TTL (crash between INCR and EXPIRE would otherwise strand
+      // a TTL-less key → permanent lock). Same mitigation as the mint limiter.
+      const ttl = await redis.ttl(key as never);
+      if (ttl < 0) await redis.expire(key as never, windowSeconds);
+    }
+
+    if (count <= max) return { allowed: true };
+
+    let retryAfter = await redis.ttl(key as never);
+    if (!Number.isFinite(retryAfter) || retryAfter < 1) retryAfter = windowSeconds;
+    return { allowed: false, retryAfterSeconds: retryAfter };
+  } catch {
+    // Fail open — a redis incident must not break shared writes.
+    return { allowed: true };
+  }
+}
+
+/** One `append` against the (user, app) daily bucket. */
+export async function checkSharedAppendRateLimit(
+  userId: number,
+  appBlockId: string
+): Promise<SharedStorageRateLimitResult> {
+  const key =
+    `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:shared-append:${appBlockId}:${userId}` as const;
+  return checkFixedWindow(
+    key,
+    SHARED_APPEND_RATE_LIMIT_MAX,
+    SHARED_APPEND_RATE_LIMIT_WINDOW_SECONDS
+  );
+}
+
+/** One `vote`/`unvote` against the (user, app) per-minute bucket. */
+export async function checkSharedVoteRateLimit(
+  userId: number,
+  appBlockId: string
+): Promise<SharedStorageRateLimitResult> {
+  const key =
+    `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:shared-vote:${appBlockId}:${userId}` as const;
+  return checkFixedWindow(
+    key,
+    SHARED_VOTE_RATE_LIMIT_MAX,
+    SHARED_VOTE_RATE_LIMIT_WINDOW_SECONDS
+  );
+}

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -67,6 +67,16 @@ export const BLOCK_SCOPE_TO_OAUTH_BIT: Record<string, ScopeBitmaskRequirement> =
   // unknown scopes, so previously a manifest *couldn't* even list it).
   'apps:storage:read': SKIP_OAUTH_CHECK,
   'apps:storage:write': SKIP_OAUTH_CHECK,
+  // apps:storage:shared:* — the SHARED (app-global / cross-user) datastore. Same
+  // no-OAuth-bit posture as apps:storage:* (never touches the user's civitai
+  // resources via the OAuth surface). SKIP_OAUTH_CHECK; the real gate is
+  // `resolveSharedContext` (apps-shared.router) which asserts the scope is present
+  // per op AND runs the min-trust gate + the dedicated fail-closed Flipt flag.
+  // DELIBERATELY kept OUT of BOTH dev-mint allowlists (DEV_TOKEN_SCOPE_ALLOWLIST,
+  // TUNNEL_HOST_MINT_SCOPE_ALLOWLIST) — granted only to approved, mod-reviewed
+  // apps that declare it, never to a pre-approval dev-tunnel/dev-token session.
+  'apps:storage:shared:read': SKIP_OAUTH_CHECK,
+  'apps:storage:shared:write': SKIP_OAUTH_CHECK,
 } as const;
 
 export type BlockScopeString = keyof typeof BLOCK_SCOPE_TO_OAUTH_BIT;


### PR DESCRIPTION
## What
Phase 1 (server core) of App Blocks **app-global / shared storage** — the platform capability that lets a block store **cross-user shared data** (shared lists, vote tallies, community feeds), which today's strictly-per-user KV can't. First consumer: an "app request + voting" app. Ships **dark + fail-closed** (dedicated Flipt flag not yet created → every op FORBIDDEN as-merged).

🔴 **This opens the App Blocks datastore to public writes for the first time** (today it's mod/app-dev-tester-only). It went through a **design-stage security review** and an **implementation security audit**.

## Design + audit trail
- Design (hardened) + both reviews are captured in the session; the implementation audit verdict: **SHIP for the dark, mod-gated Phase-1 merge** — all core controls verified correct (C1/C2/C3/H1/H2/H3/H4/isolation/scopes/flag), 2 merge-blockers fixed in this branch (M-1, H-1).

## Security model (verified by the audit)
- **C1** `append` server-generates a ULID key, INSERT-only, mutate/withdraw assert `author_user_id = subject` → no cross-user overwrite.
- **H1** vote counter is atomically gated on the vote row inserting (CTE), symmetric unvote, `CHECK(count>=0)`; **votes are the source of truth, counter is a cache**.
- **H2** FK `votes.key→shared_kv.key`; vote-on-missing → NOT_FOUND.
- **H3** new `resolveSharedContext` — the trust gate **replaces** the author-capability gate; enforces on the hydrated token subject: not-anon/not-banned/not-muted/onboarded/email-verified/account-age≥7d (+ optional paid tier). Anon = read-only. Re-hydrated every call (mute/ban immediate).
- **C3** blocking `auditPromptServer` + minor/POI hard-fail + `throwOnBlockedLinkDomain` + HTML-escape-at-rest on write.
- **H4** server-side per-`(user,appBlockId)` rate limits. **M-1** per-instance `BlockRevocation` check (this branch).
- **M4** mod-purge = session-authed `moderatorProcedure`, not block-token reachable, cascades.
- **Isolation** schema from `sanitizeAppSlug(claims.blockId)` (app A can't reach app B); `shared:read` never touches per-user `kv`; `votes` never listable.
- Scopes `apps:storage:shared:*` fail-closed, out of the dev/tunnel allowlists, behind the dedicated flag.

## Migration
`src/server/services/apps/migrations/20260708120000_app_blocks_shared_storage.sql` — targets **appsDb (cnpg-cluster-apps)**, manual-apply backfill over existing `app_*` schemas (new apps get the DDL via `provision()`). **Not applied yet** — safe, nothing reads shared storage while the flag is absent. Apply to prod appsDb + dev clone before Phase 2.

## Tests — 45 pass
33 shared-router (C1 overwrite-denial, H1 counter atomicity, H2 FK, H3 trust matrix incl. anon-read-only, C3 minor/POI/HTML/link + report, H4 rate-limit, isolation, withdraw-authz, mod-purge cascade, **M-1 revocation**) + 12 provision.

## 🔴 Required before ANY public-GA widening (tracked, NOT for this dark merge)
1. Wire `shared_kv_reports` → a monitored mod surface / `Report` model (full H-1) — the legal-escalation queue currently has no reader (this branch adds an alertable log as the interim).
2. Enforce the **opaque-origin sandbox pin** for `apps:storage:shared:write` apps + verify every host-side render escapes/`textContent` (M-2).
3. A **Postgres-executed integration test** for the counter/FK/one-vote invariants (L-4 — current tests are SQL-shape assertions).

## Phase 2/3 (follow-ups)
SDK `useSharedStorage` + the flipt-state flag PR + apply the migration → then build the request+voting app on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)