### PR TITLE
feat(generation): add Reve ecosystem (Reve 2.1)

### DIFF
--- a/docs/reve-2.1-model-update.md
+++ b/docs/reve-2.1-model-update.md
@@ -1,0 +1,71 @@
+# Reve 2.1 — Model version baseModel + description update
+
+Data updates for the mirrored **Reve** model on the `CivitaiOfficial` account. These
+are plain `UPDATE`s against existing rows (not a Prisma migration) and must be
+**applied manually** to each target environment (preview / staging / prod) — we do
+not run `prisma migrate deploy`.
+
+## Target rows (confirmed on the replica)
+
+| Field               | Value                                                                               |
+| ------------------- | ----------------------------------------------------------------------------------- |
+| ModelVersion id     | `3133202` (version name `v2.1`)                                                     |
+| Current `baseModel` | `SD 1.5` (placeholder) → **`Reve`**                                                 |
+| Model id            | `2781889` (name `Reve`, type `Checkpoint`, owner `CivitaiOfficial`, status `Draft`) |
+
+`Reve` matches the new `BaseModelRecord.name` added in
+[basemodel.constants.ts](../src/shared/constants/basemodel.constants.ts), so the
+version resolves to the new `Reve` ecosystem once this branch ships. The base-model
+name is intentionally the generic brand (not `Reve 2.1`) so a future **Reve 2.2**
+is just another `ModelVersion` under the same ecosystem — mirroring HappyHorse
+(one `HappyHorse` base model, multiple versions selected in the graph).
+
+> Apply the code change (this branch) and the SQL together. The `baseModel` string
+> only resolves to a real ecosystem after the constants change is deployed.
+
+## 1. ModelVersion.baseModel
+
+```sql
+UPDATE "ModelVersion"
+SET "baseModel" = 'Reve'
+WHERE id = 3133202;
+```
+
+## 2. Model.description
+
+Dollar-quoted (`$md$…$md$`) so the HTML's single/double quotes need no escaping.
+
+```sql
+UPDATE "Model"
+SET description = $md$<h2>Reve 2.1</h2>
+<p><strong>Reve 2.1</strong> is a controllable text-to-image generation and editing model from <a href="https://reve.com" rel="noopener nofollow" target="_blank">Reve AI</a>, an independent foundation-model lab. It is built on the idea that images should be composed like code — as hierarchical, structured regions — so that layout and control are core to the model rather than an afterthought.</p>
+<h3>Highlights</h3>
+<ul>
+<li><strong>Native 4K output.</strong> Renders dense scenes, fine text, and intricate structure directly at 4K (16&nbsp;megapixels), preserving detail through iterative refinement.</li>
+<li><strong>Layout planning.</strong> Reasons about structure, hierarchy, and spatial relationships before rendering, so it holds up on complicated, densely populated scenes.</li>
+<li><strong>Editability.</strong> Every element is addressable — a single region can be changed and re-rendered without redoing the whole image.</li>
+<li><strong>Multilingual text.</strong> Renders legible typography, including foreign scripts embedded directly in the image.</li>
+</ul>
+<p>Reve 2.1 ranks as a top 4K model on the Arena and Design Arena leaderboards while using a fraction of the compute of comparably ranked models.</p>
+<p><em>Model and imagery are the property of Reve AI, Inc. Learn more in the <a href="https://blog.reve.com/posts/launching-reve-2.1/" rel="noopener nofollow" target="_blank">Reve 2.1 launch announcement</a>. Use is subject to the <a href="https://app.reve.com/terms" rel="noopener nofollow" target="_blank">Reve AI Terms of Service</a>.</em></p>$md$
+WHERE id = 2781889;
+```
+
+## Verify
+
+```sql
+SELECT mv.id AS version_id, mv."baseModel", m.id AS model_id, left(m.description, 60) AS desc_preview
+FROM "ModelVersion" mv
+JOIN "Model" m ON m.id = mv."modelId"
+WHERE mv.id = 3133202;
+```
+
+Expect `baseModel = 'Reve'` and the description preview starting with `<h2>Reve 2.1</h2>`.
+
+## Notes
+
+- **License URL** on the new license record (`id 38`, `Reve AI Terms of Service`) is
+  `https://app.reve.com/terms` — confirm this resolves for your Reve account; adjust
+  the constant + the description link if Reve publishes a different canonical terms URL.
+- The description credits Reve AI and links the launch post per our mirrored-model
+  convention (the model lives on `CivitaiOfficial`).

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@civitai/app-sdk": "^0.14.0",
     "@civitai/auth": "workspace:*",
     "@civitai/buzz": "workspace:*",
