### PR TITLE
perf(feed): trim model.getAll serialized payload (#1 serialize-freeze source)

### DIFF
--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -111,6 +111,10 @@ import {
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
 import { getPrimaryFile, selectLiveLinkedComponents } from '~/server/utils/model-helpers';
+import {
+  GET_ALL_IMAGES_PER_MODEL,
+  GET_ALL_IMAGES_PER_MODEL_SLIM,
+} from '~/server/utils/model-getall-images';
 import { DEFAULT_PAGE_SIZE, getPagination, getPagingData } from '~/server/utils/pagination-helpers';
 import { filterSensitiveProfanityData } from '~/libs/profanity-simple/helpers';
 import {
@@ -441,11 +445,19 @@ export const getModelsInfiniteHandler = async ({
     let loopCount = 0;
     let isPrivate = false;
     let nextCursor: string | bigint | undefined;
+    // Serialize-freeze lever: the browse feed is the #1 producer of oversized tRPC
+    // responses. When the DARK `getAllModelImagesSlim` flag is on, cap each model's
+    // images to the SLIM count; OFF ⇒ today's `GET_ALL_IMAGES_PER_MODEL`. The
+    // always-on per-image field trim applies either way (see model-getall-images).
+    const imagesPerModel = ctx.features.getAllModelImagesSlim
+      ? GET_ALL_IMAGES_PER_MODEL_SLIM
+      : GET_ALL_IMAGES_PER_MODEL;
     const results: Awaited<ReturnType<typeof getModelsWithImagesAndModelVersions>>['items'] = [];
     while (results.length < (input.limit ?? 100) && loopCount < 3) {
       const result = await getModelsWithImagesAndModelVersions({
         input,
         user: ctx.user,
+        imagesPerModel,
       });
       if (result.isPrivate) isPrivate = true;
       results.push(...result.items);

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -139,6 +139,26 @@ const featureFlags = createFeatureFlags({
   // drop the threshold to 0. Supersedes the retired `imagesAsPostsPerPostCap` cap flag (which
   // truncated the gallery and was never ramped). (Mirrors the genTabDeferView precedent.)
   galleryLazyPostImages: { availability: [], fliptKey: 'gallery-lazy-post-images' },
+  // Serialize-perf: SLIM the per-model image count on `model.getAll` — the #1
+  // producer of oversized / event-loop-freezing tRPC responses (the
+  // `trpc-response-oversized` #3017 dataset; p90 > 1MB, ~20x the next path). When
+  // ON, the browse-feed response caps each model to `GET_ALL_IMAGES_PER_MODEL_SLIM`
+  // (6) images instead of `GET_ALL_IMAGES_PER_MODEL` (12) — a ~42% page-byte cut
+  // (the always-on per-image field trim in `model-getall-images` applies either
+  // way). The browse `ModelCard` renders only the cover, so nothing VISIBLE
+  // changes; the risk is browsing-level FEED-DROP: the shared image cache is
+  // ordered `postId,index` (browsing-agnostic), so a mixed-level model whose only
+  // browsing-safe image sits past index 6 is dropped from an SFW-mode viewer's
+  // feed (`hidden.noImages`). Hence `availability: []` = DARK by default and FAILS
+  // CLOSED (empty availability → static eval false when Flipt is absent/down), so
+  // the cap stays 12 (byte-identical COUNT to today) unless the Flipt
+  // `get-all-model-images-slim` threshold is ramped. Deploy dark, then ramp the
+  // threshold WHILE watching the feed-drop rate (Loki
+  // `event_name="feed_noimages_drop"`, `~/utils/faro/feedDrop`); instant rollback =
+  // set the threshold to 0. (Mirrors the galleryLazyPostImages / genTabDeferView
+  // dark-flag precedent.) No client bundle change is required (the feed already
+  // renders any-length image arrays), so this is a pure server behavior flag.
+  getAllModelImagesSlim: { availability: [], fliptKey: 'get-all-model-images-slim' },
   articles: ['public'],
   articleCreate: ['public'],
   articleRatingDispute: { availability: ['user'], fliptKey: 'article-rating-dispute' },

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -123,7 +123,10 @@ import {
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
 import type { RuleDefinition } from '~/server/utils/mod-rules';
-import { capGetAllModelImages } from '~/server/utils/model-getall-images';
+import {
+  buildGetAllModelImages,
+  GET_ALL_IMAGES_PER_MODEL,
+} from '~/server/utils/model-getall-images';
 import {
   DEFAULT_PAGE_SIZE,
   getCursorClauses,
@@ -1305,9 +1308,15 @@ export type GetModelsWithImagesAndModelVersions = AsyncReturnType<
 export const getModelsWithImagesAndModelVersions = async ({
   input,
   user,
+  // Per-model image cap for the RESPONSE (the shared image cache is untouched).
+  // The browse-feed controller selects the SLIM cap when the DARK
+  // `getAllModelImagesSlim` flag is on; other callers (home blocks, collections)
+  // default to `GET_ALL_IMAGES_PER_MODEL`.
+  imagesPerModel = GET_ALL_IMAGES_PER_MODEL,
 }: {
   input: GetAllModelsOutput;
   user?: SessionUser;
+  imagesPerModel?: number;
 }) => {
   input.limit = input.limit ?? 100;
 
@@ -1410,13 +1419,14 @@ export const getModelsWithImagesAndModelVersions = async ({
           // images: model.nsfw
           //   ? versionImages.map((x) => ({ ...x, nsfwLevel: NsfwLevel.XXX }))
           //   : versionImages,
-          // Cap the images in the getAll (browse feed) response — the browse
-          // ModelCard only renders images[0], but the shared image cache returns
-          // up to 20, bloating the tRPC payload (serialized synchronously on the
-          // event loop). `capGetAllModelImages` returns a new array, so the shared
-          // `imagesForModelVersionsCache` entries (still used at full 20 by
-          // model-detail pages, auctions, etc.) are untouched.
-          images: capGetAllModelImages(filteredImages),
+          // Trim the images in the getAll (browse feed) response — the #1
+          // serialize-freeze source. `buildGetAllModelImages` caps the array to
+          // `imagesPerModel` (flag-selected) AND drops the per-image fields no
+          // consumer reads (always-on). It returns NEW arrays/objects, so the
+          // shared `imagesForModelVersionsCache` entries (still used at full 20
+          // with all fields by model-detail pages, auctions, etc.) are untouched.
+          // See `~/server/utils/model-getall-images`.
+          images: buildGetAllModelImages(filteredImages, imagesPerModel),
           canGenerate,
         };
       })

--- a/src/server/utils/__tests__/model-getall-images.test.ts
+++ b/src/server/utils/__tests__/model-getall-images.test.ts
@@ -1,49 +1,158 @@
 import { describe, expect, it } from 'vitest';
 import {
-  GET_ALL_IMAGES_PER_MODEL,
+  buildGetAllModelImages,
   capGetAllModelImages,
+  GET_ALL_IMAGES_PER_MODEL,
+  GET_ALL_IMAGES_PER_MODEL_SLIM,
+  GETALL_DROPPED_IMAGE_FIELDS,
+  stripGetAllModelImage,
 } from '~/server/utils/model-getall-images';
 
-// The browse-feed (`model.getAll`) response caps each model's images to the first
-// few, because the browse `ModelCard` renders only `images[0]`. The shared image
-// cache (`imagesForModelVersionsCache`) still holds the full 20 for model-detail /
-// auction consumers, so the cap MUST NOT mutate the array it is given (a getAll
-// entry can alias a shared-cache array when no `excludedTagIds` filter runs).
+// The browse-feed (`model.getAll`) response is the #1 serialize-freeze source.
+// Its image trim has two parts: an ALWAYS-ON per-image field drop
+// (`stripGetAllModelImage`) and a FLAG-GATED count cap (`capGetAllModelImages`,
+// 12 default / 6 slim). Both are applied by `buildGetAllModelImages`. The shared
+// image cache (`imagesForModelVersionsCache`) still holds the full 20 with all
+// fields for model-detail / auction / carousel consumers, so neither step may
+// mutate the array or the image objects it is given (a getAll entry can alias a
+// shared-cache array when no `excludedTagIds` filter runs).
 
 const makeImages = (n: number) =>
   Array.from({ length: n }, (_, i) => ({ id: i + 1, url: `img-${i + 1}` }));
 
-describe('model-getall-images', () => {
-  it('caps to at most GET_ALL_IMAGES_PER_MODEL', () => {
-    // Pinned: the browse cap is 12 (raised 3 → 8 → 12 across the browsing-level
-    // feed-drop reviews — widens the browsing-safe band; see the constant's doc).
+// A full-fidelity image as it comes off `imagesForModelVersionsCache`.
+const makeFullImage = (id: number) => ({
+  id,
+  userId: 100 + id,
+  name: `img-${id}.png`,
+  url: `url-${id}`,
+  nsfwLevel: 1,
+  width: 1024,
+  height: 1536,
+  hash: `hash-${id}`,
+  type: 'image' as const,
+  metadata: { width: 1024, height: 1536, hash: `hash-${id}` },
+  minor: false,
+  poi: false,
+  modelVersionId: 999,
+  availability: 'Public' as const,
+  hasMeta: true,
+  hasPositivePrompt: true,
+  onSite: false,
+  remixOfId: null,
+  tags: [1, 2, 3],
+});
+
+describe('model-getall-images — cap', () => {
+  it('pins the default (12) and slim (6) caps', () => {
+    // Default raised 3 → 8 → 12 across the browsing-level feed-drop reviews; slim
+    // is the flag-gated material lever. See the constant docs.
     expect(GET_ALL_IMAGES_PER_MODEL).toBe(12);
-    const out = capGetAllModelImages(makeImages(20));
-    expect(out.length).toBe(GET_ALL_IMAGES_PER_MODEL);
+    expect(GET_ALL_IMAGES_PER_MODEL_SLIM).toBe(6);
+    expect(GET_ALL_IMAGES_PER_MODEL_SLIM).toBeLessThan(GET_ALL_IMAGES_PER_MODEL);
   });
 
-  it('keeps the leading images in order (browse UI reads images[0])', () => {
+  it('caps to at most the default limit', () => {
+    expect(capGetAllModelImages(makeImages(20))).toHaveLength(GET_ALL_IMAGES_PER_MODEL);
+  });
+
+  it('caps to the slim limit when passed', () => {
+    const out = capGetAllModelImages(makeImages(20), GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(out).toHaveLength(GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(out.map((x) => x.id)).toEqual([1, 2, 3, 4, 5, 6]);
+  });
+
+  it('keeps the leading images in order (browse UI reads the leading cover)', () => {
     const images = makeImages(20);
     const out = capGetAllModelImages(images);
     expect(out.map((x) => x.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-    // identity preserved (not re-cloned) so downstream `images[0]` is the same ref
-    expect(out[0]).toBe(images[0]);
+    expect(out[0]).toBe(images[0]); // identity preserved
   });
 
   it('returns everything when there are fewer than the cap', () => {
-    expect(capGetAllModelImages(makeImages(2)).length).toBe(2);
-    expect(capGetAllModelImages(makeImages(1)).length).toBe(1);
+    expect(capGetAllModelImages(makeImages(2))).toHaveLength(2);
     expect(capGetAllModelImages([])).toEqual([]);
   });
 
   it('does NOT mutate the source array (shared-cache safety)', () => {
-    // Simulates slicing a value that aliases a shared `imagesForModelVersionsCache`
-    // entry: the cache must still hold all 20 images afterwards.
     const cached = makeImages(20);
     const before = [...cached];
     const out = capGetAllModelImages(cached);
     expect(cached).toHaveLength(20);
     expect(cached).toEqual(before);
-    expect(out).not.toBe(cached); // a new array, not the same reference
+    expect(out).not.toBe(cached);
+  });
+});
+
+describe('model-getall-images — field strip', () => {
+  it('drops EXACTLY the unread fields and keeps everything a consumer reads', () => {
+    const img = makeFullImage(1);
+    const stripped = stripGetAllModelImage(img) as Record<string, unknown>;
+
+    for (const dropped of GETALL_DROPPED_IMAGE_FIELDS) {
+      expect(stripped, `should drop ${dropped}`).not.toHaveProperty(dropped);
+    }
+    // The keep-set: filter fields (all images) + render fields (the cover).
+    for (const kept of [
+      'id',
+      'userId',
+      'nsfwLevel',
+      'tags',
+      'poi',
+      'minor',
+      'url',
+      'name',
+      'type',
+      'hash',
+      'width',
+      'height',
+      'metadata',
+      'remixOfId',
+    ]) {
+      expect(stripped, `should keep ${kept}`).toHaveProperty(kept);
+    }
+  });
+
+  it('the drop set is exactly the 5 verified-unread fields', () => {
+    expect([...GETALL_DROPPED_IMAGE_FIELDS].sort()).toEqual(
+      ['availability', 'hasMeta', 'hasPositivePrompt', 'modelVersionId', 'onSite'].sort()
+    );
+  });
+
+  it('does NOT mutate the input image (shared-cache safety)', () => {
+    const img = makeFullImage(1);
+    const snapshot = JSON.stringify(img);
+    stripGetAllModelImage(img);
+    expect(JSON.stringify(img)).toBe(snapshot);
+    // nested references are shared (not deep-cloned) but never mutated
+    expect(stripGetAllModelImage(img).metadata).toBe(img.metadata);
+  });
+});
+
+describe('model-getall-images — buildGetAllModelImages (cap + strip)', () => {
+  it('caps then field-trims (default limit)', () => {
+    const out = buildGetAllModelImages(Array.from({ length: 20 }, (_, i) => makeFullImage(i + 1)));
+    expect(out).toHaveLength(GET_ALL_IMAGES_PER_MODEL);
+    for (const dropped of GETALL_DROPPED_IMAGE_FIELDS) {
+      expect(out[0]).not.toHaveProperty(dropped);
+    }
+    expect(out[0]).toHaveProperty('url');
+  });
+
+  it('slim limit reduces the count (flag-on path)', () => {
+    const out = buildGetAllModelImages(
+      Array.from({ length: 20 }, (_, i) => makeFullImage(i + 1)),
+      GET_ALL_IMAGES_PER_MODEL_SLIM
+    );
+    expect(out).toHaveLength(GET_ALL_IMAGES_PER_MODEL_SLIM);
+  });
+
+  it('returns a fresh array of fresh objects (never the cache refs)', () => {
+    const cached = Array.from({ length: 20 }, (_, i) => makeFullImage(i + 1));
+    const out = buildGetAllModelImages(cached);
+    expect(out).not.toBe(cached);
+    expect(out[0]).not.toBe(cached[0]);
+    expect(cached).toHaveLength(20); // cache untouched
+    expect(cached[0]).toHaveProperty('onSite'); // cache still full-fidelity
   });
 });

--- a/src/server/utils/model-getall-images.ts
+++ b/src/server/utils/model-getall-images.ts
@@ -1,39 +1,131 @@
 /**
- * Max images returned per model in the browse-feed (`model.getAll` tRPC) response.
+ * Wire-shape trimming for the browse-feed `model.getAll` tRPC response — the #1
+ * producer of oversized / event-loop-freezing tRPC responses in the
+ * serialize-freeze arc (the `trpc-response-oversized` #3017 dataset: ~20x the
+ * next path; p90 > 1MB).
  *
- * The browse `ModelCard` renders only `images[0]`; a grep of every `model.getAll`
- * consumer found none that renders `images[1+]`. Returning up to 20 images per
- * model (the shared `imagesForModelVersionsCache` size) bloated the tRPC payload
- * ~5-8x (1.5-3 MB responses serialized synchronously on the Node event loop — a
- * high-volume source of event-loop-freeze). Capping the RESPONSE removes the
- * bulk of that payload (~40% at this cap).
+ * `model.getAll` returns, per model, up to `GET_ALL_IMAGES_PER_MODEL` images taken
+ * from the SHARED `imagesForModelVersionsCache` (which holds up to 20 images at
+ * FULL fidelity for model-detail pages / auctions / carousels). The tRPC response
+ * is serialized SYNCHRONOUSLY with superjson on the Node event loop, walking every
+ * field of every image of every model — and the image ARRAY is the dominant cost
+ * (~84% of a 12-image item's bytes; measured representative split). Two levers,
+ * both scoped to the RESPONSE (the shared cache is never mutated — every helper
+ * here returns a NEW array / object):
  *
- * Set to 12 (not 1, and raised from an initial 3 → 8 → 12 across reviews): the
- * shared image array is browsing-level-AGNOSTIC and ordered `postId,index` (NOT
- * safe-first), and the client-side filter (`useApplyHiddenPreferences`, models
- * path) iterates it to pick the first image that passes the VIEWER's browsing
- * level — DROPPING the model from the feed if none survive. A too-tight cap
- * hides mixed-level models from restricted-browsing (SFW-mode) viewers whose
- * only browsing-safe image sits past the cap. 12 widens the safe band (more of
- * each model's images stay in range, so a browsing-safe one survives with higher
- * probability) while still shedding most of the payload; it is also headroom for
- * any undocumented external `/api/trpc/model.getAll` token-consumer. The drop is
- * SILENT (`hidden.noImages` is excluded from `hiddenCount`) — it is now measured
- * client-side via `emitFeedNoImagesDrop` (`~/utils/faro/feedDrop`); WATCH that
- * rate (Loki `event_name="feed_noimages_drop"`) before tuning further. Tune here
- * if feed drops rise (still << the shared cache's 20).
+ *   1. ALWAYS-ON per-image FIELD trim (`stripGetAllModelImage`) — drops the
+ *      handful of per-image fields NO `model.getAll` consumer reads (verified
+ *      across the entire consumer graph: `ModelCard` → `AspectRatioImageCard` →
+ *      `EdgeMedia2`/`MediaHash`/`ImageGuard2`, `ModelShopCard`,
+ *      `CollectionShowcase`, and the hidden-preferences `case 'models'` filter).
+ *      Multiplied over every image of every model, this is a safe, zero-UX-risk
+ *      reduction (~18% per image / ~15% of the page).
  *
- * NOTE: this caps only the getAll response mapping. The shared image cache
- * (`getImagesForModelVersionCache` / `imagesForModelVersionsCache`, 20 images)
- * is untouched — model-detail pages, auctions, and other consumers still get 20.
+ *   2. FLAG-GATED image COUNT reduction (`GET_ALL_IMAGES_PER_MODEL_SLIM`, behind
+ *      the DARK `getAllModelImagesSlim` flag) — the material lever (~42% of the
+ *      page when models carry a full showcase). See the constant docs for why it
+ *      is flag-gated (browsing-level feed-drop risk) and OFF = today's count.
+ *
+ * 🔴 RETAINED on EVERY image — do NOT add to the drop list:
+ *   - `id`, `userId`, `nsfwLevel`, `tags`, `poi`, `minor` — the client-side
+ *     hidden-preferences filter (`useApplyHiddenPreferences`, `case 'models'`)
+ *     iterates ALL images to drop those the VIEWER can't see and picks the first
+ *     survivor as the rendered cover. Dropping any silently breaks browsing-level
+ *     / hidden-tag / poi / minor moderation filtering for every feed viewer.
+ *   - `url`, `name`, `type`, `hash`, `width`, `height`, `metadata`, `remixOfId` —
+ *     read by the rendered cover (`images[0]` after client filtering). Because the
+ *     cover is the first image that SURVIVES the per-viewer filter, ANY image may
+ *     be promoted to cover — so these render fields must stay on every image, not
+ *     just index 0. (This is why non-zero images can NOT be slimmed further.)
+ */
+
+// The per-image keys dropped from the `model.getAll` wire. Exported so the unit
+// test can assert the strip drops EXACTLY this set (keeps the destructuring in
+// sync). Every entry was confirmed unread across the ENTIRE consumer graph:
+//   - onSite            — card `onSite` derives from `version.trainingStatus`.
+//   - hasMeta           — only read on IMAGE-feed cards (`image.getInfinite`),
+//                         never on `model.getAll` images.
+//   - hasPositivePrompt — read nowhere in the getAll consumer graph.
+//   - modelVersionId    — used server-side only (to bucket cache images); no
+//                         client consumer reads it off the response.
+//   - availability      — image-level availability is never read (the card's
+//                         `availability` is the MODEL's, a separate base field).
+export const GETALL_DROPPED_IMAGE_FIELDS = [
+  'onSite',
+  'hasMeta',
+  'hasPositivePrompt',
+  'modelVersionId',
+  'availability',
+] as const;
+
+/**
+ * Max images returned per model in the browse-feed (`model.getAll`) response when
+ * the DARK `getAllModelImagesSlim` flag is OFF (today's behavior).
+ *
+ * The browse `ModelCard` renders only the cover (`images[0]` after the client
+ * hidden-prefs filter); no consumer renders `images[1+]`. The shared image cache
+ * returns up to 20, ordered `postId,index` (NOT safe-first). This cap keeps the
+ * leading images so the client filter (`useApplyHiddenPreferences`, models path)
+ * still has fall-through candidates: it iterates the array to pick the first image
+ * that passes the VIEWER's browsing level and DROPS the model from the feed if
+ * none survive. 12 was chosen (raised 3 → 8 → 12 across reviews) to widen that
+ * browsing-safe band so a mixed-level model still surfaces a safe cover for an
+ * SFW-mode viewer. The drop is SILENT (`hidden.noImages` is excluded from
+ * `hiddenCount`); it is measured client-side via `emitFeedNoImagesDrop`
+ * (`~/utils/faro/feedDrop`) — WATCH `event_name="feed_noimages_drop"`.
  */
 export const GET_ALL_IMAGES_PER_MODEL = 12;
 
 /**
- * Cap a per-model images array to the browse-feed limit. Returns a NEW array
- * (never mutates the input), so slicing a value that aliases a shared-cache
- * entry does not affect the cache.
+ * SLIM per-model image cap — applied only when the DARK `getAllModelImagesSlim`
+ * flag is ON. The material serialize lever: dropping 12 → 6 images per model cuts
+ * ~42% of the browse-feed page bytes (and the proportional superjson walk) when
+ * models carry a full showcase.
+ *
+ * 🔴 FLAG-GATED (DARK `getAllModelImagesSlim`, `availability: []`) — NOT always-on
+ * — because it REINTRODUCES the browsing-level feed-drop risk the 3→8→12 reviews
+ * walked away from: with only 6 leading (postId,index-ordered, browsing-agnostic)
+ * images, a mixed-level model whose only browsing-safe image sits past index 6 is
+ * dropped from an SFW-mode viewer's feed (`hidden.noImages`). 6 (vs 1) preserves 5
+ * fall-through candidates beyond the cover and mirrors the sibling
+ * `GALLERY_POST_IMAGE_SLICE`; the residual risk is real but bounded, measured, and
+ * instantly reversible. OFF ⇒ the cap stays `GET_ALL_IMAGES_PER_MODEL` (12) — the
+ * COUNT is byte-identical to today (the always-on field trim still applies to both
+ * branches). Ramp ONLY by the Flipt threshold while watching
+ * `feed_noimages_drop`; instant rollback = drop the threshold to 0. Tune here.
  */
-export function capGetAllModelImages<T>(images: T[]): T[] {
-  return images.slice(0, GET_ALL_IMAGES_PER_MODEL);
+export const GET_ALL_IMAGES_PER_MODEL_SLIM = 6;
+
+/**
+ * Cap a per-model images array to `limit`. Returns the SAME array when already
+ * within the limit (no needless clone) and never mutates the input, so slicing a
+ * value that aliases a shared `imagesForModelVersionsCache` entry does not affect
+ * the cache. Identity of the leading elements is preserved (downstream reads
+ * `images[0]` by reference).
+ */
+export function capGetAllModelImages<T>(images: T[], limit = GET_ALL_IMAGES_PER_MODEL): T[] {
+  return images.length > limit ? images.slice(0, limit) : images;
+}
+
+/**
+ * Return a shallow copy of `image` without the wire-dropped fields. Generic so it
+ * is type-safe over the cache result type (a key absent on the input is a no-op),
+ * and the narrowed `Omit<...>` return type makes tsc flag any future consumer that
+ * starts reading a dropped field. Does not mutate the input (shared-cache safety).
+ */
+export function stripGetAllModelImage<T extends Record<string, unknown>>(image: T) {
+  const { onSite, hasMeta, hasPositivePrompt, modelVersionId, availability, ...rest } = image;
+  return rest as Omit<T, (typeof GETALL_DROPPED_IMAGE_FIELDS)[number]>;
+}
+
+/**
+ * The exact per-model image wire transform the `model.getAll` response mapping
+ * applies: cap to `limit` (flag-selected), then field-trim every surviving image.
+ * Both steps return fresh arrays/objects — the shared image cache is never touched.
+ */
+export function buildGetAllModelImages<T extends Record<string, unknown>>(
+  images: T[],
+  limit = GET_ALL_IMAGES_PER_MODEL
+) {
+  return capGetAllModelImages(images, limit).map(stripGetAllModelImage);
 }


### PR DESCRIPTION
## Why

`model.getAll` (the browse model feed) is the **#1 producer of oversized / event-loop-freezing tRPC responses** in the `trpc-response-oversized` (#3017) dataset — ~20x the next path, p90 > 1MB. superjson serializes the response synchronously on the event loop, walking every field of every image of every model.

## Measured composition (representative)

Built a representative 100-model page from the exact response shape and measured JSON byte weight (a faithful proxy for the superjson serialize walk):

| Slice | Share |
|---|---|
| **images array** (12 imgs × 19 fields) | **~84%** of a 12-image item |
| base object (name, user, version, rank, tags, hashes, cosmetic…) | ~16% |

So the **image array is the dominant contributor** — not the base object. Within the page:

| Scenario | Page bytes | vs baseline |
|---|---|---|
| baseline: 12 imgs, full fields | 789 KB | — |
| field-trim only (14 fields) | 667 KB | **-15.5%** |
| cap 12→6, full fields | 457 KB | **-42.1%** |
| both | 396 KB | **-49.8%** |

## What this changes

Both levers live in the **response mapping** (`~/server/utils/model-getall-images`). The shared `imagesForModelVersionsCache` is **never mutated** — every helper returns a new array/object, so model-detail pages / auctions / carousels still receive the full 20 images with all fields.

### 1. Always-on per-image field trim (no flag — safe)
`stripGetAllModelImage` drops the 5 per-image fields **no consumer reads**: `onSite`, `hasMeta`, `hasPositivePrompt`, `modelVersionId`, `availability`.

### 2. Flag-gated image-count reduction (dark)
Behind the DARK `getAllModelImagesSlim` flag (`availability: []`, fails closed), the browse feed caps each model to `GET_ALL_IMAGES_PER_MODEL_SLIM` (6) instead of 12. **OFF (default) = today's count** (byte-identical count; the always-on trim still applies). Not always-on because it reintroduces the browsing-level feed-drop risk the 3→8→12 reviews walked away from.

## Consumer enumeration (why it's safe)

Every `model.getAll` item flows through `useQueryModels` → `useApplyHiddenPreferences({type:'models'})` and is rendered by `ModelCard` (→ `AspectRatioImageCard` → `EdgeMedia2`/`MediaHash`/`ImageGuard2`), `ModelShopCard`, and `CollectionShowcase`. `AssociatedModels`/`search` render `ModelCard` from **other** endpoints, so they don't constrain this payload.

Per-image field verdict:

| kept on **every** image | why |
|---|---|
| `id, userId, nsfwLevel, tags, poi, minor` | hidden-prefs filter iterates **all** images (drops those the viewer can't see, picks the first survivor as cover) |
| `url, name, type, hash, width, height, metadata, remixOfId` | the rendered cover — **any** image may be promoted to cover after the per-viewer filter, so these stay on all |
| **dropped** (`onSite, hasMeta, hasPositivePrompt, modelVersionId, availability`) | unread by every consumer (`onSite` on the card derives from `version.trainingStatus`; `hasMeta`/`hasPositivePrompt` are only read on image-feed cards; `modelVersionId` is server-side-only; image `availability` is never read — the card's `availability` is the model's) |

The narrowed `Omit<…>` return type makes `tsc` flag any future consumer that starts reading a dropped field.

## Tests + typecheck

- `model-getall-images.test.ts`: 12 tests — cap (default + slim), the strip (drops exactly the 5 fields, keeps the read set, no mutation), `buildGetAllModelImages` (fresh arrays/objects, cache untouched). All pass.
- `tsc --noEmit`: **zero new errors** (only the pre-existing `event-engine-common` submodule + `kysely` missing-module errors remain).

## Measurement plan (do not merge-and-forget)

- **Always-on trim** lands immediately → watch `trpc-response-oversized {path="model.getAll"}` bytes/serializeMs + the oversized event count drop (~15%).
- **Cap flag** ships DARK. Ramp the Flipt `get-all-model-images-slim` threshold **only after** confirming steady state, watching `feed_noimages_drop` (`~/utils/faro/feedDrop`) for the browsing-level drop risk; instant rollback = threshold 0. Do **not** ramp in this PR.