### PR TITLE
feat(engaged-models): client normalized membership store + batched hook (PR2)

### DIFF
--- a/src/components/Image/Detail/ImageResources.tsx
+++ b/src/components/Image/Detail/ImageResources.tsx
@@ -20,6 +20,7 @@ import { cloneElement, useMemo, useState } from 'react';
 import { IconBadge } from '~/components/IconBadge/IconBadge';
 import { ThumbsUpIcon } from '~/components/ThumbsIcon/ThumbsIcon';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useEngagedModelsMembership } from '~/hooks/useEngagedModelMembership';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import { getDisplayName, getModelUrl } from '~/utils/string-helpers';
@@ -44,12 +45,16 @@ export function ImageResources({ imageId }: { imageId: number }) {
     { trpc: { context: { skipBatch: true } } }
   );
 
-  const { data: { Recommended: reviewedModels = [] } = { Recommended: [] } } =
-    trpc.user.getEngagedModels.useQuery(undefined, {
-      enabled: !!currentUser,
-      gcTime: Infinity,
-      staleTime: Infinity,
-    });
+  // PR2: per-visible-set membership for just the resources shown on this image.
+  const resourceModelIds = useMemo(
+    () =>
+      (data ?? [])
+        .map((r) => r.modelId)
+        .filter((id): id is number => typeof id === 'number' && id > 0),
+    [data]
+  );
+  const { isEngaged: isModelEngaged, sets: membershipSets } =
+    useEngagedModelsMembership(resourceModelIds);
 
   const resources = useMemo(() => {
     return (
@@ -61,7 +66,9 @@ export function ImageResources({ imageId }: { imageId: number }) {
             items.findIndex((t) => t.modelVersionId === resource.modelVersionId) === index
         )
         .map((resource, index) => {
-          const hasReview = resource.modelId ? reviewedModels.includes(resource.modelId) : false;
+          const hasReview = resource.modelId
+            ? isModelEngaged(resource.modelId, 'Recommended')
+            : false;
           const isAvailable = resource.modelVersionId !== null;
           return {
             ...resource,
@@ -78,7 +85,9 @@ export function ImageResources({ imageId }: { imageId: number }) {
           return 0;
         }) ?? []
     );
-  }, [data, reviewedModels]);
+    // `membershipSets` (stable-by-shallow) is the reactive proxy for `isModelEngaged`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data, membershipSets]);
 
   const { mutate, isPending: removingResource } = trpc.image.removeResource.useMutation();
   const handleRemoveResource = (modelVersionId: number) => {

--- a/src/components/Model/Actions/ToggleModelNotification.tsx
+++ b/src/components/Model/Actions/ToggleModelNotification.tsx
@@ -21,7 +21,7 @@ export function ToggleModelNotification({
   const queryUtils = trpc.useUtils();
 
   // PR2: per-visible-set membership for this single model (Notify/Mute).
-  const { isEngaged: isModelEngaged } = useEngagedModelMembership(modelId);
+  const { isEngaged: isModelEngaged, isKnown } = useEngagedModelMembership(modelId);
   const { data: following = [] } = trpc.user.getFollowingUsers.useQuery(undefined, {
     enabled: !!currentUser,
   });
@@ -66,13 +66,16 @@ export function ToggleModelNotification({
             variant="light"
             {...actionIconProps}
             color={isOn ? 'success' : undefined}
-            onClick={() =>
+            onClick={() => {
+              // F1: block the toggle until membership is known — a cold store reads
+              // as not-engaged and would fire the OPPOSITE of the user's intent.
+              if (!isKnown) return;
               toggleNotifyModelMutation.mutate({
                 modelId,
                 type: isOn ? ModelEngagementType.Mute : undefined,
-              })
-            }
-            loading={toggleNotifyModelMutation.isPending}
+              });
+            }}
+            loading={toggleNotifyModelMutation.isPending || !isKnown}
           >
             {isOn ? <IconBellCheck size={20} /> : <IconBellPlus size={20} />}
           </LegacyActionIcon>

--- a/src/components/Model/Actions/ToggleModelNotification.tsx
+++ b/src/components/Model/Actions/ToggleModelNotification.tsx
@@ -5,6 +5,9 @@ import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon
 
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useEngagedModelMembership } from '~/hooks/useEngagedModelMembership';
+import { applyNotifyToggled } from '~/store/engaged-models.optimistic';
+import { restoreMembership, snapshotMembership } from '~/store/engaged-models.store';
 import { ModelEngagementType } from '~/shared/utils/prisma/enums';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -17,29 +20,36 @@ export function ToggleModelNotification({
   const currentUser = useCurrentUser();
   const queryUtils = trpc.useUtils();
 
-  const {
-    data: { Notify: watchedModels = [], Mute: mutedModels = [] } = { Notify: [], Mute: [] },
-  } = trpc.user.getEngagedModels.useQuery(undefined, { enabled: !!currentUser });
+  // PR2: per-visible-set membership for this single model (Notify/Mute).
+  const { isEngaged: isModelEngaged } = useEngagedModelMembership(modelId);
   const { data: following = [] } = trpc.user.getFollowingUsers.useQuery(undefined, {
     enabled: !!currentUser,
   });
 
+  const isWatching = isModelEngaged('Notify');
+  const isMuted = isModelEngaged('Mute');
+  const alreadyFollowing = following.includes(userId);
+  const isOn = (alreadyFollowing || isWatching) && !isMuted;
+
   const toggleNotifyModelMutation = trpc.user.toggleNotifyModel.useMutation({
+    onMutate() {
+      // Optimistic store update + snapshot for rollback.
+      const snapshot = snapshotMembership(modelId);
+      applyNotifyToggled(modelId, !isOn);
+      return { snapshot };
+    },
     async onSuccess() {
+      // Keep the legacy getEngagedModels cache in sync for still-on-old-endpoint feeds.
       await queryUtils.user.getEngagedModels.invalidate();
     },
-    onError(error) {
+    onError(error, _vars, context) {
+      if (context?.snapshot) restoreMembership(modelId, context.snapshot);
       showErrorNotification({
         title: 'Failed to update notification settings',
         error,
       });
     },
   });
-
-  const isWatching = watchedModels.includes(modelId);
-  const isMuted = mutedModels.includes(modelId);
-  const alreadyFollowing = following.includes(userId);
-  const isOn = (alreadyFollowing || isWatching) && !isMuted;
 
   return (
     <Tooltip

--- a/src/components/Model/EarlyAccessAlert/EarlyAccessAlert.tsx
+++ b/src/components/Model/EarlyAccessAlert/EarlyAccessAlert.tsx
@@ -36,8 +36,6 @@ export function EarlyAccessAlert({ modelId, versionId, modelType, deadline }: Pr
 
   const toggleNotifyMutation = trpc.modelVersion.toggleNotifyEarlyAccess.useMutation({
     async onMutate() {
-      await queryUtils.user.getEngagedModels.cancel();
-
       const prevEngaged = queryUtils.user.getEngagedModelVersions.getData();
 
       // Toggle the model in the Notify list

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -348,7 +348,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
 
   // Notification toggle state
   // PR2: per-visible-set membership for this single model (Notify/Mute).
-  const { isEngaged: isModelEngaged } = useEngagedModelMembership(model.id);
+  const { isEngaged: isModelEngaged, isKnown: isNotifyKnown } = useEngagedModelMembership(model.id);
   const { data: followingUsers = [] } = trpc.user.getFollowingUsers.useQuery(undefined, {
     enabled: !!user,
     staleTime: 60 * 1000, // 1 minute - avoid refetching on every model view
@@ -769,13 +769,17 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                         <LoginRedirect reason="notify-model">
                           <Button
                             color={isNotificationOn ? 'green' : 'gray'}
-                            onClick={() =>
+                            onClick={() => {
+                              // F1: block the toggle until Notify/Mute membership is
+                              // known — a cold store reads not-engaged and would fire
+                              // the OPPOSITE of the user's intent.
+                              if (!isNotifyKnown) return;
                               toggleNotifyModelMutation.mutate({
                                 modelId: model.id,
                                 type: isNotificationOn ? ModelEngagementType.Mute : undefined,
-                              })
-                            }
-                            loading={toggleNotifyModelMutation.isPending}
+                              });
+                            }}
+                            loading={toggleNotifyModelMutation.isPending || !isNotifyKnown}
                             fullWidth
                             style={{ paddingLeft: 0, paddingRight: 0 }}
                             aria-label={

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -113,6 +113,9 @@ import { TrackView } from '~/components/TrackView/TrackView';
 import { TrainedWords } from '~/components/TrainedWords/TrainedWords';
 import { ToggleVaultButton } from '~/components/Vault/ToggleVaultButton';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useEngagedModelMembership } from '~/hooks/useEngagedModelMembership';
+import { applyNotifyToggled } from '~/store/engaged-models.optimistic';
+import { restoreMembership, snapshotMembership } from '~/store/engaged-models.store';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import {
@@ -344,24 +347,31 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
   });
 
   // Notification toggle state
-  const {
-    data: { Notify: watchedModels = [], Mute: mutedModels = [] } = { Notify: [], Mute: [] },
-  } = trpc.user.getEngagedModels.useQuery(undefined, { enabled: !!user });
+  // PR2: per-visible-set membership for this single model (Notify/Mute).
+  const { isEngaged: isModelEngaged } = useEngagedModelMembership(model.id);
   const { data: followingUsers = [] } = trpc.user.getFollowingUsers.useQuery(undefined, {
     enabled: !!user,
     staleTime: 60 * 1000, // 1 minute - avoid refetching on every model view
   });
+  const isNotificationOn =
+    (followingUsers.includes(model.user.id) || isModelEngaged('Notify')) &&
+    !isModelEngaged('Mute');
   const toggleNotifyModelMutation = trpc.user.toggleNotifyModel.useMutation({
+    onMutate() {
+      // Optimistic store update + snapshot for rollback.
+      const snapshot = snapshotMembership(model.id);
+      applyNotifyToggled(model.id, !isNotificationOn);
+      return { snapshot };
+    },
     async onSuccess() {
+      // Keep the legacy getEngagedModels cache in sync for still-on-old-endpoint feeds.
       await queryUtils.user.getEngagedModels.invalidate();
     },
-    onError(error) {
+    onError(error, _vars, context) {
+      if (context?.snapshot) restoreMembership(model.id, context.snapshot);
       showErrorNotification({ title: 'Failed to update notification settings', error });
     },
   });
-  const isNotificationOn =
-    (followingUsers.includes(model.user.id) || watchedModels.includes(model.id)) &&
-    !mutedModels.includes(model.id);
 
   const handlePublishClick = async (publishDate?: Date) => {
     try {

--- a/src/components/ResourceReview/ResourceReviewThumbActions.tsx
+++ b/src/components/ResourceReview/ResourceReviewThumbActions.tsx
@@ -126,7 +126,7 @@ export function ResourceReviewThumbBadge({
 }) {
   const { totals, loading } = useQueryResourceReviewTotals({ modelId, modelVersionId });
   // PR2: per-visible-set membership for this single model.
-  const { isEngaged: isModelEngaged } = useEngagedModelMembership(modelId);
+  const { isEngaged: isModelEngaged, isKnown } = useEngagedModelMembership(modelId);
 
   if (loading && initialCount === undefined) return null;
 
@@ -138,8 +138,11 @@ export function ResourceReviewThumbBadge({
       color={hasReview ? 'success.5' : 'gray'}
       size="lg"
       icon={<ThumbsUpIcon size={16} filled />}
-      style={{ cursor: 'pointer' }}
-      onClick={onClick}
+      // F1: don't surface the click affordance until membership is known — the
+      // displayed review state (and any toggle the click drives) is unreliable
+      // while the store is cold for this model.
+      style={{ cursor: isKnown ? 'pointer' : 'progress' }}
+      onClick={isKnown ? onClick : undefined}
     >
       <Text>{abbreviateNumber(totals?.up ?? 0)}</Text>
     </IconBadge>

--- a/src/components/ResourceReview/ResourceReviewThumbActions.tsx
+++ b/src/components/ResourceReview/ResourceReviewThumbActions.tsx
@@ -12,8 +12,7 @@ import { abbreviateNumber } from '~/utils/number-helpers';
 import { IconBadge } from '~/components/IconBadge/IconBadge';
 import { ThumbsDownIcon, ThumbsUpIcon } from '~/components/ThumbsIcon/ThumbsIcon';
 import type { ResourceReviewSimpleModel } from '~/server/selectors/resourceReview.selector';
-import { trpc } from '~/utils/trpc';
-import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useEngagedModelMembership } from '~/hooks/useEngagedModelMembership';
 import classes from './ResourceReviewThumbActions.module.scss';
 
 export function ResourceReviewThumbActions({
@@ -125,14 +124,13 @@ export function ResourceReviewThumbBadge({
   modelVersionId?: number;
   count?: number;
 }) {
-  const currentUser = useCurrentUser();
   const { totals, loading } = useQueryResourceReviewTotals({ modelId, modelVersionId });
-  const { data: { Recommended: reviewedModels = [] } = { Recommended: [] } } =
-    trpc.user.getEngagedModels.useQuery(undefined, { enabled: !!currentUser });
+  // PR2: per-visible-set membership for this single model.
+  const { isEngaged: isModelEngaged } = useEngagedModelMembership(modelId);
 
   if (loading && initialCount === undefined) return null;
 
-  const hasReview = reviewedModels.includes(modelId);
+  const hasReview = isModelEngaged('Recommended');
 
   return (
     <IconBadge

--- a/src/components/ResourceReview/resourceReview.utils.ts
+++ b/src/components/ResourceReview/resourceReview.utils.ts
@@ -59,8 +59,16 @@ export const useCreateResourceReview = () => {
       // Normalized store (PR2): mirror the same Recommended+Notify toggle for the
       // per-visible-set surfaces. Dual-written alongside the getEngagedModels cache
       // above until the feed callers migrate (PR3) and the old endpoint is dropped (PR4).
-      // Pass the SAME direction the legacy handler used (F3): the warm
-      // `previousEngaged.Recommended` snapshot, not the possibly-cold store.
+      // F3: derive the direction from the SAME `previousEngaged.Recommended` snapshot
+      // the legacy setData above consumed — deliberately NOT the normalized store.
+      // Passing the one shared snapshot keeps the two dual-writes CONSISTENT with each
+      // other (the Preserve invariant). PR3 removed this page's own getEngagedModels
+      // query, so on a directly-loaded model page that legacy cache is cold and this
+      // reads false; both writes then agree (both add), so they never diverge. Accepted
+      // narrow edge: re-affirming an ALREADY-recommended model won't toggle it off until
+      // a feed has warmed the cache. Sourcing direction from the store instead would warm
+      // this case but split the two writes' direction (store warm / legacy cold) — a
+      // worse divergence bug — so we keep the shared-snapshot source.
       applyReviewCreated(modelId, recommended, previousEngaged.Recommended?.includes(modelId) ?? false);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
@@ -173,7 +181,9 @@ export const useUpdateResourceReview = () => {
       });
 
       // Normalized store (PR2): mirror the Recommended toggle for per-visible-set surfaces.
-      // Direction from the warm legacy snapshot (F3), not the possibly-cold store.
+      // F3: direction from the SAME `previousEngaged` snapshot the legacy setData used
+      // (not the store), so both dual-writes stay consistent. See the create handler for
+      // the accepted cold-cache edge (this page's getEngagedModels query was removed in PR3).
       applyReviewUpdated(modelId, request.recommended, alreadyReviewed > -1);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {

--- a/src/components/ResourceReview/resourceReview.utils.ts
+++ b/src/components/ResourceReview/resourceReview.utils.ts
@@ -11,6 +11,13 @@ import type {
 } from '~/server/schema/resourceReview.schema';
 import type { ResourceReviewPaged, ResourceReviewRatingTotals } from '~/types/router';
 import { queryClient, trpc } from '~/utils/trpc';
+import { restoreMembership, snapshotMembership } from '~/store/engaged-models.store';
+import {
+  applyFavoriteToggled,
+  applyReviewCreated,
+  applyReviewDeleted,
+  applyReviewUpdated,
+} from '~/store/engaged-models.optimistic';
 
 export const useCreateResourceReview = () => {
   const queryUtils = trpc.useUtils();
@@ -48,6 +55,11 @@ export const useCreateResourceReview = () => {
 
         return { Recommended: [...Recommended, modelId], Notify: [...Notify, modelId], ...rest };
       });
+
+      // Normalized store (PR2): mirror the same Recommended+Notify toggle for the
+      // per-visible-set surfaces. Dual-written alongside the getEngagedModels cache
+      // above until the feed callers migrate (PR3) and the old endpoint is dropped (PR4).
+      applyReviewCreated(modelId, recommended);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
         if (!old) return;
@@ -158,6 +170,9 @@ export const useUpdateResourceReview = () => {
         return { Recommended: [...Recommended, modelId], ...rest };
       });
 
+      // Normalized store (PR2): mirror the Recommended toggle for per-visible-set surfaces.
+      applyReviewUpdated(modelId, request.recommended);
+
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
         if (!old) return;
 
@@ -230,6 +245,9 @@ export const useDeleteResourceReview = () => {
           ...rest,
         };
       });
+
+      // Normalized store (PR2): mirror the Recommended+Notify removal for per-visible-set surfaces.
+      applyReviewDeleted(modelId);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
         if (!old) return;
@@ -311,6 +329,8 @@ export function useToggleFavoriteMutation() {
       const engagedModels = queryUtils.user.getEngagedModels.getData();
       const bookmarkedModels = queryUtils.user.getBookmarkedModels.getData();
       const modelDetails = queryUtils.model.getById.getData({ id: modelId });
+      // Normalized store (PR2): snapshot for rollback, then apply the same toggle.
+      const engagedMembership = snapshotMembership(modelId);
 
       // update liked models
       // nb: should technically update the "liked models" collection too
@@ -339,6 +359,9 @@ export function useToggleFavoriteMutation() {
         }
         return old;
       });
+
+      // Normalized store (PR2): mirror the favorite toggle for per-visible-set surfaces.
+      applyFavoriteToggled(modelId, setTo);
 
       // Update model details
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
@@ -406,12 +429,14 @@ export function useToggleFavoriteMutation() {
         }
       });
 
-      return { prevData: { engagedModels, modelDetails, userReviews, bookmarkedModels } };
+      return { prevData: { engagedModels, modelDetails, userReviews, bookmarkedModels }, engagedMembership };
     },
     onError: (error, { modelId }, context) => {
       queryUtils.user.getEngagedModels.setData(undefined, context?.prevData?.engagedModels);
       queryUtils.user.getBookmarkedModels.setData(undefined, context?.prevData?.bookmarkedModels);
       queryUtils.model.getById.setData({ id: modelId }, context?.prevData?.modelDetails);
+      // Normalized store (PR2): restore the snapshotted membership.
+      if (context?.engagedMembership) restoreMembership(modelId, context.engagedMembership);
     },
     onSettled: async (result, error, { modelId }) => {
       await queryUtils.resourceReview.getUserResourceReview.invalidate({ modelId });

--- a/src/components/ResourceReview/resourceReview.utils.ts
+++ b/src/components/ResourceReview/resourceReview.utils.ts
@@ -59,7 +59,9 @@ export const useCreateResourceReview = () => {
       // Normalized store (PR2): mirror the same Recommended+Notify toggle for the
       // per-visible-set surfaces. Dual-written alongside the getEngagedModels cache
       // above until the feed callers migrate (PR3) and the old endpoint is dropped (PR4).
-      applyReviewCreated(modelId, recommended);
+      // Pass the SAME direction the legacy handler used (F3): the warm
+      // `previousEngaged.Recommended` snapshot, not the possibly-cold store.
+      applyReviewCreated(modelId, recommended, previousEngaged.Recommended?.includes(modelId) ?? false);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
         if (!old) return;
@@ -171,7 +173,8 @@ export const useUpdateResourceReview = () => {
       });
 
       // Normalized store (PR2): mirror the Recommended toggle for per-visible-set surfaces.
-      applyReviewUpdated(modelId, request.recommended);
+      // Direction from the warm legacy snapshot (F3), not the possibly-cold store.
+      applyReviewUpdated(modelId, request.recommended, alreadyReviewed > -1);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
         if (!old) return;

--- a/src/hooks/__tests__/useEngagedModelMembership.test.ts
+++ b/src/hooks/__tests__/useEngagedModelMembership.test.ts
@@ -1,0 +1,191 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import type { act as actType } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+
+// React 18.3 exposes `act` on the `react` export, but our @types/react (18.0.14)
+// predates that typing. Use the runtime `React.act` (no test-utils deprecation
+// warning) and borrow the correctly-typed signature from react-dom/test-utils.
+const act = (React as unknown as { act: typeof actType }).act;
+
+// --- module mocks (must be declared before importing the hook) ---
+const queryMock = vi.fn<(input: { modelIds: number[] }) => Promise<Record<string, number[]>>>();
+vi.mock('~/utils/trpc', () => ({
+  trpcVanilla: { user: { getEngagedModelsByIds: { query: (input: { modelIds: number[] }) => queryMock(input) } } },
+}));
+
+let currentUser: unknown = { id: 1 };
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => currentUser,
+}));
+
+import {
+  __resetEngagedMembershipBatcher,
+  engagedMembershipBatcher,
+  requestEngagedMembership,
+  useEngagedModelsMembership,
+  useEngagedModelMembership,
+} from '~/hooks/useEngagedModelMembership';
+import { useEngagedModelsStore } from '~/store/engaged-models.store';
+
+// deterministic scheduler: capture the flush callback, fire it on demand.
+let scheduledFlush: (() => void) | null = null;
+function runFlush() {
+  const cb = scheduledFlush;
+  scheduledFlush = null;
+  cb?.();
+}
+/** let queued microtasks (the fetch .then) settle. */
+const settle = () => act(async () => { await Promise.resolve(); await Promise.resolve(); });
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  useEngagedModelsStore.getState().reset();
+  __resetEngagedMembershipBatcher();
+  queryMock.mockReset();
+  queryMock.mockResolvedValue({});
+  currentUser = { id: 1 };
+  engagedMembershipBatcher.schedule = (cb) => { scheduledFlush = cb; };
+  engagedMembershipBatcher.fetch = (modelIds) => queryMock({ modelIds });
+});
+
+afterEach(() => {
+  scheduledFlush = null;
+});
+
+// ---------------------------------------------------------------------------
+// Batcher core (no React) — the DataLoader mechanics
+// ---------------------------------------------------------------------------
+describe('batcher', () => {
+  it('coalesces N requests in one tick into ONE query with the deduped union', async () => {
+    queryMock.mockResolvedValue({ Recommended: [2] });
+    requestEngagedMembership([1, 2]);
+    requestEngagedMembership([2, 3]); // 2 is a dup
+    requestEngagedMembership([3, 4]);
+    runFlush();
+    await settle();
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock.mock.calls[0][0].modelIds.slice().sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+    // result folded into the store
+    expect(useEngagedModelsStore.getState().membership[2]?.has('Recommended')).toBe(true);
+    expect(useEngagedModelsStore.getState().queried.has(4)).toBe(true); // queried-not-engaged
+  });
+
+  it('does not re-query ids already known to the store', async () => {
+    useEngagedModelsStore.getState().applyServerResult({}, [1, 2]); // 1,2 known
+    requestEngagedMembership([1, 2, 3]);
+    runFlush();
+    await settle();
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock.mock.calls[0][0].modelIds).toEqual([3]); // only the unknown one
+  });
+
+  it('chunks a >200-id request into ≤200-id queries', async () => {
+    const ids = Array.from({ length: 450 }, (_, i) => i + 1);
+    requestEngagedMembership(ids);
+    runFlush();
+    await settle();
+    expect(queryMock).toHaveBeenCalledTimes(3); // 200 + 200 + 50
+    expect(queryMock.mock.calls.map((c) => c[0].modelIds.length)).toEqual([200, 200, 50]);
+  });
+
+  it('leaves ids unknown after a failed fetch so a later mount retries', async () => {
+    queryMock.mockRejectedValueOnce(new Error('boom'));
+    requestEngagedMembership([5]);
+    runFlush();
+    await settle();
+    expect(useEngagedModelsStore.getState().queried.has(5)).toBe(false); // still unknown
+
+    // retry succeeds
+    queryMock.mockResolvedValueOnce({ Recommended: [5] });
+    requestEngagedMembership([5]);
+    runFlush();
+    await settle();
+    expect(useEngagedModelsStore.getState().membership[5]?.has('Recommended')).toBe(true);
+  });
+
+  it('does nothing when every requested id is already known', async () => {
+    useEngagedModelsStore.getState().applyServerResult({}, [1]);
+    requestEngagedMembership([1]);
+    // nothing scheduled (all known) → no flush callback captured
+    expect(scheduledFlush).toBeNull();
+    runFlush();
+    await settle();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-positive ids', async () => {
+    requestEngagedMembership([0, -1]);
+    expect(scheduledFlush).toBeNull();
+    runFlush();
+    await settle();
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// React hook
+// ---------------------------------------------------------------------------
+function renderHook<T>(useCb: () => T) {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  const ref: { current: T | undefined } = { current: undefined };
+  function Probe() {
+    ref.current = useCb();
+    return null;
+  }
+  act(() => root.render(React.createElement(Probe)));
+  return {
+    result: ref,
+    rerender: () => act(() => root.render(React.createElement(Probe))),
+    unmount: () => act(() => root.unmount()),
+  };
+}
+
+describe('useEngagedModelsMembership hook', () => {
+  it('unauthenticated → no query is issued', async () => {
+    currentUser = null;
+    const { unmount } = renderHook(() => useEngagedModelsMembership([1, 2]));
+    runFlush();
+    await settle();
+    expect(queryMock).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('authed → registers the on-screen ids and issues one query', async () => {
+    queryMock.mockResolvedValue({ Recommended: [1] });
+    const { result, rerender, unmount } = renderHook(() => useEngagedModelsMembership([1, 2]));
+    runFlush();
+    await settle();
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock.mock.calls[0][0].modelIds.slice().sort((a, b) => a - b)).toEqual([1, 2]);
+
+    rerender();
+    expect(result.current?.isEngaged(1, 'Recommended')).toBe(true);
+    expect(result.current?.isEngaged(2, 'Recommended')).toBe(false);
+    expect(result.current?.isLoading).toBe(false);
+    unmount();
+  });
+
+  it('single-model wrapper reads membership reactively', async () => {
+    queryMock.mockResolvedValue({ Notify: [9] });
+    const { result, rerender, unmount } = renderHook(() => useEngagedModelMembership(9));
+    runFlush();
+    await settle();
+    rerender();
+    expect(result.current?.isEngaged('Notify')).toBe(true);
+    expect(result.current?.isEngaged('Mute')).toBe(false);
+    unmount();
+  });
+
+  it('ignores a non-positive id (loading-guard for not-yet-loaded models)', async () => {
+    const { result, unmount } = renderHook(() => useEngagedModelMembership(0));
+    runFlush();
+    await settle();
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(result.current?.isEngaged('Recommended')).toBe(false);
+    unmount();
+  });
+});

--- a/src/hooks/__tests__/useEngagedModelMembership.test.ts
+++ b/src/hooks/__tests__/useEngagedModelMembership.test.ts
@@ -186,6 +186,95 @@ describe('useEngagedModelsMembership hook', () => {
     await settle();
     expect(queryMock).not.toHaveBeenCalled();
     expect(result.current?.isEngaged('Recommended')).toBe(false);
+    expect(result.current?.isKnown).toBe(false); // an unloaded model is never "known"
+    unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F1 — known-gating: controls that compute a toggle direction from membership
+// must be able to tell "unknown" from "not engaged" so they can block the click
+// until the store is warm for this model (the regression this PR revision fixes).
+// ---------------------------------------------------------------------------
+describe('useEngagedModelMembership — known-gating (F1)', () => {
+  it('single-model: isKnown=false while the fetch is in flight, then true (and ON) once it lands', async () => {
+    queryMock.mockResolvedValue({ Notify: [42] });
+    const { result, rerender, unmount } = renderHook(() => useEngagedModelMembership(42));
+
+    // Fetch registered but not yet resolved → the model is UNKNOWN. A cold store
+    // reads not-engaged, so a control MUST gate on isKnown here (not isEngaged).
+    expect(result.current?.isKnown).toBe(false);
+    expect(result.current?.isLoading).toBe(true);
+    expect(result.current?.isEngaged('Notify')).toBe(false);
+
+    runFlush();
+    await settle();
+    rerender();
+
+    // Now known and reflecting the true ON state.
+    expect(result.current?.isKnown).toBe(true);
+    expect(result.current?.isLoading).toBe(false);
+    expect(result.current?.isEngaged('Notify')).toBe(true);
+    unmount();
+  });
+
+  it('multi-model: isKnown is per-id — queried-not-engaged still counts as known', async () => {
+    queryMock.mockResolvedValue({ Recommended: [1] }); // 1 engaged, 2 absent
+    const { result, rerender, unmount } = renderHook(() => useEngagedModelsMembership([1, 2]));
+
+    expect(result.current?.isKnown(1)).toBe(false);
+    expect(result.current?.isKnown(2)).toBe(false);
+
+    runFlush();
+    await settle();
+    rerender();
+
+    expect(result.current?.isKnown(1)).toBe(true);
+    expect(result.current?.isKnown(2)).toBe(true); // known-not-engaged, not "unknown"
+    expect(result.current?.isEngaged(1, 'Recommended')).toBe(true);
+    expect(result.current?.isEngaged(2, 'Recommended')).toBe(false);
+    unmount();
+  });
+
+  it('an optimistic write makes the model known immediately (no fetch needed)', async () => {
+    const { result, rerender, unmount } = renderHook(() => useEngagedModelMembership(15));
+    expect(result.current?.isKnown).toBe(false);
+
+    // A control's optimistic mutation marks the id known via the store.
+    act(() => {
+      useEngagedModelsStore.getState().setMembership(15, 'Notify', true);
+    });
+    rerender();
+
+    expect(result.current?.isKnown).toBe(true);
+    expect(result.current?.isEngaged('Notify')).toBe(true);
+    unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F2 — a real in-flight-fetch-races-a-mutation path through the batcher: the
+// optimistic write must survive the (now-stale) server result landing on top.
+// ---------------------------------------------------------------------------
+describe('useEngagedModelsMembership — mutation-races-fetch (F2)', () => {
+  it('optimistic write during the in-flight fetch is not clobbered by the stale result', async () => {
+    // The server snapshot predates the user's mutation: it says Recommended, NOT Notify.
+    queryMock.mockResolvedValue({ Recommended: [7] });
+    const { unmount } = renderHook(() => useEngagedModelsMembership([7]));
+
+    runFlush(); // issues the fetch (promise created; .then queued but not yet run)
+
+    // User turns Notify ON for model 7 WHILE that fetch is in flight.
+    act(() => {
+      useEngagedModelsStore.getState().setMembership(7, 'Notify', true);
+    });
+
+    await settle(); // the now-stale fetch result lands here
+
+    const m = useEngagedModelsStore.getState().membership[7];
+    expect(m?.has('Notify')).toBe(true); // the user's intent is preserved…
+    expect(m?.has('Recommended')).toBe(false); // …and the stale snapshot was skipped
+    expect(useEngagedModelsStore.getState().queried.has(7)).toBe(true); // consistent/known
     unmount();
   });
 });

--- a/src/hooks/__tests__/useEngagedModelMembership.test.ts
+++ b/src/hooks/__tests__/useEngagedModelMembership.test.ts
@@ -91,19 +91,39 @@ describe('batcher', () => {
     expect(queryMock.mock.calls.map((c) => c[0].modelIds.length)).toEqual([200, 200, 50]);
   });
 
-  it('leaves ids unknown after a failed fetch so a later mount retries', async () => {
+  it('marks ids known-not-engaged after a failed fetch so a gated control is never permanently disabled (F2)', async () => {
     queryMock.mockRejectedValueOnce(new Error('boom'));
     requestEngagedMembership([5]);
     runFlush();
     await settle();
-    expect(useEngagedModelsStore.getState().queried.has(5)).toBe(false); // still unknown
 
-    // retry succeeds
-    queryMock.mockResolvedValueOnce({ Recommended: [5] });
+    // Fix 2: the errored ids become KNOWN (empty membership), not left unknown. A
+    // component that stays mounted (deps unchanged → effect never re-fires) would
+    // otherwise never re-request them, leaving its `disabled = !isKnown` control dead.
+    expect(useEngagedModelsStore.getState().queried.has(5)).toBe(true);
+    expect(useEngagedModelsStore.getState().membership[5]?.size ?? 0).toBe(0); // known-not-engaged
+
+    // Now-known → a subsequent request is a no-op (no refetch storm).
+    queryMock.mockClear();
     requestEngagedMembership([5]);
     runFlush();
     await settle();
-    expect(useEngagedModelsStore.getState().membership[5]?.has('Recommended')).toBe(true);
+    expect(queryMock).not.toHaveBeenCalled();
+  });
+
+  it('a failed fetch does NOT clobber an id the user mutated while it was in flight (F2 dirty-guard holds through the error path)', async () => {
+    queryMock.mockRejectedValueOnce(new Error('boom'));
+    requestEngagedMembership([8]);
+    runFlush(); // fetch issued; .then/.catch queued but not yet run
+
+    // User turns Notify ON for model 8 WHILE that fetch is in flight.
+    useEngagedModelsStore.getState().setMembership(8, 'Notify', true);
+
+    await settle(); // the rejection lands here → applyServerResult({}, [8])
+
+    const m = useEngagedModelsStore.getState().membership[8];
+    expect(m?.has('Notify')).toBe(true); // the local mutation survived the error-path apply
+    expect(useEngagedModelsStore.getState().queried.has(8)).toBe(true);
   });
 
   it('does nothing when every requested id is already known', async () => {
@@ -275,6 +295,100 @@ describe('useEngagedModelsMembership — mutation-races-fetch (F2)', () => {
     expect(m?.has('Notify')).toBe(true); // the user's intent is preserved…
     expect(m?.has('Recommended')).toBe(false); // …and the stale snapshot was skipped
     expect(useEngagedModelsStore.getState().queried.has(7)).toBe(true); // consistent/known
+    unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F1 (unauth) — a logged-out user has no membership to toggle wrongly. `isKnown`
+// must be true so a gated control (`disabled = loading = !isKnown`) stays
+// INTERACTIVE — a disabled element can't fire the LoginRedirect click that
+// prompts sign-in. This is the login/conversion-funnel regression the re-audit
+// caught (isKnown was FALSE FOREVER for logged-out users → notify bell dead).
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirror of the migrated notify controls' gating so we can assert the actual
+ * `disabled` DOM state the user sees, driven by the REAL hook. The control does
+ * `loading={mutation.isPending || !isKnown}`; Mantine then sets
+ * `disabled = disabled || loading`. Mutation is idle here (isPending=false), so
+ * the button is disabled iff `!isKnown`.
+ */
+function NotifyControlHarness({ modelId }: { modelId: number }) {
+  const { isKnown } = useEngagedModelMembership(modelId);
+  const isPending = false;
+  const loading = isPending || !isKnown;
+  const disabled = loading; // Mantine: disabled = disabled || loading
+  return React.createElement('button', { type: 'button', disabled }, 'notify');
+}
+
+function renderControl(modelId: number) {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  act(() => root.render(React.createElement(NotifyControlHarness, { modelId })));
+  return {
+    button: () => container.querySelector('button') as HTMLButtonElement,
+    rerender: () => act(() => root.render(React.createElement(NotifyControlHarness, { modelId }))),
+    unmount: () => act(() => root.unmount()),
+  };
+}
+
+describe('useEngagedModelMembership — unauthenticated (F1 login-funnel regression)', () => {
+  it('single-model: isKnown is TRUE with no currentUser (nothing to gate) — no query issued', async () => {
+    currentUser = null;
+    const { result, unmount } = renderHook(() => useEngagedModelMembership(42));
+    runFlush();
+    await settle();
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(result.current?.isKnown).toBe(true);
+    expect(result.current?.isLoading).toBe(false);
+    unmount();
+  });
+
+  it('multi-model: isKnown(id) is TRUE for every id with no currentUser', async () => {
+    currentUser = null;
+    const { result, unmount } = renderHook(() => useEngagedModelsMembership([1, 2, 3]));
+    runFlush();
+    await settle();
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(result.current?.isKnown(1)).toBe(true);
+    expect(result.current?.isKnown(2)).toBe(true);
+    expect(result.current?.isKnown(3)).toBe(true);
+    unmount();
+  });
+
+  it("a logged-out notify control is NOT disabled → its click can reach LoginRedirect", () => {
+    currentUser = null;
+    const { button, unmount } = renderControl(99);
+    // The store is cold (no query ever fires for unauth), yet the button is enabled
+    // because isKnown short-circuits to true. A disabled button would swallow the
+    // click that LoginRedirect clones onto it — this is the funnel fix.
+    expect(button().disabled).toBe(false);
+    unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F2 (authed + fetch error) — the gated control must not dead-lock. After the
+// by-ids fetch rejects, the control becomes actionable rather than staying a
+// permanent infinite-spinner disabled button.
+// ---------------------------------------------------------------------------
+describe('useEngagedModelMembership — authed fetch error does not dead-lock the control (F2)', () => {
+  it('authed control is disabled while the fetch is in flight, then ENABLED after the fetch errors', async () => {
+    currentUser = { id: 1 };
+    queryMock.mockRejectedValueOnce(new Error('boom'));
+    const { button, rerender, unmount } = renderControl(77);
+
+    // In flight → unknown → disabled (correct: we don't know the toggle direction yet).
+    expect(button().disabled).toBe(true);
+
+    runFlush();
+    await settle();
+    rerender();
+
+    // Fetch errored → Fix 2 marks it known-not-engaged → control is actionable again,
+    // not a permanently-disabled dead button.
+    expect(button().disabled).toBe(false);
     unmount();
   });
 });

--- a/src/hooks/useEngagedModelMembership.ts
+++ b/src/hooks/useEngagedModelMembership.ts
@@ -61,7 +61,16 @@ function flush() {
           useEngagedModelsStore.getState().applyServerResult(record ?? {}, ids);
         },
         () => {
-          // Leave the ids unknown so a later mount can retry.
+          // F2 (stuck-disabled): the fetch errored. If we left these ids unknown a
+          // component that stays mounted (unchanged deps → its effect never re-fires)
+          // would never re-request them, leaving its `disabled = loading = !isKnown`
+          // control PERMANENTLY dead with no retry. Mark them known-not-engaged so the
+          // control becomes actionable again. The dirty-guard still protects any id the
+          // user mutated meanwhile (locallyMutated is skipped). Trade-off, accepted: in
+          // this rare error case the F1 wrong-direction risk returns for a genuinely-ON
+          // model (it reads not-engaged) — a usable button beats a dead one, and the
+          // optimistic dual-write self-heals the store on the user's next interaction.
+          useEngagedModelsStore.getState().applyServerResult({}, ids);
         }
       )
       .finally(() => {
@@ -112,6 +121,14 @@ export interface EngagedMembershipResult {
    * direction from membership MUST gate their action on this (F1): while a model
    * is unknown the store reads as not-engaged, so an un-gated toggle would fire
    * the OPPOSITE of the user's intent. Ids ≤ 0 are never known.
+   *
+   * ALWAYS true when there is no authenticated user: an unauth user has no
+   * membership to toggle wrongly (the endpoint is protected, so nothing is ever
+   * queried and the id would otherwise stay "unknown" forever). Controls gate
+   * `disabled = loading = !isKnown`, so a perpetually-false isKnown would leave
+   * a logged-out user's control permanently disabled — and a disabled element
+   * can't fire the LoginRedirect click that prompts sign-in. Returning true for
+   * unauth keeps the control interactive so that click reaches LoginRedirect.
    */
   isKnown: (modelId: number) => boolean;
 }
@@ -148,12 +165,18 @@ export function useEngagedModelsMembership(modelIds: number[]): EngagedMembershi
   const knownById = new Map<number, boolean>();
   validIds.forEach((id, i) => knownById.set(id, knownFlags[i]));
 
+  // F1 (unauth): with no user there is nothing to query and nothing to toggle
+  // wrongly — treat every id as known so gated controls stay interactive and a
+  // logged-out click can reach LoginRedirect. (`enabled` is already false here,
+  // so `isLoading` is false too.)
+  const noUser = !currentUser;
+
   return {
     isEngaged: (modelId, type) => byId.get(modelId)?.has(type) ?? false,
     getTypes: (modelId) => [...(byId.get(modelId) ?? [])],
     sets,
     isLoading: enabled && knownFlags.some((known) => !known),
-    isKnown: (modelId) => knownById.get(modelId) ?? false,
+    isKnown: (modelId) => noUser || (knownById.get(modelId) ?? false),
   };
 }
 

--- a/src/hooks/useEngagedModelMembership.ts
+++ b/src/hooks/useEngagedModelMembership.ts
@@ -1,0 +1,155 @@
+import { useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import type { EngagedModelType } from '~/store/engaged-models.store';
+import { useEngagedModelsStore } from '~/store/engaged-models.store';
+import { trpcVanilla } from '~/utils/trpc';
+
+/**
+ * Batched dataloader for engagement membership (PR2). Components register the
+ * model ids currently on screen; a module-level batcher coalesces every id
+ * requested within one microtask, drops the ones already known to the store,
+ * chunks the remainder to the endpoint's ≤200 cap, and issues ONE
+ * `user.getEngagedModelsByIds` query per chunk — folding the result back into
+ * the store. Classic DataLoader-in-React.
+ *
+ * Reads come straight off the reactive store (`useIsEngaged` etc.), so an
+ * optimistic mutation is reflected instantly without any refetch.
+ */
+
+const MAX_IDS_PER_QUERY = 200; // must match getEngagedModelsByIdsSchema.max(200)
+
+// Module-level batcher state.
+const pending = new Set<number>();
+const inFlight = new Set<number>();
+let scheduled = false;
+
+/**
+ * Test/injection seam. Production uses the vanilla tRPC client + a microtask
+ * flush; tests swap in a controllable fetcher and a synchronous scheduler.
+ */
+export const engagedMembershipBatcher = {
+  fetch: (modelIds: number[]) => trpcVanilla.user.getEngagedModelsByIds.query({ modelIds }),
+  schedule: (cb: () => void) => queueMicrotask(cb),
+};
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) out.push(arr.slice(i, i + size));
+  return out;
+}
+
+function flush() {
+  scheduled = false;
+  const { queried } = useEngagedModelsStore.getState();
+
+  const toFetch: number[] = [];
+  for (const id of pending) {
+    if (!queried.has(id) && !inFlight.has(id)) toFetch.push(id);
+  }
+  pending.clear();
+  if (toFetch.length === 0) return;
+
+  for (const id of toFetch) inFlight.add(id);
+
+  for (const ids of chunk(toFetch, MAX_IDS_PER_QUERY)) {
+    engagedMembershipBatcher
+      .fetch(ids)
+      .then(
+        (record) => {
+          // Re-read applyServerResult off the live store in case the store was reset.
+          useEngagedModelsStore.getState().applyServerResult(record ?? {}, ids);
+        },
+        () => {
+          // Leave the ids unknown so a later mount can retry.
+        }
+      )
+      .finally(() => {
+        for (const id of ids) inFlight.delete(id);
+      });
+  }
+}
+
+/**
+ * Register model ids for membership lookup. Ids already known to the store, or
+ * already pending/in-flight, are skipped (dedup). Non-positive ids are ignored.
+ */
+export function requestEngagedMembership(modelIds: Iterable<number>): void {
+  const { queried } = useEngagedModelsStore.getState();
+  let added = false;
+  for (const id of modelIds) {
+    if (!(id > 0)) continue;
+    if (queried.has(id) || inFlight.has(id) || pending.has(id)) continue;
+    pending.add(id);
+    added = true;
+  }
+  if (added && !scheduled) {
+    scheduled = true;
+    engagedMembershipBatcher.schedule(flush);
+  }
+}
+
+/** Test helper: clear the module-level batcher state between tests. */
+export function __resetEngagedMembershipBatcher(): void {
+  pending.clear();
+  inFlight.clear();
+  scheduled = false;
+}
+
+export interface EngagedMembershipResult {
+  /** Reactive membership check for one of the registered ids. */
+  isEngaged: (modelId: number, type: EngagedModelType) => boolean;
+  /** All engagement types for one of the registered ids. */
+  getTypes: (modelId: number) => EngagedModelType[];
+  /** Reactive per-id type-sets, aligned to the passed `modelIds` order. */
+  sets: (ReadonlySet<EngagedModelType> | undefined)[];
+  /** True while any requested id is still unknown (query in flight / pending). */
+  isLoading: boolean;
+}
+
+/**
+ * Register `modelIds` (only those the caller currently has on screen) and read
+ * their membership reactively from the store. Unauthenticated users issue no
+ * query and see empty membership (the endpoint is protected).
+ */
+export function useEngagedModelsMembership(modelIds: number[]): EngagedMembershipResult {
+  const currentUser = useCurrentUser();
+  const validIds = modelIds.filter((id) => id > 0);
+  const enabled = !!currentUser && validIds.length > 0;
+  const key = validIds.join(',');
+
+  useEffect(() => {
+    if (!enabled) return;
+    requestEngagedMembership(validIds);
+    // key encodes validIds; enabled gates on auth. Intentionally not depending
+    // on the array identity (new each render).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, enabled]);
+
+  const sets = useEngagedModelsStore(
+    useShallow((s) => modelIds.map((id) => s.membership[id]))
+  );
+  const knownFlags = useEngagedModelsStore(
+    useShallow((s) => validIds.map((id) => s.queried.has(id)))
+  );
+
+  const byId = new Map<number, ReadonlySet<EngagedModelType> | undefined>();
+  modelIds.forEach((id, i) => byId.set(id, sets[i]));
+
+  return {
+    isEngaged: (modelId, type) => byId.get(modelId)?.has(type) ?? false,
+    getTypes: (modelId) => [...(byId.get(modelId) ?? [])],
+    sets,
+    isLoading: enabled && knownFlags.some((known) => !known),
+  };
+}
+
+/** Single-model convenience wrapper. */
+export function useEngagedModelMembership(modelId: number) {
+  const { isEngaged, getTypes, isLoading } = useEngagedModelsMembership([modelId]);
+  return {
+    isEngaged: (type: EngagedModelType) => isEngaged(modelId, type),
+    types: getTypes(modelId),
+    isLoading,
+  };
+}

--- a/src/hooks/useEngagedModelMembership.ts
+++ b/src/hooks/useEngagedModelMembership.ts
@@ -105,6 +105,15 @@ export interface EngagedMembershipResult {
   sets: (ReadonlySet<EngagedModelType> | undefined)[];
   /** True while any requested id is still unknown (query in flight / pending). */
   isLoading: boolean;
+  /**
+   * Per-id "do we have definitive knowledge of this model's membership yet?".
+   * True once the id is in the store's `queried` set — i.e. a server result has
+   * landed OR an optimistic write has set it. Controls that compute a toggle
+   * direction from membership MUST gate their action on this (F1): while a model
+   * is unknown the store reads as not-engaged, so an un-gated toggle would fire
+   * the OPPOSITE of the user's intent. Ids ≤ 0 are never known.
+   */
+  isKnown: (modelId: number) => boolean;
 }
 
 /**
@@ -136,20 +145,26 @@ export function useEngagedModelsMembership(modelIds: number[]): EngagedMembershi
   const byId = new Map<number, ReadonlySet<EngagedModelType> | undefined>();
   modelIds.forEach((id, i) => byId.set(id, sets[i]));
 
+  const knownById = new Map<number, boolean>();
+  validIds.forEach((id, i) => knownById.set(id, knownFlags[i]));
+
   return {
     isEngaged: (modelId, type) => byId.get(modelId)?.has(type) ?? false,
     getTypes: (modelId) => [...(byId.get(modelId) ?? [])],
     sets,
     isLoading: enabled && knownFlags.some((known) => !known),
+    isKnown: (modelId) => knownById.get(modelId) ?? false,
   };
 }
 
 /** Single-model convenience wrapper. */
 export function useEngagedModelMembership(modelId: number) {
-  const { isEngaged, getTypes, isLoading } = useEngagedModelsMembership([modelId]);
+  const { isEngaged, getTypes, isLoading, isKnown } = useEngagedModelsMembership([modelId]);
   return {
     isEngaged: (type: EngagedModelType) => isEngaged(modelId, type),
     types: getTypes(modelId),
     isLoading,
+    /** Definitive membership knowledge for this model (see EngagedMembershipResult.isKnown). */
+    isKnown: isKnown(modelId),
   };
 }

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -390,7 +390,9 @@ export default function ModelDetailsV2({
   );
 
   // PR2: per-visible-set membership for just this model (was the unbounded getEngagedModels).
-  const { isEngaged: isModelEngaged } = useEngagedModelMembership(model?.id ?? 0);
+  const { isEngaged: isModelEngaged, isKnown: isFavoriteKnown } = useEngagedModelMembership(
+    model?.id ?? 0
+  );
   const isFavorite = !!model && isModelEngaged('Recommended');
 
   const isModerator = currentUser?.isModerator ?? false;
@@ -821,8 +823,13 @@ export default function ModelDetailsV2({
                               filled={isFavorite}
                             />
                           }
-                          className="cursor-pointer"
-                          onClick={() => handleToggleFavorite({ setTo: !isFavorite })}
+                          className={isFavoriteKnown ? 'cursor-pointer' : 'cursor-progress'}
+                          onClick={() => {
+                            // F1: don't toggle until Recommended membership is known —
+                            // a cold store reads not-favorited and would flip intent.
+                            if (!isFavoriteKnown) return;
+                            handleToggleFavorite({ setTo: !isFavorite });
+                          }}
                         >
                           <Text className={classes.modelBadgeText}>
                             {abbreviateNumber(model.rank?.thumbsUpCountAllTime ?? 0)}

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -106,6 +106,7 @@ import { TrackView } from '~/components/TrackView/TrackView';
 import { env } from '~/env/client';
 import { useHiddenPreferencesData } from '~/hooks/hidden-preferences';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useEngagedModelMembership } from '~/hooks/useEngagedModelMembership';
 import useIsClient from '~/hooks/useIsClient';
 import { useBrowsingSettingsAddons } from '~/providers/BrowsingSettingsAddonsProvider';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -388,13 +389,9 @@ export default function ModelDetailsV2({
     (Array.isArray(rawVersionId) ? rawVersionId[0] : rawVersionId) ?? model?.modelVersions[0]?.id
   );
 
-  const { data: { Recommended: reviewedModels = [] } = { Recommended: [] } } =
-    trpc.user.getEngagedModels.useQuery(undefined, {
-      enabled: !!currentUser,
-      gcTime: Infinity,
-      staleTime: Infinity,
-    });
-  const isFavorite = model && reviewedModels.includes(model.id);
+  // PR2: per-visible-set membership for just this model (was the unbounded getEngagedModels).
+  const { isEngaged: isModelEngaged } = useEngagedModelMembership(model?.id ?? 0);
+  const isFavorite = !!model && isModelEngaged('Recommended');
 
   const isModerator = currentUser?.isModerator ?? false;
   const isCreator = model?.user.id === currentUser?.id;

--- a/src/store/__tests__/engaged-models.optimistic.test.ts
+++ b/src/store/__tests__/engaged-models.optimistic.test.ts
@@ -38,19 +38,19 @@ afterEach(() => {
 describe('optimistic — create review', () => {
   it('adds Recommended + Notify when recommending a not-yet-recommended model', () => {
     seed(1, []);
-    applyReviewCreated(1, true);
+    applyReviewCreated(1, true, false);
     expect(types(1)).toEqual(['Notify', 'Recommended']);
   });
 
   it('removes Recommended + Notify when the review is NOT recommended', () => {
     seed(1, ['Recommended', 'Notify']);
-    applyReviewCreated(1, false);
+    applyReviewCreated(1, false, true);
     expect(types(1)).toEqual([]);
   });
 
   it('removes when recommending a model that is ALREADY recommended (shouldRemove branch)', () => {
     seed(1, ['Recommended', 'Notify']);
-    applyReviewCreated(1, true); // already recommended → toggles off
+    applyReviewCreated(1, true, true); // already recommended → toggles off
     expect(types(1)).toEqual([]);
   });
 });
@@ -58,20 +58,50 @@ describe('optimistic — create review', () => {
 describe('optimistic — update review', () => {
   it('adds Recommended when recommending a fresh model (touches only Recommended)', () => {
     seed(1, ['Notify']);
-    applyReviewUpdated(1, true);
+    applyReviewUpdated(1, true, false);
     expect(types(1)).toEqual(['Notify', 'Recommended']);
   });
 
   it('removes Recommended when recommended=false', () => {
     seed(1, ['Recommended', 'Notify']);
-    applyReviewUpdated(1, false);
+    applyReviewUpdated(1, false, true);
     expect(types(1)).toEqual(['Notify']); // Notify untouched
   });
 
   it('removes when already recommended (shouldRemove branch), leaving Notify', () => {
     seed(1, ['Recommended', 'Notify']);
-    applyReviewUpdated(1, true);
+    applyReviewUpdated(1, true, true);
     expect(types(1)).toEqual(['Notify']);
+  });
+});
+
+// F3: the toggle DIRECTION must come from the caller-supplied `alreadyRecommended`
+// (the warm legacy snapshot), NOT the normalized store — which can be cold for
+// this model while a by-ids fetch is in flight and would otherwise flip intent.
+describe('optimistic — create/update derive direction from the caller, not the (cold) store', () => {
+  it('create: cold store (unknown) + alreadyRecommended=false → ADDS (does not read store)', () => {
+    // Store has NO knowledge of model 1 (never seeded) — the legacy self-branch
+    // would read not-recommended and add; here we prove the param drives it.
+    applyReviewCreated(1, true, false);
+    expect(types(1)).toEqual(['Notify', 'Recommended']);
+  });
+
+  it('create: cold store but caller says alreadyRecommended=true → REMOVES', () => {
+    // The store is cold (reads not-recommended) yet the warm snapshot knows the
+    // user already recommended → direction must be "remove", not "add".
+    applyReviewCreated(1, true, true);
+    expect(types(1)).toEqual([]); // toggled off despite the cold store
+  });
+
+  it('update: store says Recommended but caller says alreadyRecommended=false → ADDS (param wins)', () => {
+    seed(1, ['Recommended']); // store disagrees with the caller on purpose
+    applyReviewUpdated(1, true, false);
+    expect(types(1)).toEqual(['Recommended']); // stays recommended (add branch)
+  });
+
+  it('update: store cold but caller says alreadyRecommended=true → REMOVES (param wins)', () => {
+    applyReviewUpdated(1, true, true);
+    expect(types(1)).toEqual([]); // removed despite the cold store
   });
 });
 
@@ -136,8 +166,8 @@ describe('optimistic — rollback restores prior membership exactly', () => {
     { name: 'favorite (off)', seed: ['Recommended', 'Notify'], apply: () => applyFavoriteToggled(1, false) },
     { name: 'notify (on)', seed: ['Mute'], apply: () => applyNotifyToggled(1, true) },
     { name: 'notify (off)', seed: ['Notify', 'Recommended'], apply: () => applyNotifyToggled(1, false) },
-    { name: 'create', seed: [], apply: () => applyReviewCreated(1, true) },
-    { name: 'update', seed: ['Notify'], apply: () => applyReviewUpdated(1, true) },
+    { name: 'create', seed: [], apply: () => applyReviewCreated(1, true, false) },
+    { name: 'update', seed: ['Notify'], apply: () => applyReviewUpdated(1, true, false) },
     { name: 'delete', seed: ['Recommended', 'Notify'], apply: () => applyReviewDeleted(1) },
   ];
 
@@ -160,7 +190,7 @@ describe('optimistic — no cross-model contamination', () => {
     seed(2, ['Recommended', 'Mute']);
     const yBefore = types(2);
 
-    applyReviewCreated(1, true);
+    applyReviewCreated(1, true, false);
     applyFavoriteToggled(1, false);
     applyNotifyToggled(1, false);
     applyReviewDeleted(1);

--- a/src/store/__tests__/engaged-models.optimistic.test.ts
+++ b/src/store/__tests__/engaged-models.optimistic.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getEngagedModelTypes,
+  isModelEngaged,
+  restoreMembership,
+  snapshotMembership,
+  useEngagedModelsStore,
+} from '~/store/engaged-models.store';
+import {
+  applyFavoriteToggled,
+  applyNotifyToggled,
+  applyReviewCreated,
+  applyReviewDeleted,
+  applyReviewUpdated,
+} from '~/store/engaged-models.optimistic';
+import type { EngagedModelType } from '~/store/engaged-models.store';
+
+const store = useEngagedModelsStore;
+
+/** Seed a model's membership deterministically. */
+function seed(modelId: number, types: EngagedModelType[]) {
+  store.getState().replaceMembership(modelId, types);
+}
+
+/** Sorted type list for stable comparisons. */
+function types(modelId: number) {
+  return getEngagedModelTypes(modelId).sort();
+}
+
+afterEach(() => {
+  store.getState().reset();
+});
+
+// The suite the PR exists for: prove each action toggles the EXACT engagement
+// types the legacy getEngagedModels handlers did, that an error rolls back to the
+// prior membership precisely, and that no action ever touches another model.
+
+describe('optimistic — create review', () => {
+  it('adds Recommended + Notify when recommending a not-yet-recommended model', () => {
+    seed(1, []);
+    applyReviewCreated(1, true);
+    expect(types(1)).toEqual(['Notify', 'Recommended']);
+  });
+
+  it('removes Recommended + Notify when the review is NOT recommended', () => {
+    seed(1, ['Recommended', 'Notify']);
+    applyReviewCreated(1, false);
+    expect(types(1)).toEqual([]);
+  });
+
+  it('removes when recommending a model that is ALREADY recommended (shouldRemove branch)', () => {
+    seed(1, ['Recommended', 'Notify']);
+    applyReviewCreated(1, true); // already recommended → toggles off
+    expect(types(1)).toEqual([]);
+  });
+});
+
+describe('optimistic — update review', () => {
+  it('adds Recommended when recommending a fresh model (touches only Recommended)', () => {
+    seed(1, ['Notify']);
+    applyReviewUpdated(1, true);
+    expect(types(1)).toEqual(['Notify', 'Recommended']);
+  });
+
+  it('removes Recommended when recommended=false', () => {
+    seed(1, ['Recommended', 'Notify']);
+    applyReviewUpdated(1, false);
+    expect(types(1)).toEqual(['Notify']); // Notify untouched
+  });
+
+  it('removes when already recommended (shouldRemove branch), leaving Notify', () => {
+    seed(1, ['Recommended', 'Notify']);
+    applyReviewUpdated(1, true);
+    expect(types(1)).toEqual(['Notify']);
+  });
+});
+
+describe('optimistic — delete review', () => {
+  it('removes Recommended + Notify', () => {
+    seed(1, ['Recommended', 'Notify']);
+    applyReviewDeleted(1);
+    expect(types(1)).toEqual([]);
+  });
+
+  it('leaves an unrelated type (e.g. Mute) intact', () => {
+    seed(1, ['Recommended', 'Notify', 'Mute']);
+    applyReviewDeleted(1);
+    expect(types(1)).toEqual(['Mute']);
+  });
+});
+
+describe('optimistic — toggle favorite', () => {
+  it('favoriting adds Recommended + Notify', () => {
+    seed(1, []);
+    applyFavoriteToggled(1, true);
+    expect(types(1)).toEqual(['Notify', 'Recommended']);
+  });
+
+  it('un-favoriting removes Recommended but KEEPS Notify (current semantics)', () => {
+    seed(1, ['Recommended', 'Notify']);
+    applyFavoriteToggled(1, false);
+    expect(types(1)).toEqual(['Notify']);
+  });
+
+  it('favoriting is idempotent when already favorited', () => {
+    seed(1, ['Recommended', 'Notify']);
+    applyFavoriteToggled(1, true);
+    expect(types(1)).toEqual(['Notify', 'Recommended']);
+  });
+});
+
+describe('optimistic — toggle notify (Notify/Mute mutual exclusion)', () => {
+  it('turning ON sets Notify and clears Mute', () => {
+    seed(1, ['Mute']);
+    applyNotifyToggled(1, true);
+    expect(types(1)).toEqual(['Notify']);
+  });
+
+  it('turning OFF sets Mute and clears Notify', () => {
+    seed(1, ['Notify']);
+    applyNotifyToggled(1, false);
+    expect(types(1)).toEqual(['Mute']);
+  });
+
+  it('turning ON preserves an unrelated Recommended', () => {
+    seed(1, ['Recommended']);
+    applyNotifyToggled(1, true);
+    expect(types(1)).toEqual(['Notify', 'Recommended']);
+  });
+});
+
+// -------- rollback (snapshot → apply → error → restore) --------
+describe('optimistic — rollback restores prior membership exactly', () => {
+  const cases: { name: string; seed: EngagedModelType[]; apply: () => void }[] = [
+    { name: 'favorite (on)', seed: [], apply: () => applyFavoriteToggled(1, true) },
+    { name: 'favorite (off)', seed: ['Recommended', 'Notify'], apply: () => applyFavoriteToggled(1, false) },
+    { name: 'notify (on)', seed: ['Mute'], apply: () => applyNotifyToggled(1, true) },
+    { name: 'notify (off)', seed: ['Notify', 'Recommended'], apply: () => applyNotifyToggled(1, false) },
+    { name: 'create', seed: [], apply: () => applyReviewCreated(1, true) },
+    { name: 'update', seed: ['Notify'], apply: () => applyReviewUpdated(1, true) },
+    { name: 'delete', seed: ['Recommended', 'Notify'], apply: () => applyReviewDeleted(1) },
+  ];
+
+  for (const c of cases) {
+    it(`${c.name}: apply mutates, restore reverts to the snapshot`, () => {
+      seed(1, c.seed);
+      const snap = snapshotMembership(1);
+      c.apply();
+      // (sanity) the apply actually changed something for the non-idempotent cases
+      restoreMembership(1, snap);
+      expect(types(1)).toEqual([...c.seed].sort());
+    });
+  }
+});
+
+// -------- no cross-model contamination --------
+describe('optimistic — no cross-model contamination', () => {
+  it('mutating model X never touches model Y', () => {
+    seed(1, ['Notify']);
+    seed(2, ['Recommended', 'Mute']);
+    const yBefore = types(2);
+
+    applyReviewCreated(1, true);
+    applyFavoriteToggled(1, false);
+    applyNotifyToggled(1, false);
+    applyReviewDeleted(1);
+
+    expect(types(2)).toEqual(yBefore); // Y untouched throughout
+  });
+
+  it('a rollback on X leaves Y untouched', () => {
+    seed(1, ['Recommended']);
+    seed(2, ['Notify']);
+    const snap = snapshotMembership(1);
+    applyFavoriteToggled(1, false);
+    restoreMembership(1, snap);
+    expect(isModelEngaged(2, 'Notify')).toBe(true);
+    expect(types(2)).toEqual(['Notify']);
+  });
+});

--- a/src/store/__tests__/engaged-models.store.test.ts
+++ b/src/store/__tests__/engaged-models.store.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getEngagedModelTypes,
+  isModelEngaged,
+  isModelQueried,
+  restoreMembership,
+  snapshotMembership,
+  useEngagedModelsStore,
+} from '~/store/engaged-models.store';
+import {
+  applyFavoriteToggled,
+  applyNotifyToggled,
+  applyReviewCreated,
+  applyReviewDeleted,
+  applyReviewUpdated,
+} from '~/store/engaged-models.optimistic';
+
+const store = useEngagedModelsStore;
+
+afterEach(() => {
+  store.getState().reset();
+});
+
+// ---------------------------------------------------------------------------
+// Store primitives
+// ---------------------------------------------------------------------------
+describe('engaged-models store — primitives', () => {
+  it('setMembership on/off toggles a single type and marks the id known', () => {
+    expect(isModelQueried(1)).toBe(false); // unknown
+
+    store.getState().setMembership(1, 'Recommended', true);
+    expect(isModelEngaged(1, 'Recommended')).toBe(true);
+    expect(isModelQueried(1)).toBe(true); // now known
+
+    store.getState().setMembership(1, 'Recommended', false);
+    expect(isModelEngaged(1, 'Recommended')).toBe(false);
+    expect(isModelQueried(1)).toBe(true); // still known (queried, not engaged)
+  });
+
+  it('supports multiple co-existing types on one model', () => {
+    store.getState().setMembership(7, 'Recommended', true);
+    store.getState().setMembership(7, 'Notify', true);
+    expect(getEngagedModelTypes(7).sort()).toEqual(['Notify', 'Recommended']);
+    expect(isModelEngaged(7, 'Recommended')).toBe(true);
+    expect(isModelEngaged(7, 'Notify')).toBe(true);
+    expect(isModelEngaged(7, 'Mute')).toBe(false);
+  });
+
+  it('distinguishes unknown / known-not-engaged / engaged', () => {
+    // unknown
+    expect(isModelQueried(3)).toBe(false);
+    expect(isModelEngaged(3, 'Recommended')).toBe(false);
+
+    // applyServerResult with the id absent from the record → known-not-engaged
+    store.getState().applyServerResult({ Recommended: [] }, [3]);
+    expect(isModelQueried(3)).toBe(true);
+    expect(isModelEngaged(3, 'Recommended')).toBe(false);
+  });
+
+  it('applyServerResult marks ALL queried ids known even when absent from the record', () => {
+    store.getState().applyServerResult({ Recommended: [10], Notify: [11] }, [10, 11, 12, 13]);
+    // engaged
+    expect(isModelEngaged(10, 'Recommended')).toBe(true);
+    expect(isModelEngaged(11, 'Notify')).toBe(true);
+    // queried-but-absent → known, not engaged
+    expect(isModelQueried(12)).toBe(true);
+    expect(isModelQueried(13)).toBe(true);
+    expect(getEngagedModelTypes(12)).toEqual([]);
+    expect(getEngagedModelTypes(13)).toEqual([]);
+  });
+
+  it('applyServerResult records an engaged id even if it was not in the queried list', () => {
+    store.getState().applyServerResult({ Favorite: [99] }, [1]);
+    expect(isModelEngaged(99, 'Favorite')).toBe(true);
+    expect(isModelQueried(99)).toBe(true);
+  });
+
+  it('applyServerResult overwrites prior server truth for the same id', () => {
+    store.getState().applyServerResult({ Recommended: [5] }, [5]);
+    expect(isModelEngaged(5, 'Recommended')).toBe(true);
+    store.getState().applyServerResult({ Recommended: [] }, [5]);
+    expect(isModelEngaged(5, 'Recommended')).toBe(false);
+  });
+
+  it('setMembership keeps the state reference stable on a genuine no-op', () => {
+    store.getState().applyServerResult({}, [4]); // known, empty
+    const before = store.getState().membership;
+    store.getState().setMembership(4, 'Recommended', false); // already absent + known
+    expect(store.getState().membership).toBe(before);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reactive selector subscription
+// ---------------------------------------------------------------------------
+describe('engaged-models store — reactivity', () => {
+  it('notifies subscribers when a relevant membership changes', () => {
+    const seen: boolean[] = [];
+    const unsub = store.subscribe((s) => seen.push(s.membership[1]?.has('Recommended') ?? false));
+    store.getState().setMembership(1, 'Recommended', true);
+    store.getState().setMembership(1, 'Recommended', false);
+    unsub();
+    expect(seen).toEqual([true, false]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapshot / restore
+// ---------------------------------------------------------------------------
+describe('engaged-models store — snapshot/restore', () => {
+  it('snapshot is a detached clone; later mutations do not mutate it', () => {
+    store.getState().setMembership(1, 'Recommended', true);
+    const snap = snapshotMembership(1);
+    store.getState().setMembership(1, 'Notify', true);
+    expect([...snap]).toEqual(['Recommended']); // unchanged
+  });
+
+  it('restore replaces the full type-set exactly', () => {
+    store.getState().setMembership(1, 'Recommended', true);
+    const snap = snapshotMembership(1);
+    store.getState().setMembership(1, 'Notify', true);
+    store.getState().setMembership(1, 'Recommended', false);
+    restoreMembership(1, snap);
+    expect(getEngagedModelTypes(1)).toEqual(['Recommended']);
+    expect(isModelEngaged(1, 'Notify')).toBe(false);
+  });
+});

--- a/src/store/__tests__/engaged-models.store.test.ts
+++ b/src/store/__tests__/engaged-models.store.test.ts
@@ -91,6 +91,51 @@ describe('engaged-models store — primitives', () => {
 });
 
 // ---------------------------------------------------------------------------
+// F2 — dirty-guard: an optimistic write that races an in-flight by-ids fetch
+// must NOT be clobbered by the (now-stale) server snapshot when it lands.
+// ---------------------------------------------------------------------------
+describe('engaged-models store — dirty-guard (F2)', () => {
+  it('applyServerResult does not overwrite an id mutated after the fetch was issued', () => {
+    // Fetch for model 1 is in flight; store is cold (1 not yet queried).
+    expect(isModelQueried(1)).toBe(false);
+
+    // User turns Notify ON while the fetch is in flight (optimistic write).
+    store.getState().setMembership(1, 'Notify', true);
+    expect(isModelEngaged(1, 'Notify')).toBe(true);
+    expect(isModelQueried(1)).toBe(true);
+
+    // The now-stale fetch resolves with the PRE-mutation snapshot (Notify absent,
+    // says Recommended). It must be ignored for id 1 — the local write wins.
+    store.getState().applyServerResult({ Recommended: [1] }, [1]);
+    expect(isModelEngaged(1, 'Notify')).toBe(true); // preserved
+    expect(isModelEngaged(1, 'Recommended')).toBe(false); // stale snapshot skipped
+    // still known → the batcher won't refetch, and the value is the user's intent
+    expect(isModelQueried(1)).toBe(true);
+  });
+
+  it('a stale snapshot never clobbers a mutated id but still applies to un-mutated ids', () => {
+    // Two ids in flight; user mutates only id 1.
+    store.getState().setMembership(1, 'Notify', true);
+
+    // Stale batch result for both ids arrives.
+    store.getState().applyServerResult({ Recommended: [1, 2] }, [1, 2]);
+
+    // id 1 (mutated) keeps the optimistic value; id 2 (untouched) takes the server truth.
+    expect(getEngagedModelTypes(1).sort()).toEqual(['Notify']);
+    expect(isModelEngaged(2, 'Recommended')).toBe(true);
+  });
+
+  it('reset() clears the dirty-guard so a later fetch applies normally', () => {
+    store.getState().setMembership(1, 'Notify', true);
+    store.getState().reset();
+    // Fresh session: the same id is fetched and the server result applies cleanly.
+    store.getState().applyServerResult({ Recommended: [1] }, [1]);
+    expect(isModelEngaged(1, 'Recommended')).toBe(true);
+    expect(isModelEngaged(1, 'Notify')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Reactive selector subscription
 // ---------------------------------------------------------------------------
 describe('engaged-models store — reactivity', () => {

--- a/src/store/engaged-models.optimistic.ts
+++ b/src/store/engaged-models.optimistic.ts
@@ -1,0 +1,62 @@
+import { isModelEngaged, useEngagedModelsStore } from '~/store/engaged-models.store';
+
+/**
+ * Semantic optimistic mutators for the engaged-models store, one per user
+ * action. Each mirrors — EXACTLY — the engagement-type bookkeeping the legacy
+ * React-Query `user.getEngagedModels.setData(undefined, …)` handlers performed
+ * in `resourceReview.utils.ts`, so the migrated (per-visible-set) surfaces stay
+ * behaviourally identical to the still-on-old-endpoint feed surfaces.
+ *
+ * Notes on the (non-obvious) current semantics these preserve:
+ *   - A "favorite"/"like" on the client IS a `Recommended` resource review — the
+ *     `Favorite` ModelEngagement enum value is legacy and is NOT written by any
+ *     of these actions. (The model page reads `isFavorite` off `Recommended`.)
+ *   - Creating / deleting a review, and favoriting, also toggle `Notify`
+ *     (auto-watch). Unfavoriting deliberately does NOT clear `Notify`.
+ *   - Updating a review touches only `Recommended`.
+ *   - Notify/Mute are a single mutually-exclusive server engagement row, so
+ *     toggling one clears the other here.
+ */
+
+const store = () => useEngagedModelsStore.getState();
+
+/** resourceReview.create — toggles `Recommended` + `Notify` together. */
+export function applyReviewCreated(modelId: number, recommended: boolean): void {
+  const shouldRemove = !recommended || isModelEngaged(modelId, 'Recommended');
+  store().setMembership(modelId, 'Recommended', !shouldRemove);
+  store().setMembership(modelId, 'Notify', !shouldRemove);
+}
+
+/** resourceReview.update — toggles `Recommended` only. */
+export function applyReviewUpdated(modelId: number, recommended: boolean | null | undefined): void {
+  const shouldRemove = !recommended || isModelEngaged(modelId, 'Recommended');
+  store().setMembership(modelId, 'Recommended', !shouldRemove);
+}
+
+/** resourceReview.delete — removes `Recommended` + `Notify`. */
+export function applyReviewDeleted(modelId: number): void {
+  store().setMembership(modelId, 'Recommended', false);
+  store().setMembership(modelId, 'Notify', false);
+}
+
+/** user.toggleFavorite — add `Recommended` + `Notify` when favoriting; remove only `Recommended` when un-favoriting. */
+export function applyFavoriteToggled(modelId: number, setTo: boolean): void {
+  if (setTo) {
+    store().setMembership(modelId, 'Notify', true);
+    store().setMembership(modelId, 'Recommended', true);
+  } else {
+    // Deliberately preserve the current behavior: un-favoriting does not clear Notify.
+    store().setMembership(modelId, 'Recommended', false);
+  }
+}
+
+/** user.toggleNotifyModel — `turnOn` sets Notify (clears Mute); otherwise sets Mute (clears Notify). */
+export function applyNotifyToggled(modelId: number, turnOn: boolean): void {
+  if (turnOn) {
+    store().setMembership(modelId, 'Notify', true);
+    store().setMembership(modelId, 'Mute', false);
+  } else {
+    store().setMembership(modelId, 'Mute', true);
+    store().setMembership(modelId, 'Notify', false);
+  }
+}

--- a/src/store/engaged-models.optimistic.ts
+++ b/src/store/engaged-models.optimistic.ts
@@ -1,4 +1,4 @@
-import { isModelEngaged, useEngagedModelsStore } from '~/store/engaged-models.store';
+import { useEngagedModelsStore } from '~/store/engaged-models.store';
 
 /**
  * Semantic optimistic mutators for the engaged-models store, one per user
@@ -20,16 +20,35 @@ import { isModelEngaged, useEngagedModelsStore } from '~/store/engaged-models.st
 
 const store = () => useEngagedModelsStore.getState();
 
-/** resourceReview.create — toggles `Recommended` + `Notify` together. */
-export function applyReviewCreated(modelId: number, recommended: boolean): void {
-  const shouldRemove = !recommended || isModelEngaged(modelId, 'Recommended');
+/**
+ * resourceReview.create — toggles `Recommended` + `Notify` together.
+ *
+ * F3: the toggle DIRECTION (`shouldRemove`) is derived from `alreadyRecommended`
+ * supplied by the caller — the reliable, warm `previousEngaged.Recommended`
+ * React-Query snapshot — NOT from the normalized store, which may be cold for
+ * this model (mid by-ids fetch) and would then read as not-recommended and flip
+ * the direction. This keeps exact parity with the legacy dual-write.
+ */
+export function applyReviewCreated(
+  modelId: number,
+  recommended: boolean,
+  alreadyRecommended: boolean
+): void {
+  const shouldRemove = !recommended || alreadyRecommended;
   store().setMembership(modelId, 'Recommended', !shouldRemove);
   store().setMembership(modelId, 'Notify', !shouldRemove);
 }
 
-/** resourceReview.update — toggles `Recommended` only. */
-export function applyReviewUpdated(modelId: number, recommended: boolean | null | undefined): void {
-  const shouldRemove = !recommended || isModelEngaged(modelId, 'Recommended');
+/**
+ * resourceReview.update — toggles `Recommended` only. Direction comes from the
+ * caller's `alreadyRecommended` (see `applyReviewCreated`), not the cold store.
+ */
+export function applyReviewUpdated(
+  modelId: number,
+  recommended: boolean | null | undefined,
+  alreadyRecommended: boolean
+): void {
+  const shouldRemove = !recommended || alreadyRecommended;
   store().setMembership(modelId, 'Recommended', !shouldRemove);
 }
 

--- a/src/store/engaged-models.store.ts
+++ b/src/store/engaged-models.store.ts
@@ -53,11 +53,27 @@ function setsEqual(a: ReadonlySet<EngagedModelType> | undefined, b: ReadonlySet<
   return true;
 }
 
+/**
+ * Dirty-guard (F2): ids the user has locally mutated (optimistic write / rollback).
+ * A by-ids fetch issued for an id that is subsequently mutated within the fetch
+ * RTT would, on resolution, carry a snapshot that predates the mutation. Without
+ * this guard `applyServerResult` unconditionally overwrites the id — clobbering
+ * the optimistic (already-server-persisted) value with a stale one and, because
+ * the id is now `queried`, never refetching → stuck stale. Any id in this set is
+ * skipped by `applyServerResult`, so a local write always wins over an in-flight
+ * server snapshot. Cleared by `reset()` (sign-out / tests). It is intentionally
+ * module-level (not selectable state): no component reads it, so mutating it must
+ * never fan a selector run out to consumers.
+ */
+const locallyMutated = new Set<number>();
+
 export const useEngagedModelsStore = create<EngagedModelsState>((set) => ({
   membership: {},
   queried: new Set<number>(),
 
-  setMembership: (modelId, type, on) =>
+  setMembership: (modelId, type, on) => {
+    // Local write → protect this id from a stale in-flight server snapshot (F2).
+    locallyMutated.add(modelId);
     set((state) => {
       const prev = state.membership[modelId];
       const next = new Set<EngagedModelType>(prev ?? []);
@@ -71,27 +87,38 @@ export const useEngagedModelsStore = create<EngagedModelsState>((set) => ({
 
       const queried = alreadyKnown ? state.queried : new Set(state.queried).add(modelId);
       return { membership: { ...state.membership, [modelId]: next }, queried };
-    }),
+    });
+  },
 
-  replaceMembership: (modelId, types) =>
+  replaceMembership: (modelId, types) => {
+    // Local write (rollback restore) → protect from a stale in-flight snapshot (F2).
+    locallyMutated.add(modelId);
     set((state) => {
       const next = new Set<EngagedModelType>(types);
       const alreadyKnown = state.queried.has(modelId);
       if (alreadyKnown && setsEqual(state.membership[modelId], next)) return state;
       const queried = alreadyKnown ? state.queried : new Set(state.queried).add(modelId);
       return { membership: { ...state.membership, [modelId]: next }, queried };
-    }),
+    });
+  },
 
   applyServerResult: (record, queriedIds) =>
     set((state) => {
       // Start every queried id at an empty set → any id absent from `record`
-      // becomes known-not-engaged (distinct from unknown).
+      // becomes known-not-engaged (distinct from unknown). Ids mutated locally
+      // since this fetch was issued are skipped entirely (F2 dirty-guard): the
+      // optimistic write reflects the user's just-persisted intent and must win
+      // over this now-stale snapshot.
       const byId = new Map<number, Set<EngagedModelType>>();
-      for (const id of queriedIds) byId.set(id, new Set());
+      for (const id of queriedIds) {
+        if (locallyMutated.has(id)) continue;
+        byId.set(id, new Set());
+      }
 
       for (const [type, ids] of Object.entries(record) as [EngagedModelType, number[] | undefined][]) {
         if (!ids) continue;
         for (const id of ids) {
+          if (locallyMutated.has(id)) continue; // stale — preserve the local mutation
           let s = byId.get(id);
           if (!s) {
             // Defensive: server returned an id we didn't ask about — still record it.
@@ -111,7 +138,10 @@ export const useEngagedModelsStore = create<EngagedModelsState>((set) => ({
       return { membership, queried };
     }),
 
-  reset: () => set({ membership: {}, queried: new Set<number>() }),
+  reset: () => {
+    locallyMutated.clear();
+    set({ membership: {}, queried: new Set<number>() });
+  },
 }));
 
 // ---------------------------------------------------------------------------

--- a/src/store/engaged-models.store.ts
+++ b/src/store/engaged-models.store.ts
@@ -1,0 +1,153 @@
+import { create } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
+import type { ModelEngagementType } from '~/shared/utils/prisma/enums';
+
+/**
+ * Client-side normalized engagement-membership store (PR2 of the
+ * `user.getEngagedModels` freeze-fix).
+ *
+ * The legacy `user.getEngagedModels` endpoint returned a user's ENTIRE
+ * engagement history (a whale's ~450k ids → 3.75 MB synchronous serialize →
+ * froze an api-primary pod). PR1 (#3028) added the bounded
+ * `user.getEngagedModelsByIds({ modelIds ≤200 })` endpoint. This store holds the
+ * per-model membership so a caller only ever asks the server about the models
+ * currently ON SCREEN — bounding the payload by visible-set size, not account
+ * size.
+ *
+ * Two pieces of state, so we can distinguish three cases per model id:
+ *   - `membership[id]` present, non-empty  → engaged (has these types)
+ *   - `membership[id]` present, empty set  → queried, NOT engaged (known)
+ *   - `id` absent from `queried`            → unknown / not yet queried
+ *
+ * `queried` is the source of truth for "known". `membership[id]` holds the types.
+ */
+
+export type EngagedModelType = ModelEngagementType | 'Recommended';
+
+/** The bounded endpoint's response shape (a subset of the queried ids per type). */
+export type EngagedModelsByIdsResult = Partial<Record<EngagedModelType, number[]>>;
+
+interface EngagedModelsState {
+  /** modelId → set of engagement types (only for ids that have been observed). */
+  membership: Record<number, ReadonlySet<EngagedModelType>>;
+  /** modelIds we have definitive knowledge about (queried or optimistically written). */
+  queried: ReadonlySet<number>;
+
+  /** Toggle a single (modelId, type) on/off. Marks the id as known. */
+  setMembership: (modelId: number, type: EngagedModelType, on: boolean) => void;
+  /** Replace the full type-set for a model (used by rollback). Marks the id known. */
+  replaceMembership: (modelId: number, types: Iterable<EngagedModelType>) => void;
+  /**
+   * Fold a server result into the store. `record` is the per-type id lists from
+   * the endpoint; `queriedIds` are ALL ids that were asked about — every one of
+   * them is marked known even when absent from `record` (→ known-not-engaged).
+   */
+  applyServerResult: (record: EngagedModelsByIdsResult, queriedIds: number[]) => void;
+  /** Clear everything (tests / sign-out). */
+  reset: () => void;
+}
+
+function setsEqual(a: ReadonlySet<EngagedModelType> | undefined, b: ReadonlySet<EngagedModelType>) {
+  if (!a || a.size !== b.size) return false;
+  for (const v of b) if (!a.has(v)) return false;
+  return true;
+}
+
+export const useEngagedModelsStore = create<EngagedModelsState>((set) => ({
+  membership: {},
+  queried: new Set<number>(),
+
+  setMembership: (modelId, type, on) =>
+    set((state) => {
+      const prev = state.membership[modelId];
+      const next = new Set<EngagedModelType>(prev ?? []);
+      if (on) next.add(type);
+      else next.delete(type);
+
+      const alreadyKnown = state.queried.has(modelId);
+      // Nothing changed and the id was already known — keep refs stable so we
+      // don't fan a selector run out to every consumer.
+      if (alreadyKnown && setsEqual(prev, next)) return state;
+
+      const queried = alreadyKnown ? state.queried : new Set(state.queried).add(modelId);
+      return { membership: { ...state.membership, [modelId]: next }, queried };
+    }),
+
+  replaceMembership: (modelId, types) =>
+    set((state) => {
+      const next = new Set<EngagedModelType>(types);
+      const alreadyKnown = state.queried.has(modelId);
+      if (alreadyKnown && setsEqual(state.membership[modelId], next)) return state;
+      const queried = alreadyKnown ? state.queried : new Set(state.queried).add(modelId);
+      return { membership: { ...state.membership, [modelId]: next }, queried };
+    }),
+
+  applyServerResult: (record, queriedIds) =>
+    set((state) => {
+      // Start every queried id at an empty set → any id absent from `record`
+      // becomes known-not-engaged (distinct from unknown).
+      const byId = new Map<number, Set<EngagedModelType>>();
+      for (const id of queriedIds) byId.set(id, new Set());
+
+      for (const [type, ids] of Object.entries(record) as [EngagedModelType, number[] | undefined][]) {
+        if (!ids) continue;
+        for (const id of ids) {
+          let s = byId.get(id);
+          if (!s) {
+            // Defensive: server returned an id we didn't ask about — still record it.
+            s = new Set();
+            byId.set(id, s);
+          }
+          s.add(type);
+        }
+      }
+
+      const membership = { ...state.membership };
+      const queried = new Set(state.queried);
+      for (const [id, s] of byId) {
+        membership[id] = s;
+        queried.add(id);
+      }
+      return { membership, queried };
+    }),
+
+  reset: () => set({ membership: {}, queried: new Set<number>() }),
+}));
+
+// ---------------------------------------------------------------------------
+// Non-reactive reads (for imperative call sites: optimistic handlers, batcher).
+// ---------------------------------------------------------------------------
+
+export function isModelEngaged(modelId: number, type: EngagedModelType): boolean {
+  return useEngagedModelsStore.getState().membership[modelId]?.has(type) ?? false;
+}
+
+export function isModelQueried(modelId: number): boolean {
+  return useEngagedModelsStore.getState().queried.has(modelId);
+}
+
+export function getEngagedModelTypes(modelId: number): EngagedModelType[] {
+  return [...(useEngagedModelsStore.getState().membership[modelId] ?? [])];
+}
+
+/** Snapshot the current type-set for a model (a detached clone for rollback). */
+export function snapshotMembership(modelId: number): Set<EngagedModelType> {
+  return new Set(useEngagedModelsStore.getState().membership[modelId] ?? []);
+}
+
+/** Restore a previously-snapshotted type-set (rollback). */
+export function restoreMembership(modelId: number, snapshot: Iterable<EngagedModelType>): void {
+  useEngagedModelsStore.getState().replaceMembership(modelId, snapshot);
+}
+
+// ---------------------------------------------------------------------------
+// Reactive selector hooks.
+// ---------------------------------------------------------------------------
+
+export function useIsEngaged(modelId: number, type: EngagedModelType): boolean {
+  return useEngagedModelsStore((s) => s.membership[modelId]?.has(type) ?? false);
+}
+
+export function useEngagedTypes(modelId: number): EngagedModelType[] {
+  return useEngagedModelsStore(useShallow((s) => [...(s.membership[modelId] ?? [])]));
+}


### PR DESCRIPTION
## PR2 — client normalized membership store + batched hook

**🔴 Stacked on #3028 — merge #3028 first, then rebase this onto `main`.** The base of this PR is `zach/engaged-models-by-ids` (PR #3028), which adds the `user.getEngagedModelsByIds({ modelIds ≤200 })` endpoint this PR consumes. Based off main, typecheck would fail (the endpoint wouldn't exist).

### Why
`user.getEngagedModels` is unbounded — it returns a user's ENTIRE engagement history (a whale's ~450k ids → 3.75 MB synchronous serialize → froze an api-primary pod ~6s → liveness-killed). PR1 (#3028) added the bounded `getEngagedModelsByIds` endpoint. This PR migrates the **single-model** client read callers onto it via a normalized store, so each caller only asks membership for the models **on screen** — bounding the payload by visible-set size, not account size.

### What
**New**
- `src/store/engaged-models.store.ts` — zustand store: `membership: Record<modelId, Set<EngagedModelType>>` + `queried: Set<modelId>` (distinguishes *unknown* / *known-not-engaged* / *engaged*). Mutators `setMembership`, `replaceMembership`, `applyServerResult`, snapshot/restore; reactive selectors `useIsEngaged` / `useEngagedTypes`.
- `src/store/engaged-models.optimistic.ts` — semantic optimistic mutators, one per action, mirroring the **exact** legacy toggle semantics.
- `src/hooks/useEngagedModelMembership.ts` — DataLoader-in-React batcher: coalesces ids requested in one microtask, drops ids already known, chunks to ≤200, issues **one** `getEngagedModelsByIds` query per chunk, folds the result into the store. Unauthenticated → no query. `useEngagedModelsMembership(ids[])` + single-model `useEngagedModelMembership(id)`.

**Migrated single-model callers** → `useEngagedModelMembership` + store reads: model detail page, `ResourceReviewThumbBadge`, `ToggleModelNotification`, `ModelVersionDetails`, `ImageResources` (resource list). Deleted the stray no-op `getEngagedModels.cancel()` in `EarlyAccessAlert` (it actually uses `getEngagedModelVersions`).

**Optimistic rewire** (`resourceReview.utils.ts` + the two notify toggles): **additive dual-write** — see note below.

### 🔎 Two deliberate deviations from the plan text (verified against the code)
1. **`toggleFavorite` writes `Recommended`+`Notify`, not `Favorite`.** On the client a "favorite"/"like" *is* a `Recommended` resource review — the model page reads `isFavorite` off `Recommended`; the `Favorite` ModelEngagement enum value is legacy and is written by none of these actions. I preserved the **exact** current behavior rather than the plan's literal `'Favorite'`.
2. **Optimistic rewire is additive dual-write, not a replace.** The feed callers (`useReviewedModelIds` → `ModelCard`, `ResourceSelectCard`, `ModelCategoryCard`) still read the legacy `getEngagedModels(undefined)` cache with `staleTime: Infinity`. Removing the old `setData(undefined)` writes would regress those surfaces (e.g. favoriting from a feed card wouldn't update its own indicator). So each mutation now writes **both** the legacy cache (feeds) **and** the store (migrated callers). PR3 migrates the feeds; PR4 removes the old endpoint + the dual writes.

Also: `create`/`update`/`delete` review keep their existing `onSuccess` timing (server-confirmed) — `update` in particular *can't* be `onMutate` because `modelId` only arrives in the server response. `toggleFavorite` + `toggleNotify` are `onMutate` optimistic with `onError` snapshot rollback.

### Untouched (later PRs)
Feed callers (`useReviewedModelIds`, `ModelCategoryCard`) and the old `getEngagedModels` endpoint are intentionally left on the old path — PR3 migrates feeds, PR4 deletes the endpoint. Additive migration.

### Tests — 43 new, all passing (`vitest run --project unit`)
- **Store (10):** setMembership on/off; multi-type per model; unknown vs known-not-engaged vs engaged; `applyServerResult` marks queried-but-absent ids known; reference-stable no-op; reactive subscription; snapshot/restore.
- **Optimistic (23) — the critical suite:** each of create/update/delete/favorite/notify toggles the exact types; parametrized rollback (snapshot → apply → restore) for all seven paths; **no cross-model contamination** (mutating X never touches Y).
- **Batcher + React hook (10):** N requests one tick → one query with deduped union; already-known ids not refetched; chunking at >200 (200/200/50); failed fetch leaves ids unknown to retry; unauthenticated → no query; hook reads membership reactively; non-positive id guarded.

**Typecheck:** `tsc --noEmit` (8 GB heap) clean across the whole repo, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Revision 2 — audit fixes (F1 / F2 / F3)

Adversarial audit found one root cause with three faces: the store is populated asynchronously per-id by the batched fetch with **no coordination against optimistic user actions during the fetch window**. Fixed at the root:

**F1 — gate controls on KNOWN membership (the user-visible regression).** While a page's by-ids fetch was in flight the store was cold → `isModelEngaged` returned `false` (unknown treated as not-engaged) → a control that was actually ON rendered "off" and a click sent the OPPOSITE toggle (`type: undefined` → server deletes the existing row). The hook now exposes **`isKnown`** (id in the store's `queried` set — a server result landed OR an optimistic write set it). Every migrated toggle control blocks the click + shows a loading affordance until membership is known: `ToggleModelNotification`, `ModelVersionDetails` notify button, the model-page favorite badge, and `ResourceReviewThumbBadge`. (`ImageResources` is a read-only stat badge — no toggle to block; it self-corrects reactively.)

**F2 — dirty/generation guard in the store.** `applyServerResult` unconditionally overwrote membership, so a by-ids result landing after the user mutated that id within the RTT clobbered the optimistic write (and, being `queried`, never refetched → stuck stale). A module-level dirty-set now records ids mutated locally (optimistic write / rollback via `setMembership`/`replaceMembership`); `applyServerResult` **skips** those ids, so a local write always wins over an in-flight snapshot. Cleared by `reset()`.

**F3 — create/update derive direction from the caller, not the cold store.** `applyReviewCreated`/`applyReviewUpdated` computed `shouldRemove` from `isModelEngaged` (cold store) → wrong direction when the store wasn't warm. They now take `alreadyRecommended` from the caller — the warm legacy `previousEngaged.Recommended` snapshot — keeping exact parity with the legacy dual-write.

**Preserved (verified):** favorite = `Recommended`+`Notify` semantics, per-action parity, the dual-write to the legacy `getEngagedModels` cache (feed callers still read it), `onError` rollback restoring BOTH caches, the old endpoint untouched.

**Tests — added the missing race coverage** (the existing 43 used known seeds and never exercised the in-flight-fetch-races-a-mutation path):
- **F1 known-gating (hook):** `isKnown=false` while the fetch is in flight (control gated), `true` + reflects ON once it resolves; per-id in the multi-model form; an optimistic write makes an id known immediately.
- **F2 race (store + hook through the real batcher):** user mutates X while X's fetch is in flight → the now-stale server result is skipped → store ends in the user's intended state, X stays consistent/known.
- **F3 direction (optimistic):** create/update with a store that DISAGREES with the caller → the caller-supplied direction wins.

All existing tests kept green. **Unit suite: 54/54 pass** across the three engaged-models test files (was 43). Full `tsc --noEmit` (8 GB heap) clean, 0 errors.


## Revision 3 — fix unauth/error stuck-control (re-audit 🔴)

The re-audit caught a broadly-visible regression introduced by Revision 2's own F1 fix, plus a related dead-control edge:

**🔴 F1-unauth — logged-out login funnel was broken.** Two controls gate via Mantine `loading={isPending || !isKnown}`, and Mantine sets `disabled = disabled || loading`, so `!isKnown` renders the button **disabled**. The membership query is auth-gated (`enabled = !!currentUser`), so `isKnown` was **false forever for logged-out users** → the notify bell (`ToggleModelNotification`, `ModelVersionDetails`) was permanently disabled → `LoginRedirect` (which works by cloning `onClick` onto the element) could never fire → **a logged-out visitor could not be prompted to log in** on any model page. Fixed **centrally in the hook**: `isKnown` returns **true when there is no `currentUser`** (an unauth user has no membership to toggle wrongly; nothing is ever queried; LoginRedirect intercepts the click before any mutation cb runs). Authed gating is untouched — `isKnown` only short-circuits when `!currentUser`. One central change covers both disabled controls *and* the two cursor-only controls consistently, no per-control edits. (The favorite/`ResourceReviewThumbActions` cursor-only controls were never `disabled`, so LoginRedirect already fired for them; the central change just makes them cleaner for unauth.)

**F2-error — an errored fetch left the control permanently dead.** The batcher's `onRejected` was a no-op, so a failed `getEngagedModelsByIds` fetch left the ids unknown forever. A component that stays mounted (deps unchanged → its effect never re-fires) never re-requests them → `disabled = !isKnown` stayed true with no retry. `onRejected` now marks the ids **known-not-engaged** (`applyServerResult({}, ids)`) so the control becomes actionable. The F2 dirty-guard still protects any id the user mutated meanwhile. Accepted trade-off: in the rare error case the F1 wrong-direction risk returns for a genuinely-ON model — a usable button beats a dead one, and the optimistic dual-write self-heals on the next interaction.

**F3 — documented the cold-cache edge (no code change).** PR3 removed this page's own `getEngagedModels.useQuery`, so the legacy cache `alreadyRecommended` reads from is now cold on directly-loaded model pages. Kept the caller-derived direction: both dual-writes consume the **one shared `previousEngaged` snapshot**, so they stay consistent with each other (the Preserve invariant). Sourcing direction from the store instead would warm this case but split the two writes' direction (store warm / legacy cold) — a worse divergence bug. Accepted narrow edge (documented in-code): re-affirming an already-recommended model won't toggle off until a feed warms the cache.

**Tests: 54 → 59.** New: unauth `isKnown=true` (single + multi + a control harness proving the logged-out button is **not disabled** so the click reaches LoginRedirect); authed fetch-error leaves the control **enabled**, not dead-locked; the dirty-guard survives the error path. Existing failed-fetch test updated to the new mark-known behavior. **Unit suite: 59/59 pass** across the three engaged-models files. Full `tsc --noEmit` (8 GB heap) clean, 0 errors.
