### PR TITLE
fix(image): sortAt BEFORE trigger fires on all Image updates

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260716140000_sortat_trigger_all_updates/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260716140000_sortat_trigger_all_updates/migration.sql
@@ -1,0 +1,43 @@
+-- Image.sortAt — widen the BEFORE trigger to fire on EVERY Image write.
+--
+-- Amendment to 20260716130000_image_sort_at_triggers. That migration scoped the
+-- BEFORE trigger to `UPDATE OF "scannedAt", "postId"`. There is deliberately NO
+-- backfill of the historical rows (Zuri, 2026-07-16: 88.1% of ~105M rows hold a
+-- stale default-now() sortAt ⇒ a ~92M-row rewrite / 200-400GB WAL — cancelled).
+--
+-- WHY ALL-UPDATES: sortAt is NOT NULL, so those ~92M stale rows cannot be rescued
+-- by a COALESCE(NEW."sortAt", …) fallback in the downstream bitdex sync trigger —
+-- it would read and emit the stale value as sortAtUnix. With a column-listed
+-- trigger, a stale row's sortAt is only repaired if it happens to receive a
+-- scannedAt/postId write; an nsfwLevel-only edit (say) would fire the sync trigger
+-- with the stale column intact and emit GARBAGE to BitDex. Recomputing NEW.sortAt
+-- on ANY Image write makes the column correct-on-write: whatever touches the row
+-- first repairs its sortAt before the sync emission reads it.
+--
+-- Idempotency / no fight: the Post fan-out UPDATE (sortAt, updatedAt) now also
+-- fires this BEFORE trigger. At fan-out time the Post row already holds the new
+-- publishedAt (it is an AFTER trigger on Post), so set_image_sort_at() recomputes
+-- the IDENTICAL GREATEST value the fan-out's SET clause used and leaves updatedAt
+-- untouched. No recursion — a BEFORE trigger only mutates NEW in place, issuing no
+-- new UPDATE. Rejected alternative: dropping the fan-out's sortAt write and
+-- computing sortAtUnix purely in the sync emission would MISS publish changes —
+-- the Post subselect evaluates identically for OLD and NEW at fire time, so the
+-- sync trigger's OLD≠NEW change-detection never sees the publish.
+--
+-- COST: the Post PK subselect in set_image_sort_at() now runs on EVERY Image
+-- UPDATE (nsfwLevel, tags, reactions, …), not just publishes. This is exactly what
+-- W3's [PR-M2] steady-state latency gate must measure at prod write rate.
+--
+-- Mirrors packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql
+-- (re-applied every `db:program`); repeated here so a manual apply installs it.
+--
+-- MANUAL APPLY ONLY (main civitai DB does NOT auto-apply Prisma migrations).
+-- CREATE OR REPLACE TRIGGER takes SHARE ROW EXCLUSIVE on the hot 105M "Image"
+-- table (catalog-only, no rewrite, but blocks/queues behind writes) — run off-peak
+-- with `SET lock_timeout = '5s';` and retry. Idempotent / re-runnable.
+
+CREATE OR REPLACE TRIGGER image_sort_at_before
+  BEFORE INSERT OR UPDATE
+  ON "Image"
+  FOR EACH ROW
+EXECUTE FUNCTION set_image_sort_at();

--- a/packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql
+++ b/packages/civitai-db-schema/prisma/programmability/image_post_triggers.sql
@@ -6,15 +6,35 @@
 -- index (and Meili) already use — there is no sentinel, and visibility is still
 -- gated elsewhere; this only fixes the sort *position*.
 --
--- Two authors, deliberately disjoint so they never fight and never recurse:
---   1. set_image_sort_at()   BEFORE INSERT OR UPDATE OF scannedAt, postId ON Image
---      — owns changes that originate on the Image row itself.
+-- Two authors:
+--   1. set_image_sort_at()   BEFORE INSERT OR UPDATE ON Image (ALL columns)
+--      — recomputes NEW.sortAt on EVERY image write from the current Post +
+--        NEW.scannedAt/createdAt. Correct-on-write: any touch of a row fixes its
+--        sortAt before anything downstream reads it.
 --   2. update_image_sort_at() AFTER UPDATE OF publishedAt ON Post
 --      — fans a publishedAt move out to every image on the post.
