### PR TITLE
fix(user-profile): reject empty username with 400 instead of raw 500

### DIFF
--- a/src/server/schema/__tests__/user-profile.schema.test.ts
+++ b/src/server/schema/__tests__/user-profile.schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { getUserProfileSchema } from '~/server/schema/user-profile.schema';
+
+// Regression guard for the production raw-500 landmine: `userProfile.get`/`.overview`
+// were called with `{ username: '' }` (a profile page renders before the username route
+// param resolves). The empty string is falsy, so it slipped past the schema, hit the
+// service's `!username && !id` guard, threw a plain Error, and surfaced as INTERNAL_SERVER_ERROR
+// (500). An empty/absent username is invalid INPUT and must be rejected at the tRPC boundary
+// → BAD_REQUEST (400). These assertions FAIL against the old `username: z.string().optional()`
+// schema (empty string parsed successfully) and PASS with `.min(1).optional()` + the refine.
+describe('getUserProfileSchema', () => {
+  it('rejects an empty-string username (the 500 trigger)', () => {
+    const res = getUserProfileSchema.safeParse({ username: '' });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects both fields absent', () => {
+    const res = getUserProfileSchema.safeParse({});
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects an empty-string username even when id is absent', () => {
+    const res = getUserProfileSchema.safeParse({ username: '', id: undefined });
+    expect(res.success).toBe(false);
+  });
+
+  it('accepts a non-empty username', () => {
+    const res = getUserProfileSchema.safeParse({ username: 'civitai' });
+    expect(res.success).toBe(true);
+    if (res.success) expect(res.data.username).toBe('civitai');
+  });
+
+  it('accepts an id-only call (username omitted) — legit lookup-by-id path', () => {
+    const res = getUserProfileSchema.safeParse({ id: 123 });
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.data.id).toBe(123);
+      expect(res.data.username).toBeUndefined();
+    }
+  });
+
+  it('accepts both username and id present', () => {
+    const res = getUserProfileSchema.safeParse({ username: 'civitai', id: 123 });
+    expect(res.success).toBe(true);
+  });
+});

--- a/src/server/schema/user-profile.schema.ts
+++ b/src/server/schema/user-profile.schema.ts
@@ -5,10 +5,19 @@ import { LinkType } from '~/shared/utils/prisma/enums';
 import { creatorCardStatsPreferences, profilePictureSchema } from './user.schema';
 
 export type GetUserProfileSchema = z.infer<typeof getUserProfileSchema>;
-export const getUserProfileSchema = z.object({
-  username: z.string().optional(),
-  id: z.number().optional(),
-});
+export const getUserProfileSchema = z
+  .object({
+    // Reject an empty-string username at the input boundary. A profile page renders
+    // `userProfile.get`/`userProfile.overview` before the username route param resolves,
+    // sending `{ username: '' }`; that used to reach the service, fail the falsy
+    // `!username && !id` guard, and surface as a raw 500. An empty/absent username is
+    // invalid INPUT — reject it here so tRPC returns BAD_REQUEST (400).
+    username: z.string().min(1).optional(),
+    id: z.number().optional(),
+  })
+  .refine((d) => (d.username != null && d.username.length > 0) || d.id != null, {
+    message: 'username or id required',
+  });
 
 export const ProfileSectionTypeDef = {
   Showcase: 'showcase',

--- a/src/server/services/user-profile.service.ts
+++ b/src/server/services/user-profile.service.ts
@@ -14,7 +14,7 @@ import { isDefined } from '~/utils/type-guards';
 import { enqueueImageIngestion } from '~/server/services/image.service';
 import type { UserMeta } from '~/server/schema/user.schema';
 import { getUserBanDetails } from '~/utils/user-helpers';
-import { throwNotFoundError } from '~/server/utils/errorHandling';
+import { throwBadRequestError, throwNotFoundError } from '~/server/utils/errorHandling';
 import {
   getUserContentOverview as getUserContentOverviewFromCache,
   getUserContentOverviewPublic as getUserContentOverviewPublicFromCache,
@@ -36,7 +36,7 @@ export const getUserContentOverview = async ({
   variant?: UserContentOverviewVariant;
 }) => {
   if (!username && !userId) {
-    throw new Error('Either username or id must be provided');
+    throwBadRequestError('Either username or id must be provided');
   }
 
   if (!userId) {
@@ -77,7 +77,7 @@ export const getUserWithProfile = async ({
   // Use write to get the latest most accurate user here since we'll need to create the profile
   // if it doesn't exist.
   if (!username && !id) {
-    throw new Error('Either username or id must be provided');
+    throwBadRequestError('Either username or id must be provided');
   }
   const getUser = async () => {
     const user = await dbClient.user.findUniqueOrThrow({


### PR DESCRIPTION
## Root cause

`/api/trpc/userProfile.get` was raw-500ing in production — **11 of the last 12h, ~0.9/h, and every single one was the solo input `{"username":""}`** (an empty-string username). A profile page renders `userProfile.get` before the username route param resolves, so the client fires the query with an empty username.

Chain: `getUserProfileHandler` (`user-profile.controller.ts:45`) → `getUserWithProfile({username:''})` (`user-profile.service.ts`) → `if (!username && !id) throw new Error(...)` — the empty string is **falsy**, so it trips the guard → plain `Error` → handler `catch` → `throwDbError(error)` → `INTERNAL_SERVER_ERROR` (500).

An empty/absent username is invalid **input**, so it should be a **400**, not a 500.

## Fix (deterministic, at the tRPC input boundary — mirrors #3048)

- **`getUserProfileSchema`**: `username: z.string().min(1).optional()` + `.refine(d => (d.username?.length) || d.id != null)`. Empty-string username and both-absent now fail zod validation → tRPC **BAD_REQUEST (400)** before the handler runs. `.optional()` + `.min(1)` = "if present, non-empty", so the legit **id-only** call path (username omitted) still passes.
- **Defense-in-depth**: the two service guards in `user-profile.service.ts` (`getUserWithProfile` and `getUserContentOverview`) now call `throwBadRequestError(...)` instead of throwing a plain `Error`, so any non-schema caller path also yields 400.

## Tests

`src/server/schema/__tests__/user-profile.schema.test.ts` (6 cases):
- `{username:''}` → **reject** (the 500 trigger) · `{}` both-absent → **reject** · `{username:'', id:undefined}` → **reject**
- `{username:'civitai'}` → accept · `{id:123}` id-only → accept · `{username,id}` → accept

Result: **3 fail** against the old `z.string().optional()` schema (empty string parsed successfully → would 500), **all 6 pass** with the fix. Full-repo `tsc --noEmit` reports no errors in the touched files (17 pre-existing errors elsewhere, unrelated).

## Notes / out of scope

- **Real trigger is client-side**: the browser sending `userProfile.get` with `username:''` before the route param resolves is a separate client ticket. This PR is the server-typing sweep that turns the symptom from a 500 into a correct 400.
- **Secondary finding (already OK, not touched)**: app logs also show ~299× `findUniqueOrThrow ... No record was found` for real-but-nonexistent usernames. These arrive **batched** (HTTP 200 with an embedded error, invisible to Traefik) and are **not** driving 500s. Installed Prisma is `^6.3.0`, whose `findUniqueOrThrow` miss throws `PrismaClientKnownRequestError{code:'P2025'}`; `throwDbError` maps `P2025 → NOT_FOUND` (404). Verified correct — no legacy `NotFoundError` fall-through to 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)