### PR TITLE
feat(app-blocks): app generator subqueue read + cancel bridges (tag-scoped)

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -39,8 +39,7 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-  
-      },
+    },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -37,7 +37,10 @@ vi.mock('~/utils/trpc', () => ({
       estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-    },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+  
+      },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -609,6 +609,14 @@ export function PageBlockHost({
   // MUTATION for the same bearer-token reason as getMyBuzzBalance; requires the
   // `user:read:self` scope server-side.
   const getMyViewerMutation = trpc.blocks.getMyViewer.useMutation();
+  // App generator SUBQUEUE bridges (tag-scoped). queryAppWorkflows reads the
+  // calling app's OWN slice of the viewer's generation queue (the SERVER forces
+  // the per-app `app-block:<appId>` tag filter — a block can't widen it);
+  // cancelAppWorkflow stops one, FAIL-CLOSED behind the server ownership+tag
+  // guard. MUTATIONS for the same bearer-token-in-URL reason as the other
+  // block-token bridges (a .query would leak the JWT into the ?input= URL).
+  const queryAppWorkflowsMutation = trpc.blocks.queryAppWorkflows.useMutation();
+  const cancelAppWorkflowMutation = trpc.blocks.cancelAppWorkflow.useMutation();
 
   // Wildcard-pack import (W13). SESSION-authed (protectedProcedure) — it does NOT
   // take a block token; the viewer's real cookie session authenticates, which is
@@ -722,6 +730,83 @@ export function PageBlockHost({
     );
     return off;
   }, [onMessage, send, token, cancelWorkflowMutation]);
+
+  // QUERY_APP_WORKFLOWS → blocks.queryAppWorkflows → APP_WORKFLOWS_RESULT. The
+  // app's OWN tag-scoped generation subqueue (host page token + SERVER-forced
+  // per-app tag; a block can't widen the filter — the input has no `tags` field).
+  // params are spread FIRST then blockToken LAST so a block-sent
+  // `params.blockToken` can never override the authoritative page token (mirrors
+  // GET_BUZZ_TRANSACTIONS). REQUEST-style ⇒ every path MUST reply or the block
+  // hangs; on a null token we reply with the ERROR variant rather than dropping.
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; params?: unknown } | undefined>(
+      'QUERY_APP_WORKFLOWS',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string') return;
+        const requestId = raw.requestId;
+        if (!token) {
+          send('APP_WORKFLOWS_RESULT', { requestId, error: 'no block token' });
+          return;
+        }
+        try {
+          // params (cursor/limit) are schema-validated server-side; the host never
+          // trusts them. blockToken spread LAST — non-overridable page token.
+          const result = await queryAppWorkflowsMutation.mutateAsync({
+            ...((raw.params as Record<string, unknown>) ?? {}),
+            blockToken: token,
+          } as never);
+          send('APP_WORKFLOWS_RESULT', { requestId, result });
+        } catch (err) {
+          send('APP_WORKFLOWS_RESULT', {
+            requestId,
+            error: err instanceof Error ? err.message : 'unknown',
+          });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, queryAppWorkflowsMutation]);
+
+  // CANCEL_APP_WORKFLOW → blocks.cancelAppWorkflow → CANCEL_APP_WORKFLOW_RESULT.
+  // FAIL-CLOSED server-side (ownership + app-tag guard — the orchestrator by-id
+  // endpoints don't check ownership, so the router compensates). The host just
+  // forwards the (untrusted, server-validated) workflowId + the page token.
+  // REQUEST-style ⇒ reply on every path; on a null token we reply with the ERROR
+  // variant. A missing/empty workflowId is dropped without a reply (mirrors
+  // CANCEL_WORKFLOW — there's nothing legitimate to cancel).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; workflowId?: unknown } | undefined>(
+      'CANCEL_APP_WORKFLOW',
+      async (raw) => {
+        if (
+          !raw ||
+          typeof raw.requestId !== 'string' ||
+          typeof raw.workflowId !== 'string' ||
+          raw.workflowId.length === 0
+        ) {
+          return;
+        }
+        const requestId = raw.requestId;
+        if (!token) {
+          send('CANCEL_APP_WORKFLOW_RESULT', { requestId, error: 'no block token' });
+          return;
+        }
+        try {
+          const result = await cancelAppWorkflowMutation.mutateAsync({
+            blockToken: token,
+            workflowId: raw.workflowId,
+          });
+          send('CANCEL_APP_WORKFLOW_RESULT', { requestId, result });
+        } catch (err) {
+          send('CANCEL_APP_WORKFLOW_RESULT', {
+            requestId,
+            error: err instanceof Error ? err.message : 'unknown',
+          });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, cancelAppWorkflowMutation]);
 
   // GET_BUZZ_BALANCE → blocks.getMyBuzzBalance → BUZZ_BALANCE_RESULT. The block's
   // per-account (blue/green/yellow) balance read that backs the SDK

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -61,7 +61,10 @@ vi.mock('~/utils/trpc', () => ({
       estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-    },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+  
+      },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -63,8 +63,7 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-  
-      },
+    },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
@@ -51,8 +51,7 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-  
-      },
+    },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
@@ -49,7 +49,10 @@ vi.mock('~/utils/trpc', () => ({
       estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-    },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+  
+      },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
@@ -49,8 +49,7 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-  
-      },
+    },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
@@ -47,7 +47,10 @@ vi.mock('~/utils/trpc', () => ({
       estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-    },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+  
+      },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -62,7 +62,10 @@ vi.mock('~/utils/trpc', () => ({
       estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-    },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+  
+      },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -64,8 +64,7 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-  
-      },
+    },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -61,8 +61,7 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-  
-      },
+    },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -59,7 +59,10 @@ vi.mock('~/utils/trpc', () => ({
       estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-    },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+  
+      },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
@@ -80,8 +80,7 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-  
-      },
+    },
     apps: {
       storage: {
         set: { useMutation: () => ({ mutateAsync: mocks.storageSet }) },

--- a/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
@@ -78,7 +78,10 @@ vi.mock('~/utils/trpc', () => ({
       estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-    },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+  
+      },
     apps: {
       storage: {
         set: { useMutation: () => ({ mutateAsync: mocks.storageSet }) },

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -50,8 +50,7 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-  
-      },
+    },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -48,7 +48,10 @@ vi.mock('~/utils/trpc', () => ({
       estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-    },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+  
+      },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
@@ -67,7 +67,10 @@ vi.mock('~/utils/trpc', () => ({
       estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-    },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+  
+      },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
@@ -69,8 +69,7 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-  
-      },
+    },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
@@ -50,7 +50,10 @@ vi.mock('~/utils/trpc', () => ({
       estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-    },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+  
+      },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
@@ -52,8 +52,7 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-  
-      },
+    },
     apps: {
       shared: {
         append: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -42,6 +42,8 @@ const mocks = vi.hoisted(() => ({
   accounts: vi.fn(),
   dailyCompensation: vi.fn(),
   viewer: vi.fn(),
+  queryAppWorkflows: vi.fn(),
+  cancelAppWorkflow: vi.fn(),
 }));
 
 // AppBlockChrome (in the host frame) calls useCurrentUser() for the platform-nav
@@ -67,6 +69,8 @@ vi.mock('~/utils/trpc', () => ({
       getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: mocks.accounts }) },
       getMyDailyCompensation: { useMutation: () => ({ mutateAsync: mocks.dailyCompensation }) },
       getMyViewer: { useMutation: () => ({ mutateAsync: mocks.viewer }) },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: mocks.queryAppWorkflows }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: mocks.cancelAppWorkflow }) },
     },
     // PageBlockHost also wires the storage bridge (inert here — exercised in
     // PageBlockHostStorage.browser.test.tsx); stub so the component mounts.
@@ -185,6 +189,8 @@ describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
     mocks.accounts.mockReset();
     mocks.dailyCompensation.mockReset();
     mocks.viewer.mockReset();
+    mocks.queryAppWorkflows.mockReset();
+    mocks.cancelAppWorkflow.mockReset();
     // dialogStore is a module-level zustand store shared across tests — reset it
     // (the OPEN_BUZZ_PURCHASE handler triggers a dialog on it).
     useDialogStore.getState().closeAll();
@@ -823,6 +829,186 @@ describe('PageBlockHost workflow bridge (W10 money-path wiring)', () => {
         'green'
       );
     });
