### PR TITLE
fix(image): return 400 (not raw 500) on invalid cursor+prioritizedUserIds combo

### DIFF
--- a/src/server/services/__tests__/getAllImages-prioritized-guards.test.ts
+++ b/src/server/services/__tests__/getAllImages-prioritized-guards.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+// getAllImages contains input-validation guards for the `prioritizeUser`
+// (creator-first / model-showcase carousel) branch: it rejects `cursor` combined
+// with `prioritizedUserIds`, and requires `modelVersionId` when the model-version
+// cache path is taken. These are INVALID INPUT combinations (a client sending a
+// load-more `cursor` while also asking for `prioritizedUserIds`), so they must
+// surface as a tRPC BAD_REQUEST (400) — NOT a raw `Error` that the controller
+// catch (`throwDbError`) turns into an INTERNAL_SERVER_ERROR (500). See the
+// image.getInfinite raw-500 landmine (model-showcase carousel cursor +
+// prioritizedUserIds, ~27 500s/12h).
+//
+// The mock block mirrors the established image.service unit-test recipe
+// (image-metrics-timeout.test.ts): stub env + infra clients + the private
+// event-engine-common submodule so importing image.service boots no real infra.
+// On top of that we stub `enforceBlockedBrowsingTags` (so the guard is reachable)
+// and force `isFlipt` true so the model-version-cache branch (which holds both
+// guards) is taken.
+
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/prom/client')>();
+  return { ...actual, registerCounter: () => ({ inc: vi.fn() }) };
+});
+
+// event-engine-common is a private git submodule not checked out in this
+// worktree — stub the value imports image.service pulls from it.
+vi.mock('../../../../event-engine-common/services/metrics', () => ({
+  MetricService: class {
+    fetch = vi.fn();
+  },
+}));
+vi.mock('../../../../event-engine-common/feeds', () => ({ ImagesFeed: class {} }));
+vi.mock('../../../../event-engine-common/services/cache', () => ({ CacheService: class {} }));
+
+// Fully replace env (importing the real `~/env/server` validates ALL prod env
+// vars and throws in test). A Proxy returns safe values for anything read at
+// module load.
+vi.mock('~/env/server', () => ({
+  env: new Proxy({ LOGGING: [] as string[] } as Record<string, unknown>, {
+    get: (target, prop) => {
+      if (prop in target) return target[prop as string];
+      if (typeof prop === 'string' && (prop.endsWith('_URL') || prop.endsWith('_ENDPOINT')))
+        return 'https://test:test@localhost:5432/test';
+      if (
+        typeof prop === 'string' &&
+        /(_CONCURRENCY|_LIMIT|_MS|_PORT|_TIMEOUT|_MAX|_SIZE|_COUNT)$/.test(prop)
+      )
+        return 1;
+      return undefined;
+    },
+  }),
+}));
+
+// Stub the infra clients so no real DB/Redis connection is opened on import.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { packed: { get: vi.fn(), set: vi.fn() } },
+    sysRedis: {},
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+  };
+});
+
+// The guard sits after enforceBlockedBrowsingTags — stub it to a non-empty result
+// so getAllImages proceeds into the prioritizeUser branch.
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTags: vi.fn().mockResolvedValue({ emptyResult: false }),
+}));
+
+// Force the Flipt model-version-cache flag ON so `useModelVersionCache` is true
+// and the branch containing BOTH guards is taken. Keep every other flipt export
+// real (FLIPT_FEATURE_FLAGS etc. are used at module load).
+vi.mock('../../flipt/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../flipt/client')>();
+  return { ...actual, isFlipt: vi.fn().mockResolvedValue(true) };
+});
+
+import { getAllImages } from '../image.service';
+
+const baseInput = {
+  browsingLevel: 1,
+  prioritizedUserIds: [123],
+  include: [], // controller always forwards an include array
+} as any;
+
+describe('getAllImages prioritizedUserIds input guards → BAD_REQUEST (not 500)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects cursor + prioritizedUserIds with a BAD_REQUEST TRPCError (not INTERNAL_SERVER_ERROR)', async () => {
+    let caught: unknown;
+    try {
+      await getAllImages({ ...baseInput, modelVersionId: 456, cursor: 999 });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('BAD_REQUEST');
+    expect((caught as TRPCError).code).not.toBe('INTERNAL_SERVER_ERROR');
+    expect((caught as TRPCError).message).toBe('Cannot use cursor with prioritizedUserIds');
+  });
+
+  it('rejects prioritizedUserIds without modelVersionId with a BAD_REQUEST TRPCError', async () => {
+    let caught: unknown;
+    try {
+      await getAllImages({ ...baseInput }); // no cursor, no modelVersionId
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect((caught as TRPCError).code).toBe('BAD_REQUEST');
+    expect((caught as TRPCError).message).toBe(
+      'modelVersionId is required when using prioritizedUserIds'
+    );
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -1399,9 +1399,9 @@ export const getAllImages = async (
   const prioritizeUser = !!prioritizedUserIds?.length;
   const useModelVersionCache = prioritizeUser && prefetchedIsFlipt;
   if (prioritizeUser && useModelVersionCache) {
-    if (cursor) throw new Error('Cannot use cursor with prioritizedUserIds');
+    if (cursor) throw throwBadRequestError('Cannot use cursor with prioritizedUserIds');
     if (!modelVersionId)
-      throw new Error('modelVersionId is required when using prioritizedUserIds');
+      throw throwBadRequestError('modelVersionId is required when using prioritizedUserIds');
 
     const cachedData = await imagesForModelVersionsCache.fetch([modelVersionId]);
     const versionData = cachedData[modelVersionId];
@@ -1740,7 +1740,7 @@ export const getAllImages = async (
 
   if (prioritizeUser && !useModelVersionCache) {
     // [x]
-    if (cursor) throw new Error('Cannot use cursor with prioritizedUserIds');
+    if (cursor) throw throwBadRequestError('Cannot use cursor with prioritizedUserIds');
     isPersonalized = true; // prioritizedUserIds reorders/filters per-caller
     if (modelVersionId) AND.push(Prisma.sql`p."modelVersionId" = ${modelVersionId}`);
 


### PR DESCRIPTION
## Problem

`/api/trpc/image.getInfinite` throws raw **500s** (~2.25/h, **27 in 12h**) with `TRPCError: Cannot use cursor with prioritizedUserIds` (INTERNAL_SERVER_ERROR). Traces show a **4-6ms immediate throw with zero DB spans** — the request never touches the database; it's rejected by an input guard.

**Root cause:** A model-showcase carousel loads-more (sends a `cursor`) while also using `prioritizedUserIds` (creator-first ordering) + `modelVersionId`. In `getAllImages` the `prioritizeUser` branch rejects that combination with a plain `throw new Error(...)`. The controller catch (`src/server/controllers/image.controller.ts`) does `if (error instanceof TRPCError) throw error; else throw throwDbError(error)` — a plain `Error` is **not** a `TRPCError`, so `throwDbError` wraps it into an INTERNAL_SERVER_ERROR (**500**).

These are invalid **input** combinations (a client sending `cursor` + `prioritizedUserIds`, or `prioritizedUserIds` without `modelVersionId`) — they should be **400 BAD_REQUEST**, not 500. Mirrors the validation→400 template from #3048.

## Fix

Switch the three guard throws in `src/server/services/image.service.ts` from `throw new Error(...)` to `throwBadRequestError(...)` (already imported/used in this file):

- `:1402` `Cannot use cursor with prioritizedUserIds` (model-version-cache branch)
- `:1404` `modelVersionId is required when using prioritizedUserIds`
- `:1743` `Cannot use cursor with prioritizedUserIds` (non-cache branch)

`throwBadRequestError` produces `TRPCError{code:'BAD_REQUEST'}`; `throwDbError` re-throws an existing `TRPCError` **unchanged**, so a BAD_REQUEST propagates as a clean 400. **Only the error type changed** — no guard conditions or pagination logic touched.

## Self-review

- **Guards reachable only via invalid input.** The only callers passing `prioritizedUserIds` are client tRPC inputs (`ModelCarousel.tsx`, `models/[id]` page) routed through `getInfiniteImagesHandler`; there is no internal server call to `getAllImages`/`getAllImagesIndex` that relies on catching a plain `Error` from these guards. Safe to convert.
- **Propagation verified.** `throwBadRequestError` → `TRPCError` BAD_REQUEST; the controller's `if (error instanceof TRPCError) throw error` short-circuits before `throwDbError`, so it is not re-wrapped to 500.
- **Follow-up (separate client ticket, not fixed here):** the model-showcase carousel shouldn't send `cursor` together with `prioritizedUserIds` in the first place — a 400 stops the invisible 500, but that view's load-more pagination is a no-op (creator-first + cursor is unsupported by design). Track the client fix separately.

## Tests

Adds `src/server/services/__tests__/getAllImages-prioritized-guards.test.ts` (mock recipe mirrors the existing `image-metrics-timeout.test.ts` service-unit pattern). Two cases:
- `cursor` + `prioritizedUserIds` → asserts `TRPCError` BAD_REQUEST (not INTERNAL_SERVER_ERROR)
- `prioritizedUserIds` without `modelVersionId` → asserts BAD_REQUEST

**Result:** 2 fail against the pre-fix plain-`Error` code (throws a plain `Error`, not a `TRPCError`) / **2 pass** with the fix. Verified locally with `vitest run --project unit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)