### PR TITLE
perf(image): trim image.getImagesAsPostsInfinite serialize payload (#2 oversized path)

### DIFF
--- a/src/server/controllers/image.controller.ts
+++ b/src/server/controllers/image.controller.ts
@@ -81,6 +81,7 @@ import {
   moderateImages,
 } from './../services/image.service';
 import { Limiter } from '~/server/utils/concurrency-helpers';
+import { capImagesPerPost, stripImageForAsPostsWire } from '~/server/utils/images-as-posts-wire';
 import { imagesFeedWithoutIndexCounter } from '~/server/prom/client';
 import { constants, POST_IMAGE_LIMIT } from '~/server/common/constants';
 import { logToAxiom } from '~/server/logging/client';
@@ -576,7 +577,15 @@ export const getImagesAsPostsInfiniteHandler = async ({
         sortAt: image.sortAt,
         createdAt,
         user,
-        images,
+        // Serialize-cost reduction (this endpoint is the #2 oversized-tRPC-response
+        // producer): (1) OPTIONALLY cap each post's images when the DARK, user-visible
+        // `imagesAsPostsPerPostCap` flag is on — the material lever (~15% fewer images);
+        // (2) always strip per-image fields no consumer reads (zero-UX). Both run AFTER
+        // the per-post `index` sort above and after the post-level fields are read off
+        // `image`/`images[0]`, so nothing server-side needs the dropped data.
+        images: (features.imagesAsPostsPerPostCap ? capImagesPerPost(images) : images).map(
+          stripImageForAsPostsWire
+        ),
         review: review
           ? {
               rating: review.rating,

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -119,6 +119,17 @@ const featureFlags = createFeatureFlags({
   // the A/B (no flag-off cohort) and shipping the deferral fleet-wide unmeasured. OFF =
   // byte-identical to today. Measured via RUM `exp_gen_tab_defer_view`. Instant safe rollback.
   genTabDeferView: { availability: [], fliptKey: 'gen-tab-defer-view' },
+  // Serialize-perf: cap each post's embedded image list on `image.getImagesAsPostsInfinite`
+  // (the #2 producer of oversized/event-loop-freezing tRPC responses). Model galleries carry
+  // multi-image showcase posts (p90 14 imgs/post), so the cap cuts ~15% of serialized images
+  // at 12/post. 🔴 USER-VISIBLE (this card renders the FULL carousel AND seeds the detail
+  // modal from `data.images` WITHOUT refetch, so a cap hides a post's tail images from both) —
+  // hence `availability: []` = DARK by default, fails CLOSED (no cap) when Flipt is absent/down.
+  // The Flipt `images-as-posts-per-post-cap` threshold is the ONLY on-switch; ramp only after a
+  // product call on the carousel/modal truncation, and confirm the new bundle is serving first.
+  // OFF = byte-identical to today. Verify via `trpc-response-oversized {path=
+  // "image.getImagesAsPostsInfinite"}` serializeMs/bytes tail. (Mirrors the genTabDeferView precedent.)
+  imagesAsPostsPerPostCap: { availability: [], fliptKey: 'images-as-posts-per-post-cap' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },

--- a/src/server/utils/__tests__/images-as-posts-wire.test.ts
+++ b/src/server/utils/__tests__/images-as-posts-wire.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import {
+  capImagesPerPost,
+  IMAGES_AS_POSTS_DROPPED_IMAGE_FIELDS,
+  IMAGES_AS_POSTS_PER_POST_CAP,
+  stripImageForAsPostsWire,
+} from '~/server/utils/images-as-posts-wire';
+
+// `image.getImagesAsPostsInfinite` returns each post's FULL per-image object, and
+// the tRPC response is serialized synchronously with superjson on the event loop.
+// Two levers cut that cost:
+//  - `stripImageForAsPostsWire` drops the OPTIONAL per-image fields no consumer of
+//    this endpoint reads (zero-UX; the unread-but-required fields stay because the
+//    card seeds `data.images` into the detail modal whose type demands them);
+//  - `capImagesPerPost` caps a post's embedded images (material, flag-gated).
+// This test pins the contract: the drop set, the load-bearing retentions, the cap,
+// and non-mutation.
+
+// A representative per-image object with every field the endpoint emits.
+const makeImage = () => ({
+  // --- retained: rendered by the card ---
+  id: 123,
+  url: 'abc.jpeg',
+  name: 'a render',
+  nsfwLevel: 1,
+  width: 832,
+  height: 1216,
+  hash: 'UBFO~q00',
+  hasMeta: true,
+  hasPositivePrompt: true,
+  onSite: false,
+  remixOfId: null,
+  type: 'image',
+  metadata: { width: 832, height: 1216 },
+  ingestion: 'Scanned',
+  needsReview: null,
+  userId: 500,
+  postId: 8000,
+  modelVersionId: 1500,
+  minor: false,
+  poi: false,
+  modelVersionIds: [1500],
+  modelVersionIdsManual: [],
+  user: { id: 500, username: 'creator', image: null, deletedAt: null, cosmetics: [], profilePicture: null },
+  stats: { likeCountAllTime: 1, dislikeCountAllTime: 0 },
+  reactions: [],
+  cosmetic: null,
+  thumbnailUrl: undefined,
+  // --- retained: read by the seeded ImageDetail2 modal (card never reads them) ---
+  createdAt: new Date('2026-07-01T00:00:00.000Z'),
+  publishedAt: new Date('2026-07-01T00:00:00.000Z'),
+  sortAt: new Date('2026-07-01T00:00:00.000Z'),
+  blockedFor: null,
+  model3dId: null,
+  // --- retained: hidden-prefs `case 'posts'` filters on it (biggest field) ---
+  tagIds: [1, 2, 3, 4, 5],
+  // --- retained: unread by all consumers, but NON-OPTIONAL on the modal seed type
+  //     (dropping them fails typecheck at the `data.images -> ImageDetailModal` seed) ---
+  hideMeta: false,
+  scannedAt: new Date('2026-07-01T00:00:00.000Z'),
+  mimeType: 'image/jpeg',
+  index: 0,
+  postTitle: 'my post',
+  // --- dropped: unread AND optional on the seed type ---
+  meta: null,
+  availability: 'Public',
+  acceptableMinor: false,
+  baseModel: 'Illustrious',
+  judgeScore: null,
+});
+
+describe('images-as-posts-wire', () => {
+  describe('stripImageForAsPostsWire', () => {
+    it('drops exactly the declared unread+optional fields', () => {
+      const out = stripImageForAsPostsWire(makeImage());
+      for (const field of IMAGES_AS_POSTS_DROPPED_IMAGE_FIELDS) {
+        expect(out).not.toHaveProperty(field);
+      }
+      // exactly these 5 and no others were removed
+      const removed = Object.keys(makeImage()).filter((k) => !(k in out));
+      expect(removed.sort()).toEqual([...IMAGES_AS_POSTS_DROPPED_IMAGE_FIELDS].sort());
+    });
+
+    it('keeps every field a consumer reads (card, context menu, hidden-prefs, seeded modal)', () => {
+      const out = stripImageForAsPostsWire(makeImage());
+      for (const field of [
+        'id', 'url', 'name', 'nsfwLevel', 'width', 'height', 'hash', 'hasMeta',
+        'hasPositivePrompt', 'onSite', 'remixOfId', 'type', 'metadata', 'ingestion',
+        'needsReview', 'userId', 'postId', 'modelVersionId', 'minor', 'poi',
+        'modelVersionIds', 'modelVersionIdsManual', 'user', 'stats', 'reactions',
+        'cosmetic', 'thumbnailUrl',
+      ]) {
+        expect(out).toHaveProperty(field);
+      }
+      // 🔴 the load-bearing retentions: look droppable but ARE read / ARE required
+      expect(out).toHaveProperty('tagIds'); // hidden-prefs `case 'posts'`
+      expect((out as { tagIds: number[] }).tagIds).toEqual([1, 2, 3, 4, 5]);
+      for (const field of ['createdAt', 'publishedAt', 'sortAt', 'blockedFor', 'model3dId']) {
+        expect(out).toHaveProperty(field); // read by the seeded ImageDetail2 modal
+      }
+      for (const field of ['hideMeta', 'scannedAt', 'mimeType', 'index', 'postTitle']) {
+        expect(out).toHaveProperty(field); // required by the modal seed TYPE (unread but non-optional)
+      }
+      expect((out as { stats: Record<string, number> }).stats).toEqual({
+        likeCountAllTime: 1,
+        dislikeCountAllTime: 0,
+      });
+    });
+
+    it('does NOT mutate the source object', () => {
+      const source = makeImage();
+      const before = JSON.stringify(source);
+      const out = stripImageForAsPostsWire(source);
+      expect(JSON.stringify(source)).toBe(before);
+      expect(source).toHaveProperty('baseModel');
+      expect(out).not.toBe(source);
+    });
+
+    it('is a no-op for keys absent on the object (DB/Meili union safety)', () => {
+      const out = stripImageForAsPostsWire({ id: 1, url: 'x', tagIds: [9] });
+      expect(out).toEqual({ id: 1, url: 'x', tagIds: [9] });
+    });
+  });
+
+  describe('capImagesPerPost', () => {
+    const imgs = (n: number) => Array.from({ length: n }, (_, i) => ({ id: i + 1 }));
+
+    it('caps to IMAGES_AS_POSTS_PER_POST_CAP, keeping leading order (cover stays images[0])', () => {
+      expect(IMAGES_AS_POSTS_PER_POST_CAP).toBe(12);
+      const source = imgs(20);
+      const out = capImagesPerPost(source);
+      expect(out).toHaveLength(12);
+      expect(out.map((x) => x.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      expect(out[0]).toBe(source[0]);
+      expect(source).toHaveLength(20); // not mutated
+    });
+
+    it('returns the same array untouched when within the cap (typical posts)', () => {
+      const source = imgs(3);
+      expect(capImagesPerPost(source)).toBe(source);
+      expect(capImagesPerPost([])).toEqual([]);
+    });
+
+    it('honors a custom cap', () => {
+      expect(capImagesPerPost(imgs(20), 8)).toHaveLength(8);
+    });
+  });
+});

--- a/src/server/utils/images-as-posts-wire.ts
+++ b/src/server/utils/images-as-posts-wire.ts
@@ -1,0 +1,89 @@
+/**
+ * Wire-shape trimming for `image.getImagesAsPostsInfinite`.
+ *
+ * This endpoint groups images into posts and returns each post's FULL per-image
+ * object (from `getAllImages` / `getAllImagesIndex`). A single page can carry
+ * ~1000 images, and the tRPC response is serialized SYNCHRONOUSLY with superjson
+ * on the Node event loop — walking every field of every image. That walk is the
+ * event-loop freeze this endpoint produces (it is the #2 producer of oversized
+ * tRPC responses in the serialize-freeze arc). Cutting per-image fields no
+ * consumer reads directly reduces both the byte size and the serialize walk.
+ *
+ * The dropped fields below were confirmed unread across the ENTIRE consumer graph
+ * of this endpoint's result:
+ *  - the gallery card + carousel (`ImagesAsPostsCard`),
+ *  - the shared image context menu (`ImageMenuItems` — its `ImageProps` type does
+ *    not contain any of these fields),
+ *  - the hidden-preferences `posts` branch (`useApplyHiddenPreferences`),
+ *  - AND the image-detail modal seeded from the card (`ImageDetail2`), which reads
+ *    the SEEDED image objects directly (no refetch when the seed contains the
+ *    target id — `ImageDetailProvider` uses `initialImages` as-is), so its read-set
+ *    is load-bearing here and was traced explicitly.
+ *
+ * 🔴 RETAINED deliberately — do NOT add these to the drop list:
+ *  - `tagIds`  — the hidden-prefs `case 'posts'` branch filters on it
+ *    (`useApplyHiddenPreferences`). It is the single largest per-image field
+ *    (~34 tag ids on average) and looks droppable, but removing it silently breaks
+ *    hidden-tag + system-hidden-tag moderation filtering for every gallery viewer.
+ *  - `createdAt` / `publishedAt` / `sortAt` / `blockedFor` / `model3dId` / `stats`
+ *    — read by the seeded `ImageDetail2` modal even though the card never reads them.
+ *  - `hideMeta` / `index` / `scannedAt` / `mimeType` / `postTitle` — these are ALSO
+ *    unread by every consumer, but they are NON-OPTIONAL on the modal's seed type
+ *    (`ImageGetInfinite` / `ImageV2Model`): the card seeds `data.images` straight
+ *    into `ImageDetailModal`, so dropping them fails typecheck at the seed site even
+ *    though `ImageDetail2` never reads them. Removing them would require loosening
+ *    the shared modal/`image.getInfinite` types (broad blast radius) — out of scope.
+ *    They stay; the bigger serialize win for this endpoint is the per-post image
+ *    cap (flag-gated, user-visible), not this trim.
+ *
+ * So this trim only drops the OPTIONAL unread fields — a modest, strictly
+ * zero-UX-risk reduction. The material lever is `IMAGES_AS_POSTS_PER_POST_CAP`.
+ */
+
+// The per-image keys dropped from the wire. Exported so the unit test can assert
+// the function drops EXACTLY this set (keeps the destructuring below in sync).
+// Only OPTIONAL-on-`ImageV2Model` fields — see the doc block above for why the
+// unread-but-required fields (hideMeta/index/scannedAt/mimeType/postTitle) stay.
+export const IMAGES_AS_POSTS_DROPPED_IMAGE_FIELDS = [
+  'meta',
+  'availability',
+  'acceptableMinor',
+  'baseModel',
+  'judgeScore',
+] as const;
+
+/**
+ * Return a shallow copy of `image` without the wire-dropped fields. Generic so it
+ * is type-safe across the DB/Meili result union (a key absent on one side is a
+ * no-op), and the narrowed `Omit<...>` return type makes tsc flag any future
+ * consumer that starts reading a dropped field. Does not mutate the input.
+ */
+export const stripImageForAsPostsWire = <T extends Record<string, unknown>>(image: T) => {
+  const { meta, availability, acceptableMinor, baseModel, judgeScore, ...rest } = image;
+  return rest;
+};
+
+/**
+ * Per-post image cap for `image.getImagesAsPostsInfinite` — the MATERIAL serialize
+ * lever. Model galleries carry genuinely multi-image showcase posts (measured on
+ * the DB: avg 4.7 imgs/post, p90 14, p99 20), so capping each post's embedded image
+ * list cuts a large fraction of serialized images (measured ~15% at cap 12, ~28% at
+ * cap 8 across a 30-day model-gallery sample).
+ *
+ * 🔴 USER-VISIBLE, so it is FLAG-GATED (off by default). Unlike the browse feed
+ * (`post.getInfinite`, whose card renders only `images[0]`), this card renders the
+ * FULL carousel AND seeds the detail modal from `data.images` WITHOUT refetch — so
+ * a cap hides a showcase post's tail images from both the carousel and the modal.
+ * Ship dark; ramp only after a product call on the carousel/modal truncation.
+ *
+ * Value chosen to match the `model.getAll` cap (12) — healthy carousel, ~15% cut.
+ */
+export const IMAGES_AS_POSTS_PER_POST_CAP = 12;
+
+/**
+ * Return `images` capped to the first `cap` (keeps leading order — cover stays
+ * `images[0]`). Returns the SAME array when already within the cap (no needless
+ * clone) and never mutates the input.
+ */
+export const capImagesPerPost = <T>(images: T[], cap = IMAGES_AS_POSTS_PER_POST_CAP): T[] =>
+  images.length > cap ? images.slice(0, cap) : images;


### PR DESCRIPTION
## Why

`image.getImagesAsPostsInfinite` is the **#2 producer of oversized tRPC responses** in the serialize-freeze arc (max ~2.65MB; ~245 oversized events/2h on the `#3017` instrument). Its response synchronously superjson-serializes each post's **full** per-image object; a page can carry ~1000 images and the walk over every field of every image is what freezes the Node event loop → 499/504 waves.

## Composition finding (measured, not guessed)

Measured on the `cnpg-cluster-dev` clone + a real superjson bench (repo's `superjson`):

- **No single blob dominates.** `meta` and `tags` are **not even fetched** on this path — the client sends no `include`, so effective include = `cosmetics/tagIds/profilePictures` → `meta: null`, `tags: undefined`. metadata avg **92B**, url/name/hash ~**34B** each.
- Cost is **field-COUNT** (~40 keys/image) + **4 Date meta-nodes** + **`tagIds`** (avg **34 ints/image**, p90 51 — the single largest field).
- Model galleries are genuinely multi-image: **avg 4.7 imgs/post, p90 14, p99 20, max 40** (19.7k recent posts). cap@12 → 14.9% fewer images, cap@8 → 27.8%.

## What I did — two levers

**1. Field trim (always-on, zero-UX-risk) — `stripImageForAsPostsWire`.** Drops per-image fields no consumer reads *and* that are optional on the modal seed type: `meta`, `availability`, `acceptableMinor`, `baseModel`, `judgeScore`. **Measured ~5.2%** payload cut (real superjson bench on a representative 167-image page).

**2. Per-post image cap (flag-gated DARK) — the material lever.** New feature flag `imagesAsPostsPerPostCap` (`availability: []`, Flipt `images-as-posts-per-post-cap`) caps each post to 12 images. **~15% fewer serialized images at 12/post, ~28% at 8.** OFF = byte-identical to today. `trim + cap@12` bench = **15.7% total**.

## Consumer-grep results (the #3055 lesson, applied hard)

I grepped **every** consumer of the result — the card (`ImagesAsPostsCard` + carousel), the shared context menu (`ImageMenuItems`/`ContextMenu`), the hidden-preferences `posts` branch, **and the image-detail modal seeded from the card** (`ImageDetail2`, which `ImageDetailProvider` renders from the SEEDED objects **without refetch**). Key retentions that look droppable but are NOT:

- 🔴 **`tagIds` RETAINED.** Biggest easy-looking win (~34 ints/image), but `useApplyHiddenPreferences` `case 'posts'` (L638) filters on it. Dropping it silently breaks **hidden-tag + system-hidden-tag moderation** for every gallery viewer. (My first pass nearly dropped it — the grep caught it; I verified the `posts` branch reads `tagIds` while the sibling `models` branch reads `tags`.)
- 🔴 **`postId` retained** — read by `ImageMenuItems` (Save/View/Edit/Toggle-Searchable) — the exact #3055 trap.
- 🔴 **`createdAt`/`publishedAt`/`sortAt`/`blockedFor`/`model3dId`/`stats` retained** — read by the seeded `ImageDetail2` modal even though the card never reads them.
- **Hidden-prefs `posts` branch** needs `{id, userId, nsfwLevel, poi, minor, tagIds}` per image — all retained.
- `hideMeta`/`index`/`scannedAt`/`mimeType`/`postTitle` are unread too, but **NON-OPTIONAL on the modal seed type** (`ImageGetInfinite`/`ImageV2Model`) — dropping them fails typecheck at the `data.images → ImageDetailModal` seed; loosening that shared type is out of scope. They stay (this is why the pure trim is only ~5%).

**Caller graph:** only `ImagesAsPostsInfinite` / `Model3DGallery` / warmup call this endpoint — all the same gallery feed.

## Why the cap is flag-gated (user-visible)

Unlike `post.getInfinite` (cover-only card, cap invisible), this card renders the **full carousel** AND seeds the detail modal from `data.images` **with no refetch**, so a cap hides a showcase post's tail images from **both** the carousel and the modal. That's a product call → DARK by default, ramp via the Flipt threshold only after review. Instant rollback = threshold 0.

## Blast radius

- Trim is a pure wire-shape change behind a **narrowed return type** — tsc flags any future consumer that starts reading a dropped field.
- Cap is **off by default** (fails closed / no cap when Flipt absent).
- Both run AFTER the per-post `index` sort and after post-level fields are read off `image`/`images[0]`; `getReactionTotals` + the Reactions/Comments/Collected sorts read `images[0].stats` (retained). **No change to the DB query.**

## Tests / checks

- `src/server/utils/__tests__/images-as-posts-wire.test.ts` (7 tests, pass): drop set exactness, load-bearing retentions (tagIds + modal-seed fields), cap (leading order preserved, non-mutation, custom cap).
- `pnpm typecheck`: clean for the changed files. (Remaining errors are pre-existing worktree `event-engine-common`/`kysely` submodule/module-resolution noise in files I didn't touch — resolve on the primary clone/CI.)

## Post-deploy verification (human)

`#3017`:
```
{namespace="civitai-dp-prod"} |= `trpc-response-oversized` | json | path=`image.getImagesAsPostsInfinite`
```
serializeMs/bytes tail should drop ~5% on merge (trim). Then ramp `images-as-posts-per-post-cap` (after confirming the new bundle is serving everywhere) for the material ~15% (12/post) — with a product call on the carousel/modal truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
