### PR TITLE
fix(referral): pay referral rewards from central bank (account 0), not balance-checked -1

### DIFF
--- a/src/server/services/__tests__/referral.service.test.ts
+++ b/src/server/services/__tests__/referral.service.test.ts
@@ -78,6 +78,7 @@ import {
 } from '../referral.service';
 import { createBuzzTransaction } from '~/server/services/buzz.service';
 import { ReferralRewardKind, ReferralRewardStatus } from '~/shared/utils/prisma/enums';
+import { TransactionType } from '~/shared/constants/buzz.constants';
 
 const resetAllMocks = () => {
   for (const [key, v] of Object.entries(mockDbWrite)) {
@@ -818,6 +819,122 @@ describe('revokeForChargeback', () => {
 // -----------------------------------------------------------------------------
 // computeLifetimeReferralPoints — Expired status retention
 // -----------------------------------------------------------------------------
+
+// -----------------------------------------------------------------------------
+// Buzz account routing — referral rewards must mint from the central bank (0)
+// so the Buzz service's insufficient-funds check (fromAccountId !== 0) is
+// bypassed, exactly like base.reward.ts. Previously they minted from the
+// balance-checked account -1 (blue), which stranded ~190 rewards once its dust
+// was spent (regression since referral-v2 #2178).
+// -----------------------------------------------------------------------------
+
+describe('buzz account routing (central bank 0)', () => {
+  const settlePayload = {
+    refereeId: 42,
+    tier: 'bronze' as const,
+    monthlyBuzzAmount: 10_000,
+    sourceEventId: 'inv-routing-1',
+  };
+
+  const okCtx = () => {
+    mockDbWrite.userReferral.findUnique.mockResolvedValue({
+      id: 1,
+      userReferralCodeId: 99,
+      firstPaidAt: null,
+      paidMonthCount: 0,
+      userReferralCode: {
+        id: 99,
+        userId: 7,
+        deletedAt: null,
+        user: { createdAt: new Date('2024-01-01') },
+      },
+    });
+    (mockDbWrite.$queryRaw as any).mockResolvedValue([{ paidMonthCount: 0, firstPaidAt: null }]);
+    mockDbWrite.referralReward.create.mockImplementation(async ({ data }: any) => ({
+      id: 555,
+      buzzAmount: data.buzzAmount ?? 0,
+      tokenAmount: data.tokenAmount ?? 0,
+      kind: data.kind,
+      userId: data.userId,
+      refereeId: data.refereeId ?? null,
+      tierGranted: data.tierGranted ?? null,
+      ...data,
+    }));
+    mockDbWrite.userReferral.update.mockResolvedValue({});
+    mockDbWrite.referralReward.updateMany.mockResolvedValue({ count: 1 });
+  };
+
+  it('pays the referral reward FROM the central bank (fromAccountId 0), not the balance-checked -1', async () => {
+    okCtx();
+
+    await recordMembershipPaymentReward(settlePayload);
+
+    const grant = (createBuzzTransaction as any).mock.calls.find((c: any) =>
+      String(c[0].externalTransactionId).startsWith('referral-reward:')
+    );
+    expect(grant).toBeTruthy();
+    // The load-bearing assertion: 0 is the mint that bypasses the
+    // insufficient-funds check. Reverting REFERRAL_SYSTEM_ACCOUNT_ID to -1
+    // fails this (fail-before / pass-after).
+    expect(grant[0].fromAccountId).toBe(0);
+  });
+
+  it('credits the referrer blue ledger and omits fromAccountType to match base.reward', async () => {
+    okCtx();
+
+    await recordMembershipPaymentReward(settlePayload);
+
+    const grant = (createBuzzTransaction as any).mock.calls.find((c: any) =>
+      String(c[0].externalTransactionId).startsWith('referral-reward:')
+    );
+    expect(grant[0]).toMatchObject({
+      fromAccountId: 0,
+      toAccountId: 42, // the reward recipient (RefereeBonus → referee)
+      toAccountType: 'blue',
+      amount: 2_500, // 25% of 10k
+      type: TransactionType.Reward,
+    });
+    // Canonical bank-grant pattern (base.reward.ts / merch.service.ts) omits
+    // fromAccountType entirely — the recipient ledger is set via toAccountType.
+    expect(grant[0].fromAccountType).toBeUndefined();
+    expect(grant[0].externalTransactionId).toBe('referral-reward:555');
+  });
+
+  it('settles a reward against the (mocked) bank without ever tripping insufficient-funds / revert', async () => {
+    okCtx();
+
+    await recordMembershipPaymentReward(settlePayload);
+
+    // The grant succeeded, so settleRewardRow must NOT have reverted the row
+    // back to Pending. Pre-fix, a real bank would have thrown insufficient-funds
+    // from account -1 and triggered exactly this revert path.
+    const reverted = (mockDbWrite.referralReward.update as any).mock.calls.some(
+      (c: any) =>
+        c[0]?.data?.status === ReferralRewardStatus.Pending && c[0]?.data?.revokedReason
+    );
+    expect(reverted).toBe(false);
+  });
+
+  it('claws a settled reward BACK to the central bank (toAccountId 0)', async () => {
+    mockDbWrite.referralReward.findMany.mockResolvedValue([
+      { id: 2, userId: 7, status: ReferralRewardStatus.Settled, buzzAmount: 500 },
+    ]);
+    mockDbWrite.referralReward.update.mockResolvedValue({});
+
+    await revokeForChargeback({ sourceEventId: 'pi_bank', reason: 'refund' });
+
+    expect(createBuzzTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromAccountId: 7, // debit the referrer (real, balance-checked account)
+        fromAccountType: 'blue',
+        toAccountId: 0, // return to the central bank
+        amount: 500,
+        type: TransactionType.ChargeBack,
+        externalTransactionId: 'referral-clawback:2',
+      })
+    );
+  });
+});
 
 describe('computeLifetimeReferralPoints', () => {
   it('includes Expired tokens in the status filter so lifetime points do not drop', async () => {

--- a/src/server/services/__tests__/referral.service.test.ts
+++ b/src/server/services/__tests__/referral.service.test.ts
@@ -915,7 +915,7 @@ describe('buzz account routing (central bank 0)', () => {
     expect(reverted).toBe(false);
   });
 
-  it('claws a settled reward BACK to the central bank (toAccountId 0)', async () => {
+  it('claws a settled reward BACK to the central bank (toAccountId 0, bank side untyped)', async () => {
     mockDbWrite.referralReward.findMany.mockResolvedValue([
       { id: 2, userId: 7, status: ReferralRewardStatus.Settled, buzzAmount: 500 },
     ]);
@@ -923,16 +923,38 @@ describe('buzz account routing (central bank 0)', () => {
 
     await revokeForChargeback({ sourceEventId: 'pi_bank', reason: 'refund' });
 
-    expect(createBuzzTransaction).toHaveBeenCalledWith(
-      expect.objectContaining({
-        fromAccountId: 7, // debit the referrer (real, balance-checked account)
-        fromAccountType: 'blue',
-        toAccountId: 0, // return to the central bank
-        amount: 500,
-        type: TransactionType.ChargeBack,
-        externalTransactionId: 'referral-clawback:2',
-      })
+    const clawback = (createBuzzTransaction as any).mock.calls.find((c: any) =>
+      String(c[0].externalTransactionId).startsWith('referral-clawback:')
     );
+    expect(clawback).toBeTruthy();
+    expect(clawback[0]).toMatchObject({
+      fromAccountId: 7, // debit the referrer (real, balance-checked account)
+      fromAccountType: 'blue',
+      toAccountId: 0, // return to the central bank
+      amount: 500,
+      type: TransactionType.ChargeBack,
+      externalTransactionId: 'referral-clawback:2',
+    });
+    // The bank side must be untyped, matching the payout + every other
+    // send-to-bank call. `objectContaining`/`toMatchObject` can't catch an
+    // extra field, so assert its absence explicitly (fail-before if
+    // toAccountType: 'blue' is still present).
+    expect(clawback[0].toAccountType).toBeUndefined();
+  });
+
+  it('clears a stale revokedReason when a reward settles successfully', async () => {
+    okCtx();
+
+    await recordMembershipPaymentReward(settlePayload);
+
+    // settleRewardRow's CAS claim flips the row to Settled — and must also
+    // null out any lingering revokedReason (the ~190 stuck rewards carry the
+    // old insufficient-funds string). Fail-before if the claim omits it.
+    const claim = (mockDbWrite.referralReward.updateMany as any).mock.calls.find(
+      (c: any) => c[0]?.data?.status === ReferralRewardStatus.Settled
+    );
+    expect(claim).toBeTruthy();
+    expect(claim[0].data.revokedReason).toBeNull();
   });
 });
 

--- a/src/server/services/referral.service.ts
+++ b/src/server/services/referral.service.ts
@@ -491,7 +491,11 @@ async function settleRewardRow(reward: SettleableReward) {
   // runs of the cron — only one caller will see count > 0.
   const claimed = await dbWrite.referralReward.updateMany({
     where: { id: reward.id, status: ReferralRewardStatus.Pending },
-    data: { status: ReferralRewardStatus.Settled, settledAt: new Date() },
+    // Clear any stale revokedReason left by a prior failed-grant revert (the
+    // ~190 rewards stuck by the account-0 bug carry the old insufficient-funds
+    // string) so a successfully-settled reward has a clean reason. The revert
+    // path below re-sets it if the grant fails.
+    data: { status: ReferralRewardStatus.Settled, settledAt: new Date(), revokedReason: null },
   });
   if (claimed.count === 0) return;
 
@@ -576,10 +580,13 @@ export async function revokeForChargeback(params: { sourceEventId: string; reaso
   for (const reward of affected) {
     if (reward.status === ReferralRewardStatus.Settled && reward.buzzAmount > 0) {
       await createBuzzTransaction({
+        // Debit the referrer's blue ledger; return to the central bank (id 0)
+        // untyped, matching the payout + every other "send to bank" call in the
+        // repo (cosmetic-shop/report/purchasable-reward all omit the bank-side
+        // toAccountType).
         fromAccountId: reward.userId,
         fromAccountType: 'blue',
         toAccountId: REFERRAL_SYSTEM_ACCOUNT_ID,
-        toAccountType: 'blue',
         amount: reward.buzzAmount,
         type: TransactionType.ChargeBack,
         description: `Referral reward clawback (${reason})`,

--- a/src/server/services/referral.service.ts
+++ b/src/server/services/referral.service.ts
@@ -10,7 +10,12 @@ import { createBuzzTransaction } from '~/server/services/buzz.service';
 import type { ProductTier } from '~/server/schema/subscriptions.schema';
 import { logToAxiom } from '~/server/logging/client';
 
-export const REFERRAL_SYSTEM_ACCOUNT_ID = -1;
+// Central bank account. Referral rewards must mint from the bank (id 0), which
+// the Buzz service's insufficient-funds check bypasses (`fromAccountId !== 0`),
+// exactly like every other reward path (see base.reward.ts). Account -1 (blue)
+// is a normal balance-checked account and stranded ~190 rewards once its
+// incidental dust was spent — a regression-by-design since referral-v2 (#2178).
+export const REFERRAL_SYSTEM_ACCOUNT_ID = 0;
 // Distinct CustomerSubscription.buzzType so referral grants stack with paid
 // yellow/green/blue subscriptions without tripping @@unique([userId, buzzType]).
 const REFERRAL_BUZZ_TYPE = 'referral';
@@ -493,8 +498,10 @@ async function settleRewardRow(reward: SettleableReward) {
   if (reward.buzzAmount > 0) {
     try {
       await createBuzzTransaction({
+        // Mint from the central bank (id 0). Omit fromAccountType to match the
+        // canonical bank-grant pattern (base.reward.ts / merch.service.ts): the
+        // recipient's blue ledger is credited via toAccountType below.
         fromAccountId: REFERRAL_SYSTEM_ACCOUNT_ID,
-        fromAccountType: 'blue',
         toAccountId: reward.userId,
         toAccountType: 'blue',
         amount: reward.buzzAmount,


### PR DESCRIPTION
## Root cause

The `referral-settle` job fails to pay ~190 referral rewards (~475k Buzz, some unpaid 2+ months) with `TRPCError: "…you don't have enough funds…"`.

Referral rewards were the **lone reward path** minting Buzz from account **`-1` (blue)** — a normal **balance-checked** account with only incidental dust (~245 Buzz) — instead of the **central bank account `0`** that every other reward uses (`base.reward.ts`, `merch.service.ts`, `rewards-ad-impressions.ts`, …).

The Buzz service's insufficient-funds check (`src/server/services/buzz.service.ts`) only bypasses the balance gate for `fromAccountId === 0` (and `creatorProgramBank`):

```ts
if (
  payload.fromAccountId !== 0 &&
  payload.fromAccountType !== 'creatorProgramBank' &&
  (account?.balance ?? 0) < amount
) {
  throw throwInsufficientFundsError(...);
}
```

So once account `-1`'s dust was spent, every payout began throwing insufficient-funds and the rewards piled up as `Pending`. This is a **regression-by-design since the referral-v2 launch (#2178)**, not a recent change. A funding top-up would just drain again — the fix is code.

## The fix

- `REFERRAL_SYSTEM_ACCOUNT_ID = 0` (was `-1`). This one change corrects **both** call sites at once: the payout (`fromAccountId` → bank `0`) and the clawback (`toAccountId` → bank `0`).
- Dropped the payout's `fromAccountType: 'blue'` to match the canonical bank-grant pattern. `base.reward.ts` (and `merch.service.ts`, `rewards-ad-impressions.ts`, `buzz.service.ts`) all mint from bank `0` with **no `fromAccountType`** and set the recipient ledger via `toAccountType`. The referrer still receives **blue** Buzz (`toAccountType: 'blue'` unchanged) — user-visible behavior is identical; only the bank-side debit ledger label now matches every other reward.

### `fromAccountType` decision

`base.reward.ts` mints with `fromAccountId: 0` and **omits `fromAccountType` entirely** (credits the recipient via `toAccountType`). I aligned referral to it: removed `fromAccountType: 'blue'` on the payout. The balance-check bypass keys on `id === 0` regardless of type, so this doesn't affect the fix — it just makes referral Buzz behave like every other reward. The **clawback keeps `fromAccountType: 'blue'`** because its `from` side is a real balance-checked user account (we must debit the referrer's blue ledger); its `to` side is now bank `0`.

### Safety checks

- **No `from === to` collision:** payout is `0 → user` and clawback is `user → 0` (different directions; `userId` is never `0` for real users). The buzz service's `toAccountId === fromAccountId` guard is unaffected.
- **No other broken uses of the const:** repo-wide grep of `REFERRAL_SYSTEM_ACCOUNT_ID` finds only the two `createBuzzTransaction` call sites — no query/filter expects `-1`.
- Idempotency key (`referral-reward:${id}` / `referral-clawback:${id}`) and the CAS/revert logic are untouched.

## ⚠️ Deploy impact — releases ~475k Buzz to ~190 referrers

Deploying this **releases ~475k Buzz to ~190 referrers on the next cron cycle.** The 190 stuck rewards are still `Pending` and will settle automatically once the mint bypasses the balance check — **no backfill needed.** This is the intended, owner-confirmed outcome.

## Follow-up (not in this PR)

A separate, smaller integrity gap exists: ~2 rewards / ~3k Buzz that are `Settled` but were never actually paid out (the status flipped before/without a successful grant). That is **not** addressed here and should be reconciled separately.

## Tests

Added focused money-routing tests to `referral.service.test.ts` (buzz layer mocked — no real Buzz service/DB):

- payout `createBuzzTransaction` called with `fromAccountId: 0`, `toAccountId: <referrer>`, `toAccountType: 'blue'`, `amount`, `type: Reward`, and `fromAccountType` **undefined**;
- clawback targets `toAccountId: 0` (`type: ChargeBack`, `fromAccountId: <referrer>`);
- a settle succeeds against the mocked bank without hitting the insufficient-funds/revert path.

**Fail-before / pass-after** (revert const to `-1`): 3 routing tests fail with `expected -1 to be +0`; with the fix all **39** pass. Per-file typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)