### PR TITLE
perf(gen): defer generation-tab-switch remount via useDeferredValue (mobile INP), flag-gated

### DIFF
--- a/src/components/ImageGeneration/GenerationTabs.tsx
+++ b/src/components/ImageGeneration/GenerationTabs.tsx
@@ -13,7 +13,7 @@ import { Queue } from './Queue';
 import { generationGraphPanel } from '~/store/generation-graph.store';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import type { ForwardRefExoticComponent, RefAttributes } from 'react';
-import React, { useEffect, useMemo } from 'react';
+import React, { useDeferredValue, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/router';
 import { GeneratedImageActions } from '~/components/ImageGeneration/GeneratedImageActions';
 import { GeneratedRequestsProvider } from '~/components/ImageGeneration/GeneratedRequestsProvider';
@@ -66,6 +66,19 @@ function GenerationTabsContent({ fullScreen }: { fullScreen?: boolean }) {
     if (isImageFeedSeparate && view === 'generate') generationGraphPanel.setView('queue');
   }, [isImageFeedSeparate, view]);
 
+  // Perf experiment: defer the generation-tab-switch remount to fix mobile INP.
+  // Switching tabs swaps `View` to a DIFFERENT component, so React synchronously
+  // unmounts the whole GenerationFormV2 tree and mounts Queue/Feed inside the tap's
+  // onChange handler (~1s of processing_duration counted against INP). `useDeferredValue`
+  // moves that heavy remount off the urgent path; the SegmentedControl highlight stays on
+  // the live `view` for instant tap feedback. startTransition does NOT work here — zustand
+  // external-store updates via useSyncExternalStore are always urgent and can't be deferred.
+  // Flag OFF => contentView === view => behavior is byte-identical to today.
+  // Measured via RUM `session_attr_exp_gen_tab_defer_view` mobile-INP A/B.
+  const deferGenTabView = features.genTabDeferView;
+  const deferredView = useDeferredValue(view);
+  const contentView = deferGenTabView ? deferredView : view;
+
   const GenerationFormComponent = GenerationFormV2;
 
   const tabs = useMemo<Tabs>(
@@ -89,9 +102,9 @@ function GenerationTabsContent({ fullScreen }: { fullScreen?: boolean }) {
     [GenerationFormComponent]
   );
 
-  const View = isImageFeedSeparate ? tabs.generate.Component : tabs[view].Component;
+  const View = isImageFeedSeparate ? tabs.generate.Component : tabs[contentView].Component;
   // The Queue/Feed views share one workflow fetch + selection order via the provider.
-  const showResults = !isImageFeedSeparate && view !== 'generate';
+  const showResults = !isImageFeedSeparate && contentView !== 'generate';
   const tabEntries = Object.entries(tabs).filter(([key]) =>
     isImageFeedSeparate ? key !== 'generate' : true
   );
@@ -201,7 +214,7 @@ function GenerationTabsContent({ fullScreen }: { fullScreen?: boolean }) {
             />
           </div>
         </div>
-        {view !== 'generate' && !isGeneratePage && <GeneratedImageActions />}
+        {contentView !== 'generate' && !isGeneratePage && <GeneratedImageActions />}
       </div>
       {showResults ? (
         <GeneratedRequestsProvider>

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -83,6 +83,13 @@ const featureFlags = createFeatureFlags({
   // cosmetic space reservation (worst case = a little dead space, never a
   // functional break), so flipping the flag off is an instant, safe rollback.
   feedReserveCls: { availability: ['mod'], fliptKey: 'feed-reserve-cls' },
+  // Perf experiment: defer the generation-tab-switch remount (useDeferredValue) to fix
+  // mobile INP (p75 ~304ms, dominant phase = processing_duration; the gen-tab switch is
+  // the single hottest interaction). `availability: ['public']` = a clean all-user A/B with
+  // NO mod segment (a mod cohort contaminated a prior A/B) — ramp a % of ALL users via Flipt
+  // (`gen-tab-defer-view`) as a THRESHOLD rollout. OFF = byte-identical to today. Measured via
+  // RUM `exp_gen_tab_defer_view`. Flipping off is an instant, safe rollback (deferral only).
+  genTabDeferView: { availability: ['public'], fliptKey: 'gen-tab-defer-view' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -85,11 +85,14 @@ const featureFlags = createFeatureFlags({
   feedReserveCls: { availability: ['mod'], fliptKey: 'feed-reserve-cls' },
   // Perf experiment: defer the generation-tab-switch remount (useDeferredValue) to fix
   // mobile INP (p75 ~304ms, dominant phase = processing_duration; the gen-tab switch is
-  // the single hottest interaction). `availability: ['public']` = a clean all-user A/B with
-  // NO mod segment (a mod cohort contaminated a prior A/B) — ramp a % of ALL users via Flipt
-  // (`gen-tab-defer-view`) as a THRESHOLD rollout. OFF = byte-identical to today. Measured via
-  // RUM `exp_gen_tab_defer_view`. Flipping off is an instant, safe rollback (deferral only).
-  genTabDeferView: { availability: ['public'], fliptKey: 'gen-tab-defer-view' },
+  // the single hottest interaction). `availability: []` = DARK by default and fails CLOSED when
+  // the Flipt flag is absent or Flipt is down (empty availability → static eval false), so the
+  // deferral only turns on via the Flipt `gen-tab-defer-view` THRESHOLD rollout — a clean all-user
+  // A/B with NO mod segment (a mod cohort contaminated a prior A/B). NOT `['public']`: that would
+  // fail OPEN (true for 100% of users) whenever the Flipt key is missing/unreachable, defeating
+  // the A/B (no flag-off cohort) and shipping the deferral fleet-wide unmeasured. OFF =
+  // byte-identical to today. Measured via RUM `exp_gen_tab_defer_view`. Instant safe rollback.
+  genTabDeferView: { availability: [], fliptKey: 'gen-tab-defer-view' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },

--- a/src/utils/faro/__tests__/experimentFlags.test.ts
+++ b/src/utils/faro/__tests__/experimentFlags.test.ts
@@ -21,6 +21,12 @@ describe('RUM_EXPERIMENT_FLAGS (curated allowlist)', () => {
     expect(entry?.attr).toBe('exp_feed_reserve_cls');
   });
 
+  it('includes the genTabDeferView experiment with its explicit exp_ attribute name', () => {
+    const entry = RUM_EXPERIMENT_FLAGS.find((f) => f.flag === 'genTabDeferView');
+    expect(entry).toBeDefined();
+    expect(entry?.attr).toBe('exp_gen_tab_defer_view');
+  });
+
   it('every curated attribute uses the exp_ prefix (greppable Loki field contract)', () => {
     for (const { attr } of RUM_EXPERIMENT_FLAGS) {
       expect(attr.startsWith(RUM_EXPERIMENT_ATTR_PREFIX)).toBe(true);
@@ -44,9 +50,19 @@ describe('buildRumExperimentAttributes', () => {
     expect(attrs.exp_feed_reserve_cls).toBe('false');
   });
 
+  it('emits "true"/"false" cohorts for the genTabDeferView experiment', () => {
+    expect(buildRumExperimentAttributes({ genTabDeferView: true }).exp_gen_tab_defer_view).toBe(
+      'true'
+    );
+    expect(buildRumExperimentAttributes({ genTabDeferView: false }).exp_gen_tab_defer_view).toBe(
+      'false'
+    );
+  });
+
   it('treats a missing flag as off ("false"), never undefined/absent', () => {
     const attrs = buildRumExperimentAttributes({});
     expect(attrs.exp_feed_reserve_cls).toBe('false');
+    expect(attrs.exp_gen_tab_defer_view).toBe('false');
   });
 
   it('coerces every value to a string (MetaAttributes must be strings)', () => {

--- a/src/utils/faro/experimentFlags.ts
+++ b/src/utils/faro/experimentFlags.ts
@@ -56,6 +56,7 @@ export const RUM_EXPERIMENT_ATTR_PREFIX = 'exp_';
  */
 export const RUM_EXPERIMENT_FLAGS = [
   { flag: 'feedReserveCls', attr: 'exp_feed_reserve_cls' },
+  { flag: 'genTabDeferView', attr: 'exp_gen_tab_defer_view' },
 ] as const satisfies ReadonlyArray<{ flag: FeatureFlagKey; attr: string }>;
 
 /**


### PR DESCRIPTION
## What

Flag-gated fix for the mobile-INP hot spot in the generation panel.

Faro RUM shows **mobile INP p75 ~304ms (POOR, 4× desktop)**, dominant phase = `processing_duration`. The single hottest interaction (~23% of mobile poor-INP) is the generation-panel **tab switch** in `GenerationTabs.tsx`. Switching tabs changes `const View = tabs[view].Component` to a **different** component, so React synchronously unmounts the whole `GenerationFormV2` tree and mounts `Queue`/`Feed` (or vice versa) **inside the `onChange` handler** → ~1s of synchronous work counted against INP.

## The fix

- New feature flag **`genTabDeferView`** / flipt key **`gen-tab-defer-view`**, `availability: []` (DARK / fail-closed — resolves false when the Flipt key is absent or Flipt is down; NOT `['public']`, which would fail open to 100% and defeat the A/B). A clean all-user A/B with **NO mod segment** (a mod cohort contaminated a prior A/B). Roll out as a **threshold-only** percentage via Flipt; this flag is the only on-switch, so the PR is safe to merge before flipt-state #38 (stays dark until the threshold flips).
- When ON: the heavy rendered content is driven off `const deferredView = useDeferredValue(view)` (`contentView = deferGenTabView ? deferredView : view`). The `SegmentedControl` `value={view}` and the graph-panel-sync `useEffect` stay on the **live** `view` → the tab highlight flips instantly on tap (good INP) while the ~1s remount happens off the urgent path.
- `contentView` drives exactly the reads that select/wrap the mounted content subtree: `View`, `showResults`, the `GeneratedRequestsProvider` wrap, and the `GeneratedImageActions` gate (it operates on the rendered results, so it stays in sync with the deferred swap).
- When **OFF**: `contentView === view`, so the render is **byte-identical** to today. Instant, safe rollback (deferral only, no data/behavior change).

**`startTransition` was rejected** — zustand external-store updates via `useSyncExternalStore` are always urgent and cannot be deferred by a transition. `useDeferredValue` is the correct primitive.

## Measurement

Added `genTabDeferView` → `exp_gen_tab_defer_view` to `RUM_EXPERIMENT_FLAGS`, so the flag rides every Faro beacon as Loki field **`session_attr_exp_gen_tab_defer_view`** (both `"true"`/`"false"` cohorts) → readable mobile-INP A/B.

## Tests / verification

- Extended `src/utils/faro/__tests__/experimentFlags.test.ts` for `genTabDeferView` → `exp_gen_tab_defer_view` (allowlist + true/false cohort + missing-as-false). **`vitest run --project unit experimentFlags.test.ts`: 11 passed.**
- `pnpm typecheck` (`tsc --noEmit`) ran; my 4 changed files are **type-clean**. The run surfaces 17 pre-existing baseline errors in **unrelated** files (`kysely` module resolution in `packages/civitai-db*`, downstream implicit-`any` in `image.service.ts`/`bitdex-stats.ts`/`flipt/client.ts`) — none reference the changed files, so no new type errors are introduced.
- No component (browser-mode Vitest) test added: the flag-OFF byte-identical guarantee is a pure structural no-op (`contentView === view`), and the deferral is a React-runtime behavior best verified by the RUM A/B. **Manual verification note:** with the flag OFF confirm the panel behaves exactly as today; with it ON, tapping a tab should flip the segmented-control highlight immediately while the heavy content swaps a beat later.
