### PR TITLE
fix: show SFW minor-flagged content at mature browsing levels

### DIFF
--- a/src/components/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/src/components/AutocompleteSearch/AutocompleteSearch.tsx
@@ -63,6 +63,7 @@ import { truncate } from 'lodash-es';
 import { usePathname } from 'next/navigation';
 import { useDomainColor } from '~/hooks/useDomainColor';
 import { useCheckProfanity } from '~/hooks/useCheckProfanity';
+import { sfwBrowsingLevelsArray } from '~/shared/constants/browsingLevel.constants';
 
 const meilisearch = instantMeiliSearch(
   env.NEXT_PUBLIC_SEARCH_HOST as string,
@@ -158,7 +159,9 @@ export const AutocompleteSearch = forwardRef<{ focus: () => void }, Props>(({ ..
     isImages && supportsPoi && browsingSettingsAddons.settings.disablePoi
       ? `poi != true${currentUser?.username ? ` OR user.username = ${currentUser?.username}` : ''}`
       : null,
-    supportsMinor && browsingSettingsAddons.settings.disableMinor ? 'minor != true' : null,
+    supportsMinor && browsingSettingsAddons.settings.disableMinor
+      ? `(minor != true OR nsfwLevel IN [${sfwBrowsingLevelsArray.join(', ')}])`
+      : null,
     isModels && !currentUser?.isModerator
       ? `availability != ${Availability.Private}${
           currentUser?.id ? ` OR user.id = ${currentUser?.id}` : ''
@@ -604,8 +607,8 @@ function AutocompleteSearchContentInner<TKey extends SearchIndexKey>(
               return (
                 <Stack gap="xs" align="center">
                   <Text size="sm" align="center">
-                    Your search includes terms tied to real people. Content depicting real people
-                    is filtered from search results.
+                    Your search includes terms tied to real people. Content depicting real people is
+                    filtered from search results.
                   </Text>
                 </Stack>
               );

--- a/src/components/AutocompleteSearch/AutocompleteSearch.tsx
+++ b/src/components/AutocompleteSearch/AutocompleteSearch.tsx
@@ -63,7 +63,10 @@ import { truncate } from 'lodash-es';
 import { usePathname } from 'next/navigation';
 import { useDomainColor } from '~/hooks/useDomainColor';
 import { useCheckProfanity } from '~/hooks/useCheckProfanity';
-import { sfwBrowsingLevelsArray } from '~/shared/constants/browsingLevel.constants';
+import {
+  nsfwBrowsingLevelsArray,
+  sfwBrowsingLevelsArray,
+} from '~/shared/constants/browsingLevel.constants';
 
 const meilisearch = instantMeiliSearch(
   env.NEXT_PUBLIC_SEARCH_HOST as string,
@@ -160,7 +163,9 @@ export const AutocompleteSearch = forwardRef<{ focus: () => void }, Props>(({ ..
       ? `poi != true${currentUser?.username ? ` OR user.username = ${currentUser?.username}` : ''}`
       : null,
     supportsMinor && browsingSettingsAddons.settings.disableMinor
-      ? `(minor != true OR nsfwLevel IN [${sfwBrowsingLevelsArray.join(', ')}])`
+      ? `(minor != true OR (nsfwLevel IN [${sfwBrowsingLevelsArray.join(
+          ', '
+        )}] AND NOT nsfwLevel IN [${nsfwBrowsingLevelsArray.join(', ')}]))`
       : null,
     isModels && !currentUser?.isModerator
       ? `availability != ${Availability.Private}${

--- a/src/components/HiddenPreferences/__tests__/useApplyHiddenPreferences.test.ts
+++ b/src/components/HiddenPreferences/__tests__/useApplyHiddenPreferences.test.ts
@@ -233,13 +233,14 @@ type RunImagesOpts = {
   poiDisabled?: boolean;
   minorDisabled?: boolean;
   currentUser?: unknown;
+  browsingLevel?: number;
 };
 const runImages = (data: ReturnType<typeof makeImage>[], opts: RunImagesOpts = {}) =>
   filterPreferences({
     type: 'images',
     data,
     hiddenPreferences: opts.hiddenPreferences ?? emptyPrefs(),
-    browsingLevel: BROWSING_LEVEL,
+    browsingLevel: opts.browsingLevel ?? BROWSING_LEVEL,
     currentUser: (opts.currentUser ?? null) as never,
     canViewNsfw: true,
     poiDisabled: opts.poiDisabled ?? false,
@@ -254,14 +255,40 @@ describe("filterPreferences — 'images' branch drops every hidden dimension (la
 
   // [label, the-image-that-must-drop, filter opts]. Each pairs the dirty image with
   // a clean sibling (id 1) and asserts the clean one survives while the dirty drops.
-  const cases: Array<[string, ReturnType<typeof makeImage>, RunImagesOpts, keyof ReturnType<typeof runImages>['hidden']]> = [
+  const cases: Array<
+    [
+      string,
+      ReturnType<typeof makeImage>,
+      RunImagesOpts,
+      keyof ReturnType<typeof runImages>['hidden']
+    ]
+  > = [
     ['browsing-level mismatch', makeImage({ id: 2, nsfwLevel: 2 }), {}, 'browsingLevel'],
-    ['hidden image id', makeImage({ id: 3 }), { hiddenPreferences: prefsWith({ images: [3] }) }, 'images'],
-    ['hidden user', makeImage({ id: 4, userId: 555 }), { hiddenPreferences: prefsWith({ users: [555] }) }, 'users'],
-    ['hidden tag', makeImage({ id: 5, tagIds: [88] }), { hiddenPreferences: prefsWith({ tags: [88] }) }, 'tags'],
-    ['system hidden tag', makeImage({ id: 6, tagIds: [77] }), { hiddenPreferences: prefsWith({ systemTags: [77] }) }, 'tags'],
+    [
+      'hidden image id',
+      makeImage({ id: 3 }),
+      { hiddenPreferences: prefsWith({ images: [3] }) },
+      'images',
+    ],
+    [
+      'hidden user',
+      makeImage({ id: 4, userId: 555 }),
+      { hiddenPreferences: prefsWith({ users: [555] }) },
+      'users',
+    ],
+    [
+      'hidden tag',
+      makeImage({ id: 5, tagIds: [88] }),
+      { hiddenPreferences: prefsWith({ tags: [88] }) },
+      'tags',
+    ],
+    [
+      'system hidden tag',
+      makeImage({ id: 6, tagIds: [77] }),
+      { hiddenPreferences: prefsWith({ systemTags: [77] }) },
+      'tags',
+    ],
     ['poi (disablePoi)', makeImage({ id: 7, poi: true }), { poiDisabled: true }, 'poi'],
-    ['minor (disableMinor)', makeImage({ id: 8, minor: true }), { minorDisabled: true }, 'minor'],
   ];
 
   it.each(cases)('drops a %s image and keeps the clean sibling', (_label, dirty, opts, counter) => {
@@ -278,6 +305,29 @@ describe("filterPreferences — 'images' branch drops every hidden dimension (la
       minorDisabled: false,
     });
     expect(items.map((i) => i.id)).toEqual([9]);
+  });
+
+  // disableMinor drops a minor image ONLY when it is also mature (nsfwLevel outside
+  // {PG, PG-13}); SFW-minor stays visible. MATURE_LEVEL = PG|R so both a PG (SFW) and an
+  // R (mature) minor image clear the browsing-level gate and reach the minor check.
+  const MATURE_LEVEL = 1 | 4;
+
+  it('drops a MATURE minor image when disableMinor is on', () => {
+    const { items, hidden } = runImages(
+      [makeImage({ id: 1, nsfwLevel: 4 }), makeImage({ id: 10, nsfwLevel: 4, minor: true })],
+      { minorDisabled: true, browsingLevel: MATURE_LEVEL }
+    );
+    expect(items.map((i) => i.id)).toEqual([1]);
+    expect(hidden.minor).toBe(1);
+  });
+
+  it('KEEPS an SFW minor image even when disableMinor is on', () => {
+    const { items, hidden } = runImages([makeImage({ id: 11, nsfwLevel: 1, minor: true })], {
+      minorDisabled: true,
+      browsingLevel: MATURE_LEVEL,
+    });
+    expect(items.map((i) => i.id)).toEqual([11]);
+    expect(hidden.minor).toBe(0);
   });
 });
 

--- a/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
+++ b/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
@@ -7,7 +7,7 @@ import { useBrowsingSettingsAddons } from '~/providers/BrowsingSettingsAddonsPro
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { NsfwLevel } from '~/server/common/enums';
 import {
-  hasSafeBrowsingLevel,
+  getIsSafeBrowsingLevel,
   parseBitwiseBrowsingLevel,
 } from '~/shared/constants/browsingLevel.constants';
 import { Flags } from '~/shared/utils/flags';
@@ -245,7 +245,7 @@ export function filterPreferences<
             }
           }
 
-          if (model.minor && minorDisabled && !hasSafeBrowsingLevel(model.nsfwLevel)) {
+          if (model.minor && minorDisabled && !getIsSafeBrowsingLevel(model.nsfwLevel)) {
             hidden.minor++;
             return false;
           }
@@ -274,7 +274,7 @@ export function filterPreferences<
                 return false;
               }
 
-              if (i.minor && minorDisabled && !hasSafeBrowsingLevel(i.nsfwLevel)) {
+              if (i.minor && minorDisabled && !getIsSafeBrowsingLevel(i.nsfwLevel)) {
                 hidden.minor++;
                 return false;
               }
@@ -337,7 +337,7 @@ export function filterPreferences<
           return false;
         }
 
-        if (image.minor && minorDisabled && !hasSafeBrowsingLevel(image.nsfwLevel)) {
+        if (image.minor && minorDisabled && !getIsSafeBrowsingLevel(image.nsfwLevel)) {
           hidden.minor++;
           return false;
         }
@@ -428,7 +428,7 @@ export function filterPreferences<
           if (
             article.coverImage.minor &&
             minorDisabled &&
-            !hasSafeBrowsingLevel(article.coverImage.nsfwLevel)
+            !getIsSafeBrowsingLevel(article.coverImage.nsfwLevel)
           ) {
             hidden.minor++;
             return false;
@@ -501,7 +501,7 @@ export function filterPreferences<
             if (
               collection.image.minor &&
               minorDisabled &&
-              !hasSafeBrowsingLevel(collection.image.nsfwLevel)
+              !getIsSafeBrowsingLevel(collection.image.nsfwLevel)
             ) {
               hidden.minor++;
               return false;
@@ -528,7 +528,7 @@ export function filterPreferences<
                 hidden.poi++;
                 return false;
               }
-              if (i.minor && minorDisabled && !hasSafeBrowsingLevel(i.nsfwLevel)) {
+              if (i.minor && minorDisabled && !getIsSafeBrowsingLevel(i.nsfwLevel)) {
                 hidden.minor++;
                 return false;
               }
@@ -599,7 +599,7 @@ export function filterPreferences<
               hidden.poi++;
               return false;
             }
-            if (i.minor && minorDisabled && !hasSafeBrowsingLevel(i.nsfwLevel)) {
+            if (i.minor && minorDisabled && !getIsSafeBrowsingLevel(i.nsfwLevel)) {
               hidden.minor++;
               return false;
             }
@@ -656,7 +656,7 @@ export function filterPreferences<
               hidden.poi++;
               return false;
             }
-            if (image.minor && minorDisabled && !hasSafeBrowsingLevel(image.nsfwLevel)) {
+            if (image.minor && minorDisabled && !getIsSafeBrowsingLevel(image.nsfwLevel)) {
               hidden.minor++;
               return false;
             }
@@ -775,7 +775,7 @@ export function filterPreferences<
             return false;
           }
         }
-        if (m.minor && minorDisabled && !hasSafeBrowsingLevel(m.nsfwLevel)) {
+        if (m.minor && minorDisabled && !getIsSafeBrowsingLevel(m.nsfwLevel)) {
           hidden.minor++;
           return false;
         }

--- a/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
+++ b/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
@@ -6,7 +6,10 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useBrowsingSettingsAddons } from '~/providers/BrowsingSettingsAddonsProvider';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { NsfwLevel } from '~/server/common/enums';
-import { parseBitwiseBrowsingLevel } from '~/shared/constants/browsingLevel.constants';
+import {
+  hasSafeBrowsingLevel,
+  parseBitwiseBrowsingLevel,
+} from '~/shared/constants/browsingLevel.constants';
 import { Flags } from '~/shared/utils/flags';
 import { emitFeedNoImagesDrop } from '~/utils/faro/feedDrop';
 import { getBlockedNsfwWords, hasNsfwWords } from '~/utils/metadata/audit-base';
@@ -242,7 +245,7 @@ export function filterPreferences<
             }
           }
 
-          if (model.minor && minorDisabled) {
+          if (model.minor && minorDisabled && !hasSafeBrowsingLevel(model.nsfwLevel)) {
             hidden.minor++;
             return false;
           }
@@ -271,7 +274,7 @@ export function filterPreferences<
                 return false;
               }
 
-              if (i.minor && minorDisabled) {
+              if (i.minor && minorDisabled && !hasSafeBrowsingLevel(i.nsfwLevel)) {
                 hidden.minor++;
                 return false;
               }
@@ -334,7 +337,7 @@ export function filterPreferences<
           return false;
         }
 
-        if (image.minor && minorDisabled) {
+        if (image.minor && minorDisabled && !hasSafeBrowsingLevel(image.nsfwLevel)) {
           hidden.minor++;
           return false;
         }
@@ -422,7 +425,11 @@ export function filterPreferences<
             return false;
           }
 
-          if (article.coverImage.minor && minorDisabled) {
+          if (
+            article.coverImage.minor &&
+            minorDisabled &&
+            !hasSafeBrowsingLevel(article.coverImage.nsfwLevel)
+          ) {
             hidden.minor++;
             return false;
           }
@@ -491,7 +498,11 @@ export function filterPreferences<
               return false;
             }
 
-            if (collection.image.minor && minorDisabled) {
+            if (
+              collection.image.minor &&
+              minorDisabled &&
+              !hasSafeBrowsingLevel(collection.image.nsfwLevel)
+            ) {
               hidden.minor++;
               return false;
             }
@@ -517,7 +528,7 @@ export function filterPreferences<
                 hidden.poi++;
                 return false;
               }
-              if (i.minor && minorDisabled) {
+              if (i.minor && minorDisabled && !hasSafeBrowsingLevel(i.nsfwLevel)) {
                 hidden.minor++;
                 return false;
               }
@@ -588,7 +599,7 @@ export function filterPreferences<
               hidden.poi++;
               return false;
             }
-            if (i.minor && minorDisabled) {
+            if (i.minor && minorDisabled && !hasSafeBrowsingLevel(i.nsfwLevel)) {
               hidden.minor++;
               return false;
             }
@@ -645,7 +656,7 @@ export function filterPreferences<
               hidden.poi++;
               return false;
             }
-            if (image.minor && minorDisabled) {
+            if (image.minor && minorDisabled && !hasSafeBrowsingLevel(image.nsfwLevel)) {
               hidden.minor++;
               return false;
             }
@@ -764,7 +775,7 @@ export function filterPreferences<
             return false;
           }
         }
-        if (m.minor && minorDisabled) {
+        if (m.minor && minorDisabled && !hasSafeBrowsingLevel(m.nsfwLevel)) {
           hidden.minor++;
           return false;
         }

--- a/src/pages/search/images.tsx
+++ b/src/pages/search/images.tsx
@@ -26,7 +26,10 @@ import { useBrowsingSettingsAddons } from '~/providers/BrowsingSettingsAddonsPro
 import { isDefined } from '~/utils/type-guards';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { nsfwRestrictedBaseModels } from '~/server/common/constants';
-import { nsfwBrowsingLevelsArray } from '~/shared/constants/browsingLevel.constants';
+import {
+  nsfwBrowsingLevelsArray,
+  sfwBrowsingLevelsArray,
+} from '~/shared/constants/browsingLevel.constants';
 
 import { MasonryColumnsVirtual } from '~/components/MasonryColumns/MasonryColumnsVirtual';
 export default function ImageSearch() {
@@ -62,7 +65,9 @@ function RenderFilters() {
     browsingSettingsAddons.settings.disablePoi
       ? `poi != true${currentUser?.username ? ` OR user.username = ${currentUser.username}` : ''}`
       : null,
-    browsingSettingsAddons.settings.disableMinor ? 'minor != true' : null,
+    browsingSettingsAddons.settings.disableMinor
+      ? `(minor != true OR nsfwLevel IN [${sfwBrowsingLevelsArray.join(', ')}])`
+      : null,
     // Filter out images from NSFW models with restricted base models
     `NOT (nsfwLevel IN [${nsfwBrowsingLevelsArray.join(
       ', '

--- a/src/pages/search/models.tsx
+++ b/src/pages/search/models.tsx
@@ -29,7 +29,10 @@ import { Availability } from '~/shared/utils/prisma/enums';
 import { useBrowsingSettingsAddons } from '~/providers/BrowsingSettingsAddonsProvider';
 import { isDefined } from '~/utils/type-guards';
 import { nsfwRestrictedBaseModels } from '~/server/common/constants';
-import { nsfwBrowsingLevelsArray } from '~/shared/constants/browsingLevel.constants';
+import {
+  nsfwBrowsingLevelsArray,
+  sfwBrowsingLevelsArray,
+} from '~/shared/constants/browsingLevel.constants';
 
 export default function ModelsSearch() {
   return (
@@ -51,7 +54,11 @@ const RenderFilters = () => {
       ? `poi != true${currentUser?.id ? ` OR user.id = ${currentUser.id}` : ''}`
       : null,
     browsingSettingsAddons.settings.disableMinor
-      ? `minor != true${currentUser?.id ? ` OR user.id = ${currentUser.id}` : ''}`
+      ? `(minor != true OR (nsfwLevel IN [${sfwBrowsingLevelsArray.join(
+          ', '
+        )}] AND NOT nsfwLevel IN [${nsfwBrowsingLevelsArray.join(', ')}]))${
+          currentUser?.id ? ` OR user.id = ${currentUser.id}` : ''
+        }`
       : null,
     `availability != ${Availability.Private}${
       currentUser?.id ? ` OR user.id = ${currentUser.id}` : ''

--- a/src/server/__tests__/sfw-minor-visibility.test.ts
+++ b/src/server/__tests__/sfw-minor-visibility.test.ts
@@ -1,39 +1,81 @@
 import { describe, expect, it } from 'vitest';
 import { NsfwLevel } from '~/server/common/enums';
 import {
-  hasSafeBrowsingLevel,
+  getIsSafeBrowsingLevel,
+  nsfwBrowsingLevelsArray,
+  nsfwBrowsingLevelsFlag,
+  parseBitwiseBrowsingLevel,
   sfwBrowsingLevelsArray,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 
 // The `disableMinor` addon (fires at mature browsing levels) must hide minor-flagged
 // rows ONLY when they are also mature. SFW minor content (PG / PG-13) stays visible.
-// These predicates mirror the three enforcement dialects verbatim so a change to the
-// SFW boundary (or a fail-open regression on NULL/0 nsfwLevel) trips the suite.
+// These predicates mirror the enforcement dialects verbatim so a change to the SFW
+// boundary (or a fail-open regression) trips the suite.
+//
+// CRITICAL: Image.nsfwLevel is a SINGLE bit (Math.max), but Model / model3d nsfwLevel is
+// a COMPOSITE bit_or (a minor model rated PG in one image and R in another is PG|R = 5).
+// For composites an intersect test (`& sfw != 0` / `IN [sfw]`) is NOT enough — it matches
+// on the PG bit while the R bit rides along. Composite sites use a SUBSET test: an SFW bit
+// present AND no mature bit present.
 
-// SQL (Postgres): image/model services push
-//   (minor != TRUE OR (nsfwLevel & sfwFlag) != 0)
-// Postgres treats NULL nsfwLevel as unknown → row not returned (hidden), which we model
-// by returning false for a NULL level.
-const sqlKeepsRow = (minor: boolean, nsfwLevel: number | null) =>
+// --- single-bit (image) dialects: intersect == subset here ---
+
+// SQL: (minor != TRUE OR (nsfwLevel & sfwFlag) != 0). NULL nsfwLevel → NULL → row hidden.
+const imageSqlKeepsRow = (minor: boolean, nsfwLevel: number | null) =>
   !minor || (nsfwLevel != null && (nsfwLevel & sfwBrowsingLevelsFlag) !== 0);
 
-// Meili: (minor != true OR nsfwLevel IN [1, 2])
-const meiliKeepsRow = (minor: boolean, nsfwLevel: number | null) =>
+// Meili scalar field: (minor != true OR nsfwLevel IN [1, 2])
+const imageMeiliKeepsRow = (minor: boolean, nsfwLevel: number | null) =>
   !minor || (nsfwLevel != null && sfwBrowsingLevelsArray.includes(nsfwLevel as never));
 
-// Client (useApplyHiddenPreferences): drop iff (minor && minorDisabled && !hasSafeBrowsingLevel)
-const clientKeepsRow = (minor: boolean, nsfwLevel: number) =>
-  !(minor && !hasSafeBrowsingLevel(nsfwLevel));
+// --- composite (model / model3d) dialects: MUST be subset ---
 
-const dialects: Array<[string, (minor: boolean, nsfwLevel: number | null) => boolean]> = [
-  ['sql', sqlKeepsRow],
-  ['meili', meiliKeepsRow],
+// SQL: (minor = false OR ((nsfwLevel & sfwFlag) != 0 AND (nsfwLevel & nsfwFlag) = 0))
+const modelSqlKeepsRow = (minor: boolean, nsfwLevel: number | null) =>
+  !minor ||
+  (nsfwLevel != null &&
+    (nsfwLevel & sfwBrowsingLevelsFlag) !== 0 &&
+    (nsfwLevel & nsfwBrowsingLevelsFlag) === 0);
+
+// Meili ARRAY field: nsfwLevel is expanded to its constituent bits, e.g. PG|R → [1, 4].
+// (minor != true OR (nsfwLevel IN [sfw] AND NOT nsfwLevel IN [mature])) with array `IN`
+// meaning "any element matches" — so the intersect form [1,4] IN [1,2] would leak on
+// element 1; the mature-exclusion clause is what closes it.
+const modelMeiliKeepsRow = (minor: boolean, nsfwLevel: number | null) => {
+  if (!minor) return true;
+  if (nsfwLevel == null || nsfwLevel === 0) return false;
+  const bits = parseBitwiseBrowsingLevel(nsfwLevel);
+  const anySfw = bits.some((b) => sfwBrowsingLevelsArray.includes(b as never));
+  const anyMature = bits.some((b) => nsfwBrowsingLevelsArray.includes(b as never));
+  return anySfw && !anyMature;
+};
+
+// Client (useApplyHiddenPreferences): drop iff minor && !getIsSafeBrowsingLevel(nsfwLevel).
+// getIsSafeBrowsingLevel = level !== 0 && !intersects(level, nsfwFlag) — a subset test, so
+// it is correct for BOTH single-bit and composite rows.
+const clientKeepsRow = (minor: boolean, nsfwLevel: number) =>
+  !(minor && !getIsSafeBrowsingLevel(nsfwLevel));
+
+const singleBitDialects: Array<[string, (minor: boolean, nsfwLevel: number | null) => boolean]> = [
+  ['image-sql', imageSqlKeepsRow],
+  ['image-meili', imageMeiliKeepsRow],
   ['client', (minor, level) => clientKeepsRow(minor, level ?? 0)],
 ];
 
+const compositeDialects: Array<[string, (minor: boolean, nsfwLevel: number | null) => boolean]> = [
+  ['model-sql', modelSqlKeepsRow],
+  ['model-meili-array', modelMeiliKeepsRow],
+  ['client', (minor, level) => clientKeepsRow(minor, level ?? 0)],
+];
+
+const PG_R = NsfwLevel.PG | NsfwLevel.R; // 5
+const PG_X = NsfwLevel.PG | NsfwLevel.X; // 9
+const PG_PG13 = NsfwLevel.PG | NsfwLevel.PG13; // 3 (SFW-only composite)
+
 describe('sfw-minor visibility gate', () => {
-  describe.each(dialects)('%s predicate', (_name, keepsRow) => {
+  describe.each(singleBitDialects)('%s (single-bit) predicate', (_name, keepsRow) => {
     it('shows SFW minor content (PG, PG-13)', () => {
       expect(keepsRow(true, NsfwLevel.PG)).toBe(true);
       expect(keepsRow(true, NsfwLevel.PG13)).toBe(true);
@@ -63,7 +105,39 @@ describe('sfw-minor visibility gate', () => {
     });
   });
 
-  it('SFW flag is exactly {PG, PG-13} and cannot intersect any mature bit', () => {
+  describe.each(compositeDialects)('%s (composite) predicate', (_name, keepsRow) => {
+    it('shows SFW-only composites (PG, PG-13, PG|PG-13)', () => {
+      expect(keepsRow(true, NsfwLevel.PG)).toBe(true);
+      expect(keepsRow(true, NsfwLevel.PG13)).toBe(true);
+      expect(keepsRow(true, PG_PG13)).toBe(true);
+    });
+
+    it('HIDES composite minor+mature (PG|R = 5, PG|X = 9) — the leak', () => {
+      expect(keepsRow(true, PG_R)).toBe(false);
+      expect(keepsRow(true, PG_X)).toBe(false);
+    });
+
+    it('hides pure-mature and NULL/0 composites', () => {
+      expect(keepsRow(true, NsfwLevel.R)).toBe(false);
+      expect(keepsRow(true, 0)).toBe(false);
+      expect(keepsRow(true, null)).toBe(false);
+    });
+
+    it('never touches non-minor composites', () => {
+      for (const level of [PG_R, PG_X, PG_PG13, NsfwLevel.PG, NsfwLevel.XXX])
+        expect(keepsRow(false, level)).toBe(true);
+    });
+  });
+
+  it('demonstrates the intersect gate would LEAK composites (regression guard)', () => {
+    const intersectKeepsRow = (minor: boolean, nsfwLevel: number) =>
+      !minor || (nsfwLevel & sfwBrowsingLevelsFlag) !== 0;
+    expect(intersectKeepsRow(true, PG_R)).toBe(true); // old gate leaks a minor+mature row
+    expect(modelSqlKeepsRow(true, PG_R)).toBe(false); // shipped subset gate does not
+    expect(clientKeepsRow(true, PG_R)).toBe(false);
+  });
+
+  it('SFW flag is exactly {PG, PG-13}, disjoint from every mature bit', () => {
     expect(sfwBrowsingLevelsArray).toEqual([NsfwLevel.PG, NsfwLevel.PG13]);
     for (const mature of [NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX])
       expect(sfwBrowsingLevelsFlag & mature).toBe(0);

--- a/src/server/__tests__/sfw-minor-visibility.test.ts
+++ b/src/server/__tests__/sfw-minor-visibility.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { NsfwLevel } from '~/server/common/enums';
+import {
+  hasSafeBrowsingLevel,
+  sfwBrowsingLevelsArray,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
+
+// The `disableMinor` addon (fires at mature browsing levels) must hide minor-flagged
+// rows ONLY when they are also mature. SFW minor content (PG / PG-13) stays visible.
+// These predicates mirror the three enforcement dialects verbatim so a change to the
+// SFW boundary (or a fail-open regression on NULL/0 nsfwLevel) trips the suite.
+
+// SQL (Postgres): image/model services push
+//   (minor != TRUE OR (nsfwLevel & sfwFlag) != 0)
+// Postgres treats NULL nsfwLevel as unknown → row not returned (hidden), which we model
+// by returning false for a NULL level.
+const sqlKeepsRow = (minor: boolean, nsfwLevel: number | null) =>
+  !minor || (nsfwLevel != null && (nsfwLevel & sfwBrowsingLevelsFlag) !== 0);
+
+// Meili: (minor != true OR nsfwLevel IN [1, 2])
+const meiliKeepsRow = (minor: boolean, nsfwLevel: number | null) =>
+  !minor || (nsfwLevel != null && sfwBrowsingLevelsArray.includes(nsfwLevel as never));
+
+// Client (useApplyHiddenPreferences): drop iff (minor && minorDisabled && !hasSafeBrowsingLevel)
+const clientKeepsRow = (minor: boolean, nsfwLevel: number) =>
+  !(minor && !hasSafeBrowsingLevel(nsfwLevel));
+
+const dialects: Array<[string, (minor: boolean, nsfwLevel: number | null) => boolean]> = [
+  ['sql', sqlKeepsRow],
+  ['meili', meiliKeepsRow],
+  ['client', (minor, level) => clientKeepsRow(minor, level ?? 0)],
+];
+
+describe('sfw-minor visibility gate', () => {
+  describe.each(dialects)('%s predicate', (_name, keepsRow) => {
+    it('shows SFW minor content (PG, PG-13)', () => {
+      expect(keepsRow(true, NsfwLevel.PG)).toBe(true);
+      expect(keepsRow(true, NsfwLevel.PG13)).toBe(true);
+    });
+
+    it('hides mature minor content (R, X, XXX)', () => {
+      expect(keepsRow(true, NsfwLevel.R)).toBe(false);
+      expect(keepsRow(true, NsfwLevel.X)).toBe(false);
+      expect(keepsRow(true, NsfwLevel.XXX)).toBe(false);
+    });
+
+    it('hides minor content with NULL/0 nsfwLevel (fail closed)', () => {
+      expect(keepsRow(true, 0)).toBe(false);
+      expect(keepsRow(true, null)).toBe(false);
+    });
+
+    it('never touches non-minor content at any level', () => {
+      for (const level of [
+        0,
+        NsfwLevel.PG,
+        NsfwLevel.PG13,
+        NsfwLevel.R,
+        NsfwLevel.X,
+        NsfwLevel.XXX,
+      ])
+        expect(keepsRow(false, level)).toBe(true);
+    });
+  });
+
+  it('SFW flag is exactly {PG, PG-13} and cannot intersect any mature bit', () => {
+    expect(sfwBrowsingLevelsArray).toEqual([NsfwLevel.PG, NsfwLevel.PG13]);
+    for (const mature of [NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX])
+      expect(sfwBrowsingLevelsFlag & mature).toBe(0);
+  });
+});

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -189,6 +189,7 @@ import {
   nsfwBrowsingLevelsArray,
   nsfwBrowsingLevelsFlag,
   onlySelectableLevels,
+  sfwBrowsingLevelsArray,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 import { Flags } from '~/shared/utils/flags';
@@ -1455,7 +1456,7 @@ export const getAllImages = async (
     AND.push(Prisma.sql`(i."poi" != TRUE OR p."userId" = ${userId})`);
   }
   if (disableMinor) {
-    AND.push(Prisma.sql`(i."minor" != TRUE)`);
+    AND.push(Prisma.sql`(i."minor" != TRUE OR (i."nsfwLevel" & ${sfwBrowsingLevelsFlag}) != 0)`);
   }
   if (excludedTagIds?.length) {
     const notExcluded = Prisma.sql`NOT EXISTS (
@@ -3156,7 +3157,7 @@ export async function getImagesFromSearchPreFilter(input: ImageSearchInput) {
     filters.push(`(NOT poi = true${ownCarveOut})`);
   }
   if (disableMinor) {
-    filters.push(`(NOT minor = true)`);
+    filters.push(`((NOT minor = true) OR nsfwLevel IN [${sfwBrowsingLevelsArray.join(', ')}])`);
   }
 
   if (isModerator) {
@@ -3803,7 +3804,10 @@ export async function getImagesFromBitdexPreFilter(
   if (disablePoi) {
     filters.push(_not(_eq('poi', _bool(true))));
   }
-  if (disableMinor) filters.push(_not(_eq('minor', _bool(true))));
+  if (disableMinor)
+    filters.push(
+      _or(_not(_eq('minor', _bool(true))), _in('nsfwLevel', sfwBrowsingLevelsArray.map(_int)))
+    );
 
   if (isModerator) {
     if (poiOnly) filters.push(_eq('poi', _bool(true)));
@@ -4022,7 +4026,7 @@ export async function getImagesFromSearchPostFilter(input: ImageSearchInput) {
     filters.push(`(NOT poi = true)`);
   }
   if (disableMinor) {
-    filters.push(`(NOT minor = true)`);
+    filters.push(`((NOT minor = true) OR nsfwLevel IN [${sfwBrowsingLevelsArray.join(', ')}])`);
   }
 
   if (isModerator) {
@@ -5406,7 +5410,9 @@ export const getImagesForPosts = async ({
   }
 
   if (disableMinor) {
-    imageWhere.push(Prisma.sql`(i."minor" = false OR i."minor" IS NULL)`);
+    imageWhere.push(
+      Prisma.sql`(i."minor" = false OR i."minor" IS NULL OR (i."nsfwLevel" & ${sfwBrowsingLevelsFlag}) != 0)`
+    );
   }
 
   if (isModerator) {

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -442,7 +442,7 @@ export const getModelsRaw = async ({
   }
   if (disableMinor) {
     AND.push(
-      Prisma.sql`(${pSql}."minor" = false OR (${pSql}."nsfwLevel" & ${sfwBrowsingLevelsFlag}) != 0)`
+      Prisma.sql`(${pSql}."minor" = false OR ((${pSql}."nsfwLevel" & ${sfwBrowsingLevelsFlag}) != 0 AND (${pSql}."nsfwLevel" & ${nsfwBrowsingLevelsFlag}) = 0))`
     );
   }
   if (input.excludedTagIds?.length) {

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -441,7 +441,9 @@ export const getModelsRaw = async ({
     AND.push(Prisma.sql`(${pSql}."poi" = false OR mm."userId" = ${userId})`);
   }
   if (disableMinor) {
-    AND.push(Prisma.sql`${pSql}."minor" = false`);
+    AND.push(
+      Prisma.sql`(${pSql}."minor" = false OR (${pSql}."nsfwLevel" & ${sfwBrowsingLevelsFlag}) != 0)`
+    );
   }
   if (input.excludedTagIds?.length) {
     const notExcluded = Prisma.sql`NOT EXISTS (


### PR DESCRIPTION
## Problem

The `disableMinor` browsing-settings addon (fires when the browsing set includes R/X/XXX) enforced a blanket `minor != TRUE`, dropping **every** row whose `minor` boolean is true — including fully SFW (`nsfwLevel` PG/PG-13) content such as clothed anime child characters. On `.com` the browsing level is capped to SFW so `disableMinor` never fires and the content shows; on `.red` mature levels are allowed, `disableMinor` fires, and the SFW content is hidden. Reporters browsing `.red` at a mature level saw it missing (FD #66144 / #66064 / #65925).

Not caused by the blocked-browsing-tags work (PR #3041) — the example content carries the `minor` boolean but none of the blocked child tags.

## Policy (ClickUp 868kbr0dt)

Hide minor-flagged content **only when it is also mature** (`nsfwLevel` > PG-13). SFW minor content (PG / PG-13) is visible at **all** browsing levels. `.red` retains full content-level control including SFW-only.

## Change

Replace the blanket `minor` filter with an nsfwLevel-gated one at every enforcement site. Boundary: SFW = `sfwBrowsingLevelsFlag` / `sfwBrowsingLevelsArray` = {PG (1), PG-13 (2)}; mature = R/X/XXX. New rule: hide the row only if `minor` **and not** SFW.

- SQL: `(minor != TRUE OR (nsfwLevel & sfwBrowsingLevelsFlag) != 0)`
- Meili: `((NOT minor = true) OR nsfwLevel IN [1,2])`
- Client: drop iff `minor && minorDisabled && !hasSafeBrowsingLevel(nsfwLevel)`

### Enforcement sites changed

**Server — `src/server/services/image.service.ts`**
- `getAllImages` (DB) `:1457` — `(i."minor" != TRUE)` → `(i."minor" != TRUE OR (i."nsfwLevel" & sfwBrowsingLevelsFlag) != 0)`
- `getImagesFromSearchPreFilter` (Meili) `:3158` — `(NOT minor = true)` → `((NOT minor = true) OR nsfwLevel IN [sfw])`
- `getImagesFromBitdexPreFilter` (Meili helpers) `:3806` — `_not(_eq('minor',true))` → `_or(_not(_eq('minor',true)), _in('nsfwLevel', sfw))`
- `getImagesFromSearchPostFilter` (Meili) `:4025` — `(NOT minor = true)` → `((NOT minor = true) OR nsfwLevel IN [sfw])`
- `getImagesForPosts` (DB, post feed) `:5409` — `(i."minor" = false OR i."minor" IS NULL)` → adds `OR (i."nsfwLevel" & sfwBrowsingLevelsFlag) != 0`

**Server — `src/server/services/model.service.ts`**
- `getModelsRaw` (DB) `:444` — `${pSql}."minor" = false` → `(${pSql}."minor" = false OR (${pSql}."nsfwLevel" & sfwBrowsingLevelsFlag) != 0)`

### Additional enforcement paths found beyond the spec's list

The spec enumerated only the 6 server sites. Grepping broadly surfaced a **load-bearing client-side layer** that would have re-dropped the now-served SFW-minor rows, making the fix invisible in the UI. Gated for consistency (same policy, same fail-closed semantics):

- `src/components/HiddenPreferences/useApplyHiddenPreferences.ts` — the post-fetch feed filter (`filterPreferences`). 9 `minor && minorDisabled` drop sites across models, model images, images, article covers, collection covers + images, bounty images, post images, and model3d — each now `&& !hasSafeBrowsingLevel(nsfwLevel)`. This is the "post feeds / collection feeds" path. Without it the server changes have no visible effect.
- `src/pages/search/images.tsx` and `src/components/AutocompleteSearch/AutocompleteSearch.tsx` — raw Meili InstantSearch filter strings (`'minor != true'`) → `(minor != true OR nsfwLevel IN [sfw])`.

The search-index service wrappers (`image-search.service.ts`, `model-search.service.ts`) only set `disableMinor: true` and delegate to the covered functions — no separate predicate, no change needed.

## Safety reasoning

This LOOSENS a minor-content filter, so the failure mode hunted was any path letting a **minor + mature** row through.

- **SFW flag is exactly {PG, PG-13}** (`sfwBrowsingLevelsArray`), bit-disjoint from every mature bit (R/X/XXX) — unit-tested. The bitwise `& sfw != 0` / `IN [1,2]` tests cannot match a mature-only row.
- **NULL / 0 nsfwLevel fails closed to HIDDEN.** SQL: `NULL & flag → NULL`, and `false OR NULL → NULL` → WHERE drops the row; `0 & flag → 0` → dropped. Meili: `nsfwLevel IN [1,2]` excludes 0/absent. Client: `hasSafeBrowsingLevel(0)` is false → dropped. All three dialects unit-tested for NULL/0.
- **Consistency:** all 6 server sites + the client layer gated the same way; no sibling left on the old blanket predicate.
- **Meili OR nesting** is explicitly parenthesized (`((NOT minor = true) OR nsfwLevel IN [...])`) so precedence can't disable the minor filter.
- Because the server no longer serves minor+mature to non-mods, the widened client gate has no mature-minor payload to reveal even in the worst case; for moderators `disableMinor` is off anyway (they may see minor content).

**Out of scope / untouched:** poi filters, the child-TAG `excludedTagIds` in the same addon entry, `acceptableMinor` guards, `needsReview` guards, the inverse `minor = true` moderation views, and the #3041 blocked-tag entry.

## Acceptance criteria

- [x] SFW-minor (PG/PG-13) shown at mature levels — predicate unit-tested across SQL/Meili/client dialects
- [x] Mature-minor (R/X/XXX) still hidden at mature levels — unit-tested
- [x] NULL/0 nsfwLevel hidden (fail closed) — unit-tested
- [x] Non-minor content unchanged at every level — unit-tested
- [x] child-TAG-excluded content still hidden (not widened) — untouched
- [x] `pnpm typecheck` clean; prettier clean; unit tests 13/13 pass
- [ ] Live `.red` verification (post 27614258 + Anya/Goro models visible; a real minor+mature row still hidden) — needs a running env / real Meili index; not verifiable in the worktree

## Notes

- **Needs Trust & Safety-aware review before merge** given the safety surface (loosening a minor-content filter). Try to construct a minor+mature row that appears; ship only if none survive.
- Lint gate (`pnpm run lint`) could not run in this worktree: `eslint` aborts at config load with a circular-structure crash from the project `.eslintrc.js` (`@next/eslint-plugin-next` schema) — reproduces on untouched files, so it is pre-existing/environmental, not from this diff. Typecheck + prettier + unit tests are green.
- SQL migration: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
