### PR TITLE
perf(server-cpu): unify tRPC procedure-duration timing

### DIFF
--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -246,7 +246,6 @@ function runRecordProcedureDuration<T>(
   userId: number | undefined,
   next: () => Promise<T>
 ): Promise<T> {
-  const metricsEnd = TRPC_PROCEDURE_METRICS ? trpcProcedureDuration.startTimer({ path }) : undefined;
   const startedAt = performance.now();
   return next().then(
     (result) => {
@@ -255,16 +254,21 @@ function runRecordProcedureDuration<T>(
       const r = result as unknown as { ok?: boolean; error?: { code?: string } };
       const ok = r?.ok !== false;
       const errorCode = r?.ok === false ? r.error?.code : undefined;
-      metricsEnd?.();
-      maybeLogTrpcSlow({ path, type, durationMs: performance.now() - startedAt, ok, errorCode, userId });
+      const durationMs = performance.now() - startedAt;
+      // Reuse the single performance.now() delta for BOTH the opt-in histogram and
+      // the always-on slow-log — avoids startTimer's separate hrtime capture +
+      // Object.assign per procedure. Same histogram semantics (wall-clock seconds).
+      if (TRPC_PROCEDURE_METRICS) trpcProcedureDuration.observe({ path }, durationMs / 1000);
+      maybeLogTrpcSlow({ path, type, durationMs, ok, errorCode, userId });
       return result;
     },
     (err) => {
-      metricsEnd?.();
+      const durationMs = performance.now() - startedAt;
+      if (TRPC_PROCEDURE_METRICS) trpcProcedureDuration.observe({ path }, durationMs / 1000);
       maybeLogTrpcSlow({
         path,
         type,
-        durationMs: performance.now() - startedAt,
+        durationMs,
         ok: false,
         errorCode: err instanceof TRPCError ? err.code : undefined,
         userId,


### PR DESCRIPTION
## What

Reuse a single `performance.now()` delta in `runRecordProcedureDuration` for **both** the always-on slow-procedure log and the opt-in `trpc_procedure_duration_seconds` histogram — dropping the separate `startTimer()` (its own `hrtime` capture + `Object.assign` per procedure).

**No metric or behavior change:** same histogram, same `path` label, same seconds unit, same `TRPC_PROCEDURE_METRICS` gating, both success + error branches observe.

## Why

Identified via Pyroscope + source-map-resolved profiling **at peak** on the api-heavy pool. The web tier is ceiling-capped at the daily peak, so trimming per-request CPU relieves the pod ceiling. To be **booked via Pyroscope diff-by-version** on the already-armed api-heavy pool.

## Note

This PR was originally bundled with a byte-identical superjson micro-patch — **that was split out**. superjson 2.2.6 is already the latest version (no upgrade available), so a micro-patch carried maintenance + a latent-registration footgun for only ~1%. A **faster-serializer swap** (seroval/devalue vs superjson) is being **evaluated as a separate initiative** — it's the bigger superjson lever but a wire-format-change/coordinated-cutover, best decided after the Node 22 async-context-frame bump (which removes the larger ~7.6% async_hooks cluster and re-weights the profile).

## Safety
No wire/API/UX change; `tsc --noEmit`: added code type-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)