### PR TITLE
fix(model-version): deregister storage-resolver file_locations on delete

### DIFF
--- a/src/server/services/__tests__/model-version.deregister.service.test.ts
+++ b/src/server/services/__tests__/model-version.deregister.service.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Verifies deleteVersionById's post-commit cleanup: it deregisters the
+// storage-resolver file_locations rows for the deleted version (the go-forward
+// fix for leaked tiered objects) WHILE preserving the legacy ModelFile.url S3
+// cleanup for non-tiered/legacy files. deregister is best-effort — a failure
+// must not fail the (already-committed) version delete.
+
+const { mockDbWrite } = vi.hoisted(() => {
+  const mk = () => ({
+    findFirst: vi.fn(),
+    findFirstOrThrow: vi.fn(),
+    findUnique: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    delete: vi.fn(),
+    deleteMany: vi.fn(),
+    groupBy: vi.fn(),
+    count: vi.fn(),
+  });
+  const write = {
+    modelVersion: mk(),
+    modelFile: mk(),
+    entityAccess: mk(),
+    $queryRaw: vi.fn(),
+    $transaction: vi.fn(),
+  };
+  return { mockDbWrite: write };
+});
+
+const { mockDeleteModelFileObjects, mockDeregisterFileLocations } = vi.hoisted(() => ({
+  mockDeleteModelFileObjects: vi.fn(),
+  mockDeregisterFileLocations: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbWrite, dbWrite: mockDbWrite }));
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, dbReadFallbackCounter: { inc: vi.fn() } };
+});
+
+// Keep the heavy service/search-index graph out of the test module graph
+// (mirrors model-version.idempotent.service.test.ts).
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+vi.mock('~/server/redis/caches', () => ({}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return { ...actual, redis: { get: vi.fn(), set: vi.fn() }, sysRedis: { get: vi.fn() } };
+});
+vi.mock('~/server/redis/resource-data.redis', () => ({ resourceDataCache: {} }));
+vi.mock('~/server/search-index', () => ({}));
+vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
+vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({}));
+vi.mock('~/server/services/common.service', () => ({ hasEntityAccess: vi.fn() }));
+vi.mock('~/server/services/donation-goal.service', () => ({ checkDonationGoalComplete: vi.fn() }));
+vi.mock('~/server/services/image.service', () => ({
+  imagesForModelVersionsCache: {},
+  uploadImageFromUrl: vi.fn(),
+}));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
+vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
+vi.mock('~/server/services/model.service', () => ({
+  ingestModelById: vi.fn(),
+  updateModelLastVersionAt: vi.fn(),
+}));
+vi.mock('~/server/services/model-file.service', () => ({ filesForModelVersionCache: {} }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+vi.mock('~/server/db/db-lag-helpers', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, preventModelVersionLag: vi.fn() };
+});
+vi.mock('~/utils/s3-utils', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, deleteModelFileObjects: mockDeleteModelFileObjects };
+});
+vi.mock('~/utils/storage-resolver', () => ({
+  deregisterFileLocations: mockDeregisterFileLocations,
+}));
+
+import { deleteVersionById } from '~/server/services/model-version.service';
+
+// Drive the interactive transaction: invoke the callback with a `tx` that maps
+// to our mocked dbWrite delegates, so the snapshot + cascade run against mocks.
+function wireTransaction() {
+  mockDbWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) =>
+    cb(mockDbWrite)
+  );
+}
+
+const VERSION_ID = 4242;
+
+function stubVersionRows(fileUrls: string[]) {
+  mockDbWrite.modelFile.findMany.mockResolvedValue(fileUrls.map((url) => ({ url })));
+  mockDbWrite.modelVersion.findFirstOrThrow.mockResolvedValue({
+    id: VERSION_ID,
+    modelId: 7,
+    status: 'Published',
+    earlyAccessConfig: null,
+    earlyAccessEndsAt: null,
+    meta: {},
+  });
+  mockDbWrite.entityAccess.deleteMany.mockResolvedValue({ count: 0 });
+  mockDbWrite.modelVersion.delete.mockResolvedValue({ id: VERSION_ID, modelId: 7 });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  wireTransaction();
+  mockDeleteModelFileObjects.mockResolvedValue(undefined);
+  mockDeregisterFileLocations.mockResolvedValue({ deleted: 1 });
+});
+
+describe('deleteVersionById — file_locations deregistration', () => {
+  it('deregisters by version id AND still runs the legacy ModelFile.url S3 cleanup', async () => {
+    stubVersionRows(['https://s3.us-west-004.backblazeb2.com/civitai-modelfiles/model/7/a.safetensors']);
+
+    await deleteVersionById({ id: VERSION_ID });
+
+    // Legacy byte cleanup preserved for non-tiered/legacy files.
+    expect(mockDeleteModelFileObjects).toHaveBeenCalledTimes(1);
+    // The go-forward deregister, keyed on the version id (not per-file url).
+    expect(mockDeregisterFileLocations).toHaveBeenCalledTimes(1);
+    expect(mockDeregisterFileLocations).toHaveBeenCalledWith(VERSION_ID);
+  });
+
+  it('deregisters exactly once regardless of how many files the version has', async () => {
+    stubVersionRows([
+      'https://s3.us-west-004.backblazeb2.com/civitai-modelfiles/model/7/a.safetensors',
+      'https://s3.us-west-004.backblazeb2.com/civitai-modelfiles/model/7/b.yaml',
+      'https://s3.us-west-004.backblazeb2.com/civitai-modelfiles/model/7/c.vae',
+    ]);
+
+    await deleteVersionById({ id: VERSION_ID });
+
+    expect(mockDeregisterFileLocations).toHaveBeenCalledTimes(1);
+    expect(mockDeregisterFileLocations).toHaveBeenCalledWith(VERSION_ID);
+    // One batch cleanup call carrying all three urls.
+    expect(mockDeleteModelFileObjects).toHaveBeenCalledTimes(1);
+    expect(mockDeleteModelFileObjects.mock.calls[0][0]).toHaveLength(3);
+  });
+
+  it('still deregisters when the version has no model files (no legacy S3 call)', async () => {
+    stubVersionRows([]);
+
+    await deleteVersionById({ id: VERSION_ID });
+
+    // No urls → the legacy cleanup is skipped by the length guard...
+    expect(mockDeleteModelFileObjects).not.toHaveBeenCalled();
+    // ...but deregistration always runs (a never-tiered version is a no-op server-side).
+    expect(mockDeregisterFileLocations).toHaveBeenCalledWith(VERSION_ID);
+  });
+
+  it('does not fail the version delete if deregistration throws (best-effort)', async () => {
+    stubVersionRows(['https://s3.us-west-004.backblazeb2.com/civitai-modelfiles/model/7/a.safetensors']);
+    mockDeregisterFileLocations.mockRejectedValue(new Error('storage-resolver down'));
+
+    const result = await deleteVersionById({ id: VERSION_ID });
+
+    expect(result).toEqual({ id: VERSION_ID, modelId: 7 });
+    expect(mockDeregisterFileLocations).toHaveBeenCalledWith(VERSION_ID);
+  });
+});

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -107,6 +107,7 @@ import { ingestModelById, updateModelLastVersionAt } from './model.service';
 import { markFileReplaced, filesForModelVersionCache } from './model-file.service';
 import { getBuzzTransactionSupportedAccountTypes } from '~/utils/buzz';
 import { deleteModelFileObjects } from '~/utils/s3-utils';
