### PR TITLE
fix(challenges): don't reset scan verdict on non-text edits

### DIFF
--- a/src/server/services/__tests__/challenge-edit-rescan.service.test.ts
+++ b/src/server/services/__tests__/challenge-edit-rescan.service.test.ts
@@ -99,6 +99,10 @@ vi.mock('~/server/services/text-moderation.service', () => ({
   submitTextModeration: mockSubmitTextModeration,
 }));
 
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn(),
+}));
+
 vi.mock('~/utils/errorHandling', () => ({
   withRetries: vi.fn((fn: () => unknown) => fn()),
 }));

--- a/src/server/services/__tests__/challenge-edit-rescan.service.test.ts
+++ b/src/server/services/__tests__/challenge-edit-rescan.service.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression coverage for the edit→scan dedup deadlock: an edit that leaves the moderated text
+// (title/theme/description/invitation) unchanged must NOT reset ingestion to Pending. The re-scan
+// submit dedups on contentHash against the already-Succeeded EntityModeration row, so no webhook
+// ever fires to flip ingestion back to Scanned — the challenge would sit hidden until the
+// activation job voids it.
+const { mockDbRead, mockDbWrite, mockTx, mockSubmitTextModeration } = vi.hoisted(() => {
+  const mockTx = {
+    challenge: {
+      updateMany: vi.fn(),
+      findUniqueOrThrow: vi.fn(),
+    },
+    collection: { findUnique: vi.fn(), update: vi.fn() },
+  };
+  return {
+    mockTx,
+    mockDbRead: {
+      $queryRaw: vi.fn(),
+      challenge: { findUnique: vi.fn() },
+      collectionItem: { count: vi.fn() },
+      image: { findUnique: vi.fn(), findFirst: vi.fn() },
+    },
+    mockDbWrite: {
+      $transaction: vi.fn(async (fn: (tx: typeof mockTx) => Promise<unknown>) => fn(mockTx)),
+    },
+    mockSubmitTextModeration: vi.fn(),
+  };
+});
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: mockDbWrite,
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  createBuzzTransactionMany: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getChallengeConfig: vi.fn(),
+  setChallengeConfig: vi.fn(),
+  deriveChallengeNsfwLevel: vi.fn(() => 1),
+  getJudgingConfig: vi.fn(),
+  parseJudgeScore: vi.fn(),
+}));
+
+// Keep the real challenge-helpers (buildChallengeModerationText drives the behavior under test);
+// its DB/logging imports are already mocked above.
+vi.mock('~/server/games/daily-challenge/challenge-helpers', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('~/server/games/daily-challenge/challenge-helpers')
+  >();
+  return { ...actual, getChallengeById: vi.fn() };
+});
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  generateWinners: vi.fn(),
+}));
+
+vi.mock('~/server/jobs/daily-challenge-processing', () => ({
+  getJudgedEntries: vi.fn(),
+}));
+
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+}));
+
+vi.mock('~/server/services/image.service', () => ({
+  createImage: vi.fn(),
+  imagesForModelVersionsCache: { bust: vi.fn(), fetch: vi.fn(() => ({})) },
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  getCosmeticsForUsers: vi.fn(() => ({})),
+  getProfilePicturesForUsers: vi.fn(() => ({})),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-eligibility.service', () => ({
+  assertCanCreateUserChallenge: vi.fn(),
+  assertUserInGoodStanding: vi.fn(),
+  assertUserAccountInGoodStanding: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-category.service', () => ({
+  resolveJudgingCategories: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/challenge-judge.service', () => ({
+  getUserSelectableJudges: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/text-moderation.service', () => ({
+  submitTextModeration: mockSubmitTextModeration,
+}));
+
+vi.mock('~/utils/errorHandling', () => ({
+  withRetries: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('~/utils/logging', () => ({
+  createLogger: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('~/server/utils/errorHandling', () => ({
+  throwNotFoundError: vi.fn((msg: string) => {
+    throw new Error(msg);
+  }),
+}));
+
+const { upsertUserChallenge } = await import('~/server/services/challenge.service');
+
+const startsAt = new Date('2030-01-10T18:00:00Z');
+
+const existingChallenge = {
+  createdById: 111,
+  source: 'User' as const,
+  status: 'Scheduled' as const,
+  collectionId: null,
+  basePrizePool: 0,
+  metadata: null,
+  buzzType: 'yellow',
+  startsAt,
+  title: 'Cute Cats with Silly Hats',
+  description: '<p>Show us your best cat.</p>',
+  theme: 'Cats',
+  invitation: null,
+};
+
+const baseEditInput = {
+  id: 42,
+  userId: 111,
+  buzzType: 'yellow' as const,
+  title: existingChallenge.title,
+  description: existingChallenge.description,
+  theme: existingChallenge.theme,
+  invitation: null,
+  coverImage: { id: 555, url: 'unused' },
+  allowedNsfwLevel: 1,
+  modelVersionIds: [],
+  judgeId: null,
+  judgingCategories: [],
+  entryFee: 50,
+  initialPrizeBuzz: 0,
+  prizeDistribution: [],
+  maxEntriesPerUser: 5,
+  startsAt,
+  endsAt: new Date('2030-01-12T18:00:00Z'),
+};
+
+describe('upsertUserChallenge (edit branch) — ingestion reset scoped to moderated-text changes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbRead.image.findFirst.mockResolvedValue({ id: 555 });
+    // First findUnique: the edit branch's `existing` load. scanUserChallenge (text-changed case)
+    // re-reads the same row; a superset satisfies both selects.
+    mockDbRead.challenge.findUnique.mockResolvedValue(existingChallenge);
+    mockTx.challenge.updateMany.mockResolvedValue({ count: 1 });
+    mockTx.challenge.findUniqueOrThrow.mockResolvedValue({ id: 42 });
+  });
+
+  it('keeps the scan verdict and skips re-scan when moderated text is unchanged', async () => {
+    await upsertUserChallenge({
+      ...baseEditInput,
+      // Non-text edit: only the end date moves.
+      endsAt: new Date('2030-01-13T18:00:00Z'),
+    } as never);
+
+    expect(mockTx.challenge.updateMany).toHaveBeenCalledTimes(1);
+    const { data } = mockTx.challenge.updateMany.mock.calls[0][0];
+    expect(data).not.toHaveProperty('ingestion');
+    expect(data).not.toHaveProperty('scannedAt');
+    expect(mockSubmitTextModeration).not.toHaveBeenCalled();
+  });
+
+  it('resets ingestion and re-scans when moderated text changed', async () => {
+    await upsertUserChallenge({
+      ...baseEditInput,
+      title: 'Grumpy Dogs with Serious Hats',
+    } as never);
+
+    expect(mockTx.challenge.updateMany).toHaveBeenCalledTimes(1);
+    const { data } = mockTx.challenge.updateMany.mock.calls[0][0];
+    expect(data.ingestion).toBe('Pending');
+    expect(data.scannedAt).toBeNull();
+    expect(mockSubmitTextModeration).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1471,6 +1471,10 @@ export async function upsertUserChallenge({
         metadata: true,
         buzzType: true,
         startsAt: true,
+        title: true,
+        description: true,
+        theme: true,
+        invitation: true,
       },
     });
     if (!existing) throw throwNotFoundError('Challenge not found');
@@ -1515,6 +1519,13 @@ export async function upsertUserChallenge({
         message: 'Challenge must start at least 3 hours from now.',
       });
 
+    // Only reset the scan verdict when the moderated text actually changed. Resetting on every
+    // edit deadlocks: the re-scan submit dedups on contentHash against the already-Succeeded
+    // EntityModeration row, so no webhook ever flips ingestion back to Scanned and the challenge
+    // sits hidden until the activation job voids it.
+    const moderatedTextChanged =
+      buildChallengeModerationText(commonData) !== buildChallengeModerationText(existing);
+
     const updated = await dbWrite.$transaction(async (tx) => {
       // Conditional on status IN THE WRITE: the Scheduled/entry-count checks above ran on the
       // read replica, so the hourly activation job (or a racing entry charge) could have flipped
@@ -1530,9 +1541,10 @@ export async function upsertUserChallenge({
           // Edits are limited to Scheduled + no entries, so the pool equals the base here.
           basePrizePool: existing.basePrizePool,
           prizePool: existing.basePrizePool,
-          // Any content edit requires a fresh scan before the challenge is public again.
-          ingestion: ChallengeIngestionStatus.Pending,
-          scannedAt: null,
+          ...(moderatedTextChanged && {
+            ingestion: ChallengeIngestionStatus.Pending,
+            scannedAt: null,
+          }),
           // Recompute the visibility window from the (possibly updated) start date.
           visibleAt: getUserChallengeVisibleAt(rest.startsAt),
           ...(themeEls && {
@@ -1569,8 +1581,8 @@ export async function upsertUserChallenge({
       return saved;
     });
 
-    // Re-scan after any content edit (fail-soft; the scan gate hides it until Scanned).
-    await scanUserChallenge(id);
+    // Re-scan only text changes (fail-soft; the scan gate hides it until Scanned).
+    if (moderatedTextChanged) await scanUserChallenge(id);
     return updated;
   }
 


### PR DESCRIPTION
## Problem

Testers' user-created challenges got stuck as **Scheduled/Upcoming past `startsAt`** (prod challenges 400, 405).

Root cause — edit → scan dedup deadlock:

1. Create → scan succeeds → webhook sets `ingestion = Scanned` ✅
2. User edits the challenge (dates/prize only, text unchanged) → edit unconditionally resets `ingestion = Pending`, `scannedAt = null`, then re-submits the scan
3. `createXGuardModerationRequest`'s contentHash dedup sees the already-`Succeeded` EntityModeration row with the same hash → returns the cached workflowId, **no workflow submitted, no webhook, `applyResult` never runs**
4. `ingestion` stays `Pending` forever; activation requires `Scanned` → challenge never starts
5. The activation job's rescue re-scan hits the same dedup → no-op; after the 24h grace window the challenge is wrongly **voided + refunded**

Both stuck prod rows fit: `scannedAt = null` + EM row `Succeeded` + post-scan edit timestamps.

## Fix

Only reset `ingestion`/`scannedAt` and re-scan when the moderated text (title/theme/description/invitation — exactly what `buildChallengeModerationText` covers) actually changed. Unchanged-text edits keep the existing verdict.

## Behavior notes

- Blocked challenge + non-text edit → stays Blocked (no unhide loophole)
- Error/Pending verdict + unchanged-text edit → unchanged behavior owner-wise: retry cron + activation-job re-scan still recover those (dedup only matches `Succeeded` rows)
- Stuck prod rows 400/405 intentionally left as-is (tester data; grace sweep will void+refund)

## Testing

- New regression suite `challenge-edit-rescan.service.test.ts` (TDD — unchanged-text case observed failing before the fix):
  - unchanged text → no ingestion reset, no scan submit
  - changed text → reset to Pending + scan submitted
- Full `src/server/services/__tests__` sweep: 1177 pass; 7 failures pre-exist on clean main (stale `getUserSelectableJudges` mocks in `challenge-edit.service.test.ts` / `challenge-upsert-standing-real.service.test.ts`), zero regressions from this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)