### PR TITLE
fix(security): parameterize SQL injection in tag voting and article search

### DIFF
--- a/src/server/services/__tests__/tag.service.security.test.ts
+++ b/src/server/services/__tests__/tag.service.security.test.ts
@@ -1,0 +1,92 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const { executeRaw, queryRaw } = vi.hoisted(() => ({
+  executeRaw: vi.fn(),
+  queryRaw: vi.fn().mockResolvedValue([{ count: 0 }]),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbWrite: { $executeRaw: executeRaw, $queryRaw: queryRaw },
+  dbRead: {
+    $queryRaw: queryRaw,
+    model: { findFirst: vi.fn().mockResolvedValue({ userId: 1 }) },
+    image: { findFirst: vi.fn().mockResolvedValue({ userId: 1 }) },
+  },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { del: vi.fn(), packed: {} },
+  sysRedis: { del: vi.fn() },
+  REDIS_KEYS: { SYSTEM: { TAG_RULES: 't', CATEGORIES: 'c' } },
+  REDIS_SYS_KEYS: { SYSTEM: {} },
+}));
+vi.mock('~/server/redis/caches', () => ({ imageTagsCache: { bust: vi.fn() } }));
+vi.mock('~/server/services/system-cache', () => ({
+  getCategoryTags: vi.fn(),
+  getReplacedTagIds: vi.fn(),
+  getSystemTags: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('~/server/services/tagsOnImageNew.service', () => ({ upsertTagsOnImageNew: vi.fn() }));
+vi.mock('~/server/services/user-preferences.service', () => ({
+  HiddenImages: { refreshCache: vi.fn() },
+  HiddenModels: { refreshCache: vi.fn() },
+  ImplicitHiddenImages: { refreshCache: vi.fn() },
+}));
+vi.mock('~/server/utils/cache-helpers', () => ({ fetchThroughCache: vi.fn() }));
+
+import { addTagVotes, removeTagVotes, deleteTags } from '../tag.service';
+
+// A tag name crafted to break out of a naive `IN ('...')` interpolation.
+const INJECTION = `x') UNION SELECT id FROM "Tag" WHERE ('1'='1`;
+
+/** A Prisma.Sql exposes `.sql` (text with $N placeholders) and `.values` (bound params). */
+function sqlTextOf(arg: any): string {
+  return typeof arg?.sql === 'string' ? arg.sql : String(arg);
+}
+function valuesOf(arg: any): unknown[] {
+  return Array.isArray(arg?.values) ? arg.values : [];
+}
+
+describe('tag.service SQL injection guards', () => {
+  beforeEach(() => {
+    executeRaw.mockClear();
+    queryRaw.mockClear();
+  });
+
+  it('removeTagVotes binds tag names as a parameter, never interpolates them', async () => {
+    await removeTagVotes({ userId: 5, type: 'image', id: 42, tags: [INJECTION] });
+
+    const arg = executeRaw.mock.calls[0][0];
+    expect(sqlTextOf(arg)).not.toContain(INJECTION);
+    expect(sqlTextOf(arg)).toContain('ANY');
+    // The array of names must appear as a bound value.
+    expect(valuesOf(arg)).toContainEqual([INJECTION]);
+  });
+
+  it('addTagVotes binds tag names as a parameter in both the insert and the moderation check', async () => {
+    await addTagVotes({ userId: 5, type: 'image', id: 42, tags: [INJECTION], vote: 1 });
+
+    const insertArg = executeRaw.mock.calls[0][0];
+    expect(sqlTextOf(insertArg)).not.toContain(INJECTION);
+    expect(valuesOf(insertArg)).toContainEqual([INJECTION]);
+
+    const modCheckArg = queryRaw.mock.calls[0][0];
+    expect(sqlTextOf(modCheckArg)).not.toContain(INJECTION);
+    expect(valuesOf(modCheckArg)).toContainEqual([INJECTION]);
+  });
+
+  it('deleteTags binds tag names as a parameter', async () => {
+    await deleteTags({ tags: [INJECTION] });
+
+    const deleteArg = executeRaw.mock.calls[0][0];
+    expect(sqlTextOf(deleteArg)).not.toContain(INJECTION);
+    expect(valuesOf(deleteArg)).toContainEqual([INJECTION]);
+  });
+
+  it('numeric tag ids bind as an int array (no name subquery)', async () => {
+    await removeTagVotes({ userId: 5, type: 'model', id: 42, tags: [7, 8] });
+
+    const arg = executeRaw.mock.calls[0][0];
+    expect(sqlTextOf(arg)).toContain('int[]');
+    expect(valuesOf(arg)).toContainEqual([7, 8]);
+  });
+});

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -193,7 +193,7 @@ export const getArticles = async ({
     const AND: Prisma.Sql[] = [];
 
     if (query) {
-      AND.push(Prisma.raw(`a."title" ILIKE '%${query}%'`));
+      AND.push(Prisma.sql`a."title" ILIKE ${'%' + query + '%'}`);
     }
     if (!!tags?.length) {
       AND.push(

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -511,17 +511,15 @@ const clearCache = async (userId: number, entityType: TagVotableEntityType) => {
 export const removeTagVotes = async ({ userId, type, id, tags }: TagVotingInput) => {
   const voteTable = type === 'model' ? 'TagsOnModelsVote' : 'TagsOnImageVote';
   const isTagIds = typeof tags[0] === 'number';
-  const tagIn = (isTagIds ? tags : tags.map((tag) => `'${tag}'`)).join(', ');
-  await dbWrite.$executeRawUnsafe(`
+  const tagCondition = isTagIds
+    ? Prisma.sql`"tagId" = ANY(${tags as number[]}::int[])`
+    : Prisma.sql`"tagId" IN (SELECT id FROM "Tag" WHERE "name" = ANY(${tags as string[]}::text[]))`;
+  await dbWrite.$executeRaw(Prisma.sql`
     DELETE
-    FROM "${voteTable}"
+    FROM "${Prisma.raw(voteTable)}"
     WHERE "userId" = ${userId}
-      AND "${type}Id" = ${id}
-      ${
-        isTagIds
-          ? `AND "tagId" IN (${tagIn})`
-          : `AND "tagId" IN (SELECT id FROM "Tag" WHERE name IN (${tagIn}))`
-      }
+      AND "${Prisma.raw(type)}Id" = ${id}
+      AND ${tagCondition}
   `);
 
   await clearCache(userId, type);
@@ -557,28 +555,29 @@ export const addTagVotes = async ({
 
   vote *= voteWeight;
   const isTagIds = typeof tags[0] === 'number';
-  const tagSelector = isTagIds ? 'id' : 'name';
-  const tagIn = (isTagIds ? tags : tags.map((tag) => `'${tag}'`)).join(', ');
+  const tagMatch = isTagIds
+    ? Prisma.sql`"id" = ANY(${tags as number[]}::int[])`
+    : Prisma.sql`"name" = ANY(${tags as string[]}::text[])`;
   const voteTable = type === 'model' ? 'TagsOnModelsVote' : 'TagsOnImageVote';
-  await dbWrite.$executeRawUnsafe(`
-    INSERT INTO "${voteTable}" ("userId", "tagId", "${type}Id", "vote")
+  await dbWrite.$executeRaw(Prisma.sql`
+    INSERT INTO "${Prisma.raw(voteTable)}" ("userId", "tagId", "${Prisma.raw(type)}Id", "vote")
     SELECT ${userId},
            id,
            ${id},
            ${vote}
     FROM "Tag"
-    WHERE ${tagSelector} IN (${tagIn})
-    ON CONFLICT ("userId", "tagId", "${type}Id") DO UPDATE SET "vote"      = ${vote},
+    WHERE ${tagMatch}
+    ON CONFLICT ("userId", "tagId", "${Prisma.raw(type)}Id") DO UPDATE SET "vote"      = ${vote},
                                                                "createdAt" = NOW()
   `);
 
   // If voting up a tag
   if (vote > 0) {
     // Check if it's a moderation tag
-    const [{ count }] = await dbRead.$queryRawUnsafe<{ count: number }[]>(`
+    const [{ count }] = await dbRead.$queryRaw<{ count: number }[]>(Prisma.sql`
       SELECT COUNT(*)::int "count"
       FROM "Tag"
-      WHERE ${tagSelector} IN (${tagIn})
+      WHERE ${tagMatch}
         AND "type" = 'Moderation'
     `);
     if (count > 0) await clearCache(userId, type); // Clear cache if it is
@@ -595,26 +594,28 @@ export const addTags = async ({ tags, entityIds, entityType, relationship }: Adj
   const isTagIds = typeof tags[0] === 'number';
   // Explicit cast to number[] or string[] to avoid type errors
   const castedTags = isTagIds ? (tags as number[]) : (tags as string[]);
-  const tagSelector = isTagIds ? 'id' : 'name';
-  const tagIn = (isTagIds ? castedTags : castedTags.map((tag) => `'${tag}'`)).join(', ');
+  const tagFilter = (alias: string) =>
+    isTagIds
+      ? Prisma.sql`${Prisma.raw(alias)}."id" = ANY(${castedTags as number[]}::int[])`
+      : Prisma.sql`${Prisma.raw(alias)}."name" = ANY(${castedTags as string[]}::text[])`;
 
   if (entityType === 'model') {
-    await dbWrite.$executeRawUnsafe(`
+    await dbWrite.$executeRaw(Prisma.sql`
       INSERT INTO "TagsOnModels" ("modelId", "tagId")
       SELECT m."id",
              t."id"
       FROM "Model" m
-             JOIN "Tag" t ON t.${tagSelector} IN (${tagIn})
-      WHERE m."id" IN (${entityIds.join(', ')})
+             JOIN "Tag" t ON ${tagFilter('t')}
+      WHERE m."id" = ANY(${entityIds}::int[])
       ON CONFLICT DO NOTHING
     `);
   } else if (entityType === 'image') {
-    const result = await dbWrite.$queryRaw<{ imageId: number; tagId: number }[]>`
+    const result = await dbWrite.$queryRaw<{ imageId: number; tagId: number }[]>(Prisma.sql`
       SELECT i."id" AS "imageId",  t."id" AS "tagId"
       FROM "Image" i
-      JOIN "Tag" t ON t.${tagSelector} IN (${tagIn})
-      WHERE i."id" IN (${entityIds.join(', ')});
-    `;
+      JOIN "Tag" t ON ${tagFilter('t')}
+      WHERE i."id" = ANY(${entityIds}::int[]);
+    `);
     await upsertTagsOnImageNew(
       result.map(({ imageId, tagId }) => ({
         imageId,
@@ -625,26 +626,26 @@ export const addTags = async ({ tags, entityIds, entityType, relationship }: Adj
       }))
     );
   } else if (entityType === 'article') {
-    await dbWrite.$executeRawUnsafe(`
+    await dbWrite.$executeRaw(Prisma.sql`
       INSERT INTO "TagsOnArticle" ("articleId", "tagId")
       SELECT a."id",
              t."id"
       FROM "Article" a
-             JOIN "Tag" t ON t.${tagSelector} IN (${tagIn})
-      WHERE a."id" IN (${entityIds.join(', ')})
+             JOIN "Tag" t ON ${tagFilter('t')}
+      WHERE a."id" = ANY(${entityIds}::int[])
       ON CONFLICT DO NOTHING
     `);
   } else if (entityType === 'tag') {
     if (!relationship) throw new Error('Relationship must be specified for tag tagging');
 
-    await dbWrite.$executeRawUnsafe(`
+    await dbWrite.$executeRaw(Prisma.sql`
       INSERT INTO "TagsOnTags" ("fromTagId", "toTagId", type)
       SELECT fromTag."id",
              toTag."id",
-             '${relationship}'::"TagsOnTagsType"
+             ${relationship}::"TagsOnTagsType"
       FROM "Tag" toTag
-             JOIN "Tag" fromTag ON fromTag.${tagSelector} IN (${tagIn})
-      WHERE toTag."id" IN (${entityIds.join(', ')})
+             JOIN "Tag" fromTag ON ${tagFilter('fromTag')}
+      WHERE toTag."id" = ANY(${entityIds}::int[])
       ON CONFLICT DO NOTHING
     `);
 
@@ -713,45 +714,38 @@ export const disableTags = async ({ tags, entityIds, entityType }: AdjustTagsSch
   const isTagIds = typeof tags[0] === 'number';
   // Explicit cast to number[] or string[] to avoid type errors
   const castedTags = isTagIds ? (tags as number[]) : (tags as string[]);
-  const tagIn = (isTagIds ? castedTags : castedTags.map((tag) => `'${tag}'`)).join(', ');
+  const tagIdMatch = (col: string) =>
+    isTagIds
+      ? Prisma.sql`${Prisma.raw(`"${col}"`)} = ANY(${castedTags as number[]}::int[])`
+      : Prisma.sql`${Prisma.raw(
+          `"${col}"`
+        )} IN (SELECT id FROM "Tag" WHERE "name" = ANY(${castedTags as string[]}::text[]))`;
 
   // TODO.fix "disabled" doesnt exist for TagsOnModels, is this being used?
   if (entityType === 'model') {
-    await dbWrite.$executeRawUnsafe(`
+    await dbWrite.$executeRaw(Prisma.sql`
       UPDATE "TagsOnModels"
       SET "disabled" = true
-      WHERE "modelId" IN (${entityIds.join(', ')})
-        ${
-          isTagIds
-            ? `AND "tagId" IN (${tagIn})`
-            : `AND "tagId" IN (SELECT id FROM "Tag" WHERE name IN (${tagIn}))`
-        }
+      WHERE "modelId" = ANY(${entityIds}::int[])
+        AND ${tagIdMatch('tagId')}
     `);
   } else if (entityType === 'image') {
-    const toUpdate = await dbWrite.$queryRawUnsafe<{ imageId: number; tagId: number }[]>(`
+    const toUpdate = await dbWrite.$queryRaw<{ imageId: number; tagId: number }[]>(Prisma.sql`
       SELECT "imageId", "tagId"
       FROM "TagsOnImageDetails"
-      WHERE "imageId" IN (${entityIds.join(', ')})
-        ${
-          isTagIds
-            ? `AND "tagId" IN (${tagIn})`
-            : `AND "tagId" IN (SELECT id FROM "Tag" WHERE name IN (${tagIn}))`
-        }
+      WHERE "imageId" = ANY(${entityIds}::int[])
+        AND ${tagIdMatch('tagId')}
     `);
 
     await upsertTagsOnImageNew(
       toUpdate.map(({ imageId, tagId }) => ({ imageId, tagId, disabled: true, needsReview: false }))
     );
   } else if (entityType === 'tag') {
-    await dbWrite.$executeRawUnsafe(`
+    await dbWrite.$executeRaw(Prisma.sql`
       DELETE
       FROM "TagsOnTags"
-      WHERE "toTagId" IN (${entityIds.join(', ')})
-        ${
-          isTagIds
-            ? `AND "fromTagId" IN (${tagIn})`
-            : `AND "fromTagId" IN (SELECT id FROM "Tag" WHERE name IN (${tagIn}))`
-        }
+      WHERE "toTagId" = ANY(${entityIds}::int[])
+        AND ${tagIdMatch('fromTagId')}
     `);
 
     // Bust cache for tag rules (since we can't easily check the type)
@@ -794,22 +788,23 @@ export const deleteTags = async ({ tags }: DeleteTagsSchema) => {
   const isTagIds = typeof tags[0] === 'number';
   // Explicit cast to number[] or string[] to avoid type errors
   const castedTags = isTagIds ? (tags as number[]) : (tags as string[]);
-  const tagSelector = isTagIds ? 'id' : 'name';
-  const tagIn = (isTagIds ? castedTags : castedTags.map((tag) => `'${tag}'`)).join(', ');
+  const tagMatch = isTagIds
+    ? Prisma.sql`"id" = ANY(${castedTags as number[]}::int[])`
+    : Prisma.sql`"name" = ANY(${castedTags as string[]}::text[])`;
 
   // Get affected images before deletion (cascade will delete ImageTag records)
-  const affectedImages = await dbWrite.$queryRaw<{ imageId: number }[]>`
+  const affectedImages = await dbWrite.$queryRaw<{ imageId: number }[]>(Prisma.sql`
     SELECT DISTINCT "imageId"
     FROM "ImageTag"
     WHERE "tagId" IN (
-      SELECT id FROM "Tag" WHERE ${tagSelector} IN (${tagIn})
+      SELECT id FROM "Tag" WHERE ${tagMatch}
     )
-  `;
+  `);
 
-  await dbWrite.$executeRawUnsafe(`
+  await dbWrite.$executeRaw(Prisma.sql`
     DELETE
     FROM "Tag"
-    WHERE ${tagSelector} IN (${tagIn})
+    WHERE ${tagMatch}
   `);
 
   // Bust cache for affected images


### PR DESCRIPTION
## Summary

Closes a SQL injection reachable by **any authenticated user**. `addTagVotes`/`removeTagVotes` (both `protectedProcedure`) interpolated user-supplied tag *names* directly into `$executeRawUnsafe` `IN (...)` clauses; a crafted tag name in a vote request broke out of the string literal. The public article search interpolated the raw `query` string into an `ILIKE` via `Prisma.raw`. The same class of bug in the moderator-gated `addTags`/`disableTags`/`deleteTags` is folded in since they shared the pattern.

## Fix

Switched every affected query to `$executeRaw`/`$queryRaw` with `Prisma.sql`, binding all user values as parameters (`name = ANY($n::text[])`, `id = ANY($n::int[])`, `title ILIKE $n`). Server-constant identifiers (vote table name, entity id column, tag relationship enum) remain interpolated via `Prisma.raw`. Follows the existing `= ANY(...)` idiom used across image/model/strike services and the #2419 precedent.

## Notes

- No schema or query-result changes; same rows matched, names still lowercased upstream.
- Incidentally repairs two already-broken raw templates that were silently mis-compiling before: the name-based `deleteTags` cache-bust (bound `${tagSelector}` as a param so it never matched, meaning image caches were never busted after a tag delete) and the `addTags` image branch (compiled to invalid `t.$1` and threw at runtime). Both now correct.
- Adds a regression test that feeds a `') UNION SELECT ...` payload as a tag name and asserts it lands in the bound `.values`, never the SQL text.

**User-reachable — merge and deploy promptly.**