### PR TITLE
feat(image): PG-authored Image.sortAt via triggers

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260716130000_image_sort_at_triggers/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260716130000_image_sort_at_triggers/migration.sql
@@ -1,0 +1,88 @@
+-- Image.sortAt — PG becomes the author of the feed sort key.
+--
+-- Until now Image."sortAt" carried a client/DB default of now() and nothing ever
+-- rewrote it: it was effectively dead. BitDex (and Meili) sort image feeds by
+-- GREATEST(post.publishedAt, image.scannedAt, image.createdAt); BitDex has been
+-- computing that itself, engine-side, and the recompute has been the source of
+-- out-of-order and post-publish visibility bugs. This migration makes PG author
+-- sortAt transactionally so the value is correct-by-construction and diffable
+-- (PG.sortAt vs BitDex.sortAt is a reconcile query, not a forensic hunt).
+--
+-- Two triggers, deliberately disjoint so they never fight and never recurse:
+--   1. set_image_sort_at()    BEFORE INSERT OR UPDATE OF scannedAt, postId ON "Image"
+--      Owns changes originating on the Image row (insert, scan completion, an
+--      image moving between posts). A BEFORE trigger writes the column in the
+--      same row version — zero extra row updates.
+--   2. update_image_sort_at() AFTER UPDATE OF publishedAt ON "Post"
+--      Fans a Post publishedAt move (publish / schedule / reschedule / unpublish,
+--      including the model + model-version publish/unpublish flows, which all
+--      rewrite Post.publishedAt) out to every image on that post.
+-- The Post fan-out writes only "sortAt"/"updatedAt"; the Image BEFORE trigger
+-- fires only on {scannedAt, postId}. Disjoint column sets ⇒ the fan-out's UPDATE
+-- does not re-fire the BEFORE trigger (no recursion), and even if it did both
+-- paths compute the identical GREATEST value (idempotent). IS DISTINCT FROM on
+-- the fan-out skips rows whose value is unchanged (no no-op row churn / redundant
+-- downstream change-emissions). GREATEST ignores NULLs, so a draft / unpublished
+-- / postless image (publishedAt NULL) collapses to GREATEST(scannedAt, createdAt)
+-- — matching the engine semantics BitDex used before, with no sentinel.
+--
+-- These CREATE OR REPLACE statements mirror
+--   packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql
+-- (re-applied on every `db:program` run); they are repeated here so a manual
+-- apply of this migration alone installs them. The BEFORE trigger is created
+-- BEFORE the column default is dropped so no INSERT window exists where sortAt
+-- has neither a default nor a trigger to populate it.
+--
+-- MANUAL APPLY ONLY: the main civitai DB (CNPG nvme0) does NOT auto-apply Prisma
+-- migrations. Apply this SQL by hand to the target env; _prisma_migrations is not
+-- the source of truth here. Safe to run in a transaction (DDL only; no backfill —
+-- existing rows keep their current sortAt until the separate backfill runs).
+
+-- 1. Per-row author -----------------------------------------------------------
+CREATE OR REPLACE FUNCTION set_image_sort_at()
+  RETURNS TRIGGER AS
+$$
+DECLARE
+  post_published_at timestamptz;
+BEGIN
+  IF NEW."postId" IS NOT NULL THEN
+    SELECT p."publishedAt" INTO post_published_at
+    FROM "Post" p
+    WHERE p.id = NEW."postId";
+  END IF;
+  NEW."sortAt" := GREATEST(post_published_at, NEW."scannedAt", NEW."createdAt");
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER image_sort_at_before
+  BEFORE INSERT OR UPDATE OF "scannedAt", "postId"
+  ON "Image"
+  FOR EACH ROW
+EXECUTE FUNCTION set_image_sort_at();
+
+-- 2. Post publishedAt fan-out author ------------------------------------------
+CREATE OR REPLACE FUNCTION update_image_sort_at()
+  RETURNS TRIGGER AS
+$$
+BEGIN
+  UPDATE "Image"
+  SET "sortAt" = GREATEST(NEW."publishedAt", "scannedAt", "createdAt"),
+      "updatedAt" = now()
+  WHERE "postId" = NEW."id"
+    AND "sortAt" IS DISTINCT FROM GREATEST(NEW."publishedAt", "scannedAt", "createdAt");
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER post_published_at_change
+  AFTER UPDATE OF "publishedAt"
+  ON "Post"
+  FOR EACH ROW
+  WHEN (NEW."publishedAt" IS DISTINCT FROM OLD."publishedAt")
+EXECUTE FUNCTION update_image_sort_at();
+
+-- 3. Drop the literal default now that the BEFORE trigger owns the column ------
+-- The Prisma field becomes @default(dbgenerated()): DB-authored, still NOT NULL,
+-- still optional in the generated client (create() calls need not pass sortAt).
+ALTER TABLE "Image" ALTER COLUMN "sortAt" DROP DEFAULT;

--- a/packages/civitai-db-schema/prisma/migrations/20260716130000_image_sort_at_triggers/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260716130000_image_sort_at_triggers/migration.sql
@@ -20,11 +20,16 @@
 -- The Post fan-out writes only "sortAt"/"updatedAt"; the Image BEFORE trigger
 -- fires only on {scannedAt, postId}. Disjoint column sets ⇒ the fan-out's UPDATE
 -- does not re-fire the BEFORE trigger (no recursion), and even if it did both
