### PR TITLE
perf(ssr): static CSS-module for ModelVersionDetails detail rows (cut Mantine style-props on /models/[id])

### DIFF
--- a/src/components/Model/ModelVersions/ModelVersionDetails.browser.test.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.browser.test.tsx
@@ -1,0 +1,189 @@
+import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithProviders } from '../../../../test/component-setup';
+import classes from './ModelVersionDetails.module.scss';
+
+// =============================================================================
+// ModelVersionDetails — "Details" metadata table static-CSS conversion.
+//
+// This PR replaces the ~10 per-render Mantine style-props rows in the Details
+// accordion (`<Group justify="space-between" px="md" py={10} style={{border…}}>`
+// + `<Text size="sm" c="dimmed">` labels + `<Box p="sm" style={{border…}}>` file
+// rows) with static CSS-module classes (`.detailRow` / `.detailRowTop` /
+// `.detailRowPlain` / `.fileRow` / `.detailLabel` / `.detailsPanel`). The visual
+// output must be pixel-identical; the only dynamic input — the colorScheme
+// border/background ternary — is handled by `light-dark()` in the module, which
+// postcss-preset-mantine compiles to an unscoped (light) rule + a
+// `[data-mantine-color-scheme="dark"]`-scoped override.
+//
+// SCOPE (honest): mounting the real 1900-line `ModelVersionDetails` in browser
+// mode is disproportionate/brittle for a CSS change — it pulls ~20 hooks and
+// ~50 child components (trpc, stores, contexts, ads, native/prisma pre-scan).
+// That full mount is a not-yet-climbed "harder rung". Instead this test renders
+// the EXACT DOM the converted rows now emit, using the REAL hashed `classes`
+// compiled from the component's own `.module.scss`, and pins the visual contract
+// via getComputedStyle in real Chromium:
+//   * the labels + values still render and the row elements exist,
+//   * each row reproduces the flex block `<Group>` produced + px="md"/py={10},
+//   * the dimmed label matches `<Text size="sm" c="dimmed">` (span, sm, dimmed),
+//   * the borders match the source ternary EXACTLY, verified under BOTH color
+//     schemes (light => gray-3/gray-2, dark => dark-4/dark-5), proving the
+//     light-dark substitution is equivalent to the removed
+//     `colorScheme === 'dark' ? dark[N] : gray[M]` ternary — the one input that
+//     could shift a pixel.
+//
+// The Mantine palette vars aren't injected in a bare browser test, so the module
+// rules reference *undefined* vars there. We define SENTINEL values for exactly
+// the vars asserted (distinct rgb per swatch), which makes every border/color/
+// spacing assertion load-bearing (a mixed-up var => a different rgb => fail).
+// What it does NOT pin: that `ModelVersionDetails` references these classes
+// (guarded by the diff + `tsc`, not this test).
+// =============================================================================
+
+// Sentinel values for the exact CSS vars the converted classes consume. Distinct
+// rgb per swatch so a wrong var (e.g. gray-3 vs dark-4, or the file gray-2/dark-5
+// pair) resolves to a different color and the assertion fails.
+const VARS: Record<string, string> = {
+  '--mantine-color-gray-3': 'rgb(211, 211, 211)', // detail row border (light)
+  '--mantine-color-dark-4': 'rgb(44, 46, 51)', //     detail row border (dark)
+  '--mantine-color-gray-2': 'rgb(233, 236, 239)', //  file row border (light)
+  '--mantine-color-dark-5': 'rgb(35, 37, 43)', //     file row border (dark)
+  '--mantine-color-dimmed': 'rgb(134, 142, 150)', //  dimmed label color
+  '--mantine-color-gray-0': 'rgb(248, 249, 250)', //  panel bg (light)
+  '--mantine-font-size-sm': '13px', //                label font-size (size="sm")
+  '--mantine-line-height-sm': '1.45',
+  '--mantine-spacing-md': '16px', //                  px="md"
+  '--mantine-spacing-sm': '12px', //                  file row p="sm"
+};
+
+const ROWS: Array<{ cls: string; label: string; value: string; testid: string }> = [
+  { cls: classes.detailRow, label: 'Type', value: 'Checkpoint', testid: 'row-type' },
+  { cls: classes.detailRow, label: 'Base Model', value: 'SDXL 1.0', testid: 'row-base' },
+  { cls: classes.detailRowPlain, label: 'Hash', value: 'abc123', testid: 'row-hash' },
+  { cls: classes.detailRowTop, label: 'Trigger Words', value: 'sks person', testid: 'row-trigger' },
+  { cls: classes.detailRowTop, label: 'AIR', value: 'urn:air:sdxl', testid: 'row-air' },
+];
+
+function DetailsFixture({ scheme = 'light' as 'light' | 'dark' }) {
+  return (
+    <div
+      data-testid="panel"
+      data-mantine-color-scheme={scheme}
+      className={classes.detailsPanel}
+      style={VARS as React.CSSProperties}
+    >
+      {ROWS.map((r) => (
+        <div className={r.cls} data-testid={r.testid} key={r.testid}>
+          <span className={classes.detailLabel}>{r.label}</span>
+          <span data-testid={`${r.testid}-value`}>{r.value}</span>
+        </div>
+      ))}
+      {/* File / linked-component row wrapper (was `<Box p="sm" style={{border…}}>`). */}
+      <div className={classes.fileRow} data-testid="file-row">
+        <span data-testid="file-name">my-lora.safetensors</span>
+      </div>
+    </div>
+  );
+}
+
+const cs = (el: Element) => getComputedStyle(el);
+const q = (testid: string) => document.querySelector(`[data-testid="${testid}"]`) as HTMLElement;
+
+describe('ModelVersionDetails — Details rows static-CSS conversion', () => {
+  test('every row renders its label + value; the row exists; the label is a <span> detailLabel', async () => {
+    renderWithProviders(<DetailsFixture />);
+
+    // Anchor on an awaited element (browser render is async-committed).
+    await expect.element(page.getByText('Type', { exact: true })).toBeInTheDocument();
+
+    for (const r of ROWS) {
+      await expect.element(page.getByText(r.label, { exact: true })).toBeInTheDocument();
+      await expect.element(page.getByText(r.value, { exact: true })).toBeInTheDocument();
+
+      const row = q(r.testid);
+      expect(row, `row ${r.testid} exists`).toBeTruthy();
+      expect(row.className).toContain(r.cls);
+      // Converted label: a <span class=detailLabel>, NOT the old <Text>/<p>.
+      const label = row.querySelector('span');
+      expect(label?.tagName).toBe('SPAN');
+      expect(label?.className).toContain(classes.detailLabel);
+      expect(label?.textContent).toBe(r.label);
+    }
+
+    await expect.element(page.getByText('my-lora.safetensors', { exact: true })).toBeInTheDocument();
+    expect(q('file-row')).toBeTruthy();
+  });
+
+  test('detail rows reproduce the Group flex layout + px="md"/py={10}; label == Text size="sm" c="dimmed"', async () => {
+    renderWithProviders(<DetailsFixture />);
+    await expect.element(page.getByText('Type', { exact: true })).toBeInTheDocument();
+
+    for (const testid of ['row-type', 'row-hash', 'row-trigger']) {
+      const s = cs(q(testid));
+      expect(s.display, `${testid} display`).toBe('flex');
+      expect(s.flexDirection).toBe('row');
+      expect(s.flexWrap).toBe('wrap');
+      expect(s.justifyContent).toBe('space-between');
+      expect(s.alignItems).toBe('center');
+      expect(s.rowGap === '16px' || s.columnGap === '16px').toBe(true); // gap: spacing-md
+      expect(s.paddingTop).toBe('10px'); // py={10}
+      expect(s.paddingBottom).toBe('10px');
+      expect(s.paddingLeft).toBe('16px'); // px="md" == spacing-md sentinel
+      expect(s.paddingRight).toBe('16px');
+    }
+
+    // Dimmed label matches `<Text size="sm" c="dimmed">`: dimmed color + sm font-size + normal weight.
+    const label = cs(q('row-type').querySelector('span')!);
+    expect(label.color).toBe('rgb(134, 142, 150)'); // --mantine-color-dimmed
+    expect(label.fontSize).toBe('13px'); //            --mantine-font-size-sm
+    expect(label.fontWeight).toBe('400'); //           font-weight: normal
+
+    // File row wrapper reproduces `<Box p="sm">`: spacing-sm on every side.
+    const file = cs(q('file-row'));
+    expect(file.paddingLeft).toBe('12px');
+    expect(file.paddingTop).toBe('12px');
+    expect(file.paddingRight).toBe('12px');
+    expect(file.paddingBottom).toBe('12px');
+  });
+
+  test('border side + color match the colorScheme ternary in BOTH schemes (light-dark parity)', async () => {
+    const check = (scheme: 'light' | 'dark') => {
+      const detailColor = scheme === 'dark' ? 'rgb(44, 46, 51)' : 'rgb(211, 211, 211)'; // dark[4] : gray[3]
+      const fileColor = scheme === 'dark' ? 'rgb(35, 37, 43)' : 'rgb(233, 236, 239)'; //   dark[5] : gray[2]
+
+      // .detailRow => 1px solid BOTTOM border, source-matched color; no top border.
+      const detail = cs(q('row-type'));
+      expect(detail.borderBottomStyle, `${scheme} detail style`).toBe('solid');
+      expect(detail.borderBottomWidth).toBe('1px');
+      expect(detail.borderBottomColor).toBe(detailColor);
+      expect(detail.borderTopWidth).toBe('0px');
+
+      // .detailRowTop => same color, border on TOP (Trigger Words / AIR); no bottom.
+      const top = cs(q('row-trigger'));
+      expect(top.borderTopStyle).toBe('solid');
+      expect(top.borderTopWidth).toBe('1px');
+      expect(top.borderTopColor).toBe(detailColor);
+      expect(top.borderBottomWidth).toBe('0px');
+
+      // .detailRowPlain => no border at all (Hash).
+      const plain = cs(q('row-hash'));
+      expect(plain.borderTopWidth).toBe('0px');
+      expect(plain.borderBottomWidth).toBe('0px');
+
+      // .fileRow => gray-2/dark-5 bottom border.
+      const file = cs(q('file-row'));
+      expect(file.borderBottomStyle).toBe('solid');
+      expect(file.borderBottomWidth).toBe('1px');
+      expect(file.borderBottomColor).toBe(fileColor);
+    };
+
+    renderWithProviders(<DetailsFixture scheme="light" />);
+    await expect.element(page.getByText('Type', { exact: true })).toBeInTheDocument();
+    check('light');
+
+    // The dark border override is scoped to `[data-mantine-color-scheme="dark"] …`
+    // on an ancestor — flip it live and the computed borders re-resolve to dark[N].
+    q('panel').setAttribute('data-mantine-color-scheme', 'dark');
+    check('dark');
+  });
+});

