### PR TITLE
feat(trpc): instrument oversized/slow response serialization to name the culprit procedure

### DIFF
--- a/src/pages/api/trpc/[trpc].ts
+++ b/src/pages/api/trpc/[trpc].ts
@@ -8,6 +8,7 @@ import { logToAxiom, safeError } from '~/server/logging/client';
 import { recordTrpcError } from '~/server/prom/http-errors';
 import { isClientAbortError } from '~/server/utils/errorHandling';
 import { appRouter } from '~/server/routers';
+import { runWithSerializeCtx, serializeCtxFromRequest } from '~/server/logging/trpc-serialize-log';
 
 export const config = {
   api: {
@@ -139,5 +140,8 @@ const trpcHandler = createNextApiHandler({
 // handled natively by `allowMethodOverride: true` above (main), so no manual
 // restore step is needed here.
 export default withAxiom(async (req: NextApiRequest, res: NextApiResponse) => {
-  await trpcHandler(req, res);
+  // Seed the request-scoped procedure-path context so the transformer's serialize
+  // step (an awaited descendant of trpcHandler) can name the offending procedure
+  // on an oversized/slow serialize. No-op wrapper when the instrument is disabled.
+  await runWithSerializeCtx(serializeCtxFromRequest(req), () => trpcHandler(req, res));
 }) as NextApiHandler;

--- a/src/server/__tests__/trpc-serialize-log.test.ts
+++ b/src/server/__tests__/trpc-serialize-log.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  __flushPendingEmitsForTest,
+  __rateGateForTest,
+  __resetRateLimitForTests,
+  __setEmitSinkForTests,
+  instrumentSerialize,
+  resolveSerializeConfig,
+  runWithSerializeCtx,
+  serializeCtxFromRequest,
+  shouldLogSerialize,
+  type SerializeLogPayload,
+} from '~/server/logging/trpc-serialize-log';
+
+// Env keys this module reads — snapshot + restore around every test so cases can
+// tune thresholds without leaking into siblings.
+const ENV_KEYS = [
+  'TRPC_SERIALIZE_LOG_ENABLED',
+  'TRPC_SERIALIZE_SLOW_MS',
+  'TRPC_SERIALIZE_OVERSIZED_BYTES',
+  'TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS',
+  'TRPC_SERIALIZE_LOG_MAX_PER_SEC',
+] as const;
+
+describe('trpc-serialize-log', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+    for (const k of ENV_KEYS) delete process.env[k];
+    __resetRateLimitForTests();
+    __setEmitSinkForTests(undefined);
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+    __setEmitSinkForTests(undefined);
+  });
+
+  describe('shouldLogSerialize (pure trigger decision)', () => {
+    const base = { serializeMs: 0, bytes: 0, slowMs: 250, oversizedBytes: 1024 * 1024 };
+
+    it('fires when serialize duration is at/above the slow threshold', () => {
+      expect(shouldLogSerialize({ ...base, serializeMs: 250 })).toBe(true);
+      expect(shouldLogSerialize({ ...base, serializeMs: 6000 })).toBe(true);
+    });
+
+    it('fires when byte size is at/above the oversized threshold (even if fast)', () => {
+      expect(shouldLogSerialize({ ...base, bytes: 1024 * 1024 })).toBe(true);
+      expect(shouldLogSerialize({ ...base, serializeMs: 5, bytes: 5 * 1024 * 1024 })).toBe(true);
+    });
+
+    it('is silent when below BOTH thresholds', () => {
+      expect(shouldLogSerialize({ ...base, serializeMs: 249, bytes: 1024 * 1024 - 1 })).toBe(false);
+      expect(shouldLogSerialize(base)).toBe(false);
+    });
+
+    it('is NaN-safe (a NaN reading never fires)', () => {
+      expect(shouldLogSerialize({ ...base, serializeMs: NaN, bytes: NaN })).toBe(false);
+    });
+  });
+
+  describe('resolveSerializeConfig (env parsing)', () => {
+    it('defaults when unset', () => {
+      expect(resolveSerializeConfig()).toEqual({
+        enabled: true,
+        slowMs: 250,
+        oversizedBytes: 1024 * 1024,
+        floorMs: 50,
+        maxPerSec: 50,
+      });
+    });
+
+    it('honors overrides and rejects footgun values (0/neg thresholds fall back)', () => {
+      process.env.TRPC_SERIALIZE_SLOW_MS = '3000';
+      process.env.TRPC_SERIALIZE_OVERSIZED_BYTES = '524288';
+      process.env.TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS = '10';
+      const cfg = resolveSerializeConfig();
+      expect(cfg.slowMs).toBe(3000);
+      expect(cfg.oversizedBytes).toBe(524288);
+      expect(cfg.floorMs).toBe(10);
+
+      process.env.TRPC_SERIALIZE_SLOW_MS = '0'; // min=1 → reject → default
+      expect(resolveSerializeConfig().slowMs).toBe(250);
+    });
+
+    it('kill-switch: only explicit falsy tokens disable', () => {
+      for (const off of ['false', '0', 'no', 'off']) {
+        process.env.TRPC_SERIALIZE_LOG_ENABLED = off;
+        expect(resolveSerializeConfig().enabled).toBe(false);
+      }
+      for (const on of ['true', 'yes', 'on', '']) {
+        process.env.TRPC_SERIALIZE_LOG_ENABLED = on;
+        expect(resolveSerializeConfig().enabled).toBe(true);
+      }
+    });
+  });
+
+  describe('serializeCtxFromRequest (path correlation from the URL)', () => {
+    it('reads the comma-joined batch path from req.query.trpc; GET → query', () => {
+      expect(serializeCtxFromRequest({ query: { trpc: 'image.getInfinite' }, method: 'GET' })).toEqual(
+        { path: 'image.getInfinite', type: 'query' }
+      );
+    });
+
+    it('POST maps type to undefined (method-override may make it a query)', () => {
+      const ctx = serializeCtxFromRequest({ query: { trpc: 'a,b' }, method: 'POST' });
+      expect(ctx.path).toBe('a,b');
+      expect(ctx.type).toBeUndefined();
+    });
+
+    it('falls back to "unknown" when no path is present', () => {
+      expect(serializeCtxFromRequest({ query: {} }).path).toBe('unknown');
+    });
+  });
+
+  describe('rateGate (per-pod path-diverse cap)', () => {
+    it('emits a distinct path once per window, suppresses same-path repeats', () => {
+      expect(__rateGateForTest('image.getInfinite', 50, 1000)).toBe(0); // emit
+      expect(__rateGateForTest('image.getInfinite', 50, 1100)).toBe(-1); // dup → suppress
+      expect(__rateGateForTest('model.getById', 50, 1200)).toBe(0); // distinct → emit
+      expect(__rateGateForTest('image.getInfinite', 50, 2001)).toBe(0); // next window → emit
+    });
+  });
+
+  describe('instrumentSerialize (end-to-end capture)', () => {
+    it('does NOT touch the serialize result and is silent below the floor', async () => {
+      process.env.TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS = '999999'; // force sub-floor
+      const captured: SerializeLogPayload[] = [];
+      __setEmitSinkForTests((p) => captured.push(p));
+
+      const payload = { json: { hello: 'world' }, meta: undefined };
+      const out = instrumentSerialize(() => payload);
+      expect(out).toBe(payload); // passthrough, unchanged
+      await __flushPendingEmitsForTest();
+      expect(captured).toHaveLength(0); // below floor → no byte walk, no log
+    });
+
+    it('captures path + bytes + serializeMs when oversized (floor/slow tuned to force it)', async () => {
+      // floor=0 so any serialize is measured; oversized threshold tiny so a small
+      // payload trips the size trigger deterministically without a real 6s stall.
+      process.env.TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS = '0';
+      process.env.TRPC_SERIALIZE_OVERSIZED_BYTES = '10';
+      process.env.TRPC_SERIALIZE_SLOW_MS = '100000';
+      const captured: SerializeLogPayload[] = [];
+      __setEmitSinkForTests((p) => captured.push(p));
+
+      const bigPayload = { json: { data: 'x'.repeat(200) }, meta: undefined };
+      runWithSerializeCtx({ path: 'image.getInfinite', type: 'query' }, () => {
+        instrumentSerialize(() => bigPayload);
+      });
+
+      expect(captured).toHaveLength(1);
+      const log = captured[0];
+      expect(log.path).toBe('image.getInfinite');
+      expect(log.procedureType).toBe('query');
+      expect(log.bytes).toBe(Buffer.byteLength(JSON.stringify(bigPayload), 'utf8'));
+      expect(log.bytes! >= 10).toBe(true);
+      expect(log.serializeMs).toBeGreaterThanOrEqual(0);
+    });
+
+    it('is disarmed (raw passthrough, no log) when the kill-switch is off', async () => {
+      process.env.TRPC_SERIALIZE_LOG_ENABLED = 'false';
+      process.env.TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS = '0';
+      process.env.TRPC_SERIALIZE_OVERSIZED_BYTES = '1';
+      const captured: SerializeLogPayload[] = [];
+      __setEmitSinkForTests((p) => captured.push(p));
+
+      const payload = { json: { a: 1 }, meta: undefined };
+      const out = runWithSerializeCtx({ path: 'x' }, () => instrumentSerialize(() => payload));
+      expect(out).toBe(payload);
+      await __flushPendingEmitsForTest();
+      expect(captured).toHaveLength(0);
+    });
+
+    it('records "unknown" path when serialized outside a request scope (SSR/SSG)', () => {
+      process.env.TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS = '0';
+      process.env.TRPC_SERIALIZE_OVERSIZED_BYTES = '1';
+      process.env.TRPC_SERIALIZE_SLOW_MS = '100000';
+      const captured: SerializeLogPayload[] = [];
+      __setEmitSinkForTests((p) => captured.push(p));
+
+      instrumentSerialize(() => ({ json: { a: 1 }, meta: undefined }));
+      expect(captured).toHaveLength(1);
+      expect(captured[0].path).toBe('unknown');
+    });
+
+    it('propagates a serialize throw unchanged (no log)', () => {
+      process.env.TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS = '0';
+      const captured: SerializeLogPayload[] = [];
+      __setEmitSinkForTests((p) => captured.push(p));
+      const boom = new Error('serialize boom');
+      expect(() =>
+        instrumentSerialize(() => {
+          throw boom;
+        })
+      ).toThrow(boom);
+      expect(captured).toHaveLength(0);
+    });
+  });
+});