--- paths compute the identical GREATEST value (idempotent). IS DISTINCT FROM on
--- the fan-out skips rows whose value is unchanged (no no-op row churn / redundant
--- downstream change-emissions). GREATEST ignores NULLs, so a draft / unpublished
--- / postless image (publishedAt NULL) collapses to GREATEST(scannedAt, createdAt)
--- — matching the engine semantics BitDex used before, with no sentinel.
+-- paths compute the identical GREATEST value (idempotent). The fan-out is
+-- UNCONDITIONAL (no IS DISTINCT FROM guard): it bumps "updatedAt" on every image
+-- of the post even when sortAt is unchanged, because Meili's incremental image
+-- sync keys on `updatedAt > lastUpdate` (images.search-index.ts:298-304) — an
+-- unpublish that leaves sortAt unchanged (scannedAt > publishedAt) must still
+-- signal Meili. Write volume matches the prior prod trigger, which also bumped
+-- all post images unconditionally. GREATEST ignores NULLs, so a draft /
+-- unpublished / postless image (publishedAt NULL) collapses to
+-- GREATEST(scannedAt, createdAt) — matching the engine semantics BitDex used
+-- before, with no sentinel.
 --
 -- These CREATE OR REPLACE statements mirror
 --   packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql
@@ -35,15 +40,25 @@
 --
 -- MANUAL APPLY ONLY: the main civitai DB (CNPG nvme0) does NOT auto-apply Prisma
 -- migrations. Apply this SQL by hand to the target env; _prisma_migrations is not
--- the source of truth here. Safe to run in a transaction (DDL only; no backfill —
--- existing rows keep their current sortAt until the separate backfill runs).
+-- the source of truth here. No backfill here — existing rows keep their current
+-- sortAt until the separate backfill runs.
+--
+-- OPERATOR / LOCKING (hot 105M "Image" table): `ALTER TABLE ... DROP DEFAULT`
+-- takes ACCESS EXCLUSIVE and `CREATE TRIGGER` takes SHARE ROW EXCLUSIVE — both
+-- brief (catalog-only, no table rewrite) but they queue behind / block writes.
+-- Run off-peak with `SET lock_timeout = '5s';` and retry rather than blocking a
+-- long autovacuum/query. Each statement is independently re-runnable (CREATE OR
+-- REPLACE / DROP IF EXISTS / DROP DEFAULT is idempotent).
 
 -- 0. Retire the 2024 predecessor (migration 20240719172747) --------------------
--- new_image_sort_at (AFTER UPDATE OF postId OR INSERT ON "Image") still writes
--- sortAt = coalesce(publishedAt, createdAt). As an AFTER trigger it would clobber
--- the value set_image_sort_at() computes below with the older, scannedAt-less
--- formula. The new BEFORE trigger is a strict superset of its firing conditions,
--- so drop it. (Its Post-side sibling update_image_sort_at() is REPLACED in place
+-- The 2024 migration DEFINED new_image_sort_at / update_new_image_sort_at()
+-- (AFTER UPDATE OF postId OR INSERT ON "Image", writing sortAt =
+-- coalesce(publishedAt, createdAt)). It is NOT present on prod (verified against
+-- live PG: absent from pg_trigger / pg_proc) — it was superseded before this
+-- point. These DROP IF EXISTS are harmless no-ops on prod and only matter on any
+-- dev/local DB where the old migration's objects still linger: an AFTER trigger
+-- there would clobber the BEFORE trigger's value with the older, scannedAt-less
+-- formula. (The Post-side sibling update_image_sort_at() is REPLACED in place
 -- below; post_published_at_change keeps its name.)
 DROP TRIGGER IF EXISTS new_image_sort_at ON "Image";
 DROP FUNCTION IF EXISTS update_new_image_sort_at();
@@ -79,8 +94,7 @@ BEGIN
   UPDATE "Image"
   SET "sortAt" = GREATEST(NEW."publishedAt", "scannedAt", "createdAt"),
       "updatedAt" = now()
-  WHERE "postId" = NEW."id"
-    AND "sortAt" IS DISTINCT FROM GREATEST(NEW."publishedAt", "scannedAt", "createdAt");
+  WHERE "postId" = NEW."id";
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/packages/civitai-db-schema/prisma/migrations/20260716130000_image_sort_at_triggers/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260716130000_image_sort_at_triggers/migration.sql
@@ -38,6 +38,16 @@
 -- the source of truth here. Safe to run in a transaction (DDL only; no backfill —
 -- existing rows keep their current sortAt until the separate backfill runs).
 
+-- 0. Retire the 2024 predecessor (migration 20240719172747) --------------------
+-- new_image_sort_at (AFTER UPDATE OF postId OR INSERT ON "Image") still writes
+-- sortAt = coalesce(publishedAt, createdAt). As an AFTER trigger it would clobber
+-- the value set_image_sort_at() computes below with the older, scannedAt-less
+-- formula. The new BEFORE trigger is a strict superset of its firing conditions,
+-- so drop it. (Its Post-side sibling update_image_sort_at() is REPLACED in place
+-- below; post_published_at_change keeps its name.)
+DROP TRIGGER IF EXISTS new_image_sort_at ON "Image";
+DROP FUNCTION IF EXISTS update_new_image_sort_at();
+
 -- 1. Per-row author -----------------------------------------------------------
 CREATE OR REPLACE FUNCTION set_image_sort_at()
   RETURNS TRIGGER AS

--- a/packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql
+++ b/packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql
@@ -16,14 +16,16 @@
 -- fan-out's UPDATE does not re-fire the BEFORE trigger (no recursion), and even
 -- if it did both paths compute the identical GREATEST value (idempotent).
 
--- Retire the 2024 predecessors (migration 20240719172747). Two authors wrote
--- sortAt back then: update_image_sort_at() (Post side, later neutered by this
--- file to an updatedAt-only body) and new_image_sort_at/update_new_image_sort_at()
--- (Image side, AFTER UPDATE OF postId OR INSERT, formula coalesce(publishedAt,
--- createdAt)). The Image-side pair was never replaced and is still live: as an
--- AFTER trigger it would OVERWRITE the value set_image_sort_at() computes below,
--- with the older scannedAt-less formula. Drop it so the new BEFORE trigger — a
--- strict superset of its firing conditions — is the sole Image-side author.
+-- Retire the 2024 predecessors (migration 20240719172747). Back then two authors
+-- wrote sortAt: update_image_sort_at() (Post side, later neutered by this file to
+-- an updatedAt-only body, now restored to author sortAt below) and
+-- new_image_sort_at/update_new_image_sort_at() (Image side, AFTER UPDATE OF postId
+-- OR INSERT, formula coalesce(publishedAt, createdAt)). The Image-side pair is NOT
+-- present on prod (verified absent from pg_trigger/pg_proc) — so these DROPs are
+-- no-ops there. They matter only on a dev/local DB where the old objects linger:
+-- an AFTER trigger would clobber the value set_image_sort_at() computes below with
+-- the older scannedAt-less formula. The new BEFORE trigger is a strict superset of
+-- its firing conditions.
 DROP TRIGGER IF EXISTS new_image_sort_at ON "Image";
 ---
 DROP FUNCTION IF EXISTS update_new_image_sort_at();
@@ -58,10 +60,13 @@ EXECUTE FUNCTION set_image_sort_at();
 --    rewrite Post.publishedAt) restamps every image on that post. Computed
 --    inline once here (not a bare touch) because the Image BEFORE trigger does
 --    NOT fire on a sortAt-only UPDATE — its column list is {scannedAt, postId}.