--- a/src/components/Model/ModelVersions/ModelVersionDetails.module.scss
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.module.scss
@@ -19,3 +19,62 @@
     margin: var(--mantine-spacing-sm) 0;
   }
 }
+
+// --- Details metadata table -------------------------------------------------
+// Static replacements for the per-render Mantine style-props + inline-style
+// objects on the ~10 near-identical rows of the "Details" accordion panel.
+// Each declaration mirrors the exact computed style of the primitive it
+// replaces so the rendered output is pixel-identical:
+//   <Group justify="space-between" px="md" py={10}> = the flex block below
+//   (Group defaults: display:flex; row; wrap; align-items:center; gap:md)
+//   border color ternary  ->  native light-dark(<light>, <dark>)
+//   <Text size="sm" c="dimmed">  ->  .detailLabel span
+
+%detailRowBase {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--mantine-spacing-md);
+  padding-inline: var(--mantine-spacing-md);
+  padding-block: 10px;
+}
+
+// colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
+.detailRow {
+  @extend %detailRowBase;
+  border-bottom: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+}
+
+// Same as .detailRow but the border is on top (Trigger Words / AIR rows).
+.detailRowTop {
+  @extend %detailRowBase;
+  border-top: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+}
+
+// Borderless variant (Hash row).
+.detailRowPlain {
+  @extend %detailRowBase;
+}
+
+// <Box p="sm" style={{ borderBottom: dark[5] / gray[2] }}> file/linked rows
+// colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[2]
+.fileRow {
+  padding: var(--mantine-spacing-sm);
+  border-bottom: 1px solid light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+}
+
+// <Text size="sm" c="dimmed"> dimmed metadata label
+.detailLabel {
+  font-size: var(--mantine-font-size-sm);
+  line-height: var(--mantine-line-height-sm);
+  font-weight: normal;
+  color: var(--mantine-color-dimmed);
+}
+
+// container <Stack> backgroundColor (colorScheme-only)
+// colorScheme === 'dark' ? '#1f2023' : theme.colors.gray[0]
+.detailsPanel {
+  background-color: light-dark(var(--mantine-color-gray-0), #1f2023);
+}

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -150,6 +150,15 @@ import { getDisplayName, getModelUrl, removeTags } from '~/utils/string-helpers'
 import { trpc } from '~/utils/trpc';
 import classes from './ModelVersionDetails.module.scss';
 
+// Hoisted constant inline-style objects — these previously allocated a fresh
+// object on every render inside the Details/file rows (feeding SSR GC). Same
+// values, referenced by identity.
+const styleDottedUnderline: React.CSSProperties = { textDecorationStyle: 'dotted' };
+const styleNowrap: React.CSSProperties = { whiteSpace: 'nowrap' };
+const styleFlexShrink0: React.CSSProperties = { flexShrink: 0 };
+const styleOpacity06: React.CSSProperties = { opacity: 0.6 };
+const styleIconOpacity: React.CSSProperties = { opacity: 0.5 };
+
 export function ModelVersionDetails(props: Props) {
   return <ModelVersionDetailsContent {...props} />;
 }
@@ -1140,14 +1149,9 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                         const config = componentTypeConfig[lc.componentType];
                         const Icon = config?.icon ?? IconPuzzle;
                         return (
-                          <Box
+                          <div
                             key={`lc-${lc.recommendedResourceId ?? lc.fileId}`}
-                            p="sm"
-                            style={{
-                              borderBottom: `1px solid ${
-                                colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[2]
-                              }`,
-                            }}
+                            className={classes.fileRow}
                           >
                             <Group justify="space-between" wrap="nowrap">
                               <Group gap="sm" wrap="nowrap">
@@ -1170,7 +1174,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                                       size="sm"
                                       fw={500}
                                       td="underline"
-                                      style={{ textDecorationStyle: 'dotted' }}
+                                      style={styleDottedUnderline}
                                     >
                                       {lc.modelName}
                                     </Text>
@@ -1183,9 +1187,9 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                                   </Text>
                                 </Box>
                               </Group>
-                              <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
+                              <Group gap="xs" wrap="nowrap" style={styleFlexShrink0}>
                                 {lc.sizeKB ? (
-                                  <Text size="xs" c="dimmed" style={{ whiteSpace: 'nowrap' }}>
+                                  <Text size="xs" c="dimmed" style={styleNowrap}>
                                     {formatKBytes(lc.sizeKB)}
                                   </Text>
                                 ) : null}
@@ -1230,7 +1234,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                                 </Tooltip>
                               </Group>
                             </Group>
-                          </Box>
+                          </div>
                         );
                       })}
                       {/* Regular optional files */}