+    replies.stop();
+  });
+
+  // ── App generator SUBQUEUE bridges — QUERY_APP_WORKFLOWS / CANCEL_APP_WORKFLOW.
+  //    The app's OWN tag-scoped slice of the viewer's generation queue: read (image
+  //    results) + cancel. Host mediates via the block-token-authed
+  //    blocks.queryAppWorkflows / blocks.cancelAppWorkflow MUTATIONS (server forces
+  //    the per-app tag + the fail-closed cancel guard). Every path MUST reply.
+  test('QUERY_APP_WORKFLOWS forwards token + params and posts APP_WORKFLOWS_RESULT', async () => {
+    const result = {
+      workflows: [
+        {
+          workflowId: 'wf_a',
+          status: 'succeeded',
+          images: [{ url: 'https://cdn/i.png', width: 1024, height: 1024, nsfwLevel: 1 }],
+          cost: 25,
+          createdAt: '2026-07-15T00:00:00.000Z',
+        },
+      ],
+      cursor: 'next_1',
+    };
+    mocks.queryAppWorkflows.mockResolvedValue(result);
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('QUERY_APP_WORKFLOWS', { requestId: 'rq_q', params: { limit: 10 } });
+
+    await vi.waitFor(() => {
+      expect(mocks.queryAppWorkflows).toHaveBeenCalledWith({ blockToken: 'tok_abc', limit: 10 });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('APP_WORKFLOWS_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_q', result });
+    });
+    replies.stop();
+  });
+
+  test('QUERY_APP_WORKFLOWS ignores a block-supplied blockToken/tags in params (host token authoritative)', async () => {
+    mocks.queryAppWorkflows.mockResolvedValue({ workflows: [], cursor: null });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    // A block tries to smuggle its own token AND its own tags — neither can reach
+    // the server call: blockToken is spread LAST (host token wins) and the server
+    // input schema has no `tags` field (stripped), so the host-forced app tag is
+    // the ONLY scoping. Here we assert the host token wins at the bridge layer.
+    postFromBlock('QUERY_APP_WORKFLOWS', {
+      requestId: 'rq_q_evil',
+      params: { limit: 5, blockToken: 'EVIL_TOKEN', tags: ['app-block:other'] },
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.queryAppWorkflows).toHaveBeenCalled();
+    });
+    const arg = mocks.queryAppWorkflows.mock.calls[0][0] as { blockToken: string; limit: number };
+    expect(arg.blockToken).toBe('tok_abc'); // host page token, never the block-sent one
+    expect(arg.limit).toBe(5);
+    replies.stop();
+  });
+
+  test('QUERY_APP_WORKFLOWS error path posts an error-variant result (no hang)', async () => {
+    mocks.queryAppWorkflows.mockRejectedValue(new Error('block lacks ai:write:budgeted scope'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('QUERY_APP_WORKFLOWS', { requestId: 'rq_q_err' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('APP_WORKFLOWS_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_q_err',
+        error: 'block lacks ai:write:budgeted scope',
+      });
+    });
+    replies.stop();
+  });
+
+  test('QUERY_APP_WORKFLOWS with a null page token replies with the error variant (never hangs)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} token={null} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement | null;
+      if (!el?.contentWindow) throw new Error('iframe not mounted yet');
+    });
+    const replies = listenForReply();
+
+    postFromBlock('QUERY_APP_WORKFLOWS', { requestId: 'rq_q_notoken' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('APP_WORKFLOWS_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_q_notoken', error: 'no block token' });
+    });
+    expect(mocks.queryAppWorkflows).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('CANCEL_APP_WORKFLOW forwards workflowId and posts CANCEL_APP_WORKFLOW_RESULT', async () => {
+    const result = {
+      workflow: {
+        workflowId: 'wf_c',
+        status: 'canceled',
+        images: [],
+        cost: 0,
+        createdAt: '2026-07-15T00:00:00.000Z',
+      },
+    };
+    mocks.cancelAppWorkflow.mockResolvedValue(result);
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('CANCEL_APP_WORKFLOW', { requestId: 'rq_c', workflowId: 'wf_c' });
+
+    await vi.waitFor(() => {
+      expect(mocks.cancelAppWorkflow).toHaveBeenCalledWith({
+        blockToken: 'tok_abc',
+        workflowId: 'wf_c',
+      });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('CANCEL_APP_WORKFLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_c', result });
+    });
+    replies.stop();
+  });
+
+  test('CANCEL_APP_WORKFLOW error path (FORBIDDEN guard) posts an error-variant result (no hang)', async () => {
+    mocks.cancelAppWorkflow.mockRejectedValue(new Error('workflow is not in this app subqueue'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('CANCEL_APP_WORKFLOW', { requestId: 'rq_c_err', workflowId: 'wf_x' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('CANCEL_APP_WORKFLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_c_err',
+        error: 'workflow is not in this app subqueue',
+      });
+    });
+    replies.stop();
+  });
+
+  test('CANCEL_APP_WORKFLOW with a missing workflowId is dropped (no mutation, no reply)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('CANCEL_APP_WORKFLOW', { requestId: 'rq_c_noid' }); // no workflowId
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(mocks.cancelAppWorkflow).not.toHaveBeenCalled();
+    expect(replies.last('CANCEL_APP_WORKFLOW_RESULT')).toBeUndefined();
+    replies.stop();
+  });
+
+  test('CANCEL_APP_WORKFLOW with a null page token replies with the error variant (never hangs)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} token={null} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement | null;
+      if (!el?.contentWindow) throw new Error('iframe not mounted yet');
+    });
+    const replies = listenForReply();
+
+    postFromBlock('CANCEL_APP_WORKFLOW', { requestId: 'rq_c_notoken', workflowId: 'wf_c' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('CANCEL_APP_WORKFLOW_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_c_notoken', error: 'no block token' });
+    });
+    expect(mocks.cancelAppWorkflow).not.toHaveBeenCalled();
     replies.stop();
   });
 });

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -193,6 +193,29 @@ export const INVENTORY = {
     PageBlockHost: 'required',
     InlineHost: INLINE_STUB,
   },
