### PR TITLE
fix(challenge): schedule limits for user challenges — min/max duration + max future start (868kd6gmw)

### DIFF
--- a/src/components/Challenge/ChallengeUpsertForm.tsx
+++ b/src/components/Challenge/ChallengeUpsertForm.tsx
@@ -60,12 +60,18 @@ import CategoryWeights from '~/components/Challenge/CategoryWeights';
 import {
   type CategoryWeightRow,
   CHALLENGE_ENTRY_HOUSE_CUT,
+  CHALLENGE_MAX_DURATION_DAYS,
+  CHALLENGE_MAX_DURATION_MS,
   CHALLENGE_MAX_ENTRY_FEE,
   CHALLENGE_MAX_INITIAL_PRIZE,
+  CHALLENGE_MAX_START_LEAD_DAYS,
+  CHALLENGE_MIN_DURATION_HOURS,
+  CHALLENGE_MIN_DURATION_MS,
   CHALLENGE_MIN_ENTRY_FEE,
   CHALLENGE_MIN_START_LEAD_HOURS,
   DEFAULT_CATEGORY_ROWS,
   getEntryPoolContribution,
+  getMaxUserChallengeStartsAt,
   getMinUserChallengeStartsAt,
   getUserChallengeVisibleAt,
 } from '~/shared/constants/challenge.constants';
@@ -389,12 +395,34 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
         return;
       }
 
-      // Start must be >= 3h out. Mirrors the server: always on create, on edit only when the
-      // start date actually moved (so an unrelated edit near start time isn't blocked).
+      // Duration bounds mirror the server (and zod schema): intrinsic to the payload, so they
+      // apply on create and edit alike.
+      const durationMs = endsAt.getTime() - startsAt.getTime();
+      if (durationMs < CHALLENGE_MIN_DURATION_MS) {
+        form.setError('endsAt', {
+          message: `Challenge must run for at least ${CHALLENGE_MIN_DURATION_HOURS} hours.`,
+        });
+        return;
+      }
+      if (durationMs > CHALLENGE_MAX_DURATION_MS) {
+        form.setError('endsAt', {
+          message: `Challenge cannot run longer than ${CHALLENGE_MAX_DURATION_DAYS} days.`,
+        });
+        return;
+      }
+
+      // Start must be >= 3h and <= 30d out. Mirrors the server: always on create, on edit only
+      // when the start date actually moved (so an unrelated edit near start time isn't blocked).
       const startMoved = !challenge || startsAt.getTime() !== challenge.startsAt.getTime();
       if (startMoved && startsAt < getMinUserChallengeStartsAt()) {
         form.setError('startsAt', {
           message: `Challenge must start at least ${CHALLENGE_MIN_START_LEAD_HOURS} hours from now.`,
+        });
+        return;
+      }
+      if (startMoved && startsAt > getMaxUserChallengeStartsAt()) {
+        form.setError('startsAt', {
+          message: `Challenge cannot start more than ${CHALLENGE_MAX_START_LEAD_DAYS} days from now.`,
         });
         return;
       }

--- a/src/server/schema/challenge.schema.test.ts
+++ b/src/server/schema/challenge.schema.test.ts
@@ -188,4 +188,15 @@ describe('userChallengeUpsertSchema duration limits', () => {
     const result = userChallengeUpsertSchema.safeParse(endingAfter(CHALLENGE_MAX_DURATION_MS + 1));
     expect(result.success).toBe(false);
   });
+
+  it('emits only the ordering error (no spurious duration issue) when endsAt <= startsAt', () => {
+    const result = userChallengeUpsertSchema.safeParse(endingAfter(-3600 * 1000));
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(messages).toContain('End date must be after start date');
+      expect(messages.some((m) => m.includes('must run for at least'))).toBe(false);
+      expect(messages.some((m) => m.includes('cannot run longer than'))).toBe(false);
+    }
+  });
 });

