### PR TITLE
fix(metrics): avoid Postgres bind-param blowup on unbounded metric queue

### DIFF
--- a/src/server/metrics/basemodel.metrics.ts
+++ b/src/server/metrics/basemodel.metrics.ts
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client';
 import { chunk } from 'lodash-es';
 import { templateHandler } from '~/server/db/db-helpers';
 import type { MetricProcessorRunContext } from '~/server/metrics/base.metrics';
@@ -42,7 +41,7 @@ export const baseModelMetrics = createMetricProcessor({
       const queuedModelVersions = await ctx.db.$queryRaw<{ id: number }[]>`
         SELECT id
         FROM "ModelVersion"
-        WHERE "modelId" IN (${Prisma.join(ctx.queue)})
+        WHERE "modelId" = ANY(${ctx.queue}::int[])
       `;
       ctx.queuedModelVersions = queuedModelVersions.map((x) => x.id);
       log(

--- a/src/server/metrics/model.metrics.ts
+++ b/src/server/metrics/model.metrics.ts
@@ -1,4 +1,3 @@
-import { Prisma } from '@prisma/client';
 import dayjs from '~/shared/utils/dayjs';
 import { chunk } from 'lodash-es';
 import { PG_INT4_MAX, PG_INT4_MIN } from '~/server/common/constants';
@@ -68,7 +67,7 @@ export const modelMetrics = createMetricProcessor({
       const queuedModelVersions = await ctx.db.$queryRaw<{ id: number }[]>`
         SELECT id
         FROM "ModelVersion"
-        WHERE "modelId" IN (${Prisma.join(ctx.queue)})
+        WHERE "modelId" = ANY(${ctx.queue}::int[])
       `;
       ctx.queuedModelVersions = queuedModelVersions.map((x) => x.id);
     }


### PR DESCRIPTION
## Summary

`model.metrics.ts` and `basemodel.metrics.ts` drain their entire Redis metric-update queue straight into a `WHERE "modelId" IN (${Prisma.join(ctx.queue)})`. `Prisma.join` emits one bind param per element, so past Postgres' 65,535-param limit the query throws before writing any metrics. Because a throw in `update()` skips `queue.commit()`, the checkout queue is never cleared and the backlog re-grows every tick — a self-reinforcing wedge that permanently stalls model/base-model metrics.

This became newly reachable after #2652 (merged e34a4f7cf): that fix repaired a 2-year casing bug so these queues actually drain for the first time. A 111k-item backlog was measured on the post queue in prod during that work; the model queue was ~9.2k (under the limit today, but a sustained cron outage could push it past 65k).

## Fix

Both sites rewritten to a single bound array param:

```
WHERE "modelId" IN (${Prisma.join(ctx.queue)})   ->   WHERE "modelId" = ANY(${ctx.queue}::int[])
```

`= ANY(array)` takes one param regardless of array length, eliminating the limit. `ctx.queue` is `number[]` and `ModelVersion.modelId` is `Int`, so `::int[]` is the correct cast; this matches the existing `= ANY(${ids}::int[])` idiom used elsewhere in these same files and across image/model services. Same rows matched (`IN (list)` ≡ `= ANY(array)`), the `if (ctx.queue.length > 0)` guard is retained, and the now-unused `import { Prisma }` was removed from both files.

Not chunking: this lone query is a cheap indexed projection and Postgres handles a large `= ANY` array fine; everything downstream of it is already chunked. Slicing the queue is a drop-in follow-up if a pathological size ever appears.