### PR TITLE
fix(app-blocks): gate review writes on the app-listings store flag, not the block-runtime flag

### DIFF
--- a/src/server/routers/__tests__/app-listings.router.review-write-gate.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.review-write-gate.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * W13 — the review WRITE gate rides the store-visibility flag, not the held
+ * block-runtime flag.
+ *
+ * `appListings.upsertReview` / `getMyReview` are `protectedProcedure`s (auth
+ * REQUIRED) behind `enforceAppListingsWriteFlag`. That middleware is keyed on the
+ * DEDICATED store-visibility flag `isAppListingsEnabled` — the SAME flag as the
+ * store visibility + `listReviews` read path — rather than the block-runtime
+ * `isAppBlocksEnabled` (`enforceAppBlocksFlag`). Before the fix, the reads gated
+ * on `app-listings` while the writes gated on `app-blocks-enabled`, so once the
+ * store widens INDEPENDENTLY a viewer would SEE the review affordance but 403 on
+ * submit.
+ *
+ * This drives the REAL `appListingsRouter` via `createCaller` so the middleware
+ * wiring (not a mock) decides. Both flag helpers are mocked with FAITHFUL
+ * per-user impls modelling the intended launch posture:
+ *   - `isAppBlocksEnabled` (block-runtime, HELD to mods)  → ON iff moderator.
+ *   - `isAppListingsEnabled` (store visibility, WIDENED)  → ON iff moderator OR
+ *     in the store cohort.
+ * So a store-cohort NON-mod is the regression case: store-visible but
+ * block-runtime-held. The review service is mocked so importing the router never
+ * drags in the generated Prisma client (stale in a PR worktree).
+ */
+
+const STORE_IDS = new Set([5]); // widened store cohort (non-mod, store-visible)
+
+const {
+  mockIsAppListingsEnabled,
+  mockIsAppBlocksEnabled,
+  mockUpsertReview,
+  mockGetMyReview,
+  mockListReviews,
+} = vi.hoisted(() => ({
+  mockIsAppListingsEnabled: vi.fn(),
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockUpsertReview: vi.fn(async () => ({ id: 1, recommended: true })),
+  mockGetMyReview: vi.fn(async () => ({ id: 1, recommended: true, details: null, createdAt: new Date() })),
+  mockListReviews: vi.fn(async () => ({ items: [{ id: 1 }], nextCursor: undefined })),
+}));
+
+// The write gate now reads `isAppListingsEnabled`; the router module ALSO
+// references `isAppBlocksEnabled`/`isAppBlocksAuthorEnabled` for OTHER procs'
+// middleware, so provide all three (only the two under test are exercised here).
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppListingsEnabled: mockIsAppListingsEnabled,
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: vi.fn(async () => false),
+}));
+// The review service is dynamically imported by the procs; mock it so the DB /
+// generated client is never loaded, and so we can assert "NOT consulted".
+vi.mock('~/server/services/blocks/app-listing-review.service', () => ({
+  upsertAppListingReview: (...a: unknown[]) => mockUpsertReview(...a),
+  getMyAppListingReview: (...a: unknown[]) => mockGetMyReview(...a),
+  listAppListingReviews: (...a: unknown[]) => mockListReviews(...a),
+}));
+// rateLimit pulls in redis; the gate under test is the flag middleware, so stub
+// it to a pass-through (mirrors the sibling router tests).
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+// server-domain pulls in env/host helpers; the maturity host-check is not the
+// unit under test (default SFW / non-red).
+vi.mock('~/server/utils/server-domain', () => ({ isHostForColor: () => false }));
+
+import { appListingsRouter } from '../app-listings.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/** Store-visibility flag: ON iff the caller is a mod OR in the widened store cohort. */
+function fakeListingsFlag(opts?: { user?: { id?: number; isModerator?: boolean } }) {
+  const u = opts?.user;
+  return Promise.resolve(!!u && (!!u.isModerator || STORE_IDS.has(u.id ?? -1)));
+}
+/** Held block-runtime flag: ON iff the caller is a moderator (the today posture). */
+function fakeBlocksFlag(opts?: { user?: { isModerator?: boolean } }) {
+  return Promise.resolve(!!opts?.user?.isModerator);
+}
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+const modUser = { id: 1, isModerator: true, tier: 'free', username: 'mod' };
+// Store-visible but block-runtime-HELD: the case that 403'd before the fix.
+const storeUser = { id: 5, isModerator: false, tier: 'free', username: 'store-viewer' };
+// Neither store-visible nor a mod: the store is still dark for this caller.
+const darkUser = { id: 7, isModerator: false, tier: 'free', username: 'user' };
+
+const upsertInput = { appListingId: 'apl_1', recommended: true };
+const getMyInput = { appListingId: 'apl_1' };
+const listInput = { appListingId: 'apl_1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAppListingsEnabled.mockImplementation(fakeListingsFlag);
+  mockIsAppBlocksEnabled.mockImplementation(fakeBlocksFlag);
+});
+
+// ---------------------------------------------------------------------------
+// REGRESSION: store-visible but block-runtime-held → writes ALLOWED.
+// ---------------------------------------------------------------------------
+
+describe('review writes ride the store flag (regression)', () => {
+  it('upsertReview: store-cohort NON-mod (listings ON, blocks OFF) is ALLOWED — the button no longer 403s', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(storeUser) as never);
+    await expect(caller.upsertReview(upsertInput)).resolves.toMatchObject({ id: 1 });
+    expect(mockUpsertReview).toHaveBeenCalledTimes(1);
+    expect(mockUpsertReview.mock.calls[0][0]).toMatchObject({ userId: storeUser.id });
+    // The write gate must consult the STORE flag, not the held block-runtime flag.
+    expect(mockIsAppListingsEnabled).toHaveBeenCalledWith({ user: storeUser });
+    expect(mockIsAppBlocksEnabled).not.toHaveBeenCalled();
+  });
+
+  it('getMyReview: store-cohort NON-mod (listings ON, blocks OFF) is ALLOWED — form prefill loads', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(storeUser) as never);
+    await expect(caller.getMyReview(getMyInput)).resolves.toMatchObject({ id: 1 });
+    expect(mockGetMyReview).toHaveBeenCalledWith(getMyInput.appListingId, storeUser.id);
+    expect(mockIsAppBlocksEnabled).not.toHaveBeenCalled();
+  });
+
+  it('moderator still passes (OR-fallback preserves today’s access)', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(caller.upsertReview(upsertInput)).resolves.toMatchObject({ id: 1 });
+    await expect(caller.getMyReview(getMyInput)).resolves.toMatchObject({ id: 1 });
+    expect(mockUpsertReview).toHaveBeenCalledTimes(1);
+    expect(mockGetMyReview).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REJECT: store dark for the caller → UNAUTHORIZED, service NOT consulted.
+// ---------------------------------------------------------------------------
+
+describe('review writes reject when the store is dark for the caller', () => {
+  it('upsertReview: non-store non-mod (listings OFF) → UNAUTHORIZED, service NOT called', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(darkUser) as never);
+    await expect(caller.upsertReview(upsertInput)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockUpsertReview).not.toHaveBeenCalled();
+  });
+
+  it('getMyReview: non-store non-mod (listings OFF) → UNAUTHORIZED, service NOT called', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(darkUser) as never);
+    await expect(caller.getMyReview(getMyInput)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockGetMyReview).not.toHaveBeenCalled();
+  });
+
+  it('upsertReview: anonymous → UNAUTHORIZED (protectedProcedure), service NOT called', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.upsertReview(upsertInput)).rejects.toBeInstanceOf(TRPCError);
+    expect(mockUpsertReview).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// READ path unchanged: listReviews stays on the same store flag (soft, not hard).
+// ---------------------------------------------------------------------------
+
+describe('listReviews (read) — behavior unchanged', () => {
+  it('store-cohort NON-mod (listings ON): reviews served', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(storeUser) as never);
+    await expect(caller.listReviews(listInput)).resolves.toEqual({ items: [{ id: 1 }], nextCursor: undefined });
+    expect(mockListReviews).toHaveBeenCalledTimes(1);
+  });
+
+  it('non-store non-mod (listings OFF): EMPTY page (soft), service NOT consulted — no throw', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(darkUser) as never);
+    await expect(caller.listReviews(listInput)).resolves.toEqual({ items: [], nextCursor: undefined });
+    expect(mockListReviews).not.toHaveBeenCalled();
+  });
+
+  it('anonymous (listings OFF): EMPTY page (soft), never throws', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.listReviews(listInput)).resolves.toEqual({ items: [], nextCursor: undefined });
+    expect(mockListReviews).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -131,6 +131,22 @@ const enforceAppListingsReadFlag = middleware(async ({ ctx, next }) => {
 });
 
 /**
+ * Store WRITE gate — mirrors `enforceAppBlocksFlag`'s HARD-THROW shape (a write
+ * with the store dark must REJECT, not soft-fail like the read gate) but keyed on
+ * the DEDICATED store-visibility flag `isAppListingsEnabled` (which OR-falls-back
+ * to `isAppBlocksEnabled`). This keeps the review WRITEs (`upsertReview`/
+ * `getMyReview`) on the SAME flag as the store visibility + reviews read path
+ * (`enforceAppListingsReadFlag`), so once `app-listings` widens independently of
+ * the held block-runtime gate, a viewer who can SEE the review affordance can
+ * also submit — instead of seeing the button and 403-ing on write. Zero change
+ * today: the OR-fallback preserves the existing mods + app-dev-testers cohort.
+ */
+const enforceAppListingsWriteFlag = middleware(async ({ ctx, next }) => {
+  if (await isAppListingsEnabled({ user: ctx.user })) return next();
+  throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Apps are not enabled' });
+});
+
+/**
  * Red-capable host check — maturity is a HOST property (independent of moderator
  * status), so even a mod on civitai.com does not see mature (r/x) listings in
  * these viewer-facing reads. Fail-closed: a missing host → false (SFW only).
@@ -1038,12 +1054,18 @@ export const appListingsRouter = router({
   // user EXCEPT the listing owner, for BOTH kinds, NO install/usage gate.
   //
   // FLAG GATING: the WRITEs (`upsertReview`/`getMyReview`) are `protectedProcedure`
-  // (auth REQUIRED) + `enforceAppBlocksFlag` — the "store enabled for this viewer"
-  // gate that THROWS UNAUTHORIZED when off (a real anon/non-mod caller can't write
-  // until the segment widens at GA). `listReviews` is `publicProcedure` +
+  // (auth REQUIRED) + `enforceAppListingsWriteFlag` — the "store enabled for this
+  // viewer" gate keyed on the SAME dedicated `app-listings` flag as the store
+  // visibility + `listReviews` read path, THROWING UNAUTHORIZED when off (a real
+  // anon/non-store caller can't write). Keeping the writes on `app-listings`
+  // (not the held block-runtime `app-blocks-enabled`) means the review submit
+  // widens WITH the store, so a viewer who SEES the affordance can also submit
+  // instead of 403-ing. `listReviews` is `publicProcedure` +
   // `enforceAppListingsReadFlag` (empty page when off, same posture as
-  // listAvailable). The review affordance renders only on the mod-only
-  // store-preview surface today (the public `/apps/[slug]` cutover is P2d).
+  // listAvailable). Zero change today: `isAppListingsEnabled` OR-falls-back to
+  // `isAppBlocksEnabled`, so the current mods + app-dev-testers cohort is
+  // unchanged. The review affordance renders only on the mod-only store-preview
+  // surface today (the public `/apps/[slug]` cutover is P2d).
   //
   // FOLLOW-UP (deferred): a MOD exclude/report path for individual reviews.
   // `listReviews` ALREADY filters `exclude`/`tosViolation`, so a future mod action
@@ -1056,7 +1078,7 @@ export const appListingsRouter = router({
    * non-approved-listing gates are enforced in the service (FORBIDDEN / BAD_REQUEST).
    */
   upsertReview: protectedProcedure
