### PR TITLE
fix(blocklist): return 400 (not 500) on blocked link domain

### DIFF
--- a/src/server/services/__tests__/blocklist.service.test.ts
+++ b/src/server/services/__tests__/blocklist.service.test.ts
@@ -1,0 +1,72 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+// getBlocklistData -> getBlocklistDTO reads redis.get first and, when a cached
+// value is present, returns it WITHOUT touching the DB. So stubbing redis.get to
+// return a JSON blocklist is enough to drive throwOnBlockedLinkDomain end-to-end.
+const { redisGet } = vi.hoisted(() => ({ redisGet: vi.fn() }));
+
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: redisGet, set: vi.fn() },
+  REDIS_KEYS: { SYSTEM: { BLOCKLIST: 'system:blocklist' } },
+}));
+vi.mock('~/server/db/client', () => ({
+  dbWrite: { blocklist: { findFirst: vi.fn(), findUnique: vi.fn() } },
+}));
+
+import { throwOnBlockedLinkDomain } from '../blocklist.service';
+import { BlocklistType } from '~/server/common/enums';
+
+/** Make getBlocklistData return the given domains (already lower-cased in prod). */
+function setBlockedDomains(domains: string[]) {
+  redisGet.mockResolvedValue(
+    JSON.stringify({ type: BlocklistType.LinkDomain, data: domains })
+  );
+}
+
+describe('throwOnBlockedLinkDomain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a blocked link domain as a BAD_REQUEST TRPCError (400), not a 500', async () => {
+    setBlockedDomains(['bit.ly']);
+
+    let caught: unknown;
+    try {
+      await throwOnBlockedLinkDomain('check this out https://bit.ly/m/abc123');
+    } catch (e) {
+      caught = e;
+    }
+
+    // Must be a tRPC BAD_REQUEST — NOT a plain Error (which tRPC maps to
+    // INTERNAL_SERVER_ERROR / HTTP 500). This is the regression guard.
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('BAD_REQUEST');
+    expect((caught as Error).message).toContain('invalid urls: https://bit.ly/m/abc123');
+  });
+
+  it('does not throw when all link domains are allowed', async () => {
+    setBlockedDomains(['bit.ly']);
+
+    await expect(
+      throwOnBlockedLinkDomain('see https://civitai.com/models/123 and https://example.com/x')
+    ).resolves.toBeUndefined();
+  });
+
+  it('does not throw when there are no links at all', async () => {
+    setBlockedDomains(['bit.ly']);
+
+    await expect(throwOnBlockedLinkDomain('just some plain text')).resolves.toBeUndefined();
+  });
+
+  it('does not raise a raw TypeError on a malformed-but-regex-matching URL', async () => {
+    setBlockedDomains(['bit.ly']);
+
+    // An invalid IPv4 octet (256): the link regex matches it, but `new URL()`
+    // rejects it with a raw TypeError. Pre-fix, that TypeError escaped as a 500 on
+    // user input. The guard must swallow it; it maps to no blocked host, so the
+    // call resolves without throwing.
+    await expect(throwOnBlockedLinkDomain('spam http://1.1.1.256/x')).resolves.toBeUndefined();
+  });
+});

--- a/src/server/services/apps/shared-content-safety.ts
+++ b/src/server/services/apps/shared-content-safety.ts
@@ -105,7 +105,8 @@ export async function assertSharedTextSafe(
     throw new SharedContentBlockedError('poi', 'Content flagged for review');
   }
 
