### PR TITLE
perf(hidden-prefs): cut hiddenPreferences.getHidden serialize-freeze (worst single freeze, twin of user.getEngagedModels)

### DIFF
--- a/src/hooks/hidden-preferences/useHiddenPreferences.ts
+++ b/src/hooks/hidden-preferences/useHiddenPreferences.ts
@@ -13,7 +13,10 @@ export const useQueryHiddenPreferences = () => {
   // untouched. Per-field coalescing (every key defaults to `[]`) is preserved:
   // rolling deploys / stale SSR hydration can serve a response that predates a
   // field (e.g. `hiddenModel3Ds`), which would otherwise crash a consumer on
-  // `.map(...)`. Robust to either shape in both rolling-deploy directions.
+  // `.map(...)`. This makes THIS bundle (and any later one) robust to either
+  // shape — but a PRE-PR bundle has no expander and breaks on the compact shape,
+  // so the `hiddenPrefsCompact` Flipt ramp must wait until this bundle is
+  // deployed everywhere (see `~/shared/hidden-preferences/compact`).
   const _data = useMemo(() => expandHiddenPreferences(data), [data]);
   return { data: _data, ...rest };
 };

--- a/src/hooks/hidden-preferences/useHiddenPreferences.ts
+++ b/src/hooks/hidden-preferences/useHiddenPreferences.ts
@@ -1,28 +1,20 @@
 import { useMemo } from 'react';
+import { expandHiddenPreferences } from '~/shared/hidden-preferences/compact';
 import { trpc } from '~/utils/trpc';
 
 export const useQueryHiddenPreferences = () => {
   const { data, ...rest } = trpc.hiddenPreferences.getHidden.useQuery(undefined, {
     trpc: { context: { skipBatch: true } },
   });
-  // Per-field coalesce. Rolling deploys can briefly serve responses that
-  // pre-date the `hiddenModel3Ds` field (and SSR-hydrated caches from an
-  // older render carry the same risk), so a missing top-level key would
-  // crash the consumer on `data.hiddenModel3Ds.map(...)`. Defaulting at the
-  // field level — rather than only when `data` is entirely undefined — keeps
-  // the provider resilient to any older-shape response.
-  const _data = useMemo(
-    () => ({
-      hiddenModels: data?.hiddenModels ?? [],
-      hiddenModel3Ds: data?.hiddenModel3Ds ?? [],
-      hiddenImages: data?.hiddenImages ?? [],
-      hiddenTags: data?.hiddenTags ?? [],
-      hiddenUsers: data?.hiddenUsers ?? [],
-      blockedUsers: data?.blockedUsers ?? [],
-      blockedByUsers: data?.blockedByUsers ?? [],
-    }),
-    [data]
-  );
+  // `getHidden` may return the COMPACT wire shape (id-only arrays, flag-gated by
+  // `hiddenPrefsCompact`) or the legacy object shape. `expandHiddenPreferences`
+  // normalizes BOTH — plus undefined and older-field-missing responses — into
+  // the legacy `HiddenPreferenceTypes` shape so downstream consumers are
+  // untouched. Per-field coalescing (every key defaults to `[]`) is preserved:
+  // rolling deploys / stale SSR hydration can serve a response that predates a
+  // field (e.g. `hiddenModel3Ds`), which would otherwise crash a consumer on
+  // `.map(...)`. Robust to either shape in both rolling-deploy directions.
+  const _data = useMemo(() => expandHiddenPreferences(data), [data]);
   return { data: _data, ...rest };
 };
 

--- a/src/hooks/hidden-preferences/useToggleHiddenPreferences.ts
+++ b/src/hooks/hidden-preferences/useToggleHiddenPreferences.ts
@@ -1,5 +1,8 @@
-import produce from 'immer';
 import type { ToggleHiddenSchemaOutput } from '~/server/schema/user-preferences.schema';
