### PR TITLE
fix(challenge): persist user theme elements on create/edit

### DIFF
--- a/src/components/Challenge/ChallengeUpsertForm.tsx
+++ b/src/components/Challenge/ChallengeUpsertForm.tsx
@@ -376,6 +376,11 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
       return;
     }
 
+    const parsedThemeElements = data.themeElements
+      ?.split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
     if (isUser) {
       // The user schema requires description (see formSchema) — this narrows the type for the
       // mutation and is a safety net; the inline error comes from the schema on the first submit.
@@ -421,6 +426,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
         title: data.title,
         description: data.description,
         theme: data.theme,
+        themeElements: parsedThemeElements?.length ? parsedThemeElements : undefined,
         coverImage: data.coverImage,
         allowedNsfwLevel: data.allowedNsfwLevel,
         modelVersionIds: data.modelVersionIds,
@@ -457,12 +463,6 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
       return;
     }
     const visibleAt = snapScheduleHour(data.visibleAt);
-
-    // Parse comma-separated theme elements into array
-    const parsedThemeElements = data.themeElements
-      ?.split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
 
     // Shared fields for both modes
     const sharedFields = {


### PR DESCRIPTION
## Why
Theme Elements entered by creators were not persisting for user-created challenges. Creators could type values like "cute cat, silly hat", submit, and then see the field come back empty on later views/edits.

## Root Cause
The user challenge submit path parsed Theme Elements in the form, but did not include them in the upsertUserChallenge mutation payload.

## What Changed
- Parse Theme Elements once in the shared submit handler path.
- Include parsed themeElements in the user mutation payload for both create and edit flows.
- Keep existing moderator flow behavior unchanged.

## Result
User-created challenges now persist Theme Elements correctly and rehydrate them on later edits.

## Validation
- Ran: pnpm vitest src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx --run
- Result: pass

## Risk
Low. This is a narrow payload wiring fix in the user submit path.

ClickUp: https://app.clickup.com/t/868kd6h95
