### PR TITLE
fix(app-blocks): curated dashboard-type allowlist for buzz-read details (supersedes #3157)

### DIFF
--- a/src/server/services/blocks/__tests__/block-buzz-read.projection.test.ts
+++ b/src/server/services/blocks/__tests__/block-buzz-read.projection.test.ts
@@ -117,4 +117,58 @@ describe('projectBlockBuzzTransaction', () => {
   it('passes a null details through unchanged', () => {
     expect(projectBlockBuzzTransaction(row({ details: null })).details).toBeNull();
   });
+
+  it('keeps the reward classifier keys: details.type + numeric forId', () => {
+    const out = projectBlockBuzzTransaction(
+      row({
+        type: TransactionType.Reward,
+        details: { type: 'dailyBoost', forId: 20260714, byUserId: 42 },
+      })
+    );
+    const details = out.details as Record<string, unknown>;
+    expect(details.type).toBe('dailyBoost');
+    expect(details.forId).toBe(20260714);
+    // Who triggered the reward stays private (reactions are anonymous on-site).
+    expect(details).not.toHaveProperty('byUserId');
+  });
+
+  it('drops a STRING forId — the adWatched ad-session token leak guard', () => {
+    const out = projectBlockBuzzTransaction(
+      row({
+        type: TransactionType.Reward,
+        details: { type: 'adWatched', forId: 'ad-session-token-abc123' },
+      })
+    );
+    const details = out.details as Record<string, unknown>;
+    expect(details.type).toBe('adWatched');
+    expect(details.forId).toBeUndefined();
+  });
+
+  it('keeps the early-access sale classifiers: modelVersionId + type', () => {
+    const out = projectBlockBuzzTransaction(
+      row({
+        type: TransactionType.Purchase,
+        details: { modelVersionId: 501001, type: 'generation', earlyAccessPurchase: true },
+      })
+    );
+    const details = out.details as Record<string, unknown>;
+    expect(details.modelVersionId).toBe(501001);
+    expect(details.type).toBe('generation');
+    // The flag itself stays passthrough-dropped; a non-numeric value never leaks.
+    expect(details).not.toHaveProperty('earlyAccessPurchase');
+    expect(
+      (
+        projectBlockBuzzTransaction(
+          row({ details: { modelVersionId: 'not-a-number' } })
+        ).details as Record<string, unknown>
+      ).modelVersionId
+    ).toBeUndefined();
+  });
+
+  it('drops a non-string details.type (never widens beyond internal tags)', () => {
+    const out = projectBlockBuzzTransaction(
+      row({ details: { type: { nested: 'object' } } })
+    );
+    expect((out.details as Record<string, unknown>).type).toBeUndefined();
+  });
 });

--- a/src/server/services/blocks/__tests__/block-buzz-read.projection.test.ts
+++ b/src/server/services/blocks/__tests__/block-buzz-read.projection.test.ts
@@ -118,44 +118,74 @@ describe('projectBlockBuzzTransaction', () => {
     expect(projectBlockBuzzTransaction(row({ details: null })).details).toBeNull();
   });
 
-  it('keeps the reward classifier keys: details.type + numeric forId', () => {
+  // ── Curated dashboard-classifier allowlist (type + forId) ────────────────
+  // KEEP only the dashboard-relevant income/attribution types; DROP everything
+  // else (moderation / referral / follow / reaction tags + any future type).
+
+  it.each([
+    ['dailyBoost', 20260714], // claim-calendar day (YYYYMMDD)
+    ['imagePostedToModel', 501001], // modelVersionId
+    ['firstDailyPost', 999001], // postId
+    ['goodContent:image', 12345], // prefix match — reaction income (entityId)
+    ['goodContent:model', 777], // prefix match
+    ['collectedContent:image', 22222], // prefix match — collection income
+    ['collectedContent:article', 333], // prefix match
+  ])('keeps type + numeric forId for allowlisted reward type %s', (type, forId) => {
     const out = projectBlockBuzzTransaction(
-      row({
-        type: TransactionType.Reward,
-        details: { type: 'dailyBoost', forId: 20260714, byUserId: 42 },
-      })
+      row({ type: TransactionType.Reward, details: { type, forId, byUserId: 42 } })
     );
     const details = out.details as Record<string, unknown>;
-    expect(details.type).toBe('dailyBoost');
-    expect(details.forId).toBe(20260714);
+    expect(details.type).toBe(type);
+    expect(details.forId).toBe(forId);
     // Who triggered the reward stays private (reactions are anonymous on-site).
     expect(details).not.toHaveProperty('byUserId');
   });
 
-  it('drops a STRING forId — the adWatched ad-session token leak guard', () => {
+  it.each([
+    ['reportAccepted', 88123], // moderation-report activity + reportId — the sharpest leak
+    ['refereeCreated', 4242], // the referrer's user id — referral edge
+    ['firstDailyFollow', 7777], // the followed user's id — follow edge
+    ['encouragement:reaction', 5150], // the viewer's reaction footprint
+    ['ad-watched', 909], // ad session (non-dashboard)
+    ['userReferred', 4242], // referral edge (the mirror side)
+    ['someNewRewardType', 1234], // STRUCTURAL: an unknown/future type is default-denied
+  ])('drops BOTH type and forId for non-allowlisted reward type %s', (type, forId) => {
     const out = projectBlockBuzzTransaction(
-      row({
-        type: TransactionType.Reward,
-        details: { type: 'adWatched', forId: 'ad-session-token-abc123' },
-      })
+      row({ type: TransactionType.Reward, details: { type, forId } })
     );
     const details = out.details as Record<string, unknown>;
-    expect(details.type).toBe('adWatched');
+    expect(details.type).toBeUndefined();
     expect(details.forId).toBeUndefined();
   });
 
-  it('keeps the early-access sale classifiers: modelVersionId + type', () => {
+  it('drops a STRING forId even under an allowlisted type (numeric guard belt-and-suspenders)', () => {
     const out = projectBlockBuzzTransaction(
-      row({
-        type: TransactionType.Purchase,
-        details: { modelVersionId: 501001, type: 'generation', earlyAccessPurchase: true },
-      })
+      row({ type: TransactionType.Reward, details: { type: 'dailyBoost', forId: 'not-a-number' } })
     );
     const details = out.details as Record<string, unknown>;
-    expect(details.modelVersionId).toBe(501001);
-    expect(details.type).toBe('generation');
-    // The flag itself stays passthrough-dropped; a non-numeric value never leaks.
-    expect(details).not.toHaveProperty('earlyAccessPurchase');
+    // type is allowlisted so it stays; the non-numeric subject id is still dropped.
+    expect(details.type).toBe('dailyBoost');
+    expect(details.forId).toBeUndefined();
+  });
+
+  it.each(['download', 'generation'])(
+    'keeps the early-access sale classifiers for %s: modelVersionId + type',
+    (kind) => {
+      const out = projectBlockBuzzTransaction(
+        row({
+          type: TransactionType.Purchase,
+          details: { modelVersionId: 501001, type: kind, earlyAccessPurchase: true },
+        })
+      );
+      const details = out.details as Record<string, unknown>;
+      expect(details.modelVersionId).toBe(501001);
+      expect(details.type).toBe(kind);
+      // The flag itself stays passthrough-dropped.
+      expect(details).not.toHaveProperty('earlyAccessPurchase');
+    }
+  );
+
+  it('drops a non-numeric modelVersionId', () => {
     expect(
       (
         projectBlockBuzzTransaction(
@@ -167,8 +197,11 @@ describe('projectBlockBuzzTransaction', () => {
 
   it('drops a non-string details.type (never widens beyond internal tags)', () => {
     const out = projectBlockBuzzTransaction(
-      row({ details: { type: { nested: 'object' } } })
+      row({ type: TransactionType.Reward, details: { type: { nested: 'object' }, forId: 5 } })
     );
-    expect((out.details as Record<string, unknown>).type).toBeUndefined();
+    const details = out.details as Record<string, unknown>;
+    expect(details.type).toBeUndefined();
+    // A non-string type is not allowlisted, so forId drops too.
+    expect(details.forId).toBeUndefined();
   });
 });

--- a/src/server/services/blocks/block-buzz-read.projection.ts
+++ b/src/server/services/blocks/block-buzz-read.projection.ts
@@ -15,26 +15,42 @@ import type { getUserBuzzTransactions } from '~/server/services/buzz.service';
  *      buzz.service `completeStripeBuzzPurchase`). An unfiltered spread would
  *      ship the user's Stripe payment-intent reference into the third-party
  *      block iframe, so we pick ONLY the fields the dashboard needs and drop
- *      every passthrough key. Beyond the entity-attribution fields, three
- *      CLASSIFIER keys are allowlisted (evidence-based sweep of every
+ *      every passthrough key. Beyond the entity-attribution fields, the
+ *      classifier keys are allowlisted (evidence-based sweep of every
  *      `details:` writer):
- *        • `type` — the reward-event tag every Reward/Incentive row carries
- *          (rewards/base.reward.ts `sendAward`: 'dailyBoost', 'goodContent:<kind>',
- *          'collectedContent:<kind>', 'imagePostedToModel', 'adWatched', …) and
- *          the early-access purchase kind ('download' | 'generation',
- *          model-version.service). Internal tags only — this is what a rewards
- *          audit / income-stream breakdown classifies on. String-guarded.
- *        • `forId` — the reward's subject id (dailyBoost: the claimed day as
- *          YYYYMMDD, imagePostedToModel: modelVersionId, firstDailyPost: postId,
- *          goodContent: entityId, …). NUMERIC-ONLY: the one string-valued case
- *          is adWatched's `input.token` (the watched-ad session token,
- *          adWatched.reward.ts) — an opaque external token with no dashboard
- *          use, excluded by the number guard. Every dashboard classifier
- *          (claim-calendar day, entity ids) is a number.
+ *        • `type` + `forId` — the reward-event tag + subject id every
+ *          Reward/Incentive row carries (rewards/base.reward.ts `sendAward`;
+ *          the effective value is `getKey`'s returned `type`, which overrides
+ *          the definition's top-level `type` via the `...definedKey` spread).
+ *          These are NOT passed through for every reward type: `type` is an
+ *          internal classifier and several reward tags identify OTHER users or
+ *          the viewer's moderation/social activity, which must NOT reach an
+ *          untrusted installed block. So `type` (and, with it, `forId`) is kept
+ *          ONLY when `type` names a dashboard-relevant income / attribution
+ *          event — a CURATED allowlist, `isDashboardClassifierType` below:
+ *            - exact: `dailyBoost`, `imagePostedToModel`, `firstDailyPost`,
+ *              and the early-access purchase kinds `download` / `generation`
+ *              (model-version.service).
+ *            - prefix: `goodContent:<kind>`, `collectedContent:<kind>` (the
+ *              per-entity reaction/collection income tags; matched by prefix
+ *              because the writers append `:<entityType>`).
+ *          Everything else DROPS both `type` and `forId`. This structurally
+ *          excludes the leak-class tags an open pass-through would have shipped:
+ *          `reportAccepted` (the viewer's moderation-report activity + reportId
+ *          — the sharpest leak), `refereeCreated` (the referrer's user id — the
+ *          referral edge), `firstDailyFollow` (the followed user's id — a follow
+ *          edge), `encouragement:<kind>` (the viewer's reaction footprint), plus
+ *          `ad-watched` / `appBlockReview` / `generation-feedback` /
+ *          `userReferred` — AND, by DEFAULT, any FUTURE reward type until it is
+ *          deliberately added to the allowlist (default-deny, not a denylist).
+ *          `forId` additionally keeps a NUMERIC-ONLY guard (every allowlisted
+ *          tag's subject id is a number; the one string-valued writer is
+ *          adWatched's session token, already excluded by type).
  *        • `modelVersionId` — the early-access sale's sold version
  *          (model-version.service `details: { modelVersionId, type,
  *          earlyAccessPurchase: true }`) — per-version sales attribution.
- *          Number-guarded.
+ *          Only written by the allowlisted `download`/`generation` kinds and
+ *          always a public version id. Number-guarded.
  *      Still dropped (present on reward rows): `byUserId` — who triggered the
  *      reward (reactor/collector identity); reactions are anonymous on the
  *      site, so the block must not see it either.
@@ -61,6 +77,31 @@ import type { getUserBuzzTransactions } from '~/server/services/buzz.service';
  *      prefix. Every OTHER row keeps its classifier (challenge-entry/winner
  *      prizes, `referral-reward:*`, generic reward-event ids, bounty/comp tags).
  */
+
+/**
+ * Curated allowlist of `details.type` classifiers safe to expose to an untrusted
+ * installed block — the dashboard-relevant income / attribution events only.
+ * Exact matches + the `:<kind>`-suffixed reaction/collection income tags
+ * (prefix). Anything not listed — including every FUTURE reward type — is
+ * default-denied (drops both `type` and `forId`). This is deliberately a
+ * structural ALLOWLIST, never a denylist: adding a new dashboard type is an
+ * explicit, tested decision, and a new sensitive tag can never leak by omission.
+ */
+const DASHBOARD_CLASSIFIER_TYPES = new Set<string>([
+  'dailyBoost',
+  'imagePostedToModel',
+  'firstDailyPost',
+  // Early-access purchase kinds (model-version.service `details.type`).
+  'download',
+  'generation',
+]);
+const DASHBOARD_CLASSIFIER_TYPE_PREFIXES = ['goodContent:', 'collectedContent:'];
+
+export function isDashboardClassifierType(type: unknown): type is string {
+  if (typeof type !== 'string') return false;
+  if (DASHBOARD_CLASSIFIER_TYPES.has(type)) return true;
+  return DASHBOARD_CLASSIFIER_TYPE_PREFIXES.some((p) => type.startsWith(p));
+}
 
 const EXTERNAL_TXN_ID_SENSITIVE_TYPES = new Set<TransactionType>([
   TransactionType.Purchase,
@@ -115,9 +156,18 @@ export function projectBlockBuzzTransaction(row: BlockBuzzTransactionRow) {
           entityType: d.entityType,
           url: d.url,
           toAccountType: d.toAccountType,
-          // Classifier keys (see leak-class (A) above): internal tags/ids only.
-          type: typeof d.type === 'string' ? d.type : undefined,
-          forId: typeof d.forId === 'number' && Number.isFinite(d.forId) ? d.forId : undefined,
+          // Classifier keys (see leak-class (A) above): `type` + `forId` are
+          // kept ONLY for the curated dashboard income/attribution types — a
+          // structural default-deny that excludes moderation/referral/follow/
+          // reaction tags AND any future reward type. `forId` keeps a numeric
+          // guard on top (belt-and-suspenders against a string subject id).
+          type: isDashboardClassifierType(d.type) ? d.type : undefined,
+          forId:
+            isDashboardClassifierType(d.type) &&
+            typeof d.forId === 'number' &&
+            Number.isFinite(d.forId)
+              ? d.forId
+              : undefined,
           modelVersionId:
             typeof d.modelVersionId === 'number' && Number.isFinite(d.modelVersionId)
               ? d.modelVersionId

--- a/src/server/services/blocks/block-buzz-read.projection.ts
+++ b/src/server/services/blocks/block-buzz-read.projection.ts
@@ -14,8 +14,30 @@ import type { getUserBuzzTransactions } from '~/server/services/buzz.service';
  *      object and Purchase rows store `details.stripePaymentIntentId` (see
  *      buzz.service `completeStripeBuzzPurchase`). An unfiltered spread would
  *      ship the user's Stripe payment-intent reference into the third-party
- *      block iframe, so we pick ONLY the entity-attribution fields the dashboard
- *      renders and drop every passthrough key.
+ *      block iframe, so we pick ONLY the fields the dashboard needs and drop
+ *      every passthrough key. Beyond the entity-attribution fields, three
+ *      CLASSIFIER keys are allowlisted (evidence-based sweep of every
+ *      `details:` writer):
+ *        • `type` — the reward-event tag every Reward/Incentive row carries
+ *          (rewards/base.reward.ts `sendAward`: 'dailyBoost', 'goodContent:<kind>',
+ *          'collectedContent:<kind>', 'imagePostedToModel', 'adWatched', …) and
+ *          the early-access purchase kind ('download' | 'generation',
+ *          model-version.service). Internal tags only — this is what a rewards
+ *          audit / income-stream breakdown classifies on. String-guarded.
+ *        • `forId` — the reward's subject id (dailyBoost: the claimed day as
+ *          YYYYMMDD, imagePostedToModel: modelVersionId, firstDailyPost: postId,
+ *          goodContent: entityId, …). NUMERIC-ONLY: the one string-valued case
+ *          is adWatched's `input.token` (the watched-ad session token,
+ *          adWatched.reward.ts) — an opaque external token with no dashboard
+ *          use, excluded by the number guard. Every dashboard classifier
+ *          (claim-calendar day, entity ids) is a number.
+ *        • `modelVersionId` — the early-access sale's sold version
+ *          (model-version.service `details: { modelVersionId, type,
+ *          earlyAccessPurchase: true }`) — per-version sales attribution.
+ *          Number-guarded.
+ *      Still dropped (present on reward rows): `byUserId` — who triggered the
+ *      reward (reactor/collector identity); reactions are anonymous on the
+ *      site, so the block must not see it either.
  *
  *  (B) `externalTransactionId` leak class — the field is DUAL-USE and
  *      TransactionType does NOT cleanly separate the two uses (an evidence-based
@@ -73,25 +95,35 @@ type BlockBuzzTransactionRow = Awaited<
 /**
  * Project one hydrated buzz-transaction row to the block-safe shape:
  *  - `type` serialized as its enum NAME
- *  - `details` allowlisted to the entity-attribution fields (drop passthrough,
- *    incl. `stripePaymentIntentId`)
+ *  - `details` allowlisted to the entity-attribution + classifier fields (drop
+ *    passthrough, incl. `stripePaymentIntentId` and `byUserId`; `forId` only
+ *    when numeric — the adWatched token guard)
  *  - `externalTransactionId` stripped for processor-reference rows (see above)
  *  - counterparties projected to `{ id, username }` (no other `getUsers` fields)
  */
 export function projectBlockBuzzTransaction(row: BlockBuzzTransactionRow) {
   const { toUser, fromUser, details, externalTransactionId, ...t } = row;
+  // details is a zod .passthrough() object — classifier keys are untyped.
+  const d = details as (typeof details & Record<string, unknown>) | null | undefined;
   return {
     ...t,
     type: TransactionType[t.type],
-    details: details
+    details: d
       ? {
-          user: details.user,
-          entityId: details.entityId,
-          entityType: details.entityType,
-          url: details.url,
-          toAccountType: details.toAccountType,
+          user: d.user,
+          entityId: d.entityId,
+          entityType: d.entityType,
+          url: d.url,
+          toAccountType: d.toAccountType,
+          // Classifier keys (see leak-class (A) above): internal tags/ids only.
+          type: typeof d.type === 'string' ? d.type : undefined,
+          forId: typeof d.forId === 'number' && Number.isFinite(d.forId) ? d.forId : undefined,
+          modelVersionId:
+            typeof d.modelVersionId === 'number' && Number.isFinite(d.modelVersionId)
+              ? d.modelVersionId
+              : undefined,
         }
-      : details,
+      : d,
     externalTransactionId: projectExternalTransactionId(t.type, externalTransactionId),
     toUser: toUser ? { id: toUser.id, username: toUser.username } : undefined,
     fromUser: fromUser ? { id: fromUser.id, username: fromUser.username } : undefined,


### PR DESCRIPTION
Builds on @daceheg's #3157 (his allowlist commit is preserved in this branch's history) and hardens it.

## Why

#3157 restored the three classifier keys a Buzz-dashboard block needs by adding an **open** `type: string` / `forId: number` pass-through to the `details` allowlist. That open pass-through discloses **every** reward-event tag to untrusted installed block code — and several reward tags identify other users or the viewer's own moderation/social activity. Relative to the pre-#3144 state (which dropped `forId` entirely), the open pass-through is a **privacy expansion**: it newly ships into the third-party block iframe

- **moderation-report activity** — `reportAccepted` → `details.forId` = `reportId` (the sharpest leak: which reports the viewer filed)
- **the referral edge** — `refereeCreated` → `details.forId` = the referrer's user id
- **follow edges** — `firstDailyFollow` → `details.forId` = the followed user's id
- **reaction footprint** — `encouragement:<kind>` (which content the viewer reacted to)

(plus non-dashboard tags `ad-watched`, `appBlockReview`, `generation-feedback`, `userReferred`.)

A security audit flagged this over-disclosure. This PR replaces the open pass-through with a **curated allowlist** while keeping every dashboard use case dace enabled.

## The change

`type` + `forId` are kept **only** when `details.type` names a dashboard-relevant income / attribution event, via a small structural helper:

```ts
const DASHBOARD_CLASSIFIER_TYPES = new Set(['dailyBoost', 'imagePostedToModel', 'firstDailyPost', 'download', 'generation']);
const DASHBOARD_CLASSIFIER_TYPE_PREFIXES = ['goodContent:', 'collectedContent:'];
isDashboardClassifierType(type) // exact-set membership OR prefix match
```

**KEEP set** (the product decision):
- `dailyBoost`, `imagePostedToModel`, `firstDailyPost`
- `goodContent:*`, `collectedContent:*` (prefix — the writers append `:<entityType>`)
- early-access purchase kinds `download`, `generation` (`model-version.service`)

**Everything else drops BOTH `type` and `forId`.** This is a structural **default-deny**, not a denylist: `reportAccepted` / `refereeCreated` / `firstDailyFollow` / `encouragement:*` are excluded, and so is **any future reward type** until it is deliberately added to the allowlist — no sensitive tag can leak by omission. Excluded types can be added back later as an explicit, tested product decision.

- `forId` keeps its numeric guard on top (belt-and-suspenders; every allowlisted tag's subject id is a number).
- `modelVersionId` unchanged (finite-number guard) — only written by the allowlisted `download`/`generation` kinds, always a public version id.
- `externalTransactionId` nulling, counterparty `{id,username}` projection, and passthrough / `stripePaymentIntentId` / `byUserId` drops are **untouched**.

The effective `details.type` is `getKey`'s returned `type` (it overrides the definition's top-level `type` via the `...definedKey` spread in `base.reward.ts sendAward`) — the allowlist matches those effective values, which is why `goodContent`/`collectedContent` need prefix matching for their `:<kind>` suffix.

## Tests

Extended `block-buzz-read.projection.test.ts` (27 pass): parametrized KEEP cases (`dailyBoost`, `imagePostedToModel`, `firstDailyPost`, `goodContent:image|model`, `collectedContent:image|article`, early-access `download`/`generation`+`modelVersionId`); DROP cases pinning each sensitive exposure (`reportAccepted`, `refereeCreated`, `firstDailyFollow`, `encouragement:reaction`) plus a structural `someNewRewardType` default-deny case; retained the numeric-`forId` / non-numeric-`modelVersionId` / `byUserId` / non-string-`type` guards. `blocks.router.workflow` suite: 178 pass. `tsc --noEmit`: clean.

## Open item

- Confirm no already-deployed block's bundled SDK does `.strict()` validation that would reject a `details` payload now missing `type`/`forId` for non-dashboard rows (the wider #3157 payload set a precedent some SDK build may depend on).

Supersedes #3157 (kept open — will be closed separately with a thank-you).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
