### PR TITLE
fix(jobs): stop update-user-score crashing on wide checkpoint window

### DIFF
--- a/src/server/jobs/update-user-score.ts
+++ b/src/server/jobs/update-user-score.ts
@@ -14,6 +14,10 @@ import { createJob, getJobDate } from './job';
 import { userUpdateCounter } from '~/server/prom/client';
 
 const BATCH_SIZE = 500;
+// Owners per computeImageScores call. Caps the in-memory imageId->owner Map so a
+// wide checkpoint window can't exceed V8's ~16.7M Map-entry limit — the crash that
+// froze this job nightly from 2026-06-22.
+const IMAGE_SCORE_OWNER_BATCH = 2000;
 const log = createLogger('update-user-score');
 const jobKey = 'update-user-score';
 export const updateUserScore = createJob(
@@ -24,14 +28,17 @@ export const updateUserScore = createJob(
 
     // Build Context
     //-------------------------------------
-    const [lastUpdate, setLastUpdate] = await getJobDate(jobKey);
+    // Legacy combined checkpoint. Seeds each per-category checkpoint on first run
+    // after this change so the cutover doesn't rescan from epoch; ignored once the
+    // per-category keys exist and own their own progress.
+    const [legacyLastUpdate] = await getJobDate(jobKey);
     const ctx: Context = {
       db: dbWrite,
       ch: clickhouse,
       pg: pgDbWrite,
       jobContext,
       scoreMultipliers: await getScoreMultipliers(),
-      lastUpdate,
+      lastUpdate: legacyLastUpdate,
       toUpdate: {},
       setScore: (id, category, score) => {
         if (!ctx.toUpdate[id]) ctx.toUpdate[id] = {};
@@ -41,17 +48,37 @@ export const updateUserScore = createJob(
 
     // Update scores
     //-------------------------------------
+    // Each category advances its own checkpoint. A fetcher that throws is isolated:
+    // its checkpoint stays frozen (retried next run) while the others still persist
+    // and advance — one broken category can't freeze all six (as images did nightly
+    // from 2026-06-22). Failures are collected and re-thrown after the good work is
+    // committed, so the run still surfaces as failed for alerting.
     const scoreFetchers = {
-      getModelScore,
-      getArticleScore,
-      getUserScore,
-      getReportedActionedScore,
-      getReportAgainstScore,
-      getImageScore,
-    };
-    for (const [key, fetcher] of Object.entries(scoreFetchers)) {
-      log('getting score', key);
-      await fetcher(ctx);
+      models: getModelScore,
+      articles: getArticleScore,
+      users: getUserScore,
+      reportsActioned: getReportedActionedScore,
+      reportsAgainst: getReportAgainstScore,
+      images: getImageScore,
+    } as const;
+
+    const advanceCheckpoint: Array<() => Promise<void>> = [];
+    const failures: Array<{ category: string; error: string }> = [];
+    for (const [category, fetcher] of Object.entries(scoreFetchers)) {
+      const [lastUpdate, setLastUpdate] = await getJobDate(
+        `${jobKey}:${category}`,
+        legacyLastUpdate
+      );
+      ctx.lastUpdate = lastUpdate;
+      try {
+        log('getting score', category);
+        await fetcher(ctx);
+        advanceCheckpoint.push(setLastUpdate);
+      } catch (e) {
+        const error = (e as Error).message;
+        log('score category failed; leaving its checkpoint frozen', category, error);
+        failures.push({ category, error });
+      }
     }
 
     // Update score totals
@@ -60,7 +87,17 @@ export const updateUserScore = createJob(
     log('updating scores', Object.keys(ctx.toUpdate).length, 'batches', totalTasks.length);
     await limitConcurrency(totalTasks, 5);
 
-    await setLastUpdate();
+    // Advance only the categories that fetched cleanly, and only after their scores
+    // are persisted.
+    for (const setLastUpdate of advanceCheckpoint) await setLastUpdate();
+
+    if (failures.length) {
+      throw new Error(
+        `update-user-score: ${failures.length} categor${
+          failures.length > 1 ? 'ies' : 'y'
+        } failed: ${failures.map((f) => `${f.category} (${f.error})`).join('; ')}`
+      );
+    }
   },
   {
     lockExpiration: 30 * 60,
@@ -143,18 +180,21 @@ async function getImageScore(ctx: Context) {
   }
   if (!affectedUserIds.size) return;
 
-  // 3. Recompute each affected owner's FULL all-time image score (including
-  // owners who now total 0, so a previously-stale score is corrected downward).
-  const scores = await computeImageScores(
-    {
-      ch: ctx.ch,
-      pg: ctx.pg,
-      scoreMultipliers: ctx.scoreMultipliers,
-      onCancel: (cancel) => ctx.jobContext.on('cancel', cancel),
-    },
-    [...affectedUserIds]
-  );
-  for (const [userId, { score }] of scores) ctx.setScore(userId, 'images', score);
+  // 3. Recompute each affected owner's FULL all-time image score (including owners
+  // who now total 0, so a previously-stale score is corrected downward). Batched by
+  // owner: computeImageScores holds an imageId->owner Map of every image the batch
+  // owns, so an unbounded owner set (e.g. after a stale, wide checkpoint window)
+  // would exceed V8's Map cap. Batching bounds that Map to one chunk of owners.
+  const deps: ImageScoreDeps = {
+    ch: ctx.ch,
+    pg: ctx.pg,
+    scoreMultipliers: ctx.scoreMultipliers,
+    onCancel: (cancel) => ctx.jobContext.on('cancel', cancel),
+  };
+  for (const userIds of chunk([...affectedUserIds], IMAGE_SCORE_OWNER_BATCH)) {
+    const scores = await computeImageScores(deps, userIds);
+    for (const [userId, { score }] of scores) ctx.setScore(userId, 'images', score);
+  }
 }
 
 type ImageScoreDeps = {
@@ -377,16 +417,6 @@ export async function getScoreMultipliers(): Promise<ScoreMultipliers> {
 
   log('score multipliers: sysRedis + KeyValue unavailable, using hardcoded default');
   return DEFAULT_SCORE_MULTIPLIERS;
-}
-
-function getAffected(ctx: Context) {
-  return templateHandler(async (sql) => {
-    const affectedQuery = await ctx.pg.cancellableQuery<{ id: number }>(sql);
-    ctx.jobContext.on('cancel', affectedQuery.cancel);
-    const affected = await affectedQuery.result();
-    const ids = affected.map((x) => x.id);
-    return ids;
-  });
 }
 
 function getScores(ctx: Context, category: ScoreCategory) {

--- a/src/server/jobs/update-user-score.ts
+++ b/src/server/jobs/update-user-score.ts
@@ -63,7 +63,7 @@ export const updateUserScore = createJob(
     } as const;
 
     const advanceCheckpoint: Array<() => Promise<void>> = [];
-    const failures: Array<{ category: string; error: string }> = [];
+    const failures: Array<{ category: string; error: unknown }> = [];
     for (const [category, fetcher] of Object.entries(scoreFetchers)) {
       const [lastUpdate, setLastUpdate] = await getJobDate(
         `${jobKey}:${category}`,
@@ -75,9 +75,8 @@ export const updateUserScore = createJob(
         await fetcher(ctx);
         advanceCheckpoint.push(setLastUpdate);
       } catch (e) {
-        const error = (e as Error).message;
-        log('score category failed; leaving its checkpoint frozen', category, error);
-        failures.push({ category, error });
+        log('score category failed; leaving its checkpoint frozen', category, e);
+        failures.push({ category, error: e });
       }
     }
 
@@ -91,12 +90,23 @@ export const updateUserScore = createJob(
     // are persisted.
     for (const setLastUpdate of advanceCheckpoint) await setLastUpdate();
 
+    // Re-throw so the run still surfaces as failed. Each category's original stack
+    // is embedded into the thrown error's own stack: the job runner logs
+    // `error.stack` to Axiom (job.ts) and ignores `.cause`/AggregateError.errors,
+    // so embedding is the only way the real failure site survives.
     if (failures.length) {
-      throw new Error(
-        `update-user-score: ${failures.length} categor${
-          failures.length > 1 ? 'ies' : 'y'
-        } failed: ${failures.map((f) => `${f.category} (${f.error})`).join('; ')}`
-      );
+      const summary = `update-user-score: ${failures.length} categor${
+        failures.length > 1 ? 'ies' : 'y'
+      } failed (${failures.map((f) => f.category).join(', ')})`;
+      const err = new Error(summary);
+      err.stack = [
+        summary,
+        ...failures.map(({ category, error }) => {
+          const detail = error instanceof Error ? error.stack ?? error.message : String(error);
+          return `\n--- ${category} ---\n${detail}`;
+        }),
+      ].join('');
+      throw err;
     }
   },
   {


### PR DESCRIPTION
## Problem

`update-user-score` (cron, 23:55 UTC) has failed **every night since 2026-06-22** with `RangeError: Map maximum size exceeded` — 66 failed runs, zero successes, identical stack trace. All six creator-score categories (models, articles, images, users, reportsActioned, reportsAgainst) frozen, plus downstream impact on Creator Program eligibility, rate-limit tiers, and strikes.

## Root cause — self-reinforcing loop

1. `setLastUpdate()` runs once, atomically, only after all six fetchers succeed. Any throw skips it → checkpoint never advances.
2. `getImageScore` pulls images with new engagement since the checkpoint, then recomputes each affected owner's **full all-time** score. With the checkpoint frozen at June 22, the window grew to 18+ days → ~every active owner.
3. `computeImageScores` builds a single `imageId -> owner` Map across all affected owners → past V8's ~16.7M-entry (`2^24`) Map cap → throws.
4. Throw skips the checkpoint advance → window grows again next night. Never self-heals.

## Fix

- **B (structural):** `getImageScore` recomputes affected owners in batches of `IMAGE_SCORE_OWNER_BATCH = 2000`, so `ownerByImage` is bounded to one chunk's images and can't hit the Map cap regardless of window width. Image-score semantics unchanged (still full all-time recompute per affected owner) — only the memory footprint is bounded.
- **A (defense-in-depth):** each category gets its own `update-user-score:<category>` checkpoint (seeded from the legacy combined key so the cutover doesn't rescan from epoch). A throwing fetcher is isolated — its checkpoint stays frozen and retries next run while the other five persist + advance. Failures are collected and **re-thrown after** the good work commits, so the run still surfaces as failed for alerting.
- Removes the unused `getAffected()` helper in this file.

## Prod unblock (done out of band, deploy-independent)

- ✅ Advanced the `update-user-score` `KeyValue` checkpoint to now → tonight's run survives on current code.
- ⏳ One-off `admin/temp/backfill-image-scores` full sweep recovers the ~18-day images backlog.
- 🔄 Other five categories self-heal incrementally via recompute-on-touch.

This PR prevents recurrence.

## Testing

- Editor diagnostics clean.
- Integration-bound (ClickHouse + Postgres) — no unit harness for this job; verification is via the prod unblock + watching tonight's run in Axiom.

ClickUp: https://app.clickup.com/t/868kb9u4m

🤖 Generated with [Claude Code](https://claude.com/claude-code)