### PR TITLE
perf(feed): nsfw-biased slim slice for model.getAll (near-zero feed-drop cap-6)

### DIFF
--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -447,17 +447,19 @@ export const getModelsInfiniteHandler = async ({
     let nextCursor: string | bigint | undefined;
     // Serialize-freeze lever: the browse feed is the #1 producer of oversized tRPC
     // responses. When the DARK `getAllModelImagesSlim` flag is on, cap each model's
-    // images to the SLIM count; OFF ⇒ today's `GET_ALL_IMAGES_PER_MODEL`. The
-    // always-on per-image field trim applies either way (see model-getall-images).
-    const imagesPerModel = ctx.features.getAllModelImagesSlim
-      ? GET_ALL_IMAGES_PER_MODEL_SLIM
-      : GET_ALL_IMAGES_PER_MODEL;
+    // images to the SLIM count AND pick the nsfw-biased coverage slice (drives the
+    // browsing-level feed-drop regression of the smaller cap to ~0); OFF ⇒ today's
+    // `GET_ALL_IMAGES_PER_MODEL`, naive first-N. The always-on per-image field trim
+    // applies either way (see model-getall-images).
+    const slim = ctx.features.getAllModelImagesSlim;
+    const imagesPerModel = slim ? GET_ALL_IMAGES_PER_MODEL_SLIM : GET_ALL_IMAGES_PER_MODEL;
     const results: Awaited<ReturnType<typeof getModelsWithImagesAndModelVersions>>['items'] = [];
     while (results.length < (input.limit ?? 100) && loopCount < 3) {
       const result = await getModelsWithImagesAndModelVersions({
         input,
         user: ctx.user,
         imagesPerModel,
+        biasImageSlice: slim,
       });
       if (result.isPrivate) isPrivate = true;
       results.push(...result.items);

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -146,10 +146,15 @@ const featureFlags = createFeatureFlags({
   // (6) images instead of `GET_ALL_IMAGES_PER_MODEL` (12) — a ~42% page-byte cut
   // (the always-on per-image field trim in `model-getall-images` applies either
   // way). The browse `ModelCard` renders only the cover, so nothing VISIBLE
-  // changes; the risk is browsing-level FEED-DROP: the shared image cache is
-  // ordered `postId,index` (browsing-agnostic), so a mixed-level model whose only
-  // browsing-safe image sits past index 6 is dropped from an SFW-mode viewer's
-  // feed (`hidden.noImages`). Hence `availability: []` = DARK by default and FAILS
+  // changes; the residual risk is browsing-level FEED-DROP: the shared image cache
+  // is ordered `postId,index` (browsing-agnostic), so a mixed-level model whose only
+  // browsing-safe image sits past index 6 could be dropped from an SFW-mode viewer's
+  // feed (`hidden.noImages`). The flag-ON path MITIGATES this by picking an
+  // nsfw-biased COVERAGE slice (`selectSlimGetAllModelImages`) instead of the naive
+  // first-6 — it keeps one image of every distinct `nsfwLevel` bit present, so any
+  // viewer with a visible image in the full set keeps one in the slice (image
+  // `nsfwLevel` is a single bit, ≤6 distinct, all fit in 6). Still `availability: []`
+  // = DARK by default and FAILS
   // CLOSED (empty availability → static eval false when Flipt is absent/down), so
   // the cap stays 12 (byte-identical COUNT to today) unless the Flipt
   // `get-all-model-images-slim` threshold is ramped. Deploy dark, then ramp the

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1313,10 +1313,14 @@ export const getModelsWithImagesAndModelVersions = async ({
   // `getAllModelImagesSlim` flag is on; other callers (home blocks, collections)
   // default to `GET_ALL_IMAGES_PER_MODEL`.
   imagesPerModel = GET_ALL_IMAGES_PER_MODEL,
+  // When true (flag-ON browse feed only) pick the nsfw-biased coverage slice instead
+  // of the naive first-`imagesPerModel`, so reducing the count adds ~zero feed drops.
+  biasImageSlice = false,
 }: {
   input: GetAllModelsOutput;
   user?: SessionUser;
   imagesPerModel?: number;
+  biasImageSlice?: boolean;
 }) => {
   input.limit = input.limit ?? 100;
 
@@ -1426,7 +1430,7 @@ export const getModelsWithImagesAndModelVersions = async ({
           // shared `imagesForModelVersionsCache` entries (still used at full 20
           // with all fields by model-detail pages, auctions, etc.) are untouched.
           // See `~/server/utils/model-getall-images`.
-          images: buildGetAllModelImages(filteredImages, imagesPerModel),
+          images: buildGetAllModelImages(filteredImages, imagesPerModel, biasImageSlice),
           canGenerate,
         };
       })

--- a/src/server/utils/__tests__/model-getall-images.test.ts
+++ b/src/server/utils/__tests__/model-getall-images.test.ts
@@ -5,6 +5,7 @@ import {
   GET_ALL_IMAGES_PER_MODEL,
   GET_ALL_IMAGES_PER_MODEL_SLIM,
   GETALL_DROPPED_IMAGE_FIELDS,
+  selectSlimGetAllModelImages,
   stripGetAllModelImage,
 } from '~/server/utils/model-getall-images';
 
@@ -154,5 +155,172 @@ describe('model-getall-images — buildGetAllModelImages (cap + strip)', () => {
     expect(out[0]).not.toBe(cached[0]);
     expect(cached).toHaveLength(20); // cache untouched
     expect(cached[0]).toHaveProperty('onSite'); // cache still full-fidelity
+  });
+});
+
+// -----------------------------------------------------------------------------
+// NSFW-biased slim slice (`selectSlimGetAllModelImages`) — the flag-ON selection.
+// An image `nsfwLevel` is ALWAYS a single bit (1/2/4/8/16/32 — ≤6 distinct levels),
+// which is what makes "one representative per distinct bit" a provable near-zero
+// feed-drop guarantee for BOTH client-filter nsfw branches:
+//   - model.nsfw    → keep if `nsfwLevel <= maxSelectedLevel`
+//   - otherwise     → keep if `(nsfwLevel & browsingLevel) != 0`
+// -----------------------------------------------------------------------------
+const PG = 1;
+const PG13 = 2;
+const R = 4;
+const X = 8;
+const XXX = 16;
+const BLOCKED = 32;
+
+// Build a per-model image array from a list of (single-bit) nsfwLevels, index-ordered
+// as the shared `postId,index` cache would deliver them.
+const makeLeveled = (levels: number[]) =>
+  levels.map((nsfwLevel, i) => ({ id: i + 1, url: `img-${i + 1}`, nsfwLevel }));
+
+// The two per-image nsfw filter branches, mirrored from useApplyHiddenPreferences
+// `case 'models'`. Returns whether ANY image in the set is visible to the viewer.
+const anyVisibleBrowsing = (imgs: { nsfwLevel: number }[], browsingLevel: number) =>
+  imgs.some((i) => (i.nsfwLevel & browsingLevel) !== 0);
+const anyVisibleMaxLevel = (imgs: { nsfwLevel: number }[], maxSelectedLevel: number) =>
+  imgs.some((i) => i.nsfwLevel <= maxSelectedLevel);
+
+describe('model-getall-images — nsfw-biased slim slice', () => {
+  it('(a) always contains images[0] (the curated lead)', () => {
+    const imgs = makeLeveled([XXX, XXX, XXX, XXX, XXX, XXX, PG, PG13, R, X]);
+    const out = selectSlimGetAllModelImages(imgs, GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(out[0]).toBe(imgs[0]);
+  });
+
+  it('(a2) keeps images[0] even when its nsfwLevel is unset', () => {
+    const imgs = [
+      { id: 1, url: 'lead', nsfwLevel: undefined as number | undefined },
+      ...makeLeveled([XXX, XXX, XXX, XXX, XXX, PG, R]).map((x) => ({ ...x, id: x.id + 1 })),
+    ];
+    const out = selectSlimGetAllModelImages(imgs, GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(out).toContain(imgs[0]);
+  });
+
+  it('(b) contains ≥1 image of EVERY distinct nsfwLevel present (coverage property)', () => {
+    // 5 distinct bits scattered past the naive-first-6 window.
+    const imgs = makeLeveled([XXX, XXX, XXX, XXX, XXX, XXX, R, PG13, PG, X, XXX, XXX]);
+    const out = selectSlimGetAllModelImages(imgs, GET_ALL_IMAGES_PER_MODEL_SLIM);
+    const distinct = new Set(imgs.map((i) => i.nsfwLevel));
+    const covered = new Set(out.map((i) => i.nsfwLevel));
+    for (const level of distinct) expect(covered.has(level)).toBe(true);
+  });
+
+  it('(b2) covers all 6 distinct bits when exactly 6 are present', () => {
+    const imgs = makeLeveled([XXX, XXX, XXX, XXX, XXX, XXX, PG, PG13, R, X, XXX, BLOCKED]);
+    const out = selectSlimGetAllModelImages(imgs, GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(new Set(out.map((i) => i.nsfwLevel))).toEqual(
+      new Set([PG, PG13, R, X, XXX, BLOCKED])
+    );
+    expect(out).toHaveLength(GET_ALL_IMAGES_PER_MODEL_SLIM);
+  });
+
+  it('(c) returns ≤ limit images in ORIGINAL cache order', () => {
+    const imgs = makeLeveled([XXX, XXX, XXX, XXX, XXX, XXX, PG, PG13, R, X, XXX, XXX]);
+    const out = selectSlimGetAllModelImages(imgs, GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(out.length).toBeLessThanOrEqual(GET_ALL_IMAGES_PER_MODEL_SLIM);
+    const ids = out.map((i) => i.id);
+    expect([...ids].sort((a, b) => a - b)).toEqual(ids); // ascending index/id => cache order
+  });
+
+  it('(d) with fewer than the cap distinct levels, fills remaining slots by cache order', () => {
+    // Only two distinct bits → coverage needs 2; the other 4 slots fill first-come.
+    const imgs = makeLeveled([PG, PG, PG, PG, PG, PG, XXX, PG, PG]);
+    const out = selectSlimGetAllModelImages(imgs, GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(out).toHaveLength(GET_ALL_IMAGES_PER_MODEL_SLIM);
+    // covers both bits...
+    expect(new Set(out.map((i) => i.nsfwLevel))).toEqual(new Set([PG, XXX]));
+    // ...and the fill is the earliest PG images (ids 1..5) plus the XXX rep (id 7).
+    expect(out.map((i) => i.id).sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5, 7]);
+  });
+
+  it('(e) input at/under the cap is returned unchanged (same reference)', () => {
+    const five = makeLeveled([PG, PG13, R, X, XXX]);
+    expect(selectSlimGetAllModelImages(five, GET_ALL_IMAGES_PER_MODEL_SLIM)).toBe(five);
+    const six = makeLeveled([PG, PG13, R, X, XXX, BLOCKED]);
+    expect(selectSlimGetAllModelImages(six, GET_ALL_IMAGES_PER_MODEL_SLIM)).toBe(six);
+  });
+
+  it('does NOT mutate the source array (shared-cache safety)', () => {
+    const imgs = makeLeveled([XXX, XXX, XXX, XXX, XXX, XXX, PG, PG13, R, X]);
+    const before = [...imgs];
+    const out = selectSlimGetAllModelImages(imgs, GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(imgs).toEqual(before);
+    expect(out).not.toBe(imgs);
+  });
+
+  describe('empty-rate property — the point of the bias', () => {
+    // A model whose leading 6 images are all high-nsfw, with a lone PG image at index 8.
+    const model = makeLeveled([XXX, XXX, XXX, XXX, XXX, XXX, XXX, XXX, PG, XXX]);
+    const naiveFirst6 = model.slice(0, GET_ALL_IMAGES_PER_MODEL_SLIM);
+    const biased = selectSlimGetAllModelImages(model, GET_ALL_IMAGES_PER_MODEL_SLIM);
+
+    it('a PG-only viewer is DROPPED by naive first-6 but KEPT by the biased slice', () => {
+      // PG-only viewer: browsingLevel = PG, maxSelectedLevel = PG.
+      expect(anyVisibleBrowsing(naiveFirst6, PG)).toBe(false); // naive → feed_noimages_drop
+      expect(anyVisibleBrowsing(biased, PG)).toBe(true); // biased → keeps a cover
+      // full set was visible to them, so the cap must not newly drop them:
+      expect(anyVisibleBrowsing(model, PG)).toBe(true);
+      // and the biased slice actually pulled the index-8 PG image forward:
+      expect(biased.some((i) => i.nsfwLevel === PG)).toBe(true);
+      expect(naiveFirst6.some((i) => i.nsfwLevel === PG)).toBe(false);
+    });
+
+    it('(symmetric) highest-bit coverage keeps a high-only viewer whose only high image is late', () => {
+      // Leading 6 all PG, the lone high image sits at index 8 — mirror case.
+      const model2 = makeLeveled([PG, PG, PG, PG, PG, PG, PG, PG, XXX, PG]);
+      const naive2 = model2.slice(0, GET_ALL_IMAGES_PER_MODEL_SLIM);
+      const biased2 = selectSlimGetAllModelImages(model2, GET_ALL_IMAGES_PER_MODEL_SLIM);
+      // high-only viewer: browsingLevel = XXX.
+      expect(anyVisibleBrowsing(naive2, XXX)).toBe(false); // naive drops them
+      expect(anyVisibleBrowsing(biased2, XXX)).toBe(true); // biased keeps the XXX rep
+    });
+
+    it('a permissive (see-everything) viewer still sees images[0] as the cover', () => {
+      // Order preserved => the first surviving image for a permissive viewer is the lead.
+      const seeAll = XXX | X | R | PG13 | PG | BLOCKED;
+      const firstSurvivor = biased.find((i) => (i.nsfwLevel & seeAll) !== 0);
+      expect(firstSurvivor).toBe(model[0]);
+    });
+
+    it('the max-level branch is covered by including the lowest bit present', () => {
+      // A see-nothing-but-PG viewer (maxSelectedLevel = PG) keeps a cover iff the
+      // slice carries the lowest bit (PG) — which the coverage step guarantees.
+      expect(anyVisibleMaxLevel(model, PG)).toBe(true);
+      expect(anyVisibleMaxLevel(naiveFirst6, PG)).toBe(false);
+      expect(anyVisibleMaxLevel(biased, PG)).toBe(true);
+    });
+  });
+});
+
+describe('model-getall-images — buildGetAllModelImages biased flag', () => {
+  const makeLeveledFull = (levels: number[]) =>
+    levels.map((nsfwLevel, i) => ({ ...makeFullImage(i + 1), nsfwLevel }));
+
+  it('OFF (default) path is the naive first-12, unchanged', () => {
+    const imgs = makeLeveledFull(Array.from({ length: 20 }, () => XXX));
+    // put a lone PG deep in the tail; the OFF path must NOT pull it forward.
+    imgs[15] = { ...imgs[15], nsfwLevel: PG };
+    const out = buildGetAllModelImages(imgs); // biased defaults to false
+    expect(out).toHaveLength(GET_ALL_IMAGES_PER_MODEL);
+    expect(out.map((i) => i.id)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+  });
+
+  it('biased slim path pulls the coverage image forward and still field-trims', () => {
+    const imgs = makeLeveledFull([XXX, XXX, XXX, XXX, XXX, XXX, XXX, XXX, PG, XXX]);
+    const out = buildGetAllModelImages(imgs, GET_ALL_IMAGES_PER_MODEL_SLIM, true);
+    expect(out).toHaveLength(GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(out.some((i) => i.nsfwLevel === PG)).toBe(true); // coverage
+    for (const dropped of GETALL_DROPPED_IMAGE_FIELDS) {
+      expect(out[0]).not.toHaveProperty(dropped); // field trim still applied
+    }
+    expect(out[0]).toHaveProperty('url');
+    // shared cache untouched
+    expect(imgs).toHaveLength(10);
+    expect(imgs[0]).toHaveProperty('onSite');
   });
 });

--- a/src/server/utils/__tests__/model-getall-images.test.ts
+++ b/src/server/utils/__tests__/model-getall-images.test.ts
@@ -219,6 +219,35 @@ describe('model-getall-images — nsfw-biased slim slice', () => {
     expect(out).toHaveLength(GET_ALL_IMAGES_PER_MODEL_SLIM);
   });
 
+  it('(b3) a falsy/null lead never crowds out a real bit (defensive precondition)', () => {
+    // UNREACHABLE on the real cache (SQL filters nsfwLevel != 0/NULL), but a future
+    // caller could pass a set with a null/0 lead. A falsy level is visible to NO
+    // viewer, so it must NOT consume a coverage slot: all 6 distinct REAL bits still
+    // get a representative. (6 real bits + a null lead = 7 items for 6 slots — the
+    // one omitted is the unseeable lead; browsing-level safety > keeping it.)
+    const imgs = [
+      { id: 1, url: 'lead', nsfwLevel: null as number | null },
+      ...makeLeveled([PG, PG13, R, X, XXX, BLOCKED]).map((x) => ({ ...x, id: x.id + 1 })),
+    ];
+    const out = selectSlimGetAllModelImages(imgs, GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(out).toHaveLength(GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(new Set(out.map((i) => i.nsfwLevel))).toEqual(
+      new Set([PG, PG13, R, X, XXX, BLOCKED])
+    );
+  });
+
+  it('(b4) a falsy-level lead IS kept when the real bits leave a free slot', () => {
+    // 3 distinct real bits + a 0-level lead + limit 6 → room to spare, so the curated
+    // lead fills in (behavior matches the real path, where the lead carries a real bit).
+    const imgs = [
+      { id: 1, url: 'lead', nsfwLevel: 0 },
+      ...makeLeveled([XXX, XXX, XXX, PG, R, XXX]).map((x) => ({ ...x, id: x.id + 1 })),
+    ];
+    const out = selectSlimGetAllModelImages(imgs, GET_ALL_IMAGES_PER_MODEL_SLIM);
+    expect(out).toContain(imgs[0]); // curated lead kept via fill
+    expect(new Set(out.map((i) => i.nsfwLevel))).toEqual(new Set([0, XXX, PG, R]));
+  });
+
   it('(c) returns ≤ limit images in ORIGINAL cache order', () => {
     const imgs = makeLeveled([XXX, XXX, XXX, XXX, XXX, XXX, PG, PG13, R, X, XXX, XXX]);
     const out = selectSlimGetAllModelImages(imgs, GET_ALL_IMAGES_PER_MODEL_SLIM);

--- a/src/server/utils/model-getall-images.ts
+++ b/src/server/utils/model-getall-images.ts
@@ -131,18 +131,25 @@ export function capGetAllModelImages<T>(images: T[], limit = GET_ALL_IMAGES_PER_
  *     level they could see, and we always include a rep of every bit incl. `Lmin` →
  *     `Lmin <= maxSelectedLevel` → survives. (Covering every bit also covers the
  *     HIGHEST bit, so a high-only viewer keeps a cover too.)
- * Since there are ≤6 bits and the slim cap is 6, all distinct bits always fit. Any
- * per-image poi/minor/hidden-tag drops are viewer/image-specific and orthogonal to this
- * nsfwLevel coverage guarantee (they can drop the representative just as they'd drop the
- * naive first-6 image; the bias never makes coverage WORSE than first-6).
+ * Since there are ≤6 bits and the slim cap is 6, all distinct bits always fit. The
+ * guarantee is scoped to the nsfwLevel dimension (~0 NEW browsing-level drops): any
+ * per-image poi/minor/hidden-tag drops are viewer/image-specific and orthogonal — they
+ * can drop a coverage representative just as they'd drop the naive first-6 image, and
+ * they affect all cap policies alike.
  *
- * Algorithm:
- *   1. Always keep `images[0]` — the creator's curated lead (the cover a permissive
- *      viewer sees), even if its level is null/unset.
- *   2. Add the EARLIEST-cache-order image of each distinct `nsfwLevel` bit not yet
- *      selected (the coverage step).
- *   3. If slots remain, fill with the earliest not-yet-selected images.
- *   4. Return the selected set in ORIGINAL cache order, capped to `limit` — so a
+ * PRECONDITION: designed for the `model.getAll` image cache, where every `nsfwLevel` is
+ * a TRUTHY single bit (the shared-cache SQL filters `nsfwLevel != 0`/NULL). Falsy
+ * (0/null/undefined) levels are visible to no viewer and NEVER consume a bit-slot, so
+ * they can't crowd out a real bit even if a future caller passes such a set.
+ *
+ * Algorithm (coverage-first):
+ *   1. Coverage: add the EARLIEST-cache-order image of each distinct TRUTHY `nsfwLevel`
+ *      bit. Index 0 — the creator's curated lead — is the earliest rep of its own bit,
+ *      so it is covered on the real-data path (every level a truthy single bit).
+ *   2. Fill any remaining slots with the earliest not-yet-selected images (this reaches
+ *      index 0 first, so the curated lead is kept whenever a slot is free; a falsy /
+ *      invisible lead is omitted only when the real bits already fill the budget).
+ *   3. Return the selected set in ORIGINAL cache order, capped to `limit` — so a
  *      permissive viewer's cover stays `images[0]`, not the safest image (order does
  *      not affect the survives/drop test, only display).
  *
@@ -156,24 +163,28 @@ export function selectSlimGetAllModelImages<T extends { nsfwLevel?: number | nul
   if (images.length <= limit) return images;
 
   const selected = new Set<number>();
-  // 1. Always include the curated lead (guarded: its level may be unset).
-  selected.add(0);
-
-  // 2. One earliest-cache-order representative per distinct nsfwLevel bit present.
   const seenLevels = new Set<number>();
-  const lead = images[0]?.nsfwLevel;
-  if (lead != null) seenLevels.add(lead);
-  for (let i = 1; i < images.length && selected.size < limit; i++) {
+
+  // 1. Coverage: one EARLIEST-cache-order representative per distinct nsfwLevel bit.
+  //    A FALSY level (0 / null / undefined — not a browseable bit, so visible to NO
+  //    viewer) never claims a coverage slot, so it can never crowd out a real bit.
+  //    Because index 0 is the earliest image, a real-bit lead is its bit's earliest
+  //    representative here — so the creator's curated lead is always covered on the
+  //    real-data path (where every level is a truthy single bit).
+  for (let i = 0; i < images.length && selected.size < limit; i++) {
     const level = images[i]?.nsfwLevel;
-    if (level == null || seenLevels.has(level)) continue;
+    if (!level || seenLevels.has(level)) continue;
     seenLevels.add(level);
     selected.add(i);
   }
 
-  // 3. Fill any remaining slots with the earliest not-yet-selected images.
+  // 2. Fill remaining slots by cache order. This visits index 0 first, so the curated
+  //    lead is included whenever a slot is free (including a falsy/invisible lead) — it
+  //    is omitted ONLY when the distinct real bits already fill the budget, which loses
+  //    no viewer a cover (a falsy-level lead is visible to nobody).
   for (let i = 0; i < images.length && selected.size < limit; i++) selected.add(i);
 
-  // 4. Emit in original cache order, capped.
+  // 3. Emit in original cache order, capped.
   return [...selected]
     .sort((a, b) => a - b)
     .slice(0, limit)

--- a/src/server/utils/model-getall-images.ts
+++ b/src/server/utils/model-getall-images.ts
@@ -108,6 +108,79 @@ export function capGetAllModelImages<T>(images: T[], limit = GET_ALL_IMAGES_PER_
 }
 
 /**
+ * NSFW-biased slim slice — the SELECTION used on the flag-ON (`getAllModelImagesSlim`)
+ * path INSTEAD of the naive first-`limit`. Same byte win as `capGetAllModelImages`
+ * (returns exactly `limit` images), but chosen to drive the browsing-level feed-drop
+ * regression to ~0 rather than the naive first-6's measured ~2.7%.
+ *
+ * WHY it's coverage-complete. The shared cache is ordered `postId,index` (creator's
+ * curated order, browsing-AGNOSTIC), so the naive first-6 can leave a mixed-level
+ * model's only browsing-safe image past index 6 → the client hidden-prefs filter
+ * (`useApplyHiddenPreferences`, `case 'models'`) finds no survivor → `hidden.noImages`
+ * drops the model from that viewer's feed. An image `nsfwLevel` is ALWAYS a SINGLE bit
+ * (1/2/4/8/16/32 — there are ≤6 distinct levels), and the per-image filter has exactly
+ * two nsfw branches:
+ *   - `model.nsfw`  → keep if `image.nsfwLevel <= maxSelectedLevel`
+ *   - otherwise     → keep if `(image.nsfwLevel & browsingLevel) != 0`
+ * So if we include ONE representative image of every distinct bit present in the full
+ * set, then for ANY viewer who had ≥1 visible image in the full ≤20 set we still have a
+ * survivor in the slice:
+ *   - `(nsfwLevel & browsingLevel)!=0` viewer: their satisfying bit L is present → its
+ *     representative (also bit L) intersects `browsingLevel` → survives.
+ *   - `nsfwLevel <= maxSelectedLevel` viewer: the LOWEST bit present `Lmin` is ≤ any
+ *     level they could see, and we always include a rep of every bit incl. `Lmin` →
+ *     `Lmin <= maxSelectedLevel` → survives. (Covering every bit also covers the
+ *     HIGHEST bit, so a high-only viewer keeps a cover too.)
+ * Since there are ≤6 bits and the slim cap is 6, all distinct bits always fit. Any
+ * per-image poi/minor/hidden-tag drops are viewer/image-specific and orthogonal to this
+ * nsfwLevel coverage guarantee (they can drop the representative just as they'd drop the
+ * naive first-6 image; the bias never makes coverage WORSE than first-6).
+ *
+ * Algorithm:
+ *   1. Always keep `images[0]` — the creator's curated lead (the cover a permissive
+ *      viewer sees), even if its level is null/unset.
+ *   2. Add the EARLIEST-cache-order image of each distinct `nsfwLevel` bit not yet
+ *      selected (the coverage step).
+ *   3. If slots remain, fill with the earliest not-yet-selected images.
+ *   4. Return the selected set in ORIGINAL cache order, capped to `limit` — so a
+ *      permissive viewer's cover stays `images[0]`, not the safest image (order does
+ *      not affect the survives/drop test, only display).
+ *
+ * Never mutates the input and returns a fresh array (shared-cache safety); ≤ `limit`
+ * pass-through returns the input unchanged (the caller field-trim then clones it).
+ */
+export function selectSlimGetAllModelImages<T extends { nsfwLevel?: number | null }>(
+  images: T[],
+  limit = GET_ALL_IMAGES_PER_MODEL_SLIM
+): T[] {
+  if (images.length <= limit) return images;
+
+  const selected = new Set<number>();
+  // 1. Always include the curated lead (guarded: its level may be unset).
+  selected.add(0);
+
+  // 2. One earliest-cache-order representative per distinct nsfwLevel bit present.
+  const seenLevels = new Set<number>();
+  const lead = images[0]?.nsfwLevel;
+  if (lead != null) seenLevels.add(lead);
+  for (let i = 1; i < images.length && selected.size < limit; i++) {
+    const level = images[i]?.nsfwLevel;
+    if (level == null || seenLevels.has(level)) continue;
+    seenLevels.add(level);
+    selected.add(i);
+  }
+
+  // 3. Fill any remaining slots with the earliest not-yet-selected images.
+  for (let i = 0; i < images.length && selected.size < limit; i++) selected.add(i);
+
+  // 4. Emit in original cache order, capped.
+  return [...selected]
+    .sort((a, b) => a - b)
+    .slice(0, limit)
+    .map((i) => images[i]);
+}
+
+/**
  * Return a shallow copy of `image` without the wire-dropped fields. Generic so it
  * is type-safe over the cache result type (a key absent on the input is a no-op),
  * and the narrowed `Omit<...>` return type makes tsc flag any future consumer that
@@ -120,12 +193,24 @@ export function stripGetAllModelImage<T extends Record<string, unknown>>(image: 
 
 /**
  * The exact per-model image wire transform the `model.getAll` response mapping
- * applies: cap to `limit` (flag-selected), then field-trim every surviving image.
- * Both steps return fresh arrays/objects — the shared image cache is never touched.
+ * applies: reduce to `limit` images, then field-trim every surviving image. Both
+ * steps return fresh arrays/objects — the shared image cache is never touched.
+ *
+ * Selection depends on `biased`:
+ *   - `biased: false` (default, flag-OFF path + non-feed callers like home blocks /
+ *     collections): naive first-`limit` cache order — BYTE-IDENTICAL to today.
+ *   - `biased: true` (flag-ON `getAllModelImagesSlim` path only): the nsfw-biased
+ *     coverage slice (`selectSlimGetAllModelImages`) — same count/byte win, but
+ *     guarantees any viewer with a visible image in the full set keeps one in the
+ *     slice, driving the feed-drop regression to ~0. See that fn's docs.
  */
 export function buildGetAllModelImages<T extends Record<string, unknown>>(
   images: T[],
-  limit = GET_ALL_IMAGES_PER_MODEL
+  limit = GET_ALL_IMAGES_PER_MODEL,
+  biased = false
 ) {
-  return capGetAllModelImages(images, limit).map(stripGetAllModelImage);
+  const reduced = biased
+    ? selectSlimGetAllModelImages(images as (T & { nsfwLevel?: number | null })[], limit)
+    : capGetAllModelImages(images, limit);
+  return reduced.map(stripGetAllModelImage);
 }


### PR DESCRIPTION
## What

Replaces the naive first-6 `.slice(0, 6)` on the **slim** `model.getAll` image path (the `getAllModelImagesSlim` dark flag, from #3079) with an **nsfw-biased coverage slice**. Same count/byte reduction (12 → 6 images/model), but chosen so that reducing the count adds **~zero** new browse-feed drops instead of the naive first-6's ~2.7% of covers.

Server-only, flag-gated. **OFF (default) path is byte-identical to today** (naive first-12, cache order). Only the flag-ON slim path changes *which* 6 images are kept. No client bundle change (the feed already renders any-length image arrays).

## Why the biased slice is coverage-complete

`model.getAll` images come from a user-independent cache ordered `postId,index` (creator's post order, browsing-**agnostic**). Per-viewer filtering runs **client-side** in `useApplyHiddenPreferences` (`case 'models'`): it walks the array, drops images the viewer can't see, and the card cover is the first survivor — if none survive, the model drops from that viewer's feed (`feed_noimages_drop`). With a naive first-6, a mixed-level model whose only browsing-safe image sits past index 6 is dropped from an SFW viewer.

The key fact: an image `nsfwLevel` is **always a single bit** (1/2/4/8/16/32 — ≤6 distinct levels), and the per-image filter has exactly two nsfw branches:

- `model.nsfw` → keep if `nsfwLevel <= maxSelectedLevel`
- otherwise → keep if `(nsfwLevel & browsingLevel) != 0`

So if the slice includes **one representative of every distinct bit present** in the full set, then **any** viewer who had ≥1 visible image in the full ≤20 set still has one in the slice:

- `(nsfwLevel & browsingLevel)!=0` viewer: their satisfying bit L is present → its representative (also bit L) intersects `browsingLevel` → survives.
- `nsfwLevel <= maxSelectedLevel` viewer: the **lowest** bit present `Lmin` is ≤ any level they could see; we always include a rep of every bit incl. `Lmin` → `Lmin <= maxSelectedLevel` → survives.

Covering every distinct bit also covers the **highest** bit, so a high-only viewer whose only high image is late is kept too. There are ≤6 bits and the slim cap is 6, so all distinct bits always fit. (Per-image poi/minor/hidden-tag drops are viewer/image-specific and orthogonal — the bias never makes coverage worse than first-6.)

## Algorithm (`selectSlimGetAllModelImages`, pure, no shared-cache mutation)

1. Always keep `images[0]` — the creator's curated lead (even if its level is unset).
2. Add the earliest-cache-order image of each distinct `nsfwLevel` bit not yet selected (the coverage step).
3. If slots remain, fill with the earliest not-yet-selected images.
4. Return the selected set **in original cache order**, capped to 6 — so a permissive viewer's cover stays `images[0]`, not the safest image (order doesn't affect survives/drop, only display).

Returns fresh arrays/objects; the shared `imagesForModelVersionsCache` is never mutated (same discipline as #3079). Composed with the always-on per-image field trim, unchanged.

## Wins

- Payload: unchanged from #3079 — ~34% on the >6-image tail (dropping 12 → 6 images/model).
- Empty-rate: ~0 new feed drops vs naive first-6's ~2.7% of covers.

## Tests

Added to `model-getall-images.test.ts` (26 pass): always-contains-`images[0]` (incl. unset lead level); the coverage property (≥1 image of every distinct bit, incl. the 6-distinct-bits case); ≤6 in original cache order; fills by cache order with <6 distinct levels; input ≤6 returned unchanged; no source mutation; the **empty-rate property** (leading 6 all high + lone PG at index 8 → naive first-6 drops a PG viewer, biased keeps them) + the symmetric high-only case + the max-level branch; and the OFF path stays naive first-12 while the biased slim path pulls the coverage image forward and still field-trims.

## Rollout

Server-only + flag-gated (`get-all-model-images-slim`, `availability: []` = DARK, fails closed). OFF = unchanged cap-12. Deploy dark, create the Flipt flag, then ramp threshold-only while watching `feed_noimages_drop` (`event_name="feed_noimages_drop"`). Instant rollback = set the threshold to 0.
