### PR TITLE
perf(api): per-flag lazy feature-flag evaluation (stop 64-eval full compute for one flag)

### DIFF
--- a/src/server/services/__tests__/feature-flags.lazy-equivalence.test.ts
+++ b/src/server/services/__tests__/feature-flags.lazy-equivalence.test.ts
@@ -1,0 +1,209 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import type { IncomingMessage } from 'http';
+import type { NextApiRequest } from 'next';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * Per-flag lazy feature-flag evaluation — equivalence gate.
+ *
+ * `getFeatureFlagsLazy` now evaluates ONLY the accessed key (via the shared
+ * `isFeatureFlagKeyPresent`) instead of forcing a full `computeFeatureFlags` on
+ * first touch. The whole safety story is: for EVERY flag key across every
+ * representative context, `lazy.X === getFeatureFlags(ctx).X`. Data-driven over
+ * `featureFlagKeys` so a newly-added flag is auto-covered.
+ *
+ * Plus: reading the Flipt-free `canViewNsfw` triggers ZERO wasm evals; reading
+ * one fliptKey'd flag triggers exactly one — the pathology the PR fixes
+ * (`applyDomainFeature` reading `canViewNsfw` used to force up to 64 evals).
+ */
+
+// These are read at IMPORT time by the service (color-host sets) and by
+// region-blocking (restricted-region config) — set them before those modules
+// evaluate so the host/region gating branches are actually exercised.
+vi.hoisted(() => {
+  process.env.SERVER_DOMAIN_GREEN = 'civitai.com';
+  process.env.SERVER_DOMAIN_BLUE = 'civitai.blue';
+  process.env.SERVER_DOMAIN_RED = 'civitai.red';
+  // FR restricted with a past effective date → isRegionRestricted('FR') === true.
+  process.env.REGION_RESTRICTION_CONFIG = 'FR:2020-01-01';
+});
+
+const { fliptEvalCalls } = vi.hoisted(() => ({
+  fliptEvalCalls: [] as { flag: string; entityId: string }[],
+}));
+
+// Deterministic, PURE stand-in for the wasm Flipt eval: same (flag, entityId,
+// context) => same result, so eager (all keys) and lazy (one key) — which pass
+// identical args per key — cannot diverge. Mixes true / false / null so all
+// three branches of the flipt block in `hasFeature` are exercised across keys.
+function fakeIsFliptSync(
+  flag: string,
+  entityId = 'global',
+  context: Record<string, string> = {}
+): boolean | null {
+  fliptEvalCalls.push({ flag, entityId });
+  const sig = `${flag}|${entityId}|${Object.keys(context)
+    .sort()
+    .map((k) => `${k}=${context[k]}`)
+    .join('&')}`;
+  let h = 0;
+  for (let i = 0; i < sig.length; i++) h = (h * 31 + sig.charCodeAt(i)) & 0x7fffffff;
+  const m = h % 3;
+  if (m === 0) return null; // fall through to static evaluation
+  return m === 1; // true or false
+}
+
+vi.mock('~/server/flipt/client', () => ({
+  isFliptSync: (...a: Parameters<typeof fakeIsFliptSync>) => fakeIsFliptSync(...a),
+  ensureFliptInitialized: async () => {},
+}));
+
+import {
+  featureFlagKeys,
+  getFeatureFlags,
+  getFeatureFlagsLazy,
+  getFeatureFlagsAsync,
+  type FeatureFlagKey,
+} from '../feature-flags.service';
+
+type Ctx = { user?: SessionUser; req: NextApiRequest | IncomingMessage };
+
+function makeReq(host?: string, country?: string): NextApiRequest {
+  const headers: Record<string, string> = {};
+  if (host) headers.host = host;
+  if (country) headers['cf-ipcountry'] = country;
+  return { headers } as unknown as NextApiRequest;
+}
+
+function makeUser(over: Partial<SessionUser> = {}): SessionUser {
+  return {
+    id: 100,
+    username: 'u',
+    isModerator: false,
+    tier: 'free',
+    permissions: [],
+    onboarding: 0,
+    ...over,
+  } as SessionUser;
+}
+
+// A "granted-everything" user exercises every `granted` availability + permission
+// branch (permissions must contain the flag key for a granted flag to pass).
+const grantedAll = makeUser({ id: 999, permissions: [...featureFlagKeys] as string[] });
+
+const contexts: { name: string; ctx: Ctx }[] = [
+  { name: 'anon / green / US', ctx: { req: makeReq('civitai.com', 'US') } },
+  { name: 'anon / red / FR(restricted)', ctx: { req: makeReq('civitai.red', 'FR') } },
+  { name: 'anon / unknown-host / no-region', ctx: { req: makeReq('example.org') } },
+  { name: 'user free / green / US', ctx: { user: makeUser(), req: makeReq('civitai.com', 'US') } },
+  {
+    name: 'user founder / green / US',
+    ctx: { user: makeUser({ tier: 'founder' }), req: makeReq('civitai.com', 'US') },
+  },
+  {
+    name: 'user bronze / blue / US',
+    ctx: { user: makeUser({ tier: 'bronze' }), req: makeReq('civitai.blue', 'US') },
+  },
+  {
+    name: 'user silver / red / FR(restricted)',
+    ctx: { user: makeUser({ tier: 'silver' }), req: makeReq('civitai.red', 'FR') },
+  },
+  {
+    name: 'user gold / green / US',
+    ctx: { user: makeUser({ tier: 'gold' }), req: makeReq('civitai.com', 'US') },
+  },
+  {
+    name: 'user free / red / FR(restricted)',
+    ctx: { user: makeUser(), req: makeReq('civitai.red', 'FR') },
+  },
+  {
+    name: 'user gold / unknown-host / no-region',
+    ctx: { user: makeUser({ tier: 'gold' }), req: makeReq('example.org') },
+  },
+  {
+    name: 'moderator / green / US',
+    ctx: { user: makeUser({ id: 7, isModerator: true }), req: makeReq('civitai.com', 'US') },
+  },
+  {
+    name: 'moderator / red / FR(restricted)',
+    ctx: { user: makeUser({ id: 7, isModerator: true }), req: makeReq('civitai.red', 'FR') },
+  },
+  { name: 'granted-all / green / US', ctx: { user: grantedAll, req: makeReq('civitai.com', 'US') } },
+  {
+    name: 'granted-all / red / FR(restricted)',
+    ctx: { user: grantedAll, req: makeReq('civitai.red', 'FR') },
+  },
+];
+
+beforeAll(async () => {
+  // Prime the private `_fliptModule` (our mock) so the SYNCHRONOUS `isFliptSync`
+  // path inside `hasFeature` is live for both eager and lazy — otherwise the
+  // flipt branch is skipped entirely and the flipt gating is never exercised.
+  await getFeatureFlagsAsync({ req: makeReq('civitai.com', 'US') });
+});
+
+describe('lazy per-flag === eager, for every flag key across representative contexts', () => {
+  for (const { name, ctx } of contexts) {
+    it(name, () => {
+      const eager = getFeatureFlags(ctx);
+      const lazy = getFeatureFlagsLazy(ctx);
+      for (const key of featureFlagKeys) {
+        expect(
+          lazy[key as keyof typeof lazy],
+          `flag "${key}" diverged in context "${name}"`
+        ).toBe(eager[key as keyof typeof eager]);
+      }
+    });
+  }
+
+  it('covers every registered flag key (data-driven, so new flags auto-covered)', () => {
+    expect(featureFlagKeys.length).toBeGreaterThan(60);
+  });
+
+  it('is non-vacuous: a representative context yields BOTH present and absent flags', () => {
+    // Guards against a false "equivalence" where eager and lazy are identically
+    // broken (e.g. everything undefined). granted-all/green/US resolves a real
+    // mix of present (true) and absent (undefined) keys.
+    const eager = getFeatureFlags({ user: grantedAll, req: makeReq('civitai.com', 'US') });
+    const present = featureFlagKeys.filter((k) => eager[k as keyof typeof eager] === true).length;
+    const absent = featureFlagKeys.length - present;
+    expect(present).toBeGreaterThan(0);
+    expect(absent).toBeGreaterThan(0);
+  });
+});
+
+describe('lazy evaluates ONLY the accessed key', () => {
+  it('reading canViewNsfw (no fliptKey) triggers ZERO Flipt evals; a fliptKey flag triggers exactly one', () => {
+    const ctx: Ctx = { req: makeReq('civitai.com', 'US') };
+    const lazy = getFeatureFlagsLazy(ctx);
+
+    // canViewNsfw has NO fliptKey → the flipt branch must never run.
+    fliptEvalCalls.length = 0;
+    void lazy.canViewNsfw;
+    expect(fliptEvalCalls).toHaveLength(0);
+
+    // videoTraining (fliptKey 'video-training', public availability) reaches the
+    // flipt eval → exactly ONE call for that single key (not all 64).
+    fliptEvalCalls.length = 0;
+    void lazy.videoTraining;
+    expect(fliptEvalCalls).toHaveLength(1);
+    expect(fliptEvalCalls[0].flag).toBe('video-training');
+
+    // Memoized: a repeat read of the same key does not re-eval.
+    fliptEvalCalls.length = 0;
+    void lazy.videoTraining;
+    expect(fliptEvalCalls).toHaveLength(0);
+  });
+
+  it('eager compute evaluates MANY flags (the work lazy avoids)', () => {
+    // Unique user id → a fresh result-cache key so this genuinely recomputes
+    // (a previously-computed context would be served from the 10s result cache
+    // and eval zero flags).
+    const ctx: Ctx = { user: makeUser({ id: 555555 }), req: makeReq('civitai.com', 'US') };
+    fliptEvalCalls.length = 0;
+    getFeatureFlags(ctx);
+    // The full compute walks every fliptKey'd flag that passes gating — far more
+    // than the single eval the lazy path pays when only canViewNsfw is read.
+    expect(fliptEvalCalls.length).toBeGreaterThan(20);
+  });
+});

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -628,20 +628,43 @@ const hasFeature = (
 // `FeatureFlagKey`, which surfaces a type error at every consumer.
 export type FeatureAccess = Record<FeatureFlagKey, boolean>;
 
+/**
+ * SINGLE per-key evaluator — the one place that decides whether a flag key is
+ * "present" (i.e. `true`) in the sparse FeatureAccess payload. BOTH the eager
+ * `computeFeatureFlags` (every key) and the per-flag lazy getter
+ * (`getFeatureFlagsLazy`, only accessed keys) call THIS, so the two paths cannot
+ * diverge — the lazy per-flag result for key X is provably the same value eager
+ * puts at X. Semantics (must match the historical inline `computeFeatureFlags`
+ * body exactly):
+ *   1. `hasFeature` false ⇒ absent (env/region/host/role + Flipt gating).
+ *   2. A toggleable flag whose `default === false` is absent at the base layer —
+ *      logged-in users get their stored choice merged client-side (via
+ *      user.getFeatureFlags), but anonymous users have no override, so a
+ *      default-off toggleable (e.g. postsNavItem) must stay off on bare access.
+ *   3. Otherwise present.
+ * `fliptContext` is threaded in (built once per compute via buildFliptContext)
+ * so a single lazy request reuses one context across every accessed key, exactly
+ * as eager reuses it across every key.
+ */
+function isFeatureFlagKeyPresent(
+  key: FeatureFlagKey,
+  ctx: FeatureAccessContext,
+  fliptContext: Record<string, string>
+): boolean {
+  if (!hasFeature(key, ctx, fliptContext)) return false;
+  const feature = featureFlags[key];
+  if (feature.toggleable && feature.default === false) return false;
+  return true;
+}
+
 function computeFeatureFlags(ctx: FeatureAccessContext): FeatureAccess {
   // Build the Flipt context once and reuse for every flag (was rebuilt per flag).
   const fliptContext = buildFliptContext(ctx.user);
   const keys = Object.keys(featureFlags) as FeatureFlagKey[];
   return keys.reduce<FeatureAccess>((acc, key) => {
-    if (!hasFeature(key, ctx, fliptContext)) return acc;
-    const feature = featureFlags[key];
-    // Toggleable flags resolve to their default at the base layer. Logged-in
-    // users get their stored choice merged on top client-side (via
-    // user.getFeatureFlags), but anonymous users have no override — so a
-    // default-off toggleable (e.g. postsNavItem) must stay off for them rather
-    // than leak through on bare access.
-    if (feature.toggleable && feature.default === false) return acc;
-    acc[key] = true;
+    // Delegate the per-key decision to the shared evaluator so eager output is
+    // byte-identical to the lazy per-flag path (same code, same order).
+    if (isFeatureFlagKeyPresent(key, ctx, fliptContext)) acc[key] = true;
     return acc;
   }, {} as FeatureAccess);
 }
@@ -710,16 +733,55 @@ export const getFeatureFlags = (ctx: FeatureAccessContext): FeatureAccess => {
   return { ...value };
 };
 
+/**
+ * PER-FLAG lazy FeatureAccess. Accessing `features.X` evaluates ONLY key `X`
+ * (via the shared `isFeatureFlagKeyPresent`), instead of forcing a full
+ * `computeFeatureFlags` of all ~145 flags on first touch. This is the structural
+ * fix for the base tRPC chain (`applyDomainFeature`) reading a single Flipt-free
+ * flag (`canViewNsfw`) and paying for up to 64 wasm `evaluateBoolean` calls:
+ *   - reading `canViewNsfw` (no fliptKey) now evaluates ZERO Flipt flags;
+ *   - reading one fliptKey'd flag evaluates ONLY that flag (still through the
+ *     wasm eval cache in flipt/client.ts — no per-eval hit-rate regression).
+ *
+ * Correctness: the returned value for any key is identical to
+ * `getFeatureFlags(ctx)[key]` — both go through `isFeatureFlagKeyPresent`, and
+ * `fliptContext` is built once per request (memoized) exactly as eager builds it
+ * once per compute. Sparse semantics are preserved: a non-present key reads as
+ * `undefined` (property returns `undefined`, not `false`), matching the eager
+ * object where absent keys are `undefined`. Per-key results are memoized so
+ * repeat reads of the same key within a request are stable and free. Code that
+ * reads many keys (e.g. isFlagProtected) simply triggers several per-key
+ * computes — each still cheap for Flipt-free keys and eval-cached for Flipt ones.
+ *
+ * NOTE: unlike the previous implementation, this does NOT populate/read the
+ * whole-result cache in `getFeatureFlags` — that cache exists to amortize the
+ * full 145-flag compute, which is precisely the work we now avoid. Eager callers
+ * (user.getFeatureFlags, the SSR seed) still use that cache directly.
+ */
 export function getFeatureFlagsLazy(ctx: FeatureAccessContext) {
-  const obj = {} as FeatureAccess & { features: FeatureAccess };
+  const obj = {} as FeatureAccess;
+  // Built once on first flag access and reused for every accessed key this
+  // request — mirrors eager's "build fliptContext once per compute".
+  let fliptContext: Record<string, string> | undefined;
+  // Per-key memo so a second read of the same key is stable + free (and can't
+  // re-hit Flipt). Stores the raw presence boolean; the getter maps it to the
+  // sparse `true | undefined` wire value.
+  const memo = new Map<string, boolean>();
 
   for (const key in featureFlags) {
     Object.defineProperty(obj, key, {
+      // Match the previous descriptor: non-enumerable (data-shape-identical to
+      // the old lazy object) with only a getter.
       get() {
-        if (!obj.features) {
-          obj.features = getFeatureFlags(ctx);
+        let present = memo.get(key);
+        if (present === undefined) {
+          if (!fliptContext) fliptContext = buildFliptContext(ctx.user);
+          present = isFeatureFlagKeyPresent(key as FeatureFlagKey, ctx, fliptContext);
+          memo.set(key, present);
         }
-        return obj.features[key as keyof FeatureAccess];
+        // Sparse semantics: present ⇒ true, absent ⇒ undefined (NOT false), so
+        // `features.X === getFeatureFlags(ctx).X` holds for every key.
+        return present ? true : undefined;
       },
     });
   }


### PR DESCRIPTION
## The pathology

The base `publicProcedure` tRPC chain runs `applyDomainFeature` on ~every
procedure. That middleware reads exactly **one** feature flag: `ctx.features.canViewNsfw`.
`canViewNsfw` has **no `fliptKey`** — it's purely static (host / region / role).

But `ctx.features` is the lazy object returned by `getFeatureFlagsLazy`, whose
getter computed the **entire** `FeatureAccess` on first access
(`getFeatureFlags` → `computeFeatureFlags`). That walks all ~145 flags and runs
the wasm Flipt `evaluateBoolean` for the **64 `fliptKey`'d flags**. So a request
that only needs the Flipt-free `canViewNsfw` paid for up to **64 wasm evals** per
result-cache miss — pure overhead on the hottest path in the app.

## The fix

Make `getFeatureFlagsLazy` a true **per-flag** lazy getter. Accessing
`features.X` now evaluates **only** key `X`:

- A new shared per-key evaluator `isFeatureFlagKeyPresent(key, ctx, fliptContext)`
  is the single place that decides whether a flag is present in the sparse payload.
- The lazy getter builds `fliptContext` once per request (memoized) and memoizes
  each accessed key's result.
- `computeFeatureFlags` (eager) now just calls that same evaluator for every key —
  so **eager and lazy share one code path and cannot diverge**. Eager output is
  byte-identical to before (same keys, same order, same sparse semantics), so
  `user.getFeatureFlags` and the SSR seed are unchanged.

Result: reading `canViewNsfw` evaluates **zero** Flipt flags; reading a
`fliptKey`'d flag evaluates **only that one** (still through the existing wasm
eval cache — no per-eval hit-rate regression).

## The equivalence guarantee (the safety story)

A data-driven test asserts, for **every** flag key, that
`lazy.X === getFeatureFlags(ctx).X` across representative contexts: anonymous,
logged-in, moderator, each membership tier, each color host, restricted vs
non-restricted region, and a granted-everything cohort. It iterates over the
flag-key registry, so a newly-added flag is automatically covered. This proves
the per-flag lazy path never diverges from the eager full compute.

A second test asserts reading `canViewNsfw` triggers **zero** Flipt evaluations
and reading a `fliptKey`'d flag triggers **exactly one** (vs the full compute,
which evaluates many).

## Scope

Pure CPU-efficiency change — **no behavior change** and no wire-format change.
The reduction is per-request work on the base procedure chain (headroom at peak;
no user-visible effect).

Tests: `feature-flags.lazy-equivalence.test.ts` (18 tests) pass. Per-file
typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
