### PR TITLE
feat(app-blocks): W13 post-approval listing management — backend (reset-to-pending, onsite hide/relist, owner unpublish/republish, notifications)

### DIFF
--- a/prisma/migrations/20260713120000_w13_post_approval_mod_actions/migration.sql
+++ b/prisma/migrations/20260713120000_w13_post_approval_mod_actions/migration.sql
@@ -1,0 +1,65 @@
+-- ============================================================
+-- App Store Listings (W13) — post-approval mgmt: widen the app_listing_moderation_events action CHECK
+-- ============================================================
+-- Phase 1 of W13 "post-approval listing management" adds three new moderation
+-- actions that the procs write to `app_listing_moderation_events.action`:
+--   * 'reset-to-pending'  — a mod bounces an APPROVED off-site listing back into
+--     the review queue (approved -> pending + a fresh pending publish request).
+--   * 'owner-unpublish'   — the OWNER hides their own approved listing
+--     (approved -> removed), a self-service takedown (no re-review).
+--   * 'owner-republish'   — the OWNER restores their own owner-unpublished listing
+--     (removed -> approved), allowed ONLY when the most-recent event was an
+--     owner-unpublish (never a mod delist/purge takedown-for-cause).
+--
+-- The P3b PR1 CHECK (20260706120100_w13_p3b_app_listing_moderation_events) only
+-- allows delist|relist|claim|purge|report-resolve|report-dismiss, so a proc
+-- writing one of the three new actions would be REJECTED with 23514 without this
+-- widen. Postgres cannot modify a CHECK in place -> DROP then ADD. ADDITIVE: the
+-- new IN-list is a strict SUPERSET of the old one, so no existing row can violate
+-- it (nothing to backfill / re-validate).
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
+-- CNPG nvme0 DB does NOT auto-apply migrations (no prisma migrate deploy). This
+-- file is committed for HISTORY ONLY; a HUMAN applies the SQL below per
+-- environment (psql/retool). CI / deploy do NOT run it. Apply to BOTH:
+--   1. prod nvme0   (the live civitai DB)
+--   2. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev, db civitai)
+--
+-- 🔴 ORDERING: like the sibling status widen (20260706120200_..._status_add_removed)
+-- this is timing-sharp — existing code paths are unaffected, but the NEW procs'
+-- first write fails without it:
+--   * Apply to the DEV CLONE **before** the PR preview exercises the new procs, or
+--     the preview 500s on the constraint (preview-DB-drift → smoke-500 trap).
+--   * Apply to PROD nvme0 **before** this ships (main -> release), or the first
+--     live reset-to-pending / owner-unpublish / owner-republish UPDATE hits 23514.
+--
+-- The migration-agreement unit test
+-- (src/server/services/blocks/__tests__/app-listing-mod-action.constants.test.ts)
+-- parses the LATEST action-CHECK migration `.sql` (this file) and asserts its
+-- IN-list equals the code tuple APP_LISTING_MODERATION_ACTIONS, catching code/DDL
+-- drift at CI time — but it does NOT apply the DDL. The human apply above is still
+-- required.
+--
+-- Idempotent: DROP IF EXISTS then ADD, so a manual re-run is a no-op.
+--
+-- Wrapped in a single transaction so the DROP+ADD swap is ATOMIC: without it there
+-- is a sub-ms window between DROP and ADD where the table has NO action CHECK and a
+-- concurrent bad write could slip through. BEGIN/COMMIT closes that window (mirrors
+-- the status_add_removed / P0 single-transaction precedent).
+BEGIN;
+ALTER TABLE "app_listing_moderation_events"
+  DROP CONSTRAINT IF EXISTS "app_listing_mod_events_action_check";
+ALTER TABLE "app_listing_moderation_events"
+  ADD  CONSTRAINT "app_listing_mod_events_action_check"
+  CHECK ("action" IN (
+    'delist',
+    'relist',
+    'claim',
+    'purge',
+    'report-resolve',
+    'report-dismiss',
+    'reset-to-pending',
+    'owner-unpublish',
+    'owner-republish'
+  ));
+COMMIT;

--- a/src/server/notifications/app-listing.notifications.ts
+++ b/src/server/notifications/app-listing.notifications.ts
@@ -1,0 +1,102 @@
+import { NotificationCategory } from '~/server/common/enums';
+import { createNotificationProcessor } from '~/server/notifications/base.notifications';
+
+/**
+ * App Store Listings (W13) — owner-facing moderation notifications.
+ *
+ * The listing owner (an app developer) has no other signal today that a moderator
+ * acted on their off-site listing. These four IMPERATIVE notification types are
+ * emitted directly from the off-site listing/moderation services (via
+ * `createNotification`) — NOT from a scheduled `prepareQuery` scan — so they carry
+ * NO `prepareQuery`, only a `prepareMessage` (mirrors the auction / challenge
+ * imperative notifications). Each carries the acting reason (where a mod supplied
+ * one) + a link to the owner's submissions view.
+ *
+ * The `type` strings are free-form (the notifications app stores them as text — no
+ * DB enum), so adding these needs NO notifications-DB migration (same as the
+ * auction/challenge imperative types). Registered in `utils.notifications.ts`.
+ *
+ * DARK: the emitting procs are all behind the App Blocks author/mod flags, so no
+ * owner receives one until the App Blocks segment widens.
+ */
+
+export type AppListingModerationNotificationDetails = {
+  /** The public store slug (identity + link hint). */
+  slug: string;
+  /** The listing display name (best-effort — may be absent for a terse payload). */
+  name?: string | null;
+  /** The moderator's rationale, where one was supplied (delist/reset always; approve none). */
+  reason?: string | null;
+  /** The listing id (`apl_<ULID>`) for a future deep-link. */
+  listingId?: string | null;
+};
+
+/** All four owner notifications point the owner at their submissions/history view. */
+const OWNER_SUBMISSIONS_URL = '/apps/my-submissions';
+
+function appLabel(details: AppListingModerationNotificationDetails): string {
+  return details.name ? `"${details.name}"` : 'Your app';
+}
+
+/** Append ": <reason>" only when a non-empty reason is present. */
+function withReason(base: string, reason?: string | null): string {
+  const trimmed = reason?.trim();
+  return trimmed ? `${base}: ${trimmed}` : `${base}.`;
+}
+
+export const appListingNotifications = createNotificationProcessor({
+  'app-listing-approved': {
+    displayName: 'App listing approved',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppListingModerationNotificationDetails;
+      return {
+        message: `${appLabel(details)} was approved and is now live in the app store.`,
+        url: OWNER_SUBMISSIONS_URL,
+      };
+    },
+  },
+  'app-listing-rejected': {
+    displayName: 'App listing not approved',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppListingModerationNotificationDetails;
+      return {
+        message: withReason(`${appLabel(details)} was not approved`, details.reason),
+        url: OWNER_SUBMISSIONS_URL,
+      };
+    },
+  },
+  'app-listing-hidden': {
+    displayName: 'App listing hidden',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppListingModerationNotificationDetails;
+      return {
+        message: withReason(
+          `${appLabel(details)} was hidden from the app store by a moderator`,
+          details.reason
+        ),
+        url: OWNER_SUBMISSIONS_URL,
+      };
+    },
+  },
+  'app-listing-reset-to-pending': {
+    displayName: 'App listing needs re-review',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppListingModerationNotificationDetails;
+      return {
+        message: withReason(
+          `${appLabel(details)} was sent back for another review by a moderator`,
+          details.reason
+        ),
+        url: OWNER_SUBMISSIONS_URL,
+      };
+    },
+  },
+});

--- a/src/server/notifications/utils.notifications.ts
+++ b/src/server/notifications/utils.notifications.ts
@@ -2,6 +2,7 @@ import { articleNotifications } from '~/server/notifications/article.notificatio
 import { comicNotifications } from '~/server/notifications/comics.notifications';
 import { articleRatingReviewNotifications } from '~/server/notifications/article-rating-review.notifications';
 import { articleUnpublishNotifications } from '~/server/notifications/article-unpublish.notifications';
+import { appListingNotifications } from '~/server/notifications/app-listing.notifications';
 import { auctionNotifications } from '~/server/notifications/auction.notifications';
 import type { BareNotification } from '~/server/notifications/base.notifications';
 import { bountyNotifications } from '~/server/notifications/bounty.notifications';
