### PR TITLE
feat(app-blocks): W13 owner listing controls — unpublish/republish, moderation history, surfaced edit (P3)

### DIFF
--- a/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
@@ -1,65 +1,161 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
 /**
- * /apps/my-submissions OFF-SITE list — status-section restructure (UX pass).
- * The offsite (external-link) list now renders as the same four status SECTIONS as
- * the onsite list: Live + Pending (always expanded) and Rejected + Withdrawn
- * (default-collapsed `Collapse`, revealed by their toggle). Asserted via the stable
- * `apps-offsite-submissions-section-*` testids.
+ * /apps/my-submissions OFF-SITE list — status-section restructure (UX pass) + the
+ * W13 post-approval-mgmt OWNER controls (Phase 3): unpublish/republish, the
+ * moderation-history modal, and the surfaced shadow-revision Edit link.
  *
  * The list transitively imports `MySubmissionsList` (for `ReviewerNotesButton`),
  * which pulls in the analytics inline stat → `~/utils/trpc`, mocked so this stays
  * network-free. Per the documented gotcha, the wholesale `~/utils/trpc` mock
- * includes `setTrpcBatchingEnabled` (a graph-reachable module imports it). The Edit
- * affordance is now a plain LINK to `/apps/submit?edit=<id>` (the modal was
- * consolidated into the submit wizard) — no per-row trpc surface to stub.
+ * includes `setTrpcBatchingEnabled` (a graph-reachable module imports it). Phase 3
+ * added the owner-control mutations (`unpublishOwnListing`/`republishOwnListing`),
+ * the owner history query (`listMyListingModerationEvents`), and `trpc.useUtils()`
+ * (for the on-success invalidate) — all mocked below.
  */
 
-vi.mock('~/utils/trpc', () => ({
-  trpc: {
-    blocks: {
-      getMyAppAnalytics: {
-        useQuery: () => ({ data: { runs: { count: 0 }, engagement: { activeUsers: 0 } }, isLoading: false }),
-      },
-    },
-  },
-  setTrpcBatchingEnabled: vi.fn(),
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  historyItems: [] as Array<{
+    id: string;
+    action: string;
+    reason: string | null;
+    createdAt: Date;
+  }>,
 }));
 
+const showError = vi.fn();
 vi.mock('~/utils/notifications', () => ({
   showSuccessNotification: vi.fn(),
-  showErrorNotification: vi.fn(),
+  showErrorNotification: (...a: unknown[]) => showError(...a),
 }));
+
+vi.mock('~/utils/trpc', () => {
+  // A mutation mock: records (name, vars), then drives onSuccess so the invalidate +
+  // notification paths run.
+  const mutation =
+    (name: string) =>
+    (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
+      mutate: (vars: unknown) => {
+        mocks.mutate(name, vars);
+        void opts?.onSuccess?.();
+      },
+      isPending: false,
+    });
+  return {
+    trpc: {
+      useUtils: () => ({
+        appListings: { listMySubmissions: { invalidate: mocks.invalidate } },
+      }),
+      blocks: {
+        getMyAppAnalytics: {
+          useQuery: () => ({
+            data: { runs: { count: 0 }, engagement: { activeUsers: 0 } },
+            isLoading: false,
+          }),
+        },
+      },
+      appListings: {
+        unpublishOwnListing: { useMutation: mutation('unpublish') },
+        republishOwnListing: { useMutation: mutation('republish') },
+        listMyListingModerationEvents: {
+          useQuery: () => ({
+            data: { items: mocks.historyItems, nextCursor: null },
+            isLoading: false,
+            error: null,
+          }),
+        },
+      },
+    },
+    setTrpcBatchingEnabled: vi.fn(),
+  };
+});
 
 import type { OffsiteSubmission } from './OffsiteSubmissionsList';
 const { OffsiteSubmissionsList } = await import('./OffsiteSubmissionsList');
 
+beforeEach(() => {
+  mocks.mutate.mockClear();
+  mocks.invalidate.mockClear();
+  mocks.historyItems = [];
+  showError.mockClear();
+});
+
 function makeOffsite(overrides: Partial<OffsiteSubmission>): OffsiteSubmission {
+  const status = overrides.status ?? 'approved';
+  // Default the TRUE listing status to mirror the request status (the common case);
+  // tests override `appListing.status` + `lastModerationAction` to exercise the
+  // removed (owner-hidden vs mod-removed) branches.
+  const appListing =
+    overrides.appListing !== undefined
+      ? overrides.appListing
+      : {
+          name: 'Off App',
+          externalUrl: 'https://example.com/app',
+          category: 'utility',
+          contentRating: 'g',
+          status,
+        };
   return {
     id: 'o1',
     appListingId: 'listing-1',
     slug: 'off-app',
-    status: 'approved',
+    status,
     submittedAt: new Date('2026-01-01T00:00:00Z'),
     reviewedAt: new Date('2026-01-02T00:00:00Z'),
     rejectionReason: null,
     approvalNotes: null,
     changelog: null,
-    appListing: {
-      name: 'Off App',
-      externalUrl: 'https://example.com/app',
-      category: 'utility',
-      contentRating: 'g',
-    },
+    lastModerationAction: null,
     ...overrides,
+    appListing,
   };
 }
 