--- a/src/server/logging/__tests__/trpc-serialize-log.test.ts
+++ b/src/server/logging/__tests__/trpc-serialize-log.test.ts
@@ -1,8 +1,9 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   __flushPendingEmitsForTest,
   __rateGateForTest,
+  __resetConfigCacheForTests,
   __resetRateLimitForTests,
   __setEmitSinkForTests,
   instrumentSerialize,
@@ -30,6 +31,7 @@ describe('trpc-serialize-log', () => {
     savedEnv = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
     for (const k of ENV_KEYS) delete process.env[k];
     __resetRateLimitForTests();
+    __resetConfigCacheForTests(); // module-level config cache must not leak across tests
     __setEmitSinkForTests(undefined);
   });
 
@@ -39,6 +41,7 @@ describe('trpc-serialize-log', () => {
       else process.env[k] = savedEnv[k];
     }
     __setEmitSinkForTests(undefined);
+    vi.restoreAllMocks(); // undo any performance.now spy
   });
 
   describe('shouldLogSerialize (pure trigger decision)', () => {
@@ -200,6 +203,88 @@ describe('trpc-serialize-log', () => {
         })
       ).toThrow(boom);
       expect(captured).toHaveLength(0);
+    });
+
+    // FIX 1: on the loop-blocking (serializeMs >= slowMs) path, the second full
+    // JSON.stringify (safeByteLength) must NOT run per-occurrence — it is ordered
+    // AFTER the rate gate, so a slow+wave incident pays it at most maxPerSec/window,
+    // not once per serialize on the already-blocked thread.
+    it('does NOT run the byte walk per-occurrence when serializeMs >= slowMs under rate-limiting', async () => {
+      process.env.TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS = '0';
+      process.env.TRPC_SERIALIZE_SLOW_MS = '250';
+      process.env.TRPC_SERIALIZE_OVERSIZED_BYTES = '1'; // ensure size trigger would also fire — isolate the reorder
+      process.env.TRPC_SERIALIZE_LOG_MAX_PER_SEC = '50';
+      __resetConfigCacheForTests();
+
+      const captured: SerializeLogPayload[] = [];
+      __setEmitSinkForTests((p) => captured.push(p));
+
+      // Count byte walks: safeByteLength does JSON.stringify(result), which invokes
+      // the result's toJSON exactly once per call.
+      let byteWalks = 0;
+      const payload = {
+        json: { data: 'x'.repeat(64) },
+        meta: undefined,
+        toJSON() {
+          byteWalks++;
+          return { data: 'x'.repeat(64) };
+        },
+      };
+
+      // Deterministic slow serialize: mock performance.now so every call measures a
+      // 1000ms (>= slowMs 250) serialize without a real stall.
+      let nowVal = 0;
+      vi.spyOn(performance, 'now').mockImplementation(() => nowVal);
+
+      const N = 200; // distinct paths so the gate allows up to maxPerSec, then ceilings
+      for (let i = 0; i < N; i++) {
+        runWithSerializeCtx({ path: `proc.${i}`, type: 'query' }, () =>
+          instrumentSerialize(() => {
+            nowVal += 1000; // second performance.now() read → delta 1000ms
+            return payload;
+          })
+        );
+      }
+      await __flushPendingEmitsForTest();
+
+      // Gate caps distinct emits at maxPerSec=50; the byte walk runs ONLY on those,
+      // NOT once per serialize (which would be 200). This is the reorder's whole point.
+      expect(captured.length).toBe(50);
+      expect(byteWalks).toBe(50);
+      expect(byteWalks).toBeLessThanOrEqual(50); // <= maxPerSec
+      expect(byteWalks).toBeLessThan(N); // decisively not per-occurrence
+      // The emitted slow lines still carry the byte size (informational-after-gate).
+      expect(captured[0].bytes).toBeGreaterThan(0);
+    });
+
+    // FIX 1: the moderate band (floorMs <= serializeMs < slowMs) still uses bytes as
+    // the decision input for the oversized-SIZE trigger and logs when >= threshold.
+    it('still logs a moderate-duration (below slowMs) but oversized (> 1 MiB) serialize', async () => {
+      process.env.TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS = '50';
+      process.env.TRPC_SERIALIZE_SLOW_MS = '250';
+      process.env.TRPC_SERIALIZE_OVERSIZED_BYTES = String(1024 * 1024); // 1 MiB
+      __resetConfigCacheForTests();
+
+      const captured: SerializeLogPayload[] = [];
+      __setEmitSinkForTests((p) => captured.push(p));
+
+      // serializeMs = 100ms → in [floor 50, slow 250): the moderate band.
+      let nowVal = 0;
+      vi.spyOn(performance, 'now').mockImplementation(() => nowVal);
+
+      const bigPayload = { json: { data: 'y'.repeat(1024 * 1024 + 32) }, meta: undefined }; // > 1 MiB
+      runWithSerializeCtx({ path: 'image.getInfinite', type: 'query' }, () =>
+        instrumentSerialize(() => {
+          nowVal += 100; // moderate duration, below slowMs
+          return bigPayload;
+        })
+      );
+      await __flushPendingEmitsForTest();
+
+      expect(captured).toHaveLength(1);
+      expect(captured[0].path).toBe('image.getInfinite');
+      expect(captured[0].serializeMs).toBe(100);
+      expect(captured[0].bytes!).toBeGreaterThanOrEqual(1024 * 1024);
     });
   });
 });

