### PR TITLE
fix(images): a mod rating counts as reviewed when the scan never landed

### DIFF
--- a/src/server/common/__tests__/image-visibility.test.ts
+++ b/src/server/common/__tests__/image-visibility.test.ts
@@ -1,35 +1,45 @@
 import { describe, it, expect } from 'vitest';
 import { imageReviewedSql } from '~/server/common/image-visibility';
 
-// Guards the rule, not the formatting: a mod-locked rating stands in for a scan that
-// never landed, but must never resurrect Blocked/Error/NotFound. Dropping that half
-// would expose every mod-rated ToS removal (311 rows in prod when this was written).
 const render = (alias?: string) => {
   const sql = alias ? imageReviewedSql(alias) : imageReviewedSql();
-  return sql.strings.reduce((acc, s, i) => acc + s + (sql.values[i] ?? ''), '');
+  return sql.strings
+    .reduce((acc, s, i) => acc + s + (i < sql.values.length ? String(sql.values[i]) : ''), '')
+    .replace(/\s+/g, ' ')
+    .trim();
 };
 
 describe('imageReviewedSql', () => {
-  it('accepts Scanned', () => {
-    expect(render()).toContain('Scanned');
+  // Pins the whole shape, not keywords. A string-match test would still pass with the
+  // OR and AND swapped — which is the one mistake that would expose every mod-rated
+  // ToS removal (311 Blocked rows in prod when this was written).
+  it('renders scanned OR (mod-rated AND not terminal)', () => {
+    expect(render()).toBe(
+      '( "i"."ingestion" = Scanned::"ImageIngestionStatus" ' +
+        'OR ( "i"."nsfwLevelLocked" = TRUE ' +
+        'AND "i"."ingestion" NOT IN (Blocked::"ImageIngestionStatus",Error::"ImageIngestionStatus",NotFound::"ImageIngestionStatus") ) )'
+    );
   });
 
-  it('accepts a mod-locked rating in place of a scan', () => {
+  it('keeps the terminal exclusion inside the mod-rated branch, not the top level', () => {
     const sql = render();
-    expect(sql).toContain('nsfwLevelLocked');
-    expect(sql).toMatch(/nsfwLevelLocked"?\s*=\s*TRUE/);
+    const orIndex = sql.indexOf('OR');
+    // Both halves of the mod-rated branch must sit after the OR: if NOT IN escaped to
+    // the top level it would filter Scanned images too, and if the AND became an OR a
+    // mod rating alone would satisfy the predicate.
+    expect(sql.indexOf('nsfwLevelLocked')).toBeGreaterThan(orIndex);
+    expect(sql.indexOf('NOT IN')).toBeGreaterThan(sql.indexOf('nsfwLevelLocked'));
+    expect(sql).not.toMatch(/nsfwLevelLocked"\s*=\s*TRUE\s*\)?\s*OR/);
   });
 
-  it('never lets a mod rating override Blocked, Error or NotFound', () => {
-    const sql = render();
-    expect(sql).toContain('NOT IN');
+  it('excludes every terminal state a mod rating must not override', () => {
     for (const terminal of ['Blocked', 'Error', 'NotFound']) {
-      expect(sql).toContain(terminal);
+      expect(render()).toContain(`${terminal}::"ImageIngestionStatus"`);
     }
   });
 
-  it('defaults to the `i` alias and honours an override', () => {
-    expect(render()).toContain('"i"."ingestion"');
+  it('honours an alias override', () => {
     expect(render('img')).toContain('"img"."ingestion"');
+    expect(render('img')).not.toContain('"i"."ingestion"');
   });
 });

--- a/src/server/common/__tests__/image-visibility.test.ts
+++ b/src/server/common/__tests__/image-visibility.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { imageReviewedSql } from '~/server/common/image-visibility';
+
+// Guards the rule, not the formatting: a mod-locked rating stands in for a scan that
+// never landed, but must never resurrect Blocked/Error/NotFound. Dropping that half
+// would expose every mod-rated ToS removal (311 rows in prod when this was written).
+const render = (alias?: string) => {
+  const sql = alias ? imageReviewedSql(alias) : imageReviewedSql();
+  return sql.strings.reduce((acc, s, i) => acc + s + (sql.values[i] ?? ''), '');
+};
+
+describe('imageReviewedSql', () => {
+  it('accepts Scanned', () => {
+    expect(render()).toContain('Scanned');
+  });
+
+  it('accepts a mod-locked rating in place of a scan', () => {
+    const sql = render();
+    expect(sql).toContain('nsfwLevelLocked');
+    expect(sql).toMatch(/nsfwLevelLocked"?\s*=\s*TRUE/);
+  });
+
+  it('never lets a mod rating override Blocked, Error or NotFound', () => {
+    const sql = render();
+    expect(sql).toContain('NOT IN');
+    for (const terminal of ['Blocked', 'Error', 'NotFound']) {
+      expect(sql).toContain(terminal);
+    }
+  });
+
+  it('defaults to the `i` alias and honours an override', () => {
+    expect(render()).toContain('"i"."ingestion"');
+    expect(render('img')).toContain('"img"."ingestion"');
+  });
+});

--- a/src/server/common/image-visibility.ts
+++ b/src/server/common/image-visibility.ts
@@ -1,0 +1,30 @@
+import { Prisma } from '@prisma/client';
+import { ImageIngestionStatus } from '~/shared/utils/prisma/enums';
+
+// Terminal states a mod rating must never override — Blocked is a ToS removal, and
+// Error/NotFound mean there's no usable image behind the row.
+const ingestionStatesModRatingCannotOverride: ImageIngestionStatus[] = [
+  ImageIngestionStatus.Blocked,
+  ImageIngestionStatus.Error,
+  ImageIngestionStatus.NotFound,
+];
+
+/**
+ * Scans stall. When one does, the image keeps `ingestion = 'Pending'` forever and
+ * stays invisible to everyone but moderators — even after a mod rates it, because
+ * `updateImageNsfwLevel` sets the level but not the ingestion state. A locked rating
+ * is a human decision, so it counts as reviewed here in place of a scan that never
+ * arrived.
+ */
+export const imageReviewedSql = (alias = 'i') => {
+  const t = Prisma.raw(`"${alias}"`);
+  return Prisma.sql`(
+    ${t}."ingestion" = ${ImageIngestionStatus.Scanned}::"ImageIngestionStatus"
+    OR (
+      ${t}."nsfwLevelLocked" = TRUE
+      AND ${t}."ingestion" NOT IN (${Prisma.join(
+    ingestionStatesModRatingCannotOverride.map((s) => Prisma.sql`${s}::"ImageIngestionStatus"`)
+  )})
+    )
+  )`;
+};

--- a/src/server/search-index/images.search-index.ts
+++ b/src/server/search-index/images.search-index.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 import { chunk } from 'lodash-es';
 import type { FilterableAttributes, SearchableAttributes, SortableAttributes } from 'meilisearch';
 import { clickhouse } from '~/server/clickhouse/client';
+import { imageReviewedSql } from '~/server/common/image-visibility';
 import { IMAGES_SEARCH_INDEX } from '~/server/common/constants';
 import type { NsfwLevel } from '~/server/common/enums';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
@@ -153,7 +154,7 @@ type BaseImage = {
 
 const imageWhere = [
   Prisma.sql`i."postId" IS NOT NULL`,
-  Prisma.sql`i."ingestion" = ${ImageIngestionStatus.Scanned}::"ImageIngestionStatus"`,
+  imageReviewedSql(),
   Prisma.sql`i."tosViolation" = false`,
   Prisma.sql`i."needsReview" IS NULL`,
   Prisma.sql`i."minor" = false`,

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -18,6 +18,7 @@ import {
   METRICS_IMAGES_SEARCH_INDEX,
   nsfwRestrictedBaseModels,
 } from '~/server/common/constants';
+import { imageReviewedSql } from '~/server/common/image-visibility';
 import {
   BlockedReason,
   ImageScanType,
@@ -4876,7 +4877,7 @@ export const getImage = async ({
     AND.push(
       Prisma.sql`(${Prisma.join(
         [
-          Prisma.sql`i."needsReview" IS NULL AND i.ingestion = ${ImageIngestionStatus.Scanned}::"ImageIngestionStatus"`,
+          Prisma.sql`i."needsReview" IS NULL AND ${imageReviewedSql()}`,
           withoutPost
             ? null
             : Prisma.sql`


### PR DESCRIPTION
An image whose scan stalls keeps `ingestion = 'Pending'` forever and stays invisible to everyone but moderators — **even after a moderator rates it**. Reported via a `.red` image 404 (`images/136553838`: `nsfwLevel 16`, `nsfwLevelLocked true`, `scannedAt null`, `ingestion Pending`).

## Why it happens

`updateImageNsfwLevel` (the path a mod takes to set a rating) writes only:

```js
data: { nsfwLevel, nsfwLevelLocked: true, metadata: updatedMetadata }
```

It never touches `ingestion`. The flow that *does* — `handleUnblockImages` (`image.service.ts:568-578`, `ingestion = 'Scanned'` + `scannedAt = NOW()`) — is a different path. So a mod rating an image with a stalled scan changes nothing about its visibility, silently.

## Approach

Two options were on the table:

1. Have the mod path flip `ingestion` to `'Scanned'`.
2. Treat a locked rating as standing in for the scan where ingestion gates visibility.

**(2)**, because (1) would claim a scan that never happened. A locked rating is a human decision and the stronger signal; the image is simply tagless (no WD14 tags), which is strictly better than invisible. A mod can re-run the scan if tags are wanted.

## The guard — the important half

A mod rating **never** overrides `Blocked`, `Error` or `NotFound`. Blocked is a ToS removal; Error/NotFound mean there's no usable image behind the row.

Without that clause, **311 mod-rated Blocked images in prod today would become visible.** That's the whole reason this isn't a one-liner.

## Changes

- **`src/server/common/image-visibility.ts`** (new) — `imageReviewedSql(alias)`, one definition of the rule so the call sites can't drift.
- **`getImage`** — the detail-page gate (`needsReview IS NULL AND ingestion = 'Scanned'`) → uses the fragment. Fixes the 404.
- **`images.search-index`** — `imageWhere` required `ingestion = 'Scanned'`, so these images weren't *indexed* either. Fixing only the detail page would have left them permanently unindexable.

  **Caveat (found in review):** this half does **not** retroactively index the 13. `updateImageNsfwLevel` has its `imagesSearchIndex.updateSync(...)` **commented out** (`image.service.ts:6807-6809` — the index locks on single-image updates at its current size), so a mod rating never queues the row. The change makes those images *eligible* whenever something else queues them or on the next full reindex; it doesn't queue them itself. The `getImage` 404 fix — the reported bug — works immediately and unconditionally.

## Verification (against prod)

| set | count | passes new predicate |
|---|---|---|
| Pending + mod-rated (the bug) | 13 | **13** ✓ |
| **Blocked** + mod-rated | **311** | **0** ✓ |
| Error + mod-rated | 11 | **0** ✓ |
| NotFound + mod-rated | 19 | **0** ✓ |

- 4 unit tests pin the rendered **shape**, not keywords — a keyword test would pass with the inner `AND` swapped for an `OR`, which is precisely the mistake that leaks Blocked content. **Verified by mutation:** flipping that `AND` to `OR` fails 2 tests.
- `pnpm typecheck` clean.

## Review

Independent adversarial review: **PASS**. Load-bearing findings:

- **The safety premise is verified, not assumed:** `nsfwLevelLocked = true` is written in exactly three places, all moderator-only (`image.service.ts:6804` inside `if (isModerator)`, `:7118`, and `pages/api/mod/retool/image.ts`). The scanner paths that reference it are `select`s, not writes — a scanner can never self-lock a row into visibility.
- **`PendingManualAssignment` / `Rescan` are correctly left un-excluded.** The repo's own taxonomy (`blocks/app-listing-assets.service.ts:366-383`) treats NotFound + Blocked as terminal and Pending / Error-retry / PendingManualAssignment as non-terminal "still scanning". This guard excludes a superset of terminal (adds Error), and anything genuinely queued for a human is still caught by the separately-AND-ed `needsReview IS NULL`.
- **Precedence is safe at both call sites.** The fragment self-parenthesizes, so `getImage` renders `(needsReview IS NULL AND (frag)) OR collection OR owner` — preserving the pre-existing owner/contributor escapes without widening them — and `imageWhere` joins with `AND`.
- **No index consumer assumes `Scanned`:** `ingestion` is absent from `BaseImage` and the transform payload; `metrics-images.search-index.ts` never gated on it.

## Scope / notes

- **Not a scanner incident.** Pending runs ~0.1% of ~90K images/day (07-14: 84,964 Scanned vs 128 Pending) — normal straggler residue. Only 14 stragglers happened to get a mod rating, all created 07-11 → 07-14.
- **The 13 fix themselves on deploy** — no data migration. Search-index rows appear on next sync for those images.
- `images/136553838` was already unstuck by a one-off DB write (`ingestion` → `Scanned`) before this approach was chosen. That row now disagrees with the semantics here; worth reverting to `Pending` once this ships so the data stays truthful — it'll stay visible via this predicate.
- Other `ingestion = 'Scanned'` gates left alone deliberately: `collection.service.ts:1226/1295` and the near-dead `getAllImages` fallback at `image.service.ts:1825` (its `browsingLevel` is always set since #3118). Worth a follow-up sweep, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