+  // App generator SUBQUEUE bridges (tag-scoped) — the calling app's OWN slice of
+  // the viewer's generation queue: read (image results) + cancel one, both scoped
+  // to `app-block:<appId>` server-side (host-forced tag on read; fail-closed
+  // ownership+tag guard on cancel — the block never sees the user's personal
+  // gens). AHEAD of the published SDK dist union (the SDK bridge lands in a
+  // follow-up PR) — forward-looking coverage, allowed by the one-directional
+  // compile-time gate. PAGE-ONLY affordance today (a full-page generator app;
+  // model-slot apps are deferred + will get the page host too), so N/A for the
+  // model host — mirrors the buzz self-read / OPEN_RESOURCE_PICKER placement.
+  QUERY_APP_WORKFLOWS: {
+    request: true,
+    reply: 'APP_WORKFLOWS_RESULT',
+    IframeHost: 'app subqueue is a page-only affordance today; slot-apps deferred',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  CANCEL_APP_WORKFLOW: {
+    request: true,
+    reply: 'CANCEL_APP_WORKFLOW_RESULT',
+    IframeHost: 'app subqueue is a page-only affordance today; slot-apps deferred',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
   // Per-account (blue/green/yellow) balance read backing the SDK
   // `useBuzzBalance()` hook + the account-picker (Phase 3 host wiring). Host-
   // mediated via the block-token-authed `blocks.getMyBuzzBalance` MUTATION.

--- a/src/server/routers/__tests__/blocks.router.appSubqueue.test.ts
+++ b/src/server/routers/__tests__/blocks.router.appSubqueue.test.ts
@@ -440,4 +440,19 @@ describe('blocks.cancelAppWorkflow', () => {
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
     expect(mockCancelWorkflow).not.toHaveBeenCalled();
   });
+
+  it('rejects with TOO_MANY_REQUESTS when the per-instance rate limit trips (mirrors query proc; no ownership check, no orchestrator call)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockCheckBlockCatalogRateLimit.mockResolvedValue({ allowed: false });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.cancelAppWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
+    ).rejects.toMatchObject({ code: 'TOO_MANY_REQUESTS' });
+    // The limiter runs BEFORE the heavy path — no ownership lookup, no orchestrator
+    // read/DELETE. Same key/scope as queryAppWorkflows (blockInstanceId).
+    expect(mockCheckBlockCatalogRateLimit).toHaveBeenCalledWith('bki_test');
+    expect(mockBlockWorkflowOwned).not.toHaveBeenCalled();
+    expect(mockGetWorkflow).not.toHaveBeenCalled();
+    expect(mockCancelWorkflow).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/routers/__tests__/blocks.router.appSubqueue.test.ts
+++ b/src/server/routers/__tests__/blocks.router.appSubqueue.test.ts
@@ -1,0 +1,443 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * App generator SUBQUEUE bridges — `blocks.queryAppWorkflows` (tag-scoped read)
+ * + `blocks.cancelAppWorkflow` (fail-closed cancel). These are the SECURITY-
+ * critical, contract-defining half of App Blocks generator subqueue access: a
+ * block reads + cancels ONLY its OWN tag-scoped slice of the viewer's workflows,
+ * never the personal queue.
+ *
+ * We assert, per gate:
+ *   - queryAppWorkflows forces the per-app tag on the orchestrator LIST and a
+ *     malicious client `tags` input can NOT override/remove it (the tag is the
+ *     security boundary), returns the projected AppWorkflow shape, and round-
+ *     trips the cursor. Empty subqueue → empty list.
+ *   - cancelAppWorkflow FAILS CLOSED: a workflow not in the app subqueue (no
+ *     ownership row) OR one whose orchestrator record lacks the app tag →
+ *     FORBIDDEN, orchestrator cancel NOT called. Happy path → cancel once.
+ *   - the shared gates: invalid/anon token, missing scope, rate limit.
+ *
+ * Strategy mirrors blocks.router.workflow.test.ts: mock every dependency at the
+ * module boundary so the router runs in-process and we assert exact arguments.
+ */
+
+const {
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockGetOrchestratorToken,
+  mockQueryWorkflows,
+  mockGetWorkflow,
+  mockCancelWorkflow,
+  mockSubmitWorkflow,
+  mockGetUserById,
+  mockCheckBlockCatalogRateLimit,
+  mockGetSessionUser,
+  mockDbRead,
+  mockRedis,
+  mockSysRedis,
+  mockIsAppBlocksEnabled,
+  mockIsAppBlocksAuthorEnabled,
+  mockBlockWorkflowOwned,
+} = vi.hoisted(() => ({
+  mockVerifyBlockToken: vi.fn(),
+  mockParseSubjectUserId: vi.fn(),
+  mockGetOrchestratorToken: vi.fn(),
+  mockQueryWorkflows: vi.fn(),
+  mockGetWorkflow: vi.fn(),
+  mockCancelWorkflow: vi.fn(),
+  mockSubmitWorkflow: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockCheckBlockCatalogRateLimit: vi.fn(async () => ({ allowed: true })),
+  mockGetSessionUser: vi.fn(),
+  mockDbRead: {
+    modelVersion: { findUnique: vi.fn(), findFirst: vi.fn(), findMany: vi.fn() },
+    modelBlockInstall: { findUnique: vi.fn() },
+    blockUserSettings: { findUnique: vi.fn() },
+    modelMetric: { findFirst: vi.fn() },
+  },
+  mockRedis: {
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 0),
+    incr: vi.fn(async () => 1),
+    incrBy: vi.fn(async () => 1),
+    decrBy: vi.fn(async () => 0),
+    expire: vi.fn(async () => true),
+    ttl: vi.fn(async () => -1),
+    exists: vi.fn(async () => 0),
+  },
+  mockSysRedis: {
+    get: vi.fn(async () => null),
+    incrBy: vi.fn(async () => 0),
+    decrBy: vi.fn(async () => 0),
+    expire: vi.fn(async () => true),
+    ttl: vi.fn(async () => -1),
+  },
+  mockIsAppBlocksEnabled: vi.fn(async () => true),
+  mockIsAppBlocksAuthorEnabled: vi.fn(
+    async (opts?: { user?: { isModerator?: boolean } }) => !!opts?.user?.isModerator
+  ),
+  mockBlockWorkflowOwned: vi.fn(async () => true),
+}));
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...args: unknown[]) => mockParseSubjectUserId(...args),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: mockGetOrchestratorToken,
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  queryWorkflows: mockQueryWorkflows,
+  getWorkflow: mockGetWorkflow,
+  cancelWorkflow: mockCancelWorkflow,
+  submitWorkflow: mockSubmitWorkflow,
+}));
+// cancelAppWorkflow dynamic-imports the ownership guard from here; query/list
+// procedures also dynamic-import this module. Mock the whole surface.
+vi.mock('~/server/services/blocks/block-workflows.service', () => ({
+  blockWorkflowOwnedByAppUser: (...a: unknown[]) => mockBlockWorkflowOwned(...a),
+  upsertBlockWorkflowOnSubmit: vi.fn(async () => undefined),
+  listMyBlockWorkflows: vi.fn(async () => ({ items: [], nextCursor: null })),
+}));
+vi.mock('~/server/services/blocks/user-app-surface.service', () => ({
+  recordScopeInvocation: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/user.service', () => ({ getUserById: mockGetUserById }));
+vi.mock('~/server/auth/session-client', () => ({
+  sessionClient: { getSessionUserById: (...args: unknown[]) => mockGetSessionUser(...args) },
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: {
+    modelBlockInstall: { findUnique: vi.fn() },
+    model: { findUnique: vi.fn() },
+    user: { findUnique: vi.fn() },
+  },
+}));
+
+const { completeKeys } = vi.hoisted(() => {
+  const group = (explicit: Record<string, string>, name: string): Record<string, string> =>
+    new Proxy(explicit, {
+      get: (t, k) =>
+        k in t ? (t as any)[k] : typeof k === 'string' ? `mock:${name}:${k}` : (t as any)[k],
+    });
+  const completeKeys = (explicit: Record<string, Record<string, string>>) =>
+    new Proxy(explicit, {
+      get: (t, g) =>
+        g in t ? group((t as any)[g], g as string) : typeof g === 'string' ? group({}, g) : (t as any)[g],
+    });
+  return { completeKeys };
+});
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  sysRedis: mockSysRedis,
+  REDIS_KEYS: completeKeys({ BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } }),
+  REDIS_SYS_KEYS: completeKeys({ BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } }),
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: (...args: unknown[]) => mockCheckBlockCatalogRateLimit(...args),
+}));
+// Cut the rateLimit middleware's heavy Prisma-validator import chain (mirrors the
+// sibling blocks.router tests).
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function validClaims(over: Record<string, unknown> = {}) {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'jti_test',
+    blockId: 'blk_test',
+    appId: 'app_test',
+    appBlockId: 'apb_test',
+    blockInstanceId: 'bki_test',
+    ctx: { slotId: 'none', entityType: 'none' },
+    scopes: ['ai:write:budgeted'],
+    buzzBudget: 50,
+    ...over,
+  };
+}
+
+function fakeCtx() {
+  return {
+    acceptableOrigin: true,
+    user: undefined,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { canViewNsfw: false, isBlue: false, isGreen: false, isGreenSession: false } as never,
+    track: undefined,
+  };
+}
+
+// The per-app subqueue tag stamped on every app-submitted workflow.
+const APP_TAG = 'app-block:app_test';
+
+beforeEach(() => {
+  for (const fn of [
+    mockVerifyBlockToken,
+    mockParseSubjectUserId,
+    mockGetOrchestratorToken,
+    mockQueryWorkflows,
+    mockGetWorkflow,
+    mockCancelWorkflow,
+    mockGetUserById,
+    mockGetSessionUser,
+    mockCheckBlockCatalogRateLimit,
+    mockIsAppBlocksEnabled,
+    mockIsAppBlocksAuthorEnabled,
+    mockBlockWorkflowOwned,
+  ]) {
+    fn.mockReset();
+  }
+  mockIsAppBlocksEnabled.mockImplementation(async () => true);
+  mockIsAppBlocksAuthorEnabled.mockImplementation(
+    async (opts?: { user?: { isModerator?: boolean } }) => !!opts?.user?.isModerator
+  );
+  mockGetUserById.mockResolvedValue({ id: 42, isModerator: true, tier: 'free' });
+  mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: true, tier: 'free' });
+  mockParseSubjectUserId.mockImplementation((sub: string) => (sub === 'anon' ? null : 42));
+  mockGetOrchestratorToken.mockResolvedValue('orch_token');
+  mockCheckBlockCatalogRateLimit.mockResolvedValue({ allowed: true });
+  mockBlockWorkflowOwned.mockResolvedValue(true);
+  mockQueryWorkflows.mockResolvedValue({ items: [], nextCursor: null });
+});
+
+describe('blocks.queryAppWorkflows', () => {
+  it('calls the orchestrator LIST with the host-forced per-app tag + the viewer token', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await caller.queryAppWorkflows({ blockToken: 'tok' });
+    expect(mockQueryWorkflows).toHaveBeenCalledTimes(1);
+    const arg = mockQueryWorkflows.mock.calls[0][0] as { token: string; tags: string[] };
+    expect(arg.token).toBe('orch_token'); // the viewer's OWN orchestrator token
+    expect(arg.tags).toEqual([APP_TAG]); // the ONLY tag — the security boundary
+  });
+
+  it('projects orchestrator items to the clean AppWorkflow shape and round-trips the cursor', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockQueryWorkflows.mockResolvedValue({
+      nextCursor: 'cur_2',
+      items: [
+        {
+          id: 'wf_1',
+          createdAt: '2026-07-15T00:00:00.000Z',
+          status: 'succeeded',
+          cost: { total: 20 },
+          tags: ['civitai', APP_TAG],
+          steps: [
+            {
+              $type: 'textToImage',
+              name: 's',
+              status: 'succeeded',
+              metadata: {},
+              output: {
+                images: [
+                  {
+                    id: 'b',
+                    url: 'https://cdn/i.png',
+                    available: true,
+                    width: 512,
+                    height: 512,
+                    nsfwLevel: 'pg',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.queryAppWorkflows({ blockToken: 'tok', cursor: 'cur_1', limit: 5 });
+    expect(result).toEqual({
+      workflows: [
+        {
+          workflowId: 'wf_1',
+          status: 'succeeded',
+          images: [{ url: 'https://cdn/i.png', width: 512, height: 512, nsfwLevel: 1 }],
+          cost: 20,
+          createdAt: '2026-07-15T00:00:00.000Z',
+        },
+      ],
+      cursor: 'cur_2',
+    });
+    // The input cursor + limit were forwarded to the orchestrator LIST.
+    const arg = mockQueryWorkflows.mock.calls[0][0] as { cursor?: string; take?: number };
+    expect(arg.cursor).toBe('cur_1');
+    expect(arg.take).toBe(5);
+  });
+
+  it('an empty subqueue returns an empty list + null cursor', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockQueryWorkflows.mockResolvedValue({ items: [], nextCursor: undefined });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.queryAppWorkflows({ blockToken: 'tok' });
+    expect(result).toEqual({ workflows: [], cursor: null });
+  });
+
+  it('the app tag is bound from the TOKEN appId, not a client-supplied value', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ appId: 'app_other' }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    // Even if a malicious client tries to smuggle `tags`, the input schema has no
+    // such field so it is stripped by zod — the handler forces exactly one tag,
+    // derived from the verified token appId.
+    await caller.queryAppWorkflows({
+      blockToken: 'tok',
+      // @ts-expect-error — `tags` is NOT part of the input contract (the whole point).
+      tags: ['app-block:victim', 'civitai'],
+    });
+    const arg = mockQueryWorkflows.mock.calls[0][0] as { tags: string[] };
+    expect(arg.tags).toEqual(['app-block:app_other']); // token-derived, not client 'victim'
+    expect(arg.tags).not.toContain('app-block:victim');
+  });
+
+  it('rejects an invalid block token with UNAUTHORIZED (no orchestrator call)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.queryAppWorkflows({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockQueryWorkflows).not.toHaveBeenCalled();
+  });
+
+  it('rejects a token missing ai:write:budgeted scope with FORBIDDEN', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: ['models:read:self'] }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.queryAppWorkflows({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockQueryWorkflows).not.toHaveBeenCalled();
+  });
+
+  it('rejects anon subjects with UNAUTHORIZED', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ sub: 'anon' }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.queryAppWorkflows({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+  });
+
+  it('rejects with TOO_MANY_REQUESTS when the per-instance rate limit trips (no orchestrator call)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockCheckBlockCatalogRateLimit.mockResolvedValue({ allowed: false });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(caller.queryAppWorkflows({ blockToken: 'tok' })).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+    expect(mockQueryWorkflows).not.toHaveBeenCalled();
+  });
+});
+
+describe('blocks.cancelAppWorkflow', () => {
+  function ownedAppTaggedWorkflow() {
+    mockBlockWorkflowOwned.mockResolvedValue(true);
+    mockGetWorkflow.mockResolvedValue({
+      id: 'wf_1',
+      createdAt: '2026-07-15T00:00:00.000Z',
+      status: 'canceled',
+      cost: { total: 0 },
+      tags: ['civitai', APP_TAG],
+      steps: [],
+    });
+  }
+
+  it('happy path: guards pass → cancels once and returns the projected AppWorkflow', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    ownedAppTaggedWorkflow();
+    mockCancelWorkflow.mockResolvedValue(undefined);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.cancelAppWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+    expect(result.workflow).toEqual({
+      workflowId: 'wf_1',
+      status: 'canceled',
+      images: [],
+      cost: 0,
+      createdAt: '2026-07-15T00:00:00.000Z',
+    });
+    // Ownership was checked with the server-derived (userId, appBlockId, workflowId).
+    expect(mockBlockWorkflowOwned).toHaveBeenCalledWith({
+      userId: 42,
+      appBlockId: 'apb_test',
+      workflowId: 'wf_1',
+    });
+    expect(mockCancelWorkflow).toHaveBeenCalledTimes(1);
+    expect(mockCancelWorkflow).toHaveBeenCalledWith({ workflowId: 'wf_1', token: 'orch_token' });
+  });
+
+  it('FAILS CLOSED when the workflow is not in the app subqueue (no ownership row) — cancel NOT called', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockBlockWorkflowOwned.mockResolvedValue(false); // not owned by this user/app
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.cancelAppWorkflow({ blockToken: 'tok', workflowId: 'wf_other' })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockCancelWorkflow).not.toHaveBeenCalled();
+    // Fails on the ownership gate BEFORE any orchestrator read.
+    expect(mockGetWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('FAILS CLOSED when the orchestrator record lacks the app tag — cancel NOT called', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockBlockWorkflowOwned.mockResolvedValue(true);
+    // The ownership row says owned, but the orchestrator's own record is NOT tagged
+    // for this app (defense-in-depth guard b) → still FORBIDDEN.
+    mockGetWorkflow.mockResolvedValue({
+      id: 'wf_1',
+      createdAt: '2026-07-15T00:00:00.000Z',
+      status: 'processing',
+      cost: { total: 0 },
+      tags: ['civitai', 'app-block:someone_else'],
+      steps: [],
+    });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.cancelAppWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockCancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid block token with UNAUTHORIZED and never calls cancel', async () => {
+    mockVerifyBlockToken.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.cancelAppWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockCancelWorkflow).not.toHaveBeenCalled();
+    expect(mockBlockWorkflowOwned).not.toHaveBeenCalled();
+  });
+
+  it('rejects a token missing ai:write:budgeted scope with FORBIDDEN (no ownership check, no cancel)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ scopes: ['models:read:self'] }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.cancelAppWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockBlockWorkflowOwned).not.toHaveBeenCalled();
+    expect(mockCancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('rejects anon subjects with UNAUTHORIZED', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ sub: 'anon' }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.cancelAppWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockCancelWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -95,8 +95,10 @@ import { getRequestDomainColor, isHostForColor } from '~/server/utils/server-dom
 // lazy import of recordScopeInvocation below.
 import type { ResolveCanGenerateVersion } from '~/server/services/generation/generation.service';
 import {
+  appBlockTag,
   buildTextToImageInput,
   isPageLoraResource,
+  projectAppWorkflow,
   resolveBlockVersionContext,
   resolvePageResourceContext,
   snapshotFromWorkflow,
@@ -119,7 +121,12 @@ import {
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { getBaseModelSetType, WORKFLOW_TAGS } from '~/shared/constants/generation.constants';
 import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
-import { cancelWorkflow, getWorkflow, submitWorkflow } from '~/server/services/orchestrator/workflows';
+import {
+  cancelWorkflow,
+  getWorkflow,
+  queryWorkflows,
+  submitWorkflow,
+} from '~/server/services/orchestrator/workflows';
 import {
   buildGenerationContext,
   createWorkflowStepsFromGraphInput,
@@ -2601,6 +2608,170 @@ export const blocksRouter = router({
     }),
 
   /**
+   * App generator SUBQUEUE read — the calling app's OWN tag-scoped slice of the
+   * viewer's generation workflows, projected to the clean `AppWorkflow` wire
+   * shape (see projectAppWorkflow). Backs an app rebuilding its in-flight+done
+   * generation queue WITH live image results (distinct from `listMyWorkflows`,
+   * which reads only the persisted status read-model, and `pollWorkflow`, which
+   * reads ONE workflow).
+   *
+   * TWO independent scoping boundaries, both server-derived from the VERIFIED
+   * token — NEVER client input:
+   *   1. USER scope — the orchestrator LIST is called with the viewer's OWN
+   *      per-user orchestrator token, so it only ever returns that user's
+   *      workflows (the personal-queue read works the same way).
+   *   2. APP scope — a HOST-FORCED positive `tags:['app-block:<appId>']` filter
+   *      (`appBlockTag(claims.appId)`). This is the SECURITY BOUNDARY that keeps
+   *      the read to the app's OWN subqueue and OUT of the user's personal gens.
+   *      The input schema exposes NO `tags` field, so a block CANNOT pass/override
+   *      tags to widen the filter — the host tag is the only tag, always applied.
+   *
+   * MUTATION (not query) DELIBERATELY, for the same bearer-token-in-URL reason as
+   * every other block-token proc (a `.query` leaks the JWT into `?input=…` /
+   * logs / Referer where it is replayable within its TTL).
+   *
+   * Order (each step fail-closed): verify token → require `ai:write:budgeted`
+   * (same trust boundary as submit — an app that can submit gens can read its own
+   * subqueue) → self-bind userId off `claims.sub` (UNAUTHORIZED for anon) →
+   * App-Blocks kill-switch + author gate against the TOKEN subject → per-instance
+   * rate limit → orchestrator LIST with the host-forced tag → project + return.
+   */
+  queryAppWorkflows: publicProcedure
+    // Block-JWT-authed (no session for dev:live) — flag evaluated against the
+    // TOKEN subject below, not the `enforceAppBlocksFlag` middleware's ctx.user.
+    .input(
+      z.object({
+        blockToken: z.string().min(1),
+        cursor: z.string().min(1).max(256).nullish(),
+        limit: z.number().int().min(1).max(50).optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const claims = await verifyBlockToken(input.blockToken);
+      if (!claims) throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid block token' });
+      // Same trust boundary as submit: an app authorized to spend the viewer's
+      // Buzz on generation can read the subqueue of gens it produced.
+      if (!claims.scopes.includes('ai:write:budgeted')) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'block lacks ai:write:budgeted scope' });
+      }
+      const userId = parseSubjectUserId(claims.sub);
+      if (userId == null) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'workflow query requires authenticated viewer',
+        });
+      }
+      // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
+      await assertAppBlocksEnabledForTokenUser(userId);
+      await assertViewerIsAppDeveloper(userId);
+      // Per-instance rate limit (shared blocks limiter), BEFORE the orchestrator
+      // call. Bounds a block hammering the LIST onto the origin. Fail-open on a
+      // redis incident (same posture as the buzz self-read bridges).
+      const rate = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+      if (!rate.allowed) {
+        throw new TRPCError({
+          code: 'TOO_MANY_REQUESTS',
+          message: 'Rate limit exceeded, please retry shortly.',
+        });
+      }
+      const token = await getOrchestratorToken(userId, ctx);
+      // HOST-FORCED per-app tag — the ONLY tag passed (the input has no `tags`
+      // field), so a block can never remove/override/widen it. queryWorkflows
+      // itself prepends 'civitai', yielding a positive AND-match of
+      // ['civitai', 'app-block:<appId>'] scoped to the viewer's own workflows.
+      const { nextCursor, items } = await queryWorkflows({
+        token,
+        tags: [appBlockTag(claims.appId)],
+        take: input.limit ?? 20,
+        cursor: input.cursor ?? undefined,
+        hideMatureContent: false,
+      });
+      return {
+        workflows: items.map(projectAppWorkflow),
+        cursor: nextCursor ?? null,
+      };
+    }),
+
+  /**
+   * Cancel ONE workflow in the calling app's OWN subqueue — FAIL-CLOSED.
+   *
+   * The orchestrator's by-id GET/PATCH/DELETE `/{workflowId}` endpoints do NOT
+   * verify caller-vs-workflow ownership, so canceling with the viewer's token is
+   * NOT by itself a gate — a guessed/forged id belonging to another user (or a
+   * non-app personal generation) could otherwise be canceled. This procedure
+   * COMPENSATES with a two-part guard BEFORE the cancel:
+   *   (a) OWNERSHIP+ATTRIBUTION — the `block_workflows` read-model must carry a
+   *       row for the exact (userId from token `sub`, appBlockId from token,
+   *       workflowId) tuple (`blockWorkflowOwnedByAppUser`). This is the durable
+   *       USER binding the orchestrator lacks — the load-bearing check.
+   *   (b) APP TAG — the orchestrator's OWN record for the workflow must carry the
+   *       `app-block:<appId>` tag (defense-in-depth: the two systems must agree it
+   *       is this app's workflow).
+   * If EITHER fails → FORBIDDEN and the orchestrator cancel is NEVER called.
+   *
+   * MUTATION for the bearer-token-in-URL reason (see queryAppWorkflows). Scope +
+   * gate order identical to queryAppWorkflows/cancelWorkflow.
+   */
+  cancelAppWorkflow: publicProcedure
+    // Block-JWT-authed (no session for dev:live) — flag evaluated against the
+    // TOKEN subject below, not the `enforceAppBlocksFlag` middleware's ctx.user.
+    .input(
+      z.object({
+        blockToken: z.string().min(1),
+        workflowId: z.string().min(1).max(64),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      const claims = await verifyBlockToken(input.blockToken);
+      if (!claims) throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid block token' });
+      if (!claims.scopes.includes('ai:write:budgeted')) {
+        throw new TRPCError({ code: 'FORBIDDEN', message: 'block lacks ai:write:budgeted scope' });
+      }
+      const userId = parseSubjectUserId(claims.sub);
+      if (userId == null) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'workflow cancel requires authenticated viewer',
+        });
+      }
+      // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
+      await assertAppBlocksEnabledForTokenUser(userId);
+      await assertViewerIsAppDeveloper(userId);
+      // GUARD (a): the durable user+app-block-bound ownership proof. Bound
+      // entirely from the verified token — a block can only ever authorize a
+      // workflow it actually submitted for THIS viewer. Fail-closed.
+      const { blockWorkflowOwnedByAppUser } = await import(
+        '~/server/services/blocks/block-workflows.service'
+      );
+      const owned = await blockWorkflowOwnedByAppUser({
+        userId,
+        appBlockId: claims.appBlockId,
+        workflowId: input.workflowId,
+      });
+      if (!owned) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'workflow is not in this app subqueue',
+        });
+      }
+      const token = await getOrchestratorToken(userId, ctx);
+      // GUARD (b): re-read the workflow and assert the orchestrator's OWN record
+      // carries the per-app tag — defense-in-depth over (a). Done with the
+      // viewer's token (which does NOT itself gate ownership per the note above).
+      const workflow = await getWorkflow({ token, path: { workflowId: input.workflowId } });
+      if (!(workflow.tags ?? []).includes(appBlockTag(claims.appId))) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'workflow is not tagged for this app',
+        });
+      }
+      // Both guards passed — cancel, then re-read + project the terminal state.
+      await cancelWorkflow({ workflowId: input.workflowId, token });
+      const canceled = await getWorkflow({ token, path: { workflowId: input.workflowId } });
+      return { workflow: projectAppWorkflow(canceled) };
+    }),
+
+  /**
    * Cost-only preview. Builds the same orchestrator step `submitWorkflow`
    * would, then calls submit with `whatif:true` so the orchestrator computes
    * cost without queueing the job. No budget gate — estimate is how the block
@@ -4562,7 +4733,9 @@ function buildWorkflowTags(
     'txt2img',
     baseModel,
     'app-block',
-    `app-block:${claims.appId}`,
+    // Per-app subqueue tag — the SAME helper `blocks.queryAppWorkflows` filters
+    // on, so the STAMP and the READ can never desync (see appBlockTag).
+    appBlockTag(claims.appId),
     `app-block:block:${claims.blockId}`,
     `app-block:instance:${claims.blockInstanceId}`,
   ];

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -2737,6 +2737,18 @@ export const blocksRouter = router({
       // App-Blocks flag gate, evaluated against the TOKEN subject (not ctx.user).
       await assertAppBlocksEnabledForTokenUser(userId);
       await assertViewerIsAppDeveloper(userId);
+      // Per-instance rate limit (shared blocks limiter), BEFORE any orchestrator
+      // read/DELETE or DB query. Cancel is the HEAVIER path (2 orchestrator GETs +
+      // 1 DELETE + 1 DB lookup per call), so it MUST be bounded exactly like the
+      // sibling queryAppWorkflows — same key (blockInstanceId) + scope. Fail-open
+      // on a redis incident (matches the buzz self-read bridges / query proc).
+      const rate = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+      if (!rate.allowed) {
+        throw new TRPCError({
+          code: 'TOO_MANY_REQUESTS',
+          message: 'Rate limit exceeded, please retry shortly.',
+        });
+      }
       // GUARD (a): the durable user+app-block-bound ownership proof. Bound
       // entirely from the verified token — a block can only ever authorize a
       // workflow it actually submitted for THIS viewer. Fail-closed.

--- a/src/server/services/blocks/__tests__/block-workflows.service.test.ts
+++ b/src/server/services/blocks/__tests__/block-workflows.service.test.ts
@@ -24,6 +24,7 @@ import {
   upsertBlockWorkflowOnSubmit,
   updateBlockWorkflowStatus,
   listMyBlockWorkflows,
+  blockWorkflowOwnedByAppUser,
   BLOCK_WORKFLOWS_MAX_LIMIT,
 } from '../block-workflows.service';
 
@@ -208,5 +209,27 @@ describe('listMyBlockWorkflows', () => {
     // micro-ISO string (NOT '2026-07-15T12:00:02.123Z').
     expect(binds).toContain(tsA);
     expect(binds).toContain('wf_a');
+  });
+});
+
+describe('blockWorkflowOwnedByAppUser (cancel ownership guard)', () => {
+  const input = { userId: 42, appBlockId: 'apb_1', workflowId: 'wf_1' };
+
+  it('returns true when a row exists for the (userId, appBlockId, workflowId) tuple', async () => {
+    mockQueryRaw.mockResolvedValueOnce([{ one: 1 }]);
+    await expect(blockWorkflowOwnedByAppUser(input)).resolves.toBe(true);
+    // Bound params: the untrusted workflowId + BOTH server-derived scoping keys.
+    const values = valuesOf(mockQueryRaw.mock.calls[0]);
+    expect(values).toEqual(['wf_1', 42, 'apb_1']);
+  });
+
+  it('returns false when no matching row exists (not owned / wrong app / wrong user)', async () => {
+    mockQueryRaw.mockResolvedValueOnce([]);
+    await expect(blockWorkflowOwnedByAppUser(input)).resolves.toBe(false);
+  });
+
+  it('FAILS CLOSED (returns false, never throws) on a DB error', async () => {
+    mockQueryRaw.mockRejectedValueOnce(new Error('db down'));
+    await expect(blockWorkflowOwnedByAppUser(input)).resolves.toBe(false);
   });
 });

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -410,12 +410,13 @@ describe('projectAppWorkflow', () => {
 
   it('maps the orchestrator string nsfwLevel to the numeric browsing-level bitflag', () => {
     const cases: Array<[string, number | null]> = [
+      ['g', 1], // SFW 'g' → PG (the raw map lacks it; canonical helper supplies it)
       ['pg', 1],
       ['pg13', 2],
       ['r', 4],
       ['x', 8],
       ['xxx', 16],
-      ['na', null], // unrated → null
+      ['na', null], // genuinely unrated → null
     ];
     for (const [rating, expected] of cases) {
       const wf = fakeWorkflow({

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -17,10 +17,12 @@ const { mockDbRead } = vi.hoisted(() => ({
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead }));
 
 import {
+  appBlockTag,
   buildImageWorkflowInput,
   buildTextToImageInput,
   BLOCK_IMAGE_WORKFLOW_TYPES,
   isPageLoraResource,
+  projectAppWorkflow,
   resolveBlockImageWorkflowType,
   resolveBlockVersionContext,
   resolvePageResourceContext,
@@ -352,6 +354,190 @@ describe('snapshotFromWorkflow', () => {
       );
       expect(snap.spentAccountType).toBeUndefined();
     });
+  });
+});
+
+describe('appBlockTag', () => {
+  it('formats the per-app subqueue tag', () => {
+    expect(appBlockTag('app_abc')).toBe('app-block:app_abc');
+  });
+  it('is the SAME format the submit path stamps (stamp/read cannot desync)', () => {
+    // buildWorkflowTags (blocks.router) stamps `app-block:${claims.appId}`; the
+    // read filter calls appBlockTag(claims.appId). Pin the literal so a change to
+    // one without the other is caught.
+    const appId = 'oauthClient_123';
+    expect(appBlockTag(appId)).toBe(`app-block:${appId}`);
+  });
+});
+
+describe('projectAppWorkflow', () => {
+  it('projects the happy path to the clean AppWorkflow wire shape', () => {
+    const wf = fakeWorkflow({
+      id: 'wf_a',
+      createdAt: '2026-07-15T12:00:00.000Z',
+      status: 'succeeded',
+      cost: { total: 30 },
+      steps: [
+        {
+          $type: 'textToImage',
+          name: 's1',
+          status: 'succeeded',
+          metadata: {},
+          output: {
+            images: [
+              {
+                id: 'b1',
+                url: 'https://cdn/i1.png',
+                available: true,
+                width: 1024,
+                height: 768,
+                nsfwLevel: 'pg',
+                type: 'image',
+              },
+            ],
+          },
+        },
+      ],
+    });
+    expect(projectAppWorkflow(wf as never)).toEqual({
+      workflowId: 'wf_a',
+      status: 'succeeded',
+      images: [{ url: 'https://cdn/i1.png', width: 1024, height: 768, nsfwLevel: 1 }],
+      cost: 30,
+      createdAt: '2026-07-15T12:00:00.000Z',
+    });
+  });
+
+  it('maps the orchestrator string nsfwLevel to the numeric browsing-level bitflag', () => {
+    const cases: Array<[string, number | null]> = [
+      ['pg', 1],
+      ['pg13', 2],
+      ['r', 4],
+      ['x', 8],
+      ['xxx', 16],
+      ['na', null], // unrated → null
+    ];
+    for (const [rating, expected] of cases) {
+      const wf = fakeWorkflow({
+        steps: [
+          {
+            $type: 'textToImage',
+            name: 's1',
+            status: 'succeeded',
+            metadata: {},
+            output: {
+              images: [{ id: 'b', url: 'https://cdn/x.png', available: true, nsfwLevel: rating }],
+            },
+          },
+        ],
+      });
+      expect(projectAppWorkflow(wf as never).images[0].nsfwLevel).toBe(expected);
+    }
+  });
+
+  it('nulls width/height/nsfwLevel when the orchestrator omits them', () => {
+    const wf = fakeWorkflow({
+      steps: [
+        {
+          $type: 'textToImage',
+          name: 's1',
+          status: 'succeeded',
+          metadata: {},
+          output: { images: [{ id: 'b', url: 'https://cdn/x.png', available: true }] },
+        },
+      ],
+    });
+    expect(projectAppWorkflow(wf as never).images[0]).toEqual({
+      url: 'https://cdn/x.png',
+      width: null,
+      height: null,
+      nsfwLevel: null,
+    });
+  });
+
+  it('drops pending/blocked/urless blobs (no dead links leaked)', () => {
+    const wf = fakeWorkflow({
+      steps: [
+        {
+          $type: 'textToImage',
+          name: 's1',
+          status: 'processing',
+          metadata: {},
+          output: {
+            images: [
+              { id: 'b1', url: 'https://cdn/ok.png', available: true, type: 'image' },
+              { id: 'b2', url: null, available: false, type: 'image' },
+              { id: 'b3', url: 'https://cdn/blocked.png', available: false, type: 'image' },
+              { id: 'b4', url: '', available: true, type: 'image' },
+            ],
+          },
+        },
+      ],
+    });
+    expect(projectAppWorkflow(wf as never).images).toEqual([
+      { url: 'https://cdn/ok.png', width: null, height: null, nsfwLevel: null },
+    ]);
+  });
+
+  it('maps orchestrator-internal statuses to the block-contract status set', () => {
+    const map: Array<[string, string]> = [
+      ['unassigned', 'pending'],
+      ['preparing', 'pending'],
+      ['scheduled', 'pending'],
+      ['processing', 'processing'],
+      ['succeeded', 'succeeded'],
+      ['failed', 'failed'],
+      ['expired', 'expired'],
+      ['canceled', 'canceled'],
+    ];
+    for (const [orch, contract] of map) {
+      expect(projectAppWorkflow(fakeWorkflow({ status: orch }) as never).status).toBe(contract);
+    }
+  });
+
+  it('returns cost:null when the orchestrator omits a total, and an empty images list for a pending workflow', () => {
+    const wf = fakeWorkflow({ status: 'preparing', cost: {}, steps: [] });
+    const projected = projectAppWorkflow(wf as never);
+    expect(projected.cost).toBeNull();
+    expect(projected.images).toEqual([]);
+    expect(projected.status).toBe('pending');
+  });
+
+  it('does NOT leak internal fields (steps/params/tags/transactions/metadata)', () => {
+    const wf = fakeWorkflow({
+      steps: [
+        {
+          $type: 'textToImage',
+          name: 's1',
+          status: 'succeeded',
+          metadata: { params: { prompt: 'secret prompt' } },
+          output: { images: [{ id: 'b', url: 'https://cdn/x.png', available: true }] },
+        },
+      ],
+      tags: ['civitai', 'app-block:app_x'],
+      transactions: { list: [{ type: 'debit', amount: 30, accountType: 'yellow' }] },
+    });
+    const projected = projectAppWorkflow(wf as never);
+    expect(Object.keys(projected).sort()).toEqual(
+      ['cost', 'createdAt', 'images', 'status', 'workflowId'].sort()
+    );
+    expect(JSON.stringify(projected)).not.toContain('secret prompt');
+    expect(JSON.stringify(projected)).not.toContain('transactions');
+  });
+
+  it('ignores non-image-producing step types (no image leak from e.g. chatCompletion)', () => {
+    const wf = fakeWorkflow({
+      steps: [
+        {
+          $type: 'chatCompletion',
+          name: 's1',
+          status: 'succeeded',
+          metadata: {},
+          output: { images: [{ id: 'x', url: 'https://leak/', available: true }] },
+        },
+      ],
+    });
+    expect(projectAppWorkflow(wf as never).images).toEqual([]);
   });
 });
 

--- a/src/server/services/blocks/block-workflows.service.ts
+++ b/src/server/services/blocks/block-workflows.service.ts
@@ -159,6 +159,50 @@ function decodeCursor(cursor: string): { submittedAt: string; workflowId: string
 }
 
 /**
+ * SECURITY GATE for `blocks.cancelAppWorkflow`. Returns true iff a queue row
+ * exists for the exact (userId, appBlockId, workflowId) tuple — i.e. THIS viewer
+ * submitted THIS workflow through THIS app block. Both `userId` and `appBlockId`
+ * are bound SERVER-SIDE from the verified block token; `workflowId` is the
+ * (untrusted) client input being authorized.
+ *
+ * WHY this is the ownership proof (not the orchestrator by-id read): the
+ * orchestrator's GET/PATCH/DELETE `/{workflowId}` endpoints do NOT verify
+ * caller-vs-workflow ownership, so fetching/canceling a workflow with the
+ * viewer's orchestrator token is NOT by itself an ownership gate — a guessed id
+ * belonging to another user could be actioned. `block_workflows` is the ONLY
+ * durable USER-bound record of a block generation, so a matching row is the
+ * authoritative "this user owns this workflow, via this app" assertion. The
+ * caller ADDITIONALLY re-reads the workflow and asserts its `app-block:<appId>`
+ * tag as defense-in-depth (the orchestrator's own record must agree it's this
+ * app's), but THIS check is the load-bearing user binding.
+ *
+ * FAIL-CLOSED: the submit-time upsert is best-effort (fire-and-forget), so a lost
+ * write means a legitimate cancel is rejected rather than an illegitimate one
+ * allowed — the correct trade-off for a security guard. Any DB error → false
+ * (reject), never a throw that could be mistaken for "allowed".
+ */
+export async function blockWorkflowOwnedByAppUser(input: {
+  userId: number;
+  appBlockId: string;
+  workflowId: string;
+}): Promise<boolean> {
+  const { userId, appBlockId, workflowId } = input;
+  try {
+    const rows = await dbRead.$queryRaw<Array<{ one: number }>>`
+      SELECT 1 AS "one"
+      FROM "block_workflows"
+      WHERE "workflow_id" = ${workflowId}
+        AND "user_id" = ${userId}
+        AND "app_block_id" = ${appBlockId}
+      LIMIT 1
+    `;
+    return rows.length > 0;
+  } catch {
+    return false; // fail-closed
+  }
+}
+
+/**
  * Read the CALLER's OWN recent workflows for ONE app block, newest first,
  * keyset-paginated. Both `userId` and `appBlockId` are bound SERVER-SIDE from
  * the verified block token, so a block can only ever read the queue of the exact

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -2,7 +2,7 @@ import { TRPCError } from '@trpc/server';
 import type { Workflow, WorkflowStatus } from '@civitai/client';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { dbRead } from '~/server/db/client';
-import { orchestratorNsfwLevelMap } from '~/shared/constants/browsingLevel.constants';
+import { nsfwLevelFromContentRating } from '~/shared/constants/browsingLevel.constants';
 import { getBaseModelSetType } from '~/shared/constants/generation.constants';
 import { getEcosystem } from '~/shared/constants/basemodel.constants';
 import { isWorkflowAvailable } from '~/shared/data-graph/generation/config/workflows';
@@ -150,9 +150,15 @@ export function projectAppWorkflow(workflow: Workflow): AppWorkflow {
         url: img.url,
         width: typeof img.width === 'number' ? img.width : null,
         height: typeof img.height === 'number' ? img.height : null,
-        // Map the orchestrator's string rating ('pg'|'pg13'|'r'|'x'|'xxx') to the
-        // numeric civitai browsing-level bitflag. 'na'/unset/unknown → null.
-        nsfwLevel: img.nsfwLevel ? orchestratorNsfwLevelMap[img.nsfwLevel] ?? null : null,
+        // Map the orchestrator's string rating to the numeric civitai browsing-
+        // level bitflag via the CANONICAL helper (handles the SFW 'g' the raw map
+        // lacks + all of pg/pg13/r/x/xxx, fail-closed to PG for an unexpected
+        // string — so it can't drift from the platform mapping). null ONLY for the
+        // genuinely-unrated sentinel ('na') / unset.
+        nsfwLevel:
+          img.nsfwLevel && img.nsfwLevel !== 'na'
+            ? nsfwLevelFromContentRating(img.nsfwLevel)
+            : null,
       });
     }
   }

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -2,6 +2,7 @@ import { TRPCError } from '@trpc/server';
 import type { Workflow, WorkflowStatus } from '@civitai/client';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { dbRead } from '~/server/db/client';
+import { orchestratorNsfwLevelMap } from '~/shared/constants/browsingLevel.constants';
 import { getBaseModelSetType } from '~/shared/constants/generation.constants';
 import { getEcosystem } from '~/shared/constants/basemodel.constants';
 import { isWorkflowAvailable } from '~/shared/data-graph/generation/config/workflows';
@@ -68,6 +69,102 @@ export function snapshotFromWorkflow(workflow: Workflow): BlockWorkflowSnapshot 
     // optional — omitted when there's no debit to report so every existing
     // snapshot stays byte-identical to before.
     ...(spentAccountType ? { spentAccountType } : {}),
+  };
+}
+
+/**
+ * The per-APP "subqueue" tag. Every app-submitted workflow is server-stamped
+ * with this tag at submit (`buildWorkflowTags` in blocks.router), so a POSITIVE
+ * `tags:['app-block:<appId>']` filter on the orchestrator LIST returns exactly
+ * the calling app's own generations — never the user's personal queue.
+ *
+ * SINGLE SOURCE OF TRUTH: the submit-time STAMP and the read-time FILTER both
+ * call this, so the tag format can never silently desync (a mismatch would make
+ * the subqueue read return an empty list forever, or — worse if the read hard-
+ * coded a looser prefix — widen it). `appId` is always the OauthClient.id read
+ * from the VERIFIED block token, never client input.
+ */
+export function appBlockTag(appId: string): string {
+  return `app-block:${appId}`;
+}
+
+/**
+ * The clean, wire-stable projection of an orchestrator Workflow the App Blocks
+ * generator SUBQUEUE read (`blocks.queryAppWorkflows`) hands to a block. This is
+ * the CONTRACT the SDK matches — keep it minimal + additive-only. It deliberately
+ * DROPS every internal/sensitive workflow field (steps, params, prompts,
+ * resources, tokens, transactions, metadata, tags) so a block can never read
+ * generation internals of a queue it only owns by tag.
+ *
+ *   images: only blobs that are `available` with a non-null url are surfaced —
+ *           pending/blocked/expired blobs are dropped rather than handing the
+ *           block dead links (mirrors `snapshotFromWorkflow`). `width`/`height`
+ *           are null when the orchestrator hasn't populated them. `nsfwLevel` is
+ *           the numeric civitai browsing-level bitflag (1/2/4/8/16) mapped from
+ *           the orchestrator's string rating; `null` for an unrated ('na') blob.
+ *   cost:   the workflow's realized/estimated buzz total, or null when absent.
+ *   status: the block-contract status (see ORCH_STATUS_MAP) — the orchestrator's
+ *           unassigned/preparing/scheduled all collapse to `pending`.
+ */
+export type AppWorkflowImage = {
+  url: string;
+  width: number | null;
+  height: number | null;
+  nsfwLevel: number | null;
+};
+export type AppWorkflow = {
+  workflowId: string;
+  status: BlockWorkflowSnapshot['status'];
+  images: AppWorkflowImage[];
+  cost: number | null;
+  createdAt: string;
+};
+
+/**
+ * Pure projection Workflow → AppWorkflow. No IO, no throws — safe to map over a
+ * whole page of LIST results. See `AppWorkflow` for the field-by-field contract.
+ */
+export function projectAppWorkflow(workflow: Workflow): AppWorkflow {
+  const status = ORCH_STATUS_MAP[workflow.status] ?? 'pending';
+  const images: AppWorkflowImage[] = [];
+  for (const step of workflow.steps ?? []) {
+    if (step.$type !== 'textToImage' && step.$type !== 'imageGen' && step.$type !== 'comfy') {
+      continue;
+    }
+    const stepOutput = (
+      step as unknown as {
+        output?: {
+          images?: Array<{
+            url?: string | null;
+            available?: boolean;
+            width?: number | null;
+            height?: number | null;
+            nsfwLevel?: string | null;
+          }>;
+        };
+      }
+    ).output;
+    for (const img of stepOutput?.images ?? []) {
+      if (!img.available || typeof img.url !== 'string' || img.url.length === 0) continue;
+      images.push({
+        url: img.url,
+        width: typeof img.width === 'number' ? img.width : null,
+        height: typeof img.height === 'number' ? img.height : null,
+        // Map the orchestrator's string rating ('pg'|'pg13'|'r'|'x'|'xxx') to the
+        // numeric civitai browsing-level bitflag. 'na'/unset/unknown → null.
+        nsfwLevel: img.nsfwLevel ? orchestratorNsfwLevelMap[img.nsfwLevel] ?? null : null,
+      });
+    }
+  }
+  const total = workflow.cost?.total;
+  return {
+    // A real LIST/GET item always carries an id; empty-string only if the
+    // orchestrator ever omits it (never for a persisted workflow).
+    workflowId: workflow.id ?? '',
+    status,
+    images,
+    cost: typeof total === 'number' ? total : null,
+    createdAt: workflow.createdAt,
   };
 }
 