@@ -38,6 +39,7 @@ export const notificationProcessors = {
   ...unpublishNotifications,
   ...articleNotifications,
   ...articleUnpublishNotifications,
+  ...appListingNotifications,
   ...articleRatingReviewNotifications,
   ...reportNotifications,
   ...featuredNotifications,

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -43,10 +43,14 @@ import {
   dismissReportSchema,
   listListingReportsSchema,
   listModerationEventsSchema,
+  listMyListingModerationEventsSchema,
   purgeListingSchema,
   relistListingSchema,
   reportListingSchema,
+  republishOwnListingSchema,
+  resetListingToPendingSchema,
   resolveReportSchema,
+  unpublishOwnListingSchema,
 } from '~/server/schema/blocks/offsite-moderation.schema';
 import { rateLimit } from '~/server/middleware.trpc';
 import {
@@ -836,6 +840,116 @@ export const appListingsRouter = router({
         '~/server/services/blocks/offsite-moderation.service'
       );
       return listModerationEvents(input);
+    }),
+
+  // -------------------------------------------------------------------------
+  // W13 POST-APPROVAL LISTING MANAGEMENT (Phase 1) — DARK.
+  //
+  // `resetListingToPending` is a MOD action (`moderatorProcedure` + `isModerator`
+  // recheck, same posture as delist/relist/claim/purge). The three owner procs
+  // (`unpublishOwnListing` / `republishOwnListing` / `listMyListingModerationEvents`)
+  // are `appDeveloperProcedure` (mods + app-dev-testers) and are bound to the caller
+  // in the service (owner-only, else NOT_OWNED → FORBIDDEN). All typed failures map
+  // via `mapOffsiteError` (no infra leak). Offsite-only in the service.
+  // -------------------------------------------------------------------------
+
+  /**
+   * MOD reset an approved off-site listing back into the review queue (approved →
+   * pending) — mints a fresh pending publish request owned by the listing owner so a
+   * mod can re-approve/reject it through the existing flow, writes a `reset-to-pending`
+   * audit event, and notifies the owner. Typed failures map via `mapOffsiteError`
+   * (NOT_FOUND→NOT_FOUND, NOT_TRANSITIONABLE→BAD_REQUEST, infra→INTERNAL/no leak).
+   */
+  resetListingToPending: moderatorProcedure
+    .input(resetListingToPendingSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Resetting off-site listings is restricted to civitai team');
+      }
+      const { resetListingToPending } = await import(
+        '~/server/services/blocks/offsite-moderation.service'
+      );
+      try {
+        return await resetListingToPending({ input, reviewerUserId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /**
+   * OWNER unpublish their OWN approved off-site listing (approved → removed) — a
+   * self-service visibility toggle (no re-review). Owner-bound in the service
+   * (NOT_OWNED→FORBIDDEN); NOT_TRANSITIONABLE when not approved. Typed failures map
+   * via `mapOffsiteError`.
+   */
+  unpublishOwnListing: appDeveloperProcedure
+    .use(
+      rateLimit({
+        limit: 30,
+        period: 3600,
+        errorMessage: 'Too many listing changes — slow down.',
+      })
+    )
+    .input(unpublishOwnListingSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { unpublishOwnListing } = await import(
+        '~/server/services/blocks/offsite-moderation.service'
+      );
+      try {
+        return await unpublishOwnListing({ input, userId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /**
+   * OWNER republish their OWN owner-unpublished off-site listing (removed →
+   * approved). 🔴 Allowed ONLY when the listing's most-recent moderation event is an
+   * `owner-unpublish` — a listing a MODERATOR removed (delist/purge) is FORBIDDEN to
+   * self-restore (the load-bearing safety guard, in the service). Owner-bound. Typed
+   * failures map via `mapOffsiteError` (NOT_OWNED/FORBIDDEN→FORBIDDEN,
+   * NOT_TRANSITIONABLE→BAD_REQUEST).
+   */
+  republishOwnListing: appDeveloperProcedure
+    .use(
+      rateLimit({
+        limit: 30,
+        period: 3600,
+        errorMessage: 'Too many listing changes — slow down.',
+      })
+    )
+    .input(republishOwnListingSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { republishOwnListing } = await import(
+        '~/server/services/blocks/offsite-moderation.service'
+      );
+      try {
+        return await republishOwnListing({ input, userId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /**
+   * OWNER per-listing moderation history for a listing the caller OWNS (the "why was
+   * this hidden / un-approved" view). Owner-bound in the service (NOT_FOUND on a
+   * missing listing, NOT_OWNED→FORBIDDEN otherwise); same PII-safe projection as the
+   * mod `listModerationEvents`.
+   */
+  listMyListingModerationEvents: appDeveloperProcedure
+    .input(listMyListingModerationEventsSchema)
+    .query(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { listMyListingModerationEvents } = await import(
+        '~/server/services/blocks/offsite-moderation.service'
+      );
+      try {
+        return await listMyListingModerationEvents({ input, userId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
     }),
 
   // -------------------------------------------------------------------------

--- a/src/server/schema/blocks/offsite-moderation.schema.ts
+++ b/src/server/schema/blocks/offsite-moderation.schema.ts
@@ -73,13 +73,17 @@ export type ListListingReportsInput = z.infer<typeof listListingReportsSchema>;
 
 /**
  * Moderation-event action taxonomy — MUST equal the `app_listing_mod_events_action_check`
- * CHECK set (migration `20260706120100_w13_p3b_app_listing_moderation_events`). A
- * drift here would let a proc write an `action` the DB rejects (23514). The
- * action-agreement unit test pins this tuple against the migration's IN-list.
+ * CHECK set. The base six were shipped in migration
+ * `20260706120100_w13_p3b_app_listing_moderation_events`; the last three
+ * (`reset-to-pending`/`owner-unpublish`/`owner-republish`) are added by the W13
+ * post-approval-mgmt widen `20260713120000_w13_post_approval_mod_actions` (a strict
+ * superset — additive DROP+ADD CHECK). A drift here would let a proc write an
+ * `action` the DB rejects (23514). The action-agreement unit test pins this tuple
+ * against the LATEST action-CHECK migration's IN-list.
  *
- * NOTE the hyphen form (`report-resolve`/`report-dismiss`) — it matches the
- * shipped migration CHECK verbatim. `claim` is reserved for PR4 (not written by
- * any PR3 proc), but stays in the tuple because the DB CHECK already allows it.
+ * NOTE the hyphen form (`report-resolve`/`report-dismiss`/`reset-to-pending`/
+ * `owner-unpublish`/`owner-republish`) — it matches the shipped/widened migration
+ * CHECK verbatim.
  */
 export const APP_LISTING_MODERATION_ACTIONS = [
   'delist',
@@ -88,6 +92,10 @@ export const APP_LISTING_MODERATION_ACTIONS = [
   'purge',
   'report-resolve',
   'report-dismiss',
+  // W13 post-approval management (Phase 1):
+  'reset-to-pending',
+  'owner-unpublish',
+  'owner-republish',
 ] as const;
 export type AppListingModerationAction = (typeof APP_LISTING_MODERATION_ACTIONS)[number];
 
@@ -179,3 +187,66 @@ export const listModerationEventsSchema = z.object({
   limit: z.number().int().min(1).max(50).optional(),
 });
 export type ListModerationEventsInput = z.infer<typeof listModerationEventsSchema>;
+
+// ---------------------------------------------------------------------------
+// W13 post-approval listing management (Phase 1) — reset-to-pending (mod),
+// owner unpublish/republish, and the owner-scoped moderation-history read.
+// ---------------------------------------------------------------------------
+
+/**
+ * MOD reset an APPROVED off-site listing back into the review queue
+ * (approved → pending). `reason` is REQUIRED (audit — same bounds as delist/relist)
+ * because a reset un-publishes a live listing and re-opens a review. The service
+ * re-enters the listing into the queue by minting a fresh `pending`
+ * `AppListingPublishRequest` (owned by the listing owner) so a mod can then
+ * approve/reject it through the existing flow. The reviewer is bound to
+ * `ctx.user.id` — never client-supplied.
+ */
+export const resetListingToPendingSchema = z.object({
+  appListingId: z.string().min(1).max(64),
+  reason: modReason,
+});
+export type ResetListingToPendingInput = z.infer<typeof resetListingToPendingSchema>;
+
+/**
+ * OWNER unpublish their OWN approved off-site listing (approved → removed). A pure
+ * self-service visibility toggle — NO re-review, NO content-rating re-derive, NO
+ * publish request. `reason` is OPTIONAL (the owner is acting on their own listing).
+ * The owner is bound to `ctx.user.id` in the service (a caller can only unpublish a
+ * listing they own — FORBIDDEN otherwise).
+ */
+export const unpublishOwnListingSchema = z.object({
+  appListingId: z.string().min(1).max(64),
+  reason: modNote,
+});
+export type UnpublishOwnListingInput = z.infer<typeof unpublishOwnListingSchema>;
+
+/**
+ * OWNER republish their OWN owner-unpublished off-site listing (removed → approved).
+ * 🔴 SAFETY GUARD (enforced in the service): republish is allowed ONLY when the
+ * most-recent `AppListingModerationEvent` for the listing is an `owner-unpublish` —
+ * i.e. the removal was owner-initiated. If the last event is a moderator
+ * `delist`/`purge` (a takedown-for-cause), republish is FORBIDDEN (an owner may not
+ * restore a listing a moderator removed). Pure visibility toggle — no re-derive, no
+ * publish request. `reason` is OPTIONAL. Owner-bound to `ctx.user.id`.
+ */
+export const republishOwnListingSchema = z.object({
+  appListingId: z.string().min(1).max(64),
+  reason: modNote,
+});
+export type RepublishOwnListingInput = z.infer<typeof republishOwnListingSchema>;
+
+/**
+ * OWNER per-listing moderation-history read (keyset, newest-first) — the owner's
+ * "why was this hidden / un-approved" view. Mirrors `listModerationEventsSchema` but
+ * the service asserts the caller OWNS the listing (FORBIDDEN otherwise); a mod uses
+ * `listModerationEventsSchema` / `listModerationEvents` instead.
+ */
+export const listMyListingModerationEventsSchema = z.object({
+  appListingId: z.string().min(1).max(64),
+  cursor: z.string().min(1).max(64).optional(),
+  limit: z.number().int().min(1).max(50).optional(),
+});
+export type ListMyListingModerationEventsInput = z.infer<
+  typeof listMyListingModerationEventsSchema
+>;

--- a/src/server/services/blocks/__tests__/app-listing-mod-action.constants.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-mod-action.constants.test.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 import path from 'path';
 import { describe, expect, it } from 'vitest';
 
@@ -22,13 +22,26 @@ import { APP_LISTING_MODERATION_ACTIONS } from '~/server/schema/blocks/offsite-m
 const REPO_ROOT = path.resolve(__dirname, '../../../../..');
 const MIGRATIONS_DIR = path.join(REPO_ROOT, 'prisma/migrations');
 
+/**
+ * Resolve the LATEST migration `.sql` that DEFINES the action CHECK — the base
+ * table create (`..._app_listing_moderation_events`) OR a later DROP+ADD widen
+ * (e.g. `..._w13_post_approval_mod_actions`). Scan by CONTENT (any migration whose
+ * `.sql` carries an `"action" ... IN (...)` CHECK), sorted by the timestamp-prefixed
+ * dir name, so a FUTURE widen in a differently-named dir is automatically the one
+ * checked (mirrors the status-CHECK test's "latest widen wins", but content-based so
+ * the widen dir need not share a naming token with the create).
+ */
 function modEventsMigration(): string {
-  const dirs = readdirSync(MIGRATIONS_DIR)
-    .filter((d) => /_app_listing_moderation_events$/.test(d))
+  const matches = readdirSync(MIGRATIONS_DIR)
+    .filter((d) => {
+      const file = path.join(MIGRATIONS_DIR, d, 'migration.sql');
+      if (!existsSync(file)) return false;
+      return /CHECK\s*\(\s*"action"\s+IN\s*\(/i.test(readFileSync(file, 'utf8'));
+    })
     .sort();
-  if (dirs.length === 0)
-    throw new Error('no *_app_listing_moderation_events migration dir found under prisma/migrations');
-  return path.join(MIGRATIONS_DIR, dirs[dirs.length - 1], 'migration.sql');
+  if (matches.length === 0)
+    throw new Error('no migration defining the "action" CHECK found under prisma/migrations');
+  return path.join(MIGRATIONS_DIR, matches[matches.length - 1], 'migration.sql');
 }
 
 /** Extract the quoted tokens from the `... "action" IN ('a', 'b', ...)` list. */
@@ -49,8 +62,14 @@ describe('AppListingModerationEvent action: code tuple ⟺ DB CHECK agreement', 
   it('uses the HYPHEN form report-resolve / report-dismiss (matches the shipped CHECK)', () => {
     expect(APP_LISTING_MODERATION_ACTIONS).toContain('report-resolve');
     expect(APP_LISTING_MODERATION_ACTIONS).toContain('report-dismiss');
-    // The PR3 procs write these five; claim is reserved for PR4 but allowed by the CHECK.
-    for (const a of ['delist', 'relist', 'purge', 'report-resolve', 'report-dismiss']) {
+    // The base P3b procs write these; claim + purge are also allowed by the CHECK.
+    for (const a of ['delist', 'relist', 'claim', 'purge', 'report-resolve', 'report-dismiss']) {
+      expect(APP_LISTING_MODERATION_ACTIONS).toContain(a);
+    }
+  });
+
+  it('includes the W13 post-approval-mgmt actions (reset-to-pending / owner-unpublish / owner-republish)', () => {
+    for (const a of ['reset-to-pending', 'owner-unpublish', 'owner-republish']) {
       expect(APP_LISTING_MODERATION_ACTIONS).toContain(a);
     }
   });

--- a/src/server/services/blocks/__tests__/app-listing-mod-action.constants.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-mod-action.constants.test.ts
@@ -22,25 +22,32 @@ import { APP_LISTING_MODERATION_ACTIONS } from '~/server/schema/blocks/offsite-m
 const REPO_ROOT = path.resolve(__dirname, '../../../../..');
 const MIGRATIONS_DIR = path.join(REPO_ROOT, 'prisma/migrations');
 
+/** The named CHECK constraint whose IN-list is the action taxonomy under test. */
+const ACTION_CHECK_CONSTRAINT = 'app_listing_mod_events_action_check';
+
 /**
- * Resolve the LATEST migration `.sql` that DEFINES the action CHECK — the base
- * table create (`..._app_listing_moderation_events`) OR a later DROP+ADD widen
- * (e.g. `..._w13_post_approval_mod_actions`). Scan by CONTENT (any migration whose
- * `.sql` carries an `"action" ... IN (...)` CHECK), sorted by the timestamp-prefixed
- * dir name, so a FUTURE widen in a differently-named dir is automatically the one
- * checked (mirrors the status-CHECK test's "latest widen wins", but content-based so
- * the widen dir need not share a naming token with the create).
+ * Resolve the LATEST migration `.sql` that DEFINES the `app_listing_mod_events_action_check`
+ * CHECK — the base table create (`..._app_listing_moderation_events`) OR a later DROP+ADD
+ * widen (e.g. `..._w13_post_approval_mod_actions`). Scan by CONTENT but keyed to THIS
+ * SPECIFIC named constraint (not any `"action"` CHECK), so an unrelated future migration
+ * that happens to CHECK a different `"action"` column can't mis-target this test. Sorted
+ * by the timestamp-prefixed dir name → the latest widen wins (mirrors the status-CHECK
+ * test's intent, content-based so the widen dir need not share a naming token).
  */
 function modEventsMigration(): string {
   const matches = readdirSync(MIGRATIONS_DIR)
     .filter((d) => {
       const file = path.join(MIGRATIONS_DIR, d, 'migration.sql');
       if (!existsSync(file)) return false;
-      return /CHECK\s*\(\s*"action"\s+IN\s*\(/i.test(readFileSync(file, 'utf8'));
+      const sql = readFileSync(file, 'utf8');
+      // Must define OUR named constraint AND carry an `"action" IN (...)` list.
+      return sql.includes(ACTION_CHECK_CONSTRAINT) && /CHECK\s*\(\s*"action"\s+IN\s*\(/i.test(sql);
     })
     .sort();
   if (matches.length === 0)
-    throw new Error('no migration defining the "action" CHECK found under prisma/migrations');
+    throw new Error(
+      `no migration defining the "${ACTION_CHECK_CONSTRAINT}" CHECK found under prisma/migrations`
+    );
   return path.join(MIGRATIONS_DIR, matches[matches.length - 1], 'migration.sql');
 }
 

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -51,6 +51,8 @@ type Client = {
     create: ReturnType<typeof vi.fn>;
     updateMany: ReturnType<typeof vi.fn>;
   };
+  // reject/withdraw close a reset-to-pending listing by writing a moderation event.
+  appListingModerationEvent: { create: ReturnType<typeof vi.fn> };
 };
 
 // `persistListingAssetImage` dynamically imports `createImage` from the image
@@ -84,6 +86,9 @@ const { mockRead, mockWrite, ids } = vi.hoisted(() => {
       create: vi.fn(async (args: { data: unknown }) => args.data),
       updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
     },
+    appListingModerationEvent: {
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+    },
   });
   const mockRead = makeClient();
   // The PRIMARY client also owns `$transaction`; the interactive tx runs the
@@ -103,6 +108,7 @@ vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingId: () => `apl_test_${++ids.n}`,
   newAppListingPublishRequestId: () => `alpr_test_${++ids.n}`,
+  newAppListingModerationEventId: () => `alme_test_${++ids.n}`,
 }));
 // approve/reject emit an owner notification post-commit; assert it without pulling
 // the notifications client graph.
@@ -133,6 +139,9 @@ function resetClient(c: Client) {
     .mockReset()
     .mockImplementation(async (a: { data: unknown }) => a.data);
   c.appListingPublishRequest.updateMany.mockReset().mockResolvedValue({ count: 1 });
+  c.appListingModerationEvent.create
+    .mockReset()
+    .mockImplementation(async (a: { data: unknown }) => a.data);
 }
 
 beforeEach(() => {
@@ -309,16 +318,19 @@ describe('submitExternalListing', () => {
 // ---------------------------------------------------------------------------
 
 describe('withdrawExternalRequest', () => {
-  it('own pending → withdrawn + the draft listing is deleted (slug released)', async () => {
-    // Classify read is on the replica; the guarded flip + delete are on the primary.
+  it('own pending → withdrawn + the first-time DRAFT listing is deleted (slug released), in one tx', async () => {
+    // Classify read is on the replica; the guarded flip + close are on the primary (tx).
     mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'pending',
       submittedByUserId: CALLER,
       appListingId: 'apl_1',
     });
+    // The in-tx close reads the listing status → a first-time DRAFT is deleted.
+    mockWrite.appListing.findUnique.mockResolvedValue({ status: 'draft', slug: 'cool-app' });
     await withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER });
 
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
     expect(mockWrite.appListingPublishRequest.updateMany).toHaveBeenCalledWith({
       where: { id: 'alpr_1', status: 'pending' },
       data: { status: 'withdrawn' },
@@ -326,6 +338,36 @@ describe('withdrawExternalRequest', () => {
     // Draft deletion is status-guarded (never removes an approved listing).
     expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
       where: { id: 'apl_1', status: 'draft' },
+    });
+    // A draft close writes NO moderation event.
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 reset-originated (PENDING, formerly-live) withdraw → listing set REMOVED + an OWNER-UNPUBLISH mod event (owner may later republish)', async () => {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'pending',
+      submittedByUserId: CALLER,
+      appListingId: 'apl_1',
+    });
+    // The in-tx close reads status → `pending` = a reset-to-pending, formerly-live listing.
+    mockWrite.appListing.findUnique.mockResolvedValue({ status: 'pending', slug: 'cool-app' });
+    await withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER });
+
+    // NOT deleted — transitioned to `removed`.
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apl_1', status: 'pending' },
+      data: { status: 'removed' },
+    });
+    // An `owner-unpublish` event (the OWNER withdrew their OWN re-review) → the owner
+    // CAN later republishOwnListing (last event actor is the owner, not a moderator).
+    expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'owner-unpublish',
+      actorUserId: CALLER,
+      before: { status: 'pending' },
+      after: { status: 'removed' },
     });
   });
 
@@ -793,16 +835,18 @@ describe('rejectExternalRequest', () => {
     expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
   });
 
-  it('pending → rejected + reviewedBy*/rejectionReason set + draft listing DELETED, ATOMICALLY in one tx', async () => {
+  it('pending → rejected + reviewedBy*/rejectionReason set + first-time DRAFT listing DELETED, ATOMICALLY in one tx', async () => {
     mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'pending',
       kind: 'offsite',
       appListingId: 'apl_1',
     });
+    // The in-tx close reads the listing status → a first-time DRAFT is deleted (regression).
+    mockWrite.appListing.findUnique.mockResolvedValue({ status: 'draft', slug: 'cool-app' });
     await rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON });
 
-    // The flip + delete run inside ONE transaction on the primary (tx client).
+    // The flip + close run inside ONE transaction on the primary (tx client).
     expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
     const call = mockWrite.appListingPublishRequest.updateMany.mock.calls[0][0] as {
       where: Record<string, unknown>;
@@ -815,9 +859,40 @@ describe('rejectExternalRequest', () => {
       rejectionReason: REASON,
     });
     expect(call.data.reviewedAt).toBeInstanceOf(Date);
-    // The draft listing is deleted (status-guarded — never removes an approved one).
+    // The first-time draft listing is DELETED (status-guarded — never removes an approved one).
     expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
       where: { id: 'apl_1', status: 'draft' },
+    });
+    // A draft close writes NO moderation event (only the reset-to-pending path does).
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 reset-originated (PENDING, formerly-live) reject → listing set REMOVED (not deleted/stranded) + a DELIST mod event', async () => {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'pending',
+      kind: 'offsite',
+      appListingId: 'apl_1',
+    });
+    // The in-tx close reads status → `pending` = a reset-to-pending, formerly-live listing.
+    mockWrite.appListing.findUnique.mockResolvedValue({ status: 'pending', slug: 'cool-app' });
+    await rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON });
+
+    // NOT hard-deleted — transitioned to `removed` (recoverable via mod relist).
+    expect(mockWrite.appListing.deleteMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apl_1', status: 'pending' },
+      data: { status: 'removed' },
+    });
+    // A `delist` moderation event (mod re-review takedown) — so the owner-republish
+    // guard treats it as a mod takedown and FORBIDS owner self-restore.
+    expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'delist',
+      actorUserId: MOD,
+      reason: REASON,
+      before: { status: 'pending' },
+      after: { status: 'removed' },
     });
   });
 

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -96,12 +96,17 @@ const { mockRead, mockWrite, ids } = vi.hoisted(() => {
   return { mockRead, mockWrite, ids: { n: 0 } };
 });
 
+const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn(async () => undefined) }));
+
 vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
 vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage }));
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingId: () => `apl_test_${++ids.n}`,
   newAppListingPublishRequestId: () => `alpr_test_${++ids.n}`,
 }));
