### PR TITLE
Revert #3178 (client devalue input-write) — prod incident

### DIFF
--- a/src/shared/utils/__tests__/trpc-union-transformer.test.ts
+++ b/src/shared/utils/__tests__/trpc-union-transformer.test.ts
@@ -20,10 +20,8 @@ import {
  *   - READ stays the format-sniffing UNION on EVERY slot (server input-read,
  *     client response-read, SSR hydrate), so a payload written by EITHER
  *     serializer decodes regardless of which peer wrote it.
- *   - Phase 3 (safe slice): the CLIENT now WRITES devalue on INPUTS. This is
- *     ungated and cannot break a stale peer because the server input read is the
- *     UNION sniffer — it decodes devalue (updated clients) AND superjson (stale
- *     clients) alike. The client's output READ stays the union too.
+ *   - the CLIENT always WRITES superjson (the browser bundle can't be per-pool
+ *     gated; the server union-reads its inputs anyway).
  *   - the SERVER write is `serverWriteSerialize` = superjson by DEFAULT (flag
  *     unset → wire byte-identical to Phase 1) and devalue only when the pool
  *     sets `TRPC_WRITE_DEVALUE=true`.
@@ -151,49 +149,16 @@ describe('serverWriteSerialize gate (TRPC_WRITE_DEVALUE, SERVER write only)', ()
   });
 });
 
