### PR TITLE
perf(model.getAll): cap browse-feed response to 3 images per model

### DIFF
--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -117,6 +117,7 @@ import {
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
 import type { RuleDefinition } from '~/server/utils/mod-rules';
+import { capGetAllModelImages } from '~/server/utils/model-getall-images';
 import {
   DEFAULT_PAGE_SIZE,
   getCursorClauses,
@@ -1362,7 +1363,13 @@ export const getModelsWithImagesAndModelVersions = async ({
           // images: model.nsfw
           //   ? versionImages.map((x) => ({ ...x, nsfwLevel: NsfwLevel.XXX }))
           //   : versionImages,
-          images: filteredImages,
+          // Cap the images in the getAll (browse feed) response — the browse
+          // ModelCard only renders images[0], but the shared image cache returns
+          // up to 20, bloating the tRPC payload (serialized synchronously on the
+          // event loop). `capGetAllModelImages` returns a new array, so the shared
+          // `imagesForModelVersionsCache` entries (still used at full 20 by
+          // model-detail pages, auctions, etc.) are untouched.
+          images: capGetAllModelImages(filteredImages),
           canGenerate,
         };
       })

--- a/src/server/utils/__tests__/model-getall-images.test.ts
+++ b/src/server/utils/__tests__/model-getall-images.test.ts
@@ -15,16 +15,17 @@ const makeImages = (n: number) =>
 
 describe('model-getall-images', () => {
   it('caps to at most GET_ALL_IMAGES_PER_MODEL', () => {
-    expect(GET_ALL_IMAGES_PER_MODEL).toBeLessThanOrEqual(3);
+    // Pinned: the browse cap is 8 (raised from 3 after the browsing-level
+    // feed-drop review — see the constant's doc).
+    expect(GET_ALL_IMAGES_PER_MODEL).toBe(8);
     const out = capGetAllModelImages(makeImages(20));
     expect(out.length).toBe(GET_ALL_IMAGES_PER_MODEL);
-    expect(out.length).toBeLessThanOrEqual(3);
   });
 
   it('keeps the leading images in order (browse UI reads images[0])', () => {
     const images = makeImages(20);
     const out = capGetAllModelImages(images);
-    expect(out.map((x) => x.id)).toEqual([1, 2, 3]);
+    expect(out.map((x) => x.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
     // identity preserved (not re-cloned) so downstream `images[0]` is the same ref
     expect(out[0]).toBe(images[0]);
   });

--- a/src/server/utils/__tests__/model-getall-images.test.ts
+++ b/src/server/utils/__tests__/model-getall-images.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  GET_ALL_IMAGES_PER_MODEL,
+  capGetAllModelImages,
+} from '~/server/utils/model-getall-images';
+
+// The browse-feed (`model.getAll`) response caps each model's images to the first
+// few, because the browse `ModelCard` renders only `images[0]`. The shared image
+// cache (`imagesForModelVersionsCache`) still holds the full 20 for model-detail /
+// auction consumers, so the cap MUST NOT mutate the array it is given (a getAll
+// entry can alias a shared-cache array when no `excludedTagIds` filter runs).
+
+const makeImages = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ id: i + 1, url: `img-${i + 1}` }));
+
+describe('model-getall-images', () => {
+  it('caps to at most GET_ALL_IMAGES_PER_MODEL', () => {
+    expect(GET_ALL_IMAGES_PER_MODEL).toBeLessThanOrEqual(3);
+    const out = capGetAllModelImages(makeImages(20));
+    expect(out.length).toBe(GET_ALL_IMAGES_PER_MODEL);
+    expect(out.length).toBeLessThanOrEqual(3);
+  });
+
+  it('keeps the leading images in order (browse UI reads images[0])', () => {
+    const images = makeImages(20);
+    const out = capGetAllModelImages(images);
+    expect(out.map((x) => x.id)).toEqual([1, 2, 3]);
+    // identity preserved (not re-cloned) so downstream `images[0]` is the same ref
+    expect(out[0]).toBe(images[0]);
+  });
+
+  it('returns everything when there are fewer than the cap', () => {
+    expect(capGetAllModelImages(makeImages(2)).length).toBe(2);
+    expect(capGetAllModelImages(makeImages(1)).length).toBe(1);
+    expect(capGetAllModelImages([])).toEqual([]);
+  });
+
+  it('does NOT mutate the source array (shared-cache safety)', () => {
+    // Simulates slicing a value that aliases a shared `imagesForModelVersionsCache`
+    // entry: the cache must still hold all 20 images afterwards.
+    const cached = makeImages(20);
+    const before = [...cached];
+    const out = capGetAllModelImages(cached);
+    expect(cached).toHaveLength(20);
+    expect(cached).toEqual(before);
+    expect(out).not.toBe(cached); // a new array, not the same reference
+  });
+});

--- a/src/server/utils/model-getall-images.ts
+++ b/src/server/utils/model-getall-images.ts
@@ -5,20 +5,25 @@
  * consumer found none that renders `images[1+]`. Returning up to 20 images per
  * model (the shared `imagesForModelVersionsCache` size) bloated the tRPC payload
  * ~5-8x (1.5-3 MB responses serialized synchronously on the Node event loop — a
- * high-volume source of event-loop-freeze). Capping the RESPONSE to a few images
- * removes ~75-85% of that payload.
+ * high-volume source of event-loop-freeze). Capping the RESPONSE removes the
+ * bulk of that payload (~60% at this cap).
  *
