### PR TITLE
fix(app-blocks): register apps:storage:shared:* in the manifest schema

### DIFF
--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -64,7 +64,9 @@
           "block:settings:write",
           "social:tip:self",
           "apps:storage:read",
-          "apps:storage:write"
+          "apps:storage:write",
+          "apps:storage:shared:read",
+          "apps:storage:shared:write"
         ]
       }
     },

--- a/src/server/services/blocks/scope-descriptions.constants.ts
+++ b/src/server/services/blocks/scope-descriptions.constants.ts
@@ -28,6 +28,8 @@ export const SCOPE_DESCRIPTIONS: Record<string, string> = {
   'block:settings:write': "Update this block's per-install settings",
   'apps:storage:read': "Read this app's private per-install data store",
   'apps:storage:write': "Write to this app's private per-install data store",
+  'apps:storage:shared:read': "Read this app's shared, community-wide data (e.g. everyone's posts + vote counts)",
+  'apps:storage:shared:write': "Post + vote in this app's shared, community-wide data — visible to all users of the app",
 };
 
 export const SLOT_DESCRIPTIONS: Record<string, string> = {


### PR DESCRIPTION
Phase-1 (#3013) added the shared-storage scopes to the runtime constants but **not to the canonical manifest schema** (`public/schemas/app-block/v1.json`, served at civitai.com/schemas/app-block/v1.json) — so `civitai app validate` + submit **reject** a manifest declaring `apps:storage:shared:read/write`, and no app can request shared storage. Surfaced building the first shared-storage app (App Requests).

Adds the two scopes to the schema `scopes` enum + `scope-descriptions` (approve/consent UI). The runtime validator already accepts them (`block-scope.constants`, `SKIP_OAUTH_CHECK`) — this closes the registration path. Companion: civitai/cli syncs its vendored schema mirror + releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)