### PR TITLE
fix(engaged-models): explicit setTo on notify toggle — kill error-case silent-unsubscribe

### DIFF
--- a/src/components/Model/Actions/ToggleModelNotification.tsx
+++ b/src/components/Model/Actions/ToggleModelNotification.tsx
@@ -70,9 +70,19 @@ export function ToggleModelNotification({
               // F1: block the toggle until membership is known — a cold store reads
               // as not-engaged and would fire the OPPOSITE of the user's intent.
               if (!isKnown) return;
+              // Carry an EXPLICIT direction (setTo) derived from the button intent,
+              // never a blind server-side toggle. isOn=true → the user wants OFF
+              // (set Mute, which also overrides a follow-based auto-watch); isOn=false
+              // → the user wants ON (set Notify). With setTo the server sets the row
+              // to exactly this state, so even if the store fabricated "off" for a
+              // genuinely-ON model (the #3034 error-path un-stick), a click can no
+              // longer silently DELETE the existing Notify — it's an idempotent
+              // subscribe. The optimistic write below is therefore the guaranteed
+              // outcome, not a guess, so the store never ends up lying vs the server.
               toggleNotifyModelMutation.mutate({
                 modelId,
-                type: isOn ? ModelEngagementType.Mute : undefined,
+                type: isOn ? ModelEngagementType.Mute : ModelEngagementType.Notify,
+                setTo: true,
               });
             }}
             loading={toggleNotifyModelMutation.isPending || !isKnown}

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -774,9 +774,20 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                               // known — a cold store reads not-engaged and would fire
                               // the OPPOSITE of the user's intent.
                               if (!isNotifyKnown) return;
+                              // Carry an EXPLICIT direction (setTo) — never a blind
+                              // server toggle. on→OFF (set Mute, overrides a
+                              // follow-based auto-watch); off→ON (set Notify). With
+                              // setTo the server sets the row to exactly this state, so
+                              // a click acting on a fabricated/errored "off" for a
+                              // genuinely-ON model can no longer silently DELETE the
+                              // Notify — it's an idempotent subscribe, and the
+                              // optimistic write matches the guaranteed server outcome.
                               toggleNotifyModelMutation.mutate({
                                 modelId: model.id,
-                                type: isNotificationOn ? ModelEngagementType.Mute : undefined,
+                                type: isNotificationOn
+                                  ? ModelEngagementType.Mute
+                                  : ModelEngagementType.Notify,
+                                setTo: true,
                               });
                             }}
                             loading={toggleNotifyModelMutation.isPending || !isNotifyKnown}

--- a/src/hooks/__tests__/useEngagedModelMembership.test.ts
+++ b/src/hooks/__tests__/useEngagedModelMembership.test.ts
@@ -28,6 +28,7 @@ import {
   useEngagedModelMembership,
 } from '~/hooks/useEngagedModelMembership';
 import { useEngagedModelsStore } from '~/store/engaged-models.store';
+import { applyNotifyToggled } from '~/store/engaged-models.optimistic';
 
 // deterministic scheduler: capture the flush callback, fire it on demand.
 let scheduledFlush: (() => void) | null = null;
