### PR TITLE
fix(images): send browsingLevel from context so .red queries don't return zero

### DIFF
--- a/src/components/Image/image.utils.ts
+++ b/src/components/Image/image.utils.ts
@@ -4,6 +4,7 @@ import { hideNotification, showNotification } from '@mantine/notifications';
 import { isEqual } from 'lodash-es';
 import { useMemo, useState } from 'react';
 import * as z from 'zod';
+import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useZodRouteParams } from '~/hooks/useZodRouteParams';
@@ -128,6 +129,12 @@ export const useQueryImages = (
   const { applyHiddenPreferences = true, ...queryOptions } = options ?? {};
   filters ??= {};
   const browsingSettingsAddons = useBrowsingSettingsAddons();
+  // Only the domains that cap browsing (green) get `browsingLevel` backfilled by
+  // `applyDomainFeature`; on red/blue an absent level reaches the query as NULL and
+  // `(nsfwLevel & NULL)` drops every row. Default from context so a caller that omits
+  // it can't silently return zero images — inside a forced provider (minor models)
+  // this is the forced level, which is what those queries should be asking for.
+  const contextBrowsingLevel = useBrowsingLevelDebounced();
 
   // `!!currentUser` guards against `filters.userId === currentUser?.id` being
   // `undefined === undefined` for anonymous users, which treats them as the owner.
@@ -144,6 +151,7 @@ export const useQueryImages = (
   const { data, isLoading, ...rest } = trpc.image.getInfinite.useInfiniteQuery(
     {
       ...filters,
+      browsingLevel: filters.browsingLevel ?? contextBrowsingLevel,
       excludedTagIds,
       // OR-merge with the addon so either source can flag the filter.
       // Mods always have addon = false (BrowsingSettingsAddonsProvider), so

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -120,7 +120,11 @@ import { getDefaultModelVersion } from '~/server/services/model-version.service'
 import { getServerBrowsingLevel } from '~/server/utils/browsing-level';
 import { resolveBrowsingSettingsAddons } from '~/shared/constants/browsing-settings-addons';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
-import { getIsSafeBrowsingLevel } from '~/shared/constants/browsingLevel.constants';
+import {
+  getIsSafeBrowsingLevel,
+  publicBrowsingLevelsFlag,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
 import { ModelModifier } from '~/shared/utils/prisma/enums';
 import { Availability, CollectionType, ModelStatus, ModelType } from '~/shared/utils/prisma/enums';
 import type { ModelById } from '~/types/router';
@@ -311,22 +315,30 @@ export const getServerSideProps = createServerSideProps({
                 })
                 .catch(() => null)
             : null,
-          // Carousel CLS fix: SSR-prefetch the images query the ModelCarousel
-          // (and the page's own useQueryImages) run client-side, so it hydrates
-          // with isLoading already false — the carousel reserves the right height
-          // from real image dimensions instead of a fixed 600px placeholder that
-          // rarely matches (layout shift). The input MUST match useQueryImages
-          // exactly: the addon-derived excludedTagIds/disablePoi/disableMinor are
-          // resolved from the LIVE addon list at the request's browsing level (not
-          // the DEFAULT constant), or the React Query key won't line up and the
-          // client refetches. Fail-soft on any miss.
+          // Carousel CLS fix: SSR-prefetch the images query the ModelCarousel runs
+          // client-side, so it hydrates with isLoading already false — the carousel
+          // reserves the right height from real image dimensions instead of a fixed
+          // 600px placeholder that rarely matches (layout shift). The input MUST
+          // match useQueryImages exactly — browsingLevel and the addon-derived
+          // excludedTagIds/disablePoi/disableMinor all key the query — or the React
+          // Query key won't line up and the client refetches. Fail-soft on any miss.
           model && modelVersionIdParsed
             ? (async () => {
                 const { getBrowsingSettingAddons } = await import('~/server/services/system-cache');
-                const browsingLevel = getServerBrowsingLevel({
-                  canViewNsfw: features?.canViewNsfw ?? false,
-                  user: session?.user,
-                });
+                // Mirror ModelCarousel: a minor model forces its carousel to SFW for
+                // non-moderators, so SSR must resolve at that same forced level. Using
+                // the viewer's own level here would key on a different disableMinor
+                // (and browsingLevel) than the client, orphaning the prefetch on
+                // exactly the models this matters for.
+                const forceMinorLevel = !!model.minor && !session?.user?.isModerator;
+                const browsingLevel = forceMinorLevel
+                  ? session?.user
+                    ? sfwBrowsingLevelsFlag
+                    : publicBrowsingLevelsFlag
+                  : getServerBrowsingLevel({
+                      canViewNsfw: features?.canViewNsfw ?? false,
+                      user: session?.user,
+                    });
                 const addons = await getBrowsingSettingAddons().catch(() => null);
                 if (!addons) return null;
                 const addonSettings = resolveBrowsingSettingsAddons(addons, browsingLevel, {
@@ -342,6 +354,7 @@ export const getServerSideProps = createServerSideProps({
                     pending: true,
                     include: [],
                     withMeta: false,
+                    browsingLevel,
                     excludedTagIds: addonSettings.excludedTagIds,
                     disablePoi: addonSettings.disablePoi,
                     disableMinor: addonSettings.disableMinor,

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -189,6 +189,7 @@ import {
   nsfwBrowsingLevelsArray,
   nsfwBrowsingLevelsFlag,
   onlySelectableLevels,
+  publicBrowsingLevelsFlag,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 import { Flags } from '~/shared/utils/flags';
@@ -1334,6 +1335,13 @@ export const getAllImages = async (
 
   // Exclude unselectable browsing levels
   browsingLevel = onlySelectableLevels(browsingLevel);
+
+  // `applyDomainFeature` only backfills an absent `browsingLevel` on capped
+  // (green) domains, so on red/blue it can arrive undefined and reach the SQL as
+  // NULL — `(nsfwLevel & NULL)` is NULL, silently dropping every row. Fail closed
+  // to public rather than to nothing; widening here would serve levels the caller
+  // never asked for.
+  if (!browsingLevel) browsingLevel = publicBrowsingLevelsFlag;
 
   // Parse random cursor seed upfront (needed to determine if we need to fetch seed)
   let parsedRandomCursorSeed: number | undefined;


### PR DESCRIPTION
Root cause of "civitai.red hides SFW minor content regardless of browsing level" (ClickUp 868kbr0dt, FD #66144/#66064/#65925). **Not** a minor/tag/policy bug at all.

## The bug

`useQueryImages` spreads the caller's filters and never supplies a `browsingLevel`. Sending one is an unwritten per-caller contract:

| Caller | sends `browsingLevel`? |
|---|---|
| `ImagesInfinite` | ✅ `{ ...filters, browsingLevel, ... }` |
| `ImagesAsPostsInfinite` | ✅ `browsingLevel: intersection` |
| `PostDetail` | ✅ `browsingLevel: forcedBrowsingLevel` |
| **`ModelCarousel`** | ❌ **omits it** |

Invisible on `.com` because `applyDomainFeature` backfills the value — but only inside its **cap** branch:

```js
const maxAllowed = !isAuthorized ? publicBrowsingLevelsFlag
                 : !canViewNsfw  ? sfwBrowsingLevelsFlag
                 : undefined;              // ← logged-in on red/blue
if (maxAllowed !== undefined) {
  if (!input.browsingLevel) input.browsingLevel = maxAllowed;   // ← only here
}
```

A logged-in user on `.red` has **no cap** → `maxAllowed === undefined` → the block is skipped → `browsingLevel` reaches SQL as NULL → `(i."nsfwLevel" & NULL) != 0` is NULL → **every row dropped**.

Hence the reported symptom: **visible on .com, hidden on .red, at every browsing setting** — the level was never in the request, so toggling the chips cannot help. Moderators were unaffected (they skip the `forceMinorLevel` path), which made it look like a permissions rule and sent the original investigation toward the `minor` flag.

## Evidence

From a **non-mod session on .red**, using the carousel's byte-exact input (model 2586297 / mv 2905437 — 17 images, all `nsfwLevel 1`, `minor true`, no blocked tags):

```
pending:true   no browsingLevel  (what the carousel sends)  =>  0 items
pending:true   browsingLevel: 1                             => 17 items
pending:false  no browsingLevel                             =>  0 items
pending:false  browsingLevel: 1                             => 17 items
```

`pending` is irrelevant. (An API-key probe misleadingly returns 17 on both domains — it doesn't carry `.red`'s domain context, so it takes the capped path and gets the value backfilled for free.)

## Changes

**1. `src/components/Image/image.utils.ts`** — default `browsingLevel` from `useBrowsingLevelDebounced()` when the caller omits it. Central, so no caller can silently regress; explicit values still win.

Inside a forced provider (minor-model carousels/galleries) this resolves to the **forced SFW level**, which is what those queries should ask for. It does **not** re-open #3095: minor content stays gated on the *viewer's* level, not the content's rating — `browsingLevel` and `disableMinor` both derive from the same context, so R+ ⇒ `disableMinor: true` ⇒ minor hidden.

**2. `src/pages/models/[id]/[[...slug]].tsx`** — key the carousel's SSR prefetch on the same values.

That prefetch exists to kill carousel layout shift and its input must match `useQueryImages` exactly or the React Query key misses and the client refetches anyway. Two mismatches: it never sent `browsingLevel` (change 1 would have orphaned it, silently regressing CLS), and it resolved addons at the *viewer's* level while `ModelCarousel` forces SFW for non-mods — so `disableMinor` already keyed differently on exactly the models this matters for. **That prefetch was already missing before this PR.** Now mirrors the carousel's effective level; verified 0 client refetches after hydration.

**3. `src/server/services/image.service.ts`** — fail closed to `publicBrowsingLevelsFlag` instead of NULL. The non-pending path already guarded this (`browsingLevel ? ... : ingestion = 'Scanned'` — note the fallback applied **no level filter at all**); the pending path did not.

## Review

Independent adversarial review: **PASS, no policy regression.** Verified every `BrowsingLevelProvider` mount site — each one that *raises* the level pairs a nested `BrowsingSettingsAddonsProvider`, so `browsingLevel` and `disableMinor` read the identical context. The two unpaired mounts (`home/index.tsx`, `tools/[slug].tsx`) both *narrow*. No path found where an R+ level is sent with `disableMinor: false` outside the intended `forceMinorLevel` carousel.

Reviewer notes carried forward:
- Change 3 is net **narrowing** (old fallback returned every level incl. XXX) and matches the BitDex path, which already fails closed to PG. Minor caveat: the new branch drops the implicit `ingestion = 'Scanned'` requirement, bounded by `needsReview IS NULL`, `acceptableMinor = FALSE`, and the non-mod `ingestion != 'Blocked'` clause.
- This diff **closes a hole**: on `main` the minor carousel's client key had no `browsingLevel` and `disableMinor: false`, so on `.red` it refetched with no level filter at all.
- **Behavioral change worth knowing:** `PostDetail` and `models/[id]` previously sent no level and got every level back; they now filter to the viewer's level — on `.red` a PG-preference user opening an R post gets an empty post rather than blurred images. Policy-correct, but visible.
- **Pre-existing, untouched:** `NewOrderRatingGuideModal.tsx:82` passes explicit R/X/XXX levels while `disableMinor` resolves from the root addons — a genuine divergence predating this PR, scoped to curated collection 10615797. Deserves its own ticket.

## Testing

- **Reproduced** on prod `.red` in a non-mod session: carousel empty at PG-only and PG+PG-13.
- **Verified fixed** on local dev and on prod `.red` after release 5.0.2077: carousel renders (10 content images; was 0).
- **Policy intact** on prod `.red`: `disableMinor: true, browsingLevel: 3` → **0 items**.
- `pnpm typecheck` clean (2 pre-existing dependency errors unrelated to this diff).
- ⚠️ **Change 3 is not effective on the observed path.** Post-deploy, a request with no `browsingLevel` still returns 0 on prod `.red`, so the guard isn't reached by this query (likely the index/BitDex route). Harmless but currently dead for this case — needs follow-up rather than being trusted as a backstop.

## Notes

- Any `.red` query omitting `browsingLevel` hits this. Minor models were just where it was most visible.
- This answers the open question left on 868kbr0dt — *"confirm whether .red forces a minimum mature level."* No: `.red` forces nothing, and that is precisely the problem — nothing backfills the absent level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