-  // M1 — blocked link domains. `throwOnBlockedLinkDomain` throws a plain Error.
+  // M1 — blocked link domains. `throwOnBlockedLinkDomain` throws (a BAD_REQUEST
+  // TRPCError); the bare catch re-wraps any throw into SharedContentBlockedError.
   try {
     await throwOnBlockedLinkDomain(combined);
   } catch {

--- a/src/server/services/blocklist.service.ts
+++ b/src/server/services/blocklist.service.ts
@@ -7,7 +7,7 @@ import type {
   RemoveBlocklistItemSchema,
   UpsertBlocklistSchema,
 } from '~/server/schema/blocklist.schema';
-import { throwNotFoundError } from '~/server/utils/errorHandling';
+import { throwBadRequestError, throwNotFoundError } from '~/server/utils/errorHandling';
 
 export type BlocklistDTO = {
   id?: number;
@@ -98,12 +98,24 @@ export async function throwOnBlockedLinkDomain(value: string) {
   const blockedFor: string[] = [];
   if (matches) {
     for (const match of matches) {
-      const url = new URL(match);
+      let url: URL;
+      try {
+        url = new URL(match);
+      } catch {
+        // A regex-matched substring that `new URL()` can't parse isn't a URL we
+        // can attribute to a host, so it can't be a blocked-domain hit. Skip it
+        // (rather than block) — and, critically, never let a raw TypeError escape
+        // as a 500 on user input. This IS reachable: e.g. `http://1.1.1.256/x`
+        // matches the link regex but `new URL()` rejects the invalid IPv4 octet.
+        continue;
+      }
       if (blockedDomains.some((x) => x === url.host)) blockedFor.push(match);
     }
   }
 
-  if (blockedFor.length) throw new Error(`invalid urls: ${blockedFor.join(', ')}`);
+  // User-input validation rejection → BAD_REQUEST (400), not a plain Error (which
+  // the tRPC layer would wrap as INTERNAL_SERVER_ERROR / 500).
+  if (blockedFor.length) throwBadRequestError(`invalid urls: ${blockedFor.join(', ')}`);
 }
 // #endregion
 


### PR DESCRIPTION
## Problem

`/api/trpc/post.update` was returning HTTP **500** ~8×/3h on dp-prod. In Loki the cause is a single class:

```
TRPCError: invalid urls: https://bit.ly/m/...
```

— a user (bot) repeatedly submitting a **blocked link domain**. This is a **user-input validation rejection** (a client error) being surfaced as an INTERNAL_SERVER_ERROR (server fault), which inflates the 500 rate and reads as a server bug in dashboards/alerts.

## Root cause

`src/server/services/blocklist.service.ts` → `throwOnBlockedLinkDomain` rejected a blocked domain with a **plain `Error`**:

```js
if (blockedFor.length) throw new Error(`invalid urls: ${blockedFor.join(', ')}`);
```

The tRPC layer maps a non-`TRPCError` throw to `INTERNAL_SERVER_ERROR` (HTTP 500). It should be a `BAD_REQUEST` (400).

This is a **shared** helper called from many content mutations (post.update, apps-shared, comments, model/bio/article descriptions, bounties, resource reviews, chat), so the classification is fixed everywhere it's used.

## Fix

- Replace `throw new Error(...)` with `throwBadRequestError(...)` (produces `TRPCError({ code: 'BAD_REQUEST' })`), preserving the exact message.
- **Guard `new URL(match)`**: a regex-matched substring the URL parser rejects threw a raw `TypeError` → *another* 500 on user input. This is reachable — e.g. `http://1.1.1.256/x` matches the link regex but `new URL()` rejects the invalid IPv4 octet. An unparseable match can't be attributed to a host, so it can't be a blocked-domain hit → **skip it** (rather than block; skipping avoids over-blocking on something we can't even parse).

Only the error **type** changes (500→400) plus the parse guard. The blocklist matching logic is unchanged.

## Blast radius

All callers just `await throwOnBlockedLinkDomain(...)` and let it propagate (400 is now correctly returned). The only caller that *inspects* the throw — `src/server/services/apps/shared-content-safety.ts` — uses a **type-agnostic bare `catch {}`** that re-wraps any throw into `SharedContentBlockedError('link', ...)`, so it is unaffected by the `Error` → `TRPCError` change. No caller branches on the throw being a non-TRPCError / 500. Updated its stale comment.

## Tests

New `src/server/services/__tests__/blocklist.service.test.ts` (vitest, `pnpm test:unit:run`):

- blocked domain → **`BAD_REQUEST` `TRPCError`** (asserts *not* a plain `Error` / not INTERNAL_SERVER_ERROR)
- allowed-only domains → does not throw
- no links → does not throw
- malformed-but-matching URL (`http://1.1.1.256/x`) → handled, no raw `TypeError`

**2 fail against the unfixed code** (blocked-domain case throws plain `Error` not `TRPCError`; malformed-URL case throws raw `TypeError`), **all 4 pass with the fix**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)