### PR TITLE
feat(admin): correct Image.sortAt backfill + PG↔BitDex audit

### DIFF
--- a/src/pages/api/admin/temp/audit-imageSortAt.ts
+++ b/src/pages/api/admin/temp/audit-imageSortAt.ts
@@ -1,0 +1,247 @@
+import { Prisma } from '@prisma/client';
+import type { NextApiRequest } from 'next';
+import * as z from 'zod';
+import { dbRead } from '~/server/db/client';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { booleanString } from '~/utils/zod-helpers';
+
+/**
+ * PG ↔ BitDex sortAt reconcile.
+ *
+ * Samples images, computes the PG-authored sort key for each, fetches the BitDex
+ * document, and compares. Stood up BEFORE cutover so the instrument is proven to
+ * fire on a seeded mismatch; usable both pre- and post-cutover.
+ *
+ * The compared value on both sides is SECONDS:
+ *   - PG:     EXTRACT(EPOCH FROM GREATEST(p."publishedAt", i."scannedAt",
+ *             i."createdAt"))::bigint  — the exact trigger formula (PR #3168),
+ *             LEFT JOIN so draft/postless images collapse to GREATEST(scannedAt,
+ *             createdAt).
+ *   - BitDex: the `sortAt` doc field, stored in seconds
+ *             (civitai-index.yaml: `sortAtUnix -> sortAt, ms_to_seconds: true`).
+ *
+ * Modes (interpretation only — raw counts are always reported):
+ *   - mode=pre  (default): BitDex sortAt is still ENGINE-COMPUTED
+ *     GREATEST(existedAt, publishedAt) with NO scannedAt. Mismatches where
+ *     scannedAt is the max are EXPECTED — they are exactly the rows the migration
+ *     changes. Pre-cutover this run measures that divergence + proves the fetch/
+ *     compare path works; it is NOT a pass/fail gate.
+ *   - mode=post: BitDex sortAt is INGESTED from the trigger value. Any mismatch is
+ *     a real drift; `ok` is false if mismatches > 0.
+ *
+ * Populations sampled (N each):
+ *   - recent:  images on posts published within `lookbackHours` (the hot head
+ *              where drift matters most and where the W1-4 misorder class lived).
+ *   - overall: random ids across the whole table.
+ *
+ * Seeded-mismatch proof (`seedMismatch=true`): the FIRST specimen's EXPECTED
+ * value is deliberately corrupted IN MEMORY before comparison. It MUST then read
+ * as a mismatch. This proves the alarm can fire. It NEVER writes to Image.
+ *
+ * Trigger:
+ *   /api/admin/temp/audit-imageSortAt?token=$WEBHOOK_TOKEN&mode=pre&n=200
+ *   ...&mode=post                              (post-cutover: mismatch => ok:false)
+ *   ...&seedMismatch=true                      (prove the alarm fires)
+ */
+
+const BITDEX_URL = process.env.BITDEX_URL || '';
+const INDEX = 'civitai';
+
+const schema = z.object({
+  mode: z.enum(['pre', 'post']).default('pre'),
+  n: z.coerce.number().min(1).max(5000).default(200),
+  lookbackHours: z.coerce.number().min(1).max(24 * 30).default(48),
+  // Exact-second equality is expected; ±tolerance absorbs ms→s truncation noise.
+  toleranceSecs: z.coerce.number().min(0).max(60).default(1),
+  // How many mismatch specimens to include in the response body.
+  specimenLimit: z.coerce.number().min(0).max(500).default(50),
+  seedMismatch: booleanString().default(false),
+});
+
+type Sampled = {
+  id: number;
+  formulaSecs: number | null;
+  publishedAt: Date | null;
+  scannedAt: Date | null;
+  createdAt: Date;
+  population: 'recent' | 'overall';
+};
+
+type Verdict = {
+  id: number;
+  population: 'recent' | 'overall';
+  pgSecs: number | null;
+  bitdexSecs: number | null;
+  deltaSecs: number | null;
+  status: 'match' | 'mismatch' | 'missing' | 'fetch_error';
+  seeded?: boolean;
+};
+
+export default WebhookEndpoint(async (req, res) => {
+  if (!BITDEX_URL) {
+    res.status(500).json({ error: 'BITDEX_URL not configured' });
+    return;
+  }
+  const result = await audit(req);
+  res.status(200).json(result);
+});
+
+async function audit(req: NextApiRequest) {
+  const params = schema.parse(req.query);
+
+  const recent = await sampleRecent(params.n, params.lookbackHours);
+  const overall = await sampleOverall(params.n);
+  const sampled = [...recent, ...overall];
+
+  const bitdexById = await fetchBitdexSortAt(sampled.map((s) => s.id));
+
+  const verdicts: Verdict[] = sampled.map((s, idx) => {
+    // Seeded proof: corrupt the FIRST specimen's expected value in memory only.
+    const seeded = params.seedMismatch && idx === 0;
+    const pgSecs = s.formulaSecs == null ? null : seeded ? s.formulaSecs + 999_999 : s.formulaSecs;
+
+    const bd = bitdexById.get(s.id);
+    if (bd === undefined) {
+      // No entry returned at all — treat as a fetch gap, not a data mismatch.
+      return { id: s.id, population: s.population, pgSecs, bitdexSecs: null, deltaSecs: null, status: 'fetch_error', ...(seeded ? { seeded } : {}) };
+    }
+    if (bd === null) {
+      // Doc exists but has no sortAt yet (pre-ingest). Not a drift.
+      return { id: s.id, population: s.population, pgSecs, bitdexSecs: null, deltaSecs: null, status: 'missing', ...(seeded ? { seeded } : {}) };
+    }
+    if (pgSecs == null) {
+      return { id: s.id, population: s.population, pgSecs: null, bitdexSecs: bd, deltaSecs: null, status: 'mismatch', ...(seeded ? { seeded } : {}) };
+    }
+    const delta = bd - pgSecs;
+    const status = Math.abs(delta) <= params.toleranceSecs ? 'match' : 'mismatch';
+    return { id: s.id, population: s.population, pgSecs, bitdexSecs: bd, deltaSecs: delta, status, ...(seeded ? { seeded } : {}) };
+  });
+
+  const counts = tally(verdicts);
+  const mismatches = verdicts.filter((v) => v.status === 'mismatch');
+
+  // Prove the seeded specimen actually flipped the alarm.
+  const seededSpecimen = verdicts.find((v) => v.seeded);
+  const seedProven = params.seedMismatch ? seededSpecimen?.status === 'mismatch' : undefined;
+
+  const ok =
+    (params.mode === 'post' ? counts.mismatch === 0 : true) &&
+    counts.fetch_error === 0 &&
+    (params.seedMismatch ? seedProven === true : true);
+
+  return {
+    ok,
+    mode: params.mode,
+    sampled: sampled.length,
+    counts,
+    seedMismatch: params.seedMismatch,
+    seedProven,
+    note:
+      params.mode === 'pre'
+        ? 'pre-cutover: BitDex sortAt is still engine-computed (no scannedAt); mismatches are the rows the migration will change, not failures.'
+        : 'post-cutover: BitDex sortAt is ingested; any mismatch is real drift.',
+    specimens: mismatches.slice(0, params.specimenLimit),
+  };
+}
+
+function tally(verdicts: Verdict[]) {
+  const c = { match: 0, mismatch: 0, missing: 0, fetch_error: 0 };
+  for (const v of verdicts) c[v.status]++;
+  return c;
+}
+
+// --- sampling -------------------------------------------------------------
+
+async function sampleRecent(n: number, lookbackHours: number): Promise<Sampled[]> {
+  const rows = await dbRead.$queryRaw<RawRow[]>(Prisma.sql`
+    SELECT i.id,
+           EXTRACT(EPOCH FROM GREATEST(p."publishedAt", i."scannedAt", i."createdAt"))::bigint AS formula_secs,
+           p."publishedAt", i."scannedAt", i."createdAt"
+    FROM "Image" i
+    JOIN "Post" p ON p.id = i."postId"
+    WHERE p."publishedAt" > now() - (${lookbackHours} * interval '1 hour')
+      AND p."publishedAt" <= now()
+    ORDER BY random()
+    LIMIT ${n}
+  `);
+  return rows.map((r) => toSampled(r, 'recent'));
+}
+
+async function sampleOverall(n: number): Promise<Sampled[]> {
+  // Random ids across [min,max]; LATERAL grabs the nearest existing row per pick.
+  // Cheap (index scans), unlike ORDER BY random() over the full table.
+  const rows = await dbRead.$queryRaw<RawRow[]>(Prisma.sql`
+    WITH bounds AS (SELECT MIN(id) AS lo, MAX(id) AS hi FROM "Image"),
+    picks AS (
+      SELECT (b.lo + floor(random() * (b.hi - b.lo)))::int AS rid
+      FROM bounds b, generate_series(1, ${n})
+    )
+    SELECT i.id,
+           EXTRACT(EPOCH FROM GREATEST(p."publishedAt", i."scannedAt", i."createdAt"))::bigint AS formula_secs,
+           p."publishedAt", i."scannedAt", i."createdAt"
+    FROM picks
+    JOIN LATERAL (
+      SELECT * FROM "Image" im WHERE im.id >= picks.rid ORDER BY im.id LIMIT 1
+    ) i ON true
+    LEFT JOIN "Post" p ON p.id = i."postId"
+  `);
+  // DISTINCT by id (random picks can collide near the top of the range).
+  const seen = new Set<number>();
+  return rows
+    .filter((r) => (seen.has(r.id) ? false : (seen.add(r.id), true)))
+    .map((r) => toSampled(r, 'overall'));
+}
+
+type RawRow = {
+  id: number;
+  // int8/bigint: node-pg returns it as a string; Number() normalizes.
+  formula_secs: string | number | null;
+  publishedAt: Date | null;
+  scannedAt: Date | null;
+  createdAt: Date;
+};
+
+function toSampled(r: RawRow, population: 'recent' | 'overall'): Sampled {
+  return {
+    id: r.id,
+    formulaSecs: r.formula_secs == null ? null : Number(r.formula_secs),
+    publishedAt: r.publishedAt,
+    scannedAt: r.scannedAt,
+    createdAt: r.createdAt,
+    population,
+  };
+}
+
+// --- BitDex fetch ---------------------------------------------------------
+
+/**
+ * Returns a map slot_id -> sortAt seconds. Value is `null` when the doc exists
+ * but carries no sortAt; the id is ABSENT from the map when the fetch itself
+ * failed (so callers can tell "not ingested" from "couldn't ask").
+ */
+async function fetchBitdexSortAt(ids: number[]): Promise<Map<number, number | null>> {
+  const out = new Map<number, number | null>();
+  const CHUNK = 500;
+  for (let i = 0; i < ids.length; i += CHUNK) {
+    const slice = ids.slice(i, i + CHUNK);
+    try {
+      const res = await fetch(`${BITDEX_URL}/api/indexes/${INDEX}/documents`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ slot_ids: slice, fields: ['sortAt'] }),
+      });
+      if (!res.ok) {
+        console.error(`[sortAt-audit] BitDex fetch ${res.status}`);
+        continue; // leave this slice's ids absent → fetch_error
+      }
+      const json = (await res.json()) as { documents?: { id: number; sortAt?: number }[] };
+      for (const doc of json.documents ?? []) {
+        out.set(doc.id, typeof doc.sortAt === 'number' ? doc.sortAt : null);
+      }
+    } catch (e) {
+      console.error('[sortAt-audit] BitDex fetch error', (e as Error).message);
+      // leave absent → fetch_error
+    }
+  }
+  return out;
+}

