### PR TITLE
fix(build): move API-route tests out of src/pages/ (Next 16 route validator breaks main build)

### DIFF
--- a/src/__tests__/pages/api/mod/adjust-tag-level.test.ts
+++ b/src/__tests__/pages/api/mod/adjust-tag-level.test.ts
@@ -44,7 +44,7 @@ vi.mock('~/env/server', () => ({
   }),
 }));
 
-import handler from '../adjust-tag-level';
+import handler from '~/pages/api/mod/adjust-tag-level';
 
 const runRequest = (query: Record<string, string>) => {
   const req = {

--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { NextApiRequest, NextApiResponse } from 'next';
-import handler from '../image-scan-result';
+import handler from '~/pages/api/webhooks/image-scan-result';
 import { TagSource, ImageIngestionStatus } from '~/shared/utils/prisma/enums';
 import { NsfwLevel } from '~/server/common/enums';
 


### PR DESCRIPTION
## Problem — main build is red

`civitai-web-main-build` fails at `next build`:

```
.next/types/validator.ts
Type error: Type 'typeof import(".../src/pages/api/mod/__tests__/adjust-tag-level.test")'
  does not satisfy the constraint 'ApiRouteConfig'.
  Property 'default' is missing ... but required in type 'ApiRouteConfig'.
```

Next 16 (Turbopack) globs `pages/**` to generate `.next/types/validator.ts`, which requires every module under `pages/api/**` to export a `default` route handler. Two **vitest files colocated under `src/pages/api/**/__tests__/`** (added in #2419) have no default export → the generated validator fails type-check → build exits 1. It's deterministic, so Tekton retries can't recover it, and once these commits reach `release` it will break the dp-prod build too.

## Fix

Relocate both tests out of `src/pages/` (colocating tests under `pages/` is the anti-pattern) into a mirrored `src/__tests__/pages/api/...` tree:

| from | to |
|---|---|
| `src/pages/api/mod/__tests__/adjust-tag-level.test.ts` | `src/__tests__/pages/api/mod/adjust-tag-level.test.ts` |
| `src/pages/api/webhooks/__tests__/image-scan-result.test.ts` | `src/__tests__/pages/api/webhooks/image-scan-result.test.ts` |

- Still matched by the vitest unit include (`src/**/*.test.ts`), so the tests keep running.
- Out of Next's `pages/**` glob, so no route validator entry is generated.
- Handler imports switched from the sibling relative path to the `~/` alias. No other relative imports / `vi.mock` paths (all already `~/`).

## Verification

Structural (confirmed): no `*.test.ts` remains under `src/pages/`; the `~/` imports resolve to the existing handler files; the test bodies already type-checked cleanly under the build's tsc before (the original build reported *only* the validator error). Full proof is the next `civitai-web-main-build` going green.

`pageExtensions` filtering was considered and rejected — Next has no negative-glob support, so it'd require renaming every real page.