### PR TITLE
Expose model weight precision

### DIFF
--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -1,13 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import type { Session } from '~/types/session';
 import * as z from 'zod';
-import { CacheTTL } from '~/server/common/constants';
 import { dbRead } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
-import { REDIS_KEYS } from '~/server/redis/client';
 import { getFileForModelVersion } from '~/server/services/file.service';
-import { getFullTensorAnalysisCached } from '~/server/services/tensor-metadata.service';
-import { fetchThroughCache } from '~/server/utils/cache-helpers';
+import {
+  getModelTensorAnalysisCached,
+  getModelTensorSummaryCached,
+} from '~/server/services/tensor-metadata-cache.service';
 import { MixedAuthEndpoint } from '~/server/utils/endpoint-helpers';
 import {
   inferTensorMetadataFormat,
@@ -39,6 +39,7 @@ export default MixedAuthEndpoint(async function handler(
       id: true,
       modelVersionId: true,
       name: true,
+      url: true,
       type: true,
       sizeKB: true,
       metadata: true,
@@ -71,56 +72,25 @@ export default MixedAuthEndpoint(async function handler(
       fileType: file.type,
     });
 
-    // Tensor metadata is derived purely from immutable file content, so cache the parsed
-    // analysis by file id. Auth is still re-checked per request above via getFileForModelVersion.
-    //
-    // Two separate caches, by access pattern:
-    //  - FULL: the whole `analysis` incl. the ~335 KB `tensors[]` array. Highly
-    //    compressible repetitive tensor-name strings, so stored brotli-compressed at rest
-    //    (~65x). Only touched on accordion expand (!summaryOnly), or on a summary MISS.
-    //  - SUMMARY: the tiny summary fields (~256 B) with `tensors` dropped. Fired on EVERY
-    //    model-version view (the badge). A summary cache HIT must never read/decompress the
-    //    big blob — it only falls through to the full fetch on a summary MISS.
-    //
-    // HOT-PATH DECODE GUARD: even with the summary/full split, a panel-open viewer hits
-    // the FULL path on every model-page view, and the redis blob is brotli-compressed
-    // (#2649) so each full read pays an async brotli-decompress + a SYNCHRONOUS ~335 KB
-    // msgpack `unpack()` on the shared event loop. For a popular file that repeats per
-    // request and concentrates into the api-primary 504 waves. `getFullTensorAnalysisCached`
-    // wraps the redis-backed fetch in a bounded in-process LRU of the DECODED object, so a
-    // hot model is decoded at most once per pod (the redis memory win is preserved — the
-    // blob stays compressed+split in redis; we only remove the repeated hot-path decode).
-    const fetchFull = () =>
-      getFullTensorAnalysisCached(id, () =>
-        fetchThroughCache(
-          `${REDIS_KEYS.CACHES.TENSOR_METADATA}:${id}`,
-          () =>
-            parseModelTensorMetadata({
-              url: fileResult.url,
-              format,
-              fileSizeBytes: file.sizeKB * 1024,
-              estimateVram,
-            }),
-          { ttl: CacheTTL.month, compress: true }
-        )
-      );
+    // Keep the content loader lazy. The shared summary cache checks its small
+    // entry before it ever invokes this loader or touches the full decoded blob.
+    const loadAnalysis = () =>
+      parseModelTensorMetadata({
+        url: fileResult.url,
+        format,
+        fileSizeBytes: file.sizeKB * 1024,
+        estimateVram,
+      });
+    const cacheSource = { fileId: id, fileUrl: file.url };
 
     res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
 
     if (summaryOnly) {
-      const summary = await fetchThroughCache(
-        `${REDIS_KEYS.CACHES.TENSOR_METADATA_SUMMARY}:${id}`,
-        async () => {
-          const analysis = await fetchFull();
-          const { tensors, ...rest } = analysis;
-          return rest;
-        },
-        { ttl: CacheTTL.month }
-      );
+      const summary = await getModelTensorSummaryCached(cacheSource, loadAnalysis);
       return res.status(200).json(summary);
     }
 
-    const analysis = await fetchFull();
+    const analysis = await getModelTensorAnalysisCached(cacheSource, loadAnalysis);
     res.status(200).json(analysis);
   } catch (error) {
     const err = error instanceof Error ? error : new Error(String(error));

--- a/src/pages/api/v1/model-versions/mini/[id].ts
+++ b/src/pages/api/v1/model-versions/mini/[id].ts
@@ -6,11 +6,13 @@ import * as z from 'zod';
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
 import { createModelFileDownloadUrl } from '~/server/common/model-helpers';
 import { dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
 import {
   getShouldChargeForResources,
   resolveCanGenerateForVersions,
 } from '~/server/services/generation/generation.service';
 import { getFeaturedModels } from '~/server/services/model.service';
+import { getModelTensorSummaryCachedWithTimeout } from '~/server/services/tensor-metadata-cache.service';
 import type { GenerationAlias } from '~/server/schema/model-version.schema';
 import { MixedAuthEndpoint } from '~/server/utils/endpoint-helpers';
 import { getEpochJobAndFileName, getPrimaryFile } from '~/server/utils/model-helpers';
@@ -27,6 +29,16 @@ import { stringifyAIR } from '~/shared/utils/air';
 import { Flags } from '~/shared/utils/flags';
 import { UserFlag } from '~/shared/constants/user-flags.constants';
 import { ModelVersionFlag } from '~/shared/constants/model-version-flags.constants';
+import { resolveDownloadUrl } from '~/utils/delivery-worker';
+import {
+  classifyModelWeightPrecision,
+  inferTensorMetadataFormat,
+  parseModelTensorMetadata,
+  supportsTensorVramEstimate,
+  type ModelWeightPrecision,
+} from '~/utils/model-tensor-metadata';
+
+const WEIGHT_PRECISION_TIMEOUT_MS = 10_000;
 
 const schema = z.object({
   id: z.coerce.number(),
@@ -191,20 +203,25 @@ export default MixedAuthEndpoint(async function handler(
         : 'Missing model file',
     });
   }
+  const targetFileMetadata = targetFile.metadata ?? {};
 
   const baseUrl = getBaseUrl();
   let air: string;
   let downloadUrl: string;
+  let weightPrecision: ModelWeightPrecision | null = null;
 
-  if (modelVersion.availability === Availability.Private && !!targetFile.metadata.trainingResults) {
+  if (modelVersion.availability === Availability.Private && !!targetFileMetadata.trainingResults) {
+    // A private epoch URL identifies orchestrator job output, not the bytes
+    // stored under targetFile.id. Do not reuse the per-file tensor cache for it;
+    // leave precision unknown until epoch outputs have an immutable content id.
     const epoch =
-      targetFile.metadata.trainingResults.epochs?.find((e) => {
+      targetFileMetadata.trainingResults.epochs?.find((e) => {
         if ('epoch_number' in e) {
           return e.epoch_number === results.data.epoch;
         }
 
         return e.epochNumber === results.data.epoch;
-      }) ?? targetFile.metadata.trainingResults.epochs?.pop();
+      }) ?? targetFileMetadata.trainingResults.epochs?.pop();
 
     if (!epoch) {
       return res.status(404).json({ error: 'Missing epoch' });
@@ -233,13 +250,73 @@ export default MixedAuthEndpoint(async function handler(
       fileId: modelFileId,
       primary: !modelFileId,
     })}`;
+
+    const tensorFormat = inferTensorMetadataFormat({
+      name: targetFile.name,
+      metadata: targetFileMetadata,
+    });
+    if (tensorFormat) {
+      try {
+        let timedOut = false;
+        const summary = await getModelTensorSummaryCachedWithTimeout(
+          { fileId: targetFile.id, fileUrl: targetFile.url },
+          async () => {
+            const { url } = await resolveDownloadUrl(
+              targetFile.id,
+              targetFile.url,
+              targetFile.name
+            );
+            return parseModelTensorMetadata({
+              url,
+              format: tensorFormat,
+              fileSizeBytes: targetFile.sizeKB * 1024,
+              estimateVram: supportsTensorVramEstimate({
+                modelType: modelVersion.type,
+                fileType: targetFile.type,
+              }),
+            });
+          },
+          WEIGHT_PRECISION_TIMEOUT_MS,
+          () => {
+            timedOut = true;
+          }
+        );
+        if (summary) {
+          weightPrecision = classifyModelWeightPrecision(summary.dtypeCounts);
+        } else if (timedOut) {
+          // The shared cache fill continues in the background. Keep this
+          // ResourceGrain result short-lived so its next read can use it.
+          res.setHeader('X-Expires', new Date(Date.now() + 5 * 60 * 1000).toISOString());
+          logToAxiom({
+            type: 'warning',
+            name: 'model-file-weight-precision-timeout',
+            message: 'Timed out deriving model weight precision from tensor metadata',
+            modelVersionId: modelVersion.id,
+            fileId: targetFile.id,
+            timeoutMs: WEIGHT_PRECISION_TIMEOUT_MS,
+          }).catch(() => undefined);
+        }
+      } catch (error) {
+        // ResourceGrain otherwise retains this fail-open null for its normal
+        // lifetime. Ask it to retry soon without shortening successful results.
+        res.setHeader('X-Expires', new Date(Date.now() + 5 * 60 * 1000).toISOString());
+        logToAxiom({
+          type: 'warning',
+          name: 'model-file-weight-precision',
+          message: 'Failed to derive model weight precision from tensor metadata',
+          modelVersionId: modelVersion.id,
+          fileId: targetFile.id,
+          error: error instanceof Error ? error.message : String(error),
+        }).catch(() => undefined);
+      }
+    }
   }
 
   // if req url domain contains `api.`, strip /api/ from the download url
   if (req.headers.host?.includes('api.')) {
     downloadUrl = downloadUrl.replace('/api/', '/').replace('civitai.com', 'api.civitai.com');
   }
-  const { format } = targetFile.metadata;
+  const { format } = targetFileMetadata;
 
   const genStates = await resolveCanGenerateForVersions(
     [
@@ -376,6 +453,7 @@ export default MixedAuthEndpoint(async function handler(
     hashes: targetFile.hashes,
     downloadUrls: [downloadUrl], // nullable
     format, // nullable
+    weightPrecision,
     canGenerate,
     isFeatured,
     requireAuth: modelVersion.requireAuth,

--- a/src/server/services/__tests__/model-file.service.test.ts
+++ b/src/server/services/__tests__/model-file.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockDbRead } = vi.hoisted(() => ({
+const { mockDbRead, mockBustTensorMetadata, mockDeleteModelFileObject } = vi.hoisted(() => ({
   mockDbRead: {
     modelFile: {
       count: vi.fn(),
@@ -8,8 +8,11 @@ const { mockDbRead } = vi.hoisted(() => ({
       findUnique: vi.fn(),
       findMany: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
   },
+  mockBustTensorMetadata: vi.fn(),
+  mockDeleteModelFileObject: vi.fn(),
 }));
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
 
@@ -25,6 +28,10 @@ vi.mock('~/server/cloudflare/client', () => ({ purgeCache: vi.fn() }));
 vi.mock('~/server/redis/client', () => ({
   REDIS_KEYS: { CACHES: { FILES_FOR_MODEL_VERSION: 'files-for-model-version' } },
 }));
+vi.mock('~/server/services/tensor-metadata-cache.service', () => ({
+  bustModelTensorMetadataCaches: mockBustTensorMetadata,
+}));
+vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObject: mockDeleteModelFileObject }));
 
 import {
   hasOfficialFileOfSize,
@@ -32,6 +39,7 @@ import {
   markFileReplaced,
   restoreReplacedFile,
   fetchModelFilesForCache,
+  updateFile,
 } from '~/server/services/model-file.service';
 import { constants } from '~/server/common/constants';
 import { ModelFileVisibility } from '~/shared/utils/prisma/enums';
@@ -58,7 +66,45 @@ const officialBundledEncoderRow = {
   modelVersion: { name: 'v1', modelId: 8, model: { name: 'Z Image Base', type: 'Checkpoint' } },
 };
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBustTensorMetadata.mockResolvedValue(undefined);
+  mockDeleteModelFileObject.mockResolvedValue(undefined);
+});
+
+describe('updateFile tensor metadata invalidation', () => {
+  const existingFile = {
+    id: 88,
+    url: 'https://example.com/old.safetensors',
+    metadata: { format: 'SafeTensor' },
+    modelVersionId: 10,
+    sizeKB: 100,
+    modelVersion: { modelId: 7 },
+  };
+
+  it('invalidates content-derived caches when the URL changes', async () => {
+    mockDbRead.modelFile.findUnique.mockResolvedValue(existingFile);
+    mockDbRead.modelFile.updateMany.mockResolvedValue({ count: 1 });
+
+    await updateFile({
+      id: 88,
+      url: 'https://example.com/new.safetensors',
+      userId: 123,
+    });
+
+    expect(mockBustTensorMetadata).toHaveBeenCalledOnce();
+    expect(mockBustTensorMetadata).toHaveBeenCalledWith(88, existingFile.url);
+  });
+
+  it('does not invalidate content-derived caches for a metadata-only edit', async () => {
+    mockDbRead.modelFile.findUnique.mockResolvedValue(existingFile);
+    mockDbRead.modelFile.updateMany.mockResolvedValue({ count: 1 });
+
+    await updateFile({ id: 88, metadata: { fp: 'bf16' }, userId: 123 });
+
+    expect(mockBustTensorMetadata).not.toHaveBeenCalled();
+  });
+});
 
 describe('hasOfficialFileOfSize', () => {
   it('scopes to the official account and the exact sizeKB', async () => {

--- a/src/server/services/model-file.service.ts
+++ b/src/server/services/model-file.service.ts
@@ -14,6 +14,7 @@ import type {
   RecentTrainingDataInput,
 } from '~/server/schema/model-file.schema';
 import { modelFileSelect } from '~/server/selectors/modelFile.selector';
+import { bustModelTensorMetadataCaches } from '~/server/services/tensor-metadata-cache.service';
 import { createCachedObject } from '~/server/utils/cache-helpers';
 import {
   throwBadRequestError,
@@ -160,6 +161,17 @@ export async function updateFile({
   }
 
   await deleteFilesForModelVersionCache(modelFile.modelVersionId);
+
+  if (oldUrl) {
+    await bustModelTensorMetadataCaches(id, oldUrl).catch((error) =>
+      logToAxiom({
+        type: 'error',
+        name: 'model-file-tensor-metadata-cache-bust',
+        message: `Failed to invalidate tensor metadata caches for file ${id}`,
+        error,
+      }).catch(() => undefined)
+    );
+  }
 
   // Clean up old S3 object after DB update succeeds (best-effort).
   // Only fires when we actually swapped the URL on this call — pure-metadata

--- a/src/server/services/tensor-metadata-cache.service.ts
+++ b/src/server/services/tensor-metadata-cache.service.ts
@@ -1,0 +1,109 @@
+import { createHash } from 'node:crypto';
+import { CacheTTL } from '~/server/common/constants';
+import { REDIS_KEYS, redis } from '~/server/redis/client';
+import { fetchThroughCache } from '~/server/utils/cache-helpers';
+import { withTimeoutFallback } from '~/server/utils/timeout-helpers';
+import type { ModelTensorAnalysis } from '~/utils/model-tensor-metadata';
+import { bustFullTensorAnalysis, getFullTensorAnalysisCached } from './tensor-metadata.service';
+
+export type ModelTensorSummary = Omit<ModelTensorAnalysis, 'tensors'>;
+export type ModelTensorCacheSource = {
+  fileId: number;
+  /** Stable URL stored on ModelFile, never a rotating signed delivery URL. */
+  fileUrl: string;
+};
+
+function contentFingerprint(fileUrl: string) {
+  return createHash('sha256').update(fileUrl).digest('hex');
+}
+
+export function getModelTensorCacheIdentity({ fileId, fileUrl }: ModelTensorCacheSource) {
+  return `${fileId}:${contentFingerprint(fileUrl)}`;
+}
+
+const fullCacheKey = (source: ModelTensorCacheSource) =>
+  `${REDIS_KEYS.CACHES.TENSOR_METADATA}:${getModelTensorCacheIdentity(source)}` as const;
+const summaryCacheKey = (source: ModelTensorCacheSource) =>
+  `${REDIS_KEYS.CACHES.TENSOR_METADATA_SUMMARY}:${getModelTensorCacheIdentity(source)}` as const;
+const legacyFullCacheKey = (fileId: number) =>
+  `${REDIS_KEYS.CACHES.TENSOR_METADATA}:${fileId}` as const;
+const legacySummaryCacheKey = (fileId: number) =>
+  `${REDIS_KEYS.CACHES.TENSOR_METADATA_SUMMARY}:${fileId}` as const;
+
+/**
+ * Return the full tensor analysis, sharing both the compressed Redis cache and
+ * the decoded-object LRU used by the tensor-metadata API.
+ */
+export function getModelTensorAnalysisCached(
+  source: ModelTensorCacheSource,
+  loadAnalysis: () => Promise<ModelTensorAnalysis>
+) {
+  const cacheIdentity = getModelTensorCacheIdentity(source);
+  return getFullTensorAnalysisCached(cacheIdentity, () =>
+    fetchThroughCache(fullCacheKey(source), loadAnalysis, {
+      ttl: CacheTTL.month,
+      compress: true,
+    })
+  );
+}
+
+/**
+ * Return the small tensor summary without touching the full analysis on a
+ * summary-cache hit. `loadAnalysis` must stay lazy: callers may resolve signed
+ * download URLs or fetch model headers inside it without adding that work to
+ * the hot summary path.
+ */
+export function getModelTensorSummaryCached(
+  source: ModelTensorCacheSource,
+  loadAnalysis: () => Promise<ModelTensorAnalysis>
+) {
+  return fetchThroughCache(
+    summaryCacheKey(source),
+    async (): Promise<ModelTensorSummary> => {
+      const analysis = await getModelTensorAnalysisCached(source, loadAnalysis);
+      const { tensors: _tensors, ...summary } = analysis;
+      return summary;
+    },
+    { ttl: CacheTTL.month }
+  );
+}
+
+/**
+ * Bound a request that needs the summary immediately while leaving the shared
+ * cache fill running after a timeout. The caller can fail open for this response;
+ * a later retry will consume the warmed summary if the original load completes.
+ */
+export function getModelTensorSummaryCachedWithTimeout(
+  source: ModelTensorCacheSource,
+  loadAnalysis: () => Promise<ModelTensorAnalysis>,
+  timeoutMs: number,
+  onTimeout?: () => void
+) {
+  return withTimeoutFallback(
+    getModelTensorSummaryCached(source, loadAnalysis),
+    timeoutMs,
+    null,
+    onTimeout
+  );
+}
+
+/**
+ * A ModelFile URL can be replaced while retaining its database id. Evict the
+ * settled entries for the old content plus the pre-fingerprint legacy entries.
+ * An old parse already in flight may repopulate only its old fingerprint; reads
+ * for the replacement URL use a different identity and can never observe it.
+ */
+export async function bustModelTensorMetadataCaches(fileId: number, oldFileUrl?: string) {
+  // Keep the numeric eviction during rollout in case this process still holds
+  // an entry created by code using the legacy file-id-only identity.
+  bustFullTensorAnalysis(fileId);
+
+  const deletes = [redis.del(legacyFullCacheKey(fileId)), redis.del(legacySummaryCacheKey(fileId))];
+  if (oldFileUrl) {
+    const source = { fileId, fileUrl: oldFileUrl };
+    bustFullTensorAnalysis(getModelTensorCacheIdentity(source));
+    deletes.push(redis.del(fullCacheKey(source)), redis.del(summaryCacheKey(source)));
+  }
+
+  await Promise.all(deletes);
+}

--- a/src/server/services/tensor-metadata.service.ts
+++ b/src/server/services/tensor-metadata.service.ts
@@ -76,7 +76,9 @@ function estimateAnalysisBytes(analysis: ModelTensorAnalysis): number {
 // (the ttl-limit overload would require `ttlAutopurge`). The byte cap and the optional
 // TTL are spread in only when enabled, so `maxSize`+`sizeCalculation` always travel
 // together and `ttl`+`ttlAutopurge` always travel together (lru-cache v11 invariants).
-const decodedAnalysisLru = new LRUCache<number, ModelTensorAnalysis>({
+export type TensorAnalysisCacheKey = number | string;
+
+const decodedAnalysisLru = new LRUCache<TensorAnalysisCacheKey, ModelTensorAnalysis>({
   max: MAX_ITEMS > 0 ? MAX_ITEMS : 64,
   ...(MAX_SIZE_BYTES > 0
     ? { maxSize: MAX_SIZE_BYTES, sizeCalculation: estimateAnalysisBytes }
@@ -84,37 +86,37 @@ const decodedAnalysisLru = new LRUCache<number, ModelTensorAnalysis>({
   ...(TTL_MS > 0 ? { ttl: TTL_MS, ttlAutopurge: false } : {}),
 });
 
-// Per-id in-flight decode promises. The LRU only caches RESOLVED objects, so without
-// this a burst of concurrent misses for the SAME cold id (e.g. a popular model right
+// Per-identity in-flight decode promises. The LRU only caches RESOLVED objects, so without
+// this a burst of concurrent misses for the SAME cold identity (e.g. a popular model right
 // after a deploy or an eviction, before the first `.set` lands) would each run the full
 // decompress+decode — the exact cost we're removing, just confined to the warm-up window.
 // Coalescing concurrent misses onto ONE shared promise closes that residual cold-burst.
 // (The redis `fetchThroughCache` single-flight only dedups the ORIGIN PARSE on a redis
 // MISS — it does NOT dedup the decompress+decode of a redis HIT, which is the wave cost.)
-const inFlightDecodes = new Map<number, Promise<ModelTensorAnalysis>>();
+const inFlightDecodes = new Map<TensorAnalysisCacheKey, Promise<ModelTensorAnalysis>>();
 
 /**
- * Return the full decoded tensor analysis for a file id, served from the in-process
+ * Return the full decoded tensor analysis for a content identity, served from the in-process
  * LRU when warm. On a miss, `fetchDecoded` is invoked (the redis-backed compressed
  * `fetchThroughCache` path), the result is stored, and returned. Concurrent misses for
- * the same id share a single in-flight decode (no thundering herd while cold).
+ * the same identity share a single in-flight decode (no thundering herd while cold).
  *
- * @param fileId        model file id (the cache key)
+ * @param cacheKey      stable model-content identity
  * @param fetchDecoded  miss handler that produces the decoded analysis (redis-backed)
  */
 export async function getFullTensorAnalysisCached(
-  fileId: number,
+  cacheKey: TensorAnalysisCacheKey,
   fetchDecoded: () => Promise<ModelTensorAnalysis>
 ): Promise<ModelTensorAnalysis> {
-  const cached = decodedAnalysisLru.get(fileId);
+  const cached = decodedAnalysisLru.get(cacheKey);
   if (cached !== undefined) {
     cacheHitCounter.inc({ cache_name: CACHE_NAME, cache_type: 'lruCache' });
     return cached;
   }
 
-  // Join an in-flight decode for this id if one exists (counts as a hit — it avoids a
+  // Join an in-flight decode for this identity if one exists (counts as a hit — it avoids a
   // second decode). Only the request that STARTS the decode is counted as a miss.
-  const pending = inFlightDecodes.get(fileId);
+  const pending = inFlightDecodes.get(cacheKey);
   if (pending) {
     cacheHitCounter.inc({ cache_name: CACHE_NAME, cache_type: 'lruCache' });
     return pending;
@@ -125,25 +127,24 @@ export async function getFullTensorAnalysisCached(
     // `.set` only on SUCCESS; on throw nothing is cached. `finally` always clears the
     // in-flight entry so a rejected decode does not wedge future reads.
     const analysis = await fetchDecoded();
-    decodedAnalysisLru.set(fileId, analysis);
+    decodedAnalysisLru.set(cacheKey, analysis);
     return analysis;
   })().finally(() => {
-    inFlightDecodes.delete(fileId);
+    inFlightDecodes.delete(cacheKey);
   });
-  inFlightDecodes.set(fileId, decodePromise);
+  inFlightDecodes.set(cacheKey, decodePromise);
   return decodePromise;
 }
 
 /**
- * Invalidate the in-process cache for a file id. No production caller today (tensor
- * metadata is immutable per file-content and has no redis bust path), but this is the
- * hook a future re-scan / parser-version change would call to force a re-decode without
- * waiting for LRU eviction or a pod restart. Clears both the cached object and any
- * in-flight decode.
+ * Invalidate one in-process cache identity after its backing content changes.
+ * This removes the settled object and stops later callers from joining the
+ * tracked decode. It cannot cancel work that was already in flight, so that
+ * promise may still finish after the bust.
  */
-export function bustFullTensorAnalysis(fileId: number): void {
-  decodedAnalysisLru.delete(fileId);
-  inFlightDecodes.delete(fileId);
+export function bustFullTensorAnalysis(cacheKey: TensorAnalysisCacheKey): void {
+  decodedAnalysisLru.delete(cacheKey);
+  inFlightDecodes.delete(cacheKey);
 }
 
 /** Test/maintenance helpers — not used on the request path. */
@@ -158,6 +159,6 @@ export const __tensorMetadataLruInternals = {
   get inFlightSize() {
     return inFlightDecodes.size;
   },
-  has: (fileId: number) => decodedAnalysisLru.has(fileId),
-  peek: (fileId: number) => decodedAnalysisLru.peek(fileId),
+  has: (cacheKey: TensorAnalysisCacheKey) => decodedAnalysisLru.has(cacheKey),
+  peek: (cacheKey: TensorAnalysisCacheKey) => decodedAnalysisLru.peek(cacheKey),
 };

--- a/src/server/utils/__tests__/tensor-metadata-cache-split.test.ts
+++ b/src/server/utils/__tests__/tensor-metadata-cache-split.test.ts
@@ -3,8 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 /**
  * Coverage for the tensor-metadata summary/full cache SPLIT (the whale fix).
  *
- * The endpoint composes two `fetchThroughCache` calls (see
- * src/pages/api/v1/model-files/[id]/tensor-metadata.ts):
+ * The shared service composes two `fetchThroughCache` calls (see
+ * src/server/services/tensor-metadata-cache.service.ts):
  *   - FULL cache  → the whole analysis incl. the ~335 KB `tensors[]` (compressed at rest)
  *   - SUMMARY cache → the tiny `{ ...summary }` with `tensors` dropped, whose fetcher
  *     calls the full fetcher on a MISS.
@@ -63,39 +63,43 @@ vi.mock('~/server/prom/client', () => ({
   cacheFailOpenOriginFetchCounter: { inc: vi.fn() },
 }));
 
-import { CacheTTL } from '~/server/common/constants';
-import { bustFetchThroughCache, fetchThroughCache } from '~/server/utils/cache-helpers';
+import {
+  bustModelTensorMetadataCaches,
+  getModelTensorCacheIdentity,
+  getModelTensorAnalysisCached,
+  getModelTensorSummaryCached,
+  getModelTensorSummaryCachedWithTimeout,
+} from '~/server/services/tensor-metadata-cache.service';
+import { __tensorMetadataLruInternals } from '~/server/services/tensor-metadata.service';
+import { bustFetchThroughCache } from '~/server/utils/cache-helpers';
 
-const FULL_KEY = 'packed:caches:tensor-metadata:42';
-const SUMMARY_KEY = 'packed:caches:tensor-metadata-summary:42';
+const CACHE_SOURCE = { fileId: 42, fileUrl: 'https://storage.example/old.safetensors' };
+const CACHE_IDENTITY = getModelTensorCacheIdentity(CACHE_SOURCE);
+const FULL_KEY = `packed:caches:tensor-metadata:${CACHE_IDENTITY}`;
+const SUMMARY_KEY = `packed:caches:tensor-metadata-summary:${CACHE_IDENTITY}`;
+const LEGACY_FULL_KEY = 'packed:caches:tensor-metadata:42';
+const LEGACY_SUMMARY_KEY = 'packed:caches:tensor-metadata-summary:42';
 
-const makeAnalysis = () => ({
+const makeAnalysis = (dtype = 'F16') => ({
   format: 'SafeTensor' as const,
   tensorCount: 2,
   totalTensorBytes: 100,
-  dtypeCounts: [{ dtype: 'F16', count: 2, bytes: 100 }],
-  largestTensor: { name: 'a.weight', shape: [10, 10], dtype: 'F16', sizeBytes: 50 },
+  dtypeCounts: [{ dtype, count: 2, bytes: 100 }],
+  largestTensor: { name: 'a.weight', shape: [10, 10], dtype, sizeBytes: 50 },
   vramEstimate: null,
   tensors: [
-    { name: 'a.weight', shape: [10, 10], dtype: 'F16', sizeBytes: 50 },
-    { name: 'b.weight', shape: [10, 10], dtype: 'F16', sizeBytes: 50 },
+    { name: 'a.weight', shape: [10, 10], dtype, sizeBytes: 50 },
+    { name: 'b.weight', shape: [10, 10], dtype, sizeBytes: 50 },
   ],
 });
 
-// Mirrors the endpoint's composition exactly.
-function makeFetchers(parse: () => Promise<ReturnType<typeof makeAnalysis>>) {
-  const fetchFull = () =>
-    fetchThroughCache(FULL_KEY as never, parse, { ttl: CacheTTL.month, compress: true });
-  const fetchSummary = () =>
-    fetchThroughCache(
-      SUMMARY_KEY as never,
-      async () => {
-        const analysis = await fetchFull();
-        const { tensors, ...rest } = analysis;
-        return rest;
-      },
-      { ttl: CacheTTL.month }
-    );
+// Uses the same shared service as the endpoint and model-version mini response.
+function makeFetchers(
+  parse: () => Promise<ReturnType<typeof makeAnalysis>>,
+  source = CACHE_SOURCE
+) {
+  const fetchFull = () => getModelTensorAnalysisCached(source, parse);
+  const fetchSummary = () => getModelTensorSummaryCached(source, parse);
   return { fetchFull, fetchSummary };
 }
 
@@ -106,6 +110,7 @@ beforeEach(() => {
   packedSet.mockClear();
   setNxMock.mockClear().mockResolvedValue(true);
   delMock.mockClear();
+  __tensorMetadataLruInternals.clear();
 });
 
 afterEach(() => vi.restoreAllMocks());
@@ -163,6 +168,95 @@ describe('tensor-metadata summary/full cache split', () => {
     const again = await fetchFull();
     expect(parse).toHaveBeenCalledTimes(1);
     expect(again.tensors).toHaveLength(2);
+  });
+
+  it('does not cache a failed summary load and retries the lazy loader', async () => {
+    const parse = vi
+      .fn<() => Promise<ReturnType<typeof makeAnalysis>>>()
+      .mockRejectedValueOnce(new Error('header unavailable'))
+      .mockResolvedValueOnce(makeAnalysis());
+    const { fetchSummary } = makeFetchers(parse);
+
+    await expect(fetchSummary()).rejects.toThrow('header unavailable');
+    expect(store.has(SUMMARY_KEY)).toBe(false);
+    expect(store.has(FULL_KEY)).toBe(false);
+
+    await expect(fetchSummary()).resolves.toMatchObject({ tensorCount: 2 });
+    expect(parse).toHaveBeenCalledTimes(2);
+  });
+
+  it('busts the summary, full, and decoded caches for a replaced file', async () => {
+    const parse = vi.fn(async () => makeAnalysis());
+    await getModelTensorAnalysisCached(CACHE_SOURCE, parse);
+    expect(__tensorMetadataLruInternals.has(CACHE_IDENTITY)).toBe(true);
+
+    await bustModelTensorMetadataCaches(42, CACHE_SOURCE.fileUrl);
+
+    expect(__tensorMetadataLruInternals.has(CACHE_IDENTITY)).toBe(false);
+    expect(delMock).toHaveBeenCalledWith(FULL_KEY);
+    expect(delMock).toHaveBeenCalledWith(SUMMARY_KEY);
+    expect(delMock).toHaveBeenCalledWith(LEGACY_FULL_KEY);
+    expect(delMock).toHaveBeenCalledWith(LEGACY_SUMMARY_KEY);
+  });
+
+  it('never serves an old in-flight parse to a replacement URL with the same file id', async () => {
+    const oldSource = CACHE_SOURCE;
+    const newSource = { fileId: 42, fileUrl: 'https://storage.example/new.safetensors' };
+    let finishOldParse!: (analysis: ReturnType<typeof makeAnalysis>) => void;
+    const oldParse = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof makeAnalysis>>((resolve) => {
+          finishOldParse = resolve;
+        })
+    );
+
+    const oldRequest = getModelTensorSummaryCached(oldSource, oldParse);
+    await vi.waitFor(() => expect(oldParse).toHaveBeenCalledOnce());
+
+    // The mutation commits the new URL and busts while the old parse is still
+    // running. It cannot cancel that work, so the old request will populate its
+    // cache after the bust.
+    await bustModelTensorMetadataCaches(42, oldSource.fileUrl);
+
+    const newParse = vi.fn(async () => makeAnalysis('BF16'));
+    const newSummary = await getModelTensorSummaryCached(newSource, newParse);
+    expect(newSummary.dtypeCounts).toEqual([{ dtype: 'BF16', count: 2, bytes: 100 }]);
+
+    finishOldParse(makeAnalysis('F8_E4M3FN'));
+    await oldRequest;
+
+    // Even after the stale request finishes and writes its old data, the new
+    // identity remains isolated and warm with the replacement content.
+    const shouldNotParse = vi.fn(async () => makeAnalysis('F16'));
+    const newSummaryAgain = await getModelTensorSummaryCached(newSource, shouldNotParse);
+    expect(newSummaryAgain.dtypeCounts).toEqual([{ dtype: 'BF16', count: 2, bytes: 100 }]);
+    expect(newParse).toHaveBeenCalledOnce();
+    expect(shouldNotParse).not.toHaveBeenCalled();
+  });
+
+  it('fails open on a bounded summary timeout while the shared cache fill keeps warming', async () => {
+    let finishParse!: (analysis: ReturnType<typeof makeAnalysis>) => void;
+    const parse = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof makeAnalysis>>((resolve) => {
+          finishParse = resolve;
+        })
+    );
+    const onTimeout = vi.fn();
+
+    const summary = await getModelTensorSummaryCachedWithTimeout(CACHE_SOURCE, parse, 5, onTimeout);
+
+    expect(summary).toBeNull();
+    expect(onTimeout).toHaveBeenCalledOnce();
+    expect(parse).toHaveBeenCalledOnce();
+
+    finishParse(makeAnalysis('BF16'));
+    await vi.waitFor(() => expect(store.has(SUMMARY_KEY)).toBe(true));
+
+    const shouldNotParse = vi.fn(async () => makeAnalysis('F16'));
+    const warmedSummary = await getModelTensorSummaryCached(CACHE_SOURCE, shouldNotParse);
+    expect(warmedSummary.dtypeCounts).toEqual([{ dtype: 'BF16', count: 2, bytes: 100 }]);
+    expect(shouldNotParse).not.toHaveBeenCalled();
   });
 });
 

--- a/src/utils/__tests__/model-tensor-metadata.test.ts
+++ b/src/utils/__tests__/model-tensor-metadata.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { classifyModelWeightPrecision } from '../model-tensor-metadata';
+
+describe('classifyModelWeightPrecision', () => {
+  it('aggregates all float8 variants by tensor bytes', () => {
+    expect(
+      classifyModelWeightPrecision([
+        { dtype: 'F8_E4M3FN', count: 10, bytes: 40 },
+        { dtype: 'F8_E5M2', count: 10, bytes: 35 },
+        { dtype: 'BF16', count: 100, bytes: 70 },
+      ])
+    ).toBe('fp8');
+  });
+
+  it('groups BF16 and FP16 into the same pricing class', () => {
+    expect(
+      classifyModelWeightPrecision([
+        { dtype: 'BF16', count: 10, bytes: 40 },
+        { dtype: 'F16', count: 10, bytes: 35 },
+        { dtype: 'F8_E4M3FN', count: 100, bytes: 70 },
+      ])
+    ).toBe('bf16-fp16');
+  });
+
+  it('uses bytes rather than tensor count', () => {
+    expect(
+      classifyModelWeightPrecision([
+        { dtype: 'F8_E4M3FNUZ', count: 1, bytes: 100 },
+        { dtype: 'BF16', count: 1_000, bytes: 50 },
+      ])
+    ).toBe('fp8');
+  });
+
+  it.each([
+    {
+      name: 'another dtype dominates',
+      values: [
+        { dtype: 'F32', count: 1, bytes: 200 },
+        { dtype: 'BF16', count: 1, bytes: 100 },
+      ],
+    },
+    {
+      name: 'quantized bytes dominate',
+      values: [
+        { dtype: 'Q8_0', count: 1, bytes: 200 },
+        { dtype: 'F16', count: 1, bytes: 100 },
+      ],
+    },
+    {
+      name: 'the leading classes tie',
+      values: [
+        { dtype: 'F8_E4M3FN', count: 1, bytes: 100 },
+        { dtype: 'BF16', count: 1, bytes: 100 },
+      ],
+    },
+    { name: 'there are no usable bytes', values: [] },
+    {
+      name: 'byte values are invalid',
+      values: [
+        { dtype: 'F8_E4M3FN', count: 1, bytes: Number.NaN },
+        { dtype: 'BF16', count: 1, bytes: -1 },
+      ],
+    },
+  ])('returns null when $name', ({ values }) => {
+    expect(classifyModelWeightPrecision(values)).toBeNull();
+  });
+});

--- a/src/utils/model-tensor-metadata.ts
+++ b/src/utils/model-tensor-metadata.ts
@@ -29,6 +29,8 @@ export type ModelTensorDtypeSummary = {
   bytes: number;
 };
 
+export type ModelWeightPrecision = 'fp8' | 'bf16-fp16';
+
 export type ModelTensorDisplayGroup = {
   id: string;
   name: string;
@@ -119,6 +121,34 @@ export function analyzeModelTensors(
     vramEstimate: estimateVram ? estimateComfyDynamicOffloadVram(tensors) : null,
     tensors,
   };
+}
+
+/**
+ * Classify the dominant weight precision by tensor bytes. FP16 and BF16 are
+ * grouped because they have the same pricing class, while every float8 dtype
+ * variant contributes to the FP8 class. Unknown/quantized/full-precision bytes
+ * form a third bucket so a small FP8 or FP16 fragment cannot classify a model
+ * whose weights are predominantly something else.
+ */
+export function classifyModelWeightPrecision(
+  dtypeCounts: ModelTensorDtypeSummary[]
+): ModelWeightPrecision | null {
+  let fp8Bytes = 0;
+  let bf16Fp16Bytes = 0;
+  let otherBytes = 0;
+
+  for (const { dtype, bytes } of dtypeCounts) {
+    if (!Number.isFinite(bytes) || bytes <= 0) continue;
+
+    const normalized = dtype.toUpperCase();
+    if (normalized.startsWith('F8')) fp8Bytes += bytes;
+    else if (normalized === 'F16' || normalized === 'BF16') bf16Fp16Bytes += bytes;
+    else otherBytes += bytes;
+  }
+
+  if (fp8Bytes > bf16Fp16Bytes && fp8Bytes > otherBytes) return 'fp8';
+  if (bf16Fp16Bytes > fp8Bytes && bf16Fp16Bytes > otherBytes) return 'bf16-fp16';
+  return null;
 }
 
 export function supportsTensorVramEstimate({ modelType, fileType }: ModelTensorVramSupport) {


### PR DESCRIPTION
Adds content-derived FP8/BF16-FP16 precision to the selected model file response. Reuses fingerprinted tensor caches and fails open on slow or unavailable metadata.