### PR TITLE
fix(blocks): route edit-capable ecosystems to img2img:edit instead of rejecting

### DIFF
--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -12,9 +12,11 @@ import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 const blockAccountTypeSchema = z.enum(buzzSpendTypes as [BuzzSpendType, ...BuzzSpendType[]]);
 
 // `textToImage` is the block-supported kind. It now covers the whole IMAGE
-// workflow class (App Blocks IMAGE bridge, Phase-2a): a bare body maps to a
-// `txt2img` graph workflow, and a body carrying a bounded `sourceImage` maps to
-// `img2img` — see buildImageWorkflowInput / BLOCK_IMAGE_WORKFLOW_TYPES in
+// workflow class (App Blocks IMAGE bridge): a bare body maps to a `txt2img`
+// graph workflow, and a body carrying a bounded `sourceImage` maps to an img2img
+// workflow whose variant is chosen from the checkpoint's ecosystem — `img2img`
+// (SD-family) or `img2img:edit` (edit-capable: OpenAI/Qwen/Flux Kontext/…). See
+// buildImageWorkflowInput / BLOCK_IMAGE_WORKFLOW_TYPES in
 // workflow.service. A later phase adds a NON-image media class (video/audio/3D)
 // as a NEW discriminated-union `kind` here, which must also (a) extend the
 // discriminator in blocks.router workflow procedures, (b) be exposed by
@@ -106,18 +108,21 @@ const blockTextToImageBodySchema = z.object({
   // base-model-family-matches against the checkpoint before any spend. Capped
   // at MAX_ADDITIONAL_RESOURCES for the iframe posture above.
   additionalResources: z.array(blockAdditionalResourceSchema).max(MAX_ADDITIONAL_RESOURCES).optional(),
-  // Optional img2img init/source image (App Blocks IMAGE bridge, Phase-2a).
-  // When present, the block bridge emits an `img2img` graph workflow (SD-family
-  // "Image Variations") instead of `txt2img`; when absent, behavior is
-  // byte-identical to before (txt2img). Bounded to a Civitai-hosted image (see
+  // Optional img2img init/source image (App Blocks IMAGE bridge).
+  // When present, the block bridge emits an img2img graph workflow whose VARIANT
+  // is chosen from the checkpoint's ecosystem (buildImageWorkflowInput /
+  // resolveBlockImageWorkflowType): SD-family ecosystems → `img2img` ("Image
+  // Variations"); edit-capable ecosystems (OpenAI/Qwen/Flux Kontext/… —
+  // EDIT_IMG_IDS) → `img2img:edit`; when absent, behavior is byte-identical to
+  // before (txt2img). Bounded to a Civitai-hosted image (see
   // blockSourceImageSchema) — never an arbitrary remote URL.
   //
-  // Two hard scope limits are enforced downstream (NOT at the wire schema, which
-  // only bounds shape): (1) blocks.router rejects `sourceImage` on a MODEL-bound
-  // token — img2img is PAGE-only in 2a, mirroring `additionalResources`; (2)
-  // buildImageWorkflowInput rejects a non-SD-family checkpoint fail-closed —
-  // plain `img2img` is SD-family-only in the graph, and edit-capable ecosystems
-  // (Flux Kontext, Qwen → `img2img:edit`) are a Phase-2b follow-up.
+  // Two scope limits are enforced downstream (NOT at the wire schema, which only
+  // bounds shape): (1) blocks.router rejects `sourceImage` on a MODEL-bound token
+  // — img2img is PAGE-only, mirroring `additionalResources`; (2)
+  // buildImageWorkflowInput rejects fail-closed a checkpoint whose ecosystem
+  // supports NEITHER img2img variant (deterministically via `isWorkflowAvailable`,
+  // never relying on the graph's safeParse auto-correction).
   sourceImage: blockSourceImageSchema.optional(),
   // Optional viewer-picked buzz account to spend (money page blocks). Absent →
   // unchanged Auto behavior (domain-allowed currencies drained blue-first). When

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -33,6 +33,7 @@ import { blockWorkflowBodySchema } from '~/server/schema/blocks/workflow.schema'
 // live in the browser-safe `shared/` tree (no DB/redis), so we import and run
 // them for real in the integration-style test below.
 import { generationGraph } from '~/shared/data-graph/generation/generation-graph';
+import { ECO } from '~/shared/constants/basemodel.constants';
 import { toStepMetadata } from '~/shared/utils/resource.utils';
 import { removeEmpty } from '~/utils/object-helpers';
 import type { GenerationCtx } from '~/shared/data-graph/generation/context';
@@ -896,6 +897,58 @@ describe('block input yields populated workflow metadata params (real graph path
       expect.objectContaining({ url: 'https://image.civitai.com/abc/def.jpeg' }),
     ]);
   });
