### PR TITLE
fix(api/v1/models): return 503 (not raw 500) on transient model-search failure

### DIFF
--- a/src/pages/api/v1/models/index.ts
+++ b/src/pages/api/v1/models/index.ts
@@ -11,6 +11,7 @@ import {
   runModelSearch,
 } from '~/server/services/model-search.service';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { isTransientMeiliError } from '~/server/meilisearch/client';
 import { getNextPage, getPagination } from '~/server/utils/pagination-helpers';
 import {
   allBrowsingLevelsFlag,
@@ -107,14 +108,23 @@ export default MixedAuthEndpoint(async function handler(
       searchIds = meili.searchIds;
       meiliNextCursor = meili.nextCursor;
     } catch (e) {
-      if (e instanceof ModelSearchMeiliTimeoutError) {
+      // Transient model-search backend failure → retryable 503. The service
+      // now wraps a transient upstream as ModelSearchMeiliTimeoutError; we ALSO
+      // match a raw SDK Meili error that somehow escaped that wrap
+      // (isTransientMeiliError) as defense-in-depth — mirroring how
+      // /api/v1/users matches BOTH the wrapped signal and isTransientMeiliError.
+      // A non-transient error (malformed filter / auth / real app bug) is NOT
+      // matched and rethrows to surface as its real status.
+      if (e instanceof ModelSearchMeiliTimeoutError || isTransientMeiliError(e)) {
         // Override the public cache headers set by MixedAuthEndpoint —
         // without this Cloudflare caches the 503 and turns a transient
         // Meili brownout into a sticky 503 wall for every other
         // unauthenticated caller with the same query.
         res.setHeader('Cache-Control', 'no-store');
         res.setHeader('Retry-After', '2');
-        return res.status(503).json({ error: e.message });
+        return res
+          .status(503)
+          .json({ error: 'Model search is temporarily overloaded — please retry.' });
       }
       throw e;
     }

--- a/src/server/services/__tests__/get-models-raw.transient-503.test.ts
+++ b/src/server/services/__tests__/get-models-raw.transient-503.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * DIRECT test of the transient-error widening in getModelsRaw — the Meili search
+ * behind the tRPC model.getAll path (getModelsInfiniteHandler ->
+ * getModelsWithImagesAndModelVersions -> getModelsRaw). Its catch previously
+ * only converted civitai's own MeiliCallTimeoutError to a retryable TRPCError
+ * SERVICE_UNAVAILABLE; every OTHER transient Meili error (the SDK's own
+ * MeiliSearchCommunicationError 408/429/5xx, gateway 502/503/504, network drop)
+ * fell through `throw err` as a raw Error -> getModelsInfiniteHandler's
+ * throwDbError wrapped it as TRPCError INTERNAL_SERVER_ERROR -> a 500 (invisible
+ * in Axiom). The fix widens the catch to isTransientMeiliError so a transient
+ * brownout surfaces as SERVICE_UNAVAILABLE (503). A non-transient error is NOT
+ * converted and rethrows unchanged.
+ *
+ * This drives the REAL getModelsRaw. model.service transitively imports the
+ * `event-engine-common` submodule ONLY through image.service (value import) +
+ * flipt/client (isFlipt) — both of which are used LATER than the Meili catch, so
+ * stubbing them (a) breaks the missing-submodule import chain that would
+ * otherwise block loading model.service in the unit env and (b) never affects
+ * the throw path under test (the catch fires before either is reached).
+ */
+
+const { mockSearch } = vi.hoisted(() => ({ mockSearch: vi.fn() }));
+
+// Keep the REAL isTransientMeiliError + MeiliCallTimeoutError (the classifier the
+// widened catch calls); only drive the connection surface. withMeili is a
+// passthrough so whatever `search` rejects with reaches getModelsRaw's catch
+// unchanged.
+vi.mock('~/server/meilisearch/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/meilisearch/client')>();
+  return {
+    ...actual,
+    searchClient: { index: () => ({ search: mockSearch }) },
+    withMeili: (_op: string, fn: () => unknown) => fn(),
+  };
+});
+
+// Break the `event-engine-common` submodule import chain (absent from the
+// checkout → blocks importing the real model.service otherwise) + keep the
+// import light. All stubbed members are only reached AFTER the Meili catch.
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: vi.fn(),
+  queueImageSearchIndexUpdate: vi.fn(),
+}));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn().mockResolvedValue(false) }));
+
+// Stub the DB/redis surfaces model.service imports. None are reached on the
+// throw path (the Meili catch fires before any query), but importing the REAL
+// modules instantiates a Prisma client that fires a query at module load and
+// throws an UNHANDLED PrismaClientInitializationError on this host (no
+// linux-nixos query engine) — a false-positive vector Vitest flags. Stubbing
+// them keeps the run clean without touching the code under test.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {} }));
+// Keep the REAL REDIS_KEYS (the ~/server/redis/caches module reads nested keys
+// like REDIS_KEYS.*.RESOURCE_DATA at module load), but stub the redis/sysRedis
+// CLIENTS so no real connection opens. importOriginal here does not connect
+// (the client factory is guarded); it only gives us the key definitions.
+vi.mock('~/server/redis/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/redis/client')>();
+  return {
+    ...actual,
+    redis: { packed: { get: async () => null, set: async () => undefined } },
+    sysRedis: {},
+  };
+});
+
+const makeCommunicationError = (statusCode: number) => {
+  const e = new Error(statusCode === 408 ? 'Request Timeout' : 'Service Unavailable') as Error & {
+    name: string;
+    statusCode: number;
+  };
+  e.name = 'MeiliSearchCommunicationError';
+  e.statusCode = statusCode;
+  return e;
+};
+
+// Minimal input that reaches the Meili block: `if (query && searchClient &&
+// (!ids || ids.length === 0))`. Only query/take/browsingLevel/ids are read
+// before the throw; the rest are optional. Cast — the full GetAllModelsOutput
+// shape is irrelevant to the catch path.
+async function callGetModelsRaw() {
+  const { getModelsRaw } = await import('~/server/services/model.service');
+  return getModelsRaw({
+    input: { query: 'foo', browsingLevel: 1, take: 10 } as never,
+  });
+}
+
+describe('getModelsRaw — transient Meili error → TRPCError SERVICE_UNAVAILABLE (tRPC model.getAll path)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([408, 429, 500, 502, 503, 504])(
+    'converts a raw SDK MeiliSearchCommunicationError(statusCode=%i) → TRPCError SERVICE_UNAVAILABLE (the widening; fails against the narrow instanceof-only catch)',
+    async (status) => {
+      mockSearch.mockRejectedValue(makeCommunicationError(status));
+      await expect(callGetModelsRaw()).rejects.toMatchObject({
+        name: 'TRPCError',
+        code: 'SERVICE_UNAVAILABLE',
+      });
+    }
+  );
+
+  it('preserves civitai MeiliCallTimeoutError → TRPCError SERVICE_UNAVAILABLE', async () => {
+    const { MeiliCallTimeoutError } = await import('~/server/meilisearch/client');
+    mockSearch.mockRejectedValue(new MeiliCallTimeoutError('timeout'));
+    await expect(callGetModelsRaw()).rejects.toMatchObject({
+      name: 'TRPCError',
+      code: 'SERVICE_UNAVAILABLE',
+    });
+  });
+
+  it('does NOT convert a non-transient SDK 400 (malformed filter) — rethrows the raw error, NOT a TRPCError', async () => {
+    const original = makeCommunicationError(400);
+    mockSearch.mockRejectedValue(original);
+    await expect(callGetModelsRaw()).rejects.toBe(original);
+    await expect(callGetModelsRaw()).rejects.not.toBeInstanceOf(TRPCError);
+  });
+
+  it('does NOT convert a generic app error (null deref) — rethrows the raw error, NOT a TRPCError', async () => {
+    const original = new Error('cannot read properties of undefined');
+    mockSearch.mockRejectedValue(original);
+    await expect(callGetModelsRaw()).rejects.toBe(original);
+    await expect(callGetModelsRaw()).rejects.not.toBeInstanceOf(TRPCError);
+  });
+});

