### PR TITLE
feat(blocks): collections read/discover + follow + tip endpoints for App Blocks

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1616,6 +1616,13 @@ export const REDIS_SYS_KEYS = {
     EMERGENCY_KILL_LIST: 'system:blocks:emergency-kill-list',
     // Cumulative Buzz-spend cap counter, keyed `system:blocks:buzz-cap:${userId}:${appBlockId}:${day}`.
     BUZZ_CAP: 'system:blocks:buzz-cap',
+    // Cumulative TIP-spend cap counter for the block tip endpoint, keyed
+    // `system:blocks:tip-cap:${userId}:${UTC-day}`. DISTINCT from BUZZ_CAP: that
+    // bounds a user's daily generation SPEND; this bounds a user's daily Buzz
+    // TIPPED-OUT through blocks (money to third parties). Per-USER aggregate (no
+    // appBlockId) so N installed blocks share ONE daily tip ceiling. INCRBY'd by
+    // each tip amount pre-transaction (reserve-and-refund), TTL set on first write.
+    TIP_CAP: 'system:blocks:tip-cap',
     /**
      * Per-APP cumulative spend-BOUNTY accrual cap counter (audit 🟡-2 / the
      * App-Blocks Sybil-economics review). DISTINCT from BUZZ_CAP: that one

--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -81,7 +81,8 @@
           "apps:storage:shared:read",
           "apps:storage:shared:write",
           "collections:read:self",
-          "collections:write:self"
+          "collections:write:self",
+          "collections:read:private"
         ]
       }
     },

--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -79,7 +79,9 @@
           "apps:storage:read",
           "apps:storage:write",
           "apps:storage:shared:read",
-          "apps:storage:shared:write"
+          "apps:storage:shared:write",
+          "collections:read:self",
+          "collections:write:self"
         ]
       }
     },

--- a/src/pages/api/v1/blocks/buzz.ts
+++ b/src/pages/api/v1/blocks/buzz.ts
@@ -1,0 +1,56 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+
+import {
+  parseSubjectUserId,
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import { getUserBuzzAccount } from '~/server/services/buzz.service';
+
+/**
+ * GET /api/v1/blocks/buzz
+ *
+ * Block-side Buzz-balance readout. Scope `buzz:read:self`. Returns the token
+ * SUBJECT's own (yellow) Buzz balance — a low-sensitivity self-read that powers a
+ * page app's balance chrome. Self-bound: the balance is keyed on the verified
+ * token subject, never client input; anon tokens are rejected (no "self").
+ *
+ * Response: `{ balance }`.
+ */
+
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  let subjectUserId: number | null;
+  try {
+    subjectUserId = parseSubjectUserId(claims.sub);
+  } catch {
+    res.status(403).json({ error: 'Invalid subject claim' });
+    return;
+  }
+  if (subjectUserId == null) {
+    res.status(403).json({ error: 'Anonymous block tokens may not read a balance' });
+    return;
+  }
+
+  try {
+    const accounts = await getUserBuzzAccount({ accountId: subjectUserId, accountType: 'yellow' });
+    res.status(200).json({ balance: accounts[0]?.balance ?? 0 });
+    return;
+  } catch {
+    res.status(502).json({ error: 'Failed to read balance' });
+    return;
+  }
+});
+
+export default withBlockScope(baseHandler, { requiredScope: 'buzz:read:self' });

--- a/src/pages/api/v1/blocks/collections/[id]/follow.ts
+++ b/src/pages/api/v1/blocks/collections/[id]/follow.ts
@@ -1,0 +1,104 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+import type { TRPCError } from '@trpc/server';
+import { getHTTPStatusCodeFromError } from '@trpc/server/http';
+import * as z from 'zod';
+
+import {
+  parseSubjectUserId,
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import {
+  addContributorToCollection,
+  removeContributorFromCollection,
+} from '~/server/services/collection.service';
+
+/**
+ * POST /api/v1/blocks/collections/[id]/follow
+ * Body `{ follow: boolean }` — scope `collections:write:self`.
+ *
+ * Follows / unfollows (on-site bookmark) a collection ON BEHALF OF the token
+ * SUBJECT. Reuses the existing collection follow services verbatim
+ * (`addContributorToCollection` / `removeContributorFromCollection`), self-bound:
+ * `userId === targetUserId === subject`, so a block can only ever follow for the
+ * authenticated caller (never a third party). The services enforce their own
+ * permission gate (a private collection the subject can't follow throws
+ * FORBIDDEN → surfaced as 403 here).
+ *
+ * Response: `{ followed: boolean }` (the resulting follow state).
+ */
+
+export const config = { api: { bodyParser: { sizeLimit: '4kb' } } };
+
+const bodySchema = z.object({ follow: z.boolean() });
+
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  let subjectUserId: number | null;
+  try {
+    subjectUserId = parseSubjectUserId(claims.sub);
+  } catch {
+    res.status(403).json({ error: 'Invalid subject claim' });
+    return;
+  }
+  if (subjectUserId == null) {
+    res.status(403).json({ error: 'Anonymous block tokens may not follow collections' });
+    return;
+  }
+
+  const rawId = req.query.id;
+  const idStr = Array.isArray(rawId) ? undefined : rawId;
+  const collectionId = idStr != null && /^[0-9]+$/.test(idStr) ? Number.parseInt(idStr, 10) : NaN;
+  if (!Number.isInteger(collectionId) || collectionId <= 0) {
+    res.status(400).json({ error: 'Invalid collection id' });
+    return;
+  }
+
+  const parsed = bodySchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid request body', details: parsed.error.flatten() });
+    return;
+  }
+  const { follow } = parsed.data;
+
+  try {
+    if (follow) {
+      // Self-bound: userId (actor) === targetUserId === subject.
+      await addContributorToCollection({
+        collectionId,
+        userId: subjectUserId,
+        targetUserId: subjectUserId,
+      });
+    } else {
+      await removeContributorFromCollection({
+        collectionId,
+        userId: subjectUserId,
+        targetUserId: subjectUserId,
+      });
+    }
+    res.status(200).json({ followed: follow });
+    return;
+  } catch (error) {
+    // The services throw TRPCError (e.g. FORBIDDEN when the subject can't follow a
+    // private collection). Map to the corresponding HTTP status rather than a 500.
+    const trpcError = error as TRPCError;
+    const statusCode =
+      typeof trpcError?.code === 'string' ? getHTTPStatusCodeFromError(trpcError) : 500;
+    res.status(statusCode).json({ error: trpcError?.message ?? 'Failed to update follow state' });
+    return;
+  }
+});
+
+export default withBlockScope(baseHandler, { requiredScope: 'collections:write:self' });

--- a/src/pages/api/v1/blocks/collections/[id]/index.ts
+++ b/src/pages/api/v1/blocks/collections/[id]/index.ts
@@ -122,6 +122,18 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       return;
     }
 
+    // READ SPLIT (private consent gate): a PUBLIC/unlisted collection
+    // (`publicCollection`) is readable with collections:read:self. A NON-public
+    // (Private) collection is readable here ONLY because the subject is the
+    // owner/contributor — and that additionally requires the consent-gated
+    // `collections:read:private` scope. Without it, return the SAME invisible 404
+    // as a non-owner (no 403 oracle, and — critically — no "needs consent" leak to
+    // a non-owner, who can't distinguish this from a non-existent collection).
+    if (!permissions.publicCollection && !claims.scopes.includes('collections:read:private')) {
+      res.status(404).json({ error: 'Collection not found' });
+      return;
+    }
+
     // getCollectionById throws NotFound when the row is gone — map to the same 404.
     let collection;
     try {

--- a/src/pages/api/v1/blocks/collections/[id]/index.ts
+++ b/src/pages/api/v1/blocks/collections/[id]/index.ts
@@ -1,0 +1,174 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+import * as z from 'zod';
+
+import {
+  parseSubjectUserId,
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import {
+  getCollectionById,
+  getCollectionItemsByCollectionId,
+  getUserCollectionPermissionsById,
+} from '~/server/services/collection.service';
+import {
+  getFollowedCollectionIds,
+  hydrateBlockSubject,
+  mapImageItemToMedia,
+} from '~/server/services/blocks/block-collections.service';
+import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturity';
+import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
+import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
+import { CollectionItemStatus, CollectionReadConfiguration } from '~/shared/utils/prisma/enums';
+
+/**
+ * GET /api/v1/blocks/collections/[id]?cursor&limit
+ *
+ * Block-token collection DETAIL (media items) for App Blocks. Scope
+ * `collections:read:self`.
+ *
+ * VISIBILITY (existence-leak-safe): a public/unlisted collection is readable by
+ * anyone; a PRIVATE collection is readable ONLY by its owner/contributor. A
+ * caller without read permission — OR a non-existent collection — gets the SAME
+ * bare 404 (never 403), so the endpoint is not a private-collection existence
+ * oracle. The permission decision reuses `getUserCollectionPermissionsById`.
+ *
+ * MATURITY: media items are clamped to the token's `maxBrowsingLevel` ceiling
+ * (region-narrowed) by threading the clamped `browsingLevel` into
+ * `getCollectionItemsByCollectionId` — the identical authority surface
+ * /api/v1/blocks/images uses. Only image/video (playable) items are returned;
+ * model/post/article items are omitted.
+ *
+ * Response: `{ collection: { id, name, description, curator:{ userId, username },
+ *   isPublic, followed }, items: [{ mediaId, type:'image'|'video', url, width,
+ *   height, creator:{ userId, username }, nsfwLevel }], nextCursor }`.
+ */
+
+export const config = { api: { responseLimit: false } };
+
+const querySchema = z.object({
+  cursor: z.string().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(24),
+});
+
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  let subjectUserId: number | null;
+  try {
+    subjectUserId = parseSubjectUserId(claims.sub);
+  } catch {
+    res.status(403).json({ error: 'Invalid subject claim' });
+    return;
+  }
+  if (subjectUserId == null) {
+    res.status(403).json({ error: 'Anonymous block tokens may not read collections' });
+    return;
+  }
+
+  // Path param: a single numeric collection id (reject array / non-numeric).
+  const rawId = req.query.id;
+  const idStr = Array.isArray(rawId) ? undefined : rawId;
+  const collectionId = idStr != null && /^[0-9]+$/.test(idStr) ? Number.parseInt(idStr, 10) : NaN;
+  if (!Number.isInteger(collectionId) || collectionId <= 0) {
+    res.status(400).json({ error: 'Invalid collection id' });
+    return;
+  }
+
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
+  const { cursor, limit } = parsed.data;
+
+  const rateLimit = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
+    return;
+  }
+
+  const subjectUser = await hydrateBlockSubject(subjectUserId);
+  if (!subjectUser) {
+    res.status(404).json({ error: 'User not found' });
+    return;
+  }
+
+  const regionRestricted = isRegionRestricted(getRegion(req));
+  const { browsingLevel } = resolveCatalogBrowsingLevel(claims, { regionRestricted });
+
+  try {
+    // VISIBILITY gate. `read` is true for public/unlisted, and for the
+    // owner/contributor of a private collection. No read → 404 (indistinguishable
+    // from a non-existent collection — no existence oracle).
+    const permissions = await getUserCollectionPermissionsById({
+      id: collectionId,
+      userId: subjectUserId,
+      isModerator: subjectUser.isModerator,
+    });
+    if (!permissions.read) {
+      res.status(404).json({ error: 'Collection not found' });
+      return;
+    }
+
+    // getCollectionById throws NotFound when the row is gone — map to the same 404.
+    let collection;
+    try {
+      collection = await getCollectionById({ input: { id: collectionId } });
+    } catch {
+      res.status(404).json({ error: 'Collection not found' });
+      return;
+    }
+
+    const { items: expanded, nextCursor } = await getCollectionItemsByCollectionId({
+      input: {
+        collectionId,
+        limit,
+        cursor,
+        browsingLevel,
+        statuses: [CollectionItemStatus.ACCEPTED],
+      },
+      user: subjectUser,
+    });
+
+    // Only playable media (image/video). Model/post/article items are dropped.
+    const items = expanded
+      .filter((it) => it.type === 'image')
+      .map((it) => mapImageItemToMedia(it.data as Parameters<typeof mapImageItemToMedia>[0]));
+
+    const followed = await getFollowedCollectionIds(subjectUserId, [collectionId]);
+
+    res.status(200).json({
+      collection: {
+        id: collection.id,
+        name: collection.name,
+        description: collection.description ?? null,
+        curator: {
+          userId: collection.user?.id ?? collection.userId,
+          username: collection.user?.username ?? null,
+        },
+        isPublic: collection.read === CollectionReadConfiguration.Public,
+        followed: followed.has(collectionId),
+      },
+      items,
+      nextCursor,
+    });
+    return;
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to load collection' });
+    return;
+  }
+});
+
+export default withBlockScope(baseHandler, { requiredScope: 'collections:read:self' });

--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -183,10 +183,15 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       return;
     }
 
-    // mode === 'mine' — the subject's own collections (public + private). The
-    // service returns the FULL owned+contributed set (no DB pagination), so we
-    // apply the name filter + keyset (id DESC) slice in-memory. A user's own
-    // collection set is bounded, so this is safe.
+    // mode === 'mine' — the subject's own collections. The service returns the
+    // FULL owned+contributed set (no DB pagination), so we apply the name filter +
+    // keyset (id DESC) slice in-memory. A user's own collection set is bounded.
+    //
+    // READ SPLIT: own PUBLIC collections are always returned (collections:read:self
+    // gated the endpoint). Own NON-PUBLIC collections (Private/Unlisted — anything
+    // not `Public`) are included ONLY when the token ALSO carries the consent-gated
+    // `collections:read:private` scope; otherwise they are omitted entirely.
+    const canReadPrivate = claims.scopes.includes('collections:read:private');
     const owned = await getUserCollectionsWithPermissions({
       input: { userId: subjectUserId, contributingOnly: true },
     });
@@ -194,6 +199,8 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     const needle = query?.toLowerCase();
     const filtered = owned
       .filter((c) => (needle ? c.name.toLowerCase().includes(needle) : true))
+      // Read split: hide non-public own collections unless read:private is granted.
+      .filter((c) => canReadPrivate || c.read === CollectionReadConfiguration.Public)
       .filter((c) => (cursor ? c.id < cursor : true))
       .sort((a, b) => b.id - a.id);
 

--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -1,0 +1,215 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+import * as z from 'zod';
+
+import {
+  parseSubjectUserId,
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import {
+  getAllCollections,
+  getCollectionItemCount,
+  getUserCollectionsWithPermissions,
+} from '~/server/services/collection.service';
+import {
+  collectionWithinCeiling,
+  getFollowedCollectionIds,
+  hydrateBlockSubject,
+  toMediaUrl,
+} from '~/server/services/blocks/block-collections.service';
+import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturity';
+import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
+import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
+import { CollectionSort } from '~/server/common/enums';
+import { CollectionItemStatus, CollectionReadConfiguration } from '~/shared/utils/prisma/enums';
+
+/**
+ * GET /api/v1/blocks/collections?mode=public|mine&query&sort&cursor&limit
+ *
+ * Block-token collection DISCOVERY for App Blocks. Scope `collections:read:self`.
+ *
+ *   - mode=public → public collections (name-searchable, sortable) via the
+ *     existing `getAllCollections` service (privacy pinned to Public).
+ *   - mode=mine   → the SUBJECT's OWN collections (public + private) via the
+ *     existing `getUserCollectionsWithPermissions` service, keyed on the verified
+ *     token subject (never a client-supplied userId).
+ *
+ * Maturity: collections whose own `nsfwLevel` exceeds the token's clamped ceiling
+ * (`claims.maxBrowsingLevel`, region-narrowed) are dropped — a SFW-domain block
+ * can't surface a mature collection in discovery. (Per-item maturity is enforced
+ * on the detail endpoint where the media is actually read.)
+ *
+ * Response: `{ items: [{ id, name, description, coverImageUrl, itemCount,
+ *   curator:{ userId, username }, isPublic, followed }], nextCursor }`.
+ */
+
+export const config = { api: { responseLimit: false } };
+
+const querySchema = z.object({
+  mode: z.enum(['public', 'mine']).default('public'),
+  query: z.string().trim().max(100).optional(),
+  sort: z.enum(CollectionSort).default(CollectionSort.Newest),
+  // Keyset cursor on the collection id (both modes order by id DESC).
+  cursor: z.coerce.number().int().positive().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(24),
+});
+
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  let subjectUserId: number | null;
+  try {
+    subjectUserId = parseSubjectUserId(claims.sub);
+  } catch {
+    res.status(403).json({ error: 'Invalid subject claim' });
+    return;
+  }
+  if (subjectUserId == null) {
+    res.status(403).json({ error: 'Anonymous block tokens may not read collections' });
+    return;
+  }
+
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
+  const { mode, query, sort, cursor, limit } = parsed.data;
+
+  // Per-instance rate limit (shared blocks catalog limiter) — bounds a block
+  // hammering this private,no-store route onto the origin.
+  const rateLimit = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
+    return;
+  }
+
+  const regionRestricted = isRegionRestricted(getRegion(req));
+  const { browsingLevel } = resolveCatalogBrowsingLevel(claims, { regionRestricted });
+
+  const subjectUser = await hydrateBlockSubject(subjectUserId);
+  if (!subjectUser) {
+    res.status(404).json({ error: 'User not found' });
+    return;
+  }
+
+  try {
+    if (mode === 'public') {
+      // Fetch limit+1 to derive the next keyset cursor.
+      const rows = await getAllCollections({
+        input: {
+          limit: limit + 1,
+          cursor,
+          query,
+          sort,
+          privacy: [CollectionReadConfiguration.Public],
+        },
+        user: subjectUser,
+        select: {
+          id: true,
+          name: true,
+          description: true,
+          read: true,
+          nsfwLevel: true,
+          userId: true,
+          user: { select: { id: true, username: true } },
+          image: { select: { url: true, type: true } },
+        },
+      });
+
+      // Maturity: drop collections above the clamped ceiling.
+      const visible = rows.filter((c) => collectionWithinCeiling(c.nsfwLevel ?? 0, browsingLevel));
+
+      let items = visible;
+      let nextCursor: number | undefined;
+      if (items.length > limit) {
+        items = items.slice(0, limit);
+        nextCursor = items[items.length - 1]?.id;
+      }
+
+      const ids = items.map((c) => c.id);
+      const [countRows, followed] = await Promise.all([
+        getCollectionItemCount({ collectionIds: ids, status: CollectionItemStatus.ACCEPTED }),
+        getFollowedCollectionIds(subjectUserId, ids),
+      ]);
+      const countMap = new Map(countRows.map((c) => [c.id, Number(c.count)]));
+
+      res.status(200).json({
+        items: items.map((c) => ({
+          id: c.id,
+          name: c.name,
+          description: c.description ?? null,
+          coverImageUrl: toMediaUrl(c.image),
+          itemCount: countMap.get(c.id) ?? 0,
+          curator: { userId: c.userId, username: c.user?.username ?? null },
+          isPublic: c.read === CollectionReadConfiguration.Public,
+          followed: followed.has(c.id),
+        })),
+        nextCursor,
+      });
+      return;
+    }
+
+    // mode === 'mine' — the subject's own collections (public + private). The
+    // service returns the FULL owned+contributed set (no DB pagination), so we
+    // apply the name filter + keyset (id DESC) slice in-memory. A user's own
+    // collection set is bounded, so this is safe.
+    const owned = await getUserCollectionsWithPermissions({
+      input: { userId: subjectUserId, contributingOnly: true },
+    });
+
+    const needle = query?.toLowerCase();
+    const filtered = owned
+      .filter((c) => (needle ? c.name.toLowerCase().includes(needle) : true))
+      .filter((c) => (cursor ? c.id < cursor : true))
+      .sort((a, b) => b.id - a.id);
+
+    let items = filtered;
+    let nextCursor: number | undefined;
+    if (items.length > limit) {
+      items = items.slice(0, limit);
+      nextCursor = items[items.length - 1]?.id;
+    }
+
+    const ids = items.map((c) => c.id);
+    const [countRows, followed] = await Promise.all([
+      getCollectionItemCount({ collectionIds: ids, status: CollectionItemStatus.ACCEPTED }),
+      getFollowedCollectionIds(subjectUserId, ids),
+    ]);
+    const countMap = new Map(countRows.map((c) => [c.id, Number(c.count)]));
+
+    res.status(200).json({
+      items: items.map((c) => ({
+        id: c.id,
+        name: c.name,
+        description: c.description ?? null,
+        coverImageUrl: toMediaUrl(c.image),
+        itemCount: countMap.get(c.id) ?? 0,
+        curator: { userId: c.userId, username: subjectUser.username ?? null },
+        isPublic: c.read === CollectionReadConfiguration.Public,
+        followed: followed.has(c.id),
+      })),
+      nextCursor,
+    });
+    return;
+  } catch (error) {
+    res.status(500).json({ error: 'Failed to load collections' });
+    return;
+  }
+});
+
+// Scope-gated: collections:read:self (self-scope → non-anon subject enforced by
+// the middleware). Not the "any valid token" catalog mode — reads are subject-
+// bound (own private collections), so a declared+granted scope is the gate.
+export default withBlockScope(baseHandler, { requiredScope: 'collections:read:self' });

