### PR TITLE
fix(trpc): fail-open devalue write — superjson fallback + offender telemetry

### DIFF
--- a/src/server/logging/__tests__/devalue-fallback-log.test.ts
+++ b/src/server/logging/__tests__/devalue-fallback-log.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFallbackDedup, fallbackDedupKeys } from '~/server/logging/devalue-fallback-log';
+
+/**
+ * FIX 1 (PR #3186 audit): the devalue-write-fallback logger deduped on the RAW,
+ * client-controlled, comma-joined batch string from the serialize ALS ctx and
+ * never evicted its Map. These tests pin the two fixes: normalize the key to the
+ * individual PROCEDURE (so a re-framed offender can't flood Axiom) and BOUND the
+ * tracking Map (so it can't grow unboundedly on a long-lived module).
+ */
+
+describe('fallbackDedupKeys (normalize the batch path to individual procedures)', () => {
+  it('passes a single procedure through unchanged', () => {
+    expect(fallbackDedupKeys('image.getInfinite')).toEqual(['image.getInfinite']);
+  });
+
+  it('splits a comma-joined batch into its individual procedures', () => {
+    expect(fallbackDedupKeys('image.getInfinite,model.getById')).toEqual([
+      'image.getInfinite',
+      'model.getById',
+    ]);
+  });
+
+  it("splits on '/' too (the array-join separator) and de-duplicates repeats", () => {
+    expect(fallbackDedupKeys('a.x/b.y')).toEqual(['a.x', 'b.y']);
+    expect(fallbackDedupKeys('a.x,a.x,b.y')).toEqual(['a.x', 'b.y']);
+  });
+
+  it('collapses empty / whitespace-only input to ["unknown"]', () => {
+    expect(fallbackDedupKeys('')).toEqual(['unknown']);
+    expect(fallbackDedupKeys('  ,  ')).toEqual(['unknown']);
+    expect(fallbackDedupKeys('unknown')).toEqual(['unknown']);
+  });
+
+  it('keeps an SSR dehydrate marker intact (no comma/slash → single key)', () => {
+    expect(fallbackDedupKeys('ssr:dehydrate:user.[username].models')).toEqual([
+      'ssr:dehydrate:user.[username].models',
+    ]);
+  });
+});
+
+describe('createFallbackDedup — per-procedure window dedup', () => {
+  it('logs a key once per window, then again after the window elapses', () => {
+    const dedup = createFallbackDedup({ windowMs: 1000, maxSize: 100 });
+    expect(dedup.shouldLog('image.getInfinite', 0)).toBe(true);
+    expect(dedup.shouldLog('image.getInfinite', 500)).toBe(false); // within window
+    expect(dedup.shouldLog('image.getInfinite', 1001)).toBe(true); // window elapsed
+  });
+
+  it('a re-framed offender across two batch framings logs ONCE (defeats the flood)', () => {
+    // The audit's attack: hit offender.proc inside arbitrarily many batch
+    // framings — each a distinct RAW path, but the SAME offending procedure.
+    const dedup = createFallbackDedup({ windowMs: 30_000, maxSize: 100 });
+    const framings = ['offender.proc,other.a', 'offender.proc,other.b', 'offender.proc/other.c'];
+    const logged: string[] = [];
+    const now = 1000;
+    for (const raw of framings) {
+      for (const key of fallbackDedupKeys(raw)) {
+        if (dedup.shouldLog(key, now)) logged.push(key);
+      }
+    }
+    // offender.proc appears in all three framings but logs exactly once; the
+    // distinct neighbours each log once.
+    expect(logged.filter((k) => k === 'offender.proc')).toHaveLength(1);
+    expect(logged).toEqual(['offender.proc', 'other.a', 'other.b', 'other.c']);
+  });
+});
+
+describe('createFallbackDedup — the Map is SIZE-BOUNDED (never grows past the cap)', () => {
+  it('caps at maxSize with drop-oldest eviction across many distinct keys', () => {
+    const maxSize = 1000;
+    const dedup = createFallbackDedup({ windowMs: 30_000, maxSize });
+    // 10x the cap of DISTINCT keys, all within one window (so nothing dedups by time).
+    for (let i = 0; i < maxSize * 10; i++) {
+      expect(dedup.shouldLog(`proc.${i}`, 1000)).toBe(true);
+      expect(dedup.size()).toBeLessThanOrEqual(maxSize);
+    }
+    expect(dedup.size()).toBe(maxSize);
+  });
+
+  it('drops the OLDEST-logged key when at cap (recent keys stay deduped)', () => {
+    const dedup = createFallbackDedup({ windowMs: 30_000, maxSize: 2 });
+    expect(dedup.shouldLog('a', 0)).toBe(true); // {a}
+    expect(dedup.shouldLog('b', 0)).toBe(true); // {a,b}
+    expect(dedup.shouldLog('c', 0)).toBe(true); // at cap → evict oldest (a) → {b,c}
+    expect(dedup.size()).toBe(2);
+    // 'b' survived the eviction, so it is still deduped within the window…
+    expect(dedup.shouldLog('b', 0)).toBe(false);
+    // …while 'a' was evicted (its window state dropped), so it logs again.
+    expect(dedup.shouldLog('a', 0)).toBe(true);
+  });
+});

