### PR TITLE
fix(challenge): make challenge+collection deletion atomic

### DIFF
--- a/src/server/services/__tests__/challenge-delete-user.service.test.ts
+++ b/src/server/services/__tests__/challenge-delete-user.service.test.ts
@@ -17,6 +17,7 @@ const {
       delete: vi.fn().mockResolvedValue(undefined),
     },
     collection: { delete: vi.fn().mockResolvedValue(undefined) },
+    $transaction: vi.fn(),
   },
   mockRefundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
   mockQueueUpdate: vi.fn(),
@@ -52,6 +53,9 @@ describe('deleteUserChallenge', () => {
     vi.clearAllMocks();
     mockDbRead.collectionItem.count.mockResolvedValue(0);
     mockDbWrite.challenge.updateMany.mockResolvedValue({ count: 1 });
+    mockDbWrite.$transaction.mockImplementation(async (fn: any) =>
+      fn({ challenge: mockDbWrite.challenge, collection: mockDbWrite.collection })
+    );
   });
 
   it('owner + Scheduled + 0 entries: claims, refunds and deletes', async () => {
@@ -122,6 +126,9 @@ describe('deleteChallenge (direct)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockDbWrite.challenge.updateMany.mockResolvedValue({ count: 1 });
+    mockDbWrite.$transaction.mockImplementation(async (fn: any) =>
+      fn({ challenge: mockDbWrite.challenge, collection: mockDbWrite.collection })
+    );
   });
 
   it('already-Cancelled User challenge: re-refunds idempotently without re-claiming, then deletes', async () => {
@@ -133,6 +140,14 @@ describe('deleteChallenge (direct)', () => {
     expect(mockDbWrite.challenge.updateMany).not.toHaveBeenCalled();
     expect(mockRefundUserChallengeFunds).toHaveBeenCalledWith(1);
     expect(mockDbWrite.challenge.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+
+  it('fails atomically when collection deletion fails', async () => {
+    mockDbWrite.challenge.findUnique.mockResolvedValue(makeChallenge());
+    mockDbWrite.collection.delete.mockRejectedValueOnce(new Error('collection delete failed'));
+
+    await expect(deleteChallenge(1)).rejects.toThrow(/collection delete failed/i);
+    expect(mockQueueUpdate).not.toHaveBeenCalled();
   });
 
   it('blocks deleting an Active challenge', async () => {

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1770,13 +1770,19 @@ export async function deleteChallenge(id: number) {
 
   const collectionId = challenge.collectionId;
 
-  // Delete challenge first (cascades to ChallengeWinner)
-  await dbWrite.challenge.delete({ where: { id } });
+  // Keep challenge + collection deletion in one transaction so a failed collection delete
+  // cannot leave an orphaned contest collection after the challenge row is removed.
+  await dbWrite.$transaction(async (tx) => {
+    // Delete challenge first (cascades to ChallengeWinner)
+    await tx.challenge.delete({ where: { id } });
 
-  // Delete the associated collection and all its data
+    // Delete the associated collection and all its data
+    if (collectionId) {
+      await tx.collection.delete({ where: { id: collectionId } });
+    }
+  });
+
   if (collectionId) {
-    await dbWrite.collection.delete({ where: { id: collectionId } });
-
     // Remove from search index
     await collectionsSearchIndex.queueUpdate([
       { id: collectionId, action: SearchIndexUpdateQueueAction.Delete },


### PR DESCRIPTION
## Why
Deleting a user-created challenge could leave behind its linked contest collection if collection deletion failed after the challenge row had already been removed.

## Root Cause
Challenge deletion and collection deletion were performed as separate DB operations. A failure in the second step could leave an orphaned collection.

## What Changed
- Wrapped challenge + linked collection deletion in a single database transaction.
- Kept search-index delete queueing after successful transactional delete.
- Added regression test coverage for collection-delete failure to verify atomic behavior.

## Result
Challenge deletion is now atomic with linked collection cleanup, preventing new orphaned collections from this path.

## Validation
- Ran: pnpm vitest src/server/services/__tests__/challenge-delete-user.service.test.ts --run
- Result: pass

## Risk
Low. Scoped to delete flow transaction boundaries and test updates.

ClickUp: https://app.clickup.com/t/868kd6h2e