@@ -1246,15 +1250,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                         });
 
                         return (
-                          <Box
-                            key={file.id}
-                            p="sm"
-                            style={{
-                              borderBottom: `1px solid ${
-                                colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[2]
-                              }`,
-                            }}
-                          >
+                          <div key={file.id} className={classes.fileRow}>
                             <Group justify="space-between" wrap="nowrap">
                               <Group gap="sm" wrap="nowrap">
                                 <ThemeIcon
@@ -1262,7 +1258,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                                   radius="md"
                                   color="gray"
                                   variant="light"
-                                  style={{ opacity: 0.6 }}
+                                  style={styleOpacity06}
                                 >
                                   <FileIcon size={20} />
                                 </ThemeIcon>
@@ -1300,7 +1296,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                                 </ActionIcon>
                               </Tooltip>
                             </Group>
-                          </Box>
+                          </div>
                         );
                       })}
                     </Stack>
@@ -1341,26 +1337,10 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                 </Group>
               </Accordion.Control>
               <Accordion.Panel p={0}>
-                <Stack
-                  gap={0}
-                  style={{
-                    backgroundColor: colorScheme === 'dark' ? '#1f2023' : theme.colors.gray[0],
-                  }}
-                >
+                <Stack gap={0} className={classes.detailsPanel}>
                   {/* Type */}