--- a/src/server/schema/challenge.schema.test.ts
+++ b/src/server/schema/challenge.schema.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   CHALLENGE_MAX_INITIAL_PRIZE,
+  CHALLENGE_MAX_DURATION_MS,
+  CHALLENGE_MIN_DURATION_MS,
   CHALLENGE_MIN_ENTRY_FEE,
 } from '~/shared/constants/challenge.constants';
 import {
@@ -148,6 +150,42 @@ describe('upsertChallengeSchema judgingCategories', () => {
         { key: 'creativity', weight: 20 },
       ],
     });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('userChallengeUpsertSchema duration limits', () => {
+  const startsAt = new Date('2026-08-01T00:00:00Z');
+  const valid = {
+    title: 'A valid challenge title',
+    description: 'A valid challenge description.',
+    theme: 'Neon',
+    coverImage: { url: '123e4567-e89b-12d3-a456-426614174000' },
+    judgeId: 1,
+    judgingCategories: [{ key: 'theme', label: 'Theme', criteria: 'Fits the theme.', weight: 100 }],
+    entryFee: CHALLENGE_MIN_ENTRY_FEE,
+    initialPrizeBuzz: 0,
+    prizeDistribution: [50, 30, 20],
+    maxEntriesPerUser: 5,
+    startsAt,
+  };
+  const endingAfter = (ms: number) => ({ ...valid, endsAt: new Date(startsAt.getTime() + ms) });
+
+  it('accepts a duration exactly at the minimum', () => {
+    expect(userChallengeUpsertSchema.safeParse(endingAfter(CHALLENGE_MIN_DURATION_MS)).success).toBe(true);
+  });
+
+  it('rejects a duration just under the minimum', () => {
+    const result = userChallengeUpsertSchema.safeParse(endingAfter(CHALLENGE_MIN_DURATION_MS - 1));
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a duration exactly at the maximum', () => {
+    expect(userChallengeUpsertSchema.safeParse(endingAfter(CHALLENGE_MAX_DURATION_MS)).success).toBe(true);
+  });
+
+  it('rejects a duration just over the maximum', () => {
+    const result = userChallengeUpsertSchema.safeParse(endingAfter(CHALLENGE_MAX_DURATION_MS + 1));
     expect(result.success).toBe(false);
   });
 });

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -461,14 +461,26 @@ export const userChallengeUpsertSchema = userChallengeUpsertBaseSchema
     message: 'End date must be after start date',
     path: ['endsAt'],
   })
