### PR TITLE
App Blocks mod review sandbox: render pending blocks with a strict malicious-app guard

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -2115,6 +2115,17 @@ export function PageBlockHost({
       const req = resolveGetWildcardPackRequest(raw);
       if (!req) return; // missing/invalid requestId or modelVersionId → drop
       const { requestId, modelVersionId } = req;
+      if (reviewMode) {
+        // 🔴 token-INDEPENDENT (session-cookie-authed) op — it does NOT go through
+        // the scope-stripped review block token, so it is the ONE handler that
+        // would otherwise bypass the review token defense entirely: an untrusted
+        // pending block could drive the MOD's real download entitlements to
+        // resolve+fetch+unzip+parse an arbitrary modelVersionId's wildcard pack and
+        // read the contents into the sandboxed iframe. NACK before resolving or
+        // downloading anything (fail-fast, never a hang).
+        send('WILDCARD_PACK_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
+        return;
+      }
       // Concurrency cap (host-side backpressure): bound the per-tab memory. The
       // check→increment runs synchronously before the first await (single-
       // threaded), so N concurrent GET_WILDCARD_PACKs can't all pass the gate.
@@ -2156,7 +2167,7 @@ export function PageBlockHost({
       }
     });
     return off;
-  }, [onMessage, send, resolveWildcardPackMutation]);
+  }, [onMessage, send, resolveWildcardPackMutation, reviewMode]);
 
   const showIframe = status === 'loading' || status === 'ready';
   const isReady = status === 'ready';

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -124,6 +124,12 @@ const BUZZ_PURCHASE_AMOUNT_CAP = 50_000;
 
 type Status = 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token' | 'error';
 
+// MOD REVIEW SANDBOX (#2831): the reason string every reviewMode NACK carries — a
+// clear, block-surfaced message so the mod (and the block's own error UI)
+// understands why a side-effect refused, rather than the block silently hanging
+// (gotcha #73). Module-scope so referencing it in a handler adds no effect dep.
+const REVIEW_NACK_MESSAGE = 'not available in review preview';
+
 export interface PageBlockHostProps {
   /** AppBlock id (`apb_*`) — used to build the BLOCK_INIT ids + trust chrome. */
   appBlockId: string;
@@ -174,6 +180,17 @@ export interface PageBlockHostProps {
    *  in-flight mint; the endpoint is rate-limited 60/min). Omitted → Retry on an
    *  auth error only remounts (the pre-fix dead-end), so the route MUST pass it. */
   onRetryToken?: () => void;
+  /**
+   * MOD REVIEW SANDBOX (#2831) read-only gate. Default false → prod behavior is
+   * BYTE-IDENTICAL. When true (the mod review preview host only), EVERY
+   * side-effecting / money / private / cross-user handler replies with a
+   * KNOWN-SHAPE NACK (fail-fast, never a hang — gotcha #73) instead of doing the
+   * work, and the render-safe read handlers (BLOCK_INIT / BLOCK_READY / the
+   * resource+checkpoint pickers / self-viewer / shared reads / sign-in) stay live.
+   * This is a REQUIRED defense layer that holds even if the review token were ever
+   * mis-scoped — no single layer is load-bearing.
+   */
+  reviewMode?: boolean;
 }
 
 export function PageBlockHost({
@@ -198,6 +215,7 @@ export function PageBlockHost({
   theme,
   onConsentGranted,
   onRetryToken,
+  reviewMode = false,
 }: PageBlockHostProps) {
   const router = useRouter();
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
@@ -486,6 +504,10 @@ export function PageBlockHost({
   // the void and the block hung on "confirm in the Civitai dialog".
   useEffect(() => {
     const off = onMessage<{ scopes?: unknown } | undefined>('REQUEST_CONSENT', () => {
+      // reviewMode: a consent grant re-mints the token with WIDER scopes — never
+      // let untrusted review code pop a permission modal at the mod. Fire-and-
+      // forget ⇒ dropping it never hangs the block.
+      if (reviewMode) return;
       // PageBlockHost's local Status carries an extra terminal `'error'` variant
       // (a hard mint failure) the shared gate's HostStatus union doesn't model.
       // The gate only ever grants when status === 'ready', and `'error'` is a
@@ -510,7 +532,7 @@ export function PageBlockHost({
       });
     });
     return off;
-  }, [onMessage, status, missingScopes, appBlockId, appName, onConsentGranted]);
+  }, [onMessage, status, missingScopes, appBlockId, appName, onConsentGranted, reviewMode]);
 
   // Deep-link bridge — block requests in-page navigation. The block may push a
   // new sub-path WITHIN its own page space; we constrain it to the page route so
@@ -521,6 +543,11 @@ export function PageBlockHost({
   // popstate handler below.
   useEffect(() => {
     const off = onMessage<{ path?: unknown } | undefined>('NAVIGATE', (raw) => {
+      // reviewMode: the review host is a MODAL, not the `/apps/run/<slug>` page —
+      // let a block yank the mod's router and it would navigate them off the
+      // review flow (to a page a pending app doesn't even have). Fire-and-forget
+      // ⇒ dropping it never hangs the block.
+      if (reviewMode) return;
       if (status !== 'ready') return; // pre-handshake blocks can't drive nav
       const rawPath = raw && typeof raw === 'object' ? (raw as { path?: unknown }).path : undefined;
       if (typeof rawPath !== 'string') return;
@@ -533,7 +560,7 @@ export function PageBlockHost({
       void router.push(target, undefined, { shallow: true });
     });
     return off;
-  }, [onMessage, status, router, slug]);
+  }, [onMessage, status, router, slug, reviewMode]);
 
   // Forward host-side navigation (back/forward, or our own shallow push) into
   // the block so it can re-render the right view. Fires whenever the resolved
@@ -634,6 +661,17 @@ export function PageBlockHost({
     const off = onMessage<{ requestId?: unknown; body?: unknown } | undefined>(
       'SUBMIT_WORKFLOW',
       async (raw) => {
+        if (reviewMode) {
+          // Real Buzz spend — NACK with the failure snapshot the block awaits so
+          // it fails fast (never a hang) and never reaches submitWorkflowMutation.
+          if (raw && typeof raw.requestId === 'string') {
+            send('WORKFLOW_SUBMITTED', {
+              requestId: raw.requestId,
+              snapshot: failureSnapshot(new Error(REVIEW_NACK_MESSAGE)),
+            });
+          }
+          return;
+        }
         if (!raw || typeof raw.requestId !== 'string' || !token) return;
         const requestId = raw.requestId;
         try {
@@ -649,13 +687,22 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, submitWorkflowMutation]);
+  }, [onMessage, send, token, submitWorkflowMutation, reviewMode]);
 
   // ESTIMATE_WORKFLOW → blocks.estimateWorkflow → ESTIMATE_RESULT.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; body?: unknown } | undefined>(
       'ESTIMATE_WORKFLOW',
       async (raw) => {
+        if (reviewMode) {
+          if (raw && typeof raw.requestId === 'string') {
+            send('ESTIMATE_RESULT', {
+              requestId: raw.requestId,
+              snapshot: failureSnapshot(new Error(REVIEW_NACK_MESSAGE)),
+            });
+          }
+          return;
+        }
         if (!raw || typeof raw.requestId !== 'string' || !token) return;
         const requestId = raw.requestId;
         try {
@@ -670,13 +717,22 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, estimateWorkflowMutation]);
+  }, [onMessage, send, token, estimateWorkflowMutation, reviewMode]);
 
   // POLL_WORKFLOW → blocks.pollWorkflow → WORKFLOW_STATUS.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; workflowId?: unknown } | undefined>(
       'POLL_WORKFLOW',
       async (raw) => {
+        if (reviewMode) {
+          if (raw && typeof raw.requestId === 'string') {
+            send('WORKFLOW_STATUS', {
+              requestId: raw.requestId,
+              snapshot: failureSnapshot(new Error(REVIEW_NACK_MESSAGE)),
+            });
+          }
+          return;
+        }
         if (
           !raw ||
           typeof raw.requestId !== 'string' ||
@@ -699,7 +755,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, pollWorkflowMutation]);
+  }, [onMessage, send, token, pollWorkflowMutation, reviewMode]);
 
   // CANCEL_WORKFLOW → blocks.cancelWorkflow → WORKFLOW_CANCELED. Ownership is
   // enforced server-side by the viewer's orchestrator token.
@@ -707,6 +763,15 @@ export function PageBlockHost({
     const off = onMessage<{ requestId?: unknown; workflowId?: unknown } | undefined>(
       'CANCEL_WORKFLOW',
       async (raw) => {
+        if (reviewMode) {
+          if (raw && typeof raw.requestId === 'string') {
+            send('WORKFLOW_CANCELED', {
+              requestId: raw.requestId,
+              snapshot: failureSnapshot(new Error(REVIEW_NACK_MESSAGE)),
+            });
+          }
+          return;
+        }
         if (
           !raw ||
           typeof raw.requestId !== 'string' ||
@@ -729,7 +794,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, cancelWorkflowMutation]);
+  }, [onMessage, send, token, cancelWorkflowMutation, reviewMode]);
 
   // QUERY_APP_WORKFLOWS → blocks.queryAppWorkflows → APP_WORKFLOWS_RESULT. The
   // app's OWN tag-scoped generation subqueue (host page token + SERVER-forced
@@ -744,6 +809,12 @@ export function PageBlockHost({
       async (raw) => {
         if (!raw || typeof raw.requestId !== 'string') return;
         const requestId = raw.requestId;
+        if (reviewMode) {
+          // The app's generation subqueue read — NACK (workflow family, and the
+          // synthetic review appId has no queue anyway). Error-shape reply, no hang.
+          send('APP_WORKFLOWS_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
+          return;
+        }
         if (!token) {
           send('APP_WORKFLOWS_RESULT', { requestId, error: 'no block token' });
           return;
@@ -765,7 +836,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, queryAppWorkflowsMutation]);
+  }, [onMessage, send, token, queryAppWorkflowsMutation, reviewMode]);
 
   // CANCEL_APP_WORKFLOW → blocks.cancelAppWorkflow → CANCEL_APP_WORKFLOW_RESULT.
   // FAIL-CLOSED server-side (ownership + app-tag guard — the orchestrator by-id
@@ -787,6 +858,10 @@ export function PageBlockHost({
           return;
         }
         const requestId = raw.requestId;
+        if (reviewMode) {
+          send('CANCEL_APP_WORKFLOW_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
+          return;
+        }
         if (!token) {
           send('CANCEL_APP_WORKFLOW_RESULT', { requestId, error: 'no block token' });
           return;
@@ -806,7 +881,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, cancelAppWorkflowMutation]);
+  }, [onMessage, send, token, cancelAppWorkflowMutation, reviewMode]);
 
   // GET_BUZZ_BALANCE → blocks.getMyBuzzBalance → BUZZ_BALANCE_RESULT. The block's
   // per-account (blue/green/yellow) balance read that backs the SDK
@@ -828,6 +903,11 @@ export function PageBlockHost({
       async (raw) => {
         if (!raw || typeof raw.requestId !== 'string') return;
         const requestId = raw.requestId;
+        if (reviewMode) {
+          // Private financial read — NACK (the review token has no buzz:read:self).
+          send('BUZZ_BALANCE_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
+          return;
+        }
         if (!token) {
           send('BUZZ_BALANCE_RESULT', { requestId, error: 'no block token' });
           return;
@@ -844,7 +924,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, getMyBuzzBalanceMutation]);
+  }, [onMessage, send, token, getMyBuzzBalanceMutation, reviewMode]);
 
   // GET_BUZZ_TRANSACTIONS → blocks.getMyBuzzTransactions → BUZZ_TRANSACTIONS_RESULT.
   // The Buzz-dashboard ledger read. Host-MEDIATED (the iframe never holds the
@@ -858,6 +938,10 @@ export function PageBlockHost({
       async (raw) => {
         if (!raw || typeof raw.requestId !== 'string') return;
         const requestId = raw.requestId;
+        if (reviewMode) {
+          send('BUZZ_TRANSACTIONS_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
+          return;
+        }
         if (!token) {
           send('BUZZ_TRANSACTIONS_RESULT', { requestId, error: 'no block token' });
           return;
@@ -882,7 +966,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, getMyBuzzTransactionsMutation]);
+  }, [onMessage, send, token, getMyBuzzTransactionsMutation, reviewMode]);
 
   // GET_BUZZ_ACCOUNTS → blocks.getMyBuzzAccounts → BUZZ_ACCOUNTS_RESULT. All-pool
   // balances (spendable + creator payout pools). Same host-mediated + consent +
@@ -893,6 +977,10 @@ export function PageBlockHost({
       async (raw) => {
         if (!raw || typeof raw.requestId !== 'string') return;
         const requestId = raw.requestId;
+        if (reviewMode) {
+          send('BUZZ_ACCOUNTS_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
+          return;
+        }
         if (!token) {
           send('BUZZ_ACCOUNTS_RESULT', { requestId, error: 'no block token' });
           return;
@@ -909,7 +997,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, getMyBuzzAccountsMutation]);
+  }, [onMessage, send, token, getMyBuzzAccountsMutation, reviewMode]);
 
   // GET_DAILY_COMPENSATION → blocks.getMyDailyCompensation → DAILY_COMPENSATION_RESULT.
   // Per-modelVersion generation earnings for the month of `date`. Same contract.
@@ -919,6 +1007,11 @@ export function PageBlockHost({
       async (raw) => {
         if (!raw || typeof raw.requestId !== 'string') return;
         const requestId = raw.requestId;
+        if (reviewMode) {
+          // Private per-model earnings — NACK (buzz-read family; no scope granted).
+          send('DAILY_COMPENSATION_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
+          return;
+        }
         if (!token) {
           send('DAILY_COMPENSATION_RESULT', { requestId, error: 'no block token' });
           return;
@@ -940,7 +1033,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, getMyDailyCompensationMutation]);
+  }, [onMessage, send, token, getMyDailyCompensationMutation, reviewMode]);
 
   // GET_VIEWER → blocks.getMyViewer → VIEWER_RESULT. The block's "who am I" read
   // that backs the SDK `useViewer()` hook — the host-mediated successor to the
@@ -997,6 +1090,14 @@ export function PageBlockHost({
     const off = onMessage<{ requestId?: unknown; suggestedAmount?: unknown } | undefined>(
       'OPEN_BUZZ_PURCHASE',
       (raw) => {
+        if (reviewMode) {
+          // Real-money top-up — never summon the Buy-Buzz modal at the mod. Reply
+          // the not-purchased result the block awaits (fail-fast, no hang).
+          if (raw && typeof raw.requestId === 'string') {
+            send('BUZZ_PURCHASE_RESULT', { requestId: raw.requestId, purchased: false });
+          }
+          return;
+        }
         // PageBlockHost's local Status carries an extra terminal `'error'`
         // variant the shared gate's HostStatus union doesn't model; collapse it
         // to a non-ready sentinel (the gate only ever opens when status ===
@@ -1047,7 +1148,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, status, appId, appBlockId, blockInstanceId]);
+  }, [onMessage, send, status, appId, appBlockId, blockInstanceId, reviewMode]);
 
   // ── Sign-in bridge: REQUEST_SIGN_IN (anonymous conversion) ─────────────────
   //
@@ -1108,6 +1209,18 @@ export function PageBlockHost({
     const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
       'APP_STORAGE_GET',
       async (raw) => {
+        if (reviewMode) {
+          // Per-user App Storage — NACK (the synthetic review appId has no storage
+          // namespace, and the token carries no apps:storage scope). Error-shape.
+          if (raw && typeof raw.requestId === 'string') {
+            send('APP_STORAGE_GET_RESULT', {
+              requestId: raw.requestId,
+              value: null,
+              error: REVIEW_NACK_MESSAGE,
+            });
+          }
+          return;
+        }
         if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
           return;
         const requestId = raw.requestId;
@@ -1127,13 +1240,23 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, trpcUtils]);
+  }, [onMessage, send, token, trpcUtils, reviewMode]);
 
   // APP_STORAGE_SET → apps.storage.set → APP_STORAGE_SET_RESULT.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown; value?: unknown } | undefined>(
       'APP_STORAGE_SET',
       async (raw) => {
+        if (reviewMode) {
+          if (raw && typeof raw.requestId === 'string') {
+            send('APP_STORAGE_SET_RESULT', {
+              requestId: raw.requestId,
+              ok: false,
+              error: REVIEW_NACK_MESSAGE,
+            });
+          }
+          return;
+        }
         if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
           return;
         const requestId = raw.requestId;
@@ -1158,13 +1281,24 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, storageSetMutation]);
+  }, [onMessage, send, token, storageSetMutation, reviewMode]);
 
   // APP_STORAGE_DELETE → apps.storage.delete → APP_STORAGE_DELETE_RESULT.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
       'APP_STORAGE_DELETE',
       async (raw) => {
+        if (reviewMode) {
+          if (raw && typeof raw.requestId === 'string') {
+            send('APP_STORAGE_DELETE_RESULT', {
+              requestId: raw.requestId,
+              ok: false,
+              deleted: false,
+              error: REVIEW_NACK_MESSAGE,
+            });
+          }
+          return;
+        }
         if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
           return;
         const requestId = raw.requestId;
@@ -1189,7 +1323,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, storageDeleteMutation]);
+  }, [onMessage, send, token, storageDeleteMutation, reviewMode]);
 
   // APP_STORAGE_LIST → apps.storage.list → APP_STORAGE_LIST_RESULT.
   useEffect(() => {
@@ -1202,6 +1336,16 @@ export function PageBlockHost({
         }
       | undefined
     >('APP_STORAGE_LIST', async (raw) => {
+      if (reviewMode) {
+        if (raw && typeof raw.requestId === 'string') {
+          send('APP_STORAGE_LIST_RESULT', {
+            requestId: raw.requestId,
+            keys: [],
+            error: REVIEW_NACK_MESSAGE,
+          });
+        }
+        return;
+      }
       if (!raw || typeof raw.requestId !== 'string' || !token) return;
       const requestId = raw.requestId;
       try {
@@ -1234,13 +1378,26 @@ export function PageBlockHost({
       }
     });
     return off;
-  }, [onMessage, send, token, trpcUtils]);
+  }, [onMessage, send, token, trpcUtils, reviewMode]);
 
   // APP_STORAGE_QUOTA → apps.storage.getQuota → APP_STORAGE_QUOTA_RESULT.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown } | undefined>(
       'APP_STORAGE_QUOTA',
       async (raw) => {
+        if (reviewMode) {
+          if (raw && typeof raw.requestId === 'string') {
+            send('APP_STORAGE_QUOTA_RESULT', {
+              requestId: raw.requestId,
+              usedBytes: 0,
+              rowCount: 0,
+              limitBytes: 0,
+              limitRows: 0,
+              error: REVIEW_NACK_MESSAGE,
+            });
+          }
+          return;
+        }
         if (!raw || typeof raw.requestId !== 'string' || !token) return;
         const requestId = raw.requestId;
         try {
@@ -1265,7 +1422,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, trpcUtils]);
+  }, [onMessage, send, token, trpcUtils, reviewMode]);
 
   // ── App Blocks SHARED (cross-user / app-global) storage bridge (Phase 2b) ──
   //
