### PR TITLE
fix(engaged-models): re-land notify explicit-setTo onto main (was #3039)

### DIFF
--- a/src/components/Model/Actions/ToggleModelNotification.tsx
+++ b/src/components/Model/Actions/ToggleModelNotification.tsx
@@ -70,9 +70,19 @@ export function ToggleModelNotification({
               // F1: block the toggle until membership is known — a cold store reads
               // as not-engaged and would fire the OPPOSITE of the user's intent.
               if (!isKnown) return;
+              // Carry an EXPLICIT direction (setTo) derived from the button intent,
+              // never a blind server-side toggle. isOn=true → the user wants OFF
+              // (set Mute, which also overrides a follow-based auto-watch); isOn=false
+              // → the user wants ON (set Notify). With setTo the server sets the row
+              // to exactly this state, so even if the store fabricated "off" for a
+              // genuinely-ON model (the #3034 error-path un-stick), a click can no
+              // longer silently DELETE the existing Notify — it's an idempotent
+              // subscribe. The optimistic write below is therefore the guaranteed
+              // outcome, not a guess, so the store never ends up lying vs the server.
               toggleNotifyModelMutation.mutate({
                 modelId,
-                type: isOn ? ModelEngagementType.Mute : undefined,
+                type: isOn ? ModelEngagementType.Mute : ModelEngagementType.Notify,
+                setTo: true,
               });
             }}
             loading={toggleNotifyModelMutation.isPending || !isKnown}

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -774,9 +774,20 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                               // known — a cold store reads not-engaged and would fire
                               // the OPPOSITE of the user's intent.
                               if (!isNotifyKnown) return;
+                              // Carry an EXPLICIT direction (setTo) — never a blind
+                              // server toggle. on→OFF (set Mute, overrides a
+                              // follow-based auto-watch); off→ON (set Notify). With
+                              // setTo the server sets the row to exactly this state, so
+                              // a click acting on a fabricated/errored "off" for a
+                              // genuinely-ON model can no longer silently DELETE the
+                              // Notify — it's an idempotent subscribe, and the
+                              // optimistic write matches the guaranteed server outcome.
                               toggleNotifyModelMutation.mutate({
                                 modelId: model.id,
-                                type: isNotificationOn ? ModelEngagementType.Mute : undefined,
+                                type: isNotificationOn
+                                  ? ModelEngagementType.Mute
+                                  : ModelEngagementType.Notify,
+                                setTo: true,
                               });
                             }}
                             loading={toggleNotifyModelMutation.isPending || !isNotifyKnown}

--- a/src/hooks/__tests__/useEngagedModelMembership.test.ts
+++ b/src/hooks/__tests__/useEngagedModelMembership.test.ts
@@ -28,6 +28,7 @@ import {
   useEngagedModelMembership,
 } from '~/hooks/useEngagedModelMembership';
 import { useEngagedModelsStore } from '~/store/engaged-models.store';
+import { applyNotifyToggled } from '~/store/engaged-models.optimistic';
 
 // deterministic scheduler: capture the flush callback, fire it on demand.
 let scheduledFlush: (() => void) | null = null;
