### PR TITLE
perf(engaged-models): delete legacy unbounded user.getEngagedModels endpoint

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2108,7 +2108,6 @@ export const REDIS_KEYS = {
 // we should probably be flipping all redis keys to have any dynamic keys come at the end
 export const REDIS_SUB_KEYS = {
   USER: {
-    MODEL_ENGAGEMENTS: 'model-engagements', // cache
     PRIVATE_ENTITY_ACCESS: 'private-entity-access', // cache
   },
   EVENT: {

--- a/src/components/Cards/ModelCard.browser.test.tsx
+++ b/src/components/Cards/ModelCard.browser.test.tsx
@@ -1,17 +1,16 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 
 // =============================================================================
-// ModelCard — feed review-indicator now reads batched membership, not the
-// unbounded `user.getEngagedModels` endpoint (PR3 of the engaged-feed arc).
+// ModelCard — feed review-indicator reads batched membership
+// (`useEngagedModelMembership`). The legacy unbounded `user.getEngagedModels`
+// endpoint it replaced was deleted in PR4, so there is no longer a symbol to
+// spy on for a negative regression guard.
 // =============================================================================
 //
 // What this test pins (the point of the migration):
 //   * `ModelCardStats` derives its "reviewed" indicator from
 //     `useEngagedModelMembership(id).isEngaged('Recommended')` — TRUE lights the
 //     success-colored thumb (`data-reviewed="true"`), FALSE the neutral one.
-//   * the legacy `trpc.user.getEngagedModels.useQuery` is NEVER called by the
-//     card — a regression guard against reverting to the unbounded read that
-//     drives the dp-prod event-loop-freeze.
 //
 // The card is a heavy feed leaf (~10 context/child deps). We render the REAL
 // `ModelCardContent` + `ModelCardStats` and BOUNDARY-STUB the heavy children so
@@ -29,18 +28,12 @@ const mocks = vi.hoisted(() => {
     isLoading: false,
     isKnown: true,
   }));
-  const getEngagedModelsUseQuery = vi.fn(() => ({ data: undefined }));
-  return { state, membershipMock, getEngagedModelsUseQuery };
+  return { state, membershipMock };
 });
 
 // --- controllable membership hook -------------------------------------------
 vi.mock('~/hooks/useEngagedModelMembership', () => ({
   useEngagedModelMembership: (id: number) => mocks.membershipMock(id),
-}));
-
-// --- legacy endpoint spy (must never fire) ----------------------------------
-vi.mock('~/utils/trpc', () => ({
-  trpc: { user: { getEngagedModels: { useQuery: mocks.getEngagedModelsUseQuery } } },
 }));
 
 // --- boundary stubs for heavy children --------------------------------------
