### PR TITLE
test(image-scan-result): mock dbRead.model3D.findMany so webhook success path returns 200

### DIFF
--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -34,6 +34,9 @@ const {
         findMany: vi.fn(),
         createMany: vi.fn(),
       },
+      model3D: {
+        findMany: vi.fn().mockResolvedValue([]),
+      },
       $queryRawUnsafe: vi.fn(),
       $queryRaw: vi.fn(),
     },


### PR DESCRIPTION
## Baseline unit-test break on `main`

CI `preview / unit-tests` (report-only) currently fails on **every open PR** built off `main` — 4 failures in `src/__tests__/pages/api/webhooks/image-scan-result.test.ts`:

```
AssertionError: expected "vi.fn()" to be called with arguments: [ 200 ]
Received: [ 400 ]
```

### Root cause
The real failure is a `TypeError` swallowed into the 400 response:

```
TypeError: Cannot read properties of undefined (reading 'findMany')
  at updateModel3DNsfwLevelForThumbnailImage (src/server/services/nsfwLevels.service.ts:787)
  at updateImage (src/pages/api/webhooks/image-scan-result.ts:271)
  at handleSuccess (src/pages/api/webhooks/image-scan-result.ts:238)
```

The test aliases a single `mockDbWrite` object to **both** `dbWrite` and `dbRead`
(`vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite, dbRead: mockDbWrite }))`).
That object had keys `image`, `tag`, `$queryRawUnsafe`, `$queryRaw` — but **no `model3D`**.
When `updateModel3DNsfwLevelForThumbnailImage` (added to the webhook success path) calls
`dbRead.model3D.findMany(...)`, `dbRead.model3D` is `undefined`, `.findMany` throws, the
`handleSuccess` promise rejects, and the handler returns 400 instead of 200 — failing all
4 pipeline assertions. Introduced when the Model3D thumbnail step was added to the success
path without updating this mock.

### Fix
Add a `model3D.findMany` mock to `mockDbWrite` returning `[]` ("no Model3Ds reference this
image"), so the function's `if (model3ds.length)` guard short-circuits and the success path
completes with 200. **No production code changes** — the source function is correct; this is
purely a stale test mock.

### Verification (local, NixOS)
- Before fix: `4 failed | 2 passed (6)`, assertions `expected [200]` / received `[400]`.
- After fix: `6 passed (6)`.

Command: `pnpm vitest run --project unit src/__tests__/pages/api/webhooks/image-scan-result.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)