### PR TITLE
fix(new-order): map transient ClickHouse errors to 503 in counters

### DIFF
--- a/src/server/games/new-order/__tests__/counter-clickhouse-transient-503.test.ts
+++ b/src/server/games/new-order/__tests__/counter-clickhouse-transient-503.test.ts
@@ -1,0 +1,111 @@
+import { TRPCError } from '@trpc/server';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression: /api/trpc/games.newOrder.addRating returned a 500 (~10/12h) on a
+// TRANSIENT ClickHouse connection blip. On a Redis cache miss, createCounter's
+// getCount/getCountBatch call fetchCount → clickhouse.$query, which the
+// @civitai/clickhouse client flattens to `Error('ClickHouse query failed: socket
+// hang up')`. That un-try-caught throw bubbled through addImageRating →
+// processImageRating and tRPC wrapped the non-TRPCError as INTERNAL_SERVER_ERROR
+// (500). A transient dependency outage should be a retryable SERVICE_UNAVAILABLE
+// (503), not a 500. A REAL query/schema fault (non-connection CH error) must
+// still surface raw.
+
+const { mockSysRedis, mockClickhouse } = vi.hoisted(() => ({
+  mockSysRedis: {
+    // Cache miss on every read → forces the fetchCount path.
+    zScore: vi.fn().mockResolvedValue(null),
+    zAdd: vi.fn().mockResolvedValue(1),
+    zRangeWithScores: vi.fn(),
+    zRem: vi.fn().mockResolvedValue(1),
+    hDel: vi.fn().mockResolvedValue(1),
+    del: vi.fn().mockResolvedValue(1),
+  },
+  // $query is a tagged template on the client; the counter's fetchCount awaits it.
+  mockClickhouse: { $query: vi.fn() },
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  redis: {},
+  sysRedis: mockSysRedis,
+  REDIS_KEYS: {},
+  REDIS_SYS_KEYS: {
+    NEW_ORDER: {
+      FERVOR: 'new-order:fervor',
+      SANITY_CHECKS: { FAILURES: 'new-order:sanity-check-failures' },
+      JUDGEMENTS: { ACOLYTE_FAILED: 'new-order:acolyte-failed' },
+      EXP: 'new-order:exp',
+      BUZZ: 'new-order:blessed-buzz',
+      PENDING_BUZZ: 'new-order:pending-buzz',
+      RECENTLY_GRANTED_BUZZ: 'new-order:recently-granted-buzz',
+      SMITE: 'new-order:smite-progress',
+      QUEUES: 'new-order:queues',
+      RATINGS: 'new-order:ratings',
+    },
+  },
+}));
+
+vi.mock('~/server/redis/atomic', () => ({ hSetWithTTL: vi.fn(), zAddWithTTL: vi.fn() }));
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: mockClickhouse }));
+vi.mock('~/server/db/client', () => ({ dbRead: {} }));
+
+// NOTE: errorHandling is intentionally NOT mocked — we exercise the REAL
+// isClickHouseConnectionError (message-shape match) + throwServiceUnavailableError
+// (the 503 mapping) end to end.
+
+import { getImageRatingsCounter } from '~/server/games/new-order/utils';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSysRedis.zScore.mockResolvedValue(null); // re-arm cache miss after clearAllMocks
+});
+
+describe('createCounter — transient ClickHouse error → 503 (SERVICE_UNAVAILABLE)', () => {
+  it('getCount: `socket hang up` in fetchCount maps to a TRPCError SERVICE_UNAVAILABLE', async () => {
+    mockClickhouse.$query.mockRejectedValue(
+      new Error('ClickHouse query failed: socket hang up')
+    );
+
+    const counter = getImageRatingsCounter(123);
+    await expect(counter.getCount('Knight-3')).rejects.toSatisfy(
+      (e: unknown) => e instanceof TRPCError && e.code === 'SERVICE_UNAVAILABLE'
+    );
+  });
+
+  it('getCountBatch: `socket hang up` in fetchCount maps to a TRPCError SERVICE_UNAVAILABLE', async () => {
+    mockClickhouse.$query.mockRejectedValue(
+      new Error('ClickHouse query failed: socket hang up')
+    );
+
+    const counter = getImageRatingsCounter(123);
+    await expect(counter.getCountBatch(['Knight-3', 'Templar-2'])).rejects.toSatisfy(
+      (e: unknown) => e instanceof TRPCError && e.code === 'SERVICE_UNAVAILABLE'
+    );
+  });
+
+  it('preserves the original error as the TRPCError cause for diagnosability', async () => {
+    const original = new Error('ClickHouse query failed: socket hang up');
+    mockClickhouse.$query.mockRejectedValue(original);
+
+    const counter = getImageRatingsCounter(123);
+    const err = await counter.getCount('Knight-3').catch((e) => e);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).cause).toBe(original);
+  });
+
+  it('does NOT convert a real (non-connection) CH error — a syntax fault surfaces raw', async () => {
+    // Code: 62 = syntax error — a genuine query/schema bug, NOT a transient blip.
+    mockClickhouse.$query.mockRejectedValue(
+      new Error('ClickHouse query failed: Code: 62. DB::Exception: Syntax error')
+    );
+
+    const counter = getImageRatingsCounter(123);
+    const err = await counter.getCount('Knight-3').catch((e) => e);
+    // Not a 503 — must NOT be masked as SERVICE_UNAVAILABLE.
+    expect(
+      err instanceof TRPCError && (err as TRPCError).code === 'SERVICE_UNAVAILABLE'
+    ).toBe(false);
+    expect((err as Error).message).toContain('Code: 62');
+  });
+});

