### PR TITLE
fix(app-blocks): bound REST app_block_id for dev tokens + add error_class render label

### DIFF
--- a/src/pages/api/track/block-render.ts
+++ b/src/pages/api/track/block-render.ts
@@ -3,6 +3,7 @@ import { getServerAuthSession } from '~/server/auth/get-server-auth-session';
 import { Tracker } from '~/server/clickhouse/client';
 import {
   ensureRegisterAppBlockRuntimeMetrics,
+  normalizeErrorClass,
   normalizeSlotId,
 } from '~/server/metrics/app-block-runtime.metrics';
 import { boundAppBlockIdLabel } from '~/server/services/blocks/known-app-blocks.service';
@@ -70,12 +71,14 @@ export default PublicEndpoint(
     // forwarded to the ClickHouse insert (the `blockRenders` table is provisioned
     // out-of-repo by the tracker service; adding columns is out of scope here).
     // Strip them so the CH payload stays byte-identical to the pre-change insert.
-    const { status, errorClass: _errorClass, ...renderData } = result.data;
+    // `errorClass` still drives the prom label below (normalized), never the CH insert.
+    const { status, errorClass, ...renderData } = result.data;
 
     // Per-app render/impression outcome (additive + dark). `result` ∈ ok|error.
-    // All three labels are BOUNDED even though the beacon body is client-supplied
-    // and this route is public/ungated: `slot_id` clamps to the enumerated slot
-    // set, `result` is enumerated, and `app_block_id` is clamped to the
+    // ALL labels are BOUNDED even though the beacon body is client-supplied and
+    // this route is public/ungated: `slot_id` clamps to the enumerated slot set,
+    // `result` is enumerated, `error_class` clamps to the known failure set
+    // ('none' on ok, else known-or-'other'), and `app_block_id` is clamped to the
     // approved-app set (unknown → 'other') via a TTL-cached in-memory lookup — no
     // per-request DB hit — so a scripted client can't blow up prom-client's heap
     // with unbounded distinct labels. Emitted AFTER the same-origin + schema
@@ -88,6 +91,7 @@ export default PublicEndpoint(
         app_block_id: appBlockIdLabel,
         slot_id: normalizeSlotId(renderData.slotId),
         result: status,
+        error_class: normalizeErrorClass(status, errorClass),
       });
     } catch {
       // swallow — observability must not affect the response

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -164,10 +164,13 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     // default buckets are fine for this REST surface
   );
 
