### PR TITLE
feat(app-blocks): notify submitter on on-site App Block approve/reject

### DIFF
--- a/src/server/notifications/__tests__/app-block-notification.test.ts
+++ b/src/server/notifications/__tests__/app-block-notification.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { appBlockNotifications } from '~/server/notifications/app-block.notifications';
+import type { AppBlockModerationNotificationDetails } from '~/server/notifications/app-block.notifications';
+
+/**
+ * On-site App Block submitter-notification DEFINITION coverage (pure — no DB / client).
+ *
+ * Asserts the two imperative types render the right copy + url from their details:
+ *   - approved copy (+ name-present vs name-absent label),
+ *   - rejected copy WITH a reason and the empty/whitespace-reason fallback.
+ * These are the same guarantees the off-site `app-listing-*` types carry, adapted to
+ * the distinct on-site App Block copy.
+ */
+
+type Def = (typeof appBlockNotifications)['app-block-approved'];
+const approved = (appBlockNotifications as Record<string, Def>)['app-block-approved'];
+const rejected = (appBlockNotifications as Record<string, Def>)['app-block-rejected'];
+
+function msg(def: Def, details: AppBlockModerationNotificationDetails) {
+  return def.prepareMessage({ details } as Parameters<Def['prepareMessage']>[0]);
+}
+
+describe('app-block notification definitions — registration shape', () => {
+  it('both types are non-toggleable System notifications with no prepareQuery', () => {
+    for (const def of [approved, rejected]) {
+      expect(def).toBeTruthy();
+      expect(def.toggleable).toBe(false);
+      expect(def.category).toBe('System');
+      // Imperative (emitted from the service), so there is no scheduled scan.
+      expect((def as { prepareQuery?: unknown }).prepareQuery).toBeUndefined();
+    }
+  });
+});
+
+describe('app-block-approved — prepareMessage', () => {
+  it('names the block and points at the submissions view', () => {
+    const m = msg(approved, { slug: 'cool-app', name: 'Cool App', version: '1.2.0' });
+    expect(m).toBeTruthy();
+    expect(m!.message).toContain('Cool App');
+    expect(m!.message.toLowerCase()).toMatch(/approved/);
+    expect(m!.url).toBe('/apps/my-submissions');
+  });
+
+  it('falls back to a terse "Your app block" when no name is present', () => {
+    const m = msg(approved, { slug: 'cool-app' });
+    expect(m!.message).toContain('Your app block');
+    expect(m!.message).not.toContain('""');
+    expect(m!.message.toLowerCase()).toMatch(/approved/);
+  });
+
+  it('treats a whitespace-only name as absent (no empty quotes)', () => {
+    const m = msg(approved, { slug: 'cool-app', name: '   ' });
+    expect(m!.message).toContain('Your app block');
+    expect(m!.message).not.toContain('""');
+  });
+});
+
+describe('app-block-rejected — prepareMessage', () => {
+  it('renders the moderator reason inline after the block name', () => {
+    const m = msg(rejected, {
+      slug: 'cool-app',
+      name: 'Cool App',
+      reason: 'Uses a disallowed scope',
+    });
+    expect(m!.message).toContain('Cool App');
+    expect(m!.message.toLowerCase()).toMatch(/not approved/);
+    expect(m!.message).toContain('Uses a disallowed scope');
+    expect(m!.url).toBe('/apps/my-submissions');
+  });
+
+  it('falls back to a clean sentence (period, no dangling colon) when no reason is given', () => {
+    const m = msg(rejected, { slug: 'cool-app', name: 'Cool App' });
+    expect(m!.message).toContain('Cool App');
+    expect(m!.message.toLowerCase()).toMatch(/not approved/);
+    expect(m!.message.trimEnd().endsWith('.')).toBe(true);
+    expect(m!.message).not.toContain(':');
+  });
+
+  it('treats a whitespace-only reason as absent (fallback, not a dangling colon)', () => {
+    const m = msg(rejected, { slug: 'cool-app', name: 'Cool App', reason: '   ' });
+    expect(m!.message).not.toContain(':');
+    expect(m!.message.trimEnd().endsWith('.')).toBe(true);
+  });
+
+  it('uses the terse label when neither name nor reason is present', () => {
+    const m = msg(rejected, { slug: 'cool-app' });
+    expect(m!.message).toContain('Your app block');
+    expect(m!.message).not.toContain('""');
+    expect(m!.message.trimEnd().endsWith('.')).toBe(true);
+  });
+});