+// approve/reject emit an owner notification post-commit; assert it without pulling
+// the notifications client graph.
+vi.mock('~/server/services/blocks/app-listing-notify', () => ({ notifyAppListingOwner: mockNotify }));
 
 const CALLER = 42;
 const OTHER = 99;
@@ -138,6 +143,7 @@ beforeEach(() => {
     .mockReset()
     .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
   mockCreateImage.mockReset().mockResolvedValue({ id: 12345 });
+  mockNotify.mockReset().mockResolvedValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -454,6 +460,11 @@ function stageApproveScenario(listing: {
     externalUrl: listing.externalUrl ?? 'https://cool.example.com/app',
     iconId: listing.iconId === undefined ? 1 : listing.iconId,
     coverId: listing.coverId === undefined ? 2 : listing.coverId,
+    // Owner fields the approve path reads for the post-commit owner notification.
+    userId: listing.submittedByUserId ?? CALLER,
+    name: 'Cool App',
+    slug: 'cool-app',
+    revisionOfId: null,
   };
   const count = listing.screenshotCount === undefined ? 1 : listing.screenshotCount;
   mockRead.appListing.findUnique.mockResolvedValue(listingRow);
@@ -486,13 +497,40 @@ describe('approveExternalRequest', () => {
     expect(reqCall.data.reviewedAt).toBeInstanceOf(Date);
 
     // Listing flip (status-guarded so an approved listing is never re-flipped). The
+    // guard now accepts draft OR pending (the W13 reset-to-pending reopen path). The
     // derived content rating is stamped alongside the status; with no asset levels
     // staged the derive fails safe to 'g'.
     expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
-      where: { id: 'apl_1', status: 'draft' },
+      where: { id: 'apl_1', status: { in: ['draft', 'pending'] } },
       data: { status: 'approved', contentRating: 'g' },
     });
     expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
+
+    // Post-commit: the OWNER is notified their app went live.
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'app-listing-approved',
+        userId: CALLER,
+        details: expect.objectContaining({ slug: 'cool-app', listingId: 'apl_1' }),
+      })
+    );
+  });
+
+  it('W13 REOPEN round-trip: a reset-to-pending listing (status pending) re-approves via the widened {draft,pending} guard', async () => {
+    // After resetListingToPending the listing is `pending` with a fresh pending
+    // request. Re-approving must succeed — proving the widened guard accepts pending.
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1, status: 'pending' });
+    const res = await approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD });
+    expect(res).toEqual({ publishRequestId: 'alpr_1', listingId: 'apl_1', slug: 'cool-app' });
+    // The listing flip fired with the widened guard (pending row matched → approved).
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apl_1', status: { in: ['draft', 'pending'] } },
+      data: { status: 'approved', contentRating: 'g' },
+    });
+    // Owner re-notified their app is live again.
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'app-listing-approved', userId: CALLER })
+    );
   });
 
   it('the AUTHORITATIVE asset gate reads the PRIMARY (tx), not the replica', async () => {
@@ -677,8 +715,11 @@ describe('approveExternalRequest', () => {
   }
 
   function ratingStampedOnFlip(): unknown {
+    // The status flip is the updateMany that stamps `contentRating` (the widened
+    // reopen guard is `where.status = { in: ['draft','pending'] }`, no longer a
+    // plain 'draft' string — match on the data shape instead).
     const flip = mockWrite.appListing.updateMany.mock.calls.find(
-      (c) => (c[0] as { where: { status?: string } }).where.status === 'draft'
+      (c) => (c[0] as { data?: { contentRating?: unknown } }).data?.contentRating !== undefined
     );
     return (flip?.[0] as { data: { contentRating?: unknown } }).data.contentRating;
   }
@@ -778,6 +819,48 @@ describe('rejectExternalRequest', () => {
     expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
       where: { id: 'apl_1', status: 'draft' },
     });
+  });
+
+  it('notifies the OWNER their first-time submission was NOT approved (carrying the reason)', async () => {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'pending',
+      kind: 'offsite',
+      appListingId: 'apl_1',
+    });
+    // The pre-tx listing read (for the notification target) returns a first-time draft.
+    mockRead.appListing.findUnique.mockResolvedValue({
+      userId: CALLER,
+      name: 'Cool App',
+      slug: 'cool-app',
+      revisionOfId: null,
+    });
+    await rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON });
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'app-listing-rejected',
+        userId: CALLER,
+        details: expect.objectContaining({ slug: 'cool-app', reason: REASON }),
+      })
+    );
+  });
+
+  it('does NOT notify on a REVISION reject (parent stays live)', async () => {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'pending',
+      kind: 'offsite',
+      appListingId: 'apl_shadow',
+    });
+    // The rejected listing is a shadow revision (revisionOfId set) → no owner notice.
+    mockRead.appListing.findUnique.mockResolvedValue({
+      userId: CALLER,
+      name: 'Cool App',
+      slug: 'cool-app',
+      revisionOfId: 'apl_parent',
+    });
+    await rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: REASON });
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 
   it('a NON-PENDING request → NOT_PENDING, no write', async () => {

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -7,9 +7,13 @@ import {
   delistListing,
   dismissReport,
   listModerationEvents,
+  listMyListingModerationEvents,
   purgeListing,
   relistListing,
+  republishOwnListing,
+  resetListingToPending,
   resolveReport,
+  unpublishOwnListing,
 } from '~/server/services/blocks/offsite-moderation.service';
 
 /**
@@ -26,15 +30,24 @@ type WriteMock = {
   appListing: {
     updateMany: ReturnType<typeof vi.fn>;
     deleteMany: ReturnType<typeof vi.fn>;
-    // purge + claim re-read the pre-mutation snapshot on the PRIMARY inside the tx.
+    // purge + claim + reset + owner actions re-read the snapshot on the PRIMARY in-tx.
     findUnique: ReturnType<typeof vi.fn>;
   };
-  appListingModerationEvent: { create: ReturnType<typeof vi.fn> };
+  // On-site delist/relist flip the backing AppBlock's status in the same tx.
+  appBlock: { updateMany: ReturnType<typeof vi.fn> };
+  appListingModerationEvent: {
+    create: ReturnType<typeof vi.fn>;
+    // republish reads the LATEST event on the primary inside the tx.
+    findFirst: ReturnType<typeof vi.fn>;
+  };
   appListingReport: { updateMany: ReturnType<typeof vi.fn> };
   // claim validates the target owner on the primary inside the tx.
   user: { findUnique: ReturnType<typeof vi.fn> };
-  // NEVER touched by claim (the submitter record is preserved) — asserted by absence.
-  appListingPublishRequest: { updateMany: ReturnType<typeof vi.fn> };
+  // claim NEVER writes this (submitter preserved); reset CREATES a fresh pending request.
+  appListingPublishRequest: {
+    updateMany: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+  };
 };
 type ReadMock = {
   appListing: { findUnique: ReturnType<typeof vi.fn> };
@@ -42,7 +55,7 @@ type ReadMock = {
   appListingModerationEvent: { findMany: ReturnType<typeof vi.fn> };
 };
 
-const { mockRead, mockWrite, ids } = vi.hoisted(() => {
+const { mockRead, mockWrite, mockNotify, ids } = vi.hoisted(() => {
   const write: WriteMock = {
     $transaction: vi.fn(),
     appListing: {
@@ -50,10 +63,17 @@ const { mockRead, mockWrite, ids } = vi.hoisted(() => {
       deleteMany: vi.fn(async () => ({ count: 1 })),
       findUnique: vi.fn(async () => null),
     },
-    appListingModerationEvent: { create: vi.fn(async (a: { data: unknown }) => a.data) },
+    appBlock: { updateMany: vi.fn(async () => ({ count: 1 })) },
+    appListingModerationEvent: {
+      create: vi.fn(async (a: { data: unknown }) => a.data),
+      findFirst: vi.fn(async () => null),
+    },
     appListingReport: { updateMany: vi.fn(async () => ({ count: 1 })) },
     user: { findUnique: vi.fn(async () => ({ id: 1 })) },
-    appListingPublishRequest: { updateMany: vi.fn(async () => ({ count: 1 })) },
+    appListingPublishRequest: {
+      updateMany: vi.fn(async () => ({ count: 1 })),
+      create: vi.fn(async (a: { data: unknown }) => a.data),
+    },
   };
   // The tx client is the write mock itself, so tx.* calls land on the same spies.
   write.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) => cb(write));
@@ -62,14 +82,17 @@ const { mockRead, mockWrite, ids } = vi.hoisted(() => {
     appListingReport: { findUnique: vi.fn(async () => null) },
     appListingModerationEvent: { findMany: vi.fn(async () => []) },
   };
-  return { mockRead: read, mockWrite: write, ids: { n: 0 } };
+  return { mockRead: read, mockWrite: write, mockNotify: vi.fn(async () => undefined), ids: { n: 0 } };
 });
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingReportId: () => `alrp_test_${++ids.n}`,
   newAppListingModerationEventId: () => `alme_test_${++ids.n}`,
+  newAppListingPublishRequestId: () => `alpr_test_${++ids.n}`,
 }));
+// Assert owner-notification emission without pulling the notifications client graph.
+vi.mock('~/server/services/blocks/app-listing-notify', () => ({ notifyAppListingOwner: mockNotify }));
 
 const REVIEWER = 1001;
 const APP_ID = 'apl_target';
@@ -77,8 +100,16 @@ const SLUG = 'cool-app';
 const REPORT_ID = 'alrp_r1';
 const GOOD_REASON = 'impersonates a real vendor';
 
+const OWNER = 500;
+const BLOCK_ID = 'blk_backing';
+
+/** Replica classify shape — now carries userId + appBlockId (dual-action classify). */
 function offsiteListing(status: string, kind = 'offsite') {
-  return { id: APP_ID, kind, status, slug: SLUG };
+  return { id: APP_ID, kind, status, slug: SLUG, userId: OWNER, appBlockId: null };
+}
+/** An on-site listing carries a backing AppBlock id (dual-table flip target). */
+function onsiteListing(status: string) {
+  return { id: APP_ID, kind: 'onsite', status, slug: SLUG, userId: OWNER, appBlockId: BLOCK_ID };
 }
 
 beforeEach(() => {
@@ -89,17 +120,21 @@ beforeEach(() => {
   );
   mockWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
   mockWrite.appListing.deleteMany.mockResolvedValue({ count: 1 });
+  mockWrite.appBlock.updateMany.mockResolvedValue({ count: 1 });
   // Default the in-tx purge primary read to a valid offsite listing (overridden
   // per-test where the snapshot status is load-bearing).
   mockWrite.appListing.findUnique.mockResolvedValue(offsiteListing('removed'));
   mockWrite.appListingModerationEvent.create.mockImplementation(async (a: { data: unknown }) => a.data);
+  mockWrite.appListingModerationEvent.findFirst.mockResolvedValue(null);
   mockWrite.appListingReport.updateMany.mockResolvedValue({ count: 1 });
   // claim: default the target-owner lookup to a real user + the reassign to 1 row.
   mockWrite.user.findUnique.mockResolvedValue({ id: 42 });
   mockWrite.appListingPublishRequest.updateMany.mockResolvedValue({ count: 1 });
+  mockWrite.appListingPublishRequest.create.mockImplementation(async (a: { data: unknown }) => a.data);
   mockRead.appListing.findUnique.mockResolvedValue(null);
   mockRead.appListingReport.findUnique.mockResolvedValue(null);
   mockRead.appListingModerationEvent.findMany.mockResolvedValue([]);
+  mockNotify.mockResolvedValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -135,6 +170,41 @@ describe('delistListing', () => {
     });
     // No linked report → the report table is untouched.
     expect(mockWrite.appListingReport.updateMany).not.toHaveBeenCalled();
+    // OFF-SITE hide → the owner is notified (post-commit), carrying the reason.
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'app-listing-hidden',
+        userId: OWNER,
+        details: expect.objectContaining({ slug: SLUG, reason: GOOD_REASON }),
+      })
+    );
+    // OFF-SITE has no backing block to suspend.
+    expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('ON-SITE delist flips BOTH app_listings AND the backing app_blocks in one tx (no owner notif)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(onsiteListing('approved'));
+    const res = await delistListing({
+      input: { appListingId: APP_ID, reason: GOOD_REASON },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'removed' });
+    // The listing flip is kind-scoped to onsite.
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'onsite', status: 'approved' },
+      data: { status: 'removed' },
+    });
+    // The backing AppBlock is ALSO suspended (guarded approved→suspended) in the tx.
+    expect(mockWrite.appBlock.updateMany).toHaveBeenCalledWith({
+      where: { id: BLOCK_ID, status: 'approved' },
+      data: { status: 'suspended' },
+    });
+    // Still exactly one audit event.
+    expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.action).toBe('delist');
+    // ON-SITE owners are NOT notified in Phase 1.
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 
   it('a status-guarded 0-count (already removed/draft) → NOT_TRANSITIONABLE and ZERO events', async () => {
@@ -145,14 +215,8 @@ describe('delistListing', () => {
     ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'NOT_TRANSITIONABLE' });
     // Guard threw BEFORE the audit write — no event on a rolled-back mutation.
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
-  });
-
-  it('an ON-SITE listing is rejected by the kind guard (generic NOT_FOUND, no tx)', async () => {
-    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved', 'onsite'));
-    await expect(
-      delistListing({ input: { appListingId: APP_ID, reason: GOOD_REASON }, reviewerUserId: REVIEWER })
-    ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'NOT_FOUND' });
-    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+    // Rolled back → no owner notification.
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 
   it('a missing listing → generic NOT_FOUND (indistinguishable from on-site)', async () => {
@@ -237,6 +301,34 @@ describe('relistListing', () => {
       relistListing({ input: { appListingId: APP_ID, reason: 'appeal upheld' }, reviewerUserId: REVIEWER })
     ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('ON-SITE relist restores BOTH app_listings AND the backing app_blocks in one tx', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(onsiteListing('removed'));
+    const res = await relistListing({
+      input: { appListingId: APP_ID, reason: 'appeal upheld' },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'onsite', status: 'removed' },
+      data: { status: 'approved' },
+    });
+    // The backing AppBlock is restored (guarded suspended→approved).
+    expect(mockWrite.appBlock.updateMany).toHaveBeenCalledWith({
+      where: { id: BLOCK_ID, status: 'suspended' },
+      data: { status: 'approved' },
+    });
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data.action).toBe('relist');
+  });
+
+  it('OFF-SITE relist does NOT touch app_blocks', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    await relistListing({
+      input: { appListingId: APP_ID, reason: 'appeal upheld' },
+      reviewerUserId: REVIEWER,
+    });
+    expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
   });
 });
 