--- a/src/server/games/new-order/utils.ts
+++ b/src/server/games/new-order/utils.ts
@@ -8,7 +8,11 @@ import { decodeRedisString } from '~/server/redis/buffer-decode';
 import { hSetWithTTL, zAddWithTTL } from '~/server/redis/atomic';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import { logToAxiom } from '~/server/logging/client';
-import { handleLogError } from '~/server/utils/errorHandling';
+import {
+  handleLogError,
+  isClickHouseConnectionError,
+  throwServiceUnavailableError,
+} from '~/server/utils/errorHandling';
 import { NewOrderRankType } from '~/shared/utils/prisma/enums';
 
 type NewOrderRedisKeyString = Values<typeof REDIS_SYS_KEYS.NEW_ORDER>;
@@ -130,8 +134,20 @@ function createCounter<TId extends number | string = number | string>({
       return Number(countStr);
     }
 
-    // Cache miss - fetch and populate
-    const fetched = await fetchCount([id]);
+    // Cache miss - fetch and populate. A transient ClickHouse connection blip in
+    // fetchCount (e.g. `socket hang up`) is a retryable dependency outage, not a
+    // 500 — map it to a 503 so the client backs off + retries instead of the whole
+    // New Order rating mutation failing. A real query/schema fault (non-connection
+    // CH error) still surfaces raw. Covers every counter routed through
+    // createCounter (image-ratings + all player-stat counters).
+    let fetched: Map<TId, number>;
+    try {
+      fetched = await fetchCount([id]);
+    } catch (e) {
+      if (isClickHouseConnectionError(e))
+        throwServiceUnavailableError('New Order is temporarily busy, please retry.', e);
+      throw e;
+    }
     const count = fetched.get(id) ?? 0;
     await setCacheValue(id, count);
     return count;
@@ -182,9 +198,18 @@ function createCounter<TId extends number | string = number | string>({
       }
     }
 
-    // Fetch all cache misses in one call
+    // Fetch all cache misses in one call. Same transient-CH → 503 mapping as
+    // getCount (see note there): a `socket hang up` / connection brownout is
+    // retryable, a real query fault still surfaces raw.
     if (cacheMisses.length > 0) {
-      const fetchedCounts = await fetchCount(cacheMisses);
+      let fetchedCounts: Map<TId, number>;
+      try {
+        fetchedCounts = await fetchCount(cacheMisses);
+      } catch (e) {
+        if (isClickHouseConnectionError(e))
+          throwServiceUnavailableError('New Order is temporarily busy, please retry.', e);
+        throw e;
+      }
 
       // Populate cache and result
       const cachePromises: Promise<void>[] = [];


### PR DESCRIPTION
## Root cause

`/api/trpc/games.newOrder.addRating` returns a **500** (~10 per 12h in Axiom) on a **transient ClickHouse connection blip**:

```
TRPCError: ClickHouse query failed: socket hang up
```

on the `getImageRatingsCounter` `fetchCount` SELECT (`argMax(rank,createdAt) … FROM knights_new_order_image_rating WHERE imageId=… GROUP BY imageId,userId`, `utils.ts:766-774`).

**Throw path (un-try-caught on the mutation happy-path):**
`games.router addRating` → `addImageRating()` → `processImageRating()` → `getImageRatingsCounter(imageId).increment(...)` → `createCounter.increment` → `getCount` → on a Redis **cache miss**, `fetchCount([id])` runs the CH `$query` with **no try/catch** → `@civitai/clickhouse` flattens the socket error to `Error('ClickHouse query failed: socket hang up')` → tRPC wraps the non-`TRPCError` as `INTERNAL_SERVER_ERROR` → **500**. The batch variant `getCountBatch` shares the exposure, and all 6 player-stat counters route through the same `createCounter`.

This is a **transient dependency outage**, not a query/schema fault → it should be a **retryable 503**, not a 500.

## Fix

Wrap the two `fetchCount` call-sites **inside** `createCounter` — `getCount` and `getCountBatch` — with the transient-CH helpers already used elsewhere (`base.reward.ts`, `image.service.ts`, orchestrator), mirroring the merged templates #2972 / #2978 / #3049:

```ts
catch (e) {
  if (isClickHouseConnectionError(e))
    throwServiceUnavailableError('New Order is temporarily busy, please retry.', e);
  throw e;
}
```

- Maps transient CH → `SERVICE_UNAVAILABLE` (HTTP **503**, `cause` preserved) uniformly for **every** New Order counter (image-ratings + all player-stat counters) in **one place** — only the cache-**miss** `fetchCount` path is touched; the cache-hit happy path and the Redis increment logic are unchanged.
- A **real** query/schema fault (non-connection CH error, e.g. `Code: 62` syntax) still `throw e` → surfaces raw as a 500. `isClickHouseConnectionError` is transient-only (matches `socket hang up`, CH `Code 279/210/209/202`, transport syscalls) — verified it matches the exact `socket hang up` message shape thrown here (`errorHandling.ts:391`).
- No server-side retry loop: the tRPC handler (`pages/api/trpc/[trpc].ts`) already treats `SERVICE_UNAVAILABLE` as a first-class transient 503 (returns it, counts it in `civitai_app_http_errors_total{status="503"}`, skips the Axiom stack-capture) — the client retries, nothing loops server-side.

## Tests

New `counter-clickhouse-transient-503.test.ts` (exercises the **real** `isClickHouseConnectionError` + `throwServiceUnavailableError` end to end, mocks `$query` to throw):
- `getCount` / `getCountBatch` with `socket hang up` → `TRPCError` code `SERVICE_UNAVAILABLE` (**fails before / passes after** the fix — verified: 3 fail unfixed → 4 pass fixed).
- `cause` preserved on the `TRPCError`.
- A `Code: 62` syntax error → still surfaces raw (**not** masked as 503).

Full new-order unit suite: **54 pass / 8 files**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)