@@ -1391,6 +1548,13 @@ export function PageBlockHost({
     const off = onMessage<{ requestId?: unknown; value?: unknown } | undefined>(
       'SHARED_APPEND',
       async (raw) => {
+        if (reviewMode) {
+          // Cross-user shared datastore WRITE — NACK (shared reads stay live below).
+          if (raw && typeof raw.requestId === 'string') {
+            send('SHARED_APPEND_RESULT', { requestId: raw.requestId, error: REVIEW_NACK_MESSAGE });
+          }
+          return;
+        }
         if (
           !raw ||
           typeof raw.requestId !== 'string' ||
@@ -1414,7 +1578,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, sharedAppendMutation]);
+  }, [onMessage, send, token, sharedAppendMutation, reviewMode]);
 
   // SHARED_UPDATE → apps.shared.update → SHARED_UPDATE_RESULT (mutation).
   // Author-scoped in-place edit of an OWN row: the auth/author-gate/belt/quota all
@@ -1427,6 +1591,17 @@ export function PageBlockHost({
     const off = onMessage<{ requestId?: unknown; key?: unknown; value?: unknown } | undefined>(
       'SHARED_UPDATE',
       async (raw) => {
+        if (reviewMode) {
+          // Reply MUST carry ok:false or the SDK drops it (→ hang). See handler doc.
+          if (raw && typeof raw.requestId === 'string') {
+            send('SHARED_UPDATE_RESULT', {
+              requestId: raw.requestId,
+              ok: false,
+              error: REVIEW_NACK_MESSAGE,
+            });
+          }
+          return;
+        }
         if (
           !raw ||
           typeof raw.requestId !== 'string' ||
@@ -1452,13 +1627,19 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, sharedUpdateMutation]);
+  }, [onMessage, send, token, sharedUpdateMutation, reviewMode]);
 
   // SHARED_VOTE → apps.shared.vote → SHARED_VOTE_RESULT (mutation).
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
       'SHARED_VOTE',
       async (raw) => {
+        if (reviewMode) {
+          if (raw && typeof raw.requestId === 'string') {
+            send('SHARED_VOTE_RESULT', { requestId: raw.requestId, error: REVIEW_NACK_MESSAGE });
+          }
+          return;
+        }
         if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
           return;
         const requestId = raw.requestId;
@@ -1471,13 +1652,19 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, sharedVoteMutation]);
+  }, [onMessage, send, token, sharedVoteMutation, reviewMode]);
 
   // SHARED_UNVOTE → apps.shared.unvote → SHARED_UNVOTE_RESULT (mutation).
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
       'SHARED_UNVOTE',
       async (raw) => {
+        if (reviewMode) {
+          if (raw && typeof raw.requestId === 'string') {
+            send('SHARED_UNVOTE_RESULT', { requestId: raw.requestId, error: REVIEW_NACK_MESSAGE });
+          }
+          return;
+        }
         if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
           return;
         const requestId = raw.requestId;
@@ -1490,13 +1677,19 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, sharedUnvoteMutation]);
+  }, [onMessage, send, token, sharedUnvoteMutation, reviewMode]);
 
   // SHARED_WITHDRAW → apps.shared.withdraw → SHARED_WITHDRAW_RESULT (mutation).
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
       'SHARED_WITHDRAW',
       async (raw) => {
+        if (reviewMode) {
+          if (raw && typeof raw.requestId === 'string') {
+            send('SHARED_WITHDRAW_RESULT', { requestId: raw.requestId, error: REVIEW_NACK_MESSAGE });
+          }
+          return;
+        }
         if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
           return;
         const requestId = raw.requestId;
@@ -1512,7 +1705,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, sharedWithdrawMutation]);
+  }, [onMessage, send, token, sharedWithdrawMutation, reviewMode]);
 
   // ── OPEN_RESOURCE_PICKER → RESOURCE_PICKER_RESULT (Design 1 host-chrome) ────
   //