@@ -390,5 +391,121 @@ describe('useEngagedModelMembership — authed fetch error does not dead-lock th
     // not a permanently-disabled dead button.
     expect(button().disabled).toBe(false);
     unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Silent-unsubscribe fix (audit fast-follow to the #3034 error path).
+//
+// The #3034 error path marks a genuinely Notify-ON model known-not-engaged when
+// its by-ids read errors (so the gated control un-sticks). The OLD notify
+// mutation then sent `type: isOn ? Mute : undefined` — an UNDEFINED type on the
+// subscribe click → the server BLIND-toggled and DELETED the existing Notify
+// (silent unsubscribe), while `onMutate` optimistically wrote Notify=true → the
+// store was left LYING (ON on the client, OFF on the server).
+//
+// The fix carries an EXPLICIT `setTo` derived from the button intent, so the
+// click that lands on a fabricated-off (but genuinely-ON) model is an idempotent
+// subscribe, never a delete — and the optimistic write matches the guaranteed
+// server outcome. This harness replicates the REAL control's click derivation
+// (isOn + payload + onMutate optimistic) on top of the REAL hook/store/optimistic
+// modules; the server half (setTo:true never deletes) is pinned in
+// server/services/__tests__/engagement-toggle.idempotent.service.test.ts.
+// ---------------------------------------------------------------------------
+
+interface NotifyPayload {
+  modelId: number;
+  type: 'Notify' | 'Mute' | undefined;
+  setTo?: boolean;
+}
+
+/**
+ * Faithful replica of ToggleModelNotification's click path (following=[] → not
+ * following the creator). Captures the payload the control would `.mutate()` and
+ * runs the same `onMutate` optimistic write.
+ */
+function NotifyClickHarness({
+  modelId,
+  onPayload,
+}: {
+  modelId: number;
+  onPayload: (p: NotifyPayload) => void;
+}) {
+  const { isEngaged, isKnown } = useEngagedModelMembership(modelId);
+  const isWatching = isEngaged('Notify');
+  const isMuted = isEngaged('Mute');
+  const isOn = isWatching && !isMuted; // not following the creator in this harness
+
+  const onClick = () => {
+    if (!isKnown) return;
+    const payload: NotifyPayload = {
+      modelId,
+      type: isOn ? 'Mute' : 'Notify',
+      setTo: true,
+    };
+    // onMutate optimistic write (mirrors the mutation's onMutate).
+    applyNotifyToggled(modelId, !isOn);
+    onPayload(payload);
+  };
+
+  return React.createElement(
+    'button',
+    { type: 'button', disabled: !isKnown, onClick },
+    'notify'
+  );
+}
+
+describe('notify silent-unsubscribe fix — genuinely-ON model whose by-ids read errored', () => {
+  it('click on the (fabricated-off) bell sends an EXPLICIT subscribe (type=Notify, setTo=true) — never a blind toggle — and the store does not end up lying', async () => {
+    currentUser = { id: 1 };
+    const modelId = 55;
+    // The by-ids read for this genuinely Notify-ON model ERRORS.
+    queryMock.mockRejectedValueOnce(new Error('boom'));
+
+    let captured: NotifyPayload | undefined;
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    act(() =>
+      root.render(
+        React.createElement(NotifyClickHarness, { modelId, onPayload: (p) => (captured = p) })
+      )
+    );
+
+    // In flight → unknown → disabled.
+    const button = () => container.querySelector('button') as HTMLButtonElement;
+    expect(button().disabled).toBe(true);
+
+    runFlush();
+    await settle();
+    act(() =>
+      root.render(
+        React.createElement(NotifyClickHarness, { modelId, onPayload: (p) => (captured = p) })
+      )
+    );
+
+    // #3034 error path: id is now known-not-engaged (fabricated OFF) → control enabled,
+    // and the store reads Notify as absent even though the server row IS Notify.
+    expect(button().disabled).toBe(false);
+    expect(useEngagedModelsStore.getState().queried.has(modelId)).toBe(true);
+    expect(useEngagedModelsStore.getState().membership[modelId]?.has('Notify')).toBe(false);
+
+    // User clicks the bell (intending to subscribe).
+    act(() => button().click());
+
+    // 1) The payload carries EXPLICIT direction — a subscribe, not a blind toggle.
+    //    (The old bug sent `type: undefined` here → server-side blind DELETE.)
+    expect(captured).toBeDefined();
+    expect(captured?.type).toBe('Notify');
+    expect(captured?.setTo).toBe(true);
+    expect(captured?.type).not.toBeUndefined();
+
+    // 2) The optimistic write leaves the store showing Notify=ON. Because setTo:true
+    //    on an existing Notify is a no-op subscribe server-side (pinned in the service
+    //    test), the server is ALSO ON — store == server, so the UI is not left lying.
+    const m = useEngagedModelsStore.getState().membership[modelId];
+    expect(m?.has('Notify')).toBe(true);
+    expect(m?.has('Mute')).toBe(false);
+
+    act(() => root.unmount());
   });
 });

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -990,7 +990,12 @@ export const toggleNotifyModelHandler = async ({
   try {
     const { id: userId } = ctx.user;
     const result = input.type
-      ? await toggleModelEngagement({ modelId: input.modelId, type: input.type, userId })
+      ? await toggleModelEngagement({
+          modelId: input.modelId,
+          type: input.type,
+          setTo: input.setTo,
+          userId,
+        })
       : await toggleModelNotify({ ...input, userId });
 
     if (result) {

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -145,6 +145,13 @@ export type ToggleFavoriteInput = z.infer<typeof toggleFavoriteInput>;
 export const toggleModelEngagementInput = z.object({
   modelId: z.number(),
   type: z.enum(ModelEngagementType).optional(),
+  // Explicit toggle direction. When provided, the server sets the engagement to
+  // exactly this state (subscribe vs unsubscribe) instead of blind-toggling off
+  // the current row — so a caller acting on a stale/errored/fabricated client
+  // view can never fire the OPPOSITE of the user's intent (e.g. silently DELETE
+  // a genuinely-ON Notify because the client briefly read it as off). Optional
+  // for backward-compat: absent → legacy blind toggle.
+  setTo: z.boolean().optional(),
 });
 export type ToggleModelEngagementInput = z.infer<typeof toggleModelEngagementInput>;
 

--- a/src/server/services/__tests__/engagement-toggle.idempotent.service.test.ts
+++ b/src/server/services/__tests__/engagement-toggle.idempotent.service.test.ts
@@ -103,6 +103,89 @@ describe('toggleModelEngagement — idempotent on P2002 race (the confirmed prod
   });
 });
 
+describe('toggleModelEngagement — explicit setTo direction (notify silent-unsubscribe fix)', () => {
+  // Regression for the audit finding on the engaged-models client refactor:
+  // a genuinely Notify-ON model whose by-ids read errored made the client render
+  // the bell as "off"; the old notify mutation then sent `type=undefined` → the
+  // server BLIND-toggled (`setTo ??= engagement?.type===type ? false : true`) and,
+  // seeing the existing Notify row, DELETED it — a silent, wrong-direction
+  // unsubscribe. The fix makes the client always carry an explicit `setTo`, so the
+  // server sets the row to exactly the intended state and can never delete on a
+  // "subscribe" click. These tests pin BOTH: the old blind path was destructive,
+  // the new explicit-setTo path is an idempotent subscribe.
+
+  it('LEGACY blind toggle (no setTo) on an existing Notify → DELETES it (the bug being closed)', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce({ type: 'Notify' });
+
+    const result = await toggleModelEngagement({ userId: 42, modelId: 10, type: 'Notify' });
+
+    // Blind toggle: existing type === requested type → setTo resolves to false → delete.
+    expect(mockDb.modelEngagement.delete).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false); // "unsubscribed" — exactly the silent-unsubscribe symptom
+  });
+
+  it('explicit setTo:true on an existing Notify → NO delete, idempotent subscribe (returns true)', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce({ type: 'Notify' });
+
+    const result = await toggleModelEngagement({
+      userId: 42,
+      modelId: 10,
+      type: 'Notify',
+      setTo: true,
+    });
+
+    // The row already IS Notify and we asked to set it ON → no-op success, never a delete.
+    expect(mockDb.modelEngagement.delete).not.toHaveBeenCalled();
+    expect(mockDb.modelEngagement.update).not.toHaveBeenCalled();
+    expect(result).toBe(true); // still subscribed
+  });
+
+  it('explicit setTo:true on a Mute row (type Notify) → UPDATEs to Notify (un-mute subscribe), never deletes', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce({ type: 'Mute' });
+
+    const result = await toggleModelEngagement({
+      userId: 42,
+      modelId: 10,
+      type: 'Notify',
+      setTo: true,
+    });
+
+    expect(mockDb.modelEngagement.update).toHaveBeenCalledTimes(1);
+    expect(mockDb.modelEngagement.delete).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it('explicit setTo:true type Mute on an existing Notify → UPDATEs to Mute (turn-off), never blind-deletes', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce({ type: 'Notify' });
+
+    const result = await toggleModelEngagement({
+      userId: 42,
+      modelId: 10,
+      type: 'Mute',
+      setTo: true,
+    });
+
+    expect(mockDb.modelEngagement.update).toHaveBeenCalledTimes(1);
+    expect(mockDb.modelEngagement.delete).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it('explicit setTo:true with no existing row → CREATEs the requested type (fresh subscribe)', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce(null);
+
+    const result = await toggleModelEngagement({
+      userId: 42,
+      modelId: 10,
+      type: 'Notify',
+      setTo: true,
+    });
+
+    expect(mockDb.modelEngagement.create).toHaveBeenCalledTimes(1);
+    expect(mockDb.modelEngagement.delete).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+});
+
 describe('toggleUserBountyEngagement — idempotent on P2002 race (sibling)', () => {
   it('P2002 on create → returns true instead of 500', async () => {
     mockDb.bountyEngagement.findUnique.mockResolvedValueOnce(null);


### PR DESCRIPTION
Fast-follow to #3034 — fixes the notify error-case silent-unsubscribe. **Stacked on #3034; rebase onto `main` after #3034 merges.**

## The bug (audit finding on #3034)
#3034's error path marks a genuinely **Notify-ON** model *known-not-engaged* when its `getEngagedModelsByIds` read errors (to un-stick the gated control). But the notify mutation sent `type: isOn ? Mute : undefined` with **no explicit `setTo`**, and the server (`toggleModelEngagement`) does a blind server-side toggle (`setTo ??= engagement?.type===type ? false : true`). So a model the user genuinely has Notify ON, whose by-ids read errors → store shows not-engaged → bell renders "off" → user clicks intending to **subscribe** → sends `type=undefined` → server sees the existing Notify row and **DELETES it** (silent unsubscribe). `onMutate` also optimistically wrote `Notify=true` while `onSuccess` only invalidated the legacy cache, so the store was left **lying** (ON on client / OFF on server) until reload.

Favorite/Recommended already passed an explicit `setTo` and is unaffected.

## The fix — explicit direction (eliminate the blind toggle)
The notify mutation now always carries an **explicit `setTo`** derived from the button intent:
- `off → ON`: `type=Notify, setTo=true` — an idempotent **subscribe** (existing Notify → no-op success, never a delete)
- `on → OFF`: `type=Mute, setTo=true` — sets Mute (still overrides a follow-based auto-watch)

With `setTo` the server sets the row to exactly that state, so a click landing on a fabricated/errored "off" for a genuinely-ON model can **no longer delete** the Notify. The optimistic write is now the *guaranteed* server outcome, not a guess — so the store can't be left lying.

**Server:** `setTo` added to `toggleModelEngagementInput` (optional → backward-compat) and threaded through `toggleNotifyModelHandler`. The legacy blind `toggleModelNotify` fallback (`type` undefined) is untouched for API compat.

### before → after
- `ToggleModelNotification.tsx:75` — `type: isOn ? Mute : undefined` → `type: isOn ? Mute : Notify` + `setTo: true`
- `ModelVersionDetails.tsx:779` — same
- `user.schema.ts:148` — `+ setTo: z.boolean().optional()`
- `user.controller.ts:993` — thread `setTo: input.setTo` into `toggleModelEngagement`

## Preserved (#3034)
Authed happy-path gating (F1 `isKnown`), the dirty-guard (F2), favorite=Recommended+Notify semantics, dual-write to the legacy cache, rollback, unauth login-redirect (`isKnown=true`), feeds callers + old endpoint untouched.

## Tests
- **+1 client** (`useEngagedModelMembership.test.ts`): authed, genuinely Notify-ON model whose by-ids read **errors** → the (now-enabled) bell click sends explicit `type=Notify/setTo=true` (not a blind toggle) **and** the store stays truthful (Notify ON, no persistent ON-while-server-OFF).
- **+5 server** (`engagement-toggle.idempotent.service.test.ts`): pins that `setTo:true` never deletes an existing Notify (idempotent subscribe / un-mute / create), and that the **legacy blind path DID delete** — locking in the exact behavior the fix stops sending.

Engaged-models trio: 60 pass (59 original + 1 new). Service test file: 11 pass (6 original + 5 new). `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)