+import { deregisterFileLocations } from '~/utils/storage-resolver';
 import type { BaseModel, BaseModelGroup } from '~/shared/constants/basemodel.constants';
 import { getBaseModelsByGroup } from '~/shared/constants/basemodel.constants';
 import type { ImageMetadata } from '~/server/schema/media.schema';
@@ -845,6 +846,10 @@ export const deleteVersionById = async ({
   }
 
   // Post-commit S3 cleanup — only after Postgres confirms the delete stuck.
+  // Keyed on ModelFile.url; this deletes the bytes for non-tiered / legacy
+  // files. For a TIERED file ModelFile.url is a known-stale pointer, so this
+  // path misses the real object — the deregister step below is what stops that
+  // leak. The two are complementary; keep both.
   if (modelFileUrls.length > 0) {
     try {
       await deleteModelFileObjects(modelFileUrls);
@@ -856,6 +861,25 @@ export const deleteVersionById = async ({
         error,
       });
     }
+  }
+
+  // Post-commit: deregister storage-resolver file_locations rows for this
+  // version. For a tiered file the real backend object is keyed by
+  // file_locations.path (not the stale ModelFile.url the S3 cleanup used), and
+  // the surviving row keeps that object whitelisted against the dereference-
+  // quarantine sweep. Removing the row turns the now catalog-gone object into a
+  // true storage orphan the existing sweep reclaims (reversibly) on its next
+  // cycle. deregisterFileLocations is best-effort and never throws, but wrap it
+  // anyway so a future change can't turn a registry blip into a failed delete.
+  try {
+    await deregisterFileLocations(id);
+  } catch (error) {
+    logToAxiom({
+      type: 'error',
+      name: 'model-version-delete-deregister-file-locations',
+      message: `Failed to deregister file locations for model version ${id}`,
+      error,
+    });
   }
 
   return version;

--- a/src/utils/__tests__/storage-resolver.deregister.test.ts
+++ b/src/utils/__tests__/storage-resolver.deregister.test.ts
@@ -22,9 +22,6 @@ vi.mock('~/env/server', () => ({
 const { logToAxiom } = vi.hoisted(() => ({ logToAxiom: vi.fn(() => Promise.resolve()) }));
 vi.mock('~/server/logging/client', () => ({ logToAxiom }));
 
-// Keep the real fetch-timeout out of the picture (no dangling timers in tests).
-vi.mock('~/server/utils/fetch-timeout', () => ({ fetchTimeoutSignal: () => undefined }));
-
 import { deregisterFileLocations } from '~/utils/storage-resolver';
 
 const okResponse = (body: unknown) => ({
@@ -62,6 +59,8 @@ describe('deregisterFileLocations', () => {
     expect((init as RequestInit).method).toBe('POST');
     expect((init as any).headers.Authorization).toBe('Bearer test-token');
     expect(JSON.parse((init as RequestInit).body as string)).toEqual({ modelVersionId: 67890 });
+    // Unconditional abort signal so a hung resolver can't block the delete forever.
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
   });
 
   it('is a no-op returning null (and warns) when storage-resolver is not configured', async () => {
@@ -95,6 +94,21 @@ describe('deregisterFileLocations', () => {
     fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
 
     await expect(deregisterFileLocations(3)).resolves.toBeNull();
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'deregister-file-locations-error' })
+    );
+  });
+
+  it('returns null (and logs) when the request times out against a hung resolver', async () => {
+    // Simulate the AbortSignal.timeout firing: fetch rejects with an AbortError,
+    // exactly as it would when a resolver accepts the socket but never replies.
+    fetchMock.mockRejectedValue(
+      new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+    );
+
+    // Must resolve (never throw) so the awaited call in deleteVersionById can't
+    // hang or fail the already-committed version delete.
+    await expect(deregisterFileLocations(4)).resolves.toBeNull();
     expect(logToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'deregister-file-locations-error' })
     );

--- a/src/utils/__tests__/storage-resolver.deregister.test.ts
+++ b/src/utils/__tests__/storage-resolver.deregister.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Concrete internal URL + token so the configured branch is reachable. Any field
+// we don't set falls back to the global env Proxy in src/__tests__/setup.ts.
+// vi.hoisted so the object exists before the hoisted vi.mock factory runs.
+const { envValues } = vi.hoisted(() => ({
+  envValues: {
+    STORAGE_RESOLVER_INTERNAL_URL: 'http://storage-resolver.internal',
+    STORAGE_RESOLVER_INTERNAL_TOKEN: 'test-token',
+  } as Record<string, unknown>,
+}));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy(envValues, {
+    get(target, prop: string) {
+      if (prop in target) return target[prop];
+      return undefined;
+    },
+  }),
+}));
+
+const { logToAxiom } = vi.hoisted(() => ({ logToAxiom: vi.fn(() => Promise.resolve()) }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom }));
+
+// Keep the real fetch-timeout out of the picture (no dangling timers in tests).
+vi.mock('~/server/utils/fetch-timeout', () => ({ fetchTimeoutSignal: () => undefined }));
+
+import { deregisterFileLocations } from '~/utils/storage-resolver';
+
+const okResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  json: () => Promise.resolve(body),
+  text: () => Promise.resolve(JSON.stringify(body)),
+});
+
+describe('deregisterFileLocations', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    logToAxiom.mockClear();
+    vi.stubGlobal('fetch', fetchMock);
+    // Restore the configured env for each test; individual tests may clear it.
+    envValues.STORAGE_RESOLVER_INTERNAL_URL = 'http://storage-resolver.internal';
+    envValues.STORAGE_RESOLVER_INTERNAL_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs modelVersionId with the bearer token and returns the deleted count', async () => {
+    fetchMock.mockResolvedValue(okResponse({ success: true, deleted: 3, rows: [] }));
+
+    const result = await deregisterFileLocations(67890);
+
+    expect(result).toEqual({ deleted: 3 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://storage-resolver.internal/deregister');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as any).headers.Authorization).toBe('Bearer test-token');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ modelVersionId: 67890 });
+  });
+
+  it('is a no-op returning null (and warns) when storage-resolver is not configured', async () => {
+    envValues.STORAGE_RESOLVER_INTERNAL_URL = undefined;
+    envValues.STORAGE_RESOLVER_INTERNAL_TOKEN = undefined;
+
+    const result = await deregisterFileLocations(1);
+
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'deregister-file-locations-skipped' })
+    );
+  });
+
+  it('returns null (and logs) on a non-OK response — never throws', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve('boom'),
+      json: () => Promise.reject(new Error('not json')),
+    });
+
+    await expect(deregisterFileLocations(2)).resolves.toBeNull();
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'deregister-file-locations-failed', status: 500 })
+    );
+  });
+
+  it('returns null (and logs) when the resolver is unreachable — never throws', async () => {
+    fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+    await expect(deregisterFileLocations(3)).resolves.toBeNull();
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'deregister-file-locations-error' })
+    );
+  });
+});

