### PR TITLE
preview: exercise the #3198 devalue POST-body fix

### DIFF
--- a/src/shared/utils/trpc-union-transformer.ts
+++ b/src/shared/utils/trpc-union-transformer.ts
@@ -193,6 +193,12 @@ export const unionTransformer: CombinedDataTransformer = buildTransformer();
  * object — the client never serializes a response.
  */
 export const clientTransformer: CombinedDataTransformer = {
-  input: { serialize: superjson.serialize, deserialize: unionDeserialize },
+  // THROWAWAY PREVIEW ONLY — re-enables the #3178 client devalue input-write on
+  // top of the #3198 unionDeserialize double-parse fix, so this preview
+  // reproduces the exact incident trigger (client writes devalue POST bodies)
+  // against the fixed server. Mutations must WORK here; if the fix were wrong
+  // they'd 500 like prod did. DO NOT MERGE — production keeps superjson writes
+  // until the fix is deployed + verified.
+  input: { serialize: writeSerializeWithFallback, deserialize: unionDeserialize },
   output: { serialize: superjson.serialize, deserialize: unionDeserialize },
 };


### PR DESCRIPTION
**Throwaway PR — DO NOT MERGE.** Purpose: spin up a preview env at `pr-<N>.civitaic.com` that reproduces the production incident trigger against the fix, so it can be tested before we deploy to prod.

- Base = current `main`, which already has **#3198** (the `unionDeserialize` double-parse fix) and the **#3178 revert**.
- This PR re-applies **only** #3178's client change (`clientTransformer.input.serialize = writeSerializeWithFallback`), so the preview's browser bundle **writes devalue-encoded inputs** — the exact condition that broke all mutations in prod (non-batched POST body → `undefined` server-side).
- With #3198's fix present, those mutations should now **work**. If the fix were wrong, this preview would 500 on `orchestrator.generateFromGraph`, `reaction.toggle`, etc. — the same signature as the incident.

**What to test on the preview:** run the generator (`generateFromGraph`), toggle a reaction, save to a collection — anything that's a mutation. All should succeed. (Preview uses the dev DB by default.)

Production is unaffected — it keeps superjson writes until #3198 is deployed and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)