### PR TITLE
feat(app-blocks): generationSource mode for block image-upload bridge

### DIFF
--- a/src/components/AppBlocks/BlockGenerationSourceUploadModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockGenerationSourceUploadModal.browser.test.tsx
@@ -19,6 +19,8 @@ import { renderWithProviders } from '../../../test/component-setup';
 const mocks = vi.hoisted(() => ({
   uploadConsumerBlob: vi.fn(),
   getImageDimensions: vi.fn(),
+  resizeImage: vi.fn(),
+  imageToJpegBlob: vi.fn(),
   persistMutate: vi.fn(),
   gateMutate: vi.fn(),
 }));
@@ -31,6 +33,20 @@ vi.mock('~/utils/image-utils', async (orig) => {
   const actual = await orig<typeof import('~/utils/image-utils')>();
   return { ...actual, getImageDimensions: mocks.getImageDimensions };
 });
+
+// The generator's client-side resize/re-encode helpers. Mocked here as SPIES so
+// we can assert the modal downscales to the SCHEMA bound (DIM_MAX) before upload
+// — the actual canvas pixel-clamp is canvas-utils' own well-tested contract
+// (calculateAspectRatioFit). They're also mocked out of necessity: their real
+// path (imageToJpegBlob → canvasToBlobWithImageExif) uses `Buffer`, which Next
+// polyfills in the browser bundle (the shipped generator relies on exactly this)
+// but the vitest browser env does not provide. So the real pixel path is
+// exercised in production via SourceImageUpload; here we lock the ORCHESTRATION
+// (which bounds, in which order).
+vi.mock('~/shared/utils/canvas-utils', () => ({
+  resizeImage: mocks.resizeImage,
+  imageToJpegBlob: mocks.imageToJpegBlob,
+}));
 
 // The moderated scan/gate service. This modal must NEVER call it — the spies
 // stay untouched on the generationSource branch (the orchestrator scans the
@@ -51,17 +67,15 @@ import BlockGenerationSourceUploadModal from '~/components/AppBlocks/BlockGenera
 import { DialogProvider } from '~/components/Dialog/DialogProvider';
 // eslint-disable-next-line import/first
 import { dialogStore, useDialogStore } from '~/components/Dialog/dialogStore';
+// eslint-disable-next-line import/first
+import { DIM_MAX, DIM_MIN } from '~/server/schema/blocks/workflow.schema';
 
 const BLOB_URL =
   'https://orchestration.civitai.com/v2/consumer/blobs/ABC123.jpeg?sig=x&exp=2030-01-01T00:00:00Z';
 
-/** A REAL png File (canvas → toBlob); uploadConsumerBlob is mocked so bytes are inert. */
-async function makeImageFile(name = 'source.png'): Promise<File> {
-  const canvas = document.createElement('canvas');
-  canvas.width = 4;
-  canvas.height = 4;
-  const blob: Blob = await new Promise((res) => canvas.toBlob((b) => res(b!), 'image/png'));
-  return new File([blob], name, { type: 'image/png' });
+/** A minimal image File. The resize/encode helpers are mocked, so bytes are inert. */
+function makeImageFile(name = 'source.png', type = 'image/png'): File {
+  return new File([new Uint8Array([1, 2, 3, 4])], name, { type });
 }
 
 /** The hidden native <input type=file> Mantine's FileInput renders. */
@@ -82,6 +96,11 @@ function openModal(onResolved: (r: unknown) => void) {
   });
 }
 