--- a/src/server/logging/__tests__/trpc-serialize-log.test.ts
+++ b/src/server/logging/__tests__/trpc-serialize-log.test.ts
@@ -6,13 +6,20 @@ import {
   __resetConfigCacheForTests,
   __resetRateLimitForTests,
   __setEmitSinkForTests,
+  currentSerializeCtx,
   instrumentSerialize,
   resolveSerializeConfig,
   runWithSerializeCtx,
+  runWithSerializeCtxAlways,
   serializeCtxFromRequest,
   shouldLogSerialize,
+  ssrDehydrateSerializePath,
   type SerializeLogPayload,
 } from '~/server/logging/trpc-serialize-log';
+import {
+  onDevalueWriteFallback,
+  writeSerializeWithFallback,
+} from '~/shared/utils/trpc-union-transformer';
 
 // Env keys this module reads — snapshot + restore around every test so cases can
 // tune thresholds without leaking into siblings.
@@ -285,6 +292,64 @@ describe('trpc-serialize-log', () => {
       expect(captured[0].path).toBe('image.getInfinite');
       expect(captured[0].serializeMs).toBe(100);
       expect(captured[0].bytes!).toBeGreaterThanOrEqual(1024 * 1024);
+    });
+  });
+
+  // FIX 2 (PR #3186 audit): SSR dehydrate writes through the fallback serializer,
+  // but the attribution ALS was seeded ONLY at the tRPC HTTP boundary — so an SSR
+  // offender (e.g. /changelog) logged `path: 'unknown'`. The SSR path now seeds
+  // the ctx via `runWithSerializeCtxAlways` (kill-switch-independent) with a
+  // sanitized page marker from `ssrDehydrateSerializePath`.
+  describe('ssrDehydrateSerializePath (page marker survives the fallback-dedup split)', () => {
+    it('sanitizes the pathname to a single "/"-free attribution key', () => {
+      expect(ssrDehydrateSerializePath('/changelog')).toBe('ssr:dehydrate:changelog');
+      expect(ssrDehydrateSerializePath('/user/foo/models?section=x')).toBe(
+        'ssr:dehydrate:user.foo.models'
+      );
+    });
+
+    it('collapses "/" and empty to a stable root marker', () => {
+      expect(ssrDehydrateSerializePath('/')).toBe('ssr:dehydrate:root');
+      expect(ssrDehydrateSerializePath(undefined)).toBe('ssr:dehydrate:root');
+    });
+  });
+
+  describe('runWithSerializeCtxAlways (kill-switch-independent SSR attribution)', () => {
+    it('seeds the ctx even when TRPC_SERIALIZE_LOG_ENABLED is off', () => {
+      process.env.TRPC_SERIALIZE_LOG_ENABLED = 'false';
+      let seen: string | undefined;
+      runWithSerializeCtxAlways({ path: 'ssr:dehydrate:changelog' }, () => {
+        seen = currentSerializeCtx()?.path;
+      });
+      expect(seen).toBe('ssr:dehydrate:changelog');
+    });
+
+    it('contrast: the gated runWithSerializeCtx does NOT seed when disabled', () => {
+      process.env.TRPC_SERIALIZE_LOG_ENABLED = 'false';
+      let seen: string | undefined = 'sentinel';
+      runWithSerializeCtx({ path: 'x' }, () => {
+        seen = currentSerializeCtx()?.path;
+      });
+      expect(seen).toBeUndefined();
+    });
+
+    it('an SSR-origin devalue-write fallback attributes a non-"unknown" path', () => {
+      // The devalue-write-fallback observer (src/server/trpc.ts) reads
+      // currentSerializeCtx(); seeding it around dehydrate makes an SSR offender
+      // attributable. Kill-switch off to prove the SSR seed is independent of it.
+      process.env.TRPC_SERIALIZE_LOG_ENABLED = 'false';
+      const seenPaths: (string | undefined)[] = [];
+      onDevalueWriteFallback(() => seenPaths.push(currentSerializeCtx()?.path));
+      try {
+        const nonPojo = { ok: false, error: new Error('boom') }; // devalue THROWS → fallback fires
+        runWithSerializeCtxAlways({ path: ssrDehydrateSerializePath('/changelog') }, () => {
+          writeSerializeWithFallback(nonPojo);
+        });
+        expect(seenPaths).toEqual(['ssr:dehydrate:changelog']);
+        expect(seenPaths[0]).not.toBe('unknown');
+      } finally {
+        onDevalueWriteFallback(undefined as any);
+      }
     });
   });
 });