--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -106,10 +106,18 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 
   try {
     if (mode === 'public') {
-      // Fetch limit+1 to derive the next keyset cursor.
+      // Over-fetch so the maturity clamp can't under-fill the page and terminate
+      // pagination early (which would make later public collections unreachable).
+      // Walk the (createdAt DESC) rows collecting visible ones until the page is
+      // full, then continue the keyset from the FIRST fetched row we did NOT
+      // consume. getAllCollections' cursor is INCLUSIVE, so pointing next page's
+      // cursor at that first-unconsumed row resumes exactly there — no gap (the
+      // clamped-out rows before it were already walked past) and no duplicate (it
+      // was not shown on this page).
+      const OVERFETCH = limit * 4 + 1;
       const rows = await getAllCollections({
         input: {
-          limit: limit + 1,
+          limit: OVERFETCH,
           cursor,
           query,
           sort,
@@ -128,15 +136,29 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
         },
       });
 
-      // Maturity: drop collections above the clamped ceiling.
-      const visible = rows.filter((c) => collectionWithinCeiling(c.nsfwLevel ?? 0, browsingLevel));
-
-      let items = visible;
-      let nextCursor: number | undefined;
-      if (items.length > limit) {
-        items = items.slice(0, limit);
-        nextCursor = items[items.length - 1]?.id;
+      const items: typeof rows = [];
+      let firstUnconsumedId: number | undefined;
+      for (let i = 0; i < rows.length; i++) {
+        if (items.length >= limit) {
+          firstUnconsumedId = rows[i].id;
+          break;
+        }
+        if (collectionWithinCeiling(rows[i].nsfwLevel ?? 0, browsingLevel)) items.push(rows[i]);
       }
+
+      let nextCursor: number | undefined;
+      if (firstUnconsumedId !== undefined) {
+        // Page filled AND at least one fetched row remains → clean inclusive resume.
+        nextCursor = firstUnconsumedId;
+      } else if (rows.length === OVERFETCH) {
+        // Consumed the ENTIRE over-fetch without filling `limit` (a very heavy
+        // clamp) yet the source returned a full batch → more may remain. Resume
+        // from the last fetched row (inclusive → re-fetched next page; the client
+        // dedups by id). Rare (needs the clamp to drop most of 4×limit+1 rows).
+        nextCursor = rows[rows.length - 1]?.id;
+      }
+      // else: rows.length < OVERFETCH and the page wasn't over-consumed → the
+      // source is exhausted → no nextCursor.
 
       const ids = items.map((c) => c.id);
       const [countRows, followed] = await Promise.all([

--- a/src/pages/api/v1/blocks/shared-storage/increment.ts
+++ b/src/pages/api/v1/blocks/shared-storage/increment.ts
@@ -1,0 +1,73 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+import type { TRPCError } from '@trpc/server';
+import { getHTTPStatusCodeFromError } from '@trpc/server/http';
+import * as z from 'zod';
+
+import {
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import {
+  assertValidCounterKey,
+  incrementSharedCounter,
+} from '~/server/routers/apps-shared.router';
+
+/**
+ * POST /api/v1/blocks/shared-storage/increment  body `{ key }`
+ * Scope `apps:storage:shared:write`.
+ *
+ * Increments (by 1) an app-defined counter in THIS app's shared schema (e.g.
+ * `playcount:<collectionId>`). Routed through the SAME `resolveSharedContext`
+ * min-trust gate + write-scope + per-(user,app) rate limit + per-app-schema
+ * isolation as the shared append/vote path (anti-inflation): a sub-trust caller
+ * gets 403 — intended, since the app treats increment as best-effort. Money-free.
+ *
+ * Response: `{ key, count }` (the new count).
+ */
+
+export const config = { api: { bodyParser: { sizeLimit: '4kb' } } };
+
+const bodySchema = z.object({ key: z.string().min(1).max(64) });
+
+function bearer(req: NextApiRequest): string {
+  const auth = req.headers.authorization ?? '';
+  return auth.toLowerCase().startsWith('bearer ') ? auth.slice('bearer '.length).trim() : '';
+}
+
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  const parsed = bodySchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid request body', details: parsed.error.flatten() });
+    return;
+  }
+
+  try {
+    const key = assertValidCounterKey(parsed.data.key);
+    const result = await incrementSharedCounter(bearer(req), key);
+    res.status(200).json(result);
+    return;
+  } catch (error) {
+    // resolveSharedContext / the increment throw TRPCError (sub-trust → FORBIDDEN,
+    // rate-limit → TOO_MANY_REQUESTS, disabled flag → FORBIDDEN, etc.).
+    const trpcError = error as TRPCError;
+    const statusCode =
+      typeof trpcError?.code === 'string' ? getHTTPStatusCodeFromError(trpcError) : 500;
+    res.status(statusCode).json({ error: trpcError?.message ?? 'Failed to increment counter' });
+    return;
+  }
+});
+
+export default withBlockScope(baseHandler, { requiredScope: 'apps:storage:shared:write' });

--- a/src/pages/api/v1/blocks/shared-storage/top.ts
+++ b/src/pages/api/v1/blocks/shared-storage/top.ts
@@ -1,0 +1,69 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+import type { TRPCError } from '@trpc/server';
+import { getHTTPStatusCodeFromError } from '@trpc/server/http';
+import * as z from 'zod';
+
+import {
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import { getTopSharedCounters } from '~/server/routers/apps-shared.router';
+
+/**
+ * GET /api/v1/blocks/shared-storage/top?prefix=&limit=N
+ * Scope `apps:storage:shared:read`.
+ *
+ * Top-N counters (count DESC) whose key matches `prefix` in THIS app's shared
+ * schema — the "popular" rail read for app-defined counters (e.g.
+ * `prefix=playcount:`). Routed through the SAME `resolveSharedContext` (per-app
+ * isolation + read-scope + kill-switch). Money-free.
+ *
+ * Response: `[{ key, count }]`.
+ */
+
+export const config = { api: { responseLimit: false } };
+
+const querySchema = z.object({
+  prefix: z.string().max(64).optional().default(''),
+  limit: z.coerce.number().int().min(1).max(100).default(20),
+});
+
+function bearer(req: NextApiRequest): string {
+  const auth = req.headers.authorization ?? '';
+  return auth.toLowerCase().startsWith('bearer ') ? auth.slice('bearer '.length).trim() : '';
+}
+
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  const parsed = querySchema.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid query', details: parsed.error.flatten() });
+    return;
+  }
+  const { prefix, limit } = parsed.data;
+
+  try {
+    const items = await getTopSharedCounters(bearer(req), prefix, limit);
+    res.status(200).json(items);
+    return;
+  } catch (error) {
+    const trpcError = error as TRPCError;
+    const statusCode =
+      typeof trpcError?.code === 'string' ? getHTTPStatusCodeFromError(trpcError) : 500;
+    res.status(statusCode).json({ error: trpcError?.message ?? 'Failed to read counters' });
+    return;
+  }
+});
+
+export default withBlockScope(baseHandler, { requiredScope: 'apps:storage:shared:read' });

--- a/src/pages/api/v1/blocks/tip.ts
+++ b/src/pages/api/v1/blocks/tip.ts
@@ -1,0 +1,163 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+import type { TRPCError } from '@trpc/server';
+import { getHTTPStatusCodeFromError } from '@trpc/server/http';
+import * as z from 'zod';
+
+import {
+  parseSubjectUserId,
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import { createBuzzTipTransactionHandler } from '~/server/controllers/buzz.controller';
+import { Tracker } from '~/server/clickhouse/client';
+import type { ProtectedContext } from '~/server/createContext';
+import { hydrateBlockSubject } from '~/server/services/blocks/block-collections.service';
+import { checkBlockTipRateLimit } from '~/server/utils/block-tip-rate-limit';
+
+/**
+ * POST /api/v1/blocks/tip
+ * Body `{ toUserId, amount, entityType?, entityId? }` — scope `social:tip:self`.
+ *
+ * Sends a Buzz TIP from the token SUBJECT to `toUserId`. Reuses the real
+ * money-moving flow `createBuzzTipTransactionHandler` (NOT the low-level
+ * `upsertBuzzTip`, which only records a row) so every hard gate the on-site tip
+ * enforces applies here verbatim: self-tip reject, insufficient-balance,
+ * banned/blocked target, 24h-account age, and the actual Buzz transaction +
+ * notification. This endpoint self-binds the sender to the verified subject
+ * (never a client-supplied fromUserId), adds a positive-int/sane-max amount
+ * guard, a per-instance rate limit, and maps the handler's TRPCError to the
+ * corresponding HTTP status (insufficient funds → a clean 400, never a 500).
+ *
+ * Response: `{ ok: true, tip: { toUserId, amount, entityType?, entityId? } }`.
+ *
+ * 🔴 NOTE (wire-up gate for the page app): `social:tip:self` is in
+ * PAGE_FORBIDDEN_SCOPES, so the production page-token mint refuses to issue it to
+ * a full-page (entity=none) app. This endpoint is correct + fully guarded, but a
+ * page app cannot currently obtain a token carrying `social:tip:self` — see the
+ * PR description. Reconciling that page-mint rule is a separate decision.
+ */
+
+export const config = { api: { bodyParser: { sizeLimit: '4kb' } } };
+
+// Sane upper bound on a single tip call. The AUTHORITATIVE control is the
+// balance check inside the handler; this only bounds a single request's amount.
+const MAX_TIP_AMOUNT = 100_000;
+
+const bodySchema = z.object({
+  toUserId: z.number().int().positive(),
+  amount: z.number().int().positive().max(MAX_TIP_AMOUNT),
+  entityType: z.enum(['Image', 'Collection', 'User']).optional(),
+  entityId: z.number().int().positive().optional(),
+});
+
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  let subjectUserId: number | null;
+  try {
+    subjectUserId = parseSubjectUserId(claims.sub);
+  } catch {
+    res.status(403).json({ error: 'Invalid subject claim' });
+    return;
+  }
+  if (subjectUserId == null) {
+    res.status(403).json({ error: 'Anonymous block tokens may not tip' });
+    return;
+  }
+
+  const parsed = bodySchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    res.status(400).json({ error: 'Invalid request body', details: parsed.error.flatten() });
+    return;
+  }
+  const { toUserId, amount, entityType, entityId } = parsed.data;
+
+  // entityType/entityId must be supplied together (both or neither).
+  if ((entityType && !entityId) || (!entityType && entityId)) {
+    res.status(400).json({ error: 'entityType and entityId must be provided together' });
+    return;
+  }
+
+  // Self-tip guard (the handler also rejects this — belt + suspenders + a clean
+  // message before any DB work).
+  if (toUserId === subjectUserId) {
+    res.status(400).json({ error: 'You cannot tip yourself' });
+    return;
+  }
+
+  // Per-instance rate limit (fail-CLOSED on redis error — money path).
+  const rateLimit = await checkBlockTipRateLimit(claims.blockInstanceId);
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.status(429).json({ error: 'Too many tips — please retry shortly.' });
+    return;
+  }
+
+  const subjectUser = await hydrateBlockSubject(subjectUserId);
+  if (!subjectUser) {
+    res.status(404).json({ error: 'User not found' });
+    return;
+  }
+  if (subjectUser.bannedAt) {
+    res.status(403).json({ error: 'banned' });
+    return;
+  }
+  if (subjectUser.muted) {
+    res.status(403).json({ error: 'Your account is restricted' });
+    return;
+  }
+
+  // Build a minimal ProtectedContext for the controller (it reads ctx.user +
+  // ctx.track). The sender is ALWAYS the verified subject — never body input.
+  const ctx = {
+    user: subjectUser,
+    track: new Tracker(req, res),
+    ip: '',
+    cache: null,
+    req,
+    res,
+  } as unknown as ProtectedContext;
+
+  try {
+    await createBuzzTipTransactionHandler({
+      input: {
+        toAccountId: toUserId,
+        amount,
+        fromAccountType: 'yellow',
+        toAccountType: 'yellow',
+        entityType,
+        entityId,
+      },
+      ctx,
+    });
+
+    res.status(200).json({
+      ok: true,
+      tip: { toUserId, amount, entityType: entityType ?? null, entityId: entityId ?? null },
+    });
+    return;
+  } catch (error) {
+    // The handler wraps everything in a TRPCError (getTRPCErrorFromUnknown):
+    // insufficient funds / self-tip / banned target → BAD_REQUEST (400); etc.
+    const trpcError = error as TRPCError;
+    const statusCode =
+      typeof trpcError?.code === 'string' ? getHTTPStatusCodeFromError(trpcError) : 500;
+    res
+      .status(statusCode)
+      .json({ ok: false, error: trpcError?.message ?? 'Failed to send tip' });
+    return;
+  }
+});
+
+export default withBlockScope(baseHandler, { requiredScope: 'social:tip:self' });

--- a/src/pages/api/v1/blocks/tip.ts
+++ b/src/pages/api/v1/blocks/tip.ts
@@ -13,7 +13,13 @@ import { createBuzzTipTransactionHandler } from '~/server/controllers/buzz.contr
 import { Tracker } from '~/server/clickhouse/client';
 import type { ProtectedContext } from '~/server/createContext';
 import { hydrateBlockSubject } from '~/server/services/blocks/block-collections.service';
-import { checkBlockTipRateLimit } from '~/server/utils/block-tip-rate-limit';
+import {
+  BLOCK_TIP_CAP_PER_DAY,
+  BLOCK_TIP_MAX_PER_TIP,
+  checkBlockTipRateLimit,
+  refundBlockTipSpend,
+  reserveBlockTipSpend,
+} from '~/server/utils/block-tip-rate-limit';
 
 /**
  * POST /api/v1/blocks/tip
@@ -31,22 +37,20 @@ import { checkBlockTipRateLimit } from '~/server/utils/block-tip-rate-limit';
  *
  * Response: `{ ok: true, tip: { toUserId, amount, entityType?, entityId? } }`.
  *
- * 🔴 NOTE (wire-up gate for the page app): `social:tip:self` is in
- * PAGE_FORBIDDEN_SCOPES, so the production page-token mint refuses to issue it to
- * a full-page (entity=none) app. This endpoint is correct + fully guarded, but a
- * page app cannot currently obtain a token carrying `social:tip:self` — see the
- * PR description. Reconciling that page-mint rule is a separate decision.
+ * PAGE-SAFE via BOUNDED tipping: this endpoint enforces a per-tip cap
+ * (BLOCK_TIP_MAX_PER_TIP) AND a per-user daily cap (BLOCK_TIP_CAP_PER_DAY,
+ * reserve-and-refund) BEFORE any money moves — the analogue of the gen-spend
+ * `buzzBudget` + `BLOCK_BUZZ_CAP_PER_DAY` pair. Those caps are what let
+ * `social:tip:self` come off PAGE_FORBIDDEN_SCOPES (a page tip is now bounded, no
+ * longer effectively-unbounded spend). Over either cap → clean 4xx (never a 500).
  */
 
 export const config = { api: { bodyParser: { sizeLimit: '4kb' } } };
 
-// Sane upper bound on a single tip call. The AUTHORITATIVE control is the
-// balance check inside the handler; this only bounds a single request's amount.
-const MAX_TIP_AMOUNT = 100_000;
-
 const bodySchema = z.object({
   toUserId: z.number().int().positive(),
-  amount: z.number().int().positive().max(MAX_TIP_AMOUNT),
+  // Per-tip cap is the schema's hard upper bound — over-per-tip → clean 400.
+  amount: z.number().int().positive().max(BLOCK_TIP_MAX_PER_TIP),
   entityType: z.enum(['Image', 'Collection', 'User']).optional(),
   entityId: z.number().int().positive().optional(),
 });
@@ -118,6 +122,26 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     return;
   }
 
+  // PER-USER DAILY CAP — atomically RESERVE this tip against the user's UTC-day
+  // aggregate BEFORE the money moves. Fail-CLOSED on a redis error (503). Over the
+  // daily cap → refund the reservation + clean 400. The reservation stands only if
+  // the tip transaction below resolves; any throw refunds it.
+  let capKey: Awaited<ReturnType<typeof reserveBlockTipSpend>>['key'];
+  try {
+    const reserved = await reserveBlockTipSpend(subjectUserId, amount);
+    capKey = reserved.key;
+    if (reserved.total > BLOCK_TIP_CAP_PER_DAY) {
+      await refundBlockTipSpend(capKey, amount);
+      res.status(400).json({
+        error: `Daily tip limit reached (${BLOCK_TIP_CAP_PER_DAY} Buzz). Try again tomorrow.`,
+      });
+      return;
+    }
+  } catch {
+    res.status(503).json({ error: 'Tip limiter unavailable; please retry' });
+    return;
+  }
+
   // Build a minimal ProtectedContext for the controller (it reads ctx.user +
   // ctx.track). The sender is ALWAYS the verified subject — never body input.
   const ctx = {
@@ -148,6 +172,9 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     });
     return;
   } catch (error) {
+    // The tip did NOT move money — refund the daily-cap reservation so a failed
+    // attempt (insufficient funds, banned target, …) doesn't burn the user's cap.
+    await refundBlockTipSpend(capKey, amount);
     // The handler wraps everything in a TRPCError (getTRPCErrorFromUnknown):
     // insufficient funds / self-tip / banned target → BAD_REQUEST (400); etc.
     const trpcError = error as TRPCError;

--- a/src/pages/api/v1/blocks/tip.ts
+++ b/src/pages/api/v1/blocks/tip.ts
@@ -10,6 +10,7 @@ import {
   type BlockScopedNextApiRequest,
 } from '~/server/middleware/block-scope.middleware';
 import { createBuzzTipTransactionHandler } from '~/server/controllers/buzz.controller';
+import { dbRead } from '~/server/db/client';
 import { Tracker } from '~/server/clickhouse/client';
 import type { ProtectedContext } from '~/server/createContext';
 import { hydrateBlockSubject } from '~/server/services/blocks/block-collections.service';
@@ -100,6 +101,20 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     return;
   }
 
