### PR TITLE
fix(search): apply the types filter inside the Meili query, not post-hoc in the DB

### DIFF
--- a/src/pages/api/v1/blocks/models.ts
+++ b/src/pages/api/v1/blocks/models.ts
@@ -127,7 +127,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   let meiliNextCursor: string | undefined;
   if (query) {
     try {
-      const meili = await resolveModelSearchIds({ query, cursor, limit, browsingLevel });
+      const meili = await resolveModelSearchIds({ query, cursor, limit, browsingLevel, types });
       searchIds = meili.searchIds;
       meiliNextCursor = meili.nextCursor;
     } catch (e) {

--- a/src/pages/api/v1/models/index.ts
+++ b/src/pages/api/v1/models/index.ts
@@ -103,7 +103,13 @@ export default MixedAuthEndpoint(async function handler(
   let meiliNextCursor: string | undefined;
   if (query) {
     try {
-      const meili = await resolveModelSearchIds({ query, cursor, limit, browsingLevel });
+      const meili = await resolveModelSearchIds({
+        query,
+        cursor,
+        limit,
+        browsingLevel,
+        types: data.types,
+      });
       searchIds = meili.searchIds;
       meiliNextCursor = meili.nextCursor;
     } catch (e) {

--- a/src/server/services/__tests__/model-search.type-filter.test.ts
+++ b/src/server/services/__tests__/model-search.type-filter.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { allBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+
+/**
+ * Non-mocked test for the type filter INSIDE `resolveModelSearchIds`. The
+ * endpoint tests mock the whole service, so they only prove `types` is
+ * forwarded — this proves it lands in the actual Meili filter expression.
+ * Without the in-query filter, `query` + `types` intersected the top-N
+ * relevance hits (of ANY type) with the type filter in the DB, which returned
+ * empty pages for sparse types (verified on prod: `query=fantasy&
+ * types=Wildcards` → 0 items while a fantasy wildcard pack sits at #3 by
+ * downloads).
+ */
+
+const { mockSearch } = vi.hoisted(() => ({ mockSearch: vi.fn() }));
+
+vi.mock('~/server/meilisearch/client', () => ({
+  searchClient: { index: () => ({ search: mockSearch }) },
+  withMeili: (_label: string, fn: () => unknown) => fn(),
+  MeiliCallTimeoutError: class extends Error {},
+}));
+vi.mock('~/server/services/model.service', () => ({ getModelsWithVersions: vi.fn() }));
+vi.mock('~/server/services/file.service', () => ({ getDownloadFilename: vi.fn() }));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/server/common/model-helpers', () => ({ createModelFileDownloadUrl: vi.fn() }));
+
+import { resolveModelSearchIds } from '~/server/services/model-search.service';
+
+const baseOpts = { query: 'fantasy', limit: 10, browsingLevel: allBrowsingLevelsFlag };
+
+describe('resolveModelSearchIds type filter', () => {
+  beforeEach(() => {
+    mockSearch.mockReset();
+    mockSearch.mockResolvedValue({ hits: [] });
+  });
+
+  function searchFilter(): string[] {
+    return mockSearch.mock.calls[0][1].filter;
+  }
+
+  it('adds a type IN filter when types are given', async () => {
+    await resolveModelSearchIds({ ...baseOpts, types: ['Wildcards'] });
+    expect(searchFilter()).toContain('type IN [Wildcards]');
+  });
+
+  it('supports multiple types', async () => {
+    await resolveModelSearchIds({ ...baseOpts, types: ['Checkpoint', 'LORA'] });
+    expect(searchFilter()).toContain('type IN [Checkpoint,LORA]');
+  });
+
+  it('omits the type filter when types are absent (behavior unchanged)', async () => {
+    await resolveModelSearchIds(baseOpts);
+    expect(searchFilter().some((f) => f.startsWith('type'))).toBe(false);
+  });
+
+  it('drops values that are not ModelType members (block schema accepts raw strings)', async () => {
+    await resolveModelSearchIds({
+      ...baseOpts,
+      // 'toString' guards against prototype-chain membership checks (`in`).
+      types: ['Wildcards', 'NotAType', 'toString', 'x = 1 OR type IN [Checkpoint]'],
+    });
+    expect(searchFilter()).toContain('type IN [Wildcards]');
+  });
+
+  it('omits the filter entirely when no given type is valid', async () => {
+    await resolveModelSearchIds({ ...baseOpts, types: ['NotAType'] });
+    expect(searchFilter().some((f) => f.startsWith('type'))).toBe(false);
+  });
+
+  it('keeps the nsfwLevel filter alongside the type filter', async () => {
+    await resolveModelSearchIds({ ...baseOpts, types: ['Wildcards'] });
+    expect(searchFilter().some((f) => f.startsWith('nsfwLevel IN ['))).toBe(true);
+  });
+});

--- a/src/server/services/model-search.service.ts
+++ b/src/server/services/model-search.service.ts
@@ -9,7 +9,7 @@ import type { GetAllModelsOutput } from '~/server/schema/model.schema';
 import { getDownloadFilename } from '~/server/services/file.service';
 import { getModelsWithVersions } from '~/server/services/model.service';
 import { getPrimaryFile } from '~/server/utils/model-helpers';
-import { ModelFileVisibility, ModelModifier } from '~/shared/utils/prisma/enums';
+import { ModelFileVisibility, ModelModifier, ModelType } from '~/shared/utils/prisma/enums';
 import type { ModelHashType } from '~/shared/utils/prisma/enums';
 import { Flags } from '~/shared/utils/flags';
 import { safeDecodeURIComponent } from '~/utils/string-helpers';
@@ -77,6 +77,8 @@ export type RunModelSearchContext = {
   baseUrlOrigin: string;
 };
 
+const modelTypeValues = new Set<string>(Object.values(ModelType));
+
 export class ModelSearchMeiliTimeoutError extends Error {
   constructor() {
     super('Model search is temporarily overloaded — please retry.');
@@ -96,9 +98,19 @@ export async function resolveModelSearchIds(opts: {
   cursor?: GetAllModelsOutput['cursor'];
   limit: number;
   browsingLevel: number;
+  /**
+   * Type filter applied INSIDE the Meili query. Without it, a `query` +
+   * `types` request intersects the top-N relevance hits (of ANY type) with
+   * the type filter in the DB — for sparse types like Wildcards that's
+   * usually an empty page even when strong matches exist. Values are
+   * validated against ModelType here because the block endpoint's schema
+   * accepts arbitrary strings (also keeps them out of the filter expression).
+   */
+  types?: string[];
 }): Promise<{ searchIds: number[]; nextCursor?: string }> {
-  const { query, cursor, limit, browsingLevel } = opts;
+  const { query, cursor, limit, browsingLevel, types } = opts;
   const browsingLevelValues = Flags.instanceToArray(browsingLevel);
+  const typeValues = types?.filter((t) => modelTypeValues.has(t));
   const queryOffset = cursor && Number.isFinite(Number(cursor)) ? Math.max(0, Number(cursor)) : 0;
 
   let meiliResult: SearchResponse<{ id: number }> | undefined;
@@ -109,7 +121,10 @@ export async function resolveModelSearchIds(opts: {
           client.index(MODELS_SEARCH_INDEX).search<{ id: number }>(query, {
             offset: queryOffset || undefined,
             limit: limit ? limit + 1 : undefined,
-            filter: [`nsfwLevel IN [${browsingLevelValues.join(',')}]`],
+            filter: [
+              `nsfwLevel IN [${browsingLevelValues.join(',')}]`,
+              ...(typeValues?.length ? [`type IN [${typeValues.join(',')}]`] : []),
+            ],
             attributesToRetrieve: ['id'],
           })
         )

--- a/src/tests/api/v1/blocks/models-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/models-endpoint.test.ts
@@ -223,9 +223,12 @@ describe('/api/v1/blocks/models — authoritative clamp wiring', () => {
     expect(input.types).toEqual(['Checkpoint']);
     expect(input.baseModels).toEqual(['SDXL 1.0']);
     expect(input.limit).toBe(20);
-    // The Meili pre-step must be called with the CLAMPED level too.
+    // The Meili pre-step must be called with the CLAMPED level too, and the
+    // type filter must reach it (filtering only post-Meili in the DB returns
+    // empty pages for sparse types like Wildcards).
     expect(mockResolveModelSearchIds).toHaveBeenCalledTimes(1);
     expect(mockResolveModelSearchIds.mock.calls[0][0].browsingLevel).toBe(sfwBrowsingLevelsFlag);
+    expect(mockResolveModelSearchIds.mock.calls[0][0].types).toEqual(['Checkpoint']);
   });
 
   it('401s when no block claims were stamped (defense-in-depth; e.g. no token)', async () => {

--- a/src/tests/api/v1/models/index-refactor.test.ts
+++ b/src/tests/api/v1/models/index-refactor.test.ts
@@ -139,6 +139,11 @@ describe('/api/v1/models refactor — public maturity contract preserved', () =>
     expect(mockResolveModelSearchIds.mock.calls[0][0].browsingLevel).toBe(allBrowsingLevelsFlag);
   });
 
+  it('query path forwards the types filter to the Meili pre-step', async () => {
+    await invoke({ query: 'fantasy', types: 'Wildcards' });
+    expect(mockResolveModelSearchIds.mock.calls[0][0].types).toEqual(['Wildcards']);
+  });
+
   it('401s on favorites/hidden without a user (authed-only options gate preserved)', async () => {
     const res = await invoke({ favorites: 'true' });
     expect(res.statusCode).toBe(401);


### PR DESCRIPTION
## Problem

A text query combined with a `types` filter returns (near-)empty pages for sparse model types, even when strong matches exist.

**Verified on production** (2026-07-09):

| Request | Result |
|---|---|
| `/api/v1/models?types=Wildcards&query=fantasy` | **0 items** — while "Full Feature Fantasy Prompts" is the **#3 Wildcards model by downloads** |
| `/api/v1/models?types=Wildcards&query=pose` | **0 items** |
| `/api/v1/models?types=Wildcards&query=clothes` | 2 items |

### Root cause

`resolveModelSearchIds` sends **no type filter to Meilisearch** — only `nsfwLevel`. The type filter is applied afterward, in the DB, against the top-N relevance hits:

1. Meili returns the top `limit` hits for the query **across all model types** (checkpoints/LoRAs dominate relevance for almost any term).
2. `getModelsWithVersions` intersects those ids with `types`.
3. For a sparse type, the intersection is empty → empty page, `nextCursor` still advances through pages of nothing.

Browse-without-query was never affected (the no-query path filters by type in the DB from the start). Site search UI is also unaffected (it goes through instantsearch directly with its own facet filters).

## Fix

Thread `types` into the Meili filter expression (`type IN […]`) inside `resolveModelSearchIds`, for both of its two callers: the public `/api/v1/models` and the block catalog `/api/v1/blocks/models`.

```
filter: [
  `nsfwLevel IN [1,2,4,...]`,
  `type IN [Wildcards]`,        // ← new, only when `types` is passed
]
```

## Why this is safe (reviewed defensively)

- **Zero behavior change without `types`.** When `types` is absent the filter array is byte-identical to before. This covers the overwhelming majority of public API traffic, and is pinned by a test (`omits the type filter when types are absent`).
- **No index changes needed.** `type` is already in `filterableAttributes` on the models index (`models.search-index.ts`), and — stronger — the production site's search UI already refines on `type` against the same `models_v9` index, so prod filterability is proven by a feature in daily use.
- **No filter-expression injection.** Values must be exact `ModelType` enum members, validated via a `Set` of `Object.values(ModelType)` (a `Set` rather than the `in` operator, which walks the prototype chain — `types=toString` must not pass). All enum values are single alphanumeric tokens, and the unquoted `IN [a,b]` join matches the existing Meili filter convention in `image.service.ts`. The public endpoint additionally zod-validates `types` against the enum before the service sees it; the blocks endpoint's schema accepts raw strings, which is exactly why validation lives in the service.
- **Invalid/all-invalid `types` degrade to the old behavior.** Non-enum values are dropped from the Meili filter; if none survive, the filter is omitted entirely (identical to today). The strings still flow to the DB layer exactly as they did before this change — that pre-existing path is not widened.
- **Cloudflare cache:** `types` is part of the query string → part of the cache key. No cross-variant poisoning.
- **Pagination:** the query cursor is an opaque numeric offset; a cursor minted pre-deploy replays into a differently-composed stream post-deploy — a one-time transient of the same kind as any index/relevance update, with no error path.
- **Degraded modes untouched:** `searchClient` undefined, Meili timeout → 503, rate-limit 429, and the `limit+1` has-more math are all outside the diff.
- **Performance:** filtering on an indexed facet narrows the candidate set; this is not more expensive than ranking all types.

**The one intentional semantic change:** `query`+`types` now returns type-scoped relevance hits instead of `(top-N any-type) ∩ types`. Consumers get strictly more of what they asked for — the old behavior starved sparse types to empty pages, which no consumer can plausibly depend on.

## Tests

New `src/server/services/__tests__/model-search.type-filter.test.ts` (6 tests) exercises the **real** filter construction by mocking only the Meili client:

- single + multiple types land in the filter,
- absent `types` → filter untouched (the no-behavior-change pin),
- non-enum values dropped (incl. `toString` for the prototype-chain case and a filter-syntax injection string),
- all-invalid → filter omitted entirely,
- `nsfwLevel` filter preserved alongside.

Both endpoint suites gained forwarding assertions (`types` reaches the Meili pre-step). 61 tests pass across the search suites; full `tsc` typecheck clean.

Note: 4 unrelated blocks suites (`dev-token`, `submissions`, `submit-version`, `withdraw`) fail at import in this environment due to `@civitai/auth` workspace resolution — identical failure on a clean tree, untouched by this PR.

## Deployment

No migrations, no index rebuild, no env changes. Takes effect on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
