### PR TITLE
fix(pagination): reject malformed NaN/Invalid cursor with 400 instead of raw 500

### DIFF
--- a/src/server/utils/pagination-helpers.test.ts
+++ b/src/server/utils/pagination-helpers.test.ts
@@ -1,0 +1,79 @@
+import { TRPCError } from '@trpc/server';
+import { describe, expect, it } from 'vitest';
+import { getCursor } from '~/server/utils/pagination-helpers';
+
+// `parseCursor` is not exported; it is exercised here through `getCursor`, the
+// public helper every keyset-paginated endpoint uses to turn a `nextCursor`
+// string back into a SQL WHERE predicate.
+//
+// Regression context: `model.getAll` browse queries 500'd (~35/12h) with
+// `invalid input syntax for type timestamp: "NaN"`. A Newest/Oldest page that
+// ended on a model with a NULL `lastVersionAt` (the NULLS-LAST tail) emitted a
+// nextCursor of `"|<modelId>"` — `CONCAT(NULL, '|', id)`. Parsing that empty
+// leading token produced NaN, which was bound into the SQL comparison and made
+// Postgres throw → an unattributable INTERNAL_SERVER_ERROR. The fix rejects a
+// malformed/unparseable cursor token with a 400 (BAD_REQUEST) instead.
+
+/** Assert a call throws a tRPC BAD_REQUEST (the `throwBadRequestError` shape). */
+function expectBadRequest(fn: () => unknown) {
+  let thrown: unknown;
+  try {
+    fn();
+  } catch (e) {
+    thrown = e;
+  }
+  expect(thrown, 'expected a thrown error').toBeInstanceOf(TRPCError);
+  expect((thrown as TRPCError).code).toBe('BAD_REQUEST');
+}
+
+describe('parseCursor (via getCursor) — malformed-token rejection', () => {
+  it('rejects an empty leading timestamp token (the NULL-lastVersionAt bug): "|<id>" → 400, not NaN', () => {
+    // Two-field date-then-id sort, mirroring Newest/Oldest.
+    // token0 = "" (NULL date column), token1 = "2686725". Empty token → NaN.
+    expectBadRequest(() => getCursor('createdAt DESC, id DESC', '|2686725'));
+  });
+
+  it('rejects a non-numeric leading token that parses to NaN → 400', () => {
+    // Single-field numeric sort with a garbage token.
+    expectBadRequest(() => getCursor('id DESC', 'abc'));
+  });
+
+  it('rejects an unparseable/Invalid-Date token → 400', () => {
+    // token0 contains "-" so it takes the dayjs branch; "not-a-date" is Invalid.
+    expectBadRequest(() => getCursor('createdAt DESC, id DESC', 'not-a-date|123'));
+  });
+
+  it('rejects an empty trailing numeric token: "<date>|" → 400', () => {
+    expectBadRequest(() => getCursor('createdAt DESC, id DESC', '2024-01-15|'));
+  });
+});
+
+describe('parseCursor (via getCursor) — well-formed cursors parse unchanged', () => {
+  it('parses a well-formed composite date|id cursor without throwing and binds real values', () => {
+    const { where } = getCursor('createdAt DESC, id DESC', '2024-01-15|2686725');
+    expect(where).toBeDefined();
+    // Prisma.Sql exposes the flattened bound parameter list. Confirm the tokens
+    // parsed to real (non-NaN) values: a Date for `createdAt` and the id number.
+    const values = (where as unknown as { values: unknown[] }).values;
+    const numbers = values.filter((v): v is number => typeof v === 'number');
+    const dates = values.filter((v): v is Date => v instanceof Date);
+    expect(numbers).toContain(2686725);
+    expect(numbers.every((n) => !Number.isNaN(n))).toBe(true);
+    expect(dates.length).toBeGreaterThan(0);
+    expect(dates.every((d) => !Number.isNaN(d.getTime()))).toBe(true);
+    // The date token round-trips to 2024-01-15 UTC.
+    expect(dates[0].toISOString()).toBe('2024-01-15T00:00:00.000Z');
+  });
+
+  it('parses a well-formed single-field numeric cursor without throwing', () => {
+    const { where } = getCursor('id DESC', '2686725');
+    expect(where).toBeDefined();
+    const values = (where as unknown as { values: unknown[] }).values;
+    expect(values).toContain(2686725);
+  });
+
+  it('returns no predicate when there is no cursor (unchanged)', () => {
+    const { where } = getCursor('id DESC', undefined);
+    expect(where).toBeUndefined();
+  });
+});

