### PR TITLE
fix(upload): classify S3 NoSuchUpload→409 / transient→503 instead of raw 500

### DIFF
--- a/src/pages/api/upload/abort.ts
+++ b/src/pages/api/upload/abort.ts
@@ -1,7 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
-import { abortMultipartUpload, getUploadS3Client, getB2ImageS3Client } from '~/utils/s3-utils';
+import {
+  abortMultipartUpload,
+  classifyS3MultipartError,
+  getUploadS3Client,
+  getB2ImageS3Client,
+} from '~/utils/s3-utils';
 import { logToAxiom } from '~/server/logging/client';
 
 const upload = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -38,6 +43,27 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
       backend,
       error: error.message,
     });
+
+    // Classify the S3 error so a client/state fault or a transient storage blip is
+    // NOT mis-reported as a raw 500 (which the client then retries → amplification).
+    const errorClass = classifyS3MultipartError(e);
+    if (errorClass === 'not-found') {
+      // Aborting an upload that is already gone (completed/aborted) is IDEMPOTENT:
+      // the desired end-state — the upload no longer exists — already holds, so this
+      // is a success, not a conflict. 204 stops the client retry loop cleanly. (The
+      // sole caller, s3-upload.store.ts, fire-and-forgets abort and ignores the
+      // response, so 204 is safe and terminal.)
+      res.status(204).end();
+      return;
+    }
+    if (errorClass === 'transient') {
+      // Retry-able storage-backend blip (S3/B2 5xx, throttle/timing, or network).
+      res.setHeader('Retry-After', '2');
+      res.setHeader('Cache-Control', 'no-store');
+      res.status(503).json({ error: 'Storage temporarily unavailable, please retry' });
+      return;
+    }
+    // Real server fault → surface loud as a 500.
     res.status(500).json({ error });
   }
 };

--- a/src/pages/api/upload/complete.ts
+++ b/src/pages/api/upload/complete.ts
@@ -1,7 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { instrumentApiResponse } from '~/server/prom/http-errors';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
-import { completeMultipartUpload, getUploadS3Client, getB2ImageS3Client } from '~/utils/s3-utils';
+import {
+  classifyS3MultipartError,
+  completeMultipartUpload,
+  getUploadS3Client,
+  getB2ImageS3Client,
+} from '~/utils/s3-utils';
 import { logToAxiom } from '~/server/logging/client';
 
 const upload = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -39,6 +44,25 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
       backend,
       error: error.message,
     });
+
+    // Classify the S3 error so a client/state fault or a transient storage blip is
+    // NOT mis-reported as a raw 500 (which the client then retries → amplification).
+    const errorClass = classifyS3MultipartError(e);
+    if (errorClass === 'not-found') {
+      // The multipart upload is already finalized or aborted (double-submit /
+      // retry-after-success). 409 Conflict = terminal state → tells the client to
+      // STOP retrying; there is no Location to return so we can't fake a 200.
+      res.status(409).json({ error: 'Upload already finalized or aborted' });
+      return;
+    }
+    if (errorClass === 'transient') {
+      // Retry-able storage-backend blip (S3/B2 5xx, throttle/timing, or network).
+      res.setHeader('Retry-After', '2');
+      res.setHeader('Cache-Control', 'no-store');
+      res.status(503).json({ error: 'Storage temporarily unavailable, please retry' });
+      return;
+    }
+    // Real server fault → surface loud as a 500 so the upload legitimately fails.
     res.status(500).json({ error });
   }
 };