+  // RECIPIENT existence/tippable check — the shared handler only checks the target
+  // is not banned, NOT that it exists, so without this a page app could try to
+  // credit Buzz into a non-existent (or soft-deleted) account id. Reject a
+  // missing/deleted recipient with a clean 400 BEFORE any rate-limit or cap
+  // reservation is consumed. (Banned/blocked/24h checks remain the handler's.)
+  const recipient = await dbRead.user.findUnique({
+    where: { id: toUserId },
+    select: { id: true, deletedAt: true },
+  });
+  if (!recipient || recipient.deletedAt) {
+    res.status(400).json({ error: 'Recipient not found' });
+    return;
+  }
+
   // Per-instance rate limit (fail-CLOSED on redis error — money path).
   const rateLimit = await checkBlockTipRateLimit(claims.blockInstanceId);
   if (!rateLimit.allowed) {
@@ -172,14 +187,24 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     });
     return;
   } catch (error) {
-    // The tip did NOT move money — refund the daily-cap reservation so a failed
-    // attempt (insufficient funds, banned target, …) doesn't burn the user's cap.
-    await refundBlockTipSpend(capKey, amount);
-    // The handler wraps everything in a TRPCError (getTRPCErrorFromUnknown):
-    // insufficient funds / self-tip / banned target → BAD_REQUEST (400); etc.
     const trpcError = error as TRPCError;
     const statusCode =
       typeof trpcError?.code === 'string' ? getHTTPStatusCodeFromError(trpcError) : 500;
+
+    // REFUND ONLY ON A KNOWN-PRE-MONEY FAILURE. In createBuzzTipTransactionHandler
+    // the money moves at `createBuzzTransactionMany`; EVERY guard that runs before
+    // it (self-tip, banned/blocked target, 24h age, and the balance pre-check →
+    // insufficient funds) throws BAD_REQUEST — i.e. a 4xx GUARANTEES no Buzz left
+    // the sender, so the reservation must be refunded. A 5xx (or a non-TRPC throw)
+    // may originate AFTER the money moved (upsertBuzzTip / notification / metric),
+    // so we must NOT refund it — keeping the reservation only makes the daily cap
+    // STRICTER (the safe direction), never lets a real spend escape the ceiling.
+    // (Fixes the latent cap-bypass where a post-money throw refunded the cap and
+    // let the daily total under-count past the ceiling.)
+    if (statusCode >= 400 && statusCode < 500) {
+      await refundBlockTipSpend(capKey, amount);
+    }
+
     res
       .status(statusCode)
       .json({ ok: false, error: trpcError?.message ?? 'Failed to send tip' });

--- a/src/server/middleware/__tests__/collections-tip-authz.test.ts
+++ b/src/server/middleware/__tests__/collections-tip-authz.test.ts
@@ -108,6 +108,10 @@ const SCOPES = [
   'collections:read:self',
   'collections:write:self',
   'social:tip:self',
+  // buzz:read:self (balance readout) + apps:storage:shared:write (play-count
+  // increment) are ALSO self/non-anon scopes — same authz contract.
+  'buzz:read:self',
+  'apps:storage:shared:write',
 ] as const;
 
 describe.each(SCOPES)('withBlockScope authz — %s', (scope) => {
@@ -175,6 +179,56 @@ describe.each(SCOPES)('withBlockScope authz — %s', (scope) => {
     await route(makeReq(`Bearer ${bogus}`) as never, res as never);
 
     expect(res.statusCode).toBe(401);
+    expect(wrapped).not.toHaveBeenCalled();
+  });
+});
+
+// apps:storage:shared:read (play-count "top" read) is anon-ALLOWED by design (a
+// public within-app read), so it has a different anon contract than the self
+// scopes above: an anon token carrying it RUNS the handler.
+describe('withBlockScope authz — apps:storage:shared:read (anon-allowed read)', () => {
+  const scope = 'apps:storage:shared:read';
+
+  it('accepts a valid token carrying the scope → handler runs', async () => {
+    const token = await mintToken({ userId: 42, scopes: [scope] });
+    const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
+      res.status(200).json({ ok: true });
+    });
+    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const res = makeRes();
+    await route(makeReq(`Bearer ${token}`, 'GET') as never, res as never);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('ACCEPTS an ANON token carrying the scope → handler runs (public within-app read)', async () => {
+    const token = await mintToken({ userId: null, scopes: [scope] });
+    const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
+      res.status(200).json({ ok: true });
+    });
+    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const res = makeRes();
+    await route(makeReq(`Bearer ${token}`, 'GET') as never, res as never);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('rejects a token MISSING the scope → 403', async () => {
+    const token = await mintToken({ userId: 42, scopes: [] });
+    const wrapped = vi.fn();
+    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const res = makeRes();
+    await route(makeReq(`Bearer ${token}`, 'GET') as never, res as never);
+    expect(res.statusCode).toBe(403);
+    expect(wrapped).not.toHaveBeenCalled();
+  });
+
+  it('rejects a REVOKED instance → 403', async () => {
+    isRevokedMock.mockResolvedValue(true);
+    const token = await mintToken({ userId: 42, scopes: [scope] });
+    const wrapped = vi.fn();
+    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const res = makeRes();
+    await route(makeReq(`Bearer ${token}`, 'GET') as never, res as never);
+    expect(res.statusCode).toBe(403);
     expect(wrapped).not.toHaveBeenCalled();
   });
 });

--- a/src/server/middleware/__tests__/collections-tip-authz.test.ts
+++ b/src/server/middleware/__tests__/collections-tip-authz.test.ts
@@ -106,6 +106,7 @@ beforeEach(() => {
 
 const SCOPES = [
   'collections:read:self',
+  'collections:read:private',
   'collections:write:self',
   'social:tip:self',
   // buzz:read:self (balance readout) + apps:storage:shared:write (play-count

--- a/src/server/middleware/__tests__/collections-tip-authz.test.ts
+++ b/src/server/middleware/__tests__/collections-tip-authz.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+// Setup-order import: installs the ~/env/server mock with the real test RSA
+// keypair BEFORE block-token.service / the middleware evaluate env at module load
+// (same posture as block-scope.anytoken-mode.test.ts).
+import '~/__tests__/setup';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * Per-scope AUTHZ contract for the App Blocks collections + tip endpoints, run
+ * through the REAL `withBlockScope` + a REAL minted token (mirrors
+ * block-scope.anytoken-mode.test.ts). Business logic lives in the per-endpoint
+ * handler tests; THIS locks the shared authz layer for each endpoint's
+ * requiredScope:
+ *   - a valid token CARRYING the scope (non-anon subject)  → handler runs (200)
+ *   - a valid token MISSING the scope                      → 403
+ *   - an ANON token (sub:'anon') carrying the scope        → 403 (self-scope
+ *       binding — the collections + tip scopes require a real subject)
+ *   - a REVOKED instance                                   → 403
+ *
+ * Covers `collections:read:self` (GET collections + detail), `collections:write:self`
+ * (follow), and `social:tip:self` (tip).
+ */
+
+const { isFliptMock } = vi.hoisted(() => ({
+  isFliptMock: vi.fn(async (flag: string) => flag === 'app-blocks-runtime-enabled'),
+}));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: isFliptMock }));
+
+const { isRevokedMock } = vi.hoisted(() => ({ isRevokedMock: vi.fn(async () => false) }));
+vi.mock('~/server/services/block-revocation.service', () => ({
+  BlockRevocation: { isRevoked: isRevokedMock },
+}));
+
+import { withBlockScope } from '../block-scope.middleware';
+import { BlockTokenService } from '~/server/services/block-token.service';
+
+async function mintToken(opts: { userId: number | null; scopes: string[] }): Promise<string> {
+  const r = await BlockTokenService.sign({
+    userId: opts.userId,
+    blockId: 'blk_test',
+    appId: 'app_test',
+    appBlockId: 'apb_test',
+    blockInstanceId: 'bki_test',
+    scopes: opts.scopes,
+    ctx: { entityType: 'none', slotId: 'app.page' },
+    maxBrowsingLevel: 3,
+    domain: 'green',
+  });
+  return r.token;
+}
+
+function makeRes() {
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    headers: {} as Record<string, unknown>,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    send() {
+      return this;
+    },
+    end() {
+      return this;
+    },
+    setHeader(k: string, v: unknown) {
+      this.headers[k.toLowerCase()] = v;
+      return this;
+    },
+    removeHeader() {
+      return this;
+    },
+    writeHead() {
+      return this;
+    },
+    getHeader(k: string) {
+      return this.headers[k.toLowerCase()];
+    },
+    on() {
+      return this;
+    },
+  };
+  return res as unknown as NextApiResponse & { statusCode: number; body: unknown };
+}
+
+function makeReq(authHeader?: string, method = 'POST'): NextApiRequest {
+  return {
+    method,
+    headers: authHeader ? { authorization: authHeader } : {},
+    query: {},
+    url: '/api/v1/blocks/collections',
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as NextApiRequest;
+}
+
+beforeEach(() => {
+  isFliptMock.mockClear();
+  isRevokedMock.mockClear();
+  isRevokedMock.mockResolvedValue(false);
+});
+
+const SCOPES = [
+  'collections:read:self',
+  'collections:write:self',
+  'social:tip:self',
+] as const;
+
+describe.each(SCOPES)('withBlockScope authz — %s', (scope) => {
+  it('accepts a valid token carrying the scope (non-anon subject) → handler runs', async () => {
+    const token = await mintToken({ userId: 42, scopes: [scope] });
+    const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
+      res.status(200).json({ ok: true });
+    });
+    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+
+    const res = makeRes();
+    await route(makeReq(`Bearer ${token}`) as never, res as never);
+
+    expect(wrapped).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('rejects a valid token MISSING the scope → 403', async () => {
+    const token = await mintToken({ userId: 42, scopes: [] });
+    const wrapped = vi.fn();
+    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+
+    const res = makeRes();
+    await route(makeReq(`Bearer ${token}`) as never, res as never);
+
+    expect(res.statusCode).toBe(403);
+    expect(wrapped).not.toHaveBeenCalled();
+  });
+
+  it('rejects an ANON token carrying the scope → 403 (self-scope requires a real subject)', async () => {
+    const token = await mintToken({ userId: null, scopes: [scope] });
+    const wrapped = vi.fn();
+    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+
+    const res = makeRes();
+    await route(makeReq(`Bearer ${token}`) as never, res as never);
+
+    expect(res.statusCode).toBe(403);
+    expect(wrapped).not.toHaveBeenCalled();
+  });
+
+  it('rejects a REVOKED instance → 403', async () => {
+    isRevokedMock.mockResolvedValue(true);
+    const token = await mintToken({ userId: 42, scopes: [scope] });
+    const wrapped = vi.fn();
+    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+
+    const res = makeRes();
+    await route(makeReq(`Bearer ${token}`) as never, res as never);
+
+    expect(res.statusCode).toBe(403);
+    expect(wrapped).not.toHaveBeenCalled();
+  });
+
+  it('rejects an INVALID token → 401', async () => {
+    const header = Buffer.from(
+      JSON.stringify({ alg: 'RS256', typ: 'JWT', kid: 'x' })
+    ).toString('base64url');
+    const payload = Buffer.from(JSON.stringify({ sub: 'user:1' })).toString('base64url');
+    const bogus = `${header}.${payload}.bad`;
+    const wrapped = vi.fn();
+    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+
+    const res = makeRes();
+    await route(makeReq(`Bearer ${bogus}`) as never, res as never);
+
+    expect(res.statusCode).toBe(401);
+    expect(wrapped).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -632,6 +632,21 @@ export function enforceContextBinding(
         }
         break;
       }
+      case 'collections:read:self':
+      case 'collections:write:self': {
+        // Both collections scopes are :self — there is no anonymous "self" whose
+        // own/private collections to read or whose account to follow-on-behalf-of.
+        // Require an authenticated subject here (mirrors the social:tip:self /
+        // apps:storage:* :self cases). The per-op authority lives in the block
+        // collections endpoints: reads enforce collection visibility/ownership
+        // (private → 404) + the maturity clamp; the follow write is self-bound to
+        // this subject. No request-shape binding is added here — presence of the
+        // scope + a non-anon subject is the middleware check.
+        if (claims.sub === 'anon') {
+          throw forbidden(`${scope} requires authenticated subject`);
+        }
+        break;
+      }
       default:
         // Fail closed (L-M6). Reaching here means a scope passed the
         // `isKnownBlockScope` gate above (it's in BLOCK_SCOPE_TO_OAUTH_BIT)

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -633,15 +633,17 @@ export function enforceContextBinding(
         break;
       }
       case 'collections:read:self':
+      case 'collections:read:private':
       case 'collections:write:self': {
-        // Both collections scopes are :self — there is no anonymous "self" whose
-        // own/private collections to read or whose account to follow-on-behalf-of.
-        // Require an authenticated subject here (mirrors the social:tip:self /
-        // apps:storage:* :self cases). The per-op authority lives in the block
-        // collections endpoints: reads enforce collection visibility/ownership
-        // (private → 404) + the maturity clamp; the follow write is self-bound to
-        // this subject. No request-shape binding is added here — presence of the
-        // scope + a non-anon subject is the middleware check.
+        // All three collections scopes are :self — there is no anonymous "self"
+        // whose own/private collections to read or whose account to
+        // follow-on-behalf-of. Require an authenticated subject here (mirrors the
+        // social:tip:self / apps:storage:* :self cases). The per-op authority lives
+        // in the block collections endpoints: reads enforce collection
+        // visibility/ownership (a private collection is 404 without ownership AND
+        // the read:private scope) + the maturity clamp; the follow write is
+        // self-bound to this subject. No request-shape binding is added here —
+        // presence of the scope + a non-anon subject is the middleware check.
         if (claims.sub === 'anon') {
           throw forbidden(`${scope} requires authenticated subject`);
         }

--- a/src/server/routers/__tests__/apps-shared.counters.test.ts
+++ b/src/server/routers/__tests__/apps-shared.counters.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for the App Blocks play-count counter surface added to
+ * apps-shared.router: `incrementSharedCounter` (WRITE, min-trust gated),
+ * `getTopSharedCounters` (READ), and `assertValidCounterKey`. Reuses the same
+ * mock harness shape as apps-shared.router.test.ts (pg pool, block-token verifier,
+ * flag, rate limiter, subject hydration) so every gate is pinned independently.
+ *
+ * The isolation guarantee (app A can't touch app B's counters) is asserted by
+ * deriving the per-app schema from `claims.blockId` via the REAL apps-slug helper
+ * and checking the emitted SQL targets exactly that schema.
+ */
+
+const {
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockDbRead,
+  mockIsSharedEnabled,
+  mockPool,
+  mockClient,
+  mockGetSessionUser,
+  mockCheckVoteRl,
+  mockIsRevoked,
+} = vi.hoisted(() => {
+  const mockClient = {
+    query: vi.fn(async () => ({ rows: [{ count: '3' }], rowCount: 1 })),
+    release: vi.fn(),
+  };
+  const mockPool = {
+    connect: vi.fn(async () => mockClient),
+    query: vi.fn(async () => ({ rows: [], rowCount: 0 })),
+  };
+  return {
+    mockVerifyBlockToken: vi.fn(),
+    mockParseSubjectUserId: vi.fn(),
+    mockDbRead: { appBlock: { findUnique: vi.fn() }, account: { count: vi.fn(async () => 1) } },
+    mockIsSharedEnabled: vi.fn(async () => true),
+    mockPool,
+    mockClient,
+    mockGetSessionUser: vi.fn(),
+    mockCheckVoteRl: vi.fn(async () => ({ allowed: true })),
+    mockIsRevoked: vi.fn(async () => false),
+  };
+});
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...args: unknown[]) => mockParseSubjectUserId(...args),
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksSharedStorageEnabled: mockIsSharedEnabled,
+}));
+vi.mock('~/server/auth/session-client', () => ({
+  sessionClient: { getSessionUserById: (...a: unknown[]) => mockGetSessionUser(...a) },
+}));
+vi.mock('~/server/db/appsDb', () => ({ requireAppsDb: () => mockPool }));
+vi.mock('~/server/utils/shared-storage-rate-limit', () => ({
+  checkSharedAppendRateLimit: vi.fn(async () => ({ allowed: true })),
+  checkSharedVoteRateLimit: (...a: unknown[]) => mockCheckVoteRl(...a),
+}));
+vi.mock('~/server/services/block-revocation.service', () => ({
+  BlockRevocation: { isRevoked: (...a: unknown[]) => mockIsRevoked(...a) },
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+// Cut the shared-content-safety → blocklist/prompt-audit → @civitai/db import
+// chain (mirrors apps-shared.router.test.ts): the counter ops never touch the
+// content-safety belt, and these mocks keep the module graph free of the
+// workspace-package deps.
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(async () => undefined),
+}));
+
+import {
+  assertValidCounterKey,
+  getTopSharedCounters,
+  incrementSharedCounter,
+} from '../apps-shared.router';
+import { appSchemaIdent, sanitizeAppSlug } from '~/server/utils/apps-slug';
+import { OnboardingSteps } from '~/server/common/enums';
+
+const WRITE = 'apps:storage:shared:write';
+const READ = 'apps:storage:shared:read';
+
+function schemaFor(blockId: string): string {
+  return appSchemaIdent(sanitizeAppSlug(blockId) as string);
+}
+
+function claims(blockId: string, scopes: string[]) {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'j',
+    blockId,
+    appId: 'app_test',
+    appBlockId: 'apb_test',
+    blockInstanceId: 'bki_inst',
+    ctx: {},
+    scopes,
+  };
+}
+
+function trustedUser(over: Record<string, unknown> = {}) {
+  return {
+    id: 42,
+    isModerator: false,
+    bannedAt: null,
+    muted: false,
+    onboarding: OnboardingSteps.Buzz,
+    emailVerified: new Date('2020-01-01'),
+    createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000),
+    ...over,
+  };
+}
+
+function allClientSql(): string {
+  return mockClient.query.mock.calls.map((c) => String(c[0])).join('\n');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbRead.appBlock.findUnique.mockResolvedValue({ id: 'apb_test', status: 'approved' });
+  mockParseSubjectUserId.mockImplementation((sub: string) =>
+    sub === 'anon' ? null : Number.parseInt(sub.slice('user:'.length), 10)
+  );
+  mockGetSessionUser.mockResolvedValue(trustedUser());
+  mockIsSharedEnabled.mockResolvedValue(true);
+  mockIsRevoked.mockResolvedValue(false);
+  mockCheckVoteRl.mockResolvedValue({ allowed: true });
+  mockClient.query.mockResolvedValue({ rows: [{ count: '3' }], rowCount: 1 });
+});
+
+describe('assertValidCounterKey', () => {
+  it('accepts a bounded key', () => {
+    expect(assertValidCounterKey('playcount:123')).toBe('playcount:123');
+  });
+  it('rejects empty / oversized / non-string keys', () => {
+    expect(() => assertValidCounterKey('')).toThrow();
+    expect(() => assertValidCounterKey('x'.repeat(65))).toThrow();
+    expect(() => assertValidCounterKey(123 as unknown)).toThrow();
+  });
+});
+
+describe('incrementSharedCounter', () => {
+  it('happy path: a trusted subject increments → returns the new count', async () => {
+    mockVerifyBlockToken.mockResolvedValue(claims('app-voting', [READ, WRITE]));
+    const result = await incrementSharedCounter('tok', 'playcount:7');
+    expect(result).toEqual({ key: 'playcount:7', count: 3 });
+    // Targets THIS app's schema (isolation) — the counters + anchor writes.
+    const sql = allClientSql();
+    expect(sql).toContain(`${schemaFor('app-voting')}.counters`);
+    expect(sql).toContain(`${schemaFor('app-voting')}.shared_kv`);
+  });
+
+  it('sub-trust caller (account too new) → FORBIDDEN (anti-inflation min-trust gate)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(claims('app-voting', [READ, WRITE]));
+    mockGetSessionUser.mockResolvedValue(
+      trustedUser({ createdAt: new Date() }) // < 7d old → fails the trust gate
+    );
+    await expect(incrementSharedCounter('tok', 'playcount:7')).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    // No counter write happened.
+    expect(mockClient.query).not.toHaveBeenCalled();
+  });
+
+  it('missing the write scope → FORBIDDEN', async () => {
+    mockVerifyBlockToken.mockResolvedValue(claims('app-voting', [READ]));
+    await expect(incrementSharedCounter('tok', 'playcount:7')).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+  });
+
+  it('rate-limited → TOO_MANY_REQUESTS', async () => {
+    mockVerifyBlockToken.mockResolvedValue(claims('app-voting', [READ, WRITE]));
+    mockCheckVoteRl.mockResolvedValue({ allowed: false, retryAfterSeconds: 5 });
+    await expect(incrementSharedCounter('tok', 'playcount:7')).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+  });
+
+  it('CROSS-APP ISOLATION: app A and app B write to DIFFERENT schemas', async () => {
+    mockVerifyBlockToken.mockResolvedValue(claims('app-a', [READ, WRITE]));
+    await incrementSharedCounter('tokA', 'playcount:1');
+    const sqlA = allClientSql();
+    expect(sqlA).toContain(`${schemaFor('app-a')}.counters`);
+    // App A's SQL must NEVER reference app B's schema.
+    expect(sqlA).not.toContain(`${schemaFor('app-b')}.counters`);
+
+    mockClient.query.mockClear();
+    mockVerifyBlockToken.mockResolvedValue(claims('app-b', [READ, WRITE]));
+    await incrementSharedCounter('tokB', 'playcount:1');
+    const sqlB = allClientSql();
+    expect(sqlB).toContain(`${schemaFor('app-b')}.counters`);
+    expect(sqlB).not.toContain(`${schemaFor('app-a')}.counters`);
+    // The two apps resolve to distinct schemas.
+    expect(schemaFor('app-a')).not.toBe(schemaFor('app-b'));
+  });
+});
+
+describe('getTopSharedCounters', () => {
+  it('returns top-N [{key,count}] and issues a count-DESC + prefix + limit query on THIS app schema', async () => {
+    mockVerifyBlockToken.mockResolvedValue(claims('app-voting', [READ]));
+    mockPool.query.mockResolvedValue({
+      rows: [
+        { key: 'playcount:9', count: '42' },
+        { key: 'playcount:3', count: '7' },
+      ],
+      rowCount: 2,
+    });
+    const items = await getTopSharedCounters('tok', 'playcount:', 10);
+    expect(items).toEqual([
+      { key: 'playcount:9', count: 42 },
+      { key: 'playcount:3', count: 7 },
+    ]);
+    const sql = String(mockPool.query.mock.calls[0][0]);
+    const params = mockPool.query.mock.calls[0][1] as unknown[];
+    expect(sql).toContain(`${schemaFor('app-voting')}.counters`);
+    expect(sql).toContain('ORDER BY c.count DESC');
+    expect(sql).toContain('LIKE $1');
+    expect(sql).toContain('LIMIT $2');
+    // Prefix is escaped + wildcarded; limit is passed through.
+    expect(params[0]).toBe('playcount:%');
+    expect(params[1]).toBe(10);
+  });
+
+  it('anon READ is allowed by the resolver (no subject required for top)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(claims('app-voting', [READ]));
+    mockParseSubjectUserId.mockReturnValue(null); // anon
+    mockGetSessionUser.mockResolvedValue(null);
+    mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
+    const items = await getTopSharedCounters('tok', '', 20);
+    expect(items).toEqual([]);
+  });
+});

--- a/src/server/routers/apps-shared.router.ts
+++ b/src/server/routers/apps-shared.router.ts
@@ -66,8 +66,20 @@ const MIN_ACCOUNT_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 // materializes. `free`/absent tier fails when on.
 const REQUIRE_PAID_TIER = false;
 
-type SharedOp = 'list' | 'getCount' | 'append' | 'vote' | 'unvote' | 'withdraw' | 'report';
-const READ_OPS: ReadonlySet<SharedOp> = new Set<SharedOp>(['list', 'getCount']);
+type SharedOp =
+  | 'list'
+  | 'getCount'
+  | 'append'
+  | 'vote'
+  | 'unvote'
+  | 'withdraw'
+  | 'report'
+  // App Blocks play-counts (block REST endpoints /api/v1/blocks/shared-storage/*):
+  //   - 'increment' is a WRITE (min-trust gated like append/vote — anti-inflation)
+  //   - 'getTop' is a READ (anon-allowed like list/getCount)
+  | 'increment'
+  | 'getTop';
+const READ_OPS: ReadonlySet<SharedOp> = new Set<SharedOp>(['list', 'getCount', 'getTop']);
 
 const SHARED_READ_SCOPE = 'apps:storage:shared:read';
 const SHARED_WRITE_SCOPE = 'apps:storage:shared:write';