--- The Post fan-out writes only "sortAt"/"updatedAt"; the Image BEFORE trigger
--- fires only on {scannedAt, postId}. Because those column sets are disjoint, the
--- fan-out's UPDATE does not re-fire the BEFORE trigger (no recursion), and even
--- if it did both paths compute the identical GREATEST value (idempotent).
+--
+-- Why the BEFORE trigger fires on ALL updates, not just {scannedAt, postId}:
+-- there is deliberately NO backfill of the ~92M historical rows still holding a
+-- stale default-now() sortAt (Zuri, 2026-07-16: 88.1% mismatch ⇒ ~92M-row
+-- rewrite, 200-400GB WAL — cancelled). The sortAt column is NOT NULL, so a
+-- COALESCE(NEW.sortAt, …) belt in the downstream bitdex sync trigger cannot fall
+-- back — it would read and emit the stale value. Recomputing on every write means
+-- an unrelated UPDATE (e.g. an nsfwLevel-only edit) repairs the row's sortAt
+-- before the sync trigger's emission expression reads it. A column-listed trigger
+-- would leave those rows stale until they happened to receive a scannedAt/postId
+-- write.
+--
+-- Fight / recursion: the Post fan-out's UPDATE (sortAt, updatedAt) now DOES fire
+-- the BEFORE trigger. No fight — at fan-out time the Post row already holds the
+-- new publishedAt (AFTER trigger), so set_image_sort_at recomputes the IDENTICAL
+-- GREATEST value the fan-out's SET clause used, and leaves updatedAt untouched. No
+-- recursion — a BEFORE trigger only mutates NEW in place; it issues no new UPDATE.
+-- The fan-out still WRITES sortAt (rather than only bumping updatedAt and letting
+-- the BEFORE trigger compute it) because the bitdex sync trigger detects publish
+-- changes via OLD≠NEW on the stored column; a purely-computed emission expression
+-- would evaluate the Post subselect identically for OLD and NEW at fire time and
+-- MISS the publish (rejected alternative).
 
 -- Retire the 2024 predecessors (migration 20240719172747). Back then two authors
 -- wrote sortAt: update_image_sort_at() (Post side, later neutered by this file to
@@ -30,9 +50,9 @@ DROP TRIGGER IF EXISTS new_image_sort_at ON "Image";
 ---
 DROP FUNCTION IF EXISTS update_new_image_sort_at();
 ---
--- 1. Per-row author. Reads the parent Post's publishedAt directly, so a fresh
---    insert, a scan completing (scannedAt bump), or an image moving between
---    posts (postId change) all restamp sortAt from the correct post.
+-- 1. Per-row author. Reads the parent Post's publishedAt directly and restamps
+--    sortAt on every image write — insert, scan completion, postId move, or any
+--    other column edit (see the all-updates rationale in the header).
 CREATE OR REPLACE FUNCTION set_image_sort_at()
   RETURNS TRIGGER AS
 $$
@@ -50,16 +70,17 @@ END;
 $$ LANGUAGE plpgsql;
 ---
 CREATE OR REPLACE TRIGGER image_sort_at_before
-  BEFORE INSERT OR UPDATE OF "scannedAt", "postId"
+  BEFORE INSERT OR UPDATE
   ON "Image"
   FOR EACH ROW
 EXECUTE FUNCTION set_image_sort_at();
 ---
 -- 2. Fan-out author. A Post's publishedAt moving (publish, schedule, reschedule,
 --    unpublish — including the model/version publish/unpublish flows, which all
---    rewrite Post.publishedAt) restamps every image on that post. Computed
---    inline once here (not a bare touch) because the Image BEFORE trigger does
---    NOT fire on a sortAt-only UPDATE — its column list is {scannedAt, postId}.
+--    rewrite Post.publishedAt) restamps every image on that post. It WRITES sortAt
+--    (not a bare updatedAt touch) so the bitdex sync trigger sees OLD≠NEW on the
+--    column and emits the publish change (see header). The BEFORE trigger re-fires
+--    on this UPDATE and recomputes the same value — harmless.
 --    UNCONDITIONAL (no IS DISTINCT FROM guard): every image on the post gets its
 --    "updatedAt" bumped even when sortAt is unchanged. Meili's incremental image
 --    sync selects `WHERE updatedAt > lastUpdate` (images.search-index.ts:298-304),

--- a/scripts/oneoffs/verify-image-sort-at-triggers.sql
+++ b/scripts/oneoffs/verify-image-sort-at-triggers.sql
@@ -1,18 +1,21 @@
 -- Manual verification for the Image.sortAt triggers