+// Sentinel blobs threaded through the mocked resize → encode → upload pipeline so
+// each stage's output can be asserted as the next stage's input.
+const RESIZED_BLOB = new Blob(['resized-png'], { type: 'image/png' });
+const JPEG_BLOB = new Blob(['jpeg-bytes'], { type: 'image/jpeg' });
+
 describe('BlockGenerationSourceUploadModal (generationSource — unscanned source)', () => {
   beforeEach(() => {
     useDialogStore.getState().closeAll();
@@ -89,24 +108,31 @@ describe('BlockGenerationSourceUploadModal (generationSource — unscanned sourc
     mocks.getImageDimensions.mockReset();
     mocks.persistMutate.mockReset();
     mocks.gateMutate.mockReset();
+    // Happy-path resize/encode by default (individual tests assert the args).
+    mocks.resizeImage.mockReset().mockResolvedValue(RESIZED_BLOB);
+    mocks.imageToJpegBlob.mockReset().mockResolvedValue(JPEG_BLOB);
   });
 
-  test('uploads via uploadConsumerBlob and resolves { url, width, height } — no createImage/scan/gate', async () => {
+  test('resizes+re-encodes then uploads via uploadConsumerBlob, resolving { url, width, height } — no createImage/scan/gate', async () => {
     mocks.uploadConsumerBlob.mockResolvedValue({ url: BLOB_URL });
     mocks.getImageDimensions.mockResolvedValue({ width: 640, height: 480 });
     const onResolved = vi.fn();
 
     openModal(onResolved);
-    await userEvent.upload(await fileInputEl(), await makeImageFile());
+    await userEvent.upload(await fileInputEl(), makeImageFile());
 
     await vi.waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
     // Exactly the source projection — no imageId / nsfwLevel / contentRating.
     expect(onResolved).toHaveBeenCalledWith({ url: BLOB_URL, width: 640, height: 480 });
     expect(Object.keys(onResolved.mock.calls[0][0]).sort()).toEqual(['height', 'url', 'width']);
 
-    // Reused the generator's consumer-blob util with the real File.
+    // Pipeline mirrors SourceImageUpload: resizeImage → imageToJpegBlob →
+    // uploadConsumerBlob (the RE-ENCODED jpeg blob, not the raw File).
+    expect(mocks.resizeImage).toHaveBeenCalledTimes(1);
+    expect(mocks.imageToJpegBlob).toHaveBeenCalledTimes(1);
+    expect(mocks.imageToJpegBlob).toHaveBeenCalledWith(RESIZED_BLOB);
     expect(mocks.uploadConsumerBlob).toHaveBeenCalledTimes(1);
-    expect(mocks.uploadConsumerBlob.mock.calls[0][0]).toBeInstanceOf(File);
+    expect(mocks.uploadConsumerBlob).toHaveBeenCalledWith(JPEG_BLOB);
     // Real dims derived from the uploaded blob URL (mirrors SourceImageUpload).
     expect(mocks.getImageDimensions).toHaveBeenCalledWith(BLOB_URL);
 
@@ -120,9 +146,62 @@ describe('BlockGenerationSourceUploadModal (generationSource — unscanned sourc
     const onResolved = vi.fn();
 
     openModal(onResolved);
-    await userEvent.upload(await fileInputEl(), await makeImageFile());
+    await userEvent.upload(await fileInputEl(), makeImageFile());
 
     await expect.element(page.getByText(/Failed to upload blob/i)).toBeInTheDocument();
+    expect(onResolved).not.toHaveBeenCalled();
+    expect(mocks.persistMutate).not.toHaveBeenCalled();
+    expect(mocks.gateMutate).not.toHaveBeenCalled();
+  });
+
+  test('downscales to the blockSourceImageSchema bound (DIM_MAX, not the generator maxUpscaleSize) so a large image passes submit', async () => {
+    mocks.uploadConsumerBlob.mockResolvedValue({ url: BLOB_URL });
+    // The uploaded (resized) blob's dims are read here; set to the schema bound so
+    // the resolved source is within DIM_MIN..DIM_MAX (would pass blockSourceImageSchema).
+    mocks.getImageDimensions.mockResolvedValue({ width: DIM_MAX, height: 1365 });
+    const onResolved = vi.fn();
+
+    openModal(onResolved);
+    await userEvent.upload(await fileInputEl(), makeImageFile('big.png'));
+
+    await vi.waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+
+    // THE FIX: the modal caps the pre-upload resize at the sourceImage schema
+    // bound (DIM_MAX = 2048), NOT the generator's larger maxUpscaleSize (3840).
+    // resizeImage's contract (calculateAspectRatioFit) then guarantees every side
+    // ≤ maxWidth/maxHeight, so the uploaded source always lands within
+    // DIM_MIN..DIM_MAX and is accepted at workflow submit instead of clamped-rejected.
+    expect(mocks.resizeImage).toHaveBeenCalledTimes(1);
+    const [srcArg, optsArg] = mocks.resizeImage.mock.calls[0];
+    expect(srcArg).toBeInstanceOf(File);
+    expect(optsArg).toEqual({
+      maxWidth: DIM_MAX,
+      maxHeight: DIM_MAX,
+      minWidth: DIM_MIN,
+      minHeight: DIM_MIN,
+    });
+    expect(optsArg.maxWidth).toBe(2048);
+
+    // The resolved dims are within the schema bounds.
+    const resolved = onResolved.mock.calls[0][0] as { width: number; height: number };
+    expect(Math.max(resolved.width, resolved.height)).toBeLessThanOrEqual(DIM_MAX);
+    expect(Math.min(resolved.width, resolved.height)).toBeGreaterThanOrEqual(DIM_MIN);
+
+    expect(mocks.persistMutate).not.toHaveBeenCalled();
+    expect(mocks.gateMutate).not.toHaveBeenCalled();
+  });
+
+  test('a VIDEO file is rejected with a clear message and never resized or uploaded', async () => {
+    const onResolved = vi.fn();
+    openModal(onResolved);
+
+    // uploadConsumerBlob would accept video/mp4, but a video can't be an img2img
+    // source — the modal must reject it before touching the resize/upload path.
+    await userEvent.upload(await fileInputEl(), makeImageFile('clip.mp4', 'video/mp4'));
+
+    await expect.element(page.getByText(/choose an image file/i)).toBeInTheDocument();
+    expect(mocks.resizeImage).not.toHaveBeenCalled();
+    expect(mocks.uploadConsumerBlob).not.toHaveBeenCalled();
     expect(onResolved).not.toHaveBeenCalled();
     expect(mocks.persistMutate).not.toHaveBeenCalled();
     expect(mocks.gateMutate).not.toHaveBeenCalled();

--- a/src/components/AppBlocks/BlockGenerationSourceUploadModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockGenerationSourceUploadModal.browser.test.tsx
@@ -1,0 +1,130 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * BlockGenerationSourceUploadModal — the UNSCANNED `generationSource` upload path.
+ *
+ * Proves that a `generationSource` block image upload:
+ *   1. uploads through the SAME consumer-blob util the generator uses
+ *      (`uploadConsumerBlob`) — never `createImage`;
+ *   2. resolves ONLY the source shape { url, width, height } (real dims from the
+ *      blob via `getImageDimensions`);
+ *   3. NEVER touches the moderated scan/gate service (blockImageUpload.persist /
+ *      gate) — those trpc mutations are mocked with spies and asserted untouched,
+ *      a regression guard even though this modal doesn't import them today.
+ */
+
+const mocks = vi.hoisted(() => ({
+  uploadConsumerBlob: vi.fn(),
+  getImageDimensions: vi.fn(),
+  persistMutate: vi.fn(),
+  gateMutate: vi.fn(),
+}));
+
+vi.mock('~/utils/consumer-blob-upload', () => ({
+  uploadConsumerBlob: mocks.uploadConsumerBlob,
+}));
+
+vi.mock('~/utils/image-utils', async (orig) => {
+  const actual = await orig<typeof import('~/utils/image-utils')>();
+  return { ...actual, getImageDimensions: mocks.getImageDimensions };
+});
+
+// The moderated scan/gate service. This modal must NEVER call it — the spies
+// stay untouched on the generationSource branch (the orchestrator scans the
+// OUTPUT). Mocking a module the modal doesn't import is harmless, and it turns
+// "someone later wires a scan into this path" into a red test.
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    blockImageUpload: {
+      persist: { useMutation: () => ({ mutateAsync: mocks.persistMutate }) },
+      gate: { useMutation: () => ({ mutateAsync: mocks.gateMutate }) },
+    },
+  },
+}));
+
+// eslint-disable-next-line import/first
+import BlockGenerationSourceUploadModal from '~/components/AppBlocks/BlockGenerationSourceUploadModal';
+// eslint-disable-next-line import/first
+import { DialogProvider } from '~/components/Dialog/DialogProvider';
+// eslint-disable-next-line import/first
+import { dialogStore, useDialogStore } from '~/components/Dialog/dialogStore';
+
+const BLOB_URL =
+  'https://orchestration.civitai.com/v2/consumer/blobs/ABC123.jpeg?sig=x&exp=2030-01-01T00:00:00Z';
+
+/** A REAL png File (canvas → toBlob); uploadConsumerBlob is mocked so bytes are inert. */
+async function makeImageFile(name = 'source.png'): Promise<File> {
+  const canvas = document.createElement('canvas');
+  canvas.width = 4;
+  canvas.height = 4;
+  const blob: Blob = await new Promise((res) => canvas.toBlob((b) => res(b!), 'image/png'));
+  return new File([blob], name, { type: 'image/png' });
+}
+
+/** The hidden native <input type=file> Mantine's FileInput renders. */
+function fileInputEl(): Promise<HTMLInputElement> {
+  return vi.waitFor(() => {
+    const el = document.querySelector<HTMLInputElement>('input[type="file"]:not([multiple])');
+    if (!el) throw new Error('file input not found');
+    return el;
+  });
+}
+
+function openModal(onResolved: (r: unknown) => void) {
+  renderWithProviders(<DialogProvider />);
+  dialogStore.trigger({
+    id: 'gen-source-test',
+    component: BlockGenerationSourceUploadModal,
+    props: { onResolved },
+  });
+}
+
+describe('BlockGenerationSourceUploadModal (generationSource — unscanned source)', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+    mocks.uploadConsumerBlob.mockReset();
+    mocks.getImageDimensions.mockReset();
+    mocks.persistMutate.mockReset();
+    mocks.gateMutate.mockReset();
+  });
+
+  test('uploads via uploadConsumerBlob and resolves { url, width, height } — no createImage/scan/gate', async () => {
+    mocks.uploadConsumerBlob.mockResolvedValue({ url: BLOB_URL });
+    mocks.getImageDimensions.mockResolvedValue({ width: 640, height: 480 });
+    const onResolved = vi.fn();
+
+    openModal(onResolved);
+    await userEvent.upload(await fileInputEl(), await makeImageFile());
+
+    await vi.waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
+    // Exactly the source projection — no imageId / nsfwLevel / contentRating.
+    expect(onResolved).toHaveBeenCalledWith({ url: BLOB_URL, width: 640, height: 480 });
+    expect(Object.keys(onResolved.mock.calls[0][0]).sort()).toEqual(['height', 'url', 'width']);
+
+    // Reused the generator's consumer-blob util with the real File.
+    expect(mocks.uploadConsumerBlob).toHaveBeenCalledTimes(1);
+    expect(mocks.uploadConsumerBlob.mock.calls[0][0]).toBeInstanceOf(File);
+    // Real dims derived from the uploaded blob URL (mirrors SourceImageUpload).
+    expect(mocks.getImageDimensions).toHaveBeenCalledWith(BLOB_URL);
+
+    // The moderated scan/gate service is NEVER reached on this branch.
+    expect(mocks.persistMutate).not.toHaveBeenCalled();
+    expect(mocks.gateMutate).not.toHaveBeenCalled();
+  });
+
+  test('an upload failure surfaces an error and does NOT resolve (no partial source)', async () => {
+    mocks.uploadConsumerBlob.mockRejectedValue(new Error('Failed to upload blob: 500'));
+    const onResolved = vi.fn();
+
+    openModal(onResolved);
+    await userEvent.upload(await fileInputEl(), await makeImageFile());
+
+    await expect.element(page.getByText(/Failed to upload blob/i)).toBeInTheDocument();
+    expect(onResolved).not.toHaveBeenCalled();
+    expect(mocks.persistMutate).not.toHaveBeenCalled();
+    expect(mocks.gateMutate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/AppBlocks/BlockGenerationSourceUploadModal.tsx
+++ b/src/components/AppBlocks/BlockGenerationSourceUploadModal.tsx
@@ -4,6 +4,8 @@ import { useEffect, useRef, useState } from 'react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { uploadConsumerBlob } from '~/utils/consumer-blob-upload';
 import { getImageDimensions } from '~/utils/image-utils';
+import { imageToJpegBlob, resizeImage } from '~/shared/utils/canvas-utils';
+import { DIM_MAX, DIM_MIN } from '~/server/schema/blocks/workflow.schema';
 
 /**
  * App Blocks — the host modal behind PageBlockHost's `OPEN_IMAGE_UPLOAD` bridge
@@ -58,15 +60,42 @@ export default function BlockGenerationSourceUploadModal({
     const localPreview = URL.createObjectURL(file);
     objectUrlRef.current = localPreview;
     setPreviewUrl(localPreview);
-    setStatus('uploading');
     setMessage(null);
+
+    // Images only — matches the FileInput `accept` and the img2img source
+    // contract. uploadConsumerBlob would also accept video/mp4|webm, but a video
+    // can't be an img2img source (getImageDimensions would fail downstream), so
+    // reject it here with a clear message instead of a confusing error later.
+    if (!file.type.startsWith('image/')) {
+      setStatus('error');
+      setMessage('Please choose an image file (PNG, JPEG or WebP).');
+      return;
+    }
+
+    setStatus('uploading');
     try {
-      // The SAME util the generator's SourceImageUpload uses: a presigned PUT to
-      // the orchestrator consumer-blob store. NO createImage, NO scan, NO gate.
-      const blob = await uploadConsumerBlob(file);
+      // Mirror the generator's SourceImageUpload pre-upload step (handleDropCapture):
+      // downscale to fit the block source-image max dimension + re-encode to JPEG
+      // BEFORE upload, reusing the SAME resizeImage + imageToJpegBlob helpers.
+      // Capped at DIM_MAX (the sourceImage schema bound, NOT the generator's larger
+      // maxUpscaleSize) so a large-but-valid photo is downscaled to WITHIN the
+      // blockSourceImageSchema DIM bounds and works — instead of uploading fine
+      // then being rejected at workflow submit (the server clamps width/height to
+      // DIM_MIN..DIM_MAX). A too-small image throws a clear minimum-size error here.
+      const resized = await resizeImage(file, {
+        maxWidth: DIM_MAX,
+        maxHeight: DIM_MAX,
+        minWidth: DIM_MIN,
+        minHeight: DIM_MIN,
+      });
+      const jpegBlob = await imageToJpegBlob(resized);
+      // The SAME util the generator uses: a presigned PUT to the orchestrator
+      // consumer-blob store (it enforces its own 64MB cap on the uploaded blob).
+      // NO createImage, NO scan, NO gate.
+      const blob = await uploadConsumerBlob(jpegBlob);
       if (epoch !== epochRef.current) return;
       if (!blob.url) throw new Error('Upload did not return a URL');
-      // Real dimensions from the uploaded blob (mirrors SourceImageUpload).
+      // Real dimensions from the uploaded (resized) blob (mirrors SourceImageUpload).
       const { width, height } = await getImageDimensions(blob.url);
       if (epoch !== epochRef.current) return;
       setStatus('ready');

--- a/src/components/AppBlocks/BlockGenerationSourceUploadModal.tsx
+++ b/src/components/AppBlocks/BlockGenerationSourceUploadModal.tsx
@@ -1,0 +1,165 @@
+import { Alert, Badge, Button, FileInput, Group, Image, Loader, Modal, Stack, Text } from '@mantine/core';
+import { IconAlertTriangle, IconBolt, IconCheck, IconUpload } from '@tabler/icons-react';
+import { useEffect, useRef, useState } from 'react';
+import { useDialogContext } from '~/components/Dialog/DialogProvider';
+import { uploadConsumerBlob } from '~/utils/consumer-blob-upload';
+import { getImageDimensions } from '~/utils/image-utils';
+
+/**
+ * App Blocks — the host modal behind PageBlockHost's `OPEN_IMAGE_UPLOAD` bridge
+ * when a block requests `purpose: 'generationSource'`. Unlike the moderated
+ * `display` path (BlockImageUploadModal), this uploads a PRIVATE generation
+ * INPUT (an img2img source image), NOT a publicly-displayed image.
+ *
+ * It therefore reuses the SAME lightweight consumer-blob util civitai's own
+ * generator uses for a source image (`uploadConsumerBlob`, see
+ * `SourceImageUpload`): a presigned PUT to the orchestrator's consumer-blob
+ * store. There is deliberately NO `createImage` / `ingestImage`, NO public-image
+ * scan, NO SFW ceiling / flag gate, and NO `imageId` / `nsfwLevel` — the result
+ * is only `{ url, width, height }`. Platform safety is preserved because the
+ * ORCHESTRATOR auto-scans the generation OUTPUT, exactly as it does for the
+ * generator's own img2img sources.
+ *
+ * The blob resolves to an `https://orchestration…civitai.com` URL whose hostname
+ * ends in `.civitai.com`, so the returned url passes the img2img
+ * `blockSourceImageSchema` host allowlist (workflow.schema) unchanged — no
+ * loosening of that allowlist is required.
+ */
+
+export type BlockSourceImageInfo = { url: string; width: number; height: number };
+
+type UploadStatus = 'idle' | 'uploading' | 'ready' | 'error';
+
+export default function BlockGenerationSourceUploadModal({
+  onResolved,
+}: {
+  /** Called ONCE with the source projection when the consumer blob lands. */
+  onResolved: (result: BlockSourceImageInfo) => void;
+}) {
+  const dialog = useDialogContext();
+  const [status, setStatus] = useState<UploadStatus>('idle');
+  const [message, setMessage] = useState<string | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  // Guard against a resolved upload landing after the modal unmounts / a new
+  // upload supersedes it (epoch bump) — and clean up the object-URL preview.
+  const epochRef = useRef(0);
+  const objectUrlRef = useRef<string | null>(null);
+  useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    };
+  }, []);
+
+  async function handleFile(file: File | null) {
+    if (!file) return;
+    const epoch = ++epochRef.current;
+    if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    const localPreview = URL.createObjectURL(file);
+    objectUrlRef.current = localPreview;
+    setPreviewUrl(localPreview);
+    setStatus('uploading');
+    setMessage(null);
+    try {
+      // The SAME util the generator's SourceImageUpload uses: a presigned PUT to
+      // the orchestrator consumer-blob store. NO createImage, NO scan, NO gate.
+      const blob = await uploadConsumerBlob(file);
+      if (epoch !== epochRef.current) return;
+      if (!blob.url) throw new Error('Upload did not return a URL');
+      // Real dimensions from the uploaded blob (mirrors SourceImageUpload).
+      const { width, height } = await getImageDimensions(blob.url);
+      if (epoch !== epochRef.current) return;
+      setStatus('ready');
+      setMessage(null);
+      onResolved({ url: blob.url, width, height });
+      dialog.onClose();
+    } catch (err) {
+      if (epoch !== epochRef.current) return;
+      setStatus('error');
+      setMessage((err as Error).message);
+    }
+  }
+
+  const busy = status === 'uploading';
+
+  return (
+    <Modal {...dialog} withCloseButton title="Upload a source image">
+      <Stack gap="md">
+        <Alert color="blue" variant="light" icon={<IconBolt size={16} />}>
+          <Text size="sm">
+            This image is a <strong>private generation input</strong> — it isn&apos;t published.
+            Upload a PNG, JPEG or WebP.
+          </Text>
+        </Alert>
+
+        {previewUrl && (
+          <Image
+            src={previewUrl}
+            radius="sm"
+            fit="contain"
+            mah={220}
+            alt="source image preview"
+            data-testid="block-generation-source-preview"
+          />
+        )}
+
+        <Group gap={8}>
+          <StatusBadge status={status} />
+        </Group>
+
+        <FileInput
+          label="Source image"
+          placeholder="Select an image"
+          accept="image/png,image/jpeg,image/webp"
+          clearable
+          disabled={busy}
+          leftSection={<IconUpload size={16} />}
+          value={null}
+          onChange={(f: File | null) => void handleFile(f)}
+          data-testid="block-generation-source-file-input"
+        />
+
+        {message && (
+          <Text size="xs" c={status === 'error' ? 'red' : 'dimmed'}>
+            {message}
+          </Text>
+        )}
+
+        <Group justify="flex-end" gap="xs">
+          <Button size="xs" variant="default" onClick={dialog.onClose} disabled={busy}>
+            Cancel
+          </Button>
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}
+
+function StatusBadge({ status }: { status: UploadStatus }) {
+  switch (status) {
+    case 'uploading':
+      return (
+        <Badge size="xs" color="blue" leftSection={<Loader size={10} color="blue" />}>
+          uploading…
+        </Badge>
+      );
+    case 'ready':
+      return (
+        <Badge size="xs" color="green" leftSection={<IconCheck size={10} />}>
+          ready
+        </Badge>
+      );
+    case 'error':
+      return (
+        <Badge size="xs" color="red" leftSection={<IconAlertTriangle size={10} />}>
+          error
+        </Badge>
+      );
+    default:
+      return (
+        <Text size="xs" c="dimmed">
+          no image selected
+        </Text>
+      );
+  }
+}

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -17,6 +17,7 @@ import {
 } from './pageBlockHostLogic';
 import { projectSafeGenerationResource } from '~/server/schema/blocks/generation-resource-projection';
 import type { BlockUploadedImageInfo } from './BlockImageUploadModal';
+import type { BlockSourceImageInfo } from './BlockGenerationSourceUploadModal';
 import { projectBlockInitMaturity } from './projectBlockInit';
 import { sendBlockRender } from './sendBlockRender';
 import {
@@ -55,6 +56,16 @@ const BuyBuzzModal = dynamic(() => import('~/components/Modals/BuyBuzzModal'));
 const BlockImageUploadModal = dynamic(() => import('./BlockImageUploadModal'), {
   ssr: false,
 });
+
+// Sibling of BlockImageUploadModal for the OPEN_IMAGE_UPLOAD bridge's
+// `purpose: 'generationSource'` mode: an UNSCANNED private generation input (an
+// img2img source), uploaded through the SAME consumer-blob util the generator
+// uses (uploadConsumerBlob) — no createImage/scan/gate. The orchestrator scans
+// the generation OUTPUT. Returns only { url, width, height }.
+const BlockGenerationSourceUploadModal = dynamic(
+  () => import('./BlockGenerationSourceUploadModal'),
+  { ssr: false }
+);
 
 // Login flow for anonymous-conversion (REQUEST_SIGN_IN). The page route renders
 // for logged-out viewers (the BLOCK_INIT context is viewer-scoped, viewer:null),
@@ -1405,51 +1416,94 @@ export function PageBlockHost({
   // ── OPEN_IMAGE_UPLOAD → IMAGE_UPLOAD_RESULT (host-mediated block image upload) ─
   //
   // A block asks the host to let the viewer upload an image (the app decides what
-  // it is for — avatar / cover / background / reference / …). Mirrors
-  // OPEN_RESOURCE_PICKER's host-chrome pattern: the host opens its OWN upload modal,
-  // the iframe never handles the bytes. The upload routes through civitai's
-  // SESSION-AUTHED path → REAL createImage + ingestImage scan → server-side gate
-  // (blockImageUpload.persist + gate), and ONLY a moderated image id that is
-  // scanned-clean, within the SFW ceiling, and unflagged is returned — a publicly-
-  // displayed image is NOT trust-stamped (no createStoredImage).
+  // it is for). Mirrors OPEN_RESOURCE_PICKER's host-chrome pattern: the host opens
+  // its OWN upload modal, the iframe never handles the bytes. The request's
+  // optional `purpose` (normalized by resolveImageUploadRequest — absent ⇒
+  // 'display', so this stays byte-compatible with an SDK that sends none) selects
+  // the mode:
+  //
+  //   • 'display' (DEFAULT — PUBLIC image, e.g. a cosmetic background): the upload
+  //     routes through civitai's SESSION-AUTHED path → REAL createImage +
+  //     ingestImage scan → server-side gate (blockImageUpload.persist + gate), and
+  //     ONLY a moderated image id that is scanned-clean, within the SFW ceiling,
+  //     and unflagged is returned. UNCHANGED behavior.
+  //
+  //   • 'generationSource' (PRIVATE generation input — an img2img source): the
+  //     upload routes through the SAME lightweight consumer-blob util the generator
+  //     uses (uploadConsumerBlob, in BlockGenerationSourceUploadModal) — NO
+  //     createImage, NO scan, NO SFW gate, NO imageId/nsfwLevel. It returns only
+  //     the source shape { url, width, height } (the blob's real dims). Platform
+  //     safety is preserved because the ORCHESTRATOR scans the generation OUTPUT,
+  //     exactly as civitai's own generator does for its img2img sources. The blob
+  //     url is an `orchestration…civitai.com` host that passes the img2img
+  //     blockSourceImageSchema allowlist (workflow.schema) unchanged.
   //
   // Gate on status 'ready' (a pre-handshake block can't summon the modal) via the
   // same 'error'→'no_token' shim the consent/buzz handlers use. requestId threads
   // the reply so concurrent uploads never cross. A successful upload posts the
-  // minimal projection; closing without one posts a bare (cancelled) result — the
-  // modal never leaks scan/ownership internals.
+  // minimal projection; closing without one posts a bare (cancelled) result.
   useEffect(() => {
-    const off = onMessage<{ requestId?: unknown } | undefined>('OPEN_IMAGE_UPLOAD', (raw) => {
-      const gateStatus = status === 'error' ? 'no_token' : status;
-      if (gateStatus !== 'ready') return; // pre-handshake block — drop
-      const req = resolveImageUploadRequest(raw);
-      if (!req) return; // missing / non-string requestId → drop, never open the modal
-      const { requestId } = req;
+    const off = onMessage<{ requestId?: unknown; purpose?: unknown } | undefined>(
+      'OPEN_IMAGE_UPLOAD',
+      (raw) => {
+        const gateStatus = status === 'error' ? 'no_token' : status;
+        if (gateStatus !== 'ready') return; // pre-handshake block — drop
+        const req = resolveImageUploadRequest(raw);
+        if (!req) return; // missing / non-string requestId → drop, never open the modal
+        const { requestId, purpose } = req;
 
-      let resolved: BlockUploadedImageInfo | null = null;
-      dialogStore.trigger({
-        // Per-request id so multiple OPEN_IMAGE_UPLOAD calls don't dedup against
-        // each other in the dialog store's exists-check.
-        id: `block-image-upload-${requestId}`,
-        component: BlockImageUploadModal,
-        props: {
-          onResolved: (result: BlockUploadedImageInfo) => {
-            resolved = result;
+        // generationSource: UNSCANNED private img2img source (orchestrator scans
+        // the OUTPUT). Reply carries the source shape { url, width, height }; the
+        // moderated 'display' branch below is untouched.
+        if (purpose === 'generationSource') {
+          let resolvedSource: BlockSourceImageInfo | null = null;
+          dialogStore.trigger({
+            id: `block-generation-source-upload-${requestId}`,
+            component: BlockGenerationSourceUploadModal,
+            props: {
+              onResolved: (result: BlockSourceImageInfo) => {
+                resolvedSource = result;
+              },
+            },
+            options: {
+              onClose: () => {
+                if (resolvedSource) {
+                  send('IMAGE_UPLOAD_RESULT', { requestId, selected: resolvedSource });
+                } else {
+                  send('IMAGE_UPLOAD_RESULT', { requestId });
+                }
+              },
+            },
+          });
+          return;
+        }
+
+        // display (default): moderated public-image path — UNCHANGED.
+        let resolved: BlockUploadedImageInfo | null = null;
+        dialogStore.trigger({
+          // Per-request id so multiple OPEN_IMAGE_UPLOAD calls don't dedup against
+          // each other in the dialog store's exists-check.
+          id: `block-image-upload-${requestId}`,
+          component: BlockImageUploadModal,
+          props: {
+            onResolved: (result: BlockUploadedImageInfo) => {
+              resolved = result;
+            },
           },
-        },
-        options: {
-          onClose: () => {
-            // A successful upload set `resolved` before the modal closed itself;
-            // otherwise the user cancelled → reply with a bare (cancelled) result.
-            if (resolved) {
-              send('IMAGE_UPLOAD_RESULT', { requestId, selected: resolved });
-            } else {
-              send('IMAGE_UPLOAD_RESULT', { requestId });
-            }
+          options: {
+            onClose: () => {
+              // A successful upload set `resolved` before the modal closed itself;
+              // otherwise the user cancelled → reply with a bare (cancelled) result.
+              if (resolved) {
+                send('IMAGE_UPLOAD_RESULT', { requestId, selected: resolved });
+              } else {
+                send('IMAGE_UPLOAD_RESULT', { requestId });
+              }
+            },
           },
-        },
-      });
-    });
+        });
+      }
+    );
     return off;
   }, [onMessage, send, status]);
 

--- a/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
@@ -1,0 +1,263 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { useDialogStore } from '~/components/Dialog/dialogStore';
+import type { BlockUploadedImageInfo } from '~/components/AppBlocks/BlockImageUploadModal';
+import type { BlockSourceImageInfo } from '~/components/AppBlocks/BlockGenerationSourceUploadModal';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * App Blocks PAGE image upload (OPEN_IMAGE_UPLOAD) — the host-handler BRANCH test.
+ *
+ * A full-page App Block posts OPEN_IMAGE_UPLOAD; the optional `purpose` selects
+ * which host modal opens and which reply shape comes back:
+ *   • 'display' (default / absent) → the MODERATED BlockImageUploadModal
+ *     (createImage + scan + SFW gate) → { imageId, nsfwLevel, contentRating, url }.
+ *   • 'generationSource' → the UNSCANNED BlockGenerationSourceUploadModal
+ *     (uploadConsumerBlob, NO createImage/scan/gate) → { url, width, height }.
+ *
+ * These tests mount the REAL PageBlockHost and drive the actual postMessage
+ * bridge. Following the OPEN_RESOURCE_PICKER test pattern, the dynamic-import
+ * modals aren't rendered here; we assert the host opened the CORRECT modal (by
+ * dialog id) and invoke its captured `onResolved` to simulate the user's upload,
+ * then assert the IMAGE_UPLOAD_RESULT reply shape. The correct-modal assertion is
+ * itself the proof that generationSource does NOT hit the moderated scan/gate
+ * path (it opens the consumer-blob modal, never BlockImageUploadModal), and that
+ * 'display' is unchanged. The modal-internal upload behavior (that
+ * generationSource uses uploadConsumerBlob and never calls blockImageUpload) is
+ * covered directly in BlockGenerationSourceUploadModal.browser.test.tsx.
+ */
+
+// Stub trpc so PageBlockHost mounts network-free (same shape as the resource-
+// picker test). The image-upload branch itself makes no tRPC call from the host —
+// the moderated path's persist/gate live INSIDE the (unrendered) modal.
+vi.mock('~/utils/trpc', () => ({
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+function listenForReply() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+function lastDialog() {
+  const dialogs = useDialogStore.getState().dialogs;
+  if (dialogs.length === 0) throw new Error('no modal opened');
+  return dialogs[dialogs.length - 1];
+}
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'my-page-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Gen App',
+  iframeSrc: SAME_ORIGIN_SRC,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'my-page-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['ai:write:budgeted'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 42, username: 'tester' },
+  theme: 'light' as const,
+};
+
+async function driveToReady() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+describe('PageBlockHost OPEN_IMAGE_UPLOAD (purpose branch)', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+  });
+
+  test("generationSource opens the UNSCANNED consumer-blob modal (NOT the moderated one) and replies { url, width, height }", async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_src', purpose: 'generationSource' });
+
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    // The generationSource branch opens the generation-source modal — proof it
+    // does NOT route to the moderated scan/gate modal.
+    expect(lastDialog().id).toBe('block-generation-source-upload-rq_src');
+    expect(lastDialog().id).not.toBe('block-image-upload-rq_src');
+
+    // Simulate a successful consumer-blob upload inside the modal.
+    const onResolved = (lastDialog().props as { onResolved: (r: BlockSourceImageInfo) => void })
+      .onResolved;
+    const source: BlockSourceImageInfo = {
+      url: 'https://orchestration.civitai.com/v2/consumer/blobs/ABC123.jpeg?sig=x&exp=2030-01-01T00:00:00Z',
+      width: 768,
+      height: 512,
+    };
+    onResolved(source);
+    // The modal closes itself after a successful upload → the dialog's
+    // options.onClose (where the host posts the reply) fires.
+    lastDialog().options?.onClose?.();
+
+    await vi.waitFor(() => {
+      const r = replies.last('IMAGE_UPLOAD_RESULT');
+      if (!r) throw new Error('no reply yet');
+      // EXACTLY the source projection — no imageId / nsfwLevel / contentRating.
+      expect(r.payload).toEqual({ requestId: 'rq_src', selected: source });
+    });
+    const sel = (replies.last('IMAGE_UPLOAD_RESULT')!.payload as { selected: Record<string, unknown> })
+      .selected;
+    expect(Object.keys(sel).sort()).toEqual(['height', 'url', 'width']);
+    for (const k of ['imageId', 'nsfwLevel', 'contentRating']) expect(sel).not.toHaveProperty(k);
+    replies.stop();
+  });
+
+  test("display (explicit) opens the MODERATED modal and replies the moderated projection (unchanged)", async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_disp', purpose: 'display' });
+
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    expect(lastDialog().id).toBe('block-image-upload-rq_disp');
+
+    const onResolved = (lastDialog().props as { onResolved: (r: BlockUploadedImageInfo) => void })
+      .onResolved;
+    const moderated: BlockUploadedImageInfo = {
+      imageId: 55,
+      nsfwLevel: 1,
+      contentRating: 'PG' as BlockUploadedImageInfo['contentRating'],
+      url: 'https://image.civitai.com/xG/55/original.jpeg',
+    };
+    onResolved(moderated);
+    lastDialog().options?.onClose?.();
+
+    await vi.waitFor(() => {
+      const r = replies.last('IMAGE_UPLOAD_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_disp', selected: moderated });
+    });
+    replies.stop();
+  });
+
+  test("an ABSENT purpose defaults to the moderated 'display' modal (SDK back-compat)", async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+
+    // Exactly what the current SDK sends today: a bare requestId, no purpose.
+    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_bare' });
+
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    expect(lastDialog().id).toBe('block-image-upload-rq_bare');
+  });
+
+  test('generationSource cancel (close without upload) posts a bare (cancelled) result', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_cancel', purpose: 'generationSource' });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+
+    // User dismisses without a successful upload — onResolved never called, so
+    // the dialog's options.onClose posts a bare (cancelled) result.
+    lastDialog().options?.onClose?.();
+
+    await vi.waitFor(() => {
+      const r = replies.last('IMAGE_UPLOAD_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_cancel' });
+    });
+    replies.stop();
+  });
+
+  test('a request with no requestId is dropped (no modal, no reply) regardless of purpose', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_IMAGE_UPLOAD', { purpose: 'generationSource' });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(replies.last('IMAGE_UPLOAD_RESULT')).toBeUndefined();
+    replies.stop();
+  });
+});

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -179,15 +179,39 @@ describe('resolveCheckpointPickerRequest (OPEN_CHECKPOINT_PICKER — dev:live↔
   });
 });
 
