### PR TITLE
fix(moderation): don't cancel membership on scam auto-mute before mod…

### DIFF
--- a/src/server/jobs/confirm-mutes.ts
+++ b/src/server/jobs/confirm-mutes.ts
@@ -5,9 +5,11 @@ import { createJob, getJobDate } from './job';
 import { cancelSubscriptionPlan } from '~/server/services/paddle.service';
 
 export const confirmMutes = createJob('confirm-mutes', '0 1 * * *', async () => {
-  // Get all recently confirmed mutes. `mutedAt` is only set on moderator
-  // confirmation (uphold/retool/scam auto-mute), so a non-null recent value
-  // signifies a confirmed mute. Pending auto-mutes leave it null.
+  // Get all recently confirmed mutes. `mutedAt` is only set on a moderator
+  // decision (restriction uphold, retool mute, or the mod mute toggle), so a
+  // non-null recent value signifies a confirmed mute. Automatic mutes (prompt
+  // auditing, strike escalation, scam auto-mute) leave it null and are only
+  // cancelled once a moderator upholds them.
   const [lastRan, setLastRan] = await getJobDate('confirm-mutes');
   const confirmedMutes = await dbWrite.$queryRaw<{ id: number }[]>`
     SELECT id

--- a/src/server/jobs/entity-moderation.ts
+++ b/src/server/jobs/entity-moderation.ts
@@ -93,10 +93,12 @@ async function autoMuteIfScamAccount({
       return;
     }
 
-    const date = new Date();
+    // Gate the user via `muted` only. `mutedAt` is reserved for moderator
+    // confirmation (uphold) — setting it here would trip the confirm-mutes cron
+    // and cancel the membership before any moderator reviews the auto-mute.
     await updateUserById({
       id: userId,
-      data: { muted: true, mutedAt: date },
+      data: { muted: true },
       updateSource: 'entity-moderation:auto-mute-scam',
     });
     await invalidateSession(userId);


### PR DESCRIPTION
… review

Scam auto-mute (entity-moderation) was setting `mutedAt` alongside `muted`. `mutedAt` signals a *moderator-confirmed* mute, which the confirm-mutes cron uses to cancel the user's subscription — so an automatic mute was cancelling memberships before any moderator reviewed it. Set only `muted: true` for the auto-mute path and reserve `mutedAt` for moderator confirmation.