### PR TITLE
fix(announcements): SSR-exact dismiss via cookie — durable feed-CLS fix (replaces min-height reserve)

### DIFF
--- a/src/components/Announcements/Announcements.browser.test.tsx
+++ b/src/components/Announcements/Announcements.browser.test.tsx
@@ -113,11 +113,31 @@ describe('Announcements — flag ON, persistent CLS reserve', () => {
     expect(wrapper?.querySelector('[data-testid="carousel"]')).not.toBe(null);
   });
 
-  test('inner carousel momentarily null (all data dismissed post-hydration) → the wrapper STILL holds the min-height (no collapse)', async () => {
-    // Models the migration-first-load transient: server exposed the carousel
-    // (serverExposedCount>0) so the wrapper is committed, but the just-migrated
-    // store now marks every announcement dismissed → the INNER goes null. The
-    // persistent parent must remain with its min-height so the feed never shifts.
+  test('post-hydration steady state (non-dismissed, isClient=true) → wrapper still present with the carousel', async () => {
+    // After hydration the gate follows LIVE state; with an active announcement the
+    // reserve stays put (no flicker).
+    mocks.hook = {
+      data: [{ id: 1, dismissed: false }],
+      seededCount: 1,
+      serverExposedCount: 1,
+      exposeSSR: true,
+      isClient: true,
+    };
+    renderWithProviders(<Announcements className="mb-3" />);
+    const carousel = page.getByTestId('carousel');
+    await expect.element(carousel).toBeInTheDocument();
+    const wrapper = document.querySelector(RESERVE);
+    expect(wrapper).not.toBe(null);
+    expect(wrapper?.className).toContain(RESERVE_MIN_H);
+    expect(wrapper?.querySelector('[data-testid="carousel"]')).not.toBe(null);
+  });
+
+  test('LIVE DISMISS of the last announcement (post-hydration, announcements now empty) → wrapper REMOVED, NO lingering dead space', async () => {
+    // The server exposed the carousel (serverExposedCount>0), but post-hydration
+    // (isClient=true) the user has dismissed the last announcement so the live
+    // `announcements` set is empty. The live-state gate must DROP the persistent
+    // min-height wrapper so the reserved space collapses immediately (rather than
+    // lingering until a reload) — a user-initiated collapse, excluded from CLS.
     mocks.hook = {
       data: [{ id: 1, dismissed: true }],
       seededCount: 1,
@@ -126,14 +146,28 @@ describe('Announcements — flag ON, persistent CLS reserve', () => {
       isClient: true,
     };
     renderWithProviders(<Announcements className="mb-3" />);
-    await expect.poll(() => document.querySelector(RESERVE)).not.toBe(null);
-    const wrapper = document.querySelector(RESERVE);
-    // Height floor held...
-    expect(wrapper?.className).toContain(RESERVE_MIN_H);
-    // ...but the inner carousel is gone (no dead visible banner), and the empty
-    // reserved box is hidden from assistive tech.
-    expect(wrapper?.querySelector('[data-testid="carousel"]')).toBe(null);
-    expect(wrapper?.getAttribute('aria-hidden')).toBe('true');
+    await expect.poll(() => document.querySelector(RESERVE)).toBe(null);
+    // No wrapper AND no carousel → the space is fully released.
+    expect(document.querySelector('[data-testid="carousel"]')).toBe(null);
+  });
+
+  test('LIVE DISMISS of ONE of several (post-hydration, one still visible) → wrapper KEPT', async () => {
+    // Dismissing one announcement when others remain must NOT collapse the reserve
+    // (live length still > 0).
+    mocks.hook = {
+      data: [
+        { id: 1, dismissed: true },
+        { id: 2, dismissed: false },
+      ],
+      seededCount: 2,
+      serverExposedCount: 2,
+      exposeSSR: true,
+      isClient: true,
+    };
+    renderWithProviders(<Announcements className="mb-3" />);
+    const carousel = page.getByTestId('carousel');
+    await expect.element(carousel).toBeInTheDocument();
+    expect(document.querySelector(RESERVE)).not.toBe(null);
   });
 
   test('server saw the announcement as DISMISSED (serverExposedCount 0) → NO wrapper, NO dead space', async () => {

--- a/src/components/Announcements/Announcements.browser.test.tsx
+++ b/src/components/Announcements/Announcements.browser.test.tsx
@@ -4,39 +4,26 @@ import { page } from 'vitest/browser';
 import { renderWithProviders } from '../../../test/component-setup';
 
 /**
- * Announcements CLS reserve — component tests for the flag-gated space
- * reservation that stops the above-feed announcement banner from displacing the
- * tall masonry feed on load (the shift production RUM mis-attributes to
- * `MasonryContainer .queries`, the displaced victim).
+ * `Announcements` component contract AFTER the durable feed-CLS fix.
  *
- * Load-bearing behaviours:
- *   1. Flag OFF ⇒ current behaviour exactly (null when nothing to show; the
- *      carousel with no wrapper when there is — no reserved space, ever).
- *   2. Flag ON + a seeded `site` announcement + PRE-hydration (isClient=false) ⇒
- *      a PERSISTENT parent holding a responsive min-height (mobile 203 / desktop
- *      162), spacer inside.
- *   3. The SAME persistent parent (holding the min-height) is present once the
- *      carousel mounts — so the space is held continuously across the
- *      spacer→carousel swap (no collapse gap / double-shift while the dynamic
- *      chunk resolves).
- *   4. Flag ON + POST-hydration with everything dismissed ⇒ release the reserve
- *      (no permanent dead space for a dismisser).
- *   5. Reserve is scoped to `type === 'site'` — generator/training placements
- *      (above a form/wizard, not the feed) never reserve.
+ * The min-height reserve is GONE — the feed-CLS treatment now lives in
+ * `useGetAnnouncements` (SSR-exact render, gated on `feedReserveCls`, verified by
+ * the pure `announcements-exposure` + `announcements-dismissed-cookie` unit
+ * suites). This component is now a thin renderer: it shows the carousel iff the
+ * hook exposes a non-dismissed announcement, else nothing — and NEVER a reserve
+ * placeholder. These tests pin that contract at the component boundary.
+ *
+ * `useGetAnnouncements` is mocked so its (already unit-tested) internal
+ * flag/hydration logic is decoupled from the component's job.
  */
 
-// Per-test-controllable hook outputs (vi.mock is hoisted above imports).
+// Per-test-controllable hook output (vi.mock is hoisted above imports).
 const mocks = vi.hoisted(() => ({
-  feedReserveCls: false,
   hook: {
     data: [] as Array<{ id: number; dismissed: boolean }>,
     seededCount: 0,
     isClient: false,
   },
-}));
-
-vi.mock('~/providers/FeatureFlagsProvider', () => ({
-  useFeatureFlags: () => ({ feedReserveCls: mocks.feedReserveCls }),
 }));
 
 vi.mock('~/components/Announcements/announcements.utils', () => ({
@@ -51,17 +38,23 @@ vi.mock('~/components/Announcements/AnnouncementsCarousel', () => ({
 // Imported AFTER the mocks are registered.
 import { Announcements } from '~/components/Announcements/Announcements';
 
-const RESERVE_CLASSES = ['min-h-[203px]', 'md:min-h-[162px]'];
-
 beforeEach(() => {
-  mocks.feedReserveCls = false;
   mocks.hook = { data: [], seededCount: 0, isClient: false };
 });
 
-describe('Announcements CLS reserve', () => {
-  test('flag OFF, pre-hydration, seeded announcement → renders nothing (no reserve, no wrapper)', async () => {
-    mocks.feedReserveCls = false;
+describe('Announcements (reserve-free renderer)', () => {
+  test('no exposed announcements → renders nothing (and never a reserve placeholder)', async () => {
     mocks.hook = { data: [], seededCount: 1, isClient: false };
+    renderWithProviders(<Announcements className="mb-3" />);
+    // Give any async mount a beat, then assert nothing rendered.
+    await expect
+      .poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]'))
+      .toBe(null);
+    expect(document.querySelector('[data-testid="carousel"]')).toBe(null);
+  });
+
+  test('all exposed announcements dismissed → renders nothing (no dead space)', async () => {
+    mocks.hook = { data: [{ id: 1, dismissed: true }], seededCount: 1, isClient: true };
     renderWithProviders(<Announcements className="mb-3" />);
     await expect
       .poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]'))
@@ -69,61 +62,22 @@ describe('Announcements CLS reserve', () => {
     expect(document.querySelector('[data-testid="carousel"]')).toBe(null);
   });
 
-  test('flag ON, pre-hydration, seeded site announcement → persistent parent holds responsive min-height (spacer inside)', async () => {
-    mocks.feedReserveCls = true;
-    mocks.hook = { data: [], seededCount: 1, isClient: false };
-    renderWithProviders(<Announcements className="mb-3" />);
-    const reserve = page.getByTestId('announcements-cls-reserve');
-    await expect.element(reserve).toBeInTheDocument();
-    const el = reserve.element() as HTMLElement;
-    // Reserves the LARGER (mobile) height, with a desktop override — never under-reserves.
-    for (const cls of RESERVE_CLASSES) expect(el.className).toContain(cls);
-    // Spacer state: hidden from a11y, no carousel inside yet, pass-through spacing preserved.
-    expect(el.getAttribute('aria-hidden')).toBe('true');
-    expect(el.querySelector('[data-testid="carousel"]')).toBe(null);
-    expect(el.className).toContain('mb-3');
-  });
-
-  test('flag ON, visible announcement → SAME persistent parent still holds min-height, now wrapping the carousel', async () => {
-    mocks.feedReserveCls = true;
-    mocks.hook = { data: [{ id: 1, dismissed: false }], seededCount: 1, isClient: true };
-    renderWithProviders(<Announcements className="mb-3" />);
-    const reserve = page.getByTestId('announcements-cls-reserve');
-    await expect.element(reserve).toBeInTheDocument();
-    const el = reserve.element() as HTMLElement;
-    // The min-height is held by the SAME parent across the swap → no collapse gap.
-    for (const cls of RESERVE_CLASSES) expect(el.className).toContain(cls);
-    // Carousel is now nested INSIDE the persistent parent, and content is not aria-hidden.
-    expect(el.querySelector('[data-testid="carousel"]')).not.toBe(null);
-    expect(el.getAttribute('aria-hidden')).toBe(null);
-  });
-
-  test('flag ON, post-hydration, all dismissed → releases reserve (no dead space)', async () => {
-    mocks.feedReserveCls = true;
-    mocks.hook = { data: [], seededCount: 1, isClient: true };
-    renderWithProviders(<Announcements className="mb-3" />);
-    await expect
-      .poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]'))
-      .toBe(null);
-    expect(document.querySelector('[data-testid="carousel"]')).toBe(null);
-  });
-
-  test('flag ON but type !== "site" (generator) → no reserve (scoped to the feed placement)', async () => {
-    mocks.feedReserveCls = true;
-    mocks.hook = { data: [], seededCount: 1, isClient: false };
-    renderWithProviders(<Announcements type="generator" />);
-    await expect
-      .poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]'))
-      .toBe(null);
-  });
-
-  test('flag OFF, visible announcement → carousel renders directly, WITHOUT the reserve wrapper (unchanged)', async () => {
-    mocks.feedReserveCls = false;
+  test('a non-dismissed announcement → renders the carousel directly (no reserve wrapper)', async () => {
     mocks.hook = { data: [{ id: 1, dismissed: false }], seededCount: 1, isClient: true };
     renderWithProviders(<Announcements className="mb-3" />);
     const carousel = page.getByTestId('carousel');
     await expect.element(carousel).toBeInTheDocument();
-    // No persistent reserve parent in the flag-off path.
+    // No reserve placeholder wrapper in any path.
+    expect(document.querySelector('[data-testid="announcements-cls-reserve"]')).toBe(null);
+  });
+
+  test('SSR-exact case: a non-dismissed announcement exposed pre-hydration (isClient=false) → carousel already present (renders from server HTML, no post-hydration insert)', async () => {
+    // This is the flag-ON server/first-paint shape the hook now produces for a
+    // non-dismisser: data exposed even though isClient=false.
+    mocks.hook = { data: [{ id: 1, dismissed: false }], seededCount: 1, isClient: false };
+    renderWithProviders(<Announcements className="mb-3" />);
+    const carousel = page.getByTestId('carousel');
+    await expect.element(carousel).toBeInTheDocument();
     expect(document.querySelector('[data-testid="announcements-cls-reserve"]')).toBe(null);
   });
 });

--- a/src/components/Announcements/Announcements.browser.test.tsx
+++ b/src/components/Announcements/Announcements.browser.test.tsx
@@ -4,33 +4,44 @@ import { page } from 'vitest/browser';
 import { renderWithProviders } from '../../../test/component-setup';
 
 /**
- * `Announcements` component contract AFTER the durable feed-CLS fix.
+ * `Announcements` component contract for the combined feed-CLS fix: #3018's
+ * SSR-exact dismiss (carousel — or nothing — from server HTML, driven by the
+ * cookie via `useGetAnnouncements`) PLUS #3000's anti-collapse mechanism (a
+ * PERSISTENT `min-h` parent that stays mounted across the SSR→hydration handoff).
  *
- * The min-height reserve is GONE — the feed-CLS treatment now lives in
- * `useGetAnnouncements` (SSR-exact render, gated on `feedReserveCls`, verified by
- * the pure `announcements-exposure` + `announcements-dismissed-cookie` unit
- * suites). This component is now a thin renderer: it shows the carousel iff the
- * hook exposes a non-dismissed announcement, else nothing — and NEVER a reserve
- * placeholder. These tests pin that contract at the component boundary.
- *
- * `useGetAnnouncements` is mocked so its (already unit-tested) internal
- * flag/hydration logic is decoupled from the component's job.
+ * The hydration/flag logic of `useGetAnnouncements` is unit-tested by the pure
+ * `announcements-exposure` + `announcements-dismissed-cookie` suites, so it is
+ * mocked here — these tests pin the COMPONENT's job: when does the persistent
+ * reserve wrapper appear, and does the min-height floor hold when the inner
+ * carousel is momentarily null.
  */
 
+const RESERVE = '[data-testid="announcements-cls-reserve"]';
+const RESERVE_MIN_H = 'min-h-[203px]';
+
 // Per-test-controllable hook output (vi.mock is hoisted above imports).
+type HookShape = {
+  data: Array<{ id: number; dismissed: boolean }>;
+  seededCount: number;
+  serverExposedCount: number;
+  exposeSSR: boolean;
+  isClient: boolean;
+};
 const mocks = vi.hoisted(() => ({
   hook: {
     data: [] as Array<{ id: number; dismissed: boolean }>,
     seededCount: 0,
+    serverExposedCount: 0,
+    exposeSSR: false,
     isClient: false,
-  },
+  } as HookShape,
 }));
 
 vi.mock('~/components/Announcements/announcements.utils', () => ({
   useGetAnnouncements: () => mocks.hook,
 }));
 
-// Stub the dynamically-imported carousel so tests stay network/Embla-free.
+// Stub the (now statically-imported) carousel so tests stay network/Embla-free.
 vi.mock('~/components/Announcements/AnnouncementsCarousel', () => ({
   default: () => <div data-testid="carousel" />,
 }));
@@ -39,45 +50,105 @@ vi.mock('~/components/Announcements/AnnouncementsCarousel', () => ({
 import { Announcements } from '~/components/Announcements/Announcements';
 
 beforeEach(() => {
-  mocks.hook = { data: [], seededCount: 0, isClient: false };
+  mocks.hook = {
+    data: [],
+    seededCount: 0,
+    serverExposedCount: 0,
+    exposeSSR: false,
+    isClient: false,
+  };
 });
 
-describe('Announcements (reserve-free renderer)', () => {
-  test('no exposed announcements → renders nothing (and never a reserve placeholder)', async () => {
-    mocks.hook = { data: [], seededCount: 1, isClient: false };
+describe('Announcements — flag OFF / non-exposed (byte-identical to pre-fix)', () => {
+  test('flag OFF, no exposed data → renders nothing, NO reserve wrapper', async () => {
+    mocks.hook = {
+      data: [],
+      seededCount: 1,
+      serverExposedCount: 0,
+      exposeSSR: false,
+      isClient: false,
+    };
     renderWithProviders(<Announcements className="mb-3" />);
     // Give any async mount a beat, then assert nothing rendered.
-    await expect
-      .poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]'))
-      .toBe(null);
+    await expect.poll(() => document.querySelector(RESERVE)).toBe(null);
     expect(document.querySelector('[data-testid="carousel"]')).toBe(null);
   });
 
-  test('all exposed announcements dismissed → renders nothing (no dead space)', async () => {
-    mocks.hook = { data: [{ id: 1, dismissed: true }], seededCount: 1, isClient: true };
+  test('flag OFF, a non-dismissed announcement (post-hydration) → carousel directly, NO reserve wrapper', async () => {
+    mocks.hook = {
+      data: [{ id: 1, dismissed: false }],
+      seededCount: 1,
+      serverExposedCount: 0,
+      exposeSSR: false,
+      isClient: true,
+    };
     renderWithProviders(<Announcements className="mb-3" />);
-    await expect
-      .poll(() => document.querySelector('[data-testid="announcements-cls-reserve"]'))
-      .toBe(null);
+    const carousel = page.getByTestId('carousel');
+    await expect.element(carousel).toBeInTheDocument();
+    expect(document.querySelector(RESERVE)).toBe(null);
+  });
+});
+
+describe('Announcements — flag ON, persistent CLS reserve', () => {
+  test('server saw a non-dismissed announcement → persistent min-height wrapper WITH the carousel inside', async () => {
+    // The flag-ON server/first-paint shape for a non-dismisser: exposed data even
+    // though isClient=false, serverExposedCount>0.
+    mocks.hook = {
+      data: [{ id: 1, dismissed: false }],
+      seededCount: 1,
+      serverExposedCount: 1,
+      exposeSSR: true,
+      isClient: false,
+    };
+    renderWithProviders(<Announcements className="mb-3" />);
+    const carousel = page.getByTestId('carousel');
+    await expect.element(carousel).toBeInTheDocument();
+    const wrapper = document.querySelector(RESERVE);
+    expect(wrapper).not.toBe(null);
+    // The min-height floor + the caller className both live on the persistent parent.
+    expect(wrapper?.className).toContain(RESERVE_MIN_H);
+    expect(wrapper?.className).toContain('md:min-h-[162px]');
+    expect(wrapper?.className).toContain('mb-3');
+    // The carousel is a child of the persistent wrapper (not a sibling).
+    expect(wrapper?.querySelector('[data-testid="carousel"]')).not.toBe(null);
+  });
+
+  test('inner carousel momentarily null (all data dismissed post-hydration) → the wrapper STILL holds the min-height (no collapse)', async () => {
+    // Models the migration-first-load transient: server exposed the carousel
+    // (serverExposedCount>0) so the wrapper is committed, but the just-migrated
+    // store now marks every announcement dismissed → the INNER goes null. The
+    // persistent parent must remain with its min-height so the feed never shifts.
+    mocks.hook = {
+      data: [{ id: 1, dismissed: true }],
+      seededCount: 1,
+      serverExposedCount: 1,
+      exposeSSR: true,
+      isClient: true,
+    };
+    renderWithProviders(<Announcements className="mb-3" />);
+    await expect.poll(() => document.querySelector(RESERVE)).not.toBe(null);
+    const wrapper = document.querySelector(RESERVE);
+    // Height floor held...
+    expect(wrapper?.className).toContain(RESERVE_MIN_H);
+    // ...but the inner carousel is gone (no dead visible banner), and the empty
+    // reserved box is hidden from assistive tech.
+    expect(wrapper?.querySelector('[data-testid="carousel"]')).toBe(null);
+    expect(wrapper?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  test('server saw the announcement as DISMISSED (serverExposedCount 0) → NO wrapper, NO dead space', async () => {
+    // A cookie-dismisser: the server-read cookie already filters the only active
+    // announcement, so serverExposedCount is 0 → the reserve must NOT render (no
+    // reserved dead space for people who dismissed).
+    mocks.hook = {
+      data: [{ id: 1, dismissed: true }],
+      seededCount: 1,
+      serverExposedCount: 0,
+      exposeSSR: true,
+      isClient: false,
+    };
+    renderWithProviders(<Announcements className="mb-3" />);
+    await expect.poll(() => document.querySelector(RESERVE)).toBe(null);
     expect(document.querySelector('[data-testid="carousel"]')).toBe(null);
-  });
-
-  test('a non-dismissed announcement → renders the carousel directly (no reserve wrapper)', async () => {
-    mocks.hook = { data: [{ id: 1, dismissed: false }], seededCount: 1, isClient: true };
-    renderWithProviders(<Announcements className="mb-3" />);
-    const carousel = page.getByTestId('carousel');
-    await expect.element(carousel).toBeInTheDocument();
-    // No reserve placeholder wrapper in any path.
-    expect(document.querySelector('[data-testid="announcements-cls-reserve"]')).toBe(null);
-  });
-
-  test('SSR-exact case: a non-dismissed announcement exposed pre-hydration (isClient=false) → carousel already present (renders from server HTML, no post-hydration insert)', async () => {
-    // This is the flag-ON server/first-paint shape the hook now produces for a
-    // non-dismisser: data exposed even though isClient=false.
-    mocks.hook = { data: [{ id: 1, dismissed: false }], seededCount: 1, isClient: false };
-    renderWithProviders(<Announcements className="mb-3" />);
-    const carousel = page.getByTestId('carousel');
-    await expect.element(carousel).toBeInTheDocument();
-    expect(document.querySelector('[data-testid="announcements-cls-reserve"]')).toBe(null);
   });
 });

--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -1,39 +1,58 @@
 import { useGetAnnouncements } from '~/components/Announcements/announcements.utils';
 import React from 'react';
-import dynamic from 'next/dynamic';
+import clsx from 'clsx';
+// STATIC import (was `dynamic()`): the carousel is SSR-rendered above the fold in
+// the exposed case, so lazy-loading it only adds a client chunk-load gap where the
+// dynamic component renders `null` until its chunk resolves — an unmount that
+// collapses the reserved height and shifts the feed up, then remounts and shifts
+// it back (the exact double-CLS this fix targets). Importing it statically bundles
+// it with the initial render, so it is present from frame 0 with no load gap.
+// AnnouncementsCarousel is SSR-safe (embla only touches the DOM in effects; no
+// render-time window/document/matchMedia).
+import AnnouncementsCarousel from '~/components/Announcements/AnnouncementsCarousel';
 import type { AnnouncementType } from '~/server/schema/announcement.schema';
 
-// ssr:true (the default) so, when `useGetAnnouncements` exposes the dismissed
-// data server-side (flag ON, `site` placement), the REAL carousel lands in the
-// initial server HTML at its true height — the durable feed-CLS fix. Next
-// preloads the chunk for the initial render so hydration matches (no flash).
-const AnnouncementsCarousel = dynamic(
-  () => import('~/components/Announcements/AnnouncementsCarousel')
-);
+// Responsive reserved height for one announcement carousel slide, measured from
+// production (#3000): ~162px on desktop, ~203px on mobile (title/markdown/button-
+// row wrap taller in a narrow column). The persistent parent below carries this
+// min-height floor so the reserved space is held CONTINUOUSLY even if the inner
+// carousel EVER momentarily renders null across the SSR→hydration handoff — no
+// 162→0→162 collapse, so the tall masonry feed below never reflows. Written as
+// literal Tailwind classes so JIT emits them; tune here.
+const ANNOUNCEMENT_RESERVE_CLASS = 'min-h-[203px] md:min-h-[162px]';
 
 /**
  * Above-feed announcement banner.
  *
- * The feed-CLS treatment is fully driven by `useGetAnnouncements`:
- *   - `feedReserveCls` ON + `type === 'site'`: the hook exposes the dismissed data
- *     on the server + first client paint (both read the same cookie), so this
- *     renders the real carousel — or nothing, if the active announcement is
- *     dismissed — directly into the SSR HTML. No placeholder reserve, and (for the
- *     steady state) no post-hydration collapse — the net-negative mechanism this
- *     replaces.
- *   - Flag OFF / non-`site`: the hook keeps the `isClient` gate, so `data` is empty
- *     on the server + first client paint and this renders `null` there, exactly as
- *     before — byte-identical.
+ * The feed-CLS treatment combines #3018's SSR-exact dismiss (the carousel — or
+ * nothing — lands in the initial server HTML, driven by the server-read cookie via
+ * `useGetAnnouncements`) with #3000's anti-collapse mechanism (a PERSISTENT
+ * min-height parent that stays mounted across the SSR→hydration handoff):
  *
- * ONE bounded exception to "no post-hydration collapse": a user who dismissed a
- * STILL-ACTIVE announcement under the OLD localStorage bundle, on their FIRST load
- * of the new bundle with the flag ON. The localStorage→cookie migration only runs
- * CLIENT-side, so on that first load there is no cookie server-side → the seed is
- * empty → SSR + first client paint expose the carousel, then post-hydration the
- * (just-migrated) store filters it out = one upward shift. This is NOT a hydration
- * error (first paint == SSR, both off the empty server seed); it self-heals on the
- * 2nd load (the cookie now exists, so SSR renders nothing) and is scoped to the
- * flag's audience (mod-only today) + the rollout window. Accepted trade-off.
+ *   - `feedReserveCls` ON + `type === 'site'` + the SERVER saw a non-dismissed
+ *     announcement (`serverExposedCount > 0`): render the REAL carousel inside a
+ *     persistent `min-h` parent. The wrapper's existence is decided from the SSR
+ *     seed (`exposeSSR` is a base/host-level flag held in `useState` — stable, NOT
+ *     a laggy per-user overlay — and `serverExposedCount` rides the SSR snapshot),
+ *     so it is IDENTICAL on the server render and the first client paint and never
+ *     unmounts on a client transient. The `min-h` floor holds the space even if the
+ *     inner carousel briefly renders null, so the feed never collapses. In steady
+ *     state the carousel fills ~162px, so there is no dead space beyond the floor.
+ *   - Flag OFF / non-`site` / server saw nothing (or saw it dismissed): NO wrapper.
+ *     Byte-identical to today — the hook's `isClient` gate zeroes `data` on the
+ *     server + first client paint, so this renders `null` there exactly as before,
+ *     and a server-side dismisser reserves NO dead space.
+ *
+ * ONE bounded exception (unchanged from #3018): a user who dismissed a STILL-ACTIVE
+ * announcement under the OLD localStorage bundle, on their FIRST load of the new
+ * bundle with the flag ON. The localStorage→cookie migration runs CLIENT-side only,
+ * so on that first load there is no cookie server-side → the seed is empty →
+ * `serverExposedCount > 0` → SSR + first client paint render the carousel inside the
+ * reserve; post-hydration the just-migrated store filters it out and the inner goes
+ * null — but the persistent `min-h` parent HOLDS the height, so there is no feed
+ * shift (strictly better than the pre-fix double-shift). Not a hydration error
+ * (first paint == SSR, both off the empty server seed); self-heals on the 2nd load
+ * (the cookie now exists → `serverExposedCount` 0 → no wrapper, no dead space).
  */
 export function Announcements({
   className,
@@ -42,10 +61,34 @@ export function Announcements({
   className?: string;
   type?: AnnouncementType;
 }) {
-  const { data } = useGetAnnouncements(type);
+  const { data, exposeSSR, serverExposedCount } = useGetAnnouncements(type);
 
   const announcements = data.filter((x) => !x.dismissed);
 
+  // PERSISTENT reserve parent. Gated on a hydration-STABLE, seed-driven decision
+  // (`exposeSSR` base flag + `serverExposedCount` from the SSR snapshot) so this
+  // exact <div> — same element type, same tree position, no changing `key` —
+  // renders in the SSR HTML and STAYS mounted from server → hydration → steady
+  // state. Only the INNER content can swap (carousel ⇆ null), and the min-height
+  // lives on THIS parent, so the reserved space is held continuously with no
+  // collapse gap. Server + first client paint agree on both the wrapper and its
+  // contents (the hook exposes the same seed-driven `data`), so no hydration
+  // mismatch. `exposeSSR` already implies `type === 'site'`; the explicit check is
+  // defensive.
+  if (exposeSSR && type === 'site' && serverExposedCount > 0) {
+    return (
+      <div
+        className={clsx(className, ANNOUNCEMENT_RESERVE_CLASS)}
+        data-testid="announcements-cls-reserve"
+        aria-hidden={announcements.length ? undefined : true}
+      >
+        {announcements.length ? <AnnouncementsCarousel type={type} /> : null}
+      </div>
+    );
+  }
+
+  // Flag OFF / non-site / server saw nothing (or dismissed): byte-identical to the
+  // #3018 behaviour — null on the server + first client paint, carousel afterwards.
   if (!announcements.length) return null;
 
   return <AnnouncementsCarousel className={className} type={type} />;

--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -1,24 +1,29 @@
 import { useGetAnnouncements } from '~/components/Announcements/announcements.utils';
 import React from 'react';
 import dynamic from 'next/dynamic';
-import clsx from 'clsx';
 import type { AnnouncementType } from '~/server/schema/announcement.schema';
-import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 
+// ssr:true (the default) so, when `useGetAnnouncements` exposes the dismissed
+// data server-side (flag ON, `site` placement), the REAL carousel lands in the
+// initial server HTML at its true height — the durable feed-CLS fix. Next
+// preloads the chunk for the initial render so hydration matches (no flash).
 const AnnouncementsCarousel = dynamic(
   () => import('~/components/Announcements/AnnouncementsCarousel')
 );
 
-// Responsive reserved height for one announcement carousel slide, measured from
-// production: ~162px on desktop, ~203px on mobile (title/markdown/button-row wrap
-// taller in a narrow column). Reserve the LARGER per-viewport so neither
-// under-reserves (an under-reserve leaves a residual downshift; an over-reserve
-// is only cosmetic dead space, never a shift). Variable markdown still makes it
-// approximate — a longer announcement leaves a small residual shift, far less
-// than the full un-reserved push. Written as literal Tailwind classes so JIT
-// emits them; tune here.
-const ANNOUNCEMENT_RESERVE_CLASS = 'min-h-[203px] md:min-h-[162px]';
-
+/**
+ * Above-feed announcement banner.
+ *
+ * The feed-CLS treatment is fully driven by `useGetAnnouncements`:
+ *   - `feedReserveCls` ON + `type === 'site'`: the hook exposes the dismissed data
+ *     on the server + first client paint (both read the same cookie), so this
+ *     renders the real carousel — or nothing, if the active announcement is
+ *     dismissed — directly into the SSR HTML. No placeholder reserve, no
+ *     post-hydration collapse (the net-negative mechanism this replaces).
+ *   - Flag OFF / non-`site`: the hook keeps the `isClient` gate, so `data` is empty
+ *     on the server + first client paint and this renders `null` there, exactly as
+ *     before — byte-identical.
+ */
 export function Announcements({
   className,
   type = 'site',
@@ -26,47 +31,10 @@ export function Announcements({
   className?: string;
   type?: AnnouncementType;
 }) {
-  const features = useFeatureFlags();
-  const { data, seededCount, isClient } = useGetAnnouncements(type);
+  const { data } = useGetAnnouncements(type);
 
   const announcements = data.filter((x) => !x.dismissed);
 
-  // CLS reserve (flag-gated). The SSR seed tells us — dismissed-independently, via
-  // `seededCount` — whether a `site` announcement exists, so we can hold its space
-  // from first paint so the tall masonry feed below doesn't reflow when the
-  // isClient-gated / dynamically-imported carousel mounts. Scoped to `type ===
-  // 'site'` (the above-feed placement in AppLayout): the `generator`/`training`
-  // placements sit above a form/wizard, not a huge feed, so they aren't the CLS
-  // problem and don't need the reserve. Released post-hydration if everything is
-  // dismissed (see the fall-through below) so a heavy dismisser keeps no dead space.
-  const reserveActive =
-    features.feedReserveCls &&
-    type === 'site' &&
-    seededCount > 0 &&
-    (!isClient || announcements.length > 0);
-
-  if (reserveActive) {
-    // PERSISTENT parent: this same <div> renders in the SSR HTML and stays mounted
-    // (no key, same element type + tree position) from server → hydration → the
-    // carousel's dynamic-import load. Only the INNER content swaps (spacer → the
-    // real carousel), and the min-height lives on THIS parent, so the reserved
-    // space is held CONTINUOUSLY across the handoff — no 162→0→162 collapse gap
-    // (and therefore no double-shift) while the carousel chunk resolves. Server +
-    // first client render agree (both: announcements=[] via the isClient gate,
-    // same seededCount), so there's no hydration mismatch.
-    return (
-      <div
-        className={clsx(className, ANNOUNCEMENT_RESERVE_CLASS)}
-        data-testid="announcements-cls-reserve"
-        aria-hidden={announcements.length ? undefined : true}
-      >
-        {announcements.length ? <AnnouncementsCarousel type={type} /> : null}
-      </div>
-    );
-  }
-
-  // Flag OFF / non-site type / seed empty / post-hydration all-dismissed:
-  // byte-identical to the original behavior.
   if (!announcements.length) return null;
 
   return <AnnouncementsCarousel className={className} type={type} />;

--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -18,11 +18,22 @@ const AnnouncementsCarousel = dynamic(
  *   - `feedReserveCls` ON + `type === 'site'`: the hook exposes the dismissed data
  *     on the server + first client paint (both read the same cookie), so this
  *     renders the real carousel — or nothing, if the active announcement is
- *     dismissed — directly into the SSR HTML. No placeholder reserve, no
- *     post-hydration collapse (the net-negative mechanism this replaces).
+ *     dismissed — directly into the SSR HTML. No placeholder reserve, and (for the
+ *     steady state) no post-hydration collapse — the net-negative mechanism this
+ *     replaces.
  *   - Flag OFF / non-`site`: the hook keeps the `isClient` gate, so `data` is empty
  *     on the server + first client paint and this renders `null` there, exactly as
  *     before — byte-identical.
+ *
+ * ONE bounded exception to "no post-hydration collapse": a user who dismissed a
+ * STILL-ACTIVE announcement under the OLD localStorage bundle, on their FIRST load
+ * of the new bundle with the flag ON. The localStorage→cookie migration only runs
+ * CLIENT-side, so on that first load there is no cookie server-side → the seed is
+ * empty → SSR + first client paint expose the carousel, then post-hydration the
+ * (just-migrated) store filters it out = one upward shift. This is NOT a hydration
+ * error (first paint == SSR, both off the empty server seed); it self-heals on the
+ * 2nd load (the cookie now exists, so SSR renders nothing) and is scoped to the
+ * flag's audience (mod-only today) + the rollout window. Accepted trade-off.
  */
 export function Announcements({
   className,

--- a/src/components/Announcements/Announcements.tsx
+++ b/src/components/Announcements/Announcements.tsx
@@ -29,15 +29,16 @@ const ANNOUNCEMENT_RESERVE_CLASS = 'min-h-[203px] md:min-h-[162px]';
  * `useGetAnnouncements`) with #3000's anti-collapse mechanism (a PERSISTENT
  * min-height parent that stays mounted across the SSR→hydration handoff):
  *
- *   - `feedReserveCls` ON + `type === 'site'` + the SERVER saw a non-dismissed
- *     announcement (`serverExposedCount > 0`): render the REAL carousel inside a
- *     persistent `min-h` parent. The wrapper's existence is decided from the SSR
- *     seed (`exposeSSR` is a base/host-level flag held in `useState` — stable, NOT
- *     a laggy per-user overlay — and `serverExposedCount` rides the SSR snapshot),
- *     so it is IDENTICAL on the server render and the first client paint and never
- *     unmounts on a client transient. The `min-h` floor holds the space even if the
- *     inner carousel briefly renders null, so the feed never collapses. In steady
- *     state the carousel fills ~162px, so there is no dead space beyond the floor.
+ *   - `feedReserveCls` ON + `type === 'site'` + a non-dismissed announcement:
+ *     render the REAL carousel inside a persistent `min-h` parent. The wrapper is
+ *     gated on the seed (`serverExposedCount`) PRE-hydration — identical on the
+ *     server render and first client paint (`exposeSSR` is a base/host-level flag
+ *     held in `useState`, stable, NOT a laggy per-user overlay), so no hydration
+ *     mismatch and the space is held from frame 0 — and on the LIVE
+ *     `announcements.length` POST-hydration, so a live dismiss of the last
+ *     announcement collapses the reserve immediately (no dead space until reload).
+ *     In steady state the carousel fills ~162px, so there is no dead space beyond
+ *     the floor.
  *   - Flag OFF / non-`site` / server saw nothing (or saw it dismissed): NO wrapper.
  *     Byte-identical to today — the hook's `isClient` gate zeroes `data` on the
  *     server + first client paint, so this renders `null` there exactly as before,
@@ -48,11 +49,10 @@ const ANNOUNCEMENT_RESERVE_CLASS = 'min-h-[203px] md:min-h-[162px]';
  * bundle with the flag ON. The localStorage→cookie migration runs CLIENT-side only,
  * so on that first load there is no cookie server-side → the seed is empty →
  * `serverExposedCount > 0` → SSR + first client paint render the carousel inside the
- * reserve; post-hydration the just-migrated store filters it out and the inner goes
- * null — but the persistent `min-h` parent HOLDS the height, so there is no feed
- * shift (strictly better than the pre-fix double-shift). Not a hydration error
- * (first paint == SSR, both off the empty server seed); self-heals on the 2nd load
- * (the cookie now exists → `serverExposedCount` 0 → no wrapper, no dead space).
+ * reserve; post-hydration the just-migrated store empties `announcements` → the
+ * live-state gate drops the wrapper = one clean, self-healing collapse (no lingering
+ * dead space). Not a hydration error (first paint == SSR, both off the empty server
+ * seed); fully settled on the 2nd load (the cookie now exists → seed 0 → no wrapper).
  */
 export function Announcements({
   className,
@@ -61,28 +61,32 @@ export function Announcements({
   className?: string;
   type?: AnnouncementType;
 }) {
-  const { data, exposeSSR, serverExposedCount } = useGetAnnouncements(type);
+  const { data, exposeSSR, serverExposedCount, isClient } = useGetAnnouncements(type);
 
   const announcements = data.filter((x) => !x.dismissed);
 
-  // PERSISTENT reserve parent. Gated on a hydration-STABLE, seed-driven decision
-  // (`exposeSSR` base flag + `serverExposedCount` from the SSR snapshot) so this
-  // exact <div> — same element type, same tree position, no changing `key` —
-  // renders in the SSR HTML and STAYS mounted from server → hydration → steady
-  // state. Only the INNER content can swap (carousel ⇆ null), and the min-height
-  // lives on THIS parent, so the reserved space is held continuously with no
-  // collapse gap. Server + first client paint agree on both the wrapper and its
-  // contents (the hook exposes the same seed-driven `data`), so no hydration
-  // mismatch. `exposeSSR` already implies `type === 'site'`; the explicit check is
-  // defensive.
-  if (exposeSSR && type === 'site' && serverExposedCount > 0) {
+  // PERSISTENT reserve parent, gated so it MATCHES SSR pre-hydration but FOLLOWS
+  // live state after:
+  //   - pre-hydration (isClient=false, i.e. the server render AND the first client
+  //     paint): gate on the seed-driven `serverExposedCount` — identical on both,
+  //     so no hydration mismatch, and the space is held from frame 0.
+  //   - post-hydration (isClient=true): gate on the LIVE `announcements.length`, so
+  //     when the user dismisses the last announcement the wrapper is REMOVED and the
+  //     reserved space collapses immediately (no lingering dead space until reload).
+  //     That collapse is USER-INITIATED (the dismiss click) → excluded from CLS via
+  //     `hadRecentInput`, and is the expected UX. Dismissing one of several keeps the
+  //     reserve (length still > 0).
+  // Because the carousel is STATIC-imported, the inner is never transiently null
+  // while the wrapper shows (pre-hydration `serverExposedCount > 0` ⇒
+  // `announcements.length > 0`; post-hydration the gate IS `announcements.length`),
+  // so the min-height floor is belt-and-suspenders — the flash cannot return.
+  // `exposeSSR` already implies `type === 'site'`; the explicit check is defensive.
+  const showReserve =
+    exposeSSR && type === 'site' && (isClient ? announcements.length > 0 : serverExposedCount > 0);
+  if (showReserve) {
     return (
-      <div
-        className={clsx(className, ANNOUNCEMENT_RESERVE_CLASS)}
-        data-testid="announcements-cls-reserve"
-        aria-hidden={announcements.length ? undefined : true}
-      >
-        {announcements.length ? <AnnouncementsCarousel type={type} /> : null}
+      <div className={clsx(className, ANNOUNCEMENT_RESERVE_CLASS)} data-testid="announcements-cls-reserve">
+        <AnnouncementsCarousel type={type} />
       </div>
     );
   }

--- a/src/components/Announcements/announcements-dismissed-cookie.browser.test.tsx
+++ b/src/components/Announcements/announcements-dismissed-cookie.browser.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, test, beforeEach } from 'vitest';
+import {
+  ANNOUNCEMENTS_DISMISSED_COOKIE,
+  emptyDismissed,
+  migrateLegacyLocalStorageToCookie,
+  readDismissedCookieClient,
+  writeDismissedCookieClient,
+} from '~/components/Announcements/announcements-dismissed-cookie';
+
+/**
+ * DOM-backed tests for the cookie store — the read/write round-trip and the
+ * localStorage→cookie migration, which need a REAL `document.cookie` +
+ * `localStorage` (so they live in the browser project, not the node unit suite).
+ */
+
+const LEGACY_KEY = 'announcements';
+
+function clearAll() {
+  // Expire the dismissed cookie.
+  document.cookie = `${ANNOUNCEMENTS_DISMISSED_COOKIE}=; path=/; max-age=-1`;
+  window.localStorage.clear();
+}
+
+beforeEach(() => {
+  clearAll();
+});
+
+describe('cookie read/write round-trip', () => {
+  test('missing cookie → empty dismissed', () => {
+    expect(readDismissedCookieClient()).toEqual(emptyDismissed());
+  });
+
+  test('write → read preserves the per-type shape', () => {
+    const dismissed = { site: [1, 2], generator: [7], training: [] };
+    writeDismissedCookieClient(dismissed);
+    expect(readDismissedCookieClient()).toEqual(dismissed);
+  });
+
+  test('overwrite replaces the prior value', () => {
+    writeDismissedCookieClient({ site: [1], generator: [], training: [] });
+    writeDismissedCookieClient({ site: [1, 2], generator: [3], training: [] });
+    expect(readDismissedCookieClient()).toEqual({ site: [1, 2], generator: [3], training: [] });
+  });
+});
+
+describe('migrateLegacyLocalStorageToCookie', () => {
+  test('legacy v2 localStorage present, cookie absent → cookie seeded from it, legacy cleared', () => {
+    window.localStorage.setItem(
+      LEGACY_KEY,
+      JSON.stringify({
+        state: { dismissed: { site: [1, 2], generator: [9], training: [] } },
+        version: 2,
+      })
+    );
+    migrateLegacyLocalStorageToCookie();
+    // Existing dismissers keep their dismissed set — now in the cookie.
+    expect(readDismissedCookieClient()).toEqual({ site: [1, 2], generator: [9], training: [] });
+    // Legacy key cleaned up.
+    expect(window.localStorage.getItem(LEGACY_KEY)).toBe(null);
+  });
+
+  test('legacy v1 flat number[] → migrated into the site bucket', () => {
+    window.localStorage.setItem(
+      LEGACY_KEY,
+      JSON.stringify({ state: { dismissed: [11, 22] }, version: 1 })
+    );
+    migrateLegacyLocalStorageToCookie();
+    expect(readDismissedCookieClient()).toEqual({ site: [11, 22], generator: [], training: [] });
+  });
+
+  test('no-op when a cookie already exists (does not clobber current state)', () => {
+    writeDismissedCookieClient({ site: [5], generator: [], training: [] });
+    window.localStorage.setItem(
+      LEGACY_KEY,
+      JSON.stringify({ state: { dismissed: { site: [99] } }, version: 2 })
+    );
+    migrateLegacyLocalStorageToCookie();
+    // Cookie wins; legacy is left untouched (only migrated when cookie absent).
+    expect(readDismissedCookieClient()).toEqual({ site: [5], generator: [], training: [] });
+    expect(window.localStorage.getItem(LEGACY_KEY)).not.toBe(null);
+  });
+
+  test('no legacy data and no cookie → stays empty', () => {
+    migrateLegacyLocalStorageToCookie();
+    expect(readDismissedCookieClient()).toEqual(emptyDismissed());
+  });
+});

--- a/src/components/Announcements/announcements-dismissed-cookie.test.ts
+++ b/src/components/Announcements/announcements-dismissed-cookie.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'vitest';
+import {
+  emptyDismissed,
+  parseDismissedCookieValue,
+  parseLegacyPersisted,
+} from '~/components/Announcements/announcements-dismissed-cookie';
+
+/**
+ * Unit tests for the cookie-backed dismissed store's PURE layer — the pieces that
+ * run identically on the server and the client (so both compute the dismissed set
+ * the same way → hydration match). The DOM-backed read/write + migration side
+ * effects are covered in the browser test.
+ */
+
+describe('parseDismissedCookieValue', () => {
+  test('empty / missing / null cookie → empty per-type record', () => {
+    for (const raw of [undefined, null, '']) {
+      expect(parseDismissedCookieValue(raw)).toEqual(emptyDismissed());
+    }
+  });
+
+  test('round-trips the per-type shape (write JSON → parse back)', () => {
+    const dismissed = { site: [1, 2, 3], generator: [10], training: [] };
+    // The client writes via cookies-next (JSON.stringify) and reads the
+    // URL-decoded JSON string back, so parse(JSON.stringify(x)) IS the round-trip.
+    expect(parseDismissedCookieValue(JSON.stringify(dismissed))).toEqual(dismissed);
+  });
+
+  test('fills missing buckets with empty arrays (partial payload)', () => {
+    expect(parseDismissedCookieValue(JSON.stringify({ site: [5] }))).toEqual({
+      site: [5],
+      generator: [],
+      training: [],
+    });
+  });
+
+  test('malformed JSON → empty', () => {
+    expect(parseDismissedCookieValue('{not json')).toEqual(emptyDismissed());
+  });
+
+  test('non-object / wrong-typed payloads → empty (never throws)', () => {
+    expect(parseDismissedCookieValue('42')).toEqual(emptyDismissed());
+    expect(parseDismissedCookieValue('"a string"')).toEqual(emptyDismissed());
+    expect(parseDismissedCookieValue('[1,2,3]')).toEqual(emptyDismissed());
+  });
+
+  test('coerces a non-array bucket to empty rather than throwing', () => {
+    expect(
+      parseDismissedCookieValue(JSON.stringify({ site: 'nope', generator: [7], training: null }))
+    ).toEqual({ site: [], generator: [7], training: [] });
+  });
+});
+
+describe('parseLegacyPersisted (localStorage → cookie migration source)', () => {
+  test('v2 persist envelope (per-type record) is preserved', () => {
+    const legacy = JSON.stringify({
+      state: { dismissed: { site: [1, 2], generator: [9], training: [] } },
+      version: 2,
+    });
+    expect(parseLegacyPersisted(legacy)).toEqual({
+      site: [1, 2],
+      generator: [9],
+      training: [],
+    });
+  });
+
+  test('v0/v1 persist envelope (flat number[]) lands in the site bucket', () => {
+    const legacy = JSON.stringify({ state: { dismissed: [11, 22] }, version: 1 });
+    expect(parseLegacyPersisted(legacy)).toEqual({
+      site: [11, 22],
+      generator: [],
+      training: [],
+    });
+  });
+
+  test('bare (no persist envelope) record is tolerated', () => {
+    expect(parseLegacyPersisted(JSON.stringify({ dismissed: { site: [3] } }))).toEqual({
+      site: [3],
+      generator: [],
+      training: [],
+    });
+  });
+
+  test('empty / malformed legacy → empty', () => {
+    expect(parseLegacyPersisted(null)).toEqual(emptyDismissed());
+    expect(parseLegacyPersisted('')).toEqual(emptyDismissed());
+    expect(parseLegacyPersisted('{broken')).toEqual(emptyDismissed());
+  });
+});

--- a/src/components/Announcements/announcements-dismissed-cookie.ts
+++ b/src/components/Announcements/announcements-dismissed-cookie.ts
@@ -138,6 +138,10 @@ export function migrateLegacyLocalStorageToCookie(): void {
   if (!legacyRaw) return;
   writeDismissedCookieClient(parseLegacyPersisted(legacyRaw));
   try {
+    // Rollout-window caveat: clearing the legacy key means if this session THEN
+    // loads a stale OLD (pre-cookie) bundle, it reads the now-empty localStorage
+    // key → dismissals reappear for that session. Bounded by the rollout window +
+    // the flag's mod-gate; the cookie is authoritative once the new bundle sticks.
     window.localStorage.removeItem(LEGACY_LOCALSTORAGE_KEY);
   } catch {
     // Best-effort cleanup; the cookie now wins regardless.

--- a/src/components/Announcements/announcements-dismissed-cookie.ts
+++ b/src/components/Announcements/announcements-dismissed-cookie.ts
@@ -1,0 +1,145 @@
+import { getCookie, setCookie } from 'cookies-next';
+import * as z from 'zod';
+import type { AnnouncementType } from '~/server/schema/announcement.schema';
+
+/**
+ * Cookie-backed storage for the announcement `dismissed` state.
+ *
+ * WHY a cookie (not localStorage): the dismissed set has to be readable by the
+ * SERVER so SSR can render the REAL announcement carousel (or nothing) from
+ * frame 0 — matching first-client paint exactly. localStorage is client-only, so
+ * SSR could only ever render a placeholder/reserve and then collapse it
+ * post-hydration for a user who'd dismissed the active announcement — the
+ * net-negative feed-CLS mechanism this replaces. A cookie is sent with every
+ * request, so `_app`'s `getInitialProps` reads the same value the client will.
+ *
+ * The cookie is small (dismissed ids are pruned to currently-active
+ * announcements — usually 0-3 ints), UNENCRYPTED + non-httpOnly (the client
+ * reads AND writes it on dismiss; the server only reads it), `SameSite=Lax`,
+ * `path=/`, 1-year expiry. It carries the same per-type
+ * `{ site, generator, training }` shape the localStorage store used.
+ *
+ * 🔴 Hydration safety: `parseDismissedCookieValue` is the SINGLE parser used by
+ * BOTH the server (`_app` → AppProvider context) and the client store, so the
+ * dismissed set is computed identically on both sides. Keep it pure +
+ * deterministic (no Date.now/random) — a divergence here is a hydration mismatch.
+ */
+
+export type DismissedByType = Record<AnnouncementType, number[]>;
+
+export const ANNOUNCEMENTS_DISMISSED_COOKIE = 'announcements-dismissed';
+// The legacy zustand-`persist` localStorage key we migrate FROM (see below).
+const LEGACY_LOCALSTORAGE_KEY = 'announcements';
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365; // 1 year
+
+// Explicit literal (rather than deriving from `announcementTypes`) so adding a new
+// announcement type is a compile error here until its dismissed bucket is wired up.
+export function emptyDismissed(): DismissedByType {
+  return { site: [], generator: [], training: [] };
+}
+
+// A per-field `.catch([])` tolerates a missing key or a non-array value; the
+// object-level `safeParse` fallback (in `parseDismissedCookieValue`) handles a
+// non-object payload. Numbers only — ids.
+const numberArray = z.array(z.number()).catch([]);
+const dismissedSchema = z.object({
+  site: numberArray,
+  generator: numberArray,
+  training: numberArray,
+});
+
+/**
+ * Pure parser for a raw cookie value → `DismissedByType`. Used by BOTH the server
+ * (`_app` reads it from `getCookies(ctx)`) and the client store (`getCookie`),
+ * which both hand us the URL-DECODED JSON string, so both sides parse to the same
+ * value — the hydration-match guarantee. Any malformed/absent value → empty.
+ */
+export function parseDismissedCookieValue(raw: string | undefined | null): DismissedByType {
+  if (!raw) return emptyDismissed();
+  let obj: unknown;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return emptyDismissed();
+  }
+  const parsed = dismissedSchema.safeParse(obj);
+  return parsed.success ? parsed.data : emptyDismissed();
+}
+
+/**
+ * Read + parse the dismissed cookie on the CLIENT. On the server there is no
+ * `document.cookie`, so this returns empty — SSR rendering reads the per-request
+ * dismissed value threaded through AppProvider context instead of this store.
+ */
+export function readDismissedCookieClient(): DismissedByType {
+  if (typeof window === 'undefined') return emptyDismissed();
+  const raw = getCookie(ANNOUNCEMENTS_DISMISSED_COOKIE);
+  return parseDismissedCookieValue(typeof raw === 'string' ? raw : undefined);
+}
+
+/**
+ * Persist the dismissed set to the cookie (client only). `cookies-next`
+ * JSON-stringifies the object (its value starts with `{`) and URL-encodes it;
+ * `parseDismissedCookieValue` reverses that. Non-httpOnly so the client can write
+ * it; `SameSite=Lax` + `path=/` so it rides every navigation the SSR seed needs.
+ */
+export function writeDismissedCookieClient(dismissed: DismissedByType): void {
+  if (typeof window === 'undefined') return;
+  setCookie(ANNOUNCEMENTS_DISMISSED_COOKIE, dismissed, {
+    maxAge: COOKIE_MAX_AGE_SECONDS,
+    path: '/',
+    sameSite: 'lax',
+  });
+}
+
+/**
+ * Parse the legacy zustand-`persist` localStorage payload into a
+ * `DismissedByType`. Handles both shapes the old store wrote:
+ *   - v2 (current): `{ state: { dismissed: { site, generator, training } }, version: 2 }`
+ *   - v0/v1 (pre-placements): `{ state: { dismissed: number[] }, version: <2 }`
+ *     — a flat id list that belonged to the `site` bucket.
+ * Also tolerates a bare `{ dismissed: ... }` (no persist envelope).
+ */
+export function parseLegacyPersisted(raw: string | null | undefined): DismissedByType {
+  if (!raw) return emptyDismissed();
+  let obj: any;
+  try {
+    obj = JSON.parse(raw);
+  } catch {
+    return emptyDismissed();
+  }
+  const state = obj?.state ?? obj;
+  const dismissed = state?.dismissed;
+  // v0/v1: flat number[] → site bucket (mirrors the old persist `migrate`).
+  if (Array.isArray(dismissed)) {
+    return { ...emptyDismissed(), site: dismissed.filter((n: unknown) => typeof n === 'number') };
+  }
+  const parsed = dismissedSchema.safeParse(dismissed);
+  return parsed.success ? parsed.data : emptyDismissed();
+}
+
+/**
+ * One-time client migration: if the dismissed COOKIE is absent but the legacy
+ * localStorage key exists, seed the cookie from it (and clear the legacy key) so
+ * existing dismissers do NOT see previously-dismissed announcements reappear when
+ * we switch the backing store. No-op on the server, when a cookie already exists,
+ * or when there's no legacy data.
+ */
+export function migrateLegacyLocalStorageToCookie(): void {
+  if (typeof window === 'undefined') return;
+  const existing = getCookie(ANNOUNCEMENTS_DISMISSED_COOKIE);
+  if (typeof existing === 'string' && existing.length > 0) return;
+  let legacyRaw: string | null = null;
+  try {
+    legacyRaw = window.localStorage.getItem(LEGACY_LOCALSTORAGE_KEY);
+  } catch {
+    return;
+  }
+  if (!legacyRaw) return;
+  writeDismissedCookieClient(parseLegacyPersisted(legacyRaw));
+  try {
+    window.localStorage.removeItem(LEGACY_LOCALSTORAGE_KEY);
+  } catch {
+    // Best-effort cleanup; the cookie now wins regardless.
+  }
+}

--- a/src/components/Announcements/announcements-exposure.test.ts
+++ b/src/components/Announcements/announcements-exposure.test.ts
@@ -85,6 +85,41 @@ describe('resolveAnnouncementExposure — flag ON (SSR-exact, site placement)', 
     expect(server).toEqual(postHydration); // and it never inserts-then-collapses
   });
 
+  test('MIGRATION FIRST LOAD: seed empty (no cookie server-side yet) but store dismissed (client migration) → SSR/first-paint EXPOSE, post-hydration FILTERS (the one-time, self-healing divergence)', () => {
+    // A legacy localStorage dismisser's FIRST load of the new bundle: the
+    // localStorage→cookie migration runs client-only, so the server has no cookie
+    // (`dismissedSeed=[]`) while the just-migrated client store holds the dismissal
+    // (`dismissedStore=[1]`). This is the ONLY intentional SSR-vs-post-hydration
+    // divergence — a one-time upward shift that self-heals on the 2nd load (the
+    // cookie then exists → seed matches store). Pinned here as intentional.
+    const dismissedSeedMig = [] as number[]; // no cookie server-side
+    const dismissedStoreMig = [1]; // migrated from localStorage on the client
+
+    // Server render AND first client paint (both isClient=false) use the seed →
+    // #1 is NOT dismissed → the carousel is exposed. First paint == SSR (no
+    // hydration error).
+    const server = resolveAnnouncementExposure({
+      typed,
+      exposeSSR: true,
+      isClient: false,
+      dismissedStore: dismissedStoreMig,
+      dismissedSeed: dismissedSeedMig,
+    });
+    expect(visible(server)).toEqual([1, 2]);
+
+    // Post-hydration (isClient=true) switches to the migrated store → #1 filtered
+    // out. This is the single expected divergence from the pre-hydration render.
+    const postHydration = resolveAnnouncementExposure({
+      typed,
+      exposeSSR: true,
+      isClient: true,
+      dismissedStore: dismissedStoreMig,
+      dismissedSeed: dismissedSeedMig,
+    });
+    expect(visible(postHydration)).toEqual([2]);
+    expect(postHydration).not.toEqual(server); // the known one-time collapse
+  });
+
   test('NON-DISMISSER: the real carousel data is present on the server render (renders from server HTML), no post-hydration insert', () => {
     const server = resolveAnnouncementExposure({
       typed,

--- a/src/components/Announcements/announcements-exposure.test.ts
+++ b/src/components/Announcements/announcements-exposure.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'vitest';
+import { resolveAnnouncementExposure } from '~/components/Announcements/announcements-exposure';
+
+/**
+ * Deterministic regression tests for the durable feed-CLS fix. These exercise the
+ * exact SSR→hydration transitions that the net-negative min-height reserve was
+ * papering over:
+ *   - the SERVER render is `isClient=false`,
+ *   - the FIRST client paint is ALSO `isClient=false` (the useIsClient boundary),
+ *   - every render afterwards is `isClient=true`.
+ * Hydration safety = the output at the last `isClient=false` render must equal the
+ * first `isClient=true` render (given the store initialised from the same cookie).
+ */
+
+const A = { id: 1, title: 'a' };
+const B = { id: 2, title: 'b' };
+const typed = [A, B];
+const visible = (out: Array<{ id: number; dismissed: boolean }>) =>
+  out.filter((x) => !x.dismissed).map((x) => x.id);
+
+describe('resolveAnnouncementExposure — flag ON (SSR-exact, site placement)', () => {
+  // Dismisser: the active announcement #1 is in the cookie (seed AND store).
+  const dismissedStore = [1];
+  const dismissedSeed = [1];
+
+  test('DISMISSER: server + first client paint render the SAME non-empty set with #1 marked dismissed (no empty→reserve flash)', () => {
+    // Server render.
+    const server = resolveAnnouncementExposure({
+      typed,
+      exposeSSR: true,
+      isClient: false,
+      dismissedStore,
+      dismissedSeed,
+    });
+    // First client paint (still isClient=false).
+    const firstPaint = resolveAnnouncementExposure({
+      typed,
+      exposeSSR: true,
+      isClient: false,
+      dismissedStore,
+      dismissedSeed,
+    });
+    // Both expose the real data (NOT []), with #1 dismissed and #2 visible.
+    expect(server).toEqual(firstPaint);
+    expect(visible(server)).toEqual([2]);
+  });
+
+  test('DISMISSER: output is STABLE across the hydration boundary (isClient false → true) — no post-hydration collapse', () => {
+    const preHydration = resolveAnnouncementExposure({
+      typed,
+      exposeSSR: true,
+      isClient: false,
+      dismissedStore,
+      dismissedSeed,
+    });
+    const postHydration = resolveAnnouncementExposure({
+      typed,
+      exposeSSR: true,
+      isClient: true,
+      dismissedStore, // store initialised from the same cookie as the seed
+      dismissedSeed,
+    });
+    // Identical → the banner does not appear-then-collapse (the regression).
+    expect(postHydration).toEqual(preHydration);
+    expect(visible(postHydration)).toEqual([2]);
+  });
+
+  test('DISMISSER of the ONLY active announcement → empty from frame 0 and stable (SSR renders nothing, no reserve)', () => {
+    const onlyOne = [A];
+    const server = resolveAnnouncementExposure({
+      typed: onlyOne,
+      exposeSSR: true,
+      isClient: false,
+      dismissedStore: [1],
+      dismissedSeed: [1],
+    });
+    const postHydration = resolveAnnouncementExposure({
+      typed: onlyOne,
+      exposeSSR: true,
+      isClient: true,
+      dismissedStore: [1],
+      dismissedSeed: [1],
+    });
+    expect(visible(server)).toEqual([]); // nothing to render on the server
+    expect(server).toEqual(postHydration); // and it never inserts-then-collapses
+  });
+
+  test('NON-DISMISSER: the real carousel data is present on the server render (renders from server HTML), no post-hydration insert', () => {
+    const server = resolveAnnouncementExposure({
+      typed,
+      exposeSSR: true,
+      isClient: false,
+      dismissedStore: [],
+      dismissedSeed: [],
+    });
+    const postHydration = resolveAnnouncementExposure({
+      typed,
+      exposeSSR: true,
+      isClient: true,
+      dismissedStore: [],
+      dismissedSeed: [],
+    });
+    expect(visible(server)).toEqual([1, 2]); // both visible in SSR HTML
+    expect(server).toEqual(postHydration); // no shift on hydration
+  });
+});
+
+describe('resolveAnnouncementExposure — flag OFF / non-site (byte-identical to pre-fix)', () => {
+  test('FLAG OFF: server + first client paint are EMPTY regardless of cookie (isClient gate preserved)', () => {
+    const server = resolveAnnouncementExposure({
+      typed,
+      exposeSSR: false,
+      isClient: false,
+      dismissedStore: [1],
+      dismissedSeed: [1],
+    });
+    expect(server).toEqual([]); // exactly the old behaviour: nothing on the server
+  });
+
+  test('FLAG OFF: post-hydration is store-driven (the old dismissed source)', () => {
+    const postHydration = resolveAnnouncementExposure({
+      typed,
+      exposeSSR: false,
+      isClient: true,
+      dismissedStore: [1],
+      dismissedSeed: [999], // seed must be IGNORED when flag off
+    });
+    expect(visible(postHydration)).toEqual([2]); // #1 dismissed via STORE, not seed
+  });
+
+  test('FLAG OFF ignores the seed entirely (proves no accidental SSR exposure)', () => {
+    const server = resolveAnnouncementExposure({
+      typed,
+      exposeSSR: false,
+      isClient: false,
+      dismissedStore: [],
+      dismissedSeed: [], // even an empty seed must not expose on the server
+    });
+    expect(server).toEqual([]);
+  });
+});

--- a/src/components/Announcements/announcements-exposure.ts
+++ b/src/components/Announcements/announcements-exposure.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure exposure resolver for the announcement feed-CLS fix — extracted from
+ * `useGetAnnouncements` so the SSR-exact / hydration behaviour is unit-testable
+ * WITHOUT a browser or the provider/trpc graph. This is the heart of the durable
+ * fix; a regression here is the net-negative CLS mechanism coming back.
+ *
+ * Inputs:
+ *  - `typed`         — this type's SSR-seeded announcements (dismissed-independent).
+ *  - `exposeSSR`     — `feedReserveCls` ON AND `type === 'site'`. When true, the
+ *                      dismissed set is read from the cookie on BOTH the server and
+ *                      the first client paint, so the REAL banner renders from SSR.
+ *  - `isClient`      — false on the server AND the first client render (the
+ *                      `useIsClient` hydration boundary), true afterwards.
+ *  - `dismissedStore`— the client cookie-backed store's dismissed ids for the type.
+ *  - `dismissedSeed` — the server-read cookie's dismissed ids for the type (from
+ *                      AppProvider context; present on SSR + first client paint).
+ *
+ * Behaviour:
+ *  - exposeSSR OFF (flag off or non-site): keep the original `isClient` gate — []
+ *    on the server + first client paint, store-driven afterwards. BYTE-IDENTICAL
+ *    to the pre-fix behaviour.
+ *  - exposeSSR ON: always expose; the driving dismissed set is `dismissedSeed`
+ *    pre-hydration (server + first client paint agree → no hydration mismatch) and
+ *    `dismissedStore` post-hydration. Because the store is initialised from the
+ *    SAME cookie as the seed, the value is identical at the handoff → no visual
+ *    change, no collapse.
+ */
+export function resolveAnnouncementExposure<T extends { id: number }>(args: {
+  typed: T[];
+  exposeSSR: boolean;
+  isClient: boolean;
+  dismissedStore: number[];
+  dismissedSeed: number[];
+}): Array<T & { dismissed: boolean }> {
+  const { typed, exposeSSR, isClient, dismissedStore, dismissedSeed } = args;
+  if (!(exposeSSR || isClient)) return [];
+  const dismissed = exposeSSR ? (isClient ? dismissedStore : dismissedSeed) : dismissedStore;
+  return typed.map((announcement) => ({
+    ...announcement,
+    dismissed: dismissed.includes(announcement.id),
+  }));
+}

--- a/src/components/Announcements/announcements.utils.ts
+++ b/src/components/Announcements/announcements.utils.ts
@@ -104,9 +104,18 @@ export function useGetAnnouncements(type: AnnouncementType = 'site') {
   // `site` feed placement. When ON, the server + first client paint both read the
   // dismissed set from the SAME cookie (`dismissedSeed`), so SSR renders the REAL
   // carousel (or nothing) at its true height from frame 0 — no `isClient` gate, no
-  // min-height reserve, no post-hydration collapse. Post-hydration we switch to
-  // the store (initialized from the same cookie → identical value → no visual
-  // change) so live dismisses stay reactive.
+  // min-height reserve, and (steady state) no post-hydration collapse. Post-
+  // hydration we switch to the store (initialized from the same cookie → identical
+  // value → no visual change) so live dismisses stay reactive.
+  //
+  // BOUNDED exception: on a legacy dismisser's FIRST load of the new bundle the
+  // cookie doesn't exist server-side yet (the localStorage→cookie migration is
+  // client-only), so `dismissedSeed` is empty while the migrated `dismissedStore`
+  // is not → SSR/first-paint expose the carousel (seed, isClient=false) and post-
+  // hydration filters it (store, isClient=true) = one self-healing upward shift
+  // (fixed on the 2nd load once the cookie exists). Not a hydration error — first
+  // paint matches SSR. Modeled by the migration-transition case in
+  // `announcements-exposure.test.ts`.
   //
   // When OFF (or type !== 'site'): behavior is byte-identical to before — the
   // `isClient` gate zeroes `data` on the server + first client render (deferring

--- a/src/components/Announcements/announcements.utils.ts
+++ b/src/components/Announcements/announcements.utils.ts
@@ -1,11 +1,18 @@
 import { useEffect, useMemo } from 'react';
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 import { useDomainColor } from '~/hooks/useDomainColor';
 import { useIsClient } from '~/providers/IsClientProvider';
 import { useAppContext } from '~/providers/AppProvider';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import type { AnnouncementType } from '~/server/schema/announcement.schema';
 import { trpc } from '~/utils/trpc';
+import type { DismissedByType } from '~/components/Announcements/announcements-dismissed-cookie';
+import {
+  migrateLegacyLocalStorageToCookie,
+  readDismissedCookieClient,
+  writeDismissedCookieClient,
+} from '~/components/Announcements/announcements-dismissed-cookie';
+import { resolveAnnouncementExposure } from '~/components/Announcements/announcements-exposure';
 
 // The announcements query is SSR-seeded (see AppProvider / `/api/user/settings`).
 // A non-zero staleTime is what actually skips the per-bootstrap fetch: with
@@ -16,49 +23,46 @@ import { trpc } from '~/utils/trpc';
 // re-runs getInitialProps and reseeds anyway.
 const ANNOUNCEMENTS_STALE_TIME = 5 * 60 * 1000;
 
-type DismissedByType = Record<AnnouncementType, number[]>;
+// Stable empty-array reference so `dismissedSeed`'s fallback doesn't churn deps.
+const EMPTY_DISMISSED: number[] = [];
 
-// Explicit literal (rather than deriving from `announcementTypes`) so adding a new
-// announcement type is a compile error here until its dismissed bucket is wired up.
-function emptyDismissed(): DismissedByType {
-  return { site: [], generator: [], training: [] };
-}
+// Client-only: migrate the legacy localStorage `announcements` dismissed state to
+// the cookie BEFORE the store reads its initial value, so existing dismissers
+// don't see dismissed announcements reappear. No-op on the server and when a
+// cookie already exists.
+migrateLegacyLocalStorageToCookie();
 
+// Cookie-backed dismissed store (was localStorage `persist`). The switch to a
+// cookie is GLOBAL + behavior-preserving — the client still filters dismissed and
+// renders identically; only WHERE dismissed lives changes, so the SERVER can read
+// it too. On the server there is no `document.cookie`, so the store initializes
+// empty; SSR rendering reads the per-request dismissed value threaded through
+// AppProvider context (`announcementsDismissed`) instead of this store.
 export const useAnnouncementsStore = create<{
   dismissed: DismissedByType;
-}>()(
-  persist(
-    () => ({
-      dismissed: emptyDismissed(),
-    }),
-    {
-      name: 'announcements',
-      // v2: dismissed went from a flat `number[]` to a per-type record. Existing
-      // dismissed ids predate placements, so they belong to the `site` bucket.
-      version: 2,
-      migrate: (persisted, version) => {
-        if (version < 2) {
-          const legacy = (persisted as { dismissed?: number[] } | undefined)?.dismissed ?? [];
-          return { dismissed: { ...emptyDismissed(), site: legacy } };
-        }
-        return persisted as { dismissed: DismissedByType };
-      },
-    }
-  )
-);
+}>(() => ({
+  dismissed: readDismissedCookieClient(),
+}));
+
+// Single writer for the dismissed set: update the store AND persist the cookie so
+// the server sees the change on the next request.
+function setDismissed(dismissed: DismissedByType) {
+  useAnnouncementsStore.setState({ dismissed });
+  writeDismissedCookieClient(dismissed);
+}
 
 export function dismissAnnouncements(ids: number | number[], type: AnnouncementType = 'site') {
-  useAnnouncementsStore.setState((state) => ({
-    dismissed: {
-      ...state.dismissed,
-      [type]: [...new Set(state.dismissed[type].concat(ids))],
-    },
-  }));
+  const { dismissed } = useAnnouncementsStore.getState();
+  setDismissed({
+    ...dismissed,
+    [type]: [...new Set(dismissed[type].concat(ids))],
+  });
 }
 
 export function useGetAnnouncements(type: AnnouncementType = 'site') {
+  const features = useFeatureFlags();
   const isClient = useIsClient();
-  const dismissed = useAnnouncementsStore((state) => state.dismissed[type]);
+  const dismissedStore = useAnnouncementsStore((state) => state.dismissed[type]);
   const domainColor = useDomainColor();
   // Seed from the SSR snapshot carried by AppProvider. We seed HERE (not in
   // AppProvider) because the query key is `{ domain: useDomainColor() }` and only
@@ -66,7 +70,11 @@ export function useGetAnnouncements(type: AnnouncementType = 'site') {
   // content was computed server-side with `getRequestDomainColor(req)`, exactly
   // what the resolver's domain middleware uses, so it matches a live fetch under
   // this key even though the two color functions can diverge (e.g. on red).
-  const { announcements: initialData } = useAppContext();
+  // `announcementsDismissed` is the server-read dismissed set (from the same
+  // cookie the client store reads) — present on the SSR render AND the first
+  // client paint (it rides pageProps), so both read the identical value.
+  const { announcements: initialData, announcementsDismissed } = useAppContext();
+  const dismissedSeed = announcementsDismissed?.[type] ?? EMPTY_DISMISSED;
   const { data, ...rest } = trpc.announcement.getAnnouncements.useQuery(
     { domain: domainColor },
     { initialData, staleTime: ANNOUNCEMENTS_STALE_TIME }
@@ -80,47 +88,46 @@ export function useGetAnnouncements(type: AnnouncementType = 'site') {
   );
 
   // v5: query onSettled removed — prune this type's dismissed ids to those still
-  // present once data loads. Functional setState avoids depending on `dismissed`
-  // (which would re-loop the effect).
+  // present once data loads. Only WRITE (store + cookie) when something actually
+  // pruned, to avoid a gratuitous cookie write on every mount.
   useEffect(() => {
     if (!typed.length) return;
     const announcementIds = typed.map((x) => x.id);
-    useAnnouncementsStore.setState((state) => ({
-      dismissed: {
-        ...state.dismissed,
-        [type]: state.dismissed[type].filter((dismissedId) =>
-          announcementIds.includes(dismissedId)
-        ),
-      },
-    }));
+    const { dismissed } = useAnnouncementsStore.getState();
+    const pruned = dismissed[type].filter((id) => announcementIds.includes(id));
+    if (pruned.length !== dismissed[type].length) {
+      setDismissed({ ...dismissed, [type]: pruned });
+    }
   }, [typed, type]);
 
-  // Only EXPOSE the seeded data once hydrated. `dismissed` comes from a
-  // localStorage-backed zustand store that rehydrates synchronously on the
-  // client — so server (dismissed=[]) and client-first-paint (dismissed=[...])
-  // would render different banners off the SSR seed → hydration mismatch / a
-  // flash of a previously-dismissed announcement. Gating on `useIsClient()`
-  // (false on the server AND the first client render) makes SSR output match
-  // `main` (empty) and defers dismissed-dependent rendering to after hydration.
-  // The network cut is unaffected — the seed stays in the RQ cache, so no fetch
-  // fires; we just don't surface it until the client paint where `dismissed` is
-  // authoritative.
+  // SSR-exact dismiss (durable feed-CLS fix), gated on `feedReserveCls` for the
+  // `site` feed placement. When ON, the server + first client paint both read the
+  // dismissed set from the SAME cookie (`dismissedSeed`), so SSR renders the REAL
+  // carousel (or nothing) at its true height from frame 0 — no `isClient` gate, no
+  // min-height reserve, no post-hydration collapse. Post-hydration we switch to
+  // the store (initialized from the same cookie → identical value → no visual
+  // change) so live dismisses stay reactive.
+  //
+  // When OFF (or type !== 'site'): behavior is byte-identical to before — the
+  // `isClient` gate zeroes `data` on the server + first client render (deferring
+  // dismissed-dependent rendering to after hydration), and the store drives
+  // `dismissed`. The RQ seed still primes the cache, so no bootstrap fetch fires.
+  const exposeSSR = features.feedReserveCls && type === 'site';
+
   const announcements = useMemo(
     () =>
-      isClient
-        ? typed.map((announcement) => ({
-            ...announcement,
-            dismissed: dismissed.includes(announcement.id),
-          }))
-        : [],
-    [typed, dismissed, isClient]
+      resolveAnnouncementExposure({
+        typed,
+        exposeSSR,
+        isClient,
+        dismissedStore,
+        dismissedSeed,
+      }),
+    [typed, exposeSSR, isClient, dismissedStore, dismissedSeed]
   );
 
   // `seededCount` is the SSR-seeded, dismissed-independent count of this type's
-  // announcements. Unlike `data` (which the `isClient` gate zeroes on the server
-  // + first client render to avoid a dismissed-flash), it is stable across the
-  // SSR→hydration boundary, so a consumer can reserve layout space at first paint
-  // when the seed indicates an announcement WILL surface post-hydration. `isClient`
-  // lets the consumer scope that reserve to the pre-hydration window only.
+  // announcements — stable across the SSR→hydration boundary. Retained for
+  // consumers that want the dismissed-independent count.
   return { data: announcements, seededCount: typed.length, isClient, ...rest };
 }

--- a/src/components/Announcements/announcements.utils.ts
+++ b/src/components/Announcements/announcements.utils.ts
@@ -135,8 +135,28 @@ export function useGetAnnouncements(type: AnnouncementType = 'site') {
     [typed, exposeSSR, isClient, dismissedStore, dismissedSeed]
   );
 
+  // `serverExposedCount` is the SERVER's dismissed-AWARE view: this type's seeded
+  // announcements MINUS the ones the server-read cookie (`dismissedSeed`) marks
+  // dismissed. Both inputs ride the SSR snapshot (`typed` from the query seed,
+  // `dismissedSeed` from AppProvider context), so this value is IDENTICAL on the
+  // server render and the first client paint — a hydration-STABLE signal the
+  // persistent CLS reserve can gate on without ever unmounting on a client
+  // transient. Unlike `seededCount` (dismissed-INDEPENDENT) it is 0 for a
+  // dismisser, so a server-side dismisser reserves NO dead space.
+  const serverExposedCount = useMemo(
+    () => typed.reduce((n, a) => (dismissedSeed.includes(a.id) ? n : n + 1), 0),
+    [typed, dismissedSeed]
+  );
+
   // `seededCount` is the SSR-seeded, dismissed-independent count of this type's
   // announcements — stable across the SSR→hydration boundary. Retained for
   // consumers that want the dismissed-independent count.
-  return { data: announcements, seededCount: typed.length, isClient, ...rest };
+  return {
+    data: announcements,
+    seededCount: typed.length,
+    serverExposedCount,
+    exposeSSR,
+    isClient,
+    ...rest,
+  };
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -62,6 +62,11 @@ import { resolveChatSettings } from '~/server/schema/chat.schema';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import type { TosMeta } from '~/server/services/content.service';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
+import type { DismissedByType } from '~/components/Announcements/announcements-dismissed-cookie';
+import {
+  ANNOUNCEMENTS_DISMISSED_COOKIE,
+  parseDismissedCookieValue,
+} from '~/components/Announcements/announcements-dismissed-cookie';
 import type { BrowsingSettingsAddon } from '~/shared/constants/browsing-settings-addons';
 import type { ParsedCookies } from '~/shared/utils/cookies';
 import { parseCookies } from '~/shared/utils/cookies';
@@ -108,6 +113,7 @@ type CustomAppProps = {
   userFeatureFlags?: FeatureAccess;
   tosMeta?: TosMeta;
   announcements?: AnnouncementsSeed;
+  announcementsDismissed?: DismissedByType;
   following?: number[];
   seed: number;
   settings: UserContentSettings;
@@ -139,6 +145,7 @@ function MyApp(props: CustomAppProps) {
       userFeatureFlags,
       tosMeta,
       announcements,
+      announcementsDismissed,
       following,
       seed = Date.now(),
       canIndex,
@@ -198,6 +205,7 @@ function MyApp(props: CustomAppProps) {
       settings={settings}
       tosMeta={tosMeta}
       announcements={announcements}
+      announcementsDismissed={announcementsDismissed}
       following={following}
       liveNow={liveNow}
       chatSettings={chatSettings}
@@ -356,6 +364,15 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
   const colorScheme = getCookie('mantine-color-scheme', appContext.ctx) ?? 'dark';
   const cookies = getCookies(appContext.ctx);
   const parsedCookies = parseCookies(cookies);
+  // Server-read announcement `dismissed` state from the `announcements-dismissed`
+  // cookie. `getCookies` hands us the URL-decoded JSON string, which
+  // `parseDismissedCookieValue` (the SAME parser the client store uses) turns into
+  // the per-type dismissed record. Threaded down so SSR + first client paint agree.
+  const announcementsDismissed = parseDismissedCookieValue(
+    typeof cookies[ANNOUNCEMENTS_DISMISSED_COOKIE] === 'string'
+      ? (cookies[ANNOUNCEMENTS_DISMISSED_COOKIE] as string)
+      : undefined
+  );
 
   // Match BOTH session cookie families: the new hub `civ-token` / `__Secure-civ-token` AND the legacy
   // next-auth `civitai-token` / `__Secure-civitai-token` (still honored during the cutover). Note the suffixes
@@ -586,6 +603,7 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
       userFeatureFlags,
       tosMeta,
       announcements,
+      announcementsDismissed,
       following,
       seed: Date.now(),
       hasAuthCookie,

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -9,6 +9,7 @@ import { setServerDomains } from '~/utils/sync-account';
 import { trpc } from '~/utils/trpc';
 import type { AnnouncementsSeed } from '~/providers/announcements-seed';
 import { reviveAnnouncementsSeed } from '~/providers/announcements-seed';
+import type { DismissedByType } from '~/components/Announcements/announcements-dismissed-cookie';
 
 type AppProviderProps = {
   children: React.ReactNode;
@@ -22,6 +23,11 @@ type AppProviderProps = {
   // `useDomainColor()` key — this provider sits above FeatureFlagsProvider so it
   // can't compute that key itself.
   announcements?: AnnouncementsSeed;
+  // Server-read announcement `dismissed` state (from the `announcements-dismissed`
+  // cookie, parsed in `_app`). Threaded to `useGetAnnouncements` so SSR + the first
+  // client paint compute `dismissed` from the SAME value — the hydration-match
+  // guarantee behind the SSR-exact feed-CLS fix. Absent → treated as empty.
+  announcementsDismissed?: DismissedByType;
   // SSR-computed `user.getFollowingUsers` result (logged-in only) — the list of
   // followed userIds. Seeds the query directly (fixed `undefined` key) so the
   // ambient follow/notify buttons never fire it on bootstrap.
@@ -64,6 +70,7 @@ type AppContext = {
   availableOAuthProviders: string[];
   verifiedBot: VerifiedBot | null;
   announcements?: AnnouncementsSeed;
+  announcementsDismissed?: DismissedByType;
   tosMeta?: TosMeta;
 };
 const Context = createContext<AppContext | null>(null);
@@ -90,6 +97,7 @@ export function AppProvider({
   settings,
   tosMeta,
   announcements,
+  announcementsDismissed,
   following,
   liveNow,
   chatSettings,
@@ -158,6 +166,7 @@ export function AppProvider({
     availableOAuthProviders,
     verifiedBot,
     announcements: reviveAnnouncementsSeed(announcements),
+    announcementsDismissed,
     // All-string payload (current hash + baseline + field keys) — survives the
     // pageProps JSON round-trip as-is, no revival needed.
     tosMeta,


### PR DESCRIPTION
## Why

The flag-gated feed-CLS min-height reserve (`feedReserveCls`, #3000) was A/B-tested at 25% and came back **NET-NEGATIVE** (aggregate feed mean CLS +0.045 worse; `/posts` 0.074→0.244), so it was rolled back to mods-only. The mechanism:

- Announcement `dismissed` state lived in **localStorage** (zustand `persist`), which SSR can't read, so `useGetAnnouncements` gated the exposed announcements behind `useIsClient()` (`data=[]` on the server + first client paint).
- The reserve rendered a `min-h-[203px] md:min-h-[162px]` placeholder pre-hydration whenever the SSR-seeded count was > 0. Post-hydration, a user who had **dismissed** the active announcement flipped `announcements.length===0` → the reserve **collapsed upward** = a NEW upshift that flag-off users don't have. Every dismisser on every feed route with an active announcement ate it → the broad regression.

## The durable fix

Move `dismissed` from localStorage to a **cookie the SERVER can read**, so SSR computes the real dismissed state and renders the ACTUAL announcement carousel (or nothing) from frame 0 — no `isClient` gate on the dismissed dimension, no placeholder, no collapse. The real banner is in the initial HTML at its true height → zero CLS for the initial-load case (where the shift is measured, `largest_shift_time` ~1.5–2.4s).

### 1. localStorage → cookie (GLOBAL, behavior-preserving)
- The `announcements` dismissed store is now backed by an **unencrypted, non-httpOnly** `announcements-dismissed` cookie (`SameSite=Lax`, `path=/`, 1-year expiry, tiny — dismissed ids are pruned to currently-active announcements). Same per-type `{site,generator,training}` shape; the client still filters dismissed and renders identically — only WHERE dismissed lives changes.
- **Migration (no regression for current dismissers):** on first client load, if the cookie is absent but the legacy localStorage `announcements` key exists (both the v1 flat `number[]` and v2 per-type record shapes), the cookie is seeded from it and the legacy key cleared. Existing dismissers do **not** see previously-dismissed announcements reappear.

### 2. SSR-exact render, gated on `feedReserveCls` (reused flag, `site` placement)
- `_app` reads the cookie server-side (`getCookies(ctx)` — request access confirmed) and threads the dismissed ids through `AppProvider` context.
- When the flag is **ON**: `useGetAnnouncements` computes `dismissed` from the **same cookie value** on the server AND the first client paint, so the `ssr:true` dynamic-imported carousel renders into the initial server HTML with matching markup. The min-height reserve is **removed** in favor of this exact SSR render. If the active announcement is dismissed → SSR renders nothing (no reserve, no collapse).
- When the flag is **OFF** (or `type !== 'site'`): **byte-identical** to today — the `isClient` gate + store path is untouched, the RQ seed still primes the cache (no bootstrap fetch).

### 3. Hydration-match guarantee (the whole game)
Server + first-client-paint read the same cookie through a **single pure parser** (`parseDismissedCookieValue`, used identically by `_app` and the client store), and the client store is initialized from the same cookie — so the value is identical at the handoff (no visual change, no mismatch). The SSR-exposure decision is extracted into a pure `resolveAnnouncementExposure` for deterministic testing. The `dynamic()` import defaults to `ssr:true`, and the carousel (Embla) is SSR-safe (renders markup server-side, inits in a client effect).

## Tests
- **`announcements-exposure.test.ts`** (node) — the SSR→hydration regression: dismisser flag-ON output is **empty/stable across hydration** (the net-negative mechanism can't return); non-dismisser renders from server HTML with no post-hydration insert; flag-OFF ignores the seed and stays byte-identical.
- **`announcements-dismissed-cookie.test.ts`** (node) — cookie parser round-trip, per-type shape, empty/missing/malformed → empty, legacy v1/v2 migration parsing.
- **`announcements-dismissed-cookie.browser.test.tsx`** — real `document.cookie` + `localStorage` write/read round-trip and the full localStorage→cookie migration (incl. no-op-when-cookie-exists).
- **`Announcements.browser.test.tsx`** — rewritten for the reserve-free component contract.

## Verification (honest)
- **Node unit + browser suites: all green** — 17 node unit + 7 cookie browser + 4 component (browser mode run locally via nix `chromium` as the Playwright executable).
- **Typecheck (`tsc --noEmit`): zero errors in the changed files.** The full run reports 17 pre-existing environmental errors only — the private `event-engine-common` submodule (#1985) + a `kysely` workspace-resolution quirk — none in any file this PR touches.
- Not yet exercised on a live deploy; the hydration-match reasoning is above, and the browser round-trip/migration is covered by tests.

## Rollout
Replaces the net-negative reserve so `feed-reserve-cls` can be **re-ramped threshold-only (no mod segment)** and re-measured via RUM `session_attr_exp_feed_reserve_cls`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)