--- a/src/pages/api/admin/temp/audit-imageSortAt.ts
+++ b/src/pages/api/admin/temp/audit-imageSortAt.ts
@@ -21,10 +21,20 @@ import { booleanString } from '~/utils/zod-helpers';
  *             (civitai-index.yaml: `sortAtUnix -> sortAt, ms_to_seconds: true`).
  *
  * Modes (interpretation only — raw counts are always reported):
- *   - mode=pre  (default): BitDex sortAt is still ENGINE-COMPUTED
- *     GREATEST(existedAt, publishedAt) with NO scannedAt. Mismatches where
- *     scannedAt is the max are EXPECTED — they are exactly the rows the migration
- *     changes. Pre-cutover this run measures that divergence + proves the fetch/
+ *   - mode=pre  (default): BitDex sortAt is still ENGINE-COMPUTED as
+ *     GREATEST(existedAt, publishedAt), where existedAt = GREATEST(scannedAt,
+ *     createdAt). That is MATHEMATICALLY IDENTICAL to the trigger formula, so a
+ *     correctly-recomputed engine value MATCHES. Pre-cutover mismatches therefore
+ *     do NOT come from a formula difference; they come from two known classes:
+ *       (a) DOMINANT — the engine silently fails to fold a delivered publishedAt
+ *           into sortAt on ~7-28% of recent publishes (W1-4 specimens,
+ *           docs/_in/sortat-divergence-specimens-2026-07-16.md), leaving sortAt
+ *           stuck at existedAt. These are exactly the rows ingestion fixes.
+ *       (b) the scheduled / future-publishedAt head (quarantined, isPublished=
+ *           false) whose engine sortAt has not crossed Tf.
+ *     A clean-ish recent-window baseline is NOT a broken instrument — it means the
+ *     recompute happened to succeed on the sample; mismatches concentrate in
+ *     class (a). Pre-cutover this run measures that divergence + proves the fetch/
  *     compare path works; it is NOT a pass/fail gate.
  *   - mode=post: BitDex sortAt is INGESTED from the trigger value. Any mismatch is
  *     a real drift; `ok` is false if mismatches > 0.
