### PR TITLE
perf(trpc): Phase 2 — flip WRITE to devalue (READ stays union) 

### DIFF
--- a/src/server/logging/trpc-serialize-log.ts
+++ b/src/server/logging/trpc-serialize-log.ts
@@ -270,9 +270,9 @@ function rateGate(path: string, maxPerSec: number, now: number = Date.now()): nu
 // ---------------------------------------------------------------------------
 
 /**
- * Serialized byte size of the superjson output. `result` is already a JSON-safe
- * plain object ({ json, meta }) produced by superjson.serialize, so this is a
- * single JSON.stringify walk — the closest cheap proxy for the wire payload size.
+ * Serialized byte size of the transformer output. `result` is JSON-safe — either
+ * a superjson `{ json, meta }` object or a devalue string (Phase 2) — so this is a
+ * single JSON.stringify walk, the closest cheap proxy for the wire payload size.
  * NEVER runs on the common path (gated behind the duration floor). Returns
  * undefined if stringify fails, so a size-measurement failure never blocks a
  * duration-based log.

--- a/src/server/services/buzz-withdrawal-request.service.ts
+++ b/src/server/services/buzz-withdrawal-request.service.ts
@@ -670,19 +670,24 @@ export const updateBuzzWithdrawalRequest = async ({
   return await Promise.all(
     requests.map(async (req) => {
       try {
-        // Worse case is we'll need to re-process it alone, hence nothing too bad. We'll just return the error.
-        return processRequest(req);
+        // `await` so the catch below actually fires (without it the rejection
+        // escapes to Promise.all and the log never runs).
+        return await processRequest(req);
       } catch (e) {
         await logToAxiom({
           type: 'update-buzz-withdrawal-request-error',
           message: 'Failed to update withdrawal request',
           data: {
             requestId: req.id,
-            error: e,
+            error: e instanceof Error ? e.message : String(e),
           },
         });
 
-        return e;
+        // Re-throw rather than `return e`: returning an Error instance is
+        // unserializable by the devalue tRPC transformer (→ 500). Throwing
+        // surfaces the failure via tRPC's error channel, matching the prior
+        // effective behavior (any failed request fails the mutation).
+        throw e;
       }
     })
   );

--- a/src/server/services/paddle.service.ts
+++ b/src/server/services/paddle.service.ts
@@ -836,7 +836,11 @@ export const cancelSubscriptionPlan = async ({ userId }: { userId: number }) => 
 
     return true;
   } catch (e) {
-    return new Error('Failed to cancel subscription');
+    // Throw (not return) the Error: callers use .catch()/try-catch and expect a
+    // rejection on failure, and returning an Error instance as success data is a
+    // latent bug — it serialized to `{}` under superjson and THROWS under devalue
+    // (the tRPC transformer can't serialize a non-POJO class instance).
+    throw new Error('Failed to cancel subscription');
   }
 };
 
@@ -1113,7 +1117,13 @@ export const getAdjustmentsInfinite = async ({
   }
 
   return {
-    items: data,
+    // Paddle SDK returns `Adjustment` class instances (with nested AdjustmentItem/
+    // TotalAdjustments/PayoutTotalsAdjustment instances). The devalue tRPC
+    // transformer is strict and throws on class instances → 500. Coerce to plain
+    // objects; faithful since the SDK stores all data on public enumerable fields
+    // and every timestamp (createdAt/updatedAt) is already a string, so the JSON
+    // round-trip preserves the exact shape the browser received under superjson.
+    items: JSON.parse(JSON.stringify(data)) as Adjustment[],
     nextCursor: nextItem?.id,
   };
 };

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -1,7 +1,6 @@
 import { initTRPC, TRPCError } from '@trpc/server';
 import type { NextApiRequest } from 'next';
 import semver from 'semver';
-import superjson from 'superjson';
 import { OnboardingSteps } from '~/server/common/enums';
 import { withSpan } from '~/server/utils/otel-helpers';
 import {
@@ -13,7 +12,7 @@ import { trpcProcedureDuration } from '~/server/prom/client';
 import { maybeLogTrpcSlow } from '~/server/logging/trpc-slow-log';
 import { longTaskLabelsArmed, runWithLongTaskLabel } from '~/server/eventloop-longtask';
 import { instrumentSerialize } from '~/server/logging/trpc-serialize-log';
-import { unionDeserialize } from '~/shared/utils/trpc-union-transformer';
+import { buildTransformer, writeSerialize } from '~/shared/utils/trpc-union-transformer';
 import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
@@ -45,31 +44,23 @@ const t = initTRPC
   .context<Context>()
   .meta<TRPCMeta>()
   .create({
-    // Phase 1 of the superjson → devalue transformer migration (additive, wire
-    // unchanged). Split into a CombinedDataTransformer so READ and WRITE flip
-    // independently in later phases. WRITE (serialize) stays 100% superjson;
-    // READ (deserialize) becomes the format-sniffing UNION so the server can
-    // decode either format before any writer ever emits devalue. `input` is the
-    // request-read path (the only one exercised server-side); `output` is filled
-    // for a complete transformer.
-    transformer: {
-      input: {
-        serialize: (data: any) => superjson.serialize(data),
-        deserialize: unionDeserialize,
-      },
-      output: {
-        // instrumentSerialize times the serialize (the exact frame that pegs the
-        // loop on an oversized response — see trpc-serialize-log.ts) and, only
-        // above a cheap duration floor, logs the offending procedure + byte size.
-        // Disarmed by default: a single boolean branch, then the original
-        // withSpan+superjson. Kept EXACTLY as before — the write stays superjson.
-        serialize: (data: any) =>
-          instrumentSerialize(() =>
-            withSpan('trpc:serialize:superjson', () => superjson.serialize(data))
-          ),
-        deserialize: unionDeserialize,
-      },
-    },
+    // Phase 2 of the superjson → devalue transformer migration: flip the WRITE
+    // to devalue while READ stays the format-sniffing UNION (so a stale peer that
+    // still writes superjson is decoded fine, and rollback is a one-line flip of
+    // the write format back to superjson). The shared `buildTransformer` fills
+    // the request-read/response-read (union) and request-write (devalue) slots;
+    // the ONLY server-specific difference is the instrumented response-serialize
+    // below, whose inner call is still the single-sourced `writeSerialize`.
+    transformer: buildTransformer((data: any) =>
+      // instrumentSerialize times the serialize (the exact frame that pegs the
+      // loop on an oversized response — see trpc-serialize-log.ts) and, only
+      // above a cheap duration floor, logs the offending procedure + byte size.
+      // Disarmed by default: a single boolean branch, then withSpan+writeSerialize.
+      // The wrappers are pass-through — they return writeSerialize's result verbatim.
+      instrumentSerialize(() =>
+        withSpan('trpc:serialize:devalue', () => writeSerialize(data))
+      )
+    ),
     errorFormatter({ shape }) {
       return shape;
     },

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -12,7 +12,11 @@ import { trpcProcedureDuration } from '~/server/prom/client';
 import { maybeLogTrpcSlow } from '~/server/logging/trpc-slow-log';
 import { longTaskLabelsArmed, runWithLongTaskLabel } from '~/server/eventloop-longtask';
 import { instrumentSerialize } from '~/server/logging/trpc-serialize-log';
-import { buildTransformer, writeSerialize } from '~/shared/utils/trpc-union-transformer';
+import {
+  buildTransformer,
+  serverWriteSerialize,
+  WRITE_DEVALUE,
+} from '~/shared/utils/trpc-union-transformer';
 import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
@@ -44,21 +48,28 @@ const t = initTRPC
   .context<Context>()
   .meta<TRPCMeta>()
   .create({
-    // Phase 2 of the superjson → devalue transformer migration: flip the WRITE
-    // to devalue while READ stays the format-sniffing UNION (so a stale peer that
-    // still writes superjson is decoded fine, and rollback is a one-line flip of
-    // the write format back to superjson). The shared `buildTransformer` fills
-    // the request-read/response-read (union) and request-write (devalue) slots;
-    // the ONLY server-specific difference is the instrumented response-serialize
-    // below, whose inner call is still the single-sourced `writeSerialize`.
+    // Phase 2 of the superjson → devalue transformer migration: the response
+    // WRITE is env-gated PER POOL (`TRPC_WRITE_DEVALUE`, resolved once at module
+    // load into `serverWriteSerialize`) while READ stays the format-sniffing
+    // UNION (so a peer that still writes superjson is decoded fine, and rollback
+    // is unsetting the env + a pod restart). Default (flag unset) =
+    // `superjson.serialize` = byte-for-byte the Phase-1 wire, so this is safe to
+    // merge; setting the env `true` on ONE pool makes only that pool write
+    // devalue responses. The shared `buildTransformer` fills the request-read /
+    // response-read (union) and request-write (superjson, never exercised
+    // server-side) slots; the ONLY server-specific difference is the instrumented
+    // response-serialize below, whose inner call is still `serverWriteSerialize`.
     transformer: buildTransformer((data: any) =>
       // instrumentSerialize times the serialize (the exact frame that pegs the
       // loop on an oversized response — see trpc-serialize-log.ts) and, only
       // above a cheap duration floor, logs the offending procedure + byte size.
-      // Disarmed by default: a single boolean branch, then withSpan+writeSerialize.
-      // The wrappers are pass-through — they return writeSerialize's result verbatim.
+      // The span label is derived from the live gate so the freeze-instrumentation
+      // frame name matches what is ACTUALLY written (superjson vs devalue).
+      // The wrappers are pass-through — they return serverWriteSerialize's result.
       instrumentSerialize(() =>
-        withSpan('trpc:serialize:devalue', () => writeSerialize(data))
+        withSpan(`trpc:serialize:${WRITE_DEVALUE ? 'devalue' : 'superjson'}`, () =>
+          serverWriteSerialize(data)
+        )
       )
     ),
     errorFormatter({ shape }) {

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -34,11 +34,14 @@ export const getServerProxySSGHelpers = async (
       apiKeyId: undefined,
       subject: undefined,
     },
-    // Phase 2 of the superjson → devalue migration: SSR dehydrate WRITES devalue
-    // (via the shared `unionTransformer`); the client that hydrates decodes it
-    // through the union READ. SSR HTML and the JS chunks it references are the
-    // same content-hashed deploy, so dehydrate/hydrate is inherently version-
-    // matched. See src/shared/utils/trpc-union-transformer.ts.
+    // Phase 2 of the superjson → devalue migration: SSR runs server-side, so its
+    // dehydrate WRITE goes through the env-gated server writer (`unionTransformer`
+    // = `buildTransformer()` = `serverWriteSerialize`). It flips to devalue only
+    // when THIS pool's Deployment sets `TRPC_WRITE_DEVALUE=true`; otherwise it
+    // writes superjson exactly as in Phase 1. The client that hydrates decodes
+    // either format through the union READ. SSR HTML and the JS chunks it
+    // references are the same content-hashed deploy, so dehydrate/hydrate is
+    // inherently version-matched. See src/shared/utils/trpc-union-transformer.ts.
     transformer: unionTransformer,
   });
   return ssg;

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -34,9 +34,11 @@ export const getServerProxySSGHelpers = async (
       apiKeyId: undefined,
       subject: undefined,
     },
-    // Phase 1 of the superjson → devalue migration: SSR dehydrate still WRITES
-    // superjson (wire unchanged); the union READ is carried by the client that
-    // hydrates. See src/shared/utils/trpc-union-transformer.ts.
+    // Phase 2 of the superjson → devalue migration: SSR dehydrate WRITES devalue
+    // (via the shared `unionTransformer`); the client that hydrates decodes it
+    // through the union READ. SSR HTML and the JS chunks it references are the
+    // same content-hashed deploy, so dehydrate/hydrate is inherently version-
+    // matched. See src/shared/utils/trpc-union-transformer.ts.
     transformer: unionTransformer,
   });
   return ssg;

--- a/src/shared/utils/__tests__/trpc-union-transformer.test.ts
+++ b/src/shared/utils/__tests__/trpc-union-transformer.test.ts
@@ -1,17 +1,25 @@
 import { stringify as devalueStringify } from 'devalue';
 import superjson from 'superjson';
 import { describe, expect, it } from 'vitest';
-import { unionDeserialize, unionTransformer } from '~/shared/utils/trpc-union-transformer';
+import {
+  buildTransformer,
+  unionDeserialize,
+  unionTransformer,
+  writeSerialize,
+} from '~/shared/utils/trpc-union-transformer';
 
 /**
- * Phase 1 of the superjson → devalue tRPC transformer migration adds a
- * format-sniffing UNION deserializer so every reader can decode BOTH formats
- * before any writer emits devalue (the wire stays superjson in Phase 1).
- *
- * The contract under test: `unionDeserialize(write(x))` deep-equals `x` for both
- * writers, across the non-POJO types that actually reach the transformer on the
- * response/request paths — Date, top-level BigInt (feed cursor), `undefined`
- * fields, nested arrays/objects, and Map. Pure (no DB/Prisma), so it runs locally.
+ * Phase 2 of the superjson → devalue tRPC transformer migration flips every WRITE
+ * slot to devalue while the READ slots stay the format-sniffing UNION. The tests
+ * assert two contracts:
+ *   1. UNION READ is version-agnostic — a devalue-WRITTEN payload AND a legacy
+ *      superjson-WRITTEN payload BOTH round-trip through `unionDeserialize`. This
+ *      backward-read compat is what makes the write-flip safe: a stale peer that
+ *      still writes superjson is decoded fine, and rollback is one line.
+ *   2. WRITE is now devalue — every serialize slot (`writeSerialize`, the shared
+ *      `unionTransformer`, and a server-shaped `buildTransformer(...)`) emits a
+ *      devalue string, not a superjson object.
+ * Pure (no DB/Prisma), so it runs locally.
  */
 
 // A representative payload mixing the rich types the feed handlers emit.
