### PR TITLE
feat(app-blocks): per-app runtime observability via prom-client

### DIFF
--- a/src/components/AppBlocks/BlockErrorBoundary.tsx
+++ b/src/components/AppBlocks/BlockErrorBoundary.tsx
@@ -1,9 +1,17 @@
 import { Component } from 'react';
 import type { ErrorInfo, ReactNode } from 'react';
 import { BlockFallback } from './BlockFallback';
+import { sendBlockRender } from './sendBlockRender';
 
 interface Props {
   blockName?: string;
+  // Identifiers for the render-FAILURE beacon fired on a host-tree crash. When
+  // present, a caught error emits `civitai_app_block_renders_total{result=error}`
+  // (via the /api/track/block-render beacon). Optional so the boundary still
+  // works as pure render isolation where the ids aren't threaded.
+  appBlockId?: string;
+  blockInstanceId?: string;
+  slotId?: string;
   children: ReactNode;
 }
 
@@ -20,6 +28,8 @@ interface State {
  */
 export class BlockErrorBoundary extends Component<Props, State> {
   state: State = { hasError: false };
+  // Emit-once guard so a crash that re-renders can't double-fire the beacon.
+  private beaconFired = false;
 
   static getDerivedStateFromError(): State {
     return { hasError: true };
@@ -28,6 +38,21 @@ export class BlockErrorBoundary extends Component<Props, State> {
   componentDidCatch(error: Error, info: ErrorInfo) {
     // eslint-disable-next-line no-console
     console.error('[AppBlocks] block crashed', { error, info });
+
+    // Runtime observability: a host-tree crash is a genuine render failure —
+    // fire the `error` render beacon once. Only when we have the identifiers to
+    // attribute it (the v1 InlineHost-stub throw path has none, so it's skipped).
+    const { appBlockId, blockInstanceId, slotId } = this.props;
+    if (!this.beaconFired && appBlockId && blockInstanceId && slotId) {
+      this.beaconFired = true;
+      sendBlockRender({
+        appBlockId,
+        blockInstanceId,
+        slotId,
+        status: 'error',
+        errorClass: 'error_boundary',
+      });
+    }
   }
 
   render() {

--- a/src/components/AppBlocks/BlockSlotClient.tsx
+++ b/src/components/AppBlocks/BlockSlotClient.tsx
@@ -97,7 +97,12 @@ export function BlockSlotClient({ slotId, context }: BlockSlotClientProps) {
         data-block-count={1}
         data-active-block-id={install.blockInstanceId}
       >
-        <BlockErrorBoundary blockName={install.manifest.name}>
+        <BlockErrorBoundary
+          blockName={install.manifest.name}
+          appBlockId={install.appBlockId}
+          blockInstanceId={install.blockInstanceId}
+          slotId={slotId}
+        >
           <BlockHost blockInstall={install} slotContext={context} />
         </BlockErrorBoundary>
       </div>
@@ -139,6 +144,9 @@ export function BlockSlotClient({ slotId, context }: BlockSlotClientProps) {
           <BlockErrorBoundary
             key={activeInstall.blockInstanceId}
             blockName={activeInstall.manifest.name}
+            appBlockId={activeInstall.appBlockId}
+            blockInstanceId={activeInstall.blockInstanceId}
+            slotId={slotId}
           >
             <BlockHost blockInstall={activeInstall} slotContext={context} />
           </BlockErrorBoundary>

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -681,6 +681,26 @@ export function IframeHost({
     return off;
   }, [onMessage, applyHeight, install.appBlockId, install.blockInstanceId, slotId]);
 
+  // App Blocks runtime observability — render-FAILURE beacon. The success
+  // beacon fires at BLOCK_READY above (guarded by `blockRenderEmittedRef`). Here
+  // we fire the mutually-exclusive `error` beacon when the host lands on a
+  // terminal-failure state — the iframe never reached BLOCK_READY in time
+  // ('timeout'), the block reported a fatal error ('fatal'), or its token never
+  // resolved ('no_token'). Sharing the SAME emit-once ref makes ok/error
+  // mutually exclusive per mount. Fire-and-forget (beacon swallows failures).
+  useEffect(() => {
+    if (status !== 'timeout' && status !== 'fatal' && status !== 'no_token') return;
+    if (blockRenderEmittedRef.current) return;
+    blockRenderEmittedRef.current = true;
+    sendBlockRender({
+      appBlockId: install.appBlockId,
+      blockInstanceId: install.blockInstanceId,
+      slotId,
+      status: 'error',
+      errorClass: status,
+    });
+  }, [status, install.appBlockId, install.blockInstanceId, slotId]);
+
   useEffect(() => {
     const off = onMessage<unknown>('RESIZE_IFRAME', (raw) => {
       if (!raw || typeof raw !== 'object' || !('height' in raw)) return;

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -408,6 +408,27 @@ export function PageBlockHost({
     return off;
   }, [onMessage]);
 
+  // App Blocks runtime observability — render-FAILURE beacon. The success beacon
+  // fires at BLOCK_READY above (guarded by `blockRenderEmittedRef`). Here we fire
+  // the mutually-exclusive `error` beacon when the page host lands on a terminal-
+  // failure state: the iframe never reached BLOCK_READY ('timeout'), the block
+  // reported a fatal error ('fatal'), its token never resolved ('no_token'), or
+  // the mint hard-failed ('error'). Sharing the SAME emit-once ref makes ok/error
+  // mutually exclusive per mount. Fire-and-forget (beacon swallows failures).
+  useEffect(() => {
+    if (status !== 'timeout' && status !== 'fatal' && status !== 'no_token' && status !== 'error')
+      return;
+    if (blockRenderEmittedRef.current) return;
+    blockRenderEmittedRef.current = true;
+    sendBlockRender({
+      appBlockId,
+      blockInstanceId,
+      slotId: 'app.page',
+      status: 'error',
+      errorClass: status,
+    });
+  }, [status, appBlockId, blockInstanceId]);
+
   // Lazy consent (A6): the block (rendered in full for a logged-in viewer whose
   // page token is missing a consent-gated scope, e.g. `ai:write:budgeted` once
   // the page money scope is enabled) asks the host to open the consent UI when

--- a/src/components/AppBlocks/sendBlockRender.ts
+++ b/src/components/AppBlocks/sendBlockRender.ts
@@ -18,6 +18,15 @@ export type BlockRenderBeaconInput = {
   appBlockId: string;
   blockInstanceId: string;
   slotId: string;
+  // Render outcome. Omitted (or 'ok') for the BLOCK_READY success beacon; 'error'
+  // when the host detects a genuine render failure (error-boundary trip, or the
+  // iframe never reaching BLOCK_READY within its timeout). Drives the
+  // `civitai_app_block_renders_total{result}` prom counter server-side.
+  status?: 'ok' | 'error';
+  // Optional low-cardinality failure discriminator (e.g. 'timeout', 'fatal',
+  // 'no_token', 'error_boundary'). Accepted + bounded server-side; reserved for a
+  // future ClickHouse column (NOT a prom label, NOT in the CH insert today).
+  errorClass?: string;
 };
 
 export function sendBlockRender(input: BlockRenderBeaconInput) {

--- a/src/pages/api/track/block-render.ts
+++ b/src/pages/api/track/block-render.ts
@@ -1,6 +1,10 @@
 import { isDev } from '~/env/other';
 import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { Tracker } from '~/server/clickhouse/client';
+import {
+  ensureRegisterAppBlockRuntimeMetrics,
+  normalizeSlotId,
+} from '~/server/metrics/app-block-runtime.metrics';
 import { blockRenderSchema } from '~/server/schema/track.schema';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 
@@ -61,6 +65,29 @@ export default PublicEndpoint(
     const result = blockRenderSchema.safeParse(parsed);
     if (!result.success) return res.status(400).send('invalid input');
 
+    // `status`/`errorClass` drive the prom render counter ONLY — they are NOT
+    // forwarded to the ClickHouse insert (the `blockRenders` table is provisioned
+    // out-of-repo by the tracker service; adding columns is out of scope here).
+    // Strip them so the CH payload stays byte-identical to the pre-change insert.
+    const { status, errorClass: _errorClass, ...renderData } = result.data;
+
+    // Per-app render/impression outcome (additive + dark). `result` ∈ ok|error.
+    // `slot_id` is clamped to the enumerated slot set (unknown → 'other');
+    // `app_block_id` is client-supplied here (same trust level as the CH insert)
+    // — see the cardinality-budget note in app-block-runtime.metrics. Emitted
+    // AFTER the same-origin + schema gates so only well-formed beacons count.
+    // Fire-and-forget: never let a metrics failure break the beacon.
+    try {
+      const { rendersTotal } = ensureRegisterAppBlockRuntimeMetrics();
+      rendersTotal.inc({
+        app_block_id: renderData.appBlockId,
+        slot_id: normalizeSlotId(renderData.slotId),
+        result: status,
+      });
+    } catch {
+      // swallow — observability must not affect the response
+    }
+
     // Resolve the session ONCE here so we can derive isAnon, then hand it to the
     // Tracker (3rd ctor arg) so it isn't re-resolved. `isAnon` is SERVER-derived
     // (`!session?.user`) — never from the client body.
@@ -68,7 +95,7 @@ export default PublicEndpoint(
     const tracker = new Tracker(req, res, session);
     // Fire-and-forget: blockRender() dispatches the ClickHouse insert without
     // awaiting the network round-trip (same as the tRPC resolver did).
-    void tracker.blockRender({ ...result.data, isAnon: !session?.user });
+    void tracker.blockRender({ ...renderData, isAnon: !session?.user });
 
     return res.status(200).end();
   },

--- a/src/pages/api/track/block-render.ts
+++ b/src/pages/api/track/block-render.ts
@@ -5,6 +5,7 @@ import {
   ensureRegisterAppBlockRuntimeMetrics,
   normalizeSlotId,
 } from '~/server/metrics/app-block-runtime.metrics';
+import { boundAppBlockIdLabel } from '~/server/services/blocks/known-app-blocks.service';
 import { blockRenderSchema } from '~/server/schema/track.schema';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 
@@ -72,15 +73,19 @@ export default PublicEndpoint(
     const { status, errorClass: _errorClass, ...renderData } = result.data;
 
     // Per-app render/impression outcome (additive + dark). `result` ∈ ok|error.
-    // `slot_id` is clamped to the enumerated slot set (unknown → 'other');
-    // `app_block_id` is client-supplied here (same trust level as the CH insert)
-    // — see the cardinality-budget note in app-block-runtime.metrics. Emitted
-    // AFTER the same-origin + schema gates so only well-formed beacons count.
-    // Fire-and-forget: never let a metrics failure break the beacon.
+    // All three labels are BOUNDED even though the beacon body is client-supplied
+    // and this route is public/ungated: `slot_id` clamps to the enumerated slot
+    // set, `result` is enumerated, and `app_block_id` is clamped to the
+    // approved-app set (unknown → 'other') via a TTL-cached in-memory lookup — no
+    // per-request DB hit — so a scripted client can't blow up prom-client's heap
+    // with unbounded distinct labels. Emitted AFTER the same-origin + schema
+    // gates so only well-formed beacons count. Fire-and-forget: never let a
+    // metrics failure break the beacon.
     try {
+      const appBlockIdLabel = await boundAppBlockIdLabel(renderData.appBlockId);
       const { rendersTotal } = ensureRegisterAppBlockRuntimeMetrics();
       rendersTotal.inc({
-        app_block_id: renderData.appBlockId,
+        app_block_id: appBlockIdLabel,
         slot_id: normalizeSlotId(renderData.slotId),
         result: status,
       });

--- a/src/pages/api/v1/blocks/buzz.ts
+++ b/src/pages/api/v1/blocks/buzz.ts
@@ -58,6 +58,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 // the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
 // images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
 export default withBlockScope(baseHandler, {
+  endpoint: 'buzz',
   requiredScope: 'buzz:read:self',
   allowOpaqueOrigin: true,
 });

--- a/src/pages/api/v1/blocks/collections/[id]/follow.ts
+++ b/src/pages/api/v1/blocks/collections/[id]/follow.ts
@@ -106,6 +106,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 // the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
 // images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
 export default withBlockScope(baseHandler, {
+  endpoint: 'collection_follow',
   requiredScope: 'collections:write:self',
   allowOpaqueOrigin: true,
 });

--- a/src/pages/api/v1/blocks/collections/[id]/index.ts
+++ b/src/pages/api/v1/blocks/collections/[id]/index.ts
@@ -188,6 +188,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 // the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
 // images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
 export default withBlockScope(baseHandler, {
+  endpoint: 'collection',
   requiredScope: 'collections:read:self',
   allowOpaqueOrigin: true,
 });

--- a/src/pages/api/v1/blocks/collections/index.ts
+++ b/src/pages/api/v1/blocks/collections/index.ts
@@ -288,6 +288,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 // the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
 // images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
 export default withBlockScope(baseHandler, {
+  endpoint: 'collections',
   requiredScope: 'collections:read:self',
   allowOpaqueOrigin: true,
 });

--- a/src/pages/api/v1/blocks/images.ts
+++ b/src/pages/api/v1/blocks/images.ts
@@ -272,4 +272,4 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 // (`Origin: null`) so its direct catalog fetch needs `ACAO: null` to clear the
 // CORS preflight; safe here (public maturity-clamped data, no credentials,
 // still token-gated) — see WithBlockScopeOpts.allowOpaqueOrigin.
-export default withBlockScope(baseHandler, { allowOpaqueOrigin: true });
+export default withBlockScope(baseHandler, { endpoint: 'images', allowOpaqueOrigin: true });

--- a/src/pages/api/v1/blocks/me.ts
+++ b/src/pages/api/v1/blocks/me.ts
@@ -104,4 +104,4 @@ const baseHandler = withAxiom(async function handler(
   });
 });
 
-export default withBlockScope(baseHandler, { requiredScope: 'user:read:self' });
+export default withBlockScope(baseHandler, { endpoint: 'me', requiredScope: 'user:read:self' });

--- a/src/pages/api/v1/blocks/models.ts
+++ b/src/pages/api/v1/blocks/models.ts
@@ -195,4 +195,4 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 // (`Origin: null`) so its direct catalog fetch needs `ACAO: null` to clear the
 // CORS preflight; safe here (public maturity-clamped data, no credentials,
 // still token-gated) — see WithBlockScopeOpts.allowOpaqueOrigin.
-export default withBlockScope(baseHandler, { allowOpaqueOrigin: true });
+export default withBlockScope(baseHandler, { endpoint: 'models', allowOpaqueOrigin: true });

--- a/src/pages/api/v1/blocks/shared-storage/increment.ts
+++ b/src/pages/api/v1/blocks/shared-storage/increment.ts
@@ -75,6 +75,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 // the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
 // images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
 export default withBlockScope(baseHandler, {
+  endpoint: 'shared_storage_increment',
   requiredScope: 'apps:storage:shared:write',
   allowOpaqueOrigin: true,
 });

--- a/src/pages/api/v1/blocks/shared-storage/top.ts
+++ b/src/pages/api/v1/blocks/shared-storage/top.ts
@@ -71,6 +71,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 // the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
 // images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
 export default withBlockScope(baseHandler, {
+  endpoint: 'shared_storage_top',
   requiredScope: 'apps:storage:shared:read',
   allowOpaqueOrigin: true,
 });

--- a/src/pages/api/v1/blocks/tip.ts
+++ b/src/pages/api/v1/blocks/tip.ts
@@ -217,6 +217,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 // the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
 // images.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
 export default withBlockScope(baseHandler, {
+  endpoint: 'tip',
   requiredScope: 'social:tip:self',
   allowOpaqueOrigin: true,
 });

--- a/src/pages/api/v1/models/[id].ts
+++ b/src/pages/api/v1/models/[id].ts
@@ -252,4 +252,7 @@ async function fetchModelResponseCached(
 // App Blocks: allow this route to be called with an RS256 block JWT carrying
 // the `models:read:self` scope. When no block JWT is present the call falls
 // through to the existing PublicEndpoint path, so legacy callers are unaffected.
-export default withBlockScope(baseHandler, { requiredScope: 'models:read:self' });
+export default withBlockScope(baseHandler, {
+  endpoint: 'model_detail',
+  requiredScope: 'models:read:self',
+});

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -1,0 +1,150 @@
+// App Blocks — per-app runtime observability (prom-client).
+//
+// Closes the runtime-health gap for the App Blocks platform: third-party
+// mini-apps rendered as iframes on model pages + /apps/run pages previously
+// had NO per-app telemetry, so render failures and per-app API errors were
+// invisible until a human reported them. These metrics are pure prom-client
+// (no new infra, no ClickHouse migration) and are scraped by the same
+// /api/metrics endpoint that exposes every other app metric.
+//
+// Two signals:
+//   1. Per-app REST RED — emitted from block-scope.middleware for every
+//      block-JWT-authed /api/v1/blocks/* call.
+//   2. Render-failure signal — emitted from the /api/track/block-render beacon
+//      route (ok at BLOCK_READY, error on a host render failure).
+//
+// prom-client GOTCHA: Next.js can import a module twice (hot reload / route
+// bundling), and prom-client throws if a metric name is registered twice. Every
+// getter below is a get-or-create guard against the DEFAULT global registry
+// (`client.register`) — a second import reuses the existing metric instance,
+// exactly like ~/server/metrics/feed-image-existence-check.metrics.ts.
+//
+// CARDINALITY BUDGET: `app_block_id` is bounded to APPROVED apps (dozens today;
+// could reach hundreds at true-public GA). Acceptable for prom labels now. At
+// GA an allowlist/cap (bucket unknown ids into 'other') may be needed — the
+// render beacon in particular takes app_block_id from a same-origin client body
+// (not a verified JWT like the REST-RED path), so a GA hardening pass should
+// cap it there first. `endpoint`, `result`, and `slot_id` are strictly
+// enumerated (see AppBlockEndpoint / normalizeSlotId / *Result below) so they
+// can never blow up cardinality regardless of client input.
+import client, { type Counter, type Histogram, type Registry } from 'prom-client';
+
+/**
+ * Low-cardinality LOGICAL endpoint names for the block REST surface. Passed by
+ * each `withBlockScope(...)` call site (derived from the HANDLER, never from
+ * `req.url`), so ids in the path can never leak into the label.
+ */
+export type AppBlockEndpoint =
+  | 'tip'
+  | 'buzz'
+  | 'images'
+  | 'models'
+  | 'model_detail'
+  | 'me'
+  | 'collections'
+  | 'collection'
+  | 'collection_follow'
+  | 'shared_storage_top'
+  | 'shared_storage_increment';
+
+export type AppBlockRequestResult = 'success' | 'client_error' | 'server_error' | 'forbidden';
+
+export type AppBlockRenderResult = 'ok' | 'error';
+
+/** Known render slots. Anything else is bucketed to 'other' to bound the label. */
+const KNOWN_SLOT_IDS = new Set([
+  'app.page',
+  'model.sidebar_top',
+  'model.below_images',
+  'model.actions_extra',
+]);
+
+/**
+ * Clamp a client-supplied slotId to the enumerated slot set (unknown → 'other')
+ * so the `slot_id` prom label can never explode even though the beacon body is
+ * client-controlled.
+ */
+export function normalizeSlotId(slotId: string): string {
+  return KNOWN_SLOT_IDS.has(slotId) ? slotId : 'other';
+}
+
+/**
+ * Map an HTTP status code to the enumerated REST `result` label. 401/403 fold
+ * into `forbidden` (auth/scope rejections — the middleware's own 403s land here
+ * too); other 4xx → `client_error`; 5xx → `server_error`; else `success`.
+ */
+export function statusToRequestResult(status: number): AppBlockRequestResult {
+  if (status >= 500) return 'server_error';
+  if (status === 401 || status === 403) return 'forbidden';
+  if (status >= 400) return 'client_error';
+  return 'success';
+}
+
+function getOrCreateCounter(
+  reg: Registry,
+  name: string,
+  help: string,
+  labelNames: string[]
+): Counter<string> {
+  const existing = reg.getSingleMetric(name) as Counter<string> | undefined;
+  if (existing) return existing;
+  return new client.Counter({ name, help, labelNames, registers: [reg] });
+}
+
+function getOrCreateHistogram(
+  reg: Registry,
+  name: string,
+  help: string,
+  labelNames: string[],
+  buckets?: number[]
+): Histogram<string> {
+  const existing = reg.getSingleMetric(name) as Histogram<string> | undefined;
+  if (existing) return existing;
+  // prom-client v14 throws if `buckets` is present-but-undefined (it calls
+  // `.reduce` on it) — only pass the key when we actually have custom buckets,
+  // otherwise let prom-client apply its DEFAULT buckets.
+  return new client.Histogram({
+    name,
+    help,
+    labelNames,
+    ...(buckets ? { buckets } : {}),
+    registers: [reg],
+  });
+}
+
+type Bundle = {
+  requestsTotal: Counter<string>;
+  requestDurationSeconds: Histogram<string>;
+  rendersTotal: Counter<string>;
+};
+
+/**
+ * Idempotent: safe to call on every request. Returns the metric instances
+ * (existing or newly created) from the default registry that /api/metrics
+ * scrapes.
+ */
+export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.register): Bundle {
+  const requestsTotal = getOrCreateCounter(
+    reg,
+    'civitai_app_block_requests_total',
+    'App Block REST requests by app, logical endpoint, and outcome (success|client_error|server_error|forbidden)',
+    ['app_block_id', 'endpoint', 'result']
+  );
+
+  const requestDurationSeconds = getOrCreateHistogram(
+    reg,
+    'civitai_app_block_request_duration_seconds',
+    'App Block REST request duration in seconds by app and logical endpoint',
+    ['app_block_id', 'endpoint']
+    // default buckets are fine for this REST surface
+  );
+
+  const rendersTotal = getOrCreateCounter(
+    reg,
+    'civitai_app_block_renders_total',
+    'App Block host render/impression outcomes by app, slot, and result (ok|error)',
+    ['app_block_id', 'slot_id', 'result']
+  );
+
+  return { requestsTotal, requestDurationSeconds, rendersTotal };
+}

--- a/src/server/middleware/__tests__/block-scope.anytoken-mode.test.ts
+++ b/src/server/middleware/__tests__/block-scope.anytoken-mode.test.ts
@@ -148,7 +148,7 @@ describe('withBlockScope — "any valid block token" mode (no requiredScope)', (
     const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
       res.status(200).json({ via: 'block' });
     });
-    const route = withBlockScope(wrapped as never, {}); // NO requiredScope
+    const route = withBlockScope(wrapped as never, { endpoint: 'models' }); // NO requiredScope
 
     const res = makeRes();
     await route(makeReq(`Bearer ${token}`) as never, res as never);
@@ -163,7 +163,7 @@ describe('withBlockScope — "any valid block token" mode (no requiredScope)', (
 
   it('still rejects an INVALID token → 401 (full validation preserved)', async () => {
     const wrapped = vi.fn();
-    const route = withBlockScope(wrapped as never, {});
+    const route = withBlockScope(wrapped as never, { endpoint: 'models' });
 
     // 3-segment JWS with a RS256/typ:JWT/kid header (passes isBlockJwt shape)
     // but a bogus signature → verifyBlockToken returns null → 401.
@@ -184,7 +184,7 @@ describe('withBlockScope — "any valid block token" mode (no requiredScope)', (
     isRevokedMock.mockResolvedValue(true);
     const token = await mintToken([]);
     const wrapped = vi.fn();
-    const route = withBlockScope(wrapped as never, {});
+    const route = withBlockScope(wrapped as never, { endpoint: 'models' });
 
     const res = makeRes();
     await route(makeReq(`Bearer ${token}`) as never, res as never);
@@ -199,7 +199,7 @@ describe('withBlockScope — "any valid block token" mode (no requiredScope)', (
     const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
       res.status(401).json({ error: 'Block token required' });
     });
-    const route = withBlockScope(wrapped as never, {});
+    const route = withBlockScope(wrapped as never, { endpoint: 'models' });
 
     const res = makeRes();
     await route(makeReq() as never, res as never);
@@ -216,7 +216,7 @@ describe('withBlockScope — opaque-origin CORS (allowOpaqueOrigin, catalog endp
     // in, so the preflight is fully handled here (the wrapped handler — which
     // would 405 a non-GET — is never reached).
     const wrapped = vi.fn();
-    const route = withBlockScope(wrapped as never, { allowOpaqueOrigin: true });
+    const route = withBlockScope(wrapped as never, { endpoint: 'models', allowOpaqueOrigin: true });
 
     const res = makeRes();
     await route(
@@ -235,7 +235,7 @@ describe('withBlockScope — opaque-origin CORS (allowOpaqueOrigin, catalog endp
     const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
       res.status(200).json({ via: 'block' });
     });
-    const route = withBlockScope(wrapped as never, { allowOpaqueOrigin: true });
+    const route = withBlockScope(wrapped as never, { endpoint: 'models', allowOpaqueOrigin: true });
 
     const res = makeRes();
     await route(
@@ -253,7 +253,7 @@ describe('withBlockScope — opaque-origin CORS (allowOpaqueOrigin, catalog endp
     const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
       res.status(401).json({ error: 'Block token required' });
     });
-    const route = withBlockScope(wrapped as never, { allowOpaqueOrigin: true });
+    const route = withBlockScope(wrapped as never, { endpoint: 'models', allowOpaqueOrigin: true });
 
     const res = makeRes();
     // No Authorization header → falls through to the wrapped handler's 401 guard.
@@ -268,7 +268,7 @@ describe('withBlockScope — opaque-origin CORS (allowOpaqueOrigin, catalog endp
     // A scoped route (or any route without allowOpaqueOrigin) must NEVER echo
     // ACAO:null — that would let any sandboxed page read a per-user response.
     const wrapped = vi.fn();
-    const route = withBlockScope(wrapped as never, { requiredScope: 'models:read:self' });
+    const route = withBlockScope(wrapped as never, { endpoint: 'models', requiredScope: 'models:read:self' });
 
     const res = makeRes();
     await route(
@@ -283,7 +283,7 @@ describe('withBlockScope — opaque-origin CORS (allowOpaqueOrigin, catalog endp
 
   it('the opt-in does NOT widen to arbitrary real origins — only the literal `null` is special-cased', async () => {
     const wrapped = vi.fn();
-    const route = withBlockScope(wrapped as never, { allowOpaqueOrigin: true });
+    const route = withBlockScope(wrapped as never, { endpoint: 'models', allowOpaqueOrigin: true });
 
     const res = makeRes();
     await route(

--- a/src/server/middleware/__tests__/block-scope.metrics.test.ts
+++ b/src/server/middleware/__tests__/block-scope.metrics.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+// Setup-order import: installs the ~/env/server mock with the real test RSA
+// keypair BEFORE block-token.service / the middleware evaluate env at module
+// load (same posture as block-scope.runtime-flag.test.ts).
+import '~/__tests__/setup';
+import client from 'prom-client';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * App Blocks runtime observability — per-app REST RED coverage.
+ *
+ * Drives a REAL, valid block JWT (minted via BlockTokenService, signed with the
+ * test RSA key from ~/__tests__/setup) through the REAL `withBlockScope`
+ * middleware and asserts that `civitai_app_block_requests_total` increments with
+ * the correct {app_block_id, endpoint, result} on the success / 5xx /
+ * client-error / forbidden (missing-scope) paths, and that the duration
+ * histogram records a sample. Mirrors block-scope.runtime-flag.test.ts's setup;
+ * mocks ONLY the runtime flag (ON), revocation (not revoked), and the
+ * fire-and-forget audit-log service (so the finish handler doesn't touch a DB).
+ */
+
+const { mockFlipt, isFliptMock } = vi.hoisted(() => {
+  const mockFlipt = { runtime: true };
+  return {
+    mockFlipt,
+    isFliptMock: vi.fn(async (flag: string) =>
+      flag === 'app-blocks-runtime-enabled' ? mockFlipt.runtime : false
+    ),
+  };
+});
+vi.mock('~/server/flipt/client', () => ({ isFlipt: isFliptMock }));
+vi.mock('~/server/services/block-revocation.service', () => ({
+  BlockRevocation: { isRevoked: vi.fn(async () => false) },
+}));
+// The success path registers a fire-and-forget res.on('finish') audit logger
+// that dynamic-imports this service; stub it so invoking the finish listeners
+// doesn't reach a real DB.
+vi.mock('~/server/services/blocks/user-app-surface.service', () => ({
+  recordScopeInvocation: vi.fn(async () => undefined),
+}));
+
+import { withBlockScope } from '../block-scope.middleware';
+import { BlockTokenService } from '~/server/services/block-token.service';
+import type { AppBlockEndpoint } from '~/server/metrics/app-block-runtime.metrics';
+
+const MODEL_ID = 12345;
+const APP_BLOCK_ID = 'apb_metrics_test';
+const REQUIRED_SCOPE = 'models:read:self';
+
+async function mintToken(scopes: string[] = [REQUIRED_SCOPE]): Promise<string> {
+  const r = await BlockTokenService.sign({
+    userId: 42,
+    blockId: 'blk_test',
+    appId: 'app_test',
+    appBlockId: APP_BLOCK_ID,
+    blockInstanceId: 'bki_test',
+    scopes,
+    ctx: { modelId: MODEL_ID },
+  });
+  return r.token;
+}
+
+// A fake res that captures finish/close listeners so the test can drive the
+// response-finished transition the metric fires on.
+function makeRes() {
+  const finishListeners: Array<() => void> = [];
+  const res = {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+    send() {
+      return this;
+    },
+    end() {
+      return this;
+    },
+    setHeader() {
+      return this;
+    },
+    removeHeader() {
+      return this;
+    },
+    writeHead() {
+      return this;
+    },
+    getHeader() {
+      return undefined;
+    },
+    on(event: string, cb: () => void) {
+      if (event === 'finish' || event === 'close') finishListeners.push(cb);
+      return this;
+    },
+    _finish() {
+      for (const cb of finishListeners) cb();
+    },
+  };
+  return res as unknown as NextApiResponse & { statusCode: number; body: unknown; _finish(): void };
+}
+
+function makeReq(token: string): NextApiRequest {
+  return {
+    method: 'GET',
+    headers: { authorization: `Bearer ${token}` },
+    query: { id: String(MODEL_ID) },
+    socket: { remoteAddress: '127.0.0.1' },
+  } as unknown as NextApiRequest;
+}
+
+async function counterValue(endpoint: AppBlockEndpoint, result: string): Promise<number> {
+  const metric = client.register.getSingleMetric('civitai_app_block_requests_total');
+  if (!metric) return 0;
+  const data = await (metric as { get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }> }).get();
+  const match = data.values.find(
+    (v) => v.labels.app_block_id === APP_BLOCK_ID && v.labels.endpoint === endpoint && v.labels.result === result
+  );
+  return match?.value ?? 0;
+}
+
+async function histogramCount(endpoint: AppBlockEndpoint): Promise<number> {
+  const metric = client.register.getSingleMetric('civitai_app_block_request_duration_seconds');
+  if (!metric) return 0;
+  const data = await (metric as { get(): Promise<{ values: Array<{ metricName?: string; labels: Record<string, string>; value: number }> }> }).get();
+  const match = data.values.find(
+    (v) => v.metricName?.endsWith('_count') && v.labels.app_block_id === APP_BLOCK_ID && v.labels.endpoint === endpoint
+  );
+  return match?.value ?? 0;
+}
+
+/** Wrapped handler that just sets a status and returns. */
+function statusHandler(code: number) {
+  return vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
+    res.status(code).json({ ok: code < 400 });
+  });
+}
+
+beforeEach(() => {
+  mockFlipt.runtime = true;
+  isFliptMock.mockClear();
+});
+
+describe('withBlockScope — per-app REST RED metric', () => {
+  it('increments result=success + records a duration sample on a 2xx', async () => {
+    const before = await counterValue('model_detail', 'success');
+    const beforeHist = await histogramCount('model_detail');
+    const route = withBlockScope(statusHandler(200) as never, {
+      endpoint: 'model_detail',
+      requiredScope: REQUIRED_SCOPE,
+    });
+    const res = makeRes();
+    await route(makeReq(await mintToken()) as never, res as never);
+    res._finish();
+
+    expect(await counterValue('model_detail', 'success')).toBe(before + 1);
+    expect(await histogramCount('model_detail')).toBe(beforeHist + 1);
+  });
+
+  it('increments result=server_error on a 5xx', async () => {
+    const before = await counterValue('model_detail', 'server_error');
+    const route = withBlockScope(statusHandler(500) as never, {
+      endpoint: 'model_detail',
+      requiredScope: REQUIRED_SCOPE,
+    });
+    const res = makeRes();
+    await route(makeReq(await mintToken()) as never, res as never);
+    res._finish();
+
+    expect(await counterValue('model_detail', 'server_error')).toBe(before + 1);
+  });
+
+  it('increments result=client_error on a 4xx (non-403)', async () => {
+    const before = await counterValue('model_detail', 'client_error');
+    const route = withBlockScope(statusHandler(404) as never, {
+      endpoint: 'model_detail',
+      requiredScope: REQUIRED_SCOPE,
+    });
+    const res = makeRes();
+    await route(makeReq(await mintToken()) as never, res as never);
+    res._finish();
+
+    expect(await counterValue('model_detail', 'client_error')).toBe(before + 1);
+  });
+
+  it('increments result=forbidden when the middleware itself rejects a missing scope (403)', async () => {
+    const before = await counterValue('model_detail', 'forbidden');
+    // The wrapped handler would 200, but the token lacks the required scope so
+    // the middleware 403s BEFORE calling it — the metric must still attribute it.
+    const wrapped = statusHandler(200);
+    const route = withBlockScope(wrapped as never, {
+      endpoint: 'model_detail',
+      requiredScope: 'buzz:read:self', // token only carries models:read:self
+    });
+    const res = makeRes();
+    // token carries only models:read:self
+    await route(makeReq(await mintToken(['models:read:self'])) as never, res as never);
+    res._finish();
+
+    expect(res.statusCode).toBe(403);
+    expect(wrapped).not.toHaveBeenCalled();
+    expect(await counterValue('model_detail', 'forbidden')).toBe(before + 1);
+  });
+});

--- a/src/server/middleware/__tests__/block-scope.middleware.test.ts
+++ b/src/server/middleware/__tests__/block-scope.middleware.test.ts
@@ -141,7 +141,7 @@ describe('isBlockJwt header decode (audit H-1.5 / strict)', () => {
       res._status = 200;
       res.status(200);
     });
-    const route = withBlockScope(wrappedHandler as never, { requiredScope: 'models:read:self' });
+    const route = withBlockScope(wrappedHandler as never, { endpoint: 'models', requiredScope: 'models:read:self' });
     const fakeReqWithApiKey = {
       method: 'GET',
       headers: { authorization: 'Bearer foo.bar.notarealjwt' },

--- a/src/server/middleware/__tests__/block-scope.runtime-flag.test.ts
+++ b/src/server/middleware/__tests__/block-scope.runtime-flag.test.ts
@@ -144,7 +144,7 @@ describe('withBlockScope — Decision 4 runtime gate (real JWT round-trip)', () 
       res.status(200).json({ via: 'legacy' });
     });
 
-    const route = withBlockScope(wrapped as never, { requiredScope: REQUIRED_SCOPE });
+    const route = withBlockScope(wrapped as never, { endpoint: 'models', requiredScope: REQUIRED_SCOPE });
     const res = makeRes();
     await route(makeReq(token) as never, res as never);
 
@@ -169,7 +169,7 @@ describe('withBlockScope — Decision 4 runtime gate (real JWT round-trip)', () 
       res.status(200).json({ via: 'legacy' });
     });
 
-    const route = withBlockScope(wrapped as never, { requiredScope: REQUIRED_SCOPE });
+    const route = withBlockScope(wrapped as never, { endpoint: 'models', requiredScope: REQUIRED_SCOPE });
     const res = makeRes();
     await route(makeReq(token) as never, res as never);
 
@@ -187,7 +187,7 @@ describe('withBlockScope — Decision 4 runtime gate (real JWT round-trip)', () 
       res.status(200).json({ via: 'block' });
     });
 
-    const route = withBlockScope(wrapped as never, { requiredScope: REQUIRED_SCOPE });
+    const route = withBlockScope(wrapped as never, { endpoint: 'models', requiredScope: REQUIRED_SCOPE });
     const res = makeRes();
     await route(makeReq(token) as never, res as never);
 

--- a/src/server/middleware/__tests__/collections-tip-authz.test.ts
+++ b/src/server/middleware/__tests__/collections-tip-authz.test.ts
@@ -121,7 +121,7 @@ describe.each(SCOPES)('withBlockScope authz — %s', (scope) => {
     const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
       res.status(200).json({ ok: true });
     });
-    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const route = withBlockScope(wrapped as never, { endpoint: 'collections', requiredScope: scope });
 
     const res = makeRes();
     await route(makeReq(`Bearer ${token}`) as never, res as never);
@@ -133,7 +133,7 @@ describe.each(SCOPES)('withBlockScope authz — %s', (scope) => {
   it('rejects a valid token MISSING the scope → 403', async () => {
     const token = await mintToken({ userId: 42, scopes: [] });
     const wrapped = vi.fn();
-    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const route = withBlockScope(wrapped as never, { endpoint: 'collections', requiredScope: scope });
 
     const res = makeRes();
     await route(makeReq(`Bearer ${token}`) as never, res as never);
@@ -145,7 +145,7 @@ describe.each(SCOPES)('withBlockScope authz — %s', (scope) => {
   it('rejects an ANON token carrying the scope → 403 (self-scope requires a real subject)', async () => {
     const token = await mintToken({ userId: null, scopes: [scope] });
     const wrapped = vi.fn();
-    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const route = withBlockScope(wrapped as never, { endpoint: 'collections', requiredScope: scope });
 
     const res = makeRes();
     await route(makeReq(`Bearer ${token}`) as never, res as never);
@@ -158,7 +158,7 @@ describe.each(SCOPES)('withBlockScope authz — %s', (scope) => {
     isRevokedMock.mockResolvedValue(true);
     const token = await mintToken({ userId: 42, scopes: [scope] });
     const wrapped = vi.fn();
-    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const route = withBlockScope(wrapped as never, { endpoint: 'collections', requiredScope: scope });
 
     const res = makeRes();
     await route(makeReq(`Bearer ${token}`) as never, res as never);
@@ -174,7 +174,7 @@ describe.each(SCOPES)('withBlockScope authz — %s', (scope) => {
     const payload = Buffer.from(JSON.stringify({ sub: 'user:1' })).toString('base64url');
     const bogus = `${header}.${payload}.bad`;
     const wrapped = vi.fn();
-    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const route = withBlockScope(wrapped as never, { endpoint: 'collections', requiredScope: scope });
 
     const res = makeRes();
     await route(makeReq(`Bearer ${bogus}`) as never, res as never);
@@ -195,7 +195,7 @@ describe('withBlockScope authz — apps:storage:shared:read (anon-allowed read)'
     const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
       res.status(200).json({ ok: true });
     });
-    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const route = withBlockScope(wrapped as never, { endpoint: 'collections', requiredScope: scope });
     const res = makeRes();
     await route(makeReq(`Bearer ${token}`, 'GET') as never, res as never);
     expect(res.statusCode).toBe(200);
@@ -206,7 +206,7 @@ describe('withBlockScope authz — apps:storage:shared:read (anon-allowed read)'
     const wrapped = vi.fn(async (_req: NextApiRequest, res: NextApiResponse) => {
       res.status(200).json({ ok: true });
     });
-    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const route = withBlockScope(wrapped as never, { endpoint: 'collections', requiredScope: scope });
     const res = makeRes();
     await route(makeReq(`Bearer ${token}`, 'GET') as never, res as never);
     expect(res.statusCode).toBe(200);
@@ -215,7 +215,7 @@ describe('withBlockScope authz — apps:storage:shared:read (anon-allowed read)'
   it('rejects a token MISSING the scope → 403', async () => {
     const token = await mintToken({ userId: 42, scopes: [] });
     const wrapped = vi.fn();
-    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const route = withBlockScope(wrapped as never, { endpoint: 'collections', requiredScope: scope });
     const res = makeRes();
     await route(makeReq(`Bearer ${token}`, 'GET') as never, res as never);
     expect(res.statusCode).toBe(403);
@@ -226,7 +226,7 @@ describe('withBlockScope authz — apps:storage:shared:read (anon-allowed read)'
     isRevokedMock.mockResolvedValue(true);
     const token = await mintToken({ userId: 42, scopes: [scope] });
     const wrapped = vi.fn();
-    const route = withBlockScope(wrapped as never, { requiredScope: scope });
+    const route = withBlockScope(wrapped as never, { endpoint: 'collections', requiredScope: scope });
     const res = makeRes();
     await route(makeReq(`Bearer ${token}`, 'GET') as never, res as never);
     expect(res.statusCode).toBe(403);

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -1,6 +1,11 @@
 import { decodeProtectedHeader, jwtVerify } from 'jose';
 import type { NextApiHandler, NextApiRequest, NextApiResponse } from 'next';
 import { env } from '~/env/server';
+import {
+  ensureRegisterAppBlockRuntimeMetrics,
+  statusToRequestResult,
+  type AppBlockEndpoint,
+} from '~/server/metrics/app-block-runtime.metrics';
 import { isAppBlocksRuntimeEnabled } from '~/server/services/app-blocks-flag';
 import { BlockRevocation } from '~/server/services/block-revocation.service';
 import {
@@ -73,6 +78,16 @@ export type BlockScopedNextApiRequest = NextApiRequest & {
 };
 
 export interface WithBlockScopeOpts {
+  /**
+   * Low-cardinality LOGICAL name for this endpoint (e.g. 'tip', 'buzz',
+   * 'collections', 'shared_storage_top'). Used as the `endpoint` label on the
+   * per-app REST-RED metrics (`civitai_app_block_requests_total` /
+   * `civitai_app_block_request_duration_seconds`). Derived from the HANDLER, so
+   * ids in the path can never leak into the label. Strictly enumerated — see
+   * AppBlockEndpoint in ~/server/metrics/app-block-runtime.metrics.
+   */
+  endpoint: AppBlockEndpoint;
+
   /**
    * The block scope this endpoint requires. When PRESENT, the middleware
    * enforces `claims.scopes.includes(requiredScope)` (403 on miss) AND runs
@@ -719,6 +734,34 @@ export function withBlockScope(
       res.status(401).json({ error: 'invalid block token' });
       return;
     }
+
+    // Runtime observability (additive + dark — no behavior change): per-app REST
+    // RED. Recorded on response finish so it captures the wrapped handler's real
+    // status + latency AND the middleware's OWN 403 rejections below (revocation
+    // / missing-scope / context-binding). The invalid-token 401 above is
+    // intentionally NOT attributed — there are no claims, so no `app_block_id` to
+    // key on. `app_block_id` comes from the VERIFIED JWT (bounded to approved
+    // apps); `endpoint`/`result` are strictly enumerated. Fire-and-forget: a
+    // metrics failure must never poison the user-facing response.
+    const metricStart = process.hrtime.bigint();
+    let metricRecorded = false;
+    const recordBlockMetric = () => {
+      if (metricRecorded) return;
+      metricRecorded = true;
+      try {
+        const { requestsTotal, requestDurationSeconds } = ensureRegisterAppBlockRuntimeMetrics();
+        const labels = { app_block_id: claims.appBlockId, endpoint: opts.endpoint };
+        const elapsedSeconds = Number(process.hrtime.bigint() - metricStart) / 1e9;
+        requestDurationSeconds.observe(labels, elapsedSeconds);
+        requestsTotal.inc({ ...labels, result: statusToRequestResult(res.statusCode) });
+      } catch {
+        // never let observability break the request
+      }
+    };
+    // 'close' covers a client-aborted connection that never emits 'finish'; the
+    // recorded-once guard makes the pair idempotent.
+    res.on('finish', recordBlockMetric);
+    res.on('close', recordBlockMetric);
 
     // H-2: per-instance revocation check. Uninstall, toggleEnabled(false),
     // and (Phase 2) publisher-ban all write a marker that lives for one

--- a/src/server/routers/track.router.ts
+++ b/src/server/routers/track.router.ts
@@ -26,7 +26,13 @@ export const trackRouter = router({
   // for any bearer/API-key (non-cookie) caller, consistent with `addView`.
   blockRender: publicProcedure
     .input(blockRenderSchema)
-    .mutation(({ input, ctx }) => ctx.track.blockRender({ ...input, isAnon: !ctx.user })),
+    // `status`/`errorClass` are consumed only by the /api/track/block-render
+    // beacon (prom render counter); this legacy tRPC path keeps the CH insert
+    // byte-identical by stripping them before dispatch.
+    .mutation(({ input, ctx }) => {
+      const { status: _status, errorClass: _errorClass, ...renderData } = input;
+      return ctx.track.blockRender({ ...renderData, isAnon: !ctx.user });
+    }),
   trackShare: publicProcedure
     .meta({ requiredScope: TokenScope.UserWrite })
     .input(trackShareSchema)

--- a/src/server/schema/__tests__/track.blockRender.schema.test.ts
+++ b/src/server/schema/__tests__/track.blockRender.schema.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { blockRenderSchema } from '~/server/schema/track.schema';
+
+/**
+ * App Blocks runtime observability — blockRenderSchema `status`/`errorClass`
+ * additions. `status` drives the `civitai_app_block_renders_total{result}`
+ * counter; it MUST default to 'ok' so legacy/status-less beacons keep working.
+ */
+describe('blockRenderSchema — status/errorClass', () => {
+  const base = { appBlockId: 'apb_x', blockInstanceId: 'page_apb_x', slotId: 'app.page' };
+
+  it('defaults status to "ok" when omitted', () => {
+    const parsed = blockRenderSchema.parse(base);
+    expect(parsed.status).toBe('ok');
+    expect(parsed.errorClass).toBeUndefined();
+  });
+
+  it('accepts status:"error" and a bounded errorClass', () => {
+    const parsed = blockRenderSchema.parse({ ...base, status: 'error', errorClass: 'timeout' });
+    expect(parsed.status).toBe('error');
+    expect(parsed.errorClass).toBe('timeout');
+  });
+
+  it('rejects a status outside the ok|error enum', () => {
+    expect(blockRenderSchema.safeParse({ ...base, status: 'weird' }).success).toBe(false);
+  });
+
+  it('rejects an over-long errorClass (bounded to 64 chars)', () => {
+    expect(
+      blockRenderSchema.safeParse({ ...base, errorClass: 'x'.repeat(65) }).success
+    ).toBe(false);
+  });
+});

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -62,6 +62,17 @@ export const blockRenderSchema = z.object({
   // Where the block rendered: 'app.page' for the full-page runner, or a slot
   // id like 'model.sidebar_top' for the in-page slot host.
   slotId: z.string().trim().min(1).max(128),
+  // Render outcome. Defaults to 'ok' (legacy beacons + the BLOCK_READY success
+  // path omit it). 'error' is fired by the host on a genuine render failure
+  // (error-boundary trip, or the iframe never reaching BLOCK_READY within its
+  // timeout). Drives the `civitai_app_block_renders_total{result}` prom counter.
+  status: z.enum(['ok', 'error']).default('ok'),
+  // Optional low-cardinality failure discriminator (e.g. 'timeout', 'fatal',
+  // 'no_token', 'error_boundary'). Bounded but NOT put on a prom label (kept for
+  // a future ClickHouse column). Reserved: the beacon route validates it but
+  // does NOT forward it to the ClickHouse insert today (prom-only), so it never
+  // reaches the tracker payload.
+  errorClass: z.string().trim().min(1).max(64).optional(),
 });
 
 export type TrackShareInput = z.infer<typeof trackShareSchema>;

--- a/src/server/services/blocks/__tests__/known-app-blocks.service.test.ts
+++ b/src/server/services/blocks/__tests__/known-app-blocks.service.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * Known-approved AppBlock id cache — bounds the render-beacon's `app_block_id`
+ * prom label. Asserts: approved id → itself; unknown id → 'other'; the query is
+ * filtered to status:'approved'; the result is TTL-cached (a second call in the
+ * window does NOT re-query); and a DB error fails SAFE (everything → 'other').
+ */
+
+const { mockFindMany } = vi.hoisted(() => ({ mockFindMany: vi.fn() }));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlock: { findMany: mockFindMany } },
+}));
+
+import {
+  boundAppBlockIdLabel,
+  isKnownAppBlockId,
+  _internalsForTests,
+} from '../known-app-blocks.service';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _internalsForTests.reset();
+  mockFindMany.mockResolvedValue([{ id: 'apb_known_1' }, { id: 'apb_known_2' }]);
+});
+
+describe('known-app-blocks.service', () => {
+  it('preserves an approved app id and buckets an unknown one to "other"', async () => {
+    expect(await boundAppBlockIdLabel('apb_known_1')).toBe('apb_known_1');
+    expect(await boundAppBlockIdLabel('apb_attacker_garbage')).toBe('other');
+    expect(await isKnownAppBlockId('apb_known_2')).toBe(true);
+    expect(await isKnownAppBlockId('apb_nope')).toBe(false);
+  });
+
+  it('queries only status:"approved"', async () => {
+    await isKnownAppBlockId('apb_known_1');
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { status: 'approved' },
+      select: { id: true },
+    });
+  });
+
+  it('TTL-caches — a second lookup in the window does not re-query the DB', async () => {
+    await isKnownAppBlockId('apb_known_1');
+    await isKnownAppBlockId('apb_known_2');
+    await boundAppBlockIdLabel('apb_known_1');
+    expect(mockFindMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails SAFE on a DB error — unknown set, everything buckets to "other"', async () => {
+    mockFindMany.mockRejectedValueOnce(new Error('engine down'));
+    expect(await boundAppBlockIdLabel('apb_known_1')).toBe('other');
+  });
+});

--- a/src/server/services/blocks/known-app-blocks.service.ts
+++ b/src/server/services/blocks/known-app-blocks.service.ts
@@ -1,0 +1,90 @@
+// Known-approved AppBlock id set — a cheap, in-memory, TTL-cached lookup used to
+// BOUND the `app_block_id` prom label on the PUBLIC, unauthenticated
+// /api/track/block-render beacon (see src/pages/api/track/block-render.ts).
+//
+// WHY: that beacon takes `appBlockId` straight from a same-origin CLIENT body
+// (validated only for length). It has NO runtime-flag gate and NO rate limit, so
+// a scripted client could post unlimited DISTINCT ids — and prom-client retains
+// every distinct label set in the Node heap forever → unbounded heap growth (the
+// known --max-old-space-size exit-139 OOM class). Clamping unknown ids to 'other'
+// bounds the label to the real approved-app set (dozens today) while preserving
+// per-app render-failure attribution for approved apps.
+//
+// Mirrors the single-flight + TTL cache posture of `loadAllowedOrigins` in
+// block-scope.middleware.ts: at most one DB query per TTL window per pod, never a
+// per-request hit. Fails SAFE — on a cold cache or DB error the set is treated as
+// empty, so every id buckets to 'other' (bounded) rather than passing through.
+const KNOWN_APP_BLOCKS_TTL_MS = 5 * 60_000; // 5min — approved set changes rarely
+
+type CacheEntry = { ids: Set<string>; expiresAt: number };
+let _cache: CacheEntry | null = null;
+let _inflight: Promise<Set<string>> | null = null;
+
+async function loadKnownAppBlockIds(): Promise<Set<string>> {
+  const ids = new Set<string>();
+  try {
+    // Dynamic import so this module doesn't eager-load the Prisma client into
+    // the lightweight beacon route's import graph (mirrors the middleware's
+    // dynamic dbRead import).
+    const { dbRead } = await import('~/server/db/client');
+    const rows = (await dbRead.appBlock.findMany({
+      where: { status: 'approved' },
+      select: { id: true },
+    })) as Array<{ id: string }>;
+    for (const row of rows) ids.add(row.id);
+  } catch (err) {
+    // DB unreachable → return whatever we have (empty). Everything then buckets
+    // to 'other' — bounded and safe. Log once per refresh so ops can see it.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[known-app-blocks] approved AppBlock lookup failed; treating known set as empty: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+  return ids;
+}
+
+async function getKnownAppBlockIds(): Promise<Set<string>> {
+  const now = Date.now();
+  const cached = _cache;
+  if (cached && cached.expiresAt > now) return cached.ids;
+  // Single-flight: coalesce concurrent cold-start refreshes into one query.
+  if (_inflight) return _inflight;
+  _inflight = loadKnownAppBlockIds()
+    .then((ids) => {
+      _cache = { ids, expiresAt: Date.now() + KNOWN_APP_BLOCKS_TTL_MS };
+      return ids;
+    })
+    .finally(() => {
+      _inflight = null;
+    });
+  return _inflight;
+}
+
+/**
+ * True iff `appBlockId` is a currently-approved AppBlock (from the TTL-cached
+ * set). Used to clamp the render-beacon's `app_block_id` prom label. Fails safe
+ * to false (→ 'other') on a cold cache / DB error.
+ */
+export async function isKnownAppBlockId(appBlockId: string): Promise<boolean> {
+  const ids = await getKnownAppBlockIds();
+  return ids.has(appBlockId);
+}
+
+/**
+ * Clamp a client-supplied appBlockId to a bounded prom label: the id itself when
+ * it's an approved app, else 'other'. Keeps the `app_block_id` cardinality
+ * bounded to the real approved set regardless of client input.
+ */
+export async function boundAppBlockIdLabel(appBlockId: string): Promise<string> {
+  return (await isKnownAppBlockId(appBlockId)) ? appBlockId : 'other';
+}
+
+/** Test-only: clear the in-memory cache so a unit test can swap the DB mock. */
+export const _internalsForTests = {
+  reset(): void {
+    _cache = null;
+    _inflight = null;
+  },
+};

--- a/src/tests/api/track/block-render.test.ts
+++ b/src/tests/api/track/block-render.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
+import client from 'prom-client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 
 /**
@@ -240,5 +241,76 @@ describe('POST /api/track/block-render', () => {
     expect(mockBlockRender).not.toHaveBeenCalled();
     expect(mockGetSession).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+
+// --- App Blocks runtime observability: the render-outcome prom counter --------
+async function renderCounterValue(
+  appBlockId: string,
+  slotId: string,
+  result: string
+): Promise<number> {
+  const metric = client.register.getSingleMetric('civitai_app_block_renders_total');
+  if (!metric) return 0;
+  const data = await (
+    metric as { get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }> }
+  ).get();
+  const match = data.values.find(
+    (v) => v.labels.app_block_id === appBlockId && v.labels.slot_id === slotId && v.labels.result === result
+  );
+  return match?.value ?? 0;
+}
+
+describe('POST /api/track/block-render — civitai_app_block_renders_total counter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    devStore.isDev = false;
+    sessionStore.session = null;
+  });
+
+  it('increments result=ok (schema default) on a status-less beacon AND keeps status/errorClass out of the CH insert', async () => {
+    const before = await renderCounterValue('apb_test', 'app.page', 'ok');
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const req = makeReq({ origin: 'https://civitai.com', body: validInput });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(await renderCounterValue('apb_test', 'app.page', 'ok')).toBe(before + 1);
+    // status/errorClass never reach the ClickHouse insert (prom-only).
+    const arg = mockBlockRender.mock.calls[0][0];
+    expect(arg).not.toHaveProperty('status');
+    expect(arg).not.toHaveProperty('errorClass');
+    expect(arg).toEqual({ ...validInput, isAnon: true });
+  });
+
+  it('increments result=error when the beacon carries status:"error"', async () => {
+    const before = await renderCounterValue('apb_test', 'app.page', 'error');
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const req = makeReq({
+      origin: 'https://civitai.com',
+      body: { ...validInput, status: 'error', errorClass: 'timeout' },
+    });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(await renderCounterValue('apb_test', 'app.page', 'error')).toBe(before + 1);
+    // The error still writes the (identifier-only) CH row — status/errorClass stripped.
+    expect(mockBlockRender).toHaveBeenCalledWith({ ...validInput, isAnon: true });
+  });
+
+  it('clamps an unknown slot_id to "other" to bound label cardinality', async () => {
+    const before = await renderCounterValue('apb_test', 'other', 'ok');
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const req = makeReq({
+      origin: 'https://civitai.com',
+      body: { ...validInput, slotId: 'totally.unknown.slot' },
+    });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(await renderCounterValue('apb_test', 'other', 'ok')).toBe(before + 1);
   });
 });

--- a/src/tests/api/track/block-render.test.ts
+++ b/src/tests/api/track/block-render.test.ts
@@ -57,6 +57,13 @@ vi.mock('~/server/clickhouse/client', () => ({
   },
 }));
 
+// Known-app clamp: control which appBlockIds count as "approved" so the render
+// counter's `app_block_id` label bound is deterministic (real approved lookup is
+// a TTL-cached DB query — mocked here). 'apb_test' is known; everything else → 'other'.
+vi.mock('~/server/services/blocks/known-app-blocks.service', () => ({
+  boundAppBlockIdLabel: vi.fn(async (id: string) => (id === 'apb_test' ? id : 'other')),
+}));
+
 function makeRes() {
   const res = {} as NextApiResponse & { _status?: number; _body?: unknown };
   res.status = vi.fn((code: number) => {
@@ -298,6 +305,27 @@ describe('POST /api/track/block-render — civitai_app_block_renders_total count
     expect(await renderCounterValue('apb_test', 'app.page', 'error')).toBe(before + 1);
     // The error still writes the (identifier-only) CH row — status/errorClass stripped.
     expect(mockBlockRender).toHaveBeenCalledWith({ ...validInput, isAnon: true });
+  });
+
+  it('clamps an UNKNOWN app_block_id to "other" (bounds the label) and preserves a known one', async () => {
+    const beforeOther = await renderCounterValue('other', 'app.page', 'ok');
+    const beforeKnown = await renderCounterValue('apb_test', 'app.page', 'ok');
+    const handler = (await import('~/pages/api/track/block-render')).default;
+
+    // Unknown/unapproved app id from a scripted client → bucketed to 'other'.
+    const unknownReq = makeReq({
+      origin: 'https://civitai.com',
+      body: { ...validInput, appBlockId: 'apb_attacker_garbage_9f3' },
+    });
+    await handler(unknownReq as any, makeRes());
+    expect(await renderCounterValue('other', 'app.page', 'ok')).toBe(beforeOther + 1);
+
+    // A known/approved app id is preserved (per-app attribution intact). The CH
+    // insert still records the RAW client id — only the prom LABEL is clamped.
+    const knownReq = makeReq({ origin: 'https://civitai.com', body: validInput });
+    await handler(knownReq as any, makeRes());
+    expect(await renderCounterValue('apb_test', 'app.page', 'ok')).toBe(beforeKnown + 1);
+    expect(mockBlockRender).toHaveBeenLastCalledWith({ ...validInput, isAnon: true });
   });
 
   it('clamps an unknown slot_id to "other" to bound label cardinality', async () => {


### PR DESCRIPTION
App Blocks (third-party mini-apps rendered as <slug>.civit.ai iframes on
model pages + /apps/run pages) had NO runtime health telemetry — render
failures and per-app API errors were invisible until a human reported them.
Close that with pure prom-client metrics exposed on the existing /api/metrics
scrape endpoint (no new infra, no ClickHouse migration).

New metrics (default global registry, get-or-create guarded against Next's
double-import):
  - civitai_app_block_requests_total{app_block_id, endpoint, result}
  - civitai_app_block_request_duration_seconds{app_block_id, endpoint}
  - civitai_app_block_renders_total{app_block_id, slot_id, result}

REST RED is emitted from block-scope.middleware on response finish (captures
the handler's real status + latency AND the middleware's own 403 rejections);
`endpoint` is a low-cardinality logical name declared per route, never derived
from req.url. Render outcomes are emitted from the /api/track/block-render
beacon: ok at BLOCK_READY, error on a genuine host render failure (error-
boundary trip, or the iframe never reaching BLOCK_READY within its timeout —
timeout/fatal/no_token/mint-error). ok/error are mutually exclusive per mount.

A `status`/`errorClass` field is threaded through blockRenderSchema →
sendBlockRender → the beacon; it drives the prom render counter ONLY and is
kept OUT of the ClickHouse insert (the blockRenders table is provisioned out-
of-repo). slot_id is clamped to the enumerated slot set; app_block_id is
bounded to approved apps today (cardinality note + GA allowlist TODO in code).

Tests: middleware counter (success/4xx/5xx/forbidden) + duration sample;
beacon render counter (ok default / error / unknown-slot clamp) + status kept
out of the CH insert; schema default/enum/bounds. All green; tsc --noEmit
clean on all touched files.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
