### PR TITLE
perf(cleanup): remove legacy user.getEngagedModels endpoint

### DIFF
--- a/src/components/Model/Actions/ToggleModelNotification.tsx
+++ b/src/components/Model/Actions/ToggleModelNotification.tsx
@@ -18,7 +18,6 @@ export function ToggleModelNotification({
   ...actionIconProps
 }: ActionIconProps & { modelId: number; userId: number }) {
   const currentUser = useCurrentUser();
-  const queryUtils = trpc.useUtils();
 
   // PR2: per-visible-set membership for this single model (Notify/Mute).
   const { isEngaged: isModelEngaged, isKnown } = useEngagedModelMembership(modelId);
@@ -37,10 +36,6 @@ export function ToggleModelNotification({
       const snapshot = snapshotMembership(modelId);
       applyNotifyToggled(modelId, !isOn);
       return { snapshot };
-    },
-    async onSuccess() {
-      // Keep the legacy getEngagedModels cache in sync for still-on-old-endpoint feeds.
-      await queryUtils.user.getEngagedModels.invalidate();
     },
     onError(error, _vars, context) {
       if (context?.snapshot) restoreMembership(modelId, context.snapshot);

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -372,10 +372,6 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
       applyNotifyToggled(model.id, !isNotificationOn);
       return { snapshot };
     },
-    async onSuccess() {
-      // Keep the legacy getEngagedModels cache in sync for still-on-old-endpoint feeds.
-      await queryUtils.user.getEngagedModels.invalidate();
-    },
     onError(error, _vars, context) {
       if (context?.snapshot) restoreMembership(model.id, context.snapshot);
       showErrorNotification({ title: 'Failed to update notification settings', error });

--- a/src/components/ResourceReview/resourceReview.utils.ts
+++ b/src/components/ResourceReview/resourceReview.utils.ts
@@ -35,41 +35,12 @@ export const useCreateResourceReview = () => {
         return { ...old, down: old.down + 1 };
       });
 
-      const previousEngaged = queryUtils.user.getEngagedModels.getData() ?? {
-        Recommended: [] as number[],
-      };
-      const shouldRemove =
-        !recommended || (previousEngaged.Recommended?.includes(modelId) ?? false);
-
-      queryUtils.user.getEngagedModels.setData(undefined, (old) => {
-        if (!old) return;
-
-        const { Recommended = [], Notify = [], ...rest } = old;
-        if (shouldRemove) {
-          return {
-            Recommended: Recommended.filter((id) => id !== modelId),
-            Notify: Notify.filter((id) => id !== modelId),
-            ...rest,
-          };
-        }
-
-        return { Recommended: [...Recommended, modelId], Notify: [...Notify, modelId], ...rest };
-      });
-
-      // Normalized store (PR2): mirror the same Recommended+Notify toggle for the
-      // per-visible-set surfaces. Dual-written alongside the getEngagedModels cache
-      // above until the feed callers migrate (PR3) and the old endpoint is dropped (PR4).
-      // F3: derive the direction from the SAME `previousEngaged.Recommended` snapshot
-      // the legacy setData above consumed — deliberately NOT the normalized store.
-      // Passing the one shared snapshot keeps the two dual-writes CONSISTENT with each
-      // other (the Preserve invariant). PR3 removed this page's own getEngagedModels
-      // query, so on a directly-loaded model page that legacy cache is cold and this
-      // reads false; both writes then agree (both add), so they never diverge. Accepted
-      // narrow edge: re-affirming an ALREADY-recommended model won't toggle it off until
-      // a feed has warmed the cache. Sourcing direction from the store instead would warm
-      // this case but split the two writes' direction (store warm / legacy cold) — a
-      // worse divergence bug — so we keep the shared-snapshot source.
-      applyReviewCreated(modelId, recommended, previousEngaged.Recommended?.includes(modelId) ?? false);
+      // Normalized store: mirror the Recommended+Notify toggle for the per-visible-set
+      // surfaces. The legacy `user.getEngagedModels` cache dual-write was removed with the
+      // endpoint (PR4). That cache was never populated after the feeds migrated off it
+      // (PR3) — nothing queried it — so the `alreadyRecommended` direction it fed here
+      // always resolved to `false`; preserved as the literal below (behavior-identical).
+      applyReviewCreated(modelId, recommended, false);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
         if (!old) return;
@@ -160,38 +131,20 @@ export const useUpdateResourceReview = () => {
         await queryUtils.resourceReview.getPaged.invalidate();
       }
 
-      await queryUtils.user.getEngagedModels.cancel();
-
-      // Update model engagements
-      const previousEngaged = queryUtils.user.getEngagedModels.getData() ?? {
-        Recommended: [] as number[],
-        Notify: [] as number[],
-      };
-      const alreadyNotified = previousEngaged.Notify?.indexOf(modelId) ?? -1;
-      const alreadyReviewed = previousEngaged.Recommended?.indexOf(modelId) ?? -1;
-      const shouldRemove = !request.recommended || alreadyReviewed > -1;
-      // Remove from recommended list
-      queryUtils.user.getEngagedModels.setData(undefined, (old) => {
-        if (!old) return;
-
-        const { Recommended = [], ...rest } = old;
-        if (shouldRemove)
-          return { Recommended: Recommended.filter((id) => id !== modelId), ...rest };
-        return { Recommended: [...Recommended, modelId], ...rest };
-      });
-
-      // Normalized store (PR2): mirror the Recommended toggle for per-visible-set surfaces.
-      // F3: direction from the SAME `previousEngaged` snapshot the legacy setData used
-      // (not the store), so both dual-writes stay consistent. See the create handler for
-      // the accepted cold-cache edge (this page's getEngagedModels query was removed in PR3).
-      applyReviewUpdated(modelId, request.recommended, alreadyReviewed > -1);
+      // Normalized store: mirror the Recommended toggle for per-visible-set surfaces.
+      // The legacy `user.getEngagedModels` cache dual-write was removed with the endpoint
+      // (PR4); it was never populated after the feeds migrated off it (PR3), so the
+      // `alreadyRecommended` direction always resolved to `false` here — preserved below.
+      applyReviewUpdated(modelId, request.recommended, false);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
         if (!old) return;
 
         if (request.recommended === true) {
           old.rank.thumbsUpCountAllTime += 1;
-          if (alreadyNotified === -1) old.rank.collectedCountAllTime += 1;
+          // Legacy `getEngagedModels` cache is gone (PR4); its `alreadyNotified` was always
+          // -1 (cache never populated), so this collected bump was always applied.
+          old.rank.collectedCountAllTime += 1;
           if (old.rank.thumbsDownCountAllTime > 0) old.rank.thumbsDownCountAllTime -= 1;
 
           if (modelVersionId) {
@@ -247,19 +200,8 @@ export const useDeleteResourceReview = () => {
         })
       );
 
-      // Update engaged models
-      queryUtils.user.getEngagedModels.setData(undefined, (old) => {
-        if (!old) return;
-
-        const { Recommended = [], Notify = [], ...rest } = old;
-        return {
-          Recommended: Recommended.filter((id) => id !== modelId),
-          Notify: Notify.filter((id) => id !== modelId),
-          ...rest,
-        };
-      });
-
-      // Normalized store (PR2): mirror the Recommended+Notify removal for per-visible-set surfaces.
+      // Normalized store: mirror the Recommended+Notify removal for per-visible-set surfaces.
+      // (The legacy `user.getEngagedModels` cache dual-write was removed with the endpoint — PR4.)
       applyReviewDeleted(modelId);
 
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
@@ -339,7 +281,6 @@ export function useToggleFavoriteMutation() {
 
   const mutation = trpc.user.toggleFavorite.useMutation({
     onMutate: async ({ modelId, modelVersionId, setTo }) => {
-      const engagedModels = queryUtils.user.getEngagedModels.getData();
       const bookmarkedModels = queryUtils.user.getBookmarkedModels.getData();
       const modelDetails = queryUtils.model.getById.getData({ id: modelId });
       // Normalized store (PR2): snapshot for rollback, then apply the same toggle.
@@ -356,36 +297,20 @@ export function useToggleFavoriteMutation() {
         }
       });
 
-      // Update model engagements
-      const alreadyNotified = engagedModels?.Notify?.indexOf(modelId) ?? -1;
-      const alreadyReviewed = engagedModels?.Recommended?.indexOf(modelId) ?? -1;
-      queryUtils.user.getEngagedModels.setData(undefined, (old) => {
-        if (!old) return;
-        if (setTo) {
-          if (alreadyNotified === -1) old.Notify = [...(old.Notify ?? []), modelId];
-          if (alreadyReviewed === -1) old.Recommended = [...(old.Recommended ?? []), modelId];
-        } else {
-          // We don't want to remove from notify on favorite toggle
-          // if (alreadyNotified !== -1) old.Notify = old.Notify.filter((id) => id !== modelId);
-          if (alreadyReviewed !== -1)
-            old.Recommended = old.Recommended.filter((id) => id !== modelId);
-        }
-        return old;
-      });
-
-      // Normalized store (PR2): mirror the favorite toggle for per-visible-set surfaces.
+      // Normalized store: mirror the favorite toggle for per-visible-set surfaces.
+      // The legacy `user.getEngagedModels` cache dual-write was removed with the endpoint
+      // (PR4); that cache was never populated after the feeds migrated off it (PR3), so its
+      // `alreadyNotified` / `alreadyReviewed` were always -1 — the rank adjustments below
+      // are preserved exactly as they resolved with those constants (the `!setTo` up-count
+      // decrement branch, gated on `alreadyReviewed !== -1`, was already unreachable).
       applyFavoriteToggled(modelId, setTo);
 
       // Update model details
       queryUtils.model.getById.setData({ id: modelId }, (old) => {
         if (!old) return;
-        if (setTo && alreadyReviewed === -1) {
+        if (setTo) {
           old.rank.thumbsUpCountAllTime += 1;
-          if (alreadyNotified === -1) old.rank.collectedCountAllTime += 1;
-        } else if (!setTo && alreadyReviewed !== -1) {
-          old.rank.thumbsUpCountAllTime -= 1;
-          // We don't want to remove from collected on favorite toggle
-          // old.rank.collectedCountAllTime -= 1;
+          old.rank.collectedCountAllTime += 1;
         }
 
         if (old.rank.thumbsUpCountAllTime < 0) old.rank.thumbsUpCountAllTime = 0;
@@ -442,10 +367,9 @@ export function useToggleFavoriteMutation() {
         }
       });
 
-      return { prevData: { engagedModels, modelDetails, userReviews, bookmarkedModels }, engagedMembership };
+      return { prevData: { modelDetails, userReviews, bookmarkedModels }, engagedMembership };
     },
     onError: (error, { modelId }, context) => {
-      queryUtils.user.getEngagedModels.setData(undefined, context?.prevData?.engagedModels);
       queryUtils.user.getBookmarkedModels.setData(undefined, context?.prevData?.bookmarkedModels);
       queryUtils.model.getById.setData({ id: modelId }, context?.prevData?.modelDetails);
       // Normalized store (PR2): restore the snapshotted membership.

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -56,7 +56,6 @@ import type {
 import { simpleUserSelect } from '~/server/selectors/user.selector';
 import { getUserNotificationCount } from '~/server/services/notification.service';
 import {
-  getResourceReviewsByUserId,
   getUserResourceReview,
 } from '~/server/services/resourceReview.service';
 import {
@@ -82,7 +81,6 @@ import {
   getUserCosmetics,
   getUserCreator,
   getUserDownloadedModelVersions,
-  getUserEngagedModels,
   getUserEngagedModelsByIds,
   getUserEngagedModelVersions,
   getUserList,
@@ -630,46 +628,9 @@ export const restoreUserHandler = async ({
   }
 };
 
-type EngagedModelType = ModelEngagementType | 'Recommended';
-
-export const getUserEngagedModelsHandler = async ({ ctx }: { ctx: ProtectedContext }) => {
-  const { id } = ctx.user;
-
-  try {
-    const engagementsCache = await redis.get(
-      `${REDIS_KEYS.USER.BASE}:${id}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`
-    );
-    if (engagementsCache) return JSON.parse(engagementsCache) as Record<EngagedModelType, number[]>;
-
-    const engagements = await getUserEngagedModels({ id });
-    const recommendedReviews = await getResourceReviewsByUserId({ userId: id, recommended: true });
-
-    // turn array of user.engagedModels into object with `type` as key and array of modelId as value
-    const engagedModels = engagements.reduce<Record<EngagedModelType, number[]>>((acc, model) => {
-      const { type, modelId } = model;
-      if (!acc[type]) acc[type] = [];
-      acc[type].push(modelId);
-      return acc;
-    }, {} as Record<EngagedModelType, number[]>);
-    engagedModels.Recommended = recommendedReviews.map((r) => r.modelId).filter(isDefined);
-
-    await redis.set(
-      `${REDIS_KEYS.USER.BASE}:${id}:${REDIS_SUB_KEYS.USER.MODEL_ENGAGEMENTS}`,
-      JSON.stringify(engagedModels),
-      {
-        EX: 60 * 60 * 24,
-      }
-    );
-
-    return engagedModels;
-  } catch (error) {
-    if (error instanceof TRPCError) throw error;
-    throw throwDbError(error);
-  }
-};
-
-// Additive, per-visible-set counterpart to `getUserEngagedModelsHandler`. Bounded input →
-// bounded response, so (unlike the whole-history handler above) there is no cache: the tiny,
+// Per-visible-set membership handler. Replaced the removed unbounded
+// `getUserEngagedModelsHandler`, whose whole-history response was a serialize-freeze
+// source. Bounded input → bounded response, so there is no cache: the tiny,
 // index-scannable payload isn't worth the combinatorial keyspace + bust-site sprawl.
 export const getUserEngagedModelsByIdsHandler = async ({
   input,

--- a/src/server/routers/user.router.ts
+++ b/src/server/routers/user.router.ts
@@ -16,7 +16,6 @@ import {
   getUserByIdHandler,
   getUserCosmeticsHandler,
   getUserCreatorHandler,
-  getUserEngagedModelsHandler,
   getUserEngagedModelsByIdsHandler,
   getUserEngagedModelVersionsHandler,
   getUserFeatureFlagsHandler,
@@ -143,9 +142,6 @@ export const userRouter = router({
   getSelfStatus: protectedProcedure
     .meta({ requiredScope: TokenScope.UserRead })
     .query(getSelfStatusHandler),
-  getEngagedModels: protectedProcedure
-    .meta({ requiredScope: TokenScope.UserRead })
-    .query(getUserEngagedModelsHandler),
   getEngagedModelsByIds: protectedProcedure
     .meta({ requiredScope: TokenScope.UserRead })
     .input(getEngagedModelsByIdsSchema)

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -595,13 +595,6 @@ export const updateUserById = async ({
   return user;
 };
 
-export const getUserEngagedModels = ({ id, type }: { id: number; type?: ModelEngagementType }) => {
-  return dbRead.modelEngagement.findMany({
-    where: { userId: id, type },
-    select: { modelId: true, type: true },
-  });
-};
-
 export type EngagedModelType = ModelEngagementType | 'Recommended';
 
 /**


### PR DESCRIPTION
## Why

The unbounded `user.getEngagedModels` endpoint (returns a user's **entire** engagement history) was a serialize-freeze source. The feeds migrated to the bounded, per-visible-set `user.getEngagedModelsByIds` (PR3), which removed every query subscription. The only remaining references were client cache-sync writes to the now-orphan `getEngagedModels` React-Query cache — a cache that nothing populates anymore.

## Removed

**Server**
- the `getEngagedModels` procedure (`user.router.ts`)
- `getUserEngagedModelsHandler` (`user.controller.ts`) + its now-unused `getResourceReviewsByUserId` import
- the `getUserEngagedModels` service fn (`user.service.ts`)

**Client cache-sync (now dead)**
- the `getEngagedModels` `getData`/`setData`/`cancel` dual-writes in `resourceReview.utils.ts` — the create / update / delete / toggle-favorite optimistic handlers
- the toggle-notify `onSuccess` `invalidate` in `ToggleModelNotification.tsx` and `ModelVersionDetails.tsx`

## Why it's behavior-preserving

After PR3 the legacy `getEngagedModels` React-Query cache is **never populated**: no `useQuery`/prefetch remains, and every `setData` on it guarded `if (!old) return` (a no-op on an empty cache). So the values it fed into the **surviving** normalized-store optimistic updates were already runtime constants:

- `previousEngaged.Recommended?.includes(modelId)` → `false`
- `alreadyReviewed` (`indexOf ?? -1`) → `-1` (so `alreadyReviewed > -1` → `false`, `alreadyReviewed === -1` → `true`)
- `alreadyNotified` → `-1` (so the collected-count bump was always applied; the `!setTo` up-count decrement branch, gated on `alreadyReviewed !== -1`, was already unreachable)

Those constants are inlined in place, so the new-side optimistic flow (the `engaged-models` store via `applyReviewCreated/Updated/Deleted/FavoriteToggled` + snapshot/restore) is **unchanged**.

## Tests + typecheck

- `engaged-models.optimistic.test.ts`: **27 passing** (the new-side optimistic + rollback behavior).
- `tsc --noEmit`: **identical to the pre-existing baseline — zero new errors** (only the pre-existing `event-engine-common` submodule + `kysely` errors remain), and none in any touched file.

Net −135 lines.