@@ -45,18 +53,18 @@ const sample = () => ({
   ]),
 });
 
-describe('unionDeserialize', () => {
-  it('round-trips a superjson-written payload (object shape → superjson branch)', () => {
-    const x = sample();
-    const written = superjson.serialize(x); // ALWAYS an object { json, meta? }
-    expect(typeof written).not.toBe('string');
-    expect(unionDeserialize(written)).toEqual(x);
-  });
-
-  it('round-trips a devalue-written payload (string shape → devalue branch)', () => {
+describe('unionDeserialize (READ stays union in Phase 2)', () => {
+  it('round-trips a devalue-WRITTEN payload (string shape → devalue branch)', () => {
     const x = sample();
     const written = devalueStringify(x); // ALWAYS a string
     expect(typeof written).toBe('string');
+    expect(unionDeserialize(written)).toEqual(x);
+  });
+
+  it('STILL decodes a legacy superjson-WRITTEN payload (backward-read compat / rollback safety)', () => {
+    const x = sample();
+    const written = superjson.serialize(x); // ALWAYS an object { json, meta? }
+    expect(typeof written).not.toBe('string');
     expect(unionDeserialize(written)).toEqual(x);
   });
 
@@ -76,22 +84,60 @@ describe('unionDeserialize', () => {
     }
   });
 
-  it('falls to the superjson branch for null/undefined input (today’s behavior)', () => {
+  it('falls to the superjson branch for null/undefined input (empty-input behavior)', () => {
     // superjson.deserialize of an empty-ish payload — not a string, so it must
     // NOT hit devalue.parse (which would throw on null). Matches how tRPC hands
     // back an absent/empty transformer payload.
     expect(unionDeserialize(superjson.serialize(undefined))).toBeUndefined();
     expect(unionDeserialize(superjson.serialize(null))).toBeNull();
   });
+});
 
-  it('exposes a complete CombinedDataTransformer whose serialize slots stay superjson', () => {
-    // Phase 1 invariant: every WRITE slot is superjson (wire unchanged). Assert by
-    // shape-equality against superjson's own output.
-    const x = { when: new Date('2024-01-01T00:00:00.000Z'), cursor: 42n };
-    expect(unionTransformer.input.serialize(x)).toEqual(superjson.serialize(x));
-    expect(unionTransformer.output.serialize(x)).toEqual(superjson.serialize(x));
-    // READ slots are the union sniffer.
-    expect(unionTransformer.input.deserialize(superjson.serialize(x))).toEqual(x);
-    expect(unionTransformer.output.deserialize(devalueStringify(x))).toEqual(x);
+describe('WRITE is devalue in Phase 2', () => {
+  const x = { when: new Date('2024-01-01T00:00:00.000Z'), cursor: 42n };
+
+  it('writeSerialize is the single-sourced devalue write', () => {
+    const out = writeSerialize(x);
+    expect(typeof out).toBe('string');
+    expect(out).toBe(devalueStringify(x));
+    // and it round-trips through the union read
+    expect(unionDeserialize(out)).toEqual(x);
+  });
+
+  it('unionTransformer (client/SSR) writes devalue strings and reads the union', () => {
+    // WRITE slots: devalue STRING (not a superjson object).
+    expect(typeof unionTransformer.input.serialize(x)).toBe('string');
+    expect(typeof unionTransformer.output.serialize(x)).toBe('string');
+    expect(unionTransformer.input.serialize(x)).toBe(devalueStringify(x));
+    expect(unionTransformer.output.serialize(x)).toBe(devalueStringify(x));
+    // READ slots: the union sniffer decodes BOTH formats.
+    expect(unionTransformer.input.deserialize(devalueStringify(x))).toEqual(x);
+    expect(unionTransformer.output.deserialize(superjson.serialize(x))).toEqual(x);
+  });
+
+  it('server transformer (buildTransformer with an instrumentation-shaped wrapper): serialize == devalue, deserialize == union', () => {
+    // The server passes an instrumented output.serialize whose wrappers are
+    // pass-through (they time/trace, then return writeSerialize's result verbatim).
+    // Model that here with a wrapper that observes the call and returns the value
+    // unchanged — the wire contract must be identical to plain devalue.
+    let wrapped = 0;
+    const instrumentedSerialize = (data: any) => {
+      wrapped++;
+      return writeSerialize(data); // == devalue string, single-sourced
+    };
+    const serverTransformer = buildTransformer(instrumentedSerialize);
+
+    // WRITE: response-serialize is the instrumented devalue path; request-serialize
+    // is the plain single-sourced devalue write.
+    const written = serverTransformer.output.serialize(x);
+    expect(wrapped).toBe(1);
+    expect(typeof written).toBe('string');
+    expect(written).toBe(devalueStringify(x));
+    expect(serverTransformer.input.serialize(x)).toBe(devalueStringify(x));
+
+    // READ: both slots are the union sniffer — devalue string AND legacy superjson.
+    expect(serverTransformer.input.deserialize(devalueStringify(x))).toEqual(x);
+    expect(serverTransformer.input.deserialize(superjson.serialize(x))).toEqual(x);
+    expect(serverTransformer.output.deserialize(written)).toEqual(x);
   });
 });

--- a/src/shared/utils/__tests__/trpc-union-transformer.test.ts
+++ b/src/shared/utils/__tests__/trpc-union-transformer.test.ts
@@ -141,3 +141,66 @@ describe('WRITE is devalue in Phase 2', () => {
     expect(serverTransformer.output.deserialize(written)).toEqual(x);
   });
 });
+
+/**
+ * The wire-output-must-be-a-POJO contract.
+ *
+ * superjson SILENTLY coerced non-POJO tRPC outputs (a returned `Error` → `{}`, an
+ * SDK class instance → a stripped plain object), swallowing latent bugs. devalue
+ * is strict: it THROWS on any value it can't faithfully represent, which turns
+ * those same returns into a 500 the moment the write path is devalue. This encodes
+ * that boundary so a future procedure that returns a non-POJO (a raw `@paddle`/
+ * Stripe/AWS SDK entity, a caught `Error`, a symbol-keyed object, a Promise) is
+ * caught here rather than in prod. It is the invariant the paddle/buzz-withdrawal
+ * write-path fixes in this PR restore.
+ *
+ * NOTE: this guards the SERIALIZER choice, not every call site — grep can't find a
+ * positionally-returned class instance. The real defense is mapping SDK results to
+ * plain objects at the service boundary (see paddle.service `getAdjustmentsInfinite`).
+ */
+describe('write path rejects non-POJO tRPC outputs (devalue is strict)', () => {
+  class SdkEntity {
+    readonly id = 'adj_123';
+    readonly createdAt = '2024-01-01T00:00:00.000Z';
+    constructor() {}
+    // a method makes the prototype non-Object — exactly the Paddle `Adjustment` shape
+    toJSON() {
+      return { id: this.id };
+    }
+  }
+
+  it('throws on a returned Error instance (the cancelSubscriptionPlan / buzz-withdrawal class)', () => {
+    expect(() => writeSerialize(new Error('boom'))).toThrow();
+    // nested in a response object is just as fatal
+    expect(() => writeSerialize({ ok: false, error: new Error('boom') })).toThrow();
+  });
+
+  it('throws on an arbitrary class instance (the Paddle SDK `Adjustment` class)', () => {
+    expect(() => writeSerialize(new SdkEntity())).toThrow();
+    // the exact getAdjustmentsInfinite shape: { items: [<class instance>] }
+    expect(() => writeSerialize({ items: [new SdkEntity()], nextCursor: undefined })).toThrow();
+  });
+
+  it('throws on symbol-keyed objects, symbol/function values, and Promises', () => {
+    expect(() => writeSerialize({ [Symbol('k')]: 1 })).toThrow();
+    expect(() => writeSerialize({ a: Symbol('v') })).toThrow();
+    expect(() => writeSerialize({ fn: () => 1 })).toThrow();
+    expect(() => writeSerialize(Promise.resolve(1))).toThrow();
+  });
+
+  it('ACCEPTS the POJO fix shape — mapping the SDK entity to a plain object round-trips', () => {
+    // The fix: JSON round-trip (or an explicit map) turns the class instance into a
+    // POJO. This is what `getAdjustmentsInfinite` now returns.
+    const pojo = JSON.parse(JSON.stringify({ items: [new SdkEntity()], nextCursor: 'adj_9' }));
+    const out = writeSerialize(pojo);
+    expect(typeof out).toBe('string');
+    expect(unionDeserialize(out)).toEqual(pojo);
+  });
+
+  it('still ACCEPTS the rich POJO types real handlers emit (Date/Map/Set/BigInt are fine)', () => {
+    // devalue represents these faithfully — the contract rejects non-POJOs, NOT
+    // these first-class rich types (so the fix is narrow: only class instances /
+    // Errors / symbols / Promises are the hazard).
+    expect(() => writeSerialize({ d: new Date(), m: new Map([['a', 1]]), s: new Set([1]), n: 2n })).not.toThrow();
+  });
+});

--- a/src/shared/utils/__tests__/trpc-union-transformer.test.ts
+++ b/src/shared/utils/__tests__/trpc-union-transformer.test.ts
@@ -1,24 +1,31 @@
-import { stringify as devalueStringify } from 'devalue';
+import { parse as devalueParse, stringify as devalueStringify } from 'devalue';
 import superjson from 'superjson';
 import { describe, expect, it } from 'vitest';
 import {
   buildTransformer,
+  clientTransformer,
+  pickServerWriteSerialize,
+  serverWriteSerialize,
   unionDeserialize,
   unionTransformer,
+  WRITE_DEVALUE,
   writeSerialize,
 } from '~/shared/utils/trpc-union-transformer';
 
 /**
- * Phase 2 of the superjson → devalue tRPC transformer migration flips every WRITE
- * slot to devalue while the READ slots stay the format-sniffing UNION. The tests
- * assert two contracts:
- *   1. UNION READ is version-agnostic — a devalue-WRITTEN payload AND a legacy
- *      superjson-WRITTEN payload BOTH round-trip through `unionDeserialize`. This
- *      backward-read compat is what makes the write-flip safe: a stale peer that
- *      still writes superjson is decoded fine, and rollback is one line.
- *   2. WRITE is now devalue — every serialize slot (`writeSerialize`, the shared
- *      `unionTransformer`, and a server-shaped `buildTransformer(...)`) emits a
- *      devalue string, not a superjson object.
+ * Phase 2 of the superjson → devalue tRPC transformer migration env-gates ONLY
+ * the SERVER response write (`TRPC_WRITE_DEVALUE`, per-pool) while:
+ *   - READ stays the format-sniffing UNION on EVERY slot (server input-read,
+ *     client response-read, SSR hydrate), so a payload written by EITHER
+ *     serializer decodes regardless of which peer wrote it.
+ *   - the CLIENT always WRITES superjson (the browser bundle can't be per-pool
+ *     gated; the server union-reads its inputs anyway).
+ *   - the SERVER write is `serverWriteSerialize` = superjson by DEFAULT (flag
+ *     unset → wire byte-identical to Phase 1) and devalue only when the pool
+ *     sets `TRPC_WRITE_DEVALUE=true`.
+ * The tests exercise the pure SELECTION logic (`pickServerWriteSerialize`) for
+ * both gate branches rather than reloading the module, plus the union-read
+ * backward compat and the strict non-POJO devalue-write guard.
  * Pure (no DB/Prisma), so it runs locally.
  */
 
@@ -53,7 +60,7 @@ const sample = () => ({
   ]),
 });
 
-describe('unionDeserialize (READ stays union in Phase 2)', () => {
+describe('unionDeserialize (READ stays union on every slot in Phase 2)', () => {
   it('round-trips a devalue-WRITTEN payload (string shape → devalue branch)', () => {
     const x = sample();
     const written = devalueStringify(x); // ALWAYS a string
@@ -61,7 +68,7 @@ describe('unionDeserialize (READ stays union in Phase 2)', () => {
     expect(unionDeserialize(written)).toEqual(x);
   });
 
-  it('STILL decodes a legacy superjson-WRITTEN payload (backward-read compat / rollback safety)', () => {
+  it('round-trips a superjson-WRITTEN payload (object shape → superjson branch)', () => {
     const x = sample();
     const written = superjson.serialize(x); // ALWAYS an object { json, meta? }
     expect(typeof written).not.toBe('string');
@@ -93,47 +100,104 @@ describe('unionDeserialize (READ stays union in Phase 2)', () => {
   });
 });
 
-describe('WRITE is devalue in Phase 2', () => {
-  const x = { when: new Date('2024-01-01T00:00:00.000Z'), cursor: 42n };
-
-  it('writeSerialize is the single-sourced devalue write', () => {
-    const out = writeSerialize(x);
-    expect(typeof out).toBe('string');
-    expect(out).toBe(devalueStringify(x));
-    // and it round-trips through the union read
+describe('serverWriteSerialize gate (TRPC_WRITE_DEVALUE, SERVER write only)', () => {
+  it('default (flag unset in the test env) selects superjson — wire unchanged', () => {
+    // The module read process.env.TRPC_WRITE_DEVALUE at load; it is unset here.
+    expect(WRITE_DEVALUE).toBe(false);
+    const x = sample();
+    const out = serverWriteSerialize(x);
+    // superjson output is an OBJECT, not a string — byte-identical to Phase 1.
+    expect(typeof out).not.toBe('string');
+    expect(out).toEqual(superjson.serialize(x));
+    // and it still round-trips through the union read.
     expect(unionDeserialize(out)).toEqual(x);
   });
 
-  it('unionTransformer (client/SSR) writes devalue strings and reads the union', () => {
-    // WRITE slots: devalue STRING (not a superjson object).
-    expect(typeof unionTransformer.input.serialize(x)).toBe('string');
-    expect(typeof unionTransformer.output.serialize(x)).toBe('string');
-    expect(unionTransformer.input.serialize(x)).toBe(devalueStringify(x));
-    expect(unionTransformer.output.serialize(x)).toBe(devalueStringify(x));
-    // READ slots: the union sniffer decodes BOTH formats.
-    expect(unionTransformer.input.deserialize(devalueStringify(x))).toEqual(x);
-    expect(unionTransformer.output.deserialize(superjson.serialize(x))).toEqual(x);
+  it('pickServerWriteSerialize(false) → superjson OBJECT, decodable by superjson AND union', () => {
+    const write = pickServerWriteSerialize(false);
+    const x = sample();
+    const out = write(x);
+    expect(typeof out).not.toBe('string');
+    expect(superjson.deserialize(out as any)).toEqual(x);
+    expect(unionDeserialize(out)).toEqual(x);
   });
 
-  it('server transformer (buildTransformer with an instrumentation-shaped wrapper): serialize == devalue, deserialize == union', () => {
-    // The server passes an instrumented output.serialize whose wrappers are
-    // pass-through (they time/trace, then return writeSerialize's result verbatim).
-    // Model that here with a wrapper that observes the call and returns the value
-    // unchanged — the wire contract must be identical to plain devalue.
+  it('pickServerWriteSerialize(true) → devalue STRING, decodable by devalue AND union', () => {
+    const write = pickServerWriteSerialize(true);
+    const x = sample();
+    const out = write(x);
+    expect(typeof out).toBe('string');
+    expect(out).toBe(devalueStringify(x));
+    expect(devalueParse(out as string)).toEqual(x);
+    expect(unionDeserialize(out)).toEqual(x);
+  });
+
+  it('round-trips the rich types through BOTH gate selections', () => {
+    const x = sample();
+    for (const flag of [false, true]) {
+      const out = unionDeserialize(pickServerWriteSerialize(flag)(x)) as ReturnType<typeof sample>;
+      expect(out.nextCursor).toBe(9007199254740993n);
+      expect(typeof out.nextCursor).toBe('bigint');
+      expect(out.items[0].createdAt).toBeInstanceOf(Date);
+      expect(out.buckets).toBeInstanceOf(Map);
+      expect(out.buckets.get('y')).toBe(2);
+      expect('description' in out.items[0]).toBe(true);
+      expect(out.items[0].description).toBeUndefined();
+    }
+  });
+});
+
+describe('clientTransformer (browser: superjson WRITE, union READ)', () => {
+  const x = { when: new Date('2024-01-01T00:00:00.000Z'), cursor: 42n };
+
+  it('WRITES superjson (input.serialize output is an OBJECT, not a devalue string)', () => {
+    const written = clientTransformer.input.serialize(x);
+    expect(typeof written).not.toBe('string');
+    expect(written).toEqual(superjson.serialize(x));
+  });
+
+  it('READS the union on output.deserialize (decodes BOTH a superjson and a devalue response)', () => {
+    // an un-flipped pool responds superjson…
+    expect(clientTransformer.output.deserialize(superjson.serialize(x))).toEqual(x);
+    // …and a TRPC_WRITE_DEVALUE=true pool responds devalue — client decodes both.
+    expect(clientTransformer.output.deserialize(devalueStringify(x))).toEqual(x);
+    // input.deserialize is also union (unused on the client, but complete).
+    expect(clientTransformer.input.deserialize(devalueStringify(x))).toEqual(x);
+  });
+});
+
+describe('server transformer (unionTransformer + buildTransformer)', () => {
+  const x = { when: new Date('2024-01-01T00:00:00.000Z'), cursor: 42n };
+
+  it('unionTransformer (SSR/server default) WRITES via the env gate (superjson by default) and READS union', () => {
+    // Default gate off → SSR dehydrate writes superjson (object), wire unchanged.
+    const written = unionTransformer.output.serialize(x);
+    expect(typeof written).not.toBe('string');
+    expect(written).toEqual(superjson.serialize(x));
+    // READ slots are the union sniffer — decode BOTH formats.
+    expect(unionTransformer.output.deserialize(written)).toEqual(x);
+    expect(unionTransformer.output.deserialize(devalueStringify(x))).toEqual(x);
+    expect(unionTransformer.input.deserialize(devalueStringify(x))).toEqual(x);
+  });
+
+  it('buildTransformer honors an instrumentation-shaped output.serialize override; input.serialize is never exercised', () => {
+    // The server proper passes an instrumented output.serialize whose wrappers are
+    // pass-through (time/trace, then return serverWriteSerialize's result verbatim).
+    // Model that with a wrapper that observes the call and returns the value verbatim.
     let wrapped = 0;
     const instrumentedSerialize = (data: any) => {
       wrapped++;
-      return writeSerialize(data); // == devalue string, single-sourced
+      return serverWriteSerialize(data); // == the env-gated write, single-sourced
     };
     const serverTransformer = buildTransformer(instrumentedSerialize);
 
-    // WRITE: response-serialize is the instrumented devalue path; request-serialize
-    // is the plain single-sourced devalue write.
     const written = serverTransformer.output.serialize(x);
     expect(wrapped).toBe(1);
-    expect(typeof written).toBe('string');
-    expect(written).toBe(devalueStringify(x));
-    expect(serverTransformer.input.serialize(x)).toBe(devalueStringify(x));
+    // matches the gate (superjson by default in this test env).
+    expect(written).toEqual(serverWriteSerialize(x));
+
+    // input.serialize is superjson-shaped (harmless; never used server-side).
+    expect(typeof serverTransformer.input.serialize(x)).not.toBe('string');
 
     // READ: both slots are the union sniffer — devalue string AND legacy superjson.
     expect(serverTransformer.input.deserialize(devalueStringify(x))).toEqual(x);
@@ -143,22 +207,24 @@ describe('WRITE is devalue in Phase 2', () => {
 });
 
 /**
- * The wire-output-must-be-a-POJO contract.
+ * The wire-output-must-be-a-POJO contract for the DEVALUE write path.
  *
  * superjson SILENTLY coerced non-POJO tRPC outputs (a returned `Error` → `{}`, an
  * SDK class instance → a stripped plain object), swallowing latent bugs. devalue
  * is strict: it THROWS on any value it can't faithfully represent, which turns
- * those same returns into a 500 the moment the write path is devalue. This encodes
- * that boundary so a future procedure that returns a non-POJO (a raw `@paddle`/
- * Stripe/AWS SDK entity, a caught `Error`, a symbol-keyed object, a Promise) is
- * caught here rather than in prod. It is the invariant the paddle/buzz-withdrawal
- * write-path fixes in this PR restore.
+ * those same returns into a 500 the moment a pool's write path is devalue
+ * (`TRPC_WRITE_DEVALUE=true`). This encodes that boundary so a future procedure
+ * that returns a non-POJO (a raw `@paddle`/Stripe/AWS SDK entity, a caught
+ * `Error`, a symbol-keyed object, a Promise) is caught here rather than in prod
+ * when a pool flips. It is the invariant the paddle/buzz-withdrawal write-path
+ * fixes in this PR restore. `writeSerialize` is exactly the devalue branch of the
+ * gate (`pickServerWriteSerialize(true)`).
  *
  * NOTE: this guards the SERIALIZER choice, not every call site — grep can't find a
  * positionally-returned class instance. The real defense is mapping SDK results to
  * plain objects at the service boundary (see paddle.service `getAdjustmentsInfinite`).
  */
-describe('write path rejects non-POJO tRPC outputs (devalue is strict)', () => {
+describe('devalue write path rejects non-POJO tRPC outputs (devalue is strict)', () => {
   class SdkEntity {
     readonly id = 'adj_123';
     readonly createdAt = '2024-01-01T00:00:00.000Z';

--- a/src/shared/utils/trpc-union-transformer.ts
+++ b/src/shared/utils/trpc-union-transformer.ts
@@ -21,7 +21,8 @@ import superjson from 'superjson';
  * hydrate) accept EITHER format regardless of which serializer wrote the bytes.
  * The union READ is what makes the write-flip safe and reversible: a reader can
  * always decode a superjson payload written by a stale (pre-migration) peer AND
- * a devalue payload written by an up-to-date one.
+ * a devalue payload written by an up-to-date one. READ stays UNION on every slot
+ * in Phase 2 — only the SERVER response write is (env-)flipped, never the read.
  */
 export function unionDeserialize(object: unknown): any {
   return typeof object === 'string'
@@ -30,44 +31,94 @@ export function unionDeserialize(object: unknown): any {
 }
 
 /**
- * The single source of truth for the WRITE format. Phase 2 flips every write
- * slot (client request-serialize, server response-serialize, SSR dehydrate) to
- * devalue by pointing them all at THIS function — so the format can never be
- * flipped in one place and missed in another. A later phase changes only this
- * one function (and the union can then be dropped once no peer writes superjson).
- *
- * `devalue.stringify` always returns a string; the union deserializer above
- * routes that string back through `devalue.parse` on read.
+ * The devalue write. Kept as a named export because it is the value the SERVER
+ * write flips TO (see `serverWriteSerialize`) and it is the exact function the
+ * non-POJO write-path guard test exercises: `devalue.stringify` is STRICT — it
+ * THROWS on any value it can't faithfully represent (a returned `Error`, an SDK
+ * class instance, a symbol/Promise), which is the invariant the paddle/buzz
+ * write-path fixes in this PR restore. `devalue.stringify` always returns a
+ * string; the union deserializer above routes that string back through
+ * `devalue.parse` on read.
  */
 export const writeSerialize = (object: any): string => devalueStringify(object);
 
 /**
- * Build a complete `CombinedDataTransformer` with the union sniffer on both READ
- * slots and `writeSerialize` (devalue) on both WRITE slots. The server overrides
- * `output.serialize` with an instrumentation-wrapped variant (it times the
- * response serialize — the exact frame that pegs the loop on an oversized
- * response) whose inner call is STILL `writeSerialize`, so the wire format stays
- * single-sourced. Every other WRITE/READ slot is identical across client, SSR
- * and server, which is why they share this factory.
+ * Pure selector for the SERVER response write format — extracted so the
+ * env-gate's SELECTION logic is unit-testable without a module reload:
+ *   - `false` (default) → `superjson.serialize` (object output). The wire is
+ *     byte-for-byte what every pool wrote in Phase 1, so merging is zero-risk.
+ *   - `true`            → `devalue.stringify` (string output). Only a pool whose
+ *     Deployment sets `TRPC_WRITE_DEVALUE=true` writes devalue responses.
+ * (superjson v2's default-export methods are pre-bound, so passing
+ * `superjson.serialize` unbound is safe.)
+ */
+export function pickServerWriteSerialize(flag: boolean): (object: any) => any {
+  return flag ? devalueStringify : superjson.serialize;
+}
+
+/**
+ * Server-side write gate, read ONCE at module load. This is the ONLY place the
+ * Phase-2 write format flips, and it flips PER POOL: a pool's Deployment sets
+ * `TRPC_WRITE_DEVALUE=true` to make that pool (and ONLY that pool) write devalue
+ * responses; every other pool keeps writing superjson. Rollback = unset the env
+ * + restart the pod. Default (unset) = superjson everywhere = wire unchanged.
+ *
+ * Reads process.env directly (module-load constant) — the client bundle never
+ * evaluates this branch because the client transformer never references it.
+ */
+export const WRITE_DEVALUE = process.env.TRPC_WRITE_DEVALUE === 'true';
+export const serverWriteSerialize = pickServerWriteSerialize(WRITE_DEVALUE);
+
+/**
+ * Build a complete SERVER-SIDE `CombinedDataTransformer`: union sniffer on both
+ * READ slots, and the env-gated `serverWriteSerialize` on the response WRITE
+ * slot. The server (`src/server/trpc.ts`) overrides `output.serialize` with an
+ * instrumentation-wrapped variant (it times the response serialize — the exact
+ * frame that pegs the loop on an oversized response) whose inner call is STILL
+ * `serverWriteSerialize`, so the write format stays single-sourced through the
+ * gate. The SSR helper uses the default (`buildTransformer()`), so SSR dehydrate
+ * flips only when ITS pool sets `TRPC_WRITE_DEVALUE`.
+ *
+ * `input.serialize` is set to `superjson.serialize` purely to make the object
+ * complete — it is NEVER exercised server-side (the server only DESERIALIZES
+ * request inputs; the CLIENT writes them). Both this and the client transformer
+ * therefore read the union and are independent of the write gate.
  *
  * @param outputSerialize response-serialize override (server injects the
- *   instrumented wrapper). Defaults to the plain `writeSerialize` used by the
- *   client links and SSR helpers.
+ *   instrumented wrapper). Defaults to the env-gated `serverWriteSerialize`.
  */
 export function buildTransformer(
-  outputSerialize: (object: any) => any = writeSerialize
+  outputSerialize: (object: any) => any = serverWriteSerialize
 ): CombinedDataTransformer {
   return {
-    input: { serialize: writeSerialize, deserialize: unionDeserialize },
+    input: { serialize: superjson.serialize, deserialize: unionDeserialize },
     output: { serialize: outputSerialize, deserialize: unionDeserialize },
   };
 }
 
 /**
- * The client/SSR transformer: devalue WRITE (via `writeSerialize`), union READ.
- * Shared by the client tRPC links (`src/utils/trpc.ts`) and the SSR helpers
- * (`src/server/utils/server-side-helpers.ts`). The server builds its own via
+ * The SERVER-SIDE transformer used by the SSR helpers
+ * (`src/server/utils/server-side-helpers.ts`): env-gated response WRITE (via
+ * `serverWriteSerialize`), union READ. The server proper builds its own via
  * `buildTransformer(instrumentedSerialize)` in `src/server/trpc.ts` — the only
  * legitimate server-specific difference is the instrumented `output.serialize`.
  */
 export const unionTransformer: CombinedDataTransformer = buildTransformer();
+
+/**
+ * The CLIENT (browser) transformer: superjson WRITE, union READ.
+ *
+ * The browser bundle is one-size-fits-all — it can't be per-pool gated — so the
+ * client always WRITES superjson request inputs (unchanged from Phase 1). The
+ * server union-READS those inputs, so the client does NOT need to write devalue
+ * for the per-pool server canary. `output.deserialize` stays the UNION sniffer,
+ * so the client decodes BOTH a superjson response (from an un-flipped pool) and
+ * a devalue response (from a `TRPC_WRITE_DEVALUE=true` pool) transparently.
+ *
+ * `output.serialize` is set to `superjson.serialize` only to complete the
+ * object — the client never serializes a response.
+ */
+export const clientTransformer: CombinedDataTransformer = {
+  input: { serialize: superjson.serialize, deserialize: unionDeserialize },
+  output: { serialize: superjson.serialize, deserialize: unionDeserialize },
+};

--- a/src/shared/utils/trpc-union-transformer.ts
+++ b/src/shared/utils/trpc-union-transformer.ts
@@ -1,9 +1,9 @@
 import type { CombinedDataTransformer } from '@trpc/server';
-import { parse as devalueParse } from 'devalue';
+import { parse as devalueParse, stringify as devalueStringify } from 'devalue';
 import superjson from 'superjson';
 
 /**
- * Format-sniffing UNION deserializer — the first (additive) step of the phased
+ * Format-sniffing UNION deserializer — the READ half of the phased
  * superjson → devalue tRPC transformer migration.
  *
  * The two serializers emit disjoint JS types, so no negotiation/versioning is
@@ -15,13 +15,13 @@ import superjson from 'superjson';
  * `typeof x === 'string'` sniff routes each payload to the correct decoder.
  *
  * `null`/`undefined`/absent input is NOT a string, so it falls to the superjson
- * branch — byte-for-byte today's behavior for empty inputs.
+ * branch — byte-for-byte the empty-input behavior from before the migration.
  *
  * This lets every reader (server-reading-input, client-reading-response, SSR
  * hydrate) accept EITHER format regardless of which serializer wrote the bytes.
- * In Phase 1 nothing writes devalue yet (all `serialize` slots stay superjson),
- * so the wire is 100% unchanged; teaching readers both formats first is what
- * makes a later write-flip safe and reversible.
+ * The union READ is what makes the write-flip safe and reversible: a reader can
+ * always decode a superjson payload written by a stale (pre-migration) peer AND
+ * a devalue payload written by an up-to-date one.
  */
 export function unionDeserialize(object: unknown): any {
   return typeof object === 'string'
@@ -30,25 +30,44 @@ export function unionDeserialize(object: unknown): any {
 }
 
 /**
- * superjson serialize wrapped so `this` is preserved when tRPC invokes it as a
- * bare `transformer.input.serialize(x)` (the superjson default export is a class
- * instance whose methods read `this`). Phase 1 keeps every WRITE on superjson —
- * the wire format is unchanged.
+ * The single source of truth for the WRITE format. Phase 2 flips every write
+ * slot (client request-serialize, server response-serialize, SSR dehydrate) to
+ * devalue by pointing them all at THIS function — so the format can never be
+ * flipped in one place and missed in another. A later phase changes only this
+ * one function (and the union can then be dropped once no peer writes superjson).
+ *
+ * `devalue.stringify` always returns a string; the union deserializer above
+ * routes that string back through `devalue.parse` on read.
  */
-const superjsonSerialize = (object: any) => superjson.serialize(object);
+export const writeSerialize = (object: any): string => devalueStringify(object);
 
 /**
- * The Phase-1 client/SSR transformer: WRITE stays superjson, READ is the union
- * sniffer. Shared by the client tRPC links (`src/utils/trpc.ts`) and the SSR
- * helpers (`src/server/utils/server-side-helpers.ts`). The server transformer is
- * built inline in `src/server/trpc.ts` instead, because its `output.serialize`
- * keeps the serialize-timing instrumentation wrapper.
+ * Build a complete `CombinedDataTransformer` with the union sniffer on both READ
+ * slots and `writeSerialize` (devalue) on both WRITE slots. The server overrides
+ * `output.serialize` with an instrumentation-wrapped variant (it times the
+ * response serialize — the exact frame that pegs the loop on an oversized
+ * response) whose inner call is STILL `writeSerialize`, so the wire format stays
+ * single-sourced. Every other WRITE/READ slot is identical across client, SSR
+ * and server, which is why they share this factory.
  *
- * All four slots are filled so the object is a complete `CombinedDataTransformer`
- * (both `input` and `output` require `serialize` + `deserialize`); the slots a
- * given side never exercises are harmless.
+ * @param outputSerialize response-serialize override (server injects the
+ *   instrumented wrapper). Defaults to the plain `writeSerialize` used by the
+ *   client links and SSR helpers.
  */
-export const unionTransformer: CombinedDataTransformer = {
-  input: { serialize: superjsonSerialize, deserialize: unionDeserialize },
-  output: { serialize: superjsonSerialize, deserialize: unionDeserialize },
-};
+export function buildTransformer(
+  outputSerialize: (object: any) => any = writeSerialize
+): CombinedDataTransformer {
+  return {
+    input: { serialize: writeSerialize, deserialize: unionDeserialize },
+    output: { serialize: outputSerialize, deserialize: unionDeserialize },
+  };
+}
+
+/**
+ * The client/SSR transformer: devalue WRITE (via `writeSerialize`), union READ.
+ * Shared by the client tRPC links (`src/utils/trpc.ts`) and the SSR helpers
+ * (`src/server/utils/server-side-helpers.ts`). The server builds its own via
+ * `buildTransformer(instrumentedSerialize)` in `src/server/trpc.ts` — the only
+ * legitimate server-specific difference is the instrumented `output.serialize`.
+ */
+export const unionTransformer: CombinedDataTransformer = buildTransformer();

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -11,7 +11,7 @@ import {
 import type { CreateTRPCNext } from '@trpc/next';
 import { createTRPCNext } from '@trpc/next';
 import type { NextPageContext } from 'next';
-import superjson from 'superjson';
+import { stringify as devalueStringify } from 'devalue';
 import type { AppRouter } from '~/server/routers';
 import { unionTransformer } from '~/shared/utils/trpc-union-transformer';
 import { isDev } from '~/env/other';
@@ -44,10 +44,13 @@ const url = '/api/trpc';
 /**
  * Encoded-URL budget (percent-encoded chars) for a single query's input on the BATCH link.
  * Measured against the ACTUAL wire cost — `encodeURIComponent(JSON.stringify(
- * superjson.serialize(input)))`, the same transform tRPC applies when building the GET URL —
- * NOT a raw-char heuristic. Sits ~280 under the batch link's `maxURLLength: 2083` to absorb
- * the path (`/api/trpc/<proc>`) + `?batch=1&input={"0":…}` wrapper overhead, so a single op
- * can never overflow the batched GET regardless of how punctuation-dense its JSON is.
+ * devalueStringify(input)))`, the same transform tRPC applies when building the GET URL —
+ * NOT a raw-char heuristic. It MUST use the same serializer the client actually writes with
+ * (Phase 2: devalue via `input.serialize`); sizing with a different serializer would let the
+ * GET/POST batching decision drift from the real wire length. Sits ~280 under the batch link's
+ * `maxURLLength: 2083` to absorb the path (`/api/trpc/<proc>`) + `?batch=1&input={"0":…}`
+ * wrapper overhead, so a single op can never overflow the batched GET regardless of how
+ * punctuation-dense its JSON is.
  *
  * Why encoded, not raw: JSON near the limit is structurally dense (`{}",:[]`, each → %XX), so
  * the encoded URL runs ~1.75–1.9× the raw JSON — not the ~1.4× a fixed factor assumes. A raw
@@ -63,17 +66,19 @@ const URL_INPUT_BUDGET = 1800;
  * so it can never trip the "Input is too big for a single dispatch" throw.
  *
  * Measures the ACTUAL encoded wire cost — the exact `encodeURIComponent(JSON.stringify(
- * superjson.serialize(input)))` tRPC builds the GET URL from — against `URL_INPUT_BUDGET`. No
- * length-based short-circuit: a byte/char-count proxy underestimates the encoded length in the
- * unsafe direction (a small-count input can encode large — `superjson` expands special types,
- * and `encodeURIComponent` expands one non-ASCII UTF-16 unit to up to 9 chars, e.g. `中` →
- * `%E4%B8%AD`), which twice let an overflowing op stay batched. `serialize` + `stringify`
- * already run unconditionally, so the encode walk is a marginal added cost, not worth the hole.
+ * devalueStringify(input)))` tRPC builds the GET URL from — against `URL_INPUT_BUDGET`. Uses
+ * the SAME serializer the client links write with (Phase 2: devalue), so the sizer can't drift
+ * from the real URL. No length-based short-circuit: a byte/char-count proxy underestimates the
+ * encoded length in the unsafe direction (a small-count input can encode large — the serializer
+ * expands special types, and `encodeURIComponent` expands one non-ASCII UTF-16 unit to up to 9
+ * chars, e.g. `中` → `%E4%B8%AD`), which twice let an overflowing op stay batched. `stringify`
+ * already runs unconditionally on the write path, so the encode walk is a marginal added cost,
+ * not worth the hole.
  */
 export function isTooLargeToBatch(op: { type: string; input: unknown }) {
   if (op.type !== 'query' || op.input == null) return false;
   try {
-    return encodeURIComponent(JSON.stringify(superjson.serialize(op.input))).length > URL_INPUT_BUDGET;
+    return encodeURIComponent(JSON.stringify(devalueStringify(op.input))).length > URL_INPUT_BUDGET;
   } catch {
     return false;
   }
@@ -405,7 +410,7 @@ export const trpc: CreateTRPCNext<AppRouter, NextPageContext> = createTRPCNext<A
   },
   // v11: `createTRPCNext` requires the transformer at the top level of its options
   // (WithTRPCOptions intersects TransformerOptions). The link carries it too for the
-  // actual wire (de)serialization. Phase 1: union READ, superjson WRITE (wire unchanged).
+  // actual wire (de)serialization. Phase 2: union READ, devalue WRITE.
   transformer: unionTransformer,
   ssr: false,
 });

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -11,9 +11,9 @@ import {
 import type { CreateTRPCNext } from '@trpc/next';
 import { createTRPCNext } from '@trpc/next';
 import type { NextPageContext } from 'next';
-import { stringify as devalueStringify } from 'devalue';
+import superjson from 'superjson';
 import type { AppRouter } from '~/server/routers';
-import { unionTransformer } from '~/shared/utils/trpc-union-transformer';
+import { clientTransformer } from '~/shared/utils/trpc-union-transformer';
 import { isDev } from '~/env/other';
 import { env } from '~/env/client';
 import { showErrorNotification } from '~/utils/notifications';
@@ -44,10 +44,12 @@ const url = '/api/trpc';
 /**
  * Encoded-URL budget (percent-encoded chars) for a single query's input on the BATCH link.
  * Measured against the ACTUAL wire cost — `encodeURIComponent(JSON.stringify(
- * devalueStringify(input)))`, the same transform tRPC applies when building the GET URL —
+ * superjson.serialize(input)))`, the same transform tRPC applies when building the GET URL —
  * NOT a raw-char heuristic. It MUST use the same serializer the client actually writes with
- * (Phase 2: devalue via `input.serialize`); sizing with a different serializer would let the
- * GET/POST batching decision drift from the real wire length. Sits ~280 under the batch link's
+ * (the CLIENT stays superjson-write in Phase 2 — the per-pool devalue flip is SERVER-only,
+ * so the browser bundle keeps writing superjson via `input.serialize`); sizing with a
+ * different serializer would let the GET/POST batching decision drift from the real wire
+ * length. Sits ~280 under the batch link's
  * `maxURLLength: 2083` to absorb the path (`/api/trpc/<proc>`) + `?batch=1&input={"0":…}`
  * wrapper overhead, so a single op can never overflow the batched GET regardless of how
  * punctuation-dense its JSON is.
@@ -66,19 +68,19 @@ const URL_INPUT_BUDGET = 1800;
  * so it can never trip the "Input is too big for a single dispatch" throw.
  *
  * Measures the ACTUAL encoded wire cost — the exact `encodeURIComponent(JSON.stringify(
- * devalueStringify(input)))` tRPC builds the GET URL from — against `URL_INPUT_BUDGET`. Uses
- * the SAME serializer the client links write with (Phase 2: devalue), so the sizer can't drift
- * from the real URL. No length-based short-circuit: a byte/char-count proxy underestimates the
+ * superjson.serialize(input)))` tRPC builds the GET URL from — against `URL_INPUT_BUDGET`. Uses
+ * the SAME serializer the client links write with (the client stays superjson-write in Phase 2),
+ * so the sizer can't drift from the real URL. No length-based short-circuit: a byte/char-count proxy underestimates the
  * encoded length in the unsafe direction (a small-count input can encode large — the serializer
  * expands special types, and `encodeURIComponent` expands one non-ASCII UTF-16 unit to up to 9
- * chars, e.g. `中` → `%E4%B8%AD`), which twice let an overflowing op stay batched. `stringify`
+ * chars, e.g. `中` → `%E4%B8%AD`), which twice let an overflowing op stay batched. `serialize`
  * already runs unconditionally on the write path, so the encode walk is a marginal added cost,
  * not worth the hole.
  */
 export function isTooLargeToBatch(op: { type: string; input: unknown }) {
   if (op.type !== 'query' || op.input == null) return false;
   try {
-    return encodeURIComponent(JSON.stringify(devalueStringify(op.input))).length > URL_INPUT_BUDGET;
+    return encodeURIComponent(JSON.stringify(superjson.serialize(op.input))).length > URL_INPUT_BUDGET;
   } catch {
     return false;
   }
@@ -125,8 +127,8 @@ function httpLinkWithLargeQuerySupport({
 }): TRPCLink<AppRouter> {
   return splitLink({
     condition: isLargeQuery,
-    true: httpLink({ transformer: unionTransformer, url, methodOverride: 'POST', headers }),
-    false: httpLink({ transformer: unionTransformer, url, headers }),
+    true: httpLink({ transformer: clientTransformer, url, methodOverride: 'POST', headers }),
+    false: httpLink({ transformer: clientTransformer, url, headers }),
   });
 }
 
@@ -258,7 +260,7 @@ function terminatingLink({
 }): TRPCLink<AppRouter> {
   return splitLink({
     condition: shouldBatch,
-    true: httpBatchStreamLink({ transformer: unionTransformer, url, headers, maxURLLength: 2083 }),
+    true: httpBatchStreamLink({ transformer: clientTransformer, url, headers, maxURLLength: 2083 }),
     false: httpLinkWithLargeQuerySupport({ url, headers }),
   });
 }
@@ -410,8 +412,9 @@ export const trpc: CreateTRPCNext<AppRouter, NextPageContext> = createTRPCNext<A
   },
   // v11: `createTRPCNext` requires the transformer at the top level of its options
   // (WithTRPCOptions intersects TransformerOptions). The link carries it too for the
-  // actual wire (de)serialization. Phase 2: union READ, devalue WRITE.
-  transformer: unionTransformer,
+  // actual wire (de)serialization. Phase 2 CLIENT: union READ, superjson WRITE (the
+  // per-pool devalue write flip is SERVER-only — see trpc-union-transformer.ts).
+  transformer: clientTransformer,
   ssr: false,
 });
 


### PR DESCRIPTION
## ✅ Safe to merge (wire-unchanged by default) — the FLIP is a separate, gated per-pool env change · kept a DRAFT

**Reworked to shrink the blast radius to almost nothing at merge.** This PR no longer flips the wire format for anyone. With `TRPC_WRITE_DEVALUE` unset (the default), **every pool writes superjson exactly as it does today** — the wire is byte-for-byte identical to Phase 1, so merging is zero-risk and needs no client-saturation gate.

The actual devalue flip becomes a **separate, per-pool env change** (`TRPC_WRITE_DEVALUE=true` on one Deployment) that is gated on the **Faro real-browser saturation check** — not on merging this code. That flip is where the [DO-NOT-FLIP-YET] caution moves to; it is not a merge blocker.

Left as a **draft** deliberately (sequencing with the rest of the migration), but it is now safe to merge whenever.

---

## What this does

Phase 1 (already merged) added a **format-sniffing UNION deserializer** on every READ slot: `typeof x === 'string' ? devalue.parse(x) : superjson.deserialize(x)`. Because `superjson.serialize` always returns an object and `devalue.stringify` always returns a string, a reader can decode **either** format with zero negotiation. Phase 1 left every WRITE on superjson, so the wire was unchanged.

**Phase 2 (this PR) env-gates ONLY the SERVER response write, per pool; READ stays UNION everywhere; the CLIENT stays superjson-write.** This turns the highest-blast-radius step into a safe, per-pool canary with an instant env-flip rollback.

- **Server response write = env-gated.** `src/shared/utils/trpc-union-transformer.ts` reads `TRPC_WRITE_DEVALUE` **once at module load** into `serverWriteSerialize` (unset → `superjson.serialize`, `true` → `devalue.stringify`). A pure `pickServerWriteSerialize(flag)` holds the selection so it's unit-testable without a module reload. `buildTransformer(outputSerialize?)` fills union-READ on both slots + `serverWriteSerialize` on the response WRITE; `unionTransformer = buildTransformer()` is the server/SSR transformer.
- **Server** (`src/server/trpc.ts`): `transformer: buildTransformer(instrumented)`, where the instrumented response-serialize wraps `serverWriteSerialize` in the existing serialize-timing instrumentation + span. The span label is **derived from the live gate** (`trpc:serialize:${devalue|superjson}`) so the freeze-instrumentation frame name matches what is actually written.
- **SSR** (`src/server/utils/server-side-helpers.ts`): dehydrate runs server-side, so it uses the same env-gated server writer — it flips only when ITS pool sets `TRPC_WRITE_DEVALUE`.
- **Client** (`src/utils/trpc.ts`): reverted to **superjson on all write paths** (every link's `input.serialize`, and the `isTooLargeToBatch` URL-budget sizer, which must match what the client actually writes). The browser bundle is one-size-fits-all and can't be per-pool gated; the server union-reads inputs, so the client never needs to write devalue for the canary. `output.deserialize` stays UNION (decodes both a superjson response from an un-flipped pool and a devalue response from a flipped one).
- **READ stays UNION on every slot** (server input, client response, SSR hydrate) — unchanged.

## Why (summary)
devalue serializes ~2× faster, produces a **13–16% smaller wire**, and halves worst-case serialize time — attacking the sync-serialize event-loop-freeze class (the documented oversized-response failure mode). Primary value is **reliability + egress + GC**. Env-gating the SERVER write lets us prove that on one pool (api-heavy first) before widening, with rollback = unset the env + restart.

## Tests
`trpc-union-transformer.test.ts` now asserts:
- **the gate selection** — `pickServerWriteSerialize(false)` → a superjson OBJECT decodable by superjson AND the union; `pickServerWriteSerialize(true)` → a devalue STRING decodable by devalue AND the union; `serverWriteSerialize`/`WRITE_DEVALUE` default to superjson/`false` in the unset env; rich types (Date/BigInt-cursor/undefined/Map/nested) round-trip through both selections.
- **the client transformer** WRITES superjson (input.serialize output is an object) and READS the union (decodes both formats).
- the union READ still decodes both a devalue- and a legacy-superjson-written payload (backward-read compat / rollback safety).
- the strict **non-POJO devalue-write guard** (a returned `Error` / SDK class instance / symbol / Promise throws) — the invariant the paddle/buzz-withdrawal write-path fixes in this PR restore.

`tsc --noEmit` clean on all touched files (pre-existing image.service/challenge.service baseline unrelated).

## Rollout + rollback
- **Merge:** zero-risk — default (`TRPC_WRITE_DEVALUE` unset) = superjson everywhere = Phase-1 wire.
- **Flip (separate change, gated on the Faro real-browser saturation check):** set `TRPC_WRITE_DEVALUE=true` on one pool's Deployment (api-heavy first). Only that pool writes devalue responses; clients union-read them. Widen pool-by-pool, watching tRPC error rate + the serialize span.
- **Rollback (instant, asymmetric):** unset the env + restart the pod. READ stays union, so any devalue already in flight is still decodable by every reader. No client redeploy needed.

## Follow-up
Phase 3 (later, separate PR + gate): once every pool is flipped and no peer writes superjson, drop the union + the superjson dependency → plain devalue both directions.
