### PR TITLE
fix(notifications): break cancel-path pool deadlock + merge PendingNotification.users on upsert

### DIFF
--- a/apps/notifications/src/lib/server/create.behavioral.test.ts
+++ b/apps/notifications/src/lib/server/create.behavioral.test.ts
@@ -216,6 +216,33 @@ describe('UPDATE-first → INSERT-ON-CONFLICT fallback', () => {
 });
 
 // =========================================================================================================
+// Re-derives the fix from #2437 (daceheg): both upsert paths MERGE the incoming recipients into the
+// existing PendingNotification.users array instead of wholesale-replacing it. A wholesale replace drops
+// recipients a concurrent/earlier writer already accumulated for the same key before the worker consumes it.
+describe('users-array merge on upsert (does not clobber concurrently-queued recipients)', () => {
+  it('UPDATE unions existing users with the incoming set and dedups — never a bare replace', async () => {
+    h.state.updateRows = [{ id: 1 }];
+    await createNotification(payload({ userIds: [11, 22] }));
+
+    const upd = updateCall()!;
+    expect(upd.sql).toContain('unnest("users" || $1::int[])');
+    expect(upd.sql).toContain('SELECT DISTINCT');
+    // The old wholesale-replace form must be gone.
+    expect(upd.sql).not.toMatch(/SET\s+"users"\s*=\s*\$1::int\[\]/);
+  });
+
+  it('INSERT ... ON CONFLICT unions the existing row with excluded and dedups — never a bare replace', async () => {
+    h.state.updateRows = []; // force the INSERT branch
+    await createNotification(payload({ userIds: [11, 22] }));
+
+    const ins = insertCall()!;
+    expect(ins.sql).toContain('unnest("PendingNotification"."users" || excluded."users")');
+    expect(ins.sql).toContain('SELECT DISTINCT');
+    expect(ins.sql).not.toMatch(/"users"\s*=\s*excluded\."users"/);
+  });
+});
+
+// =========================================================================================================
 describe('error swallow contract (must be COUNTED, not a false success)', () => {
   it('opt-out query throws → logs to Axiom and returns {queued:0} (no throw, no false success)', async () => {
     h.state.throwOn = 'settings';

--- a/apps/notifications/src/lib/server/create.ts
+++ b/apps/notifications/src/lib/server/create.ts
@@ -42,7 +42,7 @@ export async function createNotification(
     // same key between our UPDATE and INSERT.
     const updateResp = await notifDbWrite().cancellableQuery<{ id: number }>(
       `UPDATE "PendingNotification"
-         SET "users" = $1::int[], "lastTriggered" = NOW()
+         SET "users" = ARRAY(SELECT DISTINCT unnest("users" || $1::int[])), "lastTriggered" = NOW()
        WHERE "key" = $2
        RETURNING id`,
       [targets, data.key]
@@ -54,7 +54,7 @@ export async function createNotification(
         `INSERT INTO "PendingNotification" (key, type, category, users, details, "debounceSeconds")
          VALUES ($1, $2, $3::"NotificationCategory", $4::int[], $5::jsonb, $6)
          ON CONFLICT (key)
-         DO UPDATE SET "users" = excluded."users", "lastTriggered" = NOW()`,
+         DO UPDATE SET "users" = ARRAY(SELECT DISTINCT unnest("PendingNotification"."users" || excluded."users")), "lastTriggered" = NOW()`,
         [
           data.key,
           data.type,

--- a/apps/notifications/src/lib/server/operations.createNotificationsBulk.test.ts
+++ b/apps/notifications/src/lib/server/operations.createNotificationsBulk.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Coverage for the bulk producer path (operations.ts createNotificationsBulk). Re-derives the fix from
+// #2437 (daceheg): the UPDATE and the INSERT ... ON CONFLICT fallback both MERGE the incoming recipients
+// into the existing PendingNotification.users array (dedup union) instead of wholesale-replacing it, so a
+// concurrent/earlier writer's recipients for the same key aren't dropped before the worker fans them out.
+//
+// Same "fake pool records SQL + params" idiom as operations.test.ts — the fake never runs SQL, so these
+// assert the emitted statement shape, matching the existing suites' contract.
+
+const h = vi.hoisted(() => {
+  const state = {
+    notifCalls: [] as Array<{ sql: string; params?: unknown[] }>,
+    // Keys the UPDATE ... RETURNING reports as already-present; the rest fall through to INSERT.
+    updatedKeys: [] as string[],
+  };
+  const reset = () => {
+    state.notifCalls = [];
+    state.updatedKeys = [];
+  };
+  return { state, reset };
+});
+
+vi.mock('./clients/db', () => ({
+  notifDbWrite: () => ({
+    cancellableQuery: async (sql: string, params?: unknown[]) => {
+      h.state.notifCalls.push({ sql, params });
+      if (sql.includes('UPDATE "PendingNotification"')) {
+        return { result: async () => h.state.updatedKeys.map((key) => ({ key })) };
+      }
+      return { result: async () => [] as unknown[] };
+    },
+  }),
+  notifDbRead: () => ({ cancellableQuery: async () => ({ result: async () => [] }) }),
+}));
+vi.mock('./cache', () => ({ notificationCache: {} }));
+vi.mock('./lag', () => ({
+  getNotifDbWithoutLag: async () => ({}),
+  isWritePool: () => false,
+  preventReplicationLag: async () => {},
+}));
+vi.mock('./clients/axiom', () => ({ logToAxiom: vi.fn(async () => {}), safeError: (e: unknown) => e }));
+
+import { createNotificationsBulk } from './operations';
+
+const updateCall = () => h.state.notifCalls.find((c) => c.sql.includes('UPDATE "PendingNotification"'));
+const insertCall = () => h.state.notifCalls.find((c) => c.sql.includes('INSERT INTO "PendingNotification"'));
+
+const row = (key: string, users: number[]) => ({
+  key,
+  type: 'comment',
+  category: 'Comment' as const,
+  users,
+  details: { foo: 'bar' },
+});
+
+beforeEach(() => {
+  h.reset();
+  vi.clearAllMocks();
+});
+
+describe('createNotificationsBulk users-array merge on upsert', () => {
+  it('UPDATE unions the existing row with the incoming set and dedups — never a bare replace', async () => {
+    h.state.updatedKeys = ['comment:1']; // existing key → UPDATE handles it, no INSERT
+    await createNotificationsBulk([row('comment:1', [11, 22])]);
+
+    const upd = updateCall()!;
+    expect(upd.sql).toContain('unnest(pn."users" || u.users::int[])');
+    expect(upd.sql).toContain('SELECT DISTINCT');
+    expect(upd.sql).not.toMatch(/SET\s+"users"\s*=\s*u\.users::int\[\]/);
+    // Every key was already present, so nothing falls through to INSERT.
+    expect(insertCall()).toBeUndefined();
+  });
+
+  it('INSERT ... ON CONFLICT unions the existing row with excluded and dedups — never a bare replace', async () => {
+    h.state.updatedKeys = []; // no key existed → all fall through to INSERT
+    await createNotificationsBulk([row('comment:1', [11, 22])]);
+
+    const ins = insertCall()!;
+    expect(ins.sql).toContain('unnest("PendingNotification"."users" || excluded."users")');
+    expect(ins.sql).toContain('SELECT DISTINCT');
+    expect(ins.sql).not.toMatch(/"users"\s*=\s*excluded\."users"/);
+  });
+});

--- a/apps/notifications/src/lib/server/operations.ts
+++ b/apps/notifications/src/lib/server/operations.ts
@@ -33,7 +33,7 @@ export async function createNotificationsBulk(rows: CreateNotificationRow[]): Pr
       .join(',');
     const updateResp = await write.cancellableQuery<{ key: string }>(`
       UPDATE "PendingNotification" pn
-      SET "users" = u.users::int[], "lastTriggered" = NOW()
+      SET "users" = ARRAY(SELECT DISTINCT unnest(pn."users" || u.users::int[])), "lastTriggered" = NOW()
       FROM (VALUES ${updateValues}) AS u(key, users)
       WHERE pn."key" = u.key
       RETURNING pn."key"
@@ -58,7 +58,7 @@ export async function createNotificationsBulk(rows: CreateNotificationRow[]): Pr
       const insertResp = await write.cancellableQuery(`
         INSERT INTO "PendingNotification" (key, type, category, users, details, "debounceSeconds")
         VALUES ${insertValues}
-        ON CONFLICT (key) DO UPDATE SET "users" = excluded."users", "lastTriggered" = NOW()
+        ON CONFLICT (key) DO UPDATE SET "users" = ARRAY(SELECT DISTINCT unnest("PendingNotification"."users" || excluded."users")), "lastTriggered" = NOW()
       `);
       await insertResp.result();
     }

--- a/packages/civitai-db/src/db-helpers.cancel.test.ts
+++ b/packages/civitai-db/src/db-helpers.cancel.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Re-derives the fix from #2437 (daceheg): cancellableQuery's cancel() must fire pg_cancel_backend over a
+// fresh Client OUTSIDE the pool. The old code called pool.connect() a SECOND time, which deadlocks a
+// saturated pool — every slot is held by a query awaiting cancellation and the cancel can never get a slot.
+//
+// `pg` is mocked so no DB is touched: a fake Pool hands out one connection (with a pinned processID and a
+// query we can leave pending to keep `done` false), and a fake Client records how cancel() connects.
+
+const h = vi.hoisted(() => {
+  const state = {
+    poolConnectCount: 0,
+    clients: [] as Array<{
+      options: any;
+      connectCalls: number;
+      endCalls: number;
+      queries: Array<{ sql: string; params?: unknown[] }>;
+    }>,
+    // Controls the fake connection's in-flight query promise for the current cancellableQuery.
+    resolveQuery: undefined as undefined | ((rows: unknown[]) => void),
+  };
+  const reset = () => {
+    state.poolConnectCount = 0;
+    state.clients = [];
+    state.resolveQuery = undefined;
+  };
+  return { state, reset };
+});
+
+vi.mock('pg', () => {
+  class FakePool {
+    options: any;
+    constructor(options: any) {
+      this.options = options;
+    }
+    on() {}
+    connect() {
+      h.state.poolConnectCount++;
+      const connection = {
+        processID: 4242,
+        query: () =>
+          new Promise((resolve) => {
+            h.state.resolveQuery = (rows: unknown[]) => resolve({ rows });
+          }),
+        release: () => {},
+      };
+      return Promise.resolve(connection);
+    }
+  }
+  class FakeClient {
+    rec: { options: any; connectCalls: number; endCalls: number; queries: any[] };
+    constructor(options: any) {
+      this.rec = { options, connectCalls: 0, endCalls: 0, queries: [] };
+      h.state.clients.push(this.rec);
+    }
+    connect() {
+      this.rec.connectCalls++;
+      return Promise.resolve();
+    }
+    query(sql: string, params?: unknown[]) {
+      this.rec.queries.push({ sql, params });
+      return Promise.resolve({ rows: [] });
+    }
+    end() {
+      this.rec.endCalls++;
+      return Promise.resolve();
+    }
+  }
+  const types = {
+    setTypeParser: () => {},
+    builtins: { TIMESTAMP: 1114 },
+  };
+  return { Pool: FakePool, Client: FakeClient, types };
+});
+
+import { createPool } from './db-helpers';
+
+const CONN = 'postgresql://user:pass@localhost:5432/testdb';
+
+beforeEach(() => {
+  h.reset();
+});
+
+describe('cancellableQuery cancel path', () => {
+  it('cancels via a fresh out-of-pool Client — never a second pool.connect()', async () => {
+    const pool = createPool({ connectionString: CONN, ssl: false });
+    const handle = await pool.cancellableQuery('SELECT 1');
+    expect(h.state.poolConnectCount).toBe(1); // one acquire for the query itself
+
+    await handle.cancel();
+
+    // The cancel must NOT have gone back to the pool (that is the deadlock).
+    expect(h.state.poolConnectCount).toBe(1);
+    // Exactly one out-of-pool Client, connected, used for pg_cancel_backend, and always closed.
+    expect(h.state.clients).toHaveLength(1);
+    const c = h.state.clients[0];
+    expect(c.connectCalls).toBe(1);
+    expect(c.endCalls).toBe(1);
+    expect(c.queries).toHaveLength(1);
+    expect(c.queries[0].sql).toContain('pg_cancel_backend');
+    expect(c.queries[0].params).toEqual([4242]);
+    // Connect is bounded so a best-effort cancel can't hang forever.
+    expect(c.options.connectionTimeoutMillis).toBeGreaterThan(0);
+  });
+
+  it('is a no-op once the query has already settled (done flag)', async () => {
+    const pool = createPool({ connectionString: CONN, ssl: false });
+    const handle = await pool.cancellableQuery('SELECT 1');
+    h.state.resolveQuery?.([]); // let the query finish → .finally sets done = true
+    await handle.result();
+
+    await handle.cancel();
+    expect(h.state.clients).toHaveLength(0); // no cancel Client constructed
+    expect(h.state.poolConnectCount).toBe(1);
+  });
+});

--- a/packages/civitai-db/src/db-helpers.ts
+++ b/packages/civitai-db/src/db-helpers.ts
@@ -1,6 +1,6 @@
 import { Prisma } from '@civitai/db-schema';
 import type { QueryResult, QueryResultRow } from 'pg';
-import { Pool, types } from 'pg';
+import { Client, Pool, types } from 'pg';
 import { performance } from 'node:perf_hooks';
 import client from 'prom-client';
 import { type DbLogFn } from './env';
@@ -216,10 +216,23 @@ export function createPool(options: CreatePoolOptions): AugmentedPool {
 
     const cancel = async () => {
       if (done) return;
-      const cancelConnection = await pool.connect();
-      await cancelConnection.query('SELECT pg_cancel_backend($1)', [pid]);
-      cancelConnection.release();
-      done = true;
+      // Fire the cancel over a one-shot Client OUTSIDE this pool. A saturated pool is exactly when
+      // cancellation is most urgent, and pool.connect() here would deadlock: every slot is held by a
+      // query awaiting cancellation, and the cancel itself would queue behind them forever.
+      // Don't touch `done` — the query's own .finally() owns that flag and the connection release, so a
+      // cancel that never connects can't leak the slot or double-release.
+      const cancelClient = new Client({
+        connectionString,
+        // Bound the connect: a best-effort cancel must never hang. The pool default of 0 (unlimited)
+        // would let an unreachable DB wedge this promise forever.
+        connectionTimeoutMillis: connectionTimeoutMillis || 5000,
+      });
+      try {
+        await cancelClient.connect();
+        await cancelClient.query('SELECT pg_cancel_backend($1)', [pid]);
+      } finally {
+        cancelClient.end().catch(() => null);
+      }
     };
     const result = async () => {
       const { rows } = await query;


### PR DESCRIPTION
Re-derives the two fixes from #2437 by @daceheg, who correctly diagnosed both bugs but whose PR was closed as unrebaseable — the notification pipeline was extracted into `packages/civitai-db` + `apps/notifications` after it was opened, deleting every line his patch touched. Credit to him for the diagnosis.

## Bug 1 — `cancellableQuery` cancel path deadlocks a saturated pool

`cancel()` acquired a SECOND connection from the same pool to run `pg_cancel_backend`. Under pool saturation this deadlocks: every slot is held by a query awaiting cancellation, and the cancel can never get a slot. This is the mechanism behind intermittent poll-notification stalls that only clear on a pod restart (the in-process lock-refresh spins forever, so every subsequent cron tick sees "job already running").

Fix: fire the cancel over a fresh one-shot `pg.Client` outside the pool, with a bounded connect timeout (best-effort cancel must never hang; this package defaults the pool timeout to 0/unlimited). The pid targeted is the backend pid of the query's own pooled connection (`pg_cancel_backend` is cross-connection by design), and the `done` flag stays owned by the query's `.finally()` so a failed cancel can't leak or double-release a slot. Happy path (cancel never invoked) is unchanged for every `cancellableQuery` caller repo-wide.

## Bug 2 — `PendingNotification.users` replaced instead of merged

All four producer upsert paths set `users` to the incoming recipient set wholesale, so a concurrent or earlier writer's recipients for the same key were silently dropped before the fan-out worker consumed the row. Union existing + incoming with `ARRAY(SELECT DISTINCT unnest(existing || incoming))` (dedup in SQL). The column is `integer[] NOT NULL`, so the `NULL || array` wipe footgun does not apply. The array is a grow-only accumulator consumed-and-deleted by the worker; no path ever intends to shrink it (opt-out is enforced at recipient-resolution time), so a union is the correct semantic.

## Tests

- New `db-helpers.cancel.test.ts` (mocks `pg`): proves cancel never re-enters the pool, always closes the one-shot Client, targets the query's backend pid, and no-ops after the query settles.
- Extended `create.behavioral.test.ts` + new `operations.createNotificationsBulk.test.ts` (previously 0% on the bulk path): assert all four upsert paths emit the dedup-union SQL, not a bare replace.
- civitai-db 9/9, notifications 89/89 green. Notifications typecheck clean.

## Notes

- `db-helpers.ts` is shared by every pool built via `createPool` (~68 `cancellableQuery` call sites). The change only touches the cancel/timeout path, which is strictly better for all of them; the happy path is untouched. Broad blast radius, low risk.
- Tests assert emitted-SQL shape (the repo's fake-pool idiom), not execution against a real Postgres. A manual sanity run of the `unnest`/`||`/`DISTINCT` upserts against a real DB before merge would be belt-and-suspenders.