### PR TITLE
feat(gallery): lazy-load per-post images — small feed slice + on-demand tail (cuts serialize, no truncation)

### DIFF
--- a/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
@@ -1,8 +1,10 @@
 import type { ThemeIconProps } from '@mantine/core';
 import {
   Badge,
+  Center,
   getPrimaryShade,
   HoverCard,
+  Loader,
   Paper,
   Text,
   ThemeIcon,
@@ -20,7 +22,7 @@ import {
   IconPinFilled,
   IconUserPlus,
 } from '@tabler/icons-react';
-import { memo, useMemo } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import HoverActionButton from '~/components/Cards/components/HoverActionButton';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import { RoutedDialogLink } from '~/components/Dialog/RoutedDialogLink';
@@ -44,6 +46,10 @@ import { generationGraphPanel } from '~/store/generation-graph.store';
 import { useTrackEvent } from '~/components/TrackView/track.utils';
 import { isDefined } from '~/utils/type-guards';
 import { SimpleImageCarousel } from '~/components/SimpleImageCarousel/SimpleImageCarousel';
+import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { mergePostImages, shouldFetchPostTail } from '~/components/Image/AsPosts/lazyPostImages';
+import { POST_IMAGE_LIMIT } from '~/server/common/constants';
+import { trpc } from '~/utils/trpc';
 import classes from './ImagesAsPostsCard.module.css';
 import clsx from 'clsx';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -362,104 +368,265 @@ function ImagesAsPostsCardContent({ data }: { data: ImagesAsPostModel }) {
         </>
       )}
     </ImageGuard2>
