### PR TITLE
fix(history): guard navigation.currentEntry null in getHasClientHistory (Chrome dialog-close crash)

### DIFF
--- a/src/store/ClientHistoryStore.tsx
+++ b/src/store/ClientHistoryStore.tsx
@@ -86,7 +86,7 @@ export function ClientHistoryStore() {
 export function useHasClientHistory() {
   const index = useClientHistoryStore((state) => state.index ?? 0);
   if (hasNavigation) {
-    return navigation.currentEntry.index > 0;
+    return (navigation.currentEntry?.index ?? 0) > 0;
   } else {
     return index > 0;
   }
@@ -98,7 +98,7 @@ export const getHasClientHistory = () => {
     const current = getHistoryStateKey(history.state);
     const index = current ? keys.indexOf(current) : -1;
     return index > 0;
-  } else return navigation.currentEntry.index > 0;
+  } else return (navigation.currentEntry?.index ?? 0) > 0;
 };
 
 // export function BackButton({ children }: { children: React.ReactElement }) {

--- a/src/store/__tests__/ClientHistoryStore.test.ts
+++ b/src/store/__tests__/ClientHistoryStore.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression coverage for the Chrome dialog-close crash:
+//   TypeError: null is not an object (evaluating 'navigation.currentEntry.index')
+//     at getHasClientHistory (src/store/ClientHistoryStore.tsx)
+// The Navigation API's `navigation.currentEntry` is nullable at runtime (null
+// when the document is not fully active — prerender, bfcache-restoring, or a
+// detached/inactive document). The old code read `.index` off it unguarded, so
+// closing a routed dialog while currentEntry was null threw and broke the close
+// handler. This is the `navigation.currentEntry` sibling of the #3006
+// Safari-null-`history.state` family (distinct signature).
+//
+// `getHasClientHistory` picks its branch off the module-scope `hasNavigation`
+// const, which is evaluated ONCE at import against `window.navigation`. So each
+// case sets up `window`/`navigation` (globalThis) BEFORE a fresh import — a
+// truthy `navigation` object (even with a null `currentEntry`) makes
+// `hasNavigation` true and exercises the crashing branch.
+describe('getHasClientHistory (Navigation API branch)', () => {
+  const originalWindow = (globalThis as { window?: unknown }).window;
+  const originalNavigation = (globalThis as { navigation?: unknown }).navigation;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    (globalThis as { window?: unknown }).window = originalWindow;
+    (globalThis as { navigation?: unknown }).navigation = originalNavigation;
+    vi.resetModules();
+  });
+
+  async function loadWithCurrentEntry(currentEntry: unknown) {
+    const navObj = { currentEntry };
+    (globalThis as { window?: unknown }).window = { navigation: navObj };
+    (globalThis as { navigation?: unknown }).navigation = navObj;
+    const mod = await import('~/store/ClientHistoryStore');
+    return mod.getHasClientHistory;
+  }
+
+  it('returns false (does NOT throw) when navigation.currentEntry is null — the crash', async () => {
+    const getHasClientHistory = await loadWithCurrentEntry(null);
+    expect(() => getHasClientHistory()).not.toThrow();
+    expect(getHasClientHistory()).toBe(false);
+  });
+
+  it('returns false when currentEntry is undefined (not throw)', async () => {
+    const getHasClientHistory = await loadWithCurrentEntry(undefined);
+    expect(() => getHasClientHistory()).not.toThrow();
+    expect(getHasClientHistory()).toBe(false);
+  });
+
+  it('returns true when currentEntry.index > 0 (has client history — happy path)', async () => {
+    const getHasClientHistory = await loadWithCurrentEntry({ index: 2 });
+    expect(getHasClientHistory()).toBe(true);
+  });
+
+  it('returns false when currentEntry.index is 0 (first entry — no client history)', async () => {
+    const getHasClientHistory = await loadWithCurrentEntry({ index: 0 });
+    expect(getHasClientHistory()).toBe(false);
+  });
+});


### PR DESCRIPTION
## The crash

Faro RUM surfaced a low-volume but real client-side crash in prod (~7 occurrences / 3h, Chrome), firing on dialog **close**:

```
TypeError: null is not an object (evaluating 'navigation.currentEntry.index')
  at getHasClientHistory (src/store/ClientHistoryStore.tsx:101)
  at RoutedDialogProvider.tsx:113
  at onClose (DialogProvider.tsx:28)
```

## Root cause

In `src/store/ClientHistoryStore.tsx`, `hasNavigation` only checks that the Navigation API **object** exists:

```ts
const hasNavigation = isClient && !!window.navigation;
```

But `navigation.currentEntry` is **nullable at runtime** — it's `null` when the document is not fully active (prerender, bfcache-restoring, detached/inactive documents). Both call sites dereferenced `.index` off it unguarded:

- `useHasClientHistory` (line 89): `return navigation.currentEntry.index > 0;`
- `getHasClientHistory` (line 101): `else return navigation.currentEntry.index > 0;`

The stacktrace names line 101 (the dialog-close path), but line 89 has the identical unguarded access, so both are fixed.

## The fix

Guard both sites with optional chaining and a safe `false` fallback:

```ts
return (navigation.currentEntry?.index ?? 0) > 0;
```

When `currentEntry` is `null` this yields `false` (matches the existing `index > 0` false path) → the caller degrades to a full navigation instead of `router.back()`, which is the correct safe degradation. The happy path is behavior-identical. No other logic changed. The ambient Navigation API type (`src/types/global.d.ts`) is left untouched — optional chaining is valid TS regardless of its (non-nullable) typing, and the runtime evidence is authoritative.

## Relationship to #3006

This is the residual of the #3006 Safari-null-history crash **family**, but a **distinct signature**: #3006 was `null` `history.state` (`t.state.key`), guarded by `getHistoryStateKey`. This one is `null` `navigation.currentEntry` on the Navigation API. Same failure mode (a nullable browser-history object dereferenced unguarded), different object/path.

## Test coverage

Adds `src/store/__tests__/ClientHistoryStore.test.ts` (node vitest, `test:unit` project — no browser needed) covering `getHasClientHistory`'s Navigation branch:

- `currentEntry = null` → `false`, does NOT throw (the regression test for this crash)
- `currentEntry = undefined` → `false`, does NOT throw
- `currentEntry = { index: 2 }` → `true`
- `currentEntry = { index: 0 }` → `false`

Verified the test genuinely reproduces the crash: reverting the fix makes the null/undefined cases throw and fail; with the fix all 4 pass. (`useHasClientHistory` uses the identical guard but is a React hook, not practically unit-testable in the node project; it's covered by the same one-line change.)

## Verification

- `pnpm test:unit src/store/__tests__/ClientHistoryStore.test.ts` → 4 passed.
- `pnpm typecheck` → 0 errors (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
