### PR TITLE
fix(blocks): allow opaque-origin CORS on collections/tip/buzz/shared-storage endpoints

### DIFF
--- a/src/pages/api/v1/blocks/buzz.ts
+++ b/src/pages/api/v1/blocks/buzz.ts
@@ -53,4 +53,11 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
 });
 
-export default withBlockScope(baseHandler, { requiredScope: 'buzz:read:self' });
+// allowOpaqueOrigin: an UNVERIFIED block direct-fetches this from an opaque
+// origin (`Origin: null`), so it needs `ACAO: null` to clear the CORS preflight;
+// the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
+// images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, {
+  requiredScope: 'buzz:read:self',
+  allowOpaqueOrigin: true,
+});

--- a/src/pages/api/v1/blocks/collections/[id]/follow.ts
+++ b/src/pages/api/v1/blocks/collections/[id]/follow.ts
@@ -101,4 +101,11 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
 });
 
-export default withBlockScope(baseHandler, { requiredScope: 'collections:write:self' });
+// allowOpaqueOrigin: an UNVERIFIED block direct-fetches this from an opaque
+// origin (`Origin: null`), so it needs `ACAO: null` to clear the CORS preflight;
+// the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
+// images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, {
+  requiredScope: 'collections:write:self',
+  allowOpaqueOrigin: true,
+});

--- a/src/pages/api/v1/blocks/collections/[id]/index.ts
+++ b/src/pages/api/v1/blocks/collections/[id]/index.ts
@@ -183,4 +183,11 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
 });
 
-export default withBlockScope(baseHandler, { requiredScope: 'collections:read:self' });
+// allowOpaqueOrigin: an UNVERIFIED block direct-fetches this from an opaque
+// origin (`Origin: null`), so it needs `ACAO: null` to clear the CORS preflight;
+// the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
+// images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, {
+  requiredScope: 'collections:read:self',
+  allowOpaqueOrigin: true,
+});

--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -241,4 +241,11 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 // Scope-gated: collections:read:self (self-scope → non-anon subject enforced by
 // the middleware). Not the "any valid token" catalog mode — reads are subject-
 // bound (own private collections), so a declared+granted scope is the gate.
-export default withBlockScope(baseHandler, { requiredScope: 'collections:read:self' });
+// allowOpaqueOrigin: an UNVERIFIED block direct-fetches this from an opaque
+// origin (`Origin: null`), so it needs `ACAO: null` to clear the CORS preflight;
+// the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
+// images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, {
+  requiredScope: 'collections:read:self',
+  allowOpaqueOrigin: true,
+});

--- a/src/pages/api/v1/blocks/shared-storage/increment.ts
+++ b/src/pages/api/v1/blocks/shared-storage/increment.ts
@@ -70,4 +70,11 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
 });
 
-export default withBlockScope(baseHandler, { requiredScope: 'apps:storage:shared:write' });
+// allowOpaqueOrigin: an UNVERIFIED block direct-fetches this from an opaque
+// origin (`Origin: null`), so it needs `ACAO: null` to clear the CORS preflight;
+// the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
+// images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, {
+  requiredScope: 'apps:storage:shared:write',
+  allowOpaqueOrigin: true,
+});

--- a/src/pages/api/v1/blocks/shared-storage/top.ts
+++ b/src/pages/api/v1/blocks/shared-storage/top.ts
@@ -66,4 +66,11 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
 });
 
-export default withBlockScope(baseHandler, { requiredScope: 'apps:storage:shared:read' });
+// allowOpaqueOrigin: an UNVERIFIED block direct-fetches this from an opaque
+// origin (`Origin: null`), so it needs `ACAO: null` to clear the CORS preflight;
+// the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
+// images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, {
+  requiredScope: 'apps:storage:shared:read',
+  allowOpaqueOrigin: true,
+});

--- a/src/pages/api/v1/blocks/tip.ts
+++ b/src/pages/api/v1/blocks/tip.ts
@@ -212,4 +212,11 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
 });
 
-export default withBlockScope(baseHandler, { requiredScope: 'social:tip:self' });
+// allowOpaqueOrigin: an UNVERIFIED block direct-fetches this from an opaque
+// origin (`Origin: null`), so it needs `ACAO: null` to clear the CORS preflight;
+// the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
+// images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, {
+  requiredScope: 'social:tip:self',
+  allowOpaqueOrigin: true,
+});

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -106,21 +106,27 @@ export interface WithBlockScopeOpts {
    * `src/components/AppBlocks/sandbox.ts` — only internal/verified tiers get
    * it), so the iframe runs at an OPAQUE origin and every `fetch` it makes
    * sends `Origin: null`. `null` can never be in the OauthClient.allowedOrigins