--- a/src/server/services/__tests__/model-search.transient-503.test.ts
+++ b/src/server/services/__tests__/model-search.transient-503.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit test for the transient-error widening in resolveModelSearchIds (the Meili
+ * pre-step behind /api/v1/models?query=). Before the fix its catch only
+ * converted civitai's own MeiliCallTimeoutError → ModelSearchMeiliTimeoutError;
+ * every OTHER transient Meili error (the SDK's own MeiliSearchCommunicationError
+ * 408/429/5xx, gateway 502/503/504, a network drop) fell through `throw e` as a
+ * raw Error → an unhandled HTTP 500 in the REST handler. The fix widens the
+ * catch to isTransientMeiliError so a transient brownout becomes the retryable
+ * ModelSearchMeiliTimeoutError signal. A non-transient error (malformed filter
+ * 400 / real app bug) must NOT be converted and must rethrow unchanged.
+ */
+
+const { mockSearch } = vi.hoisted(() => ({ mockSearch: vi.fn() }));
+
+// Keep the REAL isTransientMeiliError + MeiliCallTimeoutError (the classifier
+// under test); only drive the connection surface: searchClient.index().search
+// is our controllable mock, and withMeili is a passthrough so whatever `search`
+// rejects with reaches resolveModelSearchIds' catch unchanged.
+vi.mock('~/server/meilisearch/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/meilisearch/client')>();
+  return {
+    ...actual,
+    searchClient: { index: () => ({ search: mockSearch }) },
+    withMeili: (_op: string, fn: () => unknown) => fn(),
+  };
+});
+
+// Heavy collaborators the service imports at module load but resolveModelSearchIds
+// never drives — mocked so the import stays light (mirrors model-search.image-filter).
+vi.mock('~/server/services/model.service', () => ({ getModelsWithVersions: vi.fn() }));
+vi.mock('~/server/services/file.service', () => ({ getDownloadFilename: vi.fn() }));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (u: string) => u }));
+vi.mock('~/server/common/model-helpers', () => ({ createModelFileDownloadUrl: vi.fn() }));
+
+const makeCommunicationError = (statusCode: number) => {
+  const e = new Error(statusCode === 408 ? 'Request Timeout' : 'Service Unavailable') as Error & {
+    name: string;
+    statusCode: number;
+  };
+  e.name = 'MeiliSearchCommunicationError';
+  e.statusCode = statusCode;
+  return e;
+};
+
+async function callResolve() {
+  const { resolveModelSearchIds } = await import('~/server/services/model-search.service');
+  return resolveModelSearchIds({ query: 'foo', cursor: undefined, limit: 10, browsingLevel: 1 });
+}
+
+describe('resolveModelSearchIds — transient Meili error → ModelSearchMeiliTimeoutError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('happy path: returns searchIds + nextCursor', async () => {
+    // limit+1 hits → hasMore true → one page + a next cursor.
+    mockSearch.mockResolvedValue({ hits: Array.from({ length: 11 }, (_, i) => ({ id: i + 1 })) });
+    const res = await callResolve();
+    expect(res.searchIds).toHaveLength(10);
+    expect(res.nextCursor).toBe('10');
+  });
+
+  it('converts civitai MeiliCallTimeoutError → ModelSearchMeiliTimeoutError', async () => {
+    const { MeiliCallTimeoutError } = await import('~/server/meilisearch/client');
+    const { ModelSearchMeiliTimeoutError } = await import(
+      '~/server/services/model-search.service'
+    );
+    mockSearch.mockRejectedValue(new MeiliCallTimeoutError('timeout'));
+    await expect(callResolve()).rejects.toBeInstanceOf(ModelSearchMeiliTimeoutError);
+  });
+
+  it.each([408, 429, 500, 502, 503, 504])(
+    'converts a raw SDK MeiliSearchCommunicationError(statusCode=%i) → ModelSearchMeiliTimeoutError (the widening)',
+    async (status) => {
+      const { ModelSearchMeiliTimeoutError } = await import(
+        '~/server/services/model-search.service'
+      );
+      mockSearch.mockRejectedValue(makeCommunicationError(status));
+      await expect(callResolve()).rejects.toBeInstanceOf(ModelSearchMeiliTimeoutError);
+    }
+  );
+
+  it('does NOT convert a non-transient SDK 400 (malformed filter) — rethrows the original error', async () => {
+    const { ModelSearchMeiliTimeoutError } = await import(
+      '~/server/services/model-search.service'
+    );
+    const original = makeCommunicationError(400);
+    mockSearch.mockRejectedValue(original);
+    await expect(callResolve()).rejects.toBe(original);
+    await expect(callResolve()).rejects.not.toBeInstanceOf(ModelSearchMeiliTimeoutError);
+  });
+
+  it('does NOT convert a generic app error (null deref) — rethrows the original error', async () => {
+    const { ModelSearchMeiliTimeoutError } = await import(
+      '~/server/services/model-search.service'
+    );
+    const original = new Error('cannot read properties of undefined');
+    mockSearch.mockRejectedValue(original);
+    await expect(callResolve()).rejects.toBe(original);
+    await expect(callResolve()).rejects.not.toBeInstanceOf(ModelSearchMeiliTimeoutError);
+  });
+});

