### PR TITLE
feat(apps): non-error pending attach result + content-rating auto-derive/mod-override

### DIFF
--- a/src/components/Apps/ListingAssetStep.browser.test.tsx
+++ b/src/components/Apps/ListingAssetStep.browser.test.tsx
@@ -10,17 +10,16 @@ import { renderWithProviders } from '../../../test/component-setup';
  *
  * Two behaviours are asserted (the client half of the OG-pull-ingest fix):
  *  1. A freshly-ingested image is NOT attached eagerly — the row shows a
- *     "Scanning image…" state while the attach proc keeps rejecting with the
- *     RETRIABLE structural signal (tRPC code `CONFLICT` on `error.data.code`), and
- *     flips to "attached" only once the attach resolves (scan complete). The
- *     retriable rejection here uses a DELIBERATELY REWORDED human message (no
- *     "scan is not complete" text) to prove the component keeps polling off the
- *     STRUCTURAL code, not the prose. (Poll logic proven pure in
+ *     "Scanning image…" state while the attach proc RESOLVES with the non-error
+ *     `{ status: 'pending' }` result (scanning is no longer a 4xx — supersedes the
+ *     old CONFLICT), and flips to "attached" only once the attach resolves
+ *     `{ status: 'attached' }` (scan complete). The decision is structural over the
+ *     resolved `status`, never prose. (Poll logic proven pure in
  *     `__tests__/assetPolling.test.ts`; this proves the component wiring.)
- *  2. A TERMINAL ingest failure — the attach proc rejecting with the terminal
- *     code (`BAD_REQUEST`) the server returns for a `NotFound` image — surfaces
- *     the CLEAR human message and leaves the manual-upload FileInput usable (never
- *     an eternal "still scanning" dead-end).
+ *  2. A TERMINAL ingest failure — the attach proc THROWING the terminal error the
+ *     server returns for a `NotFound` image — surfaces the CLEAR human message and
+ *     leaves the manual-upload FileInput usable (never an eternal "still scanning"
+ *     dead-end).
  */
 
 /**
@@ -115,15 +114,12 @@ describe('ListingAssetStep — OG-image auto-fill', () => {
 
   test('accepting a suggestion shows a scanning state, then attaches once the scan lands', async () => {
     mocks.ingestAsync.mockResolvedValue({ imageId: 777 });
-    // The attach proc rejects with the RETRIABLE code (CONFLICT) while the image
-    // is still scanning, then resolves once the scan lands — the polling drives to
-    // attached. The message is deliberately REWORDED (no "scan is not complete"
-    // text) to prove the poll decision is structural (code), not prose-matched.
+    // The attach proc RESOLVES with the non-error `{ status: 'pending' }` while the
+    // image is still scanning (no throw — supersedes the old CONFLICT), then resolves
+    // `{ status: 'attached' }` once the scan lands — the polling drives to attached.
     mocks.setIconAsync
-      .mockRejectedValueOnce(
-        trpcAttachError('CONFLICT', 'hang tight — still checking your picture')
-      )
-      .mockResolvedValue({ ok: true });
+      .mockResolvedValueOnce({ status: 'pending' })
+      .mockResolvedValue({ status: 'attached', iconId: 777 });
 
     renderStep();
     await page.getByTestId('apps-offsite-accept-icon').click();

--- a/src/components/Apps/ListingAssetStep.tsx
+++ b/src/components/Apps/ListingAssetStep.tsx
@@ -173,24 +173,28 @@ export function ListingAssetStep({
 
   async function attachOnce(key: string, kind: AssetKind, imageId: number): Promise<AttachOutcome> {
     try {
+      let res: { status: 'pending' | 'attached'; id?: string };
       if (kind === 'icon') {
-        await setIconMutation.mutateAsync({ listingId, imageId });
+        res = await setIconMutation.mutateAsync({ listingId, imageId });
       } else if (kind === 'cover') {
-        await setCoverMutation.mutateAsync({ listingId, imageId });
+        res = await setCoverMutation.mutateAsync({ listingId, imageId });
       } else {
-        const res = await addScreenshotMutation.mutateAsync({ listingId, imageId });
-        // Capture the row id so a freshly-added screenshot is also removable.
-        if (res && typeof (res as { id?: unknown }).id === 'string') {
-          rowIdRef.current.set(key, (res as { id: string }).id);
+        res = await addScreenshotMutation.mutateAsync({ listingId, imageId });
+        // Capture the row id so a freshly-added screenshot is also removable — only
+        // present once the attach ACTUALLY happened (status 'attached'); a 'pending'
+        // result has no row yet.
+        if (res && res.status === 'attached' && typeof res.id === 'string') {
+          rowIdRef.current.set(key, res.id);
         }
       }
-      return classifyAttachResult(null);
+      // Decide retriable-vs-terminal off the mutation's resolved `status`, NOT prose.
+      // A 'pending' result → scanning (keep polling); 'attached' → done. (See
+      // assetPolling.classifyAttachResult — pending is no longer an error.)
+      return classifyAttachResult({ result: res });
     } catch (err) {
-      // Decide retriable-vs-terminal off the STRUCTURAL tRPC error code
-      // (`error.data.code`), NOT the prose. The message is passed through for
-      // DISPLAY only. (See assetPolling.classifyAttachResult.)
-      const code = (err as { data?: { code?: string } })?.data?.code;
-      return classifyAttachResult({ code, message: (err as Error).message });
+      // A THROWN error is terminal (not-found / blocked / bad-format). The message
+      // is passed through for DISPLAY only.
+      return classifyAttachResult({ error: { message: (err as Error).message } });
     }
   }
 

--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -29,6 +29,7 @@ const OFFSITE_ROW = {
 
 const mocks = vi.hoisted(() => ({
   invalidate: vi.fn().mockResolvedValue(undefined),
+  approveMutate: vi.fn(),
 }));
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
@@ -61,12 +62,27 @@ vi.mock('~/utils/trpc', () => {
         },
         getAssets: {
           useQuery: () => ({
-            data: { listingId: 'listing-1', iconId: 10, coverId: 11, screenshots: [{ imageId: 12 }] },
+            // Icon/cover PG (1); a screenshot at R (4) → derived rating 'r', which is
+            // HIGHER than the declared 'g' (mismatch case).
+            data: {
+              listingId: 'listing-1',
+              iconId: 10,
+              coverId: 11,
+              iconNsfwLevel: 1,
+              coverNsfwLevel: 1,
+              screenshots: [{ imageId: 12, nsfwLevel: 4 }],
+            },
             isLoading: false,
             error: null,
           }),
         },
-        approveExternalRequest: { useMutation: mutation },
+        approveExternalRequest: {
+          useMutation: () => ({
+            mutate: mocks.approveMutate,
+            mutateAsync: vi.fn(),
+            isPending: false,
+          }),
+        },
         rejectExternalRequest: { useMutation: mutation },
       },
     },
@@ -77,6 +93,7 @@ const { OffsiteReviewQueue } = await import('./OffsiteReviewQueue');
 
 beforeEach(() => {
   mocks.invalidate.mockClear();
+  mocks.approveMutate.mockClear();
 });
 
 describe('OffsiteReviewQueue — kind-aware review row', () => {
@@ -149,5 +166,33 @@ describe('OffsiteReviewModal — approve-notes gating, friendly date, field labe
     // The badge values they label are still rendered.
     await expect.element(page.getByText('utility', { exact: true })).toBeInTheDocument();
     await expect.element(page.getByText('g', { exact: true })).toBeInTheDocument();
+  });
+});
+
+describe('OffsiteReviewModal — content-rating derive + mod override', () => {
+  test('surfaces the DERIVED rating and FLAGS it as higher than the declared rating', async () => {
+    renderWithProviders(<OffsiteReviewQueue />);
+    await page.getByRole('button', { name: 'Review' }).click();
+    // Derived from the assets (max R) → 'r', shown alongside the declared 'g'.
+    await expect
+      .element(page.getByTestId('apps-offsite-derived-rating'))
+      .toHaveTextContent('r');
+    // Assets more mature than declared → the mismatch warning renders.
+    await expect
+      .element(page.getByTestId('apps-offsite-rating-mismatch'))
+      .toBeInTheDocument();
+  });
+
+  test('the approve rating Select defaults to the derived value and approve passes it', async () => {
+    renderWithProviders(<OffsiteReviewQueue />);
+    await page.getByRole('button', { name: 'Review' }).click();
+    await page.getByTestId('apps-offsite-approve-open').click();
+    // The Select is present (defaulting to the derived rating), and confirming approve
+    // forwards the chosen rating to the mutation.
+    await expect.element(page.getByTestId('apps-offsite-approve-rating')).toBeInTheDocument();
+    await page.getByTestId('apps-offsite-approve-confirm').click();
+    expect(mocks.approveMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ publishRequestId: 'req-1', contentRating: 'r' })
+    );
   });
 });

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -12,6 +12,7 @@ import {
   Modal,
   NumberInput,
   SegmentedControl,
+  Select,
   Stack,
   Table,
   Text,
@@ -41,7 +42,15 @@ import {
   type ReportRowAction,
 } from '~/components/Apps/appListingModerationView';
 import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
+import {
+  OFFSITE_CONTENT_RATINGS,
+  type OffsiteContentRating,
+} from '~/server/schema/blocks/offsite-listing.schema';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
+import {
+  deriveContentRatingFromAssets,
+  nsfwLevelFromContentRating,
+} from '~/shared/constants/browsingLevel.constants';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { formatDate as formatDateHelper } from '~/utils/date-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -218,6 +227,10 @@ function OffsiteReviewModal({
   // own notes textarea + confirm (approve gated behind an explicit "Approve…" click,
   // mirroring reject — so a stray click can't approve with un-reviewed notes).
   const [actionMode, setActionMode] = useState<'view' | 'reject' | 'approve'>('view');
+  // The mod's chosen final content rating. `null` = "follow the derived value" (the
+  // Select shows the derived rating as its default); a non-null value is an explicit
+  // override. The server FLOORS an under-rating override at the derived value.
+  const [ratingOverride, setRatingOverride] = useState<OffsiteContentRating | null>(null);
 
   // Asset presence for the content checklist (author/mod-gated; a mod passes the
   // author floor). Only enabled once a row with a draft listing is open.
@@ -255,16 +268,37 @@ function OffsiteReviewModal({
     setRejectionReason('');
     setApprovalNotes('');
     setActionMode('view');
+    setRatingOverride(null);
     onClose();
   }
 
   if (!request) return null;
 
-  const screenshotCount = (assetsQuery.data?.screenshots ?? []).filter(
-    (s: { imageId: number | null }) => s.imageId != null
-  ).length;
+  const screenshots = (assetsQuery.data?.screenshots ?? []) as {
+    imageId: number | null;
+    nsfwLevel?: number | null;
+  }[];
+  const screenshotCount = screenshots.filter((s) => s.imageId != null).length;
   const hasIcon = assetsQuery.data?.iconId != null;
   const hasCover = assetsQuery.data?.coverId != null;
+
+  // Content rating: DERIVE from the assets' max detected nsfwLevel (icon + cover +
+  // screenshots), surface it ALONGSIDE the author-declared rating, and FLAG when the
+  // assets are more mature than declared. The Select defaults to the derived value;
+  // the mod may rate UP (an under-rating is floored server-side).
+  const assetLevels: (number | null | undefined)[] = [
+    (assetsQuery.data as { iconNsfwLevel?: number | null } | undefined)?.iconNsfwLevel,
+    (assetsQuery.data as { coverNsfwLevel?: number | null } | undefined)?.coverNsfwLevel,
+    ...screenshots.map((s) => s.nsfwLevel),
+  ];
+  const derivedRating = deriveContentRatingFromAssets(
+    assetLevels.map((nsfwLevel) => ({ nsfwLevel: nsfwLevel ?? null }))
+  );
+  const declaredRating = request.appListing?.contentRating ?? null;
+  const ratingMismatch =
+    !assetsQuery.isLoading &&
+    nsfwLevelFromContentRating(derivedRating) > nsfwLevelFromContentRating(declaredRating);
+  const selectedRating: OffsiteContentRating = ratingOverride ?? derivedRating;
 
   const checklist = getOffsiteReviewChecklist({
     name: request.appListing?.name,
@@ -359,6 +393,24 @@ function OffsiteReviewModal({
                   <Badge size="sm" color="gray" variant="light">
                     {request.appListing.contentRating}
                   </Badge>
+                  <Text size="xs" c="dimmed">
+                    declared
+                  </Text>
+                </Group>
+              )}
+              {!assetsQuery.isLoading && (
+                <Group gap={6}>
+                  <Text size="xs" c="dimmed">
+                    Detected from assets
+                  </Text>
+                  <Badge
+                    size="sm"
+                    color={ratingMismatch ? 'red' : 'blue'}
+                    variant="light"
+                    data-testid="apps-offsite-derived-rating"
+                  >
+                    {derivedRating}
+                  </Badge>
                 </Group>
               )}
             </Group>
@@ -418,6 +470,21 @@ function OffsiteReviewModal({
           </Alert>
         )}
 
+        {ratingMismatch && (
+          <Alert
+            color="red"
+            variant="light"
+            icon={<IconAlertTriangle size={16} />}
+            data-testid="apps-offsite-rating-mismatch"
+          >
+            <Text size="sm">
+              Assets contain higher-maturity content ({derivedRating}) than the declared rating (
+              {declaredRating ?? '—'}). The final rating defaults to the detected value; rate it at
+              least that high.
+            </Text>
+          </Alert>
+        )}
+
         {actionMode === 'reject' ? (
           <Stack gap="xs">
             <Text size="sm" fw={600}>
@@ -456,6 +523,16 @@ function OffsiteReviewModal({
           </Stack>
         ) : actionMode === 'approve' ? (
           <Stack gap="xs">
+            <Select
+              label="Final content rating"
+              description="Defaults to the rating detected from the assets. You may rate up; an under-rating is floored to the detected value on save."
+              data={OFFSITE_CONTENT_RATINGS.map((r) => ({ value: r, label: r }))}
+              value={selectedRating}
+              onChange={(v) => setRatingOverride((v as OffsiteContentRating) ?? null)}
+              disabled={busy}
+              allowDeselect={false}
+              data-testid="apps-offsite-approve-rating"
+            />
             <Text size="sm" fw={600}>
               Approval notes (optional)
             </Text>
@@ -480,6 +557,7 @@ function OffsiteReviewModal({
                   approveMut.mutate({
                     publishRequestId: request.id,
                     approvalNotes: approvalNotes.trim() || undefined,
+                    contentRating: selectedRating,
                   })
                 }
                 disabled={busy}

--- a/src/components/Apps/__tests__/assetPolling.test.ts
+++ b/src/components/Apps/__tests__/assetPolling.test.ts
@@ -15,24 +15,18 @@ import {
  */
 
 describe('classifyAttachResult', () => {
-  it('null (resolved) → attached (terminal)', () => {
-    expect(classifyAttachResult(null)).toEqual({ kind: 'attached' });
+  it('a resolved { status: "attached" } → attached (terminal)', () => {
+    expect(classifyAttachResult({ result: { status: 'attached' } })).toEqual({ kind: 'attached' });
   });
 
-  it('CONFLICT code → scanning (retriable)', () => {
-    expect(
-      classifyAttachResult({
-        code: 'CONFLICT',
-        message: 'image is not approved for publishing (scan is not complete)',
-      })
-    ).toEqual({ kind: 'scanning' });
+  it('a resolved { status: "pending" } → scanning (retriable — keep polling)', () => {
+    expect(classifyAttachResult({ result: { status: 'pending' } })).toEqual({ kind: 'scanning' });
   });
 
-  it('BAD_REQUEST code → error (terminal) carrying the human message', () => {
+  it('a THROWN error → error (terminal) carrying the human message', () => {
     expect(
       classifyAttachResult({
-        code: 'BAD_REQUEST',
-        message: "that image couldn't be imported — upload it manually instead",
+        error: { message: "that image couldn't be imported — upload it manually instead" },
       })
     ).toEqual({
       kind: 'error',
@@ -40,41 +34,25 @@ describe('classifyAttachResult', () => {
     });
   });
 
-  it('BAD_REQUEST (blocked) → error (terminal)', () => {
+  it('a THROWN "blocked" error → error (terminal)', () => {
     expect(
       classifyAttachResult({
-        code: 'BAD_REQUEST',
-        message: 'that image was rejected during scanning — choose a different image',
+        error: { message: 'that image was rejected during scanning — choose a different image' },
       }).kind
     ).toBe('error');
   });
 
-  it('an undefined / unknown code → error (terminal, fail-safe)', () => {
+  // REGRESSION GUARD: pending is a resolved SUCCESS RESULT (its own `status`), NOT
+  // an error the poller keys off a tRPC code. So the decision is purely structural
+  // over `status` — prose never drives it, and there is no CONFLICT code anymore.
+  // A pending result whose (irrelevant) surrounding message would sound terminal
+  // still classifies as scanning; a thrown error that sounds retriable is still
+  // terminal.
+  it('classification is driven by the resolved status / throw, never by prose', () => {
+    expect(classifyAttachResult({ result: { status: 'pending' } }).kind).toBe('scanning');
+    // A thrown message that HAPPENS to sound like "scanning" is still terminal.
     expect(
-      classifyAttachResult({ code: undefined, message: 'Image was blocked (NSFW)' })
-    ).toEqual({ kind: 'error', message: 'Image was blocked (NSFW)' });
-  });
-
-  // REGRESSION GUARD: prose no longer drives the decision. The decision reads the
-  // structural tRPC code, so a retriable response whose human message has been
-  // COMPLETELY REWORDED (no "scan is not complete" anywhere) still classifies as
-  // `scanning` — the old regex would have mis-classified this as a terminal error
-  // and stopped polling. Conversely a reworded message that HAPPENS to sound
-  // retriable does NOT flip a BAD_REQUEST into scanning.
-  it('a reworded message does not change the classification (code-driven, not prose)', () => {
-    // Reworded retriable message, still CONFLICT → scanning.
-    expect(
-      classifyAttachResult({
-        code: 'CONFLICT',
-        message: 'hang tight — your picture is still being checked',
-      }).kind
-    ).toBe('scanning');
-    // Reworded terminal message that sounds like "scanning", still BAD_REQUEST → error.
-    expect(
-      classifyAttachResult({
-        code: 'BAD_REQUEST',
-        message: 'scan is not complete (but this is terminal)',
-      }).kind
+      classifyAttachResult({ error: { message: 'scan is not complete (but this threw)' } }).kind
     ).toBe('error');
   });
 });

--- a/src/components/Apps/assetPolling.ts
+++ b/src/components/Apps/assetPolling.ts
@@ -4,38 +4,38 @@
  * so the backoff schedule + the keep-polling / terminal decision are unit-testable
  * WITHOUT mounting the component or faking timers.
  *
- * Context: an attach (setIcon / setCover / addScreenshot) requires a
- * scan-complete image. A freshly-persisted image is still scanning, so the attach
- * first rejects with "scan is not complete". Previously the asset then sat in
- * `processing` forever until the author clicked Retry — there was NO polling. The
- * component now auto-re-runs the attach on the schedule below, transitioning to
- * `attached` the moment the scan lands, to `error` on a NON-scan failure (blocked
- * / NSFW → stop), or to `timeout` once the budget is exhausted (keep the manual
- * Retry).
+ * Context: an attach (setIcon / setCover / addScreenshot) requires a scan-complete
+ * image. A freshly-persisted image is still scanning — so the attach now RESOLVES
+ * with `{ status: 'pending' }` (a normal expected wait, NOT a 4xx) while the scan
+ * is in-flight, and `{ status: 'attached' }` once it lands. The component
+ * auto-re-runs the attach on the schedule below, transitioning to `attached` the
+ * moment the scan lands, to `error` on a THROWN terminal failure (blocked /
+ * not-found / bad-format → stop), or to `timeout` once the budget is exhausted
+ * (keep the manual Retry).
+ *
+ * (Supersedes #3016's pending-CONFLICT: pending is no longer an error the poller
+ * keys off a tRPC `code` — it is the mutation's own resolved `status`.)
  */
 
 /** The classification of a single attach() outcome, independent of React state. */
 export type AttachOutcome =
   /** The attach succeeded — the asset is scan-complete and attached. Terminal. */
   | { kind: 'attached' }
-  /** The attach rejected because the scan isn't complete yet — keep polling. */
+  /** The attach resolved `pending` because the scan isn't complete yet — keep polling. */
   | { kind: 'scanning' }
-  /** The attach rejected for a non-scan reason (blocked / NSFW / bad dims). Terminal. */
+  /** The attach THREW a terminal failure (blocked / not-found / bad-format). Terminal. */
   | { kind: 'error'; message: string };
 
+/** The resolved (success) shape of an attach mutation — the discriminant is `status`. */
+export type AttachResult = { status: 'pending' | 'attached' };
+
 /**
- * The STRUCTURAL fields of a rejected attach() — extracted from the tRPC client
- * error, NOT parsed from its prose. `null` means the attach RESOLVED (success).
- *
- *   - `code`    — the tRPC error code (`error.data.code`): `CONFLICT` (retriable,
- *                 scan not complete yet) vs anything else (terminal). tRPC ALWAYS
- *                 surfaces this on `error.data`.
- *   - `message` — the human message, for DISPLAY only.
+ * The input to {@link classifyAttachResult}: EITHER the RESOLVED mutation result
+ * (`{ result }`) — whose `status` decides pending-vs-attached — OR a THROWN terminal
+ * error (`{ error }`), carrying its human message for DISPLAY only. Pending is no
+ * longer an error, so there is no tRPC `code` to inspect.
  */
-export type AttachError = {
-  code?: string;
-  message: string;
-};
+export type AttachInput = { result: AttachResult } | { error: { message: string } };
 
 /**
  * Backoff schedule (ms) between successive attach re-tries while an image is
@@ -86,19 +86,18 @@ export function nextPollDelay(
 }
 
 /**
- * Classify an attach() result into an {@link AttachOutcome}. PURE. `error === null`
- * means the attach RESOLVED (success → `attached`).
+ * Classify an attach() outcome into an {@link AttachOutcome}. PURE.
  *
- * The retriable-vs-terminal decision is STRUCTURAL — it reads the tRPC error
- * `code`, NEVER the prose (rewording the server message can't change the outcome,
- * which is the whole point of this contract): `CONFLICT` (scan not complete yet)
- * is retriable → `scanning`; anything else is terminal → `error`. The human
- * `message` is carried on the terminal `error` for DISPLAY only.
+ * The retriable-vs-terminal decision is STRUCTURAL — it reads the mutation's own
+ * resolved `status`, NEVER prose (rewording a server message can't change the
+ * outcome). A RESOLVED result with `status: 'pending'` is retriable → `scanning`;
+ * `status: 'attached'` is done → `attached`. A THROWN error is terminal → `error`,
+ * carrying its human `message` for DISPLAY only. (No tRPC `code` inspection —
+ * pending is a success result, not an error.)
  */
-export function classifyAttachResult(error: AttachError | null): AttachOutcome {
-  if (error === null) return { kind: 'attached' };
-  if (error.code === 'CONFLICT') return { kind: 'scanning' };
-  return { kind: 'error', message: error.message };
+export function classifyAttachResult(input: AttachInput): AttachOutcome {
+  if ('error' in input) return { kind: 'error', message: input.error.message };
+  return input.result.status === 'pending' ? { kind: 'scanning' } : { kind: 'attached' };
 }
 
 /**

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -605,6 +605,7 @@ export const appListingsRouter = router({
           publishRequestId: input.publishRequestId,
           reviewerUserId: ctx.user.id,
           approvalNotes: input.approvalNotes,
+          contentRating: input.contentRating,
         });
       } catch (err) {
         throw mapOffsiteError(err);

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -189,6 +189,11 @@ export type SubmitListingRevisionInput = z.infer<typeof submitListingRevisionSch
 export const approveExternalRequestSchema = z.object({
   publishRequestId: z.string().min(1).max(64),
   approvalNotes: z.string().max(OFFSITE_APPROVAL_NOTES_MAX).optional(),
+  // Optional mod OVERRIDE of the final content rating stamped on approve. When
+  // omitted the service stamps the rating DERIVED from the assets' max detected
+  // nsfwLevel; when provided the service FLOORS it at the derived value (never
+  // publishes mature assets under a too-low rating). See `approveExternalRequest`.
+  contentRating: z.enum(OFFSITE_CONTENT_RATINGS).optional(),
 });
 export type ApproveExternalRequestInput = z.infer<typeof approveExternalRequestSchema>;
 

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -28,6 +28,7 @@ const { mockDb, ids } = vi.hoisted(() => ({
     },
     image: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
     },
     appListingScreenshot: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
@@ -58,6 +59,7 @@ function resetDb() {
   mockDb.appListing.findMany.mockReset().mockResolvedValue([]);
   mockDb.appListing.update.mockReset().mockResolvedValue({});
   mockDb.image.findUnique.mockReset().mockResolvedValue(null);
+  mockDb.image.findMany.mockReset().mockResolvedValue([]);
   mockDb.appListingScreenshot.findUnique.mockReset().mockResolvedValue(null);
   mockDb.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
   mockDb.appListingScreenshot.count.mockReset().mockResolvedValue(0);
@@ -296,7 +298,7 @@ describe('screenshot CRUD', () => {
     mockDb.appListingScreenshot.count.mockResolvedValue(3);
     const { addListingScreenshot } = await import('../app-listing-assets.service');
     const res = await addListingScreenshot({ listingId: 'apl_1', imageId: 500 }, owner);
-    expect(res.order).toBe(3);
+    expect(res).toMatchObject({ status: 'attached', order: 3 });
     expect(mockDb.appListingScreenshot.create).toHaveBeenCalledTimes(1);
     const arg = (mockDb.appListingScreenshot.create.mock.calls[0][0] as { data: { order: number } }).data;
     expect(arg.order).toBe(3);
@@ -337,7 +339,7 @@ describe('screenshot CRUD', () => {
     await expect(setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner)).rejects.toThrow();
     mockDb.image.findUnique.mockResolvedValue({ id: 9, userId: 42, type: 'image', width: 512, height: 512, mimeType: 'image/png', metadata: {}, ingestion: 'Scanned', nsfwLevel: 1 });
     const res = await setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner);
-    expect(res.iconId).toBe(9);
+    expect(res).toEqual({ status: 'attached', iconId: 9 });
     expect(mockDb.appListing.update).toHaveBeenCalledWith(
       expect.objectContaining({ data: { iconId: 9 } })
     );
@@ -482,12 +484,10 @@ describe('screenshot CRUD', () => {
     expect(mockDb.appListingScreenshot.create).not.toHaveBeenCalled();
   });
 
-  // The retriable-vs-terminal signal is the STRUCTURAL tRPC code, NOT the human
-  // message string: the transient scanning state throws CONFLICT (retry), the
-  // terminal states throw BAD_REQUEST. The client keys its poll decision off the
-  // code (`error.data.code`), so a message reword can't break the poller.
-  //
-  // Captures a thrown TRPCError so its code + message can be asserted.
+  // A still-scanning image is a NON-ERROR pending RESULT the client polls on — NOT
+  // a thrown 4xx. A TERMINAL ingestion failure still throws BAD_REQUEST so the
+  // client stops polling. Captures a thrown TRPCError so its code + message can be
+  // asserted (used by the terminal cases below).
   async function captureAttachError(
     fn: () => Promise<unknown>
   ): Promise<{ code?: string; message?: string }> {
@@ -500,22 +500,42 @@ describe('screenshot CRUD', () => {
     }
   }
 
-  it('setIcon on a not-yet-scanned Image → RETRIABLE CONFLICT (NOT BAD_REQUEST)', async () => {
+  it('setIcon on a not-yet-scanned Image → NON-ERROR { status: "pending" }, NO write (client re-polls)', async () => {
     mockDb.appListing.findUnique.mockResolvedValue(listingRow);
     mockDb.image.findUnique.mockResolvedValue({
       id: 9, userId: 42, type: 'image', width: 512, height: 512, mimeType: 'image/png',
       metadata: {}, ingestion: 'Pending', nsfwLevel: 1,
     });
     const { setListingIcon } = await import('../app-listing-assets.service');
-    const err = await captureAttachError(() =>
-      setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner)
-    );
-    // Retriable → CONFLICT, NOT the misleading BAD_REQUEST (which implies bad input).
-    expect(err.code).toBe('CONFLICT');
-    expect(err.code).not.toBe('BAD_REQUEST');
-    // Human message unchanged (display only).
-    expect(err.message).toMatch(/not approved for publishing/);
+    // The scanning state no longer throws (the old CONFLICT is gone) — it RESOLVES.
+    const res = await setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner);
+    expect(res).toEqual({ status: 'pending' });
     expect(mockDb.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('addScreenshot on a not-yet-scanned Image → { status: "pending" }, no row created', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(listingRow);
+    mockDb.image.findUnique.mockResolvedValue({
+      ...validScreenshotImage, ingestion: 'PendingManualAssignment',
+    });
+    const { addListingScreenshot } = await import('../app-listing-assets.service');
+    const res = await addListingScreenshot({ listingId: 'apl_1', imageId: 500 }, owner);
+    expect(res).toEqual({ status: 'pending' });
+    expect(mockDb.appListingScreenshot.create).not.toHaveBeenCalled();
+  });
+
+  it('setIcon on a Scanned Image → { status: "attached", iconId } and writes', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(listingRow);
+    mockDb.image.findUnique.mockResolvedValue({
+      id: 9, userId: 42, type: 'image', width: 512, height: 512, mimeType: 'image/png',
+      metadata: {}, ingestion: 'Scanned', nsfwLevel: 1,
+    });
+    const { setListingIcon } = await import('../app-listing-assets.service');
+    const res = await setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner);
+    expect(res).toEqual({ status: 'attached', iconId: 9 });
+    expect(mockDb.appListing.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { iconId: 9 } })
+    );
   });
 
   // A TERMINAL ingestion failure stays BAD_REQUEST, so the client stops polling
@@ -553,26 +573,46 @@ describe('screenshot CRUD', () => {
     expect(mockDb.appListing.update).not.toHaveBeenCalled();
   });
 
-  it('addScreenshot rejects an Image above the listing content rating (null rating → SFW)', async () => {
-    // Listing has no contentRating → fail-closed PG ceiling; image is R (NsfwLevel.R === 4).
+  // W13: the content-rating rejection is REMOVED — assets are never blocked on the
+  // listing's declared rating (the scanner's per-image level is imprecise + every
+  // off-site listing is mod-reviewed, where the rating is derived + confirmed). An
+  // image whose nsfwLevel EXCEEDS the declared rating now ATTACHES (no throw).
+  it('addScreenshot ATTACHES an image above the declared rating (rating no longer blocks)', async () => {
+    // Listing has no contentRating (formerly a fail-closed PG ceiling); image is R.
     mockDb.appListing.findUnique.mockResolvedValue(listingRow);
-    mockDb.image.findUnique.mockResolvedValue({ ...validScreenshotImage, nsfwLevel: 4 });
-    const { addListingScreenshot } = await import('../app-listing-assets.service');
-    await expect(
-      addListingScreenshot({ listingId: 'apl_1', imageId: 500 }, owner)
-    ).rejects.toThrow(/exceeds the listing/);
-    expect(mockDb.appListingScreenshot.create).not.toHaveBeenCalled();
-  });
-
-  it('addScreenshot accepts a mature image when the listing rating allows it (r → R)', async () => {
-    mockDb.appListing.findUnique.mockResolvedValue({ ...listingRow, contentRating: 'r' });
     mockDb.image.findUnique.mockResolvedValue({ ...validScreenshotImage, nsfwLevel: 4 });
     mockDb.appListingScreenshot.findMany.mockResolvedValue([]);
     mockDb.appListingScreenshot.count.mockResolvedValue(0);
     const { addListingScreenshot } = await import('../app-listing-assets.service');
     const res = await addListingScreenshot({ listingId: 'apl_1', imageId: 500 }, owner);
-    expect(res.order).toBe(0);
+    expect(res).toMatchObject({ status: 'attached', order: 0 });
     expect(mockDb.appListingScreenshot.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('setIcon ATTACHES an over-declared-rating image (X image on a g listing)', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ ...listingRow, contentRating: 'g' });
+    mockDb.image.findUnique.mockResolvedValue({
+      id: 9, userId: 42, type: 'image', width: 512, height: 512, mimeType: 'image/png',
+      metadata: {}, ingestion: 'Scanned', nsfwLevel: 8, // NsfwLevel.X
+    });
+    const { setListingIcon } = await import('../app-listing-assets.service');
+    const res = await setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner);
+    expect(res).toEqual({ status: 'attached', iconId: 9 });
+    expect(mockDb.appListing.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { iconId: 9 } })
+    );
+  });
+
+  // A Blocked image is STILL a hard integrity reject (prohibited content, not a
+  // rating mismatch) — it must never attach regardless of the listing's rating.
+  it('addScreenshot still REJECTS a Blocked image (integrity reject, not a rating gate)', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ ...listingRow, contentRating: 'x' });
+    mockDb.image.findUnique.mockResolvedValue({ ...validScreenshotImage, ingestion: 'Blocked' });
+    const { addListingScreenshot } = await import('../app-listing-assets.service');
+    await expect(
+      addListingScreenshot({ listingId: 'apl_1', imageId: 500 }, owner)
+    ).rejects.toThrow(/rejected during scanning/);
+    expect(mockDb.appListingScreenshot.create).not.toHaveBeenCalled();
   });
 
   it('reorderScreenshots rejects a same-length but FOREIGN id set', async () => {
@@ -617,6 +657,46 @@ describe('screenshot CRUD', () => {
     const res = await getListingAssets({ listingId: 'apl_1' }, mod);
     expect(res.completeness).toEqual({ complete: true });
     expect(res.screenshots).toHaveLength(1);
+  });
+
+  it('getAssets includes each asset\'s nsfwLevel (icon + cover + screenshots) for the review derive', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ ...listingRow, iconId: 1, coverId: 2 });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([
+      { id: 's1', imageId: 10, order: 0, caption: null },
+      { id: 's2', imageId: 11, order: 1, caption: null },
+    ]);
+    // Icon PG(1), cover PG13(2), screenshots R(4) + X(8).
+    mockDb.image.findMany.mockResolvedValue([
+      { id: 1, nsfwLevel: 1 },
+      { id: 2, nsfwLevel: 2 },
+      { id: 10, nsfwLevel: 4 },
+      { id: 11, nsfwLevel: 8 },
+    ]);
+    const { getListingAssets } = await import('../app-listing-assets.service');
+    const { deriveContentRatingFromAssets } = await import(
+      '~/shared/constants/browsingLevel.constants'
+    );
+    const res = await getListingAssets({ listingId: 'apl_1' }, mod);
+    expect(res.iconNsfwLevel).toBe(1);
+    expect(res.coverNsfwLevel).toBe(2);
+    expect(res.screenshots.map((s) => s.nsfwLevel)).toEqual([4, 8]);
+    // The review modal derives 'x' from the max (X=8).
+    const derived = deriveContentRatingFromAssets([
+      { nsfwLevel: res.iconNsfwLevel },
+      { nsfwLevel: res.coverNsfwLevel },
+      ...res.screenshots.map((s) => ({ nsfwLevel: s.nsfwLevel })),
+    ]);
+    expect(derived).toBe('x');
+  });
+
+  it('getAssets returns null nsfwLevels when the backing Images are absent', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ ...listingRow, iconId: 1, coverId: null });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([]);
+    mockDb.image.findMany.mockResolvedValue([]); // no rows found
+    const { getListingAssets } = await import('../app-listing-assets.service');
+    const res = await getListingAssets({ listingId: 'apl_1' }, mod);
+    expect(res.iconNsfwLevel).toBeNull();
+    expect(res.coverNsfwLevel).toBeNull();
   });
 });
 

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -61,6 +61,10 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
       updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
     },
+    // Backing-Image levels for the approve-time content-rating derive.
+    image: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
   });
   const mockRead = makeClient();
   const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
@@ -108,6 +112,7 @@ function resetAll() {
       .mockImplementation(async (a: { data: unknown }) => a.data);
     client.appListingPublishRequest.updateMany.mockReset().mockResolvedValue({ count: 1 });
     client.appListingPublishRequest.findMany.mockReset().mockResolvedValue([]);
+    client.image.findMany.mockReset().mockResolvedValue([]);
   }
   mockWrite.$transaction
     .mockReset()
@@ -601,6 +606,10 @@ describe('approveExternalRequest (revision apply)', () => {
       })
     );
     mockWrite.appListingScreenshot.count.mockResolvedValue(2);
+    // Backing-Image levels for the approve-time content-rating derive: an R asset →
+    // the revision path stamps the DERIVED rating ('r'), not the shadow's declared value.
+    mockWrite.appListingScreenshot.findMany.mockResolvedValue([{ imageId: 10 }]);
+    mockWrite.image.findMany.mockResolvedValue([{ nsfwLevel: 4 }]);
   }
 
   it('copies shadow scalars onto the PARENT (id/slug preserved), deletes the shadow, approves + re-points the request', async () => {
@@ -637,7 +646,9 @@ describe('approveExternalRequest (revision apply)', () => {
       tagline: 'edited tagline',
       description: 'edited desc',
       category: 'games',
-      contentRating: 'pg',
+      // DERIVED from the shadow's assets (max R) rather than copied from the shadow's
+      // declared 'pg' — the never-under-rate safety applies on the revision path too.
+      contentRating: 'r',
       externalUrl: 'https://cool.example.com/edited',
       connectClientId: null,
       iconId: 5,

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -39,7 +39,11 @@ type Client = {
     updateMany: ReturnType<typeof vi.fn>;
     deleteMany: ReturnType<typeof vi.fn>;
   };
-  appListingScreenshot: { count: ReturnType<typeof vi.fn> };
+  appListingScreenshot: {
+    count: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+  };
+  image: { findMany: ReturnType<typeof vi.fn> };
   appBlock: { findFirst: ReturnType<typeof vi.fn> };
   appListingPublishRequest: {
     findUnique: ReturnType<typeof vi.fn>;
@@ -66,6 +70,10 @@ const { mockRead, mockWrite, ids } = vi.hoisted(() => {
     },
     appListingScreenshot: {
       count: vi.fn(async (..._a: unknown[]) => 0),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
+    image: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
     },
     appBlock: {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
@@ -111,6 +119,8 @@ function resetClient(c: Client) {
   c.appListing.updateMany.mockReset().mockResolvedValue({ count: 1 });
   c.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
   c.appListingScreenshot.count.mockReset().mockResolvedValue(0);
+  c.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
+  c.image.findMany.mockReset().mockResolvedValue([]);
   c.appBlock.findFirst.mockReset().mockResolvedValue(null);
   c.appListingPublishRequest.findUnique.mockReset().mockResolvedValue(null);
   c.appListingPublishRequest.count.mockReset().mockResolvedValue(0);
@@ -475,10 +485,12 @@ describe('approveExternalRequest', () => {
     });
     expect(reqCall.data.reviewedAt).toBeInstanceOf(Date);
 
-    // Listing flip (status-guarded so an approved listing is never re-flipped).
+    // Listing flip (status-guarded so an approved listing is never re-flipped). The
+    // derived content rating is stamped alongside the status; with no asset levels
+    // staged the derive fails safe to 'g'.
     expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
       where: { id: 'apl_1', status: 'draft' },
-      data: { status: 'approved' },
+      data: { status: 'approved', contentRating: 'g' },
     });
     expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
   });
@@ -646,6 +658,82 @@ describe('approveExternalRequest', () => {
     await expect(
       approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
     ).resolves.toMatchObject({ publishRequestId: 'alpr_1', listingId: 'apl_1' });
+  });
+
+  // -------------------------------------------------------------------------
+  // Content-rating derive + mod override (floored). The author is never blocked on
+  // the scanner's rating; the authoritative rating is DERIVED from the assets' max
+  // detected nsfwLevel at approve, with an optional mod override that is FLOORED at
+  // the derived value (never publishes mature assets under a too-low rating).
+  // -------------------------------------------------------------------------
+
+  /** Stage the PRIMARY (tx) asset-level reads used by resolveApprovalContentRating. */
+  function stagePrimaryAssetLevels(levels: { id: number; nsfwLevel: number }[]) {
+    // The screenshot ids the derive gathers (icon/cover come from the listing row).
+    mockWrite.appListingScreenshot.findMany.mockResolvedValue(
+      levels.filter((l) => l.id >= 10).map((l) => ({ imageId: l.id }))
+    );
+    mockWrite.image.findMany.mockResolvedValue(levels.map((l) => ({ nsfwLevel: l.nsfwLevel })));
+  }
+
+  function ratingStampedOnFlip(): unknown {
+    const flip = mockWrite.appListing.updateMany.mock.calls.find(
+      (c) => (c[0] as { where: { status?: string } }).where.status === 'draft'
+    );
+    return (flip?.[0] as { data: { contentRating?: unknown } }).data.contentRating;
+  }
+
+  it('DERIVES the rating from the assets max nsfwLevel (icon PG, cover PG13, screenshot R → r)', async () => {
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
+    stagePrimaryAssetLevels([
+      { id: 1, nsfwLevel: 1 }, // icon PG
+      { id: 2, nsfwLevel: 2 }, // cover PG13
+      { id: 10, nsfwLevel: 4 }, // screenshot R
+    ]);
+    await approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD });
+    expect(ratingStampedOnFlip()).toBe('r');
+  });
+
+  it('a mod override ABOVE the derived rating is HONOURED (derived r, override x → x)', async () => {
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
+    stagePrimaryAssetLevels([
+      { id: 1, nsfwLevel: 1 },
+      { id: 2, nsfwLevel: 2 },
+      { id: 10, nsfwLevel: 4 }, // derived r
+    ]);
+    await approveExternalRequest({
+      publishRequestId: 'alpr_1',
+      reviewerUserId: MOD,
+      contentRating: 'x',
+    });
+    expect(ratingStampedOnFlip()).toBe('x');
+  });
+
+  it('🔴 an UNDER-rating override is FLOORED to the derived value (derived r, override g → r)', async () => {
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
+    stagePrimaryAssetLevels([
+      { id: 1, nsfwLevel: 1 },
+      { id: 2, nsfwLevel: 2 },
+      { id: 10, nsfwLevel: 4 }, // derived r
+    ]);
+    await approveExternalRequest({
+      publishRequestId: 'alpr_1',
+      reviewerUserId: MOD,
+      contentRating: 'g', // BELOW derived → must NOT publish mature assets as 'g'
+    });
+    // Floored UP to the derived rating — never silently under-rated.
+    expect(ratingStampedOnFlip()).toBe('r');
+  });
+
+  it('with no override, the DERIVED rating is stamped (all-PG assets → g)', async () => {
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
+    stagePrimaryAssetLevels([
+      { id: 1, nsfwLevel: 1 },
+      { id: 2, nsfwLevel: 1 },
+      { id: 10, nsfwLevel: 1 },
+    ]);
+    await approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD });
+    expect(ratingStampedOnFlip()).toBe('g');
   });
 });
 

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -3,10 +3,7 @@ import { randomUUID } from 'crypto';
 
 import { dbRead, dbWrite } from '~/server/db/client';
 import { NsfwLevel } from '~/server/common/enums';
-import {
-  getHighestBrowsingLevelBit,
-  orchestratorNsfwLevelMap,
-} from '~/shared/constants/browsingLevel.constants';
+import { nsfwLevelFromContentRating } from '~/shared/constants/browsingLevel.constants';
 import { ImageIngestionStatus } from '~/shared/utils/prisma/enums';
 import { newAppListingScreenshotId } from '~/server/utils/app-block-ids';
 import {
@@ -262,15 +259,12 @@ function assertOwnerAssetEditable(
 }
 
 /**
- * Map an `AppListing.contentRating` (`g|pg|pg13|r|x` — nullable) to the MAXIMUM
- * `NsfwLevel` bit its published assets may carry. Reuses the canonical
- * `orchestratorNsfwLevelMap` (which lacks the SFW `g` rating → PG). A
- * null/unknown rating FAILS CLOSED to PG (SFW) — never widen on ambiguity.
+ * Re-export the canonical `AppListing.contentRating` → max-`NsfwLevel` ceiling map
+ * (its home is `browsingLevel.constants`, shared with the client-side review-modal
+ * derive so the forward + inverse can never diverge). The backfill below uses it to
+ * clamp creator-derived screenshots.
  */
-export function nsfwLevelFromContentRating(rating: string | null | undefined): NsfwLevel {
-  if (!rating || rating === 'g') return NsfwLevel.PG;
-  return orchestratorNsfwLevelMap[rating] ?? NsfwLevel.PG;
-}
+export { nsfwLevelFromContentRating };
 
 /**
  * Load a listing and assert the caller owns it (or is a moderator). Throws
@@ -301,15 +295,39 @@ async function loadOwnedListing(listingId: string, user: SessionUser): Promise<O
 }
 
 /**
- * Load an Image, assert the caller owns it (or is a mod), and validate it for
- * the given asset kind. Returns the imageId once validated.
+ * The result of {@link loadValidatedImage}: a discriminated union so a still-
+ * SCANNING image is a NON-ERROR outcome the caller reports (client polls on it),
+ * NOT a thrown 4xx. TERMINAL problems still THROW (see below).
+ *
+ *   - `{ pending: true }`  — the Image exists, is owned + format-valid, but its
+ *     scan has not reached `Scanned` yet. NOT an error; NO db write; the caller
+ *     returns `{ status: 'pending' }` and the client re-polls.
+ *   - `{ pending: false, imageId }` — `Scanned` and attachable.
+ */
+type LoadValidatedImageResult = { pending: true } | { pending: false; imageId: number };
+
+/**
+ * Load an Image, assert the caller owns it (or is a mod), and validate it for the
+ * given asset kind. Returns a discriminated {@link LoadValidatedImageResult}:
+ * `{ pending: true }` while the scan is in-flight (a normal expected wait — no
+ * throw), `{ pending: false, imageId }` once `Scanned`.
+ *
+ * TERMINAL failures still THROW (real errors the client surfaces + stops polling
+ * on): missing → NOT_FOUND; not owned → FORBIDDEN; bad format → BAD_REQUEST;
+ * `ImageIngestionStatus.NotFound` (scanner couldn't fetch the bytes) → BAD_REQUEST;
+ * `Blocked` (prohibited content) → BAD_REQUEST.
+ *
+ * Content RATING is deliberately NOT gated here (W13): the scanner's per-image
+ * level is imprecise, every off-site listing is mod-reviewed before it is visible,
+ * and the rating is derived from + confirmed against the assets at approve. The
+ * `Blocked` reject is KEPT — it is a hard integrity reject (prohibited content),
+ * not a rating mismatch.
  */
 async function loadValidatedImage(
   imageId: number,
   kind: ListingAssetKind,
-  user: SessionUser,
-  contentRating: string | null
-): Promise<number> {
+  user: SessionUser
+): Promise<LoadValidatedImageResult> {
   const image = await dbRead.image.findUnique({
     where: { id: imageId },
     select: {
@@ -341,23 +359,11 @@ async function loadValidatedImage(
   );
   if (!result.ok) throw new TRPCError({ code: 'BAD_REQUEST', message: result.reason });
 
-  // Content-status gate: a listing asset is publicly rendered (P2), so the Image
-  // must be scan-complete AND within the listing's maturity ceiling. This mirrors
-  // the site-wide "don't publish un-scanned / over-rated media" invariant.
-  //
-  // Distinguish a TERMINAL ingestion failure (NotFound = the scanner couldn't
-  // fetch the bytes; Blocked = the image was rejected) from the TRANSIENT
-  // scanning states (Pending / Error-retry / PendingManualAssignment). The client
-  // polls this proc until the scan lands.
-  //
-  // The retriable-vs-terminal signal is STRUCTURAL, not prose: the transient
-  // scanning state throws `CONFLICT` (the resource isn't in an attachable state
-  // YET → retry), while the terminal states throw `BAD_REQUEST`. The client keys
-  // its poll decision off the tRPC `code` (`error.data.code`), NEVER the message —
-  // so these human messages are free to change without breaking the poller.
-  // (Previously a terminal failure had to smuggle its non-retriability into a
-  // DIFFERENT message string, which the client regex-matched; that was the brittle
-  // OG-image-import dead-end this refactor removes.)
+  // Content-status gate. A TERMINAL ingestion failure (NotFound = the scanner
+  // couldn't fetch the bytes; Blocked = prohibited content) still THROWS
+  // BAD_REQUEST — the client shows the message + stops polling. A non-terminal
+  // scanning state (Pending / Error-retry / PendingManualAssignment) is NOT an
+  // error: return `{ pending: true }` so the caller reports it as a poll-able 200.
   if (image.ingestion === ImageIngestionStatus.NotFound) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
@@ -371,58 +377,72 @@ async function loadValidatedImage(
     });
   }
   if (image.ingestion !== ImageIngestionStatus.Scanned) {
-    throw new TRPCError({
-      code: 'CONFLICT',
-      message: 'image is not approved for publishing (scan is not complete)',
-    });
+    // Still scanning — a NON-error pending result (supersedes the old CONFLICT
+    // throw; #3016's pending-CONFLICT is replaced by this poll-able result).
+    return { pending: true };
   }
-  // Fail closed: a null contentRating clamps to SFW (PG). NsfwLevel bits are
-  // severity-ordered (PG=1 < PG13=2 < R=4 < X=8 < XXX=16 < Blocked=32), so a
-  // numeric compare of the image's highest bit vs the ceiling is exact.
-  const maxLevel = nsfwLevelFromContentRating(contentRating);
-  const imageLevel = getHighestBrowsingLevelBit(image.nsfwLevel ?? 0);
-  if (imageLevel > maxLevel) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: "image exceeds the listing's content rating",
-    });
-  }
-  return image.id;
+  return { pending: false, imageId: image.id };
 }
 
 // ---------------------------------------------------------------------------
 // Creator asset management (owner/mod-gated).
 // ---------------------------------------------------------------------------
 
+/**
+ * The attach procs resolve with a discriminated `status` result instead of
+ * throwing for a still-scanning image: `{ status: 'pending' }` (200, NO db write —
+ * the client re-polls) while the Image's scan is in-flight, `{ status: 'attached',
+ * … }` once it lands and the attach is written. A TERMINAL problem (not-found /
+ * not-owned / bad-format / NotFound / Blocked) still THROWS from
+ * {@link loadValidatedImage}.
+ */
+export type SetListingIconResult = { status: 'pending' } | { status: 'attached'; iconId: number };
+export type SetListingCoverResult =
+  | { status: 'pending' }
+  | { status: 'attached'; coverId: number };
+export type AddListingScreenshotResult =
+  | { status: 'pending' }
+  | { status: 'attached'; id: string; order: number };
+
 export async function setListingIcon(
   args: { listingId: string; imageId: number },
   user: SessionUser
-): Promise<{ iconId: number }> {
+): Promise<SetListingIconResult> {
   const listing = await loadOwnedListing(args.listingId, user);
   assertOwnerAssetEditable(listing, user);
-  const iconId = await loadValidatedImage(args.imageId, 'icon', user, listing.contentRating);
-  await dbWrite.appListing.update({ where: { id: args.listingId }, data: { iconId } });
-  return { iconId };
+  const validated = await loadValidatedImage(args.imageId, 'icon', user);
+  if (validated.pending) return { status: 'pending' };
+  await dbWrite.appListing.update({
+    where: { id: args.listingId },
+    data: { iconId: validated.imageId },
+  });
+  return { status: 'attached', iconId: validated.imageId };
 }
 
 export async function setListingCover(
   args: { listingId: string; imageId: number },
   user: SessionUser
-): Promise<{ coverId: number }> {
+): Promise<SetListingCoverResult> {
   const listing = await loadOwnedListing(args.listingId, user);
   assertOwnerAssetEditable(listing, user);
-  const coverId = await loadValidatedImage(args.imageId, 'cover', user, listing.contentRating);
-  await dbWrite.appListing.update({ where: { id: args.listingId }, data: { coverId } });
-  return { coverId };
+  const validated = await loadValidatedImage(args.imageId, 'cover', user);
+  if (validated.pending) return { status: 'pending' };
+  await dbWrite.appListing.update({
+    where: { id: args.listingId },
+    data: { coverId: validated.imageId },
+  });
+  return { status: 'attached', coverId: validated.imageId };
 }
 
 export async function addListingScreenshot(
   args: { listingId: string; imageId: number; caption?: string | null },
   user: SessionUser
-): Promise<{ id: string; order: number }> {
+): Promise<AddListingScreenshotResult> {
   const listing = await loadOwnedListing(args.listingId, user);
   assertOwnerAssetEditable(listing, user);
-  const imageId = await loadValidatedImage(args.imageId, 'screenshot', user, listing.contentRating);
+  const validated = await loadValidatedImage(args.imageId, 'screenshot', user);
+  if (validated.pending) return { status: 'pending' };
+  const imageId = validated.imageId;
 
   // COUNT cap — reject the (N+1)th (mirrors E5 MAX_SCREENSHOTS "reject, not truncate").
   // Read the count + max order from dbWrite (primary), NOT the replica: under
@@ -454,7 +474,7 @@ export async function addListingScreenshot(
       caption: args.caption ?? null,
     },
   });
-  return { id, order: nextOrder };
+  return { status: 'attached', id, order: nextOrder };
 }
 
 /**
@@ -565,11 +585,26 @@ export type ListingAssetsView = {
   listingId: string;
   iconId: number | null;
   coverId: number | null;
-  screenshots: { id: string; imageId: number | null; order: number; caption: string | null }[];
+  /** Detected `nsfwLevel` of the icon/cover Image (null if unset/absent). */
+  iconNsfwLevel: number | null;
+  coverNsfwLevel: number | null;
+  screenshots: {
+    id: string;
+    imageId: number | null;
+    order: number;
+    caption: string | null;
+    /** Detected `nsfwLevel` of the backing Image (null if the Image was deleted). */
+    nsfwLevel: number | null;
+  }[];
   completeness: ListingAssetsCompleteResult;
 };
 
-/** Owner/mod read of a listing's current assets for the creator dashboard. */
+/**
+ * Owner/mod read of a listing's current assets for the creator dashboard + the mod
+ * review modal. Includes each asset's detected `nsfwLevel` (owner/mod-gated, so it
+ * is not a public exposure) so the review modal can derive the content rating from
+ * the assets' max level.
+ */
 export async function getListingAssets(
   args: { listingId: string },
   user: SessionUser
@@ -580,11 +615,32 @@ export async function getListingAssets(
     select: { id: true, imageId: true, order: true, caption: true },
     orderBy: { order: 'asc' },
   });
+
+  // Resolve the detected nsfwLevel of every backing Image in ONE query.
+  const imageIds = [
+    listing.iconId,
+    listing.coverId,
+    ...screenshots.map((s) => s.imageId),
+  ].filter((v): v is number => v != null);
+  const images = imageIds.length
+    ? await dbRead.image.findMany({
+        where: { id: { in: imageIds } },
+        select: { id: true, nsfwLevel: true },
+      })
+    : [];
+  const levelById = new Map<number, number | null>(
+    images.map((i) => [i.id, i.nsfwLevel ?? null])
+  );
+  const levelOf = (id: number | null): number | null =>
+    id == null ? null : levelById.get(id) ?? null;
+
   return {
     listingId: listing.id,
     iconId: listing.iconId,
     coverId: listing.coverId,
-    screenshots,
+    iconNsfwLevel: levelOf(listing.iconId),
+    coverNsfwLevel: levelOf(listing.coverId),
+    screenshots: screenshots.map((s) => ({ ...s, nsfwLevel: levelOf(s.imageId) })),
     completeness: checkListingAssetsComplete({
       iconId: listing.iconId,
       coverId: listing.coverId,

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -10,10 +10,15 @@ import {
   OFFSITE_CONTENT_RATINGS,
   OFFSITE_REJECTION_REASON_MAX,
   OFFSITE_REJECTION_REASON_MIN,
+  type OffsiteContentRating,
   type PersistListingAssetImageInput,
   type SubmitExternalListingInput,
 } from '~/server/schema/blocks/offsite-listing.schema';
 import { assertListingAssetsComplete } from '~/server/services/blocks/app-listing-assets.service';
+import {
+  deriveContentRatingFromAssets,
+  nsfwLevelFromContentRating,
+} from '~/shared/constants/browsingLevel.constants';
 import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 import {
   newAppListingId,
@@ -1072,6 +1077,46 @@ export type ApproveExternalRequestResult = {
 };
 
 /**
+ * Compute the content rating to STAMP on an off-site listing at approve. The
+ * scanner's per-image rating is imprecise, so the AUTHOR is never blocked on it +
+ * the author's declared rating is only a hint — the authoritative rating is DERIVED
+ * from the assets' MAX detected `nsfwLevel` (icon + cover + real screenshots) at
+ * review, with an optional mod OVERRIDE.
+ *
+ * 🔴 SAFETY (floor-at-derived): an override whose ceiling is BELOW the derived value
+ * would publish mature assets under a too-low rating — so it is clamped UP to the
+ * derived rating (never silently under-rated). An override AT or ABOVE the derived
+ * value is honoured (a mod may always rate UP). Reads the backing Image levels from
+ * the PRIMARY (`tx`) so the derived rating is row-consistent with the approve flip.
+ */
+async function resolveApprovalContentRating(
+  tx: Prisma.TransactionClient,
+  args: {
+    appListingId: string;
+    iconId: number | null;
+    coverId: number | null;
+    override?: OffsiteContentRating | null;
+  }
+): Promise<OffsiteContentRating> {
+  const shots = await tx.appListingScreenshot.findMany({
+    where: { appListingId: args.appListingId, imageId: { not: null } },
+    select: { imageId: true },
+  });
+  const imageIds = [args.iconId, args.coverId, ...shots.map((s) => s.imageId)].filter(
+    (v): v is number => v != null
+  );
+  const images = imageIds.length
+    ? await tx.image.findMany({ where: { id: { in: imageIds } }, select: { nsfwLevel: true } })
+    : [];
+  const derived = deriveContentRatingFromAssets(images.map((i) => ({ nsfwLevel: i.nsfwLevel })));
+  const override = args.override ?? null;
+  if (override == null) return derived;
+  return nsfwLevelFromContentRating(override) < nsfwLevelFromContentRating(derived)
+    ? derived // floor: an under-rating override is clamped up to the derived value
+    : override;
+}
+
+/**
  * MOD approve of a pending off-site request. Loads the request + its draft
  * `AppListing`, asserts `pending`, and enforces two gates BEFORE any mutation:
  *
@@ -1104,6 +1149,8 @@ export async function approveExternalRequest(opts: {
   publishRequestId: string;
   reviewerUserId: number;
   approvalNotes?: string | null;
+  /** Optional mod override of the final content rating (floored at the derived value). */
+  contentRating?: OffsiteContentRating | null;
 }): Promise<ApproveExternalRequestResult> {
   const { publishRequestId, reviewerUserId } = opts;
   const approvalNotes = opts.approvalNotes ?? null;
@@ -1169,6 +1216,7 @@ export async function approveExternalRequest(opts: {
       parentId: listing.revisionOfId,
       reviewerUserId,
       approvalNotes,
+      contentRating: opts.contentRating,
     });
   }
 
@@ -1246,9 +1294,18 @@ export async function approveExternalRequest(opts: {
         `cannot approve — the request is no longer pending`
       );
     }
+    // Derive (+ mod-override, floored) the content rating from the assets' max
+    // detected nsfwLevel and stamp it on the listing as it goes live. The author is
+    // never blocked on the scanner's rating — it is confirmed HERE at review.
+    const finalRating = await resolveApprovalContentRating(tx, {
+      appListingId,
+      iconId: primaryListing.iconId,
+      coverId: primaryListing.coverId,
+      override: opts.contentRating,
+    });
     const flipped = await tx.appListing.updateMany({
       where: { id: appListingId, status: 'draft' },
-      data: { status: 'approved' },
+      data: { status: 'approved', contentRating: finalRating },
     });
     if (flipped.count === 0) {
       // The draft was concurrently deleted / already flipped — abort (rolls back
@@ -1306,6 +1363,8 @@ async function applyApprovedRevision(opts: {
   parentId: string;
   reviewerUserId: number;
   approvalNotes: string | null;
+  /** Optional mod override of the final content rating (floored at the derived value). */
+  contentRating?: OffsiteContentRating | null;
 }): Promise<ApproveExternalRequestResult> {
   const { request, shadowId, parentId, reviewerUserId, approvalNotes } = opts;
 
@@ -1392,6 +1451,15 @@ async function applyApprovedRevision(opts: {
     }
 
     // (3) Copy scalars onto the parent (id / slug / appBlockId / status untouched).
+    // The content rating is DERIVED from the shadow's assets' max nsfwLevel (+ the
+    // mod override, floored) rather than trusting the shadow's declared value — same
+    // never-under-rate safety as the first-time approve path.
+    const finalRating = await resolveApprovalContentRating(tx, {
+      appListingId: shadowId,
+      iconId: shadow.iconId,
+      coverId: shadow.coverId,
+      override: opts.contentRating,
+    });
     await tx.appListing.update({
       where: { id: parentId },
       data: {
@@ -1399,7 +1467,7 @@ async function applyApprovedRevision(opts: {
         tagline: shadow.tagline,
         description: shadow.description,
         category: shadow.category,
-        contentRating: shadow.contentRating,
+        contentRating: finalRating,
         externalUrl: shadow.externalUrl,
         connectClientId: shadow.connectClientId,
         iconId: shadow.iconId,

--- a/src/shared/constants/__tests__/browsingLevel-maturity.test.ts
+++ b/src/shared/constants/__tests__/browsingLevel-maturity.test.ts
@@ -2,11 +2,17 @@ import { describe, expect, it } from 'vitest';
 import {
   allBrowsingLevelsFlag,
   allowMatureContentForCeiling,
+  contentRatingFromNsfwLevel,
+  deriveContentRatingFromAssets,
   domainBrowsingCeiling,
   nsfwBrowsingLevelsFlag,
+  nsfwLevelFromContentRating,
+  OFFSITE_CONTENT_RATING_LADDER,
   publicBrowsingLevelsFlag,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
+import { OFFSITE_CONTENT_RATINGS } from '~/server/schema/blocks/offsite-listing.schema';
+import { NsfwLevel } from '~/server/common/enums';
 import { Flags } from '~/shared/utils/flags';
 
 /**
@@ -91,5 +97,69 @@ describe('allowMatureContentForCeiling', () => {
     expect(allowMatureContentForCeiling(domainBrowsingCeiling('blue'))).toBe(false);
     expect(allowMatureContentForCeiling(domainBrowsingCeiling('red'))).toBeUndefined();
     expect(allowMatureContentForCeiling(domainBrowsingCeiling(undefined))).toBe(false);
+  });
+});
+
+/**
+ * Off-site content-rating derive (App Blocks W13). The scanner's per-image rating
+ * is imprecise, so the AUTHOR is never blocked on it — the authoritative rating is
+ * DERIVED from the assets' max detected nsfwLevel at review + a mod override
+ * (floored). The forward (`nsfwLevelFromContentRating`) + inverse
+ * (`contentRatingFromNsfwLevel`) must round-trip and fail CLOSED (never under-rate).
+ */
+describe('off-site content-rating derive', () => {
+  it('the ladder is kept in sync with the schema OFFSITE_CONTENT_RATINGS', () => {
+    expect([...OFFSITE_CONTENT_RATING_LADDER]).toEqual([...OFFSITE_CONTENT_RATINGS]);
+  });
+
+  it('nsfwLevelFromContentRating: g/pg → PG, and the rest via the orchestrator map', () => {
+    expect(nsfwLevelFromContentRating('g')).toBe(NsfwLevel.PG);
+    expect(nsfwLevelFromContentRating('pg')).toBe(NsfwLevel.PG);
+    expect(nsfwLevelFromContentRating('pg13')).toBe(NsfwLevel.PG13);
+    expect(nsfwLevelFromContentRating('r')).toBe(NsfwLevel.R);
+    expect(nsfwLevelFromContentRating('x')).toBe(NsfwLevel.X);
+    // null / unknown fail CLOSED to PG (never widen on ambiguity).
+    expect(nsfwLevelFromContentRating(null)).toBe(NsfwLevel.PG);
+    expect(nsfwLevelFromContentRating('bogus')).toBe(NsfwLevel.PG);
+  });
+
+  it('contentRatingFromNsfwLevel maps each level to the MINIMAL covering rating', () => {
+    expect(contentRatingFromNsfwLevel(NsfwLevel.PG)).toBe('g'); // g and pg share the PG ceiling → g is minimal
+    expect(contentRatingFromNsfwLevel(NsfwLevel.PG13)).toBe('pg13');
+    expect(contentRatingFromNsfwLevel(NsfwLevel.R)).toBe('r');
+    expect(contentRatingFromNsfwLevel(NsfwLevel.X)).toBe('x');
+    // No maturity signal → the lowest rating.
+    expect(contentRatingFromNsfwLevel(0)).toBe('g');
+  });
+
+  it('fails CLOSED for a level above the x ceiling (XXX / Blocked) → the TOP rating', () => {
+    expect(contentRatingFromNsfwLevel(NsfwLevel.XXX)).toBe('x');
+    expect(contentRatingFromNsfwLevel(NsfwLevel.Blocked)).toBe('x');
+  });
+
+  it('reads the HIGHEST bit of a composite level (never a lower one)', () => {
+    // Composite PG | R → the R bit governs → 'r' (not 'g').
+    expect(contentRatingFromNsfwLevel(NsfwLevel.PG | NsfwLevel.R)).toBe('r');
+  });
+
+  it('deriveContentRatingFromAssets picks the rating covering the MAX asset level', () => {
+    expect(
+      deriveContentRatingFromAssets([{ nsfwLevel: NsfwLevel.PG }, { nsfwLevel: NsfwLevel.R }])
+    ).toBe('r');
+    expect(
+      deriveContentRatingFromAssets([{ nsfwLevel: NsfwLevel.PG }, { nsfwLevel: NsfwLevel.PG13 }])
+    ).toBe('pg13');
+    // All PG → g (g/pg share the PG ceiling, g is minimal).
+    expect(deriveContentRatingFromAssets([{ nsfwLevel: NsfwLevel.PG }])).toBe('g');
+  });
+
+  it('deriveContentRatingFromAssets is fail-safe for empty / null / undefined levels → g', () => {
+    expect(deriveContentRatingFromAssets([])).toBe('g');
+    expect(deriveContentRatingFromAssets([{ nsfwLevel: null }, { nsfwLevel: undefined }])).toBe('g');
+    expect(deriveContentRatingFromAssets([{}])).toBe('g');
+  });
+
+  it('deriveContentRatingFromAssets fails CLOSED to the top rating for an XXX asset', () => {
+    expect(deriveContentRatingFromAssets([{ nsfwLevel: NsfwLevel.XXX }])).toBe('x');
   });
 });

--- a/src/shared/constants/browsingLevel.constants.ts
+++ b/src/shared/constants/browsingLevel.constants.ts
@@ -96,6 +96,70 @@ export function getBrowsingLevelLabel(value: number) {
   const highest = getHighestBrowsingLevelBit(value);
   return highest ? browsingLevelLabels[highest] : '?';
 }
+
+// ---------------------------------------------------------------------------
+// Off-site App-Listing content-rating ↔ NsfwLevel mapping (App Blocks W13).
+//
+// Client-SAFE (this module is imported by browser components), so both the review
+// modal (derive a rating from an approved listing's asset levels) AND the server
+// (approve stamp + the asset attach ceiling) share ONE implementation — a
+// divergent inverse would let mature assets publish under a too-low rating.
+// ---------------------------------------------------------------------------
+
+/**
+ * The off-site content-rating ladder, ASCENDING by maturity ceiling. Kept in sync
+ * with `OFFSITE_CONTENT_RATINGS` in `offsite-listing.schema` (a plain literal list
+ * here avoids a shared→server-schema import; a unit test asserts they match). A
+ * value typed as {@link OffsiteRatingValue} is structurally assignable to that
+ * schema's `OffsiteContentRating` (same string literals).
+ */
+export const OFFSITE_CONTENT_RATING_LADDER = ['g', 'pg', 'pg13', 'r', 'x'] as const;
+export type OffsiteRatingValue = (typeof OFFSITE_CONTENT_RATING_LADDER)[number];
+
+/**
+ * Map an off-site content rating (`g|pg|pg13|r|x` — nullable) to the MAXIMUM
+ * `NsfwLevel` bit its published assets may carry. Reuses the canonical
+ * `orchestratorNsfwLevelMap` (which lacks the SFW `g` rating → PG). A null/unknown
+ * rating FAILS CLOSED to PG (SFW) — never widen on ambiguity. (Canonical home; the
+ * app-listing-assets service re-exports this.)
+ */
+export function nsfwLevelFromContentRating(rating: string | null | undefined): NsfwLevel {
+  if (!rating || rating === 'g') return NsfwLevel.PG;
+  return orchestratorNsfwLevelMap[rating] ?? NsfwLevel.PG;
+}
+
+/**
+ * Inverse of {@link nsfwLevelFromContentRating} for a SINGLE detected level: the
+ * MINIMAL off-site rating whose ceiling covers `level`. Fail-CLOSED: a level above
+ * the `x` ceiling (X/XXX/Blocked) returns the TOP rating (`x`), NEVER a lower one —
+ * so a scanner's high reading can never be under-rated. Level 0 (no maturity
+ * signal) → `g`.
+ */
+export function contentRatingFromNsfwLevel(level: number): OffsiteRatingValue {
+  const bit = getHighestBrowsingLevelBit(level);
+  for (const rating of OFFSITE_CONTENT_RATING_LADDER) {
+    if (bit <= nsfwLevelFromContentRating(rating)) return rating;
+  }
+  // Fail closed: a bit above every ladder ceiling (X/XXX/Blocked) → the top rating.
+  return OFFSITE_CONTENT_RATING_LADDER[OFFSITE_CONTENT_RATING_LADDER.length - 1];
+}
+
+/**
+ * Derive the minimal off-site content rating that covers the MAX `nsfwLevel` across
+ * a listing's assets (icon + cover + screenshots). Empty / all-null → `g`. Used as
+ * the review modal's default + the approve-time derived floor. Fail-CLOSED via
+ * {@link contentRatingFromNsfwLevel} (never under-rates).
+ */
+export function deriveContentRatingFromAssets(
+  assets: { nsfwLevel?: number | null }[]
+): OffsiteRatingValue {
+  let maxBit = 0;
+  for (const a of assets) {
+    const bit = getHighestBrowsingLevelBit(a.nsfwLevel ?? 0);
+    if (bit > maxBit) maxBit = bit;
+  }
+  return contentRatingFromNsfwLevel(maxBit);
+}
 export const nsfwBrowsingLevelsFlag = flagifyBrowsingLevel(nsfwBrowsingLevelsArray);
 
 // all browsing levels


### PR DESCRIPTION
Two related improvements to the App Blocks external-listing asset flow, in one PR (they share `loadValidatedImage` + the asset procs). **All DARK / mod-gated** behind `app-blocks-author` / `appBlocks`. **Do not merge yet.**

## Part 1 — the "still scanning" attach is now a NON-error result (not a 4xx)

Previously (post-#3016) `setIcon`/`setCover`/`addScreenshot` **threw `CONFLICT`** while the image was still scanning, and the client retried on the error — surfacing a normal expected wait as a red 4xx in the network tab.

- `loadValidatedImage` now returns a discriminated union: `{ pending: true }` when the Image is not-yet-`Scanned` (Pending / other non-terminal ingestion), or `{ pending: false, imageId }` when `Scanned`. **Terminal cases still throw** (real errors): not-found → `NOT_FOUND`; not-owned → `FORBIDDEN`; `ImageIngestionStatus.NotFound` → `BAD_REQUEST` ("upload it manually"); `Blocked` → `BAD_REQUEST` ("rejected during scanning"); bad format → `BAD_REQUEST`.
- The attach procs resolve **`{ status: 'pending' }`** (200, **no db write** — the client re-polls) or **`{ status: 'attached', iconId/coverId/id/order }`**.
- Client `classifyAttachResult` now classifies the **resolved `status`**, never a tRPC `code`. `status:'pending'` → keep polling (existing `POLL_SCHEDULE_MS` / `POLL_BUDGET_MS`); `status:'attached'` → done; a thrown terminal error → `error` (message shown, manual upload stays usable).

**This supersedes #3016's pending-CONFLICT** with a poll-able non-error result — the `error.data.code === 'CONFLICT'` handling is removed.

### Final attach-result contract
```
loadValidatedImage → { pending: true } | { pending: false, imageId }   (terminal → throws)
setListingIcon      → { status: 'pending' } | { status: 'attached', iconId }
setListingCover     → { status: 'pending' } | { status: 'attached', coverId }
addListingScreenshot→ { status: 'pending' } | { status: 'attached', id, order }
```

## Part 2 — rating: assets always attach; rating derived from assets + mod-settable at approve

The scanner's per-image rating is imprecise, so **blocking the author on it is wrong**. Every off-site listing is mod-gated + reviewed before it's visible, so let assets through and derive/confirm the rating at review.

- **Removed** the content-rating rejection in `loadValidatedImage` (`imageLevel > maxLevel` → "exceeds the listing's content rating"). Assets are **never** blocked on the listing's declared rating. The **`Blocked` reject is kept** — a hard integrity reject (prohibited content), not a rating mismatch.
- New shared helpers in `browsingLevel.constants` (client-safe, single source shared by server + the review modal): `nsfwLevelFromContentRating` (moved here, canonical), `contentRatingFromNsfwLevel`, `deriveContentRatingFromAssets` — map the assets' **max** `nsfwLevel` → the **minimal** `OFFSITE_CONTENT_RATINGS` value whose ceiling covers it. **Fail-closed** (a level above the `x` ceiling → the top rating; empty/unknown → `g`).
- `approveExternalRequest` takes an optional `contentRating?` and **stamps the listing's `content_rating` on approve** = the mod override if provided, else the **derived** value. **🔴 Safety: floor-at-derived** — an override whose ceiling is **below** the derived value is clamped **up** to the derived rating (never publishes mature assets under a too-low rating); an override at/above derived is honoured. The same derive+floor is applied on the **revision-apply** path. The existing approve state machine (asset-complete gate, URL re-validation, tx, TOCTOU, revision-aware copy) is intact.
- `getListingAssets` now includes each asset's `nsfwLevel` (owner/mod-gated) so the review modal derives client-side.
- Mod review modal: surfaces the **derived** rating alongside the author-declared rating, **flags** when derived > declared, and a rating **Select** (default = derived) sets the final rating passed to `approveExternalRequest`.

The author's declared rating stays as a default/hint in the edit wizard but no longer blocks assets.

## Tests
- Service: attach returns `{status:'pending'}` (no throw) for a scanning image; `{status:'attached'}` for Scanned; still throws for NotFound/Blocked/not-owned/not-found; an over-declared-rating image now **attaches**; `deriveContentRatingFromAssets` mapping incl. fail-closed; `approveExternalRequest` stamps derived-or-override and **floors** an under-rating; revision-apply path derives too.
- Client: a `pending` result keeps polling then attaches on `attached`; a thrown terminal error shows the message + keeps manual upload; no code depends on the removed CONFLICT.
- Review modal: shows derived-vs-declared, flags a mismatch, defaults the Select to derived, passes the chosen rating to approve.
- `tsc` clean for all changed files (remaining tsc errors are pre-existing stale-Prisma in untouched files). **251 unit tests + 11 browser tests pass.**

**Honest preview note:** the scanner is unreachable in PR-preview (ingest → `Scanned` is prod-only), so the pending↔attached transition can't be exercised end-to-end there — but the pending/attached/rating logic is fully unit- and component-testable regardless, and is covered above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)