### PR TITLE
fix(app-blocks): gate approved apps on live deploy

### DIFF
--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -681,6 +681,19 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     res.status(403).json({ error: 'Block is not approved' });
     return;
   }
+  // DEPLOY-GATE (generic, all app-blocks): an approved app whose
+  // `<slug>.<APPS_DOMAIN>` origin has NEVER successfully deployed renders a bare
+  // 404 in the iframe. `currentVersionDeployedAt` is set (to now()) ONLY on a
+  // successful apply (build-callback.ts) and left UNCHANGED on build
+  // failure/timeout, so NULL ⇔ never-served → refuse the run-token mint. A
+  // non-null value means a live deployment exists (the app keeps serving the
+  // OLD version while a NEW one re-builds), so a re-deploying app is NOT gated.
+  // The mod-preview / dev-tunnel ephemeral sandbox mint is a separate flow that
+  // returns earlier (status:'ephemeral', never reaches here) and is unaffected.
+  if (block.currentVersionDeployedAt == null) {
+    res.status(409).json({ error: 'Block is not yet deployed' });
+    return;
+  }
 
   // PAGE-ONLY LAUNCH GATE (belt at the mint — defense-in-depth over the install
   // path). The public (non-moderator) audience may only mint a token for a

--- a/src/server/services/__tests__/block-registry.deploy-gate.test.ts
+++ b/src/server/services/__tests__/block-registry.deploy-gate.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * DEPLOY-GATE (generic, all app-blocks) on the AppBlock-native public read paths
+ * (`block-registry.service`), the LIVE store surfaces today:
+ *
+ *   - listAvailable / getFeaturedBlocks (marketplace list + featured rail) — the
+ *     SQL WHERE must exclude an ON-PLATFORM app that has never SUCCESSFULLY
+ *     deployed its `<slug>.<APPS_DOMAIN>` origin (`current_version_deployed_at IS
+ *     NULL`), while EXEMPTING off-site (external-link) apps (they host no origin
+ *     and never deploy).
+ *   - getAppDetail (per-app detail) — an approved but never-deployed on-platform
+ *     app is treated as MISSING (returns null → NOT_FOUND); a deployed one is
+ *     shown; a re-deploying one (timestamp still set) is shown; an off-site app
+ *     (external_url set, timestamp null) is shown (exempt).
+ *
+ * `current_version_deployed_at` is set (to now()) ONLY on a successful apply in
+ * build-callback.ts and left UNCHANGED on build failure/timeout AND while a NEW
+ * version rebuilds — so NULL ⇔ never-served and non-null ⇔ live (incl.
+ * mid-re-deploy).
+ *
+ * No DB in unit tests: we mock `dbRead.$queryRaw` to capture the SQL (for the
+ * list paths, where the gate is a WHERE clause) + return seeded rows (for
+ * getAppDetail, where the gate is an app-layer check on the row).
+ */
+
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    blockUserSubscription: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    appBlock: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    modelVersion: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 0),
+    scanIterator: async function* () {},
+  },
+  sysRedis: { sMembers: vi.fn(async () => []) },
+  REDIS_KEYS: {
+    BLOCKS: { REGISTRY: 'packed:caches:block-registry', TOKEN_RATE_LIMIT: 'rl', REVOKED_INSTANCE: 'rev' },
+  },
+  REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
+}));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai', LOGGING: '' } }));
+
+/** Reconstructs the SQL string from the tagged-template OR Prisma.sql args. */
+function capturedSql(): string {
+  expect(mockDbRead.$queryRaw).toHaveBeenCalled();
+  const lastCall = mockDbRead.$queryRaw.mock.calls.at(-1);
+  if (!lastCall) return '';
+  const first = lastCall[0] as { sql?: string } | TemplateStringsArray;
+  // Prisma.sql form (listAvailable/getFeaturedBlocks build with Prisma.sql).
+  if (first && typeof (first as { sql?: string }).sql === 'string') {
+    return (first as { sql: string }).sql;
+  }
+  // Raw tagged-template form (getAppDetail/listForModel).
+  const strings = first as unknown as TemplateStringsArray;
+  const values = lastCall.slice(1);
+  let sql = '';
+  for (let i = 0; i < strings.length; i++) {
+    sql += strings[i];
+    if (i < values.length) sql += `$${i + 1}`;
+  }
+  return sql;
+}
+
+/** One raw detail row (snake_case) as getAppDetail's $queryRaw returns it. */
+function detailRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'ab_1',
+    block_id: 'cool-block',
+    app_id: 'app_1',
+    app_name: 'Cool App',
+    status: 'approved',
+    content_rating: 'g',
+    version: '1.0.0',
+    approved_scopes: [],
+    external_url: null,
+    current_version_deployed_at: new Date('2026-01-01T00:00:00Z'),
+    install_count: 0n,
+    avg_rating: null,
+    review_count: 0n,
+    screenshots: null,
+    manifest: { name: 'Cool Block', description: 'does things' },
+    ...over,
+  };
+}
+
+const DEPLOY_GATE_CLAUSE =
+  /ab\.external_url IS NOT NULL OR ab\.current_version_deployed_at IS NOT NULL/i;
+
+describe('BlockRegistry.listAvailable — DEPLOY-GATE WHERE clause', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockClear();
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+  });
+
+  it('WHERE requires a deployed on-platform app (or an external one)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.listAvailable({ sort: 'newest', limit: 20 });
+    expect(capturedSql()).toMatch(DEPLOY_GATE_CLAUSE);
+  });
+});
+
+describe('BlockRegistry.getFeaturedBlocks — DEPLOY-GATE WHERE clause', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockClear();
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+  });
+
+  it('WHERE requires a deployed on-platform app (or an external one)', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.getFeaturedBlocks(10);
+    expect(capturedSql()).toMatch(DEPLOY_GATE_CLAUSE);
+  });
+});
+
+describe('BlockRegistry.listForModel — DEPLOY-GATE WHERE clause (model slots)', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockClear();
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+  });
+
+  it('every install/subscription/default branch requires a deployed origin', async () => {
+    const { BlockRegistry } = await import('../block-registry.service');
+    await BlockRegistry.listForModel({
+      modelId: 123,
+      slotId: 'model.sidebar_top',
+      modelType: 'Checkpoint',
+      modelNsfwLevel: 1,
+      viewerUserId: 7,
+      redCapable: false,
+    });
+    const sql = capturedSql();
+    // One clause per UNION branch (rank 1-4).
+    const matches = sql.match(new RegExp(DEPLOY_GATE_CLAUSE.source, 'gi')) ?? [];
+    expect(matches.length).toBe(4);
+  });
+});
+
+describe('BlockRegistry.getAppDetail — DEPLOY-GATE (app-layer)', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockClear();
+  });
+
+  it('HIDES (null) an approved on-platform app that has NEVER deployed', async () => {
+    mockDbRead.$queryRaw.mockResolvedValue([
+      detailRow({ external_url: null, current_version_deployed_at: null }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    expect(await BlockRegistry.getAppDetail('ab_1')).toBeNull();
+  });
+
+  it('SHOWS a deployed on-platform app', async () => {
+    mockDbRead.$queryRaw.mockResolvedValue([
+      detailRow({ current_version_deployed_at: new Date('2026-01-01T00:00:00Z') }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(detail).not.toBeNull();
+    expect(detail!.id).toBe('ab_1');
+  });
+
+  it('SHOWS a RE-DEPLOYING app (timestamp stays set while a new version rebuilds)', async () => {
+    mockDbRead.$queryRaw.mockResolvedValue([
+      detailRow({ current_version_deployed_at: new Date('2025-06-01T00:00:00Z') }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    expect(await BlockRegistry.getAppDetail('ab_1')).not.toBeNull();
+  });
+
+  it('SHOWS an OFF-SITE (external-link) app even though it never deploys (exempt)', async () => {
+    mockDbRead.$queryRaw.mockResolvedValue([
+      detailRow({ external_url: 'https://example.com/app', current_version_deployed_at: null }),
+    ]);
+    const { BlockRegistry } = await import('../block-registry.service');
+    const detail = await BlockRegistry.getAppDetail('ab_1');
+    expect(detail).not.toBeNull();
+    expect(detail!.externalUrl).toBe('https://example.com/app');
+  });
+});

--- a/src/server/services/__tests__/block-registry.external-url.test.ts
+++ b/src/server/services/__tests__/block-registry.external-url.test.ts
@@ -75,6 +75,10 @@ function detailRow(over: Partial<Record<string, unknown>> = {}) {
     version: '0.0.0',
     approved_scopes: [],
     external_url: 'https://example.com/cool',
+    // DEPLOY-GATE: deployed so the detail read returns its projection even for the
+    // on-platform (external_url:null) variant of this fixture (a NULL timestamp on
+    // a NULL external_url would be treated as never-deployed → NOT_FOUND).
+    current_version_deployed_at: new Date('2026-01-01T00:00:00Z'),
     install_count: 0n,
     avg_rating: null,
     review_count: 0n,

--- a/src/server/services/__tests__/block-registry.get-app-detail.test.ts
+++ b/src/server/services/__tests__/block-registry.get-app-detail.test.ts
@@ -88,6 +88,11 @@ function rawRow(over: Partial<Record<string, unknown>> = {}) {
     content_rating: 'PG',
     version: '1.2.3',
     approved_scopes: ['ai:write:budgeted', 'models:read:self'],
+    // DEPLOY-GATE: a deployed on-platform app (non-null timestamp) so the detail
+    // read returns its projection. The dedicated deploy-gate suite covers the
+    // never-deployed (NULL → NOT_FOUND) and offsite-exempt cases.
+    external_url: null,
+    current_version_deployed_at: new Date('2026-01-01T00:00:00Z'),
     install_count: 7n,
     avg_rating: 4.5,
     review_count: 12n,

--- a/src/server/services/__tests__/block-registry.nsfw-red-only.test.ts
+++ b/src/server/services/__tests__/block-registry.nsfw-red-only.test.ts
@@ -113,6 +113,9 @@ function detailRow(over: Partial<Record<string, unknown>> = {}) {
     content_rating: 'g',
     version: '1.0.0',
     approved_scopes: ['user:read:self'],
+    // DEPLOY-GATE: a deployed on-platform app so the detail read isn't gated off.
+    external_url: null,
+    current_version_deployed_at: new Date('2026-01-01T00:00:00Z'),
     install_count: 3n,
     screenshots: null,
     // page app by default so the launchOnly gate doesn't interfere

--- a/src/server/services/__tests__/block-registry.page-only-launch.test.ts
+++ b/src/server/services/__tests__/block-registry.page-only-launch.test.ts
@@ -115,6 +115,9 @@ function detailRow(over: Partial<Record<string, unknown>> = {}) {
     content_rating: null,
     version: '1.0.0',
     approved_scopes: ['user:read:self'],
+    // DEPLOY-GATE: a deployed on-platform app so the detail read isn't gated off.
+    external_url: null,
+    current_version_deployed_at: new Date('2026-01-01T00:00:00Z'),
     install_count: 3n,
     screenshots: null,
     // model app by default (no page field)

--- a/src/server/services/__tests__/listForModel.harness.ts
+++ b/src/server/services/__tests__/listForModel.harness.ts
@@ -60,7 +60,13 @@ export async function createSchema(db: PGlite): Promise<void> {
       manifest      jsonb NOT NULL DEFAULT '{}'::jsonb,
       status        text NOT NULL DEFAULT 'approved',
       render_mode   text NOT NULL DEFAULT 'iframe',
-      trust_tier    text NOT NULL DEFAULT 'unverified'
+      trust_tier    text NOT NULL DEFAULT 'unverified',
+      -- DEPLOY-GATE columns: off-site apps set external_url; current_version_
+      -- deployed_at is non-null once an app has successfully deployed. Default
+      -- now() so a seeded app is "deployed" and the render gate passes unless a
+      -- test deliberately seeds it NULL (never-deployed).
+      external_url  text,
+      current_version_deployed_at timestamptz NOT NULL DEFAULT now()
     );
 
     CREATE TABLE block_user_subscriptions (

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -385,6 +385,13 @@ export interface ResolvedBlockInstance {
     manifest: Record<string, unknown>;
     approvedScopes: string[];
     app: { allowedScopes: number } | null;
+    // DEPLOY-GATE: NULL ⇔ this app has NEVER successfully deployed its
+    // `<slug>.<APPS_DOMAIN>` origin (set to now() ONLY on a successful apply in
+    // build-callback.ts; left UNCHANGED on build failure/timeout AND while a
+    // NEW version re-builds — the old version keeps serving). The token mint
+    // requires this to be non-null so an approved-but-never-deployed app can't
+    // be run against an origin that would 404.
+    currentVersionDeployedAt: Date | null;
   };
 }
 
@@ -755,6 +762,13 @@ export class BlockRegistry {
         WHERE bus.scope = 'publisher_all_my_models'
           AND bus.enabled = TRUE
           AND ab.status = 'approved'
+          -- DEPLOY-GATE (generic, all app-blocks): don't render an installed
+          -- block on a model slot until its slug origin has SUCCESSFULLY deployed
+          -- (else the iframe 404s). Set on a successful apply, unchanged on
+          -- failure AND while a NEW version rebuilds, so a live app mid-re-deploy
+          -- keeps rendering. Off-site apps (external_url) have no iframe to
+          -- install on a slot, but the exemption keeps it uniform.
+          AND (ab.external_url IS NOT NULL OR ab.current_version_deployed_at IS NOT NULL)
           AND bus.slot_id = ${slotId}
           AND ${modelId} = ANY(bus.target_model_ids)
           AND bus.block_instance_id IS NOT NULL
@@ -809,6 +823,13 @@ export class BlockRegistry {
         WHERE bus.scope = 'publisher_all_my_models'
           AND bus.enabled = TRUE
           AND ab.status = 'approved'
+          -- DEPLOY-GATE (generic, all app-blocks): don't render an installed
+          -- block on a model slot until its slug origin has SUCCESSFULLY deployed
+          -- (else the iframe 404s). Set on a successful apply, unchanged on
+          -- failure AND while a NEW version rebuilds, so a live app mid-re-deploy
+          -- keeps rendering. Off-site apps (external_url) have no iframe to
+          -- install on a slot, but the exemption keeps it uniform.
+          AND (ab.external_url IS NOT NULL OR ab.current_version_deployed_at IS NOT NULL)
           AND bus.slot_id IS NULL
           AND cardinality(bus.target_model_ids) = 0
           AND ab.manifest @> ${slotMatch}::jsonb
@@ -880,6 +901,13 @@ export class BlockRegistry {
         WHERE pdb.slot_id = ${slotId}
           AND pdb.enabled = TRUE
           AND ab.status = 'approved'
+          -- DEPLOY-GATE (generic, all app-blocks): don't render an installed
+          -- block on a model slot until its slug origin has SUCCESSFULLY deployed
+          -- (else the iframe 404s). Set on a successful apply, unchanged on
+          -- failure AND while a NEW version rebuilds, so a live app mid-re-deploy
+          -- keeps rendering. Off-site apps (external_url) have no iframe to
+          -- install on a slot, but the exemption keeps it uniform.
+          AND (ab.external_url IS NOT NULL OR ab.current_version_deployed_at IS NOT NULL)
           -- H1 (audit-10): pass NULL when modelType is omitted so the ANY
           -- arm cannot match. The prior coalesce-to-empty-string version
           -- accidentally became an exact-match against the empty string,
@@ -947,6 +975,13 @@ export class BlockRegistry {
           AND bus.user_id = ${viewerUserId ?? -1}
           AND bus.enabled = TRUE
           AND ab.status = 'approved'
+          -- DEPLOY-GATE (generic, all app-blocks): don't render an installed
+          -- block on a model slot until its slug origin has SUCCESSFULLY deployed
+          -- (else the iframe 404s). Set on a successful apply, unchanged on
+          -- failure AND while a NEW version rebuilds, so a live app mid-re-deploy
+          -- keeps rendering. Off-site apps (external_url) have no iframe to
+          -- install on a slot, but the exemption keeps it uniform.
+          AND (ab.external_url IS NOT NULL OR ab.current_version_deployed_at IS NOT NULL)
           AND bus.slot_id IS NULL
           AND cardinality(bus.target_model_ids) = 0
           AND ab.manifest @> ${slotMatch}::jsonb
@@ -1353,6 +1388,7 @@ export class BlockRegistry {
               status: true,
               manifest: true,
               approvedScopes: true,
+              currentVersionDeployedAt: true,
               app: { select: { allowedScopes: true } },
             },
           },
@@ -1413,6 +1449,7 @@ export class BlockRegistry {
           manifest: pinnedInstall.manifest,
           approvedScopes: pinnedInstall.approvedScopes,
           app: sub.appBlock.app ? { allowedScopes: sub.appBlock.app.allowedScopes } : null,
+          currentVersionDeployedAt: sub.appBlock.currentVersionDeployedAt ?? null,
         },
       };
     }
@@ -1436,6 +1473,7 @@ export class BlockRegistry {
               status: true,
               manifest: true,
               approvedScopes: true,
+              currentVersionDeployedAt: true,
               app: { select: { allowedScopes: true } },
             },
           },
@@ -1485,6 +1523,7 @@ export class BlockRegistry {
           manifest: (pdb.appBlock.manifest ?? {}) as Record<string, unknown>,
           approvedScopes: pdb.appBlock.approvedScopes ?? [],
           app: pdb.appBlock.app ? { allowedScopes: pdb.appBlock.app.allowedScopes } : null,
+          currentVersionDeployedAt: pdb.appBlock.currentVersionDeployedAt ?? null,
         },
       };
     }
@@ -1516,6 +1555,7 @@ export class BlockRegistry {
               status: true,
               manifest: true,
               approvedScopes: true,
+              currentVersionDeployedAt: true,
               app: { select: { allowedScopes: true } },
             },
           },
@@ -1591,6 +1631,7 @@ export class BlockRegistry {
           manifest: pinnedPub.manifest,
           approvedScopes: pinnedPub.approvedScopes,
           app: bus.appBlock.app ? { allowedScopes: bus.appBlock.app.allowedScopes } : null,
+          currentVersionDeployedAt: bus.appBlock.currentVersionDeployedAt ?? null,
         },
       };
     }
@@ -1622,6 +1663,7 @@ export class BlockRegistry {
               status: true,
               manifest: true,
               approvedScopes: true,
+              currentVersionDeployedAt: true,
               app: { select: { allowedScopes: true } },
             },
           },
@@ -1707,6 +1749,7 @@ export class BlockRegistry {
           manifest: pinnedView.manifest,
           approvedScopes: pinnedView.approvedScopes,
           app: bus.appBlock.app ? { allowedScopes: bus.appBlock.app.allowedScopes } : null,
+          currentVersionDeployedAt: bus.appBlock.currentVersionDeployedAt ?? null,
         },
       };
     }
@@ -1744,6 +1787,7 @@ export class BlockRegistry {
         status: true,
         manifest: true,
         approvedScopes: true,
+        currentVersionDeployedAt: true,
         app: { select: { allowedScopes: true } },
       },
     });
@@ -1761,6 +1805,7 @@ export class BlockRegistry {
         manifest,
         approvedScopes: ab.approvedScopes ?? [],
         app: ab.app ? { allowedScopes: ab.app.allowedScopes } : null,
+        currentVersionDeployedAt: ab.currentVersionDeployedAt ?? null,
       },
     };
   }
