### PR TITLE
feat(app-blocks): buzz self-read endpoints (hardened) — supersedes #3132

### DIFF
--- a/src/pages/api/v1/blocks/buzz/accounts.ts
+++ b/src/pages/api/v1/blocks/buzz/accounts.ts
@@ -8,6 +8,7 @@ import {
 } from '~/server/middleware/block-scope.middleware';
 import { blockBuzzAccountTypes } from '~/server/schema/buzz.schema';
 import { getUserBuzzAccount } from '~/server/services/buzz.service';
+import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
 
 /**
  * GET /api/v1/blocks/buzz/accounts
@@ -43,6 +44,16 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
   if (subjectUserId == null) {
     res.status(403).json({ error: 'Anonymous block tokens may not read balances' });
+    return;
+  }
+
+  // Per-instance rate limit (shared blocks catalog limiter) — bounds a block
+  // hammering this private,no-store balance route onto the origin. Runs BEFORE
+  // the service call. Mirrors blocks/collections + blocks/models.
+  const rateLimit = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
     return;
   }
 

--- a/src/pages/api/v1/blocks/buzz/accounts.ts
+++ b/src/pages/api/v1/blocks/buzz/accounts.ts
@@ -1,0 +1,72 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+
+import {
+  parseSubjectUserId,
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import { blockBuzzAccountTypes } from '~/server/schema/buzz.schema';
+import { getUserBuzzAccount } from '~/server/services/buzz.service';
+
+/**
+ * GET /api/v1/blocks/buzz/accounts
+ *
+ * Block-side all-pool balance readout. Scope `buzz:read:self`. Returns the
+ * token SUBJECT's balance for every pool in blockBuzzAccountTypes — the three
+ * spendable types plus the creator payout pools (creator bank / cashPending /
+ * cashSettled) the single-pool ../buzz.ts endpoint doesn't cover. Self-bound:
+ * balances are keyed on the verified token subject, never client input; anon
+ * tokens are rejected (no "self").
+ *
+ * Response: `{ accounts: [{ accountType, balance }] }`.
+ */
+
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  let subjectUserId: number | null;
+  try {
+    subjectUserId = parseSubjectUserId(claims.sub);
+  } catch {
+    res.status(403).json({ error: 'Invalid subject claim' });
+    return;
+  }
+  if (subjectUserId == null) {
+    res.status(403).json({ error: 'Anonymous block tokens may not read balances' });
+    return;
+  }
+
+  try {
+    const accounts = await getUserBuzzAccount({
+      accountId: subjectUserId,
+      accountTypes: [...blockBuzzAccountTypes],
+    });
+    res.status(200).json({
+      accounts: accounts.map(({ accountType, balance }) => ({ accountType, balance })),
+    });
+    return;
+  } catch {
+    res.status(502).json({ error: 'Failed to read balances' });
+    return;
+  }
+});
+
+// allowOpaqueOrigin: an UNVERIFIED block direct-fetches this from an opaque
+// origin (`Origin: null`), so it needs `ACAO: null` to clear the CORS preflight;
+// the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
+// ../buzz.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, {
+  endpoint: 'buzz_accounts',
+  requiredScope: 'buzz:read:self',
+  allowOpaqueOrigin: true,
+});

--- a/src/pages/api/v1/blocks/buzz/daily-compensation.ts
+++ b/src/pages/api/v1/blocks/buzz/daily-compensation.ts
@@ -8,6 +8,7 @@ import {
 } from '~/server/middleware/block-scope.middleware';
 import { getBlockBuzzDailyCompensationQuery } from '~/server/schema/buzz.schema';
 import { getDailyCompensationRewardByUser } from '~/server/services/buzz.service';
+import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
 import { handleEndpointError } from '~/server/utils/endpoint-helpers';
 
 /**
@@ -56,6 +57,18 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     return;
   }
   const { date, source, accountType } = parsed.data;
+
+  // Per-instance rate limit (shared blocks catalog limiter) — bounds a block
+  // hammering this private,no-store route onto the origin. Runs BEFORE the
+  // service call, which fans out to a Postgres modelVersion.findMany + a
+  // ClickHouse scan per call — the most expensive of the three. Mirrors
+  // blocks/collections + blocks/models.
+  const rateLimit = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
+    return;
+  }
 
   try {
     const result = await getDailyCompensationRewardByUser({

--- a/src/pages/api/v1/blocks/buzz/daily-compensation.ts
+++ b/src/pages/api/v1/blocks/buzz/daily-compensation.ts
@@ -1,0 +1,83 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+
+import {
+  parseSubjectUserId,
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import { getBlockBuzzDailyCompensationQuery } from '~/server/schema/buzz.schema';
+import { getDailyCompensationRewardByUser } from '~/server/services/buzz.service';
+import { handleEndpointError } from '~/server/utils/endpoint-helpers';
+
+/**
+ * GET /api/v1/blocks/buzz/daily-compensation
+ *
+ * Block-side per-modelVersion generation-compensation readout. Scope
+ * `buzz:read:self`. Returns the token SUBJECT's own daily compensation rows for
+ * the MONTH containing `date` (that windowing lives in the service). Self-bound:
+ * userId comes from the verified token subject, never client input; anon tokens
+ * are rejected (no "self").
+ *
+ * Query: `date` (ISO; required), `source` compensation|licenseFee (default
+ * compensation), `accountType?`.
+ *
+ * Response: `{ resources[], hasPublishedResources }` — per-modelVersion daily
+ * totals, buzz + cash. Cash amounts are in TENTHS of a penny (client ÷ 10).
+ */
+
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  let subjectUserId: number | null;
+  try {
+    subjectUserId = parseSubjectUserId(claims.sub);
+  } catch {
+    res.status(403).json({ error: 'Invalid subject claim' });
+    return;
+  }
+  if (subjectUserId == null) {
+    res.status(403).json({ error: 'Anonymous block tokens may not read compensation' });
+    return;
+  }
+
+  const parsed = getBlockBuzzDailyCompensationQuery.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
+  const { date, source, accountType } = parsed.data;
+
+  try {
+    const result = await getDailyCompensationRewardByUser({
+      userId: subjectUserId,
+      date,
+      source,
+      accountType,
+    });
+    res.status(200).json(result);
+    return;
+  } catch (e) {
+    handleEndpointError(res, e);
+    return;
+  }
+});
+
+// allowOpaqueOrigin: an UNVERIFIED block direct-fetches this from an opaque
+// origin (`Origin: null`), so it needs `ACAO: null` to clear the CORS preflight;
+// the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
+// ../buzz.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, {
+  endpoint: 'buzz_daily_compensation',
+  requiredScope: 'buzz:read:self',
+  allowOpaqueOrigin: true,
+});

--- a/src/pages/api/v1/blocks/buzz/transactions.ts
+++ b/src/pages/api/v1/blocks/buzz/transactions.ts
@@ -8,6 +8,7 @@ import {
 } from '~/server/middleware/block-scope.middleware';
 import { getBlockBuzzTransactionsQuery } from '~/server/schema/buzz.schema';
 import { getUserBuzzTransactions } from '~/server/services/buzz.service';
