### PR TITLE
refactor(generation): standardize image inputs on the shared `images` node

### DIFF
--- a/.claude/skills/add-generation-support/SKILL.md
+++ b/.claude/skills/add-generation-support/SKILL.md
@@ -312,6 +312,14 @@ Use this to avoid combinatorial rule duplication, but **be aware**: adding a rul
 
 ## Gotchas
 
+### Always use the `images` node — never `sourceImage` or a singular `image` node
+
+**Uniformity decision:** every image input in a generation graph uses the shared `imagesNode` (`.node('images', imagesNode({ min, max }))`), even when a workflow accepts exactly one image — cap it with `max: 1` instead of introducing a singular `sourceImage` (or `image`) node. Handlers read `data.images[0]`.
+
+- Single-image example: `.node('images', imagesNode({ min: 1, max: 1 }))` (see `image-preprocess-graph.ts`).
+- `normalizeInput` (in `orchestration-new.service.ts`) folds any legacy `sourceImage` into `images[]`, so older stored/remixed data still resolves — do **not** reintroduce or depend on `sourceImage`.
+- Exception: a per-entry `image` field *inside a list node* (controlnet entries, Krea2 style references — each `{ image, strength }`) is a different shape and stays `image`; those are not top-level source images.
+
 ### Don't use `.effect()` to reset slider values across variants
 
 Tempting pattern (DO NOT use):

--- a/src/components/generation_v2/GenerationForm.tsx
+++ b/src/components/generation_v2/GenerationForm.tsx
@@ -1283,28 +1283,6 @@ export function GenerationForm() {
               )}
             />
 
-            {/* PolyGen source image (image-to-3D only) */}
-            <Controller
-              graph={graph}
-              name="sourceImage"
-              render={({ value, onChange, error }) => {
-                const current = value as { url: string; width: number; height: number } | undefined;
-                return (
-                  <ImageUploadMultipleInput
-                    label="Starting image"
-                    description="The reference Meshy will use to build the 3D mesh"
-                    required
-                    max={1}
-                    aspect="square"
-                    imageLayout="wrap"
-                    value={current ? [current] : []}
-                    onChange={(v) => onChange((v[0] ?? undefined) as typeof value)}
-                    error={error?.message}
-                  />
-                );
-              }}
-            />
-
             {/* PolyGen: generate texture toggle (image-to-3D only) */}
             <Controller
               graph={graph}
