### PR TITLE
perf(ssr): memoize MantineProvider CSS-variables generation (cut ~3.2% SSR busy)

### DIFF
--- a/src/providers/ThemeProvider.tsx
+++ b/src/providers/ThemeProvider.tsx
@@ -2,8 +2,9 @@ import type { MantineColorScheme } from '@mantine/core';
 import { ColorSchemeScript, createTheme, MantineProvider, Modal, colorsTuple } from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import { DateLocaleProvider } from '~/providers/DateLocaleProvider';
+import { buildMantineCssVariablesHtml } from '~/providers/mantine-css-variables';
 
-const theme = createTheme({
+export const theme = createTheme({
   components: {
     Modal: Modal.extend({
       styles: {
@@ -233,6 +234,21 @@ const theme = createTheme({
   respectReducedMotion: true,
 });
 
+// Precompute Mantine's CSS-variables `<style>` payload ONCE at module load instead of
+// letting `MantineProvider` regenerate it on every SSR render. The output depends only on
+// the (module-constant) `theme` and is independent of `colorScheme`, so it is safe to
+// hoist. `withCssVariables={false}` below disables the per-render generation; this static
+// `<style>` replaces it byte-for-byte (see `mantine-css-variables.ts` + its test). Cuts the
+// per-render `getCSSColorVariables`/`getMergedVariables`/`removeDefaultVariables` SSR cost.
+const MANTINE_CSS_VARIABLES = buildMantineCssVariablesHtml(theme);
+
+// Mirrors Mantine's internal `<MantineCssVariables>` output (same `data-mantine-styles`
+// attribute + `<style>` shape) so client hydration matches the server markup exactly.
+function StaticMantineCssVariables() {
+  if (!MANTINE_CSS_VARIABLES) return null;
+  return <style data-mantine-styles dangerouslySetInnerHTML={{ __html: MANTINE_CSS_VARIABLES }} />;
+}
+
 export function ThemeProvider({
   children,
   colorScheme: cookieColorScheme,
@@ -243,7 +259,12 @@ export function ThemeProvider({
   return (
     <>
       <ColorSchemeScript defaultColorScheme={cookieColorScheme} />
-      <MantineProvider theme={theme} defaultColorScheme={cookieColorScheme ?? 'dark'}>
+      <MantineProvider
+        theme={theme}
+        defaultColorScheme={cookieColorScheme ?? 'dark'}
+        withCssVariables={false}
+      >
+        <StaticMantineCssVariables />
         <Notifications />
         <DateLocaleProvider>{children}</DateLocaleProvider>
       </MantineProvider>

--- a/src/providers/mantine-css-variables.test.ts
+++ b/src/providers/mantine-css-variables.test.ts
@@ -1,0 +1,126 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { MantineColorScheme, MantineThemeOverride, CSSVariablesResolver } from '@mantine/core';
+import { createTheme, MantineProvider } from '@mantine/core';
+import { describe, expect, it } from 'vitest';
+import { buildMantineCssVariablesHtml } from '~/providers/mantine-css-variables';
+import { theme as appTheme } from '~/providers/ThemeProvider';
+
+/**
+ * BYTE-IDENTICAL GATE (load-bearing safety test).
+ *
+ * This is a GLOBAL change: the memoized CSS-variables `<style>` themes every page. If the
+ * precomputed output differs from what Mantine's live `<MantineProvider>` renders per-request,
+ * theming breaks fleet-wide.
+ *
+ * `renderRealMantineCssVars` renders the REAL `<MantineProvider withCssVariables>` (which
+ * mounts Mantine's internal `<MantineCssVariables>` — the exact code path this change replaces)
+ * and extracts the `<style data-mantine-styles>` payload. We assert `buildMantineCssVariablesHtml`
+ * reproduces it string-for-string, for every color scheme, for both the real app theme and
+ * synthetic themes that exercise custom colors / resolvers.
+ */
+
+// Extract the `__html` of the `<style data-mantine-styles ...>` tag that Mantine renders.
+// Mantine sets `dangerouslySetInnerHTML`, so the CSS text is emitted verbatim (only `<`, `>`,
+// `&` inside a <style> would be entity-encoded by React — Mantine's CSS-var payload contains
+// none of those characters, so the extracted text is the exact injected string).
+function renderRealMantineCssVars(
+  themeOverride: MantineThemeOverride,
+  colorScheme: MantineColorScheme,
+  extraProps: Record<string, unknown> = {}
+): string {
+  const html = renderToStaticMarkup(
+    createElement(MantineProvider, {
+      theme: themeOverride,
+      defaultColorScheme: colorScheme,
+      // getRootElement must return undefined on the server (matches app SSR).
+      getRootElement: () => undefined,
+      ...extraProps,
+      children: null,
+    })
+  );
+
+  // Pin to the CSS-VARIABLES style tag (`data-mantine-styles="true"`), NOT the global-classes
+  // tag (`data-mantine-styles="classes"`) that `MantineClasses` also renders. When Mantine
+  // dedupes every variable away (e.g. the pure default theme), it renders NO css-vars tag —
+  // which must equal our `buildMantineCssVariablesHtml` returning `''`.
+  const match = html.match(/<style[^>]*data-mantine-styles="true"[^>]*>([\s\S]*?)<\/style>/);
+  return match ? match[1] : '';
+}
+
+const COLOR_SCHEMES: MantineColorScheme[] = ['light', 'dark', 'auto'];
+
+describe('buildMantineCssVariablesHtml', () => {
+  describe('matches the real MantineProvider output byte-for-byte (app theme)', () => {
+    for (const scheme of COLOR_SCHEMES) {
+      it(`colorScheme=${scheme}`, () => {
+        const real = renderRealMantineCssVars(appTheme, scheme);
+        const memoized = buildMantineCssVariablesHtml(appTheme);
+        expect(memoized).toBe(real);
+      });
+    }
+
+    it('output is identical across all color schemes (request-invariant)', () => {
+      const outputs = COLOR_SCHEMES.map((s) => renderRealMantineCssVars(appTheme, s));
+      const memoized = buildMantineCssVariablesHtml(appTheme);
+      for (const out of outputs) expect(out).toBe(outputs[0]);
+      expect(memoized).toBe(outputs[0]);
+      expect(memoized.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('matches the real MantineProvider output for arbitrary themes', () => {
+    const customTheme = createTheme({
+      primaryColor: 'orange',
+      white: '#fefefe',
+      black: '#222',
+      colors: {
+        accent: [
+          '#F4F0EA',
+          '#E8DBCA',
+          '#E2C8A9',
+          '#E3B785',
+          '#EBA95C',
+          '#FC9C2D',
+          '#E48C27',
+          '#C37E2D',
+          '#A27036',
+          '#88643B',
+        ],
+      },
+      other: { fadeIn: 'opacity 200ms ease-in' },
+      respectReducedMotion: true,
+    });
+
+    for (const scheme of COLOR_SCHEMES) {
+      it(`custom theme, colorScheme=${scheme}`, () => {
+        const real = renderRealMantineCssVars(customTheme, scheme);
+        expect(buildMantineCssVariablesHtml(customTheme)).toBe(real);
+      });
+    }
+
+    it('empty theme override (pure default theme)', () => {
+      const real = renderRealMantineCssVars({}, 'dark');
+      expect(buildMantineCssVariablesHtml({})).toBe(real);
+    });
+
+    it('honors a custom cssVariablesResolver', () => {
+      const resolver: CSSVariablesResolver = (t) => ({
+        variables: { '--custom-shared': String(t.other.heroHeight ?? 400) },
+        light: { '--custom-color': '#E17900' },
+        dark: { '--custom-color': '#FC8C0C' },
+      });
+      const t = createTheme({ other: { heroHeight: 400 } });
+      const real = renderRealMantineCssVars(t, 'dark', { cssVariablesResolver: resolver });
+      expect(buildMantineCssVariablesHtml(t, { cssVariablesResolver: resolver })).toBe(real);
+    });
+
+    it('honors deduplicateCssVariables=false (emits color-scheme block)', () => {
+      const real = renderRealMantineCssVars(appTheme, 'dark', { deduplicateCssVariables: false });
+      const memoized = buildMantineCssVariablesHtml(appTheme, { deduplicateCssVariables: false });
+      expect(memoized).toBe(real);
+      // sanity: this path DOES append the color-scheme selector block
+      expect(memoized).toContain('[data-mantine-color-scheme="dark"] { --mantine-color-scheme: dark; }');
+    });
+  });
+});

--- a/src/providers/mantine-css-variables.ts
+++ b/src/providers/mantine-css-variables.ts
@@ -1,0 +1,122 @@
+import type {
+  ConvertCSSVariablesInput,
+  CSSVariablesResolver,
+  MantineTheme,
+  MantineThemeOverride,
+} from '@mantine/core';
+import {
+  convertCssVariables,
+  DEFAULT_THEME,
+  deepMerge,
+  defaultCssVariablesResolver,
+  keys,
+  mergeMantineTheme,
+} from '@mantine/core';
+
+/**
+ * Precompute Mantine's CSS-variables `<style>` payload ONCE at module scope instead of
+ * regenerating it on every SSR render.
+ *
+ * Mantine's internal `<MantineCssVariables>` (rendered by `MantineProvider` when
+ * `withCssVariables` is `true`) runs `getMergedVariables` → `removeDefaultVariables` →
+ * `convertCssVariables` on EVERY render of EVERY page. A fresh SSR CPU profile attributed
+ * ~3.2% of SSR busy time (plus co-dependent GC) to that per-render work.
+ *
+ * The output depends ONLY on request-invariant inputs — the theme (a module constant in
+ * `ThemeProvider`), the (absent) `cssVariablesResolver`, `cssVariablesSelector` and
+ * `deduplicateCssVariables` — and NOT on `colorScheme` (the block always emits both the
+ * light and dark variable sets). So it is safe to compute once and reuse.
+ *
+ * This module re-implements Mantine v7's `MantineCssVariables` render body byte-for-byte
+ * using only Mantine's PUBLIC exports (no node_modules fork/patch). `getMergedVariables`
+ * and `removeDefaultVariables` are not exported, so they are mirrored here verbatim from
+ * `@mantine/core@7.17.8`. A test asserts the produced string is identical to what the real
+ * `<MantineProvider>` renders for every color scheme (see
+ * `mantine-css-variables.test.ts`).
+ */
+
+// Verbatim mirror of `@mantine/core`'s internal `getMergedVariables`
+// (core/MantineProvider/MantineCssVariables/get-merged-variables.mjs).
+function getMergedVariables(theme: MantineTheme, generator?: CSSVariablesResolver) {
+  const defaultResolver = defaultCssVariablesResolver(theme);
+  const providerGenerator = generator?.(theme);
+  return providerGenerator ? deepMerge(defaultResolver, providerGenerator) : defaultResolver;
+}
+
+// Verbatim mirror of `@mantine/core`'s internal `removeDefaultVariables`
+// (core/MantineProvider/MantineCssVariables/remove-default-variables.mjs).
+const defaultCssVariables = defaultCssVariablesResolver(DEFAULT_THEME);
+function removeDefaultVariables(input: ConvertCSSVariablesInput): ConvertCSSVariablesInput {
+  const cleaned: ConvertCSSVariablesInput = {
+    variables: {},
+    light: {},
+    dark: {},
+  };
+
+  keys(input.variables).forEach((key) => {
+    if (defaultCssVariables.variables[key] !== input.variables[key]) {
+      cleaned.variables[key] = input.variables[key];
+    }
+  });
+
+  keys(input.light).forEach((key) => {
+    if (defaultCssVariables.light[key] !== input.light[key]) {
+      cleaned.light[key] = input.light[key];
+    }
+  });
+
+  keys(input.dark).forEach((key) => {
+    if (defaultCssVariables.dark[key] !== input.dark[key]) {
+      cleaned.dark[key] = input.dark[key];
+    }
+  });
+
+  return cleaned;
+}
+
+// Verbatim mirror of `@mantine/core`'s internal `getColorSchemeCssVariables`
+// (core/MantineProvider/MantineCssVariables/MantineCssVariables.mjs).
+function getColorSchemeCssVariables(selector: string) {
+  return `
+  ${selector}[data-mantine-color-scheme="dark"] { --mantine-color-scheme: dark; }
+  ${selector}[data-mantine-color-scheme="light"] { --mantine-color-scheme: light; }
+`;
+}
+
+export interface BuildMantineCssVariablesOptions {
+  /** Mirrors `MantineProvider` prop of the same name. `:root` by default. */
+  cssVariablesSelector?: string;
+  /** Mirrors `MantineProvider` prop of the same name. `true` by default. */
+  deduplicateCssVariables?: boolean;
+  /** Mirrors `MantineProvider` prop of the same name. Absent by default. */
+  cssVariablesResolver?: CSSVariablesResolver;
+}
+
+/**
+ * Build the exact `__html` string Mantine's `<MantineCssVariables>` injects into its
+ * `<style data-mantine-styles>` tag for the given theme override.
+ *
+ * The theme override is merged with `DEFAULT_THEME` here exactly as `MantineThemeProvider`
+ * does at the top level (`mergeMantineTheme(DEFAULT_THEME, theme)`), so the result matches
+ * what the live provider renders. Returns `''` when Mantine would render nothing.
+ */
+export function buildMantineCssVariablesHtml(
+  themeOverride: MantineThemeOverride,
+  {
+    cssVariablesSelector = ':root',
+    deduplicateCssVariables = true,
+    cssVariablesResolver,
+  }: BuildMantineCssVariablesOptions = {}
+): string {
+  const theme = mergeMantineTheme(DEFAULT_THEME, themeOverride);
+  const mergedVariables = getMergedVariables(theme, cssVariablesResolver);
+  const shouldCleanVariables = cssVariablesSelector === ':root' && deduplicateCssVariables;
+  const cleanedVariables = shouldCleanVariables
+    ? removeDefaultVariables(mergedVariables)
+    : mergedVariables;
+  const css = convertCssVariables(cleanedVariables, cssVariablesSelector);
+
+  if (!css) return '';
+
+  return `${css}${shouldCleanVariables ? '' : getColorSchemeCssVariables(cssVariablesSelector)}`;
+}


### PR DESCRIPTION
## What

`MantineProvider`'s internal `<MantineCssVariables>` component (rendered whenever `withCssVariables` is `true`) runs `getMergedVariables` → `removeDefaultVariables` → `convertCssVariables` **on every render of every page**. A fresh SSR CPU profile attributed **~3.2% of SSR busy time** (plus co-dependent GC churn) to `getCSSColorVariables` / `getMergedVariables` / `removeDefaultVariables` / `MantineCssVariables`.

This PR precomputes that CSS-variables `<style>` payload **once at module load** and disables Mantine's per-render generation (`withCssVariables={false}`), injecting a static `<style>` that reproduces Mantine's own output **byte-for-byte**.

## Why it's safe to hoist

The generated block depends only on **request-invariant** inputs, verified against the Mantine v7.17.8 source (`MantineCssVariables.mjs`):

| Input | Source | Varies per request? |
|---|---|---|
| `theme` (merged with `DEFAULT_THEME`) | module constant `createTheme(...)` in `ThemeProvider` | No |
| `cssVariablesResolver` (`generator`) | not passed by the app → `undefined` | No |
| `cssVariablesSelector` | default `":root"` | No |
| `deduplicateCssVariables` | default `true` | No |
| `colorScheme` | cookie (`light`/`dark`/`auto`) | **Yes — but the CSS-vars block does NOT depend on it.** The block emits *both* the light and dark variable sets; `colorScheme` only toggles the `data-mantine-color-scheme` attribute (still handled by `ColorSchemeScript`, untouched). |

So the memo has effectively **one entry** — there is no per-user accent color, no per-route/SSR-locale override feeding the theme. The theme object is a static module constant.

## Byte-identical gate (load-bearing safety test)

This is a **global** change — the CSS variables theme every page. `src/providers/mantine-css-variables.test.ts` renders the **real** `<MantineProvider withCssVariables>` (the exact internal code path this change replaces), extracts the `<style data-mantine-styles="true">` payload, and asserts the precomputed string is **identical** to it:

- app theme × `{light, dark, auto}` → all identical, and identical to each other (request-invariance)
- synthetic custom theme (custom colors/primaryColor) × 3 schemes
- pure default theme (all vars deduped → empty, matches)
- custom `cssVariablesResolver` path
- `deduplicateCssVariables=false` path (emits the color-scheme selector block)

Result: **10/10 pass.** The helper re-implements Mantine's `MantineCssVariables` render body using only **public `@mantine/core` exports** — no `node_modules` fork/patch.

## Measurement plan (post-merge)

Re-profile SSR: `getCSSColorVariables` / `getMergedVariables` / `removeDefaultVariables` self-time should drop toward 0. Watch SSR event-loop p99 + GC time. **No HPA-floor change** until a CPU-peak drop is confirmed.

## Risk

- **Blast radius:** global (every page's CSS variables). Mitigated by the byte-identical test that diffs against the live Mantine output for the actual app theme.
- **Hydration:** the static `<style>` renders on both server and client from the same deterministic module constant, so server/client markup match. `withGlobalClasses` (`MantineClasses`) is unchanged.
- **Ordering:** the css-vars `<style>` now renders after the global-classes `<style>` instead of before; irrelevant — `:root { --mantine-* }` custom-property declarations don't interact with the `.mantine-*` utility-class rules.
- **If wrong:** theming would shift globally — which is exactly what the test guards against, per color scheme.