### PR TITLE
fix(app-blocks): allowlist classifier keys in buzz-read details projection

### DIFF
--- a/src/server/services/blocks/__tests__/block-buzz-read.projection.test.ts
+++ b/src/server/services/blocks/__tests__/block-buzz-read.projection.test.ts
@@ -117,4 +117,58 @@ describe('projectBlockBuzzTransaction', () => {
   it('passes a null details through unchanged', () => {
     expect(projectBlockBuzzTransaction(row({ details: null })).details).toBeNull();
   });
+
+  it('keeps the reward classifier keys: details.type + numeric forId', () => {
+    const out = projectBlockBuzzTransaction(
+      row({
+        type: TransactionType.Reward,
+        details: { type: 'dailyBoost', forId: 20260714, byUserId: 42 },
+      })
+    );
+    const details = out.details as Record<string, unknown>;
+    expect(details.type).toBe('dailyBoost');
+    expect(details.forId).toBe(20260714);
+    // Who triggered the reward stays private (reactions are anonymous on-site).
+    expect(details).not.toHaveProperty('byUserId');
+  });
+
+  it('drops a STRING forId — the adWatched ad-session token leak guard', () => {
+    const out = projectBlockBuzzTransaction(
+      row({
+        type: TransactionType.Reward,
+        details: { type: 'adWatched', forId: 'ad-session-token-abc123' },
+      })
+    );
+    const details = out.details as Record<string, unknown>;
+    expect(details.type).toBe('adWatched');
+    expect(details.forId).toBeUndefined();
+  });
+
+  it('keeps the early-access sale classifiers: modelVersionId + type', () => {
+    const out = projectBlockBuzzTransaction(
+      row({
+        type: TransactionType.Purchase,
+        details: { modelVersionId: 501001, type: 'generation', earlyAccessPurchase: true },
+      })
+    );
+    const details = out.details as Record<string, unknown>;
+    expect(details.modelVersionId).toBe(501001);
+    expect(details.type).toBe('generation');
+    // The flag itself stays passthrough-dropped; a non-numeric value never leaks.
+    expect(details).not.toHaveProperty('earlyAccessPurchase');
+    expect(
+      (
+        projectBlockBuzzTransaction(
+          row({ details: { modelVersionId: 'not-a-number' } })
+        ).details as Record<string, unknown>
+      ).modelVersionId
+    ).toBeUndefined();
+  });
+
+  it('drops a non-string details.type (never widens beyond internal tags)', () => {
+    const out = projectBlockBuzzTransaction(
+      row({ details: { type: { nested: 'object' } } })
+    );
+    expect((out.details as Record<string, unknown>).type).toBeUndefined();
+  });
 });

--- a/src/server/services/blocks/block-buzz-read.projection.ts
+++ b/src/server/services/blocks/block-buzz-read.projection.ts
@@ -14,8 +14,30 @@ import type { getUserBuzzTransactions } from '~/server/services/buzz.service';
  *      object and Purchase rows store `details.stripePaymentIntentId` (see
  *      buzz.service `completeStripeBuzzPurchase`). An unfiltered spread would
  *      ship the user's Stripe payment-intent reference into the third-party