@@ -1722,6 +1915,17 @@ export function PageBlockHost({
     const off = onMessage<
       { requestId?: unknown; purpose?: unknown; asyncScan?: unknown } | undefined
     >('OPEN_IMAGE_UPLOAD', (raw) => {
+        if (reviewMode) {
+          // Host-mediated upload runs under the MOD's REAL session (createImage /
+          // consumer blob) — never let untrusted review code open it. Reply the
+          // bare (cancelled) result the block awaits so it fails fast (no hang).
+          if (raw && typeof (raw as { requestId?: unknown }).requestId === 'string') {
+            send('IMAGE_UPLOAD_RESULT', {
+              requestId: (raw as { requestId: string }).requestId,
+            });
+          }
+          return;
+        }
         const gateStatus = status === 'error' ? 'no_token' : status;
         if (gateStatus !== 'ready') return; // pre-handshake block — drop
         const req = resolveImageUploadRequest(raw);
@@ -1826,7 +2030,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, status]);
+  }, [onMessage, send, status, reviewMode]);
 
   // ── SET_USER_CHECKPOINT → USER_CHECKPOINT_SET (fail-fast NACK on a page) ──────
   //

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -26,6 +26,10 @@ const mocks = vi.hoisted(() => ({
   viewer: vi.fn(async () => ({ id: 42, username: 'mod' })),
   storageSet: vi.fn(async () => ({ sizeBytes: 1 })),
   sharedAppend: vi.fn(async () => ({ key: 'k' })),
+  // Session-authed (protectedProcedure) wildcard resolve — the token-INDEPENDENT
+  // handler. Returns an over-cap size so the non-reviewMode path short-circuits at
+  // the pre-download cap and never actually fetches (keeps the test network-free).
+  wildcard: vi.fn(async () => ({ sizeBytes: 10 ** 9, signedUrl: 'x', meta: {}, maturity: {} })),
 }));
 
 // AppBlockChrome (in the host frame) calls useCurrentUser() for the platform-nav
