### PR TITLE
feat(model-version): add early-access config REST endpoint for creator studio

### DIFF
--- a/src/pages/api/v1/model-versions/early-access.ts
+++ b/src/pages/api/v1/model-versions/early-access.ts
@@ -1,0 +1,76 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { updateEarlyAccessConfigSchema } from '~/server/schema/model-version.schema';
+import {
+  getUserEarlyAccessModelVersions,
+  getVersionById,
+  updateModelVersionEarlyAccessConfig,
+} from '~/server/services/model-version.service';
+import { getModel, updateModelEarlyAccessDeadline } from '~/server/services/model.service';
+import { getFeatureFlags } from '~/server/services/feature-flags.service';
+import { getMaxEarlyAccessDays, getMaxEarlyAccessModels } from '~/server/utils/early-access-helpers';
+import { AuthedEndpoint } from '~/server/utils/endpoint-helpers';
+import type { SessionUser } from '~/types/session';
+
+// Narrow cross-app write for a model version's early-access config — the creator
+// studio (SvelteKit spoke) calls this server-to-server, forwarding the shared
+// .civitai.com session cookie that AuthedEndpoint validates. Body: the
+// updateEarlyAccessConfigSchema shape ({ id, earlyAccessConfig }); a null config
+// clears early access. Version-level rules + config merge live in the service;
+// user-level limits (max days / max concurrent EA models) are enforced here.
+export default AuthedEndpoint(
+  async function handler(req: NextApiRequest, res: NextApiResponse, user: SessionUser) {
+    const parsed = updateEarlyAccessConfigSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res
+        .status(400)
+        .json({ error: 'Invalid request body', details: parsed.error.flatten() });
+    }
+    const input = parsed.data;
+
+    const version = await getVersionById({ id: input.id, select: { modelId: true } });
+    if (!version) return res.status(404).json({ error: 'Model version not found' });
+
+    if (!user.isModerator) {
+      const model = await getModel({ id: version.modelId, select: { userId: true } });
+      if (model?.userId !== user.id) {
+        return res.status(403).json({ error: 'You do not own this model version' });
+      }
+    }
+
+    const { earlyAccessConfig } = input;
+    if (earlyAccessConfig?.timeframe && !user.isModerator) {
+      const features = getFeatureFlags({ user, req });
+      const maxDays = getMaxEarlyAccessDays({ userMeta: user.meta, features });
+      if (earlyAccessConfig.timeframe > maxDays) {
+        return res.status(400).json({ error: 'Early access days exceeds user limit' });
+      }
+
+      const activeEarlyAccess = await getUserEarlyAccessModelVersions({ userId: user.id });
+      if (
+        activeEarlyAccess.length >= getMaxEarlyAccessModels({ userMeta: user.meta, features }) &&
+        !activeEarlyAccess.some((v) => v.id === input.id)
+      ) {
+        return res.status(400).json({
+          error: 'You have exceeded the maximum number of early access models you can have.',
+        });
+      }
+    }
+
+    try {
+      const updated = await updateModelVersionEarlyAccessConfig(input);
+
+      await updateModelEarlyAccessDeadline({ id: updated.modelId }).catch((e) => {
+        console.error('Unable to update model early access deadline', e);
+      });
+
+      return res
+        .status(200)
+        .json({ success: true, modelVersionId: updated.id, modelId: updated.modelId });
+    } catch (error) {
+      const err = error as { code?: string; message?: string };
+      const status = err?.code === 'BAD_REQUEST' ? 400 : 500;
+      return res.status(status).json({ error: err?.message ?? 'Failed to update early access' });
+    }
+  },
+  ['POST']
+);

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -380,6 +380,15 @@ export const earlyAccessConfigInput = modelVersionEarlyAccessConfigSchema;
 //   buzzTransactionId: true,
 // });
 