--- a/src/server/__tests__/upload-abort-endpoint.test.ts
+++ b/src/server/__tests__/upload-abort-endpoint.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+// Setup-order import: installs the shared ~/env/server / logging / prom mocks
+// before the handler evaluates env at module load.
+import '~/__tests__/setup';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * /api/upload/abort — S3 error classification (prod raw-500 landmine).
+ *
+ * Same landmine class as /api/upload/complete (~5 raw-500s/12h): the catch block
+ * `res.status(500)`'d every thrown S3 error, including the AWS-SDK `NoSuchUpload`
+ * (HTTP 404) for an upload that was already gone (completed/aborted).
+ *
+ * 409-vs-204 decision for abort: aborting an already-gone upload is IDEMPOTENT — the
+ * desired end-state (the upload no longer exists) ALREADY holds, so it's a success,
+ * not a conflict. We return 204 (the sole caller, s3-upload.store.ts, fire-and-forgets
+ * abort and ignores the response, so 204 is safe and terminal). Transient/real-fault
+ * mapping matches complete (503 / 500).
+ *
+ * Fails before the fix (everything is a raw 500); passes after.
+ */
+
+const { mockAbortMultipartUpload } = vi.hoisted(() => ({
+  mockAbortMultipartUpload: vi.fn(),
+}));
+
+vi.mock('~/utils/s3-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/utils/s3-utils')>();
+  return {
+    ...actual,
+    abortMultipartUpload: mockAbortMultipartUpload,
+    getUploadS3Client: vi.fn(() => ({})),
+    getB2ImageS3Client: vi.fn(() => ({})),
+  };
+});
+
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: vi.fn(async () => ({ user: { id: 42, bannedAt: null } })),
+}));
+
+// The real s3-utils imports ~/server/db/client (dbWrite); stub it so loading the
+// real module for `classifyS3MultipartError` doesn't spin up a real Prisma engine.
+vi.mock('~/server/db/client', () => ({ dbWrite: {}, dbRead: {} }));
+
+import handler from '~/pages/api/upload/abort';
+
+function makeRes() {
+  const headers: Record<string, string> = {};
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    ended: false,
+    headers,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    },
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+      return this;
+    },
+    removeHeader() {
+      return this;
+    },
+    getHeader(name: string) {
+      return headers[name];
+    },
+    once() {
+      return this;
+    },
+    on() {
+      return this;
+    },
+  };
+  return res as unknown as NextApiResponse & {
+    statusCode: number;
+    body: unknown;
+    ended: boolean;
+    headers: Record<string, string>;
+  };
+}
+
+function makeReq() {
+  return {
+    method: 'POST',
+    body: {
+      bucket: 'civitai-modelfiles',
+      key: 'some/key.safetensors',
+      type: 'model',
+      uploadId: 'test-upload-id',
+      backend: 'b2',
+    },
+    headers: {},
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as NextApiRequest;
+}
+
+const s3Error = (props: Record<string, unknown>) =>
+  Object.assign(new Error((props.message as string) ?? 'error'), props);
+
+beforeEach(() => {
+  mockAbortMultipartUpload.mockReset();
+});
+
+describe('/api/upload/abort — error classification', () => {
+  it('happy path: abortMultipartUpload resolves → 200', async () => {
+    mockAbortMultipartUpload.mockResolvedValue(undefined);
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('NoSuchUpload (already gone) → 204 idempotent success, not 500', async () => {
+    mockAbortMultipartUpload.mockRejectedValue(
+      s3Error({
+        name: 'NoSuchUpload',
+        message:
+          'The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.',
+        $metadata: { httpStatusCode: 404 },
+      })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(204);
+    expect(res.ended).toBe(true);
+  });
+
+  it('transient S3 500 → 503 + Retry-After header, not 500', async () => {
+    mockAbortMultipartUpload.mockRejectedValue(
+      s3Error({ name: 'InternalError', $metadata: { httpStatusCode: 500 } })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['Retry-After']).toBe('2');
+    expect(res.headers['Cache-Control']).toBe('no-store');
+  });
+
+  it('status-less network failure (ETIMEDOUT) → 503', async () => {
+    mockAbortMultipartUpload.mockRejectedValue(
+      s3Error({ code: 'ETIMEDOUT', message: 'connection timed out' })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(503);
+  });
+
+  it('a genuine server fault (unknown error) STILL surfaces as 500', async () => {
+    mockAbortMultipartUpload.mockRejectedValue(s3Error({ message: 'unexpected boom' }));
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/src/server/__tests__/upload-complete-endpoint.test.ts
+++ b/src/server/__tests__/upload-complete-endpoint.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+// Setup-order import: installs the shared ~/env/server / logging / prom mocks
+// before the handler evaluates env at module load.
+import '~/__tests__/setup';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * /api/upload/complete — S3 error classification (prod raw-500 landmine).
+ *
+ * The handler's catch block used to `res.status(500).json({ error })` for EVERY
+ * thrown S3 error. On dp-prod this surfaced ~22 raw-500s/12h whose message was the
+ * AWS-SDK `NoSuchUpload` (HTTP 404): "The specified upload does not exist. …" — a
+ * client/STATE fault (the multipart upload was already completed or aborted, i.e. a
+ * double-submit / retry-after-success). Because every retry re-500'd, the same
+ * `key`+`uploadId` repeated across pods → amplification.
+ *
+ * These drive the REAL handler through the REAL `classifyS3MultipartError` (only the
+ * s3 send + client getters + auth are stubbed), asserting the response STATUS the
+ * client sees:
+ *   - NoSuchUpload / 404      → 409 Conflict  (terminal → client stops retrying)
+ *   - transient S3 5xx / net  → 503 + Retry-After: 2  (mirror #2972/#3049)
+ *   - a genuine server fault  → 500  (fails LOUD, never masked)
+ *
+ * Fails before the fix (everything is a raw 500); passes after.
+ */
+
+const { mockCompleteMultipartUpload } = vi.hoisted(() => ({
+  mockCompleteMultipartUpload: vi.fn(),
+}));
+
+// Keep the REAL module (so the real classifyS3MultipartError runs) and override
+// only the network send + client factories.
+vi.mock('~/utils/s3-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/utils/s3-utils')>();
+  return {
+    ...actual,
+    completeMultipartUpload: mockCompleteMultipartUpload,
+    getUploadS3Client: vi.fn(() => ({})),
+    getB2ImageS3Client: vi.fn(() => ({})),
+  };
+});
+
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: vi.fn(async () => ({ user: { id: 42, bannedAt: null } })),
+}));
+
+// The real s3-utils imports ~/server/db/client (dbWrite); stub it so loading the
+// real module for `classifyS3MultipartError` doesn't spin up a real Prisma engine.
+vi.mock('~/server/db/client', () => ({ dbWrite: {}, dbRead: {} }));
+
+// NOTE: lives under src/server/__tests__ (not beside the handler) — Next.js scans
+// every .ts under src/pages/api as an API route and its route-type validator
+// rejects a test module.
+import handler from '~/pages/api/upload/complete';
+
+function makeRes() {
+  const headers: Record<string, string> = {};
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    ended: false,
+    headers,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    end() {
+      this.ended = true;
+      return this;
+    },
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+      return this;
+    },
+    removeHeader() {
+      return this;
+    },
+    getHeader(name: string) {
+      return headers[name];
+    },
+    // instrumentApiResponse registers a fire-and-forget res.once('finish', …).
+    once() {
+      return this;
+    },
+    on() {
+      return this;
+    },
+  };
+  return res as unknown as NextApiResponse & {
+    statusCode: number;
+    body: unknown;
+    ended: boolean;
+    headers: Record<string, string>;
+  };
+}
+
+function makeReq() {
+  return {
+    method: 'POST',
+    body: {
+      bucket: 'civitai-modelfiles',
+      key: 'some/key.safetensors',
+      type: 'model',
+      uploadId: 'test-upload-id',
+      parts: [{ ETag: 'e', PartNumber: 1 }],
+      backend: 'b2',
+    },
+    headers: {},
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as NextApiRequest;
+}
+
+const s3Error = (props: Record<string, unknown>) =>
+  Object.assign(new Error((props.message as string) ?? 'error'), props);
+
+beforeEach(() => {
+  mockCompleteMultipartUpload.mockReset();
+});
+
+describe('/api/upload/complete — error classification', () => {
+  it('happy path: completeMultipartUpload resolves → 200 + Location', async () => {
+    mockCompleteMultipartUpload.mockResolvedValue({ Location: 'https://cdn/x' });
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('https://cdn/x');
+  });
+
+  it('NoSuchUpload (name + $metadata 404) → 409, not 500', async () => {
+    mockCompleteMultipartUpload.mockRejectedValue(
+      s3Error({
+        name: 'NoSuchUpload',
+        message:
+          'The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.',
+        $metadata: { httpStatusCode: 404 },
+      })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({ error: 'Upload already finalized or aborted' });
+  });
+
+  it('transient S3 503 → 503 + Retry-After header, not 500', async () => {
+    mockCompleteMultipartUpload.mockRejectedValue(
+      s3Error({ name: 'ServiceUnavailable', $metadata: { httpStatusCode: 503 } })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['Retry-After']).toBe('2');
+    expect(res.headers['Cache-Control']).toBe('no-store');
+  });
+
+  it('status-less network failure (ECONNRESET) → 503', async () => {
+    mockCompleteMultipartUpload.mockRejectedValue(
+      s3Error({ code: 'ECONNRESET', message: 'socket hang up' })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(503);
+    expect(res.headers['Retry-After']).toBe('2');
+  });
+
+  it('a genuine server fault (unknown error) STILL surfaces as 500', async () => {
+    mockCompleteMultipartUpload.mockRejectedValue(s3Error({ message: 'unexpected boom' }));
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(500);
+  });
+});

--- a/src/utils/__tests__/s3-utils.test.ts
+++ b/src/utils/__tests__/s3-utils.test.ts
@@ -85,6 +85,7 @@ import {
   parseB2Url,
   deleteModelFileObject,
   deleteModelFileObjects,
+  classifyS3MultipartError,
 } from '~/utils/s3-utils';
 
 beforeEach(() => {
@@ -123,7 +124,9 @@ describe('parseKey', () => {
 describe('parseB2Url', () => {
   it('parses public path-style B2 URL (s3.<region>.backblazeb2.com)', () => {
     expect(
-      parseB2Url('https://s3.us-west-004.backblazeb2.com/civitai-modelfiles-b2/some/key.safetensors')
+      parseB2Url(
+        'https://s3.us-west-004.backblazeb2.com/civitai-modelfiles-b2/some/key.safetensors'
+      )
     ).toEqual({ bucket: 'civitai-modelfiles-b2', key: 'some/key.safetensors' });
   });
 
@@ -134,9 +137,10 @@ describe('parseB2Url', () => {
   });
 
   it('parses configured B2 endpoint (matches env.S3_UPLOAD_B2_ENDPOINT host)', () => {
-    expect(
-      parseB2Url('https://s3.us-west-004.backblazeb2.com/civitai-modelfiles-b2/k')
-    ).toEqual({ bucket: 'civitai-modelfiles-b2', key: 'k' });
+    expect(parseB2Url('https://s3.us-west-004.backblazeb2.com/civitai-modelfiles-b2/k')).toEqual({
+      bucket: 'civitai-modelfiles-b2',
+      key: 'k',
+    });
   });
 
   it('returns null for malformed URLs', () => {
@@ -184,9 +188,7 @@ describe('deleteModelFileObject — bucket allowlist gate', () => {
     mocks.findManyMock.mockResolvedValueOnce([
       { url: 'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/k', id: 7 },
     ]);
-    await deleteModelFileObject(
-      'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/k'
-    );
+    await deleteModelFileObject('https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/k');
     expect(mocks.deleteObjectCalls).toHaveLength(0);
   });
 
@@ -233,8 +235,71 @@ describe('deleteModelFileObjects — bucket allowlist + grouping', () => {
       'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/a',
       'https://civitai-prod-settled.abcd1234.r2.cloudflarestorage.com/b',
     ]);
-    expect(mocks.deleteManyObjectsCalls).toEqual([
-      { bucket: 'civitai-prod-settled', keys: ['b'] },
-    ]);
+    expect(mocks.deleteManyObjectsCalls).toEqual([{ bucket: 'civitai-prod-settled', keys: ['b'] }]);
+  });
+});
+
+// The classifier that de-fangs the multipart complete/abort raw-500 landmine
+// (~27 raw-500s/12h on dp-prod). Pure function → exercised directly here; the
+// handler-level mapping (409 vs 204 vs 503 vs 500) is covered in
+// src/server/__tests__/upload-{complete,abort}-endpoint.test.ts.
+describe('classifyS3MultipartError', () => {
+  it('classifies AWS-SDK NoSuchUpload (name + $metadata 404) as not-found', () => {
+    const err = Object.assign(
+      new Error(
+        'The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.'
+      ),
+      { name: 'NoSuchUpload', $metadata: { httpStatusCode: 404 } }
+    );
+    expect(classifyS3MultipartError(err)).toBe('not-found');
+  });
+
+  it('classifies a bare 404 (no name) as not-found', () => {
+    const err = Object.assign(new Error('not found'), { $metadata: { httpStatusCode: 404 } });
+    expect(classifyS3MultipartError(err)).toBe('not-found');
+  });
+
+  it.each([500, 502, 503, 504])('classifies an S3 HTTP %i as transient', (status) => {
+    const err = Object.assign(new Error('storage blip'), {
+      name: 'InternalError',
+      $metadata: { httpStatusCode: status },
+    });
+    expect(classifyS3MultipartError(err)).toBe('transient');
+  });
+
+  it.each(['SlowDown', 'RequestTimeout', 'RequestTimeTooSkewed', 'ServiceUnavailable'])(
+    'classifies the throttle/timing signal %s as transient',
+    (name) => {
+      // No httpStatusCode → matched purely by name.
+      const err = Object.assign(new Error(name), { name });
+      expect(classifyS3MultipartError(err)).toBe('transient');
+    }
+  );
+
+  it('classifies a status-less network failure (ECONNRESET) as transient', () => {
+    const err = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    expect(classifyS3MultipartError(err)).toBe('transient');
+  });
+
+  it('classifies a status-less ETIMEDOUT as transient', () => {
+    const err = Object.assign(new Error('connection timed out'), { code: 'ETIMEDOUT' });
+    expect(classifyS3MultipartError(err)).toBe('transient');
+  });
+
+  it('classifies a generic/unknown error as other (stays a hard 500)', () => {
+    expect(classifyS3MultipartError(new Error('boom'))).toBe('other');
+  });
+
+  it('classifies a genuine 4xx-that-is-not-404 (e.g. 400) as other', () => {
+    const err = Object.assign(new Error('bad request'), {
+      name: 'InvalidPart',
+      $metadata: { httpStatusCode: 400 },
+    });
+    expect(classifyS3MultipartError(err)).toBe('other');
+  });
+
+  it('handles null / undefined without throwing', () => {
+    expect(classifyS3MultipartError(null)).toBe('other');
+    expect(classifyS3MultipartError(undefined)).toBe('other');
   });
 });

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -20,6 +20,7 @@ import { env } from '~/env/server';
 import { logToAxiom } from '~/server/logging/client';
 import { instrumentB2Client, recordB2PresignIssued } from '~/server/prom/b2-put.metrics';
 import { registerMediaLocation } from '~/server/services/storage-resolver';
+import { isUpstreamNetworkError } from '~/server/utils/errorHandling';
 
 const missingEnvs = (): string[] => {
   const keys = [];
@@ -546,6 +547,61 @@ export async function abortMultipartUpload(
       UploadId: uploadId,
     })
   );
+}
+
+/**
+ * Classification of an S3/AWS-SDK error thrown while finalizing (complete) or
+ * aborting a multipart upload, so the `/api/upload/{complete,abort}` handlers can
+ * map it to the RIGHT HTTP status instead of a blind raw 500.
+ *
+ *  - `not-found`  — the multipart upload no longer exists: it was ALREADY completed
+ *    or aborted (a client double-submit / retry-after-success). The AWS-SDK v3
+ *    surfaces this as `NoSuchUpload` (HTTP 404). This is a client/STATE fault, not a
+ *    server fault: "The specified upload does not exist. The upload ID may be
+ *    invalid, or the upload may have been aborted or completed." Retrying it is
+ *    futile — the caller should STOP. (This was ~27 raw-500s/12h on dp-prod, the
+ *    same `key`+`uploadId` repeating across pods as the client kept retrying.)
+ *  - `transient` — a retry-able storage-backend blip: an S3/B2 HTTP 5xx, a throttle
+ *    / timing signal (`SlowDown` / `RequestTimeout` / `RequestTimeTooSkewed` /
+ *    `ServiceUnavailable` / `InternalError`), or a status-less network failure
+ *    (`ECONNRESET` / `ETIMEDOUT` / …). Mirror #2972/#3049 → 503 + Retry-After.
+ *  - `other`     — anything unrecognized, INCLUDING a genuine server-side bug. Left
+ *    to surface as a hard 500 so a real failed upload fails LOUD (never masked as a
+ *    silent 409/503).
+ *
+ * AWS-SDK v3 errors carry `error.name` (e.g. `'NoSuchUpload'`, `'SlowDown'`) and
+ * `error.$metadata.httpStatusCode`; a pre-response network failure has neither, so
+ * it is matched by {@link isUpstreamNetworkError}.
+ */
+export type S3MultipartErrorClass = 'not-found' | 'transient' | 'other';
+
+const S3_TRANSIENT_ERROR_NAMES: ReadonlySet<string> = new Set([
+  'SlowDown',
+  'RequestTimeout',
+  'RequestTimeTooSkewed',
+  'ServiceUnavailable',
+  'InternalError',
+]);
+
+export function classifyS3MultipartError(error: unknown): S3MultipartErrorClass {
+  const err = error as
+    | { name?: unknown; $metadata?: { httpStatusCode?: unknown } | null }
+    | null
+    | undefined;
+  const name = typeof err?.name === 'string' ? err.name : undefined;
+  const httpStatusCode =
+    typeof err?.$metadata?.httpStatusCode === 'number' ? err.$metadata.httpStatusCode : undefined;
+
+  // Terminal state fault: the upload is already finalized/aborted → stop retrying.
+  if (name === 'NoSuchUpload' || httpStatusCode === 404) return 'not-found';
+
+  // Retry-able storage-backend failure.
+  if (typeof httpStatusCode === 'number' && httpStatusCode >= 500) return 'transient';
+  if (name && S3_TRANSIENT_ERROR_NAMES.has(name)) return 'transient';
+  if (isUpstreamNetworkError(error)) return 'transient';
+
+  // Unrecognized — keep surfacing as a hard 500 (do NOT mask a real server fault).
+  return 'other';
 }
 
 type GetObjectOptions = {


### PR DESCRIPTION
## Root cause

`/api/upload/complete` (~22 raw-500s/12h) and `/api/upload/abort` (~5/12h) on dp-prod returned a raw HTTP **500** for **every** thrown S3 error. Root-caused from Traefik access logs + `_axiom` (2026-07-11): the dominant error message is

> The specified upload does not exist. The upload ID may be invalid, or the upload may have been aborted or completed.

= the AWS-SDK v3 **`NoSuchUpload` (HTTP 404)** — a **client/state fault**, not a server fault: the multipart upload was already completed or aborted (client double-submit / retry-after-success). Because every retry re-500'd, the **same `key`+`uploadId` repeated across pods** → amplification (the ~27/12h are retries of a handful of dead uploads, mis-counted against the 500 SLO). Same landmine class as #3048 (user-fault→4xx) and #2972 / #3049 / #3057 (transient-dep→503).

The catch blocks were **error-blind**: `completeMultipartUpload` / `abortMultipartUpload` throw → `res.status(500).json({ error })` regardless of what the error was.

## Fix

Both catch blocks now classify the S3 error before responding, via a shared **`classifyS3MultipartError`** (added to `s3-utils.ts` beside the multipart helpers; reuses `isUpstreamNetworkError` for status-less network failures):

| Error | complete | abort |
|---|---|---|
| `NoSuchUpload` / `$metadata.httpStatusCode === 404` (terminal) | **409** `{ error: 'Upload already finalized or aborted' }` | **204** No Content |
| transient (`httpStatusCode >= 500`; `SlowDown`/`RequestTimeout`/`RequestTimeTooSkewed`/`ServiceUnavailable`/`InternalError`; network `ECONNRESET`/`ETIMEDOUT`/…) | **503** + `Retry-After: 2` + `Cache-Control: no-store` | same |
| anything else (incl. a genuine server bug) | **500** (unchanged) | **500** |

**409-vs-204 for abort:** aborting an already-gone upload is **idempotent** — the desired end-state (upload no longer exists) already holds, so it is a *success*, not a conflict → **204**. complete cannot fake a 200 (there is no `Location` to return), so a terminal **409** is correct there; both stop the client retry loop. The sole client caller (`s3-upload.store.ts`) fire-and-forgets abort and only checks `.ok` on complete, so neither status breaks the flow.

**Cannot hide a real failure:** the `else → 500` branch is preserved, so a genuine server-side fault still surfaces loud (the user's upload legitimately fails) — never masked as a silent 409/503.

Existing `instrumentApiResponse` instrumentation + Axiom error logging preserved.

## Tests

- `src/utils/__tests__/s3-utils.test.ts` — `classifyS3MultipartError` unit cases (NoSuchUpload/404 → `not-found`; 5xx + throttle names + network → `transient`; generic/400 → `other`; null/undefined safe).
- `src/server/__tests__/upload-complete-endpoint.test.ts` + `upload-abort-endpoint.test.ts` — drive the **real** handlers through the **real** classifier (only s3 send + client getters + auth stubbed), asserting the response status the client sees, plus the 503 `Retry-After` header and the abort 204.

**6 fail / 42 pass** — verified by reverting the two handlers to `origin/main`: the 6 status-reclassification cases fail (raw 500), the happy-path + genuine-500 cases still pass. With the fix: 42/42 green. `tsc` clean on all changed files (the 17 pre-existing errors are missing sibling repos not checked out in the worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)