### PR TITLE
perf(system-cache): in-proc memoize global user-independent blobs

### DIFF
--- a/src/server/services/__tests__/system-cache.memoize.test.ts
+++ b/src/server/services/__tests__/system-cache.memoize.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the redis + db layers so we can assert how often the underlying redis
+// GET actually fires for the memoized global blobs. Defined via vi.hoisted so
+// the references are available inside the hoisted vi.mock factory below.
+const { packedGet, packedSet } = vi.hoisted(() => ({
+  packedGet: vi.fn(),
+  packedSet: vi.fn(),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: { get: packedGet, set: packedSet },
+    get: vi.fn(),
+    set: vi.fn(),
+  },
+  sysRedis: { get: vi.fn(), set: vi.fn() },
+  withSysReadDeadline: (p: Promise<unknown>) => p,
+  REDIS_KEYS: { SYSTEM: { MODERATED_TAGS: 'system:moderated-tags' }, LIVE_NOW: 'live-now' },
+  REDIS_SYS_KEYS: { SYSTEM: {}, CLIENT: 'client' },
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { tag: { findMany: vi.fn() }, tagsOnTags: { findMany: vi.fn() } },
+  dbWrite: { tag: { findMany: vi.fn() }, $queryRaw: vi.fn() },
+}));
+
+vi.mock('~/server/redis/fail-open-log', () => ({
+  logSysRedisFailOpen: vi.fn(),
+}));
+
+import { getModeratedTags } from '../system-cache';
+
+describe('system-cache in-proc memoize', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getModeratedTags hits redis once, then serves subsequent calls from the in-proc memo', async () => {
+    const blob = [{ id: 1, name: 'tag', nsfwLevel: 4 }];
+    packedGet.mockResolvedValue(blob);
+
+    const first = await getModeratedTags();
+    const second = await getModeratedTags();
+    const third = await getModeratedTags();
+
+    expect(first).toEqual(blob);
+    expect(second).toEqual(blob);
+    expect(third).toEqual(blob);
+    // Within the in-proc TTL all three calls collapse to a single redis GET.
+    expect(packedGet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/system-cache.ts
+++ b/src/server/services/system-cache.ts
@@ -42,6 +42,15 @@ const SYSTEM_CACHE_EXPIRY = 60 * 60 * 4;
 // to propagate, PER POD, on top of the already-4h redis staleness. Kept short (30s)
 // so that marginal delay is trivial. None of these keys are `redis.del`-invalidated
 // (verified), so the in-proc layer cannot shadow an intended prompt invalidation.
+//
+// The three fully-wrapped content getters (getModeratedTags,
+// getBlockedBrowsingTags, getHomeExcludedTags) now return the SAME array
+// reference for the whole TTL window, so they opt into `{ freeze: true }`: the
+// memoized array is Object.freeze()d (shallow) before it is stored/returned. An
+// accidental in-place mutation (`.sort()`/`.push()`/element write) by any caller
+// would otherwise silently corrupt the shared moderation/tags blob for every
+// concurrent request on the pod — freezing makes that throw instead of corrupt.
+// Current callers only `.map`/`.filter`/`.some`/spread into new arrays (verified).
 const SYSTEM_CACHE_INPROC_TTL_MS = 30_000;
 
 // LIVE_FEATURE_FLAGS behaves like an operational toggle (ops can flip a feature on/off
@@ -94,7 +103,7 @@ const getModeratedTagsMemo = createTtlMemo<SystemModerationTag[]>(async () => {
 
   log('got moderation tags');
   return combined;
-}, SYSTEM_CACHE_INPROC_TTL_MS);
+}, SYSTEM_CACHE_INPROC_TTL_MS, undefined, { freeze: true });
 
 export async function getModeratedTags(): Promise<SystemModerationTag[]> {
   return getModeratedTagsMemo();
@@ -289,7 +298,7 @@ const getBlockedBrowsingTagsMemo = createTtlMemo<{ id: number; name: string }[]>
 
   log('got blocked browsing tags');
   return tags;
-}, SYSTEM_CACHE_INPROC_TTL_MS);
+}, SYSTEM_CACHE_INPROC_TTL_MS, undefined, { freeze: true });
 
 export async function getBlockedBrowsingTags(): Promise<{ id: number; name: string }[]> {
   return getBlockedBrowsingTagsMemo();
@@ -312,7 +321,7 @@ const getHomeExcludedTagsMemo = createTtlMemo<{ id: number; name: string }[]>(as
 
   log('got home excluded tags');
   return tags;
-}, SYSTEM_CACHE_INPROC_TTL_MS);
+}, SYSTEM_CACHE_INPROC_TTL_MS, undefined, { freeze: true });
 
 export async function getHomeExcludedTags() {
   return getHomeExcludedTagsMemo();

--- a/src/server/services/system-cache.ts
+++ b/src/server/services/system-cache.ts
@@ -11,6 +11,7 @@ import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import type { FeatureFlagKey } from '~/server/services/feature-flags.service';
 import type { TagsOnTagsType } from '~/shared/utils/prisma/enums';
 import { TagType } from '~/shared/utils/prisma/enums';
+import { createTtlMemo } from '~/server/utils/ttl-memoize';
 import { indexOfOr } from '~/utils/array-helpers';
 import { createLogger } from '~/utils/logging';
 import { isDefined } from '~/utils/type-guards';
@@ -26,13 +27,41 @@ const log = createLogger('system-cache', 'green');
 
 const SYSTEM_CACHE_EXPIRY = 60 * 60 * 4;
 
+// In-process (per-pod) memoize TTL for the GLOBAL, user-independent system-cache
+// blobs below. These values are identical for every user/request, and the backing
+// redis blob itself already only changes ~every SYSTEM_CACHE_EXPIRY (4h). Putting a
+// short in-proc TTL in front of them collapses a redis GET (+ an msgpackr decode for
+// the packed MODERATED_TAGS) on every call into ~1 read / TTL / pod — mirroring the
+// live `getClientConfigCached` pattern in src/server/trpc.ts. Only successful reads
+// are memoized (a fetcher rejection propagates uncached; see createTtlMemo), so each
+// getter's existing fail-open/fail-safe behavior is preserved.
+//
+// Staleness tradeoff: the moderation-sensitive blobs (MODERATED_TAGS,
+// BLOCKED_BROWSING_TAGS, BROWSING_SETTING_ADDONS) gate which tags/content are hidden,
+// so a newly-moderated tag or a flipped browsing addon takes up to this TTL *longer*
+// to propagate, PER POD, on top of the already-4h redis staleness. Kept short (30s)
+// so that marginal delay is trivial. None of these keys are `redis.del`-invalidated
+// (verified), so the in-proc layer cannot shadow an intended prompt invalidation.
+const SYSTEM_CACHE_INPROC_TTL_MS = 30_000;
+
+// LIVE_FEATURE_FLAGS behaves like an operational toggle (ops can flip a feature on/off
+// via sysRedis), so it gets a shorter TTL than the content blobs — matching
+// CLIENT_CONFIG_TTL_MS — to keep flag-flip propagation fast (<=5s/pod) while still
+// collapsing the per-call sysRedis GET on the generation/feature-flag hot path.
+const LIVE_FLAGS_INPROC_TTL_MS = 5_000;
+
 export type SystemModerationTag = {
   id: number;
   name: string;
   nsfwLevel: NsfwLevel;
   parentId?: number;
 };
-export async function getModeratedTags(): Promise<SystemModerationTag[]> {
+// Hottest of the global blobs: fetched on the feed hidden-preferences path
+// (user-preferences.service.ts) and re-decoded via msgpackr on every call. The
+// in-proc memo cuts both the redis GET and the msgpackr decode per call. This
+// key is NOT redis.del-invalidated anywhere (only the 4h EX), so the extra
+// in-proc TTL is purely additive to the already-eventual 4h staleness.
+const getModeratedTagsMemo = createTtlMemo<SystemModerationTag[]>(async () => {
   const cachedTags = await redis.packed.get<SystemModerationTag[]>(
     REDIS_KEYS.SYSTEM.MODERATED_TAGS
   );
@@ -65,6 +94,10 @@ export async function getModeratedTags(): Promise<SystemModerationTag[]> {
 
   log('got moderation tags');
   return combined;
+}, SYSTEM_CACHE_INPROC_TTL_MS);
+
+export async function getModeratedTags(): Promise<SystemModerationTag[]> {
+  return getModeratedTagsMemo();
 }
 
 export type TagRule = {
@@ -226,7 +259,11 @@ export async function getCategoryTags(type: 'image' | 'model' | 'post' | 'articl
 // Hard navigation blocklist (W2). Seeded from BLOCKED_BROWSING_TAG_IDS; ops
 // override the live set by writing a JSON `{id, name}[]` to the redis key.
 // Names resolved from the DB (lowercase) so W2 name matching + tag-page 404 work.
-export async function getBlockedBrowsingTags(): Promise<{ id: number; name: string }[]> {
+// Global navigation blocklist on the hot feed + tag-page path. Resolves to a
+// real value (redis hit, or a DB fetch that rewrites the key) or throws on a
+// redis/DB failure — it never swallows an error into an empty list — so the
+// in-proc memo only ever caches a genuine value. Not redis.del-invalidated.
+const getBlockedBrowsingTagsMemo = createTtlMemo<{ id: number; name: string }[]>(async () => {
   const cached = await redis.get(REDIS_KEYS.SYSTEM.BLOCKED_BROWSING_TAGS);
   if (cached) {
     // Fail open on a corrupt ops-set value (this getter is on the hot feed +
@@ -252,9 +289,15 @@ export async function getBlockedBrowsingTags(): Promise<{ id: number; name: stri
 
   log('got blocked browsing tags');
   return tags;
+}, SYSTEM_CACHE_INPROC_TTL_MS);
+
+export async function getBlockedBrowsingTags(): Promise<{ id: number; name: string }[]> {
+  return getBlockedBrowsingTagsMemo();
 }
 
-export async function getHomeExcludedTags() {
+// Global, effectively static (['woman', 'women']) home-page tag exclusion.
+// Not redis.del-invalidated; resolves to a real value or throws.
+const getHomeExcludedTagsMemo = createTtlMemo<{ id: number; name: string }[]>(async () => {
   const cachedTags = await redis.get(REDIS_KEYS.SYSTEM.HOME_EXCLUDED_TAGS);
   if (cachedTags) return JSON.parse(cachedTags) as { id: number; name: string }[];
 
@@ -269,6 +312,10 @@ export async function getHomeExcludedTags() {
 
   log('got home excluded tags');
   return tags;
+}, SYSTEM_CACHE_INPROC_TTL_MS);
+
+export async function getHomeExcludedTags() {
+  return getHomeExcludedTagsMemo();
 }
 
 export async function setLiveNow(isLive: boolean) {
@@ -280,6 +327,17 @@ export async function getLiveNow() {
   return cachedLiveNow === 'true';
 }
 
+// In-proc memo over the RAW sysRedis string only — the try/catch + JSON.parse
+// fail-open below stay OUTSIDE the memo so semantics are byte-for-byte preserved:
+// a redis error/timeout rejects (→ NOT cached → outer catch fails open to
+// defaults), while an unset key (null) or a real string IS cached. This is an
+// SSR every-render read, so collapsing the per-render sysRedis GET into ~1/TTL/pod
+// is the win; parsing the small cached string per call is negligible.
+const getBrowsingSettingAddonsRawMemo = createTtlMemo<string | null>(
+  () => withSysReadDeadline(sysRedis.get(REDIS_SYS_KEYS.SYSTEM.BROWSING_SETTING_ADDONS)),
+  SYSTEM_CACHE_INPROC_TTL_MS
+);
+
 export async function getBrowsingSettingAddons() {
   let cached: string | null = null;
   try {
@@ -288,7 +346,7 @@ export async function getBrowsingSettingAddons() {
     // the awaited get ~11min on EVERY page render; the try/catch below only
     // covers a fast DOWN reject. On timeout the deadline rejects into the
     // catch → fail open to defaults.
-    cached = await withSysReadDeadline(sysRedis.get(REDIS_SYS_KEYS.SYSTEM.BROWSING_SETTING_ADDONS));
+    cached = await getBrowsingSettingAddonsRawMemo();
   } catch (err) {
     logSysRedisFailOpen('read-degraded', 'getBrowsingSettingAddons', err);
     return DEFAULT_BROWSING_SETTINGS_ADDONS;
@@ -392,12 +450,24 @@ export async function removeCreationBlockedTags(tagIds: number[]): Promise<Creat
   return setCreationBlockedTags(current.map((t) => t.id).filter((id) => !toRemove.has(id)));
 }
 
+// In-proc memo over the RAW sysRedis string only, with a SHORTER TTL than the
+// content blobs (operational toggle → fast flag-flip propagation). The try/catch
+// + JSON.parse stay OUTSIDE the memo so semantics are preserved exactly: a redis
+// error/timeout rejects (→ NOT cached → outer catch fails open to defaults);
+// unset (null) or a real string IS cached; a corrupt value still throws out of
+// JSON.parse below just as before. Evaluated on the generation/feature-flag hot
+// path, so collapsing the per-call sysRedis GET into ~1/TTL/pod is the win.
+const getLiveFeatureFlagsRawMemo = createTtlMemo<string | null>(
+  () => withSysReadDeadline(sysRedis.get(REDIS_SYS_KEYS.SYSTEM.LIVE_FEATURE_FLAGS)),
+  LIVE_FLAGS_INPROC_TTL_MS
+);
+
 export async function getLiveFeatureFlags() {
   let cached: string | null;
   try {
     // Wall-clock deadline so a silent sysRedis half-open can't park this read
     // (evaluated on the generation/feature-flag hot path) ~11min.
-    cached = await withSysReadDeadline(sysRedis.get(REDIS_SYS_KEYS.SYSTEM.LIVE_FEATURE_FLAGS));
+    cached = await getLiveFeatureFlagsRawMemo();
   } catch (err) {
     logSysRedisFailOpen('read-degraded', 'getLiveFeatureFlags', err);
     return DEFAULT_LIVE_FEATURE_FLAGS;

--- a/src/server/utils/__tests__/ttl-memoize.test.ts
+++ b/src/server/utils/__tests__/ttl-memoize.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createTtlMemo } from '../ttl-memoize';
+
+// A controllable clock so the tests are deterministic and never rely on
+// wall-clock sleeps.
+function makeClock(start = 0) {
+  let t = start;
+  return {
+    now: () => t,
+    advance: (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+describe('createTtlMemo', () => {
+  it('returns the cached value within the TTL and calls the fetcher only once', async () => {
+    const clock = makeClock();
+    const fetcher = vi.fn(async () => 'value-1');
+    const memo = createTtlMemo(fetcher, 30_000, clock.now);
+
+    expect(await memo()).toBe('value-1');
+    clock.advance(10_000); // still inside the 30s TTL
+    expect(await memo()).toBe('value-1');
+    clock.advance(19_999); // t = 29,999 < 30,000, boundary still fresh
+    expect(await memo()).toBe('value-1');
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches after the TTL expires', async () => {
+    const clock = makeClock();
+    let n = 0;
+    const fetcher = vi.fn(async () => `value-${++n}`);
+    const memo = createTtlMemo(fetcher, 30_000, clock.now);
+
+    expect(await memo()).toBe('value-1');
+    clock.advance(30_001); // past expiry (expiresAt = 30,000, needs > 30,000)
+    expect(await memo()).toBe('value-2');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    // ...and the refetched value is then cached again for the next TTL window.
+    clock.advance(1_000);
+    expect(await memo()).toBe('value-2');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('fail-open: a rejected fetch is NOT cached and the next call refetches (no poisoned value served as fresh)', async () => {
+    const clock = makeClock();
+    const outcomes: Array<() => Promise<string>> = [
+      () => Promise.reject(new Error('redis down')),
+      () => Promise.resolve('recovered'),
+    ];
+    let i = 0;
+    const fetcher = vi.fn(() => outcomes[i++]());
+    const memo = createTtlMemo(fetcher, 30_000, clock.now);
+
+    // First call rejects — the rejection must propagate unchanged.
+    await expect(memo()).rejects.toThrow('redis down');
+
+    // Immediately (well within the TTL) the next call must RE-INVOKE the fetcher
+    // rather than serve a cached error / poisoned empty value.
+    expect(await memo()).toBe('recovered');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    // The recovered value is now cached normally.
+    clock.advance(5_000);
+    expect(await memo()).toBe('recovered');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not overwrite a good cached value when a later refetch rejects', async () => {
+    const clock = makeClock();
+    const outcomes: Array<() => Promise<string>> = [
+      () => Promise.resolve('good'),
+      () => Promise.reject(new Error('transient')),
+    ];
+    let i = 0;
+    const fetcher = vi.fn(() => outcomes[i++]());
+    const memo = createTtlMemo(fetcher, 30_000, clock.now);
+
+    expect(await memo()).toBe('good');
+    clock.advance(30_001); // expire so the next call refetches
+    await expect(memo()).rejects.toThrow('transient'); // rejection propagates, not cached
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('clear() drops the cached value so the next call refetches', async () => {
+    const clock = makeClock();
+    let n = 0;
+    const fetcher = vi.fn(async () => `value-${++n}`);
+    const memo = createTtlMemo(fetcher, 30_000, clock.now);
+
+    expect(await memo()).toBe('value-1');
+    memo.clear();
+    expect(await memo()).toBe('value-2'); // refetched despite being inside the TTL
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches a legitimate null result (an unset key is a real value, not an error)', async () => {
+    const clock = makeClock();
+    const fetcher = vi.fn(async () => null as string | null);
+    const memo = createTtlMemo(fetcher, 30_000, clock.now);
+
+    expect(await memo()).toBeNull();
+    expect(await memo()).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/utils/__tests__/ttl-memoize.test.ts
+++ b/src/server/utils/__tests__/ttl-memoize.test.ts
@@ -97,6 +97,34 @@ describe('createTtlMemo', () => {
     expect(fetcher).toHaveBeenCalledTimes(2);
   });
 
+  it('freeze: the cached array is frozen so an accidental in-place mutation throws instead of corrupting the shared blob', async () => {
+    const clock = makeClock();
+    const fetcher = vi.fn(async () => [{ id: 1, name: 'tag' }]);
+    const memo = createTtlMemo(fetcher, 30_000, clock.now, { freeze: true });
+
+    const arr = await memo();
+    expect(Object.isFrozen(arr)).toBe(true);
+    // Array-level mutation must throw (strict mode) rather than silently mutate
+    // the reference shared across the TTL window.
+    expect(() => arr.push({ id: 2, name: 'other' })).toThrow();
+    expect(() => ((arr as { id: number; name: string }[]).length = 0)).toThrow();
+
+    // The SAME frozen reference is served for the rest of the TTL.
+    clock.advance(5_000);
+    const again = await memo();
+    expect(again).toBe(arr);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not freeze by default (freeze is opt-in)', async () => {
+    const clock = makeClock();
+    const fetcher = vi.fn(async () => [{ id: 1 }]);
+    const memo = createTtlMemo(fetcher, 30_000, clock.now);
+
+    const arr = await memo();
+    expect(Object.isFrozen(arr)).toBe(false);
+  });
+
   it('caches a legitimate null result (an unset key is a real value, not an error)', async () => {
     const clock = makeClock();
     const fetcher = vi.fn(async () => null as string | null);

--- a/src/server/utils/ttl-memoize.ts
+++ b/src/server/utils/ttl-memoize.ts
@@ -1,0 +1,47 @@
+// In-process (per-pod), single-slot TTL memoize for a GLOBAL async fetcher.
+//
+// Wraps a `() => Promise<T>` whose result is identical for every user/request
+// (e.g. the global system-cache blobs) and collapses repeated calls within a
+// short TTL into ~1 underlying fetch / TTL / pod. This is the exact shape of
+// `getClientConfigCached` in src/server/trpc.ts, factored out for reuse.
+//
+// Fail-open: only a *resolved* value is memoized. If the fetcher REJECTS, the
+// rejection propagates to the caller unchanged and NOTHING is cached — so a
+// transient backing-store failure is never frozen in as a "fresh" (e.g. empty)
+// value; the very next call retries. This preserves whatever fail-open/fail-safe
+// behavior the underlying getter already has (it either throws, or resolves with
+// its own fallback value which is then a legitimate cacheable result).
+//
+// 🔴 NEVER use this for user/session-keyed values — it is a single module-scope
+// slot with no key, so a per-user value would leak across users. Only wrap
+// fetchers whose output does not depend on the request/user.
+export type TtlMemo<T> = (() => Promise<T>) & {
+  /** Drop the cached value (e.g. in tests, or an explicit invalidation). */
+  clear: () => void;
+};
+
+export function createTtlMemo<T>(
+  fetcher: () => Promise<T>,
+  ttlMs: number,
+  // Injectable clock so tests can advance time deterministically without
+  // wall-clock sleeps. Defaults to Date.now in production.
+  now: () => number = Date.now
+): TtlMemo<T> {
+  let cache: { value: T; expiresAt: number } | null = null;
+
+  const memo = (async () => {
+    const t = now();
+    if (cache && cache.expiresAt > t) return cache.value;
+    // Await BEFORE assigning: a rejection skips the cache write (fail-open),
+    // exactly like getClientConfigCached only caching successful reads.
+    const value = await fetcher();
+    cache = { value, expiresAt: now() + ttlMs };
+    return value;
+  }) as TtlMemo<T>;
+
+  memo.clear = () => {
+    cache = null;
+  };
+
+  return memo;
+}

--- a/src/server/utils/ttl-memoize.ts
+++ b/src/server/utils/ttl-memoize.ts
@@ -25,7 +25,17 @@ export function createTtlMemo<T>(
   ttlMs: number,
   // Injectable clock so tests can advance time deterministically without
   // wall-clock sleeps. Defaults to Date.now in production.
-  now: () => number = Date.now
+  now: () => number = Date.now,
+  // When `freeze` is true, a resolved object/array value is Object.freeze()d
+  // (shallow) before it is stored in — and returned from — the single memo slot.
+  // The SAME reference is served to every caller for the whole TTL window, so
+  // this enforces the "don't mutate the shared cached blob" invariant
+  // STRUCTURALLY: an accidental `.push()`/`.sort()`/element write throws (strict
+  // mode) instead of silently corrupting the shared blob for every concurrent
+  // request on the pod. No-op for primitive/null values. Opt-in — most memoized
+  // values (e.g. the raw sysRedis strings, which are re-parsed into a fresh
+  // object per call outside the memo) don't need it.
+  { freeze = false }: { freeze?: boolean } = {}
 ): TtlMemo<T> {
   let cache: { value: T; expiresAt: number } | null = null;
 
@@ -35,6 +45,9 @@ export function createTtlMemo<T>(
     // Await BEFORE assigning: a rejection skips the cache write (fail-open),
     // exactly like getClientConfigCached only caching successful reads.
     const value = await fetcher();
+    // Freeze in place (Object.freeze returns the same ref) so the value we
+    // cache AND return is immutable; keep `value` typed as T for callers.
+    if (freeze && value !== null && typeof value === 'object') Object.freeze(value);
     cache = { value, expiresAt: now() + ttlMs };
     return value;
   }) as TtlMemo<T>;


### PR DESCRIPTION
## What

Adds a small reusable **per-process TTL memoize** (`createTtlMemo`) in front of the **genuinely global, user-independent** `system-cache` blobs, so they aren't redis-`GET` + msgpackr-decoded on every request.

Memoized (each confirmed user-independent — no `userId`/session arg):

| getter | key | TTL | why safe |
|---|---|---|---|
| `getModeratedTags` | `MODERATED_TAGS` (packed) | 30s | hottest — feed hidden-prefs path; cuts the msgpackr decode too; no `redis.del` invalidation |
| `getBlockedBrowsingTags` | `BLOCKED_BROWSING_TAGS` | 30s | hot feed/tag-page; no `redis.del` |
| `getHomeExcludedTags` | `HOME_EXCLUDED_TAGS` | 30s | effectively static; no `redis.del` |
| `getBrowsingSettingAddons` | `BROWSING_SETTING_ADDONS` (sysRedis) | 30s | SSR every-render read; no `redis.del` |
| `getLiveFeatureFlags` | `LIVE_FEATURE_FLAGS` (sysRedis) | **5s** | operational toggle → shorter TTL for fast flag-flip propagation |

## The lever

Per the redis + msgpackr on-CPU profiling breakdown, the global system-cache blobs are re-`GET` + re-decoded per call despite being identical for every user and changing only ~every 4h. Memoizing them cuts both the per-command redis cluster tax and (for the packed `MODERATED_TAGS`) the msgpackr decode. Estimated **~1-2% of on-CPU** — an incremental, low-risk cleanup, not a headline win. Wants true-peak confirmation, since per-call frequency scales with request rate.

## Design — mirrors the live `getClientConfigCached` (`src/server/trpc.ts`)

- **Fail-open:** only a *resolved* value is memoized. If the fetcher rejects, the rejection propagates **uncached** and the next call retries — a transient redis failure is never frozen in as a "fresh" (poisoned/empty) value. Each getter's existing fail-open/fail-safe behavior is preserved. The two sysRedis fail-open getters memoize **only the raw string**, keeping their `try/catch` + `JSON.parse` *outside* the memo → byte-for-byte identical semantics.
- **Short TTL + staleness note:** the moderation-sensitive blobs gate which tags/content are hidden, so a newly-moderated tag takes up to the TTL *longer* to propagate per pod — trivial on top of the already-4h redis staleness. Documented inline.
- **Injectable clock** so the helper is unit-tested deterministically (no wall-clock sleeps).

## Deliberately NOT memoized

- `getTagRules` — has an explicit `redis.del` invalidation contract (`tag.service.ts`) that an in-proc TTL would shadow; callers are webhook/job paths (low QPS).
- `getSystemPermissions` — read-modify-write mutation path (`add/removeSystemPermission`); a stale in-proc read could wipe a concurrent write.
- `getCreationBlockedTags` / `getCategoryTags` / `getSystemTags` / `getLiveNow` — low read-QPS, parameterized, or a staleness-sensitive live toggle.

## Risk

**LOW.** Values already tolerate 4h staleness; precedent (`getClientConfigCached`) is live and load-bearing. Pure per-pod memory (small blobs). Off-switch = revert the wrappers.

## Tests

- `ttl-memoize.test.ts` (6): cached within TTL (fetcher called once), refetch after expiry, **fail-open** (reject not cached → next call refetches, no poisoned value), a later reject doesn't overwrite a good value, `clear()`, and caching a legitimate `null`.
- `system-cache.memoize.test.ts` (1): `getModeratedTags` hits redis once then serves from the in-proc memo.
- `tsc --noEmit`: touched files clean (pre-existing `event-engine-common` baseline errors are in unrelated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)