### PR TITLE
feat(apps): preview thumbnails for uploaded listing assets + cancel a screenshot mid-scan

### DIFF
--- a/src/components/Apps/ListingAssetStep.browser.test.tsx
+++ b/src/components/Apps/ListingAssetStep.browser.test.tsx
@@ -285,7 +285,7 @@ describe('ListingAssetStep — uploaded-asset preview + cancel mid-scan', () => 
   const prefill = {
     icon: { imageId: 1, url: 'https://edge/icon.png' },
     cover: { imageId: 2, url: 'https://edge/cover.png' },
-    screenshots: [{ id: 'row-9', imageId: 3, url: 'https://edge/shot.png' }],
+    screenshots: [{ id: 'row-9', imageId: 3, url: 'https://edge/shot.png', caption: null, order: 0 }],
   };
 
   test('an attached prefilled screenshot offers NO remove/cancel when allowRemove=false', async () => {

--- a/src/components/Apps/ListingAssetStep.browser.test.tsx
+++ b/src/components/Apps/ListingAssetStep.browser.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -36,6 +36,9 @@ const mocks = vi.hoisted(() => ({
   setIconAsync: vi.fn(),
   setCoverAsync: vi.fn(),
   addScreenshotAsync: vi.fn(),
+  removeAsync: vi.fn(),
+  persistAsync: vi.fn(),
+  uploadToCF: vi.fn(),
 }));
 
 vi.mock('~/utils/trpc', () => {
@@ -43,7 +46,9 @@ vi.mock('~/utils/trpc', () => {
   return {
     trpc: {
       appListings: {
-        persistAssetImage: { useMutation: passthrough },
+        persistAssetImage: {
+          useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.persistAsync, isPending: false }),
+        },
         ingestAssetFromUrl: {
           useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.ingestAsync, isPending: false }),
         },
@@ -60,7 +65,9 @@ vi.mock('~/utils/trpc', () => {
             isPending: false,
           }),
         },
-        removeScreenshot: { useMutation: passthrough },
+        removeScreenshot: {
+          useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.removeAsync, isPending: false }),
+        },
       },
     },
   };
