### PR TITLE
fix(app-blocks): publish output-host allowlist uses Civitai image hosts (unblocks benchmark grid gen)

### DIFF
--- a/src/server/services/blocks/__tests__/block-image-upload.logic.test.ts
+++ b/src/server/services/blocks/__tests__/block-image-upload.logic.test.ts
@@ -3,6 +3,7 @@ import { ImageIngestionStatus } from '~/shared/utils/prisma/enums';
 import { NsfwLevel } from '~/server/common/enums';
 import {
   classifyBlockImageUploadScan,
+  isAllowedOutputHost,
   isWithinSfwImageCeiling,
 } from '~/server/services/blocks/block-image-upload.logic';
 
@@ -124,5 +125,41 @@ describe('isWithinSfwImageCeiling', () => {
     expect(isWithinSfwImageCeiling(NsfwLevel.XXX)).toBe(false);
     // A mixed level (PG + R) still exceeds — any nsfw bit fails the ceiling.
     expect(isWithinSfwImageCeiling(NsfwLevel.PG | NsfwLevel.R)).toBe(false);
+  });
+});
+
+/**
+ * The SSRF allowlist for a server-resolved workflow OUTPUT url. Bounded to
+ * Civitai-controlled image hosts (output blobs resolve to `orchestration…civitai.com`).
+ * Regression guard for the "output url is not an allowed generation host" bug where
+ * the allowlist was wrongly derived from the internal `ORCHESTRATOR_ENDPOINT` host.
+ */
+describe('isAllowedOutputHost', () => {
+  it('allows the real Civitai-hosted output blob hosts (apex + subdomains, https)', () => {
+    for (const url of [
+      'https://orchestration.civitai.com/v2/consumer/blobs/abc.jpeg',
+      'https://image.civitai.com/xG1nkqK-abc/width=1024/x.jpeg',
+      'https://civitai.com/x.png',
+      'https://orchestration.civitai.red/x.jpeg',
+      'https://civitai.green/x.jpeg',
+      'https://a.b.civitai.com/x.jpeg',
+    ]) {
+      expect(isAllowedOutputHost(url)).toBe(true);
+    }
+  });
+
+  it('rejects non-Civitai hosts, host-confusion tricks, and non-https', () => {
+    for (const url of [
+      'https://evil-civitai.com/x.jpeg', // suffix-without-dot
+      'https://civitai.com.evil.com/x.jpeg', // subdomain-of-attacker
+      'https://evil.com/?x=civitai.com', // query substring
+      'https://civitai.com@evil.com/x.jpeg', // userinfo
+      'http://orchestration.civitai.com/x.jpeg', // not https
+      'https://orchestration-api.orchestration-poc.svc.cluster.local:8080/x', // the internal API host
+      'https://notcivitai.com/x.jpeg',
+      'not a url',
+    ]) {
+      expect(isAllowedOutputHost(url)).toBe(false);
+    }
   });
 });

