### PR TITLE
perf(api): debounce getEngagedModelsByIds client batcher (~80ms) to cut request count

### DIFF
--- a/src/hooks/__tests__/useEngagedModelMembership.test.ts
+++ b/src/hooks/__tests__/useEngagedModelMembership.test.ts
@@ -22,6 +22,7 @@ vi.mock('~/hooks/useCurrentUser', () => ({
 
 import {
   __resetEngagedMembershipBatcher,
+  ENGAGED_MEMBERSHIP_DEBOUNCE_MS,
   engagedMembershipBatcher,
   requestEngagedMembership,
   useEngagedModelsMembership,
@@ -29,6 +30,11 @@ import {
 } from '~/hooks/useEngagedModelMembership';
 import { useEngagedModelsStore } from '~/store/engaged-models.store';
 import { applyNotifyToggled } from '~/store/engaged-models.optimistic';
+
+// The REAL production scheduler (an ~80ms setTimeout debounce), captured before
+// beforeEach swaps in the deterministic test scheduler. The debounce-window
+// suite below restores this and drives it with fake timers.
+const productionSchedule = engagedMembershipBatcher.schedule;
 
 // deterministic scheduler: capture the flush callback, fire it on demand.
 let scheduledFlush: (() => void) | null = null;
@@ -507,5 +513,124 @@ describe('notify silent-unsubscribe fix — genuinely-ON model whose by-ids read
     expect(m?.has('Mute')).toBe(false);
 
     act(() => root.unmount());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Debounce window — exercises the REAL production scheduler (an ~80ms
+// setTimeout coalesce), driven with fake timers. This is the request-count
+// reduction this PR ships: ids arriving across many render ticks inside the
+// window fold into ONE getEngagedModelsByIds call; ids after the window fire a
+// new call. (The suites above override `schedule` to a synchronous seam and so
+// do NOT cover the timing — this one does.)
+// ---------------------------------------------------------------------------
+describe('debounce window (real ~80ms scheduler)', () => {
+  // Let queued fetch `.then`/`.catch` microtasks settle. Promises are NOT faked
+  // by vi.useFakeTimers() (only the timer functions are), so awaiting real
+  // microtasks still drains the fold-into-store continuations.
+  const drain = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
+  beforeEach(() => {
+    // Outer beforeEach swapped in the synchronous test scheduler; restore the
+    // real ~80ms setTimeout one and fake the clock so we can drive the window.
+    engagedMembershipBatcher.schedule = productionSchedule;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('window constant is the documented ~80ms', () => {
+    expect(ENGAGED_MEMBERSHIP_DEBOUNCE_MS).toBe(80);
+  });
+
+  it('coalesces ids arriving across MULTIPLE ticks within the window into ONE call (deduped union)', async () => {
+    queryMock.mockResolvedValue({ Recommended: [2] });
+
+    requestEngagedMembership([1, 2]);
+    vi.advanceTimersByTime(30); // still inside the window
+    requestEngagedMembership([2, 3]); // 2 is a dup
+    vi.advanceTimersByTime(30); // still inside the window (60ms total)
+    requestEngagedMembership([3, 4]);
+
+    // Nothing has fired yet — the window (anchored at the first id) is still open.
+    expect(queryMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(ENGAGED_MEMBERSHIP_DEBOUNCE_MS); // close the window
+    await drain();
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock.mock.calls[0][0].modelIds.slice().sort((a, b) => a - b)).toEqual([1, 2, 3, 4]);
+    // (c) every requested id resolves in the store (present-or-absent).
+    const s = useEngagedModelsStore.getState();
+    for (const id of [1, 2, 3, 4]) expect(s.queried.has(id)).toBe(true);
+    expect(s.membership[2]?.has('Recommended')).toBe(true); // present
+    expect(s.membership[1]?.size ?? 0).toBe(0); // absent → known-not-engaged
+  });
+
+  it('ids requested AFTER the window fire a SECOND call', async () => {
+    requestEngagedMembership([1]);
+    vi.advanceTimersByTime(ENGAGED_MEMBERSHIP_DEBOUNCE_MS);
+    await drain();
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock.mock.calls[0][0].modelIds).toEqual([1]);
+
+    // A new id after the first window closed opens a fresh window → new call.
+    requestEngagedMembership([2]);
+    expect(queryMock).toHaveBeenCalledTimes(1); // not yet — window still open
+    vi.advanceTimersByTime(ENGAGED_MEMBERSHIP_DEBOUNCE_MS);
+    await drain();
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    expect(queryMock.mock.calls[1][0].modelIds).toEqual([2]);
+  });
+
+  it('a wide window that accumulates >cap ids still splits into ≤200-id calls', async () => {
+    queryMock.mockResolvedValue({});
+    // 450 ids dribble in across ticks inside one window → one flush, three chunks.
+    requestEngagedMembership(Array.from({ length: 200 }, (_, i) => i + 1));
+    vi.advanceTimersByTime(40);
+    requestEngagedMembership(Array.from({ length: 250 }, (_, i) => i + 201));
+    vi.advanceTimersByTime(ENGAGED_MEMBERSHIP_DEBOUNCE_MS);
+    await drain();
+
+    expect(queryMock).toHaveBeenCalledTimes(3); // 200 + 200 + 50
+    expect(queryMock.mock.calls.map((c) => c[0].modelIds.length)).toEqual([200, 200, 50]);
+    // Every one of the 450 ids ends up resolved — none dropped.
+    const s = useEngagedModelsStore.getState();
+    for (let id = 1; id <= 450; id++) expect(s.queried.has(id)).toBe(true);
+  });
+
+  it('an id whose requester unmounts before the window closes is still resolved (no hang, no leak, no unhandled rejection)', async () => {
+    queryMock.mockResolvedValue({ Notify: [11] });
+    const { unmount } = renderHook(() => useEngagedModelsMembership([11]));
+
+    // Component goes away BEFORE the ~80ms window closes.
+    unmount();
+    expect(queryMock).not.toHaveBeenCalled();
+
+    // The fire-and-forget batcher still flushes and folds the answer into the
+    // store — the id is resolved (not left permanently unknown), and the
+    // resolved promise had a rejection handler so nothing leaks.
+    vi.advanceTimersByTime(ENGAGED_MEMBERSHIP_DEBOUNCE_MS);
+    await drain();
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(queryMock.mock.calls[0][0].modelIds).toEqual([11]);
+    expect(useEngagedModelsStore.getState().queried.has(11)).toBe(true);
+  });
+
+  it('a rejected fetch still resolves the ids (known-not-engaged) — no id left hung', async () => {
+    queryMock.mockRejectedValueOnce(new Error('boom'));
+    requestEngagedMembership([21, 22]);
+    vi.advanceTimersByTime(ENGAGED_MEMBERSHIP_DEBOUNCE_MS);
+    await drain();
+
+    const s = useEngagedModelsStore.getState();
+    expect(s.queried.has(21)).toBe(true);
+    expect(s.queried.has(22)).toBe(true);
   });
 });

--- a/src/hooks/useEngagedModelMembership.ts
+++ b/src/hooks/useEngagedModelMembership.ts
@@ -8,10 +8,18 @@ import { trpcVanilla } from '~/utils/trpc';
 /**
  * Batched dataloader for engagement membership (PR2). Components register the
  * model ids currently on screen; a module-level batcher coalesces every id
- * requested within one microtask, drops the ones already known to the store,
- * chunks the remainder to the endpoint's ≤200 cap, and issues ONE
+ * requested within a short debounce WINDOW, drops the ones already known to the
+ * store, chunks the remainder to the endpoint's ≤200 cap, and issues ONE
  * `user.getEngagedModelsByIds` query per chunk — folding the result back into
  * the store. Classic DataLoader-in-React.
+ *
+ * The window is anchored at the FIRST pending id and does NOT reset on later
+ * ids (the `scheduled` flag blocks re-scheduling until `flush` runs), so under
+ * continuous scrolling the batcher still flushes every ~80ms — bounded latency,
+ * no starvation. Widening from the original single-microtask coalesce to ~80ms
+ * folds ids that arrive across many render ticks / scroll frames into a single
+ * request, cutting the number of `user.getEngagedModelsByIds` calls (and the
+ * fixed per-request middleware CPU each one carries).
  *
  * Reads come straight off the reactive store (`useIsEngaged` etc.), so an
  * optimistic mutation is reflected instantly without any refetch.
@@ -19,18 +27,31 @@ import { trpcVanilla } from '~/utils/trpc';
 
 const MAX_IDS_PER_QUERY = 200; // must match getEngagedModelsByIdsSchema.max(200)
 
+/**
+ * Client-side coalescing window for the engaged-membership batcher. Tunable.
+ * Trade-off: up to this many ms of extra latency before a model's membership
+ * (favorite-heart / notify-bell state) hydrates, in exchange for far fewer
+ * network calls. 80ms sits below the ~100ms "instant" perception threshold, so
+ * the heart/bell hydration is not perceptibly laggy, while being wide enough to
+ * absorb a burst of card mounts across several render ticks into one request.
+ */
+export const ENGAGED_MEMBERSHIP_DEBOUNCE_MS = 80;
+
 // Module-level batcher state.
 const pending = new Set<number>();
 const inFlight = new Set<number>();
 let scheduled = false;
 
 /**
- * Test/injection seam. Production uses the vanilla tRPC client + a microtask
- * flush; tests swap in a controllable fetcher and a synchronous scheduler.
+ * Test/injection seam. Production uses the vanilla tRPC client + an ~80ms
+ * debounce flush; tests swap in a controllable fetcher and a synchronous
+ * scheduler. `schedule` returns void so a test override may return void too.
  */
 export const engagedMembershipBatcher = {
   fetch: (modelIds: number[]) => trpcVanilla.user.getEngagedModelsByIds.query({ modelIds }),
-  schedule: (cb: () => void) => queueMicrotask(cb),
+  schedule: (cb: () => void): void => {
+    setTimeout(cb, ENGAGED_MEMBERSHIP_DEBOUNCE_MS);
+  },
 };
 
 function chunk<T>(arr: T[], size: number): T[][] {


### PR DESCRIPTION
## What

Widen the client-side `getEngagedModelsByIds` request batcher's coalescing window from a **single microtask** to an **~80ms debounce**, so ids that arrive across many render ticks / scroll frames fold into a single `user.getEngagedModelsByIds` call instead of one call per microtask-flush.

## Current mechanism (before)

`src/hooks/useEngagedModelMembership.ts` is a DataLoader-in-React. `requestEngagedMembership(ids)` adds ids to a module-level `pending` Set and — if `!scheduled` — calls `engagedMembershipBatcher.schedule(flush)`, which was `queueMicrotask(flush)`. The `scheduled` flag blocks re-scheduling until `flush` runs, so the window was anchored at the first pending id but only **one microtask wide**. `flush` drains `pending`, drops ids already `queried`/`inFlight`, chunks the remainder to the endpoint's ≤200 cap, and issues one query per chunk, folding the result into the zustand store.

## Change (after)

Swap the default scheduler to `setTimeout(cb, ENGAGED_MEMBERSHIP_DEBOUNCE_MS)` (80ms). Everything else is untouched:

- The window stays **anchored at the first pending id and does not reset** on later ids (the `scheduled` flag already guarantees this), so under continuous scrolling the batcher still flushes every ~80ms — bounded latency, no starvation.
- De-dup, the ≤200 max-batch cap + chunking, the F1/F2 correctness guards, and all optimistic-update behavior are unchanged. A wider window simply accumulates more ids per flush, which the existing chunker splits into ≤200-id calls.

The window is a named, documented, tunable constant (`ENGAGED_MEMBERSHIP_DEBOUNCE_MS`).

## Why ~80ms

80ms sits below the ~100ms "instant" perception threshold, so favorite-heart / notify-bell membership hydration is not perceptibly laggy, while being wide enough to absorb a burst of card mounts spanning several render ticks into one request. **Trade-off:** up to ~80ms of extra latency before a card's membership state hydrates, in exchange for far fewer network calls (and the fixed per-request middleware CPU each one carries). Tunable via the constant if the latency feels off.

## Scope / risk

- **Client-only, reversible.** No server, endpoint, schema, or feature-flag change. Rollback = revert this commit.
- Reads still come straight off the reactive store, so optimistic mutations remain instant.

## Tests

Added a fake-timer suite (`debounce window (real ~80ms scheduler)`) exercising the real production scheduler:
- ids across multiple ticks within the window → exactly ONE call with the deduped union;
- a request after the window → a second call;
- every requested id resolves in the store (present-or-absent);
- >cap ids accumulated in one wide window still split into ≤200-id calls;
- a requester that unmounts before the window closes is still resolved (no hang / leak / unhandled rejection);
- a rejected fetch still resolves its ids (known-not-engaged).

All 26 tests in the file pass (20 pre-existing + 6 new); sibling store/optimistic suites green (66 total). Typecheck is clean for the changed files (the repo's pre-existing `event-engine-common` submodule / `kysely` resolution errors are unrelated and identical with and without this change).

## Follow-up

Re-profile after deploy to **book the request-count + CPU drop** on `user.getEngagedModelsByIds` before any HPA-floor change.