### PR TITLE
perf(post): cap/trim post.getInfinite to cut tRPC serialize-freeze cost (#2 serialize load)

### DIFF
--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -62,6 +62,7 @@ import type {
 } from '~/server/services/user.service';
 import { bustCacheTag, queryCache } from '~/server/utils/cache-helpers';
 import { getPeriods } from '~/server/utils/enum-helpers';
+import { capPostGetInfiniteImages } from '~/server/utils/post-getinfinite-images';
 import {
   handleLogError,
   throwAuthorizationError,
@@ -545,7 +546,16 @@ export const getPostsInfinite = async ({
                 | null,
             },
             stats: postStats[post.id] ?? null,
-            images: _images,
+            // Cap the images embedded per post in the browse feed. The post cards
+            // render only `images[0]` (cover) + the `imageCount` field above
+            // (computed from the FULL list, so the count is unaffected), but
+            // `getImagesForPosts` returns the post's ENTIRE image list — a gallery
+            // post can carry dozens/hundreds of rows, the dominant contributor to
+            // this endpoint's ~1.6 MB payloads serialized synchronously on the
+            // event loop. The cap keeps headroom for the client hidden-preferences
+            // fall-through (see `post-getinfinite-images.ts`); `.slice` returns a
+            // new array so nothing upstream is mutated.
+            images: capPostGetInfiniteImages(_images),
             cosmetic: cosmetics[post.id] ?? null,
           };
         })