-  .refine((data) => data.endsAt.getTime() - data.startsAt.getTime() >= CHALLENGE_MIN_DURATION_MS, {
-    message: `Challenge must run for at least ${CHALLENGE_MIN_DURATION_HOURS} hours.`,
-    path: ['endsAt'],
-  })
-  .refine((data) => data.endsAt.getTime() - data.startsAt.getTime() <= CHALLENGE_MAX_DURATION_MS, {
-    message: `Challenge cannot run longer than ${CHALLENGE_MAX_DURATION_DAYS} days.`,
-    path: ['endsAt'],
-  });
+  // Duration bounds only apply once the dates are ordered — otherwise the reversed-date case
+  // would stack a spurious "must run for at least" issue on top of the ordering error above.
+  .refine(
+    (data) =>
+      data.endsAt <= data.startsAt ||
+      data.endsAt.getTime() - data.startsAt.getTime() >= CHALLENGE_MIN_DURATION_MS,
+    {
+      message: `Challenge must run for at least ${CHALLENGE_MIN_DURATION_HOURS} hours.`,
+      path: ['endsAt'],
+    }
+  )
+  .refine(
+    (data) =>
+      data.endsAt <= data.startsAt ||
+      data.endsAt.getTime() - data.startsAt.getTime() <= CHALLENGE_MAX_DURATION_MS,
+    {
+      message: `Challenge cannot run longer than ${CHALLENGE_MAX_DURATION_DAYS} days.`,
+      path: ['endsAt'],
+    }
+  );
 export type UserChallengeUpsertInput = z.infer<typeof userChallengeUpsertSchema>;
 
 // Moderator: Delete challenge

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -13,8 +13,12 @@ import {
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 import {
+  CHALLENGE_MAX_DURATION_DAYS,
+  CHALLENGE_MAX_DURATION_MS,
   CHALLENGE_MAX_ENTRY_FEE,
   CHALLENGE_MAX_INITIAL_PRIZE,
+  CHALLENGE_MIN_DURATION_HOURS,
+  CHALLENGE_MIN_DURATION_MS,
   CHALLENGE_MIN_ENTRY_FEE,
 } from '~/shared/constants/challenge.constants';
 import { infiniteQuerySchema } from './base.schema';
@@ -452,10 +456,19 @@ export const userChallengeUpsertBaseSchema = z.object({
   endsAt: z.date(),
 });
 
-export const userChallengeUpsertSchema = userChallengeUpsertBaseSchema.refine(
-  (data) => data.endsAt > data.startsAt,
-  { message: 'End date must be after start date', path: ['endsAt'] }
-);
+export const userChallengeUpsertSchema = userChallengeUpsertBaseSchema
+  .refine((data) => data.endsAt > data.startsAt, {
+    message: 'End date must be after start date',
+    path: ['endsAt'],
+  })
+  .refine((data) => data.endsAt.getTime() - data.startsAt.getTime() >= CHALLENGE_MIN_DURATION_MS, {
+    message: `Challenge must run for at least ${CHALLENGE_MIN_DURATION_HOURS} hours.`,
+    path: ['endsAt'],
+  })
+  .refine((data) => data.endsAt.getTime() - data.startsAt.getTime() <= CHALLENGE_MAX_DURATION_MS, {
+    message: `Challenge cannot run longer than ${CHALLENGE_MAX_DURATION_DAYS} days.`,
+    path: ['endsAt'],
+  });
 export type UserChallengeUpsertInput = z.infer<typeof userChallengeUpsertSchema>;
 
 // Moderator: Delete challenge

--- a/src/server/services/__tests__/challenge-edit.service.test.ts
+++ b/src/server/services/__tests__/challenge-edit.service.test.ts
@@ -443,4 +443,16 @@ describe('upsertUserChallenge — schedule limits', () => {
       } as never)
     ).rejects.toThrow('Challenge cannot start more than 30 days from now.');
   });
+
+  it('rejects an edit with a duration over the maximum', async () => {
+    const startsAt = new Date(Date.now() + 5 * DAY);
+    await expect(
+      upsertUserChallenge({
+        ...baseInput,
+        id: 42,
+        startsAt,
+        endsAt: new Date(startsAt.getTime() + 31 * DAY),
+      } as never)
+    ).rejects.toThrow('Challenge cannot run longer than 30 days.');
+  });
 });