### PR DESCRIPTION
## What

Adds the **host side** of App Blocks generator **subqueue** access: block-token bridges that let an app read + cancel **only its own tag-scoped subqueue** of generation workflows, never the user's personal queue. This is the security-critical, contract-defining half; the SDK bridge follows in a separate PR and will match the wire shape documented below.

The user's personal queue is unchanged (no exclusion) — this is purely additive, per-app, and invisible to end users.

## How it works

### Tag-scoped subqueue — no orchestrator change
Every app-submitted workflow is **already server-stamped** with `app-block` + `app-block:<appId>` at submit (`buildWorkflowTags`). Reading a subqueue is therefore just a **positive** `tags:['app-block:<appId>']` filter on the existing orchestrator LIST — the orchestrator already supports positive tag matching, so **no orchestration-repo change is needed**.

The tag format now lives in a single `appBlockTag(appId)` helper used by **both** the submit-time stamp and the read-time filter, so they can never silently desync.

### `blocks.queryAppWorkflows` — read the app's subqueue (block-token MUTATION)
`verifyBlockToken → require ai:write:budgeted → self-bind userId off claims.sub → App-Blocks enabled + author gate → per-instance rate limit → orchestrator LIST with the viewer's OWN per-user token AND a HOST-FORCED tags:['app-block:<appId>'] filter → project → { workflows, cursor }`.