@@ -35,7 +39,7 @@ vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 vi.mock('~/utils/trpc', () => ({
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
-    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: mocks.wildcard }) } },
     blocks: {
       submitWorkflow: { useMutation: () => ({ mutateAsync: mocks.submit }) },
       getMyBuzzBalance: { useMutation: () => ({ mutateAsync: mocks.buzzBalance }) },
@@ -158,6 +162,7 @@ beforeEach(() => {
   mocks.viewer.mockClear();
   mocks.storageSet.mockClear();
   mocks.sharedAppend.mockClear();
+  mocks.wildcard.mockClear();
 });
 
 describe('PageBlockHost reviewMode — side-effecting handlers fail-fast NACK, never reach the mutation', () => {
@@ -249,6 +254,22 @@ describe('PageBlockHost reviewMode — side-effecting handlers fail-fast NACK, n
     l.stop();
   });
 
+  test('GET_WILDCARD_PACK (session-authed, token-INDEPENDENT) → NACK, resolveWildcardPack NOT called', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+    const l = listenForReply();
+
+    postFromBlock('GET_WILDCARD_PACK', { requestId: 'wp1', modelVersionId: 9001 });
+
+    await vi.waitFor(() => expect(l.last('WILDCARD_PACK_RESULT')).toBeTruthy());
+    const reply = l.last('WILDCARD_PACK_RESULT')!.payload as { requestId: string; error: string };
+    expect(reply.requestId).toBe('wp1');
+    expect(reply.error).toBe('not available in review preview');
+    // The mod's session-authed download entitlement is NEVER exercised in review.
+    expect(mocks.wildcard).not.toHaveBeenCalled();
+    l.stop();
+  });
+
   test('render-safe GET_VIEWER STILL works in reviewMode (mutation reached)', async () => {
     renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
     await driveToReady();
@@ -271,6 +292,17 @@ describe('PageBlockHost reviewMode — the NON-reviewMode (prod) path is unchang
 
     // The prod path forwards to the mutation exactly as before (no NACK).
     await vi.waitFor(() => expect(mocks.submit).toHaveBeenCalledTimes(1));
+  });
+
+  test('without reviewMode, GET_WILDCARD_PACK reaches resolveWildcardPack', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+    await driveToReady();
+
+    postFromBlock('GET_WILDCARD_PACK', { requestId: 'wp2', modelVersionId: 9001 });
+
+    // The prod path resolves as before (the mock's over-cap size short-circuits at
+    // the pre-download cap → a 'too-large' reply, so no real fetch runs).
+    await vi.waitFor(() => expect(mocks.wildcard).toHaveBeenCalledTimes(1));
   });
 });
 

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -1,0 +1,333 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { useDialogStore } from '~/components/Dialog/dialogStore';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * MOD REVIEW SANDBOX (#2831) — PageBlockHost `reviewMode` read-only gate.
+ *
+ * The review preview runs UNAPPROVED, untrusted code with the mod's session. This
+ * suite drives the REAL postMessage bridge and proves, for each class of handler:
+ *   - reviewMode: every side-effecting / money / private / cross-user message
+ *     replies with a KNOWN-SHAPE, fail-fast NACK (never a hang) AND never reaches
+ *     the underlying tRPC mutation;
+ *   - reviewMode: a render-safe read (GET_VIEWER) still works (mutation reached);
+ *   - the NON-reviewMode (prod) path is UNCHANGED — the same message reaches the
+ *     mutation;
+ *   - the opaque-origin handshake: at trustTier='unverified' the iframe sandbox
+ *     drops allow-same-origin and BLOCK_INIT (carrying the review token) still
+ *     reaches BLOCK_READY (the path unverified prod blocks already use).
+ */
+
+const mocks = vi.hoisted(() => ({
+  submit: vi.fn(async () => ({ snapshot: { workflowId: 'w', status: 'ok' } })),
+  buzzBalance: vi.fn(async () => ({ balance: 5 })),
+  viewer: vi.fn(async () => ({ id: 42, username: 'mod' })),
+  storageSet: vi.fn(async () => ({ sizeBytes: 1 })),
+  sharedAppend: vi.fn(async () => ({ key: 'k' })),
+}));
+
+// AppBlockChrome (in the host frame) calls useCurrentUser() for the platform-nav
+// moderator gate; render the real host without a CivitaiSessionProvider.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+vi.mock('~/utils/trpc', () => ({
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: mocks.submit }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: mocks.buzzBalance }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: mocks.viewer }) },
+      getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: mocks.sharedAppend }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: mocks.storageSet }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+function postFromBlock(type: string, payload?: unknown, origin: string = window.location.origin) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  // NB: we pass `cw` as `source` but never READ its properties — safe even when the
+  // frame is cross-origin (opaque). `origin` selects the pinned vs opaque path.
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin,
+      source: cw,
+    })
+  );
+}
+
+function listenForReply() {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  const handler = (e: MessageEvent) => {
+    const d = e.data as { type?: string; payload?: unknown } | null;
+    if (d && typeof d.type === 'string') received.push({ type: d.type, payload: d.payload });
+  };
+  cw.addEventListener('message', handler);
+  return {
+    received,
+    last: (type: string) => [...received].reverse().find((m) => m.type === type),
+    stop: () => cw.removeEventListener('message', handler),
+  };
+}
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+const REVIEW_TOKEN = 'review.jwt.self-bound';
+
+const baseProps = {
+  appBlockId: 'pubreq_TEST',
+  blockId: 'my-page-app',
+  appId: 'pending-pubreq_TEST',
+  blockInstanceId: 'page_pubreq_TEST',
+  appName: 'Reviewed App',
+  iframeSrc: SAME_ORIGIN_SRC,
+  sandbox: 'allow-scripts',
+  // Pinned transport (internal) for deterministic delivery — reviewMode is
+  // independent of trust tier. The opaque-origin path has its own test below.
+  trustTier: 'internal' as const,
+  slug: 'my-page-app',
+  token: REVIEW_TOKEN,
+  expiresAt: new Date(Date.now() + 4 * 3_600_000).toISOString(),
+  declaredScopes: ['models:read:self', 'user:read:self'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 42, username: 'mod' },
+  theme: 'light' as const,
+};
+
+async function driveToReady() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+beforeEach(() => {
+  useDialogStore.getState().closeAll();
+  mocks.submit.mockClear();
+  mocks.buzzBalance.mockClear();
+  mocks.viewer.mockClear();
+  mocks.storageSet.mockClear();
+  mocks.sharedAppend.mockClear();
+});
+
+describe('PageBlockHost reviewMode — side-effecting handlers fail-fast NACK, never reach the mutation', () => {
+  test('SUBMIT_WORKFLOW → failed snapshot, submitWorkflow NOT called', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+    const l = listenForReply();
+
+    postFromBlock('SUBMIT_WORKFLOW', { requestId: 'r1', body: { anything: true } });
+
+    await vi.waitFor(() => expect(l.last('WORKFLOW_SUBMITTED')).toBeTruthy());
+    const reply = l.last('WORKFLOW_SUBMITTED')!.payload as {
+      requestId: string;
+      snapshot: { status: string; error: string; workflowId: string };
+    };
+    expect(reply.requestId).toBe('r1');
+    expect(reply.snapshot.status).toBe('failed');
+    expect(reply.snapshot.error).toBe('not available in review preview');
+    expect(mocks.submit).not.toHaveBeenCalled();
+    l.stop();
+  });
+
+  test('GET_BUZZ_BALANCE → error reply, getMyBuzzBalance NOT called', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+    const l = listenForReply();
+
+    postFromBlock('GET_BUZZ_BALANCE', { requestId: 'b1' });
+
+    await vi.waitFor(() => expect(l.last('BUZZ_BALANCE_RESULT')).toBeTruthy());
+    const reply = l.last('BUZZ_BALANCE_RESULT')!.payload as { requestId: string; error: string };
+    expect(reply.requestId).toBe('b1');
+    expect(reply.error).toBe('not available in review preview');
+    expect(mocks.buzzBalance).not.toHaveBeenCalled();
+    l.stop();
+  });
+
+  test('APP_STORAGE_SET → ok:false error reply, storage.set NOT called', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+    const l = listenForReply();
+
+    postFromBlock('APP_STORAGE_SET', { requestId: 's1', key: 'k', value: 'v' });
+
+    await vi.waitFor(() => expect(l.last('APP_STORAGE_SET_RESULT')).toBeTruthy());
+    const reply = l.last('APP_STORAGE_SET_RESULT')!.payload as {
+      requestId: string;
+      ok: boolean;
+      error: string;
+    };
+    expect(reply.requestId).toBe('s1');
+    expect(reply.ok).toBe(false);
+    expect(reply.error).toBe('not available in review preview');
+    expect(mocks.storageSet).not.toHaveBeenCalled();
+    l.stop();
+  });
+
+  test('SHARED_APPEND (cross-user write) → error reply, shared.append NOT called', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+    const l = listenForReply();
+
+    postFromBlock('SHARED_APPEND', { requestId: 'sa1', value: { title: 'x' } });
+
+    await vi.waitFor(() => expect(l.last('SHARED_APPEND_RESULT')).toBeTruthy());
+    const reply = l.last('SHARED_APPEND_RESULT')!.payload as { requestId: string; error: string };
+    expect(reply.requestId).toBe('sa1');
+    expect(reply.error).toBe('not available in review preview');
+    expect(mocks.sharedAppend).not.toHaveBeenCalled();
+    l.stop();
+  });
+
+  test('OPEN_BUZZ_PURCHASE → purchased:false, never opens the Buy-Buzz dialog', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+    const l = listenForReply();
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+
+    postFromBlock('OPEN_BUZZ_PURCHASE', { requestId: 'p1', suggestedAmount: 500 });
+
+    await vi.waitFor(() => expect(l.last('BUZZ_PURCHASE_RESULT')).toBeTruthy());
+    const reply = l.last('BUZZ_PURCHASE_RESULT')!.payload as {
+      requestId: string;
+      purchased: boolean;
+    };
+    expect(reply.purchased).toBe(false);
+    // No spend modal ever opened at the mod.
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    l.stop();
+  });
+
+  test('render-safe GET_VIEWER STILL works in reviewMode (mutation reached)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+    const l = listenForReply();
+
+    postFromBlock('GET_VIEWER', { requestId: 'v1' });
+
+    await vi.waitFor(() => expect(mocks.viewer).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(l.last('VIEWER_RESULT')).toBeTruthy());
+    l.stop();
+  });
+});
+
+describe('PageBlockHost reviewMode — the NON-reviewMode (prod) path is unchanged', () => {
+  test('without reviewMode, SUBMIT_WORKFLOW reaches submitWorkflow', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+    await driveToReady();
+
+    postFromBlock('SUBMIT_WORKFLOW', { requestId: 'r2', body: { ok: true } });
+
+    // The prod path forwards to the mutation exactly as before (no NACK).
+    await vi.waitFor(() => expect(mocks.submit).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe('PageBlockHost review preview handshake', () => {
+  // BLOCK_INIT carries the review token — asserted in the pinned (same-origin)
+  // transport so the test can read the frame's message channel. The token plumbing
+  // is trust-tier-independent, so this pins "posts BLOCK_INIT with the review token
+  // and the block reaches ready" (mirrors the dev host test).
+  test('posts BLOCK_INIT carrying the review token and reaches BLOCK_READY', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+    const l = listenForReply();
+    // The controller re-posts BLOCK_INIT every 400ms until BLOCK_READY — wait for a
+    // re-post to land on our listener, then assert it carries the review token.
+    await vi.waitFor(
+      () => {
+        expect(l.last('BLOCK_INIT')).toBeTruthy();
+      },
+      { timeout: 3_000, interval: 100 }
+    );
+    const initPayload = l.last('BLOCK_INIT')!.payload as { token: { raw: string } };
+    expect(initPayload.token.raw).toBe(REVIEW_TOKEN);
+
+    // Completing the handshake still works (data-block-ready flips).
+    await driveToReady();
+    l.stop();
+  });
+
+  // The C1 opaque-origin defense: at trustTier='unverified' the iframe drops
+  // allow-same-origin (runs at an opaque origin), and the host's postMessage
+  // transport ACCEPTS an inbound `origin:'null'` BLOCK_READY (the OriginMatcher
+  // opaque path unverified prod blocks already use) — completing the handshake.
+  // The frame is genuinely cross-origin here, so we drive it via a synthetic
+  // origin:'null' message rather than its contentWindow's listener.
+  test('at trustTier=unverified the sandbox is opaque and an origin:null BLOCK_READY completes the handshake', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} trustTier="unverified" reviewMode onConsentGranted={vi.fn()} />
+    );
+    await vi.waitFor(() => {
+      const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+
+    // Opaque origin: allow-same-origin is dropped, allow-scripts remains.
+    const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    const sandboxAttr = (iframeEl.getAttribute('sandbox') ?? '').split(/\s+/);
+    expect(sandboxAttr).not.toContain('allow-same-origin');
+    expect(sandboxAttr).toContain('allow-scripts');
+
+    // An opaque-origin (origin:'null') BLOCK_READY is accepted → handshake done.
+    await vi.waitFor(() => {
+      postFromBlock('BLOCK_READY', {}, 'null');
+      const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+      if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+    });
+  });
+});

--- a/src/components/AppBlocks/__tests__/sandbox.test.ts
+++ b/src/components/AppBlocks/__tests__/sandbox.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { effectiveSandboxIsOpaque, intersectSandbox } from '../sandbox';
+import { clampReviewSandbox, effectiveSandboxIsOpaque, intersectSandbox } from '../sandbox';
 
 /**
  * L-SANDBOX coverage. intersectSandbox derives the iframe `sandbox`
@@ -57,6 +57,53 @@ describe('intersectSandbox', () => {
       'allow-same-origin',
     ]);
     for (const t of out) expect(allowed.has(t)).toBe(true);
+  });
+});
+
+/**
+ * MOD REVIEW SANDBOX (#2831) — clampReviewSandbox drops every mod-reaching
+ * capability even if the pending manifest declares it, so a malicious review block
+ * can't open a popup or trigger a download at the moderator's tab.
+ */
+describe('clampReviewSandbox (mod review render-only clamp)', () => {
+  const MOD_REACHING = [
+    'allow-popups',
+    'allow-downloads',
+    'allow-modals',
+    'allow-pointer-lock',
+    'allow-top-navigation',
+    'allow-top-navigation-by-user-activation',
+    'allow-popups-to-escape-sandbox',
+  ];
+
+  it('strips every mod-reaching token a malicious manifest declares — keeps only allow-scripts + allow-forms', () => {
+    const declared =
+      'allow-scripts allow-forms allow-popups allow-downloads allow-modals ' +
+      'allow-pointer-lock allow-top-navigation allow-popups-to-escape-sandbox allow-same-origin';
+    const out = clampReviewSandbox(declared).split(/\s+/);
+    expect(out).toContain('allow-scripts');
+    expect(out).toContain('allow-forms');
+    for (const t of MOD_REACHING) expect(out).not.toContain(t);
+    // NEVER allow-same-origin (the review host also forces the opaque origin).
+    expect(out).not.toContain('allow-same-origin');
+  });
+
+  it('fails closed to the minimal allow-scripts floor for empty / all-stripped manifests', () => {
+    for (const raw of [undefined, '', '   ', 'allow-popups allow-downloads allow-same-origin']) {
+      expect(clampReviewSandbox(raw)).toBe('allow-scripts');
+    }
+  });
+
+  it('the clamped string, run through intersectSandbox(unverified), stays opaque + render-only', () => {
+    // Mirror the real wiring: ReviewBlockPreviewHost passes clampReviewSandbox()
+    // and PageBlockHost re-runs intersectSandbox(…, 'unverified').
+    const eff = intersectSandbox(clampReviewSandbox('allow-scripts allow-popups allow-downloads'), 'unverified');
+    const tokens = eff.split(/\s+/);
+    expect(tokens).toContain('allow-scripts');
+    expect(tokens).not.toContain('allow-popups');
+    expect(tokens).not.toContain('allow-downloads');
+    expect(tokens).not.toContain('allow-same-origin');
+    expect(effectiveSandboxIsOpaque(eff)).toBe(true); // opaque origin preserved
   });
 });
 

--- a/src/components/AppBlocks/sandbox.ts
+++ b/src/components/AppBlocks/sandbox.ts
@@ -46,6 +46,36 @@ export function intersectSandbox(raw: string | undefined, trustTier: string): st
 }
 
 /**
+ * MOD REVIEW SANDBOX (#2831): the ONLY sandbox tokens permitted when previewing a
+ * PENDING, un-approved block with a moderator's tab. Every capability that can
+ * REACH the mod's tab is dropped even if the manifest declares it —
+ * `allow-popups` (open a window at the mod), `allow-downloads` (trigger a download
+ * to the mod), `allow-modals`, `allow-pointer-lock`. (`allow-top-navigation*` and
+ * `allow-popups-to-escape-sandbox` are not in ALLOWED_SANDBOX_TOKENS, so
+ * intersectSandbox already strips them.) Only `allow-scripts` (mandatory to render)
+ * and `allow-forms` (low-risk to an opaque origin) survive. `allow-same-origin` is
+ * NEVER added — the review host forces `trustTier:'unverified'` (opaque origin).
+ */
+export const REVIEW_SANDBOX_ALLOWED_TOKENS: ReadonlySet<string> = new Set<string>([
+  'allow-scripts',
+  'allow-forms',
+]);
+
+/**
+ * Clamp a manifest-declared sandbox string down to the review render-only set
+ * (REVIEW_SANDBOX_ALLOWED_TOKENS ∪ the minimal floor). The output is passed to the
+ * review host, which runs it through `intersectSandbox(…, 'unverified')` again —
+ * so `allow-same-origin` is never added and the opaque origin is preserved. Fails
+ * CLOSED (an empty / all-stripped manifest → the minimal `allow-scripts` floor).
+ */
+export function clampReviewSandbox(raw: string | undefined): string {
+  const declared = (raw ?? '').split(/\s+/).filter((t) => REVIEW_SANDBOX_ALLOWED_TOKENS.has(t));
+  const tokens = new Set<string>(MINIMAL_SANDBOX); // always allow-scripts
+  for (const t of declared) tokens.add(t);
+  return Array.from(tokens).join(' ');
+}
+
+/**
  * L-OPAQUE: does the EFFECTIVE iframe sandbox (the same string handed to the
  * `<iframe sandbox=…>` attribute) lack `allow-same-origin`?
  *

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -31,6 +31,7 @@ import {
 } from '@tabler/icons-react';
 import { useMemo, useRef, useState } from 'react';
 import { pickReviewIframeSrc } from '~/components/Apps/reviewIframeSrc';
+import { ReviewBlockPreviewHost } from '~/components/Apps/ReviewBlockPreviewHost';
 import {
   FileDiffEntry,
   FileListPreview,
@@ -655,24 +656,29 @@ function ReviewPreviewPanel({
         </Alert>
       )}
       {isLive && stableIframeSrc && (
-        <iframe
-          title={`Review preview for ${slug}`}
-          src={stableIframeSrc}
-          // no-referrer: the `?mr=<token>` entry-token URL must NOT leak via the
-          // `Referer` header to assets the previewed (untrusted) block loads.
-          // (We deliberately do NOT bind the token to a publishRequestId: that
-          // binding isn't statelessly verifiable at the mod-gate without a DB
-          // lookup, which the stateless forwardAuth gate intentionally avoids.
-          // Host + mod + short TTL + no-referrer is the chosen containment.)
-          referrerPolicy="no-referrer"
+        // Mount the REAL PageBlockHost (via ReviewBlockPreviewHost) instead of a
+        // raw <iframe>: the bug was that a raw iframe had NO host bridge, so
+        // nothing posted BLOCK_INIT and the SDK block hung on "Connecting to host".
+        // The host mints a self-bound, scope-stripped block token, forces
+        // trustTier:'unverified' (opaque origin — drops allow-same-origin), and
+        // runs reviewMode (read-only NACKs). The `?mr=` entry-token URL keeps its
+        // pickReviewIframeSrc stabilization here; PageBlockHost's own iframe sets
+        // referrerPolicy="no-referrer" so the entry token never leaks via Referer.
+        <div
           style={{
             width: '100%',
             height: 420,
             border: '1px solid var(--mantine-color-default-border)',
             borderRadius: 6,
+            overflow: 'hidden',
           }}
-          sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-        />
+        >
+          <ReviewBlockPreviewHost
+            publishRequestId={publishRequestId}
+            slug={slug}
+            iframeSrc={stableIframeSrc}
+          />
+        </div>
       )}
       {statusQuery.error && (
         <Text size="xs" c="dimmed">

--- a/src/components/Apps/ReviewBlockPreviewHost.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.tsx
@@ -1,0 +1,120 @@
+import { Alert, Loader, Stack, Text, useComputedColorScheme } from '@mantine/core';
+import { useEffect } from 'react';
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * MOD REVIEW SANDBOX (#2831) — the on-site preview HOST bridge.
+ *
+ * This is the missing half of the review handshake: `ReviewPreviewPanel` used to
+ * embed the review host as a RAW `<iframe src>` with no host bridge, so nothing
+ * ever posted `BLOCK_INIT` and the SDK block hung on "Connecting to host". This
+ * component mounts the REAL production `PageBlockHost` against the review iframe,
+ * so a PENDING un-approved block actually renders inside the mod's review modal.
+ *
+ * It runs UNAPPROVED, untrusted code with the MOD's session, so it is deliberately
+ * the WEAKEST-privilege mount, layered defense-in-depth (no single layer
+ * load-bearing):
+ *   1. TOKEN — the block token comes from `blocks.mintReviewBlockToken` (mod-gated,
+ *      self-bound to the mod, render-only scope-stripped, forced-SFW, synthetic
+ *      non-resolving ids, short TTL). See the router + publish-request.service.
+ *   2. SANDBOX — `trustTier` is FORCED to `'unverified'` regardless of the
+ *      manifest's declared tier, so `intersectSandbox` drops `allow-same-origin`
+ *      → the iframe runs at an OPAQUE origin (the C1 self-escalation defense).
+ *      PageBlockHost derives its opaque postMessage transport from that same
+ *      sandbox string internally (usePostMessage), so BLOCK_INIT is posted with
+ *      `targetOrigin:'*'` and inbound `origin:'null'` is accepted — the exact path
+ *      every unverified prod block at `<slug>.civit.ai` already uses. No new
+ *      opaque-origin prop is needed.
+ *   3. HOST — `reviewMode` makes every side-effecting / money / private / cross-user
+ *      host handler reply with a fail-fast NACK instead of doing the work.
+ *
+ * The mount is isolated in its OWN component (rendered only when the preview is
+ * live) so `ReviewPreviewPanel`'s render path — and the OnsiteReviewModal browser
+ * test that never reaches a live preview — never evaluates these hooks.
+ */
+export function ReviewBlockPreviewHost({
+  publishRequestId,
+  slug,
+  iframeSrc,
+}: {
+  publishRequestId: string;
+  slug: string;
+  /** The stabilized `?mr=<entry-token>` review host URL from ReviewPreviewPanel
+   *  (pickReviewIframeSrc keeps it stable across polls; the `?mr=` token is only
+   *  the mod-gate ENTRY token, not the block token minted below). */
+  iframeSrc: string;
+}) {
+  const currentUser = useCurrentUser();
+  const colorScheme = useComputedColorScheme('dark');
+  const theme: 'light' | 'dark' = colorScheme === 'dark' ? 'dark' : 'light';
+
+  // Mint the SELF-BOUND, scope-stripped block token (mod-gated mutation). Minted
+  // once when the preview goes live; re-mintable on demand via onRetryToken (the
+  // 4h dev-lifetime token comfortably outlives a review session).
+  const mintMut = trpc.blocks.mintReviewBlockToken.useMutation();
+  const { mutate: mint, data: mintData, isError: mintError, isPending } = mintMut;
+
+  useEffect(() => {
+    // Fire once on mount for this live preview. React 18 StrictMode double-invokes
+    // effects in dev; `isPending`/`mintData` guards keep it to a single in-flight
+    // mint, and a duplicate mint is harmless (idempotent, audited).
+    if (!mintData && !isPending && !mintError) {
+      mint({ publishRequestId });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [publishRequestId]);
+
+  if (mintError) {
+    return (
+      <Alert color="red" variant="light">
+        Could not mint the review preview token. Rebuild the preview or try again.
+      </Alert>
+    );
+  }
+
+  if (!mintData) {
+    return (
+      <Stack align="center" gap={6} p="md">
+        <Loader size="sm" />
+        <Text size="xs" c="dimmed">
+          Connecting to the review host…
+        </Text>
+      </Stack>
+    );
+  }
+
+  const viewer = currentUser
+    ? { id: currentUser.id, username: currentUser.username ?? null }
+    : null;
+
+  return (
+    <PageBlockHost
+      appBlockId={mintData.appBlockId}
+      blockId={mintData.blockId}
+      appId={mintData.appId}
+      blockInstanceId={mintData.blockInstanceId}
+      appName={mintData.appName}
+      iframeSrc={iframeSrc}
+      sandbox={mintData.sandbox}
+      // FORCED unverified → opaque origin (drops allow-same-origin). C1 defense.
+      trustTier="unverified"
+      slug={slug}
+      token={mintData.token}
+      expiresAt={mintData.expiresAt}
+      declaredScopes={mintData.scopes}
+      missingScopes={[]}
+      needsConsent={false}
+      tokenError={false}
+      domain={mintData.domain}
+      maxBrowsingLevel={mintData.maxBrowsingLevel}
+      viewer={viewer}
+      theme={theme}
+      // Read-only host: every side-effecting/money/private handler NACKs.
+      reviewMode
+      // Re-mint the block token on an auth-failure Retry.
+      onRetryToken={() => mint({ publishRequestId })}
+    />
+  );
+}

--- a/src/components/Apps/ReviewBlockPreviewHost.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.tsx
@@ -1,6 +1,7 @@
 import { Alert, Loader, Stack, Text, useComputedColorScheme } from '@mantine/core';
 import { useEffect } from 'react';
 import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+import { clampReviewSandbox } from '~/components/AppBlocks/sandbox';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { trpc } from '~/utils/trpc';
 
@@ -97,7 +98,12 @@ export function ReviewBlockPreviewHost({
       blockInstanceId={mintData.blockInstanceId}
       appName={mintData.appName}
       iframeSrc={iframeSrc}
-      sandbox={mintData.sandbox}
+      // Clamp the manifest sandbox to the review render-only set: drop
+      // allow-popups / allow-downloads / allow-modals / allow-pointer-lock (+ the
+      // top-nav / escape tokens intersectSandbox already strips) so an untrusted
+      // review block can't open a popup or trigger a download aimed at the mod's
+      // tab. Keeps allow-scripts (+ allow-forms if declared).
+      sandbox={clampReviewSandbox(mintData.sandbox)}
       // FORCED unverified → opaque origin (drops allow-same-origin). C1 defense.
       trustTier="unverified"
       slug={slug}

--- a/src/server/routers/__tests__/blocks.router.reviewSandbox.test.ts
+++ b/src/server/routers/__tests__/blocks.router.reviewSandbox.test.ts
@@ -23,6 +23,7 @@ const {
   mockIsReviewSandboxEnabled,
   mockPreviewRequest,
   mockGetReviewStatus,
+  mockMintReviewBlockToken,
   mockTeardownPreview,
   mockListActivePreviews,
   mockVerifyBlockToken,
@@ -38,6 +39,7 @@ const {
   mockIsReviewSandboxEnabled: vi.fn(),
   mockPreviewRequest: vi.fn(),
   mockGetReviewStatus: vi.fn(),
+  mockMintReviewBlockToken: vi.fn(),
   mockTeardownPreview: vi.fn(),
   mockListActivePreviews: vi.fn(),
   mockVerifyBlockToken: vi.fn(),
@@ -62,6 +64,7 @@ vi.mock('~/server/services/app-blocks-flag', () => ({
 vi.mock('~/server/services/blocks/publish-request.service', () => ({
   previewRequest: mockPreviewRequest,
   getReviewStatus: mockGetReviewStatus,
+  mintReviewBlockToken: mockMintReviewBlockToken,
   teardownPreview: mockTeardownPreview,
   listActiveReviewPreviews: mockListActivePreviews,
 }));
@@ -171,6 +174,20 @@ beforeEach(() => {
   mockTeardownPreview.mockResolvedValue({ publishRequestId: PUBREQ, tornDown: true });
   mockListActivePreviews.mockReset();
   mockListActivePreviews.mockResolvedValue({ cap: 5, active: [] });
+  mockMintReviewBlockToken.mockReset();
+  mockMintReviewBlockToken.mockResolvedValue({
+    token: 'review.jwt',
+    expiresAt: '2099-01-01T00:00:00Z',
+    scopes: ['models:read:self', 'user:read:self'],
+    domain: null,
+    maxBrowsingLevel: 1,
+    blockId: 'my-app',
+    appId: `pending-${PUBREQ}`,
+    appBlockId: PUBREQ,
+    blockInstanceId: `page_${PUBREQ}`,
+    appName: 'My App',
+    sandbox: 'allow-scripts',
+  });
 });
 
 describe('blocks.previewRequest', () => {
@@ -238,6 +255,44 @@ describe('blocks.getReviewStatus', () => {
       TRPCError
     );
     expect(mockGetReviewStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('blocks.mintReviewBlockToken', () => {
+  it('moderator + flags on: mints with the SERVER-derived mod id (self-bound)', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const res = await caller.mintReviewBlockToken({ publishRequestId: PUBREQ });
+    expect(res.token).toBe('review.jwt');
+    expect(res.appBlockId).toBe(PUBREQ);
+    expect(mockMintReviewBlockToken).toHaveBeenCalledWith({
+      publishRequestId: PUBREQ,
+      modUserId: 1, // SERVER-derived, never client-supplied
+    });
+  });
+
+  it('non-moderator: UNAUTHORIZED, service NOT reached', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.mintReviewBlockToken({ publishRequestId: PUBREQ })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockMintReviewBlockToken).not.toHaveBeenCalled();
+  });
+
+  it('anonymous: UNAUTHORIZED', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.mintReviewBlockToken({ publishRequestId: PUBREQ })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockMintReviewBlockToken).not.toHaveBeenCalled();
+  });
+
+  it('moderator but review-sandbox flag OFF: UNAUTHORIZED (dark)', async () => {
+    mockIsReviewSandboxEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(caller.mintReviewBlockToken({ publishRequestId: PUBREQ })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockMintReviewBlockToken).not.toHaveBeenCalled();
   });
 });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -58,6 +58,7 @@ import {
   listApprovedRequestsSchema,
   listPendingRequestsSchema,
   listRejectedRequestsSchema,
+  mintReviewBlockTokenSchema,
   previewRequestSchema,
   rejectRequestSchema,
   teardownPreviewSchema,
@@ -1376,6 +1377,47 @@ export const blocksRouter = router({
         // short-TTL tokened previewUrl when the preview is live — the cross-origin
         // access bridge the `*.civit.ai` mod-gate forwardAuth verifies.
         return await getReviewStatus({
+          publishRequestId: input.publishRequestId,
+          modUserId: ctx.user.id,
+        });
+      } catch (err) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
+      }
+    }),
+
+  /**
+   * MOD REVIEW SANDBOX (#2831) — mint the SELF-BOUND, SCOPE-STRIPPED block token
+   * the on-site review preview host (`PageBlockHost` in `ReviewPreviewPanel`)
+   * handshakes with, so a PENDING un-approved block actually renders. The `?mr=`
+   * URL token is only the mod-gate ENTRY token (not a block token); this is the
+   * missing block-token half of the handshake.
+   *
+   * Gated IDENTICALLY to previewRequest/getReviewStatus (moderator + the
+   * isModerator belt + enforceAppBlocksFlag + the mod-only `app-blocks-review-
+   * sandbox` flag) so it ships dark. The service self-binds the token to the
+   * calling mod's id, clamps the pending manifest's scopes through the render-only
+   * belt, forces SFW + synthetic non-resolving ids, and audits the mint.
+   */
+  mintReviewBlockToken: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(mintReviewBlockTokenSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Review previews are restricted to civitai team');
+      }
+      const { isAppBlocksReviewSandboxEnabled } = await import(
+        '~/server/services/app-blocks-flag'
+      );
+      if (!(await isAppBlocksReviewSandboxEnabled({ user: ctx.user }))) {
+        throw throwAuthorizationError('The review sandbox is not enabled');
+      }
+      const { mintReviewBlockToken } = await import(
+        '~/server/services/blocks/publish-request.service'
+      );
+      try {
+        // The mod id is SERVER-derived (never client-supplied) so the token can
+        // only ever be self-bound to the calling moderator.
+        return await mintReviewBlockToken({
           publishRequestId: input.publishRequestId,
           modUserId: ctx.user.id,
         });

--- a/src/server/schema/blocks/publish-request.schema.ts
+++ b/src/server/schema/blocks/publish-request.schema.ts
@@ -145,6 +145,15 @@ export const getReviewStatusSchema = z.object({
 
 export type GetReviewStatusInput = z.infer<typeof getReviewStatusSchema>;
 
+/** Input for the MOD-ONLY review-sandbox `blocks.mintReviewBlockToken` (#2831) —
+ *  mints the self-bound, scope-stripped block token the on-site review preview
+ *  host handshakes with. Same shape as previewRequest (the pending request id). */
+export const mintReviewBlockTokenSchema = z.object({
+  publishRequestId: z.string().min(1).max(64),
+});
+
+export type MintReviewBlockTokenInput = z.infer<typeof mintReviewBlockTokenSchema>;
+
 export const teardownPreviewSchema = z.object({
   publishRequestId: z.string().min(1).max(64),
 });

--- a/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
@@ -37,6 +37,7 @@ import {
   DEV_TOKEN_SCOPE_ALLOWLIST,
   FORCED_SFW_CEILING,
   resolveDevBuzzBudget,
+  REVIEW_MINT_SCOPE_ALLOWLIST,
   signDevScopedPageToken,
   TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
 } from '~/server/services/blocks/dev-scoped-mint.service';
@@ -152,6 +153,78 @@ describe('clampDevScopes', () => {
       allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
     });
     expect(dedup).toEqual(['models:read:self', 'user:read:self']);
+  });
+});
+
+describe('clampDevScopes — REVIEW_MINT_SCOPE_ALLOWLIST (mod review sandbox #2831)', () => {
+  // The pending manifest a MALICIOUS app could declare: it asks for spend, per-user
+  // + shared storage, private collections, real-money tip, and financial read.
+  const MALICIOUS_MANIFEST_SCOPES = [
+    'models:read:self',
+    'media:read:owned',
+    'collections:read:self',
+    'ai:write:budgeted',
+    'apps:storage:read',
+    'apps:storage:write',
+    'apps:storage:shared:read',
+    'apps:storage:shared:write',
+    'collections:read:private',
+    'collections:write:self',
+    'social:tip:self',
+    'buzz:read:self',
+  ];
+
+  it('strips EVERY money/private/cross-user/write scope — only the render-only reads survive', () => {
+    const granted = clampDevScopes({
+      scopeSource: MALICIOUS_MANIFEST_SCOPES,
+      oauthAllowed: null, // pending app — no OauthClient
+      keyCanSpend: false, // review preview never spends (belt-and-suspenders)
+      allowlist: REVIEW_MINT_SCOPE_ALLOWLIST,
+    });
+    // ONLY the render-only survivors (+ the unconditional user:read:self grant).
+    expect(granted).toEqual([
+      'collections:read:self',
+      'media:read:owned',
+      'models:read:self',
+      'user:read:self',
+    ]);
+    // None of the withheld scopes can EVER reach the review JWT.
+    for (const withheld of [
+      'ai:write:budgeted',
+      'apps:storage:read',
+      'apps:storage:write',
+      'apps:storage:shared:read',
+      'apps:storage:shared:write',
+      'collections:read:private',
+      'collections:write:self',
+      'social:tip:self',
+      'buzz:read:self',
+    ]) {
+      expect(granted).not.toContain(withheld);
+    }
+  });
+
+  it('is STRICTER than the dev-tunnel allowlist — never grants ai:write:budgeted even with keyCanSpend:true', () => {
+    // Even if a caller mistakenly passed keyCanSpend:true, the allowlist itself
+    // omits ai:write:budgeted, so spend can never survive the review clamp.
+    const granted = clampDevScopes({
+      scopeSource: ['ai:write:budgeted', 'models:read:self'],
+      oauthAllowed: null,
+      keyCanSpend: true,
+      allowlist: REVIEW_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(granted).not.toContain('ai:write:budgeted');
+    expect(granted).toEqual(['models:read:self', 'user:read:self']);
+  });
+
+  it('an EMPTY manifest still yields a usable read-only token (force-granted user:read:self)', () => {
+    const granted = clampDevScopes({
+      scopeSource: [],
+      oauthAllowed: null,
+      keyCanSpend: false,
+      allowlist: REVIEW_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(granted).toEqual(['user:read:self']);
   });
 });
 

--- a/src/server/services/blocks/__tests__/publish-request.mintReviewToken.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.mintReviewToken.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * MOD REVIEW SANDBOX (#2831) — `mintReviewBlockToken` service unit coverage.
+ *
+ * This is the security crux of the review preview: it mints the block token a mod
+ * uses to run UNAPPROVED, untrusted code with their OWN session. We prove the mint
+ * is self-bound + render-only scope-stripped + forced-SFW + synthetically-attributed,
+ * exercising the REAL clamp belt (clampDevScopes + REVIEW_MINT_SCOPE_ALLOWLIST +
+ * signDevScopedPageToken) with only the DB, the JWT signer, and the audit log mocked.
+ */
+
+const { mockSign, mockFindUnique, mockLogToAxiom } = vi.hoisted(() => ({
+  mockSign: vi.fn(async (input: unknown) => ({
+    token: 'review.jwt.signed',
+    expiresAt: '2099-01-01T00:00:00Z',
+    jti: 'j',
+    _input: input,
+  })),
+  mockFindUnique: vi.fn(),
+  mockLogToAxiom: vi.fn(async () => undefined),
+}));
+
+// Sign is the real signDevScopedPageToken's downstream — mock it so we can inspect
+// the exact claims minted (self-bound sub, forced-SFW, synthetic ids, scopes).
+vi.mock('~/server/services/block-token.service', () => ({
+  BlockTokenService: { sign: mockSign },
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlockPublishRequest: { findUnique: mockFindUnique } },
+  dbWrite: {},
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...a: unknown[]) => mockLogToAxiom(...a),
+}));
+
+import { mintReviewBlockToken } from '~/server/services/blocks/publish-request.service';
+import { FORCED_SFW_CEILING } from '~/server/services/blocks/dev-scoped-mint.service';
+
+const PUBREQ = 'pubreq_0123456789ABCDEFGHJKMNPQRS';
+const MOD_ID = 4242;
+
+// A pending request whose (author-controlled, un-reviewed) manifest declares a
+// full malicious scope set + a wide sandbox.
+function pendingRow() {
+  return {
+    id: PUBREQ,
+    status: 'pending' as const,
+    slug: 'evil-app',
+    manifest: {
+      name: 'Evil App',
+      iframe: { sandbox: 'allow-scripts allow-forms allow-popups' },
+      scopes: [
+        'models:read:self',
+        'media:read:owned',
+        'collections:read:self',
+        'ai:write:budgeted',
+        'apps:storage:read',
+        'apps:storage:write',
+        'apps:storage:shared:write',
+        'collections:read:private',
+        'social:tip:self',
+        'buzz:read:self',
+      ],
+    },
+  };
+}
+
+beforeEach(() => {
+  mockSign.mockClear();
+  mockFindUnique.mockReset();
+  mockLogToAxiom.mockClear();
+});
+
+describe('mintReviewBlockToken', () => {
+  it('mints a SELF-BOUND, forced-SFW, render-only token with synthetic pubreq_ ids', async () => {
+    mockFindUnique.mockResolvedValue(pendingRow());
+
+    const res = await mintReviewBlockToken({ publishRequestId: PUBREQ, modUserId: MOD_ID });
+
+    // Resolved by publishRequestId (never ownership).
+    expect(mockFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: PUBREQ } })
+    );
+
+    // The JWT claims (from the captured sign input).
+    expect(mockSign).toHaveBeenCalledTimes(1);
+    const arg = mockSign.mock.calls[0][0] as Record<string, unknown>;
+    // SELF-BOUND to the calling mod — every *:read:self can only return the mod's data.
+    expect(arg.userId).toBe(MOD_ID);
+    // Forced-SFW ceiling + no color domain.
+    expect(arg.maxBrowsingLevel).toBe(FORCED_SFW_CEILING);
+    expect(arg.domain).toBeNull();
+    // Synthetic, non-resolving ids — appBlockId carries the recognized `pubreq_`
+    // SYNTHETIC_APP_BLOCK_ID_PREFIXES prefix; appId is the non-resolving `pending-…`.
+    expect(arg.appBlockId).toBe(PUBREQ);
+    expect(arg.appId).toBe(`pending-${PUBREQ}`);
+    expect(arg.blockInstanceId).toBe(`page_${PUBREQ}`);
+    expect(arg.blockId).toBe('evil-app');
+    // No spend budget in review, and it is a dev-lifetime page token.
+    expect(arg.buzzBudget).toBeUndefined();
+    expect(arg.dev).toBe(true);
+
+    // The minted SCOPES contain NONE of the withheld money/private/write scopes —
+    // only the render-only survivors (+ force-granted user:read:self).
+    const scopes = arg.scopes as string[];
+    expect(scopes).toEqual([
+      'collections:read:self',
+      'media:read:owned',
+      'models:read:self',
+      'user:read:self',
+    ]);
+    for (const withheld of [
+      'ai:write:budgeted',
+      'apps:storage:read',
+      'apps:storage:write',
+      'apps:storage:shared:write',
+      'collections:read:private',
+      'social:tip:self',
+      'buzz:read:self',
+    ]) {
+      expect(scopes).not.toContain(withheld);
+    }
+
+    // The returned render metadata is server-derived + consistent with the claims.
+    expect(res.token).toBe('review.jwt.signed');
+    expect(res.scopes).toEqual(scopes);
+    expect(res.appBlockId).toBe(PUBREQ);
+    expect(res.appId).toBe(`pending-${PUBREQ}`);
+    expect(res.blockInstanceId).toBe(`page_${PUBREQ}`);
+    expect(res.appName).toBe('Evil App');
+    expect(res.sandbox).toBe('allow-scripts allow-forms allow-popups');
+    expect(res.domain).toBeNull();
+    expect(res.maxBrowsingLevel).toBe(FORCED_SFW_CEILING);
+
+    // A mint-time audit event fired (never the token).
+    expect(mockLogToAxiom).toHaveBeenCalledTimes(1);
+    const [auditArg] = mockLogToAxiom.mock.calls[0] as [Record<string, unknown>];
+    expect(auditArg).toMatchObject({
+      name: 'app-blocks.review.mint',
+      modUserId: MOD_ID,
+      publishRequestId: PUBREQ,
+      slug: 'evil-app',
+    });
+    expect(JSON.stringify(auditArg)).not.toContain('review.jwt.signed');
+  });
+
+  it('defaults sandbox to allow-scripts when the manifest declares none', async () => {
+    mockFindUnique.mockResolvedValue({
+      id: PUBREQ,
+      status: 'pending',
+      slug: 'plain-app',
+      manifest: { scopes: ['models:read:self'] },
+    });
+    const res = await mintReviewBlockToken({ publishRequestId: PUBREQ, modUserId: MOD_ID });
+    expect(res.sandbox).toBe('allow-scripts');
+    expect(res.appName).toBe('plain-app'); // falls back to slug
+  });
+
+  it('THROWS for a missing request (no oracle) and never signs', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    await expect(
+      mintReviewBlockToken({ publishRequestId: PUBREQ, modUserId: MOD_ID })
+    ).rejects.toThrow(/not found/);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('THROWS for a non-pending request (fail-closed) and never signs', async () => {
+    mockFindUnique.mockResolvedValue({ ...pendingRow(), status: 'approved' });
+    await expect(
+      mintReviewBlockToken({ publishRequestId: PUBREQ, modUserId: MOD_ID })
+    ).rejects.toThrow(/not pending/);
+    expect(mockSign).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -111,6 +111,42 @@ export const TUNNEL_HOST_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<str
 ]);
 
 /**
+ * The MOD-REVIEW-SANDBOX host-mint allowlist (#2831 review preview). RENDER-ONLY:
+ * the STRICTEST of the three allowlists. A mod runs UNAPPROVED, untrusted code
+ * with their OWN session, so the review token must carry the minimum a block needs
+ * to render — self-bound reads ONLY, NEVER money / private / cross-user / write.
+ *
+ * KEEP (render-only survivors, all self-bound reads):
+ *   - `models:read:self`   the caller's own models (self-bound)
+ *   - `media:read:owned`   the caller's own media
+ *   - `user:read:self`     the caller's own identity (also force-granted post-clamp)
+ *   - `collections:read:self` own-PUBLIC + any PUBLIC collection (no per-app namespace)
+ *
+ * WITHHELD (stripped regardless of what the pending manifest declares — the clamp
+ * drops any scope not in this set, so none of these can EVER reach the review JWT):
+ *   - `ai:write:budgeted`         real Buzz spend (ALSO stripped by keyCanSpend:false)
+ *   - `apps:storage:read|write`   per-user App Storage (synthetic appId → no namespace)
+ *   - `apps:storage:shared:read|write` cross-user shared datastore (write = abuse)
+ *   - `collections:read:private`  the caller's OWN private collections (consent-gated)
+ *   - `collections:write:self`    a write surface
+ *   - `social:tip:self`           real money OUT
+ *   - `buzz:read:self`            private financial (balance / ledger / earnings)
+ *
+ * These strings are verified against block-scope.constants.ts. Modelled on
+ * TUNNEL_HOST_MINT_SCOPE_ALLOWLIST but WITHOUT `ai:write:budgeted`,
+ * `collections:write:self`, and `collections:read:private`: the dev tunnel is the
+ * AUTHOR previewing their OWN app (spend on their own Buzz is intended); the review
+ * sandbox is a MOD previewing SOMEONE ELSE'S un-approved app, so nothing that
+ * spends, writes, or reads private/cross-user data is ever granted.
+ */
+export const REVIEW_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
+  'models:read:self',
+  'media:read:owned',
+  'user:read:self',
+  'collections:read:self',
+]);
+
+/**
  * The AUDITED scope clamp belt (dev-token.ts steps 7a–7g), extracted verbatim.
  * Start from `scopeSource` (the app's approved snapshot, an owned pending request's
  * un-reviewed `manifest.scopes`, or the caller's self-declared body scopes) and:

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -3127,6 +3127,159 @@ export async function getReviewStatus(opts: {
   };
 }
 
+export type MintReviewBlockTokenResult = {
+  /** The signed, self-bound, scope-stripped block JWT for the review preview. */
+  token: string;
+  expiresAt: string;
+  /** The scopes that SURVIVED the render-only clamp (the block's real capability). */
+  scopes: string[];
+  /** Forced-SFW: the review mint never reads a color domain. */
+  domain: null;
+  maxBrowsingLevel: number;
+  // Render metadata — SERVER-DERIVED so the preview host's PageBlockHost props are
+  // guaranteed to match the token claims (no client-side id reconstruction / drift).
+  blockId: string;
+  /** Synthetic, non-resolving `pending-<pubreq_…>` — matches the token appId claim. */
+  appId: string;
+  /** The `pubreq_<ULID>` request id — matches the token appBlockId claim. */
+  appBlockId: string;
+  /** `page_<pubreq_…>` — matches the token blockInstanceId claim + BLOCK_INIT ids. */
+  blockInstanceId: string;
+  appName: string;
+  /** The pending manifest's declared iframe sandbox (render fidelity). trustTier is
+   *  forced 'unverified' at the host → allow-same-origin is dropped regardless. */
+  sandbox: string;
+};
+
+/**
+ * MOD REVIEW SANDBOX (#2831) — mint the block token the on-site review preview
+ * host (`ReviewPreviewPanel` → `PageBlockHost`) handshakes with, so a PENDING,
+ * UN-APPROVED block actually renders inside the mod's review modal.
+ *
+ * SECURITY (this runs UNAPPROVED, untrusted code with a MOD's session — the crux
+ * of the whole feature, so the mint is the first defense layer):
+ *   - Resolved by `publishRequestId` (NOT ownership — the mod is not the author).
+ *     The router gates the call: moderatorProcedure + enforceAppBlocksFlag + the
+ *     mod-only `app-blocks-review-sandbox` flag (identical to previewRequest).
+ *   - SELF-BOUND: the token `sub` is the calling MOD's id — every self-bound read
+ *     (`*:read:self`) can only ever return the MOD's own data, never the author's.
+ *   - SCOPE-STRIPPED: the pending manifest's declared `scopes` are the SOURCE, but
+ *     they are clamped through the SAME audited belt the dev-tunnel host mint uses
+ *     (`clampDevScopes`) with the STRICTEST allowlist (`REVIEW_MINT_SCOPE_ALLOWLIST`
+ *     — render-only) and `keyCanSpend:false` (belt-and-suspenders strip of the
+ *     spend scope). A manifest that declares `ai:write:budgeted` / `apps:storage:*`
+ *     / `buzz:read:self` gets NONE of them — the review JWT can carry only the
+ *     render-only survivors.
+ *   - FORCED-SFW ceiling + `domain:null` (never reads a request host).
+ *   - SYNTHETIC, NON-RESOLVING ids: `appBlockId` = the `pubreq_<ULID>` request id
+ *     (an already-recognized `SYNTHETIC_APP_BLOCK_ID_PREFIXES` prefix, so the
+ *     best-effort scope-invocation FK-fails and no spend attribution row is forged);
+ *     `appId` = the non-resolving `pending-<pubreq_…>` (attribution lookup MISSES).
+ *     No `review-` prefix is introduced (mirrors the dev-token pending path).
+ *   - SHORT TTL: inherits the dev mint's 4h `dev:true` lifetime.
+ * Defense-in-depth continues at the host (`reviewMode` read-only NACKs) and the
+ * iframe (forced `trustTier:'unverified'` → opaque origin) — no single layer is
+ * load-bearing.
+ */
+export async function mintReviewBlockToken(opts: {
+  publishRequestId: string;
+  /** The calling moderator's id — the token `sub` is bound to it (self-bound). */
+  modUserId: number;
+}): Promise<MintReviewBlockTokenResult> {
+  const { dbRead } = await import('~/server/db/client');
+  const row = await dbRead.appBlockPublishRequest.findUnique({
+    where: { id: opts.publishRequestId },
+    select: { id: true, status: true, slug: true, manifest: true },
+  });
+  if (!row) throw new Error(`publish request ${opts.publishRequestId} not found`);
+  // Only a PENDING request is previewable — an approved/rejected/withdrawn row has
+  // no review preview to mint against (fail-closed, matches previewRequest's remit).
+  if (row.status !== 'pending') {
+    throw new Error(`publish request ${opts.publishRequestId} is not pending`);
+  }
+
+  // Scope SOURCE is the pending request's UN-REVIEWED manifest.scopes (author-
+  // controlled, NOT trusted) — clamped DOWN by the render-only belt below. The
+  // name/sandbox are render metadata only (never security-load-bearing: trustTier
+  // is forced 'unverified' at the host and every side-effect NACKs).
+  const manifest = (row.manifest ?? {}) as {
+    scopes?: unknown;
+    name?: unknown;
+    iframe?: { sandbox?: unknown } | null;
+  };
+  const manifestScopes: string[] = Array.isArray(manifest.scopes)
+    ? manifest.scopes.filter((s): s is string => typeof s === 'string')
+    : [];
+  const manifestName = typeof manifest.name === 'string' ? manifest.name : row.slug;
+  const manifestSandbox =
+    manifest.iframe && typeof manifest.iframe.sandbox === 'string'
+      ? manifest.iframe.sandbox
+      : 'allow-scripts';
+
+  const {
+    clampDevScopes,
+    signDevScopedPageToken,
+    REVIEW_MINT_SCOPE_ALLOWLIST,
+    FORCED_SFW_CEILING,
+  } = await import('./dev-scoped-mint.service');
+
+  // The AUDITED clamp belt — render-only allowlist + NO OAuth ceiling (a pending
+  // app has no OauthClient) + keyCanSpend:false (belt-and-suspenders spend strip).
+  const granted = clampDevScopes({
+    scopeSource: manifestScopes,
+    oauthAllowed: null,
+    keyCanSpend: false,
+    allowlist: REVIEW_MINT_SCOPE_ALLOWLIST,
+  });
+
+  // SIGN — self-bound to the MOD, forced-SFW, domain:null, synthetic non-resolving
+  // ids (see the fn doc). `signAppBlockId` = the `pubreq_<ULID>` request id (already
+  // a recognized SYNTHETIC_APP_BLOCK_ID_PREFIXES prefix); `signAppId` = the
+  // non-resolving `pending-<id>` (mirrors the dev-token pending path — the
+  // attribution lookup misses so no spend row can be forged). blockInstanceId
+  // matches the host's `page_<pubReqId>` prop so BLOCK_INIT ids line up. No spend →
+  // no buzzBudget.
+  const result = await signDevScopedPageToken({
+    userId: opts.modUserId,
+    signBlockId: row.slug,
+    signAppId: `pending-${row.id}`,
+    signAppBlockId: row.id,
+    blockInstanceId: `page_${row.id}`,
+    granted,
+    buzzBudget: undefined,
+  });
+
+  // MINT-TIME AUDIT (mirror the `app-blocks.dev-tunnel.mint` structured event):
+  // the forensic record of granting a review token over an un-approved app. NEVER
+  // log the token. Fire-and-forget — the audit must never fail the mint.
+  const { logToAxiom } = await import('~/server/logging/client');
+  logToAxiom(
+    {
+      name: 'app-blocks.review.mint',
+      type: 'info',
+      modUserId: opts.modUserId,
+      publishRequestId: row.id,
+      slug: row.slug,
+      scopes: granted,
+    },
+    'webhooks'
+  ).catch(() => null);
+
+  return {
+    token: result.token,
+    expiresAt: result.expiresAt,
+    scopes: granted,
+    domain: null,
+    maxBrowsingLevel: FORCED_SFW_CEILING,
+    blockId: row.slug,
+    appId: `pending-${row.id}`,
+    appBlockId: row.id,
+    blockInstanceId: `page_${row.id}`,
+    appName: manifestName,
+    sandbox: manifestSandbox,
+  };
+}
+
 /**
  * Best-effort teardown of any review env attached to a publish request. Called
  * from approveRequest/rejectRequest after the decision lands. NEVER throws into


### PR DESCRIPTION
## What

Fixes the App Blocks moderator **review sandbox** so it renders pending blocks. The onsite pending-block preview never rendered: `ReviewPreviewPanel` embedded the review host as a **raw `<iframe src>`** with no host bridge, so nothing posted `BLOCK_INIT` and the SDK block hung on "Connecting to host". The `?mr=` token is only the mod-gate entry token — not a block token. This adds the missing host handshake.

Because the preview runs **UNAPPROVED, untrusted code with a moderator's session**, it is built as defense-in-depth — no single layer is load-bearing.

## Changes (per step)

1. **`blocks.mintReviewBlockToken`** — a `moderatorProcedure` mutation gated identically to `previewRequest`/`getReviewStatus` (moderator + `enforceAppBlocksFlag` + the mod-only `app-blocks-review-sandbox` flag). Resolves the pending request by `publishRequestId` (not ownership — the mod is not the author), reads the pending manifest's scopes, and reuses the audited `clampDevScopes` + `signDevScopedPageToken` belt: self-bound `sub` = the mod, forced-SFW, `domain:null`, synthetic non-resolving ids (`pubreq_…` appBlockId — an already-recognized synthetic prefix), short TTL, and a mint-time audit event (never the token).
2. **`REVIEW_MINT_SCOPE_ALLOWLIST`** (render-only) — the strictest of the three mint allowlists. KEEPS `models:read:self`, `media:read:owned`, `user:read:self`, `collections:read:self`. STRIPS regardless of manifest: `ai:write:budgeted`, `apps:storage:read|write|shared:read|shared:write`, `collections:read:private`, `collections:write:self`, `social:tip:self`, `buzz:read:self`. `keyCanSpend:false` strips spend as belt-and-suspenders.
3. **`reviewMode` read-only gate on `PageBlockHost`** (default `false` → prod path byte-identical) — every side-effecting/money/private/cross-user handler replies with a known-shape, fail-fast NACK (never a hang) and never reaches its mutation. Render-safe reads stay live (`BLOCK_INIT`, resource/checkpoint pickers, self-viewer, shared reads, sign-in, `REQUEST_TOKEN`).
4. **`ReviewBlockPreviewHost`** mounts the real `PageBlockHost` against the review iframe (replacing the raw iframe), fetching the block token from `mintReviewBlockToken` when the preview is live. Forces `trustTier:'unverified'` → opaque origin (drops `allow-same-origin`), passes `reviewMode`, and keeps the existing `pickReviewIframeSrc` stabilization + `no-referrer`.
5. **Tests** — allowlist clamp + full mint (self-bound, forced-SFW, synthetic ids, none of the withheld scopes survive), router gate coverage, `reviewMode` NACKs (each money/write/private message returns the fail-fast shape and never calls the mutation; render-safe reads still work; non-reviewMode unchanged), the review handshake to `BLOCK_READY` carrying the review token, and the opaque-origin acceptance.

## Defense-in-depth guard

| Layer | Mechanism |
|---|---|
| Opaque sandbox | `trustTier` forced `unverified` → `intersectSandbox` drops `allow-same-origin` → opaque origin (self-escalation defense) |
| Stripped self-bound token | render-only allowlist + `keyCanSpend:false`; `sub` = the mod; forced-SFW; synthetic non-resolving ids |
| Read-only host NACKs | `reviewMode` fail-fast NACKs every side-effecting/money/private/cross-user handler |
| _(pre-existing)_ | DNS-only egress + mod-gate entry token + short TTL |

**Dark / mod-gated** behind the `app-blocks-review-sandbox` flag. **No migration** (audit table already has nullable `appBlockId`/`syntheticAppId`). **No infra change.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
