### PR TITLE
feat(app-blocks): make shared-storage abuse observable + store shared text raw

### DIFF
--- a/src/server/routers/__tests__/apps-shared.router.test.ts
+++ b/src/server/routers/__tests__/apps-shared.router.test.ts
@@ -85,7 +85,7 @@ vi.mock('~/server/logging/client', () => ({
 // import chain). In the test env DISCORD_WEBHOOK_MOD_ALERTS is unset, so the notify
 // short-circuits to a no-op before any fetch — exactly the fire-and-forget path.
 
-import { appsSharedRouter, appsModRouter } from '../apps-shared.router';
+import { appsSharedRouter, appsModRouter, sanitizeDiscordText } from '../apps-shared.router';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { OnboardingSteps } from '~/server/common/enums';
 
@@ -515,29 +515,39 @@ describe('FIX 1 abuse observability (alert emits)', () => {
       .map((c) => c[0]);
   }
 
-  it('an audit-category blocked append emits an alert (widened from minor/POI)', async () => {
+  it('an audit-category block emits the SEPARATE content-block warning (not legal-block)', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
     mockAuditPromptServer.mockRejectedValueOnce(new Error('Your prompt was flagged'));
     await expect(
       caller().append({ blockToken: 't', value: { title: 'harassment text' } })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
-    const emits = auditEmits('app-blocks-shared-storage-legal-block');
-    expect(emits).toHaveLength(1);
-    // slug is the SANITIZED schema slug (matches the existing legal-block emit).
-    expect(emits[0]).toMatchObject({ category: 'audit', userId: 42, slug: 'app_voting' });
+    // audit → the lower-urgency content-block/warning event …
+    const contentEmits = auditEmits('app-blocks-shared-storage-content-block');
+    expect(contentEmits).toHaveLength(1);
+    // slug is the SANITIZED schema slug (matches the legal-block emit shape).
+    expect(contentEmits[0]).toMatchObject({
+      type: 'warning',
+      category: 'audit',
+      userId: 42,
+      slug: 'app_voting',
+    });
     // metadata only — no content text leaked
-    expect(JSON.stringify(emits[0])).not.toContain('harassment');
+    expect(JSON.stringify(contentEmits[0])).not.toContain('harassment');
+    // … and it must NOT dilute the legal-urgency (CSAM/minor) channel.
+    expect(auditEmits('app-blocks-shared-storage-legal-block')).toHaveLength(0);
   });
 
-  it('minor content STILL emits the legal-block alert', async () => {
+  it('minor content STILL emits the legal-block error (NOT the content-block event)', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
     await expect(
       caller().append({ blockToken: 't', value: { title: '13 year old girl' } })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
     const emits = auditEmits('app-blocks-shared-storage-legal-block');
     expect(emits).toHaveLength(1);
-    expect(emits[0]).toMatchObject({ category: 'minor' });
+    expect(emits[0]).toMatchObject({ type: 'error', category: 'minor' });
     expect(JSON.stringify(emits[0])).not.toContain('13 year old');
+    // legal signal stays isolated from the general content-block channel.
+    expect(auditEmits('app-blocks-shared-storage-content-block')).toHaveLength(0);
   });
 
   it('a successful append emits NO block alert', async () => {
@@ -545,6 +555,7 @@ describe('FIX 1 abuse observability (alert emits)', () => {
     mockAppendDataPath();
     await caller().append({ blockToken: 't', value: { title: 'a fine idea' } });
     expect(auditEmits('app-blocks-shared-storage-legal-block')).toHaveLength(0);
+    expect(auditEmits('app-blocks-shared-storage-content-block')).toHaveLength(0);
   });
 
   it('a USER report emits a report alert with metadata only (NO content)', async () => {
@@ -598,6 +609,44 @@ describe('FIX 1 abuse observability (alert emits)', () => {
       caller().report({ blockToken: 't', key: 'ghost' })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
     expect(auditEmits('app-blocks-shared-storage-report')).toHaveLength(0);
+  });
+});
+
+// FIX 1 (Discord phishing vector): the reporter-supplied `reason` is embedded in
+// the mod-alerts Discord message. A hostile reporter must not be able to plant a
+// masked/phishing link or other markdown. `sanitizeDiscordText` neutralizes it and
+// the embed field wraps the result in an inline code span.
+describe('sanitizeDiscordText (mod-alert reason hardening)', () => {
+  it('neutralizes a masked link + backticks (no live markdown survives)', () => {
+    const hostile = 'click [here](https://phish.example) `rm -rf` **bold** ~~s~~ ||spoiler|| > q';
+    const out = sanitizeDiscordText(hostile);
+    // structural markdown / masked-link characters are gone
+    for (const ch of ['[', ']', '(', ')', '`', '*', '_', '~', '|', '>']) {
+      expect(out).not.toContain(ch);
+    }
+    expect(out).not.toMatch(/\]\(/); // the masked-link `](` sequence specifically
+    // the human-readable words survive as inert plain text
+    expect(out).toContain('here');
+    expect(out).toContain('https://phish.example');
+  });
+
+  it('the embed field value (code-span wrapped) contains no live masked link', () => {
+    // mirror the exact construction used in notifyModsOfSharedReport
+    const fieldValue = `\`${sanitizeDiscordText('[x](http://evil) `boom`') || 'user-report'}\``;
+    expect(fieldValue).not.toMatch(/\]\(/); // no masked link
+    // exactly two backticks (the wrapping span) — none survived from the input
+    expect((fieldValue.match(/`/g) ?? []).length).toBe(2);
+    expect(fieldValue.startsWith('`')).toBe(true);
+    expect(fieldValue.endsWith('`')).toBe(true);
+  });
+
+  it('an all-markdown reason collapses to empty → falls back to user-report', () => {
+    const fieldValue = `\`${sanitizeDiscordText('[]()``') || 'user-report'}\``;
+    expect(fieldValue).toBe('`user-report`');
+  });
+
+  it('caps the sanitized output at 500 chars', () => {
+    expect(sanitizeDiscordText('a'.repeat(1000)).length).toBe(500);
   });
 });
 

--- a/src/server/routers/__tests__/apps-shared.router.test.ts
+++ b/src/server/routers/__tests__/apps-shared.router.test.ts
@@ -24,6 +24,7 @@ const {
   mockThrowOnBlockedLinkDomain,
   mockAuditPromptServer,
   mockIsRevoked,
+  mockLogToAxiom,
 } = vi.hoisted(() => {
   const mockClient = {
     query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
@@ -46,6 +47,7 @@ const {
     mockThrowOnBlockedLinkDomain: vi.fn(async () => undefined),
     mockAuditPromptServer: vi.fn(async () => undefined),
     mockIsRevoked: vi.fn(async () => false),
+    mockLogToAxiom: vi.fn(async () => undefined),
   };
 });
 
@@ -75,7 +77,13 @@ vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
 vi.mock('~/server/services/block-revocation.service', () => ({
   BlockRevocation: { isRevoked: (...a: unknown[]) => mockIsRevoked(...a) },
 }));
-vi.mock('~/server/logging/client', () => ({ logToAxiom: async () => undefined }));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...a: unknown[]) => mockLogToAxiom(...a),
+}));
+// NOTE: the report op's Discord notify does a dynamic `import('~/env/server')`; we
+// deliberately do NOT mock env (mocking it clobbers env.LOGGING and breaks the trpc
+// import chain). In the test env DISCORD_WEBHOOK_MOD_ALERTS is unset, so the notify
+// short-circuits to a no-op before any fetch — exactly the fire-and-forget path.
 
 import { appsSharedRouter, appsModRouter } from '../apps-shared.router';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
@@ -145,7 +153,20 @@ beforeEach(() => {
   mockCheckVoteRl.mockResolvedValue({ allowed: true });
   mockThrowOnBlockedLinkDomain.mockResolvedValue(undefined);
   mockAuditPromptServer.mockResolvedValue(undefined);
+  mockLogToAxiom.mockResolvedValue(undefined);
 });
+
+// Helper: the append data path needs the row-count + quota SELECTs to resolve so a
+// trusted write reaches the INSERT.
+function mockAppendDataPath() {
+  mockPool.query.mockImplementation(async (sql: string) => {
+    if (sql.includes('author_user_id') && sql.includes('count(*)'))
+      return { rows: [{ n: '0' }], rowCount: 1 };
+    if (sql.includes('.quota'))
+      return { rows: [{ used_bytes: '0', row_count: '0' }], rowCount: 1 };
+    return { rows: [], rowCount: 0 };
+  });
+}
 
 describe('resolver gates', () => {
   it('rejects an invalid token (UNAUTHORIZED)', async () => {
@@ -420,25 +441,59 @@ describe('C3 content safety (blocking on append)', () => {
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
-  it('HTML in text is stored ESCAPED (C2 stored-XSS)', async () => {
+  // FIX 2: escape-at-rest removed — text is stored RAW. XSS is contained at the
+  // text-render + opaque-origin-sandbox layers (all approved apps are `unverified`
+  // → no `allow-same-origin`), never by escaping the stored form. This test pins
+  // that the raw bytes round-trip un-escaped so the display bug (`Tom &amp; Jerry`)
+  // is gone.
+  it('FIX 2: title/body are stored RAW (un-escaped)', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
-    mockPool.query.mockImplementation(async (sql: string) => {
-      if (sql.includes('author_user_id') && sql.includes('count(*)'))
-        return { rows: [{ n: '0' }], rowCount: 1 };
-      if (sql.includes('.quota'))
-        return { rows: [{ used_bytes: '0', row_count: '0' }], rowCount: 1 };
-      return { rows: [], rowCount: 0 };
-    });
+    mockAppendDataPath();
     await caller().append({
       blockToken: 't',
-      value: { title: 'hi <script>alert(1)</script>' },
+      value: { title: `Tom & Jerry <3 "x" 'y'`, body: 'a & b <span>' },
     });
     const insert = (mockClient.query.mock.calls as Array<[string, unknown[]?]>).find((c) =>
       c[0].includes('INSERT INTO "app_app_voting".shared_kv')
     );
     const stored = String((insert![1] as unknown[])[2]);
-    expect(stored).toContain('&lt;script&gt;');
-    expect(stored).not.toContain('<script>');
+    const parsed = JSON.parse(stored) as { title: string; body?: string };
+    // RAW round-trip — the exact bytes the user typed, no HTML entities introduced.
+    expect(parsed.title).toBe(`Tom & Jerry <3 "x" 'y'`);
+    expect(parsed.body).toBe('a & b <span>');
+    expect(stored).not.toContain('&amp;');
+    expect(stored).not.toContain('&lt;');
+    expect(stored).not.toContain('&#x27;');
+    expect(stored).not.toContain('&quot;');
+  });
+
+  // FIX 2 guard: removing escape-at-rest must NOT weaken any OTHER control — the raw
+  // text still runs the full block (minor/POI/link/audit/size).
+  it('FIX 2: other safety controls STILL reject the raw text', async () => {
+    // minor
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    await expect(
+      caller().append({ blockToken: 't', value: { title: '13 year old girl' } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    // blocked link
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockThrowOnBlockedLinkDomain.mockRejectedValueOnce(new Error('invalid urls'));
+    await expect(
+      caller().append({ blockToken: 't', value: { title: 'visit http://bad.example' } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    // audit / auto-mute
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockAuditPromptServer.mockRejectedValueOnce(new Error('Your prompt was flagged'));
+    await expect(
+      caller().append({ blockToken: 't', value: { title: 'flagged text' } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    // oversized title (> SHARED_TITLE_MAX 200) — the zod input schema rejects this
+    // at the procedure boundary BEFORE the handler runs, so verifyBlockToken is
+    // never called (no mock queued on purpose — queuing one would leak an unconsumed
+    // `mockResolvedValueOnce` into the next test).
+    await expect(
+      caller().append({ blockToken: 't', value: { title: 'x'.repeat(201) } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
   it('audit rejection (auto-mute path) surfaces BAD_REQUEST', async () => {
@@ -447,6 +502,102 @@ describe('C3 content safety (blocking on append)', () => {
     await expect(
       caller().append({ blockToken: 't', value: { title: 'flagged text' } })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+});
+
+// FIX 1 — make shared-storage abuse OBSERVABLE (pre-GA gate 1). Every alert emit is
+// fire-and-forget (`.catch`) and carries METADATA ONLY, never the content text.
+describe('FIX 1 abuse observability (alert emits)', () => {
+  // Pull the payloads sent on the 'block-audit' channel by name.
+  function auditEmits(name: string) {
+    return (mockLogToAxiom.mock.calls as Array<[Record<string, unknown>, string?]>)
+      .filter((c) => c[1] === 'block-audit' && c[0]?.name === name)
+      .map((c) => c[0]);
+  }
+
+  it('an audit-category blocked append emits an alert (widened from minor/POI)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockAuditPromptServer.mockRejectedValueOnce(new Error('Your prompt was flagged'));
+    await expect(
+      caller().append({ blockToken: 't', value: { title: 'harassment text' } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    const emits = auditEmits('app-blocks-shared-storage-legal-block');
+    expect(emits).toHaveLength(1);
+    // slug is the SANITIZED schema slug (matches the existing legal-block emit).
+    expect(emits[0]).toMatchObject({ category: 'audit', userId: 42, slug: 'app_voting' });
+    // metadata only — no content text leaked
+    expect(JSON.stringify(emits[0])).not.toContain('harassment');
+  });
+
+  it('minor content STILL emits the legal-block alert', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    await expect(
+      caller().append({ blockToken: 't', value: { title: '13 year old girl' } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    const emits = auditEmits('app-blocks-shared-storage-legal-block');
+    expect(emits).toHaveLength(1);
+    expect(emits[0]).toMatchObject({ category: 'minor' });
+    expect(JSON.stringify(emits[0])).not.toContain('13 year old');
+  });
+
+  it('a successful append emits NO block alert', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockAppendDataPath();
+    await caller().append({ blockToken: 't', value: { title: 'a fine idea' } });
+    expect(auditEmits('app-blocks-shared-storage-legal-block')).toHaveLength(0);
+  });
+
+  it('a USER report emits a report alert with metadata only (NO content)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValue({ rows: [{ x: 1 }], rowCount: 1 }); // row exists
+    const out = await caller().report({
+      blockToken: 't',
+      key: 'req-123',
+      reason: 'spam and harassment',
+    });
+    expect(out).toEqual({ ok: true });
+    const emits = auditEmits('app-blocks-shared-storage-report');
+    expect(emits).toHaveLength(1);
+    expect(emits[0]).toMatchObject({
+      name: 'app-blocks-shared-storage-report',
+      userId: 42,
+      slug: 'app_voting', // sanitized schema slug
+      appBlockId: 'apb_test',
+      reason: 'spam and harassment',
+      key: 'req-123',
+    });
+    // the payload carries the reporter's reason + key, but never the reported
+    // ROW CONTENT (the op only holds the key).
+    const report = (mockPool.query.mock.calls as Array<[string, unknown[]?]>).find((c) =>
+      c[0].includes('shared_kv_reports')
+    );
+    expect(report).toBeTruthy();
+  });
+
+  it('report emit is FIRE-AND-FORGET: op still succeeds if the alert throws', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValue({ rows: [{ x: 1 }], rowCount: 1 });
+    mockLogToAxiom.mockRejectedValueOnce(new Error('axiom down'));
+    const out = await caller().report({ blockToken: 't', key: 'req-9' });
+    expect(out).toEqual({ ok: true }); // the throwing emit did not fail the report
+  });
+
+  it('block-audit emit is FIRE-AND-FORGET: op still FAILS correctly if the alert throws', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockLogToAxiom.mockRejectedValueOnce(new Error('axiom down'));
+    // minor content → BAD_REQUEST regardless of the emit throwing
+    await expect(
+      caller().append({ blockToken: 't', value: { title: '13 year old girl' } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('a report on a missing row NEVER emits (NOT_FOUND before the alert)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 }); // row does not exist
+    await expect(
+      caller().report({ blockToken: 't', key: 'ghost' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(auditEmits('app-blocks-shared-storage-report')).toHaveLength(0);
   });
 });
 

--- a/src/server/routers/apps-shared.router.ts
+++ b/src/server/routers/apps-shared.router.ts
@@ -380,17 +380,32 @@ export const appsSharedRouter = router({
           // table has no reader yet, so a moderation-blocked append would otherwise
           // be silent. Emit a structured, alertable event (METADATA ONLY — NEVER the
           // content text) so any auto-blocked write is observable before the
-          // mod-queue wiring lands. Widened from minor/POI only to ALSO fire on
-          // `audit` — that path catches the general abuse (harassment / spam that
-          // trips external moderation) now that non-mod app-dev-testers can post
-          // public content; without it that whole class was invisible. `link`/`size`
-          // stay unalerted (user error, not reportable abuse). Fire-and-forget
-          // (`.catch`) — an alert emit must NEVER block or fail the op.
-          if (e.category === 'minor' || e.category === 'poi' || e.category === 'audit') {
+          // mod-queue wiring lands. `link`/`size` stay unalerted (user error, not
+          // reportable abuse). Fire-and-forget (`.catch`) — an alert emit must NEVER
+          // block or fail the op.
+          //
+          // TWO DISTINCT signals (kept separate so the legal-urgency channel is not
+          // diluted): minor/POI are a HARD legal escalation (CSAM/minor) → the
+          // `…-legal-block` / `type:error` event; a general `audit` block (harassment
+          // / spam that trips external moderation) → the lower-urgency
+          // `…-content-block` / `type:warning` event. Same metadata-only shape.
+          if (e.category === 'minor' || e.category === 'poi') {
             logToAxiom(
               {
                 name: 'app-blocks-shared-storage-legal-block',
                 type: 'error',
+                category: e.category,
+                userId: uid,
+                slug,
+                appBlockId,
+              },
+              'block-audit'
+            ).catch(() => {});
+          } else if (e.category === 'audit') {
+            logToAxiom(
+              {
+                name: 'app-blocks-shared-storage-content-block',
+                type: 'warning',
                 category: e.category,
                 userId: uid,
                 slug,
@@ -744,6 +759,26 @@ async function insertSharedReport(
 }
 
 /**
+ * Neutralize Discord markdown in reporter-supplied free text before it is embedded
+ * in a mod-alerts message. A hostile reporter must NOT be able to plant a masked
+ * link `[label](https://phish.example)` (phishing) or other markdown/formatting in
+ * the mod channel. We strip the structural markdown characters — masked-link
+ * brackets/parens `[ ] ( )`, backticks, and emphasis/strike/spoiler/quote markers
+ * `* _ ~ | >` — then collapse whitespace. The caller ALSO wraps the result in an
+ * inline code span (belt-and-suspenders: no markdown, no URL auto-link, and no
+ * mention ping renders inside a code span). Returns a bounded, single-line string.
+ * NOTE: the Axiom copy of `reason` is deliberately left RAW — it is a structured
+ * log field, never rendered, so escaping there would only corrupt the record.
+ */
+export function sanitizeDiscordText(input: string): string {
+  return input
+    .replace(/[`[\]()*_~|>]/g, ' ') // drop markdown / masked-link structural chars
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500);
+}
+
+/**
  * FIX 1 — fire-and-forget mod-Discord notify on a USER report of a shared row.
  * Mirrors the W1 publish-request `notifyModsOfNewRequest` pattern: posts to
  * `DISCORD_WEBHOOK_MOD_ALERTS` if it is set, otherwise a no-op. NEVER throws (a
@@ -775,7 +810,10 @@ async function notifyModsOfSharedReport(opts: {
             { name: 'App block', value: `\`${opts.appBlockId}\``, inline: true },
             { name: 'Reported by', value: `user #${opts.reporterUserId}`, inline: true },
             { name: 'Row key', value: `\`${opts.reportedKey}\`` },
-            { name: 'Reason', value: opts.reason.slice(0, 500) || 'user-report' },
+            // Reporter free text: markdown-neutralized + code-span-wrapped so a
+            // hostile reason can't plant a masked/phishing link in the mod channel
+            // (the other fields are already backtick-wrapped).
+            { name: 'Reason', value: `\`${sanitizeDiscordText(opts.reason) || 'user-report'}\`` },
           ],
           footer: { text: 'App Blocks shared storage' },
           timestamp: new Date().toISOString(),

--- a/src/server/routers/apps-shared.router.ts
+++ b/src/server/routers/apps-shared.router.ts
@@ -354,7 +354,9 @@ export const appsSharedRouter = router({
         });
       }
 
-      // BLOCKING content safety → HTML-escaped, store-ready text.
+      // BLOCKING content safety → RAW, store-ready text (Fix 2: escape-at-rest
+      // removed; XSS is contained at the text-render + opaque-origin-sandbox layers,
+      // never at rest — see shared-content-safety.ts C2 note).
       let safe: { title: string; body?: string };
       try {
         safe = await assertSharedTextSafe({
@@ -374,11 +376,17 @@ export const appsSharedRouter = router({
               reason: `auto:${e.category}`,
             }).catch(() => {});
           }
-          // H-1 (audit): the `shared_kv_reports` table has no reader yet, so the
-          // LEGAL-escalation signal (minor/POI) would otherwise be silent. Emit a
-          // structured, alertable event (NEVER the content) so a CSAM/minor attempt
-          // is observable even before the mod-queue wiring lands (a pre-GA gate).
-          if (e.category === 'minor' || e.category === 'poi') {
+          // FIX 1 (pre-GA gate 1 — make abuse OBSERVABLE): the `shared_kv_reports`
+          // table has no reader yet, so a moderation-blocked append would otherwise
+          // be silent. Emit a structured, alertable event (METADATA ONLY — NEVER the
+          // content text) so any auto-blocked write is observable before the
+          // mod-queue wiring lands. Widened from minor/POI only to ALSO fire on
+          // `audit` — that path catches the general abuse (harassment / spam that
+          // trips external moderation) now that non-mod app-dev-testers can post
+          // public content; without it that whole class was invisible. `link`/`size`
+          // stay unalerted (user error, not reportable abuse). Fire-and-forget
+          // (`.catch`) — an alert emit must NEVER block or fail the op.
+          if (e.category === 'minor' || e.category === 'poi' || e.category === 'audit') {
             logToAxiom(
               {
                 name: 'app-blocks-shared-storage-legal-block',
@@ -600,18 +608,53 @@ export const appsSharedRouter = router({
       blockTokenInput.extend({ key: sharedKeyInput, reason: z.string().max(500).optional() })
     )
     .mutation(async ({ input }) => {
-      const { userId, schema } = await resolveSharedContext(input.blockToken, 'report');
+      const { userId, slug, schema, appBlockId } = await resolveSharedContext(
+        input.blockToken,
+        'report'
+      );
       const uid = userId as number;
       const pool = requireAppsDb();
       const exists = (
         await pool.query(`SELECT 1 FROM ${schema}.shared_kv WHERE key = $1`, [input.key])
       ).rowCount;
       if (!exists) throw new TRPCError({ code: 'NOT_FOUND', message: 'request not found' });
+      const reason = input.reason ?? 'user-report';
       await insertSharedReport(schema, {
         key: input.key,
         reporterUserId: uid,
-        reason: input.reason ?? 'user-report',
+        reason,
       });
+
+      // FIX 1 (pre-GA gate 1 — make abuse OBSERVABLE): a user report previously
+      // filed a `shared_kv_reports` row that NOTHING reads, so ordinary abuse
+      // (harassment / brigading / spam that dodged the auto-audit) was invisible.
+      // Emit a structured, alertable event mirroring the auto-block emit above —
+      // METADATA ONLY (userId / slug / appBlockId / reason / reported key), NEVER the
+      // reported content itself. Fire-and-forget (`.catch`) so a logging outage can
+      // never fail a legitimate report.
+      logToAxiom(
+        {
+          name: 'app-blocks-shared-storage-report',
+          type: 'warning',
+          userId: uid,
+          slug,
+          appBlockId,
+          reason,
+          key: input.key,
+        },
+        'block-audit'
+      ).catch(() => {});
+      // Also fire the mod-Discord notify if the webhook is wired (same pattern as
+      // the W1 publish-request flow). Self-contained + fire-and-forget: never awaited
+      // in a way that can block/fail the report, and swallows its own errors.
+      void notifyModsOfSharedReport({
+        slug,
+        appBlockId,
+        reportedKey: input.key,
+        reporterUserId: uid,
+        reason,
+      });
+
       return { ok: true as const };
     }),
 });
@@ -698,6 +741,58 @@ async function insertSharedReport(
      VALUES ($1, $2, $3, $4)`,
     [`skr_${newUlid()}`, args.key, args.reporterUserId, args.reason]
   );
+}
+
+/**
+ * FIX 1 — fire-and-forget mod-Discord notify on a USER report of a shared row.
+ * Mirrors the W1 publish-request `notifyModsOfNewRequest` pattern: posts to
+ * `DISCORD_WEBHOOK_MOD_ALERTS` if it is set, otherwise a no-op. NEVER throws (a
+ * Discord outage must not affect the report), and the caller does not await it —
+ * so the report op returns immediately. Carries METADATA ONLY: slug / app-block /
+ * reported key / reporter id + the reporter's stated reason (bounded to 500 chars
+ * by the input schema). It does NOT — and cannot — include the reported content
+ * (the op only holds the row key).
+ */
+async function notifyModsOfSharedReport(opts: {
+  slug: string;
+  appBlockId: string;
+  reportedKey: string;
+  reporterUserId: number;
+  reason: string;
+}): Promise<void> {
+  try {
+    const { env } = await import('~/env/server');
+    if (!env.DISCORD_WEBHOOK_MOD_ALERTS) return;
+    const baseUrl = (process.env.NEXTAUTH_URL ?? '').replace(/\/$/, '');
+    const appUrl = baseUrl ? `${baseUrl}/${opts.slug}` : opts.slug;
+    const payload = {
+      embeds: [
+        {
+          title: `Shared-storage report: ${opts.slug}`,
+          url: appUrl,
+          color: 0xe03131,
+          fields: [
+            { name: 'App block', value: `\`${opts.appBlockId}\``, inline: true },
+            { name: 'Reported by', value: `user #${opts.reporterUserId}`, inline: true },
+            { name: 'Row key', value: `\`${opts.reportedKey}\`` },
+            { name: 'Reason', value: opts.reason.slice(0, 500) || 'user-report' },
+          ],
+          footer: { text: 'App Blocks shared storage' },
+          timestamp: new Date().toISOString(),
+        },
+      ],
+    };
+    await fetch(env.DISCORD_WEBHOOK_MOD_ALERTS, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(5_000),
+    }).catch(() => {
+      /* fire and forget */
+    });
+  } catch {
+    /* never let Discord break a report */
+  }
 }
 
 function isForeignKeyViolation(err: unknown): boolean {

--- a/src/server/services/apps/shared-content-safety.ts
+++ b/src/server/services/apps/shared-content-safety.ts
@@ -10,10 +10,23 @@ import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing
  * browsers + host-side surfaces (mod queue, activity feed, notifications). This is
  * the entire new abuse surface, so every `append` runs this SYNCHRONOUSLY before a
  * row can land:
- *   - C2 (stored XSS): shared text is PLAIN TEXT. We HTML-escape on write (store
- *     escaped) so a stored `<script>` can never execute even if a
- *     featured/verified app is later granted `allow-same-origin`. The block still
- *     treats it as untrusted on read; escape-at-rest is the belt.
+ *   - C2 (stored XSS): shared text is PLAIN TEXT and is STORED RAW. Escape-at-rest
+ *     was REMOVED (2026-07 security review): it was the WRONG layer. Apps render the
+ *     value as React TEXT (children) and the host forwards `value` as DATA over
+ *     postMessage — there is NO HTML render path (no `dangerouslySetInnerHTML` /
+ *     `innerHTML` / `.html()` sink consumes it), so escaping only made stored
+ *     entities display LITERALLY (a title `Tom & Jerry <3` rendered as
+ *     `Tom &amp; Jerry &lt;3`). XSS containment now rests on (b) text-render and
+ *     (c) the opaque-origin sandbox — all approved apps are `unverified` → no
+ *     `allow-same-origin`, so even an injected `<script>` runs in an origin that
+ *     can't touch civitai. The raw text is STILL run through the full block below
+ *     (minor/POI/link/audit/size) — only the entity-escape of the stored form is
+ *     gone.
+ *     🔴 GATE-2 (pre-GA): a STRUCTURAL opaque-origin pin MUST be enforced before any
+ *     `verified`/`internal`-tier app is ever granted `apps:storage:shared:*` — a
+ *     verified app receives `allow-same-origin`, and escape-at-rest was the only
+ *     belt for that case. Do not grant a shared scope to a non-`unverified` tier
+ *     until that pin exists.
  *   - C3 (illegal content): `includesMinor` / `includesPoi` are a HARD legal fail
  *     (minor/POI/CSAM signals) — reject + the caller files a Report. Then
  *     `auditPromptServer` runs the full platform audit (regex + external
@@ -51,20 +64,6 @@ export class SharedContentBlockedError extends Error {
   }
 }
 
-/**
- * HTML-escape a plain-text field for storage-at-rest (C2). We STORE the escaped
- * form so the value is inert on every render path. `&` first so we don't
- * double-escape the entities we introduce.
- */
-export function escapeSharedText(input: string): string {
-  return input
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#x27;');
-}
-
 export interface SharedTextSafetyInput {
   title: string;
   body?: string;
@@ -76,8 +75,9 @@ export interface SharedTextSafetyInput {
 
 /**
  * Runs the full BLOCKING safety belt on shared write text. Throws
- * `SharedContentBlockedError` on any block. Returns the HTML-escaped, store-ready
- * `{ title, body }` on success.
+ * `SharedContentBlockedError` on any block. Returns the RAW, store-ready
+ * `{ title, body }` on success (see the C2 note above — the value is stored
+ * un-escaped and XSS is contained at the render + sandbox layers, NOT at rest).
  */
 export async function assertSharedTextSafe(
   input: SharedTextSafetyInput
@@ -129,5 +129,8 @@ export async function assertSharedTextSafe(
     throw new SharedContentBlockedError('audit', message);
   }
 
-  return { title: escapeSharedText(title), body: body != null ? escapeSharedText(body) : undefined };
+  // Store RAW (Fix 2 / 2026-07 security review): escape-at-rest was removed — see
+  // the C2 note. Every safety control above ran on the raw text; the returned value
+  // is the un-escaped, store-ready form.
+  return { title, body: body != null ? body : undefined };
 }


### PR DESCRIPTION
Two content-safety fixes from the security audit of App Blocks **shared** (cross-user, public) storage. Kept as two clearly-separated, commented changes. **No DB migration.**

## FIX 1 — make shared-storage abuse OBSERVABLE (pre-GA gate 1)
Now that non-mod app-dev-testers can post public content, two moderation paths were invisible:
- the `audit`-category auto-block (general moderation: harassment / spam that trips external moderation) filed a `shared_kv_reports` row but emitted **no alert** — only `minor`/`poi` did;
- the USER `report` op filed a `shared_kv_reports` row that **nothing reads**.

Changes (mirror the existing `logToAxiom(..., 'block-audit')` mechanism — **metadata only, never the content text**):
1. Widened the auto-block Axiom emit to **also fire on `category === 'audit'`** (was minor/poi only) — so any moderation-blocked append is observable. `link`/`size` stay unalerted (user error, not abuse).
2. Emit an alertable event on **every user `report`**: `{ name: 'app-blocks-shared-storage-report', userId, slug, appBlockId, reason, key }` (no content — the op only holds the row key; `reason` is the reporter's own words).
3. Added a **fire-and-forget mod-Discord notify** via `DISCORD_WEBHOOK_MOD_ALERTS` on a user report, mirroring the W1 publish-request `notifyModsOfNewRequest` pattern. No-op when the webhook is unset.

All emits are `.catch(() => {})` fire-and-forget and never block/fail the op. No new mod UI/queue was built — the goal is "abuse is observable."

> Note for alerting: the auto-block event `app-blocks-shared-storage-legal-block` now also carries `category: 'audit'` rows. Any downstream alert wanting legal-only (minor/POI) should filter on the `category` field.

## FIX 2 — remove escape-at-rest (store shared text RAW; security-posture change)
`escapeSharedText` HTML-escaped title/body and the append path **stored the escaped form**. Apps render the value as React **text** (children), so stored entities displayed **literally** — a title `Tom & Jerry <3` showed as `Tom &amp; Jerry &lt;3`.

**Escape-at-rest removed — why it's safe:** it was the wrong layer. The real XSS defenses are (b) apps rendering the value as text and (c) the **opaque-origin sandbox** — all approved apps are `unverified` → no `allow-same-origin`, so even an injected `<script>` executes in an origin that can't touch civitai. **Confirmed no server/host path renders the shared `value` as HTML:** `PageBlockHost`/`IframeHost` `SHARED_LIST_RESULT` forward it as **data over postMessage**; there is no `dangerouslySetInnerHTML` / `innerHTML` / `.html()` sink consuming it (grep-verified). The value is now **stored raw**; every other control — length caps, `assertSharedTextSafe`'s `includesMinor`/`includesPoi`, `throwOnBlockedLinkDomain`, `auditPromptServer` — **still runs on the raw text**. `escapeSharedText` had no other callers and was removed.

🔴 **GATE-2 (pre-GA), documented in code:** a **structural opaque-origin pin** MUST be enforced before any `verified`/`internal`-tier app is ever granted `apps:storage:shared:*` — a verified app receives `allow-same-origin`, and escape-at-rest was the only belt for that case.

> Pre-existing rows written before this change still hold escaped entities and will display literally until re-written (feature is flag-dark; no migration per scope).

## Tests (`src/server/routers/__tests__/apps-shared.router.test.ts`)
- **Fix 1:** user `report` emits the report alert (metadata-only, no content) + files the row; an `audit`-category blocked append emits an alert; minor/POI still alert; a successful append emits none; both emit paths are **fire-and-forget** (op succeeds/fails correctly even when the emit throws); a report on a missing row emits nothing (NOT_FOUND first).
- **Fix 2:** `append` stores **raw** title/body — `<`, `&`, `"`, `'` round-trip un-escaped in `shared_kv`; and the other safety checks (minor / blocked-link / audit / oversized) still reject.
- The old "stored ESCAPED" test was replaced by the raw round-trip test.

Local: **48/48 pass** (`vitest run src/server/routers/__tests__/apps-shared.router.test.ts`). Local `tsc` is unreliable here; pr-preview is authoritative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)