### PR TITLE
fix(internal/ping): return 400 (not raw 500) on malformed referer/body

### DIFF
--- a/src/pages/api/internal/ping.ts
+++ b/src/pages/api/internal/ping.ts
@@ -11,12 +11,32 @@ import { getMatchingPathname } from '~/shared/constants/pathname.constants';
 export default PublicEndpoint(
   async (req, res) => {
     if (isDev) return res.status(200).end();
-    const url = req.headers.referer ? new URL(req.headers.referer) : undefined;
+
+    // A malformed-but-present `referer` (bot/scraper traffic) makes `new URL()`
+    // throw a TypeError. That's invalid client input, not a server fault → 400,
+    // matching the host-mismatch case below (was an unguarded raw 500).
+    let url: URL | undefined;
+    try {
+      url = req.headers.referer ? new URL(req.headers.referer) : undefined;
+    } catch {
+      return res.status(400).send('invalid request');
+    }
     const host = req.headers.host;
 
     if (!url || url.host !== host) return res.status(400).send('invalid request');
 
-    const { ads, duration, path, windowWidth, windowHeight } = JSON.parse(req.body);
+    // This client (src/components/TrackView/TrackPageView.tsx) sends no
+    // Content-Type, so Next leaves `req.body` a raw string and JSON.parse is
+    // correct — but a malformed/empty body throws SyntaxError. Invalid input →
+    // 400 (was an unguarded raw 500). NOTE: only the parse is guarded; a genuine
+    // failure in the tracker.pageView path below still surfaces normally.
+    let body: { ads?: boolean; duration: number; path: string; windowWidth?: number; windowHeight?: number };
+    try {
+      body = JSON.parse(req.body);
+    } catch {
+      return res.status(400).send('invalid request');
+    }
+    const { ads, duration, path, windowWidth, windowHeight } = body;
     const country = (req.headers['cf-ipcountry'] as string) ?? 'undefined';
 
     const match = getMatchingPathname(path);

--- a/src/pages/api/internal/ping.ts
+++ b/src/pages/api/internal/ping.ts
@@ -50,8 +50,11 @@ export default PublicEndpoint(
       country,
       ads: ads ?? false,
       duration: Math.floor(duration),
-      windowWidth,
-      windowHeight,
+      // pageView requires number; a malformed body (the case we now tolerate) may
+      // omit these — 0 is a safe fallback (the client always sends them, so the
+      // legit path is unchanged).
+      windowWidth: windowWidth ?? 0,
+      windowHeight: windowHeight ?? 0,
     });
 
     return res.status(200).end();

--- a/src/tests/api/internal/ping.test.ts
+++ b/src/tests/api/internal/ping.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * Coverage for POST /api/internal/ping — the page-view beacon (client:
+ * src/components/TrackView/TrackPageView.tsx). It sends no Content-Type, so
+ * Next leaves `req.body` a RAW STRING and the handler does JSON.parse(req.body).
+ *
+ * Regression guard for the raw-500 landmine (was the joint-largest raw-500
+ * source at ~7.7/h): bot/scraper traffic hits the beacon with a malformed
+ * `referer` header or a malformed/empty body. Previously `new URL(referer)` and
+ * `JSON.parse(req.body)` threw un-caught → raw 500. Both are invalid client
+ * input → must be 400 (matching the existing host-mismatch 400), and the
+ * happy path must still dispatch the ClickHouse pageView insert unchanged.
+ */
+
+const { mockPageView, devStore } = vi.hoisted(() => ({
+  mockPageView: vi.fn(),
+  devStore: { isDev: false },
+}));
+
+// PublicEndpoint wraps the handler with CORS/metrics we don't exercise here —
+// pass it through so the route's own logic (referer parse, host guard, body
+// parse, pageView dispatch) is what's under test.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: any) => handler,
+}));
+
+vi.mock('~/env/other', () => ({
+  get isDev() {
+    return devStore.isDev;
+  },
+  get isProd() {
+    return !devStore.isDev;
+  },
+}));
+
+// Tracker is the shared ClickHouse client; we assert .pageView() is called with
+// the parsed payload on the happy path (identical insert to before).
+vi.mock('~/server/clickhouse/client', () => ({
+  Tracker: class {
+    pageView = mockPageView;
+  },
+}));
+
+// getMatchingPathname maps the request path to a page id; a match dispatches the
+// insert, no-match short-circuits to 200. Return the path itself as the id so a
+// known path matches and an unknown one (returning undefined) does not.
+vi.mock('~/shared/constants/pathname.constants', () => ({
+  getMatchingPathname: (path: string) => (path === '/models/1' ? '/models/[id]' : undefined),
+}));
+
+function makeRes() {
+  const res = {} as NextApiResponse & { _status?: number; _body?: unknown };
+  res.status = vi.fn((code: number) => {
+    res._status = code;
+    return res;
+  }) as any;
+  res.send = vi.fn((body: unknown) => {
+    res._body = body;
+    return res;
+  }) as any;
+  res.end = vi.fn(() => res) as any;
+  return res;
+}
+
+function makeReq(opts: { host?: string; referer?: string; body?: string }) {
+  return {
+    method: 'POST',
+    headers: {
+      host: opts.host ?? 'civitai.com',
+      ...(opts.referer !== undefined ? { referer: opts.referer } : {}),
+    },
+    // The real client always sends a JSON string (no Content-Type), so req.body
+    // is a raw string here — mirroring production.
+    body: opts.body,
+  } as unknown as NextApiRequest;
+}
+
+const validBody = JSON.stringify({
+  ads: true,
+  duration: 5000,
+  path: '/models/1',
+  windowWidth: 1920,
+  windowHeight: 1080,
+});
+
+describe('POST /api/internal/ping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    devStore.isDev = false;
+  });
+
+  it('dispatches Tracker.pageView on a well-formed same-origin request (200)', async () => {
+    const handler = (await import('~/pages/api/internal/ping')).default;
+    const req = makeReq({ host: 'civitai.com', referer: 'https://civitai.com/models/1', body: validBody });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockPageView).toHaveBeenCalledTimes(1);
+    expect(mockPageView).toHaveBeenCalledWith(
+      expect.objectContaining({ pageId: '/models/[id]', path: '/models/1', host: 'civitai.com', ads: true, duration: 5000 })
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('returns 400 (not 500) on a malformed referer header, no insert', async () => {
+    const handler = (await import('~/pages/api/internal/ping')).default;
+    // `new URL('://')` throws TypeError — the raw-500 landmine. Host is present
+    // and valid so we isolate the referer-parse throw.
+    const req = makeReq({ host: 'civitai.com', referer: '://not a url', body: validBody });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockPageView).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith('invalid request');
+  });
+
+  it('returns 400 (not 500) on a malformed body, no insert', async () => {
+    const handler = (await import('~/pages/api/internal/ping')).default;
+    // Passes the referer/host guard, then JSON.parse('{not json') throws.
+    const req = makeReq({ host: 'civitai.com', referer: 'https://civitai.com/models/1', body: '{not json' });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockPageView).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith('invalid request');
+  });
+
+  it('returns 400 (not 500) on an empty body, no insert', async () => {
+    const handler = (await import('~/pages/api/internal/ping')).default;
+    // Empty/undefined body — JSON.parse(undefined) → SyntaxError.
+    const req = makeReq({ host: 'civitai.com', referer: 'https://civitai.com/models/1' });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockPageView).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects a cross-origin request (host mismatch) with 400 and no insert', async () => {
+    const handler = (await import('~/pages/api/internal/ping')).default;
+    const req = makeReq({ host: 'civitai.com', referer: 'https://evil.example/models/1', body: validBody });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockPageView).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 200 without inserting when the path does not match a known pathname', async () => {
+    const handler = (await import('~/pages/api/internal/ping')).default;
+    const body = JSON.stringify({ duration: 5000, path: '/unknown/path' });
+    const req = makeReq({ host: 'civitai.com', referer: 'https://civitai.com/unknown/path', body });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockPageView).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('does NOT swallow a genuine tracker.pageView failure as a 400', async () => {
+    // The parse guards must catch ONLY the referer/body throws — a real failure
+    // in the insert path must still surface (reject), not become a 400.
+    mockPageView.mockRejectedValueOnce(new Error('clickhouse down'));
+    const handler = (await import('~/pages/api/internal/ping')).default;
+    const req = makeReq({ host: 'civitai.com', referer: 'https://civitai.com/models/1', body: validBody });
+    const res = makeRes();
+
+    await expect(handler(req as any, res)).rejects.toThrow('clickhouse down');
+    expect(res.status).not.toHaveBeenCalledWith(400);
+  });
+
+  it('short-circuits to 200 in dev without inserting', async () => {
+    devStore.isDev = true;
+    const handler = (await import('~/pages/api/internal/ping')).default;
+    const req = makeReq({ host: 'civitai.com', referer: 'https://civitai.com/models/1', body: validBody });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockPageView).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});


