### PR TITLE
feat(app-blocks): add host-side SHARED_UPDATE bridge handler

### DIFF
--- a/src/components/AppBlocks/IframeHost.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHost.browser.test.tsx
@@ -40,6 +40,7 @@ vi.mock('~/utils/trpc', () => ({
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -1298,6 +1298,7 @@ export function IframeHost({
   // server enforces scope + flag + trust gate (resolveSharedContext). Every reply
   // carries the same requestId on success AND error so the block never hangs.
   const sharedAppendMutation = trpc.apps.shared.append.useMutation();
+  const sharedUpdateMutation = trpc.apps.shared.update.useMutation();
   const sharedVoteMutation = trpc.apps.shared.vote.useMutation();
   const sharedUnvoteMutation = trpc.apps.shared.unvote.useMutation();
   const sharedWithdrawMutation = trpc.apps.shared.withdraw.useMutation();
@@ -1413,6 +1414,39 @@ export function IframeHost({
     );
     return off;
   }, [onMessage, send, token, sharedAppendMutation]);
+
+  // SHARED_UPDATE → apps.shared.update → SHARED_UPDATE_RESULT (author-scoped
+  // in-place edit; #3146). Reply is `{ ok, error? }` (SHARED_WITHDRAW-style, NOT
+  // SHARED_APPEND's `{ key }`) — the SDK 0.24 hook rejects on `!ok || error` and
+  // its isValidSharedUpdateResult REQUIRES a boolean `ok`, so BOTH paths send one
+  // (the error path MUST carry `ok: false` or the reply is dropped → block hangs).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown; value?: unknown } | undefined>(
+      'SHARED_UPDATE',
+      async (raw) => {
+        if (
+          !raw ||
+          typeof raw.requestId !== 'string' ||
+          typeof raw.key !== 'string' ||
+          typeof raw.value !== 'object' ||
+          raw.value === null
+        )
+          return;
+        const requestId = raw.requestId;
+        try {
+          await sharedUpdateMutation.mutateAsync({
+            blockToken: token,
+            key: raw.key,
+            value: raw.value as { title: string; body?: string },
+          });
+          send('SHARED_UPDATE_RESULT', { requestId, ok: true });
+        } catch (err) {
+          send('SHARED_UPDATE_RESULT', { requestId, ok: false, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedUpdateMutation]);
 
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -36,6 +36,7 @@ vi.mock('~/utils/trpc', () => ({
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -1154,6 +1154,7 @@ export function PageBlockHost({
   // token means the block never rendered a usable surface, so the request is
   // dropped without replying (the mint path surfaces no_token/error above).
   const sharedAppendMutation = trpc.apps.shared.append.useMutation();
+  const sharedUpdateMutation = trpc.apps.shared.update.useMutation();
   const sharedVoteMutation = trpc.apps.shared.vote.useMutation();
   const sharedUnvoteMutation = trpc.apps.shared.unvote.useMutation();
   const sharedWithdrawMutation = trpc.apps.shared.withdraw.useMutation();
@@ -1279,6 +1280,44 @@ export function PageBlockHost({
     );
     return off;
   }, [onMessage, send, token, sharedAppendMutation]);
+
+  // SHARED_UPDATE → apps.shared.update → SHARED_UPDATE_RESULT (mutation).
+  // Author-scoped in-place edit of an OWN row: the auth/author-gate/belt/quota all
+  // live in apps.shared.update (server, #3146); the host only forwards {key, value}
+  // and relays the result. Reply is `{ ok, error? }` (SHARED_WITHDRAW-style, NOT
+  // SHARED_APPEND's `{ key }`) — the SDK 0.24 hook treats `!ok || error` as reject,
+  // and its isValidSharedUpdateResult REQUIRES a boolean `ok`, so BOTH paths send
+  // one (the error path MUST carry `ok: false` or the reply is dropped → hang).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown; value?: unknown } | undefined>(
+      'SHARED_UPDATE',
+      async (raw) => {
+        if (
+          !raw ||
+          typeof raw.requestId !== 'string' ||
+          typeof raw.key !== 'string' ||
+          typeof raw.value !== 'object' ||
+          raw.value === null ||
+          !token
+        )
+          return;
+        const requestId = raw.requestId;
+        try {
+          // Server zod-validates {title, body?}; a malformed value rejects
+          // BAD_REQUEST → the error path below (never a hang).
+          await sharedUpdateMutation.mutateAsync({
+            blockToken: token,
+            key: raw.key,
+            value: raw.value as { title: string; body?: string },
+          });
+          send('SHARED_UPDATE_RESULT', { requestId, ok: true });
+        } catch (err) {
+          send('SHARED_UPDATE_RESULT', { requestId, ok: false, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedUpdateMutation]);
 
   // SHARED_VOTE → apps.shared.vote → SHARED_VOTE_RESULT (mutation).
   useEffect(() => {

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -60,6 +60,7 @@ vi.mock('~/utils/trpc', () => ({
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
@@ -48,6 +48,7 @@ vi.mock('~/utils/trpc', () => ({
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -61,6 +61,7 @@ vi.mock('~/utils/trpc', () => ({
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -58,6 +58,7 @@ vi.mock('~/utils/trpc', () => ({
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
@@ -42,6 +42,7 @@ const mocks = vi.hoisted(() => ({
   getCounts: vi.fn(),
   // shared writes
   append: vi.fn(),
+  update: vi.fn(),
   vote: vi.fn(),
   unvote: vi.fn(),
   withdraw: vi.fn(),
@@ -80,6 +81,7 @@ vi.mock('~/utils/trpc', () => ({
       },
       shared: {
         append: { useMutation: () => ({ mutateAsync: mocks.append }) },
+        update: { useMutation: () => ({ mutateAsync: mocks.update }) },
         vote: { useMutation: () => ({ mutateAsync: mocks.vote }) },
         unvote: { useMutation: () => ({ mutateAsync: mocks.unvote }) },
         withdraw: { useMutation: () => ({ mutateAsync: mocks.withdraw }) },
@@ -179,6 +181,7 @@ describe('PageBlockHost SHARED storage bridge (Phase 2b cross-user datastore)', 
     mocks.getCount.mockReset();
     mocks.getCounts.mockReset();
     mocks.append.mockReset();
+    mocks.update.mockReset();
     mocks.vote.mockReset();
     mocks.unvote.mockReset();
     mocks.withdraw.mockReset();
@@ -381,6 +384,62 @@ describe('PageBlockHost SHARED storage bridge (Phase 2b cross-user datastore)', 
       expect(r.payload).toEqual({
         requestId: 'rq_app_err',
         error: 'Too many submissions — retry in 30s',
+      });
+    });
+    replies.stop();
+  });
+
+  // ── SHARED_UPDATE ────────────────────────────────────────────────────────────
+  test('SHARED_UPDATE forwards key + value + host token and posts SHARED_UPDATE_RESULT {ok:true}', async () => {
+    mocks.update.mockResolvedValue({ ok: true });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_UPDATE', {
+      requestId: 'rq_upd',
+      key: '01EXISTING',
+      value: { title: 'Edited idea', body: 'new details' },
+      blockToken: 'SPOOFED',
+    });
+
+    await vi.waitFor(() => {
+      // Host token wins over any client-supplied blockToken.
+      expect(mocks.update).toHaveBeenCalledWith({
+        blockToken: 'tok_abc',
+        key: '01EXISTING',
+        value: { title: 'Edited idea', body: 'new details' },
+      });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_UPDATE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      // SDK 0.24 contract: { requestId, ok, error? } — resolves on ok.
+      expect(r.payload).toEqual({ requestId: 'rq_upd', ok: true });
+    });
+    replies.stop();
+  });
+
+  test('SHARED_UPDATE error path posts { requestId, ok:false, error } (no hang)', async () => {
+    mocks.update.mockRejectedValue(new Error('you can only edit your own submissions'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_UPDATE', {
+      requestId: 'rq_upd_err',
+      key: '01EXISTING',
+      value: { title: 'nope' },
+    });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_UPDATE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      // ok:false is REQUIRED — the SDK validator drops a reply without a boolean ok.
+      expect(r.payload).toEqual({
+        requestId: 'rq_upd_err',
+        ok: false,
+        error: 'you can only edit your own submissions',
       });
     });
     replies.stop();

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -47,6 +47,7 @@ vi.mock('~/utils/trpc', () => ({
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
@@ -66,6 +66,7 @@ vi.mock('~/utils/trpc', () => ({
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
@@ -49,6 +49,7 @@ vi.mock('~/utils/trpc', () => ({
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -67,6 +67,7 @@ vi.mock('~/utils/trpc', () => ({
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -355,6 +355,20 @@ export const INVENTORY = {
     PageBlockHost: 'required',
     InlineHost: INLINE_STUB,
   },
+  // Author-scoped in-place edit of an OWN shared_kv row (the sibling of
+  // SHARED_APPEND's INSERT-only write; fixes "editing creates a new one"). Same
+  // REQUEST-style hang class + same host placement as SHARED_APPEND — the shared
+  // datastore is a per-APP surface a model-slot block can also edit, so BOTH real
+  // hosts wire it. Reply is the SHARED_WITHDRAW-style `{ ok, error? }` (NOT
+  // SHARED_APPEND's `{ key }`): the SDK's isValidSharedUpdateResult REQUIRES a
+  // boolean `ok`, so the error reply MUST carry `ok: false` or it's dropped.
+  SHARED_UPDATE: {
+    request: true,
+    reply: 'SHARED_UPDATE_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
   SHARED_VOTE: {
     request: true,
     reply: 'SHARED_VOTE_RESULT',


### PR DESCRIPTION
## Problem

PR #3146 added the `apps.shared.update` tRPC op (author-scoped in-place edit of a shared-storage row) and the SDK (blocks-react 0.24) added `useSharedStorage().update()`, which posts a `SHARED_UPDATE` postMessage and awaits `SHARED_UPDATE_RESULT`. But the **host had no handler** for `SHARED_UPDATE`, so the message was dropped and the block's `update()` hung to its SDK request timeout (the gotcha-#73 "spins forever, no network call" class).

## Change

Wire `SHARED_UPDATE` into all three host-parity surfaces, mirroring the existing `SHARED_APPEND` handler:

1. **`hostHandlerParity.ts`** — register `SHARED_UPDATE` (`reply: 'SHARED_UPDATE_RESULT'`, `required` on both real hosts). The parity guard test now enforces a registered handler on both hosts.
2. **`PageBlockHost.tsx`** — `SHARED_UPDATE` → `apps.shared.update.mutate({ key, value })` → relay result. Added `trpc.apps.shared.update.useMutation()`.
3. **`IframeHost.tsx`** — same handler + mutation hook (parity with SHARED_APPEND, which exists in both hosts).

## Contract

Reply matches the **SDK 0.24 `SHARED_UPDATE_RESULT` contract `{ requestId, ok: boolean, error? }`** (verified against the published `@civitai/blocks-react@0.24.0` — `useSharedStorage().update` rejects on `!ok || error`, and `isValidSharedUpdateResult` requires a **boolean `ok`**). This is the `SHARED_WITHDRAW`-style ok/error convention, **not** `SHARED_APPEND`'s `{ key }`. Both paths send a boolean `ok`:
- success → `{ requestId, ok: true }`
- error → `{ requestId, ok: false, error: storageErrorMessage(err) }` (the `ok: false` is required — an error reply without it would be dropped by the SDK validator and still hang the block).

Pure wiring — the auth / author-gate / content-belt / quota all live server-side in `apps.shared.update` (#3146); the host just forwards `{ key, value }` and relays the result, exactly like `SHARED_APPEND`.

## Tests

- `SHARED_UPDATE` success + error host tests mirror the `SHARED_APPEND` tests (forwards `{ key, value }` + host token, host token wins over spoofed `blockToken`; error path posts `{ ok: false, error }`).
- Parity guard now covers `SHARED_UPDATE` on both hosts (106 unit assertions pass).
- Sibling AppBlocks host tests get the `apps.shared.update` mock stub so their mounts still succeed.

Verified locally: parity unit test (106 pass), `PageBlockHostSharedStorage.browser.test.tsx` (18 pass, +2 new), `IframeHost.browser.test.tsx` (5 pass). `tsc --noEmit` clean on all touched files (the 43 pre-existing errors are all in unrelated db-schema/challenge/image files, present on `main`).

> Unblocks edit-in-place end-to-end once merged + deployed alongside #3146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)