-describe('clientTransformer (browser Phase 3 safe slice: devalue INPUT write, union READ)', () => {
+describe('clientTransformer (browser: superjson WRITE, union READ)', () => {
   const x = { when: new Date('2024-01-01T00:00:00.000Z'), cursor: 42n };
 
-  it('WRITES devalue on inputs (input.serialize output is a devalue STRING, not a superjson object)', () => {
+  it('WRITES superjson (input.serialize output is an OBJECT, not a devalue string)', () => {
     const written = clientTransformer.input.serialize(x);
-    // devalue.stringify ALWAYS returns a string; superjson.serialize returns an object.
-    expect(typeof written).toBe('string');
-    expect(written).toBe(devalueStringify(x));
-    // it is NOT the superjson object shape.
-    expect(written).not.toEqual(superjson.serialize(x));
+    expect(typeof written).not.toBe('string');
+    expect(written).toEqual(superjson.serialize(x));
   });
 
-  it('input the SERVER union-reads decodes the devalue-written input back for the rich types tRPC inputs carry', () => {
-    // The safe slice hinges on this: the server input.deserialize is `unionDeserialize`,
-    // so a devalue-written CLIENT input round-trips through the server read. Exercise the
-    // rich types that appear in real tRPC query/mutation inputs.
-    const input = {
-      cursor: 9007199254740993n, // top-level BigInt cursor
-      after: new Date('2024-01-02T03:04:05.678Z'), // Date filter
-      q: undefined as string | undefined, // present-but-undefined optional
-      ids: [1, 2, 3], // nested array
-      filters: { tags: ['a', 'b'], nsfw: false, nested: { min: 0, max: 10 } }, // nested object
-    };
-    const written = clientTransformer.input.serialize(input); // client WRITES devalue
-    expect(typeof written).toBe('string');
-    const readBack = unionDeserialize(written) as typeof input; // server READS union
-    expect(readBack.cursor).toBe(9007199254740993n);
-    expect(typeof readBack.cursor).toBe('bigint');
-    expect(readBack.after).toBeInstanceOf(Date);
-    expect(readBack.after.getTime()).toBe(input.after.getTime());
-    expect('q' in readBack).toBe(true);
-    expect(readBack.q).toBeUndefined();
-    expect(readBack.ids).toEqual([1, 2, 3]);
-    expect(readBack.filters).toEqual({ tags: ['a', 'b'], nsfw: false, nested: { min: 0, max: 10 } });
-  });
-
-  it('a STALE client (superjson-written input) is STILL server-readable — the ungated safety property', () => {
-    // A client that has not yet loaded the new bundle writes superjson; the server union
-    // read decodes it just the same → no gate, no breakage during the client rollout.
-    expect(unionDeserialize(superjson.serialize(x))).toEqual(x);
-  });
-
-  it('READS the union on output.deserialize (UNCHANGED — decodes BOTH a superjson and a devalue response)', () => {
+  it('READS the union on output.deserialize (decodes BOTH a superjson and a devalue response)', () => {
     // an un-flipped pool responds superjson…
     expect(clientTransformer.output.deserialize(superjson.serialize(x))).toEqual(x);
     // …and a TRPC_WRITE_DEVALUE=true pool responds devalue — client decodes both.

--- a/src/shared/utils/trpc-union-transformer.ts
+++ b/src/shared/utils/trpc-union-transformer.ts
@@ -141,32 +141,19 @@ export function buildTransformer(
 export const unionTransformer: CombinedDataTransformer = buildTransformer();
 
 /**
- * The CLIENT (browser) transformer: devalue WRITE (inputs), union READ.
+ * The CLIENT (browser) transformer: superjson WRITE, union READ.
  *
- * Phase 3 (safe slice): `input.serialize` is `writeSerialize` (devalue), so the
- * client WRITES request inputs as devalue strings. This is UNGATED and cannot
- * break a stale peer: the SERVER's `input.deserialize` is the UNION sniffer, so
- * it reads devalue inputs from updated clients AND superjson inputs from stale
- * clients — both decode. The server therefore pays the cheaper `devalue.parse`
- * on inputs as clients update, and request bodies get slightly smaller. No env
- * gate is needed because the read side already accepts either format.
+ * The browser bundle is one-size-fits-all — it can't be per-pool gated — so the
+ * client always WRITES superjson request inputs (unchanged from Phase 1). The
+ * server union-READS those inputs, so the client does NOT need to write devalue
+ * for the per-pool server canary. `output.deserialize` stays the UNION sniffer,
+ * so the client decodes BOTH a superjson response (from an un-flipped pool) and
+ * a devalue response (from a `TRPC_WRITE_DEVALUE=true` pool) transparently.
  *
- * `output.deserialize` stays the UNION sniffer (UNCHANGED), so the client still
- * decodes BOTH a superjson response (from an un-flipped pool) and a devalue
- * response (from a `TRPC_WRITE_DEVALUE=true` pool) transparently. superjson stays
- * imported and available on the read path for that backward-compat + rollback.
- *
- * `output.serialize` is left as `superjson.serialize` only to complete the
- * object — the client never serializes a response, so it is never exercised
- * (minimal change; harmless either way).
+ * `output.serialize` is set to `superjson.serialize` only to complete the
+ * object — the client never serializes a response.
  */
 export const clientTransformer: CombinedDataTransformer = {
-  // FAIL-OPEN input write (mirrors the server's `writeSerializeWithFallback`,
-  // #3186): a non-POJO input (a class instance / Decimal / Error smuggled into
-  // an input) degrades to superjson for THAT request — which the server
-  // union-reads identically — instead of throwing strict-devalue in the browser
-  // and hard-failing the query (ungated, 100% of updated clients). Enforcement
-  // belongs in tests + telemetry, not user-facing failures.
-  input: { serialize: writeSerializeWithFallback, deserialize: unionDeserialize },
+  input: { serialize: superjson.serialize, deserialize: unionDeserialize },
   output: { serialize: superjson.serialize, deserialize: unionDeserialize },
 };

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -11,8 +11,9 @@ import {
 import type { CreateTRPCNext } from '@trpc/next';
 import { createTRPCNext } from '@trpc/next';
 import type { NextPageContext } from 'next';
+import superjson from 'superjson';
 import type { AppRouter } from '~/server/routers';
-import { clientTransformer, writeSerialize } from '~/shared/utils/trpc-union-transformer';
+import { clientTransformer } from '~/shared/utils/trpc-union-transformer';
 import { isDev } from '~/env/other';
 import { env } from '~/env/client';
 import { showErrorNotification } from '~/utils/notifications';
@@ -43,10 +44,10 @@ const url = '/api/trpc';
 /**
  * Encoded-URL budget (percent-encoded chars) for a single query's input on the BATCH link.
  * Measured against the ACTUAL wire cost — `encodeURIComponent(JSON.stringify(
- * writeSerialize(input)))`, the same transform tRPC applies when building the GET URL —
+ * superjson.serialize(input)))`, the same transform tRPC applies when building the GET URL —
  * NOT a raw-char heuristic. It MUST use the same serializer the client actually writes with
- * (Phase 3 safe slice: the CLIENT now WRITES devalue inputs via `input.serialize =
- * writeSerialize` — the server union-reads them, so no gate is needed); sizing with a
+ * (the CLIENT stays superjson-write in Phase 2 — the per-pool devalue flip is SERVER-only,
+ * so the browser bundle keeps writing superjson via `input.serialize`); sizing with a
  * different serializer would let the GET/POST batching decision drift from the real wire
  * length. Sits ~280 under the batch link's
  * `maxURLLength: 2083` to absorb the path (`/api/trpc/<proc>`) + `?batch=1&input={"0":…}`
@@ -67,8 +68,8 @@ const URL_INPUT_BUDGET = 1800;
  * so it can never trip the "Input is too big for a single dispatch" throw.
  *
  * Measures the ACTUAL encoded wire cost — the exact `encodeURIComponent(JSON.stringify(
- * writeSerialize(input)))` tRPC builds the GET URL from — against `URL_INPUT_BUDGET`. Uses
- * the SAME serializer the client links write with (Phase 3 safe slice: the client now writes devalue),
+ * superjson.serialize(input)))` tRPC builds the GET URL from — against `URL_INPUT_BUDGET`. Uses
+ * the SAME serializer the client links write with (the client stays superjson-write in Phase 2),
  * so the sizer can't drift from the real URL. No length-based short-circuit: a byte/char-count proxy underestimates the
  * encoded length in the unsafe direction (a small-count input can encode large — the serializer
  * expands special types, and `encodeURIComponent` expands one non-ASCII UTF-16 unit to up to 9
@@ -79,7 +80,7 @@ const URL_INPUT_BUDGET = 1800;
 export function isTooLargeToBatch(op: { type: string; input: unknown }) {
   if (op.type !== 'query' || op.input == null) return false;
   try {
-    return encodeURIComponent(JSON.stringify(writeSerialize(op.input))).length > URL_INPUT_BUDGET;
+    return encodeURIComponent(JSON.stringify(superjson.serialize(op.input))).length > URL_INPUT_BUDGET;
   } catch {
     return false;
   }
@@ -411,8 +412,8 @@ export const trpc: CreateTRPCNext<AppRouter, NextPageContext> = createTRPCNext<A
   },
   // v11: `createTRPCNext` requires the transformer at the top level of its options
   // (WithTRPCOptions intersects TransformerOptions). The link carries it too for the
-  // actual wire (de)serialization. Phase 3 (safe slice) CLIENT: union READ, devalue
-  // WRITE on inputs (the server union-reads them, so no gate — see trpc-union-transformer.ts).
+  // actual wire (de)serialization. Phase 2 CLIENT: union READ, superjson WRITE (the
+  // per-pool devalue write flip is SERVER-only — see trpc-union-transformer.ts).
   transformer: clientTransformer,
   ssr: false,
 });


### PR DESCRIPTION
Reverts #3178 (`834660dd5b`).

## Why
#3178 made the tRPC client write **devalue-encoded inputs** (ungated). In production this broke **mutations broadly** — the devalue-encoded input in the **POST body deserializes to `undefined` server-side**, so `reaction.toggle`, `track.trackSearch`/`addAction`, `notification.markRead`, `collection.saveItem`, `post.create`, `orchestrator.generateFromGraph` (which 500'd on a `Cannot destructure property 'input'`), etc. all failed. **5836 mutation errors vs 277 query errors** in a 15m window; queries (input in the GET URL) were unaffected.

Root cause: the server-side **union input deserializer returns `undefined` for a devalue-encoded mutation POST body** (a latent bug in the union read path, live since Phase 1, that #3178 was the first to actually exercise by writing devalue inputs). The client fail-open change wasn't relevant — the bug is the server **read**, not the client write.

## Action
dp-prod was already rolled back to the pre-#3178 image to stop the bad bundle spreading. This revert removes the devalue input-write from `main` so it can't be reintroduced on the next release, and restores the client input serializer to `superjson.serialize` (Phase-1 state; read path / union deserializer unchanged). Transformer suite: 21/21.

**Follow-up (separate):** fix the union input deserializer so a devalue POST body decodes correctly (recovers any already-cached clients, and is the prerequisite before any future re-attempt of the input-write flip). Do NOT re-land #3178 until that server-read bug is fixed + tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)