@@ -129,22 +122,19 @@ describe('ModelCard review indicator (batched membership)', () => {
   beforeEach(() => {
     mocks.state.engaged = false;
     mocks.membershipMock.mockClear();
-    mocks.getEngagedModelsUseQuery.mockClear();
   });
 
   test('renders the reviewed indicator when the model is Recommended by the user', async () => {
     mocks.state.engaged = true;
     renderWithProviders(<ModelCard data={makeData()} />);
     expect(await reviewedAttr()).toBe('true');
-    // reads membership for THIS model id, never the unbounded endpoint
+    // reads batched membership for THIS model id
     expect(mocks.membershipMock).toHaveBeenCalledWith(123);
-    expect(mocks.getEngagedModelsUseQuery).not.toHaveBeenCalled();
   });
 
   test('does NOT mark reviewed when the model is not Recommended', async () => {
     mocks.state.engaged = false;
     renderWithProviders(<ModelCard data={makeData()} />);
     expect(await reviewedAttr()).toBe('false');
-    expect(mocks.getEngagedModelsUseQuery).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Model/Actions/ToggleModelNotification.tsx
+++ b/src/components/Model/Actions/ToggleModelNotification.tsx
@@ -18,7 +18,6 @@ export function ToggleModelNotification({
   ...actionIconProps
 }: ActionIconProps & { modelId: number; userId: number }) {
   const currentUser = useCurrentUser();
-  const queryUtils = trpc.useUtils();
 
   // PR2: per-visible-set membership for this single model (Notify/Mute).
   const { isEngaged: isModelEngaged, isKnown } = useEngagedModelMembership(modelId);
@@ -37,10 +36,6 @@ export function ToggleModelNotification({
       const snapshot = snapshotMembership(modelId);
       applyNotifyToggled(modelId, !isOn);
       return { snapshot };
-    },
-    async onSuccess() {
-      // Keep the legacy getEngagedModels cache in sync for still-on-old-endpoint feeds.
-      await queryUtils.user.getEngagedModels.invalidate();
     },
     onError(error, _vars, context) {
       if (context?.snapshot) restoreMembership(modelId, context.snapshot);

--- a/src/components/Model/Categories/ModelCategoryCard.browser.test.tsx
+++ b/src/components/Model/Categories/ModelCategoryCard.browser.test.tsx
@@ -1,8 +1,10 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 
 // =============================================================================
-// ModelCategoryCard — review indicator now reads batched membership, not the
-// unbounded `user.getEngagedModels` endpoint (PR3 of the engaged-feed arc).
+// ModelCategoryCard — review indicator reads batched membership
+// (`useEngagedModelMembership`). The legacy unbounded `user.getEngagedModels`
+// endpoint it replaced was deleted in PR4, so there is no longer a symbol to
+// spy on for a negative regression guard.
 // =============================================================================
 //
 // What this pins (the migration contract):
@@ -12,8 +14,6 @@ import { describe, expect, test, vi, beforeEach } from 'vitest';
 //     ThumbsIcon stub so the isEngaged -> hasReview -> ThumbsUpIcon wiring is
 //     directly observable.
 //   * membership is requested for THIS model id (not a whole-history read).
-//   * the legacy `trpc.user.getEngagedModels.useQuery` is NEVER called — the
-//     regression guard against reverting to the unbounded endpoint.
 //
 // We render the REAL exported `ModelCategoryCard`. To keep the mount tractable
 // we pass `images: []` (skips the ImageGuard/menu/EdgeMedia block entirely) and
@@ -31,18 +31,12 @@ const mocks = vi.hoisted(() => {
     isLoading: false,
     isKnown: true,
   }));
-  const getEngagedModelsUseQuery = vi.fn(() => ({ data: undefined }));
-  return { state, membershipMock, getEngagedModelsUseQuery };
+  return { state, membershipMock };
 });
 
 // --- controllable membership hook -------------------------------------------
 vi.mock('~/hooks/useEngagedModelMembership', () => ({
   useEngagedModelMembership: (id: number) => mocks.membershipMock(id),
-}));
-
-// --- legacy endpoint spy (must never fire) ----------------------------------
-vi.mock('~/utils/trpc', () => ({
-  trpc: { user: { getEngagedModels: { useQuery: mocks.getEngagedModelsUseQuery } } },
 }));
 
 // --- context hooks ----------------------------------------------------------
@@ -120,7 +114,6 @@ describe('ModelCategoryCard review indicator (batched membership)', () => {
   beforeEach(() => {
     mocks.state.engaged = false;
     mocks.membershipMock.mockClear();
-    mocks.getEngagedModelsUseQuery.mockClear();
   });
 
   test('fills the review thumb when the model is Recommended by the user', async () => {
@@ -128,13 +121,11 @@ describe('ModelCategoryCard review indicator (batched membership)', () => {
     renderWithProviders(<ModelCategoryCard data={makeData()} height={300} />);
     expect(await thumbsFilled()).toBe('true');
     expect(mocks.membershipMock).toHaveBeenCalledWith(321);
-    expect(mocks.getEngagedModelsUseQuery).not.toHaveBeenCalled();
   });
 
   test('leaves the thumb unfilled when the model is not Recommended', async () => {
     mocks.state.engaged = false;
     renderWithProviders(<ModelCategoryCard data={makeData()} height={300} />);
     expect(await thumbsFilled()).toBe('false');
-    expect(mocks.getEngagedModelsUseQuery).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -363,10 +363,6 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
       applyNotifyToggled(model.id, !isNotificationOn);
       return { snapshot };
     },
-    async onSuccess() {
-      // Keep the legacy getEngagedModels cache in sync for still-on-old-endpoint feeds.
-      await queryUtils.user.getEngagedModels.invalidate();
-    },
     onError(error, _vars, context) {
       if (context?.snapshot) restoreMembership(model.id, context.snapshot);
       showErrorNotification({ title: 'Failed to update notification settings', error });

--- a/src/components/ResourceReview/resourceReview.utils.ts
+++ b/src/components/ResourceReview/resourceReview.utils.ts
@@ -11,7 +11,7 @@ import type {
 } from '~/server/schema/resourceReview.schema';
 import type { ResourceReviewPaged, ResourceReviewRatingTotals } from '~/types/router';
 import { queryClient, trpc } from '~/utils/trpc';
-import { restoreMembership, snapshotMembership } from '~/store/engaged-models.store';
+import { isModelEngaged, restoreMembership, snapshotMembership } from '~/store/engaged-models.store';
 import {
   applyFavoriteToggled,
   applyReviewCreated,
@@ -35,41 +35,14 @@ export const useCreateResourceReview = () => {
         return { ...old, down: old.down + 1 };
       });
 
-      const previousEngaged = queryUtils.user.getEngagedModels.getData() ?? {
-        Recommended: [] as number[],
-      };
-      const shouldRemove =
-        !recommended || (previousEngaged.Recommended?.includes(modelId) ?? false);
-
-      queryUtils.user.getEngagedModels.setData(undefined, (old) => {
-        if (!old) return;
-
-        const { Recommended = [], Notify = [], ...rest } = old;
-        if (shouldRemove) {
-          return {
-            Recommended: Recommended.filter((id) => id !== modelId),
-            Notify: Notify.filter((id) => id !== modelId),
-            ...rest,
-          };
-        }
-
-        return { Recommended: [...Recommended, modelId], Notify: [...Notify, modelId], ...rest };
-      });
-
-      // Normalized store (PR2): mirror the same Recommended+Notify toggle for the
-      // per-visible-set surfaces. Dual-written alongside the getEngagedModels cache
-      // above until the feed callers migrate (PR3) and the old endpoint is dropped (PR4).
-      // F3: derive the direction from the SAME `previousEngaged.Recommended` snapshot
-      // the legacy setData above consumed — deliberately NOT the normalized store.
-      // Passing the one shared snapshot keeps the two dual-writes CONSISTENT with each
-      // other (the Preserve invariant). PR3 removed this page's own getEngagedModels
-      // query, so on a directly-loaded model page that legacy cache is cold and this
-      // reads false; both writes then agree (both add), so they never diverge. Accepted
-      // narrow edge: re-affirming an ALREADY-recommended model won't toggle it off until
-      // a feed has warmed the cache. Sourcing direction from the store instead would warm
-      // this case but split the two writes' direction (store warm / legacy cold) — a
-      // worse divergence bug — so we keep the shared-snapshot source.
-      applyReviewCreated(modelId, recommended, previousEngaged.Recommended?.includes(modelId) ?? false);
+      // Engaged-models store (single source since PR4 dropped the legacy
+      // user.getEngagedModels cache). Re-source the re-affirm DIRECTION bit from the
+      // store's membership snapshot (read BEFORE the mutator applies).
+      // F3 accepted cold-read edge: on a directly-loaded model page no feed has warmed
+      // membership, so the store reads not-recommended and re-affirming an
+      // ALREADY-recommended model adds instead of toggling it off until a feed warms it.
+      const alreadyRecommended = isModelEngaged(modelId, 'Recommended');
+      applyReviewCreated(modelId, recommended, alreadyRecommended);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
         if (!old) return;
@@ -160,38 +133,20 @@ export const useUpdateResourceReview = () => {
         await queryUtils.resourceReview.getPaged.invalidate();
       }
 
-      await queryUtils.user.getEngagedModels.cancel();
-
-      // Update model engagements
-      const previousEngaged = queryUtils.user.getEngagedModels.getData() ?? {
-        Recommended: [] as number[],
-        Notify: [] as number[],
-      };
-      const alreadyNotified = previousEngaged.Notify?.indexOf(modelId) ?? -1;
-      const alreadyReviewed = previousEngaged.Recommended?.indexOf(modelId) ?? -1;
-      const shouldRemove = !request.recommended || alreadyReviewed > -1;
-      // Remove from recommended list
-      queryUtils.user.getEngagedModels.setData(undefined, (old) => {
-        if (!old) return;
-
-        const { Recommended = [], ...rest } = old;
-        if (shouldRemove)
-          return { Recommended: Recommended.filter((id) => id !== modelId), ...rest };
-        return { Recommended: [...Recommended, modelId], ...rest };
-      });
-
-      // Normalized store (PR2): mirror the Recommended toggle for per-visible-set surfaces.
-      // F3: direction from the SAME `previousEngaged` snapshot the legacy setData used
-      // (not the store), so both dual-writes stay consistent. See the create handler for
-      // the accepted cold-cache edge (this page's getEngagedModels query was removed in PR3).
-      applyReviewUpdated(modelId, request.recommended, alreadyReviewed > -1);
+      // Model engagements — re-source the pre-toggle membership bits from the
+      // engaged-models store (single source since PR4 dropped the legacy cache). Read
+      // BEFORE the mutator applies; `alreadyNotified` also drives the getById collected-
+      // count math below. See the create handler for the accepted F3 cold-read edge.
+      const alreadyNotified = isModelEngaged(modelId, 'Notify');
+      const alreadyReviewed = isModelEngaged(modelId, 'Recommended');
+      applyReviewUpdated(modelId, request.recommended, alreadyReviewed);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
         if (!old) return;
 
         if (request.recommended === true) {
           old.rank.thumbsUpCountAllTime += 1;
-          if (alreadyNotified === -1) old.rank.collectedCountAllTime += 1;
+          if (!alreadyNotified) old.rank.collectedCountAllTime += 1;
           if (old.rank.thumbsDownCountAllTime > 0) old.rank.thumbsDownCountAllTime -= 1;
 
           if (modelVersionId) {
@@ -247,19 +202,8 @@ export const useDeleteResourceReview = () => {
         })
       );
 
-      // Update engaged models
-      queryUtils.user.getEngagedModels.setData(undefined, (old) => {
-        if (!old) return;
-
-        const { Recommended = [], Notify = [], ...rest } = old;
-        return {
-          Recommended: Recommended.filter((id) => id !== modelId),
-          Notify: Notify.filter((id) => id !== modelId),
-          ...rest,
-        };
-      });
-
-      // Normalized store (PR2): mirror the Recommended+Notify removal for per-visible-set surfaces.
+      // Update engaged models — remove Recommended + Notify in the engaged-models store
+      // (single source since PR4 dropped the legacy user.getEngagedModels cache).
       applyReviewDeleted(modelId);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
@@ -339,7 +283,6 @@ export function useToggleFavoriteMutation() {
 
   const mutation = trpc.user.toggleFavorite.useMutation({
     onMutate: async ({ modelId, modelVersionId, setTo }) => {
-      const engagedModels = queryUtils.user.getEngagedModels.getData();
       const bookmarkedModels = queryUtils.user.getBookmarkedModels.getData();
       const modelDetails = queryUtils.model.getById.getData({ id: modelId });
       // Normalized store (PR2): snapshot for rollback, then apply the same toggle.
@@ -356,33 +299,23 @@ export function useToggleFavoriteMutation() {
         }
       });
 
-      // Update model engagements
-      const alreadyNotified = engagedModels?.Notify?.indexOf(modelId) ?? -1;
-      const alreadyReviewed = engagedModels?.Recommended?.indexOf(modelId) ?? -1;
-      queryUtils.user.getEngagedModels.setData(undefined, (old) => {
-        if (!old) return;
-        if (setTo) {
-          if (alreadyNotified === -1) old.Notify = [...(old.Notify ?? []), modelId];
-          if (alreadyReviewed === -1) old.Recommended = [...(old.Recommended ?? []), modelId];
-        } else {
-          // We don't want to remove from notify on favorite toggle
-          // if (alreadyNotified !== -1) old.Notify = old.Notify.filter((id) => id !== modelId);
-          if (alreadyReviewed !== -1)
-            old.Recommended = old.Recommended.filter((id) => id !== modelId);
-        }
-        return old;
-      });
+      // Update model engagements — re-source the pre-toggle membership bits from the
+      // engaged-models store (single source since PR4 dropped the legacy cache). Read
+      // BEFORE the mutator applies; both drive the getById optimistic count math below.
+      // See the create handler for the accepted F3 cold-read edge.
+      const alreadyNotified = isModelEngaged(modelId, 'Notify');
+      const alreadyReviewed = isModelEngaged(modelId, 'Recommended');
 
-      // Normalized store (PR2): mirror the favorite toggle for per-visible-set surfaces.
+      // Mirror the favorite toggle into the engaged-models store.
       applyFavoriteToggled(modelId, setTo);
 
       // Update model details
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
         if (!old) return;
-        if (setTo && alreadyReviewed === -1) {
+        if (setTo && !alreadyReviewed) {
           old.rank.thumbsUpCountAllTime += 1;
-          if (alreadyNotified === -1) old.rank.collectedCountAllTime += 1;
-        } else if (!setTo && alreadyReviewed !== -1) {
+          if (!alreadyNotified) old.rank.collectedCountAllTime += 1;
+        } else if (!setTo && alreadyReviewed) {
           old.rank.thumbsUpCountAllTime -= 1;
           // We don't want to remove from collected on favorite toggle
           // old.rank.collectedCountAllTime -= 1;
@@ -442,13 +375,12 @@ export function useToggleFavoriteMutation() {
         }
       });
 
-      return { prevData: { engagedModels, modelDetails, userReviews, bookmarkedModels }, engagedMembership };
+      return { prevData: { modelDetails, userReviews, bookmarkedModels }, engagedMembership };
     },
     onError: (error, { modelId }, context) => {
-      queryUtils.user.getEngagedModels.setData(undefined, context?.prevData?.engagedModels);
       queryUtils.user.getBookmarkedModels.setData(undefined, context?.prevData?.bookmarkedModels);
       queryUtils.model.getById.setData({ id: modelId }, context?.prevData?.modelDetails);
-      // Normalized store (PR2): restore the snapshotted membership.
+      // Restore the snapshotted engaged-models membership on rollback.
       if (context?.engagedMembership) restoreMembership(modelId, context.engagedMembership);
     },
     onSettled: async (result, error, { modelId }) => {

--- a/src/server/controllers/resourceReview.controller.ts
+++ b/src/server/controllers/resourceReview.controller.ts
@@ -1,6 +1,5 @@
 import type { ProtectedContext } from '~/server/createContext';
 import { dbRead } from '~/server/db/client';
-import { redis, REDIS_KEYS, REDIS_SUB_KEYS } from '~/server/redis/client';
 import type { GetByIdInput } from '~/server/schema/base.schema';
 import type { GetByUsernameSchema } from '~/server/schema/user.schema';
 import {
@@ -75,9 +74,6 @@ export const createResourceReviewHandler = async ({
       rating: result.recommended ? 5 : 1,
       nsfw: false,
     });
-    await redis.del(
-      `${REDIS_KEYS.USER.BASE}:${ctx.user.id}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`
-    );
     return result;
   } catch (error) {
     throw throwDbError(error);
@@ -100,9 +96,6 @@ export const updateResourceReviewHandler = async ({
       rating: result.rating,
       nsfw: result.nsfw,
     });
-    await redis.del(
-      `${REDIS_KEYS.USER.BASE}:${ctx.user.id}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`
-    );
     return result;
   } catch (error) {
     throw throwDbError(error);

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -16,7 +16,6 @@ import { getStaticContent } from '~/server/services/content.service';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { onboardingCompletedCounter, onboardingErrorCounter } from '~/server/prom/client';
 import { getUserFollows } from '~/server/redis/caches';
-import { redis, REDIS_KEYS, REDIS_SUB_KEYS } from '~/server/redis/client';
 import * as rewards from '~/server/rewards';
 import { firstDailyFollowReward } from '~/server/rewards/active/firstDailyFollow.reward';
 import type { GetAllSchema, GetByIdInput } from '~/server/schema/base.schema';
@@ -55,10 +54,7 @@ import type {
 } from '~/server/selectors/cosmetic.selector';
 import { simpleUserSelect } from '~/server/selectors/user.selector';
 import { getUserNotificationCount } from '~/server/services/notification.service';
-import {
-  getResourceReviewsByUserId,
-  getUserResourceReview,
-} from '~/server/services/resourceReview.service';
+import { getUserResourceReview } from '~/server/services/resourceReview.service';
 import {
   createCustomer,
   deleteCustomerPaymentMethod,
@@ -82,7 +78,6 @@ import {
   getUserCosmetics,
   getUserCreator,
   getUserDownloadedModelVersions,
-  getUserEngagedModels,
   getUserEngagedModelsByIds,
   getUserEngagedModelVersions,
   getUserList,
@@ -630,46 +625,8 @@ export const restoreUserHandler = async ({
   }
 };
 
-type EngagedModelType = ModelEngagementType | 'Recommended';
-
-export const getUserEngagedModelsHandler = async ({ ctx }: { ctx: ProtectedContext }) => {
-  const { id } = ctx.user;
-
-  try {
-    const engagementsCache = await redis.get(
-      `${REDIS_KEYS.USER.BASE}:${id}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`
-    );
-    if (engagementsCache) return JSON.parse(engagementsCache) as Record<EngagedModelType, number[]>;
-
-    const engagements = await getUserEngagedModels({ id });
-    const recommendedReviews = await getResourceReviewsByUserId({ userId: id, recommended: true });
-
-    // turn array of user.engagedModels into object with `type` as key and array of modelId as value
-    const engagedModels = engagements.reduce<Record<EngagedModelType, number[]>>((acc, model) => {
-      const { type, modelId } = model;
-      if (!acc[type]) acc[type] = [];
-      acc[type].push(modelId);
-      return acc;
-    }, {} as Record<EngagedModelType, number[]>);
-    engagedModels.Recommended = recommendedReviews.map((r) => r.modelId).filter(isDefined);
-
-    await redis.set(
-      `${REDIS_KEYS.USER.BASE}:${id}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`,
-      JSON.stringify(engagedModels),
-      {
-        EX: 60 * 60 * 24,
-      }
-    );
-
-    return engagedModels;
-  } catch (error) {
-    if (error instanceof TRPCError) throw error;
-    throw throwDbError(error);
-  }
-};
-
-// Additive, per-visible-set counterpart to `getUserEngagedModelsHandler`. Bounded input →
-// bounded response, so (unlike the whole-history handler above) there is no cache: the tiny,
+// Per-visible-set membership handler. Bounded input →
+// bounded response, so there is no cache: the tiny,
 // index-scannable payload isn't worth the combinatorial keyspace + bust-site sprawl.
 export const getUserEngagedModelsByIdsHandler = async ({
   input,
@@ -919,7 +876,6 @@ export const toggleHideModelHandler = async ({
         modelId: input.modelId,
       });
     }
-    await redis.del(`${REDIS_KEYS.USER.BASE}:${userId}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`);
   } catch (error) {
     throw throwDbError(error);
   }
@@ -975,8 +931,6 @@ export async function toggleFavoriteHandler({
       });
   }
 
-  await redis.del(`${REDIS_KEYS.USER.BASE}:${userId}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`);
-
   return reviewResult;
 }
 
@@ -1009,7 +963,6 @@ export const toggleNotifyModelHandler = async ({
         modelId: input.modelId,
       });
     }
-    await redis.del(`${REDIS_KEYS.USER.BASE}:${userId}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`);
 
     return result;
   } catch (error) {

--- a/src/server/routers/user.router.ts
+++ b/src/server/routers/user.router.ts
@@ -16,7 +16,6 @@ import {
   getUserByIdHandler,
   getUserCosmeticsHandler,
   getUserCreatorHandler,
-  getUserEngagedModelsHandler,
   getUserEngagedModelsByIdsHandler,
   getUserEngagedModelVersionsHandler,
   getUserFeatureFlagsHandler,
@@ -143,9 +142,6 @@ export const userRouter = router({
   getSelfStatus: protectedProcedure
     .meta({ requiredScope: TokenScope.UserRead })
     .query(getSelfStatusHandler),
-  getEngagedModels: protectedProcedure
-    .meta({ requiredScope: TokenScope.UserRead })
-    .query(getUserEngagedModelsHandler),
   getEngagedModelsByIds: protectedProcedure
     .meta({ requiredScope: TokenScope.UserRead })
     .input(getEngagedModelsByIdsSchema)

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -595,20 +595,14 @@ export const updateUserById = async ({
   return user;
 };
 
-export const getUserEngagedModels = ({ id, type }: { id: number; type?: ModelEngagementType }) => {
-  return dbRead.modelEngagement.findMany({
-    where: { userId: id, type },
-    select: { modelId: true, type: true },
-  });
-};
-
 export type EngagedModelType = ModelEngagementType | 'Recommended';
 
 /**
  * Per-visible-set engagement membership: given a bounded set of `modelIds`, return which of
- * them the user has engaged with, keyed by engagement type. The additive, index-bounded
- * replacement for `getUserEngagedModels` (whose caller returns a user's ENTIRE engagement
- * history — a whale's 3.75 MB / 482 ms synchronous serialize froze an api-primary pod).
+ * them the user has engaged with, keyed by engagement type. The index-bounded membership
+ * primitive that replaced the removed whole-history `getUserEngagedModels` (whose caller
+ * returned a user's ENTIRE engagement history — a whale's 3.75 MB / 482 ms synchronous
+ * serialize froze an api-primary pod).
  *
  * Every returned array is a subset of the input `modelIds` (the intersection of the user's
  * engagements ∩ input), so the response is bounded by |modelIds| × (#types) — no cache needed.

--- a/src/store/__tests__/engaged-models.optimistic.test.ts
+++ b/src/store/__tests__/engaged-models.optimistic.test.ts
@@ -75,22 +75,20 @@ describe('optimistic — update review', () => {
   });
 });
 
-// F3: the toggle DIRECTION must come from the caller-supplied `alreadyRecommended`
-// (the warm legacy snapshot), NOT the normalized store — which can be cold for
-// this model while a by-ids fetch is in flight and would otherwise flip intent.
-describe('optimistic — create/update derive direction from the caller, not the (cold) store', () => {
-  it('create: cold store (unknown) + alreadyRecommended=false → ADDS (does not read store)', () => {
-    // Store has NO knowledge of model 1 (never seeded) — the legacy self-branch
-    // would read not-recommended and add; here we prove the param drives it.
+// The toggle DIRECTION is a caller-supplied param, decoupled from whatever the
+// store holds when the mutator runs. The caller (resourceReview.utils.ts) now
+// reads that bit from the store's PRE-toggle membership via isModelEngaged
+// (PR4 removed the legacy getEngagedModels cache that used to supply it). These
+// cases pin that the mutator honors the param even when the store disagrees.
+describe('optimistic — create/update honor the caller-supplied direction param', () => {
+  it('create: alreadyRecommended=false → ADDS regardless of store state', () => {
     applyReviewCreated(1, true, false);
     expect(types(1)).toEqual(['Notify', 'Recommended']);
   });
 
-  it('create: cold store but caller says alreadyRecommended=true → REMOVES', () => {
-    // The store is cold (reads not-recommended) yet the warm snapshot knows the
-    // user already recommended → direction must be "remove", not "add".
+  it('create: alreadyRecommended=true → REMOVES (re-affirm toggles off)', () => {
     applyReviewCreated(1, true, true);
-    expect(types(1)).toEqual([]); // toggled off despite the cold store
+    expect(types(1)).toEqual([]); // toggled off
   });
 
   it('update: store says Recommended but caller says alreadyRecommended=false → ADDS (param wins)', () => {
@@ -102,6 +100,49 @@ describe('optimistic — create/update derive direction from the caller, not the
   it('update: store cold but caller says alreadyRecommended=true → REMOVES (param wins)', () => {
     applyReviewUpdated(1, true, true);
     expect(types(1)).toEqual([]); // removed despite the cold store
+  });
+});
+
+// PR4: the caller (resourceReview.utils.ts) now derives the "already engaged" bits
+// from the store's PRE-toggle membership via isModelEngaged, replacing the reads it
+// used to make against the deleted user.getEngagedModels React-Query cache. These
+// pin the exact SOURCE→direction seam: read isModelEngaged BEFORE the mutator, then
+// feed it in. The getById optimistic count math (thumbsUp/collected ±1) branches on
+// these same booleans, so their correctness is what guards the double-count risk.
+describe('optimistic — direction/count bits re-sourced from the store (PR4 caller seam)', () => {
+  it('create: re-affirming an ALREADY-recommended model does NOT double-add (toggles off)', () => {
+    seed(7, ['Recommended', 'Notify']);
+    // caller reads the pre-toggle bit exactly as resourceReview.utils.ts does
+    const alreadyRecommended = isModelEngaged(7, 'Recommended');
+    expect(alreadyRecommended).toBe(true);
+    applyReviewCreated(7, true, alreadyRecommended);
+    expect(types(7)).toEqual([]); // re-affirm path removes, no duplicate membership
+  });
+
+  it('create: warm store not-recommended → ADDS (re-source reads false)', () => {
+    seed(7, ['Mute']); // known to store but not Recommended
+    const alreadyRecommended = isModelEngaged(7, 'Recommended');
+    expect(alreadyRecommended).toBe(false);
+    applyReviewCreated(7, true, alreadyRecommended);
+    expect(types(7)).toEqual(['Mute', 'Notify', 'Recommended']);
+  });
+
+  it('favorite: alreadyReviewed/alreadyNotified bits match seeded membership (drive getById ±1)', () => {
+    // The favorite path gates thumbsUp += 1 on !alreadyReviewed and collected += 1 on
+    // !alreadyNotified. Prove the re-sourced booleans reflect the store truthfully so
+    // the count deltas fire exactly once.
+    seed(7, ['Recommended']); // reviewed, NOT notified
+    expect(isModelEngaged(7, 'Recommended')).toBe(true); // → thumbsUp delta suppressed
+    expect(isModelEngaged(7, 'Notify')).toBe(false); //     → collected delta would fire
+    applyFavoriteToggled(7, true);
+    expect(types(7)).toEqual(['Notify', 'Recommended']);
+  });
+
+  it('update: alreadyReviewed re-sourced from store drives the toggle-off direction', () => {
+    seed(7, ['Recommended', 'Notify']);
+    const alreadyReviewed = isModelEngaged(7, 'Recommended');
+    applyReviewUpdated(7, true, alreadyReviewed);
+    expect(types(7)).toEqual(['Notify']); // Recommended toggled off, Notify untouched
   });
 });
 

--- a/src/store/engaged-models.optimistic.ts
+++ b/src/store/engaged-models.optimistic.ts
@@ -2,10 +2,10 @@ import { useEngagedModelsStore } from '~/store/engaged-models.store';
 
 /**
  * Semantic optimistic mutators for the engaged-models store, one per user
- * action. Each mirrors — EXACTLY — the engagement-type bookkeeping the legacy
- * React-Query `user.getEngagedModels.setData(undefined, …)` handlers performed
- * in `resourceReview.utils.ts`, so the migrated (per-visible-set) surfaces stay
- * behaviourally identical to the still-on-old-endpoint feed surfaces.
+ * action. Each performs the engagement-type bookkeeping that the removed
+ * React-Query `user.getEngagedModels.setData(undefined, …)` handlers in
+ * `resourceReview.utils.ts` used to do — the store is now the single source for
+ * per-visible-set engagement membership (PR4 deleted the legacy endpoint + cache).
  *
  * Notes on the (non-obvious) current semantics these preserve:
  *   - A "favorite"/"like" on the client IS a `Recommended` resource review — the
@@ -24,10 +24,11 @@ const store = () => useEngagedModelsStore.getState();
  * resourceReview.create — toggles `Recommended` + `Notify` together.
  *
  * F3: the toggle DIRECTION (`shouldRemove`) is derived from `alreadyRecommended`
- * supplied by the caller — the reliable, warm `previousEngaged.Recommended`
- * React-Query snapshot — NOT from the normalized store, which may be cold for
- * this model (mid by-ids fetch) and would then read as not-recommended and flip
- * the direction. This keeps exact parity with the legacy dual-write.
+ * supplied by the caller, which now reads the store's pre-toggle membership via
+ * `isModelEngaged(modelId, 'Recommended')`. Accepted cold-read edge: on a
+ * directly-loaded model page no feed has warmed membership, so the store reads
+ * not-recommended and re-affirming an ALREADY-recommended model adds instead of
+ * toggling it off until a feed warms the model's membership.
  */
 export function applyReviewCreated(
   modelId: number,
@@ -41,7 +42,8 @@ export function applyReviewCreated(
 
 /**
  * resourceReview.update — toggles `Recommended` only. Direction comes from the
- * caller's `alreadyRecommended` (see `applyReviewCreated`), not the cold store.
+ * caller's `alreadyRecommended` (see `applyReviewCreated`), read from the store's
+ * pre-toggle membership; same accepted cold-read edge applies.
  */
 export function applyReviewUpdated(
   modelId: number,


### PR DESCRIPTION
Final PR of the tRPC-serialize event-loop-freeze arc. Removes the unbounded whole-history `user.getEngagedModels` tRPC endpoint now that every reader was migrated to the bounded `getEngagedModelsByIds` store/hook (#3028/#3034/#3056). The legacy handler synchronously serialized a user's ENTIRE engagement history (a whale's ~3.75 MB / ~482 ms serialize froze an api-primary pod's event loop).

## Server — endpoint chain deleted
- `user.router.ts`: removed the `getEngagedModels` procedure (kept `getEngagedModelsByIds` + `getEngagedModelVersions`).
- `user.controller.ts`: deleted `getUserEngagedModelsHandler` + its local `EngagedModelType`; dropped the now-unused `getUserEngagedModels` / `getResourceReviewsByUserId` imports and the whole `redis`/`REDIS_KEYS`/`REDIS_SUB_KEYS` import (grep-verified no other redis usage).
- `user.service.ts`: deleted the `getUserEngagedModels` service fn (kept `getUserEngagedModelsByIds` + the exported `EngagedModelType`).
- Removed the 24h Redis cache and **5 `MODEL_ENGAGEMENTS` bust sites** — 3 in `user.controller.ts` (toggleHideModel / toggleFavorite / toggleNotifyModel) and 2 in `resourceReview.controller.ts` (create / update); its import removed there too.
- `packages/civitai-redis`: removed the now-zero-ref `REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS` constant.

## Client — dead cache-maintenance stripped, 3 readers re-sourced
Every `queryUtils.user.getEngagedModels.*` call is gone. Pure cache-warming `invalidate()`/`setData()` deleted (`ModelVersionDetails.tsx`, `ToggleModelNotification.tsx`, and the create/update/delete/favorite paths in `resourceReview.utils.ts`). Three `getData()` calls were **readers-for-logic**, not warming — those direction/count bits are now re-sourced from the engaged-models store's synchronous `isModelEngaged(modelId, type)` (read pre-toggle):
- **create**: `alreadyRecommended` → drives the re-affirm direction into `applyReviewCreated`.
- **update**: `alreadyReviewed` (direction) + `alreadyNotified` (drives the `model.getById` collectedCount ±1).
- **favorite**: `alreadyReviewed`/`alreadyNotified` drive the `model.getById` thumbsUp/collected ±1 math; `context.prevData.engagedModels` + its onError rollback removed (the store snapshot/restore already covers rollback).

**Documented F3 cold-read edge preserved:** on a directly-loaded model page no feed has warmed membership, so the store can read not-recommended and a re-affirm adds instead of toggling off until a feed warms it. This was already the accepted behavior; comments updated to describe the store-sourced reality.

## Tests
- The two card browser tests (`ModelCard` / `ModelCategoryCard`) mocked `trpc.user.getEngagedModels.useQuery` and asserted `not.toHaveBeenCalled()` — now vacuous since the symbol is gone. Removed the spy + negative assertions (and the no-longer-needed `~/utils/trpc` mock); kept the positive `useEngagedModelMembership` render assertions.
- Added optimistic-store coverage (`engaged-models.optimistic.test.ts`) for the re-sourced seam: read `isModelEngaged` pre-toggle → feed the mutator, proving re-affirm does not double-add and the `alreadyReviewed`/`alreadyNotified` bits reflect the seeded store truthfully.

## Validation (no PR CI in this repo — typecheck is the gate)
- `tsc --noEmit`: only the 17 known pre-existing/environmental errors (kysely + the `event-engine-common` submodule not checked out + 3 `image.service.ts` implicit-any cascades). **Zero new errors; none reference the touched files.**
- Unit + component tests green: optimistic (31) + store (13) + membership + by-ids schema tests pass; both card browser tests pass. (The `get-engaged-models-by-ids.service.test.ts` fails to load only on the missing `kysely` package — pre-existing/environmental, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)