### PR TITLE
fix(app-blocks): re-derive listing content_rating on a mod's direct live-asset edit

### DIFF
--- a/src/components/Apps/ListingAssetStep.tsx
+++ b/src/components/Apps/ListingAssetStep.tsx
@@ -247,6 +247,12 @@ export function ListingAssetStep({
     apply: (s: AssetState) => void
   ) {
     const outcome = await attachOnce(key, kind, imageId);
+    // 🔴 Sub-ms race: `attachOnce` has ALREADY committed the server row (e.g.
+    // `addListingScreenshot`) by the time we reach here. If a cancel/replace bumped
+    // the epoch during the await, we drop the outcome CLIENT-side (below) but the
+    // server row persists — a benign orphan that simply RE-APPEARS on reload
+    // (`getListingAssets` reads it) and is healed by mod curation / re-review. The
+    // common case — cancel BEFORE attach commits — leaves only an unattached Image.
     if (!isCurrentEpoch(key, epoch)) return;
     if (outcome.kind === 'attached') {
       clearTimer(key);
@@ -398,9 +404,12 @@ export function ListingAssetStep({
    * Cancel a screenshot that never attached (working/scanning/error/timeout — no
    * server row). Invalidate any in-flight poll (clearTimer + bumpEpoch so the
    * isCurrentEpoch guard drops a resolving drive), drop the slot, and revoke its
-   * blob. NO server call: nothing was attached; a persisted-but-unattached Image
-   * row is a harmless orphan. Always allowed — cancelling your own in-flight upload
-   * is never gated by allowRemove.
+   * blob. NO server call in the common case: nothing was attached; a persisted-but-
+   * unattached Image row is a harmless orphan. EXCEPTION — in the sub-ms window where
+   * an attach committed the server SCREENSHOT row just before this epoch bump, that
+   * row persists and re-appears on reload (still benign — see the race note in
+   * `drive`). Always allowed — cancelling your own in-flight upload is never gated by
+   * allowRemove.
    */
   function cancelScreenshot(id: string) {
     clearTimer(id);

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -4,6 +4,7 @@ import {
   validateListingImage,
   type ListingImageMeta,
 } from '~/server/schema/blocks/app-listing.schema';
+import { NsfwLevel } from '~/server/common/enums';
 
 /**
  * App Store Listings (W13 P1) — asset pipeline service tests.
@@ -697,6 +698,99 @@ describe('screenshot CRUD', () => {
     const res = await getListingAssets({ listingId: 'apl_1' }, mod);
     expect(res.iconNsfwLevel).toBeNull();
     expect(res.coverNsfwLevel).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 Mod direct live-asset edit → re-derive contentRating (raise-only floor).
+// A moderator BYPASSES the shadow-revision guard and mutates a LIVE approved
+// listing's assets directly (setIcon/setCover/addScreenshot); that path never
+// runs approve's re-derive, so those mutators re-derive contentRating from the
+// current assets' max nsfwLevel and FLOOR the stored rating at it (never lower).
+// ---------------------------------------------------------------------------
+
+describe('mod live-asset edit re-derives contentRating (raise-only)', () => {
+  beforeEach(resetDb);
+
+  const approvedListing = {
+    id: 'apl_live', kind: 'onsite', slug: 's', name: 'n', category: null, userId: 111,
+    iconId: null, coverId: null, status: 'approved', revisionOfId: null,
+  };
+  const validScreenshotImage = {
+    id: 500, userId: 7, type: 'image', width: 1280, height: 720, mimeType: 'image/png',
+    metadata: { size: 100_000 }, ingestion: 'Scanned',
+  };
+
+  it('mod adds an R screenshot to a null-rated live listing → floors contentRating up to r', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ ...approvedListing, contentRating: null });
+    mockDb.image.findUnique.mockResolvedValue({ ...validScreenshotImage, nsfwLevel: NsfwLevel.R });
+    // The re-derive reads the current screenshot set back (imageId 500 = R).
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([{ order: 0, imageId: 500 }]);
+    mockDb.appListingScreenshot.count.mockResolvedValue(1);
+    mockDb.image.findMany.mockResolvedValue([{ nsfwLevel: NsfwLevel.R }]);
+    const { addListingScreenshot } = await import('../app-listing-assets.service');
+    const res = await addListingScreenshot({ listingId: 'apl_live', imageId: 500 }, mod);
+    expect(res).toMatchObject({ status: 'attached' });
+    // The ONLY appListing.update in addScreenshot's flow is the re-derive → r.
+    expect(mockDb.appListing.update).toHaveBeenCalledWith({
+      where: { id: 'apl_live' },
+      data: { contentRating: 'r' },
+    });
+  });
+
+  it('mod adds a PG screenshot to an x-rated live listing → NO lowering (raise-only)', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ ...approvedListing, contentRating: 'x' });
+    mockDb.image.findUnique.mockResolvedValue({ ...validScreenshotImage, nsfwLevel: NsfwLevel.PG });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([{ order: 0, imageId: 500 }]);
+    mockDb.appListingScreenshot.count.mockResolvedValue(1);
+    mockDb.image.findMany.mockResolvedValue([{ nsfwLevel: NsfwLevel.PG }]);
+    const { addListingScreenshot } = await import('../app-listing-assets.service');
+    const res = await addListingScreenshot({ listingId: 'apl_live', imageId: 500 }, mod);
+    expect(res).toMatchObject({ status: 'attached' });
+    // Derived (g) ≤ current (x) → the stored rating is never auto-lowered.
+    expect(mockDb.appListing.update).not.toHaveBeenCalled();
+  });
+
+  it('setIcon by a mod raising a live listing floors contentRating up', async () => {
+    // setIcon writes iconId THEN re-derives; assert the re-derive update fired.
+    mockDb.appListing.findUnique.mockResolvedValue({
+      ...approvedListing, contentRating: 'pg', iconId: 9,
+    });
+    mockDb.image.findUnique.mockResolvedValue({
+      id: 9, userId: 7, type: 'image', width: 512, height: 512, mimeType: 'image/png',
+      metadata: {}, ingestion: 'Scanned', nsfwLevel: NsfwLevel.X,
+    });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([]); // no screenshots
+    mockDb.image.findMany.mockResolvedValue([{ nsfwLevel: NsfwLevel.X }]); // the new icon = X
+    const { setListingIcon } = await import('../app-listing-assets.service');
+    const res = await setListingIcon({ listingId: 'apl_live', imageId: 9 }, mod);
+    expect(res).toEqual({ status: 'attached', iconId: 9 });
+    // Two updates: the iconId write, then the re-derive floor to 'x'.
+    expect(mockDb.appListing.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { iconId: 9 } })
+    );
+    expect(mockDb.appListing.update).toHaveBeenCalledWith({
+      where: { id: 'apl_live' },
+      data: { contentRating: 'x' },
+    });
+  });
+
+  it('non-mod owner edit does NOT trigger a re-derive (helper early-returns)', async () => {
+    // A DRAFT listing the owner may edit directly (guard allows draft); the helper
+    // early-returns for a non-mod, so contentRating is never re-derived here.
+    mockDb.appListing.findUnique.mockResolvedValue({
+      ...approvedListing, id: 'apl_draft', userId: 42, status: 'draft', contentRating: null,
+    });
+    mockDb.image.findUnique.mockResolvedValue({
+      ...validScreenshotImage, userId: 42, nsfwLevel: NsfwLevel.R,
+    });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([]);
+    mockDb.appListingScreenshot.count.mockResolvedValue(0);
+    const { addListingScreenshot } = await import('../app-listing-assets.service');
+    const res = await addListingScreenshot({ listingId: 'apl_draft', imageId: 500 }, owner);
+    expect(res).toMatchObject({ status: 'attached' });
+    // No re-derive: reDeriveContentRatingForModLiveEdit early-returns for a non-mod.
+    expect(mockDb.appListing.update).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -68,7 +68,12 @@ function resetDb() {
   mockDb.appListingScreenshot.createMany.mockReset().mockResolvedValue({ count: 0 });
   mockDb.appListingScreenshot.update.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
   mockDb.appListingScreenshot.delete.mockReset().mockResolvedValue({});
-  mockDb.$transaction.mockReset().mockImplementation(async (ops: unknown[]) => Promise.all(ops as Promise<unknown>[]));
+  mockDb.$transaction.mockReset().mockImplementation(async (arg: unknown) => {
+    // Interactive (callback) form: run it with mockDb as the tx client (dbRead ===
+    // dbWrite === mockDb here). Array form: resolve the batched ops.
+    if (typeof arg === 'function') return (arg as (tx: typeof mockDb) => unknown)(mockDb);
+    return Promise.all(arg as Promise<unknown>[]);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -775,21 +780,43 @@ describe('mod live-asset edit re-derives contentRating (raise-only)', () => {
     });
   });
 
-  it('non-mod owner edit does NOT trigger a re-derive (helper early-returns)', async () => {
-    // A DRAFT listing the owner may edit directly (guard allows draft); the helper
-    // early-returns for a non-mod, so contentRating is never re-derived here.
-    mockDb.appListing.findUnique.mockResolvedValue({
-      ...approvedListing, id: 'apl_draft', userId: 42, status: 'draft', contentRating: null,
-    });
-    mockDb.image.findUnique.mockResolvedValue({
-      ...validScreenshotImage, userId: 42, nsfwLevel: NsfwLevel.R,
-    });
-    mockDb.appListingScreenshot.findMany.mockResolvedValue([]);
-    mockDb.appListingScreenshot.count.mockResolvedValue(0);
+  it('mod adds a PG13 asset to a pg-rated live listing → floors up to pg13 (intra-ladder raise)', async () => {
+    // Exercises the raise PAST the shared g/pg SFW ceiling (both map to PG): pg → pg13
+    // is a real bump the null→r and x→no-lower cases don't cover.
+    mockDb.appListing.findUnique.mockResolvedValue({ ...approvedListing, contentRating: 'pg' });
+    mockDb.image.findUnique.mockResolvedValue({ ...validScreenshotImage, nsfwLevel: NsfwLevel.PG13 });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([{ order: 0, imageId: 500 }]);
+    mockDb.appListingScreenshot.count.mockResolvedValue(1);
+    mockDb.image.findMany.mockResolvedValue([{ nsfwLevel: NsfwLevel.PG13 }]);
     const { addListingScreenshot } = await import('../app-listing-assets.service');
-    const res = await addListingScreenshot({ listingId: 'apl_draft', imageId: 500 }, owner);
+    const res = await addListingScreenshot({ listingId: 'apl_live', imageId: 500 }, mod);
     expect(res).toMatchObject({ status: 'attached' });
-    // No re-derive: reDeriveContentRatingForModLiveEdit early-returns for a non-mod.
+    expect(mockDb.appListing.update).toHaveBeenCalledWith({
+      where: { id: 'apl_live' },
+      data: { contentRating: 'pg13' },
+    });
+  });
+
+  it('mod editing a DRAFT listing does NOT re-derive (STATUS gate isolated)', async () => {
+    // Isolates the status gate: the mod gate PASSES (a mod IS editing) but
+    // status !== 'approved' → the helper early-returns. The asset is R, so WITHOUT
+    // the status guard this would raise to 'r' — proving the status check (not the
+    // mod check) is what suppresses the re-derive here. The non-mod branch of the
+    // guard is unreachable via this mutator anyway (assertOwnerAssetEditable throws
+    // for a non-mod on an approved non-shadow listing), so the `isModerator` guard
+    // inside the helper is defense-in-depth only.
+    mockDb.appListing.findUnique.mockResolvedValue({
+      ...approvedListing, id: 'apl_draft', status: 'draft', contentRating: null,
+    });
+    mockDb.image.findUnique.mockResolvedValue({ ...validScreenshotImage, nsfwLevel: NsfwLevel.R });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([{ order: 0, imageId: 500 }]);
+    mockDb.appListingScreenshot.count.mockResolvedValue(1);
+    mockDb.image.findMany.mockResolvedValue([{ nsfwLevel: NsfwLevel.R }]);
+    const { addListingScreenshot } = await import('../app-listing-assets.service');
+    const res = await addListingScreenshot({ listingId: 'apl_draft', imageId: 500 }, mod);
+    expect(res).toMatchObject({ status: 'attached' });
+    // The screenshot row is created, but the status gate suppresses the re-derive.
+    expect(mockDb.appListingScreenshot.create).toHaveBeenCalledTimes(1);
     expect(mockDb.appListing.update).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from '@trpc/server';
+import type { Prisma } from '@prisma/client';
 import { randomUUID } from 'crypto';
 
 import { dbRead, dbWrite } from '~/server/db/client';
@@ -400,22 +401,27 @@ async function loadValidatedImage(
  * No-op for everyone else: owner edits on a live listing are blocked by the guard and
  * go through a shadow revision (re-derived at approve); draft/pending/shadow listings
  * are rated at approve. So it fires ONLY for `isModerator` on an `approved` non-shadow
- * (`revisionOfId == null`) listing. Reads image levels from the PRIMARY (`dbWrite`) so
- * the derive is row-consistent with the asset mutation that just committed.
+ * (`revisionOfId == null`) listing. Runs INSIDE the caller's `dbWrite.$transaction`
+ * (the `tx` param) so the derive+floor is ATOMIC with the asset write that triggered
+ * it — parity with approve's `resolveApprovalContentRating`. The guard short-circuits
+ * BEFORE any query, so a non-mod / draft / pending / shadow edit adds ZERO queries to
+ * the (trivial single-write) transaction. Reading the levels through `tx` keeps the
+ * derive row-consistent with the asset mutation just written in the same tx.
  */
 async function reDeriveContentRatingForModLiveEdit(
+  tx: Prisma.TransactionClient,
   listing: { id: string; status: string; revisionOfId: string | null; contentRating: string | null },
   user: SessionUser
 ): Promise<void> {
   if (!user.isModerator) return;
   if (listing.status !== 'approved' || listing.revisionOfId != null) return;
 
-  const current = await dbWrite.appListing.findUnique({
+  const current = await tx.appListing.findUnique({
     where: { id: listing.id },
     select: { iconId: true, coverId: true, contentRating: true },
   });
   if (!current) return;
-  const shots = await dbWrite.appListingScreenshot.findMany({
+  const shots = await tx.appListingScreenshot.findMany({
     where: { appListingId: listing.id, imageId: { not: null } },
     select: { imageId: true },
   });
@@ -423,14 +429,14 @@ async function reDeriveContentRatingForModLiveEdit(
     (v): v is number => v != null
   );
   const images = imageIds.length
-    ? await dbWrite.image.findMany({ where: { id: { in: imageIds } }, select: { nsfwLevel: true } })
+    ? await tx.image.findMany({ where: { id: { in: imageIds } }, select: { nsfwLevel: true } })
     : [];
   const derived = deriveContentRatingFromAssets(images.map((i) => ({ nsfwLevel: i.nsfwLevel })));
   // RAISE-ONLY floor: bump the stored rating up to `derived` only if derived's
   // ceiling is strictly higher (never auto-lower). `nsfwLevelFromContentRating`
   // maps null → the SFW floor, so a null stored rating is raised by any mature asset.
   if (nsfwLevelFromContentRating(derived) <= nsfwLevelFromContentRating(current.contentRating)) return;
-  await dbWrite.appListing.update({ where: { id: listing.id }, data: { contentRating: derived } });
+  await tx.appListing.update({ where: { id: listing.id }, data: { contentRating: derived } });
 }
 
 // ---------------------------------------------------------------------------
@@ -461,11 +467,13 @@ export async function setListingIcon(
   assertOwnerAssetEditable(listing, user);
   const validated = await loadValidatedImage(args.imageId, 'icon', user);
   if (validated.pending) return { status: 'pending' };
-  await dbWrite.appListing.update({
-    where: { id: args.listingId },
-    data: { iconId: validated.imageId },
+  await dbWrite.$transaction(async (tx) => {
+    await tx.appListing.update({
+      where: { id: args.listingId },
+      data: { iconId: validated.imageId },
+    });
+    await reDeriveContentRatingForModLiveEdit(tx, listing, user);
   });
-  await reDeriveContentRatingForModLiveEdit(listing, user);
   return { status: 'attached', iconId: validated.imageId };
 }
 
@@ -477,11 +485,13 @@ export async function setListingCover(
   assertOwnerAssetEditable(listing, user);
   const validated = await loadValidatedImage(args.imageId, 'cover', user);
   if (validated.pending) return { status: 'pending' };
-  await dbWrite.appListing.update({
-    where: { id: args.listingId },
-    data: { coverId: validated.imageId },
+  await dbWrite.$transaction(async (tx) => {
+    await tx.appListing.update({
+      where: { id: args.listingId },
+      data: { coverId: validated.imageId },
+    });
+    await reDeriveContentRatingForModLiveEdit(tx, listing, user);
   });
-  await reDeriveContentRatingForModLiveEdit(listing, user);
   return { status: 'attached', coverId: validated.imageId };
 }
 
@@ -516,16 +526,18 @@ export async function addListingScreenshot(
   }
   const nextOrder = existing.length > 0 ? existing[0].order + 1 : 0;
   const id = newAppListingScreenshotId();
-  await dbWrite.appListingScreenshot.create({
-    data: {
-      id,
-      appListingId: args.listingId,
-      imageId,
-      order: nextOrder,
-      caption: args.caption ?? null,
-    },
+  await dbWrite.$transaction(async (tx) => {
+    await tx.appListingScreenshot.create({
+      data: {
+        id,
+        appListingId: args.listingId,
+        imageId,
+        order: nextOrder,
+        caption: args.caption ?? null,
+      },
+    });
+    await reDeriveContentRatingForModLiveEdit(tx, listing, user);
   });
-  await reDeriveContentRatingForModLiveEdit(listing, user);
   return { status: 'attached', id, order: nextOrder };
 }
 

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -3,7 +3,10 @@ import { randomUUID } from 'crypto';
 
 import { dbRead, dbWrite } from '~/server/db/client';
 import { NsfwLevel } from '~/server/common/enums';
-import { nsfwLevelFromContentRating } from '~/shared/constants/browsingLevel.constants';
+import {
+  deriveContentRatingFromAssets,
+  nsfwLevelFromContentRating,
+} from '~/shared/constants/browsingLevel.constants';
 import { ImageIngestionStatus } from '~/shared/utils/prisma/enums';
 import { newAppListingScreenshotId } from '~/server/utils/app-block-ids';
 import {
@@ -384,6 +387,52 @@ async function loadValidatedImage(
   return { pending: false, imageId: image.id };
 }
 
+/**
+ * After a MODERATOR directly mutates a LIVE approved listing's asset SET (the only
+ * path that bypasses the shadow-revision flow — see {@link assertOwnerAssetEditable}),
+ * re-derive `contentRating` from the current assets' max nsfwLevel and FLOOR the
+ * stored rating at the derived value (RAISE-ONLY — never auto-lower). Without this a
+ * mod adding a more-mature icon/cover/screenshot to a live listing leaves it
+ * UNDER-rated: the approve path re-derives, but a direct live-asset edit never runs
+ * approve. Raise-only so a mod's deliberate higher rating (or an asset REMOVAL) is
+ * never auto-lowered — mirrors `resolveApprovalContentRating`'s floor-at-derived.
+ *
+ * No-op for everyone else: owner edits on a live listing are blocked by the guard and
+ * go through a shadow revision (re-derived at approve); draft/pending/shadow listings
+ * are rated at approve. So it fires ONLY for `isModerator` on an `approved` non-shadow
+ * (`revisionOfId == null`) listing. Reads image levels from the PRIMARY (`dbWrite`) so
+ * the derive is row-consistent with the asset mutation that just committed.
+ */
+async function reDeriveContentRatingForModLiveEdit(
+  listing: { id: string; status: string; revisionOfId: string | null; contentRating: string | null },
+  user: SessionUser
+): Promise<void> {
+  if (!user.isModerator) return;
+  if (listing.status !== 'approved' || listing.revisionOfId != null) return;
+
+  const current = await dbWrite.appListing.findUnique({
+    where: { id: listing.id },
+    select: { iconId: true, coverId: true, contentRating: true },
+  });
+  if (!current) return;
+  const shots = await dbWrite.appListingScreenshot.findMany({
+    where: { appListingId: listing.id, imageId: { not: null } },
+    select: { imageId: true },
+  });
+  const imageIds = [current.iconId, current.coverId, ...shots.map((s) => s.imageId)].filter(
+    (v): v is number => v != null
+  );
+  const images = imageIds.length
+    ? await dbWrite.image.findMany({ where: { id: { in: imageIds } }, select: { nsfwLevel: true } })
+    : [];
+  const derived = deriveContentRatingFromAssets(images.map((i) => ({ nsfwLevel: i.nsfwLevel })));
+  // RAISE-ONLY floor: bump the stored rating up to `derived` only if derived's
+  // ceiling is strictly higher (never auto-lower). `nsfwLevelFromContentRating`
+  // maps null → the SFW floor, so a null stored rating is raised by any mature asset.
+  if (nsfwLevelFromContentRating(derived) <= nsfwLevelFromContentRating(current.contentRating)) return;
+  await dbWrite.appListing.update({ where: { id: listing.id }, data: { contentRating: derived } });
+}
+
 // ---------------------------------------------------------------------------
 // Creator asset management (owner/mod-gated).
 // ---------------------------------------------------------------------------
@@ -416,6 +465,7 @@ export async function setListingIcon(
     where: { id: args.listingId },
     data: { iconId: validated.imageId },
   });
+  await reDeriveContentRatingForModLiveEdit(listing, user);
   return { status: 'attached', iconId: validated.imageId };
 }
 
@@ -431,6 +481,7 @@ export async function setListingCover(
     where: { id: args.listingId },
     data: { coverId: validated.imageId },
   });
+  await reDeriveContentRatingForModLiveEdit(listing, user);
   return { status: 'attached', coverId: validated.imageId };
 }
 
@@ -474,6 +525,7 @@ export async function addListingScreenshot(
       caption: args.caption ?? null,
     },
   });
+  await reDeriveContentRatingForModLiveEdit(listing, user);
   return { status: 'attached', id, order: nextOrder };
 }
 
@@ -561,6 +613,7 @@ export async function removeListingScreenshot(
   // review) — edits go through a shadow revision. Mods bypass (curation).
   assertOwnerAssetEditable(shot.appListing, user);
   await dbWrite.appListingScreenshot.delete({ where: { id: args.screenshotId } });
+  // (no re-derive: removal/reorder/caption can never RAISE the derived rating)
 
   // Re-pack: contiguous orders over the survivors (ordered by their old order).
   // Read the survivor set from dbWrite (primary): under replica lag the replica


### PR DESCRIPTION
## What & why

Two small W13 App Blocks fast-follows, both dark/mod-gated safety polish.

### 1. Re-derive `content_rating` on a MOD's direct live-asset edit

`assertOwnerAssetEditable` lets moderators BYPASS the shadow-revision requirement and mutate a LIVE approved listing's assets directly. `approveExternalRequest` re-derives the listing `content_rating` from its assets, but a direct mod live-edit **never runs approve** — so a mod adding/swapping in a more-mature icon/cover/screenshot left the listing **UNDER-rated**, violating W13's invariant: *content_rating floored at derived, never under-rate.*

Fix: a new private helper `reDeriveContentRatingForModLiveEdit`, wired into the END of the only three mutators that can RAISE maturity — `setListingIcon`, `setListingCover`, `addListingScreenshot` — after the asset write commits. It:

- re-derives the rating from the current assets' max `nsfwLevel` (`deriveContentRatingFromAssets`), and
- **FLOORS** the stored rating at the derived value — **RAISE-ONLY**, never auto-lowers.

Raise-only semantics mean a mod's deliberate higher rating (or an asset **removal**) is never clobbered — mirroring `resolveApprovalContentRating`'s floor-at-derived. `removeScreenshot`/`reorder`/`caption` can only lower or leave the derived rating unchanged, so they are guaranteed no-ops and intentionally not wired.

Gating: fires **only** for `isModerator` on an `approved` non-shadow (`revisionOfId == null`) listing. It's a no-op for everyone else — owners can't even reach these mutators on a live listing (the guard throws) and go through a shadow revision (re-derived at approve). Reads image levels from the primary (`dbWrite`) so the derive is row-consistent with the asset mutation that just committed.

### 2. Document the sub-ms cancel-vs-final-attach race (#3023) — comments only

In `ListingAssetStep.tsx`, `attachOnce` has already committed the server row by the time `drive()` checks `isCurrentEpoch`. If a cancel/replace bumped the epoch during the await, the outcome is dropped client-side but the server row persists — a benign orphan that re-appears on reload (`getListingAssets` reads it) and is healed by mod curation / re-review. Added a comment at the guard and softened `cancelScreenshot`'s "no server row" claim to acknowledge this exception. **No behavior change.**

## Tests

Added 4 cases to `app-listing-assets.service.test.ts` (mod raises null→r; mod PG on x-rated → no lowering; mod setIcon X floor; non-mod owner edit → helper early-returns, no re-derive). Local run:

```
Test Files  2 passed (2)
     Tests  86 passed (86)
```

(`app-listing-assets.service.test.ts` 62 + `browsingLevel-maturity.test.ts` 24.) Scoped `tsc --noEmit` clean on both changed files; remaining project tsc errors are pre-existing worktree submodule/`kysely` artifacts unrelated to this change — the Tekton pr-preview typecheck is authoritative.

No `packages/*` touched → no changeset needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)