### PR TITLE
fix(apps): App Blocks mod review — authz + scaling fixes + onsite reset-to-pending

### DIFF
--- a/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
@@ -25,11 +25,17 @@ const {
   mockListEvents,
   mockReport,
   mockListReports,
+  mockResetOnsite,
   mockIsAppBlocksEnabled,
   mockIsAppBlocksAuthorEnabled,
 } = vi.hoisted(() => ({
   mockDelist: vi.fn(async () => ({ appListingId: 'apl_1', status: 'removed' as const })),
   mockRelist: vi.fn(async () => ({ appListingId: 'apl_1', status: 'approved' as const })),
+  mockResetOnsite: vi.fn(async () => ({
+    appListingId: 'apl_1',
+    status: 'pending' as const,
+    publishRequestId: 'pubreq_1',
+  })),
   mockClaim: vi.fn(async () => ({ appListingId: 'apl_1', userId: 42 })),
   mockPurge: vi.fn(async () => ({ appListingId: 'apl_1', purged: true as const })),
   mockResolve: vi.fn(async () => undefined),
@@ -51,6 +57,7 @@ vi.mock('~/server/services/blocks/offsite-moderation.service', () => ({
   resolveReport: mockResolve,
   dismissReport: mockDismiss,
   listModerationEvents: mockListEvents,
+  resetOnsiteListingToPending: mockResetOnsite,
 }));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
@@ -138,6 +145,12 @@ const MOD_ACTIONS: Array<{
     mock: mockListEvents,
     call: (c) => c.listModerationEvents({ appListingId: 'apl_1' }),
   },
+  {
+    // W13 onsite reset-to-pending — DARK backend capability, mod-only router acceptance.
+    name: 'resetOnsiteListingToPending',
+    mock: mockResetOnsite,
+    call: (c) => c.resetOnsiteListingToPending({ appListingId: 'apl_1', reason: REASON }),
+  },
 ];
 
 describe('mod actions — every one is moderator-only', () => {
@@ -177,6 +190,15 @@ describe('mod actions — reviewer id is bound to ctx (never client-supplied)', 
       input: { appListingId: 'apl_1', targetUserId: 42, reason: REASON },
     });
     expect(mockPurge.mock.calls[0][0]).toMatchObject({ reviewerUserId: mod.id });
+  });
+
+  it('resetOnsiteListingToPending passes reviewerUserId = ctx.user.id + the input', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await caller.resetOnsiteListingToPending({ appListingId: 'apl_1', reason: REASON });
+    expect(mockResetOnsite.mock.calls[0][0]).toMatchObject({
+      reviewerUserId: mod.id,
+      input: { appListingId: 'apl_1', reason: REASON },
+    });
   });
 
   it('resolve/dismiss pass reviewerUserId = ctx.user.id', async () => {

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -895,6 +895,34 @@ export const appListingsRouter = router({
     }),
 
   /**
+   * MOD reset an approved ON-SITE (hosted app-block) listing back into the block
+   * review queue (approved → pending) — the W13-deferred onsite reset, now built.
+   * Suspends the backing block (the real runtime stop), clones the latest approved
+   * `AppBlockPublishRequest` into a fresh pending one (assets/version KEPT, NO owner
+   * resubmit) so it re-enters `listPendingRequests`, writes a `reset-to-pending` audit
+   * event, and notifies the owner; a mod re-approves it through the existing block
+   * review flow (which restores the listing + un-suspends the block). DARK backend
+   * capability — no UI wiring yet (the mgmt-table Reset button is a downstream PR).
+   * Same input shape + posture as the offsite reset; typed failures map via
+   * `mapOffsiteError` (NOT_FOUND→NOT_FOUND, NOT_TRANSITIONABLE→BAD_REQUEST).
+   */
+  resetOnsiteListingToPending: moderatorProcedure
+    .input(resetListingToPendingSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Resetting on-site listings is restricted to civitai team');
+      }
+      const { resetOnsiteListingToPending } = await import(
+        '~/server/services/blocks/offsite-moderation.service'
+      );
+      try {
+        return await resetOnsiteListingToPending({ input, reviewerUserId: ctx.user.id });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /**
    * OWNER unpublish their OWN approved off-site listing (approved → removed) — a
    * self-service visibility toggle (no re-review). Owner-bound in the service
    * (NOT_OWNED→FORBIDDEN); NOT_TRANSITIONABLE when not approved. Typed failures map

--- a/src/server/schema/blocks/__tests__/offsite-listing.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/offsite-listing.schema.test.ts
@@ -205,11 +205,20 @@ describe('rejectExternalRequestSchema', () => {
     expect(rejectExternalRequestSchema.safeParse({ publishRequestId: 'alpr_1' }).success).toBe(false);
   });
 
-  it('rejects an over-long reason (>2000)', () => {
+  it('accepts a reason at the unified mod-reason ceiling (OFFSITE_MOD_REASON_MAX=1000)', () => {
     expect(
       rejectExternalRequestSchema.safeParse({
         publishRequestId: 'alpr_1',
-        rejectionReason: 'x'.repeat(2001),
+        rejectionReason: 'x'.repeat(1000),
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects an over-long reason (>1000, the unified mod-reason ceiling)', () => {
+    expect(
+      rejectExternalRequestSchema.safeParse({
+        publishRequestId: 'alpr_1',
+        rejectionReason: 'x'.repeat(1001),
       }).success
     ).toBe(false);
   });

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -6,7 +6,10 @@ import {
   validateExternalUrl,
 } from '~/server/schema/blocks/external-app.schema';
 import { SLUG_REGEX } from '~/server/schema/blocks/publish-request.schema';
-import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
+import {
+  OFFSITE_MOD_REASON_MAX,
+  OFFSITE_MOD_REASON_MIN,
+} from '~/server/schema/blocks/offsite-moderation.schema';
 import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
 
 /**
@@ -48,7 +51,14 @@ export const OFFSITE_APPROVAL_NOTES_MAX = 2000;
 // so the reject field matches every other mod-reason field on /apps/review and
 // the client gate + server schema agree — no divergent magic `10`.
 export const OFFSITE_REJECTION_REASON_MIN = OFFSITE_MOD_REASON_MIN;
-export const OFFSITE_REJECTION_REASON_MAX = 2000;
+// Unified with the shared mod-reason CEILING (`OFFSITE_MOD_REASON_MAX`, 1000).
+// A reject of a reset-to-pending listing writes a `delist` moderation event
+// carrying THIS rejectionReason (offsite-listing.service `rejectExternalRequest` →
+// `closeTerminalListing`), so its ceiling must not exceed what a direct mod action
+// (`delistListing`, bounded by `OFFSITE_MOD_REASON_MAX`) allows — otherwise a
+// rejected-reset could persist a longer reason than the schema permits on the same
+// audit surface. (Was 2000; tightened to 1000 for parity.)
+export const OFFSITE_REJECTION_REASON_MAX = OFFSITE_MOD_REASON_MAX;
 
 /**
  * Author submit input for a pure external-link off-site listing.

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -68,7 +68,11 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
     // W13 owner controls: the batched last-moderation-event lookup (removed listings).
     appListingModerationEvent: {
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
     },
+    // Fix B4: listMySubmissions' last-event batch is now a raw `DISTINCT ON` query.
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
   });
   const mockRead = makeClient();
   const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
@@ -103,6 +107,11 @@ function resetAll() {
     client.appListing.update.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
     client.appListing.updateMany.mockReset().mockResolvedValue({ count: 1 });
     client.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
+    client.appListingModerationEvent.findFirst.mockReset().mockResolvedValue(null);
+    client.appListingModerationEvent.create
+      .mockReset()
+      .mockImplementation(async (a: { data: unknown }) => a.data);
+    client.$queryRaw.mockReset().mockResolvedValue([]);
     client.appListingScreenshot.count.mockReset().mockResolvedValue(0);
     client.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
     client.appListingScreenshot.createMany.mockReset().mockResolvedValue({ count: 0 });
@@ -875,21 +884,15 @@ describe('listMySubmissions (lastModerationAction for removed listings)', () => 
     mockRead.appListingPublishRequest.findMany
       .mockResolvedValueOnce([removedRequestRow])
       .mockResolvedValueOnce([]); // no pending revision
-    mockRead.appListingModerationEvent.findMany.mockResolvedValueOnce([
+    // Fix B4: the last-event batch is a raw `DISTINCT ON` query — one row per listing.
+    mockRead.$queryRaw.mockResolvedValueOnce([
       { appListingId: 'apl_removed', action: 'owner-unpublish' },
     ]);
 
     const res = await listMySubmissions({ userId: OWNER });
 
-    // The last-event query is scoped to the removed listing id, newest-first, distinct.
-    const eventArgs = mockRead.appListingModerationEvent.findMany.mock.calls[0][0] as Record<
-      string,
-      unknown
-    >;
-    expect(eventArgs).toMatchObject({
-      where: { appListingId: { in: ['apl_removed'] } },
-      distinct: ['appListingId'],
-    });
+    // The raw last-event query is issued exactly once for the removed listing set.
+    expect(mockRead.$queryRaw).toHaveBeenCalledTimes(1);
     expect(res.items[0]).toMatchObject({ lastModerationAction: 'owner-unpublish' });
   });
 
@@ -897,9 +900,7 @@ describe('listMySubmissions (lastModerationAction for removed listings)', () => 
     mockRead.appListingPublishRequest.findMany
       .mockResolvedValueOnce([removedRequestRow])
       .mockResolvedValueOnce([]);
-    mockRead.appListingModerationEvent.findMany.mockResolvedValueOnce([
-      { appListingId: 'apl_removed', action: 'delist' },
-    ]);
+    mockRead.$queryRaw.mockResolvedValueOnce([{ appListingId: 'apl_removed', action: 'delist' }]);
     const res = await listMySubmissions({ userId: OWNER });
     expect(res.items[0]).toMatchObject({ lastModerationAction: 'delist' });
   });
@@ -909,7 +910,7 @@ describe('listMySubmissions (lastModerationAction for removed listings)', () => 
       .mockResolvedValueOnce([liveRequestRow])
       .mockResolvedValueOnce([]);
     const res = await listMySubmissions({ userId: OWNER });
-    expect(mockRead.appListingModerationEvent.findMany).not.toHaveBeenCalled();
+    expect(mockRead.$queryRaw).not.toHaveBeenCalled();
     expect(res.items[0]).toMatchObject({ lastModerationAction: null });
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -350,7 +350,7 @@ describe('withdrawExternalRequest', () => {
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
   });
 
-  it('🔴 Fix #1: MOD-MANDATED reset (last event reset-to-pending) withdraw → REMOVED + a DELIST event (owner canNOT republish)', async () => {
+  it('🔴 Fix #1: a formerly-live PENDING (reset) withdraw → REMOVED + a DELIST event (owner canNOT republish)', async () => {
     mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'pending',
@@ -358,10 +358,9 @@ describe('withdrawExternalRequest', () => {
       appListingId: 'apl_1',
     });
     // The in-tx close reads status → `pending` = a reset-to-pending, formerly-live listing.
+    // A formerly-live pending listing is ALWAYS mod-mandated → the close writes `delist`
+    // UNCONDITIONALLY (no most-recent-event probe).
     mockWrite.appListing.findUnique.mockResolvedValue({ status: 'pending', slug: 'cool-app' });
-    // The listing's most-recent moderation event is a mod `reset-to-pending` — so this
-    // pending cycle was MOD-MANDATED and the owner must not be able to defeat it.
-    mockWrite.appListingModerationEvent.findFirst.mockResolvedValue({ action: 'reset-to-pending' });
     await withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER });
 
     // NOT deleted — transitioned to `removed`.
@@ -381,7 +380,13 @@ describe('withdrawExternalRequest', () => {
     });
   });
 
-  it('Fix #1 fallback: a PENDING listing whose latest event is NOT reset-to-pending keeps owner-unpublish (owner-republishable)', async () => {
+  it('🔴 Fix #1 regression: an intervening report-resolve event does NOT downgrade the close to owner-unpublish (still DELIST)', async () => {
+    // The exploit closed: mod resets (report-driven) → mod resolves the triggering
+    // report → the listing's NEWEST moderation event is now `report-resolve`, NOT
+    // `reset-to-pending`. A most-recent-event probe would have fallen through to
+    // `owner-unpublish` here (letting the owner republish the pre-reset content). The
+    // DETERMINISTIC rule ignores event history: a formerly-live `pending` listing is
+    // ALWAYS mod-mandated → the withdraw close STILL writes `delist`.
     mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'pending',
@@ -389,19 +394,16 @@ describe('withdrawExternalRequest', () => {
       appListingId: 'apl_1',
     });
     mockWrite.appListing.findUnique.mockResolvedValue({ status: 'pending', slug: 'cool-app' });
-    // No reset-to-pending as the latest event (default findFirst → null) → the pending
-    // close was NOT mod-mandated, so the owner-initiated `owner-unpublish` is preserved.
-    mockWrite.appListingModerationEvent.findFirst.mockResolvedValue(null);
+    // Even with the newest event being a report closure (would defeat a probe):
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValue({ action: 'report-resolve' });
     await withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER });
 
-    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
-      where: { id: 'apl_1', status: 'pending' },
-      data: { status: 'removed' },
-    });
     expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
     expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
-      action: 'owner-unpublish',
+      action: 'delist',
       actorUserId: CALLER,
+      before: { status: 'pending' },
+      after: { status: 'removed' },
     });
   });
 

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -52,7 +52,12 @@ type Client = {
     updateMany: ReturnType<typeof vi.fn>;
   };
   // reject/withdraw close a reset-to-pending listing by writing a moderation event.
-  appListingModerationEvent: { create: ReturnType<typeof vi.fn> };
+  // `findFirst` (Fix #1): the withdraw close reads the listing's latest mod event to
+  // decide owner-unpublish vs delist (a mod-mandated reset withdraw becomes a delist).
+  appListingModerationEvent: {
+    create: ReturnType<typeof vi.fn>;
+    findFirst: ReturnType<typeof vi.fn>;
+  };
 };
 
 // `persistListingAssetImage` dynamically imports `createImage` from the image
@@ -88,6 +93,7 @@ const { mockRead, mockWrite, ids } = vi.hoisted(() => {
     },
     appListingModerationEvent: {
       create: vi.fn(async (args: { data: unknown }) => args.data),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
     },
   });
   const mockRead = makeClient();
@@ -142,6 +148,7 @@ function resetClient(c: Client) {
   c.appListingModerationEvent.create
     .mockReset()
     .mockImplementation(async (a: { data: unknown }) => a.data);
+  c.appListingModerationEvent.findFirst.mockReset().mockResolvedValue(null);
 }
 
 beforeEach(() => {
@@ -343,7 +350,7 @@ describe('withdrawExternalRequest', () => {
     expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
   });
 
-  it('🔴 reset-originated (PENDING, formerly-live) withdraw → listing set REMOVED + an OWNER-UNPUBLISH mod event (owner may later republish)', async () => {
+  it('🔴 Fix #1: MOD-MANDATED reset (last event reset-to-pending) withdraw → REMOVED + a DELIST event (owner canNOT republish)', async () => {
     mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
       id: 'alpr_1',
       status: 'pending',
@@ -352,6 +359,9 @@ describe('withdrawExternalRequest', () => {
     });
     // The in-tx close reads status → `pending` = a reset-to-pending, formerly-live listing.
     mockWrite.appListing.findUnique.mockResolvedValue({ status: 'pending', slug: 'cool-app' });
+    // The listing's most-recent moderation event is a mod `reset-to-pending` — so this
+    // pending cycle was MOD-MANDATED and the owner must not be able to defeat it.
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValue({ action: 'reset-to-pending' });
     await withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER });
 
     // NOT deleted — transitioned to `removed`.
@@ -360,14 +370,38 @@ describe('withdrawExternalRequest', () => {
       where: { id: 'apl_1', status: 'pending' },
       data: { status: 'removed' },
     });
-    // An `owner-unpublish` event (the OWNER withdrew their OWN re-review) → the owner
-    // CAN later republishOwnListing (last event actor is the owner, not a moderator).
+    // 🔴 A `delist` event (NOT owner-unpublish): the last event is now a takedown, so
+    // `republishOwnListing`'s guard FORBIDS the owner — a mod must relist.
+    expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
+      action: 'delist',
+      actorUserId: CALLER,
+      before: { status: 'pending' },
+      after: { status: 'removed' },
+    });
+  });
+
+  it('Fix #1 fallback: a PENDING listing whose latest event is NOT reset-to-pending keeps owner-unpublish (owner-republishable)', async () => {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_1',
+      status: 'pending',
+      submittedByUserId: CALLER,
+      appListingId: 'apl_1',
+    });
+    mockWrite.appListing.findUnique.mockResolvedValue({ status: 'pending', slug: 'cool-app' });
+    // No reset-to-pending as the latest event (default findFirst → null) → the pending
+    // close was NOT mod-mandated, so the owner-initiated `owner-unpublish` is preserved.
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValue(null);
+    await withdrawExternalRequest({ publishRequestId: 'alpr_1', userId: CALLER });
+
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apl_1', status: 'pending' },
+      data: { status: 'removed' },
+    });
     expect(mockWrite.appListingModerationEvent.create).toHaveBeenCalledTimes(1);
     expect(mockWrite.appListingModerationEvent.create.mock.calls[0][0].data).toMatchObject({
       action: 'owner-unpublish',
       actorUserId: CALLER,
-      before: { status: 'pending' },
-      after: { status: 'removed' },
     });
   });
 
@@ -575,6 +609,28 @@ describe('approveExternalRequest', () => {
     );
   });
 
+  it('🟡 Fix #2: supersede is scoped by appListingId (NOT slug) so a concurrent REVISION survives an approve-of-reset', async () => {
+    // Approving a reset request for the PARENT listing (apl_1) must not sweep the
+    // owner's in-flight REVISION request — a revision denormalizes the PARENT slug but
+    // targets a DISTINCT shadow (a different appListingId). Scoping the supersede by
+    // appListingId leaves the revision (different id) pending.
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1, status: 'pending' });
+    await approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD });
+
+    // updateMany call[0] = the guarded request flip; call[1] = the supersede.
+    const supersede = mockWrite.appListingPublishRequest.updateMany.mock.calls[1][0] as {
+      where: Record<string, unknown>;
+    };
+    expect(supersede.where).toMatchObject({
+      appListingId: 'apl_1',
+      status: 'pending',
+      kind: 'offsite',
+      NOT: { id: 'alpr_1' },
+    });
+    // 🔴 It must NOT scope by slug (which would sweep the same-slug revision request).
+    expect(supersede.where).not.toHaveProperty('slug');
+  });
+
   it('the AUTHORITATIVE asset gate reads the PRIMARY (tx), not the replica', async () => {
     stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
     await approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD });
@@ -623,20 +679,23 @@ describe('approveExternalRequest', () => {
     expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
   });
 
-  it('supersedes any SIBLING pending request for the same slug (parity with on-site)', async () => {
+  it('supersedes any SIBLING pending request for the SAME LISTING (appListingId-scoped, Fix #2)', async () => {
     stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
     await approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD });
-    // The 2nd request updateMany is the supersede: same slug, pending, NOT this row.
+    // The 2nd request updateMany is the supersede: same LISTING (appListingId), pending,
+    // NOT this row. Scoped by appListingId (not slug) so a same-slug REVISION request
+    // (different appListingId / shadow) is left pending — see the dedicated Fix #2 test.
     const supersede = mockWrite.appListingPublishRequest.updateMany.mock.calls[1][0] as {
       where: Record<string, unknown>;
       data: Record<string, unknown>;
     };
     expect(supersede.where).toMatchObject({
-      slug: 'cool-app',
+      appListingId: 'apl_1',
       status: 'pending',
       kind: 'offsite',
       NOT: { id: 'alpr_1' },
     });
+    expect(supersede.where).not.toHaveProperty('slug');
     expect(supersede.data).toEqual({ status: 'withdrawn' });
   });
 

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.onsite-reset.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.onsite-reset.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  OffsiteModerationError,
+  resetOnsiteListingToPending,
+} from '~/server/services/blocks/offsite-moderation.service';
+
+/**
+ * W13 ONSITE reset-to-pending — service tests (the deferred onsite reset, now built).
+ *
+ * `resetOnsiteListingToPending` bounces an APPROVED on-site (hosted app-block) listing
+ * back into the block review queue: in ONE tx it flips the listing approved → pending,
+ * SUSPENDS the backing block (the real runtime stop), CLONES the latest approved
+ * `AppBlockPublishRequest` into a fresh `pending` one (assets/version KEPT — no owner
+ * resubmit) so it re-enters `listPendingRequests`, and writes a `reset-to-pending`
+ * audit event; post-commit it notifies the owner. All DB deps are mocked (no real
+ * Prisma); `dbWrite.$transaction` runs its callback against the same write mock.
+ */
+
+type WriteMock = {
+  $transaction: ReturnType<typeof vi.fn>;
+  appListing: { updateMany: ReturnType<typeof vi.fn> };
+  appBlock: { updateMany: ReturnType<typeof vi.fn> };
+  appBlockPublishRequest: { create: ReturnType<typeof vi.fn> };
+  appListingModerationEvent: { create: ReturnType<typeof vi.fn> };
+};
+type ReadMock = {
+  appListing: { findUnique: ReturnType<typeof vi.fn> };
+  appBlockPublishRequest: { findFirst: ReturnType<typeof vi.fn> };
+};
+
+const { mockRead, mockWrite, mockNotify, ids } = vi.hoisted(() => {
+  const write: WriteMock = {
+    $transaction: vi.fn(),
+    appListing: { updateMany: vi.fn(async () => ({ count: 1 })) },
+    appBlock: { updateMany: vi.fn(async () => ({ count: 1 })) },
+    appBlockPublishRequest: { create: vi.fn(async (a: { data: unknown }) => a.data) },
+    appListingModerationEvent: { create: vi.fn(async (a: { data: unknown }) => a.data) },
+  };
+  write.$transaction.mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) => cb(write));
+  const read: ReadMock = {
+    appListing: { findUnique: vi.fn(async () => null) },
+    appBlockPublishRequest: { findFirst: vi.fn(async () => null) },
+  };
+  return {
+    mockRead: read,
+    mockWrite: write,
+    mockNotify: vi.fn(async () => undefined),
+    ids: { n: 0 },
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/services/blocks/app-listing-notify', () => ({ notifyAppListingOwner: mockNotify }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingModerationEventId: () => `alme_test_${++ids.n}`,
+  newAppListingPublishRequestId: () => `alpr_test_${++ids.n}`,
+  newAppListingReportId: () => `alr_test_${++ids.n}`,
+  newUlid: () => `ULIDTEST${++ids.n}`,
+}));
+
+const MOD = 7;
+const OWNER = 42;
+
+/** The approved onsite listing being reset. */
+const onsiteListing = {
+  id: 'apl_1',
+  kind: 'onsite',
+  status: 'approved',
+  slug: 'my-app',
+  name: 'My App',
+  userId: OWNER,
+  appBlockId: 'apb_1',
+};
+
+/** The latest approved block publish request cloned into the fresh pending one. */
+const lastApprovedReq = {
+  appBlockId: 'apb_1',
+  version: '1.2.0',
+  manifest: { blockId: 'my-app', scopes: [] },
+  bundleKey: 'bundles/deadbeef.zip',
+  bundleSha256: 'deadbeef',
+  bundleSizeBytes: BigInt(1024),
+  fileSummary: { files: [], added: [], removed: [], changed: [] },
+  manifestDiffSummary: { kind: 'update' },
+  forgejoCommitSha: 'sha_abc',
+};
+
+beforeEach(() => {
+  ids.n = 0;
+  mockRead.appListing.findUnique.mockReset().mockResolvedValue(onsiteListing);
+  mockRead.appBlockPublishRequest.findFirst.mockReset();
+  // Default: (1) latest-approved lookup returns a clonable request, (2) open-pending
+  // lookup returns none.
+  mockRead.appBlockPublishRequest.findFirst
+    .mockResolvedValueOnce(lastApprovedReq)
+    .mockResolvedValueOnce(null);
+  mockWrite.$transaction
+    .mockReset()
+    .mockImplementation(async (cb: (tx: WriteMock) => Promise<unknown>) => cb(mockWrite));
+  mockWrite.appListing.updateMany.mockReset().mockResolvedValue({ count: 1 });
+  mockWrite.appBlock.updateMany.mockReset().mockResolvedValue({ count: 1 });
+  mockWrite.appBlockPublishRequest.create
+    .mockReset()
+    .mockImplementation(async (a: { data: unknown }) => a.data);
+  mockWrite.appListingModerationEvent.create
+    .mockReset()
+    .mockImplementation(async (a: { data: unknown }) => a.data);
+  mockNotify.mockReset().mockResolvedValue(undefined);
+});
+
+describe('resetOnsiteListingToPending', () => {
+  it('happy path: flips listing→pending, SUSPENDS the block, clones a fresh pending request, writes reset-to-pending, notifies', async () => {
+    const res = await resetOnsiteListingToPending({
+      input: { appListingId: 'apl_1', reason: 'needs another look' },
+      reviewerUserId: MOD,
+    });
+
+    // (1) listing approved → pending, onsite + status-guarded.
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apl_1', kind: 'onsite', status: 'approved' },
+      data: { status: 'pending' },
+    });
+    // (2) backing block approved → suspended (the real runtime stop).
+    expect(mockWrite.appBlock.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apb_1', status: 'approved' },
+      data: { status: 'suspended' },
+    });
+    // (3) fresh pending block publish request cloned from the last approved (owner-owned).
+    const reqArg = mockWrite.appBlockPublishRequest.create.mock.calls[0][0].data;
+    expect(reqArg).toMatchObject({
+      slug: 'my-app',
+      status: 'pending',
+      submittedByUserId: OWNER,
+      version: '1.2.0',
+      bundleKey: 'bundles/deadbeef.zip',
+      bundleSha256: 'deadbeef',
+      forgejoCommitSha: 'sha_abc',
+      appBlockId: 'apb_1',
+    });
+    expect(reqArg.id).toMatch(/^pubreq_/);
+    expect(typeof reqArg.bundleSizeBytes).toBe('bigint');
+    // (4) reset-to-pending audit event (acting mod).
+    const evtArg = mockWrite.appListingModerationEvent.create.mock.calls[0][0].data;
+    expect(evtArg).toMatchObject({
+      appListingId: 'apl_1',
+      action: 'reset-to-pending',
+      actorUserId: MOD,
+      before: { status: 'approved' },
+      after: { status: 'pending' },
+    });
+    // Owner notified post-commit.
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'app-listing-reset-to-pending', userId: OWNER })
+    );
+    expect(res).toMatchObject({ appListingId: 'apl_1', status: 'pending' });
+    expect(res.publishRequestId).toMatch(/^pubreq_/);
+  });
+
+  it('NOT_FOUND for a missing listing', async () => {
+    mockRead.appListing.findUnique.mockReset().mockResolvedValue(null);
+    await expect(
+      resetOnsiteListingToPending({
+        input: { appListingId: 'nope', reason: 'reason here' },
+        reviewerUserId: MOD,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('NOT_FOUND for an OFF-SITE listing (kind guard — no onsite dual-table flip)', async () => {
+    mockRead.appListing.findUnique
+      .mockReset()
+      .mockResolvedValue({ ...onsiteListing, kind: 'offsite', appBlockId: null });
+    await expect(
+      resetOnsiteListingToPending({
+        input: { appListingId: 'apl_1', reason: 'reason here' },
+        reviewerUserId: MOD,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  it('NOT_TRANSITIONABLE when the app has no approved version to re-review', async () => {
+    mockRead.appBlockPublishRequest.findFirst.mockReset().mockResolvedValue(null);
+    await expect(
+      resetOnsiteListingToPending({
+        input: { appListingId: 'apl_1', reason: 'reason here' },
+        reviewerUserId: MOD,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('NOT_TRANSITIONABLE when a review is already pending for the slug', async () => {
+    mockRead.appBlockPublishRequest.findFirst
+      .mockReset()
+      .mockResolvedValueOnce(lastApprovedReq) // latest approved
+      .mockResolvedValueOnce({ id: 'pubreq_open' }); // an open pending request exists
+    await expect(
+      resetOnsiteListingToPending({
+        input: { appListingId: 'apl_1', reason: 'reason here' },
+        reviewerUserId: MOD,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('NOT_TRANSITIONABLE when the guarded listing flip matches 0 rows (raced out of approved)', async () => {
+    mockWrite.appListing.updateMany.mockReset().mockResolvedValue({ count: 0 });
+    await expect(
+      resetOnsiteListingToPending({
+        input: { appListingId: 'apl_1', reason: 'reason here' },
+        reviewerUserId: MOD,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+    // The tx rolled back before any event/clone was written.
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('maps a P2002 one-pending-per-slug race on the clone to NOT_TRANSITIONABLE', async () => {
+    mockWrite.appBlockPublishRequest.create
+      .mockReset()
+      .mockRejectedValue(Object.assign(new Error('unique'), { code: 'P2002' }));
+    await expect(
+      resetOnsiteListingToPending({
+        input: { appListingId: 'apl_1', reason: 'reason here' },
+        reviewerUserId: MOD,
+      })
+    ).rejects.toMatchObject({ code: 'NOT_TRANSITIONABLE' });
+  });
+
+  it('rejects a too-short reason (BAD_REQUEST, before any read/write)', async () => {
+    await expect(
+      resetOnsiteListingToPending({
+        input: { appListingId: 'apl_1', reason: 'x' },
+        reviewerUserId: MOD,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('is an OffsiteModerationError instance (duck-typed by mapOffsiteError)', async () => {
+    mockRead.appListing.findUnique.mockReset().mockResolvedValue(null);
+    await resetOnsiteListingToPending({
+      input: { appListingId: 'nope', reason: 'reason here' },
+      reviewerUserId: MOD,
+    }).catch((err) => {
+      expect(err).toBeInstanceOf(OffsiteModerationError);
+    });
+  });
+});

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -724,7 +724,7 @@ describe('withdrawRequest', () => {
     expect(mockDbWrite.appBlockPublishRequest.update).not.toHaveBeenCalled();
   });
 
-  it('🔴 Fix #1 (onsite): withdrawing a MOD-MANDATED reset closes the listing REMOVED + a DELIST event (owner canNOT republish)', async () => {
+  it('🔴 Fix #1 (onsite): withdrawing a reset (pending onsite listing) closes it REMOVED + a DELIST event (owner canNOT republish)', async () => {
     const { withdrawRequest } = await import('../publish-request.service');
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
       id: 'pubreq_reset',
@@ -737,10 +737,10 @@ describe('withdrawRequest', () => {
     mockDbWrite.$transaction.mockImplementation(
       async (cb: (tx: unknown) => Promise<unknown>) => cb(mockDbWrite)
     );
-    // The reset target: an onsite listing for this slug is currently `pending` and its
-    // most-recent moderation event is a mod `reset-to-pending` (mod-mandated cycle).
+    // The reset target: an onsite listing for this slug is currently `pending`. A pending
+    // onsite listing is ALWAYS a mod reset (deterministic — NO most-recent-event probe,
+    // which an intervening report event could defeat), so the close writes `delist`.
     mockDbRead.appListing.findFirst.mockResolvedValue({ id: 'apl_1', slug: 'my-app' });
-    mockDbRead.appListingModerationEvent.findFirst.mockResolvedValue({ action: 'reset-to-pending' });
     mockDbWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
 
     await withdrawRequest({ publishRequestId: 'pubreq_reset', userId: 42 });
@@ -1347,25 +1347,64 @@ describe('approveRequest', () => {
     expect((abArg.manifest as any).iframe.src).toBe('https://hello.civit.ai/');
   });
 
-  it('W13 onsite reset re-approve: restores a reset (`pending`) listing back to approved (status-guarded)', async () => {
+  it('🔴 W13 onsite reset re-approve (SUBSEQUENT-version): restores the listing AND UN-SUSPENDS the block', async () => {
+    // The real reset scenario: the block ALREADY exists (isFirstVersion=false), so the
+    // approve takes the subsequent-version `appBlock.update` branch — which refreshes
+    // manifest/version but does NOT set status. `resetOnsiteListingToPending` left the
+    // block `suspended`, so the re-approve must un-suspend it explicitly, else the app
+    // is store-visible (listing approved) but dead (block suspended, run page 404s).
     const { approveRequest } = await import('../publish-request.service');
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(pendingRequest());
-    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
-    mockBundleBuffer.current = await makeValidBundle();
-    // Simulate a reset listing being restored (one row flipped pending → approved).
+    mockDbRead.appBlock.findFirst.mockResolvedValue({
+      id: 'apb_existing',
+      appId: 'oc_existing',
+      repoUrl: 'https://forgejo.example/civitai-apps/hello',
+      app: { allowedScopes: 33554431, allowedOrigins: ['https://hello.civit.ai'] },
+    });
+    mockBundleBuffer.current = await makeValidBundle({ version: '0.2.0' });
+    // The reset listing flip matches one row (listing WAS pending) → reset re-approve.
     mockDbWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
 
-    await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+    const result = await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+    expect(result.isFirstVersion).toBe(false);
 
-    // The approve widen restores a reset onsite listing back to approved — guarded to
-    // `pending` so a normal approve (listing already approved / none) is a 0-row no-op
-    // and it never touches category/featured (only `status`).
+    // (a) listing restored pending → approved (guarded to `pending`; status-only).
     expect(mockDbWrite.appListing.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: expect.objectContaining({ kind: 'onsite', status: 'pending' }),
+        where: expect.objectContaining({ appBlockId: 'apb_existing', kind: 'onsite', status: 'pending' }),
         data: { status: 'approved' },
       })
     );
+    // 🔴 (b) block un-suspended suspended → approved (guarded to `suspended`) — the fix
+    // for the "store-visible but dead" bug. Gated on the listing flip having matched.
+    expect(mockDbWrite.appBlock.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apb_existing', status: 'suspended' },
+      data: { status: 'approved' },
+    });
+  });
+
+  it('normal subsequent-version approve (listing NOT pending) does NOT un-suspend the block', async () => {
+    // Guard the gate: when the listing flip matches 0 rows (a normal approve of an
+    // already-approved app, NOT a reset), the block un-suspend must NOT fire — so a
+    // delisted-then-resubmitted app is never auto-un-suspended here.
+    const { approveRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(pendingRequest());
+    mockDbRead.appBlock.findFirst.mockResolvedValue({
+      id: 'apb_existing',
+      appId: 'oc_existing',
+      repoUrl: 'https://forgejo.example/civitai-apps/hello',
+      app: { allowedScopes: 33554431, allowedOrigins: ['https://hello.civit.ai'] },
+    });
+    mockBundleBuffer.current = await makeValidBundle({ version: '0.2.0' });
+    // Listing flip matches 0 rows (not a reset) → the block un-suspend is skipped.
+    mockDbWrite.appListing.updateMany.mockResolvedValue({ count: 0 });
+
+    await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+    const unsuspend = mockDbWrite.appBlock.updateMany.mock.calls.find(
+      (c: any[]) => c[0]?.data?.status === 'approved' && c[0]?.where?.status === 'suspended'
+    );
+    expect(unsuspend).toBeUndefined();
   });
 
   // PUSH-ORIGINATED approve (Phase 3 git-push authoring). The git-push webhook

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -61,7 +61,10 @@ const {
       oauthClient: { findUnique: vi.fn() },
       // W13 auto-create-on-approve: approveRequest checks for an existing onsite
       // AppListing (idempotency, keyed on appBlockId) before creating one.
-      appListing: { findUnique: vi.fn() },
+      appListing: { findUnique: vi.fn(), findFirst: vi.fn(async () => null) },
+      // Fix #1 (onsite): withdrawRequest probes the listing's latest mod event to
+      // decide whether a reset withdraw closes the listing. Null → no reset in flight.
+      appListingModerationEvent: { findFirst: vi.fn(async () => null) },
     },
     mockDbWrite: {
       // `updateMany` added (no-trust-on-push fix): approveRequest now supersedes
@@ -101,7 +104,14 @@ const {
       // W13 auto-create-on-approve: approveRequest mints the onsite AppListing
       // (idempotent skip-if-exists, P2002-tolerant) right after the AppBlock row
       // exists so the app appears on the /apps grid without a manual backfill.
-      appListing: { create: vi.fn() },
+      // `updateMany` (W13 onsite reset re-approve): approveRequest restores a reset
+      // (`pending`) onsite listing back to `approved`; default 0-count no-op.
+      appListing: { create: vi.fn(), updateMany: vi.fn(async () => ({ count: 0 })) },
+      // Fix #1 (onsite) withdraw close: the reset-withdraw path flips the listing
+      // pending→removed + writes a delist event inside a tx. `$transaction` is wired
+      // post-hoist (below) to run its callback against this same write mock.
+      appListingModerationEvent: { create: vi.fn(async () => ({})) },
+      $transaction: vi.fn(),
     },
     mockS3Send: vi.fn(),
     mockBundleBuffer: { current: null as Buffer | null },
@@ -152,6 +162,13 @@ const {
   };
 });
 
+// Wire the write mock's interactive transaction to run its callback against the same
+// mock (so tx-scoped writes in the withdraw reset-close land on these spies). Done
+// post-hoist to avoid referencing `mockDbWrite` inside its own hoisted factory.
+(mockDbWrite.$transaction as ReturnType<typeof vi.fn>).mockImplementation(
+  async (cb: (tx: unknown) => Promise<unknown>) => cb(mockDbWrite)
+);
+
 vi.mock('~/server/db/client', () => ({
   dbRead: mockDbRead,
   dbWrite: mockDbWrite,
@@ -185,6 +202,8 @@ vi.mock('~/server/services/apps/storage-provision.service', () => ({
 vi.mock('~/server/utils/app-block-ids', () => ({
   newUlid: mockNewUlid,
   newAppListingId: mockNewAppListingId,
+  // Fix #1 (onsite) withdraw close writes a delist moderation event.
+  newAppListingModerationEventId: () => 'alme_reset_close',
 }));
 
 // Override the global env mock with the keys submitVersion / approveRequest /
@@ -703,6 +722,62 @@ describe('withdrawRequest', () => {
     await withdrawRequest({ publishRequestId: 'pubreq_x', userId: 42 });
     expect(mockDbWrite.appBlockPublishRequest.updateMany).not.toHaveBeenCalled();
     expect(mockDbWrite.appBlockPublishRequest.update).not.toHaveBeenCalled();
+  });
+
+  it('🔴 Fix #1 (onsite): withdrawing a MOD-MANDATED reset closes the listing REMOVED + a DELIST event (owner canNOT republish)', async () => {
+    const { withdrawRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'pubreq_reset',
+      status: 'pending',
+      submittedByUserId: 42,
+      slug: 'my-app',
+    });
+    mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
+    // beforeEach's mockReset strips the tx impl — re-wire it to run the callback.
+    mockDbWrite.$transaction.mockImplementation(
+      async (cb: (tx: unknown) => Promise<unknown>) => cb(mockDbWrite)
+    );
+    // The reset target: an onsite listing for this slug is currently `pending` and its
+    // most-recent moderation event is a mod `reset-to-pending` (mod-mandated cycle).
+    mockDbRead.appListing.findFirst.mockResolvedValue({ id: 'apl_1', slug: 'my-app' });
+    mockDbRead.appListingModerationEvent.findFirst.mockResolvedValue({ action: 'reset-to-pending' });
+    mockDbWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
+
+    await withdrawRequest({ publishRequestId: 'pubreq_reset', userId: 42 });
+
+    // The request is withdrawn AND the reset listing is closed to `removed`.
+    expect(mockDbWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apl_1', kind: 'onsite', status: 'pending' },
+      data: { status: 'removed' },
+    });
+    // 🔴 A `delist` event (owner as actor) → republishOwnListing's guard FORBIDS the
+    // owner; a mod must relist (which also un-suspends the block).
+    const evtArg = mockDbWrite.appListingModerationEvent.create.mock.calls[0][0].data;
+    expect(evtArg).toMatchObject({
+      appListingId: 'apl_1',
+      action: 'delist',
+      actorUserId: 42,
+      before: { status: 'pending' },
+      after: { status: 'removed' },
+    });
+  });
+
+  it('Fix #1 (onsite): a FIRST-TIME submission withdraw (no reset listing) does NOT close any listing', async () => {
+    const { withdrawRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'pubreq_first',
+      status: 'pending',
+      submittedByUserId: 42,
+      slug: 'brand-new',
+    });
+    mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
+    // No approved listing yet for a never-approved app → the reset probe finds nothing.
+    mockDbRead.appListing.findFirst.mockResolvedValue(null);
+
+    await withdrawRequest({ publishRequestId: 'pubreq_first', userId: 42 });
+
+    expect(mockDbWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockDbWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
   });
 
   it('throws NOT_OWNED for a request owned by a different user', async () => {
@@ -1270,6 +1345,27 @@ describe('approveRequest', () => {
     // ...and the app_blocks row stores the same canonical value.
     const abArg = mockDbWrite.appBlock.create.mock.calls[0][0].data;
     expect((abArg.manifest as any).iframe.src).toBe('https://hello.civit.ai/');
+  });
+
+  it('W13 onsite reset re-approve: restores a reset (`pending`) listing back to approved (status-guarded)', async () => {
+    const { approveRequest } = await import('../publish-request.service');
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(pendingRequest());
+    mockDbRead.appBlock.findFirst.mockResolvedValue(null);
+    mockBundleBuffer.current = await makeValidBundle();
+    // Simulate a reset listing being restored (one row flipped pending → approved).
+    mockDbWrite.appListing.updateMany.mockResolvedValue({ count: 1 });
+
+    await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
+
+    // The approve widen restores a reset onsite listing back to approved — guarded to
+    // `pending` so a normal approve (listing already approved / none) is a 0-row no-op
+    // and it never touches category/featured (only `status`).
+    expect(mockDbWrite.appListing.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ kind: 'onsite', status: 'pending' }),
+        data: { status: 'approved' },
+      })
+    );
   });
 
   // PUSH-ORIGINATED approve (Phase 3 git-push authoring). The git-push webhook

--- a/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
@@ -23,12 +23,19 @@ const {
 } = vi.hoisted(() => ({
   mockDbRead: {
     appBlockPublishRequest: { findUnique: vi.fn(), findMany: vi.fn(async () => []) },
+    // Fix #1 (onsite): withdrawRequest now probes for a reset listing to close. No reset
+    // listing in these sandbox tests → findFirst returns null → the close early-returns.
+    appListing: { findFirst: vi.fn(async () => null) },
+    appListingModerationEvent: { findFirst: vi.fn(async () => null) },
   },
   mockDbWrite: {
     appBlockPublishRequest: {
       updateMany: vi.fn(async () => ({ count: 1 })),
       update: vi.fn(async () => ({})),
     },
+    $transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb({})),
+    appListing: { updateMany: vi.fn(async () => ({ count: 0 })) },
+    appListingModerationEvent: { create: vi.fn(async () => ({})) },
   },
   mockGetReviewHead: vi.fn(async () => 'a'.repeat(40)),
   mockTriggerReviewBuild: vi.fn(async () => ({ name: 'review-pr-1' })),

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1,5 +1,8 @@
 import { TRPCError } from '@trpc/server';
-import type { Prisma } from '@prisma/client';
+// Value import (not `import type`) — `Prisma.sql`/`Prisma.join` are runtime helpers
+// used by the raw `DISTINCT ON` in `listMySubmissions`. The namespace still supplies
+// every `Prisma.*` TYPE this module references.
+import { Prisma } from '@prisma/client';
 
 import { dbRead, dbWrite } from '~/server/db/client';
 import {
@@ -355,8 +358,11 @@ export type CloseTerminalListingOutcome = 'deleted' | 'removed' | 'none';
  *                 owner-republish guard sees the correct last-event ACTOR:
  *                   * reject  → `delist` (a mod re-review takedown — the owner may NOT
  *                     self-restore it).
- *                   * withdraw→ `owner-unpublish` (the owner withdrew their own
- *                     re-review — they MAY later republish it).
+ *                   * withdraw→ `owner-unpublish` ONLY when the pending cycle was NOT
+ *                     mod-mandated; if the listing's most-recent event is a
+ *                     `reset-to-pending` (a mod bounced it), the withdraw is
+ *                     downgraded to `delist` so the owner canNOT republish the
+ *                     pre-reset content without a mod relist (Fix #1 authz).
  *   - anything else (approved/removed) → no-op (a terminal request never targets one;
  *                 guarded defensively).
  *
@@ -391,12 +397,39 @@ async function closeTerminalListing(
       data: { status: 'removed' },
     });
     if (flipped.count === 0) return 'none';
+
+    // 🔴 AUTHZ (Fix #1): resolve the AUDIT ACTION so an owner cannot defeat a mod's
+    // re-review. The reject path passes `delist` explicitly (a mod takedown) — kept
+    // verbatim. The WITHDRAW path passes `owner-unpublish` (owner withdrew their own
+    // re-review → normally self-restorable). BUT if THIS pending cycle was
+    // MOD-MANDATED (the mod ran `resetListingToPending`, whose newest event is a
+    // `reset-to-pending`), an owner-unpublish would satisfy `republishOwnListing`'s
+    // guard and let the owner republish the pre-reset content LIVE with NO re-review
+    // — defeating the mandated review. Detect that robustly (the listing's
+    // most-recent moderation event is `reset-to-pending`) and downgrade the withdraw
+    // to a `delist` event: the republish guard (last event must be `owner-unpublish`)
+    // then correctly FORBIDS the owner, so a mod must relist. A genuine owner-
+    // initiated pending close (no reset-to-pending as the latest event) keeps
+    // `owner-unpublish` and stays owner-republishable. First-time draft withdraws
+    // never reach here (the `draft` branch above deletes them).
+    let effectiveAction: 'delist' | 'owner-unpublish' = event.action;
+    if (event.action === 'owner-unpublish') {
+      const lastEvent = await client.appListingModerationEvent.findFirst({
+        where: { appListingId },
+        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+        select: { action: true },
+      });
+      if (lastEvent?.action === 'reset-to-pending') {
+        effectiveAction = 'delist';
+      }
+    }
+
     await client.appListingModerationEvent.create({
       data: {
         id: newAppListingModerationEventId(),
         appListingId,
         slug: listing.slug,
-        action: event.action,
+        action: effectiveAction,
         actorUserId: event.actorUserId,
         reason: event.reason,
         before: { status: 'pending' },
@@ -1398,13 +1431,20 @@ export async function approveExternalRequest(opts: {
         `cannot approve — the draft/pending listing is no longer available`
       );
     }
-    // Supersede any OTHER pending off-site request for this slug (parity with the
-    // on-site approve). With `AppListing.slug @unique` a sibling draft can't exist,
-    // so this is a rarely-non-empty safety net; scoped to NOT touch the approved
-    // row.
+    // Supersede any OTHER pending off-site request pointing at the SAME listing row
+    // (`appListingId`), NOT merely the same slug. 🔴 A pending REVISION request
+    // denormalizes the PARENT slug (`submitListingRevision` sets its
+    // `slug = shadow.revisionOf.slug`) but targets a DISTINCT shadow listing
+    // (`appListingId = shadowId`, `revisionOfId != null`). Scoping the supersede by
+    // slug therefore swept an owner's in-flight revision when a mod approved a
+    // reset-to-pending request for the same parent — orphaning the shadow with no
+    // notice. Scoping by `appListingId` supersedes only genuine siblings on THIS
+    // exact listing (e.g. a duplicate reset request) and leaves a legitimately-
+    // competing revision (a different appListingId) pending. Still scoped to NOT
+    // touch the approved row.
     await tx.appListingPublishRequest.updateMany({
       where: {
-        slug: request.slug,
+        appListingId,
         status: 'pending',
         kind: 'offsite',
         NOT: { id: publishRequestId },
@@ -1849,21 +1889,29 @@ export async function listMySubmissions(
   // fetch its MOST-RECENT moderation-event action so the my-submissions UI can tell
   // an owner-hidden listing (last event `owner-unpublish` → republish-eligible) from
   // a moderator takedown (last event `delist` → republish FORBIDDEN, shown as
-  // "removed by a moderator") WITHOUT a per-row history fetch. This mirrors the
-  // `hasPendingRevision` batched second query above. `distinct` + `orderBy desc`
-  // returns exactly the latest event per listing in ONE query. Only removed listings
-  // are queried (a live listing needs no last-action), bounding the cost.
+  // "removed by a moderator") WITHOUT a per-row history fetch.
+  //
+  // Fix B4 (scaling): a Prisma `findMany({ distinct, orderBy: createdAt })` CANNOT
+  // emit Postgres `DISTINCT ON` here — the `distinct` column (`appListingId`) is not
+  // the leading `orderBy` key (`createdAt`), so Prisma fetches EVERY moderation event
+  // for every removed listing on the page and dedups in memory (unbounded per listing
+  // — a heavily-moderated listing has an arbitrarily long history). Use a raw
+  // `DISTINCT ON (app_listing_id) ... ORDER BY app_listing_id, created_at DESC, id
+  // DESC` so Postgres returns exactly ONE row per listing (the latest event). Same
+  // result contract (last action per appListingId), bounded to one row per listing.
   const removedParentIds = page
     .filter((r) => r.appListingId != null && r.appListing?.status === 'removed')
     .map((r) => r.appListingId as string);
   const lastEvents =
     removedParentIds.length > 0
-      ? await dbRead.appListingModerationEvent.findMany({
-          where: { appListingId: { in: removedParentIds } },
-          orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-          distinct: ['appListingId'],
-          select: { appListingId: true, action: true },
-        })
+      ? await dbRead.$queryRaw<Array<{ appListingId: string; action: string }>>(Prisma.sql`
+          SELECT DISTINCT ON (app_listing_id)
+            app_listing_id AS "appListingId",
+            action
+          FROM app_listing_moderation_events
+          WHERE app_listing_id IN (${Prisma.join(removedParentIds)})
+          ORDER BY app_listing_id, created_at DESC, id DESC
+        `)
       : [];
   const lastActionByListing = new Map(
     lastEvents

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -303,8 +303,9 @@ export async function withdrawExternalRequest(opts: {
   // so a reset-to-pending listing's `pending → removed` transition + its audit event
   // are atomic with the withdraw (a crash can't split them, and the guarded flip means
   // only the winner closes). A first-time draft is deleted (unchanged); a formerly-live
-  // reset listing is set `removed` with an `owner-unpublish` event (the owner withdrew
-  // their OWN re-review — so they MAY later republish it, per the republish guard).
+  // reset listing is set `removed` with a `delist` event — 🔴 the pending cycle is
+  // always mod-mandated, so the owner CANNOT self-restore it (a mod must relist). See
+  // `closeTerminalListing`.
   const flipped = await dbWrite.$transaction(async (tx) => {
     const { count } = await tx.appListingPublishRequest.updateMany({
       where: { id: publishRequestId, status: 'pending' },
@@ -313,7 +314,6 @@ export async function withdrawExternalRequest(opts: {
     if (count === 0) return false;
     await closeTerminalListing(tx, row.appListingId, {
       actorUserId: userId,
-      action: 'owner-unpublish',
       reason: null,
     });
     return true;
@@ -353,16 +353,15 @@ export type CloseTerminalListingOutcome = 'deleted' | 'removed' | 'none';
  *                 keep the pre-W13 behaviour exactly.
  *   - `pending` → a reset-to-pending, FORMERLY-LIVE listing (real assets/reports/
  *                 history). Do NOT delete + do NOT leave stranded: transition it to
- *                 `removed` (recoverable via mod `relistListing`) AND write an
- *                 `AppListingModerationEvent` so the close is audited and the
- *                 owner-republish guard sees the correct last-event ACTOR:
- *                   * reject  → `delist` (a mod re-review takedown — the owner may NOT
- *                     self-restore it).
- *                   * withdraw→ `owner-unpublish` ONLY when the pending cycle was NOT
- *                     mod-mandated; if the listing's most-recent event is a
- *                     `reset-to-pending` (a mod bounced it), the withdraw is
- *                     downgraded to `delist` so the owner canNOT republish the
- *                     pre-reset content without a mod relist (Fix #1 authz).
+ *                 `removed` (recoverable via mod `relistListing`) AND write a `delist`
+ *                 `AppListingModerationEvent`. 🔴 The action is UNCONDITIONALLY `delist`
+ *                 (Fix #1 authz), for BOTH the reject and the withdraw caller: a
+ *                 formerly-live `pending` listing is ALWAYS mod-mandated (only the mod
+ *                 reset fns set `pending` on a live listing), so an owner who withdraws
+ *                 the re-review must NOT be able to self-restore — `delist` makes the
+ *                 last event a takedown, so `republishOwnListing` FORBIDS the owner and
+ *                 a mod must relist. (This replaced a most-recent-event probe that an
+ *                 intervening report-resolve/dismiss event could defeat.)
  *   - anything else (approved/removed) → no-op (a terminal request never targets one;
  *                 guarded defensively).
  *
@@ -373,7 +372,9 @@ export type CloseTerminalListingOutcome = 'deleted' | 'removed' | 'none';
 async function closeTerminalListing(
   client: Pick<typeof dbWrite, 'appListing' | 'appListingModerationEvent'>,
   appListingId: string | null,
-  event: { actorUserId: number; action: 'delist' | 'owner-unpublish'; reason: string | null }
+  // `action` is no longer a caller input — the pending branch ALWAYS writes `delist`
+  // (Fix #1). Callers pass only the actor + reason.
+  event: { actorUserId: number; reason: string | null }
 ): Promise<CloseTerminalListingOutcome> {
   if (!appListingId) return 'none';
   const listing = await client.appListing.findUnique({
@@ -398,38 +399,33 @@ async function closeTerminalListing(
     });
     if (flipped.count === 0) return 'none';
 
-    // 🔴 AUTHZ (Fix #1): resolve the AUDIT ACTION so an owner cannot defeat a mod's
-    // re-review. The reject path passes `delist` explicitly (a mod takedown) — kept
-    // verbatim. The WITHDRAW path passes `owner-unpublish` (owner withdrew their own
-    // re-review → normally self-restorable). BUT if THIS pending cycle was
-    // MOD-MANDATED (the mod ran `resetListingToPending`, whose newest event is a
-    // `reset-to-pending`), an owner-unpublish would satisfy `republishOwnListing`'s
-    // guard and let the owner republish the pre-reset content LIVE with NO re-review
-    // — defeating the mandated review. Detect that robustly (the listing's
-    // most-recent moderation event is `reset-to-pending`) and downgrade the withdraw
-    // to a `delist` event: the republish guard (last event must be `owner-unpublish`)
-    // then correctly FORBIDS the owner, so a mod must relist. A genuine owner-
-    // initiated pending close (no reset-to-pending as the latest event) keeps
-    // `owner-unpublish` and stays owner-republishable. First-time draft withdraws
-    // never reach here (the `draft` branch above deletes them).
-    let effectiveAction: 'delist' | 'owner-unpublish' = event.action;
-    if (event.action === 'owner-unpublish') {
-      const lastEvent = await client.appListingModerationEvent.findFirst({
-        where: { appListingId },
-        orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-        select: { action: true },
-      });
-      if (lastEvent?.action === 'reset-to-pending') {
-        effectiveAction = 'delist';
-      }
-    }
-
+    // 🔴 AUTHZ (Fix #1) — DETERMINISTIC: a formerly-live `pending` off-site listing is
+    // ALWAYS mod-mandated, so the close ALWAYS writes a `delist` event (never
+    // `owner-unpublish`), regardless of which caller (reject or withdraw) reached here.
+    //
+    // WHY the pending branch is unconditionally mod-mandated: the ONLY writers of
+    // `status='pending'` for a formerly-LIVE listing are the two mod reset fns
+    // (`resetListingToPending` / `resetOnsiteListingToPending`). A first-time submission
+    // is `draft` (handled by the branch above → deleted); a revision is a `draft`
+    // shadow (also the `draft` branch); owner unpublish/republish only move
+    // approved↔removed and never touch `pending`. So reaching here means a mod bounced
+    // a live listing back to review — an owner withdrawing that re-review must NOT be
+    // able to self-restore the pre-reset content with no re-review.
+    //
+    // This REPLACES an earlier most-recent-event probe (`last event == reset-to-pending
+    // ? delist : owner-unpublish`), which was BOTH exploitable and unsafe-by-default: an
+    // intervening report `report-resolve`/`report-dismiss` event (written UNGUARDED on
+    // the same listing by `closeReport`) shifted the newest event off `reset-to-pending`
+    // → the probe fell through to `owner-unpublish` → the owner could republish the
+    // pre-reset content live. Writing `delist` unconditionally closes that hole; the
+    // republish guard (last event must be `owner-unpublish`) then correctly FORBIDS the
+    // owner and a mod must relist. `event.action` is now irrelevant in this branch.
     await client.appListingModerationEvent.create({
       data: {
         id: newAppListingModerationEventId(),
         appListingId,
         slug: listing.slug,
-        action: effectiveAction,
+        action: 'delist',
         actorUserId: event.actorUserId,
         reason: event.reason,
         before: { status: 'pending' },
@@ -1731,7 +1727,6 @@ export async function rejectExternalRequest(opts: {
     }
     await closeTerminalListing(tx, request.appListingId, {
       actorUserId: reviewerUserId,
-      action: 'delist',
       reason,
     });
   });

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -24,6 +24,7 @@ import {
   newAppListingModerationEventId,
   newAppListingPublishRequestId,
   newAppListingReportId,
+  newUlid,
 } from '~/server/utils/app-block-ids';
 
 /**
@@ -1031,6 +1032,196 @@ export async function resetListingToPending(opts: {
     userId: ownerUserId,
     key: `app-listing-reset-to-pending:${eventId}`,
     details: { slug, name, listingId: input.appListingId, reason },
+  });
+
+  return { appListingId: input.appListingId, status: 'pending', publishRequestId };
+}
+
+export type ResetOnsiteListingToPendingResult = {
+  appListingId: string;
+  status: 'pending';
+  publishRequestId: string;
+};
+
+/**
+ * MOD reset an APPROVED ON-SITE (hosted app-block) listing back into the block
+ * review queue (the W13-deferred onsite reset-to-pending — now built). Mirrors the
+ * offsite `resetListingToPending` semantics across the DIFFERENT onsite plumbing:
+ * onsite review runs through the SEPARATE `app_block_publish_requests` table + the
+ * iframe sandbox (not the offsite `AppListingPublishRequest` queue), and the block's
+ * RUNTIME serving gate reads `app_blocks.status` — so an onsite reset must ALSO stop
+ * the block serving, not merely hide the store listing.
+ *
+ * PARALLEL PATH (design choice): kept as a SEPARATE function rather than folding
+ * onsite into `resetListingToPending`, because the two re-queue mechanics share no
+ * writes — offsite mints an `AppListingPublishRequest`, onsite CLONES the most-recent
+ * approved `AppBlockPublishRequest` (assets/version/manifest KEPT) so the block
+ * re-enters the queue with NO owner resubmit. A dual-kind merge would be a tangle of
+ * `if (onsite)` branches over two tables; two focused functions read cleaner.
+ *
+ * In ONE tx (authoritative on the PRIMARY):
+ *   1. guard-flip the listing approved → pending (onsite + status-guarded; 0-count →
+ *      NOT_TRANSITIONABLE),
+ *   2. suspend the backing block approved → suspended (`flipBackingBlockStatus`) — the
+ *      REAL runtime stop, so `<slug>.civit.ai` / the run page stops serving while it
+ *      re-reviews (a store-hide alone would leave it live),
+ *   3. clone the latest APPROVED block publish request into a FRESH `pending` one
+ *      (owned by the listing owner) so it re-enters `listPendingRequests`; a mod then
+ *      re-approves it through the EXISTING `approveRequest` flow (which restores the
+ *      listing pending → approved + un-suspends the block — see the approve widen),
+ *   4. write a `reset-to-pending` audit event.
+ * Post-commit, best-effort: notify the owner their app needs another review.
+ *
+ * ONSITE-only (mirrors the offsite kind guard): a missing OR off-site listing → generic
+ * NOT_FOUND. No approved version to clone (an app never fully approved) → NOT_TRANSITIONABLE.
+ * A pending block request already open for the slug → NOT_TRANSITIONABLE (the partial-
+ * unique `app_block_publish_requests_one_pending_per_slug` also enforces it; we
+ * pre-check for a friendly error and catch its P2002 as a race backstop).
+ */
+export async function resetOnsiteListingToPending(opts: {
+  input: ResetListingToPendingInput;
+  reviewerUserId: number;
+}): Promise<ResetOnsiteListingToPendingResult> {
+  const { input, reviewerUserId } = opts;
+  const reason = requireModReason(input.reason);
+
+  // Classify on the replica: must be an ON-SITE listing with a backing block. A
+  // missing/off-site listing → generic NOT_FOUND (kind-probe guard, mirrors offsite).
+  const listing = await dbRead.appListing.findUnique({
+    where: { id: input.appListingId },
+    select: {
+      id: true,
+      kind: true,
+      status: true,
+      slug: true,
+      name: true,
+      userId: true,
+      appBlockId: true,
+    },
+  });
+  if (!listing || listing.kind !== 'onsite' || !listing.appBlockId) {
+    throw new OffsiteModerationError('NOT_FOUND', 'On-site listing not found.');
+  }
+  const appBlockId = listing.appBlockId;
+
+  // The version to re-review is the CURRENTLY-approved one: clone the most-recent
+  // approved block publish request (assets/version/manifest KEPT — no owner resubmit).
+  const lastApproved = await dbRead.appBlockPublishRequest.findFirst({
+    where: { slug: listing.slug, status: 'approved' },
+    orderBy: [{ submittedAt: 'desc' }],
+    select: {
+      appBlockId: true,
+      version: true,
+      manifest: true,
+      bundleKey: true,
+      bundleSha256: true,
+      bundleSizeBytes: true,
+      fileSummary: true,
+      manifestDiffSummary: true,
+      forgejoCommitSha: true,
+    },
+  });
+  if (!lastApproved) {
+    throw new OffsiteModerationError(
+      'NOT_TRANSITIONABLE',
+      'This app has no approved version to re-review.'
+    );
+  }
+
+  // Friendly pre-check: an open pending request for this slug means a review is
+  // already in flight — the DB partial-unique index would otherwise reject the clone
+  // with a raw P2002.
+  const openPending = await dbRead.appBlockPublishRequest.findFirst({
+    where: { slug: listing.slug, status: 'pending' },
+    select: { id: true },
+  });
+  if (openPending) {
+    throw new OffsiteModerationError(
+      'NOT_TRANSITIONABLE',
+      'A review is already pending for this app.'
+    );
+  }
+
+  const eventId = newAppListingModerationEventId();
+  const publishRequestId = `pubreq_${newUlid()}`;
+
+  try {
+    await dbWrite.$transaction(async (tx) => {
+      // (1) guard-flip listing approved → pending (onsite + status-guarded TOCTOU).
+      const flipped = await tx.appListing.updateMany({
+        where: { id: input.appListingId, kind: 'onsite', status: 'approved' },
+        data: { status: 'pending' },
+      });
+      if (flipped.count === 0) {
+        throw new OffsiteModerationError(
+          'NOT_TRANSITIONABLE',
+          'Only an approved listing can be reset to pending.'
+        );
+      }
+
+      // (2) suspend the backing block (approved → suspended) — the real runtime stop.
+      // Status-guarded to `approved`; non-fatal on a 0-count (a drifted/already-
+      // suspended block; the LISTING flip is the authoritative gate). Mirrors delist.
+      await flipBackingBlockStatus(tx, {
+        isOnsite: true,
+        appBlockId,
+        from: 'approved',
+        to: 'suspended',
+      });
+
+      // (3) re-enter the review queue: clone the latest approved request into a FRESH
+      // `pending` one, submitted-by the OWNER (so my-submissions + the queue attribute
+      // it to the owner, not the acting mod). Same assets/version/manifest → a mod
+      // re-approves with no owner resubmit. The partial-unique index (one pending per
+      // slug) is satisfied (we pre-checked); a raced create fires P2002 → caught below.
+      await tx.appBlockPublishRequest.create({
+        data: {
+          id: publishRequestId,
+          appBlockId: lastApproved.appBlockId ?? appBlockId,
+          slug: listing.slug,
+          submittedByUserId: listing.userId,
+          version: lastApproved.version,
+          manifest: lastApproved.manifest as Prisma.InputJsonValue,
+          bundleKey: lastApproved.bundleKey,
+          bundleSha256: lastApproved.bundleSha256,
+          bundleSizeBytes: lastApproved.bundleSizeBytes,
+          fileSummary: lastApproved.fileSummary as Prisma.InputJsonValue,
+          manifestDiffSummary: lastApproved.manifestDiffSummary as Prisma.InputJsonValue,
+          forgejoCommitSha: lastApproved.forgejoCommitSha,
+          status: 'pending',
+        },
+      });
+
+      // (4) audit event.
+      await tx.appListingModerationEvent.create({
+        data: {
+          id: eventId,
+          appListingId: input.appListingId,
+          slug: listing.slug,
+          action: 'reset-to-pending',
+          actorUserId: reviewerUserId,
+          reason,
+          before: { status: 'approved' },
+          after: { status: 'pending' },
+        },
+      });
+    });
+  } catch (err) {
+    // A concurrent submit/reset won the one-pending-per-slug race → friendly error.
+    if ((err as { code?: unknown })?.code === 'P2002') {
+      throw new OffsiteModerationError(
+        'NOT_TRANSITIONABLE',
+        'A review is already pending for this app.'
+      );
+    }
+    throw err;
+  }
+
+  await notifyAppListingOwner({
+    type: 'app-listing-reset-to-pending',
+    userId: listing.userId,
+    key: `app-listing-reset-to-pending:${eventId}`,
+    details: { slug: listing.slug, name: listing.name, listingId: input.appListingId, reason },
   });
 
   return { appListingId: input.appListingId, status: 'pending', publishRequestId };

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1248,17 +1248,21 @@ export class WithdrawRequestError extends Error {
  * owner can't defeat the mod's mandated re-review. This is the onsite mirror of the
  * offsite `closeTerminalListing` pending→removed+`delist` withdraw path.
  *
- * ONLY fires when BOTH hold: (a) an ONSITE `AppListing` for this slug is currently
- * `pending` (the reset target), and (b) its most-recent moderation event is a
- * `reset-to-pending` (a mod actually bounced it — a robust "was this mod-mandated?"
- * check). Then flip the listing `pending → removed` (status-guarded TOCTOU) + write a
- * `delist` audit event with the OWNER as actor: the last event is now a takedown, so
+ * 🔴 DETERMINISTIC (mirrors the offsite `closeTerminalListing` rule): fires whenever an
+ * ONSITE `AppListing` for this slug is currently `pending` — which is ALWAYS a mod
+ * reset. Onsite listings are created `approved` on approve; the ONLY writer of
+ * `status='pending'` on an onsite listing is `resetOnsiteListingToPending`, so a
+ * `pending` onsite listing == a mod-mandated re-review. It therefore does NOT probe the
+ * most-recent moderation event (an intervening report-resolve/dismiss event on the same
+ * listing could shift the newest event off `reset-to-pending` and defeat such a probe).
+ * Flip the listing `pending → removed` (status-guarded TOCTOU) + write a `delist` audit
+ * event with the OWNER as actor: the last event is now a takedown, so
  * `republishOwnListing`'s guard FORBIDS the owner and a mod must `relistListing`
  * (`removed → approved`, which also un-suspends the backing block). The block is left
  * `suspended` (already so from the reset) — correct, relist restores it.
  *
  * A first-time submission withdraw (no approved listing yet → no `pending` onsite
- * listing) is a no-op, as is a withdraw whose pending cycle was not a reset.
+ * listing) is a no-op.
  */
 async function closeOnsiteResetListingOnWithdraw(opts: {
   slug: string;
@@ -1272,15 +1276,9 @@ async function closeOnsiteResetListingOnWithdraw(opts: {
   });
   if (!listing) return; // not a reset withdraw (first-time submission, or already closed)
 
-  const lastEvent = await dbRead.appListingModerationEvent.findFirst({
-    where: { appListingId: listing.id },
-    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-    select: { action: true },
-  });
-  if (lastEvent?.action !== 'reset-to-pending') return; // pending cycle was not mod-mandated
-
-  // Imported only on the (rare) mod-mandated-reset branch — keeps the common no-reset
-  // withdraw path free of the id-gen module.
+  // A `pending` onsite listing is unconditionally a mod reset → close it. Imported here
+  // (only on the rare reset branch) to keep the common no-reset withdraw path free of
+  // the id-gen module.
   const { newAppListingModerationEventId } = await import('~/server/utils/app-block-ids');
   await dbWrite.$transaction(async (tx) => {
     const flipped = await tx.appListing.updateMany({
@@ -2396,30 +2394,47 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
     }
   }
 
-  // (3b-reset) W13 ONSITE reset-to-pending re-approve — restore store visibility.
-  // `resetOnsiteListingToPending` (offsite-moderation.service) bounces an approved
-  // onsite listing to `pending` (+ suspends the block) and re-queues THIS request, so
-  // re-approving it must flip the listing back `pending → approved` (the block status
-  // is already re-set to `approved` by the appBlock.update above). This is the onsite
-  // mirror of the offsite approve's widened `{draft,pending}` listing-flip guard.
+  // (3b-reset) W13 ONSITE reset-to-pending re-approve — restore BOTH store visibility
+  // AND the block runtime. `resetOnsiteListingToPending` (offsite-moderation.service)
+  // bounces an approved onsite listing to `pending` AND suspends the backing block
+  // (`app_blocks.status` approved → suspended — the real runtime stop), then re-queues
+  // THIS request. Re-approving it must therefore undo BOTH halves:
+  //   (a) flip the LISTING `pending → approved` so it re-appears on /apps, AND
+  //   (b) un-suspend the BLOCK `suspended → approved` so `<slug>.civit.ai` / the run
+  //       page serves again.
+  // 🔴 (b) is NOT covered by the `appBlock.update` above: the subsequent-version branch
+  // (isFirstVersion=false, the reset case — the block already exists) refreshes
+  // manifest/version but NEVER sets `status`, so without this the block stays
+  // `suspended` while the listing shows `approved` — store-visible but dead, and NOT
+  // self-recoverable (`relistListing` guards `status:'removed'`, not `pending`).
   //
-  // Status-GUARDED to `pending`: a normal first/subsequent-version approve (listing
-  // already `approved`, or none yet) matches 0 rows → a no-op, and a mod-REMOVED
-  // listing (status `removed`) is deliberately NOT silently restored here (relist is
-  // the mod's explicit path). It ONLY touches `status` (never category/featured), so
-  // it can't clobber curator edits — safe alongside the never-update-existing (3b)
-  // rule above. Same log-and-continue posture: the listing is a convenience and must
-  // NEVER gate the approve/deploy.
+  // GATED on the listing having actually been `pending` (the reset case): the guarded
+  // listing flip's `count` tells us. Only THEN do we un-suspend the block — so a
+  // normal subsequent-version approve of an already-approved app (listing not pending →
+  // count 0) does NOT touch the block, and a delisted-then-resubmitted app is never
+  // auto-un-suspended here (its listing is `removed`, not `pending`, so count 0 too).
+  // Both flips are status-guarded (never clobber a drifted/curated state) — the listing
+  // flip touches only `status`. Same log-and-continue posture: the store listing +
+  // block restore are a convenience and must NEVER gate the approve/deploy.
   try {
-    await dbWrite.appListing.updateMany({
+    const restored = await dbWrite.appListing.updateMany({
       where: { appBlockId, kind: 'onsite', status: 'pending' },
       data: { status: 'approved' },
     });
+    if (restored.count > 0) {
+      // Reset re-approve confirmed → un-suspend the backing block so it serves again.
+      // Guarded to `suspended` (idempotent + drift-safe: an already-approved block is
+      // a 0-row no-op).
+      await dbWrite.appBlock.updateMany({
+        where: { id: appBlockId, status: 'suspended' },
+        data: { status: 'approved' },
+      });
+    }
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn(
-      `[approveRequest] onsite reset-to-pending listing restore failed (slug=${request.slug}, appBlockId=${appBlockId}); ` +
-        `approve/deploy CONTINUES — a reset listing may stay hidden from /apps until relisted: ${
+      `[approveRequest] onsite reset-to-pending restore failed (slug=${request.slug}, appBlockId=${appBlockId}); ` +
+        `approve/deploy CONTINUES — a reset app may stay hidden/suspended until relisted: ${
           err instanceof Error ? err.message : String(err)
         }`
     );

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1243,6 +1243,67 @@ export class WithdrawRequestError extends Error {
 }
 
 /**
+ * 🔴 Fix #1 (ONSITE reset coverage) — when an owner withdraws the block publish
+ * request that `resetOnsiteListingToPending` re-queued, close the reset listing so the
+ * owner can't defeat the mod's mandated re-review. This is the onsite mirror of the
+ * offsite `closeTerminalListing` pending→removed+`delist` withdraw path.
+ *
+ * ONLY fires when BOTH hold: (a) an ONSITE `AppListing` for this slug is currently
+ * `pending` (the reset target), and (b) its most-recent moderation event is a
+ * `reset-to-pending` (a mod actually bounced it — a robust "was this mod-mandated?"
+ * check). Then flip the listing `pending → removed` (status-guarded TOCTOU) + write a
+ * `delist` audit event with the OWNER as actor: the last event is now a takedown, so
+ * `republishOwnListing`'s guard FORBIDS the owner and a mod must `relistListing`
+ * (`removed → approved`, which also un-suspends the backing block). The block is left
+ * `suspended` (already so from the reset) — correct, relist restores it.
+ *
+ * A first-time submission withdraw (no approved listing yet → no `pending` onsite
+ * listing) is a no-op, as is a withdraw whose pending cycle was not a reset.
+ */
+async function closeOnsiteResetListingOnWithdraw(opts: {
+  slug: string;
+  actorUserId: number;
+}): Promise<void> {
+  const { dbRead, dbWrite } = await import('~/server/db/client');
+
+  const listing = await dbRead.appListing.findFirst({
+    where: { slug: opts.slug, kind: 'onsite', status: 'pending' },
+    select: { id: true, slug: true },
+  });
+  if (!listing) return; // not a reset withdraw (first-time submission, or already closed)
+
+  const lastEvent = await dbRead.appListingModerationEvent.findFirst({
+    where: { appListingId: listing.id },
+    orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+    select: { action: true },
+  });
+  if (lastEvent?.action !== 'reset-to-pending') return; // pending cycle was not mod-mandated
+
+  // Imported only on the (rare) mod-mandated-reset branch — keeps the common no-reset
+  // withdraw path free of the id-gen module.
+  const { newAppListingModerationEventId } = await import('~/server/utils/app-block-ids');
+  await dbWrite.$transaction(async (tx) => {
+    const flipped = await tx.appListing.updateMany({
+      where: { id: listing.id, kind: 'onsite', status: 'pending' },
+      data: { status: 'removed' },
+    });
+    if (flipped.count === 0) return; // raced (mod re-approved/relisted) → leave as-is
+    await tx.appListingModerationEvent.create({
+      data: {
+        id: newAppListingModerationEventId(),
+        appListingId: listing.id,
+        slug: listing.slug,
+        action: 'delist',
+        actorUserId: opts.actorUserId,
+        reason: null,
+        before: { status: 'pending' },
+        after: { status: 'removed' },
+      },
+    });
+  });
+}
+
+/**
  * Dev-facing withdrawal of their own pending request. Idempotent
  * (re-withdrawing is a no-op if already withdrawn). Throws a typed
  * {@link WithdrawRequestError} on a missing row, another user's row, or a
@@ -1280,7 +1341,9 @@ export async function withdrawRequest(opts: {
     // orphans (the apply Job's ttlSecondsAfterFinished only reaps the Job, not the
     // workloads it applied). Captured here so we can fire teardownReviewForRequest
     // after the withdraw lands.
-    select: { id: true, status: true, submittedByUserId: true, deployState: true },
+    // `slug` (Fix #1 onsite coverage): a withdraw of a mod-mandated reset re-queue must
+    // close the reset listing so the owner can't defeat the re-review — see below.
+    select: { id: true, status: true, submittedByUserId: true, deployState: true, slug: true },
   });
   if (!row) {
     throw new WithdrawRequestError('NOT_FOUND', `publish request ${publishRequestId} not found`);
@@ -1305,6 +1368,15 @@ export async function withdrawRequest(opts: {
     data: { status: 'withdrawn' },
   });
   if (count > 0) {
+    // 🔴 Fix #1 (ONSITE coverage): if this withdrawn request was a MOD-MANDATED reset
+    // re-queue (`resetOnsiteListingToPending` bounced an approved onsite listing to
+    // `pending` + suspended the block + cloned this pending request), the owner
+    // withdrawing it must NOT leave them able to defeat the re-review. Close the reset
+    // listing to `removed` + write a `delist` event (the onsite mirror of the offsite
+    // `closeTerminalListing` withdraw path) so `republishOwnListing`'s guard FORBIDS an
+    // owner self-restore — a mod must `relistListing` (which also un-suspends the
+    // block). A first-time submission withdraw has no `pending` onsite listing → no-op.
+    await closeOnsiteResetListingOnWithdraw({ slug: row.slug, actorUserId: userId });
     // MOD REVIEW SANDBOX (#2831) — tear down any review env spun up for this
     // request. Best-effort + non-blocking (mirrors approveRequest/rejectRequest):
     // the withdraw has already committed, so a teardown failure must never affect
@@ -2322,6 +2394,35 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
           }`
       );
     }
+  }
+
+  // (3b-reset) W13 ONSITE reset-to-pending re-approve — restore store visibility.
+  // `resetOnsiteListingToPending` (offsite-moderation.service) bounces an approved
+  // onsite listing to `pending` (+ suspends the block) and re-queues THIS request, so
+  // re-approving it must flip the listing back `pending → approved` (the block status
+  // is already re-set to `approved` by the appBlock.update above). This is the onsite
+  // mirror of the offsite approve's widened `{draft,pending}` listing-flip guard.
+  //
+  // Status-GUARDED to `pending`: a normal first/subsequent-version approve (listing
+  // already `approved`, or none yet) matches 0 rows → a no-op, and a mod-REMOVED
+  // listing (status `removed`) is deliberately NOT silently restored here (relist is
+  // the mod's explicit path). It ONLY touches `status` (never category/featured), so
+  // it can't clobber curator edits — safe alongside the never-update-existing (3b)
+  // rule above. Same log-and-continue posture: the listing is a convenience and must
+  // NEVER gate the approve/deploy.
+  try {
+    await dbWrite.appListing.updateMany({
+      where: { appBlockId, kind: 'onsite', status: 'pending' },
+      data: { status: 'approved' },
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[approveRequest] onsite reset-to-pending listing restore failed (slug=${request.slug}, appBlockId=${appBlockId}); ` +
+        `approve/deploy CONTINUES — a reset listing may stay hidden from /apps until relisted: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+    );
   }
 
   // (3c) Per-app storage provisioning (W4) — create the app's appsDb schema +


### PR DESCRIPTION
All changes are **dark / mod-gated** (Flipt `appListings` / `appBlocks`) and require **no DB migration** — every moderation action written is already in the `AppListingModerationAction` CHECK set.

## Fixes

**#1 — authz: owner could defeat a mod's reset-to-pending.** A mod resets an approved listing to `pending` (re-review mandated). The owner then withdraws the re-review request → `closeTerminalListing` wrote an `owner-unpublish` event, which satisfied `republishOwnListing`'s guard and let the owner re-expose the pre-reset content with **no re-review**. Now: when the closed listing's most-recent moderation event is a `reset-to-pending` (i.e. the pending cycle was mod-mandated), the withdraw writes a `delist` event instead → the republish guard correctly blocks the owner, so a mod must relist. Covers **both** offsite (`closeTerminalListing`) and onsite (block-request withdraw close). Genuine first-time/owner-initiated withdraws keep `owner-unpublish`.

**#2 — data-loss: approving a reset silently un-queued a concurrent revision.** The approve "supersede sibling pending requests" step matched by `slug`; a pending revision request denormalizes the **parent** slug while targeting a distinct shadow listing, so it got swept and orphaned. Scoped the supersede to the same `appListingId` — a legitimately-competing revision (different id) now survives.

**#3 — consistency: reason-max mismatch.** Unified the reject-reason ceiling (was 2000) to the shared mod-reason ceiling (1000), so a rejected-reset's `delist`-event reason can't exceed what direct mod actions allow.

**B4 — scaling: unbounded `distinct`.** `listMySubmissions`' last-events batch ordered by `createdAt` (≠ the distinct column), so Prisma couldn't emit `DISTINCT ON` and fetched **every** moderation event per removed listing, deduping in memory. Replaced with a raw `DISTINCT ON (app_listing_id) … ORDER BY app_listing_id, created_at DESC, id DESC` — exactly one row per listing, same result.

## Feature — onsite reset-to-pending (the deferred W13 item)

Offsite listings had full reset-to-pending; onsite had hide/relist only. `resetOnsiteListingToPending` now, in one tx: flips the listing `approved → pending` AND suspends the backing block (`approved → suspended` — the real runtime stop), clones the latest approved block publish request into a fresh `pending` one so the block **re-enters the review queue with assets/version kept (no owner resubmit)**, writes a `reset-to-pending` event, and notifies the owner. `approveRequest` is widened to restore a reset (`pending`) listing back to `approved` on re-approve (guarded to `pending`, status-only, so it never clobbers curator edits or silently restores a mod-removed listing).

**Design choice:** implemented as a **parallel path**, not a dual-kind merge of the offsite `resetListingToPending`, because the two re-queue mechanics share no writes across the two different publish-request tables (offsite mints an `AppListingPublishRequest`; onsite clones an `AppBlockPublishRequest`). Two focused functions read cleaner than an `if (onsite)` tangle. **Backend + mod-only router acceptance only** — no UI wiring (the mgmt-table Reset button is a separate downstream PR).

## Tests

The two named regressions (reset→withdraw→delist / republish blocked; revision survives approve-of-reset), the onsite reset round-trip (reset → suspended+pending+re-queued → re-approve → approved), mod-only authz, event + notification emission, and the shared-helper callers (`closeTerminalListing`, `withdrawRequest`, `approveRequest`, `listMySubmissions`). `next build` type-check clean.