### PR TITLE
feat(app-blocks): W13 unified moderator listings management table (P2)

### DIFF
--- a/src/components/Apps/AppListingsModerationTable.browser.test.tsx
+++ b/src/components/Apps/AppListingsModerationTable.browser.test.tsx
@@ -42,11 +42,17 @@ const ROWS = [
       submittedBy: { id: 1, username: 'dev', image: null },
     },
   }),
-  offsite({ id: 'apl_a', slug: 'alpha-live', name: 'Alpha', status: 'approved' }),
+  // Server (keyset) order is NOT alphabetical (Bravo precedes Alpha) so a client
+  // A→Z sort is observable as a flip.
   offsite({ id: 'apl_b', slug: 'bravo-live', name: 'Bravo', status: 'approved' }),
+  offsite({ id: 'apl_a', slug: 'alpha-live', name: 'Alpha', status: 'approved' }),
   offsite({ id: 'apl_o', slug: 'onsite-live', name: 'Onsite', kind: 'onsite', appBlockId: 'ab_1', status: 'approved' }),
   offsite({ id: 'apl_r', slug: 'gone-ext', name: 'Gone', status: 'removed' }),
 ];
+
+// Two-page dataset (paged mode) — page 1 carries a nextCursor, page 2 does not.
+const PAGE1 = [offsite({ id: 'apl_a', slug: 'alpha-live', name: 'Alpha', status: 'approved' })];
+const PAGE2 = [offsite({ id: 'apl_z', slug: 'zebra-live', name: 'Zebra', status: 'approved' })];
 
 const mocks = vi.hoisted(() => ({
   invalidate: vi.fn().mockResolvedValue(undefined),
@@ -54,6 +60,7 @@ const mocks = vi.hoisted(() => ({
   queryInput: vi.fn(),
   errorMode: false,
   queryError: false,
+  paged: false,
 }));
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
@@ -93,12 +100,22 @@ vi.mock('~/utils/trpc', () => {
       useUtils: () => utils,
       appListings: {
         listAllListingsForModeration: {
-          useQuery: (input: unknown) => {
+          useQuery: (input: { cursor?: string }) => {
             mocks.queryInput(input);
+            if (mocks.queryError) {
+              return { data: undefined, isLoading: false, isFetching: false, error: new Error('nope') };
+            }
+            if (mocks.paged) {
+              const data = input?.cursor
+                ? { items: PAGE2, nextCursor: null }
+                : { items: PAGE1, nextCursor: 'cur-2' };
+              return { data, isLoading: false, isFetching: false, error: null };
+            }
             return {
-              data: mocks.queryError ? undefined : { items: ROWS, nextCursor: null },
+              data: { items: ROWS, nextCursor: null },
               isLoading: false,
-              error: mocks.queryError ? new Error('nope') : null,
+              isFetching: false,
+              error: null,
             };
           },
         },
@@ -138,6 +155,7 @@ beforeEach(() => {
   mocks.queryInput.mockClear();
   mocks.errorMode = false;
   mocks.queryError = false;
+  mocks.paged = false;
   showError.mockClear();
 });
 
@@ -169,21 +187,21 @@ describe('AppListingsModerationTable — sections + kind-aware visibility', () =
 });
 
 describe('AppListingsModerationTable — sort + server-side filter', () => {
-  test('the App column sorts (asc → desc reorders the Live rows)', async () => {
+  test('the App column client-sort reorders the loaded rows (server order → A→Z on click)', async () => {
     renderWithProviders(<AppListingsModerationTable />);
     await expect.element(page.getByTestId('apps-mod-listing-row-alpha-live')).toBeInTheDocument();
+    // Default = the server keyset order (Bravo precedes Alpha) — NOT a client A→Z.
     const before =
       page.getByTestId('apps-mod-listing-row-alpha-live').element()
         .compareDocumentPosition(page.getByTestId('apps-mod-listing-row-bravo-live').element());
-    // Default asc: Alpha precedes Bravo (FOLLOWING bit set on the "other" node).
-    expect(before & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(before & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy(); // bravo precedes alpha
 
     await page.getByRole('button', { name: 'Sort by App' }).first().click();
     const after =
       page.getByTestId('apps-mod-listing-row-alpha-live').element()
         .compareDocumentPosition(page.getByTestId('apps-mod-listing-row-bravo-live').element());
-    // Desc: Bravo now precedes Alpha.
-    expect(after & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+    // A→Z: Alpha now precedes Bravo.
+    expect(after & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   test('typing in the filter forwards `search` to the server query', async () => {
@@ -230,13 +248,24 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
     });
   });
 
-  test('Purge is confirm-gated: disabled until a reason is entered, then fires', async () => {
+  test('Purge is typed-confirm gated: needs BOTH reason ≥3 AND the exact slug, then fires', async () => {
     renderWithProviders(<AppListingsModerationTable />);
     await page.getByTestId('apps-mod-purge-gone-ext').click();
-    // Destructive warning + a disabled confirm while the reason is empty.
+    // Destructive warning + a disabled confirm while nothing is entered.
     await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeDisabled();
     expect(mocks.mutate).not.toHaveBeenCalled();
+
+    // Reason alone is NOT enough — the typed slug confirm is still required.
     await page.getByTestId('apps-mod-action-reason').fill('malware');
+    await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeDisabled();
+
+    // A WRONG slug keeps it disabled.
+    await page.getByTestId('apps-mod-purge-confirm').fill('wrong-slug');
+    await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeDisabled();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+
+    // The exact slug (+ reason) enables it → fires with the right args.
+    await page.getByTestId('apps-mod-purge-confirm').fill('gone-ext');
     await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeEnabled();
     await page.getByTestId('apps-mod-action-confirm').click();
     expect(mocks.mutate).toHaveBeenCalledWith('purge', { appListingId: 'apl_r', reason: 'malware' });
@@ -277,6 +306,48 @@ describe('AppListingsModerationTable — pending Review opens the review modal',
       'approve',
       expect.objectContaining({ publishRequestId: 'alpr_p' })
     );
+  });
+});
+
+describe('AppListingsModerationTable — pagination, status filter + honest truncation', () => {
+  test('Load more appends the next keyset page and hides once the cursor is exhausted', async () => {
+    mocks.paged = true;
+    renderWithProviders(<AppListingsModerationTable />);
+    // Page 1 only: alpha visible, zebra NOT yet, Load-more present.
+    await expect.element(page.getByTestId('apps-mod-listing-row-alpha-live')).toBeInTheDocument();
+    expect(page.getByTestId('apps-mod-listing-row-zebra-live').elements()).toHaveLength(0);
+    await expect.element(page.getByTestId('apps-mod-load-more')).toBeInTheDocument();
+
+    await page.getByTestId('apps-mod-load-more').click();
+    // Page 2 appended: BOTH rows now render, and Load-more is gone (nextCursor null).
+    await expect.element(page.getByTestId('apps-mod-listing-row-zebra-live')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-mod-listing-row-alpha-live')).toBeInTheDocument();
+    expect(page.getByTestId('apps-mod-load-more').elements()).toHaveLength(0);
+  });
+
+  test('the truncation indicator shows a "+more" count + Load-more only while a next page exists', async () => {
+    mocks.paged = true;
+    renderWithProviders(<AppListingsModerationTable />);
+    // Page 1 truncated → the count flags that more exist, and Load-more shows.
+    await expect
+      .element(page.getByTestId('apps-mod-listings-count'))
+      .toHaveTextContent('Showing 1+');
+    await expect.element(page.getByTestId('apps-mod-load-more')).toBeInTheDocument();
+  });
+
+  test('the count reads a plain total (no "+", no Load-more) when nothing is truncated', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    const count = page.getByTestId('apps-mod-listings-count');
+    await expect.element(count).toHaveTextContent('Showing 5');
+    expect((count.element().textContent ?? '').includes('+')).toBe(false);
+    expect(page.getByTestId('apps-mod-load-more').elements()).toHaveLength(0);
+  });
+
+  test('selecting a status re-queries the server with that `status` arg', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await page.getByRole('radio', { name: 'Removed' }).click();
+    const lastInput = mocks.queryInput.mock.calls.at(-1)?.[0] as { status?: string };
+    expect(lastInput.status).toBe('removed');
   });
 });
 

--- a/src/components/Apps/AppListingsModerationTable.browser.test.tsx
+++ b/src/components/Apps/AppListingsModerationTable.browser.test.tsx
@@ -1,0 +1,291 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * W13 post-approval mgmt (P2) — the unified moderator listings management table.
+ * Browser-mode render test (report-only in Tekton): mixed-status/kind dataset →
+ * status sections; sort + server-side filter wiring; each inline action fires the
+ * right mutation with the right args (reason forwarded, purge confirm-gated); the
+ * kind-aware action visibility (off-site-only actions hidden on on-site rows); the
+ * pending Review action opens the reused off-site review modal with the correct
+ * request id; and error surfacing.
+ */
+
+function offsite(over: Record<string, unknown>) {
+  return {
+    kind: 'offsite',
+    category: 'utility',
+    contentRating: 'g',
+    externalUrl: 'https://ex.com/app',
+    appBlockId: null,
+    owner: { id: 1, username: 'dev', image: null },
+    installCount: 0,
+    thumbsUpCount: 0,
+    thumbsDownCount: 0,
+    pendingRequest: null,
+    ...over,
+  };
+}
+
+const ROWS = [
+  offsite({
+    id: 'apl_p',
+    slug: 'pending-ext',
+    name: 'Pending Ext',
+    status: 'pending',
+    pendingRequest: {
+      id: 'alpr_p',
+      submittedAt: new Date('2026-01-01T00:00:00Z'),
+      changelog: 'a note',
+      submittedBy: { id: 1, username: 'dev', image: null },
+    },
+  }),
+  offsite({ id: 'apl_a', slug: 'alpha-live', name: 'Alpha', status: 'approved' }),
+  offsite({ id: 'apl_b', slug: 'bravo-live', name: 'Bravo', status: 'approved' }),
+  offsite({ id: 'apl_o', slug: 'onsite-live', name: 'Onsite', kind: 'onsite', appBlockId: 'ab_1', status: 'approved' }),
+  offsite({ id: 'apl_r', slug: 'gone-ext', name: 'Gone', status: 'removed' }),
+];
+
+const mocks = vi.hoisted(() => ({
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  mutate: vi.fn(),
+  queryInput: vi.fn(),
+  errorMode: false,
+  queryError: false,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true }),
+}));
+
+const showError = vi.fn();
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: (...a: unknown[]) => showError(...a),
+}));
+
+vi.mock('~/utils/trpc', () => {
+  // A mutation mock: records (name, vars), then drives onSuccess/onError so the
+  // component's success + error paths both run.
+  const mutation =
+    (name: string) =>
+    (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
+      mutate: (vars: unknown) => {
+        mocks.mutate(name, vars);
+        if (mocks.errorMode) opts?.onError?.({ message: 'boom' });
+        else void opts?.onSuccess?.();
+      },
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+  const utils = {
+    appListings: {
+      listAllListingsForModeration: { invalidate: mocks.invalidate },
+      listPendingRequests: { invalidate: mocks.invalidate },
+      listApprovedRequests: { invalidate: mocks.invalidate },
+      listRejectedRequests: { invalidate: mocks.invalidate },
+    },
+  };
+  return {
+    trpc: {
+      useUtils: () => utils,
+      appListings: {
+        listAllListingsForModeration: {
+          useQuery: (input: unknown) => {
+            mocks.queryInput(input);
+            return {
+              data: mocks.queryError ? undefined : { items: ROWS, nextCursor: null },
+              isLoading: false,
+              error: mocks.queryError ? new Error('nope') : null,
+            };
+          },
+        },
+        // The reused off-site review modal's deps:
+        getAssets: {
+          useQuery: () => ({
+            data: {
+              listingId: 'apl_p',
+              iconId: 10,
+              coverId: 11,
+              iconNsfwLevel: 1,
+              coverNsfwLevel: 1,
+              screenshots: [{ imageId: 12, nsfwLevel: 1 }],
+            },
+            isLoading: false,
+            error: null,
+          }),
+        },
+        // Lifecycle + review mutations.
+        resetListingToPending: { useMutation: mutation('reset') },
+        delistListing: { useMutation: mutation('delist') },
+        relistListing: { useMutation: mutation('relist') },
+        claimListing: { useMutation: mutation('claim') },
+        purgeListing: { useMutation: mutation('purge') },
+        approveExternalRequest: { useMutation: mutation('approve') },
+        rejectExternalRequest: { useMutation: mutation('reject') },
+      },
+    },
+  };
+});
+
+const { AppListingsModerationTable } = await import('./AppListingsModerationTable');
+
+beforeEach(() => {
+  mocks.invalidate.mockClear();
+  mocks.mutate.mockClear();
+  mocks.queryInput.mockClear();
+  mocks.errorMode = false;
+  mocks.queryError = false;
+  showError.mockClear();
+});
+
+describe('AppListingsModerationTable — sections + kind-aware visibility', () => {
+  test('renders the mixed-status dataset into status sections', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await expect.element(page.getByTestId('apps-mod-listings-section-live')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-mod-listings-section-pending')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-mod-listings-section-removed')).toBeInTheDocument();
+    // Rows from different sections are present.
+    await expect.element(page.getByText('pending-ext')).toBeInTheDocument();
+    await expect.element(page.getByText('alpha-live')).toBeInTheDocument();
+    await expect.element(page.getByText('gone-ext')).toBeInTheDocument();
+  });
+
+  test('off-site-only actions are hidden on an on-site row (kind-aware)', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    // Off-site approved → BOTH reset-to-pending + hide.
+    await expect.element(page.getByTestId('apps-mod-reset-to-pending-alpha-live')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-mod-hide-alpha-live')).toBeInTheDocument();
+    // On-site approved → hide ONLY (no reset-to-pending).
+    await expect.element(page.getByTestId('apps-mod-hide-onsite-live')).toBeInTheDocument();
+    expect(page.getByTestId('apps-mod-reset-to-pending-onsite-live').elements()).toHaveLength(0);
+    // Removed off-site → relist + claim + purge.
+    await expect.element(page.getByTestId('apps-mod-relist-gone-ext')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-mod-claim-gone-ext')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-mod-purge-gone-ext')).toBeInTheDocument();
+  });
+});
+
+describe('AppListingsModerationTable — sort + server-side filter', () => {
+  test('the App column sorts (asc → desc reorders the Live rows)', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await expect.element(page.getByTestId('apps-mod-listing-row-alpha-live')).toBeInTheDocument();
+    const before =
+      page.getByTestId('apps-mod-listing-row-alpha-live').element()
+        .compareDocumentPosition(page.getByTestId('apps-mod-listing-row-bravo-live').element());
+    // Default asc: Alpha precedes Bravo (FOLLOWING bit set on the "other" node).
+    expect(before & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+
+    await page.getByRole('button', { name: 'Sort by App' }).first().click();
+    const after =
+      page.getByTestId('apps-mod-listing-row-alpha-live').element()
+        .compareDocumentPosition(page.getByTestId('apps-mod-listing-row-bravo-live').element());
+    // Desc: Bravo now precedes Alpha.
+    expect(after & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+  });
+
+  test('typing in the filter forwards `search` to the server query', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await page.getByTestId('apps-mod-listings-filter').fill('cool');
+    const lastInput = mocks.queryInput.mock.calls.at(-1)?.[0] as { search?: string };
+    expect(lastInput.search).toBe('cool');
+  });
+});
+
+describe('AppListingsModerationTable — inline actions fire the right mutation', () => {
+  test('Hide forwards {appListingId, reason} to delistListing (dual-kind)', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await page.getByTestId('apps-mod-hide-alpha-live').click();
+    await page.getByTestId('apps-mod-action-reason').fill('spammy content');
+    await page.getByTestId('apps-mod-action-confirm').click();
+    expect(mocks.mutate).toHaveBeenCalledWith('delist', {
+      appListingId: 'apl_a',
+      reason: 'spammy content',
+    });
+  });
+
+  test('Reset to pending forwards {appListingId, reason} (off-site only)', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await page.getByTestId('apps-mod-reset-to-pending-alpha-live').click();
+    await page.getByTestId('apps-mod-action-reason').fill('needs re-review');
+    await page.getByTestId('apps-mod-action-confirm').click();
+    expect(mocks.mutate).toHaveBeenCalledWith('reset', {
+      appListingId: 'apl_a',
+      reason: 'needs re-review',
+    });
+  });
+
+  test('Claim forwards the target owner id + reason', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await page.getByTestId('apps-mod-claim-gone-ext').click();
+    await page.getByTestId('apps-mod-claim-target').fill('555');
+    await page.getByTestId('apps-mod-action-reason').fill('verified owner');
+    await page.getByTestId('apps-mod-action-confirm').click();
+    expect(mocks.mutate).toHaveBeenCalledWith('claim', {
+      appListingId: 'apl_r',
+      targetUserId: 555,
+      reason: 'verified owner',
+    });
+  });
+
+  test('Purge is confirm-gated: disabled until a reason is entered, then fires', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await page.getByTestId('apps-mod-purge-gone-ext').click();
+    // Destructive warning + a disabled confirm while the reason is empty.
+    await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeDisabled();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+    await page.getByTestId('apps-mod-action-reason').fill('malware');
+    await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeEnabled();
+    await page.getByTestId('apps-mod-action-confirm').click();
+    expect(mocks.mutate).toHaveBeenCalledWith('purge', { appListingId: 'apl_r', reason: 'malware' });
+  });
+
+  test('a reason under the 3-char floor keeps the confirm disabled', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await page.getByTestId('apps-mod-hide-alpha-live').click();
+    await page.getByTestId('apps-mod-action-reason').fill('ab');
+    await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeDisabled();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  test('a mutation error surfaces via showErrorNotification', async () => {
+    mocks.errorMode = true;
+    renderWithProviders(<AppListingsModerationTable />);
+    await page.getByTestId('apps-mod-hide-alpha-live').click();
+    await page.getByTestId('apps-mod-action-reason').fill('spammy content');
+    await page.getByTestId('apps-mod-action-confirm').click();
+    expect(showError).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Hide failed' })
+    );
+  });
+});
+
+describe('AppListingsModerationTable — pending Review opens the review modal', () => {
+  test('Review opens the off-site review modal and approve forwards the pending request id', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await page.getByTestId('apps-mod-review-pending-ext').click();
+    // The reused off-site review modal opened (content-only checklist).
+    await expect
+      .element(page.getByText('URL is https and opens externally'))
+      .toBeInTheDocument();
+    await page.getByTestId('apps-offsite-approve-open').click();
+    await page.getByTestId('apps-offsite-approve-confirm').click();
+    // Approve fires with the pending request id from the row (NOT the listing id).
+    expect(mocks.mutate).toHaveBeenCalledWith(
+      'approve',
+      expect.objectContaining({ publishRequestId: 'alpr_p' })
+    );
+  });
+});
+
+describe('AppListingsModerationTable — dark posture', () => {
+  test('renders nothing when the query errors (non-mod / flag off)', async () => {
+    mocks.queryError = true;
+    renderWithProviders(<AppListingsModerationTable />);
+    // The component returns null on a query error → none of its surface renders.
+    expect(page.getByTestId('apps-mod-listings-filter').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-mod-listing-row-alpha-live').elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -12,9 +12,10 @@ import {
   Table,
   Text,
   Textarea,
+  TextInput,
 } from '@mantine/core';
 import { IconAlertTriangle, IconBox, IconThumbUp } from '@tabler/icons-react';
-import { Fragment, useMemo, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import {
   OffsiteReviewModal,
   type OffsitePendingRow,
@@ -75,6 +76,28 @@ const MOD_ACCESSORS: SubmissionAccessors<ModerationListingRow> = {
 
 type KindFilter = 'all' | 'onsite' | 'offsite';
 
+/** The server-side status filter (the primary "reach a specific bucket" affordance).
+ *  `'all'` = no filter; otherwise the raw `AppListing.status` ('Live' = approved). */
+type StatusFilter = 'all' | 'approved' | 'pending' | 'rejected' | 'removed' | 'draft';
+
+const STATUS_FILTER_OPTIONS: { label: string; value: StatusFilter }[] = [
+  { label: 'All', value: 'all' },
+  { label: 'Live', value: 'approved' },
+  { label: 'Pending', value: 'pending' },
+  { label: 'Rejected', value: 'rejected' },
+  { label: 'Removed', value: 'removed' },
+  { label: 'Draft', value: 'draft' },
+];
+
+/** Rows per keyset page (bounded by the schema at ≤50). */
+const PAGE_SIZE = 50;
+
+/** A non-mod-table sort column, used as the "no active sort" sentinel so the App
+ *  header renders neutral until a mod explicitly clicks it (the default order is the
+ *  server keyset — newest-first — NOT a client alphabetical re-sort of a truncated
+ *  window, which would misrepresent completeness). */
+const NEUTRAL_SORT: SortState = { column: 'reviewed', direction: 'asc' };
+
 /** Build the off-site review-modal row from a pending moderation listing row. */
 function toReviewRow(row: ModerationListingRow): OffsitePendingRow | null {
   const pending = row.pendingRequest;
@@ -101,32 +124,63 @@ export function AppListingsModerationTable() {
   const utils = trpc.useUtils();
   const [search, setSearch] = useState('');
   const [kind, setKind] = useState<KindFilter>('all');
-  const [sort, setSort] = useState<SortState>({ column: 'app', direction: 'asc' });
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  // `null` = the server keyset order (newest-first). A client sort is opt-in (a mod
+  // clicks the App header) and is labelled as covering only the LOADED rows.
+  const [sort, setSort] = useState<SortState | null>(null);
+  // Keyset pagination: `cursor` drives the query; `accumulated` holds the pages
+  // already loaded so "Load more" APPENDS rather than replaces.
+  const [cursor, setCursor] = useState<string | undefined>(undefined);
+  const [accumulated, setAccumulated] = useState<ModerationListingRow[]>([]);
   const [reviewRow, setReviewRow] = useState<OffsitePendingRow | null>(null);
   const [pendingAction, setPendingAction] = useState<{
     action: ListingModAction;
     row: ModerationListingRow;
   } | null>(null);
 
+  // A filter change = a NEW result set → reset pagination (don't append across it).
+  const trimmedSearch = search.trim();
+  const filterKey = `${statusFilter}|${kind}|${trimmedSearch}`;
+  useEffect(() => {
+    setAccumulated([]);
+    setCursor(undefined);
+  }, [filterKey]);
+
   const query = trpc.appListings.listAllListingsForModeration.useQuery(
     {
-      limit: 50,
-      search: search.trim() || undefined,
+      limit: PAGE_SIZE,
+      search: trimmedSearch || undefined,
       kind: kind === 'all' ? undefined : kind,
+      status: statusFilter === 'all' ? undefined : statusFilter,
+      cursor,
     },
     { enabled: !!features?.appBlocks, retry: false }
   );
 
-  const invalidate = () => utils.appListings.listAllListingsForModeration.invalidate();
+  // Reset to page 1 on a mutation (a listing's status/order may shift) + invalidate.
+  const invalidate = () => {
+    setAccumulated([]);
+    setCursor(undefined);
+    return utils.appListings.listAllListingsForModeration.invalidate();
+  };
 
-  const items = (query.data?.items ?? []) as ModerationListingRow[];
+  const page = (query.data?.items ?? []) as ModerationListingRow[];
+  const nextCursor = query.data?.nextCursor ?? null;
 
-  // Group (one group per listing — the mod view isn't version-collapsed), sort by
-  // the chosen column, then partition into the MOD status sections.
+  // Merge the current page into the accumulated set (dedupe by id — defensive).
+  const items = useMemo(() => {
+    if (!cursor) return page;
+    const seen = new Set(accumulated.map((r) => r.id));
+    return [...accumulated, ...page.filter((r) => !seen.has(r.id))];
+  }, [accumulated, page, cursor]);
+
+  // Group (one group per listing — the mod view isn't version-collapsed), apply the
+  // (opt-in) client sort, then partition into the MOD status sections. When `sort`
+  // is null the server keyset order (newest-first) is preserved.
   const buckets = useMemo(() => {
     const grouped = groupSubmissionsByApp(items, MOD_ACCESSORS.identity, MOD_ACCESSORS.submittedAt);
-    const sorted = sortGroups(grouped, sort, MOD_ACCESSORS);
-    return bucketGroupsByStatus(sorted, MOD_ACCESSORS.status, MOD_STATUS_BUCKETS);
+    const ordered = sort ? sortGroups(grouped, sort, MOD_ACCESSORS) : grouped;
+    return bucketGroupsByStatus(ordered, MOD_ACCESSORS.status, MOD_STATUS_BUCKETS);
   }, [items, sort]);
 
   const totalGroups = MOD_STATUS_SECTION_ORDER.reduce((n, b) => n + buckets[b].length, 0);
@@ -135,7 +189,12 @@ export function AppListingsModerationTable() {
   // (unobtrusive, mirrors the sibling mod queues).
   if (query.error) return null;
 
-  const onSort = (column: SortColumn) => setSort((s) => nextSortState(s, column));
+  const onSort = (column: SortColumn) =>
+    setSort((s) => nextSortState(s ?? { column: 'app', direction: 'desc' }, column));
+  const onLoadMore = () => {
+    setAccumulated(items);
+    if (nextCursor) setCursor(nextCursor);
+  };
 
   const openAction = (action: ListingModAction, row: ModerationListingRow) => {
     if (action === 'review') {
@@ -151,7 +210,7 @@ export function AppListingsModerationTable() {
       <Table verticalSpacing="md" horizontalSpacing="md">
         <Table.Thead>
           <Table.Tr>
-            <SortableTh label="App" column="app" sort={sort} onSort={onSort} />
+            <SortableTh label="App" column="app" sort={sort ?? NEUTRAL_SORT} onSort={onSort} />
             <Table.Th>Owner</Table.Th>
             <Table.Th>Category</Table.Th>
             <Table.Th>Reviews</Table.Th>
@@ -262,6 +321,12 @@ export function AppListingsModerationTable() {
     </Card>
   );
 
+  // Honest completeness signal: whenever a next page exists the loaded set is a
+  // TRUNCATED window (the newest `items.length`), so the view must never read as a
+  // complete list — surface the count + the Load-more affordance, and (when a client
+  // sort is active) note the sort covers only the loaded rows.
+  const truncated = nextCursor != null;
+
   return (
     <Stack gap="md" mt="lg">
       <Group justify="space-between" align="flex-end">
@@ -271,19 +336,29 @@ export function AppListingsModerationTable() {
           testId="apps-mod-listings-filter"
           placeholder="Filter by app name or slug…"
         />
-        <SegmentedControl
-          size="xs"
-          value={kind}
-          onChange={(v) => setKind(v as KindFilter)}
-          data={[
-            { label: 'All', value: 'all' },
-            { label: 'On-site', value: 'onsite' },
-            { label: 'External', value: 'offsite' },
-          ]}
-        />
+        <Group gap="sm">
+          <SegmentedControl
+            size="xs"
+            value={statusFilter}
+            onChange={(v) => setStatusFilter(v as StatusFilter)}
+            data={STATUS_FILTER_OPTIONS}
+            aria-label="Filter by status"
+          />
+          <SegmentedControl
+            size="xs"
+            value={kind}
+            onChange={(v) => setKind(v as KindFilter)}
+            data={[
+              { label: 'All', value: 'all' },
+              { label: 'On-site', value: 'onsite' },
+              { label: 'External', value: 'offsite' },
+            ]}
+            aria-label="Filter by kind"
+          />
+        </Group>
       </Group>
 
-      {query.isLoading ? (
+      {query.isLoading && items.length === 0 ? (
         <Text size="sm" c="dimmed">
           Loading…
         </Text>
@@ -294,12 +369,40 @@ export function AppListingsModerationTable() {
           </Text>
         </Card>
       ) : (
-        <StatusSections
-          buckets={buckets}
-          testIdPrefix="apps-mod-listings-section"
-          order={MOD_STATUS_SECTION_ORDER}
-          renderTable={renderTable}
-        />
+        <>
+          <Group gap={6}>
+            <Text size="xs" c="dimmed" data-testid="apps-mod-listings-count">
+              Showing {items.length}
+              {truncated ? '+ (more listings exist — Load more or narrow the filters)' : ''}.
+            </Text>
+            {truncated && sort && (
+              <Text size="xs" c="orange" data-testid="apps-mod-sort-partial-note">
+                Sort covers only the loaded rows — Load more or filter to include the rest.
+              </Text>
+            )}
+          </Group>
+
+          <StatusSections
+            buckets={buckets}
+            testIdPrefix="apps-mod-listings-section"
+            order={MOD_STATUS_SECTION_ORDER}
+            renderTable={renderTable}
+          />
+
+          {truncated && (
+            <Group justify="center">
+              <Button
+                variant="default"
+                onClick={onLoadMore}
+                loading={query.isFetching}
+                disabled={query.isFetching}
+                data-testid="apps-mod-load-more"
+              >
+                Load more
+              </Button>
+            </Group>
+          )}
+        </>
       )}
 
       <OffsiteReviewModal
@@ -333,12 +436,16 @@ function ListingModActionModal({
 }) {
   const [reason, setReason] = useState('');
   const [targetUserId, setTargetUserId] = useState<number | ''>('');
+  // Typed-confirmation for the irreversible Purge: the mod must type the listing
+  // slug (in ADDITION to the reason) before the destructive button enables.
+  const [confirmText, setConfirmText] = useState('');
 
   async function afterSuccess(message: string) {
     showSuccessNotification({ message });
     await onDone();
     setReason('');
     setTargetUserId('');
+    setConfirmText('');
     onClose();
   }
   function onError(title: string) {
@@ -381,8 +488,13 @@ function ListingModActionModal({
   const trimmed = reason.trim();
   const validTarget =
     typeof targetUserId === 'number' && Number.isInteger(targetUserId) && targetUserId > 0;
+  // Purge additionally requires the mod to type the exact listing slug (typed-confirm).
+  const confirmMatches = confirmText.trim() === row.slug;
   const canSubmit =
-    !busy && trimmed.length >= OFFSITE_MOD_REASON_MIN && (!isClaim || validTarget);
+    !busy &&
+    trimmed.length >= OFFSITE_MOD_REASON_MIN &&
+    (!isClaim || validTarget) &&
+    (!destructive || confirmMatches);
 
   function submit() {
     switch (action) {
@@ -403,6 +515,7 @@ function ListingModActionModal({
   function reset() {
     setReason('');
     setTargetUserId('');
+    setConfirmText('');
     onClose();
   }
 
@@ -422,12 +535,29 @@ function ListingModActionModal({
     >
       <Stack gap="md">
         {destructive && (
-          <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
-            <Text size="sm">
-              Purge PERMANENTLY deletes this listing and its screenshots + reports. The audit event
-              (with the slug snapshot) is kept. This cannot be undone.
-            </Text>
-          </Alert>
+          <>
+            <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
+              <Text size="sm">
+                Purge PERMANENTLY deletes this listing and its screenshots + reports. The audit
+                event (with the slug snapshot) is kept. This cannot be undone.
+              </Text>
+            </Alert>
+            <TextInput
+              label={
+                <Text size="sm">
+                  Type the slug <Code>{row.slug}</Code> to confirm
+                </Text>
+              }
+              placeholder={row.slug}
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.currentTarget.value)}
+              disabled={busy}
+              error={
+                confirmText.length > 0 && !confirmMatches ? 'Does not match the slug' : undefined
+              }
+              data-testid="apps-mod-purge-confirm"
+            />
+          </>
         )}
         {isClaim && (
           <>

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -1,0 +1,481 @@
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Code,
+  Group,
+  Modal,
+  NumberInput,
+  SegmentedControl,
+  Stack,
+  Table,
+  Text,
+  Textarea,
+} from '@mantine/core';
+import { IconAlertTriangle, IconBox, IconThumbUp } from '@tabler/icons-react';
+import { Fragment, useMemo, useState } from 'react';
+import {
+  OffsiteReviewModal,
+  type OffsitePendingRow,
+} from '~/components/Apps/OffsiteReviewQueue';
+import { listingStatusChip } from '~/components/Apps/appListingModerationView';
+import {
+  isDestructiveListingModAction,
+  listingKindChip,
+  listingModActionLabel,
+  listingModActions,
+  type ListingModAction,
+} from '~/components/Apps/appListingModerationTableView';
+import {
+  MOD_STATUS_BUCKETS,
+  MOD_STATUS_SECTION_ORDER,
+  bucketGroupsByStatus,
+  groupSubmissionsByApp,
+  nextSortState,
+  sortGroups,
+  toDate,
+  type SortColumn,
+  type SortState,
+  type SubmissionAccessors,
+  type SubmissionGroup,
+} from '~/components/Apps/submissionsTable';
+import { SortableTh, StatusSections, SubmissionSearch } from '~/components/Apps/submissionsTableUi';
+import type { ModerationListingRow } from '~/server/services/blocks/app-listing.service';
+import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * /apps/review — the unified MODERATOR listings management table (W13 post-approval
+ * mgmt, P2). Reads `appListings.listAllListingsForModeration` (mod-only, all
+ * statuses) and renders it as the shared status SECTIONS
+ * (Live / Pending / Rejected / Removed / Draft) with a per-row kind badge, an owner
+ * chip, and KIND-AWARE inline lifecycle actions wired to the merged Phase 1 procs:
+ *   - pending  → Review (opens the existing off-site review modal to approve/reject),
+ *   - approved → Reset to pending (off-site) + Hide (delist, dual-kind),
+ *   - removed  → Relist (dual-kind) + Claim + Purge (off-site; Purge is destructive),
+ *   - draft/rejected → read-only (unless a pending request offers Review).
+ *
+ * Dark + mod-only: the whole /apps/review page requires `isAppReviewer`, the query
+ * is `moderatorProcedure`, and a query error (non-mod / flag off) renders nothing.
+ * Closes the "manage any listing without a report" gap (the report queue only
+ * surfaces reported listings) + gives the pending review its table-parity home.
+ */
+
+const MOD_ACCESSORS: SubmissionAccessors<ModerationListingRow> = {
+  identity: (r) => r.id,
+  name: (r) => r.name || r.slug,
+  slug: (r) => r.slug,
+  status: (r) => r.status,
+  submittedAt: (r) => toDate(r.pendingRequest?.submittedAt ?? null),
+  reviewedAt: () => null,
+};
+
+type KindFilter = 'all' | 'onsite' | 'offsite';
+
+/** Build the off-site review-modal row from a pending moderation listing row. */
+function toReviewRow(row: ModerationListingRow): OffsitePendingRow | null {
+  const pending = row.pendingRequest;
+  if (!pending) return null;
+  return {
+    id: pending.id,
+    appListingId: row.id,
+    slug: row.slug,
+    status: 'pending',
+    submittedAt: pending.submittedAt,
+    changelog: pending.changelog,
+    appListing: {
+      name: row.name,
+      externalUrl: row.externalUrl,
+      category: row.category,
+      contentRating: row.contentRating,
+    },
+    submittedBy: pending.submittedBy,
+  };
+}
+
+export function AppListingsModerationTable() {
+  const features = useFeatureFlags();
+  const utils = trpc.useUtils();
+  const [search, setSearch] = useState('');
+  const [kind, setKind] = useState<KindFilter>('all');
+  const [sort, setSort] = useState<SortState>({ column: 'app', direction: 'asc' });
+  const [reviewRow, setReviewRow] = useState<OffsitePendingRow | null>(null);
+  const [pendingAction, setPendingAction] = useState<{
+    action: ListingModAction;
+    row: ModerationListingRow;
+  } | null>(null);
+
+  const query = trpc.appListings.listAllListingsForModeration.useQuery(
+    {
+      limit: 50,
+      search: search.trim() || undefined,
+      kind: kind === 'all' ? undefined : kind,
+    },
+    { enabled: !!features?.appBlocks, retry: false }
+  );
+
+  const invalidate = () => utils.appListings.listAllListingsForModeration.invalidate();
+
+  const items = (query.data?.items ?? []) as ModerationListingRow[];
+
+  // Group (one group per listing — the mod view isn't version-collapsed), sort by
+  // the chosen column, then partition into the MOD status sections.
+  const buckets = useMemo(() => {
+    const grouped = groupSubmissionsByApp(items, MOD_ACCESSORS.identity, MOD_ACCESSORS.submittedAt);
+    const sorted = sortGroups(grouped, sort, MOD_ACCESSORS);
+    return bucketGroupsByStatus(sorted, MOD_ACCESSORS.status, MOD_STATUS_BUCKETS);
+  }, [items, sort]);
+
+  const totalGroups = MOD_STATUS_SECTION_ORDER.reduce((n, b) => n + buckets[b].length, 0);
+
+  // The query errors when the caller isn't a mod / the flag is off → render nothing
+  // (unobtrusive, mirrors the sibling mod queues).
+  if (query.error) return null;
+
+  const onSort = (column: SortColumn) => setSort((s) => nextSortState(s, column));
+
+  const openAction = (action: ListingModAction, row: ModerationListingRow) => {
+    if (action === 'review') {
+      const reviewable = toReviewRow(row);
+      if (reviewable) setReviewRow(reviewable);
+      return;
+    }
+    setPendingAction({ action, row });
+  };
+
+  const renderTable = (groups: SubmissionGroup<ModerationListingRow>[]) => (
+    <Card withBorder p={0}>
+      <Table verticalSpacing="md" horizontalSpacing="md">
+        <Table.Thead>
+          <Table.Tr>
+            <SortableTh label="App" column="app" sort={sort} onSort={onSort} />
+            <Table.Th>Owner</Table.Th>
+            <Table.Th>Category</Table.Th>
+            <Table.Th>Reviews</Table.Th>
+            <Table.Th />
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {groups.map((g) => {
+            const row = g.latest;
+            const kindChip = listingKindChip(row.kind);
+            const statusChip = listingStatusChip(row.status);
+            const actions = listingModActions({
+              status: row.status,
+              kind: row.kind,
+              hasPendingRequest: row.pendingRequest != null,
+            });
+            return (
+              <Fragment key={row.id}>
+                <Table.Tr data-testid={`apps-mod-listing-row-${row.slug}`}>
+                  <Table.Td>
+                    <Group gap={6}>
+                      <Code>{row.slug}</Code>
+                      <Badge size="xs" color={kindChip.color} variant="light">
+                        {kindChip.label}
+                      </Badge>
+                      <Badge size="xs" color={statusChip.color} variant="light">
+                        {statusChip.label}
+                      </Badge>
+                    </Group>
+                    {row.name && (
+                      <Text size="xs" c="dimmed">
+                        {row.name}
+                      </Text>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="xs">
+                      {row.owner?.username ? `@${row.owner.username}` : `#${row.owner?.id ?? '?'}`}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    {row.category ? (
+                      <Badge size="sm" variant="light">
+                        {row.category}
+                      </Badge>
+                    ) : (
+                      <Text size="xs" c="dimmed">
+                        —
+                      </Text>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    <Group gap={6}>
+                      <Badge
+                        size="sm"
+                        variant="light"
+                        color="green"
+                        leftSection={<IconThumbUp size={12} />}
+                        title="Recommend (thumbs up) count"
+                      >
+                        {row.thumbsUpCount}
+                      </Badge>
+                      <Badge
+                        size="sm"
+                        variant="light"
+                        color="blue"
+                        leftSection={<IconBox size={12} />}
+                        title="Install count"
+                      >
+                        {row.installCount}
+                      </Badge>
+                    </Group>
+                  </Table.Td>
+                  <Table.Td>
+                    {actions.length === 0 ? (
+                      <Text size="xs" c="dimmed">
+                        —
+                      </Text>
+                    ) : (
+                      <Group gap={4} justify="flex-end" wrap="nowrap">
+                        {actions.map((action) => (
+                          <Button
+                            key={action}
+                            size="xs"
+                            variant={isDestructiveListingModAction(action) ? 'filled' : 'default'}
+                            color={
+                              isDestructiveListingModAction(action)
+                                ? 'red'
+                                : action === 'review'
+                                ? 'blue'
+                                : undefined
+                            }
+                            onClick={() => openAction(action, row)}
+                            data-testid={`apps-mod-${action}-${row.slug}`}
+                          >
+                            {listingModActionLabel(action)}
+                          </Button>
+                        ))}
+                      </Group>
+                    )}
+                  </Table.Td>
+                </Table.Tr>
+              </Fragment>
+            );
+          })}
+        </Table.Tbody>
+      </Table>
+    </Card>
+  );
+
+  return (
+    <Stack gap="md" mt="lg">
+      <Group justify="space-between" align="flex-end">
+        <SubmissionSearch
+          value={search}
+          onChange={setSearch}
+          testId="apps-mod-listings-filter"
+          placeholder="Filter by app name or slug…"
+        />
+        <SegmentedControl
+          size="xs"
+          value={kind}
+          onChange={(v) => setKind(v as KindFilter)}
+          data={[
+            { label: 'All', value: 'all' },
+            { label: 'On-site', value: 'onsite' },
+            { label: 'External', value: 'offsite' },
+          ]}
+        />
+      </Group>
+
+      {query.isLoading ? (
+        <Text size="sm" c="dimmed">
+          Loading…
+        </Text>
+      ) : totalGroups === 0 ? (
+        <Card withBorder p="md">
+          <Text size="sm" c="dimmed" ta="center" py="sm">
+            No listings match the current filters.
+          </Text>
+        </Card>
+      ) : (
+        <StatusSections
+          buckets={buckets}
+          testIdPrefix="apps-mod-listings-section"
+          order={MOD_STATUS_SECTION_ORDER}
+          renderTable={renderTable}
+        />
+      )}
+
+      <OffsiteReviewModal
+        request={reviewRow}
+        onClose={() => setReviewRow(null)}
+        onActioned={invalidate}
+      />
+      <ListingModActionModal
+        pending={pendingAction}
+        onClose={() => setPendingAction(null)}
+        onDone={invalidate}
+      />
+    </Stack>
+  );
+}
+
+/**
+ * The reason/confirm modal for a single lifecycle action (reset-to-pending / hide /
+ * relist / claim / purge). Every action requires a reason (≥{@link
+ * OFFSITE_MOD_REASON_MIN} chars, audited); `claim` also needs a numeric target
+ * owner id; `purge` is destructive → an extra warning + a permanent confirm label.
+ */
+function ListingModActionModal({
+  pending,
+  onClose,
+  onDone,
+}: {
+  pending: { action: ListingModAction; row: ModerationListingRow } | null;
+  onClose: () => void;
+  onDone: () => Promise<void> | void;
+}) {
+  const [reason, setReason] = useState('');
+  const [targetUserId, setTargetUserId] = useState<number | ''>('');
+
+  async function afterSuccess(message: string) {
+    showSuccessNotification({ message });
+    await onDone();
+    setReason('');
+    setTargetUserId('');
+    onClose();
+  }
+  function onError(title: string) {
+    return (e: { message: string }) =>
+      showErrorNotification({ title, error: new Error(e.message) });
+  }
+
+  const resetMut = trpc.appListings.resetListingToPending.useMutation({
+    onSuccess: () => afterSuccess('Listing reset to pending.'),
+    onError: onError('Reset failed'),
+  });
+  const delistMut = trpc.appListings.delistListing.useMutation({
+    onSuccess: () => afterSuccess('Listing hidden.'),
+    onError: onError('Hide failed'),
+  });
+  const relistMut = trpc.appListings.relistListing.useMutation({
+    onSuccess: () => afterSuccess('Listing relisted.'),
+    onError: onError('Relist failed'),
+  });
+  const claimMut = trpc.appListings.claimListing.useMutation({
+    onSuccess: () => afterSuccess('Ownership reassigned.'),
+    onError: onError('Claim failed'),
+  });
+  const purgeMut = trpc.appListings.purgeListing.useMutation({
+    onSuccess: () => afterSuccess('Listing purged.'),
+    onError: onError('Purge failed'),
+  });
+
+  const busy =
+    resetMut.isPending ||
+    delistMut.isPending ||
+    relistMut.isPending ||
+    claimMut.isPending ||
+    purgeMut.isPending;
+
+  if (!pending) return null;
+  const { action, row } = pending;
+  const isClaim = action === 'claim';
+  const destructive = isDestructiveListingModAction(action);
+  const trimmed = reason.trim();
+  const validTarget =
+    typeof targetUserId === 'number' && Number.isInteger(targetUserId) && targetUserId > 0;
+  const canSubmit =
+    !busy && trimmed.length >= OFFSITE_MOD_REASON_MIN && (!isClaim || validTarget);
+
+  function submit() {
+    switch (action) {
+      case 'reset-to-pending':
+        return resetMut.mutate({ appListingId: row.id, reason: trimmed });
+      case 'hide':
+        return delistMut.mutate({ appListingId: row.id, reason: trimmed });
+      case 'relist':
+        return relistMut.mutate({ appListingId: row.id, reason: trimmed });
+      case 'claim':
+        if (typeof targetUserId !== 'number' || !validTarget) return;
+        return claimMut.mutate({ appListingId: row.id, targetUserId, reason: trimmed });
+      case 'purge':
+        return purgeMut.mutate({ appListingId: row.id, reason: trimmed });
+    }
+  }
+
+  function reset() {
+    setReason('');
+    setTargetUserId('');
+    onClose();
+  }
+
+  return (
+    <Modal
+      opened={!!pending}
+      onClose={() => {
+        if (busy) return;
+        reset();
+      }}
+      title={
+        <Text fw={600}>
+          {listingModActionLabel(action)} — {row.slug}
+        </Text>
+      }
+      centered
+    >
+      <Stack gap="md">
+        {destructive && (
+          <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
+            <Text size="sm">
+              Purge PERMANENTLY deletes this listing and its screenshots + reports. The audit event
+              (with the slug snapshot) is kept. This cannot be undone.
+            </Text>
+          </Alert>
+        )}
+        {isClaim && (
+          <>
+            <Alert color="blue" variant="light" icon={<IconAlertTriangle size={16} />}>
+              <Text size="sm">
+                Reassigns the listing OWNER to the user id below (verify ownership out-of-band
+                first). The original submission record is preserved. Reversible via a later claim.
+              </Text>
+            </Alert>
+            <NumberInput
+              label="New owner user id"
+              placeholder="e.g. 12345"
+              value={targetUserId}
+              onChange={(v) => setTargetUserId(typeof v === 'number' ? v : '')}
+              min={1}
+              allowNegative={false}
+              allowDecimal={false}
+              disabled={busy}
+              data-testid="apps-mod-claim-target"
+            />
+          </>
+        )}
+        <Textarea
+          label={`Reason (≥${OFFSITE_MOD_REASON_MIN} chars, audited)`}
+          autosize
+          minRows={3}
+          maxRows={8}
+          placeholder="Why this action — recorded in the audit trail."
+          value={reason}
+          onChange={(e) => setReason(e.currentTarget.value)}
+          disabled={busy}
+          data-testid="apps-mod-action-reason"
+        />
+        <Group justify="flex-end" gap="xs">
+          <Button variant="default" onClick={reset} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            color={destructive ? 'red' : undefined}
+            onClick={submit}
+            disabled={!canSubmit}
+            loading={busy}
+            data-testid="apps-mod-action-confirm"
+          >
+            {destructive ? 'Purge permanently' : listingModActionLabel(action)}
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -68,7 +68,7 @@ import { trpc } from '~/utils/trpc';
 
 type OffsiteUser = { id: number; username: string | null; image: string | null };
 
-type OffsitePendingRow = {
+export type OffsitePendingRow = {
   id: string;
   appListingId: string | null;
   slug: string;
@@ -212,12 +212,16 @@ export function OffsiteReviewQueue() {
   );
 }
 
-function OffsiteReviewModal({
+export function OffsiteReviewModal({
   request,
   onClose,
+  onActioned,
 }: {
   request: OffsitePendingRow | null;
   onClose: () => void;
+  /** Fired after a successful approve/reject — lets a host (e.g. the mod
+   *  management table) invalidate its own query in addition to the review queues. */
+  onActioned?: () => void | Promise<void>;
 }) {
   const utils = trpc.useUtils();
   const features = useFeatureFlags();
@@ -244,6 +248,7 @@ function OffsiteReviewModal({
       showSuccessNotification({ message: `Approved ${request?.slug}.` });
       await utils.appListings.listPendingRequests.invalidate();
       await utils.appListings.listApprovedRequests.invalidate();
+      await onActioned?.();
       close();
     },
     onError: (e: { message: string }) => {
@@ -255,6 +260,7 @@ function OffsiteReviewModal({
       showSuccessNotification({ message: `Rejected ${request?.slug}.` });
       await utils.appListings.listPendingRequests.invalidate();
       await utils.appListings.listRejectedRequests.invalidate();
+      await onActioned?.();
       close();
     },
     onError: (e: { message: string }) => {

--- a/src/components/Apps/__tests__/appListingModerationTableView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationTableView.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  actionRequiresReason,
+  isDestructiveListingModAction,
+  listingKindChip,
+  listingModActionLabel,
+  listingModActions,
+} from '~/components/Apps/appListingModerationTableView';
+
+/**
+ * W13 post-approval mgmt (P2) — the mod management-table action view model. The
+ * blocking correctness gate for the KIND-AWARE per-row action set (the browser
+ * suite is report-only). Pins: which actions each status offers, and that the
+ * off-site-only actions (reset-to-pending / claim / purge / review) NEVER appear
+ * on an on-site row while the dual-kind ones (hide / relist) do.
+ */
+
+describe('listingModActions — off-site rows', () => {
+  it('pending (with a pending request) → Review only', () => {
+    expect(listingModActions({ status: 'pending', kind: 'offsite', hasPendingRequest: true })).toEqual(
+      ['review']
+    );
+  });
+
+  it('approved → Reset to pending + Hide', () => {
+    expect(
+      listingModActions({ status: 'approved', kind: 'offsite', hasPendingRequest: false })
+    ).toEqual(['reset-to-pending', 'hide']);
+  });
+
+  it('removed → Relist + Claim + Purge', () => {
+    expect(
+      listingModActions({ status: 'removed', kind: 'offsite', hasPendingRequest: false })
+    ).toEqual(['relist', 'claim', 'purge']);
+  });
+
+  it('draft → no lifecycle action (unless a pending request offers Review)', () => {
+    expect(listingModActions({ status: 'draft', kind: 'offsite', hasPendingRequest: false })).toEqual(
+      []
+    );
+    expect(listingModActions({ status: 'draft', kind: 'offsite', hasPendingRequest: true })).toEqual(
+      ['review']
+    );
+  });
+
+  it('rejected → read-only', () => {
+    expect(
+      listingModActions({ status: 'rejected', kind: 'offsite', hasPendingRequest: false })
+    ).toEqual([]);
+  });
+});
+
+describe('listingModActions — on-site rows hide the off-site-only actions', () => {
+  it('approved on-site → Hide ONLY (no reset-to-pending)', () => {
+    expect(
+      listingModActions({ status: 'approved', kind: 'onsite', hasPendingRequest: false })
+    ).toEqual(['hide']);
+  });
+
+  it('removed on-site → Relist ONLY (no claim / purge)', () => {
+    expect(
+      listingModActions({ status: 'removed', kind: 'onsite', hasPendingRequest: false })
+    ).toEqual(['relist']);
+  });
+
+  it('pending on-site → NO Review (approve/reject is off-site only; onsite uses its own queue)', () => {
+    expect(
+      listingModActions({ status: 'pending', kind: 'onsite', hasPendingRequest: true })
+    ).toEqual([]);
+  });
+});
+
+describe('action metadata', () => {
+  it('only purge is destructive', () => {
+    expect(isDestructiveListingModAction('purge')).toBe(true);
+    for (const a of ['review', 'reset-to-pending', 'hide', 'relist', 'claim'] as const) {
+      expect(isDestructiveListingModAction(a)).toBe(false);
+    }
+  });
+
+  it('every action except review requires a reason', () => {
+    expect(actionRequiresReason('review')).toBe(false);
+    for (const a of ['reset-to-pending', 'hide', 'relist', 'claim', 'purge'] as const) {
+      expect(actionRequiresReason(a)).toBe(true);
+    }
+  });
+
+  it('labels each action', () => {
+    expect(listingModActionLabel('review')).toBe('Review');
+    expect(listingModActionLabel('reset-to-pending')).toBe('Reset to pending');
+    expect(listingModActionLabel('hide')).toBe('Hide');
+    expect(listingModActionLabel('relist')).toBe('Relist');
+    expect(listingModActionLabel('claim')).toBe('Claim');
+    expect(listingModActionLabel('purge')).toBe('Purge');
+  });
+
+  it('kind chip distinguishes external vs on-site', () => {
+    expect(listingKindChip('offsite')).toEqual({ label: 'external', color: 'grape' });
+    expect(listingKindChip('onsite')).toEqual({ label: 'on-site', color: 'blue' });
+  });
+});

--- a/src/components/Apps/__tests__/submissionsTable.mod.test.ts
+++ b/src/components/Apps/__tests__/submissionsTable.mod.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MOD_STATUS_BUCKETS,
+  MOD_STATUS_SECTION_ORDER,
+  bucketGroupsByStatus,
+  modStatusBucket,
+  type SubmissionGroup,
+} from '~/components/Apps/submissionsTable';
+
+/**
+ * W13 post-approval mgmt (P2) — the MOD-view bucketing extension. Proves the shared
+ * bucketing was made per-consumer WITHOUT changing the owner default:
+ *   - `modStatusBucket` maps the AppListing lifecycle (incl. `removed`/`draft`),
+ *   - `bucketGroupsByStatus(..., MOD_STATUS_BUCKETS)` yields the 5 mod sections and
+ *     buckets each listing by its own status.
+ * (The owner default — 4 sections, byte-identical — stays covered by
+ * `submissionsTable.test.ts`.)
+ */
+
+type Row = { id: string; status: string };
+
+/** A single-listing group (the mod view isn't version-collapsed). */
+function group(id: string, status: string): SubmissionGroup<Row> {
+  const latest: Row = { id, status };
+  return { identity: id, latest, older: [], versionCount: 1 };
+}
+
+const statusOf = (r: Row) => r.status;
+
+describe('modStatusBucket', () => {
+  it('maps the AppListing lifecycle to the mod sections', () => {
+    expect(modStatusBucket('approved')).toBe('live');
+    expect(modStatusBucket('pending')).toBe('pending');
+    expect(modStatusBucket('rejected')).toBe('rejected');
+    expect(modStatusBucket('removed')).toBe('removed');
+    expect(modStatusBucket('draft')).toBe('draft');
+  });
+
+  it('maps an unknown status to the (closed) draft section as a safe default', () => {
+    expect(modStatusBucket('archived')).toBe('draft');
+    expect(modStatusBucket('')).toBe('draft');
+  });
+});
+
+describe('MOD_STATUS_SECTION_ORDER', () => {
+  it('renders Live → Pending → Rejected → Removed → Draft', () => {
+    expect(MOD_STATUS_SECTION_ORDER).toEqual(['live', 'pending', 'rejected', 'removed', 'draft']);
+  });
+});
+
+describe('bucketGroupsByStatus with the MOD config', () => {
+  it('initialises exactly the five mod buckets and buckets each listing by status', () => {
+    const groups = [
+      group('a', 'approved'),
+      group('b', 'pending'),
+      group('c', 'rejected'),
+      group('d', 'removed'),
+      group('e', 'draft'),
+    ];
+    const buckets = bucketGroupsByStatus(groups, statusOf, MOD_STATUS_BUCKETS);
+    expect(Object.keys(buckets).sort()).toEqual(
+      ['draft', 'live', 'pending', 'rejected', 'removed'].sort()
+    );
+    expect(buckets.live.map((g) => g.identity)).toEqual(['a']);
+    expect(buckets.pending.map((g) => g.identity)).toEqual(['b']);
+    expect(buckets.rejected.map((g) => g.identity)).toEqual(['c']);
+    expect(buckets.removed.map((g) => g.identity)).toEqual(['d']);
+    expect(buckets.draft.map((g) => g.identity)).toEqual(['e']);
+  });
+
+  it('a removed listing buckets to Removed (NOT Live — no false any-approved promotion)', () => {
+    const buckets = bucketGroupsByStatus([group('x', 'removed')], statusOf, MOD_STATUS_BUCKETS);
+    expect(buckets.removed).toHaveLength(1);
+    expect(buckets.live).toHaveLength(0);
+  });
+
+  it('an empty input yields all five empty buckets', () => {
+    const buckets = bucketGroupsByStatus<Row, 'live' | 'pending' | 'rejected' | 'removed' | 'draft'>(
+      [],
+      statusOf,
+      MOD_STATUS_BUCKETS
+    );
+    expect(buckets).toEqual({ live: [], pending: [], rejected: [], removed: [], draft: [] });
+  });
+});

--- a/src/components/Apps/appListingModerationTableView.ts
+++ b/src/components/Apps/appListingModerationTableView.ts
@@ -1,0 +1,98 @@
+/**
+ * App Store Listings (W13 post-approval mgmt, P2) — the MOD MANAGEMENT TABLE view
+ * model (pure, React-free). The per-row lifecycle ACTION SET, computed from a
+ * listing's `status` + `kind` (+ whether a pending publish request exists), plus
+ * the human labels. Extracted so the correctness gate lives in the blocking node
+ * `unit` project (the civitai browser-mode suites are report-only), mirroring the
+ * sibling `appListingModerationView` (the report-queue view model).
+ *
+ * KIND-AWARENESS (from the merged Phase 1 procs):
+ *   - `reset-to-pending` / `claim` / `purge` are OFF-SITE ONLY (the service raises
+ *     NOT_FOUND for an on-site listing).
+ *   - `hide` (delist) / `relist` are DUAL-KIND (they flip the on-site AppBlock too).
+ *   - `review` opens the existing off-site review modal (approve/reject the pending
+ *     request) → off-site only, and only when a pending request exists.
+ */
+
+/** The lifecycle actions a mod row can offer (a subset renders per row). */
+export type ListingModAction =
+  | 'review'
+  | 'reset-to-pending'
+  | 'hide'
+  | 'relist'
+  | 'claim'
+  | 'purge';
+
+/**
+ * The ordered set of actions to render for a listing row.
+ *
+ *   - `review`: off-site + a pending publish request exists (any status — normally
+ *     a `pending` listing, but a lingering pending request on another status still
+ *     lets a mod open the review). Opens the reused off-site review modal.
+ *   - `approved` → `reset-to-pending` (off-site only) + `hide` (delist, dual-kind).
+ *   - `removed`  → `relist` (dual-kind) + `claim` + `purge` (both off-site only).
+ *   - `draft` / `rejected` → no lifecycle action (read-only) unless a pending
+ *     request makes `review` available.
+ */
+export function listingModActions(input: {
+  status: string;
+  kind: string;
+  hasPendingRequest: boolean;
+}): ListingModAction[] {
+  const offsite = input.kind === 'offsite';
+  const actions: ListingModAction[] = [];
+
+  // Review is available whenever there's a pending request to act on (off-site).
+  if (offsite && input.hasPendingRequest) actions.push('review');
+
+  if (input.status === 'approved') {
+    if (offsite) actions.push('reset-to-pending');
+    actions.push('hide'); // delist — dual-kind
+  }
+  if (input.status === 'removed') {
+    actions.push('relist'); // dual-kind
+    if (offsite) {
+      actions.push('claim');
+      actions.push('purge');
+    }
+  }
+  return actions;
+}
+
+/** Whether an action is the destructive one that must be confirmed before firing. */
+export function isDestructiveListingModAction(action: ListingModAction): boolean {
+  return action === 'purge';
+}
+
+/** Whether an action opens a reason-gated modal (all mutating actions require a reason). */
+export function actionRequiresReason(action: ListingModAction): boolean {
+  return action !== 'review';
+}
+
+/** Human label for a mod action button. */
+export function listingModActionLabel(action: ListingModAction): string {
+  switch (action) {
+    case 'review':
+      return 'Review';
+    case 'reset-to-pending':
+      return 'Reset to pending';
+    case 'hide':
+      return 'Hide';
+    case 'relist':
+      return 'Relist';
+    case 'claim':
+      return 'Claim';
+    case 'purge':
+      return 'Purge';
+  }
+}
+
+/** Chip descriptor (label + Mantine color name) for a listing's store status. */
+export type ListingKindChip = { label: string; color: string };
+
+/** Chip for a listing's `kind` (the per-row kind badge). */
+export function listingKindChip(kind: string): ListingKindChip {
+  return kind === 'offsite'
+    ? { label: 'external', color: 'grape' }
+    : { label: 'on-site', color: 'blue' };
+}

--- a/src/components/Apps/submissionsTable.ts
+++ b/src/components/Apps/submissionsTable.ts
@@ -230,7 +230,21 @@ export function ariaSortFor(
  */
 export type StatusBucket = 'live' | 'pending' | 'rejected' | 'withdrawn';
 
-/** The section render order (Live → Pending → Rejected → Withdrawn). */
+/**
+ * The MOD-view status buckets (Live / Pending / Rejected / **Removed** / Draft).
+ * The owner (submitter) view uses {@link StatusBucket} — a listing an author can
+ * `withdraw`; the moderator view manages the durable `AppListing` lifecycle
+ * (`draft|pending|approved|rejected|removed`), where the terminal takedown state
+ * is `removed` (not `withdrawn`) and an un-submitted `draft` still exists. Kept a
+ * DISTINCT union (rather than widening `StatusBucket`) so the owner lists' bucket
+ * SET stays exactly its four sections — see {@link StatusBucketConfig}.
+ */
+export type ModStatusBucket = 'live' | 'pending' | 'rejected' | 'removed' | 'draft';
+
+/** Every bucket ANY consumer can render (owner ∪ mod) — the section-META key set. */
+export type AnyStatusBucket = StatusBucket | ModStatusBucket;
+
+/** The OWNER section render order (Live → Pending → Rejected → Withdrawn). */
 export const STATUS_SECTION_ORDER: readonly StatusBucket[] = [
   'live',
   'pending',
@@ -238,7 +252,21 @@ export const STATUS_SECTION_ORDER: readonly StatusBucket[] = [
   'withdrawn',
 ];
 
-/** Map a raw submission status → its display section. Unknown → `withdrawn`. */
+/**
+ * The MOD section render order (Live → Pending → Rejected → Removed → Draft). A
+ * `draft` listing (author hasn't submitted, or an abandoned draft) is surfaced in
+ * a de-emphasised trailing section rather than DROPPED, so an all-status mod read
+ * never silently hides a row.
+ */
+export const MOD_STATUS_SECTION_ORDER: readonly ModStatusBucket[] = [
+  'live',
+  'pending',
+  'rejected',
+  'removed',
+  'draft',
+];
+
+/** Map a raw submission status → its OWNER display section. Unknown → `withdrawn`. */
 export function statusBucket(status: string): StatusBucket {
   switch (status) {
     case 'approved':
@@ -254,11 +282,64 @@ export function statusBucket(status: string): StatusBucket {
   }
 }
 
-/** Groups partitioned into the four status sections (by each group's `latest`). */
-export type BucketedGroups<T> = Record<StatusBucket, SubmissionGroup<T>[]>;
+/**
+ * Map a raw `AppListing.status` → its MOD display section. `approved` → **live**,
+ * `removed` → **removed** (the mod takedown state), `draft` → **draft**. Unknown →
+ * `draft` (a safe closed default that keeps a future status visible-but-quiet
+ * rather than vanishing).
+ */
+export function modStatusBucket(status: string): ModStatusBucket {
+  switch (status) {
+    case 'approved':
+      return 'live';
+    case 'pending':
+      return 'pending';
+    case 'rejected':
+      return 'rejected';
+    case 'removed':
+      return 'removed';
+    case 'draft':
+      return 'draft';
+    default:
+      return 'draft';
+  }
+}
 
 /**
- * Partition already-grouped submissions into the four status sections. Preserves
+ * A per-consumer bucketing config: which buckets exist (the render/init key set)
+ * and how a raw status maps into one. Lets the owner lists keep their exact four
+ * sections while the mod table uses its five — see {@link bucketGroupsByStatus}.
+ */
+export type StatusBucketConfig<B extends string> = {
+  buckets: readonly B[];
+  bucketOf: (status: string) => B;
+};
+
+/** The OWNER (submitter) bucketing config — the default for {@link bucketGroupsByStatus}. */
+export const OWNER_STATUS_BUCKETS: StatusBucketConfig<StatusBucket> = {
+  buckets: STATUS_SECTION_ORDER,
+  bucketOf: statusBucket,
+};
+
+/** The MOD (moderator listings table) bucketing config. */
+export const MOD_STATUS_BUCKETS: StatusBucketConfig<ModStatusBucket> = {
+  buckets: MOD_STATUS_SECTION_ORDER,
+  bucketOf: modStatusBucket,
+};
+
+/**
+ * Groups partitioned into a consumer's status sections. Generic over the bucket
+ * key `B` so the owner view yields exactly `{live,pending,rejected,withdrawn}` and
+ * the mod view yields its own set.
+ */
+export type BucketedGroups<T, B extends string = StatusBucket> = Record<
+  B,
+  SubmissionGroup<T>[]
+>;
+
+/**
+ * Partition already-grouped submissions into a consumer's status sections
+ * (default: the OWNER config → the original four buckets, unchanged). Preserves
  * the incoming group order within each bucket (so a pre-applied sort is retained).
  * PURE — never mutates the input.
  *
@@ -268,18 +349,22 @@ export type BucketedGroups<T> = Record<StatusBucket, SubmissionGroup<T>[]>;
  * on the published version within the group) instead of burying it in the
  * default-collapsed Rejected/Withdrawn section — reachable normally when a live app
  * gets an update that's then rejected or withdrawn. Only groups that have NEVER been
- * approved bucket by their `latest` submission's status (see {@link statusBucket}).
+ * approved bucket by their `latest` submission's status (see the config's `bucketOf`).
+ * (For the mod table each row is a single listing — one "version" — so the
+ * any-approved→live rule reduces to "an `approved` listing is Live".)
  */
-export function bucketGroupsByStatus<T>(
+export function bucketGroupsByStatus<T, B extends string = StatusBucket>(
   groups: readonly SubmissionGroup<T>[],
-  statusOf: (row: T) => string
-): BucketedGroups<T> {
-  const result: BucketedGroups<T> = { live: [], pending: [], rejected: [], withdrawn: [] };
+  statusOf: (row: T) => string,
+  config: StatusBucketConfig<B> = OWNER_STATUS_BUCKETS as unknown as StatusBucketConfig<B>
+): BucketedGroups<T, B> {
+  const result = {} as BucketedGroups<T, B>;
+  for (const b of config.buckets) result[b] = [];
   for (const group of groups) {
     const hasPublishedVersion = [group.latest, ...group.older].some(
       (v) => statusOf(v) === 'approved'
     );
-    const bucket = hasPublishedVersion ? 'live' : statusBucket(statusOf(group.latest));
+    const bucket = hasPublishedVersion ? ('live' as B) : config.bucketOf(statusOf(group.latest));
     result[bucket].push(group);
   }
   return result;

--- a/src/components/Apps/submissionsTableUi.tsx
+++ b/src/components/Apps/submissionsTableUi.tsx
@@ -11,10 +11,10 @@ import { useState, type ReactNode } from 'react';
 import {
   ariaSortFor,
   STATUS_SECTION_ORDER,
+  type AnyStatusBucket,
   type BucketedGroups,
   type SortColumn,
   type SortState,
-  type StatusBucket,
   type SubmissionGroup,
 } from '~/components/Apps/submissionsTable';
 
@@ -139,13 +139,19 @@ export function VersionCountBadge({ count }: { count: number }) {
  * focused on what still needs attention.
  */
 export const STATUS_SECTION_META: Record<
-  StatusBucket,
+  AnyStatusBucket,
   { label: string; color: string; collapsible: boolean }
 > = {
   live: { label: 'Live', color: 'green', collapsible: false },
   pending: { label: 'Pending', color: 'blue', collapsible: false },
   rejected: { label: 'Rejected', color: 'red', collapsible: true },
   withdrawn: { label: 'Withdrawn', color: 'gray', collapsible: true },
+  // Mod-view sections (Live/Pending/Rejected reuse the entries above). `removed`
+  // (the mod takedown state) stays ALWAYS-EXPANDED — a removed listing still has
+  // relist/purge/claim actions a mod needs in view; `draft` is a quiet, terminal
+  // default-collapsed trailing section.
+  removed: { label: 'Removed', color: 'red', collapsible: false },
+  draft: { label: 'Draft', color: 'gray', collapsible: true },
 };
 
 /**
@@ -217,22 +223,26 @@ function StatusSection({
  * both the onsite (`MySubmissionsList`) and offsite (`OffsiteSubmissionsList`)
  * lists so the section layout + collapse behavior are identical.
  */
-export function StatusSections<T>({
+export function StatusSections<T, B extends string = AnyStatusBucket>({
   buckets,
   testIdPrefix,
   renderTable,
+  order = STATUS_SECTION_ORDER as unknown as readonly B[],
 }: {
-  buckets: BucketedGroups<T>;
+  buckets: BucketedGroups<T, B>;
   /** e.g. `apps-submissions-section` → section testids `${prefix}-live` etc. */
   testIdPrefix: string;
   renderTable: (groups: SubmissionGroup<T>[]) => ReactNode;
+  /** Which buckets to render, in order. Defaults to the OWNER four sections; the
+   *  mod table passes `MOD_STATUS_SECTION_ORDER`. */
+  order?: readonly B[];
 }) {
   return (
     <Stack gap="lg">
-      {STATUS_SECTION_ORDER.map((bucket) => {
+      {order.map((bucket) => {
         const groups = buckets[bucket];
         if (groups.length === 0) return null;
-        const meta = STATUS_SECTION_META[bucket];
+        const meta = STATUS_SECTION_META[bucket as AnyStatusBucket];
         return (
           <StatusSection
             key={bucket}

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -37,7 +37,12 @@ import { useRouter } from 'next/router';
 import type { MouseEvent } from 'react';
 import { useMemo, useRef, useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
-import { OffsiteReportsQueue, OffsiteReviewQueue } from '~/components/Apps/OffsiteReviewQueue';
+import { AppListingsModerationTable } from '~/components/Apps/AppListingsModerationTable';
+// `OffsiteReviewQueue` (the flat pending-only off-site list) is SUPERSEDED by the
+// unified `AppListingsModerationTable` below (which covers pending too, via the
+// per-row Review action). It stays exported for a one-line rollback: swap the
+// `<AppListingsModerationTable />` in the Pending panel back to `<OffsiteReviewQueue />`.
+import { OffsiteReportsQueue } from '~/components/Apps/OffsiteReviewQueue';
 import { pickReviewIframeSrc } from '~/components/Apps/reviewIframeSrc';
 import { Meta } from '~/components/Meta/Meta';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
@@ -241,13 +246,18 @@ export default function ReviewQueuePage() {
           </Tabs.List>
 
           <Tabs.Panel value="pending" pt="md">
-            {/* On-site (App Block) queue — deep code review (byte-unchanged). */}
+            {/* On-site (App Block) queue — deep code review (byte-unchanged). The
+                onsite iframe/preview review lives here and is KEPT as-is. */}
             <PendingTab
               onSelect={(r) => setSelected({ request: r, mode: 'pending' })}
             />
-            {/* Off-site (external-link) queue — lighter content-only review (W13
-                P3a). Kind-aware: its own table + modal + approve/reject procs. */}
-            <OffsiteReviewQueue />
+            {/* Unified moderator LISTINGS MANAGEMENT table (W13 post-approval mgmt,
+                P2) — all statuses across both kinds, with per-row lifecycle actions.
+                REPLACES the flat off-site pending list (`OffsiteReviewQueue`): a
+                pending off-site row's Review action opens that same review modal, so
+                the table now covers pending too while adding post-approval
+                management (reset/hide/relist/claim/purge) that had no home. */}
+            <AppListingsModerationTable />
           </Tabs.Panel>
 
           <Tabs.Panel value="approved" pt="md">

--- a/src/server/routers/__tests__/app-listings.router.moderation-table.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.moderation-table.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * W13 post-approval mgmt (P2) — `appListings.listAllListingsForModeration` authz.
+ *
+ * The mod management-table read is a `moderatorProcedure`: anon + non-mod callers
+ * are rejected (the service is never consulted), a moderator is served, and the
+ * validated filter input is forwarded to the service. The service is mocked so
+ * importing the router doesn't drag in the generated Prisma client.
+ */
+
+const { mockListAll } = vi.hoisted(() => ({ mockListAll: vi.fn() }));
+
+vi.mock('~/server/services/blocks/app-listing.service', () => ({
+  listAllListingsForModeration: (...a: unknown[]) => mockListAll(...a),
+}));
+// rateLimit pulls in redis; stub to pass-through (the unit under test is authz).
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+vi.mock('~/server/utils/server-domain', () => ({ isHostForColor: () => false }));
+
+import { appListingsRouter } from '../app-listings.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+const modUser = { id: 1, isModerator: true, tier: 'free', username: 'mod' };
+const normalUser = { id: 2, isModerator: false, tier: 'free', username: 'user' };
+
+beforeEach(() => {
+  mockListAll.mockReset();
+  mockListAll.mockResolvedValue({ items: [{ id: 'apl_1' }], nextCursor: null });
+});
+
+describe('appListings.listAllListingsForModeration — mod-only', () => {
+  it('anonymous → rejected, service NOT consulted', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.listAllListingsForModeration({})).rejects.toBeInstanceOf(TRPCError);
+    expect(mockListAll).not.toHaveBeenCalled();
+  });
+
+  it('non-moderator → rejected, service NOT consulted', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.listAllListingsForModeration({})).rejects.toBeInstanceOf(TRPCError);
+    expect(mockListAll).not.toHaveBeenCalled();
+  });
+
+  it('moderator → served', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.listAllListingsForModeration({});
+    expect(result).toEqual({ items: [{ id: 'apl_1' }], nextCursor: null });
+    expect(mockListAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards the validated status/kind/search filters to the service', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(modUser) as never);
+    await caller.listAllListingsForModeration({
+      status: 'removed',
+      kind: 'offsite',
+      search: 'cool',
+      limit: 10,
+    });
+    expect(mockListAll).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'removed', kind: 'offsite', search: 'cool', limit: 10 })
+    );
+  });
+
+  it('rejects an out-of-range limit at the schema boundary (>50)', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(
+      caller.listAllListingsForModeration({ limit: 999 } as never)
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockListAll).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -12,6 +12,7 @@ import {
 } from '~/server/schema/blocks/app-listing.schema';
 import {
   getAppListingDetailSchema,
+  listAllListingsForModerationSchema,
   listAppListingsSchema,
 } from '~/server/schema/blocks/app-listing-read.schema';
 import {
@@ -950,6 +951,25 @@ export const appListingsRouter = router({
       } catch (err) {
         throw mapOffsiteError(err);
       }
+    }),
+
+  /**
+   * MOD: the ALL-STATUS listings management table (W13 post-approval mgmt, P2) —
+   * every lifecycle status (draft|pending|approved|rejected|removed), keyset-
+   * paginated, optional status/kind/search filters. Read-only `moderatorProcedure`
+   * (mirrors the sibling mod-read queues `listPendingRequests`/`listListingReports`
+   * — mod-only server-side; the client gates rendering on the app-blocks flag +
+   * treats a query error as "render nothing"). The per-row lifecycle ACTIONS reuse
+   * the merged Phase 1 procs (resetListingToPending / delist / relist / claim /
+   * purge) + the off-site approve/reject review flow.
+   */
+  listAllListingsForModeration: moderatorProcedure
+    .input(listAllListingsForModerationSchema)
+    .query(async ({ input }) => {
+      const { listAllListingsForModeration } = await import(
+        '~/server/services/blocks/app-listing.service'
+      );
+      return listAllListingsForModeration(input);
     }),
 
   // -------------------------------------------------------------------------

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -1,6 +1,7 @@
 import * as z from 'zod';
 
 import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
+import { APP_LISTING_STATUSES } from '~/server/services/blocks/app-listing-status.constants';
 
 /**
  * App Store Listings (W13) — P2a UNIFIED STORE READ PATH schemas + public DTOs.
@@ -56,6 +57,31 @@ export const listAppListingsSchema = z.object({
   limit: z.number().int().min(1).max(50).default(20),
 });
 export type ListAppListingsInput = z.infer<typeof listAppListingsSchema>;
+
+/**
+ * W13 POST-APPROVAL MOD MANAGEMENT — the moderator all-status listings read.
+ *
+ * Backs `appListings.listAllListingsForModeration` (moderatorProcedure): unlike
+ * the public `listAvailable` (approved-only, public allowlist), this returns
+ * listings across EVERY lifecycle status for the mod management table. All filters
+ * are optional (omitted = the whole store); `search` matches name OR slug
+ * server-side (case-insensitive). Keyset-paginated by the ULID `id` (a stable
+ * total order), bounded `limit` ≤ 50 (mirrors `listListingReportsSchema`).
+ */
+export const listAllListingsForModerationSchema = z.object({
+  // Full AppListing lifecycle set (draft|pending|approved|rejected|removed).
+  status: z.enum(APP_LISTING_STATUSES).optional(),
+  kind: z.enum(['onsite', 'offsite']).optional(),
+  // Server-side name/slug substring filter (bounded; trimmed in the service).
+  search: z.string().max(200).optional(),
+  // Opaque keyset cursor = the last row's `id` (bounded, same as the sibling
+  // mod-read queues). A tampered value just yields a different/empty page.
+  cursor: z.string().min(1).max(64).optional(),
+  limit: z.number().int().min(1).max(50).default(25),
+});
+export type ListAllListingsForModerationInput = z.infer<
+  typeof listAllListingsForModerationSchema
+>;
 
 /** Detail lookup by EXACTLY ONE of slug or id (approved listings only). */
 export const getAppListingDetailSchema = z

--- a/src/server/services/blocks/__tests__/app-listing.moderation.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.moderation.service.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * W13 POST-APPROVAL MOD MANAGEMENT (P2) — the moderator ALL-STATUS listings read
+ * (`listAllListingsForModeration`). We do NOT hit a DB — `dbRead.appListing.findMany`
+ * is mocked so we can assert the WHERE (status/kind/search + shadow exclusion), the
+ * keyset (orderBy id DESC, take limit+1, cursor skip), the pagination contract
+ * (nextCursor only on page+1), the limit clamp (≤50), and the projected row shape
+ * (owner chip, metric counts default 0, the latest pending-request projection).
+ */
+
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    appListing: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (src: string) => src }));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  queryCache:
+    () =>
+    async (sql: unknown): Promise<unknown[]> =>
+      mockDbRead.$queryRaw(sql),
+}));
+
+import {
+  listAllListingsForModeration,
+  projectModerationListing,
+} from '../app-listing.service';
+
+/** A hydrated moderation row as `moderationListingSelect` returns it. */
+function modRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 'apl_9',
+    slug: 'cool-app',
+    name: 'Cool App',
+    kind: 'offsite',
+    status: 'approved',
+    category: 'utility',
+    contentRating: 'pg',
+    externalUrl: 'https://ext.example/app',
+    appBlockId: null,
+    user: { id: 7, username: 'dev', image: 'avatar-key' },
+    metric: { installCount: 5, thumbsUpCount: 9, thumbsDownCount: 1 },
+    publishRequests: [],
+    ...over,
+  };
+}
+
+/** The last findMany call's args. */
+function lastFindMany() {
+  return mockDbRead.appListing.findMany.mock.calls.at(-1)?.[0] as {
+    where?: Record<string, unknown>;
+    orderBy?: unknown;
+    take?: number;
+    cursor?: unknown;
+    skip?: number;
+  };
+}
+
+describe('projectModerationListing', () => {
+  it('projects the row DTO (owner chip, counts, no pending request)', () => {
+    const dto = projectModerationListing(modRow() as never);
+    expect(dto).toMatchObject({
+      id: 'apl_9',
+      slug: 'cool-app',
+      name: 'Cool App',
+      kind: 'offsite',
+      status: 'approved',
+      category: 'utility',
+      contentRating: 'pg',
+      externalUrl: 'https://ext.example/app',
+      appBlockId: null,
+      owner: { id: 7, username: 'dev', image: 'avatar-key' },
+      installCount: 5,
+      thumbsUpCount: 9,
+      thumbsDownCount: 1,
+      pendingRequest: null,
+    });
+  });
+
+  it('defaults metric counts to 0 when there is no metric row', () => {
+    const dto = projectModerationListing(modRow({ metric: null }) as never);
+    expect(dto.installCount).toBe(0);
+    expect(dto.thumbsUpCount).toBe(0);
+    expect(dto.thumbsDownCount).toBe(0);
+  });
+
+  it('projects the LATEST pending publish request when present', () => {
+    const dto = projectModerationListing(
+      modRow({
+        status: 'pending',
+        publishRequests: [
+          {
+            id: 'alpr_1',
+            submittedAt: new Date('2026-01-02T00:00:00Z'),
+            changelog: 'first version',
+            submittedBy: { id: 42, username: 'author', image: null },
+          },
+        ],
+      }) as never
+    );
+    expect(dto.pendingRequest).toEqual({
+      id: 'alpr_1',
+      submittedAt: new Date('2026-01-02T00:00:00Z'),
+      changelog: 'first version',
+      submittedBy: { id: 42, username: 'author', image: null },
+    });
+  });
+
+  it('a vanished owner yields a null owner chip', () => {
+    expect(projectModerationListing(modRow({ user: null }) as never).owner).toBeNull();
+  });
+});
+
+describe('listAllListingsForModeration — filters, keyset + pagination', () => {
+  beforeEach(() => {
+    mockDbRead.appListing.findMany.mockReset();
+    mockDbRead.appListing.findMany.mockResolvedValue([]);
+  });
+
+  it('excludes shadow revision drafts (revisionOfId: null) and applies no filter by default', async () => {
+    await listAllListingsForModeration({ limit: 25 });
+    const { where, orderBy, take } = lastFindMany();
+    expect(where).toEqual({ revisionOfId: null });
+    expect(orderBy).toEqual({ id: 'desc' });
+    expect(take).toBe(26); // limit + 1
+  });
+
+  it('binds the status filter when provided', async () => {
+    await listAllListingsForModeration({ status: 'removed', limit: 25 });
+    expect(lastFindMany().where).toMatchObject({ status: 'removed', revisionOfId: null });
+  });
+
+  it('binds the kind filter when provided', async () => {
+    await listAllListingsForModeration({ kind: 'onsite', limit: 25 });
+    expect(lastFindMany().where).toMatchObject({ kind: 'onsite' });
+  });
+
+  it('builds a case-insensitive name/slug OR for search (trimmed)', async () => {
+    await listAllListingsForModeration({ search: '  Cool  ', limit: 25 });
+    expect(lastFindMany().where).toMatchObject({
+      OR: [
+        { name: { contains: 'Cool', mode: 'insensitive' } },
+        { slug: { contains: 'Cool', mode: 'insensitive' } },
+      ],
+    });
+  });
+
+  it('omits the search OR when the trimmed query is empty', async () => {
+    await listAllListingsForModeration({ search: '   ', limit: 25 });
+    expect(lastFindMany().where).not.toHaveProperty('OR');
+  });
+
+  it('clamps the page size to 50 (take = 51)', async () => {
+    // The zod schema caps at 50, but the service double-clamps (it is exported).
+    await listAllListingsForModeration({ limit: 999 as never });
+    expect(lastFindMany().take).toBe(51);
+  });
+
+  it('passes the cursor as a keyset (cursor:{id}, skip:1)', async () => {
+    await listAllListingsForModeration({ cursor: 'apl_5', limit: 25 });
+    const call = lastFindMany();
+    expect(call.cursor).toEqual({ id: 'apl_5' });
+    expect(call.skip).toBe(1);
+  });
+
+  it('no cursor/skip on the first page', async () => {
+    await listAllListingsForModeration({ limit: 25 });
+    const call = lastFindMany();
+    expect(call.cursor).toBeUndefined();
+    expect(call.skip).toBeUndefined();
+  });
+
+  it('emits nextCursor = the last row id only when a full page+1 is returned', async () => {
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([
+      modRow({ id: 'apl_3' }),
+      modRow({ id: 'apl_2' }),
+      modRow({ id: 'apl_1' }), // the +1 (dropped)
+    ]);
+    const { items, nextCursor } = await listAllListingsForModeration({ limit: 2 });
+    expect(items.map((i) => i.id)).toEqual(['apl_3', 'apl_2']);
+    expect(nextCursor).toBe('apl_2');
+  });
+
+  it('no nextCursor when the result fits in one page', async () => {
+    mockDbRead.appListing.findMany.mockResolvedValueOnce([modRow({ id: 'apl_1' })]);
+    const { items, nextCursor } = await listAllListingsForModeration({ limit: 25 });
+    expect(items).toHaveLength(1);
+    expect(nextCursor).toBeNull();
+  });
+});

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -8,6 +8,7 @@ import { toPublicBlockManifest } from '~/server/schema/blocks/subscription.schem
 import { isMatureContentRating } from '~/server/utils/server-domain';
 import type {
   GetAppListingDetailInput,
+  ListAllListingsForModerationInput,
   ListAppListingsInput,
   ListingCard,
   ListingCardKindData,
@@ -530,4 +531,153 @@ export async function getListingDetail(
   if (!redCapable && isMatureContentRating(row.contentRating)) return null;
 
   return projectListingDetail(row);
+}
+
+// ---------------------------------------------------------------------------
+// W13 POST-APPROVAL MOD MANAGEMENT — the moderator ALL-STATUS listings read.
+//
+// The mod management table's data source: listings across EVERY lifecycle status
+// (draft|pending|approved|rejected|removed), with the fields the table + the
+// per-row lifecycle actions need — NOT the public allowlist (this is mod-only, so
+// it carries `status`, the owner chip, and the latest pending publish-request id
+// so the Review action can open the existing off-site review modal). Keyset-
+// paginated by the ULID `id` (a stable total order); mirrors the sibling mod-read
+// queues' Prisma-cursor discipline. Shadow revision drafts are excluded.
+// ---------------------------------------------------------------------------
+
+/** A public creator/submitter chip (id/username/image only — the standard subset). */
+export type ModerationUserChip = { id: number; username: string | null; image: string | null };
+
+/** One row of the moderator all-status listings table (a single `AppListing`). */
+export type ModerationListingRow = {
+  id: string;
+  slug: string;
+  name: string;
+  kind: ListingKind;
+  status: string;
+  category: string | null;
+  contentRating: string | null;
+  /** Off-site external-link target (for the review modal / a Visit affordance). */
+  externalUrl: string | null;
+  /** Backing AppBlock id (onsite), else null. */
+  appBlockId: string | null;
+  owner: ModerationUserChip | null;
+  installCount: number;
+  thumbsUpCount: number;
+  thumbsDownCount: number;
+  /**
+   * The listing's LATEST pending publish request, when one exists (a pending
+   * listing has one) — carries what the reused off-site review modal needs. Null
+   * when nothing is pending review for this listing.
+   */
+  pendingRequest: {
+    id: string;
+    submittedAt: Date;
+    changelog: string | null;
+    submittedBy: ModerationUserChip | null;
+  } | null;
+};
+
+/**
+ * The Prisma `select` for a moderation-table row. Includes `status` + the owner
+ * chip + the metric counts + the SINGLE latest pending publish request (the
+ * Review action's `publishRequestId` + the fields to build the modal's row).
+ */
+export const moderationListingSelect = {
+  id: true,
+  slug: true,
+  name: true,
+  kind: true,
+  status: true,
+  category: true,
+  contentRating: true,
+  externalUrl: true,
+  appBlockId: true,
+  user: { select: { id: true, username: true, image: true } },
+  metric: { select: { installCount: true, thumbsUpCount: true, thumbsDownCount: true } },
+  publishRequests: {
+    where: { status: 'pending' },
+    orderBy: { submittedAt: 'desc' },
+    take: 1,
+    select: {
+      id: true,
+      submittedAt: true,
+      changelog: true,
+      submittedBy: { select: { id: true, username: true, image: true } },
+    },
+  },
+} satisfies Prisma.AppListingSelect;
+
+type HydratedModerationRow = Prisma.AppListingGetPayload<{ select: typeof moderationListingSelect }>;
+
+/** Project a hydrated moderation row → the {@link ModerationListingRow} DTO. */
+export function projectModerationListing(row: HydratedModerationRow): ModerationListingRow {
+  const pending = row.publishRequests[0] ?? null;
+  return {
+    id: row.id,
+    slug: row.slug,
+    name: row.name,
+    kind: row.kind as ListingKind,
+    status: row.status,
+    category: row.category ?? null,
+    contentRating: row.contentRating ?? null,
+    externalUrl: row.externalUrl ?? null,
+    appBlockId: row.appBlockId ?? null,
+    owner: creatorChip(row.user),
+    installCount: row.metric?.installCount ?? 0,
+    thumbsUpCount: row.metric?.thumbsUpCount ?? 0,
+    thumbsDownCount: row.metric?.thumbsDownCount ?? 0,
+    pendingRequest: pending
+      ? {
+          id: pending.id,
+          submittedAt: pending.submittedAt,
+          changelog: pending.changelog ?? null,
+          submittedBy: creatorChip(pending.submittedBy),
+        }
+      : null,
+  };
+}
+
+/**
+ * List listings across ALL lifecycle statuses for the mod management table.
+ * Filters (all optional): `status`, `kind`, and a server-side `search` over
+ * name/slug (case-insensitive). Keyset-paginated by the ULID `id` DESC (newest
+ * first, a stable total order — the opaque cursor is the last row's id); bounded
+ * to 50. Shadow revision drafts (`revisionOfId != null`) are never surfaced.
+ */
+export async function listAllListingsForModeration(
+  input: ListAllListingsForModerationInput
+): Promise<{ items: ModerationListingRow[]; nextCursor: string | null }> {
+  const limit = Math.min(input.limit ?? 25, 50);
+  const search = input.search?.trim();
+
+  const where: Prisma.AppListingWhereInput = {
+    // Never surface a SHADOW revision draft as its own row (mirrors the read path).
+    revisionOfId: null,
+    ...(input.status ? { status: input.status } : {}),
+    ...(input.kind ? { kind: input.kind } : {}),
+    ...(search
+      ? {
+          OR: [
+            { name: { contains: search, mode: 'insensitive' } },
+            { slug: { contains: search, mode: 'insensitive' } },
+          ],
+        }
+      : {}),
+  };
+
+  const rows = await dbRead.appListing.findMany({
+    where,
+    // `id` is `apl_<ULID>` → lexicographically creation-ordered, so `id DESC` is
+    // both "newest first" AND a stable total keyset (id is unique).
+    orderBy: { id: 'desc' },
+    take: limit + 1,
+    ...(input.cursor ? { cursor: { id: input.cursor }, skip: 1 } : {}),
+    select: moderationListingSelect,
+  });
+
+  const hasNext = rows.length > limit;
+  const page = hasNext ? rows.slice(0, limit) : rows;
+  const items = page.map(projectModerationListing);
+  return { items, nextCursor: hasNext ? items[items.length - 1].id : null };
 }


### PR DESCRIPTION
## What

Phase 2 of W13 "post-approval listing management": a unified **moderator listings management table** on `/apps/review` + the query behind it. Dark / flag-gated / reversible. Wires the **merged Phase 1** procs (no Phase 1 proc changed — this only ADDs the query + UI).

Closes two gaps:
- **"manage any listing without a report"** — the existing report queue only surfaces *reported* listings; a mod couldn't reset/hide/relist/claim/purge an arbitrary listing.
- **/apps/review table-parity** — the flat off-site pending list is replaced by an all-status table that covers pending too (via a per-row Review action).

## The query — `appListings.listAllListingsForModeration` (moderatorProcedure)
Listings across **every** lifecycle status (`draft|pending|approved|rejected|removed`), keyset-paginated by the ULID `id` (a stable total order; opaque bounded cursor, `limit ≤ 50`), optional `status` / `kind` / `search` (server-side name/slug, case-insensitive) filters, shadow revision drafts excluded. Projection = what the table + actions need: id/slug/name/kind/status/category/contentRating/externalUrl/appBlockId, owner chip, install + thumbs counts, and — for a pending listing — the **latest pending publish-request id** (+ submitter/changelog) so the review modal can open. Mod-only (mirrors the sibling mod-read queues); a query error renders nothing.

## Shared bucketing (owner lists kept green)
Made the shared `submissionsTable` bucketing **per-consumer**: added a `removed` (+ `draft`) bucket and a `MOD_STATUS_BUCKETS` config, so `MySubmissionsList` / `OffsiteSubmissionsList` keep their exact four sections (Live/Pending/Rejected/Withdrawn) **byte-identical** — their existing tests stay green — while the mod table uses **Live/Pending/Rejected/Removed/Draft**.

## The table — `AppListingsModerationTable`
Shared atoms (`StatusSections`, `SortableTh`, `SubmissionSearch`), a kind badge + owner chip per row, and **kind-aware inline actions** wired to Phase 1:
- **pending** → **Review** → opens the existing `OffsiteReviewQueue` approve/reject modal (reused, not rebuilt; the pending request id is passed from the query).
- **approved** → **Reset to pending** (off-site only) + **Hide** (`delistListing`, dual-kind).
- **removed** → **Relist** (dual-kind) + **Claim** + **Purge** (off-site; Purge is destructive → confirm + reason).
- **draft/rejected** → read-only.

Reason-gated (≥3 chars) via a small reason modal; optimistic invalidate on success; mutation errors surfaced. Mounted on `/apps/review` in place of the flat `OffsiteReviewQueue` pending list (kept importable for a **one-line rollback**); the onsite iframe review (`PendingTab`) and `OffsiteReportsQueue` are unchanged.

## Tests (complete coverage)
- **Service**: filters (status/kind/search + shadow exclusion), keyset (orderBy id DESC, take limit+1, cursor skip), pagination contract, limit clamp, projection shape.
- **Router authz**: mod-only (anon/non-mod rejected, service not consulted), filter forwarding, schema-boundary limit reject.
- **View-model** (blocking node `unit` project): kind-aware action visibility (off-site-only actions hidden on on-site rows), labels, destructive/reason metadata.
- **Mod bucketing**: the extension, owner default unchanged.
- **Browser-mode component**: sections from a mixed-status dataset; sort; server-side filter wiring; each inline action fires the right mutation with the right args (reason forwarded; purge confirm-gated); kind-aware visibility; the pending Review opens the review modal with the correct request id; error surfacing.

Local: **80 unit tests** + **12 browser tests** pass; owner-list + off-site review-queue suites stay green. Scoped `tsc --noEmit` clean on all changed files (remaining project errors are pre-existing worktree module-resolution noise: `kysely` / the `event-engine-common` submodule).

Ready for the `/audit-pr` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>