- * Kept > 1 (not sliced to the single rendered image) as headroom for:
- *  - any undocumented external `/api/trpc/model.getAll` token-consumer, and
- *  - the client-side browsing-level image filter (`useApplyHiddenPreferences`,
- *    models path) which iterates the returned array and picks the first image
- *    that passes the viewer's browsing level.
+ * Set to 8 (not 1, and raised from an initial 3 after review): the shared image
+ * array is browsing-level-AGNOSTIC, and the client-side filter
+ * (`useApplyHiddenPreferences`, models path) iterates it to pick the first image
+ * that passes the VIEWER's browsing level — DROPPING the model from the feed if
+ * none survive. A too-tight cap would hide mixed-level models from
+ * restricted-browsing (SFW-mode) viewers whose first safe image sits past the
+ * cap. 8 keeps a browsing-safe image in range with high probability while still
+ * shedding most of the payload; it is also headroom for any undocumented
+ * external `/api/trpc/model.getAll` token-consumer. Tune here if feed drops
+ * appear (still << the shared cache's 20).
  *
  * NOTE: this caps only the getAll response mapping. The shared image cache
  * (`getImagesForModelVersionCache` / `imagesForModelVersionsCache`, 20 images)
  * is untouched — model-detail pages, auctions, and other consumers still get 20.
  */
-export const GET_ALL_IMAGES_PER_MODEL = 3;
+export const GET_ALL_IMAGES_PER_MODEL = 8;
 
 /**
  * Cap a per-model images array to the browse-feed limit. Returns a NEW array

--- a/src/server/utils/model-getall-images.ts
+++ b/src/server/utils/model-getall-images.ts
@@ -1,0 +1,30 @@
+/**
+ * Max images returned per model in the browse-feed (`model.getAll` tRPC) response.
+ *
+ * The browse `ModelCard` renders only `images[0]`; a grep of every `model.getAll`
+ * consumer found none that renders `images[1+]`. Returning up to 20 images per
+ * model (the shared `imagesForModelVersionsCache` size) bloated the tRPC payload
+ * ~5-8x (1.5-3 MB responses serialized synchronously on the Node event loop — a
+ * high-volume source of event-loop-freeze). Capping the RESPONSE to a few images
+ * removes ~75-85% of that payload.
+ *
+ * Kept > 1 (not sliced to the single rendered image) as headroom for:
+ *  - any undocumented external `/api/trpc/model.getAll` token-consumer, and
+ *  - the client-side browsing-level image filter (`useApplyHiddenPreferences`,
+ *    models path) which iterates the returned array and picks the first image
+ *    that passes the viewer's browsing level.
+ *
+ * NOTE: this caps only the getAll response mapping. The shared image cache
+ * (`getImagesForModelVersionCache` / `imagesForModelVersionsCache`, 20 images)
+ * is untouched — model-detail pages, auctions, and other consumers still get 20.
+ */
+export const GET_ALL_IMAGES_PER_MODEL = 3;
+
+/**
+ * Cap a per-model images array to the browse-feed limit. Returns a NEW array
+ * (never mutates the input), so slicing a value that aliases a shared-cache
+ * entry does not affect the cache.
+ */
+export function capGetAllModelImages<T>(images: T[]): T[] {
+  return images.slice(0, GET_ALL_IMAGES_PER_MODEL);
+}


### PR DESCRIPTION
## What

Cap the images returned per model in the `model.getAll` tRPC (browse feed) response to the **first 3** (was up to **20**).

## Why

`model.getAll` returns up to 20 images per model (the shared `imagesForModelVersionsCache` size), but the browse UI's `ModelCard` renders only `images[0]`. A grep of every `model.getAll` consumer found none that renders `images[1+]`, so ~75–85% of each 1.5–3 MB response is images the UI discards. Those oversized responses are serialized synchronously on the Node event loop — a high-volume contributor to the production event-loop-freeze class (the instrument confirms `model.getAll` fires >1000 oversized responses / 6h). The `limit` is already capped at 100; the payload size is the images, not the row count.

Capping the **response** to 3 removes the bulk of the payload while leaving headroom above the single rendered image.

## Change

`src/server/services/model.service.ts`, `getModelsWithImagesAndModelVersions` per-model map:

```
- images: filteredImages,
+ images: capGetAllModelImages(filteredImages),
```

`capGetAllModelImages` (new, `src/server/utils/model-getall-images.ts`) is a pure `images.slice(0, GET_ALL_IMAGES_PER_MODEL)` (=3). Extracted into a tiny dependency-light util purely so it is unit-testable in isolation (the parent function's same-module collaborator `getModelsRaw` and heavy import graph make a faithful full-function unit test impractical).

- Sliced to **3**, not 1, as headroom for any undocumented external `/api/trpc/model.getAll` token-consumer and for the client-side browsing-level image filter (see caveat below).
- `.slice` returns a **new** array, so slicing a value that aliases a shared-cache entry does not mutate the cache.

## Scope / what is NOT touched

- The shared image cache (`getImagesForModelVersionCache` / `imagesForModelVersionsCache`, `imagesPerVersion: 20` in `image.service.ts`) is **unchanged** — model-detail pages, auctions, and other consumers still receive the full 20. `image.service.ts` has no diff.
- The documented public `/api/v1/models` endpoint uses a **separate** `model-search.service` path and is **unaffected** by this change.
- Only the `model.getAll` response mapping changes.

## Consumer re-grep

Every `model.getAll` consumer was re-checked. Renderers read only `images[0]` (`ModelCard.tsx:125/128`, `ModelCardContextMenu.tsx`). The only consumer that iterates the whole images array is `useApplyHiddenPreferences` (models path) — see caveat.

## ⚠️ Reviewer caveat — browsing-level feed interaction

The shared cache is browsing-level-**agnostic**: it stores up to 20 images spanning all NSFW levels, ordered by `postId, index` (creator showcase order). The client-side `useApplyHiddenPreferences` (models path) then filters that array by the **viewer's** browsing level and displays `images[0]`; if **no** returned image passes the viewer's level, the model is dropped from the feed.

Consequence: for a **mixed-NSFW-level** model whose browsing-safe image sits **beyond index 3** in showcase order, a restricted-browsing viewer who previously saw that later image will now see the model drop from the feed. Expected to be low-frequency (creators typically lead with a representative cover image, and 3 gives buffer over the single rendered image), but it is a real behavioral change, not a pure byte optimization. If feed completeness for restricted viewers is a concern, the mitigation is to raise `GET_ALL_IMAGES_PER_MODEL` (still far below 20) — hence it's a single named constant.

## Tests

`src/server/utils/__tests__/model-getall-images.test.ts` (4 tests, all passing): caps to ≤3, preserves leading order + `images[0]` identity, returns all when fewer than the cap, and **does not mutate the source array** (shared-cache safety).

## Response-shape note

This changes the `model.getAll` response shape: up to 20 → up to 3 images per model. Affects `model.getAll` only.


---

## Scope & disclosures (added after adversarial audit)

- **Not browse-only — also affects the home-page featured-models block and collection model items.** The cap lives in the shared `getModelsWithImagesAndModelVersions` (`model.service.ts`), which feeds `home-block.service.ts`, `collection.service.ts`, **and** `model.getAll`. Behavior is consistent across all three (each renders via `ModelCard` → `images[0]` and the same `useApplyHiddenPreferences` filter), but this is a shared-service change, not a browse-feed-only one.
- **Partial mitigation, not a full fix.** Live oversized `model.getAll` responses (Loki, 24h): p50 ~1.59 MB, p90 ~2.37 MB, max ~3.10 MB. Cap 20→8 removes ~60% of the *image* portion, so p50-ish responses drop under the 1 MB threshold, but the **p90+ tail (image-dense models / large pages) will still exceed it**. This reduces sustained event-loop-serialize pressure; it does not eliminate model.getAll oversized responses. (The 6-second freeze that motivated this arc was a different procedure, `user.getEngagedModels` — fixed separately in #3028.)
- **Browsing-level residual risk (pre-existing class, not introduced here).** The shared image array is browsing-level-agnostic; the client `useApplyHiddenPreferences` picks the first image passing the viewer's level and **drops the model from the feed if none survive**. Capping server-side narrows the pool the client filters from — a restricted-browsing (SFW-mode) viewer loses a model only if it has >8 images with *all* of its first 8 (in showcase order) above their level. Cap was raised 3→8 for margin; the exact hit-rate is untested. No finite cap eliminates this (the cache is browsing-agnostic); a zero-regression fix would need browsing-aware server-side slicing. **Heads-up for product** — the constant is the single tune point if feed drops appear.
