### PR TITLE
test(models): stub blocked-browsing-tags call in get-models-raw transient-503 test (green after #3041 co-merge)

### DIFF
--- a/src/server/services/__tests__/get-models-raw.transient-503.test.ts
+++ b/src/server/services/__tests__/get-models-raw.transient-503.test.ts
@@ -47,6 +47,21 @@ vi.mock('~/server/services/image.service', () => ({
 }));
 vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn().mockResolvedValue(false) }));
 
+// #3041 ("server-enforced blocked browsing tags") inserted a call to
+// enforceBlockedBrowsingTagsForModels(input, viewer) at the TOP of getModelsRaw,
+// BEFORE the Meili try/catch under test. Its real body runs redis.get /
+// safeError logging / system-cache / DB — orthogonal to the transient-error
+// path, but it would throw (or short-circuit) before the assertions here. Stub
+// it as a no-op that returns the "not empty" sentinel so getModelsRaw proceeds
+// into the Meili path exactly as before. Real return shape (origin/main):
+// `Promise<{ emptyResult: boolean }>` — getModelsRaw does
+// `if (blockedEnforcement.emptyResult) return { items: [], isPrivate: false }`,
+// so emptyResult:false lets it continue. This is the minimal seam (one
+// orthogonal service fn) — it won't rot on a future redis/db refactor.
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTagsForModels: vi.fn().mockResolvedValue({ emptyResult: false }),
+}));
+
 // Stub the DB/redis surfaces model.service imports. None are reached on the
 // throw path (the Meili catch fires before any query), but importing the REAL
 // modules instantiates a Prisma client that fires a query at module load and


### PR DESCRIPTION
## What / why

`get-models-raw.transient-503.test.ts` (added in #3049 — a direct test of `getModelsRaw`'s transient-Meili → `TRPCError SERVICE_UNAVAILABLE` widening) went **9/9 RED on `main`**. Not a fix regression: sibling PR #3041 ("server-enforced blocked browsing tags", `2afd4cb4b6`) co-merged and inserted a call to `enforceBlockedBrowsingTagsForModels(input, viewer)` at the **top** of `getModelsRaw`, **before** the Meili try/catch under test. Its real body runs `redis.get` / `safeError` logging / system-cache / DB — none of which this test stubbed — so `getModelsRaw` now throws before reaching the assertions.

The #3049 runtime behavior is **unchanged and correct**; this is purely stale test stubs after the co-merge.

## Fix

Mock the ONE orthogonal service function rather than adding more redis/db/system-cache stubs (minimal, most robust seam — won't rot on the next redis/db refactor):

```js
vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
  enforceBlockedBrowsingTagsForModels: vi.fn().mockResolvedValue({ emptyResult: false }),
}));
```

Return shape matched to `origin/main`: `Promise<{ emptyResult: boolean }>`. `getModelsRaw` does `if (blockedEnforcement.emptyResult) return { items: [], isPrivate: false }`, so `{ emptyResult: false }` lets it proceed into the Meili path exactly as before.

## Verification

- **9/9 pass** on the merged tree with the fix in place.
- **Assertions still real (not neutered):** with the narrow pre-#3049 catch (`instanceof MeiliCallTimeoutError` only) restored, the 6 transient `MeiliSearchCommunicationError` cases **still FAIL** even with this stub in place — proving the stub only removed the orthogonal #3041 blocker, not the transient→503 checks.
- Sibling `model-search.transient-503.test.ts` (10) + REST `transient-503.test.ts` (12) unaffected. Full set **31/31 green**.

Only the one test file changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