-    "@civitai/client": "0.2.0-beta.80",
+    "@civitai/client": "0.2.0-beta.81",
     "@civitai/cybertipline-tools": "^0.1.0",
     "@civitai/next-axiom": "^0.17.0",
     "@clavata/sdk": "^0.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,8 +38,8 @@ importers:
         specifier: workspace:*
         version: link:packages/civitai-buzz
       '@civitai/client':
-        specifier: 0.2.0-beta.80
-        version: 0.2.0-beta.80
+        specifier: 0.2.0-beta.81
+        version: 0.2.0-beta.81
       '@civitai/cybertipline-tools':
         specifier: ^0.1.0
         version: 0.1.0
@@ -1712,8 +1712,8 @@ packages:
     resolution: {integrity: sha512-dSXkI8hVoozzlPS9DymzoyncWz8eapH3wkSDzDVGWjjqamXn8Dbcq1hWu5xUZkZmqCaR76F7BS9BQNqvOJ++Sw==}
     engines: {git: '>=2.11.0', node: '>=18.0.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
 
-  '@civitai/client@0.2.0-beta.80':
-    resolution: {integrity: sha512-ybiAFk8TtwrULTwEhQPEfhWTtK7T90YUX/tBJ/t53PLisWWWJPuwC8Ux9A1P+WYhTGMQHg84utpYbQtlm41qUA==}
+  '@civitai/client@0.2.0-beta.81':
+    resolution: {integrity: sha512-vWb5PaoG7FbMPHa3s0fGpy+hX9y0kNwpEbDeisOhgNCkFlM5Oqache7h3eClRhF0+Ypxhpyt1Nic6Bt0Epxw6Q==}
     engines: {git: '>=2.11.0', node: '>=18.0.0', npm: '>=7.19.0', yarn: '>=1.7.0'}
 
   '@civitai/cybertipline-tools@0.1.0':
@@ -12815,7 +12815,7 @@ snapshots:
       rfc6902: 5.2.0
       tslib: 2.8.1
 
-  '@civitai/client@0.2.0-beta.80':
+  '@civitai/client@0.2.0-beta.81':
     dependencies:
       '@hey-api/client-fetch': 0.1.14
       rfc6902: 5.2.0

--- a/src/server/services/orchestrator/ecosystems/index.ts
+++ b/src/server/services/orchestrator/ecosystems/index.ts
@@ -46,6 +46,7 @@ import { createErnieInput } from './ernie.handler';
 import { createLensInput } from './lens.handler';
 import { createKrea2Input } from './krea2.handler';
 import { createMAIInput } from './mai.handler';
+import { createReveInput } from './reve.handler';
 import { createZImageInput } from './z-image.handler';
 import { createBooguInput } from './boogu.handler';
 import { createHiDreamInput } from './hi-dream.handler';
@@ -161,6 +162,9 @@ export type Krea2Ctx = EcosystemGraphOutput & { ecosystem: 'Krea2' };
 /** MAI context */
 export type MAICtx = EcosystemGraphOutput & { ecosystem: 'MAI' };
 
+/** Reve context */
+export type ReveCtx = EcosystemGraphOutput & { ecosystem: 'Reve' };
+
 /** Wan video ecosystems context */
 export type WanCtx = EcosystemGraphOutput & {
   ecosystem:
@@ -235,6 +239,7 @@ export { createErnieInput } from './ernie.handler';
 export { createLensInput } from './lens.handler';
 export { createKrea2Input } from './krea2.handler';
 export { createMAIInput } from './mai.handler';
+export { createReveInput } from './reve.handler';
 
 // Audio ecosystems
 export { createAceAudioInput } from './ace-audio.handler';
@@ -418,6 +423,10 @@ async function createEcosystemStep(
     // MAI (Microsoft MAI-Image-2.5, FAL engine)
     case 'MAI':
       return createMAIInput(normalizedData, handlerCtx);
+
+    // Reve (Reve AI, FAL engine)
+    case 'Reve':
+      return createReveInput(normalizedData, handlerCtx);
 
     // =========================================================================
     // Video Ecosystems - videoGen step type

--- a/src/server/services/orchestrator/ecosystems/reve.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/reve.handler.ts
@@ -1,0 +1,67 @@
+/**
+ * Reve Ecosystem Handler
+ *
+ * Handles Reve workflows using imageGen step type (FAL engine).
+ * Uses Reve AI's Reve 2.1 model. Model is locked, no LoRA support.
+ *
+ * Routes by workflow:
+ * - txt2img: text-to-image (createImage / ReveCreateFalImageGenInput)
+ * - img2img:edit: reference-frame editing (editImage / ReveEditFalImageGenInput)
+ */
+
+import type {
+  ImageGenStepTemplate,
+  ReveCreateFalImageGenInput,
+  ReveEditFalImageGenInput,
+} from '@civitai/client';
+import { removeEmpty } from '~/utils/object-helpers';
+import type { GenerationGraphTypes } from '~/shared/data-graph/generation/generation-graph';
+import { defineHandler } from './handler-factory';
+
+type EcosystemGraphOutput = Extract<GenerationGraphTypes['Ctx'], { ecosystem: string }>;
+type ReveCtx = EcosystemGraphOutput & { ecosystem: 'Reve' };
+
+type ReveAspectRatio = NonNullable<ReveCreateFalImageGenInput['aspectRatio']>;
+
+/**
+ * Creates imageGen input for the Reve ecosystem.
+ * Routes to createImage (txt2img) or editImage (img2img:edit) based on workflow.
+ */
+export const createReveInput = defineHandler<ReveCtx, [ImageGenStepTemplate]>((data) => {
+  const quantity = data.quantity ?? 1;
+
+  const baseInput = {
+    engine: 'fal' as const,
+    model: 'reve' as const,
+    prompt: data.prompt,
+    quantity,
+  };
+
+  // img2img:edit — reference-frame editing. Reve derives the output ratio from
+  // the reference frames, so no aspect-ratio picker is shown ('auto').
+  if (!data.workflow.startsWith('txt')) {
+    return [
+      {
+        $type: 'imageGen',
+        input: removeEmpty({
+          ...baseInput,
+          operation: 'editImage',
+          aspectRatio: 'auto',
+          images: data.images?.map((x) => x.url) ?? [],
+        }) as ReveEditFalImageGenInput,
+      },
+    ];
+  }
+
+  // txt2img — text-to-image
+  return [
+    {
+      $type: 'imageGen',
+      input: removeEmpty({
+        ...baseInput,
+        operation: 'createImage',
+        aspectRatio: data.aspectRatio?.value as ReveAspectRatio | undefined,
+      }) as ReveCreateFalImageGenInput,
+    },
+  ];
+});

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -216,6 +216,9 @@ export const ECO = {
   // Boogu
   Boogu: 74,
 
+  // Reve AI
+  Reve: 77,
+
   // Child ecosystems of SDXL
   Pony: 100,
   Illustrious: 101,
@@ -643,6 +646,15 @@ export const ecosystems: EcosystemRecord[] = [
     sortOrder: 180,
   },
 
+  // Reve AI Family (familyId: 24)
+  {
+    id: ECO.Reve,
+    key: 'Reve',
+    displayName: 'Reve',
+    familyId: 24,
+    sortOrder: 190,
+  },
+
   // HiDream Family (familyId: 19)
   {
     id: ECO.HiDream,
@@ -1016,6 +1028,9 @@ export const ecosystemSupport: EcosystemSupport[] = [
 
   // MAI - checkpoint only (Microsoft MAI-Image-2.5, locked, no LoRA support)
   { ecosystemId: ECO.MAI, supportType: 'generation', modelTypes: checkpointOnly },
+
+  // Reve - checkpoint only (Reve 2.1, locked, FAL engine, no LoRA support)
+  { ecosystemId: ECO.Reve, supportType: 'generation', modelTypes: checkpointOnly },
 
   // Lens - checkpoint and LORA (Civitai-internal, normal + turbo variants)
   { ecosystemId: ECO.Lens, supportType: 'generation', modelTypes: checkpointAndLora },
@@ -1509,6 +1524,13 @@ export const ecosystemSettings: EcosystemSettings[] = [
       modelLocked: true,
     },
   },
+  {
+    ecosystemId: ECO.Reve,
+    defaults: {
+      model: { id: 3133202 },
+      modelLocked: true,
+    },
+  },
 ];
 
 // =============================================================================
@@ -1974,6 +1996,7 @@ export const BM = {
   PolyGen: 92,
   Tripo: 94,
   Hunyuan3D: 95,
+  Reve: 96,
 } as const;
 
 // Guard against duplicate ids — `baseModelById` is keyed by id, so collisions
@@ -2233,6 +2256,11 @@ export const licenses: LicenseRecord[] = [
     disableMature: true,
     nonCommercial: true,
   },
+  {
+    id: 38,
+    name: 'Reve AI Terms of Service',
+    url: 'https://app.reve.com/terms',
+  },
 ];
 
 export const licenseById = new Map(licenses.map((l) => [l.id, l]));
@@ -2356,6 +2384,11 @@ export const ecosystemFamilies: BaseModelFamilyRecord[] = [
     id: 23,
     name: 'Boogu',
     description: "Boogu's unified multimodal image generation and editing models",
+  },
+  {
+    id: 24,
+    name: 'Reve AI',
+    description: "Reve AI's controllable 4K text-to-image generation and editing models",
   },
 ];
 
@@ -3010,6 +3043,16 @@ export const baseModelRecords: BaseModelRecord[] = [
     ecosystemId: ECO.SDXLDistilled,
     hidden: true,
     licenseId: 3,
+  },
+
+  // Reve
+  {
+    id: BM.Reve,
+    name: 'Reve',
+    description: "Reve AI's controllable 4K text-to-image generation and editing model",
+    type: 'image',
+    ecosystemId: ECO.Reve,
+    licenseId: 38,
   },
 
   // Seedream

--- a/src/shared/data-graph/generation/config/workflows.ts
+++ b/src/shared/data-graph/generation/config/workflows.ts
@@ -65,6 +65,7 @@ const EDIT_IMG_IDS = [
   ECO.HiDreamO1,
   ECO.MAI,
   ECO.Boogu,
+  ECO.Reve,
 ];
 
 /** Image ecosystems that support image:create */
@@ -105,6 +106,7 @@ const TXT2IMG_IDS = [
   ECO.Krea2,
   ECO.MAI,
   ECO.Boogu,
+  ECO.Reve,
 ];
 
 /** Video ecosystems that support video:create */

--- a/src/shared/data-graph/generation/ecosystem-graph.ts
+++ b/src/shared/data-graph/generation/ecosystem-graph.ts
@@ -70,6 +70,7 @@ import { ernieGraph } from './ernie-graph';
 import { lensGraph } from './lens-graph';
 import { krea2Graph } from './krea2-graph';
 import { maiGraph } from './mai-graph';
+import { reveGraph } from './reve-graph';
 import { seedanceGraph } from './seedance-graph';
 import { happyHorseGraph } from './happy-horse-graph';
 import { aceAudioGraph } from './ace-audio-graph';
@@ -385,6 +386,7 @@ export const ecosystemGraph = new DataGraph<
     { values: ['Lens'] as const, graph: lensGraph },
     { values: ['Krea2'] as const, graph: krea2Graph },
     { values: ['MAI'] as const, graph: maiGraph },
+    { values: ['Reve'] as const, graph: reveGraph },
     { values: ['OpenAI'] as const, graph: openaiGraph },
     // Video ecosystems - Wan family (ONE type branch for all Wan variants)
     {

--- a/src/shared/data-graph/generation/reve-graph.ts
+++ b/src/shared/data-graph/generation/reve-graph.ts
@@ -1,0 +1,104 @@
+/**
+ * Reve Family Graph
+ *
+ * Controls for the Reve ecosystem (Reve 2.1, FAL engine).
+ * Model is locked; no LoRA support.
+ *
+ * Controls per ReveFalImageGenInput:
+ * - aspectRatio: fixed ratios (21:9, 16:9, 3:2, 4:3, 5:4, 1:1, 4:5, 3:4, 2:3, 9:16)
+ *
+ * No negative prompt, no cfgScale, no steps. A seed control is exposed for form
+ * consistency, but the orchestrator input type does not currently accept a seed,
+ * so it is not forwarded by the handler.
+ *
+ * Supports two workflows:
+ * - txt2img: text-to-image (ReveCreateFalImageGenInput)
+ * - img2img:edit: reference-image editing (ReveEditFalImageGenInput). Reve accepts
+ *   multiple reference frames, addressed from the prompt as <frame>N</frame>.
+ */
+
+import { DataGraph } from '~/libs/data-graph/data-graph';
+import type { GenerationCtx } from './context';
+import {
+  aspectRatioNode,
+  createCheckpointGraph,
+  imagesNode,
+  promptGraph,
+  seedNode,
+  snippetsGraph,
+  triggerWordsGraph,
+} from './common';
+
+// =============================================================================
+// Version Constants
+// =============================================================================
+
+/** Reve 2.1 model version ID */
+export const reveVersionId = 3133202;
+
+// =============================================================================
+// Aspect Ratios
+// =============================================================================
+
+/** Reve aspect ratios (subset of ReveFalImageGenInput.aspectRatio; dims at native ~4K). */
+const reveAspectRatios = [
+  { label: '21:9', value: '21:9', width: 4096, height: 1755 },
+  { label: '16:9', value: '16:9', width: 4096, height: 2304 },
+  { label: '3:2', value: '3:2', width: 4096, height: 2731 },
+  { label: '4:3', value: '4:3', width: 4096, height: 3072 },
+  { label: '5:4', value: '5:4', width: 4096, height: 3277 },
+  { label: '1:1', value: '1:1', width: 4096, height: 4096 },
+  { label: '4:5', value: '4:5', width: 3277, height: 4096 },
+  { label: '3:4', value: '3:4', width: 3072, height: 4096 },
+  { label: '2:3', value: '2:3', width: 2731, height: 4096 },
+  { label: '9:16', value: '9:16', width: 2304, height: 4096 },
+];
+
+/** Standard preferred ratios shown before the "More" overflow. */
+const revePriorityRatios = ['16:9', '4:3', '1:1', '3:4', '9:16'];
+
+// =============================================================================
+// Reve Graph
+// =============================================================================
+
+/**
+ * Reve family controls. Model is locked to the single Reve 2.1 version, no
+ * LoRAs, samplers, CFG scale, steps, or CLIP skip.
+ */
+export const reveGraph = new DataGraph<{ ecosystem: string; workflow: string }, GenerationCtx>()
+  .merge(
+    () =>
+      createCheckpointGraph({
+        modelLocked: true,
+        defaultModelId: reveVersionId,
+      }),
+    []
+  )
+  .merge(triggerWordsGraph)
+  .merge(snippetsGraph)
+  .merge(promptGraph)
+  // Aspect ratio picker — shown only for txt2img. For img2img:edit the output
+  // ratio is derived by Reve from the reference frames (aspectRatio: 'auto').
+  .node(
+    'aspectRatio',
+    (ctx) => ({
+      ...aspectRatioNode({
+        options: reveAspectRatios,
+        defaultValue: '1:1',
+        priorityOptions: revePriorityRatios,
+      }),
+      when: ctx.workflow.startsWith('txt'),
+    }),
+    ['workflow']
+  )
+  // Reference frames — shown only for img2img:edit, hidden for txt2img. Reve
+  // supports multiple frames, addressed from the prompt as <frame>N</frame>.
+  .node(
+    'images',
+    (ctx) => ({
+      ...imagesNode({ min: 1, max: 4 }),
+      when: !ctx.workflow.startsWith('txt'),
+    }),
+    ['workflow']
+  )
+  .node('seed', seedNode());


### PR DESCRIPTION
Add the Reve AI ecosystem with generation support for text-to-image (createImage) and reference-frame editing (editImage) via the FAL engine, modeled on the MAI create/edit handler.

- basemodel.constants: ECO.Reve/BM.Reve, Reve AI family + Terms license, ecosystem/base-model records, checkpoint-only support, locked default (v3133202). Base model name is the generic brand "Reve" so future Reve versions slot under the same ecosystem (HappyHorse-style).
- reve-graph + reve.handler: aspect-ratio picker (txt2img), multi-frame images (edit), wired into the ecosystem discriminator, workflow config (TXT2IMG + EDIT), and the handler router.
- Bump @civitai/client 0.2.0-beta.80 -> 0.2.0-beta.81 for the Reve* FAL image-gen input types.
- docs: SQL to set ModelVersion.baseModel = 'Reve' and the model description for version 3133202 (apply manually per environment).