--- a/src/server/utils/pagination-helpers.ts
+++ b/src/server/utils/pagination-helpers.ts
@@ -111,10 +111,7 @@ function parseCursor(fields: SortField[], cursor: string | number | Date | bigin
   // deploy that changed the sort's `orderBy` field count. Reject as 400 rather
   // than crashing on the next line's `values[i].includes(...)` (undefined →
   // TypeError), which fell through to handleEndpointError's unlogged 500 branch
-  // — a silent, unattributable floor. NOTE: this guards arity only; it does NOT
-  // validate token contents, so an empty/NaN token (e.g. CONCAT(NULL,'|',id) →
-  // '|id' for a NULL sort column) still passes and parses to NaN — a separate,
-  // pre-existing issue, not addressed here.
+  // — a silent, unattributable floor.
   if (values.length !== fields.length) {
     throwBadRequestError(
       `Invalid cursor: expected ${fields.length} value(s) for this sort, received ${values.length}`
@@ -123,8 +120,27 @@ function parseCursor(fields: SortField[], cursor: string | number | Date | bigin
   const result: Record<string, number | Date> = {};
   for (let i = 0; i < fields.length; i++) {
     const value = values[i];
-    if (value.includes('-')) result[fields[i].field] = dayjs.utc(value).toDate();
-    else result[fields[i].field] = parseInt(value, 10);
+    // Validate token contents (companion to the arity guard above). A cursor's
+    // tokens come from the DB-computed `prop` (a bare column, or CONCAT(col, '|',
+    // …) for a composite sort). When a sort column is NULL — e.g. a NULLS-LAST tail
+    // reached via browse filters — `CONCAT(NULL, '|', id)` collapses to `'|id'`, so
+    // this loop sees an empty token that parses to NaN (numeric) / Invalid Date. That
+    // NaN/Invalid bound then hit the SQL comparison and Postgres threw
+    // `invalid input syntax for type timestamp: "NaN"`, which surfaced as an
+    // unattributable INTERNAL_SERVER_ERROR (500). Reject the malformed cursor as a
+    // 400 instead. (Well-formed cursors carry real DB values, so this only fires on a
+    // genuinely unparseable token — never on a legitimate cursor.)
+    if (value.includes('-')) {
+      const parsed = dayjs.utc(value);
+      if (!parsed.isValid())
+        throwBadRequestError(`Invalid cursor: unparseable date value "${value}"`);
+      result[fields[i].field] = parsed.toDate();
+    } else {
+      const parsed = parseInt(value, 10);
+      if (Number.isNaN(parsed))
+        throwBadRequestError(`Invalid cursor: unparseable numeric value "${value}"`);
+      result[fields[i].field] = parsed;
+    }
   }
   return result;
 }


### PR DESCRIPTION
## Problem

`/api/trpc/model.getAll` browse queries 500 (~2.9/h, **35/12h**) with:

```
TRPCError: invalid input syntax for type timestamp: "NaN"
```

**Root cause (end-to-end):** the `Newest`/`Oldest` sort `orderBy` uses `mm."lastVersionAt"`, and the keyset cursor `prop` is `CONCAT(mm."lastVersionAt", '|', "modelId")` (`getCursorClauses`). When a page ends on a model with a **NULL `lastVersionAt`** (the NULLS-LAST tail, reachable via browse filters), Postgres emits a `nextCursor` of `"|2686725"` — `CONCAT(NULL, '|', id)`.

On the next scroll, `parseCursor` (`pagination-helpers.ts`) splits `"|2686725"` → `["", "2686725"]`; the empty timestamp token → `parseInt("", 10)` = **`NaN`**, which is bound into the timestamp comparison → Postgres throws → `throwDbError`'s final branch → `INTERNAL_SERVER_ERROR` (500).

`parseCursor` already had an **arity guard** returning 400 (#3048), and a comment there explicitly flagged this NaN-from-`CONCAT(NULL,'|',id)` case as a known, un-addressed issue.

## Fix

In `parseCursor`'s per-token parse loop, if a parsed numeric value is `NaN` or a parsed date is Invalid, call `throwBadRequestError('Invalid cursor: …')` → **400**, matching the arity guard directly above. One localized change covers every cursor consumer.

## Blast radius (parseCursor is a SHARED helper) — checked

All callers verified:
- `parseCursor` is called **only** by `getCursor` and `getCursorClauses` (both in `pagination-helpers.ts`).
- `getCursor` → `image.service.ts` (image feed). `getCursorClauses` → `model.service.ts` (`model.getAll`).

In every path the cursor originates from the **prior page's DB-computed `nextCursor`** (the `prop` column / `CONCAT`), so a well-formed cursor always carries real DB values. A NaN/Invalid token is only ever produced by a malformed/server-bug cursor (the NULL-sort-column tail, a stale, or a hand-built cursor). No downstream code tolerates a NaN — today it deterministically 500s in Postgres — so a blanket 400 regresses **nothing**. `parseInt` stays lenient (`"123abc"` → `123`), so the guard fires only on genuinely-unparseable tokens; well-formed single **and** composite cursors parse byte-unchanged (covered by tests).

## Tests

Added `src/server/utils/pagination-helpers.test.ts` (exercises `parseCursor` via the exported `getCursor`):
- `"|2686725"` (empty leading timestamp token — the bug) → 400
- non-numeric token / Invalid-Date token / empty trailing token → 400
- well-formed composite `"2024-01-15|2686725"` + single `"2686725"` → parse unchanged, bind real (non-NaN) values
- no cursor → no predicate

**Fail-before / pass-after confirmed:** against current `main` source the 4 malformed-rejection tests FAIL (NaN passes through) and the 3 well-formed tests PASS; with the fix **7/7 pass**.

## Follow-up (separate, tracked — NOT in this PR)

A 400 stops the raw 500 immediately, but it **dead-ends infinite scroll at the NULL-`lastVersionAt` tail** (the scroll just halts instead of paging past the NULL rows). The correct long-term fix is **NULL-safe cursor gen/parse for `NULLS LAST`** — sentinel-encode the NULL sort value in `getCursorClauses`/`parseCursor`, or exclude NULL-sort-column rows as cursor anchors. That's a larger change needing its own design; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)