Two independent, **server-derived** scoping boundaries (never client input):
1. **User scope** — the LIST runs with the viewer's own per-user orchestrator token, so it only ever returns that user's workflows.
2. **App scope (the security boundary)** — the host-forced `app-block:<appId>` tag (appId from the verified token). **The input schema has no `tags` field**, so a block cannot pass/override/widen it — a malicious `tags` in the request is stripped by zod before the handler runs (covered by a test).

MUTATION (not query) so the block JWT never lands in a `?input=…` URL / logs / Referer (the leak doctrine — every block-token proc is a mutation).

### `blocks.cancelAppWorkflow` — cancel one, fail-closed (block-token MUTATION)
The orchestrator's by-id `GET/PATCH/DELETE /{workflowId}` endpoints **do NOT verify caller-vs-workflow ownership**, so canceling with the viewer's token is not by itself a gate. This procedure compensates with a two-part guard **before** the cancel:
- **(a) ownership + attribution** — the `block_workflows` read-model must carry a row for the exact `(userId from token, appBlockId from token, workflowId)` tuple (`blockWorkflowOwnedByAppUser`). This is the durable **user binding** the orchestrator lacks — the load-bearing check. Fail-closed (a lost best-effort write rejects a legit cancel rather than allowing an illegit one).
- **(b) app tag** — the orchestrator's own record for the workflow must carry the `app-block:<appId>` tag (defense-in-depth: both systems must agree it is this app's workflow).

