### PR TITLE
test(gallery): cover lazy-load hidden-prefs safety path + pre-ramp fixes (#3071 follow-up)

### DIFF
--- a/src/components/HiddenPreferences/__tests__/useApplyHiddenPreferences.test.ts
+++ b/src/components/HiddenPreferences/__tests__/useApplyHiddenPreferences.test.ts
@@ -186,3 +186,131 @@ describe('useApplyHiddenPreferences — feed-drop emit fires from the commit eff
     unmount();
   });
 });
+
+// ============================================================================
+// `case 'images'` branch — the content-safety filter the gallery's LAZY per-post
+// carousel re-applies to its fetched tail (`useApplyHiddenPreferences({ type:
+// 'images' })` in `LazyPostImagesCarousel`, #3071). #3071 shipped this branch
+// UNTESTED — the browser test stubbed the hook to identity, so it would have
+// passed even if the filter were deleted. These pin the REAL pure filter so a
+// hidden image can never silently leak into the lazily-loaded tail.
+// ============================================================================
+
+type ImgOverrides = Partial<{
+  id: number;
+  userId: number;
+  nsfwLevel: number;
+  tagIds: number[];
+  poi: boolean;
+  minor: boolean;
+  prompt: string;
+}>;
+
+// A single browsing-visible image (nsfwLevel 1 intersects BROWSING_LEVEL 1). Each
+// override flips exactly one drop dimension so a failing case isolates one rule.
+const makeImage = (o: ImgOverrides = {}) => ({
+  id: o.id ?? nextId++,
+  userId: o.userId ?? 9999,
+  nsfwLevel: o.nsfwLevel ?? 1,
+  tagIds: o.tagIds ?? [],
+  poi: o.poi ?? false,
+  minor: o.minor ?? false,
+  prompt: o.prompt ?? '',
+});
+
+const prefsWith = (
+  o: Partial<{ images: number[]; users: number[]; tags: number[]; systemTags: number[] }> = {}
+): HiddenPreferencesState => ({
+  ...emptyPrefs(),
+  hiddenImages: new Map((o.images ?? []).map((id): [number, boolean] => [id, true])),
+  hiddenUsers: new Map((o.users ?? []).map((id): [number, boolean] => [id, true])),
+  hiddenTags: new Map((o.tags ?? []).map((id): [number, boolean] => [id, true])),
+  systemHiddenTags: new Map((o.systemTags ?? []).map((id): [number, boolean] => [id, true])),
+});
+
+type RunImagesOpts = {
+  hiddenPreferences?: HiddenPreferencesState;
+  poiDisabled?: boolean;
+  minorDisabled?: boolean;
+  currentUser?: unknown;
+};
+const runImages = (data: ReturnType<typeof makeImage>[], opts: RunImagesOpts = {}) =>
+  filterPreferences({
+    type: 'images',
+    data,
+    hiddenPreferences: opts.hiddenPreferences ?? emptyPrefs(),
+    browsingLevel: BROWSING_LEVEL,
+    currentUser: (opts.currentUser ?? null) as never,
+    canViewNsfw: true,
+    poiDisabled: opts.poiDisabled ?? false,
+    minorDisabled: opts.minorDisabled ?? false,
+  });
+
+describe("filterPreferences — 'images' branch drops every hidden dimension (lazy-tail safety)", () => {
+  it('keeps a browsing-visible image untouched', () => {
+    const { items } = runImages([makeImage({ id: 1 })]);
+    expect(items.map((i) => i.id)).toEqual([1]);
+  });
+
+  // [label, the-image-that-must-drop, filter opts]. Each pairs the dirty image with
+  // a clean sibling (id 1) and asserts the clean one survives while the dirty drops.
+  const cases: Array<[string, ReturnType<typeof makeImage>, RunImagesOpts, keyof ReturnType<typeof runImages>['hidden']]> = [
+    ['browsing-level mismatch', makeImage({ id: 2, nsfwLevel: 2 }), {}, 'browsingLevel'],
+    ['hidden image id', makeImage({ id: 3 }), { hiddenPreferences: prefsWith({ images: [3] }) }, 'images'],
+    ['hidden user', makeImage({ id: 4, userId: 555 }), { hiddenPreferences: prefsWith({ users: [555] }) }, 'users'],
+    ['hidden tag', makeImage({ id: 5, tagIds: [88] }), { hiddenPreferences: prefsWith({ tags: [88] }) }, 'tags'],
+    ['system hidden tag', makeImage({ id: 6, tagIds: [77] }), { hiddenPreferences: prefsWith({ systemTags: [77] }) }, 'tags'],
+    ['poi (disablePoi)', makeImage({ id: 7, poi: true }), { poiDisabled: true }, 'poi'],
+    ['minor (disableMinor)', makeImage({ id: 8, minor: true }), { minorDisabled: true }, 'minor'],
+  ];
+
+  it.each(cases)('drops a %s image and keeps the clean sibling', (_label, dirty, opts, counter) => {
+    const { items, hidden } = runImages([makeImage({ id: 1 }), dirty], opts);
+    const ids = items.map((i) => i.id);
+    expect(ids).toContain(1); // the clean image survives
+    expect(ids).not.toContain(dirty.id); // the hidden one is filtered out
+    expect(hidden[counter]).toBe(1); // …and attributed to the right dimension
+  });
+
+  it('does NOT drop a poi/minor image when the respective toggle is OFF', () => {
+    const { items } = runImages([makeImage({ id: 9, poi: true, minor: true })], {
+      poiDisabled: false,
+      minorDisabled: false,
+    });
+    expect(items.map((i) => i.id)).toEqual([9]);
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Seed ↔ tail parity. The feed seed runs the `posts` per-image filter; the lazy
+// carousel's tail runs the `images` filter. For the shared drop dimensions the
+// `images` branch is a superset, so nothing the seed drops can reappear via the
+// tail, and a tail-only image that clears the bar is admitted.
+// ----------------------------------------------------------------------------
+describe("seed ('posts') ↔ tail ('images') filter parity — no reappear-via-tail", () => {
+  it('an image the posts-seed filter drops (hidden tag) is also dropped by the images tail', () => {
+    const clean = makeImage({ id: 10 });
+    const dirty = makeImage({ id: 11, tagIds: [42] });
+    const hiddenTag = prefsWith({ tags: [42] });
+
+    // Seed: the `posts` branch filters each post's images.
+    const posts = filterPreferences({
+      type: 'posts',
+      data: [{ userId: 9999, nsfwLevel: 1, images: [clean, dirty] }],
+      hiddenPreferences: hiddenTag,
+      browsingLevel: BROWSING_LEVEL,
+      currentUser: null as never,
+      canViewNsfw: true,
+    });
+    expect(posts.items[0].images.map((i: { id: number }) => i.id)).toEqual([10]);
+
+    // Tail: the same dirty image is dropped by the `images` branch.
+    const tail = runImages([clean, dirty], { hiddenPreferences: hiddenTag });
+    expect(tail.items.map((i) => i.id)).toEqual([10]);
+  });
+
+  it('a tail-only image that clears the bar survives the images filter', () => {
+    const tailOnly = makeImage({ id: 12 });
+    expect(runImages([tailOnly]).items.map((i) => i.id)).toEqual([12]);
+  });
+});

--- a/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsCard.tsx
@@ -559,7 +559,7 @@ export function LazyPostImagesCarousel({
   // The tail = the WHOLE post (≤ POST_IMAGE_LIMIT), same version/browsing-level
   // filters the gallery used, so the returned set matches `imageCount`. postId
   // forces the DB path server-side (covered index, ~2ms).
-  const { data: tailData } = trpc.image.getInfinite.useQuery(
+  const { data: tailData, isError: tailError } = trpc.image.getInfinite.useQuery(
     {
       ...filters,
       postId,
@@ -568,7 +568,9 @@ export function LazyPostImagesCarousel({
       include: ['cosmetics', 'tagIds'],
     },
     {
-      enabled: fetchTail,
+      // `postId != null` is the explicit invariant: a null postId must never broaden
+      // `getInfinite` to the model's general feed (it would append unrelated images).
+      enabled: fetchTail && postId != null,
       trpc: { context: { skipBatch: true } },
       staleTime: 5 * 60 * 1000,
     }
@@ -601,7 +603,13 @@ export function LazyPostImagesCarousel({
   // Before the tail resolves, advertise the true count so indicators read "1 of N".
   // After, use the actual loaded length so navigation never dead-ends if the tail
   // came back short (a hidden-pref drop) — self-correcting.
-  const effectiveTotal = fetched ? loaded.length : total;
+  //
+  // On a persistent tail-fetch ERROR the tail never arrives (`fetched` stays false),
+  // so fall back to `loaded.length` (the seed) too — otherwise `effectiveTotal` would
+  // stay at the true count while `loaded` holds only the seed, stranding the unloaded
+  // slots on an unreachable `<Loader/>` at a dead-end "1 of N". Degrade only on error;
+  // the normal in-flight case keeps the true count so the loaders show while fetching.
+  const effectiveTotal = fetched || tailError ? loaded.length : total;
 
   return (
     <SimpleImageCarousel

--- a/src/components/Image/AsPosts/ImagesAsPostsCardLazyCarousel.browser.test.tsx
+++ b/src/components/Image/AsPosts/ImagesAsPostsCardLazyCarousel.browser.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 
 // =============================================================================
@@ -9,16 +9,27 @@ import { page, userEvent } from 'vitest/browser';
 //     advertises the true total, and when the active slide approaches the loaded
 //     edge it fires `trpc.image.getInfinite({ postId })` (enabled flips true) and
 //     appends the fetched tail — image 7 becomes navigable.
+//   * CONTENT SAFETY: the fetched tail is re-run through the REAL
+//     `useApplyHiddenPreferences({ type: 'images' })` filter (not an identity
+//     stub), so a hidden image fed into the tail is genuinely dropped and never
+//     renders — and the regression test fails if the component stops filtering.
+//   * DEGRADATION: a persistent tail-fetch error collapses the count to what is
+//     loaded (no phantom `<Loader/>` slots on an unreachable "1 of N").
+//   * `postId == null` never broadens the tail query.
 //   * STATIC (flag off / post within the slice): renders all images inline and
 //     NEVER calls `getInfinite`.
 //
-// The pure decision/merge logic + the server slice/imageCount transform are
-// covered by node unit tests (lazyPostImages.test.ts, images-as-posts-wire.test.ts).
-// Here we boundary-stub the slide's heavy leaves and drive the REAL SimpleImageCarousel.
+// The pure decision/merge logic + the server slice/imageCount transform + the
+// exhaustive per-dimension `images`-filter drop cases are covered by node unit
+// tests (lazyPostImages.test.ts, images-as-posts-wire.test.ts,
+// useApplyHiddenPreferences.test.ts). Here we boundary-stub the slide's heavy
+// leaves and drive the REAL SimpleImageCarousel + REAL hidden-prefs filter.
 // =============================================================================
 
 const mocks = vi.hoisted(() => {
-  // A full-shaped image the slide can render (ids 7..20 = the lazily-fetched tail).
+  // A full-shaped image the slide can render AND that the real `images` hidden-prefs
+  // filter can evaluate (needs id/userId/nsfwLevel/tagIds/poi/minor/prompt). ids
+  // 7..20 = the lazily-fetched tail.
   const tailImage = (id: number) => ({
     id,
     type: 'image',
@@ -29,21 +40,37 @@ const mocks = vi.hoisted(() => {
     onSite: false,
     remixOfId: null,
     poi: false,
+    minor: false,
     metadata: { width: 1, height: 1 },
     thumbnailUrl: undefined,
     reactions: [],
     stats: {},
     user: { id: 9 },
+    userId: 9,
+    nsfwLevel: 1,
+    tagIds: [] as number[],
+    prompt: '',
   });
-  return {
-    // getInfinite returns the tail ONLY when enabled (mirrors react-query gating), so
-    // asserting on the returned data also proves the enable-on-approach wiring.
-    getInfiniteUseQuery: vi.fn((_input: any, opts: any) => ({
-      data: opts?.enabled
-        ? { items: Array.from({ length: 14 }, (_, i) => tailImage(i + 7)), nextCursor: undefined }
-        : undefined,
-    })),
+  // Per-test knobs (reset in beforeEach).
+  const state = { error: false };
+  const ctx = {
+    browsingLevel: 1,
+    hiddenImageIds: [] as number[],
+    hiddenTags: [] as number[],
+    hiddenUsers: [] as number[],
   };
+  // getInfinite returns the tail ONLY when enabled (mirrors react-query gating), so
+  // asserting on the returned data also proves the enable-on-approach wiring; on
+  // `state.error` it returns the react-query error shape (isError true, no data).
+  const getInfiniteUseQuery = vi.fn((_input: any, opts: any) => {
+    if (!opts?.enabled) return { data: undefined, isError: false };
+    if (state.error) return { data: undefined, isError: true };
+    return {
+      data: { items: Array.from({ length: 14 }, (_, i) => tailImage(i + 7)), nextCursor: undefined },
+      isError: false,
+    };
+  });
+  return { tailImage, state, ctx, getInfiniteUseQuery };
 });
 
 // --- tail fetch ---------------------------------------------------------------
@@ -58,20 +85,56 @@ vi.mock('~/utils/trpc', () => ({
 vi.mock('~/components/Image/AsPosts/ImagesAsPostsInfiniteProvider', () => ({
   useImagesAsPostsInfiniteContext: () => ({
     filters: { modelId: 1, modelVersionId: 2 },
-    browsingLevel: 1,
-    hiddenImageIds: [],
-    hiddenTags: [],
-    hiddenUsers: [],
+    browsingLevel: mocks.ctx.browsingLevel,
+    hiddenImageIds: mocks.ctx.hiddenImageIds,
+    hiddenTags: mocks.ctx.hiddenTags,
+    hiddenUsers: mocks.ctx.hiddenUsers,
     source: { kind: 'model', model: { id: 1, user: { id: 9 } } },
     modelVersions: [],
   }),
   ImagesAsPostsInfiniteProvider: ({ children }: any) => <>{children}</>,
 }));
 
-// --- hidden-prefs = identity pass-through (its own filtering is unit-tested) ---
-vi.mock('~/components/HiddenPreferences/useApplyHiddenPreferences', () => ({
-  useApplyHiddenPreferences: ({ data }: any) => ({ items: data ?? [] }),
-}));
+// --- hidden-prefs = the REAL `images` filter (NOT identity) --------------------
+// Route the tail through the actual pure `filterPreferences('images')` — the same
+// content-safety branch prod uses — instead of a pass-through. This makes the
+// regression guard below load-bearing: if the component stopped calling this hook
+// (or passed the wrong type), a hidden image would render.
+vi.mock('~/components/HiddenPreferences/useApplyHiddenPreferences', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('~/components/HiddenPreferences/useApplyHiddenPreferences')
+  >();
+  return {
+    ...actual,
+    useApplyHiddenPreferences: ({
+      type,
+      data,
+      hiddenImages = [],
+      hiddenUsers = [],
+      hiddenTags = [],
+      browsingLevel,
+    }: any) => {
+      const { items } = actual.filterPreferences({
+        type,
+        data,
+        hiddenPreferences: {
+          hiddenUsers: new Map(hiddenUsers.map((id: number) => [id, true])),
+          hiddenTags: new Map(hiddenTags.map((id: number) => [id, true])),
+          hiddenModels: new Map(),
+          hiddenModel3Ds: new Map(),
+          hiddenImages: new Map(hiddenImages.map((id: number) => [id, true])),
+          hiddenLoading: false,
+          moderatedTags: [],
+          systemHiddenTags: new Map(),
+        } as any,
+        browsingLevel,
+        currentUser: null as any,
+        canViewNsfw: true,
+      });
+      return { items };
+    },
+  };
+});
 
 // --- slide leaves: render a marker carrying the image id ----------------------
 vi.mock('~/components/EdgeMedia/EdgeMedia', () => ({
@@ -130,10 +193,26 @@ const slice = (n: number, from = 1) =>
 
 const activeSlideId = () => page.getByTestId('slide');
 const clickNext = () => userEvent.click(page.getByRole('button').nth(1)); // [prev, next]
+// Indicators are the only aria-hidden buttons (controls are focusable); their count
+// == the carousel's `effectiveTotal`.
+const indicatorCount = () => document.querySelectorAll('button[aria-hidden]').length;
+// Walk toward the end of the 6-image seed. At index 4 (threshold 2) the tail fetch
+// latches; six clicks lands on carousel index 6 = the first appended tail image.
+const walkToTail = async () => {
+  for (let i = 0; i < 6; i++) await clickNext();
+};
+
+beforeEach(() => {
+  mocks.getInfiniteUseQuery.mockClear();
+  mocks.state.error = false;
+  mocks.ctx.browsingLevel = 1;
+  mocks.ctx.hiddenImageIds = [];
+  mocks.ctx.hiddenTags = [];
+  mocks.ctx.hiddenUsers = [];
+});
 
 describe('LazyPostImagesCarousel', () => {
   test('advertises the true count, and lazy-loads + appends the tail on approach', async () => {
-    mocks.getInfiniteUseQuery.mockClear();
     const data = { postId: 100, imageCount: 20, images: slice(6) } as any;
     renderWithProviders(<LazyPostImagesCarousel data={data} postId={100} />);
 
@@ -146,9 +225,7 @@ describe('LazyPostImagesCarousel', () => {
       true
     );
 
-    // Walk toward the end of the loaded slice (6). At index 4 (within threshold 2)
-    // the fetch enables; keep going to index 6 — the FIRST appended tail image.
-    for (let i = 0; i < 6; i++) await clickNext();
+    await walkToTail();
 
     // The tail fetch was enabled, scoped to this post + the gallery's browsing level.
     await vi.waitFor(() => {
@@ -162,11 +239,82 @@ describe('LazyPostImagesCarousel', () => {
     // Image 7 (the first lazily-fetched image) is now navigable — NOT truncated.
     await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '7');
   });
+
+  test('re-applies hidden preferences to the tail — a hidden image never renders (safety regression guard)', async () => {
+    // The first tail image (id 7) is user-hidden. The feed forwarded it via context.
+    mocks.ctx.hiddenImageIds = [7];
+    const data = { postId: 100, imageCount: 20, images: slice(6) } as any;
+    renderWithProviders(<LazyPostImagesCarousel data={data} postId={100} />);
+
+    await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '1');
+    await walkToTail();
+
+    // With id 7 filtered out, the count self-corrects 20 → 19 and the image at
+    // carousel index 6 is id 8 (id 7 is gone). If the component stopped filtering,
+    // index 6 would be id 7 and the count would stay 20 — so this fails loudly.
+    await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '8');
+    await vi.waitFor(() => expect(indicatorCount()).toBe(19));
+  });
+
+  test('count self-corrects on a hidden drop — the last tail image stays reachable (no dead-end)', async () => {
+    mocks.ctx.hiddenImageIds = [7];
+    const data = { postId: 100, imageCount: 20, images: slice(6) } as any;
+    renderWithProviders(<LazyPostImagesCarousel data={data} postId={100} />);
+
+    await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '1');
+    await walkToTail();
+    await vi.waitFor(() => expect(indicatorCount()).toBe(19));
+
+    // Jump to the last slide (index 18 of 19) — it renders a real image (id 20),
+    // not a stranded <Loader/>.
+    await userEvent.click(page.getByRole('button').nth(1)); // step once more onto index 7
+    for (let i = 0; i < 11; i++) await clickNext(); // …to the final index (18)
+    await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '20');
+  });
+
+  test('degrades gracefully on a tail-fetch error — count collapses to loaded, no phantom loaders', async () => {
+    mocks.state.error = true;
+    const data = { postId: 100, imageCount: 20, images: slice(6) } as any;
+    renderWithProviders(<LazyPostImagesCarousel data={data} postId={100} />);
+
+    await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '1');
+    // Approach the edge to latch the fetch (index 4, threshold 2) but STAY inside the
+    // seed's 6 images so the active slide is still valid after the count collapses.
+    for (let i = 0; i < 5; i++) await clickNext(); // → index 5 (last seed image)
+
+    // The tail query WAS enabled (so the error is real, not a disabled query)…
+    await vi.waitFor(() =>
+      expect(mocks.getInfiniteUseQuery.mock.calls.some(([, opts]) => opts?.enabled === true)).toBe(
+        true
+      )
+    );
+    // …and on error the total collapses from 20 to the 6 loaded seed images — no 14
+    // phantom slots stuck on an unreachable <Loader/>. Without the fix this is 20.
+    await vi.waitFor(() => expect(indicatorCount()).toBe(6));
+    // Every reachable slide is a real image (never a loader) — walk the whole set.
+    for (let i = 0; i < 6; i++) {
+      await expect.element(activeSlideId()).toBeInTheDocument();
+      await clickNext();
+    }
+  });
+
+  test('never enables the tail query when postId is null (no broadening to the general feed)', async () => {
+    const data = { postId: null, imageCount: 20, images: slice(6) } as any;
+    renderWithProviders(<LazyPostImagesCarousel data={data} postId={null as any} />);
+
+    await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '1');
+    await walkToTail(); // would normally latch fetchTail true
+
+    // fetchTail may be latched, but `postId != null` keeps every call disabled.
+    expect(mocks.getInfiniteUseQuery).toHaveBeenCalled();
+    expect(mocks.getInfiniteUseQuery.mock.calls.every(([, opts]) => opts?.enabled === false)).toBe(
+      true
+    );
+  });
 });
 
 describe('StaticPostImagesCarousel', () => {
   test('renders all images inline and never calls getInfinite (flag OFF path)', async () => {
-    mocks.getInfiniteUseQuery.mockClear();
     renderWithProviders(<StaticPostImagesCarousel images={slice(3)} postId={100} />);
 
     await expect.element(activeSlideId()).toHaveAttribute('data-image-id', '1');


### PR DESCRIPTION
Follow-up to #3071 (gallery lazy-load per-post images). #3071 shipped the per-post
image cap as lazy-load instead of truncation: the server returns a 6-image slice +
true `imageCount`, and `LazyPostImagesCarousel` fetches the tail via
`image.getInfinite({ postId })` and re-filters it through
`useApplyHiddenPreferences({ type: 'images' })` before appending.

Two audits confirmed the content-safety logic was correct — but it was **untested**:
the only test touching it stubbed `useApplyHiddenPreferences` to identity, so it
would have passed even if the filter were deleted. This PR closes that gap and lands
two small pre-ramp hardening fixes. Flag stays dark (`galleryLazyPostImages`,
`availability: []`); no ramp. OFF-flag path (`StaticPostImagesCarousel`) is byte-identical.

## Pre-ramp code fixes (`ImagesAsPostsCard.tsx`, `LazyPostImagesCarousel`)

1. **Tail fetch-error graceful degradation.** A persistent `getInfinite` error left
   `tailData` undefined → `effectiveTotal` stayed at the true count (e.g. 20) while
   only the 6-image seed was loaded → 14 slides stuck on `<Loader/>` forever behind an
   unreachable "1 of 20". Now the query's `isError` collapses `effectiveTotal` to
   `loaded.length` on error (no phantom slots, no dead-end). The normal in-flight case
   is unchanged — loaders still show while the tail is fetching.
2. **`postId` guard on the tail query.** `enabled: fetchTail` → `enabled: fetchTail &&
   postId != null`, making the invariant explicit: a null `postId` must never broaden
   `getInfinite` to the model's general feed.

## Tests added (mapping to the gap list)

**`useApplyHiddenPreferences` node unit test** (was `'models'`-only):
- The `'images'` branch now proves every drop dimension — browsing-level mismatch,
  hidden image id, hidden user, hidden tag, system-hidden tag, poi (`disablePoi`),
  minor (`disableMinor`) — plus that poi/minor images survive when the toggles are off.
- Seed↔tail parity: an image the `'posts'` seed filter drops (hidden tag) is also
  dropped by the `'images'` tail filter (no reappear-via-tail), and a tail-only image
  that clears the bar is admitted.

**`ImagesAsPostsCardLazyCarousel.browser.test.tsx`** (replaced the identity stub of
`useApplyHiddenPreferences` with the **real** `filterPreferences('images')` so the
component exercises the actual safety path):
- **Safety regression guard** — a hidden image fed into the tail never renders and the
  count self-corrects (20 → 19). Fails loudly if the component stops filtering.
- **Count self-correction / no dead-end** — on a hidden drop the last tail image stays
  reachable and renders (not a stranded loader).
- **Tail-fetch-error degradation** — on error the count collapses to the loaded seed
  (6), no phantom loaders (covers fix #1).
- **`postId == null`** — the tail query stays disabled even after approach (covers fix #2).

## Verification

- Ran locally on NixOS (Chromium via nix, Prisma types generated via nix
  `prisma-engines`).
- **Node unit** (`vitest --project unit`): 37 passed (incl. the new `'images'` +
  parity cases and the existing wire/decision tests).
- **Browser** (`vitest --project component`, real Chromium): 6 passed.
- **Typecheck** (`tsc --noEmit`): see PR checks / notes.
- **Mutation checks (proof the tests are load-bearing):**
  - Bypassing the `useApplyHiddenPreferences` filter in the component → the 2 browser
    safety tests fail (`expected 20 to be 19` — hidden image leaks); other 4 pass. ✅
  - Making the `'images'` filter branch return unfiltered → 8 node tests fail (the 7
    drop dimensions + the parity assertion); unrelated 7 pass. ✅
  - Reverting fix #1 → error-degradation test fails (`expected 20 to be 6`). ✅
  - Reverting fix #2 → `postId == null` test fails (a call was enabled). ✅
  - All reverted; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