-    .use(enforceAppBlocksFlag)
+    .use(enforceAppListingsWriteFlag)
     .use(
       rateLimit({
         limit: 30,
@@ -1075,7 +1097,7 @@ export const appListingsRouter = router({
 
   /** USER: the caller's OWN review for a listing (form prefill), or null. */
   getMyReview: protectedProcedure
-    .use(enforceAppBlocksFlag)
+    .use(enforceAppListingsWriteFlag)
     .input(getMyAppListingReviewSchema)
     .query(async ({ ctx, input }) => {
       if (!ctx.user) return null;


### PR DESCRIPTION
## Problem

W13 (#2987) deliberately decoupled the App Blocks **store** from the block-runtime kill-switch: the store visibility + reviews **READ** path (`listReviews`, `getAppDetail`, `listAvailable`) was repointed onto the dedicated `app-listings` flag (`enforceAppListingsReadFlag` → `isAppListingsEnabled`) so the store can be widened on its own launch lever, independently of the mod-only `app-blocks-enabled` runtime gate.

But the review **WRITE** procs were left behind on the old gate:

- reads → `enforceAppListingsReadFlag` (`app-listings`)
- writes (`upsertReview` / `getMyReview`) → `enforceAppBlocksFlag` (`app-blocks-enabled`, mod-only, hard-throws `UNAUTHORIZED`)

So the moment `app-listings` is widened independently, a signed-in user would **SEE** the thumbs review button + the reviews list but their submit would 403 `"Apps are not enabled."` Root cause: #2987 repointed the reads but never the writes.

## Fix

- Add `enforceAppListingsWriteFlag` — a **hard-throw** gate (a write with the store dark must reject, not soft-fail like the read gate) that mirrors `enforceAppBlocksFlag`'s shape but is keyed on `isAppListingsEnabled`.
- Repoint `upsertReview` and `getMyReview` onto it. No other proc touched. `enforceAppBlocksFlag` is retained (still used by the mod-only `backfillAssets`).
- Fix the now-misleading flag-gating comment.

The review submit now widens **WITH** the store — a viewer who sees the affordance can also submit.

## Why it's zero behavior change today

`isAppListingsEnabled` OR-falls-back to `isAppBlocksEnabled` (verified in `app-blocks-flag.ts:249`), so today's cohort (mods + app-dev-testers via `app-blocks-enabled`) still passes. This only changes who's allowed **once `app-listings` is widened independently** — the intended launch behavior (reviews ride the store flag, per the product decision). **No new flag. No migration.**

## Tests

New `app-listings.router.review-write-gate.test.ts` (9 tests, drives the real router via `createCaller`):

- **Regression**: a store-cohort NON-mod (`isAppListingsEnabled` true, `isAppBlocksEnabled` false — the store-visible-but-block-held case that 403'd before) is **ALLOWED** for `upsertReview` + `getMyReview`; asserts the write gate consults the store flag and **not** the block-runtime flag.
- Moderator still passes (OR-fallback preserves today's access).
- **Reject** (`UNAUTHORIZED`, service not consulted) when `isAppListingsEnabled` is false, incl. anonymous.
- `listReviews` (read) behavior unchanged (soft empty-page when off, never throws).

Local `npx vitest run`: `app-listings.router.review-write-gate.test.ts` **9 passed**, `app-listings.router.read-flag-gate.test.ts` **8 passed**. Scoped `tsc --noEmit` clean on both changed files (authoritative typecheck = Tekton pr-preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
