### PR TITLE
test(image-feed): mock top-level redis.get/set in clickhouse-failsoft suite

### DIFF
--- a/src/server/services/__tests__/image-feed-clickhouse-failsoft.test.ts
+++ b/src/server/services/__tests__/image-feed-clickhouse-failsoft.test.ts
@@ -74,7 +74,17 @@ vi.mock('~/server/redis/client', () => {
   const make = (): any => new Proxy(() => 'k', { get: () => make() });
   const keyProxy = make();
   return {
-    redis: { packed: { get: vi.fn(), set: vi.fn() } },
+    // getImagesFromFeedSearch → enforceBlockedBrowsingTags → getBlockedBrowsingTags
+    // reads the blocked-browsing-tags cache via TOP-LEVEL `redis.get` (system-cache.ts),
+    // not `redis.packed.get`. Stub top-level get/set too. `get` MUST resolve a cached
+    // JSON array (not null) so the getter returns from cache and does NOT fall through
+    // to the unmocked `dbRead.tag.findMany` (dbRead is mocked as {} below) — which would
+    // throw before the code reaches the ClickHouse fail-soft path these tests assert.
+    redis: {
+      get: vi.fn().mockResolvedValue('[]'),
+      set: vi.fn().mockResolvedValue(undefined),
+      packed: { get: vi.fn(), set: vi.fn() },
+    },
     sysRedis: {},
     REDIS_KEYS: keyProxy,
     REDIS_SYS_KEYS: keyProxy,


### PR DESCRIPTION
## Baseline unit-test break on `main`

`preview / unit-tests` fails on **every fresh PR** with 5 failures in `src/server/services/__tests__/image-feed-clickhouse-failsoft.test.ts`, all:

```
TypeError: __vite_ssr_import_2__.redis.get is not a function
```

`Tests 5 failed | 6137 passed`. It's a baseline break inherited on `main` (the test file lives on `main`; failing PRs change neither the test nor the redis usage). The `preview / unit-tests` job is report-only, so it hasn't blocked merges — but it makes every PR's unit-test report red.

## Root cause

The suite mocks `~/server/redis/client` with only a `redis.packed` sub-object:

```js
redis: { packed: { get: vi.fn(), set: vi.fn() } }
```

But the exercised path — `getImagesFromFeedSearch` → `enforceBlockedBrowsingTags` → `getBlockedBrowsingTags` — reads the blocked-browsing-tags cache via **top-level `redis.get`** (`system-cache.ts:230`), not `redis.packed.get`. Since the mock's `redis` has no top-level `get`, it throws `redis.get is not a function` *before* the code ever reaches the ClickHouse fail-soft logic the 5 tests assert. A change added the top-level redis read without updating this mock.

## Fix (test-only)

Add top-level `get`/`set` to the `redis` mock. `get` resolves a **cached empty JSON array (`'[]'`)** rather than `null`, so `getBlockedBrowsingTags` returns from cache instead of falling through to the unmocked `dbRead.tag.findMany` (`dbRead` is mocked as `{}`) — which would otherwise throw and still block the code from reaching the ClickHouse path. `set` is included for the cache-miss write leg. No production code changes; the top-level redis read is legitimate.

The 5 tests now exercise their real assertions (503 remap on a transient CH transport error, rethrow on `UNKNOWN_TABLE`, rethrow on a non-CH error, happy path).

## Verification (local, NixOS)

`vitest run --project unit src/server/services/__tests__/image-feed-clickhouse-failsoft.test.ts`

- Before: `Test Files 1 failed (1)` / `Tests 5 failed (5)` — all `redis.get is not a function`
- After: `Test Files 1 passed (1)` / `Tests 5 passed (5)` — code flows into the CH fail-soft catch (visible in stderr traces), assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)