### PR TITLE
feat(user): bounded getEngagedModelsByIds membership endpoint (PR1, freeze-fix)

### DIFF
--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -24,6 +24,7 @@ import type { PaymentMethodDeleteInput } from '~/server/schema/stripe.schema';
 import type {
   DeleteUserInput,
   GetAllUsersInput,
+  GetEngagedModelsByIdsInput,
   GetByUsernameSchema,
   GetUserByUsernameSchema,
   GetUserCosmeticsSchema,
@@ -82,6 +83,7 @@ import {
   getUserCreator,
   getUserDownloadedModelVersions,
   getUserEngagedModels,
+  getUserEngagedModelsByIds,
   getUserEngagedModelVersions,
   getUserList,
   getUserPurchasedRewards,
@@ -660,6 +662,25 @@ export const getUserEngagedModelsHandler = async ({ ctx }: { ctx: ProtectedConte
     );
 
     return engagedModels;
+  } catch (error) {
+    if (error instanceof TRPCError) throw error;
+    throw throwDbError(error);
+  }
+};
+
+// Additive, per-visible-set counterpart to `getUserEngagedModelsHandler`. Bounded input →
+// bounded response, so (unlike the whole-history handler above) there is no cache: the tiny,
+// index-scannable payload isn't worth the combinatorial keyspace + bust-site sprawl.
+export const getUserEngagedModelsByIdsHandler = async ({
+  input,
+  ctx,
+}: {
+  input: GetEngagedModelsByIdsInput;
+  ctx: ProtectedContext;
+}) => {
+  const { id } = ctx.user;
+  try {
+    return await getUserEngagedModelsByIds({ id, modelIds: input.modelIds });
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     throw throwDbError(error);

--- a/src/server/routers/user.router.ts
+++ b/src/server/routers/user.router.ts
@@ -17,6 +17,7 @@ import {
   getUserCosmeticsHandler,
   getUserCreatorHandler,
   getUserEngagedModelsHandler,
+  getUserEngagedModelsByIdsHandler,
   getUserEngagedModelVersionsHandler,
   getUserFeatureFlagsHandler,
   getUserFollowingListHandler,
@@ -50,6 +51,7 @@ import {
   restoreAlertSchema,
   restoreUserSchema,
   getAllUsersInput,
+  getEngagedModelsByIdsSchema,
   getByUsernameSchema,
   getUserByUsernameSchema,
   getUserCosmeticsSchema,
@@ -144,6 +146,10 @@ export const userRouter = router({
   getEngagedModels: protectedProcedure
     .meta({ requiredScope: TokenScope.UserRead })
     .query(getUserEngagedModelsHandler),
+  getEngagedModelsByIds: protectedProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(getEngagedModelsByIdsSchema)
+    .query(getUserEngagedModelsByIdsHandler),
   getEngagedModelVersions: protectedProcedure
     .meta({ requiredScope: TokenScope.UserRead })
     .input(getByIdSchema)

--- a/src/server/schema/__tests__/get-engaged-models-by-ids.schema.test.ts
+++ b/src/server/schema/__tests__/get-engaged-models-by-ids.schema.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { getEngagedModelsByIdsSchema } from '~/server/schema/user.schema';
+
+// PR1 of the getEngagedModels freeze-fix: the per-visible-set membership input is bounded
+// (min 1, max 200) so a caller can never re-open the unbounded whole-history door that froze
+// an api-primary pod. Over-cap must REJECT (not truncate) so the widening surfaces loudly.
+describe('getEngagedModelsByIdsSchema', () => {
+  it('accepts a valid bounded modelIds array', () => {
+    const res = getEngagedModelsByIdsSchema.safeParse({ modelIds: [1, 2, 3] });
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.data.modelIds).toEqual([1, 2, 3]);
+  });
+
+  it('accepts exactly 200 ids (the cap)', () => {
+    const modelIds = Array.from({ length: 200 }, (_, i) => i + 1);
+    const res = getEngagedModelsByIdsSchema.safeParse({ modelIds });
+    expect(res.success).toBe(true);
+  });
+
+  it('rejects 201 ids (over cap) — does not truncate', () => {
+    const modelIds = Array.from({ length: 201 }, (_, i) => i + 1);
+    const res = getEngagedModelsByIdsSchema.safeParse({ modelIds });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects an empty array (min 1)', () => {
+    const res = getEngagedModelsByIdsSchema.safeParse({ modelIds: [] });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects a missing modelIds field', () => {
+    const res = getEngagedModelsByIdsSchema.safeParse({});
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects non-number ids', () => {
+    const res = getEngagedModelsByIdsSchema.safeParse({ modelIds: ['a', 'b'] });
+    expect(res.success).toBe(false);
+  });
+});

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -148,6 +148,15 @@ export const toggleModelEngagementInput = z.object({
 });
 export type ToggleModelEngagementInput = z.infer<typeof toggleModelEngagementInput>;
 
+// Per-visible-set engagement membership. Bounded (max 200) so the response is small +
+// index-scannable — the additive replacement for the unbounded `getEngagedModels`, which
+// returns a user's ENTIRE engagement history (a whale's 3.75 MB / 482 ms serialize froze
+// an api-primary pod). Reject (do not truncate) over-cap so callers can't silently widen it.
+export const getEngagedModelsByIdsSchema = z.object({
+  modelIds: z.array(z.number()).min(1).max(200),
+});
+export type GetEngagedModelsByIdsInput = z.infer<typeof getEngagedModelsByIdsSchema>;
+
 export const toggleFollowUserSchema = z.object({
   targetUserId: z.number(),
   username: usernameSchema.nullable().optional(),

--- a/src/server/services/__tests__/get-engaged-models-by-ids.service.test.ts
+++ b/src/server/services/__tests__/get-engaged-models-by-ids.service.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * PR1 of the `user.getEngagedModels` freeze-fix — the additive, per-visible-set membership
+ * service `getUserEngagedModelsByIds`, plus the `modelIds` extension of the shared
+ * `getResourceReviewsByUserId` it reuses for the `Recommended` source.
+ *
+ * The bug it replaces: the unbounded `getUserEngagedModels` handler serializes a whale's ENTIRE
+ * engagement history (3.75 MB / 482 ms synchronous serialize → 6 s api-primary event-loop freeze).
+ * These tests pin that the new path returns ONLY the intersection of (user's engagements ∩ input
+ * modelIds), keyed by engagement type, so the response is bounded by |modelIds| × (#types).
+ *
+ * `~/server/db/client` is mocked with an in-memory fixture whose `findMany` applies the real
+ * `where` clause — so the tests exercise the service's shaping AND that it passes the correct,
+ * bounded filters down to Prisma (including through the reused `getResourceReviewsByUserId`).
+ */
+
+// Model id fixtures (kept in sync with the hoisted mock below — plain numbers, safe to duplicate).
+const USER = 1;
+const OTHER_USER = 2;
+const A = 101; // Favorite + Recommended
+const B = 102; // Hide + Notify
+const C = 103; // Favorite (OUTSIDE the typical input set)
+const D = 104; // Mute (outside input)
+const E = 105; // Recommended only (outside input)
+const F = 106; // resource review but recommended:false (must never appear)
+const Z = 999; // in input but user has NO engagement
+
+const { mockDb } = vi.hoisted(() => {
+  const U = 1;
+  const OU = 2;
+  type EngRow = { userId: number; modelId: number; type: string };
+  type RevRow = { userId: number; modelId: number; modelVersionId: number; recommended: boolean };
+
+  const engagementRows: EngRow[] = [
+    { userId: U, modelId: 101, type: 'Favorite' },
+    { userId: U, modelId: 102, type: 'Hide' },
+    { userId: U, modelId: 102, type: 'Notify' },
+    { userId: U, modelId: 103, type: 'Favorite' },
+    { userId: U, modelId: 104, type: 'Mute' },
+    { userId: OU, modelId: 101, type: 'Favorite' }, // isolation: must never leak into U's result
+    { userId: OU, modelId: 102, type: 'Hide' },
+  ];
+  const reviewRows: RevRow[] = [
+    { userId: U, modelId: 101, modelVersionId: 1001, recommended: true },
+    { userId: U, modelId: 105, modelVersionId: 1002, recommended: true },
+    { userId: U, modelId: 106, modelVersionId: 1003, recommended: false },
+    { userId: OU, modelId: 101, modelVersionId: 1004, recommended: true },
+  ];
+
+  const inArr = (where: any, field: string) => where?.[field]?.in as number[] | undefined;
+
+  return {
+    mockDb: {
+      modelEngagement: {
+        findMany: vi.fn(async ({ where }: any) => {
+          const ids = inArr(where, 'modelId');
+          return engagementRows
+            .filter(
+              (r) =>
+                r.userId === where.userId &&
+                (where.type === undefined || r.type === where.type) &&
+                (!ids || ids.includes(r.modelId))
+            )
+            .map((r) => ({ modelId: r.modelId, type: r.type }));
+        }),
+      },
+      resourceReview: {
+        findMany: vi.fn(async ({ where }: any) => {
+          const ids = inArr(where, 'modelId');
+          return reviewRows
+            .filter(
+              (r) =>
+                r.userId === where.userId &&
+                (where.recommended === undefined || r.recommended === where.recommended) &&
+                (!ids || ids.includes(r.modelId))
+            )
+            .map((r) => ({ modelId: r.modelId, modelVersionId: r.modelVersionId }));
+        }),
+      },
+    },
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+// user.service reaches into user-preferences.service at import time; stub the surface
+// (matches the proven recipe in engagement-toggle.idempotent.service.test.ts).
+vi.mock('~/server/services/user-preferences.service', () => ({
+  HiddenModels: { refreshCache: vi.fn(async () => undefined) },
+  HiddenModels3D: { refreshCache: vi.fn(async () => undefined) },
+  HiddenUsers: { refreshCache: vi.fn(async () => undefined) },
+  HiddenImages: { refreshCache: vi.fn(async () => undefined) },
+  HiddenTags: { refreshCache: vi.fn(async () => undefined) },
+  BlockedUsers: { refreshCache: vi.fn(async () => undefined), getCached: vi.fn(async () => []) },
+  BlockedByUsers: { refreshCache: vi.fn(async () => undefined) },
+  ImplicitHiddenImages: { refreshCache: vi.fn(async () => undefined) },
+  toggleHidden: vi.fn(async () => ({ added: [], removed: [] })),
+}));
+
+import { getUserEngagedModelsByIds } from '~/server/services/user.service';
+import { getResourceReviewsByUserId } from '~/server/services/resourceReview.service';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getUserEngagedModelsByIds — shape', () => {
+  it('returns a Record keyed by engagement type + Recommended', async () => {
+    const res = await getUserEngagedModelsByIds({ id: USER, modelIds: [A, B, C, D] });
+    // All the user's real engagement types (over the input) are present.
+    expect(res.Favorite).toEqual(expect.arrayContaining([A, C]));
+    expect(res.Hide).toEqual([B]);
+    expect(res.Notify).toEqual([B]);
+    expect(res.Mute).toEqual([D]);
+    expect(res.Recommended).toBeDefined();
+  });
+});
+
+describe('getUserEngagedModelsByIds — membership is scoped to (engagements ∩ input)', () => {
+  it('includes only ids that are BOTH engaged AND in the input set', async () => {
+    const res = await getUserEngagedModelsByIds({ id: USER, modelIds: [A, B, Z] });
+
+    // A/B are engaged AND in input.
+    expect(res.Favorite).toEqual([A]);
+    expect(res.Hide).toEqual([B]);
+    expect(res.Notify).toEqual([B]);
+
+    // C is engaged but NOT in input → appears nowhere.
+    const allIds = Object.values(res).flat();
+    expect(allIds).not.toContain(C);
+    // D (Mute, not in input) also absent.
+    expect(allIds).not.toContain(D);
+    // Z is in input but not engaged → appears in NO array.
+    expect(allIds).not.toContain(Z);
+  });
+
+  it('passes the bounded modelId filter down to Prisma (both tables)', async () => {
+    await getUserEngagedModelsByIds({ id: USER, modelIds: [A, B, Z] });
+    expect(mockDb.modelEngagement.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: USER, modelId: { in: [A, B, Z] } } })
+    );
+    expect(mockDb.resourceReview.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: USER, recommended: true, modelId: { in: [A, B, Z] } },
+      })
+    );
+  });
+});
+
+describe('getUserEngagedModelsByIds — per-type correctness', () => {
+  it('a Hide model shows under Hide and not under Favorite', async () => {
+    const res = await getUserEngagedModelsByIds({ id: USER, modelIds: [B] });
+    expect(res.Hide).toContain(B);
+    expect(res.Favorite ?? []).not.toContain(B);
+  });
+
+  it('a model engaged as multiple types appears under each type', async () => {
+    const res = await getUserEngagedModelsByIds({ id: USER, modelIds: [B] });
+    expect(res.Hide).toContain(B);
+    expect(res.Notify).toContain(B);
+  });
+});
+
+describe('getUserEngagedModelsByIds — Recommended path', () => {
+  it('a recommended model in the input set appears under Recommended', async () => {
+    const res = await getUserEngagedModelsByIds({ id: USER, modelIds: [A] });
+    expect(res.Recommended).toEqual([A]);
+  });
+
+  it('a recommended model OUTSIDE the input set does not appear', async () => {
+    const res = await getUserEngagedModelsByIds({ id: USER, modelIds: [A, B] });
+    expect(res.Recommended).not.toContain(E);
+    expect(res.Recommended).toEqual([A]);
+  });
+
+  it('a non-recommended review (recommended:false) never appears', async () => {
+    const res = await getUserEngagedModelsByIds({ id: USER, modelIds: [A, F] });
+    expect(res.Recommended).not.toContain(F);
+  });
+});
+
+describe('getUserEngagedModelsByIds — user isolation', () => {
+  it("does not return another user's engagements on the same modelIds", async () => {
+    const res = await getUserEngagedModelsByIds({ id: USER, modelIds: [A, B] });
+    // OTHER_USER also has A/B engagements, but querying USER must only reflect USER's rows.
+    expect(res.Favorite).toEqual([A]); // A once (USER's), not doubled by OTHER_USER
+    expect(res.Hide).toEqual([B]);
+  });
+
+  it("querying the other user returns only that user's engagements", async () => {
+    const res = await getUserEngagedModelsByIds({ id: OTHER_USER, modelIds: [A, B] });
+    expect(res.Favorite).toEqual([A]);
+    expect(res.Hide).toEqual([B]);
+    expect(res.Notify ?? []).not.toContain(B); // OTHER_USER has no Notify
+    expect(res.Recommended).toEqual([A]); // OTHER_USER's own recommended review on A
+  });
+});
+
+describe('getUserEngagedModelsByIds — edge cases', () => {
+  it('empty result: user has none of the input ids → Recommended empty, no crash', async () => {
+    const res = await getUserEngagedModelsByIds({ id: USER, modelIds: [Z] });
+    expect(res.Recommended).toEqual([]);
+    // No engagement-type keys created for an absent id.
+    expect(Object.values(res).flat()).toEqual([]);
+  });
+
+  it('duplicate ids in the input do not duplicate output', async () => {
+    const res = await getUserEngagedModelsByIds({ id: USER, modelIds: [A, A, B] });
+    expect(res.Favorite).toEqual([A]);
+    expect(res.Hide).toEqual([B]);
+  });
+});
+
+describe('getUserEngagedModelsByIds — freeze-safety bound', () => {
+  it('200 ids all engaged across every type yields a bounded result (≤ ~1000 ids)', async () => {
+    const modelIds = Array.from({ length: 200 }, (_, i) => 5000 + i);
+    const types = ['Favorite', 'Hide', 'Notify', 'Mute'];
+    const bigEng = modelIds.flatMap((modelId) => types.map((type) => ({ modelId, type })));
+    const bigRev = modelIds.map((modelId, i) => ({ modelId, modelVersionId: 9000 + i }));
+
+    mockDb.modelEngagement.findMany.mockImplementationOnce(async ({ where }: any) => {
+      const ids = where.modelId.in as number[];
+      return bigEng.filter((r) => ids.includes(r.modelId));
+    });
+    mockDb.resourceReview.findMany.mockImplementationOnce(async ({ where }: any) => {
+      const ids = where.modelId.in as number[];
+      return bigRev.filter((r) => ids.includes(r.modelId));
+    });
+
+    const res = await getUserEngagedModelsByIds({ id: USER, modelIds });
+    const total = Object.values(res).reduce((n, arr) => n + arr.length, 0);
+    // 200 × 4 engagement types + 200 recommended = 1000. Bounded by input, not history.
+    expect(total).toBe(1000);
+    expect(total).toBeLessThanOrEqual(1000);
+  });
+});
+
+describe('getResourceReviewsByUserId — modelIds extension (backward-compatible)', () => {
+  it('default (no modelIds) omits the modelId filter — preserves whole-history behavior', async () => {
+    await getResourceReviewsByUserId({ userId: USER, recommended: true });
+    const call = mockDb.resourceReview.findMany.mock.calls.at(-1)?.[0];
+    expect(call.where).toEqual({ userId: USER, recommended: true });
+    expect(call.where).not.toHaveProperty('modelId');
+  });
+
+  it('with modelIds adds a bounded modelId: { in } filter', async () => {
+    await getResourceReviewsByUserId({ userId: USER, recommended: true, modelIds: [A, E] });
+    const call = mockDb.resourceReview.findMany.mock.calls.at(-1)?.[0];
+    expect(call.where).toEqual({ userId: USER, recommended: true, modelId: { in: [A, E] } });
+  });
+
+  it('filters the returned rows to the input set when modelIds is passed', async () => {
+    const rows = await getResourceReviewsByUserId({
+      userId: USER,
+      recommended: true,
+      modelIds: [A],
+    });
+    expect(rows.map((r) => r.modelId)).toEqual([A]);
+  });
+});

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -87,12 +87,16 @@ export const getUserResourceReview = async ({
 export const getResourceReviewsByUserId = ({
   userId,
   recommended,
+  modelIds,
 }: {
   userId: number;
   recommended?: boolean;
+  // When provided, bound the scan to these models (membership queries). Omitted =
+  // unfiltered = existing behavior for the current whole-history callers.
+  modelIds?: number[];
 }) => {
   return dbRead.resourceReview.findMany({
-    where: { userId, recommended },
+    where: { userId, recommended, ...(modelIds ? { modelId: { in: modelIds } } : {}) },
     select: { modelId: true, modelVersionId: true },
   });
 };

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -83,6 +83,7 @@ import {
 } from '~/server/services/user-preferences.service';
 import { createCachedObject, fetchThroughCache } from '~/server/utils/cache-helpers';
 import { bustRatingTotalsCache } from '~/server/services/resourceReview.cache';
+import { getResourceReviewsByUserId } from '~/server/services/resourceReview.service';
 import {
   handleLogError,
   isPrismaUniqueViolation,
@@ -599,6 +600,44 @@ export const getUserEngagedModels = ({ id, type }: { id: number; type?: ModelEng
     where: { userId: id, type },
     select: { modelId: true, type: true },
   });
+};
+
+export type EngagedModelType = ModelEngagementType | 'Recommended';
+
+/**
+ * Per-visible-set engagement membership: given a bounded set of `modelIds`, return which of
+ * them the user has engaged with, keyed by engagement type. The additive, index-bounded
+ * replacement for `getUserEngagedModels` (whose caller returns a user's ENTIRE engagement
+ * history — a whale's 3.75 MB / 482 ms synchronous serialize froze an api-primary pod).
+ *
+ * Every returned array is a subset of the input `modelIds` (the intersection of the user's
+ * engagements ∩ input), so the response is bounded by |modelIds| × (#types) — no cache needed.
+ * `Recommended` is derived from resource reviews, filtered to the same input set.
+ */
+export const getUserEngagedModelsByIds = async ({
+  id,
+  modelIds,
+}: {
+  id: number;
+  modelIds: number[];
+}) => {
+  const [engagements, recommendedReviews] = await Promise.all([
+    dbRead.modelEngagement.findMany({
+      where: { userId: id, modelId: { in: modelIds } },
+      select: { modelId: true, type: true },
+    }),
+    getResourceReviewsByUserId({ userId: id, recommended: true, modelIds }),
+  ]);
+
+  const engagedModels = engagements.reduce<Record<EngagedModelType, number[]>>((acc, model) => {
+    const { type, modelId } = model;
+    if (!acc[type]) acc[type] = [];
+    acc[type].push(modelId);
+    return acc;
+  }, {} as Record<EngagedModelType, number[]>);
+  engagedModels.Recommended = recommendedReviews.map((r) => r.modelId).filter(isDefined);
+
+  return engagedModels;
 };
 
 export async function getUserEngagedModelVersions({


### PR DESCRIPTION
## PR1 of the `user.getEngagedModels` freeze-fix — additive server endpoint

**Problem.** `user.getEngagedModels` returns a user's **entire** engagement history. For a whale that response is ~3.75 MB and its synchronous superjson serialize takes ~482 ms — long enough to **freeze an api-primary event loop for ~6s** (all in-flight requests on that pod stall). The unbounded read (`modelEngagement.findMany({ where: { userId } })` + an equally-unbounded `getResourceReviewsByUserId`) is the root cause.

**This PR (server-only, additive).** Adds a per-visible-set membership endpoint. Callers pass the models currently on screen (bounded, max 200); the endpoint returns only which of them the user has engaged with, in the **same** `Record<EngagedModelType, number[]>` shape. Response is bounded by `|modelIds| × (#types)` — no cache needed (a per-set cache would add a combinatorial keyspace + bust-site sprawl for no win).

The old `getEngagedModels` is left **fully intact** — callers migrate in later PRs.

### What's added
- **Schema** — `src/server/schema/user.schema.ts`: `getEngagedModelsByIdsSchema = z.object({ modelIds: z.array(z.number()).min(1).max(200) })`. Over-cap **rejects** (does not truncate).
- **Service** — `src/server/services/user.service.ts`: `getUserEngagedModelsByIds({ id, modelIds })`. Filters `modelEngagement` to the input set and reuses `getResourceReviewsByUserId` for `Recommended`.
- **`getResourceReviewsByUserId`** — `src/server/services/resourceReview.service.ts`: gains an **optional** `modelIds` param (adds `modelId: { in }`). Omitted = unfiltered = **existing behavior** for current callers.
- **Controller** — `src/server/controllers/user.controller.ts`: `getUserEngagedModelsByIdsHandler` (mirrors the existing handler's auth/ctx, minus caching).
- **Router** — `src/server/routers/user.router.ts`: `getEngagedModelsByIds` (`protectedProcedure`, `TokenScope.UserRead`).

### Backward compatibility
- `getEngagedModels` endpoint/handler/service: **untouched**.
- Existing `getResourceReviewsByUserId` caller (the old handler): unchanged behavior (new param defaults to unfiltered). Verified by a test.

### Tests — 22 passing (6 schema + 16 service)
Shape (all types + Recommended present) · intersection filtering (engaged ∩ input; out-of-input and not-engaged ids excluded) · per-type correctness (Hide≠Favorite; multi-type model under each) · Recommended path (in-set present, out-of-set absent, `recommended:false` never appears) · user isolation (another user's rows on the same ids excluded) · edge cases (empty, duplicate ids) · schema cap (200 ok / 201 rejects / empty rejects / non-number rejects) · freeze-safety bound (200 ids × all types → exactly 1000, bounded by input not history) · `getResourceReviewsByUserId` default-unfiltered vs `modelIds`-bounded where-clause.

`pnpm typecheck` (tsc --noEmit): **pass**.

### Follow-ups
- **PR2** — client store + migrate `getEngagedModels` callers to the by-ids path.
- **PR3** — feed integration.
- **PR4** — delete the old unbounded `getEngagedModels`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)