### PR TITLE
perf(track): coalesce trackSearch + addAction telemetry into a batched beacon

### DIFF
--- a/src/components/TrackView/track.utils.ts
+++ b/src/components/TrackView/track.utils.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react';
+import { enqueueTrackEvent } from '~/components/TrackView/trackEventBuffer';
 import { trpc } from '~/utils/trpc';
 import type {
   TrackActionInput,
@@ -7,31 +8,38 @@ import type {
 } from '~/server/schema/track.schema';
 
 export const useTrackEvent = () => {
+  // trackShare stays a per-event tRPC mutation: it's low-volume (user-intent share
+  // clicks) and not part of the high-volume telemetry class B1 targets.
   const { mutateAsync: trackShare } = trpc.track.trackShare.useMutation();
-  const { mutateAsync: trackAction } = trpc.track.addAction.useMutation();
-  const { mutateAsync: trackSearch } = trpc.track.trackSearch.useMutation();
 
   // React Query keeps `mutateAsync` identity stable across renders via
-  // internal refs, so these `useCallback` wrappers actually stabilize the
-  // returned handle for consumers. Downstream `useCallback` hooks that
-  // include `trackAction` in their deps (e.g. ImagesCard.handleRemixClick)
-  // won't re-invalidate every render. (Verify by checking React Query's
-  // mutation source if the assumption changes — useMutation returns
-  // mutateAsync bound to a ref, not a fresh closure per render.)
+  // internal refs, so this `useCallback` wrapper actually stabilizes the
+  // returned handle for consumers. (Verify by checking React Query's mutation
+  // source if the assumption changes — useMutation returns mutateAsync bound to
+  // a ref, not a fresh closure per render.)
   const handleTrackShare = useCallback(
     (data: TrackShareInput) => trackShare(data),
     [trackShare]
   );
 
-  const handleTrackAction = useCallback(
-    (data: TrackActionInput) => trackAction(data),
-    [trackAction]
-  );
+  // trackAction (~6.8/s) and trackSearch (~16/s) are the high-volume telemetry
+  // mutations. Instead of one tRPC call per event (full middleware chain +
+  // superjson + ClickHouse insert each), they are coalesced client-side and
+  // flushed as one batch to the /api/track/batch beacon (see trackEventBuffer).
+  // The event payload is UNCHANGED — only the transport is batched. We return a
+  // resolved promise to preserve the existing `.catch(() => …)` fire-and-forget
+  // call-site contract (no caller awaits these for control flow). Deps are empty
+  // because `enqueueTrackEvent` is a stable module-level function, so the handles
+  // stay referentially stable across renders (same guarantee as before).
+  const handleTrackAction = useCallback((data: TrackActionInput): Promise<void> => {
+    enqueueTrackEvent({ kind: 'action', data });
+    return Promise.resolve();
+  }, []);
 
-  const handleTrackSearch = useCallback(
-    (data: TrackSearchInput) => trackSearch(data),
-    [trackSearch]
-  );
+  const handleTrackSearch = useCallback((data: TrackSearchInput): Promise<void> => {
+    enqueueTrackEvent({ kind: 'search', data });
+    return Promise.resolve();
+  }, []);
 
   return {
     trackShare: handleTrackShare,

--- a/src/components/TrackView/trackEventBuffer.ts
+++ b/src/components/TrackView/trackEventBuffer.ts
@@ -20,7 +20,7 @@
 // flow. A failed interval/size flush re-queues its events (bounded to
 // TRACK_BATCH_MAX) so the next flush retries; telemetry is best-effort but not
 // silently dropped wholesale.
-import { TRACK_BATCH_MAX } from '~/server/schema/track.schema';
+import { TRACK_BATCH_MAX, isHighValueTrackEvent } from '~/server/schema/track.schema';
 import type { TrackBatchEvent } from '~/server/schema/track.schema';
 
 // Deliberately generic path (not "track"/"search"/"action") so ad/privacy blockers
@@ -120,12 +120,26 @@ function bindLifecycleListeners() {
 }
 
 // Enqueue one telemetry event. Synchronous, never throws, no-ops on the server.
-// Flushes immediately when the size cap is hit, otherwise arms the interval timer.
+//
+// High-value/conversion events (see HIGH_VALUE_ACTION_TYPES) are NEVER held: they
+// trigger an immediate flush in the same tick so a browser crash can't lose them
+// (sendBeacon only covers navigation/tab-hide, not a crash). They still go out the
+// SAME /api/track/batch transport, batched with whatever low-value events are
+// already buffered — the point is they aren't delayed by the interval.
+//
+// Low-value events (all searches + high-volume top-of-funnel clicks) coalesce:
+// flush on the size cap, otherwise arm the interval timer.
 export function enqueueTrackEvent(event: TrackBatchEvent): void {
   if (typeof window === 'undefined') return; // SSR / non-browser: no telemetry
   bindLifecycleListeners();
 
   buffer.push(event);
+
+  if (isHighValueTrackEvent(event)) {
+    flush(); // conversion/monetization event — leave now, don't wait for the interval
+    return;
+  }
+
   if (buffer.length >= FLUSH_AT_SIZE) {
     flush();
   } else {

--- a/src/components/TrackView/trackEventBuffer.ts
+++ b/src/components/TrackView/trackEventBuffer.ts
@@ -1,0 +1,147 @@
+// Client-side telemetry coalescing buffer for the high-volume `track.trackSearch`
+// (~16/s) and `track.addAction` (~6.8/s) events.
+//
+// Before: each event was a standalone `trpc.track.*.useMutation()` call, so every
+// search/action dragged the full non-batched tRPC middleware chain + superjson
+// encode + a ClickHouse insert — ~23 telemetry procedures/s fleet-wide. This
+// buffer coalesces those events in the browser and flushes them as one batch to
+// the lightweight `/api/track/batch` beacon (which runs NONE of the tRPC chain and
+// fires the identical Tracker.search()/Tracker.action() inserts), collapsing ~23
+// procedures/s into a handful of batched requests/s.
+//
+// NO EVENT LOSS on navigation/unload: the buffer flushes on a short interval, on a
+// size cap, and — critically — on `visibilitychange` (hidden) and `pagehide` using
+// `navigator.sendBeacon`, which is guaranteed to be delivered by the browser even
+// as the document is torn down (a normal fetch is cancelled on navigation). We do
+// NOT use `unload`/`beforeunload` (they disable the bfcache and don't fire on
+// mobile); `pagehide` + `visibilitychange:hidden` is the modern, reliable pair.
+//
+// FAIL-OPEN: a failed flush never throws to the caller and never blocks the user
+// flow. A failed interval/size flush re-queues its events (bounded to
+// TRACK_BATCH_MAX) so the next flush retries; telemetry is best-effort but not
+// silently dropped wholesale.
+import { TRACK_BATCH_MAX } from '~/server/schema/track.schema';
+import type { TrackBatchEvent } from '~/server/schema/track.schema';
+
+// Deliberately generic path (not "track"/"search"/"action") so ad/privacy blockers
+// don't cancel it with ERR_BLOCKED_BY_CLIENT — same reasoning as /api/internal/pulse.
+const ENDPOINT = '/api/track/batch';
+
+// Flush cadence. A few seconds of coalescing is the only user-visible delta and is
+// imperceptible. Size cap flushes early under a burst so the buffer never grows
+// large in memory; the hard cap bounds re-queued events after a failed flush.
+const FLUSH_INTERVAL_MS = 3000;
+const FLUSH_AT_SIZE = 20;
+const HARD_CAP = TRACK_BATCH_MAX; // never hold/POST more than the server accepts
+
+let buffer: TrackBatchEvent[] = [];
+let timer: ReturnType<typeof setTimeout> | null = null;
+let listenersBound = false;
+
+function clearTimer() {
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+}
+
+function scheduleTimer() {
+  if (timer !== null) return; // an interval flush is already pending
+  timer = setTimeout(() => {
+    timer = null;
+    flush();
+  }, FLUSH_INTERVAL_MS);
+}
+
+// POST a batch. On the unload path we MUST use sendBeacon (a keepalive fetch is not
+// reliably delivered while the document is being discarded). Returns whether the
+// send was accepted for delivery — false means "re-queue and retry".
+function post(events: TrackBatchEvent[], viaBeacon: boolean): Promise<boolean> {
+  const body = JSON.stringify(events);
+
+  if (viaBeacon && typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+    try {
+      // Blob type sets Content-Type: application/json so the beacon route's body
+      // parser reads it as JSON (same as a fetch with that header).
+      const ok = navigator.sendBeacon(ENDPOINT, new Blob([body], { type: 'application/json' }));
+      return Promise.resolve(ok);
+    } catch {
+      return Promise.resolve(false);
+    }
+  }
+
+  return fetch(ENDPOINT, {
+    method: 'POST',
+    // keepalive lets an interval/size flush that races a navigation still complete.
+    keepalive: true,
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  })
+    .then((res) => res.ok)
+    .catch(() => false);
+}
+
+// Drain the buffer and send it. `viaBeacon` is set on the unload/hide path.
+function flush(viaBeacon = false): void {
+  clearTimer();
+  if (buffer.length === 0) return;
+
+  // Snapshot + reset atomically so events enqueued during the async send land in
+  // the NEXT batch (and aren't dropped or double-sent).
+  const events = buffer;
+  buffer = [];
+
+  void post(events, viaBeacon).then((ok) => {
+    if (ok) return;
+    // Fail-open with a bounded retry: prepend the un-sent events (preserving order)
+    // ahead of anything queued since, clamp to the hard cap, and let the next flush
+    // pick them up. We drop the OLDEST overflow rather than the newest.
+    if (buffer.length > 0) {
+      buffer = events.concat(buffer);
+    } else {
+      buffer = events;
+    }
+    if (buffer.length > HARD_CAP) buffer = buffer.slice(buffer.length - HARD_CAP);
+    if (buffer.length > 0) scheduleTimer();
+  });
+}
+
+function bindLifecycleListeners() {
+  if (listenersBound || typeof document === 'undefined' || typeof window === 'undefined') return;
+  listenersBound = true;
+
+  // `visibilitychange -> hidden` is the reliable "user is leaving" signal on mobile
+  // (pagehide/unload often don't fire there). Flush via beacon so nothing is lost.
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden') flush(true);
+  });
+  // Desktop navigation / tab close. Beacon survives the teardown.
+  window.addEventListener('pagehide', () => flush(true));
+}
+
+// Enqueue one telemetry event. Synchronous, never throws, no-ops on the server.
+// Flushes immediately when the size cap is hit, otherwise arms the interval timer.
+export function enqueueTrackEvent(event: TrackBatchEvent): void {
+  if (typeof window === 'undefined') return; // SSR / non-browser: no telemetry
+  bindLifecycleListeners();
+
+  buffer.push(event);
+  if (buffer.length >= FLUSH_AT_SIZE) {
+    flush();
+  } else {
+    scheduleTimer();
+  }
+}
+
+// Test-only hooks. Not part of the runtime contract — let tests drive the buffer
+// deterministically (inspect pending count, force a flush, reset module state).
+export const __trackBufferTestHooks = {
+  flush,
+  pendingCount: () => buffer.length,
+  reset: () => {
+    clearTimer();
+    buffer = [];
+    listenersBound = false;
+  },
+  constants: { FLUSH_INTERVAL_MS, FLUSH_AT_SIZE, HARD_CAP },
+};

--- a/src/components/TrackView/trackEventBuffer.ts
+++ b/src/components/TrackView/trackEventBuffer.ts
@@ -4,23 +4,33 @@
 // Before: each event was a standalone `trpc.track.*.useMutation()` call, so every
 // search/action dragged the full non-batched tRPC middleware chain + superjson
 // encode + a ClickHouse insert — ~23 telemetry procedures/s fleet-wide. This
-// buffer coalesces those events in the browser and flushes them as one batch to
-// the lightweight `/api/track/batch` beacon (which runs NONE of the tRPC chain and
+// buffer coalesces those events in the browser and flushes them as batches to the
+// lightweight `/api/track/batch` beacon (which runs NONE of the tRPC chain and
 // fires the identical Tracker.search()/Tracker.action() inserts), collapsing ~23
 // procedures/s into a handful of batched requests/s.
 //
 // NO EVENT LOSS on navigation/unload: the buffer flushes on a short interval, on a
-// size cap, and — critically — on `visibilitychange` (hidden) and `pagehide` using
-// `navigator.sendBeacon`, which is guaranteed to be delivered by the browser even
-// as the document is torn down (a normal fetch is cancelled on navigation). We do
-// NOT use `unload`/`beforeunload` (they disable the bfcache and don't fire on
-// mobile); `pagehide` + `visibilitychange:hidden` is the modern, reliable pair.
+// size cap, on enqueue of an immediate-flush event, and — critically — on
+// `visibilitychange` (hidden) and `pagehide` using `navigator.sendBeacon`, which
+// the browser delivers even as the document is torn down (a normal fetch is
+// cancelled on navigation). We do NOT use `unload`/`beforeunload` (they disable the
+// bfcache and don't fire on mobile); `pagehide` + `visibilitychange:hidden` is the
+// modern, reliable pair.
 //
-// FAIL-OPEN: a failed flush never throws to the caller and never blocks the user
-// flow. A failed interval/size flush re-queues its events (bounded to
-// TRACK_BATCH_MAX) so the next flush retries; telemetry is best-effort but not
-// silently dropped wholesale.
-import { TRACK_BATCH_MAX, isHighValueTrackEvent } from '~/server/schema/track.schema';
+// OVERSIZED BATCHES: `navigator.sendBeacon` (and the shared keepalive-fetch budget)
+// cap out around ~64KB. A large or re-queued batch is split into sub-batches that
+// each fit under the cap and sent as multiple requests; if a beacon is still
+// refused (returns false), we fall back to a keepalive fetch for that chunk rather
+// than silently dropping it.
+//
+// AT-LEAST-ONCE / FAIL-OPEN: a failed flush never throws to the caller and never
+// blocks the user flow. Failed chunks are re-queued (bounded to TRACK_BATCH_MAX)
+// so the next flush retries; telemetry is best-effort but not silently dropped
+// wholesale. Because an ambiguous failure (e.g. a request that actually reached the
+// server but whose response was lost) is retried, delivery is AT-LEAST-ONCE — CH
+// rows can duplicate, so consumers must dedup (high-value events on
+// externalId/session; see the beacon route + PR notes).
+import { TRACK_BATCH_MAX, isImmediateFlushTrackEvent } from '~/server/schema/track.schema';
 import type { TrackBatchEvent } from '~/server/schema/track.schema';
 
 // Deliberately generic path (not "track"/"search"/"action") so ad/privacy blockers
@@ -33,6 +43,15 @@ const ENDPOINT = '/api/track/batch';
 const FLUSH_INTERVAL_MS = 3000;
 const FLUSH_AT_SIZE = 20;
 const HARD_CAP = TRACK_BATCH_MAX; // never hold/POST more than the server accepts
+
+// Keep each request comfortably under the ~64KB sendBeacon / keepalive-fetch cap.
+// A flush whose serialized events exceed this is split into multiple sub-requests.
+const MAX_BEACON_BYTES = 60000;
+
+const textEncoder = typeof TextEncoder !== 'undefined' ? new TextEncoder() : null;
+function byteLength(str: string): number {
+  return textEncoder ? textEncoder.encode(str).length : str.length;
+}
 
 let buffer: TrackBatchEvent[] = [];
 let timer: ReturnType<typeof setTimeout> | null = null;
@@ -53,26 +72,44 @@ function scheduleTimer() {
   }, FLUSH_INTERVAL_MS);
 }
 
-// POST a batch. On the unload path we MUST use sendBeacon (a keepalive fetch is not
-// reliably delivered while the document is being discarded). Returns whether the
-// send was accepted for delivery — false means "re-queue and retry".
-function post(events: TrackBatchEvent[], viaBeacon: boolean): Promise<boolean> {
-  const body = JSON.stringify(events);
+// Split events into ordered sub-batches that each fit under MAX_BEACON_BYTES (and
+// the server's per-request count cap). A single event larger than the cap can't be
+// split further — it goes out alone (best effort).
+function chunkEvents(events: TrackBatchEvent[]): TrackBatchEvent[][] {
+  const chunks: TrackBatchEvent[][] = [];
+  let current: TrackBatchEvent[] = [];
+  let currentBytes = 2; // "[]"
 
-  if (viaBeacon && typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
-    try {
-      // Blob type sets Content-Type: application/json so the beacon route's body
-      // parser reads it as JSON (same as a fetch with that header).
-      const ok = navigator.sendBeacon(ENDPOINT, new Blob([body], { type: 'application/json' }));
-      return Promise.resolve(ok);
-    } catch {
-      return Promise.resolve(false);
+  for (const event of events) {
+    const eventBytes = byteLength(JSON.stringify(event)) + 1; // + comma separator
+    const wouldOverflow = currentBytes + eventBytes > MAX_BEACON_BYTES;
+    const wouldExceedCount = current.length >= TRACK_BATCH_MAX;
+    if (current.length > 0 && (wouldOverflow || wouldExceedCount)) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 2;
     }
+    current.push(event);
+    currentBytes += eventBytes;
   }
+  if (current.length > 0) chunks.push(current);
+  return chunks;
+}
 
+function postBeacon(body: string): boolean {
+  try {
+    // Blob type sets Content-Type: application/json so the beacon route's body
+    // parser reads it as JSON (same as a fetch with that header).
+    return navigator.sendBeacon(ENDPOINT, new Blob([body], { type: 'application/json' }));
+  } catch {
+    return false;
+  }
+}
+
+function postFetch(body: string): Promise<boolean> {
   return fetch(ENDPOINT, {
     method: 'POST',
-    // keepalive lets an interval/size flush that races a navigation still complete.
+    // keepalive lets a flush that races a navigation still complete.
     keepalive: true,
     headers: { 'Content-Type': 'application/json' },
     body,
@@ -81,26 +118,43 @@ function post(events: TrackBatchEvent[], viaBeacon: boolean): Promise<boolean> {
     .catch(() => false);
 }
 
-// Drain the buffer and send it. `viaBeacon` is set on the unload/hide path.
+// Send ONE chunk. On the unload path we prefer sendBeacon (a keepalive fetch is not
+// reliably delivered while the document is discarded); if the beacon is REFUSED
+// (returns false — over the cap, or the browser's beacon queue is full) we fall
+// back to a keepalive fetch rather than dropping the chunk. Returns whether the
+// chunk was accepted for delivery.
+function sendChunk(chunk: TrackBatchEvent[], viaBeacon: boolean): Promise<boolean> {
+  const body = JSON.stringify(chunk);
+  if (viaBeacon && typeof navigator !== 'undefined' && typeof navigator.sendBeacon === 'function') {
+    if (postBeacon(body)) return Promise.resolve(true);
+    // Beacon refused → best-effort keepalive fetch fallback.
+    return postFetch(body);
+  }
+  return postFetch(body);
+}
+
+// Drain the buffer and send it (chunked). `viaBeacon` is set on the unload/hide
+// path. Failed chunks are re-queued (order-preserved, bounded) for the next flush.
 function flush(viaBeacon = false): void {
   clearTimer();
   if (buffer.length === 0) return;
 
   // Snapshot + reset atomically so events enqueued during the async send land in
-  // the NEXT batch (and aren't dropped or double-sent).
+  // the NEXT batch (and aren't dropped or double-sent within this flush).
   const events = buffer;
   buffer = [];
+  const chunks = chunkEvents(events);
 
-  void post(events, viaBeacon).then((ok) => {
-    if (ok) return;
-    // Fail-open with a bounded retry: prepend the un-sent events (preserving order)
-    // ahead of anything queued since, clamp to the hard cap, and let the next flush
-    // pick them up. We drop the OLDEST overflow rather than the newest.
-    if (buffer.length > 0) {
-      buffer = events.concat(buffer);
-    } else {
-      buffer = events;
-    }
+  void Promise.all(
+    chunks.map((chunk) => sendChunk(chunk, viaBeacon).then((ok) => (ok ? [] : chunk)))
+  ).then((failedGroups) => {
+    // `failedGroups` preserves chunk order, so flattening restores event order.
+    const failed = failedGroups.flat();
+    if (failed.length === 0) return;
+    // Fail-open with a bounded retry: prepend the un-sent events (older) ahead of
+    // anything queued since, clamp to the hard cap (drop OLDEST overflow), and let
+    // the next flush pick them up.
+    buffer = buffer.length > 0 ? failed.concat(buffer) : failed;
     if (buffer.length > HARD_CAP) buffer = buffer.slice(buffer.length - HARD_CAP);
     if (buffer.length > 0) scheduleTimer();
   });
@@ -121,11 +175,12 @@ function bindLifecycleListeners() {
 
 // Enqueue one telemetry event. Synchronous, never throws, no-ops on the server.
 //
-// High-value/conversion events (see HIGH_VALUE_ACTION_TYPES) are NEVER held: they
-// trigger an immediate flush in the same tick so a browser crash can't lose them
-// (sendBeacon only covers navigation/tab-hide, not a crash). They still go out the
-// SAME /api/track/batch transport, batched with whatever low-value events are
-// already buffered — the point is they aren't delayed by the interval.
+// Immediate-flush events (see IMMEDIATE_FLUSH_ACTION_TYPES — money/conversion +
+// compliance-critical) are NEVER held: they trigger an immediate flush in the same
+// tick so a browser crash can't lose them (sendBeacon only covers navigation/tab-
+// hide, not a crash). They still go out the SAME /api/track/batch transport,
+// batched with whatever low-value events are already buffered — the point is they
+// aren't delayed by the interval.
 //
 // Low-value events (all searches + high-volume top-of-funnel clicks) coalesce:
 // flush on the size cap, otherwise arm the interval timer.
@@ -135,8 +190,8 @@ export function enqueueTrackEvent(event: TrackBatchEvent): void {
 
   buffer.push(event);
 
-  if (isHighValueTrackEvent(event)) {
-    flush(); // conversion/monetization event — leave now, don't wait for the interval
+  if (isImmediateFlushTrackEvent(event)) {
+    flush(); // conversion/compliance event — leave now, don't wait for the interval
     return;
   }
 
@@ -151,11 +206,12 @@ export function enqueueTrackEvent(event: TrackBatchEvent): void {
 // deterministically (inspect pending count, force a flush, reset module state).
 export const __trackBufferTestHooks = {
   flush,
+  chunkEvents,
   pendingCount: () => buffer.length,
   reset: () => {
     clearTimer();
     buffer = [];
     listenersBound = false;
   },
-  constants: { FLUSH_INTERVAL_MS, FLUSH_AT_SIZE, HARD_CAP },
+  constants: { FLUSH_INTERVAL_MS, FLUSH_AT_SIZE, HARD_CAP, MAX_BEACON_BYTES },
 };

--- a/src/pages/api/track/batch.ts
+++ b/src/pages/api/track/batch.ts
@@ -1,0 +1,80 @@
+import { isDev } from '~/env/other';
+import { Tracker } from '~/server/clickhouse/client';
+import { trackBatchSchema } from '~/server/schema/track.schema';
+import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
+
+// Coalesced telemetry beacon — receives a BATCH of `trackSearch` / `addAction`
+// events buffered by the browser (see src/components/TrackView/trackEventBuffer.ts)
+// and dispatches each through the SAME Tracker.search()/Tracker.action() the tRPC
+// `track.trackSearch`/`track.addAction` procedures used, producing byte-identical
+// ClickHouse inserts. What changes is ONLY the transport: instead of ~23
+// telemetry tRPC procedures/s (each paying the full non-batched middleware chain +
+// superjson encode + insert), the browser flushes coalesced batches to this one
+// route, which runs none of that chain and resolves the session ONCE per batch
+// (the Tracker memoizes it across all events in the request).
+//
+// Mirrors the established beacon pattern (/api/internal/pulse for addView #2680,
+// /api/track/block-render): PublicEndpoint, POST-only, dev short-circuit,
+// same-origin guard, tolerant body parse, bounded schema validation, then
+// fire-and-forget dispatch. The browser <useTrackEvent> is always cookie-
+// authenticated; bearer/API-key callers keep using the tRPC `track.*` procedures
+// (which still enforce the UserWrite scope).
+//
+// Deliberately named generically (NOT "search"/"action") so ad/privacy blockers
+// don't cancel the beacon client-side with ERR_BLOCKED_BY_CLIENT.
+export default PublicEndpoint(
+  async (req, res) => {
+    if (isDev) return res.status(200).end();
+
+    // Same-origin guard (mirrors /api/internal/pulse + /api/track/block-render).
+    // Origin preferred, referer fallback for clients that suppress Origin.
+    const source = req.headers.origin ?? req.headers.referer;
+    const sourceHost = source
+      ? (() => {
+          try {
+            return new URL(source).host;
+          } catch {
+            return undefined;
+          }
+        })()
+      : undefined;
+    if (!sourceHost || sourceHost !== req.headers.host)
+      return res.status(400).send('invalid request');
+
+    // Next's body parser deserializes an `application/json` body into an object
+    // (both the fetch flush and the sendBeacon Blob set that Content-Type), but a
+    // Content-Type-less (text/plain) client leaves it a raw string. Handle BOTH —
+    // JSON.parse(<object>) would throw and 400 every real browser beacon (see the
+    // #2680 pulse.ts fix).
+    let parsed: unknown;
+    try {
+      parsed = typeof req.body === 'string' ? JSON.parse(req.body) : req.body;
+    } catch {
+      return res.status(400).send('invalid body');
+    }
+
+    // Validates the bounded array + each event's discriminated shape. A single
+    // malformed event rejects the whole batch (the client only ever sends
+    // well-formed, schema-typed events; a 400 here means a tampered/oversized body).
+    const result = trackBatchSchema.safeParse(parsed);
+    if (!result.success) return res.status(400).send('invalid input');
+
+    // One Tracker for the whole batch → the session/actor (userId/ip/userAgent) is
+    // resolved ONCE and reused for every event, identical to how a single tRPC
+    // request would have stamped them. Events are dispatched in array order,
+    // preserving the client's emit order.
+    const tracker = new Tracker(req, res);
+    for (const event of result.data) {
+      if (event.kind === 'search') {
+        // Fire-and-forget: dispatches the insert without awaiting the round-trip,
+        // exactly as the tRPC resolver (`ctx.track.search(input)`) did.
+        void tracker.search(event.data);
+      } else {
+        void tracker.action(event.data);
+      }
+    }
+
+    return res.status(200).end();
+  },
+  ['POST']
+);

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -502,15 +502,16 @@ export type TrackBatchEvent = z.infer<typeof trackBatchEventSchema>;
 export const trackBatchSchema = z.array(trackBatchEventSchema).min(1).max(TRACK_BATCH_MAX);
 export type TrackBatchInput = z.infer<typeof trackBatchSchema>;
 
-// Conversion/monetization-critical `addAction` kinds that must NOT be held in the
-// coalescing buffer — enqueueing one triggers an immediate flush so a browser
-// crash (which sendBeacon can't cover — it only fires on navigation/tab-hide)
-// can't lose it. Everything else (all searches + the high-VOLUME top-of-funnel
-// clicks) batches on the interval/size/unload triggers, which is where the load
-// win lives (these confirms are low-volume).
+// `addAction` kinds that must NOT be held in the coalescing buffer — enqueueing
+// one triggers an immediate flush so a browser crash (which sendBeacon can't
+// cover — it only fires on navigation/tab-hide) can't lose it. Everything else
+// (all searches + the high-VOLUME top-of-funnel clicks) batches on the
+// interval/size/unload triggers, which is where the load win lives (these
+// immediate kinds are low-volume).
 //
-// Selection is deliberately CONSERVATIVE — when in doubt an event is treated as
-// high-value (immediate). Included:
+// Two categories qualify, selected CONSERVATIVELY (when in doubt → immediate):
+//
+//   MONEY / CONVERSION-critical:
 //   - Generator_Submit      — anchors the generation→revenue funnel (externalId join)
 //   - PurchaseFunds_Confirm — buzz purchase completion (real money)
 //   - PurchaseFunds_Cancel  — checkout-funnel drop-off (purchase funnel)
@@ -520,11 +521,16 @@ export type TrackBatchInput = z.infer<typeof trackBatchSchema>;
 //   - AwardBounty_Confirm   — buzz awarded from a bounty
 //   - Membership_Cancel     — subscription churn
 //   - Membership_Downgrade  — subscription downgrade
-// Batched (low-value, high-volume or non-monetization): the *_Click intents,
+//
+//   COMPLIANCE / SAFETY-critical:
+//   - CSAM_Help_Triggered   — child-safety signal; must never be buffered/crash-lost
+//
+// Batched (low-value, high-volume or non-critical): the *_Click intents,
 // TipInteractive_Click/_Cancel (pre-confirm/cancel UI steps — the money move is
-// Tip_Confirm), LoginRedirect, ProfanitySearch, CSAM_Help_Triggered,
-// Model_Create_Click, Image_Remix_Click, and every trackSearch event.
-export const HIGH_VALUE_ACTION_TYPES = new Set<TrackActionInput['type']>([
+// Tip_Confirm), LoginRedirect, ProfanitySearch, Model_Create_Click,
+// Image_Remix_Click, and every trackSearch event.
+export const IMMEDIATE_FLUSH_ACTION_TYPES = new Set<TrackActionInput['type']>([
+  // money / conversion
   'Generator_Submit',
   'PurchaseFunds_Confirm',
   'PurchaseFunds_Cancel',
@@ -534,11 +540,13 @@ export const HIGH_VALUE_ACTION_TYPES = new Set<TrackActionInput['type']>([
   'AwardBounty_Confirm',
   'Membership_Cancel',
   'Membership_Downgrade',
+  // compliance / safety
+  'CSAM_Help_Triggered',
 ]);
 
-// A batch event is high-value only when it's an `action` whose type is in the set
-// above. Searches are never high-value (they're the bulk of the volume → always
-// batched). Used by the client buffer to decide immediate-flush vs coalesce.
-export function isHighValueTrackEvent(event: TrackBatchEvent): boolean {
-  return event.kind === 'action' && HIGH_VALUE_ACTION_TYPES.has(event.data.type);
+// A batch event flushes immediately only when it's an `action` whose type is in
+// the set above. Searches are never immediate (they're the bulk of the volume →
+// always batched). Used by the client buffer to decide immediate-flush vs coalesce.
+export function isImmediateFlushTrackEvent(event: TrackBatchEvent): boolean {
+  return event.kind === 'action' && IMMEDIATE_FLUSH_ACTION_TYPES.has(event.data.type);
 }

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -445,6 +445,23 @@ const generatorSubmitSchema = z.object({
   }),
 });
 
+// Client-coalesced telemetry batch — high-volume `track.trackSearch` (~16/s) and
+// `track.addAction` (~6.8/s) were each fired as ONE tRPC call per event, dragging
+// the full non-batched tRPC middleware chain + superjson encode + ClickHouse
+// insert per event (~23 procedures/s of pure telemetry). The browser now buffers
+// them and flushes coalesced batches to the /api/track/batch beacon, which
+// dispatches each event through the SAME Tracker.search()/Tracker.action() (byte-
+// identical ClickHouse inserts) once per batch instead of once per event.
+//
+// Each batch element is discriminated by `kind` and carries the UNCHANGED
+// per-event input under `data` — the search/action schemas below are reused
+// verbatim, so nothing about what is recorded changes, only how it's transported.
+// The array is bounded (min 1, max BATCH_MAX) so a tampered client can't bloat a
+// single request; the browser flushes well below this cap (see trackEventBuffer).
+// `trackBatchEventSchema` / `trackBatchSchema` are declared at the bottom of this
+// file (after `trackActionSchema`, which the action arm references).
+export const TRACK_BATCH_MAX = 100;
+
 export type TrackActionInput = z.infer<typeof trackActionSchema>;
 export const trackActionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('AddToBounty_Click') }),
@@ -467,3 +484,20 @@ export const trackActionSchema = z.discriminatedUnion('type', [
   imageRemixClickSchema,
   generatorSubmitSchema,
 ]);
+
+// One coalesced telemetry event in a /api/track/batch payload. `kind` selects the
+// destination (search -> Tracker.search, action -> Tracker.action) and `data` is
+// the EXACT existing per-event input for that destination. No field is added,
+// dropped, or reshaped — the transport changes, the recorded row does not.
+export const trackBatchEventSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('search'), data: trackSearchSchema }),
+  z.object({ kind: z.literal('action'), data: trackActionSchema }),
+]);
+export type TrackBatchEvent = z.infer<typeof trackBatchEventSchema>;
+
+// The whole batch: an ordered, bounded array of events. Order is preserved end to
+// end (client buffer -> array -> server iterates in order), matching the pre-batch
+// emit order. Bounded to TRACK_BATCH_MAX so a malicious/oversized body is rejected
+// at the schema layer before any Tracker dispatch.
+export const trackBatchSchema = z.array(trackBatchEventSchema).min(1).max(TRACK_BATCH_MAX);
+export type TrackBatchInput = z.infer<typeof trackBatchSchema>;

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -501,3 +501,44 @@ export type TrackBatchEvent = z.infer<typeof trackBatchEventSchema>;
 // at the schema layer before any Tracker dispatch.
 export const trackBatchSchema = z.array(trackBatchEventSchema).min(1).max(TRACK_BATCH_MAX);
 export type TrackBatchInput = z.infer<typeof trackBatchSchema>;
+
+// Conversion/monetization-critical `addAction` kinds that must NOT be held in the
+// coalescing buffer — enqueueing one triggers an immediate flush so a browser
+// crash (which sendBeacon can't cover — it only fires on navigation/tab-hide)
+// can't lose it. Everything else (all searches + the high-VOLUME top-of-funnel
+// clicks) batches on the interval/size/unload triggers, which is where the load
+// win lives (these confirms are low-volume).
+//
+// Selection is deliberately CONSERVATIVE — when in doubt an event is treated as
+// high-value (immediate). Included:
+//   - Generator_Submit      — anchors the generation→revenue funnel (externalId join)
+//   - PurchaseFunds_Confirm — buzz purchase completion (real money)
+//   - PurchaseFunds_Cancel  — checkout-funnel drop-off (purchase funnel)
+//   - NotEnoughFunds        — purchase-funnel signal (insufficient balance)
+//   - Tip_Confirm           — buzz tip send (money moves)
+//   - AddToBounty_Confirm   — buzz committed to a bounty
+//   - AwardBounty_Confirm   — buzz awarded from a bounty
+//   - Membership_Cancel     — subscription churn
+//   - Membership_Downgrade  — subscription downgrade
+// Batched (low-value, high-volume or non-monetization): the *_Click intents,
+// TipInteractive_Click/_Cancel (pre-confirm/cancel UI steps — the money move is
+// Tip_Confirm), LoginRedirect, ProfanitySearch, CSAM_Help_Triggered,
+// Model_Create_Click, Image_Remix_Click, and every trackSearch event.
+export const HIGH_VALUE_ACTION_TYPES = new Set<TrackActionInput['type']>([
+  'Generator_Submit',
+  'PurchaseFunds_Confirm',
+  'PurchaseFunds_Cancel',
+  'NotEnoughFunds',
+  'Tip_Confirm',
+  'AddToBounty_Confirm',
+  'AwardBounty_Confirm',
+  'Membership_Cancel',
+  'Membership_Downgrade',
+]);
+
+// A batch event is high-value only when it's an `action` whose type is in the set
+// above. Searches are never high-value (they're the bulk of the volume → always
+// batched). Used by the client buffer to decide immediate-flush vs coalesce.
+export function isHighValueTrackEvent(event: TrackBatchEvent): boolean {
+  return event.kind === 'action' && HIGH_VALUE_ACTION_TYPES.has(event.data.type);
+}

--- a/src/tests/api/track/batch.test.ts
+++ b/src/tests/api/track/batch.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * Coverage for POST /api/track/batch — the coalesced telemetry beacon that
+ * replaces one-tRPC-call-per-event for track.trackSearch + track.addAction
+ * (Load-reduction B1).
+ *
+ * Verifies the behavior-preserving contract:
+ *  - same-origin guard (origin/referer host must equal request host),
+ *  - tolerant body parse (object from Next's json parser OR raw string),
+ *  - trackBatchSchema validation (400 on empty / oversized / malformed batch),
+ *  - each event is dispatched via the SAME Tracker.search()/Tracker.action() the
+ *    tRPC resolvers used, with the EXACT per-event payload and in array order (so
+ *    the ClickHouse inserts are byte-identical and only the transport changed),
+ *  - dev short-circuits to 200 with no insert.
+ */
+
+const { mockSearch, mockAction, devStore } = vi.hoisted(() => ({
+  mockSearch: vi.fn(),
+  mockAction: vi.fn(),
+  devStore: { isDev: false },
+}));
+
+// PublicEndpoint wraps the handler with CORS/metrics we don't exercise here —
+// pass it through so the route's own logic (origin guard, parse, dispatch) is what's
+// under test.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: any) => handler,
+}));
+
+vi.mock('~/env/other', () => ({
+  get isDev() {
+    return devStore.isDev;
+  },
+  get isProd() {
+    return !devStore.isDev;
+  },
+}));
+
+// Tracker is the shared ClickHouse client; assert .search()/.action() are called
+// with the exact per-event payload (same methods the tRPC resolvers used).
+vi.mock('~/server/clickhouse/client', () => ({
+  Tracker: class {
+    search = mockSearch;
+    action = mockAction;
+  },
+}));
+
+function makeRes() {
+  const res = {} as NextApiResponse & { _status?: number; _body?: unknown };
+  res.status = vi.fn((code: number) => {
+    res._status = code;
+    return res;
+  }) as any;
+  res.send = vi.fn((body: unknown) => {
+    res._body = body;
+    return res;
+  }) as any;
+  res.end = vi.fn(() => res) as any;
+  return res;
+}
+
+function makeReq(opts: {
+  host?: string;
+  origin?: string;
+  referer?: string;
+  body?: unknown;
+  // Pass `body` through as an OBJECT to simulate Next's application/json parser
+  // (the real browser path). Default stringifies (text/plain client).
+  objectBody?: boolean;
+}) {
+  return {
+    method: 'POST',
+    headers: {
+      host: opts.host ?? 'civitai.com',
+      ...(opts.origin ? { origin: opts.origin } : {}),
+      ...(opts.referer ? { referer: opts.referer } : {}),
+    },
+    body: opts.objectBody
+      ? opts.body
+      : typeof opts.body === 'string'
+      ? opts.body
+      : JSON.stringify(opts.body),
+  } as unknown as NextApiRequest;
+}
+
+const searchEvent = { kind: 'search' as const, data: { query: 'cats', index: 'models' } };
+const actionEvent = {
+  kind: 'action' as const,
+  data: { type: 'Tip_Click' as const, details: { toUserId: 7 } },
+};
+
+async function importHandler() {
+  return (await import('~/pages/api/track/batch')).default;
+}
+
+describe('POST /api/track/batch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    devStore.isDev = false;
+  });
+
+  it('dispatches every event via the matching Tracker method, in order, with the exact payload', async () => {
+    const handler = await importHandler();
+    const req = makeReq({ origin: 'https://civitai.com', body: [searchEvent, actionEvent, searchEvent] });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockSearch).toHaveBeenCalledTimes(2);
+    expect(mockAction).toHaveBeenCalledTimes(1);
+    expect(mockSearch).toHaveBeenNthCalledWith(1, searchEvent.data);
+    expect(mockAction).toHaveBeenNthCalledWith(1, actionEvent.data);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('dispatches when Next pre-parsed the body to an OBJECT (application/json — real browser path)', async () => {
+    const handler = await importHandler();
+    const req = makeReq({ origin: 'https://civitai.com', body: [searchEvent], objectBody: true });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockSearch).toHaveBeenCalledTimes(1);
+    expect(mockSearch).toHaveBeenCalledWith(searchEvent.data);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('accepts the referer host as the origin fallback', async () => {
+    const handler = await importHandler();
+    const req = makeReq({ referer: 'https://civitai.com/models/1', body: [actionEvent] });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockAction).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('rejects a cross-origin request (host mismatch) with 400 and no dispatch', async () => {
+    const handler = await importHandler();
+    const req = makeReq({ origin: 'https://evil.example', body: [searchEvent] });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(mockAction).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects a request with no origin/referer with 400 and no dispatch', async () => {
+    const handler = await importHandler();
+    const req = makeReq({ body: [searchEvent] });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects an unparseable body with 400 and no dispatch', async () => {
+    const handler = await importHandler();
+    const req = makeReq({ origin: 'https://civitai.com', body: '{not json' });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects an empty batch (min 1) with 400 and no dispatch', async () => {
+    const handler = await importHandler();
+    const req = makeReq({ origin: 'https://civitai.com', body: [] });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(mockAction).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects an oversized batch (> TRACK_BATCH_MAX) with 400 and no dispatch', async () => {
+    const { TRACK_BATCH_MAX } = await import('~/server/schema/track.schema');
+    const handler = await importHandler();
+    const tooMany = Array.from({ length: TRACK_BATCH_MAX + 1 }, () => searchEvent);
+    const req = makeReq({ origin: 'https://civitai.com', body: tooMany });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects a malformed event (unknown kind) with 400 and no dispatch', async () => {
+    const handler = await importHandler();
+    const req = makeReq({ origin: 'https://civitai.com', body: [{ kind: 'bogus', data: {} }] });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(mockAction).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('rejects a malformed action event (bad discriminated type) with 400 and no dispatch', async () => {
+    const handler = await importHandler();
+    const req = makeReq({
+      origin: 'https://civitai.com',
+      body: [{ kind: 'action', data: { type: 'NotARealAction' } }],
+    });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockAction).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('short-circuits to 200 in dev without dispatching', async () => {
+    devStore.isDev = true;
+    const handler = await importHandler();
+    const req = makeReq({ origin: 'https://civitai.com', body: [searchEvent] });
+    const res = makeRes();
+
+    await handler(req as any, res);
+
+    expect(mockSearch).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/src/tests/components/TrackView/trackEventBuffer.test.ts
+++ b/src/tests/components/TrackView/trackEventBuffer.test.ts
@@ -3,27 +3,31 @@ import {
   enqueueTrackEvent,
   __trackBufferTestHooks as hooks,
 } from '~/components/TrackView/trackEventBuffer';
-import { isHighValueTrackEvent } from '~/server/schema/track.schema';
-import type { TrackActionInput } from '~/server/schema/track.schema';
+import { isImmediateFlushTrackEvent } from '~/server/schema/track.schema';
+import type { TrackActionInput, TrackBatchEvent } from '~/server/schema/track.schema';
 
 /**
  * Coverage for the client telemetry coalescing buffer (Load-reduction B1).
  *
  * The buffer replaces one-tRPC-call-per-event for trackSearch/addAction with a
- * coalesced batch flushed to /api/track/batch. These tests verify the four flush
- * triggers and the no-loss-on-unload guarantee:
+ * coalesced batch flushed to /api/track/batch. These tests verify the flush
+ * triggers, the no-loss guarantees, and the oversized-batch handling:
  *   - interval flush (timer),
  *   - size-cap flush,
+ *   - immediate flush for money/conversion + compliance (CSAM) events,
  *   - visibilitychange:hidden flush via sendBeacon,
  *   - pagehide flush via sendBeacon (nothing buffered is lost on navigation),
  *   - order + payload preservation (transport changes, recorded shape does not),
- *   - fail-open: a failed flush re-queues events for the next flush (bounded).
+ *   - fail-open: a failed flush (incl. a failed immediate high-value flush)
+ *     re-queues events for the next flush (bounded),
+ *   - sendBeacon returning false (over the ~64KB cap) falls back to keepalive
+ *     fetch instead of dropping, and oversized batches are split into sub-batches.
  *
  * Runs in the node env with a hand-rolled fake DOM so the flush triggers are fully
  * deterministic (no reliance on a headless browser or jsdom event quirks).
  */
 
-const { FLUSH_INTERVAL_MS, FLUSH_AT_SIZE, HARD_CAP } = hooks.constants;
+const { FLUSH_INTERVAL_MS, FLUSH_AT_SIZE, HARD_CAP, MAX_BEACON_BYTES } = hooks.constants;
 
 function makeFakeDom() {
   const listeners: Record<string, Array<(e?: unknown) => void>> = {};
@@ -231,6 +235,93 @@ describe('trackEventBuffer', () => {
     expect(hooks.pendingCount()).toBe(1);
   });
 
+  it('immediately flushes the compliance-critical CSAM_Help_Triggered event', async () => {
+    // Child-safety signal — must never sit buffered or be crash-losable.
+    enqueueTrackEvent({
+      kind: 'action',
+      data: { type: 'CSAM_Help_Triggered', details: { query: 'redacted' } },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(hooks.pendingCount()).toBe(0);
+    expect(await lastFetchBody()).toEqual([
+      { kind: 'action', data: { type: 'CSAM_Help_Triggered', details: { query: 'redacted' } } },
+    ]);
+  });
+
+  it('re-queues a FAILED high-value immediate flush (conversion event not lost)', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false }); // the immediate flush is rejected
+    enqueueTrackEvent({
+      kind: 'action',
+      data: { type: 'Generator_Submit', details: { fromAction: 'create' } },
+    });
+    // Let the immediate flush's post + re-queue microtask settle.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // The conversion event was re-queued, not dropped.
+    expect(hooks.pendingCount()).toBe(1);
+
+    // The re-queue armed the interval timer; next flush (fetch ok) delivers it.
+    vi.advanceTimersByTime(FLUSH_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(await lastFetchBody()).toEqual([
+      { kind: 'action', data: { type: 'Generator_Submit', details: { fromAction: 'create' } } },
+    ]);
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('handles sendBeacon returning false on unload by falling back to keepalive fetch (no silent loss)', async () => {
+    sendBeacon.mockReturnValue(false); // beacon refused (e.g. over the ~64KB cap)
+    enqueueTrackEvent({ kind: 'search', data: { query: 'q', index: 'models' } });
+
+    dom.fire('pagehide');
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Beacon was attempted, refused, then the keepalive fetch fallback carried it.
+    expect(sendBeacon).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0][1] as RequestInit).keepalive).toBe(true);
+    expect(await lastFetchBody()).toEqual([{ kind: 'search', data: { query: 'q', index: 'models' } }]);
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('splits a batch larger than the beacon cap into multiple sub-batch sends', async () => {
+    // Two events each ~ half the cap in size -> two chunks -> two beacons on unload,
+    // each under the cap. Proves oversized batches aren't sent as one over-cap blob.
+    const big = 'x'.repeat(Math.floor(MAX_BEACON_BYTES * 0.7));
+    enqueueTrackEvent({ kind: 'search', data: { query: big, index: 'models' } });
+    enqueueTrackEvent({ kind: 'search', data: { query: big, index: 'models' } });
+
+    dom.fire('pagehide');
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Two separate beacon sends (one per chunk), not one over-cap request.
+    expect(sendBeacon).toHaveBeenCalledTimes(2);
+    for (const call of sendBeacon.mock.calls) {
+      const blob = call[1] as Blob;
+      expect(blob.size).toBeLessThanOrEqual(MAX_BEACON_BYTES);
+      const parsed = JSON.parse(await blob.text());
+      expect(parsed).toHaveLength(1);
+    }
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('chunkEvents keeps each chunk within the byte cap and preserves order', () => {
+    const big = 'y'.repeat(Math.floor(MAX_BEACON_BYTES * 0.6));
+    const events: TrackBatchEvent[] = [
+      { kind: 'search', data: { query: `${big}1`, index: 'models' } },
+      { kind: 'search', data: { query: `${big}2`, index: 'models' } },
+      { kind: 'search', data: { query: `${big}3`, index: 'models' } },
+    ];
+    const chunks = hooks.chunkEvents(events);
+    expect(chunks.length).toBeGreaterThan(1);
+    // Order preserved across the flattened chunks.
+    expect(chunks.flat()).toEqual(events);
+    for (const chunk of chunks) {
+      expect(JSON.stringify(chunk).length).toBeLessThanOrEqual(MAX_BEACON_BYTES);
+    }
+  });
+
   it('bounds re-queued events to the hard cap (drops oldest overflow, never grows unbounded)', async () => {
     // Force every flush to fail so events accumulate, and keep enqueuing past the
     // hard cap. The buffer must never exceed HARD_CAP.
@@ -243,12 +334,13 @@ describe('trackEventBuffer', () => {
   });
 });
 
-describe('isHighValueTrackEvent classification', () => {
+describe('isImmediateFlushTrackEvent classification', () => {
   const action = (type: TrackActionInput['type']) =>
     ({ kind: 'action', data: { type } } as any);
 
-  it('classifies conversion/monetization action types as high-value (immediate)', () => {
-    const highValue: TrackActionInput['type'][] = [
+  it('classifies money/conversion AND compliance action types as immediate-flush', () => {
+    const immediate: TrackActionInput['type'][] = [
+      // money / conversion
       'Generator_Submit',
       'PurchaseFunds_Confirm',
       'PurchaseFunds_Cancel',
@@ -258,31 +350,32 @@ describe('isHighValueTrackEvent classification', () => {
       'AwardBounty_Confirm',
       'Membership_Cancel',
       'Membership_Downgrade',
+      // compliance / safety
+      'CSAM_Help_Triggered',
     ];
-    for (const type of highValue) {
-      expect(isHighValueTrackEvent(action(type))).toBe(true);
+    for (const type of immediate) {
+      expect(isImmediateFlushTrackEvent(action(type))).toBe(true);
     }
   });
 
-  it('classifies high-volume/non-monetization action types as low-value (batched)', () => {
-    const lowValue: TrackActionInput['type'][] = [
+  it('classifies high-volume/non-critical action types as batched (not immediate)', () => {
+    const batched: TrackActionInput['type'][] = [
       'AddToBounty_Click',
       'AwardBounty_Click',
       'Tip_Click',
       'TipInteractive_Click',
       'TipInteractive_Cancel',
       'LoginRedirect',
-      'CSAM_Help_Triggered',
       'ProfanitySearch',
       'Model_Create_Click',
       'Image_Remix_Click',
     ];
-    for (const type of lowValue) {
-      expect(isHighValueTrackEvent(action(type))).toBe(false);
+    for (const type of batched) {
+      expect(isImmediateFlushTrackEvent(action(type))).toBe(false);
     }
   });
 
-  it('never classifies a search event as high-value', () => {
-    expect(isHighValueTrackEvent({ kind: 'search', data: { query: 'x', index: 'models' } })).toBe(false);
+  it('never classifies a search event as immediate-flush', () => {
+    expect(isImmediateFlushTrackEvent({ kind: 'search', data: { query: 'x', index: 'models' } })).toBe(false);
   });
 });

--- a/src/tests/components/TrackView/trackEventBuffer.test.ts
+++ b/src/tests/components/TrackView/trackEventBuffer.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  enqueueTrackEvent,
+  __trackBufferTestHooks as hooks,
+} from '~/components/TrackView/trackEventBuffer';
+
+/**
+ * Coverage for the client telemetry coalescing buffer (Load-reduction B1).
+ *
+ * The buffer replaces one-tRPC-call-per-event for trackSearch/addAction with a
+ * coalesced batch flushed to /api/track/batch. These tests verify the four flush
+ * triggers and the no-loss-on-unload guarantee:
+ *   - interval flush (timer),
+ *   - size-cap flush,
+ *   - visibilitychange:hidden flush via sendBeacon,
+ *   - pagehide flush via sendBeacon (nothing buffered is lost on navigation),
+ *   - order + payload preservation (transport changes, recorded shape does not),
+ *   - fail-open: a failed flush re-queues events for the next flush (bounded).
+ *
+ * Runs in the node env with a hand-rolled fake DOM so the flush triggers are fully
+ * deterministic (no reliance on a headless browser or jsdom event quirks).
+ */
+
+const { FLUSH_INTERVAL_MS, FLUSH_AT_SIZE, HARD_CAP } = hooks.constants;
+
+function makeFakeDom() {
+  const listeners: Record<string, Array<(e?: unknown) => void>> = {};
+  const add = (type: string, cb: (e?: unknown) => void) => {
+    (listeners[type] ??= []).push(cb);
+  };
+  const doc = {
+    visibilityState: 'visible' as 'visible' | 'hidden',
+    addEventListener: add,
+  };
+  const win = { addEventListener: add };
+  const fire = (type: string) => (listeners[type] ?? []).forEach((cb) => cb());
+  return { doc, win, fire };
+}
+
+let sendBeacon: ReturnType<typeof vi.fn>;
+let fetchMock: ReturnType<typeof vi.fn>;
+let dom: ReturnType<typeof makeFakeDom>;
+
+beforeEach(() => {
+  hooks.reset();
+  vi.useFakeTimers();
+
+  dom = makeFakeDom();
+  sendBeacon = vi.fn(() => true);
+  fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+
+  vi.stubGlobal('window', dom.win);
+  vi.stubGlobal('document', dom.doc);
+  vi.stubGlobal('navigator', { sendBeacon });
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  hooks.reset();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+async function lastFetchBody() {
+  const call = fetchMock.mock.calls.at(-1);
+  return JSON.parse((call?.[1] as RequestInit).body as string);
+}
+
+async function lastBeaconBody() {
+  const call = sendBeacon.mock.calls.at(-1);
+  const blob = call?.[1] as Blob;
+  return JSON.parse(await blob.text());
+}
+
+describe('trackEventBuffer', () => {
+  it('does not flush until the interval elapses, then flushes via fetch', async () => {
+    enqueueTrackEvent({ kind: 'search', data: { query: 'cats', index: 'models' } });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(hooks.pendingCount()).toBe(1);
+
+    vi.advanceTimersByTime(FLUSH_INTERVAL_MS);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/track/batch');
+    expect((init as RequestInit).keepalive).toBe(true);
+    expect(await lastFetchBody()).toEqual([
+      { kind: 'search', data: { query: 'cats', index: 'models' } },
+    ]);
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('flushes immediately once the size cap is reached (no timer wait)', async () => {
+    for (let i = 0; i < FLUSH_AT_SIZE; i++) {
+      enqueueTrackEvent({ kind: 'action', data: { type: 'AwardBounty_Click' } });
+    }
+    // Cap reached -> flushed synchronously, before any timer advance.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = await lastFetchBody();
+    expect(body).toHaveLength(FLUSH_AT_SIZE);
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('preserves event order and the exact per-event payload across a batch', async () => {
+    enqueueTrackEvent({ kind: 'action', data: { type: 'Tip_Click', details: { toUserId: 7 } } });
+    enqueueTrackEvent({ kind: 'search', data: { query: 'dogs', index: 'images', filters: { a: 1 } } });
+    enqueueTrackEvent({ kind: 'action', data: { type: 'AddToBounty_Confirm' } });
+
+    vi.advanceTimersByTime(FLUSH_INTERVAL_MS);
+
+    expect(await lastFetchBody()).toEqual([
+      { kind: 'action', data: { type: 'Tip_Click', details: { toUserId: 7 } } },
+      { kind: 'search', data: { query: 'dogs', index: 'images', filters: { a: 1 } } },
+      { kind: 'action', data: { type: 'AddToBounty_Confirm' } },
+    ]);
+  });
+
+  it('flushes via sendBeacon (not fetch) on visibilitychange -> hidden', async () => {
+    enqueueTrackEvent({ kind: 'search', data: { query: 'x', index: 'models' } });
+
+    dom.doc.visibilityState = 'hidden';
+    dom.fire('visibilitychange');
+
+    expect(sendBeacon).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+    const [beaconUrl, blob] = sendBeacon.mock.calls[0];
+    expect(beaconUrl).toBe('/api/track/batch');
+    expect((blob as Blob).type).toBe('application/json');
+    expect(await lastBeaconBody()).toEqual([{ kind: 'search', data: { query: 'x', index: 'models' } }]);
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('does NOT flush on visibilitychange -> visible', () => {
+    enqueueTrackEvent({ kind: 'search', data: { query: 'x', index: 'models' } });
+    dom.doc.visibilityState = 'visible';
+    dom.fire('visibilitychange');
+    expect(sendBeacon).not.toHaveBeenCalled();
+    expect(hooks.pendingCount()).toBe(1);
+  });
+
+  it('loses no buffered events on pagehide — flushes them via sendBeacon', async () => {
+    // The core no-loss guarantee: events buffered right before navigation are
+    // delivered by the unload-safe beacon, not dropped.
+    enqueueTrackEvent({ kind: 'action', data: { type: 'AwardBounty_Click' } });
+    enqueueTrackEvent({ kind: 'search', data: { query: 'q', index: 'models' } });
+    expect(hooks.pendingCount()).toBe(2);
+
+    dom.fire('pagehide');
+
+    expect(sendBeacon).toHaveBeenCalledTimes(1);
+    expect(await lastBeaconBody()).toHaveLength(2);
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('is a no-op flush when the buffer is empty (idempotent unload handlers)', () => {
+    dom.fire('pagehide');
+    dom.doc.visibilityState = 'hidden';
+    dom.fire('visibilitychange');
+    expect(sendBeacon).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fail-open: re-queues events and retries on the next flush when a flush fails', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false }); // first flush rejected by server
+    enqueueTrackEvent({ kind: 'search', data: { query: 'retry', index: 'models' } });
+
+    vi.advanceTimersByTime(FLUSH_INTERVAL_MS);
+    // Let the post() promise + re-queue microtask settle.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Event was NOT silently lost — it's back in the buffer.
+    expect(hooks.pendingCount()).toBe(1);
+
+    // Next interval retries (fetch now succeeds by default).
+    vi.advanceTimersByTime(FLUSH_INTERVAL_MS);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(await lastFetchBody()).toEqual([
+      { kind: 'search', data: { query: 'retry', index: 'models' } },
+    ]);
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('bounds re-queued events to the hard cap (drops oldest overflow, never grows unbounded)', async () => {
+    // Force every flush to fail so events accumulate, and keep enqueuing past the
+    // hard cap. The buffer must never exceed HARD_CAP.
+    fetchMock.mockResolvedValue({ ok: false });
+    for (let i = 0; i < HARD_CAP + FLUSH_AT_SIZE; i++) {
+      enqueueTrackEvent({ kind: 'search', data: { query: `q${i}`, index: 'models' } });
+      await vi.advanceTimersByTimeAsync(0);
+    }
+    expect(hooks.pendingCount()).toBeLessThanOrEqual(HARD_CAP);
+  });
+});

--- a/src/tests/components/TrackView/trackEventBuffer.test.ts
+++ b/src/tests/components/TrackView/trackEventBuffer.test.ts
@@ -3,6 +3,8 @@ import {
   enqueueTrackEvent,
   __trackBufferTestHooks as hooks,
 } from '~/components/TrackView/trackEventBuffer';
+import { isHighValueTrackEvent } from '~/server/schema/track.schema';
+import type { TrackActionInput } from '~/server/schema/track.schema';
 
 /**
  * Coverage for the client telemetry coalescing buffer (Load-reduction B1).
@@ -102,16 +104,17 @@ describe('trackEventBuffer', () => {
   });
 
   it('preserves event order and the exact per-event payload across a batch', async () => {
+    // All low-value so the batch coalesces on the interval (order under test here).
     enqueueTrackEvent({ kind: 'action', data: { type: 'Tip_Click', details: { toUserId: 7 } } });
     enqueueTrackEvent({ kind: 'search', data: { query: 'dogs', index: 'images', filters: { a: 1 } } });
-    enqueueTrackEvent({ kind: 'action', data: { type: 'AddToBounty_Confirm' } });
+    enqueueTrackEvent({ kind: 'action', data: { type: 'AddToBounty_Click' } });
 
     vi.advanceTimersByTime(FLUSH_INTERVAL_MS);
 
     expect(await lastFetchBody()).toEqual([
       { kind: 'action', data: { type: 'Tip_Click', details: { toUserId: 7 } } },
       { kind: 'search', data: { query: 'dogs', index: 'images', filters: { a: 1 } } },
-      { kind: 'action', data: { type: 'AddToBounty_Confirm' } },
+      { kind: 'action', data: { type: 'AddToBounty_Click' } },
     ]);
   });
 
@@ -181,6 +184,53 @@ describe('trackEventBuffer', () => {
     expect(hooks.pendingCount()).toBe(0);
   });
 
+  it('immediately flushes a high-value action event (no interval wait)', async () => {
+    // PurchaseFunds_Confirm is a conversion/monetization event — it must leave in
+    // the same tick, not wait for the 3s interval (a crash before the interval
+    // would lose it). No timers are advanced here.
+    enqueueTrackEvent({
+      kind: 'action',
+      data: { type: 'PurchaseFunds_Confirm', details: { buzzAmount: 100, unitAmount: 1, method: 'card' } },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(hooks.pendingCount()).toBe(0);
+    expect(await lastFetchBody()).toEqual([
+      { kind: 'action', data: { type: 'PurchaseFunds_Confirm', details: { buzzAmount: 100, unitAmount: 1, method: 'card' } } },
+    ]);
+  });
+
+  it('a high-value flush carries already-buffered low-value events (single transport, order preserved)', async () => {
+    // A low-value event sits in the buffer; a following high-value event forces the
+    // flush and takes the buffered low-value event with it, in order.
+    enqueueTrackEvent({ kind: 'search', data: { query: 'held', index: 'models' } });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    enqueueTrackEvent({ kind: 'action', data: { type: 'Tip_Confirm', details: { toUserId: 1, amount: 5 } } });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(await lastFetchBody()).toEqual([
+      { kind: 'search', data: { query: 'held', index: 'models' } },
+      { kind: 'action', data: { type: 'Tip_Confirm', details: { toUserId: 1, amount: 5 } } },
+    ]);
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('does NOT immediately flush a low-value action event (still coalesces on the interval)', async () => {
+    enqueueTrackEvent({ kind: 'action', data: { type: 'Tip_Click', details: { toUserId: 2 } } });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(hooks.pendingCount()).toBe(1);
+
+    vi.advanceTimersByTime(FLUSH_INTERVAL_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never immediately flushes a trackSearch event (searches are the batched bulk)', () => {
+    enqueueTrackEvent({ kind: 'search', data: { query: 'x', index: 'models' } });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(hooks.pendingCount()).toBe(1);
+  });
+
   it('bounds re-queued events to the hard cap (drops oldest overflow, never grows unbounded)', async () => {
     // Force every flush to fail so events accumulate, and keep enqueuing past the
     // hard cap. The buffer must never exceed HARD_CAP.
@@ -190,5 +240,49 @@ describe('trackEventBuffer', () => {
       await vi.advanceTimersByTimeAsync(0);
     }
     expect(hooks.pendingCount()).toBeLessThanOrEqual(HARD_CAP);
+  });
+});
+
+describe('isHighValueTrackEvent classification', () => {
+  const action = (type: TrackActionInput['type']) =>
+    ({ kind: 'action', data: { type } } as any);
+
+  it('classifies conversion/monetization action types as high-value (immediate)', () => {
+    const highValue: TrackActionInput['type'][] = [
+      'Generator_Submit',
+      'PurchaseFunds_Confirm',
+      'PurchaseFunds_Cancel',
+      'NotEnoughFunds',
+      'Tip_Confirm',
+      'AddToBounty_Confirm',
+      'AwardBounty_Confirm',
+      'Membership_Cancel',
+      'Membership_Downgrade',
+    ];
+    for (const type of highValue) {
+      expect(isHighValueTrackEvent(action(type))).toBe(true);
+    }
+  });
+
+  it('classifies high-volume/non-monetization action types as low-value (batched)', () => {
+    const lowValue: TrackActionInput['type'][] = [
+      'AddToBounty_Click',
+      'AwardBounty_Click',
+      'Tip_Click',
+      'TipInteractive_Click',
+      'TipInteractive_Cancel',
+      'LoginRedirect',
+      'CSAM_Help_Triggered',
+      'ProfanitySearch',
+      'Model_Create_Click',
+      'Image_Remix_Click',
+    ];
+    for (const type of lowValue) {
+      expect(isHighValueTrackEvent(action(type))).toBe(false);
+    }
+  });
+
+  it('never classifies a search event as high-value', () => {
+    expect(isHighValueTrackEvent({ kind: 'search', data: { query: 'x', index: 'models' } })).toBe(false);
   });
 });

--- a/src/tests/components/TrackView/useTrackEvent.wiring.test.ts
+++ b/src/tests/components/TrackView/useTrackEvent.wiring.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import type { act as actType } from 'react-dom/test-utils';
+import { createRoot } from 'react-dom/client';
+
+// React 18.3 exposes `act` on the `react` export; borrow the typed signature.
+const act = (React as unknown as { act: typeof actType }).act;
+
+/**
+ * INTEGRATION coverage for the `useTrackEvent` -> `enqueueTrackEvent` wiring
+ * (Load-reduction B1).
+ *
+ * The sibling `trackEventBuffer.test.ts` drives the buffer in ISOLATION — it
+ * calls `enqueueTrackEvent` directly. That leaves ONE seam untested: whether the
+ * `useTrackEvent` React hook (the entrypoint every trackSearch/trackAction call
+ * site actually uses) still routes low-value events INTO the buffer, arms the
+ * interval, and registers the unload listeners. A regression there — the hook
+ * dropping the enqueue call, or tagging a search as the wrong `kind` — would sail
+ * past the isolated buffer tests while silently breaking coalesced telemetry in
+ * the real app. These tests exercise the FULL chain through the real hook:
+ *   hook handler -> real enqueueTrackEvent -> buffer -> interval/immediate flush
+ *   + the visibilitychange/pagehide unload listeners.
+ */
+
+// trackShare stays a per-event tRPC mutation; mock only enough for the hook to
+// instantiate. The batched search/action paths do NOT touch tRPC.
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    track: {
+      trackShare: { useMutation: () => ({ mutateAsync: vi.fn().mockResolvedValue(undefined) }) },
+    },
+  },
+}));
+
+// Real hook + real buffer (NOT mocked) — this is the wiring under test.
+import { useTrackEvent } from '~/components/TrackView/track.utils';
+import { __trackBufferTestHooks as hooks } from '~/components/TrackView/trackEventBuffer';
+
+const { FLUSH_INTERVAL_MS } = hooks.constants;
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let beaconMock: ReturnType<typeof vi.fn>;
+
+function renderTrackEvent() {
+  const container = document.createElement('div');
+  const root = createRoot(container);
+  const ref: { current: ReturnType<typeof useTrackEvent> | undefined } = { current: undefined };
+  function Probe() {
+    ref.current = useTrackEvent();
+    return null;
+  }
+  act(() => root.render(React.createElement(Probe)));
+  return ref;
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  hooks.reset();
+  vi.useFakeTimers();
+  fetchMock = vi.fn(() => Promise.resolve({ ok: true }));
+  beaconMock = vi.fn(() => true);
+  vi.stubGlobal('fetch', fetchMock);
+  // happy-dom's navigator has no sendBeacon; define one so the unload path can use it.
+  Object.defineProperty(navigator, 'sendBeacon', { value: beaconMock, configurable: true, writable: true });
+});
+
+afterEach(() => {
+  hooks.reset();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+function lastFetchBody() {
+  const call = fetchMock.mock.calls.at(-1);
+  return JSON.parse((call?.[1] as RequestInit).body as string);
+}
+
+describe('useTrackEvent -> buffer wiring', () => {
+  it('a low-value trackSearch enqueues into the buffer and flushes on the interval as kind:"search"', () => {
+    const api = renderTrackEvent();
+
+    void api.current!.trackSearch({ query: 'cats', index: 'models' });
+
+    // Enqueued, coalescing — no request yet, interval armed.
+    expect(hooks.pendingCount()).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(FLUSH_INTERVAL_MS);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/track/batch');
+    // Transport is batched; the recorded shape is the UNCHANGED per-event input.
+    expect(lastFetchBody()).toEqual([{ kind: 'search', data: { query: 'cats', index: 'models' } }]);
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('a low-value trackAction (non-immediate) enqueues as kind:"action" and coalesces (no synchronous flush)', () => {
+    const api = renderTrackEvent();
+
+    void api.current!.trackAction({ type: 'Image_Remix_Click', details: { imageId: 1 } } as never);
+
+    expect(hooks.pendingCount()).toBe(1);
+    expect(fetchMock).not.toHaveBeenCalled(); // batched, not immediate
+
+    vi.advanceTimersByTime(FLUSH_INTERVAL_MS);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(lastFetchBody()).toEqual([
+      { kind: 'action', data: { type: 'Image_Remix_Click', details: { imageId: 1 } } },
+    ]);
+  });
+
+  it('an immediate high-value trackAction (Generator_Submit) flushes synchronously through the hook (no interval wait)', () => {
+    const api = renderTrackEvent();
+
+    void api.current!.trackAction({ type: 'Generator_Submit' } as never);
+
+    // Fired in the same tick — no timer advance needed.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(lastFetchBody()).toEqual([{ kind: 'action', data: { type: 'Generator_Submit' } }]);
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('registers the unload listeners so a buffered low-value event flushes via sendBeacon on pagehide', () => {
+    const api = renderTrackEvent();
+
+    void api.current!.trackSearch({ query: 'dogs', index: 'images' });
+    expect(hooks.pendingCount()).toBe(1);
+    expect(beaconMock).not.toHaveBeenCalled();
+
+    // The pagehide listener must have been registered on the first enqueue (via the
+    // hook) — firing it should beacon the buffered event out before the interval.
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(beaconMock).toHaveBeenCalledTimes(1);
+    expect(beaconMock.mock.calls[0][0]).toBe('/api/track/batch');
+    expect(hooks.pendingCount()).toBe(0);
+  });
+
+  it('flushes a buffered event on visibilitychange:hidden (mobile-reliable unload signal)', () => {
+    const api = renderTrackEvent();
+
+    void api.current!.trackSearch({ query: 'birds', index: 'models' });
+    expect(hooks.pendingCount()).toBe(1);
+
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(beaconMock).toHaveBeenCalledTimes(1);
+    expect(beaconMock.mock.calls[0][0]).toBe('/api/track/batch');
+    expect(hooks.pendingCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

`track.trackSearch` (~16 req/s) and `track.addAction` (~6.8 req/s) were each fired as **one tRPC mutation per event**, so every search/action dragged the full non-batched tRPC middleware chain + superjson encode + a ClickHouse insert — **~23 telemetry procedures/s** of pure fire-and-forget analytics.

This PR buffers those events client-side and flushes **coalesced batches** to a new lightweight `/api/track/batch` beacon, which dispatches each event through the **same `Tracker.search()` / `Tracker.action()`** (byte-identical ClickHouse inserts) once per batch and resolves the session once per batch. That collapses ~23 telemetry procedures/s into a handful of batched requests/s.

This is the one load-reduction lever in the request-**VOLUME** class — eliminating these ~23 procedures/s is real capacity headroom (a potential HPA-floor path), not just per-request cost.

## Immediate-flush vs batched split

Money/conversion-critical AND compliance-critical `addAction` events are **never held** in the buffer — enqueueing one triggers an **immediate flush in the same tick**, over the **same** `/api/track/batch` transport (it batches with whatever low-value events are already buffered; the point is it isn't *delayed*). This closes the one gap `sendBeacon` can't cover: `sendBeacon` guarantees delivery on navigation/tab-hide, but **not on a browser crash** — so an immediate event sitting in a 3s buffer could be lost to a crash. Immediate flush removes that window.

**Immediate-flush kinds** (`IMMEDIATE_FLUSH_ACTION_TYPES`), selected conservatively (when in doubt → immediate):

| kind | category | why |
|---|---|---|
| `Generator_Submit` | money/conversion | anchors the generation→revenue funnel (externalId join) |
| `PurchaseFunds_Confirm` | money/conversion | buzz purchase completion (real money) |
| `PurchaseFunds_Cancel` | money/conversion | checkout-funnel drop-off |
| `NotEnoughFunds` | money/conversion | purchase-funnel signal (insufficient balance) |
| `Tip_Confirm` | money/conversion | buzz tip send (money moves) |
| `AddToBounty_Confirm` | money/conversion | buzz committed to a bounty |
| `AwardBounty_Confirm` | money/conversion | buzz awarded from a bounty |
| `Membership_Cancel` | money/conversion | subscription churn |
| `Membership_Downgrade` | money/conversion | subscription downgrade |
| `CSAM_Help_Triggered` | **compliance/safety** | child-safety signal — must never be buffered/crash-lost |

**Batched (low-value)** — all `trackSearch` events, plus the `*_Click` top-of-funnel intents (`AddToBounty_Click`, `AwardBounty_Click`, `Tip_Click`, `Model_Create_Click`, `Image_Remix_Click`), `TipInteractive_Click`/`_Cancel` (pre-confirm/cancel UI steps — the money move is `Tip_Confirm`), `LoginRedirect`, `ProfanitySearch`.

**The load win is preserved:** the volume lives in the batched events (`trackSearch` is the bulk at ~16/s, plus the high-frequency top-of-funnel clicks); the immediate confirms are low-volume, so flushing them eagerly costs almost nothing.

## Batching design

**Flush triggers** (client buffer, `src/components/TrackView/trackEventBuffer.ts`):
- **Immediate-flush event** — flush in the same tick (see split above).
- **Interval** — every 3s (low-value events).
- **Size cap** — flush at 20 buffered events.
- **`visibilitychange` → hidden** and **`pagehide`** — flush via `navigator.sendBeacon`.

**Oversized batches:** `sendBeacon` (and the shared keepalive-fetch budget) cap out around **~64KB**. A large or re-queued batch is split (`chunkEvents`) into ordered sub-batches that each fit under ~60KB and sent as multiple requests. If a beacon is still refused (returns `false` — over cap / queue full), that chunk **falls back to a keepalive fetch** rather than being dropped.

**No-loss guarantees (accurate):**
- **No loss on navigation / tab-hide** — the unload/hide path uses `navigator.sendBeacon`, which the browser delivers even as the document is torn down (a normal `fetch` is cancelled on navigation). We deliberately use `pagehide` + `visibilitychange:hidden` (not `unload`/`beforeunload`, which disable the bfcache and don't fire on mobile).
- **Oversized batches are chunked** to fit the beacon cap; **a rejected beacon falls back to keepalive fetch** (best-effort).
- Interval/size flushes use `fetch(..., { keepalive: true })` so a flush racing a navigation still completes. The buffer is drained atomically on flush, so events enqueued mid-send land in the next batch.
- **Residual:** a browser **crash** (not navigation — sendBeacon covers that) can still lose up to a few seconds of *low-value batched* events; immediate-flush (money/conversion + CSAM) events are not held, so they're not exposed to that window.

**Fail-open, at-least-once:** a failed flush (network error / non-2xx) **re-queues** its failed chunks (order-preserved, bounded to the server max — oldest overflow dropped) so the next flush retries — including a failed *immediate* high-value flush. It never throws to the caller and never blocks the user flow. Because an ambiguous failure (a request that actually reached the server but whose response was lost) is retried, delivery is **at-least-once**: ClickHouse rows can **duplicate**, including conversion events. **Consumers must dedup** — high-value events on `externalId` / session over a window (the same dedup already recommended for `blockRenders`, whose beacon also emits one row per mount).

**Server shape:** a new `/api/track/batch` beacon (not a new tRPC procedure). It mirrors the established high-volume-telemetry pattern in this repo — `/api/internal/pulse` (the `addView` → beacon move, #2680) and `/api/track/block-render` — and is the **smaller-blast-radius** choice because (a) the no-loss-on-navigation guarantee *requires* `sendBeacon`, which the tRPC client can't emit; (b) it skips the entire tRPC middleware chain (the actual per-call cost); (c) it doesn't change the `track.*` router. The batch input reuses the **existing** `trackSearch`/`trackAction` schemas verbatim under a bounded, `kind`-discriminated array (`trackBatchSchema`) — what is recorded is unchanged, only the transport is batched. Events dispatch in array order. Immediate and batched events share this one transport.

## Scope / behaviour

- Only `trackSearch` + `trackAction` are batched. `trackShare` stays a per-event tRPC mutation (low-volume, user-intent).
- The tRPC `track.*` procedures are **kept intact** for bearer/API-key callers; the cookie-authed browser goes through the buffer — same split as the `addView`→pulse / `blockRender`→block-render beacon moves.
- Every field each event carries today is preserved; event semantics/ordering unchanged. The only user-visible delta is low-value analytics landing a few seconds later (imperceptible, no functional loss).

## Tests

- **Client buffer** (`src/tests/components/TrackView/trackEventBuffer.test.ts`): interval flush, size-cap flush, immediate flush for money/conversion + **CSAM** compliance events, `visibilitychange:hidden`/`pagehide` → sendBeacon, no-loss-on-navigation (buffered events delivered, buffer emptied), order + payload preservation, fail-open re-queue + hard-cap bound, **failed high-value immediate flush re-queues the conversion event**, **sendBeacon-returns-false falls back to keepalive fetch (no silent loss)**, **an over-cap batch is split into multiple sub-batch sends**, `chunkEvents` cap + order, and `isImmediateFlushTrackEvent` classification both ways.
- **Server handler** (`src/tests/api/track/batch.test.ts`): dispatch via the matching Tracker method in array order with the exact payload, tolerant object/string parse, same-origin guard, empty/oversized/malformed-event rejection, dev short-circuit.

## Risk / follow-ups

- **At-least-once duplicates:** the retry can produce duplicate CH rows (incl. conversions) — dashboards must dedup on `externalId`/session (documented above).
- **Attacker-writable track tables:** this beacon is public + cookie-optional, so an anonymous caller can POST fabricated (`userId=0`) analytics rows — exactly like the existing `/api/internal/pulse` and `/api/track/block-render` beacons. CH `track` tables should be treated as attacker-writable. **Follow-up (NOT in this PR):** add per-IP/global rate-limiting to the track beacons.
- `sendBeacon` posts `application/json` (via a typed `Blob`); same-origin only, so no CORS preflight concern. The beacon route tolerates both the object (Next JSON parser) and raw-string body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
