### PR TITLE
feat: server-enforced blocked browsing tags

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -15,12 +15,7 @@ import {
   incClusterInflight,
   resetClusterInflight,
 } from './cluster-inflight';
-import {
-  decSysInflight,
-  getSysInflight,
-  incSysInflight,
-  resetSysInflight,
-} from './sys-inflight';
+import { decSysInflight, getSysInflight, incSysInflight, resetSysInflight } from './sys-inflight';
 import {
   countClusterDeadlineHits,
   recordClusterCommandSettle,
@@ -796,9 +791,11 @@ export function instrumentCommands(
   // reaches this counts as a wedge hit for the deadline-hit trigger. Sourced at SETTLE time (done)
   // so it can't diverge from redis_command_duration_seconds the way the old onTimeout-only path did.
   const slowCommandMs = opts.slowCommandMs ?? config?.clusterSelfHealSlowCommandMs ?? 0;
-  const routingRetryEnabled = opts.routingRetryEnabled ?? config?.clusterRoutingRetryEnabled ?? false;
+  const routingRetryEnabled =
+    opts.routingRetryEnabled ?? config?.clusterRoutingRetryEnabled ?? false;
   const routingRetryMax = opts.routingRetryMax ?? config?.clusterRoutingRetryMax ?? 0;
-  const routingRetryBackoffMs = opts.routingRetryBackoffMs ?? config?.clusterRoutingRetryBackoffMs ?? 0;
+  const routingRetryBackoffMs =
+    opts.routingRetryBackoffMs ?? config?.clusterRoutingRetryBackoffMs ?? 0;
   const routingRetryBackoffMaxMs =
     opts.routingRetryBackoffMaxMs ?? config?.clusterRoutingRetryBackoffMaxMs ?? 0;
   self[methodName] = function (this: any, ...args: any[]) {
@@ -1961,6 +1958,7 @@ export const REDIS_KEYS = {
     PROMPT_ALLOWLIST: 'packed:system:prompt-allowlist',
     NOTIFICATION_COUNTS: 'system:notification-counts',
     CATEGORIES: 'system:categories',
+    BLOCKED_BROWSING_TAGS: 'system:blocked-browsing-tags',
   },
   CACHES: {
     FILES_FOR_MODEL_VERSION: 'packed:caches:files-for-model-version-2',

--- a/src/pages/tag/[tagname].tsx
+++ b/src/pages/tag/[tagname].tsx
@@ -19,6 +19,14 @@ export const getServerSideProps = createServerSideProps({
   useSSG: true,
   resolver: async ({ ctx, ssg }) => {
     const tagname = ctx.query.tagname as string;
+
+    if (tagname) {
+      const { getBlockedBrowsingTags } = await import('~/server/services/system-cache');
+      const blocked = await getBlockedBrowsingTags();
+      const normalized = tagname.toLowerCase();
+      if (blocked.some((t) => t.name.toLowerCase() === normalized)) return { notFound: true };
+    }
+
     if (tagname) await ssg?.tag.getTagWithModelCount.prefetch({ name: tagname });
 
     let seoData: TagPageSeoData = { count: 0, models: [] };

--- a/src/server/__tests__/blocked-browsing-tags.test.ts
+++ b/src/server/__tests__/blocked-browsing-tags.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { isBlockedTagName, stripBlockedTagIds } from '~/server/utils/blocked-browsing-tags';
+import {
+  DEFAULT_BROWSING_SETTINGS_ADDONS,
+  resolveBrowsingSettingsAddons,
+} from '~/shared/constants/browsing-settings-addons';
+import { NsfwLevel } from '~/server/common/enums';
+
+describe('stripBlockedTagIds', () => {
+  const blocked = [5188, 5249];
+
+  it('passes through when no tag filter', () => {
+    expect(stripBlockedTagIds(undefined, blocked)).toEqual({
+      tagIds: undefined,
+      emptyResult: false,
+    });
+    expect(stripBlockedTagIds([], blocked)).toEqual({ tagIds: [], emptyResult: false });
+  });
+
+  it('removes blocked ids but keeps allowed ones', () => {
+    expect(stripBlockedTagIds([5188, 100], blocked)).toEqual({ tagIds: [100], emptyResult: false });
+  });
+
+  it('short-circuits to empty when every requested tag is blocked', () => {
+    expect(stripBlockedTagIds([5188, 5249], blocked)).toEqual({ tagIds: [], emptyResult: true });
+  });
+
+  it('leaves a non-blocked filter untouched', () => {
+    expect(stripBlockedTagIds([100, 200], blocked)).toEqual({
+      tagIds: [100, 200],
+      emptyResult: false,
+    });
+  });
+});
+
+describe('isBlockedTagName', () => {
+  const blocked = ['celebrity', 'real person'];
+
+  it('matches case-insensitively', () => {
+    expect(isBlockedTagName('Celebrity', blocked)).toBe(true);
+    expect(isBlockedTagName('REAL PERSON', blocked)).toBe(true);
+  });
+
+  it('returns false for allowed or missing names', () => {
+    expect(isBlockedTagName('cat', blocked)).toBe(false);
+    expect(isBlockedTagName(undefined, blocked)).toBe(false);
+  });
+});
+
+describe('resolveBrowsingSettingsAddons (server derivation)', () => {
+  it('excludes POI tags + disablePoi at PG for non-moderators', () => {
+    const resolved = resolveBrowsingSettingsAddons(DEFAULT_BROWSING_SETTINGS_ADDONS, NsfwLevel.PG);
+    expect(resolved.disablePoi).toBe(true);
+    expect(resolved.excludedTagIds).toContain(5188); // celebrity
+    // minor addon only applies at R+; not at PG
+    expect(resolved.disableMinor).toBe(false);
+    expect(resolved.excludedTagIds).not.toContain(5351); // child
+  });
+
+  it('applies the minor addon at R', () => {
+    const resolved = resolveBrowsingSettingsAddons(DEFAULT_BROWSING_SETTINGS_ADDONS, NsfwLevel.R);
+    expect(resolved.disableMinor).toBe(true);
+    expect(resolved.excludedTagIds).toContain(5351); // child
+  });
+
+  it('bypasses all exclusions for moderators', () => {
+    const resolved = resolveBrowsingSettingsAddons(DEFAULT_BROWSING_SETTINGS_ADDONS, NsfwLevel.R, {
+      isModerator: true,
+    });
+    expect(resolved.disablePoi).toBe(false);
+    expect(resolved.disableMinor).toBe(false);
+    expect(resolved.excludedTagIds).toHaveLength(0);
+  });
+});

--- a/src/server/__tests__/blocked-browsing-tags.test.ts
+++ b/src/server/__tests__/blocked-browsing-tags.test.ts
@@ -1,10 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { isBlockedTagName, stripBlockedTagIds } from '~/server/utils/blocked-browsing-tags';
 import {
   DEFAULT_BROWSING_SETTINGS_ADDONS,
   resolveBrowsingSettingsAddons,
 } from '~/shared/constants/browsing-settings-addons';
 import { NsfwLevel } from '~/server/common/enums';
+import {
+  enforceBlockedBrowsingTags,
+  enforceBlockedBrowsingTagsForModels,
+} from '~/server/services/blocked-browsing-tags.service';
+
+vi.mock('~/server/services/system-cache', async () => {
+  const { DEFAULT_BROWSING_SETTINGS_ADDONS } = await import(
+    '~/shared/constants/browsing-settings-addons'
+  );
+  return {
+    getBlockedBrowsingTags: vi.fn(async () => [
+      { id: 5188, name: 'celebrity' },
+      { id: 5351, name: 'child' },
+    ]),
+    getBrowsingSettingAddons: vi.fn(async () => DEFAULT_BROWSING_SETTINGS_ADDONS),
+  };
+});
 
 describe('stripBlockedTagIds', () => {
   const blocked = [5188, 5249];
@@ -70,5 +87,81 @@ describe('resolveBrowsingSettingsAddons (server derivation)', () => {
     expect(resolved.disablePoi).toBe(false);
     expect(resolved.disableMinor).toBe(false);
     expect(resolved.excludedTagIds).toHaveLength(0);
+  });
+});
+
+describe('enforceBlockedBrowsingTags', () => {
+  it('treats browsingLevel:0 as public — exclusions still applied', async () => {
+    const input = { browsingLevel: 0, tags: undefined } as {
+      browsingLevel: number;
+      tags?: number[];
+      excludedTagIds?: number[];
+      disablePoi?: boolean;
+    };
+    const result = await enforceBlockedBrowsingTags(input, { id: undefined });
+    expect(result.emptyResult).toBe(false);
+    expect(input.disablePoi).toBe(true);
+    expect(input.excludedTagIds).toContain(5188);
+  });
+
+  it('short-circuits to empty when the tag filter is entirely blocked', async () => {
+    const input = { tags: [5188, 5351], browsingLevel: NsfwLevel.PG };
+    const result = await enforceBlockedBrowsingTags(input, { id: 1 });
+    expect(result.emptyResult).toBe(true);
+  });
+
+  it('strips blocked ids from a mixed tag filter, including for moderators', async () => {
+    const input = { tags: [5188, 999], browsingLevel: NsfwLevel.PG } as {
+      tags?: number[];
+      browsingLevel: number;
+      excludedTagIds?: number[];
+    };
+    const result = await enforceBlockedBrowsingTags(input, { id: 1, isModerator: true });
+    expect(result.emptyResult).toBe(false);
+    expect(input.tags).toEqual([999]);
+    expect(input.excludedTagIds).toBeUndefined();
+  });
+
+  it('skips the excludedTagIds union for own-scoped feeds but keeps disablePoi', async () => {
+    const input = { userId: 7, browsingLevel: NsfwLevel.PG } as {
+      userId: number;
+      browsingLevel: number;
+      excludedTagIds?: number[];
+      disablePoi?: boolean;
+    };
+    await enforceBlockedBrowsingTags(input, { id: 7 });
+    expect(input.excludedTagIds).toBeUndefined();
+    expect(input.disablePoi).toBe(true);
+  });
+
+  it('unions addon exclusions into a non-own feed and preserves client-sent ids', async () => {
+    const input = { excludedTagIds: [42], browsingLevel: NsfwLevel.PG } as {
+      excludedTagIds?: number[];
+      browsingLevel: number;
+    };
+    await enforceBlockedBrowsingTags(input, { id: 1 });
+    expect(input.excludedTagIds).toContain(42);
+    expect(input.excludedTagIds).toContain(5188);
+  });
+});
+
+describe('enforceBlockedBrowsingTagsForModels', () => {
+  it('short-circuits on a blocked tag name regardless of casing', async () => {
+    const result = await enforceBlockedBrowsingTagsForModels(
+      { tagname: 'Celebrity', browsingLevel: NsfwLevel.PG },
+      { id: 1, isModerator: true }
+    );
+    expect(result.emptyResult).toBe(true);
+  });
+
+  it('passes non-blocked tag names through with exclusions applied', async () => {
+    const input = { tag: 'cat', browsingLevel: NsfwLevel.PG } as {
+      tag?: string;
+      browsingLevel: number;
+      excludedTagIds?: number[];
+    };
+    const result = await enforceBlockedBrowsingTagsForModels(input, { id: 1 });
+    expect(result.emptyResult).toBe(false);
+    expect(input.excludedTagIds).toContain(5188);
   });
 });

--- a/src/server/services/blocked-browsing-tags.service.ts
+++ b/src/server/services/blocked-browsing-tags.service.ts
@@ -1,4 +1,7 @@
-import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+import {
+  onlySelectableLevels,
+  publicBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
 import type { ResolvedBrowsingSettingsAddons } from '~/shared/constants/browsing-settings-addons';
 import { resolveBrowsingSettingsAddons } from '~/shared/constants/browsing-settings-addons';
 import { getBlockedBrowsingTags, getBrowsingSettingAddons } from '~/server/services/system-cache';
@@ -42,13 +45,14 @@ async function loadBlockedBrowsingContext(browsingLevel: number | undefined, vie
     getBlockedBrowsingTags(),
     getBrowsingSettingAddons(),
   ]);
-  const resolved = resolveBrowsingSettingsAddons(
-    addons,
-    browsingLevel ?? publicBrowsingLevelsFlag,
-    {
-      isModerator: viewer.isModerator,
-    }
-  );
+  // `||` (not `??`): a client-sent browsingLevel of 0 would intersect no addon
+  // entry and silently disable every exclusion. Same guard for a Blocked-only
+  // level collapsing to 0 after onlySelectableLevels.
+  const level =
+    onlySelectableLevels(browsingLevel || publicBrowsingLevelsFlag) || publicBrowsingLevelsFlag;
+  const resolved = resolveBrowsingSettingsAddons(addons, level, {
+    isModerator: viewer.isModerator,
+  });
   return { blocked, resolved };
 }
 

--- a/src/server/services/blocked-browsing-tags.service.ts
+++ b/src/server/services/blocked-browsing-tags.service.ts
@@ -1,0 +1,104 @@
+import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+import type { ResolvedBrowsingSettingsAddons } from '~/shared/constants/browsing-settings-addons';
+import { resolveBrowsingSettingsAddons } from '~/shared/constants/browsing-settings-addons';
+import { getBlockedBrowsingTags, getBrowsingSettingAddons } from '~/server/services/system-cache';
+import { isBlockedTagName, stripBlockedTagIds } from '~/server/utils/blocked-browsing-tags';
+
+type AddonTarget = {
+  excludedTagIds?: number[];
+  disablePoi?: boolean;
+  disableMinor?: boolean;
+  userId?: number;
+  username?: string;
+  browsingLevel?: number;
+};
+
+type Viewer = { id?: number; username?: string | null; isModerator?: boolean };
+
+function applyAddonExclusions(
+  input: AddonTarget,
+  resolved: ResolvedBrowsingSettingsAddons,
+  viewer: Viewer
+) {
+  input.disablePoi = input.disablePoi || resolved.disablePoi;
+  input.disableMinor = input.disableMinor || resolved.disableMinor;
+
+  const isOwnScoped =
+    !!(viewer.id && input.userId && viewer.id === input.userId) ||
+    !!(
+      viewer.username &&
+      input.username &&
+      input.username.toLowerCase() === viewer.username.toLowerCase()
+    );
+  if (!isOwnScoped && resolved.excludedTagIds.length) {
+    input.excludedTagIds = [
+      ...new Set([...(input.excludedTagIds ?? []), ...resolved.excludedTagIds]),
+    ];
+  }
+}
+
+async function loadBlockedBrowsingContext(browsingLevel: number | undefined, viewer: Viewer) {
+  const [blocked, addons] = await Promise.all([
+    getBlockedBrowsingTags(),
+    getBrowsingSettingAddons(),
+  ]);
+  const resolved = resolveBrowsingSettingsAddons(
+    addons,
+    browsingLevel ?? publicBrowsingLevelsFlag,
+    {
+      isModerator: viewer.isModerator,
+    }
+  );
+  return { blocked, resolved };
+}
+
+/**
+ * Server-side enforcement of the blocked-browsing-tags policy for an image feed
+ * input. Mutates `input` in place and returns `{ emptyResult }`:
+ *  - W2: strips blocked tag ids from `input.tags`; signals empty when the
+ *    caller's tag filter was entirely blocked (short-circuit to empty page).
+ *  - W1: re-derives the browsing-settings addon exclusions server-side and
+ *    unions them in. Moderators bypass (resolveBrowsingSettingsAddons); a
+ *    viewer's own-content feed keeps its tag exclusions off (own POI stays
+ *    visible), matching the client's `isOwnImages` behavior.
+ */
+export async function enforceBlockedBrowsingTags(
+  input: AddonTarget & { tags?: number[] },
+  viewer: Viewer
+): Promise<{ emptyResult: boolean }> {
+  const { blocked, resolved } = await loadBlockedBrowsingContext(input.browsingLevel, viewer);
+
+  const strip = stripBlockedTagIds(
+    input.tags,
+    blocked.map((t) => t.id)
+  );
+  if (strip.emptyResult) return { emptyResult: true };
+  input.tags = strip.tagIds;
+
+  applyAddonExclusions(input, resolved, viewer);
+  return { emptyResult: false };
+}
+
+/**
+ * Model-feed equivalent of `enforceBlockedBrowsingTags`. Models filter by a
+ * single tag name (`tag`/`tagname`) rather than an id array, so W2 short-circuits
+ * when that name is blocked.
+ */
+export async function enforceBlockedBrowsingTagsForModels(
+  input: AddonTarget & { tag?: string; tagname?: string },
+  viewer: Viewer
+): Promise<{ emptyResult: boolean }> {
+  const { blocked, resolved } = await loadBlockedBrowsingContext(input.browsingLevel, viewer);
+
+  const requestedTagName = input.tagname ?? input.tag;
+  if (
+    isBlockedTagName(
+      requestedTagName,
+      blocked.map((t) => t.name.toLowerCase())
+    )
+  )
+    return { emptyResult: true };
+
+  applyAddonExclusions(input, resolved, viewer);
+  return { emptyResult: false };
+}

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -144,6 +144,7 @@ import {
   getUserCollectionPermissionsByIds,
   removeEntityFromAllCollections,
 } from '~/server/services/collection.service';
+import { enforceBlockedBrowsingTags } from '~/server/services/blocked-browsing-tags.service';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
 import {
   getVisibleModel3DIdForPost,
@@ -1242,6 +1243,13 @@ export const getAllImages = async (
     userId?: number;
   }
 ) => {
+  const blockedEnforcement = await enforceBlockedBrowsingTags(input, {
+    id: input.user?.id,
+    username: input.user?.username,
+    isModerator: input.user?.isModerator,
+  });
+  if (blockedEnforcement.emptyResult) return { nextCursor: undefined, items: [] };
+
   const {
     limit,
     cursor,
@@ -2215,6 +2223,13 @@ export const getAllImagesIndex = async (
 
   const { include, user } = input;
 
+  const blockedEnforcement = await enforceBlockedBrowsingTags(input, {
+    id: user?.id,
+    username: user?.username,
+    isModerator: user?.isModerator,
+  });
+  if (blockedEnforcement.emptyResult) return { nextCursor: undefined, items: [] };
+
   // - cursor uses "offset|entryTimestamp" like "500|1724677401898"
   const cursorParsed = input.cursor?.toString().split('|');
   const offset = isNumber(cursorParsed?.[0]) ? Number(cursorParsed?.[0]) : 0;
@@ -2843,6 +2858,12 @@ export async function getImagesFromFeedSearch(
   input: ImageSearchInput
 ): Promise<GetAllImagesIndexResult> {
   try {
+    const blockedEnforcement = await enforceBlockedBrowsingTags(input, {
+      id: input.currentUserId,
+      isModerator: input.isModerator,
+    });
+    if (blockedEnforcement.emptyResult) return { nextCursor: undefined, items: [] };
+
     // Evaluate feature flags before creating feed. Routed through getFliptBoolean
     // (memoized once PR #2394's eval cache lands) instead of a direct per-request
     // wasm eval; it swallows errors and returns false on a missing/uninitialized
@@ -3848,9 +3869,10 @@ export async function getImagesFromBitdexPreFilter(
   if (nonRemixesOnly) filters.push(_eq('isRemix', _bool(false)));
 
   // --- Tag exclusions ---
-  // Per-user hidden tags handled client-side by useApplyHiddenPreferences.
-  // Excluding here breaks BitDex cache (every user gets a unique cache key).
-  // if (excludedTagIds?.length) filters.push(_notIn('tagIds', excludedTagIds.map(_int)));
+  // Server-enforced browsing-settings addon exclusions (uniform per browsing
+  // level, so BitDex cache keys stay stable across users). Per-user hidden tags
+  // are still applied client-side by useApplyHiddenPreferences.
+  if (excludedTagIds?.length) filters.push(_notIn('tagIds', excludedTagIds.map(_int)));
 
   // --- Metadata ---
   if (withMeta) filters.push(_eq('hasMeta', _bool(true)));

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1287,6 +1287,7 @@ export const getAllImages = async (
     baseModels,
     collectionTagId,
     excludedUserIds,
+    excludedTagIds,
     disablePoi,
     disableMinor,
     poiOnly,
@@ -1452,6 +1453,15 @@ export const getAllImages = async (
   }
   if (disableMinor) {
     AND.push(Prisma.sql`(i."minor" != TRUE)`);
+  }
+  if (excludedTagIds?.length) {
+    const notExcluded = Prisma.sql`NOT EXISTS (
+      SELECT 1 FROM "TagsOnImageDetails" toi
+      WHERE toi."imageId" = i.id
+        AND toi."tagId" IN (${Prisma.join([...new Set(excludedTagIds)])})
+        AND toi."disabled" = FALSE
+    )`;
+    AND.push(userId ? Prisma.sql`(${notExcluded} OR i."userId" = ${userId})` : notExcluded);
   }
 
   if (isModerator) {

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -421,6 +421,14 @@ export const getModelsRaw = async ({
   if (disableMinor) {
     AND.push(Prisma.sql`${pSql}."minor" = false`);
   }
+  if (input.excludedTagIds?.length) {
+    const notExcluded = Prisma.sql`NOT EXISTS (
+      SELECT 1 FROM "TagsOnModels" tom
+      WHERE tom."modelId" = m."id"
+        AND tom."tagId" IN (${Prisma.join([...new Set(input.excludedTagIds)])})
+    )`;
+    AND.push(userId ? Prisma.sql`(${notExcluded} OR m."userId" = ${userId})` : notExcluded);
+  }
 
   if (isModerator) {
     if (poiOnly) {
@@ -1026,6 +1034,15 @@ export const getModels = async <TSelect extends Prisma.ModelSelect>({
   user?: SessionUser;
   count?: boolean;
 }) => {
+  const blockedEnforcement = await enforceBlockedBrowsingTagsForModels(input, {
+    id: sessionUser?.id,
+    username: sessionUser?.username,
+    isModerator: sessionUser?.isModerator,
+  });
+  if (blockedEnforcement.emptyResult) {
+    return count ? { items: [], count: 0 } : { items: [], isPrivate: false };
+  }
+
   const {
     take,
     skip,
@@ -1113,11 +1130,14 @@ export const getModels = async <TSelect extends Prisma.ModelSelect>({
   if (excludedUserIds && excludedUserIds.length && !username) {
     AND.push({ userId: { notIn: excludedUserIds } });
   }
-  // if (excludedTagIds && excludedTagIds.length && !username) {
-  //   AND.push({
-  //     tagsOnModels: { none: { tagId: { in: excludedTagIds } } },
-  //   });
-  // }
+  if (excludedTagIds && excludedTagIds.length) {
+    AND.push({
+      OR: [
+        { tagsOnModels: { none: { tagId: { in: excludedTagIds } } } },
+        ...(sessionUser?.id ? [{ userId: sessionUser.id }] : []),
+      ],
+    });
+  }
   if (excludedModelIds && !hidden && !username) {
     AND.push({ id: { notIn: excludedModelIds } });
   }

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -79,6 +79,7 @@ import { associatedResourceSelect } from '~/server/selectors/model.selector';
 import { modelFileSelect } from '~/server/selectors/modelFile.selector';
 import { simpleUserSelect, userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import { deleteBidsForModel, getLastAuctionReset } from '~/server/services/auction.service';
+import { enforceBlockedBrowsingTagsForModels } from '~/server/services/blocked-browsing-tags.service';
 import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
 import {
   getAvailableCollectionItemsFilterForUser,
@@ -252,6 +253,13 @@ export const getModelsRaw = async ({
   /** For testing only: force the ModelBaseModelMetric query path regardless of feature flag */
   _forceBaseModelMetrics?: boolean;
 }) => {
+  const blockedEnforcement = await enforceBlockedBrowsingTagsForModels(input, {
+    id: sessionUser?.id,
+    username: sessionUser?.username,
+    isModerator: sessionUser?.isModerator,
+  });
+  if (blockedEnforcement.emptyResult) return { items: [], isPrivate: false };
+
   const {
     user,
     take,

--- a/src/server/services/system-cache.ts
+++ b/src/server/services/system-cache.ts
@@ -228,7 +228,18 @@ export async function getCategoryTags(type: 'image' | 'model' | 'post' | 'articl
 // Names resolved from the DB (lowercase) so W2 name matching + tag-page 404 work.
 export async function getBlockedBrowsingTags(): Promise<{ id: number; name: string }[]> {
   const cached = await redis.get(REDIS_KEYS.SYSTEM.BLOCKED_BROWSING_TAGS);
-  if (cached) return JSON.parse(cached) as { id: number; name: string }[];
+  if (cached) {
+    // Fail open on a corrupt ops-set value (this getter is on the hot feed +
+    // tag-page path); fall through to the DB fetch, which rewrites the key.
+    try {
+      const parsed = JSON.parse(cached);
+      if (Array.isArray(parsed)) return parsed as { id: number; name: string }[];
+    } catch (err) {
+      logSysRedisFailOpen('read-degraded', 'getBlockedBrowsingTags', err, {
+        cachedSample: cached.slice(0, 64),
+      });
+    }
+  }
 
   log('getting blocked browsing tags');
   const tags = await dbRead.tag.findMany({

--- a/src/server/services/system-cache.ts
+++ b/src/server/services/system-cache.ts
@@ -16,7 +16,10 @@ import { createLogger } from '~/utils/logging';
 import { isDefined } from '~/utils/type-guards';
 import type { LiveFeatureFlags } from '../common/constants';
 import { DEFAULT_LIVE_FEATURE_FLAGS } from '../common/constants';
-import { DEFAULT_BROWSING_SETTINGS_ADDONS } from '~/shared/constants/browsing-settings-addons';
+import {
+  BLOCKED_BROWSING_TAG_IDS,
+  DEFAULT_BROWSING_SETTINGS_ADDONS,
+} from '~/shared/constants/browsing-settings-addons';
 import type { BrowsingSettingsAddon } from '~/shared/constants/browsing-settings-addons';
 
 const log = createLogger('system-cache', 'green');
@@ -220,23 +223,25 @@ export async function getCategoryTags(type: 'image' | 'model' | 'post' | 'articl
 //   return tags;
 // }
 
-// export async function getBlockedTags() {
-//   const cachedTags = await redis.get(REDIS_KEYS.SYSTEM.TAGS_BLOCKED);
-//   if (cachedTags) return JSON.parse(cachedTags) as { id: number; name: string }[];
+// Hard navigation blocklist (W2). Seeded from BLOCKED_BROWSING_TAG_IDS; ops
+// override the live set by writing a JSON `{id, name}[]` to the redis key.
+// Names resolved from the DB (lowercase) so W2 name matching + tag-page 404 work.
+export async function getBlockedBrowsingTags(): Promise<{ id: number; name: string }[]> {
+  const cached = await redis.get(REDIS_KEYS.SYSTEM.BLOCKED_BROWSING_TAGS);
+  if (cached) return JSON.parse(cached) as { id: number; name: string }[];
 
-//   log('getting blocked tags');
-//   const tags = await dbWrite.tag.findMany({
-//     where: { nsfwLevel: NsfwLevel.Blocked },
-//     select: { id: true, name: true },
-//   });
+  log('getting blocked browsing tags');
+  const tags = await dbRead.tag.findMany({
+    where: { id: { in: BLOCKED_BROWSING_TAG_IDS } },
+    select: { id: true, name: true },
+  });
+  await redis.set(REDIS_KEYS.SYSTEM.BLOCKED_BROWSING_TAGS, JSON.stringify(tags), {
+    EX: SYSTEM_CACHE_EXPIRY,
+  });
 
-//   await redis.set(REDIS_KEYS.SYSTEM.TAGS_BLOCKED, JSON.stringify(tags), {
-//     EX: SYSTEM_CACHE_EXPIRY,
-//   });
-
-//   log('got blocked tags');
-//   return tags;
-// }
+  log('got blocked browsing tags');
+  return tags;
+}
 
 export async function getHomeExcludedTags() {
   const cachedTags = await redis.get(REDIS_KEYS.SYSTEM.HOME_EXCLUDED_TAGS);
@@ -272,9 +277,7 @@ export async function getBrowsingSettingAddons() {
     // the awaited get ~11min on EVERY page render; the try/catch below only
     // covers a fast DOWN reject. On timeout the deadline rejects into the
     // catch → fail open to defaults.
-    cached = await withSysReadDeadline(
-      sysRedis.get(REDIS_SYS_KEYS.SYSTEM.BROWSING_SETTING_ADDONS)
-    );
+    cached = await withSysReadDeadline(sysRedis.get(REDIS_SYS_KEYS.SYSTEM.BROWSING_SETTING_ADDONS));
   } catch (err) {
     logSysRedisFailOpen('read-degraded', 'getBrowsingSettingAddons', err);
     return DEFAULT_BROWSING_SETTINGS_ADDONS;

--- a/src/server/utils/blocked-browsing-tags.ts
+++ b/src/server/utils/blocked-browsing-tags.ts
@@ -1,0 +1,18 @@
+export function stripBlockedTagIds(
+  tagIds: number[] | undefined,
+  blockedIds: Iterable<number>
+): { tagIds?: number[]; emptyResult: boolean } {
+  if (!tagIds?.length) return { tagIds, emptyResult: false };
+  const blocked = blockedIds instanceof Set ? blockedIds : new Set(blockedIds);
+  const filtered = tagIds.filter((id) => !blocked.has(id));
+  return { tagIds: filtered, emptyResult: filtered.length === 0 };
+}
+
+export function isBlockedTagName(
+  name: string | undefined,
+  blockedNames: Iterable<string>
+): boolean {
+  if (!name) return false;
+  const blocked = blockedNames instanceof Set ? blockedNames : new Set(blockedNames);
+  return blocked.has(name.toLowerCase());
+}

--- a/src/shared/constants/browsing-settings-addons.ts
+++ b/src/shared/constants/browsing-settings-addons.ts
@@ -93,11 +93,17 @@ export const BLOCKED_BROWSING_TAG_IDS: number[] = [
   130818, //porn actress
   130820, //adult actress
   133182, //porn star
+  130401, //deepfake
+  110980, //public figure
   5351, //child
   306619, //child present
   154326, //toddler
   161829, //male child
   163032, //female child
+  114467, //loli
+  6641, //shota
+  250436, //minor
+  115249, //teenager
 ];
 
 export const DEFAULT_BROWSING_SETTINGS_ADDONS: BrowsingSettingsAddon[] = [
@@ -118,6 +124,8 @@ export const DEFAULT_BROWSING_SETTINGS_ADDONS: BrowsingSettingsAddon[] = [
       130818, //porn actress
       130820, //adult actress
       133182, //porn star
+      130401, //deepfake
+      110980, //public figure
     ],
   },
   {
@@ -130,6 +138,16 @@ export const DEFAULT_BROWSING_SETTINGS_ADDONS: BrowsingSettingsAddon[] = [
       154326, //toddler
       161829, //male child
       163032, //female child
+    ],
+  },
+  {
+    type: 'some',
+    nsfwLevels: [NsfwLevel.PG, NsfwLevel.PG13, NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX],
+    excludedTagIds: [
+      114467, //loli
+      6641, //shota
+      250436, //minor
+      115249, //teenager
     ],
   },
 ] as const;

--- a/src/shared/constants/browsing-settings-addons.ts
+++ b/src/shared/constants/browsing-settings-addons.ts
@@ -81,6 +81,25 @@ export function resolveBrowsingSettingsAddons(
   }, emptyResolvedAddons());
 }
 
+// Seed for the hard navigation blocklist (W2). The redis key
+// `system:blocked-browsing-tags` overrides this when present; ops manage the
+// live list there without a deploy. Kept in sync with the POI + minor
+// `excludedTagIds` in DEFAULT_BROWSING_SETTINGS_ADDONS below.
+export const BLOCKED_BROWSING_TAG_IDS: number[] = [
+  5161, //actor
+  5162, //actress
+  5188, //celebrity
+  5249, //real person
+  130818, //porn actress
+  130820, //adult actress
+  133182, //porn star
+  5351, //child
+  306619, //child present
+  154326, //toddler
+  161829, //male child
+  163032, //female child
+];
+
 export const DEFAULT_BROWSING_SETTINGS_ADDONS: BrowsingSettingsAddon[] = [
   {
     type: 'none',


### PR DESCRIPTION
## Server-enforced blocked browsing tags

Moves ToS-sensitive tag hiding (celebrity/real-person, minor-context) from
client-only enforcement to the server. Two mechanisms, one branch/PR.

### W1 — server-side addon enforcement (content hiding, browsing-level-scoped)

The addon POI/minor filters (`i."poi" != TRUE`, `i."minor" != TRUE`,
`excludedTagIds` `NOT IN`/`NOT EXISTS`) **already existed** in both feed paths —
but they only fired when the **client** supplied `disablePoi`/`disableMinor`/
`excludedTagIds` in the request. The server never re-derived them, so a raw
tRPC/REST call that omitted them returned unfiltered POI content.

This PR re-derives `resolveBrowsingSettingsAddons(addons, browsingLevel,
{ isModerator })` **server-side** from the session user + request browsing level
and unions the result into the feed input (`input.disablePoi ||= resolved.disablePoi`,
etc.) before the existing filters run — so a hostile client that omits/empties
those inputs still gets filtered. Client-sent `excludedTagIds` are still accepted
as additive input.

Enforced at the shared image feed chokepoints — `getAllImages` (DB legacy),
`getAllImagesIndex` (Meili/BitDex dispatch), `getImagesFromFeedSearch` (REST
public non-bitdex) — which together cover the tRPC `image.getInfinite` handler
**and** the REST `/api/v1/images` + `/api/v1/blocks/images` handlers
(`runImageSearch`). Also wired into `getModelsRaw` for the model feed.

- **Moderator bypass**: intact — `resolveBrowsingSettingsAddons` returns none for
  mods (existing behavior).
- **Owner-own-content bypass**: the addon `excludedTagIds` union is skipped when
  the feed is scoped to the viewer (`input.userId === viewer.id` or
  `input.username === viewer.username`), matching the client's `isOwnImages`
  behavior (`image.utils.ts`). `disablePoi`/`disableMinor` are still applied
  (also matching the client), and the existing SQL poi/minor filters already
  carry their own `OR userId = viewer` owner clause; the Meili/BitDex paths
  re-add own poi/blocked/private content via their second-pass merge.
- **BitDex gap closed**: the previously-commented `_notIn('tagIds', ...)` filter
  in `getImagesFromBitdexPreFilter` is enabled. The addon ids are uniform per
  browsing level, so BitDex cache keys stay stable across users (the original
  concern was per-user hidden tags, which remain client-side).

### W2 — hard navigation blocklist

- **Registry**: new `getBlockedBrowsingTags()` in `system-cache.ts` (modeled on
  `getSystemTags()`), backed by redis key `system:blocked-browsing-tags`, seeded
  from `BLOCKED_BROWSING_TAG_IDS` (co-located with the addon fallback) and
  overridable by writing a JSON `{id,name}[]` to the key — no deploy required.
  Removed the dead commented `getBlockedTags()` (its `nsfwLevel=Blocked` approach
  would poison image nsfwLevel computation).
- **Tag-filter stripping + empty short-circuit**: blocked tag ids/names are
  stripped from feed inputs. If the caller's tag filter was non-empty and becomes
  empty after stripping (i.e. they filtered *only* by blocked tags), the query
  short-circuits to an empty page — communicating "nothing here" instead of
  silently showing the full unfiltered feed under a `?tags=`/`/tag/` URL.
- **Tag page 404**: `/tag/[tagname]` returns `{ notFound: true }` for
  **everyone including moderators** when the tag name matches the blocklist
  (case-insensitive).

### Decisions made where the spec deferred

- **Enforcement site = image/model service functions, not `applyUserPreferences`
  middleware.** The middleware doesn't cover the image feed (`heavyProcedure`
  has no `applyUserPreferences`) nor the REST `/api/v1/images` path, and lacks a
  reliable browsing-level. The service-layer chokepoints cover tRPC + both REST
  endpoints. The spec explicitly allowed this ("a sibling step in the image/model
  services if middleware lacks browsing-level context").
- **Owner bypass via own-scope check, not a Meili `OR userId` filter.** The spec
  offered the `(NOT tagIds IN [...]) OR userId = <viewer>` Meili filter as
  preferred but accepted "apply exclusion except when the query is scoped to the
  viewer" as a fallback. I used the fallback: it's the exact behavior the client
  ships today, avoids depending on unverified Meili OR-at-nesting grammar, and
  the Meili/BitDex own-content second-pass merge already restores own
  poi/blocked/private content.
- **W1 does not add new filter clauses** where server enforcement already existed
  — it only feeds the server-derived flags into the existing filters, avoiding
  duplicate enforcement. The only newly-added filter is the BitDex `excludedTagIds`
  one (the confirmed real gap).
- **Seed = current prod addon POI+minor ids.** Confirmed (data-audit) that the
  live prod sysRedis addon list is byte-identical to the code fallback, so the
  seed constant is safe.

### Manual data step (NOT in this PR)

Set `unlisted = true` on all blocked tags so `getTags` hides them from
autocomplete/pickers (W2 discovery). This is a manual `UPDATE` against prod (same
pattern as the category prune) — no migration. Example:

```sql
UPDATE "Tag" SET "unlisted" = true
WHERE id IN (5161,5162,5188,5249,130818,130820,133182,130401,110980,
             5351,306619,154326,161829,163032,114467,6641,250436,115249);
```

Post-audit sign-off (Justin) expanded the blocklist to these 18 ids: the addon
now also excludes deepfake (130401) + public figure (110980) on the POI entry and
adds a 4th entry for loli (114467) / shota (6641) / minor (250436) / teenager
(115249) — deliberately without a `disableMinor` flag. instagram/influencer were
declined. Prod sysRedis addon value was updated in lockstep, so the code fallback
stays byte-identical.

### Acceptance criteria

- [x] (8) `pnpm run typecheck` + `pnpm run lint` clean; no new files under
      `src/pages` (tests live in `src/server/__tests__/`).
- [x] (1,2) Anon/user call with `tags:[<blocked id>]` and no `excludedTagIds` →
      empty (W2 strip + short-circuit); moderator → tag filter still stripped
      (W2 is absolute). Verified by the strip/short-circuit unit tests + code path
      (both tRPC `getInfinite` and REST `/api/v1/images` converge on the
      instrumented functions).
- [x] (6) `/tag/celebrity` → 404 for anon AND moderator; `/tag/cat` → 200
      (getServerSideProps blocklist check, applied before render for everyone).
- [x] (7) BitDex path enforces the same exclusions (excludedTagIds `_notIn`
      enabled; disablePoi/disableMinor injected).
- [x] (9) No behavior change for non-blocked tags (strip is a no-op when no
      requested tag is blocked — covered by unit test).
- [~] (3,4,5) Server-enforced POI hiding on an unfiltered feed, owner-own-content
      visible, moderator visibility intact: verified by code trace + the
      `resolveBrowsingSettingsAddons` server-derivation unit tests (mod bypass +
      per-level scoping). **Not exercised against a live feed / real Meili index**
      in this environment.

### Adversarial-review fixes (2nd push)

1. **browsingLevel:0 bypass (HIGH)**: server addon derivation now coerces falsy
   levels (and Blocked-only levels collapsing to 0 after `onlySelectableLevels`)
   to `publicBrowsingLevelsFlag` — a client-sent `browsingLevel: 0` can no
   longer disable every exclusion. Unit-tested.
2. **excludedTagIds on DB paths (MED)**: `getAllImages` and `getModelsRaw` now
   apply a `NOT EXISTS` tag-exclusion clause (owner bypass via `OR userId =
   viewer`), so group-3 tags (loli/shota/minor/teenager — deliberately no
   `disableMinor` flag) are hidden on the DB fallback and model feeds, not just
   Meili/BitDex. `getModelsRaw`'s pre-existing JS post-filter remains as defense
   in depth.
3. **Corrupt redis value (MED)**: `getBlockedBrowsingTags` fails OPEN — parse
   errors are logged (`logSysRedisFailOpen`) and fall through to the DB fetch,
   which rewrites the key (self-healing), matching sibling getters.
4. **`models.getAllPagedSimple` (MED)**: the deprecated `getModels` it routes to
   now runs `enforceBlockedBrowsingTagsForModels` (blocked-tagname
   short-circuit + W1 addon injection — mods bypass, so the moderator page that
   is its only first-party caller is unaffected) and applies the previously
   commented `tagsOnModels` exclusion filter with owner bypass.
5. **Tests**: `enforceBlockedBrowsingTags` / `...ForModels` are now exercised
   directly (browsingLevel:0, empty short-circuit, moderator tag-strip,
   own-scope bypass, client-id union, name-casing) — 16 tests total.

**Known limitation (accepted)**: the registry caches tag id+name for 4h
(`SYSTEM_CACHE_EXPIRY`); renaming a blocked tag can leave the `/tag/[name]` 404
matching the old name for up to 4h. Delete the redis key to refresh immediately.

### Not verified locally

- Live Meili/BitDex query behavior against a real index (no index access in the
  worktree). Empty-result short-circuit and excludedTagIds injection verified by
  code path + unit tests, not a live query.
- End-to-end anon REST call returning empty (no running server/index here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

