### PR TITLE
perf(search): drop exact COUNT on creator-search query path

### DIFF
--- a/src/server/services/__tests__/get-creators-count-cache.service.test.ts
+++ b/src/server/services/__tests__/get-creators-count-cache.service.test.ts
@@ -1,23 +1,30 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Tests for the getCreators count cache (perf fix for the slow /api/v1/creators).
+// Tests for the getCreators count path (perf fixes for the slow /api/v1/creators).
 //
-// EXPLAIN ANALYZE proved the `dbRead.user.count({ where })` in the `count:true`
-// branch dominates the endpoint (~1174ms — it scans the whole ~892k-row Model
-// table). The total-creators count is a slowly-moving aggregate, so the count is
-// wrapped in `fetchThroughCache` (fail-open) keyed only by the parts of `where`
-// that vary: `query` (username contains) and `excludeIds`.
+// Two perf fixes coexist here, split by whether `query` (username search) is set:
 //
-// The count is cached ONLY for the hot default listing (no `query`). `query` is
-// user-controlled (public endpoint, no schema max) and interpolated raw into the
-// cache key, so caching per-query would mint unbounded distinct Redis keys — a
-// keyspace-growth vector. So a username-search (`query` truthy) runs the count
-// inline and never touches the cache. The no-query key is `excludeIds`-only.
+//  1. NO-QUERY BROWSE path — cached exact count. EXPLAIN ANALYZE proved the
+//     `dbRead.user.count({ where })` in the `count:true` branch dominates the
+//     endpoint (~1174ms — it scans the whole ~900k-row Model table). The
+//     total-creators count is a slowly-moving aggregate, so it's wrapped in
+//     `fetchThroughCache` (fail-open) keyed only by `excludeIds` (the only
+//     varying part of `where` on the browse path).
+//
+//  2. QUERY (username-search) path — the exact COUNT is DROPPED entirely. The
+//     search count is pathological (`username LIKE '%q%'` ∩ `models: { some }` →
+//     full Model-table scan → ~90k nested-loop probes into User, ~800ms–1.4s on
+//     EVERY keystroke request) and uncacheable (user-controlled `query`, no
+//     schema max → unbounded keyspace). Instead we over-fetch `take + 1` rows and
+//     return a `hasMore` boolean; the controller maps that to lower-bound
+//     pagination metadata. NO `dbRead.user.count` runs on the query path.
 //
 // These tests exercise:
 //   - no-query MISS  → runs dbRead.user.count once and returns the value
 //   - no-query HIT   → same excludeIds does NOT call dbRead.user.count again
-//   - WITH query     → count is NOT cached; dbRead.user.count runs every call
+//   - WITH query     → count is NEVER run; take+1 hasMore probe drives pagination
+//   - take+1 boundary → exactly `take` rows ⇒ hasMore=false; `take+1` ⇒
+//     hasMore=true, items trimmed back to `take`
 //   - key VARIES by excludeIds (different inputs → separate counts)
 //   - count:false/unset → never touches the count cache
 //   - cache-throws fallback → a fetchThroughCache throw still returns a correct
@@ -123,21 +130,53 @@ describe('getCreators — count cache', () => {
     expect(mockDb.user.count).toHaveBeenCalledTimes(1);
   });
 