--- a/src/server/services/model-search.service.ts
+++ b/src/server/services/model-search.service.ts
@@ -4,7 +4,12 @@ import type { SessionUser } from '~/types/session';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
 import { createModelFileDownloadUrl } from '~/server/common/model-helpers';
-import { MeiliCallTimeoutError, searchClient, withMeili } from '~/server/meilisearch/client';
+import {
+  isTransientMeiliError,
+  MeiliCallTimeoutError,
+  searchClient,
+  withMeili,
+} from '~/server/meilisearch/client';
 import type { GetAllModelsOutput } from '~/server/schema/model.schema';
 import { getDownloadFilename } from '~/server/services/file.service';
 import { getModelsWithVersions } from '~/server/services/model.service';
@@ -115,7 +120,22 @@ export async function resolveModelSearchIds(opts: {
         )
       : undefined;
   } catch (e) {
-    if (e instanceof MeiliCallTimeoutError) throw new ModelSearchMeiliTimeoutError();
+    // Widened from `instanceof MeiliCallTimeoutError` to also cover
+    // isTransientMeiliError: the timeout-wrapper only catches civitai's own
+    // MeiliCallTimeoutError, but a Meilisearch brownout ALSO throws the SDK's
+    // OWN transient error types (MeiliSearchCommunicationError statusCode
+    // 408/429/5xx, MeiliSearchApiError with a gateway 502/503/504, the wrapped
+    // SERVICE_UNAVAILABLE, MeiliSearchTimeOutError, network ECONNRESET, …).
+    // Those previously fell through `throw e` as raw Errors → the REST handler
+    // (whose resolveModelSearchIds try/catch sits BEFORE the outer try) left
+    // them UNHANDLED → a raw HTTP 500 (the top REST 500 source on the ?query=
+    // path; the same query retried immediately returns 200 — a transient
+    // backend flap). Converting them to ModelSearchMeiliTimeoutError here lets
+    // the caller map a transient upstream to a retryable 503 (no-store +
+    // Retry-After). A non-transient error (malformed filter / auth / real app
+    // bug) is NOT matched and still surfaces as its real status.
+    if (e instanceof MeiliCallTimeoutError || isTransientMeiliError(e))
+      throw new ModelSearchMeiliTimeoutError();
     throw e;
   }
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -31,7 +31,12 @@ import {
 import { createProfanityFilter } from '~/libs/profanity-simple';
 import { isFlipt } from '~/server/flipt/client';
 import { logToAxiom } from '~/server/logging/client';
-import { MeiliCallTimeoutError, searchClient, withMeili } from '~/server/meilisearch/client';
+import {
+  isTransientMeiliError,
+  MeiliCallTimeoutError,
+  searchClient,
+  withMeili,
+} from '~/server/meilisearch/client';
 import { modelMetrics } from '~/server/metrics';
 import { withSpan } from '~/server/utils/otel-helpers';
 import {
@@ -321,7 +326,21 @@ export const getModelsRaw = async ({
         client.index(MODELS_SEARCH_INDEX).search(query, request)
       );
     } catch (err) {
-      if (err instanceof MeiliCallTimeoutError) {
+      // Widened from `instanceof MeiliCallTimeoutError` to isTransientMeiliError
+      // (same fix as /api/v1/models' resolveModelSearchIds + #2972's user
+      // search). getModelsRaw is the search path behind model.getAll (the tRPC
+      // getModelsInfiniteHandler); its timeout-wrapper only caught civitai's own
+      // MeiliCallTimeoutError. A Meilisearch brownout ALSO throws the SDK's own
+      // transient types (MeiliSearchCommunicationError 408/429/5xx,
+      // MeiliSearchApiError gateway 502/503/504, network ECONNRESET, …), which
+      // fell through `throw err` → getModelsInfiniteHandler's throwDbError
+      // wrapped them as TRPCError INTERNAL_SERVER_ERROR → a 500 (invisible in
+      // Axiom). Converting them to SERVICE_UNAVAILABLE here surfaces a transient
+      // brownout as a retryable 503 through getModelsInfiniteHandler's
+      // `if (error instanceof TRPCError) throw error` (which re-throws it
+      // unchanged). Non-transient errors (malformed filter / auth / real app
+      // bug) are NOT matched and still surface as their real status.
+      if (isTransientMeiliError(err)) {
         throw new TRPCError({
           code: 'SERVICE_UNAVAILABLE',
           message: 'Model search is temporarily overloaded — please retry.',

--- a/src/tests/api/v1/models/transient-503.test.ts
+++ b/src/tests/api/v1/models/transient-503.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * Regression test for the /api/v1/models raw-500 landmine (mirrors the
+ * /api/v1/users #2972 test). The `?query=` path calls resolveModelSearchIds
+ * (Meilisearch). A transient backend brownout — the SDK's own transient error
+ * types (MeiliSearchCommunicationError 408/429/5xx, gateway 502/503/504, a
+ * network drop) OR civitai's wrapped ModelSearchMeiliTimeoutError — MUST surface
+ * as a retryable 503 (no-store + Retry-After), NOT a raw unhandled 500. A
+ * non-transient error (malformed filter 400 / real app bug / NOT_FOUND) must NOT
+ * be masked as 503 and must still surface as its real status.
+ *
+ * The resolveModelSearchIds try/catch sits BEFORE the handler's outer try, so a
+ * rethrown non-transient error escapes the handler (→ the wrapper's real
+ * status), which is why the non-transient cases below assert the handler REJECTS
+ * and never wrote a 503.
+ */
+
+// The handler builds its response via resolveModelSearchIds (Meili pre-step) +
+// runModelSearch (data/shaping). We mock BOTH but keep the REAL
+// ModelSearchMeiliTimeoutError class so the handler's `instanceof` branch runs
+// its production logic.
+// Fully mock the service (its real module graph pulls image.service / Prisma,
+// which we don't need and which won't load in the unit env — same reason the
+// sibling index-refactor.test.ts mocks it). ModelSearchMeiliTimeoutError is a
+// hoisted local class: the handler imports THIS class and does `instanceof`
+// against it, and the test throws instances of THIS same class, so the branch
+// matches. (Defined via vi.hoisted so the hoisted mock factory can reference it.)
+const { mockResolveModelSearchIds, mockRunModelSearch, ModelSearchMeiliTimeoutError } = vi.hoisted(
+  () => {
+    class ModelSearchMeiliTimeoutError extends Error {
+      constructor() {
+        super('Model search is temporarily overloaded — please retry.');
+        this.name = 'ModelSearchMeiliTimeoutError';
+      }
+    }
+    return {
+      mockResolveModelSearchIds: vi.fn(),
+      mockRunModelSearch: vi.fn(),
+      ModelSearchMeiliTimeoutError,
+    };
+  }
+);
+
+vi.mock('~/server/services/model-search.service', () => ({
+  resolveModelSearchIds: mockResolveModelSearchIds,
+  runModelSearch: mockRunModelSearch,
+  ModelSearchMeiliTimeoutError,
+}));
+
+// Keep the REAL isTransientMeiliError so the handler's defense-in-depth branch
+// runs its production classification. Only stubbing the connection surface.
+vi.mock('~/server/meilisearch/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/meilisearch/client')>();
+  return { ...actual };
+});
+
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: vi.fn().mockReturnValue('US'),
+  isRegionRestricted: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('~/server/utils/pagination-helpers', () => ({
+  getNextPage: () => ({ baseUrl: { origin: 'https://civitai.com' }, nextPage: undefined }),
+  getPagination: () => ({ skip: 0 }),
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  getUserBookmarkCollections: vi.fn().mockResolvedValue([]),
+}));
+
+// MixedAuthEndpoint → anon passthrough; handleEndpointError → a recording
+// passthrough (the sibling models tests mock it the same way). The outer-try
+// path's status mapping is handleEndpointError's own (already guarded in
+// #2976 and unchanged here) — this test asserts only that a non-transient
+// error is NOT reclassified as 503 by the fix.
+const handleEndpointErrorSpy = vi.fn((res: any, e: any) => {
+  const status = e instanceof TRPCError && e.code === 'NOT_FOUND' ? 404 : 500;
+  return res.status(status).json({ error: String(e?.message ?? e) });
+});
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  MixedAuthEndpoint: (handler: any) => (req: any, res: any) => handler(req, res, undefined),
+  handleEndpointError: (res: any, e: any) => handleEndpointErrorSpy(res, e),
+}));
+
+// Faithful meilisearch-js 0.33 SDK transient error shape (see client.ts
+// isTransientMeiliError): name + numeric statusCode.
+const makeCommunicationError = (statusCode: number) => {
+  const e = new Error(statusCode === 408 ? 'Request Timeout' : 'Service Unavailable') as Error & {
+    name: string;
+    statusCode: number;
+  };
+  e.name = 'MeiliSearchCommunicationError';
+  e.statusCode = statusCode;
+  return e;
+};
+
+let handler: (req: NextApiRequest, res: NextApiResponse) => Promise<void> | void;
+
+beforeAll(async () => {
+  const mod = await import('~/pages/api/v1/models/index');
+  handler = mod.default as any;
+}, 120000);
+
+function fakeRes() {
+  const headers: Record<string, string> = {};
+  const res: any = {
+    headersSent: false,
+    setHeader(k: string, v: string) {
+      headers[k.toLowerCase()] = v;
+      return this;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(b: unknown) {
+      this.body = b;
+      return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    },
+    _getHeader: (k: string) => headers[k.toLowerCase()],
+  };
+  return res as NextApiResponse & {
+    statusCode?: number;
+    body?: any;
+    ended?: boolean;
+    _getHeader: (k: string) => string | undefined;
+  };
+}
+
+async function invoke(query: Record<string, unknown>) {
+  const req = {
+    method: 'GET',
+    query,
+    headers: { host: 'civitai.com' },
+    url: '/api/v1/models',
+  } as unknown as NextApiRequest;
+  const res = fakeRes();
+  await handler(req, res);
+  return res;
+}
+
+describe('/api/v1/models transient-upstream 503 reclassification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRunModelSearch.mockResolvedValue({ items: [], nextCursor: undefined });
+    mockResolveModelSearchIds.mockResolvedValue({ searchIds: [1], nextCursor: undefined });
+  });
+
+  it('happy path is unchanged (200) with no Retry-After header', async () => {
+    const res = await invoke({ query: 'foo' });
+    expect(res.statusCode).toBe(200);
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
+  it('maps the wrapped ModelSearchMeiliTimeoutError (service transient path) to a retryable 503', async () => {
+    mockResolveModelSearchIds.mockRejectedValue(new ModelSearchMeiliTimeoutError());
+    const res = await invoke({ query: 'bar' });
+
+    expect(res.statusCode).toBe(503);
+    expect(res.body).toEqual({ error: 'Model search is temporarily overloaded — please retry.' });
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+    expect(res._getHeader('Retry-After')).toBe('2');
+    expect(handleEndpointErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([408, 429, 500, 502, 503, 504])(
+    'maps a raw SDK MeiliSearchCommunicationError(statusCode=%i) that escaped the service wrap to a retryable 503 (defense-in-depth)',
+    async (status) => {
+      mockResolveModelSearchIds.mockRejectedValue(makeCommunicationError(status));
+      const res = await invoke({ query: 'carol' });
+
+      expect(res.statusCode).toBe(503);
+      expect(res.body).toEqual({
+        error: 'Model search is temporarily overloaded — please retry.',
+      });
+      expect(res._getHeader('Cache-Control')).toBe('no-store');
+      expect(res._getHeader('Retry-After')).toBe('2');
+    }
+  );
+
+  it('does NOT mask a non-transient SDK 400 (malformed filter) as 503 — rethrows, no 503 written', async () => {
+    mockResolveModelSearchIds.mockRejectedValue(makeCommunicationError(400));
+    const res = fakeRes();
+    const req = {
+      method: 'GET',
+      query: { query: 'grace' },
+      headers: { host: 'civitai.com' },
+      url: '/api/v1/models',
+    } as unknown as NextApiRequest;
+
+    await expect(handler(req, res)).rejects.toBeTruthy();
+    expect(res.statusCode).not.toBe(503);
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
+  it('does NOT mask a generic app error (null deref) as 503 — rethrows, no 503 written', async () => {
+    mockResolveModelSearchIds.mockRejectedValue(new Error('cannot read properties of undefined'));
+    const res = fakeRes();
+    const req = {
+      method: 'GET',
+      query: { query: 'frank' },
+      headers: { host: 'civitai.com' },
+      url: '/api/v1/models',
+    } as unknown as NextApiRequest;
+
+    await expect(handler(req, res)).rejects.toThrow('cannot read properties of undefined');
+    expect(res.statusCode).not.toBe(503);
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
+  it('does NOT mask a genuine (non-transient) TRPCError NOT_FOUND as 503 — rethrows, no 503 written', async () => {
+    mockResolveModelSearchIds.mockRejectedValue(
+      new TRPCError({ code: 'NOT_FOUND', message: 'nope' })
+    );
+    const res = fakeRes();
+    const req = {
+      method: 'GET',
+      query: { query: 'eve' },
+      headers: { host: 'civitai.com' },
+      url: '/api/v1/models',
+    } as unknown as NextApiRequest;
+
+    await expect(handler(req, res)).rejects.toBeTruthy();
+    expect(res.statusCode).not.toBe(503);
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+
+  it('a non-transient failure on the NON-query (runModelSearch) path goes through handleEndpointError, never 503', async () => {
+    // No `query` → no Meili pre-step; the failure is in runModelSearch, inside
+    // the outer try → handleEndpointError. The fix must not touch this path.
+    mockRunModelSearch.mockRejectedValue(
+      new TRPCError({ code: 'NOT_FOUND', message: 'model gone' })
+    );
+    const res = await invoke({});
+
+    expect(handleEndpointErrorSpy).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(404);
+    expect(res._getHeader('Retry-After')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Root cause

`GET /api/v1/models?query=<text>` 500s ~30×/2h on dp-prod, **invisible in Axiom** — a raw unhandled Next 500 (the same landmine class fixed for `/api/v1/users` in #2972). The `?query=` path calls `resolveModelSearchIds` (`src/server/services/model-search.service.ts`), whose catch only converted civitai's own `MeiliCallTimeoutError` → `ModelSearchMeiliTimeoutError`:

```js
} catch (e) {
  if (e instanceof MeiliCallTimeoutError) throw new ModelSearchMeiliTimeoutError();
  throw e;   // ← ALL OTHER transient Meili errors escape here
}
```

A Meilisearch brownout ALSO throws the SDK's OWN transient error types (`MeiliSearchCommunicationError` statusCode 408/429/5xx, `MeiliSearchApiError` with a gateway 502/503/504, `MeiliSearchTimeOutError`, network `ECONNRESET`). Those fell through `throw e` as raw `Error`s. In the REST handler the `resolveModelSearchIds` call + its try/catch sit **before** the outer `try`, so a rethrown non-timeout error is **UNHANDLED → a raw HTTP 500**. The same query retried immediately returns 200/503 (reproduced: `cursor=100` → 503, others → 200), confirming these are transient search-backend errors leaking as a **non-retryable 500**.

## Fix (mirrors #2972's two-part structure + the shared `isTransientMeiliError` predicate)

1. **Service** — `resolveModelSearchIds` catch: widen from `instanceof MeiliCallTimeoutError` to also cover `isTransientMeiliError(e)`, so ALL genuinely-transient Meili errors become `ModelSearchMeiliTimeoutError` (which the handler already maps to 503 + `Cache-Control: no-store` + `Retry-After: 2`). A non-transient error (malformed filter / auth / real app bug) is **NOT** matched and still surfaces as its real status.

2. **Handler** — `/api/v1/models`: add `|| isTransientMeiliError(e)` to the `resolveModelSearchIds` catch (defense-in-depth: a raw SDK Meili error that escaped the service wrap still → 503 with the same headers), matching how `/api/v1/users` matches BOTH the wrapped signal AND `isTransientMeiliError`. The existing `ModelSearchMeiliTimeoutError` → 503 path is unchanged (same fixed 503 body).

3. **tRPC `model.getAll`** shares **no** code with the REST search path: it runs `getModelsInfiniteHandler` → `getModelsWithImagesAndModelVersions` → `getModelsRaw` (`src/server/services/model.service.ts`), a **separate** Meili search with the **same** narrow `instanceof MeiliCallTimeoutError`-only catch (also ~15×/2h raw-500s, invisible in Axiom). Widened it to `isTransientMeiliError` so a transient brownout surfaces as a retryable `TRPCError SERVICE_UNAVAILABLE` (503) through `getModelsInfiniteHandler`'s `if (error instanceof TRPCError) throw error`, instead of `throwDbError` wrapping it as `INTERNAL_SERVER_ERROR` (500). `isTransientMeiliError` already returns `true` for `MeiliCallTimeoutError`, so the timeout→503 behavior is preserved.

`isTransientMeiliError` is the exact **narrow** predicate #2972 trusted (`src/server/meilisearch/client.ts`): a 400/401/403 or a JSON-body 500 returns `false` and bubbles as its real status — we never widen masking.

### JSON.parse landmine (#2976)

`handleEndpointError` (which this handler delegates its outer-try to) **already** guards `JSON.parse(error.message)` in a try/catch with an `{ message }` fallback (from the #2976 sweep). No change needed — noted and left untouched. The models handler itself does no inline `JSON.parse`.

## Tests

- `src/tests/api/v1/models/transient-503.test.ts` (handler) + `src/server/services/__tests__/model-search.transient-503.test.ts` (service).
- Transient (wrapped `ModelSearchMeiliTimeoutError` + raw `MeiliSearchCommunicationError` 408/429/500/502/503/504) → **503** with `no-store` + `Retry-After`; non-transient (`TRPCError NOT_FOUND`, generic `Error`, SDK 400) → **NOT 503** (rethrows to real status); happy path → **200**.
- **12 fail against the unfixed code; 22/22 pass with the fix.** Full `tsc --noEmit` clean for the changed files (only pre-existing `event-engine-common` submodule-absence errors remain, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