If **either** fails → `FORBIDDEN`, and the orchestrator cancel is **never** called. Only then does it cancel + re-read + return the projected terminal `AppWorkflow`.

### Reused scope
Both procedures reuse the existing **`ai:write:budgeted`** scope the buzz-workflow submit bridge already requires — an app authorized to spend the viewer's Buzz on generation can read/cancel the subqueue of gens it produced (same trust boundary). **No new manifest scope** was added; a separate read scope was considered unnecessary (flagged here rather than built).

## Wire contract for the SDK PR (match this exactly)

### `AppWorkflow` projection
The clean, minimal, additive-only shape handed to a block. It **drops** every internal/sensitive field (steps, params, prompts, resources, tokens, transactions, metadata, tags):

```ts
type AppWorkflow = {
  workflowId: string;
  status: 'pending' | 'processing' | 'succeeded' | 'failed' | 'expired' | 'canceled';
  images: {
    url: string;              // only `available` blobs with a non-null url are surfaced
    width: number | null;     // null when the orchestrator didn't populate it
    height: number | null;    // null when the orchestrator didn't populate it
    nsfwLevel: number | null; // numeric civitai browsing-level bitflag; null for unrated
  }[];
  cost: number | null;        // buzz total if available, else null
  createdAt: string;          // ISO-8601
};
```

