### PR TITLE
perf(api): per-user Redis cache for getEngagedModelsByIds

### DIFF
--- a/src/server/controllers/resourceReview.controller.ts
+++ b/src/server/controllers/resourceReview.controller.ts
@@ -1,6 +1,6 @@
 import type { ProtectedContext } from '~/server/createContext';
 import { dbRead } from '~/server/db/client';
-import { redis, REDIS_KEYS, REDIS_SUB_KEYS } from '~/server/redis/client';
+import { bustEngagedModelsCache } from '~/server/services/engaged-models.cache';
 import type { GetByIdInput } from '~/server/schema/base.schema';
 import type { GetByUsernameSchema } from '~/server/schema/user.schema';
 import {
@@ -75,9 +75,7 @@ export const createResourceReviewHandler = async ({
       rating: result.recommended ? 5 : 1,
       nsfw: false,
     });
-    await redis.del(
-      `${REDIS_KEYS.USER.BASE}:${ctx.user.id}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`
-    );
+    await bustEngagedModelsCache(ctx.user.id);
     return result;
   } catch (error) {
     throw throwDbError(error);
@@ -100,9 +98,7 @@ export const updateResourceReviewHandler = async ({
       rating: result.rating,
       nsfw: result.nsfw,
     });
-    await redis.del(
-      `${REDIS_KEYS.USER.BASE}:${ctx.user.id}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`
-    );
+    await bustEngagedModelsCache(ctx.user.id);
     return result;
   } catch (error) {
     throw throwDbError(error);
@@ -125,6 +121,9 @@ export const deleteResourceReviewHandler = async ({
       rating: result.rating,
       nsfw: result.nsfw,
     });
+    // Deleting a review can change the user's `Recommended` set — keep the engaged-models
+    // cache honest (create/update already bust; delete previously did not).
+    await bustEngagedModelsCache(ctx.user.id);
     return result;
   } catch (error) {
     throw throwDbError(error);

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -16,7 +16,11 @@ import { getStaticContent } from '~/server/services/content.service';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { onboardingCompletedCounter, onboardingErrorCounter } from '~/server/prom/client';
 import { getUserFollows } from '~/server/redis/caches';
-import { redis, REDIS_KEYS, REDIS_SUB_KEYS } from '~/server/redis/client';
+import {
+  bustEngagedModelsCache,
+  filterEngagedModelsByIds,
+  getEngagedModelsCached,
+} from '~/server/services/engaged-models.cache';
 import * as rewards from '~/server/rewards';
 import { firstDailyFollowReward } from '~/server/rewards/active/firstDailyFollow.reward';
 import type { GetAllSchema, GetByIdInput } from '~/server/schema/base.schema';
@@ -55,10 +59,7 @@ import type {
 } from '~/server/selectors/cosmetic.selector';
 import { simpleUserSelect } from '~/server/selectors/user.selector';
 import { getUserNotificationCount } from '~/server/services/notification.service';
-import {
-  getResourceReviewsByUserId,
-  getUserResourceReview,
-} from '~/server/services/resourceReview.service';
+import { getUserResourceReview } from '~/server/services/resourceReview.service';
 import {
   createCustomer,
   deleteCustomerPaymentMethod,
@@ -82,8 +83,6 @@ import {
   getUserCosmetics,
   getUserCreator,
   getUserDownloadedModelVersions,
-  getUserEngagedModels,
-  getUserEngagedModelsByIds,
   getUserEngagedModelVersions,
   getUserList,
   getUserPurchasedRewards,
@@ -630,47 +629,23 @@ export const restoreUserHandler = async ({
   }
 };
 
-type EngagedModelType = ModelEngagementType | 'Recommended';
-
 export const getUserEngagedModelsHandler = async ({ ctx }: { ctx: ProtectedContext }) => {
   const { id } = ctx.user;
 
   try {
-    const engagementsCache = await redis.get(
-      `${REDIS_KEYS.USER.BASE}:${id}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`
-    );
-    if (engagementsCache) return JSON.parse(engagementsCache) as Record<EngagedModelType, number[]>;
-
-    const engagements = await getUserEngagedModels({ id });
-    const recommendedReviews = await getResourceReviewsByUserId({ userId: id, recommended: true });
-
-    // turn array of user.engagedModels into object with `type` as key and array of modelId as value
-    const engagedModels = engagements.reduce<Record<EngagedModelType, number[]>>((acc, model) => {
-      const { type, modelId } = model;
-      if (!acc[type]) acc[type] = [];
-      acc[type].push(modelId);
-      return acc;
-    }, {} as Record<EngagedModelType, number[]>);
-    engagedModels.Recommended = recommendedReviews.map((r) => r.modelId).filter(isDefined);
-
-    await redis.set(
-      `${REDIS_KEYS.USER.BASE}:${id}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`,
-      JSON.stringify(engagedModels),
-      {
-        EX: 60 * 60 * 24,
-      }
-    );
-
-    return engagedModels;
+    return await getEngagedModelsCached(id);
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     throw throwDbError(error);
   }
 };
 
-// Additive, per-visible-set counterpart to `getUserEngagedModelsHandler`. Bounded input →
-// bounded response, so (unlike the whole-history handler above) there is no cache: the tiny,
-// index-scannable payload isn't worth the combinatorial keyspace + bust-site sprawl.
+// Per-visible-set counterpart to `getUserEngagedModelsHandler` — 1-in-7 of all API requests.
+// Serves the SAME per-user cached engagement set and intersects it with the requested,
+// bounded `modelIds` in process (a per-user key, not per-(user, ids), so the hit rate isn't
+// destroyed by the combinatorial id-set space). The wire response is identical to the prior
+// DB-direct path: only the engagement types the user actually has over the input set, plus
+// `Recommended`.
 export const getUserEngagedModelsByIdsHandler = async ({
   input,
   ctx,
@@ -680,7 +655,8 @@ export const getUserEngagedModelsByIdsHandler = async ({
 }) => {
   const { id } = ctx.user;
   try {
-    return await getUserEngagedModelsByIds({ id, modelIds: input.modelIds });
+    const all = await getEngagedModelsCached(id);
+    return filterEngagedModelsByIds(all, input.modelIds);
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     throw throwDbError(error);
@@ -919,7 +895,7 @@ export const toggleHideModelHandler = async ({
         modelId: input.modelId,
       });
     }
-    await redis.del(`${REDIS_KEYS.USER.BASE}:${userId}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`);
+    await bustEngagedModelsCache(userId);
   } catch (error) {
     throw throwDbError(error);
   }
@@ -975,7 +951,7 @@ export async function toggleFavoriteHandler({
       });
   }
 
-  await redis.del(`${REDIS_KEYS.USER.BASE}:${userId}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`);
+  await bustEngagedModelsCache(userId);
 
   return reviewResult;
 }
@@ -1009,7 +985,7 @@ export const toggleNotifyModelHandler = async ({
         modelId: input.modelId,
       });
     }
-    await redis.del(`${REDIS_KEYS.USER.BASE}:${userId}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`);
+    await bustEngagedModelsCache(userId);
 
     return result;
   } catch (error) {

--- a/src/server/services/__tests__/engaged-models.cache.test.ts
+++ b/src/server/services/__tests__/engaged-models.cache.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Tier B per-user Redis cache behind `user.getEngagedModels` /
+ * `user.getEngagedModelsByIds` (the latter is ~1-in-7 of all API requests, previously
+ * uncached). These tests pin the three properties the perf lever depends on being SAFE:
+ *
+ *   1. cache miss → builds from the DB AND writes the value back (populate);
+ *   2. cache hit → serves from Redis and does NOT re-query the DB (the CPU win);
+ *   3. a bust → a stale value does NOT survive (the correctness path); plus
+ *   4. `filterEngagedModelsByIds` reproduces the byte-for-byte shape of the prior
+ *      DB-direct `getUserEngagedModelsByIds` (transparent cache, no wire change).
+ *
+ * `~/server/db/client` and `~/server/redis/client` are mocked at the boundary with an
+ * in-memory Redis (a Map) and mutable fixture tables, so the real module code runs.
+ */
+
+const { store, mockRedis, mockDb, engagementRows, reviewRows } = vi.hoisted(() => {
+  type EngRow = { userId: number; modelId: number; type: string };
+  type RevRow = { userId: number; modelId: number; recommended: boolean };
+
+  const store = new Map<string, string>();
+  const engagementRows: EngRow[] = [];
+  const reviewRows: RevRow[] = [];
+
+  return {
+    store,
+    engagementRows,
+    reviewRows,
+    mockRedis: {
+      redis: {
+        get: vi.fn(async (key: string) => (store.has(key) ? store.get(key)! : null)),
+        set: vi.fn(async (key: string, value: string) => {
+          store.set(key, value);
+        }),
+        del: vi.fn(async (key: string) => {
+          store.delete(key);
+        }),
+      },
+      // Key parts — the exact literals are irrelevant to the test; consistency across
+      // get/set/del is what matters (the module derives one key from these).
+      REDIS_KEYS: { USER: { BASE: 'user' } },
+      REDIS_SUB_KEYS: { USER: { MODEL_ENGAGEMENTS: 'model-engagements' } },
+    },
+    mockDb: {
+      dbRead: {
+        modelEngagement: {
+          findMany: vi.fn(async ({ where }: any) =>
+            engagementRows
+              .filter((r) => r.userId === where.userId)
+              .map((r) => ({ modelId: r.modelId, type: r.type }))
+          ),
+        },
+        resourceReview: {
+          findMany: vi.fn(async ({ where }: any) =>
+            reviewRows
+              .filter(
+                (r) =>
+                  r.userId === where.userId &&
+                  (where.recommended === undefined || r.recommended === where.recommended)
+              )
+              .map((r) => ({ modelId: r.modelId }))
+          ),
+        },
+      },
+    },
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb.dbRead, dbWrite: mockDb.dbRead }));
+vi.mock('~/server/redis/client', () => mockRedis);
+
+import {
+  bustEngagedModelsCache,
+  filterEngagedModelsByIds,
+  getEngagedModelsCached,
+  type EngagedModelType,
+} from '~/server/services/engaged-models.cache';
+
+const USER = 1;
+const OTHER = 2;
+
+function seed() {
+  engagementRows.length = 0;
+  reviewRows.length = 0;
+  engagementRows.push(
+    { userId: USER, modelId: 101, type: 'Favorite' },
+    { userId: USER, modelId: 102, type: 'Hide' },
+    { userId: USER, modelId: 102, type: 'Notify' },
+    { userId: USER, modelId: 103, type: 'Favorite' },
+    { userId: OTHER, modelId: 999, type: 'Favorite' } // isolation
+  );
+  reviewRows.push(
+    { userId: USER, modelId: 101, recommended: true },
+    { userId: USER, modelId: 104, recommended: true },
+    { userId: USER, modelId: 105, recommended: false } // must never appear
+  );
+}
+
+beforeEach(() => {
+  store.clear();
+  vi.clearAllMocks();
+  seed();
+});
+
+describe('getEngagedModelsCached — miss → build + populate', () => {
+  it('builds the full per-user set from the DB and writes it to Redis', async () => {
+    const res = await getEngagedModelsCached(USER);
+
+    expect(res.Favorite).toEqual(expect.arrayContaining([101, 103]));
+    expect(res.Hide).toEqual([102]);
+    expect(res.Notify).toEqual([102]);
+    expect(res.Recommended).toEqual(expect.arrayContaining([101, 104]));
+    expect(res.Recommended).not.toContain(105); // recommended:false excluded
+
+    // Populated Redis for next time.
+    expect(mockRedis.redis.set).toHaveBeenCalledTimes(1);
+    expect(store.size).toBe(1);
+    // Built from the DB once each.
+    expect(mockDb.dbRead.modelEngagement.findMany).toHaveBeenCalledTimes(1);
+    expect(mockDb.dbRead.resourceReview.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not leak another user’s engagements', async () => {
+    const res = await getEngagedModelsCached(USER);
+    expect(Object.values(res).flat()).not.toContain(999);
+  });
+});
+
+describe('getEngagedModelsCached — hit serves from Redis (the CPU win)', () => {
+  it('a second read hits Redis and does NOT re-query the DB', async () => {
+    const first = await getEngagedModelsCached(USER);
+    vi.clearAllMocks();
+
+    const second = await getEngagedModelsCached(USER);
+
+    expect(second).toEqual(first); // identical result
+    expect(mockRedis.redis.get).toHaveBeenCalledTimes(1);
+    expect(mockDb.dbRead.modelEngagement.findMany).not.toHaveBeenCalled();
+    expect(mockDb.dbRead.resourceReview.findMany).not.toHaveBeenCalled();
+    expect(mockRedis.redis.set).not.toHaveBeenCalled();
+  });
+});
+
+describe('bustEngagedModelsCache — stale value does not survive', () => {
+  it('after a bust, the next read re-builds from the (now-changed) DB', async () => {
+    // Warm the cache.
+    const before = await getEngagedModelsCached(USER);
+    expect(before.Favorite).toEqual(expect.arrayContaining([101, 103]));
+
+    // Mutate the underlying data (simulate an engagement mutation) and bust.
+    engagementRows.push({ userId: USER, modelId: 200, type: 'Favorite' });
+    await bustEngagedModelsCache(USER);
+    expect(store.size).toBe(0);
+
+    const after = await getEngagedModelsCached(USER);
+    expect(after.Favorite).toEqual(expect.arrayContaining([101, 103, 200]));
+    // Proves it did NOT serve the stale pre-mutation value.
+    expect(after.Favorite).toContain(200);
+  });
+
+  it('WITHOUT a bust, the stale value IS served (guards that the bust is load-bearing)', async () => {
+    await getEngagedModelsCached(USER);
+    engagementRows.push({ userId: USER, modelId: 200, type: 'Favorite' });
+
+    const stale = await getEngagedModelsCached(USER);
+    expect(stale.Favorite).not.toContain(200); // stale by design until busted
+  });
+});
+
+describe('filterEngagedModelsByIds — transparent-cache shape parity', () => {
+  const full: Record<EngagedModelType, number[]> = {
+    Favorite: [101, 103],
+    Hide: [102],
+    Notify: [102],
+    Mute: [104],
+    Recommended: [101, 105],
+  } as Record<EngagedModelType, number[]>;
+
+  it('intersects each type with the requested ids', () => {
+    const res = filterEngagedModelsByIds(full, [101, 102]);
+    expect(res.Favorite).toEqual([101]);
+    expect(res.Hide).toEqual([102]);
+    expect(res.Notify).toEqual([102]);
+    expect(res.Recommended).toEqual([101]);
+  });
+
+  it('omits a type key entirely when nothing intersects (matches the prior reduce shape)', () => {
+    const res = filterEngagedModelsByIds(full, [101]);
+    // 101 is Favorite + Recommended only → Hide/Notify/Mute keys must be ABSENT.
+    expect(res.Favorite).toEqual([101]);
+    expect(res.Recommended).toEqual([101]);
+    expect(res).not.toHaveProperty('Hide');
+    expect(res).not.toHaveProperty('Notify');
+    expect(res).not.toHaveProperty('Mute');
+  });
+
+  it('always includes Recommended, even when empty', () => {
+    const res = filterEngagedModelsByIds(full, [999]);
+    expect(res.Recommended).toEqual([]);
+    expect(Object.values(res).flat()).toEqual([]); // no engagement-type keys for an absent id
+  });
+
+  it('an id in the request but engaged under no type appears nowhere', () => {
+    const res = filterEngagedModelsByIds(full, [102, 999]);
+    const all = Object.values(res).flat();
+    expect(all).toContain(102);
+    expect(all).not.toContain(999);
+  });
+
+  it('end-to-end: filtering the cached full set equals the intersection of (engagements ∩ ids)', async () => {
+    const cached = await getEngagedModelsCached(USER);
+    const res = filterEngagedModelsByIds(cached, [101, 102, 104]);
+    // 101 Favorite+Recommended, 102 Hide+Notify, 104 Recommended only.
+    expect(res.Favorite).toEqual([101]);
+    expect(res.Hide).toEqual([102]);
+    expect(res.Notify).toEqual([102]);
+    expect(res.Recommended).toEqual(expect.arrayContaining([101, 104]));
+    expect(res.Recommended).toHaveLength(2);
+    expect(res.Favorite).not.toContain(103); // engaged but not requested
+  });
+});

--- a/src/server/services/engaged-models.cache.ts
+++ b/src/server/services/engaged-models.cache.ts
@@ -1,0 +1,100 @@
+import { dbRead } from '~/server/db/client';
+import type { RedisKeyTemplateCache } from '~/server/redis/client';
+import { redis, REDIS_KEYS, REDIS_SUB_KEYS } from '~/server/redis/client';
+import type { ModelEngagementType } from '~/shared/utils/prisma/enums';
+import { isDefined } from '~/utils/type-guards';
+
+/**
+ * Tier B server cache for the per-user model-engagement set that backs
+ * `user.getEngagedModels` (whole set) and `user.getEngagedModelsByIds` (bounded
+ * intersection — 1-in-7 of all API requests, previously uncached).
+ *
+ * The cached value is the user's FULL engagement set keyed by engagement type
+ * (+ `Recommended`, derived from recommended resource reviews). `getEngagedModelsByIds`
+ * intersects it with the requested ids IN PROCESS — a per-user key (not per-(user,ids))
+ * so the hit rate isn't destroyed by the combinatorial id-set space. The wire response
+ * of both handlers is byte-for-byte what it was before the cache; this is a pure,
+ * transparent server-side cache.
+ *
+ * CORRECTNESS is by explicit invalidation at every mutation that changes a user's model
+ * engagement, NOT by the TTL — the 24h TTL is only a backstop. Call `bustEngagedModelsCache`
+ * from every such mutation site (see references). The key + TTL match the pre-existing
+ * `MODEL_ENGAGEMENTS` cache so this shares that cache's existing bust surface.
+ */
+
+export type EngagedModelType = ModelEngagementType | 'Recommended';
+
+// 24h backstop. Real freshness comes from bustEngagedModelsCache() at the mutation sites.
+export const ENGAGED_MODELS_CACHE_TTL = 60 * 60 * 24;
+
+const engagedModelsKey = (userId: number): RedisKeyTemplateCache =>
+  `${REDIS_KEYS.USER.BASE}:${userId}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`;
+
+/**
+ * Get the user's full engaged-models set, served from redis when warm and rebuilt from
+ * the DB on a miss (then written back). Shape: `Record<EngagedModelType, number[]>` — one
+ * array of modelIds per engagement type the user has, plus `Recommended`.
+ */
+export async function getEngagedModelsCached(
+  userId: number
+): Promise<Record<EngagedModelType, number[]>> {
+  const key = engagedModelsKey(userId);
+  const cached = await redis.get(key);
+  if (cached) return JSON.parse(cached) as Record<EngagedModelType, number[]>;
+
+  // Rebuild from the DB. These two queries mirror `getUserEngagedModels` +
+  // `getResourceReviewsByUserId({ recommended: true })` — inlined here so this cache
+  // module stays dependency-light (no service-layer import cycles).
+  const [engagements, recommendedReviews] = await Promise.all([
+    dbRead.modelEngagement.findMany({
+      where: { userId },
+      select: { modelId: true, type: true },
+    }),
+    dbRead.resourceReview.findMany({
+      where: { userId, recommended: true },
+      select: { modelId: true },
+    }),
+  ]);
+
+  const engagedModels = engagements.reduce<Record<EngagedModelType, number[]>>((acc, model) => {
+    const { type, modelId } = model;
+    if (!acc[type]) acc[type] = [];
+    acc[type].push(modelId);
+    return acc;
+  }, {} as Record<EngagedModelType, number[]>);
+  engagedModels.Recommended = recommendedReviews.map((r) => r.modelId).filter(isDefined);
+
+  await redis.set(key, JSON.stringify(engagedModels), { EX: ENGAGED_MODELS_CACHE_TTL });
+
+  return engagedModels;
+}
+
+/**
+ * Intersect the full engaged-models set with a bounded `modelIds` set, in process.
+ *
+ * Reproduces the exact shape the DB-direct `getUserEngagedModelsByIds` returned: a type
+ * key is present ONLY when at least one requested id is engaged under it, and `Recommended`
+ * is ALWAYS present (possibly empty). Array element order is irrelevant — the client folds
+ * every array into membership sets.
+ */
+export function filterEngagedModelsByIds(
+  all: Record<EngagedModelType, number[]>,
+  modelIds: number[]
+): Record<EngagedModelType, number[]> {
+  const wanted = new Set(modelIds);
+  const result = {} as Record<EngagedModelType, number[]>;
+
+  for (const type of Object.keys(all) as EngagedModelType[]) {
+    if (type === 'Recommended') continue; // always set last, even when empty
+    const filtered = (all[type] ?? []).filter((modelId) => wanted.has(modelId));
+    if (filtered.length) result[type] = filtered;
+  }
+  result.Recommended = (all.Recommended ?? []).filter((modelId) => wanted.has(modelId));
+
+  return result;
+}
+
+/** Invalidate the user's engaged-models cache. Call from every engagement mutation. */
+export async function bustEngagedModelsCache(userId: number): Promise<void> {
+  await redis.del(engagedModelsKey(userId));
+}

--- a/src/server/services/user-preferences.service.ts
+++ b/src/server/services/user-preferences.service.ts
@@ -4,6 +4,7 @@ import { userFollowsCache } from '~/server/redis/caches';
 import type { RedisKeyTemplateCache } from '~/server/redis/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import type { ToggleHiddenSchemaOutput } from '~/server/schema/user-preferences.schema';
+import { bustEngagedModelsCache } from '~/server/services/engaged-models.cache';
 import { getModeratedTags } from '~/server/services/system-cache';
 import type { HiddenPreferencesCompact } from '~/shared/hidden-preferences/compact';
 import { toCompactHiddenPreferences } from '~/shared/hidden-preferences/compact';
@@ -651,6 +652,10 @@ async function toggleHideModel({
     });
 
   await HiddenModels.refreshCache({ userId });
+  // This path mutates the same `modelEngagement` Hide rows that back the engaged-models
+  // cache (via hidden-preferences.toggleHidden), so bust it too — the user.controller
+  // toggleHideModelHandler is a DIFFERENT entry point that already busts.
+  await bustEngagedModelsCache(userId);
 
   // const addedOrUpdated = !engagement || engagement.type !== 'Hide';
   // const toReturn = { id: modelId, kind: 'model' } as HiddenPreferencesKind;


### PR DESCRIPTION
## What

`user.getEngagedModelsByIds` was **uncached** despite being **~14.3% of all API requests (1 in 7)**. Every call re-ran the fixed per-request overhead plus a DB round-trip (`modelEngagement` + `resourceReview`).

This routes it through the **same per-user engagement-set cache** that already backs `user.getEngagedModels`, and intersects the cached full set with the requested `modelIds` **in process**. Key design point: the cache key is **per-user**, not per-`(user, modelIds)` — a per-request-set key would have a terrible hit rate against the combinatorial id-set space.

## Why

It's one of the highest-volume API procedures and was doing DB work on every hit. A transparent per-user cache should meaningfully cut steady-state API CPU (order of a couple of API pods' worth of headroom).

## Wire shape is unchanged

This is a **pure, transparent server-side cache** — same output, fewer DB queries. `filterEngagedModelsByIds` reproduces the exact prior shape: a per-engagement-type key is present **only** when at least one requested id is engaged under it, and `Recommended` is **always** present (possibly empty). Array element order is irrelevant (the client folds each array into membership sets). **No feature flag, no client change.**

## Cache key + TTL

- **Key:** `user:<userId>:model-engagements` (the existing `MODEL_ENGAGEMENTS` key — shared with `getEngagedModels`, so both share one bust surface).
- **TTL:** `EX` 24h. The TTL is only a **backstop**; freshness comes from explicit invalidation at every mutation. A long TTL + complete busting maximizes hit rate while staying correct.

## Invalidation — every model-engagement mutation busts the key

All sites now go through a single `bustEngagedModelsCache(userId)` helper (centralized so the key can't drift):

| Site | Engagement affected | Status |
|---|---|---|
| `toggleHideModelHandler` (user.controller) | Hide | already busted |
| `toggleFavoriteHandler` (user.controller) | Favorite / Notify / review | already busted |
| `toggleNotifyModelHandler` (user.controller) | Notify + other types | already busted |
| `createResourceReviewHandler` (resourceReview.controller) | Recommended | already busted |
| `updateResourceReviewHandler` (resourceReview.controller) | Recommended | already busted |
| `deleteResourceReviewHandler` (resourceReview.controller) | Recommended | **NEW — closes a pre-existing gap** |
| `toggleHideModel` via `hidden-preferences.toggleHidden` (user-preferences.service) | Hide | **NEW — closes a pre-existing gap** |

The two NEW sites were already stale in the existing `getEngagedModels` handler (up to the 24h TTL) — this PR fixes them for both paths. `toggleHideModel3D` was checked and intentionally **not** included: it writes a different table (`model3DEngagement`) that doesn't back this cache.

## Tests

- New `engaged-models.cache.test.ts` (10): cache **miss → builds from DB + populates**; cache **hit serves from Redis without re-querying the DB**; **bust → a stale value does not survive** (a mutation is reflected on the next read); `filterEngagedModelsByIds` shape parity (type-key omission when empty, `Recommended` always present, intersection correctness).
- Existing `get-engaged-models-by-ids.service.test.ts` (16) still green — it guards the intersection semantics the in-process filter reproduces.
- `tsc --noEmit`: clean.

## Note

Re-profile after deploy to book the CPU-peak drop **before** any autoscaling-floor change.