### PR TITLE
fix(app-blocks): reset moderator review-modal state per selected request

### DIFF
--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -71,6 +71,9 @@ const mocks = vi.hoisted(() => ({
   // Drives the getReviewStatus mock so a test can flip the Review-preview panel
   // into the live state (default undefined = no preview → "Start preview").
   reviewStatus: undefined as unknown,
+  // When true, the approve/reject mutation mocks report `isPending: true` so the
+  // component's `busy` state (and the ref-published close-guard) can be exercised.
+  pending: false,
 }));
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
@@ -102,7 +105,7 @@ vi.mock('~/utils/trpc', () => {
         else void opts?.onSuccess?.();
       },
       mutateAsync: vi.fn(),
-      isPending: false,
+      isPending: mocks.pending,
     });
   const inert = { invalidate: mocks.invalidate };
   const utils = {
@@ -154,6 +157,7 @@ beforeEach(() => {
   mocks.mutate.mockClear();
   mocks.errorMode = false;
   mocks.reviewStatus = undefined;
+  mocks.pending = false;
   showError.mockClear();
 });
 
@@ -306,6 +310,71 @@ describe('OnsiteReviewModal — transient approve/reject state resets per reques
     // not leak into B's state).
     await page.getByRole('button', { name: 'Reject…' }).click();
     await expect.element(page.getByTestId('apps-review-reject-reason')).toHaveValue('');
+  });
+
+  test('the real close-then-reopen path (A → selection=null → B) also opens B fresh', async () => {
+    // Production never swaps A→B directly: the parent sets `selection=null`
+    // (closing the modal) and later sets it to B. This pins the
+    // `{selection && <Body/>}` unmount-gate — B mounts fresh because the body
+    // was unmounted at null — independently of the per-id `key` remount above.
+    const { rerender } = await renderWithProviders(
+      <OnsiteReviewModal
+        selection={{ request: ONSITE_PENDING, mode: 'pending' }}
+        onClose={vi.fn()}
+      />
+    );
+    await page.getByRole('button', { name: 'Reject…' }).click();
+    const reasonA = page.getByTestId('apps-review-reject-reason');
+    await reasonA.fill('leaky reason that must not survive a close');
+    await expect.element(reasonA).toHaveValue('leaky reason that must not survive a close');
+
+    // Close the modal (selection → null): the body unmounts.
+    await rerender(<OnsiteReviewModal selection={null} onClose={vi.fn()} />);
+    expect(page.getByTestId('apps-review-reject-reason').elements()).toHaveLength(0);
+
+    // Reopen with a different request B: the body remounts fresh.
+    await rerender(
+      <OnsiteReviewModal
+        selection={{ request: ONSITE_PENDING_B, mode: 'pending' }}
+        onClose={vi.fn()}
+      />
+    );
+
+    // B opens in the default view mode, no leaked reject state.
+    await expect
+      .element(page.getByRole('textbox', { name: 'Approval notes (optional)' }))
+      .toBeInTheDocument();
+    expect(page.getByTestId('apps-review-reject-reason').elements()).toHaveLength(0);
+    await page.getByRole('button', { name: 'Reject…' }).click();
+    await expect.element(page.getByTestId('apps-review-reject-reason')).toHaveValue('');
+  });
+});
+
+describe('OnsiteReviewModal — busy close-guard while a mutation is in flight', () => {
+  test('does not call onClose via Escape or the close button while a mutation is pending', async () => {
+    // Both mutation mocks report isPending:true → the modal is `busy`, so the
+    // body publishes busy=true to the shell via the ref. The shell's onClose
+    // (Escape / overlay / the X) must then refuse to invoke the parent onClose.
+    mocks.pending = true;
+    const onClose = vi.fn();
+    renderWithProviders(
+      <OnsiteReviewModal selection={{ request: ONSITE_PENDING, mode: 'pending' }} onClose={onClose} />
+    );
+    // Modal is open (body rendered).
+    await expect.element(page.getByText('View code in Forgejo')).toBeInTheDocument();
+
+    // Close vector 1 — the modal's close (X) button (Mantine static class).
+    const closeBtn = document.querySelector<HTMLButtonElement>('.mantine-Modal-close');
+    expect(closeBtn).not.toBeNull();
+    await userEvent.click(closeBtn!);
+
+    // Close vector 2 — Escape (Mantine `closeOnEscape`).
+    await userEvent.keyboard('{Escape}');
+
+    // The busy guard swallowed both — the parent onClose was never called and the
+    // modal is still mounted.
+    expect(onClose).not.toHaveBeenCalled();
+    await expect.element(page.getByText('View code in Forgejo')).toBeInTheDocument();
   });
 });
 

