### PR TITLE
feat(apps): comments on app-listing detail pages (CommentsV2 appListing entity)

### DIFF
--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -2496,6 +2496,15 @@ model AppBlockPublishRequest {
 /// NOT run prisma migrate deploy; the committed SQL is hand-applied per env.
 model AppListing {
   id              String       @id // apl_<ULID>
+  // Integer surrogate for CommentsV2. The store `id` is a TEXT ULID, but a
+  // CommentsV2 `Thread` parent FK must be Int (`Thread.appListingId Int? @unique`)
+  // — CommentsV2 is integer-keyed end to end. This UNIQUE auto-increment surrogate
+  // bridges the two; it is NOT the PK (`id` stays the ULID). DB-assigned
+  // (autoincrement) + backfilled for existing rows by the w13 comments migration.
+  serialId        Int          @unique @default(autoincrement()) @map("serial_id")
+  // The CommentsV2 discussion thread for this listing (parent = serialId). Optional
+  // 1:1 — created lazily on the first comment/lock (mirrors every other Thread parent).
+  thread          Thread?      @relation("AppListingThread")
   // Store kind discriminator: 'onsite' (an AppBlock we host) or 'offsite'
   // (external-link or OAuth-connect). Validated in the service + a DB CHECK.
   kind            String
@@ -3491,6 +3500,11 @@ model Thread {
   model3d          Model3D?        @relation(fields: [model3dId], references: [id], onDelete: SetNull)
   model3dReviewId  Int?            @unique
   model3dReview    Model3DReview?  @relation(fields: [model3dReviewId], references: [id], onDelete: SetNull)
+  // App-store listing comments (W13). References the AppListing INTEGER surrogate
+  // (`serial_id`), NOT its TEXT ULID `id` — CommentsV2 is integer-keyed. `app_listings`
+  // is the same DB (main civitai nvme0), so this is a plain FK, not a cross-DB bridge.
+  appListingId     Int?            @unique
+  appListing       AppListing?     @relation("AppListingThread", fields: [appListingId], references: [serialId], onDelete: SetNull)
 
   metadata     Json @default("{}") // unused
   commentCount Int  @default(0)

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -333,6 +333,7 @@ export type Appeal = {
 };
 export type AppListing = {
   id: string;
+  serial_id: Generated<number>;
   kind: string;
   slug: string;
   name: string;
@@ -3428,6 +3429,7 @@ export type Thread = {
   challengeId: number | null;
   model3dId: number | null;
   model3dReviewId: number | null;
+  appListingId: number | null;
   metadata: Generated<unknown>;
   commentCount: Generated<number>;
 };

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -1873,6 +1873,8 @@ export interface AppBlockPublishRequest {
 
 export interface AppListing {
   id: string;
+  serialId: number;
+  thread?: Thread | null;
   kind: string;
   slug: string;
   name: string;
@@ -2396,6 +2398,8 @@ export interface Thread {
   model3d?: Model3D | null;
   model3dReviewId: number | null;
   model3dReview?: Model3DReview | null;
+  appListingId: number | null;
+  appListing?: AppListing | null;
   metadata: JsonValue;
   commentCount: number;
   comments?: CommentV2[];

--- a/prisma/migrations/20260715120000_w13_app_listing_comments/migration.sql
+++ b/prisma/migrations/20260715120000_w13_app_listing_comments/migration.sql
@@ -1,0 +1,74 @@
+-- ============================================================
+-- App Store Listings (W13) — comments on app-listing detail pages (CommentsV2)
+-- ============================================================
+-- Attaches the reusable CommentsV2 system (polymorphic `Thread` + `CommentV2`) to
+-- `app_listings`, exactly the way `model3d` / every other entity type is attached:
+-- a new nullable-unique parent FK column on `Thread` (`appListingId`). This unlocks
+-- the shared comment write/read/moderation path (lock/hide/pin/report/rate-limit)
+-- for the entity type `appListing` with NO service code change — the service
+-- resolves the thread by string-interpolating `${entityType}Id` → `appListingId`.
+--
+-- THE ONE BRIDGE: CommentsV2 is INTEGER-keyed end to end (`Thread.<parent>Id Int?
+-- @unique`), but `app_listings` has a TEXT ULID PK (`apl_<ULID>`). So we cannot
+-- point `Thread.appListingId` (Int) at `app_listings.id` (text). We add an INTEGER
+-- surrogate `app_listings.serial_id` (UNIQUE, auto-increment, auto-backfilled for
+-- existing rows) and FK `Thread.appListingId -> app_listings.serial_id`. `id` stays
+-- the ULID PK. `Thread`, `CommentV2`, and `app_listings` are ALL in the SAME DB
+-- (main civitai CNPG nvme0) — this is an id-TYPE bridge, NOT a cross-DB one.
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai CNPG
+-- nvme0 DB does NOT auto-apply migrations (no `prisma migrate deploy`). This file is
+-- committed for HISTORY ONLY; a HUMAN applies the SQL below per environment
+-- (psql/retool). CI / deploy do NOT run it. Apply to BOTH, BEFORE the code that
+-- reads/writes the new column ships to that env:
+--   1. the dev clone (cnpg-cluster-dev, ns cnpg-database-dev, db civitai) — BEFORE
+--      the PR preview smoke.
+--   2. prod nvme0 (the live civitai DB) — BEFORE the release carrying the reader
+--      (the `serial_id` in the listing-detail DTO) + writer (the comments UI).
+--
+-- Idempotent: IF NOT EXISTS guards on the column + index, and pg_constraint guards
+-- on the two constraints, so a manual re-run is a no-op.
+
+-- ------------------------------------------------------------
+-- 1. app_listings.serial_id — the INTEGER surrogate (CommentsV2 bridge)
+-- ------------------------------------------------------------
+-- SERIAL matches the local convention (app_listing_reviews.id etc.). Adding a
+-- SERIAL column to a populated table backfills every existing row via its DEFAULT
+-- nextval() — the surrogate is assigned automatically, no manual backfill needed.
+ALTER TABLE "app_listings"
+  ADD COLUMN IF NOT EXISTS "serial_id" SERIAL;
+
+-- UNIQUE *constraint* (not just an index): a Postgres FK target must be a unique
+-- constraint / primary key, so `Thread.appListingId -> serial_id` needs this. The
+-- constraint creates its own backing unique index; Prisma reads it as `@unique`.
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'app_listings_serial_id_key'
+  ) THEN
+    ALTER TABLE "app_listings"
+      ADD CONSTRAINT "app_listings_serial_id_key" UNIQUE ("serial_id");
+  END IF;
+END $$;
+
+-- ------------------------------------------------------------
+-- 2. Thread.appListingId — the new polymorphic parent FK (mirrors model3dId)
+-- ------------------------------------------------------------
+-- Same shape as every other `Thread` parent: a nullable-unique Int column + a FK
+-- with ON DELETE SET NULL (deleting a listing detaches, never cascades, its thread)
+-- ON UPDATE CASCADE. Matches the 20260526120000_add_3d_models `model3dId` pattern.
+ALTER TABLE "Thread"
+  ADD COLUMN IF NOT EXISTS "appListingId" INTEGER;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Thread_appListingId_key"
+  ON "Thread" ("appListingId");
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'Thread_appListingId_fkey'
+  ) THEN
+    ALTER TABLE "Thread"
+      ADD CONSTRAINT "Thread_appListingId_fkey"
+      FOREIGN KEY ("appListingId") REFERENCES "app_listings" ("serial_id")
+      ON DELETE SET NULL ON UPDATE CASCADE;
+  END IF;
+END $$;

--- a/prisma/migrations/20260715120000_w13_app_listing_comments/migration.sql
+++ b/prisma/migrations/20260715120000_w13_app_listing_comments/migration.sql
@@ -26,8 +26,17 @@
 --   2. prod nvme0 (the live civitai DB) — BEFORE the release carrying the reader
 --      (the `serial_id` in the listing-detail DTO) + writer (the comments UI).
 --
--- Idempotent: IF NOT EXISTS guards on the column + index, and pg_constraint guards
+-- Idempotent: IF NOT EXISTS guards on the columns + index, and pg_constraint guards
 -- on the two constraints, so a manual re-run is a no-op.
+--
+-- 🔴 LOCK NOTE — the `Thread` unique index is built CONCURRENTLY (see step 2).
+-- `Thread` is a hot, site-wide comment table; a plain (non-CONCURRENTLY) unique
+-- index build takes a SHARE lock that blocks EVERY comment write for the build
+-- duration. CREATE INDEX CONCURRENTLY canNOT run inside a transaction/DO block —
+-- run that ONE statement OUTSIDE any transaction (e.g. as its own psql command,
+-- not inside BEGIN/COMMIT), ideally in a low-traffic window. If it ever fails
+-- mid-build it leaves an INVALID index — drop it (`DROP INDEX IF EXISTS
+-- "Thread_appListingId_key"`) and re-run this statement.
 
 -- ------------------------------------------------------------
 -- 1. app_listings.serial_id — the INTEGER surrogate (CommentsV2 bridge)
@@ -59,9 +68,15 @@ END $$;
 ALTER TABLE "Thread"
   ADD COLUMN IF NOT EXISTS "appListingId" INTEGER;
 
-CREATE UNIQUE INDEX IF NOT EXISTS "Thread_appListingId_key"
+-- 🔴 RUN OUTSIDE ANY TRANSACTION (CONCURRENTLY can't run in a txn/DO block).
+-- Non-blocking on the hot `Thread` table — a plain build would SHARE-lock every
+-- comment write for its duration. IF NOT EXISTS keeps it idempotent.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "Thread_appListingId_key"
   ON "Thread" ("appListingId");
 
+-- FK added NOT VALID (skips the full-table validation scan / its lock — trivial
+-- here since the column is all-NULL on an existing table, but correct-by-default),
+-- then VALIDATEd separately (VALIDATE takes only a light SHARE UPDATE lock).
 DO $$ BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM pg_constraint WHERE conname = 'Thread_appListingId_fkey'
@@ -69,6 +84,9 @@ DO $$ BEGIN
     ALTER TABLE "Thread"
       ADD CONSTRAINT "Thread_appListingId_fkey"
       FOREIGN KEY ("appListingId") REFERENCES "app_listings" ("serial_id")
-      ON DELETE SET NULL ON UPDATE CASCADE;
+      ON DELETE SET NULL ON UPDATE CASCADE
+      NOT VALID;
   END IF;
 END $$;
+
+ALTER TABLE "Thread" VALIDATE CONSTRAINT "Thread_appListingId_fkey";

--- a/src/components/Apps/AppListingComments.browser.test.tsx
+++ b/src/components/Apps/AppListingComments.browser.test.tsx
@@ -1,0 +1,109 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * AppListingComments — mounts the reusable CommentsV2 stack on an app-listing
+ * detail page for the entity type `appListing`, keyed on the listing's INTEGER
+ * surrogate (`serialId` = `app_listings.serial_id`), because CommentsV2 is
+ * integer-keyed and the listing PK is a TEXT ULID.
+ *
+ * This pins the integration contract without booting the whole comment stack:
+ *   - `RootThreadProvider` (the CommentsProvider entry) is mocked to RECORD the
+ *     `entityType`/`entityId` it's mounted with, then render its children so the
+ *     component's own "Discussion" wrapper renders. The leaf comment/filter UI is
+ *     stubbed to null (hermetic — no tRPC).
+ *   - serialId present (an APPROVED listing — `getListingDetail` is approved-only,
+ *     so a non-approved listing never yields a serialId-bearing detail to the body)
+ *     → the provider is mounted with entityType="appListing" + the integer id, and
+ *     the Discussion section renders.
+ *   - serialId null/undefined → the whole section renders NOTHING (the provider is
+ *     never mounted).
+ */
+
+const mocks = vi.hoisted(() => ({
+  // Records the props each RootThreadProvider mount received.
+  providerMounts: [] as Array<{ entityType: unknown; entityId: unknown }>,
+}));
+
+// Mock the CommentsProvider entry point: record the mount props + render children
+// with a benign, unlocked/loaded arg set so the component's Discussion wrapper
+// renders (leaves are stubbed below, so no network).
+vi.mock('~/components/CommentsV2/CommentsProvider', () => ({
+  RootThreadProvider: ({
+    entityType,
+    entityId,
+    children,
+  }: {
+    entityType: unknown;
+    entityId: unknown;
+    children: (args: Record<string, unknown>) => React.ReactNode;
+  }) => {
+    mocks.providerMounts.push({ entityType, entityId });
+    return (
+      <div data-testid="root-thread" data-entity-type={String(entityType)} data-entity-id={String(entityId)}>
+        {children({
+          data: [],
+          created: [],
+          isLoading: false,
+          isFetching: false,
+          isFetchingNextPage: false,
+          isLocked: false,
+          showMore: false,
+          hiddenCount: 0,
+          toggleShowMore: () => undefined,
+          sort: 'Oldest',
+          setSort: () => undefined,
+          activeComment: undefined,
+        })}
+      </div>
+    );
+  },
+}));
+
+// Leaf UI stubbed to null — keeps the render hermetic (they otherwise pull tRPC).
+vi.mock('~/components/CommentsV2/Comment/Comment', () => ({ Comment: () => null }));
+vi.mock('~/components/CommentsV2/Comment/CreateComment', () => ({ CreateComment: () => null }));
+vi.mock('~/components/CommentsV2/ReturnToRootThread', () => ({ ReturnToRootThread: () => null }));
+vi.mock('~/components/CommentsV2/HiddenCommentsModal', () => ({ default: () => null }));
+vi.mock('~/components/Filters', () => ({ SortFilter: () => null }));
+vi.mock('~/components/Dialog/dialogStore', () => ({ dialogStore: { trigger: vi.fn() } }));
+
+import { AppListingComments } from './AppListingComments';
+
+beforeEach(() => {
+  mocks.providerMounts.length = 0;
+});
+
+describe('AppListingComments', () => {
+  test('an approved listing (integer serialId) mounts CommentsProvider with entityType="appListing"', async () => {
+    renderWithProviders(<AppListingComments serialId={42} ownerUserId={7} />);
+
+    // The comments section renders…
+    await expect.element(page.getByTestId('app-listing-comments')).toBeInTheDocument();
+    await expect.element(page.getByText('Discussion')).toBeInTheDocument();
+
+    // …and the provider was mounted keyed on the appListing entity + integer id.
+    expect(mocks.providerMounts).toHaveLength(1);
+    expect(mocks.providerMounts[0]).toEqual({ entityType: 'appListing', entityId: 42 });
+
+    const node = page.getByTestId('root-thread').element();
+    expect(node.getAttribute('data-entity-type')).toBe('appListing');
+    expect(node.getAttribute('data-entity-id')).toBe('42');
+  });
+
+  test('renders nothing when serialId is null (no surrogate ⇒ no comments surface)', async () => {
+    renderWithProviders(<AppListingComments serialId={null} ownerUserId={7} />);
+    expect(page.getByTestId('app-listing-comments').query()).toBeNull();
+    expect(page.getByTestId('root-thread').query()).toBeNull();
+    expect(mocks.providerMounts).toHaveLength(0);
+  });
+
+  test('renders nothing when serialId is undefined', async () => {
+    renderWithProviders(<AppListingComments serialId={undefined} />);
+    expect(page.getByTestId('app-listing-comments').query()).toBeNull();
+    expect(page.getByTestId('root-thread').query()).toBeNull();
+    expect(mocks.providerMounts).toHaveLength(0);
+  });
+});

--- a/src/components/Apps/AppListingComments.tsx
+++ b/src/components/Apps/AppListingComments.tsx
@@ -1,0 +1,149 @@
+import { Button, Center, Divider, Group, Loader, Stack, Text, Title } from '@mantine/core';
+import { IconMessageCancel } from '@tabler/icons-react';
+import { Comment } from '~/components/CommentsV2/Comment/Comment';
+import { CreateComment } from '~/components/CommentsV2/Comment/CreateComment';
+import classes from '~/components/CommentsV2/Comment/Comment.module.css';
+import { RootThreadProvider } from '~/components/CommentsV2/CommentsProvider';
+import HiddenCommentsModal from '~/components/CommentsV2/HiddenCommentsModal';
+import { ReturnToRootThread } from '~/components/CommentsV2/ReturnToRootThread';
+import { dialogStore } from '~/components/Dialog/dialogStore';
+import { SortFilter } from '~/components/Filters';
+import type { ThreadSort } from '~/server/common/enums';
+
+/**
+ * App Store Listings (W13) — the CommentsV2 discussion on an app-listing detail
+ * page. Mirrors `Model3DComments`/`ArticleDetailComments` for the new entity type
+ * `appListing`; the entity type is registered in `commentv2.schema.ts` and the
+ * thread attaches via `Thread.appListingId` (→ `app_listings.serial_id`).
+ *
+ * Reuse: EVERYTHING here (write/read/pagination/sort + the inherited moderation —
+ * lock/hide/pin/report/rate-limit) is the shared CommentsV2 stack keyed on the
+ * Thread; there is NO per-listing permission logic. Additive + separate from the
+ * existing recommend-style `app_listing_reviews` (`AppListingReviews`).
+ *
+ * Gating: `serialId` is the listing's integer surrogate, carried only on the public
+ * `ListingDetail` DTO — which `getListingDetail` returns for APPROVED listings only
+ * (a draft/pending/rejected/removed or non-deployed listing 404s server-side, so it
+ * never reaches this body). We additionally render nothing when `serialId` is
+ * missing (defense-in-depth: no thread key ⇒ no comments surface).
+ */
+export function AppListingComments({
+  serialId,
+  ownerUserId,
+}: {
+  /** `app_listings.serial_id` — the CommentsV2 thread key (integer). */
+  serialId: number | null | undefined;
+  /** Listing owner (developer) — badged "op" in the thread. Null when unknown. */
+  ownerUserId?: number | null;
+}) {
+  if (serialId == null) return null;
+
+  return (
+    <RootThreadProvider
+      entityType="appListing"
+      entityId={serialId}
+      // Short discussion preview + "Load more" CTA, matching the other detail pages.
+      limit={5}
+      hideWhenLocked
+      badges={ownerUserId ? [{ userId: ownerUserId, label: 'op', color: 'violet' }] : undefined}
+    >
+      {({
+        data,
+        created,
+        isLoading,
+        isFetching,
+        isFetchingNextPage,
+        isLocked,
+        showMore,
+        hiddenCount,
+        toggleShowMore,
+        sort,
+        setSort,
+        activeComment,
+      }) =>
+        isLocked ? null : (
+          <Stack mt="xl" gap="xl" data-testid="app-listing-comments">
+            <Divider />
+            <Stack gap={0}>
+              <Group justify="space-between">
+                <Group gap="md">
+                  <Title order={4}>Discussion</Title>
+                  {hiddenCount > 0 && !isLoading && (
+                    <Button
+                      variant="subtle"
+                      onClick={() =>
+                        dialogStore.trigger({
+                          component: HiddenCommentsModal,
+                          props: { entityId: serialId, entityType: 'appListing', userId: ownerUserId ?? undefined },
+                        })
+                      }
+                      size="compact-xs"
+                    >
+                      <Group gap={4} justify="center">
+                        <IconMessageCancel size={16} />
+                        <Text inherit inline>
+                          {`See ${hiddenCount} more hidden ${
+                            hiddenCount > 1 ? 'comments' : 'comment'
+                          }`}
+                        </Text>
+                      </Group>
+                    </Button>
+                  )}
+                </Group>
+                <SortFilter
+                  type="threads"
+                  value={sort}
+                  onChange={(v) => setSort(v as ThreadSort)}
+                />
+              </Group>
+              <ReturnToRootThread />
+            </Stack>
+            {isLoading || isFetching ? (
+              <Center mt="xl">
+                <Loader type="bars" />
+              </Center>
+            ) : (
+              <>
+                {activeComment && (
+                  <Stack gap="xl">
+                    <Divider />
+                    <Text size="sm" c="dimmed">
+                      Viewing thread for
+                    </Text>
+                    <Comment comment={activeComment} viewOnly />
+                  </Stack>
+                )}
+                <Stack
+                  gap="xl"
+                  className={activeComment ? classes.rootCommentReplyInset : undefined}
+                >
+                  <CreateComment />
+                  <Stack className="relative" gap="xl">
+                    {data?.map((comment) => (
+                      <Comment key={comment.id} comment={comment} resourceOwnerId={ownerUserId ?? undefined} />
+                    ))}
+                  </Stack>
+                  {showMore && (
+                    <Center>
+                      <Button
+                        onClick={toggleShowMore}
+                        loading={isFetchingNextPage}
+                        variant="subtle"
+                        size="md"
+                      >
+                        Load More Comments
+                      </Button>
+                    </Center>
+                  )}
+                  {created.map((comment) => (
+                    <Comment key={comment.id} comment={comment} resourceOwnerId={ownerUserId ?? undefined} />
+                  ))}
+                </Stack>
+              </>
+            )}
+          </Stack>
+        )
+      }
+    </RootThreadProvider>
+  );
+}

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -33,6 +33,7 @@ import {
   type ListingBadgeKind,
 } from '~/components/Apps/appListingCardView';
 import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
+import { AppListingComments } from '~/components/Apps/AppListingComments';
 import { ReportListingButton } from '~/components/Apps/ReportListingButton';
 import { ReviewListingButton } from '~/components/Apps/ReviewListingButton';
 import { AppListingReviews } from '~/components/Apps/AppListingReviews';
@@ -405,6 +406,12 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
             permissions.
           </Alert>
         )}
+
+      {/* CommentsV2 discussion — reuses the shared comment + moderation stack keyed
+          on the listing's Thread (`entityType="appListing"`, integer surrogate).
+          Additive + separate from the recommend-style reviews above. Only reached
+          for an APPROVED listing (getListingDetail is approved-only). */}
+      <AppListingComments serialId={detail.serialId} ownerUserId={detail.creator?.id ?? null} />
     </Stack>
   );
 }

--- a/src/components/CommentsV2/HiddenCommentsModal.tsx
+++ b/src/components/CommentsV2/HiddenCommentsModal.tsx
@@ -19,7 +19,8 @@ type CommentEntityType =
   | 'bountyEntry'
   | 'challenge'
   | 'comment'
-  | 'image';
+  | 'image'
+  | 'appListing';
 
 export default function HiddenCommentsModal({
   entityId,

--- a/src/server/notifications/__tests__/comment.appListing-exclusion.test.ts
+++ b/src/server/notifications/__tests__/comment.appListing-exclusion.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { commentNotifications, threadUrlMap } from '~/server/notifications/comment.notifications';
+
+/**
+ * App-store-listing (`appListing`) comment threads must NOT emit reply
+ * notifications yet. The owner-facing `new-comment` processors are per-entity SQL
+ * (no appListing branch → no rows → graceful). But the entity-AGNOSTIC reply
+ * processors `new-comment-reply` + `new-thread-response` fire for a reply in ANY
+ * CommentV2 thread — and for an appListing thread they'd resolve `threadParentId`
+ * to NULL and `threadType` to the `'comment'` fallback, so `threadUrlMap` returns
+ * `undefined` (a broken-link notification). appListing pages are addressed by SLUG
+ * (not the id the notification query has), so a correct reply URL needs a slug
+ * join — deferred. Until then we EXCLUDE appListing threads from both reply
+ * processors via an `appListingId IS NULL` guard in their SQL.
+ */
+
+type Def = { prepareQuery: (args: { lastSent: string }) => string };
+const defs = commentNotifications as unknown as Record<string, Def>;
+
+describe('comment reply notifications — appListing exclusion', () => {
+  it('root cause: threadUrlMap has no appListing entry → undefined URL for such a reply', () => {
+    // The `'comment'`-fallback threadType an appListing thread would produce is not
+    // in the map → undefined (a broken-link notification). This is WHY we exclude.
+    expect(threadUrlMap({ threadType: 'comment', threadParentId: null })).toBeUndefined();
+    expect(threadUrlMap({ threadType: 'appListing', threadParentId: 5 })).toBeUndefined();
+    // Sanity: a handled type still resolves, so the exclusion is targeted.
+    expect(threadUrlMap({ threadType: 'model', threadParentId: 5 })).toContain('/models/5');
+  });
+
+  it('new-comment-reply SQL excludes appListing threads (guard on the root thread)', () => {
+    const sql = defs['new-comment-reply'].prepareQuery({ lastSent: '2026-01-01' });
+    expect(sql).toContain('root."appListingId" IS NULL');
+  });
+
+  it('new-thread-response SQL excludes appListing threads (guard on BOTH root + immediate thread)', () => {
+    const sql = defs['new-thread-response'].prepareQuery({ lastSent: '2026-01-01' });
+    expect(sql).toContain('root."appListingId" IS NULL');
+    expect(sql).toContain('t."appListingId" IS NULL');
+  });
+});

--- a/src/server/notifications/comment.notifications.ts
+++ b/src/server/notifications/comment.notifications.ts
@@ -195,6 +195,11 @@ export const commentNotifications = createNotificationProcessor({
         JOIN "User" u ON c."userId" = u.id
         JOIN "Thread" root ON root.id = t."rootThreadId"
         WHERE c."createdAt" > '${lastSent}' AND c."userId" != pc."userId"
+          -- Exclude appListing (app-store listing) threads: they are addressed by
+          -- SLUG, not the id this query has, so threadUrlMap can't build a reply
+          -- URL (→ url:undefined). appListing reply notifications are deferred
+          -- until a slug-resolving URL exists. (appListingId lives on the root.)
+          AND root."appListingId" IS NULL
       )
       SELECT
         concat('new-comment-reply:owner:v2:', details->>'commentId') "key",
@@ -326,6 +331,12 @@ export const commentNotifications = createNotificationProcessor({
           -- Unhandled thread types...
           AND t."questionId" IS NULL
           AND t."answerId" IS NULL
+          -- Exclude appListing (app-store listing) threads — same reason as
+          -- new-comment-reply above: no slug-resolving URL yet, so a reply here
+          -- would emit a notification with url:undefined. Guard BOTH the root and
+          -- the immediate thread (the entity parent may sit on either here).
+          AND root."appListingId" IS NULL
+          AND t."appListingId" IS NULL
       )
       SELECT
         concat('new-thread-response:user:', case when details->>'version' is not null then 'v2:' else 'v1:' end, details->>'commentId') "key",

--- a/src/server/schema/__tests__/commentv2.appListing.schema.test.ts
+++ b/src/server/schema/__tests__/commentv2.appListing.schema.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import {
+  commentConnectorSchema,
+  toggleHideCommentSchema,
+} from '~/server/schema/commentv2.schema';
+
+/**
+ * CommentsV2 schema — the `appListing` entity type must be accepted by BOTH the
+ * supported-parent enums that gate the shared comment procs. These two enums must
+ * agree; a value in one but not the other silently breaks a moderation path.
+ */
+describe('commentv2 schema — appListing entity type', () => {
+  it('commentConnectorSchema accepts appListing with a numeric entityId', () => {
+    const parsed = commentConnectorSchema.parse({ entityType: 'appListing', entityId: 42 });
+    expect(parsed.entityType).toBe('appListing');
+    expect(parsed.entityId).toBe(42);
+  });
+
+  it('commentConnectorSchema rejects a non-numeric entityId (CommentsV2 is int-keyed)', () => {
+    // The listing PK is a TEXT ULID, but the comment thread key is the INTEGER
+    // surrogate — passing the ULID here must fail (guards the id-type bridge).
+    expect(() =>
+      commentConnectorSchema.parse({ entityType: 'appListing', entityId: 'apl_01H' as unknown as number })
+    ).toThrow();
+  });
+
+  it('toggleHideCommentSchema (moderation) accepts appListing', () => {
+    const parsed = toggleHideCommentSchema.parse({
+      id: 1,
+      entityType: 'appListing',
+      entityId: 42,
+    });
+    expect(parsed.entityType).toBe('appListing');
+  });
+
+  it('rejects an unknown entity type', () => {
+    expect(() =>
+      commentConnectorSchema.parse({ entityType: 'notAThing', entityId: 1 })
+    ).toThrow();
+  });
+});

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -185,6 +185,14 @@ export type ListingDetailKindData =
 /** Full public detail for one approved listing (card fields + gallery + body). */
 export type ListingDetail = {
   id: string;
+  /**
+   * Integer surrogate key (`app_listings.serial_id`). Carried so the detail page
+   * can mount the CommentsV2 discussion (`<CommentsProvider entityType="appListing"
+   * entityId={serialId} />`) — CommentsV2 is integer-keyed, the store `id` is a TEXT
+   * ULID. Public + non-sensitive (an opaque row number, like the numeric ids already
+   * exposed for images/models/posts).
+   */
+  serialId: number;
   slug: string;
   kind: ListingKind;
   name: string;

--- a/src/server/schema/commentv2.schema.ts
+++ b/src/server/schema/commentv2.schema.ts
@@ -21,6 +21,7 @@ export const commentConnectorSchema = z.object({
     'comicChapter',
     'model3d',
     'model3dReview',
+    'appListing',
   ]),
   hidden: z.boolean().nullish(),
   parentThreadId: z.number().optional(),
@@ -60,6 +61,7 @@ export const toggleHideCommentSchema = z.object({
     'comicChapter',
     'model3d',
     'model3dReview',
+    'appListing',
   ]),
 });
 

--- a/src/server/services/__tests__/commentsv2.appListing.service.test.ts
+++ b/src/server/services/__tests__/commentsv2.appListing.service.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * CommentsV2 — `appListing` entity type (W13 app-store-listing comments).
+ *
+ * The reusable CommentsV2 service resolves/creates a listing's thread by
+ * string-interpolating the parent column: `where: { [`${entityType}Id`]: entityId }`.
+ * These tests pin that the NEW entity type `appListing` maps to the
+ * `Thread.appListingId` column across the read / write / moderation paths — the
+ * whole integration is "the column + the enum value exist", so this is the
+ * behavioural contract that the feature rides on. No DB: `dbRead`/`dbWrite` are
+ * mocked so we can assert the exact `where`/`data` the service builds.
+ */
+
+const { db } = vi.hoisted(() => {
+  const tx = {
+    thread: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 100, locked: false })),
+    },
+    commentV2: {
+      create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 999 })),
+    },
+  };
+  return {
+    db: {
+      tx,
+      thread: {
+        findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+        create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ locked: true })),
+        update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ locked: true })),
+      },
+      commentV2: {
+        create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 999 })),
+        count: vi.fn(async (..._a: unknown[]): Promise<number> => 0),
+        findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+        findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+        update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 1 })),
+      },
+      $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      $transaction: vi.fn(async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx)),
+    },
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: db, dbWrite: db }));
+// No blocklist round-trip in a unit test; the comment content passes.
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: vi.fn(async () => undefined),
+}));
+// otel `withSpan` → passthrough (avoid booting the telemetry SDK in node env).
+vi.mock('~/server/utils/otel-helpers', () => ({
+  withSpan: (_name: string, fn: () => unknown) => fn(),
+}));
+
+import {
+  getCommentCount,
+  getCommentsInfinite,
+  toggleLockCommentsThread,
+  togglePinComment,
+  upsertComment,
+} from '../commentsv2.service';
+
+/** The `where` of the last call to a mocked Prisma delegate method. */
+function lastWhere(fn: { mock: { calls: unknown[][] } }): Record<string, unknown> {
+  const arg = fn.mock.calls.at(-1)?.[0] as { where?: Record<string, unknown> } | undefined;
+  return arg?.where ?? {};
+}
+function lastData(fn: { mock: { calls: unknown[][] } }): Record<string, unknown> {
+  const arg = fn.mock.calls.at(-1)?.[0] as { data?: Record<string, unknown> } | undefined;
+  return arg?.data ?? {};
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CommentsV2 appListing thread resolution', () => {
+  it('getCommentCount resolves the thread by appListingId', async () => {
+    db.thread.findUnique.mockResolvedValueOnce({ commentCount: 7 });
+    const count = await getCommentCount({ entityType: 'appListing', entityId: 42 });
+    expect(count).toBe(7);
+    // The crux: entityType 'appListing' → column `appListingId`.
+    expect(lastWhere(db.thread.findUnique)).toEqual({ appListingId: 42 });
+  });
+
+  it('getCommentsInfinite resolves the thread by appListingId (returns null when absent)', async () => {
+    db.thread.findUnique.mockResolvedValueOnce(null);
+    const result = await getCommentsInfinite({
+      entityType: 'appListing',
+      entityId: 42,
+      limit: 5,
+    } as Parameters<typeof getCommentsInfinite>[0]);
+    expect(result).toBeNull();
+    expect(lastWhere(db.thread.findUnique)).toEqual({ appListingId: 42 });
+  });
+
+  it('upsertComment creates the thread with appListingId on first comment', async () => {
+    db.thread.findUnique.mockResolvedValueOnce(null); // no existing thread
+    await upsertComment({
+      userId: 5,
+      entityType: 'appListing',
+      entityId: 42,
+      content: 'great app',
+    } as Parameters<typeof upsertComment>[0]);
+    // The new thread is created keyed on the appListing surrogate.
+    expect(lastData(db.tx.thread.create)).toMatchObject({ appListingId: 42 });
+    // …and the comment attaches to that thread.
+    expect(db.tx.commentV2.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('is generic — a different entityType maps to its own column (model → modelId)', async () => {
+    db.thread.findUnique.mockResolvedValueOnce({ commentCount: 1 });
+    await getCommentCount({ entityType: 'model', entityId: 7 });
+    expect(lastWhere(db.thread.findUnique)).toEqual({ modelId: 7 });
+  });
+});
+
+describe('CommentsV2 appListing moderation inheritance', () => {
+  it('lock (toggleLockCommentsThread) keys the thread on appListingId and creates it locked', async () => {
+    db.thread.findUnique.mockResolvedValueOnce(null); // no thread yet
+    const res = (await toggleLockCommentsThread({
+      entityType: 'appListing',
+      entityId: 42,
+    })) as { locked: boolean };
+    expect(lastWhere(db.thread.findUnique)).toEqual({ appListingId: 42 });
+    // Creates the thread in the locked state, keyed on the surrogate.
+    expect(lastData(db.thread.create)).toMatchObject({ appListingId: 42, locked: true });
+    expect(res.locked).toBe(true);
+  });
+
+  it('lock toggles an existing appListing thread', async () => {
+    db.thread.findUnique.mockResolvedValueOnce({ id: 100, locked: false });
+    await toggleLockCommentsThread({ entityType: 'appListing', entityId: 42 });
+    expect(lastWhere(db.thread.update)).toEqual({ appListingId: 42 });
+    expect(lastData(db.thread.update)).toEqual({ locked: true });
+  });
+
+  it('pin (togglePinComment) flows through by comment id — entity-agnostic', async () => {
+    db.commentV2.findUnique.mockResolvedValueOnce({ pinnedAt: null });
+    await togglePinComment({ id: 999 });
+    expect(lastWhere(db.commentV2.update)).toEqual({ id: 999 });
+    // null → sets a pin timestamp.
+    expect(lastData(db.commentV2.update).pinnedAt).toBeInstanceOf(Date);
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -67,6 +67,8 @@ function capturedValues(): unknown[] {
 function hydratedRow(over: Record<string, unknown> = {}) {
   return {
     id: 'apl_1',
+    // Integer surrogate (CommentsV2 thread key) — projected into the detail DTO only.
+    serialId: 101,
     kind: 'onsite',
     slug: 'cool-app',
     name: 'Cool App',
@@ -317,12 +319,15 @@ describe('projectListingDetail — public allowlist + gallery', () => {
         'recommend',
         'reviewCount',
         'screenshots',
+        'serialId',
         'slug',
         'tagline',
       ].sort()
     );
     expect(detail).not.toHaveProperty('status');
     expect(detail.description).toBe('# Cool app\n\nbody');
+    // The integer surrogate is surfaced for the CommentsV2 thread key.
+    expect(detail.serialId).toBe(101);
   });
 
   it('onsite detail kindData carries appBlockId, hasPage + the computed liveUrl', () => {

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -195,6 +195,9 @@ function manifestHasPage(manifest: unknown): boolean {
  */
 export const listingHydrateSelect = {
   id: true,
+  // Integer surrogate — projected into the detail DTO only (the comments thread
+  // key). Harmless extra column for the card projection, which doesn't surface it.
+  serialId: true,
   kind: true,
   slug: true,
   name: true,
@@ -308,6 +311,7 @@ export function projectListingDetail(row: HydratedListing): ListingDetail {
   const recommend = recommendRollup(row.metric);
   return {
     id: row.id,
+    serialId: row.serialId,
     slug: row.slug,
     kind: row.kind as ListingKind,
     name: row.name,


### PR DESCRIPTION
## What

Adds a comment discussion to app-store **listing detail pages** by reusing the existing **CommentsV2** system, registered as a new entity type `appListing`. Comments are **additive and separate** from the existing recommend-style `app_listing_reviews`.

The integration is deliberately the same shape as every other CommentsV2 entity type (e.g. `model3d`): a new nullable-unique parent FK column on the polymorphic `Thread`. Everything else — write/read/pagination/sort **plus the full moderation surface (lock / hide / pin / report / rate-limit)** — is inherited from the shared stack keyed on the `Thread`, with **no service code change**. The service resolves the thread by string-interpolating the parent column: `where: { [`${entityType}Id`]: entityId }` → `appListingId`.

## The one bridge — an id-TYPE mismatch, not a cross-DB one

CommentsV2 is **integer-keyed end to end** (`Thread.<parent>Id Int? @unique`, `CommentV2` int PK), but `app_listings` has a **TEXT ULID PK** (`apl_<ULID>`). So `Thread.appListingId` (Int) can't reference `app_listings.id` (text).

Fix: add an **integer surrogate** `app_listings.serial_id` (UNIQUE, auto-increment, auto-backfilled for existing rows) and FK `Thread.appListingId → app_listings.serial_id`. The ULID `id` stays the PK. `Thread`, `CommentV2`, and `app_listings` are **all in the same database**, so this is purely an id-type bridge — there is no cross-DB problem.

## Changes

- **Schema / migration** — `AppListing.serialId` (`@unique @default(autoincrement())`) + `Thread.appListingId Int? @unique` with a DB FK to `app_listings(serial_id)`. Regenerated the committed Prisma outputs (`models.ts`, `kysely/types.ts`).
- **Enum** — added `'appListing'` to **both** supported-parent enums (`commentConnectorSchema` + `toggleHideCommentSchema`) that gate the shared procs; they must agree.
- **Read path** — surface `serialId` on the public `ListingDetail` DTO (`appListings.getAppDetail`) via an allowlist-only projection addition.
- **Frontend** — new `AppListingComments` (mirrors `Model3DComments`) mounting `<CommentsProvider entityType="appListing" entityId={serialId}>`, rendered on the `AppListing`-backed detail body (`AppListingDetailBody`, the `/apps/store-preview/<slug>` surface).
- **Reply notifications** — excluded appListing threads from the two entity-agnostic reply processors (see below).

## Migration is MANUAL-apply (not auto-run)

The main DB does not auto-apply migrations — the `.sql` is committed for history and **a human applies it per environment**, to the **dev database before the PR-preview smoke** and to the **prod database before the release that carries the reader/writer**. Idempotent (guards on every statement).

> ⚠️ **The `Thread` unique index is built `CONCURRENTLY` and MUST run OUTSIDE a transaction** (CONCURRENTLY can't run in a txn/DO block). `Thread` is a hot, site-wide comment table — a plain build would SHARE-lock every comment write for its duration. Run that one statement on its own (not inside BEGIN/COMMIT), ideally in a low-traffic window. The FK is added `NOT VALID` then `VALIDATE`d separately to trim its lock. Deploy order: apply **before** the code that reads `serial_id` / writes the thread ships to that env.

```sql
-- 1. integer surrogate on app_listings (id is a TEXT ULID; CommentsV2 is int-keyed)
ALTER TABLE "app_listings" ADD COLUMN IF NOT EXISTS "serial_id" SERIAL;
DO $$ BEGIN
  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'app_listings_serial_id_key') THEN
    ALTER TABLE "app_listings" ADD CONSTRAINT "app_listings_serial_id_key" UNIQUE ("serial_id");
  END IF;
END $$;

-- 2. Thread.appListingId — the new polymorphic parent FK (mirrors model3dId)
ALTER TABLE "Thread" ADD COLUMN IF NOT EXISTS "appListingId" INTEGER;

-- 🔴 RUN OUTSIDE ANY TRANSACTION (CONCURRENTLY can't run in a txn/DO block);
--    low-traffic window. Non-blocking on the hot Thread table.
CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "Thread_appListingId_key" ON "Thread" ("appListingId");

-- FK added NOT VALID (skips the validation-scan lock), then validated separately.
DO $$ BEGIN
  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'Thread_appListingId_fkey') THEN
    ALTER TABLE "Thread" ADD CONSTRAINT "Thread_appListingId_fkey"
      FOREIGN KEY ("appListingId") REFERENCES "app_listings" ("serial_id")
      ON DELETE SET NULL ON UPDATE CASCADE NOT VALID;
  END IF;
END $$;
ALTER TABLE "Thread" VALIDATE CONSTRAINT "Thread_appListingId_fkey";
```

## Comment-reply notifications for appListing — excluded (deferred)

The owner-facing `new-comment` processors are per-entity SQL (no appListing branch → no rows → genuinely graceful). But the **entity-agnostic** reply processors `new-comment-reply` + `new-thread-response` fire for a reply in ANY CommentV2 thread — and for an appListing thread they'd resolve `threadParentId`→NULL and `threadType`→the `'comment'` fallback, so `threadUrlMap` returns `undefined` (a broken-link notification). appListing pages are addressed by **slug**, not the id the notification query has, so a correct reply URL needs a slug join.

Rather than half-wire a URL, both reply processors now **exclude appListing threads** (`appListingId IS NULL` guard — on the root thread, and on both root + immediate thread for `new-thread-response`). **Follow-up (deferred): appListing comment-reply notifications need a slug-resolving URL** before they can be enabled.

## Tests

- **Service** (`commentsv2.appListing.service.test.ts`) — `appListing` resolves/creates its thread by `appListingId` across getCount / getInfinite / upsert; a contrast case proves the interpolation stays generic (`model` → `modelId`); **moderation inheritance**: lock creates/toggles the `appListingId` thread, pin flows through by comment id.
- **Schema** (`commentv2.appListing.schema.test.ts`) — both enums accept `appListing`; a non-numeric `entityId` (the ULID) is rejected (guards the int bridge).
- **Notifications** (`comment.appListing-exclusion.test.ts`) — both reply-processor SQL strings carry the `appListingId IS NULL` guard; `threadUrlMap` returns `undefined` for the `'comment'`/`'appListing'` threadType (the root cause).
- **Frontend** (`AppListingComments.browser.test.tsx`) — mounts the provider with `entityType="appListing"` + the integer `serialId` and renders the discussion for an approved listing; renders nothing when `serialId` is null/undefined.
- Updated the existing `app-listing.service.test.ts` DTO-allowlist assertion for the new `serialId` field.

## Judgment calls

- **Surrogate column** — used `SERIAL` (matches the local convention; `app_listing_reviews.id` etc. — the repo has no `IDENTITY` columns) as a **secondary** unique column, not the PK. The unique is a real **constraint** (not just an index) because a Postgres FK target must be a unique constraint / PK.
- **Approved-only gating** — the authoritative gate is `getListingDetail`, which is approved-only and 404s a draft/pending/rejected/removed or never-deployed listing server-side, so a non-approved listing never reaches the detail body. `AppListingComments` adds a defensive `serialId`-presence gate on top (no surrogate ⇒ no comments surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
