### PR TITLE
fix(app-blocks): follow orchestrator output-blob redirects when publishing generation outputs

### DIFF
--- a/src/server/services/blocks/__tests__/block-image-upload.service.test.ts
+++ b/src/server/services/blocks/__tests__/block-image-upload.service.test.ts
@@ -61,7 +61,11 @@ function imageResponse(
     status: 200,
     ok: true,
     headers: { get: (k: string) => lower[k.toLowerCase()] ?? null },
-    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    arrayBuffer: async () => {
+      const ab = new ArrayBuffer(bytes.byteLength);
+      new Uint8Array(ab).set(bytes);
+      return ab;
+    },
     body: null,
   };
 }

--- a/src/server/services/blocks/__tests__/block-image-upload.service.test.ts
+++ b/src/server/services/blocks/__tests__/block-image-upload.service.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * App Blocks (Phase-1 seam) — `persistBlockWorkflowOutputImage` redirect-follow
+ * regression tests.
+ *
+ * The real orchestrator output-blob url returns a `301` to a SAME-host content url
+ * (a relative `Location`) before the `200 image/jpeg`. The fetch used to run with
+ * `redirect:'error'`, which THREW on that normal 301 → every benchmark-grid cell
+ * publish failed with "could not fetch the generation output to publish". The fix
+ * follows redirects MANUALLY up to `MAX_OUTPUT_REDIRECTS` hops, re-validating the
+ * host against `isAllowedOutputHost` BEFORE each hop opens a socket, so the
+ * Civitai-hosts-only SSRF bound (PR #3187) still holds for every hop.
+ *
+ * All network/store/DB deps are mocked — no real fetch / S3 / Prisma / image.service.
+ */
+
+const { mockUpload, mockCreateImage } = vi.hoisted(() => ({
+  mockUpload: vi.fn(async (..._a: unknown[]): Promise<{ key: string }> => ({ key: 'uuid-key' })),
+  mockCreateImage: vi.fn(async (..._a: unknown[]): Promise<{ id: number }> => ({ id: 4242 })),
+}));
+
+// The service statically imports dbRead + getEdgeUrl; stub both so the module
+// graph never touches a real Prisma client / cf-images env.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (u: string) => `edge:${u}` }));
+vi.mock('~/utils/s3-utils', () => ({ uploadImageBufferToStore: mockUpload }));
+// `createImage` is dynamically imported inside the service.
+vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage }));
+
+// A minimal fetch Response stand-in. A 3xx carries a `location` header; a 2xx
+// carries the body bytes. `body.cancel` is asserted to run on every redirect hop
+// (the service frees the socket before the next hop).
+type MockResponse = {
+  status: number;
+  ok: boolean;
+  headers: { get: (k: string) => string | null };
+  arrayBuffer: () => Promise<ArrayBuffer>;
+  body: { cancel: ReturnType<typeof vi.fn> } | null;
+};
+
+function redirectResponse(status: number, location: string | null): MockResponse {
+  return {
+    status,
+    ok: false,
+    headers: { get: (k: string) => (k.toLowerCase() === 'location' ? location : null) },
+    arrayBuffer: async () => new ArrayBuffer(0),
+    body: { cancel: vi.fn(async () => undefined) },
+  };
+}
+
+// Valid JPEG: magic bytes ff d8 ff, padded past the 12-byte sniff minimum.
+const JPEG_BYTES = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0]), Buffer.alloc(16, 0)]);
+
+function imageResponse(
+  bytes: Buffer = JPEG_BYTES,
+  headers: Record<string, string> = {}
+): MockResponse {
+  const lower = Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    status: 200,
+    ok: true,
+    headers: { get: (k: string) => lower[k.toLowerCase()] ?? null },
+    arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    body: null,
+  };
+}
+
+// Mirror of the service's module-private MAX_OUTPUT_REDIRECTS (the too-many-
+// redirects test below pins the bound; the service const isn't exported).
+const MAX_OUTPUT_REDIRECTS_EXPECTED = 3;
+
+const fetchMock = vi.fn();
+
+async function callPersist(imageUrl: string) {
+  const { persistBlockWorkflowOutputImage } = await import('../block-image-upload.service');
+  return persistBlockWorkflowOutputImage({
+    imageUrl,
+    width: 1024,
+    height: 1024,
+    userId: 7,
+    appId: 'oc_app_1',
+  });
+}
+
+async function captureError(fn: () => Promise<unknown>): Promise<{ code?: string; message?: string }> {
+  try {
+    await fn();
+    throw new Error('expected the publish to reject, but it resolved');
+  } catch (err) {
+    const e = err as { code?: string; message?: string };
+    return { code: e.code, message: e.message };
+  }
+}
+
+describe('persistBlockWorkflowOutputImage — orchestrator output-blob redirect follow', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+    mockUpload.mockReset().mockResolvedValue({ key: 'uuid-key' });
+    mockCreateImage.mockReset().mockResolvedValue({ id: 4242 });
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const OUTPUT_URL = 'https://orchestration.civitai.com/v2/consumer/blobs/abc.jpeg?sig=xyz';
+
+  it('301 same-host → 200 jpeg PUBLISHES (the exact regression this fixes)', async () => {
+    const redirect = redirectResponse(301, '/v2/consumer/blobs/content/b64payload');
+    fetchMock.mockResolvedValueOnce(redirect).mockResolvedValueOnce(imageResponse());
+
+    const res = await callPersist(OUTPUT_URL);
+
+    expect(res).toEqual({ imageId: 4242 });
+    // Two fetches: the 301, then the resolved SAME-host content url.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toBe(OUTPUT_URL);
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://orchestration.civitai.com/v2/consumer/blobs/content/b64payload'
+    );
+    // Both hops used manual redirect handling.
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ redirect: 'manual' });
+    // The redirect body's socket was freed before the next hop.
+    expect(redirect.body?.cancel).toHaveBeenCalledTimes(1);
+    // The image was stored + a bare row created.
+    expect(mockUpload).toHaveBeenCalledTimes(1);
+    expect(mockUpload.mock.calls[0][1]).toMatchObject({ contentType: 'image/jpeg' });
+    expect(mockCreateImage).toHaveBeenCalledTimes(1);
+    expect(mockCreateImage.mock.calls[0][0]).toMatchObject({
+      url: 'uuid-key',
+      mimeType: 'image/jpeg',
+      userId: 7,
+      metadata: expect.objectContaining({ blockPublishedAppId: 'oc_app_1' }),
+    });
+  });
+
+  it('direct 200 (no redirect) still publishes', async () => {
+    fetchMock.mockResolvedValueOnce(imageResponse());
+    const res = await callPersist(OUTPUT_URL);
+    expect(res).toEqual({ imageId: 4242 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mockCreateImage).toHaveBeenCalledTimes(1);
+  });
+
+  it('redirect to an OFF-allowlist host is REJECTED before opening its socket', async () => {
+    // First hop 301s to an attacker host. The second fetch must NEVER happen —
+    // the loop re-validates the host at the TOP of the next iteration.
+    fetchMock.mockResolvedValueOnce(redirectResponse(301, 'https://evil.example.com/x.jpg'));
+
+    const err = await captureError(() => callPersist(OUTPUT_URL));
+    expect(err.code).toBe('BAD_REQUEST');
+    expect(err.message).toBe('output url is not an allowed generation host');
+    // Only the first (allowlisted) fetch ran; the evil host was never fetched.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(mockUpload).not.toHaveBeenCalled();
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('too many redirects (> MAX_OUTPUT_REDIRECTS same-host hops) → BAD_REQUEST', async () => {
+    // Endless same-host 301 chain. The bound stops it at MAX_OUTPUT_REDIRECTS (3):
+    // hops 0,1,2 follow, the 4th 3xx (hops===3) throws — so 4 fetches total.
+    fetchMock.mockResolvedValue(
+      redirectResponse(301, 'https://orchestration.civitai.com/v2/consumer/blobs/next')
+    );
+    const err = await captureError(() => callPersist(OUTPUT_URL));
+    expect(err.code).toBe('BAD_REQUEST');
+    expect(err.message).toBe('could not fetch the generation output to publish');
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_OUTPUT_REDIRECTS_EXPECTED + 1);
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('an off-allowlist STARTING url is rejected with no fetch at all', async () => {
+    const err = await captureError(() => callPersist('https://evil.example.com/x.jpg'));
+    expect(err.code).toBe('BAD_REQUEST');
+    expect(err.message).toBe('output url is not an allowed generation host');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('a 3xx with NO Location header → BAD_REQUEST (unfollowable)', async () => {
+    fetchMock.mockResolvedValueOnce(redirectResponse(302, null));
+    const err = await captureError(() => callPersist(OUTPUT_URL));
+    expect(err.code).toBe('BAD_REQUEST');
+    expect(err.message).toBe('could not fetch the generation output to publish');
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/block-image-upload.service.ts
+++ b/src/server/services/blocks/block-image-upload.service.ts
@@ -68,6 +68,15 @@ export const BLOCK_PUBLISHED_APP_ID_META_KEY = 'blockPublishedAppId' as const;
 const BLOCK_PUBLISH_MAX_BYTES = 40 * 1024 * 1024;
 
 /**
+ * Max redirect hops we follow when fetching a workflow output blob. The real
+ * orchestrator output url returns a `301` to a SAME-host content url (a relative
+ * `Location`), so we must follow at least one hop; the bound stops a redirect loop
+ * from stalling the request. Every hop's host is re-validated against
+ * {@link isAllowedOutputHost} BEFORE its socket opens.
+ */
+const MAX_OUTPUT_REDIRECTS = 3;
+
+/**
  * Is this a supported still-image by MAGIC BYTES (not by the url/extension or a
  * spoofable content-type header)? JPEG / PNG / GIF / WEBP. Returns the canonical
  * content-type so the store upload is labelled from the BYTES, not the response.
@@ -99,10 +108,13 @@ function sniffSupportedImage(b: Buffer): string | null {
  * workflow (`blockWorkflowOwnedByAppUser` + the orchestrator app-tag re-read)
  * and passes it here. The iframe only ever sent a `workflowId` + `imageIndexes`,
  * so it can never inject an arbitrary blob. The fetch is HARDENED: host-
- * allowlisted ({@link isAllowedOutputHost}), redirects DISABLED (`redirect:'error'`
- * — no fetch-then-follow to an off-allowlist host), byte-capped
- * ({@link BLOCK_PUBLISH_MAX_BYTES}), and magic-byte-validated
- * ({@link sniffSupportedImage} — a spoofed content-type can't smuggle a non-image).
+ * allowlisted ({@link isAllowedOutputHost}), redirects FOLLOWED MANUALLY up to
+ * {@link MAX_OUTPUT_REDIRECTS} hops with the host re-validated against
+ * {@link isAllowedOutputHost} BEFORE each hop's socket opens (a real output blob
+ * 301s to a same-host content url, so we must follow it, but a redirect can never
+ * reach an off-allowlist host), byte-capped ({@link BLOCK_PUBLISH_MAX_BYTES}), and
+ * magic-byte-validated ({@link sniffSupportedImage} — a spoofed content-type can't
+ * smuggle a non-image).
  *
  * The store re-upload uses {@link uploadImageBufferToStore} (the B2 image bucket
  * the edge URL + scanner resolve, with the uuid→backend registration awaited) —
@@ -127,23 +139,69 @@ export async function persistBlockWorkflowOutputImage(opts: {
 
   // HARDENED fetch of the orchestrator blob. A rejected host / failed fetch /
   // oversize / non-image is a client-correctable upstream problem — BAD_REQUEST.
-  if (!isAllowedOutputHost(imageUrl)) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'output url is not an allowed generation host',
-    });
-  }
+  //
+  // The real output blob url 301s to a SAME-host content url, so we FOLLOW
+  // redirects manually (up to MAX_OUTPUT_REDIRECTS hops) instead of the browser
+  // `redirect:'error'`/`'follow'`. `redirect:'manual'` in Node/undici exposes the
+  // REAL 3xx status + `location` header (unlike a browser's opaque redirect), and
+  // — critically — we re-validate the host against isAllowedOutputHost at the TOP
+  // of every hop, BEFORE the socket opens, so a redirect can never reach an
+  // off-allowlist host (the SSRF bound holds for every hop, not just the first).
   let response: Response;
-  try {
-    response = await fetch(imageUrl, {
-      redirect: 'error', // never follow a redirect off the allowlisted host
-      signal: AbortSignal.timeout(60_000),
-    });
-  } catch {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: 'could not fetch the generation output to publish',
-    });
+  let currentUrl = imageUrl;
+  let hops = 0;
+  for (;;) {
+    if (!isAllowedOutputHost(currentUrl)) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'output url is not an allowed generation host',
+      });
+    }
+    let hopResponse: Response;
+    try {
+      hopResponse = await fetch(currentUrl, {
+        redirect: 'manual', // follow manually so we can re-validate each hop's host
+        signal: AbortSignal.timeout(60_000),
+      });
+    } catch {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'could not fetch the generation output to publish',
+      });
+    }
+    // A 3xx is the orchestrator's normal same-host content redirect — follow it,
+    // re-validating the resolved host on the next loop iteration.
+    if (hopResponse.status >= 300 && hopResponse.status < 400) {
+      if (hops >= MAX_OUTPUT_REDIRECTS) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'could not fetch the generation output to publish',
+        });
+      }
+      const location = hopResponse.headers.get('location');
+      if (!location) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'could not fetch the generation output to publish',
+        });
+      }
+      let resolved: URL;
+      try {
+        resolved = new URL(location, currentUrl); // resolve relative Location against the hop url
+      } catch {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'could not fetch the generation output to publish',
+        });
+      }
+      // Free the redirect response's socket before opening the next hop.
+      await hopResponse.body?.cancel().catch(() => undefined);
+      currentUrl = resolved.toString();
+      hops += 1;
+      continue;
+    }
+    response = hopResponse;
+    break;
   }
   if (!response.ok) {
     throw new TRPCError({


### PR DESCRIPTION
## Symptom

Publishing a benchmark-grid cell's generation output failed for **every** cell with the error **"could not fetch the generation output to publish"**, blocking the Model-Benchmarking publish flow end-to-end.

## Root cause

`persistBlockWorkflowOutputImage` (in `block-image-upload.service.ts`) fetched the workflow output blob with `redirect: 'error'`, which throws on **any** 3xx response. The real generation output blob url returns a **`301 Moved Permanently`** to a **same-host** content url (a relative `Location`) before serving the final `200 image/jpeg`. That perfectly-normal 301 threw → was caught → the publish surfaced the generic fetch-failure message and never reached the upload/persist step.

This is the *next* bug in the same code path, exposed once #3187 fixed the host allowlist (`isAllowedOutputHost`): with the allowlist passing, the request now reaches the fetch, which then throws on the redirect.

## Fix

Replace the single `redirect: 'error'` fetch with a **bounded manual-redirect loop**:

- `redirect: 'manual'`, up to `MAX_OUTPUT_REDIRECTS = 3` hops. (In Node/undici `redirect: 'manual'` exposes the real 3xx status + `location` header, unlike a browser's opaque redirect.)
- The host is re-validated against `isAllowedOutputHost` at the **top of every hop, before the socket opens** — so a redirect can **never** reach an off-allowlist host. This keeps the #3187 Civitai-hosts-only SSRF bound intact for *every* hop, not just the first.
- The redirect response body's socket is freed before the next hop; a missing/unparseable `Location`, or exceeding the hop bound, throws the existing `BAD_REQUEST`.

Everything downstream (content-length cap, byte cap, magic-byte sniff, store upload, bare `createImage` row) is unchanged.

## Tests

Adds a service unit test (`block-image-upload.service.test.ts`) covering:
- **301 same-host → 200 jpeg publishes** (the exact regression) — asserts the resolved same-host content url is fetched and a row is created.
- direct 200 (no redirect) still publishes.
- **redirect to an off-allowlist host is rejected before its socket opens** — the off-allowlist host is never fetched.
- too-many-redirects (a chain past the hop bound) → `BAD_REQUEST`.
- an off-allowlist starting url (no fetch at all), and a 3xx with no `Location`.

Follows #3187 / #3171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)