### PR TITLE
feat(apps/review): "Open full-page preview" link on Active previews rows

### DIFF
--- a/src/components/Apps/ActivePreviewsPanel.browser.test.tsx
+++ b/src/components/Apps/ActivePreviewsPanel.browser.test.tsx
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * Global "Active previews (N / cap)" panel — browser-mode render test
+ * (report-only in Tekton). The panel was extracted from `src/pages/apps/review.tsx`
+ * to `ActivePreviewsPanel.tsx` (mirrors the #3163 `OnsiteReviewModal` extraction)
+ * so it is importable WITHOUT the page's `getServerSideProps` server graph — this
+ * suite is the coverage that extraction unlocks. Asserts:
+ *  - a `preview-live` row renders an "Open full-page preview" link to the internal
+ *    same-origin `/apps/review/preview/<id>` route (new tab) AND still renders
+ *    "Tear down";
+ *  - a `preview-building` / `preview-deploying` row renders NO "Open" link (only
+ *    "Tear down") — a not-yet-live preview isn't openable;
+ *  - "Tear down" fires `blocks.teardownPreview` with the row's publishRequestId.
+ */
+
+const ROWS = [
+  {
+    publishRequestId: 'req-live',
+    slug: 'live-block',
+    version: '1.0.0',
+    state: 'preview-live',
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  },
+  {
+    publishRequestId: 'req-building',
+    slug: 'building-block',
+    version: '2.0.0',
+    state: 'preview-building',
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  },
+  {
+    publishRequestId: 'req-deploying',
+    slug: 'deploying-block',
+    version: '3.0.0',
+    state: 'preview-deploying',
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+  },
+];
+
+const mocks = vi.hoisted(() => ({
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  mutate: vi.fn(),
+  // Query state the panel renders from — { cap, active } | undefined, plus an
+  // optional error to exercise the authz-silent / transient-retry branches.
+  data: undefined as unknown,
+  error: null as unknown,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true }),
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+vi.mock('~/utils/trpc', () => {
+  const mutation =
+    (name: string) =>
+    (opts?: { onSuccess?: (res: unknown, vars: unknown) => void; onError?: (e: { message: string }) => void }) => ({
+      mutate: (vars: unknown) => {
+        mocks.mutate(name, vars);
+        void opts?.onSuccess?.(undefined, vars);
+      },
+      mutateAsync: vi.fn(),
+      isPending: false,
+      variables: undefined,
+    });
+  const inert = { invalidate: mocks.invalidate };
+  const utils = {
+    blocks: {
+      listActivePreviews: inert,
+      getReviewStatus: inert,
+    },
+  };
+  return {
+    trpc: {
+      useUtils: () => utils,
+      blocks: {
+        listActivePreviews: {
+          useQuery: () => ({
+            data: mocks.data,
+            error: mocks.error,
+            isFetching: false,
+            refetch: vi.fn(),
+          }),
+        },
+        teardownPreview: { useMutation: mutation('teardown') },
+      },
+    },
+  };
+});
+
+const { ActivePreviewsPanel } = await import('./ActivePreviewsPanel');
+
+beforeEach(() => {
+  mocks.invalidate.mockClear();
+  mocks.mutate.mockClear();
+  mocks.data = { cap: 3, active: ROWS };
+  mocks.error = null;
+});
+
+describe('ActivePreviewsPanel — Open affordance is live-only + coexists with Tear down', () => {
+  test('a preview-live row renders an "Open full-page preview" link to the internal route (new tab) plus Tear down', async () => {
+    renderWithProviders(<ActivePreviewsPanel />);
+
+    // The panel header + count render for a non-empty active set.
+    await expect.element(page.getByText('Active previews')).toBeInTheDocument();
+
+    // The live row exposes the Open link, keyed by publishRequestId to the
+    // same-origin internal review route — opened top-level in a new tab.
+    const link = page.getByRole('link', { name: /Open full-page preview/ });
+    await expect.element(link).toBeInTheDocument();
+    const el = link.element() as HTMLAnchorElement;
+    expect(el.getAttribute('href')).toBe('/apps/review/preview/req-live');
+    expect(el.getAttribute('target')).toBe('_blank');
+    expect(el.getAttribute('rel')).toContain('noopener');
+
+    // Tear down is still present on every row (3 rows → 3 buttons).
+    expect(page.getByRole('button', { name: 'Tear down' }).elements()).toHaveLength(3);
+
+    // Exactly ONE Open link — only the single live row is openable.
+    expect(page.getByRole('link', { name: /Open full-page preview/ }).elements()).toHaveLength(1);
+  });
+
+  test('a building / deploying row renders NO Open link (only Tear down)', async () => {
+    // Restrict the dataset to the two non-live rows so no live row exists.
+    mocks.data = {
+      cap: 3,
+      active: ROWS.filter((r) => r.state !== 'preview-live'),
+    };
+    renderWithProviders(<ActivePreviewsPanel />);
+
+    await expect.element(page.getByText('Active previews')).toBeInTheDocument();
+    // Both non-live rows still get a Tear down…
+    expect(page.getByRole('button', { name: 'Tear down' }).elements()).toHaveLength(2);
+    // …but neither is openable.
+    expect(page.getByRole('link', { name: /Open full-page preview/ }).elements()).toHaveLength(0);
+  });
+});
+
+describe('ActivePreviewsPanel — Tear down fires the mutation', () => {
+  test('clicking Tear down fires blocks.teardownPreview with the row publishRequestId', async () => {
+    mocks.data = { cap: 1, active: [ROWS[0]] };
+    renderWithProviders(<ActivePreviewsPanel />);
+    await page.getByRole('button', { name: 'Tear down' }).click();
+    expect(mocks.mutate).toHaveBeenCalledWith('teardown', { publishRequestId: 'req-live' });
+  });
+});

--- a/src/components/Apps/ActivePreviewsPanel.tsx
+++ b/src/components/Apps/ActivePreviewsPanel.tsx
@@ -1,0 +1,188 @@
+import { Badge, Button, Card, Code, Group, Table, Text } from '@mantine/core';
+import { IconExternalLink, IconWindow, IconX } from '@tabler/icons-react';
+import { ModQueryError, isModAuthzError } from '~/components/Apps/ModQuerySurface';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * MOD REVIEW SANDBOX — global "Active previews (N / cap)" panel. Extracted from
+ * `src/pages/apps/review.tsx` (mirrors the #3163 `OnsiteReviewModal` extraction)
+ * so it can be mounted in a browser (jsdom) test WITHOUT pulling the page's
+ * `getServerSideProps`/`createServerSideProps` tRPC-server graph. `review.tsx`
+ * imports it back and renders it exactly as before (zero behaviour change).
+ *
+ * Review previews are capped globally across all mods (each holds a review
+ * Deployment + Service + IngressRoute), so this surfaces every active preview +
+ * a per-row Tear down so a mod can free a slot, plus (for a LIVE preview) an
+ * "Open full-page preview" link to the same-origin internal review route the
+ * per-request modal uses. Polls every 30s so the count stays fresh. Dark behind
+ * the same mod-only review-sandbox flag as the per-request panel: when off,
+ * listActivePreviews throws UNAUTHORIZED and this renders nothing.
+ *
+ * Everything here is server-graph-free: `ModQuerySurface` (pure Mantine),
+ * `useFeatureFlags`, `~/utils/notifications`, and `~/utils/trpc` are the same
+ * imports the browser-tested `OnsiteReviewModal` uses.
+ */
+
+// Compact relative age ("just now" / "5m" / "2h" / "3d") for the active-preview
+// panel — the exact timestamp isn't useful there, freshness is.
+export function formatAge(d: string | Date | null | undefined): string {
+  if (!d) return '—';
+  const date = typeof d === 'string' ? new Date(d) : d;
+  const ms = Date.now() - date.getTime();
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return 'just now';
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}
+
+export function ActivePreviewsPanel() {
+  const features = useFeatureFlags();
+  const utils = trpc.useUtils();
+
+  const query = trpc.blocks.listActivePreviews.useQuery(undefined, {
+    enabled: !!features?.appBlocks,
+    retry: false,
+    // Poll every 30s to keep the count fresh WHILE it's working, but stop once the
+    // query errors — when the review-sandbox flag is off (appBlocks on, sandbox
+    // flag off) the server throws UNAUTHORIZED, and a fixed interval would re-fire
+    // that guaranteed-dead request forever. (react-query v5: the callback gets the
+    // Query; teardown mutations still invalidate → refetch, so a resume path exists.)
+    refetchInterval: (q) => (q.state.error ? false : 30000),
+  });
+
+  const teardownMut = trpc.blocks.teardownPreview.useMutation({
+    onSuccess: async (_res, vars) => {
+      showSuccessNotification({ message: 'Review preview torn down.' });
+      await Promise.all([
+        utils.blocks.listActivePreviews.invalidate(),
+        utils.blocks.getReviewStatus.invalidate({ publishRequestId: vars.publishRequestId }),
+      ]);
+    },
+    onError: (e) => {
+      showErrorNotification({ title: 'Could not tear down preview', error: new Error(e.message) });
+    },
+  });
+
+  // Flag off / not enabled or nothing active → render nothing so the panel stays
+  // unobtrusive when the sandbox isn't in use. An AUTHZ error (sandbox flag off →
+  // UNAUTHORIZED) is that intended silent case; a TRANSIENT error surfaces a retry
+  // instead of silently disappearing.
+  const cap = query.data?.cap ?? 0;
+  const active = query.data?.active ?? [];
+  if (!features?.appBlocks) return null;
+  if (query.error) {
+    if (isModAuthzError(query.error)) return null;
+    return (
+      <ModQueryError
+        error={query.error}
+        onRetry={() => query.refetch()}
+        isRetrying={query.isFetching}
+        title="Couldn’t load active previews"
+        testId="apps-active-previews-error"
+        mt="md"
+      />
+    );
+  }
+  if (active.length === 0) return null;
+
+  const atCap = cap > 0 && active.length >= cap;
+
+  return (
+    <Card withBorder p="md" mb="md">
+      <Group gap={6} mb="xs">
+        <IconWindow size={16} />
+        <Text size="sm" fw={600}>
+          Active previews
+        </Text>
+        <Badge size="sm" variant="light" color={atCap ? 'red' : 'blue'}>
+          {active.length} / {cap}
+        </Badge>
+        {atCap && (
+          <Text size="xs" c="red">
+            Cap reached — tear one down to start another.
+          </Text>
+        )}
+      </Group>
+      <Table verticalSpacing="xs" horizontalSpacing="md">
+        <Table.Thead>
+          <Table.Tr>
+            <Table.Th>App</Table.Th>
+            <Table.Th>Version</Table.Th>
+            <Table.Th>State</Table.Th>
+            <Table.Th>Age</Table.Th>
+            <Table.Th />
+          </Table.Tr>
+        </Table.Thead>
+        <Table.Tbody>
+          {active.map((p) => (
+            <Table.Tr key={p.publishRequestId}>
+              <Table.Td>
+                <Code>{p.slug}</Code>
+              </Table.Td>
+              <Table.Td>
+                <Code>{p.version}</Code>
+              </Table.Td>
+              <Table.Td>
+                <Badge
+                  size="sm"
+                  variant="light"
+                  color={p.state === 'preview-live' ? 'green' : 'blue'}
+                >
+                  {p.state.replace('preview-', '')}
+                </Badge>
+              </Table.Td>
+              <Table.Td>
+                <Text size="xs" c="dimmed">
+                  {formatAge(p.updatedAt)}
+                </Text>
+              </Table.Td>
+              <Table.Td>
+                <Group gap="xs">
+                  {/* Only a LIVE preview is openable — a building/deploying/failed
+                      preview's full-page route shows a non-live message, so we
+                      don't offer "Open" until it's live. Links by publishRequestId
+                      to the SAME same-origin internal route the per-request modal's
+                      ReviewPreviewPanel uses (top-level, new tab) — NOT the raw
+                      `?mr=` host URL, which hangs on "Connecting to host" opened
+                      top-level (it has no host bridge). */}
+                  {p.state === 'preview-live' && (
+                    <Button
+                      size="xs"
+                      variant="default"
+                      component="a"
+                      href={`/apps/review/preview/${p.publishRequestId}`}
+                      target="_blank"
+                      rel="noopener"
+                      rightSection={<IconExternalLink size={12} />}
+                    >
+                      Open full-page preview ↗
+                    </Button>
+                  )}
+                  <Button
+                    size="xs"
+                    variant="light"
+                    color="red"
+                    leftSection={<IconX size={12} />}
+                    loading={
+                      teardownMut.isPending &&
+                      teardownMut.variables?.publishRequestId === p.publishRequestId
+                    }
+                    onClick={() => teardownMut.mutate({ publishRequestId: p.publishRequestId })}
+                  >
+                    Tear down
+                  </Button>
+                </Group>
+              </Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    </Card>
+  );
+}

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -16,15 +16,14 @@ import {
   IconClock,
   IconExternalLink,
   IconFlag,
-  IconWindow,
   IconX,
 } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 import type { MouseEvent } from 'react';
 import { useMemo, useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
+import { ActivePreviewsPanel } from '~/components/Apps/ActivePreviewsPanel';
 import { AppListingsModerationTable } from '~/components/Apps/AppListingsModerationTable';
-import { ModQueryError, isModAuthzError } from '~/components/Apps/ModQuerySurface';
 // `OffsiteReviewQueue` (the flat pending-only off-site list) is SUPERSEDED by the
 // unified `AppListingsModerationTable` below (which covers pending too, via the
 // per-row Review action). It stays exported for a one-line rollback: swap the
@@ -52,7 +51,6 @@ import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
-import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
 /**
@@ -102,22 +100,10 @@ function isTabValue(v: unknown): v is TabValue {
 }
 
 // `formatBytes` + `formatDate` moved to `OnsiteReviewModal.tsx` (imported above).
-
-// Compact relative age ("just now" / "5m" / "2h" / "3d") for the active-preview
-// panel — the exact timestamp isn't useful there, freshness is.
-function formatAge(d: string | Date | null | undefined): string {
-  if (!d) return '—';
-  const date = typeof d === 'string' ? new Date(d) : d;
-  const ms = Date.now() - date.getTime();
-  if (!Number.isFinite(ms) || ms < 0) return '—';
-  const s = Math.floor(ms / 1000);
-  if (s < 60) return 'just now';
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h`;
-  return `${Math.floor(h / 24)}d`;
-}
+// The global active-previews panel + its `formatAge` helper moved to
+// `~/components/Apps/ActivePreviewsPanel` (mirrors the OnsiteReviewModal
+// extraction) so the panel is mountable in a browser test without this page's
+// `getServerSideProps` server graph. It's imported above and rendered identically.
 
 export default function ReviewQueuePage() {
   const features = useFeatureFlags();
@@ -214,139 +200,6 @@ export default function ReviewQueuePage() {
         onClose={() => setSelected(null)}
       />
     </>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// MOD REVIEW SANDBOX — global "Active previews (N / cap)" panel. Review previews
-// are capped globally across all mods (each holds a review Deployment + Service
-// + IngressRoute), so this surfaces every active preview + a per-row Tear down
-// so a mod can free a slot. Polls every 30s so the count stays fresh. Dark
-// behind the same mod-only review-sandbox flag as the per-request panel: when
-// off, listActivePreviews throws UNAUTHORIZED and this renders nothing.
-// ---------------------------------------------------------------------------
-
-function ActivePreviewsPanel() {
-  const features = useFeatureFlags();
-  const utils = trpc.useUtils();
-
-  const query = trpc.blocks.listActivePreviews.useQuery(undefined, {
-    enabled: !!features?.appBlocks,
-    retry: false,
-    // Poll every 30s to keep the count fresh WHILE it's working, but stop once the
-    // query errors — when the review-sandbox flag is off (appBlocks on, sandbox
-    // flag off) the server throws UNAUTHORIZED, and a fixed interval would re-fire
-    // that guaranteed-dead request forever. (react-query v5: the callback gets the
-    // Query; teardown mutations still invalidate → refetch, so a resume path exists.)
-    refetchInterval: (q) => (q.state.error ? false : 30000),
-  });
-
-  const teardownMut = trpc.blocks.teardownPreview.useMutation({
-    onSuccess: async (_res, vars) => {
-      showSuccessNotification({ message: 'Review preview torn down.' });
-      await Promise.all([
-        utils.blocks.listActivePreviews.invalidate(),
-        utils.blocks.getReviewStatus.invalidate({ publishRequestId: vars.publishRequestId }),
-      ]);
-    },
-    onError: (e) => {
-      showErrorNotification({ title: 'Could not tear down preview', error: new Error(e.message) });
-    },
-  });
-
-  // Flag off / not enabled or nothing active → render nothing so the panel stays
-  // unobtrusive when the sandbox isn't in use. An AUTHZ error (sandbox flag off →
-  // UNAUTHORIZED) is that intended silent case; a TRANSIENT error surfaces a retry
-  // instead of silently disappearing.
-  const cap = query.data?.cap ?? 0;
-  const active = query.data?.active ?? [];
-  if (!features?.appBlocks) return null;
-  if (query.error) {
-    if (isModAuthzError(query.error)) return null;
-    return (
-      <ModQueryError
-        error={query.error}
-        onRetry={() => query.refetch()}
-        isRetrying={query.isFetching}
-        title="Couldn’t load active previews"
-        testId="apps-active-previews-error"
-        mt="md"
-      />
-    );
-  }
-  if (active.length === 0) return null;
-
-  const atCap = cap > 0 && active.length >= cap;
-
-  return (
-    <Card withBorder p="md" mb="md">
-      <Group gap={6} mb="xs">
-        <IconWindow size={16} />
-        <Text size="sm" fw={600}>
-          Active previews
-        </Text>
-        <Badge size="sm" variant="light" color={atCap ? 'red' : 'blue'}>
-          {active.length} / {cap}
-        </Badge>
-        {atCap && (
-          <Text size="xs" c="red">
-            Cap reached — tear one down to start another.
-          </Text>
-        )}
-      </Group>
-      <Table verticalSpacing="xs" horizontalSpacing="md">
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>App</Table.Th>
-            <Table.Th>Version</Table.Th>
-            <Table.Th>State</Table.Th>
-            <Table.Th>Age</Table.Th>
-            <Table.Th />
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {active.map((p) => (
-            <Table.Tr key={p.publishRequestId}>
-              <Table.Td>
-                <Code>{p.slug}</Code>
-              </Table.Td>
-              <Table.Td>
-                <Code>{p.version}</Code>
-              </Table.Td>
-              <Table.Td>
-                <Badge
-                  size="sm"
-                  variant="light"
-                  color={p.state === 'preview-live' ? 'green' : 'blue'}
-                >
-                  {p.state.replace('preview-', '')}
-                </Badge>
-              </Table.Td>
-              <Table.Td>
-                <Text size="xs" c="dimmed">
-                  {formatAge(p.updatedAt)}
-                </Text>
-              </Table.Td>
-              <Table.Td>
-                <Button
-                  size="xs"
-                  variant="light"
-                  color="red"
-                  leftSection={<IconX size={12} />}
-                  loading={
-                    teardownMut.isPending &&
-                    teardownMut.variables?.publishRequestId === p.publishRequestId
-                  }
-                  onClick={() => teardownMut.mutate({ publishRequestId: p.publishRequestId })}
-                >
-                  Tear down
-                </Button>
-              </Table.Td>
-            </Table.Tr>
-          ))}
-        </Table.Tbody>
-      </Table>
-    </Card>
   );
 }
 


### PR DESCRIPTION
## What

The moderator App-Blocks review page (`/apps/review`) shows a global **Active previews** panel listing every active review preview with a **Tear down** button — but there was **no way to open a live preview full-page** from that panel. A mod had to open the per-request review modal to reach the "Open full-page preview" link.

This adds an **"Open full-page preview ↗"** affordance directly to each **live** row in the Active previews panel, mirroring the exact pattern already used in the per-request modal (`OnsiteReviewModal`'s `ReviewPreviewPanel`):

- Shown **only when `state === 'preview-live'`** — a `building`/`deploying`/`failed` preview isn't openable (its full-page route shows a non-live message), so we don't offer "Open" until it's live.
- Links to the **same-origin internal route** `/apps/review/preview/<publishRequestId>` (keyed by request id, **not** the raw `?mr=` host URL, which hangs on "Connecting to host" opened top-level), **new tab** (`target="_blank" rel="noopener"`).
- Placed alongside **Tear down** in a `Group gap="xs"`, styled `size="xs" variant="default"` with an `IconExternalLink` — consistent with the modal's button.

**Teardown, polling, cap logic, and the preview route itself are unchanged.**

## Panel extraction (behavior-preserving)

`ActivePreviewsPanel` was defined **inline** in `src/pages/apps/review.tsx`, which pulls the page's `getServerSideProps`/tRPC-server graph and isn't browser-testable as-is. Mirroring the #3163 extraction of `OnsiteReviewModal`, the panel (and its small `formatAge` helper) is extracted to `src/components/Apps/ActivePreviewsPanel.tsx` — a server-graph-free module (same imports the browser-tested modal uses) — and imported back into `review.tsx`. The page renders it identically; **zero behavior change** (verified: the sibling `OnsiteReviewModal` browser suite still passes 10/10, and the net review.tsx diff is import + removal only).

## Tests

New browser-mode suite `ActivePreviewsPanel.browser.test.tsx` (mirrors the modal's trpc-mock approach, mocking `blocks.listActivePreviews.useQuery` with mixed-state rows):

- a `preview-live` row renders the Open link with `href="/apps/review/preview/req-live"` + `target="_blank"` + `rel` noopener, AND still renders "Tear down"; exactly one Open link for the single live row.
- `preview-building` / `preview-deploying` rows render **no** Open link (only "Tear down").
- "Tear down" fires `blocks.teardownPreview` with the row's `publishRequestId`.

Evidence:
- `ActivePreviewsPanel.browser.test.tsx` — **3 passed**
- `OnsiteReviewModal.browser.test.tsx` (unaffected sibling) — **10 passed**
- `tsc --noEmit` — **0 errors in changed files** (17 pre-existing environmental errors from the missing `kysely` package + `event-engine-common` submodule in the throwaway worktree; none reference the changed files → 0 delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)