### PR TITLE
feat(blocks): generic bounded image-workflow bridge (txt2img + img2img)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -611,6 +611,22 @@ describe('blocks.estimateWorkflow', () => {
       caller.estimateWorkflow({ blockToken: 'tok', body: validBody() })
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
+
+  it('rejects a source image (img2img) on a MODEL-bound token — img2img is PAGE-only in 2a', async () => {
+    // The default validClaims() is a model-bound token (ctx.modelId=7). img2img
+    // via sourceImage is a page-only feature this phase, so a model-bound token
+    // carrying one must be rejected fail-closed BEFORE any spend.
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.estimateWorkflow({
+        blockToken: 'tok',
+        body: validBody({
+          sourceImage: { url: 'https://image.civitai.com/abc/def.jpeg', width: 768, height: 1024 },
+        }),
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
 });
 
 describe('blocks.submitWorkflow', () => {
@@ -1085,6 +1101,19 @@ describe('blocks.submitWorkflow', () => {
     const caller = blocksRouter.createCaller(fakeCtx() as never);
     await expect(
       caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('rejects a source image (img2img) on a MODEL-bound token — img2img is PAGE-only in 2a', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.submitWorkflow({
+        blockToken: 'tok',
+        body: validBody({
+          sourceImage: { url: 'https://image.civitai.com/abc/def.jpeg', width: 768, height: 1024 },
+        }),
+      })
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -2523,6 +2523,16 @@ export const blocksRouter = router({
             message: 'additionalResources are not supported for model-bound blocks',
           });
         }
+        // IMAGE bridge (Phase-2a): img2img via `sourceImage` is a PAGE-ONLY
+        // feature. Custom Generators is a page app; model-bound img2img is out
+        // of scope and unvetted for 2a, so reject it fail-closed on the model
+        // path (mirrors the additionalResources guard above).
+        if (input.body.sourceImage) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'source image (img2img) is not supported for model-bound blocks',
+          });
+        }
       }
       const userId = parseSubjectUserId(claims.sub);
       if (userId == null) {
@@ -2668,6 +2678,15 @@ export const blocksRouter = router({
           throw new TRPCError({
             code: 'FORBIDDEN',
             message: 'additionalResources are not supported for model-bound blocks',
+          });
+        }
+        // IMAGE bridge (Phase-2a): img2img via `sourceImage` is PAGE-ONLY.
+        // Reject it fail-closed on the model path (see estimateWorkflow for the
+        // same guard). Custom Generators is a page app.
+        if (input.body.sourceImage) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'source image (img2img) is not supported for model-bound blocks',
           });
         }
       }

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -104,9 +104,16 @@ const blockTextToImageBodySchema = z.object({
   additionalResources: z.array(blockAdditionalResourceSchema).max(MAX_ADDITIONAL_RESOURCES).optional(),
   // Optional img2img init/source image (App Blocks IMAGE bridge, Phase-2a).
   // When present, the block bridge emits an `img2img` graph workflow (SD-family
-  // image variations) instead of `txt2img`; when absent, behavior is
+  // "Image Variations") instead of `txt2img`; when absent, behavior is
   // byte-identical to before (txt2img). Bounded to a Civitai-hosted image (see
   // blockSourceImageSchema) — never an arbitrary remote URL.
+  //
+  // Two hard scope limits are enforced downstream (NOT at the wire schema, which
+  // only bounds shape): (1) blocks.router rejects `sourceImage` on a MODEL-bound
+  // token — img2img is PAGE-only in 2a, mirroring `additionalResources`; (2)
+  // buildImageWorkflowInput rejects a non-SD-family checkpoint fail-closed —
+  // plain `img2img` is SD-family-only in the graph, and edit-capable ecosystems
+  // (Flux Kontext, Qwen → `img2img:edit`) are a Phase-2b follow-up.
   sourceImage: blockSourceImageSchema.optional(),
   // Optional viewer-picked buzz account to spend (money page blocks). Absent →
   // unchanged Auto behavior (domain-allowed currencies drained blue-first). When

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -11,9 +11,14 @@ import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 // surface; it never widens the allowed set.
 const blockAccountTypeSchema = z.enum(buzzSpendTypes as [BuzzSpendType, ...BuzzSpendType[]]);
 
-// v1: textToImage is the only block-supported kind. Adding a new kind here
-// must also (a) extend the discriminator in blocks.router workflow procedures,
-// (b) be exposed by @civitai/app-sdk's useBuzzWorkflow contract.
+// `textToImage` is the block-supported kind. It now covers the whole IMAGE
+// workflow class (App Blocks IMAGE bridge, Phase-2a): a bare body maps to a
+// `txt2img` graph workflow, and a body carrying a bounded `sourceImage` maps to
+// `img2img` — see buildImageWorkflowInput / BLOCK_IMAGE_WORKFLOW_TYPES in
+// workflow.service. A later phase adds a NON-image media class (video/audio/3D)
+// as a NEW discriminated-union `kind` here, which must also (a) extend the
+// discriminator in blocks.router workflow procedures, (b) be exposed by
+// @civitai/app-sdk's useBuzzWorkflow contract.
 //
 // Caps are intentionally tighter than the platform-wide generateImageSchema —
 // blocks run in untrusted iframes and the token issuer caps per-call buzz at
@@ -50,6 +55,44 @@ const blockAdditionalResourceSchema = z.object({
   strength: z.number().min(LORA_STRENGTH_MIN).max(LORA_STRENGTH_MAX).default(1),
 });
 
+// ── img2img source image (App Blocks IMAGE bridge, Phase-2a) ─────────────────
+// The block body is UNTRUSTED iframe input, so an init/source image MUST NOT be
+// an arbitrary remote URL the generator would fetch (SSRF / arbitrary-fetch).
+// It is bounded to a Civitai-controlled host. An uploaded image resolves to an
+// `https://orchestration…civitai.com` URL, so this same bound covers the
+// "uploaded image" case WITHOUT widening to attacker-controlled origins.
+//
+// This is validated by parsed URL HOSTNAME (not a substring match), which is
+// intentionally tighter than the platform's server `sourceImageSchema`
+// (`.includes('image.civitai.com')`) — a substring check would accept
+// `https://evil.example/?x=image.civitai.com`; a hostname check rejects it and
+// also rejects non-https, userinfo, and host-confusion tricks. Kept LOCAL
+// (rather than importing the server orchestrator schema) so this module stays
+// client-safe — it is `import type`'d by a client component (failureSnapshot).
+const CIVITAI_IMAGE_HOSTS = ['civitai.com', 'civitai.red', 'civitai.green'] as const;
+function isCivitaiHostedImageUrl(raw: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') return false;
+  const host = parsed.hostname.toLowerCase();
+  return CIVITAI_IMAGE_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
+}
+
+const blockSourceImageSchema = z.object({
+  url: z
+    .string()
+    .max(2048)
+    .refine(isCivitaiHostedImageUrl, 'source image must be a Civitai-hosted https image URL'),
+  // Dimension hints for the graph's denoise/aspect derivation. Bounded to the
+  // same block caps as params so an iframe can't send absurd dimensions.
+  width: z.coerce.number().int().min(DIM_MIN).max(DIM_MAX),
+  height: z.coerce.number().int().min(DIM_MIN).max(DIM_MAX),
+});
+
 const blockTextToImageBodySchema = z.object({
   kind: z.literal('textToImage'),
   modelId: z.number().int().positive(),
@@ -59,6 +102,12 @@ const blockTextToImageBodySchema = z.object({
   // base-model-family-matches against the checkpoint before any spend. Capped
   // at MAX_ADDITIONAL_RESOURCES for the iframe posture above.
   additionalResources: z.array(blockAdditionalResourceSchema).max(MAX_ADDITIONAL_RESOURCES).optional(),
+  // Optional img2img init/source image (App Blocks IMAGE bridge, Phase-2a).
+  // When present, the block bridge emits an `img2img` graph workflow (SD-family
+  // image variations) instead of `txt2img`; when absent, behavior is
+  // byte-identical to before (txt2img). Bounded to a Civitai-hosted image (see
+  // blockSourceImageSchema) — never an arbitrary remote URL.
+  sourceImage: blockSourceImageSchema.optional(),
   // Optional viewer-picked buzz account to spend (money page blocks). Absent →
   // unchanged Auto behavior (domain-allowed currencies drained blue-first). When
   // present, blocks.router moves it to the FRONT of the domain-allowed currency

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -1012,6 +1012,73 @@ describe('buildImageWorkflowInput (generalized image-workflow bridge)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// App Blocks IMAGE bridge (Phase-2a): img2img ecosystem fail-close guard
+//
+// Plain `img2img` ("Image Variations") is SD-family-only in the generation
+// graph. buildImageWorkflowInput must reject a non-SD-family checkpoint + source
+// image with BAD_REQUEST rather than let DataGraph.safeParse silently auto-
+// correct the ecosystem to SD1 and return a mis-routed graph as success.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('buildImageWorkflowInput img2img ecosystem guard (SD-family only in 2a)', () => {
+  const baseBody = {
+    kind: 'textToImage' as const,
+    modelId: 7,
+    modelVersionId: 99,
+    params: { prompt: 'a cat', quantity: 1 },
+    sourceImage: { url: 'https://image.civitai.com/abc/def.jpeg', width: 768, height: 1024 },
+  };
+  const resolved = (checkpointBaseModel: string) => ({
+    baseModel: checkpointBaseModel,
+    modelType: 'Checkpoint',
+    checkpointVersionId: 99,
+    checkpointBaseModel,
+  });
+
+  // baseModel → expected graph ecosystem key. These are the SD-family members
+  // configured for plain img2img (SD_FAMILY_IDS).
+  it.each([
+    ['SDXL 1.0', 'SDXL'],
+    ['SD 1.5', 'SD1'],
+    ['Pony', 'Pony'],
+    ['Illustrious', 'Illustrious'],
+    ['NoobAI', 'NoobAI'],
+  ])('builds img2img for SD-family checkpoint %s (ecosystem %s)', (baseModel, ecoKey) => {
+    const out = buildImageWorkflowInput(baseBody as never, resolved(baseModel));
+    expect(out.workflow).toBe('img2img');
+    expect(out.ecosystem).toBe(ecoKey);
+    expect(out.images).toHaveLength(1);
+  });
+
+  // Non-SD-family checkpoints: plain img2img is NOT available, so the builder
+  // must throw BAD_REQUEST (not silently emit an SD1-corrected graph). Covers
+  // edit-capable ecosystems (Flux Kontext, Qwen — Phase-2b) and others.
+  it.each(['Flux.1 D', 'Flux.1 Kontext', 'Qwen', 'SD 3.5', 'Chroma', 'SD 2.1'])(
+    'rejects img2img for non-SD-family checkpoint %s with BAD_REQUEST',
+    (baseModel) => {
+      let caught: unknown;
+      try {
+        buildImageWorkflowInput(baseBody as never, resolved(baseModel));
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(TRPCError);
+      expect(caught).toMatchObject({ code: 'BAD_REQUEST' });
+      expect((caught as TRPCError).message).toMatch(/SD-family/);
+    }
+  );
+
+  it('still builds txt2img (no source image) for a non-SD-family checkpoint (guard is img2img-only)', () => {
+    // The guard must not affect the txt2img path — a Flux block with no source
+    // image is unchanged.
+    const { sourceImage, ...txtBody } = baseBody;
+    void sourceImage;
+    const out = buildImageWorkflowInput(txtBody as never, resolved('Flux.1 D'));
+    expect(out.workflow).toBe('txt2img');
+    expect(out.ecosystem).toBe('Flux1');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // App Blocks IMAGE bridge (Phase-2a): source-image URL bound (untrusted iframe)
 // ─────────────────────────────────────────────────────────────────────────────
 describe('blockWorkflowBodySchema sourceImage bound (SSRF / arbitrary-URL guard)', () => {

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -17,12 +17,16 @@ const { mockDbRead } = vi.hoisted(() => ({
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead }));
 
 import {
+  buildImageWorkflowInput,
   buildTextToImageInput,
+  BLOCK_IMAGE_WORKFLOW_TYPES,
   isPageLoraResource,
+  resolveBlockImageWorkflowType,
   resolveBlockVersionContext,
   resolvePageResourceContext,
   snapshotFromWorkflow,
 } from '../workflow.service';
+import { blockWorkflowBodySchema } from '~/server/schema/blocks/workflow.schema';
 // REAL param-building path (no mocks): the generation graph validator and the
 // step-metadata snapshot fn are the exact functions the orchestrator's
 // `createWorkflowStepsFromGraph` runs to derive `workflowMetadata.params`. Both
@@ -862,5 +866,205 @@ describe('block input yields populated workflow metadata params (real graph path
       quantity: 2,
     });
     expect(params.aspectRatio).toMatchObject({ width: 512, height: 512 });
+  });
+
+  it('emitted img2img input validates through the REAL generation graph (SDXL)', () => {
+    // Proves the generalized bridge output is graph-valid end-to-end: a bounded
+    // source image → workflow:img2img with an images[] init node the SD-family
+    // graph accepts (denoise applies at its default; aspectRatio is dropped).
+    const body = {
+      kind: 'textToImage' as const,
+      modelId: 7,
+      modelVersionId: 99,
+      params: { prompt: 'a cat', quantity: 1 },
+      sourceImage: { url: 'https://image.civitai.com/abc/def.jpeg', width: 768, height: 1024 },
+    };
+    const resolved = {
+      baseModel: 'SDXL 1.0',
+      modelType: 'Checkpoint',
+      checkpointVersionId: 99,
+      checkpointBaseModel: 'SDXL 1.0',
+    };
+    const input = buildImageWorkflowInput(body as never, resolved);
+    const result = generationGraph.safeParse(input, externalCtx);
+    if (!result.success) {
+      throw new Error(`img2img graph validation failed: ${JSON.stringify(result.errors)}`);
+    }
+    expect((result.data as { workflow: string }).workflow).toBe('img2img');
+    const images = (result.data as { images?: Array<{ url: string }> }).images;
+    expect(images).toEqual([
+      expect.objectContaining({ url: 'https://image.civitai.com/abc/def.jpeg' }),
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App Blocks IMAGE bridge (Phase-2a): generalized image-workflow builder
+// ─────────────────────────────────────────────────────────────────────────────
+describe('buildImageWorkflowInput (generalized image-workflow bridge)', () => {
+  const baseBody = {
+    kind: 'textToImage' as const,
+    modelId: 7,
+    modelVersionId: 99,
+    params: { prompt: 'a cat', quantity: 1 },
+  };
+  const checkpointResolved = {
+    baseModel: 'SDXL 1.0',
+    modelType: 'Checkpoint',
+    checkpointVersionId: 99,
+    checkpointBaseModel: 'SDXL 1.0',
+  };
+  const validSourceImage = {
+    url: 'https://image.civitai.com/abc/def.jpeg',
+    width: 768,
+    height: 1024,
+  };
+
+  it('exposes exactly the image workflow allowlist (txt2img, img2img)', () => {
+    expect([...BLOCK_IMAGE_WORKFLOW_TYPES]).toEqual(['txt2img', 'img2img']);
+  });
+
+  it('resolveBlockImageWorkflowType derives img2img with a source image, txt2img without', () => {
+    expect(resolveBlockImageWorkflowType(baseBody as never)).toBe('txt2img');
+    expect(
+      resolveBlockImageWorkflowType({ ...baseBody, sourceImage: validSourceImage } as never)
+    ).toBe('img2img');
+  });
+
+  it('emits workflow:img2img + an images[] init image when a source image is present', () => {
+    const body = { ...baseBody, sourceImage: validSourceImage };
+    const out = buildImageWorkflowInput(body as never, checkpointResolved);
+    expect(out.workflow).toBe('img2img');
+    // The graph's imagesNode consumes { url, width, height }.
+    expect(out.images).toEqual([
+      { url: 'https://image.civitai.com/abc/def.jpeg', width: 768, height: 1024 },
+    ]);
+    // Dimensions come from the source image in img2img → aspectRatio is omitted
+    // (the SD graph gates aspectRatio to `when: !hasImages`).
+    expect(out.aspectRatio).toBeUndefined();
+    // The checkpoint anchor + cost-profile fields are unchanged.
+    expect(out.model).toEqual({ id: 99 });
+    expect(out.quantity).toBe(1);
+    expect(out.priority).toBe('low');
+  });
+
+  it('emits workflow:txt2img (with aspectRatio, no images) when there is no source image', () => {
+    const out = buildImageWorkflowInput(baseBody as never, checkpointResolved);
+    expect(out.workflow).toBe('txt2img');
+    expect(out.images).toBeUndefined();
+    expect(out.aspectRatio).toMatchObject({ width: 1024, height: 1024 });
+  });
+
+  it('buildTextToImageInput is the same builder (back-compat alias) and stays txt2img-compatible', () => {
+    expect(buildTextToImageInput).toBe(buildImageWorkflowInput);
+    const out = buildTextToImageInput(baseBody as never, checkpointResolved);
+    expect(out.workflow).toBe('txt2img');
+  });
+
+  it('rejects a non-image (explicit) workflow type fail-closed with BAD_REQUEST', () => {
+    let caught: unknown;
+    try {
+      buildImageWorkflowInput(baseBody as never, checkpointResolved, 'txt2vid');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect(caught).toMatchObject({ code: 'BAD_REQUEST' });
+    expect((caught as TRPCError).message).toMatch(/only image workflows/);
+  });
+
+  it('preserves the LoRA-stack fan-out on the img2img path (gates + resources unchanged)', () => {
+    // The additionalResources fan-out (each entry gated per-item upstream in the
+    // router) must apply identically whether or not a source image is present —
+    // generalizing the builder must not drop the resource path.
+    const body = {
+      ...baseBody,
+      sourceImage: validSourceImage,
+      additionalResources: [
+        { modelVersionId: 201, strength: 0.8 },
+        { modelVersionId: 202, strength: 1.2 },
+      ],
+    };
+    const out = buildImageWorkflowInput(body as never, checkpointResolved);
+    expect(out.workflow).toBe('img2img');
+    expect(out.model).toEqual({ id: 99 });
+    expect(out.resources).toEqual([
+      { id: 201, strength: 0.8 },
+      { id: 202, strength: 1.2 },
+    ]);
+    // The init image rides alongside the resources — both are present.
+    expect(out.images).toHaveLength(1);
+  });
+
+  it('carries the same cost-profile fields on img2img as txt2img (budget preflight sees the same shape)', () => {
+    // The router's budget preflight costs the built input via the orchestrator
+    // whatIf. Generalizing to img2img must not change the fields that drive cost
+    // (quantity / priority / prompt / resources) — only add the init image.
+    const txt = buildImageWorkflowInput(baseBody as never, checkpointResolved);
+    const img = buildImageWorkflowInput(
+      { ...baseBody, sourceImage: validSourceImage } as never,
+      checkpointResolved
+    );
+    for (const key of ['quantity', 'priority', 'prompt', 'model', 'resources', 'ecosystem']) {
+      expect(img[key]).toEqual(txt[key]);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App Blocks IMAGE bridge (Phase-2a): source-image URL bound (untrusted iframe)
+// ─────────────────────────────────────────────────────────────────────────────
+describe('blockWorkflowBodySchema sourceImage bound (SSRF / arbitrary-URL guard)', () => {
+  const baseBody = {
+    kind: 'textToImage' as const,
+    modelId: 7,
+    modelVersionId: 99,
+    params: { prompt: 'a cat', quantity: 1 },
+  };
+  function parseWithSource(url: string) {
+    return blockWorkflowBodySchema.safeParse({
+      ...baseBody,
+      sourceImage: { url, width: 768, height: 1024 },
+    });
+  }
+
+  it('accepts a body with NO source image (byte-compatible txt2img path)', () => {
+    const res = blockWorkflowBodySchema.safeParse(baseBody);
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts a Civitai-hosted https source image (orchestrator / CDN / apex)', () => {
+    expect(parseWithSource('https://orchestration.civitai.com/v2/blobs/abc.jpeg').success).toBe(
+      true
+    );
+    expect(parseWithSource('https://image.civitai.com/abc/def.jpeg').success).toBe(true);
+    expect(parseWithSource('https://civitai.com/images/xyz.jpeg').success).toBe(true);
+    expect(parseWithSource('https://image.civitai.red/abc/def.jpeg').success).toBe(true);
+  });
+
+  it('rejects an arbitrary/remote source-image URL', () => {
+    expect(parseWithSource('https://evil.example/x.png').success).toBe(false);
+    expect(parseWithSource('https://cdn.attacker.io/leak.png').success).toBe(false);
+  });
+
+  it('rejects a non-https URL (no http SSRF)', () => {
+    expect(parseWithSource('http://image.civitai.com/abc.jpeg').success).toBe(false);
+    expect(parseWithSource('ftp://image.civitai.com/abc.jpeg').success).toBe(false);
+  });
+
+  it('rejects a host-confusion URL that merely CONTAINS a civitai host as a substring', () => {
+    // The bound is hostname-based, not substring — so this attacker origin is
+    // rejected where a `.includes("image.civitai.com")` check would accept it.
+    expect(parseWithSource('https://evil.example/?x=image.civitai.com').success).toBe(false);
+    expect(parseWithSource('https://image.civitai.com.evil.example/x.png').success).toBe(false);
+  });
+
+  it('rejects out-of-bound source-image dimensions', () => {
+    expect(
+      blockWorkflowBodySchema.safeParse({
+        ...baseBody,
+        sourceImage: { url: 'https://image.civitai.com/a.jpeg', width: 99999, height: 1024 },
+      }).success
+    ).toBe(false);
   });
 });

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -252,13 +252,45 @@ function defaultDimensions(baseModel: string): { width: number; height: number }
   }
 }
 
+// ── Bounded image-workflow allowlist (App Blocks IMAGE bridge, Phase-2a) ─────
+// The block bridge maps an untrusted block body into a generation-graph input.
+// This phase deliberately produces ONLY image graph workflows. The workflow
+// type is a validated value (checked against this allowlist), never a
+// hardcoded literal — so a body can never drive the block bridge into a
+// non-image graph workflow.
+//
+// EXTENDING to a new media class later (video/audio/3D) is additive and does
+// NOT require a rewrite: (1) add the graph workflow key(s) here, (2) add a
+// per-type param-mapping branch in buildImageWorkflowInput below (its own
+// bounded validator for that class's params), and (3) add the corresponding
+// discriminated-union `kind` in workflow.schema. Everything else — the
+// resource fan-out, the router's per-item entitlement gate, the LoRA gate, the
+// budget preflight — is workflow-type-agnostic and stays as-is.
+export const BLOCK_IMAGE_WORKFLOW_TYPES = ['txt2img', 'img2img'] as const;
+export type BlockImageWorkflowType = (typeof BLOCK_IMAGE_WORKFLOW_TYPES)[number];
+
+function isBlockImageWorkflowType(workflow: string): workflow is BlockImageWorkflowType {
+  return (BLOCK_IMAGE_WORKFLOW_TYPES as readonly string[]).includes(workflow);
+}
+
+/**
+ * Resolve which image graph workflow a block body maps to: `img2img` when a
+ * bounded source/init image is present (image variations), else `txt2img`.
+ * Purely structural — the schema already validated/bounded `sourceImage`.
+ */
+export function resolveBlockImageWorkflowType(
+  body: Extract<BlockWorkflowBody, { kind: 'textToImage' }>
+): BlockImageWorkflowType {
+  return body.sourceImage ? 'img2img' : 'txt2img';
+}
+
 /**
  * Translate the block's narrow body into the platform's generation-graph
  * `input` (the flat `Record<string, unknown>` shape `generateFromGraph` /
- * `createWorkflowStepsFromGraphInput` consume). Defaults are intentionally
- * conservative — matches the comics-router preset (sampler=Euler, steps=25,
- * priority=low) so block submissions and platform submissions share the same
- * orchestrator cost profile.
+ * `createWorkflowStepsFromGraphInput` consume), for the IMAGE workflow class
+ * (txt2img / img2img). Defaults are intentionally conservative — matches the
+ * comics-router preset (sampler=Euler, steps=25, priority=low) so block
+ * submissions and platform submissions share the same orchestrator cost profile.
  *
  * Migrated off the deleted legacy `createTextToImageStep` path (which consumed
  * the old `{ params, resources }` `GenerateImageSchema`). The new graph
@@ -279,21 +311,36 @@ function defaultDimensions(baseModel: string): { width: number; height: number }
  * model is its own anchor). For LoRA installs the resolver returns a different
  * checkpoint; the bound LoRA is pushed into `resources`.
  *
- * DIMENSIONS: the graph's `aspectRatio` node snaps the block-supplied
+ * WORKFLOW TYPE: `workflowType` defaults to the type derived from the body
+ * (`sourceImage` presence → img2img, else txt2img) and is VALIDATED against
+ * BLOCK_IMAGE_WORKFLOW_TYPES — a non-image type is rejected fail-closed with a
+ * BAD_REQUEST rather than silently producing a workflow this phase does not
+ * support. The explicit parameter is the seam a later phase / an explicit-type
+ * body flows through; the router passes nothing and gets the derived type.
+ *
+ * DIMENSIONS: for txt2img the graph's `aspectRatio` node snaps the block-supplied
  * width/height to the ecosystem's nearest canonical bucket (the block sends
- * arbitrary 64–2048 dims from untrusted iframe UI). This is a deliberate
- * behavior change from the deleted path, which passed exact dims through — the
- * orchestrator prefers canonical dims and the main generator already snaps.
+ * arbitrary 64–2048 dims from untrusted iframe UI). For img2img the graph derives
+ * output dimensions from the source image, so aspectRatio is omitted.
  */
-export function buildTextToImageInput(
+export function buildImageWorkflowInput(
   body: Extract<BlockWorkflowBody, { kind: 'textToImage' }>,
   resolved: {
     baseModel: string;
     modelType: string;
     checkpointVersionId: number;
     checkpointBaseModel: string;
-  }
+  },
+  workflowType: string = resolveBlockImageWorkflowType(body)
 ): Record<string, unknown> {
+  if (!isBlockImageWorkflowType(workflowType)) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `unsupported block workflow type '${workflowType}' — only image workflows (${BLOCK_IMAGE_WORKFLOW_TYPES.join(
+        ', '
+      )}) are supported`,
+    });
+  }
   const dims = defaultDimensions(resolved.checkpointBaseModel);
   const width = body.params.width ?? dims.width;
   const height = body.params.height ?? dims.height;
@@ -325,8 +372,8 @@ export function buildTextToImageInput(
   // unrecognized — the resource belt will still gate it.
   const ecosystem = getEcosystem(resolved.checkpointBaseModel)?.key ?? 'SDXL';
 
-  return {
-    workflow: 'txt2img',
+  const input: Record<string, unknown> = {
+    workflow: workflowType,
     ecosystem,
     model: { id: resolved.checkpointVersionId },
     resources,
@@ -340,10 +387,38 @@ export function buildTextToImageInput(
     // pipelines have no clipSkip node (silently ignored); SD1/SDXL apply it at
     // the CLIP-encoder node. Omit when not set so the ecosystem uses its default.
     ...(body.params.clipSkip != null ? { clipSkip: body.params.clipSkip } : {}),
-    // The aspectRatio node accepts { value, width, height } and snaps to the
-    // nearest bucket by dimensions — see the DIMENSIONS note above.
-    aspectRatio: { value: `${width}:${height}`, width, height },
     quantity: body.params.quantity,
     priority: 'low',
   };
+
+  if (workflowType === 'img2img') {
+    // img2img (SD-family image variations): the graph's `images` node is the
+    // init image; the denoise node applies at its default strength (0.75), and
+    // the graph derives output dimensions from the source image — so aspectRatio
+    // is OMITTED here (the SD graph gates aspectRatio to `when: !hasImages`).
+    // `sourceImage` is guaranteed present here (resolveBlockImageWorkflowType
+    // only returns 'img2img' when the body carries one); the fallback keeps the
+    // types honest for an explicit-type caller. The graph's imagesNode reads
+    // { url, width, height }; extra fields are stripped by its object parse.
+    if (body.sourceImage) {
+      input.images = [
+        {
+          url: body.sourceImage.url,
+          width: body.sourceImage.width,
+          height: body.sourceImage.height,
+        },
+      ];
+    }
+    return input;
+  }
+
+  // txt2img: the aspectRatio node accepts { value, width, height } and snaps to
+  // the nearest bucket by dimensions — see the DIMENSIONS note above.
+  input.aspectRatio = { value: `${width}:${height}`, width, height };
+  return input;
 }
+
+// Back-compat alias. Existing router call sites + tests reference
+// `buildTextToImageInput`; it is now the IMAGE-class builder (txt2img when the
+// body has no source image — byte-identical to before — img2img when it does).
+export const buildTextToImageInput = buildImageWorkflowInput;

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -4,6 +4,7 @@ import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { dbRead } from '~/server/db/client';
 import { getBaseModelSetType } from '~/shared/constants/generation.constants';
 import { getEcosystem } from '~/shared/constants/basemodel.constants';
+import { isWorkflowAvailable } from '~/shared/data-graph/generation/config/workflows';
 import { ModelType } from '~/shared/utils/prisma/enums';
 import type {
   BlockWorkflowBody,
@@ -370,7 +371,29 @@ export function buildImageWorkflowInput(
   // Ecosystem drives the graph's branch + resource enrichment. Fall back to
   // SDXL (the graph's ultimate fallback) if the checkpoint's baseModel is
   // unrecognized — the resource belt will still gate it.
-  const ecosystem = getEcosystem(resolved.checkpointBaseModel)?.key ?? 'SDXL';
+  const ecoRecord = getEcosystem(resolved.checkpointBaseModel);
+  const ecosystem = ecoRecord?.key ?? 'SDXL';
+
+  // img2img fail-CLOSED ecosystem guard (Phase-2a). Plain `img2img`
+  // ("Image Variations") is configured SD-family-only in the generation graph
+  // (config/workflows: SD_FAMILY_IDS = SD1/SDXL/Pony/Illustrious/NoobAI). We
+  // MUST reject a non-SD-family checkpoint here rather than lean on the graph:
+  // `DataGraph.safeParse` runs its auto-correct pass (`_evaluate`) BEFORE
+  // `_validate`, so a Flux / Flux Kontext / Qwen / SD3 / Chroma / SD2 checkpoint
+  // would be silently REWRITTEN to `ecosystem: 'SD1'` (while keeping the caller's
+  // checkpoint version id) and returned as a SUCCESSFUL but mis-routed graph —
+  // the whatIf preflight would price that mis-route too. Deriving support from
+  // `isWorkflowAvailable('img2img', …)` keeps this in lockstep with the graph
+  // config (single source of truth). Edit-capable ecosystems (Flux Kontext,
+  // Qwen) route through `img2img:edit`, NOT plain `img2img` — mapping those is a
+  // Phase-2b follow-up; for 2a every non-SD-family checkpoint + source image is
+  // a hard BAD_REQUEST.
+  if (workflowType === 'img2img' && (!ecoRecord || !isWorkflowAvailable('img2img', ecoRecord.id))) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `img2img (source image) is only supported for SD-family checkpoints (SD1/SDXL/Pony/Illustrious/NoobAI) in this phase; base model '${resolved.checkpointBaseModel}' is not supported`,
+    });
+  }
 
   const input: Record<string, unknown> = {
     workflow: workflowType,


### PR DESCRIPTION
## What

Phase-2a PR-A of the first-party Custom Generators App Blocks app: extend the block generation bridge from **txt2img-only** to a **generic, bounded graph-input mapping enabled for the IMAGE workflow class** (`txt2img` + `img2img`), structured so later phases add video/audio/3D incrementally.

**Server-side only.** The host (`IframeHost`/`PageBlockHost`) already forwards the block's generation `body` verbatim to the server, so no host/client changes are needed.

## Changes

- **`schema/blocks/workflow.schema.ts`** — add an optional `sourceImage` field (`{ url, width, height }`) to the `textToImage` block body. The URL is bounded by a **hostname-based Civitai-host allowlist** (`civitai.com` / `.red` / `.green`, https only). An uploaded image resolves to an `orchestration…civitai.com` URL, so the same bound covers "uploaded image" without accepting arbitrary remote URLs. Dimensions are capped to the existing block `DIM_MIN..DIM_MAX` bounds.
- **`services/blocks/workflow.service.ts`** — generalize `buildTextToImageInput` → `buildImageWorkflowInput`, driven by a validated `BLOCK_IMAGE_WORKFLOW_TYPES` allowlist (`['txt2img','img2img']`). The workflow type is derived from `sourceImage` presence (img2img → SD-family image variations, `images[]` init node, default denoise; else txt2img) and validated — a non-image type is rejected fail-closed with a `BAD_REQUEST`. `buildTextToImageInput` is kept as a back-compat alias.
- **Tests** — img2img emission + **real generation-graph validity**, txt2img unchanged, non-image type rejected, arbitrary/remote + host-confusion + non-https source URLs rejected, out-of-bound dims rejected, LoRA-stack fan-out preserved on the img2img path, and the cost-profile fields (budget preflight input) unchanged.

## Security / safety posture

- The block body is untrusted iframe input. `sourceImage` is Zod-validated and **hostname-bounded** (parsed-URL hostname, not a substring match — so `https://evil.example/?x=image.civitai.com` and `https://image.civitai.com.evil.example/x.png` are rejected, and non-https is rejected). No SSRF / arbitrary-fetch surface is introduced.
- **Additive / dark:** a body with no `sourceImage` produces byte-identical `txt2img` output. There is no live consumer yet (the app ships later), so existing blocks are unaffected.
- All existing gates are workflow-type-agnostic and unchanged: per-item `resolveCanGenerateForVersions` (fail-closed), the page LoRA gate (`resolvePageLoraGates`), and the buzz budget preflight (`BUZZ_BUDGET_CAP` / daily cap). Attribution creator dimension, the output-queue read model, per-app spend cap, and budget tiering are **not** touched (separate wave-2 PRs).

## Extensibility

Adding a non-image media class later (video/audio/3D) is additive: (1) add the graph workflow key(s) to `BLOCK_IMAGE_WORKFLOW_TYPES`, (2) add a per-type param-mapping branch in `buildImageWorkflowInput` (its own bounded validator), and (3) add the corresponding discriminated-union `kind` in the schema. The resource fan-out, router gates, and budget preflight stay as-is.

## Co-requisite (not blocking)

The `@civitai/app-sdk` block **body** contract is external (not in this repo). It needs a matching optional `sourceImage` field so app authors can send an init image. This PR does not depend on that change — the server accepts the field as soon as the SDK emits it.

## Scope note (honest)

`img2img` maps to the SD-family "Image Variations" graph workflow (denoise-based), which covers SD1/SDXL/Pony/Illustrious/NoobAI. Non-SD-family checkpoints (Flux, Flux Kontext, Qwen, SD3.5, Chroma, SD2.1) are **rejected fail-closed with a `BAD_REQUEST` by an explicit ecosystem guard in `buildImageWorkflowInput`** — NOT left to graph validation. (`DataGraph.safeParse` runs its auto-correct pass before validation, so it would silently rewrite a non-SD ecosystem to SD1 and return a mis-routed graph as success; the guard prevents that.) Edit-capable ecosystems (Flux Kontext, Qwen → `img2img:edit`) are a **Phase-2b** follow-up.

img2img is **PAGE-only** in 2a: `sourceImage` on a MODEL-bound token is rejected (`FORBIDDEN`) in both `estimateWorkflow` and `submitWorkflow`, mirroring the page-only `additionalResources` guard. Custom Generators is a page app; model-bound img2img is out of scope + unvetted for 2a.

### Audit fix (commit 2)

The initial commit emitted `img2img` for any checkpoint and enabled it on both surfaces. A pre-merge audit caught that this mis-routed non-SD-family checkpoints (silent SD1 auto-correction) and that img2img should be page-locked. Both are fixed above; per-ecosystem builder tests + model-bound-rejection router tests were added.

## Testing

- `vitest run src/server/services/blocks/__tests__/workflow.service.test.ts` → **74 passing** (img2img emission + real-graph validity, per-ecosystem SD-family-builds / non-SD-BAD_REQUEST guard, source-image URL bound, txt2img byte-compat).
- `vitest run src/server/routers/__tests__/blocks.router.workflow.test.ts` → **139 passing** (incl. new model-bound `sourceImage` rejection in estimate + submit).
- `NODE_OPTIONS=--max_old_space_size=8192 tsc --noEmit` clean; no errors in any touched file.
- Not run against prod.


