### PR TITLE
feat(model-version): DB-driven Licensing Base picker on version edit

### DIFF
--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -263,13 +263,16 @@ export function ModelVersionUpsertForm({
     { baseModel, modelType: model?.type },
     { enabled: !!baseModel }
   );
-  // Exclude the version being edited — a root defines its own fee and must not
-  // point at itself. The picker always carries an explicit default option (the
-  // base model's standard-fee root), so a single remaining root is still a real
-  // choice; we only hide the whole picker when there are no roots at all.
-  const licensingRoots = (licensingRootsData?.roots ?? []).filter((r) => r.id !== version?.id);
+  // Exclude the version being edited (a root can't point at itself) and the
+  // standard-fee root (it's already the explicit default option, so listing it
+  // again would be a duplicate with different persisted semantics). We only hide
+  // the whole picker when no other roots remain.
+  const standardLicensingId = licensingRootsData?.standardVersionId ?? null;
   const standardLicensingFee = licensingRootsData?.standardFee ?? null;
   const standardLicensingName = licensingRootsData?.standardVersionName ?? null;
+  const licensingRoots = (licensingRootsData?.roots ?? []).filter(
+    (r) => r.id !== version?.id && r.id !== standardLicensingId
+  );
 
   // A licensing lineage root is scoped to a base model, so a base-model change
   // invalidates any selected source. Skip the initial value (edit pre-fill).
@@ -921,7 +924,7 @@ export function ModelVersionUpsertForm({
                   },
                   ...licensingRoots.map((r) => ({
                     value: String(r.id),
-                    label: licensingOptionLabel(r.versionName, Number(r.licensingFee)),
+                    label: licensingOptionLabel(r.versionName, r.licensingFee),
                   })),
                 ]}
               />

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -142,6 +142,12 @@ const schema = modelVersionUpsertSchema2
 type Schema = z.infer<typeof schema>;
 
 const baseModelTypeOptions = constants.baseModelTypes.map((x) => ({ label: x, value: x }));
