### PR TITLE
refactor(apps): consolidate mod-review reason-gating + expose onsite reset-to-pending

### DIFF
--- a/src/components/Apps/AppListingsModerationTable.browser.test.tsx
+++ b/src/components/Apps/AppListingsModerationTable.browser.test.tsx
@@ -48,6 +48,22 @@ const ROWS = [
   offsite({ id: 'apl_a', slug: 'alpha-live', name: 'Alpha', status: 'approved' }),
   offsite({ id: 'apl_o', slug: 'onsite-live', name: 'Onsite', kind: 'onsite', appBlockId: 'ab_1', status: 'approved' }),
   offsite({ id: 'apl_r', slug: 'gone-ext', name: 'Gone', status: 'removed' }),
+  // D: an on-site + pending listing — it belongs to the on-site review FIFO queue, so
+  // the mgmt table must HIDE it (it would otherwise be a dead-end `—`-action row).
+  offsite({
+    id: 'apl_op',
+    slug: 'onsite-pending',
+    name: 'Onsite Pending',
+    kind: 'onsite',
+    appBlockId: 'ab_2',
+    status: 'pending',
+    pendingRequest: {
+      id: 'alpr_op',
+      submittedAt: new Date('2026-01-01T00:00:00Z'),
+      changelog: null,
+      submittedBy: { id: 1, username: 'dev', image: null },
+    },
+  }),
 ];
 
 // Two-page dataset (paged mode) — page 1 carries a nextCursor, page 2 does not.
@@ -58,8 +74,12 @@ const mocks = vi.hoisted(() => ({
   invalidate: vi.fn().mockResolvedValue(undefined),
   mutate: vi.fn(),
   queryInput: vi.fn(),
+  refetch: vi.fn(),
   errorMode: false,
   queryError: false,
+  // null → a transient (non-authz) error (Alert + Retry); a code string → an authz
+  // error (render nothing).
+  queryErrorCode: null as string | null,
   paged: false,
 }));
 
@@ -103,19 +123,29 @@ vi.mock('~/utils/trpc', () => {
           useQuery: (input: { cursor?: string }) => {
             mocks.queryInput(input);
             if (mocks.queryError) {
-              return { data: undefined, isLoading: false, isFetching: false, error: new Error('nope') };
+              const error = mocks.queryErrorCode
+                ? Object.assign(new Error('forbidden'), { data: { code: mocks.queryErrorCode } })
+                : Object.assign(new Error('transient boom'), { data: { code: 'INTERNAL_SERVER_ERROR' } });
+              return {
+                data: undefined,
+                isLoading: false,
+                isFetching: false,
+                error,
+                refetch: mocks.refetch,
+              };
             }
             if (mocks.paged) {
               const data = input?.cursor
                 ? { items: PAGE2, nextCursor: null }
                 : { items: PAGE1, nextCursor: 'cur-2' };
-              return { data, isLoading: false, isFetching: false, error: null };
+              return { data, isLoading: false, isFetching: false, error: null, refetch: mocks.refetch };
             }
             return {
               data: { items: ROWS, nextCursor: null },
               isLoading: false,
               isFetching: false,
               error: null,
+              refetch: mocks.refetch,
             };
           },
         },
@@ -136,6 +166,7 @@ vi.mock('~/utils/trpc', () => {
         },
         // Lifecycle + review mutations.
         resetListingToPending: { useMutation: mutation('reset') },
+        resetOnsiteListingToPending: { useMutation: mutation('resetOnsite') },
         delistListing: { useMutation: mutation('delist') },
         relistListing: { useMutation: mutation('relist') },
         claimListing: { useMutation: mutation('claim') },
@@ -153,8 +184,10 @@ beforeEach(() => {
   mocks.invalidate.mockClear();
   mocks.mutate.mockClear();
   mocks.queryInput.mockClear();
+  mocks.refetch.mockClear();
   mocks.errorMode = false;
   mocks.queryError = false;
+  mocks.queryErrorCode = null;
   mocks.paged = false;
   showError.mockClear();
 });
@@ -176,13 +209,27 @@ describe('AppListingsModerationTable — sections + kind-aware visibility', () =
     // Off-site approved → BOTH reset-to-pending + hide.
     await expect.element(page.getByTestId('apps-mod-reset-to-pending-alpha-live')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-mod-hide-alpha-live')).toBeInTheDocument();
-    // On-site approved → hide ONLY (no reset-to-pending).
+    // On-site approved → reset-to-pending (now dual-kind, #3165) + hide, but NEVER the
+    // off-site-only claim/purge (those don't apply to an on-site row).
     await expect.element(page.getByTestId('apps-mod-hide-onsite-live')).toBeInTheDocument();
-    expect(page.getByTestId('apps-mod-reset-to-pending-onsite-live').elements()).toHaveLength(0);
+    await expect
+      .element(page.getByTestId('apps-mod-reset-to-pending-onsite-live'))
+      .toBeInTheDocument();
     // Removed off-site → relist + claim + purge.
     await expect.element(page.getByTestId('apps-mod-relist-gone-ext')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-mod-claim-gone-ext')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-mod-purge-gone-ext')).toBeInTheDocument();
+  });
+
+  // D — an on-site + pending listing is the actionable on-site review queue's job; the
+  // mgmt table filters it out so it isn't a dead-end row. An OFF-SITE pending row (which
+  // carries the Review action) still shows.
+  test('an on-site + pending row is hidden from the table, while off-site pending shows', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    // Off-site pending still present (has the Review action).
+    await expect.element(page.getByTestId('apps-mod-listing-row-pending-ext')).toBeInTheDocument();
+    // On-site pending filtered out entirely (no row, no dead-end).
+    expect(page.getByTestId('apps-mod-listing-row-onsite-pending').elements()).toHaveLength(0);
   });
 });
 
@@ -204,11 +251,41 @@ describe('AppListingsModerationTable — sort + server-side filter', () => {
     expect(after & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
-  test('typing in the filter forwards `search` to the server query', async () => {
+  // F — the search is DEBOUNCED: the typed value reaches the server query (eventually),
+  // rather than firing one query per keystroke.
+  test('typing in the filter forwards the (debounced) `search` to the server query', async () => {
     renderWithProviders(<AppListingsModerationTable />);
     await page.getByTestId('apps-mod-listings-filter').fill('cool');
-    const lastInput = mocks.queryInput.mock.calls.at(-1)?.[0] as { search?: string };
-    expect(lastInput.search).toBe('cool');
+    await vi.waitFor(() => {
+      const lastInput = mocks.queryInput.mock.calls.at(-1)?.[0] as { search?: string };
+      expect(lastInput.search).toBe('cool');
+    });
+  });
+
+  // F — a filter change mid-pagination must reset the cursor SYNCHRONOUSLY, so no query
+  // ever fires pairing the OLD cursor with the NEW filter (the stale-cursor window).
+  test('changing a filter mid-pagination resets the cursor with no stale-cursor query', async () => {
+    mocks.paged = true;
+    renderWithProviders(<AppListingsModerationTable />);
+    // Page to cursor 'cur-2'.
+    await page.getByTestId('apps-mod-load-more').click();
+    await vi.waitFor(() => {
+      const withCursor = mocks.queryInput.mock.calls.find(([i]) => i?.cursor === 'cur-2');
+      expect(withCursor).toBeTruthy();
+    });
+    // Now change the status filter.
+    await page.getByRole('radio', { name: 'Removed' }).click();
+    // No query was ever fired with the OLD cursor AND the NEW status together.
+    const stale = mocks.queryInput.mock.calls.find(
+      ([i]) => i?.cursor === 'cur-2' && i?.status === 'removed'
+    );
+    expect(stale).toBeUndefined();
+    // The post-change query uses the NEW status with a CLEARED cursor.
+    await vi.waitFor(() => {
+      const last = mocks.queryInput.mock.calls.at(-1)?.[0] as { status?: string; cursor?: string };
+      expect(last.status).toBe('removed');
+      expect(last.cursor).toBeUndefined();
+    });
   });
 });
 
@@ -224,7 +301,7 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
     });
   });
 
-  test('Reset to pending forwards {appListingId, reason} (off-site only)', async () => {
+  test('Reset to pending on an OFF-SITE row forwards {appListingId, reason} to the offsite proc', async () => {
     renderWithProviders(<AppListingsModerationTable />);
     await page.getByTestId('apps-mod-reset-to-pending-alpha-live').click();
     await page.getByTestId('apps-mod-action-reason').fill('needs re-review');
@@ -233,6 +310,21 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
       appListingId: 'apl_a',
       reason: 'needs re-review',
     });
+  });
+
+  // Onsite reset UI wiring (#3165): an on-site approved row now offers Reset, and it
+  // must route to the ON-SITE proc (resetOnsiteListingToPending), NOT the off-site one.
+  test('Reset to pending on an ON-SITE row fires the ONSITE proc with {appListingId, reason}', async () => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await page.getByTestId('apps-mod-reset-to-pending-onsite-live').click();
+    await page.getByTestId('apps-mod-action-reason').fill('re-review this block');
+    await page.getByTestId('apps-mod-action-confirm').click();
+    expect(mocks.mutate).toHaveBeenCalledWith('resetOnsite', {
+      appListingId: 'apl_o',
+      reason: 're-review this block',
+    });
+    // And NOT the off-site reset proc.
+    expect(mocks.mutate).not.toHaveBeenCalledWith('reset', expect.anything());
   });
 
   // Relist is the SOLE recovery path for a mistaken takedown — a removed row must
@@ -285,10 +377,33 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
     expect(mocks.mutate).toHaveBeenCalledWith('purge', { appListingId: 'apl_r', reason: 'malware' });
   });
 
