### PR TITLE
feat(cosmetic-shop): dead-letter + retry failed creator payouts

### DIFF
--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -3762,6 +3762,31 @@ model UserCosmeticShopPurchases {
   refunded          Boolean
 }
 
+// Cosmetic shop creator payouts that failed after the buyer was charged. Deliberately has no
+// foreign keys: a row is buzz still owed, so it must outlive deletion of the item/cosmetic/purchase.
+model CosmeticShopPayoutDeadLetter {
+  id                    Int       @id @default(autoincrement())
+  // Replayed verbatim rather than recomputed — it is the buzz service's idempotency key, so
+  // preserving the original value is what makes a retry unable to double-pay.
+  externalTransactionId String    @unique
+  purchaseTransactionId String
+  recipientUserId       Int
+  buyerId               Int
+  shopItemId            Int
+  cosmeticId            Int
+  amount                Int
+  originalAmount        Int
+  buzzType              String
+  description           String
+  attempts              Int       @default(0)
+  lastError             String?
+  resolvedAt            DateTime?
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
+
+  @@index([resolvedAt])
+}
+
 enum BuzzAccountType {
   user
   generation

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -1829,6 +1829,24 @@ export type CosmeticShopItem = {
   reviewedAt: Timestamp | null;
   rejectionReason: string | null;
 };
+export type CosmeticShopPayoutDeadLetter = {
+  id: Generated<number>;
+  externalTransactionId: string;
+  purchaseTransactionId: string;
+  recipientUserId: number;
+  buyerId: number;
+  shopItemId: number;
+  cosmeticId: number;
+  amount: number;
+  originalAmount: number;
+  buzzType: string;
+  description: string;
+  attempts: Generated<number>;
+  lastError: string | null;
+  resolvedAt: Timestamp | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Timestamp;
+};
 export type CosmeticShopSection = {
   id: Generated<number>;
   addedById: number | null;
@@ -3863,6 +3881,7 @@ export type DB = {
   CommentV2Report: CommentV2Report;
   Cosmetic: Cosmetic;
   CosmeticShopItem: CosmeticShopItem;
+  CosmeticShopPayoutDeadLetter: CosmeticShopPayoutDeadLetter;
   CosmeticShopSection: CosmeticShopSection;
   CosmeticShopSectionItem: CosmeticShopSectionItem;
   CoveredCheckpoint: CoveredCheckpoint;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -2599,6 +2599,25 @@ export interface UserCosmeticShopPurchases {
   refunded: boolean;
 }
 
+export interface CosmeticShopPayoutDeadLetter {
+  id: number;
+  externalTransactionId: string;
+  purchaseTransactionId: string;
+  recipientUserId: number;
+  buyerId: number;
+  shopItemId: number;
+  cosmeticId: number;
+  amount: number;
+  originalAmount: number;
+  buzzType: string;
+  description: string;
+  attempts: number;
+  lastError: string | null;
+  resolvedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface BuzzClaim {
   key: string;
   title: string;

--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -220,6 +220,15 @@ export const creatorCompAmountPaidCounter = registerCounterWithLabels({
   labelNames: ['account_type'] as const,
 });
 
+// Cosmetic shop payouts that failed after the buyer was charged and are still owed to a creator.
+// `pending` rows are awaiting a retry; `exhausted` rows have burned their retries and need a human.
+// Set by the retry job, not collect() — the value comes from a DB count and every pod would run it.
+export const cosmeticPayoutDeadLetterGauge = registerGaugeWithLabels({
+  name: 'cosmetic_payout_dead_letter_rows',
+  help: 'Unresolved cosmetic shop creator payouts (buzz owed), by retry state',
+  labelNames: ['state'] as const,
+});
+
 // License fee payout metrics
 export const licenseFeeCreatorsPaidCounter = registerCounterWithLabels({
   name: 'license_fee_creators_paid_total',

--- a/prisma/migrations/20260714142244_cosmetic_shop_payout_dead_letter/migration.sql
+++ b/prisma/migrations/20260714142244_cosmetic_shop_payout_dead_letter/migration.sql
@@ -1,0 +1,30 @@
+-- Dead-letter record for cosmetic shop creator payouts (bank -> creator) that failed after
+-- the buyer was already charged. No foreign keys on purpose: these rows are a record of buzz
+-- still owed, so they must outlive deletion of the shop item, cosmetic, or purchase row.
+CREATE TABLE IF NOT EXISTS "CosmeticShopPayoutDeadLetter" (
+  "id" SERIAL NOT NULL,
+  "externalTransactionId" TEXT NOT NULL,
+  "purchaseTransactionId" TEXT NOT NULL,
+  "recipientUserId" INTEGER NOT NULL,
+  "buyerId" INTEGER NOT NULL,
+  "shopItemId" INTEGER NOT NULL,
+  "cosmeticId" INTEGER NOT NULL,
+  "amount" INTEGER NOT NULL,
+  "originalAmount" INTEGER NOT NULL,
+  "buzzType" TEXT NOT NULL,
+  "description" TEXT NOT NULL,
+  "attempts" INTEGER NOT NULL DEFAULT 0,
+  "lastError" TEXT,
+  "resolvedAt" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "CosmeticShopPayoutDeadLetter_pkey" PRIMARY KEY ("id")
+);
+
+-- The buzz service treats externalTransactionId as the idempotency key, so it also uniquely
+-- identifies the debt: re-recording the same failed payout must update, never insert.
+CREATE UNIQUE INDEX IF NOT EXISTS "CosmeticShopPayoutDeadLetter_externalTransactionId_key"
+  ON "CosmeticShopPayoutDeadLetter"("externalTransactionId");
+
+CREATE INDEX IF NOT EXISTS "CosmeticShopPayoutDeadLetter_resolvedAt_idx"
+  ON "CosmeticShopPayoutDeadLetter"("resolvedAt");

--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -42,6 +42,7 @@ import {
 } from '~/server/jobs/referral-program-jobs';
 import { prepaidMembershipJobs } from '~/server/jobs/prepaid-membership-jobs';
 import { updateCreatorResourceCompensation } from '~/server/jobs/deliver-creator-compensation';
+import { retryCosmeticShopPayouts } from '~/server/jobs/retry-cosmetic-shop-payouts';
 import { deliverLeaderboardCosmetics } from '~/server/jobs/deliver-leaderboard-cosmetics';
 import { deliverPurchasedCosmetics } from '~/server/jobs/deliver-purchased-cosmetics';
 import { dummyJob } from '~/server/jobs/dummy-job';
@@ -162,6 +163,7 @@ export const jobs: Job[] = [
   tempSetMissingNsfwLevel,
   imagesCreatedEvents,
   updateCreatorResourceCompensation,
+  retryCosmeticShopPayouts,
   confirmMutes,
   confirmPendingBlockAttributions,
   bulkPayoutBlockAttributions,
@@ -224,8 +226,7 @@ export default WebhookEndpoint(async (req, res) => {
   const { name, run, options } = job;
 
   const lock = await acquireLock(name, options.lockExpiration, noCheck);
-  if (!lock)
-    return res.status(200).json({ ok: true, error: 'Job already running' });
+  if (!lock) return res.status(200).json({ ok: true, error: 'Job already running' });
 
   const jobStart = Date.now();
   const axiom = req.log.with({ scope: 'job', name, pod });

--- a/src/server/jobs/retry-cosmetic-shop-payouts.ts
+++ b/src/server/jobs/retry-cosmetic-shop-payouts.ts
@@ -1,0 +1,124 @@
+import { createJob } from './job';
+import { dbWrite } from '~/server/db/client';
+import { createBuzzTransactionMany } from '~/server/services/buzz.service';
+import { logToAxiom } from '~/server/logging/client';
+import { cosmeticPayoutDeadLetterGauge } from '~/server/prom/client';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
+import { TransactionType } from '~/shared/constants/buzz.constants';
+import { createLogger } from '~/utils/logging';
+
+const log = createLogger('retry-cosmetic-shop-payouts', 'green');
+
+const MAX_ATTEMPTS = 5;
+const BATCH_SIZE = 100;
+
+type DeadLetterRow = {
+  id: number;
+  externalTransactionId: string;
+  recipientUserId: number;
+  buyerId: number;
+  amount: number;
+  originalAmount: number;
+  buzzType: string;
+  description: string;
+};
+
+export const retryCosmeticShopPayouts = createJob(
+  'retry-cosmetic-shop-payouts',
+  '*/10 * * * *',
+  async () => {
+    const rows = await dbWrite.cosmeticShopPayoutDeadLetter.findMany({
+      where: { resolvedAt: null, attempts: { lt: MAX_ATTEMPTS } },
+      orderBy: { createdAt: 'asc' },
+      take: BATCH_SIZE,
+      select: {
+        id: true,
+        externalTransactionId: true,
+        recipientUserId: true,
+        buyerId: true,
+        amount: true,
+        originalAmount: true,
+        buzzType: true,
+        description: true,
+      },
+    });
+
+    if (rows.length) {
+      log(`Retrying ${rows.length} unpaid cosmetic payouts`);
+      await limitConcurrency(
+        rows.map((row) => async () => settlePayout(row)),
+        5
+      );
+    }
+
+    await publishDeadLetterGauge();
+  }
+);
+
+async function settlePayout(row: DeadLetterRow) {
+  try {
+    // One payout per call: the batch endpoint reports successes as opaque transaction ids, so a
+    // multi-row batch can't be attributed back to the rows that actually settled.
+    const result = await createBuzzTransactionMany([
+      {
+        fromAccountId: 0,
+        toAccountId: row.recipientUserId,
+        toAccountType: row.buzzType as BuzzSpendType,
+        amount: row.amount,
+        type: TransactionType.Sell,
+        description: row.description,
+        // Replayed verbatim — see CosmeticShopPayoutDeadLetter.externalTransactionId.
+        externalTransactionId: row.externalTransactionId,
+        details: { purchasedBy: row.buyerId, originalAmount: row.originalAmount },
+      },
+    ]);
+
+    // A conflict is the idempotency guard saying this exact payout already moved — the creator has
+    // their buzz, so the debt is settled. Anything else means the money did not move.
+    const settled = result.transactions.length + result.conflicts.length > 0;
+    if (!settled) throw new Error('Buzz service accepted no transaction for this payout');
+
+    await dbWrite.cosmeticShopPayoutDeadLetter.update({
+      where: { id: row.id },
+      data: { resolvedAt: new Date(), attempts: { increment: 1 }, lastError: null },
+    });
+  } catch (e) {
+    const lastError = e instanceof Error ? e.message : String(e);
+    const { attempts } = await dbWrite.cosmeticShopPayoutDeadLetter.update({
+      where: { id: row.id },
+      data: { attempts: { increment: 1 }, lastError },
+      select: { attempts: true },
+    });
+
+    if (attempts >= MAX_ATTEMPTS) {
+      logToAxiom({
+        level: 'error',
+        message: 'Cosmetic payout dead letter exhausted retries — creator still owed buzz',
+        data: {
+          id: row.id,
+          externalTransactionId: row.externalTransactionId,
+          recipientUserId: row.recipientUserId,
+          amount: row.amount,
+          buzzType: row.buzzType,
+          attempts,
+          error: lastError,
+        },
+      });
+    }
+  }
+}
+
+async function publishDeadLetterGauge() {
+  const [pending, exhausted] = await Promise.all([
+    dbWrite.cosmeticShopPayoutDeadLetter.count({
+      where: { resolvedAt: null, attempts: { lt: MAX_ATTEMPTS } },
+    }),
+    dbWrite.cosmeticShopPayoutDeadLetter.count({
+      where: { resolvedAt: null, attempts: { gte: MAX_ATTEMPTS } },
+    }),
+  ]);
+
+  cosmeticPayoutDeadLetterGauge.set({ state: 'pending' }, pending);
+  cosmeticPayoutDeadLetterGauge.set({ state: 'exhausted' }, exhausted);
+}

--- a/src/server/services/cosmetic-shop.service.ts
+++ b/src/server/services/cosmetic-shop.service.ts
@@ -475,6 +475,76 @@ export const getShopSectionsWithItems = async ({
   );
 };
 
+// Suffixed only when the pool is split, so the two payouts don't collide on the same external id.
+// The buzz service keys idempotency on this value, so the dead-letter row and the original attempt
+// MUST derive it identically — a retry under a different id would double-pay.
+const cosmeticPayoutExternalId = (transactionId: string, recipientCount: number, userId: number) =>
+  recipientCount > 1 ? `${transactionId}:${userId}` : transactionId;
+
+// Records buzz owed to creators after the buyer was already charged, for `retry-cosmetic-shop-payouts`
+// to settle. Never throws: the purchase must not fail because we couldn't write the debt down.
+async function recordCosmeticPayoutFailure({
+  recipients,
+  transactionId,
+  buyerId,
+  shopItemId,
+  cosmeticId,
+  originalAmount,
+  buzzType,
+  description,
+  error,
+}: {
+  recipients: { userId: number; amount: number }[];
+  transactionId: string;
+  buyerId: number;
+  shopItemId: number;
+  cosmeticId: number;
+  originalAmount: number;
+  buzzType: BuzzSpendType;
+  description: string;
+  error: unknown;
+}) {
+  const lastError = error instanceof Error ? error.message : String(error);
+
+  try {
+    await Promise.all(
+      recipients
+        .filter((r) => r.amount > 0)
+        .map((r) => {
+          const externalTransactionId = cosmeticPayoutExternalId(
+            transactionId,
+            recipients.length,
+            r.userId
+          );
+
+          return dbWrite.cosmeticShopPayoutDeadLetter.upsert({
+            where: { externalTransactionId },
+            create: {
+              externalTransactionId,
+              purchaseTransactionId: transactionId,
+              recipientUserId: r.userId,
+              buyerId,
+              shopItemId,
+              cosmeticId,
+              amount: r.amount,
+              originalAmount,
+              buzzType,
+              description,
+              lastError,
+            },
+            update: { lastError },
+          });
+        })
+    );
+  } catch (e) {
+    logToAxiom({
+      level: 'error',
+      message: 'Failed to record cosmetic payout dead letter',
+      data: { shopItemId, buyerId, transactionId, recipients, error: e },
+    });
+  }
+}
+
 export const purchaseCosmeticShopItem = async ({
   userId,
   shopItemId,
@@ -631,74 +701,78 @@ export const purchaseCosmeticShopItem = async ({
       return userCosmetic;
     });
 
+    const description = `A user has purchased your cosmetic - ${shopItem.title}`;
+    // Resolved outside the retry so the catch below still knows who was owed what and can
+    // dead-letter the debt. The buyer has already paid at this point.
+    let recipients: { userId: number; amount: number }[] = [];
     try {
-      await withRetries(async () => {
-        // We do this last mainly because we don't want to fail the purchase if this fails.
-        // We can divide the funds later if needed.
-        // Creator Shop items pay the cosmetic's creator (cosmetic.createdById)
-        // their 70% share directly. When another creator (the seller = addedById)
-        // lists a sellable-by-others cosmetic, that 70% pool is split by the
-        // cosmetic's sellerShare (% of price the seller keeps; creator gets the
-        // rest). Official items keep the legacy meta.paidToUserIds distribution.
-        const price = shopItem.unitAmount;
-        const creatorId = shopItem.cosmetic.createdById;
-        const { creatorPool, sellerAmount, creatorAmount } = computeCreatorShopSplit(
-          price,
-          meta?.sellerShare ?? 0
-        );
+      // Creator Shop items pay the cosmetic's creator (cosmetic.createdById)
+      // their 70% share directly. When another creator (the seller = addedById)
+      // lists a sellable-by-others cosmetic, that 70% pool is split by the
+      // cosmetic's sellerShare (% of price the seller keeps; creator gets the
+      // rest). Official items keep the legacy meta.paidToUserIds distribution.
+      const price = shopItem.unitAmount;
+      const creatorId = shopItem.cosmetic.createdById;
+      const { creatorPool, sellerAmount, creatorAmount } = computeCreatorShopSplit(
+        price,
+        meta?.sellerShare ?? 0
+      );
 
-        // Cross-creator resale: when bought through another creator's shop
-        // (viaShopUserId) that actually resells this sellable item, split the 70%
-        // pool by the item's sellerShare. Verified server-side so credit can't be
-        // spoofed; otherwise the creator keeps the full 70%.
-        let resellerId: number | undefined;
-        if (viaShopUserId && creatorId && viaShopUserId !== creatorId && meta?.sellableByOthers) {
-          const viaUser = await dbRead.user.findUnique({
-            where: { id: viaShopUserId },
-            select: { settings: true },
-          });
-          const resoldIds =
-            (viaUser?.settings as { creatorShop?: { resoldItemIds?: number[] } } | null)
-              ?.creatorShop?.resoldItemIds ?? [];
-          if (resoldIds.includes(shopItem.id)) resellerId = viaShopUserId;
-        }
+      // Cross-creator resale: when bought through another creator's shop
+      // (viaShopUserId) that actually resells this sellable item, split the 70%
+      // pool by the item's sellerShare. Verified server-side so credit can't be
+      // spoofed; otherwise the creator keeps the full 70%.
+      let resellerId: number | undefined;
+      if (viaShopUserId && creatorId && viaShopUserId !== creatorId && meta?.sellableByOthers) {
+        const viaUser = await dbRead.user.findUnique({
+          where: { id: viaShopUserId },
+          select: { settings: true },
+        });
+        const resoldIds =
+          (viaUser?.settings as { creatorShop?: { resoldItemIds?: number[] } } | null)?.creatorShop
+            ?.resoldItemIds ?? [];
+        if (resoldIds.includes(shopItem.id)) resellerId = viaShopUserId;
+      }
 
-        let recipients: { userId: number; amount: number }[];
-        if (creatorId) {
-          if (resellerId) {
-            recipients = [
-              ...(creatorAmount > 0 ? [{ userId: creatorId, amount: creatorAmount }] : []),
-              ...(sellerAmount > 0 ? [{ userId: resellerId, amount: sellerAmount }] : []),
-            ];
-          } else {
-            recipients = [{ userId: creatorId, amount: creatorPool }];
-          }
+      if (creatorId) {
+        if (resellerId) {
+          recipients = [
+            ...(creatorAmount > 0 ? [{ userId: creatorId, amount: creatorAmount }] : []),
+            ...(sellerAmount > 0 ? [{ userId: resellerId, amount: sellerAmount }] : []),
+          ];
         } else {
-          recipients = (meta?.paidToUserIds ?? []).map((uid) => ({
-            userId: uid,
-            amount: Math.floor(price / (meta?.paidToUserIds?.length ?? 1)),
-          }));
+          recipients = [{ userId: creatorId, amount: creatorPool }];
         }
+      } else {
+        recipients = (meta?.paidToUserIds ?? []).map((uid) => ({
+          userId: uid,
+          amount: Math.floor(price / (meta?.paidToUserIds?.length ?? 1)),
+        }));
+      }
 
-        await Promise.all(
-          recipients.map((r) =>
-            createBuzzTransaction({
-              fromAccountId: 0,
-              toAccountId: r.userId,
-              // Pay creators/resellers in the same Buzz color the buyer paid with.
-              toAccountType: buzzType,
-              amount: r.amount,
-              type: TransactionType.Sell,
-              description: `A user has purchased your cosmetic - ${shopItem.title}`,
-              // Unique per recipient when the pool is split, so the two payouts
-              // don't collide on the same external id.
-              externalTransactionId:
-                recipients.length > 1 ? `${transactionId}:${r.userId}` : transactionId,
-              details: { purchasedBy: userId, originalAmount: shopItem.unitAmount },
-            })
-          )
-        );
-      }, 3);
+      await withRetries(
+        () =>
+          Promise.all(
+            recipients.map((r) =>
+              createBuzzTransaction({
+                fromAccountId: 0,
+                toAccountId: r.userId,
+                // Pay creators/resellers in the same Buzz color the buyer paid with.
+                toAccountType: buzzType,
+                amount: r.amount,
+                type: TransactionType.Sell,
+                description,
+                externalTransactionId: cosmeticPayoutExternalId(
+                  transactionId,
+                  recipients.length,
+                  r.userId
+                ),
+                details: { purchasedBy: userId, originalAmount: shopItem.unitAmount },
+              })
+            )
+          ),
+        3
+      );
     } catch (e) {
       // We will NOT stop the user interaction for this.
       logToAxiom({
@@ -710,6 +784,18 @@ export const purchaseCosmeticShopItem = async ({
           transactionId,
           error: e,
         },
+      });
+
+      await recordCosmeticPayoutFailure({
+        recipients,
+        transactionId,
+        buyerId: userId,
+        shopItemId,
+        cosmeticId: shopItem.cosmeticId,
+        originalAmount: shopItem.unitAmount,
+        buzzType,
+        description,
+        error: e,
       });
     }
 


### PR DESCRIPTION
## The gap

A cosmetic purchase is **two** buzz transactions:

1. **Buyer -> bank** (`Purchase`, `toAccountId: 0`) — this one is authoritative; if it fails, the purchase fails.
2. **Bank -> creator** (`Sell`, ~70% share, split with a reseller for `sellableByOthers` items) — this one was **best-effort**: `withRetries(..., 3)` and a catch that only logged to Axiom.

So when leg 2 failed, the sale still succeeded, the platform kept the buyer's buzz, and the creator was silently never credited. The only trace was a log line with no recipient or amount on it — nothing to report on, nothing to settle from, and no way to answer "who are we behind on?"

## Design

A durable Postgres dead-letter row plus a job that replays it.

- **`CosmeticShopPayoutDeadLetter`** — written from the existing catch block, so the purchase still never fails on a payout error (the write itself is also non-throwing). Captures everything needed to settle later: the purchase transaction id, recipient, amount, buzz type, shop item / cosmetic, the error, attempts, and `resolvedAt`.
- **`retry-cosmetic-shop-payouts`** (every 10 min) — replays unresolved rows, marks them resolved, and stops after 5 attempts, logging loudly rather than looping forever.
- **`cosmetic_payout_dead_letter_rows`** gauge, labelled `pending` / `exhausted` — "hopefully that won't happen" is now falsifiable. Set from the job rather than `collect()`, since the value comes from a DB count and every pod would otherwise run it on each scrape.

**Why not query Axiom** (it was on the table): it's a lossy log store, `civitai-prod` is at its column cap, and it's the wrong source of truth for money. Postgres is the thing we already trust for the rest of this flow.

Recipient resolution moved out of the `withRetries` closure so the catch block still knows who was owed what. That accounts for most of the diff — it's a reindent, not a logic change.

## Why the retry can't double-pay

Leg 2's `externalTransactionId` is already deterministic (`${transactionId}` or `${transactionId}:${userId}` when the pool is split) — unlike leg 1, which embeds `Date.now()`. The buzz service treats it as an idempotency key. The dead-letter row **stores the id rather than recomputing it**, so a replay is byte-identical even if the split logic changes later, and the retry derives it from the same helper as the original attempt.

Worth knowing for review: the purchase path calls `createBuzzTransaction` (singular), where a duplicate id surfaces as a **thrown** 409 (`mapError` in `buzz.service.ts`). The job deliberately uses `createBuzzTransactionMany` instead, which reports a duplicate in a `conflicts` array — a conflict means the money already moved, so the job treats it as **settled**, with no error-message sniffing. It sends **one payout per call** because the batch endpoint returns opaque ids for successes, so a multi-row batch can't be attributed back to the rows that settled.

This is why partial failures self-correct: if recipient A was paid and B failed, both get dead-lettered, and the replay resolves A via conflict and pays B.

(Context: the 2025-10-17 comp re-run double-paid 8.17M buzz precisely because it suffixed its ids with `-redo`. Keeping the key identical is the whole point.)

## Migration needs manual application

`prisma/migrations/20260714142244_cosmetic_shop_payout_dead_letter/migration.sql` — **must be applied by hand** (we don't run `prisma migrate deploy`). It's an additive `CREATE TABLE` + two indexes; no backfill, no changes to existing tables. **The job no-ops harmlessly until it's applied, but the dead-letter write will fail (and be swallowed to Axiom) until then — so apply it before/with the deploy or failures in that window still go unrecorded.**

No foreign keys, deliberately: a row is buzz still owed, so it must outlive deletion of the shop item, cosmetic, or purchase.

## Out of scope

- **No historical backfill or replay.** This ships the mechanism only; it catches failures from deploy onward. Past failures are only in Axiom and are not addressed here.
- No change to leg 1, and no change to how the split itself is computed.

## Incidental fix

A zero-amount recipient (possible via the legacy `meta.paidToUserIds` path, where `Math.floor(price / n)` can floor to 0) made `createBuzzTransaction` throw `Invalid amount`, which rejected the whole `Promise.all` and blocked payouts for *every* recipient on that purchase. Those now get dead-lettered and the non-zero recipients settle on retry.

## Verification

`pnpm typecheck` and prettier are clean. ESLint could not run in this worktree — it fails at config load (`Converting circular structure to JSON`) on untouched files too, so it's environmental, not from this change. The job path has not been exercised against a live DB, since the table doesn't exist until the migration is applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
