### PR TITLE
perf(post): trim post.getInfinite per-post base objects (image cap #3052 underdelivered — base weight is the real cost)

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -5425,9 +5425,10 @@ export const getImagesForPosts = async ({
       width: number;
       height: number;
       hash: string;
-      // postId is fetched only to group images under their post server-side
-      // (post.service groups on `x.postId === post.id`); it is stripped from
-      // the response before serialization (see stripPostGetInfiniteImageFields).
+      // postId groups images under their post server-side (post.service groups
+      // on `x.postId === post.id`) AND is read on the response by
+      // ImageContextMenu → ImageMenuItems (collection/view/edit/searchable menu
+      // items on the browse post cards) — kept.
       postId: number;
       type: MediaType;
       metadata: ImageMetadata | VideoMetadata | null;

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -5425,17 +5425,24 @@ export const getImagesForPosts = async ({
       width: number;
       height: number;
       hash: string;
-      createdAt: Date;
+      // postId is fetched only to group images under their post server-side
+      // (post.service groups on `x.postId === post.id`); it is stripped from
+      // the response before serialization (see stripPostGetInfiniteImageFields).
       postId: number;
       type: MediaType;
       metadata: ImageMetadata | VideoMetadata | null;
-      hasMeta: boolean;
       onSite: boolean;
       remixOfId?: number | null;
-      hasPositivePrompt?: boolean;
       poi?: boolean;
       minor?: boolean;
     }[]
+    // NOTE: getImagesForPosts is used ONLY by getPostsInfinite. The browse
+    // cards render `images[0]` and the hidden-preferences filter reads
+    // {id,userId,nsfwLevel,tagIds,poi,minor}; NO consumer reads createdAt,
+    // hasMeta, or hasPositivePrompt — dropped here to cut per-image serialize
+    // weight (this endpoint's payload is ~85% images at ~7 images/post, so the
+    // per-image field COUNT — not the #3052 image CAP, which only trims the
+    // rare >8-image gallery tail — is what drives bytes + superjson serializeMs).
   >`
     SELECT
       i.id,
@@ -5448,22 +5455,7 @@ export const getImagesForPosts = async ({
       i.hash,
       i.type,
       i.metadata,
-      i."createdAt",
       i."postId",
-      (
-        CASE
-          WHEN i.meta IS NULL OR jsonb_typeof(i.meta) = 'null' OR i."hideMeta" THEN FALSE
-          ELSE TRUE
-        END
-      ) AS "hasMeta",
-      (
-        CASE
-          WHEN i.meta IS NOT NULL AND jsonb_typeof(i.meta) != 'null' AND NOT i."hideMeta"
-            AND i.meta->>'prompt' IS NOT NULL
-          THEN TRUE
-          ELSE FALSE
-        END
-      ) AS "hasPositivePrompt",
       ${imageOnSiteSql()} as "onSite",
       i.metadata->>'remixOfId' as "remixOfId",
       i.minor,

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -62,7 +62,10 @@ import type {
 } from '~/server/services/user.service';
 import { bustCacheTag, queryCache } from '~/server/utils/cache-helpers';
 import { getPeriods } from '~/server/utils/enum-helpers';
-import { capPostGetInfiniteImages } from '~/server/utils/post-getinfinite-images';
+import {
+  capPostGetInfiniteImages,
+  stripPostGetInfiniteImageFields,
+} from '~/server/utils/post-getinfinite-images';
 import {
   handleLogError,
   throwAuthorizationError,
@@ -528,7 +531,11 @@ export const getPostsInfinite = async ({
 
           return true;
         })
-        .map(({ userId: creatorId, ...post }) => {
+        // Strip `cursorId` from each item: it's the raw sort-key value selected
+        // for keyset pagination (surfaced via the page-level `nextCursor`), NOT
+        // a per-item field — no consumer reads `item.cursorId`. Dropping it
+        // removes one field (a superjson-typed Date/number node) PER POST.
+        .map(({ userId: creatorId, cursorId: _cursorId, ...post }) => {
           const _images = images.filter((x) => x.postId === post.id);
           const { username, image, deletedAt } = userData[creatorId] || {};
 
@@ -555,7 +562,7 @@ export const getPostsInfinite = async ({
             // event loop. The cap keeps headroom for the client hidden-preferences
             // fall-through (see `post-getinfinite-images.ts`); `.slice` returns a
             // new array so nothing upstream is mutated.
-            images: capPostGetInfiniteImages(_images),
+            images: stripPostGetInfiniteImageFields(capPostGetInfiniteImages(_images)),
             cosmetic: cosmetics[post.id] ?? null,
           };
         })

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -62,10 +62,7 @@ import type {
 } from '~/server/services/user.service';
 import { bustCacheTag, queryCache } from '~/server/utils/cache-helpers';
 import { getPeriods } from '~/server/utils/enum-helpers';
-import {
-  capPostGetInfiniteImages,
-  stripPostGetInfiniteImageFields,
-} from '~/server/utils/post-getinfinite-images';
+import { capPostGetInfiniteImages } from '~/server/utils/post-getinfinite-images';
 import {
   handleLogError,
   throwAuthorizationError,
@@ -562,7 +559,7 @@ export const getPostsInfinite = async ({
             // event loop. The cap keeps headroom for the client hidden-preferences
             // fall-through (see `post-getinfinite-images.ts`); `.slice` returns a
             // new array so nothing upstream is mutated.
-            images: stripPostGetInfiniteImageFields(capPostGetInfiniteImages(_images)),
+            images: capPostGetInfiniteImages(_images),
             cosmetic: cosmetics[post.id] ?? null,
           };
         })

--- a/src/server/utils/__tests__/post-getinfinite-images.test.ts
+++ b/src/server/utils/__tests__/post-getinfinite-images.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   POST_GETINFINITE_IMAGES_PER_POST,
   capPostGetInfiniteImages,
+  stripPostGetInfiniteImageFields,
 } from '~/server/utils/post-getinfinite-images';
 
 // The browse-feed (`post.getInfinite`) response caps each post's embedded images
@@ -45,5 +46,74 @@ describe('post-getinfinite-images', () => {
     expect(source).toHaveLength(50);
     expect(source).toEqual(before);
     expect(out).not.toBe(source); // a new array, not the same reference
+  });
+});
+
+describe('stripPostGetInfiniteImageFields', () => {
+  // A representative post.getInfinite image row: the server-only grouping field
+  // `postId` alongside the fields consumers DO read (cover render +
+  // hidden-preferences filter).
+  const makeRow = (id: number) => ({
+    id,
+    postId: 999,
+    userId: 42,
+    url: `url-${id}`,
+    name: `img-${id}`,
+    nsfwLevel: 1,
+    width: 512,
+    height: 512,
+    hash: 'abc',
+    type: 'image',
+    metadata: { width: 512, height: 512 },
+    onSite: true,
+    remixOfId: null,
+    poi: false,
+    minor: false,
+    tagIds: [1, 2, 3],
+  });
+
+  it('drops postId from every image', () => {
+    const out = stripPostGetInfiniteImageFields([makeRow(1), makeRow(2)]);
+    expect(out).toHaveLength(2);
+    for (const img of out) {
+      expect('postId' in img).toBe(false);
+    }
+  });
+
+  it('preserves every field a consumer reads (cover render + hidden-preferences)', () => {
+    const [out] = stripPostGetInfiniteImageFields([makeRow(7)]);
+    // cover render path (PostsCard / PostCard / EdgeMedia2 / MediaHash / OnsiteIndicator)
+    for (const key of [
+      'id',
+      'url',
+      'name',
+      'nsfwLevel',
+      'width',
+      'height',
+      'hash',
+      'type',
+      'metadata',
+      'onSite',
+      'remixOfId',
+    ]) {
+      expect(out).toHaveProperty(key);
+    }
+    // hidden-preferences filter (useApplyHiddenPreferences, posts path)
+    for (const key of ['id', 'userId', 'nsfwLevel', 'tagIds', 'poi', 'minor']) {
+      expect(out).toHaveProperty(key);
+    }
+    expect(out.url).toBe('url-7');
+    expect(out.tagIds).toEqual([1, 2, 3]);
+  });
+
+  it('returns NEW objects and does not mutate the input', () => {
+    const source = [makeRow(1)];
+    const out = stripPostGetInfiniteImageFields(source);
+    expect(out[0]).not.toBe(source[0]);
+    expect('postId' in source[0]).toBe(true); // input untouched
+  });
+
+  it('handles an empty array', () => {
+    expect(stripPostGetInfiniteImageFields([])).toEqual([]);
   });
 });

--- a/src/server/utils/__tests__/post-getinfinite-images.test.ts
+++ b/src/server/utils/__tests__/post-getinfinite-images.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import {
   POST_GETINFINITE_IMAGES_PER_POST,
   capPostGetInfiniteImages,
-  stripPostGetInfiniteImageFields,
 } from '~/server/utils/post-getinfinite-images';
 
 // The browse-feed (`post.getInfinite`) response caps each post's embedded images
@@ -46,74 +45,5 @@ describe('post-getinfinite-images', () => {
     expect(source).toHaveLength(50);
     expect(source).toEqual(before);
     expect(out).not.toBe(source); // a new array, not the same reference
-  });
-});
-
-describe('stripPostGetInfiniteImageFields', () => {
-  // A representative post.getInfinite image row: the server-only grouping field
-  // `postId` alongside the fields consumers DO read (cover render +
-  // hidden-preferences filter).
-  const makeRow = (id: number) => ({
-    id,
-    postId: 999,
-    userId: 42,
-    url: `url-${id}`,
-    name: `img-${id}`,
-    nsfwLevel: 1,
-    width: 512,
-    height: 512,
-    hash: 'abc',
-    type: 'image',
-    metadata: { width: 512, height: 512 },
-    onSite: true,
-    remixOfId: null,
-    poi: false,
-    minor: false,
-    tagIds: [1, 2, 3],
-  });
-
-  it('drops postId from every image', () => {
-    const out = stripPostGetInfiniteImageFields([makeRow(1), makeRow(2)]);
-    expect(out).toHaveLength(2);
-    for (const img of out) {
-      expect('postId' in img).toBe(false);
-    }
-  });
-
-  it('preserves every field a consumer reads (cover render + hidden-preferences)', () => {
-    const [out] = stripPostGetInfiniteImageFields([makeRow(7)]);
-    // cover render path (PostsCard / PostCard / EdgeMedia2 / MediaHash / OnsiteIndicator)
-    for (const key of [
-      'id',
-      'url',
-      'name',
-      'nsfwLevel',
-      'width',
-      'height',
-      'hash',
-      'type',
-      'metadata',
-      'onSite',
-      'remixOfId',
-    ]) {
-      expect(out).toHaveProperty(key);
-    }
-    // hidden-preferences filter (useApplyHiddenPreferences, posts path)
-    for (const key of ['id', 'userId', 'nsfwLevel', 'tagIds', 'poi', 'minor']) {
-      expect(out).toHaveProperty(key);
-    }
-    expect(out.url).toBe('url-7');
-    expect(out.tagIds).toEqual([1, 2, 3]);
-  });
-
-  it('returns NEW objects and does not mutate the input', () => {
-    const source = [makeRow(1)];
-    const out = stripPostGetInfiniteImageFields(source);
-    expect(out[0]).not.toBe(source[0]);
-    expect('postId' in source[0]).toBe(true); // input untouched
-  });
-
-  it('handles an empty array', () => {
-    expect(stripPostGetInfiniteImageFields([])).toEqual([]);
   });
 });

--- a/src/server/utils/post-getinfinite-images.ts
+++ b/src/server/utils/post-getinfinite-images.ts
@@ -6,12 +6,20 @@
  * every `post.getInfinite` consumer found none that renders `images[1+]`. But
  * `getPostsInfinite` embeds the post's ENTIRE image list (`getImagesForPosts`
  * accepts a `coverOnly` flag that is currently UNUSED — the query has no per-post
- * LIMIT), so a gallery post can carry dozens–hundreds of image rows. This is the
- * dominant contributor to `post.getInfinite`'s ~1.6 MB payloads (the #2 total
- * serialize load in the system: ~80,000 serializeMs / 2h), serialized
+ * LIMIT), so a gallery post can carry dozens–hundreds of image rows, serialized
  * synchronously on the Node event loop — a source of the event-loop-freeze class.
  * Capping the RESPONSE sheds the heavy-gallery tail (a 100-image post → 8 rows)
  * while leaving typical posts (< cap) untouched.
+ *
+ * CORRECTION (measured live via the #3017 `trpc-response-oversized` instrument):
+ * capping ALONE moved this endpoint's payload only ~8% (max 1.20 → 1.10 MB) with
+ * FLAT serializeMs — because typical published posts average ~7 images (measured),
+ * i.e. already ≤ the cap, so the cap only trims the RARE >8-image gallery. The
+ * real driver is the per-image FIELD COUNT applied to every one of those ~7
+ * images × up-to-200 posts. The field-level trim (`stripPostGetInfiniteImageFields`
+ * + the createdAt/hasMeta/hasPositivePrompt SQL drop in `getImagesForPosts`) is
+ * what moves bytes AND serializeMs on the common case; this cap remains as the
+ * gallery-tail guard.
  *
  * Mirrors `model-getall-images.ts` (`GET_ALL_IMAGES_PER_MODEL`). Set to 8 (not 1)
  * as HEADROOM for the client-side filter (`useApplyHiddenPreferences`, posts
@@ -37,4 +45,25 @@ export const POST_GETINFINITE_IMAGES_PER_POST = 8;
  */
 export function capPostGetInfiniteImages<T>(images: T[]): T[] {
   return images.slice(0, POST_GETINFINITE_IMAGES_PER_POST);
+}
+
+/**
+ * Per-image response-field trim for the `post.getInfinite` browse feed.
+ *
+ * `getImagesForPosts` fetches `postId` only to group images under their post
+ * server-side; NO `post.getInfinite` consumer reads it off the response (the
+ * images are already nested under their post). Stripping it removes one field
+ * PER IMAGE — and this endpoint's payload is ~85% images (~7 images/post), so
+ * per-image field count is the dominant driver of both bytes and the
+ * synchronous superjson `serializeMs` (the #3052 image CAP only trimmed the
+ * rare >8-image gallery tail, hence its ~8% payload move). `createdAt`,
+ * `hasMeta`, and `hasPositivePrompt` — likewise unread by every consumer — are
+ * already dropped at the SQL layer in `getImagesForPosts`.
+ *
+ * Returns NEW image objects (object rest); never mutates the input.
+ */
+export function stripPostGetInfiniteImageFields<T extends { postId?: unknown }>(
+  images: T[]
+): Omit<T, 'postId'>[] {
+  return images.map(({ postId: _postId, ...rest }) => rest);
 }

--- a/src/server/utils/post-getinfinite-images.ts
+++ b/src/server/utils/post-getinfinite-images.ts
@@ -16,10 +16,11 @@
  * FLAT serializeMs — because typical published posts average ~7 images (measured),
  * i.e. already ≤ the cap, so the cap only trims the RARE >8-image gallery. The
  * real driver is the per-image FIELD COUNT applied to every one of those ~7
- * images × up-to-200 posts. The field-level trim (`stripPostGetInfiniteImageFields`
- * + the createdAt/hasMeta/hasPositivePrompt SQL drop in `getImagesForPosts`) is
- * what moves bytes AND serializeMs on the common case; this cap remains as the
- * gallery-tail guard.
+ * images × up-to-200 posts. The field-level trim (the createdAt/hasMeta/
+ * hasPositivePrompt SQL drop in `getImagesForPosts`, plus the post-level
+ * `cursorId` strip in post.service) is what moves bytes AND serializeMs on the
+ * common case; this cap remains as the gallery-tail guard. (`postId` is NOT
+ * trimmed — ImageContextMenu reads it off the response image.)
  *
  * Mirrors `model-getall-images.ts` (`GET_ALL_IMAGES_PER_MODEL`). Set to 8 (not 1)
  * as HEADROOM for the client-side filter (`useApplyHiddenPreferences`, posts
@@ -47,23 +48,10 @@ export function capPostGetInfiniteImages<T>(images: T[]): T[] {
   return images.slice(0, POST_GETINFINITE_IMAGES_PER_POST);
 }
 
-/**
- * Per-image response-field trim for the `post.getInfinite` browse feed.
- *
- * `getImagesForPosts` fetches `postId` only to group images under their post
- * server-side; NO `post.getInfinite` consumer reads it off the response (the
- * images are already nested under their post). Stripping it removes one field
- * PER IMAGE — and this endpoint's payload is ~85% images (~7 images/post), so
- * per-image field count is the dominant driver of both bytes and the
- * synchronous superjson `serializeMs` (the #3052 image CAP only trimmed the
- * rare >8-image gallery tail, hence its ~8% payload move). `createdAt`,
- * `hasMeta`, and `hasPositivePrompt` — likewise unread by every consumer — are
- * already dropped at the SQL layer in `getImagesForPosts`.
- *
- * Returns NEW image objects (object rest); never mutates the input.
- */
-export function stripPostGetInfiniteImageFields<T extends { postId?: unknown }>(
-  images: T[]
-): Omit<T, 'postId'>[] {
-  return images.map(({ postId: _postId, ...rest }) => rest);
-}
+// NOTE: `postId` is INTENTIONALLY kept on each response image. It's read by
+// ImageContextMenu → ImageMenuItems (destructured off the image) for the
+// "Save post to collection" / "View Post" / "Edit Post" / "Toggle Searchable"
+// menu items on the browse post cards — so it is NOT an unread field and must
+// survive serialization. The per-image trim is done at the SQL layer in
+// `getImagesForPosts` (dropping the genuinely-unread createdAt / hasMeta /
+// hasPositivePrompt).


### PR DESCRIPTION
## Why — #3052 underdelivered (verified in prod)

#3052 capped each post's embedded `images` array to 8 to shrink the `post.getInfinite` tRPC serialize payload. The live **#3017 `trpc-response-oversized`** instrument shows it barely moved this path: **max bytes 1.20 → 1.10 MB (~8%)** with **FLAT serializeMs (57 → 58)**.

**Root cause of the underdelivery (measured against real data):** recently-published posts average **~7 images each** — already at/under the cap of 8 — so the cap only trims the *rare* >8-image gallery tail, not the common case.

## Composition finding (measured, dev clone, 100-post page)

- Images are **~87%** of the payload (~525 B/image raw JSON at ~7 images/post).
- The dominant driver is the per-image **field COUNT** applied to every one of those ~7 images × up-to-200 posts — which is exactly what superjson walks to produce `serializeMs`. The image *cap* left that untouched (hence flat serializeMs).

## What this trims (drop only fields verified read by NO consumer)

Verified by grepping **every** `post.getInfinite` consumer (`PostsCard`, `Cards/PostCard`, `PostsInfinite`, `ResourceReviewDetail`, `ImageContextMenu`/`ImageMenuItems`) **and** the hidden-preferences filter (`useApplyHiddenPreferences` posts path):

- `getImagesForPosts` (used **only** by `getPostsInfinite`): drop **`createdAt`**, **`hasMeta`**, **`hasPositivePrompt`** at the SQL layer. (Their only readers are on `image.getInfinite`, a different endpoint.) Dropping `createdAt` (a Date) also removes a superjson-typed node **+ its meta-map entry** per image → disproportionately helps `serializeMs`.
- Strip **`cursorId`** (raw keyset sort value; pagination uses the page-level `nextCursor`) from each post item.

**`postId` is intentionally KEPT** on each response image — `ImageContextMenu → ImageMenuItems` reads it for the "Save post to collection" / "View Post" / "Edit Post" / "Toggle Searchable" menu items on the browse cards. (An earlier revision of this PR stripped it; an adversarial audit caught that it would silently break those menu items — reverted.)

**No cap change, no `limit` change, no DB/query shape change** beyond dropping the three unread columns.

## Expected impact (honest, revised)

- **~15.6% reduction on the image portion** (measured, raw-JSON floor: 294 KB → 248 KB) ⇒ **~14–15% total payload**, higher under superjson (the `createdAt`×~525 + `cursorId`×100 Date nodes drop from the meta map).
- Materially better than #3052's 8%, and **unlike #3052 it should move `serializeMs` DOWN** (fewer superjson nodes per response on the *common* case, not just the gallery tail).

## Blast radius

Low. Only unread fields are dropped; all cover-render, hidden-preferences, and context-menu reads are untouched. `getImagesForPosts` has a single caller so the SQL trim is contained. No flag gate.

## Not done (deliberately)

- **Lowering the default `limit` (100→50)** — user-visible, higher blast radius; not needed since the field trim delivers.
- **Slimming *non-cover* images** — bigger byte lever but risks a cover-shift regression for hidden-tag users; would need client cooperation + a flag. Deferred.

## Tests

- Existing `post-getinfinite-images` cap unit tests unchanged: `pnpm test:unit` for the file → **4/4 pass**.
- `pnpm typecheck`: **0 new errors** (the 17 reported are pre-existing `event-engine-common` submodule + `kysely` workspace-resolution failures, byte-identical before/after this diff, none in the changed regions).

## Post-deploy verification (the real proof)

`#3017` for `path=post.getInfinite`: `serializeMs` and max bytes should drop **meaningfully** (target well beyond #3052's 8%), and — unlike #3052 — serializeMs should actually decrease.

```
{namespace="civitai-dp-prod"} |= `trpc-response-oversized` | json | path="post.getInfinite"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)