--- a/src/server/notifications/app-block.notifications.ts
+++ b/src/server/notifications/app-block.notifications.ts
@@ -1,0 +1,78 @@
+import { NotificationCategory } from '~/server/common/enums';
+import { createNotificationProcessor } from '~/server/notifications/base.notifications';
+
+/**
+ * App Blocks (on-site) — submitter-facing moderation notifications.
+ *
+ * The ON-SITE App Block publish flow (submit a version → a moderator approves it,
+ * which kicks the build/deploy, or rejects it with a reason) previously sent the
+ * submitting developer NOTHING — only moderators got a Discord alert on a new
+ * submission. These two IMPERATIVE notification types close that gap: they are
+ * emitted directly from `approveRequest` / `rejectRequest` (via `createNotification`,
+ * behind the `notifyAppBlockSubmitter` helper) POST-COMMIT — NOT from a scheduled
+ * `prepareQuery` scan — so they carry NO `prepareQuery`, only a `prepareMessage`
+ * (mirrors the off-site app-store-listing imperative notifications, and the
+ * auction / challenge imperative types).
+ *
+ * DISTINCT from the off-site W13 `app-listing-*` types: the on-site App Block flow
+ * is a different surface (a per-slug block that builds + deploys to <slug>.civit.ai),
+ * so it gets its own copy + type strings rather than reusing the store-listing ones.
+ *
+ * The `type` strings are free-form (the notifications app stores them as text — no
+ * DB enum), so adding these needs NO notifications-DB migration (same as the
+ * off-site / auction / challenge imperative types). Registered in
+ * `utils.notifications.ts`.
+ */
+
+export type AppBlockModerationNotificationDetails = {
+  /** The block's public slug (identity + link hint; also serves <slug>.civit.ai). */
+  slug: string;
+  /** The block display name (best-effort — may be absent for a terse payload). */
+  name?: string | null;
+  /** The submitted version string (best-effort — for a future per-version deep-link). */
+  version?: string | null;
+  /** The moderator's rejection reason (reject only; approve carries none). */
+  reason?: string | null;
+};
+
+/** Both submitter notifications point the developer at their submissions view. */
+const SUBMITTER_SUBMISSIONS_URL = '/apps/my-submissions';
+
+/** `Your app block "Name"` when a name is present, else a terse `Your app block`. */
+function blockLabel(details: AppBlockModerationNotificationDetails): string {
+  const name = details.name?.trim();
+  return name ? `Your app block "${name}"` : 'Your app block';
+}
+
+/** Append ": <reason>" only when a non-empty reason is present, else a period. */
+function withReason(base: string, reason?: string | null): string {
+  const trimmed = reason?.trim();
+  return trimmed ? `${base}: ${trimmed}` : `${base}.`;
+}
+
+export const appBlockNotifications = createNotificationProcessor({
+  'app-block-approved': {
+    displayName: 'App block approved',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppBlockModerationNotificationDetails;
+      return {
+        message: `${blockLabel(details)} was approved and is being built and deployed.`,
+        url: SUBMITTER_SUBMISSIONS_URL,
+      };
+    },
+  },
+  'app-block-rejected': {
+    displayName: 'App block not approved',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: (notification) => {
+      const details = notification.details as AppBlockModerationNotificationDetails;
+      return {
+        message: withReason(`${blockLabel(details)} was not approved`, details.reason),
+        url: SUBMITTER_SUBMISSIONS_URL,
+      };
+    },
+  },
+});