+import {
+  applyOptimisticHiddenToggle,
+  applyServerHiddenToggle,
+} from '~/shared/hidden-preferences/compact';
 import { trpc } from '~/utils/trpc';
 
 const kindMap = {
@@ -10,6 +13,19 @@ const kindMap = {
   user: 'hiddenUsers',
   blockedUser: 'blockedUsers',
 } as const;
+
+// Legacy (object-wrapped) empty cache — used only when the query cache is empty
+// during an optimistic write (rare; getHidden is prefetched). A real fetch
+// overwrites this, and `expandHiddenPreferences` reads the legacy shape fine.
+const emptyLegacy = {
+  hiddenImages: [],
+  hiddenModels: [],
+  hiddenModel3Ds: [],
+  hiddenUsers: [],
+  hiddenTags: [],
+  blockedUsers: [],
+  blockedByUsers: [],
+};
 
 export const useToggleHiddenPreferences = () => {
   const queryUtils = trpc.useUtils();
@@ -27,30 +43,10 @@ export const useToggleHiddenPreferences = () => {
     },
     onSuccess: async ({ added, removed }, { kind }) => {
       const key = kindMap[kind];
-      queryUtils.hiddenPreferences.getHidden.setData(
-        undefined,
-        (
-          old = {
-            hiddenImages: [],
-            hiddenModels: [],
-            hiddenModel3Ds: [],
-            hiddenUsers: [],
-            hiddenTags: [],
-            blockedUsers: [],
-            blockedByUsers: [],
-          }
-        ) =>
-          produce(old, (draft) => {
-            for (const { kind, id, ...props } of added) {
-              const index = draft[key].findIndex((x) => x.id === id && x.hidden);
-              if (index === -1) draft[key].push({ id, ...props } as any);
-              else draft[key][index] = { id, ...props };
-            }
-            for (const { kind, id, ...props } of removed) {
-              const index = draft[key].findIndex((x) => x.id === id && x.hidden);
-              if (index > -1) draft[key].splice(index, 1);
-            }
-          })
+      // Shape-aware: `applyServerHiddenToggle` writes bare ids for the compact
+      // id-only sets and `{ id, hidden }` objects for the legacy / object sets.
+      queryUtils.hiddenPreferences.getHidden.setData(undefined, (old = emptyLegacy as any) =>
+        applyServerHiddenToggle(old, key, added, removed)
       );
 
       // Invalidate user lists when user or blockedUser preferences change
@@ -70,30 +66,8 @@ export const useUpdateHiddenPreferences = () => {
   const queryUtils = trpc.useUtils();
   const updateHiddenPreferences = ({ kind, data, hidden }: ToggleHiddenSchemaOutput) => {
     const key = kindMap[kind];
-    queryUtils.hiddenPreferences.getHidden.setData(
-      undefined,
-      (
-        old = {
-          hiddenImages: [],
-          hiddenModels: [],
-          hiddenModel3Ds: [],
-          hiddenUsers: [],
-          hiddenTags: [],
-          blockedUsers: [],
-          blockedByUsers: [],
-        }
-      ) =>
-        produce(old, (draft) => {
-          for (const item of data) {
-            const index = draft[key].findIndex((x) => x.id === item.id && x.hidden);
-            if (hidden === true && index === -1) draft[key].push({ ...item, hidden: true } as any);
-            else if (hidden === false && index > -1) draft[key].splice(index, 1);
-            else if (hidden === undefined) {
-              if (index > -1) draft[key].splice(index, 1);
-              else draft[key].push({ ...item, hidden: true } as any);
-            }
-          }
-        })
+    queryUtils.hiddenPreferences.getHidden.setData(undefined, (old = emptyLegacy as any) =>
+      applyOptimisticHiddenToggle(old, key, data, hidden)
     );
   };
 

--- a/src/server/routers/hidden-preferences.router.ts
+++ b/src/server/routers/hidden-preferences.router.ts
@@ -10,7 +10,14 @@ export const hiddenPreferencesRouter = router({
     // Prevents edge caching hidden preferences since they're being cache in redis already
     // NOTE: this is required because this endpoint is being forcefully cache in the browser wihout reason
     .use(noEdgeCache())
-    .query(({ ctx }) => getAllHiddenForUser({ userId: ctx.user?.id })),
+    // `hiddenPrefsCompact` (Flipt-ramped) → emit the compact wire shape, which
+    // strips the pure-overhead object wrapping on the id-only sets so superjson
+    // doesn't freeze the event loop re-serializing a whale's entire hidden set
+    // on every response (incl. cache hits). The client re-expands to the legacy
+    // shape, so downstream data is identical. See `~/shared/hidden-preferences/compact`.
+    .query(({ ctx }) =>
+      getAllHiddenForUser({ userId: ctx.user?.id, compact: !!ctx.features?.hiddenPrefsCompact })
+    ),
   toggleHidden: protectedProcedure
     .meta({ requiredScope: TokenScope.UserWrite })
     .input(toggleHiddenSchema)

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -83,6 +83,18 @@ const featureFlags = createFeatureFlags({
   // cosmetic space reservation (worst case = a little dead space, never a
   // functional break), so flipping the flag off is an instant, safe rollback.
   feedReserveCls: { availability: ['mod'], fliptKey: 'feed-reserve-cls' },
+  // Perf: emit the COMPACT wire shape for `hiddenPreferences.getHidden` (id-only
+  // arrays for the model / model3d / explicit-image sets instead of
+  // `{ id, hidden: true }` objects). `getHidden` returns a user's ENTIRE hidden
+  // set; for a whale it superjson-serializes ~12.4MB / ~1.15s SYNCHRONOUSLY on
+  // every response (incl. cache hits) — the single worst event-loop freeze in
+  // the `trpc-response-oversized` dataset (twin of `user.getEngagedModels`). The
+  // client re-expands to the legacy shape so downstream data is identical.
+  // Default OFF (mods only) so the change is DARK at deploy while client bundles
+  // that understand both shapes roll out; then ramp % via Flipt
+  // (`hidden-prefs-compact`). Instant rollback = flip OFF. Verify via
+  // `trpc-response-oversized {path="hiddenPreferences.getHidden"}` serializeMs tail.
+  hiddenPrefsCompact: { availability: ['mod'], fliptKey: 'hidden-prefs-compact' },
   // Perf experiment: defer the generation-tab-switch remount (useDeferredValue) to fix
   // mobile INP (p75 ~304ms, dominant phase = processing_duration; the gen-tab switch is
   // the single hottest interaction). `availability: []` = DARK by default and fails CLOSED when

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -89,12 +89,24 @@ const featureFlags = createFeatureFlags({
   // set; for a whale it superjson-serializes ~12.4MB / ~1.15s SYNCHRONOUSLY on
   // every response (incl. cache hits) — the single worst event-loop freeze in
   // the `trpc-response-oversized` dataset (twin of `user.getEngagedModels`). The
-  // client re-expands to the legacy shape so downstream data is identical.
-  // Default OFF (mods only) so the change is DARK at deploy while client bundles
-  // that understand both shapes roll out; then ramp % via Flipt
-  // (`hidden-prefs-compact`). Instant rollback = flip OFF. Verify via
+  // client re-expands to the legacy shape so downstream data is identical —
+  // BUT ONLY a client bundle that ships with this PR (which contains
+  // `expandHiddenPreferences`). A PRE-PR bundle reads the compact `number[]` as
+  // `{ id }[]`, gets `x.id === undefined`, and UN-HIDES the user's entire hidden
+  // set (incl. NSFW/moderated) until a hard reload.
+  //
+  // 🔴 RAMP DISCIPLINE: `availability: []` = DARK by default and FAILS CLOSED
+  // (empty availability → static eval false when Flipt is absent/down), so the
+  // Flipt `hidden-prefs-compact` threshold is the ONLY on-switch. NOT `['mod']`:
+  // that would turn compact ON for every mod the instant the server deploys,
+  // while their tabs may still run the OLD bundle → guaranteed un-hide exposure
+  // window on every deploy. Deploy dark, CONFIRM the new bundle is serving
+  // everywhere (hours — see the SPA-cache rollout pattern), THEN ramp the Flipt
+  // threshold; never ramp during/immediately-after a deploy. Instant rollback =
+  // set the threshold to 0. Verify via
   // `trpc-response-oversized {path="hiddenPreferences.getHidden"}` serializeMs tail.
-  hiddenPrefsCompact: { availability: ['mod'], fliptKey: 'hidden-prefs-compact' },
+  // (Mirrors the `genTabDeferView` / `coinbasePayments` `availability: []` precedent.)
+  hiddenPrefsCompact: { availability: [], fliptKey: 'hidden-prefs-compact' },
   // Perf experiment: defer the generation-tab-switch remount (useDeferredValue) to fix
   // mobile INP (p75 ~304ms, dominant phase = processing_duration; the gen-tab switch is
   // the single hottest interaction). `availability: []` = DARK by default and fails CLOSED when

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -5,6 +5,8 @@ import type { RedisKeyTemplateCache } from '~/server/redis/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import type { ToggleHiddenSchemaOutput } from '~/server/schema/user-preferences.schema';
 import { getModeratedTags } from '~/server/services/system-cache';
+import type { HiddenPreferencesCompact } from '~/shared/hidden-preferences/compact';
+import { toCompactHiddenPreferences } from '~/shared/hidden-preferences/compact';
 import { isPrismaUniqueViolation } from '~/server/utils/errorHandling';
 import { withSpan } from '~/server/utils/otel-helpers';
 import { TagEngagementType, UserEngagementType } from '~/shared/utils/prisma/enums';
@@ -248,7 +250,7 @@ export interface HiddenTag extends HiddenPreferenceBase {
   hidden?: boolean;
 }
 
-interface HiddenUser extends HiddenPreferenceBase {
+export interface HiddenUser extends HiddenPreferenceBase {
   id: number;
   username?: string | null;
   hidden: boolean;
@@ -264,7 +266,7 @@ interface HiddenModel3D extends HiddenPreferenceBase {
   hidden: boolean;
 }
 
-interface HiddenImage extends HiddenPreferenceBase {
+export interface HiddenImage extends HiddenPreferenceBase {
   id: number;
   /** the presence of a tagId indicates that this image is hidden due to a user's tag vote */
   tagId?: number;
@@ -447,13 +449,38 @@ const getAllHiddenForUserFresh = async ({ userId }: { userId: number }) => {
   };
 };
 
+export async function getAllHiddenForUser(args: {
+  userId?: number;
+  refreshCache?: boolean;
+  compact?: false;
+}): Promise<HiddenPreferenceTypes>;
+export async function getAllHiddenForUser(args: {
+  userId?: number;
+  refreshCache?: boolean;
+  compact: true;
+}): Promise<HiddenPreferencesCompact>;
+// Non-literal (runtime flag) callers — the router passes a boolean; the client
+// handles either shape.
+export async function getAllHiddenForUser(args: {
+  userId?: number;
+  refreshCache?: boolean;
+  compact: boolean;
+}): Promise<HiddenPreferenceTypes | HiddenPreferencesCompact>;
 export async function getAllHiddenForUser({
   userId = -1, // Default to civitai account
   refreshCache,
+  compact = false,
 }: {
   userId?: number;
   refreshCache?: boolean;
-}): Promise<HiddenPreferenceTypes> {
+  // When true, return the compact wire shape (id-only arrays for the model /
+  // model3d / explicit-image sets) instead of the object-wrapped legacy shape.
+  // Cuts the synchronous superjson serialize cost that freezes the event loop
+  // for power-users with huge hidden sets. Flag-gated at the router
+  // (`hiddenPrefsCompact`); the client re-expands to the legacy shape so
+  // downstream consumers are unaffected. See `~/shared/hidden-preferences/compact`.
+  compact?: boolean;
+}): Promise<HiddenPreferenceTypes | HiddenPreferencesCompact> {
   const {
     moderatedTags,
     hiddenTags,
@@ -478,7 +505,7 @@ export async function getAllHiddenForUser({
     blockedByUsers: blockedByUsers.map((user) => ({ ...user, hidden: true })),
   } as HiddenPreferenceTypes;
 
-  return result;
+  return compact ? toCompactHiddenPreferences(result) : result;
 }
 
 export async function toggleHidden({

--- a/src/shared/hidden-preferences/__tests__/compact.test.ts
+++ b/src/shared/hidden-preferences/__tests__/compact.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import type { HiddenPreferenceTypes } from '~/server/services/user-preferences.service';
+import {
+  applyOptimisticHiddenToggle,
+  applyServerHiddenToggle,
+  expandHiddenPreferences,
+  HIDDEN_PREFS_COMPACT_VERSION,
+  isCompactHiddenPreferences,
+  toCompactHiddenPreferences,
+} from '~/shared/hidden-preferences/compact';
+
+/**
+ * The compact wire shape is a serialize-cost optimization for
+ * `hiddenPreferences.getHidden`: it strips the pure-overhead `{ id, hidden: true }`
+ * object wrapping on the id-only sets so superjson doesn't freeze the event loop.
+ * These tests pin the invariant that MATTERS: expand(compact(legacy)) must be
+ * byte-identical to the legacy response — the client-visible data cannot change.
+ */
+
+const legacy: HiddenPreferenceTypes = {
+  hiddenTags: [
+    { id: 1, name: 'nsfw', hidden: true },
+    { id: 2, name: 'gore', nsfwLevel: 8 }, // moderated tag (no `hidden`)
+  ],
+  hiddenUsers: [
+    { id: 10, username: 'alice', hidden: true },
+    { id: 11, username: null, hidden: true },
+  ],
+  hiddenModels: [
+    { id: 100, hidden: true },
+    { id: 101, hidden: true },
+  ],
+  hiddenModel3Ds: [{ id: 200, hidden: true }],
+  hiddenImages: [
+    { id: 300, hidden: true }, // explicit hide
+    { id: 301, hidden: true }, // explicit hide
+    { id: 302, tagId: 2 }, // implicit (tag-vote) hide
+  ],
+  blockedUsers: [{ id: 20, username: 'bob', hidden: true }],
+  blockedByUsers: [{ id: 21, username: 'carol', hidden: true }],
+};
+
+describe('hidden-preferences compact shape', () => {
+  it('compact shape carries id-only arrays for the model/model3d/explicit-image sets', () => {
+    const compact = toCompactHiddenPreferences(legacy);
+    expect(compact.__v).toBe(HIDDEN_PREFS_COMPACT_VERSION);
+    expect(compact.hiddenModels).toEqual([100, 101]);
+    expect(compact.hiddenModel3Ds).toEqual([200]);
+    // explicit hides become bare ids; implicit (tagId-bearing) hides stay objects
+    expect(compact.hiddenImages).toEqual([300, 301]);
+    expect(compact.hiddenImagesImplicit).toEqual([{ id: 302, tagId: 2 }]);
+    // object-carrying sets are passed through verbatim (username/name/nsfwLevel intact)
+    expect(compact.hiddenTags).toEqual(legacy.hiddenTags);
+    expect(compact.hiddenUsers).toEqual(legacy.hiddenUsers);
+    expect(compact.blockedUsers).toEqual(legacy.blockedUsers);
+    expect(compact.blockedByUsers).toEqual(legacy.blockedByUsers);
+  });
+
+  it('expand(compact(legacy)) round-trips to the exact legacy shape', () => {
+    const roundTripped = expandHiddenPreferences(toCompactHiddenPreferences(legacy));
+    expect(roundTripped).toEqual(legacy);
+  });
+
+  it('preserves explicit-then-implicit image ordering on expand', () => {
+    const roundTripped = expandHiddenPreferences(toCompactHiddenPreferences(legacy));
+    expect(roundTripped.hiddenImages).toEqual([
+      { id: 300, hidden: true },
+      { id: 301, hidden: true },
+      { id: 302, tagId: 2 },
+    ]);
+  });
+
+  it('expand passes a LEGACY response through unchanged (rolling-deploy safety)', () => {
+    expect(expandHiddenPreferences(legacy)).toEqual(legacy);
+  });
+
+  it('expand coalesces undefined / missing fields to empty arrays', () => {
+    const expanded = expandHiddenPreferences(undefined);
+    expect(expanded).toEqual({
+      hiddenTags: [],
+      hiddenUsers: [],
+      hiddenModels: [],
+      hiddenModel3Ds: [],
+      hiddenImages: [],
+      blockedUsers: [],
+      blockedByUsers: [],
+    });
+    // a legacy response missing a newer field (e.g. hiddenModel3Ds) must not crash
+    const partial = { hiddenModels: [{ id: 1, hidden: true }] } as unknown as HiddenPreferenceTypes;
+    expect(expandHiddenPreferences(partial).hiddenModel3Ds).toEqual([]);
+  });
+
+  it('isCompactHiddenPreferences discriminates the two shapes (incl. empty arrays)', () => {
+    expect(isCompactHiddenPreferences(toCompactHiddenPreferences(legacy))).toBe(true);
+    expect(isCompactHiddenPreferences(legacy)).toBe(false);
+    expect(isCompactHiddenPreferences(undefined)).toBe(false);
+    // empty arrays are shape-ambiguous WITHOUT the __v discriminator — the whole
+    // reason it exists (so the optimistic-update path knows the target shape)
+    const emptyCompact = toCompactHiddenPreferences({
+      hiddenTags: [],
+      hiddenUsers: [],
+      hiddenModels: [],
+      hiddenModel3Ds: [],
+      hiddenImages: [],
+      blockedUsers: [],
+      blockedByUsers: [],
+    });
+    expect(isCompactHiddenPreferences(emptyCompact)).toBe(true);
+    expect(emptyCompact.hiddenModels).toEqual([]);
+  });
+});
+
+describe('optimistic cache mutation — shape parity (compact vs legacy)', () => {
+  // The load-bearing invariant: an optimistic toggle applied to the COMPACT cache
+  // must, after expand, equal the same toggle applied to the LEGACY cache. If it
+  // ever diverges, the flag flip silently changes what the user sees hidden.
+  // Every consumer of `hiddenImages`/etc. is membership-based (a Map keyed by id,
+  // or `.some(x => x.id === …)`), so array ORDER is irrelevant — only the SET of
+  // elements matters. (A compact explicit-image add lands before the implicit
+  // images; the legacy merged array appends at the end. Same set, different
+  // order.) Compare each set order-independently.
+  const asSets = (data: any) =>
+    Object.fromEntries(
+      Object.entries(data).map(([k, v]) => [
+        k,
+        new Set((v as any[]).map((el) => JSON.stringify(el))),
+      ])
+    );
+  const bothShapesAgree = (
+    _key: string,
+    apply: (cache: any) => any
+    // apply() to legacy directly, apply() to compact then expand → same membership
+  ) => {
+    const legacyResult = expandHiddenPreferences(apply(structuredClone(legacy)));
+    const compactResult = expandHiddenPreferences(apply(toCompactHiddenPreferences(legacy)));
+    expect(asSets(compactResult)).toEqual(asSets(legacyResult));
+    return compactResult;
+  };
+
+  it('optimistic ADD of a model matches across shapes', () => {
+    const res = bothShapesAgree('hiddenModels', (cache) =>
+      applyOptimisticHiddenToggle(cache, 'hiddenModels', [{ id: 999 }], true)
+    );
+    expect(res.hiddenModels.map((x) => x.id)).toContain(999);
+  });
+
+  it('optimistic REMOVE of a model matches across shapes', () => {
+    const res = bothShapesAgree('hiddenModels', (cache) =>
+      applyOptimisticHiddenToggle(cache, 'hiddenModels', [{ id: 100 }], false)
+    );
+    expect(res.hiddenModels.map((x) => x.id)).not.toContain(100);
+  });
+
+  it('optimistic TOGGLE (hidden=undefined) of an explicit image matches across shapes', () => {
+    // 300 present → toggled off; 400 absent → toggled on
+    const res = bothShapesAgree('hiddenImages', (cache) =>
+      applyOptimisticHiddenToggle(cache, 'hiddenImages', [{ id: 300 }, { id: 400 }], undefined)
+    );
+    const ids = res.hiddenImages.map((x) => x.id);
+    expect(ids).not.toContain(300);
+    expect(ids).toContain(400);
+    // implicit tag-vote image untouched
+    expect(res.hiddenImages).toContainEqual({ id: 302, tagId: 2 });
+  });
+
+  it('optimistic toggle of an OBJECT set (hiddenUsers) preserves username across shapes', () => {
+    const res = bothShapesAgree('hiddenUsers', (cache) =>
+      applyOptimisticHiddenToggle(
+        cache,
+        'hiddenUsers',
+        [{ id: 30, username: 'dave' }],
+        true
+      )
+    );
+    expect(res.hiddenUsers).toContainEqual({ id: 30, username: 'dave', hidden: true });
+  });
+
+  it('server-diff reconcile (added/removed) matches across shapes', () => {
+    const res = bothShapesAgree('hiddenModels', (cache) =>
+      applyServerHiddenToggle(
+        cache,
+        'hiddenModels',
+        [{ kind: 'model', id: 500, hidden: true }],
+        [{ kind: 'model', id: 100, hidden: true }]
+      )
+    );
+    const ids = res.hiddenModels.map((x) => x.id);
+    expect(ids).toContain(500);
+    expect(ids).not.toContain(100);
+  });
+});

--- a/src/shared/hidden-preferences/compact.ts
+++ b/src/shared/hidden-preferences/compact.ts
@@ -21,10 +21,18 @@
 // The client (`useQueryHiddenPreferences`) EXPANDS this back to the legacy
 // `HiddenPreferenceTypes` shape so the ~30 downstream consumers are untouched.
 // A `__v` discriminator lets both the read-expander and the optimistic-update
-// path detect the shape unambiguously (empty arrays are otherwise ambiguous),
-// and lets a stale client bundle from a rolling deploy keep working against
-// either shape. Emission is flag-gated (`hiddenPrefsCompact`) so it can be
-// ramped via Flipt and rolled back instantly.
+// path detect the shape unambiguously (empty arrays are otherwise ambiguous).
+//
+// 🔴 The `__v` guard protects NEW clients (this PR or later — the ones that ship
+// `expandHiddenPreferences`) reading EITHER shape, in either rolling-deploy
+// direction. It does NOT protect a PRE-PR bundle: that bundle has no expander,
+// reads the compact `number[]` as `{ id }[]`, gets `x.id === undefined`, and
+// UN-HIDES the user's entire hidden set (incl. NSFW/moderated) until a hard
+// reload. Emission is therefore flag-gated (`hiddenPrefsCompact`) and DARK by
+// default: the Flipt threshold MUST NOT be ramped until the new client bundle is
+// deployed EVERYWHERE (hours — see the SPA-cache rollout pattern). Ramping during
+// or immediately after a deploy is the exposure window this design forbids.
+// Rollback = set the Flipt threshold to 0.
 
 import produce from 'immer';
 import type {

--- a/src/shared/hidden-preferences/compact.ts
+++ b/src/shared/hidden-preferences/compact.ts
@@ -1,0 +1,231 @@
+// Compact wire shape for `hiddenPreferences.getHidden`.
+//
+// WHY: `getHidden` returns a user's ENTIRE hidden set. For a power-user who has
+// hidden thousands of models/images, the legacy response wraps every id in a
+// `{ id, hidden: true }` object. superjson re-serializes that whole object tree
+// SYNCHRONOUSLY on every response — INCLUDING Redis cache hits (the cache saves
+// the DB read, not the serialize) — freezing the Node event loop (observed:
+// 803ms p99 / 1151ms max serializeMs / 12.4MB, the single worst per-event freeze
+// on civitai-dp-prod; see instrument `trpc-response-oversized`). This is the
+// structural twin of `user.getEngagedModels` (PR #3028/#3034).
+//
+// The full membership set is genuinely needed client-side for feed filtering, so
+// it CANNOT be paginated/capped. Instead we strip the pure-overhead object
+// wrapping on the id-only sets (models / model3ds / explicit hidden images):
+// the wire carries `number[]` instead of `{ id, hidden: true }[]`, which both
+// shrinks bytes ~6x AND — the real win — collapses thousands of superjson object
+// nodes to a flat number array (the per-node walk is what pegs the event loop).
+// Sets that carry real payload (tags: name/nsfwLevel, users: username) stay as
+// objects — their data is used verbatim on the account pages.
+//
+// The client (`useQueryHiddenPreferences`) EXPANDS this back to the legacy
+// `HiddenPreferenceTypes` shape so the ~30 downstream consumers are untouched.
+// A `__v` discriminator lets both the read-expander and the optimistic-update
+// path detect the shape unambiguously (empty arrays are otherwise ambiguous),
+// and lets a stale client bundle from a rolling deploy keep working against
+// either shape. Emission is flag-gated (`hiddenPrefsCompact`) so it can be
+// ramped via Flipt and rolled back instantly.
+
+import produce from 'immer';
+import type {
+  HiddenImage,
+  HiddenPreferenceTypes,
+  HiddenTag,
+  HiddenUser,
+} from '~/server/services/user-preferences.service';
+
+// Bump if the compact shape ever changes in a non-additive way.
+export const HIDDEN_PREFS_COMPACT_VERSION = 2 as const;
+
+// The id-only sets that the compact shape flattens to `number[]`. These are the
+// keys the optimistic-update path must treat as numbers (not objects) when the
+// cache holds the compact shape. `hiddenImages` here is EXPLICIT hides only —
+// implicit (tag-vote) hidden images carry a `tagId` and live in
+// `hiddenImagesImplicit`.
+export const COMPACT_ID_KEYS = ['hiddenModels', 'hiddenModel3Ds', 'hiddenImages'] as const;
+export type CompactIdKey = (typeof COMPACT_ID_KEYS)[number];
+
+export type HiddenPreferencesCompact = {
+  __v: typeof HIDDEN_PREFS_COMPACT_VERSION;
+  hiddenTags: HiddenTag[];
+  hiddenUsers: HiddenUser[];
+  hiddenModels: number[];
+  hiddenModel3Ds: number[];
+  /** explicit `hide image` engagements, id-only */
+  hiddenImages: number[];
+  /** images hidden implicitly by a hidden/moderated tag vote — carry `tagId` */
+  hiddenImagesImplicit: HiddenImage[];
+  blockedUsers: HiddenUser[];
+  blockedByUsers: HiddenUser[];
+};
+
+export function isCompactHiddenPreferences(
+  data: HiddenPreferenceTypes | HiddenPreferencesCompact | null | undefined
+): data is HiddenPreferencesCompact {
+  return (
+    !!data && (data as HiddenPreferencesCompact).__v === HIDDEN_PREFS_COMPACT_VERSION
+  );
+}
+
+/**
+ * Build the compact wire shape from the fully-materialized legacy sets. Runs
+ * server-side, right before superjson serializes the tRPC response. Splits the
+ * merged `hiddenImages` back into explicit ids + implicit (tagId-bearing)
+ * objects so `expandHiddenPreferences` can reconstruct the exact legacy order.
+ */
+export function toCompactHiddenPreferences(
+  data: HiddenPreferenceTypes
+): HiddenPreferencesCompact {
+  const explicitImages: number[] = [];
+  const implicitImages: HiddenImage[] = [];
+  for (const img of data.hiddenImages) {
+    // implicit (tag-vote) images carry a tagId; explicit hides do not
+    if (img.tagId != null) implicitImages.push(img);
+    else explicitImages.push(img.id);
+  }
+
+  return {
+    __v: HIDDEN_PREFS_COMPACT_VERSION,
+    hiddenTags: data.hiddenTags,
+    hiddenUsers: data.hiddenUsers,
+    hiddenModels: data.hiddenModels.map((x) => x.id),
+    hiddenModel3Ds: data.hiddenModel3Ds.map((x) => x.id),
+    hiddenImages: explicitImages,
+    hiddenImagesImplicit: implicitImages,
+    blockedUsers: data.blockedUsers,
+    blockedByUsers: data.blockedByUsers,
+  };
+}
+
+/**
+ * Normalize whatever `getHidden` returned (compact OR legacy OR undefined) into
+ * the legacy `HiddenPreferenceTypes` shape the downstream consumers expect.
+ *
+ * Field-level coalescing is preserved from the pre-existing hook: rolling
+ * deploys / stale SSR hydration can serve a response that predates a field
+ * (e.g. `hiddenModel3Ds`), and a missing top-level key would crash a consumer
+ * on `.map(...)`. Every field defaults to `[]`.
+ */
+export function expandHiddenPreferences(
+  data: HiddenPreferenceTypes | HiddenPreferencesCompact | null | undefined
+): HiddenPreferenceTypes {
+  if (isCompactHiddenPreferences(data)) {
+    return {
+      hiddenTags: data.hiddenTags ?? [],
+      hiddenUsers: data.hiddenUsers ?? [],
+      hiddenModels: (data.hiddenModels ?? []).map((id) => ({ id, hidden: true })),
+      hiddenModel3Ds: (data.hiddenModel3Ds ?? []).map((id) => ({ id, hidden: true })),
+      // legacy order: explicit hides first, then implicit tag-vote images
+      hiddenImages: [
+        ...(data.hiddenImages ?? []).map((id) => ({ id, hidden: true })),
+        ...(data.hiddenImagesImplicit ?? []),
+      ],
+      blockedUsers: data.blockedUsers ?? [],
+      blockedByUsers: data.blockedByUsers ?? [],
+    };
+  }
+
+  return {
+    hiddenModels: data?.hiddenModels ?? [],
+    hiddenModel3Ds: data?.hiddenModel3Ds ?? [],
+    hiddenImages: data?.hiddenImages ?? [],
+    hiddenTags: data?.hiddenTags ?? [],
+    hiddenUsers: data?.hiddenUsers ?? [],
+    blockedUsers: data?.blockedUsers ?? [],
+    blockedByUsers: data?.blockedByUsers ?? [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Optimistic-cache mutation (shape-aware)
+//
+// The tRPC query cache holds whatever `getHidden` returned — compact OR legacy.
+// The optimistic `toggleHidden` path mutates that cache in-place, so it must
+// write the shape the cache is currently in: bare ids for the compact id-only
+// sets, `{ id, hidden }` objects otherwise. These pure helpers encapsulate that
+// branching (kept out of the React hook so they're unit-testable).
+// ---------------------------------------------------------------------------
+
+type HiddenCache = HiddenPreferenceTypes | HiddenPreferencesCompact;
+
+const compactIdKeySet = new Set<string>(COMPACT_ID_KEYS);
+
+// Is `key` stored as a bare `number[]` in THIS cache blob? Only when the cache
+// holds the compact shape AND the key is an id-only set. Tags/users/blocked stay
+// objects even in the compact shape, and everything is objects in the legacy shape.
+function isCompactIdKey(cache: HiddenCache, key: string): key is CompactIdKey {
+  return isCompactHiddenPreferences(cache) && compactIdKeySet.has(key);
+}
+
+/** Add/remove a single id in an id-only `number[]` set (compact shape). */
+function toggleCompactId(arr: number[], id: number, hidden?: boolean) {
+  const index = arr.indexOf(id);
+  if (hidden === true && index === -1) arr.push(id);
+  else if (hidden === false && index > -1) arr.splice(index, 1);
+  else if (hidden === undefined) {
+    if (index > -1) arr.splice(index, 1);
+    else arr.push(id);
+  }
+}
+
+/** Add/remove a single item in an object-wrapped set (legacy shape). */
+function toggleLegacyItem(arr: Array<{ id: number; hidden?: boolean }>, item: { id: number }, hidden?: boolean) {
+  const index = arr.findIndex((x) => x.id === item.id && x.hidden);
+  if (hidden === true && index === -1) arr.push({ ...item, hidden: true });
+  else if (hidden === false && index > -1) arr.splice(index, 1);
+  else if (hidden === undefined) {
+    if (index > -1) arr.splice(index, 1);
+    else arr.push({ ...item, hidden: true });
+  }
+}
+
+/**
+ * Optimistic toggle (client-side, pre-server): apply add/remove/toggle of the
+ * given `items` to `cache[key]` — mirrors the pre-existing legacy semantics for
+ * object sets, and the id-only equivalent when the cache is compact.
+ */
+export function applyOptimisticHiddenToggle(
+  cache: HiddenCache,
+  key: string,
+  items: Array<{ id: number }>,
+  hidden?: boolean
+): HiddenCache {
+  return produce(cache, (draft: any) => {
+    if (isCompactIdKey(draft, key)) {
+      const arr = draft[key] as number[];
+      for (const item of items) toggleCompactId(arr, item.id, hidden);
+      return;
+    }
+    for (const item of items) toggleLegacyItem(draft[key], item, hidden);
+  });
+}
+
+/**
+ * Reconcile the cache with the server's authoritative `added`/`removed` diff
+ * (the `toggleHidden` mutation result). Same shape-branching as the optimistic
+ * path; object sets replace-in-place to pick up server-provided fields.
+ */
+export function applyServerHiddenToggle(
+  cache: HiddenCache,
+  key: string,
+  added: Array<{ id: number }>,
+  removed: Array<{ id: number }>
+): HiddenCache {
+  return produce(cache, (draft: any) => {
+    if (isCompactIdKey(draft, key)) {
+      const arr = draft[key] as number[];
+      for (const { id } of added) toggleCompactId(arr, id, true);
+      for (const { id } of removed) toggleCompactId(arr, id, false);
+      return;
+    }
+    for (const { kind, id, ...props } of added as Array<Record<string, unknown> & { id: number }>) {
+      const index = draft[key].findIndex((x: any) => x.id === id && x.hidden);
+      if (index === -1) draft[key].push({ id, ...props });
+      else draft[key][index] = { id, ...props };
+    }
+    for (const { kind, id, ...props } of removed as Array<Record<string, unknown> & { id: number }>) {
+      const index = draft[key].findIndex((x: any) => x.id === id && x.hidden);
+      if (index > -1) draft[key].splice(index, 1);
+    }
+  });
+}


### PR DESCRIPTION
## The single worst per-event serialize-freeze in the arc dataset

`hiddenPreferences.getHidden` returns a user's **entire** hidden set (all hidden tags + users + models + model3ds + images + blocked users). For a power-user who has hidden thousands of items, the legacy response wraps every id in a `{ id, hidden: true }` object, and superjson re-serializes that whole object tree **synchronously on every response — including Redis cache hits** (the cache saves the DB read, not the serialize). The `trpc-response-oversized` instrument (#3017) measured it as the **worst single freeze in the whole dataset**:

- **803ms p99 / 1,151ms max `serializeMs`**
- **12.4MB max payload**

A ~1.15s synchronous serialize pegs the api-primary event loop for that whole window → in-flight requests stall → the 499/504 waves + liveness-SIGKILL that opened this arc.

## Structural twin of `user.getEngagedModels`

Same failure shape as #3028/#3034: an **unbounded per-user aggregate re-serialized in full on every call**, where the Redis cache doesn't help because it caches the deserialized object, not the serialized bytes. The twin fix **bounded** the set (callers pass the on-screen models). That doesn't transfer here: the whole membership set is genuinely needed client-side for **feed filtering** (`HiddenPreferencesProvider` builds membership `Map`s consumed across the feed), so capping/paginating would break filtering.

The arc-consistent lever for the "full set is needed" case is the one the handoff calls out: **compact the shape (IDs not objects) so superjson stops walking the full object tree**, keeping the data intact.

## The fix (compact wire shape, flag-gated)

Strip the **pure-overhead** object wrapping on the id-only sets — models, model3ds, and explicit hidden images are only in the list *because* they're hidden, so `{ id, hidden: true }` carries no information beyond the id:

- Wire carries `number[]` instead of `{ id, hidden: true }[]` for those three sets. This both shrinks bytes (~6×) and — the real win — collapses thousands of superjson object nodes to flat number arrays (the per-node walk is what pegs the loop).
- Sets that carry **real payload** stay as objects: `hiddenTags` (name/nsfwLevel), `hiddenUsers`/`blockedUsers`/`blockedByUsers` (username). Their data is used verbatim on the account pages.
- Implicit (tag-vote) hidden images keep their `tagId` in a separate `hiddenImagesImplicit` array; `expand` re-merges them into `hiddenImages` in the exact legacy order.

**The client re-expands to the exact legacy `HiddenPreferenceTypes` shape** in `useQueryHiddenPreferences`, so **all ~30 downstream consumers, the 9 SSR-prefetch pages, and the 3 other server callers of `getAllHiddenForUser` are untouched** and client-visible data is byte-identical.

### Flag gate + rollout safety
`hiddenPrefsCompact` (Flipt `hidden-prefs-compact`, default **OFF / mods only**) — mirrors the arc's ramp pattern (`feedReserveCls`, `faro`). Sequence:
1. Merge + deploy with the flag **OFF** → zero behavior change; client bundles that understand **both** shapes roll out.
2. After bundles roll, ramp `%` via Flipt (mods first).
3. Instant rollback = flip OFF.

A `__v: 2` discriminator on the compact object lets the read-expander AND the optimistic-update path detect the shape unambiguously (empty arrays are otherwise shape-ambiguous), and lets a stale client bundle keep working against either shape in both rolling-deploy directions.

## Blast radius
- **Server**: `getAllHiddenForUser` gains an additive, overloaded `compact` param (default legacy → the 3 existing callers — `middleware.trpc`, `pages/api/user/getHiddenPreferences`, `cache-check` — are unchanged). Only the tRPC router opts in, and only under the flag.
- **Client**: contained to 2 hook files (`useHiddenPreferences` read-expand, `useToggleHiddenPreferences` optimistic writes) + the new shared module. Downstream consumers unchanged.
- **Optimistic path** is the one correctness-sensitive spot (it mutates the raw cache in whatever shape it holds); covered by parity tests.

## Tests (`src/shared/hidden-preferences/__tests__/compact.test.ts`, 11 cases)
- `expand(compact(legacy))` round-trips **byte-identical** to the legacy response (incl. explicit-then-implicit image ordering).
- `expand` passes a legacy response through unchanged (rolling-deploy safety) and coalesces undefined / older-field-missing responses to `[]`.
- `__v` discriminates both shapes incl. the empty-array case.
- **Optimistic parity**: add / remove / toggle (and the server-diff reconcile) produce **identical membership** whether applied to the compact or the legacy cache — the load-bearing invariant that the flag flip cannot change what the user sees hidden. (Order-independent by design: every consumer is membership-based — `Map` / `.some(x => x.id === …)`; verified no consumer reads `hiddenImages` array order.)

## Verification (verbatim)
- `vitest run --project unit` (compact + `middleware.trpc` + `useApplyHiddenPreferences`): **21 passed**.
- `tsc --noEmit`: **zero new errors in any touched file** or in the consumers of the changed type. (The 17 baseline errors in this checkout are pre-existing, unrelated: the `event-engine-common` git submodule + generated `kysely` types aren't present — all in untouched files: `image.service`, `bitdex-stats`, `flipt/client`, `packages/civitai-db*`.)
- **Not yet verified against prod** — true proof is post-merge: once `hiddenPrefsCompact` ramps, `{namespace="civitai-dp-prod"} |= "trpc-response-oversized" | json` filtered to `path="hiddenPreferences.getHidden"` should show the `serializeMs` p99 (803ms) and the 12.4MB payload tail collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 🔴 RAMP DISCIPLINE (flag-hardening, commit `9a9f95c`)
Adversarial audit flagged that `availability: ['mod']` would turn the compact shape ON for every mod **the instant the server deploys** — while their tabs may still run the OLD (pre-PR) bundle that has no `expandHiddenPreferences`. That bundle reads the compact `number[]` as `{ id }[]` → `x.id === undefined` → **un-hides the user's entire hidden set (incl. NSFW/moderated) until a hard reload**. Fixed:

- Flag is now **`availability: []`** — dark by default, fails closed (empty availability → static `false` when Flipt is absent/down). The Flipt `hidden-prefs-compact` threshold is the **only** on-switch.
- The `__v` discriminator protects **new (this-PR-or-later) clients** reading either shape; it does **not** protect a pre-PR bundle.
- **Deploy dark → confirm the new client bundle is serving everywhere (hours, per the SPA-cache rollout pattern) → THEN ramp the Flipt threshold. Never ramp during/immediately-after a deploy.** Rollback = threshold to 0.
