### PR TITLE
feat(app-blocks): rename "JWT scopes" → "Permissions" + per-scope justifications for mod review

### DIFF
--- a/docs/features/app-blocks.md
+++ b/docs/features/app-blocks.md
@@ -299,6 +299,28 @@ A submitted ZIP needs only **`block.manifest.json`** at the root plus your app
 platform-owned recipe and ignores (and drops) any tenant-supplied build files
 (audit A8/BUILD-1 Phase 2). Shipping them is harmless but inert.
 
+### Per-scope justifications (optional)
+
+A manifest MAY include an optional `scopeJustifications` object — a map of
+scope-id → free-text rationale explaining WHY the app needs each requested
+permission. It is surfaced to the moderator during review (`/apps/review`).
+
+```jsonc
+"scopes": ["models:read:self", "user:read:self"],
+"scopeJustifications": {
+  "models:read:self": "We render the page model in a comparison widget.",
+  "user:read:self": "We greet the returning viewer by username."
+}
+```
+
+Rules (enforced by `BlockManifestValidator` + the published schema): backward-
+compatible (omit it and the manifest stays valid; `scopes` is unchanged); every
+key MUST be a scope also listed in `scopes` (a justification for an un-requested
+scope is rejected); each value is a non-empty string ≤500 chars. Authors can set
+it in the submitted `block.manifest.json` or via the web manifest editor
+(`/apps/<id>/edit-manifest`). NOTE: this only CAPTURES the developer's stated
+rationale — the platform does not (yet) verify the claims.
+
 ## Known gaps before a moderator suspend/deprecate tool ships
 
 The moderator review workflow itself has shipped (see "Publish / review /

--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -86,6 +86,15 @@
         ]
       }
     },
+    "scopeJustifications": {
+      "type": "object",
+      "description": "OPTIONAL per-scope justification: a map of scope-id → free-text rationale explaining WHY the app needs that permission, shown to the moderator during review. Backward-compatible — omit it and the manifest stays valid; `scopes` is unchanged. Every key MUST be a scope also present in `scopes` (justifications for scopes you don't request are rejected). Each value is a non-empty string of at most 500 characters. NOTE: this captures the developer's STATED rationale only; the platform does not verify the claims.",
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      }
+    },
     "minApiVersion": {
       "type": "string",
       "description": "Minimum App SDK API version the block targets (informational).",

--- a/src/components/Apps/BlockScopeList.tsx
+++ b/src/components/Apps/BlockScopeList.tsx
@@ -11,7 +11,7 @@ import { SCOPE_DESCRIPTIONS } from '~/server/services/blocks/scope-descriptions.
  */
 export function BlockScopeList({
   scopes,
-  emptyLabel = "This app doesn't claim any JWT scopes — it only consumes data from the host-bridge postMessage protocol.",
+  emptyLabel = "This app doesn't request any permissions — it only consumes data from the host-bridge postMessage protocol.",
 }: {
   scopes: string[];
   emptyLabel?: string;

--- a/src/components/Apps/ManifestEditForm.browser.test.tsx
+++ b/src/components/Apps/ManifestEditForm.browser.test.tsx
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * ManifestEditForm — browser-mode render test (report-only in Tekton).
+ *
+ * Covers the per-scope justification authoring surface: a Textarea is rendered
+ * for each declared scope (seeded from the stored manifest's
+ * scopeJustifications), and Save submits a `scopeJustifications` map keyed by the
+ * declared scopes onto the updateManifest patch. (AI/agent verification of the
+ * rationale is deliberately out of scope — the form only CAPTURES it.)
+ */
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  invalidate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    useUtils: () => ({
+      blocks: { getMyAppManifest: { invalidate: mocks.invalidate } },
+    }),
+    blocks: {
+      updateManifest: {
+        useMutation: (opts?: { onSuccess?: (r: unknown) => void }) => ({
+          mutate: (vars: unknown) => {
+            mocks.mutate(vars);
+            void opts?.onSuccess?.({ version: '1.0.1', publishRequestId: 'pr-1' });
+          },
+          isPending: false,
+          error: null,
+          data: undefined,
+        }),
+      },
+    },
+  },
+}));
+
+const { ManifestEditForm } = await import('./ManifestEditForm');
+
+const BASE_MANIFEST = {
+  blockId: 'my-block',
+  version: '1.0.0',
+  name: 'My Block',
+  contentRating: 'g',
+  scopes: ['models:read:self', 'user:read:self'],
+  scopeJustifications: {
+    'models:read:self': 'We show the page model in a widget.',
+  },
+  targets: [],
+};
+
+beforeEach(() => {
+  mocks.mutate.mockClear();
+  mocks.invalidate.mockClear();
+});
+
+describe('ManifestEditForm — per-scope justification authoring', () => {
+  test('renders a justification input per declared scope, seeded from the manifest', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={BASE_MANIFEST}
+      />
+    );
+    // One Textarea per declared scope, labelled by the scope id.
+    await expect
+      .element(page.getByRole('textbox', { name: 'models:read:self' }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole('textbox', { name: 'user:read:self' }))
+      .toBeInTheDocument();
+    // The seeded justification is pre-filled.
+    await expect
+      .element(page.getByRole('textbox', { name: 'models:read:self' }))
+      .toHaveValue('We show the page model in a widget.');
+  });
+
+  test('Save submits scopeJustifications keyed by declared scopes', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={BASE_MANIFEST}
+      />
+    );
+    // Add a justification for the second scope.
+    const secondInput = page.getByRole('textbox', { name: 'user:read:self' });
+    await userEvent.fill(secondInput, 'We greet the viewer by username.');
+
+    await userEvent.click(page.getByRole('button', { name: 'Save & submit for review' }));
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    const arg = mocks.mutate.mock.calls[0][0] as {
+      patch: { scopeJustifications?: Record<string, string> };
+    };
+    expect(arg.patch.scopeJustifications).toEqual({
+      'models:read:self': 'We show the page model in a widget.',
+      'user:read:self': 'We greet the viewer by username.',
+    });
+  });
+});

