### PR TITLE
fix(home): cloned home blocks read content selection through to system source

### DIFF
--- a/src/server/services/home-block-cache.service.ts
+++ b/src/server/services/home-block-cache.service.ts
@@ -28,12 +28,15 @@ const log = createLogger('home-block-cache', 'green');
 function getHomeBlockIdentifier(homeBlock: HomeBlockForCache) {
   switch (homeBlock.type) {
     case HomeBlockType.Collection:
-      return homeBlock.metadata.collection?.id;
+      // Clones read content through to their source block, so a content-id key would store
+      // source data under the clone's stale snapshot id and poison sibling blocks genuinely
+      // featuring that content. Bucket clones per-block instead.
+      return homeBlock.sourceId ? homeBlock.id : homeBlock.metadata.collection?.id;
     case HomeBlockType.Leaderboard:
     case HomeBlockType.Announcement:
       return homeBlock.id;
     case HomeBlockType.CosmeticShop:
-      return homeBlock.metadata.cosmeticShopSection?.id;
+      return homeBlock.sourceId ? homeBlock.id : homeBlock.metadata.cosmeticShopSection?.id;
     case HomeBlockType.FeaturedModelVersion:
       return 'default';
     case HomeBlockType.FeaturedCollections:

--- a/src/server/services/home-block-cache.service.ts
+++ b/src/server/services/home-block-cache.service.ts
@@ -20,6 +20,7 @@ type HomeBlockForCache = {
   id: number;
   type: HomeBlockType;
   metadata: HomeBlockMetaSchema;
+  sourceId?: number | null;
 };
 
 const log = createLogger('home-block-cache', 'green');

--- a/src/server/services/home-block-cache.service.ts
+++ b/src/server/services/home-block-cache.service.ts
@@ -28,14 +28,15 @@ const log = createLogger('home-block-cache', 'green');
 function getHomeBlockIdentifier(homeBlock: HomeBlockForCache) {
   switch (homeBlock.type) {
     case HomeBlockType.Collection:
-      // Clones read content through to their source block, so a content-id key would store
-      // source data under the clone's stale snapshot id and poison sibling blocks genuinely
-      // featuring that content. Bucket clones per-block instead.
-      return homeBlock.sourceId ? homeBlock.id : homeBlock.metadata.collection?.id;
+      // Keyed by collection id so the ~110k clones of a system block share one entry and stay
+      // reachable by homeBlockCacheBust(Collection, collectionId) when the collection changes.
+      return homeBlock.metadata.collection?.id;
     case HomeBlockType.Leaderboard:
     case HomeBlockType.Announcement:
       return homeBlock.id;
     case HomeBlockType.CosmeticShop:
+      // Clones read the section through to their source, so a section-id key would store source
+      // data under the clone's stale snapshot id and poison blocks genuinely on that section.
       return homeBlock.sourceId ? homeBlock.id : homeBlock.metadata.cosmeticShopSection?.id;
     case HomeBlockType.FeaturedModelVersion:
       return 'default';

--- a/src/server/services/home-block-cache.service.ts
+++ b/src/server/services/home-block-cache.service.ts
@@ -63,6 +63,9 @@ export async function getHomeBlockCached(homeBlock: HomeBlockForCache) {
   const parsedHomeBlock = {
     ...(homeBlockWithData || {}),
     ...homeBlock,
+    // ...but metadata may have been resolved through to the source block, so it can't come from
+    // the clone's snapshot.
+    metadata: homeBlockWithData?.metadata ?? homeBlock.metadata,
   };
 
   if (homeBlockWithData) {

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -191,6 +191,12 @@ export type HomeBlockWithData = {
   pickedCollections?: PickedFeaturedCollection[];
 };
 
+const readThroughTypes: HomeBlockType[] = [
+  HomeBlockType.Leaderboard,
+  HomeBlockType.CosmeticShop,
+  HomeBlockType.FeaturedCollections,
+];
+
 export const getHomeBlockData = async ({
   user,
   input,
@@ -211,10 +217,11 @@ export const getHomeBlockData = async ({
   const metadata: HomeBlockMetaSchema = (homeBlock.metadata || {}) as HomeBlockMetaSchema;
 
   // System block is source of truth for content selection; cloned user blocks read through to
-  // source so mods only update the singleton and clones stay in sync. Fetched once here so each
-  // case can reuse it rather than fetch the source per block type.
+  // source so mods only update the singleton and clones stay in sync. Only the types below drift
+  // in practice — upsertHomeBlock already propagates metadata to clones, so this covers system
+  // blocks edited out-of-band (direct SQL/Retool).
   let sourceMetadata: HomeBlockMetaSchema | undefined;
-  if (homeBlock.sourceId) {
+  if (homeBlock.sourceId && readThroughTypes.includes(homeBlock.type)) {
     const source = await dbRead.homeBlock.findUnique({
       where: { id: homeBlock.sourceId },
       select: { metadata: true },
@@ -224,13 +231,12 @@ export const getHomeBlockData = async ({
 
   switch (homeBlock.type) {
     case HomeBlockType.Collection: {
-      const collectionMeta = sourceMetadata?.collection ?? metadata.collection;
-      if (!collectionMeta || !collectionMeta.id) {
+      if (!metadata.collection || !metadata.collection.id) {
         return null;
       }
 
       const collection = await getCollectionById({
-        input: { id: collectionMeta.id },
+        input: { id: metadata.collection.id },
       });
 
       if (!collection) {
@@ -243,9 +249,9 @@ export const getHomeBlockData = async ({
             user,
             input: {
               collectionId: collection.id,
-              limit: input.limit || collectionMeta.limit,
+              limit: input.limit || metadata.collection.limit,
               browsingLevel: sfwBrowsingLevelsFlag,
-              collectionTagId: collectionMeta.tagId,
+              collectionTagId: metadata.collection.tagId,
             },
           });
 

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -210,14 +210,27 @@ export const getHomeBlockData = async ({
 }): Promise<HomeBlockWithData | null> => {
   const metadata: HomeBlockMetaSchema = (homeBlock.metadata || {}) as HomeBlockMetaSchema;
 
+  // System block is source of truth for content selection; cloned user blocks read through to
+  // source so mods only update the singleton and clones stay in sync. Fetched once here so each
+  // case can reuse it rather than fetch the source per block type.
+  let sourceMetadata: HomeBlockMetaSchema | undefined;
+  if (homeBlock.sourceId) {
+    const source = await dbRead.homeBlock.findUnique({
+      where: { id: homeBlock.sourceId },
+      select: { metadata: true },
+    });
+    sourceMetadata = (source?.metadata || undefined) as HomeBlockMetaSchema | undefined;
+  }
+
   switch (homeBlock.type) {
     case HomeBlockType.Collection: {
-      if (!metadata.collection || !metadata.collection.id) {
+      const collectionMeta = sourceMetadata?.collection ?? metadata.collection;
+      if (!collectionMeta || !collectionMeta.id) {
         return null;
       }
 
       const collection = await getCollectionById({
-        input: { id: metadata.collection.id },
+        input: { id: collectionMeta.id },
       });
 
       if (!collection) {
@@ -230,9 +243,9 @@ export const getHomeBlockData = async ({
             user,
             input: {
               collectionId: collection.id,
-              limit: input.limit || metadata.collection.limit,
+              limit: input.limit || collectionMeta.limit,
               browsingLevel: sfwBrowsingLevelsFlag,
-              collectionTagId: metadata.collection.tagId,
+              collectionTagId: collectionMeta.tagId,
             },
           });
 
@@ -247,11 +260,12 @@ export const getHomeBlockData = async ({
       };
     }
     case HomeBlockType.Leaderboard: {
-      if (!metadata.leaderboards) {
+      const leaderboards = sourceMetadata?.leaderboards ?? metadata.leaderboards;
+      if (!leaderboards) {
         return null;
       }
 
-      const leaderboardIds = metadata.leaderboards.map((leaderboard) => leaderboard.id);
+      const leaderboardIds = leaderboards.map((leaderboard) => leaderboard.id);
 
       const leaderboardsWithResults = await getLeaderboardsWithResults({
         ids: leaderboardIds,
@@ -262,26 +276,24 @@ export const getHomeBlockData = async ({
         ...homeBlock,
         metadata,
         leaderboards: leaderboardsWithResults.sort((a, b) => {
-          if (!metadata.leaderboards) {
-            return 0;
-          }
-
-          const aIndex = metadata.leaderboards.find((item) => item.id === a.id)?.index ?? 0;
-          const bIndex = metadata.leaderboards.find((item) => item.id === b.id)?.index ?? 0;
+          const aIndex = leaderboards.find((item) => item.id === a.id)?.index ?? 0;
+          const bIndex = leaderboards.find((item) => item.id === b.id)?.index ?? 0;
 
           return aIndex - bIndex;
         }),
       };
     }
     case HomeBlockType.CosmeticShop: {
-      if (!metadata.cosmeticShopSection) {
+      const cosmeticShopSectionMeta =
+        sourceMetadata?.cosmeticShopSection ?? metadata.cosmeticShopSection;
+      if (!cosmeticShopSectionMeta) {
         return null;
       }
 
       // No feature flags in this context — creator-listed items stay excluded
       // from homepage shop blocks until the creatorShop flag goes GA.
       const data = await getShopSectionsWithItems({
-        sectionId: metadata.cosmeticShopSection.id,
+        sectionId: cosmeticShopSectionMeta.id,
       });
 
       const [cosmeticShopSection] = data;
@@ -297,17 +309,7 @@ export const getHomeBlockData = async ({
       };
     }
     case HomeBlockType.FeaturedCollections: {
-      // System block is source of truth for pool; cloned user blocks read through to source
-      // so mods only update the singleton and clones stay in sync.
-      let effectivePool = metadata.featuredCollections;
-      if (homeBlock.sourceId) {
-        const source = await dbRead.homeBlock.findUnique({
-          where: { id: homeBlock.sourceId },
-          select: { metadata: true },
-        });
-        const sourceMeta = (source?.metadata || {}) as HomeBlockMetaSchema;
-        effectivePool = sourceMeta.featuredCollections ?? effectivePool;
-      }
+      const effectivePool = sourceMetadata?.featuredCollections ?? metadata.featuredCollections;
       if (!effectivePool?.collectionIds?.length) return null;
 
       const state = await getFeaturedCollectionsState();

--- a/src/server/services/home-block.service.ts
+++ b/src/server/services/home-block.service.ts
@@ -310,7 +310,9 @@ export const getHomeBlockData = async ({
 
       return {
         ...homeBlock,
-        metadata,
+        // Client slices by metadata.cosmeticShopSection.maxItems, so hand back the section we
+        // actually resolved rather than the clone's snapshot of a different section.
+        metadata: { ...metadata, cosmeticShopSection: cosmeticShopSectionMeta },
         cosmeticShopSection,
       };
     }


### PR DESCRIPTION
## Problem

`upsertHomeBlock` clones every non-permanent system home block (`userId -1`) into per-user rows the first time a user customizes their homepage, copying the system block's `metadata` and setting `sourceId`.

Editing a system block **through the app** already propagates to clones:

```js
dbWrite.homeBlock.updateMany({ where: { OR: [{ id }, { sourceId: id }] }, data: { metadata, index } })
```

So drift only appears when a system block's metadata is edited **out-of-band** (direct SQL / Retool) — which is exactly what the ecosystem-leaderboard playbook does. Prod today:

| Type | Clones | Stale |
|---|---:|---:|
| Leaderboard | 60,562 | **58,847** (clone has 25 or 26 leaderboards, source has 27) |
| CosmeticShop | 4 | **4** (clone section 16 / `maxItems` 4, source section 23 / `maxItems` 6) |
| Collection | 110,631 | **0** — every clone matches its source exactly |
| FeaturedCollections | 9,423 | already read through (shipped earlier) |

That's the reported Krea 2 / Anima bug: customized users were stuck on the pre-Anima leaderboard set.

## What changed

`getHomeBlockData` fetches the source block's metadata once when `homeBlock.sourceId` is set **and the type is one that actually drifts** — `Leaderboard`, `CosmeticShop`, `FeaturedCollections`. Each of those cases reads content selection through to the source, falling back to the clone's copy when the source is missing.

- **Leaderboard** — `metadata.leaderboards` now resolved from source; sort still uses the effective list's `index`.
- **CosmeticShop** — `metadata.cosmeticShopSection` resolved from source. The cache key for clones moves to the block id, because a section-id key would store source data under the clone's stale snapshot id and poison blocks genuinely on that section. Nothing busts `CosmeticShop` keys today and the TTL is 3 min, so no invalidation is orphaned.
- **FeaturedCollections** — refactored onto the shared up-front fetch; behavior unchanged.
- **`getHomeBlockCached`** no longer lets the clone's metadata snapshot clobber resolved metadata on the returned object. This is a no-op for every type except CosmeticShop (all other cases return the metadata they were handed) and matters because `CosmeticShopSectionHomeBlock` slices client-side by `metadata.cosmeticShopSection.maxItems`.

## Deliberately **not** changed

**Collection.** An earlier revision of this PR read Collection through to source and keyed clone cache entries per block. Both were dropped:

- There is no drift to fix — all 110,631 clones match source.
- Collection clones currently share **2** cache entries (keyed by collection id, 3 min TTL). Per-block keys would split that into up to 110,631 entries, so every active customized user would rebuild `getCollectionItemsByCollectionId(limit 56)` for their own copy of Featured Images instead of once site-wide.
- `homeBlockCacheBust(Collection, collectionId)` (fired from `collection.service.ts` whenever collection items change) only reaches `packed:home-blocks:Collection:<collectionId>`. Per-block keys would silently orphan 71k users' blocks from that invalidation.

**Announcement / Social / Event.** These render purely from `metadata` client-side and have no structured content-selection sub-field to isolate, so a read-through would be a partial fix at best. Known limitation, unchanged.

## Cost

- One extra `findUnique` (PK lookup) per cache miss for the three read-through types. Worst case ~60k over an hour as the Leaderboard cache re-warms.
- No migration. No backfill required — read-through makes the divergent rows inert. A one-time sync of clone `metadata.leaderboards` from source is optional cleanup, not a prerequisite.
- **Cache purge on deploy:** `packed:home-blocks:Leaderboard:*` (1 h TTL, keyed per clone) so the 58,847 stale blocks pick up the read-through immediately instead of over the next hour. CosmeticShop self-heals in 3 min.

## Validation

- `pnpm run typecheck` — clean.
- `pnpm exec prettier --check` on both changed files — clean.
- Prod data for every claim above measured directly against the replica.
- Adversarially reviewed (two independent passes). One real finding — the CosmeticShop `maxItems` seam — fixed in `5e357c2`.