-  it('WITH query: count is NOT cached — dbRead.user.count runs on every call', async () => {
-    // `query` is user-controlled with no schema max → caching per-query would mint
-    // unbounded keys. So the username-search count runs inline and never consults
-    // the cache: two calls with the SAME query both invoke dbRead.user.count, and
-    // nothing is written to the cache store.
-    mockDb.user.count.mockResolvedValueOnce(10).mockResolvedValueOnce(11);
+  it('WITH query: the exact COUNT is dropped — dbRead.user.count is NEVER called', async () => {
+    // The username-search count is pathological + uncacheable, so the query path
+    // drops it entirely and derives pagination from a take+1 over-fetch. No count
+    // runs, and the cache machinery is never consulted.
+    mockDb.user.findMany.mockResolvedValueOnce([{ username: 'a' }, { username: 'b' }]);
 
-    const a = await getCreators({ select, count: true, excludeIds: [-1], query: 'foo' });
-    const b = await getCreators({ select, count: true, excludeIds: [-1], query: 'foo' });
+    const result = await getCreators({ select, count: true, excludeIds: [-1], query: 'foo', take: 20 });
 
-    expect(a.count).toBe(10);
-    expect(b.count).toBe(11);
-    expect(mockDb.user.count).toHaveBeenCalledTimes(2);
-    // The cache machinery was never consulted for a query'd request.
+    expect(mockDb.user.count).not.toHaveBeenCalled();
     expect(cacheStore.size).toBe(0);
+    // Returns a hasMore boolean instead of a count.
+    expect(result).not.toHaveProperty('count');
+    expect(result).toHaveProperty('hasMore');
+  });
+
+  it('WITH query, take+1 boundary: fewer than take+1 rows ⇒ hasMore=false, items untrimmed', async () => {
+    // take=3 and exactly 3 rows returned (no +1 sentinel) → this is the last page.
+    mockDb.user.findMany.mockResolvedValueOnce([
+      { username: 'a' },
+      { username: 'b' },
+      { username: 'c' },
+    ]);
+
+    const result = await getCreators({ select, count: true, excludeIds: [-1], query: 'foo', take: 3 });
+
+    // over-fetched take+1 = 4 rows
+    expect(mockDb.user.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 4 }));
+    expect((result as { hasMore: boolean }).hasMore).toBe(false);
+    expect(result.items).toHaveLength(3);
+  });
+
+  it('WITH query, take+1 boundary: take+1 rows ⇒ hasMore=true, items trimmed back to take', async () => {
+    // take=3 and 4 rows returned (the +1 sentinel) → there IS another page; the
+    // sentinel row is trimmed off the returned items.
+    mockDb.user.findMany.mockResolvedValueOnce([
+      { username: 'a' },
+      { username: 'b' },
+      { username: 'c' },
+      { username: 'd' },
+    ]);
+
+    const result = await getCreators({ select, count: true, excludeIds: [-1], query: 'foo', take: 3 });
+
+    expect(mockDb.user.findMany).toHaveBeenCalledWith(expect.objectContaining({ take: 4 }));
+    expect((result as { hasMore: boolean }).hasMore).toBe(true);
+    expect(result.items).toHaveLength(3);
+    expect(result.items).toEqual([{ username: 'a' }, { username: 'b' }, { username: 'c' }]);
   });
 
   it('cache key VARIES by excludeIds → separate counts', async () => {

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -720,8 +720,12 @@ export const getCreators = async <TSelect extends Prisma.UserSelect>({
     id: excludeIds.length ? { notIn: excludeIds } : undefined,
     deletedAt: null,
   };
+  // On the username-search (query) path we replace the exact COUNT with a take+1
+  // "hasMore" probe (see the comment in the `count` block below): over-fetch one
+  // row so we can tell whether another page exists without running an aggregate.
+  const useHasMore = count && !!query && take != null;
   const items = await dbRead.user.findMany({
-    take,
+    take: useHasMore ? (take as number) + 1 : take,
     skip,
     select,
     where,
@@ -729,25 +733,37 @@ export const getCreators = async <TSelect extends Prisma.UserSelect>({
   });
 
   if (count) {
-    // The count scans the whole ~892k-row Model table (index-only scan on
-    // Model_userId → HashAggregate distinct userIds → nested-loop to User,
-    // ~1174ms in EXPLAIN ANALYZE) on EVERY request and dominates this endpoint's
-    // latency. It's a slowly-moving aggregate, so cache it: a few-minutes-stale
-    // totalItems/totalPages is harmless. Cache unconditionally (no IS_DATAPACKET
-    // gate) — the 892k-row scan is expensive on every cluster. TTL = 10min
-    // (CacheTTL.md): cheap-to-refresh, bounds staleness to a sub-page drift on an
-    // ~86.5k-creator total.
+    // ── Username-search path (query present): DROP the exact COUNT ────────────
+    // The search count is pathological. `where.username = { contains: query }`
+    // compiles to `username LIKE '%query%'` (a leading wildcard no btree can
+    // serve) intersected with `models: { some: {} }`. Both sides are
+    // non-selective (~90k model-owners, tens-of-thousands of `%q%` matches) with
+    // a tiny intersection, so the planner scans the whole ~900k-row Model table →
+    // HashAggregate to ~90k distinct owners → nested-loop into User applying the
+    // LIKE as a filter: ~800ms–1.4s on EVERY keystroke-driven request, dominating
+    // this endpoint's DB latency (~53,000s of replica CPU / 37d in prod). It is
+    // also uncacheable: `query` is user-controlled on a public endpoint with no
+    // `.max()` in its zod schema, so per-query cache keys are an unbounded
+    // keyspace-growth vector.
     //
-    // Cache ONLY the hot default-listing count (no `query`). `query` is
-    // user-controlled on a public endpoint with no `.max()` in its zod schema and
-    // is interpolated raw into the cache key, so caching per-query would let
-    // arbitrary `?query=<random>` values mint UNBOUNDED distinct keys (each held
-    // EX=2×600s) on the shared cache cluster — a keyspace-growth vector. Per-query
-    // counts are also low-hit-rate. So run the username-search count inline.
+    // So on the query path we return a `hasMore` boolean derived from the take+1
+    // over-fetch instead of a count. The controller maps this to pagination
+    // metadata (totalItems/totalPages become monotonic lower-bounds that are
+    // exact on the final page; `hasMore` is the authoritative next-page signal
+    // and the REST nextPage/prevPage links keep working). The no-query BROWSE
+    // path below keeps its cached exact count unchanged.
     if (query) {
-      const queryCount = await dbRead.user.count({ where });
-      return { items, count: queryCount };
+      const hasMore = take != null && items.length > (take as number);
+      return { items: hasMore ? items.slice(0, take as number) : items, hasMore };
     }
+    // ── No-query browse path (unchanged): cached exact count ──────────────────
+    // The browse count scans the whole ~900k-row Model table (index-only scan on
+    // Model_userId → HashAggregate distinct userIds → nested-loop to User,
+    // ~1174ms in EXPLAIN ANALYZE). It's a slowly-moving aggregate, so cache it: a
+    // few-minutes-stale totalItems/totalPages is harmless. Cache unconditionally
+    // (no IS_DATAPACKET gate) — the scan is expensive on every cluster. TTL =
+    // 10min (CacheTTL.md): cheap-to-refresh, bounds staleness to a sub-page drift
+    // on an ~86.5k-creator total.
     // No-query path: key by `excludeIds` only (the only remaining varying part of
     // `where`; models:{some:{}} and deletedAt:null are constant).
     const sortedExcludeIds = [...excludeIds].sort((a, b) => a - b).join(',');

--- a/src/server/utils/pagination-helpers.test.ts
+++ b/src/server/utils/pagination-helpers.test.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { describe, expect, it } from 'vitest';
-import { getCursor } from '~/server/utils/pagination-helpers';
+import { getCursor, getPagingData } from '~/server/utils/pagination-helpers';
 
 // `parseCursor` is not exported; it is exercised here through `getCursor`, the
 // public helper every keyset-paginated endpoint uses to turn a `nextCursor`
@@ -75,5 +75,63 @@ describe('parseCursor (via getCursor) — well-formed cursors parse unchanged', 
   it('returns no predicate when there is no cursor (unchanged)', () => {
     const { where } = getCursor('id DESC', undefined);
     expect(where).toBeUndefined();
+  });
+});
+
+describe('getPagingData', () => {
+  const items = [{ id: 1 }, { id: 2 }, { id: 3 }];
+
+  describe('exact-count path (unchanged — browse / count:true no-query)', () => {
+    it('derives totalItems/totalPages from an exact count', () => {
+      const result = getPagingData({ count: 45, items }, 20, 2);
+      expect(result).toEqual({
+        items,
+        totalItems: 45,
+        currentPage: 2,
+        pageSize: 20,
+        totalPages: 3, // ceil(45/20)
+      });
+      // No hasMore field on the exact-count path — response shape is unchanged.
+      expect(result).not.toHaveProperty('hasMore');
+    });
+
+    it('defaults totalItems to 0 and totalPages to 1 when no count is given', () => {
+      const result = getPagingData({ items }, 20, 1);
+      expect(result.totalItems).toBe(0);
+      expect(result.totalPages).toBe(1);
+      expect(result).not.toHaveProperty('hasMore');
+    });
+  });
+
+  describe('hasMore path (search — exact COUNT dropped)', () => {
+    it('hasMore=true ⇒ totalPages is currentPage+1 (nextPage link stays live)', () => {
+      // page 1, pageSize 20, a full page + "there is more"
+      const result = getPagingData({ items, hasMore: true }, 20, 1);
+      expect(result.hasMore).toBe(true);
+      expect(result.currentPage).toBe(1);
+      expect(result.totalPages).toBe(2); // currentPage + 1 ⇒ getPaginationLinks emits nextPage
+      // lower-bound total: 0 skipped + 3 items + 1 (more) = 4
+      expect(result.totalItems).toBe(4);
+      // fields required by the public /api/v1/creators contract are all present + numeric
+      expect(typeof result.totalItems).toBe('number');
+      expect(typeof result.totalPages).toBe('number');
+      expect(typeof result.pageSize).toBe('number');
+    });
+
+    it('hasMore=false ⇒ totalPages is currentPage (last page; no nextPage)', () => {
+      const result = getPagingData({ items, hasMore: false }, 20, 1);
+      expect(result.hasMore).toBe(false);
+      expect(result.totalPages).toBe(1); // currentPage ⇒ currentPage < totalPages is false
+      // exact on the final page: 0 skipped + 3 items = 3
+      expect(result.totalItems).toBe(3);
+    });
+
+    it('accounts for skipped pages in the lower-bound total (page 3, hasMore)', () => {
+      const result = getPagingData({ items, hasMore: true }, 20, 3);
+      // skipped = (3-1)*20 = 40; +3 items +1 more = 44
+      expect(result.totalItems).toBe(44);
+      expect(result.totalPages).toBe(4); // currentPage + 1
+      expect(result.currentPage).toBe(3);
+    });
   });
 });

--- a/src/server/utils/pagination-helpers.ts
+++ b/src/server/utils/pagination-helpers.ts
@@ -16,13 +16,27 @@ export function getPagination(limit: number, page: number | undefined) {
 }
 
 export function getPagingData<T>(
-  data: { count?: number; items: T[] },
+  data: { count?: number; items: T[]; hasMore?: boolean },
   limit?: number,
   page?: number
 ) {
-  const { count: totalItems = 0, items } = data;
+  const { count: totalItems = 0, items, hasMore } = data;
   const currentPage = page ?? 1;
   const pageSize = limit ?? totalItems;
+
+  // hasMore-based pagination (e.g. the creator username-search path, which drops
+  // the expensive exact COUNT). No exact total is available, so totalItems and
+  // totalPages are monotonic LOWER-BOUNDS: exact once we've reached the final
+  // page (hasMore=false), otherwise "at least one more". `hasMore` is the
+  // authoritative next-page signal and keeps getPaginationLinks' nextPage link
+  // working (currentPage < totalPages ⇒ true while more pages remain).
+  if (hasMore !== undefined) {
+    const skipped = pageSize && currentPage > 1 ? (currentPage - 1) * pageSize : 0;
+    const boundTotalItems = skipped + items.length + (hasMore ? 1 : 0);
+    const totalPages = hasMore ? currentPage + 1 : currentPage;
+    return { items, totalItems: boundTotalItems, currentPage, pageSize, totalPages, hasMore };
+  }
+
   const totalPages = pageSize && totalItems ? Math.ceil((totalItems as number) / pageSize) : 1;
 
   return { items, totalItems, currentPage, pageSize, totalPages };

--- a/src/tests/api/v1/creators.test.ts
+++ b/src/tests/api/v1/creators.test.ts
@@ -94,6 +94,36 @@ describe('/api/v1/creators error-body JSON.parse guard', () => {
     expect(body.metadata.currentPage).toBe(1);
   });
 
+  it('search path (?query=): hasMore metadata still emits a nextPage link + valid totals', async () => {
+    // The username-search path drops the exact COUNT and returns hasMore-based
+    // lower-bound pagination (totalPages = currentPage+1 while more remain). The
+    // public response shape must stay intact: items mapped, metadata.totalItems /
+    // totalPages present + numeric, and nextPage generated so REST pagination
+    // keeps working.
+    mockGetCreators.mockResolvedValue({
+      items: [{ username: 'bob', _count: { models: 1 } }],
+      totalItems: 21, // lower bound (skipped 20 + 1 item + 1 more)
+      currentPage: 1,
+      pageSize: 20,
+      totalPages: 2, // currentPage + 1
+      hasMore: true,
+    });
+    const { req, res } = createMocks({ query: { query: 'bo' } });
+
+    await handler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const body = res._getJSONData();
+    expect(body.items[0].username).toBe('bob');
+    // contract fields present + numeric
+    expect(typeof body.metadata.totalItems).toBe('number');
+    expect(typeof body.metadata.totalPages).toBe('number');
+    expect(body.metadata.currentPage).toBe(1);
+    expect(body.metadata.hasMore).toBe(true);
+    // nextPage link is emitted (currentPage < totalPages) so callers can page on.
+    expect(body.metadata.nextPage).toContain('page=2');
+  });
+
   it('a TRPCError with a JSON-stringified message is parsed and returned as before (no regression)', async () => {
     // Some errors legitimately carry a JSON-stringified body (zod/validation).
     // The pre-existing success path must keep parsing them.


### PR DESCRIPTION
## Problem (validated via replica `EXPLAIN ANALYZE`)

`user.getCreators` (tRPC) and the public `/api/v1/creators` endpoint run, when `?query=` is present, an **exact `COUNT`** whose plan is pathological:

- `where.username = { contains: query }` compiles to `username LIKE '%query%'` — a **leading wildcard** no btree can serve.
- intersected with `models: { some: {} }`.

Both sides are non-selective (~90k model-owners; tens-of-thousands of `%q%` matches) with a tiny intersection, so the planner:

1. scans the whole ~900k-row `Model` table (`Model.userId`),
2. HashAggregates to ~90k distinct owners,
3. nested-loop probes each owner into `User`, applying the `LIKE` as a filter — **~806ms per call**.

Over 37 days: **65,693 calls × 806ms ≈ 53,000s of replica CPU** — the single biggest DB-latency lever on this endpoint, and user-felt on creator-search / @mention flows. The count is also **uncacheable**: `query` is user-controlled with no `.max()` in its zod schema, so per-query cache keys are an unbounded keyspace-growth vector (which is why the existing count cache deliberately only covers the no-query browse path).

## Fix

On the **query-present path**, drop the exact `COUNT` entirely. Over-fetch `take + 1` rows and derive a `hasMore` boolean (trimming the sentinel row back to `take`). This replaces an aggregate over ~900k rows with one extra row on the page fetch.

The **no-query browse path is unchanged** — its count is already cached (10-min TTL, keyed by `excludeIds`) and cheap.

## Public API contract handling (the key risk)

`/api/v1/creators` is a public REST endpoint; external consumers may read `metadata.totalItems` / `metadata.totalPages`. The response **shape is preserved** — no field is removed:

- `getPagingData` gains a `hasMore` mode. When `hasMore` is provided (only the search path), `totalItems` / `totalPages` become **monotonic lower-bounds**: exact once the final page is reached (`hasMore=false` → `totalPages = currentPage`), otherwise "at least one more" (`hasMore=true` → `totalPages = currentPage + 1`).
- An authoritative **`hasMore`** field is added to the search-path metadata (additive; browse responses are byte-identical to before).
- Because `totalPages` stays `> currentPage` while more pages remain, `getPaginationLinks` keeps emitting a correct **`nextPage`** link — REST pagination continues to work.
- All contract fields (`totalItems`, `totalPages`, `currentPage`, `pageSize`) remain **present and numeric**.

So the only observable change under `?query=`: `totalItems`/`totalPages` report a lower bound instead of the exact total (documented behavior); everything needed to page through results is intact.

### Consumers verified
- **The only in-repo consumer** of `user.getCreators` is `src/pages/api/v1/creators.ts`, which reads `items` + `_count.models` (via `mapCreatorItem`) and passes `metadata` to `getPaginationLinks` — it does **not** depend on an exact total.
- The tRPC `user.getCreators` procedure has **no client/UI consumers** (the creator-search UI / @mention autocomplete use a different, Meili-backed path) — so nothing infinite-query depends on `totalPages` here.
- `getLeaderboardHandler` also calls `getCreators` but without `count: true`, so it is unaffected.

## Expected win

Eliminates the ~806ms full-`Model`-scan aggregate on every `?query=` creator-search request (~65.7k calls / 37d ≈ 53,000s replica CPU), replacing it with a `take + 1` over-fetch. User-felt latency on creator-search / @mention drops to the page-fetch cost.

## Tests

- `get-creators-count-cache.service.test.ts`: query path never calls `dbRead.user.count`; `take + 1` boundary (exactly `take` → `hasMore=false`, untrimmed; `take + 1` → `hasMore=true`, trimmed to `take`); no-query browse path still returns the cached exact count (unchanged).
- `pagination-helpers.test.ts`: `getPagingData` exact-count path unchanged; hasMore path lower-bound totals + `totalPages` (nextPage-live vs last-page); skipped-page accounting.
- `creators.test.ts`: public endpoint on the search path emits a valid `metadata` (numeric totals, `hasMore`, `nextPage=…page=2`).

30/30 pass; per-file `tsc --noEmit` clean.
