### PR TITLE
test(app-blocks): annotate drift-test parity-callback params (cosmetic, noImplicitAny)

### DIFF
--- a/src/server/services/__tests__/build-command-outputdir.schema-drift.test.ts
+++ b/src/server/services/__tests__/build-command-outputdir.schema-drift.test.ts
@@ -93,7 +93,7 @@ describe('app-block v1 schema ⇄ block-manifest-validator drift guard (buildCom
   };
   const validatorAcceptsBuildCommand = (value: string): boolean => {
     const result = BlockManifestValidator.validate({ ...VALID_MANIFEST, buildCommand: value }, APP_CTX);
-    return result.valid || !result.errors.some((e) => e.includes('buildCommand'));
+    return result.valid || !result.errors.some((e: string) => e.includes('buildCommand'));
   };
 
   const BUILD_COMMAND_CASES: Array<[string, boolean]> = [
@@ -136,7 +136,7 @@ describe('app-block v1 schema ⇄ block-manifest-validator drift guard (buildCom
       { ...VALID_MANIFEST, buildCommand: 'npm run build', outputDir: value },
       APP_CTX
     );
-    return result.valid || !result.errors.some((e) => e.includes('outputDir'));
+    return result.valid || !result.errors.some((e: string) => e.includes('outputDir'));
   };
 
   const OUTPUT_DIR_CASES: Array<[string, boolean]> = [


### PR DESCRIPTION
Followup to #3188 (merged). Cosmetic type-only change to the buildCommand/outputDir schema-drift test.

## What
Annotate the two parity-helper `.some()` callback params as `e: string`:
```
result.valid || !result.errors.some((e: string) => e.includes('buildCommand'/'outputDir'))
```

## Why (and why it's NOT a bug fix)
`BlockManifestValidator.validate` returns `ValidationResult = { valid: true } | { valid: false; errors: string[] }`. In `result.valid || !result.errors.some(...)`, TS narrows `result` to the error branch, so under real module resolution `e` infers as `string` — this is a **no-op at runtime and type-checks fine as-is** (the existing `block-manifest-validator.service.test.ts`, already in prod, uses the same un-annotated `result.errors.some((e) => ...)` pattern).

The value here is purely removing recurring editor/LSP **implicit-any noise** that appears when the file is analyzed without resolving the `~/...` path aliases (e.g. in an isolated worktree), and keeping the file's typing style explicit. No behavior change; the drift guard's assertions are unchanged.