### PR TITLE
fix(app-blocks): allow buzz:read:self in dev-mint + surface un-grantable dev-preview consent

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -17,6 +17,14 @@ import { renderWithProviders } from '../../../test/component-setup';
 // moderator gate; these suites render the real host without a CivitaiSessionProvider.
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 
+// Issue B: spy on the toast so the un-grantable-consent path is assertable without
+// mounting the full Notifications provider. Preserve the module's other exports.
+const showNotificationSpy = vi.fn();
+vi.mock('@mantine/notifications', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@mantine/notifications')>();
+  return { ...actual, showNotification: (args: unknown) => showNotificationSpy(args) };
+});
+
 vi.mock('~/utils/trpc', () => ({
   // FeatureFlagsProvider (pulled into PageBlockHost's real render graph) statically
   // imports `setTrpcBatchingEnabled` from this module (added in #2946). Because
@@ -167,6 +175,7 @@ describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
   beforeEach(() => {
     // dialogStore is a module-level zustand store shared across tests — reset it.
     useDialogStore.getState().closeAll();
+    showNotificationSpy.mockClear();
   });
 
   test('after BLOCK_READY, REQUEST_CONSENT opens the consent dialog with the server-known missing set', async () => {
@@ -237,9 +246,56 @@ describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
     );
 
     await driveToReady();
+    // baseProps.declaredScopes already carries ai:write:budgeted, so with nothing
+    // missing it is ALREADY granted → benign re-request → no dialog AND no toast.
     postFromBlock('REQUEST_CONSENT', { scopes: ['ai:write:budgeted'] });
 
     await new Promise((r) => setTimeout(r, 150));
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+    expect(showNotificationSpy).not.toHaveBeenCalled();
+  });
+
+  test('Issue B: an UN-GRANTABLE requested scope (clamped at mint) surfaces a toast, not a silent drop', async () => {
+    // The preview token carries no storage scopes and nothing is grantable via
+    // consent (missingScopes empty) — a block asking for apps:storage:write can
+    // NEVER be satisfied here. Instead of dropping silently (dead-looking button),
+    // the host surfaces a user-visible message.
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        declaredScopes={['models:read:self']}
+        missingScopes={[]}
+        needsConsent={false}
+        onConsentGranted={vi.fn()}
+      />
+    );
+
+    await driveToReady();
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', { scopes: ['apps:storage:write'] });
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    });
+    // No consent dialog is opened for an un-grantable scope.
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+  });
+
+  test('Issue B: reviewMode never toasts an un-grantable consent request (untrusted preview stays silent)', async () => {
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        declaredScopes={['models:read:self']}
+        missingScopes={[]}
+        needsConsent={false}
+        reviewMode
+        onConsentGranted={vi.fn()}
+      />
+    );
+
+    await driveToReady();
+    postFromBlock('REQUEST_CONSENT', { scopes: ['apps:storage:write'] });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(showNotificationSpy).not.toHaveBeenCalled();
     expect(useDialogStore.getState().dialogs).toHaveLength(0);
   });
 });

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -16,6 +16,7 @@ import {
   resolveImageUploadRequest,
   resolvePublishGenerationOutputsRequest,
   resolveResourcePickerRequest,
+  resolveUngrantableConsentScopes,
 } from './pageBlockHostLogic';
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import { projectSafeGenerationResource } from '~/server/schema/blocks/generation-resource-projection';
@@ -38,6 +39,7 @@ import { PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
 import { usePostMessage } from './usePostMessage';
 import type { BlockInitPayload, PageContext } from './types';
 import { dialogStore } from '~/components/Dialog/dialogStore';
+import { showNotification } from '@mantine/notifications';
 import { openLoginPopup } from '~/utils/auth-helpers';
 import type { BuyBuzzModalProps } from '~/components/Modals/BuyBuzzModal';
 import { openResourceSelectModal } from '~/components/Dialog/triggers/resource-select';
@@ -506,7 +508,7 @@ export function PageBlockHost({
   // but never ported this handler from IframeHost, so REQUEST_CONSENT fired into
   // the void and the block hung on "confirm in the Civitai dialog".
   useEffect(() => {
-    const off = onMessage<{ scopes?: unknown } | undefined>('REQUEST_CONSENT', () => {
+    const off = onMessage<{ scopes?: unknown } | undefined>('REQUEST_CONSENT', (payload) => {
       // reviewMode: a consent grant re-mints the token with WIDER scopes — never
       // let untrusted review code pop a permission modal at the mod. Fire-and-
       // forget ⇒ dropping it never hangs the block.
@@ -518,24 +520,55 @@ export function PageBlockHost({
       // to a non-ready sentinel before delegating — semantics are unchanged (it
       // would return null either way), this just satisfies the union type.
       const gateStatus = status === 'error' ? 'no_token' : status;
+      // Only act on a post-handshake request; a pre-handshake block never gets a
+      // modal OR a toast (same posture as the consent gate itself).
+      if (gateStatus !== 'ready') return;
       const scopesToGrant = resolveRequestConsent(gateStatus, missingScopes ?? []);
-      if (scopesToGrant == null) return; // not ready, or nothing missing — drop
-      dialogStore.trigger({
-        component: BlockConsentModal,
-        props: {
-          appBlockId,
-          // PageBlockHost surfaces the app name as `appName` (the model host
-          // uses `install.manifest.name`).
-          blockName: appName,
-          missingScopes: scopesToGrant,
-          onGranted: () => {
-            onConsentGranted?.();
+      if (scopesToGrant != null) {
+        dialogStore.trigger({
+          component: BlockConsentModal,
+          props: {
+            appBlockId,
+            // PageBlockHost surfaces the app name as `appName` (the model host
+            // uses `install.manifest.name`).
+            blockName: appName,
+            missingScopes: scopesToGrant,
+            onGranted: () => {
+              onConsentGranted?.();
+            },
           },
-        },
+        });
+        return;
+      }
+      // Issue B — nothing is grantable-via-consent. Distinguish the BENIGN case
+      // (the block re-requested a scope it ALREADY holds → keep the silent no-op)
+      // from the UN-GRANTABLE case (a requested scope was clamped/withheld at mint
+      // and can never be added via consent here — e.g. a dev-tunnel preview token
+      // that doesn't carry it). Only the latter, proven from the block's advisory
+      // `scopes` hint, surfaces a message so the app doesn't silently look dead.
+      const ungrantable = resolveUngrantableConsentScopes(
+        payload?.scopes,
+        grantedScopes,
+        missingScopes
+      );
+      if (ungrantable.length === 0) return; // already-granted or no hint — drop
+      showNotification({
+        color: 'yellow',
+        title: 'Permission unavailable',
+        message: 'This app requested a permission that isn’t available in this preview.',
       });
     });
     return off;
-  }, [onMessage, status, missingScopes, appBlockId, appName, onConsentGranted, reviewMode]);
+  }, [
+    onMessage,
+    status,
+    missingScopes,
+    grantedScopes,
+    appBlockId,
+    appName,
+    onConsentGranted,
+    reviewMode,
+  ]);
 
   // Deep-link bridge — block requests in-page navigation. The block may push a
   // new sub-path WITHIN its own page space; we constrain it to the page route so

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -5,6 +5,7 @@ import {
   resolveCheckpointPickerRequest,
   resolveImageUploadRequest,
   resolveResourcePickerRequest,
+  resolveUngrantableConsentScopes,
   PAGE_RESOURCE_PICKER_TYPES,
   type PageHostStatus,
 } from '../pageBlockHostLogic';
@@ -45,6 +46,55 @@ describe('grantedPageScopes (#3/#6 — BLOCK_INIT carries the JWT scopes, not []
   it('is a no-op for a missingScopes entry that was never declared', () => {
     const declared = ['apps:storage:read'];
     expect(grantedPageScopes(declared, ['ai:write:budgeted'])).toEqual(declared);
+  });
+});
+
+describe('resolveUngrantableConsentScopes (Issue B — un-grantable dev-preview consent → toast)', () => {
+  it('returns the un-grantable subset when a requested scope is neither granted NOR missing (clamped at mint)', () => {
+    // dev-tunnel preview: the token carries models:read:self; the block asks for
+    // a scope the tunnel allowlist withheld → not granted, not addable via consent.
+    const out = resolveUngrantableConsentScopes(
+      ['apps:storage:read'],
+      ['models:read:self'],
+      []
+    );
+    expect(out).toEqual(['apps:storage:read']);
+  });
+
+  it('returns EMPTY for the BENIGN already-granted case (block re-requests a held scope) — no toast', () => {
+    expect(
+      resolveUngrantableConsentScopes(['buzz:read:self'], ['buzz:read:self', 'models:read:self'], [])
+    ).toEqual([]);
+  });
+
+  it('returns EMPTY when the requested scope is grantable via consent (it is in missingScopes) — modal path owns it', () => {
+    expect(
+      resolveUngrantableConsentScopes(['ai:write:budgeted'], ['models:read:self'], [
+        'ai:write:budgeted',
+      ])
+    ).toEqual([]);
+  });
+
+  it('returns EMPTY when the block sends no hint / a garbage hint (never a fragile heuristic)', () => {
+    expect(resolveUngrantableConsentScopes(undefined, ['models:read:self'], [])).toEqual([]);
+    expect(resolveUngrantableConsentScopes([], ['models:read:self'], [])).toEqual([]);
+    expect(resolveUngrantableConsentScopes('nope', ['models:read:self'], [])).toEqual([]);
+    expect(resolveUngrantableConsentScopes([1, null, ''], ['models:read:self'], [])).toEqual([]);
+  });
+
+  it('reports ONLY the un-grantable scopes from a mixed hint (drops granted + missing), sorted+deduped', () => {
+    const out = resolveUngrantableConsentScopes(
+      ['apps:storage:write', 'apps:storage:read', 'apps:storage:write', 'buzz:read:self', 'ai:write:budgeted'],
+      ['buzz:read:self'], // already granted
+      ['ai:write:budgeted'] // grantable via consent
+    );
+    expect(out).toEqual(['apps:storage:read', 'apps:storage:write']);
+  });
+
+  it('tolerates an undefined missingScopes', () => {
+    expect(
+      resolveUngrantableConsentScopes(['apps:storage:read'], ['models:read:self'], undefined)
+    ).toEqual(['apps:storage:read']);
   });
 });
 

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -28,6 +28,44 @@ export function grantedPageScopes(
   return declaredScopes.filter((s) => !withheld.has(s));
 }
 
+/**
+ * Issue B (defensive UX): decide whether a REQUEST_CONSENT whose grantable set is
+ * EMPTY should surface a user-visible "not available in this preview" message
+ * instead of the silent no-op that makes an app look dead.
+ *
+ * A block MAY send an advisory `scopes` hint listing what it wants. The host does
+ * NOT use it to GRANT anything (the grant set is bounded server-side to
+ * `missingScopes`), but it CAN use it to tell apart two otherwise-identical
+ * silent-drop cases when nothing is grantable-via-consent:
+ *   - BENIGN (drop silently): every requested scope is ALREADY granted — a block
+ *     re-requesting a scope its token already carries.
+ *   - UN-GRANTABLE (surface a message): a requested scope is neither currently
+ *     granted NOR addable via consent (`missingScopes`) — it was clamped/withheld
+ *     at mint (e.g. a dev-tunnel token that stripped a scope the tunnel allowlist
+ *     doesn't carry), so the block's consent round-trip can never resolve it.
+ *
+ * Returns the un-grantable subset (requested − granted − missing), sorted+deduped.
+ * Returns EMPTY when the hint is absent/garbage OR everything requested is already
+ * granted — the caller then keeps the silent no-op (no fragile heuristic: without
+ * an explicit requested scope proven un-grantable, we never toast).
+ */
+export function resolveUngrantableConsentScopes(
+  rawScopesHint: unknown,
+  grantedScopes: string[],
+  missingScopes: string[] | undefined
+): string[] {
+  if (!Array.isArray(rawScopesHint)) return [];
+  const requested = rawScopesHint.filter(
+    (s): s is string => typeof s === 'string' && s.length > 0
+  );
+  if (requested.length === 0) return [];
+  const granted = new Set<string>(grantedScopes);
+  const missing = new Set<string>(missingScopes ?? []);
+  return Array.from(
+    new Set(requested.filter((s: string) => !granted.has(s) && !missing.has(s)))
+  ).sort();
+}
+
 // ── OPEN_RESOURCE_PICKER (Design 1 host-chrome resource picker) ──────────────
 //
 // The page block asks the HOST to open its native ResourceSelectModal so the

--- a/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
@@ -53,8 +53,8 @@ const FULL_SOURCE = [
   'ai:write:budgeted',
   'apps:storage:read',
   'apps:storage:write',
-  'social:tip:self', // PAGE_FORBIDDEN
-  'buzz:read:self', // PAGE_FORBIDDEN
+  'social:tip:self', // money-OUT — in NO allowlist, always stripped
+  'buzz:read:self', // own-ledger READ — in both dev allowlists, NOT the review one
   'block:settings:read', // not in either dev allowlist
   'totally:fake:scope', // unknown
 ];
@@ -69,6 +69,7 @@ describe('clampDevScopes', () => {
     });
     expect(granted).toEqual([
       'ai:write:budgeted',
+      'buzz:read:self',
       'media:read:owned',
       'models:read:self',
       'user:read:self',
@@ -76,6 +77,9 @@ describe('clampDevScopes', () => {
     // App Storage never survives the tunnel clamp.
     expect(granted).not.toContain('apps:storage:read');
     expect(granted).not.toContain('apps:storage:write');
+    // buzz:read:self (own-ledger read) survives; social:tip:self (money OUT) never does.
+    expect(granted).toContain('buzz:read:self');
+    expect(granted).not.toContain('social:tip:self');
   });
 
   it('DEV (bearer) allowlist KEEPS apps:storage:* — the tunnel-vs-bearer difference is exactly storage', () => {
@@ -87,9 +91,10 @@ describe('clampDevScopes', () => {
     });
     expect(granted).toContain('apps:storage:read');
     expect(granted).toContain('apps:storage:write');
-    // Still drops forbidden/unknown/out-of-allowlist.
+    // buzz:read:self (own-ledger read) is in the bearer dev allowlist too.
+    expect(granted).toContain('buzz:read:self');
+    // Still drops money-OUT/unknown/out-of-allowlist.
     expect(granted).not.toContain('social:tip:self');
-    expect(granted).not.toContain('buzz:read:self');
     expect(granted).not.toContain('block:settings:read');
     expect(granted).not.toContain('totally:fake:scope');
   });
@@ -153,6 +158,43 @@ describe('clampDevScopes', () => {
       allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
     });
     expect(dedup).toEqual(['models:read:self', 'user:read:self']);
+  });
+});
+
+describe('buzz:read:self allowlist membership (own-ledger read, self-bound)', () => {
+  it('is in BOTH dev allowlists but NOT the mod-review sandbox allowlist', () => {
+    expect(DEV_TOKEN_SCOPE_ALLOWLIST.has('buzz:read:self')).toBe(true);
+    expect(TUNNEL_HOST_MINT_SCOPE_ALLOWLIST.has('buzz:read:self')).toBe(true);
+    expect(REVIEW_MINT_SCOPE_ALLOWLIST.has('buzz:read:self')).toBe(false);
+  });
+
+  it('the money-OUT scope social:tip:self is in NONE of the allowlists', () => {
+    expect(DEV_TOKEN_SCOPE_ALLOWLIST.has('social:tip:self')).toBe(false);
+    expect(TUNNEL_HOST_MINT_SCOPE_ALLOWLIST.has('social:tip:self')).toBe(false);
+    expect(REVIEW_MINT_SCOPE_ALLOWLIST.has('social:tip:self')).toBe(false);
+  });
+
+  it('a dev-tunnel manifest requesting buzz:read:self KEEPS the scope through the clamp (consent works)', () => {
+    const granted = clampDevScopes({
+      scopeSource: ['buzz:read:self', 'models:read:self'],
+      oauthAllowed: null, // pre-approval dev tunnel — no OauthClient
+      keyCanSpend: true,
+      allowlist: TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
+    });
+    // The scope survives → the block's REQUEST_CONSENT resolves a real
+    // missingScope instead of an empty set (the reported "dead button" bug).
+    expect(granted).toContain('buzz:read:self');
+    expect(granted).toEqual(['buzz:read:self', 'models:read:self', 'user:read:self']);
+  });
+
+  it('the mod-review sandbox STRIPS buzz:read:self even when the pending manifest declares it', () => {
+    const granted = clampDevScopes({
+      scopeSource: ['buzz:read:self', 'models:read:self'],
+      oauthAllowed: null,
+      keyCanSpend: false,
+      allowlist: REVIEW_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(granted).not.toContain('buzz:read:self');
   });
 });
 

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -84,6 +84,18 @@ export const DEV_TOKEN_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
   'collections:read:self',
   'collections:write:self',
   'collections:read:private',
+  // buzz:read:self (own ledger / balance / earnings) is included in BOTH dev
+  // allowlists (this bearer path + the tunnel path below). In prod it's
+  // consent-gated, but the dev-mint path is self-bound to the dev's OWN account
+  // (the token `sub` is the authenticated dev via the mint's subject-user
+  // resolution; the buzz-read bridge derives userId off `claims.sub`, never body
+  // input), so it reads ONLY the dev's own ledger — no third-party financial data
+  // and no consent round-trip. It's a pure READ (no money moves); the money-OUT
+  // scope `social:tip:self` stays EXCLUDED everywhere. Consistent with these dev
+  // allowlists ALREADY granting `ai:write:budgeted` (real Buzz SPEND) and
+  // `collections:read:private` — forbidding a dev from READING their own balance
+  // while permitting SPENDING it is incoherent.
+  'buzz:read:self',
 ]);
 
 /**
@@ -108,6 +120,12 @@ export const TUNNEL_HOST_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<str
   'collections:read:self',
   'collections:write:self',
   'collections:read:private',
+  // buzz:read:self — INCLUDED here too (see DEV_TOKEN_SCOPE_ALLOWLIST rationale):
+  // self-bound to the dev's OWN ledger via the token subject, a pure READ, no
+  // consent round-trip needed in the author's own dev-tunnel preview. Deliberately
+  // WITHHELD from the mod-review sandbox below (a mod previewing another author's
+  // app must not leak the mod's own balance).
+  'buzz:read:self',
 ]);
 
 /**

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -799,9 +799,9 @@ describe('POST /api/v1/blocks/dev-token', () => {
             page: { title: 'evil' },
             scopes: [
               'models:read:self', // legit → kept
-              'social:tip:self', // dev-excluded + page-forbidden → stripped
+              'social:tip:self', // dev-excluded (money OUT) → stripped
               'block:settings:write', // dev-excluded → stripped
-              'buzz:read:self', // page-forbidden → stripped
+              'buzz:read:self', // own-ledger read, in dev allowlist → kept
               'totally:unknown:scope', // not a known block scope → stripped
             ],
           },
@@ -812,12 +812,13 @@ describe('POST /api/v1/blocks/dev-token', () => {
 
       expect(res._getStatusCode()).toBe(200);
       const arg = mockSign.mock.calls[0][0];
-      // Only the legit scope + the force-granted user:read:self survive — proving
-      // the un-reviewed manifest cannot escalate past the dev belt.
-      expect(arg.scopes).toEqual(['models:read:self', 'user:read:self']);
+      // The legit reads (incl. self-bound buzz:read:self) + the force-granted
+      // user:read:self survive; the ESCALATED money/write/unknown scopes are
+      // stripped — proving the un-reviewed manifest cannot escalate past the belt.
+      expect(arg.scopes).toEqual(['buzz:read:self', 'models:read:self', 'user:read:self']);
       expect(arg.scopes).not.toContain('social:tip:self');
       expect(arg.scopes).not.toContain('block:settings:write');
-      expect(arg.scopes).not.toContain('buzz:read:self');
+      expect(arg.scopes).toContain('buzz:read:self');
       expect(arg.scopes).not.toContain('totally:unknown:scope');
     });
 
@@ -1153,9 +1154,9 @@ describe('POST /api/v1/blocks/dev-token', () => {
         slug: 'brand-new-app',
         scopes: [
           'models:read:self', // legit → kept
-          'social:tip:self', // dev-excluded + page-forbidden → stripped
+          'social:tip:self', // dev-excluded (money OUT) → stripped
           'block:settings:write', // dev-excluded → stripped
-          'buzz:read:self', // page-forbidden → stripped
+          'buzz:read:self', // own-ledger read, in dev allowlist → kept
           'totally:unknown', // not a known block scope → stripped
         ],
       });
@@ -1163,12 +1164,13 @@ describe('POST /api/v1/blocks/dev-token', () => {
 
       expect(res._getStatusCode()).toBe(200);
       const arg = mockSign.mock.calls[0][0];
-      // Only the legit scope + force-granted user:read:self survive — proving the
-      // un-reviewed CLIENT manifest cannot escalate past the dev belt.
-      expect(arg.scopes).toEqual(['models:read:self', 'user:read:self']);
+      // The legit reads (incl. self-bound buzz:read:self) + force-granted
+      // user:read:self survive; the ESCALATED money/write/unknown scopes are
+      // stripped — proving the un-reviewed CLIENT manifest cannot escalate.
+      expect(arg.scopes).toEqual(['buzz:read:self', 'models:read:self', 'user:read:self']);
       expect(arg.scopes).not.toContain('social:tip:self');
       expect(arg.scopes).not.toContain('block:settings:write');
-      expect(arg.scopes).not.toContain('buzz:read:self');
+      expect(arg.scopes).toContain('buzz:read:self');
       expect(arg.scopes).not.toContain('totally:unknown');
     });
 


### PR DESCRIPTION
## Summary

Fixes two related App Blocks **dev-tunnel consent** issues reported by an app author. Dev-tunnel / mod-gated (dark) — no change to the prod approved-app consent path.

## Issue A (server — the real fix): `buzz:read:self` missing from the dev-mint allowlists

`dev-scoped-mint.service.ts` defines three scope allowlists the mint clamp filters against. `buzz:read:self` was in **none** of them, so in the dev-tunnel the clamp stripped it before consent — the block's `REQUEST_CONSENT` resolved an empty `missingScopes`, and the app's "Allow ledger access" button looked dead.

**Fix:** add `buzz:read:self` to **`DEV_TOKEN_SCOPE_ALLOWLIST`** (bearer dev-token) and **`TUNNEL_HOST_MINT_SCOPE_ALLOWLIST`** (cookie dev-tunnel host-mint) only.

Why it's safe:
- **Self-bound to the dev's OWN ledger.** The dev-mint signs the token with the authenticated dev's `userId` as subject, and the buzz-read bridge (`authorizeBlockBuzzRead`) derives `userId` off `claims.sub` — never body input — then re-checks `assertViewerIsAppDeveloper`. So the scope reads only the dev's own balance/ledger/earnings, no third-party financial data, no consent round-trip needed.
- **Pure read.** All `buzz:read:self` handlers require `TokenScope.BuzzRead`; no money moves. The money-OUT scope `social:tip:self` (`TokenScope.SocialTip`) stays **excluded everywhere**.
- **Consistent** with the dev allowlists already granting `ai:write:budgeted` (real Buzz *spend*) and `collections:read:private` — forbidding a dev from *reading* their own balance while permitting *spending* it is incoherent.

**Deliberately withheld** from the mod-review sandbox allowlist (`REVIEW_MINT_SCOPE_ALLOWLIST`, unchanged): a mod previewing *someone else's* unapproved app must not leak the mod's own balance.

## Issue B (client — defensive UX): un-grantable `REQUEST_CONSENT` dropped silently

`PageBlockHost` previously no-op'd whenever the grantable set was empty, so a request for a permission that was clamped/withheld at mint (un-grantable in this preview) vanished silently — the app looked broken.

Now it distinguishes, deterministically:
- **Benign** — every requested scope is already granted (a block re-requesting a held scope) → keep the silent no-op.
- **Un-grantable** — a requested scope is neither currently granted nor addable via consent (`missingScopes`) → surface a "permission isn't available in this preview" toast.

The distinction uses the block's advisory `scopes` hint **only to decide whether to inform the user** — never to widen the grant (still bounded server-side to `missingScopes`). `reviewMode` stays silent. The decision logic is extracted to a pure, unit-tested helper (`resolveUngrantableConsentScopes`).

## Tests

- `dev-scoped-mint.service.test.ts`: `buzz:read:self` ∈ both dev allowlists, ∉ mod-review sandbox; `social:tip:self` ∉ all; a dev-tunnel manifest requesting `buzz:read:self` keeps the scope through the clamp; the sandbox strips it.
- `dev-token.test.ts`: R1 escalation-defense tests updated — `buzz:read:self` now legitimately survives the bearer path; money/write/unknown scopes still stripped.
- `pageBlockHostLogic.test.ts`: full coverage of the un-grantable/benign/grantable/no-hint cases for the new helper.
- `PageBlockHost.browser.test.tsx`: un-grantable request toasts (no dialog); benign no-op neither toasts nor dialogs; `reviewMode` stays silent.

All targeted unit + browser tests pass (129 unit + 25 browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
