### PR TITLE
test: restore unit baseline — stub newly-called deps in challenge/image-scan suites

### DIFF
--- a/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
+++ b/src/__tests__/pages/api/webhooks/image-scan-result.test.ts
@@ -102,6 +102,12 @@ vi.mock('~/server/redis/caches', () => ({
   tagIdsForImagesCache: {
     refresh: vi.fn().mockResolvedValue(undefined),
   },
+  // updateImage() busts the per-user image/video count cache on the success path;
+  // without this export the mocked module throws and handleSuccess never reaches res.status(200).
+  userImageVideoCountCaches: {
+    bust: vi.fn().mockResolvedValue(undefined),
+    refresh: vi.fn().mockResolvedValue(undefined),
+  },
   tagCache: {
     bust: vi.fn().mockResolvedValue(undefined),
   },

--- a/src/server/notifications/__tests__/challenge-cancelled-notification.test.ts
+++ b/src/server/notifications/__tests__/challenge-cancelled-notification.test.ts
@@ -43,6 +43,10 @@ const {
   mockDbWrite: {
     challenge: {
       update: vi.fn().mockResolvedValue(undefined),
+      // voidChallenge claims the row Active/Scheduled -> Cancelled via updateMany and
+      // requires claimed.count === 1 to proceed to the refund + entrant-notification path;
+      // default to a successful single-row claim so the tests exercise that path.
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       // Final-prize recompute (User source, endChallengeAndPickWinners only) — null distribution
       // skips it so the zero-winner tests exercise the notification branch unchanged.
       findUnique: vi.fn().mockResolvedValue({ prizePool: 0, prizeDistribution: null }),
@@ -200,9 +204,12 @@ describe('voidChallenge — entrant cancellation notification', () => {
     expect(logCall.challengeId).toBe(7);
     expect(logCall.message).toBe('transient DB error');
     // The refund already happened, so money movement isn't blocked by the notification failure —
-    // the status update must still run.
-    expect(mockDbWrite.challenge.update).toHaveBeenCalledWith({
-      where: { id: 7 },
+    // the status claim (Active/Scheduled -> Cancelled) must still have run.
+    expect(mockDbWrite.challenge.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: 7,
+        status: { in: [ChallengeStatus.Active, ChallengeStatus.Scheduled] },
+      },
       data: { status: ChallengeStatus.Cancelled },
     });
   });


### PR DESCRIPTION
## What & why

CI `preview / unit-tests` was red on fresh PRs. Two **unrelated** fresh PRs — #3183 (system-cache) and #3178 (trpc-client) — failed the **same** unit suites, which means this is a **baseline break on `main`**, not any one branch. The report-only label let breaks accumulate. This restores the unit baseline.

Both failures are **mock gaps**: production code added a new call that the test's module mock didn't stub, so the code threw before reaching its assertion. **Test-only changes; no production code touched.**

## Per-suite root cause + fix + evidence

### 1. `src/server/notifications/__tests__/challenge-cancelled-notification.test.ts`
`voidChallenge()` now claims the row `Active/Scheduled -> Cancelled` via `dbWrite.challenge.updateMany(...)` (replacing the old `.update(...)` status flip; see `challenge.service.ts:2494`), but the `dbWrite` mock only stubbed `.update`/`.findUnique`.

- Error: `TypeError: __vite_ssr_import_2__.dbWrite.challenge.updateMany is not a function`
- Fix: added `updateMany: vi.fn().mockResolvedValue({ count: 1 })` so the claim succeeds (`claimed.count === 1`) and the refund + entrant-notification path is exercised.
- Also updated the "best-effort" test's **stale assertion** from `challenge.update` → `challenge.updateMany` — `voidChallenge` no longer calls `.update` on that path, so the old assertion checked a call that never happens. The corrected assertion preserves the test's real intent: the status flip to `Cancelled` still completes even when the notification send throws.

```
BEFORE:  Tests  3 failed | 4 passed (7)   — all 3 "updateMany is not a function"
AFTER:   Tests  7 passed (7)
```

### 2. `src/__tests__/pages/api/webhooks/image-scan-result.test.ts`
`updateImage()` (`image-scan-result.ts:264`) now calls `userImageVideoCountCaches.bust(image.userId)` from `~/server/redis/caches`, but the test's mock of that module didn't export `userImageVideoCountCaches`. The mocked module threw, `handleSuccess` never reached `res.status(200)`, so the handler returned 500.

- Real stack (before the 200-assertion): `Error: [vitest] No "userImageVideoCountCaches" export is defined on the "~/server/redis/caches" mock` → `at updateImage (image-scan-result.ts:264:13)` → `at handleSuccess (…:240:5)`
- Fix: added `userImageVideoCountCaches: { bust, refresh }` to the mock so the success path completes and the real `200` / `dbWrite.image.update` assertions run.

```
BEFORE:  Tests  4 failed | 2 passed (6)   — all 4 "expected vi.fn() to be called with [ 200 ]"
AFTER:   Tests  6 passed (6)
```

## Real code regression? None found — and the blocks suites are NOT a baseline break

The task flagged the blocks endpoint suites (`shared-storage-increment-endpoint.test.ts`, `tip-endpoint.test.ts`, "expected 500 to be 200") as possible baseline failures to root-cause. **On current `origin/main` they PASS** — both in isolation and grouped with the two suites above (`28/28`). The 500s those PRs saw were on their older bases where the break was live; it has since been fixed upstream. So there is nothing to fix for blocks here, and I deliberately did **not** touch them or mask anything.

All runs performed locally with `vitest run --project unit <file>` on the branch tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
