### PR TITLE
Detect model file metadata

### DIFF
--- a/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
+++ b/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
@@ -42,7 +42,7 @@ const MIN_VRAM_INFO =
   'Rough lower bound to run this model, estimated from its tensor sizes and precision plus typical runtime overhead. At this level weights are streamed onto the GPU as needed, so it runs but more slowly. Actual usage varies by the tool and settings you use.';
 const RECOMMENDED_VRAM_INFO =
   'Rough target for smooth performance, estimated from its tensor sizes and precision plus typical runtime overhead. At this level the full set of weights can stay resident on the GPU at once. Actual usage varies by the tool and settings you use.';
-const TENSOR_METADATA_RESPONSE_VERSION = 2;
+const TENSOR_METADATA_RESPONSE_VERSION = 3;
 
 export function ModelTensorMetadata({ files, userPreferences, enabled, selectedFileId }: Props) {
   const theme = useMantineTheme();

--- a/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
+++ b/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
@@ -42,6 +42,7 @@ const MIN_VRAM_INFO =
   'Rough lower bound to run this model, estimated from its tensor sizes and precision plus typical runtime overhead. At this level weights are streamed onto the GPU as needed, so it runs but more slowly. Actual usage varies by the tool and settings you use.';
 const RECOMMENDED_VRAM_INFO =
   'Rough target for smooth performance, estimated from its tensor sizes and precision plus typical runtime overhead. At this level the full set of weights can stay resident on the GPU at once. Actual usage varies by the tool and settings you use.';
+const TENSOR_METADATA_RESPONSE_VERSION = 2;
 
 export function ModelTensorMetadata({ files, userPreferences, enabled, selectedFileId }: Props) {
   const theme = useMantineTheme();
@@ -84,6 +85,8 @@ export function ModelTensorMetadata({ files, userPreferences, enabled, selectedF
 
   const vramEstimate = summaryQuery.data?.vramEstimate ?? null;
   const tensorCount = summaryQuery.data?.tensorCount ?? null;
+  const weightPrecision =
+    summaryQuery.data?.weightPrecision ?? selectedFile?.metadata?.weightPrecision;
 
   return (
     <Accordion.Item value="tensor-metadata">
@@ -98,6 +101,11 @@ export function ModelTensorMetadata({ files, userPreferences, enabled, selectedF
             )}
           </Group>
           <Group gap={6} wrap="nowrap">
+            {weightPrecision && (
+              <Badge size="sm" variant="light" color="gray" title="Weight precision">
+                {weightPrecision}
+              </Badge>
+            )}
             {vramEstimate ? (
               <VramSegmentedBadge vramEstimate={vramEstimate} />
             ) : summaryQuery.isFetching ? (
@@ -378,7 +386,9 @@ function formatShape(shape: number[]) {
 }
 
 async function fetchTensorSummary(fileId: number) {
-  const response = await fetch(`/api/v1/model-files/${fileId}/tensor-metadata?summaryOnly=true`);
+  const response = await fetch(
+    `/api/v1/model-files/${fileId}/tensor-metadata?summaryOnly=true&v=${TENSOR_METADATA_RESPONSE_VERSION}`
+  );
   if (!response.ok) {
     const body = (await response.json().catch(() => null)) as { error?: string } | null;
     throw new Error(body?.error ?? 'Failed to load tensor metadata');
@@ -388,7 +398,9 @@ async function fetchTensorSummary(fileId: number) {
 }
 
 async function fetchTensorMetadata(fileId: number) {
-  const response = await fetch(`/api/v1/model-files/${fileId}/tensor-metadata`);
+  const response = await fetch(
+    `/api/v1/model-files/${fileId}/tensor-metadata?v=${TENSOR_METADATA_RESPONSE_VERSION}`
+  );
   if (!response.ok) {
     const body = (await response.json().catch(() => null)) as { error?: string } | null;
     throw new Error(body?.error ?? 'Failed to load tensor metadata');

--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -6,13 +6,16 @@ import { dbRead } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { REDIS_KEYS } from '~/server/redis/client';
 import { getFileForModelVersion } from '~/server/services/file.service';
+import { persistModelWeightPrecision } from '~/server/services/tensor-metadata-persistence.service';
 import { getFullTensorAnalysisCached } from '~/server/services/tensor-metadata.service';
 import { fetchThroughCache } from '~/server/utils/cache-helpers';
 import { MixedAuthEndpoint } from '~/server/utils/endpoint-helpers';
 import {
+  getDominantWeightPrecision,
   inferTensorMetadataFormat,
   parseModelTensorMetadata,
   supportsTensorVramEstimate,
+  type ModelTensorAnalysis,
 } from '~/utils/model-tensor-metadata';
 
 const schema = z.object({
@@ -39,6 +42,7 @@ export default MixedAuthEndpoint(async function handler(
       id: true,
       modelVersionId: true,
       name: true,
+      url: true,
       type: true,
       sizeKB: true,
       metadata: true,
@@ -70,6 +74,23 @@ export default MixedAuthEndpoint(async function handler(
       modelType: file.modelVersion.model.type,
       fileType: file.type,
     });
+    const currentWeightPrecision = (file.metadata as BasicFileMetadata | null)?.weightPrecision;
+    const addWeightPrecision = async <
+      T extends Pick<ModelTensorAnalysis, 'dtypeCounts'> &
+        Partial<Pick<ModelTensorAnalysis, 'weightPrecision'>>
+    >(
+      data: T
+    ) => {
+      const weightPrecision = data.weightPrecision ?? getDominantWeightPrecision(data.dtypeCounts);
+      await persistModelWeightPrecision({
+        fileId: file.id,
+        fileUrl: file.url,
+        modelVersionId: file.modelVersionId,
+        currentWeightPrecision,
+        weightPrecision,
+      });
+      return { ...data, weightPrecision };
+    };
 
     // Tensor metadata is derived purely from immutable file content, so cache the parsed
     // analysis by file id. Auth is still re-checked per request above via getFileForModelVersion.
@@ -105,8 +126,6 @@ export default MixedAuthEndpoint(async function handler(
         )
       );
 
-    res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
-
     if (summaryOnly) {
       const summary = await fetchThroughCache(
         `${REDIS_KEYS.CACHES.TENSOR_METADATA_SUMMARY}:${id}`,
@@ -117,12 +136,17 @@ export default MixedAuthEndpoint(async function handler(
         },
         { ttl: CacheTTL.month }
       );
-      return res.status(200).json(summary);
+      const response = await addWeightPrecision(summary);
+      res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
+      return res.status(200).json(response);
     }
 
     const analysis = await fetchFull();
-    res.status(200).json(analysis);
+    const response = await addWeightPrecision(analysis);
+    res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
+    res.status(200).json(response);
   } catch (error) {
+    res.setHeader('Cache-Control', 'private, no-store');
     const err = error instanceof Error ? error : new Error(String(error));
     logToAxiom({
       name: 'model-file-tensor-metadata',

--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -6,16 +6,19 @@ import { dbRead } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { REDIS_KEYS } from '~/server/redis/client';
 import { getFileForModelVersion } from '~/server/services/file.service';
-import { persistModelWeightPrecision } from '~/server/services/tensor-metadata-persistence.service';
+import { persistModelTensorHeaderMetadata } from '~/server/services/tensor-metadata-persistence.service';
 import { getFullTensorAnalysisCached } from '~/server/services/tensor-metadata.service';
 import { fetchThroughCache } from '~/server/utils/cache-helpers';
 import { MixedAuthEndpoint } from '~/server/utils/endpoint-helpers';
 import {
+  detectModelTypeFromTensors,
   getDominantWeightPrecision,
+  getModelFileTypeCorrection,
   inferTensorMetadataFormat,
   parseModelTensorMetadata,
   supportsTensorVramEstimate,
   type ModelTensorAnalysis,
+  weightPrecisionToModelFileFp,
 } from '~/utils/model-tensor-metadata';
 
 const schema = z.object({
@@ -23,6 +26,9 @@ const schema = z.object({
   summaryOnly: z.preprocess((val) => val === 'true' || val === true, z.boolean().optional()),
 });
 const TENSOR_METADATA_CACHE_CONTROL = 'public, max-age=31536000, s-maxage=31536000, immutable';
+// Version the small summary independently so existing full tensor caches can be
+// enriched without another model-host range request.
+const TENSOR_METADATA_SUMMARY_VERSION = 2;
 
 export default MixedAuthEndpoint(async function handler(
   req: NextApiRequest,
@@ -74,22 +80,54 @@ export default MixedAuthEndpoint(async function handler(
       modelType: file.modelVersion.model.type,
       fileType: file.type,
     });
-    const currentWeightPrecision = (file.metadata as BasicFileMetadata | null)?.weightPrecision;
-    const addWeightPrecision = async <
+    const currentMetadata = file.metadata as BasicFileMetadata | null;
+    const addDerivedMetadata = <
       T extends Pick<ModelTensorAnalysis, 'dtypeCounts'> &
-        Partial<Pick<ModelTensorAnalysis, 'weightPrecision'>>
+        Partial<Pick<ModelTensorAnalysis, 'weightPrecision' | 'detectedModelType' | 'tensors'>>
     >(
       data: T
     ) => {
-      const weightPrecision = data.weightPrecision ?? getDominantWeightPrecision(data.dtypeCounts);
-      await persistModelWeightPrecision({
+      // Cached analyses can contain older derived values. Recompute whenever the
+      // underlying dtype totals or tensor names are available.
+      const weightPrecision = getDominantWeightPrecision(data.dtypeCounts);
+      const detectedModelType =
+        format === 'SafeTensor'
+          ? data.tensors
+            ? detectModelTypeFromTensors(data.tensors)
+            : data.detectedModelType ?? null
+          : null;
+      return { ...data, weightPrecision, detectedModelType };
+    };
+    const persistDerivedMetadata = async <
+      T extends Pick<ModelTensorAnalysis, 'dtypeCounts'> &
+        Partial<Pick<ModelTensorAnalysis, 'weightPrecision' | 'detectedModelType' | 'tensors'>>
+    >(
+      data: T
+    ) => {
+      const enriched = addDerivedMetadata(data);
+      const fp =
+        format === 'SafeTensor' ? weightPrecisionToModelFileFp(enriched.weightPrecision) : null;
+      const correctedFileType =
+        format === 'SafeTensor'
+          ? getModelFileTypeCorrection({
+              detectedModelType: enriched.detectedModelType,
+              modelType: file.modelVersion.model.type,
+              currentFileType: file.type,
+            })
+          : null;
+
+      await persistModelTensorHeaderMetadata({
         fileId: file.id,
         fileUrl: file.url,
         modelVersionId: file.modelVersionId,
-        currentWeightPrecision,
-        weightPrecision,
+        currentWeightPrecision: currentMetadata?.weightPrecision,
+        weightPrecision: enriched.weightPrecision,
+        currentFp: currentMetadata?.fp,
+        fp,
+        currentFileType: file.type,
+        correctedFileType,
       });
-      return { ...data, weightPrecision };
+      return enriched;
     };
 
     // Tensor metadata is derived purely from immutable file content, so cache the parsed
@@ -111,24 +149,26 @@ export default MixedAuthEndpoint(async function handler(
     // wraps the redis-backed fetch in a bounded in-process LRU of the DECODED object, so a
     // hot model is decoded at most once per pod (the redis memory win is preserved — the
     // blob stays compressed+split in redis; we only remove the repeated hot-path decode).
-    const fetchFull = () =>
-      getFullTensorAnalysisCached(id, () =>
-        fetchThroughCache(
-          `${REDIS_KEYS.CACHES.TENSOR_METADATA}:${id}`,
-          () =>
-            parseModelTensorMetadata({
-              url: fileResult.url,
-              format,
-              fileSizeBytes: file.sizeKB * 1024,
-              estimateVram,
-            }),
-          { ttl: CacheTTL.month, compress: true }
+    const fetchFull = async () =>
+      addDerivedMetadata(
+        await getFullTensorAnalysisCached(id, () =>
+          fetchThroughCache(
+            `${REDIS_KEYS.CACHES.TENSOR_METADATA}:${id}`,
+            () =>
+              parseModelTensorMetadata({
+                url: fileResult.url,
+                format,
+                fileSizeBytes: file.sizeKB * 1024,
+                estimateVram,
+              }),
+            { ttl: CacheTTL.month, compress: true }
+          )
         )
       );
 
     if (summaryOnly) {
       const summary = await fetchThroughCache(
-        `${REDIS_KEYS.CACHES.TENSOR_METADATA_SUMMARY}:${id}`,
+        `${REDIS_KEYS.CACHES.TENSOR_METADATA_SUMMARY}:${TENSOR_METADATA_SUMMARY_VERSION}:${id}`,
         async () => {
           const analysis = await fetchFull();
           const { tensors, ...rest } = analysis;
@@ -136,13 +176,13 @@ export default MixedAuthEndpoint(async function handler(
         },
         { ttl: CacheTTL.month }
       );
-      const response = await addWeightPrecision(summary);
+      const response = await persistDerivedMetadata(summary);
       res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
       return res.status(200).json(response);
     }
 
     const analysis = await fetchFull();
-    const response = await addWeightPrecision(analysis);
+    const response = await persistDerivedMetadata(analysis);
     res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
     res.status(200).json(response);
   } catch (error) {

--- a/src/server/services/__tests__/tensor-metadata-persistence.service.test.ts
+++ b/src/server/services/__tests__/tensor-metadata-persistence.service.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { executeRaw, deleteFilesForModelVersionCache } = vi.hoisted(() => ({
+  executeRaw: vi.fn(),
+  deleteFilesForModelVersionCache: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbWrite: { $executeRaw: executeRaw },
+}));
+vi.mock('~/server/services/model-file.service', () => ({ deleteFilesForModelVersionCache }));
+
+import { persistModelWeightPrecision } from '~/server/services/tensor-metadata-persistence.service';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  executeRaw.mockResolvedValue(1);
+  deleteFilesForModelVersionCache.mockResolvedValue(undefined);
+});
+
+describe('persistModelWeightPrecision', () => {
+  it('skips empty or already-current precision values', async () => {
+    await expect(
+      persistModelWeightPrecision({
+        fileId: 42,
+        fileUrl: 'https://example.com/model.gguf',
+        modelVersionId: 7,
+        currentWeightPrecision: 'Q4',
+        weightPrecision: 'Q4',
+      })
+    ).resolves.toBe(false);
+
+    expect(executeRaw).not.toHaveBeenCalled();
+    expect(deleteFilesForModelVersionCache).not.toHaveBeenCalled();
+  });
+
+  it('atomically merges precision for the current file content and busts the file cache', async () => {
+    await expect(
+      persistModelWeightPrecision({
+        fileId: 42,
+        fileUrl: 'https://example.com/model.gguf',
+        modelVersionId: 7,
+        currentWeightPrecision: null,
+        weightPrecision: 'Q4',
+      })
+    ).resolves.toBe(true);
+
+    const query = executeRaw.mock.calls[0][0];
+    expect(query.sql).toContain('jsonb_build_object');
+    expect(query.sql).toContain('"url" =');
+    expect(query.values).toEqual(
+      expect.arrayContaining(['Q4', 42, 'https://example.com/model.gguf'])
+    );
+    expect(deleteFilesForModelVersionCache).toHaveBeenCalledWith(7);
+  });
+
+  it('busts stale model-file cache data when another request won the database write', async () => {
+    executeRaw.mockResolvedValue(0);
+
+    await expect(
+      persistModelWeightPrecision({
+        fileId: 42,
+        fileUrl: 'https://example.com/model.safetensors',
+        modelVersionId: 7,
+        weightPrecision: 'BF16',
+      })
+    ).resolves.toBe(false);
+
+    expect(deleteFilesForModelVersionCache).toHaveBeenCalledWith(7);
+  });
+});

--- a/src/server/services/__tests__/tensor-metadata-persistence.service.test.ts
+++ b/src/server/services/__tests__/tensor-metadata-persistence.service.test.ts
@@ -10,7 +10,7 @@ vi.mock('~/server/db/client', () => ({
 }));
 vi.mock('~/server/services/model-file.service', () => ({ deleteFilesForModelVersionCache }));
 
-import { persistModelWeightPrecision } from '~/server/services/tensor-metadata-persistence.service';
+import { persistModelTensorHeaderMetadata } from '~/server/services/tensor-metadata-persistence.service';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -18,15 +18,16 @@ beforeEach(() => {
   deleteFilesForModelVersionCache.mockResolvedValue(undefined);
 });
 
-describe('persistModelWeightPrecision', () => {
-  it('skips empty or already-current precision values', async () => {
+describe('persistModelTensorHeaderMetadata', () => {
+  it('skips already-current derived values', async () => {
     await expect(
-      persistModelWeightPrecision({
+      persistModelTensorHeaderMetadata({
         fileId: 42,
         fileUrl: 'https://example.com/model.gguf',
         modelVersionId: 7,
         currentWeightPrecision: 'Q4',
         weightPrecision: 'Q4',
+        currentFileType: 'Model',
       })
     ).resolves.toBe(false);
 
@@ -36,21 +37,47 @@ describe('persistModelWeightPrecision', () => {
 
   it('atomically merges precision for the current file content and busts the file cache', async () => {
     await expect(
-      persistModelWeightPrecision({
+      persistModelTensorHeaderMetadata({
         fileId: 42,
         fileUrl: 'https://example.com/model.gguf',
         modelVersionId: 7,
         currentWeightPrecision: null,
         weightPrecision: 'Q4',
+        currentFileType: 'Model',
       })
     ).resolves.toBe(true);
 
     const query = executeRaw.mock.calls[0][0];
-    expect(query.sql).toContain('jsonb_build_object');
+    expect(query.sql).toContain('::jsonb');
     expect(query.sql).toContain('"url" =');
     expect(query.values).toEqual(
-      expect.arrayContaining(['Q4', 42, 'https://example.com/model.gguf'])
+      expect.arrayContaining([
+        JSON.stringify({ weightPrecision: 'Q4' }),
+        42,
+        'https://example.com/model.gguf',
+      ])
     );
+    expect(deleteFilesForModelVersionCache).toHaveBeenCalledWith(7);
+  });
+
+  it('corrects fp and an unambiguous file type in the same guarded update', async () => {
+    await expect(
+      persistModelTensorHeaderMetadata({
+        fileId: 42,
+        fileUrl: 'https://example.com/model.safetensors',
+        modelVersionId: 7,
+        currentWeightPrecision: 'BF16',
+        weightPrecision: 'BF16',
+        currentFp: 'fp16',
+        fp: 'bf16',
+        currentFileType: 'Other',
+        correctedFileType: 'VAE',
+      })
+    ).resolves.toBe(true);
+
+    const query = executeRaw.mock.calls[0][0];
+    expect(query.sql).toContain('"type" =');
+    expect(query.values).toEqual(expect.arrayContaining([JSON.stringify({ fp: 'bf16' }), 'VAE']));
     expect(deleteFilesForModelVersionCache).toHaveBeenCalledWith(7);
   });
 
@@ -58,11 +85,12 @@ describe('persistModelWeightPrecision', () => {
     executeRaw.mockResolvedValue(0);
 
     await expect(
-      persistModelWeightPrecision({
+      persistModelTensorHeaderMetadata({
         fileId: 42,
         fileUrl: 'https://example.com/model.safetensors',
         modelVersionId: 7,
         weightPrecision: 'BF16',
+        currentFileType: 'Model',
       })
     ).resolves.toBe(false);
 

--- a/src/server/services/__tests__/tensor-metadata-service.test.ts
+++ b/src/server/services/__tests__/tensor-metadata-service.test.ts
@@ -25,6 +25,7 @@ function makeAnalysis(tensorCount: number, marker: string): ModelTensorAnalysis 
     tensorCount,
     totalTensorBytes: tensorCount * 1000,
     dtypeCounts: [],
+    weightPrecision: null,
     largestTensor: null,
     vramEstimate: null,
     tensors: Array.from({ length: tensorCount }, (_, i) => ({

--- a/src/server/services/__tests__/tensor-metadata-service.test.ts
+++ b/src/server/services/__tests__/tensor-metadata-service.test.ts
@@ -26,6 +26,7 @@ function makeAnalysis(tensorCount: number, marker: string): ModelTensorAnalysis 
     totalTensorBytes: tensorCount * 1000,
     dtypeCounts: [],
     weightPrecision: null,
+    detectedModelType: null,
     largestTensor: null,
     vramEstimate: null,
     tensors: Array.from({ length: tensorCount }, (_, i) => ({

--- a/src/server/services/tensor-metadata-persistence.service.ts
+++ b/src/server/services/tensor-metadata-persistence.service.ts
@@ -2,28 +2,47 @@ import { Prisma } from '@prisma/client';
 import { dbWrite } from '~/server/db/client';
 import { deleteFilesForModelVersionCache } from '~/server/services/model-file.service';
 
-type PersistModelWeightPrecisionOptions = {
+type PersistModelTensorHeaderMetadataOptions = {
   fileId: number;
   fileUrl: string;
   modelVersionId: number;
   currentWeightPrecision?: string | null;
   weightPrecision: string | null;
+  currentFp?: ModelFileFp | null;
+  fp?: ModelFileFp | null;
+  currentFileType: string;
+  correctedFileType?: string | null;
 };
 
-export async function persistModelWeightPrecision({
+export async function persistModelTensorHeaderMetadata({
   fileId,
   fileUrl,
   modelVersionId,
   currentWeightPrecision,
   weightPrecision,
-}: PersistModelWeightPrecisionOptions) {
-  if (!weightPrecision || currentWeightPrecision === weightPrecision) return false;
+  currentFp,
+  fp,
+  currentFileType,
+  correctedFileType,
+}: PersistModelTensorHeaderMetadataOptions) {
+  const metadataPatch: Record<string, string> = {};
+  if (weightPrecision && currentWeightPrecision !== weightPrecision)
+    metadataPatch.weightPrecision = weightPrecision;
+  if (fp && currentFp !== fp) metadataPatch.fp = fp;
+
+  const shouldCorrectFileType = !!correctedFileType && correctedFileType !== currentFileType;
+  if (!Object.keys(metadataPatch).length && !shouldCorrectFileType) return false;
+
+  const typeUpdate = shouldCorrectFileType
+    ? Prisma.sql`, "type" = ${correctedFileType}`
+    : Prisma.empty;
 
   const updated = await dbWrite.$executeRaw(
     Prisma.sql`
       UPDATE "ModelFile"
       SET "metadata" = COALESCE(NULLIF("metadata", 'null'::jsonb), '{}'::jsonb) ||
-        jsonb_build_object('weightPrecision', ${weightPrecision})
+        ${JSON.stringify(metadataPatch)}::jsonb
+        ${typeUpdate}
       WHERE "id" = ${fileId}
         AND "url" = ${fileUrl}
         AND (
@@ -31,12 +50,11 @@ export async function persistModelWeightPrecision({
           "metadata" = 'null'::jsonb OR
           jsonb_typeof("metadata") = 'object'
         )
-        AND ("metadata"->>'weightPrecision') IS DISTINCT FROM ${weightPrecision}
     `
   );
 
-  // The caller read metadata without this value, so clear the model-file cache even
-  // when the write was a no-op because another request persisted it first.
+  // The caller read stale derived fields, so clear the model-file cache even when
+  // another request won the guarded write first.
   await deleteFilesForModelVersionCache(modelVersionId);
   return updated > 0;
 }

--- a/src/server/services/tensor-metadata-persistence.service.ts
+++ b/src/server/services/tensor-metadata-persistence.service.ts
@@ -1,0 +1,42 @@
+import { Prisma } from '@prisma/client';
+import { dbWrite } from '~/server/db/client';
+import { deleteFilesForModelVersionCache } from '~/server/services/model-file.service';
+
+type PersistModelWeightPrecisionOptions = {
+  fileId: number;
+  fileUrl: string;
+  modelVersionId: number;
+  currentWeightPrecision?: string | null;
+  weightPrecision: string | null;
+};
+
+export async function persistModelWeightPrecision({
+  fileId,
+  fileUrl,
+  modelVersionId,
+  currentWeightPrecision,
+  weightPrecision,
+}: PersistModelWeightPrecisionOptions) {
+  if (!weightPrecision || currentWeightPrecision === weightPrecision) return false;
+
+  const updated = await dbWrite.$executeRaw(
+    Prisma.sql`
+      UPDATE "ModelFile"
+      SET "metadata" = COALESCE(NULLIF("metadata", 'null'::jsonb), '{}'::jsonb) ||
+        jsonb_build_object('weightPrecision', ${weightPrecision})
+      WHERE "id" = ${fileId}
+        AND "url" = ${fileUrl}
+        AND (
+          "metadata" IS NULL OR
+          "metadata" = 'null'::jsonb OR
+          jsonb_typeof("metadata") = 'object'
+        )
+        AND ("metadata"->>'weightPrecision') IS DISTINCT FROM ${weightPrecision}
+    `
+  );
+
+  // The caller read metadata without this value, so clear the model-file cache even
+  // when the write was a no-op because another request persisted it first.
+  await deleteFilesForModelVersionCache(modelVersionId);
+  return updated > 0;
+}

--- a/src/server/utils/__tests__/tensor-metadata-cache-split.test.ts
+++ b/src/server/utils/__tests__/tensor-metadata-cache-split.test.ts
@@ -74,6 +74,7 @@ const makeAnalysis = () => ({
   tensorCount: 2,
   totalTensorBytes: 100,
   dtypeCounts: [{ dtype: 'F16', count: 2, bytes: 100 }],
+  weightPrecision: 'FP16',
   largestTensor: { name: 'a.weight', shape: [10, 10], dtype: 'F16', sizeBytes: 50 },
   vramEstimate: null,
   tensors: [

--- a/src/server/utils/__tests__/tensor-metadata-cache-split.test.ts
+++ b/src/server/utils/__tests__/tensor-metadata-cache-split.test.ts
@@ -67,7 +67,7 @@ import { CacheTTL } from '~/server/common/constants';
 import { bustFetchThroughCache, fetchThroughCache } from '~/server/utils/cache-helpers';
 
 const FULL_KEY = 'packed:caches:tensor-metadata:42';
-const SUMMARY_KEY = 'packed:caches:tensor-metadata-summary:42';
+const SUMMARY_KEY = 'packed:caches:tensor-metadata-summary:2:42';
 
 const makeAnalysis = () => ({
   format: 'SafeTensor' as const,
@@ -75,6 +75,7 @@ const makeAnalysis = () => ({
   totalTensorBytes: 100,
   dtypeCounts: [{ dtype: 'F16', count: 2, bytes: 100 }],
   weightPrecision: 'FP16',
+  detectedModelType: null,
   largestTensor: { name: 'a.weight', shape: [10, 10], dtype: 'F16', sizeBytes: 50 },
   vramEstimate: null,
   tensors: [

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -162,6 +162,7 @@ declare global {
     size?: ModelFileSize;
     fp?: ModelFileFp;
     quantType?: ModelFileQuantType;
+    weightPrecision?: string;
     isRequired?: boolean;
   };
 

--- a/src/utils/__tests__/model-tensor-metadata.test.ts
+++ b/src/utils/__tests__/model-tensor-metadata.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { analyzeModelTensors, getDominantWeightPrecision } from '~/utils/model-tensor-metadata';
+import {
+  analyzeModelTensors,
+  detectModelTypeFromTensors,
+  getDominantWeightPrecision,
+  getModelFileTypeCorrection,
+  weightPrecisionToModelFileFp,
+} from '~/utils/model-tensor-metadata';
 
 describe('getDominantWeightPrecision', () => {
   it('combines float8 variants into FP8 before comparing their weight bytes', () => {
@@ -27,6 +33,139 @@ describe('getDominantWeightPrecision', () => {
   });
 });
 
+describe('weightPrecisionToModelFileFp', () => {
+  it.each([
+    ['FP32', 'fp32'],
+    ['FP64', 'fp32'],
+    ['FP16', 'fp16'],
+    ['BF16', 'bf16'],
+    ['FP8', 'fp8'],
+    ['NF4', 'nf4'],
+  ])('maps %s to %s', (precision, expected) => {
+    expect(weightPrecisionToModelFileFp(precision)).toBe(expected);
+  });
+
+  it('does not force unsupported tensor precisions into the file fp field', () => {
+    expect(weightPrecisionToModelFileFp('Q4')).toBeNull();
+  });
+});
+
+describe('detectModelTypeFromTensors', () => {
+  const detect = (...names: string[]) =>
+    detectModelTypeFromTensors(names.map((name) => ({ name })));
+
+  it('recognizes a full diffusion checkpoint before its individual components', () => {
+    expect(
+      detect(
+        'model.diffusion_model.input_blocks.0.0.weight',
+        'model.diffusion_model.middle_block.0.weight',
+        'first_stage_model.encoder.conv_in.weight',
+        'cond_stage_model.transformer.text_model.encoder.layers.0.weight'
+      )
+    ).toBe('Checkpoint');
+  });
+
+  it('lets a specific ControlNet signature outrank bundled checkpoint namespaces', () => {
+    expect(
+      detect(
+        'model.diffusion_model.input_blocks.0.0.weight',
+        'first_stage_model.encoder.conv_in.weight',
+        'controlnet_blocks.0.weight'
+      )
+    ).toBe('ControlNet');
+  });
+
+  it.each([
+    [
+      'LoRA',
+      [
+        'base_model.model.blocks.0.attn.to_q.lora_A.weight',
+        'base_model.model.blocks.0.attn.to_q.lora_B.weight',
+      ],
+    ],
+    [
+      'VAE',
+      [
+        'encoder.downsamples.0.residual.0.weight',
+        'encoder.downsamples.1.residual.0.weight',
+        'decoder.upsamples.0.residual.0.weight',
+        'decoder.upsamples.1.residual.0.weight',
+      ],
+    ],
+    [
+      'TextEncoder',
+      [
+        'text_model.embeddings.token_embedding.weight',
+        'text_model.encoder.layers.0.self_attn.q_proj.weight',
+      ],
+    ],
+    [
+      'VisionEncoder',
+      [
+        'vision_model.embeddings.patch_embedding.weight',
+        'vision_model.encoder.layers.0.self_attn.q_proj.weight',
+      ],
+    ],
+    ['UNet', ['input_blocks.0.0.weight', 'middle_block.0.weight', 'output_blocks.0.0.weight']],
+    ['DiffusionModel', ['double_blocks.0.img_attn.qkv.weight', 'single_blocks.0.linear1.weight']],
+    ['ControlNet', ['controlnet_blocks.0.weight', 'controlnet_blocks.1.weight']],
+  ])('recognizes %s tensor namespaces', (expected, names) => {
+    expect(detect(...names)).toBe(expected);
+  });
+
+  it('leaves ambiguous encoder-decoder headers unclassified', () => {
+    expect(
+      detect(
+        'encoder.block.0.layer.0.weight',
+        'encoder.block.1.layer.0.weight',
+        'decoder.block.0.layer.0.weight',
+        'decoder.block.1.layer.0.weight'
+      )
+    ).toBeNull();
+  });
+});
+
+describe('getModelFileTypeCorrection', () => {
+  it.each([
+    ['VAE', 'VAE', 'Other', 'Model'],
+    ['VAE', 'Checkpoint', 'Model', 'VAE'],
+    ['TextEncoder', 'TextEncoder', 'Text Encoder', 'Model'],
+    ['TextEncoder', 'Checkpoint', 'Other', 'Text Encoder'],
+    ['VisionEncoder', 'CLIP', 'Text Encoder', 'Vision Encoder'],
+    ['UNet', 'UNet', 'UNet', 'Model'],
+    ['DiffusionModel', 'Checkpoint', 'Other', 'Diffusion Model'],
+    ['ControlNet', 'Controlnet', 'ControlNet', 'Model'],
+    ['LoRA', 'Checkpoint', 'Other', 'Enhancement LoRA'],
+  ])('corrects %s in a %s model from %s to %s', (detected, modelType, current, expected) => {
+    expect(
+      getModelFileTypeCorrection({
+        detectedModelType: detected as Parameters<
+          typeof getModelFileTypeCorrection
+        >[0]['detectedModelType'],
+        modelType,
+        currentFileType: current,
+      })
+    ).toBe(expected);
+  });
+
+  it('preserves compatible distinctions that tensor names cannot prove', () => {
+    expect(
+      getModelFileTypeCorrection({
+        detectedModelType: 'Checkpoint',
+        modelType: 'Checkpoint',
+        currentFileType: 'Pruned Model',
+      })
+    ).toBeNull();
+    expect(
+      getModelFileTypeCorrection({
+        detectedModelType: 'LoRA',
+        modelType: 'LORA',
+        currentFileType: 'Model',
+      })
+    ).toBeNull();
+  });
+});
+
 describe('analyzeModelTensors', () => {
   it('includes the dominant weight precision in the cached analysis', () => {
     const analysis = analyzeModelTensors(
@@ -39,5 +178,6 @@ describe('analyzeModelTensors', () => {
     );
 
     expect(analysis.weightPrecision).toBe('Q4');
+    expect(analysis.detectedModelType).toBeNull();
   });
 });

--- a/src/utils/__tests__/model-tensor-metadata.test.ts
+++ b/src/utils/__tests__/model-tensor-metadata.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeModelTensors, getDominantWeightPrecision } from '~/utils/model-tensor-metadata';
+
+describe('getDominantWeightPrecision', () => {
+  it('combines float8 variants into FP8 before comparing their weight bytes', () => {
+    expect(
+      getDominantWeightPrecision([
+        { dtype: 'F8_E4M3FN', count: 2, bytes: 40 },
+        { dtype: 'F8_E5M2', count: 1, bytes: 30 },
+        { dtype: 'BF16', count: 1, bytes: 60 },
+      ])
+    ).toBe('FP8');
+  });
+
+  it.each([
+    ['BF16', 'BF16'],
+    ['F16', 'FP16'],
+    ['Q4_K', 'Q4'],
+    ['Q8_0', 'Q8'],
+    ['IQ4_XS', 'IQ4'],
+  ])('normalizes %s as %s', (dtype, expected) => {
+    expect(getDominantWeightPrecision([{ dtype, count: 1, bytes: 100 }])).toBe(expected);
+  });
+
+  it('returns null when no dtype accounts for any weight bytes', () => {
+    expect(getDominantWeightPrecision([{ dtype: 'F16', count: 0, bytes: 0 }])).toBeNull();
+  });
+});
+
+describe('analyzeModelTensors', () => {
+  it('includes the dominant weight precision in the cached analysis', () => {
+    const analysis = analyzeModelTensors(
+      'GGUF',
+      [
+        { name: 'layer.0.weight', shape: [1], dtype: 'Q4_K', sizeBytes: 90 },
+        { name: 'layer.0.scale', shape: [1], dtype: 'Q6_K', sizeBytes: 10 },
+      ],
+      { estimateVram: false }
+    );
+
+    expect(analysis.weightPrecision).toBe('Q4');
+  });
+});

--- a/src/utils/model-tensor-metadata.ts
+++ b/src/utils/model-tensor-metadata.ts
@@ -57,6 +57,7 @@ export type ModelTensorAnalysis = {
   tensorCount: number;
   totalTensorBytes: number;
   dtypeCounts: ModelTensorDtypeSummary[];
+  weightPrecision: string | null;
   largestTensor: ModelTensorInfo | null;
   vramEstimate: ModelVramEstimate | null;
   tensors: ModelTensorInfo[];
@@ -110,15 +111,54 @@ export function analyzeModelTensors(
     dtypeCounts.set(tensor.dtype, summary);
   }
 
+  const dtypeSummary = [...dtypeCounts.values()].sort((a, b) => b.bytes - a.bytes);
+
   return {
     format,
     tensorCount: tensors.length,
     totalTensorBytes,
-    dtypeCounts: [...dtypeCounts.values()].sort((a, b) => b.bytes - a.bytes),
+    dtypeCounts: dtypeSummary,
+    weightPrecision: getDominantWeightPrecision(dtypeSummary),
     largestTensor,
     vramEstimate: estimateVram ? estimateComfyDynamicOffloadVram(tensors) : null,
     tensors,
   };
+}
+
+export function getDominantWeightPrecision(dtypeCounts: ModelTensorDtypeSummary[]) {
+  const bytesByPrecision = new Map<string, number>();
+
+  for (const { dtype, bytes } of dtypeCounts) {
+    if (!Number.isFinite(bytes) || bytes <= 0) continue;
+    const precision = toWeightPrecision(dtype);
+    bytesByPrecision.set(precision, (bytesByPrecision.get(precision) ?? 0) + bytes);
+  }
+
+  let dominant: { precision: string; bytes: number } | null = null;
+  for (const [precision, bytes] of bytesByPrecision) {
+    if (!dominant || bytes > dominant.bytes) dominant = { precision, bytes };
+  }
+
+  return dominant?.precision ?? null;
+}
+
+function toWeightPrecision(dtype: string) {
+  const normalized = normalizePrecision(dtype);
+  if (normalized.startsWith('F8')) return 'FP8';
+
+  const floatMatch = /^F(\d+)$/.exec(normalized);
+  if (floatMatch) return `FP${floatMatch[1]}`;
+
+  const quantizedMatch = /^(I?Q)(\d+)/.exec(normalized);
+  if (quantizedMatch) return `${quantizedMatch[1]}${quantizedMatch[2]}`;
+
+  const integerMatch = /^I(\d+)$/.exec(normalized);
+  if (integerMatch) return `INT${integerMatch[1]}`;
+
+  const unsignedIntegerMatch = /^U(\d+)$/.exec(normalized);
+  if (unsignedIntegerMatch) return `UINT${unsignedIntegerMatch[1]}`;
+
+  return normalized;
 }
 
 export function supportsTensorVramEstimate({ modelType, fileType }: ModelTensorVramSupport) {

--- a/src/utils/model-tensor-metadata.ts
+++ b/src/utils/model-tensor-metadata.ts
@@ -1,3 +1,5 @@
+import type { ModelFileType } from '~/server/common/constants';
+
 const MiB = 1024 * 1024;
 const GiB = 1024 * MiB;
 
@@ -11,6 +13,15 @@ const COMFY_DYNAMIC_VRAM_PAGE_BYTES = 32 * MiB;
 type FetchLike = typeof fetch;
 
 export type ModelTensorFormat = 'SafeTensor' | 'GGUF';
+export type DetectedModelTensorType =
+  | 'Checkpoint'
+  | 'LoRA'
+  | 'VAE'
+  | 'TextEncoder'
+  | 'VisionEncoder'
+  | 'UNet'
+  | 'DiffusionModel'
+  | 'ControlNet';
 export type ModelTensorVramSupport = {
   modelType?: string | null;
   fileType?: string | null;
@@ -58,6 +69,7 @@ export type ModelTensorAnalysis = {
   totalTensorBytes: number;
   dtypeCounts: ModelTensorDtypeSummary[];
   weightPrecision: string | null;
+  detectedModelType: DetectedModelTensorType | null;
   largestTensor: ModelTensorInfo | null;
   vramEstimate: ModelVramEstimate | null;
   tensors: ModelTensorInfo[];
@@ -119,6 +131,7 @@ export function analyzeModelTensors(
     totalTensorBytes,
     dtypeCounts: dtypeSummary,
     weightPrecision: getDominantWeightPrecision(dtypeSummary),
+    detectedModelType: format === 'SafeTensor' ? detectModelTypeFromTensors(tensors) : null,
     largestTensor,
     vramEstimate: estimateVram ? estimateComfyDynamicOffloadVram(tensors) : null,
     tensors,
@@ -140,6 +153,175 @@ export function getDominantWeightPrecision(dtypeCounts: ModelTensorDtypeSummary[
   }
 
   return dominant?.precision ?? null;
+}
+
+export function weightPrecisionToModelFileFp(
+  weightPrecision: string | null | undefined
+): ModelFileFp | null {
+  switch (weightPrecision?.toUpperCase()) {
+    case 'FP32':
+    case 'FP64':
+      return 'fp32';
+    case 'FP16':
+      return 'fp16';
+    case 'BF16':
+      return 'bf16';
+    case 'FP8':
+      return 'fp8';
+    case 'NF4':
+      return 'nf4';
+    default:
+      return null;
+  }
+}
+
+export function detectModelTypeFromTensors(
+  tensors: Pick<ModelTensorInfo, 'name'>[]
+): DetectedModelTensorType | null {
+  const names = tensors.map(({ name }) => name.toLowerCase());
+  const has = (predicate: (name: string) => boolean) => names.some(predicate);
+  const count = (predicate: (name: string) => boolean) => names.filter(predicate).length;
+  const startsWithAny = (name: string, prefixes: string[]) =>
+    prefixes.some((prefix) => name.startsWith(prefix));
+
+  const hasLoraA = has((name) => /\.lora_(?:a|down)\.weight$/.test(name));
+  const hasLoraB = has((name) => /\.lora_(?:b|up)\.weight$/.test(name));
+  if (hasLoraA && hasLoraB) return 'LoRA';
+
+  if (
+    has((name) =>
+      startsWithAny(name, [
+        'control_model.',
+        'controlnet_blocks.',
+        'controlnet_down_blocks.',
+        'controlnet_mid_block.',
+        'zero_convs.',
+        'input_hint_block.',
+      ])
+    )
+  )
+    return 'ControlNet';
+
+  const diffusionPrefixes = ['model.diffusion_model.', 'diffusion_model.'];
+  const hasDiffusionNamespace = has((name) => startsWithAny(name, diffusionPrefixes));
+  const hasCheckpointComponents = has((name) =>
+    startsWithAny(name, ['first_stage_model.', 'cond_stage_model.', 'conditioner.embedders.'])
+  );
+  if (hasDiffusionNamespace && hasCheckpointComponents) return 'Checkpoint';
+
+  const encoderCount = count((name) => name.startsWith('encoder.'));
+  const decoderCount = count((name) => name.startsWith('decoder.'));
+  const hasVaeEncoderStructure = has((name) =>
+    /^(?:encoder\.(?:down|downsamples|conv_in|mid)|quant_conv\.)/.test(name)
+  );
+  const hasVaeDecoderStructure = has((name) =>
+    /^(?:decoder\.(?:up|upsamples|conv_out|mid)|post_quant_conv\.)/.test(name)
+  );
+  if (encoderCount >= 2 && decoderCount >= 2 && hasVaeEncoderStructure && hasVaeDecoderStructure)
+    return 'VAE';
+
+  if (
+    has((name) => name.includes('vision_model.embeddings.')) &&
+    has((name) => name.includes('vision_model.encoder.'))
+  )
+    return 'VisionEncoder';
+
+  const hasClipTextEncoder =
+    has((name) => name.includes('text_model.embeddings.')) &&
+    has((name) => name.includes('text_model.encoder.'));
+  const hasLlmTextEncoder =
+    has((name) => name.endsWith('embed_tokens.weight')) &&
+    count((name) => /(?:^|\.)layers\.\d+\./.test(name)) >= 2;
+  const hasT5TextEncoder =
+    has((name) => name === 'shared.weight' || name.endsWith('.shared.weight')) &&
+    count((name) => /(?:^|\.)encoder\.block\.\d+\./.test(name)) >= 2;
+  if (hasClipTextEncoder || hasLlmTextEncoder || hasT5TextEncoder) return 'TextEncoder';
+
+  const hasInputBlocks = has((name) =>
+    /^(?:(?:model\.)?diffusion_model\.)?input_blocks\./.test(name)
+  );
+  const hasMiddleBlock = has((name) =>
+    /^(?:(?:model\.)?diffusion_model\.)?middle_block\./.test(name)
+  );
+  const hasOutputBlocks = has((name) =>
+    /^(?:(?:model\.)?diffusion_model\.)?output_blocks\./.test(name)
+  );
+  if (hasInputBlocks && hasMiddleBlock && hasOutputBlocks) return 'UNet';
+
+  const hasFluxBlocks =
+    has((name) => name.startsWith('double_blocks.')) &&
+    has((name) => name.startsWith('single_blocks.'));
+  const hasJointTransformer =
+    has((name) => name.startsWith('joint_blocks.')) &&
+    has((name) => /^(?:x|context)_embedder\./.test(name));
+  const hasDiffusersTransformer =
+    has((name) => name.startsWith('transformer_blocks.')) &&
+    has((name) => /^(?:patch_embed|pos_embed|proj_in|x_embedder)\./.test(name));
+  const hasKreaTransformer =
+    count((name) => /^blocks\.\d+\./.test(name)) >= 2 &&
+    has((name) => name === 'first.weight') &&
+    has((name) => name === 'last.linear.weight');
+  if (hasFluxBlocks || hasJointTransformer || hasDiffusersTransformer || hasKreaTransformer)
+    return 'DiffusionModel';
+
+  return null;
+}
+
+export function getModelFileTypeCorrection({
+  detectedModelType,
+  modelType,
+  currentFileType,
+}: {
+  detectedModelType: DetectedModelTensorType | null | undefined;
+  modelType?: string | null;
+  currentFileType?: string | null;
+}): ModelFileType | null {
+  if (!detectedModelType) return null;
+
+  let canonicalType: ModelFileType;
+  let compatibleTypes: readonly string[] = [];
+
+  switch (detectedModelType) {
+    case 'Checkpoint':
+      canonicalType = 'Model';
+      compatibleTypes = modelType === 'Checkpoint' ? ['Model', 'Pruned Model'] : ['Model'];
+      break;
+    case 'LoRA':
+      if (modelType === 'LORA' || modelType === 'DoRA' || modelType === 'LoCon') {
+        canonicalType = 'Model';
+        compatibleTypes = ['Model', 'Pruned Model'];
+      } else {
+        canonicalType = 'Enhancement LoRA';
+      }
+      break;
+    case 'VAE':
+      canonicalType = modelType === 'VAE' ? 'Model' : 'VAE';
+      break;
+    case 'TextEncoder':
+      canonicalType = modelType === 'TextEncoder' ? 'Model' : 'Text Encoder';
+      break;
+    case 'VisionEncoder':
+      canonicalType =
+        modelType === 'CLIPVision'
+          ? 'Model'
+          : modelType === 'CLIP'
+          ? 'Vision Encoder'
+          : 'CLIPVision';
+      break;
+    case 'UNet':
+      canonicalType = modelType === 'UNet' ? 'Model' : 'UNet';
+      break;
+    case 'DiffusionModel':
+      canonicalType = modelType === 'UNet' ? 'Model' : 'Diffusion Model';
+      break;
+    case 'ControlNet':
+      canonicalType = modelType === 'Controlnet' ? 'Model' : 'ControlNet';
+      break;
+  }
+
+  if (currentFileType === canonicalType || compatibleTypes.includes(currentFileType ?? ''))
+    return null;
+  return canonicalType;
 }
 
 function toWeightPrecision(dtype: string) {


### PR DESCRIPTION
Uses SafeTensor headers as the source of truth for file precision and unambiguous file type corrections. Keeps weight precision in the tensor API and overview while reusing cached tensor data.