@@ -138,7 +150,7 @@ interface SharedContext {
  *   4. for WRITE ops: authenticated subject + the min-trust gate
  * Anon may READ list/counts; anon NEVER writes/votes.
  */
-async function resolveSharedContext(blockToken: string, op: SharedOp): Promise<SharedContext> {
+export async function resolveSharedContext(blockToken: string, op: SharedOp): Promise<SharedContext> {
   const claims = await verifyBlockToken(blockToken);
   if (!claims) throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid block token' });
 
@@ -698,6 +710,120 @@ export const appsSharedRouter = router({
       return { ok: true as const };
     }),
 });
+
+// ── App Blocks play-counts (block REST endpoints) ─────────────────────────────
+// A monotonic per-key counter surface over the SAME `counters` table the
+// vote-tally uses, for app-defined counters (e.g. `playcount:<collectionId>`).
+// Reuses resolveSharedContext so ALL the shared-storage security holds verbatim:
+// per-app schema isolation (sanitizeAppSlug), approved-block + revocation checks,
+// the per-op scope assertion, the fail-closed Flipt kill-switch, and — for the
+// WRITE (increment) — the min-trust gate + write-scope. This is the anti-inflation
+// posture the coordinator required: a sub-trust caller is DENIED (the app treats
+// increment as best-effort/fire-and-forget), so a fresh/sybil account can't pump
+// a count.
+
+// Per-app counter keys are bounded to the shared key shape (≤64 chars) — same
+// bound as the vote `key` input.
+const COUNTER_KEY_MAX = 64;
+
+/**
+ * Increment (by 1) the counter for `key` in THIS app's shared schema. The
+ * `counters.key` column FK-references `shared_kv.key`, so we first upsert a tiny
+ * ANCHOR `shared_kv` row for the key (value `{}`) inside the same txn (under the
+ * quota GUC), then upsert the counter. Rate-limited on the SAME per-(user, app)
+ * vote bucket as the shared vote path. Returns the new count.
+ *
+ * NOTE (best-effort/anti-abuse): the per-user shared_kv row cap that `append`
+ * enforces is intentionally NOT applied here — counter keys are app-global
+ * (one anchor row per key across ALL users), created at most once per key. The
+ * write-scope + min-trust gate + rate limit + the app byte/row quota trigger are
+ * the bounds. Counter anchor rows carry a distinct app-chosen key prefix (e.g.
+ * `playcount:`), so an app that also runs a request feed keeps them separable.
+ */
+export async function incrementSharedCounter(
+  blockToken: string,
+  key: string
+): Promise<{ key: string; count: number }> {
+  const { userId, schema, appBlockId } = await resolveSharedContext(blockToken, 'increment');
+  const uid = userId as number; // non-null (write path ran the trust gate)
+
+  const rl = await checkSharedVoteRateLimit(uid, appBlockId);
+  if (!rl.allowed) {
+    throw new TRPCError({
+      code: 'TOO_MANY_REQUESTS',
+      message: `Too many increments — retry in ${rl.retryAfterSeconds}s`,
+    });
+  }
+
+  const pool = requireAppsDb();
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    // GUC drives the shared_kv quota trigger (byte/row accounting on the anchor).
+    await client.query(`SET LOCAL app.current_app_block_id = ${pgQuoteLiteral(appBlockId)}`);
+    // Anchor row so the counters FK holds. INSERT-or-ignore: created once per key.
+    await client.query(
+      `INSERT INTO ${schema}.shared_kv (key, author_user_id, value)
+       VALUES ($1, $2, '{}'::jsonb)
+       ON CONFLICT (key) DO NOTHING`,
+      [key, uid]
+    );
+    const rows = (
+      await client.query<{ count: string }>(
+        `INSERT INTO ${schema}.counters AS c (key, count)
+         VALUES ($1, 1)
+         ON CONFLICT (key) DO UPDATE SET count = c.count + 1
+         RETURNING c.count::text AS count`,
+        [key]
+      )
+    ).rows;
+    await client.query('COMMIT');
+    return { key, count: Number(rows[0]?.count ?? '0') };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Top-N counters (by count DESC) whose key matches `prefix` in THIS app's shared
+ * schema. READ op (anon-allowed by the resolver; the block REST endpoint gates on
+ * the shared:read scope). Hidden anchor rows are excluded. `limit` is bounded by
+ * the caller. Returns `[{ key, count }]`.
+ */
+export async function getTopSharedCounters(
+  blockToken: string,
+  prefix: string,
+  limit: number
+): Promise<Array<{ key: string; count: number }>> {
+  const { schema } = await resolveSharedContext(blockToken, 'getTop');
+  const pool = requireAppsDb();
+  // Escape LIKE metacharacters in the app-supplied prefix (same escape as list).
+  const escapedPrefix = (prefix ?? '').replace(/([\\%_])/g, '\\$1');
+  const rows = (
+    await pool.query<{ key: string; count: string }>(
+      `SELECT c.key, c.count::text AS count
+         FROM ${schema}.counters c
+         JOIN ${schema}.shared_kv s ON s.key = c.key
+        WHERE s.hidden_at IS NULL
+          AND c.key LIKE $1 ESCAPE '\\'
+        ORDER BY c.count DESC, c.key ASC
+        LIMIT $2`,
+      [`${escapedPrefix}%`, limit]
+    )
+  ).rows;
+  return rows.map((r) => ({ key: r.key, count: Number(r.count) }));
+}
+
+/** Shared key-shape validator for the block counter endpoints (≤64 chars). */
+export function assertValidCounterKey(key: unknown): string {
+  if (typeof key !== 'string' || key.length < 1 || key.length > COUNTER_KEY_MAX) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'invalid counter key' });
+  }
+  return key;
+}
 
 /**
  * Cross-app moderator surface (design M4). SESSION-authed (moderatorProcedure) —

--- a/src/server/schema/collection.schema.ts
+++ b/src/server/schema/collection.schema.ts
@@ -233,6 +233,11 @@ export type GetAllCollectionsInfiniteSchema = z.infer<typeof getAllCollectionsIn
 export const getAllCollectionsInfiniteSchema = infiniteQuerySchema
   .extend({
     userId: z.number(),
+    // Optional case-insensitive name search (additive — omitted by every existing
+    // caller, so behaviour is byte-identical when absent). Threaded into
+    // getAllCollections' where clause. Added for the App Blocks collections
+    // discovery surface (search box).
+    query: z.string().trim().max(100),
     types: z.array(z.enum(CollectionType)),
     privacy: z.array(z.enum(CollectionReadConfiguration)),
     sort: z.enum(CollectionSort).default(constants.collectionFilterDefaults.sort),

--- a/src/server/services/blocks/__tests__/collections-scope-plumbing.test.ts
+++ b/src/server/services/blocks/__tests__/collections-scope-plumbing.test.ts
@@ -35,6 +35,7 @@ import {
 describe('collections scopes — registry + #3090 plumbing', () => {
   const READ = 'collections:read:self';
   const WRITE = 'collections:write:self';
+  const PRIVATE = 'collections:read:private';
 
   it('are known, no-OAuth-bit (SKIP_OAUTH_CHECK) registry scopes', () => {
     expect(isKnownBlockScope(READ)).toBe(true);
@@ -51,13 +52,33 @@ describe('collections scopes — registry + #3090 plumbing', () => {
     expect(missing).toEqual([]);
   });
 
-  it('consentGatedScopes excludes the collections scopes (they are exempt)', () => {
-    // A consent-gated scope (buzz:read:self) is retained; the exempt collections
-    // scopes are dropped from the "requires a grant" set.
-    const gated = consentGatedScopes([READ, WRITE, 'buzz:read:self']);
+  it('consentGatedScopes excludes the exempt collections scopes but KEEPS read:private', () => {
+    // read:self + write:self are exempt (dropped); buzz:read:self + the
+    // consent-GATED read:private are retained in the "requires a grant" set.
+    const gated = consentGatedScopes([READ, WRITE, PRIVATE, 'buzz:read:self']);
     expect(gated).toContain('buzz:read:self');
+    expect(gated).toContain(PRIVATE);
     expect(gated).not.toContain(READ);
     expect(gated).not.toContain(WRITE);
+  });
+
+  it('read:private is a known SKIP_OAUTH_CHECK scope but is CONSENT-GATED (not exempt)', () => {
+    expect(isKnownBlockScope(PRIVATE)).toBe(true);
+    expect(BLOCK_SCOPE_TO_OAUTH_BIT[PRIVATE]).toBe(SKIP_OAUTH_CHECK);
+    // With NO grant, read:private is WITHHELD (unlike the exempt read:self/write:self).
+    const { signable, missing } = partitionByConsent([READ, PRIVATE], new Set<string>());
+    expect(signable).toContain(READ); // exempt → always signable
+    expect(signable).not.toContain(PRIVATE); // gated → withheld without a grant
+    expect(missing).toEqual([PRIVATE]);
+  });
+
+  it('read:private mints ONCE the user has granted it', () => {
+    const { signable, missing } = partitionByConsent(
+      [READ, PRIVATE],
+      new Set<string>([PRIVATE])
+    );
+    expect(signable).toEqual(expect.arrayContaining([READ, PRIVATE]));
+    expect(missing).toEqual([]);
   });
 
   it('are included in BOTH dev-mint allowlists (dev:live + dev-tunnel can exercise them)', () => {

--- a/src/server/services/blocks/__tests__/collections-scope-plumbing.test.ts
+++ b/src/server/services/blocks/__tests__/collections-scope-plumbing.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// scope-grant.service imports the Prisma client at module load; mock it so the
+// (pure) partitionByConsent / consentGatedScopes helpers run without a real
+// Prisma engine (mirrors scope-grant.service.test.ts).
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
+import {
+  BLOCK_SCOPE_TO_OAUTH_BIT,
+  isKnownBlockScope,
+  SKIP_OAUTH_CHECK,
+} from '~/shared/constants/block-scope.constants';
+import {
+  consentGatedScopes,
+  partitionByConsent,
+} from '~/server/services/blocks/scope-grant.service';
+import {
+  DEV_TOKEN_SCOPE_ALLOWLIST,
+  TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+} from '~/server/services/blocks/dev-scoped-mint.service';
+
+/**
+ * The #3090 scope-plumbing guard for `collections:read:self` /
+ * `collections:write:self`.
+ *
+ * #3090: a page-app token that declared a CONSENT-GATED scope silently dropped it
+ * at mint (the viewer had no grant row) → every op that needed the scope 403'd.
+ * The fix is to make the collections scopes CONSENT-EXEMPT, so the mint's
+ * `partitionByConsent` puts them in `signable` UNCONDITIONALLY (no grant needed)
+ * and the minted token therefore actually CARRIES them end-to-end.
+ *
+ * This test locks the deterministic mint-time seam (partitionByConsent /
+ * consentGatedScopes) rather than the whole HTTP mint path.
+ */
+describe('collections scopes — registry + #3090 plumbing', () => {
+  const READ = 'collections:read:self';
+  const WRITE = 'collections:write:self';
+
+  it('are known, no-OAuth-bit (SKIP_OAUTH_CHECK) registry scopes', () => {
+    expect(isKnownBlockScope(READ)).toBe(true);
+    expect(isKnownBlockScope(WRITE)).toBe(true);
+    expect(BLOCK_SCOPE_TO_OAUTH_BIT[READ]).toBe(SKIP_OAUTH_CHECK);
+    expect(BLOCK_SCOPE_TO_OAUTH_BIT[WRITE]).toBe(SKIP_OAUTH_CHECK);
+  });
+
+  it('#3090: a token minted with the collections scopes CARRIES them even with NO user grant', () => {
+    // Empty grant set = the viewer has consented to nothing. Consent-gated scopes
+    // would be WITHHELD (the #3090 failure); consent-exempt scopes must survive.
+    const { signable, missing } = partitionByConsent([READ, WRITE], new Set<string>());
+    expect(signable).toEqual(expect.arrayContaining([READ, WRITE]));
+    expect(missing).toEqual([]);
+  });
+
+  it('consentGatedScopes excludes the collections scopes (they are exempt)', () => {
+    // A consent-gated scope (buzz:read:self) is retained; the exempt collections
+    // scopes are dropped from the "requires a grant" set.
+    const gated = consentGatedScopes([READ, WRITE, 'buzz:read:self']);
+    expect(gated).toContain('buzz:read:self');
+    expect(gated).not.toContain(READ);
+    expect(gated).not.toContain(WRITE);
+  });
+
+  it('are included in BOTH dev-mint allowlists (dev:live + dev-tunnel can exercise them)', () => {
+    expect(DEV_TOKEN_SCOPE_ALLOWLIST.has(READ)).toBe(true);
+    expect(DEV_TOKEN_SCOPE_ALLOWLIST.has(WRITE)).toBe(true);
+    expect(TUNNEL_HOST_MINT_SCOPE_ALLOWLIST.has(READ)).toBe(true);
+    expect(TUNNEL_HOST_MINT_SCOPE_ALLOWLIST.has(WRITE)).toBe(true);
+    // social:tip:self stays OUT of the dev allowlists (real money).
+    expect(DEV_TOKEN_SCOPE_ALLOWLIST.has('social:tip:self')).toBe(false);
+    expect(TUNNEL_HOST_MINT_SCOPE_ALLOWLIST.has('social:tip:self')).toBe(false);
+  });
+});

--- a/src/server/services/blocks/block-collections.service.ts
+++ b/src/server/services/blocks/block-collections.service.ts
@@ -1,0 +1,114 @@
+/**
+ * Shared helpers for the App Blocks COLLECTIONS surface
+ * (`/api/v1/blocks/collections*`). Keeps the three REST endpoints
+ * (discovery, detail, follow) DRY without re-implementing any collection
+ * business logic — every real read/write goes through the existing
+ * `collection.service` functions; this module only:
+ *   - hydrates the block-token SUBJECT into a full SessionUser (the authority
+ *     for ownership/visibility + the viewer identity the collection services
+ *     accept), mirroring apps-shared.router / blocks.router;
+ *   - resolves which of a set of collections the subject already FOLLOWS
+ *     (a plain CollectionContributor membership read — the on-site "follow" is
+ *     a contributor row, added by `addContributorToCollection`);
+ *   - maps a collection cover Image + a collection Image item to the block
+ *     wire contracts (edge-url composed, maturity already clamped upstream).
+ *
+ * NOTE the maturity clamp itself is NOT applied here — the caller resolves the
+ * token ceiling via `resolveCatalogBrowsingLevel(claims)` and passes the clamped
+ * `browsingLevel` into the collection item service, so items are filtered at the
+ * source (identical authority surface to /api/v1/blocks/images). Discovery
+ * additionally drops collections whose own `nsfwLevel` exceeds the ceiling.
+ */
+
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { dbRead } from '~/server/db/client';
+import { sessionClient } from '~/server/auth/session-client';
+import type { SessionUser } from '~/types/session';
+import { Flags } from '~/shared/utils/flags';
+
+/**
+ * Resolve the FULL server-side SessionUser for a verified block-token subject
+ * userId. Fail-closed: a vanished subject resolves to null and the caller
+ * refuses. Same resolver the shared-storage + blocks routers use.
+ */
+export async function hydrateBlockSubject(userId: number): Promise<SessionUser | null> {
+  return (await sessionClient.getSessionUserById(userId)) as SessionUser | null;
+}
+
+/**
+ * Which of `collectionIds` the `userId` currently follows on-site. The on-site
+ * follow is a `CollectionContributor` row (see `addContributorToCollection`), so
+ * membership in that table IS the "followed" signal. Returns an empty set for an
+ * empty id list. Never throws — a lookup failure surfaces as "not followed"
+ * rather than failing the read.
+ */
+export async function getFollowedCollectionIds(
+  userId: number,
+  collectionIds: number[]
+): Promise<Set<number>> {
+  if (collectionIds.length === 0) return new Set();
+  const rows = await dbRead.collectionContributor.findMany({
+    where: { userId, collectionId: { in: collectionIds } },
+    select: { collectionId: true },
+  });
+  return new Set(rows.map((r) => r.collectionId));
+}
+
+/**
+ * Compose a directly-usable CDN url for a collection cover / media Image from its
+ * stored key + media type. Returns null when there is no image key. Mirrors the
+ * `getEdgeUrl(image.url, { original: true, type })` shape the public
+ * /api/v1/images formatter uses so blocks get a ready-to-render url.
+ */
+export function toMediaUrl(
+  image: { url?: string | null; type?: string | null } | null | undefined
+): string | null {
+  if (!image?.url) return null;
+  return getEdgeUrl(image.url, {
+    original: true,
+    type: (image.type as 'image' | 'video' | undefined) ?? 'image',
+  });
+}
+
+/** True iff the collection's own nsfwLevel is permitted by the clamped ceiling. */
+export function collectionWithinCeiling(nsfwLevel: number, browsingLevel: number): boolean {
+  // A level of 0 (unrated) is always allowed; otherwise it must intersect the
+  // clamped browsing level (identical bitwise test the feed uses).
+  if (!nsfwLevel) return true;
+  return Flags.intersects(nsfwLevel, browsingLevel);
+}
+
+export type BlockCollectionMediaItem = {
+  mediaId: number;
+  type: 'image' | 'video';
+  url: string | null;
+  width: number | null;
+  height: number | null;
+  creator: { userId: number; username: string | null } | null;
+  nsfwLevel: number;
+};
+
+/**
+ * Map an IMAGE-type expanded collection item (`getCollectionItemsByCollectionId`
+ * → `{ type: 'image', data: ImagesInfiniteModel }`) to the block media contract.
+ */
+export function mapImageItemToMedia(data: {
+  id: number;
+  url?: string | null;
+  type?: string | null;
+  width?: number | null;
+  height?: number | null;
+  nsfwLevel?: number | null;
+  user?: { id: number; username?: string | null } | null;
+}): BlockCollectionMediaItem {
+  const mediaType: 'image' | 'video' = data.type === 'video' ? 'video' : 'image';
+  return {
+    mediaId: data.id,
+    type: mediaType,
+    url: toMediaUrl({ url: data.url, type: mediaType }),
+    width: data.width ?? null,
+    height: data.height ?? null,
+    creator: data.user ? { userId: data.user.id, username: data.user.username ?? null } : null,
+    nsfwLevel: data.nsfwLevel ?? 0,
+  };
+}

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -66,6 +66,20 @@ export const DEV_TOKEN_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
   'ai:write:budgeted',
   'apps:storage:read',
   'apps:storage:write',