--- a/src/server/notifications/utils.notifications.ts
+++ b/src/server/notifications/utils.notifications.ts
@@ -2,6 +2,7 @@ import { articleNotifications } from '~/server/notifications/article.notificatio
 import { comicNotifications } from '~/server/notifications/comics.notifications';
 import { articleRatingReviewNotifications } from '~/server/notifications/article-rating-review.notifications';
 import { articleUnpublishNotifications } from '~/server/notifications/article-unpublish.notifications';
+import { appBlockNotifications } from '~/server/notifications/app-block.notifications';
 import { appListingNotifications } from '~/server/notifications/app-listing.notifications';
 import { auctionNotifications } from '~/server/notifications/auction.notifications';
 import type { BareNotification } from '~/server/notifications/base.notifications';
@@ -40,6 +41,7 @@ export const notificationProcessors = {
   ...articleNotifications,
   ...articleUnpublishNotifications,
   ...appListingNotifications,
+  ...appBlockNotifications,
   ...articleRatingReviewNotifications,
   ...reportNotifications,
   ...featuredNotifications,

--- a/src/server/services/blocks/__tests__/app-block-notify.test.ts
+++ b/src/server/services/blocks/__tests__/app-block-notify.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `notifyAppBlockSubmitter` helper — forwards to `createNotification` with the right
+ * shape via its dynamic import. Only the notifications client is mocked; the helper's
+ * static import is a type (erased), so nothing else is pulled. `~/server/common/enums`
+ * is the REAL module (so we assert the actual `NotificationCategory.System` value).
+ */
+
+const { mockCreateNotification } = vi.hoisted(() => ({
+  mockCreateNotification: vi.fn(async (..._a: unknown[]) => undefined),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: mockCreateNotification,
+}));
+
+const { notifyAppBlockSubmitter } = await import('~/server/services/blocks/app-block-notify');
+
+beforeEach(() => {
+  mockCreateNotification.mockReset().mockResolvedValue(undefined);
+});
+
+describe('notifyAppBlockSubmitter', () => {
+  it('forwards a single-user System notification with the type, key and details', async () => {
+    await notifyAppBlockSubmitter({
+      type: 'app-block-approved',
+      userId: 77,
+      key: 'app-block-approved:req_1',
+      details: { slug: 'cool-app', name: 'Cool App', version: '1.0.0' },
+    });
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    const arg = mockCreateNotification.mock.calls[0][0];
+    expect(arg).toMatchObject({
+      userId: 77,
+      category: 'System',
+      type: 'app-block-approved',
+      key: 'app-block-approved:req_1',
+      details: { slug: 'cool-app', name: 'Cool App', version: '1.0.0' },
+    });
+  });
+
+  it('carries the rejection reason through in details', async () => {
+    await notifyAppBlockSubmitter({
+      type: 'app-block-rejected',
+      userId: 5,
+      key: 'app-block-rejected:req_2',
+      details: { slug: 's', reason: 'nope' },
+    });
+    const arg = mockCreateNotification.mock.calls[0][0];
+    expect(arg.type).toBe('app-block-rejected');
+    expect(arg.details.reason).toBe('nope');
+  });
+});

--- a/src/server/services/blocks/__tests__/publish-request.notify.service.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.notify.service.test.ts
@@ -1,0 +1,292 @@
+import JSZip from 'jszip';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * On-site App Block submitter-notification SERVICE emission tests.
+ *
+ * Mirrors the off-site emission tests (offsite-listing.service.test.ts):
+ * `approveRequest` / `rejectRequest` are exercised with their DB + heavy deps mocked,
+ * and the emit helper `~/server/services/blocks/app-block-notify` is mocked so we can
+ * assert the POST-COMMIT call WITHOUT pulling the notifications client graph.
+ *
+ * The four guarantees under test:
+ *   1. approve emits `app-block-approved` to `submittedByUserId` (right key + details),
+ *   2. reject emits `app-block-rejected` with the trimmed reason,
+ *   3. BEST-EFFORT — a notify failure is swallowed; the approve/reject still succeeds,
+ *   4. POST-COMMIT ordering — a FAILED approve/reject emits nothing.
+ */
+
+const { mockNotify, db, s3, holder } = vi.hoisted(() => {
+  const mockNotify = vi.fn(async (..._a: unknown[]) => undefined);
+  const holder: { zipBytes: Uint8Array } = { zipBytes: new Uint8Array() };
+  const makeDb = () => ({
+    appBlockPublishRequest: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      update: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appBlock: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 'apb_existing' })),
+      create: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+      update: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+    },
+    oauthClient: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+      update: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+    },
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 'apl_existing' })),
+      create: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+    },
+  });
+  const db = { read: makeDb(), write: makeDb() };
+  const s3 = {
+    send: vi.fn(async () => ({
+      Body: { transformToByteArray: async () => holder.zipBytes },
+    })),
+  };
+  return { mockNotify, db, s3, holder };
+});
+
+vi.mock('~/server/services/blocks/app-block-notify', () => ({
+  notifyAppBlockSubmitter: mockNotify,
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: db.read, dbWrite: db.write }));
+vi.mock('~/env/server', () => ({
+  env: {
+    FORGEJO_BASE_URL: 'https://forgejo.example',
+    FORGEJO_ADMIN_TOKEN: 'tok',
+    FORGEJO_WEBHOOK_SECRET: 'sec',
+    APPS_DOMAIN: 'apps.example',
+    NEXTAUTH_URL: 'https://civitai.example',
+  },
+}));
+vi.mock('~/server/utils/app-block-ids', () => ({ newUlid: () => 'ULID000' }));
+vi.mock('~/server/services/block-manifest-validator.service', () => ({
+  BlockManifestValidator: { validate: () => ({ valid: true, errors: [] }) },
+}));
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  commitFiles: vi.fn(async () => ({ sha: 'deadbeefsha' })),
+  setCommitStatus: vi.fn(async () => undefined),
+  createRepoFromTemplate: vi.fn(async () => ({ html_url: 'https://forgejo.example/x' })),
+  ensurePushWebhook: vi.fn(async () => undefined),
+  listRepoTreeAtRef: vi.fn(async () => new Map()),
+  getBlobContent: vi.fn(async () => Buffer.from('')),
+}));
+vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
+  triggerBuild: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/blocks/app-listing-mapper', () => ({
+  mapAppBlockToListing: () => ({ id: 'apl_mapped' }),
+}));
+vi.mock('~/utils/bundle-s3', () => ({
+  getBundleBucket: () => 'bundles',
+  getBundleS3Client: () => s3,
+}));
+
+const { approveRequest, rejectRequest } = await import(
+  '~/server/services/blocks/publish-request.service'
+);
+const pipeline = await import('~/server/services/blocks/apps-pipeline.service');
+
+const SUBMITTER = 4242;
+
+/** A pending, subsequent-version request row (existing AppBlock ⇒ no repo creation). */
+function pendingApproveRow() {
+  return {
+    id: 'req_appr_1',
+    status: 'pending',
+    slug: 'cool-app',
+    version: '1.2.0',
+    manifest: { name: 'Cool App', scopes: [] },
+    bundleKey: 'bundles/cool-app.zip',
+    forgejoCommitSha: '',
+    submittedByUserId: SUBMITTER,
+    appBlockId: 'apb_existing',
+    deployState: null,
+  };
+}
+
+function existingAppBlock() {
+  return {
+    id: 'apb_existing',
+    appId: 'app_1',
+    repoUrl: 'https://forgejo.example/cool-app',
+    trustTier: 'unverified',
+    app: { allowedScopes: 0, allowedOrigins: ['https://cool-app.apps.example'] },
+  };
+}
+
+beforeAll(async () => {
+  const zip = new JSZip();
+  zip.file('block.manifest.json', JSON.stringify({ name: 'Cool App', scopes: [] }));
+  zip.file('index.html', '<html></html>');
+  holder.zipBytes = await zip.generateAsync({ type: 'uint8array' });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockNotify.mockResolvedValue(undefined);
+  // Re-seed the default happy-path resolutions cleared by clearAllMocks.
+  db.write.appBlockPublishRequest.update.mockImplementation(
+    async (a: { data?: unknown }) => a?.data ?? {}
+  );
+  db.write.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
+  db.write.appBlock.update.mockImplementation(async (a: { data?: unknown }) => a?.data ?? {});
+  db.write.appBlock.updateMany.mockResolvedValue({ count: 0 });
+  db.write.appBlock.findUnique.mockResolvedValue({ id: 'apb_existing' });
+  db.write.oauthClient.update.mockResolvedValue({});
+  db.write.appListing.updateMany.mockResolvedValue({ count: 0 });
+  db.read.appListing.findUnique.mockResolvedValue({ id: 'apl_existing' });
+  s3.send.mockImplementation(async () => ({
+    Body: { transformToByteArray: async () => holder.zipBytes },
+  }));
+  (pipeline.triggerBuild as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+describe('approveRequest — submitter notification (post-commit, best-effort)', () => {
+  it('emits app-block-approved to the submitter with the right key + details', async () => {
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValueOnce(pendingApproveRow());
+    db.read.appBlock.findFirst.mockResolvedValueOnce(existingAppBlock());
+
+    await approveRequest({ publishRequestId: 'req_appr_1', reviewerUserId: 9 });
+
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    const arg = mockNotify.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.type).toBe('app-block-approved');
+    expect(arg.userId).toBe(SUBMITTER);
+    expect(arg.key).toBe('app-block-approved:req_appr_1');
+    expect(arg.details).toMatchObject({ slug: 'cool-app', name: 'Cool App', version: '1.2.0' });
+  });
+
+  it('is BEST-EFFORT: a notify failure is swallowed and the approve still resolves', async () => {
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValueOnce(pendingApproveRow());
+    db.read.appBlock.findFirst.mockResolvedValueOnce(existingAppBlock());
+    mockNotify.mockRejectedValueOnce(new Error('notifications down'));
+
+    // The approve must resolve to its normal result despite the notify throw — the
+    // status flip + build trigger already committed. (If the call site were made
+    // non-swallowing, this await would REJECT and the test would fail.)
+    await expect(
+      approveRequest({ publishRequestId: 'req_appr_1', reviewerUserId: 9 })
+    ).resolves.toMatchObject({ publishRequestId: 'req_appr_1', appBlockId: 'apb_existing' });
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST-COMMIT ordering: a FAILED approve (non-pending row) emits nothing', async () => {
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValueOnce({
+      ...pendingApproveRow(),
+      status: 'approved',
+    });
+
+    await expect(
+      approveRequest({ publishRequestId: 'req_appr_1', reviewerUserId: 9 })
+    ).rejects.toThrow(/cannot approve/);
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('POST-COMMIT ordering: notify runs AFTER the build trigger — a triggerBuild failure emits nothing', async () => {
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValueOnce(pendingApproveRow());
+    db.read.appBlock.findFirst.mockResolvedValueOnce(existingAppBlock());
+    (pipeline.triggerBuild as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('tekton unavailable')
+    );
+
+    await expect(
+      approveRequest({ publishRequestId: 'req_appr_1', reviewerUserId: 9 })
+    ).rejects.toThrow();
+    // triggerBuild is BEFORE the notify in the flow → a build-trigger failure means
+    // the submitter is never told the block was approved.
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+});
+
+describe('rejectRequest — submitter notification (post-commit, best-effort)', () => {
+  function pendingRejectRow() {
+    return {
+      id: 'req_rej_1',
+      status: 'pending',
+      deployState: null,
+      slug: 'cool-app',
+      version: '1.2.0',
+      manifest: { name: 'Cool App' },
+      submittedByUserId: SUBMITTER,
+    };
+  }
+
+  it('emits app-block-rejected to the submitter with the trimmed reason + right key', async () => {
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValueOnce(pendingRejectRow());
+
+    await rejectRequest({
+      publishRequestId: 'req_rej_1',
+      reviewerUserId: 9,
+      rejectionReason: '  Uses a disallowed scope  ',
+    });
+
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    const arg = mockNotify.mock.calls[0][0] as Record<string, unknown>;
+    expect(arg.type).toBe('app-block-rejected');
+    expect(arg.userId).toBe(SUBMITTER);
+    expect(arg.key).toBe('app-block-rejected:req_rej_1');
+    expect(arg.details).toMatchObject({
+      slug: 'cool-app',
+      name: 'Cool App',
+      version: '1.2.0',
+      reason: 'Uses a disallowed scope',
+    });
+    // The rejection row committed before the notify.
+    expect(db.write.appBlockPublishRequest.update).toHaveBeenCalledWith({
+      where: { id: 'req_rej_1' },
+      data: expect.objectContaining({ status: 'rejected', rejectionReason: 'Uses a disallowed scope' }),
+    });
+  });
+
+  it('is BEST-EFFORT: a notify failure is swallowed and the reject still resolves', async () => {
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValueOnce(pendingRejectRow());
+    mockNotify.mockRejectedValueOnce(new Error('notifications down'));
+
+    await expect(
+      rejectRequest({
+        publishRequestId: 'req_rej_1',
+        reviewerUserId: 9,
+        rejectionReason: 'Uses a disallowed scope',
+      })
+    ).resolves.toBeUndefined();
+    expect(mockNotify).toHaveBeenCalledTimes(1);
+    // The reject still committed.
+    expect(db.write.appBlockPublishRequest.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST-COMMIT ordering: a FAILED reject (non-pending row) emits nothing and never writes', async () => {
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValueOnce({
+      ...pendingRejectRow(),
+      status: 'approved',
+    });
+
+    await expect(
+      rejectRequest({
+        publishRequestId: 'req_rej_1',
+        reviewerUserId: 9,
+        rejectionReason: 'Uses a disallowed scope',
+      })
+    ).rejects.toThrow(/cannot reject/);
+    expect(db.write.appBlockPublishRequest.update).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('a too-short reason rejects BEFORE any DB read and emits nothing', async () => {
+    await expect(
+      rejectRequest({ publishRequestId: 'req_rej_1', reviewerUserId: 9, rejectionReason: 'x' })
+    ).rejects.toThrow();
+    expect(db.read.appBlockPublishRequest.findUnique).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/app-block-notify.ts
+++ b/src/server/services/blocks/app-block-notify.ts
@@ -1,0 +1,43 @@
+import type { AppBlockModerationNotificationDetails } from '~/server/notifications/app-block.notifications';
+
+/**
+ * App Blocks (on-site) — submitter-notification emit helper.
+ *
+ * A thin, best-effort wrapper `approveRequest` / `rejectRequest` call AFTER their
+ * state transition commits, to notify the SUBMITTING developer of the moderator
+ * decision. Kept in a DEDICATED module whose ONLY static import is a TYPE (erased at
+ * compile), and which DYNAMICALLY imports `createNotification` +
+ * `NotificationCategory` inside the async body — so importing this helper adds ZERO
+ * runtime graph to the caller (mirrors the off-site `app-listing-notify` helper and
+ * the publish-request service's own dynamic-import discipline for heavy deps). This
+ * keeps the service's unit tests from pulling the notifications client; a test that
+ * asserts emission mocks THIS module (`~/server/services/blocks/app-block-notify`),
+ * and a test that asserts the swallow mocks `~/server/services/notification.service`.
+ *
+ * `createNotification` is itself best-effort (it swallows client errors + logs), and
+ * this is emitted post-commit, so a notification failure never affects the decision.
+ * The CALLERS additionally wrap this call in a try/catch — so even a defect that made
+ * this helper throw can never fail or roll back a moderator approve/reject.
+ */
+
+export type AppBlockSubmitterNotificationType = 'app-block-approved' | 'app-block-rejected';
+
+export async function notifyAppBlockSubmitter(opts: {
+  type: AppBlockSubmitterNotificationType;
+  userId: number;
+  /** Idempotency key — dedups repeat emissions of the same event to the same user. */
+  key: string;
+  details: AppBlockModerationNotificationDetails;
+}): Promise<void> {
+  const [{ createNotification }, { NotificationCategory }] = await Promise.all([
+    import('~/server/services/notification.service'),
+    import('~/server/common/enums'),
+  ]);
+  await createNotification({
+    userId: opts.userId,
+    category: NotificationCategory.System,
+    type: opts.type,
+    key: opts.key,
+    details: opts.details,
+  });
+}

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -20,6 +20,11 @@ import {
 import { deriveOauthBitmaskFromBlockScopes } from '~/shared/constants/block-scope.constants';
 // Pure (no env/Prisma) — stamps the platform-owned iframe.src onto a manifest.
 import { stampCanonicalIframeSrc } from '~/server/services/blocks/manifest-normalize';
+// Zero-runtime-graph helper (its ONLY static import is a type; it DYNAMICALLY imports
+// the notifications client in its body). approve/reject call it POST-COMMIT to notify
+// the submitting developer of the moderator decision — best-effort, wrapped in a
+// try/catch at each call site so a notification failure can never fail the decision.
+import { notifyAppBlockSubmitter } from '~/server/services/blocks/app-block-notify';
 // Pure const (no env/Prisma) — the marketplace category taxonomy + type guard.
 // approveRequest copies a validated manifest `category` onto AppBlock.category.
 import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
@@ -2680,6 +2685,32 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   // 'building'), so the common no-preview approve does zero extra DB/k8s work.
   if (hadReviewPreview) void teardownReviewForRequest(request.id);
 
+  // POST-COMMIT, best-effort — notify the submitting developer their block was
+  // approved (and is now building/deploying). This runs AFTER the status flip to
+  // 'approved' + the build trigger have both succeeded (a failed approve throws
+  // above and never reaches here → no notification for a rolled-back approve). The
+  // whole call is wrapped so a notification failure can NEVER fail or roll back the
+  // approve — the decision is already durable. Keyed by the request id for
+  // idempotency (a re-approve of the same request notifies once).
+  try {
+    await notifyAppBlockSubmitter({
+      type: 'app-block-approved',
+      userId: request.submittedByUserId,
+      key: `app-block-approved:${params.publishRequestId}`,
+      details: {
+        slug: request.slug,
+        name: typeof manifest.name === 'string' ? manifest.name : null,
+        version: request.version,
+      },
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[approveRequest] submitter notification failed (id=${params.publishRequestId}); ` +
+        `approve stands: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
   return {
     publishRequestId: request.id,
     appBlockId,
@@ -3717,7 +3748,17 @@ export async function rejectRequest(params: RejectRequestParams): Promise<void> 
   const row = await dbRead.appBlockPublishRequest.findUnique({
     where: { id: params.publishRequestId },
     // deployState (#2831): only fire the review teardown if a preview was started.
-    select: { id: true, status: true, deployState: true },
+    // slug/version/manifest/submittedByUserId feed the POST-COMMIT submitter
+    // notification (best-effort; see below).
+    select: {
+      id: true,
+      status: true,
+      deployState: true,
+      slug: true,
+      version: true,
+      manifest: true,
+      submittedByUserId: true,
+    },
   });
   if (!row) throw new Error(`publish request ${params.publishRequestId} not found`);
   if (row.status !== 'pending') {
@@ -3741,4 +3782,34 @@ export async function rejectRequest(params: RejectRequestParams): Promise<void> 
   // must never affect the outcome. Gated on a preview actually having been
   // started so the common no-preview reject does zero extra work.
   if (hadReviewPreview) void teardownReviewForRequest(row.id);
+
+  // POST-COMMIT, best-effort — notify the submitting developer their block was NOT
+  // approved, carrying the (already-trimmed) moderator reason so it shows inline on
+  // /apps/my-submissions. Runs AFTER the status flip to 'rejected' commits (a reject
+  // that throws above — bad reason length, non-pending row — never reaches here → no
+  // notification). Wrapped so a notification failure can NEVER fail the reject.
+  // Keyed by the request id for idempotency.
+  const rejectManifest =
+    row.manifest && typeof row.manifest === 'object'
+      ? (row.manifest as Record<string, unknown>)
+      : {};
+  try {
+    await notifyAppBlockSubmitter({
+      type: 'app-block-rejected',
+      userId: row.submittedByUserId,
+      key: `app-block-rejected:${params.publishRequestId}`,
+      details: {
+        slug: row.slug,
+        name: typeof rejectManifest.name === 'string' ? rejectManifest.name : null,
+        version: row.version,
+        reason,
+      },
+    });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[rejectRequest] submitter notification failed (id=${params.publishRequestId}); ` +
+        `reject stands: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
 }


### PR DESCRIPTION
## What & why

The **on-site App Block** publish flow told the submitting developer **nothing** when a moderator acted on their request — only mods got a Discord alert on a new submission. This wires the developer into the loop: they now get an **in-app notification the moment their block is approved or rejected**, honoring their notification preferences (delivered through the standard notifications pipeline).

This **mirrors the off-site app-store-listing pattern** already in the repo (`app-listing.notifications.ts` + `app-listing-notify.ts`) rather than reusing it — the on-site App Block flow is a distinct surface (a per-slug block that builds + deploys to `<slug>.civit.ai`), so it gets its own copy and its own free-form type strings.

## Design notes

- **New notification types** `app-block-approved` / `app-block-rejected` — `System` category, non-toggleable, imperative (`prepareMessage`-only, no scheduled `prepareQuery`). Emitted directly from the service post-commit.
  - Approved → `Your app block "<name>" was approved and is being built and deployed.`
  - Rejected → `Your app block "<name>" was not approved: <reason>` (falls back to a clean period-terminated sentence when no reason; terse `Your app block` when no name).
  - URL → `/apps/my-submissions` (the same submissions/history view the off-site types point at).
- **No DB migration.** Type strings are free-form text (the notifications app stores them as text — no enum), same as the off-site / auction / challenge imperative types.
- **New emit helper `notifyAppBlockSubmitter`** — a dedicated sibling of `app-listing-notify.ts` whose only static import is a **type** (erased at compile) and which **dynamically imports** the notifications client in its body, so it adds zero runtime graph to the caller.
- **Post-commit + best-effort.** Both call sites (`approveRequest`, `rejectRequest`) emit **after** the state transition commits, wrapped in a `try/catch`, so a notification failure can **never fail or roll back a moderator decision** — a failed approve/reject emits nothing. Keyed by `publishRequestId` for idempotency.

## Test evidence

`tsc --noEmit` (8 GiB heap): **0 errors in changed files** (17 total, all pre-existing baseline files — `image.service.ts`, `flipt/client.ts`, `bitdex-stats.ts`, workspace `kysely` — none touched here).

New + adjacent unit tests — **64 passed**:
- **Notification processors** (8) — approved/rejected copy + url, reason inline vs empty/whitespace fallback, name-present vs absent label.
- **Emit helper** (2) — forwards `type`/`userId`/`key`/`details`/`System` category to `createNotification`.
- **Service emission** (8) — approve emits `app-block-approved` to `submittedByUserId` with the right key+details; reject emits `app-block-rejected` with the trimmed reason; **best-effort** (`createNotification`/helper throws → approve/reject still resolves); **post-commit ordering** (non-pending row, too-short reason, and a `triggerBuild` failure each emit nothing).
- Adjacent suites (`publish-request.service.test.ts` 39, `challenge-cancelled-notification.test.ts` 7) still green.

The best-effort guarantee was verified by temporarily removing the call-site `try/catch` and confirming the "notify failure is swallowed" test **fails** (rejects), then restoring it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
