### PR TITLE
fix(images): stop profile image count caching a pre-scan zero

### DIFF
--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -18,7 +18,7 @@ import { stripBenignPhrases } from '~/server/services/blocklist.service';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { getExplainSql } from '~/server/db/db-helpers';
 import { logToAxiom } from '~/server/logging/client';
-import { tagIdsForImagesCache } from '~/server/redis/caches';
+import { tagIdsForImagesCache, userImageVideoCountCaches } from '~/server/redis/caches';
 import type { ImageMetadata, VideoMetadata } from '~/server/schema/media.schema';
 import { addImageToQueue } from '~/server/services/games/new-order.service';
 import { createImageTagsForReview } from '~/server/services/image-review.service';
@@ -261,6 +261,7 @@ async function updateImage(
         ]);
       }
 
+      await userImageVideoCountCaches.bust(image.userId);
       await tagIdsForImagesCache.refresh(id);
 
       const isProfilePicture = image.metadata?.profilePicture === true;

--- a/src/server/jobs/process-scheduled-publishing.ts
+++ b/src/server/jobs/process-scheduled-publishing.ts
@@ -2,7 +2,8 @@ import { Prisma } from '@prisma/client';
 import { dbWrite } from '~/server/db/client';
 import { eventEngine } from '~/server/events';
 import { NotificationCategory, SearchIndexUpdateQueueAction } from '~/server/common/enums';
-import { dataForModelsCache } from '~/server/redis/caches';
+import { uniq } from 'lodash-es';
+import { dataForModelsCache, userImageVideoCountCaches } from '~/server/redis/caches';
 import { queueImageSearchIndexUpdate } from '~/server/services/image.service';
 import {
   bustMvCache,
@@ -292,6 +293,9 @@ export const processScheduledPublishing = createJob(
           action: SearchIndexUpdateQueueAction.Update,
         });
       }