+  // collections:* — INCLUDED in the dev allowlists (both this bearer path and the
+  // tunnel path below). Unlike apps:storage:shared:* (deliberately withheld pre-
+  // approval because a pre-approval app's storage NAMESPACE is synthetic and could
+  // collide across the approve boundary), the collections surface has NO per-app
+  // namespace: read operates on the dev's OWN collections + PUBLIC collections and
+  // is gated server-side by visibility/ownership + the maturity clamp; follow is
+  // self-bound to the dev's account. There is no cross-approve-boundary state to
+  // protect, so a developer iterating on a collections app in dev:live / dev-tunnel
+  // can safely exercise discover/read/follow. `social:tip:self` stays EXCLUDED
+  // (real money OUT — unchanged), so a collections app's TIP button is not
+  // exercisable via a dev token (matches the existing "no real money in dev"
+  // posture).
+  'collections:read:self',
+  'collections:write:self',
 ]);
 
 /**
@@ -83,6 +97,12 @@ export const TUNNEL_HOST_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<str
   'media:read:owned',
   'user:read:self',
   'ai:write:budgeted',
+  // collections:* — INCLUDED here too (see DEV_TOKEN_SCOPE_ALLOWLIST rationale):
+  // no per-app namespace, gated server-side by visibility/ownership/subject, so
+  // there is no pre-approval collision to protect against (contrast
+  // apps:storage:*, which this tunnel allowlist withholds until approval).
+  'collections:read:self',
+  'collections:write:self',
 ]);
 
 /**

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -77,9 +77,13 @@ export const DEV_TOKEN_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
   // can safely exercise discover/read/follow. `social:tip:self` stays EXCLUDED
   // (real money OUT — unchanged), so a collections app's TIP button is not
   // exercisable via a dev token (matches the existing "no real money in dev"
-  // posture).
+  // posture). `collections:read:private` (own private collections) is included:
+  // in prod it's consent-gated, but the dev-token path is self-bound to the dev's
+  // OWN account (no third-party data), so a dev iterating locally can read their
+  // own private collections without a consent round-trip.
   'collections:read:self',
   'collections:write:self',
+  'collections:read:private',
 ]);
 
 /**
@@ -103,6 +107,7 @@ export const TUNNEL_HOST_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<str
   // apps:storage:*, which this tunnel allowlist withholds until approval).
   'collections:read:self',
   'collections:write:self',
+  'collections:read:private',
 ]);
 
 /**

--- a/src/server/services/blocks/scope-descriptions.constants.ts
+++ b/src/server/services/blocks/scope-descriptions.constants.ts
@@ -30,6 +30,8 @@ export const SCOPE_DESCRIPTIONS: Record<string, string> = {
   'apps:storage:write': "Write to this app's private per-install data store",
   'apps:storage:shared:read': "Read this app's shared, community-wide data (e.g. everyone's posts + vote counts)",
   'apps:storage:shared:write': "Post + vote in this app's shared, community-wide data — visible to all users of the app",
+  'collections:read:self': 'Browse and read Civitai collections (your private collections, and any public collection)',
+  'collections:write:self': 'Bookmark (follow) collections on your behalf',
 };
 
 export const SLOT_DESCRIPTIONS: Record<string, string> = {

--- a/src/server/services/blocks/scope-descriptions.constants.ts
+++ b/src/server/services/blocks/scope-descriptions.constants.ts
@@ -30,8 +30,9 @@ export const SCOPE_DESCRIPTIONS: Record<string, string> = {
   'apps:storage:write': "Write to this app's private per-install data store",
   'apps:storage:shared:read': "Read this app's shared, community-wide data (e.g. everyone's posts + vote counts)",
   'apps:storage:shared:write': "Post + vote in this app's shared, community-wide data — visible to all users of the app",
-  'collections:read:self': 'Browse and read Civitai collections (your private collections, and any public collection)',
+  'collections:read:self': 'Browse and read public Civitai collections, and your own public collections',
   'collections:write:self': 'Bookmark (follow) collections on your behalf',
+  'collections:read:private': 'Read your private collections',
 };
 
 export const SLOT_DESCRIPTIONS: Record<string, string> = {

--- a/src/server/services/blocks/scope-grant.service.ts
+++ b/src/server/services/blocks/scope-grant.service.ts
@@ -145,6 +145,20 @@ export async function recordScopeGrant(opts: {
  * is reserved for the money / AI scopes (`ai:write:budgeted`, `buzz:read:self`),
  * which the host requests lazily on the first buzz-spending action (Generate)
  * rather than on load.
+ *
+ * `collections:read:self` / `collections:write:self` are ALSO exempt — the gate
+ * is SERVER-SIDE per op, not a per-scope consent prompt: reads enforce collection
+ * VISIBILITY/OWNERSHIP (a private collection is 404 to a non-owner/contributor)
+ * and clamp items to the token's maturity ceiling; the follow write is SELF-BOUND
+ * to the token subject (the block follows on the caller's OWN behalf). A per-scope
+ * consent prompt would add nothing the visibility/ownership/subject checks don't
+ * already enforce. Exempting them is ALSO the #3090 fix: a page-app token that
+ * declared a consent-gated scope silently dropped it at mint (the user had no
+ * grant row) → every collections op 403'd; consent-exempt scopes flow through the
+ * mint's partitionByConsent unconditionally, so the minted PAGE token actually
+ * carries them end-to-end. (The follow write, being a bookmark on a viewer's own
+ * account, is a candidate for an EXPLICIT consent prompt pre-GA if the audience
+ * widens past the mod-only posture — NOT built here.)
  */
 const CONSENT_EXEMPT_SCOPES = new Set([
   'block:settings:read',
@@ -156,6 +170,11 @@ const CONSENT_EXEMPT_SCOPES = new Set([
   'apps:storage:shared:read',
   'apps:storage:shared:write',
   'models:read:self',
+  // Collections — server-side visibility/ownership (read) + self-bound subject
+  // (follow) are the gate; see the block collections endpoints. #3090: exempting
+  // them guarantees they reach `claims.scopes` in the minted page token.
+  'collections:read:self',
+  'collections:write:self',
 ]);
 
 export function partitionByConsent(

--- a/src/server/services/blocks/scope-grant.service.ts
+++ b/src/server/services/blocks/scope-grant.service.ts
@@ -146,19 +146,24 @@ export async function recordScopeGrant(opts: {
  * which the host requests lazily on the first buzz-spending action (Generate)
  * rather than on load.
  *
- * `collections:read:self` / `collections:write:self` are ALSO exempt — the gate
- * is SERVER-SIDE per op, not a per-scope consent prompt: reads enforce collection
- * VISIBILITY/OWNERSHIP (a private collection is 404 to a non-owner/contributor)
- * and clamp items to the token's maturity ceiling; the follow write is SELF-BOUND
- * to the token subject (the block follows on the caller's OWN behalf). A per-scope
- * consent prompt would add nothing the visibility/ownership/subject checks don't
- * already enforce. Exempting them is ALSO the #3090 fix: a page-app token that
- * declared a consent-gated scope silently dropped it at mint (the user had no
- * grant row) → every collections op 403'd; consent-exempt scopes flow through the
- * mint's partitionByConsent unconditionally, so the minted PAGE token actually
- * carries them end-to-end. (The follow write, being a bookmark on a viewer's own
- * account, is a candidate for an EXPLICIT consent prompt pre-GA if the audience
- * widens past the mod-only posture — NOT built here.)
+ * `collections:read:self` / `collections:write:self` are exempt — but
+ * `collections:read:private` is DELIBERATELY NOT (the read split, below). The
+ * exempt pair's gate is SERVER-SIDE per op, not a per-scope consent prompt:
+ * read:self covers own-PUBLIC + any PUBLIC collection (public data — nothing
+ * sensitive to consent to), and the follow write is SELF-BOUND to the token
+ * subject (a bookmark on the caller's OWN account). A per-scope consent prompt
+ * would add nothing the visibility/ownership/subject checks don't already
+ * enforce. Exempting them is ALSO the #3090 fix: a page-app token that declared a
+ * consent-gated scope silently dropped it at mint (the user had no grant row) →
+ * every op 403'd; consent-exempt scopes flow through partitionByConsent
+ * unconditionally, so the minted PAGE token actually carries them end-to-end.
+ *
+ * `collections:read:private` (the subject's OWN PRIVATE collections) is the
+ * CONSENT-GATED half of the read split and is INTENTIONALLY absent from this set:
+ * reading a user's private collections IS sensitive, so it must flow through the
+ * gated branch — the host surfaces it as `needs_consent`, the user grants it, and
+ * only then does a token carry it. (This is the deliberate contrast to the #3090
+ * exemption above: read:self always mints; read:private mints only after consent.)
  */
 const CONSENT_EXEMPT_SCOPES = new Set([
   'block:settings:read',

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -134,7 +134,7 @@ export async function updateCollectionRandomSeed(): Promise<number> {
 }
 
 export const getAllCollections = async <TSelect extends Prisma.CollectionSelect>({
-  input: { limit, cursor, privacy, types, userId, sort, ids, modes },
+  input: { limit, cursor, privacy, types, userId, sort, ids, modes, query },
   user,
   select,
 }: {
@@ -148,6 +148,10 @@ export const getAllCollections = async <TSelect extends Prisma.CollectionSelect>
   if (sort === CollectionSort.MostContributors)
     orderBy.unshift({ contributors: { _count: 'desc' } });
 
+  // Optional case-insensitive name search (additive — `query` is omitted by every
+  // pre-existing caller, so `undefined` leaves the where clause byte-identical).
+  const trimmedQuery = query?.trim();
+
   const collections = await dbRead.collection.findMany({
     take: limit,
     cursor: cursor ? { id: cursor } : undefined,
@@ -157,6 +161,7 @@ export const getAllCollections = async <TSelect extends Prisma.CollectionSelect>
       type: types && types.length > 0 ? { in: types } : undefined,
       userId,
       mode: modes && modes.length > 0 && user?.isModerator ? { in: modes } : undefined,
+      name: trimmedQuery ? { contains: trimmedQuery, mode: 'insensitive' } : undefined,
     },
     select,
     orderBy,

--- a/src/server/utils/__tests__/block-tip-rate-limit.test.ts
+++ b/src/server/utils/__tests__/block-tip-rate-limit.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Direct unit coverage for the tip cap/limit REDIS PRIMITIVES
+ * (`reserveBlockTipSpend` / `refundBlockTipSpend` / `checkBlockTipRateLimit`),
+ * exercised against an in-memory redis mock so the concurrency/TTL/refund/
+ * fail-closed logic is tested for real (the endpoint tests mock these away).
+ */
+
+const { sysStore, sysTtls, mockSys, cacheStore, cacheTtls, mockCache } = vi.hoisted(() => {
+  const sysStore = new Map<string, number>();
+  const sysTtls = new Map<string, number>();
+  const cacheStore = new Map<string, number>();
+  const cacheTtls = new Map<string, number>();
+  const mockSys = {
+    incrBy: vi.fn(async (k: string, n: number) => {
+      const v = (sysStore.get(k) ?? 0) + n;
+      sysStore.set(k, v);
+      return v;
+    }),
+    decrBy: vi.fn(async (k: string, n: number) => {
+      const v = (sysStore.get(k) ?? 0) - n;
+      sysStore.set(k, v);
+      return v;
+    }),
+    expire: vi.fn(async (k: string, s: number) => {
+      sysTtls.set(k, s);
+      return true;
+    }),
+    ttl: vi.fn(async (k: string) => sysTtls.get(k) ?? -1),
+  };
+  const mockCache = {
+    incrBy: vi.fn(async (k: string, n: number) => {
+      const v = (cacheStore.get(k) ?? 0) + n;
+      cacheStore.set(k, v);
+      return v;
+    }),
+    expire: vi.fn(async (k: string, s: number) => {
+      cacheTtls.set(k, s);
+      return true;
+    }),
+    ttl: vi.fn(async (k: string) => cacheTtls.get(k) ?? -1),
+  };
+  return { sysStore, sysTtls, mockSys, cacheStore, cacheTtls, mockCache };
+});
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: mockSys,
+  redis: mockCache,
+  REDIS_SYS_KEYS: { BLOCKS: { TIP_CAP: 'system:blocks:tip-cap' } },
+  REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'rl' } },
+}));
+
+import {
+  BLOCK_TIP_RATE_LIMIT_MAX,
+  checkBlockTipRateLimit,
+  refundBlockTipSpend,
+  reserveBlockTipSpend,
+} from '../block-tip-rate-limit';
+
+const TODAY = new Date().toISOString().slice(0, 10);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sysStore.clear();
+  sysTtls.clear();
+  cacheStore.clear();
+  cacheTtls.clear();
+});
+
+describe('reserveBlockTipSpend', () => {
+  it('reserves the amount, returns a UTC-day-scoped key, and SETS the TTL on the first write', async () => {
+    const { total, key } = await reserveBlockTipSpend(42, 100);
+    expect(total).toBe(100);
+    expect(key).toBe(`system:blocks:tip-cap:42:${TODAY}`);
+    // TTL armed on first write (~25h).
+    expect(mockSys.expire).toHaveBeenCalledWith(key, 25 * 60 * 60);
+    expect(sysStore.get(key)).toBe(100);
+  });
+
+  it('accumulates concurrent reservations and does NOT re-arm the TTL when one is set', async () => {
+    const first = await reserveBlockTipSpend(42, 100);
+    mockSys.expire.mockClear();
+    const second = await reserveBlockTipSpend(42, 150);
+    expect(second.total).toBe(250); // 100 + 150 — atomic INCRBY accumulation
+    expect(second.key).toBe(first.key);
+    // TTL already set (>=0) → no re-arm on the subsequent write.
+    expect(mockSys.expire).not.toHaveBeenCalled();
+  });
+
+  it('re-arms a LOST TTL (ttl < 0) on a subsequent write (self-heal)', async () => {
+    const { key } = await reserveBlockTipSpend(42, 100);
+    sysTtls.delete(key); // simulate a TTL-less key (crash / manual SET)
+    mockSys.expire.mockClear();
+    await reserveBlockTipSpend(42, 50);
+    expect(mockSys.expire).toHaveBeenCalledWith(key, 25 * 60 * 60);
+  });
+
+  it('FAILS-CLOSED (throws) on a redis error — the caller turns this into a 503', async () => {
+    mockSys.incrBy.mockRejectedValueOnce(new Error('redis down'));
+    await expect(reserveBlockTipSpend(42, 100)).rejects.toThrow();
+  });
+});
+
+describe('refundBlockTipSpend', () => {
+  it('decrements the EXACT captured key by the exact amount', async () => {
+    const { key } = await reserveBlockTipSpend(42, 300);
+    await refundBlockTipSpend(key, 300);
+    expect(mockSys.decrBy).toHaveBeenCalledWith(key, 300);
+    expect(sysStore.get(key)).toBe(0);
+  });
+
+  it('MIDNIGHT STRADDLE: refunds the day it RESERVED, not the current-day key', async () => {
+    // A request that reserved yesterday must refund yesterday's key even if "now"
+    // is a new UTC day. The primitive takes the CAPTURED key, so re-derivation can
+    // never point it at the wrong day.
+    const yesterdayKey = 'system:blocks:tip-cap:42:2020-01-01';
+    sysStore.set(yesterdayKey, 500);
+    await refundBlockTipSpend(yesterdayKey as never, 500);
+    expect(mockSys.decrBy).toHaveBeenCalledWith(yesterdayKey, 500);
+    expect(sysStore.get(yesterdayKey)).toBe(0);
+    // The current-day key is untouched.
+    expect(sysStore.get(`system:blocks:tip-cap:42:${TODAY}`)).toBeUndefined();
+  });
+
+  it('is best-effort — a failed DECRBY never throws (a lost refund only over-counts)', async () => {
+    mockSys.decrBy.mockRejectedValueOnce(new Error('redis blip'));
+    await expect(refundBlockTipSpend('k' as never, 100)).resolves.toBeUndefined();
+  });
+});
+
+describe('checkBlockTipRateLimit', () => {
+  it('allows under the ceiling', async () => {
+    const r = await checkBlockTipRateLimit('bki_1');
+    expect(r).toEqual({ allowed: true });
+  });
+
+  it('blocks once the window count exceeds the ceiling', async () => {
+    let last;
+    for (let i = 0; i < BLOCK_TIP_RATE_LIMIT_MAX + 1; i++) {
+      last = await checkBlockTipRateLimit('bki_2');
+    }
+    expect(last).toMatchObject({ allowed: false });
+  });
+
+  it('FAILS-CLOSED on a redis error (money path)', async () => {
+    mockCache.incrBy.mockRejectedValueOnce(new Error('redis down'));
+    const r = await checkBlockTipRateLimit('bki_3');
+    expect(r).toMatchObject({ allowed: false });
+  });
+});

--- a/src/server/utils/block-tip-rate-limit.ts
+++ b/src/server/utils/block-tip-rate-limit.ts
@@ -1,4 +1,4 @@
-import { redis, REDIS_KEYS } from '~/server/redis/client';
+import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 
 /**
  * Per-instance fixed-window rate limit for the App Blocks TIP endpoint
@@ -71,4 +71,77 @@ export async function checkBlockTipRateLimit(
     // limiter's redis is unreachable. Surface a retryable back-off.
     return { allowed: false, retryAfterSeconds: BLOCK_TIP_RATE_LIMIT_WINDOW_SECONDS };
   }
+}
+
+// ── Tip amount caps (what makes block tipping PAGE-SAFE) ──────────────────────
+// Tipping is money OUT to third parties and is NOT gated by the per-gen
+// `buzzBudget` cost-preflight, so a page tip needs its OWN explicit bounds — the
+// analogue of the gen-spend `buzzBudget` + `BLOCK_BUZZ_CAP_PER_DAY` pair. These
+// two caps are the load-bearing safety that let `social:tip:self` come off
+// PAGE_FORBIDDEN_SCOPES: a compromised/buggy block can neither drain an account
+// in one call (per-tip cap) nor bleed it over a day (per-user daily cap).
+
+// Per-single-tip ceiling. Bounds one call; a block can't move a large sum in one
+// shot. Conservative vs. the gen per-call budget cap (1000) — a tip is a direct
+// transfer to another user, but a legitimate creator tip can reasonably exceed
+// 1000, so this is set higher while still hard-bounding a single request.
+export const BLOCK_TIP_MAX_PER_TIP = 5_000;
+// Per-USER daily aggregate across ALL of a user's installed blocks (the key omits
+// appBlockId, mirroring BLOCK_BUZZ_CAP_PER_DAY, so a publisher can't multiply the
+// ceiling by spinning up N blocks). Set BELOW the gen daily cap (50_000) because
+// tips are irreversible transfers to third parties.
+export const BLOCK_TIP_CAP_PER_DAY = 25_000;
+// 25h TTL: covers a UTC-day window plus skew; the key is re-derived per day so a
+// stale counter never bleeds into the next window.
+const BLOCK_TIP_CAP_TTL_SECONDS = 25 * 60 * 60;
+
+function tipCapWindowKey(): string {
+  return new Date().toISOString().slice(0, 10); // UTC calendar day
+}
+
+function tipCapRedisKey(userId: number): `${typeof REDIS_SYS_KEYS.BLOCKS.TIP_CAP}:${string}` {
+  // PER-USER aggregate: appBlockId is intentionally NOT part of the key.
+  return `${REDIS_SYS_KEYS.BLOCKS.TIP_CAP}:${userId}:${tipCapWindowKey()}`;
+}
+
+/**
+ * Atomically reserves `amount` against this user's cumulative UTC-day tip counter
+ * and returns the new running total + the exact key reserved. INCRBY is atomic so
+ * concurrent tips accumulate correctly with no read→check→record TOCTOU. Sets the
+ * TTL on the (effectively) first write. No try/catch: a Redis error throws and
+ * fails the tip CLOSED (mirrors reserveBlockBuzzSpend). Caller compares `total`
+ * against BLOCK_TIP_CAP_PER_DAY and refunds via the returned key on over-cap /
+ * on any downstream failure.
+ */
+export async function reserveBlockTipSpend(
+  userId: number,
+  amount: number
+): Promise<{ total: number; key: ReturnType<typeof tipCapRedisKey> }> {
+  const key = tipCapRedisKey(userId);
+  const total = await sysRedis.incrBy(key, Math.ceil(amount));
+  if (total <= Math.ceil(amount)) {
+    await sysRedis.expire(key, BLOCK_TIP_CAP_TTL_SECONDS);
+  } else {
+    const ttl = await sysRedis.ttl(key);
+    if (ttl < 0) await sysRedis.expire(key, BLOCK_TIP_CAP_TTL_SECONDS);
+  }
+  return { total, key };
+}
+
+/**
+ * Refunds a previously-reserved tip `amount` (best-effort DECRBY) against the
+ * EXACT key returned by reserveBlockTipSpend. Used when the reservation pushed the
+ * total over the daily cap, or when the tip transaction throws (insufficient
+ * funds, etc.). Best-effort: a failed refund leaves the reservation in place →
+ * OVER-counts → the cap is only made STRICTER (the safe direction). Never throws.
+ * Takes the reserved key (not re-derived) so a request straddling midnight UTC
+ * refunds the day it reserved, not the next day's key.
+ */
+export async function refundBlockTipSpend(
+  key: ReturnType<typeof tipCapRedisKey>,
+  amount: number
+): Promise<void> {
+  await sysRedis.decrBy(key, Math.ceil(amount)).catch(() => {
+    /* best-effort — a lost refund over-counts (stricter cap) */
+  });
 }

--- a/src/server/utils/block-tip-rate-limit.ts
+++ b/src/server/utils/block-tip-rate-limit.ts
@@ -1,0 +1,74 @@
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+
+/**
+ * Per-instance fixed-window rate limit for the App Blocks TIP endpoint
+ * (`POST /api/v1/blocks/tip`).
+ *
+ * WHY: tipping moves REAL Buzz out of the viewer's account. The underlying
+ * `createBuzzTipTransactionHandler` already enforces balance, self-tip, banned,
+ * blocked, and 24h-account gates, but a block that hammered the endpoint (a UI
+ * bug or a hostile iframe) could still churn many small tips + notifications.
+ * This bounds the per-instance tip RATE without touching the money-authority
+ * surface (the handler stays the sole arbiter of whether a tip is allowed).
+ *
+ * PATTERN: reuses the established blocks fixed-window limiter — the SAME
+ * INCR + EXPIRE shape as `checkBlockCatalogRateLimit` /
+ * `BlockTokenService.checkRateLimit`, on the `redis` cache client, under a
+ * distinct `:tip:` sub-namespace so it never contends with the mint-token or
+ * catalog buckets.
+ *
+ * KEY: `claims.blockInstanceId` — the stable per-instance identity the same
+ * in-block iframe reuses. We key on the instance (not `jti`, which rotates on
+ * every re-mint) so an abuser can't churn tokens for a fresh bucket.
+ *
+ * FAIL-CLOSED: unlike the catalog limiter (which fails OPEN so a read surface
+ * never breaks on a redis blip), the tip limiter fails CLOSED on a redis error
+ * — a money-moving endpoint must not become unbounded when its limiter is down.
+ * The caller surfaces this as a retryable 429/503.
+ */
+
+// CEILING: a human tipping through a player taps at most a handful of times a
+// minute (tip creator / tip curator on the current media). 10 tips / 60s per
+// instance is generous for real use and bounds a runaway loop / hostile churn.
+export const BLOCK_TIP_RATE_LIMIT_MAX = 10;
+export const BLOCK_TIP_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+export type BlockTipRateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number };
+
+/**
+ * Records one tip attempt against `blockInstanceId`'s window and reports whether
+ * it is within the per-instance ceiling.
+ *
+ * @param blockInstanceId stable per-instance identity from `req.blockClaims`.
+ * @returns `{ allowed: true }` under the limit; `{ allowed: false,
+ *   retryAfterSeconds }` once the window's count exceeds the ceiling OR on any
+ *   redis error (FAIL-CLOSED — money path).
+ */
+export async function checkBlockTipRateLimit(
+  blockInstanceId: string
+): Promise<BlockTipRateLimitResult> {
+  const key = `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:tip:${blockInstanceId}` as const;
+  try {
+    const count = await redis.incrBy(key as never, 1);
+    if (count === 1) {
+      await redis.expire(key as never, BLOCK_TIP_RATE_LIMIT_WINDOW_SECONDS);
+    } else {
+      const ttl = await redis.ttl(key as never);
+      if (ttl < 0) await redis.expire(key as never, BLOCK_TIP_RATE_LIMIT_WINDOW_SECONDS);
+    }
+
+    if (count <= BLOCK_TIP_RATE_LIMIT_MAX) return { allowed: true };
+
+    let retryAfter = await redis.ttl(key as never);
+    if (!Number.isFinite(retryAfter) || retryAfter < 1) {
+      retryAfter = BLOCK_TIP_RATE_LIMIT_WINDOW_SECONDS;
+    }
+    return { allowed: false, retryAfterSeconds: retryAfter };
+  } catch {
+    // FAIL-CLOSED — a money-moving endpoint must not run unbounded when the
+    // limiter's redis is unreachable. Surface a retryable back-off.
+    return { allowed: false, retryAfterSeconds: BLOCK_TIP_RATE_LIMIT_WINDOW_SECONDS };
+  }
+}

--- a/src/shared/constants/__tests__/block-scope.schema-drift.test.ts
+++ b/src/shared/constants/__tests__/block-scope.schema-drift.test.ts
@@ -34,9 +34,10 @@ describe('app-block v1 schema ⇄ BLOCK_SCOPE_TO_OAUTH_BIT drift guard', () => {
     expect(schemaEnum).toEqual(Object.keys(BLOCK_SCOPE_TO_OAUTH_BIT));
   });
 
-  it('includes the two new collections scopes', () => {
+  it('includes the three collections scopes (read:self, write:self, read:private)', () => {
     const schemaEnum = schema.properties?.scopes?.items?.enum as string[];
     expect(schemaEnum).toContain('collections:read:self');
     expect(schemaEnum).toContain('collections:write:self');
+    expect(schemaEnum).toContain('collections:read:private');
   });
 });

--- a/src/shared/constants/__tests__/block-scope.schema-drift.test.ts
+++ b/src/shared/constants/__tests__/block-scope.schema-drift.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { BLOCK_SCOPE_TO_OAUTH_BIT } from '../block-scope.constants';
+
+/**
+ * Drift guard: the canonical published manifest schema at
+ * `public/schemas/app-block/v1.json` declares `scopes.items.enum` — the list of
+ * scopes a block manifest may request. That enum MUST equal the KEYS of
+ * `BLOCK_SCOPE_TO_OAUTH_BIT` (the authoritative runtime scope registry) EXACTLY,
+ * in the same order. The schema is what the `civitai` CLI's vendored copy +
+ * editor validation compare against; the registry is what the server-side
+ * middleware / mint / validator reference. If a scope is added/removed in ONE
+ * place only, this fails loudly so the canonical schema and the runtime registry
+ * can never silently diverge (mirrors the MARKETPLACE_CATEGORIES drift guard).
+ */
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const SCHEMA_PATH = path.join(REPO_ROOT, 'public/schemas/app-block/v1.json');
+
+describe('app-block v1 schema ⇄ BLOCK_SCOPE_TO_OAUTH_BIT drift guard', () => {
+  const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8')) as {
+    properties?: { scopes?: { items?: { enum?: unknown } } };
+  };
+
+  it('declares scopes.items.enum as a string array', () => {
+    const enumVal = schema.properties?.scopes?.items?.enum;
+    expect(Array.isArray(enumVal)).toBe(true);
+    expect((enumVal as unknown[]).every((s) => typeof s === 'string')).toBe(true);
+  });
+
+  it('scopes enum equals the registry keys exactly (order included)', () => {
+    const schemaEnum = schema.properties?.scopes?.items?.enum as string[];
+    expect(schemaEnum).toEqual(Object.keys(BLOCK_SCOPE_TO_OAUTH_BIT));
+  });
+
+  it('includes the two new collections scopes', () => {
+    const schemaEnum = schema.properties?.scopes?.items?.enum as string[];
+    expect(schemaEnum).toContain('collections:read:self');
+    expect(schemaEnum).toContain('collections:write:self');
+  });
+});

--- a/src/shared/constants/__tests__/slot-registry.test.ts
+++ b/src/shared/constants/__tests__/slot-registry.test.ts
@@ -68,16 +68,20 @@ describe('slot-registry (Phase 0 foundation)', () => {
     );
   });
 
-  // W10 generation spend: `ai:write:budgeted` is NO LONGER page-forbidden —
-  // pages can spend Buzz on generation, bounded by the manifest per-gen budget
-  // (page.buzzBudgetPerGen) + the per-user daily cap. Tipping + balance-read
-  // stay forbidden (see the doc comment on PAGE_FORBIDDEN_SCOPES for why).
-  it('PAGE_FORBIDDEN_SCOPES forbids only tipping + balance-read (NOT budgeted gen)', () => {
-    expect([...PAGE_FORBIDDEN_SCOPES].sort()).toEqual(['buzz:read:self', 'social:tip:self'].sort());
+  // PAGE_FORBIDDEN_SCOPES is now EMPTY — every money/spend scope a page can
+  // request is BOUNDED (gen: per-gen buzzBudget + BLOCK_BUZZ_CAP_PER_DAY; tip:
+  // BLOCK_TIP_MAX_PER_TIP + BLOCK_TIP_CAP_PER_DAY; buzz:read:self is a
+  // self-balance read with no spend authority). Tipping came off the list once it
+  // gained explicit caps (bounded, no longer effectively-unbounded spend).
+  it('PAGE_FORBIDDEN_SCOPES is empty — no money/spend scope is categorically forbidden for pages', () => {
+    expect([...PAGE_FORBIDDEN_SCOPES]).toEqual([]);
   });
 
-  it('ai:write:budgeted is NOT forbidden for pages (generation spend allowed)', () => {
-    expect((PAGE_FORBIDDEN_SCOPES as readonly string[]).includes('ai:write:budgeted')).toBe(false);
+  it('none of ai:write:budgeted / social:tip:self / buzz:read:self is page-forbidden (all bounded)', () => {
+    const forbidden = PAGE_FORBIDDEN_SCOPES as readonly string[];
+    expect(forbidden.includes('ai:write:budgeted')).toBe(false);
+    expect(forbidden.includes('social:tip:self')).toBe(false);
+    expect(forbidden.includes('buzz:read:self')).toBe(false);
   });
 
   // Only `none` and `model` entities are wired in this build. user/image are

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -95,6 +95,16 @@ export const BLOCK_SCOPE_TO_OAUTH_BIT: Record<string, ScopeBitmaskRequirement> =
   // declarable manifest scopes (the manifest validator rejects unknown scopes).
   'collections:read:self': SKIP_OAUTH_CHECK,
   'collections:write:self': SKIP_OAUTH_CHECK,
+  // collections:read:private — the subject's OWN PRIVATE collections. Split out
+  // from collections:read:self (which covers own-PUBLIC + any PUBLIC collection)
+  // so that reading a user's PRIVATE collections requires an EXPLICIT per-user
+  // consent grant. Same no-OAuth-bit posture (SKIP_OAUTH_CHECK; server enforces
+  // ownership), and self-scope (non-anon subject) in the middleware. CRITICAL:
+  // this scope is CONSENT-GATED — it is deliberately NOT in CONSENT_EXEMPT_SCOPES,
+  // so it flows through partitionByConsent's gated set and the user must grant it
+  // via the host consent gate before a token carries it (contrast read:self,
+  // which is exempt and always mints). See scope-grant.service.ts.
+  'collections:read:private': SKIP_OAUTH_CHECK,
 } as const;
 
 export type BlockScopeString = keyof typeof BLOCK_SCOPE_TO_OAUTH_BIT;

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -77,6 +77,24 @@ export const BLOCK_SCOPE_TO_OAUTH_BIT: Record<string, ScopeBitmaskRequirement> =
   // apps that declare it, never to a pre-approval dev-tunnel/dev-token session.
   'apps:storage:shared:read': SKIP_OAUTH_CHECK,
   'apps:storage:shared:write': SKIP_OAUTH_CHECK,
+  // collections:read:self / collections:write:self — the App Blocks Collections
+  // surface (discover + read public collections and the viewer's OWN collections;
+  // follow/bookmark a collection on the viewer's behalf). Same no-OAuth-bit
+  // posture as apps:storage:* — these never touch the user's civitai resources
+  // through the OAuth surface, so there is no bitmask bit; SKIP_OAUTH_CHECK makes
+  // that explicit. The REAL gate is SERVER-SIDE and per-op:
+  //   - read: collection VISIBILITY/OWNERSHIP — a private collection is 404 to a
+  //     non-owner/contributor (existence-leak-safe), and item reads are clamped to
+  //     the token's `maxBrowsingLevel` maturity ceiling;
+  //   - write (follow): the token SUBJECT is the actor (self-bound), the block
+  //     endpoint follows/unfollows on the caller's own behalf.
+  // Both are additionally bound to a NON-ANON subject in the block-scope
+  // middleware (self-scopes), and both are consent-exempt (server
+  // visibility/ownership is the gate, not a per-scope consent prompt) — see
+  // scope-grant.service.ts CONSENT_EXEMPT_SCOPES. Adding them here also makes them
+  // declarable manifest scopes (the manifest validator rejects unknown scopes).
+  'collections:read:self': SKIP_OAUTH_CHECK,
+  'collections:write:self': SKIP_OAUTH_CHECK,
 } as const;
 
 export type BlockScopeString = keyof typeof BLOCK_SCOPE_TO_OAUTH_BIT;

--- a/src/shared/constants/slot-registry.ts
+++ b/src/shared/constants/slot-registry.ts
@@ -159,24 +159,25 @@ export function isKnownSlotId(id: string): id is SlotId {
  * if an app's approved manifest declared one of these, a `kind==='page'` mint
  * rejects it.
  *
- * W10 generation spend: `ai:write:budgeted` is NO LONGER forbidden for pages.
- * A page is stateless (no install settings row), so its per-generation budget
- * comes from the approved manifest's `page.buzzBudgetPerGen` field — server-read,
- * clamped to BUZZ_BUDGET_CAP, defaulted to BUZZ_BUDGET_DEFAULT when the manifest
- * omits it (see resolveBuzzBudget in the mint handler). Page generation spend is
- * therefore bounded by exactly the same two limits a model slot is: the per-gen
- * `buzzBudget` claim AND the per-user daily cap (BLOCK_BUZZ_CAP_PER_DAY in
- * blocks.router.ts) — neither is bypassed for pages.
+ * NOW EMPTY — every money/spend scope a page can request is BOUNDED, so none is
+ * categorically forbidden:
+ *   - `ai:write:budgeted` (generation): bounded by the per-gen `buzzBudget` claim
+ *     (from the approved manifest's `page.buzzBudgetPerGen`, server-read + clamped
+ *     to BUZZ_BUDGET_CAP) AND the per-user daily cap (BLOCK_BUZZ_CAP_PER_DAY).
+ *   - `social:tip:self` (tipping): bounded by a per-tip cap (BLOCK_TIP_MAX_PER_TIP)
+ *     AND a per-user daily cap (BLOCK_TIP_CAP_PER_DAY, reserve-and-refund) enforced
+ *     in `/api/v1/blocks/tip` BEFORE any money moves — the exact analogue of the
+ *     gen-spend pair. Tipping was previously forbidden ONLY because it lacked such
+ *     bounds; now that it has them, a page tip is bounded spend, not unbounded, so
+ *     it is page-safe. (Tipping is also self-bound to the token subject and
+ *     rate-limited per instance.)
+ *   - `buzz:read:self` (balance read): a low-sensitivity read of the viewer's OWN
+ *     balance, needed for a page app's Buzz-balance readout; no spend authority.
  *
- * The two scopes below STAY forbidden for pages:
- *   - `social:tip:self` — tipping is NOT gated by the buzzBudget cost-preflight,
- *     so the manifest budget cap does not bound it. On a stateless page (no
- *     per-content owner to attribute against, no per-gen cost ceiling) a tip
- *     scope would be effectively unbounded spend, so it remains rejected.
- *   - `buzz:read:self` — balance read isn't needed to spend a bounded budget,
- *     and a page (entity=none) has no reason to read the viewer's balance.
+ * Keep this list as the deterministic mint-time belt: to re-forbid a scope for
+ * pages, add it back here (the mint filters requested page scopes against it).
  */
-export const PAGE_FORBIDDEN_SCOPES = ['buzz:read:self', 'social:tip:self'] as const;
+export const PAGE_FORBIDDEN_SCOPES = [] as const;
 
 /** Does the slot render a full standalone page (W10)? */
 export function isPageSlot(id: string): boolean {

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -302,43 +302,52 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
     expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects a page manifest that declares a still-forbidden money scope (page hard rule)', async () => {
-    // The OAuth client ALLOWS the money scope + it's in the approved set — so
-    // the earlier OAuth/approved gates pass and the PAGE HARD RULE is what
-    // rejects (proves the page-specific gate, not the generic allowlist).
-    // social:tip:self is NOT un-forbidden by W10 (only ai:write:budgeted is).
-    mockBlockRegistry.resolvePageBlock.mockResolvedValue(
-      PAGE_BLOCK(
-        ['apps:storage:read', 'social:tip:self'],
-        ['apps:storage:read', 'social:tip:self'],
-        MONEY_BITS
-      )
-    );
-    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
-    const res = makeRes();
-    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
-
-    expect(res._status).toBe(403);
-    expect(res._body.error).toMatch(/money\/spend scopes/);
-    expect(mockTokenService.sign).not.toHaveBeenCalled();
-  });
-
-  // W10: ai:write:budgeted is INTENTIONALLY absent here — it is now allowed for
-  // pages (covered by the budget tests below). Only tipping + balance-read stay
-  // page-forbidden.
+  // BOUNDED-TIPPING: social:tip:self + buzz:read:self are NO LONGER page-forbidden
+  // (PAGE_FORBIDDEN_SCOPES is now empty). Tipping is bounded by per-tip +
+  // per-user-daily caps in /api/v1/blocks/tip, which made it page-safe. A page
+  // manifest declaring these scopes now MINTS end-to-end (given the user's
+  // consent grant — they're consent-gated, not exempt) rather than 403'ing.
   it.each([['buzz:read:self'], ['social:tip:self']])(
-    'rejects forbidden page scope %s',
+    'now MINTS a page token carrying the (bounded) scope %s (no longer page-forbidden)',
     async (scope) => {
+      mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+        grantedScopes: [scope],
+        revokedAt: null,
+      });
       mockBlockRegistry.resolvePageBlock.mockResolvedValue(
         PAGE_BLOCK([scope], [scope], MONEY_BITS)
       );
       const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
       const res = makeRes();
       await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
-      expect(res._status).toBe(403);
-      expect(mockTokenService.sign).not.toHaveBeenCalled();
+      // No page-hard-rule 403 — the token is signed and carries the scope.
+      expect(res._status).toBe(200);
+      expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
+      expect(mockTokenService.sign.mock.calls[0][0].scopes).toContain(scope);
     }
   );
+
+  it('MINTS a page token declaring BOTH social:tip:self + buzz:read:self (end-to-end)', async () => {
+    mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+      grantedScopes: ['social:tip:self', 'buzz:read:self'],
+      revokedAt: null,
+    });
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(
+      PAGE_BLOCK(
+        ['social:tip:self', 'buzz:read:self'],
+        ['social:tip:self', 'buzz:read:self'],
+        MONEY_BITS
+      )
+    );
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+    expect(res._status).toBe(200);
+    const signArg = mockTokenService.sign.mock.calls[0][0];
+    expect(signArg.scopes).toEqual(
+      expect.arrayContaining(['social:tip:self', 'buzz:read:self'])
+    );
+  });
 
   it('is flag-gated on appBlocksPages (appBlocks alone is not enough → 403, no token)', async () => {
     (mockFlags.getFeatureFlags as any).mockImplementation(() => ({
@@ -564,10 +573,11 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
     });
   });
 
-  // ── Audit: a MIXED manifest with one still-forbidden money scope is a HARD
-  // reject of the WHOLE request — the allowed ai:write:budgeted does not
-  // "rescue" the request when social:tip:self rides alongside it. ───────────
-  it('MIXED manifest [ai:write:budgeted, social:tip:self] → 403, whole request rejected', async () => {
+  // BOUNDED-TIPPING: a MIXED manifest [ai:write:budgeted, social:tip:self] now
+  // MINTS both scopes — both are bounded spend (gen by buzzBudget + daily cap,
+  // tip by per-tip + daily cap), so neither is page-forbidden. (Previously this
+  // was a hard 403 because tipping was categorically forbidden for pages.)
+  it('MIXED manifest [ai:write:budgeted, social:tip:self] now MINTS both (both bounded)', async () => {
     mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
       grantedScopes: ['ai:write:budgeted', 'social:tip:self'],
       revokedAt: null,
@@ -583,8 +593,6 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
           page: { path: '/', title: 'Hello' },
         },
         approvedScopes: ['ai:write:budgeted', 'social:tip:self'],
-        // Allow both bits so the OAuth/approved gates pass and the PAGE HARD
-        // RULE is what rejects (social:tip:self stays page-forbidden).
         app: { allowedScopes: MONEY_BITS },
       },
     });
@@ -592,9 +600,14 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
     const res = makeRes();
     await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
 
-    expect(res._status).toBe(403);
-    // No partial mint — the whole request is rejected, no token signed.
-    expect(mockTokenService.sign).not.toHaveBeenCalled();
+    expect(res._status).toBe(200);
+    const signArg = mockTokenService.sign.mock.calls[0][0];
+    expect(signArg.scopes).toEqual(
+      expect.arrayContaining(['ai:write:budgeted', 'social:tip:self'])
+    );
+    // Generation budget still resolves (default 10) since the page manifest
+    // omits page.buzzBudgetPerGen.
+    expect(signArg.buzzBudget).toBe(10);
   });
 
   // ── MODEL_INSTALL positive regression: the path the integer-enforcement fix

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -717,4 +717,60 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
     expect(signArg.scopes).toEqual(['models:read:self']);
     expect(signArg.blockInstanceId).toBe('bki_x');
   });
