### PR TITLE
feat(app-blocks): provision per-app storage schema on moderator approve

### DIFF
--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -38,6 +38,7 @@ const {
   mockNewUlid,
   mockAplSeq,
   mockNewAppListingId,
+  mockProvision,
 } = vi.hoisted(() => {
   const ulidSeq: { i: number } = { i: 0 };
   // Dedicated counter for AppListing ids so minting a listing id does NOT
@@ -143,6 +144,11 @@ const {
       aplSeq.i += 1;
       return `apl_test_${aplSeq.i}`;
     }),
+    // W4 storage-provision-on-approve: approveRequest dynamically imports
+    // AppStorageProvisioner and calls provision() for a storage-declaring app so
+    // its appsDb schema exists at approve (no manual admin backfill). Mocked so
+    // the approve tests never reach the real cnpg-cluster-apps DDL path.
+    mockProvision: vi.fn(async () => undefined),
   };
 });
 
@@ -167,6 +173,13 @@ vi.mock('~/server/services/blocks/forgejo.service', () => mockForgejo);
 // triggers builds). Mock the resolved absolute id the service sees.
 vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
   triggerBuild: mockTriggerBuild,
+}));
+
+// approveRequest does `await import('~/server/services/apps/storage-provision.service')`
+// to provision the app's appsDb schema (W4). Mock the resolved id the service
+// sees so the (3c) block never touches the real appsDb/pg module graph.
+vi.mock('~/server/services/apps/storage-provision.service', () => ({
+  AppStorageProvisioner: { provision: mockProvision },
 }));
 
 vi.mock('~/server/utils/app-block-ids', () => ({
@@ -274,6 +287,10 @@ beforeEach(() => {
   mockForgejo.setCommitStatus.mockResolvedValue(undefined);
   mockTriggerBuild.mockClear();
   mockTriggerBuild.mockResolvedValue({ name: 'pipelinerun-mock' });
+  // W4 storage-provision-on-approve default: provision() resolves cleanly. Tests
+  // that exercise the failure path override with mockRejectedValueOnce.
+  mockProvision.mockReset();
+  mockProvision.mockResolvedValue(undefined);
   mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 0 });
   mockDbWrite.appBlock.update.mockResolvedValue(undefined);
   // W13 category-on-approve default: the no-clobber category `updateMany` is a
@@ -2294,6 +2311,155 @@ describe('approveRequest', () => {
       // Pre-validation fails before any category write or listing-create.
       expect(mockDbWrite.appBlock.updateMany).not.toHaveBeenCalled();
       expect(mockDbWrite.appListing.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- W4: per-app storage provisioning-on-approve -----------------------
+  //
+  // approveRequest now provisions the app's appsDb schema (kv / quota /
+  // shared_kv / votes / counters / shared_kv_reports + triggers + role) at
+  // approve — but ONLY when the approved manifest declares any `apps:storage:*`
+  // scope — so a storage-declaring app has its datastore the moment it deploys,
+  // without a manual `/api/admin/apps-storage-backfill` run. It reuses the SAME
+  // `sanitizeAppSlug(blockId)` derivation the backfill uses, is idempotent
+  // (CREATE ... IF NOT EXISTS DDL), and — like (3a)/(3b)/#3085/#3089 — it
+  // log-and-continues on ANY error so provisioning can NEVER gate the deploy.
+  describe('W4: storage provisioning-on-approve', () => {
+    it('provisions the appsDb schema ONCE for a storage-declaring app with slug = sanitized blockId', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: manifest({ scopes: ['apps:storage:read', 'apps:storage:write'] }) })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle({
+        scopes: ['apps:storage:read', 'apps:storage:write'],
+      });
+
+      const result = await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      // Provisioned exactly once, with the appBlockId of the freshly-created row
+      // and the sanitized slug (blockId 'hello' → schema slug 'hello').
+      expect(mockProvision).toHaveBeenCalledTimes(1);
+      expect(mockProvision).toHaveBeenCalledWith({ appBlockId: result.appBlockId, slug: 'hello' });
+      // The approve itself completed end-to-end.
+      expect(result.forgejoCommitSha).toBe('commit_sha_abc');
+      expect(mockTriggerBuild).toHaveBeenCalledOnce();
+    });
+
+    it('provisions for a SHARED-storage-only app (apps:storage:shared:*)', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: manifest({ scopes: ['apps:storage:shared:read'] }) })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle({ scopes: ['apps:storage:shared:read'] });
+
+      const result = await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      expect(mockProvision).toHaveBeenCalledTimes(1);
+      expect(mockProvision).toHaveBeenCalledWith({ appBlockId: result.appBlockId, slug: 'hello' });
+    });
+
+    it('derives the schema slug from the blockId via sanitizeAppSlug (hyphens → underscores)', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      // blockId 'my-cool-app' → appsDb schema slug 'my_cool_app' (hyphens folded).
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({
+          slug: 'my-cool-app',
+          manifest: manifest({ blockId: 'my-cool-app', scopes: ['apps:storage:write'] }),
+        })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle({
+        blockId: 'my-cool-app',
+        scopes: ['apps:storage:write'],
+      });
+
+      const result = await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      expect(mockProvision).toHaveBeenCalledWith({
+        appBlockId: result.appBlockId,
+        slug: 'my_cool_app',
+      });
+    });
+
+    it('does NOT provision a non-storage app (declares only ai:write:budgeted)', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: manifest({ scopes: ['ai:write:budgeted'] }) })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle({ scopes: ['ai:write:budgeted'] });
+
+      const result = await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      // Gen-only app never touches the datastore → no empty 6-table schema minted.
+      expect(mockProvision).not.toHaveBeenCalled();
+      // …and the approve still completes normally.
+      expect(result.forgejoCommitSha).toBe('commit_sha_abc');
+      expect(mockTriggerBuild).toHaveBeenCalledOnce();
+    });
+
+    it('does NOT provision an app with no scopes at all (default manifest)', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(pendingRequest());
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle();
+
+      await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      expect(mockProvision).not.toHaveBeenCalled();
+    });
+
+    // TRANSACTION-BOUNDARY / log-and-continue coverage (mirrors the (3b)/(3a)
+    // tx-boundary tests): provisioning is a side effect that must NEVER gate the
+    // approve/deploy. A provision() throw is logged and the approve CONTINUES.
+    it('tx-boundary: a provision() error does NOT abort the approve — commit/finalise/build still run (backfill-recoverable)', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({ manifest: manifest({ scopes: ['apps:storage:read'] }) })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+      mockBundleBuffer.current = await makeValidBundle({ scopes: ['apps:storage:read'] });
+      // The appsDb DDL fails (e.g. cnpg-cluster-apps briefly unavailable).
+      mockProvision.mockRejectedValueOnce(new Error('cnpg-cluster-apps: connection refused'));
+
+      const result = await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      // The provision was attempted and failed…
+      expect(mockProvision).toHaveBeenCalledTimes(1);
+      // …but the approve proceeded end-to-end: AppBlock create, commit, finalise, build.
+      expect(result.forgejoCommitSha).toBe('commit_sha_abc');
+      expect(mockDbWrite.appBlock.create).toHaveBeenCalledOnce();
+      expect(mockForgejo.commitFiles).toHaveBeenCalledOnce();
+      expect(mockDbWrite.appBlockPublishRequest.update).toHaveBeenCalledOnce();
+      expect(mockTriggerBuild).toHaveBeenCalledOnce();
+    });
+
+    it('idempotency: a subsequent-version re-approve provisions again (safe — CREATE ... IF NOT EXISTS)', async () => {
+      const { approveRequest } = await import('../publish-request.service');
+      mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+        pendingRequest({
+          manifest: manifest({ version: '0.2.0', scopes: ['apps:storage:read'] }),
+        })
+      );
+      mockDbRead.appBlock.findFirst.mockResolvedValue({
+        id: 'apb_existing',
+        appId: 'oc_existing',
+        repoUrl: 'https://forgejo.example/civitai-apps/hello',
+        app: { allowedScopes: 33554431, allowedOrigins: ['https://hello.civit.ai'] },
+      });
+      mockBundleBuffer.current = await makeValidBundle({
+        version: '0.2.0',
+        scopes: ['apps:storage:read'],
+      });
+
+      const result = await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+      // Re-runs the idempotent DDL against the EXISTING app block's id + slug.
+      expect(result.appBlockId).toBe('apb_existing');
+      expect(mockProvision).toHaveBeenCalledTimes(1);
+      expect(mockProvision).toHaveBeenCalledWith({ appBlockId: 'apb_existing', slug: 'hello' });
     });
   });
 });

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -25,6 +25,11 @@ import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-cate
 // AppBlock→AppListing mapper consumes (see the (3b) auto-create block in
 // approveRequest). The mapper VALUE itself is dynamically imported at use.
 import type { SourceAppBlock } from '~/server/services/blocks/app-listing-mapper';