+import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
 import { handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 
@@ -60,6 +61,16 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
   const { accountType, type, cursor, start, end, limit } = parsed.data;
 
+  // Per-instance rate limit (shared blocks catalog limiter) — bounds a block
+  // hammering this private,no-store ledger route onto the origin. Runs BEFORE
+  // the buzz-service call. Mirrors blocks/collections + blocks/models.
+  const rateLimit = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
+    return;
+  }
+
   try {
     const { cursor: nextCursor, transactions } = await getUserBuzzTransactions({
       accountId: subjectUserId,
@@ -73,9 +84,27 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 
     res.status(200).json({
       cursor: nextCursor,
-      transactions: transactions.map(({ toUser, fromUser, ...t }) => ({
+      transactions: transactions.map(({ toUser, fromUser, details, ...t }) => ({
         ...t,
         type: TransactionType[t.type],
+        // Allowlist the `details` projection to the entity-attribution fields
+        // the dashboard renders (tips/rewards/challenges). `buzzTransactionDetails`
+        // is a `.passthrough()` object, and Purchase rows store
+        // `details.stripePaymentIntentId` (see buzz.service completeStripeBuzzPurchase),
+        // so an unfiltered spread would ship the user's Stripe payment-intent
+        // reference to the block iframe. Deny-by-default, mirroring the
+        // `{ id, username }` counterparty projection beside it: pick only the
+        // known attribution fields, drop stripePaymentIntentId + any other
+        // passthrough key.
+        details: details
+          ? {
+              user: details.user,
+              entityId: details.entityId,
+              entityType: details.entityType,
+              url: details.url,
+              toAccountType: details.toAccountType,
+            }
+          : details,
         toUser: toUser ? { id: toUser.id, username: toUser.username } : undefined,
         fromUser: fromUser ? { id: fromUser.id, username: fromUser.username } : undefined,
       })),

--- a/src/pages/api/v1/blocks/buzz/transactions.ts
+++ b/src/pages/api/v1/blocks/buzz/transactions.ts
@@ -24,10 +24,12 @@ import { TransactionType } from '~/shared/constants/buzz.constants';
  * (TransactionType NAME, e.g. "Tip"), `cursor?`/`start?`/`end?` (ISO dates),
  * `limit` 1–200 (default 50).
  *
- * Response: `{ cursor, transactions[] }`. Rows keep `description`, `details`
- * (entity attribution), and `externalTransactionId` (reward/challenge
- * classification); `type` is serialized as its name; counterparties are
- * projected to `{ id, username }` only.
+ * Response: `{ cursor, transactions[] }`. Rows keep `description` and an
+ * allowlisted `details` (entity attribution only — no passthrough); `type` is
+ * serialized as its name; counterparties are projected to `{ id, username }`
+ * only. `externalTransactionId` is exposed ONLY for non-Purchase rows (its
+ * reward/challenge classifier); it is NULLED on Purchase rows, where it is the
+ * payment-processor reference (Stripe/Paddle/PayPal/crypto).
  */
 
 const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -84,7 +86,7 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
 
     res.status(200).json({
       cursor: nextCursor,
-      transactions: transactions.map(({ toUser, fromUser, details, ...t }) => ({
+      transactions: transactions.map(({ toUser, fromUser, details, externalTransactionId, ...t }) => ({
         ...t,
         type: TransactionType[t.type],
         // Allowlist the `details` projection to the entity-attribution fields
@@ -105,6 +107,18 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
               toAccountType: details.toAccountType,
             }
           : details,
+        // externalTransactionId is DUAL-USE. On Purchase rows it is the payment-
+        // processor reference — the SAME value F1 stripped from `details`
+        // (Stripe `paymentIntent.id`, Paddle `transaction.id`, `PAYPAL_ORDER:…`,
+        // crypto order ids — every external buy-in flow lands as
+        // TransactionType.Purchase via grantBuzzPurchase / completeStripeBuzzPurchase).
+        // Null it for Purchase so the processor ref never reaches the block iframe.
+        // On Reward/challenge/etc. rows it is a non-sensitive semantic classifier
+        // (`challenge-entry-prize-…`, `referral-reward:…`) the dashboard needs to
+        // categorize prizes — keep it. Type-based, NOT a string-prefix check:
+        // Stripe/Paddle refs are bare ids with no distinctive prefix.
+        externalTransactionId:
+          t.type === TransactionType.Purchase ? null : externalTransactionId,
         toUser: toUser ? { id: toUser.id, username: toUser.username } : undefined,
         fromUser: fromUser ? { id: fromUser.id, username: fromUser.username } : undefined,
       })),

--- a/src/pages/api/v1/blocks/buzz/transactions.ts
+++ b/src/pages/api/v1/blocks/buzz/transactions.ts
@@ -27,10 +27,60 @@ import { TransactionType } from '~/shared/constants/buzz.constants';
  * Response: `{ cursor, transactions[] }`. Rows keep `description` and an
  * allowlisted `details` (entity attribution only — no passthrough); `type` is
  * serialized as its name; counterparties are projected to `{ id, username }`
- * only. `externalTransactionId` is exposed ONLY for non-Purchase rows (its
- * reward/challenge classifier); it is NULLED on Purchase rows, where it is the
- * payment-processor reference (Stripe/Paddle/PayPal/crypto).
+ * only. `externalTransactionId` is exposed only where it is a civitai-internal
+ * reward/prize classifier; it is NULLED wherever it holds a payment-processor /
+ * external-financial reference (money-movement types + the merch Shopify value —
+ * see projectExternalTransactionId).
  */
+
+// `externalTransactionId` is DUAL-USE across the ledger, and TransactionType
+// does NOT cleanly separate the two uses — so the block projection strips it
+// deny-first. Two rules (an evidence-based sweep of every `externalTransactionId`
+// assignment in the buzz + payment services):
+//
+//  (1) SENSITIVE TYPES — the money-movement types where the field holds a raw
+//      payment-processor / external-financial reference. Nulled wholesale so a
+//      third-party block never receives the user's processor ids:
+//        • Purchase   – every external buy-in lands here via grantBuzzPurchase /
+//                       completeStripeBuzzPurchase: Stripe paymentIntent.id +
+//                       invoice.id, Paddle transaction.id, `PAYPAL_ORDER:<id>`,
+//                       NOWPayments/Coinbase/EmerchantPay order ids, subscription
+//                       payment refs.
+//        • Refund     – a PayPal reversal stores the BARE PayPal transaction id
+//                       (paypal.service) with no distinguishing prefix, so the
+//                       value can't be told apart from the internal ones — null
+//                       the whole type.
+//        • ChargeBack / Withdrawal – payment-dispute / cash-out financial-movement
+//                       types; nulled defensively (no dashboard classifier need;
+//                       future processor/bank refs land here by convention).
+//  (2) SENSITIVE VALUE PREFIX — the ONE external reference that rides a
+//      non-money-movement type: merch grants a Shopify order id under type
+//      *Reward* as `merchPurchase:<shopifyOrderId>` (merch.service). Nulled by
+//      prefix so it doesn't leak through the kept-Reward path.
+//
+// Every OTHER row keeps its externalTransactionId — it is a civitai-internal
+// semantic classifier the dashboard renders (challenge-entry/winner prizes,
+// `referral-reward:*`, generic reward-event ids, bounty/compensation tags).
+const EXTERNAL_TXN_ID_SENSITIVE_TYPES = new Set<TransactionType>([
+  TransactionType.Purchase,
+  TransactionType.Refund,
+  TransactionType.ChargeBack,
+  TransactionType.Withdrawal,
+]);
+const EXTERNAL_TXN_ID_SENSITIVE_VALUE_PREFIXES = ['merchPurchase:'];
+
+function projectExternalTransactionId(
+  type: TransactionType,
+  externalTransactionId: string | null | undefined
+): string | null {
+  if (EXTERNAL_TXN_ID_SENSITIVE_TYPES.has(type)) return null;
+  if (
+    externalTransactionId != null &&
+    EXTERNAL_TXN_ID_SENSITIVE_VALUE_PREFIXES.some((p) => externalTransactionId.startsWith(p))
+  )
+    return null;
+  return externalTransactionId ?? null;
+}
 
 const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -107,18 +157,11 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
               toAccountType: details.toAccountType,
             }
           : details,
-        // externalTransactionId is DUAL-USE. On Purchase rows it is the payment-
-        // processor reference — the SAME value F1 stripped from `details`
-        // (Stripe `paymentIntent.id`, Paddle `transaction.id`, `PAYPAL_ORDER:…`,
-        // crypto order ids — every external buy-in flow lands as
-        // TransactionType.Purchase via grantBuzzPurchase / completeStripeBuzzPurchase).
-        // Null it for Purchase so the processor ref never reaches the block iframe.
-        // On Reward/challenge/etc. rows it is a non-sensitive semantic classifier
-        // (`challenge-entry-prize-…`, `referral-reward:…`) the dashboard needs to
-        // categorize prizes — keep it. Type-based, NOT a string-prefix check:
-        // Stripe/Paddle refs are bare ids with no distinctive prefix.
-        externalTransactionId:
-          t.type === TransactionType.Purchase ? null : externalTransactionId,
+        // Strip externalTransactionId wherever it holds a payment-processor /
+        // external-financial reference (money-movement types + the merch Shopify
+        // value); keep it where it is a civitai-internal prize/reward classifier
+        // the dashboard renders. See projectExternalTransactionId above.
+        externalTransactionId: projectExternalTransactionId(t.type, externalTransactionId),
         toUser: toUser ? { id: toUser.id, username: toUser.username } : undefined,
         fromUser: fromUser ? { id: fromUser.id, username: fromUser.username } : undefined,
       })),

--- a/src/pages/api/v1/blocks/buzz/transactions.ts
+++ b/src/pages/api/v1/blocks/buzz/transactions.ts
@@ -1,0 +1,98 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+
+import {
+  parseSubjectUserId,
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import { getBlockBuzzTransactionsQuery } from '~/server/schema/buzz.schema';
+import { getUserBuzzTransactions } from '~/server/services/buzz.service';
+import { handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { TransactionType } from '~/shared/constants/buzz.constants';
+
+/**
+ * GET /api/v1/blocks/buzz/transactions
+ *
+ * Block-side Buzz-ledger readout. Scope `buzz:read:self`. Pages the token
+ * SUBJECT's own transactions for ONE pool per call (per-pool cursors upstream).
+ * Self-bound: the account is keyed on the verified token subject, never client
+ * input; anon tokens are rejected (no "self").
+ *
+ * Query: `accountType` (default yellow — see blockBuzzAccountTypes), `type?`
+ * (TransactionType NAME, e.g. "Tip"), `cursor?`/`start?`/`end?` (ISO dates),
+ * `limit` 1–200 (default 50).
+ *
+ * Response: `{ cursor, transactions[] }`. Rows keep `description`, `details`
+ * (entity attribution), and `externalTransactionId` (reward/challenge
+ * classification); `type` is serialized as its name; counterparties are
+ * projected to `{ id, username }` only.
+ */
+
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  let subjectUserId: number | null;
+  try {
+    subjectUserId = parseSubjectUserId(claims.sub);
+  } catch {
+    res.status(403).json({ error: 'Invalid subject claim' });
+    return;
+  }
+  if (subjectUserId == null) {
+    res.status(403).json({ error: 'Anonymous block tokens may not read transactions' });
+    return;
+  }
+
+  const parsed = getBlockBuzzTransactionsQuery.safeParse(req.query);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error });
+    return;
+  }
+  const { accountType, type, cursor, start, end, limit } = parsed.data;
+
+  try {
+    const { cursor: nextCursor, transactions } = await getUserBuzzTransactions({
+      accountId: subjectUserId,
+      accountType,
+      type: type ? TransactionType[type] : undefined,
+      cursor,
+      start,
+      end,
+      limit,
+    });
+
+    res.status(200).json({
+      cursor: nextCursor,
+      transactions: transactions.map(({ toUser, fromUser, ...t }) => ({
+        ...t,
+        type: TransactionType[t.type],
+        toUser: toUser ? { id: toUser.id, username: toUser.username } : undefined,
+        fromUser: fromUser ? { id: fromUser.id, username: fromUser.username } : undefined,
+      })),
+    });
+    return;
+  } catch (e) {
+    handleEndpointError(res, e);
+    return;
+  }
+});
+
+// allowOpaqueOrigin: an UNVERIFIED block direct-fetches this from an opaque
+// origin (`Origin: null`), so it needs `ACAO: null` to clear the CORS preflight;
+// the Bearer block-JWT (no cookies) remains the sole authz gate — mirrors
+// ../buzz.ts; see WithBlockScopeOpts.allowOpaqueOrigin.
+export default withBlockScope(baseHandler, {
+  endpoint: 'buzz_transactions',
+  requiredScope: 'buzz:read:self',
+  allowOpaqueOrigin: true,
+});

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -46,7 +46,10 @@ export type AppBlockEndpoint =
   | 'collection_follow'
   | 'shared_storage_top'
   | 'shared_storage_increment'
-  | 'generation_resources';
+  | 'generation_resources'
+  | 'buzz_transactions'
+  | 'buzz_daily_compensation'
+  | 'buzz_accounts';
 
 export type AppBlockRequestResult = 'success' | 'client_error' | 'server_error' | 'forbidden';
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3160,14 +3160,14 @@ export const blocksRouter = router({
    * account picker + "you have N buzz" without the page ever holding the
    * `buzz:read:self` scope.
    *
-   * POLICY REVERSAL (intentional, scoped): App Blocks pages are deliberately
-   * FORBIDDEN the `buzz:read:self` scope — a page has no business reading the
-   * viewer's balance directly. This procedure is the FIRST-PARTY host exposing
-   * the viewer's OWN balance to their OWN page session, mediated by the
-   * proof-of-session block token: userId is derived from the token `sub`
-   * (self-bound), NEVER from client input, so a page can only ever read the
-   * balance of the exact user whose session minted the token. This does NOT
-   * lift the scope forbid; `buzz:read:self` stays denied for pages.
+   * NOTE: `buzz:read:self` is page-safe (PAGE_FORBIDDEN_SCOPES is empty — see
+   * slot-registry.ts), so a page CAN declare the scope and hit the
+   * /api/v1/blocks/buzz/* REST endpoints directly. This procedure remains the
+   * scope-free convenience path: the FIRST-PARTY host exposing the viewer's OWN
+   * balance to their OWN page session, mediated by the proof-of-session block
+   * token — userId is derived from the token `sub` (self-bound), NEVER from
+   * client input, so a page can only ever read the balance of the exact user
+   * whose session minted the token.
    *
    * Auth model is IDENTICAL to submitWorkflow's block-token gate: verify the
    * token, require an authenticated (non-anon) subject, then the App-Blocks

--- a/src/server/schema/buzz.schema.ts
+++ b/src/server/schema/buzz.schema.ts
@@ -1,5 +1,5 @@
 import * as z from 'zod';
-import type { BuzzApiAccountType } from '~/shared/constants/buzz.constants';
+import type { BuzzAccountType, BuzzApiAccountType } from '~/shared/constants/buzz.constants';
 import {
   BuzzTypes,
   TransactionType,
@@ -185,6 +185,42 @@ export const getDailyBuzzCompensationInput = z.object({
   date: z.coerce.date(),
   accountType: z.preprocess(preprocessAccountType, z.enum(buzzAccountTypes)).optional(),
   source: z.enum(compensationSources).default('compensation'),
+});
+
+// The pools the block API exposes: the three spendable types plus the creator
+// payout pools. `red` (disabled) and `club` (legacy) are deliberately excluded.
+export const blockBuzzAccountTypes = [
+  'yellow',
+  'blue',
+  'green',
+  'creatorProgramBank',
+  'creatorProgramBankGreen',
+  'cashPending',
+  'cashSettled',
+] as const satisfies readonly BuzzAccountType[];
+
+const transactionTypeNames = Object.keys(TransactionType).filter((key) =>
+  Number.isNaN(Number(key))
+) as [keyof typeof TransactionType, ...(keyof typeof TransactionType)[]];
+
+// Query-string contracts for GET /api/v1/blocks/buzz/* — everything arrives as
+// strings, hence the coercions. `type` takes the TransactionType NAME ("Tip"),
+// not the numeric value.
+export type GetBlockBuzzTransactionsQuery = z.infer<typeof getBlockBuzzTransactionsQuery>;
+export const getBlockBuzzTransactionsQuery = z.object({
+  accountType: z.enum(blockBuzzAccountTypes).default('yellow'),
+  type: z.enum(transactionTypeNames).optional(),
+  cursor: z.coerce.date().optional(),
+  start: z.coerce.date().optional(),
+  end: z.coerce.date().optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+});
+
+export type GetBlockBuzzDailyCompensationQuery = z.infer<typeof getBlockBuzzDailyCompensationQuery>;
+export const getBlockBuzzDailyCompensationQuery = z.object({
+  date: z.coerce.date(),
+  source: z.enum(compensationSources).default('compensation'),
+  accountType: z.enum(blockBuzzAccountTypes).optional(),
 });
 
 export type ClaimWatchedAdRewardInput = z.infer<typeof claimWatchedAdRewardSchema>;

--- a/src/tests/api/v1/blocks/buzz-accounts-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/buzz-accounts-endpoint.test.ts
@@ -17,6 +17,7 @@ function createMocks({ method = 'GET' }: { method?: string } = {}) {
   } as unknown as Record<string, unknown>;
   let statusCode = 200;
   let payload: unknown;
+  const headers: Record<string, string> = {};
   const res = {
     status(c: number) {
       statusCode = c;
@@ -26,12 +27,15 @@ function createMocks({ method = 'GET' }: { method?: string } = {}) {
       payload = b;
       return res;
     },
-    setHeader() {},
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
     end() {
       return res;
     },
     _status: () => statusCode,
     _json: () => payload,
+    _headers: () => headers,
   };
   return { req, res };
 }
@@ -54,8 +58,11 @@ vi.mock('~/server/middleware/block-scope.middleware', () => ({
 }));
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
 
-const { mockAccount } = vi.hoisted(() => ({ mockAccount: vi.fn() }));
+const { mockAccount, mockRate } = vi.hoisted(() => ({ mockAccount: vi.fn(), mockRate: vi.fn() }));
 vi.mock('~/server/services/buzz.service', () => ({ getUserBuzzAccount: mockAccount }));
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: mockRate,
+}));
 
 import handler from '~/pages/api/v1/blocks/buzz/accounts';
 import { blockBuzzAccountTypes } from '~/server/schema/buzz.schema';
@@ -81,6 +88,7 @@ function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
 beforeEach(() => {
   vi.clearAllMocks();
   claimsBox.claims = fakeClaims();
+  mockRate.mockResolvedValue({ allowed: true });
   mockAccount.mockResolvedValue(
     blockBuzzAccountTypes.map((accountType, i) => ({
       id: 42,
@@ -111,6 +119,32 @@ describe('GET /api/v1/blocks/buzz/accounts', () => {
     await handler(req as never, res as never);
     expect(res._status()).toBe(403);
     expect(mockAccount).not.toHaveBeenCalled();
+  });
+
+  it('429 when the per-instance rate limit trips, before the balance service is called', async () => {
+    mockRate.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 7 });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(429);
+    expect(res._headers()['Retry-After']).toBe('7');
+    expect(mockAccount).not.toHaveBeenCalled();
+  });
+
+  it('checks the rate limit (keyed on blockInstanceId) before the service call', async () => {
+    const order: string[] = [];
+    mockRate.mockImplementationOnce(async () => {
+      order.push('rate');
+      return { allowed: true };
+    });
+    mockAccount.mockImplementationOnce(async () => {
+      order.push('service');
+      return [];
+    });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(mockRate).toHaveBeenCalledWith('bki');
+    expect(order).toEqual(['rate', 'service']);
   });
 
   it('200: reads every exposed pool for the verified subject, projecting {accountType, balance}', async () => {

--- a/src/tests/api/v1/blocks/buzz-accounts-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/buzz-accounts-endpoint.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * Handler-level coverage for GET /api/v1/blocks/buzz/accounts (all-pool balance
+ * readout). Authz is middleware territory; CORS/scope wiring is in
+ * scoped-endpoints-cors-wiring.test.ts. This exercises the inner handler's
+ * self-bound multi-pool read and response projection.
+ */
+
+function createMocks({ method = 'GET' }: { method?: string } = {}) {
+  const req = {
+    method,
+    query: {},
+    headers: {},
+    socket: { remoteAddress: '203.0.113.7' },
+  } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader() {},
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+class ForbiddenError extends Error {
+  readonly status = 403 as const;
+}
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+  parseSubjectUserId: (sub: string): number | null => {
+    if (sub === 'anon') return null;
+    if (!/^user:\d+$/.test(sub)) throw new ForbiddenError('bad');
+    return Number.parseInt(sub.slice('user:'.length), 10);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const { mockAccount } = vi.hoisted(() => ({ mockAccount: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({ getUserBuzzAccount: mockAccount }));
+
+import handler from '~/pages/api/v1/blocks/buzz/accounts';
+import { blockBuzzAccountTypes } from '~/server/schema/buzz.schema';
+
+function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'j',
+    blockId: 'b',
+    appId: 'a',
+    appBlockId: 'apb',
+    blockInstanceId: 'bki',
+    ctx: {},
+    scopes: ['buzz:read:self'],
+    ...over,
+  } as BlockTokenClaims;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockAccount.mockResolvedValue(
+    blockBuzzAccountTypes.map((accountType, i) => ({
+      id: 42,
+      balance: (i + 1) * 100,
+      lifetimeBalance: null,
+      accountType,
+    }))
+  );
+});
+
+describe('GET /api/v1/blocks/buzz/accounts', () => {
+  it('405 for a non-GET method', async () => {
+    const { req, res } = createMocks({ method: 'POST' });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(405);
+  });
+
+  it('401 when blockClaims is absent', async () => {
+    claimsBox.claims = undefined;
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(401);
+  });
+
+  it('403 for an anonymous token (no "self" balances)', async () => {
+    claimsBox.claims = fakeClaims({ sub: 'anon' as never });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+    expect(mockAccount).not.toHaveBeenCalled();
+  });
+
+  it('200: reads every exposed pool for the verified subject, projecting {accountType, balance}', async () => {
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    // Keyed on the verified subject (42), never client input.
+    expect(mockAccount).toHaveBeenCalledWith({
+      accountId: 42,
+      accountTypes: [...blockBuzzAccountTypes],
+    });
+    expect(res._json()).toEqual({
+      accounts: blockBuzzAccountTypes.map((accountType, i) => ({
+        accountType,
+        balance: (i + 1) * 100,
+      })),
+    });
+  });
+
+  it('502 when the balance service throws', async () => {
+    mockAccount.mockRejectedValueOnce(new Error('buzz down'));
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(502);
+  });
+});

--- a/src/tests/api/v1/blocks/buzz-daily-compensation-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/buzz-daily-compensation-endpoint.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * Handler-level coverage for GET /api/v1/blocks/buzz/daily-compensation
+ * (per-modelVersion generation earnings). Authz is middleware territory;
+ * CORS/scope wiring is in scoped-endpoints-cors-wiring.test.ts. This exercises
+ * the inner handler: self-binding and query parsing.
+ */
+
+function createMocks({
+  method = 'GET',
+  query = {},
+}: { method?: string; query?: Record<string, string> } = {}) {
+  const req = {
+    method,
+    query,
+    headers: {},
+    socket: { remoteAddress: '203.0.113.7' },
+  } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader() {},
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+class ForbiddenError extends Error {
+  readonly status = 403 as const;
+}
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+  parseSubjectUserId: (sub: string): number | null => {
+    if (sub === 'anon') return null;
+    if (!/^user:\d+$/.test(sub)) throw new ForbiddenError('bad');
+    return Number.parseInt(sub.slice('user:'.length), 10);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const { mockGetDailyCompensation, mockHandleEndpointError } = vi.hoisted(() => ({
+  mockGetDailyCompensation: vi.fn(),
+  mockHandleEndpointError: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getDailyCompensationRewardByUser: mockGetDailyCompensation,
+}));
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  handleEndpointError: mockHandleEndpointError,
+}));
+
+import handler from '~/pages/api/v1/blocks/buzz/daily-compensation';
+
+function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'j',
+    blockId: 'b',
+    appId: 'a',
+    appBlockId: 'apb',
+    blockInstanceId: 'bki',
+    ctx: {},
+    scopes: ['buzz:read:self'],
+    ...over,
+  } as BlockTokenClaims;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockGetDailyCompensation.mockResolvedValue({ resources: [], hasPublishedResources: false });
+});
+
+describe('GET /api/v1/blocks/buzz/daily-compensation', () => {
+  it('405 for a non-GET method', async () => {
+    const { req, res } = createMocks({ method: 'POST', query: { date: '2026-07-01' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(405);
+  });
+
+  it('401 when blockClaims is absent', async () => {
+    claimsBox.claims = undefined;
+    const { req, res } = createMocks({ query: { date: '2026-07-01' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(401);
+  });
+
+  it('403 for an anonymous token (no "self" compensation)', async () => {
+    claimsBox.claims = fakeClaims({ sub: 'anon' as never });
+    const { req, res } = createMocks({ query: { date: '2026-07-01' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+    expect(mockGetDailyCompensation).not.toHaveBeenCalled();
+  });
+
+  it('400 when date is missing or invalid', async () => {
+    const badQueries: Record<string, string>[] = [
+      {},
+      { date: 'not-a-date' },
+      { date: '2026-07-01', source: 'nope' },
+    ];
+    for (const query of badQueries) {
+      const { req, res } = createMocks({ query });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(400);
+    }
+    expect(mockGetDailyCompensation).not.toHaveBeenCalled();
+  });
+
+  it('200: keyed on the verified subject, source defaults to compensation', async () => {
+    const { req, res } = createMocks({ query: { date: '2026-07-01' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual({ resources: [], hasPublishedResources: false });
+    expect(mockGetDailyCompensation).toHaveBeenCalledWith({
+      userId: 42,
+      date: new Date('2026-07-01'),
+      source: 'compensation',
+      accountType: undefined,
+    });
+  });
+
+  it('200: passes source/accountType through', async () => {
+    const { req, res } = createMocks({
+      query: { date: '2026-06-15', source: 'licenseFee', accountType: 'green' },
+    });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(mockGetDailyCompensation).toHaveBeenCalledWith({
+      userId: 42,
+      date: new Date('2026-06-15'),
+      source: 'licenseFee',
+      accountType: 'green',
+    });
+  });
+
+  it('delegates service failures to handleEndpointError', async () => {
+    mockGetDailyCompensation.mockRejectedValueOnce(new Error('clickhouse down'));
+    const { req, res } = createMocks({ query: { date: '2026-07-01' } });
+    await handler(req as never, res as never);
+    expect(mockHandleEndpointError).toHaveBeenCalledWith(res, expect.any(Error));
+  });
+});

--- a/src/tests/api/v1/blocks/buzz-daily-compensation-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/buzz-daily-compensation-endpoint.test.ts
@@ -20,6 +20,7 @@ function createMocks({
   } as unknown as Record<string, unknown>;
   let statusCode = 200;
   let payload: unknown;
+  const headers: Record<string, string> = {};
   const res = {
     status(c: number) {
       statusCode = c;
@@ -29,12 +30,15 @@ function createMocks({
       payload = b;
       return res;
     },
-    setHeader() {},
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
     end() {
       return res;
     },
     _status: () => statusCode,
     _json: () => payload,
+    _headers: () => headers,
   };
   return { req, res };
 }
@@ -57,15 +61,19 @@ vi.mock('~/server/middleware/block-scope.middleware', () => ({
 }));
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
 
-const { mockGetDailyCompensation, mockHandleEndpointError } = vi.hoisted(() => ({
+const { mockGetDailyCompensation, mockHandleEndpointError, mockRate } = vi.hoisted(() => ({
   mockGetDailyCompensation: vi.fn(),
   mockHandleEndpointError: vi.fn(),
+  mockRate: vi.fn(),
 }));
 vi.mock('~/server/services/buzz.service', () => ({
   getDailyCompensationRewardByUser: mockGetDailyCompensation,
 }));
 vi.mock('~/server/utils/endpoint-helpers', () => ({
   handleEndpointError: mockHandleEndpointError,
+}));
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: mockRate,
 }));
 
 import handler from '~/pages/api/v1/blocks/buzz/daily-compensation';
@@ -91,6 +99,7 @@ function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
 beforeEach(() => {
   vi.clearAllMocks();
   claimsBox.claims = fakeClaims();
+  mockRate.mockResolvedValue({ allowed: true });
   mockGetDailyCompensation.mockResolvedValue({ resources: [], hasPublishedResources: false });
 });
 
@@ -128,6 +137,32 @@ describe('GET /api/v1/blocks/buzz/daily-compensation', () => {
       expect(res._status()).toBe(400);
     }
     expect(mockGetDailyCompensation).not.toHaveBeenCalled();
+  });
+
+  it('429 when the per-instance rate limit trips, before the ClickHouse-backed service is called', async () => {
+    mockRate.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 7 });
+    const { req, res } = createMocks({ query: { date: '2026-07-01' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(429);
+    expect(res._headers()['Retry-After']).toBe('7');
+    expect(mockGetDailyCompensation).not.toHaveBeenCalled();
+  });
+
+  it('checks the rate limit (keyed on blockInstanceId) before the service call', async () => {
+    const order: string[] = [];
+    mockRate.mockImplementationOnce(async () => {
+      order.push('rate');
+      return { allowed: true };
+    });
+    mockGetDailyCompensation.mockImplementationOnce(async () => {
+      order.push('service');
+      return { resources: [], hasPublishedResources: false };
+    });
+    const { req, res } = createMocks({ query: { date: '2026-07-01' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(mockRate).toHaveBeenCalledWith('bki');
+    expect(order).toEqual(['rate', 'service']);
   });
 
   it('200: keyed on the verified subject, source defaults to compensation', async () => {

--- a/src/tests/api/v1/blocks/buzz-transactions-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/buzz-transactions-endpoint.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+import { TransactionType } from '~/shared/constants/buzz.constants';
+
+/**
+ * Handler-level coverage for GET /api/v1/blocks/buzz/transactions (ledger
+ * readout). Authz (missing-scope / revoked) is middleware territory; CORS/scope
+ * wiring is in scoped-endpoints-cors-wiring.test.ts. This exercises the inner
+ * handler: self-binding, query parsing, and the response projection.
+ */
+
+function createMocks({
+  method = 'GET',
+  query = {},
+}: { method?: string; query?: Record<string, string> } = {}) {
+  const req = {
+    method,
+    query,
+    headers: {},
+    socket: { remoteAddress: '203.0.113.7' },
+  } as unknown as Record<string, unknown>;
+  let statusCode = 200;
+  let payload: unknown;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader() {},
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+class ForbiddenError extends Error {
+  readonly status = 403 as const;
+}
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any) => (req: any, res: any) => {
+    req.blockClaims = claimsBox.claims;
+    return handler(req, res);
+  },
+  parseSubjectUserId: (sub: string): number | null => {
+    if (sub === 'anon') return null;
+    if (!/^user:\d+$/.test(sub)) throw new ForbiddenError('bad');
+    return Number.parseInt(sub.slice('user:'.length), 10);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const { mockGetTransactions, mockHandleEndpointError } = vi.hoisted(() => ({
+  mockGetTransactions: vi.fn(),
+  mockHandleEndpointError: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzTransactions: mockGetTransactions,
+}));
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  handleEndpointError: mockHandleEndpointError,
+}));
+
+import handler from '~/pages/api/v1/blocks/buzz/transactions';
+
+function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'j',
+    blockId: 'b',
+    appId: 'a',
+    appBlockId: 'apb',
+    blockInstanceId: 'bki',
+    ctx: {},
+    scopes: ['buzz:read:self'],
+    ...over,
+  } as BlockTokenClaims;
+}
+
+const sampleRow = {
+  date: new Date('2026-07-01T12:00:00Z'),
+  type: TransactionType.Tip,
+  fromAccountId: 7,
+  toAccountId: 42,
+  fromAccountType: 'yellow',
+  toAccountType: 'yellow',
+  amount: 100,
+  description: 'Tip: nice model',
+  details: { entityId: 5, entityType: 'Model' },
+  externalTransactionId: 'ext-1',
+  // Extra user fields prove the {id, username} projection strips them.
+  fromUser: { id: 7, username: 'tipper', status: 'active' },
+  toUser: { id: 42, username: 'me', status: 'active' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockGetTransactions.mockResolvedValue({
+    cursor: new Date('2026-06-30T00:00:00Z'),
+    transactions: [sampleRow],
+  });
+});
+
+describe('GET /api/v1/blocks/buzz/transactions', () => {
+  it('405 for a non-GET method', async () => {
+    const { req, res } = createMocks({ method: 'POST' });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(405);
+  });
+
+  it('401 when blockClaims is absent', async () => {
+    claimsBox.claims = undefined;
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(401);
+  });
+
+  it('403 for an anonymous token (no "self" ledger)', async () => {
+    claimsBox.claims = fakeClaims({ sub: 'anon' as never });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(403);
+    expect(mockGetTransactions).not.toHaveBeenCalled();
+  });
+
+  it('400 for an invalid query (unknown pool / out-of-range limit)', async () => {
+    const badQueries: Record<string, string>[] = [
+      { accountType: 'red' },
+      { limit: '500' },
+      { cursor: 'not-a-date' },
+    ];
+    for (const query of badQueries) {
+      const { req, res } = createMocks({ query });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(400);
+    }
+    expect(mockGetTransactions).not.toHaveBeenCalled();
+  });
+
+  it('200: defaults to yellow/limit 50, keyed on the verified subject', async () => {
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(mockGetTransactions).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: 42, accountType: 'yellow', limit: 50 })
+    );
+  });
+
+  it('200: coerces query params and maps the type name to its enum value', async () => {
+    const { req, res } = createMocks({
+      query: {
+        accountType: 'creatorProgramBank',
+        type: 'Tip',
+        cursor: '2026-06-01T00:00:00Z',
+        start: '2026-05-01T00:00:00Z',
+        end: '2026-07-01T00:00:00Z',
+        limit: '200',
+      },
+    });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(mockGetTransactions).toHaveBeenCalledWith({
+      accountId: 42,
+      accountType: 'creatorProgramBank',
+      type: TransactionType.Tip,
+      cursor: new Date('2026-06-01T00:00:00Z'),
+      start: new Date('2026-05-01T00:00:00Z'),
+      end: new Date('2026-07-01T00:00:00Z'),
+      limit: 200,
+    });
+  });
+
+  it('200: passes attribution fields through and projects counterparties to {id, username}', async () => {
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    const body = res._json() as { cursor: Date; transactions: Record<string, unknown>[] };
+    expect(body.cursor).toEqual(new Date('2026-06-30T00:00:00Z'));
+    expect(body.transactions).toHaveLength(1);
+    const row = body.transactions[0];
+    expect(row.type).toBe('Tip');
+    expect(row.description).toBe('Tip: nice model');
+    expect(row.details).toEqual({ entityId: 5, entityType: 'Model' });
+    expect(row.externalTransactionId).toBe('ext-1');
+    expect(row.fromUser).toEqual({ id: 7, username: 'tipper' });
+    expect(row.toUser).toEqual({ id: 42, username: 'me' });
+  });
+
+  it('delegates service failures to handleEndpointError', async () => {
+    mockGetTransactions.mockRejectedValueOnce(new Error('buzz down'));
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(mockHandleEndpointError).toHaveBeenCalledWith(res, expect.any(Error));
+  });
+});

--- a/src/tests/api/v1/blocks/buzz-transactions-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/buzz-transactions-endpoint.test.ts
@@ -21,6 +21,7 @@ function createMocks({
   } as unknown as Record<string, unknown>;
   let statusCode = 200;
   let payload: unknown;
+  const headers: Record<string, string> = {};
   const res = {
     status(c: number) {
       statusCode = c;
@@ -30,12 +31,15 @@ function createMocks({
       payload = b;
       return res;
     },
-    setHeader() {},
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
     end() {
       return res;
     },
     _status: () => statusCode,
     _json: () => payload,
+    _headers: () => headers,
   };
   return { req, res };
 }
@@ -58,15 +62,19 @@ vi.mock('~/server/middleware/block-scope.middleware', () => ({
 }));
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
 
-const { mockGetTransactions, mockHandleEndpointError } = vi.hoisted(() => ({
+const { mockGetTransactions, mockHandleEndpointError, mockRate } = vi.hoisted(() => ({
   mockGetTransactions: vi.fn(),
   mockHandleEndpointError: vi.fn(),
+  mockRate: vi.fn(),
 }));
 vi.mock('~/server/services/buzz.service', () => ({
   getUserBuzzTransactions: mockGetTransactions,
 }));
 vi.mock('~/server/utils/endpoint-helpers', () => ({
   handleEndpointError: mockHandleEndpointError,
+}));
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: mockRate,
 }));
 
 import handler from '~/pages/api/v1/blocks/buzz/transactions';
@@ -108,6 +116,7 @@ const sampleRow = {
 beforeEach(() => {
   vi.clearAllMocks();
   claimsBox.claims = fakeClaims();
+  mockRate.mockResolvedValue({ allowed: true });
   mockGetTransactions.mockResolvedValue({
     cursor: new Date('2026-06-30T00:00:00Z'),
     transactions: [sampleRow],
@@ -180,6 +189,69 @@ describe('GET /api/v1/blocks/buzz/transactions', () => {
       start: new Date('2026-05-01T00:00:00Z'),
       end: new Date('2026-07-01T00:00:00Z'),
       limit: 200,
+    });
+  });
+
+  it('429 when the per-instance rate limit trips, before the service is called', async () => {
+    mockRate.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 7 });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(429);
+    expect(res._headers()['Retry-After']).toBe('7');
+    expect(mockGetTransactions).not.toHaveBeenCalled();
+  });
+
+  it('checks the rate limit (keyed on blockInstanceId) before the service call', async () => {
+    const order: string[] = [];
+    mockRate.mockImplementationOnce(async () => {
+      order.push('rate');
+      return { allowed: true };
+    });
+    mockGetTransactions.mockImplementationOnce(async () => {
+      order.push('service');
+      return { cursor: null, transactions: [] };
+    });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(mockRate).toHaveBeenCalledWith('bki');
+    expect(order).toEqual(['rate', 'service']);
+  });
+
+  it('F1: allowlists details — DROPS stripePaymentIntentId, keeps attribution fields', async () => {
+    // A Purchase row: buzz.service stores the Stripe payment-intent ref inside
+    // details.passthrough(). It must never reach the block iframe.
+    mockGetTransactions.mockResolvedValueOnce({
+      cursor: null,
+      transactions: [
+        {
+          ...sampleRow,
+          details: {
+            user: 'buyer',
+            entityId: 5,
+            entityType: 'Model',
+            url: '/models/5',
+            toAccountType: 'yellow',
+            stripePaymentIntentId: 'pi_secret_123',
+            someOtherPassthrough: 'leak',
+          },
+          externalTransactionId: 'pi_secret_123',
+        },
+      ],
+    });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    const body = res._json() as { transactions: Record<string, unknown>[] };
+    const details = body.transactions[0].details as Record<string, unknown>;
+    expect(details).not.toHaveProperty('stripePaymentIntentId');
+    expect(details).not.toHaveProperty('someOtherPassthrough');
+    // Attribution fields the dashboard renders are preserved.
+    expect(details).toMatchObject({
+      user: 'buyer',
+      entityId: 5,
+      entityType: 'Model',
+      url: '/models/5',
+      toAccountType: 'yellow',
     });
   });
 

--- a/src/tests/api/v1/blocks/buzz-transactions-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/buzz-transactions-endpoint.test.ts
@@ -218,14 +218,17 @@ describe('GET /api/v1/blocks/buzz/transactions', () => {
     expect(order).toEqual(['rate', 'service']);
   });
 
-  it('F1: allowlists details — DROPS stripePaymentIntentId, keeps attribution fields', async () => {
-    // A Purchase row: buzz.service stores the Stripe payment-intent ref inside
-    // details.passthrough(). It must never reach the block iframe.
+  it('F1: Purchase row DROPS details.stripePaymentIntentId AND nulls the top-level externalTransactionId, keeps attribution', async () => {
+    // A Purchase row (every external buy-in flow — Stripe/Paddle/PayPal/crypto —
+    // lands as TransactionType.Purchase). buzz.service stores the Stripe
+    // payment-intent ref BOTH inside details.passthrough() AND as the top-level
+    // externalTransactionId (= paymentIntent.id). Neither may reach the iframe.
     mockGetTransactions.mockResolvedValueOnce({
       cursor: null,
       transactions: [
         {
           ...sampleRow,
+          type: TransactionType.Purchase,
           details: {
             user: 'buyer',
             entityId: 5,
@@ -242,7 +245,8 @@ describe('GET /api/v1/blocks/buzz/transactions', () => {
     const { req, res } = createMocks();
     await handler(req as never, res as never);
     const body = res._json() as { transactions: Record<string, unknown>[] };
-    const details = body.transactions[0].details as Record<string, unknown>;
+    const row = body.transactions[0];
+    const details = row.details as Record<string, unknown>;
     expect(details).not.toHaveProperty('stripePaymentIntentId');
     expect(details).not.toHaveProperty('someOtherPassthrough');
     // Attribution fields the dashboard renders are preserved.
@@ -253,6 +257,25 @@ describe('GET /api/v1/blocks/buzz/transactions', () => {
       url: '/models/5',
       toAccountType: 'yellow',
     });
+    // The processor reference is stripped from the top-level field too.
+    expect(row.externalTransactionId).toBeNull();
+  });
+
+  it('F1: non-Purchase (Reward/challenge) row KEEPS externalTransactionId — the prize classifier the dashboard needs', async () => {
+    mockGetTransactions.mockResolvedValueOnce({
+      cursor: null,
+      transactions: [
+        {
+          ...sampleRow,
+          type: TransactionType.Reward,
+          externalTransactionId: 'challenge-winner-prize-2026-07',
+        },
+      ],
+    });
+    const { req, res } = createMocks();
+    await handler(req as never, res as never);
+    const body = res._json() as { transactions: Record<string, unknown>[] };
+    expect(body.transactions[0].externalTransactionId).toBe('challenge-winner-prize-2026-07');
   });
 
   it('200: passes attribution fields through and projects counterparties to {id, username}', async () => {

--- a/src/tests/api/v1/blocks/buzz-transactions-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/buzz-transactions-endpoint.test.ts
@@ -261,21 +261,63 @@ describe('GET /api/v1/blocks/buzz/transactions', () => {
     expect(row.externalTransactionId).toBeNull();
   });
 
-  it('F1: non-Purchase (Reward/challenge) row KEEPS externalTransactionId — the prize classifier the dashboard needs', async () => {
+  it('F1: nulls externalTransactionId for EVERY money-movement / external-financial type', async () => {
+    // Each of these types carries a raw payment-processor / external reference in
+    // externalTransactionId (Purchase: Stripe/Paddle/PayPal/crypto; Refund: bare
+    // PayPal txn id; ChargeBack/Withdrawal: dispute / cash-out refs). None may
+    // reach the block iframe. The value used here stands in for the processor id.
+    const sensitiveTypes = [
+      TransactionType.Purchase,
+      TransactionType.Refund,
+      TransactionType.ChargeBack,
+      TransactionType.Withdrawal,
+    ];
+    for (const type of sensitiveTypes) {
+      mockGetTransactions.mockResolvedValueOnce({
+        cursor: null,
+        transactions: [{ ...sampleRow, type, externalTransactionId: 'processor-ref-xyz' }],
+      });
+      const { req, res } = createMocks();
+      await handler(req as never, res as never);
+      const body = res._json() as { transactions: Record<string, unknown>[] };
+      expect(body.transactions[0].externalTransactionId, `type ${TransactionType[type]}`).toBeNull();
+    }
+  });
+
+  it('F1: nulls externalTransactionId when it is a merch Shopify ref, even under type Reward', async () => {
+    // merch.service grants buzz as a Reward but stores the Shopify order id as
+    // `merchPurchase:<shopifyOrderId>` — a cross-type external-commerce ref that
+    // the value-prefix guard must strip even though Reward is otherwise kept.
     mockGetTransactions.mockResolvedValueOnce({
       cursor: null,
       transactions: [
-        {
-          ...sampleRow,
-          type: TransactionType.Reward,
-          externalTransactionId: 'challenge-winner-prize-2026-07',
-        },
+        { ...sampleRow, type: TransactionType.Reward, externalTransactionId: 'merchPurchase:SHOP-9981' },
       ],
     });
     const { req, res } = createMocks();
     await handler(req as never, res as never);
     const body = res._json() as { transactions: Record<string, unknown>[] };
-    expect(body.transactions[0].externalTransactionId).toBe('challenge-winner-prize-2026-07');
+    expect(body.transactions[0].externalTransactionId).toBeNull();
+  });
+
+  it('F1: KEEPS externalTransactionId for civitai-internal reward/prize classifiers the dashboard renders', async () => {
+    const keptClassifiers = [
+      { type: TransactionType.Reward, id: 'challenge-winner-prize-2026-07-place-1' },
+      { type: TransactionType.Reward, id: 'referral-reward:1234' },
+      { type: TransactionType.Reward, id: 'appBlockReview:ab_42' },
+      { type: TransactionType.Bounty, id: 'bounty-award-88-yellow' },
+      { type: TransactionType.Compensation, id: 'license-fee-2026-07-01-42-blue' },
+    ];
+    for (const { type, id } of keptClassifiers) {
+      mockGetTransactions.mockResolvedValueOnce({
+        cursor: null,
+        transactions: [{ ...sampleRow, type, externalTransactionId: id }],
+      });
+      const { req, res } = createMocks();
+      await handler(req as never, res as never);
+      const body = res._json() as { transactions: Record<string, unknown>[] };
+      expect(body.transactions[0].externalTransactionId, `type ${TransactionType[type]}`).toBe(id);
+    }
   });
 
   it('200: passes attribution fields through and projects counterparties to {id, username}', async () => {

--- a/src/tests/api/v1/blocks/scoped-endpoints-cors-wiring.test.ts
+++ b/src/tests/api/v1/blocks/scoped-endpoints-cors-wiring.test.ts
@@ -9,7 +9,7 @@ import { describe, it, expect, vi } from 'vitest';
  * `src/server/middleware/__tests__/block-scope.anytoken-mode.test.ts`. And the
  * two CATALOG endpoints are guarded by `catalog-cors-wiring.test.ts`.
  *
- * But those prove nothing about whether these six per-user endpoints actually
+ * But those prove nothing about whether these per-user endpoints actually
  * OPT IN. The endpoint-behavior tests (buzz-endpoint / tip-endpoint /
  * collections-endpoint / …) mock `withBlockScope` as a passthrough whose
  * `res.setHeader` is a no-op, so the real CORS layer never runs there — dropping
@@ -80,7 +80,12 @@ vi.mock('~/server/utils/block-tip-rate-limit', () => ({
   refundBlockTipSpend: vi.fn(),
   reserveBlockTipSpend: vi.fn(),
 }));
-vi.mock('~/server/services/buzz.service', () => ({ getUserBuzzAccount: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccount: vi.fn(),
+  getUserBuzzTransactions: vi.fn(),
+  getDailyCompensationRewardByUser: vi.fn(),
+}));
+vi.mock('~/server/utils/endpoint-helpers', () => ({ handleEndpointError: vi.fn() }));
 vi.mock('~/server/routers/apps-shared.router', () => ({
   assertValidCounterKey: vi.fn(),
   incrementSharedCounter: vi.fn(),
@@ -91,32 +96,48 @@ vi.mock('~/server/routers/apps-shared.router', () => ({
 // `captured` index; asserting the scope proves the CORS change didn't drop it.
 const ENDPOINTS: Array<{ module: string; requiredScope: string }> = [
   { module: '~/pages/api/v1/blocks/collections/index', requiredScope: 'collections:read:self' },
-  { module: '~/pages/api/v1/blocks/collections/[id]/index', requiredScope: 'collections:read:self' },
-  { module: '~/pages/api/v1/blocks/collections/[id]/follow', requiredScope: 'collections:write:self' },
+  {
+    module: '~/pages/api/v1/blocks/collections/[id]/index',
+    requiredScope: 'collections:read:self',
+  },
+  {
+    module: '~/pages/api/v1/blocks/collections/[id]/follow',
+    requiredScope: 'collections:write:self',
+  },
   { module: '~/pages/api/v1/blocks/tip', requiredScope: 'social:tip:self' },
   { module: '~/pages/api/v1/blocks/buzz', requiredScope: 'buzz:read:self' },
-  { module: '~/pages/api/v1/blocks/shared-storage/increment', requiredScope: 'apps:storage:shared:write' },
+  { module: '~/pages/api/v1/blocks/buzz/transactions', requiredScope: 'buzz:read:self' },
+  { module: '~/pages/api/v1/blocks/buzz/daily-compensation', requiredScope: 'buzz:read:self' },
+  { module: '~/pages/api/v1/blocks/buzz/accounts', requiredScope: 'buzz:read:self' },
+  {
+    module: '~/pages/api/v1/blocks/shared-storage/increment',
+    requiredScope: 'apps:storage:shared:write',
+  },
   { module: '~/pages/api/v1/blocks/shared-storage/top', requiredScope: 'apps:storage:shared:read' },
 ];
 
 describe('scoped block endpoints — opaque-origin CORS wiring', () => {
   // The `await import(...)` cold-transforms a Next API page graph each; give the
   // import-bound test a generous budget (mirrors catalog-cors-wiring.test.ts).
-  it('every collections/tip/buzz/shared-storage endpoint opts into allowOpaqueOrigin while keeping its requiredScope', { timeout: 60000 }, async () => {
-    for (const { module } of ENDPOINTS) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      await import(module);
+  it(
+    'every collections/tip/buzz/shared-storage endpoint opts into allowOpaqueOrigin while keeping its requiredScope',
+    { timeout: 60000 },
+    async () => {
+      for (const { module } of ENDPOINTS) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        await import(module);
+      }
+
+      expect(captured).toHaveLength(ENDPOINTS.length);
+
+      ENDPOINTS.forEach(({ requiredScope }, i) => {
+        const opts = captured[i];
+        // Must opt in — else an unverified (opaque-origin) block's direct fetch
+        // 405s on the CORS preflight again.
+        expect(opts.allowOpaqueOrigin).toBe(true);
+        // CORS-only change: the per-user authorization gate must be unchanged.
+        expect(opts.requiredScope).toBe(requiredScope);
+      });
     }
-
-    expect(captured).toHaveLength(ENDPOINTS.length);
-
-    ENDPOINTS.forEach(({ requiredScope }, i) => {
-      const opts = captured[i];
-      // Must opt in — else an unverified (opaque-origin) block's direct fetch
-      // 405s on the CORS preflight again.
-      expect(opts.allowOpaqueOrigin).toBe(true);
-      // CORS-only change: the per-user authorization gate must be unchanged.
-      expect(opts.requiredScope).toBe(requiredScope);
-    });
-  });
+  );
 });


### PR DESCRIPTION
**Supersedes #3132 by @daceheg.** Their endpoint design + the airtight self-binding are preserved as-is (this branch is based directly on their commit, which stays first in the history), and this PR only adds the two follow-ups from the security review on top.

## Audit outcome

Reviewed daceheg's three `/api/v1/blocks/buzz/*` self-read endpoints. No 🔴 findings:

- **IDOR / self-binding is airtight.** Every handler keys the account on `parseSubjectUserId(claims.sub)` (the verified token subject), never client input; anon tokens are rejected (403). There is no client-supplied userId path.
- **The endpoint-vs-bridge choice is correct.** Unlike the wildcard-pack download (which had its own authorization system to re-derive + a decompression-bomb OOM surface), these are thin JSON reads over existing services with capped limits — the verified `sub` in the block token *is* the authorization, and `buzz:read:self` is the purpose-built consent surface. Nothing to move to the host bridge; endpoints also serve model-slot blocks the bridge can't.

Two MEDIUM follow-ups, both fixed here.

## Fixes

**F2 (required) — per-instance rate limit.** The three new endpoints had no rate limiter, unlike every sibling block read endpoint (`blocks/collections`, `blocks/models`, `blocks/images`). `daily-compensation` fans out to a Postgres `modelVersion.findMany` + a ClickHouse scan on every call — a directly hammerable cost surface on a `private, no-store` (Cloudflare-uncacheable) route. Added `checkBlockCatalogRateLimit(claims.blockInstanceId)` to **all three**, running BEFORE any db/service/ClickHouse work, returning the same 429 + `Retry-After` shape the siblings use.

**F1 (recommended) — allowlist the transactions `details` projection.** `buzzTransactionDetails` is a `.passthrough()` zod object, and Purchase rows store `details.stripePaymentIntentId` (see `buzz.service` `completeStripeBuzzPurchase`). daceheg's row projection spread the full `details` object, so the block iframe would receive the user's Stripe payment-intent reference — an allow-by-default leak inconsistent with the deny-by-default `{ id, username }` counterparty projection beside it. Replaced the spread with an explicit allowlist of the entity-attribution fields the dashboard renders — **kept** `user`, `entityId`, `entityType`, `url`, `toAccountType`; **dropped** `stripePaymentIntentId` and every other passthrough key. (`externalTransactionId` is a sibling top-level field, not in `details` — kept as daceheg intended, since it's the only way to classify challenge prizes.)

## Tests

All 26 of daceheg's tests + the cors-wiring drift guard stay green. Added 7:
- Rate limit: 429 + `Retry-After` when the limiter trips (service not called), and an ordering assertion that the limiter runs BEFORE the service, on all three endpoints.
- Details allowlist: a transactions row whose `details` carries `stripePaymentIntentId` + an unknown passthrough key → response row drops both, keeps the attribution fields. Pins F1 against regression.

`npx vitest run` on the touched suites: **298 passed** across the full `blocks/` dir (28 in the 4 buzz+cors files). Scoped `tsc --noEmit` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
