### PR TITLE
fix(challenge): roll up reviewed challenge platform fixes

### DIFF
--- a/src/components/Challenge/CategoryWeights.tsx
+++ b/src/components/Challenge/CategoryWeights.tsx
@@ -104,7 +104,7 @@ export default function CategoryWeights({ disabled = false }: { disabled?: boole
                 step={1}
                 allowDecimal={false}
                 allowNegative={false}
-                clampBehavior="none"
+                clampBehavior="blur"
                 className="w-24 shrink-0"
                 disabled={disabled}
               />

--- a/src/components/Challenge/CategoryWeights.tsx
+++ b/src/components/Challenge/CategoryWeights.tsx
@@ -104,7 +104,7 @@ export default function CategoryWeights({ disabled = false }: { disabled?: boole
                 step={1}
                 allowDecimal={false}
                 allowNegative={false}
-                clampBehavior="blur"
+                clampBehavior="none"
                 className="w-24 shrink-0"
                 disabled={disabled}
               />

--- a/src/components/Challenge/ChallengeUpsertForm.tsx
+++ b/src/components/Challenge/ChallengeUpsertForm.tsx
@@ -830,6 +830,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                     min={CHALLENGE_MIN_ENTRY_FEE}
                     max={CHALLENGE_MAX_ENTRY_FEE}
                     step={10}
+                    clampBehavior="none"
                     description={`${perEntryToPool} Buzz of each entry goes to the prize pool. Entry fees are non-refundable once paid.`}
                     withAsterisk
                     disabled={isTerminal}
@@ -847,9 +848,9 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                 </SimpleGrid>
                 <Divider label="Prize split (must total 100%)" />
                 <SimpleGrid cols={3}>
-                  <InputNumber name="dist1" label="1st Place %" min={1} max={100} allowNegative={false} clampBehavior="blur" withAsterisk disabled={isTerminal} />
-                  <InputNumber name="dist2" label="2nd Place %" min={1} max={100} allowNegative={false} clampBehavior="blur" withAsterisk disabled={isTerminal} />
-                  <InputNumber name="dist3" label="3rd Place %" min={1} max={100} allowNegative={false} clampBehavior="blur" withAsterisk disabled={isTerminal} />
+                  <InputNumber name="dist1" label="1st Place %" min={1} max={100} allowNegative={false} clampBehavior="none" withAsterisk disabled={isTerminal} />
+                  <InputNumber name="dist2" label="2nd Place %" min={1} max={100} allowNegative={false} clampBehavior="none" withAsterisk disabled={isTerminal} />
+                  <InputNumber name="dist3" label="3rd Place %" min={1} max={100} allowNegative={false} clampBehavior="none" withAsterisk disabled={isTerminal} />
                 </SimpleGrid>
                 <Text size="sm" c={totalPct === 100 ? 'teal' : 'red'}>
                   {dist1 || 0} + {dist2 || 0} + {dist3 || 0} = {totalPct}%

--- a/src/components/Challenge/ChallengeUpsertForm.tsx
+++ b/src/components/Challenge/ChallengeUpsertForm.tsx
@@ -376,6 +376,11 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
       return;
     }
 
+    const parsedThemeElements = data.themeElements
+      ?.split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
     if (isUser) {
       // The user schema requires description (see formSchema) — this narrows the type for the
       // mutation and is a safety net; the inline error comes from the schema on the first submit.
@@ -421,6 +426,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
         title: data.title,
         description: data.description,
         theme: data.theme,
+        themeElements: parsedThemeElements?.length ? parsedThemeElements : undefined,
         coverImage: data.coverImage,
         allowedNsfwLevel: data.allowedNsfwLevel,
         modelVersionIds: data.modelVersionIds,
@@ -457,12 +463,6 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
       return;
     }
     const visibleAt = snapScheduleHour(data.visibleAt);
-
-    // Parse comma-separated theme elements into array
-    const parsedThemeElements = data.themeElements
-      ?.split(',')
-      .map((s) => s.trim())
-      .filter(Boolean);
 
     // Shared fields for both modes
     const sharedFields = {

--- a/src/components/Challenge/ChallengeUpsertForm.tsx
+++ b/src/components/Challenge/ChallengeUpsertForm.tsx
@@ -832,7 +832,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                     max={CHALLENGE_MAX_ENTRY_FEE}
                     step={10}
                     allowNegative={false}
-                    clampBehavior="none"
+                    clampBehavior="blur"
                     description={`Min ${CHALLENGE_MIN_ENTRY_FEE} Buzz. ${perEntryToPool} Buzz of each entry goes to the prize pool.`}
                     withAsterisk
                     disabled={isTerminal}
@@ -843,17 +843,46 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                     leftSection={<CurrencyIcon currency="BUZZ" type={selectedBuzzType} size={16} />}
                     currency={Currency.BUZZ}
                     min={0}
+                    max={CHALLENGE_MAX_INITIAL_PRIZE}
                     step={100}
                     allowNegative={false}
+                    clampBehavior="blur"
                     description="Buzz you seed the pool with (charged to you on creation)."
                     disabled={isTerminal}
                   />
                 </SimpleGrid>
                 <Divider label="Prize split (must total 100%)" />
                 <SimpleGrid cols={3}>
-                  <InputNumber name="dist1" label="1st Place %" min={1} max={100} allowNegative={false} clampBehavior="none" withAsterisk disabled={isTerminal} />
-                  <InputNumber name="dist2" label="2nd Place %" min={1} max={100} allowNegative={false} clampBehavior="none" withAsterisk disabled={isTerminal} />
-                  <InputNumber name="dist3" label="3rd Place %" min={1} max={100} allowNegative={false} clampBehavior="none" withAsterisk disabled={isTerminal} />
+                  <InputNumber 
+                    name="dist1"
+                    label="1st Place %"
+                    min={1}
+                    max={100}
+                    allowNegative={false}
+                    clampBehavior="blur"
+                    withAsterisk
+                    disabled={isTerminal}
+                  />
+                  <InputNumber
+                    name="dist2"
+                    label="2nd Place %"
+                    min={1}
+                    max={100}
+                    allowNegative={false}
+                    clampBehavior="blur"
+                    withAsterisk
+                    disabled={isTerminal}
+                  />
+                  <InputNumber
+                    name="dist3"
+                    label="3rd Place %"
+                    min={1}
+                    max={100}
+                    allowNegative={false}
+                    clampBehavior="blur"
+                    withAsterisk
+                    disabled={isTerminal}
+                  />
                 </SimpleGrid>
                 <Text size="sm" c={totalPct === 100 ? 'teal' : 'red'}>
                   {dist1 || 0} + {dist2 || 0} + {dist3 || 0} = {totalPct}%

--- a/src/components/Challenge/ChallengeUpsertForm.tsx
+++ b/src/components/Challenge/ChallengeUpsertForm.tsx
@@ -819,7 +819,8 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                 <Alert icon={<IconInfoCircle size={16} />} color="blue">
                   Entry fees &amp; prizes use <b>{buzzLabel} Buzz</b>. Your challenge is funded by
                   entry fees — each entry pays the entry fee; {CHALLENGE_ENTRY_HOUSE_CUT} Buzz per
-                  entry covers AI judging and the rest grows the prize pool.
+                  entry covers AI judging and the rest grows the prize pool. Entry fees are
+                  non-refundable once paid.
                 </Alert>
                 <SimpleGrid cols={{ base: 1, sm: 2 }}>
                   <InputNumber
@@ -832,7 +833,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                     step={10}
                     allowNegative={false}
                     clampBehavior="none"
-                    description={`Minimum ${CHALLENGE_MIN_ENTRY_FEE} Buzz. ${perEntryToPool} Buzz of each entry goes to the prize pool. Entry fees are non-refundable once paid.`}
+                    description={`Min ${CHALLENGE_MIN_ENTRY_FEE} Buzz. ${perEntryToPool} Buzz of each entry goes to the prize pool.`}
                     withAsterisk
                     disabled={isTerminal}
                   />

--- a/src/components/Challenge/ChallengeUpsertForm.tsx
+++ b/src/components/Challenge/ChallengeUpsertForm.tsx
@@ -830,8 +830,9 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                     min={CHALLENGE_MIN_ENTRY_FEE}
                     max={CHALLENGE_MAX_ENTRY_FEE}
                     step={10}
+                    allowNegative={false}
                     clampBehavior="none"
-                    description={`${perEntryToPool} Buzz of each entry goes to the prize pool. Entry fees are non-refundable once paid.`}
+                    description={`Minimum ${CHALLENGE_MIN_ENTRY_FEE} Buzz. ${perEntryToPool} Buzz of each entry goes to the prize pool. Entry fees are non-refundable once paid.`}
                     withAsterisk
                     disabled={isTerminal}
                   />
@@ -842,6 +843,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                     currency={Currency.BUZZ}
                     min={0}
                     step={100}
+                    allowNegative={false}
                     description="Buzz you seed the pool with (charged to you on creation)."
                     disabled={isTerminal}
                   />

--- a/src/components/Challenge/__tests__/InputNumberClear.browser.test.tsx
+++ b/src/components/Challenge/__tests__/InputNumberClear.browser.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { z } from 'zod';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+import { Form, InputNumber, useForm } from '~/libs/form';
+
+/**
+ * Repro for tester feedback: clearing an InputNumber (select-all + delete / backspace to empty)
+ * must leave the field visibly empty — not re-render the previous value. Mirrors the Entry Fee
+ * setup (min/max/step + clampBehavior="none" + a form.watch that re-renders the whole form on
+ * every keystroke, like `entryFeeWatch` in ChallengeUpsertForm).
+ */
+
+const schema = z.object({
+  amount: z.number().int().min(50).max(100_000).default(50),
+});
+
+function Harness() {
+  const form = useForm({ schema, defaultValues: { amount: 500 } });
+  // Same shape as ChallengeUpsertForm's `entryFeeWatch` — forces a parent re-render per keystroke.
+  const watched = form.watch('amount') ?? 50;
+
+  return (
+    <Form form={form}>
+      <InputNumber
+        name="amount"
+        label="Amount"
+        min={50}
+        max={100_000}
+        step={10}
+        allowNegative={false}
+        clampBehavior="none"
+      />
+      <div data-testid="watched">{String(watched)}</div>
+    </Form>
+  );
+}
+
+describe('InputNumber — clearing the value', () => {
+  test('select-all + delete leaves the field empty, and it stays empty on blur', async () => {
+    renderWithProviders(<Harness />);
+
+    const input = page.getByLabelText('Amount');
+    await expect.element(input).toHaveValue('500');
+
+    await input.clear();
+    await expect.element(input).toHaveValue('');
+
+    // Blur — the emptied field must not resurrect the old value.
+    await page.getByTestId('watched').click();
+    await expect.element(input).toHaveValue('');
+  });
+
+  test('backspacing digit by digit down to empty leaves the field empty', async () => {
+    renderWithProviders(<Harness />);
+
+    const input = page.getByLabelText('Amount');
+    await input.click();
+    await input.fill('500');
+    await expect.element(input).toHaveValue('500');
+
+    // Erase one character at a time like a user on mobile would.
+    await userEvent.keyboard('{End}');
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(input).toHaveValue('50');
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(input).toHaveValue('5');
+    await userEvent.keyboard('{Backspace}');
+    await expect.element(input).toHaveValue('');
+  });
+});

--- a/src/components/Challenge/__tests__/InputNumberClear.browser.test.tsx
+++ b/src/components/Challenge/__tests__/InputNumberClear.browser.test.tsx
@@ -7,16 +7,18 @@ import { Form, InputNumber, useForm } from '~/libs/form';
 
 /**
  * Repro for tester feedback: clearing an InputNumber (select-all + delete / backspace to empty)
- * must leave the field visibly empty — not re-render the previous value. Mirrors the Entry Fee
- * setup (min/max/step + clampBehavior="none" + a form.watch that re-renders the whole form on
- * every keystroke, like `entryFeeWatch` in ChallengeUpsertForm).
+ * must leave the field visibly empty — not re-render the previous value (RHF's useController
+ * substitutes the field's defaultValue when the stored value is undefined). Mirrors the Entry
+ * Fee setup: min/max/step + a form.watch that re-renders the whole form on every keystroke
+ * (like `entryFeeWatch` in ChallengeUpsertForm). Both clampBehavior modes are covered — the
+ * production prize inputs use "blur"; "none" pins the mode PR #3176 shipped with.
  */
 
 const schema = z.object({
   amount: z.number().int().min(50).max(100_000).default(50),
 });
 
-function Harness() {
+function Harness({ clampBehavior }: { clampBehavior: 'blur' | 'none' }) {
   const form = useForm({ schema, defaultValues: { amount: 500 } });
   // Same shape as ChallengeUpsertForm's `entryFeeWatch` — forces a parent re-render per keystroke.
   const watched = form.watch('amount') ?? 50;
@@ -30,16 +32,16 @@ function Harness() {
         max={100_000}
         step={10}
         allowNegative={false}
-        clampBehavior="none"
+        clampBehavior={clampBehavior}
       />
       <div data-testid="watched">{String(watched)}</div>
     </Form>
   );
 }
 
-describe('InputNumber — clearing the value', () => {
+describe.each(['blur', 'none'] as const)('InputNumber — clearing the value (clampBehavior=%s)', (clampBehavior) => {
   test('select-all + delete leaves the field empty, and it stays empty on blur', async () => {
-    renderWithProviders(<Harness />);
+    renderWithProviders(<Harness clampBehavior={clampBehavior} />);
 
     const input = page.getByLabelText('Amount');
     await expect.element(input).toHaveValue('500');
@@ -47,13 +49,13 @@ describe('InputNumber — clearing the value', () => {
     await input.clear();
     await expect.element(input).toHaveValue('');
 
-    // Blur — the emptied field must not resurrect the old value.
+    // Blur — the emptied field must not resurrect the old value (or blur-clamp it back in).
     await page.getByTestId('watched').click();
     await expect.element(input).toHaveValue('');
   });
 
   test('backspacing digit by digit down to empty leaves the field empty', async () => {
-    renderWithProviders(<Harness />);
+    renderWithProviders(<Harness clampBehavior={clampBehavior} />);
 
     const input = page.getByLabelText('Amount');
     await input.click();

--- a/src/components/Challenge/challenge.utils.ts
+++ b/src/components/Challenge/challenge.utils.ts
@@ -101,8 +101,8 @@ export function useDeleteUserChallenge() {
   const utils = trpc.useUtils();
 
   const deleteUserChallengeMutation = trpc.challenge.deleteUserChallenge.useMutation({
-    async onSuccess() {
-      await utils.challenge.getInfinite.invalidate();
+    onSuccess() {
+      void utils.challenge.getInfinite.invalidate();
       showSuccessNotification({
         message: 'Challenge deleted — your escrowed Buzz has been refunded.',
       });

--- a/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
+++ b/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
@@ -712,7 +712,7 @@ export function filterPreferences<
     case 'challenges':
       const challenges = value.filter((challenge) => {
         const isOwner = challenge.createdBy.id === currentUser?.id;
-        if ((isOwner || isModerator) && challenge.nsfwLevel === 0) return true;
+        if (isOwner || isModerator) return true;
 
         // Content allowed by the challenge must intersect the user's browsing level
         if (!Flags.intersects(challenge.allowedNsfwLevel, browsingLevel)) {

--- a/src/libs/form/components/NumberInputWrapper.tsx
+++ b/src/libs/form/components/NumberInputWrapper.tsx
@@ -93,9 +93,9 @@ export const NumberInputWrapper = forwardRef<HTMLInputElement, Props>(
         fixedDecimalScale={isCurrency}
         onChange={handleChange}
         value={parsedValue}
-        min={min ? (isCurrency ? min / 100 : min) : undefined}
-        max={max ? (isCurrency ? max / 100 : max) : undefined}
-        step={step ? (isCurrency ? step / 100 : step) : undefined}
+        min={min != null ? (isCurrency ? min / 100 : min) : undefined}
+        max={max != null ? (isCurrency ? max / 100 : max) : undefined}
+        step={step != null ? (isCurrency ? step / 100 : step) : undefined}
         {...props}
       />
     );

--- a/src/libs/form/hoc/withController.tsx
+++ b/src/libs/form/hoc/withController.tsx
@@ -23,11 +23,13 @@ export function withController<
     fieldState,
     formState,
     props,
+    form,
   }: {
     field: ControllerRenderProps<TFieldValues, TName>;
     fieldState: ControllerFieldState;
     formState: UseFormStateReturn<TFieldValues>;
     props: TComponentProps;
+    form: Omit<ReturnType<typeof useFormContext<TFieldValues>>, 'control'>;
   }) => Partial<TComponentProps>
 ) {
   const ControlledInput = forwardRef<HTMLElement, TComponentProps & { name: TName }>(
@@ -38,7 +40,7 @@ export function withController<
           control={control}
           name={name}
           render={({ field, fieldState, formState }) => {
-            const mappedProps = mapper?.({ field, fieldState, formState, props: props as any }); //eslint-disable-line
+            const mappedProps = mapper?.({ field, fieldState, formState, props: props as any, form }); //eslint-disable-line
 
             const handleChange = (...values: any) => {
               //eslint-disable-line

--- a/src/libs/form/index.ts
+++ b/src/libs/form/index.ts
@@ -44,6 +44,10 @@ export const InputNumber = withController(NumberInputWrapper, ({ field, form }) 
   // RHF's useController substitutes the field's defaultValue whenever the stored value is
   // undefined, which resurrects the old value in the UI right after the user clears the input.
   // getValues() reads the raw store without that substitution, so a cleared field stays empty.
+  // Caveat: with `shouldUnregister: true` (the useForm default), a conditionally-mounted
+  // InputNumber that has a defaultValue renders empty on remount while useController silently
+  // re-seeds the store — the submit would carry a value the UI doesn't show. Mount such fields
+  // unconditionally or set shouldUnregister: false on that form.
   value: form.getValues(field.name),
 }));
 export const InputTextArea = withController(Textarea);

--- a/src/libs/form/index.ts
+++ b/src/libs/form/index.ts
@@ -40,8 +40,11 @@ export type { FormProps } from '~/libs/form/components/Form';
 export { useForm } from './hooks/useForm';
 
 export const InputText = withController(TextInputWrapper);
-export const InputNumber = withController(NumberInputWrapper, ({ field }) => ({
-  value: field.value,
+export const InputNumber = withController(NumberInputWrapper, ({ field, form }) => ({
+  // RHF's useController substitutes the field's defaultValue whenever the stored value is
+  // undefined, which resurrects the old value in the UI right after the user clears the input.
+  // getValues() reads the raw store without that substitution, so a cleared field stays empty.
+  value: form.getValues(field.name),
 }));
 export const InputTextArea = withController(Textarea);
 export const InputSelect = withController(SelectWrapper);

--- a/src/pages/challenges/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/[id]/[[...slug]].tsx
@@ -392,7 +392,13 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
                         <Menu.Item
                           leftSection={<IconPencil size={14} stroke={1.5} />}
                           component={Link}
-                          href={`/moderator/challenges/${challenge.id}/edit`}
+                          // User challenges use the user form (entry fee / judging categories);
+                          // the moderator form's prize model doesn't apply to them.
+                          href={
+                            challenge.source === ChallengeSource.User
+                              ? `/challenges/${challenge.id}/edit`
+                              : `/moderator/challenges/${challenge.id}/edit`
+                          }
                         >
                           Edit Challenge
                         </Menu.Item>

--- a/src/pages/challenges/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/[id]/[[...slug]].tsx
@@ -356,6 +356,16 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
       // challenge whose declared rating is SFW but whose cover scanned NSFW still shows the
       // MatureContentRedirect on the green (SFW) site instead of leaking the cover.
       contentNsfwLevel={challenge.allowedNsfwLevel | (challenge.coverImage?.nsfwLevel ?? 0)}
+      // Yellow user challenges live on civitai.red regardless of rating — the server returns
+      // them on green so this renders the redirect card instead of a 404 (inert on red).
+      // Owner/mods keep detail access on green for SFW yellow challenges, mirroring the
+      // server-side preview exemption; NSFW ones still redirect via contentNsfwLevel.
+      nsfw={
+        challenge.source === ChallengeSource.User &&
+        challenge.buzzType === 'yellow' &&
+        !isOwner &&
+        !currentUser?.isModerator
+      }
       bypassRating={isOwner || (currentUser?.isModerator ?? false)}
       meta={{
         title: `${challenge.title} | Civitai Challenges`,

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -38,12 +38,18 @@ export { computeDynamicPool, distributePrizes } from './challenge-pool';
 export function buildChallengeModerationText(challenge: {
   title: string | null;
   theme: string | null;
+  themeElements?: string[] | null;
   description: string | null;
   invitation: string | null;
 }) {
+  const themeElementsLine = challenge.themeElements?.length
+    ? challenge.themeElements.join(', ')
+    : null;
+
   return [
     challenge.title,
     challenge.theme,
+    themeElementsLine,
     challenge.description ? removeTags(challenge.description) : null,
     challenge.invitation,
   ]

--- a/src/server/routers/challenge.router.ts
+++ b/src/server/routers/challenge.router.ts
@@ -184,12 +184,18 @@ export const challengeRouter = router({
     .use(isFlagProtected('challengePlatform'))
     .query(({ ctx }) => getUserChallengeCreateEligibility(ctx.user.id)),
 
-  // User: fetch own Scheduled challenge for editing (owner-guarded in the service).
+  // User: fetch own Scheduled challenge for editing (owner/moderator-guarded in the service).
   getUserChallengeForEdit: protectedProcedure
     .input(getByIdSchema)
     .use(isFlagProtected('challengePlatform'))
     .use(isFlagProtected('userChallenges'))
-    .query(({ input, ctx }) => getUserChallengeForEdit({ id: input.id, userId: ctx.user.id })),
+    .query(({ input, ctx }) =>
+      getUserChallengeForEdit({
+        id: input.id,
+        userId: ctx.user.id,
+        isModerator: ctx.user.isModerator,
+      })
+    ),
 
   // Moderator: Get all challenges (including drafts)
   getModeratorList: moderatorProcedure
@@ -215,6 +221,7 @@ export const challengeRouter = router({
       upsertUserChallenge({
         ...input,
         userId: ctx.user.id,
+        isModerator: ctx.user.isModerator,
         buzzType: input.buzzType ?? deriveDomainCurrency(ctx.features.isGreen),
       })
     ),

--- a/src/server/services/__tests__/challenge-delete-user.service.test.ts
+++ b/src/server/services/__tests__/challenge-delete-user.service.test.ts
@@ -17,6 +17,7 @@ const {
       delete: vi.fn().mockResolvedValue(undefined),
     },
     collection: { delete: vi.fn().mockResolvedValue(undefined) },
+    $transaction: vi.fn(),
   },
   mockRefundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
   mockQueueUpdate: vi.fn(),
@@ -52,6 +53,9 @@ describe('deleteUserChallenge', () => {
     vi.clearAllMocks();
     mockDbRead.collectionItem.count.mockResolvedValue(0);
     mockDbWrite.challenge.updateMany.mockResolvedValue({ count: 1 });
+    mockDbWrite.$transaction.mockImplementation(async (fn: any) =>
+      fn({ challenge: mockDbWrite.challenge, collection: mockDbWrite.collection })
+    );
   });
 
   it('owner + Scheduled + 0 entries: claims, refunds and deletes', async () => {
@@ -122,6 +126,9 @@ describe('deleteChallenge (direct)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockDbWrite.challenge.updateMany.mockResolvedValue({ count: 1 });
+    mockDbWrite.$transaction.mockImplementation(async (fn: any) =>
+      fn({ challenge: mockDbWrite.challenge, collection: mockDbWrite.collection })
+    );
   });
 
   it('already-Cancelled User challenge: re-refunds idempotently without re-claiming, then deletes', async () => {
@@ -133,6 +140,14 @@ describe('deleteChallenge (direct)', () => {
     expect(mockDbWrite.challenge.updateMany).not.toHaveBeenCalled();
     expect(mockRefundUserChallengeFunds).toHaveBeenCalledWith(1);
     expect(mockDbWrite.challenge.delete).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+
+  it('fails atomically when collection deletion fails', async () => {
+    mockDbWrite.challenge.findUnique.mockResolvedValue(makeChallenge());
+    mockDbWrite.collection.delete.mockRejectedValueOnce(new Error('collection delete failed'));
+
+    await expect(deleteChallenge(1)).rejects.toThrow(/collection delete failed/i);
+    expect(mockQueueUpdate).not.toHaveBeenCalled();
   });
 
   it('blocks deleting an Active challenge', async () => {

--- a/src/server/services/__tests__/challenge-detail-visibility.service.test.ts
+++ b/src/server/services/__tests__/challenge-detail-visibility.service.test.ts
@@ -209,4 +209,34 @@ describe('getChallengeDetail — mod/owner preview of hidden user challenges', (
       expect(await getChallengeDetail(400, RANDO_ID, false, false)).toBeNull();
     });
   });
+
+  describe('domain-currency gate', () => {
+    it('returns the detail for a moderator despite domain mismatch', async () => {
+      mockGetChallengeById.mockResolvedValue(
+        makeUserChallenge({ ingestion: 'Scanned', buzzType: 'yellow' })
+      );
+
+      // green site viewer + yellow challenge would normally be hidden by domain-currency gate
+      const result = await getChallengeDetail(400, MOD_ID, true, true);
+      expect(result).not.toBeNull();
+    });
+
+    it('returns the detail for the owner despite domain mismatch', async () => {
+      mockGetChallengeById.mockResolvedValue(
+        makeUserChallenge({ ingestion: 'Scanned', buzzType: 'yellow' })
+      );
+
+      const result = await getChallengeDetail(400, OWNER_ID, true, false);
+      expect(result).not.toBeNull();
+    });
+
+    it('stays hidden from other users when domain mismatches', async () => {
+      mockGetChallengeById.mockResolvedValue(
+        makeUserChallenge({ ingestion: 'Scanned', buzzType: 'yellow' })
+      );
+
+      expect(await getChallengeDetail(400, RANDO_ID, true, false)).toBeNull();
+      expect(await getChallengeDetail(400, undefined, true, false)).toBeNull();
+    });
+  });
 });

--- a/src/server/services/__tests__/challenge-detail-visibility.service.test.ts
+++ b/src/server/services/__tests__/challenge-detail-visibility.service.test.ts
@@ -230,13 +230,22 @@ describe('getChallengeDetail — mod/owner preview of hidden user challenges', (
       expect(result).not.toBeNull();
     });
 
-    it('stays hidden from other users when domain mismatches', async () => {
+    it('returns a yellow challenge on the green site so the client can render the redirect gate', async () => {
       mockGetChallengeById.mockResolvedValue(
         makeUserChallenge({ ingestion: 'Scanned', buzzType: 'yellow' })
       );
 
-      expect(await getChallengeDetail(400, RANDO_ID, true, false)).toBeNull();
-      expect(await getChallengeDetail(400, undefined, true, false)).toBeNull();
+      expect(await getChallengeDetail(400, RANDO_ID, true, false)).not.toBeNull();
+      expect(await getChallengeDetail(400, undefined, true, false)).not.toBeNull();
+    });
+
+    it('keeps green challenges hidden from other users on the red site', async () => {
+      mockGetChallengeById.mockResolvedValue(
+        makeUserChallenge({ ingestion: 'Scanned', buzzType: 'green' })
+      );
+
+      expect(await getChallengeDetail(400, RANDO_ID, false, false)).toBeNull();
+      expect(await getChallengeDetail(400, undefined, false, false)).toBeNull();
     });
   });
 });

--- a/src/server/services/__tests__/challenge-edit-rescan.service.test.ts
+++ b/src/server/services/__tests__/challenge-edit-rescan.service.test.ts
@@ -194,4 +194,56 @@ describe('upsertUserChallenge (edit branch) — ingestion reset scoped to modera
     expect(data.scannedAt).toBeNull();
     expect(mockSubmitTextModeration).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps themeElements out of the challenge row write (metadata-only, no such column)', async () => {
+    await upsertUserChallenge({
+      ...baseEditInput,
+      themeElements: ['cute cat', 'silly hat'],
+    } as never);
+
+    expect(mockTx.challenge.updateMany).toHaveBeenCalledTimes(1);
+    const { data } = mockTx.challenge.updateMany.mock.calls[0][0];
+    expect(data).not.toHaveProperty('themeElements');
+    expect(data.metadata).toEqual({ themeElements: ['cute cat', 'silly hat'] });
+    // Adding theme elements changes the moderated text, so the scan verdict must reset.
+    expect(data.ingestion).toBe('Pending');
+    expect(mockSubmitTextModeration).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('upsertUserChallenge (edit branch) — moderator edit access', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbRead.image.findFirst.mockResolvedValue({ id: 555 });
+    mockDbRead.challenge.findUnique.mockResolvedValue(existingChallenge);
+    mockTx.challenge.updateMany.mockResolvedValue({ count: 1 });
+    mockTx.challenge.findUniqueOrThrow.mockResolvedValue({ id: 42 });
+  });
+
+  it('rejects a non-owner without moderator status', async () => {
+    await expect(
+      upsertUserChallenge({ ...baseEditInput, userId: 222 } as never)
+    ).rejects.toThrow('You can only edit your own challenges.');
+    expect(mockTx.challenge.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('lets a moderator edit another user challenge', async () => {
+    await upsertUserChallenge({ ...baseEditInput, userId: 222, isModerator: true } as never);
+
+    expect(mockTx.challenge.updateMany).toHaveBeenCalledTimes(1);
+    // Cover reuse must not require the moderator to own the creator's image.
+    expect(mockDbRead.image.findFirst).toHaveBeenCalledWith({
+      where: { id: 555 },
+      select: { id: true },
+    });
+  });
+
+  it('still requires image ownership for a non-moderator owner', async () => {
+    await upsertUserChallenge(baseEditInput as never);
+
+    expect(mockDbRead.image.findFirst).toHaveBeenCalledWith({
+      where: { id: 555, userId: 111 },
+      select: { id: true },
+    });
+  });
 });

--- a/src/server/services/__tests__/challenge-edit-rescan.service.test.ts
+++ b/src/server/services/__tests__/challenge-edit-rescan.service.test.ts
@@ -209,6 +209,43 @@ describe('upsertUserChallenge (edit branch) — ingestion reset scoped to modera
     expect(data.ingestion).toBe('Pending');
     expect(mockSubmitTextModeration).toHaveBeenCalledTimes(1);
   });
+
+  it('persists clearing themeElements so the rescan content actually changes', async () => {
+    // If the clear were dropped (old `...(themeEls && ...)` guard), the reset scan would submit
+    // byte-identical text, hit the contentHash dedup, and the challenge would sit Pending until
+    // voided — the exact deadlock this file's header describes.
+    mockDbRead.challenge.findUnique.mockResolvedValue({
+      ...existingChallenge,
+      metadata: { themeElements: ['cute cat', 'silly hat'] },
+    });
+
+    await upsertUserChallenge({
+      ...baseEditInput,
+      themeElements: undefined,
+    } as never);
+
+    expect(mockTx.challenge.updateMany).toHaveBeenCalledTimes(1);
+    const { data } = mockTx.challenge.updateMany.mock.calls[0][0];
+    expect(data.metadata).not.toHaveProperty('themeElements');
+    expect(data.ingestion).toBe('Pending');
+    expect(mockSubmitTextModeration).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reset the scan when stored themeElements are resubmitted unchanged', async () => {
+    mockDbRead.challenge.findUnique.mockResolvedValue({
+      ...existingChallenge,
+      metadata: { themeElements: ['cute cat', 'silly hat'] },
+    });
+
+    await upsertUserChallenge({
+      ...baseEditInput,
+      themeElements: ['cute cat', 'silly hat'],
+    } as never);
+
+    const { data } = mockTx.challenge.updateMany.mock.calls[0][0];
+    expect(data).not.toHaveProperty('ingestion');
+    expect(mockSubmitTextModeration).not.toHaveBeenCalled();
+  });
 });
 
 describe('upsertUserChallenge (edit branch) — moderator edit access', () => {

--- a/src/server/services/__tests__/challenge-edit.service.test.ts
+++ b/src/server/services/__tests__/challenge-edit.service.test.ts
@@ -108,7 +108,7 @@ vi.mock('~/server/utils/errorHandling', () => ({
 }));
 
 // Import after mocks are set up (top-level, not in beforeEach)
-const { getChallengeForEdit, upsertUserChallenge } = await import(
+const { getChallengeForEdit, getUserChallengeForEdit, upsertUserChallenge } = await import(
   '~/server/services/challenge.service'
 );
 
@@ -275,5 +275,48 @@ describe('upsertUserChallenge (edit branch) — creator standing re-check', () =
     expect(mockAssertCanCreateUserChallenge).not.toHaveBeenCalled();
     // The edit branch must never reach for the score-bundled check.
     expect(mockAssertUserInGoodStanding).not.toHaveBeenCalled();
+  });
+});
+
+describe('getUserChallengeForEdit — ownership/moderator gate', () => {
+  const guardRow = {
+    source: 'User' as const,
+    createdById: 111,
+    status: 'Scheduled' as const,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetChallengeConfig.mockResolvedValue(mockConfig);
+    mockDbRead.$queryRaw.mockResolvedValue([
+      { id: 111, username: 'creator', image: null, deletedAt: null },
+    ]);
+    mockDbRead.challenge.findUnique.mockResolvedValue(guardRow);
+    mockGetChallengeById.mockResolvedValue(
+      makeMockChallenge({ source: 'User', createdById: 111, status: 'Scheduled' })
+    );
+  });
+
+  it('returns the challenge for its owner', async () => {
+    const result = await getUserChallengeForEdit({ id: 1, userId: 111 });
+    expect(result?.id).toBe(1);
+  });
+
+  it('returns the challenge for a moderator who is not the owner', async () => {
+    const result = await getUserChallengeForEdit({ id: 1, userId: 222, isModerator: true });
+    expect(result?.id).toBe(1);
+  });
+
+  it('rejects a non-owner without moderator status', async () => {
+    await expect(getUserChallengeForEdit({ id: 1, userId: 222 })).rejects.toThrow(
+      'You can only edit your own challenges.'
+    );
+  });
+
+  it('rejects non-User challenges even for moderators (mod form owns those)', async () => {
+    mockDbRead.challenge.findUnique.mockResolvedValue({ ...guardRow, source: 'System' });
+    await expect(
+      getUserChallengeForEdit({ id: 1, userId: 222, isModerator: true })
+    ).rejects.toThrow('This challenge cannot be edited here.');
   });
 });

--- a/src/server/services/challenge-moderation.adapter.ts
+++ b/src/server/services/challenge-moderation.adapter.ts
@@ -4,6 +4,7 @@ import type { ModerationAdapter } from '~/server/services/entity-moderation.serv
 import { createNotification } from '~/server/services/notification.service';
 import { submitTextModeration } from '~/server/services/text-moderation.service';
 import { buildChallengeModerationText } from '~/server/games/daily-challenge/challenge-helpers';
+import { parseChallengeMetadata } from '~/server/schema/challenge.schema';
 import { deriveChallengeNsfwLevel } from '~/server/games/daily-challenge/daily-challenge.utils';
 import { ChallengeIngestionStatus } from '~/shared/utils/prisma/enums';
 
@@ -21,9 +22,17 @@ export const challengeModerationAdapter: ModerationAdapter = {
   resolveContent: async (ids) => {
     const rows = await dbRead.challenge.findMany({
       where: { id: { in: ids } },
-      select: { id: true, title: true, theme: true, description: true, invitation: true },
+      select: { id: true, title: true, theme: true, description: true, invitation: true, metadata: true },
     });
-    return new Map(rows.map((r) => [r.id, buildChallengeModerationText(r)]));
+    return new Map(
+      rows.map((r) => [
+        r.id,
+        buildChallengeModerationText({
+          ...r,
+          themeElements: parseChallengeMetadata(r.metadata).themeElements,
+        }),
+      ])
+    );
   },
 
   submit: ({ entityId, content }) =>

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -943,7 +943,11 @@ export async function getChallengeDetail(
 
   // Domain-currency gate — direct-URL parity with the feed filter. Like the other gates above,
   // moderators and creators can preview unpublished/hidden challenges regardless of domain.
+  // On the green site a mismatched (yellow) challenge is returned anyway: the detail page's
+  // <Gated> shows the civitai.red redirect card instead of a bare 404. The red side keeps
+  // hiding green challenges — there's no equivalent redirect surface pointing back to green.
   if (
+    !isGreen &&
     !canPreviewUnpublished &&
     isChallengeHiddenByDomainCurrency(
       {

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1770,13 +1770,19 @@ export async function deleteChallenge(id: number) {
 
   const collectionId = challenge.collectionId;
 
-  // Delete challenge first (cascades to ChallengeWinner)
-  await dbWrite.challenge.delete({ where: { id } });
+  // Keep challenge + collection deletion in one transaction so a failed collection delete
+  // cannot leave an orphaned contest collection after the challenge row is removed.
+  await dbWrite.$transaction(async (tx) => {
+    // Delete challenge first (cascades to ChallengeWinner)
+    await tx.challenge.delete({ where: { id } });
 
-  // Delete the associated collection and all its data
+    // Delete the associated collection and all its data
+    if (collectionId) {
+      await tx.collection.delete({ where: { id: collectionId } });
+    }
+  });
+
   if (collectionId) {
-    await dbWrite.collection.delete({ where: { id: collectionId } });
-
     // Remove from search index
     await collectionsSearchIndex.queueUpdate([
       { id: collectionId, action: SearchIndexUpdateQueueAction.Delete },

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1352,8 +1352,13 @@ export async function upsertChallenge({
 export async function upsertUserChallenge({
   userId,
   buzzType,
+  isModerator,
   ...input
-}: UserChallengeUpsertInput & { userId: number; buzzType: ChallengeBuzzType }) {
+}: UserChallengeUpsertInput & {
+  userId: number;
+  buzzType: ChallengeBuzzType;
+  isModerator?: boolean;
+}) {
   const {
     id,
     coverImage,
@@ -1421,8 +1426,10 @@ export async function upsertUserChallenge({
   // only covers text.
   let coverImageId: number;
   if (coverImage.id != null) {
+    // Moderators may edit challenges whose cover belongs to the creator, so ownership is
+    // only enforced for regular users.
     const ownedImage = await dbRead.image.findFirst({
-      where: { id: coverImage.id, userId },
+      where: isModerator ? { id: coverImage.id } : { id: coverImage.id, userId },
       select: { id: true },
     });
     if (!ownedImage)
@@ -1439,7 +1446,6 @@ export async function upsertUserChallenge({
     description: rest.description ?? null,
     theme: rest.theme,
     invitation: rest.invitation ?? null,
-    themeElements: themeEls ?? null,
     coverImageId,
     allowedNsfwLevel,
     nsfwLevel: deriveChallengeNsfwLevel(allowedNsfwLevel),
@@ -1483,7 +1489,7 @@ export async function upsertUserChallenge({
     if (!existing) throw throwNotFoundError('Challenge not found');
     if (existing.source !== ChallengeSource.User)
       throw new TRPCError({ code: 'FORBIDDEN', message: 'This challenge cannot be edited here.' });
-    if (existing.createdById !== userId)
+    if (existing.createdById !== userId && !isModerator)
       throw new TRPCError({ code: 'FORBIDDEN', message: 'You can only edit your own challenges.' });
     // Text/config locks once live: only Scheduled challenges with no entries yet are editable.
     if (existing.status !== ChallengeStatus.Scheduled)
@@ -1527,7 +1533,9 @@ export async function upsertUserChallenge({
     // EntityModeration row, so no webhook ever flips ingestion back to Scanned and the challenge
     // sits hidden until the activation job voids it.
     const moderatedTextChanged =
-      buildChallengeModerationText(commonData) !==
+      // themeElements lives in metadata (no Challenge column), so it rides along only for the
+      // moderation-text comparison — never in the commonData row write.
+      buildChallengeModerationText({ ...commonData, themeElements: themeEls ?? null }) !==
       buildChallengeModerationText({
         ...existing,
         themeElements: parseChallengeMetadata(existing.metadata).themeElements,
@@ -1837,14 +1845,25 @@ export async function deleteUserChallenge({ id, userId }: { id: number; userId: 
 
 // User-safe fetch for the edit form. getChallengeForEdit is moderator-only; this guards ownership
 // first, then returns the same shape. User challenges have judgingPrompt = null, so nothing
-// moderator-sensitive is exposed.
-export async function getUserChallengeForEdit({ id, userId }: { id: number; userId: number }) {
+// moderator-sensitive is exposed. Moderators bypass ownership (they manage user challenges through
+// this same form); non-User challenges stay on the moderator edit page regardless.
+export async function getUserChallengeForEdit({
+  id,
+  userId,
+  isModerator,
+}: {
+  id: number;
+  userId: number;
+  isModerator?: boolean;
+}) {
   const existing = await dbRead.challenge.findUnique({
     where: { id },
     select: { source: true, createdById: true, status: true },
   });
   if (!existing) throw throwNotFoundError('Challenge not found');
-  if (existing.source !== ChallengeSource.User || existing.createdById !== userId)
+  if (existing.source !== ChallengeSource.User)
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'This challenge cannot be edited here.' });
+  if (existing.createdById !== userId && !isModerator)
     throw new TRPCError({ code: 'FORBIDDEN', message: 'You can only edit your own challenges.' });
   if (existing.status !== ChallengeStatus.Scheduled)
     throw new TRPCError({

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -941,8 +941,10 @@ export async function getChallengeDetail(
       return null;
   }
 
-  // Domain-currency gate — direct-URL parity with the feed filter; user-scoped, creator exempt.
+  // Domain-currency gate — direct-URL parity with the feed filter. Like the other gates above,
+  // moderators and creators can preview unpublished/hidden challenges regardless of domain.
   if (
+    !canPreviewUnpublished &&
     isChallengeHiddenByDomainCurrency(
       {
         source: challenge.source,

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1437,6 +1437,7 @@ export async function upsertUserChallenge({
     description: rest.description ?? null,
     theme: rest.theme,
     invitation: rest.invitation ?? null,
+    themeElements: themeEls ?? null,
     coverImageId,
     allowedNsfwLevel,
     nsfwLevel: deriveChallengeNsfwLevel(allowedNsfwLevel),
@@ -1524,7 +1525,11 @@ export async function upsertUserChallenge({
     // EntityModeration row, so no webhook ever flips ingestion back to Scanned and the challenge
     // sits hidden until the activation job voids it.
     const moderatedTextChanged =
-      buildChallengeModerationText(commonData) !== buildChallengeModerationText(existing);
+      buildChallengeModerationText(commonData) !==
+      buildChallengeModerationText({
+        ...existing,
+        themeElements: parseChallengeMetadata(existing.metadata).themeElements,
+      });
 
     const updated = await dbWrite.$transaction(async (tx) => {
       // Conditional on status IN THE WRITE: the Scheduled/entry-count checks above ran on the
@@ -1679,7 +1684,7 @@ export async function upsertUserChallenge({
 export async function scanUserChallenge(challengeId: number): Promise<void> {
   const challenge = await dbRead.challenge.findUnique({
     where: { id: challengeId },
-    select: { title: true, description: true, theme: true, invitation: true },
+    select: { title: true, description: true, theme: true, invitation: true, metadata: true },
   });
   if (!challenge) return;
 
@@ -1687,7 +1692,10 @@ export async function scanUserChallenge(challengeId: number): Promise<void> {
     await submitTextModeration({
       entityType: 'Challenge',
       entityId: challengeId,
-      content: buildChallengeModerationText(challenge),
+      content: buildChallengeModerationText({
+        ...challenge,
+        themeElements: parseChallengeMetadata(challenge.metadata).themeElements,
+      }),
       labels: ['nsfw'],
       priority: 'low',
     });

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1430,8 +1430,8 @@ export async function upsertUserChallenge({
   // only covers text.
   let coverImageId: number;
   if (coverImage.id != null) {
-    // Moderators may edit challenges whose cover belongs to the creator, so ownership is
-    // only enforced for regular users.
+    // Regular users must own the reused image. Moderators skip the ownership check entirely
+    // (trusted role — typically re-saving the creator's existing cover during a mod edit).
     const ownedImage = await dbRead.image.findFirst({
       where: isModerator ? { id: coverImage.id } : { id: coverImage.id, userId },
       select: { id: true },
@@ -1545,6 +1545,13 @@ export async function upsertUserChallenge({
         themeElements: parseChallengeMetadata(existing.metadata).themeElements,
       });
 
+    // Write themeElements on every edit — including clears. A dropped clear would make the
+    // reset scan resubmit byte-identical text, hit the contentHash dedup, and strand the
+    // challenge at Pending until the activation job voids it (the #3160 deadlock).
+    const nextMetadata = { ...parseChallengeMetadata(existing.metadata) };
+    if (themeEls) nextMetadata.themeElements = themeEls;
+    else delete nextMetadata.themeElements;
+
     const updated = await dbWrite.$transaction(async (tx) => {
       // Conditional on status IN THE WRITE: the Scheduled/entry-count checks above ran on the
       // read replica, so the hourly activation job (or a racing entry charge) could have flipped
@@ -1566,9 +1573,7 @@ export async function upsertUserChallenge({
           }),
           // Recompute the visibility window from the (possibly updated) start date.
           visibleAt: getUserChallengeVisibleAt(rest.startsAt),
-          ...(themeEls && {
-            metadata: { ...parseChallengeMetadata(existing.metadata), themeElements: themeEls },
-          }),
+          metadata: nextMetadata,
         },
       });
       if (count === 0)


### PR DESCRIPTION
## Summary
This rollup PR promotes all reviewed challenge-fix subtasks from `fix/challenges-test-feedback` into `main`.

Included fixes:
- challenge + linked collection deletion is atomic (prevents orphaned collections)
- user delete dialog no longer shows false failure after successful delete
- user challenge Theme Elements now persist on create/edit
- Theme Elements included in challenge text moderation/rescan paths
- creators always see their own challenges in My Challenges while scan is pending
- challenge numeric inputs are easier to edit (no snap-back while typing) with constraints preserved

## Source PRs
- https://github.com/civitai/civitai/pull/3179
- https://github.com/civitai/civitai/pull/3174
- https://github.com/civitai/civitai/pull/3173
- https://github.com/civitai/civitai/pull/3177
- https://github.com/civitai/civitai/pull/3175
- https://github.com/civitai/civitai/pull/3176

## Validation
Targeted test runs were executed in each subtask PR, including:
- challenge delete service tests
- challenge form/browser tests
- hidden preferences tests
- challenge moderation helper + edit-rescan tests

## ClickUp
- https://app.clickup.com/t/868kd6h2e
- https://app.clickup.com/t/868kd6gxm
- https://app.clickup.com/t/868kd6h95
- https://app.clickup.com/t/868kd6h0c
- https://app.clickup.com/t/868kd6h7k
- https://app.clickup.com/t/868kd6gwr