+// Sentinel for the Licensing Base picker's default option; maps to a null
+// licensingSourceVersionId (inherit the base model's standard-fee root).
+const LICENSING_DEFAULT = 'default';
+const capitalizeFirst = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+const licensingOptionLabel = (versionName: string, fee: number | null) =>
+  `${capitalizeFirst(versionName)}${fee != null ? ` (${fee} Buzz)` : ''}`;
 const querySchema = z.object({
   templateId: z.coerce.number().optional(),
   bountyId: z.coerce.number().optional(),
@@ -253,15 +259,17 @@ export function ModelVersionUpsertForm({
     !!currentUser?.isModerator;
 
   const licensingSourceVersionId = form.watch('licensingSourceVersionId') ?? null;
-  const { data: licensingRootsData = [] } = trpc.modelVersion.getLicensingRoots.useQuery(
-    { baseModel },
+  const { data: licensingRootsData } = trpc.modelVersion.getLicensingRoots.useQuery(
+    { baseModel, modelType: model?.type },
     { enabled: !!baseModel }
   );
   // Exclude the version being edited — a root defines its own fee and must not
-  // point at itself. The picker always carries an implicit "Default (base model
-  // standard fee)" option, so a single remaining root is still a real choice
-  // (default vs that lineage); we only hide it when there are no roots at all.
-  const licensingRoots = licensingRootsData.filter((r) => r.id !== version?.id);
+  // point at itself. The picker always carries an explicit default option (the
+  // base model's standard-fee root), so a single remaining root is still a real
+  // choice; we only hide the whole picker when there are no roots at all.
+  const licensingRoots = (licensingRootsData?.roots ?? []).filter((r) => r.id !== version?.id);
+  const standardLicensingFee = licensingRootsData?.standardFee ?? null;
+  const standardLicensingName = licensingRootsData?.standardVersionName ?? null;
 
   // A licensing lineage root is scoped to a base model, so a base-model change
   // invalidates any selected source. Skip the initial value (edit pre-fill).
@@ -825,30 +833,6 @@ export function ModelVersionUpsertForm({
               <Divider my="md" />
             </Stack>
           )}
-          {(showLicensingFeeBlock || !!currentUser?.isModerator) && licensingRoots.length > 0 && (
-            <Stack gap="xs">
-              <Select
-                label="Licensing base"
-                description="If this model is built on a specific base, pick it so generations inherit that base's licensing fee. Leave as default to use the base model's standard fee."
-                placeholder="Default (base model standard fee)"
-                clearable
-                value={licensingSourceVersionId ? String(licensingSourceVersionId) : null}
-                onChange={(val) =>
-                  form.setValue('licensingSourceVersionId', val ? Number(val) : null, {
-                    shouldDirty: true,
-                  })
-                }
-                data={licensingRoots.map((r) => ({
-                  value: String(r.id),
-                  label: `${r.modelName} — ${r.versionName} (${Number(r.licensingFee)} Buzz${
-                    r.licensingFeeSettlementCurrency === LicensingFeeSettlementCurrency.Cash
-                      ? ', cash'
-                      : ''
-                  })`,
-                }))}
-              />
-            </Stack>
-          )}
           {showLicensingFeeBlock && (
             <Stack gap="xs">
               <InputNumber
@@ -913,6 +897,36 @@ export function ModelVersionUpsertForm({
               />
             )}
           </Group>
+          {licensingRoots.length > 0 && (
+            <Stack gap="xs">
+              <Select
+                label="Licensing Base"
+                description="If this model is built on a specific base, pick it so generations inherit that base's licensing fee."
+                allowDeselect={false}
+                comboboxProps={{ withinPortal: true }}
+                value={licensingSourceVersionId ? String(licensingSourceVersionId) : LICENSING_DEFAULT}
+                onChange={(val) =>
+                  form.setValue(
+                    'licensingSourceVersionId',
+                    val && val !== LICENSING_DEFAULT ? Number(val) : null,
+                    { shouldDirty: true }
+                  )
+                }
+                data={[
+                  {
+                    value: LICENSING_DEFAULT,
+                    label: standardLicensingName
+                      ? licensingOptionLabel(standardLicensingName, standardLicensingFee)
+                      : 'Default',
+                  },
+                  ...licensingRoots.map((r) => ({
+                    value: String(r.id),
+                    label: licensingOptionLabel(r.versionName, Number(r.licensingFee)),
+                  })),
+                ]}
+              />
+            </Stack>
+          )}
           {hasNsfwBaseModelViolation && (
             <Alert color="red" title="License Restriction Violation">
               <Text size="sm">
@@ -951,7 +965,6 @@ export function ModelVersionUpsertForm({
             key="description"
             name="description"
             label="Version changes or notes"
-            description="Tell us about this version"
             includeControls={['formatting', 'list', 'link']}
             editorSize="xl"
           />

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -331,6 +331,7 @@ export const getModelHandler = async ({
 
       return {
         ...version,
+        licensingFee: version.licensingFee != null ? Number(version.licensingFee) : null,
         metrics: undefined,
         rank: {
           generationCountAllTime: versionMetrics?.generationCount ?? 0,

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -440,6 +440,7 @@ export const getModelVersionSchema = z.object({
 export type GetLicensingRootsSchema = z.infer<typeof getLicensingRootsSchema>;
 export const getLicensingRootsSchema = z.object({
   baseModel: z.string(),
+  modelType: z.enum(ModelType).optional(),
 });
 
 export type UpsertExplorationPromptInput = z.infer<typeof upsertExplorationPromptSchema>;

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -271,8 +271,16 @@ export const getUserEarlyAccessModelVersions = async ({ userId }: { userId: numb
 // Licensing lineage roots selectable for a given base model — the versions
 // flagged LicensingRoot that define a fee others can inherit (e.g. an
 // ecosystem's Base / Turbo checkpoints). Feeds the version-form picker.
-export const getLicensingRoots = async ({ baseModel }: { baseModel: string }) => {
-  return dbRead.$queryRaw<
+// `standardFee` is the fee the "Default" option inherits: the (baseModel,
+// modelType) BaseModelLicensingFee rule's root version fee, live from the DB.
+export const getLicensingRoots = async ({
+  baseModel,
+  modelType,
+}: {
+  baseModel: string;
+  modelType?: ModelType;
+}) => {
+  const roots = await dbRead.$queryRaw<
     Array<{
       id: number;
       modelId: number;
@@ -303,6 +311,26 @@ export const getLicensingRoots = async ({ baseModel }: { baseModel: string }) =>
       AND m."deletedAt" IS NULL
     ORDER BY m.name, mv.index
   `;
+
+  let standardFee: number | null = null;
+  let standardVersionName: string | null = null;
+  if (modelType) {
+    const [rule] = await dbRead.$queryRaw<
+      Array<{ licensingFee: number | null; versionName: string | null }>
+    >`
+      SELECT
+        rmv."licensingFee"::float8 AS "licensingFee",
+        rmv.name AS "versionName"
+      FROM "BaseModelLicensingFee" bmlf
+      JOIN "ModelVersion" rmv ON rmv.id = bmlf."modelVersionId"
+      WHERE bmlf."baseModel" = ${baseModel}
+        AND bmlf."modelType" = ${modelType}::"ModelType"
+    `;
+    standardFee = rule?.licensingFee ?? null;
+    standardVersionName = rule?.versionName ?? null;
+  }
+
+  return { roots, standardFee, standardVersionName };
 };
 
 export const upsertModelVersion = async ({

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -271,8 +271,10 @@ export const getUserEarlyAccessModelVersions = async ({ userId }: { userId: numb
 // Licensing lineage roots selectable for a given base model — the versions
 // flagged LicensingRoot that define a fee others can inherit (e.g. an
 // ecosystem's Base / Turbo checkpoints). Feeds the version-form picker.
-// `standardFee` is the fee the "Default" option inherits: the (baseModel,
-// modelType) BaseModelLicensingFee rule's root version fee, live from the DB.
+// `standard*` describes the (baseModel, modelType) BaseModelLicensingFee rule's
+// root version — the "Default" option's live fee/name. The id lets the client
+// drop that version from `roots` so it can't appear as both Default and a pick.
+type StandardRule = { versionId: number; licensingFee: number | null; versionName: string | null };
 export const getLicensingRoots = async ({
   baseModel,
   modelType,
@@ -280,57 +282,57 @@ export const getLicensingRoots = async ({
   baseModel: string;
   modelType?: ModelType;
 }) => {
-  const roots = await dbRead.$queryRaw<
-    Array<{
-      id: number;
-      modelId: number;
-      modelName: string;
-      versionName: string;
-      licensingFee: number | null;
-      licensingFeeType: LicensingFeeType | null;
-      licensingFeeSettlementCurrency: LicensingFeeSettlementCurrency | null;
-    }>
-  >`
-    SELECT
-      mv.id,
-      mv."modelId",
-      m.name AS "modelName",
-      mv.name AS "versionName",
-      mv."licensingFee"::float8 AS "licensingFee",
-      mv."licensingFeeType",
-      mv."licensingFeeSettlementCurrency"
-    FROM "ModelVersion" mv
-    JOIN "Model" m ON m.id = mv."modelId"
-    WHERE mv."baseModel" = ${baseModel}
-      AND (mv.flags & ${ModelVersionFlag.LicensingRoot}) = ${ModelVersionFlag.LicensingRoot}
-      AND mv.status = ${ModelStatus.Published}::"ModelStatus"
-      AND mv."licensingFee" IS NOT NULL
-      AND mv."licensingFee" > 0
-      AND m.status = ${ModelStatus.Published}::"ModelStatus"
-      AND m.availability = ${Availability.Public}::"Availability"
-      AND m."deletedAt" IS NULL
-    ORDER BY m.name, mv.index
-  `;
-
-  let standardFee: number | null = null;
-  let standardVersionName: string | null = null;
-  if (modelType) {
-    const [rule] = await dbRead.$queryRaw<
-      Array<{ licensingFee: number | null; versionName: string | null }>
+  const [roots, standardRows] = await Promise.all([
+    dbRead.$queryRaw<
+      Array<{
+        id: number;
+        modelId: number;
+        versionName: string;
+        licensingFee: number | null;
+        licensingFeeType: LicensingFeeType | null;
+        licensingFeeSettlementCurrency: LicensingFeeSettlementCurrency | null;
+      }>
     >`
       SELECT
-        rmv."licensingFee"::float8 AS "licensingFee",
-        rmv.name AS "versionName"
-      FROM "BaseModelLicensingFee" bmlf
-      JOIN "ModelVersion" rmv ON rmv.id = bmlf."modelVersionId"
-      WHERE bmlf."baseModel" = ${baseModel}
-        AND bmlf."modelType" = ${modelType}::"ModelType"
-    `;
-    standardFee = rule?.licensingFee ?? null;
-    standardVersionName = rule?.versionName ?? null;
-  }
+        mv.id,
+        mv."modelId",
+        mv.name AS "versionName",
+        mv."licensingFee"::float8 AS "licensingFee",
+        mv."licensingFeeType",
+        mv."licensingFeeSettlementCurrency"
+      FROM "ModelVersion" mv
+      JOIN "Model" m ON m.id = mv."modelId"
+      WHERE mv."baseModel" = ${baseModel}
+        AND (mv.flags & ${ModelVersionFlag.LicensingRoot}) = ${ModelVersionFlag.LicensingRoot}
+        AND mv.status = ${ModelStatus.Published}::"ModelStatus"
+        AND mv."licensingFee" IS NOT NULL
+        AND mv."licensingFee" > 0
+        AND m.status = ${ModelStatus.Published}::"ModelStatus"
+        AND m.availability = ${Availability.Public}::"Availability"
+        AND m."deletedAt" IS NULL
+      ORDER BY m.name, mv.index
+    `,
+    modelType
+      ? dbRead.$queryRaw<StandardRule[]>`
+          SELECT
+            rmv.id AS "versionId",
+            rmv."licensingFee"::float8 AS "licensingFee",
+            rmv.name AS "versionName"
+          FROM "BaseModelLicensingFee" bmlf
+          JOIN "ModelVersion" rmv ON rmv.id = bmlf."modelVersionId"
+          WHERE bmlf."baseModel" = ${baseModel}
+            AND bmlf."modelType" = ${modelType}::"ModelType"
+        `
+      : Promise.resolve([] as StandardRule[]),
+  ]);
 
-  return { roots, standardFee, standardVersionName };
+  const rule = standardRows[0];
+  return {
+    roots,
+    standardVersionId: rule?.versionId ?? null,
+    standardFee: rule?.licensingFee ?? null,
+    standardVersionName: rule?.versionName ?? null,
+  };
 };
 
 export const upsertModelVersion = async ({


### PR DESCRIPTION
## What
Reworks the **Licensing Base** picker in the model-version edit form and fixes a related serialization bug surfaced along the way.

### Behavior
- **Ungated from the licensing-fee flag.** The picker now shows purely based on data (`licensingRoots.length > 0`) instead of `features.licensingFee`/moderator. It appears **only** when the base model has licensing-root versions (`flags & LicensingRoot AND licensingFee > 0`), so it never renders on ecosystems where it makes no sense. (The *License Fee per Image* input remains flag-gated — unchanged.)
- **Moved** below Base Model / Base Model Type.
- **Explicit default option** labeled with the base model's standard-fee root — version name + fee resolved live from `BaseModelLicensingFee` → its root `ModelVersion` (e.g. `Base-v1.0 (5 Buzz)`). Falls back to `"Default"` only when no rule exists. Selecting it clears `licensingSourceVersionId`.
- Root labels simplified: dropped the `— model — version (…, cash)` form for `Version (N Buzz)`; default + roots share one formatter.
- Trimmed the field description and removed the "Version changes or notes" subtext.

### Data
- `getLicensingRoots({ baseModel, modelType })` now returns `{ roots, standardFee, standardVersionName }` — the default label is fully DB-driven, no hardcoded fees/names.

### Bug fix (surfaced during testing)
- `model.getById` returned `modelVersion.licensingFee` as a Prisma `Decimal`, which is **not JSON-serializable out of `getServerSideProps`** → model pages for any version with a licensing fee set threw a serialization error (rendered as a 404). Coerced to `number`.

## Testing
- Verified in dev against prod data: default renders `Base-v1.0 (5 Buzz)`, root `Turbo-v1.0 (2 Buzz)`, both live from DB.
- `getLicensingRoots` endpoint returns `{ roots: [turbo-v1.0/2], standardFee: 5, standardVersionName: "base-v1.0" }`.
- `pnpm typecheck` clean (one unrelated pre-existing `boogu.handler.ts` error).

## Migration / ops
None. No schema changes. `BaseModelLicensingFee` already exists in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)