--- a/src/server/logging/trpc-serialize-log.ts
+++ b/src/server/logging/trpc-serialize-log.ts
@@ -38,28 +38,46 @@
  * dehydration) there is no scope → path is 'unknown', still with bytes+serializeMs.
  *
  * Design guarantees (mirrors trpc-slow-log.ts / eventloop-longtask.ts):
- *  - COMMON PATH IS A NUMERIC COMPARE. Every serialize pays two `performance.now()`
- *    reads; below `TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS` (default 50ms — a normal
- *    small response serializes in well under 1ms) it returns immediately with NO
- *    byte walk, NO allocation, NO log. We NEVER double-serialize the common path:
- *    the byte size is measured (one JSON.stringify of the already-superjson-reduced
- *    output) ONLY above the floor, i.e. only on responses already large/slow enough
- *    to matter.
- *  - DISARMED (`TRPC_SERIALIZE_LOG_ENABLED` off): `instrumentSerialize` returns the
- *    raw serialize with a single boolean branch and the ALS wrapper at the handler
- *    boundary is skipped — byte-for-byte the pre-instrumentation path.
+ *  - CHEAP COMMON PATH. Per serialize the enabled path pays: one kill-switch check,
+ *    one CACHED-config read (the env config is resolved once and refreshed on an
+ *    interval, NOT rebuilt per call — see getSerializeConfig), two `performance.now()`
+ *    reads and one numeric compare. Below `TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS`
+ *    (default 50ms — a normal small response serializes in well under 1ms) it returns
+ *    immediately with NO byte walk, NO per-call config allocation, NO log.
+ *  - THE BYTE WALK NEVER RUNS PER-OCCURRENCE ON THE INCIDENT PATH. `safeByteLength`
+ *    is a SECOND O(payload) JSON.stringify (a multi-MB string alloc for the monster
+ *    responses this exists to catch), so running it once per serialize during an
+ *    oversized-response WAVE would amplify the exact loop-block it measures. It is
+ *    ordered AFTER the trigger + rate gate: for the loop-blocking case
+ *    (serializeMs >= slowMs) DURATION ALONE decides, so the byte size is computed
+ *    only AFTER the gate allows an emit (≤ maxPerSec times/window, informational);
+ *    it is a decision INPUT only in the moderate band (floorMs <= serializeMs <
+ *    slowMs — the smaller payloads that didn't block long enough, since the 6MB
+ *    monsters take >250ms and hit the first branch). We NEVER double-serialize the
+ *    common (sub-floor) path.
+ *  - DISARMED (`TRPC_SERIALIZE_LOG_ENABLED` off): `instrumentSerialize` checks the
+ *    kill-switch FIRST and returns the raw serialize in a single boolean branch —
+ *    before any config is built — and the ALS wrapper at the handler boundary is
+ *    skipped, so it is byte-for-byte the pre-instrumentation path.
  *  - NEVER throws, NEVER delays the request path — all logging is best-effort and
- *    swallowed; a serialize failure/throw propagates unchanged (we time in finally).
+ *    swallowed; the serialize is timed INLINE (not in a finally), so a serialize
+ *    throw propagates unchanged and correctly skips timing + logging (there is no
+ *    output to size or attribute).
  *  - SELF-AMPLIFICATION GUARD: during a real wave many oversized responses cross at
  *    once; a per-pod PATH-DIVERSE token cap (`TRPC_SERIALIZE_LOG_MAX_PER_SEC`,
  *    default 50/s) bounds the stderr burst while still naming each distinct offender
- *    once/window. Suppressed lines are counted (`droppedSinceLastLog`), never
- *    silently dropped.
- *  - PRIVACY: logs ONLY the procedure path (a fixed dotted name), best-effort type,
- *    the serialized byte SIZE, and the duration. It does NOT log the payload or any
- *    field values, so no prompt / PII is ever captured.
+ *    once/window. Lines suppressed by the hard CEILING are counted and surfaced as
+ *    `droppedSinceLastLog` on the next emit; same-path repeats within a window are
+ *    deduped (they carry no new which-procedure signal) and intentionally NOT counted.
+ *  - PRIVACY: logs ONLY the procedure path, best-effort type, the serialized byte
+ *    SIZE, and the duration. It does NOT log the payload or any field values, so no
+ *    prompt / PII is ever captured. The `path` is the client-controlled `req.query.trpc`
+ *    URL segment (a caller can put arbitrary text there), which is safe because
+ *    `logToAxiom` JSON-encodes the value — it can't break the log structure — and it
+ *    carries no PII beyond the requested procedure path itself.
  *
- * Env knobs (read lazily per-call, tunable without a rebuild):
+ * Env knobs (resolved into a short-lived cache, refreshed on an interval — tunable
+ * without a rebuild; a change takes effect within one refresh interval):
  *  - TRPC_SERIALIZE_LOG_ENABLED (default true) — kill-switch; disabled ONLY by an
  *    explicit falsy token (false/0/no/off), so it can't be turned off by =yes/=on.
  *  - TRPC_SERIALIZE_SLOW_MS (default 250) — a single serialize taking >= this many
@@ -115,7 +133,7 @@ export interface SerializeLogConfig {
   maxPerSec: number;
 }
 
