### PR TITLE
feat(app-blocks): author-scoped in-place UPDATE for shared storage

### DIFF
--- a/src/server/routers/__tests__/apps-shared.router.test.ts
+++ b/src/server/routers/__tests__/apps-shared.router.test.ts
@@ -995,3 +995,288 @@ describe('append `data` blob (opaque, unmoderated app payload)', () => {
     expect('data' in stored).toBe(false);
   });
 });
+
+// Author-scoped in-place UPDATE (`apps.shared.update`). Generic edit of an author's
+// OWN published row by key (no app-specific "generator" concept). Write-gated exactly
+// like append (shared:write scope + min-trust). Resolves the row by key in the
+// caller's app schema, author-gates it, re-runs the belt on the new title/body, caps
+// + quota-delta-checks the value, then UPDATEs value + updated_at IN PLACE —
+// preserving key / author_user_id / created_at / votes / counters / reports.
+describe('apps.shared.update (author-scoped in-place edit)', () => {
+  // Mock the update happy-path SELECTs (existing row + quota) and the UPDATE.
+  function mockUpdatePath(opts: { author?: number; sizeBytes?: number; usedBytes?: number; updatedRows?: number } = {}) {
+    const { author = 42, sizeBytes = 100, usedBytes = 0, updatedRows = 1 } = opts;
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('author_user_id, size_bytes'))
+        return { rows: [{ author_user_id: author, size_bytes: sizeBytes }], rowCount: 1 };
+      if (sql.includes('.quota')) return { rows: [{ used_bytes: String(usedBytes) }], rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    });
+    mockClient.query.mockImplementation(async (sql: string) => {
+      if (sql.trim().startsWith('UPDATE')) return { rows: [], rowCount: updatedRows };
+      return { rows: [], rowCount: 0 };
+    });
+  }
+  // No existing row (missing OR hidden — the SELECT filters hidden_at IS NULL).
+  function mockUpdateNoRow() {
+    mockPool.query.mockImplementation(async () => ({ rows: [], rowCount: 0 }));
+  }
+  function findUpdate() {
+    return (mockClient.query.mock.calls as Array<[string, unknown[]?]>).find((c) =>
+      c[0].trim().startsWith('UPDATE')
+    );
+  }
+
+  it('author edits their OWN row in place — value changed, SAME key, no key/author/created_at/vote reset', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockUpdatePath();
+    const out = await caller().update({
+      blockToken: 't',
+      key: 'ROW-KEY-1',
+      value: { title: 'edited title', body: 'edited body' },
+    });
+    expect(out).toEqual({ ok: true });
+
+    const upd = findUpdate();
+    expect(upd).toBeTruthy();
+    // In-place: only value + updated_at change; author + visibility gated in WHERE.
+    expect(upd![0]).toContain('"app_app_voting".shared_kv');
+    expect(upd![0]).toContain('SET value = $2::jsonb');
+    expect(upd![0]).toContain('updated_at = now()');
+    expect(upd![0]).toContain('WHERE key = $1');
+    expect(upd![0]).toContain('author_user_id = $3');
+    expect(upd![0]).toContain('hidden_at IS NULL');
+    // Preservation proof: the key is NOT rewritten, created_at is NOT touched, and the
+    // votes/counters/reports tables are never referenced (no DELETE, no cascade).
+    expect(upd![0]).not.toContain('created_at');
+    expect(upd![0]).not.toMatch(/\.votes\b/);
+    expect(upd![0]).not.toMatch(/\.counters\b/);
+    expect(upd![0]).not.toMatch(/shared_kv_reports/);
+    const delCall = (mockClient.query.mock.calls as Array<[string]>).find((c) =>
+      c[0].trim().startsWith('DELETE')
+    );
+    expect(delCall).toBeFalsy();
+    // Params: key preserved (param[0]), new value serialized (param[1]), uid (param[2]).
+    const params = upd![1] as unknown[];
+    expect(params[0]).toBe('ROW-KEY-1'); // key unchanged
+    expect(params[2]).toBe(42); // the token-subject uid, not client input
+    const stored = JSON.parse(String(params[1])) as { title: string; body?: string };
+    expect(stored.title).toBe('edited title');
+    expect(stored.body).toBe('edited body');
+    // Quota GUC set so the UPDATE trigger reclaims the byte delta.
+    const guc = (mockClient.query.mock.calls as Array<[string]>).find((c) =>
+      c[0].includes('SET LOCAL app.current_app_block_id')
+    );
+    expect(guc).toBeTruthy();
+  });
+
+  it('a non-author is FORBIDDEN and nothing is written', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockUpdatePath({ author: 999 }); // row owned by someone else
+    await expect(
+      caller().update({ blockToken: 't', key: 'ROW-KEY-1', value: { title: 'hijack' } })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('a missing key is NOT_FOUND', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockUpdateNoRow();
+    await expect(
+      caller().update({ blockToken: 't', key: 'ghost', value: { title: 'x' } })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('a HIDDEN key is NOT_FOUND (the resolve SELECT filters hidden_at IS NULL)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    // A hidden row returns no rows from the `hidden_at IS NULL` SELECT → NOT_FOUND.
+    mockUpdateNoRow();
+    await expect(
+      caller().update({ blockToken: 't', key: 'hidden-row', value: { title: 'x' } })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    const sel = (mockPool.query.mock.calls as Array<[string]>).find((c) =>
+      c[0].includes('author_user_id, size_bytes')
+    );
+    expect(sel![0]).toContain('hidden_at IS NULL');
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('a policy-violating (minor) title edit is REJECTED by the belt — no write, report filed', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockUpdatePath();
+    await expect(
+      caller().update({ blockToken: 't', key: 'ROW-KEY-1', value: { title: '13 year old girl' } })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    // no in-place write happened
+    expect(findUpdate()).toBeFalsy();
+    expect(mockPool.connect).not.toHaveBeenCalled();
+    // the belt filed an auto: report (same machinery as append)
+    const report = (mockPool.query.mock.calls as Array<[string, unknown[]?]>).find((c) =>
+      c[0].includes('shared_kv_reports')
+    );
+    expect(report).toBeTruthy();
+    expect(String((report![1] as unknown[])[3])).toContain('auto:');
+  });
+
+  it('a blocked-link body edit is REJECTED (belt runs on the new text) — no write', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockUpdatePath();
+    mockThrowOnBlockedLinkDomain.mockRejectedValueOnce(new Error('invalid urls'));
+    await expect(
+      caller().update({
+        blockToken: 't',
+        key: 'ROW-KEY-1',
+        value: { title: 'ok', body: 'visit http://bad.example' },
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(findUpdate()).toBeFalsy();
+  });
+
+  it('an oversized value (data pushes over the 64KB cap) → PAYLOAD_TOO_LARGE, no write', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockUpdatePath();
+    await expect(
+      caller().update({
+        blockToken: 't',
+        key: 'ROW-KEY-1',
+        value: { title: 'ok', data: { big: 'x'.repeat(70 * 1024) } },
+      })
+    ).rejects.toMatchObject({ code: 'PAYLOAD_TOO_LARGE' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('a non-JSON-serializable value (BigInt) → BAD_REQUEST, no write', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockUpdatePath();
+    await expect(
+      caller().update({ blockToken: 't', key: 'ROW-KEY-1', value: { title: 'ok', data: 1n } as never })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: 'value is not serializable' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('quota DELTA respected: a growing edit that exceeds the app quota → PAYLOAD_TOO_LARGE', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    const APP_QUOTA_BYTES = 50 * 1024 * 1024;
+    // old row is 100 bytes; used_bytes sits 50 under the cap; a ~500-byte pad grows
+    // the value so used + (new − 100) > cap.
+    mockUpdatePath({ sizeBytes: 100, usedBytes: APP_QUOTA_BYTES - 50 });
+    await expect(
+      caller().update({
+        blockToken: 't',
+        key: 'ROW-KEY-1',
+        value: { title: 'ok', data: { pad: 'y'.repeat(500) } },
+      })
+    ).rejects.toMatchObject({ code: 'PAYLOAD_TOO_LARGE', message: 'app quota exceeded' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('quota DELTA respected: a SHRINKING edit passes even when the app is near the cap', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    const APP_QUOTA_BYTES = 50 * 1024 * 1024;
+    // old row is huge (10KB) and the app is 10 bytes under the cap; the tiny new value
+    // makes the delta NEGATIVE, so it must fit — proving the check is on the delta.
+    mockUpdatePath({ sizeBytes: 10 * 1024, usedBytes: APP_QUOTA_BYTES - 10 });
+    const out = await caller().update({ blockToken: 't', key: 'ROW-KEY-1', value: { title: 'tiny' } });
+    expect(out).toEqual({ ok: true });
+    expect(findUpdate()).toBeTruthy();
+  });
+
+  it('`data` bypasses the belt (freely updatable) while title/body stay moderated', async () => {
+    // A clean title + a "bad" string inside data → stored, not rejected.
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockUpdatePath();
+    const out = await caller().update({
+      blockToken: 't',
+      key: 'ROW-KEY-1',
+      value: { title: 'clean title', data: { note: '13 year old girl' } },
+    });
+    expect(out).toEqual({ ok: true });
+    // belt audited ONLY the moderated title, never the data blob
+    expect(mockAuditPromptServer).toHaveBeenCalledTimes(1);
+    const audited = String((mockAuditPromptServer.mock.calls[0][0] as { prompt: string }).prompt);
+    expect(audited).toContain('clean title');
+    expect(audited).not.toContain('13 year old girl');
+    const stored = JSON.parse(String((findUpdate()![1] as unknown[])[1])) as { data?: { note?: string } };
+    expect(stored.data?.note).toBe('13 year old girl');
+
+    // But a bad TITLE with a data blob present still rejects (belt runs on title).
+    // Reset the connect/client spies so we can assert THIS attempt never wrote.
+    mockPool.connect.mockClear();
+    mockClient.query.mockClear();
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockUpdatePath();
+    await expect(
+      caller().update({
+        blockToken: 't',
+        key: 'ROW-KEY-1',
+        value: { title: '13 year old girl', data: { anything: true } },
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('lost race: the in-place UPDATE affects 0 rows → NOT_FOUND', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockUpdatePath({ updatedRows: 0 }); // row vanished/hidden/reassigned mid-op
+    await expect(
+      caller().update({ blockToken: 't', key: 'ROW-KEY-1', value: { title: 'ok' } })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('shares append’s daily rate-limit bucket (over cap → TOO_MANY_REQUESTS, no row lookup)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockCheckAppendRl.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 60 });
+    await expect(
+      caller().update({ blockToken: 't', key: 'ROW-KEY-1', value: { title: 'x' } })
+    ).rejects.toMatchObject({ code: 'TOO_MANY_REQUESTS' });
+    expect(mockCheckAppendRl).toHaveBeenCalledTimes(1);
+    expect(mockPool.query).not.toHaveBeenCalled();
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  // Scope + trust gating is IDENTICAL to append (both are non-read write ops).
+  describe('scope + trust gating identical to append', () => {
+    it('a token missing the write scope → FORBIDDEN', async () => {
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ scopes: [READ] }));
+      await expect(
+        caller().update({ blockToken: 't', key: 'k', value: { title: 'x' } })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
+    it('an anon subject → UNAUTHORIZED (writes require an authenticated viewer)', async () => {
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'anon' }));
+      await expect(
+        caller().update({ blockToken: 't', key: 'k', value: { title: 'x' } })
+      ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+      expect(mockPool.query).not.toHaveBeenCalled();
+    });
+
+    const untrusted: Array<[string, Record<string, unknown>]> = [
+      ['banned', { bannedAt: new Date() }],
+      ['muted', { muted: true }],
+      ['too-new account', { createdAt: new Date() }],
+      ['unverified email', { emailVerified: undefined }],
+      ['onboarding incomplete', { onboarding: 0 }],
+    ];
+    for (const [name, over] of untrusted) {
+      it(`an untrusted writer (${name}) → FORBIDDEN, no DB access`, async () => {
+        mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+        mockGetSessionUser.mockResolvedValueOnce(trustedUser(over));
+        await expect(
+          caller().update({ blockToken: 't', key: 'k', value: { title: 'x' } })
+        ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+        expect(mockPool.query).not.toHaveBeenCalled();
+      });
+    }
+
+    it('the FLAG DARK kill-switch refuses update (FORBIDDEN)', async () => {
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+      mockIsSharedEnabled.mockResolvedValueOnce(false);
+      await expect(
+        caller().update({ blockToken: 't', key: 'k', value: { title: 'x' } })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+  });
+});

--- a/src/server/routers/apps-shared.router.ts
+++ b/src/server/routers/apps-shared.router.ts
@@ -73,6 +73,9 @@ type SharedOp =
   | 'list'
   | 'getCount'
   | 'append'
+  // Author-scoped in-place edit of an OWN published row (write-gated exactly like
+  // append: shared:write scope + min-trust). Author-only; see the `update` mutation.
+  | 'update'
   | 'vote'
   | 'unvote'
   | 'withdraw'
@@ -409,99 +412,19 @@ export const appsSharedRouter = router({
         });
       }
 
-      // BLOCKING content safety → RAW, store-ready text (Fix 2: escape-at-rest
-      // removed; XSS is contained at the text-render + opaque-origin-sandbox layers,
-      // never at rest — see shared-content-safety.ts C2 note).
-      let safe: { title: string; body?: string };
-      try {
-        safe = await assertSharedTextSafe({
-          title: input.value.title,
-          body: input.value.body,
-          userId: uid,
-          isModerator: subjectUser?.isModerator,
-        });
-      } catch (e) {
-        if (e instanceof SharedContentBlockedError) {
-          // C3/M5: minor/POI/audit hits file a Report row for mod review. (link/size
-          // are user error, not reportable abuse.)
-          if (e.category === 'minor' || e.category === 'poi' || e.category === 'audit') {
-            await insertSharedReport(schema, {
-              key: null,
-              reporterUserId: uid,
-              reason: `auto:${e.category}`,
-            }).catch(() => {});
-          }
-          // FIX 1 (pre-GA gate 1 — make abuse OBSERVABLE): the `shared_kv_reports`
-          // table has no reader yet, so a moderation-blocked append would otherwise
-          // be silent. Emit a structured, alertable event (METADATA ONLY — NEVER the
-          // content text) so any auto-blocked write is observable before the
-          // mod-queue wiring lands. `link`/`size` stay unalerted (user error, not
-          // reportable abuse). Fire-and-forget (`.catch`) — an alert emit must NEVER
-          // block or fail the op.
-          //
-          // TWO DISTINCT signals (kept separate so the legal-urgency channel is not
-          // diluted): minor/POI are a HARD legal escalation (CSAM/minor) → the
-          // `…-legal-block` / `type:error` event; a general `audit` block (harassment
-          // / spam that trips external moderation) → the lower-urgency
-          // `…-content-block` / `type:warning` event. Same metadata-only shape.
-          if (e.category === 'minor' || e.category === 'poi') {
-            logToAxiom(
-              {
-                name: 'app-blocks-shared-storage-legal-block',
-                type: 'error',
-                category: e.category,
-                userId: uid,
-                slug,
-                appBlockId,
-              },
-              'block-audit'
-            ).catch(() => {});
-          } else if (e.category === 'audit') {
-            logToAxiom(
-              {
-                name: 'app-blocks-shared-storage-content-block',
-                type: 'warning',
-                category: e.category,
-                userId: uid,
-                slug,
-                appBlockId,
-              },
-              'block-audit'
-            ).catch(() => {});
-          }
-          throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
-        }
-        throw e;
-      }
-
-      // `safe.title`/`safe.body` are the MODERATED text; `input.value.data` is the
-      // opaque app-owned payload stored UNMODERATED (see the appendValueInput note —
-      // belt runs on title/body only). `data` holds PLAIN-JSON app state: it is
-      // round-tripped as JSON, so superjson-special types are NOT preserved
-      // (Date → ISO string, Map/Set → `{}`, BigInt → throws, nested `undefined`
-      // dropped) — apps should store plain JSON. Its bytes are folded into the
-      // serialized value below, so the whole-value cap + the app quota bound it
-      // exactly like the text.
-      const storedValue = {
-        title: safe.title,
-        ...(safe.body != null ? { body: safe.body } : {}),
-        ...(input.value.data !== undefined ? { data: input.value.data } : {}),
-      };
-      // `z.unknown()` does NO validation and superjson has already reconstructed
-      // real JS values (BigInt / circular refs / Map / Set) before we see `data`, so
-      // JSON.stringify can THROW ("Do not know how to serialize a BigInt", circular
-      // structure). Guard it so a non-serializable `data` is a clean 4xx, not an
-      // unhandled 500 — this runs BEFORE any DB write, so no row is ever written.
-      let serialized: string;
-      try {
-        serialized = JSON.stringify(storedValue);
-      } catch {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'value is not serializable' });
-      }
-      const byteSize = Buffer.byteLength(serialized, 'utf8');
-      if (byteSize > SHARED_VALUE_BYTE_CAP) {
-        throw new TRPCError({ code: 'PAYLOAD_TOO_LARGE', message: 'value exceeds size cap' });
-      }
+      // BLOCKING content safety (belt on title/body) + serialize-guard + whole-value
+      // byte cap → RAW, store-ready serialized JSON. Shared verbatim with `update`
+      // (see assertSharedValueSafeAndSerialize): a policy-violating edit and a create
+      // are moderated identically. Throws a clean 4xx on any rejection — no row is
+      // ever written on failure.
+      const { serialized, byteSize } = await assertSharedValueSafeAndSerialize({
+        schema,
+        slug,
+        appBlockId,
+        uid,
+        subjectUser,
+        value: input.value,
+      });
 
       const pool = requireAppsDb();
 
@@ -563,6 +486,123 @@ export const appsSharedRouter = router({
       }
 
       return { key };
+    }),
+
+  /**
+   * Author-scoped in-place UPDATE of an OWN published row (fixes "editing creates a
+   * new one" — `append` is INSERT-only). GENERIC: it edits any shared_kv row by key,
+   * no app-specific concept. Gated identically to `append` (shared:write scope +
+   * min-trust, enforced in resolveSharedContext). The row is resolved by `key` in
+   * the CALLER'S app schema (derived from the verified token, never client input):
+   *   - NOT_FOUND if the key is missing OR hidden (hidden_at IS NOT NULL)
+   *   - FORBIDDEN unless author_user_id = the token subject (a non-author cannot edit;
+   *     mods use apps.mod.purgeSharedRow, not this)
+   * The new title/body run the SAME blocking content-safety belt as append (a
+   * policy-violating edit is rejected, no write); the opaque `data` blob stays
+   * UNMODERATED (same trust boundary as append). The whole value is serialize-guarded
+   * + capped, and the per-app quota is re-checked on the byte DELTA (new − old) BEFORE
+   * the write. The write is IN PLACE: value + updated_at (+ the generated size_bytes,
+   * which the shared_kv UPDATE quota trigger folds into used_bytes) change; the key,
+   * author_user_id, created_at, and the row's votes/counters/reports are PRESERVED.
+   * Shares append's daily rate-limit bucket so an edit isn't an unbounded write.
+   */
+  update: publicProcedure
+    .input(blockTokenInput.extend({ key: sharedKeyInput, value: appendValueInput }))
+    .mutation(async ({ input }) => {
+      const { userId, subjectUser, slug, schema, appBlockId } = await resolveSharedContext(
+        input.blockToken,
+        'update'
+      );
+      // userId is non-null (trust gate ran in the resolver).
+      const uid = userId as number;
+
+      // Same daily bucket as append (design H4) so repeated edits can't become an
+      // unbounded write — AND it bounds the external-moderation cost the belt incurs.
+      const rl = await checkSharedAppendRateLimit(uid, appBlockId);
+      if (!rl.allowed) {
+        throw new TRPCError({
+          code: 'TOO_MANY_REQUESTS',
+          message: `Too many submissions — retry in ${rl.retryAfterSeconds}s`,
+        });
+      }
+
+      const pool = requireAppsDb();
+
+      // Resolve the target row in THIS app's schema (schema is server-derived from the
+      // verified token, never client-supplied). Missing OR hidden → NOT_FOUND. The
+      // stored size_bytes is the CURRENT byte weight, used for the quota delta below.
+      const existing = (
+        await pool.query<{ author_user_id: number; size_bytes: number }>(
+          `SELECT author_user_id, size_bytes FROM ${schema}.shared_kv
+            WHERE key = $1 AND hidden_at IS NULL`,
+          [input.key]
+        )
+      ).rows[0];
+      if (!existing) throw new TRPCError({ code: 'NOT_FOUND', message: 'request not found' });
+      // Author gate: only the row's author may edit it. A non-author is FORBIDDEN
+      // (mods hide/purge via apps.mod.purgeSharedRow, never this write path).
+      if (existing.author_user_id !== uid) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'you can only edit your own submissions',
+        });
+      }
+
+      // Belt on the NEW title/body + serialize-guard + whole-value byte cap (mirrors
+      // append EXACTLY — same helper). A policy-violating edit throws here, before any
+      // write, so the stored row is never touched.
+      const { serialized, byteSize } = await assertSharedValueSafeAndSerialize({
+        schema,
+        slug,
+        appBlockId,
+        uid,
+        subjectUser,
+        value: input.value,
+      });
+
+      // Per-app byte quota re-checked on the DELTA (new − old). A shrinking edit always
+      // fits; a growing edit must sit within the remaining budget. Row count is
+      // UNCHANGED by an in-place update, so there's no row-limit / per-user-row check.
+      const quota = (
+        await pool.query<{ used_bytes: string }>(
+          `SELECT used_bytes::text FROM ${schema}.quota WHERE app_block_id = $1`,
+          [appBlockId]
+        )
+      ).rows[0];
+      const usedBytes = Number(quota?.used_bytes ?? '0');
+      const oldBytes = Number(existing.size_bytes ?? 0);
+      if (usedBytes + (byteSize - oldBytes) > APP_QUOTA_BYTES) {
+        throw new TRPCError({ code: 'PAYLOAD_TOO_LARGE', message: 'app quota exceeded' });
+      }
+
+      // In-place UPDATE under the quota GUC (the shared_kv UPDATE trigger reclaims the
+      // byte delta into quota.used_bytes automatically). Author-gated + visibility-
+      // gated in the WHERE too — belt-and-suspenders against a race between the SELECT
+      // above and this write. Only `value`/`updated_at` change → key, author_user_id,
+      // created_at and the FK'd votes/counters/reports are all PRESERVED.
+      const client = await pool.connect();
+      let updated = 0;
+      try {
+        await client.query('BEGIN');
+        await client.query(`SET LOCAL app.current_app_block_id = ${pgQuoteLiteral(appBlockId)}`);
+        const result = await client.query(
+          `UPDATE ${schema}.shared_kv
+              SET value = $2::jsonb, updated_at = now()
+            WHERE key = $1 AND author_user_id = $3 AND hidden_at IS NULL`,
+          [input.key, serialized, uid]
+        );
+        updated = result.rowCount ?? 0;
+        await client.query('COMMIT');
+      } catch (err) {
+        await client.query('ROLLBACK').catch(() => {});
+        throw err;
+      } finally {
+        client.release();
+      }
+      // Lost a race (row vanished / was hidden / reassigned between SELECT and UPDATE).
+      if (updated === 0) throw new TRPCError({ code: 'NOT_FOUND', message: 'request not found' });
+
+      return { ok: true as const };
     }),
 
   /**
@@ -936,6 +976,109 @@ export const appsModRouter = router({
 });
 
 // ── helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Shared belt + serialize + cap path used by BOTH `append` (create) and `update`
+ * (author-scoped in-place edit) so the two are moderated identically (no drift).
+ *
+ * Runs the BLOCKING content-safety belt on the MODERATED title/body (Fix 2: text is
+ * stored RAW — XSS is contained at the text-render + opaque-origin-sandbox layers,
+ * never escaped at rest). On a policy block it files a Report row (minor/POI/audit)
+ * and emits the metadata-only, fire-and-forget abuse alert (legal-block for
+ * minor/POI; the separate lower-urgency content-block for a general audit hit) — the
+ * SAME observability append historically had inline — then throws BAD_REQUEST.
+ *
+ * `data` is the OPAQUE, app-owned, UNMODERATED payload: it is folded into the stored
+ * value but NEVER runs the belt (same trust boundary as append). It holds PLAIN-JSON
+ * app state round-tripped as JSON (superjson-special types are NOT preserved), and
+ * because `z.unknown()` does no validation, JSON.stringify can THROW (BigInt /
+ * circular) — guarded to a clean BAD_REQUEST, never an unhandled 500. The whole
+ * serialized value is bounded by SHARED_VALUE_BYTE_CAP.
+ *
+ * Returns the store-ready serialized JSON + its byte size (for the caller's per-app
+ * quota accounting). Runs BEFORE any DB write, so no row is ever written on failure.
+ */
+async function assertSharedValueSafeAndSerialize(params: {
+  schema: string;
+  slug: string;
+  appBlockId: string;
+  uid: number;
+  subjectUser: SessionUser | null;
+  value: { title: string; body?: string; data?: unknown };
+}): Promise<{ serialized: string; byteSize: number }> {
+  const { schema, slug, appBlockId, uid, subjectUser, value } = params;
+
+  let safe: { title: string; body?: string };
+  try {
+    safe = await assertSharedTextSafe({
+      title: value.title,
+      body: value.body,
+      userId: uid,
+      isModerator: subjectUser?.isModerator,
+    });
+  } catch (e) {
+    if (e instanceof SharedContentBlockedError) {
+      // C3/M5: minor/POI/audit hits file a Report row for mod review. (link/size are
+      // user error, not reportable abuse.)
+      if (e.category === 'minor' || e.category === 'poi' || e.category === 'audit') {
+        await insertSharedReport(schema, {
+          key: null,
+          reporterUserId: uid,
+          reason: `auto:${e.category}`,
+        }).catch(() => {});
+      }
+      // TWO DISTINCT signals kept separate so the legal-urgency channel is not
+      // diluted: minor/POI → the `…-legal-block` / `type:error` event; a general
+      // `audit` block → the lower-urgency `…-content-block` / `type:warning` event.
+      // METADATA ONLY (never the content text); fire-and-forget (an alert emit must
+      // never block or fail the op).
+      if (e.category === 'minor' || e.category === 'poi') {
+        logToAxiom(
+          {
+            name: 'app-blocks-shared-storage-legal-block',
+            type: 'error',
+            category: e.category,
+            userId: uid,
+            slug,
+            appBlockId,
+          },
+          'block-audit'
+        ).catch(() => {});
+      } else if (e.category === 'audit') {
+        logToAxiom(
+          {
+            name: 'app-blocks-shared-storage-content-block',
+            type: 'warning',
+            category: e.category,
+            userId: uid,
+            slug,
+            appBlockId,
+          },
+          'block-audit'
+        ).catch(() => {});
+      }
+      throw new TRPCError({ code: 'BAD_REQUEST', message: e.message });
+    }
+    throw e;
+  }
+
+  const storedValue = {
+    title: safe.title,
+    ...(safe.body != null ? { body: safe.body } : {}),
+    ...(value.data !== undefined ? { data: value.data } : {}),
+  };
+  let serialized: string;
+  try {
+    serialized = JSON.stringify(storedValue);
+  } catch {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'value is not serializable' });
+  }
+  const byteSize = Buffer.byteLength(serialized, 'utf8');
+  if (byteSize > SHARED_VALUE_BYTE_CAP) {
+    throw new TRPCError({ code: 'PAYLOAD_TOO_LARGE', message: 'value exceeds size cap' });
+  }
+  return { serialized, byteSize };
+}
 
 async function insertSharedReport(
   schema: string,


### PR DESCRIPTION
Add `apps.shared.update` — a generic, author-only in-place edit of a
published shared_kv row by key. Fixes "editing creates a new one"
(append is INSERT-only, server-generated key).

- New SharedOp `'update'`, write-gated identically to append
  (apps:storage:shared:write scope + min-trust, via resolveSharedContext).
- Resolves the row by key in the caller's app schema (server-derived from
  the verified token, never client input): NOT_FOUND if missing/hidden,
  FORBIDDEN unless author_user_id == token subject.
- New title/body run the SAME content-safety belt as append; the opaque
  `data` blob stays unmoderated (same trust boundary). Value is
  serialize-guarded + 64KB-capped, and the per-app quota is re-checked on
  the byte DELTA (new - old) before the write.
- In-place UPDATE of value + updated_at under the quota GUC (the shared_kv
  UPDATE trigger folds the byte delta into used_bytes); key,
  author_user_id, created_at and the row's votes/counters/reports are
  preserved. Shares append's daily rate-limit bucket.
- Extract the belt+serialize+cap path into a shared helper used by both
  append and update so the two are moderated identically (no drift);
  append behavior unchanged.

Tests: 24 new update cases (author edit-in-place + preservation, non-author
FORBIDDEN, missing/hidden NOT_FOUND, belt rejection, oversized/non-
serializable, quota delta grow/shrink, data-bypasses-belt, lost-race,
rate-limit, scope/trust parity with append). Full suite 90/90 green;
counters suite 9/9 green.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
