### PR TITLE
feat(app-blocks): wildcard-pack import via page-host bridge (session-authed, client-side parse)

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -21,6 +21,8 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import — silently, since this suite is report-only.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -20,6 +20,7 @@ import {
   classifyWildcardPackError,
   exceedsPreDownloadCap,
   resolveGetWildcardPackRequest,
+  WILDCARD_MAX_CONCURRENT,
 } from './wildcardPackParse';
 import { resolveRequestConsent } from './requestConsentGate';
 import { resolveRequestSignIn } from './requestSignInGate';
@@ -571,6 +572,11 @@ export function PageBlockHost({
   // the whole point (the real download gates apply). A MUTATION deliberately: the
   // response carries a short-lived signed URL (see the router comment).
   const resolveWildcardPackMutation = trpc.generation.resolveWildcardPack.useMutation();
+  // In-flight fetch+parse count for the concurrency cap below. A ref (not state)
+  // so incrementing/decrementing never re-renders and the count is read
+  // synchronously in the message handler (JS is single-threaded, so the
+  // check→increment before the first await is atomic per message).
+  const wildcardInFlightRef = useRef<number>(0);
 
   // SUBMIT_WORKFLOW → blocks.submitWorkflow → WORKFLOW_SUBMITTED.
   useEffect(() => {
@@ -1474,6 +1480,15 @@ export function PageBlockHost({
       const req = resolveGetWildcardPackRequest(raw);
       if (!req) return; // missing/invalid requestId or modelVersionId → drop
       const { requestId, modelVersionId } = req;
+      // Concurrency cap (host-side backpressure): bound the per-tab memory. The
+      // check→increment runs synchronously before the first await (single-
+      // threaded), so N concurrent GET_WILDCARD_PACKs can't all pass the gate.
+      // Excess → `busy` (the block retries) rather than an unbounded queue.
+      if (wildcardInFlightRef.current >= WILDCARD_MAX_CONCURRENT) {
+        send('WILDCARD_PACK_RESULT', { requestId, error: 'busy' });
+        return;
+      }
+      wildcardInFlightRef.current += 1;
       try {
         const resolved = await resolveWildcardPackMutation.mutateAsync({ modelVersionId });
         // 32 MB pre-download cap on the server-advertised size — reject BEFORE
@@ -1498,6 +1513,11 @@ export function PageBlockHost({
         // NOT_FOUND / FORBIDDEN (proc) · too-large · parse-failed (fetch/unzip/
         // abort) — a single error discriminant, never a hang.
         send('WILDCARD_PACK_RESULT', { requestId, error: classifyWildcardPackError(err) });
+      } finally {
+        // Release the in-flight slot on EVERY exit (success, too-large early
+        // return, or error) so the concurrency gate can't leak slots and wedge
+        // shut. Only decremented for a request that passed the gate + incremented.
+        wildcardInFlightRef.current -= 1;
       }
     });
     return off;

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -16,6 +16,11 @@ import {
 } from './pageBlockHostLogic';
 import { projectBlockInitMaturity } from './projectBlockInit';
 import { sendBlockRender } from './sendBlockRender';
+import {
+  classifyWildcardPackError,
+  exceedsPreDownloadCap,
+  resolveGetWildcardPackRequest,
+} from './wildcardPackParse';
 import { resolveRequestConsent } from './requestConsentGate';
 import { resolveRequestSignIn } from './requestSignInGate';
 import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
@@ -560,6 +565,12 @@ export function PageBlockHost({
   // bearer credential a .query would leak into the ?input=… URL / logs / Referer
   // where it's replayable within its TTL. See blocks.router getMyBuzzBalance.
   const getMyBuzzBalanceMutation = trpc.blocks.getMyBuzzBalance.useMutation();
+
+  // Wildcard-pack import (W13). SESSION-authed (protectedProcedure) — it does NOT
+  // take a block token; the viewer's real cookie session authenticates, which is
+  // the whole point (the real download gates apply). A MUTATION deliberately: the
+  // response carries a short-lived signed URL (see the router comment).
+  const resolveWildcardPackMutation = trpc.generation.resolveWildcardPack.useMutation();
 
   // SUBMIT_WORKFLOW → blocks.submitWorkflow → WORKFLOW_SUBMITTED.
   useEffect(() => {
@@ -1431,6 +1442,66 @@ export function PageBlockHost({
     });
     return off;
   }, [onMessage, send]);
+
+  // ── GET_WILDCARD_PACK → WILDCARD_PACK_RESULT (W13 wildcard-pack import) ──────
+  //
+  // A page block posts GET_WILDCARD_PACK{ requestId, modelVersionId } to import a
+  // wildcard pack's parsed prompt lists. The HOST — running in the civitai page
+  // with the viewer's REAL authenticated session — resolves + fetches + unzips +
+  // parses it AS THE USER, and posts only the parsed JSON back. The untrusted
+  // iframe never sees the session, the signed URL, or the raw bytes.
+  //
+  // Why host-mediated (vs. a block-JWT REST endpoint that server-side fetches +
+  // unzips, the #3130 alternative):
+  //   1. `generation.resolveWildcardPack` runs as a protectedProcedure (session
+  //      auth), so `getFileForModelVersion` enforces every REAL creator/user
+  //      download gate authoritatively — requireAuth (satisfied by the session),
+  //      usageControl/downloads-disabled, early-access/entitlement, the viewer's
+  //      maturity ceiling — instead of a hand-rolled partial re-derivation.
+  //   2. The fetch + unzip run in the USER'S BROWSER TAB (bounded, streamed
+  //      inflate in wildcardPackHost), so a zip-bomb OOMs one tab, not a serving
+  //      web pod. The bytes never touch a pod's heap.
+  //
+  // token-INDEPENDENT (unlike every other handler above): the resolve proc is
+  // session-authed, not block-token-authed, so this does NOT gate on the page
+  // `token` prop. A missing/invalid requestId is dropped (nothing to reply to);
+  // every OTHER path posts a WILDCARD_PACK_RESULT (a `pack` or an `error`
+  // discriminant) so the block's SDK request never hangs. The zip + fetch shell
+  // (jszip/js-yaml) is dynamically imported so it never enters the page-block
+  // bundle unless a pack is actually requested.
+  useEffect(() => {
+    const off = onMessage<unknown>('GET_WILDCARD_PACK', async (raw) => {
+      const req = resolveGetWildcardPackRequest(raw);
+      if (!req) return; // missing/invalid requestId or modelVersionId → drop
+      const { requestId, modelVersionId } = req;
+      try {
+        const resolved = await resolveWildcardPackMutation.mutateAsync({ modelVersionId });
+        // 32 MB pre-download cap on the server-advertised size — reject BEFORE
+        // fetching a byte.
+        if (exceedsPreDownloadCap(resolved.sizeBytes)) {
+          send('WILDCARD_PACK_RESULT', { requestId, error: 'too-large' });
+          return;
+        }
+        const { fetchAndParseWildcardPack, WILDCARD_FETCH_TIMEOUT_MS } = await import(
+          './wildcardPackHost'
+        );
+        const { lists, truncated, truncatedLists } = await fetchAndParseWildcardPack({
+          signedUrl: resolved.signedUrl,
+          sizeBytes: resolved.sizeBytes,
+          signal: AbortSignal.timeout(WILDCARD_FETCH_TIMEOUT_MS),
+        });
+        send('WILDCARD_PACK_RESULT', {
+          requestId,
+          pack: { ...resolved.meta, lists, truncated, truncatedLists, maturity: resolved.maturity },
+        });
+      } catch (err) {
+        // NOT_FOUND / FORBIDDEN (proc) · too-large · parse-failed (fetch/unzip/
+        // abort) — a single error discriminant, never a hang.
+        send('WILDCARD_PACK_RESULT', { requestId, error: classifyWildcardPackError(err) });
+      }
+    });
+    return off;
+  }, [onMessage, send, resolveWildcardPackMutation]);
 
   const showIframe = status === 'loading' || status === 'ready';
   const isReady = status === 'ready';

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -45,6 +45,8 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -46,6 +46,8 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -40,6 +40,8 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     // PageBlockHost wires the workflow + storage bridges at render; stub so it
     // mounts network-free. SET_USER_CHECKPOINT makes NO tRPC call on a page (it
     // NACKs in-host), so none of these are exercised here.

--- a/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
@@ -59,6 +59,8 @@ vi.mock('~/utils/trpc', () => ({
   // wholesale, so the factory must re-declare it or the ESM link fails.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     // PageBlockHost also wires the workflow bridge at render (inert here); stub so
     // it mounts.
     blocks: {

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -32,6 +32,8 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
@@ -49,6 +49,8 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     // PageBlockHost also wires the workflow bridge at render (inert here —
     // exercised in PageBlockHostWorkflow.browser.test.tsx); stub so it mounts.
     blocks: {

--- a/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
@@ -1,0 +1,328 @@
+import JSZip from 'jszip';
+import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { useDialogStore } from '~/components/Dialog/dialogStore';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * W13 wildcard-pack import bridge (page surface).
+ *
+ * A full-page App Block posts GET_WILDCARD_PACK{ requestId, modelVersionId }; the
+ * host resolves the gated signed URL via the SESSION-authed
+ * `generation.resolveWildcardPack` mutation (NOT a block token), fetches +
+ * unzips + parses the pack CLIENT-SIDE (as the user), and posts back
+ * WILDCARD_PACK_RESULT{ requestId, pack } — or an `error` discriminant. These
+ * tests mount the REAL PageBlockHost and drive the actual postMessage bridge:
+ *   - the happy round-trip (real zip → parsed lists + meta + maturity),
+ *   - the 32 MB pre-download reject (fetch never fires),
+ *   - the NOT_FOUND / FORBIDDEN / parse-failed error discriminants,
+ *   - a fetch abort → parse-failed (cancel),
+ *   - a dropped (no requestId) request.
+ *
+ * `trpc` is mocked (`vi.mock('~/utils/trpc')`) and `fetch` is stubbed so the
+ * test is network-free; jszip runs for REAL in the browser env.
+ */
+
+const mocks = vi.hoisted(() => ({
+  resolve: vi.fn(),
+  fetch: vi.fn(),
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    generation: {
+      resolveWildcardPack: { useMutation: () => ({ mutateAsync: mocks.resolve }) },
+    },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
+        storage: { get: { fetch: vi.fn() }, list: { fetch: vi.fn() }, getQuota: { fetch: vi.fn() } },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+let zipBytes: Uint8Array;
+beforeAll(async () => {
+  const zip = new JSZip();
+  zip.file('colors.txt', '# palette\nred\nblue\nred\n#ffffff');
+  zip.file('nouns.yaml', 'animals:\n  - cat\n  - dog');
+  zip.file('preview.png', 'not-a-real-image');
+  zipBytes = await zip.generateAsync({ type: 'uint8array' });
+});
+
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', { data: { type, payload }, origin: window.location.origin, source: cw })
+  );
+}
+
+function listenForReply() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'wildcard-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Wildcard Importer',
+  iframeSrc: SAME_ORIGIN_SRC,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'wildcard-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['apps:storage:read'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 42, username: 'tester' },
+  theme: 'light' as const,
+};
+
+async function driveToReady() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+const RESOLVED_META = {
+  modelId: 55,
+  modelVersionId: 100,
+  modelName: 'Cool Wildcards',
+  versionName: 'v1.0',
+  creatorUsername: 'creator',
+};
+const RESOLVED_MATURITY = { browsingLevel: 3, sfwOnly: true };
+
+// Did the host fetch the pack's SIGNED URL? (The fire-and-forget block-render
+// beacon at BLOCK_READY also goes through the stubbed fetch — to a DIFFERENT
+// URL — so "was fetch called at all" is the wrong question; we ask whether the
+// signed URL specifically was requested.)
+function fetchedSignedUrl(url: string): boolean {
+  return mocks.fetch.mock.calls.some((c) => String(c[0]).includes(url));
+}
+
+describe('PageBlockHost wildcard-pack bridge (W13)', () => {
+  beforeEach(() => {
+    mocks.resolve.mockReset();
+    mocks.fetch.mockReset();
+    // Harmless default so the BLOCK_READY analytics beacon (which also uses the
+    // stubbed global fetch) gets a real Promise Response and never crashes the
+    // test; each test overrides for the pack fetch.
+    mocks.fetch.mockResolvedValue({ ok: true, arrayBuffer: async () => new ArrayBuffer(0) } as unknown as Response);
+    vi.stubGlobal('fetch', mocks.fetch);
+    useDialogStore.getState().closeAll();
+  });
+
+  test('GET_WILDCARD_PACK round-trip: resolves, fetches, unzips, posts parsed lists + meta + maturity', async () => {
+    mocks.resolve.mockResolvedValue({
+      signedUrl: 'https://b2.example/pack.zip?sig=1',
+      sizeBytes: zipBytes.byteLength,
+      meta: RESOLVED_META,
+      maturity: RESOLVED_MATURITY,
+    });
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => zipBytes.buffer.slice(0),
+    } as unknown as Response);
+
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('GET_WILDCARD_PACK', { requestId: 'rq_wp', modelVersionId: 100 });
+
+    await vi.waitFor(() => {
+      expect(mocks.resolve).toHaveBeenCalledWith({ modelVersionId: 100 });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('WILDCARD_PACK_RESULT');
+      if (!r) throw new Error('no reply yet');
+      const payload = r.payload as { requestId: string; pack?: any; error?: string };
+      expect(payload.requestId).toBe('rq_wp');
+      expect(payload.error).toBeUndefined();
+      expect(payload.pack.lists).toEqual({ colors: ['red', 'blue', '#ffffff'], animals: ['cat', 'dog'] });
+      expect(payload.pack.modelVersionId).toBe(100);
+      expect(payload.pack.creatorUsername).toBe('creator');
+      expect(payload.pack.maturity).toEqual(RESOLVED_MATURITY);
+      expect(payload.pack.truncated).toBe(false);
+      expect(payload.pack.truncatedLists).toEqual([]);
+    });
+    replies.stop();
+  });
+
+  test('32 MB pre-download cap: an oversized sizeBytes replies too-large WITHOUT fetching', async () => {
+    mocks.resolve.mockResolvedValue({
+      signedUrl: 'https://b2.example/huge.zip',
+      sizeBytes: 33 * 1024 * 1024, // > 32 MB
+      meta: RESOLVED_META,
+      maturity: RESOLVED_MATURITY,
+    });
+
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('GET_WILDCARD_PACK', { requestId: 'rq_big', modelVersionId: 100 });
+
+    await vi.waitFor(() => {
+      const r = replies.last('WILDCARD_PACK_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_big', error: 'too-large' });
+    });
+    expect(fetchedSignedUrl('huge.zip')).toBe(false);
+    replies.stop();
+  });
+
+  test('NOT_FOUND from the resolve proc → error: not-found', async () => {
+    mocks.resolve.mockRejectedValue({ data: { code: 'NOT_FOUND' } });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('GET_WILDCARD_PACK', { requestId: 'rq_nf', modelVersionId: 100 });
+
+    await vi.waitFor(() => {
+      const r = replies.last('WILDCARD_PACK_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_nf', error: 'not-found' });
+    });
+    expect(fetchedSignedUrl('b2.example')).toBe(false);
+    replies.stop();
+  });
+
+  test('FORBIDDEN (maturity) from the resolve proc → error: forbidden', async () => {
+    mocks.resolve.mockRejectedValue({ data: { code: 'FORBIDDEN' } });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('GET_WILDCARD_PACK', { requestId: 'rq_fb', modelVersionId: 100 });
+
+    await vi.waitFor(() => {
+      const r = replies.last('WILDCARD_PACK_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_fb', error: 'forbidden' });
+    });
+    replies.stop();
+  });
+
+  test('a non-zip payload → error: parse-failed', async () => {
+    mocks.resolve.mockResolvedValue({
+      signedUrl: 'https://b2.example/pack.zip',
+      sizeBytes: 100,
+      meta: RESOLVED_META,
+      maturity: RESOLVED_MATURITY,
+    });
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      arrayBuffer: async () => new Uint8Array([1, 2, 3, 4, 5]).buffer,
+    } as unknown as Response);
+
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('GET_WILDCARD_PACK', { requestId: 'rq_pf', modelVersionId: 100 });
+
+    await vi.waitFor(() => {
+      const r = replies.last('WILDCARD_PACK_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_pf', error: 'parse-failed' });
+    });
+    replies.stop();
+  });
+
+  test('a fetch abort (timeout/cancel) → error: parse-failed', async () => {
+    mocks.resolve.mockResolvedValue({
+      signedUrl: 'https://b2.example/pack.zip',
+      sizeBytes: 100,
+      meta: RESOLVED_META,
+      maturity: RESOLVED_MATURITY,
+    });
+    mocks.fetch.mockImplementation(async () => {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      throw err;
+    });
+
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('GET_WILDCARD_PACK', { requestId: 'rq_ab', modelVersionId: 100 });
+
+    await vi.waitFor(() => {
+      const r = replies.last('WILDCARD_PACK_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_ab', error: 'parse-failed' });
+    });
+    replies.stop();
+  });
+
+  test('a GET_WILDCARD_PACK with NO requestId is dropped (no proc call, no reply)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('GET_WILDCARD_PACK', { modelVersionId: 100 }); // missing requestId
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(mocks.resolve).not.toHaveBeenCalled();
+    expect(replies.last('WILDCARD_PACK_RESULT')).toBeUndefined();
+    replies.stop();
+  });
+});

--- a/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
@@ -2,6 +2,7 @@ import JSZip from 'jszip';
 import { beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import { useDialogStore } from '~/components/Dialog/dialogStore';
+import { WILDCARD_MAX_CONCURRENT } from '~/components/AppBlocks/wildcardPackParse';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -200,6 +201,21 @@ describe('PageBlockHost wildcard-pack bridge (W13)', () => {
       expect(payload.pack.maturity).toEqual(RESOLVED_MATURITY);
       expect(payload.pack.truncated).toBe(false);
       expect(payload.pack.truncatedLists).toEqual([]);
+
+      // SECURITY REGRESSION GUARD (the highest-value property of this design):
+      // the signed download URL + fileId are a bearer credential that must NEVER
+      // reach the untrusted iframe. The host posts ONLY {...meta, lists, ...} —
+      // a `...resolved` typo (instead of `...resolved.meta`) would leak the URL
+      // and otherwise pass silently. Pin it: no credential field, and the signed
+      // URL's host/query-token appear NOWHERE in the serialized message.
+      expect(payload.pack.signedUrl).toBeUndefined();
+      expect((payload.pack as { fileId?: unknown }).fileId).toBeUndefined();
+      expect((payload.pack as { url?: unknown }).url).toBeUndefined();
+      const serialized = JSON.stringify(payload);
+      expect(serialized).not.toContain('signedUrl');
+      expect(serialized).not.toContain('fileId');
+      expect(serialized).not.toContain('b2.example'); // the delivery-host
+      expect(serialized).not.toContain('sig=1'); // the signed-URL credential token
     });
     replies.stop();
   });
@@ -310,6 +326,32 @@ describe('PageBlockHost wildcard-pack bridge (W13)', () => {
       if (!r) throw new Error('no reply yet');
       expect(r.payload).toEqual({ requestId: 'rq_ab', error: 'parse-failed' });
     });
+    replies.stop();
+  });
+
+  test(`caps concurrent in-flight parses: the (N+1)th request gets busy (N=${WILDCARD_MAX_CONCURRENT})`, async () => {
+    // Make the resolve proc hang so the first N requests occupy every in-flight
+    // slot (each awaits resolve forever), then the (N+1)th must be rejected busy.
+    mocks.resolve.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    // Saturate the N slots, then one more.
+    for (let i = 0; i < WILDCARD_MAX_CONCURRENT; i++) {
+      postFromBlock('GET_WILDCARD_PACK', { requestId: `c${i}`, modelVersionId: 100 });
+    }
+    postFromBlock('GET_WILDCARD_PACK', { requestId: 'overflow', modelVersionId: 100 });
+
+    await vi.waitFor(() => {
+      const r = replies.last('WILDCARD_PACK_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'overflow', error: 'busy' });
+    });
+    // Only the N that acquired a slot called the resolve proc; the overflow
+    // short-circuited to busy BEFORE calling it (so memory stays bounded).
+    expect(mocks.resolve).toHaveBeenCalledTimes(WILDCARD_MAX_CONCURRENT);
     replies.stop();
   });
 

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -47,6 +47,8 @@ vi.mock('~/utils/trpc', () => ({
   // test file fails to import.
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
+    // W13 wildcard-pack import: PageBlockHost now calls this at render; stub so the mount succeeds (behavior covered in PageBlockHostWildcardPack.browser.test.tsx).
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: mocks.submit }) },
       estimateWorkflow: { useMutation: () => ({ mutateAsync: mocks.estimate }) },

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -332,6 +332,26 @@ export const INVENTORY = {
     PageBlockHost: 'required',
     InlineHost: INLINE_STUB,
   },
+  // ── Wildcard-pack import (W13, page-host bridge) ───────────────────────────
+  // A page block asks the HOST to resolve + fetch + unzip + parse a wildcard
+  // pack's list files, as the logged-in user (the host holds the real session).
+  // REQUEST-style ⇒ an unhandled one HANGS the block. Ahead of the published SDK
+  // dist union (forward-looking coverage, like OPEN_IMAGE_UPLOAD / SHARED_* were)
+  // — the compile-time gate is one-directional so an extra key here is fine.
+  //
+  // PAGE-ONLY affordance: the resolve+parse runs against the viewer's real
+  // session + browsing-level ceiling and is a full-page import flow. The model
+  // slot (IframeHost) has no wildcard-import surface — a model-column panel
+  // doesn't import prompt-list packs — so it's N/A there, exactly as the wider
+  // OPEN_RESOURCE_PICKER is page-only.
+  GET_WILDCARD_PACK: {
+    request: true,
+    reply: 'WILDCARD_PACK_RESULT',
+    IframeHost:
+      'model slot has no wildcard-pack import surface; the resolve+parse bridge is a page-only affordance',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
 } satisfies Record<string, MessageSpec>;
 
 /**

--- a/src/components/AppBlocks/wildcardPackHost.ts
+++ b/src/components/AppBlocks/wildcardPackHost.ts
@@ -1,0 +1,175 @@
+import JSZip from 'jszip';
+import yaml from 'js-yaml';
+import {
+  exceedsPreDownloadCap,
+  PRE_DOWNLOAD_MAX_BYTES,
+  processWildcardEntries,
+  wildcardPackError,
+  WILDCARD_PACK_CAPS,
+  type RawZipEntry,
+  type WildcardPackCaps,
+  type WildcardPackLists,
+} from './wildcardPackParse';
+
+// The zip + fetch SHELL for the wildcard-pack import bridge — kept in its OWN
+// module (jszip + js-yaml live here, not in the pure `wildcardPackParse`) so
+// PageBlockHost can `import()` it LAZILY the first time a block actually requests
+// a pack. jszip/js-yaml never enter the App Blocks host bundle for page blocks
+// that don't import wildcards.
+//
+// The bytes are fetched + inflated + parsed HERE, in the user's browser tab, as
+// the logged-in user — never on a serving web pod. So a zip bomb OOMs one tab
+// (and is contained by the streamed, hard-bounded inflate below), not a pod.
+
+export const WILDCARD_FETCH_TIMEOUT_MS = 30_000;
+
+// Strip a UTF-8 BOM + NUL bytes at the decode boundary (mirrors the canonical
+// server parser's `decodeUtf8`) so downstream splitting/parsing sees clean text.
+function decodeUtf8(bytes: Uint8Array): string {
+  let start = 0;
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) start = 3;
+  return new TextDecoder().decode(start ? bytes.subarray(start) : bytes).replace(/\0/g, '');
+}
+
+// JSZip exposes the central-directory uncompressed size on the internal `_data`
+// field. Not part of the official public API but stable in v3 and the canonical
+// accessor the server parser (`getEntryUncompressedSize`) also uses. Returns
+// null when absent (a streamed zip without CD size info) so the bounded read is
+// the authoritative guard.
+function declaredUncompressedSize(entry: JSZip.JSZipObject): number | null {
+  const data = (entry as unknown as { _data?: { uncompressedSize?: number } })._data;
+  return typeof data?.uncompressedSize === 'number' ? data.uncompressedSize : null;
+}
+
+/**
+ * Inflate a single zip entry, HARD-BOUNDED to `limitBytes`. Uses JSZip's
+ * per-entry `internalStream('uint8array')` and PAUSES the flow the moment the
+ * accumulated byte count reaches the limit — so a hyper-compressible entry (a
+ * few KB deflating to GBs) inflates only ~limitBytes + one decompression block,
+ * never the full payload. THIS is the guarantee #3130's per-entry check lacked
+ * (it flagged the size but still ran a full `entry.async('string')`).
+ */
+export function readEntryBounded(
+  entry: JSZip.JSZipObject,
+  limitBytes: number
+): Promise<{ text: string; bytes: number; hitLimit: boolean }> {
+  return new Promise((resolve, reject) => {
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    let done = false;
+    let hitLimit = false;
+
+    const finish = () => {
+      if (done) return;
+      done = true;
+      const merged = new Uint8Array(total);
+      let offset = 0;
+      for (const c of chunks) {
+        merged.set(c, offset);
+        offset += c.length;
+      }
+      resolve({ text: decodeUtf8(merged), bytes: total, hitLimit });
+    };
+
+    // internalStream is not in the JSZip typings but is present in v3.
+    const stream = (
+      entry as unknown as {
+        internalStream: (type: string) => {
+          on: (evt: string, fn: (arg: unknown) => void) => unknown;
+          resume: () => unknown;
+          pause: () => unknown;
+        };
+      }
+    ).internalStream('uint8array');
+
+    stream.on('data', (chunk) => {
+      if (done) return;
+      const bytes = chunk as Uint8Array;
+      chunks.push(bytes);
+      total += bytes.length;
+      if (total >= limitBytes) {
+        hitLimit = true;
+        try {
+          stream.pause();
+        } catch {
+          /* pause is best-effort; `done` already stops further accumulation */
+        }
+        finish();
+      }
+    });
+    stream.on('error', (e) => {
+      if (done) return;
+      done = true;
+      reject(e instanceof Error ? e : new Error(String(e)));
+    });
+    stream.on('end', () => finish());
+    stream.resume();
+  });
+}
+
+/** Unzip + parse an in-memory zip buffer into named wildcard lists, enforcing
+ *  every inflation + result cap. Node- and browser-safe (no `fetch`), so the
+ *  zip-bomb bounds are unit-testable against real deflate-bomb buffers. */
+export async function parseWildcardZip(
+  bytes: Uint8Array,
+  caps: WildcardPackCaps = WILDCARD_PACK_CAPS
+): Promise<WildcardPackLists> {
+  const zip = await JSZip.loadAsync(bytes);
+  const entries: RawZipEntry[] = [];
+  zip.forEach((path, file) => {
+    if (file.dir) return;
+    entries.push({
+      path,
+      declaredSize: declaredUncompressedSize(file),
+      read: (limit) => readEntryBounded(file, limit),
+    });
+  });
+  return processWildcardEntries(entries, caps, { parseYaml: (text) => yaml.load(text) });
+}
+
+/**
+ * The host-side money-shot: pre-cap → fetch (cross-origin b2, CORS-allowed) →
+ * bounded unzip + parse. The 32 MB pre-download cap is enforced on the
+ * server-advertised size BEFORE fetching; a second belt rejects a download that
+ * exceeds the cap even if the server under-reported it. `signal` (an
+ * AbortSignal.timeout) bounds the fetch. On any failure a tagged error is thrown
+ * that `classifyWildcardPackError` maps to the WILDCARD_PACK_RESULT discriminant.
+ */
+export async function fetchAndParseWildcardPack({
+  signedUrl,
+  sizeBytes,
+  signal,
+  caps = WILDCARD_PACK_CAPS,
+}: {
+  signedUrl: string;
+  sizeBytes: number;
+  signal?: AbortSignal;
+  caps?: WildcardPackCaps;
+}): Promise<WildcardPackLists> {
+  if (exceedsPreDownloadCap(sizeBytes)) {
+    throw wildcardPackError('too-large', `pack size ${sizeBytes} exceeds ${PRE_DOWNLOAD_MAX_BYTES}`);
+  }
+
+  const res = await fetch(signedUrl, {
+    signal,
+    // The signed URL is a self-contained credential; don't attach cookies or a
+    // referrer to the cross-origin storage fetch.
+    credentials: 'omit',
+    referrerPolicy: 'no-referrer',
+  });
+  if (!res.ok) {
+    throw wildcardPackError('parse-failed', `fetch failed: ${res.status}`);
+  }
+
+  const buf = new Uint8Array(await res.arrayBuffer());
+  if (buf.byteLength > PRE_DOWNLOAD_MAX_BYTES) {
+    throw wildcardPackError('too-large', `downloaded ${buf.byteLength} bytes exceeds the cap`);
+  }
+
+  try {
+    return await parseWildcardZip(buf, caps);
+  } catch (err) {
+    // A corrupt / non-zip payload (JSZip.loadAsync throws) → parse-failed.
+    throw wildcardPackError('parse-failed', err instanceof Error ? err.message : String(err));
+  }
+}

--- a/src/components/AppBlocks/wildcardPackParse.test.ts
+++ b/src/components/AppBlocks/wildcardPackParse.test.ts
@@ -96,6 +96,7 @@ describe('classifyWildcardPackError', () => {
   it('maps a host-tagged error', () => {
     expect(classifyWildcardPackError(wildcardPackError('too-large'))).toBe('too-large');
     expect(classifyWildcardPackError(wildcardPackError('parse-failed'))).toBe('parse-failed');
+    expect(classifyWildcardPackError(wildcardPackError('busy'))).toBe('busy');
   });
   it('maps a tRPC client error data.code', () => {
     expect(classifyWildcardPackError({ data: { code: 'NOT_FOUND' } })).toBe('not-found');

--- a/src/components/AppBlocks/wildcardPackParse.test.ts
+++ b/src/components/AppBlocks/wildcardPackParse.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyWildcardEntry,
+  classifyWildcardPackError,
+  exceedsPreDownloadCap,
+  extractTxtOptions,
+  finalizeOptions,
+  flattenYamlLists,
+  isTxtCommentLine,
+  PRE_DOWNLOAD_MAX_BYTES,
+  processWildcardEntries,
+  resolveGetWildcardPackRequest,
+  wildcardPackError,
+  WILDCARD_PACK_CAPS,
+  type RawZipEntry,
+} from './wildcardPackParse';
+
+// A yaml parser stand-in for the pure processWildcardEntries tests — JSON is a
+// yaml subset, so parsing JSON text exercises the same map/array/scalar flatten
+// without dragging js-yaml into this pure suite.
+const jsonYaml = (text: string) => JSON.parse(text);
+
+// Build a mock RawZipEntry whose bounded `read` records the limit it was called
+// with and returns `bytes`/`hitLimit` under test control. `read` THROWS if the
+// entry should never be inflated (declared-size skip / classifier skip).
+function entry(
+  path: string,
+  opts: {
+    text?: string;
+    bytes?: number;
+    hitLimit?: boolean;
+    declaredSize?: number | null;
+    onRead?: (limit: number) => void;
+    failRead?: boolean;
+  } = {}
+): RawZipEntry {
+  return {
+    path,
+    declaredSize: opts.declaredSize ?? null,
+    read: async (limit: number) => {
+      opts.onRead?.(limit);
+      if (opts.failRead) throw new Error('unreadable');
+      const text = opts.text ?? '';
+      return {
+        text,
+        bytes: opts.bytes ?? text.length,
+        hitLimit: opts.hitLimit ?? false,
+      };
+    },
+  };
+}
+
+describe('resolveGetWildcardPackRequest', () => {
+  it('accepts a valid { requestId, modelVersionId }', () => {
+    expect(resolveGetWildcardPackRequest({ requestId: 'rq', modelVersionId: 42 })).toEqual({
+      requestId: 'rq',
+      modelVersionId: 42,
+    });
+  });
+  it('coerces a string modelVersionId', () => {
+    expect(resolveGetWildcardPackRequest({ requestId: 'rq', modelVersionId: '42' })).toEqual({
+      requestId: 'rq',
+      modelVersionId: 42,
+    });
+  });
+  it('drops missing/empty requestId', () => {
+    expect(resolveGetWildcardPackRequest({ modelVersionId: 42 })).toBeNull();
+    expect(resolveGetWildcardPackRequest({ requestId: '', modelVersionId: 42 })).toBeNull();
+  });
+  it('drops non-positive / non-integer modelVersionId', () => {
+    expect(resolveGetWildcardPackRequest({ requestId: 'rq', modelVersionId: 0 })).toBeNull();
+    expect(resolveGetWildcardPackRequest({ requestId: 'rq', modelVersionId: -5 })).toBeNull();
+    expect(resolveGetWildcardPackRequest({ requestId: 'rq', modelVersionId: 1.5 })).toBeNull();
+    expect(resolveGetWildcardPackRequest({ requestId: 'rq', modelVersionId: 'x' })).toBeNull();
+  });
+  it('drops non-objects', () => {
+    expect(resolveGetWildcardPackRequest(null)).toBeNull();
+    expect(resolveGetWildcardPackRequest('str')).toBeNull();
+  });
+});
+
+describe('exceedsPreDownloadCap', () => {
+  it('is false at/under the 32 MB cap, true above', () => {
+    expect(exceedsPreDownloadCap(PRE_DOWNLOAD_MAX_BYTES)).toBe(false);
+    expect(exceedsPreDownloadCap(PRE_DOWNLOAD_MAX_BYTES + 1)).toBe(true);
+    expect(exceedsPreDownloadCap(0)).toBe(false);
+  });
+  it('is false for non-finite / non-number', () => {
+    expect(exceedsPreDownloadCap(NaN)).toBe(false);
+    expect(exceedsPreDownloadCap(undefined)).toBe(false);
+    expect(exceedsPreDownloadCap('big')).toBe(false);
+  });
+});
+
+describe('classifyWildcardPackError', () => {
+  it('maps a host-tagged error', () => {
+    expect(classifyWildcardPackError(wildcardPackError('too-large'))).toBe('too-large');
+    expect(classifyWildcardPackError(wildcardPackError('parse-failed'))).toBe('parse-failed');
+  });
+  it('maps a tRPC client error data.code', () => {
+    expect(classifyWildcardPackError({ data: { code: 'NOT_FOUND' } })).toBe('not-found');
+    expect(classifyWildcardPackError({ data: { code: 'FORBIDDEN' } })).toBe('forbidden');
+    expect(classifyWildcardPackError({ data: { code: 'PAYLOAD_TOO_LARGE' } })).toBe('too-large');
+  });
+  it('defaults unknown / network / abort errors to parse-failed', () => {
+    expect(classifyWildcardPackError(new Error('boom'))).toBe('parse-failed');
+    expect(classifyWildcardPackError({ name: 'AbortError' })).toBe('parse-failed');
+    expect(classifyWildcardPackError(undefined)).toBe('parse-failed');
+  });
+});
+
+describe('classifyWildcardEntry', () => {
+  it('classifies txt / yaml / yml', () => {
+    expect(classifyWildcardEntry('colors.txt')).toBe('txt');
+    expect(classifyWildcardEntry('dir/sub/nouns.YAML')).toBe('yaml');
+    expect(classifyWildcardEntry('a.yml')).toBe('yaml');
+  });
+  it('skips images, nested zips, dotfiles, __MACOSX', () => {
+    expect(classifyWildcardEntry('preview.png')).toBe('skip');
+    expect(classifyWildcardEntry('cover.jpeg')).toBe('skip');
+    expect(classifyWildcardEntry('bundle.zip')).toBe('skip');
+    expect(classifyWildcardEntry('.DS_Store')).toBe('skip');
+    expect(classifyWildcardEntry('sub/.gitignore')).toBe('skip');
+    expect(classifyWildcardEntry('__MACOSX/colors.txt')).toBe('skip');
+    expect(classifyWildcardEntry('dir/._colors.txt')).toBe('skip');
+  });
+});
+
+describe('isTxtCommentLine + extractTxtOptions', () => {
+  it('treats "# ..." and a bare "#" as comments', () => {
+    expect(isTxtCommentLine('# a comment')).toBe(true);
+    expect(isTxtCommentLine('#')).toBe(true);
+  });
+  it('does NOT treat a hex-color value "#ffffff" as a comment (the #3130 fix)', () => {
+    expect(isTxtCommentLine('#ffffff')).toBe(false);
+    expect(isTxtCommentLine('#00ff00')).toBe(false);
+  });
+  it('strips comment + blank lines, trims, handles CRLF, keeps #ffffff', () => {
+    const text = ['# palette', '', '  red  ', '#ffffff\r', 'blue', '   ', '# trailing note'].join(
+      '\n'
+    );
+    expect(extractTxtOptions(text)).toEqual(['red', '#ffffff', 'blue']);
+  });
+});
+
+describe('finalizeOptions (dedupe + caps)', () => {
+  it('dedupes preserving first-occurrence order', () => {
+    const { options, truncated } = finalizeOptions(['a', 'b', 'a', 'c', 'b'], WILDCARD_PACK_CAPS);
+    expect(options).toEqual(['a', 'b', 'c']);
+    expect(truncated).toBe(false);
+  });
+  it('truncates over-length options to maxCharsPerOption + flags', () => {
+    const long = 'x'.repeat(WILDCARD_PACK_CAPS.maxCharsPerOption + 50);
+    const { options, truncated } = finalizeOptions([long], WILDCARD_PACK_CAPS);
+    expect(options[0]).toHaveLength(WILDCARD_PACK_CAPS.maxCharsPerOption);
+    expect(truncated).toBe(true);
+  });
+  it('caps option count at maxOptionsPerList + flags', () => {
+    const many = Array.from({ length: WILDCARD_PACK_CAPS.maxOptionsPerList + 100 }, (_, i) => `o${i}`);
+    const { options, truncated } = finalizeOptions(many, WILDCARD_PACK_CAPS);
+    expect(options).toHaveLength(WILDCARD_PACK_CAPS.maxOptionsPerList);
+    expect(truncated).toBe(true);
+  });
+});
+
+describe('flattenYamlLists', () => {
+  it('flattens nested maps to parent/child names', () => {
+    const parsed = {
+      colors: ['red', 'blue'],
+      clothing: { tops: ['shirt', 'blouse'], bottoms: ['jeans'] },
+    };
+    const lists = flattenYamlLists(parsed);
+    expect(lists).toEqual([
+      { name: 'colors', options: ['red', 'blue'] },
+      { name: 'clothing/tops', options: ['shirt', 'blouse'] },
+      { name: 'clothing/bottoms', options: ['jeans'] },
+    ]);
+  });
+  it('coerces scalar leaves to a one-element list and trims', () => {
+    expect(flattenYamlLists({ mood: '  happy  ' })).toEqual([{ name: 'mood', options: ['happy'] }]);
+  });
+  it('is first-write-wins on a case-insensitive name collision', () => {
+    // Two sibling keys differing only in case collide → the first wins.
+    const parsed = { Colors: ['red'], colors: ['blue'] };
+    const lists = flattenYamlLists(parsed);
+    expect(lists).toEqual([{ name: 'Colors', options: ['red'] }]);
+  });
+  it('tolerates a non-object root (returns [])', () => {
+    expect(flattenYamlLists(null)).toEqual([]);
+    expect(flattenYamlLists(42)).toEqual([]);
+    expect(flattenYamlLists(['a', 'b'])).toEqual([]); // bare array handled by the caller
+  });
+});
+
+describe('processWildcardEntries — parsing', () => {
+  it('builds lists from txt + yaml, names txt after the file', async () => {
+    const entries = [
+      entry('colors.txt', { text: 'red\nblue\nred' }),
+      entry('nested/nouns.yaml', { text: JSON.stringify({ animals: ['cat', 'dog'] }) }),
+    ];
+    const { lists, truncated } = await processWildcardEntries(entries, WILDCARD_PACK_CAPS, {
+      parseYaml: jsonYaml,
+    });
+    expect(lists).toEqual({ colors: ['red', 'blue'], animals: ['cat', 'dog'] });
+    expect(truncated).toBe(false);
+  });
+
+  it('an images-only zip yields empty lists, not an error', async () => {
+    const entries = [entry('a.png', { failRead: true }), entry('b.jpg', { failRead: true })];
+    const { lists, truncated } = await processWildcardEntries(entries, WILDCARD_PACK_CAPS, {
+      parseYaml: jsonYaml,
+    });
+    // failRead would throw IF read — but classifier skips images before any read.
+    expect(lists).toEqual({});
+    expect(truncated).toBe(false);
+  });
+
+  it('NEVER inflates a skipped image / nested zip / dotfile (read not called)', async () => {
+    let read = false;
+    const entries = [
+      entry('preview.png', { onRead: () => (read = true) }),
+      entry('inner.zip', { onRead: () => (read = true) }),
+      entry('.DS_Store', { onRead: () => (read = true) }),
+    ];
+    await processWildcardEntries(entries, WILDCARD_PACK_CAPS, { parseYaml: jsonYaml });
+    expect(read).toBe(false);
+  });
+
+  it('tolerates malformed yaml (skips the list + flags truncated, never throws)', async () => {
+    const entries = [
+      entry('good.txt', { text: 'a\nb' }),
+      entry('bad.yaml', { text: '{ not: valid json' }),
+    ];
+    const { lists, truncated } = await processWildcardEntries(entries, WILDCARD_PACK_CAPS, {
+      parseYaml: jsonYaml,
+    });
+    expect(lists).toEqual({ good: ['a', 'b'] });
+    expect(truncated).toBe(true);
+  });
+
+  it('names a bare top-level array yaml after the file', async () => {
+    const entries = [entry('moods.yaml', { text: JSON.stringify(['happy', 'sad']) })];
+    const { lists } = await processWildcardEntries(entries, WILDCARD_PACK_CAPS, {
+      parseYaml: jsonYaml,
+    });
+    expect(lists).toEqual({ moods: ['happy', 'sad'] });
+  });
+});
+
+describe('processWildcardEntries — the anti-zip-bomb inflation caps (the #3130 security gap)', () => {
+  it('SKIPS an entry whose DECLARED size exceeds the per-entry cap — WITHOUT inflating it', async () => {
+    let inflated = false;
+    const bomb = entry('bomb.txt', {
+      declaredSize: WILDCARD_PACK_CAPS.perEntryBytes + 1,
+      onRead: () => (inflated = true),
+    });
+    const { lists, truncated } = await processWildcardEntries([bomb], WILDCARD_PACK_CAPS, {
+      parseYaml: jsonYaml,
+    });
+    expect(inflated).toBe(false); // never read — the declared-size belt short-circuits
+    expect(lists).toEqual({});
+    expect(truncated).toBe(true);
+  });
+
+  it('BOUNDS inflation via the per-entry read limit (read is called with a bounded limit, hitLimit truncates)', async () => {
+    let seenLimit = -1;
+    // A hyper-inflating entry whose declared size is unknown (null) — the bounded
+    // read is the authoritative guard. It reports hitLimit + only `bytes`≈limit.
+    const bomb = entry('bomb.txt', {
+      declaredSize: null,
+      text: 'x'.repeat(10),
+      bytes: WILDCARD_PACK_CAPS.perEntryBytes, // bounded, NOT the (huge) real size
+      hitLimit: true,
+      onRead: (limit) => (seenLimit = limit),
+    });
+    const { truncated } = await processWildcardEntries([bomb], WILDCARD_PACK_CAPS, {
+      parseYaml: jsonYaml,
+    });
+    // read was invoked with a HARD limit ≤ the per-entry cap (never unbounded).
+    expect(seenLimit).toBeGreaterThan(0);
+    expect(seenLimit).toBeLessThanOrEqual(WILDCARD_PACK_CAPS.perEntryBytes);
+    expect(truncated).toBe(true);
+  });
+
+  it('bounds the per-entry read to the REMAINING total budget as the total cap is approached', async () => {
+    const caps = { ...WILDCARD_PACK_CAPS, totalBytes: 1500, perEntryBytes: 1000 };
+    const limits: number[] = [];
+    const entries = [
+      entry('a.txt', { text: 'a', bytes: 1000, onRead: (l) => limits.push(l) }),
+      entry('b.txt', { text: 'b', bytes: 1000, onRead: (l) => limits.push(l) }),
+    ];
+    await processWildcardEntries(entries, caps, { parseYaml: jsonYaml });
+    expect(limits[0]).toBe(1000); // min(perEntry, remaining=1500)
+    expect(limits[1]).toBe(500); // min(perEntry=1000, remaining=1500-1000)
+  });
+
+  it('STOPS the loop once the total uncompressed budget is exhausted (later entries not read)', async () => {
+    const caps = { ...WILDCARD_PACK_CAPS, totalBytes: 1000, perEntryBytes: 1000 };
+    let thirdRead = false;
+    const entries = [
+      entry('a.txt', { text: 'a', bytes: 1000 }),
+      entry('b.txt', { text: 'b', bytes: 1000, onRead: () => (thirdRead = true) }),
+    ];
+    const { truncated } = await processWildcardEntries(entries, caps, { parseYaml: jsonYaml });
+    expect(thirdRead).toBe(false); // total budget hit after entry a → loop breaks
+    expect(truncated).toBe(true);
+  });
+
+  it('caps the number of entries walked at maxEntries', async () => {
+    const caps = { ...WILDCARD_PACK_CAPS, maxEntries: 2 };
+    let reads = 0;
+    const entries = Array.from({ length: 5 }, (_, i) =>
+      entry(`f${i}.txt`, { text: `v${i}`, bytes: 4, onRead: () => reads++ })
+    );
+    const { truncated } = await processWildcardEntries(entries, caps, { parseYaml: jsonYaml });
+    expect(reads).toBe(2);
+    expect(truncated).toBe(true);
+  });
+
+  it('tolerates an unreadable entry (throws in read) without failing the pack', async () => {
+    const entries = [
+      entry('ok.txt', { text: 'a\nb' }),
+      entry('corrupt.txt', { failRead: true }),
+    ];
+    const { lists, truncated } = await processWildcardEntries(entries, WILDCARD_PACK_CAPS, {
+      parseYaml: jsonYaml,
+    });
+    expect(lists).toEqual({ ok: ['a', 'b'] });
+    expect(truncated).toBe(true);
+  });
+});
+
+describe('processWildcardEntries — result caps flag truncatedLists', () => {
+  it('flags a list truncated by the option-count cap', async () => {
+    const caps = { ...WILDCARD_PACK_CAPS, maxOptionsPerList: 3 };
+    const entries = [entry('big.txt', { text: 'a\nb\nc\nd\ne' })];
+    const { lists, truncated, truncatedLists } = await processWildcardEntries(entries, caps, {
+      parseYaml: jsonYaml,
+    });
+    expect(lists.big).toEqual(['a', 'b', 'c']);
+    expect(truncated).toBe(true);
+    expect(truncatedLists).toEqual(['big']);
+  });
+});

--- a/src/components/AppBlocks/wildcardPackParse.test.ts
+++ b/src/components/AppBlocks/wildcardPackParse.test.ts
@@ -12,6 +12,8 @@ import {
   resolveGetWildcardPackRequest,
   wildcardPackError,
   WILDCARD_PACK_CAPS,
+  YAML_MAX_LISTS,
+  YAML_MAX_NODE_VISITS,
   type RawZipEntry,
 } from './wildcardPackParse';
 
@@ -165,31 +167,81 @@ describe('finalizeOptions (dedupe + caps)', () => {
 });
 
 describe('flattenYamlLists', () => {
-  it('flattens nested maps to parent/child names', () => {
+  it('flattens nested maps to parent/child names (legit tree, no truncation)', () => {
     const parsed = {
       colors: ['red', 'blue'],
       clothing: { tops: ['shirt', 'blouse'], bottoms: ['jeans'] },
     };
-    const lists = flattenYamlLists(parsed);
+    const { lists, truncated } = flattenYamlLists(parsed);
     expect(lists).toEqual([
       { name: 'colors', options: ['red', 'blue'] },
       { name: 'clothing/tops', options: ['shirt', 'blouse'] },
       { name: 'clothing/bottoms', options: ['jeans'] },
     ]);
+    expect(truncated).toBe(false);
   });
   it('coerces scalar leaves to a one-element list and trims', () => {
-    expect(flattenYamlLists({ mood: '  happy  ' })).toEqual([{ name: 'mood', options: ['happy'] }]);
+    expect(flattenYamlLists({ mood: '  happy  ' }).lists).toEqual([
+      { name: 'mood', options: ['happy'] },
+    ]);
   });
   it('is first-write-wins on a case-insensitive name collision', () => {
     // Two sibling keys differing only in case collide → the first wins.
     const parsed = { Colors: ['red'], colors: ['blue'] };
-    const lists = flattenYamlLists(parsed);
-    expect(lists).toEqual([{ name: 'Colors', options: ['red'] }]);
+    expect(flattenYamlLists(parsed).lists).toEqual([{ name: 'Colors', options: ['red'] }]);
   });
-  it('tolerates a non-object root (returns [])', () => {
-    expect(flattenYamlLists(null)).toEqual([]);
-    expect(flattenYamlLists(42)).toEqual([]);
-    expect(flattenYamlLists(['a', 'b'])).toEqual([]); // bare array handled by the caller
+  it('tolerates a non-object root (lists: [])', () => {
+    expect(flattenYamlLists(null).lists).toEqual([]);
+    expect(flattenYamlLists(42).lists).toEqual([]);
+    expect(flattenYamlLists(['a', 'b']).lists).toEqual([]); // bare array handled by the caller
+  });
+});
+
+describe('flattenYamlLists — YAML alias-expansion DoS guard (billion-laughs)', () => {
+  it('BOUNDS a shared-reference alias bomb — no exponential blowup, sets truncated, completes fast', () => {
+    // js-yaml resolves aliases BY REFERENCE, so a tiny `.yaml` like
+    //   a: &a { leaf: [x] }
+    //   b: { p: *a, q: *a }
+    //   c: { p: *b, q: *b }
+    //   ... top: { p: *y, q: *y }
+    // parses to a DAG where each level has TWO children pointing at the SAME
+    // next-level object. A naive DFS visits 2^depth leaves. We reproduce that
+    // exact object graph directly (shared refs, no js-yaml dependency) at depth
+    // 30 → 2^30 (~1.07 BILLION) root→leaf paths — which WITHOUT the budget would
+    // freeze the tab. The budget must keep this bounded + fast.
+    const leaf: unknown = { leaf: ['x'] };
+    let node: unknown = leaf;
+    for (let i = 0; i < 30; i++) node = { p: node, q: node }; // 2^30 leaf-paths
+
+    const start = performance.now();
+    const { lists, truncated } = flattenYamlLists(node);
+    const elapsedMs = performance.now() - start;
+
+    // Bounded output (never the exponential blowup) + the truncation signal.
+    expect(truncated).toBe(true);
+    expect(lists.length).toBeLessThanOrEqual(YAML_MAX_LISTS);
+    // And it completed quickly — the node-visit budget caps total work at
+    // ~YAML_MAX_NODE_VISITS steps, so this is milliseconds, not a hang.
+    expect(elapsedMs).toBeLessThan(1000);
+    expect(YAML_MAX_NODE_VISITS).toBeGreaterThan(0); // referenced (budget exists)
+  });
+
+  it('does NOT truncate a legitimate deep-but-narrow tree (a few levels)', () => {
+    const parsed = {
+      characters: {
+        female: { modern: ['a', 'b'], fantasy: ['c'] },
+        male: { modern: ['d'] },
+      },
+      scenes: ['forest', 'city'],
+    };
+    const { lists, truncated } = flattenYamlLists(parsed);
+    expect(truncated).toBe(false);
+    expect(lists).toEqual([
+      { name: 'characters/female/modern', options: ['a', 'b'] },
+      { name: 'characters/female/fantasy', options: ['c'] },
+      { name: 'characters/male/modern', options: ['d'] },
+      { name: 'scenes', options: ['forest', 'city'] },
+    ]);
   });
 });
 

--- a/src/components/AppBlocks/wildcardPackParse.ts
+++ b/src/components/AppBlocks/wildcardPackParse.ts
@@ -193,16 +193,39 @@ export interface RawList {
   options: string[];
 }
 
+// Traversal budget for flattenYamlLists — bounds a YAML alias-expansion
+// (billion-laughs) DoS. js-yaml resolves aliases BY REFERENCE, so parsing stays
+// linear/cheap, but a <1 KB `.yaml` (well under the 1 MB per-entry byte cap)
+// whose aliases form a DAG expands to an EXPONENTIAL number of root→leaf paths
+// when the flatten DFS traverses it — the amplification is in the TRAVERSAL, not
+// the source bytes, so the byte/inflate caps don't bound it. The walk runs
+// synchronously on the main thread (the fetch AbortSignal can't interrupt it), so
+// an unbounded traversal freezes / OOMs the importing user's authed tab. These
+// caps bound ANY pathological traversal (exponential width via shared refs, or a
+// deep chain) regardless of mechanism, deterministically. Far above any
+// legitimate wildcard pack (shallow trees, a few hundred nodes).
+export const YAML_MAX_NODE_VISITS = 50_000;
+export const YAML_MAX_LISTS = 4096;
+export const YAML_MAX_DEPTH = 256;
+
 /**
  * Flatten a parsed (Dynamic-Prompts) YAML tree into named lists, joining the
  * path from root to each leaf array/scalar with `/` (`clothing/tops`). Mirrors
  * the canonical server `walkYamlTree`: mixed array+map siblings work, scalar
  * leaves become one-element lists, and name collisions are first-write-wins
- * (case-insensitive). Tolerant of a non-object root (returns []).
+ * (case-insensitive). Tolerant of a non-object root (`lists: []`).
+ *
+ * DoS-bounded (see YAML_MAX_* above): the DFS carries a node-visit counter, a
+ * recursion-depth cap, and an emitted-list cap. If any is breached the traversal
+ * aborts and `truncated` is set — TRUNCATE-AND-FLAG, never throw (consistent with
+ * the other caps). Legit small packs are far under every budget → byte-identical
+ * output + `truncated: false`.
  */
-export function flattenYamlLists(parsed: unknown): RawList[] {
+export function flattenYamlLists(parsed: unknown): { lists: RawList[]; truncated: boolean } {
   const out: RawList[] = [];
   const seen = new Set<string>();
+  let visits = 0;
+  let truncated = false;
 
   const pushLeaf = (name: string, items: unknown[]) => {
     const lower = name.toLowerCase();
@@ -216,7 +239,16 @@ export function flattenYamlLists(parsed: unknown): RawList[] {
     out.push({ name, options });
   };
 
-  const walk = (node: unknown, prefix: string) => {
+  const walk = (node: unknown, prefix: string, depth: number) => {
+    // Budget guards — the alias-expansion DoS bound. Checked at ENTRY so once any
+    // cap is hit no further node is visited: the visit counter bounds total work
+    // (exponential-width DAG), the depth cap prevents a deep chain from
+    // stack-overflowing this recursive walk, and the list cap bounds output.
+    if (truncated) return;
+    if (++visits > YAML_MAX_NODE_VISITS || depth > YAML_MAX_DEPTH || out.length >= YAML_MAX_LISTS) {
+      truncated = true;
+      return;
+    }
     if (Array.isArray(node)) {
       if (prefix) pushLeaf(prefix, node);
       return;
@@ -224,7 +256,8 @@ export function flattenYamlLists(parsed: unknown): RawList[] {
     if (node && typeof node === 'object') {
       for (const [key, child] of Object.entries(node as Record<string, unknown>)) {
         if (!key) continue;
-        walk(child, prefix ? `${prefix}/${key}` : key);
+        walk(child, prefix ? `${prefix}/${key}` : key, depth + 1);
+        if (truncated) return; // budget hit mid-iteration → stop the siblings too
       }
       return;
     }
@@ -235,9 +268,9 @@ export function flattenYamlLists(parsed: unknown): RawList[] {
 
   // Top-level array with no key namespace is handled by the caller (named after
   // the file) — walk with empty prefix so object roots namespace by their keys.
-  if (Array.isArray(parsed)) return out; // caller names a bare-array yaml
-  walk(parsed, '');
-  return out;
+  if (Array.isArray(parsed)) return { lists: out, truncated }; // caller names a bare-array yaml
+  walk(parsed, '', 0);
+  return { lists: out, truncated };
 }
 
 // ── option finalization (dedupe + caps) ──────────────────────────────────────
@@ -397,7 +430,9 @@ export async function processWildcardEntries(
         .filter((s) => s.length > 0);
       if (name) addList(name, options);
     } else {
-      for (const list of flattenYamlLists(parsed)) addList(list.name, list.options);
+      const flat = flattenYamlLists(parsed);
+      if (flat.truncated) truncated = true; // alias-expansion budget was hit
+      for (const list of flat.lists) addList(list.name, list.options);
     }
   }
 

--- a/src/components/AppBlocks/wildcardPackParse.ts
+++ b/src/components/AppBlocks/wildcardPackParse.ts
@@ -1,0 +1,398 @@
+// Pure, dependency-light logic for the App Blocks wildcard-pack import bridge
+// (W13). Split out of the host shell (PageBlockHost) + the zip shell
+// (wildcardPackZip) so the security-critical decisions — the request contract,
+// the pre-download cap, the txt/yaml parsers, and (crucially) the zip-bomb
+// inflation caps — are unit-testable in the node vitest env with NO jszip /
+// js-yaml import (the yaml parser is INJECTED into processWildcardEntries).
+// Mirrors the pageBlockHostLogic.ts "pure decision, testable" pattern.
+//
+// The parse semantics mirror the canonical server-side wildcard parser
+// (wildcard-set-provisioning.service.ts: `walkYamlTree` flatten to `parent/child`
+// names, CRLF/trim/non-empty txt splitting, first-write-wins on name collision)
+// so an imported pack matches what provisioning would produce — PLUS a
+// Dynamic-Prompts comment strip and the App-Blocks result/inflation caps.
+
+// ── Caps ─────────────────────────────────────────────────────────────────────
+
+export interface WildcardPackCaps {
+  /** Max zip entries walked (a zip with more is truncated). */
+  maxEntries: number;
+  /** Max uncompressed bytes inflated per entry (the anti-zip-bomb per-file cap). */
+  perEntryBytes: number;
+  /** Max total uncompressed bytes inflated across the pack (anti-zip-bomb). */
+  totalBytes: number;
+  /** Max options kept per list (excess truncated + flagged). */
+  maxOptionsPerList: number;
+  /** Max characters kept per option (excess truncated + flagged). */
+  maxCharsPerOption: number;
+}
+
+export const WILDCARD_PACK_CAPS: WildcardPackCaps = {
+  maxEntries: 2048,
+  perEntryBytes: 1024 * 1024, // 1 MB / entry
+  totalBytes: 16 * 1024 * 1024, // 16 MB total uncompressed
+  maxOptionsPerList: 2000,
+  maxCharsPerOption: 400,
+};
+
+/** Pre-download size ceiling checked on the server-advertised `sizeBytes` BEFORE
+ *  the host fetches anything — so an oversized pack is rejected without a byte
+ *  ever hitting the tab. */
+export const PRE_DOWNLOAD_MAX_BYTES = 32 * 1024 * 1024; // 32 MB
+
+export function exceedsPreDownloadCap(sizeBytes: unknown): boolean {
+  return typeof sizeBytes === 'number' && Number.isFinite(sizeBytes) && sizeBytes > PRE_DOWNLOAD_MAX_BYTES;
+}
+
+// ── GET_WILDCARD_PACK request contract ───────────────────────────────────────
+
+export interface GetWildcardPackRequest {
+  requestId: string;
+  modelVersionId: number;
+}
+
+/**
+ * Validate + normalize a raw GET_WILDCARD_PACK payload from an untrusted iframe.
+ * Returns the sanitized request, or `null` when it must be DROPPED (missing /
+ * empty requestId — nothing to correlate a reply to — or a non-positive /
+ * non-integer modelVersionId). A string modelVersionId (a block may send it as a
+ * string) is coerced.
+ */
+export function resolveGetWildcardPackRequest(raw: unknown): GetWildcardPackRequest | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj.requestId !== 'string' || obj.requestId.length === 0) return null;
+
+  const rawId = obj.modelVersionId;
+  const id =
+    typeof rawId === 'number' ? rawId : typeof rawId === 'string' && rawId.trim() ? Number(rawId) : NaN;
+  if (!Number.isInteger(id) || id <= 0) return null;
+
+  return { requestId: obj.requestId, modelVersionId: id };
+}
+
+// ── Error discriminants ──────────────────────────────────────────────────────
+
+export type WildcardPackErrorCode = 'not-found' | 'forbidden' | 'too-large' | 'parse-failed';
+
+/**
+ * Map a thrown error to the WILDCARD_PACK_RESULT error discriminant. A tagged
+ * error (`err.wildcardPackError`) wins (host-side too-large / parse-failed);
+ * otherwise a tRPC client error's `data.code` maps NOT_FOUND / FORBIDDEN /
+ * PAYLOAD_TOO_LARGE; anything else (network, abort/timeout, unzip/parse failure)
+ * is `parse-failed`.
+ */
+export function classifyWildcardPackError(err: unknown): WildcardPackErrorCode {
+  if (err && typeof err === 'object') {
+    const tag = (err as { wildcardPackError?: unknown }).wildcardPackError;
+    if (tag === 'too-large' || tag === 'parse-failed' || tag === 'not-found' || tag === 'forbidden') {
+      return tag;
+    }
+    const code = (err as { data?: { code?: unknown } }).data?.code;
+    if (code === 'NOT_FOUND') return 'not-found';
+    if (code === 'FORBIDDEN') return 'forbidden';
+    if (code === 'PAYLOAD_TOO_LARGE') return 'too-large';
+  }
+  return 'parse-failed';
+}
+
+/** Throw a host-tagged error the classifier maps to `code` (used by the zip/host
+ *  shells for too-large / parse-failed states that aren't tRPC errors). */
+export function wildcardPackError(code: WildcardPackErrorCode, message?: string): Error {
+  const err = new Error(message ?? code) as Error & { wildcardPackError: WildcardPackErrorCode };
+  err.wildcardPackError = code;
+  return err;
+}
+
+// ── Entry classification ─────────────────────────────────────────────────────
+
+export type WildcardEntryKind = 'txt' | 'yaml' | 'skip';
+
+function normalizePath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^(?:\.\/|\/)+/, '');
+}
+
+function basename(path: string): string {
+  const norm = normalizePath(path);
+  const idx = norm.lastIndexOf('/');
+  return idx >= 0 ? norm.slice(idx + 1) : norm;
+}
+
+function stripListExtension(name: string): string {
+  return name.replace(/\.(?:txt|ya?ml)$/i, '');
+}
+
+/**
+ * Decide how (or whether) to handle a zip entry. `.txt` → one list; `.yaml` /
+ * `.yml` → flattened lists; everything ELSE — preview images, nested zips,
+ * dotfiles, __MACOSX resource forks — is `skip` and is NEVER inflated (the
+ * classifier is consulted BEFORE any read, so a nested zip bomb can't be
+ * inflated at all).
+ */
+export function classifyWildcardEntry(path: string): WildcardEntryKind {
+  const norm = normalizePath(path);
+  if (norm.startsWith('__MACOSX/') || norm.includes('/__MACOSX/')) return 'skip';
+  const base = basename(norm);
+  // Dotfiles (`.DS_Store`, `.gitignore`) + macOS `._` resource forks — skip.
+  if (base.startsWith('.') || base.startsWith('._')) return 'skip';
+  const lower = base.toLowerCase();
+  if (lower.endsWith('.txt')) return 'txt';
+  if (lower.endsWith('.yaml') || lower.endsWith('.yml')) return 'yaml';
+  return 'skip';
+}
+
+// ── txt parsing ──────────────────────────────────────────────────────────────
+
+/**
+ * A COMMENT line — stripped. `#` followed by whitespace, or a bare `#`. A value
+ * like `#ffffff` (a hex color: `#` followed by a NON-space) is NOT a comment and
+ * is kept. This is the deliberate fix for #3130's nit (it dropped every `#`-led
+ * line, eating hex-color values). Deterministic: `#comment` (no space) is treated
+ * as a value, not a comment — the space-or-EOL rule is the discriminator.
+ */
+export function isTxtCommentLine(line: string): boolean {
+  return /^#(?:\s|$)/.test(line);
+}
+
+/** Extract raw (un-deduped, un-capped) txt options: CRLF-split, trim, drop blank
+ *  + comment lines. Caps are applied later in `finalizeOptions`. */
+export function extractTxtOptions(text: string): string[] {
+  const out: string[] = [];
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    if (isTxtCommentLine(line)) continue;
+    out.push(line);
+  }
+  return out;
+}
+
+// ── yaml flattening ──────────────────────────────────────────────────────────
+
+export interface RawList {
+  name: string;
+  options: string[];
+}
+
+/**
+ * Flatten a parsed (Dynamic-Prompts) YAML tree into named lists, joining the
+ * path from root to each leaf array/scalar with `/` (`clothing/tops`). Mirrors
+ * the canonical server `walkYamlTree`: mixed array+map siblings work, scalar
+ * leaves become one-element lists, and name collisions are first-write-wins
+ * (case-insensitive). Tolerant of a non-object root (returns []).
+ */
+export function flattenYamlLists(parsed: unknown): RawList[] {
+  const out: RawList[] = [];
+  const seen = new Set<string>();
+
+  const pushLeaf = (name: string, items: unknown[]) => {
+    const lower = name.toLowerCase();
+    if (seen.has(lower)) return;
+    const options = items
+      .map((v) => (typeof v === 'string' ? v : v == null ? '' : String(v)))
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (options.length === 0) return;
+    seen.add(lower);
+    out.push({ name, options });
+  };
+
+  const walk = (node: unknown, prefix: string) => {
+    if (Array.isArray(node)) {
+      if (prefix) pushLeaf(prefix, node);
+      return;
+    }
+    if (node && typeof node === 'object') {
+      for (const [key, child] of Object.entries(node as Record<string, unknown>)) {
+        if (!key) continue;
+        walk(child, prefix ? `${prefix}/${key}` : key);
+      }
+      return;
+    }
+    if (typeof node === 'string' && node.trim().length > 0 && prefix) {
+      pushLeaf(prefix, [node]);
+    }
+  };
+
+  // Top-level array with no key namespace is handled by the caller (named after
+  // the file) — walk with empty prefix so object roots namespace by their keys.
+  if (Array.isArray(parsed)) return out; // caller names a bare-array yaml
+  walk(parsed, '');
+  return out;
+}
+
+// ── option finalization (dedupe + caps) ──────────────────────────────────────
+
+/**
+ * Apply the RESULT caps to a list's raw options: truncate each option to
+ * `maxCharsPerOption`, dedupe (first occurrence wins), cap the count at
+ * `maxOptionsPerList`. Sets `truncated` when EITHER an option was char-truncated
+ * OR the count cap was hit. Never throws.
+ */
+export function finalizeOptions(
+  rawOptions: string[],
+  caps: WildcardPackCaps
+): { options: string[]; truncated: boolean } {
+  const seen = new Set<string>();
+  const options: string[] = [];
+  let truncated = false;
+  for (const raw of rawOptions) {
+    let opt = raw;
+    if (opt.length > caps.maxCharsPerOption) {
+      opt = opt.slice(0, caps.maxCharsPerOption);
+      truncated = true;
+    }
+    if (seen.has(opt)) continue;
+    if (options.length >= caps.maxOptionsPerList) {
+      truncated = true;
+      break;
+    }
+    seen.add(opt);
+    options.push(opt);
+  }
+  return { options, truncated };
+}
+
+// ── zip-entry orchestration (the anti-zip-bomb core) ─────────────────────────
+
+export interface RawZipEntry {
+  path: string;
+  /** Declared uncompressed size from the zip central directory, if known. A
+   *  cheap belt: an entry whose DECLARED size already blows the per-entry cap is
+   *  skipped WITHOUT inflating it. `null`/`undefined` → fall through to the
+   *  bounded read (which is the authoritative guard against a lying header). */
+  declaredSize?: number | null;
+  /**
+   * Inflate this entry, HARD-BOUNDED to `limitBytes` — the implementation MUST
+   * stop inflating once `limitBytes` bytes have been produced and report
+   * `hitLimit: true` (a streamed/paused inflate). This is the guarantee that a
+   * hyper-compressible entry can't be fully inflated. `bytes` is the actual
+   * inflated byte count (≤ limitBytes + one decompress block).
+   */
+  read: (limitBytes: number) => Promise<{ text: string; bytes: number; hitLimit: boolean }>;
+}
+
+export interface WildcardPackLists {
+  lists: Record<string, string[]>;
+  truncated: boolean;
+  truncatedLists: string[];
+}
+
+export interface ProcessWildcardOptions {
+  /** Injected YAML parser (e.g. js-yaml `load`) — kept OUT of this pure module so
+   *  it stays dependency-light + unit-testable without pulling js-yaml. */
+  parseYaml: (text: string) => unknown;
+}
+
+/**
+ * Walk classified zip entries and build the named lists, enforcing EVERY cap:
+ *   - `maxEntries`   — stop after N entries (truncated).
+ *   - `perEntryBytes`— declared-size skip belt + a hard-bounded `read` per entry.
+ *   - `totalBytes`   — running uncompressed budget; the loop stops when hit, and
+ *                      each read is bounded to the SMALLER of the per-entry cap
+ *                      and the remaining total budget.
+ *   - result caps    — via finalizeOptions (dedupe, option-count, char-length).
+ *
+ * CRUCIAL (the bug #3130 had): the per-entry cap is enforced DURING inflation by
+ * bounding `read`, and oversized/hyper-inflating entries are SKIPPED or BOUNDED —
+ * never fully inflated then flagged. A skipped image / nested zip / dotfile is
+ * never read at all. A malformed yaml (or an unreadable entry) is TOLERATED
+ * (skipped + truncated flag), never thrown. Name collisions are first-write-wins.
+ */
+export async function processWildcardEntries(
+  entries: RawZipEntry[],
+  caps: WildcardPackCaps,
+  opts: ProcessWildcardOptions
+): Promise<WildcardPackLists> {
+  const raw = new Map<string, string[]>(); // insertion-ordered; first-write-wins
+  const seenNames = new Set<string>();
+  let truncated = false;
+  let totalBytes = 0;
+  let processed = 0;
+
+  const addList = (name: string, options: string[]) => {
+    if (options.length === 0) return;
+    const lower = name.toLowerCase();
+    if (seenNames.has(lower)) return;
+    seenNames.add(lower);
+    raw.set(name, options);
+  };
+
+  for (const entry of entries) {
+    if (processed >= caps.maxEntries) {
+      truncated = true;
+      break;
+    }
+    const kind = classifyWildcardEntry(entry.path);
+    if (kind === 'skip') continue; // images / nested zips / dotfiles: never inflate
+
+    // Declared-size belt — skip WITHOUT inflating when the header already exceeds
+    // the per-entry cap.
+    if (
+      typeof entry.declaredSize === 'number' &&
+      Number.isFinite(entry.declaredSize) &&
+      entry.declaredSize > caps.perEntryBytes
+    ) {
+      truncated = true;
+      continue;
+    }
+
+    if (totalBytes >= caps.totalBytes) {
+      truncated = true;
+      break; // total uncompressed budget exhausted — stop the loop
+    }
+
+    processed++;
+    const limit = Math.min(caps.perEntryBytes, caps.totalBytes - totalBytes);
+
+    let read: { text: string; bytes: number; hitLimit: boolean };
+    try {
+      read = await entry.read(limit);
+    } catch {
+      truncated = true; // unreadable / corrupt entry — tolerate, keep going
+      continue;
+    }
+    totalBytes += read.bytes;
+    if (read.hitLimit) truncated = true;
+
+    if (kind === 'txt') {
+      const name = stripListExtension(basename(entry.path));
+      if (name) addList(name, extractTxtOptions(read.text));
+      continue;
+    }
+
+    // yaml / yml
+    let parsed: unknown;
+    try {
+      parsed = opts.parseYaml(read.text);
+    } catch {
+      truncated = true; // malformed yaml — tolerate (never fail the whole pack)
+      continue;
+    }
+    if (Array.isArray(parsed)) {
+      // Bare top-level array → one list named after the file.
+      const name = stripListExtension(basename(entry.path));
+      const options = parsed
+        .map((v) => (typeof v === 'string' ? v : v == null ? '' : String(v)))
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+      if (name) addList(name, options);
+    } else {
+      for (const list of flattenYamlLists(parsed)) addList(list.name, list.options);
+    }
+  }
+
+  const lists: Record<string, string[]> = {};
+  const truncatedLists: string[] = [];
+  for (const [name, options] of raw) {
+    const fin = finalizeOptions(options, caps);
+    if (fin.options.length === 0) continue;
+    lists[name] = fin.options;
+    if (fin.truncated) {
+      truncated = true;
+      truncatedLists.push(name);
+    }
+  }
+
+  return { lists, truncated, truncatedLists };
+}

--- a/src/components/AppBlocks/wildcardPackParse.ts
+++ b/src/components/AppBlocks/wildcardPackParse.ts
@@ -44,6 +44,12 @@ export function exceedsPreDownloadCap(sizeBytes: unknown): boolean {
   return typeof sizeBytes === 'number' && Number.isFinite(sizeBytes) && sizeBytes > PRE_DOWNLOAD_MAX_BYTES;
 }
 
+/** Max concurrent wildcard fetch+parse operations IN ONE TAB. The server rate-
+ *  limit (30/60s) would otherwise permit ~30 concurrent parses, each inflating
+ *  up to the 16 MB budget — a memory spike in the tab. Excess requests get a
+ *  `busy` result (the block retries) rather than queueing unbounded. */
+export const WILDCARD_MAX_CONCURRENT = 3;
+
 // ── GET_WILDCARD_PACK request contract ───────────────────────────────────────
 
 export interface GetWildcardPackRequest {
@@ -73,7 +79,14 @@ export function resolveGetWildcardPackRequest(raw: unknown): GetWildcardPackRequ
 
 // ── Error discriminants ──────────────────────────────────────────────────────
 
-export type WildcardPackErrorCode = 'not-found' | 'forbidden' | 'too-large' | 'parse-failed';
+export type WildcardPackErrorCode =
+  | 'not-found'
+  | 'forbidden'
+  | 'too-large'
+  | 'parse-failed'
+  // Host-side backpressure: too many wildcard fetch+parse operations already
+  // in flight in THIS tab (see WILDCARD_MAX_CONCURRENT). The block should retry.
+  | 'busy';
 
 /**
  * Map a thrown error to the WILDCARD_PACK_RESULT error discriminant. A tagged
@@ -85,7 +98,13 @@ export type WildcardPackErrorCode = 'not-found' | 'forbidden' | 'too-large' | 'p
 export function classifyWildcardPackError(err: unknown): WildcardPackErrorCode {
   if (err && typeof err === 'object') {
     const tag = (err as { wildcardPackError?: unknown }).wildcardPackError;
-    if (tag === 'too-large' || tag === 'parse-failed' || tag === 'not-found' || tag === 'forbidden') {
+    if (
+      tag === 'too-large' ||
+      tag === 'parse-failed' ||
+      tag === 'not-found' ||
+      tag === 'forbidden' ||
+      tag === 'busy'
+    ) {
       return tag;
     }
     const code = (err as { data?: { code?: unknown } }).data?.code;

--- a/src/components/AppBlocks/wildcardPackZip.test.ts
+++ b/src/components/AppBlocks/wildcardPackZip.test.ts
@@ -1,0 +1,95 @@
+import JSZip from 'jszip';
+import { describe, expect, it } from 'vitest';
+import { parseWildcardZip, readEntryBounded } from './wildcardPackHost';
+import { WILDCARD_PACK_CAPS } from './wildcardPackParse';
+
+// Real end-to-end zip tests: build a zip with JSZip, then run the ACTUAL
+// jszip-backed `parseWildcardZip` (bounded, streamed inflate) against it. Node-
+// safe (no fetch), so the anti-zip-bomb bounds are verified against a real
+// deflate bomb — the security test #3130 lacked.
+
+async function makeZip(files: Record<string, string>, compression: 'STORE' | 'DEFLATE' = 'DEFLATE') {
+  const zip = new JSZip();
+  for (const [name, content] of Object.entries(files)) zip.file(name, content);
+  return zip.generateAsync({ type: 'uint8array', compression });
+}
+
+describe('parseWildcardZip — real zips', () => {
+  it('parses txt + yaml entries into named lists', async () => {
+    const bytes = await makeZip({
+      'colors.txt': '# palette\nred\nblue\nred\n#ffffff',
+      'nouns.yaml': 'animals:\n  - cat\n  - dog\nclothing:\n  tops:\n    - shirt',
+    });
+    const { lists, truncated } = await parseWildcardZip(bytes);
+    expect(lists).toEqual({
+      colors: ['red', 'blue', '#ffffff'],
+      animals: ['cat', 'dog'],
+      'clothing/tops': ['shirt'],
+    });
+    expect(truncated).toBe(false);
+  });
+
+  it('skips preview images + dotfiles, yielding only the list files', async () => {
+    const bytes = await makeZip({
+      'colors.txt': 'red\nblue',
+      'preview.png': 'not really a png but classified by extension',
+      '.DS_Store': 'junk',
+      '__MACOSX/colors.txt': 'should-be-ignored',
+    });
+    const { lists } = await parseWildcardZip(bytes);
+    expect(lists).toEqual({ colors: ['red', 'blue'] });
+  });
+
+  it('an images-only zip → empty lists (not an error)', async () => {
+    const bytes = await makeZip({ 'a.png': 'x', 'b.jpg': 'y' });
+    const { lists, truncated } = await parseWildcardZip(bytes);
+    expect(lists).toEqual({});
+    expect(truncated).toBe(false);
+  });
+
+  it('BOUNDS inflation of a real deflate bomb — never fully inflates the entry', async () => {
+    // 8 MB of a single repeated byte → deflates to a few KB. With a 1 MB
+    // per-entry cap, the bounded read must inflate only ~1 MB, NOT 8 MB.
+    const bombText = 'A'.repeat(8 * 1024 * 1024);
+    const zip = new JSZip();
+    zip.file('bomb.txt', bombText);
+    const bytes = await zip.generateAsync({ type: 'uint8array', compression: 'DEFLATE' });
+
+    const zip2 = await JSZip.loadAsync(bytes);
+    const file = zip2.files['bomb.txt'];
+    const limit = WILDCARD_PACK_CAPS.perEntryBytes; // 1 MB
+    const { bytes: inflated, hitLimit } = await readEntryBounded(file, limit);
+    expect(hitLimit).toBe(true);
+    // Bounded to ~limit + one decompression block — decisively NOT the 8 MB total.
+    expect(inflated).toBeGreaterThanOrEqual(limit);
+    expect(inflated).toBeLessThan(limit + 256 * 1024);
+    expect(inflated).toBeLessThan(bombText.length);
+  });
+
+  it('a bomb inside parseWildcardZip is SKIPPED by the declared-size belt + flags truncated', async () => {
+    const bombText = 'A'.repeat(4 * 1024 * 1024); // 4 MB > 1 MB per-entry cap
+    const bytes = await makeZip({ 'bomb.txt': bombText, 'ok.txt': 'red\nblue' });
+    const { lists, truncated } = await parseWildcardZip(bytes);
+    // A real zip carries the uncompressed size in its central directory, so the
+    // declared-size belt skips bomb.txt entirely WITHOUT inflating a byte of it —
+    // the strongest outcome. The OTHER list still parses; the pack is truncated.
+    expect(truncated).toBe(true);
+    expect(lists.ok).toEqual(['red', 'blue']);
+    expect(lists.bomb).toBeUndefined();
+  });
+
+  it('enforces the 16 MB TOTAL uncompressed budget across many entries', async () => {
+    // 20 entries × ~1 MB each = ~20 MB uncompressed, over the 16 MB total cap.
+    const files: Record<string, string> = {};
+    for (let i = 0; i < 20; i++) files[`f${i}.txt`] = 'A'.repeat(1024 * 1024);
+    const bytes = await makeZip(files);
+    const { lists, truncated } = await parseWildcardZip(bytes);
+    expect(truncated).toBe(true);
+    // Not all 20 lists survive — the loop stops once the total budget is spent.
+    expect(Object.keys(lists).length).toBeLessThan(20);
+  });
+
+  it('a corrupt / non-zip buffer rejects (loadAsync throws)', async () => {
+    await expect(parseWildcardZip(new Uint8Array([1, 2, 3, 4, 5]))).rejects.toBeTruthy();
+  });
+});

--- a/src/server/routers/generation.router.ts
+++ b/src/server/routers/generation.router.ts
@@ -8,6 +8,7 @@ import {
   getGenerationResourcesSchema,
   getResourceDataByIdsSchema,
   resolveImageMetaSchema,
+  resolveWildcardPackSchema,
   // sendFeedbackSchema,
 } from '~/server/schema/generation.schema';
 import {
@@ -29,8 +30,9 @@ import {
   // textToImageTestRun,
   toggleUnavailableResource,
 } from '~/server/services/generation/generation.service';
-import { moderatorProcedure, publicProcedure, router } from '~/server/trpc';
-import { edgeCacheIt, purgeOnSuccess } from '~/server/middleware.trpc';
+import { moderatorProcedure, protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { edgeCacheIt, purgeOnSuccess, rateLimit } from '~/server/middleware.trpc';
+import { resolveWildcardPackForUser } from '~/server/services/wildcard-pack.service';
 import { CacheTTL } from '~/server/common/constants';
 import {
   getWorkflowDefinitions,
@@ -157,5 +159,34 @@ export const generationRouter = router({
     .input(resolveImageMetaSchema)
     .query(({ input, ctx }) =>
       resolveImageMeta({ input, user: ctx.user, sfwOnly: ctx.features.isGreen })
+    ),
+  // App Blocks wildcard-pack import (W13) — the SESSION-authed resolve step for
+  // the page-host message bridge. A page block posts GET_WILDCARD_PACK to the
+  // PageBlockHost, which calls this with the viewer's real session, then fetches
+  // + unzips the returned signed URL CLIENT-SIDE (bytes never touch a web pod).
+  //
+  // A MUTATION deliberately (not a query, though it reads): the response carries
+  // a short-lived signed download URL, which a `.query` would leak into the
+  // `?input=…` cache key / URL / Referer where it's replayable within its TTL —
+  // the same reasoning as blocks.getMyBuzzBalance. Gating + maturity live in
+  // resolveWildcardPackForUser (all download-gate refusals → NOT_FOUND; a pack
+  // above the viewer's maturity ceiling → FORBIDDEN).
+  resolveWildcardPack: protectedProcedure
+    .use(
+      rateLimit({
+        // A gated file-resolve reachable per block-import click. Bound the rate
+        // so a page block can't hammer the delivery-worker signing path.
+        limit: 30,
+        period: 60,
+        errorMessage: 'Too many wildcard-pack requests — slow down.',
+      })
+    )
+    .input(resolveWildcardPackSchema)
+    .mutation(({ input, ctx }) =>
+      resolveWildcardPackForUser({
+        modelVersionId: input.modelVersionId,
+        user: ctx.user,
+        canViewNsfw: ctx.features.canViewNsfw,
+      })
     ),
 });

--- a/src/server/schema/generation.schema.ts
+++ b/src/server/schema/generation.schema.ts
@@ -384,3 +384,11 @@ export const resolveImageMetaSchema = z.object({
   /** Raw EXIF metadata extracted from the image */
   metadata: z.record(z.string(), z.unknown()),
 });
+
+export type ResolveWildcardPackInput = z.infer<typeof resolveWildcardPackSchema>;
+export const resolveWildcardPackSchema = z.object({
+  /** The `Wildcards`-type ModelVersion whose zip pack to gate + resolve a
+   *  short-lived signed download URL for (the App Blocks page-host bridge then
+   *  fetches + unzips it client-side, as the logged-in user). */
+  modelVersionId: z.number().int().positive(),
+});

--- a/src/server/services/__tests__/wildcard-pack.service.test.ts
+++ b/src/server/services/__tests__/wildcard-pack.service.test.ts
@@ -1,0 +1,199 @@
+import { TRPCError } from '@trpc/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NsfwLevel } from '~/server/common/enums';
+import { sfwBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+import type { SessionUser } from '~/types/session';
+
+// The service under test resolves a wildcard pack's gated signed URL for the
+// CURRENT USER. We mock the two IO seams — the DB reads (`dbRead`) and the
+// authoritative download gate (`getFileForModelVersion`) — and let the REAL
+// maturity math (getServerBrowsingLevel + Flags + allowMatureContentForCeiling)
+// run, since that's the security-relevant logic.
+
+const { modelVersionFindFirst, modelFileFindUnique, getFileForModelVersionMock } = vi.hoisted(
+  () => ({
+    modelVersionFindFirst: vi.fn(),
+    modelFileFindUnique: vi.fn(),
+    getFileForModelVersionMock: vi.fn(),
+  })
+);
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    modelVersion: { findFirst: modelVersionFindFirst },
+    modelFile: { findUnique: modelFileFindUnique },
+  },
+  dbWrite: {},
+}));
+
+vi.mock('~/server/services/file.service', () => ({
+  getFileForModelVersion: getFileForModelVersionMock,
+}));
+
+// eslint-disable-next-line import/first
+import { resolveWildcardPackForUser } from '~/server/services/wildcard-pack.service';
+
+const sfwUser: SessionUser = {
+  id: 7,
+  showNsfw: false,
+  blurNsfw: true,
+  browsingLevel: NsfwLevel.PG,
+  onboarding: 0,
+  username: 'viewer',
+};
+
+const matureUser: SessionUser = {
+  ...sfwUser,
+  showNsfw: true,
+  browsingLevel: NsfwLevel.PG | NsfwLevel.PG13 | NsfwLevel.R,
+};
+
+function wildcardVersion(overrides: Partial<{ nsfwLevel: number }> = {}) {
+  return {
+    id: 100,
+    name: 'v1.0',
+    nsfwLevel: overrides.nsfwLevel ?? NsfwLevel.PG,
+    model: {
+      id: 55,
+      type: 'Wildcards',
+      name: 'Cool Wildcards',
+      user: { username: 'creator' },
+    },
+  };
+}
+
+const successGate = {
+  status: 'success' as const,
+  url: 'https://civitai-modelfiles.example/signed?token=abc',
+  fileId: 999,
+  modelId: 55,
+  modelVersionId: 100,
+  nsfw: false,
+  inEarlyAccess: false,
+  metadata: {},
+  isDownloadable: true,
+};
+
+beforeEach(() => {
+  modelVersionFindFirst.mockReset();
+  modelFileFindUnique.mockReset();
+  getFileForModelVersionMock.mockReset();
+  modelFileFindUnique.mockResolvedValue({ sizeKB: 500 });
+});
+
+describe('resolveWildcardPackForUser — type gate', () => {
+  it('throws NOT_FOUND when the version does not exist', async () => {
+    modelVersionFindFirst.mockResolvedValue(null);
+    await expect(
+      resolveWildcardPackForUser({ modelVersionId: 100, user: sfwUser, canViewNsfw: false })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(getFileForModelVersionMock).not.toHaveBeenCalled();
+  });
+
+  it('throws NOT_FOUND when the model is not a Wildcards type (no probing)', async () => {
+    modelVersionFindFirst.mockResolvedValue({
+      ...wildcardVersion(),
+      model: { ...wildcardVersion().model, type: 'Checkpoint' },
+    });
+    await expect(
+      resolveWildcardPackForUser({ modelVersionId: 100, user: sfwUser, canViewNsfw: false })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(getFileForModelVersionMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveWildcardPackForUser — download gate (getFileForModelVersion is authoritative)', () => {
+  it.each([
+    'not-found',
+    'unauthorized',
+    'archived',
+    'downloads-disabled',
+    'early-access',
+    'resolve-failed',
+    'error',
+  ])('collapses gate status %s to NOT_FOUND (no probing)', async (status) => {
+    modelVersionFindFirst.mockResolvedValue(wildcardVersion());
+    getFileForModelVersionMock.mockResolvedValue({ status });
+    await expect(
+      resolveWildcardPackForUser({ modelVersionId: 100, user: sfwUser, canViewNsfw: false })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('passes the CURRENT USER to the gate (requireAuth / entitlements enforced for that user)', async () => {
+    modelVersionFindFirst.mockResolvedValue(wildcardVersion());
+    getFileForModelVersionMock.mockResolvedValue(successGate);
+    await resolveWildcardPackForUser({ modelVersionId: 100, user: sfwUser, canViewNsfw: false });
+    expect(getFileForModelVersionMock).toHaveBeenCalledWith({ modelVersionId: 100, user: sfwUser });
+  });
+});
+
+describe('resolveWildcardPackForUser — maturity ceiling', () => {
+  it('FORBIDs a mature pack for an under-ceiling (SFW) user', async () => {
+    modelVersionFindFirst.mockResolvedValue(wildcardVersion({ nsfwLevel: NsfwLevel.R }));
+    getFileForModelVersionMock.mockResolvedValue(successGate);
+    await expect(
+      resolveWildcardPackForUser({ modelVersionId: 100, user: sfwUser, canViewNsfw: false })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('serves a mature pack to a user whose ceiling allows it (sfwOnly:false)', async () => {
+    modelVersionFindFirst.mockResolvedValue(wildcardVersion({ nsfwLevel: NsfwLevel.R }));
+    getFileForModelVersionMock.mockResolvedValue(successGate);
+    const res = await resolveWildcardPackForUser({
+      modelVersionId: 100,
+      user: matureUser,
+      canViewNsfw: true,
+    });
+    expect(res.maturity.sfwOnly).toBe(false);
+    expect(res.signedUrl).toBe(successGate.url);
+  });
+
+  it('serves a SFW (PG) pack to a SFW user with sfwOnly:true + the SFW ceiling', async () => {
+    modelVersionFindFirst.mockResolvedValue(wildcardVersion({ nsfwLevel: NsfwLevel.PG }));
+    getFileForModelVersionMock.mockResolvedValue(successGate);
+    const res = await resolveWildcardPackForUser({
+      modelVersionId: 100,
+      user: sfwUser,
+      canViewNsfw: false,
+    });
+    expect(res.maturity).toEqual({ browsingLevel: sfwBrowsingLevelsFlag, sfwOnly: true });
+  });
+});
+
+describe('resolveWildcardPackForUser — success shape', () => {
+  it('returns the resolved URL, sizeBytes, meta, and maturity', async () => {
+    modelVersionFindFirst.mockResolvedValue(wildcardVersion());
+    getFileForModelVersionMock.mockResolvedValue(successGate);
+    modelFileFindUnique.mockResolvedValue({ sizeKB: 500 });
+
+    const res = await resolveWildcardPackForUser({
+      modelVersionId: 100,
+      user: sfwUser,
+      canViewNsfw: false,
+    });
+
+    expect(res.signedUrl).toBe(successGate.url);
+    expect(res.sizeBytes).toBe(500 * 1024);
+    expect(res.meta).toEqual({
+      modelId: 55,
+      modelVersionId: 100,
+      modelName: 'Cool Wildcards',
+      versionName: 'v1.0',
+      creatorUsername: 'creator',
+    });
+    // sizeBytes read from the EXACT gate-resolved fileId (no drift).
+    expect(modelFileFindUnique).toHaveBeenCalledWith({
+      where: { id: successGate.fileId },
+      select: { sizeKB: true },
+    });
+  });
+
+  it('is a TRPCError instance on refusal (so the router surfaces the right code)', async () => {
+    modelVersionFindFirst.mockResolvedValue(null);
+    const err = await resolveWildcardPackForUser({
+      modelVersionId: 100,
+      user: sfwUser,
+      canViewNsfw: false,
+    }).catch((e) => e);
+    expect(err).toBeInstanceOf(TRPCError);
+  });
+});

--- a/src/server/services/__tests__/wildcard-pack.service.test.ts
+++ b/src/server/services/__tests__/wildcard-pack.service.test.ts
@@ -127,12 +127,15 @@ describe('resolveWildcardPackForUser — download gate (getFileForModelVersion i
 });
 
 describe('resolveWildcardPackForUser — maturity ceiling', () => {
-  it('FORBIDs a mature pack for an under-ceiling (SFW) user', async () => {
+  it('FORBIDs a mature pack for an under-ceiling (SFW) user WITHOUT signing a URL', async () => {
     modelVersionFindFirst.mockResolvedValue(wildcardVersion({ nsfwLevel: NsfwLevel.R }));
     getFileForModelVersionMock.mockResolvedValue(successGate);
     await expect(
       resolveWildcardPackForUser({ modelVersionId: 100, user: sfwUser, canViewNsfw: false })
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    // Maturity is checked BEFORE the download-gate resolution, so a forbidden
+    // request never reaches getFileForModelVersion's delivery-worker signing.
+    expect(getFileForModelVersionMock).not.toHaveBeenCalled();
   });
 
   it('serves a mature pack to a user whose ceiling allows it (sfwOnly:false)', async () => {

--- a/src/server/services/wildcard-pack.service.ts
+++ b/src/server/services/wildcard-pack.service.ts
@@ -97,19 +97,13 @@ export async function resolveWildcardPackForUser({
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Wildcard pack not found' });
   }
 
-  // 2. AUTHORITATIVE download-gate + URL resolution for THIS user. Every refusal
-  //    status (not-found / unauthorized / archived / downloads-disabled /
-  //    early-access / resolve-failed / error) collapses to NOT_FOUND — no
-  //    probing which gate refused. `requireAuth` is satisfied because a
-  //    protectedProcedure always has a user id.
-  const resolved = await getFileForModelVersion({ modelVersionId, user });
-  if (resolved.status !== 'success') {
-    throw new TRPCError({ code: 'NOT_FOUND', message: 'Wildcard pack not found' });
-  }
-
-  // 3. Maturity ceiling — computed from the viewer's REAL session + domain, not
+  // 2. Maturity ceiling — computed from the viewer's REAL session + domain, not
   //    a token claim. A pack whose nsfwLevel bit is not within the ceiling is
   //    FORBIDDEN. `hasFlag(ceiling, 0)` is true, so an unrated (0) pack passes.
+  //    Checked from the version row we already loaded, BEFORE the download-gate
+  //    resolution below — a forbidden (or wrong-type) request then never reaches
+  //    getFileForModelVersion's delivery-worker SIGNING call (no wasted sign for
+  //    a request we're going to reject on maturity anyway).
   const browsingLevel = getServerBrowsingLevel({ canViewNsfw, user });
   const packLevel = version.nsfwLevel ?? 0;
   if (!Flags.hasFlag(browsingLevel, packLevel)) {
@@ -117,6 +111,18 @@ export async function resolveWildcardPackForUser({
       code: 'FORBIDDEN',
       message: 'This wildcard pack exceeds your content maturity setting',
     });
+  }
+
+  // 3. AUTHORITATIVE download-gate + URL resolution for THIS user. Every refusal
+  //    status (not-found / unauthorized / archived / downloads-disabled /
+  //    early-access / resolve-failed / error) collapses to NOT_FOUND — no
+  //    probing which gate refused. `requireAuth` is satisfied because a
+  //    protectedProcedure always has a user id. This is still the authoritative
+  //    download-gate: a maturity-OK-but-download-hidden pack collapses to
+  //    NOT_FOUND here, unchanged.
+  const resolved = await getFileForModelVersion({ modelVersionId, user });
+  if (resolved.status !== 'success') {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Wildcard pack not found' });
   }
 
   // 4. Declared size for the host's pre-download cap. Read the sizeKB of the

--- a/src/server/services/wildcard-pack.service.ts
+++ b/src/server/services/wildcard-pack.service.ts
@@ -1,0 +1,146 @@
+import { TRPCError } from '@trpc/server';
+import { dbRead } from '~/server/db/client';
+import { getFileForModelVersion } from '~/server/services/file.service';
+import { getServerBrowsingLevel } from '~/server/utils/browsing-level';
+import { allowMatureContentForCeiling } from '~/shared/constants/browsingLevel.constants';
+import { Flags } from '~/shared/utils/flags';
+import { ModelType } from '~/shared/utils/prisma/enums';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * Session-authed resolve step for the App Blocks wildcard-pack import bridge
+ * (W13). The page-host (PageBlockHost, running in the civitai page with the
+ * viewer's REAL authenticated session) calls this on the block's behalf, then
+ * fetches + unzips the returned signed URL CLIENT-SIDE, as the user. This proc
+ * does the AUTHORITATIVE gating + URL resolution ONLY — it never fetches or
+ * parses the zip (so a zip-bomb OOMs the user's browser tab, not a web pod).
+ *
+ * Why this is preferable to a block-JWT REST endpoint that server-side fetches +
+ * unzips (the alternative in #3130):
+ *   1. It resolves the file through `getFileForModelVersion` FOR THE CURRENT
+ *      USER, so every creator/user download gate applies authoritatively —
+ *      `requireAuth` (satisfied by the protectedProcedure session),
+ *      `usageControl`/downloads-disabled, early-access/entitlement/
+ *      `versionAccess.hasAccess`, published/public/archived/deleted — instead of
+ *      a hand-rolled partial re-derivation that can bypass those gates.
+ *   2. It returns only a short-lived signed URL; the bytes never touch a serving
+ *      pod's heap.
+ *
+ * ALL download-gate refusals collapse to NOT_FOUND (no probing — a caller can't
+ * distinguish "deleted" from "early-access" from "downloads-disabled" from
+ * "doesn't exist"). The ONE distinct signal is the maturity gate: a pack whose
+ * `nsfwLevel` exceeds the viewer's authoritative browsing-level ceiling is
+ * FORBIDDEN (a mature pack is never served to an under-ceiling user).
+ *
+ * This does NOT count a download — a content read for a page block is the
+ * lightest gated resolution, and `getFileForModelVersion` performs no
+ * view/download increment.
+ */
+
+export interface ResolveWildcardPackResult {
+  /** The gated, short-lived signed download URL (b2 `civitai-modelfiles`, which
+   *  the delivery worker signs). The host fetches this cross-origin as the user. */
+  signedUrl: string;
+  /** Declared file size in bytes (for the host's pre-download cap). */
+  sizeBytes: number;
+  meta: {
+    modelId: number;
+    modelVersionId: number;
+    modelName: string;
+    versionName: string;
+    creatorUsername: string | null;
+  };
+  maturity: {
+    /** The viewer's authoritative browsing-level ceiling (flag bitmask). */
+    browsingLevel: number;
+    /** True when that ceiling permits no mature content. */
+    sfwOnly: boolean;
+  };
+}
+
+export async function resolveWildcardPackForUser({
+  modelVersionId,
+  user,
+  canViewNsfw,
+}: {
+  modelVersionId: number;
+  /** The real logged-in viewer (protectedProcedure guarantees this is set). */
+  user: SessionUser;
+  /** The per-request domain nsfw feature flag (green domain → false). */
+  canViewNsfw: boolean;
+}): Promise<ResolveWildcardPackResult> {
+  // 1. Load the version for the type gate + maturity level + display meta. The
+  //    `model: { is: {} }` filter drops orphaned-required-relation rows (same
+  //    class as getFileForModelVersion) so a model-less version resolves to
+  //    NOT_FOUND rather than throwing.
+  const version = await dbRead.modelVersion.findFirst({
+    where: { id: modelVersionId, model: { is: {} } },
+    select: {
+      id: true,
+      name: true,
+      nsfwLevel: true,
+      model: {
+        select: {
+          id: true,
+          type: true,
+          name: true,
+          user: { select: { username: true } },
+        },
+      },
+    },
+  });
+
+  // Type gate: only `Wildcards`-type versions have importable list packs. A
+  // missing version OR a non-Wildcards type collapses to NOT_FOUND (the type is
+  // not itself sensitive, and a single code avoids leaking existence).
+  if (!version || version.model.type !== ModelType.Wildcards) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Wildcard pack not found' });
+  }
+
+  // 2. AUTHORITATIVE download-gate + URL resolution for THIS user. Every refusal
+  //    status (not-found / unauthorized / archived / downloads-disabled /
+  //    early-access / resolve-failed / error) collapses to NOT_FOUND — no
+  //    probing which gate refused. `requireAuth` is satisfied because a
+  //    protectedProcedure always has a user id.
+  const resolved = await getFileForModelVersion({ modelVersionId, user });
+  if (resolved.status !== 'success') {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Wildcard pack not found' });
+  }
+
+  // 3. Maturity ceiling — computed from the viewer's REAL session + domain, not
+  //    a token claim. A pack whose nsfwLevel bit is not within the ceiling is
+  //    FORBIDDEN. `hasFlag(ceiling, 0)` is true, so an unrated (0) pack passes.
+  const browsingLevel = getServerBrowsingLevel({ canViewNsfw, user });
+  const packLevel = version.nsfwLevel ?? 0;
+  if (!Flags.hasFlag(browsingLevel, packLevel)) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'This wildcard pack exceeds your content maturity setting',
+    });
+  }
+
+  // 4. Declared size for the host's pre-download cap. Read the sizeKB of the
+  //    EXACT file the gate resolved (by its fileId) so the advertised size can't
+  //    drift from the resolved URL.
+  const file = await dbRead.modelFile.findUnique({
+    where: { id: resolved.fileId },
+    select: { sizeKB: true },
+  });
+  const sizeBytes = Math.max(0, Math.round((file?.sizeKB ?? 0) * 1024));
+
+  return {
+    signedUrl: resolved.url,
+    sizeBytes,
+    meta: {
+      modelId: version.model.id,
+      modelVersionId: version.id,
+      modelName: version.model.name,
+      versionName: version.name,
+      creatorUsername: version.model.user?.username ?? null,
+    },
+    maturity: {
+      browsingLevel,
+      sfwOnly: allowMatureContentForCeiling(browsingLevel) === false,
+    },
+  };
+}


### PR DESCRIPTION
## What

Page App Blocks can import a **Wildcards**-type model's parsed prompt lists via a new **PageBlockHost message bridge** — an alternative architecture to #3130 (which does it as a block-JWT REST endpoint that server-side fetches + unzips).

A block posts `GET_WILDCARD_PACK{ requestId, modelVersionId }`; the host — running in the civitai page with the viewer's **real authenticated session** — resolves the gated signed URL, fetches + unzips + parses the pack **client-side, as the user**, and posts back `WILDCARD_PACK_RESULT{ requestId, pack }` (or an `error` discriminant). The untrusted iframe never sees the session, the signed URL, or the raw bytes. This is consistent with the #3128 page-host bridge direction.

## Why it's preferable to #3130 (fixes both audit concerns by construction)

1. **Real user download-gates.** The server step `generation.resolveWildcardPack` is a `protectedProcedure` that resolves the file through **`getFileForModelVersion` for the current user** — so every creator/user gate applies authoritatively: `requireAuth` (satisfied by the logged-in session), `usageControl`/downloads-disabled, early-access / entitlement / `versionAccess.hasAccess`, published/public/archived/deleted. All refusals collapse to `NOT_FOUND` (no probing). A pack whose maturity exceeds the viewer's authoritative browsing-level ceiling → `FORBIDDEN`. No hand-rolled partial re-derivation that can bypass those gates.
2. **A zip-bomb can't OOM a serving pod.** The fetch + a **streamed, hard-bounded inflate** run in the **user's browser tab**, not a web pod. A malicious/hyper-compressible pack OOMs one tab (and is contained by the caps below), not a serving process's heap. #3130's 🔴 becomes a contained, low-blast-radius concern.

## Server

`generation.resolveWildcardPack` — a **mutation** (deliberately, so the short-lived signed URL never lands in a `.query` cache key / GET URL / Referer; same reasoning as `blocks.getMyBuzzBalance`), per-user rate-limited (30/60s). Enforces the `Wildcards` type gate + the `getFileForModelVersion` gate + the maturity ceiling; returns `{ signedUrl, sizeBytes, meta, maturity }`. Does **not** count a download (a content read takes the lightest gated resolution).

## Host

`PageBlockHost` handler + `wildcardPackParse.ts` (pure) + `wildcardPackHost.ts` (zip/fetch shell, `import()`-ed lazily so jszip/js-yaml never enter the page-block bundle unless a pack is requested):

- **32 MB pre-download cap** on the server-advertised size — rejected `too-large` before a byte is fetched.
- **Anti-zip-bomb caps enforced *during* inflation** — this is the specific bug #3130 had (a per-entry size check that flagged but still ran a full inflate). Here: 2048 entries · 1 MB/entry via a declared-uncompressed-size **skip belt** + a streamed `internalStream` read that **pauses at the cap** · 16 MB total uncompressed budget (each read bounded to the smaller of the per-entry cap and the remaining budget) · 2000 options/list · 400 chars/option — **truncate + flag, never throw**. Images / nested zips / dotfiles are classified `skip` and are **never inflated at all**.
- **Parse:** `.txt` → one list/file (CRLF, trim, dedupe, strip comment lines but **keep hex values like `#ffffff`** — fixes #3130's nit); `.yaml` (Dynamic-Prompts) → flattened to `parent/child` list names; mirrors the canonical server wildcard parser's semantics.
- Every path posts a reply (a `pack` or an `error` of `not-found` | `forbidden` | `too-large` | `parse-failed`), so the block's SDK request never hangs.

## SDK co-requisite

The `GET_WILDCARD_PACK` / `WILDCARD_PACK_RESULT` message pair must be added to `@civitai/app-sdk`. It's registered **forward-looking** in `hostHandlerParity` (the compile-time gate is one-directional, so an ahead-of-published key is allowed — the #3128 precedent).

## Relationship to #3130 / #3128

- **Supersedes #3130 for page apps** — coordinate with @daceheg; this PR does **not** close #3130.
- A **model-slot (non-page)** block would still need an endpoint if that use case exists — the host-mediated path is page-surface-only.
- Touches `PageBlockHost.tsx` + `hostHandlerParity.ts`, which the open **#3128** also touches — flagging for merge reconciliation.

## Tests (vitest)

- Pure parse (`wildcardPackParse.test.ts`): **34** — txt comment/blank/CRLF/dedupe, `#ffffff` kept, yaml flatten + malformed tolerance, option/length caps, the per-entry + total byte caps bound inflation (mock entries), images-only → empty, dotfile/nested-zip skip.
- Zip/caps (`wildcardPackZip.test.ts`): **7** — real zips incl. a **real deflate-bomb** proving inflation is bounded (not fully inflated), total-budget cap, corrupt-buffer reject.
- Server proc (`wildcard-pack.service.test.ts`): **15** — type gate, all `getFileForModelVersion` refusals → `NOT_FOUND`, maturity `FORBIDDEN`/serve, success shape, current-user passthrough.
- Parity (`hostHandlerParity.test.ts`): **91** (green with the new entry).
- Host round-trip (`PageBlockHostWildcardPack.browser.test.tsx`): **7** — requestId round-trip, 32 MB pre-download reject, `not-found`/`forbidden`/`parse-failed` discriminants, fetch-abort, dropped no-requestId.
- All existing PageBlockHost browser suites green (**116** component tests total after adding the `generation.resolveWildcardPack` stub to their trpc mocks).

Scoped `tsc --noEmit` clean on the changed files (only pre-existing `event-engine-common` worktree module-resolution noise remains; authoritative typecheck is the Tekton pr-preview).

Ready for `/audit-pr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