--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -55,6 +55,15 @@ const ONSITE_APPROVED = {
   reviewedBy: { id: 99, username: 'mod-user', image: null },
 };
 
+// A SECOND pending request (distinct `id`) used to prove the transient
+// approve/reject state does not leak when the mod switches from one app to
+// another in the same long-lived modal.
+const ONSITE_PENDING_B = {
+  ...ONSITE_PENDING,
+  id: 'onsite-req-3',
+  slug: 'other-onsite-block',
+};
+
 const mocks = vi.hoisted(() => ({
   invalidate: vi.fn().mockResolvedValue(undefined),
   mutate: vi.fn(),
@@ -256,6 +265,47 @@ describe('OnsiteReviewModal — onsite reject: reason gate + fired mutation', ()
       publishRequestId: 'onsite-req-1',
       rejectionReason: 'needs changes',
     });
+  });
+});
+
+describe('OnsiteReviewModal — transient approve/reject state resets per request', () => {
+  test('switching from a request in reject-mode to a different request opens in the default view mode with an empty reason', async () => {
+    // Render request A and put it into reject mode with a typed reason.
+    const { rerender } = await renderWithProviders(
+      <OnsiteReviewModal
+        selection={{ request: ONSITE_PENDING, mode: 'pending' }}
+        onClose={vi.fn()}
+      />
+    );
+    await page.getByRole('button', { name: 'Reject…' }).click();
+    const reasonA = page.getByTestId('apps-review-reject-reason');
+    await expect.element(reasonA).toBeInTheDocument();
+    await reasonA.fill('this needs changes before approval');
+    await expect.element(reasonA).toHaveValue('this needs changes before approval');
+
+    // Switch the SAME long-lived modal to a DIFFERENT pending request (new id).
+    await rerender(
+      <OnsiteReviewModal
+        selection={{ request: ONSITE_PENDING_B, mode: 'pending' }}
+        onClose={vi.fn()}
+      />
+    );
+
+    // B must open in the DEFAULT view mode: the approve/notes UI is shown and
+    // the reject textarea is gone (actionMode reset to 'view' via the keyed
+    // remount — not carried over from A).
+    await expect
+      .element(page.getByRole('textbox', { name: 'Approval notes (optional)' }))
+      .toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Approve + build' })).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Reject…' })).toBeInTheDocument();
+    // The reject reason field from A must NOT be present (and thus carries no text).
+    expect(page.getByTestId('apps-review-reject-reason').elements()).toHaveLength(0);
+
+    // And re-entering reject mode on B starts from an EMPTY reason (A's text did
+    // not leak into B's state).
+    await page.getByRole('button', { name: 'Reject…' }).click();
+    await expect.element(page.getByTestId('apps-review-reject-reason')).toHaveValue('');
   });
 });
 

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -29,7 +29,7 @@ import {
   IconWindow,
   IconX,
 } from '@tabler/icons-react';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { ReviewBlockPreviewHost } from '~/components/Apps/ReviewBlockPreviewHost';
 import { useReviewPreview } from '~/components/Apps/useReviewPreview';
 import {

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -151,6 +151,19 @@ export function formatDate(d: string | Date | null | undefined): string {
 // prominently.
 // ---------------------------------------------------------------------------
 
+/**
+ * Thin outer shell. Owns the Mantine `<Modal>` (kept mounted + `opened`-toggled
+ * so open/close still animates and doesn't flash) and derives only the static,
+ * per-request title from `selection`. The interactive body — which holds the
+ * transient approve/reject UI state — is rendered as a SEPARATE component keyed
+ * on `selection.request.id` so it REMOUNTS whenever a different request is
+ * selected. That remount is what deterministically resets `approvalNotes` /
+ * `rejectionReason` / `actionMode` per request: previously this state lived on
+ * one long-lived component that only swapped its `selection` prop, so switching
+ * from one app to another leaked the prior app's reject-mode + reason text (a
+ * mod who clicked "Reject…" on app A then opened app B saw B stuck in reject
+ * mode with A's reason). Keying here means no caller has to remember to key it.
+ */
 export function OnsiteReviewModal({
   selection,
   onClose,
@@ -158,15 +171,92 @@ export function OnsiteReviewModal({
   selection: OnsiteReviewSelection;
   onClose: () => void;
 }) {
+  // Set by the body while an approve/reject mutation is in flight so this shell's
+  // onClose (Escape / overlay click / the X) refuses to close mid-action — the
+  // same guard the pre-split modal had inline. Written by the body during its
+  // render; only read here in the (post-commit) close handler, so the value is
+  // always current by the time a close is triggered.
+  const busyRef = useRef(false);
+
+  return (
+    <Modal
+      opened={!!selection}
+      onClose={() => {
+        if (busyRef.current) return;
+        onClose();
+      }}
+      title={selection ? <OnsiteReviewModalTitle selection={selection} /> : null}
+      size="xl"
+      centered
+    >
+      {selection && (
+        <OnsiteReviewModalBody
+          key={selection.request.id}
+          selection={selection}
+          onClose={onClose}
+          busyRef={busyRef}
+        />
+      )}
+    </Modal>
+  );
+}
+
+/** Static, per-request modal title (slug + version + a mode/first-version badge).
+ *  Derived purely from `selection` — no transient state — so it lives on the
+ *  stable shell, not the keyed body. */
+function OnsiteReviewModalTitle({ selection }: { selection: NonNullable<OnsiteReviewSelection> }) {
+  const { request, mode } = selection;
+  const mds = (request.manifestDiffSummary ?? {}) as ManifestDiffSummary;
+  return (
+    <Group gap={6}>
+      <Text fw={600}>{request.slug}</Text>
+      <Code>{request.version}</Code>
+      {mds.kind === 'first-version' && (
+        <Badge color="violet" size="sm">
+          first version
+        </Badge>
+      )}
+      {mode === 'approved' && (
+        <Badge color="green" size="sm">
+          approved
+        </Badge>
+      )}
+      {mode === 'rejected' && (
+        <Badge color="red" size="sm">
+          rejected
+        </Badge>
+      )}
+    </Group>
+  );
+}
+
+/**
+ * Interactive review body. Holds the transient approve/reject UI state
+ * (`approvalNotes` / `rejectionReason` / `actionMode`) plus the approve/reject
+ * mutations. The parent keys this on `selection.request.id`, so all of that
+ * state is fresh on every request switch — no manual reset needed, and the
+ * `onSuccess → onClose` paths are safe because the next open remounts fresh.
+ */
+function OnsiteReviewModalBody({
+  selection,
+  onClose,
+  busyRef,
+}: {
+  selection: NonNullable<OnsiteReviewSelection>;
+  onClose: () => void;
+  busyRef: { current: boolean };
+}) {
   const utils = trpc.useUtils();
   const [approvalNotes, setApprovalNotes] = useState('');
   const [rejectionReason, setRejectionReason] = useState('');
   const [actionMode, setActionMode] = useState<'view' | 'reject'>('view');
 
+  const { request, mode } = selection;
+
   const approveMut = trpc.blocks.approveRequest.useMutation({
     onSuccess: async () => {
       showSuccessNotification({
-        message: `Approved ${selection?.request.slug} v${selection?.request.version}. Build started.`,
+        message: `Approved ${request.slug} v${request.version}. Build started.`,
       });
       await utils.blocks.listPendingRequests.invalidate();
       await utils.blocks.listApprovedRequests.invalidate();
@@ -182,7 +272,7 @@ export function OnsiteReviewModal({
   const rejectMut = trpc.blocks.rejectRequest.useMutation({
     onSuccess: async () => {
       showSuccessNotification({
-        message: `Rejected ${selection?.request.slug} v${selection?.request.version}.`,
+        message: `Rejected ${request.slug} v${request.version}.`,
       });
       await utils.blocks.listPendingRequests.invalidate();
       await utils.blocks.listRejectedRequests.invalidate();
@@ -196,53 +286,20 @@ export function OnsiteReviewModal({
     },
   });
 
-  if (!selection) return null;
-  const { request, mode } = selection;
   const readOnly = mode !== 'pending';
 
   const manifest = request.manifest as Record<string, unknown>;
   const fs = (request.fileSummary ?? {}) as FileSummary;
   const mds = (request.manifestDiffSummary ?? {}) as ManifestDiffSummary;
   const busy = approveMut.isPending || rejectMut.isPending;
+  // Publish the in-flight state up to the shell so its onClose can guard on it.
+  busyRef.current = busy;
 
   const approved = mode === 'approved' ? (request as ApprovedRequest) : null;
   const rejected = mode === 'rejected' ? (request as RejectedRequest) : null;
 
   return (
-    <Modal
-      opened={!!selection}
-      onClose={() => {
-        if (busy) return;
-        setApprovalNotes('');
-        setRejectionReason('');
-        setActionMode('view');
-        onClose();
-      }}
-      title={
-        <Group gap={6}>
-          <Text fw={600}>{request.slug}</Text>
-          <Code>{request.version}</Code>
-          {mds.kind === 'first-version' && (
-            <Badge color="violet" size="sm">
-              first version
-            </Badge>
-          )}
-          {mode === 'approved' && (
-            <Badge color="green" size="sm">
-              approved
-            </Badge>
-          )}
-          {mode === 'rejected' && (
-            <Badge color="red" size="sm">
-              rejected
-            </Badge>
-          )}
-        </Group>
-      }
-      size="xl"
-      centered
-    >
-      <Stack gap="md">
+    <Stack gap="md">
         <Group gap="xs" align="flex-start">
           <Text size="xs" c="dimmed">
             Submitter:
@@ -470,7 +527,6 @@ export function OnsiteReviewModal({
           </Stack>
         )}
       </Stack>
-    </Modal>
   );
 }
 


### PR DESCRIPTION
## Problem

On `/apps/review`, the App Blocks **moderator review modal** leaked its transient approve/reject UI state between apps.

Reproduction: a moderator clicks **"Reject…"** on app A (switching the modal into reject mode, revealing the rejection-reason textarea), then opens the review modal for a **different** app B. App B opened **still in reject mode, carrying A's rejection-reason text**.

Root cause: the parent page renders one long-lived `<OnsiteReviewModal>` and only swaps its `selection` prop. The modal's transient `useState` (`approvalNotes`, `rejectionReason`, `actionMode`) was never reset when the selected request changed, and the approve/reject `onSuccess` handlers called the parent `onClose` directly, bypassing the internal reset path.

## Fix (structural — not a sprinkled manual reset)

Split `OnsiteReviewModal` into:

- a **thin outer shell** that owns the stable Mantine `<Modal>` (kept mounted + `opened`-toggled so open/close still animates and doesn't flash) and derives only the static per-request title; and
- an **inner body** (`OnsiteReviewModalBody`) that holds the transient approve/reject state + the approve/reject mutations + the approve/reject/notes UI.

The body is rendered with **`key={selection.request.id}`**, so it **remounts fresh** whenever a different request is selected → all transient state resets deterministically. No caller has to remember to key it. The in-flight (busy) close-guard the pre-split modal had is preserved via a ref the body publishes to the shell.

No approve/reject business logic changed — only *where/how* the transient UI state is reset. The change is confined to the `OnsiteReviewModal` function region and does not touch the review-preview panel.

## Test evidence

Added a browser-mode regression test in `OnsiteReviewModal.browser.test.tsx` that:
1. renders pending request A, clicks "Reject…", types a reason;
2. switches the same modal to a different pending request B (new `selection.request.id`);
3. asserts B opens in the **default view mode** (approve/notes UI, no reject textarea) and that re-entering reject mode on B starts from an **empty** reason.

- Verified the new test **FAILS without** the keyed remount (modal stays in reject mode with A's state) and **PASSES with** it.
- Full suite: **6/6 pass** (`vitest run --project component`).
- Typecheck: the change adds **zero** new `tsc --noEmit` errors (verified against a pristine tree of the same base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)