### PR TITLE
feat(app-blocks): GET_VIEWER page-host bridge (blocks.getMyViewer) + retire-/me doc + buzz comment sweep

### DIFF
--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -60,7 +60,7 @@ check at request time (`enforceContextBinding`).
 | `media:read:owned`               | non-anon `sub`                                    |                                   |
 | `buzz:read:self`                 | non-anon `sub`                                    |                                   |
 | `social:tip:self`                | non-anon `sub`                                    |                                   |
-| `user:read:self`                 | non-anon `sub`                                    | `/api/v1/blocks/me`               |
+| `user:read:self`                 | non-anon `sub`                                    | viewer identity — read via the `useViewer()` hook (`GET_VIEWER` bridge → `blocks.getMyViewer`). Also gates the **deprecated** `/api/v1/blocks/me` REST route (retiring) |
 | `ai:write:budgeted`              | positive `buzzBudget`                             |                                   |
 | `block:settings:read` / `:write` | `query.blockInstanceId == claims.blockInstanceId` | + caller-is-installer at issuance; `SKIP_OAUTH_CHECK` |
 | `apps:storage:read` / `:write`   | scope present on `claims.scopes` per op           | per-app KV store (App Storage); no OAuth bit (`SKIP_OAUTH_CHECK`) — gated by the approved-scope snapshot + `resolveStorageContext` |
@@ -78,7 +78,7 @@ Unknown scopes are rejected at runtime (deny-by-default in middleware).
 | ---------------------------------------------- | -------------------- | ------------------------------- |
 | `POST /api/v1/block-tokens`                    | same-origin session  | — (any approved install)        |
 | `GET /api/v1/block-tokens/jwks`                | public               | —                               |
-| `GET /api/v1/blocks/me`                        | block JWT            | `user:read:self`                |
+| `GET /api/v1/blocks/me` _(deprecated, retiring)_ | block JWT          | `user:read:self` — superseded by the `useViewer()` hook (`GET_VIEWER` bridge). Kept live for now; migrate to the hook |
 | `GET /api/v1/models/[id]`                      | session OR block JWT | `models:read:self` (block path) |
 | `POST /api/v1/developer/block-manifests`       | `JOB_TOKEN`          | —                               |
 | `POST /api/internal/blocks/workflow-completed` | `JOB_TOKEN` + Flipt  | —                               |
@@ -138,8 +138,11 @@ the token endpoint has resolved. Matches `@civitai/app-sdk/blocks` v1:
     id: number;
     username: string | null;
     // NOTE: moderation `status` (ban/mute) is intentionally NOT sent to the
-    // iframe — no block consumes it and it's a viewer-privacy leak. A block's
-    // authoritative check is its own /api/v1/blocks/me call.
+    // iframe in this render-time payload — it's a viewer-privacy leak. A block
+    // that needs a fresh, authoritative viewer (incl. `status: 'active'|'muted'`)
+    // reads it via the `useViewer()` hook (the `GET_VIEWER` page-host bridge →
+    // `blocks.getMyViewer`), the successor to the deprecated /api/v1/blocks/me
+    // call.
   } | null;                            // null for anon viewers
   theme: 'light' | 'dark';             // matches host color scheme
   renderMode: 'iframe' | 'inline';     // always 'iframe' today (the inline host is a stub)
@@ -176,6 +179,11 @@ read that file. As of this writing the families are:
 - **Lifecycle** (fire-and-forget): `BLOCK_READY`, `BLOCK_ERROR`, `RESIZE_IFRAME`.
 - **Auth / consent**: `REQUEST_TOKEN` (→ `TOKEN_REFRESH_RESPONSE`),
   `REQUEST_SIGN_IN`, `REQUEST_CONSENT`.
