### PR TITLE
feat(licensing-fee): rename-contract (phase 4 — final)

### DIFF
--- a/docs/features/fractional-licensing-fee-migration.md
+++ b/docs/features/fractional-licensing-fee-migration.md
@@ -10,7 +10,7 @@ two in sync during the rollout window. Contract drops the old column + trigger. 
 column to `licensingFee` and removes the `@map` — itself an expand/contract pair, since a bare `RENAME` isn't
 rolling-safe either.
 
-**Progress:** Phase 1 ✅ · Phase 2 ✅ (applied) · Phase 3 (rename) — code ready in this tree, deploy pending.
+**Progress:** Phase 1 ✅ · Phase 2 ✅ · Phase 3a (rename-expand) ✅ merged · Phase 3b (rename-contract) — this tree, final drop.
 
 ---
 
@@ -47,23 +47,19 @@ Clean final schema: the decimal column should be named `licensingFee`, not `lice
 invisible `@map`. A bare `RENAME COLUMN` can't run under a rolling deploy, so the rename is itself an
 expand/contract pair.
 
-### 3a — Rename-expand (code + additive migration)
+### 3a — Rename-expand ✅ (merged to main)
 `…_licensing_fee_rename_expand/migration.sql` adds the target-named `licensingFee` decimal column, backfills it,
 and installs a bidirectional **exact** sync trigger; the code drops the `@map` and repoints raw SQL to
 `licensingFee`.
-- [ ] Apply the rename-expand migration **before** the code deploys (additive; old pods keep using `licensingFeeAmount`).
-- [ ] Ship the code (normal rolling deploy — no window). New pods use `licensingFee`; the trigger keeps both columns identical.
-- [ ] Confirm the whole fleet rolled over and the two columns stay in sync.
+- [x] Apply the rename-expand migration before the code deploys (additive; old pods keep using `licensingFeeAmount`).
+- [x] Ship the code (normal rolling deploy — no window). New pods use `licensingFee`; the trigger keeps both columns identical.
+- [ ] Confirm the whole fleet rolled over and the two columns stay in sync (before running 3b).
 
-### 3b — Rename-contract (a SEPARATE, later migration — after 3a is 100% rolled out)
-```sql
-DROP TRIGGER IF EXISTS "modelVersionLicensingFeeRenameSync" ON "ModelVersion";
-DROP FUNCTION IF EXISTS "syncModelVersionLicensingFeeRename"();
-SET lock_timeout = '5s';
-ALTER TABLE "ModelVersion" DROP COLUMN IF EXISTS "licensingFeeAmount";
-```
+### 3b — Rename-contract — `feat/fractional-licensing-fee-rename-contract`
+`…_licensing_fee_rename_contract/migration.sql` drops the rename sync trigger + function and the now-unused
+`licensingFeeAmount` column. Migration-only, no code change.
 - [ ] Confirm 3a fully rolled out; confirm no ClickPipe/CDC consumer depends on `licensingFeeAmount`.
-- [ ] Apply manually. **End state:** clean schema — field `licensingFee` → column `licensingFee`, no `@map`.
+- [ ] Apply manually. **End state:** clean schema — field `licensingFee` → column `licensingFee`, no `@map`. **Migration complete.**
 
 ---
 

--- a/packages/civitai-db-schema/prisma/migrations/20260712120000_model_version_licensing_fee_rename_contract/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260712120000_model_version_licensing_fee_rename_contract/migration.sql
@@ -1,0 +1,19 @@
+-- A2 — fractional licensing fee, RENAME-CONTRACT (phase 4 — final step).
+--
+-- Drops the rename sync trigger + function and the now-unused "licensingFeeAmount" column. After phase 3a
+-- (rename-expand) is 100% rolled out, all code reads/writes "licensingFee" and nothing references
+-- "licensingFeeAmount" (verified repo-wide). This completes the migration: the end state is a single
+-- "licensingFee" DECIMAL(10,2) column, no @map, matching the Prisma field name — code and DB agree.
+--
+-- Run ONLY after phase 3a is fully rolled out (no pod still reads/writes "licensingFeeAmount"). Confirm no
+-- ClickPipe/CDC consumer depends on "licensingFeeAmount". Migration-only — no code change or client regen.
+--
+-- Irreversible ("licensingFeeAmount" is gone). Applied manually per repo convention; idempotent.
+
+DROP TRIGGER IF EXISTS "modelVersionLicensingFeeRenameSync" ON "ModelVersion";
+DROP FUNCTION IF EXISTS "syncModelVersionLicensingFeeRename"();
+
+-- DROP COLUMN takes a brief ACCESS EXCLUSIVE lock on the hot "ModelVersion" table; fail fast rather than queue
+-- every query behind it, and just re-run if it times out.
+SET lock_timeout = '5s';
+ALTER TABLE "ModelVersion" DROP COLUMN IF EXISTS "licensingFeeAmount";


### PR DESCRIPTION
Drop the rename sync trigger + function and the now-unused `licensingFeeAmount` column. Completes the A2 migration: a single `licensingFee` DECIMAL(10,2) column, no `@map` — code and DB agree.

Migration-only, no code change. Run ONLY after phase 3a (rename-expand) is 100% rolled out. Idempotent, lock_timeout-guarded. Applied manually per repo convention.