- **`queryAppWorkflows` returns** `{ workflows: AppWorkflow[]; cursor: string | null }`.
- **`cancelAppWorkflow` returns** `{ workflow: AppWorkflow }` (the terminal, now-canceled state).

### Status enum
The orchestrator's **actual** workflow status values are `unassigned | preparing | scheduled | processing | succeeded | failed | expired | canceled`. `AppWorkflow.status` uses the established **block-contract normalization** (shared `ORCH_STATUS_MAP`, same vocabulary as the existing `BlockWorkflowSnapshot`): the three not-yet-running states collapse to `pending`.

| orchestrator status | AppWorkflow.status |
|---|---|
| `unassigned` / `preparing` / `scheduled` | `pending` |
| `processing` | `processing` |
| `succeeded` | `succeeded` |
| `failed` | `failed` |
| `expired` | `expired` |
| `canceled` | `canceled` |

### `nsfwLevel` mapping
The orchestrator emits a string rating; the projection maps it to the numeric civitai browsing-level bitflag: `pg→1`, `pg13→2`, `r→4`, `x→8`, `xxx→16`; `na`/unset/unknown → `null`.

### Fields that can be null / omitted
`width`, `height`, `cost`, and `nsfwLevel` are `null` when the source lacks them. `images` is `[]` for a pending workflow (no blobs yet) and drops unavailable/urless/blocked blobs (no dead links).