+// Narrow input for editing only a version's early-access config (e.g. from the
+// creator studio) without round-tripping the whole version. `id` is named for
+// the `isOwnerOrModerator` middleware; a null config clears early access.
+export type UpdateEarlyAccessConfigInput = z.infer<typeof updateEarlyAccessConfigSchema>;
+export const updateEarlyAccessConfigSchema = z.object({
+  id: z.number(),
+  earlyAccessConfig: earlyAccessConfigInput.nullish(),
+});
+
 export const modelVersionUpsertSchema2 = z.object({
   modelId: z.number(),
   id: z.number().optional(),

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -61,6 +61,7 @@ import type {
   LinkedComponentSettings,
   LinkOfficialFileByHashInput,
   SetLinkedComponentsInput,
+  UpdateEarlyAccessConfigInput,
   UpsertExplorationPromptInput,
 } from '~/server/schema/model-version.schema';
 import type { ModelMeta, UnpublishModelSchema } from '~/server/schema/model.schema';
@@ -99,6 +100,7 @@ import {
   LicensingFeeSettlementCurrency,
   LicensingFeeType,
   ModelStatus,
+  ModelUsageControl,
 } from '~/shared/utils/prisma/enums';
 import { isDefined } from '~/utils/type-guards';
 import { ingestModelById, updateModelLastVersionAt } from './model.service';
@@ -305,6 +307,69 @@ export const getLicensingRoots = async ({ baseModel }: { baseModel: string }) =>
   `;
 };
 
+// Field-level early-access requirements (status-independent): a timeframe needs
+// a charge, and each enabled charge needs a price.
+function assertEarlyAccessChargeConfig(
+  config: ModelVersionEarlyAccessConfig | null | undefined
+) {
+  if (config?.timeframe && !config.chargeForDownload && !config.chargeForGeneration) {
+    throw throwBadRequestError(
+      'You must charge for downloads or generations if you set an early access time frame.'
+    );
+  }
+  if (config?.chargeForDownload && !config.downloadPrice) {
+    throw throwBadRequestError('You must provide a download price when charging for downloads.');
+  }
+  if (config?.chargeForGeneration && !config.generationPrice) {
+    throw throwBadRequestError('You must provide a generation price when charging for generations.');
+  }
+}
+
+// Post-publish guards + merge. Once published a creator can only loosen terms
+// (can't add EA, raise price/timeframe, or change donation goals), and the merge
+// preserves hidden fields the UI never sends back (e.g. buzzTransactionId).
+function mergeEarlyAccessConfigUpdate({
+  existingConfig,
+  updatedConfig,
+  status,
+}: {
+  existingConfig: ModelVersionEarlyAccessConfig | null;
+  updatedConfig: ModelVersionEarlyAccessConfig | null | undefined;
+  status: ModelStatus;
+}): ModelVersionEarlyAccessConfig | null | undefined {
+  if (status === ModelStatus.Published && !!updatedConfig && !existingConfig) {
+    throw throwBadRequestError('You cannot add early access on a model after it has been published.');
+  }
+
+  if (status === ModelStatus.Published && updatedConfig && existingConfig) {
+    if (
+      updatedConfig.chargeForDownload &&
+      (updatedConfig.downloadPrice as number) > (existingConfig.downloadPrice as number)
+    ) {
+      throw throwBadRequestError(
+        'You cannot increase the download price on a model after it has been published.'
+      );
+    }
+
+    if (updatedConfig.timeframe > existingConfig.timeframe) {
+      throw throwBadRequestError(
+        'You cannot increase the early access time frame for a published early access model version.'
+      );
+    }
+
+    if (
+      updatedConfig.donationGoalEnabled !== existingConfig.donationGoalEnabled ||
+      updatedConfig.donationGoal !== existingConfig.donationGoal
+    ) {
+      throw throwBadRequestError(
+        'You cannot update donation goals on a published early access model version.'
+      );
+    }
+  }
+
+  return updatedConfig ? { ...existingConfig, ...updatedConfig } : updatedConfig;
+}
+
 export const upsertModelVersion = async ({
   id,
   monetization,
@@ -375,25 +440,7 @@ export const upsertModelVersion = async ({
     );
   }
 
-  if (
-    updatedEarlyAccessConfig?.timeframe &&
-    !updatedEarlyAccessConfig?.chargeForDownload &&
-    !updatedEarlyAccessConfig?.chargeForGeneration
-  ) {
-    throw throwBadRequestError(
-      'You must charge for downloads or generations if you set an early access time frame.'
-    );
-  }
-
-  if (updatedEarlyAccessConfig?.chargeForDownload && !updatedEarlyAccessConfig.downloadPrice) {
-    throw throwBadRequestError('You must provide a download price when charging for downloads.');
-  }
-
-  if (updatedEarlyAccessConfig?.chargeForGeneration && !updatedEarlyAccessConfig.generationPrice) {
-    throw throwBadRequestError(
-      'You must provide a generation price when charging for generations.'
-    );
-  }
+  assertEarlyAccessChargeConfig(updatedEarlyAccessConfig);
 
   if (!id || templateId) {
     const existingVersions = await dbWrite.modelVersion.findMany({
@@ -511,53 +558,11 @@ export const upsertModelVersion = async ({
         ? (existingVersion.earlyAccessConfig as unknown as ModelVersionEarlyAccessConfig)
         : null;
 
-    if (
-      existingVersion.status === ModelStatus.Published &&
-      !!updatedEarlyAccessConfig &&
-      !earlyAccessConfig
-    ) {
-      throw throwBadRequestError(
-        'You cannot add early access on a model after it has been published.'
-      );
-    }
-
-    if (
-      existingVersion.status === ModelStatus.Published &&
-      updatedEarlyAccessConfig &&
-      earlyAccessConfig
-    ) {
-      // Check all changes related now:
-
-      if (
-        updatedEarlyAccessConfig.chargeForDownload &&
-        (updatedEarlyAccessConfig.downloadPrice as number) >
-          (earlyAccessConfig.downloadPrice as number)
-      ) {
-        throw throwBadRequestError(
-          'You cannot increase the download price on a model after it has been published.'
-        );
-      }
-
-      if (updatedEarlyAccessConfig.timeframe > earlyAccessConfig?.timeframe) {
-        throw throwBadRequestError(
-          'You cannot increase the early access time frame for a published early access model version.'
-        );
-      }
-
-      if (
-        updatedEarlyAccessConfig.donationGoalEnabled !== earlyAccessConfig.donationGoalEnabled ||
-        updatedEarlyAccessConfig.donationGoal !== earlyAccessConfig.donationGoal
-      ) {
-        throw throwBadRequestError(
-          'You cannot update donation goals on a published early access model version.'
-        );
-      }
-    }
-
-    updatedEarlyAccessConfig = updatedEarlyAccessConfig
-      ? // Ensures we keep relevant data such as buzzTransactionId even if the user changes something.
-        { ...earlyAccessConfig, ...updatedEarlyAccessConfig }
-      : updatedEarlyAccessConfig;
+    updatedEarlyAccessConfig = mergeEarlyAccessConfigUpdate({
+      existingConfig: earlyAccessConfig,
+      updatedConfig: updatedEarlyAccessConfig,
+      status: existingVersion.status,
+    });
 
     // Check if trying to publish a model version when model is marked as cannotPublish
     const existingModelMeta = existingVersion.model.meta as ModelMeta | null;
@@ -666,6 +671,74 @@ export const upsertModelVersion = async ({
 
     return version;
   }
+};
+
+// Narrow write for just the early-access config — the studio (and any caller
+// that only wants to edit monetization) doesn't have to round-trip the whole
+// version payload through `upsertModelVersion`. Shares the same guards + merge.
+export const updateModelVersionEarlyAccessConfig = async ({
+  id,
+  earlyAccessConfig: updatedEarlyAccessConfig,
+}: UpdateEarlyAccessConfigInput) => {
+  const existingVersion = await dbWrite.modelVersion.findUniqueOrThrow({
+    where: { id },
+    select: {
+      id: true,
+      status: true,
+      baseModel: true,
+      usageControl: true,
+      earlyAccessConfig: true,
+      modelId: true,
+    },
+  });
+
+  if (isNonCommercialBaseModel(existingVersion.baseModel) && !!updatedEarlyAccessConfig) {
+    throw throwBadRequestError(
+      `The base model "${existingVersion.baseModel}" is licensed for non-commercial use and cannot be monetized.`
+    );
+  }
+
+  if (
+    existingVersion.usageControl !== ModelUsageControl.Download &&
+    updatedEarlyAccessConfig?.chargeForDownload
+  ) {
+    throw throwBadRequestError(
+      'Cannot charge for download if downloads are disabled for this model version'
+    );
+  }
+
+  assertEarlyAccessChargeConfig(updatedEarlyAccessConfig);
+
+  const existingConfig =
+    existingVersion.earlyAccessConfig !== null
+      ? (existingVersion.earlyAccessConfig as unknown as ModelVersionEarlyAccessConfig)
+      : null;
+
+  const mergedConfig = mergeEarlyAccessConfigUpdate({
+    existingConfig,
+    updatedConfig: updatedEarlyAccessConfig,
+    status: existingVersion.status,
+  });
+
+  const version = await dbWrite.modelVersion.update({
+    where: { id },
+    data: {
+      earlyAccessConfig: mergedConfig !== null ? mergedConfig : Prisma.JsonNull,
+    },
+    select: { id: true, modelId: true, earlyAccessConfig: true },
+  });
+
+  await Promise.all([
+    preventModelVersionLag(version.modelId, version.id),
+    bustMvCache(version.id, version.modelId),
+    dataForModelsCache.refresh(version.modelId),
+  ]);
+
+  ingestModelById({ id: version.modelId }).catch((error) =>
+    logToAxiom({ type: 'error', name: 'model-ingestion', error, modelId: version.modelId })
+  );
+
+  return version;
 };
 
 export const deleteVersionById = async ({


### PR DESCRIPTION
Adds POST /api/v1/model-versions/early-access — a narrow, session-authed write for a version's earlyAccessConfig so the creator-studio spoke can edit early access without round-tripping the full upsert payload. The spoke calls it server-to-server, forwarding the shared .civitai.com session cookie.

- New service updateModelVersionEarlyAccessConfig; extracts the EA validation + merge (post-publish guards, price/timeframe rules, buzzTransactionId-preserving merge) into shared helpers now also used by upsertModelVersion (single source of truth).
- Route enforces ownership + per-user EA limits (max days, max concurrent) and the updateModelEarlyAccessDeadline side effect; version-level guards live in the service.