@@ -3035,6 +3080,14 @@ export class BlockRegistry {
       FROM app_blocks ab
       LEFT JOIN "OauthClient" oc ON oc.id = ab.app_id
       WHERE ab.status = 'approved'
+        -- DEPLOY-GATE (generic, all app-blocks): only list an ON-PLATFORM app
+        -- once it has SUCCESSFULLY deployed its slug origin at least once.
+        -- current_version_deployed_at is set on a successful apply and left
+        -- unchanged on build failure/timeout AND while a NEW version rebuilds, so
+        -- NULL means never-served (hide) and non-null means live (show, incl.
+        -- mid-re-deploy). OFF-SITE (external-link) apps host no origin and never
+        -- deploy, so external_url presence exempts them (they use externalUrl).
+        AND (ab.external_url IS NOT NULL OR ab.current_version_deployed_at IS NOT NULL)
         -- PAGE-ONLY LAUNCH GATE: non-mod callers see launch (page) apps only.
         AND ${launchOnlySqlFilter(launchOnly)}
         -- NSFW-APP-RED-ONLY: hide mature (r/x) apps on non-red hosts.
@@ -3153,6 +3206,7 @@ export class BlockRegistry {
       version: string | null;
       approved_scopes: string[] | null;
       external_url: string | null;
+      current_version_deployed_at: Date | null;
       install_count: bigint;
       avg_rating: number | null;
       review_count: bigint;
@@ -3173,6 +3227,7 @@ export class BlockRegistry {
         ab.version,
         ab.approved_scopes,
         ab.external_url,
+        ab.current_version_deployed_at,
         ab.screenshots,
         (SELECT COUNT(DISTINCT bus.user_id)::bigint FROM block_user_subscriptions bus
          WHERE bus.app_block_id = ab.id) AS install_count,
@@ -3194,6 +3249,14 @@ export class BlockRegistry {
     // router surfaces NOT_FOUND (no detail leak). isAppLaunchEligible reuses the
     // same "declares a page" predicate as the listing filter + the page mint.
     if (launchOnly && !isAppLaunchEligible(row.manifest)) return null;
+    // DEPLOY-GATE (generic, all app-blocks): an ON-PLATFORM app that has NEVER
+    // successfully deployed its `<slug>.<APPS_DOMAIN>` origin is indistinguishable
+    // from a missing one — its detail's liveUrl would 404 and it isn't runnable.
+    // `current_version_deployed_at` is NULL until the first successful apply and
+    // stays set while a NEW version rebuilds (so a live app mid-re-deploy still
+    // resolves). OFF-SITE (external-link) apps host no origin and never deploy —
+    // `external_url` presence exempts them.
+    if (row.external_url == null && row.current_version_deployed_at == null) return null;
     // NSFW-APP-RED-ONLY (non-red host): a mature (r/x) app is indistinguishable
     // from a missing one off .red — return null → NOT_FOUND. Uses the
     // authoritative content_rating column (set on approve), not the manifest.
@@ -3296,6 +3359,14 @@ export class BlockRegistry {
       FROM app_blocks ab
       LEFT JOIN "OauthClient" oc ON oc.id = ab.app_id
       WHERE ab.status = 'approved'
+        -- DEPLOY-GATE (generic, all app-blocks): only list an ON-PLATFORM app
+        -- once it has SUCCESSFULLY deployed its slug origin at least once.
+        -- current_version_deployed_at is set on a successful apply and left
+        -- unchanged on build failure/timeout AND while a NEW version rebuilds, so
+        -- NULL means never-served (hide) and non-null means live (show, incl.
+        -- mid-re-deploy). OFF-SITE (external-link) apps host no origin and never
+        -- deploy, so external_url presence exempts them (they use externalUrl).
+        AND (ab.external_url IS NOT NULL OR ab.current_version_deployed_at IS NOT NULL)
         -- PAGE-ONLY LAUNCH GATE: non-mod callers see launch (page) apps only.
         AND ${launchOnlySqlFilter(launchOnly)}
         -- NSFW-APP-RED-ONLY: hide mature (r/x) apps on non-red hosts.

--- a/src/server/services/blocks/__tests__/app-listing.deploy-gate.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.deploy-gate.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * DEPLOY-GATE (generic, all app-blocks) on the AppListing-backed unified store
+ * (`app-listing.service`, the twin read path):
+ *
+ *   - listAvailableListings — the keyset SQL must EXCLUDE an ONSITE
+ *     (block-backed) listing whose backing AppBlock has never SUCCESSFULLY
+ *     deployed (`current_version_deployed_at IS NULL`), while leaving OFFSITE
+ *     (external-link, no AppBlock/deploy) listings UNAFFECTED (discriminate on
+ *     `kind`, never on appBlockId nullness).
+ *   - getListingDetail — an ONSITE listing whose backing block has never
+ *     deployed is treated as MISSING (returns null); a deployed one is shown; a
+ *     re-deploying one (timestamp still set) is shown; an OFFSITE listing (no
+ *     backing AppBlock) is shown (exempt).
+ *
+ * No DB in unit tests: mock `dbRead.$queryRaw` (keyset id page — capture the
+ * SQL) + `dbRead.appListing.findFirst/findMany` (hydration — return seeded rows).
+ */
+
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    appListing: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (src: string) => src }));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  queryCache:
+    () =>
+    async (sql: unknown): Promise<unknown[]> =>
+      mockDbRead.$queryRaw(sql),
+}));
+
+import { getListingDetail, listAvailableListings } from '../app-listing.service';
+
+/** Reconstruct the SQL string Prisma received (single Prisma.Sql arg). */
+function capturedSql(): string {
+  const last = mockDbRead.$queryRaw.mock.calls.at(-1);
+  const first = last?.[0] as { sql?: unknown } | undefined;
+  return first && typeof first.sql === 'string' ? first.sql : '';
+}
+
+/** A hydrated ONSITE listing row (as `listingHydrateSelect` returns). */
+function onsiteRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 'apl_1',
+    kind: 'onsite',
+    slug: 'cool-app',
+    name: 'Cool App',
+    tagline: 't',
+    description: 'body',
+    category: 'utility',
+    contentRating: 'pg',
+    externalUrl: null,
+    connectClientId: null,
+    appBlockId: 'ab_1',
+    icon: null,
+    cover: null,
+    user: { id: 7, username: 'dev', image: null },
+    metric: null,
+    appBlock: {
+      currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
+      manifest: { name: 'Cool App', page: { path: '/run' } },
+    },
+    screenshots: [],
+    ...over,
+  };
+}
+
+/** A hydrated OFFSITE (external-link) listing row — NO backing AppBlock. */
+function offsiteRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 'apl_2',
+    kind: 'offsite',
+    slug: 'ext-app',
+    name: 'Ext App',
+    tagline: 't',
+    description: 'body',
+    category: 'utility',
+    contentRating: 'pg',
+    externalUrl: 'https://example.com/ext',
+    connectClientId: null,
+    appBlockId: null,
+    icon: null,
+    cover: null,
+    user: { id: 7, username: 'dev', image: null },
+    metric: null,
+    appBlock: null,
+    screenshots: [],
+    ...over,
+  };
+}
+
+const ONSITE_DEPLOY_GATE =
+  /al\.kind <> 'onsite' OR ab\.current_version_deployed_at IS NOT NULL/i;
+
+describe('listAvailableListings — DEPLOY-GATE WHERE clause', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockReset();
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+    mockDbRead.appListing.findMany.mockReset();
+    mockDbRead.appListing.findMany.mockResolvedValue([]);
+  });
+
+  it('JOINs app_blocks and gates ONSITE rows on a non-null deploy timestamp', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
+    const sql = capturedSql();
+    expect(sql).toMatch(/LEFT JOIN app_blocks ab ON ab\.id = al\.app_block_id/i);
+    expect(sql).toMatch(ONSITE_DEPLOY_GATE);
+  });
+});
+
+describe('getListingDetail — DEPLOY-GATE (app-layer)', () => {
+  beforeEach(() => {
+    mockDbRead.appListing.findFirst.mockReset();
+  });
+
+  it('HIDES (null) an ONSITE listing whose backing block has NEVER deployed', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({
+      ...onsiteRow({ appBlock: { currentVersionDeployedAt: null, manifest: {} } }),
+      status: 'approved',
+    });
+    expect(await getListingDetail({ slug: 'cool-app' })).toBeNull();
+  });
+
+  it('SHOWS a deployed ONSITE listing', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...onsiteRow(), status: 'approved' });
+    const detail = await getListingDetail({ slug: 'cool-app' });
+    expect(detail).not.toBeNull();
+    expect(detail!.id).toBe('apl_1');
+  });
+
+  it('SHOWS a RE-DEPLOYING ONSITE listing (timestamp stays set during a rebuild)', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({
+      ...onsiteRow({
+        appBlock: {
+          currentVersionDeployedAt: new Date('2025-06-01T00:00:00Z'),
+          manifest: { name: 'Cool App' },
+        },
+      }),
+      status: 'approved',
+    });
+    expect(await getListingDetail({ slug: 'cool-app' })).not.toBeNull();
+  });
+
+  it('SHOWS an OFFSITE listing (no backing AppBlock/deploy — exempt)', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...offsiteRow(), status: 'approved' });
+    const detail = await getListingDetail({ slug: 'ext-app' });
+    expect(detail).not.toBeNull();
+    expect(detail!.id).toBe('apl_2');
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -82,6 +82,10 @@ function hydratedRow(over: Record<string, unknown> = {}) {
     user: { id: 7, username: 'dev', image: 'avatar-key' },
     metric: { thumbsUpCount: 9, thumbsDownCount: 1 },
     appBlock: {
+      // DEPLOY-GATE: a deployed onsite block (non-null timestamp) so the detail
+      // read returns its projection. The dedicated deploy-gate suite covers the
+      // never-deployed (NULL → unavailable) onsite case.
+      currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
       manifest: {
         name: 'Cool App',
         page: { path: '/run' },

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -209,7 +209,11 @@ export const listingHydrateSelect = {
   cover: { select: { url: true } },
   user: { select: { id: true, username: true, image: true } },
   metric: { select: { thumbsUpCount: true, thumbsDownCount: true } },
-  appBlock: { select: { manifest: true } },
+  // `currentVersionDeployedAt` powers the DEPLOY-GATE on the detail read (an
+  // onsite listing whose backing block has never successfully deployed is
+  // treated as unavailable). NULL ⇔ never-deployed; non-null ⇔ live (stays
+  // available while a new version re-builds).
+  appBlock: { select: { manifest: true, currentVersionDeployedAt: true } },
   screenshots: {
     where: { imageId: { not: null } },
     // Stable order: `id` tiebreaks rows with a tied `order` (default 0), which
@@ -454,10 +458,20 @@ export async function listAvailableListings(
     SELECT al.id, ${sortKeyExpr} AS sort_key
     FROM app_listings al
     LEFT JOIN app_listing_metrics m ON m.app_listing_id = al.id
+    -- DEPLOY-GATE: join the backing AppBlock (onsite only) so we can require it
+    -- has actually deployed its slug origin before listing it.
+    LEFT JOIN app_blocks ab ON ab.id = al.app_block_id
     WHERE al.status = 'approved'
       -- Never surface a SHADOW revision draft. Shadows are status='draft' so the
       -- approved-only filter already hides them; this is defense-in-depth.
       AND al.revision_of_id IS NULL
+      -- DEPLOY-GATE (generic, all app-blocks): an ONSITE (block-backed) listing
+      -- only appears once its backing AppBlock has SUCCESSFULLY deployed at least
+      -- once (current_version_deployed_at set on a successful apply, left NULL
+      -- while first-building). A re-deploying app keeps its non-null timestamp,
+      -- so it stays listed. OFFSITE listings have no AppBlock/deploy concept and
+      -- are UNAFFECTED (kind discriminates, never appBlockId nullness).
+      AND (al.kind <> 'onsite' OR ab.current_version_deployed_at IS NOT NULL)
       AND (${kindParam}::text IS NULL OR al.kind = ${kindParam}::text)
       AND (${categoryParam}::text IS NULL OR al.category = ${categoryParam}::text)
       AND ${listingMatureFilter(redCapable)}
@@ -526,6 +540,13 @@ export async function getListingDetail(
   // can't reuse this for a non-public path: a non-approved row returns null
   // exactly like a missing one — never its data.
   if (!row || row.status !== 'approved') return null;
+  // DEPLOY-GATE (generic, all app-blocks): an ONSITE listing whose backing
+  // AppBlock has NEVER successfully deployed is indistinguishable from a missing
+  // one — its `<slug>.<APPS_DOMAIN>` origin would 404. `currentVersionDeployedAt`
+  // is set only on a successful apply and stays set while a NEW version rebuilds,
+  // so a live app mid-re-deploy is still shown. OFFSITE listings have no
+  // AppBlock/deploy concept and are UNAFFECTED (discriminate on `kind`).
+  if (row.kind === 'onsite' && row.appBlock?.currentVersionDeployedAt == null) return null;
   // Maturity gate off a non-red host: a mature listing is indistinguishable from
   // a missing one (mirrors the AppBlock detail's red-only 404).
   if (!redCapable && isMatureContentRating(row.contentRating)) return null;

--- a/src/tests/api/v1/block-tokens/index.test.ts
+++ b/src/tests/api/v1/block-tokens/index.test.ts
@@ -156,6 +156,10 @@ const RESOLVED_INSTALL = {
     blockId: 'blk',
     appId: 'app',
     status: 'approved',
+    // DEPLOY-GATE: a non-null timestamp = this app has successfully deployed its
+    // origin, so the run-mint proceeds. (NULL would be blocked with 409 — the
+    // dedicated deploy-gate suite covers that.)
+    currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
     manifest: { scopes: ['models:read:self'] },
     approvedScopes: ['models:read:self'],
     app: { allowedScopes: 4 /* TokenScope.ModelsRead */ },

--- a/src/tests/api/v1/block-tokens/page-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/page-mint.test.ts
@@ -174,6 +174,8 @@ const PAGE_BLOCK = (
     blockId: 'hello-page',
     appId: 'appblk-hello-page',
     status: 'approved',
+    // DEPLOY-GATE: deployed → run-mint proceeds (NULL would 409; see deploy-gate suite).
+    currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
     manifest: { scopes: manifestScopes, page: { path: '/', title: 'Hello' } },
     approvedScopes,
     app: { allowedScopes },
@@ -193,6 +195,7 @@ const PAGE_BUDGET_BLOCK = (manifestBudget?: number) => ({
     blockId: 'hello-page',
     appId: 'appblk-hello-page',
     status: 'approved',
+    currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
     manifest: {
       scopes: ['ai:write:budgeted'],
       page: {
@@ -224,6 +227,7 @@ const MODEL_INSTALL = {
     blockId: 'generate-from-model',
     appId: 'appblk-generate-from-model',
     status: 'approved',
+    currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
     manifest: { scopes: ['models:read:self'] },
     approvedScopes: ['models:read:self'],
     app: { allowedScopes: 4 /* TokenScope.ModelsRead */ },
@@ -588,6 +592,7 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
         blockId: 'hello-page',
         appId: 'appblk-hello-page',
         status: 'approved',
+        currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
         manifest: {
           scopes: ['ai:write:budgeted', 'social:tip:self'],
           page: { path: '/', title: 'Hello' },
@@ -772,5 +777,107 @@ describe('POST /api/v1/block-tokens — W10 page mint', () => {
       expect(res._body.needsConsent).toBe(false);
       expect(res._body.missingScopes).toEqual([]);
     });
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// DEPLOY-GATE (generic, all app-blocks): the run-mint must REFUSE to mint a
+// production run token for an APPROVED app that has never SUCCESSFULLY deployed
+// its <slug>.<APPS_DOMAIN> origin (currentVersionDeployedAt IS NULL) — otherwise
+// the block renders a bare 404. It must ALLOW an app that has deployed at least
+// once, INCLUDING while a NEW version is re-building (the old version keeps
+// serving, so the timestamp stays non-null). Applies to BOTH the stateless page
+// mint (resolvePageBlock) and the model-slot mint (resolveBlockInstance) since
+// they share the single gate. The mod-preview / dev-tunnel ephemeral sandbox
+// mint is a SEPARATE flow (status:'ephemeral', returns earlier) — unaffected.
+// ───────────────────────────────────────────────────────────────────────────
+describe('POST /api/v1/block-tokens — DEPLOY-GATE (never-deployed refusal)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSession.value = MOD;
+    mockBlockRegistry.resolveBlockInstance.mockReset();
+    mockBlockRegistry.resolvePageBlock.mockReset();
+    mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: null, bannedAt: null });
+    mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+      grantedScopes: ['apps:storage:read', 'apps:storage:write'],
+      revokedAt: null,
+    });
+    mockRedis.incrBy.mockResolvedValue(1);
+    mockTokenService.checkRateLimit.mockResolvedValue(true);
+    (mockFlags.getFeatureFlags as any).mockImplementation(
+      ({ user }: { user?: { isModerator?: boolean } }) => ({
+        appBlocks: !!user?.isModerator,
+        appBlocksPages: !!user?.isModerator,
+      })
+    );
+  });
+
+  // A PAGE_BLOCK variant with an explicit currentVersionDeployedAt override.
+  const pageBlockWithDeploy = (deployedAt: Date | null) => {
+    const base = PAGE_BLOCK(['apps:storage:read', 'apps:storage:write']);
+    return { appBlock: { ...base.appBlock, currentVersionDeployedAt: deployedAt } };
+  };
+
+  it('REFUSES (409, no token) a page mint for an approved app that has NEVER deployed (currentVersionDeployedAt=null)', async () => {
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(pageBlockWithDeploy(null));
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+    expect(res._status).toBe(409);
+    expect((res._body as { error: string }).error).toMatch(/not yet deployed/i);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('ALLOWS (200) a page mint once the app has deployed at least once', async () => {
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(
+      pageBlockWithDeploy(new Date('2026-01-01T00:00:00Z'))
+    );
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+    expect(res._status).toBe(200);
+    expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
+  });
+
+  it('ALLOWS (200) a RE-DEPLOYING app — a non-null timestamp survives while a NEW version rebuilds, so it keeps minting', async () => {
+    // "Re-deploying" is indistinguishable at the gate from "deployed": the app
+    // has a prior successful deploy (timestamp set) and the build-callback leaves
+    // it UNCHANGED during the rebuild, so the old version keeps serving + minting.
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(
+      pageBlockWithDeploy(new Date('2025-06-01T00:00:00Z'))
+    );
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: pageBody() }), res);
+    expect(res._status).toBe(200);
+    expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
+  });
+
+  it('REFUSES (409, no token) a MODEL-SLOT mint for a never-deployed app (same shared gate)', async () => {
+    mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
+      ...MODEL_INSTALL,
+      appBlock: { ...MODEL_INSTALL.appBlock, currentVersionDeployedAt: null },
+    });
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: modelBody() }), res);
+    expect(res._status).toBe(409);
+    expect((res._body as { error: string }).error).toMatch(/not yet deployed/i);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('ALLOWS (200) a MODEL-SLOT mint for a deployed app', async () => {
+    mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
+      ...MODEL_INSTALL,
+      appBlock: {
+        ...MODEL_INSTALL.appBlock,
+        currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
+      },
+    });
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const res = makeRes();
+    await handler(makeReq({ origin: 'https://civitai.com', body: modelBody() }), res);
+    expect(res._status).toBe(200);
+    expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Problem
A newly-approved App Block appeared in the store **and** was runnable during its build window — before its `<slug>.civit.ai` origin had deployed — so it rendered a bare 404. This is generic (affects all app-blocks); dogfooding *custom-generators* surfaced it.

## Signal (no migration)
`AppBlock.currentVersionDeployedAt` is set to `now()` **only** on a successful deploy (build-callback.ts, immediately before marking the request `live`) and is deliberately left **unchanged** on build failure/timeout AND while a *new* version re-builds (the old version keeps serving). So:
- `currentVersionDeployedAt IS NULL` ⇔ never successfully deployed → **hide + block**
- `currentVersionDeployedAt IS NOT NULL` ⇔ has a live deployment → **show + allow**, including mid-re-deploy.

It's the only write site (verified — nothing sets it on approve or anywhere pre-deploy).

## Gates added
| Surface | File | Gate |
|---|---|---|
| Run-token mint (page + model-slot, shared gate) | `pages/api/v1/block-tokens/index.ts` | `409 { error: 'Block is not yet deployed' }` when `currentVersionDeployedAt == null` |
| Marketplace list + featured rail | `block-registry.service.ts` (`listAvailable`, `getFeaturedBlocks`) | `WHERE (external_url IS NOT NULL OR current_version_deployed_at IS NOT NULL)` |
| Per-app detail | `block-registry.service.ts` (`getAppDetail`) | never-deployed on-platform app → `null` (NOT_FOUND) |
| Unified store list + detail | `blocks/app-listing.service.ts` (`listAvailableListings`, `getListingDetail`) | onsite rows gated; **offsite unaffected** (discriminate on `kind`) |
| Model-slot render | `block-registry.service.ts` (`listForModel`) | all 4 union branches gated |

The new field is selected on every block/listing query it needs (no N+1) and threaded through `ResolvedBlockInstance` / `PageBlockResolution`.

## Not regressed
- A live app **mid-re-deploy** keeps its non-null timestamp → stays listed + runnable.
- **Off-site** (external-link) listings/apps host no origin and never deploy → exempt everywhere.
- **Mod-preview / dev-tunnel** ephemeral sandbox mint returns earlier (`status:'ephemeral'`) → unaffected.

## Tests (outside `src/pages/**`)
- Run-mint: `null → 409` (no token), deployed → mint, re-deploying → mint, model-slot both cases.
- Listing: never-deployed onsite excluded from `listAvailable`/`listAvailableListings`; deployed included; offsite unaffected; re-deploy included; `getAppDetail`/`getListingDetail` behavior.
- Existing block/listing suites updated (fixtures now carry a deploy timestamp); pglite `listForModel` harness schema extended with the columns.
- `tsc --noEmit` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)