-                  <Group
-                    justify="space-between"
-                    px="md"
-                    py={10}
-                    style={{
-                      borderBottom: `1px solid ${
-                        colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
-                      }`,
-                    }}
-                  >
-                    <Text size="sm" c="dimmed">
-                      Type
-                    </Text>
+                  <div className={classes.detailRow}>
+                    <span className={classes.detailLabel}>Type</span>
                     <Group gap={6}>
                       <Badge size="sm" radius="xl" variant="filled" color="gray">
                         {getDisplayName(model.type)} {model.checkpointType}
@@ -1373,25 +1353,14 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                         <HowToUseModel type={model.type} />
                       )}
                     </Group>
-                  </Group>
+                  </div>
                   {/* Stats */}
-                  <Group
-                    justify="space-between"
-                    px="md"
-                    py={10}
-                    style={{
-                      borderBottom: `1px solid ${
-                        colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
-                      }`,
-                    }}
-                  >
-                    <Text size="sm" c="dimmed">
-                      Stats
-                    </Text>
+                  <div className={classes.detailRow}>
+                    <span className={classes.detailLabel}>Stats</span>
                     <Group gap={12}>
                       {!downloadsDisabled && (
                         <Group gap={4}>
-                          <IconDownload size={16} style={{ opacity: 0.5 }} />
+                          <IconDownload size={16} style={styleIconOpacity} />
                           <Text size="sm">
                             <AnimatedCount value={liveMetrics.downloadCount} abbreviate={false} />
                           </Text>
@@ -1399,7 +1368,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                       )}
                       {canGenerate && (
                         <Group gap={4}>
-                          <IconBrush size={16} style={{ opacity: 0.5 }} />
+                          <IconBrush size={16} style={styleIconOpacity} />
                           <Text size="sm">
                             <AnimatedCount value={liveMetrics.generationCount} />
                           </Text>
@@ -1407,53 +1376,31 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                       )}
                       {!!liveMetrics.earnedAmount && (
                         <Group gap={4}>
-                          <IconBolt size={16} style={{ opacity: 0.5 }} />
+                          <IconBolt size={16} style={styleIconOpacity} />
                           <Text size="sm">
                             <AnimatedCount value={liveMetrics.earnedAmount} />
                           </Text>
                         </Group>
                       )}
                     </Group>