@@ -641,10 +733,268 @@ describe('listModerationEvents', () => {
   });
 });
 
-describe('OffsiteModerationError (PR3/PR4 codes)', () => {
-  it('carries the NOT_TRANSITIONABLE / REPORT_NOT_PENDING / INVALID_TARGET_USER codes', () => {
+// ---------------------------------------------------------------------------
+// resetListingToPending (W13 post-approval mgmt) — MOD bounce back to review.
+// ---------------------------------------------------------------------------
+
+describe('resetListingToPending', () => {
+  /** The in-tx PRIMARY snapshot shape reset reads (userId + status + kind + slug + name). */
+  function primary(status: string, kind = 'offsite') {
+    return { userId: OWNER, status, kind, slug: SLUG, name: 'Cool App' };
+  }
+
+  it('flips approved → pending, mints a fresh pending request owned by the OWNER, writes ONE reset event + notifies', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(primary('approved'));
+    const res = await resetListingToPending({
+      input: { appListingId: APP_ID, reason: GOOD_REASON },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toMatchObject({ appListingId: APP_ID, status: 'pending' });
+    expect(res.publishRequestId).toMatch(/^alpr_test_/);
+
+    // Guarded flip approved → pending (offsite).
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'offsite', status: 'approved' },
+      data: { status: 'pending' },
+    });
+    // A fresh pending request re-enters the queue, SUBMITTED-BY THE OWNER (not the mod).
+    expect(mockWrite.appListingPublishRequest.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingPublishRequest.create.mock.calls[0][0].data).toMatchObject({
+      appListingId: APP_ID,
+      kind: 'offsite',
+      slug: SLUG,
+      submittedByUserId: OWNER,
+      status: 'pending',
+    });
+    // Exactly one reset-to-pending audit event.
+    expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'reset-to-pending',
+      actorUserId: REVIEWER,
+      reason: GOOD_REASON,
+      before: { status: 'approved' },
+      after: { status: 'pending' },
+    });
+    // Owner notified their app needs re-review.
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'app-listing-reset-to-pending',
+        userId: OWNER,
+        details: expect.objectContaining({ slug: SLUG, reason: GOOD_REASON }),
+      })
+    );
+  });
+
+  it('a non-approved (guard 0-count) listing → NOT_TRANSITIONABLE, ZERO events/requests/notif', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(primary('removed'));
+    mockWrite.appListing.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(
+      resetListingToPending({ input: { appListingId: APP_ID, reason: GOOD_REASON }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('a missing / on-site listing → generic NOT_FOUND (offsite-only), no tx', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved', 'onsite'));
+    await expect(
+      resetListingToPending({ input: { appListingId: APP_ID, reason: GOOD_REASON }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('a too-short reason is a BAD_REQUEST with no DB touch', async () => {
+    await expect(
+      resetListingToPending({ input: { appListingId: APP_ID, reason: 'x' }, reviewerUserId: REVIEWER })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockRead.appListing.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// unpublishOwnListing / republishOwnListing (owner) — the safety guard is load-bearing.
+// ---------------------------------------------------------------------------
+
+describe('unpublishOwnListing', () => {
+  function ownerPrimary(status: string, kind = 'offsite', userId = OWNER) {
+    return { userId, status, kind, slug: SLUG, name: 'Cool App' };
+  }
+
+  it('OWNER hides their approved listing (approved → removed) + one owner-unpublish event, no notif/publish-request', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('approved'));
+    const res = await unpublishOwnListing({
+      input: { appListingId: APP_ID },
+      userId: OWNER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'removed' });
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'offsite', status: 'approved' },
+      data: { status: 'removed' },
+    });
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'owner-unpublish',
+      actorUserId: OWNER,
+      before: { status: 'approved' },
+      after: { status: 'removed' },
+    });
+    // Pure visibility toggle — no re-review artifact, no owner self-notification.
+    expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('a NON-owner caller → NOT_OWNED (FORBIDDEN), no flip/event', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('approved', 'offsite', OWNER));
+    await expect(
+      unpublishOwnListing({ input: { appListingId: APP_ID }, userId: 999 })
+    ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'NOT_OWNED' });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('a non-approved owned listing → NOT_TRANSITIONABLE', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed'));
+    await expect(
+      unpublishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('an on-site owned listing → generic NOT_FOUND (offsite-only owner self-service)', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('approved', 'onsite'));
+    await expect(
+      unpublishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
+
+describe('republishOwnListing (🔴 the last-event safety guard)', () => {
+  function ownerPrimary(status: string, kind = 'offsite', userId = OWNER) {
+    return { userId, status, kind, slug: SLUG, name: 'Cool App' };
+  }
+
+  it('OWNER restores their OWN owner-unpublished listing (removed → approved) + owner-republish event', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed'));
+    // The most-recent event is the owner's own unpublish → restore allowed.
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'owner-unpublish' });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'offsite', status: 'removed' },
+      data: { status: 'approved' },
+    });
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'owner-republish',
+      before: { status: 'removed' },
+      after: { status: 'approved' },
+    });
+  });
+
+  it('🔴 FORBIDDEN when the last event is a MOD delist (takedown-for-cause) — no flip, no event', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed'));
+    // The most-recent event is a moderator delist → owner may NOT self-restore.
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'delist' });
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'FORBIDDEN' });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 FORBIDDEN when the last event is a MOD purge', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed'));
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'purge' });
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('FORBIDDEN when there is NO prior event (cannot prove owner-initiated removal)', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed'));
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce(null);
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('a NON-owner caller → NOT_OWNED (FORBIDDEN)', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed', 'offsite', OWNER));
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: 999 })
+    ).rejects.toMatchObject({ code: 'NOT_OWNED' });
+    // Ownership fails before the last-event check + the flip.
+    expect(mockWrite.appListingModerationEvent.findFirst).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('a non-removed owned listing → NOT_TRANSITIONABLE (before the last-event check)', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('approved'));
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+    expect(mockWrite.appListingModerationEvent.findFirst).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listMyListingModerationEvents (owner-scoped history).
+// ---------------------------------------------------------------------------
+
+describe('listMyListingModerationEvents', () => {
+  const evt = (id: string) => ({
+    id,
+    appListingId: APP_ID,
+    slug: SLUG,
+    action: 'owner-unpublish',
+    reason: null,
+    detail: null,
+    before: { status: 'approved' },
+    after: { status: 'removed' },
+    reportId: null,
+    createdAt: new Date(),
+    actor: { id: OWNER, username: 'dev', image: null },
+  });
+
+  it('returns the OWN-listing events (owner-authz) with the same newest-first keyset shape', async () => {
+    // Ownership check reads the listing owner...
+    mockRead.appListing.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    // ...then the events query returns the page.
+    mockRead.appListingModerationEvent.findMany.mockResolvedValueOnce([evt('alme_2'), evt('alme_1')]);
+    const res = await listMyListingModerationEvents({
+      input: { appListingId: APP_ID, limit: 1 },
+      userId: OWNER,
+    });
+    expect(res.items).toHaveLength(1);
+    expect(res.nextCursor).toBe('alme_2');
+    const args = mockRead.appListingModerationEvent.findMany.mock.calls[0][0];
+    expect(args.where).toEqual({ appListingId: APP_ID });
+    expect(args.orderBy).toEqual([{ createdAt: 'desc' }, { id: 'desc' }]);
+  });
+
+  it('FORBIDDEN (NOT_OWNED) on a listing the caller does NOT own — no events read', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce({ userId: 12345 });
+    await expect(
+      listMyListingModerationEvents({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'NOT_OWNED' });
+    expect(mockRead.appListingModerationEvent.findMany).not.toHaveBeenCalled();
+  });
+
+  it('NOT_FOUND on a missing listing', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(null);
+    await expect(
+      listMyListingModerationEvents({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
+
+describe('OffsiteModerationError (PR3/PR4 + W13 codes)', () => {
+  it('carries the NOT_TRANSITIONABLE / REPORT_NOT_PENDING / INVALID_TARGET_USER / NOT_OWNED / FORBIDDEN codes', () => {
     expect(new OffsiteModerationError('NOT_TRANSITIONABLE', 'x').code).toBe('NOT_TRANSITIONABLE');
     expect(new OffsiteModerationError('REPORT_NOT_PENDING', 'x').code).toBe('REPORT_NOT_PENDING');
     expect(new OffsiteModerationError('INVALID_TARGET_USER', 'x').code).toBe('INVALID_TARGET_USER');
+    expect(new OffsiteModerationError('NOT_OWNED', 'x').code).toBe('NOT_OWNED');
+    expect(new OffsiteModerationError('FORBIDDEN', 'x').code).toBe('FORBIDDEN');
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -103,13 +103,21 @@ const GOOD_REASON = 'impersonates a real vendor';
 const OWNER = 500;
 const BLOCK_ID = 'blk_backing';
 
-/** Replica classify shape — now carries userId + appBlockId (dual-action classify). */
+/** Replica classify shape — carries userId + name + appBlockId (dual-action classify). */
 function offsiteListing(status: string, kind = 'offsite') {
-  return { id: APP_ID, kind, status, slug: SLUG, userId: OWNER, appBlockId: null };
+  return { id: APP_ID, kind, status, slug: SLUG, name: 'Cool App', userId: OWNER, appBlockId: null };
 }
 /** An on-site listing carries a backing AppBlock id (dual-table flip target). */
 function onsiteListing(status: string) {
-  return { id: APP_ID, kind: 'onsite', status, slug: SLUG, userId: OWNER, appBlockId: BLOCK_ID };
+  return {
+    id: APP_ID,
+    kind: 'onsite',
+    status,
+    slug: SLUG,
+    name: 'Cool App',
+    userId: OWNER,
+    appBlockId: BLOCK_ID,
+  };
 }
 
 beforeEach(() => {
@@ -150,9 +158,9 @@ describe('delistListing', () => {
     });
     expect(res).toEqual({ appListingId: APP_ID, status: 'removed' });
 
-    // The mutate is status+kind-guarded (approved-only, offsite-only).
+    // The mutate is status+kind-guarded (approved OR removed → removed, offsite-only).
     expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
-      where: { id: APP_ID, kind: 'offsite', status: 'approved' },
+      where: { id: APP_ID, kind: 'offsite', status: { in: ['approved', 'removed'] } },
       data: { status: 'removed' },
     });
     // Exactly ONE audit event, with the correct action/actor/reason/slug/before/after.
@@ -190,9 +198,9 @@ describe('delistListing', () => {
       reviewerUserId: REVIEWER,
     });
     expect(res).toEqual({ appListingId: APP_ID, status: 'removed' });
-    // The listing flip is kind-scoped to onsite.
+    // The listing flip is kind-scoped to onsite (approved OR removed → removed).
     expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
-      where: { id: APP_ID, kind: 'onsite', status: 'approved' },
+      where: { id: APP_ID, kind: 'onsite', status: { in: ['approved', 'removed'] } },
       data: { status: 'removed' },
     });
     // The backing AppBlock is ALSO suspended (guarded approved→suspended) in the tx.
@@ -207,8 +215,8 @@ describe('delistListing', () => {
     expect(mockNotify).not.toHaveBeenCalled();
   });
 
-  it('a status-guarded 0-count (already removed/draft) → NOT_TRANSITIONABLE and ZERO events', async () => {
-    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+  it('a status-guarded 0-count (concurrently moved out of {approved,removed}, e.g. to draft/pending) → NOT_TRANSITIONABLE, ZERO events', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('approved'));
     mockWrite.appListing.updateMany.mockResolvedValueOnce({ count: 0 });
     await expect(
       delistListing({ input: { appListingId: APP_ID, reason: GOOD_REASON }, reviewerUserId: REVIEWER })
@@ -217,6 +225,29 @@ describe('delistListing', () => {
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
     // Rolled back → no owner notification.
     expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('🔴 ENFORCED-TAKEDOWN LOCK: delist on an already-REMOVED (owner-unpublished) listing succeeds + writes a delist event (before status removed)', async () => {
+    // The owner previously self-unpublished (status removed). A mod delist is idempotent
+    // (stays removed) but ALWAYS writes a `delist` event → the LAST event is now a mod
+    // takedown, so republishOwnListing's guard forbids the owner re-exposing it.
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    const res = await delistListing({
+      input: { appListingId: APP_ID, reason: 'confirmed impersonation' },
+      reviewerUserId: REVIEWER,
+    });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'removed' });
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'offsite', status: { in: ['approved', 'removed'] } },
+      data: { status: 'removed' },
+    });
+    expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'delist',
+      // The pre-state is reflected accurately (removed, not a hardcoded approved).
+      before: { status: 'removed' },
+      after: { status: 'removed' },
+    });
   });
 
   it('a missing listing → generic NOT_FOUND (indistinguishable from on-site)', async () => {

--- a/src/server/services/blocks/app-listing-notify.ts
+++ b/src/server/services/blocks/app-listing-notify.ts
@@ -1,0 +1,43 @@
+import type { AppListingModerationNotificationDetails } from '~/server/notifications/app-listing.notifications';
+
+/**
+ * App Store Listings (W13) — owner-notification emit helper.
+ *
+ * A thin, best-effort wrapper the off-site listing/moderation services call AFTER
+ * their transaction commits to notify the listing owner of a mod action. Kept in a
+ * DEDICATED module whose ONLY static import is a TYPE (erased at compile), and which
+ * DYNAMICALLY imports `createNotification` + `NotificationCategory` inside the async
+ * body — so importing this helper adds ZERO runtime graph to a caller (mirrors the
+ * services' own dynamic-import discipline for heavy deps). This keeps the service
+ * unit tests (which mock only `dbRead`/`dbWrite`) from pulling the notifications
+ * client; a test that asserts emission mocks `~/server/services/notification.service`.
+ *
+ * `createNotification` is itself best-effort (it swallows client errors + logs), and
+ * these are emitted post-commit, so a notification failure never affects the action.
+ */
+
+export type AppListingOwnerNotificationType =
+  | 'app-listing-approved'
+  | 'app-listing-rejected'
+  | 'app-listing-hidden'
+  | 'app-listing-reset-to-pending';
+
+export async function notifyAppListingOwner(opts: {
+  type: AppListingOwnerNotificationType;
+  userId: number;
+  /** Idempotency key — dedups repeat emissions of the same event to the same user. */
+  key: string;
+  details: AppListingModerationNotificationDetails;
+}): Promise<void> {
+  const [{ createNotification }, { NotificationCategory }] = await Promise.all([
+    import('~/server/services/notification.service'),
+    import('~/server/common/enums'),
+  ]);
+  await createNotification({
+    userId: opts.userId,
+    category: NotificationCategory.System,
+    type: opts.type,
+    key: opts.key,
+    details: opts.details,
+  });
+}

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -15,6 +15,7 @@ import {
   type SubmitExternalListingInput,
 } from '~/server/schema/blocks/offsite-listing.schema';
 import { assertListingAssetsComplete } from '~/server/services/blocks/app-listing-assets.service';
+import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
 import {
   deriveContentRatingFromAssets,
   nsfwLevelFromContentRating,
@@ -1199,6 +1200,10 @@ export async function approveExternalRequest(opts: {
       iconId: true,
       coverId: true,
       revisionOfId: true,
+      // Owner (for the post-commit "approved" owner notification) + name (message).
+      userId: true,
+      name: true,
+      slug: true,
     },
   });
   if (!listing) {
@@ -1303,16 +1308,23 @@ export async function approveExternalRequest(opts: {
       coverId: primaryListing.coverId,
       override: opts.contentRating,
     });
+    // Guard flips a `draft` OR a `pending` listing → approved. `pending` is the W13
+    // post-approval-mgmt REOPEN path: `resetListingToPending` bounces an approved
+    // listing back to `pending` + mints a fresh pending request pointing at it (a
+    // non-shadow request), so re-approving that request must accept a `pending`
+    // listing — not only a first-time `draft`. Additive: a first-time draft still
+    // flips exactly as before. Status-guarded so a concurrently deleted/moved row
+    // rolls the request flip back rather than approving a listing that is gone.
     const flipped = await tx.appListing.updateMany({
-      where: { id: appListingId, status: 'draft' },
+      where: { id: appListingId, status: { in: ['draft', 'pending'] } },
       data: { status: 'approved', contentRating: finalRating },
     });
     if (flipped.count === 0) {
-      // The draft was concurrently deleted / already flipped — abort (rolls back
-      // the request flip) rather than approve a request whose listing is gone.
+      // The draft/pending listing was concurrently deleted / already flipped — abort
+      // (rolls back the request flip) rather than approve a request whose listing is gone.
       throw new OffsiteRequestError(
         'NOT_PENDING',
-        `cannot approve — the draft listing is no longer available`
+        `cannot approve — the draft/pending listing is no longer available`
       );
     }
     // Supersede any OTHER pending off-site request for this slug (parity with the
@@ -1328,6 +1340,19 @@ export async function approveExternalRequest(opts: {
       },
       data: { status: 'withdrawn' },
     });
+  });
+
+  // Post-commit, best-effort: notify the listing OWNER their app went live. Emitted
+  // AFTER the tx so a notification failure can't roll back the approval, and only on
+  // a committed approve. Keyed by the publish request so a ret/replay dedups. Covers
+  // BOTH a first-time approve and a reset-to-pending re-approve (both land here — the
+  // revision-apply path returns earlier). (The listing owner may differ from the
+  // submitter after a mod claim, so target `AppListing.userId`, not submittedBy.)
+  await notifyAppListingOwner({
+    type: 'app-listing-approved',
+    userId: listing.userId,
+    key: `app-listing-approved:${publishRequestId}`,
+    details: { slug: listing.slug, name: listing.name, listingId: appListingId, reason: null },
   });
 
   return { publishRequestId, listingId: appListingId, slug: request.slug };
@@ -1551,6 +1576,20 @@ export async function rejectExternalRequest(opts: {
     );
   }
 
+  // Snapshot the owner + display fields for the post-commit "not approved" owner
+  // notification BEFORE the tx deletes the draft (the row is gone afterwards). A
+  // REVISION reject (the request points at a shadow — `revisionOfId != null`) is
+  // NOT a first-time rejection: the parent listing stays LIVE, so a "your app was
+  // not approved" notice would be misleading — skip it (revision-edit rejection
+  // notices are out of Phase-1 scope). A request whose listing was already gone
+  // (`appListingId` null) → nothing to notify.
+  const rejectedListing = request.appListingId
+    ? await dbRead.appListing.findUnique({
+        where: { id: request.appListingId },
+        select: { userId: true, name: true, slug: true, revisionOfId: true },
+      })
+    : null;
+
   // ONE transaction: status-guarded flip + draft delete, so a crash between them
   // can't orphan a hidden `draft` listing that keeps squatting the slug. The flip
   // is TOCTOU-guarded (`status:'pending'`): a concurrent approve/withdraw that
@@ -1575,6 +1614,23 @@ export async function rejectExternalRequest(opts: {
     }
     await deleteDraftListing(request.appListingId, tx);
   });
+
+  // Post-commit, best-effort: notify the owner their first-time submission was not
+  // approved, carrying the mod reason. Skipped for a revision reject (parent still
+  // live) and when there was no listing. Keyed by the request → dedups a replay.
+  if (rejectedListing && rejectedListing.revisionOfId == null) {
+    await notifyAppListingOwner({
+      type: 'app-listing-rejected',
+      userId: rejectedListing.userId,
+      key: `app-listing-rejected:${publishRequestId}`,
+      details: {
+        slug: rejectedListing.slug,
+        name: rejectedListing.name,
+        listingId: request.appListingId,
+        reason,
+      },
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -23,6 +23,7 @@ import {
 import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 import {
   newAppListingId,
+  newAppListingModerationEventId,
   newAppListingPublishRequestId,
   newAppListingScreenshotId,
   newUlid,
@@ -255,11 +256,13 @@ export async function submitExternalListing(opts: {
  * never remove an approved listing.
  *
  * REVISION-AWARE (no branch needed): a pending REVISION request points at a SHADOW
- * `AppListing`, which is itself `status:'draft'`. So the same status-guarded
- * `deleteDraftListing` deletes ONLY the shadow — the LIVE parent (a separate,
- * `approved` row, never referenced by this request's `appListingId`) is untouched
- * and stays live. Withdrawing a revision therefore behaves exactly like withdrawing
- * a first-time submission, by construction.
+ * `AppListing`, which is itself `status:'draft'`. So the status-aware
+ * `closeTerminalListing` DELETES ONLY the shadow (the `draft` branch) — the LIVE
+ * parent (a separate, `approved` row, never referenced by this request's
+ * `appListingId`) is untouched and stays live. Withdrawing a revision therefore
+ * behaves exactly like withdrawing a first-time submission, by construction. (A
+ * reset-to-pending, formerly-live listing is instead transitioned to `removed`; see
+ * `closeTerminalListing`.)
  *
  * CONCURRENCY (TOCTOU): the `findUnique` only CLASSIFIES; the mutation is a
  * status-guarded `updateMany({ id, status:'pending' })`, so a withdraw that read
@@ -293,14 +296,26 @@ export async function withdrawExternalRequest(opts: {
     );
   }
 
-  // Status-guarded write: only flip a STILL-`pending` row (closes the TOCTOU
-  // window against a concurrent approve).
-  const { count } = await dbWrite.appListingPublishRequest.updateMany({
-    where: { id: publishRequestId, status: 'pending' },
-    data: { status: 'withdrawn' },
+  // ONE transaction: status-guarded request flip + the status-aware listing close,
+  // so a reset-to-pending listing's `pending → removed` transition + its audit event
+  // are atomic with the withdraw (a crash can't split them, and the guarded flip means
+  // only the winner closes). A first-time draft is deleted (unchanged); a formerly-live
+  // reset listing is set `removed` with an `owner-unpublish` event (the owner withdrew
+  // their OWN re-review — so they MAY later republish it, per the republish guard).
+  const flipped = await dbWrite.$transaction(async (tx) => {
+    const { count } = await tx.appListingPublishRequest.updateMany({
+      where: { id: publishRequestId, status: 'pending' },
+      data: { status: 'withdrawn' },
+    });
+    if (count === 0) return false;
+    await closeTerminalListing(tx, row.appListingId, {
+      actorUserId: userId,
+      action: 'owner-unpublish',
+      reason: null,
+    });
+    return true;
   });
-  if (count > 0) {
-    await deleteDraftListing(row.appListingId);
+  if (flipped) {
     return;
   }
 
@@ -323,19 +338,75 @@ export async function withdrawExternalRequest(opts: {
   );
 }
 
+export type CloseTerminalListingOutcome = 'deleted' | 'removed' | 'none';
+
 /**
- * Delete a still-DRAFT off-site listing (releases the slug; cascades its
- * screenshots via `onDelete: Cascade`). Status-guarded so an approved listing is
- * never removed; no-op when the request had no linked listing. Accepts an optional
- * transaction client so the caller can make the flip + delete atomic (reject);
- * defaults to `dbWrite` (autocommit) for withdraw.
+ * Terminal-close the `AppListing` backing a rejected/withdrawn request, in the
+ * caller's transaction — status-AWARE so a reset-to-pending (formerly-LIVE) listing
+ * is never hard-deleted nor stranded in `pending`:
+ *
+ *   - `draft`   → DELETE (releases the slug; cascades screenshots). Covers a FIRST-TIME
+ *                 submission AND a SHADOW revision (shadows are always `draft`) — both
+ *                 keep the pre-W13 behaviour exactly.
+ *   - `pending` → a reset-to-pending, FORMERLY-LIVE listing (real assets/reports/
+ *                 history). Do NOT delete + do NOT leave stranded: transition it to
+ *                 `removed` (recoverable via mod `relistListing`) AND write an
+ *                 `AppListingModerationEvent` so the close is audited and the
+ *                 owner-republish guard sees the correct last-event ACTOR:
+ *                   * reject  → `delist` (a mod re-review takedown — the owner may NOT
+ *                     self-restore it).
+ *                   * withdraw→ `owner-unpublish` (the owner withdrew their own
+ *                     re-review — they MAY later republish it).
+ *   - anything else (approved/removed) → no-op (a terminal request never targets one;
+ *                 guarded defensively).
+ *
+ * The `pending → removed` flip is status-guarded (TOCTOU): a 0-count (raced) → `none`
+ * with no event. Accepts a tx client so the flip + event are atomic with the caller's
+ * request-status flip. No-op when the request had no linked listing.
  */
-async function deleteDraftListing(
+async function closeTerminalListing(
+  client: Pick<typeof dbWrite, 'appListing' | 'appListingModerationEvent'>,
   appListingId: string | null,
-  client: Pick<typeof dbWrite, 'appListing'> = dbWrite
-): Promise<void> {
-  if (!appListingId) return;
-  await client.appListing.deleteMany({ where: { id: appListingId, status: 'draft' } });
+  event: { actorUserId: number; action: 'delist' | 'owner-unpublish'; reason: string | null }
+): Promise<CloseTerminalListingOutcome> {
+  if (!appListingId) return 'none';
+  const listing = await client.appListing.findUnique({
+    where: { id: appListingId },
+    select: { status: true, slug: true },
+  });
+  if (!listing) return 'none';
+
+  if (listing.status === 'draft') {
+    // First-time draft OR a shadow revision — delete as before (status-guarded so it
+    // can never remove an approved/removed row).
+    await client.appListing.deleteMany({ where: { id: appListingId, status: 'draft' } });
+    return 'deleted';
+  }
+
+  if (listing.status === 'pending') {
+    // Reset-to-pending, formerly-live listing → transition to `removed` (recoverable),
+    // never delete/strand. Status-guarded flip; on a raced 0-count, do nothing.
+    const flipped = await client.appListing.updateMany({
+      where: { id: appListingId, status: 'pending' },
+      data: { status: 'removed' },
+    });
+    if (flipped.count === 0) return 'none';
+    await client.appListingModerationEvent.create({
+      data: {
+        id: newAppListingModerationEventId(),
+        appListingId,
+        slug: listing.slug,
+        action: event.action,
+        actorUserId: event.actorUserId,
+        reason: event.reason,
+        before: { status: 'pending' },
+        after: { status: 'removed' },
+      },
+    });
+    return 'removed';
+  }
+
+  return 'none';
 }
 
 // ---------------------------------------------------------------------------
@@ -1531,10 +1602,12 @@ async function applyApprovedRevision(opts: {
  * Non-pending → NOT_PENDING.
  *
  * REVISION-AWARE (no branch needed): a pending REVISION request points at a SHADOW
- * `AppListing`, which is `status:'draft'`, so the status-guarded `deleteDraftListing`
- * deletes ONLY the shadow — the LIVE parent (a separate `approved` row) is untouched
- * and stays live. Rejecting a revision therefore behaves exactly like rejecting a
- * first-time submission, by construction.
+ * `AppListing`, which is `status:'draft'`, so `closeTerminalListing` DELETES ONLY the
+ * shadow (the `draft` branch) — the LIVE parent (a separate `approved` row) is
+ * untouched and stays live. Rejecting a revision therefore behaves exactly like
+ * rejecting a first-time submission, by construction. A reset-to-pending, formerly-live
+ * listing is instead transitioned to `removed` + a `delist` audit event (a rejected
+ * re-review = a MOD takedown the owner cannot self-restore); see `closeTerminalListing`.
  */
 export async function rejectExternalRequest(opts: {
   publishRequestId: string;
@@ -1590,12 +1663,15 @@ export async function rejectExternalRequest(opts: {
       })
     : null;
 
-  // ONE transaction: status-guarded flip + draft delete, so a crash between them
-  // can't orphan a hidden `draft` listing that keeps squatting the slug. The flip
-  // is TOCTOU-guarded (`status:'pending'`): a concurrent approve/withdraw that
-  // already flipped the row matches 0 → NOT_PENDING (throwing rolls the tx back
-  // before any delete); only the winner deletes. The delete is status-guarded
-  // (`status:'draft'`) so it can never remove an approved listing.
+  // ONE transaction: status-guarded flip + the status-aware listing close, so a crash
+  // between them can't orphan a hidden listing / squat the slug. The flip is
+  // TOCTOU-guarded (`status:'pending'`): a concurrent approve/withdraw that already
+  // flipped the row matches 0 → NOT_PENDING (throwing rolls the tx back before the
+  // close); only the winner closes. `closeTerminalListing` deletes a first-time
+  // `draft` (releases the slug — unchanged) but transitions a reset-to-pending,
+  // formerly-LIVE listing to `removed` (recoverable; NEVER stranded in `pending` nor
+  // hard-deleted) + writes a `delist` audit event so a rejected re-review reads as a
+  // MOD takedown — the owner CANNOT self-restore it via `republishOwnListing`.
   await dbWrite.$transaction(async (tx) => {
     const { count } = await tx.appListingPublishRequest.updateMany({
       where: { id: publishRequestId, status: 'pending' },
@@ -1612,7 +1688,11 @@ export async function rejectExternalRequest(opts: {
         `cannot reject — the request is no longer pending`
       );
     }
-    await deleteDraftListing(request.appListingId, tx);
+    await closeTerminalListing(tx, request.appListingId, {
+      actorUserId: reviewerUserId,
+      action: 'delist',
+      reason,
+    });
   });
 
   // Post-commit, best-effort: notify the owner their first-time submission was not

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -1,4 +1,5 @@
 import { TRPCError } from '@trpc/server';
+import type { Prisma } from '@prisma/client';
 
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
@@ -9,13 +10,19 @@ import {
   type DismissReportInput,
   type ListListingReportsInput,
   type ListModerationEventsInput,
+  type ListMyListingModerationEventsInput,
   type PurgeListingInput,
   type RelistListingInput,
   type ReportListingInput,
+  type RepublishOwnListingInput,
+  type ResetListingToPendingInput,
   type ResolveReportInput,
+  type UnpublishOwnListingInput,
 } from '~/server/schema/blocks/offsite-moderation.schema';
+import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
 import {
   newAppListingModerationEventId,
+  newAppListingPublishRequestId,
   newAppListingReportId,
 } from '~/server/utils/app-block-ids';
 
@@ -50,6 +57,14 @@ export type OffsiteModerationErrorCode =
   | 'NOT_FOUND'
   | 'NOT_REPORTABLE'
   | 'ALREADY_REPORTED'
+  // W13 post-approval-mgmt owner actions:
+  //   NOT_OWNED  — an owner action (unpublish/republish/my-history) on a listing the
+  //     caller does not own → FORBIDDEN (router maps NOT_OWNED/FORBIDDEN → FORBIDDEN).
+  //   FORBIDDEN  — a forbidden owner transition, notably republish of a listing whose
+  //     LAST moderation event is a mod delist/purge (a takedown-for-cause the owner
+  //     may not self-restore) → FORBIDDEN.
+  | 'NOT_OWNED'
+  | 'FORBIDDEN'
   // PR3 mod-action failure modes:
   //   NOT_TRANSITIONABLE — a status-guarded delist/relist/claim matched 0 rows (the
   //     listing was already moved by a concurrent action, or is not in a claimable
@@ -279,16 +294,61 @@ async function classifyOffsiteListing(
   return { id: listing.id, status: listing.status, slug: listing.slug };
 }
 
+/**
+ * Load + classify a listing for the DUAL-KIND delist/relist actions (which apply to
+ * BOTH kinds, unlike claim/purge which stay offsite-only via `classifyOffsiteListing`).
+ * Returns the fields those actions need: kind (to branch the on-site dual-table flip),
+ * status/slug, the backing `appBlockId` (on-site: flip the block's status too), and
+ * the owner `userId` (the off-site hide notification target). A missing listing →
+ * generic NOT_FOUND (no kind guard here — both kinds are valid targets).
+ */
+async function classifyListingForAction(appListingId: string): Promise<{
+  id: string;
+  kind: string;
+  status: string;
+  slug: string;
+  appBlockId: string | null;
+  userId: number;
+}> {
+  const listing = await dbRead.appListing.findUnique({
+    where: { id: appListingId },
+    select: { id: true, kind: true, status: true, slug: true, appBlockId: true, userId: true },
+  });
+  if (!listing) {
+    throw new OffsiteModerationError('NOT_FOUND', 'Listing not found.');
+  }
+  return {
+    id: listing.id,
+    kind: listing.kind,
+    status: listing.status,
+    slug: listing.slug,
+    appBlockId: listing.appBlockId,
+    userId: listing.userId,
+  };
+}
+
 export type DelistListingResult = { appListingId: string; status: 'removed' };
 
 /**
- * MOD delist an APPROVED off-site listing (approved → removed). The read path is
- * approved-only, so a `removed` listing drops out of `listAvailableListings` +
- * `getListingDetail` automatically (no read-path change). Status-guarded: the
- * mutate is `updateMany({ id, kind:'offsite', status:'approved' })`; a 0-count
- * means a concurrent action already moved the row → NOT_TRANSITIONABLE and the tx
- * rolls back BEFORE the audit event is written (so a guarded failure emits ZERO
- * events). Optionally resolves the triggering `reportId` in the same tx.
+ * MOD delist an APPROVED listing (approved → removed) — now DUAL-KIND (W13
+ * post-approval mgmt). The store read path is approved-only, so a `removed` listing
+ * drops out of `listAvailableListings` + `getListingDetail` automatically.
+ *
+ *   - OFF-SITE: flip only `app_listings.status` approved → removed, then notify the
+ *     owner their app was hidden (post-commit, carrying the mod reason).
+ *   - ON-SITE: flip BOTH `app_listings.status` (approved → removed) AND the backing
+ *     `app_blocks.status` (approved → suspended) in the SAME tx — a hosted block's
+ *     runtime serving gate reads `app_blocks.status`, so hiding it from the store
+ *     WITHOUT suspending the block would leave `<slug>.civit.ai` still serving. No
+ *     owner notification on the on-site path (out of Phase-1 scope). The listing
+ *     flip is the authoritative guard; the block flip is status-guarded to avoid
+ *     clobbering a drifted state but is non-fatal on a 0-count (the store status is
+ *     the source of truth for visibility).
+ *
+ * Status-guarded: the listing mutate is `updateMany({ id, kind, status:'approved' })`;
+ * a 0-count means a concurrent action already moved the row → NOT_TRANSITIONABLE and
+ * the tx rolls back BEFORE the audit event is written (ZERO events on a guarded
+ * failure). Optionally resolves the triggering `reportId` in the same tx.
  */
 export async function delistListing(opts: {
   input: DelistListingInput;
@@ -296,11 +356,13 @@ export async function delistListing(opts: {
 }): Promise<DelistListingResult> {
   const { input, reviewerUserId } = opts;
   const reason = requireModReason(input.reason);
-  const listing = await classifyOffsiteListing(input.appListingId);
+  const listing = await classifyListingForAction(input.appListingId);
+  const isOnsite = listing.kind === 'onsite';
+  const eventId = newAppListingModerationEventId();
 
   await dbWrite.$transaction(async (tx) => {
     const flipped = await tx.appListing.updateMany({
-      where: { id: input.appListingId, kind: 'offsite', status: 'approved' },
+      where: { id: input.appListingId, kind: listing.kind, status: 'approved' },
       data: { status: 'removed' },
     });
     if (flipped.count === 0) {
@@ -309,9 +371,17 @@ export async function delistListing(opts: {
         'This listing can no longer be delisted.'
       );
     }
+    // ON-SITE: also suspend the backing AppBlock so the block runtime stops serving.
+    // Guarded to `approved` (don't clobber a drifted state); non-fatal on 0-count.
+    if (isOnsite && listing.appBlockId) {
+      await tx.appBlock.updateMany({
+        where: { id: listing.appBlockId, status: 'approved' },
+        data: { status: 'suspended' },
+      });
+    }
     await tx.appListingModerationEvent.create({
       data: {
-        id: newAppListingModerationEventId(),
+        id: eventId,
         appListingId: input.appListingId,
         slug: listing.slug,
         action: 'delist',
@@ -338,15 +408,35 @@ export async function delistListing(opts: {
     }
   });
 
+  // OFF-SITE only: post-commit, best-effort — notify the owner their app was hidden,
+  // carrying the mod reason. (On-site owners aren't notified in Phase 1.)
+  if (!isOnsite) {
+    await notifyAppListingOwner({
+      type: 'app-listing-hidden',
+      userId: listing.userId,
+      // Keyed by the audit event id so each distinct hide (delist→relist→delist)
+      // notifies once, without a fresh nonce.
+      key: `app-listing-hidden:${eventId}`,
+      details: { slug: listing.slug, listingId: input.appListingId, reason },
+    });
+  }
+
   return { appListingId: input.appListingId, status: 'removed' };
 }
 
 export type RelistListingResult = { appListingId: string; status: 'approved' };
 
 /**
- * MOD relist a REMOVED off-site listing (removed → approved) — reversibility for a
- * mistaken/appealed takedown; restores store visibility instantly. Status-guarded
- * (`status:'removed'`) + one audit event, same TOCTOU discipline as delist.
+ * MOD relist a REMOVED listing (removed → approved) — DUAL-KIND reversibility for a
+ * mistaken/appealed takedown; restores store visibility instantly. The mirror of
+ * delist:
+ *   - OFF-SITE: flip only `app_listings.status` removed → approved.
+ *   - ON-SITE: flip BOTH `app_listings.status` (removed → approved) AND the backing
+ *     `app_blocks.status` (suspended → approved) in the SAME tx, so the block starts
+ *     serving again. The block flip is status-guarded (suspended-only) + non-fatal on
+ *     a 0-count (drift-tolerant), same as delist.
+ * Status-guarded (`status:'removed'`) + one audit event, same TOCTOU discipline as
+ * delist. No owner notification (a relist is a RESTORE — nothing adverse to notify).
  */
 export async function relistListing(opts: {
   input: RelistListingInput;
@@ -354,11 +444,12 @@ export async function relistListing(opts: {
 }): Promise<RelistListingResult> {
   const { input, reviewerUserId } = opts;
   const reason = requireModReason(input.reason);
-  const listing = await classifyOffsiteListing(input.appListingId);
+  const listing = await classifyListingForAction(input.appListingId);
+  const isOnsite = listing.kind === 'onsite';
 
   await dbWrite.$transaction(async (tx) => {
     const flipped = await tx.appListing.updateMany({
-      where: { id: input.appListingId, kind: 'offsite', status: 'removed' },
+      where: { id: input.appListingId, kind: listing.kind, status: 'removed' },
       data: { status: 'approved' },
     });
     if (flipped.count === 0) {
@@ -366,6 +457,14 @@ export async function relistListing(opts: {
         'NOT_TRANSITIONABLE',
         'This listing can no longer be relisted.'
       );
+    }
+    // ON-SITE: restore the backing AppBlock so the block runtime serves again.
+    // Guarded to `suspended` (don't clobber a drifted state); non-fatal on 0-count.
+    if (isOnsite && listing.appBlockId) {
+      await tx.appBlock.updateMany({
+        where: { id: listing.appBlockId, status: 'suspended' },
+        data: { status: 'approved' },
+      });
     }
     await tx.appListingModerationEvent.create({
       data: {
@@ -698,7 +797,11 @@ const moderationEventSelect = {
  * the event id (`alme_<ULID>`, time-sortable so it tracks the `createdAt desc`
  * order); the `id` tie-break makes same-millisecond ordering deterministic.
  */
-export async function listModerationEvents(opts: ListModerationEventsInput) {
+async function queryModerationEvents(opts: {
+  appListingId: string;
+  cursor?: string;
+  limit?: number;
+}) {
   const limit = Math.min(opts.limit ?? 25, 50);
   const rows = await dbRead.appListingModerationEvent.findMany({
     where: { appListingId: opts.appListingId },
@@ -710,4 +813,294 @@ export async function listModerationEvents(opts: ListModerationEventsInput) {
   const hasNext = rows.length > limit;
   const items = hasNext ? rows.slice(0, limit) : rows;
   return { items, nextCursor: hasNext ? items[items.length - 1].id : null };
+}
+
+export async function listModerationEvents(opts: ListModerationEventsInput) {
+  return queryModerationEvents(opts);
+}
+
+// ---------------------------------------------------------------------------
+// W13 post-approval listing management (Phase 1).
+//   resetListingToPending  — MOD bounce an approved off-site listing back to review.
+//   unpublishOwnListing    — OWNER self-hide an approved off-site listing.
+//   republishOwnListing    — OWNER restore an OWNER-unpublished off-site listing
+//                            (forbidden if the last event was a mod takedown).
+//   listMyListingModerationEvents — OWNER-scoped per-listing audit history.
+//
+// resetListingToPending is offsite-only + `moderatorProcedure`; the three owner
+// procs are offsite-only + `appDeveloperProcedure`, and every owner proc is bound to
+// the caller (`AppListing.userId === callerUserId`, else NOT_OWNED → FORBIDDEN). All
+// write exactly one `AppListingModerationEvent` in the same tx as their mutation
+// (a guarded 0-count rolls the whole tx — incl. the event — back).
+// ---------------------------------------------------------------------------
+
+export type ResetListingToPendingResult = {
+  appListingId: string;
+  status: 'pending';
+  publishRequestId: string;
+};
+
+/**
+ * MOD reset an APPROVED off-site listing back into the review queue (approved →
+ * pending). In ONE tx (authoritative on the PRIMARY): guard-flip the listing
+ * approved → pending (offsite + status-guarded; 0-count → NOT_TRANSITIONABLE),
+ * mint a FRESH `pending` `AppListingPublishRequest` owned by the listing owner
+ * (`submittedByUserId = AppListing.userId`) so the listing re-enters the mod queue
+ * (a NON-shadow request — `approveExternalRequest`'s widened `{draft,pending}` guard
+ * re-approves it), and write a `reset-to-pending` audit event. Post-commit,
+ * best-effort: notify the owner their app needs another review (carrying the reason).
+ *
+ * Offsite-only (mirrors claim/purge): a missing OR on-site listing → generic
+ * NOT_FOUND. The owner snapshot is read on the PRIMARY inside the tx (a replica read
+ * could stamp a stale owner under lag).
+ */
+export async function resetListingToPending(opts: {
+  input: ResetListingToPendingInput;
+  reviewerUserId: number;
+}): Promise<ResetListingToPendingResult> {
+  const { input, reviewerUserId } = opts;
+  const reason = requireModReason(input.reason);
+  // Fail-fast + info-leak parity (replica): missing/on-site → generic NOT_FOUND
+  // before any tx. The authoritative snapshot is re-read on the primary in the tx.
+  await classifyOffsiteListing(input.appListingId);
+
+  const eventId = newAppListingModerationEventId();
+  const publishRequestId = newAppListingPublishRequestId();
+  let ownerUserId = 0;
+  let slug = '';
+  let name: string | null = null;
+
+  await dbWrite.$transaction(async (tx) => {
+    const current = await tx.appListing.findUnique({
+      where: { id: input.appListingId },
+      select: { userId: true, status: true, kind: true, slug: true, name: true },
+    });
+    if (!current || current.kind !== 'offsite') {
+      throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+    }
+    ownerUserId = current.userId;
+    slug = current.slug;
+    name = current.name;
+
+    // Guard-flip approved → pending (offsite + status-guarded TOCTOU).
+    const flipped = await tx.appListing.updateMany({
+      where: { id: input.appListingId, kind: 'offsite', status: 'approved' },
+      data: { status: 'pending' },
+    });
+    if (flipped.count === 0) {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'Only an approved listing can be reset to pending.'
+      );
+    }
+
+    // Re-enter the review queue: a fresh pending request pointing at the (now
+    // pending) listing, submitted-by the OWNER (not the acting mod) so the queue +
+    // my-submissions attribute it to the owner. Non-shadow (no revisionOfId), so
+    // re-approve runs the first-time approve path.
+    await tx.appListingPublishRequest.create({
+      data: {
+        id: publishRequestId,
+        appListingId: input.appListingId,
+        kind: 'offsite',
+        slug: current.slug,
+        submittedByUserId: current.userId,
+        status: 'pending',
+      },
+    });
+
+    await tx.appListingModerationEvent.create({
+      data: {
+        id: eventId,
+        appListingId: input.appListingId,
+        slug: current.slug,
+        action: 'reset-to-pending',
+        actorUserId: reviewerUserId,
+        reason,
+        before: { status: 'approved' },
+        after: { status: 'pending' },
+      },
+    });
+  });
+
+  await notifyAppListingOwner({
+    type: 'app-listing-reset-to-pending',
+    userId: ownerUserId,
+    key: `app-listing-reset-to-pending:${eventId}`,
+    details: { slug, name, listingId: input.appListingId, reason },
+  });
+
+  return { appListingId: input.appListingId, status: 'pending', publishRequestId };
+}
+
+/**
+ * Load an OFF-SITE listing the caller OWNS for an owner action, on the PRIMARY
+ * inside a tx. A missing OR on-site listing → generic NOT_FOUND (offsite-only owner
+ * self-service, parity with claim/purge); a listing owned by someone else →
+ * NOT_OWNED (router → FORBIDDEN).
+ */
+async function loadOwnedOffsiteInTx(
+  tx: Prisma.TransactionClient,
+  appListingId: string,
+  callerUserId: number
+): Promise<{ userId: number; status: string; slug: string; name: string | null }> {
+  const listing = await tx.appListing.findUnique({
+    where: { id: appListingId },
+    select: { userId: true, status: true, kind: true, slug: true, name: true },
+  });
+  if (!listing || listing.kind !== 'offsite') {
+    throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+  }
+  if (listing.userId !== callerUserId) {
+    throw new OffsiteModerationError('NOT_OWNED', 'You can only manage your own listings.');
+  }
+  return { userId: listing.userId, status: listing.status, slug: listing.slug, name: listing.name };
+}
+
+export type UnpublishOwnListingResult = { appListingId: string; status: 'removed' };
+
+/**
+ * OWNER self-hide their OWN approved off-site listing (approved → removed). A pure
+ * visibility toggle — NO content-rating re-derive, NO asset change, NO publish
+ * request. In ONE tx (primary): owner-load + guard offsite/owner/status, guard-flip
+ * approved → removed (0-count → NOT_TRANSITIONABLE), write an `owner-unpublish`
+ * event. No notification (the owner performed the action). `reason` optional.
+ */
+export async function unpublishOwnListing(opts: {
+  input: UnpublishOwnListingInput;
+  userId: number;
+}): Promise<UnpublishOwnListingResult> {
+  const { input, userId } = opts;
+  const reason = input.reason?.trim() ? input.reason.trim() : null;
+
+  await dbWrite.$transaction(async (tx) => {
+    const listing = await loadOwnedOffsiteInTx(tx, input.appListingId, userId);
+    if (listing.status !== 'approved') {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'Only an approved listing can be unpublished.'
+      );
+    }
+    const flipped = await tx.appListing.updateMany({
+      where: { id: input.appListingId, kind: 'offsite', status: 'approved' },
+      data: { status: 'removed' },
+    });
+    if (flipped.count === 0) {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'This listing can no longer be unpublished.'
+      );
+    }
+    await tx.appListingModerationEvent.create({
+      data: {
+        id: newAppListingModerationEventId(),
+        appListingId: input.appListingId,
+        slug: listing.slug,
+        action: 'owner-unpublish',
+        actorUserId: userId,
+        reason,
+        before: { status: 'approved' },
+        after: { status: 'removed' },
+      },
+    });
+  });
+
+  return { appListingId: input.appListingId, status: 'removed' };
+}
+
+export type RepublishOwnListingResult = { appListingId: string; status: 'approved' };
+
+/**
+ * OWNER restore their OWN owner-unpublished off-site listing (removed → approved).
+ *
+ * 🔴 SAFETY GUARD (load-bearing): republish is allowed ONLY when the MOST-RECENT
+ * `AppListingModerationEvent` for the listing is an `owner-unpublish`. If the last
+ * event is a moderator `delist`/`purge` (a takedown-for-cause), republish is
+ * FORBIDDEN — an owner must NOT be able to self-restore a listing a moderator
+ * removed. No events at all → also FORBIDDEN (can't prove owner-initiated removal).
+ * The latest-event read + the flip are in ONE tx on the PRIMARY so a concurrent mod
+ * takedown can't slip between the check and the restore. Pure visibility toggle — no
+ * re-derive, no publish request. `reason` optional.
+ */
+export async function republishOwnListing(opts: {
+  input: RepublishOwnListingInput;
+  userId: number;
+}): Promise<RepublishOwnListingResult> {
+  const { input, userId } = opts;
+  const reason = input.reason?.trim() ? input.reason.trim() : null;
+
+  await dbWrite.$transaction(async (tx) => {
+    const listing = await loadOwnedOffsiteInTx(tx, input.appListingId, userId);
+    if (listing.status !== 'removed') {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'Only a removed listing can be republished.'
+      );
+    }
+    // 🔴 The most-recent moderation event must be the OWNER's own unpublish. Read on
+    // the PRIMARY inside the tx (a concurrent mod delist/purge would otherwise race
+    // between a replica read and the flip). A mod delist/purge (or NO event) → the
+    // owner may not self-restore.
+    const lastEvent = await tx.appListingModerationEvent.findFirst({
+      where: { appListingId: input.appListingId },
+      orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+      select: { action: true },
+    });
+    if (!lastEvent || lastEvent.action !== 'owner-unpublish') {
+      throw new OffsiteModerationError(
+        'FORBIDDEN',
+        'This listing was removed by a moderator and cannot be restored by its owner.'
+      );
+    }
+    const flipped = await tx.appListing.updateMany({
+      where: { id: input.appListingId, kind: 'offsite', status: 'removed' },
+      data: { status: 'approved' },
+    });
+    if (flipped.count === 0) {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'This listing can no longer be republished.'
+      );
+    }
+    await tx.appListingModerationEvent.create({
+      data: {
+        id: newAppListingModerationEventId(),
+        appListingId: input.appListingId,
+        slug: listing.slug,
+        action: 'owner-republish',
+        actorUserId: userId,
+        reason,
+        before: { status: 'removed' },
+        after: { status: 'approved' },
+      },
+    });
+  });
+
+  return { appListingId: input.appListingId, status: 'approved' };
+}
+
+/**
+ * OWNER per-listing moderation history (audit trail) for a listing the CALLER OWNS
+ * — the owner's "why was this hidden / un-approved" view. Asserts ownership
+ * (NOT_FOUND on a missing listing, NOT_OWNED → FORBIDDEN otherwise) then returns the
+ * SAME newest-first, keyset-paginated, PII-safe projection as the mod
+ * `listModerationEvents`. Offsite-only is NOT enforced here (an owner can only pass
+ * their own listing id regardless of kind; the projection is already PII-safe).
+ */
+export async function listMyListingModerationEvents(opts: {
+  input: ListMyListingModerationEventsInput;
+  userId: number;
+}) {
+  const { input, userId } = opts;
+  const listing = await dbRead.appListing.findUnique({
+    where: { id: input.appListingId },
+    select: { userId: true },
+  });
+  if (!listing) {
+    throw new OffsiteModerationError('NOT_FOUND', 'Listing not found.');
+  }
+  if (listing.userId !== userId) {
+    throw new OffsiteModerationError('NOT_OWNED', 'You can only view your own listings.');
+  }
+  return queryModerationEvents(input);
 }

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -307,12 +307,21 @@ async function classifyListingForAction(appListingId: string): Promise<{
   kind: string;
   status: string;
   slug: string;
+  name: string | null;
   appBlockId: string | null;
   userId: number;
 }> {
   const listing = await dbRead.appListing.findUnique({
     where: { id: appListingId },
-    select: { id: true, kind: true, status: true, slug: true, appBlockId: true, userId: true },
+    select: {
+      id: true,
+      kind: true,
+      status: true,
+      slug: true,
+      name: true,
+      appBlockId: true,
+      userId: true,
+    },
   });
   if (!listing) {
     throw new OffsiteModerationError('NOT_FOUND', 'Listing not found.');
@@ -322,6 +331,7 @@ async function classifyListingForAction(appListingId: string): Promise<{
     kind: listing.kind,
     status: listing.status,
     slug: listing.slug,
+    name: listing.name,
     appBlockId: listing.appBlockId,
     userId: listing.userId,
   };
@@ -345,10 +355,16 @@ export type DelistListingResult = { appListingId: string; status: 'removed' };
  *     clobbering a drifted state but is non-fatal on a 0-count (the store status is
  *     the source of truth for visibility).
  *
- * Status-guarded: the listing mutate is `updateMany({ id, kind, status:'approved' })`;
- * a 0-count means a concurrent action already moved the row → NOT_TRANSITIONABLE and
- * the tx rolls back BEFORE the audit event is written (ZERO events on a guarded
- * failure). Optionally resolves the triggering `reportId` in the same tx.
+ * STATUS: a delist is allowed on an `approved` OR an already-`removed` listing. The
+ * `removed → removed` case is the 🔴 "convert an owner-hide into an ENFORCED takedown"
+ * path: an owner who self-unpublished (last event = `owner-unpublish`) could otherwise
+ * freely `republishOwnListing` — a mod delist on the removed listing is idempotent
+ * (stays `removed`) but ALWAYS writes a `delist` event, making the LAST event a mod
+ * takedown so the republish guard then FORBIDS the owner from re-exposing it (a
+ * reversible lock-down without a hard `purge`). Status-guarded to `{approved,removed}`;
+ * a 0-count means a concurrent action moved the row out of that set → NOT_TRANSITIONABLE
+ * and the tx rolls back BEFORE the event is written (ZERO events on a guarded failure).
+ * Optionally resolves the triggering `reportId` in the same tx.
  */
 export async function delistListing(opts: {
   input: DelistListingInput;
@@ -361,8 +377,11 @@ export async function delistListing(opts: {
   const eventId = newAppListingModerationEventId();
 
   await dbWrite.$transaction(async (tx) => {
+    // Allow approved → removed AND removed → removed (the enforced-takedown lock). The
+    // idempotent removed→removed write keeps status `removed` but still counts (1 row),
+    // so the event below is ALWAYS written on a matched row.
     const flipped = await tx.appListing.updateMany({
-      where: { id: input.appListingId, kind: listing.kind, status: 'approved' },
+      where: { id: input.appListingId, kind: listing.kind, status: { in: ['approved', 'removed'] } },
       data: { status: 'removed' },
     });
     if (flipped.count === 0) {
@@ -372,7 +391,8 @@ export async function delistListing(opts: {
       );
     }
     // ON-SITE: also suspend the backing AppBlock so the block runtime stops serving.
-    // Guarded to `approved` (don't clobber a drifted state); non-fatal on 0-count.
+    // Guarded to `approved` (don't clobber a drifted/already-suspended state); non-fatal
+    // on 0-count (also covers the removed→removed lock, where the block is already suspended).
     if (isOnsite && listing.appBlockId) {
       await tx.appBlock.updateMany({
         where: { id: listing.appBlockId, status: 'approved' },
@@ -388,7 +408,8 @@ export async function delistListing(opts: {
         actorUserId: reviewerUserId,
         reason,
         reportId: input.reportId ?? null,
-        before: { status: 'approved' },
+        // Reflect the actual pre-state (approved for a hide, removed for the lock-down).
+        before: { status: listing.status },
         after: { status: 'removed' },
       },
     });
@@ -417,7 +438,7 @@ export async function delistListing(opts: {
       // Keyed by the audit event id so each distinct hide (delist→relist→delist)
       // notifies once, without a fresh nonce.
       key: `app-listing-hidden:${eventId}`,
-      details: { slug: listing.slug, listingId: input.appListingId, reason },
+      details: { slug: listing.slug, name: listing.name, listingId: input.appListingId, reason },
     });
   }
 
@@ -446,6 +467,8 @@ export async function relistListing(opts: {
   const reason = requireModReason(input.reason);
   const listing = await classifyListingForAction(input.appListingId);
   const isOnsite = listing.kind === 'onsite';
+  // Set when the on-site block-restore flip matched 0 rows (drift — see below).
+  let onsiteBlockRestoreDrift = false;
 
   await dbWrite.$transaction(async (tx) => {
     const flipped = await tx.appListing.updateMany({
@@ -460,11 +483,19 @@ export async function relistListing(opts: {
     }
     // ON-SITE: restore the backing AppBlock so the block runtime serves again.
     // Guarded to `suspended` (don't clobber a drifted state); non-fatal on 0-count.
+    //
+    // DRIFT CAVEAT: if the block was NOT `suspended` (e.g. `deprecated`, or already
+    // `approved`) the guard matches 0 rows and the block is left as-is. The listing
+    // then shows `approved` while the block may not serve — a BLANK/BROKEN block
+    // surface, NOT an exposure (the store card links to a block that renders nothing).
+    // Non-fatal (store visibility IS restored); flagged for a post-commit warn so the
+    // divergence is observable rather than silent.
     if (isOnsite && listing.appBlockId) {
-      await tx.appBlock.updateMany({
+      const blockFlip = await tx.appBlock.updateMany({
         where: { id: listing.appBlockId, status: 'suspended' },
         data: { status: 'approved' },
       });
+      if (blockFlip.count === 0) onsiteBlockRestoreDrift = true;
     }
     await tx.appListingModerationEvent.create({
       data: {
@@ -479,6 +510,26 @@ export async function relistListing(opts: {
       },
     });
   });
+
+  // Post-commit, best-effort: warn when an on-site relist restored the LISTING but the
+  // backing block wasn't `suspended` (so it may not serve) — observability for the
+  // drift caveat above. Dynamic import keeps the logging graph out of the tx path.
+  if (onsiteBlockRestoreDrift) {
+    void import('~/server/logging/client')
+      .then(({ logToAxiom }) =>
+        logToAxiom(
+          {
+            type: 'warning',
+            name: 'app-listing-relist-block-drift',
+            message:
+              'onsite relist: backing app_block was not suspended; the block may not serve',
+            details: { appListingId: input.appListingId, appBlockId: listing.appBlockId },
+          },
+          'app-blocks'
+        )
+      )
+      .catch(() => undefined);
+  }
 
   return { appListingId: input.appListingId, status: 'approved' };
 }


### PR DESCRIPTION
## What

Phase 1 of W13 **post-approval listing management** — backend only, entirely **dark** behind the existing App Blocks author/mod flags. Mirrors the P3a/P3b delivery pattern (in-tx, status-guarded `updateMany`, exactly one `AppListingModerationEvent` per mutation in the same tx, reviewer/owner bound to `ctx.user.id`, typed errors mapped by `mapOffsiteError`).

## Procs

- **`resetListingToPending`** (mod, offsite): guard-flips the listing `approved → pending`, mints a **fresh `pending` `AppListingPublishRequest`** owned by the listing owner so it re-enters the review queue, writes a `reset-to-pending` audit event, and notifies the owner. `approveExternalRequest`'s in-tx listing-flip guard is widened `draft → {draft,pending}` so the reopened listing re-approves through the existing (non-shadow) approve path; the "no longer available" error text updated to "draft/pending".
- **Dual-kind `delist`/`relist`**: an **on-site** listing now flips BOTH `app_listings.status` AND the backing `app_blocks.status` (`suspended`/`approved`) in one tx (the block runtime serving gate reads `app_blocks.status`); the off-site path is byte-unchanged. Closes the no-onsite-delist gap. `reason` stays required.
- **`unpublishOwnListing`** / **`republishOwnListing`** (owner, offsite): pure visibility toggles — no re-review, no contentRating re-derive, no publish request. 🔴 **Safety guard:** republish is **FORBIDDEN** unless the listing's most-recent `AppListingModerationEvent` is an `owner-unpublish` — a mod `delist`/`purge` (takedown-for-cause), or no prior event, cannot be self-restored. Checked on the primary inside the tx so a concurrent mod takedown can't slip in.
- **`listMyListingModerationEvents`** (owner): owner-authz per-listing audit history (same PII-safe projection as the mod read).

## Migration (⚠️ RULE #8 — write-only, human-applied)

`prisma/migrations/20260713120000_w13_post_approval_mod_actions/migration.sql` widens `app_listing_mod_events_action_check` (DROP+ADD, additive superset — no existing row violated) to add `reset-to-pending` / `owner-unpublish` / `owner-republish`. **Apply to the dev clone BEFORE the preview exercises the new procs, and prod nvme0 BEFORE release** (order-safe/additive). `APP_LISTING_MODERATION_ACTIONS` is widened to match; the action-agreement test now scans for the **latest** migration defining the action CHECK (content-based), so it stays green with the widen in a differently-named dir.

## Notifications (net-new)

New `src/server/notifications/app-listing.notifications.ts` (owner-facing types: approved / rejected / hidden / reset-to-pending, each carrying the mod reason where present) + a dynamic-import emit helper. Emitted **post-commit** from `approveExternalRequest`, `rejectExternalRequest` (first-time rejects only — revision rejects skipped), the off-site `delistListing`, and `resetListingToPending`, targeting the listing owner. **No second migration needed** — the notification `type` is a free string and `category` reuses the existing `System` value (auction/challenge imperative-type precedent).

## Tests

Extended the mod-actions + offsite-listing service suites and the action-agreement test — **126 passing** across the 5 touched suites. Coverage: reset happy-path (flip + new pending request + event + notification) / guard-abort / authz; the **reset → re-approve round-trip** proving the widened `{draft,pending}` guard; onsite delist/relist **dual-table** flips (+ offsite untouched); owner unpublish/republish happy-paths; the **republish-FORBIDDEN-on-mod-takedown** safety guard; owner-history authz; and `createNotification`-emission assertions for approve/reject/hide/reset.

## Posture

All dark/flag-gated Phase 1 of the W13 post-approval scope. Ready for the adversarial `/audit-pr` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>