### PR TITLE
fix(orchestrator/imageUpload): map transient upload failures to 503, content-reject to 400

### DIFF
--- a/src/server/services/orchestrator/__tests__/imageUpload.error-mapping.test.ts
+++ b/src/server/services/orchestrator/__tests__/imageUpload.error-mapping.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * Error mapping for orchestrator.imageUpload (imageUpload.ts).
+ *
+ * Drives the REAL `imageUpload` through its `if (!data)` → `switch (status)`
+ * branches, mocking ONLY the generated `@civitai/client` + the client factory so
+ * the real `~/server/utils/errorHandling` TRPCError mapping AND the real
+ * `~/shared/constants/orchestrator.constants` `isMature` run end-to-end.
+ *
+ * The bug this covers (masked causeless generic 500s — the #1 dp-prod 500 source
+ * at ~178/h and climbing, 2026-07-10):
+ *  - The `switch (error.status)` `default` case threw a plain `Error`, so an
+ *    upstream orchestrator HTTP 5xx (500/502/503/504) OR a status-less
+ *    network/timeout failure (no HTTP status) surfaced as a generic tRPC
+ *    INTERNAL_SERVER_ERROR (500) with an EMPTY cause chain — INVISIBLE in
+ *    `_axiom` and non-retryable. Now mapped to a retry-able SERVICE_UNAVAILABLE
+ *    (503) with the ORIGINAL client error preserved as `cause` (mirror #3047 /
+ *    #2978).
+ *  - The mature-content rejection (`allowMatureContent === false` + a mature
+ *    blob) threw a plain `Error('mature content not allowed')` → a 500 for what is
+ *    a USER-CONTENT rejection. Now a 400 BAD_REQUEST.
+ */
+
+const { mockInvokeImageUploadStepTemplate } = vi.hoisted(() => ({
+  mockInvokeImageUploadStepTemplate: vi.fn(),
+}));
+
+// NsfwLevel + WorkflowStatus are read at module-load by orchestrator.constants; give
+// them real-ish string enums so `isMature` runs against the SAME values as the test.
+vi.mock('@civitai/client', () => ({
+  invokeImageUploadStepTemplate: mockInvokeImageUploadStepTemplate,
+  // handleError derives the fallback user-facing message string from the client error.
+  handleError: vi.fn((e: unknown) => {
+    if (typeof e === 'string') return e;
+    if (e && typeof e === 'object') {
+      const rec = e as Record<string, unknown>;
+      if (typeof rec.detail === 'string') return rec.detail;
+      if (typeof rec.title === 'string') return rec.title;
+    }
+    return undefined;
+  }),
+  NsfwLevel: { PG: 'PG', PG13: 'PG13', R: 'R', X: 'X', XXX: 'XXX' },
+  WorkflowStatus: {
+    UNASSIGNED: 'unassigned',
+    PREPARING: 'preparing',
+    SCHEDULED: 'scheduled',
+    PROCESSING: 'processing',
+    SUCCEEDED: 'succeeded',
+    FAILED: 'failed',
+    EXPIRED: 'expired',
+    CANCELED: 'canceled',
+  },
+}));
+
+vi.mock('~/server/services/orchestrator/client', () => ({
+  createOrchestratorClient: vi.fn(() => ({})),
+  internalOrchestratorClient: {},
+}));
+
+import { imageUpload } from '~/server/services/orchestrator/imageUpload';
+
+// A resolve shape (NOT a reject): the @civitai/client with no `throwOnError` RESOLVES
+// `{ data: undefined, error }` on an upstream error response.
+const errorResolve = (error: unknown) => ({ data: undefined, error });
+
+const run = (allowMatureContent?: boolean) =>
+  imageUpload({ sourceImage: 'https://x/y.png', token: 'tok', allowMatureContent }).catch(
+    (e) => e
+  );
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('imageUpload — transient upstream failures → retry-able 503, cause preserved', () => {
+  it.each([500, 502, 503, 504])(
+    'maps an orchestrator HTTP %i to SERVICE_UNAVAILABLE (503), NOT a plain Error / generic 500',
+    async (status) => {
+      mockInvokeImageUploadStepTemplate.mockResolvedValue(
+        errorResolve({ status, detail: 'orchestrator exploded' })
+      );
+
+      const err = await run();
+
+      expect(err).toBeInstanceOf(TRPCError);
+      expect(err).not.toBeInstanceOf(TypeError);
+      expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+      // The ORIGINAL client error is preserved on `.cause` (was masked/empty before).
+      expect((err as TRPCError).cause).toMatchObject({ status, detail: 'orchestrator exploded' });
+    }
+  );
+
+  it('maps a status-less network/timeout error (bare Error, no status) to SERVICE_UNAVAILABLE (503)', async () => {
+    // A TCP/DNS/TLS failure reaches the client as a bare Error with no `status`.
+    const networkError = new Error('fetch failed');
+    mockInvokeImageUploadStepTemplate.mockResolvedValue(errorResolve(networkError));
+
+    const err = await run();
+
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+    expect((err as TRPCError).cause).toBe(networkError);
+  });
+
+  it('maps a client error object with an undefined status field to 503', async () => {
+    mockInvokeImageUploadStepTemplate.mockResolvedValue(
+      errorResolve({ status: undefined, detail: 'no response' })
+    );
+
+    const err = await run();
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+  });
+});
+
+describe('imageUpload — client faults are unchanged (NOT converted to 503)', () => {
+  it('keeps status 400 as BAD_REQUEST', async () => {
+    mockInvokeImageUploadStepTemplate.mockResolvedValue(
+      errorResolve({ status: 400, detail: 'bad input' })
+    );
+
+    const err = await run();
+    expect((err as TRPCError).code).toBe('BAD_REQUEST');
+  });
+
+  it('keeps status 401 as UNAUTHORIZED', async () => {
+    mockInvokeImageUploadStepTemplate.mockResolvedValue(
+      errorResolve({ status: 401, detail: 'no token' })
+    );
+
+    const err = await run();
+    expect((err as TRPCError).code).toBe('UNAUTHORIZED');
+  });
+});
+
+describe('imageUpload — an unexpected non-5xx anomaly stays a hard error (no over-broad 503)', () => {
+  it('an unexpected 4xx status (418) stays a plain Error, NOT a 503', async () => {
+    mockInvokeImageUploadStepTemplate.mockResolvedValue(
+      errorResolve({ status: 418, detail: 'teapot' })
+    );
+
+    const err = await run();
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBeUndefined();
+  });
+});
+
+describe('imageUpload — mature-content rejection is a 400 BAD_REQUEST, not a 500', () => {
+  it('rejects a mature blob when allowMatureContent === false with BAD_REQUEST', async () => {
+    // data present (success round-trip) but a mature nsfwLevel → user-content reject.
+    mockInvokeImageUploadStepTemplate.mockResolvedValue({
+      data: { blob: { nsfwLevel: 'R' } },
+      error: undefined,
+    });
+
+    const err = await run(false);
+
+    expect(err).toBeInstanceOf(TRPCError);
+    expect(err).not.toBeInstanceOf(TypeError);
+    expect((err as TRPCError).code).toBe('BAD_REQUEST');
+    expect((err as TRPCError).message).toMatch(/mature content not allowed/i);
+  });
+
+  it('returns data untouched on the success path (safe blob)', async () => {
+    const data = { blob: { nsfwLevel: 'PG' } };
+    mockInvokeImageUploadStepTemplate.mockResolvedValue({ data, error: undefined });
+
+    const result = await imageUpload({
+      sourceImage: 'https://x/y.png',
+      token: 'tok',
+      allowMatureContent: false,
+    });
+    expect(result).toBe(data);
+  });
+
+  it('returns a mature blob untouched when allowMatureContent is not false', async () => {
+    const data = { blob: { nsfwLevel: 'R' } };
+    mockInvokeImageUploadStepTemplate.mockResolvedValue({ data, error: undefined });
+
+    const result = await imageUpload({ sourceImage: 'https://x/y.png', token: 'tok' });
+    expect(result).toBe(data);
+  });
+});

--- a/src/server/services/orchestrator/imageUpload.ts
+++ b/src/server/services/orchestrator/imageUpload.ts
@@ -1,6 +1,10 @@
 import { NsfwLevel, handleError, invokeImageUploadStepTemplate } from '@civitai/client';
 import { createOrchestratorClient } from '~/server/services/orchestrator/client';
-import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
+import {
+  throwAuthorizationError,
+  throwBadRequestError,
+  throwServiceUnavailableError,
+} from '~/server/utils/errorHandling';
 import { isMature } from '~/shared/constants/orchestrator.constants';
 
 export async function imageUpload({
@@ -24,20 +28,43 @@ export async function imageUpload({
 
   if (!data) {
     const messages = handleError(error);
-    switch (error.status) {
+    const status =
+      typeof error === 'object' && error !== null && 'status' in error
+        ? (error as { status?: number }).status
+        : undefined;
+    switch (status) {
       case 400:
         throw throwBadRequestError(messages);
       case 401:
         throw throwAuthorizationError(messages);
       default:
+        // A genuine upstream 5xx (orchestrator HTTP 500/502/503/504) OR a status-less
+        // network/timeout failure (no HTTP status — the TCP/DNS/TLS layer failed
+        // before any response) is a TRANSIENT dependency outage, NOT this app's own
+        // fault. Mirror #3047 (training) / #2978 (submit): surface it as a retry-able
+        // 503 SERVICE_UNAVAILABLE with the ORIGINAL error preserved as `cause`,
+        // instead of a plain `Error` that tRPC wraps into a generic
+        // INTERNAL_SERVER_ERROR (500) with an EMPTY cause chain. That masked-cause 500
+        // is exactly what surfaced ~178×/h and CLIMBING on orchestrator.imageUpload
+        // (2026-07-10): a degrading upload backend mis-counted against our 500 SLO AND
+        // non-retryable to the client. This block is only reached on a `!data` result
+        // from the orchestrator round-trip, so a local/logic bug thrown BEFORE the
+        // call never reaches here — only real upstream failures do.
+        if (status === undefined || status >= 500)
+          throw throwServiceUnavailableError(messages ?? null, error);
+        // Any OTHER unexpected non-5xx status is a real, non-transient anomaly — keep
+        // it a hard error so a genuine bug is NOT silently masked as a retry-able 503.
         throw new Error(messages);
     }
   }
 
   const { nsfwLevel } = data.blob;
 
+  // A mature blob when the caller disallowed mature content is a USER-CONTENT
+  // rejection (client fault), not a server fault — surface it as a 400 BAD_REQUEST,
+  // not a plain Error that tRPC maps to a 500.
   if (allowMatureContent === false && isMature(nsfwLevel))
-    throw new Error('mature content not allowed');
+    throw throwBadRequestError('mature content not allowed');
 
   return data;
 }


### PR DESCRIPTION
## Problem

`POST /api/trpc/orchestrator.imageUpload` was the **#1 dp-prod 500 source** — **~178/h and climbing** (2026-07-10) — and **INVISIBLE in `_axiom`**. The masked catch surfaced a raw `INTERNAL_SERVER_ERROR` (500) with an **empty cause chain**, so the trigger was never captured. Same class as #3047 (training) / #2978 (submit).

## Root cause

In `src/server/services/orchestrator/imageUpload.ts`, `invokeImageUploadStepTemplate` (from `@civitai/client`) returns `{ data, error }` (RFC 7807 ProblemDetails whose `.status` echoes the HTTP status). On a `!data` result the `switch (error.status)` `default` case threw a **plain `Error`**:

- An upstream orchestrator HTTP **5xx** (500/502/503/504) **OR** a **status-less** network/timeout failure (no HTTP status) → generic **non-retryable tRPC 500**, mis-counted against our 500 SLO.
- Separately, a mature blob under `allowMatureContent === false` threw `new Error('mature content not allowed')` → a **500** for what is a **user-content rejection**.

## Fix (mirrors #3047's taxonomy + cause preservation)

- **`default` case**: `status === undefined || status >= 500` → retry-able **503 `SERVICE_UNAVAILABLE`** via `throwServiceUnavailableError(messages, error)`, with the **original error preserved as `cause`**. `400`/`401` unchanged. Any **other** unexpected non-5xx status keeps the hard `Error` so a genuine bug is **not** silently masked as a retry-able 503.
- **Mature-content rejection** → `throwBadRequestError('mature content not allowed')` (**400**), not a 500.

Only transient upstream failures become 503, never a local/logic bug: the `!data` block is only reached on an orchestrator round-trip result, so a throw *before* the call cannot reach it. The **sole caller** is the passthrough `orchestrator.imageUpload` tRPC procedure (no error-code branching), so mature→400 breaks nothing that branched on the old 500.

## ⚠️ This does NOT cure the backend

The **climbing** rate indicates the orchestrator image-upload **backend is degrading** (a separate infra issue under investigation). This PR makes the failure **retryable + visible** (503 with cause) so it stops polluting the 500 SLO and its trigger becomes diagnosable — it does **not** fix the underlying upload backend failure.

## Tests

`src/server/services/orchestrator/__tests__/imageUpload.error-mapping.test.ts` drives the **real** `imageUpload` end-to-end through the real `~/server/utils/errorHandling` mapping + real `isMature` (only `@civitai/client` + the client factory stubbed). **7 fail before / 12 pass after** (verified by reverting the source):

- 500/502/503/504 + status-less network / undefined-status → `SERVICE_UNAVAILABLE`, cause preserved
- 400 → `BAD_REQUEST`, 401 → `UNAUTHORIZED` (unchanged)
- an unexpected 4xx (418) stays a plain `Error`, not a 503 (guards over-broad 503)
- mature blob + `allowMatureContent:false` → `BAD_REQUEST` (was a 500)

`tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