@@ -68,7 +75,7 @@ vi.mock('~/utils/trpc', () => {
 
 vi.mock('~/hooks/useCFImageUpload', () => ({
   useCFImageUpload: () => ({
-    uploadToCF: vi.fn(),
+    uploadToCF: mocks.uploadToCF,
     files: [],
     resetFiles: vi.fn(),
     removeImage: vi.fn(),
@@ -87,10 +94,51 @@ const suggestions = {
   coverImageUrl: 'https://cdn.example.com/cover.png',
 };
 
-function renderStep() {
+function renderStep(props: Partial<Parameters<typeof ListingAssetStep>[0]> = {}) {
   return renderWithProviders(
-    <ListingAssetStep listingId="listing-1" contentRating="g" suggestions={suggestions} />
+    <ListingAssetStep
+      listingId="listing-1"
+      contentRating="g"
+      suggestions={suggestions}
+      {...props}
+    />
   );
+}
+
+/**
+ * Generate a REAL png File (via canvas → toBlob) — an arbitrary-bytes File would
+ * fail `createImageBitmap` in the upload path (readImageDimensions), so the row
+ * would never reach the scanning state we assert on.
+ */
+async function makeImageFile(name = 'shot.png'): Promise<File> {
+  const canvas = document.createElement('canvas');
+  canvas.width = 200;
+  canvas.height = 150;
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('toBlob null'))), 'image/png');
+  });
+  return new File([blob], name, { type: 'image/png' });
+}
+
+/**
+ * The hidden native <input type=file> Mantine's FileInput renders (display:none).
+ * icon/cover = not-multiple by DOM order; screenshots = multiple. Waits for React
+ * to commit (querying synchronously right after render finds nothing).
+ */
+function fileInputEl(which: 'icon' | 'cover' | 'screenshots'): Promise<HTMLInputElement> {
+  return vi.waitFor(() => {
+    if (which === 'screenshots') {
+      const el = document.querySelector<HTMLInputElement>('input[type="file"][multiple]');
+      if (!el) throw new Error('screenshots file input not found');
+      return el;
+    }
+    const singles = document.querySelectorAll<HTMLInputElement>(
+      'input[type="file"]:not([multiple])'
+    );
+    const el = singles[which === 'icon' ? 0 : 1];
+    if (!el) throw new Error(`${which} file input not found`);
+    return el;
+  });
 }
 
 beforeEach(() => {
@@ -98,6 +146,13 @@ beforeEach(() => {
   mocks.setIconAsync.mockReset();
   mocks.setCoverAsync.mockReset();
   mocks.addScreenshotAsync.mockReset();
+  mocks.removeAsync.mockReset();
+  mocks.persistAsync.mockReset();
+  mocks.uploadToCF.mockReset();
+  // Default upload pipeline: CF upload + persist resolve so the row can reach
+  // the scanning state driven by the attach proc.
+  mocks.uploadToCF.mockResolvedValue({ id: 'cf-image-id' });
+  mocks.persistAsync.mockResolvedValue({ imageId: 501 });
 });
 
 describe('ListingAssetStep — OG-image auto-fill', () => {
@@ -163,5 +218,110 @@ describe('ListingAssetStep — OG-image auto-fill', () => {
     // the author is never stuck on the failed auto-fill.
     await expect.element(page.getByText('Upload icon', { exact: true })).toBeInTheDocument();
     expect(page.getByTestId('apps-offsite-accept-icon').elements()).toHaveLength(0);
+  });
+});
+
+describe('ListingAssetStep — uploaded-asset preview + cancel mid-scan', () => {
+  test('a freshly-uploaded screenshot shows a preview thumbnail while it scans', async () => {
+    // Attach proc resolves `pending` → the row stays in the scanning state.
+    mocks.addScreenshotAsync.mockResolvedValue({ status: 'pending' });
+    renderStep();
+
+    await userEvent.upload(await fileInputEl('screenshots'), await makeImageFile());
+
+    // The local object-URL preview thumbnail renders BEFORE the attach lands…
+    const preview = page.getByTestId('apps-offsite-screenshot-preview-0');
+    await expect.element(preview).toBeInTheDocument();
+    // …and its src is the local blob: object URL (what the user just picked).
+    expect(preview.element().getAttribute('src') ?? '').toMatch(/^blob:/);
+    // …and the row is scanning (not eagerly attached).
+    await expect.element(page.getByText(/Scanning image/i)).toBeInTheDocument();
+  });
+
+  test('a freshly-uploaded icon shows a preview thumbnail while it scans', async () => {
+    mocks.setIconAsync.mockResolvedValue({ status: 'pending' });
+    renderStep();
+
+    await userEvent.upload(await fileInputEl('icon'), await makeImageFile('icon.png'));
+
+    const preview = page.getByTestId('apps-offsite-current-icon-preview');
+    await expect.element(preview).toBeInTheDocument();
+    expect(preview.element().getAttribute('src') ?? '').toMatch(/^blob:/);
+    await expect.element(page.getByText(/Scanning image/i)).toBeInTheDocument();
+  });
+
+  test('a scanning screenshot can be CANCELLED (allowRemove=false) — slot drops, poll stops, blob revoked', async () => {
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL');
+    mocks.addScreenshotAsync.mockResolvedValue({ status: 'pending' });
+    // create mode → allowRemove defaults to false; cancelling your own in-flight
+    // upload must STILL be allowed.
+    renderStep();
+
+    await userEvent.upload(await fileInputEl('screenshots'), await makeImageFile());
+    await expect.element(page.getByText(/Scanning image/i)).toBeInTheDocument();
+
+    // The cancel control is offered mid-scan even with allowRemove=false.
+    const cancel = page.getByTestId('apps-offsite-screenshot-cancel-0');
+    await expect.element(cancel).toBeInTheDocument();
+    // Capture the blob URL now (so we can assert it's revoked on cancel).
+    const blobUrl = page
+      .getByTestId('apps-offsite-screenshot-preview-0')
+      .element()
+      .getAttribute('src');
+    const callsBeforeCancel = mocks.addScreenshotAsync.mock.calls.length;
+
+    await cancel.click();
+
+    // The slot is gone (no preview, no "Screenshot 1" row).
+    await expect.element(page.getByText('Screenshot 1')).not.toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-screenshot-preview-0').elements()).toHaveLength(0);
+    // The poll stopped: no further attach mutation fires after the cancel.
+    expect(mocks.addScreenshotAsync.mock.calls.length).toBe(callsBeforeCancel);
+    // The local object URL was revoked (no blob leak).
+    expect(revokeSpy).toHaveBeenCalledWith(blobUrl);
+    revokeSpy.mockRestore();
+  });
+
+  const prefill = {
+    icon: { imageId: 1, url: 'https://edge/icon.png' },
+    cover: { imageId: 2, url: 'https://edge/cover.png' },
+    screenshots: [{ id: 'row-9', imageId: 3, url: 'https://edge/shot.png' }],
+  };
+
+  test('an attached prefilled screenshot offers NO remove/cancel when allowRemove=false', async () => {
+    renderStep({ initial: prefill, allowRemove: false });
+    await expect.element(page.getByText('Screenshot 1')).toBeInTheDocument();
+    // Attached, server-owned row → not locally cancellable, and not removable
+    // without allowRemove (create-flow behaviour, unchanged).
+    expect(page.getByTestId('apps-offsite-screenshot-remove-0').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-offsite-screenshot-cancel-0').elements()).toHaveLength(0);
+  });
+
+  test('an attached prefilled screenshot uses the server remove proc when allowRemove=true', async () => {
+    mocks.removeAsync.mockResolvedValue({ ok: true });
+    renderStep({ initial: prefill, allowRemove: true });
+    const remove = page.getByTestId('apps-offsite-screenshot-remove-0');
+    await expect.element(remove).toBeInTheDocument();
+    await remove.click();
+    await vi.waitFor(() =>
+      expect(mocks.removeAsync).toHaveBeenCalledWith({ screenshotId: 'row-9' })
+    );
+  });
+
+  test('repeated upload + cancel does not crash or leak (blobs revoked each cycle)', async () => {
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL');
+    mocks.addScreenshotAsync.mockResolvedValue({ status: 'pending' });
+    renderStep();
+
+    for (let i = 0; i < 3; i++) {
+      await userEvent.upload(await fileInputEl('screenshots'), await makeImageFile(`s${i}.png`));
+      const cancel = page.getByTestId('apps-offsite-screenshot-cancel-0');
+      await expect.element(cancel).toBeInTheDocument();
+      await cancel.click();
+      await expect.element(page.getByText('Screenshot 1')).not.toBeInTheDocument();
+    }
+    // One revoke per cancelled cycle (no leak, no crash).
+    expect(revokeSpy.mock.calls.length).toBeGreaterThanOrEqual(3);
+    revokeSpy.mockRestore();
   });
 });

--- a/src/components/Apps/ListingAssetStep.tsx
+++ b/src/components/Apps/ListingAssetStep.tsx
@@ -6,6 +6,7 @@ import {
   IconRefresh,
   IconTrash,
   IconUpload,
+  IconX,
 } from '@tabler/icons-react';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
@@ -61,6 +62,19 @@ export const emptyAsset: AssetState = { status: 'idle', imageId: null, message: 
 function assetFromInitial(a: EditAsset | undefined): AssetState {
   if (!a || a.imageId == null) return emptyAsset;
   return { status: 'attached', imageId: a.imageId, message: null, previewUrl: a.url };
+}
+
+/**
+ * Merge a next icon/cover AssetState onto the previous one, PRESERVING the live
+ * preview thumbnail across lifecycle transitions. The lifecycle helpers (drive,
+ * retryAttach) apply state objects that don't carry a `previewUrl`; without this
+ * the freshly-uploaded thumbnail would vanish the instant the scan lands. A
+ * `previewUrl` of `undefined` means "leave the preview alone"; an explicit value
+ * (a string, or `null` to clear on cancel) replaces it.
+ */
+function mergePreview(prev: AssetState, next: AssetState): AssetState {
+  if (next.previewUrl !== undefined) return next;
+  return { ...next, previewUrl: prev.previewUrl };
 }
 
 /** Read the intrinsic pixel dimensions of an image File (the attach proc rejects zero/unknown). */
@@ -132,6 +146,29 @@ export function ListingAssetStep({
   // Slot key → the AppListingScreenshot row id returned by addScreenshot (so a
   // freshly-added screenshot is also removable). Prefilled rows use screenshotMeta.
   const rowIdRef = useRef<Map<string, string>>(new Map());
+  // Slot key → the LOCAL object URL (URL.createObjectURL) we minted so the user
+  // sees the image they uploaded THROUGH the scan. ONLY object URLs live here
+  // (prefill/suggestion URLs never do), so revoking any value here is always safe
+  // and never touches a non-object URL. Revoked on replace/remove/cancel/unmount.
+  const objectUrlsRef = useRef<Map<string, string>>(new Map());
+
+  // Adopt a fresh object URL for a key, revoking any prior object URL it held (a
+  // REPLACE must not leak the previous blob).
+  function setObjectUrl(key: string, url: string) {
+    const prev = objectUrlsRef.current.get(key);
+    if (prev && prev !== url) URL.revokeObjectURL(prev);
+    objectUrlsRef.current.set(key, url);
+  }
+  function revokeObjectUrl(key: string) {
+    const prev = objectUrlsRef.current.get(key);
+    if (prev) URL.revokeObjectURL(prev);
+    objectUrlsRef.current.delete(key);
+  }
+
+  // Preserving appliers for icon/cover: keep the live preview thumbnail across the
+  // working→scanning→attached transitions (see mergePreview).
+  const applyIcon = (s: AssetState) => setIcon((prev) => mergePreview(prev, s));
+  const applyCover = (s: AssetState) => setCover((prev) => mergePreview(prev, s));
 
   function clearTimer(key: string) {
     const t = timersRef.current.get(key);
@@ -151,9 +188,12 @@ export function ListingAssetStep({
 
   useEffect(() => {
     const timers = timersRef.current;
+    const urls = objectUrlsRef.current;
     return () => {
       for (const t of timers.values()) clearTimeout(t);
       timers.clear();
+      for (const u of urls.values()) URL.revokeObjectURL(u);
+      urls.clear();
     };
   }, []);
 
@@ -246,7 +286,20 @@ export function ListingAssetStep({
     if (!file) return;
     clearTimer(key);
     const epoch = bumpEpoch(key);
-    apply({ status: 'working', imageId: null, message: null });
+    // Seed a LOCAL preview immediately so the user SEES the image they uploaded
+    // while it scans (whole working→scanning→attached lifecycle, not just attached).
+    // setObjectUrl revokes any prior blob for this key (a replace mid-scan).
+    const previewUrl = URL.createObjectURL(file);
+    setObjectUrl(key, previewUrl);
+    if (kind === 'screenshot') {
+      setScreenshotMeta((prev) => ({
+        ...prev,
+        [key]: { rowId: prev[key]?.rowId ?? null, previewUrl },
+      }));
+      apply({ status: 'working', imageId: null, message: null });
+    } else {
+      apply({ status: 'working', imageId: null, message: null, previewUrl });
+    }
     try {
       const imageId = await uploadAndPersist(file);
       if (!isCurrentEpoch(key, epoch)) return;
@@ -267,7 +320,10 @@ export function ListingAssetStep({
   ) {
     clearTimer(key);
     const epoch = bumpEpoch(key);
-    apply({ status: 'working', imageId: null, message: null });
+    // The suggestion URL is itself a usable preview — show it through the scan.
+    // It's NOT an object URL, so drop any prior blob for this key (never track it).
+    revokeObjectUrl(key);
+    apply({ status: 'working', imageId: null, message: null, previewUrl: url });
     try {
       const { imageId } = await ingestMutation.mutateAsync({ url, kind });
       if (!isCurrentEpoch(key, epoch)) return;
@@ -310,6 +366,17 @@ export function ListingAssetStep({
     );
   }
 
+  function dropScreenshotSlot(id: string) {
+    setScreenshots((prev) => prev.filter((s) => s.id !== id));
+    setScreenshotMeta((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+    rowIdRef.current.delete(id);
+    revokeObjectUrl(id);
+  }
+
   async function removeScreenshot(id: string) {
     const rowId = screenshotMeta[id]?.rowId ?? rowIdRef.current.get(id) ?? null;
     // Optimistically drop the slot; if the server delete fails, surface it and
@@ -323,14 +390,30 @@ export function ListingAssetStep({
         return;
       }
     }
-    setScreenshots((prev) => prev.filter((s) => s.id !== id));
-    setScreenshotMeta((prev) => {
-      const next = { ...prev };
-      delete next[id];
-      return next;
-    });
-    rowIdRef.current.delete(id);
+    dropScreenshotSlot(id);
     onAssetMutated?.();
+  }
+
+  /**
+   * Cancel a screenshot that never attached (working/scanning/error/timeout — no
+   * server row). Invalidate any in-flight poll (clearTimer + bumpEpoch so the
+   * isCurrentEpoch guard drops a resolving drive), drop the slot, and revoke its
+   * blob. NO server call: nothing was attached; a persisted-but-unattached Image
+   * row is a harmless orphan. Always allowed — cancelling your own in-flight upload
+   * is never gated by allowRemove.
+   */
+  function cancelScreenshot(id: string) {
+    clearTimer(id);
+    bumpEpoch(id);
+    dropScreenshotSlot(id);
+  }
+
+  /** Reset an icon/cover row to idle (the wrong-upload escape hatch mid-scan). */
+  function cancelAsset(key: string, apply: (s: AssetState) => void) {
+    clearTimer(key);
+    bumpEpoch(key);
+    revokeObjectUrl(key);
+    apply({ status: 'idle', imageId: null, message: null, previewUrl: null });
   }
 
   const attachedScreenshots = screenshots.filter((s) => s.status === 'attached').length;
@@ -346,14 +429,15 @@ export function ListingAssetStep({
         label="Icon"
         description="Square-ish, ≥128px, png/jpeg/webp."
         state={icon}
-        onFile={(f) => void startAttach('icon', 'icon', f, setIcon)}
+        onFile={(f) => void startAttach('icon', 'icon', f, applyIcon)}
         onRetry={() => {
-          if (icon.imageId != null) void retryAttach('icon', 'icon', icon.imageId, setIcon);
+          if (icon.imageId != null) void retryAttach('icon', 'icon', icon.imageId, applyIcon);
         }}
+        onCancel={() => cancelAsset('icon', applyIcon)}
         suggestionUrl={suggestions.iconImageUrl}
         onAcceptSuggestion={() => {
           if (suggestions.iconImageUrl)
-            void acceptSuggestion('icon', 'icon', suggestions.iconImageUrl, setIcon);
+            void acceptSuggestion('icon', 'icon', suggestions.iconImageUrl, applyIcon);
         }}
       />
       <AssetRow
@@ -361,14 +445,15 @@ export function ListingAssetStep({
         label="Cover"
         description="Landscape, ≥640px wide, png/jpeg/webp."
         state={cover}
-        onFile={(f) => void startAttach('cover', 'cover', f, setCover)}
+        onFile={(f) => void startAttach('cover', 'cover', f, applyCover)}
         onRetry={() => {
-          if (cover.imageId != null) void retryAttach('cover', 'cover', cover.imageId, setCover);
+          if (cover.imageId != null) void retryAttach('cover', 'cover', cover.imageId, applyCover);
         }}
+        onCancel={() => cancelAsset('cover', applyCover)}
         suggestionUrl={suggestions.coverImageUrl}
         onAcceptSuggestion={() => {
           if (suggestions.coverImageUrl)
-            void acceptSuggestion('cover', 'cover', suggestions.coverImageUrl, setCover);
+            void acceptSuggestion('cover', 'cover', suggestions.coverImageUrl, applyCover);
         }}
       />
 
@@ -397,13 +482,26 @@ export function ListingAssetStep({
             <Stack gap={4}>
               {screenshots.map((s, i) => {
                 const previewUrl = screenshotMeta[s.id]?.previewUrl ?? null;
-                const removable =
-                  allowRemove && (screenshotMeta[s.id]?.rowId != null || rowIdRef.current.has(s.id));
+                const rowId = screenshotMeta[s.id]?.rowId ?? rowIdRef.current.get(s.id) ?? null;
+                // Attached (has a server row) → server-side delete, gated by
+                // allowRemove (edit mode). Otherwise (in-progress / error / timeout,
+                // no row) → a LOCAL cancel, ALWAYS allowed — cancelling your own
+                // in-flight upload is never gated by allowRemove.
+                const attached = s.status === 'attached' && rowId != null;
+                const showControl = attached ? allowRemove : true;
                 return (
                   <Group key={s.id} gap={8} justify="space-between">
                     <Group gap={8}>
                       {previewUrl && (
-                        <Image src={previewUrl} w={40} h={28} radius="sm" fit="cover" alt="" />
+                        <Image
+                          src={previewUrl}
+                          w={40}
+                          h={28}
+                          radius="sm"
+                          fit="cover"
+                          alt=""
+                          data-testid={`apps-offsite-screenshot-preview-${i}`}
+                        />
                       )}
                       <Text size="xs">Screenshot {i + 1}</Text>
                     </Group>
@@ -419,18 +517,30 @@ export function ListingAssetStep({
                           Retry
                         </Button>
                       )}
-                      {removable && (
-                        <Button
-                          size="compact-xs"
-                          variant="subtle"
-                          color="red"
-                          leftSection={<IconTrash size={12} />}
-                          onClick={() => void removeScreenshot(s.id)}
-                          data-testid={`apps-offsite-screenshot-remove-${i}`}
-                        >
-                          Remove
-                        </Button>
-                      )}
+                      {showControl &&
+                        (attached ? (
+                          <Button
+                            size="compact-xs"
+                            variant="subtle"
+                            color="red"
+                            leftSection={<IconTrash size={12} />}
+                            onClick={() => void removeScreenshot(s.id)}
+                            data-testid={`apps-offsite-screenshot-remove-${i}`}
+                          >
+                            Remove
+                          </Button>
+                        ) : (
+                          <Button
+                            size="compact-xs"
+                            variant="subtle"
+                            color="red"
+                            leftSection={<IconX size={12} />}
+                            onClick={() => cancelScreenshot(s.id)}
+                            data-testid={`apps-offsite-screenshot-cancel-${i}`}
+                          >
+                            Cancel
+                          </Button>
+                        ))}
                     </Group>
                   </Group>
                 );
@@ -464,6 +574,7 @@ function AssetRow({
   state,
   onFile,
   onRetry,
+  onCancel,
   suggestionUrl,
   onAcceptSuggestion,
 }: {
@@ -473,11 +584,22 @@ function AssetRow({
   state: AssetState;
   onFile: (file: File | null) => void;
   onRetry: () => void;
+  onCancel?: () => void;
   suggestionUrl?: string;
   onAcceptSuggestion?: () => void;
 }) {
   const showSuggestion = state.status === 'idle' && !!suggestionUrl && !!onAcceptSuggestion;
-  const showPreview = state.status === 'attached' && !!state.previewUrl;
+  // Show the preview thumbnail through the WHOLE upload lifecycle (working →
+  // scanning → attached), not just once attached — so the user sees what they
+  // uploaded while it scans.
+  const showPreview = state.status !== 'idle' && !!state.previewUrl;
+  // A wrong upload mustn't trap the user: offer Cancel while in-progress/errored.
+  const showCancel =
+    !!onCancel &&
+    (state.status === 'working' ||
+      state.status === 'scanning' ||
+      state.status === 'error' ||
+      state.status === 'timeout');
   return (
     <Card withBorder p="sm">
       <Stack gap="xs">
@@ -498,6 +620,18 @@ function AssetRow({
                 onClick={onRetry}
               >
                 Retry
+              </Button>
+            )}
+            {showCancel && (
+              <Button
+                size="compact-xs"
+                variant="subtle"
+                color="red"
+                leftSection={<IconX size={12} />}
+                onClick={onCancel}
+                data-testid={`apps-offsite-cancel-${kind}`}
+              >
+                Cancel
               </Button>
             )}
           </Group>
@@ -547,7 +681,9 @@ function AssetRow({
         )}
         <FileInput
           label={
-            showPreview
+            // "Replace" only once a committed asset is attached; while a preview is
+            // merely scanning/errored the author is still on their FIRST upload.
+            state.status === 'attached'
               ? `Replace ${kind}`
               : showSuggestion
               ? `Or upload your own ${kind}`
@@ -560,7 +696,6 @@ function AssetRow({
           leftSection={<IconUpload size={16} />}
           value={null}
           onChange={onFile}
-          disabled={state.status === 'working' || state.status === 'scanning'}
         />
         {state.message && (
           <Text size="xs" c={state.status === 'error' ? 'red' : 'dimmed'}>


### PR DESCRIPTION
Two UX gaps in the App Blocks listing-asset upload step (`src/components/Apps/ListingAssetStep.tsx`, shared by the create + edit external-listing wizards). Dark/mod-gated behind `app-blocks-author`; **client-only — no server/proc/schema change**.

## Fix 1 — preview thumbnail through the whole scan lifecycle
Previously a preview thumbnail was only seeded from the EDIT prefill, so a freshly-uploaded asset showed nothing while it scanned.

- **File uploads (icon, cover, screenshots):** on file-select in `startAttach`, generate `URL.createObjectURL(file)` and show it immediately — the user sees the image they uploaded across `working → scanning → attached`, not just once attached (icon/cover on `AssetState.previewUrl`; screenshots on `screenshotMeta[id].previewUrl`).
- **Accept-suggestion path (`acceptSuggestion`):** the suggestion URL is itself a usable preview, so it renders through the scan too.
- `showPreview` for icon/cover now renders in `working`/`scanning`; the FileInput "Replace vs Upload" label still tracks `attached` only (so the existing terminal-error test is preserved).

### Object-URL lifecycle (no leaks)
A per-slot `objectUrlsRef` tracks **only** the local blob URLs we mint. They're `URL.revokeObjectURL`'d on **replace** (a new upload for the same slot revokes the prior blob), **remove/cancel**, and **on unmount**. Prefill/suggestion URLs are never tracked and never revoked.

## Fix 2 — cancel/remove an in-progress or errored asset (wrong-upload escape hatch)
- **Screenshots** can now be dropped in ANY state:
  - attached (has `rowId`) → existing server `removeScreenshot` path, still gated by `allowRemove` (unchanged).
  - in-progress (`working`/`scanning`) or `error`/`timeout` (no `rowId`) → **cancel locally**: `clearTimer` + `bumpEpoch` (invalidates any in-flight `drive` poll via the `isCurrentEpoch` guard), drop the slot from `screenshots`/`screenshotMeta`/`rowIdRef`, revoke the blob. **No server call** (the persisted Image row is a harmless unattached orphan). Always allowed regardless of `allowRemove`. Labelled "Cancel" while in-progress, "Remove" when attached.
- **Icon/cover:** the FileInput is no longer hard-disabled during `working`/`scanning`, so a wrong icon/cover can be replaced mid-scan (a new `startAttach` already `bumpEpoch`s the old poll + revokes the old blob). A small "Cancel" also resets the row to `idle`.

The pending/attached poll contract (#3020), the completeness gate, and `onAssetMutated` are untouched; the create flow is not regressed.

## Tests (browser-mode, `ListingAssetStep.browser.test.tsx`)
Added a describe block (drives the real Mantine hidden file input via `userEvent.upload` with a canvas-generated PNG so the upload pipeline reaches `scanning`):
- freshly-uploaded **screenshot** shows a `blob:` preview thumbnail while scanning
- freshly-uploaded **icon** shows a `blob:` preview thumbnail while scanning
- a scanning screenshot can be **cancelled with `allowRemove=false`** — slot drops, the poll stops (no further attach mutation), and the blob is revoked
- an attached prefilled screenshot offers no remove/cancel when `allowRemove=false`, and uses the server `removeScreenshot` proc when `allowRemove=true`
- repeated upload+cancel doesn't crash or leak (a revoke per cycle)

`9 passed` (3 pre-existing OG-image tests + 6 new). tsc clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)