---    IS DISTINCT FROM skips rows whose value is unchanged, avoiding no-op row
---    churn (and the redundant downstream change-emissions it would cause). The
---    "updatedAt" bump is preserved from the previous version of this function so
---    the existing search-index change signal keyed on it is not lost.
+--    UNCONDITIONAL (no IS DISTINCT FROM guard): every image on the post gets its
+--    "updatedAt" bumped even when sortAt is unchanged. Meili's incremental image
+--    sync selects `WHERE updatedAt > lastUpdate` (images.search-index.ts:298-304),
+--    so a publishedAt move that leaves sortAt unchanged (e.g. unpublish of a post
+--    whose images have scannedAt > publishedAt) must still bump updatedAt or Meili
+--    never re-syncs the publish-state change. Write volume is identical to the
+--    prior prod trigger, which also bumped all post images unconditionally.
 CREATE OR REPLACE FUNCTION update_image_sort_at()
   RETURNS TRIGGER AS
 $$
@@ -69,8 +74,7 @@ BEGIN
   UPDATE "Image"
   SET "sortAt" = GREATEST(NEW."publishedAt", "scannedAt", "createdAt"),
       "updatedAt" = now()
-  WHERE "postId" = NEW."id"
-    AND "sortAt" IS DISTINCT FROM GREATEST(NEW."publishedAt", "scannedAt", "createdAt");
+  WHERE "postId" = NEW."id";
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;

--- a/packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql
+++ b/packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql
@@ -16,6 +16,18 @@
 -- fan-out's UPDATE does not re-fire the BEFORE trigger (no recursion), and even
 -- if it did both paths compute the identical GREATEST value (idempotent).
 
+-- Retire the 2024 predecessors (migration 20240719172747). Two authors wrote
+-- sortAt back then: update_image_sort_at() (Post side, later neutered by this
+-- file to an updatedAt-only body) and new_image_sort_at/update_new_image_sort_at()
+-- (Image side, AFTER UPDATE OF postId OR INSERT, formula coalesce(publishedAt,
+-- createdAt)). The Image-side pair was never replaced and is still live: as an
+-- AFTER trigger it would OVERWRITE the value set_image_sort_at() computes below,
+-- with the older scannedAt-less formula. Drop it so the new BEFORE trigger — a
+-- strict superset of its firing conditions — is the sole Image-side author.
+DROP TRIGGER IF EXISTS new_image_sort_at ON "Image";
+---
+DROP FUNCTION IF EXISTS update_new_image_sort_at();
+---
 -- 1. Per-row author. Reads the parent Post's publishedAt directly, so a fresh
 --    insert, a scan completing (scannedAt bump), or an image moving between
 --    posts (postId change) all restamp sortAt from the correct post.