+
+  // ── #3090 read-split PROOF: collections:read:private is CONSENT-GATED, while
+  // collections:read:self is CONSENT-EXEMPT. Driven through the REAL mint handler
+  // (partitionByConsent + getGrantedScopes over the mocked appUserScopeGrant) so
+  // the consent surfacing + carry is proven end-to-end — the exact thing #3090
+  // showed can silently fail. ────────────────────────────────────────────────
+  describe('collections read split — consent gating (#3090 proof)', () => {
+    const PAGE_COLLECTIONS_BLOCK = () =>
+      PAGE_BLOCK(
+        ['collections:read:self', 'collections:read:private'],
+        ['collections:read:self', 'collections:read:private'],
+        0 // both are SKIP_OAUTH_CHECK → allowedScopes irrelevant
+      );
+
+    it('NO grant: token OMITS read:private (exempt read:self still mints); needsConsent surfaces it', async () => {
+      // User has consented to NOTHING for this app.
+      mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+        grantedScopes: [],
+        revokedAt: null,
+      });
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_COLLECTIONS_BLOCK());
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+      expect(res._status).toBe(200);
+      const signArg = mockTokenService.sign.mock.calls[0][0];
+      // read:self is CONSENT-EXEMPT → always carried.
+      expect(signArg.scopes).toContain('collections:read:self');
+      // read:private is CONSENT-GATED → WITHHELD without a grant (the #3090 point).
+      expect(signArg.scopes).not.toContain('collections:read:private');
+      // …and surfaced to the host as needing consent.
+      expect(res._body.needsConsent).toBe(true);
+      expect(res._body.missingScopes).toContain('collections:read:private');
+      expect(res._body.missingScopes).not.toContain('collections:read:self');
+    });
+
+    it('WITH grant: token CARRIES read:private; needsConsent is false', async () => {
+      mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+        grantedScopes: ['collections:read:private'],
+        revokedAt: null,
+      });
+      mockBlockRegistry.resolvePageBlock.mockResolvedValue(PAGE_COLLECTIONS_BLOCK());
+      const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+      const res = makeRes();
+      await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+
+      expect(res._status).toBe(200);
+      const signArg = mockTokenService.sign.mock.calls[0][0];
+      expect(signArg.scopes).toEqual(
+        expect.arrayContaining(['collections:read:self', 'collections:read:private'])
+      );
+      expect(res._body.needsConsent).toBe(false);
+      expect(res._body.missingScopes).toEqual([]);
+    });
+  });
 });