+/** A LIVE off-site listing (approved request + approved listing). */
+const live = (over: Partial<OffsiteSubmission> = {}) =>
+  makeOffsite({ id: 'a', slug: 'live-off', appListingId: 'l-a', status: 'approved', ...over });
+
+/** A removed listing whose LAST event was the owner's own unpublish. */
+const ownerHidden = () =>
+  makeOffsite({
+    id: 'h',
+    slug: 'hidden-off',
+    appListingId: 'l-h',
+    status: 'approved', // the publish request stays approved after an unpublish
+    appListing: {
+      name: 'Hidden App',
+      externalUrl: 'https://example.com/hidden',
+      category: 'utility',
+      contentRating: 'g',
+      status: 'removed',
+    },
+    lastModerationAction: 'owner-unpublish',
+  });
+
+/** A removed listing taken down by a MODERATOR (last event = delist). */
+const modRemoved = () =>
+  makeOffsite({
+    id: 'm',
+    slug: 'gone-off',
+    appListingId: 'l-m',
+    status: 'approved',
+    appListing: {
+      name: 'Gone App',
+      externalUrl: 'https://example.com/gone',
+      category: 'utility',
+      contentRating: 'g',
+      status: 'removed',
+    },
+    lastModerationAction: 'delist',
+  });
+
 const oneOfEach = (): OffsiteSubmission[] => [
-  makeOffsite({ id: 'a', slug: 'live-off', appListingId: 'l-a', status: 'approved' }),
+  live(),
   makeOffsite({ id: 'b', slug: 'pending-off', appListingId: 'l-b', status: 'pending', reviewedAt: null }),
   makeOffsite({ id: 'c', slug: 'rejected-off', appListingId: null, status: 'rejected' }),
   makeOffsite({ id: 'd', slug: 'withdrawn-off', appListingId: null, status: 'withdrawn' }),
@@ -125,9 +221,7 @@ describe('OffsiteSubmissionsList — status sections', () => {
   test('an editable row renders an Edit link to the submit wizard in edit mode', async () => {
     renderWithProviders(
       <OffsiteSubmissionsList
-        submissions={[
-          makeOffsite({ id: 'a', slug: 'live-off', appListingId: 'l-a', status: 'approved' }),
-        ]}
+        submissions={[live()]}
         onWithdraw={vi.fn()}
         withdrawing={false}
       />
@@ -142,8 +236,8 @@ describe('OffsiteSubmissionsList — status sections', () => {
     renderWithProviders(
       <OffsiteSubmissionsList
         submissions={[
-          makeOffsite({ id: 'a', slug: 'alpha-off', appListingId: 'l-a', status: 'approved' }),
-          makeOffsite({ id: 'b', slug: 'bravo-off', appListingId: 'l-b', status: 'approved' }),
+          live({ id: 'a', slug: 'alpha-off', appListingId: 'l-a' }),
+          live({ id: 'b', slug: 'bravo-off', appListingId: 'l-b' }),
         ]}
         onWithdraw={vi.fn()}
         withdrawing={false}
@@ -154,5 +248,111 @@ describe('OffsiteSubmissionsList — status sections', () => {
     await page.getByTestId('apps-offsite-submissions-filter').fill('bravo');
     await expect.element(page.getByText('bravo-off', { exact: false })).toBeInTheDocument();
     expect(page.getByText('alpha-off', { exact: false }).elements()).toHaveLength(0);
+  });
+});
+
+describe('OffsiteSubmissionsList — owner unpublish (live listing)', () => {
+  test('a live listing shows Unpublish; the confirm gate fires unpublishOwnListing with the listing id', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList submissions={[live()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    // The row Unpublish button opens a confirm modal — it does NOT fire the mutation.
+    await page.getByTestId('apps-offsite-unpublish-live-off').click();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+
+    // Confirming in the modal fires the mutation with the right listing id (no reason).
+    await page.getByTestId('apps-offsite-unpublish-confirm').click();
+    expect(mocks.mutate).toHaveBeenCalledWith('unpublish', {
+      appListingId: 'l-a',
+      reason: undefined,
+    });
+    // On success it invalidates the my-submissions query so the list refetches.
+    expect(mocks.invalidate).toHaveBeenCalled();
+  });
+
+  test('an optional reason is forwarded (trimmed) when provided', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList submissions={[live()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await page.getByTestId('apps-offsite-unpublish-live-off').click();
+    await page.getByTestId('apps-offsite-unpublish-reason').fill('  taking a break  ');
+    await page.getByTestId('apps-offsite-unpublish-confirm').click();
+    expect(mocks.mutate).toHaveBeenCalledWith('unpublish', {
+      appListingId: 'l-a',
+      reason: 'taking a break',
+    });
+  });
+
+  test('a live listing does NOT show Republish or the mod-removed state', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList submissions={[live()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await expect.element(page.getByTestId('apps-offsite-unpublish-live-off')).toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-republish-live-off').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-offsite-mod-removed-live-off').elements()).toHaveLength(0);
+  });
+});
+
+describe('OffsiteSubmissionsList — owner republish vs moderator takedown (load-bearing)', () => {
+  test('an OWNER-hidden listing shows Republish → fires republishOwnListing (no Unpublish)', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList submissions={[ownerHidden()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    const republish = page.getByTestId('apps-offsite-republish-hidden-off');
+    await expect.element(republish).toBeInTheDocument();
+    // No mod-removed state, and no Unpublish (it's already hidden).
+    expect(page.getByTestId('apps-offsite-mod-removed-hidden-off').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-offsite-unpublish-hidden-off').elements()).toHaveLength(0);
+
+    await republish.click();
+    expect(mocks.mutate).toHaveBeenCalledWith('republish', { appListingId: 'l-h' });
+    expect(mocks.invalidate).toHaveBeenCalled();
+  });
+
+  test('a MODERATOR-removed listing shows "Removed by a moderator" and NO republish button', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList submissions={[modRemoved()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await expect.element(page.getByTestId('apps-offsite-mod-removed-gone-off')).toBeInTheDocument();
+    // The load-bearing safety guard: NO republish affordance on a mod takedown.
+    expect(page.getByTestId('apps-offsite-republish-gone-off').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-offsite-unpublish-gone-off').elements()).toHaveLength(0);
+  });
+});
+
+describe('OffsiteSubmissionsList — moderation history modal', () => {
+  test('the History button opens the timeline with actions + verbatim reasons', async () => {
+    mocks.historyItems = [
+      {
+        id: 'e2',
+        action: 'delist',
+        reason: 'Reported for spam',
+        createdAt: new Date('2026-02-02T00:00:00Z'),
+      },
+      {
+        id: 'e1',
+        action: 'owner-unpublish',
+        reason: null,
+        createdAt: new Date('2026-02-01T00:00:00Z'),
+      },
+    ];
+    renderWithProviders(
+      <OffsiteSubmissionsList submissions={[modRemoved()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await page.getByTestId('apps-offsite-history-gone-off').click();
+    // The timeline renders both events (verbatim reason + the action chip labels).
+    await expect.element(page.getByText('Reported for spam')).toBeInTheDocument();
+    await expect.element(page.getByText('Delisted')).toBeInTheDocument();
+    await expect.element(page.getByText('Unpublished by you')).toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-history-entry').elements().length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('an empty history shows the empty-state copy', async () => {
+    mocks.historyItems = [];
+    renderWithProviders(
+      <OffsiteSubmissionsList submissions={[live()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await page.getByTestId('apps-offsite-history-live-off').click();
+    await expect.element(page.getByTestId('apps-offsite-history-empty')).toBeInTheDocument();
   });
 });

--- a/src/components/Apps/OffsiteSubmissionsList.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.tsx
@@ -1,5 +1,25 @@
-import { Anchor, Badge, Button, Card, Code, Group, Stack, Table, Text } from '@mantine/core';
-import { IconExternalLink, IconPencil } from '@tabler/icons-react';
+import {
+  Alert,
+  Anchor,
+  Badge,
+  Button,
+  Card,
+  Code,
+  Group,
+  Modal,
+  Stack,
+  Table,
+  Text,
+  Textarea,
+} from '@mantine/core';
+import {
+  IconAlertTriangle,
+  IconExternalLink,
+  IconEye,
+  IconEyeOff,
+  IconHistory,
+  IconPencil,
+} from '@tabler/icons-react';
 import Link from 'next/link';
 import { Fragment, useMemo, useState, type ReactNode } from 'react';
 import {
@@ -7,7 +27,16 @@ import {
   isWithdrawableOffsiteStatus,
   offsiteStatusChip,
 } from '~/components/Apps/offsiteSubmissionStatus';
+import { moderationActionChip } from '~/components/Apps/appListingModerationView';
+import {
+  canOwnerRepublish,
+  canOwnerUnpublish,
+  ownerListingState,
+  ownerStateChip,
+  type OwnerListingState,
+} from '~/components/Apps/offsiteOwnerControls';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
+import { OFFSITE_MOD_NOTE_MAX } from '~/server/schema/blocks/offsite-moderation.schema';
 import { ReviewerNotesButton } from '~/components/Apps/MySubmissionsList';
 import {
   bucketGroupsByStatus,
@@ -19,6 +48,8 @@ import {
   type SubmissionGroup,
 } from '~/components/Apps/submissionsTable';
 import { StatusSections, SubmissionSearch, VersionToggle } from '~/components/Apps/submissionsTableUi';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
 
 /**
  * /apps/my-submissions — the author's OFF-SITE (external-link) submissions, shown
@@ -31,6 +62,20 @@ import { StatusSections, SubmissionSearch, VersionToggle } from '~/components/Ap
  * (App/Status/Submitted/Reviewed), and per-app version-collapse (grouped by
  * `slug`, newest shown, older versions expandable). The filter/sort/group logic is
  * the shared pure `submissionsTable.ts` (identical to the onsite list).
+ *
+ * W13 post-approval management (Phase 3) — OWNER controls on the author's own
+ * off-site listings (offsite-only; the procs are offsite-scoped):
+ *   - a LIVE (approved) listing → **Unpublish** (confirm-gated; hides it from the
+ *     store, no re-review) + the existing shadow-revision **Edit** entry point.
+ *   - an owner-unpublished listing → **Republish** (removed → approved).
+ *   - a moderator-removed listing → a "removed by a moderator" state (NO republish —
+ *     the server FORBIDS self-restore of a takedown) linking to its history.
+ *   - a **View history** modal on any live/removed listing showing its
+ *     `AppListingModerationEvent` timeline (the owner's "why was this hidden /
+ *     un-approved" view).
+ * The owner-hidden-vs-mod-removed distinction — which gates Republish — is read from
+ * the row's `lastModerationAction` (the list query's projection), NOT a per-row fetch;
+ * the server guard remains authoritative (a race surfaces as a mutation error).
  */
 
 export type OffsiteSubmission = {
@@ -50,9 +95,18 @@ export type OffsiteSubmission = {
     contentRating: string | null;
     /** Non-null only for a shadow revision draft (never surfaced here — inferred). */
     revisionOfId?: string | null;
+    /** The listing's TRUE lifecycle status (`draft|pending|approved|rejected|removed`)
+     *  — DISTINCT from `status` (the publish-REQUEST status). Drives the owner
+     *  unpublish/republish affordances: an owner-hide/mod-delist flips this to
+     *  `removed` while the request stays `approved`. */
+    status?: string | null;
   } | null;
   /** True when this parent listing has an in-flight shadow revision under review. */
   hasPendingRevision?: boolean;
+  /** The listing's most-recent moderation-event action (populated for a `removed`
+   *  listing) — `owner-unpublish` ⇒ owner-hidden (republish-eligible), anything else
+   *  (a moderator `delist`) ⇒ mod-removed (republish forbidden). */
+  lastModerationAction?: string | null;
 };
 
 /** Field adapters for the shared filter/sort/group helpers. Collapse identity =
@@ -73,8 +127,26 @@ function formatDate(d: string | Date | null | undefined): string {
   return date.toLocaleString();
 }
 
-function StatusCell({ submission }: { submission: OffsiteSubmission }) {
-  const chip = offsiteStatusChip(submission.status);
+/** Derive the owner-control state for a row's listing (live / owner-hidden /
+ *  mod-removed / inactive) from its true listing status + last mod-event action. */
+function rowOwnerState(s: OffsiteSubmission): OwnerListingState {
+  return ownerListingState({
+    listingStatus: s.appListing?.status,
+    lastModerationAction: s.lastModerationAction,
+  });
+}
+
+function StatusCell({
+  submission,
+  ownerState,
+}: {
+  submission: OffsiteSubmission;
+  ownerState: OwnerListingState;
+}) {
+  // For a removed listing the request status still reads `approved`, so override the
+  // chip with the owner-facing state (unpublished / removed-by-a-moderator).
+  const stateChip = ownerStateChip(ownerState);
+  const chip = stateChip ?? offsiteStatusChip(submission.status);
   const notes =
     submission.status === 'rejected'
       ? submission.rejectionReason
@@ -123,11 +195,20 @@ function LinkCell({ submission }: { submission: OffsiteSubmission }) {
   );
 }
 
+/** Owner-control handlers threaded from the list down to each latest row. */
+type OwnerControls = {
+  onUnpublish: (listingId: string, slug: string) => void;
+  onRepublish: (listingId: string) => void;
+  republishing: boolean;
+  onViewHistory: (listingId: string, slug: string) => void;
+};
+
 function OffsiteRow({
   submission,
   nested,
   onWithdraw,
   withdrawing,
+  owner,
   toggle,
 }: {
   submission: OffsiteSubmission;
@@ -135,16 +216,41 @@ function OffsiteRow({
   nested: boolean;
   onWithdraw: (publishRequestId: string) => void;
   withdrawing: boolean;
+  /** Owner-control handlers (only wired on the latest, non-nested row). */
+  owner: OwnerControls;
   /** The "N versions" expand/collapse control (only on a collapsible latest row). */
   toggle?: ReactNode;
 }) {
   const s = submission;
-  // Edit only on the latest (non-nested) row of an editable request; older
-  // versions are historical. Withdraw stays available per-row where applicable.
-  const canEdit = !nested && isEditableOffsiteStatus(s.status) && !!s.appListingId;
+  const listingStatus = s.appListing?.status ?? null;
+  const ownerState = rowOwnerState(s);
+  // Edit only on the latest (non-nested) row of an editable request; older versions
+  // are historical, and a REMOVED listing is not editable (the service FORBIDs it),
+  // so exclude it here even though its request status is still `approved`.
+  const canEdit =
+    !nested &&
+    isEditableOffsiteStatus(s.status) &&
+    !!s.appListingId &&
+    listingStatus !== 'removed';
   const canWithdraw = isWithdrawableOffsiteStatus(s.status);
+  // Owner takedown affordances live ONLY on the latest row with a real listing id.
+  const showOwner = !nested && !!s.appListingId;
+  const canUnpublish = showOwner && canOwnerUnpublish(ownerState);
+  const canRepublish = showOwner && canOwnerRepublish(ownerState);
+  const isModRemoved = showOwner && ownerState === 'mod-removed';
+  // History is offered whenever there's a live/removed listing that can carry events.
+  const canViewHistory = showOwner && (ownerState !== 'inactive');
+
   const renderActions = () => {
-    if (!canEdit && !canWithdraw && !s.hasPendingRevision) {
+    const hasAny =
+      canEdit ||
+      canWithdraw ||
+      s.hasPendingRevision ||
+      canUnpublish ||
+      canRepublish ||
+      isModRemoved ||
+      canViewHistory;
+    if (!hasAny) {
       return (
         <Text size="xs" c="dimmed">
           —
@@ -165,6 +271,37 @@ function OffsiteRow({
             Edit
           </Button>
         )}
+        {canUnpublish && s.appListingId && (
+          <Button
+            size="xs"
+            variant="default"
+            color="orange"
+            onClick={() => owner.onUnpublish(s.appListingId as string, s.slug)}
+            leftSection={<IconEyeOff size={12} />}
+            data-testid={`apps-offsite-unpublish-${s.slug}`}
+          >
+            Unpublish
+          </Button>
+        )}
+        {canRepublish && s.appListingId && (
+          <Button
+            size="xs"
+            variant="default"
+            color="green"
+            onClick={() => owner.onRepublish(s.appListingId as string)}
+            disabled={owner.republishing}
+            loading={owner.republishing}
+            leftSection={<IconEye size={12} />}
+            data-testid={`apps-offsite-republish-${s.slug}`}
+          >
+            Republish
+          </Button>
+        )}
+        {isModRemoved && (
+          <Text size="xs" c="red" data-testid={`apps-offsite-mod-removed-${s.slug}`}>
+            Removed by a moderator
+          </Text>
+        )}
         {canWithdraw && (
           <Button
             size="xs"
@@ -176,6 +313,18 @@ function OffsiteRow({
             data-testid={`apps-offsite-withdraw-${s.slug}`}
           >
             Withdraw
+          </Button>
+        )}
+        {canViewHistory && s.appListingId && (
+          <Button
+            size="xs"
+            variant="subtle"
+            color="gray"
+            onClick={() => owner.onViewHistory(s.appListingId as string, s.slug)}
+            leftSection={<IconHistory size={12} />}
+            data-testid={`apps-offsite-history-${s.slug}`}
+          >
+            History
           </Button>
         )}
         {s.hasPendingRevision && (
@@ -218,7 +367,7 @@ function OffsiteRow({
         <LinkCell submission={s} />
       </Table.Td>
       <Table.Td>
-        <StatusCell submission={s} />
+        <StatusCell submission={s} ownerState={nested ? 'inactive' : ownerState} />
       </Table.Td>
       <Table.Td>
         <Text size="xs">{formatDate(s.submittedAt)}</Text>
@@ -244,6 +393,26 @@ export function OffsiteSubmissionsList({
 }) {
   const [query, setQuery] = useState('');
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [unpublishTarget, setUnpublishTarget] = useState<{ id: string; slug: string } | null>(null);
+  const [historyTarget, setHistoryTarget] = useState<{ id: string; slug: string } | null>(null);
+
+  const utils = trpc.useUtils();
+  const invalidateSubmissions = () => utils.appListings.listMySubmissions.invalidate();
+
+  const republishMutation = trpc.appListings.republishOwnListing.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({ message: 'App republished — it is live in the store again.' });
+      await invalidateSubmissions();
+    },
+    onError: (e) => showErrorNotification({ title: 'Republish failed', error: new Error(e.message) }),
+  });
+
+  const owner: OwnerControls = {
+    onUnpublish: (id, slug) => setUnpublishTarget({ id, slug }),
+    onRepublish: (id) => republishMutation.mutate({ appListingId: id }),
+    republishing: republishMutation.isPending,
+    onViewHistory: (id, slug) => setHistoryTarget({ id, slug }),
+  };
 
   // Group → filter → sort newest-first → partition into status SECTIONS. Status is
   // now the section (Live / Pending / Rejected / Withdrawn), so the header column is
@@ -300,6 +469,7 @@ export function OffsiteSubmissionsList({
                   nested={false}
                   onWithdraw={onWithdraw}
                   withdrawing={withdrawing}
+                  owner={owner}
                   toggle={
                     g.older.length > 0 ? (
                       <VersionToggle
@@ -319,6 +489,7 @@ export function OffsiteSubmissionsList({
                       nested
                       onWithdraw={onWithdraw}
                       withdrawing={withdrawing}
+                      owner={owner}
                     />
                   ))}
               </Fragment>
@@ -349,6 +520,178 @@ export function OffsiteSubmissionsList({
           renderTable={renderTable}
         />
       )}
+
+      <OwnerUnpublishModal
+        target={unpublishTarget}
+        onClose={() => setUnpublishTarget(null)}
+        onDone={invalidateSubmissions}
+      />
+      <OwnerModerationHistoryModal
+        target={historyTarget}
+        onClose={() => setHistoryTarget(null)}
+      />
     </Stack>
+  );
+}
+
+/**
+ * Confirm-gated OWNER unpublish (approved → removed). Hides the live app from the
+ * store immediately — no re-review needed, and the owner can republish it
+ * themselves. `reason` is optional (the owner is acting on their own listing).
+ */
+function OwnerUnpublishModal({
+  target,
+  onClose,
+  onDone,
+}: {
+  target: { id: string; slug: string } | null;
+  onClose: () => void;
+  onDone: () => Promise<void> | void;
+}) {
+  const [reason, setReason] = useState('');
+  const mutation = trpc.appListings.unpublishOwnListing.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({ message: 'App unpublished — it is now hidden from the store.' });
+      await onDone();
+      setReason('');
+      onClose();
+    },
+    onError: (e) => showErrorNotification({ title: 'Unpublish failed', error: new Error(e.message) }),
+  });
+
+  function close() {
+    if (mutation.isPending) return;
+    setReason('');
+    onClose();
+  }
+
+  if (!target) return null;
+  return (
+    <Modal
+      opened={!!target}
+      onClose={close}
+      title={
+        <Text fw={600}>
+          Unpublish <Code>{target.slug}</Code>
+        </Text>
+      }
+      centered
+    >
+      <Stack gap="md">
+        <Alert color="orange" variant="light" icon={<IconAlertTriangle size={16} />}>
+          <Text size="sm">
+            Unpublishing hides your live app from the store immediately. You can republish it
+            yourself at any time — no re-review needed.
+          </Text>
+        </Alert>
+        <Textarea
+          label="Reason (optional)"
+          autosize
+          minRows={2}
+          maxRows={6}
+          maxLength={OFFSITE_MOD_NOTE_MAX}
+          placeholder="Optional — a note for your own records / the listing history."
+          value={reason}
+          onChange={(e) => setReason(e.currentTarget.value)}
+          disabled={mutation.isPending}
+          data-testid="apps-offsite-unpublish-reason"
+        />
+        <Group justify="flex-end" gap="xs">
+          <Button variant="default" onClick={close} disabled={mutation.isPending}>
+            Cancel
+          </Button>
+          <Button
+            color="orange"
+            onClick={() =>
+              mutation.mutate({
+                appListingId: target.id,
+                reason: reason.trim() ? reason.trim() : undefined,
+              })
+            }
+            loading={mutation.isPending}
+            disabled={mutation.isPending}
+            data-testid="apps-offsite-unpublish-confirm"
+          >
+            Unpublish
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}
+
+/**
+ * OWNER moderation-history modal — the "why was this hidden / un-approved" view.
+ * Renders the listing's `AppListingModerationEvent` timeline (newest-first) via the
+ * owner-scoped `listMyListingModerationEvents` proc: each entry's action + date +
+ * (verbatim) reason. Owner-scoped server-side (own listing only).
+ */
+function OwnerModerationHistoryModal({
+  target,
+  onClose,
+}: {
+  target: { id: string; slug: string } | null;
+  onClose: () => void;
+}) {
+  const query = trpc.appListings.listMyListingModerationEvents.useQuery(
+    { appListingId: target?.id ?? '', limit: 50 },
+    { enabled: !!target }
+  );
+  const items = (query.data?.items ?? []) as Array<{
+    id: string;
+    action: string;
+    reason: string | null;
+    createdAt: string | Date;
+  }>;
+
+  return (
+    <Modal
+      opened={!!target}
+      onClose={onClose}
+      title={
+        <Text fw={600}>
+          Moderation history{target ? <> — <Code>{target.slug}</Code></> : null}
+        </Text>
+      }
+      size="lg"
+      centered
+    >
+      {query.isLoading ? (
+        <Text size="sm" c="dimmed">
+          Loading…
+        </Text>
+      ) : query.error ? (
+        <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
+          {query.error.message}
+        </Alert>
+      ) : items.length === 0 ? (
+        <Text size="sm" c="dimmed" data-testid="apps-offsite-history-empty">
+          No moderation history yet.
+        </Text>
+      ) : (
+        <Stack gap="sm" data-testid="apps-offsite-history-list">
+          {items.map((ev) => {
+            const chip = moderationActionChip(ev.action);
+            return (
+              <Card key={ev.id} withBorder p="sm" data-testid="apps-offsite-history-entry">
+                <Group justify="space-between" gap="xs" wrap="nowrap">
+                  <Badge color={chip.color} variant="light">
+                    {chip.label}
+                  </Badge>
+                  <Text size="xs" c="dimmed">
+                    {formatDate(ev.createdAt)}
+                  </Text>
+                </Group>
+                {ev.reason && (
+                  <Text size="sm" mt={6} style={{ whiteSpace: 'pre-wrap' }}>
+                    {ev.reason}
+                  </Text>
+                )}
+              </Card>
+            );
+          })}
+        </Stack>
+      )}
+    </Modal>
   );
 }

--- a/src/components/Apps/__tests__/offsiteOwnerControls.test.ts
+++ b/src/components/Apps/__tests__/offsiteOwnerControls.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  OWNER_UNPUBLISH_ACTION,
+  canOwnerRepublish,
+  canOwnerUnpublish,
+  ownerListingState,
+  ownerStateChip,
+} from '~/components/Apps/offsiteOwnerControls';
+import { APP_LISTING_MODERATION_ACTIONS } from '~/server/schema/blocks/offsite-moderation.schema';
+
+/**
+ * W13 post-approval mgmt (Phase 3) — pure OWNER-control view model (the BLOCKING
+ * gate for the load-bearing owner-hidden-vs-mod-removed distinction that gates the
+ * Republish button; the browser-mode list test is report-only). Pins the
+ * status/last-event → state matrix + the two capability predicates.
+ */
+
+describe('ownerListingState — classify a listing for owner controls', () => {
+  it('an approved listing is LIVE (regardless of any last action)', () => {
+    expect(ownerListingState({ listingStatus: 'approved', lastModerationAction: null })).toBe(
+      'live'
+    );
+    expect(
+      ownerListingState({ listingStatus: 'approved', lastModerationAction: 'owner-republish' })
+    ).toBe('live');
+  });
+
+  it('a removed listing whose LAST event is owner-unpublish is OWNER-HIDDEN', () => {
+    expect(
+      ownerListingState({ listingStatus: 'removed', lastModerationAction: 'owner-unpublish' })
+    ).toBe('owner-hidden');
+  });
+
+  it('a removed listing whose last event is a moderator delist is MOD-REMOVED', () => {
+    expect(
+      ownerListingState({ listingStatus: 'removed', lastModerationAction: 'delist' })
+    ).toBe('mod-removed');
+  });
+
+  it('a removed listing with NO last event is MOD-REMOVED (fail-safe — no republish)', () => {
+    expect(ownerListingState({ listingStatus: 'removed', lastModerationAction: null })).toBe(
+      'mod-removed'
+    );
+    expect(
+      ownerListingState({ listingStatus: 'removed', lastModerationAction: undefined })
+    ).toBe('mod-removed');
+  });
+
+  it('any other listing status is INACTIVE (draft/pending/rejected/missing)', () => {
+    for (const status of ['draft', 'pending', 'rejected', null, undefined]) {
+      expect(ownerListingState({ listingStatus: status, lastModerationAction: null })).toBe(
+        'inactive'
+      );
+    }
+  });
+});
+
+describe('capability predicates', () => {
+  it('unpublish is allowed ONLY on a live listing', () => {
+    expect(canOwnerUnpublish('live')).toBe(true);
+    expect(canOwnerUnpublish('owner-hidden')).toBe(false);
+    expect(canOwnerUnpublish('mod-removed')).toBe(false);
+    expect(canOwnerUnpublish('inactive')).toBe(false);
+  });
+
+  it('republish is allowed ONLY on an owner-hidden listing — NEVER a mod takedown', () => {
+    expect(canOwnerRepublish('owner-hidden')).toBe(true);
+    expect(canOwnerRepublish('mod-removed')).toBe(false);
+    expect(canOwnerRepublish('live')).toBe(false);
+    expect(canOwnerRepublish('inactive')).toBe(false);
+  });
+});
+
+describe('ownerStateChip — the removed-listing badge override', () => {
+  it('labels an owner-hidden listing "unpublished" and a mod-removed one distinctly', () => {
+    expect(ownerStateChip('owner-hidden')).toEqual({ label: 'unpublished', color: 'gray' });
+    expect(ownerStateChip('mod-removed')).toEqual({
+      label: 'removed by a moderator',
+      color: 'red',
+    });
+  });
+
+  it('returns null for live/inactive (the caller keeps the request-status chip)', () => {
+    expect(ownerStateChip('live')).toBeNull();
+    expect(ownerStateChip('inactive')).toBeNull();
+  });
+});
+
+describe('the owner-unpublish action agreement', () => {
+  it('OWNER_UNPUBLISH_ACTION is a real moderation-event action in the shared taxonomy', () => {
+    expect(APP_LISTING_MODERATION_ACTIONS).toContain(OWNER_UNPUBLISH_ACTION);
+  });
+});

--- a/src/components/Apps/appListingModerationView.ts
+++ b/src/components/Apps/appListingModerationView.ts
@@ -99,6 +99,11 @@ const MOD_ACTION_CHIPS: Record<string, Chip> = {
   claim: { label: 'Ownership claimed', color: 'blue' },
   'report-resolve': { label: 'Report resolved', color: 'green' },
   'report-dismiss': { label: 'Report dismissed', color: 'gray' },
+  // W13 post-approval management (Phase 1) — surfaced in the OWNER moderation-history
+  // view (and the mod one). `owner-*` are the author's own visibility toggles.
+  'reset-to-pending': { label: 'Reset to pending', color: 'yellow' },
+  'owner-unpublish': { label: 'Unpublished by you', color: 'gray' },
+  'owner-republish': { label: 'Republished by you', color: 'green' },
 };
 
 /** Chip for a moderation-event action, for the per-listing history view. */

--- a/src/components/Apps/offsiteOwnerControls.ts
+++ b/src/components/Apps/offsiteOwnerControls.ts
@@ -1,0 +1,80 @@
+/**
+ * App Store Listings (W13 post-approval mgmt, Phase 3) — OWNER-control view model
+ * (pure, React-free). Given a my-submissions row's TRUE listing status
+ * (`AppListing.status`, distinct from the publish-REQUEST status) and its
+ * most-recent moderation-event action, decide which owner affordance the row
+ * offers:
+ *
+ *   - `live`         — listing is `approved` (visible in the store) → **Unpublish**.
+ *   - `owner-hidden` — listing is `removed` AND its last moderation event is the
+ *                      owner's own `owner-unpublish` → **Republish** (the server
+ *                      allows republish ONLY here).
+ *   - `mod-removed`  — listing is `removed` but the last event is a moderator
+ *                      takedown (`delist`/`purge`/…), OR there is no event → NO
+ *                      republish (it would 403); show a "removed by a moderator"
+ *                      state linking to the history.
+ *   - `inactive`     — any other listing status (draft/pending/rejected/…) → no
+ *                      owner takedown affordance.
+ *
+ * Extracted so this load-bearing owner-hidden-vs-mod-removed distinction (which
+ * gates the Republish button) is covered by the BLOCKING node `unit` project — the
+ * civitai browser-mode component suites are report-only. The republish eligibility
+ * here is the CLIENT mirror of the server guard in
+ * `offsite-moderation.service.ts#republishOwnListing` (last event must be
+ * `owner-unpublish`); the server remains authoritative (a race still 403s, surfaced
+ * as a mutation error).
+ */
+
+/** The moderation-event action that marks an owner-initiated (not mod) unpublish. */
+export const OWNER_UNPUBLISH_ACTION = 'owner-unpublish';
+
+export type OwnerListingState = 'live' | 'owner-hidden' | 'mod-removed' | 'inactive';
+
+/**
+ * Classify a listing for the owner-control affordances. `listingStatus` is the real
+ * `AppListing.status`; `lastModerationAction` is the listing's most-recent
+ * moderation-event action (null when it has none / isn't removed).
+ */
+export function ownerListingState(input: {
+  listingStatus: string | null | undefined;
+  lastModerationAction: string | null | undefined;
+}): OwnerListingState {
+  const status = input.listingStatus ?? null;
+  if (status === 'approved') return 'live';
+  if (status === 'removed') {
+    return input.lastModerationAction === OWNER_UNPUBLISH_ACTION ? 'owner-hidden' : 'mod-removed';
+  }
+  return 'inactive';
+}
+
+/** True when the owner may unpublish (hide) the listing — only a live listing. */
+export function canOwnerUnpublish(state: OwnerListingState): boolean {
+  return state === 'live';
+}
+
+/**
+ * True when the owner may republish the listing — ONLY an owner-hidden one. A
+ * mod-removed listing is deliberately excluded (the server FORBIDS it).
+ */
+export function canOwnerRepublish(state: OwnerListingState): boolean {
+  return state === 'owner-hidden';
+}
+
+/** Pill descriptor for a removed listing's owner-facing status badge (label + Mantine color). */
+export type OwnerStateChip = { label: string; color: string };
+
+/**
+ * The status badge to show for a removed listing (overriding the request-status
+ * chip, which would misleadingly read `approved`). Returns null for `live`/`inactive`
+ * (the caller keeps the normal request-status chip).
+ */
+export function ownerStateChip(state: OwnerListingState): OwnerStateChip | null {
+  switch (state) {
+    case 'owner-hidden':
+      return { label: 'unpublished', color: 'gray' };
+    case 'mod-removed':
+      return { label: 'removed by a moderator', color: 'red' };
+    default:
+      return null;
+  }
+}

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -65,6 +65,10 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
     image: {
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
     },
+    // W13 owner controls: the batched last-moderation-event lookup (removed listings).
+    appListingModerationEvent: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    },
   });
   const mockRead = makeClient();
   const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
@@ -113,6 +117,7 @@ function resetAll() {
     client.appListingPublishRequest.updateMany.mockReset().mockResolvedValue({ count: 1 });
     client.appListingPublishRequest.findMany.mockReset().mockResolvedValue([]);
     client.image.findMany.mockReset().mockResolvedValue([]);
+    client.appListingModerationEvent.findMany.mockReset().mockResolvedValue([]);
   }
   mockWrite.$transaction
     .mockReset()
@@ -828,5 +833,69 @@ describe('listMySubmissions (shadow handling)', () => {
       .mockResolvedValueOnce([]); // shadow exists in the DB, but no PENDING request targets it
     const res = await listMySubmissions({ userId: OWNER });
     expect(res.items[0]).toMatchObject({ hasPendingRevision: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listMySubmissions — lastModerationAction projection (W13 owner controls)
+// ---------------------------------------------------------------------------
+
+describe('listMySubmissions (lastModerationAction for removed listings)', () => {
+  /** A REMOVED listing's request row (the request stays `approved` after a takedown). */
+  const removedRequestRow = {
+    id: 'alpr_removed',
+    appListingId: 'apl_removed',
+    slug: 'gone-app',
+    status: 'approved',
+    appListing: { name: 'Gone App', revisionOfId: null, status: 'removed' },
+  };
+  const liveRequestRow = {
+    id: 'alpr_live',
+    appListingId: 'apl_live',
+    slug: 'live-app',
+    status: 'approved',
+    appListing: { name: 'Live App', revisionOfId: null, status: 'approved' },
+  };
+
+  it('attaches the latest moderation-event action for a REMOVED listing (owner-unpublish → eligible)', async () => {
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([removedRequestRow])
+      .mockResolvedValueOnce([]); // no pending revision
+    mockRead.appListingModerationEvent.findMany.mockResolvedValueOnce([
+      { appListingId: 'apl_removed', action: 'owner-unpublish' },
+    ]);
+
+    const res = await listMySubmissions({ userId: OWNER });
+
+    // The last-event query is scoped to the removed listing id, newest-first, distinct.
+    const eventArgs = mockRead.appListingModerationEvent.findMany.mock.calls[0][0] as Record<
+      string,
+      unknown
+    >;
+    expect(eventArgs).toMatchObject({
+      where: { appListingId: { in: ['apl_removed'] } },
+      distinct: ['appListingId'],
+    });
+    expect(res.items[0]).toMatchObject({ lastModerationAction: 'owner-unpublish' });
+  });
+
+  it('surfaces a moderator takedown (delist) as the lastModerationAction (republish forbidden client-side)', async () => {
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([removedRequestRow])
+      .mockResolvedValueOnce([]);
+    mockRead.appListingModerationEvent.findMany.mockResolvedValueOnce([
+      { appListingId: 'apl_removed', action: 'delist' },
+    ]);
+    const res = await listMySubmissions({ userId: OWNER });
+    expect(res.items[0]).toMatchObject({ lastModerationAction: 'delist' });
+  });
+
+  it('does NOT query moderation events for a LIVE listing (no removed rows) → null action', async () => {
+    mockRead.appListingPublishRequest.findMany
+      .mockResolvedValueOnce([liveRequestRow])
+      .mockResolvedValueOnce([]);
+    const res = await listMySubmissions({ userId: OWNER });
+    expect(mockRead.appListingModerationEvent.findMany).not.toHaveBeenCalled();
+    expect(res.items[0]).toMatchObject({ lastModerationAction: null });
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -739,6 +739,17 @@ describe('reject/withdraw a pending REVISION', () => {
       kind: 'offsite',
       appListingId: 'apl_shadow', // the shadow, a draft
     });
+    // Pre-tx notification snapshot: the shadow reads as a REVISION (revisionOfId set)
+    // → the "not approved" owner notice is skipped (parent stays live).
+    mockRead.appListing.findUnique.mockResolvedValue({
+      userId: OWNER,
+      name: 'Cool App',
+      slug: 'cool-app',
+      revisionOfId: 'apl_parent',
+    });
+    // In-tx `closeTerminalListing` reads the listing on the WRITE client (the tx) to
+    // pick the delete-vs-flip branch — a draft shadow → the status-guarded delete.
+    mockWrite.appListing.findUnique.mockResolvedValue({ status: 'draft', slug: 'apl_shadow' });
     await rejectExternalRequest({
       publishRequestId: 'alpr_rev',
       reviewerUserId: MOD,
@@ -761,6 +772,9 @@ describe('reject/withdraw a pending REVISION', () => {
       submittedByUserId: OWNER,
       appListingId: 'apl_shadow',
     });
+    // In-tx `closeTerminalListing` reads the listing on the WRITE client (the tx) to
+    // pick the delete-vs-flip branch — a draft shadow → the status-guarded delete.
+    mockWrite.appListing.findUnique.mockResolvedValue({ status: 'draft', slug: 'apl_shadow' });
     await withdrawExternalRequest({ publishRequestId: 'alpr_rev', userId: OWNER });
     expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
       where: { id: 'apl_shadow', status: 'draft' },

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -1004,6 +1004,25 @@ describe('listMyListingModerationEvents', () => {
     expect(args.orderBy).toEqual([{ createdAt: 'desc' }, { id: 'desc' }]);
   });
 
+  it('🔴 uses the OWNER-scoped projection — NO acting-mod identity / reportId / detail / snapshots', async () => {
+    // Privacy guard: a taken-down app's owner must not learn WHICH moderator acted
+    // (harassment vector) nor read internal report/detail fields. The owner read must
+    // request ONLY {id, action, reason, createdAt} — dropping actor/reportId/detail/
+    // before/after (which the MOD-facing read keeps). Asserted on the `select` the proc
+    // passes to Prisma (the source of truth for what leaves the DB).
+    mockRead.appListing.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    mockRead.appListingModerationEvent.findMany.mockResolvedValueOnce([evt('alme_1')]);
+    await listMyListingModerationEvents({ input: { appListingId: APP_ID }, userId: OWNER });
+    const select = mockRead.appListingModerationEvent.findMany.mock.calls[0][0].select as Record<
+      string,
+      unknown
+    >;
+    expect(select).toEqual({ id: true, action: true, reason: true, createdAt: true });
+    for (const dropped of ['actor', 'reportId', 'detail', 'before', 'after', 'appListingId', 'slug']) {
+      expect(select).not.toHaveProperty(dropped);
+    }
+  });
+
   it('FORBIDDEN (NOT_OWNED) on a listing the caller does NOT own — no events read', async () => {
     mockRead.appListing.findUnique.mockResolvedValueOnce({ userId: 12345 });
     await expect(

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1771,6 +1771,13 @@ const submissionSelect = {
       category: true,
       contentRating: true,
       revisionOfId: true,
+      // The listing's TRUE lifecycle status (`draft|pending|approved|rejected|
+      // removed`) — DISTINCT from the publish-REQUEST `status`. An owner unpublish
+      // / mod delist flips `AppListing.status` approved → removed WITHOUT touching
+      // the (still-`approved`) request, so my-submissions can only distinguish a
+      // live listing from a hidden one by reading THIS field. Additive/PII-safe;
+      // the mod queues that spread `submissionSelect` gain it harmlessly.
+      status: true,
     },
   },
 } as const;
@@ -1836,9 +1843,40 @@ export async function listMySubmissions(
       .map((r) => r.appListing?.revisionOfId)
       .filter((id): id is string => id != null)
   );
+
+  // W13 post-approval mgmt (owner controls): for every REMOVED listing on the page,
+  // fetch its MOST-RECENT moderation-event action so the my-submissions UI can tell
+  // an owner-hidden listing (last event `owner-unpublish` → republish-eligible) from
+  // a moderator takedown (last event `delist` → republish FORBIDDEN, shown as
+  // "removed by a moderator") WITHOUT a per-row history fetch. This mirrors the
+  // `hasPendingRevision` batched second query above. `distinct` + `orderBy desc`
+  // returns exactly the latest event per listing in ONE query. Only removed listings
+  // are queried (a live listing needs no last-action), bounding the cost.
+  const removedParentIds = page
+    .filter((r) => r.appListingId != null && r.appListing?.status === 'removed')
+    .map((r) => r.appListingId as string);
+  const lastEvents =
+    removedParentIds.length > 0
+      ? await dbRead.appListingModerationEvent.findMany({
+          where: { appListingId: { in: removedParentIds } },
+          orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+          distinct: ['appListingId'],
+          select: { appListingId: true, action: true },
+        })
+      : [];
+  const lastActionByListing = new Map(
+    lastEvents
+      .filter((e): e is { appListingId: string; action: string } => e.appListingId != null)
+      .map((e) => [e.appListingId, e.action])
+  );
+
   const items = page.map((r) => ({
     ...r,
     hasPendingRevision: r.appListingId != null && parentsWithRevision.has(r.appListingId),
+    // Null for a non-removed listing (or one with no events) — the UI only reads it
+    // when `appListing.status === 'removed'` to gate the Republish affordance.
+    lastModerationAction:
+      r.appListingId != null ? lastActionByListing.get(r.appListingId) ?? null : null,
   }));
 
   return { items, nextCursor: hasNext ? items[items.length - 1].id : null };

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -827,7 +827,8 @@ export async function dismissReport(opts: {
 
 /**
  * PII-safe moderation-event projection: the audit fields + the acting mod's public
- * chip ({id,username,image}) + the denormalized slug. No raw actorUserId FK.
+ * chip ({id,username,image}) + the denormalized slug. No raw actorUserId FK. Used by
+ * the MOD-facing `listModerationEvents` only.
  */
 const moderationEventSelect = {
   id: true,
@@ -844,14 +845,34 @@ const moderationEventSelect = {
 } as const;
 
 /**
- * MOD per-listing moderation history, NEWEST-first, keyset-paginated. The cursor is
- * the event id (`alme_<ULID>`, time-sortable so it tracks the `createdAt desc`
- * order); the `id` tie-break makes same-millisecond ordering deterministic.
+ * OWNER-scoped projection for a listing OWNER reading their OWN moderation history
+ * ("why was this hidden / un-approved"). 🔴 Privacy: deliberately DROPS the acting
+ * moderator's chip (`actor`), the linked `reportId`, the `detail` blob, and the
+ * `before`/`after` snapshots — so a taken-down app's owner never learns WHICH mod
+ * delisted/purged it (a harassment vector) nor sees internal report/detail fields.
+ * Returns only what the owner history modal renders: the action, when, and the
+ * verbatim reason (+ `id` for the React key / keyset cursor). The mod-facing
+ * `moderationEventSelect` above is UNCHANGED (mods still see the actor).
+ */
+const ownerModerationEventSelect = {
+  id: true,
+  action: true,
+  reason: true,
+  createdAt: true,
+} as const;
+
+/**
+ * Per-listing moderation history, NEWEST-first, keyset-paginated. The cursor is the
+ * event id (`alme_<ULID>`, time-sortable so it tracks the `createdAt desc` order);
+ * the `id` tie-break makes same-millisecond ordering deterministic. `ownerScoped`
+ * selects the privacy-minimal `ownerModerationEventSelect` (no mod identity / report/
+ * detail) for the owner read; the mod read keeps the full `moderationEventSelect`.
  */
 async function queryModerationEvents(opts: {
   appListingId: string;
   cursor?: string;
   limit?: number;
+  ownerScoped?: boolean;
 }) {
   const limit = Math.min(opts.limit ?? 25, 50);
   const rows = await dbRead.appListingModerationEvent.findMany({
@@ -859,7 +880,7 @@ async function queryModerationEvents(opts: {
     orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
     take: limit + 1,
     ...(opts.cursor ? { cursor: { id: opts.cursor }, skip: 1 } : {}),
-    select: moderationEventSelect,
+    select: opts.ownerScoped ? ownerModerationEventSelect : moderationEventSelect,
   });
   const hasNext = rows.length > limit;
   const items = hasNext ? rows.slice(0, limit) : rows;
@@ -1134,9 +1155,12 @@ export async function republishOwnListing(opts: {
  * OWNER per-listing moderation history (audit trail) for a listing the CALLER OWNS
  * — the owner's "why was this hidden / un-approved" view. Asserts ownership
  * (NOT_FOUND on a missing listing, NOT_OWNED → FORBIDDEN otherwise) then returns the
- * SAME newest-first, keyset-paginated, PII-safe projection as the mod
- * `listModerationEvents`. Offsite-only is NOT enforced here (an owner can only pass
- * their own listing id regardless of kind; the projection is already PII-safe).
+ * newest-first, keyset-paginated history through the OWNER-scoped
+ * `ownerModerationEventSelect` — 🔴 which DROPS the acting-mod chip (`actor`),
+ * `reportId`, `detail`, and `before`/`after` so a taken-down app's owner can't learn
+ * which moderator acted (harassment vector) nor read internal report/detail fields.
+ * The mod-facing `listModerationEvents` keeps the full projection. Offsite-only is
+ * NOT enforced here (an owner can only pass their own listing id regardless of kind).
  */
 export async function listMyListingModerationEvents(opts: {
   input: ListMyListingModerationEventsInput;
@@ -1153,5 +1177,7 @@ export async function listMyListingModerationEvents(opts: {
   if (listing.userId !== userId) {
     throw new OffsiteModerationError('NOT_OWNED', 'You can only view your own listings.');
   }
-  return queryModerationEvents(input);
+  // 🔴 Owner read → the privacy-minimal projection (no acting-mod identity / reportId /
+  // detail / before-after). The mod read (`listModerationEvents`) keeps the full one.
+  return queryModerationEvents({ ...input, ownerScoped: true });
 }


### PR DESCRIPTION
## W13 App Blocks — owner listing controls (Phase 3)

Owner-facing post-approval controls on **/apps/my-submissions** for **off-site (external-link)** listings, wiring the already-merged Phase 1 owner procs (`unpublishOwnListing` / `republishOwnListing` / `listMyListingModerationEvents`). Everything stays **dark** behind the existing `app-blocks-author` / `appListings` gates already on the page. **No migration.**

### What's here
- **Unpublish (live → hidden).** A live listing gets a confirm-gated **Unpublish** action (`unpublishOwnListing`) — hides the app from the store immediately, no re-review. Reason optional.
- **Republish vs moderator takedown (the load-bearing distinction).** A removed listing shows **Republish** *only* when its most-recent moderation event is the owner's own `owner-unpublish`. A listing a **moderator** removed (delist/purge) instead shows a **"Removed by a moderator"** state with **no republish button** — the server forbids an owner self-restoring a takedown, so the UI must never offer a button that would 403. Eligibility is read from the listing's last moderation-event action (surfaced in the list query), not a per-row history fetch; the server guard remains authoritative (a race surfaces as a mutation error).
- **Moderation-history modal** ("why was this hidden / un-approved?"). Renders the listing's moderation-event timeline via `listMyListingModerationEvents` — action + date + verbatim reason, newest-first, owner-scoped.
- **Surfaced edit.** The existing shadow-revision **Edit** entry point (`/apps/submit?edit=<id>`) is preserved and hardened to hide on a removed listing (edit is forbidden there server-side). No backend change.

### How republish eligibility is determined
`listMySubmissions`' projection is extended (additively, PII-safe) with:
- the listing's **true lifecycle status** (`AppListing.status`) — distinct from the publish-**request** status, which stays `approved` after an owner-hide / mod-delist, so the list can't otherwise tell a live listing from a hidden one; and
- **`lastModerationAction`** — a single batched last-event query over the removed listings on the page (mirrors the existing `hasPendingRevision` second query). This drives the owner-hidden-vs-mod-removed branch without an N+1 per-row fetch.

### Scope
Owner unpublish/republish + moderation-history + surfaced-edit are **off-site only** — the Phase 1 procs are offsite-scoped (on-site app-block listings manage via the block flow, which has a different edit path and no owner-takedown surface). Removed listings keep their existing status-section placement; the per-row badge + actions reflect the true listing state. The shared owner table config (`submissionsTable.ts` / `submissionsTableUi.tsx`) is untouched.

### Tests
- **Blocking unit project:** a pure owner-control view model (`offsiteOwnerControls`) pinning the status/last-event → state matrix and the unpublish/republish capability predicates (the browser-mode component suite is report-only).
- **Browser-mode component tests** (`OffsiteSubmissionsList`): live listing shows Unpublish and the confirm gate fires `unpublishOwnListing` with the right listing id (+ optional reason); an owner-hidden listing shows Republish → fires `republishOwnListing`; a mod-removed listing shows the "Removed by a moderator" state and **no** republish button; the history modal renders the timeline with verbatim reasons; the Edit link points at `/apps/submit?edit=<id>`. Existing section/filter/edit tests stay green.
- **Service tests:** the `lastModerationAction` projection (owner-unpublish ⇒ eligible, delist ⇒ forbidden, live ⇒ no events queried / null).

Ready for the audit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