-describe('resolveImageUploadRequest (OPEN_IMAGE_UPLOAD — requestId drop rule)', () => {
-  it('accepts a valid string requestId', () => {
-    expect(resolveImageUploadRequest({ requestId: 'u1' })).toEqual({ requestId: 'u1' });
+describe('resolveImageUploadRequest (OPEN_IMAGE_UPLOAD — requestId drop rule + purpose)', () => {
+  it('accepts a valid string requestId and defaults purpose to display', () => {
+    expect(resolveImageUploadRequest({ requestId: 'u1' })).toEqual({
+      requestId: 'u1',
+      purpose: 'display',
+    });
   });
 
-  it('ignores extra fields (only requestId is threaded — the rest is server-gated)', () => {
+  it('ignores extra fields (only requestId + purpose are threaded — the rest is server-gated)', () => {
     expect(resolveImageUploadRequest({ requestId: 'u2', junk: 'x', imageId: 5 })).toEqual({
       requestId: 'u2',
+      purpose: 'display',
     });
+  });
+
+  it('threads purpose:generationSource when the block requests the unscanned source mode', () => {
+    expect(
+      resolveImageUploadRequest({ requestId: 'u_src', purpose: 'generationSource' })
+    ).toEqual({ requestId: 'u_src', purpose: 'generationSource' });
+  });
+
+  it('normalizes an absent purpose to display (SDK back-compat — current SDK sends none)', () => {
+    expect(resolveImageUploadRequest({ requestId: 'u_def' }).purpose).toBe('display');
+  });
+
+  it('normalizes an unknown / non-string purpose to the safe moderated default (display)', () => {
+    expect(resolveImageUploadRequest({ requestId: 'u_x', purpose: 'evil' }).purpose).toBe('display');
+    expect(resolveImageUploadRequest({ requestId: 'u_y', purpose: 42 }).purpose).toBe('display');
+    expect(resolveImageUploadRequest({ requestId: 'u_z', purpose: null }).purpose).toBe('display');
+    // Case-sensitive: only the exact literal opts into the unscanned path.
+    expect(resolveImageUploadRequest({ requestId: 'u_c', purpose: 'GenerationSource' }).purpose).toBe(
+      'display'
+    );
   });
 
   it('DROPS a request with a missing / empty / non-string requestId', () => {

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -126,30 +126,48 @@ export function resolveCheckpointPickerRequest(raw: unknown): CheckpointPickerRe
 // ── OPEN_IMAGE_UPLOAD (host-mediated block image-upload bridge) ──────────────
 //
 // A block asks the HOST to open its native upload modal so the viewer can upload
-// an image (the app decides what it is for). The iframe never handles the bytes:
-// they flow through civitai's session-authed upload → REAL scan → SFW/flag gate,
-// and only a moderated image id (never above the SFW ceiling, never flagged) comes
-// back via IMAGE_UPLOAD_RESULT. The only wire-validation is: require a string
-// requestId (drop otherwise, never open the modal) — everything security-relevant
-// (scan + SFW ceiling + flag rejection) is enforced server-side. Kept pure +
-// unit-tested for the same reason as resolveResourcePickerRequest (the drop rule
-// is the relevant part).
+// an image (the app decides what it is for). The iframe never handles the bytes.
+//
+// The optional `purpose` field selects the upload MODE:
+//   - 'display' (DEFAULT — absent/unrecognized falls back to this, so it stays
+//     byte-compatible with an SDK that sends no `purpose`): a PUBLIC image
+//     (cosmetic backgrounds, cover art, …). The bytes flow through civitai's
+//     session-authed upload → REAL scan → SFW/flag gate, and only a moderated
+//     image id (never above the SFW ceiling, never flagged) comes back via
+//     IMAGE_UPLOAD_RESULT. Everything security-relevant (scan + SFW ceiling +
+//     flag rejection) is enforced server-side.
+//   - 'generationSource': a PRIVATE generation INPUT (an img2img source image).
+//     It uploads via the SAME lightweight consumer-blob path civitai's own
+//     generator uses (uploadConsumerBlob) — NO createImage, NO scan, NO SFW
+//     gate — and returns only { url, width, height }. Platform safety is
+//     preserved because the ORCHESTRATOR scans the generation OUTPUT.
+//
+// The only wire-validation is: require a string requestId (drop otherwise, never
+// open the modal) and normalize `purpose` to the safe default when unknown. Kept
+// pure + unit-tested for the same reason as resolveResourcePickerRequest.
+
+export type BlockUploadPurpose = 'display' | 'generationSource';
 
 export type ImageUploadRequest = {
   requestId: string;
+  /** Normalized upload mode; 'display' when the SDK omits/sends an unknown value. */
+  purpose: BlockUploadPurpose;
 };
 
 /**
  * Validate a raw OPEN_IMAGE_UPLOAD payload from an untrusted iframe. Returns the
- * sanitized request, or `null` when it must be DROPPED (missing/non-string
- * requestId). The CALLER opens the native upload modal — this only decides whether
- * to. There is no other client-side gate: the scan + SFW ceiling live server-side.
+ * sanitized request (requestId + normalized purpose), or `null` when it must be
+ * DROPPED (missing/non-string requestId). The CALLER opens the native upload
+ * modal — this only decides whether to, and which mode. An absent or
+ * unrecognized `purpose` normalizes to the safe moderated default ('display').
  */
 export function resolveImageUploadRequest(raw: unknown): ImageUploadRequest | null {
   if (!raw || typeof raw !== 'object') return null;
   const obj = raw as Record<string, unknown>;
   if (typeof obj.requestId !== 'string' || obj.requestId.length === 0) return null;
-  return { requestId: obj.requestId };
+  const purpose: BlockUploadPurpose =
+    obj.purpose === 'generationSource' ? 'generationSource' : 'display';
+  return { requestId: obj.requestId, purpose };
 }
 
 export type PageFallbackReason = 'timeout' | 'token_error' | 'fatal_block_error';

--- a/src/server/schema/blocks/__tests__/workflow.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/workflow.schema.test.ts
@@ -164,3 +164,46 @@ describe('blockWorkflowBodySchema — sharedContentKey (G5)', () => {
     expect(() => blockWorkflowBodySchema.parse(baseBody({ sharedContentKey: 123 }))).toThrow();
   });
 });
+
+/**
+ * img2img sourceImage host allowlist (blockSourceImageSchema).
+ *
+ * The `generationSource` block-upload mode returns an orchestrator consumer-blob
+ * URL (`https://orchestration…civitai.com/v2/consumer/blobs/…`) — the SAME host
+ * the generator's own SourceImageUpload yields. This locks in that such a URL
+ * PASSES the existing allowlist unchanged (hostname ends in `.civitai.com`), so
+ * no loosening was required, while attacker-controlled / non-https / host-
+ * confusion URLs are still rejected.
+ */
+describe('blockWorkflowBodySchema — sourceImage host allowlist (generationSource reconciliation)', () => {
+  const withSource = (url: string) =>
+    blockWorkflowBodySchema.parse(baseBody({ sourceImage: { url, width: 512, height: 512 } }));
+
+  it('accepts the orchestrator consumer-blob URL that generationSource yields', () => {
+    // Representative of uploadConsumerBlob's result (see SourceImageUpload).
+    const parsed = withSource(
+      'https://orchestration.civitai.com/v2/consumer/blobs/CXJQSCS1TYZR1PX45C7QBVB8E0.jpeg?sig=abc&exp=2030-01-01T00:00:00Z'
+    );
+    expect((parsed as { sourceImage?: { url: string } }).sourceImage?.url).toContain(
+      'orchestration.civitai.com'
+    );
+  });
+
+  it('accepts the orchestration-new subdomain variant (hostname still ends in .civitai.com)', () => {
+    expect(() =>
+      withSource('https://orchestration-new.civitai.com/v2/consumer/blobs/E8S6FBPH50ENNVF2PD5.jpeg')
+    ).not.toThrow();
+  });
+
+  it('REJECTS a host-confusion URL that merely contains the allowed host as a substring', () => {
+    expect(() =>
+      withSource('https://evil.example/?x=orchestration.civitai.com/blob.jpeg')
+    ).toThrow();
+  });
+
+  it('REJECTS a non-https orchestrator URL', () => {
+    expect(() =>
+      withSource('http://orchestration.civitai.com/v2/consumer/blobs/abc.jpeg')
+    ).toThrow();
+  });
+});

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -28,8 +28,12 @@ const blockAccountTypeSchema = z.enum(buzzSpendTypes as [BuzzSpendType, ...BuzzS
 
 const PROMPT_MAX = 1500;
 const NEG_PROMPT_MAX = 1500;
-const DIM_MIN = 64;
-const DIM_MAX = 2048;
+// Exported so the client-side generationSource upload modal
+// (BlockGenerationSourceUploadModal) can downscale a chosen image to fit the
+// SAME bounds the sourceImage schema enforces BEFORE upload — a single source of
+// truth, so the client resize target can never drift from the server clamp.
+export const DIM_MIN = 64;
+export const DIM_MAX = 2048;
 const STEPS_MAX = 50;
 const QUANTITY_MAX = 4;
 const CLIP_SKIP_MAX = 12;


### PR DESCRIPTION
## What

Adds an optional **`purpose`** to the App Blocks `OPEN_IMAGE_UPLOAD` host bridge so a block can upload an **img2img SOURCE image** without the moderated public-image scan+gate — because the orchestrator scans the generation **output** (platform-side safety), exactly like civitai's own generator does for img2img sources. The existing moderated path for PUBLIC images (cosmetic backgrounds) is unchanged.

## The `purpose` contract

`OPEN_IMAGE_UPLOAD` request gains an optional `purpose`, read by the host (`resolveImageUploadRequest`) and **normalized**:

| `purpose` | Behavior | `IMAGE_UPLOAD_RESULT.selected` shape |
|---|---|---|
| `'display'` (default; **absent/unknown → this**) | UNCHANGED moderated public-image path (`createImage` + `ingestImage` scan → gate: scanned-clean + SFW ceiling + unflagged) | `{ imageId, nsfwLevel, contentRating, url }` |
| `'generationSource'` | UNSCANNED private generation input — uploads via the **same `uploadConsumerBlob`** util the generator uses; **no** createImage / scan / SFW-gate / imageId | `{ url, width, height }` |

Because absent/unrecognized normalizes to `'display'`, this is **backward-compatible** with the current SDK (which sends no `purpose`).

## How the generator util is reused

New `BlockGenerationSourceUploadModal` mirrors the generator's `SourceImageUpload` source-upload sequence: `uploadConsumerBlob(file)` (presigned PUT to the orchestrator consumer-blob store) → `getImageDimensions(blob.url)` for real dims → resolves `{ url, width, height }`. No `createImage`, no `ingestImage`, no `blockImageUpload.persist`/`gate`. The host `OPEN_IMAGE_UPLOAD` handler branches on `purpose`; the `'display'` branch (its `dialogStore.trigger` + reply logic) is byte-identical to today.

## Allowlist reconciliation (PR #3127)

`uploadConsumerBlob` yields an `https://orchestration.civitai.com/v2/consumer/blobs/…` (or `orchestration-new.civitai.com`) URL. Its **hostname ends in `.civitai.com`**, so it **passes `blockSourceImageSchema`'s host allowlist unchanged** (`hostname === h || endsWith('.'+h)` for `civitai.{com,red,green}`, https-only). **No allowlist loosening was required.** A locked-in test asserts the blob URL passes while host-confusion / non-https URLs are still rejected.

## What stays byte-identical

The `'display'` path: same `BlockImageUploadModal`, same `createImage`+scan+gate, same `{ imageId, nsfwLevel, contentRating, url }` reply. No scan/gate on the `generationSource` path; no `imageId`/`nsfwLevel` leaked. Naming is fully generic — any app can request a `generationSource` upload (no generator/app-specific terms).

## SDK co-requisite (drive separately — not in this PR)

`@civitai/app-sdk` / `@civitai/blocks-react` (`civitai-app-starters`) must add, to align with this host change:
- `OPEN_IMAGE_UPLOAD` request: `purpose?: 'display' | 'generationSource'` (omit ⇒ host defaults to `'display'`).
- `IMAGE_UPLOAD_RESULT` source-result variant: `selected: { url: string; width: number; height: number }` (no `imageId`/`nsfwLevel`/`contentRating`).
- `useImageUpload({ purpose })` option threading `purpose` into the request and returning the source shape when `purpose: 'generationSource'`.

## Tests

- `pageBlockHostLogic.test.ts` — `purpose` parsing: default/absent → `'display'`, explicit `'generationSource'`, unknown/non-string/wrong-case → `'display'`.
- `PageBlockHostImageUpload.browser.test.tsx` — host branch: `generationSource` opens the consumer-blob modal (not the moderated one) → `{ url, width, height }`; `display` (and absent) opens the moderated modal → moderated projection; cancel → bare result; no-requestId dropped.
- `BlockGenerationSourceUploadModal.browser.test.tsx` — modal uploads via `uploadConsumerBlob`, resolves `{ url, width, height }`, and **never** calls the scan/gate service (spies asserted untouched); upload failure surfaces an error and does not resolve.
- `workflow.schema.test.ts` — the consumer-blob URL passes `blockSourceImageSchema`; host-confusion + non-https rejected.

All new tests pass (unit + browser). `NODE_OPTIONS=--max_old_space_size=8192 tsc --noEmit` is clean on the touched files (the repo's pre-existing workspace-package errors are identical with/without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)