### PR TITLE
feat(telemetry): client-version READ-capability saturation counter

### DIFF
--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -201,6 +201,20 @@ export const trpcProcedureDuration = registerHistogram({
   buckets: [0.05, 0.25, 1, 2, 5, 10, 30],
 });
 
+// Web-client READ-capability saturation for the superjson → devalue serializer
+// migration. Incremented per web tRPC procedure, bucketed by whether the request's
+// reported `x-client-version` belongs to a build that can decode the union
+// serializer (Phase-1-capable). LOW cardinality by construction: a single boolean
+// label (`phase1_capable` = 'true' | 'false') — NOT the raw version string. The
+// Phase-2 write-flip go/no-go reads the saturation ratio:
+//   rate(...{phase1_capable="true"}) / rate(...) — the fraction of live web traffic
+//   that can safely decode a devalue response.
+export const trpcClientReadCapabilityRequests = registerCounterWithLabels({
+  name: 'trpc_client_read_capability_requests_total',
+  help: 'Web tRPC procedures bucketed by client union-decode (Phase-1) capability',
+  labelNames: ['phase1_capable'] as const,
+});
+
 // Image feed metrics
 export const imagesFeedWithoutIndexCounter = registerCounter({
   name: 'images_feed_without_index_total',

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -9,7 +9,8 @@ import {
   BulkheadFullError,
   HEAVY_REQUEST_CONCURRENCY,
 } from '~/server/utils/request-bulkhead';
-import { trpcProcedureDuration } from '~/server/prom/client';
+import { trpcProcedureDuration, trpcClientReadCapabilityRequests } from '~/server/prom/client';
+import { phase1CapableLabel } from '~/server/utils/client-version-saturation';
 import { maybeLogTrpcSlow } from '~/server/logging/trpc-slow-log';
 import { longTaskLabelsArmed, runWithLongTaskLabel } from '~/server/eventloop-longtask';
 import { instrumentSerialize } from '~/server/logging/trpc-serialize-log';
@@ -141,6 +142,17 @@ async function needsUpdate(req?: NextApiRequest) {
 }
 
 const enforceClientVersion = t.middleware(async ({ next, ctx }) => {
+  // Serializer-migration saturation instrument: for WEB clients only, bucket this
+  // procedure by whether the reported bundle can decode the union serializer
+  // (Phase-1-capable). Bounded label (true/false), memoized semver compare — a
+  // Map lookup on the hot path after warmup. Non-web (API-key / server-to-server)
+  // requests have no browser bundle and are excluded so the ratio stays purely
+  // about the SPA population the Phase-2 write-flip gate cares about. Counted
+  // before next() so it reflects attempts even if the resolver throws.
+  if ((ctx.req?.headers['x-client'] as string) === 'web') {
+    const phase1Capable = phase1CapableLabel(ctx.req?.headers['x-client-version'] as string);
+    trpcClientReadCapabilityRequests.inc({ phase1_capable: phase1Capable });
+  }
   // if (await needsUpdate(ctx.req)) {
   //   throw new TRPCError({
   //     code: 'PRECONDITION_FAILED',

--- a/src/server/utils/__tests__/client-version-saturation.test.ts
+++ b/src/server/utils/__tests__/client-version-saturation.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetCapabilityCacheForTests,
+  isPhase1CapableClientVersion,
+  PHASE1_CLIENT_VERSION,
+  phase1CapableLabel,
+} from '~/server/utils/client-version-saturation';
+
+/**
+ * The Phase-2 (superjson → devalue write-flip) saturation gate reads a counter
+ * bucketed by `isPhase1CapableClientVersion`. The bucketing must be:
+ *   - correct at the threshold (>= 5.0.2080 capable; the ambiguous 5.0.2079 and
+ *     everything older NOT capable — the safe lower-bound direction),
+ *   - conservative for missing / unknown / garbage versions (NOT capable),
+ *   - low-cardinality (a boolean label), and
+ *   - stable under memoization.
+ */
+
+describe('isPhase1CapableClientVersion', () => {
+  beforeEach(() => __resetCapabilityCacheForTests());
+
+  it('threshold constant is the first unambiguously-Phase-1 version', () => {
+    expect(PHASE1_CLIENT_VERSION).toBe('5.0.2080');
+  });
+
+  it('the exact threshold version is capable', () => {
+    expect(isPhase1CapableClientVersion('5.0.2080')).toBe(true);
+  });
+
+  it('deployed Phase-1 builds and anything newer are capable', () => {
+    for (const v of ['5.0.2081', '5.0.2082', '5.0.2100', '5.1.0', '6.0.0']) {
+      expect(isPhase1CapableClientVersion(v)).toBe(true);
+    }
+  });
+
+  it('the ambiguous straddle version 5.0.2079 and older are NOT capable', () => {
+    for (const v of ['5.0.2079', '5.0.2078', '5.0.2000', '5.0.0', '4.9.9', '0.0.1']) {
+      expect(isPhase1CapableClientVersion(v)).toBe(false);
+    }
+  });
+
+  it('missing / empty / unknown / garbage versions are NOT capable (conservative)', () => {
+    for (const v of [undefined, null, '', 'unknown', 'not-a-version', 'v5', '5.0']) {
+      expect(isPhase1CapableClientVersion(v as any)).toBe(false);
+    }
+  });
+
+  it('is stable across repeated (memoized) calls', () => {
+    expect(isPhase1CapableClientVersion('5.0.2081')).toBe(true);
+    expect(isPhase1CapableClientVersion('5.0.2081')).toBe(true);
+    expect(isPhase1CapableClientVersion('5.0.2079')).toBe(false);
+    expect(isPhase1CapableClientVersion('5.0.2079')).toBe(false);
+  });
+});
+
+describe('phase1CapableLabel', () => {
+  beforeEach(() => __resetCapabilityCacheForTests());
+
+  it('maps to a bounded string label', () => {
+    expect(phase1CapableLabel('5.0.2081')).toBe('true');
+    expect(phase1CapableLabel('5.0.2079')).toBe('false');
+    expect(phase1CapableLabel(undefined)).toBe('false');
+  });
+});

--- a/src/server/utils/client-version-saturation.ts
+++ b/src/server/utils/client-version-saturation.ts
@@ -1,0 +1,73 @@
+import semver from 'semver';
+
+/**
+ * Client-version SATURATION instrument for the superjson → devalue tRPC
+ * serializer migration.
+ *
+ * WHY THIS EXISTS: Phase 2 of the migration flips the tRPC wire format to devalue
+ * on 100% of traffic. That flip is only safe once the overwhelming majority of
+ * live browser bundles are "Phase-1-capable" — i.e. they contain the union
+ * deserializer (`unionDeserialize`) and can therefore decode a devalue response.
+ * A pre-Phase-1 bundle still executing in a stale tab would throw on a devalue
+ * response. Nothing currently exports the client-version distribution, so the
+ * Phase-2 go/no-go gate is unmeasurable. This module defines the bucketing that
+ * makes it measurable at BOUNDED cardinality (one boolean label, not the raw
+ * version string).
+ *
+ * THE THRESHOLD. `x-client-version` is the web bundle's `package.json` version
+ * (`next.config.mjs` injects `packageJson.version` as `process.env.version`,
+ * sent by every web client — `src/utils/trpc.ts`). Version bumps are their own
+ * commits, and a feature PR inherits whatever version the previous bump left in
+ * `package.json`. The Phase-1 union deserializer merged while `package.json` read
+ * `5.0.2079` — but a PRE-Phase-1 build also reported `5.0.2079` (the bump to 2079
+ * predates the Phase-1 merge), so `5.0.2079` STRADDLES the boundary and is
+ * ambiguous. The first version that is UNAMBIGUOUSLY Phase-1-capable — every build
+ * reporting it contains the union deserializer — is the first bump AFTER the merge:
+ * `5.0.2080`. (The first Phase-1 build to actually reach production reported
+ * `5.0.2081`; `>= 5.0.2080` cleanly covers it and everything newer.)
+ *
+ * Bucketing `>= 5.0.2080` as capable is the SAFE (lower-bound) direction: the one
+ * ambiguous version (2079) counts as not-capable, so saturation is never
+ * over-reported and the gate can only err toward waiting longer.
+ */
+export const PHASE1_CLIENT_VERSION = '5.0.2080';
+
+// Memoize the semver comparison. Every web tRPC procedure runs through the client
+// -version middleware, and the set of distinct live client versions is tiny (a
+// handful of deployed builds at once), so a Map keyed by the raw version string
+// collapses a per-procedure semver parse into a single Map lookup after warmup.
+// A size guard clears the cache if it ever grows unexpectedly (e.g. spoofed
+// headers) so it can't become an unbounded leak.
+const capabilityCache = new Map<string, boolean>();
+const CAPABILITY_CACHE_MAX = 256;
+
+/**
+ * Whether a reported `x-client-version` belongs to a build that can decode the
+ * union serializer (Phase-1-capable, i.e. `>= PHASE1_CLIENT_VERSION`).
+ *
+ * Missing / empty / `'unknown'` / unparseable versions are treated as NOT capable
+ * (the conservative direction — an old bundle that can't even report a valid
+ * version is certainly not Phase-1-capable).
+ */
+export function isPhase1CapableClientVersion(version: string | undefined | null): boolean {
+  if (!version) return false;
+  const cached = capabilityCache.get(version);
+  if (cached !== undefined) return cached;
+
+  const valid = semver.valid(version);
+  const capable = valid ? semver.gte(valid, PHASE1_CLIENT_VERSION) : false;
+
+  if (capabilityCache.size >= CAPABILITY_CACHE_MAX) capabilityCache.clear();
+  capabilityCache.set(version, capable);
+  return capable;
+}
+
+/** The bounded metric label value for a reported client version. */
+export function phase1CapableLabel(version: string | undefined | null): 'true' | 'false' {
+  return isPhase1CapableClientVersion(version) ? 'true' : 'false';
+}
+
+/** TEST-ONLY: drop the memo cache so a test can assert cold-path behavior. */
+export function __resetCapabilityCacheForTests(): void {
+  capabilityCache.clear();
+}


### PR DESCRIPTION
## Client-version READ-capability saturation counter (serializer migration gate)

Adds the telemetry needed to gate the next phase of the superjson → devalue tRPC serializer migration. **Independent and mergeable now** — it only ADDS a metric; it changes no wire format and no behavior. Deploying it early lets us measure the client-bundle drain during the wait.

### Why
The migration's next phase flips the tRPC wire format on all traffic, which is only safe once nearly all live browser bundles contain the union deserializer that can decode the new format. Nothing currently exports the client-version distribution, so that go/no-go is unmeasurable. This adds a **bounded-cardinality** measurement.

### What
- **`src/server/utils/client-version-saturation.ts`** — the single source of truth for the capability threshold (`PHASE1_CLIENT_VERSION = '5.0.2080'`) and a memoized `isPhase1CapableClientVersion(x-client-version)` (semver `>= threshold`). Missing / unknown / unparseable versions bucket as not-capable (conservative). The memo collapses a per-procedure semver parse into a Map lookup after warmup, with a size guard so a spoofed-header storm can't grow it unbounded.
- **New counter** `civitai_app_trpc_client_read_capability_requests_total{phase1_capable="true"|"false"}` — incremented once per **web** tRPC procedure in the existing client-version middleware. **Low cardinality by construction:** a single boolean label, NOT the raw version string. Non-web (API-key / server-to-server) requests are excluded so the ratio is purely about the browser-SPA population the gate cares about.
- Wired the increment into `enforceClientVersion` (before `next()`, so it counts attempts even if the resolver throws).

### Threshold rationale (`5.0.2080`)
`x-client-version` is the web bundle's `package.json` version. Version bumps are their own commits, so a feature PR inherits the previous bump's version. The union deserializer merged while `package.json` read `5.0.2079` — but a **pre-migration** build also reported `5.0.2079` (that bump predates the merge), so `2079` **straddles the boundary** and is ambiguous. The first *unambiguously* capable version is the first bump after the merge, **`5.0.2080`**. Bucketing `>= 2080` as capable is the safe lower-bound (never over-reports saturation).

### Saturation query
```promql
sum(rate(civitai_app_trpc_client_read_capability_requests_total{phase1_capable="true"}[10m]))
/
sum(rate(civitai_app_trpc_client_read_capability_requests_total[10m]))
```

### Tests
`client-version-saturation.test.ts` covers the threshold (`>= 5.0.2080` capable; the ambiguous `5.0.2079` and older not-capable), conservative handling of missing/unknown/garbage versions, memo stability, and the bounded label mapping.

`tsc --noEmit` clean on all touched files.

### Cost
One counter `.inc()` with a precomputed bounded label + a memoized semver compare per web procedure — negligible next to the middleware's existing cached-redis read.
