### PR TITLE
fix(search): resilient Meili client — graceful degradation on comm error (kills ~1.6k/3h uncaught RUM exceptions)

### DIFF
--- a/src/components/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/src/components/AutocompleteSearch/AutocompleteSearch.tsx
@@ -28,6 +28,7 @@ import { ClearableAutoComplete } from '~/components/ClearableAutoComplete/Cleara
 import { getModelUrl, slugit } from '~/utils/string-helpers';
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 import { env } from '~/env/client';
+import { createResilientSearchClient } from '~/components/Search/resilientSearchClient';
 import { ModelSearchItem } from '~/components/AutocompleteSearch/renderItems/models';
 import { ArticlesSearchItem } from '~/components/AutocompleteSearch/renderItems/articles';
 import { UserSearchItem } from '~/components/AutocompleteSearch/renderItems/users';
@@ -71,7 +72,9 @@ type Props = Omit<AutocompleteProps, 'data' | 'onSubmit'> & {
   searchBoxProps?: SearchBoxProps;
 };
 
-const searchClient: InstantSearchProps['searchClient'] = {
+// Wrapped so a Meili outage degrades to empty results instead of an uncaught
+// `MeiliSearchCommunicationError`. Fails quietly (header autocomplete, no banner).
+const searchClient: InstantSearchProps['searchClient'] = createResilientSearchClient({
   ...meilisearch,
   search(requests) {
     // Prevent making a request if there is no query
@@ -95,7 +98,7 @@ const searchClient: InstantSearchProps['searchClient'] = {
 
     return meilisearch.search(requests);
   },
-};
+});
 
 const DEFAULT_DROPDOWN_ITEM_LIMIT = 6;
 

--- a/src/components/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/src/components/AutocompleteSearch/AutocompleteSearch.tsx
@@ -29,6 +29,10 @@ import { getModelUrl, slugit } from '~/utils/string-helpers';
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 import { env } from '~/env/client';
 import { createResilientSearchClient } from '~/components/Search/resilientSearchClient';
+import {
+  autocompleteAvailability,
+  useAutocompleteAvailabilityStore,
+} from '~/components/Search/search-availability.store';
 import { ModelSearchItem } from '~/components/AutocompleteSearch/renderItems/models';
 import { ArticlesSearchItem } from '~/components/AutocompleteSearch/renderItems/articles';
 import { UserSearchItem } from '~/components/AutocompleteSearch/renderItems/users';
@@ -73,32 +77,40 @@ type Props = Omit<AutocompleteProps, 'data' | 'onSubmit'> & {
 };
 
 // Wrapped so a Meili outage degrades to empty results instead of an uncaught
-// `MeiliSearchCommunicationError`. Fails quietly (header autocomplete, no banner).
-const searchClient: InstantSearchProps['searchClient'] = createResilientSearchClient({
-  ...meilisearch,
-  search(requests) {
-    // Prevent making a request if there is no query
-    // @see https://www.algolia.com/doc/guides/building-search-ui/going-further/conditional-requests/react/#detecting-empty-search-requests
-    // @see https://github.com/algolia/react-instantsearch/issues/1111#issuecomment-496132977
-    if (requests.every(({ params }) => !params?.query)) {
-      return Promise.resolve({
-        results: requests.map(() => ({
-          hits: [],
-          nbHits: 0,
-          nbPages: 0,
-          page: 0,
-          processingTimeMS: 0,
-          hitsPerPage: 0,
-          exhaustiveNbHits: false,
-          query: '',
-          params: '',
-        })),
-      });
-    }
+// `MeiliSearchCommunicationError`. On fallback it flips the autocomplete
+// availability flag so the dropdown shows its "Error" item (the swallowed error
+// never reaches `useInstantSearch().status`, so we can't key off that).
+const searchClient: InstantSearchProps['searchClient'] = createResilientSearchClient(
+  {
+    ...meilisearch,
+    search(requests) {
+      // Prevent making a request if there is no query
+      // @see https://www.algolia.com/doc/guides/building-search-ui/going-further/conditional-requests/react/#detecting-empty-search-requests
+      // @see https://github.com/algolia/react-instantsearch/issues/1111#issuecomment-496132977
+      if (requests.every(({ params }) => !params?.query)) {
+        return Promise.resolve({
+          results: requests.map(() => ({
+            hits: [],
+            nbHits: 0,
+            nbPages: 0,
+            page: 0,
+            processingTimeMS: 0,
+            hitsPerPage: 0,
+            exhaustiveNbHits: false,
+            query: '',
+            params: '',
+          })),
+        });
+      }
 
-    return meilisearch.search(requests);
+      return meilisearch.search(requests);
+    },
   },
-});
+  {
+    onError: () => autocompleteAvailability.setUnavailable(true),
+    onSuccess: () => autocompleteAvailability.setUnavailable(false),
+  }
+);
 
 const DEFAULT_DROPDOWN_ITEM_LIMIT = 6;
 
@@ -227,7 +239,11 @@ function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
   const [debouncedSearch] = useDebouncedValue(search, 300);
 
   const { trackSearch, trackAction } = useTrackEvent();
-  const searchErrorState = status === 'error';
+  // The resilient search client swallows Meili comm errors (so they never reach
+  // `useInstantSearch().status === 'error'`); it flips this flag on fallback
+  // instead, which keeps the dropdown's "Error" item + the AIR-redirect gate
+  // working during a Meili blip.
+  const searchErrorState = useAutocompleteAvailabilityStore((state) => state.unavailable);
 
   const { key, value } = paired<SearchIndexDataMap>(indexName, hits as SearchIndexDataMap[TKey]);
   const { items: filtered } = useApplyHiddenPreferences({
@@ -337,7 +353,7 @@ function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
       items.push({ key: 'view-more', value: query, hit: null as any, label: 'View more results' });
 
     return items;
-  }, [status, filtered, results?.nbHits, query]);
+  }, [status, searchErrorState, filtered, results?.nbHits, query]);
 
   // Track profanity search separately to avoid side effects in useMemo
   useEffect(() => {

--- a/src/components/CollectionSelectModal/CollectionSelectModal.tsx
+++ b/src/components/CollectionSelectModal/CollectionSelectModal.tsx
@@ -19,6 +19,7 @@ import cardClasses from '~/components/Cards/Cards.module.css';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { CustomSearchBox } from '~/components/Search/CustomSearchComponents';
+import { createResilientSearchClient } from '~/components/Search/resilientSearchClient';
 import { searchIndexMap } from '~/components/Search/search.types';
 import type { SearchIndexDataMap } from '~/components/Search/search.utils2';
 import { useInfiniteHitsTransformed } from '~/components/Search/search.utils2';
@@ -267,9 +268,11 @@ const meilisearch = instantMeiliSearch(
   { primaryKey: 'id', keepZeroFacets: true }
 );
 
-const searchClient: InstantSearchProps['searchClient'] = {
+// Wrapped so a Meili outage degrades to empty results instead of an uncaught
+// `MeiliSearchCommunicationError`. Fails quietly (modal picker, no banner).
+const searchClient: InstantSearchProps['searchClient'] = createResilientSearchClient({
   ...meilisearch,
   search(requests) {
     return meilisearch.search(requests);
   },
-};
+});

--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/searchClient.ts
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/searchClient.ts
@@ -1,6 +1,7 @@
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 import type { InstantSearchProps } from 'react-instantsearch';
 import { env } from '~/env/client';
+import { createResilientSearchClient } from '~/components/Search/resilientSearchClient';
 
 const meilisearch = instantMeiliSearch(
   env.NEXT_PUBLIC_SEARCH_HOST as string,
@@ -8,9 +9,11 @@ const meilisearch = instantMeiliSearch(
   { primaryKey: 'id', keepZeroFacets: true }
 );
 
-export const searchClient: InstantSearchProps['searchClient'] = {
+// Wrapped so a Meili outage degrades to empty results instead of an uncaught
+// `MeiliSearchCommunicationError`. Fails quietly (modal picker, no banner).
+export const searchClient: InstantSearchProps['searchClient'] = createResilientSearchClient({
   ...meilisearch,
   search(requests) {
     return meilisearch.search(requests);
   },
-};
+});

--- a/src/components/Search/QuickSearchDropdown.tsx
+++ b/src/components/Search/QuickSearchDropdown.tsx
@@ -26,16 +26,20 @@ import { IMAGES_SEARCH_INDEX, TOOLS_SEARCH_INDEX } from '~/server/common/constan
 import type { ShowcaseItemSchema } from '~/server/schema/user-profile.schema';
 import { paired } from '~/utils/type-guards';
 import { searchClient } from '~/components/Search/search.client';
+import { createResilientSearchClient } from '~/components/Search/resilientSearchClient';
 import { ApplyCustomFilter, BrowsingLevelFilter } from './CustomSearchComponents';
 import { ToolSearchItem } from '~/components/AutocompleteSearch/renderItems/tools';
 import { ComicsSearchItem } from '~/components/AutocompleteSearch/renderItems/comics';
 import classes from './QuickSearchDropdown.module.scss';
 import { truncate } from 'lodash-es';
 
-const meilisearch = instantMeiliSearch(
-  env.NEXT_PUBLIC_SEARCH_HOST as string,
-  env.NEXT_PUBLIC_SEARCH_CLIENT_KEY,
-  { primaryKey: 'id' }
+// Wrapped so a Meili outage degrades this dropdown to an empty result set
+// instead of an uncaught `MeiliSearchCommunicationError`. Fails quietly (no
+// banner) — the header quick-search just shows nothing during a blip.
+const meilisearch = createResilientSearchClient(
+  instantMeiliSearch(env.NEXT_PUBLIC_SEARCH_HOST as string, env.NEXT_PUBLIC_SEARCH_CLIENT_KEY, {
+    primaryKey: 'id',
+  })
 );
 
 // TODO: These styles were taken from the original SearchBar component. We should probably migrate that searchbar to use this component.

--- a/src/components/Search/SearchLayout.tsx
+++ b/src/components/Search/SearchLayout.tsx
@@ -11,11 +11,17 @@ import {
   UnstyledButton,
 } from '@mantine/core';
 
+import { Alert } from '@mantine/core';
 import { createContext, useContext, useEffect, useMemo, useState, useCallback } from 'react';
 import { AppLayout } from '~/components/AppLayout/AppLayout';
 import { IconAlertTriangle, IconChevronsLeft } from '@tabler/icons-react';
 import { routing } from '~/components/Search/useSearchState';
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
+import { createResilientSearchClient } from '~/components/Search/resilientSearchClient';
+import {
+  searchAvailability,
+  useSearchAvailabilityStore,
+} from '~/components/Search/search-availability.store';
 import Link from 'next/link';
 import { env } from '~/env/client';
 import type { SearchIndex } from '~/components/Search/parsers/base';
@@ -45,12 +51,16 @@ const meilisearch = instantMeiliSearch(
   { primaryKey: 'id', keepZeroFacets: true }
 );
 
-const searchClient: InstantSearchProps['searchClient'] = {
-  ...meilisearch,
-  search(requests) {
-    return meilisearch.search(requests);
-  },
-};
+// Wrap the Meili client so a backend outage/blip degrades to an empty result set
+// (with a "temporarily unavailable" banner) instead of throwing an uncaught
+// `MeiliSearchCommunicationError`. Happy path is unchanged: a successful search
+// returns Meili's response verbatim. The availability store is the side-channel
+// used to render the banner (the swallowed error never reaches
+// `useInstantSearch().status`).
+const searchClient: InstantSearchProps['searchClient'] = createResilientSearchClient(meilisearch, {
+  onError: () => searchAvailability.setUnavailable(true),
+  onSuccess: () => searchAvailability.setUnavailable(false),
+});
 
 // #region [ImageGuardContext]
 type SearchLayoutState = {
@@ -193,6 +203,7 @@ export function SearchLayout({
   ]);
 
   const isProfaneSearch = profanityAnalysis.hasProfanity;
+  const isSearchUnavailable = useSearchAvailabilityStore((state) => state.unavailable);
 
   return (
     <SearchLayoutCtx.Provider value={ctx}>
@@ -341,7 +352,22 @@ export function SearchLayout({
               </SearchLayout.Content>
             </SearchLayout.Root>
           ) : (
-            <>{children}</>
+            <>
+              {isSearchUnavailable && (
+                <SearchLayout.Content>
+                  <Alert
+                    icon={<IconAlertTriangle size={18} />}
+                    color="yellow"
+                    variant="light"
+                    title="Search is temporarily unavailable"
+                  >
+                    We couldn&apos;t reach search just now. This is usually brief — please try your
+                    search again in a moment.
+                  </Alert>
+                </SearchLayout.Content>
+              )}
+              {children}
+            </>
           )}
         </AppLayout>
       </InstantSearch>

--- a/src/components/Search/resilientSearchClient.test.ts
+++ b/src/components/Search/resilientSearchClient.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createResilientSearchClient,
+  isMeiliCommunicationError,
+} from '~/components/Search/resilientSearchClient';
+
+// Minimal fake requests shaped like what react-instantsearch passes through.
+const twoRequests = [
+  { indexName: 'models', params: { query: 'cat' } },
+  { indexName: 'images', params: { query: 'cat' } },
+] as any;
+
+const okResponse = {
+  results: [
+    { hits: [{ id: 1 }], nbHits: 1, page: 0, nbPages: 1, hitsPerPage: 1, processingTimeMS: 3, query: 'cat', params: '' },
+  ],
+} as any;
+
+const commError = Object.assign(new Error('NetworkError when attempting to fetch resource'), {
+  name: 'MeiliSearchCommunicationError',
+});
+
+function makeClient(overrides: Record<string, any> = {}) {
+  return {
+    search: vi.fn(),
+    searchForFacetValues: vi.fn(),
+    clearCache: vi.fn(),
+    ...overrides,
+  } as any;
+}
+
+describe('isMeiliCommunicationError', () => {
+  it('matches the MeiliSearchCommunicationError name (any casing)', () => {
+    expect(isMeiliCommunicationError({ name: 'MeiliSearchCommunicationError' })).toBe(true);
+  });
+
+  it('matches network-ish messages across browser engines', () => {
+    expect(isMeiliCommunicationError(new Error('NetworkError when attempting to fetch'))).toBe(true);
+    expect(isMeiliCommunicationError(new Error('Failed to fetch'))).toBe(true);
+    expect(isMeiliCommunicationError(new Error('Load failed'))).toBe(true);
+  });
+
+  it('does not match unrelated / falsy errors', () => {
+    expect(isMeiliCommunicationError(null)).toBe(false);
+    expect(isMeiliCommunicationError(undefined)).toBe(false);
+    expect(isMeiliCommunicationError(new Error('invalid_request: bad filter'))).toBe(false);
+  });
+});
+
+describe('createResilientSearchClient — happy path', () => {
+  it('passes the base response through untouched and calls onSuccess (not onError)', async () => {
+    const onError = vi.fn();
+    const onSuccess = vi.fn();
+    const base = makeClient({ search: vi.fn().mockResolvedValue(okResponse) });
+
+    const client = createResilientSearchClient(base, { onError, onSuccess });
+    const result = await client.search!(twoRequests);
+
+    expect(result).toBe(okResponse); // byte-identical reference — no transformation
+    expect(base.search).toHaveBeenCalledTimes(1);
+    expect(base.search).toHaveBeenCalledWith(twoRequests);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('preserves other client members (spread + searchForFacetValues wrapped)', () => {
+    const base = makeClient();
+    const client = createResilientSearchClient(base);
+    expect(typeof client.search).toBe('function');
+    expect(typeof (client as any).clearCache).toBe('function');
+    expect(typeof client.searchForFacetValues).toBe('function');
+  });
+});
+
+describe('createResilientSearchClient — communication error fallback', () => {
+  it('returns a valid empty response (no throw) and sets the unavailable flag via onError', async () => {
+    const onError = vi.fn();
+    const onSuccess = vi.fn();
+    const base = makeClient({ search: vi.fn().mockRejectedValue(commError) });
+
+    const client = createResilientSearchClient(base, {
+      onError,
+      onSuccess,
+      retryDelayMs: 0,
+    });
+
+    const result = await client.search!(twoRequests);
+
+    // Valid empty InstantSearch response, same arity as the requests.
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toEqual({
+      hits: [],
+      nbHits: 0,
+      nbPages: 0,
+      page: 0,
+      processingTimeMS: 0,
+      hitsPerPage: 0,
+      exhaustiveNbHits: false,
+      query: '',
+      params: '',
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(commError);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('retries a transient comm error exactly once, then falls back', async () => {
+    const search = vi.fn().mockRejectedValue(commError);
+    const client = createResilientSearchClient(makeClient({ search }), { retryDelayMs: 0 });
+
+    const result = await client.search!(twoRequests);
+
+    // default retries = 1 → initial attempt + one retry = 2 calls
+    expect(search).toHaveBeenCalledTimes(2);
+    expect(result.results).toHaveLength(2);
+  });
+
+  it('recovers if the retry succeeds — returns the response, calls onSuccess not onError', async () => {
+    const onError = vi.fn();
+    const onSuccess = vi.fn();
+    const search = vi.fn().mockRejectedValueOnce(commError).mockResolvedValueOnce(okResponse);
+    const client = createResilientSearchClient(makeClient({ search }), {
+      onError,
+      onSuccess,
+      retryDelayMs: 0,
+    });
+
+    const result = await client.search!(twoRequests);
+
+    expect(search).toHaveBeenCalledTimes(2);
+    expect(result).toBe(okResponse);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('does NOT retry a non-communication error — falls back after one attempt', async () => {
+    const onError = vi.fn();
+    const badQueryError = new Error('invalid_request: unknown filter field');
+    const search = vi.fn().mockRejectedValue(badQueryError);
+    const client = createResilientSearchClient(makeClient({ search }), {
+      onError,
+      retryDelayMs: 0,
+    });
+
+    const result = await client.search!(twoRequests);
+
+    expect(search).toHaveBeenCalledTimes(1); // no retry for non-transient errors
+    expect(result.results).toHaveLength(2);
+    expect(onError).toHaveBeenCalledWith(badQueryError);
+  });
+
+  it('handles an empty requests array without crashing', async () => {
+    const client = createResilientSearchClient(
+      makeClient({ search: vi.fn().mockRejectedValue(commError) }),
+      { retryDelayMs: 0 }
+    );
+    const result = await client.search!([] as any);
+    expect(result.results).toEqual([]);
+  });
+});
+
+describe('createResilientSearchClient — searchForFacetValues', () => {
+  it('swallows a facet-search error and returns valid empty facet results', async () => {
+    const onError = vi.fn();
+    const base = makeClient({
+      searchForFacetValues: vi.fn().mockRejectedValue(commError),
+    });
+    const client = createResilientSearchClient(base, { onError, retryDelayMs: 0 });
+
+    const requests = [{ indexName: 'models', params: {} }, { indexName: 'images', params: {} }] as any;
+    const result = await client.searchForFacetValues!(requests);
+
+    expect(result).toEqual([
+      { facetHits: [], exhaustiveFacetsCount: true, processingTimeMS: 0 },
+      { facetHits: [], exhaustiveFacetsCount: true, processingTimeMS: 0 },
+    ]);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes facet results through on success', async () => {
+    const facetResponse = [{ facetHits: [{ value: 'x', count: 3 }], exhaustiveFacetsCount: true }];
+    const base = makeClient({
+      searchForFacetValues: vi.fn().mockResolvedValue(facetResponse),
+    });
+    const client = createResilientSearchClient(base);
+    const result = await client.searchForFacetValues!([{ indexName: 'models', params: {} }] as any);
+    expect(result).toBe(facetResponse);
+  });
+
+  it('leaves searchForFacetValues undefined when the base client lacks it', () => {
+    const base = { search: vi.fn(), clearCache: vi.fn() } as any;
+    const client = createResilientSearchClient(base);
+    expect(client.searchForFacetValues).toBeUndefined();
+  });
+});

--- a/src/components/Search/resilientSearchClient.ts
+++ b/src/components/Search/resilientSearchClient.ts
@@ -1,0 +1,174 @@
+import type { InstantSearchProps } from 'react-instantsearch';
+
+/**
+ * Resilient wrapper around a react-instantsearch `searchClient`.
+ *
+ * A Meilisearch backend blip surfaces to the browser as an UNCAUGHT
+ * `MeiliSearchCommunicationError: NetworkError when attempting to fetch resource`
+ * thrown out of the vendored `@meilisearch/instant-meilisearch` adapter. That
+ * uncaught throw both spams Faro RUM (~1.6k/3h, 95% on `/search`) and breaks the
+ * search UX for the user during the blip.
+ *
+ * This wrapper catches communication/network errors from `.search`
+ * (and `.searchForFacetValues` when present), optionally retries once for
+ * transient blips, and — if it still can't reach Meili — resolves to a VALID
+ * empty InstantSearch response so react-instantsearch renders a normal empty
+ * state instead of crashing. The error is NEVER re-thrown, so it stops being an
+ * uncaught exception. Callers can observe the failure via `onError`/`onSuccess`
+ * to surface a distinguishable "temporarily unavailable" banner (as opposed to a
+ * misleading "no results found").
+ *
+ * Happy path is untouched: on a successful `.search` the base client's response
+ * is returned verbatim (only `onSuccess` is invoked to clear any prior banner).
+ */
+
+type SearchClient = NonNullable<InstantSearchProps['searchClient']>;
+type SearchMethod = SearchClient['search'];
+type SearchRequests = Parameters<SearchMethod>[0];
+type FacetRequests = Parameters<NonNullable<SearchClient['searchForFacetValues']>>[0];
+
+// Lower-cased substrings that identify a Meili communication / network / connectivity
+// failure. Covers the browser fetch wordings across engines (Firefox "NetworkError
+// when attempting to fetch resource", Chrome "Failed to fetch", Safari "Load failed")
+// plus the adapter's own error class name.
+const COMMUNICATION_ERROR_SUBSTRINGS = [
+  'networkerror',
+  'failed to fetch',
+  'load failed',
+  'network request failed',
+  'communication',
+  'err_network',
+  'err_connection',
+  'err_internet_disconnected',
+  'connection refused',
+  'the network connection was lost',
+];
+
+function toLowerString(value: unknown): string {
+  if (typeof value === 'string') return value.toLowerCase();
+  if (value == null) return '';
+  try {
+    return String(value).toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * True for the transient Meili connectivity errors we want to retry + swallow.
+ * Non-communication errors (e.g. a malformed-query 4xx) are still swallowed to
+ * empty results by the wrapper, but are NOT retried and do not match here.
+ */
+export function isMeiliCommunicationError(err: unknown): boolean {
+  if (!err) return false;
+  const name = toLowerString((err as { name?: unknown })?.name);
+  if (name === 'meilisearchcommunicationerror') return true;
+
+  const message = toLowerString((err as { message?: unknown })?.message);
+  const cause = toLowerString((err as { cause?: unknown })?.cause);
+  return COMMUNICATION_ERROR_SUBSTRINGS.some(
+    (needle) => message.includes(needle) || cause.includes(needle)
+  );
+}
+
+/**
+ * A valid, empty InstantSearch multi-search response of the same arity as the
+ * incoming requests. Matches the shape react-instantsearch expects (mirrors the
+ * empty-query short-circuit already used in `search.client.ts`).
+ */
+function emptySearchResults(requests: SearchRequests) {
+  return {
+    results: (requests ?? []).map(() => ({
+      hits: [],
+      nbHits: 0,
+      nbPages: 0,
+      page: 0,
+      processingTimeMS: 0,
+      hitsPerPage: 0,
+      exhaustiveNbHits: false,
+      query: '',
+      params: '',
+    })),
+  };
+}
+
+function emptyFacetResults(requests: readonly unknown[]) {
+  return (requests ?? []).map(() => ({
+    facetHits: [],
+    exhaustiveFacetsCount: true,
+    processingTimeMS: 0,
+  }));
+}
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export type ResilientSearchClientOptions = {
+  /** Number of retries for a transient communication error before falling back. Default 1. */
+  retries?: number;
+  /** Delay (ms) between the failed attempt and the retry. Default 250. */
+  retryDelayMs?: number;
+  /** Invoked once when a search ultimately falls back to empty results (Meili unreachable). */
+  onError?: (error: unknown) => void;
+  /** Invoked on every successful search — lets callers clear a prior "unavailable" state. */
+  onSuccess?: () => void;
+};
+
+/**
+ * Wrap a react-instantsearch `searchClient` so a Meili outage degrades gracefully
+ * to an empty result set instead of throwing an uncaught exception.
+ */
+export function createResilientSearchClient<T extends SearchClient>(
+  client: T,
+  options: ResilientSearchClientOptions = {}
+): T {
+  const { retries = 1, retryDelayMs = 250, onError, onSuccess } = options;
+
+  const resilientSearch = async (requests: SearchRequests) => {
+    let lastError: unknown;
+    for (let attempt = 0; attempt <= retries; attempt++) {
+      try {
+        const response = await client.search(requests);
+        onSuccess?.();
+        return response;
+      } catch (error) {
+        lastError = error;
+        // Only retry transient communication blips; a non-comm error won't get
+        // better on retry, so fall back immediately.
+        if (attempt < retries && isMeiliCommunicationError(error)) {
+          await delay(retryDelayMs);
+          continue;
+        }
+        break;
+      }
+    }
+    onError?.(lastError);
+    return emptySearchResults(requests);
+  };
+
+  const resilientFacetSearch = async (requests: FacetRequests) => {
+    const baseFacetSearch = client.searchForFacetValues;
+    try {
+      const response = await baseFacetSearch!.call(client, requests);
+      onSuccess?.();
+      return response;
+    } catch (error) {
+      onError?.(error);
+      return emptyFacetResults(requests);
+    }
+  };
+
+  // The library's `search`/`searchForFacetValues` are generic over the hit type
+  // (`<TObject>`). A concrete wrapper can't preserve that variance while also
+  // awaiting the result for retry logic, so we assemble the object and cast once
+  // at the boundary — the wrapper is generic-transparent at runtime (it either
+  // returns the base client's response verbatim or a valid empty response of the
+  // same shape). `searchForFacetValues` is only added when the base client
+  // implements it (the Meili adapter does).
+  return {
+    ...client,
+    search: resilientSearch,
+    ...(typeof client.searchForFacetValues === 'function'
+      ? { searchForFacetValues: resilientFacetSearch }
+      : {}),
+  } as unknown as T;
+}

--- a/src/components/Search/search-availability.store.ts
+++ b/src/components/Search/search-availability.store.ts
@@ -1,30 +1,45 @@
 import { create } from 'zustand';
 
 /**
- * Tracks whether the Meili-backed search is currently unreachable, so the
- * `/search` results area can render a distinguishable "temporarily unavailable"
- * banner instead of a misleading "no results found" empty state.
+ * Tracks whether a Meili-backed search surface is currently unreachable, so the
+ * UI can render a distinguishable "temporarily unavailable" / error state
+ * instead of a misleading "no results found" empty state.
  *
  * The resilient search client swallows communication errors (to kill the
  * uncaught RUM exception), which means react-instantsearch's own
  * `useInstantSearch().status` never flips to `'error'`. This store is the
  * side-channel: the wrapped client flips `unavailable` on fallback and clears it
  * on the next successful search.
+ *
+ * Each surface gets its own store instance so an outage on one (e.g. the header
+ * autocomplete) doesn't drive the error UI of another (e.g. the `/search` page).
  */
 type SearchAvailabilityState = {
   unavailable: boolean;
   setUnavailable: (value: boolean) => void;
 };
 
-export const useSearchAvailabilityStore = create<SearchAvailabilityState>((set) => ({
-  unavailable: false,
-  setUnavailable: (value) =>
-    // Avoid a no-op state write (and re-render) when the flag is unchanged —
-    // `.search` fires on every keystroke, so `onSuccess` runs constantly.
-    set((state) => (state.unavailable === value ? state : { unavailable: value })),
-}));
+function createAvailabilityStore() {
+  const useStore = create<SearchAvailabilityState>((set) => ({
+    unavailable: false,
+    setUnavailable: (value) =>
+      // Avoid a no-op state write (and re-render) when the flag is unchanged —
+      // `.search` fires on every keystroke, so `onSuccess` runs constantly.
+      set((state) => (state.unavailable === value ? state : { unavailable: value })),
+  }));
 
-export const searchAvailability = {
-  setUnavailable: (value: boolean) =>
-    useSearchAvailabilityStore.getState().setUnavailable(value),
-};
+  return {
+    useStore,
+    setUnavailable: (value: boolean) => useStore.getState().setUnavailable(value),
+  };
+}
+
+// `/search` results-area banner (SearchLayout).
+const searchStore = createAvailabilityStore();
+export const useSearchAvailabilityStore = searchStore.useStore;
+export const searchAvailability = { setUnavailable: searchStore.setUnavailable };
+
+// Header quick-search autocomplete dropdown error item (AutocompleteSearch).
+const autocompleteStore = createAvailabilityStore();
+export const useAutocompleteAvailabilityStore = autocompleteStore.useStore;
+export const autocompleteAvailability = { setUnavailable: autocompleteStore.setUnavailable };

--- a/src/components/Search/search-availability.store.ts
+++ b/src/components/Search/search-availability.store.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+
+/**
+ * Tracks whether the Meili-backed search is currently unreachable, so the
+ * `/search` results area can render a distinguishable "temporarily unavailable"
+ * banner instead of a misleading "no results found" empty state.
+ *
+ * The resilient search client swallows communication errors (to kill the
+ * uncaught RUM exception), which means react-instantsearch's own
+ * `useInstantSearch().status` never flips to `'error'`. This store is the
+ * side-channel: the wrapped client flips `unavailable` on fallback and clears it
+ * on the next successful search.
+ */
+type SearchAvailabilityState = {
+  unavailable: boolean;
+  setUnavailable: (value: boolean) => void;
+};
+
+export const useSearchAvailabilityStore = create<SearchAvailabilityState>((set) => ({
+  unavailable: false,
+  setUnavailable: (value) =>
+    // Avoid a no-op state write (and re-render) when the flag is unchanged —
+    // `.search` fires on every keystroke, so `onSuccess` runs constantly.
+    set((state) => (state.unavailable === value ? state : { unavailable: value })),
+}));
+
+export const searchAvailability = {
+  setUnavailable: (value: boolean) =>
+    useSearchAvailabilityStore.getState().setUnavailable(value),
+};

--- a/src/components/Search/search.client.ts
+++ b/src/components/Search/search.client.ts
@@ -1,6 +1,7 @@
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 import type { InstantSearchProps } from 'react-instantsearch';
 import { env } from '~/env/client';
+import { createResilientSearchClient } from '~/components/Search/resilientSearchClient';
 
 const meilisearch = instantMeiliSearch(
   env.NEXT_PUBLIC_SEARCH_HOST as string,
@@ -8,7 +9,7 @@ const meilisearch = instantMeiliSearch(
   { primaryKey: 'id', keepZeroFacets: true }
 );
 
-export const searchClient: InstantSearchProps['searchClient'] = {
+const baseSearchClient: InstantSearchProps['searchClient'] = {
   ...meilisearch,
   search(requests) {
     // Prevent making a request if there is no query
@@ -36,3 +37,9 @@ export const searchClient: InstantSearchProps['searchClient'] = {
     return meilisearch.search(requests);
   },
 };
+
+// Wrap so a Meili outage degrades to empty results instead of an uncaught
+// `MeiliSearchCommunicationError`. This client backs the header quick-search
+// dropdown (and other autocomplete surfaces), so it fails quietly — no banner.
+export const searchClient: InstantSearchProps['searchClient'] =
+  createResilientSearchClient(baseSearchClient);


### PR DESCRIPTION
## Evidence
Faro RUM shows `Error: MeiliSearchCommunicationError: NetworkError when attempting to fetch resource` at **~1,674/3h, 95% on `/search`** (next route <35 each). The stack points at the vendored `@meilisearch/instant-meilisearch` InstantSearch client (`instant-meilisearch.umd.js:4998`), which **throws an UNCAUGHT exception** when it can't reach Meili — captured by Faro AND breaking the search UX for the user during a Meili blip.

**Root cause is the Meili backend (a separate team's lane).** This PR is purely **client resilience** — it does not touch Meili.

## What the wrapper does
New shared `createResilientSearchClient(client, opts)` (`src/components/Search/resilientSearchClient.ts`) wraps a react-instantsearch `searchClient`:

- `.search` (and `.searchForFacetValues` when present) **catches** communication/network errors (`MeiliSearchCommunicationError`, `NetworkError`, `Failed to fetch`, `Load failed`, …).
- **One short retry** (default 250ms) for a *transient* comm blip — non-communication errors (e.g. a bad query) are not retried.
- If Meili is still unreachable, it **resolves to a VALID empty InstantSearch response** of the same arity (`{ results: requests.map(() => ({ hits: [], nbHits: 0, … })) }`, mirroring the shape already used by the empty-query short-circuit), so react-instantsearch renders a normal empty state.
- The error is **never re-thrown** → the uncaught RUM exception is gone.

## Distinguishable "unavailable" state (not "no results")
On `/search` (`SearchLayout` — the 95%), a swallowed error flips a tiny zustand store (`search-availability.store.ts`) so the results area shows a **"Search is temporarily unavailable, try again"** banner instead of a misleading "No results found". The store clears on the next successful search. (react-instantsearch's own `useInstantSearch().status` never sees `'error'` because we swallow it, hence the side-channel.) Quick-search dropdown / header autocomplete / modal pickers fall back to empty **quietly** (no banner).

## Applied to every Meili client construction site
`SearchLayout` (banner) + `search.client.ts`, `QuickSearchDropdown`, `AutocompleteSearch`, `CollectionSelectModal`, `ResourceSelectModal/searchClient` (quiet) — same class of uncaught exception on each surface.

## Happy path unchanged
A successful `.search` returns Meili's response **verbatim** (same client passed to `<InstantSearch>`); the wrapper only invokes `onSuccess` to clear any prior banner. No feature flag — this is a pure resilience improvement with **no happy-path behavior change** (the wrapper only intervenes on a thrown error), so gating it would add a failure mode (flag-off = the crash returns) with no upside.

## Tests
`resilientSearchClient.test.ts` (13 tests, pure node — no browser): comm-error → valid empty response + `onError` flag, no throw; happy-path passthrough (asserts byte-identical response reference + same client passed through); single retry then fallback; retry recovery; non-comm errors not retried; facet-value fallback; error-classifier matrix.

`pnpm test:unit:run` → **13 passed**. `pnpm typecheck` → the touched files are **type-clean** (remaining errors in the run are pre-existing worktree-environment artifacts — uninitialized `event-engine-common` submodule + workspace `kysely` linkage — in files this PR never touches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)