### PR TITLE
perf(load): server-cache global bug/changelog getLatest (per-domain in-proc memo)

### DIFF
--- a/src/server/services/bug.service.ts
+++ b/src/server/services/bug.service.ts
@@ -14,6 +14,7 @@ import type {
 import dayjs from '~/shared/utils/dayjs';
 import { cachedCounter } from '~/server/utils/cache-helpers';
 import { throwDbError, throwNotFoundError } from '~/server/utils/errorHandling';
+import { createKeyedTtlMemo } from '~/server/utils/ttl-memoize';
 import { DomainColor } from '~/shared/utils/prisma/enums';
 
 const bugSelect = Prisma.validator<Prisma.BugSelect>()({
@@ -181,8 +182,23 @@ export const deleteBug = async ({ id }: DeleteBugInput) => {
   }
 };
 
-export const getLatestBugUpdate = async (input?: { domain?: DomainColor }) => {
-  const { domain } = input ?? {};
+// `getLatest` is a global-per-domain query (identical for every user of a given
+// domain color) that the client polls on a 60s staleTime. It was previously an
+// uncached dbRead.findFirst on EVERY call — one of the hottest uncached reads at
+// peak. An in-proc (per-pod), per-domain TTL memo collapses that to ~1 DB read /
+// domain / TTL / pod.
+//
+// Staleness: this in-proc TTL (CacheTTL.xs, 60s) STACKS on top of the existing
+// edgeCacheIt({ ttl: CacheTTL.xs }) 60s CDN cache (+ staleWhileRevalidate 30s) on
+// the resolver, so worst-case value age is ~2×TTL (~120s) rather than the edge
+// TTL alone. Also, `new Date()` in the where-clause below is frozen for the memo
+// window, so a scheduled / future-dated bug can surface up to ~TTL (~60s) late.
+// Immaterial for minute-scale banner data. Fail-open: a DB error propagates
+// uncached (see createKeyedTtlMemo), preserving the prior throw-on-error path.
+const LATEST_BUG_UPDATE_INPROC_TTL_MS = CacheTTL.xs * 1000;
+
+const getLatestBugUpdateMemo = createKeyedTtlMemo<number>(async (domainKey) => {
+  const domain = domainKey ? (domainKey as DomainColor) : undefined;
   const bug = await dbRead.bug.findFirst({
     select: { updatedAt: true },
     where: {
@@ -194,6 +210,10 @@ export const getLatestBugUpdate = async (input?: { domain?: DomainColor }) => {
     orderBy: { updatedAt: 'desc' },
   });
   return !bug ? 0 : bug.updatedAt.getTime();
+}, LATEST_BUG_UPDATE_INPROC_TTL_MS);
+
+export const getLatestBugUpdate = async (input?: { domain?: DomainColor }) => {
+  return getLatestBugUpdateMemo(input?.domain ?? '');
 };
 
 export const getBugStatusForReport = async (bugId: number) => {

--- a/src/server/services/changelog.service.ts
+++ b/src/server/services/changelog.service.ts
@@ -1,4 +1,5 @@
 import { Prisma } from '@prisma/client';
+import { CacheTTL } from '~/server/common/constants';
 import { dbRead, dbWrite } from '~/server/db/client';
 import type {
   CreateChangelogInput,
@@ -7,6 +8,7 @@ import type {
   UpdateChangelogInput,
 } from '~/server/schema/changelog.schema';
 import { throwDbError } from '~/server/utils/errorHandling';
+import { createKeyedTtlMemo } from '~/server/utils/ttl-memoize';
 import { DomainColor } from '~/shared/utils/prisma/enums';
 
 export type Changelog = AsyncReturnType<typeof getChangelogs>['items'][number];
@@ -168,8 +170,22 @@ export const getAllTags = async (input?: { domain?: DomainColor }) => {
   return [...new Set(data.flatMap((x) => x.tags ?? []))];
 };
 
-export const getLatestChangelog = async (input?: { domain?: DomainColor }) => {
-  const { domain } = input ?? {};
+// Global-per-domain "latest changelog" timestamp — identical for every user of a
+// given domain color. Previously an uncached dbRead.findFirst on EVERY call; an
+// in-proc (per-pod), per-domain TTL memo collapses that to ~1 DB read / domain /
+// TTL / pod.
+//
+// Staleness: this in-proc TTL (CacheTTL.xs, 60s) STACKS on top of the existing
+// edgeCacheIt({ ttl: CacheTTL.xs }) 60s CDN cache (+ staleWhileRevalidate 30s) on
+// the resolver, so worst-case value age is ~2×TTL (~120s). And `new Date()` in
+// the where-clause below is frozen for the memo window, so a scheduled /
+// future-dated changelog can surface up to ~TTL (~60s) late. Immaterial for
+// minute-scale banner data. Fail-open: a DB error propagates uncached (see
+// createKeyedTtlMemo).
+const LATEST_CHANGELOG_INPROC_TTL_MS = CacheTTL.xs * 1000;
+
+const getLatestChangelogMemo = createKeyedTtlMemo<number>(async (domainKey) => {
+  const domain = domainKey ? (domainKey as DomainColor) : undefined;
 
   const cl = await dbRead.changelog.findFirst({
     select: { effectiveAt: true },
@@ -183,4 +199,8 @@ export const getLatestChangelog = async (input?: { domain?: DomainColor }) => {
   });
 
   return !cl ? 0 : cl.effectiveAt.getTime();
+}, LATEST_CHANGELOG_INPROC_TTL_MS);
+
+export const getLatestChangelog = async (input?: { domain?: DomainColor }) => {
+  return getLatestChangelogMemo(input?.domain ?? '');
 };

--- a/src/server/utils/__tests__/ttl-memoize.test.ts
+++ b/src/server/utils/__tests__/ttl-memoize.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createTtlMemo } from '../ttl-memoize';
+import { createKeyedTtlMemo, createTtlMemo } from '../ttl-memoize';
 
 // A controllable clock so the tests are deterministic and never rely on
 // wall-clock sleeps.
@@ -133,5 +133,80 @@ describe('createTtlMemo', () => {
     expect(await memo()).toBeNull();
     expect(await memo()).toBeNull();
     expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createKeyedTtlMemo', () => {
+  it('memoizes per key: each distinct key hits the fetcher once within the TTL', async () => {
+    const clock = makeClock();
+    const fetcher = vi.fn(async (key: string) => `value-for-${key}`);
+    const memo = createKeyedTtlMemo(fetcher, 30_000, clock.now);
+
+    // First touch of each key fetches once; repeats within the TTL are cached.
+    expect(await memo('all')).toBe('value-for-all');
+    expect(await memo('red')).toBe('value-for-red');
+    clock.advance(10_000); // still inside the 30s TTL
+    expect(await memo('all')).toBe('value-for-all');
+    expect(await memo('red')).toBe('value-for-red');
+
+    // One fetch per DISTINCT key, not per call.
+    expect(fetcher).toHaveBeenCalledTimes(2);
+    expect(fetcher).toHaveBeenCalledWith('all');
+    expect(fetcher).toHaveBeenCalledWith('red');
+  });
+
+  it('keys are independent — expiring/refetching one key does not disturb another', async () => {
+    const clock = makeClock();
+    const counters: Record<string, number> = {};
+    const fetcher = vi.fn(async (key: string) => {
+      counters[key] = (counters[key] ?? 0) + 1;
+      return `${key}-${counters[key]}`;
+    });
+    const memo = createKeyedTtlMemo(fetcher, 30_000, clock.now);
+
+    expect(await memo('all')).toBe('all-1');
+    expect(await memo('red')).toBe('red-1');
+
+    clock.advance(30_001); // both keys' TTL windows expire together
+    expect(await memo('all')).toBe('all-2'); // refetched independently
+    expect(await memo('red')).toBe('red-2');
+    expect(fetcher).toHaveBeenCalledTimes(4);
+  });
+
+  it('fail-open per key: a rejected fetch is not cached and the next call refetches that key', async () => {
+    const clock = makeClock();
+    const outcomes: Record<string, Array<() => Promise<string>>> = {
+      all: [() => Promise.reject(new Error('db down')), () => Promise.resolve('recovered')],
+    };
+    const idx: Record<string, number> = { all: 0 };
+    const fetcher = vi.fn((key: string) => outcomes[key][idx[key]++]());
+    const memo = createKeyedTtlMemo(fetcher, 30_000, clock.now);
+
+    await expect(memo('all')).rejects.toThrow('db down');
+    // Immediately (within the TTL) the next call re-invokes rather than serving a
+    // cached error / poisoned value — preserving the resolver's fail-open path.
+    expect(await memo('all')).toBe('recovered');
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('clear(key) drops just that key; clear() drops all', async () => {
+    const clock = makeClock();
+    const counters: Record<string, number> = {};
+    const fetcher = vi.fn(async (key: string) => {
+      counters[key] = (counters[key] ?? 0) + 1;
+      return `${key}-${counters[key]}`;
+    });
+    const memo = createKeyedTtlMemo(fetcher, 30_000, clock.now);
+
+    expect(await memo('all')).toBe('all-1');
+    expect(await memo('red')).toBe('red-1');
+
+    memo.clear('all'); // only 'all' is dropped
+    expect(await memo('all')).toBe('all-2'); // refetched
+    expect(await memo('red')).toBe('red-1'); // untouched, still cached
+
+    memo.clear(); // drops everything
+    expect(await memo('all')).toBe('all-3');
+    expect(await memo('red')).toBe('red-2');
   });
 });

--- a/src/server/utils/ttl-memoize.ts
+++ b/src/server/utils/ttl-memoize.ts
@@ -58,3 +58,43 @@ export function createTtlMemo<T>(
 
   return memo;
 }
+
+// Keyed variant of createTtlMemo for a GLOBAL-per-key async fetcher — i.e. a
+// fetcher whose result depends ONLY on a small, bounded key (not on the
+// user/session), e.g. the per-domain "latest bug/changelog" timestamp. Each
+// distinct key gets its own independent single-slot TTL memo (same fail-open
+// semantics: only a resolved value is cached, a rejection propagates uncached).
+//
+// 🔴 The key space MUST be bounded (an enum, a domain list, …). This holds one
+// slot per distinct key forever, so a per-user / unbounded key would both leak
+// memory AND — because a slot is user-independent by contract — is still only
+// safe for values that don't depend on the request/user beyond the key itself.
+export type KeyedTtlMemo<T> = ((key: string) => Promise<T>) & {
+  /** Drop one key's cached value, or (no arg) every key's. */
+  clear: (key?: string) => void;
+};
+
+export function createKeyedTtlMemo<T>(
+  fetcher: (key: string) => Promise<T>,
+  ttlMs: number,
+  now: () => number = Date.now,
+  opts: { freeze?: boolean } = {}
+): KeyedTtlMemo<T> {
+  const slots = new Map<string, TtlMemo<T>>();
+
+  const keyed = ((key: string) => {
+    let slot = slots.get(key);
+    if (!slot) {
+      slot = createTtlMemo(() => fetcher(key), ttlMs, now, opts);
+      slots.set(key, slot);
+    }
+    return slot();
+  }) as KeyedTtlMemo<T>;
+
+  keyed.clear = (key?: string) => {
+    if (key === undefined) slots.clear();
+    else slots.get(key)?.clear();
+  };
+
+  return keyed;
+}


### PR DESCRIPTION
## What

Server-cache the two global banner queries `bug.getLatest` + `changelog.getLatest`, the hottest **uncached** read paths of their kind at peak. A cost/efficiency win (fewer DB reads), not capacity — read replicas have ample headroom, so this is pod-neutral.

Both resolvers did an uncached `dbRead.findFirst` on **every** call (~36 req/s combined at peak — `bug.getLatest` ~21/s, `changelog.getLatest` ~15/s) even though the result is identical for every user of a given domain color: it's a global-per-domain value the client polls on a 60s staleTime.

- Added `createKeyedTtlMemo` — a keyed variant of the existing `createTtlMemo` (the in-proc single-slot memo already behind `getClientConfigCached` and `getModeratedTags`/etc.). It keeps one independent TTL slot per key over a **bounded** key space (here the 4 `DomainColor` values; documented in-code), each with the same fail-open semantics.
- Wrapped `getLatestBugUpdate` / `getLatestChangelog` with it, keyed by domain → collapses the read to **~1 DB query / domain / TTL / pod**.

## Staleness (stated accurately)

The in-proc TTL (`CacheTTL.xs`, 60s) **stacks on top of** the existing `edgeCacheIt({ ttl: CacheTTL.xs })` 60s CDN cache (+ `staleWhileRevalidate: 30`) already on these resolvers, so worst-case value age becomes **~2×TTL (~120s)** rather than the edge TTL alone. Additionally, the `new Date()` in the where-clause (`publishedAt: { lte: new Date() }` / `effectiveAt: { lte: new Date() }`) is frozen for the memo window, so a **scheduled / future-dated** entry can surface **up to ~TTL (~60s) late**. Immaterial for minute-scale banner data, but called out honestly rather than claimed "byte-identical".

**Fail-open preserved**: only a resolved value is memoized; a DB error propagates uncached (the next call retries), so a transient failure is never frozen in as a fresh value. No cross-domain leak (per-key slots).

## Why (data, peak)

`bug.getLatest` ~21 req/s and `changelog.getLatest` ~15 req/s, both **uncached `dbRead.findFirst`/call**, global-per-domain. DB replicas have huge headroom, so the relief here is **cost/efficiency**, not capacity.

## Tests

Extended `src/server/utils/__tests__/ttl-memoize.test.ts` with `createKeyedTtlMemo` coverage: per-key memoization (one fetch per distinct key), key independence across TTL expiry, per-key fail-open (rejection not cached), and `clear(key)` / `clear()` semantics. All 12 tests pass.

## Risk / notes

- `createKeyedTtlMemo` must only be used for a **bounded** key space (documented in-code); domain has 4 possible values so the slot map cannot grow unboundedly.
- Not merged, not deployed — awaiting review.

_(An earlier revision also proposed a client `staleTime` on `buzz.getBuzzAccount` — dropped after review: that query already inherits the global default `staleTime: Infinity` and is deliberately signal-driven with no refetch-on-mount, so adding a `staleTime` would have *added* buzz-service QPS. Reverted; this PR is A1-only.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
