### PR TITLE
fix(app-blocks): flip block_workflows read-model to terminal from pollWorkflow (G6)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -157,11 +157,16 @@ const {
   mockRefundAppSpend,
   mockUpsertBlockWorkflow,
   mockListMyBlockWorkflows,
+  mockUpdateBlockWorkflowStatus,
 } = vi.hoisted(() => ({
   mockReserveAppSpend: vi.fn(),
   mockRefundAppSpend: vi.fn(async () => undefined),
   mockUpsertBlockWorkflow: vi.fn(async () => undefined),
   mockListMyBlockWorkflows: vi.fn(),
+  // G6 — the read-model terminal flip pollWorkflow fires best-effort when it
+  // observes a terminal orchestrator status. Mocked at the module boundary so
+  // we assert exact (server-derived) args + that a throw here never breaks poll.
+  mockUpdateBlockWorkflowStatus: vi.fn(async () => 1),
 }));
 vi.mock('~/server/services/blocks/app-spend-cap.service', () => ({
   reserveAppSpend: (...a: unknown[]) => mockReserveAppSpend(...(a as [])),
@@ -170,6 +175,7 @@ vi.mock('~/server/services/blocks/app-spend-cap.service', () => ({
 vi.mock('~/server/services/blocks/block-workflows.service', () => ({
   upsertBlockWorkflowOnSubmit: (...a: unknown[]) => mockUpsertBlockWorkflow(...(a as [])),
   listMyBlockWorkflows: (...a: unknown[]) => mockListMyBlockWorkflows(...(a as [])),
+  updateBlockWorkflowStatus: (...a: unknown[]) => mockUpdateBlockWorkflowStatus(...(a as [])),
 }));
 // submitWorkflow fires recordScopeInvocation (detached) which dynamic-imports the
 // REAL, heavy user-app-surface.service. That first-time real import serializes the
@@ -453,6 +459,7 @@ beforeEach(() => {
     mockRefundAppSpend,
     mockUpsertBlockWorkflow,
     mockListMyBlockWorkflows,
+    mockUpdateBlockWorkflowStatus,
   ]) {
     fn.mockReset();
   }
@@ -468,6 +475,9 @@ beforeEach(() => {
   mockRefundAppSpend.mockResolvedValue(undefined);
   mockUpsertBlockWorkflow.mockResolvedValue(undefined);
   mockListMyBlockWorkflows.mockResolvedValue({ items: [], nextCursor: null });
+  // G6 read-model flip: default to a resolved 1-row UPDATE. Tests exercising the
+  // non-terminal (never-called) + best-effort (rejects) paths override this.
+  mockUpdateBlockWorkflowStatus.mockResolvedValue(1);
   // F4 defaults: no active dev tunnel (getActiveDevTunnel → null) so the dev
   // spend backstop is inert for every non-dev test. The F4 tests override these.
   mockGetActiveDevTunnel.mockResolvedValue(null);
@@ -621,6 +631,91 @@ describe('blocks.pollWorkflow', () => {
     await expect(
       caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' })
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  // ---- G6: read-model terminal flip -------------------------------------
+  //
+  // The orchestrator completion callback is unregistered, so `block_workflows`
+  // rows never advance past `pending`. pollWorkflow (which page apps already
+  // poll to terminal) mirrors an observed TERMINAL status into the read-model so
+  // `listMyWorkflows` rebuilds a correct queue on reload. The flip is
+  // best-effort and must never fail the poll.
+  describe('read-model terminal flip (G6)', () => {
+    function pollTerminal(status: 'succeeded' | 'failed' | 'expired' | 'canceled') {
+      mockVerifyBlockToken.mockResolvedValue(validClaims());
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_1',
+        status, // orchestrator terminal status → same block-contract status
+        cost: { total: 10 },
+        steps: [],
+      });
+      return blocksRouter.createCaller(fakeCtx() as never);
+    }
+
+    it('flips the read-model once on a SUCCEEDED poll and still returns the snapshot', async () => {
+      const caller = pollTerminal('succeeded');
+      const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+      expect(result.snapshot.status).toBe('succeeded');
+      expect(mockUpdateBlockWorkflowStatus).toHaveBeenCalledTimes(1);
+      expect(mockUpdateBlockWorkflowStatus).toHaveBeenCalledWith({
+        workflowId: 'wf_1',
+        status: 'succeeded',
+      });
+    });
+
+    it('flips the read-model on a FAILED poll', async () => {
+      const caller = pollTerminal('failed');
+      const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+      expect(result.snapshot.status).toBe('failed');
+      expect(mockUpdateBlockWorkflowStatus).toHaveBeenCalledWith({
+        workflowId: 'wf_1',
+        status: 'failed',
+      });
+    });
+
+    it('does NOT flip on a non-terminal (processing) poll — no DB write on intermediate polls', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims());
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_1',
+        status: 'processing',
+        cost: { total: 10 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+      expect(result.snapshot.status).toBe('processing');
+      expect(mockUpdateBlockWorkflowStatus).not.toHaveBeenCalled();
+    });
+
+    it('does NOT flip on a still-queued (unassigned → pending) poll', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims());
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_1',
+        status: 'unassigned', // maps to the non-terminal block-contract `pending`
+        cost: { total: 10 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+      expect(result.snapshot.status).toBe('pending');
+      expect(mockUpdateBlockWorkflowStatus).not.toHaveBeenCalled();
+    });
+
+    it('a read-model write failure NEVER breaks the poll (still returns the snapshot)', async () => {
+      const caller = pollTerminal('succeeded');
+      mockUpdateBlockWorkflowStatus.mockRejectedValue(new Error('db down'));
+      const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+      // The poll's contract is to return the snapshot — the flip is best-effort.
+      expect(result.snapshot.status).toBe('succeeded');
+    });
+
+    it('is idempotent across repeated terminal polls (safe to flip each time)', async () => {
+      const caller = pollTerminal('succeeded');
+      await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+      await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+      // Fired on each terminal poll — harmless, the UPDATE is an idempotent set.
+      expect(mockUpdateBlockWorkflowStatus).toHaveBeenCalledTimes(2);
+    });
   });
 });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -112,6 +112,10 @@ import {
 // path (mirrors recordSpendAttribution / the dev-tunnel backstop), so this adds
 // no import-time cost and nothing to mock beyond the dynamic module.
 import type { AppSpendDailyKey } from '~/server/services/blocks/app-spend-cap.service';
+// G6 — persistent block-workflow read-model. Type-only import (erased at runtime):
+// `updateBlockWorkflowStatus` is dynamic-imported in pollWorkflow (mirrors
+// listMyBlockWorkflows), so nothing beyond the dynamic module needs mocking.
+import type { BlockWorkflowStatus } from '~/server/services/blocks/block-workflows.service';
 import { getResourceGenerationSupport } from '~/shared/constants/basemodel.constants';
 import type { ModelType } from '~/shared/utils/prisma/enums';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
@@ -148,6 +152,17 @@ import {
 } from '~/server/trpc';
 import { throwAuthorizationError, throwNotFoundError } from '~/server/utils/errorHandling';
 import type { SessionUser } from '~/types/session';
+
+// G6 — the terminal orchestrator states (as mapped onto the block-contract
+// status by snapshotFromWorkflow). A block-workflow read-model row only ever
+// advances to one of these; `pending`/`processing` are still in-flight. Typed
+// against BlockWorkflowStatus so it can't drift from BLOCK_WORKFLOW_STATUSES.
+const TERMINAL_BLOCK_WORKFLOW_STATUSES = new Set<BlockWorkflowStatus>([
+  'succeeded',
+  'failed',
+  'expired',
+  'canceled',
+]);
 
 /**
  * H-2: every blocks router procedure gates on the Flipt flag. When the
@@ -2551,7 +2566,31 @@ export const blocksRouter = router({
       await assertViewerIsAppDeveloper(userId);
       const token = await getOrchestratorToken(userId, ctx);
       const workflow = await getWorkflow({ token, path: { workflowId: input.workflowId } });
-      return { snapshot: snapshotFromWorkflow(workflow) };
+      const snapshot = snapshotFromWorkflow(workflow);
+      // G6 — mirror an observed TERMINAL status into the durable read-model.
+      // The orchestrator completion callback (`workflow-completed.ts`) is not
+      // wired to fire, so `block_workflows` rows otherwise stay `pending`
+      // forever. Page apps already poll this proc to terminal, so the queue that
+      // `listMyWorkflows` rebuilds on reload converges as a side effect of the
+      // poll. Fires ~once (only on a terminal status, not on 2s intermediate
+      // polls), page-shape-agnostic (keyed on workflowId), and BEST-EFFORT: a
+      // read-model write failure must NEVER fail the poll (its contract is to
+      // return the snapshot). `updateBlockWorkflowStatus` is an indexed UPDATE
+      // that no-ops (0 rows) when the row was never recorded (dev:live tokens).
+      if (TERMINAL_BLOCK_WORKFLOW_STATUSES.has(snapshot.status)) {
+        try {
+          const { updateBlockWorkflowStatus } = await import(
+            '~/server/services/blocks/block-workflows.service'
+          );
+          await updateBlockWorkflowStatus({
+            workflowId: input.workflowId,
+            status: snapshot.status,
+          });
+        } catch {
+          /* best-effort: a read-model write failure never breaks the poll */
+        }
+      }
+      return { snapshot };
     }),
 
   /**


### PR DESCRIPTION
## Symptom

A page app's generation queue never resolves on reload: completed cells still render as "generating." The durable per-viewer read-model (`block_workflows`, read by `blocks.listMyWorkflows` to rebuild a block's in-flight + completed queue) never advances a row past `pending` — even for generations that fully completed and published.

## Root cause

`updateBlockWorkflowStatus` is the only writer that flips a `block_workflows` row terminal, and its only caller is the internal `workflow-completed.ts` handler — a completion callback that is **never registered** on the workflow submission. So nothing ever flips a row terminal, and rows stay `pending` forever. This is broader than page apps: no app's rows advance today.

## Fix (Option A1 — poll-driven read-model flip)

Page apps already poll `blocks.pollWorkflow` to terminal to display their own result. `pollWorkflow` now mirrors an observed **terminal** status (`succeeded` / `failed` / `expired` / `canceled`) into the read-model, so `listMyWorkflows` rebuilds a correct queue on reload as a side effect of the existing poll.

- Fires **only** on a terminal status — not on the intermediate 2s polls (no per-poll DB write).
- **Best-effort:** the write is guarded so a read-model failure can never fail the poll (the poll's contract is to return the snapshot). `updateBlockWorkflowStatus` is a single indexed `UPDATE` keyed on `workflowId` that no-ops (0 rows) when no row was recorded.
- **Page-shape-agnostic:** keyed on `workflowId`, so it works for every instance shape with **no schema change, no migration**, and no change to `workflow-completed.ts`.

## Tests

Extends `blocks.router.workflow.test.ts` with a `read-model terminal flip (G6)` suite: terminal `succeeded`/`failed` polls flip the read-model once with the right args; non-terminal (`processing`, still-queued `pending`) polls do **not** write; a read-model write failure still resolves `{ snapshot }`; and repeated terminal polls are safe (idempotent `UPDATE`). Full file passes locally (185 tests).

## Deferred

The durable Phase-3 answer — registering the orchestrator completion callback and widening `workflow-completed.ts` to accept the page instance shape (so completion is captured even if the tab closes before the poll reaches terminal) — is deferred. See the `app-blocks-g6-page-workflow-completion` scope doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