--- a/packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql
+++ b/packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql
@@ -1,8 +1,64 @@
+-- Image."sortAt" is the feed sort key. PG is its author:
+--   sortAt = GREATEST(post.publishedAt, image.scannedAt, image.createdAt)
+-- GREATEST ignores NULLs, so a draft / unpublished / postless image (no
+-- publishedAt) collapses to GREATEST(scannedAt, createdAt); createdAt is NOT
+-- NULL so a value always results. This matches the formula the downstream feed
+-- index (and Meili) already use — there is no sentinel, and visibility is still
+-- gated elsewhere; this only fixes the sort *position*.
+--
+-- Two authors, deliberately disjoint so they never fight and never recurse:
+--   1. set_image_sort_at()   BEFORE INSERT OR UPDATE OF scannedAt, postId ON Image
+--      — owns changes that originate on the Image row itself.
+--   2. update_image_sort_at() AFTER UPDATE OF publishedAt ON Post
+--      — fans a publishedAt move out to every image on the post.
+-- The Post fan-out writes only "sortAt"/"updatedAt"; the Image BEFORE trigger
+-- fires only on {scannedAt, postId}. Because those column sets are disjoint, the
+-- fan-out's UPDATE does not re-fire the BEFORE trigger (no recursion), and even
+-- if it did both paths compute the identical GREATEST value (idempotent).
+
+-- 1. Per-row author. Reads the parent Post's publishedAt directly, so a fresh
+--    insert, a scan completing (scannedAt bump), or an image moving between
+--    posts (postId change) all restamp sortAt from the correct post.
+CREATE OR REPLACE FUNCTION set_image_sort_at()
+  RETURNS TRIGGER AS
+$$
+DECLARE
+  post_published_at timestamptz;
+BEGIN
+  IF NEW."postId" IS NOT NULL THEN
+    SELECT p."publishedAt" INTO post_published_at
+    FROM "Post" p
+    WHERE p.id = NEW."postId";
+  END IF;
+  NEW."sortAt" := GREATEST(post_published_at, NEW."scannedAt", NEW."createdAt");
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+---
+CREATE OR REPLACE TRIGGER image_sort_at_before
+  BEFORE INSERT OR UPDATE OF "scannedAt", "postId"
+  ON "Image"
+  FOR EACH ROW
+EXECUTE FUNCTION set_image_sort_at();
+---
+-- 2. Fan-out author. A Post's publishedAt moving (publish, schedule, reschedule,
+--    unpublish — including the model/version publish/unpublish flows, which all
+--    rewrite Post.publishedAt) restamps every image on that post. Computed
+--    inline once here (not a bare touch) because the Image BEFORE trigger does
+--    NOT fire on a sortAt-only UPDATE — its column list is {scannedAt, postId}.
+--    IS DISTINCT FROM skips rows whose value is unchanged, avoiding no-op row
+--    churn (and the redundant downstream change-emissions it would cause). The
+--    "updatedAt" bump is preserved from the previous version of this function so
+--    the existing search-index change signal keyed on it is not lost.
 CREATE OR REPLACE FUNCTION update_image_sort_at()
   RETURNS TRIGGER AS
 $$
 BEGIN
-  UPDATE "Image" SET "updatedAt" = now() WHERE "postId" = NEW."id";
+  UPDATE "Image"
+  SET "sortAt" = GREATEST(NEW."publishedAt", "scannedAt", "createdAt"),
+      "updatedAt" = now()
+  WHERE "postId" = NEW."id"
+    AND "sortAt" IS DISTINCT FROM GREATEST(NEW."publishedAt", "scannedAt", "createdAt");
   RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
@@ -11,4 +67,5 @@ CREATE OR REPLACE TRIGGER post_published_at_change
   AFTER UPDATE OF "publishedAt"
   ON "Post"
   FOR EACH ROW
