### PR TITLE
fix(fetch): add conservative anti-hang timeouts to untimed fetch() on hot paths

### DIFF
--- a/src/pages/api/generation/history/index.ts
+++ b/src/pages/api/generation/history/index.ts
@@ -3,6 +3,7 @@ import { env } from '~/env/server';
 import { CacheTTL } from '~/server/common/constants';
 import { REDIS_SYS_KEYS } from '~/server/redis/client';
 import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 import { createLimiter } from '~/server/utils/rate-limiting';
 
 const historyLimiter = createLimiter({
@@ -36,7 +37,7 @@ export default AuthedEndpoint(async function handler(req, res, user) {
       callbackUrl: `${env.NEXTAUTH_URL}/api/generation/history/callback?userId=${user.id}`,
     });
 
-  const response = await fetch(url, { signal: AbortSignal.timeout(60_000) });
+  const response = await fetch(url, { signal: fetchTimeoutSignal(60_000) });
   if (!response.ok) throw new Error(`failed to get download url: ${response.statusText}`);
   const preSignedUrl = await response.json();
 

--- a/src/pages/api/generation/history/index.ts
+++ b/src/pages/api/generation/history/index.ts
@@ -36,7 +36,7 @@ export default AuthedEndpoint(async function handler(req, res, user) {
       callbackUrl: `${env.NEXTAUTH_URL}/api/generation/history/callback?userId=${user.id}`,
     });
 
-  const response = await fetch(url);
+  const response = await fetch(url, { signal: AbortSignal.timeout(60_000) });
   if (!response.ok) throw new Error(`failed to get download url: ${response.statusText}`);
   const preSignedUrl = await response.json();
 

--- a/src/pages/api/internal/assess-image.ts
+++ b/src/pages/api/internal/assess-image.ts
@@ -28,6 +28,7 @@ export default TokenSecuredEndpoint(
           'Content-Type': 'application/x-www-form-urlencoded',
         },
         body: new URLSearchParams({ url }),
+        signal: AbortSignal.timeout(60_000),
       });
 
       if (!response.ok) throw new Error('Network response was not ok');

--- a/src/pages/api/internal/assess-image.ts
+++ b/src/pages/api/internal/assess-image.ts
@@ -2,6 +2,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
 import { env } from '~/env/server';
 import { addCorsHeaders, TokenSecuredEndpoint } from '~/server/utils/endpoint-helpers';
+import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 
 const schema = z.object({
   url: z.string(),
@@ -28,7 +29,7 @@ export default TokenSecuredEndpoint(
           'Content-Type': 'application/x-www-form-urlencoded',
         },
         body: new URLSearchParams({ url }),
-        signal: AbortSignal.timeout(60_000),
+        signal: fetchTimeoutSignal(60_000),
       });
 
       if (!response.ok) throw new Error('Network response was not ok');