+// Pure util (no env/Prisma) — folds a blockId to the appsDb schema slug. Used by
+// the (3c) storage-provision-on-approve block; matches the admin backfill's
+// derivation exactly. The provisioner VALUE is dynamically imported at use so
+// appsDb/pg stay out of this module's static graph (mirrors the (3b) mapper).
+import { sanitizeAppSlug } from '~/server/utils/apps-slug';
 
 // dbRead/dbWrite/newUlid/bundle-s3 are dynamically imported inside the
 // functions that need them so the pure helpers (extract/diff) can be
@@ -2314,6 +2319,70 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
             err instanceof Error ? err.message : String(err)
           }`
       );
+    }
+  }
+
+  // (3c) Per-app storage provisioning (W4) — create the app's appsDb schema +
+  // tables (kv / quota / shared_kv / votes / counters / shared_kv_reports + the
+  // quota triggers + per-app role) at approve, so a storage-declaring app has its
+  // datastore the moment it deploys — WITHOUT a manual
+  // `/api/admin/apps-storage-backfill` run. Closes the same "approve silently
+  // didn't do X" gap as (3a)/(3b): before this, an approved+deployed app that
+  // declared `apps:storage:*` had NO schema until someone hand-ran the backfill,
+  // so its FIRST storage call 500'd with `relation "app_<slug>.shared_kv" does not
+  // exist` (this bit the live `app-requests` app).
+  //
+  // GATED ON STORAGE SCOPE (design decision): we provision ONLY when the approved
+  // manifest declares any `apps:storage:*` scope (per-user read/write OR shared
+  // read/write). A gen-only app (e.g. one declaring just `ai:write:budgeted`)
+  // never touches the datastore, so minting an empty 6-table schema + role for it
+  // is pure litter. An app that ADDS storage in a LATER version is provisioned on
+  // THAT version's approve — a scope change requires a new approved version, and
+  // the DDL is idempotent, so there is no "added storage but never provisioned"
+  // hole. (The admin backfill still provisions ALL approved apps unconditionally;
+  // this go-forward path is deliberately narrower.) The scope snapshot used here
+  // is the SAME `manifestScopes` written to `AppBlock.approvedScopes` above, so
+  // the provision decision matches what the token-mint path will actually grant.
+  //
+  // IDEMPOTENT: `AppStorageProvisioner.provision` is `CREATE ... IF NOT EXISTS` /
+  // DO-block / ON CONFLICT throughout, so first-version and every subsequent-
+  // version approve (a re-approve just re-runs the DDL) are equally safe.
+  //
+  // LOG-AND-CONTINUE (same posture as (3a)/(3b) + #3085/#3089/#3090): storage
+  // provisioning must NEVER block an app's approve/deploy. On ANY error we emit a
+  // structured warning and CONTINUE — the app still deploys and the schema is
+  // recoverable via `/api/admin/apps-storage-backfill`. If we rethrew, a
+  // deterministically-failing appsDb (e.g. cnpg-cluster-apps briefly down) would
+  // wedge the app's deploy forever over a datastore miss.
+  const declaresStorageScope = manifestScopes.some((s) => s.startsWith('apps:storage:'));
+  if (declaresStorageScope) {
+    // Same slug derivation the backfill uses: sanitizeAppSlug(blockId). request.slug
+    // is the manifest blockId (== AppBlock.blockId), already SLUG_REGEX-validated at
+    // submit; sanitizeAppSlug folds it to the appsDb schema slug (hyphens → `_`).
+    const storageSlug = sanitizeAppSlug(request.slug);
+    if (!storageSlug) {
+      // Anomalous — a submit-validated blockId should always normalize. Skip +
+      // warn rather than throw into the already-side-effecting approve flow.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[approveRequest] storage provisioning skipped (slug=${request.slug}, appBlockId=${appBlockId}); ` +
+          `blockId does not normalize to a valid appsDb slug — recoverable via /api/admin/apps-storage-backfill`
+      );
+    } else {
+      try {
+        const { AppStorageProvisioner } = await import(
+          '~/server/services/apps/storage-provision.service'
+        );
+        await AppStorageProvisioner.provision({ appBlockId, slug: storageSlug });
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[approveRequest] storage provisioning failed (slug=${request.slug}, appBlockId=${appBlockId}, storageSlug=${storageSlug}); ` +
+            `approve/deploy CONTINUES — the app's datastore schema is absent this pass, recoverable via /api/admin/apps-storage-backfill: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## The bug

Storage-using App Blocks keep their data in a **separate database** (appsDb, CNPG `cnpg-cluster-apps`, DB `apps`) — one Postgres schema per app: `app_<sanitizeAppSlug(blockId)>` with tables `kv` / `quota` / `shared_kv` / `votes` / `counters` / `shared_kv_reports` (+ quota triggers + a per-app role). The DDL lives in `AppStorageProvisioner.provision()` and is idempotent (`CREATE ... IF NOT EXISTS` throughout).

The **only** caller of `provision()` was the admin backfill endpoint `/api/admin/apps-storage-backfill` — it was **never** called from `approveRequest`, the git-push webhook, or the build-callback. So an approved + deployed app that declares `apps:storage:*` scopes had **no schema** until someone hand-ran the backfill, and its first storage call 500'd with `relation "app_<slug>.shared_kv" does not exist`. This just bit the live `app-requests` app.

This is the third in the "approve silently didn't do X" series (siblings #3085 auto-create listing, #3089 manifest category, #3090 shared-scope exempt — all merged).

## The fix

Wire provisioning into `approveRequest` as a **(3c)** side effect, right after the AppBlock row exists — alongside the #3089 **(3a)** category-on-approve and #3085 **(3b)** listing-create blocks.

```
const declaresStorageScope = manifestScopes.some((s) => s.startsWith('apps:storage:'));
if (declaresStorageScope) {
  const storageSlug = sanitizeAppSlug(request.slug);
  // ...try { provision({ appBlockId, slug: storageSlug }) } catch → warn + continue
}
```

### provision-when: gated on storage scope

We provision **only when the approved manifest declares any `apps:storage:*` scope** (per-user `read`/`write` OR shared `shared:read`/`shared:write`). Rationale:

- A gen-only app (e.g. one declaring just `ai:write:budgeted`) never touches the datastore, so minting an empty 6-table schema + role for it is pure litter.
- An app that **adds** storage in a later version is provisioned on **that version's** approve — a scope change requires a new approved version, and the DDL is idempotent, so there is no "added storage but never provisioned" hole.
- The scope snapshot used is the **same `manifestScopes`** written to `AppBlock.approvedScopes`, so the provision decision matches what the token-mint path will actually grant.

The admin backfill still provisions **all** approved apps unconditionally (can't-miss safety net); this go-forward path is deliberately narrower. Slug derivation is identical to the backfill's (`sanitizeAppSlug(blockId)`).

### log-and-continue (critical — same posture as #3085/#3089/#3090)

`provision()` is wrapped in try/catch. On **any** error we emit a structured warning and **continue** — the app still deploys and the schema is recoverable via `/api/admin/apps-storage-backfill`. Storage provisioning must never gate an app's approve/deploy; if we rethrew, a deterministically-failing appsDb (e.g. `cnpg-cluster-apps` briefly down) would wedge the app's deploy forever. Provisioner is dynamically imported so appsDb/pg stay out of the module's static graph (mirrors the (3b) mapper import).

## No migration

Runtime DDL only — no `schema.prisma` change. **Already-approved apps were backfilled separately**; this fixes go-forward.

## Tests

`publish-request.orchestration.test.ts` (new `W4: storage provisioning-on-approve` describe):

1. Storage-declaring app → `provision` called **once** with `{ appBlockId, slug: 'hello' }` (slug = sanitized blockId).
2. Shared-storage-only app (`apps:storage:shared:read`) → provisions.
3. Hyphen blockId (`my-cool-app`) → slug folded to `my_cool_app`.
4. Gen-only app (`ai:write:budgeted`) → **not** called.
5. No-scope default manifest → **not** called.
6. tx-boundary: `provision()` throws → approve **completes** (AppBlock create / commit / finalise / build all still run), warning logged, no rethrow.
7. Idempotency: subsequent-version re-approve → provisions again against the existing appBlockId (safe — `CREATE ... IF NOT EXISTS`).

Local: **106** orchestration + **39** service tests pass. (Local `tsc` is unreliable on this box; pr-preview is the authoritative typecheck.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