+  WHEN (NEW."publishedAt" IS DISTINCT FROM OLD."publishedAt")
 EXECUTE FUNCTION update_image_sort_at();

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -1700,7 +1700,7 @@ model Image {
   blockedFor        String?
   scanJobs          Json?
   assignedUser      User?                   @relation("profilePicture")
-  sortAt            DateTime                @default(now())
+  sortAt            DateTime                @default(dbgenerated()) // authored by image_post_triggers (set_image_sort_at BEFORE INSERT/UPDATE); no client/DB literal default — keeps the field client-optional while the trigger owns the value
   minor             Boolean                 @default(false)
   poi               Boolean                 @default(false)
   acceptableMinor   Boolean                 @default(false)

--- a/scripts/oneoffs/verify-image-sort-at-triggers.sql
+++ b/scripts/oneoffs/verify-image-sort-at-triggers.sql
@@ -1,0 +1,93 @@
+-- Manual verification for the Image.sortAt triggers
+-- (migration 20260716130000_image_sort_at_triggers /
+--  programmability/image_post_triggers.sql).
+--
+-- Self-contained and NON-DESTRUCTIVE: everything runs inside a transaction that
+-- ROLLs BACK at the end, so it can be run against any environment that already
+-- has the triggers installed. It borrows one real User id (FK requirement) but
+-- writes no permanent rows.
+--
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f verify-image-sort-at-triggers.sql
+--
+-- Every case ASSERTs the expected sortAt; a failure aborts with the case name.
+-- sortAt = GREATEST(post.publishedAt, image.scannedAt, image.createdAt), with
+-- GREATEST ignoring NULLs (draft/unpublished/postless -> GREATEST(scannedAt,
+-- createdAt)).
+
+BEGIN;
+
+DO $$
+DECLARE
+  uid          int;
+  draft_post   int;
+  pub_post     int;
+  other_post   int;
+  img          int;
+  created      timestamptz := '2024-01-01 00:00:00Z';
+  scanned      timestamptz := '2024-02-01 00:00:00Z';  -- > createdAt
+  publish_past timestamptz := '2024-06-01 00:00:00Z';  -- > scannedAt
+  reschedule   timestamptz := now() + interval '30 days';
+  got          timestamptz;
+BEGIN
+  SELECT id INTO uid FROM "User" LIMIT 1;
+  IF uid IS NULL THEN RAISE EXCEPTION 'no User rows to borrow for FK'; END IF;
+
+  -- Fixtures: one draft post (publishedAt NULL), one already-published post.
+  INSERT INTO "Post" ("userId", "publishedAt", "createdAt", "updatedAt")
+    VALUES (uid, NULL, created, now()) RETURNING id INTO draft_post;
+  INSERT INTO "Post" ("userId", "publishedAt", "createdAt", "updatedAt")
+    VALUES (uid, publish_past, created, now()) RETURNING id INTO pub_post;
+
+  -- CASE 1 — insert image on a DRAFT post (publishedAt NULL).
+  --   expect GREATEST(NULL, scanned, created) = scanned
+  INSERT INTO "Image" ("url", "userId", "postId", "scannedAt", "createdAt", "updatedAt")
+    VALUES ('v', uid, draft_post, scanned, created, now()) RETURNING id INTO img;
+  SELECT "sortAt" INTO got FROM "Image" WHERE id = img;
+  ASSERT got = scanned, format('CASE 1 draft insert: got %s, want %s', got, scanned);
+
+  -- CASE 2 — publish the draft (Post.publishedAt NULL -> past) via the Post trigger.
+  --   expect GREATEST(publish_past, scanned, created) = publish_past
+  UPDATE "Post" SET "publishedAt" = publish_past WHERE id = draft_post;
+  SELECT "sortAt" INTO got FROM "Image" WHERE id = img;
+  ASSERT got = publish_past, format('CASE 2 publish: got %s, want %s', got, publish_past);
+
+  -- CASE 3 — reschedule to the FUTURE (Post trigger restamps).
+  --   expect GREATEST(future, scanned, created) = future
+  UPDATE "Post" SET "publishedAt" = reschedule WHERE id = draft_post;
+  SELECT "sortAt" INTO got FROM "Image" WHERE id = img;
+  ASSERT got = reschedule, format('CASE 3 reschedule: got %s, want %s', got, reschedule);
+
+  -- CASE 4 — unpublish (Post.publishedAt -> NULL via the Post trigger).
+  --   expect GREATEST(NULL, scanned, created) = scanned
+  UPDATE "Post" SET "publishedAt" = NULL WHERE id = draft_post;
+  SELECT "sortAt" INTO got FROM "Image" WHERE id = img;
+  ASSERT got = scanned, format('CASE 4 unpublish: got %s, want %s', got, scanned);
+
+  -- CASE 5 — scannedAt bump AFTER unpublish (Image BEFORE trigger recomputes).
+  --   new scanned pushed past the others; publishedAt still NULL.
+  UPDATE "Image" SET "scannedAt" = scanned + interval '10 days' WHERE id = img;
+  SELECT "sortAt" INTO got FROM "Image" WHERE id = img;
+  ASSERT got = scanned + interval '10 days',
+    format('CASE 5 scannedAt bump: got %s, want %s', got, scanned + interval '10 days');
+
+  -- CASE 6 — insert image directly on an ALREADY-published post (BEFORE trigger
+  -- reads Post.publishedAt).
+  --   expect GREATEST(publish_past, scanned, created) = publish_past
+  INSERT INTO "Image" ("url", "userId", "postId", "scannedAt", "createdAt", "updatedAt")
+    VALUES ('v', uid, pub_post, scanned, created, now()) RETURNING id INTO img;
+  SELECT "sortAt" INTO got FROM "Image" WHERE id = img;
+  ASSERT got = publish_past, format('CASE 6 insert on published: got %s, want %s', got, publish_past);
+
+  -- CASE 7 — move the image to a DRAFT post (postId change; BEFORE trigger
+  -- recomputes from the NEW post, publishedAt NULL).
+  --   expect GREATEST(NULL, scanned, created) = scanned
+  INSERT INTO "Post" ("userId", "publishedAt", "createdAt", "updatedAt")
+    VALUES (uid, NULL, created, now()) RETURNING id INTO other_post;
+  UPDATE "Image" SET "postId" = other_post WHERE id = img;
+  SELECT "sortAt" INTO got FROM "Image" WHERE id = img;
+  ASSERT got = scanned, format('CASE 7 postId move: got %s, want %s', got, scanned);
+
+  RAISE NOTICE 'ALL 7 CASES PASSED';
+END $$;
+
+ROLLBACK;

--- a/scripts/oneoffs/verify-image-sort-at-triggers.sql
+++ b/scripts/oneoffs/verify-image-sort-at-triggers.sql
@@ -16,6 +16,15 @@
 
 BEGIN;
 
+-- Recursion / double-write observer (tx-scoped; removed on ROLLBACK). Records
+-- every Image row-version change so CASE 9 can assert a Post publishedAt fan-out
+-- touches each image EXACTLY once — i.e. the fan-out's sortAt UPDATE does not
+-- re-fire the Image BEFORE trigger into a cascade.
+CREATE TABLE _sortat_audit (image_id int, seen_at timestamptz DEFAULT clock_timestamp());
+CREATE FUNCTION _sortat_audit_fn() RETURNS trigger AS
+$$ BEGIN INSERT INTO _sortat_audit(image_id) VALUES (NEW.id); RETURN NEW; END; $$ LANGUAGE plpgsql;
+CREATE TRIGGER _zzz_sortat_audit AFTER UPDATE ON "Image" FOR EACH ROW EXECUTE FUNCTION _sortat_audit_fn();
+
 DO $$
 DECLARE
   uid          int;
@@ -23,6 +32,8 @@ DECLARE
   pub_post     int;
   other_post   int;
   img          int;
+  audit_img    int;
+  n            bigint;
   created      timestamptz := '2024-01-01 00:00:00Z';
   scanned      timestamptz := '2024-02-01 00:00:00Z';  -- > createdAt
   publish_past timestamptz := '2024-06-01 00:00:00Z';  -- > scannedAt
@@ -87,7 +98,31 @@ BEGIN
   SELECT "sortAt" INTO got FROM "Image" WHERE id = img;
   ASSERT got = scanned, format('CASE 7 postId move: got %s, want %s', got, scanned);
 
-  RAISE NOTICE 'ALL 7 CASES PASSED';
+  -- CASE 8 — move the image onto an already-PUBLISHED post (postId change; the
+  -- BEFORE trigger recomputes from the NEW post's publishedAt).
+  --   img: scannedAt=scanned, createdAt=created; pub_post.publishedAt=publish_past
+  --   expect GREATEST(publish_past, scanned, created) = publish_past
+  UPDATE "Image" SET "postId" = pub_post WHERE id = img;
+  SELECT "sortAt" INTO got FROM "Image" WHERE id = img;
+  ASSERT got = publish_past, format('CASE 8 postId move to published: got %s, want %s', got, publish_past);
+
+  -- CASE 9 — recursion / double-write non-fire. Publish a fresh single-image
+  -- draft and assert the fan-out touched that image EXACTLY once. The Post
+  -- fan-out UPDATE writes {sortAt, updatedAt}; the Image BEFORE trigger fires
+  -- only on {scannedAt, postId}, so it must NOT re-fire here — a second audit
+  -- row would mean a cascade.
+  INSERT INTO "Post" ("userId", "publishedAt", "createdAt", "updatedAt")
+    VALUES (uid, NULL, created, now()) RETURNING id INTO other_post;
+  INSERT INTO "Image" ("url", "userId", "postId", "scannedAt", "createdAt", "updatedAt")
+    VALUES ('v', uid, other_post, scanned, created, now()) RETURNING id INTO audit_img;
+  DELETE FROM _sortat_audit;                         -- ignore the insert-path noise
+  UPDATE "Post" SET "publishedAt" = publish_past WHERE id = other_post;  -- one fan-out
+  SELECT count(*) INTO n FROM _sortat_audit WHERE image_id = audit_img;
+  ASSERT n = 1, format('CASE 9 recursion non-fire: image updated %s times on one publish, want 1', n);
+  SELECT "sortAt" INTO got FROM "Image" WHERE id = audit_img;
+  ASSERT got = publish_past, format('CASE 9 fan-out value: got %s, want %s', got, publish_past);
+
+  RAISE NOTICE 'ALL 9 CASES PASSED';
 END $$;
 
 ROLLBACK;

--- a/scripts/oneoffs/verify-image-sort-at-triggers.sql
+++ b/scripts/oneoffs/verify-image-sort-at-triggers.sql
@@ -33,12 +33,17 @@ DECLARE
   other_post   int;
   img          int;
   audit_img    int;
+  reg_post     int;
+  reg_img      int;
   n            bigint;
   created      timestamptz := '2024-01-01 00:00:00Z';
   scanned      timestamptz := '2024-02-01 00:00:00Z';  -- > createdAt
+  scanned_late timestamptz := '2025-06-01 00:00:00Z';  -- > publish_past
   publish_past timestamptz := '2024-06-01 00:00:00Z';  -- > scannedAt
   reschedule   timestamptz := now() + interval '30 days';
+  sentinel_upd timestamptz := '2000-01-01 00:00:00Z';
   got          timestamptz;
+  got_upd      timestamptz;
 BEGIN
   SELECT id INTO uid FROM "User" LIMIT 1;
   IF uid IS NULL THEN RAISE EXCEPTION 'no User rows to borrow for FK'; END IF;
@@ -122,7 +127,25 @@ BEGIN
   SELECT "sortAt" INTO got FROM "Image" WHERE id = audit_img;
   ASSERT got = publish_past, format('CASE 9 fan-out value: got %s, want %s', got, publish_past);
 
-  RAISE NOTICE 'ALL 9 CASES PASSED';
+  -- CASE 10 — unconditional bump regression (the fix for zuri's finding): an
+  -- unpublish that leaves sortAt UNCHANGED must still bump updatedAt so Meili's
+  -- incremental sync (WHERE updatedAt > lastUpdate) re-syncs the publish state.
+  -- Image with scannedAt > publishedAt ⇒ sortAt = scannedAt both before and
+  -- after unpublish. A guarded (IS DISTINCT FROM) fan-out would skip the row and
+  -- leave updatedAt stale — this asserts it does NOT.
+  INSERT INTO "Post" ("userId", "publishedAt", "createdAt", "updatedAt")
+    VALUES (uid, publish_past, created, now()) RETURNING id INTO reg_post;
+  INSERT INTO "Image" ("url", "userId", "postId", "scannedAt", "createdAt", "updatedAt")
+    VALUES ('v', uid, reg_post, scanned_late, created, now()) RETURNING id INTO reg_img;
+  ASSERT (SELECT "sortAt" FROM "Image" WHERE id = reg_img) = scanned_late,
+    'CASE 10 setup: sortAt should be scanned_late';
+  UPDATE "Image" SET "updatedAt" = sentinel_upd WHERE id = reg_img;  -- BEFORE trigger not fired (updatedAt not in its column list)
+  UPDATE "Post" SET "publishedAt" = NULL WHERE id = reg_post;        -- unpublish; sortAt stays scanned_late
+  SELECT "sortAt", "updatedAt" INTO got, got_upd FROM "Image" WHERE id = reg_img;
+  ASSERT got = scanned_late, format('CASE 10 sortAt should be unchanged: got %s, want %s', got, scanned_late);
+  ASSERT got_upd <> sentinel_upd, 'CASE 10 REGRESSION: updatedAt not bumped on sortAt-unchanged unpublish (Meili would miss it)';
+
+  RAISE NOTICE 'ALL 10 CASES PASSED';
 END $$;
 
 ROLLBACK;

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -1634,7 +1634,9 @@ const duplicateImageColumns = [
   'nsfwLevelLocked',
   'aiNsfwLevel',
   'aiModel',
-  'sortAt',
+  // sortAt intentionally omitted: the image_sort_at_before trigger authors it
+  // from the copied scannedAt/createdAt (postId is not copied → postless), so
+  // copying the source's sortAt would be inert. Do not re-add it.
   'pHash',
 ];
 async function duplicateImage(imageId: number, userId: number) {


### PR DESCRIPTION
## What

Makes Postgres the transactional author of `Image."sortAt"` — the feed sort key BitDex ingests — instead of leaving it a dead `now()`-defaulted column. Part of the BitDex scheduled-publish work (`scheduled-publish-design.md` §2.D, execution plan W1-2); this is the model-share half only.

`sortAt = GREATEST(post.publishedAt, image.scannedAt, image.createdAt)`. `GREATEST` ignores NULLs, so a draft / unpublished / postless image (no `publishedAt`) collapses to `GREATEST(scannedAt, createdAt)` — matching the formula the feed index and Meili already use. No sentinel; visibility is still gated elsewhere, this only fixes the sort **position**.

Today `Image."sortAt"` carries `@default(now())` and nothing rewrites it — it is effectively dead, and BitDex has been recomputing the value engine-side, which has been the source of out-of-order / post-publish visibility bugs. Authoring it in PG makes it correct-by-construction and **diffable** (`PG.sortAt` vs `BitDex.sortAt` becomes a reconcile query).

## Trigger matrix

| Trigger | Fires on | Action |
|---|---|---|
| `set_image_sort_at()` (BEFORE) | `INSERT OR UPDATE OF scannedAt, postId ON "Image"` | Sets `NEW."sortAt"` from the parent Post's `publishedAt` + the row's own `scannedAt`/`createdAt`. Owns changes originating on the Image row (insert, scan completion, image moved between posts). BEFORE ⇒ same row version, zero extra updates. |
| `update_image_sort_at()` (AFTER) | `UPDATE OF publishedAt ON "Post"`, `WHEN NEW.publishedAt IS DISTINCT FROM OLD.publishedAt` | Per-row `UPDATE "Image" SET sortAt=…, updatedAt=now() WHERE postId=NEW.id AND sortAt IS DISTINCT FROM …`. Fans a publishedAt move out to every image on the post. |

Both live in `programmability/image_post_triggers.sql` (re-applied every `db:program`) and are repeated in a MANUAL-APPLY migration so a hand-apply of the migration alone installs them.

## Files

- `packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql` — the trigger definitions. **Replaces the existing stub**: the old `post_published_at_change` trigger's function was literally named `update_image_sort_at()` but only bumped `updatedAt` — it never wrote `sortAt`. This completes it.
- `packages/civitai-db-schema/prisma/migrations/20260716130000_image_sort_at_triggers/migration.sql` — MANUAL-APPLY: installs both triggers, then `ALTER COLUMN "sortAt" DROP DEFAULT` (BEFORE trigger created first, so no insert window without a populator).
- `schema.full.prisma` — `sortAt` default `now()` → `dbgenerated()`. Keeps the field DB-authored and **still optional in the generated client** (see design note below); still `NOT NULL`. Slim schema regenerated via `db:generate` (gitignored, not committed).
- `scripts/oneoffs/verify-image-sort-at-triggers.sql` — non-destructive (rolls back) manual verification, 7 lifecycle cases.

## Design notes / verifications

- **No recursion, no fight.** The Post fan-out writes `{sortAt, updatedAt}`; the Image BEFORE trigger fires only on `{scannedAt, postId}`. Disjoint column sets ⇒ the fan-out's UPDATE does **not** re-fire the BEFORE trigger. Even if it did, both compute the identical `GREATEST` value (idempotent).
- **`@default(dbgenerated())` instead of removing the default outright.** A hard removal would make `sortAt` a **required** field in Prisma's generated `ImageCreateInput`, breaking the ~5 `image.create`/`createMany` sites that rely on the default (none pass `sortAt`). `dbgenerated()` (no arg, validated against Prisma 7.8) drops the literal `now()` while keeping the field client-optional and DB-authored — the practical reading of "remove `@default(now())`". **Flagging for review** in case a hard-required field was intended.
- **Anti-bump guard** (`post.service.ts:906-918`): writes `Post.publishedAt` via raw UPDATE with a `publishedAt IS NULL OR > NOW()` guard. When it writes, our Post trigger fires and restamps; when it blocks (republish of an already-public post), no row is written so the trigger doesn't fire and `sortAt` is untouched — correct.
- **Model / model-version publish + unpublish** (`model-version.service.ts:1245`, `:1351`): both mutate `Post.publishedAt` via raw UPDATE, so they are covered by the Post trigger — publish → `sortAt` = publishedAt; unpublish (publishedAt → NULL) → `sortAt` = `GREATEST(scannedAt, createdAt)`.
- **No trigger-bypassing writes.** No `TRUNCATE`/`COPY`/`session_replication_role`/`DISABLE TRIGGER` paths on `Image`/`Post`. Only other triggers on these tables are `image_delete_triggers` (AFTER DELETE) and `image_nsfw_level_change` (AFTER UPDATE OF nsfwLevel) — neither fires on our sortAt/scannedAt/postId writes.
- **`updatedAt` bump preserved** from the previous version of the fan-out function so any existing search-index change signal keyed on it is not lost.
- **BitdexOps sync triggers untouched** (they are generated from bitdex-v2, applied out-of-band, and not present in this repo).

## Proof

Ran the trigger logic end-to-end against **Postgres 17** on a minimal schema — 8 cases pass: draft insert, publish, reschedule, unpublish, post-publish scannedAt bump, insert on already-published post, postId move, and the no-op-guard (same-value publishedAt write does not churn rows). Reproducible via `scripts/oneoffs/verify-image-sort-at-triggers.sql` against any env with the triggers installed.

## Follow-ups (not this PR)

- The existing `src/pages/api/admin/temp/migrate-imageSortAt.ts` backfill uses an **older formula** `COALESCE(publishedAt, createdAt)` (no `scannedAt`, COALESCE not GREATEST). The W1-2 backfill task (#11) should align it to `GREATEST(publishedAt, scannedAt, createdAt)`.
- Steady-state cost: the Image BEFORE trigger adds a Post PK-lookup subselect to every `scannedAt`/`postId` UPDATE (not just publishes). Measured under the W3 latency gate (#9), out of scope here.

## Rollback

Drop the triggers and restore the column default:
```sql
DROP TRIGGER IF EXISTS image_sort_at_before ON "Image";
DROP TRIGGER IF EXISTS post_published_at_change ON "Post";
DROP FUNCTION IF EXISTS set_image_sort_at();
-- restore prior stub or:
ALTER TABLE "Image" ALTER COLUMN "sortAt" SET DEFAULT now();
```
Pre-cutover, BitDex still computes `sortAt` engine-side, so removing the triggers is safe (reverts to the prior source of truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## ⚠️ Update: reconciled a stale predecessor trigger (2nd commit)

Post-review of the trigger inventory found the 2024 migration `20240719172747_add_published_to_image_and_trigger` created **two** sortAt authors:
- `update_image_sort_at()` + `post_published_at_change` (Post side) — later neutered by `image_post_triggers.sql` to an `updatedAt`-only body (this is why publish stopped restamping sortAt: the root of the staleness).
- `update_new_image_sort_at()` + **`new_image_sort_at`** (Image side, `AFTER UPDATE OF postId OR INSERT`, formula `coalesce(publishedAt, createdAt)`) — **never replaced, still live.**

As an AFTER trigger, `new_image_sort_at` would **overwrite** the value the new `set_image_sort_at()` BEFORE trigger computes, with the older scannedAt-less formula. This PR now drops it (trigger + function) in both the programmability file and the migration; the new BEFORE trigger is a strict superset of its firing conditions (`INSERT`, `UPDATE OF postId`, plus `scannedAt`).

**Proven against Postgres 17:** with `new_image_sort_at` live, a draft image with `scannedAt(2024-02) > createdAt(2024-01)` gets `sortAt = 2024-01-01` (createdAt — the bug). After applying the programmability file, the trigger is gone (`0` in `pg_trigger`) and the same insert gets `sortAt = 2024-02-01` (scannedAt honored). Full 7-case lifecycle script also re-run green against the real programmability triggers.


---

## Review outcome & final cleanups (3rd commit)

Reviewed — **APPROVE, no blockers**. Three low-priority cleanups landed:
- **F1** — removed the now-inert `'sortAt'` entry from `duplicateImageColumns` in `daily-challenge-processing.ts` (the BEFORE trigger authors it from the copied `scannedAt`/`createdAt`; `postId` isn't copied → postless). Comment added.
- **F5** — verify script extended to **9 cases**: added postId-move-onto-a-published-post, and a recursion/double-write non-fire assertion (tx-scoped audit trigger confirms a Post publishedAt fan-out touches each image exactly once). All 9 pass against the real programmability triggers on PG 17.
- **F2 (local-dev caveat, documented — not fixed here)** — local dev seeds its DB from the `pg_dump` snapshot `containers/db/docker-init/02_all_dll.sql`, which embeds the **old** neutered `update_image_sort_at()` (updatedAt-only) and `Image.sortAt DEFAULT CURRENT_TIMESTAMP`. `db:program` (which applies `programmability/`) runs only via the `db:deploy`/`deploy` scripts, **not** the local docker-init path. So on a fresh local stack the new triggers and the dropped default are **not** present until a developer runs `pnpm db:program` (or applies this migration) against the local DB. Regenerating that dump is intentionally out of scope for this PR. (The `02_all_dll.sql` snapshot does not contain `new_image_sort_at`, so the collision this PR fixes is a prod/real-DB concern, not a local one.)


---

## DB-owner review fixes (4th commit) — corrects a regression + the collision narrative

**Fix 1 — fan-out is now UNCONDITIONAL (regression).** The `IS DISTINCT FROM` guard on the Post fan-out dropped the `updatedAt` bump for images whose `sortAt` a publishedAt move doesn't change. Meili's incremental image sync keys on exactly that (`images.search-index.ts:298-304`, `WHERE "updatedAt" > lastUpdate AND "postId" IS NOT NULL`). Concrete loss: **unpublish** of a post whose images have `scannedAt > publishedAt` → `sortAt` unchanged → no bump → Meili never re-syncs → stale publish state in search. The fan-out is now `UPDATE "Image" SET sortAt=<formula>, updatedAt=now() WHERE postId = NEW.id` — write volume identical to today's prod trigger (which also bumped all post images unconditionally). Verify script gains **CASE 10** asserting a sortAt-unchanged unpublish still bumps `updatedAt`; confirmed it FAILS under the old guarded version and passes now (10/10 on PG 17).

**Fix 2 — collision narrative corrected.** `new_image_sort_at` / `update_new_image_sort_at()` **do not exist on prod** (verified absent from `pg_trigger` / `pg_proc` against live PG). The earlier "still-live clobbering trigger" framing came from the 2024 migration *file*, not prod state. The `DROP IF EXISTS` statements stay — they're harmless no-ops on prod and only matter on a dev/local DB where the 2024 objects may still linger — but the migration/programmability comments no longer claim it's live on prod.

**Operator notes (hand-apply).** On the hot ~105M `Image` table: `ALTER TABLE ... DROP DEFAULT` takes **ACCESS EXCLUSIVE**, `CREATE TRIGGER` takes **SHARE ROW EXCLUSIVE** — both brief (catalog-only, no rewrite) but they block/queue behind writes. Apply off-peak with `SET lock_timeout = '5s';` and retry rather than blocking a long autovacuum/query; every statement is independently re-runnable. The verify script creates objects **on `"Image"`** (a tx-scoped audit trigger) — it is **dev-only, never run it against prod**.