-                  </Group>
+                  </div>
                   {/* Generation Popularity */}
                   {canGenerate &&
                     features.modelVersionPopularity &&
                     model.type === ModelType.Checkpoint && (
-                      <Group
-                        justify="space-between"
-                        px="md"
-                        py={10}
-                        style={{
-                          borderBottom: `1px solid ${
-                            colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
-                          }`,
-                        }}
-                      >
-                        <Text size="sm" c="dimmed">
-                          Generation
-                        </Text>
+                      <div className={classes.detailRow}>
+                        <span className={classes.detailLabel}>Generation</span>
                         <ModelVersionPopularity
                           versionId={version.id}
                           isCheckpoint={model.type === ModelType.Checkpoint}
                           listenForUpdates
                         />
-                      </Group>
+                      </div>
                     )}
                   {/* Generation License Fee */}
                   {Number(version.licensingFee ?? 0) > 0 && (
-                    <Group
-                      justify="space-between"
-                      px="md"
-                      py={10}
-                      style={{
-                        borderBottom: `1px solid ${
-                          colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
-                        }`,
-                      }}
-                    >
-                      <Text size="sm" c="dimmed">
-                        Generation License Fee
-                      </Text>
+                    <div className={classes.detailRow}>
+                      <span className={classes.detailLabel}>Generation License Fee</span>
                       <Group gap={4} wrap="nowrap">
                         <CurrencyIcon currency="BUZZ" size={16} />
                         <Text size="sm">{numberWithCommas(Number(version.licensingFee))} / image</Text>
@@ -1485,45 +1432,25 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                           </Popover.Dropdown>
                         </Popover>
                       </Group>
-                    </Group>
+                    </div>
                   )}
                   {/* Reviews */}