-   * allowlist, so a direct (non-bridge) catalog fetch's CORS preflight falls
-   * through to the handler and 405s — the in-block resource browser then can't
-   * load. (Generation/money go through the postMessage host bridge, which is
-   * CORS-free; the catalog selector is the one path that direct-fetches.)
+   * allowlist, so a direct (non-bridge) fetch's CORS preflight falls through to
+   * the handler and 405s — the in-block resource browser (or collections / tip /
+   * buzz / shared-storage rail) then can't load. (First hit by the catalog
+   * selector; the collections, tip, buzz, and shared-storage REST endpoints a
+   * block direct-fetches hit the SAME wall.)
    *
-   * SAFE ONLY for the block CATALOG endpoints (/api/v1/blocks/{models,images}),
-   * which is why this is an explicit per-endpoint opt-in and NOT a blanket
-   * middleware behavior: they return PUBLIC, maturity-clamped data (strictly ⊆
-   * the public, already-`ACAO:*` /api/v1/models), carry NO credentials
-   * (Allow-Credentials is omitted and block iframes have no civitai cookie), and
-   * the real request still requires a valid short-lived block JWT in
-   * `Authorization` (an attacker's own null-origin sandboxed page can't mint
-   * one). The preflight is CORS POLICY only; the token remains the gate. NEVER
-   * set this on a scoped/credentialed endpoint (me.ts, settings, …) — `ACAO:
-   * null` there would let ANY sandboxed page read a per-user response.
+   * SAFE wherever authorization rests SOLELY on the Bearer block-JWT with NO
+   * ambient/cookie credential — which is every block REST endpoint, so this is
+   * set on both the PUBLIC catalog endpoints (/api/v1/blocks/{models,images})
+   * and the per-user scoped ones (collections/tip/buzz/shared-storage). Block
+   * iframes carry no civitai cookie and `Access-Control-Allow-Credentials` is
+   * omitted, so `ACAO: null` grants NO tokenless access: the real request still
+   * requires a valid short-lived block JWT in `Authorization` (an attacker's own
+   * null-origin sandboxed page can't mint one), and per-user responses are bound
+   * to the token's SUBJECT — the preflight is CORS POLICY only; the token is the
+   * gate, not CORS. That is why it stays an explicit per-endpoint opt-in and not
+   * blanket middleware behavior. Do NOT set it on any endpoint that would
+   * authorize via an AMBIENT credential (a civitai session cookie) — there
+   * `ACAO: null` could let a sandboxed page read a per-user response WITHOUT
+   * presenting a token. (No block endpoint reads cookies today; the catalog
+   * endpoints additionally return only PUBLIC maturity-clamped data.)
    */
   allowOpaqueOrigin?: boolean;
 }
@@ -296,7 +302,7 @@ async function setBlockCors(
     return 'fallthrough';
   }
 
-  // Opaque-origin (`Origin: null`) opt-in — CATALOG endpoints only (see
+  // Opaque-origin (`Origin: null`) opt-in — opted-in block endpoints only (see
   // WithBlockScopeOpts.allowOpaqueOrigin). Unverified blocks run sandboxed
   // without `allow-same-origin` → opaque origin → `Origin: null`, which can
   // never be in the allowlist above. We echo `ACAO: null` ONLY when the

