### PR TITLE
feat(apps/review): full-page mod review preview route + shared preview hook

### DIFF
--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -59,10 +59,20 @@ const mocks = vi.hoisted(() => ({
   invalidate: vi.fn().mockResolvedValue(undefined),
   mutate: vi.fn(),
   errorMode: false,
+  // Drives the getReviewStatus mock so a test can flip the Review-preview panel
+  // into the live state (default undefined = no preview → "Start preview").
+  reviewStatus: undefined as unknown,
 }));
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true }),
+}));
+
+// Stub the review host bridge so the live-preview branch can render (and the
+// full-page link asserted) WITHOUT mounting the real PageBlockHost graph. The
+// bridge's own behaviour is covered by PageBlockHostReviewMode.browser.test.tsx.
+vi.mock('~/components/Apps/ReviewBlockPreviewHost', () => ({
+  ReviewBlockPreviewHost: () => <div data-testid="review-host-stub" />,
 }));
 
 const showError = vi.fn();
@@ -107,7 +117,7 @@ vi.mock('~/utils/trpc', () => {
         // Sub-panel queries the modal mounts (Review-preview / Screenshots / Code
         // diff) — kept network-free with empty/no-op state.
         getReviewStatus: {
-          useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+          useQuery: () => ({ data: mocks.reviewStatus, isLoading: false, error: null }),
         },
         previewRequest: { useMutation: mutation('preview') },
         teardownPreview: { useMutation: mutation('teardown') },
@@ -134,6 +144,7 @@ beforeEach(() => {
   mocks.invalidate.mockClear();
   mocks.mutate.mockClear();
   mocks.errorMode = false;
+  mocks.reviewStatus = undefined;
   showError.mockClear();
 });
 
@@ -157,6 +168,40 @@ describe('OnsiteReviewModal — onsite-specific contract', () => {
     // Both action entry points are present on a pending request.
     await expect.element(page.getByRole('button', { name: 'Approve + build' })).toBeInTheDocument();
     await expect.element(page.getByRole('button', { name: 'Reject…' })).toBeInTheDocument();
+  });
+});
+
+describe('OnsiteReviewModal — live preview links to the full-page route (not the raw host)', () => {
+  test('a live preview renders the "Open full-page preview" link (internal same-origin route, new tab) and NOT the old raw-host button', async () => {
+    // Flip the shared getReviewStatus poll into the live state. previewUrl carries
+    // the raw `?mr=` host URL the OLD "Open review host" button used to link — the
+    // new button must ignore it and link to the internal /apps/review/preview route.
+    mocks.reviewStatus = {
+      state: 'preview-live',
+      detail: { host: 'my-onsite-block.civit.ai', url: 'https://my-onsite-block.civit.ai/my-onsite-block' },
+      previewUrl: 'https://my-onsite-block.civit.ai/my-onsite-block?mr=raw-entry-token',
+    };
+    renderWithProviders(
+      <OnsiteReviewModal selection={{ request: ONSITE_PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+
+    const link = page.getByRole('link', { name: /Open full-page preview/ });
+    await expect.element(link).toBeInTheDocument();
+    // Same-origin internal route, keyed by publishRequestId — NOT the raw `?mr=` URL.
+    const el = link.element() as HTMLAnchorElement;
+    expect(el.getAttribute('href')).toBe('/apps/review/preview/onsite-req-1');
+    expect(el.getAttribute('target')).toBe('_blank');
+    expect(el.getAttribute('href')).not.toContain('?mr=');
+    expect(el.getAttribute('href')).not.toContain('civit.ai');
+
+    // The old raw-host button is GONE, and no anchor in the panel links to the
+    // broken raw `?mr=` host URL.
+    expect(page.getByText('Open review host').elements()).toHaveLength(0);
+    const rawHostLinks = page
+      .getByRole('link')
+      .elements()
+      .filter((a) => (a as HTMLAnchorElement).getAttribute('href')?.includes('?mr='));
+    expect(rawHostLinks).toHaveLength(0);
   });
 });
 

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -29,9 +29,9 @@ import {
   IconWindow,
   IconX,
 } from '@tabler/icons-react';
-import { useMemo, useRef, useState } from 'react';
-import { pickReviewIframeSrc } from '~/components/Apps/reviewIframeSrc';
+import { useMemo, useState } from 'react';
 import { ReviewBlockPreviewHost } from '~/components/Apps/ReviewBlockPreviewHost';
+import { useReviewPreview } from '~/components/Apps/useReviewPreview';
 import {
   FileDiffEntry,
   FileListPreview,
@@ -491,39 +491,13 @@ function ReviewPreviewPanel({
   publishRequestId: string;
   slug: string;
 }) {
-  const features = useFeatureFlags();
   const utils = trpc.useUtils();
 
-  // Poll the review status. Enabled on mount (not gated on a client "started"
-  // flag) so a preview already live on the row is picked up after a page reload
-  // / modal re-open — getReviewStatus returns the PERSISTED deploy_state, so we
-  // derive the button + live iframe from the server, not from ephemeral React
-  // state (which reset to "Start preview" on reload). building/deploying poll
-  // fast, live polls slow, none/failed do a single fetch then stop (see
-  // refetchInterval).
-  const statusQuery = trpc.blocks.getReviewStatus.useQuery(
-    { publishRequestId },
-    {
-      enabled: !!features?.appBlocks,
-      retry: false,
-      refetchInterval: (query) => {
-        // react-query v5: the callback receives the Query; the data is at
-        // query.state.data (matches the my-submissions.tsx idiom).
-        const s = query.state.data?.state;
-        if (s === 'preview-building' || s === 'preview-deploying') return 3000;
-        // Keep a SLOW poll alive while the preview is live — it detects
-        // approve/reject/teardown state changes. getReviewStatus mints a fresh
-        // `?mr=<token>` previewUrl (120s TTL) on every poll, but the IFRAME src is
-        // DECOUPLED from the poll via pickReviewIframeSrc (see `stableIframeSrc`
-        // below): the iframe keeps its src until the embedded token nears expiry,
-        // then swaps ONCE — so the live preview doesn't hard-reload every minute
-        // (which would wipe in-progress interaction). A 60s poll < 120s TTL still
-        // guarantees a fresh token is always available when a swap is due.
-        if (s === 'preview-live') return 60000;
-        return false; // failed or none → stop polling
-      },
-    }
-  );
+  // Shared live-preview poll + iframe-src stabilization (extracted verbatim to
+  // `useReviewPreview` so this in-modal preview and the full-page preview route
+  // stay behaviourally identical).
+  const { state, detail, isLive, inProgress, isFailed, stableIframeSrc, error } =
+    useReviewPreview(publishRequestId);
 
   const previewMut = trpc.blocks.previewRequest.useMutation({
     onSuccess: async () => {
@@ -549,34 +523,6 @@ function ReviewPreviewPanel({
       showErrorNotification({ title: 'Could not tear down preview', error: new Error(e.message) });
     },
   });
-
-  const state = statusQuery.data?.state ?? null;
-  const detail = statusQuery.data?.detail;
-  // Prefer the FRESH, mod-bound, short-TTL tokened URL (`?mr=<token>`) the server
-  // mints on every poll when the preview is live — that token is the cross-origin
-  // access bridge the `*.civit.ai` mod-gate forwardAuth verifies on the iframe's
-  // entry document request. Read from the latest query data each render so the
-  // iframe never mounts with an expired token. Fall back to the bare host URL
-  // (e.g. while building) only for display.
-  const url = statusQuery.data?.previewUrl ?? detail?.url;
-  const inProgress = state === 'preview-building' || state === 'preview-deploying';
-  const isLive = state === 'preview-live';
-  const isFailed = state === 'preview-failed';
-
-  // Stabilize the IFRAME src so it does NOT change on every poll. getReviewStatus
-  // mints a fresh `?mr=<token>` previewUrl every 60s poll; binding the iframe
-  // straight to `url` would hard-reload it each minute, wiping in-progress
-  // interaction in the previewed block. pickReviewIframeSrc keeps the embedded
-  // src until its token nears expiry (TTL 120s), then swaps once. The Open-host
-  // button + the `url` display still use the freshest token. Held in a ref so the
-  // chosen src survives re-renders; recomputed each render via the pure helper.
-  const iframeSrcRef = useRef<string | undefined>(undefined);
-  const stableIframeSrc = isLive
-    ? pickReviewIframeSrc(iframeSrcRef.current, url, Date.now())
-    : undefined;
-  // Persist the choice so the next render compares against the embedded token,
-  // not the latest poll's. Clear when the preview leaves the live state.
-  iframeSrcRef.current = stableIframeSrc || undefined;
 
   return (
     <Stack gap={4}>
@@ -611,17 +557,23 @@ function ReviewPreviewPanel({
         >
           {state ? 'Rebuild preview' : 'Start preview'}
         </Button>
-        {isLive && url && (
+        {isLive && (
+          // Full-page preview on a SAME-ORIGIN internal route that mounts the same
+          // review host bridge at full viewport — opened top-level, so the mod
+          // reviews the app "as the user would see it" while keeping this modal
+          // open. It links by publishRequestId (NOT the raw `?mr=` host URL): that
+          // raw URL is broken opened top-level — it has no host bridge, so the SDK
+          // block hangs on "Connecting to host" (the bug #3172 fixed for the iframe).
           <Button
             size="xs"
             variant="default"
             component="a"
-            href={url}
+            href={`/apps/review/preview/${publishRequestId}`}
             target="_blank"
             rel="noopener"
             rightSection={<IconExternalLink size={12} />}
           >
-            Open review host
+            Open full-page preview ↗
           </Button>
         )}
         {state && (
@@ -680,9 +632,9 @@ function ReviewPreviewPanel({
           />
         </div>
       )}
-      {statusQuery.error && (
+      {error && (
         <Text size="xs" c="dimmed">
-          {statusQuery.error.message}
+          {error.message}
         </Text>
       )}
     </Stack>

--- a/src/components/Apps/useReviewPreview.ts
+++ b/src/components/Apps/useReviewPreview.ts
@@ -1,0 +1,87 @@
+import { useRef } from 'react';
+import { pickReviewIframeSrc } from '~/components/Apps/reviewIframeSrc';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * MOD REVIEW SANDBOX (#2831) — shared live-preview poll + iframe-src stabilization
+ * for the review host bridge.
+ *
+ * Extracted VERBATIM from `ReviewPreviewPanel` (OnsiteReviewModal.tsx) so the
+ * in-modal 420px preview and the new full-page preview route
+ * (`/apps/review/preview/<publishRequestId>`) share ONE source of truth for the
+ * poll cadence + token-swap stabilization. The behaviour here is byte-for-byte
+ * the panel's prior inline logic — do not change the poll intervals or the
+ * `pickReviewIframeSrc` wiring without updating both callers.
+ *
+ * Poll the review status. Enabled on mount (not gated on a client "started" flag)
+ * so a preview already live on the row is picked up after a page reload / modal
+ * re-open — getReviewStatus returns the PERSISTED deploy_state, so callers derive
+ * the button + live host from the server, not from ephemeral React state.
+ * building/deploying poll fast, live polls slow, none/failed do a single fetch
+ * then stop (see refetchInterval).
+ */
+export function useReviewPreview(publishRequestId: string) {
+  const features = useFeatureFlags();
+
+  const statusQuery = trpc.blocks.getReviewStatus.useQuery(
+    { publishRequestId },
+    {
+      enabled: !!features?.appBlocks,
+      retry: false,
+      refetchInterval: (query) => {
+        // react-query v5: the callback receives the Query; the data is at
+        // query.state.data (matches the my-submissions.tsx idiom).
+        const s = query.state.data?.state;
+        if (s === 'preview-building' || s === 'preview-deploying') return 3000;
+        // Keep a SLOW poll alive while the preview is live — it detects
+        // approve/reject/teardown state changes. getReviewStatus mints a fresh
+        // `?mr=<token>` previewUrl (120s TTL) on every poll, but the IFRAME src is
+        // DECOUPLED from the poll via pickReviewIframeSrc (see `stableIframeSrc`
+        // below): the iframe keeps its src until the embedded token nears expiry,
+        // then swaps ONCE — so the live preview doesn't hard-reload every minute
+        // (which would wipe in-progress interaction). A 60s poll < 120s TTL still
+        // guarantees a fresh token is always available when a swap is due.
+        if (s === 'preview-live') return 60000;
+        return false; // failed or none → stop polling
+      },
+    }
+  );
+
+  const state = statusQuery.data?.state ?? null;
+  const detail = statusQuery.data?.detail;
+  // Prefer the FRESH, mod-bound, short-TTL tokened URL (`?mr=<token>`) the server
+  // mints on every poll when the preview is live — that token is the cross-origin
+  // access bridge the `*.civit.ai` mod-gate forwardAuth verifies on the iframe's
+  // entry document request. Read from the latest query data each render so the
+  // iframe never mounts with an expired token. Fall back to the bare host URL
+  // (e.g. while building) only for stabilization input.
+  const url = statusQuery.data?.previewUrl ?? detail?.url;
+  const inProgress = state === 'preview-building' || state === 'preview-deploying';
+  const isLive = state === 'preview-live';
+  const isFailed = state === 'preview-failed';
+
+  // Stabilize the IFRAME src so it does NOT change on every poll. getReviewStatus
+  // mints a fresh `?mr=<token>` previewUrl every 60s poll; binding the iframe
+  // straight to `url` would hard-reload it each minute, wiping in-progress
+  // interaction in the previewed block. pickReviewIframeSrc keeps the embedded
+  // src until its token nears expiry (TTL 120s), then swaps once. Held in a ref so
+  // the chosen src survives re-renders; recomputed each render via the pure helper.
+  const iframeSrcRef = useRef<string | undefined>(undefined);
+  const stableIframeSrc = isLive
+    ? pickReviewIframeSrc(iframeSrcRef.current, url, Date.now())
+    : undefined;
+  // Persist the choice so the next render compares against the embedded token,
+  // not the latest poll's. Clear when the preview leaves the live state.
+  iframeSrcRef.current = stableIframeSrc || undefined;
+
+  return {
+    state,
+    detail,
+    isLive,
+    inProgress,
+    isFailed,
+    stableIframeSrc,
+    error: statusQuery.error,
+  };
+}

--- a/src/pages/apps/review/preview/[publishRequestId].tsx
+++ b/src/pages/apps/review/preview/[publishRequestId].tsx
@@ -1,0 +1,169 @@
+import { Alert, Box, Button, Group, Loader, Stack, Text } from '@mantine/core';
+import { IconArrowLeft, IconWindow, IconX } from '@tabler/icons-react';
+import Link from 'next/link';
+import { NotFound } from '~/components/AppLayout/NotFound';
+import { ReviewBlockPreviewHost } from '~/components/Apps/ReviewBlockPreviewHost';
+import { useReviewPreview } from '~/components/Apps/useReviewPreview';
+import { Meta } from '~/components/Meta/Meta';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { isAppReviewer } from '~/shared/utils/app-blocks-access';
+import { getLoginLink } from '~/utils/login-helpers';
+
+/**
+ * MOD REVIEW SANDBOX (#2831) — full-page review preview
+ * (`/apps/review/preview/<publishRequestId>`).
+ *
+ * The review modal's inline preview mounts the block in a squished 420px iframe.
+ * This page mounts the SAME review host bridge (`ReviewBlockPreviewHost`) at FULL
+ * VIEWPORT so a mod can review the pending app "as the user would see it", and —
+ * because it's its own tab — keep the review modal open alongside it.
+ *
+ * It replaces the old modal "Open review host" button, which linked to the raw
+ * `<host>/<slug>?mr=<token>` URL: opened top-level that URL has no host bridge, so
+ * the SDK block hangs on "Connecting to host" (the bug #3172 fixed for the iframe).
+ * This route is same-origin and mounts the real bridge, so the block renders.
+ *
+ * GATE: mirrors `/apps/review` exactly — `features.appBlocks` required (else 404),
+ * login required (else redirect), moderator required via `isAppReviewer` (else
+ * 404). Fail-closed for non-moderators and when the flag is off. The `slug` is
+ * resolved server-side (the shared `getReviewStatus` shape omits it, kept minimal
+ * for the modal path); a missing / non-pending request 404s.
+ */
+
+interface ReviewPreviewPageProps {
+  publishRequestId: string;
+  slug: string;
+}
+
+export const getServerSideProps = createServerSideProps<ReviewPreviewPageProps>({
+  useSession: true,
+  resolver: async ({ features, session, ctx }) => {
+    if (!features?.appBlocks) return { notFound: true };
+    if (!session?.user) {
+      return {
+        redirect: {
+          destination: getLoginLink({ returnUrl: ctx.resolvedUrl }),
+          permanent: false,
+        },
+      };
+    }
+    if (!isAppReviewer(session.user)) {
+      return { notFound: true };
+    }
+
+    const rawId = ctx.params?.publishRequestId;
+    const publishRequestId =
+      typeof rawId === 'string' ? rawId : Array.isArray(rawId) ? rawId[0] : '';
+    if (!publishRequestId) return { notFound: true };
+
+    // Resolve the slug for the host bridge server-side. Missing / non-pending
+    // request → the same fail-closed 404 (never leaks which).
+    const { resolveReviewPreviewTarget } = await import(
+      '~/server/services/blocks/publish-request.service'
+    );
+    const target = await resolveReviewPreviewTarget(publishRequestId);
+    if (!target) return { notFound: true };
+
+    return { props: { publishRequestId: target.id, slug: target.slug } };
+  },
+});
+
+export default function ReviewPreviewPage({ publishRequestId, slug }: ReviewPreviewPageProps) {
+  const features = useFeatureFlags();
+  const { detail, isLive, inProgress, isFailed, stableIframeSrc, error } =
+    useReviewPreview(publishRequestId);
+
+  // Belt-and-suspenders client gate (the SSR resolver already fail-closed).
+  if (!features?.appBlocks) return <NotFound />;
+
+  return (
+    <>
+      <Meta title={`Review preview — ${slug}`} deIndex />
+      {/* Fill the viewport under the global 60px header so the mod reviews the
+          app full-size (the modal used a fixed 420px iframe). */}
+      <Box style={{ height: 'calc(100dvh - var(--header-height))', width: '100%' }}>
+        {isLive && stableIframeSrc ? (
+          <ReviewBlockPreviewHost
+            publishRequestId={publishRequestId}
+            slug={slug}
+            iframeSrc={stableIframeSrc}
+          />
+        ) : (
+          <NonLiveState
+            slug={slug}
+            inProgress={inProgress}
+            isFailed={isFailed}
+            failureDetail={detail?.error}
+            buildingSha={detail?.sha}
+            errorMessage={error?.message}
+          />
+        )}
+      </Box>
+    </>
+  );
+}
+
+/**
+ * Centered status surface for every non-live preview state. `none` (no preview
+ * started) points the mod back to the queue; building/deploying shows progress;
+ * failed shows the error. Only `preview-live` mounts the host (handled above).
+ */
+function NonLiveState({
+  slug,
+  inProgress,
+  isFailed,
+  failureDetail,
+  buildingSha,
+  errorMessage,
+}: {
+  slug: string;
+  inProgress: boolean;
+  isFailed: boolean;
+  failureDetail?: string;
+  buildingSha?: string;
+  errorMessage?: string;
+}) {
+  return (
+    <Stack align="center" justify="center" gap="md" p="xl" style={{ height: '100%' }}>
+      <Group gap={6}>
+        <IconWindow size={18} />
+        <Text fw={600}>Review preview — {slug}</Text>
+      </Group>
+
+      {inProgress ? (
+        <Stack align="center" gap={6}>
+          <Loader size="sm" />
+          <Text size="sm" c="dimmed">
+            Building preview…
+            {buildingSha ? ` (sha ${buildingSha.slice(0, 12)})` : ''}
+          </Text>
+        </Stack>
+      ) : isFailed ? (
+        <Alert color="red" variant="light" icon={<IconX size={16} />} maw={520}>
+          {failureDetail ?? 'Review preview failed.'}
+        </Alert>
+      ) : (
+        <Text size="sm" c="dimmed" ta="center" maw={520}>
+          No active review preview — start one from the review queue.
+        </Text>
+      )}
+
+      {errorMessage && (
+        <Text size="xs" c="dimmed" ta="center" maw={520}>
+          {errorMessage}
+        </Text>
+      )}
+
+      <Button
+        component={Link}
+        href="/apps/review"
+        variant="default"
+        size="xs"
+        leftSection={<IconArrowLeft size={14} />}
+      >
+        Back to review queue
+      </Button>
+    </Stack>
+  );
+}

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -3141,6 +3141,11 @@ export async function getReviewStatus(opts: {
  * approve/reject, matching `mintReviewBlockToken`'s pending gate). Returns null
  * for a missing / non-pending request so the page fails closed with a 404 and
  * never leaks which of the two it was.
+ *
+ * NO AUTHORIZATION is performed here (like `getReviewStatus` / `mintReviewBlockToken`,
+ * which rely on their router gate) — this leaks a pending app's slug by id, so
+ * EVERY caller MUST already be moderator-gated (today: the page resolver runs the
+ * `isAppReviewer` gate before calling). Do not call from a non-mod-gated path.
  */
 export async function resolveReviewPreviewTarget(
   publishRequestId: string

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -3127,6 +3127,34 @@ export async function getReviewStatus(opts: {
   };
 }
 
+/**
+ * MOD REVIEW SANDBOX (#2831) — resolve the target for a full-page review preview
+ * mount (`/apps/review/preview/<publishRequestId>`).
+ *
+ * The page needs the `slug` to drive `ReviewBlockPreviewHost`, but the shared
+ * `getReviewStatus` return shape deliberately does NOT carry it (that shape feeds
+ * the modal poll and is kept minimal). This resolves the row by id server-side in
+ * the page's `getServerSideProps` instead of widening `getReviewStatus`.
+ *
+ * Returns `{ id, slug }` ONLY for an EXISTING, PENDING request — the only state a
+ * review preview can ever be live against (teardown clears the preview on
+ * approve/reject, matching `mintReviewBlockToken`'s pending gate). Returns null
+ * for a missing / non-pending request so the page fails closed with a 404 and
+ * never leaks which of the two it was.
+ */
+export async function resolveReviewPreviewTarget(
+  publishRequestId: string
+): Promise<{ id: string; slug: string } | null> {
+  const { dbRead } = await import('~/server/db/client');
+  const row = await dbRead.appBlockPublishRequest.findUnique({
+    where: { id: publishRequestId },
+    select: { id: true, status: true, slug: true },
+  });
+  if (!row) return null;
+  if (row.status !== 'pending') return null;
+  return { id: row.id, slug: row.slug };
+}
+
 export type MintReviewBlockTokenResult = {
   /** The signed, self-bound, scope-stripped block JWT for the review preview. */
   token: string;

--- a/src/tests/pages/apps/review/review-preview-page-gate.test.ts
+++ b/src/tests/pages/apps/review/review-preview-page-gate.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * MOD REVIEW SANDBOX (#2831) — full-page review preview SSR gate
+ * (`/apps/review/preview/<publishRequestId>`).
+ *
+ * Mirrors `run-page-maturity.test.ts`: we mock `createServerSideProps` to capture
+ * the resolver, then invoke it with a controlled `features`/`session`/`ctx`. The
+ * gate must mirror `/apps/review` exactly — `appBlocks` off → 404, no session →
+ * login redirect, non-moderator → 404 — plus resolve the `slug` server-side and
+ * 404 a missing / non-pending request.
+ *
+ * NOTE: this test lives under `src/tests/` (NOT co-located under `src/pages/`).
+ * Next treats every file under `pages/` as a route needing a default export, so a
+ * `*.test.ts` there fails `next build`'s route-type validator (tsc/vitest do not
+ * catch it). The page module is imported via the `~/pages/...` alias.
+ */
+
+const { capturedResolver } = vi.hoisted(() => ({
+  capturedResolver: { fn: null as null | ((c: any) => Promise<any>) },
+}));
+
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: (opts: { resolver: (c: any) => Promise<any> }) => {
+    capturedResolver.fn = opts.resolver;
+    return async () => ({ props: {} });
+  },
+}));
+
+const { mockResolveReviewPreviewTarget } = vi.hoisted(() => ({
+  mockResolveReviewPreviewTarget: vi.fn<(...a: any[]) => Promise<any>>(),
+}));
+vi.mock('~/server/services/blocks/publish-request.service', () => ({
+  resolveReviewPreviewTarget: mockResolveReviewPreviewTarget,
+}));
+
+vi.mock('~/utils/login-helpers', () => ({
+  getLoginLink: ({ returnUrl }: { returnUrl: string }) => `/login?returnUrl=${returnUrl}`,
+}));
+
+// The page imports React/Mantine/component bits at module top; stub the heavy
+// ones so importing the page module in a node unit test doesn't pull a DOM. The
+// resolver (the unit under test) touches none of them. `isAppReviewer` is left
+// REAL (it's a pure predicate) so the moderator gate is exercised for real.
+vi.mock('@mantine/core', () => ({
+  Alert: () => null,
+  Box: () => null,
+  Button: () => null,
+  Group: () => null,
+  Loader: () => null,
+  Stack: () => null,
+  Text: () => null,
+}));
+vi.mock('@tabler/icons-react', () => ({
+  IconArrowLeft: () => null,
+  IconWindow: () => null,
+  IconX: () => null,
+}));
+vi.mock('next/link', () => ({ default: () => null }));
+vi.mock('~/components/AppLayout/NotFound', () => ({ NotFound: () => null }));
+vi.mock('~/components/Apps/ReviewBlockPreviewHost', () => ({ ReviewBlockPreviewHost: () => null }));
+vi.mock('~/components/Apps/useReviewPreview', () => ({ useReviewPreview: () => ({}) }));
+vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({ useFeatureFlags: () => ({ appBlocks: true }) }));
+
+function makeCtx(
+  opts: {
+    appBlocks?: boolean;
+    user?: { isModerator?: boolean } | null;
+    publishRequestId?: string | undefined;
+    resolvedUrl?: string;
+  } = {}
+) {
+  const {
+    appBlocks = true,
+    user = { isModerator: true } as { isModerator?: boolean } | null,
+    resolvedUrl = '/apps/review/preview/pubreq_1',
+  } = opts;
+  // Read via `in` so an EXPLICIT `{ publishRequestId: undefined }` models a
+  // missing route param (a destructuring default would wrongly re-apply the id).
+  const publishRequestId = 'publishRequestId' in opts ? opts.publishRequestId : 'pubreq_1';
+  return {
+    features: { appBlocks },
+    session: user ? { user } : null,
+    ctx: { params: { publishRequestId }, resolvedUrl },
+  };
+}
+
+async function loadResolver() {
+  await import('~/pages/apps/review/preview/[publishRequestId]');
+  if (!capturedResolver.fn) throw new Error('resolver not captured');
+  return capturedResolver.fn;
+}
+
+describe('review-preview page SSR — moderator + flag gate', () => {
+  beforeEach(() => {
+    // Only reset the service mock — NOT capturedResolver (ESM module cache means
+    // createServerSideProps captures the resolver on the FIRST import only).
+    mockResolveReviewPreviewTarget.mockReset();
+  });
+
+  it('404s when the appBlocks flag is off', async () => {
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ appBlocks: false }));
+    expect(result).toEqual({ notFound: true });
+    expect(mockResolveReviewPreviewTarget).not.toHaveBeenCalled();
+  });
+
+  it('redirects to login when there is no session', async () => {
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ user: null }));
+    expect(result.redirect?.destination).toContain('/login');
+    expect(result.redirect?.permanent).toBe(false);
+  });
+
+  it('404s for a logged-in NON-moderator', async () => {
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ user: { isModerator: false } }));
+    expect(result).toEqual({ notFound: true });
+    expect(mockResolveReviewPreviewTarget).not.toHaveBeenCalled();
+  });
+
+  it('404s when the publishRequestId param is missing', async () => {
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ publishRequestId: undefined }));
+    expect(result).toEqual({ notFound: true });
+    expect(mockResolveReviewPreviewTarget).not.toHaveBeenCalled();
+  });
+
+  it('404s when the request is missing / not pending (resolver returns null)', async () => {
+    mockResolveReviewPreviewTarget.mockResolvedValue(null);
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ publishRequestId: 'pubreq_missing' }));
+    expect(result).toEqual({ notFound: true });
+    expect(mockResolveReviewPreviewTarget).toHaveBeenCalledWith('pubreq_missing');
+  });
+
+  it('returns props with the resolved slug for a valid moderator + pending request', async () => {
+    mockResolveReviewPreviewTarget.mockResolvedValue({ id: 'pubreq_1', slug: 'my-block' });
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ publishRequestId: 'pubreq_1' }));
+    expect(result).toEqual({ props: { publishRequestId: 'pubreq_1', slug: 'my-block' } });
+  });
+});