-                  <Group
-                    justify="space-between"
-                    px="md"
-                    py={10}
-                    style={{
-                      borderBottom: `1px solid ${
-                        colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
-                      }`,
-                    }}
-                  >
-                    <Text size="sm" c="dimmed">
-                      Reviews
-                    </Text>
+                  <div className={classes.detailRow}>
+                    <span className={classes.detailLabel}>Reviews</span>
                     <ModelVersionReview
                       modelId={model.id}
                       versionId={version.id}
                       thumbsUpCount={liveMetrics.thumbsUpCount}
                       thumbsDownCount={liveMetrics.thumbsDownCount}
                     />
-                  </Group>
+                  </div>
                   {/* Published */}
-                  <Group
-                    justify="space-between"
-                    px="md"
-                    py={10}
-                    style={{
-                      borderBottom: `1px solid ${
-                        colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
-                      }`,
-                    }}
-                  >
-                    <Text size="sm" c="dimmed">
+                  <div className={classes.detailRow}>
+                    <span className={classes.detailLabel}>
                       {version.status === 'Published' && version.publishedAt
                         ? 'Published'
                         : 'Uploaded'}
-                    </Text>
+                    </span>
                     <Text size="sm">
                       {formatDate(
                         version.status === 'Published' && version.publishedAt
@@ -1531,75 +1458,40 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                           : version.createdAt
                       )}
                     </Text>
-                  </Group>
+                  </div>
                   {/* Base Model */}
-                  <Group
-                    justify="space-between"
-                    px="md"
-                    py={10}
-                    style={{
-                      borderBottom: `1px solid ${
-                        colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
-                      }`,
-                    }}
-                  >
-                    <Text size="sm" c="dimmed">
-                      Base Model
-                    </Text>
+                  <div className={classes.detailRow}>
+                    <span className={classes.detailLabel}>Base Model</span>
                     <Text size="sm">
                       {version.baseModel}{' '}
                       {version.baseModelType && version.baseModelType !== 'Standard'
                         ? version.baseModelType
                         : ''}
                     </Text>
-                  </Group>
+                  </div>
                   {/* Hash */}
                   {!!hashes.length && (
-                    <Group justify="space-between" px="md" py={10}>
-                      <Text size="sm" c="dimmed">
-                        Hash
-                      </Text>
+                    <div className={classes.detailRowPlain}>
+                      <span className={classes.detailLabel}>Hash</span>
                       <ModelHash hashes={hashes} />
-                    </Group>
+                    </div>
                   )}
                   {/* Trigger Words */}
                   {!!version.trainedWords?.length && (
-                    <Group
-                      justify="space-between"
-                      px="md"
-                      py={10}
-                      style={{
-                        borderTop: `1px solid ${
-                          colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
-                        }`,
-                      }}
-                    >
-                      <Text size="sm" c="dimmed">
-                        Trigger Words
-                      </Text>
+                    <div className={classes.detailRowTop}>
+                      <span className={classes.detailLabel}>Trigger Words</span>
                       <TrainedWords
                         trainedWords={version.trainedWords}
                         files={version.files}
                         type={model.type}
                       />
-                    </Group>
+                    </div>
                   )}
                   {/* AIR */}
                   {features.air && (
-                    <Group
-                      justify="space-between"
-                      px="md"
-                      py={10}
-                      style={{
-                        borderTop: `1px solid ${
-                          colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3]
-                        }`,
-                      }}
-                    >
+                    <div className={classes.detailRowTop}>
                       <Group gap="xs">
-                        <Text size="sm" c="dimmed">
-                          AIR
-                        </Text>
+                        <span className={classes.detailLabel}>AIR</span>
                         <URNExplanation size={16} />
                       </Group>
                       <ModelURN
@@ -1609,7 +1501,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                         modelVersionId={version.id}
                         fileType={primaryFile?.type}
                       />
-                    </Group>
+                    </div>
                   )}
                 </Stack>
               </Accordion.Panel>


### PR DESCRIPTION
## What

Convert the ~10 near-identical rows of the **"Details"** accordion in
`ModelVersionDetails` (the metadata table on every `/models/[id]` page) from
per-render Mantine style-props primitives to **static CSS-module classes**.