+      // This job publishes via raw SQL rather than updatePost, so it owns the
+      // count refresh for the posts it flips.
+      await userImageVideoCountCaches.refresh(uniq(scheduledPosts.map((p) => p.userId)));
     }
 
     const processedModelIds = [

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -758,7 +758,7 @@ export const userImageVideoCountSfwCache = createUserContentCountCache<UserImage
 );
 export const userImageVideoCountPublicCache = createUserContentCountCache<UserImageVideoCount>(
   'imageVideoCount:public',
-  async (userIds) => dbRead.$queryRaw`
+  async (userIds, fromWrite) => (fromWrite ? dbWrite : dbRead).$queryRaw`
     SELECT
       "userId" as id,
       COALESCE(SUM(IIF("type" = 'image', 1, 0)), 0)::INT as "imageCount",
@@ -798,8 +798,13 @@ export const userImageVideoCountCaches = {
   refresh: async (userIds: number | number[]) => {
     await Promise.all(userImageVideoCountVariants.map((cache) => cache.refresh(userIds)));
   },
+  // allSettled, not all: unlike refresh(), the underlying bust has no internal
+  // catch, and its cluster read rejects on a Redis stall. This runs on the
+  // scan-result webhook for every image, where a throw would fail the callback
+  // and trigger scanner redelivery against an already-committed row. A dropped
+  // bust only costs staleness until the TTL expires.
   bust: async (userIds: number | number[]) => {
-    await Promise.all(userImageVideoCountVariants.map((cache) => cache.bust(userIds)));
+    await Promise.allSettled(userImageVideoCountVariants.map((cache) => cache.bust(userIds)));
   },
 };
 

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -778,6 +778,31 @@ export const userImageVideoCountPublicCache = createUserContentCountCache<UserIm
   `
 );
 
+const userImageVideoCountVariants = [
+  userImageVideoCountCache,
+  userImageVideoCountSfwCache,
+  userImageVideoCountPublicCache,
+];
+
+/**
+ * The image/video count is cached once per browsing-level variant, and all three
+ * move together whenever a user's countable images change.
+ *
+ * `refresh` re-queries eagerly, so it is only safe once the image already
+ * satisfies the count predicate (Scanned, on a post that is published and not
+ * future-dated). Calling it mid-transition caches the pre-transition count for
+ * the full TTL — prefer `bust` on any path that can fire before the image
+ * qualifies.
+ */
+export const userImageVideoCountCaches = {
+  refresh: async (userIds: number | number[]) => {
+    await Promise.all(userImageVideoCountVariants.map((cache) => cache.refresh(userIds)));
+  },
+  bust: async (userIds: number | number[]) => {
+    await Promise.all(userImageVideoCountVariants.map((cache) => cache.bust(userIds)));
+  },
+};
+
 type UserArticleCount = { id: number; articleCount: number };
 export const userArticleCountCache = createUserContentCountCache<UserArticleCount>(
   'articleCount',

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -39,7 +39,11 @@ import {
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 import { createImageTagsForReview } from '~/server/services/image-review.service';
-import { tagIdsForImagesCache, tagCacheByName } from '~/server/redis/caches';
+import {
+  tagIdsForImagesCache,
+  tagCacheByName,
+  userImageVideoCountCaches,
+} from '~/server/redis/caches';
 import type { MediaMetadata } from '~/server/schema/media.schema';
 import { deleteUserProfilePictureCache } from '~/server/services/user.service';
 import { bustCachesForPosts, updatePostNsfwLevel } from '~/server/services/post.service';
@@ -1012,6 +1016,10 @@ async function applyIngestionSideEffects({
 
   // handle scanned image updates
   if (outcome.ingestion === ImageIngestionStatus.Scanned) {
+    // Scanning is what makes an already-published image countable. Bust rather
+    // than refresh: this fires once per image, so a re-query here would be N
+    // identical counts for an N-image post.
+    await userImageVideoCountCaches.bust(image.userId);
     await tagIdsForImagesCache.refresh(image.id);
     if (
       typeof image.metadata === 'object' &&

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -79,7 +79,6 @@ import {
   tagCache,
   tagIdsForImagesCache,
   thumbnailCache,
-  userImageVideoCountCache,
 } from '~/server/redis/caches';
 import type { RedisKeyTemplateSys } from '~/server/redis/client';
 import {
@@ -5771,7 +5770,9 @@ export async function createImage({
     });
   }
 
-  await userImageVideoCountCache.refresh(image.userId);
+  // No count refresh here: a new image is Pending and unpublished, so it does not
+  // yet satisfy the count predicate. The count is refreshed once it qualifies —
+  // on publish (post.service) and on scan completion (image-scan-result.service).
 
   return result;
 }

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -5770,9 +5770,10 @@ export async function createImage({
     });
   }
 
-  // No count refresh here: a new image is Pending and unpublished, so it does not
-  // yet satisfy the count predicate. The count is refreshed once it qualifies —
-  // on publish (post.service) and on scan completion (image-scan-result.service).
+  // No count refresh here: a new image is Pending and unpublished, so it cannot
+  // satisfy the count predicate yet, and caching that zero pins it for the TTL.
+  // The count is updated on the transitions that make an image countable —
+  // publish and scan completion.
 
   return result;
 }

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -20,6 +20,7 @@ import {
   thumbnailCache,
   imageMetadataCache,
   userBasicCache,
+  userImageVideoCountCaches,
   userPostCountCache,
 } from '~/server/redis/caches';
 import type { GetByIdInput } from '~/server/schema/base.schema';
@@ -950,6 +951,7 @@ export const updatePost = async ({
         action: SearchIndexUpdateQueueAction.Update,
       });
     }
+    await userImageVideoCountCaches.refresh(post.userId);
   }
 
   return post;


### PR DESCRIPTION
## Problem

`/user/<name>/images` showed **Images: 0** for users who clearly had images (reported for `NekoInNight`, user 2717887). The cache was not failing to bust — it busted and immediately re-primed itself with a wrong `0`.

Profile tab counts come from `trpc.userProfile.overview` → `userImageVideoCountCache` (`src/server/redis/caches.ts`), a live Postgres `COUNT` wrapped in Redis at 24h freshness / 48h physical (`staleWhileRevalidate` defaults true → `ttl*2`). The count query requires:

```sql
AND "ingestion" = 'Scanned'
AND "postId" NOT IN (SELECT id FROM "Post" WHERE "publishedAt" IS NULL OR availability = 'Private' OR "publishedAt" > NOW())
```

`createImage` fired the refresh synchronously right after `await ingestImage(...)` — which only **enqueues** an async scan (it submits a workflow / posts to `/enqueue` and checks for HTTP 202 Accepted; the `// wait: true` sync flag is commented out, and results arrive later via the `callbackUrl` webhook). So the refresh re-queried while the image was still `Pending` and its post unpublished, counted 0, and cached it.

Exact prod timeline for the reported user:

| Time (UTC) | Event |
|---|---|
| 19:01:02 – 19:01:38 | 12 images created (`ingestion='Pending'`) |
| **19:01:39.218** | **cache written → `imageCount: 0`** |
| 19:01:19 – 19:02:05 | scans complete → `Scanned` |
| 19:05:12 | post 29800935 published |

The refresh lands in the gap. Worse than not busting at all: without it the key would have aged out and self-healed. Because every upload rewrote `cachedAt`, an active uploader reset the 24h clock indefinitely — the count never recovered.

## Fix

Update the count only where an image actually becomes countable:

- **`post.service.ts` `updatePost`** — eager `refresh` inside the existing `publishedAtWritten` guard. One event per post, `userId` in hand.
- **`process-scheduled-publishing.ts`** — publishes via raw SQL rather than `updatePost`, so it owns its own refresh; bulk, deduped by `userId`.
- **`image-scan-result.service.ts` + `webhooks/image-scan-result.ts`** — scan completion uses the cheap `bust`. Fires once per image, so a re-query here would be N identical counts for an N-image post.
- **`image.service.ts` `createImage`** — premature refresh removed.

Both orderings converge: publish-then-scan is caught by the scan bust; scan-then-publish by the publish refresh.

All three browsing-level variants now move together via a new `userImageVideoCountCaches` helper. The variants themselves are pre-existing; the bug was that the image path reached past them and called single-variant `userImageVideoCountCache.refresh` directly, so `sfw` and `public` — what green-domain and anonymous visitors read — were never busted from the image path at all.

## Fixed in review (second commit)

Two defects caught by adversarial review, both of which this branch would have introduced:

1. **`userImageVideoCountPublicCache` hardcoded `dbRead`**, dropping the `fromWrite` parameter its `all`/`sfw` siblings honor. `refresh` calls `lookupFn(ids, true)` specifically to read the primary — so the new publish-path refresh would have counted against a lagging replica and pinned a pre-publish count for the full TTL, reproducing this exact bug on the variant anonymous visitors read. (`preventReplicationLag` does not help: it only flags Redis for lag-aware readers, and the cache lookupFn never consults `getDbWithoutLag`.)
2. **`bust` could throw and fail the scan webhook.** `bust` resolves to `invalidate`, whose cluster read is unguarded — `refresh` has its own catch, `invalidate` does not. On the per-image scan path a Redis stall would have failed the callback and triggered scanner redelivery against an already-committed row. Now `allSettled`.

## Verification

- `pnpm typecheck` — clean (exit 0).
- `vitest run` on `cache-helpers*` — 16 passed.
- Confirmed the poisoned state in prod Redis (all three variants held `imageCount: 0`) and decoded the msgpack `cachedAt` to establish the timeline above.
- Expected values for user 2717887 after the post-deploy purge:

| variant | imageCount | videoCount | cached before fix |
|---|---|---|---|
| `all` | 8 | 43 | 0 / 45 |
| `sfw` | 8 | 3 | 0 / 3 |
| `public` | 4 | 1 | 0 / 1 |

Not covered by an automated test — reproducing it needs Redis plus the async scanner. The behavioural check is the table above after the purge.

## Post-deploy step

Existing poisoned keys survive the deploy with up to 48h TTL, so the fix is invisible for already-affected users until purged:

```
packed:caches:overview-users:imageVideoCount*
```

## Known gaps (follow-up)

All are **pre-existing and unchanged by this PR** — `main` is equally stale on every one. They share a property that made them safe to defer: nothing on these paths writes a fresh `cachedAt`, so unlike the bug above they self-heal at TTL, and heal early on the user's next scanned image (the bust is per-user, not per-image).

- **Publish fan-outs that bypass `updatePost`**: `publishModelVersionById` (`model-version.service.ts:1246`), `publishModelById` (`model.service.ts:2251`), bulk/republish (`model.service.ts:3889`), collection publish (`collection.service.ts:927`). Model gallery images are the largest source, so this is the highest-value follow-up.
- **`handleUnblockImages`** (`image.service.ts:530`) — a third writer of `ingestion='Scanned'`; also clears `needsReview`, so it is the true transition *into* the predicate for reviewed images.
- **Delete / block / unpublish** — `deleteImageById`, `deleteImages`, `deletePost`, `handleBlockImages`, and the unpublish fan-outs. These leave the count stale *high*; note the overview count is a bare integer next to a grid served by `getInfiniteImages`, so no deleted content is exposed — the number just disagrees.
- **`userPostCountCache.refresh`** (`post.service.ts`) still refreshes only the `all` variant, so postCount has the same single-variant gap imageCount just lost.
- **`userModelCountPublicCache`, `userPostCountPublicCache`, `userModel3DCountPublicCache`** and the other `*PublicCache` lookupFns share the hardcoded-`dbRead` defect fixed here for images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
