### PR TITLE
fix(buzz): map transient ClickHouse errors to 503 in getDailyBuzzCompensation (per-endpoint, recurrence of #3064)

### DIFF
--- a/src/server/services/buzz.service.ts
+++ b/src/server/services/buzz.service.ts
@@ -53,6 +53,7 @@ import { createNotification } from '~/server/services/notification.service';
 import { logToAxiom } from '~/server/logging/client';
 import { createCachedObject, fetchThroughCache } from '~/server/utils/cache-helpers';
 import {
+  runClickHouseRead,
   throwBadRequestError,
   throwInsufficientFundsError,
   withRetries,
@@ -1063,32 +1064,43 @@ export const getDailyCompensationRewardByUser = async ({
 
   const hasPublishedResources = modelVersions.length > 0;
   if (!clickhouse || !modelVersions.length) return { resources: [], hasPublishedResources };
+  // Capture the narrowed (non-undefined) client so the read closure below keeps the
+  // type guard — TS doesn't propagate the `!clickhouse` narrowing into a callback.
+  const ch = clickhouse;
 
   const minDate = dayjs.utc(date).startOf('day').startOf('month').toDate();
   const maxDate = dayjs.utc(date).endOf('day').endOf('month').toDate();
 
   const versionIds = modelVersions.map((v) => v.id);
-  const generationData = await clickhouse.$query<Row>`
-    SELECT
-      date,
-      modelVersionId,
-      accountType,
-      SUM(FLOOR(amount))::int AS total
-    FROM orchestration.resourceCompensations
-    WHERE date BETWEEN ${minDate} AND ${maxDate}
-      AND modelVersionId IN (${versionIds})
-      AND amount > 0
-      AND source ${source === 'licenseFee' ? '=' : '!='} 'licenseFee'
-      -- We do this weird conversion here because the DB sometimes has Yellow and sometimes User. Yellow being the alias for User.
-      -- License fees can settle to cash OR buzz, so we ignore the accountType filter on that source and surface all of them together.
-      AND ${
-        accountType && source !== 'licenseFee'
-          ? `accountType IN ('${BuzzTypes.toApiType(accountType)}', '${toPascalCase(accountType)}')`
-          : '1=1'
-      }
-    GROUP BY modelVersionId, accountType, date
-    ORDER BY date DESC, total DESC
-  `;
+  // A transient ClickHouse connection blip in this read (e.g. `socket hang up`) is a
+  // retryable dependency outage, not a query fault — map it to a retryable 503 (so the
+  // client backs off + retries) instead of the whole compensation query 500ing. A real
+  // query/schema fault (non-connection CH error) still surfaces raw. Same class as the
+  // #3064 New Order counter fix / #2978 / #3049.
+  const generationData = await runClickHouseRead(
+    () => ch.$query<Row>`
+      SELECT
+        date,
+        modelVersionId,
+        accountType,
+        SUM(FLOOR(amount))::int AS total
+      FROM orchestration.resourceCompensations
+      WHERE date BETWEEN ${minDate} AND ${maxDate}
+        AND modelVersionId IN (${versionIds})
+        AND amount > 0
+        AND source ${source === 'licenseFee' ? '=' : '!='} 'licenseFee'
+        -- We do this weird conversion here because the DB sometimes has Yellow and sometimes User. Yellow being the alias for User.
+        -- License fees can settle to cash OR buzz, so we ignore the accountType filter on that source and surface all of them together.
+        AND ${
+          accountType && source !== 'licenseFee'
+            ? `accountType IN ('${BuzzTypes.toApiType(accountType)}', '${toPascalCase(accountType)}')`
+            : '1=1'
+        }
+      GROUP BY modelVersionId, accountType, date
+      ORDER BY date DESC, total DESC
+    `,
+    'Daily Buzz compensation is temporarily unavailable, please retry.'
+  );
 
   if (!generationData.length) return { resources: [], hasPublishedResources };
 

--- a/src/server/utils/__tests__/errorHandling.runClickHouseRead.test.ts
+++ b/src/server/utils/__tests__/errorHandling.runClickHouseRead.test.ts
@@ -1,0 +1,85 @@
+import { TRPCError } from '@trpc/server';
+import { describe, it, expect, vi } from 'vitest';
+import { runClickHouseRead } from '~/server/utils/errorHandling';
+
+// Regression for the recurring "transient ClickHouse read → raw 500" class.
+//
+// 2026-07-11: /api/trpc/buzz.getDailyBuzzCompensation 500'd (~1.2/h) on a transient
+// ClickHouse connection blip — its `clickhouse.$query` SELECT against
+// orchestration.resourceCompensations threw `Error('ClickHouse query failed: socket
+// hang up')`, which bubbled up un-try-caught and tRPC wrapped as
+// INTERNAL_SERVER_ERROR (500). Same class #3064 fixed for the New Order counters.
+//
+// runClickHouseRead is the reusable form of that guard: getDailyCompensationRewardByUser
+// wraps its CH read in it, so this suite pins the exact behavior that endpoint relies on
+// (importing the real buzz.service in a unit test is impractical — its module graph drags
+// in the whole search-index/event-engine chain, which is why every sibling suite mocks it).
+//
+// Contract:
+//   - a TRANSIENT connection/transport error (socket hang up, syscall reset, CH transient
+//     Code 279/210/209/202) → TRPCError SERVICE_UNAVAILABLE (503), original preserved as cause;
+//   - a REAL query/schema fault (non-connection CH error, e.g. Code: 62 syntax) → rethrown
+//     UNCHANGED so it still surfaces (and alerts) as a 500;
+//   - a successful read passes its value straight through.
+
+describe('runClickHouseRead — transient ClickHouse error → 503 (SERVICE_UNAVAILABLE)', () => {
+  it('passes the value through on success (no wrapping)', async () => {
+    const rows = [{ id: 1 }];
+    await expect(runClickHouseRead(async () => rows)).resolves.toBe(rows);
+  });
+
+  it('maps a `socket hang up` read failure to a TRPCError SERVICE_UNAVAILABLE', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('ClickHouse query failed: socket hang up'));
+    await expect(runClickHouseRead(fn)).rejects.toSatisfy(
+      (e: unknown) => e instanceof TRPCError && e.code === 'SERVICE_UNAVAILABLE'
+    );
+  });
+
+  it('maps a transient CH capacity brownout (Code: 202) to SERVICE_UNAVAILABLE', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValue(
+        new Error('ClickHouse query failed: Code: 202. DB::Exception: Too many simultaneous queries')
+      );
+    await expect(runClickHouseRead(fn)).rejects.toSatisfy(
+      (e: unknown) => e instanceof TRPCError && e.code === 'SERVICE_UNAVAILABLE'
+    );
+  });
+
+  it('maps a raw socket syscall (ECONNRESET) to SERVICE_UNAVAILABLE', async () => {
+    const err = Object.assign(new Error('read ECONNRESET'), { code: 'ECONNRESET' });
+    await expect(runClickHouseRead(async () => Promise.reject(err))).rejects.toSatisfy(
+      (e: unknown) => e instanceof TRPCError && e.code === 'SERVICE_UNAVAILABLE'
+    );
+  });
+
+  it('uses the caller-supplied message and preserves the original error as cause', async () => {
+    const original = new Error('ClickHouse query failed: socket hang up');
+    const err = await runClickHouseRead(
+      () => Promise.reject(original),
+      'Daily Buzz compensation is temporarily unavailable, please retry.'
+    ).catch((e) => e);
+    expect(err).toBeInstanceOf(TRPCError);
+    expect((err as TRPCError).code).toBe('SERVICE_UNAVAILABLE');
+    expect((err as TRPCError).message).toBe(
+      'Daily Buzz compensation is temporarily unavailable, please retry.'
+    );
+    expect((err as TRPCError).cause).toBe(original);
+  });
+
+  it('does NOT convert a real (non-connection) CH error — a syntax fault surfaces raw', async () => {
+    // Code: 62 = syntax error — a genuine query/schema bug, NOT a transient blip. It must
+    // NOT be masked as a 503 (so a schema break / bad SELECT still 500s + alerts).
+    const original = new Error('ClickHouse query failed: Code: 62. DB::Exception: Syntax error');
+    const err = await runClickHouseRead(() => Promise.reject(original)).catch((e) => e);
+    expect(err).toBe(original);
+    expect(err instanceof TRPCError).toBe(false);
+  });
+
+  it('does NOT convert an arbitrary application error (e.g. undefined access) — surfaces raw', async () => {
+    const original = new TypeError("Cannot read properties of undefined (reading 'x')");
+    const err = await runClickHouseRead(() => Promise.reject(original)).catch((e) => e);
+    expect(err).toBe(original);
+    expect(err instanceof TRPCError).toBe(false);
+  });
+});

--- a/src/server/utils/errorHandling.ts
+++ b/src/server/utils/errorHandling.ts
@@ -408,6 +408,36 @@ export function isClickHouseConnectionError(e: unknown): boolean {
   return false;
 }
 
+/**
+ * Run a ClickHouse READ and map a TRANSIENT connection/transport blip to a
+ * retryable SERVICE_UNAVAILABLE (HTTP 503) instead of a raw INTERNAL_SERVER_ERROR
+ * (500). A transient dependency outage — a `socket hang up`, a dropped/reset socket,
+ * a momentary CH-Cloud capacity brownout (Code 279/210/209/202) — is retryable, so a
+ * polling client should back off + retry rather than the user-facing query 500ing and
+ * counting against this app's 500 SLO. A REAL query/schema fault (non-connection CH
+ * error — bad SELECT, UNKNOWN_TABLE, `Code: 62/60/349`) is rethrown UNCHANGED so it
+ * still surfaces (and alerts) as a 500. The original error is always preserved as the
+ * TRPCError `cause`.
+ *
+ * This is the reusable form of the inline guard hand-written for the New Order
+ * counters (#3064) and #2978/#3049 — wrap ONLY the READ call-sites you want to
+ * fail-503 on a CH brownout. It is deliberately NOT applied to the shared
+ * `clickhouse.$query` client boundary, which also serves inserts + background/cron
+ * reads where a tRPC-typed 503 would be semantically wrong; classification stays a
+ * narrow, transient-only allowlist (see {@link isClickHouseConnectionError}).
+ */
+export async function runClickHouseRead<T>(
+  fn: () => Promise<T>,
+  message = 'This service is temporarily unavailable. Please try again.'
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (e) {
+    if (isClickHouseConnectionError(e)) throwServiceUnavailableError(message, e);
+    throw e;
+  }
+}
+
 export function handleLogError(e: Error, name?: string, details?: MixedObject) {
   const error = new Error(e.message ?? 'Unexpected error occurred', { cause: e });
   if (isProd)


### PR DESCRIPTION
## Problem

`/api/trpc/buzz.getDailyBuzzCompensation` returned a **500** (~1.2/h; 5 in 251min on 2026-07-11) with `TRPCError: ClickHouse query failed: socket hang up` on its `SELECT date, ...` query. That's a **transient ClickHouse connection blip**, not a query/schema fault.

`getDailyCompensationRewardByUser` (`src/server/services/buzz.service.ts`) runs an **un-try-caught** `clickhouse.$query` read. The `@civitai/clickhouse` client flattens a dropped connection to `Error('ClickHouse query failed: socket hang up')`; that throw bubbles up and tRPC wraps the non-`TRPCError` as `INTERNAL_SERVER_ERROR` (500). A transient dependency outage is **retryable** — it should be a **503** (`SERVICE_UNAVAILABLE`), not a 500.

Same class as #3064 (`games.newOrder.addRating`) / #2978 / #3049 — this is its **recurrence** on a second endpoint.

## Central vs per-endpoint

**Per-endpoint** (not a central choke). There is no safe shared read boundary to wrap: CH reads call `clickhouse.$query` directly across ~54 sites, many in **background jobs / crons / search-index** where a tRPC-typed 503 is semantically wrong, and the client boundary also serves **inserts**. Wrapping `$query` itself would mislabel writes and background reads. So the fix maps at the call-site, mirroring #3064.

To avoid a third hand-inlined copy of the guard, #3064's inline `try/catch` is factored into a small reusable helper:

```ts
export async function runClickHouseRead<T>(fn: () => Promise<T>, message?): Promise<T> {
  try { return await fn(); }
  catch (e) {
    if (isClickHouseConnectionError(e)) throwServiceUnavailableError(message, e);
    throw e;  // real query/schema fault surfaces raw
  }
}
```

Callers **opt in** by wrapping a read — it is deliberately NOT applied to the `clickhouse.$query` client boundary.

## Behavior

- Transient CH (`socket hang up` / syscall reset / CH transient `Code 279/210/209/202`) → retryable **503**, original error preserved as `cause`.
- A **real** query/schema fault (non-connection CH error — `Code 62` syntax, `Code 60` UNKNOWN_TABLE, …) is **rethrown unchanged** → still surfaces (and alerts) as a 500. Classification stays the existing narrow transient-only allowlist `isClickHouseConnectionError`.
- The read is a read-only idempotent SELECT, so a client retry on 503 is safe.

## Tests

7 new tests on `runClickHouseRead` (`errorHandling.runClickHouseRead.test.ts`): `socket hang up` / `Code 202` / `ECONNRESET` → `SERVICE_UNAVAILABLE`; caller message + `cause` preserved; success passthrough; `Code 62` syntax and an arbitrary `TypeError` surface raw. **Fail-before** (4 fail with the guard neutered) / **pass-after** (7 pass). Full `errorHandling` suite: 38 pass. `tsc --noEmit` clean on both changed files.

Testing the helper directly (rather than importing the real `buzz.service`) is deliberate — `buzz.service`'s module graph drags in the search-index/event-engine chain (every sibling suite mocks it); the helper is the exact code the endpoint runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