--- a/src/server/services/__tests__/challenge-edit.service.test.ts
+++ b/src/server/services/__tests__/challenge-edit.service.test.ts
@@ -323,6 +323,8 @@ describe('getUserChallengeForEdit — ownership/moderator gate', () => {
 
 describe('upsertUserChallenge — schedule limits', () => {
   // Minimal input: schedule checks run before judge/standing/DB lookups, so most fields are unused.
+  // judgingCategories still carries a contract-valid shape (theme once, weights sum 100) so the
+  // fixture stays representative if the service ever validates it before the schedule gate.
   const baseInput = {
     userId: 111,
     buzzType: 'yellow' as const,
@@ -333,10 +335,10 @@ describe('upsertUserChallenge — schedule limits', () => {
     allowedNsfwLevel: 1,
     modelVersionIds: [],
     judgeId: 1,
-    judgingCategories: [],
+    judgingCategories: [{ key: 'theme', label: 'Theme', criteria: 'Fits the theme.', weight: 100 }],
     entryFee: 50,
     initialPrizeBuzz: 0,
-    prizeDistribution: [],
+    prizeDistribution: [50, 30, 20],
     maxEntriesPerUser: 5,
   };
   const HOUR = 60 * 60 * 1000;

--- a/src/server/services/__tests__/challenge-edit.service.test.ts
+++ b/src/server/services/__tests__/challenge-edit.service.test.ts
@@ -320,3 +320,127 @@ describe('getUserChallengeForEdit — ownership/moderator gate', () => {
     ).rejects.toThrow('This challenge cannot be edited here.');
   });
 });
+
+describe('upsertUserChallenge — schedule limits', () => {
+  // Minimal input: schedule checks run before judge/standing/DB lookups, so most fields are unused.
+  const baseInput = {
+    userId: 111,
+    buzzType: 'yellow' as const,
+    title: 'Schedule test',
+    description: 'desc',
+    theme: 'Neon',
+    coverImage: { id: 555, url: 'unused' },
+    allowedNsfwLevel: 1,
+    modelVersionIds: [],
+    judgeId: 1,
+    judgingCategories: [],
+    entryFee: 50,
+    initialPrizeBuzz: 0,
+    prizeDistribution: [],
+    maxEntriesPerUser: 5,
+  };
+  const HOUR = 60 * 60 * 1000;
+  const DAY = 24 * HOUR;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects a create with a duration under the minimum', async () => {
+    const startsAt = new Date(Date.now() + 4 * HOUR);
+    await expect(
+      upsertUserChallenge({
+        ...baseInput,
+        startsAt,
+        endsAt: new Date(startsAt.getTime() + 23 * HOUR),
+      } as never)
+    ).rejects.toThrow('Challenge must run for at least 24 hours.');
+  });
+
+  it('rejects a create with a duration over the maximum', async () => {
+    const startsAt = new Date(Date.now() + 4 * HOUR);
+    await expect(
+      upsertUserChallenge({
+        ...baseInput,
+        startsAt,
+        endsAt: new Date(startsAt.getTime() + 31 * DAY),
+      } as never)
+    ).rejects.toThrow('Challenge cannot run longer than 30 days.');
+  });
+
+  it('rejects a create starting more than 30 days out', async () => {
+    const startsAt = new Date(Date.now() + 31 * DAY);
+    await expect(
+      upsertUserChallenge({
+        ...baseInput,
+        startsAt,
+        endsAt: new Date(startsAt.getTime() + 2 * DAY),
+      } as never)
+    ).rejects.toThrow('Challenge cannot start more than 30 days from now.');
+  });
+
+  it('does NOT apply the create-path max-future check on an edit', async () => {
+    // Stored start > 30d out (e.g. created before the limit existed) and unchanged in the
+    // payload. The top-of-function max-future check must be create-only (`!id`) — the call must
+    // get past all top-of-function schedule gates and reach the challenge lookup, whose null
+    // sentinel produces "Challenge not found".
+    const storedStartsAt = new Date(Date.now() + 40 * DAY);
+    mockAssertUserAccountInGoodStanding.mockResolvedValueOnce({
+      scoreTotal: 0,
+      bannedAt: null,
+      muted: false,
+      deletedAt: null,
+      activeStrikes: 0,
+    });
+    mockDbRead.image.findFirst.mockResolvedValue({ id: 555 });
+    mockDbRead.challenge.findUnique.mockResolvedValueOnce(null);
+
+    await expect(
+      upsertUserChallenge({
+        ...baseInput,
+        id: 42,
+        startsAt: storedStartsAt,
+        endsAt: new Date(storedStartsAt.getTime() + 2 * DAY),
+      } as never)
+    ).rejects.toThrow('Challenge not found');
+  });
+
+  it('rejects an edit that MOVES the start date beyond 30 days out', async () => {
+    const storedStartsAt = new Date(Date.now() + 5 * DAY);
+    const movedStartsAt = new Date(Date.now() + 35 * DAY);
+    mockAssertUserAccountInGoodStanding.mockResolvedValueOnce({
+      scoreTotal: 0,
+      bannedAt: null,
+      muted: false,
+      deletedAt: null,
+      activeStrikes: 0,
+    });
+    mockDbRead.image.findFirst.mockResolvedValue({ id: 555 });
+    // Row shape mirrors the edit branch's findUnique select (challenge.service.ts:~1477-1492).
+    // collectionId: null skips the entry-count query; buzzType/basePrizePool/allowedNsfwLevel
+    // clear the currency + green-SFW gates that run before the startChanged check.
+    mockDbRead.challenge.findUnique.mockResolvedValueOnce({
+      createdById: 111,
+      source: 'User',
+      status: 'Scheduled',
+      collectionId: null,
+      basePrizePool: 0,
+      metadata: null,
+      buzzType: 'yellow',
+      startsAt: storedStartsAt,
+      title: 'Schedule test',
+      description: 'desc',
+      theme: 'Neon',
+      invitation: null,
+    });
+
+    await expect(
+      upsertUserChallenge({
+        ...baseInput,
+        id: 42,
+        startsAt: movedStartsAt,
+        endsAt: new Date(movedStartsAt.getTime() + 2 * DAY),
+      } as never)
+    ).rejects.toThrow('Challenge cannot start more than 30 days from now.');
+  });
+});

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -85,7 +85,14 @@ import {
   type ChallengeBuzzType,
 } from '~/server/games/daily-challenge/challenge-currency';
 import {
+  CHALLENGE_MAX_DURATION_DAYS,
+  CHALLENGE_MAX_DURATION_MS,
+  CHALLENGE_MAX_START_LEAD_DAYS,
+  CHALLENGE_MIN_DURATION_HOURS,
+  CHALLENGE_MIN_DURATION_MS,
+  CHALLENGE_MIN_START_LEAD_HOURS,
   getEntryPoolContribution,
+  getMaxUserChallengeStartsAt,
   getMinUserChallengeStartsAt,
   getUserChallengeVisibleAt,
 } from '~/shared/constants/challenge.constants';
@@ -1380,14 +1387,38 @@ export async function upsertUserChallenge({
     throw new TRPCError({ code: 'BAD_REQUEST', message: 'End date must be after start date' });
   }
 
-  // Start must be at least CHALLENGE_MIN_START_LEAD_HOURS out — no "starts right now" challenges.
-  // On create this always applies; on edit it's only re-checked when the start date actually moves
-  // (guarded below, against the stored startsAt), so an unrelated edit near start time isn't blocked.
+  // Duration bounds are intrinsic to the payload (also validated by the Zod schema), so they
+  // apply on create and edit alike.
+  const durationMs = rest.endsAt.getTime() - rest.startsAt.getTime();
+  if (durationMs < CHALLENGE_MIN_DURATION_MS) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Challenge must run for at least ${CHALLENGE_MIN_DURATION_HOURS} hours.`,
+    });
+  }
+  if (durationMs > CHALLENGE_MAX_DURATION_MS) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Challenge cannot run longer than ${CHALLENGE_MAX_DURATION_DAYS} days.`,
+    });
+  }
+
+  // Start must be at least CHALLENGE_MIN_START_LEAD_HOURS out (no "starts right now") and at
+  // most CHALLENGE_MAX_START_LEAD_DAYS out (no far-future squatting). On create these always
+  // apply; on edit they're only re-checked when the start date actually moves (guarded below,
+  // against the stored startsAt), so an unrelated edit near start time isn't blocked.
   const minStartsAt = getMinUserChallengeStartsAt();