@@ -2257,6 +2235,8 @@ function ImagesInput({
     <ImageUploadMultipleInput
       value={value}
       onChange={onChange}
+      label={meta?.label}
+      description={meta?.description}
       aspect="square"
       max={meta?.max}
       slots={meta?.slots}

--- a/src/components/generation_v2/GenerationFormProvider.tsx
+++ b/src/components/generation_v2/GenerationFormProvider.tsx
@@ -508,7 +508,7 @@ function InnerProvider({
           graph.reset({ exclude: ['quantity', 'priority', 'outputFormat'] });
           // PolyGen lives in a discriminated subgraph (activates only when
           // `ecosystem: 'PolyGen'`), and its child nodes — `polygenMode`,
-          // `targetPolycount`, `sourceImage`, `enableRigging`, etc. — only
+          // `targetPolycount`, `images`, `enableRigging`, etc. — only
           // exist while that subgraph is active. A single `graph.set` with
           // the full blob can drop those child keys because they're
           // evaluated before the discriminator has switched, so the remix

--- a/src/components/generation_v2/hooks/useGeneratedItemWorkflows.ts
+++ b/src/components/generation_v2/hooks/useGeneratedItemWorkflows.ts
@@ -158,17 +158,6 @@ function isCrossMediaWorkflow(image: BlobData, workflowId: string): boolean {
 }
 
 /**
- * Whether the workflow feeds its image into PolyGen's single `sourceImage`
- * node rather than the standard `images` array (i.e. img2model3d). Detected by
- * config — `workflowHasNode` can't see `sourceImage` since it's nested behind
- * the ecosystem + process discriminators.
- */
-function usesSourceImageInput(workflowId: string): boolean {
-  const config = workflowConfigByKey.get(workflowId);
-  return config?.category === 'model3d' && getInputTypeForWorkflow(workflowId) === 'image';
-}
-
-/**
  * Get the target ecosystem for a workflow, respecting stored preferences.
  * - Cross-media with alias constraint: force an ecosystem from the alias's ecosystemIds
  * - Cross-media with single-ecosystem workflow: force that ecosystem (e.g., ref2vid → Vidu)
@@ -259,24 +248,12 @@ async function applyWorkflowToForm({
 
   const inputType = getInputTypeForWorkflow(workflowId);
 
-  // PolyGen img2model3d takes its image on a single `sourceImage` node rather
-  // than the standard `images` array; feed it there instead.
-  const usesSourceImage = usesSourceImageInput(workflowId);
-
-  // Build images in graph format { url, width, height }[]
-  // Pass image for workflows that require it (inputType: 'image') OR
-  // for text-input workflows whose graph has an 'images' node.
   const isImageType = image.mediaType === 'image';
   const acceptsImages =
-    !usesSourceImage &&
-    (inputType === 'image' || (isImageType && workflowHasNode(workflowId, 'images')));
+    inputType === 'image' || (isImageType && workflowHasNode(workflowId, 'images'));
 
   let images: { url: string; width: number; height: number }[] | undefined;
-  let sourceImage: { url: string; width: number; height: number } | undefined;
-  if (usesSourceImage && isImageType) {
-    const { width, height } = await resolveImageDimensions(image);
-    sourceImage = { url: image.url, width, height };
-  } else if (acceptsImages) {
+  if (acceptsImages) {
     const { width, height } = await resolveImageDimensions(image);
     images = [{ url: image.url, width, height }];
   }
@@ -296,7 +273,6 @@ async function applyWorkflowToForm({
       prompt: image.params?.prompt,
       negativePrompt: image.params?.negativePrompt,
       ...(images ? { images } : {}),
-      ...(sourceImage ? { sourceImage } : {}),
       ...(inputType === 'video' ? { video: image.url } : {}),
       ...(ecosystem ? { ecosystem } : {}),
     },
@@ -332,9 +308,10 @@ export async function applyWorkflowWithCheck({
   const config = workflowConfigByKey.get(workflowId);
   const isStandalone = (config?.ecosystemIds.length ?? 0) === 0;
   const isEnhancement = config?.enhancement === true;
+  const isModel3d = config?.category === 'model3d';
 
   // Enhancement and standalone workflows: apply directly (no ecosystem choice needed)
-  if (isEnhancement || isStandalone) {
+  if (isEnhancement || isStandalone || isModel3d) {
     // Upscale always appends images to build a batch
     if (workflowId === 'img2img:upscale') {
       await appendUpscaleImage(image);
@@ -345,22 +322,7 @@ export async function applyWorkflowWithCheck({
       workflowId,
       image,
       ecosystem: getTargetEcosystemKey(workflowId, ecosystemKey, isCrossMedia, aliasEcosystemIds),
-      clearResources: isStandalone || isCrossMedia,
-    });
-    return;
-  }
-
-  // PolyGen image-to-3D: force the workflow's ecosystem and feed the image
-  // into the `sourceImage` node, dropping the source's SD params/resources.
-  // Must run before the `compatible` replay branch below, which would
-  // otherwise carry the source image's params and set `images` (neither of
-  // which the PolyGen graph reads).
-  if (usesSourceImageInput(workflowId)) {
-    await applyWorkflowToForm({
-      workflowId,
-      image,
-      ecosystem: getTargetEcosystemKey(workflowId, ecosystemKey, isCrossMedia, aliasEcosystemIds),
-      clearResources: true,
+      clearResources: isStandalone || isCrossMedia || isModel3d,
     });
     return;
   }

--- a/src/server/services/orchestrator/ecosystems/polygen-graph.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/polygen-graph.handler.ts
@@ -62,10 +62,15 @@ const MODEL_3D_PREVIEW_CAMERA_POSE = {
 export const createPolyGenInput = defineHandler<PolyGenCtx, StepInput[]>((data, ctx) => {
   const { polygenMode, ...rest } = data as PolyGenCtx & { polygenMode?: 'preview' | 'full' };
 
-  // Synthesize the schema shape `toMeshyPolyGenInput` expects.
+  // The orchestrator schema discriminates on `process` and speaks `sourceImage`;
+  // derive both from `workflow` + `images[0]` (the graph carries neither).
+  const process = data.workflow.startsWith('txt') ? 'textTo3D' : 'imageTo3D';
+  const sourceImage = process === 'imageTo3D' ? data.images?.[0] : undefined;
   const schemaShape = {
     ...rest,
+    process,
     ...(polygenMode !== undefined ? { mode: polygenMode } : {}),
+    ...(sourceImage ? { sourceImage } : {}),
   } as unknown as Model3DGenerationSchema;
 
   const input = toMeshyPolyGenInput(schemaShape) as

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -504,6 +504,13 @@ function normalizeVideoWorkflow(input: Record<string, unknown>): Record<string, 
  * Handles txt2img ↔ img2img:edit and video workflow corrections.
  */
 function normalizeInput(input: Record<string, unknown>): Record<string, unknown> {
+  // Back-compat: older stored/remixed inputs carry a singular `sourceImage`;
+  // fold it into `images[]` so normalization and the graph nodes see one shape.
+  if (input.sourceImage && !input.images) {
+    const { sourceImage, ...rest } = input;
+    input = { ...rest, images: [sourceImage] };
+  }
+
   // Resolve workflow variants to their base workflow before processing.
   // e.g., 'img2vid:first-last' → 'img2vid' so handlers don't need to know about variants.
   const config = workflowConfigByKey.get(input.workflow as string);
@@ -1037,127 +1044,122 @@ export async function createWorkflowStepsFromGraph({
   // workflow-level metadata, and the extra tags from the resolved data.
   // Return the assembled result directly as this function's result so the span
   // wraps the whole assembly and no fragile re-destructure/rename is needed.
-  return withSpan(
-    'gen:createSteps:assemble',
-    async () => {
-      const steps: StepInput[] = [];
-      for (const overlay of overlays) {
-        const isSnippetVariant = !isEmptyObject(overlay);
-        const variantData = isSnippetVariant
-          ? ({ ...resolvedData, ...overlay } as typeof resolvedData)
-          : resolvedData;
-        const variantStepMetadata = isSnippetVariant
-          ? buildVariantStepMetadata(variantData, computedKeys)
-          : stepMetadata;
+  return withSpan('gen:createSteps:assemble', async () => {
+    const steps: StepInput[] = [];
+    for (const overlay of overlays) {
+      const isSnippetVariant = !isEmptyObject(overlay);
+      const variantData = isSnippetVariant
+        ? ({ ...resolvedData, ...overlay } as typeof resolvedData)
+        : resolvedData;
+      const variantStepMetadata = isSnippetVariant
+        ? buildVariantStepMetadata(variantData, computedKeys)
+        : stepMetadata;
 
-        // Advance baseStepIndex per variant so cross-step `$ref` objects (e.g.
-        // preprocess → gen wiring inside controlnet handlers) resolve to the
-        // correct global step position after concatenation.
-        const variantSteps = await createStepInputs(
-          variantData,
-          { ...handlerCtx, baseStepIndex: steps.length },
-          {
-            stepMetadata: variantStepMetadata,
-            isWhatIf,
-            sourceCtx,
-          }
-        );
-
-        // Per-step metadata for snippet variants records ONLY the substituted
-        // snippet-target fields (e.g. `prompt`, `negativePrompt`) — a small DELTA — in
-        // `params`, plus `partialParams: true` to flag it as such. The workflow-level
-        // metadata already carries the full template + params snapshot, so we keep the
-        // per-step payload tiny (no full params duplicated per variant) and let the
-        // client spread the delta over the workflow params when reading.
-        // See docs/generation-metadata-architecture.md.
-        if (isSnippetVariant) {
-          for (const step of variantSteps) {
-            const existingMeta = (step.metadata ?? {}) as Record<string, unknown>;
-            const existingParams =
-              (existingMeta.params as Record<string, unknown> | undefined) ?? {};
-            step.metadata = {
-              ...existingMeta,
-              params: { ...existingParams, ...overlay },
-              partialParams: true,
-            };
-          }
+      // Advance baseStepIndex per variant so cross-step `$ref` objects (e.g.
+      // preprocess → gen wiring inside controlnet handlers) resolve to the
+      // correct global step position after concatenation.
+      const variantSteps = await createStepInputs(
+        variantData,
+        { ...handlerCtx, baseStepIndex: steps.length },
+        {
+          stepMetadata: variantStepMetadata,
+          isWhatIf,
+          sourceCtx,
         }
+      );
 
-        steps.push(...variantSteps);
+      // Per-step metadata for snippet variants records ONLY the substituted
+      // snippet-target fields (e.g. `prompt`, `negativePrompt`) — a small DELTA — in
+      // `params`, plus `partialParams: true` to flag it as such. The workflow-level
+      // metadata already carries the full template + params snapshot, so we keep the
+      // per-step payload tiny (no full params duplicated per variant) and let the
+      // client spread the delta over the workflow params when reading.
+      // See docs/generation-metadata-architecture.md.
+      if (isSnippetVariant) {
+        for (const step of variantSteps) {
+          const existingMeta = (step.metadata ?? {}) as Record<string, unknown>;
+          const existingParams = (existingMeta.params as Record<string, unknown> | undefined) ?? {};
+          step.metadata = {
+            ...existingMeta,
+            params: { ...existingParams, ...overlay },
+            partialParams: true,
+          };
+        }
       }
 
-      // Wrap with request-level concerns: priority, timeout, outputFormat
-      // isPrivateGeneration lives on workflow.metadata, not per-step.
-      // `remixOfId` is ALSO copied onto each step's metadata: the orchestrator's
-      // `WorkflowStepHandler.GenerateJobsAsync` reads `workflowStep.Metadata["remixOfId"]`
-      // (not workflow-level metadata) to thread the remix source id into the job
-      // record → MongoDB `prod.jobs.Properties.remixOfId` → CDC → ClickHouse
-      // `orchestration.jobs`, which is what makes the remix product loop measurable.
-      // See civitai-orchestration#216. Kept on workflow.metadata as well for the
-      // app's own replay/normalization path (NormalizedWorkflowMetadata.remixOfId).
-      // Intermediate steps (videoInterpolation) don't get outputFormat injected.
-      const wrappedSteps = steps.map((step) => ({
-        $type: step.$type,
-        input: {
-          ...(step.input as object),
-          // A handler-set outputFormat wins (e.g. model3DPreview pins 'png');
-          // otherwise inherit the workflow's image outputFormat choice. For
-          // non-image workflows `data.outputFormat` is undefined, so this also
-          // avoids clobbering an intermediate step's own format with undefined.
-          outputFormat:
-            (step.input as { outputFormat?: string }).outputFormat ?? data.outputFormat,
-        },
-        priority: data.priority,
-        timeout,
-        metadata: isWhatIf
-          ? undefined
-          : ({
-              ...((step.metadata as object) ?? {}),
-              ...(remixOfId != null ? { remixOfId } : {}),
-            } as object),
-      })) as WorkflowStepTemplate[];
-
-      // Build workflow-level metadata — the form input snapshot for workflow-level
-      // replay. `params.snippets` rides along automatically because it's a
-      // graph-level node captured by `toStepMetadata`.
-      //
-      // Snippet-specific persistence cleanup:
-      // - When the resolver didn't fire (snippets node at defaults, no refs, no
-      //   batch request), strip the entire `snippets` entry so non-snippet
-      //   generations don't carry an unused blob. The `wildcards` workflow tag
-      //   remains the canonical "did this use snippets" signal.
-      // - When the resolver did fire, overwrite `snippets.targets` with the
-      //   parsed-refs snapshot (each `#ref` as `{ category, selections: [] }`)
-      //   so workflow.metadata records exactly which refs the submission used.
-      //   And drop `snippets.seed` — that field is preview-only and remixes
-      //   should re-roll the random picks.
-      const persistedParams = removeEmpty(stepMetadata.params as Record<string, unknown>);
-      if (!snippetsExpanded) {
-        delete persistedParams.snippets;
-      } else if (persistedParams.snippets && typeof persistedParams.snippets === 'object') {
-        const persistedSnippets = persistedParams.snippets as Record<string, unknown>;
-        persistedSnippets.targets = parsedTargets;
-        delete persistedSnippets.seed;
-      }
-      const workflowMetadata = isWhatIf
-        ? undefined
-        : removeEmpty({
-            params: persistedParams,
-            resources: stepMetadata.resources,
-            remixOfId,
-            isPrivateGeneration,
-          });
-
-      const extraTags: string[] = [];
-      if (snippetsExpanded) extraTags.push(WORKFLOW_TAGS.WILDCARDS);
-
-      return {
-        steps: wrappedSteps,
-        workflowMetadata,
-        tags: extraTags,
-      };
+      steps.push(...variantSteps);
     }
-  );
+
+    // Wrap with request-level concerns: priority, timeout, outputFormat
+    // isPrivateGeneration lives on workflow.metadata, not per-step.
+    // `remixOfId` is ALSO copied onto each step's metadata: the orchestrator's
+    // `WorkflowStepHandler.GenerateJobsAsync` reads `workflowStep.Metadata["remixOfId"]`
+    // (not workflow-level metadata) to thread the remix source id into the job
+    // record → MongoDB `prod.jobs.Properties.remixOfId` → CDC → ClickHouse
+    // `orchestration.jobs`, which is what makes the remix product loop measurable.
+    // See civitai-orchestration#216. Kept on workflow.metadata as well for the
+    // app's own replay/normalization path (NormalizedWorkflowMetadata.remixOfId).
+    // Intermediate steps (videoInterpolation) don't get outputFormat injected.
+    const wrappedSteps = steps.map((step) => ({
+      $type: step.$type,
+      input: {
+        ...(step.input as object),
+        // A handler-set outputFormat wins (e.g. model3DPreview pins 'png');
+        // otherwise inherit the workflow's image outputFormat choice. For
+        // non-image workflows `data.outputFormat` is undefined, so this also
+        // avoids clobbering an intermediate step's own format with undefined.
+        outputFormat: (step.input as { outputFormat?: string }).outputFormat ?? data.outputFormat,
+      },
+      priority: data.priority,
+      timeout,
+      metadata: isWhatIf
+        ? undefined
+        : ({
+            ...((step.metadata as object) ?? {}),
+            ...(remixOfId != null ? { remixOfId } : {}),
+          } as object),
+    })) as WorkflowStepTemplate[];
+
+    // Build workflow-level metadata — the form input snapshot for workflow-level
+    // replay. `params.snippets` rides along automatically because it's a
+    // graph-level node captured by `toStepMetadata`.
+    //
+    // Snippet-specific persistence cleanup:
+    // - When the resolver didn't fire (snippets node at defaults, no refs, no
+    //   batch request), strip the entire `snippets` entry so non-snippet
+    //   generations don't carry an unused blob. The `wildcards` workflow tag
+    //   remains the canonical "did this use snippets" signal.
+    // - When the resolver did fire, overwrite `snippets.targets` with the
+    //   parsed-refs snapshot (each `#ref` as `{ category, selections: [] }`)
+    //   so workflow.metadata records exactly which refs the submission used.
+    //   And drop `snippets.seed` — that field is preview-only and remixes
+    //   should re-roll the random picks.
+    const persistedParams = removeEmpty(stepMetadata.params as Record<string, unknown>);
+    if (!snippetsExpanded) {
+      delete persistedParams.snippets;
+    } else if (persistedParams.snippets && typeof persistedParams.snippets === 'object') {
+      const persistedSnippets = persistedParams.snippets as Record<string, unknown>;
+      persistedSnippets.targets = parsedTargets;
+      delete persistedSnippets.seed;
+    }
+    const workflowMetadata = isWhatIf
+      ? undefined
+      : removeEmpty({
+          params: persistedParams,
+          resources: stepMetadata.resources,
+          remixOfId,
+          isPrivateGeneration,
+        });
+
+    const extraTags: string[] = [];
+    if (snippetsExpanded) extraTags.push(WORKFLOW_TAGS.WILDCARDS);
+
+    return {
+      steps: wrappedSteps,
+      workflowMetadata,
+      tags: extraTags,
+    };
+  });
 }
 
 /**
@@ -2099,16 +2101,8 @@ export function formatStepOutputs(
       };
 
       const ba = item.basicAnimations ?? undefined;
-      const walking = toAsset(
-        ba?.walkingModel,
-        ba?.walkingFbxModel,
-        ba?.walkingArmatureModel
-      );
-      const running = toAsset(
-        ba?.runningModel,
-        ba?.runningFbxModel,
-        ba?.runningArmatureModel
-      );
+      const walking = toAsset(ba?.walkingModel, ba?.walkingFbxModel, ba?.walkingArmatureModel);
+      const running = toAsset(ba?.runningModel, ba?.runningFbxModel, ba?.runningArmatureModel);
 
       return {
         ...base,
@@ -2124,8 +2118,7 @@ export function formatStepOutputs(
         thumbnailNsfwLevel: thumb?.nsfwLevel,
         rigged: toAsset(item.riggedModel, item.riggedFbxModel, null),
         animated: toAsset(item.animatedModel, item.animatedFbxModel, null),
-        basicAnimations:
-          walking || running ? { walking, running } : undefined,
+        basicAnimations: walking || running ? { walking, running } : undefined,
       } satisfies NormalizedModel3DOutput;
     }
 

--- a/src/shared/data-graph/generation/common.ts
+++ b/src/shared/data-graph/generation/common.ts
@@ -1292,6 +1292,10 @@ export interface ImagesNodeConfig {
   max?: number;
   /** Minimum number of images required (default: 1) */
   min?: number;
+  /** Input label shown above the dropzone */
+  label?: string;
+  /** Helper text shown under the label */
+  description?: string;
   /**
    * Named slots for fixed-position images (e.g., first/last frame).
    * When provided, renders side-by-side dropzones with labels.
@@ -1340,6 +1344,8 @@ export interface ImagesNodeConfig {
 export function imagesNode({
   min = 1,
   max = 1,
+  label,
+  description,
   slots,
   modes,
   warnOnMissingAiMetadata,
@@ -1383,6 +1389,8 @@ export function imagesNode({
     meta: {
       min: effectiveMin,
       max: effectiveMax,
+      label,
+      description,
       slots,
       modes,
       warnOnMissingAiMetadata,

--- a/src/shared/data-graph/generation/polygen-graph.ts
+++ b/src/shared/data-graph/generation/polygen-graph.ts
@@ -4,32 +4,24 @@
  * Controls for the PolyGen (Meshy via Fal) 3D-model generation ecosystem.
  *
  * Supports two workflows:
- * - txt2model3d (process = 'textTo3D'): prompt → 3D model
- * - img2model3d (process = 'imageTo3D'): source image → 3D model
+ * - txt2model3d: prompt → 3D model
+ * - img2model3d: source image → 3D model
  *
- * Shape mirrors `ace-audio-graph.ts`: a top-level discriminator (`process`)
- * gates per-process subgraphs while shared Meshy controls (targetPolycount,
- * topology, symmetryMode, etc.) live above the discriminator so both branches
- * inherit them via the subgraph ctx.
- *
- * The corresponding handler (`polygen.handler.ts`) consumes the validated
- * snapshot and emits a `PolyGenStepTemplate` matching the schema in
- * `src/server/orchestrator/polygen/polygen.schema.ts`.
+ * Follows the standard convention (happy-horse/kling/wan): a single flat set of
+ * nodes whose per-workflow fields are gated by `when` on `workflow`, rather than
+ * an internal discriminator. The orchestrator schema
+ * (`src/server/orchestrator/polygen/polygen.schema.ts`) discriminates on
+ * `process` (textTo3D/imageTo3D), which the handler derives from `workflow`.
  */
 
 import z from 'zod';
 import { DataGraph } from '~/libs/data-graph/data-graph';
 import type { GenerationCtx } from './context';
-import { seedNode, sliderNode, textNode } from './common';
+import { imagesNode, seedNode, sliderNode, textNode } from './common';
 
 // =============================================================================
 // Constants
 // =============================================================================
-
-export const polygenProcessOptions = [
-  { label: 'Text to 3D', value: 'textTo3D' as const },
-  { label: 'Image to 3D', value: 'imageTo3D' as const },
-];
 
 export const polygenTextModeOptions = [
   { label: 'Preview', value: 'preview' as const },
@@ -62,119 +54,77 @@ const polygenPolycountPresets = [
 ];
 
 // =============================================================================
-// Source image schema (image-to-3D)
-// =============================================================================
-
-/**
- * Minimal source-image shape — matches what `ImageUploadMultipleInput` emits.
- * The orchestrator submission layer extracts `.url` only; width/height ride
- * along for UI sanity (preview render) but the orchestrator only requires
- * the URL.
- */
-const polygenSourceImageSchema = z.object({
-  url: z.string(),
-  width: z.number(),
-  height: z.number(),
-});
-
-export type PolygenSourceImage = z.infer<typeof polygenSourceImageSchema>;
-
-// =============================================================================
-// Subgraph context
-// =============================================================================
-
-/** Context shape inherited by polygen process subgraphs. */
-type PolyGenProcessCtx = {
-  ecosystem: string;
-  workflow: string;
-  process: 'textTo3D' | 'imageTo3D';
-};
-
-// =============================================================================
-// Text-to-3D subgraph
-// =============================================================================
-
-const textTo3DGraph = new DataGraph<PolyGenProcessCtx, GenerationCtx>()
-  // Use the shared `textNode` factory so the prompt's meta shape matches the
-  // single-source-of-truth in `common.ts` (`{ required, targetKey, snippets,
-  // triggerWords, placeholder, info }`). This keeps the meta union
-  // compatible with the existing prompt Controller in GenerationForm.tsx.
-  .node(
-    'prompt',
-    textNode({
-      name: 'prompt',
-      required: true,
-      emptyMessage: 'Prompt is required',
-      maxLength: POLYGEN_MAX_PROMPT_LENGTH,
-      placeholder: 'A low-poly fantasy treasure chest…',
-    })
-  )
-  // Named `polygenMode` (not `mode`) to avoid colliding with the standard
-  // `mode` Radio.Group Controller in `GenerationForm.tsx` (Kling
-  // standard/professional). The handler maps this back to the schema's
-  // `mode` field before forwarding to `toMeshyPolyGenInput`.
-  .node('polygenMode', {
-    input: z.enum(['preview', 'full']).optional(),
-    output: z.enum(['preview', 'full']),
-    defaultValue: 'full' as const,
-    meta: { options: polygenTextModeOptions },
-  })
-  .node('enablePromptExpansion', {
-    input: z.boolean().optional(),
-    output: z.boolean(),
-    defaultValue: false,
-  });
-
-// =============================================================================
-// Image-to-3D subgraph
-// =============================================================================
-
-const imageTo3DGraph = new DataGraph<PolyGenProcessCtx, GenerationCtx>()
-  .node('sourceImage', {
-    input: polygenSourceImageSchema.optional(),
-    output: polygenSourceImageSchema,
-    defaultValue: undefined,
-    meta: {
-      required: true,
-    },
-  })
-  .node('shouldTexture', {
-    input: z.boolean().optional(),
-    output: z.boolean(),
-    defaultValue: true,
-  });
-
-// =============================================================================
-// PolyGen Graph (top-level)
+// PolyGen Graph
 // =============================================================================
 
 type PolyGenCtx = { ecosystem: string; workflow: string };
 
 export const polyGenGraph = new DataGraph<PolyGenCtx, GenerationCtx>()
-  // Process is driven entirely by `workflow` — the V2 form collapses
-  // "workflow" and "process" into the single Text-to-3D / Image-to-3D
-  // toggle at the top of the panel (mirrors the Image segment's
-  // txt2img/img2img toggle). The `transform` re-syncs process whenever
-  // workflow changes so the user can't get them out-of-step, and the
-  // process Controller is intentionally NOT rendered in the form.
+  // --- Text-to-3D fields (hidden for img2model3d) ---
   .node(
-    'process',
-    (ctx) => {
-      const processForWorkflow = ctx.workflow === 'img2model3d' ? 'imageTo3D' : 'textTo3D';
-      return {
-        input: z.enum(['textTo3D', 'imageTo3D']).optional(),
-        output: z.enum(['textTo3D', 'imageTo3D']),
-        defaultValue: processForWorkflow as 'textTo3D' | 'imageTo3D',
-        meta: { options: polygenProcessOptions },
-        // Force process to follow workflow on workflow-change so the
-        // graph stays consistent with whichever segment is active.
-        transform: () => processForWorkflow as 'textTo3D' | 'imageTo3D',
-      };
-    },
+    'prompt',
+    (ctx) => ({
+      ...textNode({
+        name: 'prompt',
+        required: true,
+        emptyMessage: 'Prompt is required',
+        maxLength: POLYGEN_MAX_PROMPT_LENGTH,
+        placeholder: 'A low-poly fantasy treasure chest…',
+      }),
+      when: ctx.workflow.startsWith('txt'),
+    }),
+    ['workflow']
+  )
+  // Named `polygenMode` (not `mode`) to avoid colliding with the standard `mode`
+  // Controller in GenerationForm.tsx; the handler maps it back to `mode`.
+  .node(
+    'polygenMode',
+    (ctx) => ({
+      input: z.enum(['preview', 'full']).optional(),
+      output: z.enum(['preview', 'full']),
+      defaultValue: 'full' as const,
+      meta: { options: polygenTextModeOptions },
+      when: ctx.workflow.startsWith('txt'),
+    }),
+    ['workflow']
+  )
+  .node(
+    'enablePromptExpansion',
+    (ctx) => ({
+      input: z.boolean().optional(),
+      output: z.boolean(),
+      defaultValue: false,
+      when: ctx.workflow.startsWith('txt'),
+    }),
     ['workflow']
   )
 
-  // Shared Meshy controls — both processes consume these.
+  // --- Image-to-3D fields (hidden for txt2model3d) ---
+  .node(
+    'images',
+    (ctx) => ({
+      ...imagesNode({
+        min: 1,
+        max: 1,
+        label: 'Starting image',
+        description: 'The reference Meshy will use to build the 3D mesh',
+      }),
+      when: !ctx.workflow.startsWith('txt'),
+    }),
+    ['workflow']
+  )
+  .node(
+    'shouldTexture',
+    (ctx) => ({
+      input: z.boolean().optional(),
+      output: z.boolean(),
+      defaultValue: true,
+      when: !ctx.workflow.startsWith('txt'),
+    }),
+    ['workflow']
+  )
+
+  // --- Shared Meshy controls (both workflows) ---
   .node(
     'targetPolycount',
     () =>
@@ -234,13 +184,7 @@ export const polyGenGraph = new DataGraph<PolyGenCtx, GenerationCtx>()
   })
   // Meshy accepts a 32-bit signed int seed; we keep it optional so the
   // workflow handler can randomize when omitted.
-  .node('seed', seedNode())
-
-  // Discriminate per process. Per-process fields live in the subgraphs above.
-  .discriminator('process', {
-    textTo3D: textTo3DGraph,
-    imageTo3D: imageTo3DGraph,
-  });
+  .node('seed', seedNode());
 
 export type PolyGenGraphCtx = ReturnType<typeof polyGenGraph.init>;
 


### PR DESCRIPTION
- PolyGen: replace the bespoke `sourceImage` node with the shared `imagesNode` (single image = array capped at 1); drop the `PolygenSourceImage` schema/type
- Restructure the PolyGen graph to convention: `when: !workflow.startsWith('txt')` gating instead of an internal `process` discriminator; derive `process` in the handler from `workflow` (the graph no longer carries it)
- Extend `imagesNode` with optional `label`/`description`; `ImagesInput` reads them
- Remove the `usesNestedImageInput` / `category === 'model3d'` node-detection hack now that `images` sits where `workflowHasNode` can find it
- Add a `normalizeInput` back-compat shim mapping legacy/remixed `sourceImage` to `images[]`
- Document the "always use the `images` node" convention in the add-generation-support skill