### PR TITLE
fix(apps): reject-button gating feedback + dark-theme diff backgrounds on /apps/review

### DIFF
--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -148,6 +148,32 @@ describe('OffsiteReviewModal — approve-notes gating, friendly date, field labe
     await expect.element(page.getByTestId('apps-offsite-reject-confirm')).toBeInTheDocument();
   });
 
+  // Bug 1: the Reject confirm was gated on a silent 10-char minimum (every other
+  // mod-reason field uses the shared 3-char `OFFSITE_MOD_REASON_MIN`). Gate is now
+  // unified on that minimum with inline feedback — assert the disabled→enabled
+  // transition (also catches a genuine wiring defect if the gate never opens).
+  test('Reject confirm is disabled until a ≥min-length reason is typed', async () => {
+    renderWithProviders(<OffsiteReviewQueue />);
+    await page.getByRole('button', { name: 'Review' }).click();
+    await page.getByTestId('apps-offsite-reject-open').click();
+
+    const confirm = page.getByTestId('apps-offsite-reject-confirm');
+    // Empty reason → disabled.
+    await expect.element(confirm).toBeDisabled();
+
+    // A too-short reason (2 < OFFSITE_MOD_REASON_MIN=3) → still disabled.
+    await page.getByTestId('apps-offsite-reject-reason').fill('no');
+    await expect.element(confirm).toBeDisabled();
+
+    // A reason at/above the 3-char minimum → enabled.
+    await page.getByTestId('apps-offsite-reject-reason').fill('needs a real reason');
+    await expect.element(confirm).toBeEnabled();
+
+    // Whitespace-only padding does NOT satisfy the gate (trimmed length counts).
+    await page.getByTestId('apps-offsite-reject-reason').fill('  a  ');
+    await expect.element(confirm).toBeDisabled();
+  });
+
   test('the submitted timestamp renders as "Month D, YYYY" (no time-of-day)', async () => {
     renderWithProviders(<OffsiteReviewQueue />);
     // Self-consistent with the component (same helper) → TZ-agnostic.

--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -174,6 +174,22 @@ describe('OffsiteReviewModal — approve-notes gating, friendly date, field labe
     await expect.element(confirm).toBeDisabled();
   });
 
+  // The disabled-reason Tooltip wraps the disabled Button in a Box so it still
+  // fires on hover (a native disabled <button> emits no pointer events). Assert
+  // the hint text surfaces while the gate is closed.
+  test('hovering the disabled Reject confirm surfaces the reason hint', async () => {
+    renderWithProviders(<OffsiteReviewQueue />);
+    await page.getByRole('button', { name: 'Review' }).click();
+    await page.getByTestId('apps-offsite-reject-open').click();
+
+    const confirm = page.getByTestId('apps-offsite-reject-confirm');
+    await expect.element(confirm).toBeDisabled();
+    await confirm.hover();
+    await expect
+      .element(page.getByText('Enter a reason — at least 3 characters.'))
+      .toBeInTheDocument();
+  });
+
   test('the submitted timestamp renders as "Month D, YYYY" (no time-of-day)', async () => {
     renderWithProviders(<OffsiteReviewQueue />);
     // Self-consistent with the component (same helper) → TZ-agnostic.

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -2,6 +2,7 @@ import {
   Alert,
   Anchor,
   Badge,
+  Box,
   Button,
   Card,
   Code,
@@ -527,21 +528,26 @@ export function OffsiteReviewModal({
                     disabled={!reasonTooShort}
                     withArrow
                   >
-                    <Button
-                      color="red"
-                      leftSection={<IconX size={14} />}
-                      onClick={() =>
-                        rejectMut.mutate({
-                          publishRequestId: request.id,
-                          rejectionReason: rejectionReason.trim(),
-                        })
-                      }
-                      disabled={rejectDisabled}
-                      loading={rejectMut.isPending}
-                      data-testid="apps-offsite-reject-confirm"
-                    >
-                      Reject
-                    </Button>
+                    {/* A native disabled <button> fires no pointer events, so the
+                        Tooltip must attach to a wrapper to show in the exact state
+                        it explains (Mantine's documented disabled-target pattern). */}
+                    <Box>
+                      <Button
+                        color="red"
+                        leftSection={<IconX size={14} />}
+                        onClick={() =>
+                          rejectMut.mutate({
+                            publishRequestId: request.id,
+                            rejectionReason: rejectionReason.trim(),
+                          })
+                        }
+                        disabled={rejectDisabled}
+                        loading={rejectMut.isPending}
+                        data-testid="apps-offsite-reject-confirm"
+                      >
+                        Reject
+                      </Button>
+                    </Box>
                   </Tooltip>
                 </Group>
               </Stack>

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -18,6 +18,7 @@ import {
   Text,
   Textarea,
   ThemeIcon,
+  Tooltip,
 } from '@mantine/core';
 import {
   IconAlertTriangle,
@@ -492,41 +493,60 @@ export function OffsiteReviewModal({
         )}
 
         {actionMode === 'reject' ? (
-          <Stack gap="xs">
-            <Text size="sm" fw={600}>
-              Rejection reason
-            </Text>
-            <Textarea
-              autosize
-              minRows={3}
-              maxRows={10}
-              placeholder="Explain what needs to change (≥10 chars, shown to the author)."
-              value={rejectionReason}
-              onChange={(e) => setRejectionReason(e.currentTarget.value)}
-              disabled={busy}
-              data-testid="apps-offsite-reject-reason"
-            />
-            <Group justify="flex-end" gap="xs">
-              <Button variant="default" onClick={() => setActionMode('view')} disabled={busy}>
-                Cancel
-              </Button>
-              <Button
-                color="red"
-                leftSection={<IconX size={14} />}
-                onClick={() =>
-                  rejectMut.mutate({
-                    publishRequestId: request.id,
-                    rejectionReason: rejectionReason.trim(),
-                  })
-                }
-                disabled={busy || rejectionReason.trim().length < 10}
-                loading={rejectMut.isPending}
-                data-testid="apps-offsite-reject-confirm"
-              >
-                Reject
-              </Button>
-            </Group>
-          </Stack>
+          (() => {
+            const reasonLen = rejectionReason.trim().length;
+            const reasonTooShort = reasonLen < OFFSITE_MOD_REASON_MIN;
+            const rejectDisabled = busy || reasonTooShort;
+            return (
+              <Stack gap="xs">
+                <Text size="sm" fw={600}>
+                  Rejection reason
+                </Text>
+                <Textarea
+                  autosize
+                  minRows={3}
+                  maxRows={10}
+                  placeholder={`Explain what needs to change (≥${OFFSITE_MOD_REASON_MIN} chars, shown to the author).`}
+                  description={`${reasonLen}/${OFFSITE_MOD_REASON_MIN} characters minimum`}
+                  error={
+                    reasonTooShort && reasonLen > 0
+                      ? `Enter at least ${OFFSITE_MOD_REASON_MIN} characters.`
+                      : undefined
+                  }
+                  value={rejectionReason}
+                  onChange={(e) => setRejectionReason(e.currentTarget.value)}
+                  disabled={busy}
+                  data-testid="apps-offsite-reject-reason"
+                />
+                <Group justify="flex-end" gap="xs">
+                  <Button variant="default" onClick={() => setActionMode('view')} disabled={busy}>
+                    Cancel
+                  </Button>
+                  <Tooltip
+                    label={`Enter a reason — at least ${OFFSITE_MOD_REASON_MIN} characters.`}
+                    disabled={!reasonTooShort}
+                    withArrow
+                  >
+                    <Button
+                      color="red"
+                      leftSection={<IconX size={14} />}
+                      onClick={() =>
+                        rejectMut.mutate({
+                          publishRequestId: request.id,
+                          rejectionReason: rejectionReason.trim(),
+                        })
+                      }
+                      disabled={rejectDisabled}
+                      loading={rejectMut.isPending}
+                      data-testid="apps-offsite-reject-confirm"
+                    >
+                      Reject
+                    </Button>
+                  </Tooltip>
+                </Group>
+              </Stack>
+            );
+          })()
         ) : actionMode === 'approve' ? (
           <Stack gap="xs">
             <Select

--- a/src/components/Apps/reviewDiffPanels.tsx
+++ b/src/components/Apps/reviewDiffPanels.tsx
@@ -1,0 +1,282 @@
+import { Badge, Button, Card, Code, Group, ScrollArea, Stack, Text } from '@mantine/core';
+import { IconCode, IconExternalLink } from '@tabler/icons-react';
+import { useState } from 'react';
+
+/**
+ * Diff-preview panels for the /apps/review moderator queue (on-site version
+ * review). Extracted from `~/pages/apps/review` — the page pulls in the full
+ * tRPC server graph via `createServerSideProps`, so keeping these pure,
+ * server-free presentational components in their own module lets them be unit
+ * tested in browser mode without booting the server.
+ *
+ * Theme note: all panel/line backgrounds use `light-dark(...)` so they remap for
+ * the dark color scheme instead of rendering a fixed light `gray-0`/`green-0`/
+ * `red-0` shade (the "white diff box in dark mode" bug). Precedent:
+ * `~/pages/moderator/scanner-policies` `bg="light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6))"`.
+ */
+
+// Shared panel background — light gray in the light scheme, a dark surface in
+// the dark scheme (single source of truth for the three diff panels).
+const PANEL_BG = 'light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6))';
+
+export function FileListPreview({
+  added,
+  removed,
+  changed,
+}: {
+  added?: string[];
+  removed?: string[];
+  changed?: string[];
+}) {
+  const lines: Array<{ sigil: '+' | '~' | '-'; path: string; color: string }> = [];
+  for (const p of added ?? []) lines.push({ sigil: '+', path: p, color: 'green' });
+  for (const p of changed ?? []) lines.push({ sigil: '~', path: p, color: 'yellow' });
+  for (const p of removed ?? []) lines.push({ sigil: '-', path: p, color: 'red' });
+  if (lines.length === 0) {
+    return (
+      <Text size="xs" c="dimmed">
+        No file-level changes.
+      </Text>
+    );
+  }
+  return (
+    <ScrollArea.Autosize mah={180} style={{ background: PANEL_BG }}>
+      <Stack gap={2} p={6}>
+        {lines.map((l) => (
+          <Group key={`${l.sigil}-${l.path}`} gap={6} wrap="nowrap">
+            <Text size="xs" c={l.color} fw={700} style={{ width: 12 }}>
+              {l.sigil}
+            </Text>
+            <Code style={{ fontSize: 11 }}>{l.path}</Code>
+          </Group>
+        ))}
+      </Stack>
+    </ScrollArea.Autosize>
+  );
+}
+
+export type FileLineDiff = {
+  path: string;
+  changeKind: 'added' | 'changed';
+  hunks: Array<{
+    oldStart: number;
+    oldLines: number;
+    newStart: number;
+    newLines: number;
+    lines: string[];
+  }>;
+  skipReason: 'binary' | 'too-large' | 'diff-too-large' | 'file-cap' | null;
+  added: number;
+  removed: number;
+};
+
+const SKIP_LABEL: Record<NonNullable<FileLineDiff['skipReason']>, string> = {
+  binary: 'Binary file — view in Forgejo',
+  'too-large': 'File too large to diff — view in Forgejo',
+  'diff-too-large': 'Diff too large to display — view in Forgejo',
+  'file-cap': 'Too many changed files — view this one in Forgejo',
+};
+
+export function FileDiffEntry({ file, forgejoUrl }: { file: FileLineDiff; forgejoUrl: string }) {
+  const [open, setOpen] = useState(false);
+  const elided = file.skipReason !== null;
+
+  return (
+    <Card withBorder p={0}>
+      <Group
+        justify="space-between"
+        wrap="nowrap"
+        p={8}
+        style={{ cursor: elided ? 'default' : 'pointer' }}
+        onClick={() => {
+          if (!elided) setOpen((v) => !v);
+        }}
+      >
+        <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
+          <Badge
+            size="xs"
+            color={file.changeKind === 'added' ? 'green' : 'yellow'}
+            variant="light"
+          >
+            {file.changeKind === 'added' ? 'added' : 'changed'}
+          </Badge>
+          <Code style={{ fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {file.path}
+          </Code>
+        </Group>
+        <Group gap={6} wrap="nowrap">
+          {!elided && file.added > 0 && (
+            <Text size="xs" c="green" fw={700}>
+              +{file.added}
+            </Text>
+          )}
+          {!elided && file.removed > 0 && (
+            <Text size="xs" c="red" fw={700}>
+              −{file.removed}
+            </Text>
+          )}
+          {elided && (
+            <Text size="xs" c="dimmed" fs="italic">
+              {SKIP_LABEL[file.skipReason!]}
+            </Text>
+          )}
+          {!elided && (
+            <Text size="xs" c="blue">
+              {open ? 'hide' : 'show'}
+            </Text>
+          )}
+        </Group>
+      </Group>
+
+      {elided && (
+        <Group p={8} pt={0}>
+          <Button
+            component="a"
+            href={forgejoUrl}
+            target="_blank"
+            rel="noopener"
+            size="compact-xs"
+            variant="subtle"
+            leftSection={<IconCode size={12} />}
+            rightSection={<IconExternalLink size={10} />}
+          >
+            View in Forgejo
+          </Button>
+        </Group>
+      )}
+
+      {open && !elided && (
+        <ScrollArea.Autosize mah={320} style={{ background: PANEL_BG }}>
+          <Stack gap={0} p={6} style={{ fontFamily: 'ui-monospace, monospace', fontSize: 11 }}>
+            {file.hunks.length === 0 ? (
+              <Text size="xs" c="dimmed">
+                No textual change (whitespace/metadata only).
+              </Text>
+            ) : (
+              file.hunks.map((h, hi) => <DiffHunkView key={hi} hunk={h} />)
+            )}
+          </Stack>
+        </ScrollArea.Autosize>
+      )}
+    </Card>
+  );
+}
+
+export function DiffHunkView({
+  hunk,
+}: {
+  hunk: {
+    oldStart: number;
+    oldLines: number;
+    newStart: number;
+    newLines: number;
+    lines: string[];
+  };
+}) {
+  return (
+    <>
+      <Text size="xs" c="cyan" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+        {`@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`}
+      </Text>
+      {hunk.lines.map((line, i) => {
+        const sigil = line[0];
+        const color = sigil === '+' ? 'green' : sigil === '-' ? 'red' : undefined;
+        // Dark-aware +/- highlight — the +9/-9 dark shades keep the add/remove
+        // semantics legible against the dark panel while the light scheme keeps
+        // the familiar pale green/red.
+        const bg =
+          sigil === '+'
+            ? 'light-dark(var(--mantine-color-green-0), var(--mantine-color-green-9))'
+            : sigil === '-'
+            ? 'light-dark(var(--mantine-color-red-0), var(--mantine-color-red-9))'
+            : undefined;
+        return (
+          <Text
+            key={i}
+            size="xs"
+            c={color}
+            style={{
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-all',
+              background: bg,
+              paddingLeft: 4,
+            }}
+          >
+            {line.length === 0 ? ' ' : line}
+          </Text>
+        );
+      })}
+    </>
+  );
+}
+
+export function ManifestDiffPreview({
+  diff,
+}: {
+  diff: { added: string[]; removed: string[]; changed: Array<{ field: string; from: unknown; to: unknown }> };
+}) {
+  if (diff.added.length === 0 && diff.removed.length === 0 && diff.changed.length === 0) {
+    return (
+      <Text size="xs" c="dimmed">
+        No manifest changes (bundle resubmit with code-only diff).
+      </Text>
+    );
+  }
+  return (
+    <ScrollArea.Autosize mah={260} style={{ background: PANEL_BG }}>
+      <Stack gap={6} p={8}>
+        {diff.added.map((field) => (
+          <Group key={`+${field}`} gap={6}>
+            <Text size="xs" c="green" fw={700}>
+              +
+            </Text>
+            <Code style={{ fontSize: 11 }}>{field}</Code>
+            <Text size="xs" c="dimmed">
+              added
+            </Text>
+          </Group>
+        ))}
+        {diff.removed.map((field) => (
+          <Group key={`-${field}`} gap={6}>
+            <Text size="xs" c="red" fw={700}>
+              −
+            </Text>
+            <Code style={{ fontSize: 11 }}>{field}</Code>
+            <Text size="xs" c="dimmed">
+              removed
+            </Text>
+          </Group>
+        ))}
+        {diff.changed.map((change) => (
+          <Stack key={`~${change.field}`} gap={2}>
+            <Group gap={6}>
+              <Text size="xs" c="yellow" fw={700}>
+                ~
+              </Text>
+              <Code style={{ fontSize: 11 }}>{change.field}</Code>
+              <Text size="xs" c="dimmed">
+                changed
+              </Text>
+            </Group>
+            <Group gap={8} pl={18} align="flex-start">
+              <Text size="xs" c="dimmed" style={{ minWidth: 32 }}>
+                from
+              </Text>
+              <Code style={{ fontSize: 10, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                {JSON.stringify(change.from)}
+              </Code>
+            </Group>
+            <Group gap={8} pl={18} align="flex-start">
+              <Text size="xs" c="dimmed" style={{ minWidth: 32 }}>
+                to
+              </Text>
+              <Code style={{ fontSize: 10, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
+                {JSON.stringify(change.to)}
+              </Code>
+            </Group>
+          </Stack>
+        ))}
+      </Stack>
+    </ScrollArea.Autosize>
+  );
+}

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -2,6 +2,7 @@ import {
   Accordion,
   Alert,
   Badge,
+  Box,
   Button,
   Card,
   Code,
@@ -1040,21 +1041,26 @@ function ReviewModal({
                     disabled={!reasonTooShort}
                     withArrow
                   >
-                    <Button
-                      color="red"
-                      leftSection={<IconX size={14} />}
-                      onClick={() =>
-                        rejectMut.mutate({
-                          publishRequestId: request.id,
-                          rejectionReason: rejectionReason.trim(),
-                        })
-                      }
-                      disabled={rejectDisabled}
-                      loading={rejectMut.isPending}
-                      data-testid="apps-review-reject-confirm"
-                    >
-                      Reject
-                    </Button>
+                    {/* A native disabled <button> fires no pointer events, so the
+                        Tooltip must attach to a wrapper to show in the exact state
+                        it explains (Mantine's documented disabled-target pattern). */}
+                    <Box>
+                      <Button
+                        color="red"
+                        leftSection={<IconX size={14} />}
+                        onClick={() =>
+                          rejectMut.mutate({
+                            publishRequestId: request.id,
+                            rejectionReason: rejectionReason.trim(),
+                          })
+                        }
+                        disabled={rejectDisabled}
+                        loading={rejectMut.isPending}
+                        data-testid="apps-review-reject-confirm"
+                      >
+                        Reject
+                      </Button>
+                    </Box>
                   </Tooltip>
                 </Group>
               </Stack>

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -51,6 +51,13 @@ import {
   SCOPE_DESCRIPTIONS,
   SLOT_DESCRIPTIONS,
 } from '~/server/services/blocks/scope-descriptions.constants';
+import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
+import {
+  FileDiffEntry,
+  FileListPreview,
+  ManifestDiffPreview,
+  type FileLineDiff,
+} from '~/components/Apps/reviewDiffPanels';
 import {
   MARKETPLACE_CATEGORIES,
   MARKETPLACE_CATEGORY_LABELS,
@@ -999,39 +1006,60 @@ function ReviewModal({
         </Stack>
 
         {readOnly ? null : actionMode === 'reject' ? (
-          <Stack gap="xs">
-            <Text size="sm" fw={600}>
-              Rejection reason
-            </Text>
-            <Textarea
-              autosize
-              minRows={3}
-              maxRows={10}
-              placeholder="Explain what needs to change before this can be approved (≥10 chars, shown to the dev)."
-              value={rejectionReason}
-              onChange={(e) => setRejectionReason(e.currentTarget.value)}
-              disabled={busy}
-            />
-            <Group justify="flex-end" gap="xs">
-              <Button variant="default" onClick={() => setActionMode('view')} disabled={busy}>
-                Cancel
-              </Button>
-              <Button
-                color="red"
-                leftSection={<IconX size={14} />}
-                onClick={() =>
-                  rejectMut.mutate({
-                    publishRequestId: request.id,
-                    rejectionReason: rejectionReason.trim(),
-                  })
-                }
-                disabled={busy || rejectionReason.trim().length < 10}
-                loading={rejectMut.isPending}
-              >
-                Reject
-              </Button>
-            </Group>
-          </Stack>
+          (() => {
+            const reasonLen = rejectionReason.trim().length;
+            const reasonTooShort = reasonLen < OFFSITE_MOD_REASON_MIN;
+            const rejectDisabled = busy || reasonTooShort;
+            return (
+              <Stack gap="xs">
+                <Text size="sm" fw={600}>
+                  Rejection reason
+                </Text>
+                <Textarea
+                  autosize
+                  minRows={3}
+                  maxRows={10}
+                  placeholder={`Explain what needs to change before this can be approved (≥${OFFSITE_MOD_REASON_MIN} chars, shown to the dev).`}
+                  description={`${reasonLen}/${OFFSITE_MOD_REASON_MIN} characters minimum`}
+                  error={
+                    reasonTooShort && reasonLen > 0
+                      ? `Enter at least ${OFFSITE_MOD_REASON_MIN} characters.`
+                      : undefined
+                  }
+                  value={rejectionReason}
+                  onChange={(e) => setRejectionReason(e.currentTarget.value)}
+                  disabled={busy}
+                  data-testid="apps-review-reject-reason"
+                />
+                <Group justify="flex-end" gap="xs">
+                  <Button variant="default" onClick={() => setActionMode('view')} disabled={busy}>
+                    Cancel
+                  </Button>
+                  <Tooltip
+                    label={`Enter a reason — at least ${OFFSITE_MOD_REASON_MIN} characters.`}
+                    disabled={!reasonTooShort}
+                    withArrow
+                  >
+                    <Button
+                      color="red"
+                      leftSection={<IconX size={14} />}
+                      onClick={() =>
+                        rejectMut.mutate({
+                          publishRequestId: request.id,
+                          rejectionReason: rejectionReason.trim(),
+                        })
+                      }
+                      disabled={rejectDisabled}
+                      loading={rejectMut.isPending}
+                      data-testid="apps-review-reject-confirm"
+                    >
+                      Reject
+                    </Button>
+                  </Tooltip>
+                </Group>
+              </Stack>
+            );
+          })()
         ) : (
           <Stack gap="xs">
             <Textarea
@@ -1495,71 +1523,18 @@ function CurationPanel({ appBlockId }: { appBlockId: string }) {
   );
 }
 
-function FileListPreview({
-  added,
-  removed,
-  changed,
-}: {
-  added?: string[];
-  removed?: string[];
-  changed?: string[];
-}) {
-  const lines: Array<{ sigil: '+' | '~' | '-'; path: string; color: string }> = [];
-  for (const p of added ?? []) lines.push({ sigil: '+', path: p, color: 'green' });
-  for (const p of changed ?? []) lines.push({ sigil: '~', path: p, color: 'yellow' });
-  for (const p of removed ?? []) lines.push({ sigil: '-', path: p, color: 'red' });
-  if (lines.length === 0) {
-    return (
-      <Text size="xs" c="dimmed">
-        No file-level changes.
-      </Text>
-    );
-  }
-  return (
-    <ScrollArea.Autosize mah={180} style={{ background: 'var(--mantine-color-gray-0)' }}>
-      <Stack gap={2} p={6}>
-        {lines.map((l) => (
-          <Group key={`${l.sigil}-${l.path}`} gap={6} wrap="nowrap">
-            <Text size="xs" c={l.color} fw={700} style={{ width: 12 }}>
-              {l.sigil}
-            </Text>
-            <Code style={{ fontSize: 11 }}>{l.path}</Code>
-          </Group>
-        ))}
-      </Stack>
-    </ScrollArea.Autosize>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Line-level code diff — expands the file-level summary with the actual unified
 // line diff per changed/added text file. Lazy: the query only fires once the mod
 // toggles "Show code diff" on, so the modal default stays light. Bounded
 // server-side (text-only, byte/line/file caps); elided files render a "view in
 // Forgejo" fallback rather than inlining unbounded content.
+//
+// The presentational panels (FileListPreview / FileDiffEntry / DiffHunkView /
+// ManifestDiffPreview) + the FileLineDiff type live in the server-free
+// `~/components/Apps/reviewDiffPanels` module so they can be unit tested in
+// browser mode without importing this page's tRPC server graph.
 // ---------------------------------------------------------------------------
-
-type FileLineDiff = {
-  path: string;
-  changeKind: 'added' | 'changed';
-  hunks: Array<{
-    oldStart: number;
-    oldLines: number;
-    newStart: number;
-    newLines: number;
-    lines: string[];
-  }>;
-  skipReason: 'binary' | 'too-large' | 'diff-too-large' | 'file-cap' | null;
-  added: number;
-  removed: number;
-};
-
-const SKIP_LABEL: Record<NonNullable<FileLineDiff['skipReason']>, string> = {
-  binary: 'Binary file — view in Forgejo',
-  'too-large': 'File too large to diff — view in Forgejo',
-  'diff-too-large': 'Diff too large to display — view in Forgejo',
-  'file-cap': 'Too many changed files — view this one in Forgejo',
-};
 
 function CodeDiffPanel({
   publishRequestId,
@@ -1618,211 +1593,6 @@ function CodeDiffPanel({
           </Stack>
         ))}
     </Stack>
-  );
-}
-
-function FileDiffEntry({ file, forgejoUrl }: { file: FileLineDiff; forgejoUrl: string }) {
-  const [open, setOpen] = useState(false);
-  const elided = file.skipReason !== null;
-
-  return (
-    <Card withBorder p={0}>
-      <Group
-        justify="space-between"
-        wrap="nowrap"
-        p={8}
-        style={{ cursor: elided ? 'default' : 'pointer' }}
-        onClick={() => {
-          if (!elided) setOpen((v) => !v);
-        }}
-      >
-        <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
-          <Badge
-            size="xs"
-            color={file.changeKind === 'added' ? 'green' : 'yellow'}
-            variant="light"
-          >
-            {file.changeKind === 'added' ? 'added' : 'changed'}
-          </Badge>
-          <Code style={{ fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis' }}>
-            {file.path}
-          </Code>
-        </Group>
-        <Group gap={6} wrap="nowrap">
-          {!elided && file.added > 0 && (
-            <Text size="xs" c="green" fw={700}>
-              +{file.added}
-            </Text>
-          )}
-          {!elided && file.removed > 0 && (
-            <Text size="xs" c="red" fw={700}>
-              −{file.removed}
-            </Text>
-          )}
-          {elided && (
-            <Text size="xs" c="dimmed" fs="italic">
-              {SKIP_LABEL[file.skipReason!]}
-            </Text>
-          )}
-          {!elided && (
-            <Text size="xs" c="blue">
-              {open ? 'hide' : 'show'}
-            </Text>
-          )}
-        </Group>
-      </Group>
-
-      {elided && (
-        <Group p={8} pt={0}>
-          <Button
-            component="a"
-            href={forgejoUrl}
-            target="_blank"
-            rel="noopener"
-            size="compact-xs"
-            variant="subtle"
-            leftSection={<IconCode size={12} />}
-            rightSection={<IconExternalLink size={10} />}
-          >
-            View in Forgejo
-          </Button>
-        </Group>
-      )}
-
-      {open && !elided && (
-        <ScrollArea.Autosize mah={320} style={{ background: 'var(--mantine-color-gray-0)' }}>
-          <Stack gap={0} p={6} style={{ fontFamily: 'ui-monospace, monospace', fontSize: 11 }}>
-            {file.hunks.length === 0 ? (
-              <Text size="xs" c="dimmed">
-                No textual change (whitespace/metadata only).
-              </Text>
-            ) : (
-              file.hunks.map((h, hi) => <DiffHunkView key={hi} hunk={h} />)
-            )}
-          </Stack>
-        </ScrollArea.Autosize>
-      )}
-    </Card>
-  );
-}
-
-function DiffHunkView({
-  hunk,
-}: {
-  hunk: {
-    oldStart: number;
-    oldLines: number;
-    newStart: number;
-    newLines: number;
-    lines: string[];
-  };
-}) {
-  return (
-    <>
-      <Text size="xs" c="cyan" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-        {`@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`}
-      </Text>
-      {hunk.lines.map((line, i) => {
-        const sigil = line[0];
-        const color = sigil === '+' ? 'green' : sigil === '-' ? 'red' : undefined;
-        const bg =
-          sigil === '+'
-            ? 'var(--mantine-color-green-0)'
-            : sigil === '-'
-            ? 'var(--mantine-color-red-0)'
-            : undefined;
-        return (
-          <Text
-            key={i}
-            size="xs"
-            c={color}
-            style={{
-              whiteSpace: 'pre-wrap',
-              wordBreak: 'break-all',
-              background: bg,
-              paddingLeft: 4,
-            }}
-          >
-            {line.length === 0 ? ' ' : line}
-          </Text>
-        );
-      })}
-    </>
-  );
-}
-
-function ManifestDiffPreview({
-  diff,
-}: {
-  diff: { added: string[]; removed: string[]; changed: Array<{ field: string; from: unknown; to: unknown }> };
-}) {
-  if (
-    diff.added.length === 0 &&
-    diff.removed.length === 0 &&
-    diff.changed.length === 0
-  ) {
-    return (
-      <Text size="xs" c="dimmed">
-        No manifest changes (bundle resubmit with code-only diff).
-      </Text>
-    );
-  }
-  return (
-    <ScrollArea.Autosize mah={260} style={{ background: 'var(--mantine-color-gray-0)' }}>
-      <Stack gap={6} p={8}>
-        {diff.added.map((field) => (
-          <Group key={`+${field}`} gap={6}>
-            <Text size="xs" c="green" fw={700}>
-              +
-            </Text>
-            <Code style={{ fontSize: 11 }}>{field}</Code>
-            <Text size="xs" c="dimmed">
-              added
-            </Text>
-          </Group>
-        ))}
-        {diff.removed.map((field) => (
-          <Group key={`-${field}`} gap={6}>
-            <Text size="xs" c="red" fw={700}>
-              −
-            </Text>
-            <Code style={{ fontSize: 11 }}>{field}</Code>
-            <Text size="xs" c="dimmed">
-              removed
-            </Text>
-          </Group>
-        ))}
-        {diff.changed.map((change) => (
-          <Stack key={`~${change.field}`} gap={2}>
-            <Group gap={6}>
-              <Text size="xs" c="yellow" fw={700}>
-                ~
-              </Text>
-              <Code style={{ fontSize: 11 }}>{change.field}</Code>
-              <Text size="xs" c="dimmed">
-                changed
-              </Text>
-            </Group>
-            <Group gap={8} pl={18} align="flex-start">
-              <Text size="xs" c="dimmed" style={{ minWidth: 32 }}>
-                from
-              </Text>
-              <Code style={{ fontSize: 10, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-                {JSON.stringify(change.from)}
-              </Code>
-            </Group>
-            <Group gap={8} pl={18} align="flex-start">
-              <Text size="xs" c="dimmed" style={{ minWidth: 32 }}>
-                to
-              </Text>
-              <Code style={{ fontSize: 10, whiteSpace: 'pre-wrap', wordBreak: 'break-all' }}>
-                {JSON.stringify(change.to)}
-              </Code>
-            </Group>
-          </Stack>
-        ))}
-      </Stack>
-    </ScrollArea.Autosize>
   );
 }
 

--- a/src/server/routers/__tests__/app-listings.router.offsite-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.offsite-authz.test.ts
@@ -362,10 +362,10 @@ describe('rejectExternalRequest — moderatorProcedure', () => {
     });
   });
 
-  it('a short reason is rejected at the SCHEMA boundary (min 10)', async () => {
+  it('a short reason is rejected at the SCHEMA boundary (min 3)', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
     await expect(
-      caller.rejectExternalRequest({ publishRequestId: 'alpr_1', rejectionReason: 'short' })
+      caller.rejectExternalRequest({ publishRequestId: 'alpr_1', rejectionReason: 'no' })
     ).rejects.toBeInstanceOf(TRPCError);
     expect(mockReject).not.toHaveBeenCalled();
   });

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -634,7 +634,8 @@ export const appListingsRouter = router({
     }),
 
   /**
-   * MOD: reject a pending off-site request (PR-b). Requires `rejectionReason` ≥10
+   * MOD: reject a pending off-site request (PR-b). Requires `rejectionReason`
+   * ≥`OFFSITE_REJECTION_REASON_MIN` (the shared `OFFSITE_MOD_REASON_MIN`, 3)
    * chars; in ONE tx flips the request→rejected + sets `reviewedBy*` and DELETES
    * the draft listing (status-guarded — releases the slug, never removes an
    * approved listing). Failure modes are mapped by `mapOffsiteError` (typed

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1549,8 +1549,9 @@ export const blocksRouter = router({
     }),
 
   /**
-   * Reject a pending publish request. Reason is required (≥10 chars) and
-   * shown to the dev inline on /apps/my-submissions.
+   * Reject a pending publish request. Reason is required
+   * (≥`PUBLISH_REJECTION_REASON_MIN` — the shared `OFFSITE_MOD_REASON_MIN`, 3 —
+   * chars) and shown to the dev inline on /apps/my-submissions.
    */
   rejectRequest: moderatorProcedure
     .use(enforceAppBlocksFlag)

--- a/src/server/schema/blocks/__tests__/offsite-listing.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/offsite-listing.schema.test.ts
@@ -185,7 +185,7 @@ describe('approveExternalRequestSchema', () => {
 });
 
 describe('rejectExternalRequestSchema', () => {
-  it('accepts a reason ≥10 chars', () => {
+  it('accepts a reason ≥ the shared min (OFFSITE_MOD_REASON_MIN=3)', () => {
     expect(
       rejectExternalRequestSchema.safeParse({
         publishRequestId: 'alpr_1',
@@ -194,9 +194,9 @@ describe('rejectExternalRequestSchema', () => {
     ).toBe(true);
   });
 
-  it('rejects a reason <10 chars', () => {
+  it('rejects a reason shorter than the shared min (OFFSITE_MOD_REASON_MIN=3)', () => {
     expect(
-      rejectExternalRequestSchema.safeParse({ publishRequestId: 'alpr_1', rejectionReason: 'short' })
+      rejectExternalRequestSchema.safeParse({ publishRequestId: 'alpr_1', rejectionReason: 'no' })
         .success
     ).toBe(false);
   });

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -6,6 +6,7 @@ import {
   validateExternalUrl,
 } from '~/server/schema/blocks/external-app.schema';
 import { SLUG_REGEX } from '~/server/schema/blocks/publish-request.schema';
+import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
 import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
 
 /**
@@ -43,7 +44,10 @@ export const OFFSITE_CHANGELOG_MAX = 2000;
 
 /** Mod-review note bounds (mirror the on-site approve/reject shapes). */
 export const OFFSITE_APPROVAL_NOTES_MAX = 2000;
-export const OFFSITE_REJECTION_REASON_MIN = 10;
+// Unified with the shared moderator-reason floor (`OFFSITE_MOD_REASON_MIN`, 3)
+// so the reject field matches every other mod-reason field on /apps/review and
+// the client gate + server schema agree — no divergent magic `10`.
+export const OFFSITE_REJECTION_REASON_MIN = OFFSITE_MOD_REASON_MIN;
 export const OFFSITE_REJECTION_REASON_MAX = 2000;
 
 /**
@@ -200,8 +204,10 @@ export type ApproveExternalRequestInput = z.infer<typeof approveExternalRequestS
 /**
  * MOD reject of a pending off-site request (PR-b). Mirrors the on-site
  * `rejectRequestSchema` shape: the request id + a `rejectionReason` of at least
- * 10 chars (the service re-checks the trimmed length as defense-in-depth, since
- * the service is exported + unit-tested directly).
+ * `OFFSITE_REJECTION_REASON_MIN` chars — unified with the shared
+ * `OFFSITE_MOD_REASON_MIN` (3) so it matches every other mod-reason field and the
+ * client gate. The service re-checks the trimmed length as defense-in-depth,
+ * since the service is exported + unit-tested directly.
  */
 export const rejectExternalRequestSchema = z.object({
   publishRequestId: z.string().min(1).max(64),

--- a/src/server/schema/blocks/publish-request.schema.ts
+++ b/src/server/schema/blocks/publish-request.schema.ts
@@ -1,4 +1,5 @@
 import * as z from 'zod';
+import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
 
 /**
  * Schemas for the App Blocks W1 publish-request flow.
@@ -96,9 +97,20 @@ export const approveRequestSchema = z.object({
 
 export type ApproveRequestInput = z.infer<typeof approveRequestSchema>;
 
+/**
+ * On-site reject-reason floor, unified with the shared moderator-reason minimum
+ * (`OFFSITE_MOD_REASON_MIN`, 3) so it matches every other mod-reason field on
+ * /apps/review and the client gate agrees with the server schema (was a magic 10).
+ */
+export const PUBLISH_REJECTION_REASON_MIN = OFFSITE_MOD_REASON_MIN;
+export const PUBLISH_REJECTION_REASON_MAX = 2000;
+
 export const rejectRequestSchema = z.object({
   publishRequestId: z.string().min(1).max(64),
-  rejectionReason: z.string().min(10).max(2000),
+  rejectionReason: z
+    .string()
+    .min(PUBLISH_REJECTION_REASON_MIN)
+    .max(PUBLISH_REJECTION_REASON_MAX),
 });
 
 export type RejectRequestInput = z.infer<typeof rejectRequestSchema>;

--- a/src/server/schema/blocks/reject-reason-min.test.ts
+++ b/src/server/schema/blocks/reject-reason-min.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
+import {
+  OFFSITE_REJECTION_REASON_MIN,
+  rejectExternalRequestSchema,
+} from '~/server/schema/blocks/offsite-listing.schema';
+import {
+  PUBLISH_REJECTION_REASON_MIN,
+  rejectRequestSchema,
+} from '~/server/schema/blocks/publish-request.schema';
+
+/**
+ * Bug 1: the /apps/review Reject confirm was gated on a silent 10-char minimum
+ * while every other moderator-reason field on the page uses the shared 3-char
+ * `OFFSITE_MOD_REASON_MIN`. The minimum is now unified across BOTH server reject
+ * schemas (off-site + on-site) so the client gate and server validation agree —
+ * this test locks that lockstep so a future edit can't silently re-diverge.
+ */
+describe('reject-reason minimum is unified on OFFSITE_MOD_REASON_MIN (Bug 1)', () => {
+  it('both reject-reason floors equal the shared moderator-reason minimum (3)', () => {
+    expect(OFFSITE_MOD_REASON_MIN).toBe(3);
+    expect(OFFSITE_REJECTION_REASON_MIN).toBe(OFFSITE_MOD_REASON_MIN);
+    expect(PUBLISH_REJECTION_REASON_MIN).toBe(OFFSITE_MOD_REASON_MIN);
+  });
+
+  it('off-site reject schema accepts a min-length reason and rejects a shorter one', () => {
+    const atMin = 'a'.repeat(OFFSITE_MOD_REASON_MIN);
+    const tooShort = 'a'.repeat(OFFSITE_MOD_REASON_MIN - 1);
+    expect(
+      rejectExternalRequestSchema.safeParse({ publishRequestId: 'req-1', rejectionReason: atMin })
+        .success
+    ).toBe(true);
+    expect(
+      rejectExternalRequestSchema.safeParse({
+        publishRequestId: 'req-1',
+        rejectionReason: tooShort,
+      }).success
+    ).toBe(false);
+  });
+
+  it('on-site reject schema accepts a min-length reason and rejects a shorter one', () => {
+    const atMin = 'a'.repeat(OFFSITE_MOD_REASON_MIN);
+    const tooShort = 'a'.repeat(OFFSITE_MOD_REASON_MIN - 1);
+    expect(
+      rejectRequestSchema.safeParse({ publishRequestId: 'req-1', rejectionReason: atMin }).success
+    ).toBe(true);
+    expect(
+      rejectRequestSchema.safeParse({ publishRequestId: 'req-1', rejectionReason: tooShort })
+        .success
+    ).toBe(false);
+  });
+});

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -827,9 +827,9 @@ describe('approveExternalRequest', () => {
 describe('rejectExternalRequest', () => {
   const REASON = 'not a real app, looks like spam';
 
-  it('reason < 10 chars → BAD_REQUEST, no DB read/write', async () => {
+  it('reason shorter than the shared min (3) → BAD_REQUEST, no DB read/write', async () => {
     await expect(
-      rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: 'too short' })
+      rejectExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD, rejectionReason: 'no' })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('at least') });
     expect(mockRead.appListingPublishRequest.findUnique).not.toHaveBeenCalled();
     expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -2502,15 +2502,15 @@ describe('rejectRequest', () => {
     expect(updateArg.data.rejectionReason).toBe('short but valid here');
   });
 
-  it('rejects reasons shorter than 10 characters (after trim)', async () => {
+  it('rejects reasons shorter than the shared min (3) after trim', async () => {
     const { rejectRequest } = await import('../publish-request.service');
     await expect(
       rejectRequest({
         publishRequestId: 'pubreq_x',
         reviewerUserId: 999,
-        rejectionReason: '   short   ',
+        rejectionReason: '  no  ',
       })
-    ).rejects.toThrow(/at least 10 characters/);
+    ).rejects.toThrow(/at least 3 characters/);
   });
 
   it('rejects reasons longer than 2000 characters', async () => {

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1590,7 +1590,8 @@ async function applyApprovedRevision(opts: {
 }
 
 /**
- * MOD reject of a pending off-site request. Requires a `rejectionReason` of ≥10
+ * MOD reject of a pending off-site request. Requires a `rejectionReason` of
+ * ≥`OFFSITE_REJECTION_REASON_MIN` (the shared `OFFSITE_MOD_REASON_MIN`, 3)
  * (trimmed) chars, then — in ONE transaction — flips the request
  * `pending → rejected` + sets `reviewedBy*` / `rejectionReason` and DELETES the
  * draft `AppListing` (status-guarded `deleteMany({ id, status:'draft' })` so it can

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -9,6 +9,8 @@ import {
   MAX_SCREENSHOT_SIZE_BYTES,
   MAX_SCREENSHOTS,
   MAX_TOTAL_DECOMPRESSED_BYTES,
+  PUBLISH_REJECTION_REASON_MAX,
+  PUBLISH_REJECTION_REASON_MIN,
   SCREENSHOT_DIR,
   SCREENSHOT_EXTENSIONS,
   type ScreenshotExtension,
@@ -3399,11 +3401,15 @@ export type RejectRequestParams = {
 export async function rejectRequest(params: RejectRequestParams): Promise<void> {
   const { dbRead, dbWrite } = await import('~/server/db/client');
   const reason = params.rejectionReason.trim();
-  if (reason.length < 10) {
-    throw new Error('rejection reason must be at least 10 characters');
+  if (reason.length < PUBLISH_REJECTION_REASON_MIN) {
+    throw new Error(
+      `rejection reason must be at least ${PUBLISH_REJECTION_REASON_MIN} characters`
+    );
   }
-  if (reason.length > 2000) {
-    throw new Error('rejection reason must be at most 2000 characters');
+  if (reason.length > PUBLISH_REJECTION_REASON_MAX) {
+    throw new Error(
+      `rejection reason must be at most ${PUBLISH_REJECTION_REASON_MAX} characters`
+    );
   }
 
   const row = await dbRead.appBlockPublishRequest.findUnique({

--- a/src/tests/pages/apps/review-diff-panels.browser.test.tsx
+++ b/src/tests/pages/apps/review-diff-panels.browser.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so reach it relatively (apps → pages → tests → src → root).
+import { renderWithProviders } from '../../../../test/component-setup';
+import {
+  DiffHunkView,
+  FileDiffEntry,
+  FileListPreview,
+  ManifestDiffPreview,
+  type FileLineDiff,
+} from '~/components/Apps/reviewDiffPanels';
+
+/**
+ * Bug 2 regression — the on-site /apps/review diff panels rendered a fixed light
+ * `gray-0` (and `green-0`/`red-0` line highlights), so in the dark color scheme
+ * the "changed"/diff boxes rendered as white slabs. The fix uses the codebase's
+ * theme-aware `light-dark(...)` convention so the panels remap for dark mode.
+ *
+ * These assertions are color-scheme-independent: they check the AUTHORED inline
+ * style string (which the browser preserves verbatim on the `style` attribute)
+ * contains a `light-dark(...)` value with a dark-scheme fallback — i.e. the
+ * background is NOT hardcoded light-only. That catches a regression to a bare
+ * `var(--mantine-color-gray-0)` without depending on computed-style resolution.
+ */
+
+const inlineStyles = () =>
+  Array.from(document.querySelectorAll<HTMLElement>('[style]')).map(
+    (el) => el.getAttribute('style') ?? ''
+  );
+
+// Every element that paints a `gray-0`/`green-0`/`red-0` diff surface must wrap
+// it in `light-dark(...)` — a bare light-only token is the bug.
+const assertNoLightOnlyDiffBg = () => {
+  for (const s of inlineStyles()) {
+    for (const token of ['gray-0', 'green-0', 'red-0']) {
+      if (s.includes(`var(--mantine-color-${token})`)) {
+        expect(s, `light-only ${token} background must be wrapped in light-dark()`).toContain(
+          'light-dark('
+        );
+      }
+    }
+  }
+};
+
+describe('reviewDiffPanels — dark-theme-aware backgrounds (Bug 2)', () => {
+  test('FileListPreview panel uses a light-dark background, not a fixed light gray', async () => {
+    renderWithProviders(
+      <FileListPreview added={['a.ts']} removed={['b.ts']} changed={['c.ts']} />
+    );
+    await expect.element(page.getByText('a.ts')).toBeInTheDocument();
+    const panel = inlineStyles().find(
+      (s) => s.includes('light-dark(') && s.includes('gray-0') && s.includes('dark-6')
+    );
+    expect(panel, 'FileListPreview scroll panel background').toBeTruthy();
+    assertNoLightOnlyDiffBg();
+  });
+
+  test('ManifestDiffPreview panel uses a light-dark background', async () => {
+    renderWithProviders(
+      <ManifestDiffPreview diff={{ added: ['scopes'], removed: [], changed: [] }} />
+    );
+    await expect.element(page.getByText('scopes')).toBeInTheDocument();
+    const panel = inlineStyles().find(
+      (s) => s.includes('light-dark(') && s.includes('gray-0') && s.includes('dark-6')
+    );
+    expect(panel, 'ManifestDiffPreview scroll panel background').toBeTruthy();
+    assertNoLightOnlyDiffBg();
+  });
+
+  test('DiffHunkView +/- line highlights are dark-aware (green-9/red-9 fallbacks)', async () => {
+    renderWithProviders(
+      <DiffHunkView
+        hunk={{
+          oldStart: 1,
+          oldLines: 1,
+          newStart: 1,
+          newLines: 2,
+          lines: ['+added line', '-removed line', ' context line'],
+        }}
+      />
+    );
+    await expect.element(page.getByText('+added line')).toBeInTheDocument();
+    const styles = inlineStyles();
+    const added = styles.find((s) => s.includes('light-dark(') && s.includes('green-9'));
+    const removed = styles.find((s) => s.includes('light-dark(') && s.includes('red-9'));
+    expect(added, 'added-line highlight uses light-dark green').toBeTruthy();
+    expect(removed, 'removed-line highlight uses light-dark red').toBeTruthy();
+    assertNoLightOnlyDiffBg();
+  });
+
+  test('FileDiffEntry code panel (once expanded) uses a light-dark background', async () => {
+    const file: FileLineDiff = {
+      path: 'src/changed-file.ts',
+      changeKind: 'changed',
+      skipReason: null,
+      added: 1,
+      removed: 1,
+      hunks: [
+        {
+          oldStart: 1,
+          oldLines: 1,
+          newStart: 1,
+          newLines: 1,
+          lines: ['+new', '-old'],
+        },
+      ],
+    };
+    renderWithProviders(<FileDiffEntry file={file} forgejoUrl="https://forge.example/x" />);
+
+    // Collapsed by default → no diff panel painted yet.
+    expect(
+      inlineStyles().some((s) => s.includes('light-dark(') && s.includes('dark-6'))
+    ).toBe(false);
+
+    // Expand the entry (its header toggles the code panel).
+    await page.getByText('src/changed-file.ts').click();
+
+    const panel = inlineStyles().find(
+      (s) => s.includes('light-dark(') && s.includes('gray-0') && s.includes('dark-6')
+    );
+    expect(panel, 'FileDiffEntry expanded code panel background').toBeTruthy();
+    assertNoLightOnlyDiffBg();
+  });
+});


### PR DESCRIPTION
## Bug 1 — Reject button stuck silently disabled

Both moderator review modals on `/apps/review` — the off-site `OffsiteReviewQueue` and the on-site `ReviewModal` — gated their **Reject** confirm on a hardcoded **10-char** minimum with **no inline feedback**, while every other moderator-reason field on the same page uses the shared **3-char** `OFFSITE_MOD_REASON_MIN`. A mod who typed a short reason saw Reject stay silently greyed out.

**Root cause:** magic `10` literals in the two client gates and the two server schemas, divergent from the page's shared reason floor.

**Fix (deterministic — no hardcoded numbers):**
- **Unify the reject-reason minimum on `OFFSITE_MOD_REASON_MIN` (3)** across **both client gates AND both server schemas**, so client and server agree in lockstep:
  - `offsite-listing.schema`: `OFFSITE_REJECTION_REASON_MIN` now `= OFFSITE_MOD_REASON_MIN`.
  - `publish-request.schema`: `rejectRequestSchema` uses a new `PUBLISH_REJECTION_REASON_MIN` (`= OFFSITE_MOD_REASON_MIN`); the `publish-request.service` defense-in-depth check now uses the constant instead of a bare `< 10`.
- **Inline feedback so the gate is never silent again:** a live character counter (`N/3 characters minimum`) + an error hint on the reject textarea, and a disabled-reason `Tooltip` on the Reject confirm button.
- Updated the three now-stale `≥10` doc comments (router + service) to reference the shared constant.

## Bug 2 — diff / "changed" panels rendered white in dark theme

Three on-site diff panels (`FileListPreview`, `FileDiffEntry`, `ManifestDiffPreview`) hardcoded a fixed light `var(--mantine-color-gray-0)` background, and the per-line diff highlights hardcoded `green-0` / `red-0` — none remapped for the dark color scheme, so the diff boxes rendered as white slabs in dark mode.

**Fix:** the codebase's theme-aware `light-dark()` convention (direct precedent: `moderator/scanner-policies` `bg="light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6))"`):
- panels → `light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6))`
- `+` lines → `light-dark(var(--mantine-color-green-0), var(--mantine-color-green-9))`
- `-` lines → `light-dark(var(--mantine-color-red-0), var(--mantine-color-red-9))`

The pure presentational panels were extracted into a **server-free** `~/components/Apps/reviewDiffPanels` module — the `review` page pulls in the full tRPC server graph via `createServerSideProps`, so the panels can't be browser-tested from the page itself.

## Tests
- **`OffsiteReviewQueue.browser.test`** (extended): Reject confirm is **disabled** with an empty/too-short reason and becomes **enabled** once a ≥min-length reason is typed (and disabled again on whitespace-only) — also catches any genuine wiring defect if the gate never opens.
- **`reject-reason-min.test`** (new unit): locks the **client+server constant lockstep** — both reject schemas accept a 3-char reason and reject a 2-char one; all three floors equal `OFFSITE_MOD_REASON_MIN`.
- **`review-diff-panels.browser.test`** (new): the three panels + the `+`/`-` line highlights use `light-dark(...)` (asserts no light-only token), including the expand-to-open `FileDiffEntry` code panel.

All new/touched tests pass (29 component + 3 unit). `tsc --noEmit` is clean for every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)