### PR TITLE
fix(blocks): media-only collection discovery, cover fallback, sort alias, string 400s

### DIFF
--- a/src/pages/api/v1/blocks/collections/[id]/index.ts
+++ b/src/pages/api/v1/blocks/collections/[id]/index.ts
@@ -87,7 +87,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 
   const parsed = querySchema.safeParse(req.query);
   if (!parsed.success) {
-    res.status(400).json({ error: parsed.error });
+    res.status(400).json({ error: 'Invalid query parameters', details: parsed.error.flatten() });
     return;
   }
   const { cursor, limit } = parsed.data;

--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -14,15 +14,20 @@ import {
 } from '~/server/services/collection.service';
 import {
   collectionWithinCeiling,
+  getFallbackCoverImages,
   getFollowedCollectionIds,
   hydrateBlockSubject,
-  toMediaUrl,
+  toCoverImageUrl,
 } from '~/server/services/blocks/block-collections.service';
 import { resolveCatalogBrowsingLevel } from '~/server/utils/block-catalog-maturity';
 import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 import { CollectionSort } from '~/server/common/enums';
-import { CollectionItemStatus, CollectionReadConfiguration } from '~/shared/utils/prisma/enums';
+import {
+  CollectionItemStatus,
+  CollectionReadConfiguration,
+  CollectionType,
+} from '~/shared/utils/prisma/enums';
 
 /**
  * GET /api/v1/blocks/collections?mode=public|mine&query&sort&cursor&limit
@@ -46,10 +51,25 @@ import { CollectionItemStatus, CollectionReadConfiguration } from '~/shared/util
 
 export const config = { api: { responseLimit: false } };
 
+// Block-friendly `sort` aliases → the internal CollectionSort enum. Accepted IN
+// ADDITION to the raw enum values (backward-compat), so a block may send the
+// simple `newest`/`popular` OR the underlying `Newest`/`Most Followers`. There is
+// no media-count popularity sort on the service — `popular` maps to the closest
+// available ranking, MostContributors ('Most Followers').
+const SORT_ALIAS: Record<string, CollectionSort> = {
+  newest: CollectionSort.Newest,
+  popular: CollectionSort.MostContributors,
+};
+
 const querySchema = z.object({
   mode: z.enum(['public', 'mine']).default('public'),
   query: z.string().trim().max(100).optional(),
-  sort: z.enum(CollectionSort).default(CollectionSort.Newest),
+  // Preprocess maps a friendly alias (case-insensitive) to the enum value; a raw
+  // enum value passes through unchanged; undefined falls to the enum default.
+  sort: z.preprocess(
+    (v) => (typeof v === 'string' ? SORT_ALIAS[v.toLowerCase()] ?? v : v),
+    z.enum(CollectionSort).default(CollectionSort.Newest)
+  ),
   // Keyset cursor on the collection id (both modes order by id DESC).
   cursor: z.coerce.number().int().positive().optional(),
   limit: z.coerce.number().int().min(1).max(100).default(24),
@@ -81,7 +101,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 
   const parsed = querySchema.safeParse(req.query);
   if (!parsed.success) {
-    res.status(400).json({ error: parsed.error });
+    res.status(400).json({ error: 'Invalid query parameters', details: parsed.error.flatten() });
     return;
   }
   const { mode, query, sort, cursor, limit } = parsed.data;
@@ -122,6 +142,10 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
           query,
           sort,
           privacy: [CollectionReadConfiguration.Public],
+          // MEDIA collections only — a Model/Article/Post collection renders an
+          // empty player (the detail endpoint drops non-image items), so restrict
+          // discovery to Image collections (which hold images + videos).
+          types: [CollectionType.Image],
         },
         user: subjectUser,
         select: {
@@ -161,9 +185,13 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       // source is exhausted → no nextCursor.
 
       const ids = items.map((c) => c.id);
-      const [countRows, followed] = await Promise.all([
+      // Cover fallback: for collections whose own cover `image` is null, derive a
+      // cover from the collection's first accepted media item (batched).
+      const missingCoverIds = items.filter((c) => !c.image?.url).map((c) => c.id);
+      const [countRows, followed, fallbackCovers] = await Promise.all([
         getCollectionItemCount({ collectionIds: ids, status: CollectionItemStatus.ACCEPTED }),
         getFollowedCollectionIds(subjectUserId, ids),
+        getFallbackCoverImages(missingCoverIds),
       ]);
       const countMap = new Map(countRows.map((c) => [c.id, Number(c.count)]));
 
@@ -172,7 +200,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
           id: c.id,
           name: c.name,
           description: c.description ?? null,
-          coverImageUrl: toMediaUrl(c.image),
+          coverImageUrl: toCoverImageUrl(c.image ?? fallbackCovers.get(c.id)),
           itemCount: countMap.get(c.id) ?? 0,
           curator: { userId: c.userId, username: c.user?.username ?? null },
           isPublic: c.read === CollectionReadConfiguration.Public,
@@ -212,9 +240,11 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     }
 
     const ids = items.map((c) => c.id);
-    const [countRows, followed] = await Promise.all([
+    const missingCoverIds = items.filter((c) => !c.image?.url).map((c) => c.id);
+    const [countRows, followed, fallbackCovers] = await Promise.all([
       getCollectionItemCount({ collectionIds: ids, status: CollectionItemStatus.ACCEPTED }),
       getFollowedCollectionIds(subjectUserId, ids),
+      getFallbackCoverImages(missingCoverIds),
     ]);
     const countMap = new Map(countRows.map((c) => [c.id, Number(c.count)]));
 
@@ -223,7 +253,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
         id: c.id,
         name: c.name,
         description: c.description ?? null,
-        coverImageUrl: toMediaUrl(c.image),
+        coverImageUrl: toCoverImageUrl(c.image ?? fallbackCovers.get(c.id)),
         itemCount: countMap.get(c.id) ?? 0,
         curator: { userId: c.userId, username: subjectUser.username ?? null },
         isPublic: c.read === CollectionReadConfiguration.Public,

--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -156,7 +156,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
           nsfwLevel: true,
           userId: true,
           user: { select: { id: true, username: true } },
-          image: { select: { url: true, type: true } },
+          image: { select: { url: true, type: true, nsfwLevel: true } },
         },
       });
 
@@ -185,13 +185,20 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
       // source is exhausted → no nextCursor.
 
       const ids = items.map((c) => c.id);
-      // Cover fallback: for collections whose own cover `image` is null, derive a
-      // cover from the collection's first accepted media item (batched).
-      const missingCoverIds = items.filter((c) => !c.image?.url).map((c) => c.id);
+      // Cover fallback + MATURITY CLAMP: a cover is usable only when it exists AND
+      // its own nsfwLevel is within the token's clamped ceiling. A MIXED-bucket
+      // collection can pass the collection-level discovery gate (bitwise) yet have
+      // a mature cover / first item, so an unclamped cover would leak mature media
+      // on a SFW-domain / region-restricted token. When the primary cover is null
+      // OR over the ceiling, fall back to the newest CLAMPED item (same authority
+      // the detail path uses).
+      const primaryCoverUsable = (c: (typeof items)[number]) =>
+        !!c.image?.url && collectionWithinCeiling(c.image.nsfwLevel ?? 0, browsingLevel);
+      const missingCoverIds = items.filter((c) => !primaryCoverUsable(c)).map((c) => c.id);
       const [countRows, followed, fallbackCovers] = await Promise.all([
         getCollectionItemCount({ collectionIds: ids, status: CollectionItemStatus.ACCEPTED }),
         getFollowedCollectionIds(subjectUserId, ids),
-        getFallbackCoverImages(missingCoverIds),
+        getFallbackCoverImages(missingCoverIds, browsingLevel),
       ]);
       const countMap = new Map(countRows.map((c) => [c.id, Number(c.count)]));
 
@@ -200,7 +207,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
           id: c.id,
           name: c.name,
           description: c.description ?? null,
-          coverImageUrl: toCoverImageUrl(c.image ?? fallbackCovers.get(c.id)),
+          coverImageUrl: toCoverImageUrl(primaryCoverUsable(c) ? c.image : fallbackCovers.get(c.id)),
           itemCount: countMap.get(c.id) ?? 0,
           curator: { userId: c.userId, username: c.user?.username ?? null },
           isPublic: c.read === CollectionReadConfiguration.Public,
@@ -240,11 +247,16 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     }
 
     const ids = items.map((c) => c.id);
-    const missingCoverIds = items.filter((c) => !c.image?.url).map((c) => c.id);
+    // Same maturity clamp as public discovery: a primary cover over the ceiling
+    // (or null) falls back to the newest CLAMPED item so a SFW-domain / region-
+    // restricted token never gets a mature thumbnail — even for own collections.
+    const primaryCoverUsable = (c: (typeof items)[number]) =>
+      !!c.image?.url && collectionWithinCeiling(c.image.nsfwLevel ?? 0, browsingLevel);
+    const missingCoverIds = items.filter((c) => !primaryCoverUsable(c)).map((c) => c.id);
     const [countRows, followed, fallbackCovers] = await Promise.all([
       getCollectionItemCount({ collectionIds: ids, status: CollectionItemStatus.ACCEPTED }),
       getFollowedCollectionIds(subjectUserId, ids),
-      getFallbackCoverImages(missingCoverIds),
+      getFallbackCoverImages(missingCoverIds, browsingLevel),
     ]);
     const countMap = new Map(countRows.map((c) => [c.id, Number(c.count)]));
 
@@ -253,7 +265,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
         id: c.id,
         name: c.name,
         description: c.description ?? null,
-        coverImageUrl: toCoverImageUrl(c.image ?? fallbackCovers.get(c.id)),
+        coverImageUrl: toCoverImageUrl(primaryCoverUsable(c) ? c.image : fallbackCovers.get(c.id)),
         itemCount: countMap.get(c.id) ?? 0,
         curator: { userId: c.userId, username: subjectUser.username ?? null },
         isPublic: c.read === CollectionReadConfiguration.Public,

--- a/src/server/services/blocks/block-collections.service.ts
+++ b/src/server/services/blocks/block-collections.service.ts
@@ -20,6 +20,7 @@
  * additionally drops collections whose own `nsfwLevel` exceeds the ceiling.
  */
 