--- a/src/tests/api/v1/blocks/scoped-endpoints-cors-wiring.test.ts
+++ b/src/tests/api/v1/blocks/scoped-endpoints-cors-wiring.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * Wiring guard for the opaque-origin CORS fix on the SCOPED block endpoints
+ * (collections / tip / buzz / shared-storage).
+ *
+ * The middleware MECHANISM — `withBlockScope` honoring `Origin: null` only when
+ * `allowOpaqueOrigin` is set — is covered in
+ * `src/server/middleware/__tests__/block-scope.anytoken-mode.test.ts`. And the
+ * two CATALOG endpoints are guarded by `catalog-cors-wiring.test.ts`.
+ *
+ * But those prove nothing about whether these six per-user endpoints actually
+ * OPT IN. The endpoint-behavior tests (buzz-endpoint / tip-endpoint /
+ * collections-endpoint / …) mock `withBlockScope` as a passthrough whose
+ * `res.setHeader` is a no-op, so the real CORS layer never runs there — dropping
+ * `allowOpaqueOrigin: true` from any of these modules would leave every one of
+ * those tests green while re-breaking the in-block fetch for unverified
+ * (opaque-origin) blocks in prod (405 on the CORS preflight).
+ *
+ * This test captures the exact opts each endpoint module passes to
+ * `withBlockScope` at import time and asserts BOTH that the opaque-origin opt is
+ * present AND that the endpoint's `requiredScope` authorization gate is intact
+ * (the change must be CORS-only — it must not drop the scope).
+ */
+
+// Capture the opts each endpoint hands to withBlockScope at module-eval time.
+const captured: Array<Record<string, unknown>> = [];
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (_handler: unknown, opts: Record<string, unknown>) => {
+    captured.push(opts ?? {});
+    // Return a stand-in handler; this test never invokes it.
+    return () => undefined;
+  },
+  // Imported by several endpoints; only referenced inside the (never-run)
+  // handler bodies, but provide a stub so the named import resolves.
+  parseSubjectUserId: () => null,
+}));
+
+// Mock the heavy service/db/router imports the endpoints pull at module load so
+// importing them doesn't drag the Prisma client / external clients. Union of the
+// mock sets the existing per-endpoint tests use. None of these are invoked (we
+// only capture opts at module eval), so bare stubs suffice.
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
+vi.mock('~/server/services/collection.service', () => ({
+  getAllCollections: vi.fn(),
+  getCollectionItemCount: vi.fn(),
+  getUserCollectionsWithPermissions: vi.fn(),
+  getCollectionById: vi.fn(),
+  getCollectionItemsByCollectionId: vi.fn(),
+  getUserCollectionPermissionsById: vi.fn(),
+  addContributorToCollection: vi.fn(),
+  removeContributorFromCollection: vi.fn(),
+}));
+vi.mock('~/server/services/blocks/block-collections.service', () => ({
+  collectionWithinCeiling: vi.fn(),
+  getFollowedCollectionIds: vi.fn(),
+  hydrateBlockSubject: vi.fn(),
+  toMediaUrl: vi.fn(),
+  mapImageItemToMedia: vi.fn(),
+}));
+vi.mock('~/server/utils/block-catalog-maturity', () => ({
+  resolveCatalogBrowsingLevel: vi.fn(),
+}));
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: vi.fn(),
+}));
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: vi.fn(),
+  isRegionRestricted: vi.fn(),
+}));
+vi.mock('~/server/controllers/buzz.controller', () => ({
+  createBuzzTipTransactionHandler: vi.fn(),
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ Tracker: class {} }));
+vi.mock('~/server/utils/block-tip-rate-limit', () => ({
+  BLOCK_TIP_CAP_PER_DAY: 0,
+  BLOCK_TIP_MAX_PER_TIP: 0,
+  checkBlockTipRateLimit: vi.fn(),
+  refundBlockTipSpend: vi.fn(),
+  reserveBlockTipSpend: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({ getUserBuzzAccount: vi.fn() }));
+vi.mock('~/server/routers/apps-shared.router', () => ({
+  assertValidCounterKey: vi.fn(),
+  incrementSharedCounter: vi.fn(),
+  getTopSharedCounters: vi.fn(),
+}));
+
+// The endpoint → expected requiredScope contract. Import order fixes the
+// `captured` index; asserting the scope proves the CORS change didn't drop it.
+const ENDPOINTS: Array<{ module: string; requiredScope: string }> = [
+  { module: '~/pages/api/v1/blocks/collections/index', requiredScope: 'collections:read:self' },
+  { module: '~/pages/api/v1/blocks/collections/[id]/index', requiredScope: 'collections:read:self' },
+  { module: '~/pages/api/v1/blocks/collections/[id]/follow', requiredScope: 'collections:write:self' },
+  { module: '~/pages/api/v1/blocks/tip', requiredScope: 'social:tip:self' },
+  { module: '~/pages/api/v1/blocks/buzz', requiredScope: 'buzz:read:self' },
+  { module: '~/pages/api/v1/blocks/shared-storage/increment', requiredScope: 'apps:storage:shared:write' },
+  { module: '~/pages/api/v1/blocks/shared-storage/top', requiredScope: 'apps:storage:shared:read' },
+];
+
+describe('scoped block endpoints — opaque-origin CORS wiring', () => {
+  // The `await import(...)` cold-transforms a Next API page graph each; give the
+  // import-bound test a generous budget (mirrors catalog-cors-wiring.test.ts).
+  it('every collections/tip/buzz/shared-storage endpoint opts into allowOpaqueOrigin while keeping its requiredScope', { timeout: 60000 }, async () => {
+    for (const { module } of ENDPOINTS) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      await import(module);
+    }
+
+    expect(captured).toHaveLength(ENDPOINTS.length);
+
+    ENDPOINTS.forEach(({ requiredScope }, i) => {
+      const opts = captured[i];
+      // Must opt in — else an unverified (opaque-origin) block's direct fetch
+      // 405s on the CORS preflight again.
+      expect(opts.allowOpaqueOrigin).toBe(true);
+      // CORS-only change: the per-user authorization gate must be unchanged.
+      expect(opts.requiredScope).toBe(requiredScope);
+    });
+  });
+});


### PR DESCRIPTION
## The bug

An **unverified** App Block runs sandboxed **without** `allow-same-origin`, so its iframe is at an **opaque origin** and every cross-origin `fetch` it makes to the block REST API sends `Origin: null`. `null` can never appear in an app's `allowedOrigins` allowlist, so the browser's CORS preflight falls through the origin check and the handler 405s the `OPTIONS` — the in-block **collections / tip / buzz / shared-storage** rails can't load from a real (unverified) block.

The catalog endpoint `src/pages/api/v1/blocks/images.ts` already solved this: its default export is `withBlockScope(handler, { allowOpaqueOrigin: true })`, which makes the middleware echo `Access-Control-Allow-Origin: null` for an opaque-origin caller so the preflight clears. These newer scoped endpoints shipped without the flag.

## The change

Add `allowOpaqueOrigin: true` **alongside** each endpoint's existing `requiredScope` on the `withBlockScope(...)` default export of:

- `blocks/collections/index.ts` (`collections:read:self`)
- `blocks/collections/[id]/index.ts` (`collections:read:self`)
- `blocks/collections/[id]/follow.ts` (`collections:write:self`)
- `blocks/tip.ts` (`social:tip:self`)
- `blocks/buzz.ts` (`buzz:read:self`)
- `blocks/shared-storage/increment.ts` (`apps:storage:shared:write`)
- `blocks/shared-storage/top.ts` (`apps:storage:shared:read`)

No handler logic is touched — the only change per endpoint is the CORS opt (plus a one-line comment mirroring `images.ts`). Each endpoint keeps its `requiredScope` unchanged.

The `allowOpaqueOrigin` JSDoc previously said "SAFE ONLY for catalog endpoints / NEVER on a scoped endpoint". That framing is corrected (comment-only in the middleware) to the accurate invariant, since this change relies on it: **safe wherever authorization rests solely on the Bearer block-JWT with no ambient cookie credential — which is every block REST endpoint.**

## Security rationale

`allowOpaqueOrigin` **only** makes `withBlockScope` echo `Access-Control-Allow-Origin: null` (a CORS **policy** response) for an opaque-origin caller. It does **not** weaken authorization:

- **The block JWT (Bearer header, not a cookie) remains the sole authz gate.** `ACAO: null` grants no *tokenless* access — the real request still requires a valid short-lived block token an attacker's own null-origin sandboxed page cannot mint.
- **No credentialed-cookie context.** Block iframes carry no session cookie and `Access-Control-Allow-Credentials` is omitted, so `ACAO: null` cannot be leveraged to read a response via ambient credentials.
- **Per-user responses stay bound to the token subject.** A block only ever sees data authorized to *its* token; the CORS change only governs whether the block's own JS may read its own authorized response.

This is identical to the already-audited `images.ts` posture, extended to the per-user endpoints on the basis that they are token-gated with no cookies. Each endpoint's token/scope/revocation/ownership checks are unchanged; the only change is the CORS opt.

The one place this would be unsafe — an endpoint that authorizes via an **ambient** credential (a session cookie) — does not exist among the block REST endpoints, and the corrected JSDoc calls that out explicitly.

## Tests

The per-endpoint behavior tests mock `withBlockScope` as a passthrough (its `setHeader` is a no-op), so the real CORS layer never runs there — a dropped `allowOpaqueOrigin` would leave them green while re-breaking prod. This mirrors the existing `catalog-cors-wiring.test.ts`. Added `scoped-endpoints-cors-wiring.test.ts`, which imports each of the 7 endpoints and asserts the exact opts passed to `withBlockScope`:

- `allowOpaqueOrigin === true` (the fix), **and**
- `requiredScope` equals the endpoint's expected scope (proves the CORS change did not drop the authz gate).

The middleware CORS mechanism itself (honoring `Origin: null` only when opted in, still requiring a token, not widening to arbitrary origins) is already covered in `block-scope.anytoken-mode.test.ts`.

## Verify

- `NODE_OPTIONS=--max_old_space_size=8192 tsc --noEmit`: clean on all changed files.
- Block-endpoint + wiring + middleware CORS vitest suites: 78 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
