### PR TITLE
fix(challenge): keep owner challenges visible despite cover scan state

### DIFF
--- a/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
+++ b/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
@@ -712,7 +712,7 @@ export function filterPreferences<
     case 'challenges':
       const challenges = value.filter((challenge) => {
         const isOwner = challenge.createdBy.id === currentUser?.id;
-        if ((isOwner || isModerator) && challenge.nsfwLevel === 0) return true;
+        if (isOwner || isModerator) return true;
 
         // Content allowed by the challenge must intersect the user's browsing level
         if (!Flags.intersects(challenge.allowedNsfwLevel, browsingLevel)) {


### PR DESCRIPTION
## Why
Creators reported their own challenges disappearing from My Challenges while cover scan/rating was still pending.

## Root Cause
The hidden-preferences challenge filter still applied browsing-level and cover-image visibility checks to owner views, which can hide owner content before scan completion.

## What Changed
- In hidden-preferences filtering for challenges, owner/moderator now bypasses challenge visibility filtering in that client-side pass.

## Result
Creators can always see their own challenges in My Challenges, even when cover scan is pending. Public visibility rules remain unchanged.

## Validation
- Ran: pnpm vitest src/components/HiddenPreferences/__tests__/useApplyHiddenPreferences.test.ts --run
- Result: pass

## Risk
Low. Scope is limited to owner/moderator view in client-side hidden-preferences filtering.

ClickUp: https://app.clickup.com/t/868kd6h7k