--- a/src/server/services/blocks/block-image-upload.logic.ts
+++ b/src/server/services/blocks/block-image-upload.logic.ts
@@ -97,3 +97,31 @@ export function classifyBlockImageUploadScan(image: {
 
   return { status: 'ready', contentRating };
 }
+
+// Civitai-controlled image hosts. A workflow OUTPUT blob resolves to an
+// `https://orchestration…civitai.com` url (the same bound the vetted
+// `blockSourceImageSchema` in workflow.schema.ts applies to SOURCE images) — NOT
+// the `ORCHESTRATOR_ENDPOINT` API host, which is an internal cluster service
+// whose registrable domain (e.g. `cluster.local`) does not cover the public blob
+// / media-CDN host and so rejected every real output. Bounded by parsed HOSTNAME
+// (not substring) so userinfo / host-confusion tricks are rejected.
+const CIVITAI_OUTPUT_IMAGE_HOSTS = ['civitai.com', 'civitai.red', 'civitai.green'] as const;
+
+/**
+ * SSRF allowlist for a workflow output url. The url is server-resolved from the
+ * ownership-verified workflow (the block never supplies it), so the realistic
+ * threat is only a compromised/misbehaving orchestrator response — but we still
+ * gate defensively: HTTPS only, on a Civitai-controlled image host (+ subdomains),
+ * matched by parsed hostname.
+ */
+export function isAllowedOutputHost(rawUrl: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (u.protocol !== 'https:') return false;
+  const host = u.hostname.toLowerCase();
+  return CIVITAI_OUTPUT_IMAGE_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
+}

--- a/src/server/services/blocks/block-image-upload.service.ts
+++ b/src/server/services/blocks/block-image-upload.service.ts
@@ -4,13 +4,13 @@ import { dbRead } from '~/server/db/client';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import {
   classifyBlockImageUploadScan,
+  isAllowedOutputHost,
   type BlockImageUploadScanOutcome,
 } from '~/server/services/blocks/block-image-upload.logic';
 import type { OffsiteRatingValue } from '~/shared/constants/browsingLevel.constants';
 import type { PersistBlockUploadImageInput } from '~/server/schema/blocks/block-image-upload.schema';
 import type { SessionUser } from '~/types/session';
 import { uploadImageBufferToStore } from '~/utils/s3-utils';
-import { env } from '~/env/server';
 
 /**
  * App Blocks (Phase-2a PR-C) — server glue for the host-mediated `OPEN_IMAGE_UPLOAD`
@@ -84,36 +84,6 @@ function sniffSupportedImage(b: Buffer): string | null {
     return 'image/webp';
   }
   return null;
-}
-
-/**
- * SSRF allowlist for a workflow output url. The url is server-resolved from the
- * ownership-verified workflow (the block never supplies it), so the realistic
- * threat is only a compromised/misbehaving orchestrator response — but we still
- * gate defensively. Allows HTTPS on the orchestrator's own registrable domain
- * (derived at runtime from `env.ORCHESTRATOR_ENDPOINT` — no host hardcoded in
- * this public repo, no infra internals leaked) and its subdomains (output blobs
- * + the media CDN live under it). Fail-closed when the endpoint isn't configured.
- */
-function isAllowedOutputHost(rawUrl: string): boolean {
-  let u: URL;
-  try {
-    u = new URL(rawUrl);
-  } catch {
-    return false;
-  }
-  if (u.protocol !== 'https:') return false;
-  const endpoint = env.ORCHESTRATOR_ENDPOINT;
-  if (!endpoint) return false; // no allowlist configured → fail closed
-  let apex: string;
-  try {
-    apex = new URL(endpoint).hostname.toLowerCase().split('.').slice(-2).join('.');
-  } catch {
-    return false;
-  }
-  if (!apex) return false;
-  const host = u.hostname.toLowerCase();
-  return host === apex || host.endsWith('.' + apex);
 }
 
 /**


### PR DESCRIPTION
**Bug:** running a cell in the Model Benchmarking block failed with `output url is not an allowed generation host`. The `publishGenerationOutputs` SSRF allowlist (`isAllowedOutputHost`) derived its host bound from `env.ORCHESTRATOR_ENDPOINT` (the orchestrator **API** host), but generated-output image blobs are served from a **Civitai image host** (`orchestration…civitai.com`) — a different registrable domain — so **every** real output was rejected.

**Fix:** bound the output url to the vetted **Civitai-hosted-image host set** (`civitai.com`/`.red`/`.green` + subdomains, parsed hostname) — the exact bound `blockSourceImageSchema` already applies to img2img SOURCE images. Still SSRF-safe (Civitai-controlled hosts only; https-only; hostname-matched so userinfo/host-confusion/substring tricks are rejected). Redirects-disabled + byte-cap + magic-byte + own rate bucket unchanged.

Moved `isAllowedOutputHost` into the pure `block-image-upload.logic` module and added a **host-match + SSRF-bypass regression test** (it was previously untested — flagged by the seam audit). Dropped the now-unused `env` import from the service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)