+import { Prisma } from '@prisma/client';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { dbRead } from '~/server/db/client';
 import { sessionClient } from '~/server/auth/session-client';
@@ -93,33 +94,44 @@ export function toCoverImageUrl(
 }
 
 /**
- * Fallback cover source for collections whose own `image` (cover) is null: the
- * media (url,type) of each collection's most-recent ACCEPTED image/video item.
- * Batched (one query for all ids) with `distinct` on collectionId so we take a
- * single representative item per collection. Returns a Map keyed by collectionId;
- * collections with no accepted media item are simply absent (→ placeholder tile).
+ * Fallback cover source for collections whose own cover is null OR is itself over
+ * the ceiling: the media (url,type) of each collection's most-recent ACCEPTED
+ * item WHOSE OWN `Image.nsfwLevel` is PERMITTED by the token's clamped
+ * `browsingLevel`. This is the maturity clamp the discovery cover MUST apply — a
+ * MIXED-bucket collection (nsfwLevel 29) intersects a SFW ceiling and passes the
+ * collection-level discovery gate, but its newest item can be R/X; surfacing that
+ * thumbnail on a SFW-domain / region-restricted token would leak mature media.
+ *
+ * The nsfw test is BITWISE (`nsfwLevel & browsingLevel != 0`, plus unrated 0 —
+ * the identical authority the detail path + images service use), applied IN the
+ * WHERE so `DISTINCT ON (collectionId)` picks the newest *permitted* item per
+ * collection (filtering after `distinct` would drop the cover entirely). Returns
+ * a Map keyed by collectionId; a collection with no permitted item is absent
+ * (→ placeholder tile).
  */
 export async function getFallbackCoverImages(
-  collectionIds: number[]
+  collectionIds: number[],
+  browsingLevel: number
 ): Promise<Map<number, { url: string | null; type: string | null }>> {
   if (collectionIds.length === 0) return new Map();
-  const rows = await dbRead.collectionItem.findMany({
-    where: {
-      collectionId: { in: collectionIds },
-      imageId: { not: null },
-      status: CollectionItemStatus.ACCEPTED,
-    },
-    select: {
-      collectionId: true,
-      image: { select: { url: true, type: true } },
-    },
-    orderBy: [{ collectionId: 'asc' }, { createdAt: 'desc' }],
-    distinct: ['collectionId'],
-  });
+  const rows = await dbRead.$queryRaw<
+    { collectionId: number; url: string | null; type: string | null }[]
+  >`
+    SELECT DISTINCT ON (ci."collectionId")
+      ci."collectionId" as "collectionId",
+      i."url" as "url",
+      i."type"::text as "type"
+    FROM "CollectionItem" ci
+    JOIN "Image" i ON i."id" = ci."imageId"
+    WHERE ci."collectionId" IN (${Prisma.join(collectionIds)})
+      AND ci."status" = ${CollectionItemStatus.ACCEPTED}::"CollectionItemStatus"
+      AND ((i."nsfwLevel" & ${browsingLevel}) != 0 OR i."nsfwLevel" = 0)
+    ORDER BY ci."collectionId", ci."createdAt" DESC
+  `;
   const map = new Map<number, { url: string | null; type: string | null }>();
   for (const r of rows) {
-    if (r.collectionId != null && r.image?.url) {
-      map.set(r.collectionId, { url: r.image.url, type: r.image.type ?? null });
+    if (r.collectionId != null && r.url) {
+      map.set(r.collectionId, { url: r.url, type: r.type ?? null });
     }
   }
   return map;

--- a/src/server/services/blocks/block-collections.service.ts
+++ b/src/server/services/blocks/block-collections.service.ts
@@ -25,6 +25,7 @@ import { dbRead } from '~/server/db/client';
 import { sessionClient } from '~/server/auth/session-client';
 import type { SessionUser } from '~/types/session';
 import { Flags } from '~/shared/utils/flags';
+import { CollectionItemStatus } from '~/shared/utils/prisma/enums';
 
 /**
  * Resolve the FULL server-side SessionUser for a verified block-token subject
@@ -68,6 +69,60 @@ export function toMediaUrl(
     original: true,
     type: (image.type as 'image' | 'video' | undefined) ?? 'image',
   });
+}
+
+/**
+ * Compose a directly-`<img>`-renderable COVER url for a collection cover Image.
+ * Identical to `toMediaUrl` for a still image, but for a VIDEO cover it requests
+ * a transcoded still frame (`type: 'image'` + `transcode` + `anim: false`) so the
+ * returned url is a poster/first-frame JPEG — NOT the raw `.mp4` an `<img>` tag
+ * can't display (the cause of the "missing thumbnail" cards). Returns null when
+ * there is no image key so the block renders its placeholder tile.
+ *
+ * Distinct from `toMediaUrl` (used for the player's media items, where a video
+ * item must keep its playable `.mp4` url).
+ */
+export function toCoverImageUrl(
+  image: { url?: string | null; type?: string | null } | null | undefined
+): string | null {
+  if (!image?.url) return null;
+  const isVideo = image.type === 'video';
+  return isVideo
+    ? getEdgeUrl(image.url, { original: true, type: 'image', transcode: true, anim: false })
+    : getEdgeUrl(image.url, { original: true, type: 'image' });
+}
+
+/**
+ * Fallback cover source for collections whose own `image` (cover) is null: the
+ * media (url,type) of each collection's most-recent ACCEPTED image/video item.
+ * Batched (one query for all ids) with `distinct` on collectionId so we take a
+ * single representative item per collection. Returns a Map keyed by collectionId;
+ * collections with no accepted media item are simply absent (→ placeholder tile).
+ */
+export async function getFallbackCoverImages(
+  collectionIds: number[]
+): Promise<Map<number, { url: string | null; type: string | null }>> {
+  if (collectionIds.length === 0) return new Map();
+  const rows = await dbRead.collectionItem.findMany({
+    where: {
+      collectionId: { in: collectionIds },
+      imageId: { not: null },
+      status: CollectionItemStatus.ACCEPTED,
+    },
+    select: {
+      collectionId: true,
+      image: { select: { url: true, type: true } },
+    },
+    orderBy: [{ collectionId: 'asc' }, { createdAt: 'desc' }],
+    distinct: ['collectionId'],
+  });
+  const map = new Map<number, { url: string | null; type: string | null }>();
+  for (const r of rows) {
+    if (r.collectionId != null && r.image?.url) {
+      map.set(r.collectionId, { url: r.image.url, type: r.image.type ?? null });
+    }
+  }
+  return map;
 }
 
 /** True iff the collection's own nsfwLevel is permitted by the clamped ceiling. */

--- a/src/tests/api/v1/blocks/block-collections-cover.test.ts
+++ b/src/tests/api/v1/blocks/block-collections-cover.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 
 /**
  * Unit coverage for the REAL `toCoverImageUrl` (the endpoint test mocks it). The
@@ -14,10 +14,14 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('~/client-utils/cf-images-utils', () => ({
   getEdgeUrl: (src: string, opts: Record<string, unknown>) => JSON.stringify({ src, ...opts }),
 }));
-vi.mock('~/server/db/client', () => ({ dbRead: {} }));
+const mockQueryRaw = vi.hoisted(() => vi.fn());
+vi.mock('~/server/db/client', () => ({ dbRead: { $queryRaw: mockQueryRaw } }));
 vi.mock('~/server/auth/session-client', () => ({ sessionClient: {} }));
 
-import { toCoverImageUrl } from '~/server/services/blocks/block-collections.service';
+import {
+  getFallbackCoverImages,
+  toCoverImageUrl,
+} from '~/server/services/blocks/block-collections.service';
 
 describe('toCoverImageUrl', () => {
   it('returns null when the image / url is missing', () => {
@@ -42,5 +46,45 @@ describe('toCoverImageUrl', () => {
     expect(out.type).toBe('image');
     expect(out.transcode).toBe(true);
     expect(out.anim).toBe(false);
+  });
+});
+
+describe('getFallbackCoverImages (maturity clamp)', () => {
+  beforeEach(() => mockQueryRaw.mockReset());
+
+  it('no ids → no query, empty map', async () => {
+    const map = await getFallbackCoverImages([], 3);
+    expect(map.size).toBe(0);
+    expect(mockQueryRaw).not.toHaveBeenCalled();
+  });
+
+  it('threads browsingLevel into a BITWISE-clamped query and maps only url-bearing rows', async () => {
+    mockQueryRaw.mockResolvedValueOnce([
+      { collectionId: 10, url: 'sfw-10', type: 'image' },
+      { collectionId: 11, url: 'clip-11', type: 'video' },
+      { collectionId: 12, url: null, type: 'image' }, // no url → dropped (placeholder)
+    ]);
+    const map = await getFallbackCoverImages([10, 11, 12], 3);
+    expect(map.get(10)).toEqual({ url: 'sfw-10', type: 'image' });
+    expect(map.get(11)).toEqual({ url: 'clip-11', type: 'video' });
+    expect(map.has(12)).toBe(false);
+
+    // The raw tagged-template call must carry the browsingLevel (3) as a bound
+    // value and use a bitwise nsfwLevel predicate + DISTINCT ON so the newest
+    // PERMITTED item per collection is selected (not filtered-after-distinct).
+    const call = mockQueryRaw.mock.calls[0] as unknown as [TemplateStringsArray, ...unknown[]];
+    const [strings, ...values] = call;
+    const sql = strings.join(' ? ');
+    expect(sql).toContain('"nsfwLevel" &');
+    expect(sql).toContain('DISTINCT ON (ci."collectionId")');
+    expect(sql).toContain('ORDER BY ci."collectionId", ci."createdAt" DESC');
+    expect(values).toContain(3);
+  });
+
+  it('a stricter ceiling is threaded through verbatim', async () => {
+    mockQueryRaw.mockResolvedValueOnce([]);
+    await getFallbackCoverImages([10], 1);
+    const [, ...values] = mockQueryRaw.mock.calls[0] as unknown as [TemplateStringsArray, ...unknown[]];
+    expect(values).toContain(1);
   });
 });

--- a/src/tests/api/v1/blocks/block-collections-cover.test.ts
+++ b/src/tests/api/v1/blocks/block-collections-cover.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest';
+
+/**
+ * Unit coverage for the REAL `toCoverImageUrl` (the endpoint test mocks it). The
+ * feedback fix: a collection cover must always be `<img>`-renderable, so a VIDEO
+ * cover has to resolve to a transcoded still frame (poster), never the raw `.mp4`.
+ *
+ * `getEdgeUrl` reaches into client-only modules at import; the block service's DB
+ * client is irrelevant here — both are mocked so we exercise only the option
+ * shaping `toCoverImageUrl` performs.
+ */
+
+// Echo the args so we can assert exactly what getEdgeUrl was asked to produce.
+vi.mock('~/client-utils/cf-images-utils', () => ({
+  getEdgeUrl: (src: string, opts: Record<string, unknown>) => JSON.stringify({ src, ...opts }),
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: {} }));
+vi.mock('~/server/auth/session-client', () => ({ sessionClient: {} }));
+
+import { toCoverImageUrl } from '~/server/services/blocks/block-collections.service';
+
+describe('toCoverImageUrl', () => {
+  it('returns null when the image / url is missing', () => {
+    expect(toCoverImageUrl(null)).toBeNull();
+    expect(toCoverImageUrl(undefined)).toBeNull();
+    expect(toCoverImageUrl({ url: null, type: 'image' })).toBeNull();
+    expect(toCoverImageUrl({ url: '', type: 'image' })).toBeNull();
+  });
+
+  it('a still IMAGE cover renders as an image (no transcode)', () => {
+    const out = JSON.parse(toCoverImageUrl({ url: 'abc', type: 'image' })!);
+    expect(out.src).toBe('abc');
+    expect(out.type).toBe('image');
+    expect(out.original).toBe(true);
+    expect(out.transcode).toBeUndefined();
+  });
+
+  it('a VIDEO cover renders as a transcoded, non-animated POSTER (image), not raw video', () => {
+    const out = JSON.parse(toCoverImageUrl({ url: 'clip', type: 'video' })!);
+    expect(out.src).toBe('clip');
+    // Rendered as an image (poster), NOT type: 'video' — an <img> can't play mp4.
+    expect(out.type).toBe('image');
+    expect(out.transcode).toBe(true);
+    expect(out.anim).toBe(false);
+  });
+});

--- a/src/tests/api/v1/blocks/collections-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/collections-endpoint.test.ts
@@ -94,8 +94,11 @@ vi.mock('~/server/services/blocks/block-collections.service', () => ({
   // image yields `edge:`; null when there is no url — mirrors toCoverImageUrl.
   toCoverImageUrl: (img: any) =>
     img?.url ? `${img.type === 'video' ? 'poster' : 'edge'}:${img.url}` : null,
-  // Drop a collection whose nsfwLevel exceeds the (test) ceiling of 3.
-  collectionWithinCeiling: (nsfwLevel: number, level: number) => nsfwLevel <= level,
+  // REAL bitwise semantics (Flags.intersects OR unrated 0) — NOT a `<=` — so the
+  // maturity clamp on covers is exercised faithfully: a MIXED bucket (29) still
+  // intersects a SFW ceiling (3), and a mature bucket (28) does NOT (28 & 3 = 0).
+  collectionWithinCeiling: (nsfwLevel: number, level: number) =>
+    !nsfwLevel || (nsfwLevel & level) !== 0,
 }));
 vi.mock('~/server/utils/block-catalog-rate-limit', () => ({ checkBlockCatalogRateLimit: mockRate }));
 vi.mock('~/server/utils/block-catalog-maturity', () => ({
@@ -420,8 +423,9 @@ describe('GET /api/v1/blocks/collections', () => {
     await handler(req as never, res as never);
     const body = res._json() as any;
     expect(body.items[0].coverImageUrl).toBe('edge:first-item-10');
-    // Only the cover-less collection id is passed to the fallback lookup.
-    expect(mockFallbackCovers).toHaveBeenCalledWith([10]);
+    // Only the cover-less collection id is passed to the fallback lookup, WITH the
+    // token's clamped browsingLevel (3) so the fallback query filters by maturity.
+    expect(mockFallbackCovers).toHaveBeenCalledWith([10], 3);
   });
 
   it('mode=public: a VIDEO first-item cover yields a poster url (not a raw video)', async () => {
@@ -437,6 +441,84 @@ describe('GET /api/v1/blocks/collections', () => {
     const body = res._json() as any;
     // toCoverImageUrl renders a video cover as a poster (image), never the .mp4.
     expect(body.items[0].coverImageUrl).toBe('poster:clip-10');
+  });
+
+  it('mode=public: a MATURE primary cover is clamped out → uses the clamped fallback (no mature-thumbnail leak)', async () => {
+    // Collection nsfwLevel 1 passes the discovery gate, but its OWN cover image is
+    // mature (bucket 28). On a SFW ceiling (3): 28 & 3 === 0 → the primary cover
+    // must be rejected and replaced by the maturity-clamped fallback item.
+    mockGetAll.mockResolvedValueOnce([
+      {
+        id: 10,
+        name: 'A',
+        description: null,
+        read: 'Public',
+        nsfwLevel: 1,
+        userId: 1,
+        user: { id: 1, username: 'a' },
+        image: { url: 'mature-cover', type: 'image', nsfwLevel: 28 },
+      },
+    ]);
+    mockFallbackCovers.mockResolvedValueOnce(new Map([[10, { url: 'sfw-item', type: 'image' }]]));
+    mockItemCount.mockResolvedValueOnce([{ id: 10, count: 3 }]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    // NEVER the mature primary cover.
+    expect(body.items[0].coverImageUrl).toBe('edge:sfw-item');
+    expect(body.items[0].coverImageUrl).not.toBe('edge:mature-cover');
+    // The cover-less-after-clamp id is sent to the fallback WITH browsingLevel 3.
+    expect(mockFallbackCovers).toHaveBeenCalledWith([10], 3);
+  });
+
+  it('mode=public: a MIXED-bucket (29) collection passes the gate but its cover is CLAMPED via the fallback', async () => {
+    // 29 & 3 === 1 → the mixed collection passes discovery. Cover is null, so it
+    // takes the fallback — which is threaded browsingLevel so the query returns the
+    // newest PERMITTED (SFW) item, never the mature newest one.
+    mockGetAll.mockResolvedValueOnce([
+      {
+        id: 10,
+        name: 'Mixed',
+        description: null,
+        read: 'Public',
+        nsfwLevel: 29,
+        userId: 1,
+        user: { id: 1, username: 'a' },
+        image: null,
+      },
+    ]);
+    mockFallbackCovers.mockResolvedValueOnce(new Map([[10, { url: 'sfw-item', type: 'image' }]]));
+    mockItemCount.mockResolvedValueOnce([{ id: 10, count: 5 }]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    // The mixed collection IS surfaced (passes the bitwise gate)…
+    expect(body.items.map((i: any) => i.id)).toEqual([10]);
+    // …but its cover comes from the maturity-clamped fallback.
+    expect(body.items[0].coverImageUrl).toBe('edge:sfw-item');
+    expect(mockFallbackCovers).toHaveBeenCalledWith([10], 3);
+  });
+
+  it('mode=public: a SFW primary cover within the ceiling is used directly (no fallback)', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      {
+        id: 10,
+        name: 'A',
+        description: null,
+        read: 'Public',
+        nsfwLevel: 1,
+        userId: 1,
+        user: { id: 1, username: 'a' },
+        image: { url: 'sfw-cover', type: 'image', nsfwLevel: 1 },
+      },
+    ]);
+    mockItemCount.mockResolvedValueOnce([{ id: 10, count: 1 }]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items[0].coverImageUrl).toBe('edge:sfw-cover');
+    // Nothing needed the fallback (primary within ceiling).
+    expect(mockFallbackCovers).toHaveBeenCalledWith([], 3);
   });
 
   it('400 returns a STRING error message + flattened details (not a raw ZodError)', async () => {

--- a/src/tests/api/v1/blocks/collections-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/collections-endpoint.test.ts
@@ -69,6 +69,7 @@ const {
   mockFollowed,
   mockRate,
   mockMaturity,
+  mockFallbackCovers,
 } = vi.hoisted(() => ({
   mockGetAll: vi.fn(),
   mockItemCount: vi.fn(),
@@ -77,6 +78,7 @@ const {
   mockFollowed: vi.fn(),
   mockRate: vi.fn(),
   mockMaturity: vi.fn(),
+  mockFallbackCovers: vi.fn(),
 }));
 
 vi.mock('~/server/services/collection.service', () => ({
@@ -87,7 +89,11 @@ vi.mock('~/server/services/collection.service', () => ({
 vi.mock('~/server/services/blocks/block-collections.service', () => ({
   hydrateBlockSubject: mockHydrate,
   getFollowedCollectionIds: mockFollowed,
-  toMediaUrl: (img: any) => (img?.url ? `edge:${img.url}` : null),
+  getFallbackCoverImages: mockFallbackCovers,
+  // Cover url helper: a video cover yields a poster (`poster:` prefix), a still
+  // image yields `edge:`; null when there is no url — mirrors toCoverImageUrl.
+  toCoverImageUrl: (img: any) =>
+    img?.url ? `${img.type === 'video' ? 'poster' : 'edge'}:${img.url}` : null,
   // Drop a collection whose nsfwLevel exceeds the (test) ceiling of 3.
   collectionWithinCeiling: (nsfwLevel: number, level: number) => nsfwLevel <= level,
 }));
@@ -128,6 +134,7 @@ beforeEach(() => {
   mockMaturity.mockReturnValue({ browsingLevel: 3, isSfwCeiling: true });
   mockHydrate.mockResolvedValue({ id: 42, username: 'mod', isModerator: true });
   mockFollowed.mockResolvedValue(new Set<number>([10]));
+  mockFallbackCovers.mockResolvedValue(new Map());
   mockItemCount.mockResolvedValue([
     { id: 10, count: 5 },
     { id: 11, count: 2 },
@@ -352,5 +359,96 @@ describe('GET /api/v1/blocks/collections', () => {
     const { req, res } = createMocks();
     await handler(req as never, res as never);
     expect(res._status()).toBe(404);
+  });
+
+  // ---- feedback fixes ----
+
+  it('mode=public: restricts discovery to Image (media) collections (type filter)', async () => {
+    mockGetAll.mockResolvedValueOnce([]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    // The block list surfaces media collections only — a Model/Article/Post
+    // collection would render an empty player, so getAllCollections is passed the
+    // Image type filter.
+    expect(mockGetAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ types: ['Image'] }),
+      })
+    );
+  });
+
+  it('sort=popular alias maps to CollectionSort.MostContributors on the wire', async () => {
+    mockGetAll.mockResolvedValueOnce([]);
+    const { req, res } = createMocks({ query: { mode: 'public', sort: 'popular' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(mockGetAll).toHaveBeenCalledWith(
+      expect.objectContaining({ input: expect.objectContaining({ sort: 'Most Followers' }) })
+    );
+  });
+
+  it('sort=newest alias maps to CollectionSort.Newest', async () => {
+    mockGetAll.mockResolvedValueOnce([]);
+    const { req, res } = createMocks({ query: { mode: 'public', sort: 'newest' } });
+    await handler(req as never, res as never);
+    expect(mockGetAll).toHaveBeenCalledWith(
+      expect.objectContaining({ input: expect.objectContaining({ sort: 'Newest' }) })
+    );
+  });
+
+  it('sort: the raw CollectionSort enum value is still accepted (backward-compat)', async () => {
+    mockGetAll.mockResolvedValueOnce([]);
+    const { req, res } = createMocks({ query: { mode: 'public', sort: 'Most Followers' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(mockGetAll).toHaveBeenCalledWith(
+      expect.objectContaining({ input: expect.objectContaining({ sort: 'Most Followers' }) })
+    );
+  });
+
+  it('mode=public: derives a cover from the first item when the collection cover is null', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      { id: 10, name: 'A', description: null, read: 'Public', nsfwLevel: 0, userId: 1, user: { id: 1, username: 'a' }, image: null },
+    ]);
+    // The fallback query returns a still-image cover for collection 10.
+    mockFallbackCovers.mockResolvedValueOnce(
+      new Map([[10, { url: 'first-item-10', type: 'image' }]])
+    );
+    mockItemCount.mockResolvedValueOnce([{ id: 10, count: 4 }]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    expect(body.items[0].coverImageUrl).toBe('edge:first-item-10');
+    // Only the cover-less collection id is passed to the fallback lookup.
+    expect(mockFallbackCovers).toHaveBeenCalledWith([10]);
+  });
+
+  it('mode=public: a VIDEO first-item cover yields a poster url (not a raw video)', async () => {
+    mockGetAll.mockResolvedValueOnce([
+      { id: 10, name: 'A', description: null, read: 'Public', nsfwLevel: 0, userId: 1, user: { id: 1, username: 'a' }, image: null },
+    ]);
+    mockFallbackCovers.mockResolvedValueOnce(
+      new Map([[10, { url: 'clip-10', type: 'video' }]])
+    );
+    mockItemCount.mockResolvedValueOnce([{ id: 10, count: 4 }]);
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '24' } });
+    await handler(req as never, res as never);
+    const body = res._json() as any;
+    // toCoverImageUrl renders a video cover as a poster (image), never the .mp4.
+    expect(body.items[0].coverImageUrl).toBe('poster:clip-10');
+  });
+
+  it('400 returns a STRING error message + flattened details (not a raw ZodError)', async () => {
+    // limit 0 fails the .min(1) gate deterministically.
+    const { req, res } = createMocks({ query: { mode: 'public', limit: '0' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(400);
+    const body = res._json() as any;
+    expect(typeof body.error).toBe('string');
+    expect(body.error).toBe('Invalid query parameters');
+    // flatten() shape: { formErrors, fieldErrors }.
+    expect(body.details).toBeTruthy();
+    expect(body.details).toHaveProperty('fieldErrors');
   });
 });


### PR DESCRIPTION
## Playable Collections app-block — server-side follow-ups

Server changes for the Playable Collections app block, from a real mod run. All scoped to the two block collection endpoints (`GET /api/v1/blocks/collections` and `/collections/[id]`) + their shared service helpers. The companion app-side fixes (limit≤100 pagination, session cache, default sort, placeholder tile) ship separately in the block app repo and do **not** depend on this PR.

### Changes

1. **Media collections only.** The public list called `getAllCollections` with no `type` filter, so Model/Article/Post collections leaked into discovery — and since the detail endpoint keeps only image/video items, a Model collection renders an **empty player**. The list now passes `types: [Image]` so only media (image/video) collections are surfaced.

2. **Cover thumbnail robustness.** Some cards rendered no cover:
   - When a collection has no cover image, `coverImageUrl` now falls back to the collection's **first accepted media item** (batched lookup).
   - New `toCoverImageUrl` renders a **video** cover as a transcoded still-frame **poster** (image) instead of the raw `.mp4` an `<img>` can't display. `toMediaUrl` (used for the player's media items, where a video must keep its playable URL) is unchanged.

3. **Block-friendly sort alias.** The list endpoint now accepts `newest`|`popular` (mapped to `Newest`|`MostContributors`) **in addition** to the raw enum values (backward-compat), matching the already-filed follow-up.

4. **Cleaner 400s.** Both endpoints returned a raw `ZodError` object on a validation failure (the client had to be hardened against it). They now return a string message + flattened details: `{ error: 'Invalid query parameters', details: parsed.error.flatten() }`.

### Tests
- Extends `collections-endpoint.test.ts`: `types: [Image]` filter, `popular`/`newest` alias → enum mapping (+ raw enum still accepted), null-cover fallback wiring, video-cover poster, and the string+details 400.
- New `block-collections-cover.test.ts`: unit coverage of `toCoverImageUrl` (null handling, image passthrough, video → transcoded non-animated poster).

### Verification
- Endpoint + cover tests green (23 tests).
- `tsc --noEmit` clean on the touched files (no new type errors introduced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)