## Host wiring
PageBlockHost handlers `QUERY_APP_WORKFLOWS → APP_WORKFLOWS_RESULT` and `CANCEL_APP_WORKFLOW → CANCEL_APP_WORKFLOW_RESULT` (host forces the page token; server forces the app tag), plus `hostHandlerParity` registry entries (ahead-of-published SDK, page-only for now). The two new mutation hooks would crash sibling `PageBlockHost*.browser.test.tsx` at render, so each got the two mock stubs.

## Tests
- **`workflow.service.test.ts`** — `projectAppWorkflow` (happy path, nsfwLevel string→bitflag for all ratings, null dims, drop dead/blocked blobs, status map, cost-null, no internal-field leak, non-image steps ignored) + `appBlockTag`.
- **`block-workflows.service.test.ts`** — `blockWorkflowOwnedByAppUser` (owned tuple, not-owned, fail-closed on DB error).
- **`blocks.router.appSubqueue.test.ts`** — queryAppWorkflows forces the tag / a client `tags` can't override it / tag bound from token appId / projection + cursor round-trip / empty list / rate-limit / anon / invalid-token / missing-scope; cancelAppWorkflow happy path (cancel once) / fail-closed on no-ownership-row (cancel not called) / fail-closed on missing app tag / invalid-token / missing-scope / anon.
- **`PageBlockHostWorkflow.browser.test.tsx`** — 8 new bridge tests (forward + reply, host-token-authoritative over block-sent token/tags, error variant, null-token, missing-id drop).

## Note on the orchestrator by-id ownership gap
This PR does not fix the underlying orchestrator gap (by-id GET/PATCH/DELETE don't verify ownership); it compensates on the host side for the app-block cancel path. The existing personal `blocks.cancelWorkflow` / `pollWorkflow` procedures still rely on the token as the gate — worth a follow-up look, but out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