@@ -138,7 +148,7 @@ async function audit(req: NextApiRequest) {
     seedProven,
     note:
       params.mode === 'pre'
-        ? 'pre-cutover: BitDex sortAt is still engine-computed (no scannedAt); mismatches are the rows the migration will change, not failures.'
+        ? 'pre-cutover: engine sortAt = GREATEST(existedAt, publishedAt) is formula-identical to the trigger; mismatches are the engine recompute-failure class (~7-28% of recent publishes, sortAt stuck at existedAt) + the scheduled future-publishedAt head, not failures of this audit.'
         : 'post-cutover: BitDex sortAt is ingested; any mismatch is real drift.',
     specimens: mismatches.slice(0, params.specimenLimit),
   };

--- a/src/pages/api/admin/temp/migrate-imageSortAt.ts
+++ b/src/pages/api/admin/temp/migrate-imageSortAt.ts
@@ -41,10 +41,18 @@ import { booleanString } from '~/utils/zod-helpers';
  *     Both are required here, so the loop is explicit and ordered. The keyset
  *     shape (id-range windows, cancellableQuery) is retained from the original.
  *
+ * Cost per batch: each row the UPDATE actually writes fires the live BitDex Image
+ * trigger, which runs ~6 Post PK subselects to rebuild the row's fan-out payload.
+ * So a batch's true cost scales with rows CHANGED (not rows scanned) times that
+ * per-row trigger work — another reason batchSize is capped modestly (200k) and
+ * the skip-correct guard matters: unchanged rows pay neither the write nor the
+ * trigger.
+ *
  * Pacing / safety for a 105M-row table:
  *   - `sleepMs` between batches.