### PR DESCRIPTION
## What

On the App Blocks **moderator review modal**, replace the broken **"Open review host"** button with an **"Open full-page preview ↗"** link to a new same-origin route, `/apps/review/preview/<publishRequestId>`, that mounts the real review host bridge at **full viewport**.

## Why

The old button linked to the raw `<host>/<slug>?mr=<token>` preview URL. Opened top-level, that page has **no host bridge**, so the block SDK hangs on **"Connecting to host"** — the exact failure #3172 fixed for the in-modal iframe. The button therefore always led to a broken page.

The new route is **internal + same-origin** and mounts the same host bridge, so the pending app actually renders — and at **full size**, "as the user would see it", instead of the squished 420px modal iframe. Because it opens in a new tab, the mod can keep the review modal open alongside it.

## Changes

- **Remove** the raw-host "Open review host" button; **add** "Open full-page preview ↗" (new tab, `rel=noopener`) linking by `publishRequestId` — it no longer depends on the raw `?mr=` URL.
- **New page** `/apps/review/preview/[publishRequestId]` mounts the existing `ReviewBlockPreviewHost` full-viewport (fills under the global header). Non-live states show building / failed / "no active preview" messaging with a link back to the review queue; only a live preview mounts the host.
- **Shared hook** `useReviewPreview` — extracts the live-preview poll + iframe-src token-swap stabilization + state derivation so the modal panel and the new page share one source of truth. The modal panel's behaviour is **unchanged** (same poll intervals, same stabilization); the inline 420px preview is untouched.
- **SSR gate** mirrors `/apps/review` exactly: `appBlocks` flag off → 404, no session → login redirect, non-moderator → 404. The `slug` (which the host bridge needs) is resolved **server-side** without widening the shared review-status shape; a missing / non-pending request → 404.
- Ships **behind the existing mod-only App Blocks review-sandbox flag** — no user-visible change when the flag is off.

## Tests

- Extended the modal browser test: a live preview renders the **"Open full-page preview"** link with `href=/apps/review/preview/<id>` + `target=_blank`, and asserts the old "Open review host" text and any raw `?mr=` link are **gone**.
- New SSR-gate test for the page (mirrors the run-page gate test): flag-off → 404, no session → login redirect, non-moderator → 404, missing/invalid `publishRequestId` → 404, valid moderator + pending request → props include the resolved `slug`.

Evidence (run locally in a worktree with the repo's deps):

- `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` → **0 errors, exit 0**.
- `vitest run` — page-gate suite **6/6 pass**; modal browser suite **6/6 pass** (5 pre-existing + 1 new); reviewIframeSrc + both reviewSandbox suites **58/58 pass** (no regression from the extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)