### PR TITLE
fix(challenge): improve number input editability and constraints

### DIFF
--- a/src/components/Challenge/CategoryWeights.tsx
+++ b/src/components/Challenge/CategoryWeights.tsx
@@ -104,7 +104,7 @@ export default function CategoryWeights({ disabled = false }: { disabled?: boole
                 step={1}
                 allowDecimal={false}
                 allowNegative={false}
-                clampBehavior="blur"
+                clampBehavior="none"
                 className="w-24 shrink-0"
                 disabled={disabled}
               />

--- a/src/components/Challenge/ChallengeUpsertForm.tsx
+++ b/src/components/Challenge/ChallengeUpsertForm.tsx
@@ -830,6 +830,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                     min={CHALLENGE_MIN_ENTRY_FEE}
                     max={CHALLENGE_MAX_ENTRY_FEE}
                     step={10}
+                    clampBehavior="none"
                     description={`${perEntryToPool} Buzz of each entry goes to the prize pool. Entry fees are non-refundable once paid.`}
                     withAsterisk
                     disabled={isTerminal}
@@ -847,9 +848,9 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                 </SimpleGrid>
                 <Divider label="Prize split (must total 100%)" />
                 <SimpleGrid cols={3}>
-                  <InputNumber name="dist1" label="1st Place %" min={1} max={100} allowNegative={false} clampBehavior="blur" withAsterisk disabled={isTerminal} />
-                  <InputNumber name="dist2" label="2nd Place %" min={1} max={100} allowNegative={false} clampBehavior="blur" withAsterisk disabled={isTerminal} />
-                  <InputNumber name="dist3" label="3rd Place %" min={1} max={100} allowNegative={false} clampBehavior="blur" withAsterisk disabled={isTerminal} />
+                  <InputNumber name="dist1" label="1st Place %" min={1} max={100} allowNegative={false} clampBehavior="none" withAsterisk disabled={isTerminal} />
+                  <InputNumber name="dist2" label="2nd Place %" min={1} max={100} allowNegative={false} clampBehavior="none" withAsterisk disabled={isTerminal} />
+                  <InputNumber name="dist3" label="3rd Place %" min={1} max={100} allowNegative={false} clampBehavior="none" withAsterisk disabled={isTerminal} />
                 </SimpleGrid>
                 <Text size="sm" c={totalPct === 100 ? 'teal' : 'red'}>
                   {dist1 || 0} + {dist2 || 0} + {dist3 || 0} = {totalPct}%

--- a/src/libs/form/components/NumberInputWrapper.tsx
+++ b/src/libs/form/components/NumberInputWrapper.tsx
@@ -93,9 +93,9 @@ export const NumberInputWrapper = forwardRef<HTMLInputElement, Props>(
         fixedDecimalScale={isCurrency}
         onChange={handleChange}
         value={parsedValue}
-        min={min ? (isCurrency ? min / 100 : min) : undefined}
-        max={max ? (isCurrency ? max / 100 : max) : undefined}
-        step={step ? (isCurrency ? step / 100 : step) : undefined}
+        min={min != null ? (isCurrency ? min / 100 : min) : undefined}
+        max={max != null ? (isCurrency ? max / 100 : max) : undefined}
+        step={step != null ? (isCurrency ? step / 100 : step) : undefined}
         {...props}
       />
     );


### PR DESCRIPTION
## Why
Several challenge numeric inputs were difficult to edit (especially on mobile): users could not fully erase values without snap-back behavior, and min/step handling had edge-case issues when set to 0.

## Root Cause
- NumberInputWrapper treated min/max/step as truthy checks, so 0 could be dropped.
- Some challenge NumberInput fields used clamp behavior that snapped during editing.

## What Changed
- NumberInputWrapper now applies min/max/step when values are present, including 0.
- Updated challenge Entry Fee, prize split %, and category weight inputs to avoid clamp snap-back during typing.

## Result
Numeric fields are easier to clear and retype, with constraints still enforced by validation and submit-time checks.

## Validation
- Ran: pnpm vitest src/components/Challenge --run
- Result: pass

## Risk
Low to medium. UX behavior changed for input clamping, but validation guards remain in place.

ClickUp: https://app.clickup.com/t/868kd6gwr
