### PR TITLE
fix(browsing): drop the loli/shota/teenager block from the addon fallback

### DIFF
--- a/src/shared/constants/browsing-settings-addons.ts
+++ b/src/shared/constants/browsing-settings-addons.ts
@@ -81,10 +81,15 @@ export function resolveBrowsingSettingsAddons(
   }, emptyResolvedAddons());
 }
 
-// Seed for the hard navigation blocklist (W2). The redis key
-// `system:blocked-browsing-tags` overrides this when present; ops manage the
-// live list there without a deploy. Kept in sync with the POI + minor
-// `excludedTagIds` in DEFAULT_BROWSING_SETTINGS_ADDONS below.
+// Seed for the hard navigation blocklist (W2) — blocks the tag page and nav, not the
+// content carrying the tag. The redis key `system:blocked-browsing-tags` overrides this
+// when present; ops manage the live list there without a deploy.
+//
+// Deliberately NOT a mirror of the addon `excludedTagIds` below: loli/shota/teenager are
+// listed here but excluded from no addon, so their tag pages 404 while their content
+// stays subject to the normal browsing-level rules. Hiding the content was WD14's call to
+// make and it isn't good enough at it — 459,896 `loli` tags at ~59% average confidence,
+// unreviewed. Don't "re-sync" the two lists.
 export const BLOCKED_BROWSING_TAG_IDS: number[] = [
   5161, //actor
   5162, //actress
@@ -137,15 +142,6 @@ export const DEFAULT_BROWSING_SETTINGS_ADDONS: BrowsingSettingsAddon[] = [
       154326, //toddler
       161829, //male child
       163032, //female child
-    ],
-  },
-  {
-    type: 'some',
-    nsfwLevels: [NsfwLevel.PG, NsfwLevel.PG13, NsfwLevel.R, NsfwLevel.X, NsfwLevel.XXX],
-    excludedTagIds: [
-      114467, //loli
-      6641, //shota
-      115249, //teenager
     ],
   },
 ] as const;


### PR DESCRIPTION
Config-drift cleanup. **No behaviour change in prod today** — closes a gap that would silently reintroduce a content block we deliberately removed.

## The gap

The all-levels `excludedTagIds` rule blocking `loli` / `shota` / `teenager` was removed from the **live** addon list (`system:browsing-setting-addons` in sysRedis). That key overrides the code constant, so prod is already correct.

`DEFAULT_BROWSING_SETTINGS_ADDONS` was never updated. It's what `getBrowsingSettingAddons()` falls back to whenever sysRedis is unreadable, the key is absent, or the value fails to parse (`system-cache.ts` fails open to defaults on a read error, a corrupt value, or a timeout). So if that key were ever lost, wiped, or re-seeded, **the block would come back silently** — at every browsing level, with nothing in the logs.

Same shape as the bug that started this thread: a stale copy of config somewhere nobody reads. (There were two live copies of this key; one in the wrong Redis namespace cost an afternoon.)

## Why the block was removed

`loli` is applied by the **WD14 auto-tagger**: **459,896 tags at ~59% average confidence**, none human-reviewed. The two examples that surfaced this were tagged **74%** and **39%**. Blocking content on that signal hid legal adult content site-wide — invisible to the creator, no appeal, ~9.5K images/month.

`teenager` by contrast is applied **only by humans** (15 tags, all `source: User`), so there was never a false-positive machine problem there — it rode along in the same rule.

## After

Fallback now matches what prod serves — 3 rules, identical sets:

| rule | levels | flags | tags |
|---|---|---|---|
| 1 | X, XXX | — | (footer links) |
| 2 | all | `disablePoi` | 9 POI tags |
| 3 | R, X, XXX | `disableMinor` | 5 child tags |

## What deliberately did *not* change

`BLOCKED_BROWSING_TAG_IDS` still lists `loli` / `shota` / `teenager`. That list drives the **W2 nav blocklist and the tag-page 404** — it blocks the tag, not the content carrying it. Those pages still 404, and the tags stay unlisted.

The two lists now intentionally diverge, so the comment claiming they were "kept in sync" had to go — following it would re-add the block. The replacement says why they differ.

## Testing

- `blocked-browsing-tags` suite green (16/16)
- `pnpm typecheck` clean
- Verified the fallback equals the live sysRedis value field-for-field: 3 rules, same tag sets, same flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)
