### PR TITLE
fix(upload): classify S3 InvalidPart as 422 (not raw 500) on complete

### DIFF
--- a/src/pages/api/upload/abort.ts
+++ b/src/pages/api/upload/abort.ts
@@ -56,6 +56,15 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
       res.status(204).end();
       return;
     }
+    if (errorClass === 'invalid-parts') {
+      // A parts-manifest fault (400-class) surfaced on the abort path — terminal, the
+      // client must stop retrying and re-upload. 422 Unprocessable Entity mirrors the
+      // complete handler. no-store so nothing caches the failure. (The sole caller
+      // fire-and-forgets abort and ignores the body, so the status alone is safe.)
+      res.setHeader('Cache-Control', 'no-store');
+      res.status(422).json({ error: 'Upload parts invalid or incomplete — please re-upload' });
+      return;
+    }
     if (errorClass === 'transient') {
       // Retry-able storage-backend blip (S3/B2 5xx, throttle/timing, or network).
       res.setHeader('Retry-After', '2');

--- a/src/pages/api/upload/complete.ts
+++ b/src/pages/api/upload/complete.ts
@@ -55,6 +55,16 @@ const upload = async (req: NextApiRequest, res: NextApiResponse) => {
       res.status(409).json({ error: 'Upload already finalized or aborted' });
       return;
     }
+    if (errorClass === 'invalid-parts') {
+      // The parts manifest the client sent doesn't match what the backend stored
+      // (a part upload failed/expired, a stale ETag, or an empty/mis-ordered list) —
+      // a B2/S3 400-class fault. 422 Unprocessable Entity = the request was well
+      // formed but the upload STATE isn't; terminal → the client must stop retrying
+      // this manifest and re-upload. no-store so nothing caches the failure.
+      res.setHeader('Cache-Control', 'no-store');
+      res.status(422).json({ error: 'Upload parts invalid or incomplete — please re-upload' });
+      return;
+    }
     if (errorClass === 'transient') {
       // Retry-able storage-backend blip (S3/B2 5xx, throttle/timing, or network).
       res.setHeader('Retry-After', '2');

--- a/src/server/__tests__/upload-abort-endpoint.test.ts
+++ b/src/server/__tests__/upload-abort-endpoint.test.ts
@@ -133,6 +133,31 @@ describe('/api/upload/abort — error classification', () => {
     expect(res.ended).toBe(true);
   });
 
+  it('InvalidPart (name + $metadata 400) → 422 + no-store, not 500', async () => {
+    mockAbortMultipartUpload.mockRejectedValue(
+      s3Error({
+        name: 'InvalidPart',
+        message:
+          'One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part\'s entity tag.',
+        $metadata: { httpStatusCode: 400 },
+      })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(422);
+    expect(res.body).toEqual({ error: 'Upload parts invalid or incomplete — please re-upload' });
+    expect(res.headers['Cache-Control']).toBe('no-store');
+  });
+
+  it('an unknown 400 (not a parts fault) STILL surfaces as 500, not 422', async () => {
+    mockAbortMultipartUpload.mockRejectedValue(
+      s3Error({ name: 'SomeUnknownClientError', $metadata: { httpStatusCode: 400 } })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(500);
+  });
+
   it('transient S3 500 → 503 + Retry-After header, not 500', async () => {
     mockAbortMultipartUpload.mockRejectedValue(
       s3Error({ name: 'InternalError', $metadata: { httpStatusCode: 500 } })

--- a/src/server/__tests__/upload-complete-endpoint.test.ts
+++ b/src/server/__tests__/upload-complete-endpoint.test.ts
@@ -145,6 +145,44 @@ describe('/api/upload/complete — error classification', () => {
     expect(res.body).toEqual({ error: 'Upload already finalized or aborted' });
   });
 
+  it('InvalidPart (name + $metadata 400) → 422 + no-store, not 500', async () => {
+    mockCompleteMultipartUpload.mockRejectedValue(
+      s3Error({
+        name: 'InvalidPart',
+        message:
+          'One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part\'s entity tag.',
+        $metadata: { httpStatusCode: 400 },
+      })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(422);
+    expect(res.body).toEqual({ error: 'Upload parts invalid or incomplete — please re-upload' });
+    expect(res.headers['Cache-Control']).toBe('no-store');
+  });
+
+  it('InvalidRequest ("must specify at least one part") + 400 → 422', async () => {
+    mockCompleteMultipartUpload.mockRejectedValue(
+      s3Error({
+        name: 'InvalidRequest',
+        message: 'You must specify at least one part',
+        $metadata: { httpStatusCode: 400 },
+      })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(422);
+  });
+
+  it('an unknown 400 (not a parts fault) STILL surfaces as 500, not 422', async () => {
+    mockCompleteMultipartUpload.mockRejectedValue(
+      s3Error({ name: 'SomeUnknownClientError', $metadata: { httpStatusCode: 400 } })
+    );
+    const res = makeRes();
+    await handler(makeReq(), res);
+    expect(res.statusCode).toBe(500);
+  });
+
   it('transient S3 503 → 503 + Retry-After header, not 500', async () => {
     mockCompleteMultipartUpload.mockRejectedValue(
       s3Error({ name: 'ServiceUnavailable', $metadata: { httpStatusCode: 503 } })

--- a/src/utils/__tests__/s3-utils.test.ts
+++ b/src/utils/__tests__/s3-utils.test.ts
@@ -286,15 +286,54 @@ describe('classifyS3MultipartError', () => {
     expect(classifyS3MultipartError(err)).toBe('transient');
   });
 
+  it.each(['InvalidPart', 'InvalidPartOrder', 'EntityTooSmall', 'MalformedXML'])(
+    'classifies the parts-manifest fault %s (400) as invalid-parts',
+    (name) => {
+      const err = Object.assign(new Error('parts mismatch'), {
+        name,
+        $metadata: { httpStatusCode: 400 },
+      });
+      expect(classifyS3MultipartError(err)).toBe('invalid-parts');
+    }
+  );
+
+  it('classifies InvalidPart by name even without a status code as invalid-parts', () => {
+    // The dominant dp-prod signature carries $metadata 400, but the name alone is
+    // an unambiguous parts fault.
+    const err = Object.assign(
+      new Error(
+        'One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part\'s entity tag.'
+      ),
+      { name: 'InvalidPart' }
+    );
+    expect(classifyS3MultipartError(err)).toBe('invalid-parts');
+  });
+
+  it('classifies InvalidRequest + 400 ("must specify at least one part") as invalid-parts', () => {
+    const err = Object.assign(new Error('You must specify at least one part'), {
+      name: 'InvalidRequest',
+      $metadata: { httpStatusCode: 400 },
+    });
+    expect(classifyS3MultipartError(err)).toBe('invalid-parts');
+  });
+
   it('classifies a generic/unknown error as other (stays a hard 500)', () => {
     expect(classifyS3MultipartError(new Error('boom'))).toBe('other');
   });
 
-  it('classifies a genuine 4xx-that-is-not-404 (e.g. 400) as other', () => {
+  it('does NOT over-broaden: an unknown 4xx name (400) still classifies as other', () => {
+    // Guard against the client-fault bucket swallowing genuine unrecognized 400s —
+    // only the named parts-manifest faults (+ InvalidRequest/400) are invalid-parts.
     const err = Object.assign(new Error('bad request'), {
-      name: 'InvalidPart',
+      name: 'SomeUnknownClientError',
       $metadata: { httpStatusCode: 400 },
     });
+    expect(classifyS3MultipartError(err)).toBe('other');
+  });
+
+  it('does NOT map InvalidRequest without a 400 (e.g. no status) as invalid-parts', () => {
+    // InvalidRequest is a generic name; only a 400 on this path is a parts fault.
+    const err = Object.assign(new Error('generic invalid request'), { name: 'InvalidRequest' });
     expect(classifyS3MultipartError(err)).toBe('other');
   });
 

--- a/src/utils/s3-utils.ts
+++ b/src/utils/s3-utils.ts
@@ -561,19 +561,30 @@ export async function abortMultipartUpload(
  *    invalid, or the upload may have been aborted or completed." Retrying it is
  *    futile — the caller should STOP. (This was ~27 raw-500s/12h on dp-prod, the
  *    same `key`+`uploadId` repeating across pods as the client kept retrying.)
+ *  - `invalid-parts` — a client/STATE fault in the parts manifest the browser sent
+ *    to CompleteMultipartUpload: the ETag+PartNumber array doesn't match what the
+ *    backend stored (a part upload silently failed/expired, or a stale ETag), or the
+ *    manifest is empty/mis-ordered/malformed. The AWS-SDK v3 surfaces these as
+ *    `InvalidPart` ("One or more of the specified parts could not be found. …"),
+ *    `InvalidPartOrder`, `EntityTooSmall`, `MalformedXML`, or `InvalidRequest`
+ *    ("You must specify at least one part") — ALL HTTP 400. Retrying with the SAME
+ *    bad manifest is futile → the caller must STOP and re-upload. Mapped to a
+ *    terminal 422 (not a raw 500 that invites SDK retry amplification + pollutes the
+ *    500 alert). This was ~25 raw-500s/24h on dp-prod, the dominant residual after
+ *    #3065's not-found/transient split.
  *  - `transient` — a retry-able storage-backend blip: an S3/B2 HTTP 5xx, a throttle
  *    / timing signal (`SlowDown` / `RequestTimeout` / `RequestTimeTooSkewed` /
  *    `ServiceUnavailable` / `InternalError`), or a status-less network failure
  *    (`ECONNRESET` / `ETIMEDOUT` / …). Mirror #2972/#3049 → 503 + Retry-After.
  *  - `other`     — anything unrecognized, INCLUDING a genuine server-side bug. Left
  *    to surface as a hard 500 so a real failed upload fails LOUD (never masked as a
- *    silent 409/503).
+ *    silent 409/422/503).
  *
  * AWS-SDK v3 errors carry `error.name` (e.g. `'NoSuchUpload'`, `'SlowDown'`) and
  * `error.$metadata.httpStatusCode`; a pre-response network failure has neither, so
  * it is matched by {@link isUpstreamNetworkError}.
  */
-export type S3MultipartErrorClass = 'not-found' | 'transient' | 'other';
+export type S3MultipartErrorClass = 'not-found' | 'invalid-parts' | 'transient' | 'other';
 
 const S3_TRANSIENT_ERROR_NAMES: ReadonlySet<string> = new Set([
   'SlowDown',
@@ -581,6 +592,18 @@ const S3_TRANSIENT_ERROR_NAMES: ReadonlySet<string> = new Set([
   'RequestTimeTooSkewed',
   'ServiceUnavailable',
   'InternalError',
+]);
+
+// Client/STATE faults in the parts manifest sent to CompleteMultipartUpload — all
+// HTTP 400. Terminal: retrying the same bad manifest is futile, the client must
+// re-upload. (`InvalidRequest`/"you must specify at least one part" is matched
+// separately below since that name is generic and only 400-on-this-path is a
+// parts fault.)
+const S3_INVALID_PARTS_ERROR_NAMES: ReadonlySet<string> = new Set([
+  'InvalidPart',
+  'InvalidPartOrder',
+  'EntityTooSmall',
+  'MalformedXML',
 ]);
 
 export function classifyS3MultipartError(error: unknown): S3MultipartErrorClass {
@@ -594,6 +617,11 @@ export function classifyS3MultipartError(error: unknown): S3MultipartErrorClass 
 
   // Terminal state fault: the upload is already finalized/aborted → stop retrying.
   if (name === 'NoSuchUpload' || httpStatusCode === 404) return 'not-found';
+
+  // Terminal client/STATE fault: the parts manifest doesn't match what the backend
+  // stored (or is empty/mis-ordered/malformed) → re-upload, don't retry as-is.
+  if (name && S3_INVALID_PARTS_ERROR_NAMES.has(name)) return 'invalid-parts';
+  if (name === 'InvalidRequest' && httpStatusCode === 400) return 'invalid-parts';
 
   // Retry-able storage-backend failure.
   if (typeof httpStatusCode === 'number' && httpStatusCode >= 500) return 'transient';


### PR DESCRIPTION
## Root cause

`/api/upload/complete` (and `/api/upload/abort`) still returned a **raw 500** for the B2/S3 `InvalidPart` error — **~25/24h on dp-prod, the dominant residual 500** after #3065 split off `not-found`/`transient`.

`InvalidPart` — *"One or more of the specified parts could not be found. The part may not have been uploaded, or the specified entity tag may not match the part's entity tag."* — is **HTTP 400**, a **client/STATE fault**: the browser's `parts` array (ETag+PartNumber) doesn't match what B2 stored (a part upload silently failed/expired, or a stale ETag). `classifyS3MultipartError` saw `httpStatusCode===400` (not 404, not >=500, name not transient, not a network error) → fell through to `'other'` → **500**.

Retrying the same bad manifest is futile, so the 500 only invites **SDK retry amplification** and **pollutes the 500 alert**. It should be a **terminal 4xx** telling the client to stop and re-upload.

Also mapped defensively (same 400-class client-fault family, mostly 0 occurrences now): `InvalidPartOrder`, `EntityTooSmall`, `MalformedXML`, and `InvalidRequest`+400 ("You must specify at least one part", ~1/24h).

## Fix

- `classifyS3MultipartError` (`src/utils/s3-utils.ts`): new `'invalid-parts'` bucket in the return union, placed **after** the `NoSuchUpload`/404 check and **before** the `>=500` transient check. Matches the named parts-manifest faults via a `Set`, plus `InvalidRequest` **only when** `httpStatusCode===400` (that name is generic).
- Both handlers (`complete.ts`, `abort.ts`) map `'invalid-parts'` → **HTTP 422** Unprocessable Entity + `Cache-Control: no-store`, with `{ error: 'Upload parts invalid or incomplete — please re-upload' }`.

**Why 422 over 400:** the request was well-formed; it's the upload *state* that's unprocessable — mirrors the existing terminal-4xx semantics (409 for already-finalized). 400 would be defensible; 422 more precisely signals "well-formed request, unprocessable state".

The `not-found` (409/204), `transient` (503) and `other` (500) branches and `instrumentApiResponse` logging are unchanged. A genuine unrecognized 400 still falls through to `'other'` → 500 (no over-broadening — verified by test).

## Client caller check

The sole caller (`src/store/s3-upload.store.ts`) calls `completeUpload()` via `fetch`, whose `.catch` fires only on a network reject — a **422 resolves normally with `.ok === false`**, so the code hits `if (!completeResult.ok) return;` and **stops cleanly, no retry loop / no hang** (identical handling to the existing 409). `abort` is fire-and-forget (response ignored). So 422 does not break the upload flow.

## Tests

Extended `src/utils/__tests__/s3-utils.test.ts` + `src/server/__tests__/upload-{complete,abort}-endpoint.test.ts`:
- `InvalidPart`/`InvalidPartOrder`/`EntityTooSmall`/`MalformedXML` (400) → `'invalid-parts'` → **422 + no-store**
- `InvalidRequest`+400 → `'invalid-parts'` → 422
- unknown 400 name → still `'other'` → **500** (over-broadening guard)
- `InvalidRequest` without 400 → `'other'` (guard)
- existing `NoSuchUpload`→409/204, transient→503, other→500 unchanged

**Fail-before / pass-after:** against the current classifier the new tests fail **9/54**; with the fix **54/54 pass**.

**tsc:** `NODE_OPTIONS='--max_old_space_size=8192' npx tsc --noEmit -p tsconfig.json` — zero errors reference the changed files.

## Follow-up (out of scope)

A separate `AggregateError` class (~4/24h) is *probably* a missed transient whose real codes are nested in `.errors[]` (which `isUpstreamNetworkError` misses — it only walks `.cause`), but it's **unconfirmed** (sub-codes couldn't be retrieved). Left unmapped until the sub-codes are confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)