+- **Viewer**: `GET_VIEWER` (→ `VIEWER_RESULT`) — the viewer self-read ("who am
+  I") backing the SDK `useViewer()` hook, host-mediated via the
+  `user:read:self`-gated `blocks.getMyViewer` mutation (token-`sub`-bound
+  server-side). The host-mediated successor to `GET /api/v1/blocks/me` (which
+  stays live for now; migrate to the hook). Page host only today.
 - **Workflows** (REQUEST-style, host-brokered via `blocks.submitWorkflow` /
   `estimateWorkflow` / `pollWorkflow`): `SUBMIT_WORKFLOW`, `ESTIMATE_WORKFLOW`,
   `POLL_WORKFLOW`, `CANCEL_WORKFLOW`.

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -26,6 +26,7 @@ vi.mock('~/utils/trpc', () => ({
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -594,6 +594,11 @@ export function PageBlockHost({
   const getMyBuzzTransactionsMutation = trpc.blocks.getMyBuzzTransactions.useMutation();
   const getMyBuzzAccountsMutation = trpc.blocks.getMyBuzzAccounts.useMutation();
   const getMyDailyCompensationMutation = trpc.blocks.getMyDailyCompensation.useMutation();
+  // Viewer self-read bridge (a page block reading "who am I") — backs the SDK
+  // `useViewer()` hook and is the host-mediated successor to GET /blocks/me. A
+  // MUTATION for the same bearer-token reason as getMyBuzzBalance; requires the
+  // `user:read:self` scope server-side.
+  const getMyViewerMutation = trpc.blocks.getMyViewer.useMutation();
 
   // Wildcard-pack import (W13). SESSION-authed (protectedProcedure) — it does NOT
   // take a block token; the viewer's real cookie session authenticates, which is
@@ -841,6 +846,41 @@ export function PageBlockHost({
     );
     return off;
   }, [onMessage, send, token, getMyDailyCompensationMutation]);
+
+  // GET_VIEWER → blocks.getMyViewer → VIEWER_RESULT. The block's "who am I" read
+  // that backs the SDK `useViewer()` hook — the host-mediated successor to the
+  // GET /blocks/me REST call, so a page block can render the viewer's name /
+  // gate write UI on their moderation status without holding the scope directly.
+  // Host-MEDIATED: the iframe never sees a session; the identity is derived from
+  // the token's SELF-BOUND `sub` server-side (never client input), gated on the
+  // `user:read:self` scope. GET_VIEWER takes NO params, so only the host page
+  // token is forwarded (a block-sent field can't override it). REQUEST-style ⇒
+  // every path MUST reply or the block hangs to its SDK timeout: on a null token
+  // we reply with the ERROR variant (mirrors GET_BUZZ_BALANCE) rather than
+  // dropping. A missing requestId is still dropped without replying.
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown } | undefined>(
+      'GET_VIEWER',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string') return;
+        const requestId = raw.requestId;
+        if (!token) {
+          send('VIEWER_RESULT', { requestId, error: 'no block token' });
+          return;
+        }
+        try {
+          const viewer = await getMyViewerMutation.mutateAsync({ blockToken: token });
+          send('VIEWER_RESULT', { requestId, viewer });
+        } catch (err) {
+          send('VIEWER_RESULT', {
+            requestId,
+            error: err instanceof Error ? err.message : 'unknown',
+          });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, getMyViewerMutation]);
 
   // OPEN_BUZZ_PURCHASE → BUZZ_PURCHASE_RESULT. The generator's insufficient-Buzz
   // top-up CTA. Gate on BLOCK_READY (+ payload validity) via the shared

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -50,6 +50,7 @@ vi.mock('~/utils/trpc', () => ({
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
@@ -38,6 +38,7 @@ vi.mock('~/utils/trpc', () => ({
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -51,6 +51,7 @@ vi.mock('~/utils/trpc', () => ({
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -48,6 +48,7 @@ vi.mock('~/utils/trpc', () => ({
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
@@ -67,6 +67,7 @@ vi.mock('~/utils/trpc', () => ({
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -37,6 +37,7 @@ vi.mock('~/utils/trpc', () => ({
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
@@ -56,6 +56,7 @@ vi.mock('~/utils/trpc', () => ({
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
@@ -39,6 +39,7 @@ vi.mock('~/utils/trpc', () => ({
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -41,6 +41,7 @@ const mocks = vi.hoisted(() => ({
   transactions: vi.fn(),
   accounts: vi.fn(),
   dailyCompensation: vi.fn(),
+  viewer: vi.fn(),
 }));
 
 vi.mock('~/utils/trpc', () => ({
@@ -61,6 +62,7 @@ vi.mock('~/utils/trpc', () => ({
       getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: mocks.transactions }) },
       getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: mocks.accounts }) },
       getMyDailyCompensation: { useMutation: () => ({ mutateAsync: mocks.dailyCompensation }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: mocks.viewer }) },
     },
     // PageBlockHost also wires the storage bridge (inert here — exercised in
     // PageBlockHostStorage.browser.test.tsx); stub so the component mounts.
@@ -178,6 +180,7 @@ describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
     mocks.transactions.mockReset();
     mocks.accounts.mockReset();
     mocks.dailyCompensation.mockReset();
+    mocks.viewer.mockReset();
     // dialogStore is a module-level zustand store shared across tests — reset it
     // (the OPEN_BUZZ_PURCHASE handler triggers a dialog on it).
     useDialogStore.getState().closeAll();
@@ -524,6 +527,88 @@ describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
     });
     // No server call is made without a token.
     expect(mocks.balance).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  // ── Viewer self-read — GET_VIEWER → VIEWER_RESULT. The block reads its own
+  //    identity ("who am I") via the @civitai/blocks-react `useViewer()` hook,
+  //    which posts GET_VIEWER and awaits VIEWER_RESULT. The host mediates it
+  //    through the block-token-authed `blocks.getMyViewer` MUTATION (token-`sub`-
+  //    bound + user:read:self server-side). GET_VIEWER takes NO params, so only
+  //    the page token is forwarded — a block-sent field can't override it. Every
+  //    path MUST reply or the block hangs to its SDK timeout.
+  test('GET_VIEWER forwards ONLY the page token to getMyViewer and posts VIEWER_RESULT', async () => {
+    const viewer = { id: 42, username: 'u', status: 'active', buzzBudget: 50 };
+    mocks.viewer.mockResolvedValue(viewer);
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('GET_VIEWER', { requestId: 'rq_viewer' });
+
+    await vi.waitFor(() => {
+      // Forwarded ONLY the page `token` PROP as blockToken (the SELF-BOUND
+      // credential) — GET_VIEWER carries no params, and the handler never trusts
+      // a client-supplied identity.
+      expect(mocks.viewer).toHaveBeenCalledWith({ blockToken: 'tok_abc' });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('VIEWER_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_viewer', viewer });
+    });
+    replies.stop();
+  });
+
+  test('GET_VIEWER error path posts an error-variant VIEWER_RESULT (no hang)', async () => {
+    mocks.viewer.mockRejectedValue(new Error('block lacks user:read:self scope'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('GET_VIEWER', { requestId: 'rq_viewer_err' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('VIEWER_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_viewer_err',
+        error: 'block lacks user:read:self scope',
+      });
+    });
+    replies.stop();
+  });
+
+  test('GET_VIEWER with NO requestId is dropped (no mutation, no reply)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('GET_VIEWER', {}); // missing requestId
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(mocks.viewer).not.toHaveBeenCalled();
+    expect(replies.last('VIEWER_RESULT')).toBeUndefined();
+    replies.stop();
+  });
+
+  test('GET_VIEWER with a null page token replies with the error variant (never hangs)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} token={null} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement | null;
+      if (!el?.contentWindow) throw new Error('iframe not mounted yet');
+    });
+    const replies = listenForReply();
+
+    postFromBlock('GET_VIEWER', { requestId: 'rq_viewer_notoken' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('VIEWER_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_viewer_notoken', error: 'no block token' });
+    });
+    // No server call is made without a token.
+    expect(mocks.viewer).not.toHaveBeenCalled();
     replies.stop();
   });
 

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -204,6 +204,21 @@ export const INVENTORY = {
     PageBlockHost: 'required',
     InlineHost: INLINE_STUB,
   },
+  // Viewer self-read ("who am I") backing the SDK `useViewer()` hook — host-
+  // mediated via the `user:read:self`-gated `blocks.getMyViewer` MUTATION, the
+  // successor to GET /blocks/me (which stays live until the hook publishes +
+  // consumers migrate). AHEAD of the published SDK dist union (SDK co-requisite
+  // — forward-looking coverage, allowed by the one-directional compile-time
+  // gate). PAGE-ONLY affordance today (a page block reading its viewer; model-
+  // slot apps are deferred + will get page-host too), so N/A for the model host
+  // — mirrors the buzz self-read dashboard bridges.
+  GET_VIEWER: {
+    request: true,
+    reply: 'VIEWER_RESULT',
+    IframeHost: 'viewer self-read is a page-only affordance; slot-apps deferred',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
   // Buzz self-read dashboard bridges (ledger / all-pool balances / per-model
   // earnings) — host-mediated via the `buzz:read:self`-gated `blocks.getMyBuzz*`
   // MUTATIONS. AHEAD of the published SDK dist union (SDK co-requisite —

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -79,8 +79,8 @@ export type BlockScopedNextApiRequest = NextApiRequest & {
 
 export interface WithBlockScopeOpts {
   /**
-   * Low-cardinality LOGICAL name for this endpoint (e.g. 'tip', 'buzz',
-   * 'collections', 'shared_storage_top'). Used as the `endpoint` label on the
+   * Low-cardinality LOGICAL name for this endpoint (e.g. 'tip', 'me',
+   * 'model_detail', 'collections', 'shared_storage_top'). Used as the `endpoint` label on the
    * per-app REST-RED metrics (`civitai_app_block_requests_total` /
    * `civitai_app_block_request_duration_seconds`). Derived from the HANDLER, so
    * ids in the path can never leak into the label. Strictly enumerated — see
@@ -123,14 +123,14 @@ export interface WithBlockScopeOpts {
    * sends `Origin: null`. `null` can never be in the OauthClient.allowedOrigins
    * allowlist, so a direct (non-bridge) fetch's CORS preflight falls through to
    * the handler and 405s — the in-block resource browser (or collections / tip /
-   * buzz / shared-storage rail) then can't load. (First hit by the catalog
-   * selector; the collections, tip, buzz, and shared-storage REST endpoints a
+   * shared-storage rail) then can't load. (First hit by the catalog
+   * selector; the collections, tip, and shared-storage REST endpoints a
    * block direct-fetches hit the SAME wall.)
    *
    * SAFE wherever authorization rests SOLELY on the Bearer block-JWT with NO
    * ambient/cookie credential — which is every block REST endpoint, so this is
    * set on both the PUBLIC catalog endpoints (/api/v1/blocks/{models,images})
-   * and the per-user scoped ones (collections/tip/buzz/shared-storage). Block
+   * and the per-user scoped ones (collections/tip/shared-storage). Block
    * iframes carry no civitai cookie and `Access-Control-Allow-Credentials` is
    * omitted, so `ACAO: null` grants NO tokenless access: the real request still
    * requires a valid short-lived block JWT in `Authorization` (an attacker's own

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -39,8 +39,12 @@ const {
   mockSysRedis,
   mockResolveCanGenerateForVersions,
   mockRecordSpendAttribution,
+  mockDbWriteUserFindUnique,
 } = vi.hoisted(() => ({
   mockVerifyBlockToken: vi.fn(),
+  // getMyViewer reads the viewer's ban/mute/deleted state from dbWrite.user
+  // (the PRIMARY, like /blocks/me). Hoisted so tests can drive it + reset it.
+  mockDbWriteUserFindUnique: vi.fn(),
   mockParseSubjectUserId: vi.fn(),
   mockGetOrchestratorToken: vi.fn(),
   mockSubmitWorkflow: vi.fn(),
@@ -209,7 +213,12 @@ vi.mock('~/server/db/client', () => ({
   dbRead: mockDbRead,
   // dbWrite is referenced for install-management procedures; stub the few
   // shapes the unrelated procedures could hit so the import doesn't crash.
-  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+  dbWrite: {
+    modelBlockInstall: { findUnique: vi.fn() },
+    model: { findUnique: vi.fn() },
+    // getMyViewer's ban/mute/deleted lookup (mirrors /blocks/me — PRIMARY read).
+    user: { findUnique: (...a: unknown[]) => mockDbWriteUserFindUnique(...a) },
+  },
 }));
 // blocks.router transitively pulls in many redis-cache modules that read
 // `REDIS_KEYS.<GROUP>.<KEY>` AT IMPORT TIME. The real keys live in redis/client
@@ -430,6 +439,7 @@ beforeEach(() => {
     mockSysRedis.ttl,
     mockResolveCanGenerateForVersions,
     mockRecordSpendAttribution,
+    mockDbWriteUserFindUnique,
     mockIsAppBlocksAuthorEnabled,
     mockGetActiveDevTunnel,
     mockReserveDevSessionBuzz,
@@ -483,6 +493,15 @@ beforeEach(() => {
   mockSysRedis.ttl.mockResolvedValue(-1);
   // Buzz self-read bridges: default the per-instance rate limit to allowed.
   mockCheckBlockCatalogRateLimit.mockResolvedValue({ allowed: true });
+  // getMyViewer: default the viewer to an active (non-banned, non-muted,
+  // non-deleted) user. Ban/mute/deleted tests override this.
+  mockDbWriteUserFindUnique.mockResolvedValue({
+    id: 42,
+    username: 'u',
+    bannedAt: null,
+    muted: false,
+    deletedAt: null,
+  });
   // Defaults — every test starts with the flag on, a valid claim, an
   // authenticated subject, a fresh user/version row. Tests override only the
   // gate they're exercising. NB: mockReset wipes the implementation, so the
@@ -3938,6 +3957,152 @@ describe('blocks.getMyBuzzBalance', () => {
       code: 'FORBIDDEN',
     });
     expect(mockGetUserBuzzAccounts).not.toHaveBeenCalled();
+  });
+});
+
+// ---- getMyViewer (host-mediated, token-bound viewer identity read) ----------
+// A page block reads the VIEWER's OWN identity ("who am I") via the block token,
+// backing the SDK useViewer() hook. userId is derived from the self-bound token
+// sub (never client input), gated on the `user:read:self` consent scope (unlike
+// the scope-free getMyBuzzBalance). Mirrors /api/v1/blocks/me: dbWrite ban/mute/
+// deleted lookup, 404 on deleted, 403 on banned, `status:'muted'` for muted.
+const VIEWER_READ = ['user:read:self'];
+
+describe('blocks.getMyViewer', () => {
+  it('returns the SELF-BOUND viewer identity for a valid token (id/username/status/buzzBudget)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: VIEWER_READ }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.getMyViewer({ blockToken: 'tok' });
+    // buzzBudget comes from the token claim (validClaims default 50).
+    expect(result).toEqual({ id: 42, username: 'u', status: 'active', buzzBudget: 50 });
+    // The identity is read for the TOKEN subject (42) — NEVER a client input.
+    expect(mockDbWriteUserFindUnique.mock.calls[0][0].where).toEqual({ id: 42 });
+  });
+
+  it('passes a muted viewer through with status:muted', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: VIEWER_READ }));
+    mockDbWriteUserFindUnique.mockResolvedValue({
+      id: 42,
+      username: 'u',
+      bannedAt: null,
+      muted: true,
+      deletedAt: null,
+    });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.getMyViewer({ blockToken: 'tok' });
+    expect(result.status).toBe('muted');
+  });
+
+  it('surfaces buzzBudget as null when the token carries no budget claim', async () => {
+    mockVerifyBlockToken.mockResolvedValue(
+      validClaims({ scopes: VIEWER_READ, buzzBudget: undefined })
+    );
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.getMyViewer({ blockToken: 'tok' });
+    expect(result.buzzBudget).toBeNull();
+  });
+
+  it('rejects a token missing user:read:self with FORBIDDEN (never reads the db)', async () => {
+    // Default validClaims scopes are ['ai:write:budgeted'] — no viewer consent.
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyViewer({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockDbWriteUserFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid block token with UNAUTHORIZED (never reads the db)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyViewer({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockDbWriteUserFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('rejects an anon subject with UNAUTHORIZED (no viewer identity to read)', async () => {
+    // Carries the scope so it reaches the self-bind step, which rejects anon.
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: VIEWER_READ, sub: 'anon' }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyViewer({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockDbWriteUserFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the App Blocks flag is disabled (kill-switch, no db read)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: VIEWER_READ }));
+    mockIsAppBlocksEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyViewer({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+      message: 'Apps are not enabled',
+    });
+    expect(mockDbWriteUserFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-author subject with FORBIDDEN (author gate, no db read)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: VIEWER_READ }));
+    mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: false, tier: 'free' });
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyViewer({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockDbWriteUserFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits per blockInstanceId BEFORE the db read (TOO_MANY_REQUESTS)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: VIEWER_READ }));
+    mockCheckBlockCatalogRateLimit.mockResolvedValue({ allowed: false });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyViewer({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+    // The rate limit is checked on the SELF-BOUND blockInstanceId, before the db.
+    expect(mockCheckBlockCatalogRateLimit).toHaveBeenCalledWith('bki_test');
+    expect(mockDbWriteUserFindUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns NOT_FOUND when the resolved viewer is deleted', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: VIEWER_READ }));
+    mockDbWriteUserFindUnique.mockResolvedValue({
+      id: 42,
+      username: 'u',
+      bannedAt: null,
+      muted: false,
+      deletedAt: new Date('2026-01-01T00:00:00Z'),
+    });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyViewer({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('returns NOT_FOUND when the viewer row has vanished', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: VIEWER_READ }));
+    mockDbWriteUserFindUnique.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyViewer({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('returns FORBIDDEN (banned) when the resolved viewer is banned', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: VIEWER_READ }));
+    mockDbWriteUserFindUnique.mockResolvedValue({
+      id: 42,
+      username: 'u',
+      bannedAt: new Date('2026-01-01T00:00:00Z'),
+      muted: false,
+      deletedAt: null,
+    });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.getMyViewer({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'banned',
+    });
   });
 });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3495,6 +3495,101 @@ export const blocksRouter = router({
     }),
 
   /**
+   * HOST-MEDIATED viewer self-read for the token-bound viewer (a page block
+   * reading "who am I"). Backs the SDK `useViewer()` hook via the GET_VIEWER
+   * page-host bridge, and is the host-mediated successor to the
+   * `GET /api/v1/blocks/me` REST endpoint (which STAYS LIVE for now — this
+   * bridge supersedes it once the SDK hook publishes + consumers migrate; a
+   * later follow-up retires /me).
+   *
+   * MUTATION (not query) DELIBERATELY, for the SAME reason as getMyBuzzBalance:
+   * the block JWT is a bearer credential a `.query` would leak into the
+   * `?input=…` URL / logs / Referer where it is replayable within its TTL. Keep
+   * it a mutation (token rides the POST body).
+   *
+   * CONSENT: requires the `user:read:self` scope — the least-privileged scope
+   * that conveys "viewer identity" (audit I3; mirrors how /blocks/me gates via
+   * `withBlockScope({ requiredScope: 'user:read:self' })`). Unlike the scope-free
+   * getMyBuzzBalance, a block must declare+be-granted this scope.
+   *
+   * Order (each step fail-closed): verify token → require the consent scope →
+   * self-bind the userId off `claims.sub` (never client input; UNAUTHORIZED for
+   * anon) → App-Blocks kill-switch + author gate against the TOKEN subject →
+   * per-instance rate limit (keyed on the stable `blockInstanceId`, BEFORE the
+   * db read — the ban/mute lookup hits the PRIMARY, so a hammering block must be
+   * bounded) → the /blocks/me identity read.
+   *
+   * The identity read mirrors src/pages/api/v1/blocks/me.ts EXACTLY: `dbWrite`
+   * (NOT the replica) so a banned/muted-during-replication-lag viewer can't
+   * surface as active; 404 (NOT_FOUND) on a vanished/deleted user; 403
+   * (FORBIDDEN) on a banned viewer (a token minted just before a ban is valid
+   * for up to ~15min — reject here as a second line of defense); a muted viewer
+   * passes through with `status: 'muted'` so the block can suppress write UI.
+   * `buzzBudget` is surfaced from the token claim (if present) so a block can
+   * clamp UI without a second call — same shape /me returns.
+   */
+  getMyViewer: publicProcedure
+    // Block-JWT-authed (no session for dev:live) — flag evaluated against the
+    // TOKEN subject below, not the `enforceAppBlocksFlag` middleware's ctx.user.
+    // MUTATION for the bearer-token-in-URL reason above (see getMyBuzzBalance).
+    .input(z.object({ blockToken: z.string().min(1) }))
+    .mutation(async ({ input }) => {
+      const claims = await verifyBlockToken(input.blockToken);
+      if (!claims) throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid block token' });
+      // CONSENT: the least-privileged "viewer identity" scope (mirrors /blocks/me).
+      if (!claims.scopes.includes('user:read:self')) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'block lacks user:read:self scope' });
+      }
+      // Derive the user from the SELF-BOUND token subject, never client input.
+      const userId = parseSubjectUserId(claims.sub);
+      if (userId == null) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'viewer read requires an authenticated viewer',
+        });
+      }
+      // Same gates as the other block-token procs, evaluated against the TOKEN
+      // subject: the enabled kill-switch AND the author capability (pre-GA
+      // team-only gate — the router-side equivalent of /blocks/me's isModerator
+      // check).
+      await assertAppBlocksEnabledForTokenUser(userId);
+      await assertViewerIsAppDeveloper(userId);
+      // Per-instance rate limit (shared blocks limiter) — bounds a block
+      // hammering the PRIMARY (the ban/mute lookup below reads dbWrite). Runs
+      // BEFORE the db read. Fail-open on a redis incident.
+      const rate = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+      if (!rate.allowed) {
+        throw new TRPCError({
+          code: 'TOO_MANY_REQUESTS',
+          message: 'Rate limit exceeded, please retry shortly.',
+        });
+      }
+      // dbWrite (NOT the replica) for the ban/mute/deleted lookup — mirrors
+      // /blocks/me: reading the replica lets a banned-during-replication-lag
+      // viewer surface to the block as active.
+      const user = await dbWrite.user.findUnique({
+        where: { id: userId },
+        select: { id: true, username: true, bannedAt: true, muted: true, deletedAt: true },
+      });
+      if (!user || user.deletedAt) {
+        throw new TRPCError({ code: 'NOT_FOUND', message: 'User not found' });
+      }
+      // A banned user with a still-valid token must NOT surface as a real viewer.
+      if (user.bannedAt) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'banned' });
+      }
+      return {
+        id: user.id,
+        username: user.username,
+        // Muted viewers pass through so the block can suppress write UI.
+        status: (user.muted ? 'muted' : 'active') as 'active' | 'muted',
+        // Per-call spend cap the block was issued with — surfaced so the block
+        // can clamp UI without a second call (mirrors /blocks/me).
+        buzzBudget: claims.buzzBudget ?? null,
+      };
+    }),
+
+  /**
    * Read up to N showcase images for a model version with their gen-meta
    * extracted. Used by the block UI to render a "click an image to copy
    * its params" carousel. Public — showcase images are already public on


### PR DESCRIPTION
## What

Adds a **viewer self-read ("who am I") page-host bridge** for App Blocks, mirroring the buzz-read bridges just merged in #3144. A page block reads the viewer's identity via the SDK `useViewer()` hook → `GET_VIEWER` message → host-mediated `blocks.getMyViewer` tRPC mutation.

Design carried over verbatim from the buzz-read bridges:
- **self-bound** to the verified token subject (`claims.sub`), never client input
- **`user:read:self`** consent scope required (the least-privileged "viewer identity" scope; mirrors how `/api/v1/blocks/me` gates via `withBlockScope({ requiredScope: 'user:read:self' })`)
- a **MUTATION, not a query** — the block JWT is a bearer credential a `.query` would leak into the `?input=…` URL / logs / Referer where it's replayable within its TTL

### `blocks.getMyViewer`
`publicProcedure.mutation({ blockToken })`, order (each step fail-closed): verify token → require `user:read:self` (FORBIDDEN) → self-bind `userId` off `claims.sub` (UNAUTHORIZED for anon) → App-Blocks kill-switch + author gate against the **token** subject → per-instance rate limit on `blockInstanceId` **before** the db read (the ban/mute lookup hits the PRIMARY) → the `/blocks/me` identity read (`dbWrite`, 404 on deleted, 403 on banned, `status:'muted'` for muted).

**Shipped payload** (so the SDK matches): `{ id: number, username: string | null, status: 'active' | 'muted', buzzBudget: number | null }` (`buzzBudget` from the token claim, `null` if absent — mirrors `/me`).

### Host wiring
`PageBlockHost` + `hostHandlerParity`: `GET_VIEWER {requestId}` → forward **only** the page token → post `VIEWER_RESULT {requestId, viewer}` (error variant on no-token / thrown; replies on every path). Page-only; model host N/A (slot-apps deferred), mirroring the buzz self-read bridges.

### `/api/v1/blocks/me` stays live
This is the "bridge-ify the viewer self-read" decision — the REST endpoint is **kept live for now** and only marked deprecated/retiring in the docs. A **later follow-up** retires it once the SDK `useViewer()` hook publishes + consumers migrate.

## Mechanical doc/comment sweep (folded in)
- `block-scope.middleware.ts`: drop the now-retired `buzz` REST endpoint from the doc examples (buzz self-reads are host-mediated mutations since #3144); use a still-valid `AppBlockEndpoint` example (`'me'`/`'model_detail'`).
- `docs/features/app-blocks.md`: teach `useViewer()` (via the `GET_VIEWER` bridge) as the viewer-read path; mark the `/api/v1/blocks/me` route + `user:read:self` scope row **deprecated / retiring** (kept live, migrate to the hook).

## Tests
- **Router** (`blocks.router.workflow.test.ts`, createCaller): self-bind (identity from `sub`, never input), missing `user:read:self` → FORBIDDEN, invalid/anon → UNAUTHORIZED, banned → FORBIDDEN, deleted/vanished → NOT_FOUND, muted → `status:'muted'`, kill-switch, non-author, `buzzBudget` null-when-absent, **rate-limit-before-db**. Adds a `dbWrite.user.findUnique` mock (+ default + reset).
- **Host** (`PageBlockHostWorkflow.browser.test.tsx`): `GET_VIEWER` round-trip (requestId correlation, token-only forwarding), error variant, no-requestId drop, null-token error variant.
- **Render safety**: `trpc.blocks.getMyViewer.useMutation()` stubbed in **all 10** `PageBlockHost*.browser.test.tsx` (+ reset in the workflow `beforeEach`) so every PageBlockHost mount still renders (the #3144 gotcha).

Router/host suites can't run in the sandbox — the Tekton pr-preview is the authoritative typecheck.

## SDK co-requisite
The `GET_VIEWER` / `VIEWER_RESULT` message pair + the `useViewer()` hook are being added to `@civitai/app-sdk` / `@civitai/blocks-react` in parallel.

Ready for /audit-pr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)