### PR TITLE
feat(app-blocks): generic published-content-author attribution for block spend

### DIFF
--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -572,6 +572,7 @@ model User {
   blockAttributionPayouts          BlockAttributionPayout[]  @relation("BlockAttributionPayoutOwner")
   blockSpendAttributionsAsSpender  BlockSpendAttribution[]   @relation("BlockSpendAttributionSpender")
   blockSpendAttributionsAsAppOwner BlockSpendAttribution[]   @relation("BlockSpendAttributionAppOwner")
+  blockSpendAttributionsAsContentAuthor BlockSpendAttribution[] @relation("BlockSpendAttributionContentAuthor")
   blockSubscriptionAttributionsAsPurchaser BlockSubscriptionAttribution[] @relation("BlockSubscriptionAttributionPurchaser")
   blockSubscriptionAttributionsAsAppOwner  BlockSubscriptionAttribution[] @relation("BlockSubscriptionAttributionAppOwner")
   publishRequestsSubmitted   AppBlockPublishRequest[]        @relation("PublishRequestSubmitter")
@@ -3044,6 +3045,20 @@ model BlockSpendAttribution {
   appOwnerUserId     Int      @map("app_owner_user_id")
   appOwner           User     @relation("BlockSpendAttributionAppOwner", fields: [appOwnerUserId], references: [id], onDelete: Restrict)
 
+  /// The USER who published the shared content this generation ran on behalf
+  /// of (the "content author") — the durable BASIS for a FUTURE creator
+  /// payout. Resolved SERVER-SIDE from `sharedContentKey` against the calling
+  /// app's own `app_<slug>.shared_kv`, never client-supplied. NULL when no
+  /// key was supplied, the row is missing/hidden, or the author is the
+  /// spender (self) or the app owner. FULLY GENERIC — any app that publishes
+  /// cross-user shared content can populate it — not tied to any one app kind.
+  /// TRACK-ONLY today: nothing pays out on it yet.
+  contentAuthorUserId Int?    @map("content_author_user_id")
+  contentAuthor       User?   @relation("BlockSpendAttributionContentAuthor", fields: [contentAuthorUserId], references: [id], onDelete: SetNull)
+  /// The opaque shared-storage `key` the app supplied for this generation
+  /// (bounded, app-owned). NULL when the app supplied none.
+  sharedContentKey    String? @map("shared_content_key")
+
   status             String   @default("pending")
   /// 'self_spend' / 'internal_owner' / 'manual_review'. Spend has no
   /// refund path, so this is never 'refund'/'chargeback'.
@@ -3057,6 +3072,7 @@ model BlockSpendAttribution {
   @@unique([workflowId, appBlockId], map: "block_spend_attribution_workflow_app_uniq")
   @@index([appOwnerUserId, attributedAt(sort: Desc)], map: "bsa_publisher_dashboard_idx")
   @@index([appBlockId, attributedAt(sort: Desc)], map: "bsa_app_block_dashboard_idx")
+  @@index([contentAuthorUserId, attributedAt(sort: Desc)], map: "bsa_content_author_idx")
   @@map("block_spend_attribution")
 }
 

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -811,6 +811,22 @@ export type BlockSpendAttribution = {
   spend_share_pct: number;
   app_owner_share_cents: number;
   app_owner_user_id: number;
+  /**
+   * The USER who published the shared content this generation ran on behalf
+   * of (the "content author") — the durable BASIS for a FUTURE creator
+   * payout. Resolved SERVER-SIDE from `sharedContentKey` against the calling
+   * app's own `app_<slug>.shared_kv`, never client-supplied. NULL when no
+   * key was supplied, the row is missing/hidden, or the author is the
+   * spender (self) or the app owner. FULLY GENERIC — any app that publishes
+   * cross-user shared content can populate it — not tied to any one app kind.
+   * TRACK-ONLY today: nothing pays out on it yet.
+   */
+  content_author_user_id: number | null;
+  /**
+   * The opaque shared-storage `key` the app supplied for this generation
+   * (bounded, app-owned). NULL when the app supplied none.
+   */
+  shared_content_key: string | null;
   status: Generated<string>;
   /**
    * 'self_spend' / 'internal_owner' / 'manual_review'. Spend has no

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -624,6 +624,7 @@ export interface User {
   blockAttributionPayouts?: BlockAttributionPayout[];
   blockSpendAttributionsAsSpender?: BlockSpendAttribution[];
   blockSpendAttributionsAsAppOwner?: BlockSpendAttribution[];
+  blockSpendAttributionsAsContentAuthor?: BlockSpendAttribution[];
   blockSubscriptionAttributionsAsPurchaser?: BlockSubscriptionAttribution[];
   blockSubscriptionAttributionsAsAppOwner?: BlockSubscriptionAttribution[];
   publishRequestsSubmitted?: AppBlockPublishRequest[];
@@ -2104,6 +2105,9 @@ export interface BlockSpendAttribution {
   appOwnerShareCents: number;
   appOwnerUserId: number;
   appOwner?: User;
+  contentAuthorUserId: number | null;
+  contentAuthor?: User | null;
+  sharedContentKey: string | null;
   status: string;
   voidedReason: string | null;
   attributedAt: Date;

--- a/prisma/migrations/20260715120000_block_spend_content_author/migration.sql
+++ b/prisma/migrations/20260715120000_block_spend_content_author/migration.sql
@@ -1,0 +1,56 @@
+-- ============================================================
+-- App Blocks — buzz SPEND attribution: published-content-author basis
+-- ============================================================
+-- Additive, nullable columns on block_spend_attribution so a block-
+-- initiated generation can ALSO capture the USER who published the shared
+-- content the generation ran on behalf of (the "content author"), not just
+-- the app owner. This is the durable BASIS for a FUTURE creator payout to
+-- content authors — it is TRACK-ONLY today (no payout/share logic reads
+-- these columns yet).
+--
+-- FULLY GENERIC: there is no "generator" concept here. Any app whose users
+-- publish cross-user shared content (per-app schema `app_<slug>.shared_kv`)
+-- that drives generation spend can populate these columns. The mechanism is
+-- the same for every app.
+--
+--   content_author_user_id  the User who authored the shared_kv row this
+--                           generation ran on behalf of. Resolved SERVER-
+--                           SIDE from `shared_content_key` against the
+--                           calling app's own `app_<slug>.shared_kv`
+--                           (author_user_id WHERE key = $1 AND hidden_at IS
+--                           NULL) — NEVER a client-supplied author. NULL
+--                           when: no key supplied, the row is missing /
+--                           hidden, or the author is the spender (self) or
+--                           the app owner (fail-open — see the service).
+--   shared_content_key      the opaque shared-storage `key` the app supplied
+--                           for this generation (bounded, app-owned). NULL
+--                           when the app supplied none.
+--
+-- ⚠️ MANUAL-APPLY: committed for history, NOT auto-applied. A human applies
+--    this to prod and the dev database out of band (the main civitai DB is
+--    not on an auto-migrate path). Both columns are ADDITIVE + NULLABLE with
+--    no default and NO backfill, so the apply is order-safe: it can land
+--    before OR after the code that writes them deploys (there are zero readers
+--    of these columns until a future payout slice ships). Existing rows stay
+--    NULL.
+--
+-- content_author_user_id carries a nullable FK to User with ON DELETE SET
+-- NULL (NOT the ON DELETE RESTRICT used by the mandatory user_id /
+-- app_owner_user_id columns): a payout-basis reference must never block a
+-- user account deletion, and losing the basis on deletion is acceptable.
+
+ALTER TABLE "block_spend_attribution"
+  ADD COLUMN "content_author_user_id" INTEGER,
+  ADD COLUMN "shared_content_key"     TEXT;
+
+ALTER TABLE "block_spend_attribution"
+  ADD CONSTRAINT "block_spend_attribution_content_author_fkey"
+    FOREIGN KEY ("content_author_user_id") REFERENCES "User"("id")
+    ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- Future creator-payout access path: "everything credited to content author
+-- X, newest first". Partial (only the populated rows) so it stays tiny while
+-- the column is sparsely populated.
+CREATE INDEX "bsa_content_author_idx"
+  ON "block_spend_attribution" ("content_author_user_id", "attributed_at" DESC)
+  WHERE "content_author_user_id" IS NOT NULL;

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1379,6 +1379,40 @@ describe('blocks.submitWorkflow', () => {
     expect(arg.buzzAmount).toBe(25);
   });
 
+  it('G5: threads the body sharedContentKey (opaque) through to the spend attribution', async () => {
+    // The published-content-author key is app-supplied on the BODY and passed
+    // OPAQUE to the service (which resolves the author server-side). Assert it
+    // is threaded through; when absent it is null (unchanged behaviour).
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+    happyVersionLookup();
+    happyUser();
+    happySubmitWithWorkflow(25, 'wf_real');
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await caller.submitWorkflow({
+      blockToken: 'tok',
+      body: validBody({ sharedContentKey: 'k_content_01ABC' }),
+    });
+    await flushMicrotasks();
+
+    expect(mockRecordSpendAttribution).toHaveBeenCalledTimes(1);
+    expect(mockRecordSpendAttribution.mock.calls[0][0].sharedContentKey).toBe('k_content_01ABC');
+  });
+
+  it('G5: sharedContentKey is null on the attribution when the body omits it', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+    happyVersionLookup();
+    happyUser();
+    happySubmitWithWorkflow(25, 'wf_real');
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+    await flushMicrotasks();
+
+    expect(mockRecordSpendAttribution).toHaveBeenCalledTimes(1);
+    expect(mockRecordSpendAttribution.mock.calls[0][0].sharedContentKey).toBeNull();
+  });
+
   // 🟡-1: the bounty must accrue off the REALIZED debit on the submit
   // snapshot, not the whatif preflight ESTIMATE. Drive the whatif and the
   // real submit to DIFFERENT costs so a regression to `Math.ceil(cost)`

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3139,6 +3139,12 @@ export const blocksRouter = router({
             appBlockId: claims.appBlockId,
             blockInstanceId: claims.blockInstanceId,
             modelId: resolved.modelId,
+            // GENERIC published-content-author basis: the opaque shared-storage
+            // key the app supplied for the content this generation runs on
+            // behalf of. Passed through OPAQUE — the service resolves the author
+            // SERVER-SIDE from the app's own shared storage (never trusts the
+            // client). Omitted → unchanged app-owner-only attribution.
+            sharedContentKey: input.body.sharedContentKey ?? null,
           });
         })().catch(() => {
           /* best-effort: a failed attribution write never breaks submit */

--- a/src/server/schema/blocks/__tests__/workflow.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/workflow.schema.test.ts
@@ -133,3 +133,34 @@ describe('blockWorkflowBodySchema — additionalResources (Page-LoRA)', () => {
     expect((parsed as any).additionalResources[0].strength).toBe(1);
   });
 });
+
+/**
+ * G5 — generic published-content-author key. Opaque, optional, bounded to the
+ * shared-storage key shape (≤64). The server resolves the author from it; the
+ * wire schema only bounds shape.
+ */
+describe('blockWorkflowBodySchema — sharedContentKey (G5)', () => {
+  it('is optional — a body without it parses (field stays undefined)', () => {
+    const parsed = blockWorkflowBodySchema.parse(baseBody());
+    expect((parsed as { sharedContentKey?: unknown }).sharedContentKey).toBeUndefined();
+  });
+
+  it('accepts a bounded opaque key', () => {
+    const parsed = blockWorkflowBodySchema.parse(baseBody({ sharedContentKey: 'k_01ABCDEF' }));
+    expect((parsed as { sharedContentKey?: string }).sharedContentKey).toBe('k_01ABCDEF');
+  });
+
+  it('rejects an over-long key (> 64 chars)', () => {
+    expect(() =>
+      blockWorkflowBodySchema.parse(baseBody({ sharedContentKey: 'k'.repeat(65) }))
+    ).toThrow();
+  });
+
+  it('rejects an empty key', () => {
+    expect(() => blockWorkflowBodySchema.parse(baseBody({ sharedContentKey: '' }))).toThrow();
+  });
+
+  it('rejects a non-string key', () => {
+    expect(() => blockWorkflowBodySchema.parse(baseBody({ sharedContentKey: 123 }))).toThrow();
+  });
+});

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -33,6 +33,10 @@ const DIM_MAX = 2048;
 const STEPS_MAX = 50;
 const QUANTITY_MAX = 4;
 const CLIP_SKIP_MAX = 12;
+// Bound for the opaque published-content-author key (`sharedContentKey`).
+// Matches the shared-storage key shape (apps-shared.router `sharedKeyInput`
+// is ≤64) so a server-ULID row key or an app counter key both fit.
+const SHARED_CONTENT_KEY_MAX = 64;
 
 // Page-LoRA caps (App Blocks Page-LoRA, Increment 1). Intentionally tighter
 // than the platform per-tier resource cap — these come from an untrusted
@@ -122,6 +126,19 @@ const blockTextToImageBodySchema = z.object({
   // domain-allowed set — the maturity policy is never widened here. See
   // `resolveBlockCurrenciesForAccount`.
   accountType: blockAccountTypeSchema.optional(),
+  // Optional GENERIC published-content-author attribution basis. The opaque
+  // shared-storage `key` of the cross-user published content this generation
+  // is running on behalf of — the app supplies it out-of-band from its own
+  // shared storage (`app_<slug>.shared_kv`). When present, the server resolves
+  // it (SERVER-SIDE, off the submit critical path) to the content's AUTHOR and
+  // records that user as the payout basis on the spend-attribution row. Purely
+  // opaque + advisory here: this is NEVER trusted as an author (the author is
+  // re-derived from the key server-side), so a forged key can at worst point at
+  // a non-existent row (→ no attribution). Bounded to the same key shape as the
+  // shared-storage surface (≤64). Omit when N/A — behavior is unchanged.
+  // FULLY GENERIC: any app that publishes cross-user content can send it — not
+  // tied to any one app kind.
+  sharedContentKey: z.string().min(1).max(SHARED_CONTENT_KEY_MAX).optional(),
   params: z.object({
     prompt: z.string().max(PROMPT_MAX).default(''),
     negativePrompt: z.string().max(NEG_PROMPT_MAX).optional(),

--- a/src/server/services/blocks/__tests__/spend-attribution.service.test.ts
+++ b/src/server/services/blocks/__tests__/spend-attribution.service.test.ts
@@ -30,20 +30,31 @@ class FakePrismaKnownError extends Error {
   }
 }
 
-const { mockDbRead, mockDbWrite, mockLog } = vi.hoisted(() => ({
+const { mockDbRead, mockDbWrite, mockLog, mockAppsQuery, mockRequireAppsDb } = vi.hoisted(() => ({
   mockDbRead: {
     oauthClient: { findUnique: vi.fn() },
     blockSpendAttribution: { findUnique: vi.fn() },
+    // G5 content-author resolution reads AppBlock.blockId to derive the app's
+    // shared-storage schema slug (server-side, from the appBlockId).
+    appBlock: { findUnique: vi.fn() },
   },
   mockDbWrite: {
     blockSpendAttribution: { create: vi.fn() },
   },
   mockLog: vi.fn(),
+  // G5: the app-shared datastore pool (`app_<slug>.shared_kv` lookup).
+  mockAppsQuery: vi.fn(),
+  mockRequireAppsDb: vi.fn(),
 }));
 
 vi.mock('~/server/db/client', () => ({
   dbRead: mockDbRead,
   dbWrite: mockDbWrite,
+}));
+// G5: mock the app-shared datastore. `apps-slug` (sanitizeAppSlug/appSchemaIdent)
+// runs REAL — it's a pure, deterministic string helper.
+vi.mock('~/server/db/appsDb', () => ({
+  requireAppsDb: (...args: unknown[]) => mockRequireAppsDb(...args),
 }));
 vi.mock('~/server/logging/client', () => ({
   logToAxiom: (...args: unknown[]) => {
@@ -143,18 +154,30 @@ function createEchoesData() {
 beforeEach(() => {
   mockDbRead.oauthClient.findUnique.mockReset();
   mockDbRead.blockSpendAttribution.findUnique.mockReset();
+  mockDbRead.appBlock.findUnique.mockReset();
   mockDbWrite.blockSpendAttribution.create.mockReset();
   mockLog.mockReset();
   computeSpendShareSpy.mockReset();
   reserveAppBountySpy.mockReset();
   refundAppBountySpy.mockReset();
+  mockAppsQuery.mockReset();
+  mockRequireAppsDb.mockReset();
   // Default: app exists, owned by a different user than the spender.
   mockDbRead.oauthClient.findUnique.mockResolvedValue({
     id: APP_ID,
     userId: APP_OWNER_USER_ID,
   });
+  // G5 defaults: the AppBlock resolves to a valid slug; the shared datastore is
+  // available but returns NO row (so an unset key path is a clean no-author).
+  mockDbRead.appBlock.findUnique.mockResolvedValue({ blockId: 'blk_test' });
+  mockRequireAppsDb.mockReturnValue({ query: mockAppsQuery });
+  mockAppsQuery.mockResolvedValue({ rows: [] });
   createEchoesData();
 });
+
+// G5 shared_kv author fixtures.
+const CONTENT_KEY = 'k_content_01ABC';
+const CONTENT_AUTHOR_ID = 777; // distinct from spender + app owner
 
 describe('buzzSpendToUsdCents', () => {
   it('converts Buzz to USD cents at the 1000:1 ratio, floored', () => {
@@ -345,5 +368,166 @@ describe('recordSpendAttribution', () => {
     });
     // Did NOT fall through to the idempotent lookup.
     expect(mockDbRead.blockSpendAttribution.findUnique).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * G5 — GENERIC published-content-author attribution. When the app supplies an
+ * opaque `sharedContentKey`, the CONTENT AUTHOR is resolved SERVER-SIDE from the
+ * app's own shared storage (`app_<slug>.shared_kv`) and recorded as the
+ * future-payout basis. Track-only; the existing app-owner attribution is
+ * unchanged in every case. FULLY GENERIC — not tied to any one app kind.
+ */
+describe('recordSpendAttribution — content-author basis (G5)', () => {
+  it('valid key → records content_author_user_id = the shared_kv row author, + the key', async () => {
+    mockAppsQuery.mockResolvedValueOnce({ rows: [{ author_user_id: CONTENT_AUTHOR_ID }] });
+
+    const res = await recordSpendAttribution(fakeInput({ sharedContentKey: CONTENT_KEY }));
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+
+    // The content author is the shared_kv row's author_user_id — server-resolved.
+    expect(data.contentAuthorUserId).toBe(CONTENT_AUTHOR_ID);
+    // The opaque key is recorded verbatim as audit context.
+    expect(data.sharedContentKey).toBe(CONTENT_KEY);
+    // App-owner attribution is UNCHANGED (still the OauthClient owner, share 0).
+    expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
+    expect(data.appOwnerShareCents).toBe(0);
+    expect(res.written).toBe(true);
+
+    // FORGE-SAFETY: the schema is derived from the SERVER `appBlockId`
+    // (AppBlock.blockId 'blk_test' → schema "app_blk_test") and the ONLY bound
+    // param is the supplied key — the author is read from the DB, never input.
+    expect(mockDbRead.appBlock.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: APP_BLOCK_ID } })
+    );
+    const [sql, params] = mockAppsQuery.mock.calls[0];
+    expect(sql).toContain('"app_blk_test".shared_kv');
+    expect(sql).toContain('hidden_at IS NULL');
+    expect(params).toEqual([CONTENT_KEY]);
+  });
+
+  it('absent key → content_author NULL, key NULL, shared datastore NOT queried', async () => {
+    const res = await recordSpendAttribution(fakeInput()); // no sharedContentKey
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(data.contentAuthorUserId).toBeNull();
+    expect(data.sharedContentKey).toBeNull();
+    // No key → no lookup work at all (unchanged behaviour, zero extra DB work).
+    expect(mockRequireAppsDb).not.toHaveBeenCalled();
+    expect(mockAppsQuery).not.toHaveBeenCalled();
+    expect(mockDbRead.appBlock.findUnique).not.toHaveBeenCalled();
+    // App-owner attribution unchanged.
+    expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
+    expect(res.written).toBe(true);
+  });
+
+  it('non-existent key (no row) → content_author NULL; app-owner attribution unchanged', async () => {
+    mockAppsQuery.mockResolvedValueOnce({ rows: [] });
+    const res = await recordSpendAttribution(fakeInput({ sharedContentKey: 'k_missing' }));
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(data.contentAuthorUserId).toBeNull();
+    // The supplied key is still recorded (opaque audit context).
+    expect(data.sharedContentKey).toBe('k_missing');
+    expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
+    expect(res.written).toBe(true);
+  });
+
+  it('hidden row → excluded by the query (hidden_at IS NULL) → content_author NULL', async () => {
+    // A hidden row returns no result from the `hidden_at IS NULL` filter.
+    mockAppsQuery.mockResolvedValueOnce({ rows: [] });
+    await recordSpendAttribution(fakeInput({ sharedContentKey: CONTENT_KEY }));
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(data.contentAuthorUserId).toBeNull();
+    expect(mockAppsQuery.mock.calls[0][0]).toContain('hidden_at IS NULL');
+  });
+
+  it('self-author (content author == spender) → content_author NULL', async () => {
+    mockAppsQuery.mockResolvedValueOnce({ rows: [{ author_user_id: SPENDER_ID }] });
+    const res = await recordSpendAttribution(fakeInput({ sharedContentKey: CONTENT_KEY }));
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(data.contentAuthorUserId).toBeNull();
+    expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
+    expect(res.written).toBe(true);
+  });
+
+  it('owner-author (content author == app owner) → content_author NULL (already app-owner-attributed)', async () => {
+    mockAppsQuery.mockResolvedValueOnce({ rows: [{ author_user_id: APP_OWNER_USER_ID }] });
+    const res = await recordSpendAttribution(fakeInput({ sharedContentKey: CONTENT_KEY }));
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(data.contentAuthorUserId).toBeNull();
+    expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
+    expect(res.written).toBe(true);
+  });
+
+  it('FORGE-SAFETY: a client cannot influence the recorded author — it is read from the key, not the body', async () => {
+    // The input carries NO author field; even a hostile body pointing the key at
+    // a valuable account only credits whoever the DB row says authored it.
+    mockAppsQuery.mockResolvedValueOnce({ rows: [{ author_user_id: CONTENT_AUTHOR_ID }] });
+    // Sneak an extra (ignored) property onto the input — it must NOT leak through.
+    const hostile = {
+      ...fakeInput({ sharedContentKey: CONTENT_KEY }),
+      contentAuthorUserId: 4242, // attacker-chosen; not part of the input contract
+    } as RecordSpendAttributionInput;
+    await recordSpendAttribution(hostile);
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    // Recorded author is the DB row's author (777), NOT the injected 4242.
+    expect(data.contentAuthorUserId).toBe(CONTENT_AUTHOR_ID);
+    expect(data.contentAuthorUserId).not.toBe(4242);
+  });
+
+  it('a shared-datastore lookup FAILURE degrades to NULL — never throws into the write', async () => {
+    mockAppsQuery.mockRejectedValueOnce(new Error('apps db down'));
+    // The write must still succeed with a NULL content author.
+    const res = await recordSpendAttribution(fakeInput({ sharedContentKey: CONTENT_KEY }));
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(res.written).toBe(true);
+    expect(data.contentAuthorUserId).toBeNull();
+    expect(data.appOwnerUserId).toBe(APP_OWNER_USER_ID);
+  });
+
+  it('shared datastore unavailable (requireAppsDb throws) → NULL, still writes', async () => {
+    mockRequireAppsDb.mockImplementationOnce(() => {
+      throw new Error('APPS_DATABASE_URL is not configured');
+    });
+    const res = await recordSpendAttribution(fakeInput({ sharedContentKey: CONTENT_KEY }));
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(res.written).toBe(true);
+    expect(data.contentAuthorUserId).toBeNull();
+  });
+
+  it('appBlock/slug unresolvable → NULL, still writes', async () => {
+    mockDbRead.appBlock.findUnique.mockResolvedValueOnce(null);
+    const res = await recordSpendAttribution(fakeInput({ sharedContentKey: CONTENT_KEY }));
+    const { data } = mockDbWrite.blockSpendAttribution.create.mock.calls[0][0];
+    expect(res.written).toBe(true);
+    expect(data.contentAuthorUserId).toBeNull();
+    // Never reached the datastore query.
+    expect(mockAppsQuery).not.toHaveBeenCalled();
+  });
+
+  it('idempotency preserved with a key: a duplicate returns the existing row, no second write', async () => {
+    mockAppsQuery.mockResolvedValue({ rows: [{ author_user_id: CONTENT_AUTHOR_ID }] });
+    const first = await recordSpendAttribution(fakeInput({ sharedContentKey: CONTENT_KEY }));
+    expect(first.written).toBe(true);
+
+    mockDbWrite.blockSpendAttribution.create.mockRejectedValueOnce(
+      new FakePrismaKnownError('dup', 'P2002')
+    );
+    mockDbRead.blockSpendAttribution.findUnique.mockResolvedValueOnce({
+      id: 'bsa_existing',
+      status: 'tracked',
+      appOwnerShareCents: 0,
+      spendSharePct: 0,
+      grossValueCents: 500,
+      rateCardVersion: 'unrated',
+      voidedReason: null,
+    });
+    const second = await recordSpendAttribution(fakeInput({ sharedContentKey: CONTENT_KEY }));
+    expect(second.written).toBe(false);
+    expect(second.row.id).toBe('bsa_existing');
+    expect(mockDbRead.blockSpendAttribution.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { workflowId_appBlockId: { workflowId: WORKFLOW_ID, appBlockId: APP_BLOCK_ID } },
+      })
+    );
   });
 });

--- a/src/server/services/blocks/buzz-attribution.service.ts
+++ b/src/server/services/blocks/buzz-attribution.service.ts
@@ -297,6 +297,16 @@ export type RecordSpendAttributionInput = {
   blockInstanceId: string;
   /** Optional: model the generation ran against (analytics only). */
   modelId?: number | null;
+  /**
+   * Optional GENERIC published-content-author basis. The opaque shared-storage
+   * `key` of the cross-user published content this generation is running on
+   * behalf of (the app supplies it from its own `app_<slug>.shared_kv`). When
+   * present, the CONTENT AUTHOR is resolved SERVER-SIDE from this key against
+   * the calling app's shared storage (NEVER trusted from the client) and
+   * recorded as the future-payout basis. Omit when N/A. FULLY GENERIC — works
+   * for any app that publishes cross-user content, not tied to any one app kind.
+   */
+  sharedContentKey?: string | null;
 };
 
 export type RecordSpendAttributionResult = {
@@ -312,6 +322,78 @@ export type RecordSpendAttributionResult = {
     voidedReason: string | null;
   };
 };
+
+/**
+ * Resolve the GENERIC published-content AUTHOR for a spend attribution,
+ * SERVER-SIDE, from the opaque `sharedContentKey` the app supplied.
+ *
+ * FORGE-SAFETY: the author is NEVER taken from client input. It is looked up
+ * from the calling app's OWN shared storage — the per-app Postgres schema
+ * `app_<slug>.shared_kv` (the same store `apps.shared.list` reads) — via
+ * `author_user_id WHERE key = $1 AND hidden_at IS NULL`. The app slug is
+ * derived from the AppBlock row addressed by the SERVER-derived `appBlockId`
+ * (itself from the verified block token), so app A can only ever resolve keys
+ * in app A's schema. A forged/bogus key at worst points at a non-existent row
+ * → NULL (no attribution).
+ *
+ * FAIL-OPEN — returns NULL (leaving content_author_user_id unset, app-owner
+ * attribution untouched) when: the AppBlock/slug can't be resolved, the shared
+ * datastore is unavailable, the row is missing or hidden, or the resolved
+ * author is the spender (self) or the app owner. Any error is swallowed → NULL.
+ * A resolution failure must NEVER throw into the (fire-and-forget) attribution
+ * path and NEVER add latency to the user's submit response.
+ *
+ * FULLY GENERIC: this works for ANY app whose users publish cross-user shared
+ * content that drives generation spend — not tied to any one app kind.
+ */
+export async function resolvePublishedContentAuthorUserId(args: {
+  /** Server-derived AppBlock PK (from the verified token) — selects the schema. */
+  appBlockId: string;
+  /** The opaque shared-storage key the app supplied (bounded upstream). */
+  sharedContentKey: string;
+  /** The spender (self-author → NULL). */
+  spenderUserId: number;
+  /** The app owner (owner-author → NULL; app-owner attribution already covers it). */
+  appOwnerUserId: number;
+}): Promise<number | null> {
+  try {
+    // Derive the app's shared-storage schema from the SERVER-derived appBlockId
+    // (never a client value): AppBlock.blockId → sanitizeAppSlug → app_<slug>.
+    // This is the identical slug the shared-storage writer/reader use.
+    const block = await dbRead.appBlock.findUnique({
+      where: { id: args.appBlockId },
+      select: { blockId: true },
+    });
+    if (!block?.blockId) return null;
+    const { sanitizeAppSlug, appSchemaIdent } = await import('~/server/utils/apps-slug');
+    const slug = sanitizeAppSlug(block.blockId);
+    if (!slug) return null;
+    const schema = appSchemaIdent(slug);
+
+    // The shared datastore lives in cnpg-cluster-apps; requireAppsDb throws in
+    // environments without it (PR previews / dev) — caught below → NULL.
+    const { requireAppsDb } = await import('~/server/db/appsDb');
+    const pool = requireAppsDb();
+    const rows = (
+      await pool.query<{ author_user_id: number }>(
+        `SELECT author_user_id FROM ${schema}.shared_kv WHERE key = $1 AND hidden_at IS NULL LIMIT 1`,
+        [args.sharedContentKey]
+      )
+    ).rows;
+
+    const authorUserId = rows[0]?.author_user_id ?? null;
+    if (authorUserId == null) return null;
+    // Fail-open: self-author (the spender published it) or owner-author (the
+    // app owner published it — already credited via the app-owner attribution).
+    if (authorUserId === args.spenderUserId || authorUserId === args.appOwnerUserId) {
+      return null;
+    }
+    return authorUserId;
+  } catch {
+    // Any failure degrades to NULL — never break the attribution/submit.
+    return null;
+  }
+}
 
 /**
  * Record an author bounty for a block-initiated generation that SPENT the
@@ -368,6 +450,7 @@ export async function recordSpendAttribution(
     appBlockId,
     blockInstanceId,
     modelId = null,
+    sharedContentKey = null,
   } = input;
 
   // Resolve + snapshot the app owner (mirrors recordAttribution). The
@@ -395,6 +478,23 @@ export async function recordSpendAttribution(
   const grossValueCents = buzzSpendToUsdCents(buzzAmount);
   const isSelfSpend = userId === app.userId;
   const isInternal = ACTIVE_RATE_CARD.internalAppOwnerUserIds.includes(app.userId);
+
+  // GENERIC published-content-author basis (track-only). When the app supplied
+  // an opaque `sharedContentKey`, resolve the content AUTHOR SERVER-SIDE from
+  // the app's own shared storage and record it as the future-payout basis. This
+  // is off the submit critical path (recordSpendAttribution is fire-and-forget)
+  // and fail-open: any miss/failure/self/owner degrades to NULL, leaving the
+  // existing app-owner attribution untouched. NEVER trusts a client-supplied
+  // author — the author is re-derived from the key. Skip the lookup entirely
+  // when there's no key (unchanged behaviour, zero extra DB work).
+  const contentAuthorUserId = sharedContentKey
+    ? await resolvePublishedContentAuthorUserId({
+        appBlockId,
+        sharedContentKey,
+        spenderUserId: userId,
+        appOwnerUserId: app.userId,
+      })
+    : null;
 
   // TRACK-ONLY money basis: record the gross (USD value of the Buzz burned),
   // defer the bounty. NO rate card is applied here (no computeSpendShare
@@ -449,6 +549,12 @@ export async function recordSpendAttribution(
         spendSharePct,
         appOwnerShareCents,
         appOwnerUserId: app.userId,
+        // GENERIC published-content-author basis (server-resolved; NULL when no
+        // key / miss / self / owner). `sharedContentKey` is the opaque app-
+        // supplied key stored verbatim as audit context; `contentAuthorUserId`
+        // is the forge-safe server-resolved credit.
+        contentAuthorUserId,
+        sharedContentKey,
         status,
         voidedReason,
         voidedAt,
@@ -478,6 +584,10 @@ export async function recordSpendAttribution(
         spendSharePct,
         appOwnerShareCents,
         rateCardVersion,
+        // GENERIC content-author observability: whether a key was supplied and
+        // whether it resolved to a creditable author. Both are opaque/ids only.
+        sharedContentKeyPresent: sharedContentKey != null,
+        contentAuthorUserId,
         status,
         voidedReason,
         isSelfSpend,


### PR DESCRIPTION
## What

Adds **generic published-content-author attribution** for block-initiated generation spend. When a block runs a generation on behalf of cross-user **published shared content**, we now capture the USER who authored that content (the "content author") as the durable basis for a future creator payout — additive to, and independent of, the existing app-owner spend attribution.

Fully generic: there is no app-specific concept. It works for **any** app whose users publish cross-user shared content (`app_<slug>.shared_kv`) that drives generation spend.

**Track-only** — this only captures the author basis. No payout / rate-card / share logic is touched.

## Changes

**1. Migration (additive, nullable — MANUAL-APPLY, not auto-applied)**
`block_spend_attribution` gains:
- `content_author_user_id INT NULL` — FK to `User`, `ON DELETE SET NULL` (a payout-basis reference must never block a user deletion).
- `shared_content_key TEXT NULL` — the opaque app-supplied shared-storage key.
- `bsa_content_author_idx` — partial index (`WHERE content_author_user_id IS NOT NULL`) for the future payout-by-author read path.

Both columns are additive + nullable, no default, **no backfill** → order-safe (can land before or after this code deploys; zero readers until a future payout slice). A human applies it to prod + the dev database out of band.

**2. Body field**
`blockTextToImageBodySchema` gains an optional, bounded (≤64) `sharedContentKey` — the opaque shared-storage `key` of the published content this generation runs on behalf of. The app supplies it out-of-band from its own shared storage; omit when N/A.

**3. Server-side, forge-safe author resolution**
In the fire-and-forget spend-attribution path (`recordSpendAttribution`, fed from `submitWorkflow`), when `sharedContentKey` is present the content author is resolved **server-side** against the calling app's OWN `app_<slug>.shared_kv` (`author_user_id WHERE key = $1 AND hidden_at IS NULL`). The app schema is derived from the server-side `appBlockId` (from the verified block token), so app A can only ever resolve keys in app A's schema. The author is **never** taken from the client body — a forged key at worst points at a non-existent row.

**Fail-open** → `content_author_user_id` stays NULL when: no key supplied, the row is missing / hidden, or the author is the spender (self) or the app owner. Off the submit critical path; any lookup failure (incl. datastore unavailable) degrades to NULL and never throws into submit/attribution. Idempotency + forge-safety of the existing row are preserved.

## Tests
New/updated coverage (all outside `src/pages/**`):
- **Service** (`spend-attribution.service.test.ts`): valid key → author recorded; absent / non-existent / hidden / self-author / owner-author → NULL with app-owner attribution unchanged; forge-safety (author read from the key, not the body); lookup failure + datastore-unavailable degrade to NULL without throwing; idempotency preserved with a key.
- **Router** (`blocks.router.workflow.test.ts`): the opaque `sharedContentKey` is threaded body → attribution; null when omitted.
- **Schema** (`workflow.schema.test.ts`): the field is optional + bounded (≤64, non-empty, string).

`vitest` — 254 passing across the touched suites. `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` — clean.
