### PR TITLE
feat(app-blocks): W13 onsite owner listing controls + Open-live run-page link (P4)

### DIFF
--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -826,6 +826,22 @@ describe('MySubmissionsList — P4 onsite unpublish / republish / history', () =
     await expect.element(page.getByText('Unpublished by you')).toBeInTheDocument();
     expect(page.getByTestId('apps-onsite-history-entry').elements().length).toBeGreaterThanOrEqual(2);
   });
+
+  test('a pristine, never-moderated LIVE app shows NO History button', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={[live()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    // The row rendered (Unpublish is present) — but there's no History affordance.
+    await expect.element(page.getByTestId('apps-onsite-unpublish-live-app')).toBeInTheDocument();
+    expect(page.getByTestId('apps-onsite-history-live-app').elements()).toHaveLength(0);
+  });
+
+  test('a removed/hidden app DOES show a History button', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={[ownerHidden()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await expect.element(page.getByTestId('apps-onsite-history-hidden-app')).toBeInTheDocument();
+  });
 });
 
 describe('MySubmissionsList — P4 surfaced manage links', () => {

--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -28,24 +28,68 @@ const mocks = vi.hoisted(() => ({
   // Spy on the analytics query so we can assert the input (e.g. the floored
   // `from`) every approved row passes — the per-row dedup key depends on it.
   analyticsUseQuery: vi.fn(),
+  // W13 P4 owner controls: record (name, vars) of the owner mutations + the
+  // invalidate, and drive the moderation-history query's items.
+  mutate: vi.fn(),
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  historyItems: [] as Array<{
+    id: string;
+    action: string;
+    reason: string | null;
+    createdAt: Date;
+  }>,
 }));
 
-vi.mock('~/utils/trpc', () => ({
-  trpc: {
-    blocks: {
-      getMyAppAnalytics: {
-        useQuery: (...args: unknown[]) => {
-          mocks.analyticsUseQuery(...args);
-          return { data: mocks.analytics, isLoading: mocks.analyticsLoading };
+const showError = vi.fn();
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: (...a: unknown[]) => showError(...a),
+}));
+
+vi.mock('~/utils/trpc', () => {
+  // A mutation mock: records (name, vars), then drives onSuccess so the invalidate +
+  // notification paths run.
+  const mutation =
+    (name: string) =>
+    (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
+      mutate: (vars: unknown) => {
+        mocks.mutate(name, vars);
+        void opts?.onSuccess?.();
+      },
+      isPending: false,
+    });
+  return {
+    trpc: {
+      useUtils: () => ({
+        blocks: { listMyPublishRequests: { invalidate: mocks.invalidate } },
+      }),
+      blocks: {
+        getMyAppAnalytics: {
+          useQuery: (...args: unknown[]) => {
+            mocks.analyticsUseQuery(...args);
+            return { data: mocks.analytics, isLoading: mocks.analyticsLoading };
+          },
+        },
+        // getMyApps is used only by the (mocked-away) panel; keep a stub so any
+        // accidental call is harmless.
+        getMyApps: { useQuery: () => ({ data: [], isLoading: false }) },
+        getMyAppRepo: { useQuery: () => ({ data: undefined, isLoading: false }) },
+      },
+      appListings: {
+        unpublishOwnListing: { useMutation: mutation('unpublish') },
+        republishOwnListing: { useMutation: mutation('republish') },
+        listMyListingModerationEvents: {
+          useQuery: () => ({
+            data: { items: mocks.historyItems, nextCursor: null },
+            isLoading: false,
+            error: null,
+          }),
         },
       },
-      // getMyApps is used only by the (mocked-away) panel; keep a stub so any
-      // accidental call is harmless.
-      getMyApps: { useQuery: () => ({ data: [], isLoading: false }) },
-      getMyAppRepo: { useQuery: () => ({ data: undefined, isLoading: false }) },
     },
-  },
-}));
+    setTrpcBatchingEnabled: vi.fn(),
+  };
+});
 
 // The real AppAnalyticsPanel pulls in chart.js; replace it with a marker that
 // records the scoped appBlockId it was opened with.
@@ -79,6 +123,13 @@ function makeSubmission(overrides: Partial<Submission>): Submission {
     manifestDiffSummary: { kind: 'update', added: [], removed: [], changed: [] },
     modelInstallCount: 3,
     userSubscriptionCount: 5,
+    // W13 P4 owner-control fields — default to a LIVE page app (backing listing
+    // approved, manifest declares a page). Owner-hidden / mod-removed / model-slot
+    // cases override `listingStatus` / `lastModerationAction` / `hasPage`.
+    appListingId: 'listing-1',
+    listingStatus: 'approved',
+    lastModerationAction: null,
+    hasPage: true,
     ...overrides,
   };
 }