@@ -390,5 +391,121 @@ describe('useEngagedModelMembership — authed fetch error does not dead-lock th
     // not a permanently-disabled dead button.
     expect(button().disabled).toBe(false);
     unmount();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Silent-unsubscribe fix (audit fast-follow to the #3034 error path).
+//
+// The #3034 error path marks a genuinely Notify-ON model known-not-engaged when
+// its by-ids read errors (so the gated control un-sticks). The OLD notify
+// mutation then sent `type: isOn ? Mute : undefined` — an UNDEFINED type on the
+// subscribe click → the server BLIND-toggled and DELETED the existing Notify
+// (silent unsubscribe), while `onMutate` optimistically wrote Notify=true → the
+// store was left LYING (ON on the client, OFF on the server).
+//
+// The fix carries an EXPLICIT `setTo` derived from the button intent, so the
+// click that lands on a fabricated-off (but genuinely-ON) model is an idempotent
+// subscribe, never a delete — and the optimistic write matches the guaranteed
+// server outcome. This harness replicates the REAL control's click derivation
+// (isOn + payload + onMutate optimistic) on top of the REAL hook/store/optimistic
+// modules; the server half (setTo:true never deletes) is pinned in
+// server/services/__tests__/engagement-toggle.idempotent.service.test.ts.
+// ---------------------------------------------------------------------------
+
+interface NotifyPayload {
+  modelId: number;
+  type: 'Notify' | 'Mute' | undefined;
+  setTo?: boolean;
+}
+
+/**
+ * Faithful replica of ToggleModelNotification's click path (following=[] → not
+ * following the creator). Captures the payload the control would `.mutate()` and
+ * runs the same `onMutate` optimistic write.
+ */
+function NotifyClickHarness({
+  modelId,
+  onPayload,
+}: {
+  modelId: number;
+  onPayload: (p: NotifyPayload) => void;
+}) {
+  const { isEngaged, isKnown } = useEngagedModelMembership(modelId);
+  const isWatching = isEngaged('Notify');
+  const isMuted = isEngaged('Mute');
+  const isOn = isWatching && !isMuted; // not following the creator in this harness
+
+  const onClick = () => {
+    if (!isKnown) return;
+    const payload: NotifyPayload = {
+      modelId,
+      type: isOn ? 'Mute' : 'Notify',
+      setTo: true,
+    };
+    // onMutate optimistic write (mirrors the mutation's onMutate).
+    applyNotifyToggled(modelId, !isOn);
+    onPayload(payload);
+  };
+
+  return React.createElement(
+    'button',
+    { type: 'button', disabled: !isKnown, onClick },
+    'notify'
+  );
+}
+
+describe('notify silent-unsubscribe fix — genuinely-ON model whose by-ids read errored', () => {
+  it('click on the (fabricated-off) bell sends an EXPLICIT subscribe (type=Notify, setTo=true) — never a blind toggle — and the store does not end up lying', async () => {
+    currentUser = { id: 1 };
+    const modelId = 55;
+    // The by-ids read for this genuinely Notify-ON model ERRORS.
+    queryMock.mockRejectedValueOnce(new Error('boom'));
+
+    let captured: NotifyPayload | undefined;
+    const container = document.createElement('div');
+    const root = createRoot(container);
+    act(() =>
+      root.render(
+        React.createElement(NotifyClickHarness, { modelId, onPayload: (p) => (captured = p) })
+      )
+    );
+
+    // In flight → unknown → disabled.
+    const button = () => container.querySelector('button') as HTMLButtonElement;
+    expect(button().disabled).toBe(true);
+
+    runFlush();
+    await settle();
+    act(() =>
+      root.render(
+        React.createElement(NotifyClickHarness, { modelId, onPayload: (p) => (captured = p) })
+      )
+    );
+
+    // #3034 error path: id is now known-not-engaged (fabricated OFF) → control enabled,
+    // and the store reads Notify as absent even though the server row IS Notify.
+    expect(button().disabled).toBe(false);
+    expect(useEngagedModelsStore.getState().queried.has(modelId)).toBe(true);
+    expect(useEngagedModelsStore.getState().membership[modelId]?.has('Notify')).toBe(false);
+
+    // User clicks the bell (intending to subscribe).
+    act(() => button().click());
+
+    // 1) The payload carries EXPLICIT direction — a subscribe, not a blind toggle.
+    //    (The old bug sent `type: undefined` here → server-side blind DELETE.)
+    expect(captured).toBeDefined();
+    expect(captured?.type).toBe('Notify');
+    expect(captured?.setTo).toBe(true);
+    expect(captured?.type).not.toBeUndefined();
+
+    // 2) The optimistic write leaves the store showing Notify=ON. Because setTo:true
+    //    on an existing Notify is a no-op subscribe server-side (pinned in the service
+    //    test), the server is ALSO ON — store == server, so the UI is not left lying.
+    const m = useEngagedModelsStore.getState().membership[modelId];
+    expect(m?.has('Notify')).toBe(true);
+    expect(m?.has('Mute')).toBe(false);
+
+    act(() => root.unmount());
   });
 });

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -990,7 +990,12 @@ export const toggleNotifyModelHandler = async ({
   try {
     const { id: userId } = ctx.user;
     const result = input.type
-      ? await toggleModelEngagement({ modelId: input.modelId, type: input.type, userId })
+      ? await toggleModelEngagement({
+          modelId: input.modelId,
+          type: input.type,
+          setTo: input.setTo,
+          userId,
+        })
       : await toggleModelNotify({ ...input, userId });
 
     if (result) {

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -145,6 +145,13 @@ export type ToggleFavoriteInput = z.infer<typeof toggleFavoriteInput>;
 export const toggleModelEngagementInput = z.object({
   modelId: z.number(),
   type: z.enum(ModelEngagementType).optional(),
+  // Explicit toggle direction. When provided, the server sets the engagement to
+  // exactly this state (subscribe vs unsubscribe) instead of blind-toggling off
+  // the current row — so a caller acting on a stale/errored/fabricated client
+  // view can never fire the OPPOSITE of the user's intent (e.g. silently DELETE
+  // a genuinely-ON Notify because the client briefly read it as off). Optional
+  // for backward-compat: absent → legacy blind toggle.
+  setTo: z.boolean().optional(),
 });
 export type ToggleModelEngagementInput = z.infer<typeof toggleModelEngagementInput>;
 

--- a/src/server/services/__tests__/engagement-toggle.idempotent.service.test.ts
+++ b/src/server/services/__tests__/engagement-toggle.idempotent.service.test.ts
@@ -103,6 +103,89 @@ describe('toggleModelEngagement — idempotent on P2002 race (the confirmed prod
   });
 });
 
+describe('toggleModelEngagement — explicit setTo direction (notify silent-unsubscribe fix)', () => {
+  // Regression for the audit finding on the engaged-models client refactor:
+  // a genuinely Notify-ON model whose by-ids read errored made the client render
+  // the bell as "off"; the old notify mutation then sent `type=undefined` → the
+  // server BLIND-toggled (`setTo ??= engagement?.type===type ? false : true`) and,
+  // seeing the existing Notify row, DELETED it — a silent, wrong-direction
+  // unsubscribe. The fix makes the client always carry an explicit `setTo`, so the
+  // server sets the row to exactly the intended state and can never delete on a
+  // "subscribe" click. These tests pin BOTH: the old blind path was destructive,
+  // the new explicit-setTo path is an idempotent subscribe.
+
+  it('LEGACY blind toggle (no setTo) on an existing Notify → DELETES it (the bug being closed)', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce({ type: 'Notify' });
+
+    const result = await toggleModelEngagement({ userId: 42, modelId: 10, type: 'Notify' });
+
+    // Blind toggle: existing type === requested type → setTo resolves to false → delete.
+    expect(mockDb.modelEngagement.delete).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false); // "unsubscribed" — exactly the silent-unsubscribe symptom
+  });
+
+  it('explicit setTo:true on an existing Notify → NO delete, idempotent subscribe (returns true)', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce({ type: 'Notify' });
+
+    const result = await toggleModelEngagement({
+      userId: 42,
+      modelId: 10,
+      type: 'Notify',
+      setTo: true,
+    });
+
+    // The row already IS Notify and we asked to set it ON → no-op success, never a delete.
+    expect(mockDb.modelEngagement.delete).not.toHaveBeenCalled();
+    expect(mockDb.modelEngagement.update).not.toHaveBeenCalled();
+    expect(result).toBe(true); // still subscribed
+  });
+
+  it('explicit setTo:true on a Mute row (type Notify) → UPDATEs to Notify (un-mute subscribe), never deletes', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce({ type: 'Mute' });
+
+    const result = await toggleModelEngagement({
+      userId: 42,
+      modelId: 10,
+      type: 'Notify',
+      setTo: true,
+    });
+
+    expect(mockDb.modelEngagement.update).toHaveBeenCalledTimes(1);
+    expect(mockDb.modelEngagement.delete).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it('explicit setTo:true type Mute on an existing Notify → UPDATEs to Mute (turn-off), never blind-deletes', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce({ type: 'Notify' });
+
+    const result = await toggleModelEngagement({
+      userId: 42,
+      modelId: 10,
+      type: 'Mute',
+      setTo: true,
+    });
+
+    expect(mockDb.modelEngagement.update).toHaveBeenCalledTimes(1);
+    expect(mockDb.modelEngagement.delete).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+
+  it('explicit setTo:true with no existing row → CREATEs the requested type (fresh subscribe)', async () => {
+    mockDb.modelEngagement.findUnique.mockResolvedValueOnce(null);
+
+    const result = await toggleModelEngagement({
+      userId: 42,
+      modelId: 10,
+      type: 'Notify',
+      setTo: true,
+    });
+
+    expect(mockDb.modelEngagement.create).toHaveBeenCalledTimes(1);
+    expect(mockDb.modelEngagement.delete).not.toHaveBeenCalled();
+    expect(result).toBe(true);
+  });
+});
+
 describe('toggleUserBountyEngagement — idempotent on P2002 race (sibling)', () => {
   it('P2002 on create → returns true instead of 500', async () => {
     mockDb.bountyEngagement.findUnique.mockResolvedValueOnce(null);


### PR DESCRIPTION
Re-lands the notify silent-unsubscribe fix from **#3039** onto `main`.

**Why a new PR:** #3039 was (mistakenly) stacked on #3034's branch (`base: zach/engaged-models-client-store`). #3034 squash-merged to `main` at 23:26Z; #3039 then merged at 23:40Z **into the now-orphaned #3034 branch, not `main`** — so its change never reached `main` (the classic stacked-PR hazard). Meanwhile #3034's error-path (which can fabricate a "not-engaged" state) IS on `main`, so the silent-unsubscribe bug this fixes is currently live-able on `main`.

**Content:** identical to the merged #3039 (cherry-pick of `8c7e346dfa`), which was adversarially audited — verdict *safe to merge, no 🔴*: byte-identical to legacy behavior in every flow except the exact bug case; Notify/Mute transitions correct; `setTo` param backward-compatible (omitting callers hit the unchanged blind-toggle branch).

The notify mutation now carries an explicit `setTo: true` so the server sets the row to exactly the intended state instead of blind-toggling — the delete branch is unreachable on a subscribe click, and the optimistic write matches the server outcome.

Cleanup: the orphaned `zach/engaged-models-client-store` branch (holding the mis-merged #3039 commit) can be deleted once this lands.