### PR TITLE
fix(leaderboard): exclude deleted/banned/confirmed-muted users at prep level

### DIFF
--- a/src/server/jobs/prepare-leaderboard.ts
+++ b/src/server/jobs/prepare-leaderboard.ts
@@ -19,6 +19,12 @@ import { createJob, getJobDate } from './job';
 
 const log = createLogger('leaderboard', 'blue');
 
+// Accounts that must never appear on any leaderboard, regardless of the board's query.
+// Applied uniformly across every population path so exclusion lives at the system level, not per-query.
+// Mutes only count once confirmed by a moderator (mutedAt set); an unconfirmed `muted` flag does not exclude.
+const eligibleAccountSql = (alias = 'u') =>
+  `${alias}."deletedAt" IS NULL AND ${alias}."bannedAt" IS NULL AND ${alias}."mutedAt" IS NULL`;
+
 const prepareLeaderboard = createJob('prepare-leaderboard', '0 23 * * *', async (jobContext) => {
   const [lastRun, setLastRun] = await getJobDate('prepare-leaderboard');
 
@@ -139,7 +145,7 @@ async function updateLegendsBoardResults() {
           NOT u."excludeFromLeaderboards"
           OR EXISTS (SELECT 1 FROM "Leaderboard" l WHERE l.id = lr."leaderboardId" AND NOT l.public)
         )
-        AND u."deletedAt" IS NULL
+        AND ${eligibleAccountSql()}
       GROUP BY "userId", "leaderboardId"
     ), positions AS (
       SELECT
@@ -214,6 +220,7 @@ async function defaultLeadboardPopulation(ctx: LeaderboardContext) {
       NOT u."excludeFromLeaderboards"
       OR EXISTS (SELECT 1 FROM "Leaderboard" l WHERE l.id = '${ctx.id}' AND NOT l.public)
     )
+      AND ${eligibleAccountSql()}
     ORDER BY score DESC
     LIMIT 1000
   `);
@@ -368,7 +375,7 @@ async function imageLeaderboardPopulation(ctx: LeaderboardContext, [min, max]: [
       row_number() OVER (ORDER BY (s->>'score')::int DESC) as position
     FROM jsonb_array_elements('${userScoresJson}'::jsonb) s
     JOIN "User" u ON u.id = (s->>'userId')::int
-    WHERE u."deletedAt" IS NULL AND u.id > 0
+    WHERE ${eligibleAccountSql()} AND u.id > 0
       AND NOT u."excludeFromLeaderboards"
     ORDER BY (s->>'score')::int DESC
     LIMIT 1000
@@ -486,7 +493,7 @@ async function clickhouseLeaderboardPopulation(ctx: LeaderboardContext) {
         s.*,
         (${positionStart} + row_number() OVER (ORDER BY score DESC)) as position
       FROM scores s
-      JOIN "User" u ON u.id = s."userId" AND NOT u."isModerator" AND u."bannedAt" IS NULL AND u."deletedAt" IS NULL
+      JOIN "User" u ON u.id = s."userId" AND NOT u."isModerator" AND ${eligibleAccountSql()}
       WHERE NOT u."excludeFromLeaderboards"
     `);
     ctx.jobContext.on('cancel', query.cancel);


### PR DESCRIPTION
## What

Leaderboards were still counting inactive accounts. Deleted users (and, depending on the board, banned/muted) leaked onto boards.

The `prepare-leaderboard` cron has **four** population paths — `defaultLeadboardPopulation`, `imageLeaderboardPopulation`, `clickhouseLeaderboardPopulation`, and `updateLegendsBoardResults` — and each hand-rolled its own `"User"` filter, so exclusion was inconsistent:

| Path | Before |
|------|--------|
| default | `excludeFromLeaderboards` only — no deleted/banned/muted |
| image | `deletedAt` only |
| clickhouse | `deletedAt` + `bannedAt` (+ `isModerator`) |
| legends | `deletedAt` only |

## Change

Centralized account eligibility into one fragment applied to **all four** paths (system level, not per-query):

```sql
u."deletedAt" IS NULL AND u."bannedAt" IS NULL AND u."mutedAt" IS NULL
```

- **Muted:** only **moderator-confirmed** mutes exclude (`mutedAt IS NOT NULL`). An unconfirmed `muted` flag does **not** exclude — matches the `isUpheld = !!mutedAt` semantics used in `GenerationMutedNotice`.
- `excludeFromLeaderboards` (with its non-public-board exception) and the clickhouse `isModerator` exclusion are preserved.

## Rollout / follow-up (no migration)

- Takes effect on the next daily prep run (23:00 UTC) for newly-built dates. The legends board `TRUNCATE`s + rebuilds every run, so it self-heals immediately.
- **Gap:** already-populated `LeaderboardResult` rows for the current date still contain inactive users, and the read path (`leaderboard.service.ts`) doesn't filter them. If we want those scrubbed before the next run, a manual `DELETE ... USING "User"` cleanup can be applied (manual-apply per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
