### PR TITLE
fix(challenge): include theme elements in moderation scans

### DIFF
--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -38,12 +38,18 @@ export { computeDynamicPool, distributePrizes } from './challenge-pool';
 export function buildChallengeModerationText(challenge: {
   title: string | null;
   theme: string | null;
+  themeElements?: string[] | null;
   description: string | null;
   invitation: string | null;
 }) {
+  const themeElementsLine = challenge.themeElements?.length
+    ? challenge.themeElements.join(', ')
+    : null;
+
   return [
     challenge.title,
     challenge.theme,
+    themeElementsLine,
     challenge.description ? removeTags(challenge.description) : null,
     challenge.invitation,
   ]

--- a/src/server/services/challenge-moderation.adapter.ts
+++ b/src/server/services/challenge-moderation.adapter.ts
@@ -4,6 +4,7 @@ import type { ModerationAdapter } from '~/server/services/entity-moderation.serv
 import { createNotification } from '~/server/services/notification.service';
 import { submitTextModeration } from '~/server/services/text-moderation.service';
 import { buildChallengeModerationText } from '~/server/games/daily-challenge/challenge-helpers';
+import { parseChallengeMetadata } from '~/server/schema/challenge.schema';
 import { deriveChallengeNsfwLevel } from '~/server/games/daily-challenge/daily-challenge.utils';
 import { ChallengeIngestionStatus } from '~/shared/utils/prisma/enums';
 
@@ -21,9 +22,17 @@ export const challengeModerationAdapter: ModerationAdapter = {
   resolveContent: async (ids) => {
     const rows = await dbRead.challenge.findMany({
       where: { id: { in: ids } },
-      select: { id: true, title: true, theme: true, description: true, invitation: true },
+      select: { id: true, title: true, theme: true, description: true, invitation: true, metadata: true },
     });
-    return new Map(rows.map((r) => [r.id, buildChallengeModerationText(r)]));
+    return new Map(
+      rows.map((r) => [
+        r.id,
+        buildChallengeModerationText({
+          ...r,
+          themeElements: parseChallengeMetadata(r.metadata).themeElements,
+        }),
+      ])
+    );
   },
 
   submit: ({ entityId, content }) =>

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1437,6 +1437,7 @@ export async function upsertUserChallenge({
     description: rest.description ?? null,
     theme: rest.theme,
     invitation: rest.invitation ?? null,
+    themeElements: themeEls ?? null,
     coverImageId,
     allowedNsfwLevel,
     nsfwLevel: deriveChallengeNsfwLevel(allowedNsfwLevel),
@@ -1524,7 +1525,11 @@ export async function upsertUserChallenge({
     // EntityModeration row, so no webhook ever flips ingestion back to Scanned and the challenge
     // sits hidden until the activation job voids it.
     const moderatedTextChanged =
-      buildChallengeModerationText(commonData) !== buildChallengeModerationText(existing);
+      buildChallengeModerationText(commonData) !==
+      buildChallengeModerationText({
+        ...existing,
+        themeElements: parseChallengeMetadata(existing.metadata).themeElements,
+      });
 
     const updated = await dbWrite.$transaction(async (tx) => {
       // Conditional on status IN THE WRITE: the Scheduled/entry-count checks above ran on the
@@ -1679,7 +1684,7 @@ export async function upsertUserChallenge({
 export async function scanUserChallenge(challengeId: number): Promise<void> {
   const challenge = await dbRead.challenge.findUnique({
     where: { id: challengeId },
-    select: { title: true, description: true, theme: true, invitation: true },
+    select: { title: true, description: true, theme: true, invitation: true, metadata: true },
   });
   if (!challenge) return;
 
@@ -1687,7 +1692,10 @@ export async function scanUserChallenge(challengeId: number): Promise<void> {
     await submitTextModeration({
       entityType: 'Challenge',
       entityId: challengeId,
-      content: buildChallengeModerationText(challenge),
+      content: buildChallengeModerationText({
+        ...challenge,
+        themeElements: parseChallengeMetadata(challenge.metadata).themeElements,
+      }),
       labels: ['nsfw'],
       priority: 'low',
     });


### PR DESCRIPTION
## Why
Challenge text moderation did not include Theme Elements, allowing unmoderated text in that field to bypass the moderation content set.

## Root Cause
Theme Elements were not consistently included in moderation text construction and comparison paths.

## What Changed
- Added Theme Elements to challenge moderation text builder.
- Adapter content resolution now reads Theme Elements from challenge metadata and includes them in moderation payload content.
- User challenge edit/create moderation comparison and scan submission now include Theme Elements.

## Result
Theme Elements are now moderated alongside title, theme, description, and invitation.

## Validation
- Ran: pnpm vitest src/server/services/__tests__/challenge-edit-rescan.service.test.ts src/server/games/daily-challenge/__tests__/challenge-helpers.test.ts --run
- Result: pass

## Risk
Low. Change is scoped to moderation content composition and related comparison paths.

ClickUp: https://app.clickup.com/t/868kd6h0c