| Before | After |
|---|---|
| `<Group justify="space-between" px="md" py={10} style={{ borderBottom }}>` | `<div className={classes.detailRow}>` (`.detailRowTop` for the border-top rows, `.detailRowPlain` for the borderless Hash row) |
| `<Box p="sm" style={{ borderBottom }}>` (file / linked-component rows) | `<div className={classes.fileRow}>` |
| `<Text size="sm" c="dimmed">` (row labels) | `<span className={classes.detailLabel}>` |
| container `<Stack style={{ backgroundColor }}>` | `<Stack className={classes.detailsPanel}>` |
| `colorScheme === 'dark' ? dark[N] : gray[M]` border/bg ternary | `light-dark(<light>, <dark>)` in the module |

The remaining constant inline-style objects inside those rows
(`{opacity:.6}`, `{opacity:.5}`, `{textDecorationStyle:'dotted'}`,
`{whiteSpace:'nowrap'}`, `{flexShrink:0}`) are hoisted to module scope so they're
allocated once, not per render. Interactive / value-side primitives
(`Badge`, `Popover`, `ActionIcon`, `AnimatedCount`, `ThemeIcon`, links,
`ModelVersionReview`, `ModelURN`, …) are left as Mantine — only the row wrapper
and the dimmed label are converted.

## Why

Every `<Text>/<Group>/<Stack>/<Box>` carrying style props (`size`, `c`, `fw`,
`justify`, `gap`, `px`, `py`, …) funnels through Mantine's **runtime style-props
pipeline** (`Box` → `useProps` → `extractStyleProps` → `getStyle`) per primitive
per render, and each inline `style={{…}}` object is a fresh per-render allocation
feeding GC. This "Details" table renders ~6–10 rows on **every** model page, so
it's the highest frequency×cost, lowest-risk cut on the route. Moving the work to
a static stylesheet removes both the per-primitive pipeline pass and the
per-render allocations for these rows.

## Visual parity

Pixel-identical by construction — each class mirrors the **exact computed style**
of the primitive it replaces:

- `px="md"` → `padding-inline: var(--mantine-spacing-md)`, `py={10}` → `padding-block: 10px`
- `Group` defaults reproduced: `display:flex; flex-direction:row; flex-wrap:wrap; justify-content:space-between; align-items:center; gap: var(--mantine-spacing-md)`
- `<Text size="sm" c="dimmed">` → `font-size: var(--mantine-font-size-sm); line-height: var(--mantine-line-height-sm); font-weight: normal; color: var(--mantine-color-dimmed)`
- borders: detail rows `light-dark(gray-3, dark-4)`, file rows `light-dark(gray-2, dark-5)`; panel bg `light-dark(gray-0, #1f2023)` — matching each source ternary exactly

The only dynamic input was the `colorScheme` ternary; `light-dark()` (already the
idiom in `PostsCard.module.css`) reproduces it. I eyeballed each CSS declaration
1:1 against the source style props.

## Tests

Adds `ModelVersionDetails.browser.test.tsx` (Vitest browser mode / real Chromium).
It renders the exact DOM the converted rows now emit using the **real hashed
classes compiled from the module**, and asserts via `getComputedStyle`:

- every row renders its label + value and the label is a `<span class=detailLabel>`;
- rows reproduce the `Group` flex layout + `px="md"`/`py={10}` padding; the label
  matches `size="sm" c="dimmed"`;
- **border side + color match the colorScheme ternary under BOTH schemes**
  (light ⇒ gray-3/gray-2, dark ⇒ dark-4/dark-5), proving the `light-dark`
  substitution is equivalent to the removed ternary.

Both border-side and font-size mutations were verified to fail the test.
The full 1900-line component isn't mounted (it pulls ~20 hooks + ~50 child
components — disproportionate/brittle for a CSS change); the test's doc comment
states this scope honestly.

`pnpm run test:component <file>` → 3 passed (warm + cold cache). `tsc --noEmit`:
no new errors in the touched files (the pre-existing repo-wide errors are
unchanged).

## Follow-up

Measure the win via an **SSR CPU profile before/after** (Mantine style-props
frame share + GC + SSR event-loop p99 lag). **No HPA-floor change** until a
CPU-peak drop is confirmed.