+  const maxStartsAt = getMaxUserChallengeStartsAt();
   if (!id && rest.startsAt < minStartsAt) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
-      message: 'Challenge must start at least 3 hours from now.',
+      message: `Challenge must start at least ${CHALLENGE_MIN_START_LEAD_HOURS} hours from now.`,
+    });
+  }
+  if (!id && rest.startsAt > maxStartsAt) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `Challenge cannot start more than ${CHALLENGE_MAX_START_LEAD_DAYS} days from now.`,
     });
   }
 
@@ -1529,7 +1560,12 @@ export async function upsertUserChallenge({
     if (startChanged && rest.startsAt < minStartsAt)
       throw new TRPCError({
         code: 'BAD_REQUEST',
-        message: 'Challenge must start at least 3 hours from now.',
+        message: `Challenge must start at least ${CHALLENGE_MIN_START_LEAD_HOURS} hours from now.`,
+      });
+    if (startChanged && rest.startsAt > maxStartsAt)
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `Challenge cannot start more than ${CHALLENGE_MAX_START_LEAD_DAYS} days from now.`,
       });
 
     // Only reset the scan verdict when the moderated text actually changed. Resetting on every

--- a/src/shared/constants/challenge.constants.ts
+++ b/src/shared/constants/challenge.constants.ts
@@ -35,6 +35,22 @@ export function getMinUserChallengeStartsAt(from: Date = new Date()): Date {
   return new Date(from.getTime() + CHALLENGE_MIN_START_LEAD_HOURS * 60 * 60 * 1000);
 }
 