- *      block iframe, so we pick ONLY the entity-attribution fields the dashboard
- *      renders and drop every passthrough key.
+ *      block iframe, so we pick ONLY the fields the dashboard needs and drop
+ *      every passthrough key. Beyond the entity-attribution fields, three
+ *      CLASSIFIER keys are allowlisted (evidence-based sweep of every
+ *      `details:` writer):
+ *        • `type` — the reward-event tag every Reward/Incentive row carries
+ *          (rewards/base.reward.ts `sendAward`: 'dailyBoost', 'goodContent:<kind>',
+ *          'collectedContent:<kind>', 'imagePostedToModel', 'adWatched', …) and
+ *          the early-access purchase kind ('download' | 'generation',
+ *          model-version.service). Internal tags only — this is what a rewards
+ *          audit / income-stream breakdown classifies on. String-guarded.
+ *        • `forId` — the reward's subject id (dailyBoost: the claimed day as
+ *          YYYYMMDD, imagePostedToModel: modelVersionId, firstDailyPost: postId,
+ *          goodContent: entityId, …). NUMERIC-ONLY: the one string-valued case
+ *          is adWatched's `input.token` (the watched-ad session token,
+ *          adWatched.reward.ts) — an opaque external token with no dashboard
+ *          use, excluded by the number guard. Every dashboard classifier
+ *          (claim-calendar day, entity ids) is a number.
+ *        • `modelVersionId` — the early-access sale's sold version
+ *          (model-version.service `details: { modelVersionId, type,
+ *          earlyAccessPurchase: true }`) — per-version sales attribution.
+ *          Number-guarded.
+ *      Still dropped (present on reward rows): `byUserId` — who triggered the
+ *      reward (reactor/collector identity); reactions are anonymous on the
+ *      site, so the block must not see it either.
  *
  *  (B) `externalTransactionId` leak class — the field is DUAL-USE and
  *      TransactionType does NOT cleanly separate the two uses (an evidence-based
@@ -73,25 +95,35 @@ type BlockBuzzTransactionRow = Awaited<
 /**
  * Project one hydrated buzz-transaction row to the block-safe shape:
  *  - `type` serialized as its enum NAME
- *  - `details` allowlisted to the entity-attribution fields (drop passthrough,
- *    incl. `stripePaymentIntentId`)
+ *  - `details` allowlisted to the entity-attribution + classifier fields (drop
+ *    passthrough, incl. `stripePaymentIntentId` and `byUserId`; `forId` only
+ *    when numeric — the adWatched token guard)
  *  - `externalTransactionId` stripped for processor-reference rows (see above)
  *  - counterparties projected to `{ id, username }` (no other `getUsers` fields)
  */
 export function projectBlockBuzzTransaction(row: BlockBuzzTransactionRow) {
   const { toUser, fromUser, details, externalTransactionId, ...t } = row;
+  // details is a zod .passthrough() object — classifier keys are untyped.
+  const d = details as (typeof details & Record<string, unknown>) | null | undefined;
   return {
     ...t,
     type: TransactionType[t.type],
-    details: details
+    details: d
       ? {
-          user: details.user,
-          entityId: details.entityId,
-          entityType: details.entityType,
-          url: details.url,
-          toAccountType: details.toAccountType,
+          user: d.user,
+          entityId: d.entityId,
+          entityType: d.entityType,
+          url: d.url,
+          toAccountType: d.toAccountType,
+          // Classifier keys (see leak-class (A) above): internal tags/ids only.
+          type: typeof d.type === 'string' ? d.type : undefined,
+          forId: typeof d.forId === 'number' && Number.isFinite(d.forId) ? d.forId : undefined,
+          modelVersionId:
+            typeof d.modelVersionId === 'number' && Number.isFinite(d.modelVersionId)
+              ? d.modelVersionId
+              : undefined,
         }
-      : details,
+      : d,
     externalTransactionId: projectExternalTransactionId(t.type, externalTransactionId),
     toUser: toUser ? { id: toUser.id, username: toUser.username } : undefined,
     fromUser: fromUser ? { id: fromUser.id, username: fromUser.username } : undefined,


### PR DESCRIPTION
## What

Follow-up to #3144 (buzz self-read page-host bridges). The `details` allowlist in `projectBlockBuzzTransaction` kept only the five entity-attribution fields — which unintentionally strips the three **classifier** keys a Buzz-dashboard app needs (all three were present on the wire in the superseded REST endpoints' rows):

| Key | Written by | Powers | Guard |
| --- | --- | --- | --- |
| `details.type` | every reward row (`rewards/base.reward.ts` `sendAward`: `dailyBoost`, `goodContent:<kind>`, `collectedContent:<kind>`, `imagePostedToModel`, `adWatched`, …) + early-access purchases (`'download' \| 'generation'`) | rewards audit, income-stream breakdown | string-typed only |
| `details.forId` | reward subject id — dailyBoost: claimed day as `YYYYMMDD`; imagePostedToModel: modelVersionId; firstDailyPost: postId; goodContent: entityId | daily-claim calendar, per-entity income | **numeric only** |
| `details.modelVersionId` | early-access sales (`model-version.service`: `details: { modelVersionId, type, earlyAccessPurchase: true }`) | per-version sales attribution | number-typed only |

## Why the guards are sufficient (evidence sweep)

- `details.type` values are internal tags everywhere it is written (reward event types + the early-access kind). Non-string values are dropped.
- `forId` has exactly ONE string-valued writer: **adWatched**'s `input.token` (the watched-ad session token, `adWatched.reward.ts`) — an opaque external token with no dashboard use. The numeric-only guard excludes it structurally, not by enumeration, so any future string-valued `forId` is excluded by default. Every dashboard-relevant `forId` is a number.
- `byUserId` (also on reward rows) stays **dropped** — reactor/collector identity; reactions are anonymous on-site, so a block must not see who reacted.
- Everything else is unchanged: passthrough keys (incl. `stripePaymentIntentId`) still dropped, `externalTransactionId` leak-class handling untouched, counterparty projection untouched.

## Tests

`block-buzz-read.projection.test.ts`: +5 cases — classifier keys kept, `byUserId` dropped, string `forId` (ad token) dropped, non-numeric `modelVersionId` dropped, non-string `type` dropped. 12/12 projection + 178/178 `blocks.router.workflow` tests pass.

## SDK lockstep

`@civitai/app-sdk`'s `BlockBuzzTransaction.details` type gains the three optional keys in a follow-up SDK release (runtime consumers already tolerate the superset; existing blocks unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)