### PR TITLE
fix(app-blocks/security): stop block buzz projection re-leaking reward counterparty/IP via externalTransactionId

### DIFF
--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3899,7 +3899,8 @@ export const blocksRouter = router({
    * Response rows carry the SECURITY-HARDENED projection
    * (projectBlockBuzzTransaction): `details` allowlisted to entity-attribution
    * only (no passthrough / no stripePaymentIntentId), `externalTransactionId`
-   * nulled for payment-processor-reference rows, counterparties stripped to
+   * nulled by default (default-deny — processor refs AND reward rows whose
+   * ext-id embeds counterparty/IP identity), counterparties stripped to
    * `{ id, username }`, `type` serialized as its name.
    */
   getMyBuzzTransactions: publicProcedure

--- a/src/server/services/blocks/__tests__/block-buzz-read.projection.test.ts
+++ b/src/server/services/blocks/__tests__/block-buzz-read.projection.test.ts
@@ -31,37 +31,51 @@ function row(over: Record<string, unknown> = {}) {
   } as never;
 }
 
-describe('projectExternalTransactionId', () => {
-  it('nulls every money-movement / external-financial type', () => {
-    for (const type of [
-      TransactionType.Purchase,
-      TransactionType.Refund,
-      TransactionType.ChargeBack,
-      TransactionType.Withdrawal,
+describe('projectExternalTransactionId (default-deny)', () => {
+  // ── The identity re-leak this fix closes (leak-class B) ───────────────────
+  // rewards/base.reward.ts `sendAward` writes EVERY reward row's ext-id as
+  // `${eventType}:${forId}-${toUserId}-${byUserId}` (the reactor/collector id),
+  // or `${eventType}:${forId}-${ip}` for referral rows. The `details` allowlist
+  // already drops `details.byUserId`, so exposing this ext-id would be a
+  // redaction bypass. It MUST NOT reach a block.
+  it('nulls a reward ext-id embedding the counterparty byUserId (no identity tail)', () => {
+    const projected = projectExternalTransactionId('goodContent:image:123-456-789');
+    expect(projected).toBeNull();
+    // Belt-and-suspenders: whatever the projection returns must not carry the id.
+    expect(projected ?? '').not.toContain('456');
+    expect(projected ?? '').not.toContain('789');
+  });
+
+  it('nulls a referral reward ext-id embedding an IP (no IP tail)', () => {
+    const projected = projectExternalTransactionId('userReferred:123-203.0.113.7');
+    expect(projected).toBeNull();
+    expect(projected ?? '').not.toContain('203.0.113.7');
+  });
+
+  it('nulls every money-movement / external-financial processor ref', () => {
+    for (const value of [
+      'pi_stripe_secret_123', // Stripe paymentIntent.id (Purchase)
+      'PAYPAL_ORDER:5AB12345', // PayPal order (Purchase)
+      'processor-ref-xyz', // Refund / ChargeBack / Withdrawal bare ref
     ]) {
-      expect(projectExternalTransactionId(type, 'processor-ref-xyz'), TransactionType[type]).toBeNull();
+      expect(projectExternalTransactionId(value), value).toBeNull();
     }
   });
 
-  it('nulls a merch Shopify ref even under type Reward (cross-type value guard)', () => {
-    expect(projectExternalTransactionId(TransactionType.Reward, 'merchPurchase:SHOP-9981')).toBeNull();
+  it('nulls a merch Shopify ref (merchPurchase:<shopifyOrderId>)', () => {
+    expect(projectExternalTransactionId('merchPurchase:SHOP-9981')).toBeNull();
   });
 
-  it('keeps civitai-internal classifiers on non-money-movement types', () => {
-    expect(
-      projectExternalTransactionId(TransactionType.Reward, 'challenge-winner-prize-2026-07-place-1')
-    ).toBe('challenge-winner-prize-2026-07-place-1');
-    expect(projectExternalTransactionId(TransactionType.Reward, 'referral-reward:1234')).toBe(
-      'referral-reward:1234'
-    );
-    expect(projectExternalTransactionId(TransactionType.Bounty, 'bounty-award-88-yellow')).toBe(
-      'bounty-award-88-yellow'
-    );
-    expect(projectExternalTransactionId(TransactionType.Tip, 'ext-1')).toBe('ext-1');
+  it('nulls civitai-internal reward/prize classifiers (default-deny — dashboard reads details.type, not ext-id)', () => {
+    expect(projectExternalTransactionId('challenge-winner-prize-2026-07-place-1')).toBeNull();
+    expect(projectExternalTransactionId('referral-reward:1234')).toBeNull();
+    expect(projectExternalTransactionId('bounty-award-88-yellow')).toBeNull();
+    expect(projectExternalTransactionId('ext-1')).toBeNull();
   });
 
-  it('normalizes undefined to null', () => {
-    expect(projectExternalTransactionId(TransactionType.Tip, undefined)).toBeNull();
+  it('normalizes null / undefined to null', () => {
+    expect(projectExternalTransactionId(undefined)).toBeNull();
+    expect(projectExternalTransactionId(null)).toBeNull();
   });
 });
 
@@ -102,16 +116,42 @@ describe('projectBlockBuzzTransaction', () => {
     });
   });
 
-  it('nulls externalTransactionId on a Purchase row (processor ref), keeps it on a Reward classifier', () => {
+  it('nulls externalTransactionId by default — processor refs AND reward classifiers', () => {
     expect(
       projectBlockBuzzTransaction(row({ type: TransactionType.Purchase, externalTransactionId: 'pi_x' }))
         .externalTransactionId
     ).toBeNull();
+    // Reward classifier is nulled too now (default-deny) — dashboard reads details.type.
     expect(
       projectBlockBuzzTransaction(
         row({ type: TransactionType.Reward, externalTransactionId: 'challenge-winner-prize-1' })
       ).externalTransactionId
-    ).toBe('challenge-winner-prize-1');
+    ).toBeNull();
+  });
+
+  it('never re-leaks the reward counterparty byUserId via ext-id (redaction-bypass guard)', () => {
+    // The row-level twin of the sendAward leak: details.byUserId is dropped AND
+    // the identity-bearing ext-id must not carry it back through the ext-id field.
+    const out = projectBlockBuzzTransaction(
+      row({
+        type: TransactionType.Reward,
+        details: { type: 'goodContent:image', forId: 123, byUserId: 789 },
+        externalTransactionId: 'goodContent:image:123-456-789',
+      })
+    );
+    const details = out.details as Record<string, unknown>;
+    expect(details).not.toHaveProperty('byUserId');
+    expect(out.externalTransactionId).toBeNull();
+    // Nothing anywhere in the projected row carries the counterparty id.
+    expect(JSON.stringify(out)).not.toContain('789');
+  });
+
+  it('never re-leaks a referral IP via ext-id', () => {
+    const out = projectBlockBuzzTransaction(
+      row({ type: TransactionType.Reward, externalTransactionId: 'userReferred:123-203.0.113.7' })
+    );
+    expect(out.externalTransactionId).toBeNull();
+    expect(JSON.stringify(out)).not.toContain('203.0.113.7');
   });
 
   it('passes a null details through unchanged', () => {

--- a/src/server/services/blocks/block-buzz-read.projection.ts
+++ b/src/server/services/blocks/block-buzz-read.projection.ts
@@ -55,27 +55,37 @@ import type { getUserBuzzTransactions } from '~/server/services/buzz.service';
  *      reward (reactor/collector identity); reactions are anonymous on the
  *      site, so the block must not see it either.
  *
- *  (B) `externalTransactionId` leak class — the field is DUAL-USE and
- *      TransactionType does NOT cleanly separate the two uses (an evidence-based
- *      sweep of every `externalTransactionId` assignment in the buzz + payment
- *      services). It holds a raw payment-processor / external-financial
- *      reference on the money-movement types, and a civitai-internal
- *      prize/reward classifier elsewhere:
- *        • Purchase   – every external buy-in lands here via grantBuzzPurchase /
- *                       completeStripeBuzzPurchase: Stripe paymentIntent.id +
- *                       invoice.id, Paddle transaction.id, `PAYPAL_ORDER:<id>`,
- *                       NOWPayments/Coinbase/EmerchantPay order ids, subscription
- *                       payment refs.
- *        • Refund     – a PayPal reversal stores the BARE PayPal transaction id
- *                       (paypal.service) with no distinguishing prefix, so the
- *                       whole type is nulled.
- *        • ChargeBack / Withdrawal – payment-dispute / cash-out financial-movement
- *                       types; nulled defensively (no dashboard classifier need;
- *                       future processor/bank refs land here by convention).
- *      Plus the ONE cross-type value: merch grants a Shopify order id under type
- *      *Reward* as `merchPurchase:<shopifyOrderId>` (merch.service), nulled by
- *      prefix. Every OTHER row keeps its classifier (challenge-entry/winner
- *      prizes, `referral-reward:*`, generic reward-event ids, bounty/comp tags).
+ *  (B) `externalTransactionId` leak class — DEFAULT-DENY. The field is dual-use
+ *      and TransactionType does NOT cleanly separate the uses (an evidence-based
+ *      sweep of every `externalTransactionId` writer in the buzz + payment +
+ *      rewards services), and — critically — NEITHER use is block-safe:
+ *        • money-movement rows carry a raw payment-processor / bank reference:
+ *          Purchase (Stripe paymentIntent.id + invoice.id, Paddle transaction.id,
+ *          `PAYPAL_ORDER:<id>`, NOWPayments/Coinbase/EmerchantPay order ids,
+ *          subscription refs), Refund (bare PayPal transaction id), ChargeBack,
+ *          Withdrawal (processor/bank cash-out refs).
+ *        • reward rows carry a civitai-internal classifier that EMBEDS
+ *          COUNTERPARTY IDENTITY. `sendAward` (rewards/base.reward.ts) writes
+ *          EVERY reward row's ext-id as
+ *          `${eventType}:${forId}-${toUserId}-${byUserId}` — the reactor /
+ *          collector `byUserId` — or, for referral rows (`userReferred` /
+ *          `refereeCreated`), `${eventType}:${forId}-${ip}` — an IP. The
+ *          `details` allowlist in (A) deliberately DROPS `details.byUserId`
+ *          (reactions are anonymous on-site and must not reach an untrusted
+ *          block), so exposing this ext-id would be a REDACTION BYPASS of that
+ *          very defense. Other reward/prize ext-ids (`challenge-*`,
+ *          `referral-reward:*`, `bounty-award-*`, comp/settlement tags) embed the
+ *          row-owner's own id and are of no dashboard use.
+ *      The block dashboard sources its income/attribution classifier from the
+ *      allowlisted `details.type` / `forId` (leak-class A), NEVER from ext-id.
+ *      So the projection nulls `externalTransactionId` for EVERY row unless its
+ *      value is on an explicit safe-value allowlist below — which is currently
+ *      EMPTY. This mirrors leak-class (A): exposure is only ever an explicit,
+ *      tested allowlist addition, and no identity-bearing ext-id — reward
+ *      counterparty/IP today, or any future writer under ANY TransactionType —
+ *      can leak by omission (the field is default-ALLOW no longer). The SDK
+ *      already types `externalTransactionId: string | null` and its mock host
+ *      nulls it, so nulling it here is contract-safe.
  */
 
 /**
@@ -103,30 +113,30 @@ export function isDashboardClassifierType(type: unknown): type is string {
   return DASHBOARD_CLASSIFIER_TYPE_PREFIXES.some((p) => type.startsWith(p));
 }
 
-const EXTERNAL_TXN_ID_SENSITIVE_TYPES = new Set<TransactionType>([
-  TransactionType.Purchase,
-  TransactionType.Refund,
-  TransactionType.ChargeBack,
-  TransactionType.Withdrawal,
-]);
-const EXTERNAL_TXN_ID_SENSITIVE_VALUE_PREFIXES = ['merchPurchase:'];
+/**
+ * Safe-value allowlist for `externalTransactionId` — value shapes PROVEN to be
+ * non-identity classifiers the block dashboard needs (matched by prefix). It is
+ * deliberately EMPTY: the dashboard reads its income/attribution classifier from
+ * the allowlisted `details.type` / `forId` (leak-class A), never from ext-id,
+ * and every reward-row ext-id embeds counterparty/IP identity (base.reward.ts).
+ * Adding a shape here is an explicit, tested decision — see leak-class (B) above.
+ */
+const EXTERNAL_TXN_ID_SAFE_VALUE_PREFIXES: readonly string[] = [];
 
 /**
- * Null `externalTransactionId` wherever it holds a payment-processor /
- * external-financial reference (money-movement types + the merch Shopify value);
- * pass it through where it is a civitai-internal prize/reward classifier.
+ * Block-safe projection of `externalTransactionId`: DEFAULT-DENY (see leak-class
+ * (B) above). Returns the value only if it is on the safe-value allowlist;
+ * otherwise `null`. Type-agnostic on purpose — the field is unsafe on money
+ * types (processor refs) AND on reward types (counterparty/IP identity), so
+ * nothing is exposed by omission.
  */
 export function projectExternalTransactionId(
-  type: TransactionType,
   externalTransactionId: string | null | undefined
 ): string | null {
-  if (EXTERNAL_TXN_ID_SENSITIVE_TYPES.has(type)) return null;
-  if (
-    externalTransactionId != null &&
-    EXTERNAL_TXN_ID_SENSITIVE_VALUE_PREFIXES.some((p) => externalTransactionId.startsWith(p))
-  )
-    return null;
-  return externalTransactionId ?? null;
+  if (externalTransactionId == null) return null;
+  return EXTERNAL_TXN_ID_SAFE_VALUE_PREFIXES.some((p) => externalTransactionId.startsWith(p))
+    ? externalTransactionId
+    : null;
 }
 
 type BlockBuzzTransactionRow = Awaited<
@@ -139,7 +149,7 @@ type BlockBuzzTransactionRow = Awaited<
  *  - `details` allowlisted to the entity-attribution + classifier fields (drop
  *    passthrough, incl. `stripePaymentIntentId` and `byUserId`; `forId` only
  *    when numeric — the adWatched token guard)
- *  - `externalTransactionId` stripped for processor-reference rows (see above)
+ *  - `externalTransactionId` nulled by default (safe-value allowlist; see (B))
  *  - counterparties projected to `{ id, username }` (no other `getUsers` fields)
  */
 export function projectBlockBuzzTransaction(row: BlockBuzzTransactionRow) {
@@ -174,7 +184,7 @@ export function projectBlockBuzzTransaction(row: BlockBuzzTransactionRow) {
               : undefined,
         }
       : d,
-    externalTransactionId: projectExternalTransactionId(t.type, externalTransactionId),
+    externalTransactionId: projectExternalTransactionId(externalTransactionId),
     toUser: toUser ? { id: toUser.id, username: toUser.username } : undefined,
     fromUser: fromUser ? { id: fromUser.id, username: fromUser.username } : undefined,
   };


### PR DESCRIPTION
## Summary

The block-facing buzz projection (`blocks.getMyBuzzTransactions`, mediated by `projectBlockBuzzTransaction`) re-leaked identity that the `details` allowlist deliberately redacts — via `externalTransactionId`.

`sendAward` (`src/server/rewards/base.reward.ts`) writes **every** reward row's `externalTransactionId` as an identity-bearing string:

- `` `${eventType}:${forId}-${toUserId}-${byUserId}` `` — the `byUserId` is the reactor/collector (a **different** user), and
- `` `${eventType}:${forId}-${ip}` `` for referral rows (`userReferred` / `refereeCreated`) — an **IP address**.

The projection's `details` allowlist already **drops `details.byUserId`** (reactions are anonymous on-site; the module comment says it "must not reach an untrusted installed block"). But `projectExternalTransactionId` was a **denylist** — it only nulled `externalTransactionId` for four money-movement `TransactionType`s (Purchase/Refund/ChargeBack/Withdrawal) plus the `merchPurchase:` value-prefix. `TransactionType.Reward` was **default-allow**, so the identity-bearing ext-id passed through verbatim — a redaction bypass of the very `byUserId`/IP the `details` projection removed.

App Blocks is **mod-gated / dark** (not GA), so exposure is limited, but this is a real self-read identity leak into an untrusted third-party block iframe.

## `externalTransactionId`-writer sweep

Evidence-based sweep (`git grep -n externalTransactionId src/server`), classified by whether the value embeds a **counterparty** identity (another user / IP) reachable by a block viewer reading their own ledger:

| Writer | TransactionType | Value shape | Counterparty identity? |
|---|---|---|---|
| `rewards/base.reward.ts` `sendAward` | **Reward** | `${type}:${forId}-${toUserId}-${byUserId}` / `${type}:${forId}-${ip}` | **YES — `byUserId` (reactor/collector) or referral IP** |
| `services/referral.service.ts` | Reward / ChargeBack | `referral-reward:${reward.id}` / `referral-clawback:${reward.id}` | No (reward-row id) |
| `merch.service.ts` | Reward | `merchPurchase:${shopifyOrderId}` | No (Shopify order — already nulled) |
| `games/daily-challenge/*`, `challenge.service.ts` | Reward | `challenge-*-${challengeId}-${userId}` | No (row-owner's own id) |
| `bountyEntry.service.ts`, `prepare-bounties.ts` | Bounty | `bounty-award-${id}-${accountType}` | No (bounty id) |
| `jobs/creators-program-jobs.ts`, `deliver-creator-compensation.ts`, `creator-program.service.ts` | Reward/Comp | `comp-*`/`settlement-*`/`extraction-*-${userId}` | No (row-owner's own id) |
| `cosmetic-shop.service.ts`, `creator-shop.service.ts` | Purchase | `cosmetic-purchase-${userId}-...` | No (own id) + money type |
| Payment services (Stripe/Paddle/PayPal/Coinbase/NOWPayments/EmerchantPay/withdrawal) | Purchase/Refund/ChargeBack/Withdrawal | processor/bank refs | Not identity, but sensitive (already nulled) |

**Finding:** the only ext-id that embeds a *counterparty's* identity is the `sendAward` Reward/referral row. All other reward/prize ext-ids embed the **row-owner's own** id (harmless to a self-read) or a processor ref (already nulled). The block read path is **only** the single tRPC bridge `blocks.getMyBuzzTransactions` (no separate block-JWT REST endpoint); both would route through `projectBlockBuzzTransaction` regardless.

## Fix — default-deny (consistent with the module's `details` philosophy)

`details.type` handling in this module is a default-**deny** allowlist precisely so "a new sensitive tag can never leak by omission." `externalTransactionId` was the inconsistent default-**allow**. This flips it:

`projectExternalTransactionId(value)` now nulls `externalTransactionId` for **every** row unless its value is on an explicit `EXTERNAL_TXN_ID_SAFE_VALUE_PREFIXES` allowlist — **currently empty**, because the dashboard sources its income/attribution classifier from the already-allowlisted `details.type` / `forId`, never from ext-id. The `type` param is dropped: with default-deny, per-type reasoning is unnecessary and a money-type row with an unexpected value is nulled too. No identity-bearing ext-id — reward counterparty/IP today, or any future writer under any `TransactionType` — can reach a block by omission.

**Contract-safe:** the SDK types `externalTransactionId: string | null` and its mock host nulls it; the in-repo sweep confirms no block-dashboard/component consumer reads block ext-id (the only `externalTransactionId` UI consumer, `PrepaidBuzzTransactions.tsx`, is the membership dashboard on its own tRPC data, not the block projection).

## Tests

`src/server/services/blocks/__tests__/block-buzz-read.projection.test.ts` (31 pass):

- **New:** a `Reward` row `goodContent:image:123-456-789` → projected ext-id `null` and the row's JSON contains no `456`/`789`; `details.byUserId` still dropped.
- **New:** a referral `Reward` row `userReferred:123-203.0.113.7` → ext-id `null`, no IP anywhere in the projected row.
- **Preserved:** Purchase/Refund/ChargeBack/Withdrawal processor refs still nulled; `merchPurchase:` still nulled; the `details.type`/`forId` dashboard allowlist and the `details.byUserId` drop unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
