### PR TITLE
feat(app-blocks): shared-storage host handlers — Phase 2b (SHARED_* bridge)

### DIFF
--- a/src/components/AppBlocks/IframeHost.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHost.browser.test.tsx
@@ -38,6 +38,12 @@ vi.mock('~/utils/trpc', () => ({
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: mocks.balance }) },
     },
     apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -45,6 +51,11 @@ vi.mock('~/utils/trpc', () => ({
     },
     useUtils: () => ({
       apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
         storage: {
           get: { fetch: vi.fn() },
           list: { fetch: vi.fn() },

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -1268,6 +1268,186 @@ export function IframeHost({
     return off;
   }, [onMessage, send, token, trpcUtils]);
 
+  // App Blocks SHARED (cross-user / app-global) storage bridge (Phase 2b). The
+  // public-write sibling of the per-user KV handlers above — a block token that
+  // carries `apps:storage:shared:*` drives the shared datastore via the SDK
+  // shared-storage hook (SHARED_LIST / GET_COUNT / GET_COUNTS / APPEND / VOTE /
+  // UNVOTE / WITHDRAW → SHARED_*_RESULT). The host injects the `token` it holds as
+  // `blockToken` (never trusts a message token); reads go through
+  // trpc.useUtils().apps.shared.*.fetch, writes through the useMutation hooks; the
+  // server enforces scope + flag + trust gate (resolveSharedContext). Every reply
+  // carries the same requestId on success AND error so the block never hangs.
+  const sharedAppendMutation = trpc.apps.shared.append.useMutation();
+  const sharedVoteMutation = trpc.apps.shared.vote.useMutation();
+  const sharedUnvoteMutation = trpc.apps.shared.unvote.useMutation();
+  const sharedWithdrawMutation = trpc.apps.shared.withdraw.useMutation();
+
+  useEffect(() => {
+    const off = onMessage<
+      | {
+          requestId?: unknown;
+          prefix?: unknown;
+          limit?: unknown;
+          cursor?: unknown;
+        }
+      | undefined
+    >('SHARED_LIST', async (raw) => {
+      if (!raw || typeof raw.requestId !== 'string') return;
+      const requestId = raw.requestId;
+      try {
+        const prefix = typeof raw.prefix === 'string' ? raw.prefix : undefined;
+        const limit =
+          typeof raw.limit === 'number' && Number.isFinite(raw.limit)
+            ? Math.min(Math.max(Math.floor(raw.limit), 1), 100)
+            : 50;
+        const cursor = typeof raw.cursor === 'string' ? raw.cursor : undefined;
+        const result = await trpcUtils.apps.shared.list.fetch({
+          blockToken: token,
+          prefix,
+          limit,
+          cursor,
+        });
+        send('SHARED_LIST_RESULT', {
+          requestId,
+          items: result.items.map((it) => ({
+            key: it.key,
+            authorUserId: it.authorUserId,
+            value: it.value,
+            count: it.count,
+            createdAt:
+              it.createdAt instanceof Date ? it.createdAt.toISOString() : String(it.createdAt),
+            updatedAt:
+              it.updatedAt instanceof Date ? it.updatedAt.toISOString() : String(it.updatedAt),
+          })),
+          nextCursor: result.nextCursor,
+        });
+      } catch (err) {
+        send('SHARED_LIST_RESULT', { requestId, error: storageErrorMessage(err) });
+      }
+    });
+    return off;
+  }, [onMessage, send, token, trpcUtils]);
+
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'SHARED_GET_COUNT',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string') return;
+        const requestId = raw.requestId;
+        try {
+          const result = await trpcUtils.apps.shared.getCount.fetch({
+            blockToken: token,
+            key: raw.key,
+          });
+          send('SHARED_GET_COUNT_RESULT', { requestId, count: result.count });
+        } catch (err) {
+          send('SHARED_GET_COUNT_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, trpcUtils]);
+
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; keys?: unknown } | undefined>(
+      'SHARED_GET_COUNTS',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || !Array.isArray(raw.keys)) return;
+        const requestId = raw.requestId;
+        try {
+          const result = await trpcUtils.apps.shared.getCounts.fetch({
+            blockToken: token,
+            keys: raw.keys as string[],
+          });
+          send('SHARED_GET_COUNTS_RESULT', { requestId, counts: result.counts });
+        } catch (err) {
+          send('SHARED_GET_COUNTS_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, trpcUtils]);
+
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; value?: unknown } | undefined>(
+      'SHARED_APPEND',
+      async (raw) => {
+        if (
+          !raw ||
+          typeof raw.requestId !== 'string' ||
+          typeof raw.value !== 'object' ||
+          raw.value === null
+        )
+          return;
+        const requestId = raw.requestId;
+        try {
+          const result = await sharedAppendMutation.mutateAsync({
+            blockToken: token,
+            value: raw.value as { title: string; body?: string },
+          });
+          send('SHARED_APPEND_RESULT', { requestId, key: result.key });
+        } catch (err) {
+          send('SHARED_APPEND_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedAppendMutation]);
+
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'SHARED_VOTE',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string') return;
+        const requestId = raw.requestId;
+        try {
+          const result = await sharedVoteMutation.mutateAsync({ blockToken: token, key: raw.key });
+          send('SHARED_VOTE_RESULT', { requestId, count: result.count });
+        } catch (err) {
+          send('SHARED_VOTE_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedVoteMutation]);
+
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'SHARED_UNVOTE',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string') return;
+        const requestId = raw.requestId;
+        try {
+          const result = await sharedUnvoteMutation.mutateAsync({ blockToken: token, key: raw.key });
+          send('SHARED_UNVOTE_RESULT', { requestId, count: result.count });
+        } catch (err) {
+          send('SHARED_UNVOTE_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedUnvoteMutation]);
+
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'SHARED_WITHDRAW',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string') return;
+        const requestId = raw.requestId;
+        try {
+          const result = await sharedWithdrawMutation.mutateAsync({
+            blockToken: token,
+            key: raw.key,
+          });
+          send('SHARED_WITHDRAW_RESULT', { requestId, ok: result.ok, deleted: result.deleted });
+        } catch (err) {
+          send('SHARED_WITHDRAW_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedWithdrawMutation]);
+
   useEffect(() => {
     if (status !== 'ready') return;
     const handler = () => {

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -29,6 +29,12 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -36,6 +42,11 @@ vi.mock('~/utils/trpc', () => ({
     },
     useUtils: () => ({
       apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
         storage: {
           get: { fetch: vi.fn() },
           list: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -970,6 +970,214 @@ export function PageBlockHost({
     return off;
   }, [onMessage, send, token, trpcUtils]);
 
+  // ── App Blocks SHARED (cross-user / app-global) storage bridge (Phase 2b) ──
+  //
+  // The public-write sibling of the per-user KV bridge above. A page block
+  // (e.g. a community "requests"/voting app, entity=none) drives the shared
+  // datastore via the @civitai/app-sdk shared-storage hook, which posts
+  // SHARED_LIST / GET_COUNT / GET_COUNTS / APPEND / VOTE / UNVOTE / WITHDRAW and
+  // AWAITS the matching SHARED_*_RESULT. Unhandled ⇒ the block hangs to the SDK
+  // 30s timeout (the gotcha-#73 "spins forever" class). We mirror the APP_STORAGE
+  // handlers EXACTLY: the HOST injects the block `token` prop it already holds as
+  // `blockToken` (NEVER trusts a token from the message), reads go through
+  // trpc.useUtils().apps.shared.*.fetch, writes through the useMutation hooks, and
+  // every reply comes back with the SAME requestId on BOTH the success path and
+  // the error path (`error: <string>`, never thrown upward) so the block-side
+  // hook rejects cleanly instead of stranding the bridge.
+  //
+  // NO client-side scope/flag gate here (mirrors APP_STORAGE): the block token
+  // must carry `apps:storage:shared:*` and the dedicated fail-closed Flipt flag +
+  // trust gate are enforced SERVER-side (resolveSharedContext). The only client
+  // precondition is the same non-null `token` the storage handlers use — a null
+  // token means the block never rendered a usable surface, so the request is
+  // dropped without replying (the mint path surfaces no_token/error above).
+  const sharedAppendMutation = trpc.apps.shared.append.useMutation();
+  const sharedVoteMutation = trpc.apps.shared.vote.useMutation();
+  const sharedUnvoteMutation = trpc.apps.shared.unvote.useMutation();
+  const sharedWithdrawMutation = trpc.apps.shared.withdraw.useMutation();
+
+  // SHARED_LIST → apps.shared.list → SHARED_LIST_RESULT (query).
+  useEffect(() => {
+    const off = onMessage<
+      | {
+          requestId?: unknown;
+          prefix?: unknown;
+          limit?: unknown;
+          cursor?: unknown;
+        }
+      | undefined
+    >('SHARED_LIST', async (raw) => {
+      if (!raw || typeof raw.requestId !== 'string' || !token) return;
+      const requestId = raw.requestId;
+      try {
+        const prefix = typeof raw.prefix === 'string' ? raw.prefix : undefined;
+        // Server caps `limit` at 100; clamp client-side to match (mirrors the
+        // APP_STORAGE_LIST 200-clamp against its own server max).
+        const limit =
+          typeof raw.limit === 'number' && Number.isFinite(raw.limit)
+            ? Math.min(Math.max(Math.floor(raw.limit), 1), 100)
+            : 50;
+        const cursor = typeof raw.cursor === 'string' ? raw.cursor : undefined;
+        const result = await trpcUtils.apps.shared.list.fetch({
+          blockToken: token,
+          prefix,
+          limit,
+          cursor,
+        });
+        send('SHARED_LIST_RESULT', {
+          requestId,
+          items: result.items.map((it) => ({
+            key: it.key,
+            authorUserId: it.authorUserId,
+            value: it.value,
+            count: it.count,
+            createdAt:
+              it.createdAt instanceof Date ? it.createdAt.toISOString() : String(it.createdAt),
+            updatedAt:
+              it.updatedAt instanceof Date ? it.updatedAt.toISOString() : String(it.updatedAt),
+          })),
+          nextCursor: result.nextCursor,
+        });
+      } catch (err) {
+        send('SHARED_LIST_RESULT', { requestId, error: storageErrorMessage(err) });
+      }
+    });
+    return off;
+  }, [onMessage, send, token, trpcUtils]);
+
+  // SHARED_GET_COUNT → apps.shared.getCount → SHARED_GET_COUNT_RESULT (query).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'SHARED_GET_COUNT',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
+          return;
+        const requestId = raw.requestId;
+        try {
+          const result = await trpcUtils.apps.shared.getCount.fetch({
+            blockToken: token,
+            key: raw.key,
+          });
+          send('SHARED_GET_COUNT_RESULT', { requestId, count: result.count });
+        } catch (err) {
+          send('SHARED_GET_COUNT_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, trpcUtils]);
+
+  // SHARED_GET_COUNTS → apps.shared.getCounts → SHARED_GET_COUNTS_RESULT (query).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; keys?: unknown } | undefined>(
+      'SHARED_GET_COUNTS',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || !Array.isArray(raw.keys) || !token) return;
+        const requestId = raw.requestId;
+        try {
+          const result = await trpcUtils.apps.shared.getCounts.fetch({
+            blockToken: token,
+            keys: raw.keys as string[],
+          });
+          send('SHARED_GET_COUNTS_RESULT', { requestId, counts: result.counts });
+        } catch (err) {
+          send('SHARED_GET_COUNTS_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, trpcUtils]);
+
+  // SHARED_APPEND → apps.shared.append → SHARED_APPEND_RESULT (mutation).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; value?: unknown } | undefined>(
+      'SHARED_APPEND',
+      async (raw) => {
+        if (
+          !raw ||
+          typeof raw.requestId !== 'string' ||
+          typeof raw.value !== 'object' ||
+          raw.value === null ||
+          !token
+        )
+          return;
+        const requestId = raw.requestId;
+        try {
+          // Server zod-validates {title, body?}; a malformed value rejects
+          // BAD_REQUEST → the error path below (never a hang).
+          const result = await sharedAppendMutation.mutateAsync({
+            blockToken: token,
+            value: raw.value as { title: string; body?: string },
+          });
+          send('SHARED_APPEND_RESULT', { requestId, key: result.key });
+        } catch (err) {
+          send('SHARED_APPEND_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedAppendMutation]);
+
+  // SHARED_VOTE → apps.shared.vote → SHARED_VOTE_RESULT (mutation).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'SHARED_VOTE',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
+          return;
+        const requestId = raw.requestId;
+        try {
+          const result = await sharedVoteMutation.mutateAsync({ blockToken: token, key: raw.key });
+          send('SHARED_VOTE_RESULT', { requestId, count: result.count });
+        } catch (err) {
+          send('SHARED_VOTE_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedVoteMutation]);
+
+  // SHARED_UNVOTE → apps.shared.unvote → SHARED_UNVOTE_RESULT (mutation).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'SHARED_UNVOTE',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
+          return;
+        const requestId = raw.requestId;
+        try {
+          const result = await sharedUnvoteMutation.mutateAsync({ blockToken: token, key: raw.key });
+          send('SHARED_UNVOTE_RESULT', { requestId, count: result.count });
+        } catch (err) {
+          send('SHARED_UNVOTE_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedUnvoteMutation]);
+
+  // SHARED_WITHDRAW → apps.shared.withdraw → SHARED_WITHDRAW_RESULT (mutation).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'SHARED_WITHDRAW',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
+          return;
+        const requestId = raw.requestId;
+        try {
+          const result = await sharedWithdrawMutation.mutateAsync({
+            blockToken: token,
+            key: raw.key,
+          });
+          send('SHARED_WITHDRAW_RESULT', { requestId, ok: result.ok, deleted: result.deleted });
+        } catch (err) {
+          send('SHARED_WITHDRAW_RESULT', { requestId, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedWithdrawMutation]);
+
   // ── OPEN_RESOURCE_PICKER → RESOURCE_PICKER_RESULT (Design 1 host-chrome) ────
   //
   // Generalizes the model-slot OPEN_CHECKPOINT_PICKER (IframeHost) to the page

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -53,6 +53,12 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -60,6 +66,11 @@ vi.mock('~/utils/trpc', () => ({
     },
     useUtils: () => ({
       apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
         storage: {
           get: { fetch: vi.fn() },
           list: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -54,6 +54,12 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -61,6 +67,11 @@ vi.mock('~/utils/trpc', () => ({
     },
     useUtils: () => ({
       apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
         storage: {
           get: { fetch: vi.fn() },
           list: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -51,6 +51,12 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -58,6 +64,11 @@ vi.mock('~/utils/trpc', () => ({
     },
     useUtils: () => ({
       apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
         storage: {
           get: { fetch: vi.fn() },
           list: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
@@ -1,0 +1,525 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { useDialogStore } from '~/components/Dialog/dialogStore';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * App Blocks SHARED (cross-user / app-global) storage bridge — host side (Phase 2b).
+ *
+ * A full-page App Block (`/apps/run/<slug>`, entity=none) that uses the SHARED
+ * datastore drives it through the @civitai/app-sdk shared-storage hook, which
+ * posts SHARED_LIST / GET_COUNT / GET_COUNTS / APPEND / VOTE / UNVOTE / WITHDRAW
+ * and AWAITS the matching SHARED_*_RESULT. Unhandled ⇒ the block hangs to the SDK
+ * 30s timeout (the same "spins forever, no network call, no error" class as the
+ * per-user APP_STORAGE gap). PageBlockHost bridges each to `trpc.apps.shared.*`.
+ *
+ * These tests mount the REAL PageBlockHost and drive the actual postMessage
+ * bridge, asserting for each of the 7 ops that the host:
+ *   1. forwards to the matching `apps.shared.*` proc — reads via
+ *      trpc.useUtils()...fetch, writes via the useMutation mock — with the page
+ *      `token` prop injected as `blockToken` (NEVER a token from the message) +
+ *      the args, and
+ *   2. posts the matching `*_RESULT` reply with the requestId + expected payload
+ *      on BOTH the success path and the error path (`{ requestId, error }`, never
+ *      a hang).
+ * Plus: a shared message with the block token spoofed in the message body still
+ * forwards the HOST token; a message with no requestId is dropped; and a null
+ * page token forwards no proc call.
+ *
+ * trpc is mocked via `vi.mock('~/utils/trpc')` (the scaffold's documented
+ * pattern) so this stays network-free. Replies are captured on the iframe's
+ * contentWindow `message` channel — identical to the APP_STORAGE test.
+ */
+
+// Per-test-controllable proc impls. `vi.mock` is hoisted, so the fns live in a
+// hoisted block the factory closes over. Reads go through trpc.useUtils()...fetch;
+// writes through trpc.apps.shared.{append,vote,unvote,withdraw}.useMutation().mutateAsync.
+const mocks = vi.hoisted(() => ({
+  // shared reads
+  list: vi.fn(),
+  getCount: vi.fn(),
+  getCounts: vi.fn(),
+  // shared writes
+  append: vi.fn(),
+  vote: vi.fn(),
+  unvote: vi.fn(),
+  withdraw: vi.fn(),
+  // per-user storage reads/writes (also wired at render; inert here)
+  storageGet: vi.fn(),
+  storageSet: vi.fn(),
+  storageDelete: vi.fn(),
+  storageList: vi.fn(),
+  storageGetQuota: vi.fn(),
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider (in PageBlockHost's real render graph) statically imports
+  // `setTrpcBatchingEnabled` from this module (#2946). vi.mock replaces the module
+  // wholesale, so the factory must re-declare it or the ESM link fails.
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    // PageBlockHost also wires the workflow bridge at render (inert here); stub so
+    // it mounts.
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: mocks.storageSet }) },
+        delete: { useMutation: () => ({ mutateAsync: mocks.storageDelete }) },
+      },
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: mocks.append }) },
+        vote: { useMutation: () => ({ mutateAsync: mocks.vote }) },
+        unvote: { useMutation: () => ({ mutateAsync: mocks.unvote }) },
+        withdraw: { useMutation: () => ({ mutateAsync: mocks.withdraw }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        storage: {
+          get: { fetch: mocks.storageGet },
+          list: { fetch: mocks.storageList },
+          getQuota: { fetch: mocks.storageGetQuota },
+        },
+        shared: {
+          list: { fetch: mocks.list },
+          getCount: { fetch: mocks.getCount },
+          getCounts: { fetch: mocks.getCounts },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+// Dispatch a message FROM the host iframe: source = iframe.contentWindow,
+// origin = host expectedOrigin (same-origin src). Satisfies both authenticating
+// pins usePostMessage enforces.
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+// Capture host→block replies. `send` posts onto the iframe's contentWindow.
+function listenForReply() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'my-page-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Requests',
+  iframeSrc: SAME_ORIGIN_SRC,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'my-page-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['apps:storage:shared:read', 'apps:storage:shared:write'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 42, username: 'tester' },
+  theme: 'light' as const,
+};
+
+async function driveToReady() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+describe('PageBlockHost SHARED storage bridge (Phase 2b cross-user datastore)', () => {
+  beforeEach(() => {
+    mocks.list.mockReset();
+    mocks.getCount.mockReset();
+    mocks.getCounts.mockReset();
+    mocks.append.mockReset();
+    mocks.vote.mockReset();
+    mocks.unvote.mockReset();
+    mocks.withdraw.mockReset();
+    useDialogStore.getState().closeAll();
+  });
+
+  // ── SHARED_LIST ────────────────────────────────────────────────────────────
+  test('SHARED_LIST forwards clamped args + host token and posts SHARED_LIST_RESULT', async () => {
+    const createdAt = new Date('2026-06-17T00:00:00.000Z');
+    const updatedAt = new Date('2026-06-18T00:00:00.000Z');
+    mocks.list.mockResolvedValue({
+      items: [
+        {
+          key: '01ABC',
+          authorUserId: 7,
+          value: { title: 'Add dark mode', body: 'please' },
+          count: 3,
+          createdAt,
+          updatedAt,
+        },
+      ],
+      nextCursor: 'cur2',
+    });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    // limit 9999 clamped to the server max (100); a spoofed blockToken in the
+    // message body must be IGNORED (host injects its own token).
+    postFromBlock('SHARED_LIST', {
+      requestId: 'rq_list',
+      prefix: 'p',
+      limit: 9999,
+      cursor: 'cur1',
+      blockToken: 'SPOOFED',
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.list).toHaveBeenCalledWith({
+        blockToken: 'tok_abc',
+        prefix: 'p',
+        limit: 100,
+        cursor: 'cur1',
+      });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_LIST_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_list',
+        items: [
+          {
+            key: '01ABC',
+            authorUserId: 7,
+            value: { title: 'Add dark mode', body: 'please' },
+            count: 3,
+            createdAt: '2026-06-17T00:00:00.000Z',
+            updatedAt: '2026-06-18T00:00:00.000Z',
+          },
+        ],
+        nextCursor: 'cur2',
+      });
+    });
+    replies.stop();
+  });
+
+  test('SHARED_LIST error path posts { requestId, error } (no hang)', async () => {
+    mocks.list.mockRejectedValue(new Error('shared storage is not enabled'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_LIST', { requestId: 'rq_list_err' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_LIST_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_list_err',
+        error: 'shared storage is not enabled',
+      });
+    });
+    replies.stop();
+  });
+
+  // ── SHARED_GET_COUNT ─────────────────────────────────────────────────────────
+  test('SHARED_GET_COUNT forwards key + host token and posts SHARED_GET_COUNT_RESULT', async () => {
+    mocks.getCount.mockResolvedValue({ count: 5 });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_GET_COUNT', { requestId: 'rq_gc', key: '01ABC', blockToken: 'SPOOFED' });
+
+    await vi.waitFor(() => {
+      expect(mocks.getCount).toHaveBeenCalledWith({ blockToken: 'tok_abc', key: '01ABC' });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_GET_COUNT_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_gc', count: 5 });
+    });
+    replies.stop();
+  });
+
+  test('SHARED_GET_COUNT error path posts { requestId, error } (no hang)', async () => {
+    mocks.getCount.mockRejectedValue(new Error('request not found'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_GET_COUNT', { requestId: 'rq_gc_err', key: 'missing' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_GET_COUNT_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_gc_err', error: 'request not found' });
+    });
+    replies.stop();
+  });
+
+  // ── SHARED_GET_COUNTS ────────────────────────────────────────────────────────
+  test('SHARED_GET_COUNTS forwards keys + host token and posts SHARED_GET_COUNTS_RESULT', async () => {
+    mocks.getCounts.mockResolvedValue({ counts: { a: 1, b: 0 } });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_GET_COUNTS', {
+      requestId: 'rq_gcs',
+      keys: ['a', 'b'],
+      blockToken: 'SPOOFED',
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.getCounts).toHaveBeenCalledWith({ blockToken: 'tok_abc', keys: ['a', 'b'] });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_GET_COUNTS_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_gcs', counts: { a: 1, b: 0 } });
+    });
+    replies.stop();
+  });
+
+  test('SHARED_GET_COUNTS error path posts { requestId, error } (no hang)', async () => {
+    mocks.getCounts.mockRejectedValue(new Error('too many keys'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_GET_COUNTS', { requestId: 'rq_gcs_err', keys: ['a'] });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_GET_COUNTS_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_gcs_err', error: 'too many keys' });
+    });
+    replies.stop();
+  });
+
+  // ── SHARED_APPEND ────────────────────────────────────────────────────────────
+  test('SHARED_APPEND forwards value + host token and posts SHARED_APPEND_RESULT', async () => {
+    mocks.append.mockResolvedValue({ key: '01NEW' });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_APPEND', {
+      requestId: 'rq_app',
+      value: { title: 'New idea', body: 'details' },
+      blockToken: 'SPOOFED',
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.append).toHaveBeenCalledWith({
+        blockToken: 'tok_abc',
+        value: { title: 'New idea', body: 'details' },
+      });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_APPEND_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_app', key: '01NEW' });
+    });
+    replies.stop();
+  });
+
+  test('SHARED_APPEND error path posts { requestId, error } (no hang)', async () => {
+    mocks.append.mockRejectedValue(new Error('Too many submissions — retry in 30s'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_APPEND', { requestId: 'rq_app_err', value: { title: 'spam' } });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_APPEND_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_app_err',
+        error: 'Too many submissions — retry in 30s',
+      });
+    });
+    replies.stop();
+  });
+
+  // ── SHARED_VOTE ──────────────────────────────────────────────────────────────
+  test('SHARED_VOTE forwards key + host token and posts SHARED_VOTE_RESULT', async () => {
+    mocks.vote.mockResolvedValue({ count: 4 });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_VOTE', { requestId: 'rq_vote', key: '01ABC', blockToken: 'SPOOFED' });
+
+    await vi.waitFor(() => {
+      expect(mocks.vote).toHaveBeenCalledWith({ blockToken: 'tok_abc', key: '01ABC' });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_VOTE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_vote', count: 4 });
+    });
+    replies.stop();
+  });
+
+  test('SHARED_VOTE error path posts { requestId, error } (no hang)', async () => {
+    mocks.vote.mockRejectedValue(new Error('request not found'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_VOTE', { requestId: 'rq_vote_err', key: 'missing' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_VOTE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_vote_err', error: 'request not found' });
+    });
+    replies.stop();
+  });
+
+  // ── SHARED_UNVOTE ────────────────────────────────────────────────────────────
+  test('SHARED_UNVOTE forwards key + host token and posts SHARED_UNVOTE_RESULT', async () => {
+    mocks.unvote.mockResolvedValue({ count: 2 });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_UNVOTE', { requestId: 'rq_unvote', key: '01ABC', blockToken: 'SPOOFED' });
+
+    await vi.waitFor(() => {
+      expect(mocks.unvote).toHaveBeenCalledWith({ blockToken: 'tok_abc', key: '01ABC' });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_UNVOTE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_unvote', count: 2 });
+    });
+    replies.stop();
+  });
+
+  test('SHARED_UNVOTE error path posts { requestId, error } (no hang)', async () => {
+    mocks.unvote.mockRejectedValue(new Error('Too many votes — retry in 10s'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_UNVOTE', { requestId: 'rq_unvote_err', key: '01ABC' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_UNVOTE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_unvote_err',
+        error: 'Too many votes — retry in 10s',
+      });
+    });
+    replies.stop();
+  });
+
+  // ── SHARED_WITHDRAW ──────────────────────────────────────────────────────────
+  test('SHARED_WITHDRAW forwards key + host token and posts SHARED_WITHDRAW_RESULT', async () => {
+    mocks.withdraw.mockResolvedValue({ ok: true, deleted: true });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_WITHDRAW', {
+      requestId: 'rq_wd',
+      key: '01ABC',
+      blockToken: 'SPOOFED',
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.withdraw).toHaveBeenCalledWith({ blockToken: 'tok_abc', key: '01ABC' });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_WITHDRAW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_wd', ok: true, deleted: true });
+    });
+    replies.stop();
+  });
+
+  test('SHARED_WITHDRAW error path posts { requestId, error } (no hang)', async () => {
+    mocks.withdraw.mockRejectedValue(new Error('storage unavailable'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_WITHDRAW', { requestId: 'rq_wd_err', key: '01ABC' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_WITHDRAW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_wd_err', error: 'storage unavailable' });
+    });
+    replies.stop();
+  });
+
+  // ── Gating: pre-ready / no requestId / null token ────────────────────────────
+  test('a shared message with NO requestId is dropped (no proc call, no reply)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_VOTE', { key: '01ABC' }); // missing requestId
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(mocks.vote).not.toHaveBeenCalled();
+    expect(replies.last('SHARED_VOTE_RESULT')).toBeUndefined();
+    replies.stop();
+  });
+
+  test('a shared message with a null page token is dropped (cannot forward a shared call)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} token={null} />);
+    // With a null token the host never reaches BLOCK_READY (the iframe gates on
+    // token); either way the handler must refuse to call the proc — apps.shared.*
+    // require a non-null blockToken.
+    await vi.waitFor(() => {
+      const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement | null;
+      if (!el) return;
+    });
+    expect(mocks.vote).not.toHaveBeenCalled();
+    expect(mocks.list).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -40,6 +40,12 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -47,6 +53,11 @@ vi.mock('~/utils/trpc', () => ({
     },
     useUtils: () => ({
       apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
         storage: {
           get: { fetch: vi.fn() },
           list: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
@@ -59,6 +59,12 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
       storage: {
         set: { useMutation: () => ({ mutateAsync: mocks.set }) },
         delete: { useMutation: () => ({ mutateAsync: mocks.del }) },
@@ -66,6 +72,11 @@ vi.mock('~/utils/trpc', () => ({
     },
     useUtils: () => ({
       apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
         storage: {
           get: { fetch: mocks.get },
           list: { fetch: mocks.list },

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -57,6 +57,12 @@ vi.mock('~/utils/trpc', () => ({
     // PageBlockHost also wires the storage bridge (inert here — exercised in
     // PageBlockHostStorage.browser.test.tsx); stub so the component mounts.
     apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -64,6 +70,11 @@ vi.mock('~/utils/trpc', () => ({
     },
     useUtils: () => ({
       apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
         storage: {
           get: { fetch: vi.fn() },
           list: { fetch: vi.fn() },

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -274,6 +274,64 @@ export const INVENTORY = {
     PageBlockHost: 'required',
     InlineHost: INLINE_STUB,
   },
+  // ── SHARED (cross-user / app-global) storage (Phase 2b) ────────────────────
+  // The public-write sibling of the per-user APP_STORAGE_* bridge. REQUEST-style
+  // (each awaits its SHARED_*_RESULT ⇒ unhandled HANGS the block). The shared
+  // voting/requests app is a PAGE app (entity=none) so PageBlockHost is the
+  // primary target, but the shared datastore is a per-APP surface an app's
+  // model-slot block could also read, so BOTH real hosts wire it (matching the
+  // per-user APP_STORAGE_* placement). Ahead of the published SDK dist union
+  // (forward-looking coverage, like APP_STORAGE_* were) — the compile-time gate
+  // is one-directional so extra keys here are fine.
+  SHARED_LIST: {
+    request: true,
+    reply: 'SHARED_LIST_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  SHARED_GET_COUNT: {
+    request: true,
+    reply: 'SHARED_GET_COUNT_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  SHARED_GET_COUNTS: {
+    request: true,
+    reply: 'SHARED_GET_COUNTS_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  SHARED_APPEND: {
+    request: true,
+    reply: 'SHARED_APPEND_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  SHARED_VOTE: {
+    request: true,
+    reply: 'SHARED_VOTE_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  SHARED_UNVOTE: {
+    request: true,
+    reply: 'SHARED_UNVOTE_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  SHARED_WITHDRAW: {
+    request: true,
+    reply: 'SHARED_WITHDRAW_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
 } satisfies Record<string, MessageSpec>;
 
 /**


### PR DESCRIPTION
Phase 2b of App Blocks **shared/cross-user storage**: the civitai **host** postMessage bridge from a block's shared-storage requests to the `trpc.apps.shared.*` server endpoints (server core = #3013). Pairs with the SDK hook (civitai-app-starters#126).

## What
7 `SHARED_*` `onMessage` handlers in **PageBlockHost + IframeHost**, mirroring the existing `APP_STORAGE_*` handlers exactly:
`SHARED_LIST / GET_COUNT / GET_COUNTS` (queries) + `SHARED_APPEND / VOTE / UNVOTE / WITHDRAW` (mutations) → `SHARED_*_RESULT`.

- **Host injects the block token** it already holds (`token` prop); a message-supplied `blockToken` is ignored (tested).
- Same gates as the storage handlers (non-null token + `requestId`); `storageErrorMessage` on failure; error reply is exactly `{ requestId, error }`.
- **Dates serialized to ISO strings** on the wire (matches the SDK hook, which rehydrates to `Date`).
- `hostHandlerParity` INVENTORY updated (both hosts `required`).

**Inert until** a block's token carries `apps:storage:shared:*` (approved app declares the scope) **and** the `app-blocks-shared-storage` flag is on — so nothing activates on merge.

## Protocol agreement with the SDK (civitai-app-starters#126)
Independently converged: no token in the message · ISO-string dates · `{requestId, error}` error shape · item `{key, authorUserId, value:{title,body?}, count, createdAt, updatedAt}` · vote/unvote return post-op count · withdraw `{ok, deleted}`.

## Regression fixed
The new render-time `trpc.apps.shared.<write>.useMutation()` calls needed `apps.shared` stubs in the 8 existing host browser-test mocks (mirroring the `apps.storage` stubs) — else render crashed with a 10s timeout. Added; no behavior change to existing handlers.

## Tests — 109 component + 88 parity pass
New `PageBlockHostSharedStorage.browser.test.tsx` (16: 7 ops × success+error, host-token-injection + spoof-ignored, no-requestId drop, null-token drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)