### PR TITLE
test(challenges): fix stale judge mocks in upsert test suites

### DIFF
--- a/src/server/services/__tests__/challenge-edit.service.test.ts
+++ b/src/server/services/__tests__/challenge-edit.service.test.ts
@@ -17,7 +17,6 @@ const {
       modelVersion: { findMany: vi.fn() },
       image: { findUnique: vi.fn(), findFirst: vi.fn() },
       challenge: { findUnique: vi.fn() },
-      challengeJudge: { findFirst: vi.fn() },
     },
     mockGetChallengeConfig: vi.fn(),
     mockGetChallengeById: vi.fn(),
@@ -86,6 +85,12 @@ vi.mock('~/server/services/challenge-eligibility.service', () => ({
 
 vi.mock('~/server/services/challenge-category.service', () => ({
   resolveJudgingCategories: mockResolveJudgingCategories,
+}));
+
+// Judge validation (read/write parity with the picker) runs before the standing gate; must
+// include editInput.judgeId so these tests exercise the standing checks, not judge lookup.
+vi.mock('~/server/services/challenge-judge.service', () => ({
+  getUserSelectableJudges: vi.fn(() => [{ id: 1 }]),
 }));
 
 vi.mock('~/utils/errorHandling', () => ({
@@ -229,7 +234,6 @@ describe('upsertUserChallenge (edit branch) — creator standing re-check', () =
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockDbRead.challengeJudge.findFirst.mockResolvedValue({ id: 1 });
     mockDbRead.image.findFirst.mockResolvedValue({ id: 555 });
     mockResolveJudgingCategories.mockResolvedValue([]);
   });

--- a/src/server/services/__tests__/challenge-upsert-standing-real.service.test.ts
+++ b/src/server/services/__tests__/challenge-upsert-standing-real.service.test.ts
@@ -15,7 +15,6 @@ const { mockDbRead, mockGetChallengeConfig, mockResolveJudgingCategories } = vi.
       modelVersion: { findMany: vi.fn() },
       image: { findUnique: vi.fn(), findFirst: vi.fn() },
       challenge: { findUnique: vi.fn(), count: vi.fn() },
-      challengeJudge: { findFirst: vi.fn() },
     },
     mockGetChallengeConfig: vi.fn(),
     mockResolveJudgingCategories: vi.fn(),
@@ -80,6 +79,12 @@ vi.mock('~/server/services/challenge-category.service', () => ({
   resolveJudgingCategories: mockResolveJudgingCategories,
 }));
 
+// Judge validation (read/write parity with the picker) runs before the standing gate; must
+// include baseInput.judgeId so these tests exercise the eligibility checks, not judge lookup.
+vi.mock('~/server/services/challenge-judge.service', () => ({
+  getUserSelectableJudges: vi.fn(() => [{ id: 1 }]),
+}));
+
 vi.mock('~/utils/errorHandling', () => ({
   withRetries: vi.fn((fn: () => unknown) => fn()),
 }));
@@ -133,7 +138,6 @@ const baseInput = {
 describe('upsertUserChallenge — real eligibility gate (no mocked assert* functions)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockDbRead.challengeJudge.findFirst.mockResolvedValue({ id: 1 });
     mockDbRead.image.findFirst.mockResolvedValue({ id: 555 });
     mockDbRead.userStrike.count.mockResolvedValue(0);
     mockResolveJudgingCategories.mockResolvedValue([]);


### PR DESCRIPTION
## Problem

7 tests failed on `main` (pre-existing, surfaced while working on #3160/#3162):

- `challenge-edit.service.test.ts` — 2 failures
- `challenge-upsert-standing-real.service.test.ts` — 5 failures

All with `TypeError: dbRead.challengeJudge.findMany is not a function`. Both suites still mocked `dbRead.challengeJudge.findFirst`, which predates the switch to `getUserSelectableJudges()` (read/write-parity judge validation). Judge validation runs before the standing gate in `upsertUserChallenge`, so every test passing a `judgeId` crashed in the real `challenge-judge.service` before reaching its actual assertions.

## Fix

- Mock `~/server/services/challenge-judge.service` with a selectable judge matching the input's `judgeId` (same pattern as the newer challenge suites)
- Drop the dead `challengeJudge` db mocks

Test-only change; no production code touched.

## Verification

- Both suites: 10/10 pass
- Full `src/server/services/__tests__` sweep: **1197 pass, 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)