--- a/src/pages/moderator/review/training-data/[versionId].tsx
+++ b/src/pages/moderator/review/training-data/[versionId].tsx
@@ -50,7 +50,7 @@ function ReviewTrainingData() {
     if (requestedRef.current || urls.length > 0) return;
     requestedRef.current = true;
     setLoading(true);
-    fetchBlob(`/api/download/training-data/${versionId}`)
+    fetchBlob(`/api/download/training-data/${versionId}`, 300_000)
       .then(async (zip) => {
         if (zip) {
           const zipReader = await getJSZip();

--- a/src/pages/moderator/training-models.tsx
+++ b/src/pages/moderator/training-models.tsx
@@ -304,7 +304,7 @@ export default function TrainingModerationFeedPage() {
     requestedRef.current = false;
 
     try {
-      const zip = await fetchBlob(`/api/download/training-data/${versionId}`);
+      const zip = await fetchBlob(`/api/download/training-data/${versionId}`, 300_000);
       if (zip) {
         const zipReader = await getJSZip();
         const zData = await zipReader.loadAsync(zip);

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -54,6 +54,10 @@ export enum FLIPT_FEATURE_FLAGS {
   HIGH_REPLICATION_LAG_MODE = 'high-replication-lag-mode',
   LICENSING_FEE = 'licensing-fee',
   WILDCARDS = 'wildcards',
+  // Global kill-switch for the anti-hang timeouts on server request-path fetches,
+  // DEFAULT-ON (apply the timeout unless explicitly disabled). Flip OFF to revert
+  // to the prior no-timeout behavior during an incident. See fetchTimeoutSignal.
+  HOT_PATH_FETCH_TIMEOUTS = 'hot-path-fetch-timeouts',
 }
 
 const FLIPT_INIT_TIMEOUT_MS = 5000;

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -54,9 +54,9 @@ export enum FLIPT_FEATURE_FLAGS {
   HIGH_REPLICATION_LAG_MODE = 'high-replication-lag-mode',
   LICENSING_FEE = 'licensing-fee',
   WILDCARDS = 'wildcards',
-  // Global kill-switch for the anti-hang timeouts on server request-path fetches,
-  // DEFAULT-ON (apply the timeout unless explicitly disabled). Flip OFF to revert
-  // to the prior no-timeout behavior during an incident. See fetchTimeoutSignal.
+  // Global flag for the anti-hang timeouts on server request-path fetches,
+  // DEFAULT-OFF (feature ships dormant; the timeout applies only when this is
+  // explicitly ON). Flip ON to activate. See fetchTimeoutSignal.
   HOT_PATH_FETCH_TIMEOUTS = 'hot-path-fetch-timeouts',
 }
 

--- a/src/server/http/httpCaller.ts
+++ b/src/server/http/httpCaller.ts
@@ -1,4 +1,5 @@
 import { QS } from '~/utils/qs';
+import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 import { handleLogError } from '../utils/errorHandling';
 
 export abstract class HttpCaller {
@@ -38,7 +39,7 @@ export abstract class HttpCaller {
         ...this.baseHeaders,
         ...opts?.headers,
       },
-      signal: AbortSignal.timeout(this.timeout),
+      signal: fetchTimeoutSignal(this.timeout),
     });
   }
 
@@ -61,7 +62,7 @@ export abstract class HttpCaller {
       method: 'POST',
       body,
       headers: { ...this.baseHeaders, ...headers },
-      signal: AbortSignal.timeout(this.timeout),
+      signal: fetchTimeoutSignal(this.timeout),
     });
   }
 
@@ -94,7 +95,7 @@ export abstract class HttpCaller {
       method: 'PUT',
       body,
       headers: { ...this.baseHeaders, ...headers },
-      signal: AbortSignal.timeout(this.timeout),
+      signal: fetchTimeoutSignal(this.timeout),
     });
   }
 
@@ -119,7 +120,7 @@ export abstract class HttpCaller {
   public async deleteRaw(endpoint: string) {
     return await fetch(`${this.baseUrl}${endpoint}`, {
       method: 'DELETE',
-      signal: AbortSignal.timeout(this.timeout),
+      signal: fetchTimeoutSignal(this.timeout),
     });
   }
 

--- a/src/server/http/httpCaller.ts
+++ b/src/server/http/httpCaller.ts
@@ -4,10 +4,15 @@ import { handleLogError } from '../utils/errorHandling';
 export abstract class HttpCaller {
   private baseUrl: string;
   private baseHeaders: MixedObject;
+  // Anti-hang ceiling only — without it a hung vendor (payment/orchestrator/etc.)
+  // parks the request for undici's ~300s default. Generous so slow-but-legit
+  // captures are never cut off; override per-caller via the constructor option.
+  private timeout: number;
 
-  constructor(baseUrl: string, options?: { headers?: MixedObject }) {
+  constructor(baseUrl: string, options?: { headers?: MixedObject; timeout?: number }) {
     this.baseUrl = baseUrl;
     this.baseHeaders = options?.headers || {};
+    this.timeout = options?.timeout ?? 120_000;
   }
 
   private async prepareResponse<TData = any>(response: Response) {
@@ -33,6 +38,7 @@ export abstract class HttpCaller {
         ...this.baseHeaders,
         ...opts?.headers,
       },
+      signal: AbortSignal.timeout(this.timeout),
     });
   }
 
@@ -55,6 +61,7 @@ export abstract class HttpCaller {
       method: 'POST',
       body,
       headers: { ...this.baseHeaders, ...headers },
+      signal: AbortSignal.timeout(this.timeout),
     });
   }
 