--- a/src/tests/api/v1/blocks/buzz-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/buzz-endpoint.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * Handler-level coverage for GET /api/v1/blocks/buzz (balance readout). Authz
+ * (missing-scope / revoked) is in collections-tip-authz.test.ts; this exercises
+ * the inner handler's self-bound balance read.
+ */
+
+function createMocks({ method = 'GET' }: { method?: string } = {}) {
+  const req = { method, query: {}, headers: {}, socket: { remoteAddress: '203.0.113.7' } } as unknown as Record<
+    string,
+    unknown
+  >;
+  let statusCode = 200;
+  let payload: unknown;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader() {},
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+class ForbiddenError extends Error {
+  readonly status = 403 as const;
+}
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+  parseSubjectUserId: (sub: string): number | null => {
+    if (sub === 'anon') return null;
+    if (!/^user:\d+$/.test(sub)) throw new ForbiddenError('bad');
+    return Number.parseInt(sub.slice('user:'.length), 10);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const { mockAccount } = vi.hoisted(() => ({ mockAccount: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({ getUserBuzzAccount: mockAccount }));
+
+import handler from '~/pages/api/v1/blocks/buzz';
+
+function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'j',
+    blockId: 'b',
+    appId: 'a',
+    appBlockId: 'apb',
+    blockInstanceId: 'bki',
+    ctx: {},
+    scopes: ['buzz:read:self'],
+    ...over,
+  } as BlockTokenClaims;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockAccount.mockResolvedValue([{ id: 42, balance: 1234, accountType: 'yellow' }]);
+});
+
+describe('GET /api/v1/blocks/buzz', () => {
+  it('405 for a non-GET method', async () => {
+    const { req, res } = createMocks({ method: 'POST' });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(405);
+  });
+
+  it('401 when blockClaims is absent', async () => {
+    claimsBox.claims = undefined;
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(401);
+  });
+
+  it('403 for an anonymous token (no "self" balance)', async () => {
+    claimsBox.claims = fakeClaims({ sub: 'anon' as never });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+    expect(mockAccount).not.toHaveBeenCalled();
+  });
+
+  it('200: returns the subject-bound balance', async () => {
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual({ balance: 1234 });
+    // Balance is keyed on the verified subject (42), never client input.
+    expect(mockAccount).toHaveBeenCalledWith({ accountId: 42, accountType: 'yellow' });
+  });
+
+  it('502 when the balance service throws', async () => {
+    mockAccount.mockRejectedValueOnce(new Error('buzz down'));
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(502);
+  });
+});

--- a/src/tests/api/v1/blocks/collection-detail-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/collection-detail-endpoint.test.ts
@@ -121,7 +121,8 @@ beforeEach(() => {
   mockRate.mockResolvedValue({ allowed: true });
   mockMaturity.mockReturnValue({ browsingLevel: 3, isSfwCeiling: true });
   mockHydrate.mockResolvedValue({ id: 42, username: 'mod', isModerator: false });
-  mockPerms.mockResolvedValue({ read: true });
+  // Default: a PUBLIC collection (readable, publicCollection=true).
+  mockPerms.mockResolvedValue({ read: true, publicCollection: true });
   mockFollowed.mockResolvedValue(new Set<number>([7]));
   mockGetById.mockResolvedValue({
     id: 7,
@@ -161,12 +162,35 @@ describe('GET /api/v1/blocks/collections/[id]', () => {
   });
 
   it('404 (not 403) for a private collection the subject cannot read — no existence oracle', async () => {
-    mockPerms.mockResolvedValueOnce({ read: false });
+    mockPerms.mockResolvedValueOnce({ read: false, publicCollection: false });
     const { req, res } = createMocks({ query: { id: '7' } });
     await handler(req as never, res as never);
     expect(res._status()).toBe(404);
     // getCollectionById is never reached (visibility gate fails first).
     expect(mockGetById).not.toHaveBeenCalled();
+  });
+
+  it('404 for an OWNED PRIVATE collection WITHOUT read:private — invisible-existence (no 403, no consent leak)', async () => {
+    // Subject owns it (read=true) but it is NOT public and the token lacks
+    // read:private → the SAME bare 404 a non-owner sees.
+    mockPerms.mockResolvedValueOnce({ read: true, publicCollection: false });
+    // Default claims carry only collections:read:self.
+    const { req, res } = createMocks({ query: { id: '7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(404);
+    expect(mockGetById).not.toHaveBeenCalled();
+  });
+
+  it('200 for an OWNED PRIVATE collection WITH read:private', async () => {
+    claimsBox.claims = fakeClaims({
+      scopes: ['collections:read:self', 'collections:read:private'],
+    });
+    mockPerms.mockResolvedValueOnce({ read: true, publicCollection: false });
+    mockItems.mockResolvedValueOnce({ items: [], nextCursor: undefined });
+    const { req, res } = createMocks({ query: { id: '7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(mockGetById).toHaveBeenCalled();
   });
 
   it('404 when the collection row is gone (getCollectionById throws)', async () => {

--- a/src/tests/api/v1/blocks/collection-detail-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/collection-detail-endpoint.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * Handler-level coverage for GET /api/v1/blocks/collections/[id] (detail). Authz
+ * (scope/revoked/anon-token) is in collections-tip-authz.test.ts; this exercises
+ * visibility (private→404), the maturity clamp threading, media mapping, and the
+ * playable-only (image/video) filter.
+ */
+
+function createMocks({
+  method = 'GET',
+  query = {},
+}: { method?: string; query?: Record<string, unknown> } = {}) {
+  const req = { method, query, headers: {}, socket: { remoteAddress: '203.0.113.7' } } as unknown as Record<
+    string,
+    unknown
+  >;
+  let statusCode = 200;
+  let payload: unknown;
+  const headers: Record<string, string> = {};
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+class ForbiddenError extends Error {
+  readonly status = 403 as const;
+}
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+  parseSubjectUserId: (sub: string): number | null => {
+    if (sub === 'anon') return null;
+    if (!/^user:\d+$/.test(sub)) throw new ForbiddenError('bad');
+    return Number.parseInt(sub.slice('user:'.length), 10);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const { mockPerms, mockGetById, mockItems, mockHydrate, mockFollowed, mockRate, mockMaturity } =
+  vi.hoisted(() => ({
+    mockPerms: vi.fn(),
+    mockGetById: vi.fn(),
+    mockItems: vi.fn(),
+    mockHydrate: vi.fn(),
+    mockFollowed: vi.fn(),
+    mockRate: vi.fn(),
+    mockMaturity: vi.fn(),
+  }));
+
+vi.mock('~/server/services/collection.service', () => ({
+  getUserCollectionPermissionsById: mockPerms,
+  getCollectionById: mockGetById,
+  getCollectionItemsByCollectionId: mockItems,
+}));
+vi.mock('~/server/services/blocks/block-collections.service', () => ({
+  hydrateBlockSubject: mockHydrate,
+  getFollowedCollectionIds: mockFollowed,
+  mapImageItemToMedia: (data: any) => ({
+    mediaId: data.id,
+    type: data.type === 'video' ? 'video' : 'image',
+    url: `edge:${data.url}`,
+    width: data.width ?? null,
+    height: data.height ?? null,
+    creator: data.user ? { userId: data.user.id, username: data.user.username } : null,
+    nsfwLevel: data.nsfwLevel ?? 0,
+  }),
+}));
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({ checkBlockCatalogRateLimit: mockRate }));
+vi.mock('~/server/utils/block-catalog-maturity', () => ({ resolveCatalogBrowsingLevel: mockMaturity }));
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => ({}),
+  isRegionRestricted: () => false,
+}));
+
+import handler from '~/pages/api/v1/blocks/collections/[id]/index';
+
+function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'j',
+    blockId: 'blk',
+    appId: 'app',
+    appBlockId: 'apb',
+    blockInstanceId: 'bki',
+    ctx: {},
+    scopes: ['collections:read:self'],
+    maxBrowsingLevel: 3,
+    ...over,
+  } as BlockTokenClaims;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockRate.mockResolvedValue({ allowed: true });
+  mockMaturity.mockReturnValue({ browsingLevel: 3, isSfwCeiling: true });
+  mockHydrate.mockResolvedValue({ id: 42, username: 'mod', isModerator: false });
+  mockPerms.mockResolvedValue({ read: true });
+  mockFollowed.mockResolvedValue(new Set<number>([7]));
+  mockGetById.mockResolvedValue({
+    id: 7,
+    name: 'Playlist',
+    description: 'a mix',
+    read: 'Public',
+    userId: 100,
+    user: { id: 100, username: 'alice' },
+  });
+});
+
+describe('GET /api/v1/blocks/collections/[id]', () => {
+  it('405 for a non-GET method', async () => {
+    const { req, res } = createMocks({ method: 'POST', query: { id: '7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(405);
+  });
+
+  it('401 when blockClaims is absent', async () => {
+    claimsBox.claims = undefined;
+    const { req, res } = createMocks({ query: { id: '7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(401);
+  });
+
+  it('403 for an anonymous token', async () => {
+    claimsBox.claims = fakeClaims({ sub: 'anon' as never });
+    const { req, res } = createMocks({ query: { id: '7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+  });
+
+  it('400 for a non-numeric collection id', async () => {
+    const { req, res } = createMocks({ query: { id: 'abc' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+  });
+
+  it('404 (not 403) for a private collection the subject cannot read — no existence oracle', async () => {
+    mockPerms.mockResolvedValueOnce({ read: false });
+    const { req, res } = createMocks({ query: { id: '7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(404);
+    // getCollectionById is never reached (visibility gate fails first).
+    expect(mockGetById).not.toHaveBeenCalled();
+  });
+
+  it('404 when the collection row is gone (getCollectionById throws)', async () => {
+    mockGetById.mockRejectedValueOnce(new Error('No collection'));
+    const { req, res } = createMocks({ query: { id: '7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(404);
+  });
+
+  it('200: threads the clamped browsingLevel, maps image/video, drops non-media, sets followed', async () => {
+    mockItems.mockResolvedValueOnce({
+      items: [
+        { type: 'image', data: { id: 1, url: 'i1', type: 'image', width: 512, height: 512, nsfwLevel: 1, user: { id: 100, username: 'alice' } } },
+        { type: 'image', data: { id: 2, url: 'v2', type: 'video', width: 1280, height: 720, nsfwLevel: 1, user: { id: 100, username: 'alice' } } },
+        { type: 'model', data: { id: 999 } }, // dropped — not playable media
+      ],
+      nextCursor: '2',
+    });
+    const { req, res } = createMocks({ query: { id: '7', limit: '24' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    const body = res._json() as any;
+    // The maturity clamp is the token ceiling threaded into the item service.
+    expect(mockItems).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ collectionId: 7, browsingLevel: 3, statuses: ['ACCEPTED'] }),
+        user: expect.objectContaining({ id: 42 }),
+      })
+    );
+    expect(body.collection).toEqual({
+      id: 7,
+      name: 'Playlist',
+      description: 'a mix',
+      curator: { userId: 100, username: 'alice' },
+      isPublic: true,
+      followed: true,
+    });
+    // Only the 2 media items; the model item is dropped. Video type preserved.
+    expect(body.items).toHaveLength(2);
+    expect(body.items[0]).toMatchObject({ mediaId: 1, type: 'image', url: 'edge:i1' });
+    expect(body.items[1]).toMatchObject({ mediaId: 2, type: 'video', url: 'edge:v2' });
+    expect(body.nextCursor).toBe('2');
+  });
+});

--- a/src/tests/api/v1/blocks/collection-follow-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/collection-follow-endpoint.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * Handler-level coverage for POST /api/v1/blocks/collections/[id]/follow. Authz
+ * is in collections-tip-authz.test.ts; this exercises the follow/unfollow reuse
+ * (self-bound to the subject) + TRPCError→HTTP mapping.
+ */
+
+function createMocks({
+  method = 'POST',
+  query = {},
+  body = {},
+}: { method?: string; query?: Record<string, unknown>; body?: unknown } = {}) {
+  const req = { method, query, body, headers: {}, socket: { remoteAddress: '203.0.113.7' } } as unknown as Record<
+    string,
+    unknown
+  >;
+  let statusCode = 200;
+  let payload: unknown;
+  const headers: Record<string, string> = {};
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+class ForbiddenError extends Error {
+  readonly status = 403 as const;
+}
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+  parseSubjectUserId: (sub: string): number | null => {
+    if (sub === 'anon') return null;
+    if (!/^user:\d+$/.test(sub)) throw new ForbiddenError('bad');
+    return Number.parseInt(sub.slice('user:'.length), 10);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const { mockAdd, mockRemove } = vi.hoisted(() => ({ mockAdd: vi.fn(), mockRemove: vi.fn() }));
+vi.mock('~/server/services/collection.service', () => ({
+  addContributorToCollection: mockAdd,
+  removeContributorFromCollection: mockRemove,
+}));
+
+import handler from '~/pages/api/v1/blocks/collections/[id]/follow';
+
+function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'j',
+    blockId: 'b',
+    appId: 'a',
+    appBlockId: 'apb',
+    blockInstanceId: 'bki',
+    ctx: {},
+    scopes: ['collections:write:self'],
+    ...over,
+  } as BlockTokenClaims;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockAdd.mockResolvedValue({});
+  mockRemove.mockResolvedValue({});
+});
+
+describe('POST /api/v1/blocks/collections/[id]/follow', () => {
+  it('405 for a non-POST method', async () => {
+    const { req, res } = createMocks({ method: 'GET', query: { id: '7' }, body: { follow: true } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(405);
+  });
+
+  it('401 when blockClaims is absent', async () => {
+    claimsBox.claims = undefined;
+    const { req, res } = createMocks({ query: { id: '7' }, body: { follow: true } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(401);
+  });
+
+  it('403 for an anonymous token', async () => {
+    claimsBox.claims = fakeClaims({ sub: 'anon' as never });
+    const { req, res } = createMocks({ query: { id: '7' }, body: { follow: true } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+  });
+
+  it('400 for a non-numeric id', async () => {
+    const { req, res } = createMocks({ query: { id: 'x' }, body: { follow: true } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+  });
+
+  it('400 for a non-boolean follow body', async () => {
+    const { req, res } = createMocks({ query: { id: '7' }, body: { follow: 'yes' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+  });
+
+  it('follow=true → addContributorToCollection self-bound → { followed: true }', async () => {
+    const { req, res } = createMocks({ query: { id: '7' }, body: { follow: true } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual({ followed: true });
+    expect(mockAdd).toHaveBeenCalledWith({ collectionId: 7, userId: 42, targetUserId: 42 });
+    expect(mockRemove).not.toHaveBeenCalled();
+  });
+
+  it('follow=false → removeContributorFromCollection self-bound → { followed: false }', async () => {
+    const { req, res } = createMocks({ query: { id: '7' }, body: { follow: false } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual({ followed: false });
+    expect(mockRemove).toHaveBeenCalledWith({ collectionId: 7, userId: 42, targetUserId: 42 });
+    expect(mockAdd).not.toHaveBeenCalled();
+  });
+
+  it('maps a service FORBIDDEN (e.g. cannot follow a private collection) → 403', async () => {
+    mockAdd.mockRejectedValueOnce(
+      new TRPCError({ code: 'FORBIDDEN', message: 'no permission' })
+    );
+    const { req, res } = createMocks({ query: { id: '7' }, body: { follow: true } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+    expect((res._json() as any).error).toBe('no permission');
+  });
+
+  it('maps an unexpected non-TRPC error → 500', async () => {
+    mockAdd.mockRejectedValueOnce(new Error('boom'));
+    const { req, res } = createMocks({ query: { id: '7' }, body: { follow: true } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(500);
+  });
+});

--- a/src/tests/api/v1/blocks/collections-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/collections-endpoint.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * Handler-level coverage for GET /api/v1/blocks/collections (discovery). The
+ * shared authz layer (missing scope / revoked / anon-token via a real minted
+ * token) is covered in collections-tip-authz.test.ts; withBlockScope is mocked
+ * here as a passthrough that stamps req.blockClaims so we exercise the inner
+ * handler's discovery + mapping + maturity + subject-binding logic.
+ */
+
+function createMocks({
+  method = 'GET',
+  query = {},
+}: { method?: string; query?: Record<string, unknown> } = {}) {
+  const req = { method, query, headers: {}, socket: { remoteAddress: '203.0.113.7' } } as unknown as Record<
+    string,
+    unknown
+  >;
+  let statusCode = 200;
+  let payload: unknown;
+  const headers: Record<string, string> = {};
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+    _headers: () => headers,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+
+class ForbiddenError extends Error {
+  readonly status = 403 as const;
+}
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+  parseSubjectUserId: (sub: string): number | null => {
+    if (sub === 'anon') return null;
+    if (!/^user:\d+$/.test(sub)) throw new ForbiddenError('malformed sub claim');
+    return Number.parseInt(sub.slice('user:'.length), 10);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const {
+  mockGetAll,
+  mockItemCount,
+  mockUserCollections,
+  mockHydrate,
+  mockFollowed,
+  mockRate,
+  mockMaturity,
+} = vi.hoisted(() => ({
+  mockGetAll: vi.fn(),
+  mockItemCount: vi.fn(),
+  mockUserCollections: vi.fn(),
+  mockHydrate: vi.fn(),
+  mockFollowed: vi.fn(),
+  mockRate: vi.fn(),
+  mockMaturity: vi.fn(),
+}));
+
+vi.mock('~/server/services/collection.service', () => ({
+  getAllCollections: mockGetAll,
+  getCollectionItemCount: mockItemCount,
+  getUserCollectionsWithPermissions: mockUserCollections,
+}));
+vi.mock('~/server/services/blocks/block-collections.service', () => ({
+  hydrateBlockSubject: mockHydrate,
+  getFollowedCollectionIds: mockFollowed,
+  toMediaUrl: (img: any) => (img?.url ? `edge:${img.url}` : null),
+  // Drop a collection whose nsfwLevel exceeds the (test) ceiling of 3.
+  collectionWithinCeiling: (nsfwLevel: number, level: number) => nsfwLevel <= level,
+}));
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({ checkBlockCatalogRateLimit: mockRate }));
+vi.mock('~/server/utils/block-catalog-maturity', () => ({
+  resolveCatalogBrowsingLevel: mockMaturity,
+}));
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => ({}),
+  isRegionRestricted: () => false,
+}));
+
+import handler from '~/pages/api/v1/blocks/collections/index';
+
+function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'jti',
+    blockId: 'blk',
+    appId: 'app',
+    appBlockId: 'apb_test',
+    blockInstanceId: 'bki_test',
+    ctx: {},
+    scopes: ['collections:read:self'],
+    maxBrowsingLevel: 3,
+    ...over,
+  } as BlockTokenClaims;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockRate.mockResolvedValue({ allowed: true });
+  mockMaturity.mockReturnValue({ browsingLevel: 3, isSfwCeiling: true });
+  mockHydrate.mockResolvedValue({ id: 42, username: 'mod', isModerator: true });
+  mockFollowed.mockResolvedValue(new Set<number>([10]));
+  mockItemCount.mockResolvedValue([
+    { id: 10, count: 5 },
+    { id: 11, count: 2 },
+  ]);
+});
+
+describe('GET /api/v1/blocks/collections', () => {
+  it('405 for a non-GET method', async () => {
+    const { req, res } = createMocks({ method: 'POST' });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(405);
+  });
+
+  it('401 when blockClaims is absent', async () => {
+    claimsBox.claims = undefined;
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(401);
+  });
+
+  it('403 for an anonymous token (sub=anon)', async () => {
+    claimsBox.claims = fakeClaims({ sub: 'anon' as never });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+  });
+
+  it('403 for a malformed subject claim', async () => {
+    claimsBox.claims = fakeClaims({ sub: 'garbage' as never });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+  });
+
+  it('429 when the per-instance rate limit trips', async () => {
+    mockRate.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 7 });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(429);
+    expect(res._headers()['Retry-After']).toBe('7');
+  });
+
+  it('mode=public: maps collections, applies itemCount + followed + maturity drop', async () => {
+    // id 10 (nsfw 1, followed) kept, id 11 (nsfw 1) kept, id 12 (nsfw 8 > ceiling 3) dropped.
+    mockGetAll.mockResolvedValueOnce([
+      {
+        id: 10,
+        name: 'A',
+        description: 'desc A',
+        read: 'Public',
+        nsfwLevel: 1,
+        userId: 100,
+        user: { id: 100, username: 'alice' },
+        image: { url: 'img10', type: 'image' },
+      },
+      {
+        id: 11,
+        name: 'B',
+        description: null,
+        read: 'Private',
+        nsfwLevel: 1,
+        userId: 101,
+        user: { id: 101, username: 'bob' },
+        image: null,
+      },
+      {
+        id: 12,
+        name: 'Mature',
+        description: null,
+        read: 'Public',
+        nsfwLevel: 8,
+        userId: 102,
+        user: { id: 102, username: 'carol' },
+        image: { url: 'img12', type: 'image' },
+      },
+    ]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    const body = res._json() as any;
+    // The mature (nsfw 8) collection is dropped by the ceiling filter.
+    expect(body.items).toHaveLength(2);
+    expect(body.items[0]).toEqual({
+      id: 10,
+      name: 'A',
+      description: 'desc A',
+      coverImageUrl: 'edge:img10',
+      itemCount: 5,
+      curator: { userId: 100, username: 'alice' },
+      isPublic: true,
+      followed: true,
+    });
+    expect(body.items[1]).toMatchObject({
+      id: 11,
+      coverImageUrl: null,
+      isPublic: false,
+      followed: false,
+      itemCount: 2,
+    });
+    // Public discovery pins privacy to Public.
+    expect(mockGetAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ privacy: ['Public'] }),
+        user: expect.objectContaining({ id: 42 }),
+      })
+    );
+  });
+
+  it('mode=public: derives nextCursor when more than `limit` rows return', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      { id: 10, name: 'A', description: null, read: 'Public', nsfwLevel: 0, userId: 1, user: { id: 1, username: 'a' }, image: null },
+      { id: 9, name: 'B', description: null, read: 'Public', nsfwLevel: 0, userId: 1, user: { id: 1, username: 'a' }, image: null },
+    ]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '1' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items).toHaveLength(1);
+    expect(body.nextCursor).toBe(10);
+  });
+
+  it('mode=mine: keyed on the token subject, in-memory name filter + id-DESC keyset', async () => {
+    mockUserCollections.mockResolvedValueOnce([
+      { id: 20, name: 'My Cats', description: 'meow', read: 'Private', userId: 42, image: { url: 'c20', type: 'image' } },
+      { id: 21, name: 'Dogs', description: null, read: 'Public', userId: 42, image: null },
+      { id: 22, name: 'More Cats', description: null, read: 'Private', userId: 42, image: null },
+    ]);
+    mockItemCount.mockResolvedValueOnce([{ id: 22, count: 3 }, { id: 20, count: 1 }]);
+    mockFollowed.mockResolvedValueOnce(new Set<number>());
+    const { req, res } = createMocks({ query: { mode: 'mine', query: 'cat', limit: '24' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    const body = res._json() as any;
+    // Only the two "cat" collections, id DESC.
+    expect(body.items.map((i: any) => i.id)).toEqual([22, 20]);
+    expect(mockUserCollections).toHaveBeenCalledWith(
+      expect.objectContaining({ input: expect.objectContaining({ userId: 42 }) })
+    );
+  });
+
+  it('404 when the token subject cannot be hydrated', async () => {
+    mockHydrate.mockResolvedValueOnce(null);
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(404);
+  });
+});

--- a/src/tests/api/v1/blocks/collections-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/collections-endpoint.test.ts
@@ -236,7 +236,7 @@ describe('GET /api/v1/blocks/collections', () => {
     );
   });
 
-  it('mode=public: derives nextCursor when more than `limit` rows return', async () => {
+  it('mode=public: nextCursor is the first UNCONSUMED row (clean inclusive resume, no dup)', async () => {
     mockGetAll.mockResolvedValueOnce([
       { id: 10, name: 'A', description: null, read: 'Public', nsfwLevel: 0, userId: 1, user: { id: 1, username: 'a' }, image: null },
       { id: 9, name: 'B', description: null, read: 'Public', nsfwLevel: 0, userId: 1, user: { id: 1, username: 'a' }, image: null },
@@ -245,7 +245,47 @@ describe('GET /api/v1/blocks/collections', () => {
     await handler(req as never, res as never);
     const body = res._json() as any;
     expect(body.items).toHaveLength(1);
-    expect(body.nextCursor).toBe(10);
+    expect(body.items[0].id).toBe(10);
+    // Page shows [10]; the next page resumes INCLUSIVELY at the first unconsumed
+    // row (9), never re-showing 10. Over-fetches (limit*4+1) in one query.
+    expect(body.nextCursor).toBe(9);
+    expect(mockGetAll).toHaveBeenCalledWith(
+      expect.objectContaining({ input: expect.objectContaining({ limit: 1 * 4 + 1 }) })
+    );
+  });
+
+  it('mode=public: a maturity-clamped page STILL FILLS to `limit` and advances the cursor (no early termination)', async () => {
+    // r9 (nsfw 8) is over the ceiling (3) → dropped by the clamp. The page must
+    // still fill 2 VISIBLE items and set nextCursor past the last consumed row, so
+    // later collections stay reachable (the pre-fix bug terminated pagination when
+    // the clamp under-filled the sliced page).
+    mockGetAll.mockResolvedValueOnce([
+      { id: 10, name: 'A', description: null, read: 'Public', nsfwLevel: 1, userId: 1, user: { id: 1, username: 'a' }, image: null },
+      { id: 9, name: 'Mature', description: null, read: 'Public', nsfwLevel: 8, userId: 1, user: { id: 1, username: 'a' }, image: null },
+      { id: 8, name: 'B', description: null, read: 'Public', nsfwLevel: 1, userId: 1, user: { id: 1, username: 'a' }, image: null },
+      { id: 7, name: 'C', description: null, read: 'Public', nsfwLevel: 1, userId: 1, user: { id: 1, username: 'a' }, image: null },
+      { id: 6, name: 'D', description: null, read: 'Public', nsfwLevel: 1, userId: 1, user: { id: 1, username: 'a' }, image: null },
+    ]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '2' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    // Page filled with the 2 visible collections (10, 8) — the mature 9 dropped.
+    expect(body.items.map((i: any) => i.id)).toEqual([10, 8]);
+    // Cursor advances to the first unconsumed row (7), NOT terminated early.
+    expect(body.nextCursor).toBe(7);
+  });
+
+  it('mode=public: exhausted source (fewer than the over-fetch) → no nextCursor', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      { id: 10, name: 'A', description: null, read: 'Public', nsfwLevel: 1, userId: 1, user: { id: 1, username: 'a' }, image: null },
+      { id: 9, name: 'Mature', description: null, read: 'Public', nsfwLevel: 8, userId: 1, user: { id: 1, username: 'a' }, image: null },
+      { id: 8, name: 'B', description: null, read: 'Public', nsfwLevel: 1, userId: 1, user: { id: 1, username: 'a' }, image: null },
+    ]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '2' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items.map((i: any) => i.id)).toEqual([10, 8]);
+    expect(body.nextCursor).toBeUndefined();
   });
 
   it('mode=mine: keyed on the token subject, in-memory name filter + id-DESC keyset', async () => {

--- a/src/tests/api/v1/blocks/collections-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/collections-endpoint.test.ts
@@ -288,7 +288,11 @@ describe('GET /api/v1/blocks/collections', () => {
     expect(body.nextCursor).toBeUndefined();
   });
 
-  it('mode=mine: keyed on the token subject, in-memory name filter + id-DESC keyset', async () => {
+  it('mode=mine: keyed on the token subject, in-memory name filter + id-DESC keyset (with read:private)', async () => {
+    // The private cats are only visible because this token ALSO carries read:private.
+    claimsBox.claims = fakeClaims({
+      scopes: ['collections:read:self', 'collections:read:private'],
+    });
     mockUserCollections.mockResolvedValueOnce([
       { id: 20, name: 'My Cats', description: 'meow', read: 'Private', userId: 42, image: { url: 'c20', type: 'image' } },
       { id: 21, name: 'Dogs', description: null, read: 'Public', userId: 42, image: null },
@@ -305,6 +309,42 @@ describe('GET /api/v1/blocks/collections', () => {
     expect(mockUserCollections).toHaveBeenCalledWith(
       expect.objectContaining({ input: expect.objectContaining({ userId: 42 }) })
     );
+  });
+
+  it('mode=mine WITHOUT read:private: OMITS the subject\'s non-public collections', async () => {
+    // Default claims carry only collections:read:self → private/unlisted are hidden.
+    mockUserCollections.mockResolvedValueOnce([
+      { id: 20, name: 'Secret', description: null, read: 'Private', userId: 42, image: null },
+      { id: 21, name: 'Public Playlist', description: null, read: 'Public', userId: 42, image: null },
+      { id: 22, name: 'Unlisted', description: null, read: 'Unlisted', userId: 42, image: null },
+    ]);
+    mockItemCount.mockResolvedValueOnce([{ id: 21, count: 1 }]);
+    mockFollowed.mockResolvedValueOnce(new Set<number>());
+    const { req, res } = createMocks({ query: { mode: 'mine', limit: '24' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    const body = res._json() as any;
+    // Only the PUBLIC collection is returned; Private + Unlisted are omitted.
+    expect(body.items.map((i: any) => i.id)).toEqual([21]);
+  });
+
+  it('mode=mine WITH read:private: INCLUDES the subject\'s non-public collections', async () => {
+    claimsBox.claims = fakeClaims({
+      scopes: ['collections:read:self', 'collections:read:private'],
+    });
+    mockUserCollections.mockResolvedValueOnce([
+      { id: 20, name: 'Secret', description: null, read: 'Private', userId: 42, image: null },
+      { id: 21, name: 'Public Playlist', description: null, read: 'Public', userId: 42, image: null },
+      { id: 22, name: 'Unlisted', description: null, read: 'Unlisted', userId: 42, image: null },
+    ]);
+    mockItemCount.mockResolvedValueOnce([]);
+    mockFollowed.mockResolvedValueOnce(new Set<number>());
+    const { req, res } = createMocks({ query: { mode: 'mine', limit: '24' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    const body = res._json() as any;
+    // All three (id DESC) — the read:private scope unlocks the non-public ones.
+    expect(body.items.map((i: any) => i.id)).toEqual([22, 21, 20]);
   });
 
   it('404 when the token subject cannot be hydrated', async () => {

--- a/src/tests/api/v1/blocks/shared-storage-increment-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/shared-storage-increment-endpoint.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * Handler-level coverage for POST /api/v1/blocks/shared-storage/increment. Authz
+ * (scope/revoked/anon) is in collections-tip-authz.test.ts; the isolation +
+ * min-trust gate live in apps-shared.counters.test.ts. This exercises the REST
+ * wrapper: method/body guards, the bearer passthrough, and TRPCError→HTTP mapping
+ * (sub-trust FORBIDDEN → 403, rate-limit → 429).
+ */
+
+function createMocks({
+  method = 'POST',
+  body = {},
+  auth = 'Bearer tok',
+}: { method?: string; body?: unknown; auth?: string } = {}) {
+  const req = {
+    method,
+    body,
+    query: {},
+    headers: { authorization: auth },
+    socket: { remoteAddress: '203.0.113.7' },
+  } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader() {},
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const { mockIncrement } = vi.hoisted(() => ({ mockIncrement: vi.fn() }));
+vi.mock('~/server/routers/apps-shared.router', () => ({
+  incrementSharedCounter: mockIncrement,
+  // identity — the endpoint's zod schema already bounds the key
+  assertValidCounterKey: (k: string) => k,
+}));
+
+import handler from '~/pages/api/v1/blocks/shared-storage/increment';
+
+function fakeClaims(): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'j',
+    blockId: 'b',
+    appId: 'a',
+    appBlockId: 'apb',
+    blockInstanceId: 'bki',
+    ctx: {},
+    scopes: ['apps:storage:shared:write'],
+  } as BlockTokenClaims;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockIncrement.mockResolvedValue({ key: 'playcount:7', count: 4 });
+});
+
+describe('POST /api/v1/blocks/shared-storage/increment', () => {
+  it('405 for a non-POST method', async () => {
+    const { req, res } = createMocks({ method: 'GET' });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(405);
+  });
+
+  it('401 when blockClaims is absent', async () => {
+    claimsBox.claims = undefined;
+    const { req, res } = createMocks({ body: { key: 'playcount:7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(401);
+  });
+
+  it('400 for a missing/invalid key', async () => {
+    const { req, res } = createMocks({ body: {} });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    expect(mockIncrement).not.toHaveBeenCalled();
+  });
+
+  it('400 for an oversized key (>64)', async () => {
+    const { req, res } = createMocks({ body: { key: 'x'.repeat(65) } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+  });
+
+  it('200: increments and returns { key, count }, passing the bearer through', async () => {
+    const { req, res } = createMocks({ body: { key: 'playcount:7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual({ key: 'playcount:7', count: 4 });
+    expect(mockIncrement).toHaveBeenCalledWith('tok', 'playcount:7');
+  });
+
+  it('maps a sub-trust FORBIDDEN → 403 (min-trust gate; app treats increment as best-effort)', async () => {
+    mockIncrement.mockRejectedValueOnce(
+      new TRPCError({ code: 'FORBIDDEN', message: 'account too new' })
+    );
+    const { req, res } = createMocks({ body: { key: 'playcount:7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+  });
+
+  it('maps a rate-limit TOO_MANY_REQUESTS → 429', async () => {
+    mockIncrement.mockRejectedValueOnce(
+      new TRPCError({ code: 'TOO_MANY_REQUESTS', message: 'slow down' })
+    );
+    const { req, res } = createMocks({ body: { key: 'playcount:7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(429);
+  });
+});

--- a/src/tests/api/v1/blocks/shared-storage-top-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/shared-storage-top-endpoint.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * Handler-level coverage for GET /api/v1/blocks/shared-storage/top. Authz is in
+ * collections-tip-authz.test.ts; ordering/prefix/isolation live in
+ * apps-shared.counters.test.ts. This exercises the REST wrapper: method guard,
+ * the query bounds (limit), the bearer passthrough, and the response shape.
+ */
+
+function createMocks({
+  method = 'GET',
+  query = {},
+}: { method?: string; query?: Record<string, unknown> } = {}) {
+  const req = {
+    method,
+    query,
+    headers: { authorization: 'Bearer tok' },
+    socket: { remoteAddress: '203.0.113.7' },
+  } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader() {},
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const { mockTop } = vi.hoisted(() => ({ mockTop: vi.fn() }));
+vi.mock('~/server/routers/apps-shared.router', () => ({ getTopSharedCounters: mockTop }));
+
+import handler from '~/pages/api/v1/blocks/shared-storage/top';
+
+function fakeClaims(): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'j',
+    blockId: 'b',
+    appId: 'a',
+    appBlockId: 'apb',
+    blockInstanceId: 'bki',
+    ctx: {},
+    scopes: ['apps:storage:shared:read'],
+  } as BlockTokenClaims;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockTop.mockResolvedValue([
+    { key: 'playcount:9', count: 42 },
+    { key: 'playcount:3', count: 7 },
+  ]);
+});
+
+describe('GET /api/v1/blocks/shared-storage/top', () => {
+  it('405 for a non-GET method', async () => {
+    const { req, res } = createMocks({ method: 'POST' });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(405);
+  });
+
+  it('401 when blockClaims is absent', async () => {
+    claimsBox.claims = undefined;
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(401);
+  });
+
+  it('200: returns the top list, passing prefix + limit through', async () => {
+    const { req, res } = createMocks({ query: { prefix: 'playcount:', limit: '10' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual([
+      { key: 'playcount:9', count: 42 },
+      { key: 'playcount:3', count: 7 },
+    ]);
+    expect(mockTop).toHaveBeenCalledWith('tok', 'playcount:', 10);
+  });
+
+  it('defaults prefix="" and limit=20 when omitted', async () => {
+    const { req, res } = createMocks({ query: {} });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(mockTop).toHaveBeenCalledWith('tok', '', 20);
+  });
+
+  it('400 for an over-max limit (>100) — bounded', async () => {
+    const { req, res } = createMocks({ query: { limit: '1000' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    expect(mockTop).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/api/v1/blocks/tip-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tip-endpoint.test.ts
@@ -61,10 +61,12 @@ vi.mock('~/server/middleware/block-scope.middleware', () => ({
 }));
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
 
-const { mockTip, mockHydrate, mockRate } = vi.hoisted(() => ({
+const { mockTip, mockHydrate, mockRate, mockReserve, mockRefund } = vi.hoisted(() => ({
   mockTip: vi.fn(),
   mockHydrate: vi.fn(),
   mockRate: vi.fn(),
+  mockReserve: vi.fn(),
+  mockRefund: vi.fn(),
 }));
 
 vi.mock('~/server/controllers/buzz.controller', () => ({
@@ -75,7 +77,13 @@ vi.mock('~/server/clickhouse/client', () => ({ Tracker: class {} }));
 vi.mock('~/server/services/blocks/block-collections.service', () => ({
   hydrateBlockSubject: mockHydrate,
 }));
-vi.mock('~/server/utils/block-tip-rate-limit', () => ({ checkBlockTipRateLimit: mockRate }));
+vi.mock('~/server/utils/block-tip-rate-limit', () => ({
+  checkBlockTipRateLimit: mockRate,
+  reserveBlockTipSpend: mockReserve,
+  refundBlockTipSpend: mockRefund,
+  BLOCK_TIP_MAX_PER_TIP: 5_000,
+  BLOCK_TIP_CAP_PER_DAY: 25_000,
+}));
 
 import handler from '~/pages/api/v1/blocks/tip';
 
@@ -103,6 +111,9 @@ beforeEach(() => {
   mockRate.mockResolvedValue({ allowed: true });
   mockHydrate.mockResolvedValue({ id: 42, username: 'mod', bannedAt: null, muted: false });
   mockTip.mockResolvedValue([{ transactionId: 't1' }]);
+  // Default: reservation well under the daily cap.
+  mockReserve.mockResolvedValue({ total: 25, key: 'system:blocks:tip-cap:42:2026-07-13' });
+  mockRefund.mockResolvedValue(undefined);
 });
 
 describe('POST /api/v1/blocks/tip', () => {
@@ -132,13 +143,43 @@ describe('POST /api/v1/blocks/tip', () => {
     expect(res._status()).toBe(400);
   });
 
-  it('400 for a non-positive / over-max amount', async () => {
+  it('400 for a non-positive amount', async () => {
     const { req, res } = createMocks({ body: { toUserId: 5, amount: 0 } });
     await handler(req as never, res as never);
     expect(res._status()).toBe(400);
-    const over = createMocks({ body: { toUserId: 5, amount: 1_000_000 } });
-    await handler(over.req as never, over.res as never);
-    expect(over.res._status()).toBe(400);
+  });
+
+  it('400 for an amount over the per-tip cap (BLOCK_TIP_MAX_PER_TIP=5000) — no reservation, no tip', async () => {
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 5_001 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    // Rejected by the schema bound before any reserve / money move.
+    expect(mockReserve).not.toHaveBeenCalled();
+    expect(mockTip).not.toHaveBeenCalled();
+  });
+
+  it('accepts an amount exactly at the per-tip cap (5000)', async () => {
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 5_000 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+  });
+
+  it('400 when the per-user DAILY tip cap is exceeded — reservation refunded, tip NOT sent', async () => {
+    mockReserve.mockResolvedValueOnce({ total: 25_001, key: 'k' }); // just over BLOCK_TIP_CAP_PER_DAY
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 100 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    expect((res._json() as any).error).toMatch(/[Dd]aily tip limit/);
+    expect(mockRefund).toHaveBeenCalledWith('k', 100); // over-cap reservation refunded
+    expect(mockTip).not.toHaveBeenCalled();
+  });
+
+  it('503 (fail-closed) when the daily-cap reservation redis call throws', async () => {
+    mockReserve.mockRejectedValueOnce(new Error('redis down'));
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 100 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(503);
+    expect(mockTip).not.toHaveBeenCalled();
   });
 
   it('400 when entityType is supplied without entityId', async () => {
@@ -206,6 +247,9 @@ describe('POST /api/v1/blocks/tip', () => {
     expect(res._status()).toBe(400);
     expect((res._json() as any).ok).toBe(false);
     expect((res._json() as any).error).toMatch(/funds/);
+    // A failed tip must REFUND the daily-cap reservation (a failed attempt can't
+    // burn the user's cap).
+    expect(mockRefund).toHaveBeenCalledWith('system:blocks:tip-cap:42:2026-07-13', 999);
   });
 
   it('maps an unexpected non-TRPC error → 500', async () => {

--- a/src/tests/api/v1/blocks/tip-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tip-endpoint.test.ts
@@ -61,17 +61,19 @@ vi.mock('~/server/middleware/block-scope.middleware', () => ({
 }));
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
 
-const { mockTip, mockHydrate, mockRate, mockReserve, mockRefund } = vi.hoisted(() => ({
+const { mockTip, mockHydrate, mockRate, mockReserve, mockRefund, mockUserFind } = vi.hoisted(() => ({
   mockTip: vi.fn(),
   mockHydrate: vi.fn(),
   mockRate: vi.fn(),
   mockReserve: vi.fn(),
   mockRefund: vi.fn(),
+  mockUserFind: vi.fn(),
 }));
 
 vi.mock('~/server/controllers/buzz.controller', () => ({
   createBuzzTipTransactionHandler: mockTip,
 }));
+vi.mock('~/server/db/client', () => ({ dbRead: { user: { findUnique: mockUserFind } } }));
 // Tracker is instantiated for the fabricated ctx — a no-op class is enough.
 vi.mock('~/server/clickhouse/client', () => ({ Tracker: class {} }));
 vi.mock('~/server/services/blocks/block-collections.service', () => ({
@@ -114,6 +116,8 @@ beforeEach(() => {
   // Default: reservation well under the daily cap.
   mockReserve.mockResolvedValue({ total: 25, key: 'system:blocks:tip-cap:42:2026-07-13' });
   mockRefund.mockResolvedValue(undefined);
+  // Default: the recipient exists and is not deleted.
+  mockUserFind.mockResolvedValue({ id: 5, deletedAt: null });
 });
 
 describe('POST /api/v1/blocks/tip', () => {
@@ -196,6 +200,24 @@ describe('POST /api/v1/blocks/tip', () => {
     expect(mockTip).not.toHaveBeenCalled();
   });
 
+  it('400 when the recipient does not exist — no reservation, no tip', async () => {
+    mockUserFind.mockResolvedValueOnce(null);
+    const { req, res } = createMocks({ body: { toUserId: 999, amount: 10 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    expect((res._json() as any).error).toMatch(/Recipient not found/);
+    expect(mockReserve).not.toHaveBeenCalled();
+    expect(mockTip).not.toHaveBeenCalled();
+  });
+
+  it('400 when the recipient is soft-deleted', async () => {
+    mockUserFind.mockResolvedValueOnce({ id: 5, deletedAt: new Date() });
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 10 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    expect(mockTip).not.toHaveBeenCalled();
+  });
+
   it('429 when the per-instance tip rate limit trips', async () => {
     mockRate.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 30 });
     const { req, res } = createMocks({ body: { toUserId: 5, amount: 10 } });
@@ -247,9 +269,22 @@ describe('POST /api/v1/blocks/tip', () => {
     expect(res._status()).toBe(400);
     expect((res._json() as any).ok).toBe(false);
     expect((res._json() as any).error).toMatch(/funds/);
-    // A failed tip must REFUND the daily-cap reservation (a failed attempt can't
-    // burn the user's cap).
+    // A PRE-money failure (4xx) must REFUND the daily-cap reservation (a failed
+    // attempt can't burn the user's cap).
     expect(mockRefund).toHaveBeenCalledWith('system:blocks:tip-cap:42:2026-07-13', 999);
+  });
+
+  it('does NOT refund on a POST-money failure (5xx) — the reservation must stand (cap-bypass guard)', async () => {
+    // A 5xx from the tip handler may originate AFTER createBuzzTransactionMany moved
+    // Buzz (upsertBuzzTip / notification / metric). Refunding it would let the daily
+    // total under-count → drain past the ceiling. So a 5xx keeps the reservation.
+    mockTip.mockRejectedValueOnce(
+      new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'post-money boom' })
+    );
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 100 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(500);
+    expect(mockRefund).not.toHaveBeenCalled();
   });
 
   it('maps an unexpected non-TRPC error → 500', async () => {

--- a/src/tests/api/v1/blocks/tip-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tip-endpoint.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * Handler-level coverage for POST /api/v1/blocks/tip. Authz is in
+ * collections-tip-authz.test.ts; this exercises the input guards (self-tip,
+ * amount bounds, entity pairing), the per-instance rate limit, banned/muted
+ * gates, the reuse of the REAL money flow (createBuzzTipTransactionHandler,
+ * self-bound sender), and TRPCError→HTTP mapping (insufficient funds → 400).
+ */
+
+function createMocks({
+  method = 'POST',
+  body = {},
+}: { method?: string; body?: unknown } = {}) {
+  const req = { method, body, query: {}, headers: {}, socket: { remoteAddress: '203.0.113.7' } } as unknown as Record<
+    string,
+    unknown
+  >;
+  let statusCode = 200;
+  let payload: unknown;
+  const headers: Record<string, string> = {};
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+    _headers: () => headers,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+class ForbiddenError extends Error {
+  readonly status = 403 as const;
+}
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+  parseSubjectUserId: (sub: string): number | null => {
+    if (sub === 'anon') return null;
+    if (!/^user:\d+$/.test(sub)) throw new ForbiddenError('bad');
+    return Number.parseInt(sub.slice('user:'.length), 10);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const { mockTip, mockHydrate, mockRate } = vi.hoisted(() => ({
+  mockTip: vi.fn(),
+  mockHydrate: vi.fn(),
+  mockRate: vi.fn(),
+}));
+
+vi.mock('~/server/controllers/buzz.controller', () => ({
+  createBuzzTipTransactionHandler: mockTip,
+}));
+// Tracker is instantiated for the fabricated ctx — a no-op class is enough.
+vi.mock('~/server/clickhouse/client', () => ({ Tracker: class {} }));
+vi.mock('~/server/services/blocks/block-collections.service', () => ({
+  hydrateBlockSubject: mockHydrate,
+}));
+vi.mock('~/server/utils/block-tip-rate-limit', () => ({ checkBlockTipRateLimit: mockRate }));
+
+import handler from '~/pages/api/v1/blocks/tip';
+
+function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'j',
+    blockId: 'b',
+    appId: 'a',
+    appBlockId: 'apb',
+    blockInstanceId: 'bki',
+    ctx: {},
+    scopes: ['social:tip:self'],
+    ...over,
+  } as BlockTokenClaims;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockRate.mockResolvedValue({ allowed: true });
+  mockHydrate.mockResolvedValue({ id: 42, username: 'mod', bannedAt: null, muted: false });
+  mockTip.mockResolvedValue([{ transactionId: 't1' }]);
+});
+
+describe('POST /api/v1/blocks/tip', () => {
+  it('405 for a non-POST method', async () => {
+    const { req, res } = createMocks({ method: 'GET' });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(405);
+  });
+
+  it('401 when blockClaims is absent', async () => {
+    claimsBox.claims = undefined;
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 10 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(401);
+  });
+
+  it('403 for an anonymous token', async () => {
+    claimsBox.claims = fakeClaims({ sub: 'anon' as never });
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 10 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+  });
+
+  it('400 for a missing/invalid body', async () => {
+    const { req, res } = createMocks({ body: { toUserId: 5 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+  });
+
+  it('400 for a non-positive / over-max amount', async () => {
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 0 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    const over = createMocks({ body: { toUserId: 5, amount: 1_000_000 } });
+    await handler(over.req as never, over.res as never);
+    expect(over.res._status()).toBe(400);
+  });
+
+  it('400 when entityType is supplied without entityId', async () => {
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 10, entityType: 'Image' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    expect(mockTip).not.toHaveBeenCalled();
+  });
+
+  it('400 for a self-tip (toUserId === subject)', async () => {
+    const { req, res } = createMocks({ body: { toUserId: 42, amount: 10 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    expect(mockTip).not.toHaveBeenCalled();
+  });
+
+  it('429 when the per-instance tip rate limit trips', async () => {
+    mockRate.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 30 });
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 10 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(429);
+    expect(res._headers()['Retry-After']).toBe('30');
+    expect(mockTip).not.toHaveBeenCalled();
+  });
+
+  it('403 when the subject is banned', async () => {
+    mockHydrate.mockResolvedValueOnce({ id: 42, bannedAt: new Date(), muted: false });
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 10 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+    expect(mockTip).not.toHaveBeenCalled();
+  });
+
+  it('200: reuses createBuzzTipTransactionHandler with a self-bound sender', async () => {
+    const { req, res } = createMocks({
+      body: { toUserId: 5, amount: 25, entityType: 'Image', entityId: 99 },
+    });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual({
+      ok: true,
+      tip: { toUserId: 5, amount: 25, entityType: 'Image', entityId: 99 },
+    });
+    expect(mockTip).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: {
+          toAccountId: 5,
+          amount: 25,
+          fromAccountType: 'yellow',
+          toAccountType: 'yellow',
+          entityType: 'Image',
+          entityId: 99,
+        },
+        ctx: expect.objectContaining({ user: expect.objectContaining({ id: 42 }) }),
+      })
+    );
+  });
+
+  it('surfaces insufficient balance as a clean 400 (not a 500)', async () => {
+    mockTip.mockRejectedValueOnce(
+      new TRPCError({ code: 'BAD_REQUEST', message: "you don't have enough funds" })
+    );
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 999 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    expect((res._json() as any).ok).toBe(false);
+    expect((res._json() as any).error).toMatch(/funds/);
+  });
+
+  it('maps an unexpected non-TRPC error → 500', async () => {
+    mockTip.mockRejectedValueOnce(new Error('boom'));
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 10 } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary

App Blocks platform surface so a page-app can **read/discover collections**, **follow (bookmark)**, **tip users (bounded)**, **read its viewer's Buzz balance**, and keep **shared play-counts** — all via block tokens. Reuses the existing collection / buzz / shared-storage services; no business logic is reimplemented.

## Three new block scopes (collections read is split by privacy)

All `SKIP_OAUTH_CHECK` (no OAuth bit) — the real gate is server-side and per-op, mirroring `apps:storage:*`. Self-scopes (non-anon subject enforced in the middleware):

- **`collections:read:self`** — own **PUBLIC** collections + any **PUBLIC** collection (discover). Public data → **consent-exempt** (always mints). Items maturity-clamped to the token ceiling.
- **`collections:read:private`** — the subject's **OWN PRIVATE** collections. **Consent-GATED** (deliberately NOT exempt): reading a user's private collections is sensitive, so it flows through `partitionByConsent`'s gated branch — the host surfaces `needs_consent`, the user grants it, and only then does a token carry it.
- **`collections:write:self`** — follow/unfollow (bookmark), self-bound to the token subject. Consent-exempt.

The **read split** ("own public exempt, own private consented") is the deliberate contrast that proves consent works: `read:self` always mints; `read:private` mints only after the user grants it. Added in lockstep to the scope registry, the canonical `app-block/v1.json` `scopes.items.enum` (drift-guard test), the UI scope descriptions, and the block-scope middleware. Only the two non-sensitive scopes are in `CONSENT_EXEMPT_SCOPES` (the #3090 fix — exempt scopes flow through the mint unconditionally so they actually reach the token); `read:private` is intentionally excluded so it must be consented.

## 🔴 Security change — bounded tipping for pages (relaxes a W10 rule)

`PAGE_FORBIDDEN_SCOPES` is now **empty**. `social:tip:self` + `buzz:read:self` previously could not be minted for a full-page (entity=none) app. They are now page-safe because tipping is **bounded**, exactly like generation spend:

- **Per-tip cap** `BLOCK_TIP_MAX_PER_TIP = 5000` (schema hard bound → over-per-tip = clean 400).
- **Per-user daily cap** `BLOCK_TIP_CAP_PER_DAY = 25000` — a per-user (aggregate across all blocks) UTC-day counter with an atomic **reserve-and-refund** (a failed tip refunds; a redis error fails **closed** with 503). This is the analogue of `BLOCK_BUZZ_CAP_PER_DAY`.
- Tipping is additionally **self-bound** to the token subject and **rate-limited per instance**.

The previously-passing page-mint tests that asserted `403` for these scopes are **inverted** to assert the token now mints and carries them. This deliberately weakens the W10 "money scopes forbidden on pages" belt — please review the caps as the load-bearing safety.

## Endpoints (all `withBlockScope`-guarded)

| Method | Path | Scope | Notes |
|---|---|---|---|
| GET | `/api/v1/blocks/collections` | `collections:read:self` | `?mode=public\|mine`; `mine` includes own **private** only if `collections:read:private` is also on the token |
| GET | `/api/v1/blocks/collections/[id]` | `collections:read:self` | media items; a **private** collection returns only when subject owns it **and** `collections:read:private` is present, else invisible 404 |
| POST | `/api/v1/blocks/collections/[id]/follow` | `collections:write:self` | `{ follow }`, self-bound |
| POST | `/api/v1/blocks/tip` | `social:tip:self` | bounded (per-tip + daily caps); reuses the real tip money-flow |
| GET | `/api/v1/blocks/buzz` | `buzz:read:self` | `{ balance }` (subject-bound) |
| POST | `/api/v1/blocks/shared-storage/increment` | `apps:storage:shared:write` | `{ key }` → `{ key, count }` — app-defined counter |
| GET | `/api/v1/blocks/shared-storage/top` | `apps:storage:shared:read` | `?prefix=&limit=N` → `[{ key, count }]` |

Response shapes:
- **collections**: `{ items: [{ id, name, description, coverImageUrl, itemCount, curator:{userId,username}, isPublic, followed }], nextCursor }`
- **collections/[id]**: `{ collection:{ id, name, description, curator:{userId,username}, isPublic, followed }, items:[{ mediaId, type:'image'|'video', url, width, height, creator:{userId,username}, nsfwLevel }], nextCursor }`
- **follow**: `{ followed }` · **tip**: `{ ok, tip:{ toUserId, amount, entityType, entityId } }` · **buzz**: `{ balance }`
- **shared increment**: `{ key, count }` · **shared top**: `[{ key, count }]`

### Shared play-counts

Reuse the existing shared-storage security: `resolveSharedContext` is exported and gains `increment`/`getTop` ops. Both go through the SAME per-app-schema isolation (`sanitizeAppSlug(claims.blockId)`), approved-block + revocation checks, per-op scope assertion, and the fail-closed Flipt kill-switch. `increment` additionally runs the **min-trust gate** + the shared write-scope + the per-(user,app) vote rate limit (anti-inflation — a sub-trust caller gets 403, which the app treats as best-effort/fire-and-forget). A counter write anchors a tiny `shared_kv` row (value `{}`) to satisfy the `counters` FK, under the app's quota GUC. Money-free.

## Additive service change

Optional case-insensitive `query` name search on `getAllCollections` (+ the discovery schema). Omitted by every existing caller → behaviour-identical when absent.

## Tests

Per-endpoint happy/authz/edge coverage; the schema↔registry drift-guard; the scope-plumbing guard; tip caps (per-tip, daily, refund-on-fail, fail-closed 503); the page-mint inversion (both scopes now mint end-to-end); shared increment (happy / sub-trust 403 / rate-limit / **cross-app isolation**); shared top (ordering / prefix / limit bound); and per-scope authz for every new scope through the real `withBlockScope`. `tsc --noEmit` clean for all changed files; the vitest unit suite for the touched areas is green (incl. the unchanged existing `apps-shared.router` 61-test suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Pre-merge audit fixes (post-review, folded in)

Adversarial audit returned SAFE TO MERGE; these latent issues in the load-bearing cap path were fixed before merge:

1. **Cap-bypass hardening** — `/api/v1/blocks/tip` now refunds the daily-cap reservation **only on a known-pre-money failure** (a 4xx: every guard before `createBuzzTransactionMany` throws `BAD_REQUEST`). A 5xx / non-TRPC throw may originate **after** money moved (`upsertBuzzTip`/notification/metric), so it no longer refunds — a lingering reservation only makes the cap **stricter**, never lets a real spend escape the ceiling. Test proves a post-money 500 does **not** refund.
2. **Direct primitive test** — `block-tip-rate-limit.ts` reserve/refund is now unit-tested against an in-memory redis: accumulation + TTL-on-first-write + lost-TTL self-heal, exact-key/exact-amount refund, **midnight-key straddle** (refund hits the day it reserved), and fail-closed on a redis error.
3. **Recipient existence check** — a missing/soft-deleted `toUserId` → 400 before any rate-limit/cap reservation (the shared handler only checks banned, not existence).
4. **Clamp-safe public pagination** — the maturity clamp no longer runs after slicing (which terminated pagination early and hid later collections). Over-fetches, fills the page with visible rows, and resumes the keyset from the first **unconsumed** row (inclusive cursor → no gap, no dup).

---

## Privacy read split (post-decision, folded in)

Per the "own public exempt, own private consented" decision, the collections read scope is split into `collections:read:self` (own-public + any-public; **consent-exempt**) and the new `collections:read:private` (own-private; **consent-gated**). `mode=mine` returns own-public always and own-private only with `read:private`; `GET /collections/[id]` returns a private collection only when the subject owns it **and** carries `read:private`, else the same invisible 404 (no 403 oracle, no consent-needed leak to a non-owner). A test through the **real** `block-tokens` mint handler proves `read:private` is consent-gated end-to-end (no grant → omitted + `needsConsent`; with grant → carried), contrasted with `read:self` (exempt → always mints).