-/** Resolve the full config from env (lazy, per-call). Exported for tests. */
+/** Resolve the full config from env (fresh read — no cache). Exported for tests. */
 export function resolveSerializeConfig(): SerializeLogConfig {
   return {
     enabled: !envDisabled('TRPC_SERIALIZE_LOG_ENABLED'),
@@ -124,6 +142,29 @@ export function resolveSerializeConfig(): SerializeLogConfig {
     floorMs: envNumber('TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS', DEFAULT_SIZE_CHECK_FLOOR_MS, 0),
     maxPerSec: envNumber('TRPC_SERIALIZE_LOG_MAX_PER_SEC', DEFAULT_MAX_PER_SEC, 1),
   };
+}
+
+// Cached config so the hot path (several thousand serializes/sec) does NOT re-read
+// 5 env vars + allocate a fresh config object on every call. Resolved once and
+// refreshed on a fixed interval so env overrides still take effect without a rebuild
+// (within one CONFIG_TTL_MS window). Module-local, one cache per pod.
+const CONFIG_TTL_MS = 5000;
+let cachedConfig: SerializeLogConfig | undefined;
+let cachedConfigAt = 0;
+
+/** Cached config accessor — refreshes at most once per CONFIG_TTL_MS. */
+function getSerializeConfig(now: number = Date.now()): SerializeLogConfig {
+  if (cachedConfig === undefined || now - cachedConfigAt >= CONFIG_TTL_MS) {
+    cachedConfig = resolveSerializeConfig();
+    cachedConfigAt = now;
+  }
+  return cachedConfig;
+}
+
+/** TEST-ONLY: drop the cached config so an env change is picked up immediately. */
+export function __resetConfigCacheForTests(): void {
+  cachedConfig = undefined;
+  cachedConfigAt = 0;
 }
 
 /**
@@ -322,20 +363,33 @@ function emit(payload: SerializeLogPayload): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Wrap the tRPC transformer's `serialize`. Times the serialize (always — two
- * timestamps), and ONLY when it crosses the cheap duration floor measures the
- * output byte size and, if slow OR oversized, emits ONE rate-limited structured
- * log naming the procedure path (from the request-scoped ALS ctx). Returns the
- * raw serialize result unchanged; a serialize throw propagates unchanged (timed
- * in `finally`, but a throw skips the size/log tail since there is no output).
+ * Wrap the tRPC transformer's `serialize`. Checks the kill-switch FIRST (disabled →
+ * a single boolean branch, no config built), then times the serialize INLINE (two
+ * timestamps). Below the cheap duration floor it returns immediately. Above the
+ * floor it decides whether to log WITHOUT paying the byte walk on the incident path:
+ *
+ *  - serializeMs >= slowMs (the loop-blocking case, e.g. the ~6s incident): duration
+ *    alone qualifies, so we hit the RATE GATE FIRST and only compute the byte size
+ *    (for the log payload) AFTER the gate allows an emit. On an oversized-response
+ *    WAVE this means `safeByteLength` — a second full JSON.stringify — runs at most
+ *    `maxPerSec` times/window on the already-blocked thread, not once per serialize.
+ *  - floorMs <= serializeMs < slowMs (the moderate band, smaller payloads by
+ *    definition): here the byte size is a decision INPUT for the oversized-SIZE
+ *    trigger, so it is computed to evaluate `bytes >= oversizedBytes` before gating.
+ *
+ * Returns the raw serialize result unchanged; a serialize throw propagates unchanged
+ * (timed inline — a throw skips timing + the size/log tail since there is no output).
  *
  * @param rawSerialize the real serialize (e.g. `() => superjson.serialize(data)`,
  *                      optionally wrapped in the existing withSpan). Its return
  *                      value is passed through verbatim.
  */
 export function instrumentSerialize<T>(rawSerialize: () => T): T {
-  const cfg = resolveSerializeConfig();
-  if (!cfg.enabled) return rawSerialize();
+  // FIRST: kill-switch. Disabled → a single boolean branch, before any config is
+  // built or allocated (mirrors runWithSerializeCtx's short-circuit).
+  if (envDisabled('TRPC_SERIALIZE_LOG_ENABLED')) return rawSerialize();
+
+  const cfg = getSerializeConfig(); // cached — not rebuilt per call
 
   const startedAt = performance.now();
   const result = rawSerialize();
@@ -346,23 +400,48 @@ export function instrumentSerialize<T>(rawSerialize: () => T): T {
   if (!(serializeMs >= cfg.floorMs)) return result;
 
   try {
-    const bytes = safeByteLength(result);
-    if (!shouldLogSerialize({ serializeMs, bytes: bytes ?? 0, slowMs: cfg.slowMs, oversizedBytes: cfg.oversizedBytes })) {
-      return result;
-    }
     const ctx = currentSerializeCtx();
+    // `path` is the client-controlled `req.query.trpc` URL segment (see the ALS
+    // seed in [trpc].ts). Safe to log: `logToAxiom` JSON-encodes it, and it carries
+    // no PII beyond the requested procedure path.
     const path = ctx?.path ?? 'unknown';
-    const dropped = rateGate(path, cfg.maxPerSec);
-    if (dropped < 0) return result; // suppressed (dup-this-window or ceiling)
-    emit({
-      path,
-      bytes,
-      serializeMs: Math.round(serializeMs * 100) / 100,
-      procedureType: ctx?.type,
-      slowMs: cfg.slowMs,
-      oversizedBytes: cfg.oversizedBytes,
-      droppedSinceLastLog: dropped,
-    });
+
+    if (serializeMs >= cfg.slowMs) {
+      // LOOP-BLOCKING: duration alone decides — gate BEFORE the byte walk so the
+      // second stringify is not paid per-occurrence during a slow+wave incident.
+      const dropped = rateGate(path, cfg.maxPerSec);
+      if (dropped < 0) return result; // suppressed (dup-this-window or ceiling)
+      const bytes = safeByteLength(result); // informational, only after the gate
+      emit({
+        path,
+        bytes,
+        serializeMs: Math.round(serializeMs * 100) / 100,
+        procedureType: ctx?.type,
+        slowMs: cfg.slowMs,
+        oversizedBytes: cfg.oversizedBytes,
+        droppedSinceLastLog: dropped,
+      });
+    } else {
+      // MODERATE band (floorMs <= serializeMs < slowMs): the oversized-SIZE trigger
+      // needs the byte size to decide. These are the smaller payloads (the 6MB
+      // monsters block > slowMs and took the branch above).
+      const bytes = safeByteLength(result);
+      // serializeMs < slowMs here, so shouldLogSerialize reduces to the size trigger.
+      if (!shouldLogSerialize({ serializeMs, bytes: bytes ?? 0, slowMs: cfg.slowMs, oversizedBytes: cfg.oversizedBytes })) {
+        return result;
+      }
+      const dropped = rateGate(path, cfg.maxPerSec);
+      if (dropped < 0) return result; // suppressed (dup-this-window or ceiling)
+      emit({
+        path,
+        bytes,
+        serializeMs: Math.round(serializeMs * 100) / 100,
+        procedureType: ctx?.type,
+        slowMs: cfg.slowMs,
+        oversizedBytes: cfg.oversizedBytes,
+        droppedSinceLastLog: dropped,
+      });
+    }
   } catch {
     // Instrumentation must never throw into the serialize path.
   }

--- a/src/server/logging/trpc-serialize-log.ts
+++ b/src/server/logging/trpc-serialize-log.ts
@@ -1,0 +1,370 @@
+/**
+ * Oversized / slow tRPC RESPONSE-SERIALIZATION instrumentation.
+ *
+ * WHY THIS EXISTS: civitai-dp-prod api-primary periodically 504/499s in bursts
+ * when a single oversized tRPC response is serialized synchronously (superjson)
+ * on the one JS thread, pegging the event loop for SECONDS and starving every
+ * other in-flight request on the pod (a liveness kill on the worst pod). Captured
+ * CPU profiles show the spin dominated by
+ *   resolveResponse -> transformTRPCResponse -> transformer.serialize
+ *     -> superjson.serialize (recursive walk) + GC churn
+ * i.e. the block is in RESPONSE SERIALIZATION, which happens in tRPC's response
+ * pipeline AFTER the resolver has already returned.
+ *
+ * THE BLIND SPOT THIS CLOSES: the sibling `trpc-slow-log.ts` times the RESOLVER
+ * (the middleware chain + `next()`), so a procedure whose resolver is fast but
+ * whose RESULT is huge-and-slow-to-serialize is invisible to it — the blocking
+ * time is spent after the timed window closes. This module instruments the
+ * serialize step itself and names the offending procedure on the NEXT occurrence:
+ * it wraps the transformer's `serialize` (see src/server/trpc.ts) and, when a
+ * single serialize is slow OR its output is oversized, emits ONE structured
+ * `logToAxiom` line with { path, bytes, serializeMs, procedureType }.
+ *   Query in Loki: `{namespace="civitai-dp-prod"} | json | name="trpc-response-oversized"`.
+ *
+ * PROCEDURE-PATH CORRELATION: the transformer's `serialize(data)` receives only
+ * the payload, not the procedure it belongs to. tRPC does NOT thread the path
+ * into the transformer, and there is no always-on OTEL procedure span to read
+ * (OTEL is opt-in + 10%-sampled here, and only inbound-HTTP + manual withSpan
+ * spans exist). So we correlate the path deterministically via a request-scoped
+ * AsyncLocalStorage seeded at the HTTP-handler boundary (src/pages/api/trpc/[trpc].ts)
+ * from `req.query.trpc` — the comma-joined batch procedure path(s) that are
+ * already in the request URL. The serialize call runs inside that ALS scope
+ * (resolveResponse is an awaited descendant of the wrapped handler), so
+ * `currentSerializeCtx()` reads the request's path synchronously with no
+ * async_hooks / per-resource cost. Batches are ~99% single-procedure (see the
+ * dp-prod tRPC-batching note), so `path` is almost always the exact culprit; for
+ * a multi-procedure batch it's the small candidate set (the oversized one is the
+ * one whose serialize is slow). Outside an HTTP request (SSR createCaller / SSG
+ * dehydration) there is no scope → path is 'unknown', still with bytes+serializeMs.
+ *
+ * Design guarantees (mirrors trpc-slow-log.ts / eventloop-longtask.ts):
+ *  - COMMON PATH IS A NUMERIC COMPARE. Every serialize pays two `performance.now()`
+ *    reads; below `TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS` (default 50ms — a normal
+ *    small response serializes in well under 1ms) it returns immediately with NO
+ *    byte walk, NO allocation, NO log. We NEVER double-serialize the common path:
+ *    the byte size is measured (one JSON.stringify of the already-superjson-reduced
+ *    output) ONLY above the floor, i.e. only on responses already large/slow enough
+ *    to matter.
+ *  - DISARMED (`TRPC_SERIALIZE_LOG_ENABLED` off): `instrumentSerialize` returns the
+ *    raw serialize with a single boolean branch and the ALS wrapper at the handler
+ *    boundary is skipped — byte-for-byte the pre-instrumentation path.
+ *  - NEVER throws, NEVER delays the request path — all logging is best-effort and
+ *    swallowed; a serialize failure/throw propagates unchanged (we time in finally).
+ *  - SELF-AMPLIFICATION GUARD: during a real wave many oversized responses cross at
+ *    once; a per-pod PATH-DIVERSE token cap (`TRPC_SERIALIZE_LOG_MAX_PER_SEC`,
+ *    default 50/s) bounds the stderr burst while still naming each distinct offender
+ *    once/window. Suppressed lines are counted (`droppedSinceLastLog`), never
+ *    silently dropped.
+ *  - PRIVACY: logs ONLY the procedure path (a fixed dotted name), best-effort type,
+ *    the serialized byte SIZE, and the duration. It does NOT log the payload or any
+ *    field values, so no prompt / PII is ever captured.
+ *
+ * Env knobs (read lazily per-call, tunable without a rebuild):
+ *  - TRPC_SERIALIZE_LOG_ENABLED (default true) — kill-switch; disabled ONLY by an
+ *    explicit falsy token (false/0/no/off), so it can't be turned off by =yes/=on.
+ *  - TRPC_SERIALIZE_SLOW_MS (default 250) — a single serialize taking >= this many
+ *    ms is loop-blocking and logged. Normal serialize is sub-ms; the incident was
+ *    ~6000ms. This is the AUTHORITATIVE loop-blocking trigger.
+ *  - TRPC_SERIALIZE_OVERSIZED_BYTES (default 1048576 = 1 MiB) — serialized output at
+ *    or above this size is logged even if it happened to serialize under SLOW_MS,
+ *    as an early/proactive signal (the request body limit is 17mb; a 1MiB RESPONSE
+ *    is already the danger zone that pegs the loop under concurrency).
+ *  - TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS (default 50) — the cheap gate: below this
+ *    serialize duration we do NOT compute the byte size or log. Anything that blocks
+ *    the loop OR is oversized-enough-to-matter takes >= this long to superjson-walk,
+ *    so the floor drops no actionable event while keeping the 1500 req/s common path
+ *    free. Lower it (toward 0) during an active hunt to widen the size trigger.
+ *  - TRPC_SERIALIZE_LOG_MAX_PER_SEC (default 50) — per-pod path-diverse ceiling.
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const DEFAULT_SLOW_MS = 250;
+const DEFAULT_OVERSIZED_BYTES = 1024 * 1024; // 1 MiB
+const DEFAULT_SIZE_CHECK_FLOOR_MS = 50;
+const DEFAULT_MAX_PER_SEC = 50;
+
+// ---------------------------------------------------------------------------
+// Env config (lazy, mirrors trpc-slow-log.ts)
+// ---------------------------------------------------------------------------
+
+// `min` lets a threshold reject 0 / negatives (which would mean "log everything",
+// a firehose footgun) and fall back to the default instead.
+function envNumber(name: string, fallback: number, min = 0): number {
+  const raw = process.env[name];
+  if (raw == null || raw === '') return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= min ? n : fallback;
+}
+
+// Default-ON kill-switch: only an EXPLICIT falsy token disables. Avoids the footgun
+// where an operator sets `=yes`/`=on` to "turn it on" and a strict `==='true'`
+// check silently turns it OFF instead.
+function envDisabled(name: string): boolean {
+  const raw = process.env[name];
+  if (raw == null || raw === '') return false; // unset → enabled
+  const v = raw.trim().toLowerCase();
+  return v === 'false' || v === '0' || v === 'no' || v === 'off';
+}
+
+export interface SerializeLogConfig {
+  enabled: boolean;
+  slowMs: number;
+  oversizedBytes: number;
+  floorMs: number;
+  maxPerSec: number;
+}
+
+/** Resolve the full config from env (lazy, per-call). Exported for tests. */
+export function resolveSerializeConfig(): SerializeLogConfig {
+  return {
+    enabled: !envDisabled('TRPC_SERIALIZE_LOG_ENABLED'),
+    slowMs: envNumber('TRPC_SERIALIZE_SLOW_MS', DEFAULT_SLOW_MS, 1),
+    oversizedBytes: envNumber('TRPC_SERIALIZE_OVERSIZED_BYTES', DEFAULT_OVERSIZED_BYTES, 1),
+    floorMs: envNumber('TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS', DEFAULT_SIZE_CHECK_FLOOR_MS, 0),
+    maxPerSec: envNumber('TRPC_SERIALIZE_LOG_MAX_PER_SEC', DEFAULT_MAX_PER_SEC, 1),
+  };
+}
+
+/**
+ * Pure decision: given a measured serialize duration + byte size and the resolved
+ * thresholds, should this serialize be logged? Factored out so the trigger logic
+ * is unit-testable without a real serialize/timer. Fires when the serialize was
+ * slow (loop-blocking) OR its output was oversized.
+ *
+ * NaN-safe: written as `>=` (not `!(<)`) so a NaN duration/size — `NaN >= x` is
+ * false — is rejected rather than slipping through as a null-valued line.
+ */
+export function shouldLogSerialize(args: {
+  serializeMs: number;
+  bytes: number;
+  slowMs: number;
+  oversizedBytes: number;
+}): boolean {
+  const { serializeMs, bytes, slowMs, oversizedBytes } = args;
+  return serializeMs >= slowMs || bytes >= oversizedBytes;
+}
+
+// ---------------------------------------------------------------------------
+// Request-scoped procedure-path context (ALS)
+// ---------------------------------------------------------------------------
+
+export interface SerializeCtx {
+  /** Comma-joined batch procedure path(s) from the request URL, e.g. `image.getInfinite`. */
+  path: string;
+  /** Best-effort tRPC kind derived from the HTTP method ('query' for GET). */
+  type?: string;
+}
+
+const serializeCtxStorage = new AsyncLocalStorage<SerializeCtx>();
+
+/**
+ * Run `fn` with `ctx` as the active serialize-attribution context. Called at the
+ * tRPC HTTP-handler boundary so the (awaited-descendant) serialize step can read
+ * the request's procedure path. Gated on the enabled flag: when disabled this is a
+ * direct `fn()` with NO ALS store created (zero added async-context cost), so the
+ * disarmed request hot path is untouched.
+ */
+export function runWithSerializeCtx<T>(ctx: SerializeCtx, fn: () => T): T {
+  if (envDisabled('TRPC_SERIALIZE_LOG_ENABLED')) return fn();
+  return serializeCtxStorage.run(ctx, fn);
+}
+
+function currentSerializeCtx(): SerializeCtx | undefined {
+  return serializeCtxStorage.getStore();
+}
+
+/**
+ * Derive the SerializeCtx from a Next API request. `req.query.trpc` is the single
+ * `[trpc]` path segment — the comma-joined batch procedure path(s). Method is a
+ * best-effort type hint: a GET is always a query; a POST may be a mutation OR a
+ * method-overridden query (allowMethodOverride), so POST maps to undefined rather
+ * than mislabel it. The path is the load-bearing field.
+ */
+export function serializeCtxFromRequest(req: {
+  query?: Partial<{ trpc: string | string[] }>;
+  method?: string;
+}): SerializeCtx {
+  const raw = req.query?.trpc;
+  const path = (Array.isArray(raw) ? raw.join('/') : raw) || 'unknown';
+  const type = (req.method || '').toUpperCase() === 'GET' ? 'query' : undefined;
+  return { path, type };
+}
+
+// ---------------------------------------------------------------------------
+// Per-pod path-diverse rate limiter (mirrors trpc-slow-log.ts)
+// ---------------------------------------------------------------------------
+
+let rlWindowStartMs = 0;
+let rlCountThisWindow = 0;
+let rlDroppedSinceEmit = 0;
+let rlSeenPaths = new Set<string>();
+
+/**
+ * Per-window, path-aware gate. Emits each distinct `path` at most once per 1s
+ * window (a repeat carries no new "which-procedure" signal), with a hard ceiling
+ * backstop. Returns the count suppressed-by-ceiling since the last EMITTED line
+ * (to attach as `droppedSinceLastLog`), or -1 if THIS call must be suppressed.
+ */
+function rateGate(path: string, maxPerSec: number, now: number = Date.now()): number {
+  if (now - rlWindowStartMs >= 1000) {
+    rlWindowStartMs = now;
+    rlCountThisWindow = 0;
+    rlSeenPaths.clear();
+  }
+  if (rlSeenPaths.has(path)) return -1;
+  if (rlCountThisWindow >= maxPerSec) {
+    rlDroppedSinceEmit++;
+    return -1;
+  }
+  rlSeenPaths.add(path);
+  rlCountThisWindow++;
+  const carried = rlDroppedSinceEmit;
+  rlDroppedSinceEmit = 0;
+  return carried;
+}
+
+// ---------------------------------------------------------------------------
+// Byte-size measurement (only ever called above the floor — never common path)
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialized byte size of the superjson output. `result` is already a JSON-safe
+ * plain object ({ json, meta }) produced by superjson.serialize, so this is a
+ * single JSON.stringify walk — the closest cheap proxy for the wire payload size.
+ * NEVER runs on the common path (gated behind the duration floor). Returns
+ * undefined if stringify fails, so a size-measurement failure never blocks a
+ * duration-based log.
+ */
+function safeByteLength(result: unknown): number | undefined {
+  try {
+    return Buffer.byteLength(JSON.stringify(result) ?? '', 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Emit (fire-and-forget, injectable sink for tests)
+// ---------------------------------------------------------------------------
+
+export interface SerializeLogPayload {
+  path: string;
+  bytes: number | undefined;
+  serializeMs: number;
+  procedureType?: string;
+  slowMs: number;
+  oversizedBytes: number;
+  droppedSinceLastLog: number;
+}
+
+type EmitSink = (payload: SerializeLogPayload) => void;
+
+let emitSink: EmitSink | undefined;
+
+/** TEST-ONLY: capture emitted payloads instead of shipping to Axiom. */
+export function __setEmitSinkForTests(sink: EmitSink | undefined): void {
+  emitSink = sink;
+}
+
+const pendingEmits = new Set<Promise<void>>();
+
+/** TEST-ONLY: resolve once every in-flight fire-and-forget emit tail has settled. */
+export function __flushPendingEmitsForTest(): Promise<void> {
+  return Promise.allSettled([...pendingEmits]).then(() => undefined);
+}
+
+/** TEST-ONLY: reset the per-pod rate-limiter window so tests don't share state. */
+export function __resetRateLimitForTests(): void {
+  rlWindowStartMs = 0;
+  rlCountThisWindow = 0;
+  rlDroppedSinceEmit = 0;
+  rlSeenPaths.clear();
+}
+
+/** TEST-ONLY: drive `rateGate` with an explicit clock for deterministic assertions. */
+export function __rateGateForTest(path: string, maxPerSec: number, now: number): number {
+  return rateGate(path, maxPerSec, now);
+}
+
+function emit(payload: SerializeLogPayload): void {
+  if (typeof window !== 'undefined') return; // defensive server-only guard
+  if (emitSink) {
+    emitSink(payload);
+    return;
+  }
+  const tail = (async () => {
+    try {
+      const body: Record<string, unknown> = {
+        name: 'trpc-response-oversized',
+        type: 'warning',
+        path: payload.path,
+        serializeMs: payload.serializeMs,
+        slowThresholdMs: payload.slowMs,
+        oversizedThresholdBytes: payload.oversizedBytes,
+      };
+      if (payload.bytes != null) body.bytes = payload.bytes;
+      if (payload.procedureType) body.procedureType = payload.procedureType;
+      if (payload.droppedSinceLastLog > 0) body.droppedSinceLastLog = payload.droppedSinceLastLog;
+
+      const { logToAxiom } = await import('~/server/logging/client');
+      await logToAxiom(body);
+    } catch {
+      // Logging failure must never surface.
+    }
+  })();
+  pendingEmits.add(tail);
+  void tail.finally(() => pendingEmits.delete(tail));
+}
+
+// ---------------------------------------------------------------------------
+// The serialize wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Wrap the tRPC transformer's `serialize`. Times the serialize (always — two
+ * timestamps), and ONLY when it crosses the cheap duration floor measures the
+ * output byte size and, if slow OR oversized, emits ONE rate-limited structured
+ * log naming the procedure path (from the request-scoped ALS ctx). Returns the
+ * raw serialize result unchanged; a serialize throw propagates unchanged (timed
+ * in `finally`, but a throw skips the size/log tail since there is no output).
+ *
+ * @param rawSerialize the real serialize (e.g. `() => superjson.serialize(data)`,
+ *                      optionally wrapped in the existing withSpan). Its return
+ *                      value is passed through verbatim.
+ */
+export function instrumentSerialize<T>(rawSerialize: () => T): T {
+  const cfg = resolveSerializeConfig();
+  if (!cfg.enabled) return rawSerialize();
+
+  const startedAt = performance.now();
+  const result = rawSerialize();
+  const serializeMs = performance.now() - startedAt;
+
+  // Cheap common-path exit: a sub-floor serialize is neither loop-blocking nor
+  // oversized-enough-to-matter — no byte walk, no log.
+  if (!(serializeMs >= cfg.floorMs)) return result;
+
+  try {
+    const bytes = safeByteLength(result);
+    if (!shouldLogSerialize({ serializeMs, bytes: bytes ?? 0, slowMs: cfg.slowMs, oversizedBytes: cfg.oversizedBytes })) {
+      return result;
+    }
+    const ctx = currentSerializeCtx();
+    const path = ctx?.path ?? 'unknown';
+    const dropped = rateGate(path, cfg.maxPerSec);
+    if (dropped < 0) return result; // suppressed (dup-this-window or ceiling)
+    emit({
+      path,
+      bytes,
+      serializeMs: Math.round(serializeMs * 100) / 100,
+      procedureType: ctx?.type,
+      slowMs: cfg.slowMs,
+      oversizedBytes: cfg.oversizedBytes,
+      droppedSinceLastLog: dropped,
+    });
+  } catch {
+    // Instrumentation must never throw into the serialize path.
+  }
+  return result;
+}

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -12,6 +12,7 @@ import {
 import { trpcProcedureDuration } from '~/server/prom/client';
 import { maybeLogTrpcSlow } from '~/server/logging/trpc-slow-log';
 import { longTaskLabelsArmed, runWithLongTaskLabel } from '~/server/eventloop-longtask';
+import { instrumentSerialize } from '~/server/logging/trpc-serialize-log';
 import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
@@ -44,8 +45,14 @@ const t = initTRPC
   .meta<TRPCMeta>()
   .create({
     transformer: {
+      // instrumentSerialize times the serialize (the exact frame that pegs the
+      // loop on an oversized response — see trpc-serialize-log.ts) and, only above
+      // a cheap duration floor, logs the offending procedure + byte size. Disarmed
+      // by default: a single boolean branch, then the original withSpan+superjson.
       serialize: (data: any) =>
-        withSpan('trpc:serialize:superjson', () => superjson.serialize(data)),
+        instrumentSerialize(() =>
+          withSpan('trpc:serialize:superjson', () => superjson.serialize(data))
+        ),
       deserialize: superjson.deserialize.bind(superjson),
     },
     errorFormatter({ shape }) {


### PR DESCRIPTION
## What & why

`civitai-dp-prod-api-primary` 504/499 bursts (2026-07-09 ~02:25 and ~08:49 UTC) trace to **an oversized tRPC response serialized synchronously (superjson) on the single JS thread**, pegging the event loop ~6s and starving every other in-flight request on the pod (one pod, `ttxc5`, froze ~5 min and was liveness-killed). Two captured V8 CPU profiles show the spin dominated by:

```
resolveResponse → transformTRPCResponse → transformTRPCResponseItem
  → serialize (app transformer, trpc.ts)
    → withSpan('trpc:serialize:superjson') → superjson.serialize   ← recursive walk (the peg)
  + heavy (garbage collector)                                       ← LOW heap = allocation churn, not a leak
```

**The blind spot this closes:** the existing `trpc-slow-log.ts` times the **resolver** (middleware chain + `next()`), but this block happens in **response serialization *after* the resolver returns** — so the whole class is invisible and the offending procedure can't be named.

## The change (instrumentation only)

Always-on, threshold-gated instrumentation of the serialize step. It wraps the transformer's `serialize` (the exact blocking frame — `src/server/trpc.ts`) and, **only above a cheap duration floor**, measures the serialized byte size and emits **one** structured `logToAxiom` line on a slow **or** oversized serialize:

```
{ name: 'trpc-response-oversized', path, bytes, serializeMs, procedureType, slowThresholdMs, oversizedThresholdBytes }
```
Query: `{namespace="civitai-dp-prod"} | json | name="trpc-response-oversized"`

**Hook (`src/server/trpc.ts:46`):** the transformer `serialize` is exactly `serialize@src_server_1a47e1f._.js → withSpan → superjson j@_07i4tsr._.js` in the profiles — i.e. the precise frame that pegs the loop. Wrapping it captures both the true serialize **duration** and the output **byte size** at the source.

**Procedure-path correlation:** the transformer receives only the payload — tRPC doesn't thread the path into it, and there's no always-on OTEL procedure span here (OTEL is opt-in + 10%-sampled, inbound-HTTP + manual `withSpan` only). So the path is carried via a request-scoped `AsyncLocalStorage` seeded at the tRPC HTTP-handler boundary (`src/pages/api/trpc/[trpc].ts`) from `req.query.trpc` (the comma-joined batch path already in the URL), read synchronously inside serialize (an awaited descendant of the handler) — **no async_hooks / per-resource cost**. Batches are ~99% single-procedure, so `path` is almost always the exact culprit; for a multi-proc batch it's the small candidate set (the oversized one is the slow serialize).

## Thresholds (env-overridable, justified)

| Env | Default | Why |
|---|---|---|
| `TRPC_SERIALIZE_LOG_ENABLED` | on | kill-switch; only explicit `false/0/no/off` disables |
| `TRPC_SERIALIZE_SLOW_MS` | `250` | authoritative loop-blocking trigger. Normal serialize is sub-ms; incident was ~6000ms. Matches the task's 200–250ms band and the sibling duration-gated convention. |
| `TRPC_SERIALIZE_OVERSIZED_BYTES` | `1048576` (1 MiB) | proactive size trigger even if it serialized under `SLOW_MS`. Request body limit is 17mb; a 1 MiB **response** is already the danger zone under concurrency. (512KB was rejected as too noisy — image feeds legitimately approach it.) |
| `TRPC_SERIALIZE_SIZE_CHECK_FLOOR_MS` | `50` | the cheap gate — below this serialize duration we do **no** byte walk and **no** log. Anything loop-blocking or oversized-enough-to-matter takes ≥ this to superjson-walk, so the floor drops no actionable event while keeping the 1500 req/s common path a cheap constant-time gate (two `performance.now()` reads + one numeric compare, no byte walk). Lower toward 0 during a hunt to widen the size trigger. |
| `TRPC_SERIALIZE_LOG_MAX_PER_SEC` | `50` | per-pod path-diverse ceiling (storm guard) |

## Guarantees (mirrors `trpc-slow-log.ts` / `eventloop-longtask.ts`)

- **Cheap common path.** Per serialize the enabled path pays a kill-switch check, a **cached**-config read (config is resolved once and refreshed on a 5 s interval, not rebuilt per call), two `performance.now()` reads and one numeric compare; below the floor it returns immediately — no byte walk, no per-call allocation, no log. **Never double-serializes** the common (small-response) path.
- **Byte walk never runs per-occurrence on the incident path.** `safeByteLength` is a *second* O(payload) `JSON.stringify` (a multi-MB alloc for the monster responses this catches), so it is ordered **after** the trigger + rate gate: for the loop-blocking case (`serializeMs >= slowMs`) duration alone decides and the byte size is computed only *after* the gate allows an emit (≤ `MAX_PER_SEC`/window, informational); it is a decision input only in the moderate band (`floorMs ≤ serializeMs < slowMs`, the smaller payloads). A slow-serialize **wave** therefore never pays the second stringify once-per-occurrence on the already-blocked thread.
- **Disarmed** (`TRPC_SERIALIZE_LOG_ENABLED` off) is byte-for-byte the prior path — the kill-switch is checked **first**, before any config is built, in a single boolean branch; the ALS wrapper at the boundary is skipped.
- Never throws, never delays the request; the serialize is timed **inline** (not in a `finally`), so a serialize throw propagates unchanged and correctly skips timing + logging. Logs only the procedure path + size + duration — **no payload / PII**. (`path` is the client-controlled `req.query.trpc` URL segment; safe because `logToAxiom` JSON-encodes it and it carries no PII beyond the requested procedure path.)

## Task 1 — can the profiles name the culprit? Honest answer: **inconclusive**

The serialize subtree in both profiles is **pure superjson recursion over an opaque object** — zero procedure-identifying frames below `serialize`. The concurrently-running app frames in the unblock window are dominated by `feature-flags.service` (`getFeatureFlags`, runs on ~every request), `cache-helpers`, and faintly `model_controller` / `model-version_controller` / `image_schema` — but those are just what else was executing, **not** provably the offender. Weak circumstantial lean toward a large model/image feed response, but not enough to name it. **This PR is the instrument that will name it deterministically on the next occurrence** — that log line is the intended first-fix target.

## Audit fixes (revision 2)

An adversarial audit found the design sound (never fails a request, ALS scope correct, no double-serialize on the common path) but flagged three hot-path costs and some stale comments — all fixed here:

- **FIX 1 (byte walk amplified the incident it measures):** the full `Buffer.byteLength(JSON.stringify(result))` ran *before* the rate gate, so on an oversized-response wave every occurrence paid a second O(payload) stringify on the already-blocked thread. Reordered so duration-qualified (`serializeMs >= slowMs`) logs gate **first** and compute bytes only after an emit is allowed; bytes are a decision input only in the moderate `floorMs ≤ serializeMs < slowMs` band. See the "byte walk never runs per-occurrence" guarantee above.
- **FIX 2 (config allocated every call):** `resolveSerializeConfig()` read 5 env vars + allocated a fresh object per serialize (several thousand/s). Now cached and refreshed on a 5 s interval (env overrides still take effect within the window).
- **FIX 3 (disabled path still did work):** the kill-switch is now checked first (before any config is built), so the disarmed path is a genuine single boolean branch.
- Nits: corrected the "timed in `finally`" comments (it is timed inline), made the `droppedSinceLastLog` comment accurate about the dedup case, noted the client-controlled-`path` safety, moved the test to the sibling convention `src/server/logging/__tests__/`, and softened the "single numeric compare" wording to what the code does.

## Tests / gate

- Unit test `src/server/logging/__tests__/trpc-serialize-log.test.ts` (**18 cases**): pure trigger decision (fires above slow, fires above oversized, silent below both, NaN-safe), env parsing + kill-switch, path-from-URL correlation, path-diverse rate gate, and end-to-end `instrumentSerialize` (captures path+bytes+serializeMs; silent below floor; disarmed passthrough; `unknown` path outside a request scope; propagates a serialize throw). **+2 new** for the FIX 1 reorder: the byte walk does **not** run per-occurrence when `serializeMs >= slowMs` under rate-limiting (byte-walk count == `MAX_PER_SEC` = 50 across 200 slow serializes, decisively not 200), and the moderate 50–250 ms / >1 MiB case still logs. **18/18 pass.**
- `tsc --noEmit` (repo's `typecheck`, 8 GB heap): **0 errors in the touched files**. The 17 project errors are pre-existing/environmental in the fresh worktree (missing `event-engine-common` sibling dir + `kysely` resolution), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