--- (migration 20260716130000_image_sort_at_triggers /
+-- (migrations 20260716130000_image_sort_at_triggers +
+--  20260716140000_sortat_trigger_all_updates /
 --  programmability/image_post_triggers.sql).
 --
--- Self-contained and NON-DESTRUCTIVE: everything runs inside a transaction that
--- ROLLs BACK at the end, so it can be run against any environment that already
--- has the triggers installed. It borrows one real User id (FK requirement) but
--- writes no permanent rows.
+-- Runs inside a transaction that ROLLs BACK at the end. It borrows one real User
+-- id (FK requirement) but writes no permanent rows.
+--
+-- DEV-ONLY: creates a tx-scoped audit trigger on "Image" and (CASE 11) briefly
+-- DISABLEs/ENABLEs the sortAt trigger to inject a stale value. Never run against
+-- prod.
 --
 --   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f verify-image-sort-at-triggers.sql
 --
 -- Every case ASSERTs the expected sortAt; a failure aborts with the case name.
 -- sortAt = GREATEST(post.publishedAt, image.scannedAt, image.createdAt), with
 -- GREATEST ignoring NULLs (draft/unpublished/postless -> GREATEST(scannedAt,
--- createdAt)).
+-- createdAt)). The BEFORE trigger fires on EVERY Image write (all-updates).
 
 BEGIN;
 
@@ -35,6 +38,8 @@ DECLARE
   audit_img    int;
   reg_post     int;
   reg_img      int;
+  stale_post   int;
+  stale_img    int;
   n            bigint;
   created      timestamptz := '2024-01-01 00:00:00Z';
   scanned      timestamptz := '2024-02-01 00:00:00Z';  -- > createdAt
@@ -112,10 +117,10 @@ BEGIN
   ASSERT got = publish_past, format('CASE 8 postId move to published: got %s, want %s', got, publish_past);
 
   -- CASE 9 — recursion / double-write non-fire. Publish a fresh single-image
-  -- draft and assert the fan-out touched that image EXACTLY once. The Post
-  -- fan-out UPDATE writes {sortAt, updatedAt}; the Image BEFORE trigger fires
-  -- only on {scannedAt, postId}, so it must NOT re-fire here — a second audit
-  -- row would mean a cascade.
+  -- draft and assert the fan-out produced EXACTLY one Image row-version. The Post
+  -- fan-out UPDATE now DOES re-fire the all-updates BEFORE trigger, but a BEFORE
+  -- trigger only mutates NEW in place (no new UPDATE), so it must not add a second
+  -- row-version — a count > 1 would mean a real cascade.
   INSERT INTO "Post" ("userId", "publishedAt", "createdAt", "updatedAt")
     VALUES (uid, NULL, created, now()) RETURNING id INTO other_post;
   INSERT INTO "Image" ("url", "userId", "postId", "scannedAt", "createdAt", "updatedAt")
@@ -139,13 +144,32 @@ BEGIN
     VALUES ('v', uid, reg_post, scanned_late, created, now()) RETURNING id INTO reg_img;
   ASSERT (SELECT "sortAt" FROM "Image" WHERE id = reg_img) = scanned_late,
     'CASE 10 setup: sortAt should be scanned_late';
-  UPDATE "Image" SET "updatedAt" = sentinel_upd WHERE id = reg_img;  -- BEFORE trigger not fired (updatedAt not in its column list)
+  UPDATE "Image" SET "updatedAt" = sentinel_upd WHERE id = reg_img;  -- BEFORE trigger re-fires, recomputes same sortAt (scanned_late is the max)
   UPDATE "Post" SET "publishedAt" = NULL WHERE id = reg_post;        -- unpublish; sortAt stays scanned_late
   SELECT "sortAt", "updatedAt" INTO got, got_upd FROM "Image" WHERE id = reg_img;
   ASSERT got = scanned_late, format('CASE 10 sortAt should be unchanged: got %s, want %s', got, scanned_late);
   ASSERT got_upd <> sentinel_upd, 'CASE 10 REGRESSION: updatedAt not bumped on sortAt-unchanged unpublish (Meili would miss it)';
 
-  RAISE NOTICE 'ALL 10 CASES PASSED';
+  -- CASE 11 — ALL-UPDATES repair of a STALE sortAt (the ~92M no-backfill rows).
+  -- Simulate a pre-existing stale row by injecting a bogus sortAt with the BEFORE
+  -- trigger disabled, then prove an UNRELATED column edit (nsfwLevel) recomputes
+  -- it correct-on-write. A column-listed {scannedAt,postId} trigger would leave it
+  -- stale, and the downstream sync trigger would emit the garbage value.
+  INSERT INTO "Post" ("userId", "publishedAt", "createdAt", "updatedAt")
+    VALUES (uid, publish_past, created, now()) RETURNING id INTO stale_post;
+  INSERT INTO "Image" ("url", "userId", "postId", "scannedAt", "createdAt", "updatedAt")
+    VALUES ('v', uid, stale_post, scanned, created, now()) RETURNING id INTO stale_img;
+  ALTER TABLE "Image" DISABLE TRIGGER image_sort_at_before;
+  UPDATE "Image" SET "sortAt" = '1999-01-01Z' WHERE id = stale_img;   -- inject stale value
+  ALTER TABLE "Image" ENABLE TRIGGER image_sort_at_before;
+  ASSERT (SELECT "sortAt" FROM "Image" WHERE id = stale_img) = '1999-01-01Z'::timestamptz,
+    'CASE 11 setup: stale sortAt not injected';
+  UPDATE "Image" SET "nsfwLevel" = 5 WHERE id = stale_img;            -- unrelated edit, no sortAt/scannedAt/postId
+  SELECT "sortAt" INTO got FROM "Image" WHERE id = stale_img;
+  ASSERT got = publish_past,
+    format('CASE 11 stale repair: unrelated edit left sortAt %s, want %s (all-updates recompute)', got, publish_past);
+
+  RAISE NOTICE 'ALL 11 CASES PASSED';
 END $$;
 
 ROLLBACK;


