### PR TITLE
fix(app-blocks): tighten canonical manifest schema to match the validator (buildCommand allowlist + outputDir traversal) + drift guard

### DIFF
--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -93,16 +93,22 @@
     },
     "buildCommand": {
       "type": "string",
-      "description": "Config-as-code: command the platform runs to build the static bundle (e.g. \"npm run build\"). Omit for no-build (static) apps. When set, outputDir must also be set.",
+      "description": "Config-as-code: command the platform runs to build the static bundle. Must be one of an allowlisted set of build invocations (defense-in-depth against shell injection): \"npm run <script>\", \"pnpm run <script>\", \"yarn run <script>\" (where <script> is a package.json script name), \"vite build\", or \"npx vite build\". Omit for no-build (static) apps. When set, outputDir must also be set. The pattern and max length are kept in lockstep with BUILD_COMMAND_RE / BUILD_COMMAND_MAX_LENGTH in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality).",
       "minLength": 1,
-      "maxLength": 256
+      "maxLength": 128,
+      "pattern": "^(?:(?:npm|pnpm|yarn) run [a-zA-Z0-9:_-]+|(?:npx )?vite build)$"
     },
     "outputDir": {
       "type": "string",
-      "description": "Config-as-code: directory (relative to the project root) the buildCommand emits static files into (e.g. \"dist\"). Required when buildCommand is set.",
+      "description": "Config-as-code: directory (relative to the project root) the buildCommand emits static files into (e.g. \"dist\"). Must be a safe relative path \u2014 no leading \"/\", no \"..\" path traversal, no backslash separators, and no Windows drive prefix (e.g. C:). Required when buildCommand is set. Kept in lockstep with the outputDir checks in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality). (The server additionally rejects a NUL byte; that impossible-in-a-manifest case is intentionally omitted here for RE2 regex portability.)",
       "minLength": 1,
       "maxLength": 256,
-      "pattern": "^[^/].*"
+      "allOf": [
+        { "$comment": "no leading '/' (absolute path)", "not": { "pattern": "^/" } },
+        { "$comment": "no backslash separators (Windows / '\\..' traversal)", "not": { "pattern": "\\\\" } },
+        { "$comment": "no '..' path-traversal segment", "not": { "pattern": "(^|/)\\.\\.(/|$)" } },
+        { "$comment": "no Windows drive prefix (e.g. C:)", "not": { "pattern": "^[A-Za-z]:" } }
+      ]
     },
     "publicSettingsKeys": {
       "type": "array",

--- a/src/server/services/__tests__/build-command-outputdir.schema-drift.test.ts
+++ b/src/server/services/__tests__/build-command-outputdir.schema-drift.test.ts
@@ -117,7 +117,7 @@ describe('app-block v1 schema ⇄ block-manifest-validator drift guard (buildCom
     ['x'.repeat(129), false], // over maxLength
   ];
 
-  it.each(BUILD_COMMAND_CASES)('buildCommand %j → schema/validator agree (accept=%s)', (value, expected) => {
+  it.each(BUILD_COMMAND_CASES)('buildCommand %j → schema/validator agree (accept=%s)', (value: string, expected: boolean) => {
     expect(schemaAcceptsBuildCommand(value)).toBe(expected);
     expect(validatorAcceptsBuildCommand(value)).toBe(expected);
     expect(schemaAcceptsBuildCommand(value)).toBe(validatorAcceptsBuildCommand(value));
@@ -156,7 +156,7 @@ describe('app-block v1 schema ⇄ block-manifest-validator drift guard (buildCom
     ['c:foo', false], // Windows drive prefix
   ];
 
-  it.each(OUTPUT_DIR_CASES)('outputDir %j → schema/validator agree (accept=%s)', (value, expected) => {
+  it.each(OUTPUT_DIR_CASES)('outputDir %j → schema/validator agree (accept=%s)', (value: string, expected: boolean) => {
     expect(schemaAcceptsOutputDir(value)).toBe(expected);
     expect(validatorAcceptsOutputDir(value)).toBe(expected);
     expect(schemaAcceptsOutputDir(value)).toBe(validatorAcceptsOutputDir(value));

--- a/src/server/services/__tests__/build-command-outputdir.schema-drift.test.ts
+++ b/src/server/services/__tests__/build-command-outputdir.schema-drift.test.ts
@@ -1,0 +1,164 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import {
+  BlockManifestValidator,
+  BUILD_COMMAND_MAX_LENGTH,
+  BUILD_COMMAND_RE,
+} from '../block-manifest-validator.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * Drift guard (App Blocks config-as-code: buildCommand + outputDir).
+ *
+ * The canonical published manifest schema at `public/schemas/app-block/v1.json`
+ * is the SOURCE OF TRUTH that the `civitai` CLI's vendored copy + the
+ * `civitai-app-starters` SDK mirror byte-for-byte, and that editor validation
+ * compiles + evaluates (santhosh-tekuri/jsonschema, RE2) client-side. The
+ * imperative server validator `block-manifest-validator.service.ts` is the
+ * RUNTIME enforcer. If the two drift, `civitai app validate` green-lights
+ * buildCommands / outputDirs the server later rejects.
+ *
+ * This guard fails loudly if they diverge, on TWO axes:
+ *   1. Structural — the schema's buildCommand.pattern / maxLength are pinned to
+ *      the validator's exported BUILD_COMMAND_RE / BUILD_COMMAND_MAX_LENGTH, and
+ *      outputDir is expressed as an allOf of four `not.pattern` traversal gates.
+ *   2. Behavioral parity — for a table of buildCommand + outputDir values, the
+ *      SCHEMA verdict (evaluating just that property's pattern/maxLength) equals
+ *      the VALIDATOR's field verdict.
+ *
+ * One INTENTIONAL divergence: the validator additionally rejects a NUL byte in
+ * outputDir; that impossible-in-a-manifest-string case is omitted from the
+ * schema for RE2 regex portability, so it is not exercised here.
+ */
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const SCHEMA_PATH = path.join(REPO_ROOT, 'public/schemas/app-block/v1.json');
+
+type OutputDirClause = { not: { pattern: string } };
+const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8')) as {
+  properties: {
+    buildCommand: { type: string; minLength: number; maxLength: number; pattern: string };
+    outputDir: { type: string; minLength: number; maxLength: number; allOf: OutputDirClause[] };
+  };
+};
+
+// Reused from block-manifest-validator.service.test.ts — an otherwise-valid
+// manifest + an AppContext whose allowedOrigins covers the iframe.src origin, so
+// only the field under test can produce an error.
+const VALID_MANIFEST = {
+  blockId: 'test-block',
+  version: '1.0.0',
+  name: 'Test Block',
+  contentRating: 'g',
+  renderMode: 'iframe',
+  trustTier: 'unverified',
+  scopes: ['models:read:self'],
+  iframe: {
+    src: 'https://blocks.civitai.com/test',
+    minHeight: 200,
+    maxHeight: null,
+    resizable: true,
+    sandbox: 'allow-scripts',
+  },
+};
+const APP_CTX = {
+  allowedScopes: TokenScope.ModelsRead,
+  allowedOrigins: ['https://blocks.civitai.com'],
+};
+
+describe('app-block v1 schema ⇄ block-manifest-validator drift guard (buildCommand + outputDir)', () => {
+  // ---- Structural assertions --------------------------------------------
+  it('pins buildCommand.pattern + maxLength to the validator consts', () => {
+    expect(schema.properties.buildCommand.pattern).toBe(BUILD_COMMAND_RE.source);
+    expect(schema.properties.buildCommand.maxLength).toBe(BUILD_COMMAND_MAX_LENGTH);
+    expect(schema.properties.buildCommand.minLength).toBe(1);
+  });
+
+  it('expresses outputDir as an allOf of four not.pattern traversal gates', () => {
+    const allOf = schema.properties.outputDir.allOf;
+    expect(Array.isArray(allOf)).toBe(true);
+    expect(allOf).toHaveLength(4);
+    for (const clause of allOf) {
+      expect(typeof clause.not.pattern).toBe('string');
+      // each pattern must compile to a valid regex
+      expect(() => new RegExp(clause.not.pattern)).not.toThrow();
+    }
+  });
+
+  // ---- Behavioral parity: buildCommand ----------------------------------
+  const schemaAcceptsBuildCommand = (value: string): boolean => {
+    const { pattern, maxLength, minLength } = schema.properties.buildCommand;
+    return value.length >= minLength && value.length <= maxLength && new RegExp(pattern).test(value);
+  };
+  const validatorAcceptsBuildCommand = (value: string): boolean => {
+    const result = BlockManifestValidator.validate({ ...VALID_MANIFEST, buildCommand: value }, APP_CTX);
+    return result.valid || !result.errors.some((e) => e.includes('buildCommand'));
+  };
+
+  const BUILD_COMMAND_CASES: Array<[string, boolean]> = [
+    // accept
+    ['npm run build', true],
+    ['pnpm run build', true],
+    ['yarn run test:e2e', true],
+    ['vite build', true],
+    ['npx vite build', true],
+    ['npm run a_b-c:d', true],
+    // reject
+    ['make all', false],
+    ['npm run build && rm -rf /', false],
+    ['bash -c x', false],
+    ['vite build --watch', false],
+    ['npm install', false],
+    ['npx vite build --mode x', false],
+    ['npm run ', false], // trailing space
+    ['npm  run build', false], // double space
+    ['yarn build', false],
+    ['x'.repeat(129), false], // over maxLength
+  ];
+
+  it.each(BUILD_COMMAND_CASES)('buildCommand %j → schema/validator agree (accept=%s)', (value, expected) => {
+    expect(schemaAcceptsBuildCommand(value)).toBe(expected);
+    expect(validatorAcceptsBuildCommand(value)).toBe(expected);
+    expect(schemaAcceptsBuildCommand(value)).toBe(validatorAcceptsBuildCommand(value));
+  });
+
+  // ---- Behavioral parity: outputDir -------------------------------------
+  const schemaAcceptsOutputDir = (value: string): boolean => {
+    const { allOf, maxLength, minLength } = schema.properties.outputDir;
+    if (value.length < minLength || value.length > maxLength) return false;
+    return !allOf.some((clause) => new RegExp(clause.not.pattern).test(value));
+  };
+  const validatorAcceptsOutputDir = (value: string): boolean => {
+    // outputDir is only validated meaningfully alongside a buildCommand; use a
+    // valid one so no unrelated buildCommand error fires.
+    const result = BlockManifestValidator.validate(
+      { ...VALID_MANIFEST, buildCommand: 'npm run build', outputDir: value },
+      APP_CTX
+    );
+    return result.valid || !result.errors.some((e) => e.includes('outputDir'));
+  };
+
+  const OUTPUT_DIR_CASES: Array<[string, boolean]> = [
+    // accept
+    ['dist', true],
+    ['build/out', true],
+    ['packages/app/dist', true],
+    ['a.b..c', true], // '..' not on a segment boundary → safe
+    // reject
+    ['/abs', false], // leading '/'
+    ['../escape', false], // '..' segment at start
+    ['a/../b', false], // '..' segment in the middle
+    ['..', false], // bare '..'
+    ['a/..', false], // '..' segment at end
+    ['dist\\x', false], // backslash separator
+    ['C:\\proj', false], // Windows drive + backslash
+    ['c:foo', false], // Windows drive prefix
+  ];
+
+  it.each(OUTPUT_DIR_CASES)('outputDir %j → schema/validator agree (accept=%s)', (value, expected) => {
+    expect(schemaAcceptsOutputDir(value)).toBe(expected);
+    expect(validatorAcceptsOutputDir(value)).toBe(expected);
+    expect(schemaAcceptsOutputDir(value)).toBe(validatorAcceptsOutputDir(value));
+  });
+});

--- a/src/server/services/block-manifest-validator.service.ts
+++ b/src/server/services/block-manifest-validator.service.ts
@@ -117,8 +117,8 @@ const VERSION_RE = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/;
 // Anything else — extra args, flags, shell metacharacters, multiple commands —
 // is rejected. The separate SHELL_METACHAR_RE below is a redundant second gate
 // so the rejection reason is explicit when a metachar is what tripped it.
-const BUILD_COMMAND_MAX_LENGTH = 128;
-const BUILD_COMMAND_RE =
+export const BUILD_COMMAND_MAX_LENGTH = 128;
+export const BUILD_COMMAND_RE =
   /^(?:(?:npm|pnpm|yarn) run [a-zA-Z0-9:_-]+|(?:npx )?vite build)$/;
 // Shell metacharacters that must never appear in a buildCommand. Checked first
 // so the error is specific ("contains shell metacharacters") rather than the


### PR DESCRIPTION
## What

Tightens the canonical published App Blocks manifest schema `public/schemas/app-block/v1.json` so it matches the imperative server validator (`src/server/services/block-manifest-validator.service.ts`) on the two config-as-code fields:

- **`buildCommand`** — `maxLength` 256 → **128**, and adds the allowlist `pattern` `^(?:(?:npm|pnpm|yarn) run [a-zA-Z0-9:_-]+|(?:npx )?vite build)$` (npm/pnpm/yarn `run <script>`, `vite build`, or `npx vite build`).
- **`outputDir`** — replaces the loose `^[^/].*` with an `allOf` of four `not`-pattern gates rejecting a leading `/`, backslash separators, a `..` path-traversal segment, and a Windows drive prefix.

Adds a drift-guard test `src/server/services/__tests__/build-command-outputdir.schema-drift.test.ts` that locks the schema to the validator's now-exported consts (`BUILD_COMMAND_RE`, `BUILD_COMMAND_MAX_LENGTH`) and asserts behavioral parity: for a table of buildCommand and outputDir values, the schema's verdict (property pattern/maxLength) equals the validator's field verdict. The two consts in the validator are now `export`ed (purely additive, no logic change).

## Why

This schema is not just documentation — the Go CLI (`civitai/cli`) and editor validation compile and evaluate it (santhosh-tekuri/jsonschema, RE2) to validate manifests client-side. The prior looseness meant `civitai app validate` could green-light `buildCommand`/`outputDir` values that the server later rejects at submit time. This change is superset-safe: it only **adds** constraints the runtime validator already enforces, so nothing that validated on the server can newly fail.

The one intentional divergence: the validator also rejects a NUL byte in `outputDir`; that impossible-in-a-manifest-string case is omitted from the schema for RE2 regex portability. The drift test documents this.

## ⚠️ Sequencing

**Merge this FIRST.** The SDK (`civitai-app-starters`) and the Go CLI (`civitai/cli`) byte-mirror this schema. Their companion re-vendor PRs must merge only **after** this change deploys to the live `https://civitai.com/schemas/app-block/v1.json` (served from the release branch) — until then their check-canonical-schema guards compare the mirror against the still-old live URL and would fail.

## Test

Targeted vitest run (drift guard + existing validator suite) — both green:

```
✓ build-command-outputdir.schema-drift.test.ts (30 tests)
✓ block-manifest-validator.service.test.ts (119 tests)
Test Files 2 passed (2) · Tests 149 passed (149)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
