### PR TITLE
feat(app-blocks): flow manifest category to marketplace listing on approve

### DIFF
--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -38,6 +38,19 @@
       "description": "Content rating of the app surface.",
       "enum": ["g", "pg", "pg13", "r", "x"]
     },
+    "category": {
+      "type": "string",
+      "description": "Optional marketplace category for the app's `/apps` store listing. When present it flows to the listing automatically on moderator-approve (only when a moderator has not already curated a category). Omit to let a moderator categorise the app. Must be one of the known marketplace categories — this enum is kept in lockstep with MARKETPLACE_CATEGORIES in src/server/services/blocks/marketplace-categories.constants.ts (a drift-guard test enforces equality).",
+      "enum": [
+        "generation",
+        "games",
+        "utility",
+        "discovery",
+        "moderation",
+        "analytics",
+        "other"
+      ]
+    },
     "renderMode": {
       "type": "string",
       "description": "How the block renders. Defaults to \"iframe\". \"inline\"/\"hybrid\" require a verified/internal trust tier (server-assigned), so authors should leave this as iframe.",

--- a/src/server/services/__tests__/block-manifest-validator.service.test.ts
+++ b/src/server/services/__tests__/block-manifest-validator.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { BlockManifestValidator } from '../block-manifest-validator.service';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
 
 const VALID_MANIFEST = {
   blockId: 'test-block',
@@ -612,6 +613,39 @@ describe('BlockManifestValidator', () => {
       expect(result.valid).toBe(false);
       if (!result.valid) {
         expect(result.errors.some((e) => e.includes('iframe.src'))).toBe(true);
+      }
+    });
+  });
+
+  // W13 category-on-approve — the OPTIONAL marketplace `category`. Absent is
+  // fine; present must be a MARKETPLACE_CATEGORIES member (single-sourced with
+  // the const + the published schema's `category` enum).
+  describe('category (optional marketplace taxonomy)', () => {
+    it('accepts a manifest with NO category (optional)', () => {
+      // VALID_MANIFEST declares no category.
+      expect(BlockManifestValidator.validate(VALID_MANIFEST, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it.each(MARKETPLACE_CATEGORIES.map((c) => [c] as const))(
+      'accepts the valid category %j',
+      (category) => {
+        const manifest = { ...VALID_MANIFEST, category };
+        expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+      }
+    );
+
+    it.each([
+      ['productivity', 'not in the taxonomy'],
+      ['Generation', 'wrong case'],
+      ['', 'empty string'],
+      [42, 'non-string'],
+      [null, 'null'],
+    ])('rejects category %j (%s) with a clear error', (category) => {
+      const manifest = { ...VALID_MANIFEST, category };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.startsWith('category must be one of'))).toBe(true);
       }
     });
   });

--- a/src/server/services/block-manifest-validator.service.ts
+++ b/src/server/services/block-manifest-validator.service.ts
@@ -3,6 +3,10 @@ import {
   validateBlockScopesAgainstOauthClient,
 } from '~/shared/constants/block-scope.constants';
 import { isKnownSlotId, isPageSlot } from '~/shared/constants/slot-registry';
+import {
+  MARKETPLACE_CATEGORIES,
+  isMarketplaceCategory,
+} from '~/server/services/blocks/marketplace-categories.constants';
 // The lexical SSRF hostname guards were EXTRACTED to a shared, dependency-free
 // module (no `node:dns`, so this validator stays client-bundle-safe — it is
 // imported by `ManifestEditForm.tsx`). `safe-fetch.ts` imports the same helpers,
@@ -19,6 +23,14 @@ interface RawManifest {
   renderMode?: unknown;
   trustTier?: unknown;
   scopes?: unknown;
+  /**
+   * OPTIONAL marketplace category. When present it MUST be a member of
+   * `MARKETPLACE_CATEGORIES` (single-sourced with the const + the published
+   * schema's `category` enum). It flows to the app's `/apps` store listing on
+   * moderator-approve (populated onto `AppBlock.category` only when a moderator
+   * hasn't already curated one — see `approveRequest`). Absent is fine.
+   */
+  category?: unknown;
   iframe?: {
     src?: unknown;
     minHeight?: unknown;
@@ -287,6 +299,18 @@ export class BlockManifestValidator {
 
     if ((renderMode === 'inline' || renderMode === 'hybrid') && trustTier === 'unverified') {
       errors.push('INLINE_REQUIRES_VERIFIED_TIER');
+    }
+
+    // Optional marketplace `category`. When present it must be one of the known
+    // MARKETPLACE_CATEGORIES (referenced directly — never a second hardcoded
+    // copy, so the validator, the const, and the published schema's `category`
+    // enum can't drift). Absent is fine (a moderator can categorise later). On
+    // approve, a present+valid category is copied onto AppBlock.category only
+    // when a moderator hasn't already curated one (see approveRequest), so it
+    // flows to the auto-created store listing. Mirrors how the offsite
+    // submission path validates its taxonomy category.
+    if (m.category !== undefined && !isMarketplaceCategory(m.category)) {
+      errors.push(`category must be one of ${MARKETPLACE_CATEGORIES.join(', ')}`);
     }
 
     if (!Array.isArray(m.scopes)) {

--- a/src/server/services/blocks/__tests__/marketplace-categories.schema-drift.test.ts
+++ b/src/server/services/blocks/__tests__/marketplace-categories.schema-drift.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { MARKETPLACE_CATEGORIES } from '../marketplace-categories.constants';
+
+/**
+ * Drift guard (W13 category-on-approve): the canonical published manifest schema
+ * at `public/schemas/app-block/v1.json` declares an OPTIONAL top-level `category`
+ * whose `enum` MUST equal `MARKETPLACE_CATEGORIES` exactly. The schema is the
+ * source of truth the `civitai` CLI's vendored copy + editor validation compare
+ * against; the const is what the server-side validator + approve path reference.
+ * If someone adds/removes a category in ONE place only, this fails loudly so the
+ * canonical schema and the runtime const can never silently diverge.
+ */
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+const SCHEMA_PATH = path.join(REPO_ROOT, 'public/schemas/app-block/v1.json');
+
+describe('app-block v1 schema ⇄ MARKETPLACE_CATEGORIES drift guard', () => {
+  const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8')) as {
+    properties?: { category?: { type?: unknown; enum?: unknown } };
+  };
+
+  it('declares category as an optional string enum', () => {
+    const category = schema.properties?.category;
+    expect(category).toBeDefined();
+    expect(category?.type).toBe('string');
+    expect(Array.isArray(category?.enum)).toBe(true);
+    // Optional: must NOT be listed in the schema's top-level `required`.
+    const required = (schema as { required?: unknown }).required;
+    expect(Array.isArray(required) ? (required as string[]) : []).not.toContain('category');
+  });
+
+  it('category enum equals MARKETPLACE_CATEGORIES exactly (order included)', () => {
+    const schemaEnum = schema.properties?.category?.enum as string[];
+    expect(schemaEnum).toEqual([...MARKETPLACE_CATEGORIES]);
+  });
+});

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -82,7 +82,16 @@ const {
       // `findUnique` added (W13 auto-create-on-approve): approveRequest re-reads
       // the freshly-approved AppBlock's own columns off the PRIMARY to map it into
       // the onsite AppListing (same projection the backfill selects).
-      appBlock: { create: vi.fn(), update: vi.fn(), findUnique: vi.fn() },
+      // `updateMany` added (W13 category-on-approve): approveRequest copies a
+      // validated manifest `category` onto AppBlock.category via a targeted,
+      // no-clobber `updateMany` (gated on category=null) right before the (3b)
+      // listing-create re-read.
+      appBlock: {
+        create: vi.fn(),
+        update: vi.fn(),
+        updateMany: vi.fn(),
+        findUnique: vi.fn(),
+      },
       // `update` added 2026-06-02 (audit A1 fix): approveRequest now re-caps
       // the app-block OauthClient's allowedScopes to the manifest-derived
       // ceiling + forces grants:[] on the subsequent-version + P2002-retry
@@ -267,6 +276,9 @@ beforeEach(() => {
   mockTriggerBuild.mockResolvedValue({ name: 'pipelinerun-mock' });
   mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 0 });
   mockDbWrite.appBlock.update.mockResolvedValue(undefined);
+  // W13 category-on-approve default: the no-clobber category `updateMany` is a
+  // no-op unless a test opts in (the default manifest declares no category).
+  mockDbWrite.appBlock.updateMany.mockResolvedValue({ count: 0 });
 
   // Default: no pending conflict, no existing app block, user lookup OK.
   mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue(null);
@@ -2110,6 +2122,136 @@ describe('approveRequest', () => {
       expect(result.forgejoCommitSha).toBe('commit_sha_abc');
       // Still exactly ONE listing create across BOTH approves — no duplicate.
       expect(mockDbWrite.appListing.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---- W13: category-on-approve ------------------------------------------
+  //
+  // approveRequest now copies a VALIDATED manifest `category` onto
+  // AppBlock.category so it flows to the auto-created (3b) store listing —
+  // WITHOUT touching (3b) or the mapper (they already read AppBlock.category).
+  // It's a targeted, NO-CLOBBER `updateMany` gated on `category: null`, run at
+  // the PRIMARY right before the (3b) re-read (read-your-writes), so a mod's
+  // curated category is never overridden and a manifest with no category leaves
+  // the column null.
+  describe('W13: category-on-approve (manifest category → AppBlock.category → listing)', () => {
+    // Simulate the DB row's category column with no-clobber `updateMany`
+    // (category set ONLY when currently null) feeding the (3b) findUnique
+    // re-read — so the listing-create assertion is genuinely end-to-end, not a
+    // tautology. `initial` is whatever category the row already carries.
+    function simulateCategoryPersistence(initial: string | null) {
+      const state: { category: string | null } = { category: initial };
+      mockDbWrite.appBlock.updateMany.mockImplementation(
+        async (args: { where: { category: unknown }; data: { category?: string } }) => {
+          // Mirror the SQL `WHERE category IS NULL` gate: only set when null.
+          if (state.category === null && typeof args.data.category === 'string') {
+            state.category = args.data.category;
+            return { count: 1 };
+          }
+          return { count: 0 };
+        }
+      );
+      mockDbWrite.appBlock.findUnique.mockImplementation(
+        async (args: { where: { id: string } }) => ({
+          id: args.where.id,
+          blockId: 'hello',
+          manifest: manifest(),
+          contentRating: 'g',
+          category: state.category,
+          featured: false,
+          featuredOrder: null,
+          externalUrl: null,
+          app: { userId: 42 },
+        })
+      );
+      return state;
+    }
+
+    it('first-version approve with a manifest category sets AppBlock.category (no-clobber gate) and the listing mirrors it', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: manifest({ category: 'generation' }) })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle({ category: 'generation' });
+      const state = simulateCategoryPersistence(null);
+
+      const result = await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      // The category-set is a targeted, no-clobber updateMany gated on category=null.
+      expect(mockDbWrite.appBlock.updateMany).toHaveBeenCalledWith({
+        where: { id: result.appBlockId, category: null },
+        data: { category: 'generation' },
+      });
+      expect(state.category).toBe('generation');
+      // End-to-end: the auto-created onsite listing is categorised from the manifest.
+      expect(mockDbWrite.appListing.create).toHaveBeenCalledTimes(1);
+      const data = mockDbWrite.appListing.create.mock.calls[0][0].data;
+      expect(data.category).toBe('generation');
+    });
+
+    it('no-clobber: a moderator-curated category is NOT overridden by a re-approve whose manifest declares a different one', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      // Subsequent-version approve; the manifest declares 'games'…
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: manifest({ version: '0.2.0', category: 'games' }) })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue({
+        id: 'apb_existing',
+        appId: 'oc_existing',
+        repoUrl: 'https://forgejo.example/civitai-apps/hello',
+        app: { allowedScopes: 33554431, allowedOrigins: ['https://hello.civit.ai'] },
+      });
+      // …but the row already carries the moderator's curated 'utility'. Use the
+      // transition case (no prior listing) so a listing IS minted and we can
+      // assert its category faithfully mirrors the curated value, not 'games'.
+      mockDbRead.appListing.findUnique.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle({ version: '0.2.0', category: 'games' });
+      const state = simulateCategoryPersistence('utility');
+
+      await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      // The updateMany still runs (manifest has a category) but its null-gate
+      // matches 0 rows, so the curated value survives.
+      expect(mockDbWrite.appBlock.updateMany).toHaveBeenCalledWith({
+        where: { id: 'apb_existing', category: null },
+        data: { category: 'games' },
+      });
+      expect(state.category).toBe('utility');
+      const data = mockDbWrite.appListing.create.mock.calls[0][0].data;
+      expect(data.category).toBe('utility');
+    });
+
+    it('manifest with NO category leaves AppBlock.category null (no updateMany, listing uncategorised)', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(pendingRequest());
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle();
+      const state = simulateCategoryPersistence(null);
+
+      await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      // No manifest category ⇒ the category-set is skipped entirely.
+      expect(mockDbWrite.appBlock.updateMany).not.toHaveBeenCalled();
+      expect(state.category).toBeNull();
+      const data = mockDbWrite.appListing.create.mock.calls[0][0].data;
+      expect(data.category).toBeNull();
+    });
+
+    it('rejects an approve whose manifest declares an unknown category (validator gate)', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: manifest({ category: 'not-a-category' }) })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle({ category: 'not-a-category' });
+
+      await expect(
+        approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 })
+      ).rejects.toThrow(/Invalid manifest — cannot approve/);
+      // Pre-validation fails before any category write or listing-create.
+      expect(mockDbWrite.appBlock.updateMany).not.toHaveBeenCalled();
+      expect(mockDbWrite.appListing.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -2238,6 +2238,48 @@ describe('approveRequest', () => {
       expect(data.category).toBeNull();
     });
 
+    it('tx-boundary: a transient category updateMany error does NOT abort the approve — commit/finalise/build still run, category simply unset (mirrors #3085 listing posture)', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: manifest({ category: 'generation' }) })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle({ category: 'generation' });
+      // The (3a) category-set hits a transient DB error. It FEEDS the convenience
+      // listing, so — like the (3b) listing-create — it must log-and-continue,
+      // never gate the approve/deploy.
+      mockDbWrite.appBlock.updateMany.mockRejectedValueOnce(
+        new Error('deadlock detected on app_blocks update')
+      );
+      // The (3b) re-read still returns a null category (the set never landed).
+      mockDbWrite.appBlock.findUnique.mockImplementation(
+        async (args: { where: { id: string } }) => ({
+          id: args.where.id,
+          blockId: 'hello',
+          manifest: manifest(),
+          contentRating: 'g',
+          category: null,
+          featured: false,
+          featuredOrder: null,
+          externalUrl: null,
+          app: { userId: 42 },
+        })
+      );
+
+      const result = await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      // The category write was attempted and failed…
+      expect(mockDbWrite.appBlock.updateMany).toHaveBeenCalledTimes(1);
+      // …but the approve still COMPLETED end-to-end: commit + build + finalise.
+      expect(result.forgejoCommitSha).toBe('commit_sha_abc');
+      expect(mockForgejo.commitFiles).toHaveBeenCalledOnce();
+      expect(mockTriggerBuild).toHaveBeenCalledOnce();
+      // The listing is still minted (its own create didn't fail), just uncategorised.
+      expect(mockDbWrite.appListing.create).toHaveBeenCalledTimes(1);
+      const data = mockDbWrite.appListing.create.mock.calls[0][0].data;
+      expect(data.category).toBeNull();
+    });
+
     it('rejects an approve whose manifest declares an unknown category (validator gate)', async () => {
       const { approveRequest } = await import('../publish-request.service');
       mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -18,6 +18,9 @@ import {
 import { deriveOauthBitmaskFromBlockScopes } from '~/shared/constants/block-scope.constants';
 // Pure (no env/Prisma) — stamps the platform-owned iframe.src onto a manifest.
 import { stampCanonicalIframeSrc } from '~/server/services/blocks/manifest-normalize';
+// Pure const (no env/Prisma) — the marketplace category taxonomy + type guard.
+// approveRequest copies a validated manifest `category` onto AppBlock.category.
+import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 // Type-only (erased at runtime) — the AppBlock projection the shared
 // AppBlock→AppListing mapper consumes (see the (3b) auto-create block in
 // approveRequest). The mapper VALUE itself is dynamically imported at use.
@@ -1906,6 +1909,13 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
     typeof manifest.contentRating === 'string' ? manifest.contentRating : 'g';
   const manifestRenderMode =
     typeof manifest.renderMode === 'string' ? manifest.renderMode : 'iframe';
+  // W13 category-on-approve: the OPTIONAL marketplace `category` the manifest
+  // declares (already shape-validated below by BlockManifestValidator — if
+  // present it is guaranteed a MARKETPLACE_CATEGORIES member; the guard here
+  // narrows the type + is defense-in-depth). `null` when the manifest omits it.
+  // Copied onto AppBlock.category ONLY when the row has no curated category yet
+  // (no-clobber — see the updateMany just before the (3b) listing-create block).
+  const manifestCategory = isMarketplaceCategory(manifest.category) ? manifest.category : null;
 
   // Determine first-vs-subsequent via the existing app_blocks row.
   // We don't rely on request.appBlockId being null because two requests
@@ -2170,6 +2180,30 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
     await dbWrite.oauthClient.update({
       where: { id: existingAppBlock.appId },
       data: { grants: [], allowedScopes: derivedOauthCeiling },
+    });
+  }
+
+  // (3a) Category-on-approve (W13 follow-up to (3b)) — populate AppBlock.category
+  // from the validated manifest `category` so it flows to the auto-created store
+  // listing below WITHOUT any change to (3b)/`mapAppBlockToListing` (they already
+  // read AppBlock.category). NO-CLOBBER + read-your-writes, done as ONE atomic
+  // write across every path (first-version create, P2002-retry, subsequent
+  // version): a targeted `updateMany` gated on `category: null` sets it ONLY when
+  // no category is present yet. This is immune to replica lag (the gate is
+  // evaluated at the PRIMARY, unlike the `dbRead` row read above) and guarantees
+  // a moderator's curated category (set via `setMarketplaceMeta`) is never
+  // overridden by a re-approve. Skipped entirely when the manifest declares no
+  // category (the row keeps whatever it had — null for a fresh app). Runs BEFORE
+  // the (3b) block's `dbWrite.appBlock.findUnique` re-read (same PRIMARY), so the
+  // listing-create reads the just-written category (read-your-writes). A first-
+  // version approve whose manifest declares a category therefore mints a listing
+  // already categorised; a manifest with no category leaves it null (mod-curated
+  // later). The "category added in a LATER version" case (listing already exists,
+  // so (3b) skips it) is an accepted non-goal — recoverable via mod curation.
+  if (manifestCategory !== null) {
+    await dbWrite.appBlock.updateMany({
+      where: { id: appBlockId, category: null },
+      data: { category: manifestCategory },
     });
   }
 

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -2201,10 +2201,27 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   // later). The "category added in a LATER version" case (listing already exists,
   // so (3b) skips it) is an accepted non-goal — recoverable via mod curation.
   if (manifestCategory !== null) {
-    await dbWrite.appBlock.updateMany({
-      where: { id: appBlockId, category: null },
-      data: { category: manifestCategory },
-    });
+    try {
+      await dbWrite.appBlock.updateMany({
+        where: { id: appBlockId, category: null },
+        data: { category: manifestCategory },
+      });
+    } catch (err) {
+      // Same posture as the (3b) listing-create below (and #3085): the category
+      // FEEDS the convenience store listing, so it must NEVER gate the
+      // approve/deploy. On ANY error (transient DB blip, etc.) log-and-CONTINUE
+      // — the app still deploys, the category is simply absent this pass and is
+      // recoverable on a re-approve (the null-gate re-applies idempotently) or
+      // via mod curation. If we rethrew, a deterministically-failing write here
+      // could wedge the app's deploy forever over a mere categorisation miss.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[approveRequest] category-from-manifest set failed (slug=${request.slug}, appBlockId=${appBlockId}); ` +
+          `approve/deploy CONTINUES — AppBlock.category is unset this pass, recoverable on re-approve or via mod curation: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+      );
+    }
   }
 
   // (3b) App Store listing (W13) — auto-create the onsite `AppListing` for this


### PR DESCRIPTION
## What & why

Follow-up to #3085 (merged), which auto-creates the onsite `AppListing` on moderator-approve. That mapper (`mapAppBlockToListing`) reads `AppBlock.category`, but `category` was only ever set by mod curation (`setMarketplaceMeta`) — a manifest could *declare* a `category`, yet it was silently ignored on the onsite/approve path, so a fresh approve left `AppBlock.category` null and the app landed on `/apps` uncategorised.

This makes the manifest `category` field **first-class** so it flows to the marketplace listing automatically on approve — **no change** to #3085's `(3b)` block or the mapper (they already read `AppBlock.category`).

## The change (server-side only)

1. **Canonical schema** `public/schemas/app-block/v1.json` — adds an OPTIONAL top-level `category` string `enum` = exactly `MARKETPLACE_CATEGORIES` (`generation, games, utility, discovery, moderation, analytics, other`). This is the source of truth the CLI's vendored copy + editor validation compare against.
2. **`BlockManifestValidator`** — validates `manifest.category`: present ⇒ must be a `MARKETPLACE_CATEGORIES` member (clear error otherwise); absent ⇒ fine (optional). References the const directly — no second hardcoded copy. Client-bundle-safe (the const is pure, no env/Prisma).
3. **`approveRequest`** — copies the validated manifest `category` onto `AppBlock.category` **only when the row has no category yet**. Implemented as a targeted, atomic `updateMany` gated on `category: null`, run at the **primary** right after the AppBlock create/update and immediately **before** the `(3b)` `dbWrite.appBlock.findUnique` re-read — so the listing-create reads the just-written value (read-your-writes), and the null-gate is evaluated at the primary (immune to the replica-lag hazard of the `dbRead` existing-row read).

**No-clobber** (load-bearing): a moderator's curated category is never overridden by a re-approve; a manifest with no category leaves the column null (mod-curated later). First-version approve with a manifest category → `AppBlock.category` set → `(3b)` mints an already-categorised listing.

## Out of scope / accepted non-goals

- **Category added in a LATER version**: app approved v1 with no manifest category (listing created null), then v2 adds a manifest category → `AppBlock.category` becomes set, but the **existing** listing is not updated (`(3b)` is skip-if-exists by design). Consistent with the no-clobber model, recoverable via mod curation. No listing-update logic added — kept minimal and consistent with #3085.
- **No DB migration** — `app_blocks.category` is an existing free-text column.
- **CLI vendored-schema sync + Go validator + release** — a **separate** follow-up the coordinator handles **after this deploys**, since the CLI drift-check compares to the LIVE canonical schema URL.

## Tests (complete)

- Validator: accepts each valid category, accepts a manifest with **no** category, rejects an unknown/wrong-case/empty/non-string category with a clear error.
- Approve first-version with `manifest.category='generation'` (null `AppBlock.category`) → atomic no-clobber `updateMany` fires and the auto-created listing's `category` is `'generation'` (end-to-end through `(3b)`).
- Approve no-clobber: row already curated `'utility'`, re-approve manifest declares `'games'` → `updateMany` null-gate matches 0 rows, category stays `'utility'` (and the transition-case listing mirrors `'utility'`, not `'games'`).
- Approve with **no** manifest category → `updateMany` not called, `AppBlock.category` + listing stay null.
- Approve with an unknown manifest category → rejected at the validator gate before any write.
- **Schema/const drift guard**: asserts the `category` enum in `public/schemas/app-block/v1.json` equals `MARKETPLACE_CATEGORIES` exactly.

Local run (unit project, against the primary clone's deps): **121 passed** (validator + drift-guard) and **98 passed** (publish-request orchestration, incl. the 4 new category-on-approve cases). Local full `tsc` is unreliable on this box — the Tekton pr-preview is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
