### PR TITLE
fix(trpc): unionDeserialize recovers double-parsed devalue POST-body input

### DIFF
--- a/src/shared/utils/__tests__/trpc-union-transformer.test.ts
+++ b/src/shared/utils/__tests__/trpc-union-transformer.test.ts
@@ -102,6 +102,83 @@ describe('unionDeserialize (READ stays union on every slot in Phase 2)', () => {
   });
 });
 
+/**
+ * Regression: the all-mutations "input deserializes to undefined" 500 incident.
+ *
+ * On the Next.js **pages-router** adapter a devalue INPUT delivered in the POST
+ * BODY is JSON-parsed TWICE before it reaches `unionDeserialize` — the single
+ * JSON-string quoting that `@trpc/client`'s `getBody` puts around the devalue
+ * payload is stripped by (1) Next's `bodyParser` and (2) tRPC's `createBody`
+ * `typeof req.body === 'string'` short-circuit — so tRPC's `req.json()` parses
+ * the devalue string itself (a JSON array) into an ARRAY. That defeated the
+ * `typeof === 'string'` sniff, `superjson.deserialize(array)` returned undefined,
+ * and every non-batched mutation (generateFromGraph, track.*, reaction.toggle …)
+ * 500'd. Superjson inputs never hit this — their `{ json, meta }` OBJECT survives
+ * `createBody`'s re-`JSON.stringify`. This models that exact double-parse.
+ */
+function pagesRouterPostBodyDoubleParse(clientSerialized: unknown): unknown {
+  // @trpc/client getBody: the transformer output is JSON.stringify'd once.
+  const wireBody = JSON.stringify(clientSerialized);
+  // Next.js bodyParser (application/json) parses the raw body → req.body.
+  const reqBody = JSON.parse(wireBody);
+  // @trpc/server node-http createBody: a STRING req.body is returned as-is (NOT
+  // re-quoted); a non-string is re-JSON.stringify'd.
+  const fetchBody = typeof reqBody === 'string' ? reqBody : JSON.stringify(reqBody);
+  // @trpc/server resolveResponse getInputs (non-batch): result[0] = req.json().
+  return JSON.parse(fetchBody);
+}
+
+describe('unionDeserialize — pages-router POST-body double-parse recovery (mutations 500 incident)', () => {
+  it('recovers a devalue INPUT that the pages adapter double-parsed into an array (was → undefined)', () => {
+    const x = sample();
+    // What a devalue-writing (e.g. cached #3178) client sends as the input.
+    const clientSerialized = devalueStringify(x);
+    const afterDoubleParse = pagesRouterPostBodyDoubleParse(clientSerialized);
+
+    // Precondition: the double-parse HAS destroyed the string-ness (this is the bug).
+    expect(typeof afterDoubleParse).not.toBe('string');
+    expect(Array.isArray(afterDoubleParse)).toBe(true);
+
+    // The fix recovers the full value (pre-fix this returned `undefined`).
+    const out = unionDeserialize(afterDoubleParse) as ReturnType<typeof sample>;
+    expect(out).not.toBeUndefined();
+    expect(out).toEqual(x);
+    expect(out.nextCursor).toBe(9007199254740993n);
+    expect(out.buckets).toBeInstanceOf(Map);
+    expect(out.items[0].createdAt).toBeInstanceOf(Date);
+  });
+
+  it('recovers the generateFromGraph mutation input shape (would 500 on the {input} destructure)', () => {
+    const gfg = {
+      input: { workflow: 'txt2img', prompt: 'a cat', disablePoi: false },
+      tags: ['new'],
+      civitaiTip: 0,
+      creatorTip: 0,
+      buzzType: 'blue',
+      externalId: 'abc',
+    };
+    const out = unionDeserialize(pagesRouterPostBodyDoubleParse(devalueStringify(gfg)));
+    expect(out).toEqual(gfg);
+    // The resolver does `const { input } = input` — must not be undefined.
+    expect(out.input.workflow).toBe('txt2img');
+  });
+
+  it('recovers a double-parsed devalue PRIMITIVE / bare-array input', () => {
+    for (const x of [42, 'plain', true, [1, 2, 3], { a: 1 }]) {
+      expect(unionDeserialize(pagesRouterPostBodyDoubleParse(devalueStringify(x)))).toEqual(x);
+    }
+  });
+
+  it('still routes a superjson envelope (its object survives createBody re-stringify) to superjson', () => {
+    const x = sample();
+    // Superjson path: createBody re-JSON.stringify's the object, so req.json()
+    // yields the { json, meta } envelope intact — must NOT hit the devalue branch.
+    const afterRoundTrip = pagesRouterPostBodyDoubleParse(superjson.serialize(x));
+    expect(afterRoundTrip).not.toBeInstanceOf(Array);
+    expect(unionDeserialize(afterRoundTrip)).toEqual(x);
+  });
+});
+
 describe('serverWriteSerialize gate (TRPC_WRITE_DEVALUE, SERVER write only)', () => {
   it('default (flag unset in the test env) selects superjson — wire unchanged', () => {
     // The module read process.env.TRPC_WRITE_DEVALUE at load; it is unset here.

--- a/src/shared/utils/__tests__/trpc-union-transformer.test.ts
+++ b/src/shared/utils/__tests__/trpc-union-transformer.test.ts
@@ -169,6 +169,30 @@ describe('unionDeserialize — pages-router POST-body double-parse recovery (mut
     }
   });
 
+  // Contract pin #1: devalue encodes these as BARE negative-int markers
+  // (undefined→-1, NaN→-3, Infinity→-4, -Infinity→-5, -0→-6), so after the
+  // double-parse they arrive as bare NUMBERS, not arrays. They must not collide
+  // with isSuperjsonEnvelope and must round-trip losslessly. Guards the
+  // "devalue top-level is array-or-negative-number" contract the fix rests on.
+  it('recovers double-parsed devalue SPECIAL primitives (bare marker numbers)', () => {
+    expect(unionDeserialize(pagesRouterPostBodyDoubleParse(devalueStringify(undefined)))).toBeUndefined();
+    expect(unionDeserialize(pagesRouterPostBodyDoubleParse(devalueStringify(NaN)))).toBeNaN();
+    expect(unionDeserialize(pagesRouterPostBodyDoubleParse(devalueStringify(Infinity)))).toBe(Infinity);
+    expect(unionDeserialize(pagesRouterPostBodyDoubleParse(devalueStringify(-Infinity)))).toBe(-Infinity);
+    // -0 must survive as -0 (devalue emits the -6 marker, not a raw -0).
+    expect(Object.is(unionDeserialize(pagesRouterPostBodyDoubleParse(devalueStringify(-0))), -0)).toBe(true);
+  });
+
+  // Contract pin #2: a user input literally shaped like a superjson envelope
+  // ({ json, ... }) must NOT be mistaken for one. devalue flattens any top-level
+  // object to an ARRAY, so isSuperjsonEnvelope never matches it. Guards the
+  // "superjson-envelope sniff can't be spoofed by user data" contract.
+  it('recovers a devalue input literally shaped like a { json, ... } superjson envelope', () => {
+    for (const x of [{ json: 5 }, { json: 5, meta: 6 }, { json: { nested: true }, extra: 'x' }]) {
+      expect(unionDeserialize(pagesRouterPostBodyDoubleParse(devalueStringify(x)))).toEqual(x);
+    }
+  });
+
   it('still routes a superjson envelope (its object survives createBody re-stringify) to superjson', () => {
     const x = sample();
     // Superjson path: createBody re-JSON.stringify's the object, so req.json()

--- a/src/shared/utils/trpc-union-transformer.ts
+++ b/src/shared/utils/trpc-union-transformer.ts
@@ -23,9 +23,48 @@ import superjson from 'superjson';
  * always decode a superjson payload written by a stale (pre-migration) peer AND
  * a devalue payload written by an up-to-date one. READ stays UNION on every slot
  * in Phase 2 — only the SERVER response write is (env-)flipped, never the read.
+ *
+ * DOUBLE-PARSE RECOVERY (the generateFromGraph / all-mutations 500 incident):
+ * on the Next.js **pages-router** adapter a devalue INPUT that arrives in the
+ * POST BODY is JSON-parsed twice before it reaches us — once by Next's
+ * `bodyParser` (`req.body` becomes the bare devalue STRING) and again by tRPC's
+ * `createBody` short-circuit (`typeof req.body === 'string'` returns it un-re-
+ * quoted) + `req.json()`. The single JSON-string quoting that `getBody` put
+ * around the devalue payload is gone, so `req.json()` parses the devalue string
+ * itself (a JSON array, e.g. `[{…},…]`) into an ARRAY. The `typeof === 'string'`
+ * sniff then misses, `superjson.deserialize(array)` returns `undefined`, and the
+ * resolver receives `undefined` input (500 on procedures that destructure it,
+ * BAD_REQUEST on zod-validated ones). Superjson inputs are unaffected — their
+ * `{ json, meta }` object survives `createBody`'s re-`JSON.stringify`. GET/query
+ * inputs are unaffected — they ride the URL, not the body. Batched inputs are
+ * unaffected — the devalue string is nested inside the batch `{ "0": … }` object,
+ * which `createBody` re-stringifies intact.
+ *
+ * Recovery: `superjson.serialize` ALWAYS emits a `{ json, meta? }` OBJECT
+ * envelope, whereas a double-parsed devalue payload is an ARRAY (or a bare
+ * primitive) — never such an envelope — so the two never collide. Any non-string,
+ * non-null value that is NOT a superjson envelope is a double-parsed devalue
+ * payload: re-`JSON.stringify` it (this exactly reconstructs devalue's canonical
+ * JSON string) and hand it to `devalue.parse`. This makes the SERVER robust to
+ * already-cached clients that still WRITE devalue inputs, independent of the
+ * client write format, so those clients recover without a bundle refresh.
  */
+function isSuperjsonEnvelope(object: unknown): object is { json: unknown; meta?: unknown } {
+  return (
+    typeof object === 'object' &&
+    object !== null &&
+    !Array.isArray(object) &&
+    'json' in (object as Record<string, unknown>)
+  );
+}
+
 export function unionDeserialize(object: unknown): any {
-  return typeof object === 'string' ? devalueParse(object) : superjson.deserialize(object as any);
+  if (typeof object === 'string') return devalueParse(object);
+  if (object == null) return superjson.deserialize(object as any);
+  if (isSuperjsonEnvelope(object)) return superjson.deserialize(object as any);
+  // A devalue payload double-parsed out of its JSON-string quoting on the
+  // pages-router POST-body path (see the DOUBLE-PARSE RECOVERY note above).
+  return devalueParse(JSON.stringify(object));
 }
 
 /**


### PR DESCRIPTION
## The incident this fixes
5.0.2105 (#3178, since reverted in #3197) made the tRPC client write **devalue-encoded inputs**. In prod this broke **mutations broadly** — the devalue input in a **non-batched POST body deserialized to `undefined` server-side** (5836 mutation errors vs 277 query errors in 15m; `orchestrator.generateFromGraph` 500'd, the rest returned zod `BAD_REQUEST "received undefined"`).

## Root cause (double JSON-parse)
The client writes devalue as a JSON **string**. On the Next.js pages-router path, a non-batched POST body is parsed twice: Next `bodyParser` `JSON.parse`s it once (stripping devalue's string-quoting → a bare array), then tRPC `createBody` returns it un-re-quoted. `unionDeserialize`'s `typeof === 'string'` sniff then misses and routes it to `superjson.deserialize(array)` → **`undefined`**. Queries (GET URL) and batched requests keep their quoting intact — which is exactly why only non-batched mutations broke. Version-independent (same sniff in both images), so the image rollback alone couldn't fix already-cached clients.

## The fix
Harden `unionDeserialize`: if the value is neither a string nor a superjson `{json,meta}` envelope, treat it as a double-parsed devalue payload → `devalueParse(JSON.stringify(object))`.
- superjson **always** emits a `{json,meta}` envelope; devalue's top-level output is **always a JSON array** — so the two branches never collide.
- The new branch is **inert on every non-buggy path** (client response reads, SSR hydrate, batched inputs, GET inputs are byte-identical).
- **Recovers already-cached devalue-writing clients the moment it deploys**, and is forward-safe if the input-write flip is ever re-attempted on top of this fix.

Adds 3 tests modelling the pages-router double-parse (they fail against the old one-liner). Suite: **25/25**.

## ⚠️ Do not merge yet
An adversarial audit of this change is in progress (sniff-collision safety, `JSON.stringify∘JSON.parse` round-trip fidelity, bare-primitive/array inputs, response/SSR inertness). Hold for the audit; and per the incident lesson, validate against a **real cached-client devalue mutation** after deploy before declaring the incident closed — deployed ≠ verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)