--- a/src/server/utils/__tests__/post-getinfinite-images.test.ts
+++ b/src/server/utils/__tests__/post-getinfinite-images.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  POST_GETINFINITE_IMAGES_PER_POST,
+  capPostGetInfiniteImages,
+} from '~/server/utils/post-getinfinite-images';
+
+// The browse-feed (`post.getInfinite`) response caps each post's embedded images
+// to the first few, because the browse post cards render only `images[0]` (the
+// cover) and read the separate `imageCount` field (computed from the FULL list)
+// for the count. `getImagesForPosts` returns the post's ENTIRE image list, so a
+// gallery post bloats the tRPC payload (serialized synchronously on the event
+// loop). The cap keeps leading order (cover stays `images[0]`), keeps headroom
+// for the client hidden-preferences fall-through, and MUST NOT mutate its input.
+
+const makeImages = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ id: i + 1, url: `img-${i + 1}` }));
+
+describe('post-getinfinite-images', () => {
+  it('caps to at most POST_GETINFINITE_IMAGES_PER_POST', () => {
+    // Pinned: the browse cap is 8 (headroom over the single rendered cover image
+    // for the client hidden-preferences fall-through — see the constant's doc).
+    expect(POST_GETINFINITE_IMAGES_PER_POST).toBe(8);
+    const out = capPostGetInfiniteImages(makeImages(50));
+    expect(out.length).toBe(POST_GETINFINITE_IMAGES_PER_POST);
+  });
+
+  it('keeps the leading images in order (browse cards read images[0])', () => {
+    const images = makeImages(50);
+    const out = capPostGetInfiniteImages(images);
+    expect(out.map((x) => x.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    // identity preserved (not re-cloned) so downstream `images[0]` is the same ref
+    expect(out[0]).toBe(images[0]);
+  });
+
+  it('returns everything when there are fewer than the cap (typical posts untouched)', () => {
+    expect(capPostGetInfiniteImages(makeImages(3)).length).toBe(3);
+    expect(capPostGetInfiniteImages(makeImages(1)).length).toBe(1);
+    expect(capPostGetInfiniteImages([])).toEqual([]);
+  });
+
+  it('does NOT mutate the source array', () => {
+    const source = makeImages(50);
+    const before = [...source];
+    const out = capPostGetInfiniteImages(source);
+    expect(source).toHaveLength(50);
+    expect(source).toEqual(before);
+    expect(out).not.toBe(source); // a new array, not the same reference
+  });
+});

--- a/src/server/utils/post-getinfinite-images.ts
+++ b/src/server/utils/post-getinfinite-images.ts
@@ -1,0 +1,40 @@
+/**
+ * Max images embedded per post in the browse-feed (`post.getInfinite` tRPC) response.
+ *
+ * The browse post cards (`PostsCard`, `Cards/PostCard`) render only `images[0]`
+ * (the cover) and read the separate `imageCount` field for the count; a grep of
+ * every `post.getInfinite` consumer found none that renders `images[1+]`. But
+ * `getPostsInfinite` embeds the post's ENTIRE image list (`getImagesForPosts`
+ * accepts a `coverOnly` flag that is currently UNUSED — the query has no per-post
+ * LIMIT), so a gallery post can carry dozens–hundreds of image rows. This is the
+ * dominant contributor to `post.getInfinite`'s ~1.6 MB payloads (the #2 total
+ * serialize load in the system: ~80,000 serializeMs / 2h), serialized
+ * synchronously on the Node event loop — a source of the event-loop-freeze class.
+ * Capping the RESPONSE sheds the heavy-gallery tail (a 100-image post → 8 rows)
+ * while leaving typical posts (< cap) untouched.
+ *
+ * Mirrors `model-getall-images.ts` (`GET_ALL_IMAGES_PER_MODEL`). Set to 8 (not 1)
+ * as HEADROOM for the client-side filter (`useApplyHiddenPreferences`, posts
+ * path), which iterates the images to drop those the VIEWER has hidden
+ * (hiddenImages / hiddenTags / systemHiddenTags) and DROPS the whole post from
+ * the feed if none survive (`hidden.noImages`). If the cover (`images[0]`) is
+ * hidden by a per-user preference, a later un-hidden image must remain in range
+ * to keep the post. This is STRICTLY safer than the `model.getAll` cap: the
+ * server already browsing-level- AND poi/minor-filters these images
+ * (`getImagesForPosts` receives `browsingLevel`/`disablePoi`/`disableMinor`), so
+ * the only residual client drops are the rarer per-user hidden-tag/hidden-image
+ * opt-ins — 8 gives 7 images of fall-through headroom. `imageCount` is computed
+ * from the FULL list before this cap, so the count display is unaffected. Tune
+ * here if `feed_noimages_drop` (Faro RUM, `~/utils/faro/feedDrop`) rises.
+ *
+ * NOTE: this caps only the getInfinite response mapping — no DB/query change.
+ */
+export const POST_GETINFINITE_IMAGES_PER_POST = 8;
+
+/**
+ * Cap a per-post images array to the browse-feed limit. Returns a NEW array
+ * (never mutates the input) via `slice`.
+ */
+export function capPostGetInfiniteImages<T>(images: T[]): T[] {
+  return images.slice(0, POST_GETINFINITE_IMAGES_PER_POST);
+}


### PR DESCRIPTION
## Why

Part of the **dp-prod tRPC-serialize event-loop-freeze arc**. A RUM+server analysis identified `post.getInfinite` as the **#2 total serialize load in the whole system**: ~**80,000 serializeMs / 2h**, **~1.6 MB** payloads, **1,164 oversized events / 2h** (per the merged `#3017` `trpc-response-oversized` instrument) — and it was in **no in-flight arc PR**. Oversized tRPC responses are superjson-serialized **synchronously** on the single Node event loop; that freeze is the 499/504-wave failure class this arc targets.

## Root cause

`getPostsInfinite` embeds each post's **entire** image list. `getImagesForPosts` accepts a `coverOnly` flag that is **currently unused** — the query has **no per-post LIMIT** — so a gallery post carries dozens–hundreds of image rows. But the browse post cards (`PostsCard`, `Cards/PostCard`) render only **`images[0]`** (the cover) and read the separate **`imageCount`** field; a grep of every `post.getInfinite` consumer found **none** reading `images[1+]`. The heavy-gallery tail dominates the payload.

## Change (mirrors the `model.getAll` cap #3027/#3037)

Trim the embedded `images` array **per post to the first 8** in the response `.map()` (not the shared query fn), via a pure `slice` util `capPostGetInfiniteImages` (`src/server/utils/post-getinfinite-images.ts`, `POST_GETINFINITE_IMAGES_PER_POST = 8`).

- `imageCount` is computed from the **full** list **before** the cap → the count display is unaffected.
- Typical posts (< 8 images) are **untouched**; only the pathological gallery tail is capped.
- **Not flag-gated** — matches the arc's cap PRs (`#3027`/`#3037` are direct util caps, no flag). **No visible feed change**: still 100 posts/page, each still shows its cover.
- `limit` (default 100 / max 200) is left alone — the payload is the per-post images, not the row count. Matches `model.getAll`, which kept its limit and trimmed images.

## Blast radius

The client `useApplyHiddenPreferences` (posts path) iterates `post.images` to drop viewer-hidden images and **drops the whole post** if none survive (`hidden.noImages`). If the cover is hidden by a per-user preference, a later un-hidden image must remain in range.

This cap is **strictly safer** than the `model.getAll` cap: the **server already browsing-level- AND poi/minor-filters** these images (`getImagesForPosts` receives `browsingLevel`/`disablePoi`/`disableMinor`), so the only residual **client** drops are the rarer per-user **hidden-tag / hidden-image** opt-ins. **8 gives 7 images of fall-through headroom.** Tune via `POST_GETINFINITE_IMAGES_PER_POST` if the arc's existing `feed_noimages_drop` Faro RUM metric rises.

## Tests

`src/server/utils/__tests__/post-getinfinite-images.test.ts` (4, unit project, pass): cap `toBe(8)` + 50→8, leading order `[1..8]` with cover ref preserved, typical posts (< cap) untouched, non-mutation of the source array. `pnpm typecheck` — changed files are type-clean (the only errors are the pre-existing missing private `event-engine-common` submodule + `kysely`, unrelated to this diff).

## Post-deploy verification (the true proof — human runs after merge)

The `#3017` `trpc-response-oversized` instrument's `serializeMs` / `bytes` for `path=post.getInfinite` should **drop**:

```logql
{namespace="civitai-dp-prod"} |= `trpc-response-oversized` | json | path="post.getInfinite"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)