- *   - After each batch, wait for the read replicas to catch up (checkNotUpToDate)
- *     before issuing the next write, bounding replica lag. Capped by maxLagWaitMs.
+ *   - After each batch, wait for the read replicas to replay THIS batch's own
+ *     write (checkNotUpToDate on the post-UPDATE LSN) before the next write,
+ *     bounding replica lag. Capped by maxLagWaitMs.
  *   - Resumable: the last completed cursor is persisted in KeyValue under
  *     `PROGRESS_KEY`; a re-run with resume=true (default) continues from there.
  *
@@ -63,8 +71,10 @@ const PROGRESS_KEY = 'backfill:image-sortat:v2';
 
 const schema = z.object({
   dryRun: booleanString().default(true),
-  // id-range width per batch (keyset window, not a row count).
-  batchSize: z.coerce.number().min(1).max(5_000_000).default(50_000),
+  // id-range width per batch (keyset window, not a row count). Capped at 200k:
+  // the write is a single transaction and each CHANGED row also pays ~6 Post PK
+  // subselects in the live BitDex Image trigger, so a wide window is a footgun.
+  batchSize: z.coerce.number().min(1).max(200_000).default(50_000),
   // Milliseconds to sleep between batches (throttle write pressure).
   sleepMs: z.coerce.number().min(0).max(60_000).default(250),
   // Explicit lower bound. Omitted + resume=true → continue from saved cursor.
@@ -123,11 +133,14 @@ async function run(req: NextApiRequest) {
       totalScanned += hi - lo;
       totalUpdated += Number(rows[0]?.would ?? 0);
     } else {
-      const lsnBefore = await getCurrentLSN();
       const { result } = await pgDbWrite.cancellableQuery<{ id: number }>(updateSql(lo, hi));
       const rows = await result();
       totalScanned += hi - lo;
       totalUpdated += rows.length; // RETURNING i.id → one row per write
+
+      // Capture the LSN AFTER this batch commits so the gate below waits for THIS
+      // batch's own write to replay — not the previous one.
+      const lsnAfter = await getCurrentLSN();
 
       // Persist progress after each committed batch so a crash/kill resumes here.
       await dbKV.set<Progress>(PROGRESS_KEY, {
@@ -139,10 +152,10 @@ async function run(req: NextApiRequest) {
 
       // Bound replica lag: don't start the next write until the replicas have
       // replayed this one (or we hit the cap).
-      if (params.lagCheck && lsnBefore) {
+      if (params.lagCheck && lsnAfter) {
         const waitStart = Date.now();
         while (
-          (await checkNotUpToDate(lsnBefore)) &&
+          (await checkNotUpToDate(lsnAfter)) &&
           Date.now() - waitStart < params.maxLagWaitMs
         ) {
           await sleep(500);

--- a/src/pages/api/admin/temp/migrate-imageSortAt.ts
+++ b/src/pages/api/admin/temp/migrate-imageSortAt.ts
@@ -2,63 +2,208 @@ import { Prisma } from '@prisma/client';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
 import { dbRead } from '~/server/db/client';
-import { dataProcessor } from '~/server/db/db-helpers';
+import { checkNotUpToDate, dbKV, getCurrentLSN } from '~/server/db/db-helpers';
 import { pgDbWrite } from '~/server/db/pgDb';
+import { sleep } from '~/server/utils/concurrency-helpers';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { booleanString } from '~/utils/zod-helpers';
+
+/**
+ * Backfill Image."sortAt" to the PG-authored feed sort key.
+ *
+ * This restates, for every historical row, the exact value the steady-state
+ * triggers now write (packages/civitai-db-schema/prisma/programmability/
+ * image_post_triggers.sql, PR #3168):
+ *
+ *   sortAt = GREATEST(post.publishedAt, image.scannedAt, image.createdAt)
+ *
+ * GREATEST ignores NULLs, so a draft / unpublished / postless image (no
+ * publishedAt, resolved here by the LEFT JOIN yielding NULL) collapses to
+ * GREATEST(scannedAt, createdAt); createdAt is NOT NULL so a value always
+ * results. There is NO sentinel — this only fixes the sort *position*;
+ * visibility is gated downstream (isPublished under the frozen BitDex engine).
+ *
+ * The previous body of this file used COALESCE(post.publishedAt, createdAt) with
+ * NO scannedAt — the OLD, WRONG formula. It has been replaced wholesale.
+ *
+ * Semantics vs the old script:
+ *   - Correct formula (adds scannedAt; GREATEST not COALESCE).
+ *   - Skip-correct: the UPDATE writes only rows whose sortAt IS DISTINCT FROM the
+ *     formula, so a second pass over an already-correct range does ZERO writes.
+ *     This makes the job idempotent and cheap to re-run.
+ *   - Does NOT bump updatedAt. This is a data correction; bumping updatedAt on
+ *     105M rows would fan a re-index / change-emission storm. (The steady-state
+ *     Post fan-out trigger DOES bump updatedAt on live publishes — that path is
+ *     unaffected; only this bulk correction abstains.)
+ *   - Sequential keyset cursor (not the concurrent dataProcessor): the concurrent
+ *     scheduler completes id-ranges out of order, which is incompatible with a
+ *     correct resumable high-water mark and with per-batch replica-lag gating.
+ *     Both are required here, so the loop is explicit and ordered. The keyset
+ *     shape (id-range windows, cancellableQuery) is retained from the original.
+ *
+ * Pacing / safety for a 105M-row table:
+ *   - `sleepMs` between batches.
+ *   - After each batch, wait for the read replicas to catch up (checkNotUpToDate)
+ *     before issuing the next write, bounding replica lag. Capped by maxLagWaitMs.
+ *   - Resumable: the last completed cursor is persisted in KeyValue under
+ *     `PROGRESS_KEY`; a re-run with resume=true (default) continues from there.
+ *
+ * Dry-run by default — counts rows that WOULD change per batch, writes nothing.
+ *
+ * Trigger:
+ *   /api/admin/temp/migrate-imageSortAt?token=$WEBHOOK_TOKEN                 (dry run)
+ *   /api/admin/temp/migrate-imageSortAt?token=$WEBHOOK_TOKEN&dryRun=false    (apply)
+ *   ...&dryRun=false&resume=false&start=0                                    (restart)
+ */
+
+const PROGRESS_KEY = 'backfill:image-sortat:v2';
 
 const schema = z.object({
-  concurrency: z.coerce.number().min(1).max(50).optional().default(15),
-  batchSize: z.coerce.number().min(0).optional().default(500),
-  start: z.coerce.number().min(0).optional().default(0),
+  dryRun: booleanString().default(true),
+  // id-range width per batch (keyset window, not a row count).
+  batchSize: z.coerce.number().min(1).max(5_000_000).default(50_000),
+  // Milliseconds to sleep between batches (throttle write pressure).
+  sleepMs: z.coerce.number().min(0).max(60_000).default(250),
+  // Explicit lower bound. Omitted + resume=true → continue from saved cursor.
+  start: z.coerce.number().min(0).optional(),
+  // Explicit upper bound (inclusive). Omitted → MAX(id) at launch.
   end: z.coerce.number().min(0).optional(),
-  after: z.coerce.date().optional(),
-  before: z.coerce.date().optional(),
+  // Continue from the persisted cursor when `start` is not given.
+  resume: booleanString().default(true),
+  // Gate the next batch on read-replica catch-up.
+  lagCheck: booleanString().default(true),
+  // Max time to wait for replicas per batch before proceeding anyway (ms).
+  maxLagWaitMs: z.coerce.number().min(0).max(300_000).default(30_000),
 });
+
+type Progress = { cursor: number; updated: number; scanned: number; updatedAt: string };
 
 export default WebhookEndpoint(async (req, res) => {
-  console.time('MIGRATION_TIMER');
-  await migrateImages(req, res);
-  console.timeEnd('MIGRATION_TIMER');
-  res.status(200).json({ finished: true });
+  console.time('IMAGE_SORTAT_BACKFILL');
+  const result = await run(req);
+  console.timeEnd('IMAGE_SORTAT_BACKFILL');
+  res.status(200).json(result);
 });
 
-async function migrateImages(req: NextApiRequest, res: NextApiResponse) {
+async function run(req: NextApiRequest) {
   const params = schema.parse(req.query);
-  await dataProcessor({
-    params,
-    runContext: res,
-    rangeFetcher: async (context) => {
-      if (params.after) {
-        const results = await dbRead.$queryRaw<{ start: number; end: number }[]>`
-        WITH dates AS (
-          SELECT
-          MIN("createdAt") as start,
-          MAX("createdAt") as end
-          FROM "Image" WHERE "createdAt" > ${params.after}
-        )
-        SELECT MIN(id) as start, MAX(id) as end
-        FROM "Image" i
-        JOIN dates d ON d.start = i."createdAt" OR d.end = i."createdAt";`;
-        return results[0];
-      }
-      const [{ max }] = await dbRead.$queryRaw<{ max: number }[]>(
-        Prisma.sql`SELECT MAX(id) "max" FROM "Image";`
+
+  const [{ max }] = await dbRead.$queryRaw<{ max: number }[]>(
+    Prisma.sql`SELECT MAX(id)::int AS max FROM "Image";`
+  );
+  const end = params.end ?? max ?? 0;
+
+  // Resume: explicit start wins; else saved cursor; else 0.
+  const saved = params.resume ? await dbKV.get<Progress>(PROGRESS_KEY) : undefined;
+  const start = params.start ?? saved?.cursor ?? 0;
+
+  console.log(
+    `[sortAt-backfill] start=${start} end=${end} batchSize=${params.batchSize} ` +
+      `sleepMs=${params.sleepMs} dryRun=${params.dryRun} resume=${params.resume}` +
+      (saved ? ` (resumed from cursor=${saved.cursor}, prior updated=${saved.updated})` : '')
+  );
+
+  let cursor = start;
+  let totalScanned = saved && params.resume ? saved.scanned : 0;
+  let totalUpdated = saved && params.resume ? saved.updated : 0;
+  let batches = 0;
+
+  while (cursor <= end) {
+    const lo = cursor;
+    const hi = Math.min(cursor + params.batchSize, end + 1); // [lo, hi)
+
+    if (params.dryRun) {
+      const { result } = await pgDbWrite.cancellableQuery<{ would: number }>(
+        candidateCountSql(lo, hi)
       );
-      return { ...context, end: max };
-    },
-    processor: async ({ start, end, cancelFns }) => {
-      const { cancel, result } = await pgDbWrite.cancellableQuery(Prisma.sql`
-        UPDATE "Image" i
-        SET "sortAt" =  COALESCE((
-          SELECT "publishedAt"
-          FROM "Post" p
-          WHERE p.id = i."postId"
-        ), i."createdAt")
-        WHERE i.id BETWEEN ${start} AND ${end};
-      `);
-      cancelFns.push(cancel);
-      await result();
-      console.log(`Updated images ${start} - ${end}`);
-    },
-  });
+      const rows = await result();
+      totalScanned += hi - lo;
+      totalUpdated += Number(rows[0]?.would ?? 0);
+    } else {
+      const lsnBefore = await getCurrentLSN();
+      const { result } = await pgDbWrite.cancellableQuery<{ id: number }>(updateSql(lo, hi));
+      const rows = await result();
+      totalScanned += hi - lo;
+      totalUpdated += rows.length; // RETURNING i.id → one row per write
+
+      // Persist progress after each committed batch so a crash/kill resumes here.
+      await dbKV.set<Progress>(PROGRESS_KEY, {
+        cursor: hi,
+        updated: totalUpdated,
+        scanned: totalScanned,
+        updatedAt: new Date().toISOString(),
+      });
+
+      // Bound replica lag: don't start the next write until the replicas have
+      // replayed this one (or we hit the cap).
+      if (params.lagCheck && lsnBefore) {
+        const waitStart = Date.now();
+        while (
+          (await checkNotUpToDate(lsnBefore)) &&
+          Date.now() - waitStart < params.maxLagWaitMs
+        ) {
+          await sleep(500);
+        }
+        if (Date.now() - waitStart >= params.maxLagWaitMs) {
+          console.warn(
+            `[sortAt-backfill] replica lag > ${params.maxLagWaitMs}ms at cursor=${hi}; proceeding`
+          );
+        }
+      }
+    }
+
+    batches++;
+    if (batches % 20 === 0) {
+      console.log(
+        `[sortAt-backfill] cursor=${hi}/${end} scanned=${totalScanned} ${
+          params.dryRun ? 'wouldUpdate' : 'updated'
+        }=${totalUpdated}`
+      );
+    }
+
+    cursor = hi;
+    if (params.sleepMs > 0 && cursor <= end) await sleep(params.sleepMs);
+  }
+
+  const summary = {
+    finished: true,
+    dryRun: params.dryRun,
+    start,
+    end,
+    batches,
+    scanned: totalScanned,
+    [params.dryRun ? 'wouldUpdate' : 'updated']: totalUpdated,
+  };
+  console.log('[sortAt-backfill] done', summary);
+  return summary;
+}
+
+// GREATEST(post.publishedAt, image.scannedAt, image.createdAt), skip-correct.
+// LEFT JOIN → NULL publishedAt for draft/postless images; GREATEST ignores it.
+function updateSql(lo: number, hi: number) {
+  return Prisma.sql`
+    WITH batch AS (
+      SELECT i.id,
+             GREATEST(p."publishedAt", i."scannedAt", i."createdAt") AS new_sort_at
+      FROM "Image" i
+      LEFT JOIN "Post" p ON p.id = i."postId"
+      WHERE i.id >= ${lo} AND i.id < ${hi}
+    )
+    UPDATE "Image" i
+    SET "sortAt" = b.new_sort_at
+    FROM batch b
+    WHERE i.id = b.id
+      AND i."sortAt" IS DISTINCT FROM b.new_sort_at
+    RETURNING i.id
+  `;
+}
+
+function candidateCountSql(lo: number, hi: number) {
+  return Prisma.sql`
+    SELECT COUNT(*)::int AS would
+    FROM "Image" i
+    LEFT JOIN "Post" p ON p.id = i."postId"
+    WHERE i.id >= ${lo} AND i.id < ${hi}
+      AND i."sortAt" IS DISTINCT FROM GREATEST(p."publishedAt", i."scannedAt", i."createdAt")
+  `;
 }

--- a/src/pages/api/admin/temp/migrate-imageSortAt.ts
+++ b/src/pages/api/admin/temp/migrate-imageSortAt.ts
@@ -49,6 +49,9 @@ import { booleanString } from '~/utils/zod-helpers';
  *     `PROGRESS_KEY`; a re-run with resume=true (default) continues from there.
  *
  * Dry-run by default — counts rows that WOULD change per batch, writes nothing.
+ * Note: a dry run also honors the saved resume cursor, so after a partial apply it
+ * estimates only the REMAINING id-range. For a full-table estimate pass
+ * resume=false (dry runs never write the cursor, so this is safe).
  *
  * Trigger:
  *   /api/admin/temp/migrate-imageSortAt?token=$WEBHOOK_TOKEN                 (dry run)


### PR DESCRIPTION
Task **W2-3 (#11)** of BitDex `scheduled-publish-execution-plan.md`. Two admin endpoints under `src/pages/api/admin/temp/`. **Do not merge** — awaiting independent review + Justin's approval per the standing rule.

## What

- **`migrate-imageSortAt.ts`** (rewritten): backfill `Image.sortAt` to the PG-authored feed sort key.
- **`audit-imageSortAt.ts`** (new): PG↔BitDex `sortAt` reconcile, stood up pre-cutover with a seeded-alarm proof.

## The formula (from PR #3168 triggers, verbatim)

```
sortAt = GREATEST(post.publishedAt, image.scannedAt, image.createdAt)
```

`GREATEST` ignores NULLs → draft/postless images (LEFT JOIN, NULL publishedAt) collapse to `GREATEST(scannedAt, createdAt)`. The **old** body used `COALESCE(publishedAt, createdAt)` — dropped `scannedAt`, wrong. Replaced wholesale.

## Backfill design

- **Skip-correct**: writes only rows where `sortAt IS DISTINCT FROM` the formula → idempotent, re-runs are cheap.
- **No `updatedAt` bump** (a 105M-row bump would fan a re-index storm; the live Post fan-out trigger still bumps on real publishes).
- **Sequential keyset cursor** (not the concurrent `dataProcessor`): reviewed the original — keyset/batch shape sound, but no pacing / no lag-awareness / no recorded progress, and `dataProcessor`'s out-of-order completion is incompatible with a correct resume cursor + per-batch lag gating. Keyset id-range windows + `cancellableQuery` retained.
- **Resumable** (`KeyValue` cursor), **replica-lag aware** (`checkNotUpToDate` gate per batch), **configurable sleep**. Dry-run by default.

## Audit design

- Samples `recent` (posts published within `lookbackHours`) + `overall` (random ids); compares PG formula **seconds** vs BitDex doc `sortAt` **seconds** (BitDex stores `ms_to_seconds`).
- `mode=pre` (informational — pre-cutover divergence is expected where scannedAt dominates) / `mode=post` (mismatch ⇒ `ok:false`).
- `seedMismatch=true` corrupts the first specimen's **expected** value in memory to prove the alarm fires — **never writes to `Image`**.

## Verification

- `npx tsc --noEmit` clean project-wide.
- How-to (pacing for 105M+, expected duration, rollback rationale): `docs/_in/sortat-backfill-audit-howto-2026-07-16.md` in bitdex-v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)