### PR TITLE
feat(app-blocks): non-blocking cosmetic-image upload with async scan verdict

### DIFF
--- a/src/components/AppBlocks/BlockImageScanPoller.tsx
+++ b/src/components/AppBlocks/BlockImageScanPoller.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useRef } from 'react';
+import { nextPollDelay } from '~/components/Apps/assetPolling';
+import { classifyScanThrow, type BlockImageScanResult } from './blockImageScanLogic';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App Blocks (Phase-2b) — the HOST-mounted async scan poller behind the
+ * non-blocking cosmetic-image upload. It is mounted by PageBlockHost (NOT the
+ * upload modal) so it SURVIVES the modal's close: the modal resolves EARLY on
+ * persist and unmounts, while this component keeps polling the authoritative
+ * `blockImageUpload.gate` in the background until the scan lands, then reports
+ * the verdict ONCE via `onResult`. The host forwards that verdict to the block
+ * as the parent→block `IMAGE_SCAN_RESOLVED` push and unmounts this poller.
+ *
+ * It renders nothing. The gate + the pure {@link classifyScanThrow} remain the
+ * security boundary — this only drives the poll schedule (the SAME `nextPollDelay`
+ * budget the blocking modal uses) and maps each outcome to a
+ * {@link BlockImageScanResult}:
+ *   - gate `ready`        → `{ status: 'scanned', image }` (moderated projection).
+ *   - gate `pending`      → re-poll on the backoff schedule until the budget is
+ *                           spent → `{ status: 'error' }` (retryable timeout).
+ *   - THROWN BAD_REQUEST  → `{ status: 'blocked', reason }` (terminal moderation).
+ *   - THROWN other/network→ `{ status: 'error', message }` (retryable).
+ *
+ * `onResult` fires AT MOST ONCE (a `done` guard) — a late poll landing after the
+ * verdict, or an unmount mid-flight, can never emit a second verdict.
+ */
+export function BlockImageScanPoller({
+  imageId,
+  onResult,
+}: {
+  imageId: number;
+  onResult: (result: BlockImageScanResult) => void;
+}) {
+  const gateMutation = trpc.blockImageUpload.gate.useMutation();
+
+  // Keep the latest `mutateAsync` / `onResult` in refs so the polling effect can
+  // run once (keyed by imageId) without re-subscribing on every render — react-
+  // query recreates `mutateAsync` across renders, and the caller may pass a fresh
+  // `onResult` closure each render.
+  const mutateRef = useRef(gateMutation.mutateAsync);
+  mutateRef.current = gateMutation.mutateAsync;
+  const onResultRef = useRef(onResult);
+  onResultRef.current = onResult;
+
+  useEffect(() => {
+    let cancelled = false;
+    let done = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const finish = (result: BlockImageScanResult) => {
+      if (done || cancelled) return;
+      done = true;
+      onResultRef.current(result);
+    };
+
+    async function poll(attempt: number) {
+      if (cancelled || done) return;
+      let res: Awaited<ReturnType<typeof gateMutation.mutateAsync>>;
+      try {
+        res = await mutateRef.current({ imageId });
+      } catch (err) {
+        finish(classifyScanThrow(err));
+        return;
+      }
+      if (cancelled || done) return;
+      if (res.status === 'ready') {
+        finish({
+          status: 'scanned',
+          image: {
+            imageId: res.imageId,
+            nsfwLevel: res.nsfwLevel,
+            contentRating: res.contentRating,
+            url: res.url,
+          },
+        });
+        return;
+      }
+      // Still scanning — schedule the next poll while budget remains.
+      const delayMs = nextPollDelay(attempt);
+      if (delayMs === null) {
+        finish({ status: 'error', message: 'Image scan timed out — please try again.' });
+        return;
+      }
+      timer = setTimeout(() => void poll(attempt + 1), delayMs);
+    }
+
+    void poll(0);
+
+    return () => {
+      cancelled = true;
+      if (timer !== null) clearTimeout(timer);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- poll once per imageId;
+    // mutateAsync/onResult are read via refs so they must NOT re-arm the effect.
+  }, [imageId]);
+
+  return null;
+}

--- a/src/components/AppBlocks/BlockImageUploadModal.tsx
+++ b/src/components/AppBlocks/BlockImageUploadModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
 import { nextPollDelay } from '~/components/Apps/assetPolling';
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import type { OffsiteRatingValue } from '~/shared/constants/browsingLevel.constants';
 import { trpc } from '~/utils/trpc';
 
@@ -23,6 +24,17 @@ import { trpc } from '~/utils/trpc';
  *   with the MINIMAL public projection and close; the host posts IMAGE_UPLOAD_RESULT.
  *   If the user closes without a successful upload, the host posts a bare
  *   (cancelled) result — see the OPEN_IMAGE_UPLOAD handler's `options.onClose`.
+ *
+ * ASYNC (non-blocking) mode — when the caller passes `onAccepted`: the modal
+ * resolves the INSTANT the image is PERSISTED (imageId known, scan still
+ * in-flight) and SKIPS the in-modal poll gate entirely. It hands back a pending
+ * handle `{ imageId, url }` (the author's OWN just-uploaded edge URL — an
+ * unguessable UUID key, author-preview-only) and closes. The scan verdict is
+ * then streamed to the block asynchronously by a HOST-mounted poller
+ * (`BlockImageScanPoller`) that survives this modal's unmount — see PageBlockHost's
+ * OPEN_IMAGE_UPLOAD handler. The authoritative server gate is UNCHANGED: the
+ * pending handle exposes only the author's own preview URL, and no cross-user
+ * surface persists the image until the async verdict is `scanned`.
  */
 
 export type BlockUploadedImageInfo = {
@@ -45,9 +57,17 @@ async function readImageDimensions(file: File): Promise<{ width: number; height:
 
 export default function BlockImageUploadModal({
   onResolved,
+  onAccepted,
 }: {
-  /** Called ONCE with the moderated result when a clean+SFW+unflagged image lands. */
+  /** Called ONCE with the moderated result when a clean+SFW+unflagged image lands.
+   *  BLOCKING mode only (ignored when `onAccepted` is provided). */
   onResolved: (result: BlockUploadedImageInfo) => void;
+  /** ASYNC (non-blocking) mode. When provided, the modal resolves EARLY — the
+   *  instant the image is persisted (imageId known) — with a pending handle and
+   *  closes, SKIPPING the in-modal poll gate. The scan verdict is streamed later
+   *  by a host-mounted poller. The `url` is the author's OWN just-uploaded edge
+   *  URL (unguessable UUID key), for author preview only. */
+  onAccepted?: (handle: { imageId: number; url: string }) => void;
 }) {
   const dialog = useDialogContext();
   const { uploadToCF } = useCFImageUpload();
@@ -141,6 +161,17 @@ export default function BlockImageUploadModal({
         sizeBytes: file.size,
       });
       if (epoch !== epochRef.current) return;
+      // ASYNC (non-blocking) mode: the caller wants the modal to resolve the
+      // instant the image is persisted (imageId known) and to stream the scan
+      // verdict itself via a host-mounted poller. Compute the author's preview
+      // URL with the SAME edge transform the server gate uses (uploaded.id is the
+      // CF key), hand back the pending handle, and close — SKIP the poll gate.
+      if (onAccepted) {
+        const url = getEdgeUrl(uploaded.id, { width: 1200 });
+        onAccepted({ imageId, url });
+        dialog.onClose();
+        return;
+      }
       await pollGate(imageId, 0, epoch);
     } catch (err) {
       if (epoch !== epochRef.current) return;

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -18,6 +18,8 @@ import {
 import { projectSafeGenerationResource } from '~/server/schema/blocks/generation-resource-projection';
 import type { BlockUploadedImageInfo } from './BlockImageUploadModal';
 import type { BlockSourceImageInfo } from './BlockGenerationSourceUploadModal';
+import { BlockImageScanPoller } from './BlockImageScanPoller';
+import type { BlockImageScanResult } from './blockImageScanLogic';
 import { projectBlockInitMaturity } from './projectBlockInit';
 import { sendBlockRender } from './sendBlockRender';
 import {
@@ -210,6 +212,14 @@ export function PageBlockHost({
   // fresh `contentWindow`), so the re-armed init handshake talks to a clean
   // frame instead of a wedged one. See `handleRetry`.
   const [reloadNonce, setReloadNonce] = useState<number>(0);
+  // Active async cosmetic-image scan pollers (non-blocking OPEN_IMAGE_UPLOAD).
+  // Keyed by the OPEN_IMAGE_UPLOAD requestId; each entry mounts one
+  // BlockImageScanPoller (below) that survives the upload modal's close, polls
+  // the authoritative scan gate, and on a verdict fires IMAGE_SCAN_RESOLVED then
+  // removes itself. See the OPEN_IMAGE_UPLOAD handler + the render block.
+  const [imageScanPollers, setImageScanPollers] = useState<
+    Array<{ requestId: string; imageId: number }>
+  >([]);
   const initSentRef = useRef<boolean>(false);
   const controllerRef = useRef<IframeInitController | null>(null);
   const buildInitPayloadRef = useRef<() => BlockInitPayload>();
@@ -1584,14 +1594,14 @@ export function PageBlockHost({
   // the reply so concurrent uploads never cross. A successful upload posts the
   // minimal projection; closing without one posts a bare (cancelled) result.
   useEffect(() => {
-    const off = onMessage<{ requestId?: unknown; purpose?: unknown } | undefined>(
-      'OPEN_IMAGE_UPLOAD',
-      (raw) => {
+    const off = onMessage<
+      { requestId?: unknown; purpose?: unknown; asyncScan?: unknown } | undefined
+    >('OPEN_IMAGE_UPLOAD', (raw) => {
         const gateStatus = status === 'error' ? 'no_token' : status;
         if (gateStatus !== 'ready') return; // pre-handshake block — drop
         const req = resolveImageUploadRequest(raw);
         if (!req) return; // missing / non-string requestId → drop, never open the modal
-        const { requestId, purpose } = req;
+        const { requestId, purpose, asyncScan } = req;
 
         // generationSource: UNSCANNED private img2img source (orchestrator scans
         // the OUTPUT). Reply carries the source shape { url, width, height }; the
@@ -1613,6 +1623,51 @@ export function PageBlockHost({
                 } else {
                   send('IMAGE_UPLOAD_RESULT', { requestId });
                 }
+              },
+            },
+          });
+          return;
+        }
+
+        // display + asyncScan: NON-BLOCKING moderated path. The host modal resolves
+        // EARLY on persist (returning a PENDING handle — the author's own preview
+        // URL) and CLOSES; a host-mounted BlockImageScanPoller (registered below,
+        // which SURVIVES this modal's unmount) polls the authoritative scan gate and
+        // streams the verdict to the block via the parent→block IMAGE_SCAN_RESOLVED
+        // push. The server gate is UNCHANGED — nothing cross-user is persisted until
+        // the app sees a `scanned` verdict, and `gate` still only ever returns a
+        // moderated projection on Scanned + within-SFW-ceiling + unflagged.
+        if (asyncScan) {
+          let accepted = false;
+          dialogStore.trigger({
+            id: `block-image-upload-${requestId}`,
+            component: BlockImageUploadModal,
+            props: {
+              // BLOCKING-mode callback — unused in async mode (onAccepted drives the
+              // early resolve); a no-op that satisfies the modal's required prop.
+              onResolved: () => undefined,
+              onAccepted: ({ imageId, url }: { imageId: number; url: string }) => {
+                accepted = true;
+                // Early-resolve: the upload is accepted (image persisted, scan still
+                // in-flight). Hand the block the PENDING handle and register the
+                // background poller keyed by requestId.
+                send('IMAGE_UPLOAD_RESULT', {
+                  requestId,
+                  selected: { status: 'pending', imageId, url },
+                });
+                setImageScanPollers((prev) =>
+                  prev.some((p) => p.requestId === requestId)
+                    ? prev
+                    : [...prev, { requestId, imageId }]
+                );
+              },
+            },
+            options: {
+              onClose: () => {
+                // Dismissed WITHOUT accepting → bare (cancelled) result, no poller.
+                // On accept, onClose fires AFTER onAccepted set `accepted`, so the
+                // early-resolve reply is not followed by a spurious cancel.
+                if (!accepted) send('IMAGE_UPLOAD_RESULT', { requestId });
               },
             },
           });
@@ -1854,6 +1909,22 @@ export function PageBlockHost({
       data-needs-consent={needsConsent ? 'true' : 'false'}
     >
       <AppBlockChrome blockInstanceId={blockInstanceId} appName={appName} slotId={PAGE_SLOT_ID} />
+      {/* Async cosmetic-image scan pollers (non-blocking OPEN_IMAGE_UPLOAD). Each
+          renders nothing; it polls the authoritative scan gate in the background —
+          SURVIVING the upload modal's close — and on a verdict fires
+          IMAGE_SCAN_RESOLVED to the block then removes itself. Rendered here (not in
+          the iframe/fallback branches) so a page that falls back mid-scan still
+          resolves the pending upload. */}
+      {imageScanPollers.map((p) => (
+        <BlockImageScanPoller
+          key={p.requestId}
+          imageId={p.imageId}
+          onResult={(result: BlockImageScanResult) => {
+            send('IMAGE_SCAN_RESOLVED', { requestId: p.requestId, imageId: p.imageId, result });
+            setImageScanPollers((prev) => prev.filter((x) => x.requestId !== p.requestId));
+          }}
+        />
+      ))}
       {showIframe ? (
         // The iframe fills the remaining viewport. While the block is still
         // handshaking (status === 'loading', before BLOCK_READY), the surface

--- a/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
@@ -1,0 +1,296 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { useDialogStore } from '~/components/Dialog/dialogStore';
+import type { BlockUploadedImageInfo } from '~/components/AppBlocks/BlockImageUploadModal';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * App Blocks PAGE image upload — the ASYNC (non-blocking) scan branch of
+ * OPEN_IMAGE_UPLOAD (`asyncScan: true` + display).
+ *
+ * Target behavior: the host modal resolves EARLY on persist — replying
+ * IMAGE_UPLOAD_RESULT with a PENDING handle `{ status:'pending', imageId, url }`
+ * and closing — while a host-mounted BlockImageScanPoller (which survives the
+ * modal close) polls the authoritative gate and later streams the verdict as the
+ * parent→block IMAGE_SCAN_RESOLVED push.
+ *
+ * Like the sibling purpose-branch test, the dynamic-import modal isn't rendered;
+ * we capture its `onAccepted` (async early-resolve) / `onResolved` props from the
+ * dialog and invoke them to simulate the user's upload. The POLLER, however, IS
+ * rendered by the real PageBlockHost — so the gate mutation is driven by the
+ * programmable `gateMutateAsync` mock below to exercise scanned / blocked / error.
+ */
+
+const h = vi.hoisted(() => ({ gateMutateAsync: vi.fn() }));
+
+vi.mock('~/utils/trpc', () => ({
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blockImageUpload: {
+      persist: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      // The host-mounted poller's gate mutation — programmable per test.
+      gate: { useMutation: () => ({ mutateAsync: h.gateMutateAsync }) },
+    },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', { data: { type, payload }, origin: window.location.origin, source: cw })
+  );
+}
+
+function listenForReply() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    count: (type: string) => received.filter((m) => m.type === type).length,
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+function lastDialog() {
+  const dialogs = useDialogStore.getState().dialogs;
+  if (dialogs.length === 0) throw new Error('no modal opened');
+  return dialogs[dialogs.length - 1];
+}
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'my-page-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Gen App',
+  iframeSrc: SAME_ORIGIN_SRC,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'my-page-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['ai:write:budgeted'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 42, username: 'tester' },
+  theme: 'light' as const,
+};
+
+async function driveToReady() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+// Open the async upload, capture the modal's onAccepted, then simulate the modal's
+// early-resolve (persist done → onAccepted → modal closes).
+function acceptUpload(requestId: string, handle: { imageId: number; url: string }) {
+  const props = lastDialog().props as {
+    onAccepted?: (h: { imageId: number; url: string }) => void;
+  };
+  if (!props.onAccepted) throw new Error('modal was not opened in async (onAccepted) mode');
+  props.onAccepted(handle);
+  // The modal calls dialog.onClose() right after onAccepted; replay that.
+  lastDialog().options?.onClose?.();
+}
+
+const READY_IMAGE: BlockUploadedImageInfo = {
+  imageId: 77,
+  nsfwLevel: 1,
+  contentRating: 'PG' as BlockUploadedImageInfo['contentRating'],
+  url: 'https://image.civitai.com/xG/77/width=1200/original.jpeg',
+};
+
+describe('PageBlockHost OPEN_IMAGE_UPLOAD (asyncScan branch)', () => {
+  beforeEach(() => {
+    useDialogStore.getState().closeAll();
+    h.gateMutateAsync.mockReset();
+  });
+
+  test('early-resolve: accept replies a PENDING handle and closes the modal', async () => {
+    // Gate never asked to resolve within this test — keep it pending so no verdict races.
+    h.gateMutateAsync.mockResolvedValue({ status: 'pending' });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_async', asyncScan: true });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    // The MODERATED modal is opened (async is a display-only mode).
+    expect(lastDialog().id).toBe('block-image-upload-rq_async');
+
+    acceptUpload('rq_async', { imageId: 77, url: 'https://image.civitai.com/xG/77/width=1200/x.jpeg' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('IMAGE_UPLOAD_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_async',
+        selected: { status: 'pending', imageId: 77, url: 'https://image.civitai.com/xG/77/width=1200/x.jpeg' },
+      });
+    });
+    // Auto-close semantics: the host replied EXACTLY ONCE on accept — the modal's
+    // simulated onClose (accepted=true) must NOT emit a second/bare result (the
+    // accepted-guard), so the block never sees a spurious cancel after the pending
+    // handle. (The modal's own dialog.onClose() is a modal-internal behavior,
+    // covered where the modal is rendered.)
+    await new Promise((r) => setTimeout(r, 100));
+    expect(replies.count('IMAGE_UPLOAD_RESULT')).toBe(1);
+    replies.stop();
+  });
+
+  test('pending → scanned: the poller streams IMAGE_SCAN_RESOLVED with the moderated image', async () => {
+    h.gateMutateAsync.mockResolvedValue({ status: 'ready', ...READY_IMAGE });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_scan', asyncScan: true });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    acceptUpload('rq_scan', { imageId: 77, url: 'https://preview/x.jpeg' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('IMAGE_SCAN_RESOLVED');
+      if (!r) throw new Error('no verdict yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_scan',
+        imageId: 77,
+        result: { status: 'scanned', image: READY_IMAGE },
+      });
+    });
+    expect(h.gateMutateAsync).toHaveBeenCalledWith({ imageId: 77 });
+    // Emitted exactly once.
+    expect(replies.count('IMAGE_SCAN_RESOLVED')).toBe(1);
+    replies.stop();
+  });
+
+  test('pending → blocked: a BAD_REQUEST gate throw streams blocked, leaking NO moderated image', async () => {
+    h.gateMutateAsync.mockRejectedValue({
+      data: { code: 'BAD_REQUEST' },
+      message: 'that image was rejected during scanning — choose a different image',
+    });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_block', asyncScan: true });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    acceptUpload('rq_block', { imageId: 88, url: 'https://preview/y.jpeg' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('IMAGE_SCAN_RESOLVED');
+      if (!r) throw new Error('no verdict yet');
+      const payload = r.payload as { requestId: string; imageId: number; result: Record<string, unknown> };
+      expect(payload.requestId).toBe('rq_block');
+      expect(payload.result.status).toBe('blocked');
+      expect(payload.result.reason).toContain('rejected during scanning');
+      // A blocked verdict must carry NO block-usable moderated image.
+      expect(payload.result).not.toHaveProperty('image');
+    });
+    replies.stop();
+  });
+
+  test('scan error: a NOT_FOUND / network gate throw streams a RETRYABLE error (not blocked)', async () => {
+    h.gateMutateAsync.mockRejectedValue({ data: { code: 'NOT_FOUND' }, message: 'Image not found' });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_err', asyncScan: true });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+    acceptUpload('rq_err', { imageId: 99, url: 'https://preview/z.jpeg' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('IMAGE_SCAN_RESOLVED');
+      if (!r) throw new Error('no verdict yet');
+      const payload = r.payload as { result: { status: string; message?: string } };
+      expect(payload.result.status).toBe('error');
+      expect(payload.result.message).toBe('Image not found');
+    });
+    replies.stop();
+  });
+
+  test('dismiss (close without accept): a bare IMAGE_UPLOAD_RESULT, NO poller, NO gate call', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('OPEN_IMAGE_UPLOAD', { requestId: 'rq_dismiss', asyncScan: true });
+    await vi.waitFor(() => expect(useDialogStore.getState().dialogs).toHaveLength(1));
+
+    // User closes without accepting — onAccepted never fires.
+    lastDialog().options?.onClose?.();
+
+    await vi.waitFor(() => {
+      const r = replies.last('IMAGE_UPLOAD_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_dismiss' });
+    });
+    // No poller registered → no scan verdict, no gate mutation.
+    await new Promise((r) => setTimeout(r, 150));
+    expect(replies.last('IMAGE_SCAN_RESOLVED')).toBeUndefined();
+    expect(h.gateMutateAsync).not.toHaveBeenCalled();
+    replies.stop();
+  });
+});

--- a/src/components/AppBlocks/__tests__/blockImageScanLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/blockImageScanLogic.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyScanThrow,
+  extractErrorMessage,
+  extractTrpcErrorCode,
+} from '../blockImageScanLogic';
+
+/**
+ * App Blocks (Phase-2b) — the async scan verdict classifier. The blocked-vs-error
+ * split is SECURITY-relevant (blocked = terminal moderation refusal, error =
+ * retryable transient), so it is a PURE, node-unit-tested decision that reads the
+ * tRPC error CODE, never prose. Mirrors a TRPCClientError's observed shape
+ * (`.data.code` / `.shape.data.code` + `.message`).
+ */
+
+// A minimal stand-in for a TRPCClientError as observed on the client.
+function trpcErr(code: string, message = 'server said no') {
+  return { name: 'TRPCClientError', message, data: { code, httpStatus: 400 } };
+}
+
+describe('extractTrpcErrorCode', () => {
+  it('reads .data.code', () => {
+    expect(extractTrpcErrorCode(trpcErr('BAD_REQUEST'))).toBe('BAD_REQUEST');
+  });
+
+  it('falls back to .shape.data.code', () => {
+    expect(extractTrpcErrorCode({ shape: { data: { code: 'NOT_FOUND' } } })).toBe('NOT_FOUND');
+  });
+
+  it('returns undefined for a non-tRPC throw (network TypeError, string, null)', () => {
+    expect(extractTrpcErrorCode(new TypeError('Failed to fetch'))).toBeUndefined();
+    expect(extractTrpcErrorCode('boom')).toBeUndefined();
+    expect(extractTrpcErrorCode(null)).toBeUndefined();
+    expect(extractTrpcErrorCode({ data: { code: 42 } })).toBeUndefined();
+  });
+});
+
+describe('extractErrorMessage', () => {
+  it('reads a non-empty string .message', () => {
+    expect(extractErrorMessage({ message: 'nope' })).toBe('nope');
+    expect(extractErrorMessage(new Error('kaboom'))).toBe('kaboom');
+  });
+  it('returns undefined for a missing / empty / non-string message', () => {
+    expect(extractErrorMessage({})).toBeUndefined();
+    expect(extractErrorMessage({ message: '' })).toBeUndefined();
+    expect(extractErrorMessage({ message: 42 })).toBeUndefined();
+    expect(extractErrorMessage(null)).toBeUndefined();
+  });
+});
+
+describe('classifyScanThrow (blocked = terminal moderation, error = retryable)', () => {
+  it('BAD_REQUEST → blocked, carrying the server message as reason', () => {
+    expect(classifyScanThrow(trpcErr('BAD_REQUEST', 'that image was rejected during scanning'))).toEqual(
+      { status: 'blocked', reason: 'that image was rejected during scanning' }
+    );
+  });
+
+  it('BAD_REQUEST with no message → blocked without a reason', () => {
+    expect(classifyScanThrow({ data: { code: 'BAD_REQUEST' } })).toEqual({ status: 'blocked' });
+  });
+
+  it('NOT_FOUND → error (retryable), NOT blocked', () => {
+    expect(classifyScanThrow(trpcErr('NOT_FOUND', 'Image not found'))).toEqual({
+      status: 'error',
+      message: 'Image not found',
+    });
+  });
+
+  it('FORBIDDEN → error (retryable), NOT blocked', () => {
+    const r = classifyScanThrow(trpcErr('FORBIDDEN', 'You do not own this image'));
+    expect(r.status).toBe('error');
+  });
+
+  it('a network throw (no tRPC code) → error, NEVER mislabelled blocked', () => {
+    const r = classifyScanThrow(new TypeError('Failed to fetch'));
+    expect(r).toEqual({ status: 'error', message: 'Failed to fetch' });
+    expect(r.status).not.toBe('blocked');
+  });
+
+  it('an unknown tRPC code → error (only BAD_REQUEST is terminal moderation)', () => {
+    expect(classifyScanThrow(trpcErr('INTERNAL_SERVER_ERROR')).status).toBe('error');
+    expect(classifyScanThrow(trpcErr('TIMEOUT')).status).toBe('error');
+  });
+});

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -180,24 +180,40 @@ describe('resolveCheckpointPickerRequest (OPEN_CHECKPOINT_PICKER — dev:live↔
 });
 
 describe('resolveImageUploadRequest (OPEN_IMAGE_UPLOAD — requestId drop rule + purpose)', () => {
-  it('accepts a valid string requestId and defaults purpose to display', () => {
+  it('accepts a valid string requestId and defaults purpose to display + asyncScan false', () => {
     expect(resolveImageUploadRequest({ requestId: 'u1' })).toEqual({
       requestId: 'u1',
       purpose: 'display',
+      asyncScan: false,
     });
   });
 
-  it('ignores extra fields (only requestId + purpose are threaded — the rest is server-gated)', () => {
+  it('ignores extra fields (only requestId + purpose + asyncScan are threaded — the rest is server-gated)', () => {
     expect(resolveImageUploadRequest({ requestId: 'u2', junk: 'x', imageId: 5 })).toEqual({
       requestId: 'u2',
       purpose: 'display',
+      asyncScan: false,
     });
   });
 
   it('threads purpose:generationSource when the block requests the unscanned source mode', () => {
     expect(
       resolveImageUploadRequest({ requestId: 'u_src', purpose: 'generationSource' })
-    ).toEqual({ requestId: 'u_src', purpose: 'generationSource' });
+    ).toEqual({ requestId: 'u_src', purpose: 'generationSource', asyncScan: false });
+  });
+
+  it('opts into asyncScan ONLY for a literal asyncScan === true', () => {
+    expect(resolveImageUploadRequest({ requestId: 'u_a', asyncScan: true })).toEqual({
+      requestId: 'u_a',
+      purpose: 'display',
+      asyncScan: true,
+    });
+    // Any non-true value → false (byte-compatible blocking for an old SDK).
+    for (const v of [false, undefined, null, 'true', 1, {}]) {
+      expect(resolveImageUploadRequest({ requestId: 'u_b', asyncScan: v }).asyncScan).toBe(false);
+    }
+    // Absent flag → false.
+    expect(resolveImageUploadRequest({ requestId: 'u_c' }).asyncScan).toBe(false);
   });
 
   it('normalizes an absent purpose to display (SDK back-compat — current SDK sends none)', () => {

--- a/src/components/AppBlocks/blockImageScanLogic.ts
+++ b/src/components/AppBlocks/blockImageScanLogic.ts
@@ -1,0 +1,96 @@
+import type { BlockUploadedImageInfo } from './BlockImageUploadModal';
+
+/**
+ * App Blocks (Phase-2b) — pure classification for the ASYNC (non-blocking)
+ * cosmetic-image scan verdict, extracted so the security-relevant
+ * blocked-vs-error discriminant is unit-testable in the node vitest env (no
+ * React / no tRPC — mirrors pageBlockHostLogic + block-image-upload.logic).
+ *
+ * Background: in async mode the host modal resolves EARLY (on persist, imageId
+ * known) and a host-mounted poller streams the eventual scan verdict to the
+ * block via the parent→block `IMAGE_SCAN_RESOLVED` push. The authoritative gate
+ * is UNCHANGED — `blockImageUpload.gate` still returns a moderated projection
+ * ONLY on Scanned + within-SFW-ceiling + unflagged, and THROWS a TRPCError on
+ * every terminal / access / not-found case. This module only maps that
+ * client-observed throw into the verdict the block receives.
+ *
+ * The blocked-vs-error split is SECURITY-relevant: a `blocked` verdict is a
+ * TERMINAL moderation refusal (the block must not use the image and must not
+ * retry), whereas an `error` verdict is a transient/host-side failure the block
+ * MAY retry. Mislabelling a network blip as `blocked` would wrongly reject a
+ * clean image; mislabelling a real moderation refusal as `error` would invite a
+ * pointless retry loop but can NEVER cause an unscanned image to be served —
+ * cross-user serving stays gated server-side on a `scanned` verdict.
+ */
+
+/**
+ * The async scan verdict for a pending display upload (host→block). Mirrors the
+ * SDK `BlockImageScanResult`:
+ *   - `scanned` — clean + within the SFW ceiling + unflagged. Carries the
+ *     moderated projection (imageId / nsfwLevel / contentRating / url).
+ *   - `blocked` — TERMINAL non-clean (scan-blocked / above-SFW / flagged /
+ *     import-failed). The gate raised a BAD_REQUEST TRPCError.
+ *   - `error`  — transient/host-side error or poll-budget timeout. Retryable.
+ */
+export type BlockImageScanResult =
+  | { status: 'scanned'; image: BlockUploadedImageInfo }
+  | { status: 'blocked'; reason?: string }
+  | { status: 'error'; message?: string };
+
+/**
+ * Best-effort extraction of a tRPC error code (`'BAD_REQUEST'` / `'NOT_FOUND'` /
+ * `'FORBIDDEN'` / …) from a thrown value. A `TRPCClientError` exposes the code
+ * at `.data.code` (and, defensively, `.shape.data.code`). Returns `undefined`
+ * for a non-tRPC throw (a network `TypeError`, an aborted request, …) — which is
+ * treated as a retryable `error`, NOT a moderation `blocked`.
+ */
+export function extractTrpcErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== 'object') return undefined;
+  const data = (err as { data?: unknown }).data;
+  if (data && typeof data === 'object') {
+    const code = (data as { code?: unknown }).code;
+    if (typeof code === 'string') return code;
+  }
+  const shape = (err as { shape?: unknown }).shape;
+  if (shape && typeof shape === 'object') {
+    const sdata = (shape as { data?: unknown }).data;
+    if (sdata && typeof sdata === 'object') {
+      const code = (sdata as { code?: unknown }).code;
+      if (typeof code === 'string') return code;
+    }
+  }
+  return undefined;
+}
+
+/** Best-effort human message from a thrown value (the server message on a
+ *  TRPCClientError). Conservative — the block is untrusted, so we never leak a
+ *  stack trace; a non-string / empty message yields `undefined`. */
+export function extractErrorMessage(err: unknown): string | undefined {
+  if (err && typeof err === 'object' && 'message' in err) {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === 'string' && message.length > 0) return message;
+  }
+  return undefined;
+}
+
+/**
+ * Classify a THROWN gate error into the terminal verdict the block receives.
+ * PURE + STRUCTURAL — the retryable-vs-terminal decision reads the tRPC error
+ * CODE, never prose (rewording a server message can't change the outcome):
+ *   - `BAD_REQUEST` → the pure scan classifier rejected the bytes (scan-blocked
+ *     / above-SFW / flagged / import-failed) → `blocked` (do NOT retry). The
+ *     server message becomes the display `reason`.
+ *   - anything else (`NOT_FOUND` / `FORBIDDEN` / a network throw / an unknown
+ *     code / a poll-budget timeout mapped by the caller) → `error` (retryable).
+ *     A network blip is NEVER mislabelled `blocked`.
+ */
+export function classifyScanThrow(
+  err: unknown
+): { status: 'blocked'; reason?: string } | { status: 'error'; message?: string } {
+  const code = extractTrpcErrorCode(err);
+  const message = extractErrorMessage(err);
+  if (code === 'BAD_REQUEST') {
+    return { status: 'blocked', ...(message ? { reason: message } : {}) };
+  }
+  return { status: 'error', ...(message ? { message } : {}) };
+}

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -263,6 +263,13 @@ export const INVENTORY = {
   // published SDK dist union (the SDK contract is external + a co-requisite) —
   // forward-looking coverage, allowed by the one-directional compile-time gate.
   // A page-only affordance today, so N/A for the model host.
+  //
+  // NOTE (async cosmetic-image scan): the non-blocking mode's scan VERDICT rides a
+  // separate PARENT→BLOCK push, `IMAGE_SCAN_RESOLVED`, which is NOT a
+  // BlockToParentMessage and so does NOT belong in this INVENTORY (it tracks only
+  // block→host REQUEST types + their replies). OPEN_IMAGE_UPLOAD's TYPE is unchanged
+  // — async mode only adds an OPTIONAL `asyncScan` payload field — so no new entry
+  // is needed here. Do NOT "add" IMAGE_SCAN_RESOLVED to this map.
   OPEN_IMAGE_UPLOAD: {
     request: true,
     reply: 'IMAGE_UPLOAD_RESULT',

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -152,14 +152,25 @@ export type ImageUploadRequest = {
   requestId: string;
   /** Normalized upload mode; 'display' when the SDK omits/sends an unknown value. */
   purpose: BlockUploadPurpose;
+  /**
+   * NON-BLOCKING scan opt-in (display uploads only). When true, the host modal
+   * resolves EARLY on persist (returning a PENDING handle) and streams the scan
+   * verdict asynchronously to the block via the parent→block IMAGE_SCAN_RESOLVED
+   * push, instead of blocking the modal on the poll gate. Normalized to `true`
+   * ONLY for a literal `asyncScan === true` (any other value ⇒ false), so an old
+   * SDK that sends no flag keeps the byte-compatible blocking behavior, and the
+   * flag is IGNORED for generationSource (that path has no scan).
+   */
+  asyncScan: boolean;
 };
 
 /**
  * Validate a raw OPEN_IMAGE_UPLOAD payload from an untrusted iframe. Returns the
- * sanitized request (requestId + normalized purpose), or `null` when it must be
- * DROPPED (missing/non-string requestId). The CALLER opens the native upload
- * modal — this only decides whether to, and which mode. An absent or
- * unrecognized `purpose` normalizes to the safe moderated default ('display').
+ * sanitized request (requestId + normalized purpose + asyncScan), or `null` when
+ * it must be DROPPED (missing/non-string requestId). The CALLER opens the native
+ * upload modal — this only decides whether to, which mode, and blocking-vs-async.
+ * An absent or unrecognized `purpose` normalizes to the safe moderated default
+ * ('display'); `asyncScan` is `true` ONLY for a literal `true` (default false).
  */
 export function resolveImageUploadRequest(raw: unknown): ImageUploadRequest | null {
   if (!raw || typeof raw !== 'object') return null;
@@ -167,7 +178,8 @@ export function resolveImageUploadRequest(raw: unknown): ImageUploadRequest | nu
   if (typeof obj.requestId !== 'string' || obj.requestId.length === 0) return null;
   const purpose: BlockUploadPurpose =
     obj.purpose === 'generationSource' ? 'generationSource' : 'display';
-  return { requestId: obj.requestId, purpose };
+  const asyncScan = obj.asyncScan === true;
+  return { requestId: obj.requestId, purpose, asyncScan };
 }
 
 export type PageFallbackReason = 'timeout' | 'token_error' | 'fatal_block_error';


### PR DESCRIPTION
## Non-blocking cosmetic-image upload (async scan verdict)

Makes the App Blocks cosmetic-image (`display`) upload **non-blocking**: the host upload modal resolves/closes early on upload-accept (handing the block a `pending` handle), and the moderation scan verdict is then streamed to the block asynchronously — instead of the modal blocking on the gate poll while the user waits. Opt-in; the existing blocking path is unchanged.

Companion to the SDK change `@civitai/app-sdk 0.22.0` / `@civitai/blocks-react 0.26.0` (civitai-app-starters `zach/sdk-image-async-scan`). This host change is **inert until a block opts in** via the new SDK's `asyncScan` flag, so it has no coupling to the SDK release timing.

### What changed
- `BlockImageUploadModal.tsx` — optional `onAccepted`; in async mode early-resolves after the image is persisted (imageId known) and closes, skipping the in-modal poll. Blocking path byte-unchanged.
- `BlockImageScanPoller.tsx` (new) — host-mounted, survives modal close, polls `blockImageUpload.gate` on the same delay budget; `ready`→scanned, budget-exhaust→error, throw→classifier.
- `blockImageScanLogic.ts` (new) — pure, structural classifier: tRPC `BAD_REQUEST`→`blocked`, everything else (network / NOT_FOUND / FORBIDDEN / timeout)→`error`. A network blip can never be mislabeled `blocked` or `scanned`.
- `PageBlockHost.tsx` — reads `asyncScan`; `generationSource` handled first (async ignored there, per contract), then the async-display branch emits the pending result and registers a per-request poller that pushes `IMAGE_SCAN_RESOLVED` then unmounts. Blocking + generationSource branches untouched.
- `pageBlockHostLogic.ts` / `hostHandlerParity.ts` — flag plumbing; no new block→host handler (the push is parent→block), parity guard intact.

### Security invariants (independently audited — verdict: merge)
- **Gated-until-clean stays server-authoritative:** `blockImageUpload.gate` is unchanged; a `scanned` verdict is emitted only on gate `ready` (Scanned ingestion + within SFW ceiling + unflagged), and the consuming block persists a cross-user reference only on `scanned`.
- **Fail-closed:** blocked / above-SFW / flagged / import-failed / timeout / network-error → non-clean verdict, never persisted.
- **No cross-author leak:** the pending handle is the author's own just-uploaded image (`getEdgeUrl` of their CF key), and the gate enforces `image.userId === user.id`.
- **Backward/forward compatible:** blocking wire byte-identical; old-block × new-host and new-block × old-host both safe (no hang, no leak). Model-slot / `generationSource` paths untouched.

### Tests
Component (async early-resolve / auto-close / pending→scanned / pending→blocked-with-no-leak / error / dismiss) + the pure classifier node test + parity tests — all pass. Local whole-repo `tsc` skipped (stale-Prisma env); the PR preview typecheck is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