+  ) : features.galleryLazyPostImages &&
+    data.imageCount != null &&
+    data.imageCount > data.images.length ? (
+    // LAZY: server sent a first slice + the true `imageCount`; load the tail on
+    // approach so the initial feed payload stays small without truncating the UX.
+    <LazyPostImagesCarousel data={data} postId={postId} />
   ) : (
-    <SimpleImageCarousel loop total={data.images.length} className="flex h-full flex-col">
+    // Today's behaviour (flag OFF, or a post already within the slice): all images
+    // are inline — render them directly, no lazy fetch.
+    <StaticPostImagesCarousel images={data.images} postId={postId} />
+  );
+}
+
+const carouselIndicatorProps = {
+  className: 'flex w-full gap-px',
+  indicatorClassName:
+    'h-2 flex-1 bg-white opacity-60 shadow-sm data-[active]:opacity-100',
+} as const;
+
+/**
+ * One carousel slide's content (blur guard, remix, image, reactions, meta). Shared
+ * by the static and lazy carousels so an appended (lazily-fetched) image renders
+ * byte-identically to a seeded one. `dialogImages` seeds the detail modal with the
+ * carousel's currently-loaded set.
+ */
+function PostCarouselSlide({
+  image,
+  postId,
+  dialogImages,
+}: {
+  image: ImagesAsPostModel['images'][number];
+  postId: number;
+  dialogImages: ImagesAsPostModel['images'];
+}) {
+  const features = useFeatureFlags();
+  const { trackAction } = useTrackEvent();
+  const handleRemixClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    trackAction({
+      type: 'Image_Remix_Click',
+      details: { imageId: image.id, imageType: image.type, source: 'remix:model-gallery' },
+    }).catch(() => undefined);
+    generationGraphPanel.open({ type: image.type, id: image.id });
+  };
+
+  return (
+    <ImageGuard2 image={image} connectType="post" connectId={postId}>
+      {(safe) => (
+        <>
+          {image.onSite && <OnsiteIndicator isRemix={!!image.remixOfId} />}
+          <ImageGuard2.BlurToggle className="absolute left-2 top-2 z-10" />
+          {safe && (
+            <div className="absolute right-2 top-2 z-10 flex flex-col gap-2">
+              <ImagesAsPostsContextMenu image={image} />
+              {features.imageGeneration && (image.hasPositivePrompt ?? image.hasMeta) && (
+                <HoverActionButton
+                  label="Remix"
+                  size={30}
+                  color="white"
+                  variant="filled"
+                  data-activity="remix:model-gallery"
+                  onClick={handleRemixClick}
+                >
+                  <IconBrush stroke={2.5} size={16} />
+                </HoverActionButton>
+              )}
+            </div>
+          )}
+          <RoutedDialogLink
+            name="imageDetail"
+            state={{ imageId: image.id }}
+            getState={() => ({ imageId: image.id, images: dialogImages })}
+            className={classes.link}
+          >
+            <>
+              <MediaHash {...image} className="opacity-70" />
+
+              {safe && (
+                <EdgeMedia2
+                  metadata={image.metadata}
+                  src={image.url}
+                  thumbnailUrl={image.thumbnailUrl}
+                  name={image.name ?? image.id.toString()}
+                  alt={image.name ?? undefined}
+                  type={image.type}
+                  imageId={image.id}
+                  width={450}
+                  placeholder="empty"
+                  wrapperProps={edgeMediaWrapperProps}
+                  skip={getSkipValue(image)}
+                  className="z-[1] object-cover"
+                />
+              )}
+            </>
+          </RoutedDialogLink>
+          <Reactions
+            entityId={image.id}
+            entityType="image"
+            reactions={image.reactions}
+            metrics={{
+              likeCount: image.stats?.likeCountAllTime,
+              dislikeCount: image.stats?.dislikeCountAllTime,
+              heartCount: image.stats?.heartCountAllTime,
+              laughCount: image.stats?.laughCountAllTime,
+              cryCount: image.stats?.cryCountAllTime,
+              tippedAmountCount: image.stats?.tippedAmountCountAllTime,
+            }}
+            readonly={!safe}
+            className={classes.reactions}
+            targetUserId={image.user.id}
+            disableBuzzTip={image.poi}
+          />
+          {image.hasMeta && (
+            <div className="absolute bottom-1 right-0.5 z-10">
+              <ImageMetaPopover2 imageId={image.id} type={image.type}>
+                <div className="m-0.5 flex size-7 items-center justify-center rounded-full bg-black/50">
+                  <IconInfoCircle color="white" opacity={0.9} strokeWidth={2.5} size={20} />
+                </div>
+              </ImageMetaPopover2>
+            </div>
+          )}
+        </>
+      )}
+    </ImageGuard2>
+  );
+}
+
+/** Today's carousel: every image is already in hand. Exported for component tests. */
+export function StaticPostImagesCarousel({
+  images,
+  postId,
+}: {
+  images: ImagesAsPostModel['images'];
+  postId: number;
+}) {
+  return (
+    <SimpleImageCarousel loop total={images.length} className="flex h-full flex-col">
       <SimpleImageCarousel.Viewport className="relative flex-1">
         <SimpleImageCarousel.Container className="h-full">
-          {data.images.map((image, index) => (
+          {images.map((image, index) => (
             <SimpleImageCarousel.Slide key={index} index={index} className="relative">
-              <ImageGuard2 image={image} connectType="post" connectId={postId}>
-                {(safe) => (
-                  <>
-                    {image.onSite && <OnsiteIndicator isRemix={!!image.remixOfId} />}
-                    <ImageGuard2.BlurToggle className="absolute left-2 top-2 z-10" />
-                    {safe && (
-                      <div className="absolute right-2 top-2 z-10 flex flex-col gap-2">
-                        <ImagesAsPostsContextMenu image={image} />
-                        {features.imageGeneration && (image.hasPositivePrompt ?? image.hasMeta) && (
-                          <HoverActionButton
-                            label="Remix"
-                            size={30}
-                            color="white"
-                            variant="filled"
-                            data-activity="remix:model-gallery"
-                            onClick={handleRemixClick(image)}
-                          >
-                            <IconBrush stroke={2.5} size={16} />
-                          </HoverActionButton>
-                        )}
-                      </div>
-                    )}
-                    <RoutedDialogLink
-                      name="imageDetail"
-                      state={{ imageId: image.id }}
-                      getState={() => ({ imageId: image.id, images: data.images })}
-                      className={classes.link}
-                    >
-                      <>
-                        <MediaHash {...image} className="opacity-70" />
-
-                        {safe && (
-                          <EdgeMedia2
-                            metadata={image.metadata}
-                            src={image.url}
-                            thumbnailUrl={image.thumbnailUrl}
-                            name={image.name ?? image.id.toString()}
-                            alt={image.name ?? undefined}
-                            type={image.type}
-                            imageId={image.id}
-                            width={450}
-                            placeholder="empty"
-                            wrapperProps={edgeMediaWrapperProps}
-                            skip={getSkipValue(image)}
-                            className="z-[1] object-cover"
-                          />
-                        )}
-                      </>
-                    </RoutedDialogLink>
-                    <Reactions
-                      entityId={image.id}
-                      entityType="image"
-                      reactions={image.reactions}
-                      metrics={{
-                        likeCount: image.stats?.likeCountAllTime,
-                        dislikeCount: image.stats?.dislikeCountAllTime,
-                        heartCount: image.stats?.heartCountAllTime,
-                        laughCount: image.stats?.laughCountAllTime,
-                        cryCount: image.stats?.cryCountAllTime,
-                        tippedAmountCount: image.stats?.tippedAmountCountAllTime,
-                      }}
-                      readonly={!safe}
-                      className={classes.reactions}
-                      targetUserId={image.user.id}
-                      disableBuzzTip={image.poi}
-                    />
-                    {image.hasMeta && (
-                      <div className="absolute bottom-1 right-0.5 z-10">
-                        <ImageMetaPopover2 imageId={image.id} type={image.type}>
-                          <div className="m-0.5 flex size-7 items-center justify-center rounded-full bg-black/50">
-                            <IconInfoCircle
-                              color="white"
-                              opacity={0.9}
-                              strokeWidth={2.5}
-                              size={20}
-                            />
-                          </div>
-                        </ImageMetaPopover2>
-                      </div>
-                    )}
-                  </>
-                )}
-              </ImageGuard2>
+              <PostCarouselSlide image={image} postId={postId} dialogImages={images} />
             </SimpleImageCarousel.Slide>
           ))}
         </SimpleImageCarousel.Container>
         <SimpleImageCarousel.Controls />
       </SimpleImageCarousel.Viewport>
-      <SimpleImageCarousel.Indicators
-        className="flex w-full gap-px"
-        indicatorClassName="h-2 flex-1 bg-white opacity-60 shadow-sm data-[active]:opacity-100"
-      />
+      <SimpleImageCarousel.Indicators {...carouselIndicatorProps} />
+    </SimpleImageCarousel>
+  );
+}
+
+/**
+ * Lazy carousel: seeded with the first slice + the true `imageCount`. Shows "1 of
+ * N" immediately (indicators from `imageCount`); fetches the post's remaining
+ * images via `trpc.image.getInfinite({ postId })` when the active slide approaches
+ * the loaded edge, re-applies the feed's hidden preferences to the fetched tail
+ * (content safety), and appends. The detail modal is seeded with whatever is
+ * loaded at click time.
+ *
+ * Exported for component tests.
+ */
+export function LazyPostImagesCarousel({
+  data,
+  postId,
+}: {
+  data: ImagesAsPostModel;
+  postId: number;
+}) {
+  const { filters, browsingLevel, hiddenImageIds, hiddenTags, hiddenUsers } =
+    useImagesAsPostsInfiniteContext();
+  const seed = data.images;
+  const total = data.imageCount ?? seed.length;
+
+  // Latch: fire the tail fetch once, when the active slide nears the loaded edge.
+  const [fetchTail, setFetchTail] = useState(false);
+  const handleIndexChange = useCallback(
+    (index: number) => {
+      setFetchTail(
+        (prev) =>
+          prev ||
+          shouldFetchPostTail({ currentIndex: index, loadedCount: seed.length, total })
+      );
+    },
+    [seed.length, total]
+  );
+
+  // The tail = the WHOLE post (≤ POST_IMAGE_LIMIT), same version/browsing-level
+  // filters the gallery used, so the returned set matches `imageCount`. postId
+  // forces the DB path server-side (covered index, ~2ms).
+  const { data: tailData } = trpc.image.getInfinite.useQuery(
+    {
+      ...filters,
+      postId,
+      browsingLevel,
+      limit: POST_IMAGE_LIMIT,
+      include: ['cosmetics', 'tagIds'],
+    },
+    {
+      enabled: fetchTail,
+      trpc: { context: { skipBatch: true } },
+      staleTime: 5 * 60 * 1000,
+    }
+  );
+
+  // Content safety: re-apply the feed's hidden preferences to the fetched tail so
+  // it never surfaces images the feed slice would have dropped (owner/user-hidden,
+  // system-hidden tags, poi/minor). Browsing level is already applied server-side.
+  const { items: filteredTail } = useApplyHiddenPreferences({
+    type: 'images',
+    data: tailData?.items,
+    hiddenImages: hiddenImageIds,
+    hiddenUsers,
+    hiddenTags,
+    browsingLevel,
+  });
+
+  const fetched = !!tailData;
+  const loaded = useMemo(
+    () =>
+      fetched
+        ? (mergePostImages(
+            seed as { id: number }[],
+            (filteredTail ?? []) as { id: number }[]
+          ) as ImagesAsPostModel['images'])
+        : seed,
+    [fetched, seed, filteredTail]
+  );
+
+  // Before the tail resolves, advertise the true count so indicators read "1 of N".
+  // After, use the actual loaded length so navigation never dead-ends if the tail
+  // came back short (a hidden-pref drop) — self-correcting.
+  const effectiveTotal = fetched ? loaded.length : total;
+
+  return (
+    <SimpleImageCarousel
+      loop
+      total={effectiveTotal}
+      onIndexChange={handleIndexChange}
+      className="flex h-full flex-col"
+    >
+      <SimpleImageCarousel.Viewport className="relative flex-1">
+        <SimpleImageCarousel.Container className="h-full">
+          {Array.from({ length: effectiveTotal }).map((_, index) => (
+            <SimpleImageCarousel.Slide key={index} index={index} className="relative">
+              {loaded[index] ? (
+                <PostCarouselSlide image={loaded[index]} postId={postId} dialogImages={loaded} />
+              ) : (
+                <Center className="size-full">
+                  <Loader />
+                </Center>
+              )}
+            </SimpleImageCarousel.Slide>
+          ))}
+        </SimpleImageCarousel.Container>
+        <SimpleImageCarousel.Controls />
+      </SimpleImageCarousel.Viewport>
+      <SimpleImageCarousel.Indicators {...carouselIndicatorProps} />
     </SimpleImageCarousel>
   );
 }

--- a/src/components/Image/AsPosts/ImagesAsPostsCardLazyCarousel.browser.test.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsCardLazyCarousel.browser.test.tsx
@@ -1,0 +1,179 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+
+// =============================================================================
+// Gallery lazy per-post carousel (`galleryLazyPostImages`).
+//
+// Pins the WIRING the node tests can't reach:
+//   * LAZY (server sent a 6-image slice + true `imageCount` 20): the carousel
+//     advertises the true total, and when the active slide approaches the loaded
+//     edge it fires `trpc.image.getInfinite({ postId })` (enabled flips true) and
+//     appends the fetched tail — image 7 becomes navigable.
+//   * STATIC (flag off / post within the slice): renders all images inline and
+//     NEVER calls `getInfinite`.
+//
+// The pure decision/merge logic + the server slice/imageCount transform are
+// covered by node unit tests (lazyPostImages.test.ts, images-as-posts-wire.test.ts).
+// Here we boundary-stub the slide's heavy leaves and drive the REAL SimpleImageCarousel.
+// =============================================================================
+
+const mocks = vi.hoisted(() => {
+  // A full-shaped image the slide can render (ids 7..20 = the lazily-fetched tail).
+  const tailImage = (id: number) => ({
+    id,
+    type: 'image',
+    url: `img-${id}.jpeg`,
+    name: null,
+    hasMeta: false,
+    hasPositivePrompt: false,
+    onSite: false,
+    remixOfId: null,
+    poi: false,
+    metadata: { width: 1, height: 1 },
+    thumbnailUrl: undefined,
+    reactions: [],
+    stats: {},
+    user: { id: 9 },
+  });
+  return {
+    // getInfinite returns the tail ONLY when enabled (mirrors react-query gating), so
+    // asserting on the returned data also proves the enable-on-approach wiring.
+    getInfiniteUseQuery: vi.fn((_input: any, opts: any) => ({
+      data: opts?.enabled
+        ? { items: Array.from({ length: 14 }, (_, i) => tailImage(i + 7)), nextCursor: undefined }
+        : undefined,
+    })),
+  };
+});
+
+// --- tail fetch ---------------------------------------------------------------
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    image: { getInfinite: { useQuery: mocks.getInfiniteUseQuery } },
+    useUtils: () => ({}),
+  },
+}));
+
+// --- gallery context (filters + browsing level + hidden-pref inputs) ----------
+vi.mock('~/components/Image/AsPosts/ImagesAsPostsInfiniteProvider', () => ({
+  useImagesAsPostsInfiniteContext: () => ({
+    filters: { modelId: 1, modelVersionId: 2 },
+    browsingLevel: 1,
+    hiddenImageIds: [],
+    hiddenTags: [],
+    hiddenUsers: [],
+    source: { kind: 'model', model: { id: 1, user: { id: 9 } } },
+    modelVersions: [],
+  }),
+  ImagesAsPostsInfiniteProvider: ({ children }: any) => <>{children}</>,
+}));
+
+// --- hidden-prefs = identity pass-through (its own filtering is unit-tested) ---
+vi.mock('~/components/HiddenPreferences/useApplyHiddenPreferences', () => ({
+  useApplyHiddenPreferences: ({ data }: any) => ({ items: data ?? [] }),
+}));
+
+// --- slide leaves: render a marker carrying the image id ----------------------
+vi.mock('~/components/EdgeMedia/EdgeMedia', () => ({
+  EdgeMedia2: ({ imageId }: any) => <div data-testid="slide" data-image-id={String(imageId)} />,
+  EdgeMedia: () => null,
+}));
+vi.mock('~/components/EdgeMedia/EdgeMedia.util', () => ({ getSkipValue: () => undefined }));
+vi.mock('~/components/ImageGuard/ImageGuard2', () => {
+  const ImageGuard2 = ({ children }: any) => <>{children(true)}</>;
+  ImageGuard2.BlurToggle = () => null;
+  return { ImageGuard2 };
+});
+vi.mock('~/components/ImageHash/ImageHash', () => ({ MediaHash: () => null }));
+vi.mock('~/components/Reaction/Reactions', () => ({ Reactions: () => null }));
+vi.mock('~/components/Image/Indicators/OnsiteIndicator', () => ({ OnsiteIndicator: () => null }));
+vi.mock('~/components/Image/ContextMenu/ImagesAsPostsContextMenu', () => ({
+  ImagesAsPostsContextMenu: () => null,
+}));
+vi.mock('~/components/Image/Meta/ImageMetaPopover', () => ({ ImageMetaPopover2: () => null }));
+vi.mock('~/components/Cards/components/HoverActionButton', () => ({ default: () => null }));
+vi.mock('~/components/Dialog/RoutedDialogLink', () => ({
+  RoutedDialogLink: ({ children }: any) => <a>{children}</a>,
+}));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ imageGeneration: false }),
+}));
+vi.mock('~/components/TrackView/track.utils', () => ({
+  useTrackEvent: () => ({ trackAction: vi.fn().mockResolvedValue(undefined) }),
+}));
+vi.mock('~/store/generation-graph.store', () => ({ generationGraphPanel: { open: vi.fn() } }));
+
+// Import AFTER the mocks are registered.
+import { renderWithProviders } from '../../../../test/component-setup';
+import {
+  LazyPostImagesCarousel,
+  StaticPostImagesCarousel,
+} from '~/components/Image/AsPosts/ImagesAsPostsCard';
+
+const slice = (n: number, from = 1) =>
+  Array.from({ length: n }, (_, i) => ({
+    id: from + i,
+    type: 'image',
+    url: `img-${from + i}.jpeg`,
+    name: null,
+    hasMeta: false,
+    hasPositivePrompt: false,
+    onSite: false,
+    remixOfId: null,
+    poi: false,
+    metadata: { width: 1, height: 1 },
+    thumbnailUrl: undefined,
+    reactions: [],
+    stats: {},
+    user: { id: 9 },
+  })) as any;
+
+const activeSlideId = () => page.getByTestId('slide');
+const clickNext = () => userEvent.click(page.getByRole('button').nth(1)); // [prev, next]
+
+describe('LazyPostImagesCarousel', () => {
+  test('advertises the true count, and lazy-loads + appends the tail on approach', async () => {
+    mocks.getInfiniteUseQuery.mockClear();
+    const data = { postId: 100, imageCount: 20, images: slice(6) } as any;
+    renderWithProviders(<LazyPostImagesCarousel data={data} postId={100} />);
+
+    // Cover (index 0) is the first slice image.
+    await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '1');
+
+    // On mount the tail fetch is NOT enabled (index 0 is far from the loaded edge).
+    expect(mocks.getInfiniteUseQuery).toHaveBeenCalled();
+    expect(mocks.getInfiniteUseQuery.mock.calls.every(([, opts]) => opts?.enabled === false)).toBe(
+      true
+    );
+
+    // Walk toward the end of the loaded slice (6). At index 4 (within threshold 2)
+    // the fetch enables; keep going to index 6 — the FIRST appended tail image.
+    for (let i = 0; i < 6; i++) await clickNext();
+
+    // The tail fetch was enabled, scoped to this post + the gallery's browsing level.
+    await vi.waitFor(() => {
+      expect(mocks.getInfiniteUseQuery.mock.calls.some(([, opts]) => opts?.enabled === true)).toBe(
+        true
+      );
+    });
+    const enabledCall = mocks.getInfiniteUseQuery.mock.calls.find(([, opts]) => opts?.enabled)!;
+    expect(enabledCall[0]).toMatchObject({ postId: 100, browsingLevel: 1, modelVersionId: 2 });
+
+    // Image 7 (the first lazily-fetched image) is now navigable — NOT truncated.
+    await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '7');
+  });
+});
+
+describe('StaticPostImagesCarousel', () => {
+  test('renders all images inline and never calls getInfinite (flag OFF path)', async () => {
+    mocks.getInfiniteUseQuery.mockClear();
+    renderWithProviders(<StaticPostImagesCarousel images={slice(3)} postId={100} />);
+
+    await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '1');
+    await clickNext();
+    await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '2');
+
+    // No lazy tail fetch on the static path.
+    expect(mocks.getInfiniteUseQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Image/AsPosts/ImagesAsPostsInfinite.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsInfinite.tsx
@@ -221,8 +221,30 @@ export function ImagesAsPostsInfinite({
         !!gallerySettings?.hiddenTags.length;
 
   const providerValue = useMemo(
-    () => ({ filters, modelVersions, showModerationOptions, source }),
-    [filters, modelVersions, showModerationOptions, source]
+    () => ({
+      filters,
+      modelVersions,
+      showModerationOptions,
+      source,
+      // Forwarded so the lazy per-post carousel (`galleryLazyPostImages`) can
+      // reproduce the gallery's visibility for its `getInfinite({ postId })` tail
+      // fetch and re-apply the same hidden preferences to the fetched tail.
+      browsingLevel: intersection,
+      hiddenImageIds: !showHidden ? hiddenImageIds : undefined,
+      hiddenTags: !showHidden ? hiddenTags : undefined,
+      hiddenUsers: !showHidden ? hiddenUsers : undefined,
+    }),
+    [
+      filters,
+      modelVersions,
+      showModerationOptions,
+      source,
+      intersection,
+      showHidden,
+      hiddenImageIds,
+      hiddenTags,
+      hiddenUsers,
+    ]
   );
 
   return (

--- a/src/components/Image/AsPosts/ImagesAsPostsInfiniteProvider.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsInfiniteProvider.tsx
@@ -29,6 +29,22 @@ type ImagesAsPostsInfiniteState = {
     modelVersionId?: number;
   } & Record<string, unknown>;
   showModerationOptions?: boolean;
+  /**
+   * The effective browsing level the gallery query used (system level ∩ the
+   * gallery's capped level). The lazy per-post carousel reuses it so its
+   * `getInfinite({ postId })` tail fetch returns the SAME visible set the feed
+   * slice + `imageCount` were computed from.
+   */
+  browsingLevel?: number;
+  /**
+   * Hidden-preference inputs the feed applied to the slice, forwarded so the lazy
+   * carousel re-applies them to the fetched tail (content safety — the tail must
+   * NOT surface gallery-owner-hidden / user-hidden / system-hidden-tagged /
+   * poi/minor images the feed would have dropped).
+   */
+  hiddenImageIds?: number[];
+  hiddenTags?: number[];
+  hiddenUsers?: number[];
 };
 const ImagesAsPostsInfiniteContext = createContext<ImagesAsPostsInfiniteState | null>(null);
 export const useImagesAsPostsInfiniteContext = () => {

--- a/src/components/Image/AsPosts/__tests__/lazyPostImages.test.ts
+++ b/src/components/Image/AsPosts/__tests__/lazyPostImages.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergePostImages,
+  POST_TAIL_PREFETCH_THRESHOLD,
+  shouldFetchPostTail,
+} from '~/components/Image/AsPosts/lazyPostImages';
+
+// Pure decision logic for the gallery's lazy per-post carousel. These run in node
+// (no DOM), so the browser component test only has to cover wiring.
+
+describe('shouldFetchPostTail', () => {
+  // Typical lazy post: seeded with 6 (the slice), true total 20.
+  const loadedCount = 6;
+  const total = 20;
+
+  it('does NOT fetch while the active slide is comfortably inside the loaded set', () => {
+    // threshold = 2 → fetch once currentIndex >= 6 - 2 = 4
+    expect(shouldFetchPostTail({ currentIndex: 0, loadedCount, total })).toBe(false);
+    expect(shouldFetchPostTail({ currentIndex: 3, loadedCount, total })).toBe(false);
+  });
+
+  it('fetches on APPROACH (within threshold of the loaded edge) — hides the round-trip', () => {
+    expect(POST_TAIL_PREFETCH_THRESHOLD).toBe(2);
+    expect(shouldFetchPostTail({ currentIndex: 4, loadedCount, total })).toBe(true); // 6-2
+    expect(shouldFetchPostTail({ currentIndex: 5, loadedCount, total })).toBe(true);
+  });
+
+  it('fetches when the user jumps straight to the (unloaded) end via an indicator', () => {
+    expect(shouldFetchPostTail({ currentIndex: 19, loadedCount, total })).toBe(true);
+  });
+
+  it('never fetches once everything is loaded (loadedCount >= total)', () => {
+    expect(shouldFetchPostTail({ currentIndex: 19, loadedCount: 20, total: 20 })).toBe(false);
+    expect(shouldFetchPostTail({ currentIndex: 25, loadedCount: 20, total: 18 })).toBe(false);
+  });
+
+  it('honors a custom threshold', () => {
+    expect(shouldFetchPostTail({ currentIndex: 1, loadedCount: 6, total: 20, threshold: 5 })).toBe(
+      true
+    ); // 6-5=1
+    expect(shouldFetchPostTail({ currentIndex: 0, loadedCount: 6, total: 20, threshold: 5 })).toBe(
+      false
+    );
+  });
+});
+
+describe('mergePostImages', () => {
+  const seed = [{ id: 1 }, { id: 2 }, { id: 3 }];
+
+  it('appends the tail after the seed, preserving order', () => {
+    const out = mergePostImages(seed, [{ id: 4 }, { id: 5 }]);
+    expect(out.map((x) => x.id)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('de-duplicates by id (the tail overlaps the seed — getInfinite returns the whole post)', () => {
+    // getInfinite({postId}) returns ALL images incl. the leading slice; the seed
+    // stays authoritative for its ids, the tail only contributes the new ones.
+    const out = mergePostImages(seed, [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]);
+    expect(out.map((x) => x.id)).toEqual([1, 2, 3, 4, 5]);
+    // the seed objects are kept (not replaced by the tail copies)
+    expect(out[0]).toBe(seed[0]);
+  });
+
+  it('keeps the cover (index 0) from the seed', () => {
+    const out = mergePostImages(seed, [{ id: 9 }]);
+    expect(out[0]).toBe(seed[0]);
+  });
+
+  it('returns the seed untouched when the tail is empty', () => {
+    expect(mergePostImages(seed, [])).toBe(seed);
+  });
+
+  it('does not mutate the inputs', () => {
+    const s = [{ id: 1 }];
+    const t = [{ id: 2 }];
+    mergePostImages(s, t);
+    expect(s).toEqual([{ id: 1 }]);
+    expect(t).toEqual([{ id: 2 }]);
+  });
+});

--- a/src/components/Image/AsPosts/lazyPostImages.ts
+++ b/src/components/Image/AsPosts/lazyPostImages.ts
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers for the gallery's LAZY per-post image carousel
+ * (`ImagesAsPostsCard`, flag `galleryLazyPostImages`).
+ *
+ * The server returns only the first `GALLERY_POST_IMAGE_SLICE` images of a
+ * showcase post plus the true `imageCount`; the carousel loads the remainder on
+ * demand via `trpc.image.getInfinite({ postId })`. These helpers keep the
+ * fetch-on-approach decision and the seed⊕tail merge deterministic and unit-
+ * testable in node (no React/DOM), so the browser test only has to cover wiring.
+ */
+
+// Prefetch the tail when the active slide is within this many of the loaded edge,
+// so the round-trip is hidden before the user reaches the unloaded range.
+export const POST_TAIL_PREFETCH_THRESHOLD = 2;
+
+/**
+ * Should the carousel fetch a post's remaining images now?
+ *
+ * True when there is more to load (`loadedCount < total`) AND the active slide is
+ * within `threshold` of the last loaded slide. `total` is the post's true
+ * `imageCount`; `loadedCount` is how many images are currently in hand (the seed
+ * slice, later the full hidden-pref-filtered set). Pure — the caller latches the
+ * result so the fetch fires once.
+ */
+export function shouldFetchPostTail({
+  currentIndex,
+  loadedCount,
+  total,
+  threshold = POST_TAIL_PREFETCH_THRESHOLD,
+}: {
+  currentIndex: number;
+  loadedCount: number;
+  total: number;
+  threshold?: number;
+}): boolean {
+  if (loadedCount >= total) return false; // nothing more to load
+  return currentIndex >= loadedCount - threshold;
+}
+
+/**
+ * Merge the authoritative leading `seed` slice with a lazily-fetched `tail`,
+ * de-duplicated by `id`, preserving order: the seed first (keeps the cover =
+ * index 0 and the feed's ordering/filtering), then any tail images not already in
+ * the seed (in tail order). Never mutates the inputs.
+ *
+ * Generic over the minimal `{ id }` shape so it is safe across the sliced-gallery
+ * image type and the `getInfinite` tail type (which carries a superset of fields —
+ * extra fields render harmlessly and the hidden-prefs fields are preserved).
+ */
+export function mergePostImages<T extends { id: number }>(seed: T[], tail: T[]): T[] {
+  if (!tail.length) return seed;
+  const seen = new Set(seed.map((x) => x.id));
+  const merged = seed.slice();
+  for (const img of tail) {
+    if (!seen.has(img.id)) {
+      seen.add(img.id);
+      merged.push(img);
+    }
+  }
+  return merged;
+}

--- a/src/components/SimpleImageCarousel/SimpleImageCarousel.tsx
+++ b/src/components/SimpleImageCarousel/SimpleImageCarousel.tsx
@@ -1,7 +1,7 @@
 import { IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import clsx from 'clsx';
 import type { CSSProperties, ReactNode } from 'react';
-import { createContext, useCallback, useContext, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 
 type SimpleCarouselContextType = {
   currentIndex: number;
@@ -30,6 +30,12 @@ type SimpleImageCarouselProps = {
   loop?: boolean;
   total: number;
   initialIndex?: number;
+  /**
+   * Fired (from a commit effect, not during render) whenever the active slide
+   * changes — including the initial mount. Used by the gallery's lazy per-post
+   * carousel to prefetch the tail on approach.
+   */
+  onIndexChange?: (index: number) => void;
 };
 
 export function SimpleImageCarousel({
@@ -39,8 +45,18 @@ export function SimpleImageCarousel({
   loop = false,
   total,
   initialIndex = 0,
+  onIndexChange,
 }: SimpleImageCarouselProps) {
   const [currentIndex, setCurrentIndex] = useState(initialIndex);
+
+  // Notify on index change (and initial mount) from an effect so callers can
+  // trigger side effects (a tail fetch) without violating render purity. Ref-held
+  // so a changing `onIndexChange` identity doesn't refire for the same index.
+  const onIndexChangeRef = useRef(onIndexChange);
+  onIndexChangeRef.current = onIndexChange;
+  useEffect(() => {
+    onIndexChangeRef.current?.(currentIndex);
+  }, [currentIndex]);
 
   const canScrollNext = loop || currentIndex < total - 1;
   const canScrollPrev = loop || currentIndex > 0;

--- a/src/server/controllers/image.controller.ts
+++ b/src/server/controllers/image.controller.ts
@@ -81,7 +81,7 @@ import {
   moderateImages,
 } from './../services/image.service';
 import { Limiter } from '~/server/utils/concurrency-helpers';
-import { capImagesPerPost, stripImageForAsPostsWire } from '~/server/utils/images-as-posts-wire';
+import { buildPostImagesWire } from '~/server/utils/images-as-posts-wire';
 import { imagesFeedWithoutIndexCounter } from '~/server/prom/client';
 import { constants, POST_IMAGE_LIMIT } from '~/server/common/constants';
 import { logToAxiom } from '~/server/logging/client';
@@ -578,14 +578,23 @@ export const getImagesAsPostsInfiniteHandler = async ({
         createdAt,
         user,
         // Serialize-cost reduction (this endpoint is the #2 oversized-tRPC-response
-        // producer): (1) OPTIONALLY cap each post's images when the DARK, user-visible
-        // `imagesAsPostsPerPostCap` flag is on — the material lever (~15% fewer images);
-        // (2) always strip per-image fields no consumer reads (zero-UX). Both run AFTER
-        // the per-post `index` sort above and after the post-level fields are read off
-        // `image`/`images[0]`, so nothing server-side needs the dropped data.
-        images: (features.imagesAsPostsPerPostCap ? capImagesPerPost(images) : images).map(
-          stripImageForAsPostsWire
-        ),
+        // producer). Two levers:
+        //  (1) LAZY per-post image slice — when the DARK `galleryLazyPostImages`
+        //      flag is on, return only the first `GALLERY_POST_IMAGE_SLICE` images
+        //      plus the TRUE `imageCount` (computed from the FULL `images` array
+        //      BELOW, before the slice, so "1 of N" is accurate). The card carousel
+        //      lazy-loads the tail via `trpc.image.getInfinite({ postId })` — the UX
+        //      is NOT truncated, only the initial payload shrinks. OFF ⇒ all images
+        //      inline AND no `imageCount` field (byte-identical to today).
+        //  (2) always strip per-image fields no consumer reads (zero-UX).
+        // Both run AFTER the per-post `index` sort above and after the post-level
+        // fields are read off `image`/`images[0]`, so nothing server-side needs the
+        // dropped/sliced data. `imageCount` reflects the count AFTER the server-side
+        // browsing-level/poi/minor filtering `getAllImages` already applied and
+        // BEFORE the slice — matching what a full `getInfinite({ postId })` tail
+        // fetch (same browsingLevel/version filters) returns, so the carousel never
+        // dead-ends. (`buildPostImagesWire` is unit-tested in isolation.)
+        ...buildPostImagesWire(images, { lazy: features.galleryLazyPostImages }),
         review: review
           ? {
               rating: review.rating,

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -119,17 +119,26 @@ const featureFlags = createFeatureFlags({
   // the A/B (no flag-off cohort) and shipping the deferral fleet-wide unmeasured. OFF =
   // byte-identical to today. Measured via RUM `exp_gen_tab_defer_view`. Instant safe rollback.
   genTabDeferView: { availability: [], fliptKey: 'gen-tab-defer-view' },
-  // Serialize-perf: cap each post's embedded image list on `image.getImagesAsPostsInfinite`
-  // (the #2 producer of oversized/event-loop-freezing tRPC responses). Model galleries carry
-  // multi-image showcase posts (p90 14 imgs/post), so the cap cuts ~15% of serialized images
-  // at 12/post. 🔴 USER-VISIBLE (this card renders the FULL carousel AND seeds the detail
-  // modal from `data.images` WITHOUT refetch, so a cap hides a post's tail images from both) —
-  // hence `availability: []` = DARK by default, fails CLOSED (no cap) when Flipt is absent/down.
-  // The Flipt `images-as-posts-per-post-cap` threshold is the ONLY on-switch; ramp only after a
-  // product call on the carousel/modal truncation, and confirm the new bundle is serving first.
-  // OFF = byte-identical to today. Verify via `trpc-response-oversized {path=
-  // "image.getImagesAsPostsInfinite"}` serializeMs/bytes tail. (Mirrors the genTabDeferView precedent.)
-  imagesAsPostsPerPostCap: { availability: [], fliptKey: 'images-as-posts-per-post-cap' },
+  // Serialize-perf: LAZY per-post image load on `image.getImagesAsPostsInfinite` (the #2
+  // producer of oversized/event-loop-freezing tRPC responses). Model galleries carry
+  // multi-image showcase posts (17% have >12 images; p90/p99 ≈ 20). When ON the server
+  // returns only the first `GALLERY_POST_IMAGE_SLICE` (6) images per post PLUS the true
+  // `imageCount`; the card carousel lazy-loads the remainder on approach via
+  // `trpc.image.getInfinite({ postId })`. So the gallery is NOT truncated — only the initial
+  // payload shrinks (a large cut on the heavy tail). OFF = byte-identical to today (all
+  // images inline, no `imageCount`).
+  //
+  // 🔴 SERVER-SIDE flag → STALE-CLIENT RAMP DISCIPLINE (same class as the shape-swap flags):
+  // a PRE-this-PR bundle (no lazy-load code) would render only the 6-image slice with
+  // `total = slice.length` → "6 of 6" instead of "1 of 20" until the user reloads. That's a
+  // UX-truncation regression (NOT content-unsafe; browsing-level filtering is unchanged),
+  // self-healing on reload. Hence `availability: []` = DARK by default, fails CLOSED (no
+  // slice) when Flipt is absent/down; the Flipt `gallery-lazy-post-images` THRESHOLD is the
+  // ONLY on-switch. Ramp ONLY after the new bundle is serving everywhere (confirm via RUM
+  // app_version — hours, per the SPA-cache rollout pattern); threshold-only; instant rollback =
+  // drop the threshold to 0. Supersedes the retired `imagesAsPostsPerPostCap` cap flag (which
+  // truncated the gallery and was never ramped). (Mirrors the genTabDeferView precedent.)
+  galleryLazyPostImages: { availability: [], fliptKey: 'gallery-lazy-post-images' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },

--- a/src/server/utils/__tests__/images-as-posts-wire.test.ts
+++ b/src/server/utils/__tests__/images-as-posts-wire.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
-  capImagesPerPost,
+  buildPostImagesWire,
+  GALLERY_POST_IMAGE_SLICE,
   IMAGES_AS_POSTS_DROPPED_IMAGE_FIELDS,
-  IMAGES_AS_POSTS_PER_POST_CAP,
+  sliceImagesForPost,
   stripImageForAsPostsWire,
 } from '~/server/utils/images-as-posts-wire';
 
@@ -12,8 +13,9 @@ import {
 //  - `stripImageForAsPostsWire` drops the OPTIONAL per-image fields no consumer of
 //    this endpoint reads (zero-UX; the unread-but-required fields stay because the
 //    card seeds `data.images` into the detail modal whose type demands them);
-//  - `capImagesPerPost` caps a post's embedded images (material, flag-gated).
-// This test pins the contract: the drop set, the load-bearing retentions, the cap,
+//  - `sliceImagesForPost` returns only the first slice of a post's images (material,
+//    flag-gated) — the card carousel lazy-loads the tail, so the UX is NOT truncated.
+// This test pins the contract: the drop set, the load-bearing retentions, the slice,
 // and non-mutation.
 
 // A representative per-image object with every field the endpoint emits.
@@ -122,27 +124,79 @@ describe('images-as-posts-wire', () => {
     });
   });
 
-  describe('capImagesPerPost', () => {
+  describe('sliceImagesForPost', () => {
     const imgs = (n: number) => Array.from({ length: n }, (_, i) => ({ id: i + 1 }));
 
-    it('caps to IMAGES_AS_POSTS_PER_POST_CAP, keeping leading order (cover stays images[0])', () => {
-      expect(IMAGES_AS_POSTS_PER_POST_CAP).toBe(12);
+    it('slices to GALLERY_POST_IMAGE_SLICE, keeping leading order (cover stays images[0])', () => {
+      expect(GALLERY_POST_IMAGE_SLICE).toBe(6);
       const source = imgs(20);
-      const out = capImagesPerPost(source);
-      expect(out).toHaveLength(12);
-      expect(out.map((x) => x.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+      const out = sliceImagesForPost(source);
+      expect(out).toHaveLength(6);
+      expect(out.map((x) => x.id)).toEqual([1, 2, 3, 4, 5, 6]);
       expect(out[0]).toBe(source[0]);
       expect(source).toHaveLength(20); // not mutated
     });
 
-    it('returns the same array untouched when within the cap (typical posts)', () => {
+    it('returns the same array untouched when within the slice (typical posts)', () => {
       const source = imgs(3);
-      expect(capImagesPerPost(source)).toBe(source);
-      expect(capImagesPerPost([])).toEqual([]);
+      expect(sliceImagesForPost(source)).toBe(source);
+      expect(sliceImagesForPost([])).toEqual([]);
     });
 
-    it('honors a custom cap', () => {
-      expect(capImagesPerPost(imgs(20), 8)).toHaveLength(8);
+    it('is a no-op at exactly the slice size (boundary)', () => {
+      const source = imgs(6);
+      expect(sliceImagesForPost(source)).toBe(source);
+    });
+
+    it('honors a custom slice size', () => {
+      expect(sliceImagesForPost(imgs(20), 8)).toHaveLength(8);
+    });
+  });
+
+  describe('buildPostImagesWire (the handler transform)', () => {
+    // Images carrying the hidden-prefs fields + a dropped field, to prove both the
+    // slice and the trim behave together.
+    const imgs = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        id: i + 1,
+        userId: 500,
+        nsfwLevel: 1,
+        tagIds: [1, 2],
+        poi: false,
+        minor: false,
+        url: `img-${i + 1}.jpeg`,
+        meta: { seed: i }, // dropped by stripImageForAsPostsWire
+      }));
+
+    it('flag OFF → all images, field-trimmed, and NO imageCount (byte-identical shape)', () => {
+      const out = buildPostImagesWire(imgs(20), { lazy: false });
+      expect(out).not.toHaveProperty('imageCount');
+      expect(out.images).toHaveLength(20); // not sliced
+      // trim still runs (always-on)
+      expect(out.images[0]).not.toHaveProperty('meta');
+    });
+
+    it('flag ON → sliced to GALLERY_POST_IMAGE_SLICE + imageCount = the FULL count (before slice)', () => {
+      const out = buildPostImagesWire(imgs(20), { lazy: true });
+      expect(out.images).toHaveLength(GALLERY_POST_IMAGE_SLICE); // 6
+      // imageCount is the true full count, computed BEFORE the slice
+      expect((out as { imageCount: number }).imageCount).toBe(20);
+    });
+
+    it('flag ON, post within the slice → imageCount === images.length (no truncation)', () => {
+      const out = buildPostImagesWire(imgs(4), { lazy: true });
+      expect(out.images).toHaveLength(4);
+      expect((out as { imageCount: number }).imageCount).toBe(4);
+    });
+
+    it('flag ON → the hidden-prefs fields survive in the slice (the #3055 lesson)', () => {
+      const out = buildPostImagesWire(imgs(20), { lazy: true });
+      for (const image of out.images) {
+        for (const field of ['id', 'userId', 'nsfwLevel', 'tagIds', 'poi', 'minor']) {
+          expect(image).toHaveProperty(field);
+        }
+        expect(image).not.toHaveProperty('meta'); // dropped field still gone
+      }
     });
   });
 });

--- a/src/server/utils/images-as-posts-wire.ts
+++ b/src/server/utils/images-as-posts-wire.ts
@@ -37,7 +37,10 @@
  *    cap (flag-gated, user-visible), not this trim.
  *
  * So this trim only drops the OPTIONAL unread fields — a modest, strictly
- * zero-UX-risk reduction. The material lever is `IMAGES_AS_POSTS_PER_POST_CAP`.
+ * zero-UX-risk reduction. The material lever is the LAZY per-post image slice
+ * (`sliceImagesForPost` below), which cuts the heavy tail of showcase posts from
+ * the initial payload WITHOUT truncating the UX — the card carousel lazy-loads a
+ * post's remaining images on demand (`trpc.image.getInfinite({ postId })`).
  */
 
 // The per-image keys dropped from the wire. Exported so the unit test can assert
@@ -64,26 +67,60 @@ export const stripImageForAsPostsWire = <T extends Record<string, unknown>>(imag
 };
 
 /**
- * Per-post image cap for `image.getImagesAsPostsInfinite` — the MATERIAL serialize
- * lever. Model galleries carry genuinely multi-image showcase posts (measured on
- * the DB: avg 4.7 imgs/post, p90 14, p99 20), so capping each post's embedded image
- * list cuts a large fraction of serialized images (measured ~15% at cap 12, ~28% at
- * cap 8 across a 30-day model-gallery sample).
+ * First-slice size for the LAZY per-post image load — the MATERIAL serialize lever
+ * for `image.getImagesAsPostsInfinite`. Model galleries carry genuinely multi-image
+ * showcase posts (17% of posts have >12 images; avg ~5.7, p90/p99 ≈ 20 — the upload
+ * max). Serializing every image of every post inline is the event-loop-freeze cost.
  *
- * 🔴 USER-VISIBLE, so it is FLAG-GATED (off by default). Unlike the browse feed
- * (`post.getInfinite`, whose card renders only `images[0]`), this card renders the
- * FULL carousel AND seeds the detail modal from `data.images` WITHOUT refetch — so
- * a cap hides a showcase post's tail images from both the carousel and the modal.
- * Ship dark; ramp only after a product call on the carousel/modal truncation.
+ * Instead of CAPPING (which would truncate the gallery), the server returns only the
+ * first `GALLERY_POST_IMAGE_SLICE` images PLUS the post's true `imageCount`, and the
+ * card carousel lazy-loads the remainder on approach via
+ * `trpc.image.getInfinite({ postId })`. So the UX is complete; only the *initial*
+ * payload shrinks.
  *
- * Value chosen to match the `model.getAll` cap (12) — healthy carousel, ~15% cut.
+ * 🔴 Value = 6, deliberately > 1 for HIDDEN-PREFERENCES HEADROOM. The feed's
+ * `useApplyHiddenPreferences('posts')` filters each post's images CLIENT-side and
+ * DROPS the whole post if none survive. Browsing-level (the dominant filter) is
+ * already applied SERVER-side before this slice, so the residual client-side drops
+ * are only the per-user hidden-image/tag/user + poi/minor prefs — rare within a
+ * single post. Six leading images make "all of the slice hidden → post dropped"
+ * very unlikely (vs. a slice of 1). The residual risk (a post whose first 6 visible
+ * images are all user-hidden but image 7+ would survive gets dropped) is documented
+ * and measured; fully eliminating it would need a feed-level tail refetch (deferred).
+ *
+ * 🔴 FLAG-GATED (`galleryLazyPostImages`, DARK). OFF ⇒ byte-identical to today
+ * (all images inline, no `imageCount`). Verify via `trpc-response-oversized
+ * {path="image.getImagesAsPostsInfinite"}` serializeMs/bytes tail once ramped.
  */
-export const IMAGES_AS_POSTS_PER_POST_CAP = 12;
+export const GALLERY_POST_IMAGE_SLICE = 6;
 
 /**
- * Return `images` capped to the first `cap` (keeps leading order — cover stays
- * `images[0]`). Returns the SAME array when already within the cap (no needless
- * clone) and never mutates the input.
+ * Return the first `slice` images of a post (keeps leading order — cover stays
+ * `images[0]`). Returns the SAME array when already within the slice (no needless
+ * clone) and never mutates the input. The true full count is emitted separately as
+ * `imageCount`, so the client can show "1 of N" and lazy-load the tail.
  */
-export const capImagesPerPost = <T>(images: T[], cap = IMAGES_AS_POSTS_PER_POST_CAP): T[] =>
-  images.length > cap ? images.slice(0, cap) : images;
+export const sliceImagesForPost = <T>(images: T[], slice = GALLERY_POST_IMAGE_SLICE): T[] =>
+  images.length > slice ? images.slice(0, slice) : images;
+
+/**
+ * The exact per-post wire transform the `getImagesAsPostsInfinite` handler applies,
+ * extracted so it is unit-testable without booting the controller.
+ *
+ *  - `lazy: false` (flag OFF) → all images, field-trimmed, and NO `imageCount` →
+ *    byte-identical to today.
+ *  - `lazy: true` (flag ON) → the leading `GALLERY_POST_IMAGE_SLICE` images,
+ *    field-trimmed, PLUS `imageCount` computed from the FULL array BEFORE the slice
+ *    (so "1 of N" is the post's true visible count, matching a `getInfinite` tail).
+ *
+ * Both branches run the always-on `stripImageForAsPostsWire`, so every field a
+ * consumer reads (incl. the hidden-prefs `{id,userId,nsfwLevel,tagIds,poi,minor}`)
+ * survives in the returned slice.
+ */
+export function buildPostImagesWire<T extends Record<string, unknown>>(
+  images: T[],
+  { lazy }: { lazy: boolean }
+) {
+  const wireImages = (lazy ? sliceImagesForPost(images) : images).map(stripImageForAsPostsWire);
+  return lazy ? { imageCount: images.length, images: wireImages } : { images: wireImages };
+}


### PR DESCRIPTION
## Problem
`image.getImagesAsPostsInfinite` (the model-page + 3D-model-page community **Gallery** — `/models/[id]` `ModelGallery`→`ImagesAsPostsInfinite`→`ImagesAsPostsCard`, `/3d-models/[id]` `Model3DGallery`) returns **every image of every post inline**. Serializing that with superjson on the single JS thread is the **#2 producer** of the oversized-tRPC-response event-loop freeze class (`handoff-dp-prod-trpc-serialize-freeze-arc-2026-07-09`, `#3017`).

A blunt per-post **cap** (the retired dark `imagesAsPostsPerPostCap`, PR #3069) would **truncate the gallery**: the DB shows **17% of posts have >12 images** (p90/p99 ≈ 20, the upload max), and the card renders ALL images in a swipeable carousel + the detail modal navigates them.

## Fix — small first slice + on-demand tail (no truncation)
Behind the **DARK** `galleryLazyPostImages` flag (Flipt `gallery-lazy-post-images`, `availability: []` fail-closed), the server returns only the **first `GALLERY_POST_IMAGE_SLICE` (6)** images per post **plus the true `imageCount`**; the card carousel **lazy-loads the remainder on approach** via `trpc.image.getInfinite({ postId })` (the `postId` filter already exists — **no new endpoint**). The UX is complete; only the *initial* payload shrinks. **OFF ⇒ byte-identical to today** (all images inline, no `imageCount`).

### Server
- `buildPostImagesWire(images, { lazy })` (unit-tested seam): OFF → all images, no count; ON → first-slice + `imageCount` computed from the **FULL array BEFORE the slice** (so "1 of N" matches a full `getInfinite({ postId })` tail with the same browsing-level/version filters → carousel never dead-ends). Keeps #3069's always-on field-trim.
- **Supersedes** the retired dark `imagesAsPostsPerPostCap` cap flag (was never ramped; removed cap logic + flag, kept the field-trim).

### Client
- `SimpleImageCarousel`: added `onIndexChange` (commit-effect) for prefetch-on-approach.
- `LazyPostImagesCarousel`: advertises the true `imageCount`, fetches the tail when the active slide is **within 2** of the loaded edge, and appends (dedup by id, cover stays index 0). Self-corrects the indicator count if the tail returns short.
- 🔴 **Hidden-preferences on the tail (content safety):** the fetched tail is re-run through the feed's `useApplyHiddenPreferences` (owner/user-hidden images, system-hidden tags, poi/minor) — threaded through the provider — so a lazily-loaded image can never surface content the feed slice would have dropped. Browsing level is already applied server-side.
- **Hidden-prefs headroom:** slice = **6** (not 1) so "all of the slice hidden → post dropped" is very unlikely (browsing level, the dominant filter, is server-side). Residual (first 6 visible all user-hidden but image 7+ would survive → post dropped) is documented; a feed-level tail refetch is deferred.
- Preserves every field the card / context-menu / hidden-prefs read in **both** the slice and the tail (the #3055 lesson).

### Detail modal — documented follow-up
Kept seeding today's slice. Neither "free" option is safe/complete: unseed→`postId`-fetch regresses the gallery's **client-side hidden-prefs** in the modal; seed-from-`loaded` truncates when opened before the carousel scrolls. Both need a dedicated `ImageDetailProvider` seed⊕fetch pass. The **carousel (primary surface) is fully non-truncated**; the modal shows the first 6 when the flag is on — a known, flag-gated, DARK limitation.

## 🔴 Ramp discipline (server-side flag, same class as #3053)
A **stale pre-this-PR bundle** (no lazy-load code) would render only the 6-image slice with `total = 6` → "6 of 6" instead of "1 of 20" until reload — a **self-healing UX-truncation** regression (NOT content-unsafe; browsing-level filtering unchanged). So: ship **DARK**, ramp **only after the new bundle is serving everywhere** (verify RUM `app_version` — hours, SPA-cache), **threshold-only**, rollback = drop the threshold to 0. **Do NOT ramp at deploy.**

## Expected serialize win
On the heavy tail, per-post images drop from p90/p99 ≈ 20 → 6 (~70% fewer serialized images on those posts); posts ≤6 images (the majority; avg ≈ 5.7) are untouched. Honest caveat: the win concentrates on the multi-image showcase posts that drive the freeze tail, not the average post.

## Tests
- **Node unit:** `buildPostImagesWire` (flag OFF byte-identical / ON slice+count, `imageCount` computed before slice, hidden-prefs fields survive), `sliceImagesForPost` boundaries, `shouldFetchPostTail` (approach/jump/all-loaded/custom threshold), `mergePostImages` (dedup/order/cover/no-mutate). — 22 pass.
- **Browser (vitest chromium):** lazy carousel advertises the true count + enables the `getInfinite({ postId })` fetch on approach + appends the tail (image 7 navigable); static path renders inline and never fetches. — 2 pass.

## Post-deploy proof
`{namespace="civitai-dp-prod"} |= \`trpc-response-oversized\` | json` — watch `serializeMs`/`bytes` for `path="image.getImagesAsPostsInfinite"` drop once ramped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)