-  test('a reason under the 3-char floor keeps the confirm disabled', async () => {
+  test('a reason under the 3-char floor keeps the confirm disabled + shows the live counter', async () => {
     renderWithProviders(<AppListingsModerationTable />);
     await page.getByTestId('apps-mod-hide-alpha-live').click();
+    // The live counter is present from the empty state (matches the reject paths' UX).
+    await expect.element(page.getByText('0/3 characters minimum')).toBeInTheDocument();
     await page.getByTestId('apps-mod-action-reason').fill('ab');
+    await expect.element(page.getByText('2/3 characters minimum')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeDisabled();
+    // The inline too-short error surfaces once something is typed.
+    await expect.element(page.getByText('Enter at least 3 characters.')).toBeInTheDocument();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  // Finding A: EVERY post-approval action modal now carries the reason gate (counter +
+  // disabled-under-floor), not just the two reject paths. Cover each action's open→gate.
+  test.each([
+    ['reset-to-pending', 'alpha-live'],
+    ['hide', 'alpha-live'],
+    ['relist', 'gone-ext'],
+    ['claim', 'gone-ext'],
+    ['purge', 'gone-ext'],
+  ])('the %s action shows the counter and disables the confirm under the floor', async (action, slug) => {
+    renderWithProviders(<AppListingsModerationTable />);
+    await page.getByTestId(`apps-mod-${action}-${slug}`).click();
+    await expect.element(page.getByText('0/3 characters minimum')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeDisabled();
+    await page.getByTestId('apps-mod-action-reason').fill('xy');
     await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeDisabled();
     expect(mocks.mutate).not.toHaveBeenCalled();
   });
@@ -365,12 +480,29 @@ describe('AppListingsModerationTable — pagination, status filter + honest trun
   });
 });
 
-describe('AppListingsModerationTable — dark posture', () => {
-  test('renders nothing when the query errors (non-mod / flag off)', async () => {
+describe('AppListingsModerationTable — dark posture + error resilience (C)', () => {
+  test('renders nothing on an AUTHZ error (non-mod / flag off)', async () => {
     mocks.queryError = true;
+    mocks.queryErrorCode = 'FORBIDDEN';
     renderWithProviders(<AppListingsModerationTable />);
-    // The component returns null on a query error → none of its surface renders.
+    // The component returns null on an authz error → none of its surface renders.
     expect(page.getByTestId('apps-mod-listings-filter').elements()).toHaveLength(0);
     expect(page.getByTestId('apps-mod-listing-row-alpha-live').elements()).toHaveLength(0);
+    // Crucially NOT the transient-error retry Alert.
+    expect(page.getByTestId('apps-mod-listings-error').elements()).toHaveLength(0);
+  });
+
+  // A transient 500 / network blip must NOT silently blank the surface — it renders a
+  // retryable Alert (so a flaky load is recoverable, not indistinguishable from "not a mod").
+  test('a TRANSIENT (non-authz) error renders an Alert + a Retry that refetches', async () => {
+    mocks.queryError = true;
+    mocks.queryErrorCode = null; // → INTERNAL_SERVER_ERROR (non-authz)
+    renderWithProviders(<AppListingsModerationTable />);
+    await expect.element(page.getByTestId('apps-mod-listings-error')).toBeInTheDocument();
+    // The intended dark surface (filter/rows) is NOT rendered under an error.
+    expect(page.getByTestId('apps-mod-listings-filter').elements()).toHaveLength(0);
+    // Retry calls refetch().
+    await page.getByTestId('apps-mod-listings-error-retry').click();
+    expect(mocks.refetch).toHaveBeenCalled();
   });
 });

--- a/src/components/Apps/AppListingsModerationTable.browser.test.tsx
+++ b/src/components/Apps/AppListingsModerationTable.browser.test.tsx
@@ -70,6 +70,30 @@ const ROWS = [
 const PAGE1 = [offsite({ id: 'apl_a', slug: 'alpha-live', name: 'Alpha', status: 'approved' })];
 const PAGE2 = [offsite({ id: 'apl_z', slug: 'zebra-live', name: 'Zebra', status: 'approved' })];
 
+// D-stranding regression fixtures: page 1 is a FULL page (PAGE_SIZE=50) of on-site
+// pending rows (every one filtered out by D) but has a next cursor; page 2 has a
+// visible off-site row. Without the fix, page 1's empty post-filter set would render
+// the "No listings match" dead end and suppress Load-more → page 2 unreachable.
+const STRANDED_PAGE1 = Array.from({ length: 50 }, (_, i) =>
+  offsite({
+    id: `apl_sp_${i}`,
+    slug: `stranded-onsite-${i}`,
+    name: `Stranded ${i}`,
+    kind: 'onsite',
+    appBlockId: `ab_sp_${i}`,
+    status: 'pending',
+    pendingRequest: {
+      id: `alpr_sp_${i}`,
+      submittedAt: new Date('2026-01-01T00:00:00Z'),
+      changelog: null,
+      submittedBy: { id: 1, username: 'dev', image: null },
+    },
+  })
+);
+const STRANDED_PAGE2 = [
+  offsite({ id: 'apl_reach', slug: 'reachable-ext', name: 'Reachable', status: 'approved' }),
+];
+
 const mocks = vi.hoisted(() => ({
   invalidate: vi.fn().mockResolvedValue(undefined),
   mutate: vi.fn(),
@@ -81,6 +105,9 @@ const mocks = vi.hoisted(() => ({
   // error (render nothing).
   queryErrorCode: null as string | null,
   paged: false,
+  // D-stranding regression: page 1 is a FULL server page of on-site pending rows (all
+  // filtered out client-side) but a next cursor exists; page 2 carries a visible row.
+  strandedD: false,
 }));
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
@@ -133,6 +160,14 @@ vi.mock('~/utils/trpc', () => {
                 error,
                 refetch: mocks.refetch,
               };
+            }
+            if (mocks.strandedD) {
+              // Page 1: a full PAGE_SIZE page of on-site pending rows (all filtered by
+              // D) + a next cursor. Page 2: one visible off-site approved row, no cursor.
+              const data = input?.cursor
+                ? { items: STRANDED_PAGE2, nextCursor: null }
+                : { items: STRANDED_PAGE1, nextCursor: 'cur-2' };
+              return { data, isLoading: false, isFetching: false, error: null, refetch: mocks.refetch };
             }
             if (mocks.paged) {
               const data = input?.cursor
@@ -189,6 +224,7 @@ beforeEach(() => {
   mocks.queryError = false;
   mocks.queryErrorCode = null;
   mocks.paged = false;
+  mocks.strandedD = false;
   showError.mockClear();
 });
 
@@ -451,6 +487,24 @@ describe('AppListingsModerationTable — pagination, status filter + honest trun
     // Page 2 appended: BOTH rows now render, and Load-more is gone (nextCursor null).
     await expect.element(page.getByTestId('apps-mod-listing-row-zebra-live')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-mod-listing-row-alpha-live')).toBeInTheDocument();
+    expect(page.getByTestId('apps-mod-load-more').elements()).toHaveLength(0);
+  });
+
+  // D-stranding regression: a full server page of on-site pending rows (all filtered
+  // out by D) with a next cursor must STILL render Load-more — the empty post-filter
+  // page must not win the empty-state branch and strand the later (matching) pages.
+  test('a fully-filtered page with a next cursor still renders Load-more (D does not strand later pages)', async () => {
+    mocks.strandedD = true;
+    renderWithProviders(<AppListingsModerationTable />);
+    // Load-more IS present (a next cursor exists), even though the page rendered no rows.
+    await expect.element(page.getByTestId('apps-mod-load-more')).toBeInTheDocument();
+    // Page 1: every row filtered out → NO rows, and the dead-end empty state must NOT show.
+    expect(page.getByTestId('apps-mod-listing-row-stranded-onsite-0').elements()).toHaveLength(0);
+    expect(page.getByText('No listings match the current filters.').elements()).toHaveLength(0);
+
+    // Clicking it fetches page 2 → the previously-unreachable off-site row appears.
+    await page.getByTestId('apps-mod-load-more').click();
+    await expect.element(page.getByTestId('apps-mod-listing-row-reachable-ext')).toBeInTheDocument();
     expect(page.getByTestId('apps-mod-load-more').elements()).toHaveLength(0);
   });
 

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -5,21 +5,22 @@ import {
   Card,
   Code,
   Group,
-  Modal,
   NumberInput,
   SegmentedControl,
   Stack,
   Table,
   Text,
-  Textarea,
-  TextInput,
 } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
 import { IconAlertTriangle, IconBox, IconThumbUp } from '@tabler/icons-react';
-import { Fragment, useEffect, useMemo, useState } from 'react';
+import { keepPreviousData } from '@tanstack/react-query';
+import { Fragment, useMemo, useState } from 'react';
 import {
   OffsiteReviewModal,
   type OffsitePendingRow,
 } from '~/components/Apps/OffsiteReviewQueue';
+import { ModQueryError, isModAuthzError } from '~/components/Apps/ModQuerySurface';
+import { ReasonGatedActionModal } from '~/components/Apps/ReasonGatedActionModal';
 import { listingStatusChip } from '~/components/Apps/appListingModerationView';
 import {
   isDestructiveListingModAction,
@@ -138,40 +139,68 @@ export function AppListingsModerationTable() {
     row: ModerationListingRow;
   } | null>(null);
 
-  // A filter change = a NEW result set → reset pagination (don't append across it).
-  const trimmedSearch = search.trim();
-  const filterKey = `${statusFilter}|${kind}|${trimmedSearch}`;
-  useEffect(() => {
+  // A filter/search change = a NEW result set → reset pagination SYNCHRONOUSLY in the
+  // onChange handler (batched with the filter state change in the same React event) so
+  // there's no render where the OLD cursor is paired with the NEW filter — that stale
+  // window fired one query with a mismatched cursor. Search is DEBOUNCED so keystrokes
+  // don't storm the server; the raw `search` drives the input, `debouncedSearch` the
+  // query. Resetting on each keystroke keeps the debounced query cursor-clean.
+  const [debouncedSearch] = useDebouncedValue(search.trim(), 300);
+  const resetPaging = () => {
     setAccumulated([]);
     setCursor(undefined);
-  }, [filterKey]);
+  };
+  const onSearchChange = (value: string) => {
+    resetPaging();
+    setSearch(value);
+  };
+  const onKindChange = (value: KindFilter) => {
+    resetPaging();
+    setKind(value);
+  };
+  const onStatusChange = (value: StatusFilter) => {
+    resetPaging();
+    setStatusFilter(value);
+  };
 
   const query = trpc.appListings.listAllListingsForModeration.useQuery(
     {
       limit: PAGE_SIZE,
-      search: trimmedSearch || undefined,
+      search: debouncedSearch || undefined,
       kind: kind === 'all' ? undefined : kind,
       status: statusFilter === 'all' ? undefined : statusFilter,
       cursor,
     },
-    { enabled: !!features?.appBlocks, retry: false }
+    {
+      enabled: !!features?.appBlocks,
+      retry: false,
+      // Keep the last page visible WHILE the next one loads so the Load-more block
+      // (driven by `query.data.nextCursor`) doesn't unmount mid-fetch and flicker.
+      placeholderData: keepPreviousData,
+    }
   );
 
   // Reset to page 1 on a mutation (a listing's status/order may shift) + invalidate.
   const invalidate = () => {
-    setAccumulated([]);
-    setCursor(undefined);
+    resetPaging();
     return utils.appListings.listAllListingsForModeration.invalidate();
   };
 
   const page = (query.data?.items ?? []) as ModerationListingRow[];
   const nextCursor = query.data?.nextCursor ?? null;
 
-  // Merge the current page into the accumulated set (dedupe by id — defensive).
+  // Merge the current page into the accumulated set (dedupe by id — defensive), then
+  // drop on-site + pending rows: those live in the actionable on-site review FIFO queue
+  // (with a Review action); here they'd render as a dead-end `—`-action row. Off-site
+  // pending stays (it carries the Review action).
   const items = useMemo(() => {
-    if (!cursor) return page;
-    const seen = new Set(accumulated.map((r) => r.id));
-    return [...accumulated, ...page.filter((r) => !seen.has(r.id))];
+    const merged = !cursor
+      ? page
+      : (() => {
+          const seen = new Set(accumulated.map((r) => r.id));
+          return [...accumulated, ...page.filter((r) => !seen.has(r.id))];
+        })();
+    return merged.filter((r) => !(r.kind === 'onsite' && r.status === 'pending'));
   }, [accumulated, page, cursor]);
 
   // Group (one group per listing — the mod view isn't version-collapsed), apply the
@@ -185,9 +214,24 @@ export function AppListingsModerationTable() {
 
   const totalGroups = MOD_STATUS_SECTION_ORDER.reduce((n, b) => n + buckets[b].length, 0);
 
-  // The query errors when the caller isn't a mod / the flag is off → render nothing
-  // (unobtrusive, mirrors the sibling mod queues).
-  if (query.error) return null;
+  // Dark posture: the flag being off → render nothing (the query never runs). An
+  // AUTHZ error (a non-mod somehow reaching the moderatorProcedure) → also nothing.
+  // But a TRANSIENT error (500 / network) must NOT silently blank the whole surface —
+  // it renders a retryable Alert instead, so a flaky load isn't indistinguishable from
+  // "you're not a mod".
+  if (!features?.appBlocks) return null;
+  if (query.error) {
+    if (isModAuthzError(query.error)) return null;
+    return (
+      <ModQueryError
+        error={query.error}
+        onRetry={() => query.refetch()}
+        isRetrying={query.isFetching}
+        title="Couldn’t load listings"
+        testId="apps-mod-listings-error"
+      />
+    );
+  }
 
   const onSort = (column: SortColumn) =>
     setSort((s) => nextSortState(s ?? { column: 'app', direction: 'desc' }, column));
@@ -332,7 +376,7 @@ export function AppListingsModerationTable() {
       <Group justify="space-between" align="flex-end">
         <SubmissionSearch
           value={search}
-          onChange={setSearch}
+          onChange={onSearchChange}
           testId="apps-mod-listings-filter"
           placeholder="Filter by app name or slug…"
         />
@@ -340,14 +384,14 @@ export function AppListingsModerationTable() {
           <SegmentedControl
             size="xs"
             value={statusFilter}
-            onChange={(v) => setStatusFilter(v as StatusFilter)}
+            onChange={(v) => onStatusChange(v as StatusFilter)}
             data={STATUS_FILTER_OPTIONS}
             aria-label="Filter by status"
           />
           <SegmentedControl
             size="xs"
             value={kind}
-            onChange={(v) => setKind(v as KindFilter)}
+            onChange={(v) => onKindChange(v as KindFilter)}
             data={[
               { label: 'All', value: 'all' },
               { label: 'On-site', value: 'onsite' },
@@ -423,7 +467,12 @@ export function AppListingsModerationTable() {
  * The reason/confirm modal for a single lifecycle action (reset-to-pending / hide /
  * relist / claim / purge). Every action requires a reason (≥{@link
  * OFFSITE_MOD_REASON_MIN} chars, audited); `claim` also needs a numeric target
- * owner id; `purge` is destructive → an extra warning + a permanent confirm label.
+ * owner id; `purge` is destructive → an extra warning + a typed-slug confirm.
+ *
+ * The reason field + counter + inline error + disabled-with-Tooltip submit come from
+ * the shared {@link ReasonGatedActionModal} (identical UX to the reject paths). Reset
+ * routes by kind: an on-site listing calls `resetOnsiteListingToPending` (suspend +
+ * re-queue the block review, #3165), an off-site one `resetListingToPending`.
  */
 function ListingModActionModal({
   pending,
@@ -457,6 +506,11 @@ function ListingModActionModal({
     onSuccess: () => afterSuccess('Listing reset to pending.'),
     onError: onError('Reset failed'),
   });
+  // On-site reset routes through the block-review re-queue proc (#3165).
+  const resetOnsiteMut = trpc.appListings.resetOnsiteListingToPending.useMutation({
+    onSuccess: () => afterSuccess('Listing reset to pending.'),
+    onError: onError('Reset failed'),
+  });
   const delistMut = trpc.appListings.delistListing.useMutation({
     onSuccess: () => afterSuccess('Listing hidden.'),
     onError: onError('Hide failed'),
@@ -476,6 +530,7 @@ function ListingModActionModal({
 
   const busy =
     resetMut.isPending ||
+    resetOnsiteMut.isPending ||
     delistMut.isPending ||
     relistMut.isPending ||
     claimMut.isPending ||
@@ -488,18 +543,13 @@ function ListingModActionModal({
   const trimmed = reason.trim();
   const validTarget =
     typeof targetUserId === 'number' && Number.isInteger(targetUserId) && targetUserId > 0;
-  // Purge additionally requires the mod to type the exact listing slug (typed-confirm).
-  const confirmMatches = confirmText.trim() === row.slug;
-  const canSubmit =
-    !busy &&
-    trimmed.length >= OFFSITE_MOD_REASON_MIN &&
-    (!isClaim || validTarget) &&
-    (!destructive || confirmMatches);
 
   function submit() {
     switch (action) {
       case 'reset-to-pending':
-        return resetMut.mutate({ appListingId: row.id, reason: trimmed });
+        return row.kind === 'onsite'
+          ? resetOnsiteMut.mutate({ appListingId: row.id, reason: trimmed })
+          : resetMut.mutate({ appListingId: row.id, reason: trimmed });
       case 'hide':
         return delistMut.mutate({ appListingId: row.id, reason: trimmed });
       case 'relist':
@@ -520,46 +570,32 @@ function ListingModActionModal({
   }
 
   return (
-    <Modal
+    <ReasonGatedActionModal
       opened={!!pending}
-      onClose={() => {
-        if (busy) return;
-        reset();
-      }}
+      onCancel={reset}
+      busy={busy}
       title={
         <Text fw={600}>
           {listingModActionLabel(action)} — {row.slug}
         </Text>
       }
-      centered
-    >
-      <Stack gap="md">
-        {destructive && (
-          <>
-            <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
-              <Text size="sm">
-                Purge PERMANENTLY deletes this listing and its screenshots + reports. The audit
-                event (with the slug snapshot) is kept. This cannot be undone.
-              </Text>
-            </Alert>
-            <TextInput
-              label={
-                <Text size="sm">
-                  Type the slug <Code>{row.slug}</Code> to confirm
-                </Text>
-              }
-              placeholder={row.slug}
-              value={confirmText}
-              onChange={(e) => setConfirmText(e.currentTarget.value)}
-              disabled={busy}
-              error={
-                confirmText.length > 0 && !confirmMatches ? 'Does not match the slug' : undefined
-              }
-              data-testid="apps-mod-purge-confirm"
-            />
-          </>
-        )}
-        {isClaim && (
+      reason={reason}
+      onReasonChange={setReason}
+      reasonLabel={`Reason (≥${OFFSITE_MOD_REASON_MIN} chars, audited)`}
+      reasonTestId="apps-mod-action-reason"
+      destructive={destructive}
+      destructiveWarning={
+        <Text size="sm">
+          Purge PERMANENTLY deletes this listing and its screenshots + reports. The audit event
+          (with the slug snapshot) is kept. This cannot be undone.
+        </Text>
+      }
+      confirmSlug={destructive ? row.slug : undefined}
+      confirmValue={confirmText}
+      onConfirmChange={setConfirmText}
+      confirmTestId="apps-mod-purge-confirm"
+      extraSlot={
+        isClaim ? (
           <>
             <Alert color="blue" variant="light" icon={<IconAlertTriangle size={16} />}>
               <Text size="sm">
@@ -579,33 +615,13 @@ function ListingModActionModal({
               data-testid="apps-mod-claim-target"
             />
           </>
-        )}
-        <Textarea
-          label={`Reason (≥${OFFSITE_MOD_REASON_MIN} chars, audited)`}
-          autosize
-          minRows={3}
-          maxRows={8}
-          placeholder="Why this action — recorded in the audit trail."
-          value={reason}
-          onChange={(e) => setReason(e.currentTarget.value)}
-          disabled={busy}
-          data-testid="apps-mod-action-reason"
-        />
-        <Group justify="flex-end" gap="xs">
-          <Button variant="default" onClick={reset} disabled={busy}>
-            Cancel
-          </Button>
-          <Button
-            color={destructive ? 'red' : undefined}
-            onClick={submit}
-            disabled={!canSubmit}
-            loading={busy}
-            data-testid="apps-mod-action-confirm"
-          >
-            {destructive ? 'Purge permanently' : listingModActionLabel(action)}
-          </Button>
-        </Group>
-      </Stack>
-    </Modal>
+        ) : undefined
+      }
+      extraGateSatisfied={!isClaim || validTarget}
+      extraGateTooltip="Enter a valid new owner id."
+      submitLabel={destructive ? 'Purge permanently' : listingModActionLabel(action)}
+      submitTestId="apps-mod-action-confirm"
+      onSubmit={submit}
+    />
   );
 }

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -406,7 +406,11 @@ export function AppListingsModerationTable() {
         <Text size="sm" c="dimmed">
           Loading…
         </Text>
-      ) : totalGroups === 0 ? (
+      ) : totalGroups === 0 && !truncated ? (
+        // Genuinely empty ONLY when there's no next page. If a next cursor exists, the
+        // current post-filter page can be empty (e.g. a full server page of on-site
+        // pending rows filtered out by D) while later pages still hold matching rows —
+        // that case must fall through to render Load-more, never this dead end.
         <Card withBorder p="md">
           <Text size="sm" c="dimmed" ta="center" py="sm">
             No listings match the current filters.
@@ -416,8 +420,14 @@ export function AppListingsModerationTable() {
         <>
           <Group gap={6}>
             <Text size="xs" c="dimmed" data-testid="apps-mod-listings-count">
-              Showing {items.length}
-              {truncated ? '+ (more listings exist — Load more or narrow the filters)' : ''}.
+              {items.length === 0 && truncated ? (
+                <>No matching listings on this page — more exist, Load more to reach them.</>
+              ) : (
+                <>
+                  Showing {items.length}
+                  {truncated ? '+ (more listings exist — Load more or narrow the filters)' : ''}.
+                </>
+              )}
             </Text>
             {truncated && sort && (
               <Text size="xs" c="orange" data-testid="apps-mod-sort-partial-note">

--- a/src/components/Apps/ModQuerySurface.tsx
+++ b/src/components/Apps/ModQuerySurface.tsx
@@ -1,0 +1,69 @@
+import { Alert, Button, Group, Stack, Text } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import type { ReactNode } from 'react';
+
+/**
+ * Shared error handling for the DARK, mod-only App Blocks review surfaces
+ * (AppListingsModerationTable, OffsiteReviewQueue, OffsiteReportsQueue, the review
+ * page's active-previews panel). Every one gates its query on
+ * `enabled: !!features?.appBlocks` + `retry: false` and used to do a blanket
+ * `if (query.error) return null` — which correctly hides the surface for a non-mod
+ * (moderatorProcedure → UNAUTHORIZED/FORBIDDEN) but ALSO silently blanked the whole
+ * surface on a transient 500 / network blip, with no way to recover.
+ *
+ * {@link isModAuthzError} isolates the intended "render nothing" case (authz), so a
+ * caller can keep returning null for it while rendering {@link ModQueryError} (an
+ * Alert + a Retry that refetches) for everything else.
+ */
+
+/** A tRPC client error carries the server error code at `data.code`. */
+type MaybeTrpcError = { message?: string; data?: { code?: string } | null } | null | undefined;
+
+/** True for the AUTHZ codes a non-mod / unauthenticated caller hits — the ONLY case
+ *  a dark mod surface should silently render nothing for. */
+export function isModAuthzError(error: MaybeTrpcError): boolean {
+  const code = error?.data?.code;
+  return code === 'UNAUTHORIZED' || code === 'FORBIDDEN';
+}
+
+export function ModQueryError({
+  error,
+  onRetry,
+  isRetrying,
+  title = 'Couldn’t load',
+  testId,
+  mt = 'lg',
+}: {
+  error: MaybeTrpcError;
+  onRetry: () => void;
+  isRetrying?: boolean;
+  title?: ReactNode;
+  testId?: string;
+  mt?: string;
+}) {
+  return (
+    <Alert
+      color="red"
+      variant="light"
+      icon={<IconAlertTriangle size={16} />}
+      title={title}
+      mt={mt}
+      data-testid={testId}
+    >
+      <Stack gap="xs">
+        <Text size="sm">{error?.message ?? 'Something went wrong.'}</Text>
+        <Group>
+          <Button
+            size="xs"
+            variant="default"
+            onClick={onRetry}
+            loading={isRetrying}
+            data-testid={testId ? `${testId}-retry` : undefined}
+          >
+            Retry
+          </Button>
+        </Group>
+      </Stack>
+    </Alert>
+  );
+}

--- a/src/components/Apps/OffsiteReportsQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReportsQueue.browser.test.tsx
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * /apps/review reports queue — the `ReportActionModal` now routes its reason field +
+ * submit through the shared {@link ReasonGatedActionModal} (B3), so delist / relist /
+ * claim / purge get the SAME live counter + inline error + disabled-with-Tooltip gate
+ * the reject paths have (finding A). resolve / dismiss keep the OPTIONAL note (no gate).
+ * Browser-mode (report-only in Tekton): the gate + the fired mutations.
+ */
+
+const REPORT = {
+  id: 'rep-1',
+  appListingId: 'listing-9',
+  reason: 'impersonation',
+  details: 'copies another app',
+  status: 'pending',
+  createdAt: new Date('2026-01-01T00:00:00Z'),
+  resolvedAt: null,
+  reporter: { id: 5, username: 'reporter', image: null },
+  // `removed` listing → relist + claim + purge (+ resolve/dismiss for a pending report).
+  appListing: { slug: 'bad-app', name: 'Bad App', kind: 'offsite', status: 'removed' },
+};
+
+const mocks = vi.hoisted(() => ({
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  mutate: vi.fn(),
+  errorMode: false,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true }),
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+vi.mock('~/utils/trpc', () => {
+  const mutation =
+    (name: string) =>
+    (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
+      mutate: (vars: unknown) => {
+        mocks.mutate(name, vars);
+        if (mocks.errorMode) opts?.onError?.({ message: 'boom' });
+        else void opts?.onSuccess?.();
+      },
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+  return {
+    trpc: {
+      useUtils: () => ({
+        appListings: { listListingReports: { invalidate: mocks.invalidate } },
+      }),
+      appListings: {
+        listListingReports: {
+          useQuery: () => ({
+            data: { items: [REPORT], nextCursor: null },
+            isLoading: false,
+            isFetching: false,
+            error: null,
+            refetch: vi.fn(),
+          }),
+        },
+        listModerationEvents: {
+          useQuery: () => ({ data: { items: [] }, isLoading: false, error: null }),
+        },
+        delistListing: { useMutation: mutation('delist') },
+        relistListing: { useMutation: mutation('relist') },
+        claimListing: { useMutation: mutation('claim') },
+        purgeListing: { useMutation: mutation('purge') },
+        resolveReport: { useMutation: mutation('resolve') },
+        dismissReport: { useMutation: mutation('dismiss') },
+      },
+    },
+  };
+});
+
+const { OffsiteReportsQueue } = await import('./OffsiteReviewQueue');
+
+beforeEach(() => {
+  mocks.invalidate.mockClear();
+  mocks.mutate.mockClear();
+  mocks.errorMode = false;
+});
+
+describe('OffsiteReportsQueue — reason-gated report actions (finding A)', () => {
+  test('Relist shows the live counter + inline error, disables under the floor, then fires', async () => {
+    renderWithProviders(<OffsiteReportsQueue />);
+    await page.getByTestId('apps-report-relist-bad-app').click();
+    // The gate UX now matches the reject paths.
+    await expect.element(page.getByText('0/3 characters minimum')).toBeInTheDocument();
+    const confirm = page.getByTestId('apps-report-action-confirm');
+    await expect.element(confirm).toBeDisabled();
+
+    await page.getByTestId('apps-report-action-reason').fill('ab');
+    await expect.element(page.getByText('2/3 characters minimum')).toBeInTheDocument();
+    await expect.element(page.getByText('Enter at least 3 characters.')).toBeInTheDocument();
+    await expect.element(confirm).toBeDisabled();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+
+    await page.getByTestId('apps-report-action-reason').fill('takedown was wrong');
+    await expect.element(confirm).toBeEnabled();
+    await confirm.click();
+    expect(mocks.mutate).toHaveBeenCalledWith('relist', {
+      appListingId: 'listing-9',
+      reason: 'takedown was wrong',
+    });
+  });
+
+  test('Purge is destructive (red "Purge permanently"), counter-gated, then fires', async () => {
+    renderWithProviders(<OffsiteReportsQueue />);
+    await page.getByTestId('apps-report-purge-bad-app').click();
+    await expect.element(page.getByText('0/3 characters minimum')).toBeInTheDocument();
+    const confirm = page.getByTestId('apps-report-action-confirm');
+    await expect.element(confirm).toHaveTextContent('Purge permanently');
+    await expect.element(confirm).toBeDisabled();
+
+    await page.getByTestId('apps-report-action-reason').fill('malware payload');
+    await expect.element(confirm).toBeEnabled();
+    await confirm.click();
+    expect(mocks.mutate).toHaveBeenCalledWith('purge', {
+      appListingId: 'listing-9',
+      reason: 'malware payload',
+    });
+  });
+
+  test('Claim is gated on BOTH a valid target and a ≥3 reason', async () => {
+    renderWithProviders(<OffsiteReportsQueue />);
+    await page.getByTestId('apps-report-claim-bad-app').click();
+    const confirm = page.getByTestId('apps-report-action-confirm');
+    await expect.element(confirm).toBeDisabled();
+    // Reason alone (no target) stays disabled.
+    await page.getByTestId('apps-report-action-reason').fill('verified real owner');
+    await expect.element(confirm).toBeDisabled();
+    await page.getByTestId('apps-report-claim-target').fill('777');
+    await expect.element(confirm).toBeEnabled();
+    await confirm.click();
+    expect(mocks.mutate).toHaveBeenCalledWith('claim', {
+      appListingId: 'listing-9',
+      targetUserId: 777,
+      reason: 'verified real owner',
+      reportId: 'rep-1',
+    });
+  });
+
+  test('Resolve is an OPTIONAL note — enabled with no reason, no counter, fires resolveReport', async () => {
+    renderWithProviders(<OffsiteReportsQueue />);
+    await page.getByTestId('apps-report-resolve-bad-app').click();
+    // No reason floor for a note → no counter, and the confirm is immediately enabled.
+    expect(page.getByText('0/3 characters minimum').elements()).toHaveLength(0);
+    const confirm = page.getByTestId('apps-report-action-confirm');
+    await expect.element(confirm).toBeEnabled();
+    await confirm.click();
+    expect(mocks.mutate).toHaveBeenCalledWith('resolve', { reportId: 'rep-1', note: undefined });
+  });
+});

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -2,7 +2,6 @@ import {
   Alert,
   Anchor,
   Badge,
-  Box,
   Button,
   Card,
   Code,
@@ -19,7 +18,6 @@ import {
   Text,
   Textarea,
   ThemeIcon,
-  Tooltip,
 } from '@mantine/core';
 import {
   IconAlertTriangle,
@@ -32,6 +30,13 @@ import {
   IconX,
 } from '@tabler/icons-react';
 import { useState } from 'react';
+import { ModQueryError, isModAuthzError } from '~/components/Apps/ModQuerySurface';
+import {
+  ReasonGatedActionModal,
+  ReasonGatedField,
+  ReasonGatedSubmitButton,
+  reasonMeetsMin,
+} from '~/components/Apps/ReasonGatedActionModal';
 import { getOffsiteReviewChecklist } from '~/components/Apps/offsiteReviewChecklist';
 import { getReportReasonLabel } from '~/components/Apps/appListingReportView';
 import {
@@ -114,9 +119,21 @@ export function OffsiteReviewQueue() {
     { enabled: !!features?.appBlocks, retry: false }
   );
 
-  // Flag off / not enabled → the query errors (moderatorProcedure); render nothing
-  // so the section stays unobtrusive when off-site review isn't in use.
-  if (queue.error) return null;
+  // Dark posture: flag off → nothing. An AUTHZ error (non-mod) → nothing. But a
+  // TRANSIENT error must surface a retry rather than silently blank the section.
+  if (!features?.appBlocks) return null;
+  if (queue.error) {
+    if (isModAuthzError(queue.error)) return null;
+    return (
+      <ModQueryError
+        error={queue.error}
+        onRetry={() => queue.refetch()}
+        isRetrying={queue.isFetching}
+        title="Couldn’t load external submissions"
+        testId="apps-offsite-queue-error"
+      />
+    );
+  }
 
   const items = (queue.data?.items ?? []) as OffsitePendingRow[];
 
@@ -494,65 +511,37 @@ export function OffsiteReviewModal({
         )}
 
         {actionMode === 'reject' ? (
-          (() => {
-            const reasonLen = rejectionReason.trim().length;
-            const reasonTooShort = reasonLen < OFFSITE_MOD_REASON_MIN;
-            const rejectDisabled = busy || reasonTooShort;
-            return (
-              <Stack gap="xs">
-                <Text size="sm" fw={600}>
-                  Rejection reason
-                </Text>
-                <Textarea
-                  autosize
-                  minRows={3}
-                  maxRows={10}
-                  placeholder={`Explain what needs to change (≥${OFFSITE_MOD_REASON_MIN} chars, shown to the author).`}
-                  description={`${reasonLen}/${OFFSITE_MOD_REASON_MIN} characters minimum`}
-                  error={
-                    reasonTooShort && reasonLen > 0
-                      ? `Enter at least ${OFFSITE_MOD_REASON_MIN} characters.`
-                      : undefined
-                  }
-                  value={rejectionReason}
-                  onChange={(e) => setRejectionReason(e.currentTarget.value)}
-                  disabled={busy}
-                  data-testid="apps-offsite-reject-reason"
-                />
-                <Group justify="flex-end" gap="xs">
-                  <Button variant="default" onClick={() => setActionMode('view')} disabled={busy}>
-                    Cancel
-                  </Button>
-                  <Tooltip
-                    label={`Enter a reason — at least ${OFFSITE_MOD_REASON_MIN} characters.`}
-                    disabled={!reasonTooShort}
-                    withArrow
-                  >
-                    {/* A native disabled <button> fires no pointer events, so the
-                        Tooltip must attach to a wrapper to show in the exact state
-                        it explains (Mantine's documented disabled-target pattern). */}
-                    <Box>
-                      <Button
-                        color="red"
-                        leftSection={<IconX size={14} />}
-                        onClick={() =>
-                          rejectMut.mutate({
-                            publishRequestId: request.id,
-                            rejectionReason: rejectionReason.trim(),
-                          })
-                        }
-                        disabled={rejectDisabled}
-                        loading={rejectMut.isPending}
-                        data-testid="apps-offsite-reject-confirm"
-                      >
-                        Reject
-                      </Button>
-                    </Box>
-                  </Tooltip>
-                </Group>
-              </Stack>
-            );
-          })()
+          <Stack gap="xs">
+            <ReasonGatedField
+              value={rejectionReason}
+              onChange={setRejectionReason}
+              disabled={busy}
+              label="Rejection reason"
+              placeholder={`Explain what needs to change (≥${OFFSITE_MOD_REASON_MIN} chars, shown to the author).`}
+              testId="apps-offsite-reject-reason"
+              minRows={3}
+              maxRows={10}
+            />
+            <Group justify="flex-end" gap="xs">
+              <Button variant="default" onClick={() => setActionMode('view')} disabled={busy}>
+                Cancel
+              </Button>
+              <ReasonGatedSubmitButton
+                onClick={() =>
+                  rejectMut.mutate({
+                    publishRequestId: request.id,
+                    rejectionReason: rejectionReason.trim(),
+                  })
+                }
+                gateOpen={reasonMeetsMin(rejectionReason)}
+                busy={rejectMut.isPending}
+                color="red"
+                leftSection={<IconX size={14} />}
+                label="Reject"
+                testId="apps-offsite-reject-confirm"
+              />
+            </Group>
+          </Stack>
         ) : actionMode === 'approve' ? (
           <Stack gap="xs">
             <Select
@@ -672,8 +661,20 @@ export function OffsiteReportsQueue() {
     { enabled: !!features?.appBlocks, retry: false }
   );
 
-  // Flag off / not a mod → the query errors (moderatorProcedure); render nothing.
-  if (queue.error) return null;
+  // Dark posture: flag off / non-mod → nothing; a transient error → a retry Alert.
+  if (!features?.appBlocks) return null;
+  if (queue.error) {
+    if (isModAuthzError(queue.error)) return null;
+    return (
+      <ModQueryError
+        error={queue.error}
+        onRetry={() => queue.refetch()}
+        isRetrying={queue.isFetching}
+        title="Couldn’t load reports"
+        testId="apps-reports-queue-error"
+      />
+    );
+  }
 
   const items = (queue.data?.items ?? []) as ReportRow[];
 
@@ -891,12 +892,15 @@ function ReportActionModal({
   const reasonRequired =
     action === 'delist' || action === 'relist' || action === 'claim' || action === 'purge';
   const isClaim = action === 'claim';
+  const destructive = isDestructiveAction(action);
   const trimmed = text.trim();
   const validTarget = typeof targetUserId === 'number' && Number.isInteger(targetUserId) && targetUserId > 0;
-  const canSubmit =
-    !busy &&
-    (!reasonRequired || trimmed.length >= OFFSITE_MOD_REASON_MIN) &&
-    (!isClaim || validTarget);
+
+  function reset() {
+    setText('');
+    setTargetUserId('');
+    onClose();
+  }
 
   function submit() {
     switch (action) {
@@ -930,14 +934,10 @@ function ReportActionModal({
   }
 
   return (
-    <Modal
+    <ReasonGatedActionModal
       opened={!!pending}
-      onClose={() => {
-        if (busy) return;
-        setText('');
-        setTargetUserId('');
-        onClose();
-      }}
+      onCancel={reset}
+      busy={busy}
       title={
         <Group gap={6}>
           <Text fw={600}>
@@ -945,18 +945,27 @@ function ReportActionModal({
           </Text>
         </Group>
       }
-      centered
-    >
-      <Stack gap="md">
-        {isDestructiveAction(action) && (
-          <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
-            <Text size="sm">
-              Purge PERMANENTLY deletes this listing and its screenshots + reports. The audit event
-              (with the slug snapshot) is kept. This cannot be undone.
-            </Text>
-          </Alert>
-        )}
-        {isClaim && (
+      reason={text}
+      onReasonChange={setText}
+      reasonRequired={reasonRequired}
+      reasonLabel={
+        reasonRequired ? `Reason (≥${OFFSITE_MOD_REASON_MIN} chars, audited)` : 'Note (optional)'
+      }
+      reasonPlaceholder={
+        reasonRequired
+          ? 'Why this action — recorded in the audit trail.'
+          : 'Optional resolution note (audited).'
+      }
+      reasonTestId="apps-report-action-reason"
+      destructive={destructive}
+      destructiveWarning={
+        <Text size="sm">
+          Purge PERMANENTLY deletes this listing and its screenshots + reports. The audit event
+          (with the slug snapshot) is kept. This cannot be undone.
+        </Text>
+      }
+      extraSlot={
+        isClaim ? (
           <>
             <Alert color="blue" variant="light" icon={<IconAlertTriangle size={16} />}>
               <Text size="sm">
@@ -976,46 +985,14 @@ function ReportActionModal({
               data-testid="apps-report-claim-target"
             />
           </>
-        )}
-        <Textarea
-          label={reasonRequired ? `Reason (≥${OFFSITE_MOD_REASON_MIN} chars, audited)` : 'Note (optional)'}
-          autosize
-          minRows={3}
-          maxRows={8}
-          placeholder={
-            reasonRequired
-              ? 'Why this action — recorded in the audit trail.'
-              : 'Optional resolution note (audited).'
-          }
-          value={text}
-          onChange={(e) => setText(e.currentTarget.value)}
-          disabled={busy}
-          data-testid="apps-report-action-reason"
-        />
-        <Group justify="flex-end" gap="xs">
-          <Button
-            variant="default"
-            onClick={() => {
-              setText('');
-              setTargetUserId('');
-              onClose();
-            }}
-            disabled={busy}
-          >
-            Cancel
-          </Button>
-          <Button
-            color={isDestructiveAction(action) ? 'red' : undefined}
-            onClick={submit}
-            disabled={!canSubmit}
-            loading={busy}
-            data-testid="apps-report-action-confirm"
-          >
-            {isDestructiveAction(action) ? 'Purge permanently' : reportActionLabel(action)}
-          </Button>
-        </Group>
-      </Stack>
-    </Modal>
+        ) : undefined
+      }
+      extraGateSatisfied={!isClaim || validTarget}
+      extraGateTooltip="Enter a valid new owner id."
+      submitLabel={destructive ? 'Purge permanently' : reportActionLabel(action)}
+      submitTestId="apps-report-action-confirm"
+      onSubmit={submit}
+    />
   );
 }
 

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -2,7 +2,6 @@ import {
   Accordion,
   Alert,
   Badge,
-  Box,
   Button,
   Card,
   Code,
@@ -38,6 +37,11 @@ import {
   ManifestDiffPreview,
   type FileLineDiff,
 } from '~/components/Apps/reviewDiffPanels';
+import {
+  ReasonGatedField,
+  ReasonGatedSubmitButton,
+  reasonMeetsMin,
+} from '~/components/Apps/ReasonGatedActionModal';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
 import {
@@ -394,65 +398,37 @@ export function OnsiteReviewModal({
         </Stack>
 
         {readOnly ? null : actionMode === 'reject' ? (
-          (() => {
-            const reasonLen = rejectionReason.trim().length;
-            const reasonTooShort = reasonLen < OFFSITE_MOD_REASON_MIN;
-            const rejectDisabled = busy || reasonTooShort;
-            return (
-              <Stack gap="xs">
-                <Text size="sm" fw={600}>
-                  Rejection reason
-                </Text>
-                <Textarea
-                  autosize
-                  minRows={3}
-                  maxRows={10}
-                  placeholder={`Explain what needs to change before this can be approved (≥${OFFSITE_MOD_REASON_MIN} chars, shown to the dev).`}
-                  description={`${reasonLen}/${OFFSITE_MOD_REASON_MIN} characters minimum`}
-                  error={
-                    reasonTooShort && reasonLen > 0
-                      ? `Enter at least ${OFFSITE_MOD_REASON_MIN} characters.`
-                      : undefined
-                  }
-                  value={rejectionReason}
-                  onChange={(e) => setRejectionReason(e.currentTarget.value)}
-                  disabled={busy}
-                  data-testid="apps-review-reject-reason"
-                />
-                <Group justify="flex-end" gap="xs">
-                  <Button variant="default" onClick={() => setActionMode('view')} disabled={busy}>
-                    Cancel
-                  </Button>
-                  <Tooltip
-                    label={`Enter a reason — at least ${OFFSITE_MOD_REASON_MIN} characters.`}
-                    disabled={!reasonTooShort}
-                    withArrow
-                  >
-                    {/* A native disabled <button> fires no pointer events, so the
-                        Tooltip must attach to a wrapper to show in the exact state
-                        it explains (Mantine's documented disabled-target pattern). */}
-                    <Box>
-                      <Button
-                        color="red"
-                        leftSection={<IconX size={14} />}
-                        onClick={() =>
-                          rejectMut.mutate({
-                            publishRequestId: request.id,
-                            rejectionReason: rejectionReason.trim(),
-                          })
-                        }
-                        disabled={rejectDisabled}
-                        loading={rejectMut.isPending}
-                        data-testid="apps-review-reject-confirm"
-                      >
-                        Reject
-                      </Button>
-                    </Box>
-                  </Tooltip>
-                </Group>
-              </Stack>
-            );
-          })()
+          <Stack gap="xs">
+            <ReasonGatedField
+              value={rejectionReason}
+              onChange={setRejectionReason}
+              disabled={busy}
+              label="Rejection reason"
+              placeholder={`Explain what needs to change before this can be approved (≥${OFFSITE_MOD_REASON_MIN} chars, shown to the dev).`}
+              testId="apps-review-reject-reason"
+              minRows={3}
+              maxRows={10}
+            />
+            <Group justify="flex-end" gap="xs">
+              <Button variant="default" onClick={() => setActionMode('view')} disabled={busy}>
+                Cancel
+              </Button>
+              <ReasonGatedSubmitButton
+                onClick={() =>
+                  rejectMut.mutate({
+                    publishRequestId: request.id,
+                    rejectionReason: rejectionReason.trim(),
+                  })
+                }
+                gateOpen={reasonMeetsMin(rejectionReason)}
+                busy={rejectMut.isPending}
+                color="red"
+                leftSection={<IconX size={14} />}
+                label="Reject"
+                testId="apps-review-reject-confirm"
+              />
+            </Group>
+          </Stack>
         ) : (
           <Stack gap="xs">
             <Textarea

--- a/src/components/Apps/ReasonGatedActionModal.browser.test.tsx
+++ b/src/components/Apps/ReasonGatedActionModal.browser.test.tsx
@@ -1,0 +1,180 @@
+import { NumberInput } from '@mantine/core';
+import { useState } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import {
+  ReasonGatedActionModal,
+  ReasonGatedField,
+  ReasonGatedSubmitButton,
+  reasonGateTooltip,
+  reasonMeetsMin,
+} from './ReasonGatedActionModal';
+
+/**
+ * The shared reason-gated primitives (B3) that back EVERY App Blocks moderator
+ * reason-required action. Browser-mode (report-only in Tekton): the live counter +
+ * the inline too-short error at the floor boundary; the disabled-with-Tooltip submit;
+ * and the full modal's typed-slug (purge) + extra-input (claim) gates.
+ */
+
+describe('reasonMeetsMin', () => {
+  test('floors on the trimmed length', () => {
+    expect(reasonMeetsMin('')).toBe(false);
+    expect(reasonMeetsMin('ab')).toBe(false);
+    expect(reasonMeetsMin('  a  ')).toBe(false); // trimmed → 1 char
+    expect(reasonMeetsMin('abc')).toBe(true);
+    expect(reasonMeetsMin('ab', 2)).toBe(true);
+  });
+});
+
+function FieldHarness({ required = true }: { required?: boolean }) {
+  const [v, setV] = useState('');
+  return <ReasonGatedField value={v} onChange={setV} required={required} testId="rg-field" />;
+}
+
+describe('ReasonGatedField — counter + inline error at the floor boundary', () => {
+  test('empty → neutral counter, no error; under floor → counter + error; at floor → error clears', async () => {
+    renderWithProviders(<FieldHarness />);
+    await expect.element(page.getByText('0/3 characters minimum')).toBeInTheDocument();
+    // Empty is neutral (no red error yet).
+    expect(page.getByText('Enter at least 3 characters.').elements()).toHaveLength(0);
+
+    await page.getByTestId('rg-field').fill('ab');
+    await expect.element(page.getByText('2/3 characters minimum')).toBeInTheDocument();
+    await expect.element(page.getByText('Enter at least 3 characters.')).toBeInTheDocument();
+
+    await page.getByTestId('rg-field').fill('abc');
+    await expect.element(page.getByText('3/3 characters minimum')).toBeInTheDocument();
+    expect(page.getByText('Enter at least 3 characters.').elements()).toHaveLength(0);
+  });
+
+  test('an OPTIONAL note has no counter/floor/error', async () => {
+    renderWithProviders(<FieldHarness required={false} />);
+    await expect.element(page.getByTestId('rg-field')).toBeInTheDocument();
+    expect(page.getByText('0/3 characters minimum').elements()).toHaveLength(0);
+    await page.getByTestId('rg-field').fill('x');
+    expect(page.getByText('Enter at least 3 characters.').elements()).toHaveLength(0);
+  });
+});
+
+describe('ReasonGatedSubmitButton — disabled-with-Tooltip', () => {
+  test('closed gate → disabled + the hint surfaces on hover', async () => {
+    const onClick = vi.fn();
+    renderWithProviders(
+      <ReasonGatedSubmitButton onClick={onClick} gateOpen={false} label="Go" testId="rg-submit" />
+    );
+    const btn = page.getByTestId('rg-submit');
+    await expect.element(btn).toBeDisabled();
+    await btn.hover();
+    await expect.element(page.getByText(reasonGateTooltip())).toBeInTheDocument();
+  });
+
+  test('open gate → enabled + fires', async () => {
+    const onClick = vi.fn();
+    renderWithProviders(
+      <ReasonGatedSubmitButton onClick={onClick} gateOpen label="Go" testId="rg-submit2" />
+    );
+    const btn = page.getByTestId('rg-submit2');
+    await expect.element(btn).toBeEnabled();
+    await btn.click();
+    expect(onClick).toHaveBeenCalled();
+  });
+});
+
+function PurgeHarness({ onSubmit }: { onSubmit: () => void }) {
+  const [reason, setReason] = useState('');
+  const [confirm, setConfirm] = useState('');
+  return (
+    <ReasonGatedActionModal
+      opened
+      onCancel={vi.fn()}
+      title="Purge — my-slug"
+      reason={reason}
+      onReasonChange={setReason}
+      reasonTestId="rg-modal-reason"
+      destructive
+      confirmSlug="my-slug"
+      confirmValue={confirm}
+      onConfirmChange={setConfirm}
+      confirmTestId="rg-modal-purge"
+      submitLabel="Purge permanently"
+      submitTestId="rg-modal-confirm"
+      onSubmit={onSubmit}
+    />
+  );
+}
+
+function ClaimHarness({ onSubmit }: { onSubmit: () => void }) {
+  const [reason, setReason] = useState('');
+  const [target, setTarget] = useState<number | ''>('');
+  const valid = typeof target === 'number' && target > 0;
+  return (
+    <ReasonGatedActionModal
+      opened
+      onCancel={vi.fn()}
+      title="Claim — my-slug"
+      reason={reason}
+      onReasonChange={setReason}
+      reasonTestId="rg-modal-reason"
+      extraSlot={
+        <NumberInput
+          label="New owner user id"
+          value={target}
+          onChange={(v) => setTarget(typeof v === 'number' ? v : '')}
+          data-testid="rg-modal-target"
+        />
+      }
+      extraGateSatisfied={valid}
+      extraGateTooltip="Enter a valid new owner id."
+      submitLabel="Claim"
+      submitTestId="rg-modal-confirm"
+      onSubmit={onSubmit}
+    />
+  );
+}
+
+describe('ReasonGatedActionModal — composed gates', () => {
+  test('purge needs BOTH the reason floor AND the exact typed slug', async () => {
+    const onSubmit = vi.fn();
+    renderWithProviders(<PurgeHarness onSubmit={onSubmit} />);
+    const confirm = page.getByTestId('rg-modal-confirm');
+    await expect.element(confirm).toBeDisabled();
+
+    // Reason alone is not enough.
+    await page.getByTestId('rg-modal-reason').fill('malware');
+    await expect.element(confirm).toBeDisabled();
+    // Hover explains the remaining (typed-slug) gate.
+    await confirm.hover();
+    await expect.element(page.getByText('Type the slug to confirm.')).toBeInTheDocument();
+
+    // A wrong slug keeps it disabled.
+    await page.getByTestId('rg-modal-purge').fill('nope');
+    await expect.element(confirm).toBeDisabled();
+
+    // The exact slug enables it → fires.
+    await page.getByTestId('rg-modal-purge').fill('my-slug');
+    await expect.element(confirm).toBeEnabled();
+    await confirm.click();
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  test('claim needs BOTH the reason floor AND a valid target (extra gate)', async () => {
+    const onSubmit = vi.fn();
+    renderWithProviders(<ClaimHarness onSubmit={onSubmit} />);
+    const confirm = page.getByTestId('rg-modal-confirm');
+    await expect.element(confirm).toBeDisabled();
+
+    await page.getByTestId('rg-modal-reason').fill('verified owner');
+    // Reason met but target invalid → still disabled; hover explains the extra gate.
+    await expect.element(confirm).toBeDisabled();
+    await confirm.hover();
+    await expect.element(page.getByText('Enter a valid new owner id.')).toBeInTheDocument();
+
+    await page.getByTestId('rg-modal-target').fill('555');
+    await expect.element(confirm).toBeEnabled();
+    await confirm.click();
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});

--- a/src/components/Apps/ReasonGatedActionModal.tsx
+++ b/src/components/Apps/ReasonGatedActionModal.tsx
@@ -1,0 +1,261 @@
+import { Alert, Box, Button, Code, Group, Modal, Stack, Text, Textarea, TextInput, Tooltip } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import type { ReactNode } from 'react';
+import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
+
+/**
+ * Shared reason-gated action UI (App Blocks moderator surfaces). BEFORE this, four
+ * separate modals hand-rolled the "reason textarea + ≥{@link OFFSITE_MOD_REASON_MIN}
+ * gate + disabled submit" pattern, and only the two REJECT paths got the #3154 UX
+ * (a live `N/min` counter, an inline "too short" error, and a disabled-with-Tooltip
+ * submit). The post-approval action modals (reset / hide / relist / claim / purge)
+ * showed only a static label + a dead greyed button.
+ *
+ * These primitives give EVERY reason-required action the same feedback:
+ *  - {@link ReasonGatedField} — the reason textarea + the live counter + the inline
+ *    too-short error (the counter/error are suppressed for an OPTIONAL note).
+ *  - {@link ReasonGatedSubmitButton} — the submit button wrapped in a disabled
+ *    Tooltip (Mantine's documented Box-wrapper pattern, since a native disabled
+ *    `<button>` fires no pointer events) that explains the closed gate on hover.
+ *  - {@link ReasonGatedActionModal} — the full single-action modal composing both,
+ *    plus optional slots for a claim-target input and the destructive typed-slug
+ *    purge confirm. Consumed by the mgmt-table + reports-queue action modals.
+ *
+ * The two inline reject panels (OnsiteReviewModal / OffsiteReviewModal) live INSIDE
+ * a larger review modal, so they consume the two atoms directly rather than the
+ * whole modal shell. Mutation wiring/semantics stay with each caller — this is a
+ * UX-consistency + dedup layer, not a behaviour change to the actions.
+ */
+
+/** The default hover hint for the disabled reason gate (matches the #3154 reject copy). */
+export function reasonGateTooltip(minLength: number = OFFSITE_MOD_REASON_MIN): string {
+  return `Enter a reason — at least ${minLength} characters.`;
+}
+
+/** Whether a reason value clears the minimum-length floor (trimmed). */
+export function reasonMeetsMin(value: string, minLength: number = OFFSITE_MOD_REASON_MIN): boolean {
+  return value.trim().length >= minLength;
+}
+
+export function ReasonGatedField({
+  value,
+  onChange,
+  disabled,
+  minLength = OFFSITE_MOD_REASON_MIN,
+  required = true,
+  label,
+  placeholder,
+  testId,
+  minRows = 3,
+  maxRows = 8,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  disabled?: boolean;
+  minLength?: number;
+  /** When false, this is an OPTIONAL note — no counter, no floor, no inline error. */
+  required?: boolean;
+  label?: ReactNode;
+  placeholder?: string;
+  testId?: string;
+  minRows?: number;
+  maxRows?: number;
+}) {
+  const len = value.trim().length;
+  const tooShort = required && len < minLength;
+  return (
+    <Textarea
+      label={label}
+      autosize
+      minRows={minRows}
+      maxRows={maxRows}
+      placeholder={placeholder}
+      // Live counter — only meaningful when a floor applies.
+      description={required ? `${len}/${minLength} characters minimum` : undefined}
+      // Inline error once the mod has typed SOMETHING but not enough (an empty field
+      // shows the neutral counter, not a red error).
+      error={tooShort && len > 0 ? `Enter at least ${minLength} characters.` : undefined}
+      value={value}
+      onChange={(e) => onChange(e.currentTarget.value)}
+      disabled={disabled}
+      data-testid={testId}
+    />
+  );
+}
+
+export function ReasonGatedSubmitButton({
+  onClick,
+  gateOpen,
+  busy,
+  label,
+  color,
+  leftSection,
+  tooltipLabel,
+  testId,
+}: {
+  onClick: () => void;
+  /** The full gate (reason + any extra inputs). When false the Tooltip shows. */
+  gateOpen: boolean;
+  busy?: boolean;
+  label: ReactNode;
+  color?: string;
+  leftSection?: ReactNode;
+  tooltipLabel?: string;
+  testId?: string;
+}) {
+  return (
+    <Tooltip label={tooltipLabel ?? reasonGateTooltip()} disabled={gateOpen} withArrow>
+      {/* A native disabled <button> fires no pointer events, so the Tooltip attaches
+          to a wrapper to show in the exact disabled state it explains. */}
+      <Box>
+        <Button
+          color={color}
+          leftSection={leftSection}
+          onClick={onClick}
+          disabled={busy || !gateOpen}
+          loading={busy}
+          data-testid={testId}
+        >
+          {label}
+        </Button>
+      </Box>
+    </Tooltip>
+  );
+}
+
+export function ReasonGatedActionModal({
+  opened,
+  onCancel,
+  title,
+  busy,
+  reason,
+  onReasonChange,
+  reasonRequired = true,
+  minLength = OFFSITE_MOD_REASON_MIN,
+  reasonLabel,
+  reasonPlaceholder = 'Why this action — recorded in the audit trail.',
+  reasonTestId,
+  destructive = false,
+  destructiveWarning,
+  /** When a non-empty string, render the typed-slug purge confirm and gate on an
+   *  exact match. Undefined/empty → no typed-slug confirm (e.g. the reports queue). */
+  confirmSlug,
+  confirmValue = '',
+  onConfirmChange,
+  confirmTestId,
+  /** Extra content (e.g. a claim target-owner input + its notice) rendered above the reason. */
+  extraSlot,
+  /** An additional gate condition (e.g. a valid claim target). Defaults to satisfied. */
+  extraGateSatisfied = true,
+  extraGateTooltip,
+  submitLabel,
+  submitTestId,
+  onSubmit,
+}: {
+  opened: boolean;
+  onCancel: () => void;
+  title: ReactNode;
+  busy?: boolean;
+  reason: string;
+  onReasonChange: (value: string) => void;
+  reasonRequired?: boolean;
+  minLength?: number;
+  reasonLabel?: ReactNode;
+  reasonPlaceholder?: string;
+  reasonTestId?: string;
+  destructive?: boolean;
+  destructiveWarning?: ReactNode;
+  confirmSlug?: string | null;
+  confirmValue?: string;
+  onConfirmChange?: (value: string) => void;
+  confirmTestId?: string;
+  extraSlot?: ReactNode;
+  extraGateSatisfied?: boolean;
+  extraGateTooltip?: string;
+  submitLabel: ReactNode;
+  submitTestId?: string;
+  onSubmit: () => void;
+}) {
+  const reasonMet = !reasonRequired || reasonMeetsMin(reason, minLength);
+  const hasTypedConfirm = !!confirmSlug;
+  const confirmMatches = !hasTypedConfirm || confirmValue.trim() === confirmSlug;
+  const gateOpen = reasonMet && extraGateSatisfied && confirmMatches;
+
+  // Explain the FIRST unmet gate on hover (reason floor is the most common).
+  const tooltipLabel = !reasonMet
+    ? reasonGateTooltip(minLength)
+    : !extraGateSatisfied
+    ? extraGateTooltip ?? 'Complete the required fields.'
+    : !confirmMatches
+    ? `Type the slug to confirm.`
+    : undefined;
+
+  return (
+    <Modal
+      opened={opened}
+      onClose={() => {
+        if (busy) return;
+        onCancel();
+      }}
+      title={title}
+      centered
+    >
+      <Stack gap="md">
+        {destructive && (
+          <>
+            <Alert color="red" variant="light" icon={<IconAlertTriangle size={16} />}>
+              {destructiveWarning ?? (
+                <Text size="sm">
+                  This PERMANENTLY deletes the listing and its screenshots + reports. The audit
+                  event (with the slug snapshot) is kept. This cannot be undone.
+                </Text>
+              )}
+            </Alert>
+            {hasTypedConfirm && (
+              <TextInput
+                label={
+                  <Text size="sm">
+                    Type the slug <Code>{confirmSlug}</Code> to confirm
+                  </Text>
+                }
+                placeholder={confirmSlug ?? undefined}
+                value={confirmValue}
+                onChange={(e) => onConfirmChange?.(e.currentTarget.value)}
+                disabled={busy}
+                error={
+                  confirmValue.length > 0 && !confirmMatches ? 'Does not match the slug' : undefined
+                }
+                data-testid={confirmTestId}
+              />
+            )}
+          </>
+        )}
+        {extraSlot}
+        <ReasonGatedField
+          value={reason}
+          onChange={onReasonChange}
+          disabled={busy}
+          required={reasonRequired}
+          minLength={minLength}
+          label={reasonLabel}
+          placeholder={reasonPlaceholder}
+          testId={reasonTestId}
+        />
+        <Group justify="flex-end" gap="xs">
+          <Button variant="default" onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+          <ReasonGatedSubmitButton
+            onClick={onSubmit}
+            gateOpen={gateOpen}
+            busy={busy}
+            color={destructive ? 'red' : undefined}
+            label={submitLabel}
+            tooltipLabel={tooltipLabel}
+            testId={submitTestId}
+          />
+        </Group>
+      </Stack>
+    </Modal>
+  );
+}

--- a/src/components/Apps/__tests__/appListingModerationTableView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationTableView.test.ts
@@ -12,8 +12,8 @@ import {
  * W13 post-approval mgmt (P2) — the mod management-table action view model. The
  * blocking correctness gate for the KIND-AWARE per-row action set (the browser
  * suite is report-only). Pins: which actions each status offers, and that the
- * off-site-only actions (reset-to-pending / claim / purge / review) NEVER appear
- * on an on-site row while the dual-kind ones (hide / relist) do.
+ * off-site-only actions (claim / purge / review) NEVER appear on an on-site row
+ * while the dual-kind ones (reset-to-pending / hide / relist) do.
  */
 
 describe('listingModActions — off-site rows', () => {
@@ -52,10 +52,10 @@ describe('listingModActions — off-site rows', () => {
 });
 
 describe('listingModActions — on-site rows hide the off-site-only actions', () => {
-  it('approved on-site → Hide ONLY (no reset-to-pending)', () => {
+  it('approved on-site → Reset to pending + Hide (reset is now dual-kind, #3165)', () => {
     expect(
       listingModActions({ status: 'approved', kind: 'onsite', hasPendingRequest: false })
-    ).toEqual(['hide']);
+    ).toEqual(['reset-to-pending', 'hide']);
   });
 
   it('removed on-site → Relist ONLY (no claim / purge)', () => {

--- a/src/components/Apps/appListingModerationTableView.ts
+++ b/src/components/Apps/appListingModerationTableView.ts
@@ -6,9 +6,13 @@
  * `unit` project (the civitai browser-mode suites are report-only), mirroring the
  * sibling `appListingModerationView` (the report-queue view model).
  *
- * KIND-AWARENESS (from the merged Phase 1 procs):
- *   - `reset-to-pending` / `claim` / `purge` are OFF-SITE ONLY (the service raises
- *     NOT_FOUND for an on-site listing).
+ * KIND-AWARENESS (from the merged Phase 1 procs + the #3165 onsite reset backend):
+ *   - `reset-to-pending` is DUAL-KIND — off-site routes through
+ *     `resetListingToPending`, on-site through `resetOnsiteListingToPending` (which
+ *     suspends the backing block + re-queues the block review). The caller routes by
+ *     kind; the action is offered for an approved listing of EITHER kind.
+ *   - `claim` / `purge` are OFF-SITE ONLY (the service raises NOT_FOUND for an
+ *     on-site listing).
  *   - `hide` (delist) / `relist` are DUAL-KIND (they flip the on-site AppBlock too).
  *   - `review` opens the existing off-site review modal (approve/reject the pending
  *     request) → off-site only, and only when a pending request exists.
@@ -29,7 +33,8 @@ export type ListingModAction =
  *   - `review`: off-site + a pending publish request exists (any status — normally
  *     a `pending` listing, but a lingering pending request on another status still
  *     lets a mod open the review). Opens the reused off-site review modal.
- *   - `approved` → `reset-to-pending` (off-site only) + `hide` (delist, dual-kind).
+ *   - `approved` → `reset-to-pending` (dual-kind — off-site + on-site re-queue) +
+ *     `hide` (delist, dual-kind).
  *   - `removed`  → `relist` (dual-kind) + `claim` + `purge` (both off-site only).
  *   - `draft` / `rejected` → no lifecycle action (read-only) unless a pending
  *     request makes `review` available.
@@ -46,7 +51,9 @@ export function listingModActions(input: {
   if (offsite && input.hasPendingRequest) actions.push('review');
 
   if (input.status === 'approved') {
-    if (offsite) actions.push('reset-to-pending');
+    // Reset-to-pending is now dual-kind: off-site → resetListingToPending, on-site →
+    // resetOnsiteListingToPending (#3165). The mgmt table routes by kind.
+    actions.push('reset-to-pending');
     actions.push('hide'); // delist — dual-kind
   }
   if (input.status === 'removed') {

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -24,6 +24,7 @@ import type { MouseEvent } from 'react';
 import { useMemo, useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppListingsModerationTable } from '~/components/Apps/AppListingsModerationTable';
+import { ModQueryError, isModAuthzError } from '~/components/Apps/ModQuerySurface';
 // `OffsiteReviewQueue` (the flat pending-only off-site list) is SUPERSEDED by the
 // unified `AppListingsModerationTable` below (which covers pending too, via the
 // per-row Review action). It stays exported for a one-line rollback: swap the
@@ -253,11 +254,27 @@ function ActivePreviewsPanel() {
     },
   });
 
-  // Flag off / not enabled (query errors) or nothing active → render nothing so
-  // the panel stays unobtrusive when the sandbox isn't in use.
+  // Flag off / not enabled or nothing active → render nothing so the panel stays
+  // unobtrusive when the sandbox isn't in use. An AUTHZ error (sandbox flag off →
+  // UNAUTHORIZED) is that intended silent case; a TRANSIENT error surfaces a retry
+  // instead of silently disappearing.
   const cap = query.data?.cap ?? 0;
   const active = query.data?.active ?? [];
-  if (query.error || active.length === 0) return null;
+  if (!features?.appBlocks) return null;
+  if (query.error) {
+    if (isModAuthzError(query.error)) return null;
+    return (
+      <ModQueryError
+        error={query.error}
+        onRetry={() => query.refetch()}
+        isRetrying={query.isFetching}
+        title="Couldn’t load active previews"
+        testId="apps-active-previews-error"
+        mt="md"
+      />
+    );
+  }
+  if (active.length === 0) return null;
 
   const atCap = cap > 0 && active.length >= cap;
 


### PR DESCRIPTION
Consolidates the App Blocks moderator review flow (`/apps/review`) — builds on #3163 (extracted `OnsiteReviewModal`) and #3165 (onsite reset-to-pending backend). Dark / mod-gated (`appListings`/`appBlocks` Flipt flags, `moderatorProcedure`). No migration. No behavior change to the action semantics — this is UX consolidation + exposing the already-shipped onsite reset backend.

## Per-item

**B3 — shared reason-gated component (the backbone).** New `ReasonGatedActionModal.tsx`:
- `ReasonGatedField` — reason textarea + live `N/min` counter + inline too-short error (suppressed for optional notes).
- `ReasonGatedSubmitButton` — submit wrapped in a disabled Tooltip (Box-wrapper pattern) that explains the closed gate on hover.
- `ReasonGatedActionModal` — full single-action modal composing both, with optional slots for a claim-target input and the destructive typed-slug purge confirm.

Consumed by **all four** reason-required modals: the onsite reject (`OnsiteReviewModal`) and offsite reject (`OffsiteReviewModal`) use the two atoms directly; the mgmt-table `ListingModActionModal` and reports-queue `ReportActionModal` use the full modal. Each modal keeps its own mutation wiring.

**A — reason-gating UX on every reason-required action.** reset/hide/relist/claim/purge (mgmt table) and delist/relist/claim/purge (reports queue) now show the same live counter + inline error + disabled-with-tooltip the reject paths already had. No more static-label/dead-button.

**C — no silent unmount on a query error.** New `ModQuerySurface.tsx` (`isModAuthzError` + `ModQueryError`). The silent `return null` is now gated to the AUTHZ (`UNAUTHORIZED`/`FORBIDDEN`) + flag-off case only; a transient 500/network error renders an Alert + Retry (refetch). Applied to the mgmt table, offsite queue, reports queue, and the active-previews panel.

**D — hide onsite-pending rows from the mgmt table.** Onsite + pending listings are filtered out client-side (they're the onsite review FIFO queue's job — they'd render as a dead-end `—` row here). Offsite-pending still shows (it carries the Review action).

**E — load-more flicker.** The mgmt-table query gets `placeholderData: keepPreviousData` so the Load-more block doesn't unmount mid-fetch.

**F — filter/search pagination reset + debounce.** Pagination reset moved out of the `useEffect([filterKey])` into the filter/search onChange handlers (reset synchronously, batched with the filter change → no stale-cursor query window); the search input is debounced (no per-keystroke query storm).

**Onsite reset-to-pending UI (exposes the #3165 backend).** An onsite approved row now offers **Reset to pending**; the mgmt table routes reset to `resetOnsiteListingToPending` for onsite rows and `resetListingToPending` for offsite rows. The kind-gating view model + its unit test are updated from "reset is offsite-only" to the dual-kind behavior.

## Tests
- `ReasonGatedActionModal.browser.test.tsx` — counter/error at the floor boundary, disabled-with-tooltip, and the composed purge (typed-slug) / claim (extra-gate) gates.
- `OffsiteReportsQueue.browser.test.tsx` (new) — the reports-queue actions now show the gate + fire correctly; resolve stays an optional note.
- `AppListingsModerationTable.browser.test.tsx` — parametrized gate coverage for every post-approval action; D (onsite-pending hidden); onsite-vs-offsite reset routing; C (authz null vs transient Alert+Retry); F (debounce + no stale-cursor query on filter change).
- `appListingModerationTableView.test.ts` — flipped to the dual-kind reset assertion.
- Full affected suites green: 12 unit + 57 browser. `tsc --noEmit` clean for all touched files.