--- a/src/server/logging/devalue-fallback-log.ts
+++ b/src/server/logging/devalue-fallback-log.ts
@@ -1,0 +1,77 @@
+/**
+ * Dedup + attribution helpers for the devalue-write fallback logger
+ * (src/server/trpc.ts). Kept pure + standalone so the bound/normalize logic is
+ * unit-testable without importing the heavyweight server `trpc.ts` module.
+ *
+ * WHY THIS EXISTS: a devalue-write fallback (a non-POJO response that fell back
+ * to superjson — see `writeSerializeWithFallback`) is attributed via the
+ * serialize ALS ctx, whose `path` is the RAW, client-controlled, comma-joined
+ * batch string from `req.query.trpc` (e.g. `image.getInfinite,model.getById`).
+ * Keying the dedup on that raw string has two defects:
+ *   (a) a client can hit ONE offending procedure inside arbitrarily many batch
+ *       framings (`offender,a` / `offender,b` / …), each a NEW key, defeating the
+ *       "deduped so a hot offender can't flood Axiom" intent; and
+ *   (b) the dedup Map is `set` but never evicted → unbounded growth on a
+ *       long-lived module.
+ * `fallbackDedupKeys` closes (a) by normalizing to the individual procedure(s);
+ * `createFallbackDedup` closes (b) with a size cap + LRU drop-oldest eviction.
+ */
+
+/**
+ * Normalize the client-controlled batch path to the SET of individual procedures
+ * it names. The path is a comma-joined batch string, optionally '/'-joined when
+ * the `[trpc]` catch-all segment arrives as an array (see `serializeCtxFromRequest`).
+ * Splitting on BOTH separators and deduping means a single offending procedure
+ * re-framed inside many batches collapses to one dedup key — so a hot offender
+ * can no longer flood Axiom by varying its co-batched neighbours.
+ *
+ * Returns an order-preserving, de-duplicated list. Empty / whitespace-only input
+ * collapses to `['unknown']` (mirrors the ctx-absent fallback).
+ */
+export function fallbackDedupKeys(rawPath: string): string[] {
+  const parts = rawPath
+    .split(/[,/]/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return ['unknown'];
+  return Array.from(new Set(parts));
+}
+
+export interface FallbackDedup {
+  /**
+   * Should `key` be logged at `now`? Returns true at most once per `windowMs` per
+   * key, recording the key (and refreshing its LRU recency) when it returns true.
+   */
+  shouldLog(key: string, now?: number): boolean;
+  /** Current tracked-key count — never exceeds `maxSize`. For assertions/introspection. */
+  size(): number;
+}
+
+/**
+ * Windowed, SIZE-BOUNDED per-key dedup. A key logs at most once per `windowMs`;
+ * the tracking Map is capped at `maxSize` with LRU drop-oldest eviction so a
+ * long-lived module can't grow it unboundedly across distinct offenders.
+ */
+export function createFallbackDedup(opts: { windowMs: number; maxSize: number }): FallbackDedup {
+  const { windowMs, maxSize } = opts;
+  const lastLogged = new Map<string, number>();
+  return {
+    shouldLog(key: string, now: number = Date.now()): boolean {
+      const last = lastLogged.get(key);
+      if (last !== undefined && now - last < windowMs) return false;
+      // LRU refresh: delete-then-set moves the key to the most-recent position
+      // (Map preserves insertion order). When at cap, evict the oldest (least
+      // recently logged) key BEFORE inserting so size never exceeds maxSize.
+      lastLogged.delete(key);
+      if (lastLogged.size >= maxSize) {
+        const oldest = lastLogged.keys().next().value;
+        if (oldest !== undefined) lastLogged.delete(oldest);
+      }
+      lastLogged.set(key, now);
+      return true;
+    },
+    size() {
+      return lastLogged.size;
+    },
+  };
+}

--- a/src/server/logging/trpc-serialize-log.ts
+++ b/src/server/logging/trpc-serialize-log.ts
@@ -211,6 +211,21 @@ export function runWithSerializeCtx<T>(ctx: SerializeCtx, fn: () => T): T {
   return serializeCtxStorage.run(ctx, fn);
 }
 
+/**
+ * Seed the serialize-attribution ctx UNCONDITIONALLY — independent of the
+ * `TRPC_SERIALIZE_LOG_ENABLED` kill-switch. Use OFF the hot request path (e.g.
+ * SSR dehydrate), where the async-context cost is negligible (once per page
+ * render, not per tRPC batch at ~thousands/s) and we want the
+ * devalue-write-fallback observer (src/server/trpc.ts) to be able to attribute
+ * an SSR offender even when serialize-SLOW logging is turned off. The gated
+ * `runWithSerializeCtx` stays the hot-path seed: decoupling the fallback
+ * attribution from the slow-log kill-switch on the HTTP boundary too would
+ * reintroduce the per-request async_hooks cost that gate exists to avoid.
+ */
+export function runWithSerializeCtxAlways<T>(ctx: SerializeCtx, fn: () => T): T {
+  return serializeCtxStorage.run(ctx, fn);
+}
+
 /** Read the active request's serialize-attribution ctx (also used by the
  *  devalue-write-fallback logger in src/server/trpc.ts to name the offender). */
 export function currentSerializeCtx(): SerializeCtx | undefined {
@@ -232,6 +247,21 @@ export function serializeCtxFromRequest(req: {
   const path = (Array.isArray(raw) ? raw.join('/') : raw) || 'unknown';
   const type = (req.method || '').toUpperCase() === 'GET' ? 'query' : undefined;
   return { path, type };
+}
+
+/**
+ * Build a stable, attribution-safe serialize `path` for an SSR dehydrate — so an
+ * SSR devalue-write fallback (e.g. `/changelog`) attributes to the page instead
+ * of `unknown`. Sanitizes the request URL's pathname so the marker survives the
+ * devalue-fallback-dedup normalizer (which splits on `,` and `/`): leading
+ * slashes trimmed, internal `/` → `.`, query string dropped — so the whole
+ * marker is ONE attribution key (`ssr:dehydrate:user.[username].models`), never
+ * fragmented. Empty → `ssr:dehydrate:root`.
+ */
+export function ssrDehydrateSerializePath(url: string | undefined): string {
+  const pathname = (url ?? '').split('?')[0];
+  const slug = pathname.replace(/^\/+/, '').replace(/\/+/g, '.') || 'root';
+  return `ssr:dehydrate:${slug}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/logging/trpc-serialize-log.ts
+++ b/src/server/logging/trpc-serialize-log.ts
@@ -211,7 +211,9 @@ export function runWithSerializeCtx<T>(ctx: SerializeCtx, fn: () => T): T {
   return serializeCtxStorage.run(ctx, fn);
 }
 
-function currentSerializeCtx(): SerializeCtx | undefined {
+/** Read the active request's serialize-attribution ctx (also used by the
+ *  devalue-write-fallback logger in src/server/trpc.ts to name the offender). */
+export function currentSerializeCtx(): SerializeCtx | undefined {
   return serializeCtxStorage.getStore();
 }
 
@@ -427,7 +429,14 @@ export function instrumentSerialize<T>(rawSerialize: () => T): T {
       // monsters block > slowMs and took the branch above).
       const bytes = safeByteLength(result);
       // serializeMs < slowMs here, so shouldLogSerialize reduces to the size trigger.
-      if (!shouldLogSerialize({ serializeMs, bytes: bytes ?? 0, slowMs: cfg.slowMs, oversizedBytes: cfg.oversizedBytes })) {
+      if (
+        !shouldLogSerialize({
+          serializeMs,
+          bytes: bytes ?? 0,
+          slowMs: cfg.slowMs,
+          oversizedBytes: cfg.oversizedBytes,
+        })
+      ) {
         return result;
       }
       const dropped = rateGate(path, cfg.maxPerSec);

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -20,6 +20,7 @@ import {
   WRITE_DEVALUE,
 } from '~/shared/utils/trpc-union-transformer';
 import { logToAxiom } from '~/server/logging/client';
+import { createFallbackDedup, fallbackDedupKeys } from '~/server/logging/devalue-fallback-log';
 import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
@@ -37,22 +38,30 @@ import type { Context } from './createContext';
 // Attribute + ship each devalue-write fallback (a non-POJO response payload that
 // fell back to superjson — see writeSerializeWithFallback). Path comes from the
 // serialize ALS ctx because tRPC doesn't thread the procedure into the
-// transformer (and onError never fires — the response still succeeds). Deduped
-// per path per window so a hot offender can't flood Axiom.
-const fallbackLogWindowMs = 30_000;
-const fallbackLastLogged = new Map<string, number>();
+// transformer (and onError never fires — the response still succeeds).
+//
+// The ctx path is the RAW, client-controlled, comma-joined batch string
+// (`req.query.trpc`), so we normalize it to the individual offending
+// procedure(s) (fallbackDedupKeys) before deduping — otherwise a client could
+// re-frame one offender across many batches to defeat the window — and dedup
+// through a SIZE-BOUNDED windowed map so a long-lived module can't grow it
+// unboundedly. Each distinct procedure logs at most once per window; a
+// multi-procedure batch (~1% of traffic) over-attributes to its co-batched
+// procedures, which is an acceptable, bounded cost for the offender list.
+const fallbackDedup = createFallbackDedup({ windowMs: 30_000, maxSize: 1000 });
 onDevalueWriteFallback((error) => {
-  const path = currentSerializeCtx()?.path ?? 'unknown';
+  const rawPath = currentSerializeCtx()?.path ?? 'unknown';
   const now = Date.now();
-  const last = fallbackLastLogged.get(path);
-  if (last !== undefined && now - last < fallbackLogWindowMs) return;
-  fallbackLastLogged.set(path, now);
-  void logToAxiom({
-    name: 'devalue-write-fallback',
-    type: 'warning',
-    path,
-    message: error instanceof Error ? error.message : String(error),
-  }).catch(() => undefined);
+  const message = error instanceof Error ? error.message : String(error);
+  for (const path of fallbackDedupKeys(rawPath)) {
+    if (!fallbackDedup.shouldLog(path, now)) continue;
+    void logToAxiom({
+      name: 'devalue-write-fallback',
+      type: 'warning',
+      path,
+      message,
+    }).catch(() => undefined);
+  }
 });
 
 export interface TRPCMeta {

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -12,12 +12,14 @@ import { trpcProcedureDuration, trpcClientReadCapabilityRequests } from '~/serve
 import { phase1CapableLabel } from '~/server/utils/client-version-saturation';
 import { maybeLogTrpcSlow } from '~/server/logging/trpc-slow-log';
 import { longTaskLabelsArmed, runWithLongTaskLabel } from '~/server/eventloop-longtask';
-import { instrumentSerialize } from '~/server/logging/trpc-serialize-log';
+import { currentSerializeCtx, instrumentSerialize } from '~/server/logging/trpc-serialize-log';
 import {
   buildTransformer,
+  onDevalueWriteFallback,
   serverWriteSerialize,
   WRITE_DEVALUE,
 } from '~/shared/utils/trpc-union-transformer';
+import { logToAxiom } from '~/server/logging/client';
 import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
@@ -31,6 +33,27 @@ import { Flags } from '~/shared/utils/flags';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { parseVerifiedBotHeader, VERIFIED_BOT_HEADER } from '~/server/utils/bot-detection/header';
 import type { Context } from './createContext';
+
+// Attribute + ship each devalue-write fallback (a non-POJO response payload that
+// fell back to superjson — see writeSerializeWithFallback). Path comes from the
+// serialize ALS ctx because tRPC doesn't thread the procedure into the
+// transformer (and onError never fires — the response still succeeds). Deduped
+// per path per window so a hot offender can't flood Axiom.
+const fallbackLogWindowMs = 30_000;
+const fallbackLastLogged = new Map<string, number>();
+onDevalueWriteFallback((error) => {
+  const path = currentSerializeCtx()?.path ?? 'unknown';
+  const now = Date.now();
+  const last = fallbackLastLogged.get(path);
+  if (last !== undefined && now - last < fallbackLogWindowMs) return;
+  fallbackLastLogged.set(path, now);
+  void logToAxiom({
+    name: 'devalue-write-fallback',
+    type: 'warning',
+    path,
+    message: error instanceof Error ? error.message : String(error),
+  }).catch(() => undefined);
+});
 
 export interface TRPCMeta {
   /** Bitwise token scope required for this procedure. Checked against ctx.tokenScope. */

--- a/src/server/utils/server-side-helpers.ts
+++ b/src/server/utils/server-side-helpers.ts
@@ -3,6 +3,10 @@ import type { GetServerSidePropsContext, GetServerSidePropsResult, Redirect } fr
 import type { Session } from '~/types/session';
 import { Tracker } from '~/server/clickhouse/client';
 import { unionTransformer } from '~/shared/utils/trpc-union-transformer';
+import {
+  runWithSerializeCtxAlways,
+  ssrDehydrateSerializePath,
+} from '~/server/logging/trpc-serialize-log';
 
 import { appRouter } from '~/server/routers';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
@@ -107,11 +111,20 @@ export function createServerSideProps<P>({
         // dehydrated state, and the devalue write (TRPC_WRITE_DEVALUE) throws on
         // non-POJOs — turning one failed prefetch into a page-wide SSR 500. Dropping
         // errored queries lets the client refetch instead.
+        //
+        // Seed the serialize-attribution ctx (kill-switch-independent — this is the
+        // once-per-render SSR path, not the hot tRPC batch path) with the page
+        // route so a devalue-write fallback during dehydrate attributes to the
+        // page (`ssr:dehydrate:<route>`) instead of `unknown`.
         ...(ssg
           ? {
-              trpcState: ssg.dehydrate({
-                shouldDehydrateQuery: (query) => query.state.status === 'success',
-              }),
+              trpcState: runWithSerializeCtxAlways(
+                { path: ssrDehydrateSerializePath(context.resolvedUrl), type: 'ssr' },
+                () =>
+                  ssg.dehydrate({
+                    shouldDehydrateQuery: (query) => query.state.status === 'success',
+                  })
+              ),
             }
           : {}),
         session,

--- a/src/shared/utils/__tests__/trpc-union-transformer.test.ts
+++ b/src/shared/utils/__tests__/trpc-union-transformer.test.ts
@@ -4,12 +4,14 @@ import { describe, expect, it } from 'vitest';
 import {
   buildTransformer,
   clientTransformer,
+  onDevalueWriteFallback,
   pickServerWriteSerialize,
   serverWriteSerialize,
   unionDeserialize,
   unionTransformer,
   WRITE_DEVALUE,
   writeSerialize,
+  writeSerializeWithFallback,
 } from '~/shared/utils/trpc-union-transformer';
 
 /**
@@ -267,6 +269,72 @@ describe('devalue write path rejects non-POJO tRPC outputs (devalue is strict)',
     // devalue represents these faithfully — the contract rejects non-POJOs, NOT
     // these first-class rich types (so the fix is narrow: only class instances /
     // Errors / symbols / Promises are the hazard).
-    expect(() => writeSerialize({ d: new Date(), m: new Map([['a', 1]]), s: new Set([1]), n: 2n })).not.toThrow();
+    expect(() =>
+      writeSerialize({ d: new Date(), m: new Map([['a', 1]]), s: new Set([1]), n: 2n })
+    ).not.toThrow();
+  });
+});
+
+/**
+ * FAIL-OPEN gate: `pickServerWriteSerialize(true)` routes through
+ * `writeSerializeWithFallback`, which keeps devalue's strictness observable
+ * (via the observer hook) without letting a non-POJO payload become a
+ * user-facing 500 — the fallback superjson write decodes through the same
+ * union READ every peer already runs. `writeSerialize` (above) stays the
+ * strict contract for tests.
+ */
+describe('writeSerializeWithFallback (fail-open devalue write)', () => {
+  it('writes devalue (string) for POJO payloads — identical to the strict write', () => {
+    const x = sample();
+    const out = writeSerializeWithFallback(x);
+    expect(typeof out).toBe('string');
+    expect(out).toBe(devalueStringify(x));
+    expect(unionDeserialize(out)).toEqual(x);
+  });
+
+  it('falls back to superjson (object) on a non-POJO payload and notifies the observer', () => {
+    const seen: unknown[] = [];
+    onDevalueWriteFallback((err) => seen.push(err));
+    try {
+      const payload = { ok: false, error: new Error('boom') };
+      const out = writeSerializeWithFallback(payload);
+      // superjson object — NOT a devalue string — still union-decodable.
+      expect(typeof out).not.toBe('string');
+      expect(out).toEqual(superjson.serialize(payload));
+      expect(unionDeserialize(out)).toEqual(
+        superjson.deserialize(superjson.serialize(payload) as any)
+      );
+      expect(seen).toHaveLength(1);
+    } finally {
+      onDevalueWriteFallback(undefined as any);
+    }
+  });
+
+  it('a throwing observer never breaks the response path', () => {
+    onDevalueWriteFallback(() => {
+      throw new Error('observer boom');
+    });
+    try {
+      expect(() => writeSerializeWithFallback({ e: new Error('x') })).not.toThrow();
+    } finally {
+      onDevalueWriteFallback(undefined as any);
+    }
+  });
+
+  it('pickServerWriteSerialize(true) IS the fail-open write (non-POJO → superjson, no throw)', () => {
+    const write = pickServerWriteSerialize(true);
+    const payload = {
+      items: [
+        new (class Sdk {
+          id = 1;
+          toJSON() {
+            return { id: this.id };
+          }
+        })(),
+      ],
+    };
+    let out: unknown;
+    expect(() => (out = write(payload))).not.toThrow();
+    expect(typeof out).not.toBe('string');
   });
 });

--- a/src/shared/utils/trpc-union-transformer.ts
+++ b/src/shared/utils/trpc-union-transformer.ts
@@ -25,9 +25,7 @@ import superjson from 'superjson';
  * in Phase 2 — only the SERVER response write is (env-)flipped, never the read.
  */
 export function unionDeserialize(object: unknown): any {
-  return typeof object === 'string'
-    ? devalueParse(object)
-    : superjson.deserialize(object as any);
+  return typeof object === 'string' ? devalueParse(object) : superjson.deserialize(object as any);
 }
 
 /**
@@ -43,17 +41,54 @@ export function unionDeserialize(object: unknown): any {
 export const writeSerialize = (object: any): string => devalueStringify(object);
 
 /**
+ * Observer for devalue-write fallbacks. The shared module can't import server
+ * logging (this file is in the client bundle), so the server registers a
+ * listener at init (src/server/trpc.ts) that attributes the offending
+ * procedure via the serialize ALS ctx and ships it to Axiom.
+ */
+let devalueFallbackObserver: ((error: unknown) => void) | undefined;
+export function onDevalueWriteFallback(observer: (error: unknown) => void): void {
+  devalueFallbackObserver = observer;
+}
+
+/**
+ * FAIL-OPEN devalue write: try devalue, and on a strict-mode throw (a non-POJO
+ * in the payload — a returned Error, an SDK class instance, a Prisma Decimal)
+ * fall back to superjson for THAT response and notify the observer.
+ *
+ * Rationale: the prod flip (#3135) surfaced latent non-POJO write paths as
+ * hard 500s (e.g. /changelog SSR, model-version Decimal). devalue's strictness
+ * is the right long-term contract, but enforcement belongs in tests + telemetry,
+ * not user-facing failures: every reader is the format-sniffing UNION, so a
+ * per-response superjson fallback decodes identically on every client. The
+ * observer gives us the exact offender list to fix before Phase 3 goes strict.
+ */
+export const writeSerializeWithFallback = (object: any): unknown => {
+  try {
+    return devalueStringify(object);
+  } catch (error) {
+    try {
+      devalueFallbackObserver?.(error);
+    } catch {
+      // observer failures must never affect the response path
+    }
+    return superjson.serialize(object);
+  }
+};
+
+/**
  * Pure selector for the SERVER response write format — extracted so the
  * env-gate's SELECTION logic is unit-testable without a module reload:
  *   - `false` (default) → `superjson.serialize` (object output). The wire is
  *     byte-for-byte what every pool wrote in Phase 1, so merging is zero-risk.
- *   - `true`            → `devalue.stringify` (string output). Only a pool whose
- *     Deployment sets `TRPC_WRITE_DEVALUE=true` writes devalue responses.
+ *   - `true`            → `writeSerializeWithFallback` (devalue string output,
+ *     with a per-response superjson fallback on non-POJO payloads — see above).
+ *     Only a pool whose Deployment sets `TRPC_WRITE_DEVALUE=true` writes devalue.
  * (superjson v2's default-export methods are pre-bound, so passing
  * `superjson.serialize` unbound is safe.)
  */
 export function pickServerWriteSerialize(flag: boolean): (object: any) => any {
-  return flag ? devalueStringify : superjson.serialize;
+  return flag ? writeSerializeWithFallback : superjson.serialize;
 }
 
 /**


### PR DESCRIPTION
## Context

The Phase 2 devalue write flip (#3135, `TRPC_WRITE_DEVALUE=true` on prod pools) surfaced latent non-POJO response payloads as hard user-facing 500s:

- `/changelog` was fully down: an errored SSR prefetch (latent middleware bug since #1816, fixed in `ba9d43b468`) put a `TRPCError` instance in the dehydrated state and `devalue.stringify` threw inside `getServerSideProps`.
- ~4.3k `Cannot stringify arbitrary non-POJOs` TRPCErrors in 8h on the response-serialize path (e.g. Prisma `Decimal` — `6fff53fa3a`), with **no procedure attribution** in logs (tRPC doesn't thread the path into the transformer, and `onError` gets `path: undefined` for serialize failures).

The flag has been rolled back to superjson for now (talos trunk `12c1a8269`). This PR makes re-flipping safe.

## What this does

- **`writeSerializeWithFallback`**: try devalue; on a strict-mode throw, notify an observer and write superjson for that response. Every reader is already the format-sniffing union, so the fallback decodes identically on every client — nothing user-facing can break.
- **`pickServerWriteSerialize(true)`** now selects the fail-open write. The strict `writeSerialize` stays exported as the tested POJO contract.
- **Observer registration in `src/server/trpc.ts`**: each fallback logs `name:'devalue-write-fallback'` to Axiom with the procedure path from the serialize ALS ctx (`trpc-serialize-log`), deduped per path per 30s window. This finally names the offenders.

## Why fail-open instead of fixing each offender first

The failures are data-dependent (the same procedures serialize fine locally), so the offender list can't be enumerated statically or from existing logs. Fail-open inverts the discovery: re-flip the flag, `devalue-write-fallback` lines name each offender with zero user impact, fix them at leisure, then Phase 3 can go strict once the log is quiet.

## Rollout

1. Merge + deploy this (and `ba9d43b468`, already on main).
2. Re-set `TRPC_WRITE_DEVALUE=true` (api-heavy first, per the original plan).
3. Watch `name == 'devalue-write-fallback'` in Axiom; fix offenders as they appear.
4. Phase 3 (strict, drop superjson) only when the fallback log is quiet.

## Tests

`trpc-union-transformer.test.ts`: 21 passing — new coverage for the fallback (POJO → identical devalue string; non-POJO → superjson object + observer notified; throwing observer never breaks the response; `pickServerWriteSerialize(true)` is fail-open). Strict-contract tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)