### PR DESCRIPTION
## What

Amendment to #3168: widen the `image_sort_at_before` trigger from `BEFORE INSERT OR UPDATE OF "scannedAt", "postId"` to **`BEFORE INSERT OR UPDATE`** (no column list) — every Image write recomputes `NEW."sortAt"` from the current Post + NEW values.

One-line diff to the trigger; the migration + programmability file + verify script carry the rationale and proof.

## Why (the no-backfill consequence)

The backfill of historical `sortAt` was **cancelled** (Zuri, 2026-07-16: 88.1% of ~105M rows mismatch the correct formula ⇒ a ~92M-row rewrite / 200-400GB WAL). So ~92M rows keep a **stale `default-now()` `sortAt`**.

`sortAt` is `NOT NULL`, so a `COALESCE(NEW."sortAt", …)` belt in the downstream **bitdex sync trigger** cannot fall back — it reads and emits the stale value as `sortAtUnix`. With the column-listed trigger, a stale row is only repaired if it happens to receive a `scannedAt`/`postId` write; an unrelated edit (e.g. `nsfwLevel`) fires the sync trigger with the stale column intact and **emits garbage to BitDex**.

Recomputing `NEW."sortAt"` on **every** Image write makes the column **correct-on-write**: whatever touches a row first repairs its `sortAt` before the sync emission reads it.

## Idempotency / no fight (verified)

The Post fan-out `UPDATE "Image" SET sortAt, updatedAt …` now also fires this BEFORE trigger. No fight: at fan-out time the Post row already holds the new `publishedAt` (it's an AFTER trigger on Post), so `set_image_sort_at()` recomputes the **identical** `GREATEST` value the fan-out's SET clause used, and leaves `updatedAt` untouched. No recursion: a BEFORE trigger only mutates `NEW` in place, issuing no new UPDATE.

**Rejected alternative (noted for the record):** drop the fan-out's `sortAt` write and compute `sortAtUnix` purely in the sync emission. That would MISS publish changes — the Post subselect evaluates identically for OLD and NEW at fire time, so the sync trigger's `OLD ≠ NEW` change-detection never sees the publish. The fan-out therefore keeps physically writing `sortAt`.

## Cost

The Post PK subselect in `set_image_sort_at()` now runs on **every** Image UPDATE (nsfwLevel, tags, reactions, …), not just publishes. This is exactly what **W3's [PR-M2] steady-state latency gate** must measure at prod write rate — flagging, not resolving, here.

## Proof

Verify script gains **CASE 11**: inject a stale `sortAt` (BEFORE trigger disabled), then an unrelated `nsfwLevel`-only edit must recompute it. Proven both ways on Postgres 17:
- Under the **column-listed** trigger (merged #3168): the `nsfwLevel` edit leaves `sortAt` stale → CASE 11 fails (the bug this PR fixes).
- Under **all-updates**: the edit repairs `sortAt` → CASE 11 passes. **All 11 cases green.**

## Files

- `programmability/image_post_triggers.sql` — trigger widened; disjointness/recursion comments rewritten for the all-updates model.
- `migrations/20260716140000_sortat_trigger_all_updates/migration.sql` — MANUAL-APPLY `CREATE OR REPLACE TRIGGER` (SHARE ROW EXCLUSIVE on the hot 105M table → `lock_timeout='5s'` + off-peak + retry).
- `scripts/oneoffs/verify-image-sort-at-triggers.sql` — CASE 11 + refreshed comments (now marked dev-only: it DISABLE/ENABLEs the trigger to seed the stale row).

## Rollback

Re-apply the column-listed form: `CREATE OR REPLACE TRIGGER image_sort_at_before BEFORE INSERT OR UPDATE OF "scannedAt", "postId" ON "Image" FOR EACH ROW EXECUTE FUNCTION set_image_sort_at();` (reverts to #3168 behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