### PR DESCRIPTION
## Problem

The POST-only page-view beacon `src/pages/api/internal/ping.ts` (`PublicEndpoint(handler, ['POST'])`) 500s on malformed input and had become the **joint-largest raw-500 source** — ~7.7/h, **92 in 12h** (root-caused 2026-07-13). The traffic is bot/scraper probes (UA stripped to `-`, absent/garbage headers). Two unguarded throws produce the raw 500s:

- **`new URL(req.headers.referer)`** — throws `TypeError` on a malformed-but-*present* `referer` header.
- **`JSON.parse(req.body)`** — throws `SyntaxError` on a malformed/empty body.

Both are invalid **client** input, so they should be a **400** (the handler already returns `res.status(400).send('invalid request')` for the host-mismatch case), not a raw 500. (A bare GET already correctly 400s via the `['POST']` method guard — this fix is only the malformed-referer/body POSTs.)

## Fix

Guard the two throwing calls so malformed input → the existing 400 response, mirroring the already-hardened sibling `/api/internal/pulse`:

- Wrap `new URL(referer)` in try/catch → `400 invalid request` on throw.
- Wrap `JSON.parse(req.body)` in try/catch → `400 invalid request` on throw.

**`req.body` shape:** the client (`src/components/TrackView/TrackPageView.tsx`) `fetch`es with **no `Content-Type`**, so Next leaves `req.body` a **raw string** → `JSON.parse(req.body)` is correct (confirmed against the live SyntaxError and the `pulse.ts` comment). No body-parser change needed.

Everything else is unchanged: the `isDev` short-circuit, the host-mismatch 400, the `getMatchingPathname` no-match 200, the `tracker.pageView(...)` happy path, and the `['POST']` restriction. The guards catch **only** the parse/URL-construction throw — a genuine `tracker.pageView` failure still surfaces normally (asserted in a test), so no real bug is swallowed.

## Tests

`src/tests/api/internal/ping.test.ts` (mirrors `pulse.test.ts`):

- **fail-before / pass-after:** malformed `referer` → 400, malformed body → 400, empty body → 400 (against the unguarded handler these 3 throw → 500; **3 failed / 5 passed** before, **8 passed** after).
- **behavior-preservation:** well-formed POST dispatches `Tracker.pageView` (200), host-mismatch → 400, no-match pathname → 200 with no insert, dev short-circuit → 200, and a rejected `pageView` is **not** swallowed as a 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)