### PR TITLE
fix(app-blocks): audit-detail enrichment must never 500 the tip/shared-storage endpoints

### DIFF
--- a/src/pages/api/v1/blocks/shared-storage/increment.ts
+++ b/src/pages/api/v1/blocks/shared-storage/increment.ts
@@ -60,7 +60,18 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
     const result = await incrementSharedCounter(bearer(req), key);
     // W13 richer audit detail — stash a structured ref so the middleware
     // finish-writer records "Bumped shared counter <key>". Best-effort.
-    stashBlockActionDetail(res, { action: 'storage.increment', key, outcome: 'ok' });
+    //
+    // 🔴 The ENTIRE enrichment (detail construction AND the stash call) is wrapped
+    // in a swallow-everything try/catch so it can NEVER change this endpoint's
+    // outcome. A successful increment ALWAYS returns its real 200 even if
+    // enrichment throws (undefined stash export, non-writable `res`, …) — the audit
+    // row is simply skipped. (Regression: #3161's stash sat inside the handler try
+    // and a throw at the call site surfaced as a 500 on the happy path.)
+    try {
+      stashBlockActionDetail(res, { action: 'storage.increment', key, outcome: 'ok' });
+    } catch {
+      /* audit enrichment is best-effort — it must never perturb the response */
+    }
     res.status(200).json(result);
     return;
   } catch (error) {

--- a/src/pages/api/v1/blocks/tip.ts
+++ b/src/pages/api/v1/blocks/tip.ts
@@ -189,16 +189,28 @@ export const baseHandler = withAxiom(async function handler(
 
     // W13 richer audit detail — stash a structured ref so the middleware
     // finish-writer records "Tipped N Buzz to @recipient" (the view resolves
-    // toUserId → @username). Best-effort: stash swallows, never perturbs the
-    // money path. `amount` is positive here (a credit TO the recipient).
-    stashBlockActionDetail(res, {
-      action: 'tip',
-      amount,
-      toUserId,
-      ...(entityType ? { entityType } : {}),
-      ...(entityId ? { entityId } : {}),
-      outcome: 'ok',
-    });
+    // toUserId → @username). Best-effort: `amount` is positive here (a credit TO
+    // the recipient).
+    //
+    // 🔴 The ENTIRE enrichment (detail construction AND the stash call) is wrapped
+    // in a swallow-everything try/catch so it can NEVER change this endpoint's
+    // outcome. A successful tip ALWAYS returns its real 200 even if enrichment
+    // throws — a missing/undefined stash export, a null-deref building the detail,
+    // or a non-writable `res` all no-op the audit row, they do not 500 a tip whose
+    // money already moved. (Regression: #3161's stash sat inside the money-path try
+    // and a throw at the call site surfaced as a 500 on the happy path.)
+    try {
+      stashBlockActionDetail(res, {
+        action: 'tip',
+        amount,
+        toUserId,
+        ...(entityType ? { entityType } : {}),
+        ...(entityId ? { entityId } : {}),
+        outcome: 'ok',
+      });
+    } catch {
+      /* audit enrichment is best-effort — it must never perturb the money path */
+    }
 
     res.status(200).json({
       ok: true,

--- a/src/tests/api/v1/blocks/shared-storage-increment-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/shared-storage-increment-endpoint.test.ts
@@ -50,10 +50,19 @@ vi.mock('~/server/middleware/block-scope.middleware', () => ({
     req.blockClaims = claimsBox.claims;
     return handler(req, res);
   },
+  // W13 audit-detail stash — the endpoint imports + calls this on the happy path.
+  // Omitting it (as this mock originally did) is exactly what made the call site
+  // `undefined(...)` → TypeError → 500 on a successful increment (#3161 regression);
+  // exported here so the happy path exercises a real fn, and the regression test
+  // below overrides it to throw to prove the enrichment can never 500.
+  stashBlockActionDetail: (...args: unknown[]) => mockStash(...args),
 }));
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
 
-const { mockIncrement } = vi.hoisted(() => ({ mockIncrement: vi.fn() }));
+const { mockIncrement, mockStash } = vi.hoisted(() => ({
+  mockIncrement: vi.fn(),
+  mockStash: vi.fn(),
+}));
 vi.mock('~/server/routers/apps-shared.router', () => ({
   incrementSharedCounter: mockIncrement,
   // identity — the endpoint's zod schema already bounds the key
@@ -118,6 +127,23 @@ describe('POST /api/v1/blocks/shared-storage/increment', () => {
     expect(res._status()).toBe(200);
     expect(res._json()).toEqual({ key: 'playcount:7', count: 4 });
     expect(mockIncrement).toHaveBeenCalledWith('tok', 'playcount:7');
+  });
+
+  it('REGRESSION: audit-detail enrichment that THROWS still returns the real 200 (never 500)', async () => {
+    // #3161 added a best-effort audit-detail stash on the happy path, inside the
+    // handler try/catch. ANY throw at the enrichment call site (missing stash
+    // export → `undefined(...)`, non-writable `res`, …) surfaced as a 500 on an
+    // increment that already succeeded. The endpoint now wraps the entire
+    // enrichment in a swallow-everything guard.
+    mockStash.mockImplementationOnce(() => {
+      throw new Error('stash boom (non-writable res)');
+    });
+    const { req, res } = createMocks({ body: { key: 'playcount:7' } });
+    await handler(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual({ key: 'playcount:7', count: 4 });
+    expect(mockIncrement).toHaveBeenCalledWith('tok', 'playcount:7');
+    expect(mockStash).toHaveBeenCalledTimes(1);
   });
 
   it('maps a sub-trust FORBIDDEN → 403 (min-trust gate; app treats increment as best-effort)', async () => {

--- a/src/tests/api/v1/blocks/tip-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tip-endpoint.test.ts
@@ -58,17 +58,25 @@ vi.mock('~/server/middleware/block-scope.middleware', () => ({
     if (!/^user:\d+$/.test(sub)) throw new ForbiddenError('bad');
     return Number.parseInt(sub.slice('user:'.length), 10);
   },
+  // W13 audit-detail stash — the endpoint imports + calls this on the happy path.
+  // Omitting it (as this mock originally did) is exactly what made the call site
+  // `undefined(...)` → TypeError → 500 on a successful tip (#3161 regression); it
+  // is exported here so the happy path exercises a real fn, and the regression
+  // test below overrides it to throw to prove the enrichment can never 500.
+  stashBlockActionDetail: (...args: unknown[]) => mockStash(...args),
 }));
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
 
-const { mockTip, mockHydrate, mockRate, mockReserve, mockRefund, mockUserFind } = vi.hoisted(() => ({
-  mockTip: vi.fn(),
-  mockHydrate: vi.fn(),
-  mockRate: vi.fn(),
-  mockReserve: vi.fn(),
-  mockRefund: vi.fn(),
-  mockUserFind: vi.fn(),
-}));
+const { mockTip, mockHydrate, mockRate, mockReserve, mockRefund, mockUserFind, mockStash } =
+  vi.hoisted(() => ({
+    mockTip: vi.fn(),
+    mockHydrate: vi.fn(),
+    mockRate: vi.fn(),
+    mockReserve: vi.fn(),
+    mockRefund: vi.fn(),
+    mockUserFind: vi.fn(),
+    mockStash: vi.fn(),
+  }));
 
 vi.mock('~/server/controllers/buzz.controller', () => ({
   createBuzzTipTransactionHandler: mockTip,
@@ -258,6 +266,30 @@ describe('POST /api/v1/blocks/tip', () => {
         ctx: expect.objectContaining({ user: expect.objectContaining({ id: 42 }) }),
       })
     );
+  });
+
+  it('REGRESSION: audit-detail enrichment that THROWS still returns the real 200 (never 500)', async () => {
+    // #3161 added a best-effort audit-detail stash on the happy path. It sat inside
+    // the money-path try/catch, so ANY throw at the enrichment call site (a missing
+    // stash export → `undefined(...)`, a null-deref building the detail, or a
+    // non-writable `res`) surfaced as a 500 on a tip whose money already moved.
+    // The endpoint now wraps the entire enrichment in a swallow-everything guard:
+    // enrichment failure must NEVER change the response.
+    mockStash.mockImplementationOnce(() => {
+      throw new Error('stash boom (detail-build / non-writable res)');
+    });
+    const { req, res } = createMocks({ body: { toUserId: 5, amount: 25 } });
+    await handler(req as never, res as never);
+    // The tip still moved money and the real success body is returned intact.
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual({
+      ok: true,
+      tip: { toUserId: 5, amount: 25, entityType: null, entityId: null },
+    });
+    expect(mockTip).toHaveBeenCalledTimes(1);
+    // No refund — a post-success enrichment throw is not a money failure.
+    expect(mockRefund).not.toHaveBeenCalled();
+    expect(mockStash).toHaveBeenCalledTimes(1);
   });
 
   it('surfaces insufficient balance as a clean 400 (not a 500)', async () => {


### PR DESCRIPTION
## The regression (root cause)

#3161 added a best-effort **W13 audit-detail stash** (`stashBlockActionDetail`) to the happy path of the App Blocks **tip** (`/api/v1/blocks/tip`) and **shared-storage increment** (`/api/v1/blocks/shared-storage/increment`) endpoints. Its audit claimed *"the stash is self-swallowing and can never propagate into the handler."* That is **false**: the stash *helper* has an internal `try/catch`, but the **call site** in each handler sits **inside the handler's outer money-path `try/catch`**. Any throw at that call site — the imported `stashBlockActionDetail` being `undefined`, a null-deref while constructing the `BlockActionDetail`, or a non-writable `res` — is caught by the outer handler and re-mapped to a generic **500**, on a request whose money / increment had **already committed**.

This left three report-only checks RED on `main`:

- `tip-endpoint.test.ts` — *accepts an amount exactly at the per-tip cap (5000)* → `500` instead of `200`
- `tip-endpoint.test.ts` — *reuses createBuzzTipTransactionHandler with a self-bound sender* → `500` instead of `200`
- `shared-storage-increment-endpoint.test.ts` — *increments and returns { key, count }* → `500` instead of `200`

**Root cause of the RED tests = test-mock-only, but it exposes a real design fragility.** The handler-test mocks of the block-scope middleware omitted the `stashBlockActionDetail` export the endpoints now import, so at the call site it was `undefined` → `undefined(...)` → `TypeError` → outer catch → 500. In production the real `stashBlockActionDetail` exists and swallows, and the detail objects are built from already-in-scope primitives (no null-deref), so the **prod happy path was not at risk from this specific path**. But a money/storage endpoint that can be 500'd by a purely-cosmetic audit annotation — from *any* `res`/stash/detail variant — is unacceptable risk. So the fix hardens the handler, not just the mock.

## The fix

Wrap the **entire enrichment** (detail construction **and** the stash call) in a swallow-everything `try/catch` in both endpoints. A successful tip / increment now **always** returns its real `200` even if enrichment throws — the audit row is simply skipped. The response is never a function of the audit annotation.

The test mocks are also corrected to export `stashBlockActionDetail` (the omission that surfaced the bug), so the happy path exercises a real function.

## Test coverage

- Both handler suites go green (tip: 20 tests, increment: 8 tests).
- **New regression test in each suite**: forces the enrichment to throw and asserts the endpoint **still returns its real 200 + correct body** (and, for tip, does not spuriously refund). This is the test #3161 should have had.
- #3161's own detail suites (`block-action-detail`, `block-action-detail-stash`, `tip.detail`, `record-scope-invocation-detail`) still pass (26 tests).
- `tsc --noEmit` introduces **zero** new type errors (identical error count vs the pristine baseline; none reference the changed files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