+
+  // Edit-capable ecosystems (EDIT_IMG_IDS) route a source-image body to
+  // `img2img:edit`, NOT plain `img2img`. Prove end-to-end that the emitted input
+  // validates through the REAL generation graph AND routes to img2img:edit (i.e.
+  // the ecosystem is NOT silently auto-corrected) for each edit ecosystem — the
+  // same `images` reference node the onsite generator feeds (openai-graph /
+  // flux-kontext-graph / qwen-graph). `checkpointVersionId` uses each ecosystem's
+  // real locked version id so the modelLocked graph doesn't remap it.
+  it.each([
+    ['OpenAI', 'OpenAI', 1733399],
+    ['Qwen', 'Qwen', 2558804],
+    ['Flux.1 Kontext', 'Flux1Kontext', 1892509],
+  ])(
+    'emitted img2img:edit input validates through the REAL graph for %s (ecosystem %s)',
+    (baseModel, ecoKey, versionId) => {
+      const body = {
+        kind: 'textToImage' as const,
+        modelId: 7,
+        modelVersionId: versionId,
+        params: { prompt: 'make the cat wear a hat', quantity: 1 },
+        sourceImage: {
+          url: 'https://image.civitai.com/abc/def.jpeg',
+          width: 1024,
+          height: 1024,
+        },
+      };
+      const resolved = {
+        baseModel,
+        modelType: 'Checkpoint',
+        checkpointVersionId: versionId,
+        checkpointBaseModel: baseModel,
+      };
+      const input = buildImageWorkflowInput(body as never, resolved);
+      // The builder routes to img2img:edit deterministically.
+      expect(input.workflow).toBe('img2img:edit');
+      expect(input.ecosystem).toBe(ecoKey);
+
+      // The REAL graph accepts it AND keeps it routed to img2img:edit on the
+      // asserted ecosystem (no auto-correction to a supported-but-wrong route).
+      const result = generationGraph.safeParse(input, externalCtx);
+      if (!result.success) {
+        throw new Error(`img2img:edit graph validation failed: ${JSON.stringify(result.errors)}`);
+      }
+      const data = result.data as { workflow: string; ecosystem: string; images?: Array<{ url: string }> };
+      expect(data.workflow).toBe('img2img:edit');
+      expect(data.ecosystem).toBe(ecoKey);
+      // The bounded source image rides into the graph's reference `images` node.
+      expect(data.images).toEqual([
+        expect.objectContaining({ url: 'https://image.civitai.com/abc/def.jpeg' }),
+      ]);
+    }
+  );
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -920,15 +973,44 @@ describe('buildImageWorkflowInput (generalized image-workflow bridge)', () => {
     height: 1024,
   };
 
-  it('exposes exactly the image workflow allowlist (txt2img, img2img)', () => {
-    expect([...BLOCK_IMAGE_WORKFLOW_TYPES]).toEqual(['txt2img', 'img2img']);
+  it('exposes exactly the image workflow allowlist (txt2img, img2img, img2img:edit)', () => {
+    expect([...BLOCK_IMAGE_WORKFLOW_TYPES]).toEqual(['txt2img', 'img2img', 'img2img:edit']);
   });
 
-  it('resolveBlockImageWorkflowType derives img2img with a source image, txt2img without', () => {
+  it('resolveBlockImageWorkflowType derives the variant from body + ecosystem', () => {
+    // No source image → txt2img regardless of ecosystem.
     expect(resolveBlockImageWorkflowType(baseBody as never)).toBe('txt2img');
+    expect(resolveBlockImageWorkflowType(baseBody as never, ECO.OpenAI)).toBe('txt2img');
+    // Source image + SD-family ecosystem → img2img.
     expect(
-      resolveBlockImageWorkflowType({ ...baseBody, sourceImage: validSourceImage } as never)
+      resolveBlockImageWorkflowType(
+        { ...baseBody, sourceImage: validSourceImage } as never,
+        ECO.SDXL
+      )
     ).toBe('img2img');
+    // Source image + edit-capable ecosystem → img2img:edit.
+    for (const eco of [ECO.OpenAI, ECO.Qwen, ECO.Flux1Kontext]) {
+      expect(
+        resolveBlockImageWorkflowType({ ...baseBody, sourceImage: validSourceImage } as never, eco)
+      ).toBe('img2img:edit');
+    }
+    // Source image + ecosystem that supports neither img2img variant (Flux.1 →
+    // Flux1, txt2img-only) → BAD_REQUEST.
+    let caught: unknown;
+    try {
+      resolveBlockImageWorkflowType(
+        { ...baseBody, sourceImage: validSourceImage } as never,
+        ECO.Flux1
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect(caught).toMatchObject({ code: 'BAD_REQUEST' });
+    // Source image + unknown ecosystem (undefined) → BAD_REQUEST too.
+    expect(() =>
+      resolveBlockImageWorkflowType({ ...baseBody, sourceImage: validSourceImage } as never)
+    ).toThrow(TRPCError);
   });
 
   it('emits workflow:img2img + an images[] init image when a source image is present', () => {
@@ -1012,14 +1094,17 @@ describe('buildImageWorkflowInput (generalized image-workflow bridge)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// App Blocks IMAGE bridge (Phase-2a): img2img ecosystem fail-close guard
+// App Blocks IMAGE bridge: img2img variant selection + fail-close guard
 //
-// Plain `img2img` ("Image Variations") is SD-family-only in the generation
-// graph. buildImageWorkflowInput must reject a non-SD-family checkpoint + source
-// image with BAD_REQUEST rather than let DataGraph.safeParse silently auto-
-// correct the ecosystem to SD1 and return a mis-routed graph as success.
+// Plain `img2img` ("Image Variations") is SD-family-only and `img2img:edit` is
+// EDIT_IMG_IDS-only (OpenAI/Qwen/Flux Kontext/…) in the generation graph.
+// buildImageWorkflowInput must (a) route SD-family checkpoints to `img2img`, (b)
+// route edit-capable checkpoints to `img2img:edit`, and (c) reject a checkpoint
+// whose ecosystem supports NEITHER variant with BAD_REQUEST — deterministically,
+// rather than let DataGraph.safeParse silently auto-correct the ecosystem and
+// return a mis-routed graph as success.
 // ─────────────────────────────────────────────────────────────────────────────
-describe('buildImageWorkflowInput img2img ecosystem guard (SD-family only in 2a)', () => {
+describe('buildImageWorkflowInput img2img variant selection + ecosystem guard', () => {
   const baseBody = {
     kind: 'textToImage' as const,
     modelId: 7,
@@ -1049,11 +1134,27 @@ describe('buildImageWorkflowInput img2img ecosystem guard (SD-family only in 2a)
     expect(out.images).toHaveLength(1);
   });
 
-  // Non-SD-family checkpoints: plain img2img is NOT available, so the builder
-  // must throw BAD_REQUEST (not silently emit an SD1-corrected graph). Covers
-  // edit-capable ecosystems (Flux Kontext, Qwen — Phase-2b) and others.
-  it.each(['Flux.1 D', 'Flux.1 Kontext', 'Qwen', 'SD 3.5', 'Chroma', 'SD 2.1'])(
-    'rejects img2img for non-SD-family checkpoint %s with BAD_REQUEST',
+  // Edit-capable checkpoints (EDIT_IMG_IDS): plain img2img is NOT available but
+  // img2img:edit IS — the builder must route them to `img2img:edit` (NOT reject,
+  // NOT silently SD1-correct) and still carry the source image.
+  it.each([
+    ['Flux.1 Kontext', 'Flux1Kontext'],
+    ['Qwen', 'Qwen'],
+    ['OpenAI', 'OpenAI'],
+  ])('builds img2img:edit for edit-capable checkpoint %s (ecosystem %s)', (baseModel, ecoKey) => {
+    const out = buildImageWorkflowInput(baseBody as never, resolved(baseModel));
+    expect(out.workflow).toBe('img2img:edit');
+    expect(out.ecosystem).toBe(ecoKey);
+    expect(out.images).toHaveLength(1);
+    // aspectRatio is omitted for the edit variant (graph default applies).
+    expect(out.aspectRatio).toBeUndefined();
+  });
+
+  // Checkpoints whose ecosystem supports NEITHER img2img variant: the builder
+  // must throw BAD_REQUEST (not silently emit an auto-corrected graph). Flux.1 D
+  // (Flux1) / Chroma are txt2img-only; SD 3.5 / SD 2.1 are in neither set.
+  it.each(['Flux.1 D', 'SD 3.5', 'Chroma', 'SD 2.1'])(
+    'rejects img2img for a no-img2img-variant checkpoint %s with BAD_REQUEST',
     (baseModel) => {
       let caught: unknown;
       try {
@@ -1063,7 +1164,7 @@ describe('buildImageWorkflowInput img2img ecosystem guard (SD-family only in 2a)
       }
       expect(caught).toBeInstanceOf(TRPCError);
       expect(caught).toMatchObject({ code: 'BAD_REQUEST' });
-      expect((caught as TRPCError).message).toMatch(/SD-family/);
+      expect((caught as TRPCError).message).toMatch(/not supported/);
     }
   );
 

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -267,7 +267,7 @@ function defaultDimensions(baseModel: string): { width: number; height: number }
 // discriminated-union `kind` in workflow.schema. Everything else — the
 // resource fan-out, the router's per-item entitlement gate, the LoRA gate, the
 // budget preflight — is workflow-type-agnostic and stays as-is.
-export const BLOCK_IMAGE_WORKFLOW_TYPES = ['txt2img', 'img2img'] as const;
+export const BLOCK_IMAGE_WORKFLOW_TYPES = ['txt2img', 'img2img', 'img2img:edit'] as const;
 export type BlockImageWorkflowType = (typeof BLOCK_IMAGE_WORKFLOW_TYPES)[number];
 
 function isBlockImageWorkflowType(workflow: string): workflow is BlockImageWorkflowType {
@@ -275,14 +275,35 @@ function isBlockImageWorkflowType(workflow: string): workflow is BlockImageWorkf
 }
 
 /**
- * Resolve which image graph workflow a block body maps to: `img2img` when a
- * bounded source/init image is present (image variations), else `txt2img`.
- * Purely structural — the schema already validated/bounded `sourceImage`.
+ * Resolve which image graph workflow a block body maps to when combined with the
+ * checkpoint's ecosystem:
+ *   - no source image                          → `txt2img`
+ *   - source image + SD-family ecosystem       → `img2img`      (Image Variations)
+ *   - source image + edit-capable ecosystem    → `img2img:edit` (OpenAI / Qwen /
+ *                                                Flux Kontext / … — EDIT_IMG_IDS)
+ *   - source image + neither variant available → BAD_REQUEST
+ *
+ * Variant selection is DETERMINISTIC via `isWorkflowAvailable` (the same
+ * availability check the generation graph uses) — it never leans on
+ * `DataGraph.safeParse` auto-correcting a mis-routed ecosystem (the #3127 bug
+ * class: safeParse runs `_evaluate` before `_validate`, silently rewriting an
+ * unsupported ecosystem to a supported one and returning a mis-routed graph as
+ * success). `ecosystemId` is the checkpoint's resolved ecosystem id; when it is
+ * omitted (unrecognized base model) a source-image body is rejected fail-closed.
  */
 export function resolveBlockImageWorkflowType(
-  body: Extract<BlockWorkflowBody, { kind: 'textToImage' }>
+  body: Extract<BlockWorkflowBody, { kind: 'textToImage' }>,
+  ecosystemId?: number
 ): BlockImageWorkflowType {
-  return body.sourceImage ? 'img2img' : 'txt2img';
+  if (!body.sourceImage) return 'txt2img';
+  if (ecosystemId != null && isWorkflowAvailable('img2img', ecosystemId)) return 'img2img';
+  if (ecosystemId != null && isWorkflowAvailable('img2img:edit', ecosystemId)) return 'img2img:edit';
+  throw new TRPCError({
+    code: 'BAD_REQUEST',
+    message:
+      'img2img (source image) is not supported for this checkpoint — its ecosystem supports ' +
+      'neither img2img (SD-family) nor img2img:edit (edit-capable: OpenAI/Qwen/Flux Kontext/…)',
+  });
 }
 
 /**
@@ -312,17 +333,22 @@ export function resolveBlockImageWorkflowType(
  * model is its own anchor). For LoRA installs the resolver returns a different
  * checkpoint; the bound LoRA is pushed into `resources`.
  *
- * WORKFLOW TYPE: `workflowType` defaults to the type derived from the body
- * (`sourceImage` presence → img2img, else txt2img) and is VALIDATED against
- * BLOCK_IMAGE_WORKFLOW_TYPES — a non-image type is rejected fail-closed with a
- * BAD_REQUEST rather than silently producing a workflow this phase does not
- * support. The explicit parameter is the seam a later phase / an explicit-type
- * body flows through; the router passes nothing and gets the derived type.
+ * WORKFLOW TYPE: with no override, the variant is derived from the body + the
+ * checkpoint's ecosystem (`resolveBlockImageWorkflowType`): no source image →
+ * txt2img; source image + SD-family → img2img; source image + edit-capable
+ * ecosystem (OpenAI/Qwen/Flux Kontext/… — EDIT_IMG_IDS) → img2img:edit; source
+ * image + neither variant → BAD_REQUEST. Selection is DETERMINISTIC via
+ * `isWorkflowAvailable`, never safeParse auto-correction (#3127). The resolved
+ * type is VALIDATED against BLOCK_IMAGE_WORKFLOW_TYPES — a non-image type is
+ * rejected fail-closed. The explicit `workflowTypeOverride` parameter is the
+ * seam a later phase / an explicit-type body flows through; the router passes
+ * nothing and gets the derived type.
  *
  * DIMENSIONS: for txt2img the graph's `aspectRatio` node snaps the block-supplied
  * width/height to the ecosystem's nearest canonical bucket (the block sends
- * arbitrary 64–2048 dims from untrusted iframe UI). For img2img the graph derives
- * output dimensions from the source image, so aspectRatio is omitted.
+ * arbitrary 64–2048 dims from untrusted iframe UI). For both img2img variants the
+ * graph derives output dimensions from the source image (SD) or the ecosystem's
+ * aspectRatio default (edit), so aspectRatio is omitted.
  */
 export function buildImageWorkflowInput(
   body: Extract<BlockWorkflowBody, { kind: 'textToImage' }>,
@@ -332,8 +358,21 @@ export function buildImageWorkflowInput(
     checkpointVersionId: number;
     checkpointBaseModel: string;
   },
-  workflowType: string = resolveBlockImageWorkflowType(body)
+  workflowTypeOverride?: string
 ): Record<string, unknown> {
+  // Ecosystem drives the graph's branch + resource enrichment AND the img2img
+  // variant selection. Fall back to SDXL (the graph's ultimate fallback) if the
+  // checkpoint's baseModel is unrecognized — the resource belt will still gate it.
+  const ecoRecord = getEcosystem(resolved.checkpointBaseModel);
+  const ecosystem = ecoRecord?.key ?? 'SDXL';
+
+  // Resolve the workflow variant. The router passes no override → derive it from
+  // the body + ecosystem (txt2img / img2img / img2img:edit, DETERMINISTICALLY via
+  // isWorkflowAvailable — see resolveBlockImageWorkflowType). An explicit override
+  // is the seam a later phase / an explicit-type body flows through; it is
+  // validated against the image allowlist + the ecosystem-variant guard below.
+  const workflowType = workflowTypeOverride ?? resolveBlockImageWorkflowType(body, ecoRecord?.id);
+
   if (!isBlockImageWorkflowType(workflowType)) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
@@ -342,6 +381,28 @@ export function buildImageWorkflowInput(
       )}) are supported`,
     });
   }
+
+  // Deterministic ecosystem/variant guard (covers BOTH the derive- and
+  // override-paths). Plain `img2img` ("Image Variations") is SD-family-only and
+  // `img2img:edit` is EDIT_IMG_IDS-only (OpenAI/Qwen/Flux Kontext/…) in the
+  // generation graph. Reject a variant the checkpoint's ecosystem doesn't support
+  // HERE rather than lean on the graph: `DataGraph.safeParse` runs its auto-
+  // correct pass (`_evaluate`) BEFORE `_validate`, so an unsupported checkpoint
+  // would be silently REWRITTEN to a supported ecosystem (keeping the caller's
+  // checkpoint version id) and returned as a SUCCESSFUL but mis-routed graph —
+  // the whatIf preflight would price that mis-route too. Deriving support from
+  // `isWorkflowAvailable(workflowType, …)` keeps this in lockstep with the graph
+  // config (single source of truth) — the #3127 bug class.
+  if (
+    (workflowType === 'img2img' || workflowType === 'img2img:edit') &&
+    (!ecoRecord || !isWorkflowAvailable(workflowType, ecoRecord.id))
+  ) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `workflow '${workflowType}' is not supported for base model '${resolved.checkpointBaseModel}'`,
+    });
+  }
+
   const dims = defaultDimensions(resolved.checkpointBaseModel);
   const width = body.params.width ?? dims.width;
   const height = body.params.height ?? dims.height;
@@ -368,33 +429,6 @@ export function buildImageWorkflowInput(
     }
   }
 
-  // Ecosystem drives the graph's branch + resource enrichment. Fall back to
-  // SDXL (the graph's ultimate fallback) if the checkpoint's baseModel is
-  // unrecognized — the resource belt will still gate it.
-  const ecoRecord = getEcosystem(resolved.checkpointBaseModel);
-  const ecosystem = ecoRecord?.key ?? 'SDXL';
-
-  // img2img fail-CLOSED ecosystem guard (Phase-2a). Plain `img2img`
-  // ("Image Variations") is configured SD-family-only in the generation graph
-  // (config/workflows: SD_FAMILY_IDS = SD1/SDXL/Pony/Illustrious/NoobAI). We
-  // MUST reject a non-SD-family checkpoint here rather than lean on the graph:
-  // `DataGraph.safeParse` runs its auto-correct pass (`_evaluate`) BEFORE
-  // `_validate`, so a Flux / Flux Kontext / Qwen / SD3 / Chroma / SD2 checkpoint
-  // would be silently REWRITTEN to `ecosystem: 'SD1'` (while keeping the caller's
-  // checkpoint version id) and returned as a SUCCESSFUL but mis-routed graph —
-  // the whatIf preflight would price that mis-route too. Deriving support from
-  // `isWorkflowAvailable('img2img', …)` keeps this in lockstep with the graph
-  // config (single source of truth). Edit-capable ecosystems (Flux Kontext,
-  // Qwen) route through `img2img:edit`, NOT plain `img2img` — mapping those is a
-  // Phase-2b follow-up; for 2a every non-SD-family checkpoint + source image is
-  // a hard BAD_REQUEST.
-  if (workflowType === 'img2img' && (!ecoRecord || !isWorkflowAvailable('img2img', ecoRecord.id))) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: `img2img (source image) is only supported for SD-family checkpoints (SD1/SDXL/Pony/Illustrious/NoobAI) in this phase; base model '${resolved.checkpointBaseModel}' is not supported`,
-    });
-  }
-
   const input: Record<string, unknown> = {
     workflow: workflowType,
     ecosystem,
@@ -414,15 +448,20 @@ export function buildImageWorkflowInput(
     priority: 'low',
   };
 
-  if (workflowType === 'img2img') {
-    // img2img (SD-family image variations): the graph's `images` node is the
-    // init image; the denoise node applies at its default strength (0.75), and
-    // the graph derives output dimensions from the source image — so aspectRatio
-    // is OMITTED here (the SD graph gates aspectRatio to `when: !hasImages`).
-    // `sourceImage` is guaranteed present here (resolveBlockImageWorkflowType
-    // only returns 'img2img' when the body carries one); the fallback keeps the
-    // types honest for an explicit-type caller. The graph's imagesNode reads
-    // { url, width, height }; extra fields are stripped by its object parse.
+  if (workflowType === 'img2img' || workflowType === 'img2img:edit') {
+    // Both img2img variants take the bounded source image as the graph's
+    // `images` init/reference node — SD-family "Image Variations" (`img2img`)
+    // AND edit-capable "img2img:edit" (OpenAI/Qwen/Flux Kontext/…). This mirrors
+    // the onsite generator, which feeds the source image into the same `images`
+    // node for these ecosystems (see openai-graph / flux-kontext-graph /
+    // qwen-graph: `images` node shown `when: !workflow.startsWith('txt')`). The
+    // denoise/edit node applies at its default and output dimensions derive from
+    // the source (SD) or the ecosystem's aspectRatio default (edit) — so
+    // aspectRatio is OMITTED here. `sourceImage` is guaranteed present (the
+    // variant only resolves to an img2img* type when the body carries one); the
+    // fallback keeps the types honest for an explicit-type caller. The graph's
+    // imagesNode reads { url, width, height }; extra fields are stripped by its
+    // object parse.
     if (body.sourceImage) {
       input.images = [
         {


### PR DESCRIPTION
## Problem

PR #3127 added a guard in `buildImageWorkflowInput` (blocks `workflow.service.ts`) that fail-closes the block img2img bridge for **all** non-SD-family checkpoints, throwing `BAD_REQUEST` ("img2img … only supported for SD-family checkpoints"). That was an intentional Phase-2a scope limit, but it's wrong: **edit-capable ecosystems (OpenAI/GPT-Image, Qwen, Flux Kontext, …) support image-to-image via the `img2img:edit` workflow** — the onsite generator does this fine.

## Fix

`buildImageWorkflowInput` now resolves the img2img variant **deterministically** from the checkpoint's ecosystem via `isWorkflowAvailable` — never leaning on `DataGraph.safeParse` auto-correction (the #3127 bug class, where safeParse's `_evaluate` silently rewrites a mis-routed ecosystem before `_validate`):

- SD-family ecosystem (`SD_FAMILY_IDS`) → `workflow: 'img2img'` (unchanged, Image Variations)
- edit-capable ecosystem (`EDIT_IMG_IDS`: OpenAI/Qwen/Flux Kontext/Seedream/NanoBanana/Flux2/Grok/…) → `workflow: 'img2img:edit'` (new)
- ecosystem supporting **neither** variant → `BAD_REQUEST` with an accurate message

The bounded source image rides into the graph's `images` reference node for both variants — the same node the onsite `openai-graph` / `flux-kontext-graph` / `qwen-graph` feed (`images` shown `when: !workflow.startsWith('txt')`). `aspectRatio` is omitted for edit (the ecosystem's default applies).

All existing gates are untouched: per-item `resolveCanGenerateForVersions`, the budget preflight, page-only, and `resolvePageLoraGates` (edit ecosystems like OpenAI take no LoRAs → empty stack in practice; resource validation is **not** loosened). Stale "SD-family only" comments + the `sourceImage` schema doc are corrected to state the real behavior.

## Tests

Extended `workflow.service.test.ts` (78 pass):
- Source image + **OpenAI**, **Qwen**, **Flux Kontext** checkpoints → emits `workflow: 'img2img:edit'` and the input validates through the **real** `generationGraph.safeParse`, routing to `img2img:edit` on the asserted ecosystem (proving no silent auto-correction).
- SD-family (SDXL/SD1/Pony/Illustrious/NoobAI) → still `img2img`.
- Ecosystem with no img2img variant (Flux.1 D / Chroma / SD 3.5 / SD 2.1) → `BAD_REQUEST`.
- `txt2img` path unchanged; `resolveBlockImageWorkflowType` variant resolution covered per-ecosystem.

`npx tsc --noEmit` clean on the touched files.

## Scope

Only the img2img workflow-variant selection. Does not change txt2img, and does not touch the `display`/generationSource upload (separate PR #3141).

🤖 Generated with [Claude Code](https://claude.com/claude-code)