### PR TITLE
fix(tags): strip unlisted tags server-side before they reach the client

### DIFF
--- a/src/server/services/__tests__/tag.service.unlisted.test.ts
+++ b/src/server/services/__tests__/tag.service.unlisted.test.ts
@@ -1,9 +1,5 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
-// Unlisted tags are hidden from tag lists, search and tag pages. They must not
-// reach the client on votable chips either — that would advertise the exact tags
-// we delisted and invite votes on them.
-
 const { imageTagsFetch, tagCacheFetch, imageVotes, modelTagFindMany, modelVotes } = vi.hoisted(
   () => ({
     imageTagsFetch: vi.fn(),

--- a/src/server/services/__tests__/tag.service.unlisted.test.ts
+++ b/src/server/services/__tests__/tag.service.unlisted.test.ts
@@ -1,0 +1,114 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// Unlisted tags are hidden from tag lists, search and tag pages. They must not
+// reach the client on votable chips either — that would advertise the exact tags
+// we delisted and invite votes on them.
+
+const { imageTagsFetch, tagCacheFetch, imageVotes, modelTagFindMany, modelVotes } = vi.hoisted(
+  () => ({
+    imageTagsFetch: vi.fn(),
+    tagCacheFetch: vi.fn(),
+    imageVotes: vi.fn().mockResolvedValue([]),
+    modelTagFindMany: vi.fn(),
+    modelVotes: vi.fn().mockResolvedValue([]),
+  })
+);
+
+vi.mock('~/server/redis/caches', () => ({
+  imageTagsCache: { fetch: imageTagsFetch, bust: vi.fn() },
+  tagCache: { fetch: tagCacheFetch },
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    tagsOnImageVote: { findMany: imageVotes },
+    tagsOnModelsVote: { findMany: modelVotes },
+    modelTag: { findMany: modelTagFindMany },
+  },
+  dbWrite: {},
+}));
+
+import { getVotableTags } from '~/server/services/tag.service';
+
+const LOLI = 114467;
+const NUDE = 304;
+
+function imageTag(tagId: number, tagName: string) {
+  return {
+    tagId,
+    tagName,
+    tagType: 'UserGenerated',
+    tagNsfwLevel: 1,
+    score: 10,
+    upVotes: 10,
+    downVotes: 0,
+    automated: true,
+    needsReview: false,
+    concrete: true, // survives the vote-cutoff filter
+    lastUpvote: null,
+    source: 'WD14',
+  };
+}
+
+describe('getVotableTags — unlisted tags never reach the client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    imageVotes.mockResolvedValue([]);
+    modelVotes.mockResolvedValue([]);
+    imageTagsFetch.mockResolvedValue({
+      1: { imageId: 1, tags: [imageTag(NUDE, 'nude'), imageTag(LOLI, 'loli')] },
+    });
+    // loli is unlisted; nude is not
+    tagCacheFetch.mockResolvedValue({
+      [NUDE]: { id: NUDE, name: 'nude', unlisted: undefined },
+      [LOLI]: { id: LOLI, name: 'loli', unlisted: true },
+    });
+  });
+
+  it('drops an unlisted tag for a normal user', async () => {
+    const tags = await getVotableTags({ type: 'image', id: 1, isModerator: false });
+    expect(tags.map((t) => t.id)).toEqual([NUDE]);
+  });
+
+  it('keeps unlisted tags for moderators, who need to see what content is flagged as', async () => {
+    const tags = await getVotableTags({ type: 'image', id: 1, isModerator: true });
+    expect(tags.map((t) => t.id).sort()).toEqual([NUDE, LOLI].sort());
+    // moderators short-circuit the strip — no cache lookup needed
+    expect(tagCacheFetch).not.toHaveBeenCalled();
+  });
+
+  it('keeps listed tags untouched', async () => {
+    imageTagsFetch.mockResolvedValue({ 1: { imageId: 1, tags: [imageTag(NUDE, 'nude')] } });
+    const tags = await getVotableTags({ type: 'image', id: 1, isModerator: false });
+    expect(tags.map((t) => t.id)).toEqual([NUDE]);
+  });
+
+  it('strips unlisted tags on models too, not just images', async () => {
+    modelTagFindMany.mockResolvedValue([
+      {
+        tagId: NUDE,
+        tagName: 'nude',
+        tagType: 'UserGenerated',
+        score: 5,
+        upVotes: 5,
+        downVotes: 0,
+      },
+      {
+        tagId: LOLI,
+        tagName: 'loli',
+        tagType: 'UserGenerated',
+        score: 5,
+        upVotes: 5,
+        downVotes: 0,
+      },
+    ]);
+    const tags = await getVotableTags({ type: 'model', id: 1, isModerator: false });
+    expect(tags.map((t) => t.id)).toEqual([NUDE]);
+  });
+
+  it('does not hit the tag cache when there are no tags', async () => {
+    imageTagsFetch.mockResolvedValue({ 1: { imageId: 1, tags: [] } });
+    const tags = await getVotableTags({ type: 'image', id: 1, isModerator: false });
+    expect(tags).toEqual([]);
+    expect(tagCacheFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/tag.service.unlisted.test.ts
+++ b/src/server/services/__tests__/tag.service.unlisted.test.ts
@@ -28,83 +28,81 @@ import { getVotableTags } from '~/server/services/tag.service';
 const LOLI = 114467;
 const NUDE = 304;
 
-function imageTag(tagId: number, tagName: string) {
-  return {
-    tagId,
-    tagName,
-    tagType: 'UserGenerated',
-    tagNsfwLevel: 1,
-    score: 10,
-    upVotes: 10,
-    downVotes: 0,
-    automated: true,
-    needsReview: false,
-    concrete: true, // survives the vote-cutoff filter
-    lastUpvote: null,
-    source: 'WD14',
-  };
+function modelTag(tagId: number, tagName: string) {
+  return { tagId, tagName, tagType: 'UserGenerated', score: 5, upVotes: 5, downVotes: 0 };
 }
 
-describe('getVotableTags — unlisted tags never reach the client', () => {
+describe('getVotableTags — model tags', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    imageVotes.mockResolvedValue([]);
     modelVotes.mockResolvedValue([]);
-    imageTagsFetch.mockResolvedValue({
-      1: { imageId: 1, tags: [imageTag(NUDE, 'nude'), imageTag(LOLI, 'loli')] },
-    });
-    // loli is unlisted; nude is not
+    modelTagFindMany.mockResolvedValue([modelTag(NUDE, 'nude'), modelTag(LOLI, 'loli')]);
     tagCacheFetch.mockResolvedValue({
       [NUDE]: { id: NUDE, name: 'nude', unlisted: undefined },
       [LOLI]: { id: LOLI, name: 'loli', unlisted: true },
     });
   });
 
-  it('drops an unlisted tag for a normal user', async () => {
-    const tags = await getVotableTags({ type: 'image', id: 1, isModerator: false });
+  // ModelTag has no unlisted filter of its own (unlike the ImageTag view), so the
+  // service has to drop them or they reach the votable chips.
+  it('drops unlisted tags for a normal user', async () => {
+    const tags = await getVotableTags({ type: 'model', id: 1, isModerator: false });
     expect(tags.map((t) => t.id)).toEqual([NUDE]);
   });
 
   it('keeps unlisted tags for moderators, who need to see what content is flagged as', async () => {
-    const tags = await getVotableTags({ type: 'image', id: 1, isModerator: true });
+    const tags = await getVotableTags({ type: 'model', id: 1, isModerator: true });
     expect(tags.map((t) => t.id).sort()).toEqual([NUDE, LOLI].sort());
-    // moderators short-circuit the strip — no cache lookup needed
     expect(tagCacheFetch).not.toHaveBeenCalled();
   });
 
-  it('keeps listed tags untouched', async () => {
-    imageTagsFetch.mockResolvedValue({ 1: { imageId: 1, tags: [imageTag(NUDE, 'nude')] } });
-    const tags = await getVotableTags({ type: 'image', id: 1, isModerator: false });
-    expect(tags.map((t) => t.id)).toEqual([NUDE]);
-  });
-
-  it('strips unlisted tags on models too, not just images', async () => {
-    modelTagFindMany.mockResolvedValue([
-      {
-        tagId: NUDE,
-        tagName: 'nude',
-        tagType: 'UserGenerated',
-        score: 5,
-        upVotes: 5,
-        downVotes: 0,
-      },
-      {
-        tagId: LOLI,
-        tagName: 'loli',
-        tagType: 'UserGenerated',
-        score: 5,
-        upVotes: 5,
-        downVotes: 0,
-      },
-    ]);
+  it('leaves listed tags untouched', async () => {
+    modelTagFindMany.mockResolvedValue([modelTag(NUDE, 'nude')]);
     const tags = await getVotableTags({ type: 'model', id: 1, isModerator: false });
     expect(tags.map((t) => t.id)).toEqual([NUDE]);
   });
 
   it('does not hit the tag cache when there are no tags', async () => {
-    imageTagsFetch.mockResolvedValue({ 1: { imageId: 1, tags: [] } });
-    const tags = await getVotableTags({ type: 'image', id: 1, isModerator: false });
+    modelTagFindMany.mockResolvedValue([]);
+    const tags = await getVotableTags({ type: 'model', id: 1, isModerator: false });
     expect(tags).toEqual([]);
+    expect(tagCacheFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('getVotableTags — image tags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    imageVotes.mockResolvedValue([]);
+    imageTagsFetch.mockResolvedValue({
+      1: {
+        imageId: 1,
+        tags: [
+          {
+            tagId: NUDE,
+            tagName: 'nude',
+            tagType: 'UserGenerated',
+            tagNsfwLevel: 1,
+            score: 10,
+            upVotes: 10,
+            downVotes: 0,
+            automated: true,
+            needsReview: false,
+            concrete: true,
+            lastUpvote: null,
+            source: 'WD14',
+          },
+        ],
+      },
+    });
+  });
+
+  // Images need no strip: the ImageTag view the cache reads from already excludes
+  // unlisted tags, so one can't reach here. Asserting we don't pay for a redundant
+  // cache lookup on the image-detail path.
+  it('does not do an unlisted lookup — the ImageTag view already filters them', async () => {
+    const tags = await getVotableTags({ type: 'image', id: 1, isModerator: false });
+    expect(tags.map((t) => t.id)).toEqual([NUDE]);
     expect(tagCacheFetch).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -11,7 +11,7 @@ import {
 import { CacheTTL, constants } from '~/server/common/constants';
 import { NsfwLevel, TagSort } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
-import { imageTagsCache } from '~/server/redis/caches';
+import { imageTagsCache, tagCache as basicTagCache } from '~/server/redis/caches';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import type {
   AdjustTagsSchema,
@@ -325,6 +325,27 @@ export const getTags = async ({
 };
 
 // #region [tag voting]
+/**
+ * Drop unlisted tags before they reach the client. They're already hidden from
+ * tag lists, search and tag pages, so surfacing them on votable chips would
+ * advertise the exact tags we delisted — and invite votes on them. Moderators
+ * keep them; they need to see what a piece of content is flagged as.
+ *
+ * `unlisted` isn't on the ImageTag/ModelTag composites, so it's resolved from
+ * the basic tag cache rather than widened into those payloads — imageTagsCache
+ * is the largest consumer of next-redis-cluster (see the 2026-06-09 audit note
+ * on its definition) and shouldn't grow. Reading it here also means a tag being
+ * unlisted takes effect without purging the composite caches.
+ */
+async function stripUnlistedTags<T extends { id: number }>(
+  tags: T[],
+  isModerator: boolean
+): Promise<T[]> {
+  if (isModerator || !tags.length) return tags;
+  const cached = await basicTagCache.fetch(tags.map((tag) => tag.id));
+  return tags.filter((tag) => !cached[tag.id]?.unlisted);
+}
+
 export const getVotableTags = async ({
   userId,
   type,
@@ -412,7 +433,7 @@ export const getVotableTags = async ({
     );
   }
 
-  return results;
+  return stripUnlistedTags(results, isModerator);
 };
 
 export async function getVotableImageTags({
@@ -471,7 +492,7 @@ export async function getVotableImageTags({
     if (userVote) tag.vote = userVote.vote > 0 ? 1 : -1;
   }
 
-  return allImageTags;
+  return stripUnlistedTags(allImageTags, !!user.isModerator);
 }
 
 // TODO - create function for getting model tag votes and then finish abstracting this fuction - replaces `getVotableTags`
@@ -717,9 +738,9 @@ export const disableTags = async ({ tags, entityIds, entityType }: AdjustTagsSch
   const tagIdMatch = (col: string) =>
     isTagIds
       ? Prisma.sql`${Prisma.raw(`"${col}"`)} = ANY(${castedTags as number[]}::int[])`
-      : Prisma.sql`${Prisma.raw(
-          `"${col}"`
-        )} IN (SELECT id FROM "Tag" WHERE "name" = ANY(${castedTags as string[]}::text[]))`;
+      : Prisma.sql`${Prisma.raw(`"${col}"`)} IN (SELECT id FROM "Tag" WHERE "name" = ANY(${
+          castedTags as string[]
+        }::text[]))`;
 
   // TODO.fix "disabled" doesnt exist for TagsOnModels, is this being used?
   if (entityType === 'model') {

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -325,18 +325,8 @@ export const getTags = async ({
 };
 
 // #region [tag voting]
-/**
- * Drop unlisted tags before they reach the client. They're already hidden from
- * tag lists, search and tag pages, so surfacing them on votable chips would
- * advertise the exact tags we delisted — and invite votes on them. Moderators
- * keep them; they need to see what a piece of content is flagged as.
- *
- * `unlisted` isn't on the ImageTag/ModelTag composites, so it's resolved from
- * the basic tag cache rather than widened into those payloads — imageTagsCache
- * is the largest consumer of next-redis-cluster (see the 2026-06-09 audit note
- * on its definition) and shouldn't grow. Reading it here also means a tag being
- * unlisted takes effect without purging the composite caches.
- */
+// `unlisted` isn't on the tag composites — read the small cache rather than widen
+// imageTagsCache. Mods keep unlisted tags so they can see what content is flagged as.
 async function stripUnlistedTags<T extends { id: number }>(
   tags: T[],
   isModerator: boolean

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -325,8 +325,9 @@ export const getTags = async ({
 };
 
 // #region [tag voting]
-// `unlisted` isn't on the tag composites — read the small cache rather than widen
-// imageTagsCache. Mods keep unlisted tags so they can see what content is flagged as.
+// The ImageTag view already drops unlisted tags (`AND NOT t_1.unlisted` in its Tag
+// lateral); ModelTag does not, so only the model path needs this. Mods keep them so
+// they can see what content is flagged as.
 async function stripUnlistedTags<T extends { id: number }>(
   tags: T[],
   isModerator: boolean
@@ -374,6 +375,7 @@ export const getVotableTags = async ({
         if (userVote) tag.vote = userVote.vote;
       }
     }
+    results = await stripUnlistedTags(results, isModerator);
   } else if (type === 'image') {
     const voteCutoff = new Date(Date.now() + constants.tagVoting.voteDuration);
 
@@ -423,7 +425,7 @@ export const getVotableTags = async ({
     );
   }
 
-  return stripUnlistedTags(results, isModerator);
+  return results;
 };
 
 export async function getVotableImageTags({
@@ -482,7 +484,7 @@ export async function getVotableImageTags({
     if (userVote) tag.vote = userVote.vote > 0 ? 1 : -1;
   }
 
-  return stripUnlistedTags(allImageTags, !!user.isModerator);
+  return allImageTags;
 }
 
 // TODO - create function for getting model tag votes and then finish abstracting this fuction - replaces `getVotableTags`


### PR DESCRIPTION
Prerequisite for removing the all-levels `loli`/`shota`/`teenager` content block. Model votable-tag chips leak unlisted tags today; images don't.

## The problem

Unlisted tags (`Tag.unlisted = true` — **127** of them, including `loli`, `shota`, `teenager`, `minor`, but also `girl`, `boy`, `baby`, `teen`, `child`, `book`, `alcohol`, `smoking`, and the POI set) are hidden from tag lists, search, autocomplete (`tag.service.ts:186`) and tag pages (`pages/tag/[tagname].tsx`). They should not be displayed on votable chips either.

**Models leak. Images don't.**

- `ModelTag` has **no** unlisted filter — which is exactly why `model.controller.ts:1717` hand-filters for the model *page*. The votable-chip path had no equivalent, so it serves them. **Live today:** model 10128 serves the unlisted `girl` tag.
- The `ImageTag` view **already** excludes them. Its Tag lateral is `CROSS JOIN LATERAL (SELECT ... FROM "Tag" t_1 WHERE t_1.id = it."tagId" AND NOT t_1.unlisted LIMIT 1)` — a CROSS JOIN, so an unlisted tag drops the row entirely and can never reach `getVotableTags`. Confirmed on prod: image 136692785 carries a `loli` tag and serves 38 votable tags, **zero unlisted**.

> An earlier revision of this PR stripped the image path too, on the incorrect claim that it leaked. It doesn't. That strip was removed — it was redundant *and* cost a Redis roundtrip per image-detail view for a guarantee the view already makes.

## The fix

`stripUnlistedTags(tags, isModerator)`, applied to the **model branch of `getVotableTags` only**.

Resolves `unlisted` from the small `tagCache` rather than widening `modelTagCompositeSelect`, so unlisting a tag takes effect without purging the composite caches. (Imported as `basicTagCache` — a local `const tagCache` already exists at ~line 683.)

**Moderators keep unlisted tags** and short-circuit the lookup entirely. They need to see what content is flagged as; hiding `loli` from a mod reviewing a report would be actively harmful.

## Why this must land before the block removal

Today `loli`-tagged content is hidden outright, so its chip is unreachable. Remove that block first and the tag becomes visible on content that's now visible — content shown **and** the delisted tag advertised on it. Order: this first, block removal second.

## Scope note

This removes vote chips for **all 127** unlisted tags on models, not just the sensitive ones — `girl`, `book`, `alcohol` and friends included. That is the intended behaviour ("unlisted means never displayed"), but it is a broader UX change than the `loli` framing suggests, and it is visible: model 10128 goes from 3 chips to 2.

## Known and accepted — cache staleness on an `unlisted` flip

Nothing busts either cache when `Tag.unlisted` changes, so a tag unlisted *after* population keeps appearing until the entry expires:

| path | cache | TTL | stale window |
|---|---|---|---|
| image | `imageTagsCache` | 1h | ≤ 1h |
| model | `tagCache` | **1 day** | **≤ 24h** |

**Accepted in principle** — "It's fine if there's a one hour delay on something becoming unlisted." Note the model path (this fix) is the *longer* of the two at 24h, not 1h, which is worth knowing given ~18 tags are pending a manual `unlisted = true`.

**Operational remedy, no code needed:** purge `packed:caches:basic-tags*` (cache-purge skill) right after flipping tags, and the change is immediate.

## Testing

- 5 unit tests: model strip drops unlisted for normal users; mods keep them (and skip the cache lookup); listed tags untouched; no cache call on an empty set; and the image branch asserts **no** lookup happens (documenting the view guarantee rather than mocking a fiction).
- **Verified on dev as a real non-mod** (`isModerator: false`):
  - model 10128 → 2 tags (`anime`, `character`), `girl` stripped. Prod serves 3 including `girl`.
  - image 136692785 → 38 tags, none unlisted. Unchanged, as intended.
- Adjacent tag suites green (13/13: `tag.service.security`, `tagsOnImageNew.service`, `image-tagids-fetcher`).
- `pnpm typecheck` clean (2 pre-existing dependency errors unrelated to this diff).

## Notes

- Model **page** tags were already filtered (`model.controller.ts:1717`); this closes the votable-chip path, which wasn't.
- Display only — does not change what content is visible. That's the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