@@ -87,6 +94,7 @@ export abstract class HttpCaller {
       method: 'PUT',
       body,
       headers: { ...this.baseHeaders, ...headers },
+      signal: AbortSignal.timeout(this.timeout),
     });
   }
 
@@ -111,6 +119,7 @@ export abstract class HttpCaller {
   public async deleteRaw(endpoint: string) {
     return await fetch(`${this.baseUrl}${endpoint}`, {
       method: 'DELETE',
+      signal: AbortSignal.timeout(this.timeout),
     });
   }
 

--- a/src/server/jobs/process-vault-items.ts
+++ b/src/server/jobs/process-vault-items.ts
@@ -69,7 +69,7 @@ export const processVaultItems = createJob('process-vault-items', '*/10 * * * *'
         images.map(async (img, idx) => {
           try {
             const imageUrl = getEdgeUrl(img.url, { type: img.type });
-            const blob = await fetchBlob(imageUrl);
+            const blob = await fetchBlob(imageUrl, 300_000);
             const filename = img.name ?? imageUrl.split('/').pop();
 
             if (filename && blob) {

--- a/src/server/recaptcha/client.ts
+++ b/src/server/recaptcha/client.ts
@@ -5,6 +5,7 @@ import { throwBadRequestError } from '~/server/utils/errorHandling';
 import { isDefined } from '~/utils/type-guards';
 import * as z from 'zod';
 import { logToAxiom } from '~/server/logging/client';
+import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 
 // Taken from package as they don't export it :shrug:
 // enum ClassificationReason {
@@ -130,7 +131,7 @@ export async function verifyCaptchaToken({
       response: token,
       remoteip: ip,
     }),
-    signal: AbortSignal.timeout(30_000),
+    signal: fetchTimeoutSignal(30_000),
   });
   const verifyLatencyMs = Date.now() - startedAt;
   const cfRay = result.headers.get('cf-ray') ?? undefined;

--- a/src/server/recaptcha/client.ts
+++ b/src/server/recaptcha/client.ts
@@ -130,6 +130,7 @@ export async function verifyCaptchaToken({
       response: token,
       remoteip: ip,
     }),
+    signal: AbortSignal.timeout(30_000),
   });
   const verifyLatencyMs = Date.now() - startedAt;
   const cfRay = result.headers.get('cf-ray') ?? undefined;

--- a/src/server/routers/comics.router.ts
+++ b/src/server/routers/comics.router.ts
@@ -10,6 +10,7 @@ import {
   isFlagProtected,
 } from '~/server/trpc';
 import { dbRead, dbWrite } from '~/server/db/client';
+import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 import {
   throwAuthorizationError,
   throwBadRequestError,
@@ -3492,7 +3493,7 @@ export const comicsRouter = router({
             }
 
             try {
-              const resp = await fetch(candidateImg.url, { signal: AbortSignal.timeout(120_000) });
+              const resp = await fetch(candidateImg.url, { signal: fetchTimeoutSignal(120_000) });
               if (!resp.ok) {
                 blurredPreviews.push(null);
                 continue;
@@ -3645,7 +3646,7 @@ export const comicsRouter = router({
           // Single-image path (or multi-image with only 1 result)
           let s3ImageKey: string;
           try {
-            const imageResponse = await fetch(imageUrl, { signal: AbortSignal.timeout(120_000) });
+            const imageResponse = await fetch(imageUrl, { signal: fetchTimeoutSignal(120_000) });
             if (!imageResponse.ok) throw new Error(`Failed to download: ${imageResponse.status}`);
             const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
 
@@ -3902,7 +3903,7 @@ export const comicsRouter = router({
 
         let s3Key: string;
         try {
-          const resp = await fetch(clean.url, { signal: AbortSignal.timeout(120_000) });
+          const resp = await fetch(clean.url, { signal: fetchTimeoutSignal(120_000) });
           if (!resp.ok) throw new Error(`Failed to download: ${resp.status}`);
           const buf = Buffer.from(await resp.arrayBuffer());
           s3Key = randomUUID();
@@ -4017,7 +4018,7 @@ export const comicsRouter = router({
         }
 
         try {
-          const resp = await fetch(out.url, { signal: AbortSignal.timeout(120_000) });
+          const resp = await fetch(out.url, { signal: fetchTimeoutSignal(120_000) });
           if (!resp.ok) {
             newCandidates.push({
               requiresUnlock: true,

--- a/src/server/routers/comics.router.ts
+++ b/src/server/routers/comics.router.ts
@@ -3492,7 +3492,7 @@ export const comicsRouter = router({
             }
 
             try {
-              const resp = await fetch(candidateImg.url);
+              const resp = await fetch(candidateImg.url, { signal: AbortSignal.timeout(120_000) });
               if (!resp.ok) {
                 blurredPreviews.push(null);
                 continue;
@@ -3645,7 +3645,7 @@ export const comicsRouter = router({
           // Single-image path (or multi-image with only 1 result)
           let s3ImageKey: string;
           try {
-            const imageResponse = await fetch(imageUrl);
+            const imageResponse = await fetch(imageUrl, { signal: AbortSignal.timeout(120_000) });
             if (!imageResponse.ok) throw new Error(`Failed to download: ${imageResponse.status}`);
             const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
 
@@ -3902,7 +3902,7 @@ export const comicsRouter = router({
 
         let s3Key: string;
         try {
-          const resp = await fetch(clean.url);
+          const resp = await fetch(clean.url, { signal: AbortSignal.timeout(120_000) });
           if (!resp.ok) throw new Error(`Failed to download: ${resp.status}`);
           const buf = Buffer.from(await resp.arrayBuffer());
           s3Key = randomUUID();
@@ -4017,7 +4017,7 @@ export const comicsRouter = router({
         }
 
         try {
-          const resp = await fetch(out.url);
+          const resp = await fetch(out.url, { signal: AbortSignal.timeout(120_000) });
           if (!resp.ok) {
             newCandidates.push({
               requiresUnlock: true,

--- a/src/server/routers/games.router.ts
+++ b/src/server/routers/games.router.ts
@@ -60,6 +60,7 @@ async function createGameInstance(code: string) {
       code,
       token: env.CHOPPED_TOKEN,
     }),
+    signal: AbortSignal.timeout(60_000),
   });
 
   if (!response.ok) {

--- a/src/server/routers/games.router.ts
+++ b/src/server/routers/games.router.ts
@@ -3,6 +3,7 @@ import { ComputeCost, GAME_TOKEN_LENGTH } from '~/components/Chopped/chopped.uti
 import { env as clientEnv } from '~/env/client';
 import { env } from '~/env/server';
 import { TransactionType } from '~/shared/constants/buzz.constants';
+import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 import {
   addImageRatingSchema,
   cleanseSmiteSchema,
@@ -60,7 +61,7 @@ async function createGameInstance(code: string) {
       code,
       token: env.CHOPPED_TOKEN,
     }),
-    signal: AbortSignal.timeout(60_000),
+    signal: fetchTimeoutSignal(60_000),
   });
 
   if (!response.ok) {

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -931,6 +931,7 @@ export const ingestImage = async ({
   const response = await fetch(scanUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    signal: AbortSignal.timeout(60_000),
     body: JSON.stringify({
       imageId: id,
       imageKey: url,
@@ -1037,6 +1038,7 @@ export const ingestImageBulk = async ({
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      signal: AbortSignal.timeout(60_000),
       body: JSON.stringify(
         images.map((image) => ({
           imageId: image.id,

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -181,6 +181,7 @@ import {
   throwDbError,
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
+import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 import type { RuleDefinition } from '~/server/utils/mod-rules';
 import { getCursor } from '~/server/utils/pagination-helpers';
 import {
@@ -931,7 +932,7 @@ export const ingestImage = async ({
   const response = await fetch(scanUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    signal: AbortSignal.timeout(60_000),
+    signal: fetchTimeoutSignal(60_000),
     body: JSON.stringify({
       imageId: id,
       imageKey: url,
@@ -1038,7 +1039,7 @@ export const ingestImageBulk = async ({
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      signal: AbortSignal.timeout(60_000),
+      signal: fetchTimeoutSignal(60_000),
       body: JSON.stringify(
         images.map((image) => ({
           imageId: image.id,

--- a/src/server/services/paypal.service.ts
+++ b/src/server/services/paypal.service.ts
@@ -2,6 +2,7 @@ import { env } from '~/env/server';
 import { logToAxiom } from '../logging/client';
 import type { PaypalPurchaseBuzzSchema } from '../schema/paypal.schema';
 import { throwBadRequestError } from '../utils/errorHandling';
+import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 import { createBuzzTransaction } from './buzz.service';
 import { TransactionType, buzzConstants } from '~/shared/constants/buzz.constants';
 
@@ -28,7 +29,7 @@ export const createBuzzOrder = async ({
       'Content-Type': 'application/json',
       Authorization,
     },
-    signal: AbortSignal.timeout(120_000),
+    signal: fetchTimeoutSignal(120_000),
     body: JSON.stringify({
       intent: 'CAPTURE',
       purchase_units: [
@@ -73,7 +74,7 @@ export const processBuzzOrder = async (orderId: string | number) => {
     headers: {
       Authorization,
     },
-    signal: AbortSignal.timeout(120_000),
+    signal: fetchTimeoutSignal(120_000),
   });
 
   if (response.status === 200) {
@@ -107,7 +108,7 @@ export const processBuzzOrder = async (orderId: string | number) => {
           'Content-Type': 'application/json',
           Authorization,
         },
-        signal: AbortSignal.timeout(120_000),
+        signal: fetchTimeoutSignal(120_000),
         body: JSON.stringify([
           {
             op: 'add',
@@ -124,7 +125,7 @@ export const processBuzzOrder = async (orderId: string | number) => {
           'Content-Type': 'application/json',
           Authorization,
         },
-        signal: AbortSignal.timeout(120_000),
+        signal: fetchTimeoutSignal(120_000),
       });
 
       if (capture.status !== 201 && capture.status !== 200) {

--- a/src/server/services/paypal.service.ts
+++ b/src/server/services/paypal.service.ts
@@ -28,6 +28,7 @@ export const createBuzzOrder = async ({
       'Content-Type': 'application/json',
       Authorization,
     },
+    signal: AbortSignal.timeout(120_000),
     body: JSON.stringify({
       intent: 'CAPTURE',
       purchase_units: [
@@ -72,6 +73,7 @@ export const processBuzzOrder = async (orderId: string | number) => {
     headers: {
       Authorization,
     },
+    signal: AbortSignal.timeout(120_000),
   });
 
   if (response.status === 200) {
@@ -105,6 +107,7 @@ export const processBuzzOrder = async (orderId: string | number) => {
           'Content-Type': 'application/json',
           Authorization,
         },
+        signal: AbortSignal.timeout(120_000),
         body: JSON.stringify([
           {
             op: 'add',
@@ -121,6 +124,7 @@ export const processBuzzOrder = async (orderId: string | number) => {
           'Content-Type': 'application/json',
           Authorization,
         },
+        signal: AbortSignal.timeout(120_000),
       });
 
       if (capture.status !== 201 && capture.status !== 200) {

--- a/src/server/services/storage-resolver.ts
+++ b/src/server/services/storage-resolver.ts
@@ -1,4 +1,5 @@
 import { env } from '~/env/server';
+import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 import type { ImageUploadBackend } from '~/utils/s3-utils';
 
 const STORAGE_RESOLVER_URL =
@@ -20,7 +21,7 @@ export async function registerMediaLocation(
         Authorization: `Bearer ${STORAGE_RESOLVER_TOKEN}`,
       },
       body: JSON.stringify({ uuid, backend, sizeBytes }),
-      signal: AbortSignal.timeout(60_000),
+      signal: fetchTimeoutSignal(60_000),
     });
   } catch (e) {
     // Fire-and-forget — don't block uploads on registry failure
@@ -39,7 +40,7 @@ export async function resolveMediaLocation(
         ...(STORAGE_RESOLVER_TOKEN && { Authorization: `Bearer ${STORAGE_RESOLVER_TOKEN}` }),
       },
       body: JSON.stringify({ uuid }),
-      signal: AbortSignal.timeout(60_000),
+      signal: fetchTimeoutSignal(60_000),
     });
     if (!res.ok) return null;
     return res.json() as Promise<{ backend: ImageUploadBackend; url: string }>;

--- a/src/server/services/storage-resolver.ts
+++ b/src/server/services/storage-resolver.ts
@@ -20,6 +20,7 @@ export async function registerMediaLocation(
         Authorization: `Bearer ${STORAGE_RESOLVER_TOKEN}`,
       },
       body: JSON.stringify({ uuid, backend, sizeBytes }),
+      signal: AbortSignal.timeout(60_000),
     });
   } catch (e) {
     // Fire-and-forget — don't block uploads on registry failure
@@ -38,6 +39,7 @@ export async function resolveMediaLocation(
         ...(STORAGE_RESOLVER_TOKEN && { Authorization: `Bearer ${STORAGE_RESOLVER_TOKEN}` }),
       },
       body: JSON.stringify({ uuid }),
+      signal: AbortSignal.timeout(60_000),
     });
     if (!res.ok) return null;
     return res.json() as Promise<{ backend: ImageUploadBackend; url: string }>;

--- a/src/server/utils/fetch-timeout.ts
+++ b/src/server/utils/fetch-timeout.ts
@@ -1,12 +1,14 @@
 import { FLIPT_FEATURE_FLAGS, isFliptSync } from '~/server/flipt/client';
 
 /**
- * Anti-hang fetch timeout, behind a default-ON kill-switch.
- * Returns AbortSignal.timeout(ms) UNLESS the hot-path-fetch-timeouts flag is
- * explicitly OFF. isFliptSync returns null when Flipt is uninitialized or the
- * flag is absent -> treat as ON (apply the timeout).
+ * Anti-hang fetch timeout, behind a default-OFF Flipt flag.
+ * Returns AbortSignal.timeout(ms) ONLY when the hot-path-fetch-timeouts flag is
+ * explicitly ON. isFliptSync returns null when Flipt is uninitialized or the flag
+ * is absent -> treated as OFF (no timeout). The feature ships dormant; flip the
+ * flag ON to activate the timeouts. Absent-or-off both mean off, so there is no
+ * ordering dependency on the flag existing and no delete footgun.
  */
 export function fetchTimeoutSignal(ms: number): AbortSignal | undefined {
-  if (isFliptSync(FLIPT_FEATURE_FLAGS.HOT_PATH_FETCH_TIMEOUTS) === false) return undefined;
-  return AbortSignal.timeout(ms);
+  if (isFliptSync(FLIPT_FEATURE_FLAGS.HOT_PATH_FETCH_TIMEOUTS) === true) return AbortSignal.timeout(ms);
+  return undefined;
 }

--- a/src/server/utils/fetch-timeout.ts
+++ b/src/server/utils/fetch-timeout.ts
@@ -1,0 +1,12 @@
+import { FLIPT_FEATURE_FLAGS, isFliptSync } from '~/server/flipt/client';
+
+/**
+ * Anti-hang fetch timeout, behind a default-ON kill-switch.
+ * Returns AbortSignal.timeout(ms) UNLESS the hot-path-fetch-timeouts flag is
+ * explicitly OFF. isFliptSync returns null when Flipt is uninitialized or the
+ * flag is absent -> treat as ON (apply the timeout).
+ */
+export function fetchTimeoutSignal(ms: number): AbortSignal | undefined {
+  if (isFliptSync(FLIPT_FEATURE_FLAGS.HOT_PATH_FETCH_TIMEOUTS) === false) return undefined;
+  return AbortSignal.timeout(ms);
+}

--- a/src/server/youtube/client.ts
+++ b/src/server/youtube/client.ts
@@ -75,7 +75,7 @@ export const uploadYoutubeVideo = async ({
   description,
 }: S3ToYoutubeInput) => {
   const service = youtube('v3');
-  const blob = await fetchBlob(getEdgeUrl(url, { type: 'video', original: true }));
+  const blob = await fetchBlob(getEdgeUrl(url, { type: 'video', original: true }), 300_000);
   if (!blob) return;
 
   const stream = (blob as Blob).stream();

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -3,6 +3,9 @@
 // (video/zip) pass a bigger timeoutMs rather than risk cutting off a slow-but-legit transfer.
 export async function fetchBlob(src: string | Blob | File, timeoutMs = 120_000) {
   if (src instanceof Blob) return src;
+  // Intentionally NOT behind the hot-path-fetch-timeouts Flipt kill-switch: this
+  // is isomorphic (bundled client-side) so it can't import the server-only
+  // isFliptSync, and its callers are background/media downloads where an abort is benign.
   else
     return await fetch(src, { signal: AbortSignal.timeout(timeoutMs) }).then((response) =>
       response.blob().catch(() => null)

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -1,6 +1,12 @@
-export async function fetchBlob(src: string | Blob | File) {
+// Anti-hang ceiling only: a hung upstream would otherwise park the request for
+// undici's ~300s default. Generous by design — callers downloading large media
+// (video/zip) pass a bigger timeoutMs rather than risk cutting off a slow-but-legit transfer.
+export async function fetchBlob(src: string | Blob | File, timeoutMs = 120_000) {
   if (src instanceof Blob) return src;
-  else return await fetch(src).then((response) => response.blob().catch(() => null));
+  else
+    return await fetch(src, { signal: AbortSignal.timeout(timeoutMs) }).then((response) =>
+      response.blob().catch(() => null)
+    );
 }
 
 /** Trigger a browser download for the given blob with the provided filename. */


### PR DESCRIPTION
Untimed `fetch()` on request paths inherits undici's ~300s default, so a hung upstream parks the request and ties up server resources. This adds **generous** `AbortSignal.timeout` ceilings whose only purpose is to prevent indefinite hangs — **not** to trim latency. Every timeout is sized so a slow-but-legit call is never cut off; when unsure we went bigger. Success behavior is unchanged; a fired timeout surfaces as a `TimeoutError` fetch rejection that each call site already handles like a network failure.

## Shared choke points (one edit covers many callers)
- **`fetchBlob`** (`src/utils/file-utils.ts`) — optional `timeoutMs`, default 120s. The genuinely-large-media callers override to 300s: youtube video (`youtube/client.ts`), vault items (`jobs/process-vault-items.ts`), and training-data zips (`moderator/training-models.tsx`, `moderator/review/training-data/[versionId].tsx`). No caller ever passed its own signal, so nothing is clobbered. All remaining callers are image-sized (csam scans, image uploads, dropzones, comic panels) where 120s is ample.
- **`HttpCaller`** base class — configurable constructor `timeout` (default 120s) applied to get/post/put/delete; inherited by shopify/tipalti/orchestrator/coinbase/etc. No subclass previously set a signal. Each vendor can override via `super(url, { timeout })` if a specific call is legitimately slower.

## Individual hot sites
Turnstile siteverify 30s; PayPal create/get/patch/capture 120s; chopped game-create 60s; comic image downloads 120s; image-scan enqueue 60s; storage-resolver 60s; generation-history download 60s; thehive assess-image 60s.

Follows the repo's established `AbortSignal.timeout(ms)` precedent (`orchestrator/workflows.ts`, `integrations/moderation.ts`). No function signatures broken (new params optional/defaulted). No unrelated refactors.

## Review notes (non-blocking)
- PayPal capture at 120s aborts with the same `TimeoutError`-as-network-failure shape the capture path already handles today; 120s is generous for a capture. No new risk vs the current untimed behavior.
- Client-side generated-output downloads sit at the 120s default; a generated video on a slow link is the one borderline case — acceptable for a user-initiated download of typically-small media. Bump if a real timeout is observed.
- `HttpCaller`'s uniform 120s applies to every vendor verb; if a specific batch call (e.g. a large Tipalti payout) is legitimately slower it needs a per-subclass override. None observed today.

## Kill-switch flag — DEFAULT-OFF (ships dormant)

All server request-path timeouts here are behind the global Flipt flag `hot-path-fetch-timeouts`, via the helper `fetchTimeoutSignal(ms)` (uses the synchronous cached `isFliptSync`). It is **default-OFF**: the timeout applies **only** when the flag is explicitly ON. An absent, uninitialized, or off flag all mean no timeout — so the feature ships **dormant** (current no-timeout behavior is unchanged on merge) with no ordering dependency on the flag existing and no delete footgun.

To activate: flip `hot-path-fetch-timeouts` to `true` (a plain global boolean in Flipt). Propagation is ~70s worst case (≈10s eval cache + 60s config poll); it's not in the eval-cache bypass set — add it there if near-instant toggling is ever needed.

`fetchBlob` is intentionally **not** gated: it's client-bundled and can't import the server-only Flipt client, and its aborts are benign background/media downloads (its own timeout stays always-on).