### PR TITLE
perf(model.getAll): widen image cap 8→12 + instrument silent browsing-level feed-drop

### DIFF
--- a/src/components/HiddenPreferences/__tests__/useApplyHiddenPreferences.test.ts
+++ b/src/components/HiddenPreferences/__tests__/useApplyHiddenPreferences.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the telemetry sink so the filter's aggregate emit is observable without touching Faro.
+vi.mock('~/utils/faro/feedDrop', () => ({ emitFeedNoImagesDrop: vi.fn() }));
+
+import { filterPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import type { HiddenPreferencesState } from '~/components/HiddenPreferences/HiddenPreferencesProvider';
+import { emitFeedNoImagesDrop } from '~/utils/faro/feedDrop';
+
+/**
+ * Covers the browsing-level feed-drop instrumentation wired into the `case 'models'` branch:
+ * the filter emits exactly ONE aggregate telemetry event per call (never per dropped model),
+ * carrying the per-page `{ droppedNoImages, total, browsingLevel }` counts. The emit/sampling/
+ * shape contract itself is covered in `~/utils/faro/__tests__/feedDrop.test.ts`.
+ *
+ * Setup: browsingLevel = 1 (a single-bit "SFW" level). A model row with `nsfwLevel: 1` passes
+ * the row gate; its images are then kept iff `nsfwLevel & 1 !== 0`. So an image of `nsfwLevel: 2`
+ * is filtered out — a model whose ONLY image is `nsfwLevel: 2` drops for `noImages`.
+ */
+
+const BROWSING_LEVEL = 1;
+
+const emptyPrefs = (): HiddenPreferencesState => ({
+  hiddenUsers: new Map(),
+  hiddenTags: new Map(),
+  hiddenModels: new Map(),
+  hiddenModel3Ds: new Map(),
+  hiddenImages: new Map(),
+  hiddenLoading: false,
+  moderatedTags: [],
+  systemHiddenTags: new Map(),
+});
+
+let nextId = 1;
+/** A model that KEEPS (has a browsing-safe image) or DROPS (only unsafe images). */
+const makeModel = (kind: 'keep' | 'drop') => ({
+  id: nextId++,
+  user: { id: 9999 },
+  nsfwLevel: 1, // intersects browsingLevel → row passes the browsing-level gate
+  nsfw: false,
+  name: 'm',
+  images: [{ id: nextId++, nsfwLevel: kind === 'keep' ? 1 : 2 }],
+});
+
+const runModels = (models: ReturnType<typeof makeModel>[]) =>
+  filterPreferences({
+    type: 'models',
+    data: models,
+    hiddenPreferences: emptyPrefs(),
+    browsingLevel: BROWSING_LEVEL,
+    currentUser: null as never,
+    canViewNsfw: true,
+  });
+
+describe('filterPreferences — models browsing-level drop instrumentation', () => {
+  beforeEach(() => {
+    vi.mocked(emitFeedNoImagesDrop).mockClear();
+    nextId = 1;
+  });
+
+  it('emits ONE aggregate event with droppedNoImages=M, total=N (not one per dropped model)', () => {
+    // 5 models in, 2 drop for noImages, 3 survive.
+    const models = [
+      makeModel('keep'),
+      makeModel('drop'),
+      makeModel('keep'),
+      makeModel('drop'),
+      makeModel('keep'),
+    ];
+
+    const { items, hidden } = runModels(models);
+
+    // sanity: the filter itself dropped 2 and kept 3
+    expect(hidden.noImages).toBe(2);
+    expect(items).toHaveLength(3);
+
+    // exactly ONE emit for the whole page — proves it is aggregate, not per dropped model
+    expect(emitFeedNoImagesDrop).toHaveBeenCalledTimes(1);
+    expect(emitFeedNoImagesDrop).toHaveBeenCalledWith({
+      droppedNoImages: 2,
+      total: 5,
+      browsingLevel: BROWSING_LEVEL,
+    });
+  });
+
+  it('still emits exactly once (droppedNoImages=0) when nothing drops — gating is delegated to the sink', () => {
+    // The M===0 "stay silent" decision lives in emitFeedNoImagesDrop (mocked here); the filter
+    // always makes exactly one aggregate call, so there is no per-model emit path to regress.
+    const { hidden } = runModels([makeModel('keep'), makeModel('keep')]);
+
+    expect(hidden.noImages).toBe(0);
+    expect(emitFeedNoImagesDrop).toHaveBeenCalledTimes(1);
+    expect(emitFeedNoImagesDrop).toHaveBeenCalledWith({
+      droppedNoImages: 0,
+      total: 2,
+      browsingLevel: BROWSING_LEVEL,
+    });
+  });
+});

--- a/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
+++ b/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
@@ -8,6 +8,7 @@ import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { NsfwLevel } from '~/server/common/enums';
 import { parseBitwiseBrowsingLevel } from '~/shared/constants/browsingLevel.constants';
 import { Flags } from '~/shared/utils/flags';
+import { emitFeedNoImagesDrop } from '~/utils/faro/feedDrop';
 import { getBlockedNsfwWords, hasNsfwWords } from '~/utils/metadata/audit-base';
 import { isDefined, paired } from '~/utils/type-guards';
 
@@ -125,7 +126,9 @@ type FilterPreferencesProps<TKey, TData> = {
   minorDisabled?: boolean;
 };
 
-function filterPreferences<
+// Exported for unit tests (the `case 'models'` browsing-level drop counting + the single
+// aggregate `emitFeedNoImagesDrop` call). Pure aside from that best-effort telemetry emit.
+export function filterPreferences<
   TKey extends keyof BaseDataTypeMap,
   TData extends BaseDataTypeMap[TKey]
 >({
@@ -272,6 +275,18 @@ function filterPreferences<
             : null;
         })
         .filter(isDefined);
+
+      // Aggregate telemetry for the SILENT browsing-level feed-drop: one event per filter
+      // call (NOT per dropped model) carrying the per-page drop count, sampled + gated on
+      // `noImages > 0`. `hidden.noImages` is excluded from `hiddenCount`, so this is the only
+      // way the drop rate is measurable. Best-effort — never throws. See feedDrop.ts for what
+      // it measures, its limitation (can't isolate the getAll cap's contribution), the
+      // sampling, and the Loki watch query.
+      emitFeedNoImagesDrop({
+        droppedNoImages: hidden.noImages,
+        total: value.length,
+        browsingLevel,
+      });
 
       return { items: models, hidden };
     case 'images':

--- a/src/server/utils/__tests__/model-getall-images.test.ts
+++ b/src/server/utils/__tests__/model-getall-images.test.ts
@@ -15,9 +15,9 @@ const makeImages = (n: number) =>
 
 describe('model-getall-images', () => {
   it('caps to at most GET_ALL_IMAGES_PER_MODEL', () => {
-    // Pinned: the browse cap is 8 (raised from 3 after the browsing-level
-    // feed-drop review — see the constant's doc).
-    expect(GET_ALL_IMAGES_PER_MODEL).toBe(8);
+    // Pinned: the browse cap is 12 (raised 3 → 8 → 12 across the browsing-level
+    // feed-drop reviews — widens the browsing-safe band; see the constant's doc).
+    expect(GET_ALL_IMAGES_PER_MODEL).toBe(12);
     const out = capGetAllModelImages(makeImages(20));
     expect(out.length).toBe(GET_ALL_IMAGES_PER_MODEL);
   });
@@ -25,7 +25,7 @@ describe('model-getall-images', () => {
   it('keeps the leading images in order (browse UI reads images[0])', () => {
     const images = makeImages(20);
     const out = capGetAllModelImages(images);
-    expect(out.map((x) => x.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(out.map((x) => x.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
     // identity preserved (not re-cloned) so downstream `images[0]` is the same ref
     expect(out[0]).toBe(images[0]);
   });

--- a/src/server/utils/model-getall-images.ts
+++ b/src/server/utils/model-getall-images.ts
@@ -6,24 +6,28 @@
  * model (the shared `imagesForModelVersionsCache` size) bloated the tRPC payload
  * ~5-8x (1.5-3 MB responses serialized synchronously on the Node event loop — a
  * high-volume source of event-loop-freeze). Capping the RESPONSE removes the
- * bulk of that payload (~60% at this cap).
+ * bulk of that payload (~40% at this cap).
  *
- * Set to 8 (not 1, and raised from an initial 3 after review): the shared image
- * array is browsing-level-AGNOSTIC, and the client-side filter
- * (`useApplyHiddenPreferences`, models path) iterates it to pick the first image
- * that passes the VIEWER's browsing level — DROPPING the model from the feed if
- * none survive. A too-tight cap would hide mixed-level models from
- * restricted-browsing (SFW-mode) viewers whose first safe image sits past the
- * cap. 8 keeps a browsing-safe image in range with high probability while still
- * shedding most of the payload; it is also headroom for any undocumented
- * external `/api/trpc/model.getAll` token-consumer. Tune here if feed drops
- * appear (still << the shared cache's 20).
+ * Set to 12 (not 1, and raised from an initial 3 → 8 → 12 across reviews): the
+ * shared image array is browsing-level-AGNOSTIC and ordered `postId,index` (NOT
+ * safe-first), and the client-side filter (`useApplyHiddenPreferences`, models
+ * path) iterates it to pick the first image that passes the VIEWER's browsing
+ * level — DROPPING the model from the feed if none survive. A too-tight cap
+ * hides mixed-level models from restricted-browsing (SFW-mode) viewers whose
+ * only browsing-safe image sits past the cap. 12 widens the safe band (more of
+ * each model's images stay in range, so a browsing-safe one survives with higher
+ * probability) while still shedding most of the payload; it is also headroom for
+ * any undocumented external `/api/trpc/model.getAll` token-consumer. The drop is
+ * SILENT (`hidden.noImages` is excluded from `hiddenCount`) — it is now measured
+ * client-side via `emitFeedNoImagesDrop` (`~/utils/faro/feedDrop`); WATCH that
+ * rate (Loki `event_name="feed_noimages_drop"`) before tuning further. Tune here
+ * if feed drops rise (still << the shared cache's 20).
  *
  * NOTE: this caps only the getAll response mapping. The shared image cache
  * (`getImagesForModelVersionCache` / `imagesForModelVersionsCache`, 20 images)
  * is untouched — model-detail pages, auctions, and other consumers still get 20.
  */
-export const GET_ALL_IMAGES_PER_MODEL = 8;
+export const GET_ALL_IMAGES_PER_MODEL = 12;
 
 /**
  * Cap a per-model images array to the browse-feed limit. Returns a NEW array

--- a/src/utils/faro/__tests__/feedDrop.test.ts
+++ b/src/utils/faro/__tests__/feedDrop.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  emitFeedNoImagesDrop,
+  FEED_DROP_DEFAULT_SAMPLE_RATE,
+  FEED_NOIMAGES_DROP_EVENT,
+} from '~/utils/faro/feedDrop';
+
+/**
+ * Unit tests for the silent browsing-level feed-drop telemetry (`emitFeedNoImagesDrop`).
+ * The counting integration (that the `case 'models'` filter feeds it the right aggregate) is
+ * covered in `useApplyHiddenPreferences.test.ts`; this covers the emit/sampling/shape contract.
+ */
+
+describe('emitFeedNoImagesDrop', () => {
+  it('emits ONE event with the aggregate shape when a model was dropped', () => {
+    const pushEvent = vi.fn();
+    emitFeedNoImagesDrop(
+      { droppedNoImages: 3, total: 20, browsingLevel: 1 },
+      { pushEvent, sampleRate: 1 } // sampleRate 1 → deterministic (no RNG gate)
+    );
+    expect(pushEvent).toHaveBeenCalledTimes(1);
+    expect(pushEvent).toHaveBeenCalledWith(FEED_NOIMAGES_DROP_EVENT, {
+      droppedNoImages: '3',
+      total: '20',
+      browsingLevel: '1',
+      sampleRate: '1',
+    });
+  });
+
+  it('is SILENT when nothing was dropped (droppedNoImages === 0)', () => {
+    const pushEvent = vi.fn();
+    emitFeedNoImagesDrop(
+      { droppedNoImages: 0, total: 20, browsingLevel: 1 },
+      { pushEvent, sampleRate: 1 }
+    );
+    expect(pushEvent).not.toHaveBeenCalled();
+  });
+
+  it('is SILENT for a negative/absent drop count', () => {
+    const pushEvent = vi.fn();
+    emitFeedNoImagesDrop(
+      { droppedNoImages: -1, total: 20, browsingLevel: 1 },
+      { pushEvent, sampleRate: 1 }
+    );
+    expect(pushEvent).not.toHaveBeenCalled();
+  });
+
+  it('honours the sample-rate gate: emits when RNG < rate, drops when RNG >= rate', () => {
+    const dropped = vi.fn();
+    emitFeedNoImagesDrop(
+      { droppedNoImages: 1, total: 10, browsingLevel: 1 },
+      { pushEvent: dropped, sampleRate: 0.05, random: () => 0.9 } // 0.9 >= 0.05 → drop
+    );
+    expect(dropped).not.toHaveBeenCalled();
+
+    const kept = vi.fn();
+    emitFeedNoImagesDrop(
+      { droppedNoImages: 1, total: 10, browsingLevel: 1 },
+      { pushEvent: kept, sampleRate: 0.05, random: () => 0.0 } // 0.0 < 0.05 → emit
+    );
+    expect(kept).toHaveBeenCalledTimes(1);
+    expect(kept).toHaveBeenCalledWith(
+      FEED_NOIMAGES_DROP_EVENT,
+      expect.objectContaining({ sampleRate: '0.05' })
+    );
+  });
+
+  it('includes `surface` when provided and omits it otherwise', () => {
+    const withSurface = vi.fn();
+    emitFeedNoImagesDrop(
+      { droppedNoImages: 2, total: 5, browsingLevel: 3, surface: 'home-block' },
+      { pushEvent: withSurface, sampleRate: 1 }
+    );
+    expect(withSurface).toHaveBeenCalledWith(
+      FEED_NOIMAGES_DROP_EVENT,
+      expect.objectContaining({ surface: 'home-block' })
+    );
+
+    const noSurface = vi.fn();
+    emitFeedNoImagesDrop(
+      { droppedNoImages: 2, total: 5, browsingLevel: 3 },
+      { pushEvent: noSurface, sampleRate: 1 }
+    );
+    expect(noSurface.mock.calls[0][1]).not.toHaveProperty('surface');
+  });
+
+  it('never throws if the telemetry sink throws (best-effort)', () => {
+    const pushEvent = vi.fn(() => {
+      throw new Error('faro down');
+    });
+    expect(() =>
+      emitFeedNoImagesDrop(
+        { droppedNoImages: 1, total: 10, browsingLevel: 1 },
+        { pushEvent, sampleRate: 1 }
+      )
+    ).not.toThrow();
+  });
+
+  it('exposes a default sample rate matching the resource_timing precedent', () => {
+    expect(FEED_DROP_DEFAULT_SAMPLE_RATE).toBe(0.05);
+  });
+});

--- a/src/utils/faro/feedDrop.ts
+++ b/src/utils/faro/feedDrop.ts
@@ -1,0 +1,119 @@
+import { faro } from '@grafana/faro-web-sdk';
+
+/**
+ * Telemetry for the SILENT browsing-level feed-drop in `useApplyHiddenPreferences`
+ * (`case 'models'`).
+ *
+ * WHAT THIS MEASURES — and its limitation (be honest):
+ * The models filter drops a model from the feed when NONE of that model's returned images
+ * survive the VIEWER's browsing level (`hidden.noImages++` then `return null`). That drop is
+ * invisible in product: `hidden.noImages` is deliberately EXCLUDED from the user-facing
+ * `hiddenCount`, so nobody can see how often the feed silently loses models for
+ * restricted-browsing (SFW-mode) viewers. This event makes that drop rate MEASURABLE.
+ *
+ * 🔴 It measures the TOTAL restricted-browsing noImages-drop rate — it does NOT (and CANNOT
+ * from the client) isolate the `model.getAll` image-cap's contribution. The shared image array
+ * is browsing-level-AGNOSTIC and ordered `postId,index` (not safe-first), so a mixed-level
+ * model whose only browsing-safe image sits PAST the cap disappears for SFW viewers. But the
+ * client only ever sees the ≤`GET_ALL_IMAGES_PER_MODEL` post-cap images, so a drop where "the
+ * cap cut the safe image" is indistinguishable here from a drop where "there genuinely is no
+ * browsing-safe image among the returned set". The right use of this signal is to WATCH the
+ * aggregate rate: if it is non-trivial or RISES (e.g. after a cap change), the cap or the
+ * content mix is dropping models for SFW viewers and a server-side browsing-aware slice is
+ * warranted. See `~/server/utils/model-getall-images.ts`.
+ *
+ * VOLUME — this runs on the feed hot path (`useApplyHiddenPreferences` re-filters on every
+ * feed data change, at civitai's request scale). Two gates keep it cheap and non-flooding:
+ *   1. AGGREGATE, not per-model: exactly ONE event per filter call, carrying the per-page
+ *      `{ droppedNoImages, total }` counts — never one event per dropped model.
+ *   2. Only emit when `droppedNoImages > 0` (the common `M === 0` render is silent), then a
+ *      low per-emit `sampleRate` (default 0.05) on the drop-present renders — mirroring
+ *      `ResourceTimingInstrumentation`'s 0.05 default, chosen to keep the shared
+ *      `source="faro-rum"` Loki stream under its ~10 MB/s per-stream ceiling even if SFW-mode
+ *      dropping becomes systemic. Because it is a sample, read the emitted counts as a RATE
+ *      (proportional), not an exact total; the `sampleRate` rides on each event so a query can
+ *      scale.
+ *
+ * WHERE TO WATCH IT (so the metric isn't itself born-invisible) — Faro `pushEvent` lands in
+ * Loki as `kind=event` with `event_name=` + `event_data_*` (see
+ * `claudedocs/faro-rum-logql-query-patterns.md`). Drop-events per browsing level:
+ *
+ *   sum by (event_data_browsingLevel) (
+ *     count_over_time({service_name="civitai-dp-prod", source="faro-rum"}
+ *       |= `kind=event` |= `feed_noimages_drop` [$__auto])
+ *   )
+ *
+ * Scaled models-dropped total (divide by the sample rate, 0.05):
+ *
+ *   sum(sum_over_time({service_name="civitai-dp-prod", source="faro-rum"}
+ *     |= `feed_noimages_drop` | logfmt | unwrap event_data_droppedNoImages [$__range])) / 0.05
+ */
+
+/** Faro event name (→ Loki `event_name="feed_noimages_drop"`). */
+export const FEED_NOIMAGES_DROP_EVENT = 'feed_noimages_drop';
+
+/**
+ * Default per-emit sample rate for drop-present renders. 0.05 matches
+ * `RESOURCE_TIMING_DEFAULTS.sampleRate` — the fraction chosen to keep the shared faro-rum Loki
+ * stream under its ~10 MB/s per-stream ceiling at civitai's concurrency.
+ */
+export const FEED_DROP_DEFAULT_SAMPLE_RATE = 0.05;
+
+export interface FeedNoImagesDropSignal {
+  /** Models dropped from THIS page because no returned image survived the viewer's browsing level. */
+  droppedNoImages: number;
+  /** Total models in the page BEFORE the browsing-level image filter (input length). */
+  total: number;
+  /** The viewer's active (bitwise) browsing level the filter ran at. */
+  browsingLevel: number;
+  /** Optional surface tag (feed / collection / home-block …) if the caller knows it. */
+  surface?: string;
+}
+
+export interface EmitFeedNoImagesDropDeps {
+  /**
+   * The Faro `pushEvent` fn. Defaults to the global faro instance's api (a no-op when Faro is
+   * not initialised — SSR, or the `faro` flag off). Injectable for tests.
+   */
+  pushEvent?: (name: string, attributes: Record<string, string>) => void;
+  /** Injectable RNG — for tests. Defaults to `Math.random`. */
+  random?: () => number;
+  /** Per-emit sample rate in [0, 1]. Defaults to `FEED_DROP_DEFAULT_SAMPLE_RATE`. */
+  sampleRate?: number;
+}
+
+/**
+ * Emit ONE aggregate telemetry event per feed filter call when the browsing-level filter
+ * dropped ≥1 model for `noImages`. Silent when nothing dropped, and sampled otherwise — see the
+ * module doc for the volume rationale + the exact Loki watch query. Best-effort: never throws.
+ */
+export function emitFeedNoImagesDrop(
+  signal: FeedNoImagesDropSignal,
+  deps: EmitFeedNoImagesDropDeps = {}
+): void {
+  const { droppedNoImages, total, browsingLevel, surface } = signal;
+
+  // Gate 1 — only emit when something was actually dropped. The overwhelmingly common
+  // `droppedNoImages === 0` render is silent, so this alone sheds the vast majority of calls.
+  if (!(droppedNoImages > 0)) return;
+
+  // Gate 2 — low sample rate on the remaining (drop-present) renders, so a systemic SFW-mode
+  // drop can't flood the shared faro-rum Loki stream at request scale.
+  const sampleRate = deps.sampleRate ?? FEED_DROP_DEFAULT_SAMPLE_RATE;
+  const random = deps.random ?? Math.random;
+  if (sampleRate < 1 && random() >= sampleRate) return;
+
+  try {
+    const pushEvent = deps.pushEvent ?? faro?.api?.pushEvent?.bind(faro.api);
+    if (!pushEvent) return; // Faro not initialised (SSR / flag off) → no-op.
+    pushEvent(FEED_NOIMAGES_DROP_EVENT, {
+      droppedNoImages: String(droppedNoImages),
+      total: String(total),
+      browsingLevel: String(browsingLevel),
+      sampleRate: String(sampleRate),
+      ...(surface ? { surface } : {}),
+    });
+  } catch {
+    // Telemetry must never break the feed render.
+  }
+}


### PR DESCRIPTION
Fast-follow to #3027 (browse-feed `model.getAll` image cap). Two changes: widen the cap, and make the *silent* browsing-level feed-drop that the cap can worsen **measurable** so a real fix (a browsing-aware server slice) can be decided on data.

## 1. Widen the cap 8 → 12
`src/server/utils/model-getall-images.ts` — `GET_ALL_IMAGES_PER_MODEL` 8 → 12 (payload reduction now ~40%, was ~60% at the tighter cap).

**Why:** the shared per-model image array is browsing-level-**agnostic** and ordered `postId,index` (NOT safe-first). The client filter (`useApplyHiddenPreferences`, models path) picks the first image that passes the *viewer's* browsing level and **drops the model** if none survive. So a mixed-level model whose only browsing-safe image sits **past the cap** disappears for restricted-browsing (SFW-mode) viewers. 12 widens the safe band (more of each model's images stay in range → a browsing-safe one survives with higher probability) while still shedding most of the oversized tRPC payload that #3027 targeted.

## 2. Instrument the silent drop (the point of this PR)
The drop is invisible in product: `hidden.noImages` is **excluded from the user-facing `hiddenCount`**, so nobody can see how often the feed silently loses models for SFW viewers. This wires the app's existing **Grafana Faro RUM** client telemetry (`faro.api.pushEvent`, same sink as ResourceTiming/web-vitals — browser → Loki/Tempo) into the `case 'models'` branch.

- **New util `src/utils/faro/feedDrop.ts`** → `emitFeedNoImagesDrop({ droppedNoImages, total, browsingLevel, surface? })`, event name `feed_noimages_drop`.
- **Aggregate, not per-model:** exactly **one** event per filter call carrying the per-page `{ droppedNoImages, total }` counts — never one per dropped model.
- **Low-overhead / no spam** (this runs on the same feed hot path we've been de-pressurizing): two gates — (1) only emit when `droppedNoImages > 0` (the common `M===0` render is silent → sheds the vast majority of calls), then (2) a low per-emit **sample rate `0.05`**, mirroring `ResourceTimingInstrumentation`'s 0.05 default chosen to keep the shared `source="faro-rum"` Loki stream under its ~10 MB/s per-stream ceiling at civitai's concurrency. Read the counts as a **rate** (proportional); the `sampleRate` rides on each event so a query can scale.

### What it measures — and the honest limitation
It measures the **TOTAL restricted-browsing `noImages`-drop rate**. It does **not** (and *cannot* from the client) isolate the cap's contribution: the client only ever sees the ≤12 post-cap images, so a drop where "the cap cut the safe image" is indistinguishable here from "there genuinely is no browsing-safe image in the returned set". The right use is to **watch the aggregate**: if it's non-trivial or **rises** (e.g. after a cap change), the cap or the content mix is dropping models for SFW viewers and a server-side browsing-aware slice is warranted. (Stated in the module doc + a code comment.)

### Watch query (so the metric isn't itself born-invisible)
Faro `pushEvent` lands in Loki as `kind=event` with `event_name=` + `event_data_*`. Drop-events per browsing level:
```logql
sum by (event_data_browsingLevel) (
  count_over_time({service_name="civitai-dp-prod", source="faro-rum"}
    |= `kind=event` |= `feed_noimages_drop` [$__auto])
)
```
Scaled models-dropped total (divide by the sample rate):
```logql
sum(sum_over_time({service_name="civitai-dp-prod", source="faro-rum"}
  |= `feed_noimages_drop` | logfmt | unwrap event_data_droppedNoImages [$__range])) / 0.05
```

## Tests (13 pass, unit project)
- `model-getall-images.test.ts` (4) — cap `toBe(12)`, leading order `[1..12]`, 20→12, non-mutation, <cap.
- `feedDrop.test.ts` (7) — emits once with the string attr shape; silent when `M===0` / negative; sample-rate gate (RNG < rate emits, ≥ rate drops); includes/omits `surface`; never throws if the sink throws; default rate 0.05.
- `useApplyHiddenPreferences.test.ts` (2) — `filterPreferences('models', …)` with 5 in / 2 dropping emits **exactly one** aggregate event `{droppedNoImages:2, total:5, browsingLevel}` (proves aggregate, not per-model); and one call with `droppedNoImages:0` when nothing drops.

**Typecheck:** `tsc --noEmit` (8 GB heap) clean, exit 0.

## Hot-path overhead
Bounded: one aggregate call per filter (no per-model emit), gated on `droppedNoImages>0` then sampled at 0.05, wrapped best-effort (never throws) and a no-op when Faro is uninitialised (SSR / flag off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)