+/** Minimum user-challenge duration — a shorter challenge can't realistically collect entries. */
+export const CHALLENGE_MIN_DURATION_HOURS = 24;
+export const CHALLENGE_MIN_DURATION_MS = CHALLENGE_MIN_DURATION_HOURS * 60 * 60 * 1000;
+
+/** Maximum user-challenge duration — bounds how long one occupies a concurrent-challenge slot. */
+export const CHALLENGE_MAX_DURATION_DAYS = 30;
+export const CHALLENGE_MAX_DURATION_MS = CHALLENGE_MAX_DURATION_DAYS * 24 * 60 * 60 * 1000;
+
+/** Max lead time between now and a user challenge's startsAt — blocks far-future squatting. */
+export const CHALLENGE_MAX_START_LEAD_DAYS = 30;
+
+/** Latest allowed startsAt for a user challenge (now + CHALLENGE_MAX_START_LEAD_DAYS). */
+export function getMaxUserChallengeStartsAt(from: Date = new Date()): Date {
+  return new Date(from.getTime() + CHALLENGE_MAX_START_LEAD_DAYS * 24 * 60 * 60 * 1000);
+}
+
 /** Max simultaneously Scheduled+Active user-created challenges, by membership tier.
  * (fib: free 1, bronze 2, silver 3, gold 5; founder treated as bronze.) */
 export const CHALLENGE_TIER_ACTIVE_LIMITS: Record<string, number> = {


### PR DESCRIPTION
## What

Adds three schedule limits to **user-created (public) challenges**, closing tester-reported gaps where a challenge could be created for 1 hour, run for years, or start far in the future.

| Limit | Value | Layer |
|-------|-------|-------|
| Min duration | 24h | zod schema + service + client |
| Max duration | 30 days | zod schema + service + client |
| Max future start | 30 days out | service + client |

Existing validations (`endsAt > startsAt`, start ≥ now+3h) unchanged.

## Scope

- **User challenge path only.** The moderator upsert schema/service (`upsertChallengeSchema` / `upsertChallenge`) is untouched — mods keep full scheduling freedom.
- Duration bounds are intrinsic to the payload → enforced in the zod refine and re-checked in the service; apply to **create and edit** alike.
- Max-future start is `now`-relative → lives in the service + client (not the schema); applies on create always, on edit **only when the start date actually moves** (mirrors the existing 3h-lead guard).
- Error copy is interpolated from the constants in `challenge.constants.ts` so the three layers can't drift.

## 3-hour pre-start review window

The ClickUp task asked to revisit it — **left unchanged.** The content scan is async (submitted at create/edit, resolved via the moderation webhook) and challenge activation hard-gates start on `ingestion = Scanned` (24h re-scan grace, then void+refund). Safety comes from the scan gate, not the window size.

## Testing

- **Unit** — schema boundary tests (exact 24h / 30d inclusive, ±1ms) and service tests (create min/max duration, create max-future start, edit that does NOT re-apply the create-only max-future check when start is unchanged, edit that moves start beyond 30d, edit-path duration violation). 32/32 pass across the two files.
- **Live QA** — authenticated tRPC mutation on a dev server confirmed all three limits fire end-to-end with the exact messages, and a valid 7-day / 5-day-out payload passed the schedule gates (no false-positive).

## Backward compatibility

Pre-existing user challenges whose stored duration is now out of range can't be re-saved until brought into range (delete remains available) — accepted per the spec. A grandfathered far-future start that isn't moved on edit stays editable (max-future is `startChanged`-gated).

## Migration

None. Limits are hardcoded constants, consistent with the other challenge policy values (entry-fee caps, tier limits).

Spec: `docs/superpowers/specs/2026-07-16-challenge-schedule-limits-design.md`
Plan: `docs/superpowers/plans/2026-07-16-challenge-schedule-limits.md`
ClickUp: https://app.clickup.com/t/868kd6gmw

🤖 Generated with [Claude Code](https://claude.com/claude-code)
