### PR TITLE
fix(challenge): avoid false delete error toast after success

### DIFF
--- a/src/components/Challenge/challenge.utils.ts
+++ b/src/components/Challenge/challenge.utils.ts
@@ -101,8 +101,8 @@ export function useDeleteUserChallenge() {
   const utils = trpc.useUtils();
 
   const deleteUserChallengeMutation = trpc.challenge.deleteUserChallenge.useMutation({
-    async onSuccess() {
-      await utils.challenge.getInfinite.invalidate();
+    onSuccess() {
+      void utils.challenge.getInfinite.invalidate();
       showSuccessNotification({
         message: 'Challenge deleted — your escrowed Buzz has been refunded.',
       });


### PR DESCRIPTION
## Why
Deleting a user-created challenge could succeed server-side but still show an error toast and keep the confirm dialog open. This made successful deletes look like failures.

## Root Cause
The success callback awaited cache invalidation. If invalidation rejected or raced with route changes, the mutation flow could fall into error UI despite the delete having already completed.

## What Changed
- In useDeleteUserChallenge success handler, made challenge list invalidation fire-and-forget instead of awaited.
- Kept success notification behavior intact.

## Result
After successful delete:
- Dialog closes reliably.
- Redirect flow proceeds.
- No false failure toast from post-success invalidation issues.

## Validation
- Manual code-path verification in detail/context-menu delete flow.

## Risk
Low. No server behavior change; only post-success client-side sequencing.

ClickUp: https://app.clickup.com/t/868kd6gxm