--- a/src/utils/storage-resolver.ts
+++ b/src/utils/storage-resolver.ts
@@ -1,6 +1,5 @@
 import { env } from '~/env/server';
 import { logToAxiom } from '~/server/logging/client';
-import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 
 export async function registerFileLocation(params: {
   fileId: number;
@@ -80,7 +79,12 @@ export async function deregisterFileLocations(
         Authorization: `Bearer ${env.STORAGE_RESOLVER_INTERNAL_TOKEN}`,
       },
       body: JSON.stringify({ modelVersionId }),
-      signal: fetchTimeoutSignal(60_000),
+      // Unconditional timeout (NOT the flag-gated hot-path helper): deleteVersionById
+      // is awaited on the tRPC request path, and a hung resolver — one that accepts
+      // the socket but never replies — would otherwise block a user's delete
+      // indefinitely. Version-delete is a rare owner/mod action, so a fixed 30s cap
+      // is safe; best-effort semantics are unchanged (an abort is caught below).
+      signal: AbortSignal.timeout(30_000),
     });
 
     if (!response.ok) {

--- a/src/utils/storage-resolver.ts
+++ b/src/utils/storage-resolver.ts
@@ -1,5 +1,6 @@
 import { env } from '~/env/server';
 import { logToAxiom } from '~/server/logging/client';
+import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
 
 export async function registerFileLocation(params: {
   fileId: number;
@@ -36,4 +37,75 @@ export async function registerFileLocation(params: {
   }
 
   return response.json();
+}
+
+type DeregisterFileLocationsResult = { deleted: number };
+
+/**
+ * Deregister ALL storage-resolver `file_locations` rows for a deleted model
+ * version. Best-effort by design: this runs post-commit in the version-delete
+ * path and must never throw into (or block) the delete — every failure is
+ * caught and logged, and the function resolves to `null`.
+ *
+ * Why this exists: for a tiered file, `ModelFile.url` is a known-stale pointer
+ * (the tiering jobs move bytes between backends and update
+ * `file_locations.path`/`backend` without rewriting `ModelFile.url`), so the
+ * `ModelFile.url`-keyed S3 cleanup misses the real object AND the surviving
+ * `file_locations` row keeps that object whitelisted against the dereference-
+ * quarantine sweep — a permanent leak. Removing the row here turns the object
+ * into a true storage orphan the existing sweep reclaims (reversibly) on its
+ * next cycle. No bytes are deleted from civitai; deregistration is the whole fix.
+ */
+export async function deregisterFileLocations(
+  modelVersionId: number
+): Promise<DeregisterFileLocationsResult | null> {
+  if (!env.STORAGE_RESOLVER_INTERNAL_URL || !env.STORAGE_RESOLVER_INTERNAL_TOKEN) {
+    // Not configured in this pod — nothing to deregister. Surface once to Axiom
+    // (a silently-skipped deregister re-grows the orphan backlog just like a
+    // thrown error would), then return.
+    logToAxiom({
+      type: 'warning',
+      name: 'deregister-file-locations-skipped',
+      reason: 'storage-resolver-not-configured',
+      modelVersionId,
+    }).catch(() => undefined);
+    return null;
+  }
+
+  try {
+    const response = await fetch(`${env.STORAGE_RESOLVER_INTERNAL_URL}/deregister`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${env.STORAGE_RESOLVER_INTERNAL_TOKEN}`,
+      },
+      body: JSON.stringify({ modelVersionId }),
+      signal: fetchTimeoutSignal(60_000),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => 'unknown error');
+      logToAxiom({
+        type: 'error',
+        name: 'deregister-file-locations-failed',
+        modelVersionId,
+        status: response.status,
+        message: text,
+      }).catch(() => undefined);
+      return null;
+    }
+
+    const result = (await response.json().catch(() => null)) as {
+      deleted?: number;
+    } | null;
+    return { deleted: result?.deleted ?? 0 };
+  } catch (error) {
+    logToAxiom({
+      type: 'error',
+      name: 'deregister-file-locations-error',
+      modelVersionId,
+      error,
+    }).catch(() => undefined);
+    return null;
+  }
 }


### PR DESCRIPTION
## Problem

On model-version delete, the post-commit cleanup deletes stored objects keyed on `ModelFile.url`. For a **storage-tiered** file, `ModelFile.url` is a **known-stale pointer**: the tiering jobs move the bytes between storage backends and update the storage-resolver `file_locations` row's `path`/`backend` **without** rewriting `ModelFile.url`. So the url-keyed cleanup misses the real object, and the surviving `file_locations` row keeps that object referenced (whitelisted) against the dereference-quarantine sweep.

Net effect: every delete of a tiered file leaks **both** the stored object **and** the registry row. This has been accumulating.

## Fix

Add a best-effort post-commit **deregister** step in `deleteVersionById`: after the delete commits, call storage-resolver's new `POST /deregister` to remove all `file_locations` rows for the version.

Deregistering the row is the whole go-forward fix: once no registry row references the object and the catalog entry is gone, the object becomes a **true storage orphan** that the **existing dereference-quarantine sweep reclaims (reversibly, into a lifecycle-expiring quarantine bucket) on its next cycle**. No bytes are deleted by this change.

- The **legacy `ModelFile.url` S3 cleanup is unchanged** — behavior is preserved for non-tiered/legacy files. The two paths are complementary; both run.
- `deregisterFileLocations` **never throws** (network / non-OK / not-configured are caught and logged), and the call site is additionally wrapped so a registry blip can never fail the already-committed version delete — consistent with the other best-effort post-commit steps.

## Tests

- **Client** (`deregisterFileLocations`): configured happy-path (POSTs `modelVersionId` + bearer, returns count), not-configured no-op, non-OK response, unreachable — all return `null` without throwing.
- **`deleteVersionById` integration**: deregisters once by version id, still runs the legacy S3 cleanup, a single deregister call regardless of file count, no legacy call when the version has no files, and a deregister failure does not fail the delete.

## Paired PR — land AFTER storage-resolver

This depends on the new `POST /deregister` endpoint. Land and deploy **storage-resolver first**, then this. Companion: `civitai/storage-resolver#4`.

The reversible-quarantine reclamation is delivered by the **existing** dereference-quarantine sweep, not by new code in this PR.