-  // Cardinality: renders_total ≈ (approvedApps+1 for 'dev'/'other') × 5 slot_id
-  // (4 known + 'other') × 6 error_class ('none' + 5 known + 'other', but 'none'
-  // only pairs with result=ok and the 5+other only with result=error) × 2 result
-  // — every factor strictly bounded, so the series count stays small.
+  // Cardinality: renders_total ≈ (A+1) × 5 slot_id × 7 error_class ≈ 1785 at
+  // A=50, where A = approved apps (+1 for the 'other' bucket), slot_id = 4 known
+  // + 'other', and error_class = 'none' + 5 known + 'other' (7). `result` is NOT
+  // an independent multiplier — it's coupled to error_class ('none' pairs only
+  // with result=ok; the 5-known+'other' pair only with result=error), so the 7
+  // error_class values already encode the result split. Every factor is strictly
+  // bounded, so the series count stays small.
   const rendersTotal = getOrCreateCounter(
     reg,
     'civitai_app_block_renders_total',

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -60,12 +60,37 @@ const KNOWN_SLOT_IDS = new Set([
 ]);
 
 /**
+ * Known render-failure discriminators the hosts emit:
+ *   - timeout        — iframe never reached BLOCK_READY within the readiness window
+ *   - fatal          — the block posted BLOCK_ERROR{fatal:true}
+ *   - no_token       — the block token never resolved
+ *   - error          — a hard token-mint failure (PageBlockHost only)
+ *   - error_boundary — the host React tree threw (BlockErrorBoundary caught it)
+ * Anything else is bucketed to 'other'. A successful render uses 'none'.
+ */
+const KNOWN_ERROR_CLASSES = new Set(['timeout', 'fatal', 'no_token', 'error', 'error_boundary']);
+
+/**
  * Clamp a client-supplied slotId to the enumerated slot set (unknown → 'other')
  * so the `slot_id` prom label can never explode even though the beacon body is
  * client-controlled.
  */
 export function normalizeSlotId(slotId: string): string {
   return KNOWN_SLOT_IDS.has(slotId) ? slotId : 'other';
+}
+
+/**
+ * Resolve the strictly-bounded `error_class` render label. A successful render
+ * (`result==='ok'`) is always 'none'; on error the client-sent errorClass is
+ * kept only if it's in the known set, else 'other'. A raw/unbounded errorClass
+ * can never become the label (the beacon body is client-controlled).
+ */
+export function normalizeErrorClass(
+  result: AppBlockRenderResult,
+  errorClass: string | undefined
+): string {
+  if (result === 'ok') return 'none';
+  return errorClass && KNOWN_ERROR_CLASSES.has(errorClass) ? errorClass : 'other';
 }
 
 /**
@@ -139,11 +164,15 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     // default buckets are fine for this REST surface
   );
 
+  // Cardinality: renders_total ≈ (approvedApps+1 for 'dev'/'other') × 5 slot_id
+  // (4 known + 'other') × 6 error_class ('none' + 5 known + 'other', but 'none'
+  // only pairs with result=ok and the 5+other only with result=error) × 2 result
+  // — every factor strictly bounded, so the series count stays small.
   const rendersTotal = getOrCreateCounter(
     reg,
     'civitai_app_block_renders_total',
-    'App Block host render/impression outcomes by app, slot, and result (ok|error)',
-    ['app_block_id', 'slot_id', 'result']
+    'App Block host render/impression outcomes by app, slot, result (ok|error), and error_class (none when ok; timeout|fatal|no_token|error|error_boundary|other on error)',
+    ['app_block_id', 'slot_id', 'result', 'error_class']
   );
 
   return { requestsTotal, requestDurationSeconds, rendersTotal };

--- a/src/server/middleware/__tests__/block-scope.metrics.test.ts
+++ b/src/server/middleware/__tests__/block-scope.metrics.test.ts
@@ -47,15 +47,19 @@ const MODEL_ID = 12345;
 const APP_BLOCK_ID = 'apb_metrics_test';
 const REQUIRED_SCOPE = 'models:read:self';
 
-async function mintToken(scopes: string[] = [REQUIRED_SCOPE]): Promise<string> {
+async function mintToken(
+  scopes: string[] = [REQUIRED_SCOPE],
+  opts: { dev?: boolean; appBlockId?: string } = {}
+): Promise<string> {
   const r = await BlockTokenService.sign({
     userId: 42,
     blockId: 'blk_test',
     appId: 'app_test',
-    appBlockId: APP_BLOCK_ID,
+    appBlockId: opts.appBlockId ?? APP_BLOCK_ID,
     blockInstanceId: 'bki_test',
     scopes,
     ctx: { modelId: MODEL_ID },
+    ...(opts.dev ? { dev: true } : {}),
   });
   return r.token;
 }
@@ -113,12 +117,16 @@ function makeReq(token: string): NextApiRequest {
   } as unknown as NextApiRequest;
 }
 
-async function counterValue(endpoint: AppBlockEndpoint, result: string): Promise<number> {
+async function counterValue(
+  endpoint: AppBlockEndpoint,
+  result: string,
+  appBlockId: string = APP_BLOCK_ID
+): Promise<number> {
   const metric = client.register.getSingleMetric('civitai_app_block_requests_total');
   if (!metric) return 0;
   const data = await (metric as { get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }> }).get();
   const match = data.values.find(
-    (v) => v.labels.app_block_id === APP_BLOCK_ID && v.labels.endpoint === endpoint && v.labels.result === result
+    (v) => v.labels.app_block_id === appBlockId && v.labels.endpoint === endpoint && v.labels.result === result
   );
   return match?.value ?? 0;
 }
@@ -204,5 +212,38 @@ describe('withBlockScope — per-app REST RED metric', () => {
     expect(res.statusCode).toBe(403);
     expect(wrapped).not.toHaveBeenCalled();
     expect(await counterValue('model_detail', 'forbidden')).toBe(before + 1);
+  });
+
+  it('buckets a DEV token (synthetic appBlockId) to app_block_id="dev"', async () => {
+    const before = await counterValue('model_detail', 'success', 'dev');
+    // Dev tokens carry a caller-constructed synthetic appBlockId — an unbounded
+    // label vector. It must collapse to the single 'dev' bucket, NOT pass raw.
+    const route = withBlockScope(statusHandler(200) as never, {
+      endpoint: 'model_detail',
+      requiredScope: REQUIRED_SCOPE,
+    });
+    const res = makeRes();
+    await route(
+      makeReq(await mintToken([REQUIRED_SCOPE], { dev: true, appBlockId: 'apb_synthetic_dev_xyz' })) as never,
+      res as never
+    );
+    res._finish();
+
+    expect(await counterValue('model_detail', 'success', 'dev')).toBe(before + 1);
+    // The synthetic id NEVER became a label.
+    expect(await counterValue('model_detail', 'success', 'apb_synthetic_dev_xyz')).toBe(0);
+  });
+
+  it('keeps a normal (non-dev) token on its real appBlockId', async () => {
+    const before = await counterValue('model_detail', 'success', APP_BLOCK_ID);
+    const route = withBlockScope(statusHandler(200) as never, {
+      endpoint: 'model_detail',
+      requiredScope: REQUIRED_SCOPE,
+    });
+    const res = makeRes();
+    await route(makeReq(await mintToken()) as never, res as never);
+    res._finish();
+
+    expect(await counterValue('model_detail', 'success', APP_BLOCK_ID)).toBe(before + 1);
   });
 });

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -740,9 +740,17 @@ export function withBlockScope(
     // status + latency AND the middleware's OWN 403 rejections below (revocation
     // / missing-scope / context-binding). The invalid-token 401 above is
     // intentionally NOT attributed — there are no claims, so no `app_block_id` to
-    // key on. `app_block_id` comes from the VERIFIED JWT (bounded to approved
-    // apps); `endpoint`/`result` are strictly enumerated. Fire-and-forget: a
+    // key on. `endpoint`/`result` are strictly enumerated. Fire-and-forget: a
     // metrics failure must never poison the user-facing response.
+    //
+    // `app_block_id` cardinality: a normal (approved/pre-approval) token carries
+    // a real FK appBlockId bounded to the approved-app set. A DEV token
+    // (`claims.dev === true`, the same discriminator the max-age cap + audit path
+    // use) carries a CALLER-CONSTRUCTED, synthetic, non-resolving appBlockId (see
+    // dev-scoped-mint.service) — an unbounded label vector even though minting is
+    // mod/dev-cohort gated. Bucket ALL dev tokens to the single stable label
+    // 'dev' so that vector is closed while real per-app attribution is preserved.
+    const appBlockIdLabel = claims.dev === true ? 'dev' : claims.appBlockId;
     const metricStart = process.hrtime.bigint();
     let metricRecorded = false;
     const recordBlockMetric = () => {
@@ -750,7 +758,7 @@ export function withBlockScope(
       metricRecorded = true;
       try {
         const { requestsTotal, requestDurationSeconds } = ensureRegisterAppBlockRuntimeMetrics();
-        const labels = { app_block_id: claims.appBlockId, endpoint: opts.endpoint };
+        const labels = { app_block_id: appBlockIdLabel, endpoint: opts.endpoint };
         const elapsedSeconds = Number(process.hrtime.bigint() - metricStart) / 1e9;
         requestDurationSeconds.observe(labels, elapsedSeconds);
         requestsTotal.inc({ ...labels, result: statusToRequestResult(res.statusCode) });

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -68,10 +68,11 @@ export const blockRenderSchema = z.object({
   // timeout). Drives the `civitai_app_block_renders_total{result}` prom counter.
   status: z.enum(['ok', 'error']).default('ok'),
   // Optional low-cardinality failure discriminator (e.g. 'timeout', 'fatal',
-  // 'no_token', 'error_boundary'). Bounded but NOT put on a prom label (kept for
-  // a future ClickHouse column). Reserved: the beacon route validates it but
-  // does NOT forward it to the ClickHouse insert today (prom-only), so it never
-  // reaches the tracker payload.
+  // 'no_token', 'error', 'error_boundary'). Drives the bounded `error_class`
+  // label on `civitai_app_block_renders_total` (via `normalizeErrorClass`, which
+  // clamps any value outside the known set to 'other'). It is STILL stripped from
+  // the ClickHouse insert — it never reaches the tracker payload, only the prom
+  // label.
   errorClass: z.string().trim().min(1).max(64).optional(),
 });
 

--- a/src/tests/api/track/block-render.test.ts
+++ b/src/tests/api/track/block-render.test.ts
@@ -255,7 +255,8 @@ describe('POST /api/track/block-render', () => {
 async function renderCounterValue(
   appBlockId: string,
   slotId: string,
-  result: string
+  result: string,
+  errorClass?: string
 ): Promise<number> {
   const metric = client.register.getSingleMetric('civitai_app_block_renders_total');
   if (!metric) return 0;
@@ -263,7 +264,11 @@ async function renderCounterValue(
     metric as { get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }> }
   ).get();
   const match = data.values.find(
-    (v) => v.labels.app_block_id === appBlockId && v.labels.slot_id === slotId && v.labels.result === result
+    (v) =>
+      v.labels.app_block_id === appBlockId &&
+      v.labels.slot_id === slotId &&
+      v.labels.result === result &&
+      (errorClass === undefined || v.labels.error_class === errorClass)
   );
   return match?.value ?? 0;
 }
@@ -275,15 +280,15 @@ describe('POST /api/track/block-render — civitai_app_block_renders_total count
     sessionStore.session = null;
   });
 
-  it('increments result=ok (schema default) on a status-less beacon AND keeps status/errorClass out of the CH insert', async () => {
-    const before = await renderCounterValue('apb_test', 'app.page', 'ok');
+  it('increments result=ok with error_class=none on a status-less beacon AND keeps status/errorClass out of the CH insert', async () => {
+    const before = await renderCounterValue('apb_test', 'app.page', 'ok', 'none');
     const handler = (await import('~/pages/api/track/block-render')).default;
     const req = makeReq({ origin: 'https://civitai.com', body: validInput });
     const res = makeRes();
 
     await handler(req as any, res);
 
-    expect(await renderCounterValue('apb_test', 'app.page', 'ok')).toBe(before + 1);
+    expect(await renderCounterValue('apb_test', 'app.page', 'ok', 'none')).toBe(before + 1);
     // status/errorClass never reach the ClickHouse insert (prom-only).
     const arg = mockBlockRender.mock.calls[0][0];
     expect(arg).not.toHaveProperty('status');
@@ -291,8 +296,8 @@ describe('POST /api/track/block-render — civitai_app_block_renders_total count
     expect(arg).toEqual({ ...validInput, isAnon: true });
   });
 
-  it('increments result=error when the beacon carries status:"error"', async () => {
-    const before = await renderCounterValue('apb_test', 'app.page', 'error');
+  it('increments result=error with the sent error_class label when the beacon carries status:"error"', async () => {
+    const before = await renderCounterValue('apb_test', 'app.page', 'error', 'timeout');
     const handler = (await import('~/pages/api/track/block-render')).default;
     const req = makeReq({
       origin: 'https://civitai.com',
@@ -302,9 +307,43 @@ describe('POST /api/track/block-render — civitai_app_block_renders_total count
 
     await handler(req as any, res);
 
-    expect(await renderCounterValue('apb_test', 'app.page', 'error')).toBe(before + 1);
+    expect(await renderCounterValue('apb_test', 'app.page', 'error', 'timeout')).toBe(before + 1);
     // The error still writes the (identifier-only) CH row — status/errorClass stripped.
     expect(mockBlockRender).toHaveBeenCalledWith({ ...validInput, isAnon: true });
+  });
+
+  it('preserves each KNOWN error_class on the label', async () => {
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    for (const ec of ['fatal', 'no_token', 'error', 'error_boundary'] as const) {
+      const before = await renderCounterValue('apb_test', 'app.page', 'error', ec);
+      await handler(
+        makeReq({
+          origin: 'https://civitai.com',
+          body: { ...validInput, status: 'error', errorClass: ec },
+        }) as any,
+        makeRes()
+      );
+      expect(await renderCounterValue('apb_test', 'app.page', 'error', ec)).toBe(before + 1);
+    }
+  });
+
+  it('clamps an UNKNOWN error_class to "other" (bounds the label) and still strips it from the CH insert', async () => {
+    const before = await renderCounterValue('apb_test', 'app.page', 'error', 'other');
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const req = makeReq({
+      origin: 'https://civitai.com',
+      body: { ...validInput, status: 'error', errorClass: 'attacker_garbage_zzz' },
+    });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(await renderCounterValue('apb_test', 'app.page', 'error', 'other')).toBe(before + 1);
+    // CH insert stays byte-identical: neither status nor errorClass is forwarded.
+    const arg = mockBlockRender.mock.calls[0][0];
+    expect(arg).not.toHaveProperty('status');
+    expect(arg).not.toHaveProperty('errorClass');
+    expect(arg).toEqual({ ...validInput, isAnon: true });
   });
 
   it('clamps an UNKNOWN app_block_id to "other" (bounds the label) and preserves a known one', async () => {


### PR DESCRIPTION
Two cardinality/obs-quality fast-follows to the App Blocks runtime metrics
(#3117):

1. REST app_block_id — dev-token bucketing. block-scope.middleware recorded
   `app_block_id: claims.appBlockId` raw. A DEV token (claims.dev === true — the
   same discriminator the max-age cap + audit path use) carries a caller-
   constructed synthetic, non-resolving appBlockId (dev-scoped-mint.service) —
   an unbounded label vector even though minting is mod/dev-cohort gated. Bucket
   all dev tokens to a single stable 'dev' label; real per-app attribution (incl.
   legit pre-approval apps) is preserved. Metric-label only; authz/audit untouched.

2. renders_total error_class label. The render counter collapsed every failure
   into result="error". The host already sends an errorClass (timeout | fatal |
   no_token | error | error_boundary) that was parsed then stripped before the
   prom emit. Surface it as a STRICTLY-enumerated `error_class` label:
   result=ok → 'none'; on error the sent class if in KNOWN_ERROR_CLASSES, else
   'other'. Never lets a raw/unbounded errorClass become a label. status/
   errorClass STILL stay out of the ClickHouse insert (byte-identical). No client
   change needed — the hosts already send exactly these values (verified).

renders_total label set is now {app_block_id, slot_id, result, error_class},
all strictly bounded.

Tests: beacon (ok→none, each known class preserved, unknown→other, CH insert
still strips status/errorClass); middleware (dev token → 'dev', normal → real
appBlockId). block-render + middleware + metrics + service suites green;
tsc --noEmit clean on touched files.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