@@ -88,6 +139,10 @@ beforeEach(() => {
   mocks.analyticsLoading = false;
   mocks.panelRenders.mockClear();
   mocks.analyticsUseQuery.mockClear();
+  mocks.mutate.mockClear();
+  mocks.invalidate.mockClear();
+  mocks.historyItems = [];
+  showError.mockClear();
 });
 
 describe('MySubmissionsList', () => {
@@ -629,5 +684,214 @@ describe('MySubmissionsList — UX pass 2: dates, author, first-version, live/Op
     // Approved + currently-published, but deploy failed → no Open live, no "live" badge.
     expect(page.getByRole('link', { name: /open live/i }).elements()).toHaveLength(0);
     expect(page.getByText('live', { exact: true }).elements()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// W13 P4 — ON-SITE owner controls (unpublish / republish / mod-removed / history)
+// + the surfaced manage links + the Open-live run-page branching.
+// ---------------------------------------------------------------------------
+
+/** A LIVE on-site app (approved request + approved backing listing, page app). */
+const live = (over: Partial<Submission> = {}) =>
+  makeSubmission({
+    id: 'a',
+    slug: 'live-app',
+    appBlockId: 'block-a',
+    appListingId: 'l-a',
+    status: 'approved',
+    deployState: 'live',
+    listingStatus: 'approved',
+    lastModerationAction: null,
+    hasPage: true,
+    ...over,
+  });
+
+/** An owner-UNPUBLISHED app: the backing listing is removed, last event = owner-unpublish
+ *  (the publish request stays approved, so it still lives in the Live section). */
+const ownerHidden = () =>
+  makeSubmission({
+    id: 'h',
+    slug: 'hidden-app',
+    appBlockId: 'block-h',
+    appListingId: 'l-h',
+    status: 'approved',
+    deployState: 'live',
+    listingStatus: 'removed',
+    lastModerationAction: 'owner-unpublish',
+    hasPage: true,
+  });
+
+/** A MODERATOR-removed app: backing listing removed, last event = delist. */
+const modRemoved = () =>
+  makeSubmission({
+    id: 'm',
+    slug: 'gone-app',
+    appBlockId: 'block-m',
+    appListingId: 'l-m',
+    status: 'approved',
+    deployState: 'live',
+    listingStatus: 'removed',
+    lastModerationAction: 'delist',
+    hasPage: true,
+  });
+
+describe('MySubmissionsList — P4 onsite owner status badge', () => {
+  test('a LIVE app shows the "live" badge + Unpublish (no Republish / mod-removed)', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={[live()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await expect.element(page.getByText('live', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-onsite-unpublish-live-app')).toBeInTheDocument();
+    expect(page.getByTestId('apps-onsite-republish-live-app').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-onsite-mod-removed-live-app').elements()).toHaveLength(0);
+  });
+
+  test('an OWNER-hidden app shows the "unpublished" badge + Republish (no Unpublish / Open-live)', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={[ownerHidden()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await expect.element(page.getByText('unpublished', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-onsite-republish-hidden-app')).toBeInTheDocument();
+    expect(page.getByTestId('apps-onsite-unpublish-hidden-app').elements()).toHaveLength(0);
+    // Not serving → no Open-live affordance.
+    expect(page.getByTestId('apps-submissions-open-hidden-app').elements()).toHaveLength(0);
+  });
+
+  test('a MOD-removed app shows "removed by a moderator" + NO Republish button (the load-bearing guard)', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={[modRemoved()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    // The overridden status badge.
+    await expect
+      .element(page.getByText('removed by a moderator', { exact: true }))
+      .toBeInTheDocument();
+    // The inline mod-removed marker.
+    await expect.element(page.getByTestId('apps-onsite-mod-removed-gone-app')).toBeInTheDocument();
+    // NEVER a republish/unpublish button on a mod takedown.
+    expect(page.getByTestId('apps-onsite-republish-gone-app').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-onsite-unpublish-gone-app').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-submissions-open-gone-app').elements()).toHaveLength(0);
+  });
+});
+
+describe('MySubmissionsList — P4 onsite unpublish / republish / history', () => {
+  test('Unpublish opens a confirm gate; confirming fires unpublishOwnListing with the listing id', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={[live()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    // The row button opens the modal — it does NOT fire the mutation yet.
+    await page.getByTestId('apps-onsite-unpublish-live-app').click();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+    // Confirming fires the mutation with the backing listing id (no reason).
+    await page.getByTestId('apps-onsite-unpublish-confirm').click();
+    expect(mocks.mutate).toHaveBeenCalledWith('unpublish', {
+      appListingId: 'l-a',
+      reason: undefined,
+    });
+    // On success it invalidates the my-submissions (publish-requests) query.
+    expect(mocks.invalidate).toHaveBeenCalled();
+  });
+
+  test('Republish fires republishOwnListing with the listing id', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={[ownerHidden()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await page.getByTestId('apps-onsite-republish-hidden-app').click();
+    expect(mocks.mutate).toHaveBeenCalledWith('republish', { appListingId: 'l-h' });
+    expect(mocks.invalidate).toHaveBeenCalled();
+  });
+
+  test('the History button opens the moderation timeline (actions + verbatim reasons)', async () => {
+    mocks.historyItems = [
+      {
+        id: 'e2',
+        action: 'delist',
+        reason: 'Reported for policy',
+        createdAt: new Date('2026-02-02T00:00:00Z'),
+      },
+      {
+        id: 'e1',
+        action: 'owner-unpublish',
+        reason: null,
+        createdAt: new Date('2026-02-01T00:00:00Z'),
+      },
+    ];
+    renderWithProviders(
+      <MySubmissionsList submissions={[modRemoved()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await page.getByTestId('apps-onsite-history-gone-app').click();
+    await expect.element(page.getByText('Reported for policy')).toBeInTheDocument();
+    await expect.element(page.getByText('Delisted')).toBeInTheDocument();
+    await expect.element(page.getByText('Unpublished by you')).toBeInTheDocument();
+    expect(page.getByTestId('apps-onsite-history-entry').elements().length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('MySubmissionsList — P4 surfaced manage links', () => {
+  test('a live app links Edit → edit-manifest and Revenue → revenue for the app block', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={[live()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    const edit = page.getByTestId('apps-onsite-edit-live-app');
+    await expect.element(edit).toBeInTheDocument();
+    expect(edit.element().getAttribute('href')).toBe('/apps/block-a/edit-manifest');
+    const revenue = page.getByTestId('apps-onsite-revenue-live-app');
+    await expect.element(revenue).toBeInTheDocument();
+    expect(revenue.element().getAttribute('href')).toBe('/apps/block-a/revenue');
+  });
+
+  test('a MOD-removed app keeps Revenue but drops Edit', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={[modRemoved()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await expect.element(page.getByTestId('apps-onsite-revenue-gone-app')).toBeInTheDocument();
+    expect(page.getByTestId('apps-onsite-edit-gone-app').elements()).toHaveLength(0);
+  });
+});
+
+describe('MySubmissionsList — P4 Open-live run-page branching (graceful, no dead link)', () => {
+  test('a page app the viewer CAN open → /apps/run/<slug> (internal)', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[live({ hasPage: true })]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+        canOpenPage
+      />
+    );
+    const open = page.getByTestId('apps-submissions-open-live-app');
+    await expect.element(open).toBeInTheDocument();
+    expect(open.element().getAttribute('href')).toBe('/apps/run/live-app');
+  });
+
+  test('a page app the viewer CANNOT open (flag dark) → the standalone <slug>.civit.ai origin', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[live({ hasPage: true })]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+        canOpenPage={false}
+      />
+    );
+    const open = page.getByTestId('apps-submissions-open-live-app');
+    await expect.element(open).toBeInTheDocument();
+    expect(open.element().getAttribute('href')).toBe('https://live-app.civit.ai/');
+  });
+
+  test('a model-slot app (no launch page) → informational "Runs on model pages", never a dead standalone link', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[live({ hasPage: false })]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+        canOpenPage
+      />
+    );
+    const open = page.getByTestId('apps-submissions-open-live-app');
+    await expect.element(open).toBeInTheDocument();
+    // Not the standalone origin — it links to the block detail (install lives there).
+    expect(open.element().getAttribute('href')).not.toBe('https://live-app.civit.ai/');
+    await expect.element(page.getByText('Runs on model pages', { exact: false })).toBeInTheDocument();
   });
 });

--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -6,15 +6,32 @@ import {
   IconBox,
   IconCheck,
   IconClock,
+  IconCoin,
   IconExternalLink,
+  IconEye,
+  IconEyeOff,
+  IconHistory,
   IconMessage,
+  IconPencil,
   IconUsers,
   IconX,
 } from '@tabler/icons-react';
 import Link from 'next/link';
 import { Fragment, useMemo, useState, type ReactNode } from 'react';
 import { AppAnalyticsInline } from '~/components/Apps/AppAnalyticsInline';
+import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
 import { isStaleDeploy } from '~/components/Apps/deploy-status';
+import {
+  canOwnerRepublish,
+  canOwnerUnpublish,
+  ownerListingState,
+  ownerStateChip,
+  type OwnerListingState,
+} from '~/components/Apps/offsiteOwnerControls';
+import {
+  OwnerModerationHistoryModal,
+  OwnerUnpublishModal,
+} from '~/components/Apps/ownerListingModals';
 import {
   bucketGroupsByStatus,
   currentlyPublishedVersionId,
@@ -27,6 +44,8 @@ import {
 } from '~/components/Apps/submissionsTable';
 import { StatusSections, SubmissionSearch, VersionToggle } from '~/components/Apps/submissionsTableUi';
 import { formatDate } from '~/utils/date-helpers';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
 
 export type FileSummary = {
   files?: Array<{ path: string; sha256: string; sizeBytes: number }>;
@@ -66,7 +85,41 @@ export type Submission = {
   modelInstallCount: number | null;
   /** Total BlockUserSubscription rows. */
   userSubscriptionCount: number | null;
+  /** W13 P4 owner controls — the backing on-site `AppListing.id` (the target for
+   *  unpublish/republish/history). Null when no listing row exists yet (a pending
+   *  first version, or a pre-W13 backfill gap). */
+  appListingId?: string | null;
+  /** The backing `AppListing`'s TRUE lifecycle status
+   *  (`draft|pending|approved|rejected|removed`) — DISTINCT from `status` (the
+   *  publish-REQUEST status). An owner unpublish flips this to `removed` while the
+   *  request stays `approved`, so it drives the live/hidden/removed owner state. Null
+   *  when there's no backing listing. */
+  listingStatus?: string | null;
+  /** The backing listing's most-recent moderation-event action (populated for a
+   *  `removed` listing) — `owner-unpublish` ⇒ owner-hidden (Republish-eligible),
+   *  anything else (a moderator `delist`/`purge`) ⇒ mod-removed (Republish forbidden). */
+  lastModerationAction?: string | null;
+  /** Whether the backing block's manifest declares a launchable page — drives the
+   *  Open-live → `/apps/run/<slug>` vs standalone-origin vs model-slot branching. */
+  hasPage?: boolean | null;
 };
+
+/** Owner-control handlers threaded from the list down to each latest row. */
+type OnsiteOwnerControls = {
+  onUnpublish: (listingId: string, slug: string) => void;
+  onRepublish: (listingId: string) => void;
+  republishing: boolean;
+  onViewHistory: (listingId: string, slug: string) => void;
+};
+
+/** Derive the owner-control state (live / owner-hidden / mod-removed / inactive) for a
+ *  row from its TRUE backing-listing status + last moderation-event action. */
+function rowOwnerState(s: Submission): OwnerListingState {
+  return ownerListingState({
+    listingStatus: s.listingStatus,
+    lastModerationAction: s.lastModerationAction,
+  });
+}
 
 /** "Month D, YYYY" (e.g. `June 7, 2026`) — the whole-day form used for the
  *  submitted / reviewed timestamps (no hour/minute; those aren't decision-useful
@@ -209,17 +262,29 @@ export function ReviewerNotesButton({
 function StatusCell({
   submission,
   isCurrentlyPublished,
+  ownerState,
 }: {
   submission: Submission;
   isCurrentlyPublished: boolean;
+  /** Owner-facing state; when owner-hidden / mod-removed it OVERRIDES the badge (the
+   *  publish request still reads `approved`, which would misleadingly show "live"). */
+  ownerState: OwnerListingState;
 }) {
   const { status, rejectionReason, approvalNotes } = submission;
   const notes =
     status === 'rejected' ? rejectionReason : status === 'approved' ? approvalNotes : null;
   const variant = status === 'rejected' ? 'rejected' : 'approved';
+  // A removed backing listing (owner-hidden / mod-removed) overrides the deploy/request
+  // badge with the owner-facing state; live/inactive keep the normal badge.
+  const override = ownerStateChip(ownerState);
+  const chip = override ? (
+    <Badge color={override.color}>{override.label}</Badge>
+  ) : (
+    statusBadge(submission, isCurrentlyPublished)
+  );
   return (
     <Stack gap={6} align="flex-start">
-      {statusBadge(submission, isCurrentlyPublished)}
+      {chip}
       {notes && <ReviewerNotesButton notes={notes} variant={variant} />}
     </Stack>
   );
@@ -249,6 +314,8 @@ function OnsiteRow({
   isCurrentlyPublished,
   onWithdraw,
   withdrawing,
+  owner,
+  canOpenPage,
   toggle,
 }: {
   s: Submission;
@@ -256,9 +323,15 @@ function OnsiteRow({
   isCurrentlyPublished: boolean;
   onWithdraw: (id: string) => void;
   withdrawing: boolean;
+  /** Owner-control handlers (wired only on the latest, non-nested row). */
+  owner: OnsiteOwnerControls;
+  /** Mirrors the `appBlocksPages` flag — gates the /apps/run/<slug> Open link. */
+  canOpenPage: boolean;
   toggle?: ReactNode;
 }) {
   const isApproved = s.status === 'approved';
+  // Owner state lives on the latest (non-nested) row only; older versions are history.
+  const ownerState = nested ? ('inactive' as OwnerListingState) : rowOwnerState(s);
   return (
     <>
       <Table.Tr>
@@ -279,7 +352,11 @@ function OnsiteRow({
           <Code>{s.version}</Code>
         </Table.Td>
         <Table.Td>
-          <StatusCell submission={s} isCurrentlyPublished={isCurrentlyPublished} />
+          <StatusCell
+            submission={s}
+            isCurrentlyPublished={isCurrentlyPublished}
+            ownerState={ownerState}
+          />
         </Table.Td>
         <Table.Td>
           <Text size="xs">{formatSubmissionDate(s.submittedAt)}</Text>
@@ -314,6 +391,10 @@ function OnsiteRow({
             isCurrentlyPublished={isCurrentlyPublished}
             onWithdraw={() => onWithdraw(s.id)}
             busy={withdrawing}
+            nested={nested}
+            ownerState={ownerState}
+            owner={owner}
+            canOpenPage={canOpenPage}
           />
         </Table.Td>
       </Table.Tr>
@@ -343,13 +424,38 @@ export function MySubmissionsList({
   submissions,
   onWithdraw,
   withdrawing,
+  canOpenPage = false,
 }: {
   submissions: Submission[];
   onWithdraw: (id: string) => void;
   withdrawing: boolean;
+  /** Mirrors the viewer's `appBlocksPages` flag — an on-site page app only routes to
+   *  the /apps/run/<slug> in-host page when this is true; otherwise the Open-live
+   *  falls back to the standalone origin (never a dead run link). */
+  canOpenPage?: boolean;
 }) {
   const [query, setQuery] = useState('');
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [unpublishTarget, setUnpublishTarget] = useState<{ id: string; slug: string } | null>(null);
+  const [historyTarget, setHistoryTarget] = useState<{ id: string; slug: string } | null>(null);
+
+  const utils = trpc.useUtils();
+  const invalidateSubmissions = () => utils.blocks.listMyPublishRequests.invalidate();
+
+  const republishMutation = trpc.appListings.republishOwnListing.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({ message: 'App republished — it is live again.' });
+      await invalidateSubmissions();
+    },
+    onError: (e) => showErrorNotification({ title: 'Republish failed', error: new Error(e.message) }),
+  });
+
+  const owner: OnsiteOwnerControls = {
+    onUnpublish: (id, slug) => setUnpublishTarget({ id, slug }),
+    onRepublish: (id) => republishMutation.mutate({ appListingId: id }),
+    republishing: republishMutation.isPending,
+    onViewHistory: (id, slug) => setHistoryTarget({ id, slug }),
+  };
 
   // Group by app, apply the text filter, sort newest-first, then partition into
   // status SECTIONS (Live / Pending / Rejected / Withdrawn). Status is now the
@@ -413,6 +519,8 @@ export function MySubmissionsList({
                   isCurrentlyPublished={g.latest.id === publishedId}
                   onWithdraw={onWithdraw}
                   withdrawing={withdrawing}
+                  owner={owner}
+                  canOpenPage={canOpenPage}
                   toggle={
                     g.older.length > 0 ? (
                       <VersionToggle
@@ -434,6 +542,8 @@ export function MySubmissionsList({
                       isCurrentlyPublished={older.id === publishedId}
                       onWithdraw={onWithdraw}
                       withdrawing={withdrawing}
+                      owner={owner}
+                      canOpenPage={canOpenPage}
                     />
                   ))}
               </Fragment>
@@ -460,7 +570,103 @@ export function MySubmissionsList({
           renderTable={renderTable}
         />
       )}
+
+      <OwnerUnpublishModal
+        target={unpublishTarget}
+        onClose={() => setUnpublishTarget(null)}
+        onDone={invalidateSubmissions}
+        testIdPrefix="apps-onsite"
+        variant="offline"
+      />
+      <OwnerModerationHistoryModal
+        target={historyTarget}
+        onClose={() => setHistoryTarget(null)}
+        testIdPrefix="apps-onsite"
+      />
     </Stack>
+  );
+}
+
+/**
+ * The primary "open the running app" affordance for an APPROVED, currently-published,
+ * serving on-site app — graceful, never a dead link. Reuses the shared
+ * {@link getDetailPrimaryAction} matrix (identical to the store detail):
+ *   - page app + canOpenPage → **Open** → `/apps/run/<slug>` (internal in-host page).
+ *   - page app + !canOpenPage → **Open live** → the standalone `<slug>.civit.ai` origin.
+ *   - model-slot app (no page) → informational "Runs on model pages" → the block detail.
+ */
+function OpenLiveAction({
+  submission,
+  canOpenPage,
+}: {
+  submission: Submission;
+  canOpenPage: boolean;
+}) {
+  const action = getDetailPrimaryAction(
+    {
+      slug: submission.slug,
+      kind: 'onsite',
+      kindData: {
+        kind: 'onsite',
+        appBlockId: submission.appBlockId ?? null,
+        hasPage: !!submission.hasPage,
+        // The already-public standalone origin (the pre-P4 hardcoded target).
+        liveUrl: `https://${submission.slug}.civit.ai/`,
+      },
+    },
+    { canOpenPage }
+  );
+  const testId = `apps-submissions-open-${submission.slug}`;
+  if (action.mode === 'open') {
+    return (
+      <Button
+        size="xs"
+        variant="default"
+        component={Link}
+        href={action.href ?? '#'}
+        rightSection={<IconArrowRight size={12} />}
+        data-testid={testId}
+      >
+        {action.label}
+      </Button>
+    );
+  }
+  if (action.mode === 'visit' && action.href) {
+    return (
+      <Button
+        size="xs"
+        variant="default"
+        component="a"
+        href={action.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        rightSection={<IconExternalLink size={12} />}
+        data-testid={testId}
+      >
+        {action.label}
+      </Button>
+    );
+  }
+  // Model-slot / no launchable page → informational; links to the block detail where
+  // the install affordance lives, never a dead standalone link.
+  if (action.href) {
+    return (
+      <Button
+        size="xs"
+        variant="subtle"
+        color="gray"
+        component={Link}
+        href={action.href}
+        data-testid={testId}
+      >
+        {action.label}
+      </Button>
+    );
+  }
+  return (
+    <Text size="xs" c="dimmed" data-testid={testId}>
+      {action.label}
+    </Text>
   );
 }
 
@@ -469,13 +675,22 @@ function SubmissionActions({
   isCurrentlyPublished,
   onWithdraw,
   busy,
+  nested,
+  ownerState,
+  owner,
+  canOpenPage,
 }: {
   submission: Submission;
   isCurrentlyPublished: boolean;
   onWithdraw: () => void;
   busy: boolean;
+  nested: boolean;
+  ownerState: OwnerListingState;
+  owner: OnsiteOwnerControls;
+  canOpenPage: boolean;
 }) {
-  if (submission.status === 'pending') {
+  const s = submission;
+  if (s.status === 'pending') {
     return (
       <Button
         size="xs"
@@ -489,14 +704,35 @@ function SubmissionActions({
       </Button>
     );
   }
-  if (submission.status === 'approved') {
-    // "Open live" belongs ONLY on the currently-published version AND only when
-    // it is actually serving — an older approved version links to nothing live,
-    // and a published version still building / with a failed deploy would link to
-    // a slug that 404s (and disagree with its "deploy failed"/"building" badge).
-    // `null` deployState = legacy/untracked → treated as live (pre-UX-pass behavior).
-    const isLiveNow = submission.deployState === 'live' || submission.deployState == null;
-    if (!isCurrentlyPublished || !isLiveNow) {
+  if (s.status === 'approved') {
+    // A removed backing listing (owner-hidden / mod-removed) is NOT serving — never
+    // offer an Open affordance for it. `null` deployState = legacy/untracked → live.
+    const isRemoved = ownerState === 'owner-hidden' || ownerState === 'mod-removed';
+    const isLiveNow = s.deployState === 'live' || s.deployState == null;
+    const showOpen = isCurrentlyPublished && isLiveNow && !isRemoved;
+
+    // Owner takedown affordances live ONLY on the latest (non-nested) row with a
+    // backing listing id (unpublish/republish/history all target the AppListing).
+    const showOwner = !nested && !!s.appListingId;
+    const listingId = s.appListingId as string;
+    const canUnpublish = showOwner && canOwnerUnpublish(ownerState);
+    const canRepublish = showOwner && canOwnerRepublish(ownerState);
+    const isModRemoved = showOwner && ownerState === 'mod-removed';
+    const canViewHistory = showOwner && ownerState !== 'inactive';
+    // Surface the manage entry points on any live / owner-hidden app (an app the owner
+    // still controls); a mod takedown hides Edit (mirrors the off-site list), Revenue
+    // stays (earnings are historical + viewable regardless of visibility).
+    const canManage = showOwner && s.appBlockId;
+    const showEdit = canManage && ownerState !== 'mod-removed';
+
+    const hasAny =
+      showOpen ||
+      canUnpublish ||
+      canRepublish ||
+      isModRemoved ||
+      canViewHistory ||
+      canManage;
+    if (!hasAny) {
       return (
         <Text size="xs" c="dimmed">
           —
@@ -504,20 +740,79 @@ function SubmissionActions({
       );
     }
     return (
-      <Button
-        size="xs"
-        variant="default"
-        component="a"
-        href={`https://${submission.slug}.civit.ai/`}
-        target="_blank"
-        rel="noopener"
-        rightSection={<IconExternalLink size={12} />}
-      >
-        Open live
-      </Button>
+      <Group gap={6} wrap="nowrap">
+        {showOpen && <OpenLiveAction submission={s} canOpenPage={canOpenPage} />}
+        {canUnpublish && (
+          <Button
+            size="xs"
+            variant="default"
+            color="orange"
+            onClick={() => owner.onUnpublish(listingId, s.slug)}
+            leftSection={<IconEyeOff size={12} />}
+            data-testid={`apps-onsite-unpublish-${s.slug}`}
+          >
+            Unpublish
+          </Button>
+        )}
+        {canRepublish && (
+          <Button
+            size="xs"
+            variant="default"
+            color="green"
+            onClick={() => owner.onRepublish(listingId)}
+            disabled={owner.republishing}
+            loading={owner.republishing}
+            leftSection={<IconEye size={12} />}
+            data-testid={`apps-onsite-republish-${s.slug}`}
+          >
+            Republish
+          </Button>
+        )}
+        {isModRemoved && (
+          <Text size="xs" c="red" data-testid={`apps-onsite-mod-removed-${s.slug}`}>
+            Removed by a moderator
+          </Text>
+        )}
+        {showEdit && s.appBlockId && (
+          <Button
+            size="xs"
+            variant="default"
+            component={Link}
+            href={`/apps/${encodeURIComponent(s.appBlockId)}/edit-manifest`}
+            leftSection={<IconPencil size={12} />}
+            data-testid={`apps-onsite-edit-${s.slug}`}
+          >
+            Edit
+          </Button>
+        )}
+        {canManage && s.appBlockId && (
+          <Button
+            size="xs"
+            variant="default"
+            component={Link}
+            href={`/apps/${encodeURIComponent(s.appBlockId)}/revenue`}
+            leftSection={<IconCoin size={12} />}
+            data-testid={`apps-onsite-revenue-${s.slug}`}
+          >
+            Revenue
+          </Button>
+        )}
+        {canViewHistory && (
+          <Button
+            size="xs"
+            variant="subtle"
+            color="gray"
+            onClick={() => owner.onViewHistory(listingId, s.slug)}
+            leftSection={<IconHistory size={12} />}
+            data-testid={`apps-onsite-history-${s.slug}`}
+          >
+            History
+          </Button>
+        )}
+      </Group>
     );
   }
-  if (submission.status === 'rejected') {
+  if (s.status === 'rejected') {
     return (
       <Button
         size="xs"

--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -718,7 +718,14 @@ function SubmissionActions({
     const canUnpublish = showOwner && canOwnerUnpublish(ownerState);
     const canRepublish = showOwner && canOwnerRepublish(ownerState);
     const isModRemoved = showOwner && ownerState === 'mod-removed';
-    const canViewHistory = showOwner && ownerState !== 'inactive';
+    // History only when there IS history — a removed/hidden listing, or any recorded
+    // moderation event. A pristine, never-moderated live app shows no History button
+    // (it would just open to "No moderation history yet.").
+    const canViewHistory =
+      showOwner &&
+      (ownerState === 'owner-hidden' ||
+        ownerState === 'mod-removed' ||
+        !!s.lastModerationAction);
     // Surface the manage entry points on any live / owner-hidden app (an app the owner
     // still controls); a mod takedown hides Edit (mirrors the off-site list), Revenue
     // stays (earnings are historical + viewable regardless of visibility).

--- a/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
@@ -348,11 +348,14 @@ describe('OffsiteSubmissionsList — moderation history modal', () => {
   });
 
   test('an empty history shows the empty-state copy', async () => {
+    // History only renders on a removed/hidden listing now (a pristine live app shows
+    // no History button), so exercise the empty-state on an owner-hidden listing whose
+    // history query returns [].
     mocks.historyItems = [];
     renderWithProviders(
-      <OffsiteSubmissionsList submissions={[live()]} onWithdraw={vi.fn()} withdrawing={false} />
+      <OffsiteSubmissionsList submissions={[ownerHidden()]} onWithdraw={vi.fn()} withdrawing={false} />
     );
-    await page.getByTestId('apps-offsite-history-live-off').click();
+    await page.getByTestId('apps-offsite-history-hidden-off').click();
     await expect.element(page.getByTestId('apps-offsite-history-empty')).toBeInTheDocument();
   });
 });

--- a/src/components/Apps/OffsiteSubmissionsList.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.tsx
@@ -1,19 +1,15 @@
 import {
-  Alert,
   Anchor,
   Badge,
   Button,
   Card,
   Code,
   Group,
-  Modal,
   Stack,
   Table,
   Text,
-  Textarea,
 } from '@mantine/core';
 import {
-  IconAlertTriangle,
   IconExternalLink,
   IconEye,
   IconEyeOff,
@@ -27,7 +23,6 @@ import {
   isWithdrawableOffsiteStatus,
   offsiteStatusChip,
 } from '~/components/Apps/offsiteSubmissionStatus';
-import { moderationActionChip } from '~/components/Apps/appListingModerationView';
 import {
   canOwnerRepublish,
   canOwnerUnpublish,
@@ -35,8 +30,11 @@ import {
   ownerStateChip,
   type OwnerListingState,
 } from '~/components/Apps/offsiteOwnerControls';
+import {
+  OwnerModerationHistoryModal,
+  OwnerUnpublishModal,
+} from '~/components/Apps/ownerListingModals';
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
-import { OFFSITE_MOD_NOTE_MAX } from '~/server/schema/blocks/offsite-moderation.schema';
 import { ReviewerNotesButton } from '~/components/Apps/MySubmissionsList';
 import {
   bucketGroupsByStatus,
@@ -525,173 +523,14 @@ export function OffsiteSubmissionsList({
         target={unpublishTarget}
         onClose={() => setUnpublishTarget(null)}
         onDone={invalidateSubmissions}
+        testIdPrefix="apps-offsite"
+        variant="store"
       />
       <OwnerModerationHistoryModal
         target={historyTarget}
         onClose={() => setHistoryTarget(null)}
+        testIdPrefix="apps-offsite"
       />
     </Stack>
-  );
-}
-
-/**
- * Confirm-gated OWNER unpublish (approved → removed). Hides the live app from the
- * store immediately — no re-review needed, and the owner can republish it
- * themselves. `reason` is optional (the owner is acting on their own listing).
- */
-function OwnerUnpublishModal({
-  target,
-  onClose,
-  onDone,
-}: {
-  target: { id: string; slug: string } | null;
-  onClose: () => void;
-  onDone: () => Promise<void> | void;
-}) {
-  const [reason, setReason] = useState('');
-  const mutation = trpc.appListings.unpublishOwnListing.useMutation({
-    onSuccess: async () => {
-      showSuccessNotification({ message: 'App unpublished — it is now hidden from the store.' });
-      await onDone();
-      setReason('');
-      onClose();
-    },
-    onError: (e) => showErrorNotification({ title: 'Unpublish failed', error: new Error(e.message) }),
-  });
-
-  function close() {
-    if (mutation.isPending) return;
-    setReason('');
-    onClose();
-  }
-
-  if (!target) return null;
-  return (
-    <Modal
-      opened={!!target}
-      onClose={close}
-      title={
-        <Text fw={600}>
-          Unpublish <Code>{target.slug}</Code>
-        </Text>
-      }
-      centered
-    >
-      <Stack gap="md">
-        <Alert color="orange" variant="light" icon={<IconAlertTriangle size={16} />}>
-          <Text size="sm">
-            Unpublishing hides your live app from the store immediately. You can republish it
-            yourself at any time — no re-review needed.
-          </Text>
-        </Alert>
-        <Textarea
-          label="Reason (optional)"
-          autosize
-          minRows={2}
-          maxRows={6}
-          maxLength={OFFSITE_MOD_NOTE_MAX}
-          placeholder="Optional — a note for your own records / the listing history."
-          value={reason}
-          onChange={(e) => setReason(e.currentTarget.value)}
-          disabled={mutation.isPending}
-          data-testid="apps-offsite-unpublish-reason"
-        />
-        <Group justify="flex-end" gap="xs">
-          <Button variant="default" onClick={close} disabled={mutation.isPending}>
-            Cancel
-          </Button>
-          <Button
-            color="orange"
-            onClick={() =>
-              mutation.mutate({
-                appListingId: target.id,
-                reason: reason.trim() ? reason.trim() : undefined,
-              })
-            }
-            loading={mutation.isPending}
-            disabled={mutation.isPending}
-            data-testid="apps-offsite-unpublish-confirm"
-          >
-            Unpublish
-          </Button>
-        </Group>
-      </Stack>
-    </Modal>
-  );
-}
-
-/**
- * OWNER moderation-history modal — the "why was this hidden / un-approved" view.
- * Renders the listing's `AppListingModerationEvent` timeline (newest-first) via the
- * owner-scoped `listMyListingModerationEvents` proc: each entry's action + date +
- * (verbatim) reason. Owner-scoped server-side (own listing only).
- */
-function OwnerModerationHistoryModal({
-  target,
-  onClose,
-}: {
-  target: { id: string; slug: string } | null;
-  onClose: () => void;
-}) {
-  const query = trpc.appListings.listMyListingModerationEvents.useQuery(
-    { appListingId: target?.id ?? '', limit: 50 },
-    { enabled: !!target }
-  );
-  const items = (query.data?.items ?? []) as Array<{
-    id: string;
-    action: string;
-    reason: string | null;
-    createdAt: string | Date;
-  }>;
-
-  return (
-    <Modal
-      opened={!!target}
-      onClose={onClose}
-      title={
-        <Text fw={600}>
-          Moderation history{target ? <> — <Code>{target.slug}</Code></> : null}
-        </Text>
-      }
-      size="lg"
-      centered
-    >
-      {query.isLoading ? (
-        <Text size="sm" c="dimmed">
-          Loading…
-        </Text>
-      ) : query.error ? (
-        <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
-          {query.error.message}
-        </Alert>
-      ) : items.length === 0 ? (
-        <Text size="sm" c="dimmed" data-testid="apps-offsite-history-empty">
-          No moderation history yet.
-        </Text>
-      ) : (
-        <Stack gap="sm" data-testid="apps-offsite-history-list">
-          {items.map((ev) => {
-            const chip = moderationActionChip(ev.action);
-            return (
-              <Card key={ev.id} withBorder p="sm" data-testid="apps-offsite-history-entry">
-                <Group justify="space-between" gap="xs" wrap="nowrap">
-                  <Badge color={chip.color} variant="light">
-                    {chip.label}
-                  </Badge>
-                  <Text size="xs" c="dimmed">
-                    {formatDate(ev.createdAt)}
-                  </Text>
-                </Group>
-                {ev.reason && (
-                  <Text size="sm" mt={6} style={{ whiteSpace: 'pre-wrap' }}>
-                    {ev.reason}
-                  </Text>
-                )}
-              </Card>
-            );
-          })}
-        </Stack>
-      )}
-    </Modal>
   );
 }

--- a/src/components/Apps/OffsiteSubmissionsList.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.tsx
@@ -236,8 +236,14 @@ function OffsiteRow({
   const canUnpublish = showOwner && canOwnerUnpublish(ownerState);
   const canRepublish = showOwner && canOwnerRepublish(ownerState);
   const isModRemoved = showOwner && ownerState === 'mod-removed';
-  // History is offered whenever there's a live/removed listing that can carry events.
-  const canViewHistory = showOwner && (ownerState !== 'inactive');
+  // History only when there IS history — a removed/hidden listing, or any recorded
+  // moderation event. A pristine, never-moderated live listing shows no History button
+  // (it would just open to "No moderation history yet.").
+  const canViewHistory =
+    showOwner &&
+    (ownerState === 'owner-hidden' ||
+      ownerState === 'mod-removed' ||
+      !!s.lastModerationAction);
 
   const renderActions = () => {
     const hasAny =

--- a/src/components/Apps/ownerListingModals.tsx
+++ b/src/components/Apps/ownerListingModals.tsx
@@ -3,6 +3,7 @@ import { IconAlertTriangle } from '@tabler/icons-react';
 import { useState } from 'react';
 import { moderationActionChip } from '~/components/Apps/appListingModerationView';
 import { OFFSITE_MOD_NOTE_MAX } from '~/server/schema/blocks/offsite-moderation.schema';
+import { formatDate } from '~/utils/date-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -23,12 +24,6 @@ import { trpc } from '~/utils/trpc';
  *     `offline` (on-site: a FULL takedown — the app goes OFFLINE at `<slug>.civit.ai`
  *     / the run page, not just delisted from the store).
  */
-
-function formatDate(d: string | Date | null | undefined): string {
-  if (!d) return '—';
-  const date = typeof d === 'string' ? new Date(d) : d;
-  return date.toLocaleString();
-}
 
 export type OwnerModalTarget = { id: string; slug: string } | null;
 

--- a/src/components/Apps/ownerListingModals.tsx
+++ b/src/components/Apps/ownerListingModals.tsx
@@ -1,0 +1,214 @@
+import { Alert, Badge, Button, Card, Code, Group, Modal, Stack, Text, Textarea } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { useState } from 'react';
+import { moderationActionChip } from '~/components/Apps/appListingModerationView';
+import { OFFSITE_MOD_NOTE_MAX } from '~/server/schema/blocks/offsite-moderation.schema';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * Shared OWNER-control modals for the App Store my-submissions surfaces (W13
+ * post-approval mgmt). Factored out of the P3 `OffsiteSubmissionsList` so the P4
+ * on-site `MySubmissionsList` reuses the EXACT same confirm-gated unpublish flow +
+ * moderation-history timeline (no fork-copy). Both are DUAL-KIND: they hit the
+ * widened `appListings.unpublishOwnListing` / `listMyListingModerationEvents` procs,
+ * which handle on-site AND off-site listings server-side.
+ *
+ * The caller supplies:
+ *   - `testIdPrefix` (`apps-offsite` | `apps-onsite`) so the two surfaces keep
+ *     distinct, stable test hooks.
+ *   - `onDone` — the query to invalidate on success (off-site:
+ *     `appListings.listMySubmissions`; on-site: `blocks.listMyPublishRequests`).
+ *   - `variant` — the takedown copy: `store` (off-site: "hidden from the store") vs
+ *     `offline` (on-site: a FULL takedown — the app goes OFFLINE at `<slug>.civit.ai`
+ *     / the run page, not just delisted from the store).
+ */
+
+function formatDate(d: string | Date | null | undefined): string {
+  if (!d) return '—';
+  const date = typeof d === 'string' ? new Date(d) : d;
+  return date.toLocaleString();
+}
+
+export type OwnerModalTarget = { id: string; slug: string } | null;
+
+/** Copy variant: `store` = off-site delist; `offline` = on-site full takedown. */
+export type OwnerUnpublishVariant = 'store' | 'offline';
+
+/**
+ * Confirm-gated OWNER unpublish (approved → removed). Hides the listing from the
+ * store immediately — no re-review needed, and the owner can republish it themselves.
+ * On the on-site (`offline`) variant it ALSO takes the app OFFLINE (the backing block
+ * is suspended server-side). `reason` is optional (the owner acts on their own listing).
+ */
+export function OwnerUnpublishModal({
+  target,
+  onClose,
+  onDone,
+  testIdPrefix,
+  variant,
+}: {
+  target: OwnerModalTarget;
+  onClose: () => void;
+  onDone: () => Promise<void> | void;
+  testIdPrefix: string;
+  variant: OwnerUnpublishVariant;
+}) {
+  const [reason, setReason] = useState('');
+  const mutation = trpc.appListings.unpublishOwnListing.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({
+        message:
+          variant === 'offline'
+            ? 'App unpublished — it is now offline and hidden from the store.'
+            : 'App unpublished — it is now hidden from the store.',
+      });
+      await onDone();
+      setReason('');
+      onClose();
+    },
+    onError: (e) => showErrorNotification({ title: 'Unpublish failed', error: new Error(e.message) }),
+  });
+
+  function close() {
+    if (mutation.isPending) return;
+    setReason('');
+    onClose();
+  }
+
+  if (!target) return null;
+  return (
+    <Modal
+      opened={!!target}
+      onClose={close}
+      title={
+        <Text fw={600}>
+          Unpublish <Code>{target.slug}</Code>
+        </Text>
+      }
+      centered
+    >
+      <Stack gap="md">
+        <Alert color="orange" variant="light" icon={<IconAlertTriangle size={16} />}>
+          <Text size="sm">
+            {variant === 'offline'
+              ? 'Unpublishing takes your app OFFLINE immediately — it stops serving at its ' +
+                'app page and is removed from the store. This is a full takedown, not just a ' +
+                'delist. You can republish it yourself at any time — no re-review needed.'
+              : 'Unpublishing hides your live app from the store immediately. You can republish ' +
+                'it yourself at any time — no re-review needed.'}
+          </Text>
+        </Alert>
+        <Textarea
+          label="Reason (optional)"
+          autosize
+          minRows={2}
+          maxRows={6}
+          maxLength={OFFSITE_MOD_NOTE_MAX}
+          placeholder="Optional — a note for your own records / the listing history."
+          value={reason}
+          onChange={(e) => setReason(e.currentTarget.value)}
+          disabled={mutation.isPending}
+          data-testid={`${testIdPrefix}-unpublish-reason`}
+        />
+        <Group justify="flex-end" gap="xs">
+          <Button variant="default" onClick={close} disabled={mutation.isPending}>
+            Cancel
+          </Button>
+          <Button
+            color="orange"
+            onClick={() =>
+              mutation.mutate({
+                appListingId: target.id,
+                reason: reason.trim() ? reason.trim() : undefined,
+              })
+            }
+            loading={mutation.isPending}
+            disabled={mutation.isPending}
+            data-testid={`${testIdPrefix}-unpublish-confirm`}
+          >
+            Unpublish
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}
+
+/**
+ * OWNER moderation-history modal — the "why was this hidden / un-approved" view.
+ * Renders the listing's `AppListingModerationEvent` timeline (newest-first) via the
+ * owner-scoped, PII-minimal `listMyListingModerationEvents` proc: each entry's action
+ * + date + (verbatim) reason. Owner-scoped server-side (own listing only).
+ */
+export function OwnerModerationHistoryModal({
+  target,
+  onClose,
+  testIdPrefix,
+}: {
+  target: OwnerModalTarget;
+  onClose: () => void;
+  testIdPrefix: string;
+}) {
+  const query = trpc.appListings.listMyListingModerationEvents.useQuery(
+    { appListingId: target?.id ?? '', limit: 50 },
+    { enabled: !!target }
+  );
+  const items = (query.data?.items ?? []) as Array<{
+    id: string;
+    action: string;
+    reason: string | null;
+    createdAt: string | Date;
+  }>;
+
+  return (
+    <Modal
+      opened={!!target}
+      onClose={onClose}
+      title={
+        <Text fw={600}>
+          Moderation history{target ? <> — <Code>{target.slug}</Code></> : null}
+        </Text>
+      }
+      size="lg"
+      centered
+    >
+      {query.isLoading ? (
+        <Text size="sm" c="dimmed">
+          Loading…
+        </Text>
+      ) : query.error ? (
+        <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
+          {query.error.message}
+        </Alert>
+      ) : items.length === 0 ? (
+        <Text size="sm" c="dimmed" data-testid={`${testIdPrefix}-history-empty`}>
+          No moderation history yet.
+        </Text>
+      ) : (
+        <Stack gap="sm" data-testid={`${testIdPrefix}-history-list`}>
+          {items.map((ev) => {
+            const chip = moderationActionChip(ev.action);
+            return (
+              <Card key={ev.id} withBorder p="sm" data-testid={`${testIdPrefix}-history-entry`}>
+                <Group justify="space-between" gap="xs" wrap="nowrap">
+                  <Badge color={chip.color} variant="light">
+                    {chip.label}
+                  </Badge>
+                  <Text size="xs" c="dimmed">
+                    {formatDate(ev.createdAt)}
+                  </Text>
+                </Group>
+                {ev.reason && (
+                  <Text size="sm" mt={6} style={{ whiteSpace: 'pre-wrap' }}>
+                    {ev.reason}
+                  </Text>
+                )}
+              </Card>
+            );
+          })}
+        </Stack>
+      )}
+    </Modal>
+  );
+}

--- a/src/pages/apps/my-submissions.tsx
+++ b/src/pages/apps/my-submissions.tsx
@@ -142,6 +142,7 @@ export default function MySubmissionsPage() {
             submissions={submissions}
             onWithdraw={(id) => withdrawMutation.mutate({ publishRequestId: id })}
             withdrawing={withdrawMutation.isPending}
+            canOpenPage={!!features?.appBlocksPages}
           />
         )}
 

--- a/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
+++ b/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
@@ -1,0 +1,260 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * W13 P4 — `blocks.listMyPublishRequests` OWNER-control augmentation.
+ *
+ * Asserts the ROUTER query now carries, per publish-request row: the backing
+ * on-site `AppListing.id` + its TRUE lifecycle `status` (distinct from the request
+ * status), the last moderation action for a REMOVED listing (owner-hidden vs
+ * mod-removed), and `hasPage` (does the manifest declare a launch page). Also pins
+ * the BATCHED shape — ONE `appListing.findMany` + ONE `appListingModerationEvent
+ * .findMany` for the whole page, NOT an N+1 per row.
+ *
+ * Same heavy-mock skeleton as `blocks.router.getMyAppAnalytics.test.ts` (services
+ * stubbed so importing the router doesn't drag in the generated Prisma client);
+ * `getFeatureFlags` is mocked so the `appDeveloperProcedure` author gate passes.
+ */
+
+const { mockIsAppBlocksEnabled, mockDbRead } = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockDbRead: {
+    appBlockPublishRequest: { findMany: vi.fn() },
+    appListing: { findMany: vi.fn() },
+    appListingModerationEvent: { findMany: vi.fn() },
+    blockUserSubscription: { groupBy: vi.fn() },
+  },
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: vi.fn(async () => true),
+}));
+vi.mock('~/server/services/feature-flags.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/server/services/feature-flags.service')>()),
+  getFeatureFlags: () => ({ appBlocks: true, appBlocksAuthor: true, appBlocksPages: false }),
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: vi.fn(),
+  parseSubjectUserId: vi.fn(),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({ getOrchestratorToken: vi.fn() }));
+vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
+  buildGenerationContext: vi.fn(),
+  createWorkflowStepsFromGraphInput: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({ auditPromptServer: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: {},
+}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  return {
+    ...actual,
+    redis: { get: vi.fn(), set: vi.fn() },
+    sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  };
+});
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({ getUserBuzzAccounts: vi.fn() }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: true, appBlocksAuthor: true } as never,
+    track: undefined,
+  };
+}
+
+const owner = { id: 7, isModerator: false, tier: 'free', username: 'owner' };
+
+/** A page-app manifest (declares a launch page → hasPage true). */
+const PAGE_MANIFEST = { name: 'App', page: { path: '/' } };
+/** A model-slot manifest (no page → hasPage false). */
+const SLOT_MANIFEST = { name: 'App', targets: ['model.sidebar_top'] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAppBlocksEnabled.mockResolvedValue(true);
+  mockDbRead.blockUserSubscription.groupBy.mockResolvedValue([]);
+  mockDbRead.appListing.findMany.mockResolvedValue([]);
+  mockDbRead.appListingModerationEvent.findMany.mockResolvedValue([]);
+});
+
+describe('listMyPublishRequests — P4 owner-control augmentation', () => {
+  it('carries the backing listing id + TRUE status + hasPage; a LIVE (approved) listing has no last action', async () => {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([
+      {
+        id: 'req-1',
+        appBlockId: null,
+        slug: 'live-app',
+        version: '1.0.0',
+        status: 'approved',
+        submittedAt: new Date('2026-01-01'),
+        reviewedAt: new Date('2026-01-02'),
+        rejectionReason: null,
+        approvalNotes: null,
+        deployState: 'live',
+        deployDetail: null,
+        deployUpdatedAt: new Date('2026-01-02'),
+        fileSummary: null,
+        manifestDiffSummary: null,
+        appBlock: { id: 'block-a', manifest: PAGE_MANIFEST, _count: { userSubscriptions: 4 } },
+      },
+    ]);
+    mockDbRead.appListing.findMany.mockResolvedValue([
+      { id: 'l-a', appBlockId: 'block-a', status: 'approved' },
+    ]);
+
+    const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
+    const rows = await caller.listMyPublishRequests();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      appListingId: 'l-a',
+      listingStatus: 'approved',
+      lastModerationAction: null,
+      hasPage: true,
+    });
+    // Approved (live) listing → NO moderation-action lookup (only removed listings).
+    expect(mockDbRead.appListingModerationEvent.findMany).not.toHaveBeenCalled();
+  });
+
+  it('a REMOVED listing carries its last moderation action (owner-hidden vs mod-removed), BATCHED (one findMany, not N+1)', async () => {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([
+      {
+        id: 'req-h',
+        appBlockId: null,
+        slug: 'hidden-app',
+        version: '1.0.0',
+        status: 'approved',
+        submittedAt: new Date('2026-01-01'),
+        reviewedAt: new Date('2026-01-02'),
+        rejectionReason: null,
+        approvalNotes: null,
+        deployState: 'live',
+        deployDetail: null,
+        deployUpdatedAt: null,
+        fileSummary: null,
+        manifestDiffSummary: null,
+        appBlock: { id: 'block-h', manifest: SLOT_MANIFEST, _count: { userSubscriptions: 0 } },
+      },
+      {
+        id: 'req-m',
+        appBlockId: null,
+        slug: 'gone-app',
+        version: '1.0.0',
+        status: 'approved',
+        submittedAt: new Date('2026-01-01'),
+        reviewedAt: new Date('2026-01-02'),
+        rejectionReason: null,
+        approvalNotes: null,
+        deployState: 'live',
+        deployDetail: null,
+        deployUpdatedAt: null,
+        fileSummary: null,
+        manifestDiffSummary: null,
+        appBlock: { id: 'block-m', manifest: PAGE_MANIFEST, _count: { userSubscriptions: 0 } },
+      },
+    ]);
+    mockDbRead.appListing.findMany.mockResolvedValue([
+      { id: 'l-h', appBlockId: 'block-h', status: 'removed' },
+      { id: 'l-m', appBlockId: 'block-m', status: 'removed' },
+    ]);
+    mockDbRead.appListingModerationEvent.findMany.mockResolvedValue([
+      { appListingId: 'l-h', action: 'owner-unpublish' },
+      { appListingId: 'l-m', action: 'delist' },
+    ]);
+
+    const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
+    const rows = await caller.listMyPublishRequests();
+
+    const byListing = Object.fromEntries(rows.map((r) => [r.appListingId, r]));
+    expect(byListing['l-h']).toMatchObject({
+      listingStatus: 'removed',
+      lastModerationAction: 'owner-unpublish',
+      hasPage: false, // slot manifest
+    });
+    expect(byListing['l-m']).toMatchObject({
+      listingStatus: 'removed',
+      lastModerationAction: 'delist',
+      hasPage: true, // page manifest
+    });
+    // BATCHED: exactly ONE moderation-event query for the whole page, over BOTH
+    // removed listing ids (not one query per row).
+    expect(mockDbRead.appListingModerationEvent.findMany).toHaveBeenCalledTimes(1);
+    const modArgs = mockDbRead.appListingModerationEvent.findMany.mock.calls[0][0];
+    expect(modArgs.where.appListingId.in.sort()).toEqual(['l-h', 'l-m']);
+    expect(modArgs.distinct).toEqual(['appListingId']);
+    // And exactly ONE backing-listing query for the whole page.
+    expect(mockDbRead.appListing.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('a row with no backing listing (pending first version) → null listing fields, null last action', async () => {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([
+      {
+        id: 'req-p',
+        appBlockId: null,
+        slug: 'pending-app',
+        version: '1.0.0',
+        status: 'pending',
+        submittedAt: new Date('2026-01-01'),
+        reviewedAt: null,
+        rejectionReason: null,
+        approvalNotes: null,
+        deployState: null,
+        deployDetail: null,
+        deployUpdatedAt: null,
+        fileSummary: null,
+        manifestDiffSummary: null,
+        appBlock: null,
+      },
+    ]);
+
+    const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
+    const rows = await caller.listMyPublishRequests();
+
+    expect(rows[0]).toMatchObject({
+      appListingId: null,
+      listingStatus: null,
+      lastModerationAction: null,
+      hasPage: false,
+    });
+    // No app-block ids on the page → no backing-listing / moderation queries at all.
+    expect(mockDbRead.appListing.findMany).not.toHaveBeenCalled();
+    expect(mockDbRead.appListingModerationEvent.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -25,6 +25,7 @@ import {
   setAppReviewExcludedSchema,
   setMarketplaceMetaSchema,
   subscriptionScopeSchema,
+  toPublicBlockManifest,
   upsertAppBlockReviewSchema,
 } from '~/server/schema/blocks/subscription.schema';
 import {
@@ -1547,6 +1548,9 @@ export const blocksRouter = router({
           appBlock: {
             select: {
               id: true,
+              // W13 P4: `hasPage` for the Open-live run-page link (does the manifest
+              // declare a launchable page). PUBLIC subset only — never the raw manifest.
+              manifest: true,
               _count: { select: { userSubscriptions: true } },
             },
           },
@@ -1580,10 +1584,51 @@ export const blocksRouter = router({
             return acc;
           }, {})
         : {};
+
+      // W13 P4 (owner controls): resolve the backing on-site `AppListing` (1:1 with
+      // the AppBlock — `AppListing.appBlockId`) for each row so the UI reads the TRUE
+      // live/removed listing state. A publish request stays `approved` after an owner
+      // unpublish, so the request status alone can't tell live from owner-hidden. One
+      // batched findMany (NOT per-row) keyed by appBlockId.
+      const listingByBlockId = new Map<string, { id: string; status: string }>();
+      if (appBlockIds.length) {
+        const listings = await dbRead.appListing.findMany({
+          where: { appBlockId: { in: appBlockIds }, kind: 'onsite' },
+          select: { id: true, appBlockId: true, status: true },
+        });
+        for (const l of listings) {
+          if (l.appBlockId) listingByBlockId.set(l.appBlockId, { id: l.id, status: l.status });
+        }
+      }
+
+      // For every REMOVED backing listing, its MOST-RECENT moderation-event action —
+      // so the UI distinguishes an owner-hidden listing (last event `owner-unpublish`
+      // → Republish-eligible) from a moderator takedown (last event `delist`/`purge` →
+      // Republish FORBIDDEN, shown as "removed by a moderator"). Batched `distinct` +
+      // `orderBy desc` (ONE query, latest per listing), only over removed listings —
+      // mirrors the off-site `listMySubmissions` approach.
+      const removedListingIds = [...listingByBlockId.values()]
+        .filter((l) => l.status === 'removed')
+        .map((l) => l.id);
+      const lastEvents = removedListingIds.length
+        ? await dbRead.appListingModerationEvent.findMany({
+            where: { appListingId: { in: removedListingIds } },
+            orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+            distinct: ['appListingId'],
+            select: { appListingId: true, action: true },
+          })
+        : [];
+      const lastActionByListingId = new Map(
+        lastEvents
+          .filter((e): e is { appListingId: string; action: string } => e.appListingId != null)
+          .map((e) => [e.appListingId, e.action])
+      );
+
       type RowWithCount = (typeof rows)[number];
       return rows.map((r: RowWithCount) => {
         const counts = r.appBlock?._count;
         const appBlockId = r.appBlock?.id;
+        const manifest = r.appBlock?.manifest;
         const { appBlock: _drop, ...rest } = r;
         // userSubscriptionCount keeps the historical meaning ("blanket +
         // pinned subscriptions for this app"); modelInstallCount is the
@@ -1591,10 +1636,22 @@ export const blocksRouter = router({
         // model_block_installs row count meant.
         const totalSubs = counts?.userSubscriptions ?? null;
         const pinnedCount = appBlockId ? pinnedCounts[appBlockId] ?? 0 : null;
+        const listing = appBlockId ? listingByBlockId.get(appBlockId) : undefined;
         return {
           ...rest,
           modelInstallCount: pinnedCount,
           userSubscriptionCount: totalSubs,
+          // The backing on-site listing id (owner unpublish/republish/history target)
+          // + its TRUE lifecycle status, and — for a removed listing — the last mod
+          // action (owner-hidden vs mod-removed). Null when no backing listing exists
+          // (e.g. a pending first-version request, or a pre-W13 backfill gap).
+          appListingId: listing?.id ?? null,
+          listingStatus: listing?.status ?? null,
+          lastModerationAction: listing ? lastActionByListingId.get(listing.id) ?? null : null,
+          // Whether the manifest declares a launchable page (drives the Open-live →
+          // /apps/run/<slug> vs standalone-origin vs model-slot branching). PUBLIC
+          // subset only.
+          hasPage: !!toPublicBlockManifest(manifest).hasPage,
         };
       });
     }),

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -850,11 +850,11 @@ describe('resetListingToPending', () => {
 // ---------------------------------------------------------------------------
 
 describe('unpublishOwnListing', () => {
-  function ownerPrimary(status: string, kind = 'offsite', userId = OWNER) {
-    return { userId, status, kind, slug: SLUG, name: 'Cool App' };
+  function ownerPrimary(status: string, kind = 'offsite', userId = OWNER, appBlockId: string | null = null) {
+    return { userId, status, kind, slug: SLUG, name: 'Cool App', appBlockId };
   }
 
-  it('OWNER hides their approved listing (approved → removed) + one owner-unpublish event, no notif/publish-request', async () => {
+  it('OWNER hides their approved OFF-SITE listing (approved → removed) + one owner-unpublish event, no notif/publish-request/block-flip', async () => {
     mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('approved'));
     const res = await unpublishOwnListing({
       input: { appListingId: APP_ID },
@@ -871,9 +871,32 @@ describe('unpublishOwnListing', () => {
       before: { status: 'approved' },
       after: { status: 'removed' },
     });
+    // OFF-SITE: no backing block to suspend.
+    expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
     // Pure visibility toggle — no re-review artifact, no owner self-notification.
     expect(mockWrite.appListingPublishRequest.create).not.toHaveBeenCalled();
     expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('🔴 ON-SITE full takedown: flips BOTH app_listings AND the backing app_blocks (approved → suspended) in ONE tx + owner-unpublish event', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('approved', 'onsite', OWNER, BLOCK_ID));
+    const res = await unpublishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'removed' });
+    // The listing flip is kind-scoped to onsite.
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'onsite', status: 'approved' },
+      data: { status: 'removed' },
+    });
+    // The backing block is suspended (guarded to approved) so the runtime stops serving.
+    expect(mockWrite.appBlock.updateMany).toHaveBeenCalledWith({
+      where: { id: BLOCK_ID, status: 'approved' },
+      data: { status: 'suspended' },
+    });
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'owner-unpublish',
+      before: { status: 'approved' },
+      after: { status: 'removed' },
+    });
   });
 
   it('a NON-owner caller → NOT_OWNED (FORBIDDEN), no flip/event', async () => {
@@ -882,6 +905,7 @@ describe('unpublishOwnListing', () => {
       unpublishOwnListing({ input: { appListingId: APP_ID }, userId: 999 })
     ).rejects.toMatchObject({ name: 'OffsiteModerationError', code: 'NOT_OWNED' });
     expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
   });
 
@@ -893,8 +917,8 @@ describe('unpublishOwnListing', () => {
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
   });
 
-  it('an on-site owned listing → generic NOT_FOUND (offsite-only owner self-service)', async () => {
-    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('approved', 'onsite'));
+  it('a missing listing → generic NOT_FOUND', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(null);
     await expect(
       unpublishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
     ).rejects.toMatchObject({ code: 'NOT_FOUND' });
@@ -902,11 +926,11 @@ describe('unpublishOwnListing', () => {
 });
 
 describe('republishOwnListing (🔴 the last-event safety guard)', () => {
-  function ownerPrimary(status: string, kind = 'offsite', userId = OWNER) {
-    return { userId, status, kind, slug: SLUG, name: 'Cool App' };
+  function ownerPrimary(status: string, kind = 'offsite', userId = OWNER, appBlockId: string | null = null) {
+    return { userId, status, kind, slug: SLUG, name: 'Cool App', appBlockId };
   }
 
-  it('OWNER restores their OWN owner-unpublished listing (removed → approved) + owner-republish event', async () => {
+  it('OWNER restores their OWN owner-unpublished OFF-SITE listing (removed → approved) + owner-republish event, no block-flip', async () => {
     mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed'));
     // The most-recent event is the owner's own unpublish → restore allowed.
     mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'owner-unpublish' });
@@ -916,11 +940,41 @@ describe('republishOwnListing (🔴 the last-event safety guard)', () => {
       where: { id: APP_ID, kind: 'offsite', status: 'removed' },
       data: { status: 'approved' },
     });
+    expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
     expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
       action: 'owner-republish',
       before: { status: 'removed' },
       after: { status: 'approved' },
     });
+  });
+
+  it('🔴 ON-SITE republish restores BOTH app_listings AND the backing app_blocks (suspended → approved) in ONE tx + owner-republish event', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed', 'onsite', OWNER, BLOCK_ID));
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'owner-unpublish' });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: APP_ID, kind: 'onsite', status: 'removed' },
+      data: { status: 'approved' },
+    });
+    expect(mockWrite.appBlock.updateMany).toHaveBeenCalledWith({
+      where: { id: BLOCK_ID, status: 'suspended' },
+      data: { status: 'approved' },
+    });
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'owner-republish',
+    });
+  });
+
+  it('🔴 ON-SITE republish FORBIDDEN when the last event is a MOD delist — no listing flip AND no block flip', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed', 'onsite', OWNER, BLOCK_ID));
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'delist' });
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
   });
 
   it('🔴 FORBIDDEN when the last event is a MOD delist (takedown-for-cause) — no flip, no event', async () => {

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -55,7 +55,7 @@ type ReadMock = {
   appListingModerationEvent: { findMany: ReturnType<typeof vi.fn> };
 };
 
-const { mockRead, mockWrite, mockNotify, ids } = vi.hoisted(() => {
+const { mockRead, mockWrite, mockNotify, mockLogToAxiom, ids } = vi.hoisted(() => {
   const write: WriteMock = {
     $transaction: vi.fn(),
     appListing: {
@@ -82,10 +82,18 @@ const { mockRead, mockWrite, mockNotify, ids } = vi.hoisted(() => {
     appListingReport: { findUnique: vi.fn(async () => null) },
     appListingModerationEvent: { findMany: vi.fn(async () => []) },
   };
-  return { mockRead: read, mockWrite: write, mockNotify: vi.fn(async () => undefined), ids: { n: 0 } };
+  return {
+    mockRead: read,
+    mockWrite: write,
+    mockNotify: vi.fn(async () => undefined),
+    mockLogToAxiom: vi.fn(async () => undefined),
+    ids: { n: 0 },
+  };
 });
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+// The on-site relist / owner-republish drift warn is a dynamic import of this module.
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingReportId: () => `alrp_test_${++ids.n}`,
   newAppListingModerationEventId: () => `alme_test_${++ids.n}`,
@@ -143,6 +151,7 @@ beforeEach(() => {
   mockRead.appListingReport.findUnique.mockResolvedValue(null);
   mockRead.appListingModerationEvent.findMany.mockResolvedValue([]);
   mockNotify.mockResolvedValue(undefined);
+  mockLogToAxiom.mockResolvedValue(undefined);
 });
 
 // ---------------------------------------------------------------------------
@@ -975,6 +984,23 @@ describe('republishOwnListing (🔴 the last-event safety guard)', () => {
     expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
     expect(mockWrite.appBlock.updateMany).not.toHaveBeenCalled();
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('ON-SITE republish whose block-restore flip is a 0-count (drift) emits the post-commit warn (observability, mirrors mod relist)', async () => {
+    mockWrite.appListing.findUnique.mockResolvedValueOnce(ownerPrimary('removed', 'onsite', OWNER, BLOCK_ID));
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({ action: 'owner-unpublish' });
+    // The backing block wasn't `suspended` → the guarded block flip matches 0 rows.
+    mockWrite.appBlock.updateMany.mockResolvedValueOnce({ count: 0 });
+    const res = await republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER });
+    // The listing is still restored (non-fatal) — visibility IS back.
+    expect(res).toEqual({ appListingId: APP_ID, status: 'approved' });
+    // …but the block-serve divergence is warned post-commit (best-effort dynamic import).
+    await vi.waitFor(() => expect(mockLogToAxiom).toHaveBeenCalledTimes(1));
+    expect(mockLogToAxiom.mock.calls[0][0]).toMatchObject({
+      type: 'warning',
+      name: 'app-listing-relist-block-drift',
+      details: { appListingId: APP_ID, appBlockId: BLOCK_ID },
+    });
   });
 
   it('🔴 FORBIDDEN when the last event is a MOD delist (takedown-for-cause) — no flip, no event', async () => {

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -1166,6 +1166,9 @@ export async function republishOwnListing(opts: {
 }): Promise<RepublishOwnListingResult> {
   const { input, userId } = opts;
   const reason = input.reason?.trim() ? input.reason.trim() : null;
+  // Set when the on-site block-restore flip matched 0 rows (drift — mirrors relist).
+  let onsiteBlockRestoreDrift = false;
+  let onsiteBlockId: string | null = null;
 
   await dbWrite.$transaction(async (tx) => {
     const listing = await loadOwnedListingInTx(tx, input.appListingId, userId);
@@ -1201,13 +1204,22 @@ export async function republishOwnListing(opts: {
         'This listing can no longer be republished.'
       );
     }
-    // ON-SITE: restore the backing block so the runtime serves again.
-    await flipBackingBlockStatus(tx, {
-      isOnsite,
-      appBlockId: listing.appBlockId,
-      from: 'suspended',
-      to: 'approved',
-    });
+    // ON-SITE: restore the backing block so the runtime serves again. Guarded to
+    // `suspended` + non-fatal on a 0-count; a 0-count means the block wasn't suspended
+    // (drift) → the listing shows approved but the block may not serve (store card →
+    // a blank/broken block; Open 404s). Non-fatal (store visibility IS restored), but
+    // flagged for a post-commit warn so the divergence is observable on the OWNER path
+    // too (mirrors the mod `relistListing` drift warn).
+    if (isOnsite && listing.appBlockId) {
+      onsiteBlockId = listing.appBlockId;
+      const flippedBlock = await flipBackingBlockStatus(tx, {
+        isOnsite,
+        appBlockId: listing.appBlockId,
+        from: 'suspended',
+        to: 'approved',
+      });
+      if (!flippedBlock) onsiteBlockRestoreDrift = true;
+    }
     await tx.appListingModerationEvent.create({
       data: {
         id: newAppListingModerationEventId(),
@@ -1221,6 +1233,27 @@ export async function republishOwnListing(opts: {
       },
     });
   });
+
+  // Post-commit, best-effort: warn when an on-site owner-republish restored the LISTING
+  // but the backing block wasn't `suspended` (so it may not serve) — the same drift
+  // observability the mod `relistListing` emits. Dynamic import keeps the logging graph
+  // out of the tx path.
+  if (onsiteBlockRestoreDrift) {
+    void import('~/server/logging/client')
+      .then(({ logToAxiom }) =>
+        logToAxiom(
+          {
+            type: 'warning',
+            name: 'app-listing-relist-block-drift',
+            message:
+              'onsite owner-republish: backing app_block was not suspended; the block may not serve',
+            details: { appListingId: input.appListingId, appBlockId: onsiteBlockId },
+          },
+          'app-blocks'
+        )
+      )
+      .catch(() => undefined);
+  }
 
   return { appListingId: input.appListingId, status: 'approved' };
 }

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -337,6 +337,34 @@ async function classifyListingForAction(appListingId: string): Promise<{
   };
 }
 
+/**
+ * Shared ON-SITE dual-table status flip. An on-site `AppListing` is 1:1 with a
+ * backing `AppBlock`, and the block RUNTIME serving gate (`<slug>.civit.ai` / the
+ * in-host page) reads `app_blocks.status` — NOT the listing status. So any action
+ * that hides/restores an on-site listing must flip the backing block IN THE SAME TX
+ * or store-visibility and runtime-serving drift apart (hidden in the store but still
+ * serving, or restored in the store but a suspended/blank block).
+ *
+ * Factored out of the mod `delistListing`/`relistListing` (approved↔suspended) so the
+ * OWNER `unpublishOwnListing`/`republishOwnListing` reuse the EXACT same flip. The
+ * write is status-guarded to the expected `from` (don't clobber a drifted/already-set
+ * state) and NON-FATAL on a 0-count (the LISTING flip is the authoritative visibility
+ * gate; a drifted block is a benign blank/broken surface, not an exposure). No-op for
+ * an off-site listing (no backing block). Returns true when a block row was flipped,
+ * false on a 0-count (drift) or an off-site listing — the caller may log the drift.
+ */
+async function flipBackingBlockStatus(
+  tx: Prisma.TransactionClient,
+  opts: { isOnsite: boolean; appBlockId: string | null; from: string; to: string }
+): Promise<boolean> {
+  if (!opts.isOnsite || !opts.appBlockId) return false;
+  const flip = await tx.appBlock.updateMany({
+    where: { id: opts.appBlockId, status: opts.from },
+    data: { status: opts.to },
+  });
+  return flip.count > 0;
+}
+
 export type DelistListingResult = { appListingId: string; status: 'removed' };
 
 /**
@@ -392,13 +420,14 @@ export async function delistListing(opts: {
     }
     // ON-SITE: also suspend the backing AppBlock so the block runtime stops serving.
     // Guarded to `approved` (don't clobber a drifted/already-suspended state); non-fatal
-    // on 0-count (also covers the removed→removed lock, where the block is already suspended).
-    if (isOnsite && listing.appBlockId) {
-      await tx.appBlock.updateMany({
-        where: { id: listing.appBlockId, status: 'approved' },
-        data: { status: 'suspended' },
-      });
-    }
+    // on 0-count (also covers the removed→removed lock, where the block is already
+    // suspended). Shared with relist + the owner unpublish/republish procs.
+    await flipBackingBlockStatus(tx, {
+      isOnsite,
+      appBlockId: listing.appBlockId,
+      from: 'approved',
+      to: 'suspended',
+    });
     await tx.appListingModerationEvent.create({
       data: {
         id: eventId,
@@ -491,11 +520,13 @@ export async function relistListing(opts: {
     // Non-fatal (store visibility IS restored); flagged for a post-commit warn so the
     // divergence is observable rather than silent.
     if (isOnsite && listing.appBlockId) {
-      const blockFlip = await tx.appBlock.updateMany({
-        where: { id: listing.appBlockId, status: 'suspended' },
-        data: { status: 'approved' },
+      const flipped = await flipBackingBlockStatus(tx, {
+        isOnsite,
+        appBlockId: listing.appBlockId,
+        from: 'suspended',
+        to: 'approved',
       });
-      if (blockFlip.count === 0) onsiteBlockRestoreDrift = true;
+      if (!flipped) onsiteBlockRestoreDrift = true;
     }
     await tx.appListingModerationEvent.create({
       data: {
@@ -1006,37 +1037,59 @@ export async function resetListingToPending(opts: {
 }
 
 /**
- * Load an OFF-SITE listing the caller OWNS for an owner action, on the PRIMARY
- * inside a tx. A missing OR on-site listing → generic NOT_FOUND (offsite-only owner
- * self-service, parity with claim/purge); a listing owned by someone else →
- * NOT_OWNED (router → FORBIDDEN).
+ * Load a listing the caller OWNS for an owner action, on the PRIMARY inside a tx.
+ * DUAL-KIND (W13 P4): both on-site AND off-site listings are valid owner self-service
+ * targets — the on-site path additionally flips the backing block (see
+ * {@link flipBackingBlockStatus}), so `kind` + `appBlockId` are returned to branch it.
+ * A missing listing → generic NOT_FOUND; a listing owned by someone else → NOT_OWNED
+ * (router → FORBIDDEN). (Widened from the P3 offsite-only `loadOwnedOffsiteInTx`.)
  */
-async function loadOwnedOffsiteInTx(
+async function loadOwnedListingInTx(
   tx: Prisma.TransactionClient,
   appListingId: string,
   callerUserId: number
-): Promise<{ userId: number; status: string; slug: string; name: string | null }> {
+): Promise<{
+  userId: number;
+  status: string;
+  kind: string;
+  slug: string;
+  name: string | null;
+  appBlockId: string | null;
+}> {
   const listing = await tx.appListing.findUnique({
     where: { id: appListingId },
-    select: { userId: true, status: true, kind: true, slug: true, name: true },
+    select: { userId: true, status: true, kind: true, slug: true, name: true, appBlockId: true },
   });
-  if (!listing || listing.kind !== 'offsite') {
-    throw new OffsiteModerationError('NOT_FOUND', 'Off-site listing not found.');
+  if (!listing) {
+    throw new OffsiteModerationError('NOT_FOUND', 'Listing not found.');
   }
   if (listing.userId !== callerUserId) {
     throw new OffsiteModerationError('NOT_OWNED', 'You can only manage your own listings.');
   }
-  return { userId: listing.userId, status: listing.status, slug: listing.slug, name: listing.name };
+  return {
+    userId: listing.userId,
+    status: listing.status,
+    kind: listing.kind,
+    slug: listing.slug,
+    name: listing.name,
+    appBlockId: listing.appBlockId,
+  };
 }
 
 export type UnpublishOwnListingResult = { appListingId: string; status: 'removed' };
 
 /**
- * OWNER self-hide their OWN approved off-site listing (approved → removed). A pure
- * visibility toggle — NO content-rating re-derive, NO asset change, NO publish
- * request. In ONE tx (primary): owner-load + guard offsite/owner/status, guard-flip
- * approved → removed (0-count → NOT_TRANSITIONABLE), write an `owner-unpublish`
- * event. No notification (the owner performed the action). `reason` optional.
+ * OWNER self-hide their OWN approved listing (approved → removed) — DUAL-KIND
+ * (W13 P4). A pure visibility toggle: NO content-rating re-derive, NO asset change,
+ * NO publish request. In ONE tx (primary): owner-load + guard owner/status, guard-flip
+ * the listing approved → removed (0-count → NOT_TRANSITIONABLE), write an
+ * `owner-unpublish` event.
+ *
+ * ON-SITE: it's a FULL TAKEDOWN — the backing `AppBlock` is also flipped approved →
+ * suspended in the SAME tx (via {@link flipBackingBlockStatus}), so the app leaves the
+ * store AND stops serving at `<slug>.civit.ai` / the run page (the block runtime gate
+ * reads `app_blocks.status`). OFF-SITE: only the listing flips (no backing block). No
+ * notification (the owner performed the action). `reason` optional.
  */
 export async function unpublishOwnListing(opts: {
   input: UnpublishOwnListingInput;
@@ -1046,15 +1099,16 @@ export async function unpublishOwnListing(opts: {
   const reason = input.reason?.trim() ? input.reason.trim() : null;
 
   await dbWrite.$transaction(async (tx) => {
-    const listing = await loadOwnedOffsiteInTx(tx, input.appListingId, userId);
+    const listing = await loadOwnedListingInTx(tx, input.appListingId, userId);
     if (listing.status !== 'approved') {
       throw new OffsiteModerationError(
         'NOT_TRANSITIONABLE',
         'Only an approved listing can be unpublished.'
       );
     }
+    const isOnsite = listing.kind === 'onsite';
     const flipped = await tx.appListing.updateMany({
-      where: { id: input.appListingId, kind: 'offsite', status: 'approved' },
+      where: { id: input.appListingId, kind: listing.kind, status: 'approved' },
       data: { status: 'removed' },
     });
     if (flipped.count === 0) {
@@ -1063,6 +1117,13 @@ export async function unpublishOwnListing(opts: {
         'This listing can no longer be unpublished.'
       );
     }
+    // ON-SITE full takedown: suspend the backing block so the runtime stops serving.
+    await flipBackingBlockStatus(tx, {
+      isOnsite,
+      appBlockId: listing.appBlockId,
+      from: 'approved',
+      to: 'suspended',
+    });
     await tx.appListingModerationEvent.create({
       data: {
         id: newAppListingModerationEventId(),
@@ -1083,7 +1144,8 @@ export async function unpublishOwnListing(opts: {
 export type RepublishOwnListingResult = { appListingId: string; status: 'approved' };
 
 /**
- * OWNER restore their OWN owner-unpublished off-site listing (removed → approved).
+ * OWNER restore their OWN owner-unpublished listing (removed → approved) — DUAL-KIND
+ * (W13 P4).
  *
  * 🔴 SAFETY GUARD (load-bearing): republish is allowed ONLY when the MOST-RECENT
  * `AppListingModerationEvent` for the listing is an `owner-unpublish`. If the last
@@ -1091,8 +1153,12 @@ export type RepublishOwnListingResult = { appListingId: string; status: 'approve
  * FORBIDDEN — an owner must NOT be able to self-restore a listing a moderator
  * removed. No events at all → also FORBIDDEN (can't prove owner-initiated removal).
  * The latest-event read + the flip are in ONE tx on the PRIMARY so a concurrent mod
- * takedown can't slip between the check and the restore. Pure visibility toggle — no
- * re-derive, no publish request. `reason` optional.
+ * takedown can't slip between the check and the restore.
+ *
+ * ON-SITE: the backing `AppBlock` is also restored suspended → approved in the SAME
+ * tx (via {@link flipBackingBlockStatus}), so the app serves again. OFF-SITE: only the
+ * listing flips. Pure visibility toggle — no re-derive, no publish request. `reason`
+ * optional.
  */
 export async function republishOwnListing(opts: {
   input: RepublishOwnListingInput;
@@ -1102,7 +1168,7 @@ export async function republishOwnListing(opts: {
   const reason = input.reason?.trim() ? input.reason.trim() : null;
 
   await dbWrite.$transaction(async (tx) => {
-    const listing = await loadOwnedOffsiteInTx(tx, input.appListingId, userId);
+    const listing = await loadOwnedListingInTx(tx, input.appListingId, userId);
     if (listing.status !== 'removed') {
       throw new OffsiteModerationError(
         'NOT_TRANSITIONABLE',
@@ -1124,8 +1190,9 @@ export async function republishOwnListing(opts: {
         'This listing was removed by a moderator and cannot be restored by its owner.'
       );
     }
+    const isOnsite = listing.kind === 'onsite';
     const flipped = await tx.appListing.updateMany({
-      where: { id: input.appListingId, kind: 'offsite', status: 'removed' },
+      where: { id: input.appListingId, kind: listing.kind, status: 'removed' },
       data: { status: 'approved' },
     });
     if (flipped.count === 0) {
@@ -1134,6 +1201,13 @@ export async function republishOwnListing(opts: {
         'This listing can no longer be republished.'
       );
     }
+    // ON-SITE: restore the backing block so the runtime serves again.
+    await flipBackingBlockStatus(tx, {
+      isOnsite,
+      appBlockId: listing.appBlockId,
+      from: 'suspended',
+      to: 'approved',
+    });
     await tx.appListingModerationEvent.create({
       data: {
         id: newAppListingModerationEventId(),


### PR DESCRIPTION
## W13 App Blocks post-approval management — Phase 4 (ON-SITE owner controls)

Widens the merged P3 **offsite** owner controls to **on-site** apps in `MySubmissionsList`, and fixes the "Open live" button to route gracefully. Dark / flag-gated, **no migration** (wires the already-merged owner procs).

### Backend
- **`unpublishOwnListing` / `republishOwnListing` are now DUAL-KIND.** On-site unpublish is a **full takedown**: one tx flips `app_listings` `approved→removed` **AND** the backing `app_blocks` `approved→suspended` (the block runtime serving gate reads `app_blocks.status`, so the app leaves the store **and** stops serving at `<slug>.civit.ai` / the run page). Republish reverses both. The **load-bearing safety guard is unchanged**: republish is allowed ONLY when the last moderation event is `owner-unpublish` — a mod `delist`/`purge` stays **FORBIDDEN**.
- **Factored the dual-table status flip** (previously inline in the mod `delistListing`/`relistListing`) into a shared `flipBackingBlockStatus` helper and reused it across delist/relist **and** both owner procs. No migration — `owner-unpublish`/`owner-republish` + `app_blocks.status='suspended'` are already valid.
- **Augmented `blocks.listMyPublishRequests`:** each row now carries the backing on-site `AppListing.id` + its TRUE `status` (a hidden app's publish request still reads `approved`), a **batched** `lastModerationAction` over the removed listings (one `distinct` `findMany`, **not N+1**), and `hasPage`. The publish-request `select` is inline — **no shared-select blast radius**.

### Frontend
- **`MySubmissionsList` owner controls** (mirror P3 offsite): status badge override (**Live** / **unpublished** / **removed by a moderator**), confirm-gated **Unpublish** (copy makes clear it takes the app **OFFLINE**, not just delists), **Republish** on an owner-hidden app, the owner **moderation-history** modal, and surfaced **Edit** (`/apps/[appBlockId]/edit-manifest`) + **Revenue** (`/apps/[appBlockId]/revenue`) links. The owner-hidden-vs-mod-removed distinction gates Republish — never render a button that 403s.
- **Factored shared modals:** extracted `OwnerUnpublishModal` + `OwnerModerationHistoryModal` into `ownerListingModals.tsx` (parameterized `testIdPrefix` + copy variant) and reused them in **both** the offsite and onsite lists (no fork-copy); the pure owner-control view-model (`offsiteOwnerControls`) is reused as-is.
- **Open-live fix** (`MySubmissionsList` no longer hardcodes `https://<slug>.civit.ai/`): branches via the shared `getDetailPrimaryAction` — a page app the viewer can open → **`/apps/run/<slug>`**; a page app they can't (flag dark) → the standalone origin; a model-slot app (no page) → **"Runs on model pages"** (block detail). Never a dead link.

### Tests
- **Service** (`offsite-moderation.service.mod-actions.test.ts`): on-site unpublish flips BOTH tables in one tx; on-site republish reverses both; republish **FORBIDDEN when the last event is a mod delist** (on the on-site path); non-owner FORBIDDEN; off-site path unchanged.
- **Query** (`blocks.router.listMyPublishRequests.test.ts`): the augmented query returns TRUE `AppListing.status` + `lastModerationAction` (**batched**, one moderation `findMany`) + `hasPage`; null-listing rows degrade gracefully.
- **Browser-mode** (`MySubmissionsList.browser.test.tsx`): status badges (Live / unpublished+Republish / removed-by-mod+**no** button); Unpublish confirm→`unpublishOwnListing`; Republish→`republishOwnListing`; history modal; edit-manifest + revenue links; Open-live branching across all three cases.

**Verbatim local counts:** service+view-model `68 passed`; query caller `3 passed`; related router/detail suites `73 passed`; browser-mode `43 passed` (MySubmissionsList 31, Offsite 12). Full `tsc --noEmit`: **0 errors**.

Ready for `/audit-pr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>