### PR TITLE
fix(app-blocks): exempt shared-storage scopes from per-user consent

### DIFF
--- a/src/server/routers/__tests__/apps-shared.router.test.ts
+++ b/src/server/routers/__tests__/apps-shared.router.test.ts
@@ -274,6 +274,8 @@ describe('trust gate is independent of the (now-exempt) shared:write scope', () 
   });
 
   const ineligible: Array<[string, Record<string, unknown>]> = [
+    ['banned', { bannedAt: new Date() }],
+    ['muted', { muted: true }],
     ['too-new account', { createdAt: new Date() }],
     ['unverified email', { emailVerified: undefined }],
     ['onboarding incomplete', { onboarding: 0 }],

--- a/src/server/routers/__tests__/apps-shared.router.test.ts
+++ b/src/server/routers/__tests__/apps-shared.router.test.ts
@@ -256,6 +256,51 @@ describe('H3 min-trust gate (write + vote)', () => {
   });
 });
 
+// Defense-in-depth for the CONSENT_EXEMPT change (shared scopes now sign into
+// tokens without a per-user consent grant, so an anon/low-trust token can now
+// legitimately CARRY apps:storage:shared:write). These pin that the trust gate
+// is enforced INDEPENDENTLY of the scope: even with the write scope present on
+// the claims, an anon / too-new / unverified subject is rejected BEFORE any data
+// access. `validClaims()` already carries [READ, WRITE], so every claim here has
+// the write scope present.
+describe('trust gate is independent of the (now-exempt) shared:write scope', () => {
+  it('anon subject with the write scope present → UNAUTHORIZED, no DB access', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'anon' })); // scopes include WRITE
+    await expect(
+      caller().append({ blockToken: 't', value: { title: 'x' } })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  const ineligible: Array<[string, Record<string, unknown>]> = [
+    ['too-new account', { createdAt: new Date() }],
+    ['unverified email', { emailVerified: undefined }],
+    ['onboarding incomplete', { onboarding: 0 }],
+  ];
+  for (const [name, over] of ineligible) {
+    it(`authenticated but ineligible (${name}) with the write scope present → FORBIDDEN, no DB access`, async () => {
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims()); // sub: user:42, scopes include WRITE
+      mockGetSessionUser.mockResolvedValueOnce(trustedUser(over));
+      await expect(caller().vote({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+      });
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+  }
+
+  it('a trusted subject with the scope present is allowed (reaches the vote CTE)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.trim().startsWith('SELECT 1')) return { rows: [{ x: 1 }], rowCount: 1 };
+      if (sql.includes('WITH ins AS')) return { rows: [{ count: '1' }], rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    });
+    const out = await caller().vote({ blockToken: 't', key: 'req1' });
+    expect(out.count).toBe(1);
+  });
+});
+
 describe('C1 cross-user overwrite', () => {
   it('append SERVER-generates the key (client key never used)', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());

--- a/src/server/services/blocks/__tests__/scope-grant.service.test.ts
+++ b/src/server/services/blocks/__tests__/scope-grant.service.test.ts
@@ -149,6 +149,33 @@ describe('scope-grant.service', () => {
       );
       expect(missing).toEqual([]);
     });
+
+    it('signs the SHARED storage scopes WITHOUT any grant (governed by resolveSharedContext, not consent)', async () => {
+      // Regression: shared-storage apps 403'd at runtime because the shared
+      // scopes fell into `missing` (not consent-exempt) and were stripped from
+      // the minted token. They are now exempt — their gate is the server-side
+      // min-trust + moderation layer in apps-shared.router, not a consent prompt.
+      const { partitionByConsent } = await import('../scope-grant.service');
+      const { signable, missing } = partitionByConsent(
+        ['apps:storage:shared:read', 'apps:storage:shared:write'],
+        new Set() // user granted nothing
+      );
+      expect(new Set(signable)).toEqual(
+        new Set(['apps:storage:shared:read', 'apps:storage:shared:write'])
+      );
+      expect(missing).toEqual([]);
+    });
+
+    it('mint model: a shared-storage manifest with NO grant → both shared scopes signable (authenticated branch)', async () => {
+      // Mirrors the token-mint authenticated branch (block-tokens/index.ts):
+      // requestedScopes ∩ consent → `signable` is what gets signed. A shared app
+      // whose approved manifest declares the shared scopes must produce a token
+      // carrying BOTH even though the user has granted nothing.
+      const { partitionByConsent } = await import('../scope-grant.service');
+      const manifestScopes = ['apps:storage:shared:read', 'apps:storage:shared:write'];
+      const { signable } = partitionByConsent(manifestScopes, new Set());
+      expect(signable).toEqual(manifestScopes);
+    });
   });
 
   describe('consentGatedScopes', () => {
@@ -162,6 +189,24 @@ describe('scope-grant.service', () => {
           'models:read:self',
           'block:settings:read',
           'apps:storage:read',
+          'ai:write:budgeted',
+        ])
+      ).toEqual(['ai:write:budgeted']);
+    });
+
+    it('drops the SHARED storage scopes → the anon-strip KEEPS them + install does not record them as gated', async () => {
+      // consentGatedScopes drives BOTH (a) the anon-scope strip at mint (an anon
+      // token keeps only NON-gated scopes) and (b) what the install/subscribe
+      // implicit grant records. The shared scopes must be exempt so an anon read
+      // token can carry shared:read (public community data) and install doesn't
+      // demand a grant that would never be given. Anon WRITE remains impossible:
+      // resolveSharedContext rejects a null subject before any data access,
+      // independent of the scope (see apps-shared.router tests).
+      const { consentGatedScopes } = await import('../scope-grant.service');
+      expect(
+        consentGatedScopes([
+          'apps:storage:shared:read',
+          'apps:storage:shared:write',
           'ai:write:budgeted',
         ])
       ).toEqual(['ai:write:budgeted']);

--- a/src/server/services/blocks/scope-grant.service.ts
+++ b/src/server/services/blocks/scope-grant.service.ts
@@ -114,13 +114,29 @@ export async function recordScopeGrant(opts: {
  * granted scopes, returning the granted subset to sign + the withheld scopes
  * the host must re-consent for.
  *
- * `block:settings:*` and `apps:storage:*` are intentionally NOT consent-gated
- * here — they are publisher-only / ambient-but-otherwise-gated scopes that have
- * their own issuance-time checks (caller-is-installer, resolveStorageContext).
- * Subjecting them to per-user consent would make the publisher re-consent to
- * their own block's settings on every version bump for no security gain. The
- * remaining user-resource scopes (media/user/ai/buzz/social, models:write)
- * flow through the consent gate.
+ * `block:settings:*` and `apps:storage:*` (per-user KV) are intentionally NOT
+ * consent-gated here — they are publisher-only / ambient-but-otherwise-gated
+ * scopes that have their own issuance-time checks (caller-is-installer,
+ * resolveStorageContext). Subjecting them to per-user consent would make the
+ * publisher re-consent to their own block's settings on every version bump for
+ * no security gain. The remaining user-resource scopes (media/user/ai/buzz/
+ * social, models:write) flow through the consent gate.
+ *
+ * `apps:storage:shared:read` / `apps:storage:shared:write` (the SHARED, app-
+ * global / cross-user datastore) are ALSO exempt — and, unlike the per-user
+ * scopes, they are NOT publisher-only. Their governance is NOT a per-scope
+ * consent prompt but the SERVER-SIDE controls in `resolveSharedContext`
+ * (apps-shared.router.ts): a fail-closed min-trust gate (not-anon, not-banned,
+ * not-muted, onboarding-complete, email-verified, account age ≥ 7d) plus
+ * content moderation and one-vote / per-user-row / rate limits, all enforced at
+ * every read/write REGARDLESS of the token scope. `shared:read` is reading
+ * PUBLIC community data (anon-safe — the router allows anon reads by design);
+ * `shared:write` is trust-gated PUBLIC posting/voting (the resolver rejects anon
+ * and any ineligible caller before touching data, whether or not the scope is
+ * present). A per-scope consent prompt would add nothing that the trust gate +
+ * moderation don't already enforce — so, mirroring the per-user storage scopes,
+ * these sign without a grant. (Pre-GA consideration, NOT built here: an EXPLICIT
+ * shared-WRITE consent prompt if widening the audience beyond the trust gate.)
  *
  * `models:read:self` is ALSO exempt (allow-by-default): a low-sensitivity read
  * of the viewer's OWN models, and a no-op for an anon viewer (no user → nothing
@@ -135,6 +151,10 @@ const CONSENT_EXEMPT_SCOPES = new Set([
   'block:settings:write',
   'apps:storage:read',
   'apps:storage:write',
+  // SHARED (cross-user) storage — governed by resolveSharedContext's server-side
+  // min-trust gate + content moderation + rate limits, not per-scope consent.
+  'apps:storage:shared:read',
+  'apps:storage:shared:write',
   'models:read:self',
 ]);
 


### PR DESCRIPTION
## Bug

App Blocks shared-storage apps (live example: `/apps/run/app-requests`) **403 at runtime** on every `apps.shared.*` op with e.g. *"shared storage list requires the `apps:storage:shared:read` scope."* The shared datastore is unreachable even for an approved app that declares the scopes in its manifest.

## Root cause

The page-token mint (`src/pages/api/v1/block-tokens/index.ts`) runs the requested manifest scopes through `partitionByConsent` (`src/server/services/blocks/scope-grant.service.ts`). `CONSENT_EXEMPT_SCOPES` there exempted the **per-user** storage scopes (`apps:storage:read`, `apps:storage:write`) but **not** the **shared** ones (`apps:storage:shared:read` / `:write`).

No consent flow ever requests the shared scopes — the page host only prompts consent for money/AI scopes — so the shared scopes fell into `missing` (not exempt, no grant), got **stripped from the minted token**, and `apps-shared.router.ts` rejected at each op. Every *other* mint filter passes them (`SKIP_OAUTH_CHECK`, approved-snapshot, `isKnownBlockScope`, not `PAGE_FORBIDDEN_SCOPES`), so `CONSENT_EXEMPT_SCOPES` was the sole gate.

## Change

Add both `apps:storage:shared:read` and `apps:storage:shared:write` to `CONSENT_EXEMPT_SCOPES`, with a doc comment explaining **why**.

**Decision — exempt BOTH from consent.** The shared datastore's governance is the **server-side min-trust gate + content moderation + one-vote / per-user-row / rate limits** in `resolveSharedContext` (`apps-shared.router.ts`), not a per-scope consent prompt. `shared:read` = reading public community data; `shared:write` = posting/voting publicly, gated by that same trust+moderation layer. This mirrors how the per-user `apps:storage:*` are already exempt.

## End-to-end verification

Traced the mint after the change: for an authenticated viewer, a page-mint for an approved shared-storage app now produces a token whose `scopes[]` includes **both** shared scopes — confirmed no other filter strips them.

**Anon / low-trust defense-in-depth (security invariant holds).** After exempting, the anon-strip (`consentGatedScopes`) no longer removes the shared scopes, so an anon page token now *carries* them. This creates no exposure because `resolveSharedContext` enforces the trust gate **independently of the token scope**, before any data access:

- **Reads** are `publicProcedure` by design — anon reads of public community data are already the intended behavior; carrying `shared:read` in an anon token changes nothing.
- **Writes**: the resolver requires `userId != null` (anon `sub` → `parseSubjectUserId` returns `null` → `UNAUTHORIZED`) **and** passes through `assertSharedWriteTrust` (not-anon, not-banned, not-muted, onboarding-complete, email-verified, account age ≥ 7d). The scope check (lines 155–161) and the write-trust gate (lines 185–194) are separate code paths — the trust gate is **not** conditioned on the scope. So even a token that carries `shared:write` cannot write unless the subject independently clears the trust gate.

## Tests

- `scope-grant.service.test.ts`: shared `:read`/`:write` are now `signable` **without** any grant; a mint-model assertion that a shared manifest with no grant yields both scopes signable; `consentGatedScopes` drops the shared scopes (anon-strip keeps them, install doesn't record them as gated).
- `apps-shared.router.test.ts`: new `trust gate is independent of the (now-exempt) shared:write scope` suite — with the write scope **present** on the claims, an anon subject → `UNAUTHORIZED` and an authenticated-but-ineligible subject (too-new / unverified / onboarding-incomplete) → `FORBIDDEN`, both **before** any DB access; a trusted subject with the scope present is allowed.

Local run of both suites: **50 passed** (`vitest run`). Local full `tsc` is unreliable on this box; pr-preview is authoritative for typecheck.

## Not built now (pre-GA consideration)

An **explicit shared-WRITE consent prompt** could be added if the shared surface is later widened beyond the current trust gate. Not needed today — the trust gate + moderation are the governing controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