--- a/src/components/Apps/ManifestEditForm.browser.test.tsx
+++ b/src/components/Apps/ManifestEditForm.browser.test.tsx
@@ -110,4 +110,29 @@ describe('ManifestEditForm — per-scope justification authoring', () => {
       'user:read:self': 'We greet the viewer by username.',
     });
   });
+
+  test('clearing all justification inputs submits an explicit empty object (not undefined) so stored rationale is overwritten', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={BASE_MANIFEST}
+      />
+    );
+    // BASE_MANIFEST seeds a justification for models:read:self — clear it.
+    const seededInput = page.getByRole('textbox', { name: 'models:read:self' });
+    await userEvent.clear(seededInput);
+
+    await userEvent.click(page.getByRole('button', { name: 'Save & submit for review' }));
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    const arg = mocks.mutate.mock.calls[0][0] as {
+      patch: { scopeJustifications?: Record<string, string> };
+    };
+    // Explicit {} — NOT undefined — so the server merge overwrites/clears the
+    // previously-stored justifications instead of retaining stale rationale.
+    expect(arg.patch.scopeJustifications).toEqual({});
+    expect(arg.patch.scopeJustifications).not.toBeUndefined();
+  });
 });

--- a/src/components/Apps/ManifestEditForm.tsx
+++ b/src/components/Apps/ManifestEditForm.tsx
@@ -104,14 +104,28 @@ export function ManifestEditForm({
 
   function handleSave() {
     // Only submit justifications for currently-declared scopes, trimmed and
-    // non-empty. Omit the field entirely when there are none (keeps the manifest
-    // backward-compatible — the server rejects a justification for an undeclared
-    // scope, so filtering here also avoids a needless validation error).
+    // non-empty (the server rejects a justification for an undeclared scope, so
+    // filtering here also avoids a needless validation error).
     const scopeJustifications: Record<string, string> = {};
     for (const scope of scopes) {
       const j = (justifications[scope] ?? '').trim();
       if (j.length > 0) scopeJustifications[scope] = j;
     }
+    // Decide whether to SEND the map. Send an explicit (possibly EMPTY) object
+    // whenever there is something to write OR something to clear — i.e. the
+    // stored manifest already had justifications. If we sent `undefined` for the
+    // cleared case, superjson may drop the key in transit, so the server's
+    // `{...stored, ...patch}` merge would RETAIN the old justifications and keep
+    // showing stale rationale to the mod. `{}` overwrites/clears them (the
+    // validator treats a defined-but-empty map as a valid "no justifications"
+    // state). Only omit the field entirely when there were none before AND none
+    // now, keeping never-used manifests backward-compatible.
+    const storedHadJustifications =
+      !!manifest.scopeJustifications &&
+      typeof manifest.scopeJustifications === 'object' &&
+      Object.keys(manifest.scopeJustifications).length > 0;
+    const shouldSend =
+      Object.keys(scopeJustifications).length > 0 || storedHadJustifications;
     mutation.mutate({
       appBlockId,
       patch: {
@@ -120,8 +134,7 @@ export function ManifestEditForm({
         description: description.trim() || undefined,
         contentRating,
         scopes,
-        scopeJustifications:
-          Object.keys(scopeJustifications).length > 0 ? scopeJustifications : undefined,
+        scopeJustifications: shouldSend ? scopeJustifications : undefined,
         targets: selectedSlots.map((slotId) => ({ slotId })),
       },
     });

--- a/src/components/Apps/ManifestEditForm.tsx
+++ b/src/components/Apps/ManifestEditForm.tsx
@@ -38,8 +38,12 @@ type StoredManifest = Record<string, unknown> & {
   description?: string;
   contentRating?: string;
   scopes?: string[];
+  scopeJustifications?: Record<string, string>;
   targets?: Array<{ slotId?: string }>;
 };
+
+/** Max length of a single per-scope justification (mirrors the server validator). */
+const SCOPE_JUSTIFICATION_MAX_LENGTH = 500;
 
 export function ManifestEditForm({
   appBlockId,
@@ -59,6 +63,16 @@ export function ManifestEditForm({
   const [contentRating, setContentRating] = useState<string>(manifest.contentRating ?? 'g');
   const [version, setVersion] = useState<string>(bumpPatch(currentVersion));
   const [scopesText, setScopesText] = useState<string>((manifest.scopes ?? []).join('\n'));
+  // Per-scope justification the dev supplies for the moderator (scope-id →
+  // rationale). Kept as a superset map keyed by scope; only justifications for
+  // currently-declared scopes are submitted (see handleSave). Editing a scope out
+  // of the textarea therefore hides its input but preserves any text if it's added
+  // back before saving.
+  const [justifications, setJustifications] = useState<Record<string, string>>(
+    manifest.scopeJustifications && typeof manifest.scopeJustifications === 'object'
+      ? { ...manifest.scopeJustifications }
+      : {}
+  );
   const [selectedSlots, setSelectedSlots] = useState<string[]>(
     (manifest.targets ?? []).map((t) => t?.slotId).filter((s): s is string => !!s)
   );
@@ -89,6 +103,15 @@ export function ManifestEditForm({
   });
 
   function handleSave() {
+    // Only submit justifications for currently-declared scopes, trimmed and
+    // non-empty. Omit the field entirely when there are none (keeps the manifest
+    // backward-compatible — the server rejects a justification for an undeclared
+    // scope, so filtering here also avoids a needless validation error).
+    const scopeJustifications: Record<string, string> = {};
+    for (const scope of scopes) {
+      const j = (justifications[scope] ?? '').trim();
+      if (j.length > 0) scopeJustifications[scope] = j;
+    }
     mutation.mutate({
       appBlockId,
       patch: {
@@ -97,6 +120,8 @@ export function ManifestEditForm({
         description: description.trim() || undefined,
         contentRating,
         scopes,
+        scopeJustifications:
+          Object.keys(scopeJustifications).length > 0 ? scopeJustifications : undefined,
         targets: selectedSlots.map((slotId) => ({ slotId })),
       },
     });
@@ -164,6 +189,37 @@ export function ManifestEditForm({
         value={scopesText}
         onChange={(e) => setScopesText(e.currentTarget.value)}
       />
+
+      {scopes.length > 0 && (
+        <Stack gap={4}>
+          <Text size="sm" fw={500}>
+            Permission justifications
+          </Text>
+          <Text size="xs" c="dimmed">
+            Optional. Explain why your app needs each requested permission — a
+            moderator sees this during review. (These are shown as-is and are not
+            automatically verified.)
+          </Text>
+          <Stack gap="xs" mt={4}>
+            {scopes.map((scope) => (
+              <Textarea
+                key={scope}
+                label={scope}
+                placeholder={`Why does this app need "${scope}"?`}
+                autosize
+                minRows={1}
+                maxRows={4}
+                maxLength={SCOPE_JUSTIFICATION_MAX_LENGTH}
+                value={justifications[scope] ?? ''}
+                onChange={(e) =>
+                  setJustifications((prev) => ({ ...prev, [scope]: e.currentTarget.value }))
+                }
+                styles={{ label: { fontFamily: 'ui-monospace, monospace', fontWeight: 400 } }}
+              />
+            ))}
+          </Stack>
+        </Stack>
+      )}
 
       <Stack gap={4}>
         <Text size="sm" fw={500}>

--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -172,7 +172,7 @@ describe('OnsiteReviewModal — onsite-specific contract', () => {
     await expect.element(page.getByText('Review preview')).toBeInTheDocument();
     await expect.element(page.getByRole('button', { name: 'Start preview' })).toBeInTheDocument();
     // Structured manifest render (scopes + slot targets), not a raw JSON dump.
-    await expect.element(page.getByText('JWT scopes (1)')).toBeInTheDocument();
+    await expect.element(page.getByText('Permissions (1)')).toBeInTheDocument();
     await expect.element(page.getByText('model.sidebar_top')).toBeInTheDocument();
     // A first-version submission shows the full-manifest note (no diff).
     await expect
@@ -181,6 +181,44 @@ describe('OnsiteReviewModal — onsite-specific contract', () => {
     // Both action entry points are present on a pending request.
     await expect.element(page.getByRole('button', { name: 'Approve + build' })).toBeInTheDocument();
     await expect.element(page.getByRole('button', { name: 'Reject…' })).toBeInTheDocument();
+  });
+});
+
+describe('OnsiteReviewModal — per-scope justifications shown to the mod', () => {
+  test('renders each declared permission with its dev-supplied justification, and a "No justification provided" fallback when absent', async () => {
+    const withJustifications = {
+      ...ONSITE_PENDING,
+      id: 'onsite-req-justify',
+      slug: 'justify-block',
+      manifest: {
+        ...ONSITE_PENDING.manifest,
+        scopes: ['models:read:self', 'user:read:self'],
+        // Only the first scope carries a justification — the second must fall back.
+        scopeJustifications: {
+          'models:read:self': 'We render the page model in a side-by-side comparison widget.',
+        },
+      },
+    };
+    renderWithProviders(
+      <OnsiteReviewModal
+        selection={{ request: withJustifications, mode: 'pending' }}
+        onClose={vi.fn()}
+      />
+    );
+    // Header uses the renamed "Permissions" copy with the count.
+    await expect.element(page.getByText('Permissions (2)')).toBeInTheDocument();
+    // The supplied justification is surfaced verbatim under its badge, prefixed
+    // with the "Why:" label. Exact match on the full paragraph disambiguates from
+    // the raw manifest-JSON panel (which contains the string but not "Why:").
+    await expect
+      .element(
+        page.getByText('Why: We render the page model in a side-by-side comparison widget.', {
+          exact: true,
+        })
+      )
+      .toBeInTheDocument();
+    // The scope with no justification shows the muted fallback.
+    await expect.element(page.getByText('No justification provided')).toBeInTheDocument();
   });
 });
 

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -15,6 +15,7 @@ import {
   Switch,
   Text,
   Textarea,
+  ThemeIcon,
   Tooltip,
 } from '@mantine/core';
 import {
@@ -23,6 +24,7 @@ import {
   IconCheck,
   IconCode,
   IconExternalLink,
+  IconInfoCircle,
   IconKey,
   IconLayoutGrid,
   IconShieldLock,
@@ -1145,38 +1147,76 @@ function ManifestScopes({ manifest }: { manifest: Record<string, unknown> }) {
   const scopes = Array.isArray(manifest.scopes)
     ? (manifest.scopes as unknown[]).filter((s): s is string => typeof s === 'string')
     : [];
+  // Optional dev-supplied per-scope justification (scope-id → rationale). Shown
+  // to the moderator so they can weigh WHY the app requested each permission.
+  // NOTE: these are the developer's STATED rationale — the platform does not (yet)
+  // verify the claims; this surface only DISPLAYS them.
+  const justifications =
+    manifest.scopeJustifications &&
+    typeof manifest.scopeJustifications === 'object' &&
+    !Array.isArray(manifest.scopeJustifications)
+      ? (manifest.scopeJustifications as Record<string, unknown>)
+      : {};
   return (
     <Card withBorder p="sm">
       <Stack gap="xs">
         <Group gap={6}>
           <IconKey size={14} />
           <Text size="sm" fw={600}>
-            JWT scopes ({scopes.length})
+            Permissions ({scopes.length})
           </Text>
+          <Tooltip
+            multiline
+            w={280}
+            label="Permissions the block requests. They are encoded as scopes in the app's signed block-token JWT (distinct from OAuth scopes) and enforced at token issuance."
+          >
+            <ThemeIcon size="xs" variant="subtle" color="gray">
+              <IconInfoCircle size={13} />
+            </ThemeIcon>
+          </Tooltip>
         </Group>
         {scopes.length === 0 ? (
           <Text size="xs" c="dimmed" fs="italic">
-            No scopes requested — block can only consume host postMessage
+            No permissions requested — block can only consume host postMessage
             data, no scope-gated platform APIs.
           </Text>
         ) : (
-          <Stack gap={4}>
+          <Stack gap={8}>
             {scopes.map((s) => {
               const desc = SCOPE_DESCRIPTIONS[s];
               const known = !!desc;
+              const rawJustification = justifications[s];
+              const justification =
+                typeof rawJustification === 'string' && rawJustification.trim().length > 0
+                  ? rawJustification.trim()
+                  : null;
               return (
-                <Group key={s} gap={8} align="flex-start" wrap="nowrap">
-                  <Badge
-                    variant={known ? 'light' : 'outline'}
-                    color={known ? 'blue' : 'red'}
-                    style={{ fontFamily: 'ui-monospace, monospace' }}
-                  >
-                    {s}
-                  </Badge>
-                  <Text size="xs" c={known ? 'dimmed' : 'red'}>
-                    {desc ?? 'Unknown scope — would fail at token issuance.'}
-                  </Text>
-                </Group>
+                <Stack key={s} gap={2}>
+                  <Group gap={8} align="flex-start" wrap="nowrap">
+                    <Badge
+                      variant={known ? 'light' : 'outline'}
+                      color={known ? 'blue' : 'red'}
+                      style={{ fontFamily: 'ui-monospace, monospace' }}
+                    >
+                      {s}
+                    </Badge>
+                    <Text size="xs" c={known ? 'dimmed' : 'red'}>
+                      {desc ?? 'Unknown scope — would fail at token issuance.'}
+                    </Text>
+                  </Group>
+                  {justification ? (
+                    <Text size="xs" c="dimmed" style={{ whiteSpace: 'pre-wrap' }}>
+                      <Text span fw={600} c="dimmed">
+                        Why:{' '}
+                      </Text>
+                      {justification}
+                    </Text>
+                  ) : (
+                    <Text size="xs" c="dimmed" fs="italic">
+                      No justification provided
+                    </Text>
+                  )}
+                </Stack>
               );
             })}
           </Stack>

--- a/src/components/Apps/offsiteReviewChecklist.ts
+++ b/src/components/Apps/offsiteReviewChecklist.ts
@@ -69,7 +69,7 @@ export function getOnsiteReviewChecklist(): ReviewChecklistItem[] {
     },
     {
       id: 'scopes',
-      label: 'Requested JWT scopes justified',
+      label: 'Requested permissions justified',
       hint: 'Every requested scope is needed for the stated functionality.',
       status: 'todo',
     },

--- a/src/server/routers/__tests__/blocks.router.updateManifest.scopeJustifications.test.ts
+++ b/src/server/routers/__tests__/blocks.router.updateManifest.scopeJustifications.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `blocks.updateManifest` — per-scope justification ENFORCEMENT at the router
+ * boundary. Unlike the sibling `blocks.router.updateManifest.test.ts` (which
+ * MOCKS BlockManifestValidator to isolate the gates), this suite drives the
+ * router with the REAL validator + the REAL iframe.src stamper, so the
+ * `scopeJustifications` rules actually run through the mutation. This locks the
+ * enforcement: a future refactor that narrows or drops the validator call fails
+ * the bad-key case here (zod's input schema does NOT check key-in-scopes).
+ *
+ * Base manifest is otherwise FULLY VALID (passes the real validator), so a
+ * rejection is attributable to the justification rule under test — proven by the
+ * "valid justification commits" control.
+ */
+
+const { mockIsAppBlocksEnabled, mockCommitFiles, mockRecordPending } = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockCommitFiles: vi.fn(),
+  mockRecordPending: vi.fn(),
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+}));
+// env comes from the global ~/env/server mock in src/__tests__/setup.ts
+// (APPS_DOMAIN='civit.ai', so the canonical iframe.src stamp lands on
+// https://my-app.civit.ai/ — matching the app's allowedOrigins below).
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  FORGEJO_ORG: 'civitai-apps',
+  commitFiles: mockCommitFiles,
+  addCollaborator: vi.fn(),
+}));
+vi.mock('~/server/services/blocks/publish-request.service', () => ({
+  recordPendingFromPush: mockRecordPending,
+}));
+// NOTE: `block-manifest-validator.service` + `manifest-normalize` are DELIBERATELY
+// NOT mocked here — the real validator/stamper run so the justification rules
+// (and the canonical iframe.src stamp) are exercised end-to-end.
+
+// --- the rest of the router's static import graph (stubbed, as in the sibling
+// updateManifest suite) so the router module imports cleanly ---
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    getAppDetail: vi.fn(),
+    getFeaturedBlocks: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    listUserSubscriptions: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: vi.fn(),
+  parseSubjectUserId: vi.fn(),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({ getOrchestratorToken: vi.fn() }));
+vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
+  buildGenerationContext: vi.fn(),
+  createWorkflowStepsFromGraphInput: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({ auditPromptServer: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlock: { findUnique: vi.fn() } },
+  dbWrite: {},
+}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>(
+    '@civitai/redis/client'
+  );
+  return {
+    ...actual,
+    redis: { get: vi.fn(), set: vi.fn() },
+    sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  };
+});
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/rewards/active/appBlockReview.reward', () => ({
+  appBlockReviewReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/appBlockReview.service', () => ({
+  upsertAppBlockReview: vi.fn(),
+  listAppBlockReviews: vi.fn(),
+  getMyAppBlockReview: vi.fn(),
+  setAppReviewExcluded: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: vi.fn(async () => ({ yellow: 0, blue: 0, green: 0 })),
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { dbRead } from '~/server/db/client';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: true } as never,
+    track: undefined,
+  };
+}
+
+const ownerUser = { id: 7, isModerator: false, tier: 'free', username: 'owner' };
+
+const findUnique = dbRead.appBlock.findUnique as ReturnType<typeof vi.fn>;
+
+// A stored manifest that is FULLY VALID under the real validator (iframe block,
+// contentRating, a single OAuth-eligible scope). The app's allowedScopes cover
+// that scope and allowedOrigins cover the canonical per-app subdomain the
+// stamper writes (https://my-app.civit.ai/).
+const approvedBlock = {
+  id: 'ab_1',
+  blockId: 'my-app',
+  status: 'approved',
+  version: '1.0.0',
+  trustTier: 'unverified',
+  manifest: {
+    blockId: 'my-app',
+    version: '1.0.0',
+    name: 'My App',
+    contentRating: 'g',
+    renderMode: 'iframe',
+    trustTier: 'unverified',
+    scopes: ['models:read:self'],
+    iframe: {
+      src: 'https://my-app.civit.ai/',
+      minHeight: 200,
+      maxHeight: null,
+      resizable: true,
+      sandbox: 'allow-scripts',
+    },
+  },
+  app: {
+    userId: ownerUser.id,
+    allowedScopes: TokenScope.ModelsRead,
+    allowedOrigins: ['https://my-app.civit.ai'],
+  },
+};
+
+// Base patch: keeps the manifest valid (scopes unchanged), bumps the version.
+const basePatch = {
+  version: '1.0.1',
+  name: 'My App v2',
+  contentRating: 'g',
+  scopes: ['models:read:self'],
+};
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset().mockResolvedValue(true);
+  mockCommitFiles.mockReset().mockResolvedValue({ sha: 'a'.repeat(40) });
+  mockRecordPending.mockReset().mockResolvedValue({ publishRequestId: 'pubreq_x' });
+  findUnique.mockReset().mockResolvedValue(approvedBlock);
+});
+
+describe('blocks.updateManifest — scopeJustifications enforcement (real validator)', () => {
+  it('CONTROL: a valid justification (declared scope, ≤500 chars) commits + records a PENDING review', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    const res = await caller.updateManifest({
+      appBlockId: 'ab_1',
+      patch: {
+        ...basePatch,
+        scopeJustifications: { 'models:read:self': 'We render the page model in a widget.' },
+      },
+    });
+
+    expect(res.status).toBe('pending');
+    expect(mockCommitFiles).toHaveBeenCalledTimes(1);
+    // The justification survives into the committed manifest bytes (so the mod
+    // sees it).
+    const committed = JSON.parse(mockCommitFiles.mock.calls[0][0].files[0].content.toString('utf8'));
+    expect(committed.scopeJustifications).toEqual({
+      'models:read:self': 'We render the page model in a widget.',
+    });
+    expect(mockRecordPending).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a justification whose key is NOT one of the manifest scopes (validator-only rule → BAD_REQUEST, nothing committed)', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await expect(
+      caller.updateManifest({
+        appBlockId: 'ab_1',
+        patch: {
+          ...basePatch,
+          // scopes is ['models:read:self']; user:read:self is a real scope but
+          // NOT requested here — the validator must reject the dangling rationale.
+          scopeJustifications: { 'user:read:self': 'we do not even request this' },
+        },
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCommitFiles).not.toHaveBeenCalled();
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the specific validator error for an undeclared-scope justification', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await expect(
+      caller.updateManifest({
+        appBlockId: 'ab_1',
+        patch: {
+          ...basePatch,
+          scopeJustifications: { 'user:read:self': 'nope' },
+        },
+      })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('not in the manifest'),
+    });
+  });
+
+  it('rejects an oversized (>500-char) justification value → BAD_REQUEST, nothing committed', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await expect(
+      caller.updateManifest({
+        appBlockId: 'ab_1',
+        patch: {
+          ...basePatch,
+          scopeJustifications: { 'models:read:self': 'a'.repeat(501) },
+        },
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCommitFiles).not.toHaveBeenCalled();
+    expect(mockRecordPending).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty-string justification value (validator-only: zod permits it, the validator does not)', async () => {
+    // z.string().max(500) accepts '' (no min), so this reaches the validator —
+    // which requires a NON-EMPTY string. Locks the validator specifically.
+    const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+    await expect(
+      caller.updateManifest({
+        appBlockId: 'ab_1',
+        patch: {
+          ...basePatch,
+          scopeJustifications: { 'models:read:self': '' },
+        },
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCommitFiles).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -4625,6 +4625,11 @@ export const blocksRouter = router({
             trustTier: z.string().min(1).max(16).optional(),
             description: z.string().max(5000).optional(),
             scopes: z.array(z.string().min(1).max(128)).max(64).optional(),
+            // Optional per-scope justification map (scope-id → rationale). The
+            // BlockManifestValidator re-checks it below (keys must be declared
+            // scopes, values non-empty ≤500 chars) — this bound is just a coarse
+            // request-size guard.
+            scopeJustifications: z.record(z.string().min(1).max(128), z.string().max(500)).optional(),
             publicSettingsKeys: z.array(z.string().min(1).max(64)).max(32).optional(),
             targets: z
               .array(z.object({ slotId: z.string().min(1).max(64) }).passthrough())

--- a/src/server/services/__tests__/block-manifest-validator.service.test.ts
+++ b/src/server/services/__tests__/block-manifest-validator.service.test.ts
@@ -649,4 +649,92 @@ describe('BlockManifestValidator', () => {
       }
     });
   });
+
+  // Per-scope justifications — OPTIONAL, backward-compatible dev-supplied map of
+  // scope-id → rationale (captured for mod review; NOT verified by the platform).
+  describe('scopeJustifications (optional per-scope rationale)', () => {
+    it('accepts a manifest with NO scopeJustifications (optional, backward-compatible)', () => {
+      // VALID_MANIFEST declares no scopeJustifications.
+      expect(BlockManifestValidator.validate(VALID_MANIFEST, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it('accepts a justification keyed by a declared scope', () => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        scopeJustifications: { 'models:read:self': 'We render the page model in a comparison widget.' },
+      };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it('accepts an empty scopeJustifications object', () => {
+      const manifest = { ...VALID_MANIFEST, scopeJustifications: {} };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it('accepts a justification at the max length boundary (500 chars)', () => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        scopeJustifications: { 'models:read:self': 'a'.repeat(500) },
+      };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it('rejects a justification for a scope NOT in the manifest scopes', () => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        // user:read:self is a real block scope but is NOT declared in scopes here.
+        scopeJustifications: { 'user:read:self': 'reason' },
+      };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(
+          result.errors.some((e) => e.includes('user:read:self') && e.includes('not in the manifest'))
+        ).toBe(true);
+      }
+    });
+
+    it('rejects a justification longer than 500 chars', () => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        scopeJustifications: { 'models:read:self': 'a'.repeat(501) },
+      };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('≤500 chars'))).toBe(true);
+      }
+    });
+
+    it.each([
+      ['', 'empty string'],
+      [42, 'non-string'],
+      [null, 'null'],
+    ])('rejects a %j (%s) justification value', (value) => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        scopeJustifications: { 'models:read:self': value },
+      };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.includes('models:read:self'))).toBe(true);
+      }
+    });
+
+    it.each([
+      [['models:read:self'], 'an array'],
+      [null, 'null'],
+      ['reason', 'a string'],
+    ])('rejects scopeJustifications that is %s (not a plain object)', (scopeJustifications) => {
+      const manifest = { ...VALID_MANIFEST, scopeJustifications };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(
+          result.errors.some((e) => e.startsWith('scopeJustifications must be an object'))
+        ).toBe(true);
+      }
+    });
+  });
 });

--- a/src/server/services/block-manifest-validator.service.ts
+++ b/src/server/services/block-manifest-validator.service.ts
@@ -82,6 +82,17 @@ interface RawManifest {
    */
   buildCommand?: unknown;
   outputDir?: unknown;
+  /**
+   * OPTIONAL per-scope justification — a map of scope-id → free-text rationale
+   * the developer supplies to explain WHY the app requests each scope. Surfaced
+   * to the moderator in review. Backward-compatible: absent ⇒ still valid, and
+   * `scopes` is unchanged. Every key MUST be a scope present in `scopes` (a
+   * justification for a scope the app doesn't request is REJECTED, so the mod
+   * never sees dangling rationale). Each value is a non-empty string bounded by
+   * SCOPE_JUSTIFICATION_MAX_LENGTH. This only CAPTURES the dev's stated claim —
+   * the platform does not verify it (verification is a deliberate follow-up).
+   */
+  scopeJustifications?: unknown;
   [key: string]: unknown;
 }
 
@@ -124,6 +135,12 @@ export const BUILD_COMMAND_RE =
 // so the error is specific ("contains shell metacharacters") rather than the
 // generic allowlist-miss message.
 const SHELL_METACHAR_RE = /[;|&$`<>(){}\\!*?\[\]'"\n\r]/;
+
+// Max length of a single per-scope justification string (scopeJustifications
+// map value). Bounded so a malicious/careless manifest can't bloat the stored
+// blob or the mod-review render. Single-sourced with the published schema's
+// scopeJustifications.additionalProperties.maxLength.
+export const SCOPE_JUSTIFICATION_MAX_LENGTH = 500;
 
 // Min/max for the iframe height envelope. The host clamps incoming
 // RESIZE_IFRAME to these bounds, but rejecting absurd values at
@@ -344,6 +361,45 @@ export class BlockManifestValidator {
         errors.push(
           `requested scopes exceed OAuth client allowedScopes: ${scopeCheck.rejectedScopes.join(', ')}`
         );
+      }
+    }
+
+    // Optional per-scope justifications (scope-id → rationale). Backward-compatible:
+    // absent ⇒ nothing to check. When present it must be a plain object; every key
+    // must be a scope the manifest actually declares (a justification for a scope
+    // NOT in `scopes` is rejected, so no dangling rationale reaches the mod), and
+    // every value must be a non-empty string ≤ SCOPE_JUSTIFICATION_MAX_LENGTH. The
+    // platform only CAPTURES the dev's stated rationale here — it does not verify it.
+    if (m.scopeJustifications !== undefined) {
+      if (
+        !m.scopeJustifications ||
+        typeof m.scopeJustifications !== 'object' ||
+        Array.isArray(m.scopeJustifications)
+      ) {
+        errors.push('scopeJustifications must be an object mapping scope-id to a justification string');
+      } else {
+        const declaredScopes = new Set(
+          Array.isArray(m.scopes)
+            ? (m.scopes as unknown[]).filter((s): s is string => typeof s === 'string')
+            : []
+        );
+        for (const [scope, justification] of Object.entries(
+          m.scopeJustifications as Record<string, unknown>
+        )) {
+          if (!declaredScopes.has(scope)) {
+            errors.push(
+              `scopeJustifications references scope "${scope}" which is not in the manifest's scopes`
+            );
+            continue;
+          }
+          if (typeof justification !== 'string' || justification.length === 0) {
+            errors.push(`scopeJustifications["${scope}"] must be a non-empty string`);
+          } else if (justification.length > SCOPE_JUSTIFICATION_MAX_LENGTH) {
+            errors.push(
+              `scopeJustifications["${scope}"] must be ≤${SCOPE_JUSTIFICATION_MAX_LENGTH} chars`
+            );
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## What & why

Two related App Blocks scopes/permissions-UI changes, in one PR (they overlap in the same files).

### 1. Rename user-facing "JWT scopes" → "Permissions"
"JWT scopes" leaked an implementation detail (the scopes are carried in the app's signed block-token JWT). Renamed the **user-visible copy only**:
- Review modal (`/apps/review`) scopes card header → **"Permissions (N)"**, with an info tooltip that keeps the nuance ("encoded as scopes in the app's signed block-token JWT, distinct from OAuth scopes").
- On-site review checklist item → **"Requested permissions justified"**.
- `BlockScopeList` empty state → "doesn't request any permissions…".

Internal identifiers, type names, variable names, and the `block-scope.constants.ts` explanatory comment are **unchanged** — code-level accuracy stays; only human-visible strings changed.

### 2. Per-scope justification (dev-supplied), shown to the moderator
A developer can now supply an **optional** per-scope justification explaining *why* their app requests each scope, surfaced to the moderator in review.

- **Schema**: new optional top-level manifest field `scopeJustifications?: Record<string, string>` (scope-id → rationale). `scopes: string[]` is untouched, so existing manifests stay valid. Rules: every key must be a scope **also declared in `scopes`** (a justification for an un-requested scope is **rejected** — no dangling rationale reaches the mod); each value is a non-empty string **≤500 chars**.
- **Authoring** (both paths supported): the submitted `block.manifest.json` bundle file **and** the web manifest editor (`/apps/<id>/edit-manifest`), which now renders a per-requested-scope input seeded from the stored manifest.
- **Review display** (the load-bearing part): each scope's justification renders under its badge in the review modal; a muted **"No justification provided"** shows when absent.

**AI/agent verification of these claims is explicitly deferred** — this only captures + displays the developer's stated rationale.

## Design decisions
- **Field shape — map (`Record<scope,string>`) over inline-object scopes.** Keeps `scopes: string[]` byte-for-byte unchanged (backward-compatible; the subset check, token-mint path, and the `scopes.map` UI all keep working) and makes unknown-scope justifications trivial to detect. Unknown-scope keys are **rejected** (deterministic, avoids confusing mod display).
- **Authoring path.** Manifest is authorable as the bundle `block.manifest.json` *and* via the post-approval web form editor — so the field is validated in the schema (bundle path) **and** given a per-scope input in `ManifestEditForm` (form path).
- **Rename word.** "Permissions" for headers/counts; "Requested permissions justified" for the checklist item (verb reads better there).

## Schema mirror copies
- `public/schemas/app-block/v1.json` — single-source schema (updated).
- `src/server/services/block-manifest-validator.service.ts` — imperative validator (updated).
- `src/server/routers/blocks.router.ts` `updateManifest` patch — tRPC input (updated).
- `docs/features/app-blocks.md` — feature doc (updated).
- **Out-of-repo `civitai` Go CLI** manifest validator — needs the same optional field added; **flagged**, not present in this repo.

## Test evidence
- `block-manifest-validator.service.test.ts` — **131 passed** (adds: optional/absent valid, keyed-by-declared-scope, empty-object, 500-char boundary, >500 rejected, unknown-scope rejected, empty/non-string/null value rejected, non-object rejected).
- `OnsiteReviewModal.browser.test.tsx` — **10 passed** (adds: justification rendered verbatim + "No justification provided" fallback; rename assertion updated to "Permissions (1)").
- `ManifestEditForm.browser.test.tsx` (new) — **2 passed** (per-scope inputs seeded from manifest; Save submits `scopeJustifications` keyed by declared scopes).
- `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` — **0 errors in changed files**; the ~17 pre-existing environmental errors (`kysely` / `event-engine-common` submodule / `image.service.ts`) are unchanged (0 delta).
- Note: `manifest-schema-endpoint.test.ts` fails to import in this local env (`Cannot find package 'kysely'`, same pre-existing environmental cause) — it reads the schema file verbatim, so the content change is structurally covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
