### PR TITLE
perf(cache): in-proc short-TTL memoize of global system/config reads

### DIFF
--- a/src/server/services/__tests__/announcement.memoize.test.ts
+++ b/src/server/services/__tests__/announcement.memoize.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The announcement redis read (getAnnouncementsCached) is memoized per domain,
+// while getCurrentAnnouncements applies the per-user (targetAudience) + active
+// time-window filter AFTER, in JS. These tests prove the read collapses per
+// domain and is user-INDEPENDENT (so the memo is safe). TTL expiry is covered
+// in ttl-memoize.test.ts. Fresh module (fresh memos) per test via resetModules.
+const { redisGet, redisSet } = vi.hoisted(() => ({
+  redisGet: vi.fn(),
+  redisSet: vi.fn(),
+}));
+
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { day: 86400 } }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { announcement: { findMany: vi.fn(), count: vi.fn() }, $transaction: vi.fn() },
+  dbWrite: { announcement: { findMany: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: redisGet, set: redisSet, del: vi.fn() },
+  REDIS_KEYS: { CACHES: { ANNOUNCEMENTS: 'packed:caches:announcements' } },
+}));
+vi.mock('~/server/utils/pagination-helpers', () => ({
+  DEFAULT_PAGE_SIZE: 20,
+  getPagination: vi.fn(),
+  getPagingData: vi.fn(),
+}));
+vi.mock('~/shared/utils/prisma/enums', () => ({
+  DomainColor: { all: 'all', green: 'green', red: 'red' },
+}));
+// ttl-memoize intentionally NOT mocked — the real memo is under test.
+
+async function loadService() {
+  vi.resetModules();
+  return import('../announcement.service');
+}
+
+// A single always-active, audience-agnostic announcement so the downstream
+// user/time filter keeps it for every caller.
+function activeAnnouncement() {
+  return [
+    {
+      id: 1,
+      title: 't',
+      content: 'c',
+      color: 'blue',
+      emoji: null,
+      createdAt: new Date('2000-01-01').toISOString(),
+      startsAt: new Date('2000-01-01').toISOString(),
+      endsAt: new Date('2100-01-01').toISOString(),
+      metadata: {},
+    },
+  ];
+}
+
+describe('announcement in-proc memoize (per domain)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('collapses the redis read across calls for the same domain, independent of userId', async () => {
+    const { getCurrentAnnouncements } = await loadService();
+    redisGet.mockResolvedValue(JSON.stringify(activeAnnouncement()));
+
+    const anon = await getCurrentAnnouncements({ domain: 'green' as never });
+    const authed = await getCurrentAnnouncements({ userId: 42, domain: 'green' as never });
+
+    // Both callers get the same (audience-agnostic) announcement...
+    expect(anon).toHaveLength(1);
+    expect(authed).toHaveLength(1);
+    // ...from a SINGLE redis GET — the per-user filter runs outside the memo.
+    expect(redisGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('memoizes each domain independently (separate redis read per domain)', async () => {
+    const { getCurrentAnnouncements } = await loadService();
+    redisGet.mockResolvedValue(JSON.stringify(activeAnnouncement()));
+
+    await getCurrentAnnouncements({ domain: 'green' as never });
+    await getCurrentAnnouncements({ domain: 'green' as never }); // collapsed
+    await getCurrentAnnouncements({ domain: 'red' as never }); // separate slot
+    await getCurrentAnnouncements({}); // no-domain default -> separate slot
+
+    expect(redisGet).toHaveBeenCalledTimes(3);
+  });
+
+  it('fail-open: a rejected redis read is not cached and the next call retries', async () => {
+    const { getCurrentAnnouncements } = await loadService();
+    redisGet.mockRejectedValueOnce(new Error('redis down'));
+
+    await expect(getCurrentAnnouncements({ domain: 'green' as never })).rejects.toThrow(
+      'redis down'
+    );
+
+    redisGet.mockResolvedValue(JSON.stringify(activeAnnouncement()));
+    const recovered = await getCurrentAnnouncements({ domain: 'green' as never });
+    expect(recovered).toHaveLength(1);
+    expect(redisGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/server/services/__tests__/nowpayments.currencies.memoize.test.ts
+++ b/src/server/services/__tests__/nowpayments.currencies.memoize.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Focused test for the in-proc memoization of getSupportedCurrencies (a GLOBAL,
+// rarely-changing list). Mocks only what nowpayments.service needs to import;
+// the REAL ttl-memoize is used so we exercise the actual memo. Each test
+// re-imports the module after vi.resetModules() for a fresh memo slate. TTL
+// expiry itself is covered deterministically in ttl-memoize.test.ts.
+const { packedGet, packedSet, getMerchantCoins, getFullCurrencies, getMinimumPaymentAmount } =
+  vi.hoisted(() => ({
+    packedGet: vi.fn(),
+    packedSet: vi.fn(),
+    getMerchantCoins: vi.fn(),
+    getFullCurrencies: vi.fn(),
+    getMinimumPaymentAmount: vi.fn(),
+  }));
+
+vi.mock('~/env/server', () => ({ env: { NEXTAUTH_URL: 'https://example.test' } }));
+vi.mock('../../logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('../buzz.service', () => ({
+  getMultipliersForUser: vi.fn(),
+  getTransactionByExternalId: vi.fn(),
+  grantBuzzPurchase: vi.fn(),
+}));
+vi.mock('~/server/http/nowpayments/nowpayments.caller', () => ({
+  default: { getMerchantCoins, getFullCurrencies, getMinimumPaymentAmount },
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+vi.mock('~/server/utils/distributed-lock', () => ({ withDistributedLock: vi.fn() }));
+vi.mock('~/utils/signal-client', () => ({ signalClient: { send: vi.fn() } }));
+vi.mock('~/server/common/enums', () => ({
+  SignalMessages: { CryptoDepositUpdate: 'x' },
+  NotificationCategory: { Buzz: 'buzz' },
+}));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/redis/client', () => ({
+  redis: { packed: { get: packedGet, set: packedSet } },
+  REDIS_KEYS: { CACHES: { SUPPORTED_CRYPTO_CURRENCIES: 'packed:caches:supported-crypto' } },
+}));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+vi.mock('~/server/utils/cache-helpers', () => ({ fetchThroughCache: vi.fn() }));
+vi.mock('~/server/common/chain-config', () => ({
+  getChainConfig: vi.fn(),
+  getChainForNetworkWithFallback: vi.fn(() => ({ chain: 'eth' })),
+  isDepositComplete: vi.fn(),
+  outcomeAmountToBuzz: vi.fn(),
+}));
+// NOTE: ttl-memoize is intentionally NOT mocked — the real memo is under test.
+
+async function loadService() {
+  vi.resetModules();
+  return import('../nowpayments.service');
+}
+
+describe('getSupportedCurrencies in-proc memoize', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('serves a redis-cached list from the in-proc memo, collapsing repeat calls to one GET', async () => {
+    const { getSupportedCurrencies } = await loadService();
+    const group = [{ ticker: 'btc', name: 'Bitcoin', networks: [] }];
+    packedGet.mockResolvedValue(group);
+
+    expect(await getSupportedCurrencies()).toEqual(group);
+    expect(await getSupportedCurrencies()).toEqual(group);
+
+    // Within the TTL both calls collapse to a single redis GET, and the upstream
+    // NowPayments API is never touched on the cached path.
+    expect(packedGet).toHaveBeenCalledTimes(1);
+    expect(getMerchantCoins).not.toHaveBeenCalled();
+  });
+
+  it('fail-open: an upstream miss returns [] and is NOT memoized (next call retries)', async () => {
+    const { getSupportedCurrencies } = await loadService();
+    packedGet.mockResolvedValue(null); // force the upstream fetch path
+    // First call: upstream unavailable -> [] (not cached).
+    getMerchantCoins.mockResolvedValueOnce(null);
+    getFullCurrencies.mockResolvedValueOnce(null);
+
+    expect(await getSupportedCurrencies()).toEqual([]);
+
+    // Second call must re-attempt the upstream fetch rather than serve a cached [].
+    getMerchantCoins.mockResolvedValueOnce({ selectedCurrencies: [] });
+    getFullCurrencies.mockResolvedValueOnce({ currencies: [] });
+    expect(await getSupportedCurrencies()).toEqual([]);
+
+    // Two full attempts => the memo did not freeze in the first failure.
+    expect(getMerchantCoins).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/server/services/__tests__/system-cache.memoize.test.ts
+++ b/src/server/services/__tests__/system-cache.memoize.test.ts
@@ -3,33 +3,57 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock the redis + db layers so we can assert how often the underlying redis
 // GET actually fires for the memoized global blobs. Defined via vi.hoisted so
 // the references are available inside the hoisted vi.mock factory below.
-const { packedGet, packedSet } = vi.hoisted(() => ({
+//
+// NOTE: the wired getters use MODULE-SCOPE memos that capture `Date.now` at load
+// time, so a test can't drive their real (30s/5s) TTL expiry with fake timers.
+// TTL-EXPIRY is therefore covered deterministically (injected clock) in
+// utils/__tests__/ttl-memoize.test.ts. Here we cover the wiring: same-call
+// COLLAPSE within the TTL, per-key isolation, and FAIL-OPEN (a rejected read is
+// never cached, so the next call retries). Each test re-imports the module after
+// vi.resetModules() so it starts from a FRESH (empty) memo slate.
+const { packedGet, packedSet, redisGet, redisSet, queryRaw, tagFindMany } = vi.hoisted(() => ({
   packedGet: vi.fn(),
   packedSet: vi.fn(),
+  redisGet: vi.fn(),
+  redisSet: vi.fn(),
+  queryRaw: vi.fn(),
+  tagFindMany: vi.fn(),
 }));
 
 vi.mock('~/server/redis/client', () => ({
   redis: {
     packed: { get: packedGet, set: packedSet },
-    get: vi.fn(),
-    set: vi.fn(),
+    get: redisGet,
+    set: redisSet,
   },
   sysRedis: { get: vi.fn(), set: vi.fn() },
   withSysReadDeadline: (p: Promise<unknown>) => p,
-  REDIS_KEYS: { SYSTEM: { MODERATED_TAGS: 'system:moderated-tags' }, LIVE_NOW: 'live-now' },
+  REDIS_KEYS: {
+    SYSTEM: {
+      MODERATED_TAGS: 'system:moderated-tags',
+      TAG_RULES: 'system:tag-rules',
+      SYSTEM_TAGS: 'system:system-tags',
+      CATEGORIES: 'system:categories',
+    },
+    LIVE_NOW: 'live-now',
+  },
   REDIS_SYS_KEYS: { SYSTEM: {}, CLIENT: 'client' },
 }));
 
 vi.mock('~/server/db/client', () => ({
   dbRead: { tag: { findMany: vi.fn() }, tagsOnTags: { findMany: vi.fn() } },
-  dbWrite: { tag: { findMany: vi.fn() }, $queryRaw: vi.fn() },
+  dbWrite: { tag: { findMany: tagFindMany }, $queryRaw: queryRaw },
 }));
 
 vi.mock('~/server/redis/fail-open-log', () => ({
   logSysRedisFailOpen: vi.fn(),
 }));
 
-import { getModeratedTags } from '../system-cache';
+// Fresh module (fresh memos) per test.
+async function loadSystemCache() {
+  vi.resetModules();
+  return import('../system-cache');
+}
 
 describe('system-cache in-proc memoize', () => {
   beforeEach(() => {
@@ -37,6 +61,7 @@ describe('system-cache in-proc memoize', () => {
   });
 
   it('getModeratedTags hits redis once, then serves subsequent calls from the in-proc memo', async () => {
+    const { getModeratedTags } = await loadSystemCache();
     const blob = [{ id: 1, name: 'tag', nsfwLevel: 4 }];
     packedGet.mockResolvedValue(blob);
 
@@ -49,5 +74,67 @@ describe('system-cache in-proc memoize', () => {
     expect(third).toEqual(blob);
     // Within the in-proc TTL all three calls collapse to a single redis GET.
     expect(packedGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('getTagRules collapses repeated calls to a single redis GET within the TTL', async () => {
+    const { getTagRules } = await loadSystemCache();
+    const rules = [{ fromId: 1, toId: 2, fromTag: 'a', toTag: 'b', type: 'Replace' }];
+    redisGet.mockResolvedValue(JSON.stringify(rules));
+
+    const a = await getTagRules();
+    const b = await getTagRules();
+
+    expect(a).toEqual(rules);
+    expect(b).toEqual(rules);
+    expect(redisGet).toHaveBeenCalledTimes(1);
+    // A redis HIT must never touch the DB fallback.
+    expect(queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('getSystemTags collapses repeated calls to a single redis GET within the TTL', async () => {
+    const { getSystemTags } = await loadSystemCache();
+    const tags = [{ id: 7, name: 'image category' }];
+    redisGet.mockResolvedValue(JSON.stringify(tags));
+
+    expect(await getSystemTags()).toEqual(tags);
+    expect(await getSystemTags()).toEqual(tags);
+    expect(redisGet).toHaveBeenCalledTimes(1);
+    expect(tagFindMany).not.toHaveBeenCalled();
+  });
+
+  it('getLiveNow collapses repeated calls to a single redis GET within the TTL', async () => {
+    const { getLiveNow } = await loadSystemCache();
+    redisGet.mockResolvedValue('true');
+
+    expect(await getLiveNow()).toBe(true);
+    expect(await getLiveNow()).toBe(true);
+    expect(redisGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('getCategoryTags memoizes per type independently', async () => {
+    const { getCategoryTags } = await loadSystemCache();
+    // Redis hit path: return a JSON array so the getter never touches the DB.
+    redisGet.mockImplementation(async (key: string) =>
+      JSON.stringify([{ id: 1, name: `${key}` }])
+    );
+
+    await getCategoryTags('image');
+    await getCategoryTags('image'); // collapsed for 'image'
+    await getCategoryTags('model'); // separate slot for 'model'
+
+    // 1 GET for 'image' (second collapsed) + 1 GET for 'model' = 2 total.
+    expect(redisGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('getTagRules is fail-open: a rejected redis read is not cached and the next call retries', async () => {
+    const { getTagRules } = await loadSystemCache();
+    redisGet.mockRejectedValueOnce(new Error('redis down'));
+    await expect(getTagRules()).rejects.toThrow('redis down');
+
+    // The rejection was not memoized — the very next call re-reads redis.
+    const rules = [{ fromId: 3, toId: 4, fromTag: 'c', toTag: 'd', type: 'Append' }];
+    redisGet.mockResolvedValue(JSON.stringify(rules));
+    expect(await getTagRules()).toEqual(rules);
+    expect(redisGet).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/server/services/announcement.service.ts
+++ b/src/server/services/announcement.service.ts
@@ -9,6 +9,7 @@ import type {
 } from '~/server/schema/announcement.schema';
 import { DEFAULT_PAGE_SIZE, getPagination, getPagingData } from '~/server/utils/pagination-helpers';
 import { DomainColor } from '~/shared/utils/prisma/enums';
+import { createKeyedTtlMemo } from '~/server/utils/ttl-memoize';
 
 const domainColors = Object.values(DomainColor);
 const announcementRedisKeys = ['', ...domainColors].map((domain) =>
@@ -93,21 +94,39 @@ export async function getCurrentAnnouncements({
   });
 }
 
+// This redis read is GLOBAL per domain — the per-user (targetAudience) + active
+// time-window filter is applied by getCurrentAnnouncements AFTER this, in JS — so
+// it is safe to memoize per domain (a bounded DomainColor set). Collapses the
+// frequent redis.get + JSON.parse into ~1 read / TTL / pod. The announcement
+// caches are redis.del-invalidated on upsert/delete, so the in-proc memo adds at
+// most this TTL of per-pod propagation on top of that del; announcements are also
+// start/end-time gated downstream, so a few seconds is invisible. Keyed by
+// `domain ?? ''` (empty string = the no-domain default cache).
+const ANNOUNCEMENTS_INPROC_TTL_MS = 30_000;
+
+const getAnnouncementsCachedMemo = createKeyedTtlMemo<AnnouncementDTO[]>(
+  async (domainKey) => {
+    const domain = (domainKey || undefined) as DomainColor | undefined;
+    const cacheKey: RedisKeyTemplateCache = domain
+      ? `${REDIS_KEYS.CACHES.ANNOUNCEMENTS}:${domain as string}`
+      : REDIS_KEYS.CACHES.ANNOUNCEMENTS;
+
+    const cached = await redis.get(cacheKey);
+    if (cached) return JSON.parse(cached) as AnnouncementDTO[];
+
+    const announcements = await getAnnouncements(domain);
+
+    await redis.set(cacheKey, JSON.stringify(announcements), {
+      EX: CacheTTL.day,
+    });
+
+    return announcements;
+  },
+  ANNOUNCEMENTS_INPROC_TTL_MS
+);
+
 async function getAnnouncementsCached(domain?: DomainColor) {
-  const cacheKey: RedisKeyTemplateCache = domain
-    ? `${REDIS_KEYS.CACHES.ANNOUNCEMENTS}:${domain as string}`
-    : REDIS_KEYS.CACHES.ANNOUNCEMENTS;
-
-  const cached = await redis.get(cacheKey);
-  if (cached) return JSON.parse(cached) as AnnouncementDTO[];
-
-  const announcements = await getAnnouncements(domain);
-
-  await redis.set(cacheKey, JSON.stringify(announcements), {
-    EX: CacheTTL.day,
-  });
-
-  return announcements;
+  return getAnnouncementsCachedMemo(domain ?? '');
 }
 
 export type AnnouncementDTO = Awaited<ReturnType<typeof getAnnouncements>>[number];

--- a/src/server/services/announcement.service.ts
+++ b/src/server/services/announcement.service.ts
@@ -101,7 +101,10 @@ export async function getCurrentAnnouncements({
 // caches are redis.del-invalidated on upsert/delete, so the in-proc memo adds at
 // most this TTL of per-pod propagation on top of that del; announcements are also
 // start/end-time gated downstream, so a few seconds is invisible. Keyed by
-// `domain ?? ''` (empty string = the no-domain default cache).
+// `domain ?? ''` (empty string = the no-domain default cache). The only consumer
+// (getCurrentAnnouncements) reads it via .filter() into a new array, so it opts
+// into { freeze: true } to structurally reject a future in-place mutation of the
+// shared per-domain array.
 const ANNOUNCEMENTS_INPROC_TTL_MS = 30_000;
 
 const getAnnouncementsCachedMemo = createKeyedTtlMemo<AnnouncementDTO[]>(
@@ -122,7 +125,9 @@ const getAnnouncementsCachedMemo = createKeyedTtlMemo<AnnouncementDTO[]>(
 
     return announcements;
   },
-  ANNOUNCEMENTS_INPROC_TTL_MS
+  ANNOUNCEMENTS_INPROC_TTL_MS,
+  undefined,
+  { freeze: true }
 );
 
 async function getAnnouncementsCached(domain?: DomainColor) {

--- a/src/server/services/nowpayments.service.ts
+++ b/src/server/services/nowpayments.service.ts
@@ -16,6 +16,7 @@ import type { RedisKeyTemplateCache } from '~/server/redis/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { CacheTTL } from '~/server/common/constants';
 import { fetchThroughCache } from '~/server/utils/cache-helpers';
+import { createTtlMemo } from '~/server/utils/ttl-memoize';
 import {
   getChainConfig,
   getChainForNetworkWithFallback,
@@ -796,7 +797,21 @@ async function mapWithConcurrency<T, R>(
   return results;
 }
 
-export const getSupportedCurrencies = async (): Promise<SupportedCurrencyGroup[]> => {
+// The supported-currency list is GLOBAL (identical for every user) and changes
+// rarely — it is already redis-cached for 3h and refreshed via an admin `del` of
+// CACHE_KEY. An in-proc memo in front of it collapses the frequent
+// redis.packed.get + msgpackr decode into ~1 read / TTL / pod. TTL is longer than
+// the system-cache blobs (this list barely moves) but still bounded so an admin
+// CACHE_KEY refresh propagates within a minute per pod.
+const SUPPORTED_CURRENCIES_INPROC_TTL_MS = 60_000;
+
+// Sentinel so the public getter can distinguish "upstream NowPayments returned no
+// data" (→ fail open to []) from a real infra error (→ propagate). Thrown instead
+// of returning [] so createTtlMemo does NOT memoize the empty fallback — the next
+// call retries the upstream fetch immediately, preserving the original semantics.
+class NowPaymentsCurrencyUnavailableError extends Error {}
+
+const getSupportedCurrenciesMemo = createTtlMemo<SupportedCurrencyGroup[]>(async () => {
   // Check cache first
   const cached = await redis.packed.get<SupportedCurrencyGroup[]>(CACHE_KEY);
   if (cached) return cached;
@@ -812,7 +827,7 @@ export const getSupportedCurrencies = async (): Promise<SupportedCurrencyGroup[]
       hasMerchantCoins: !!merchantCoins,
       hasFullCurrencies: !!fullCurrencies,
     });
-    return [];
+    throw new NowPaymentsCurrencyUnavailableError('Failed to fetch currency data from NowPayments');
   }
 
   const selectedCodes = new Set(merchantCoins.selectedCurrencies.map((c) => c.toLowerCase()));
@@ -870,6 +885,17 @@ export const getSupportedCurrencies = async (): Promise<SupportedCurrencyGroup[]
   await redis.packed.set(CACHE_KEY, result, { EX: CacheTTL.hour * 3 });
 
   return result;
+}, SUPPORTED_CURRENCIES_INPROC_TTL_MS);
+
+export const getSupportedCurrencies = async (): Promise<SupportedCurrencyGroup[]> => {
+  try {
+    return await getSupportedCurrenciesMemo();
+  } catch (e) {
+    // Preserve the original fail-open: an upstream NowPayments miss yields [];
+    // any other (infra) error propagates unchanged — and neither is memoized.
+    if (e instanceof NowPaymentsCurrencyUnavailableError) return [];
+    throw e;
+  }
 };
 
 /**

--- a/src/server/services/nowpayments.service.ts
+++ b/src/server/services/nowpayments.service.ts
@@ -802,7 +802,10 @@ async function mapWithConcurrency<T, R>(
 // CACHE_KEY. An in-proc memo in front of it collapses the frequent
 // redis.packed.get + msgpackr decode into ~1 read / TTL / pod. TTL is longer than
 // the system-cache blobs (this list barely moves) but still bounded so an admin
-// CACHE_KEY refresh propagates within a minute per pod.
+// CACHE_KEY refresh propagates within a minute per pod. The result is served
+// straight to serialization (no mutation — verified), so it opts into
+// { freeze: true } to structurally reject a future in-place mutation of the
+// shared array.
 const SUPPORTED_CURRENCIES_INPROC_TTL_MS = 60_000;
 
 // Sentinel so the public getter can distinguish "upstream NowPayments returned no
@@ -885,7 +888,7 @@ const getSupportedCurrenciesMemo = createTtlMemo<SupportedCurrencyGroup[]>(async
   await redis.packed.set(CACHE_KEY, result, { EX: CacheTTL.hour * 3 });
 
   return result;
-}, SUPPORTED_CURRENCIES_INPROC_TTL_MS);
+}, SUPPORTED_CURRENCIES_INPROC_TTL_MS, undefined, { freeze: true });
 
 export const getSupportedCurrencies = async (): Promise<SupportedCurrencyGroup[]> => {
   try {

--- a/src/server/services/system-cache.ts
+++ b/src/server/services/system-cache.ts
@@ -11,7 +11,7 @@ import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import type { FeatureFlagKey } from '~/server/services/feature-flags.service';
 import type { TagsOnTagsType } from '~/shared/utils/prisma/enums';
 import { TagType } from '~/shared/utils/prisma/enums';
-import { createTtlMemo } from '~/server/utils/ttl-memoize';
+import { createKeyedTtlMemo, createTtlMemo } from '~/server/utils/ttl-memoize';
 import { indexOfOr } from '~/utils/array-helpers';
 import { createLogger } from '~/utils/logging';
 import { isDefined } from '~/utils/type-guards';
@@ -58,6 +58,27 @@ const SYSTEM_CACHE_INPROC_TTL_MS = 30_000;
 // CLIENT_CONFIG_TTL_MS — to keep flag-flip propagation fast (<=5s/pod) while still
 // collapsing the per-call sysRedis GET on the generation/feature-flag hot path.
 const LIVE_FLAGS_INPROC_TTL_MS = 5_000;
+
+// getLiveNow is a global boolean (`live-now` redis key, flipped by the twitch
+// stream.online/offline webhook via setLiveNow). It is read on a high-frequency
+// hot path (system.getLiveNow) but only changes when a stream goes on/offline,
+// and the client itself polls it every ~5 min — so a 5s in-proc TTL per pod
+// collapses the per-call redis GET while keeping on/offline flips visible
+// within ~5s.
+const LIVE_NOW_INPROC_TTL_MS = 5_000;
+
+// getTagRules / getSystemTags / getCategoryTags are GLOBAL, user-independent
+// config blobs on the same 4h-redis (SYSTEM_CACHE_EXPIRY) as the moderated-tags
+// family above, so they reuse the same short in-proc TTL. Unlike that family,
+// TAG_RULES + CATEGORIES:<type> ARE opportunistically redis.del-invalidated by
+// tag mutations (tag.service.ts add/removeTagsOnTags) — so the in-proc memo adds
+// at most SYSTEM_CACHE_INPROC_TTL_MS of PER-POD propagation delay on top of that
+// del, after which the pod re-reads redis. Their consumers are backend scan /
+// tag-application paths (image-scan webhooks, the apply-tag-rules job, tag
+// listing) that already tolerate the 4h eventual staleness, so an extra ~30s is
+// invisible. All current consumers use the returned arrays read-only
+// (.map/.filter/.find/.some/.slice — verified), so they opt into { freeze: true }
+// to structurally reject an accidental in-place mutation of the shared blob.
 
 export type SystemModerationTag = {
   id: number;
@@ -117,47 +138,65 @@ export type TagRule = {
   type: TagsOnTagsType;
   createdAt: Date;
 };
+const getTagRulesMemo = createTtlMemo<TagRule[]>(
+  async () => {
+    const cached = await redis.get(REDIS_KEYS.SYSTEM.TAG_RULES);
+    if (cached) return JSON.parse(cached) as TagRule[];
+
+    log('getting tag rules');
+    const rules = await dbWrite.$queryRaw<TagRule[]>`
+      SELECT
+        "fromTagId" as "fromId",
+        "toTagId" as "toId",
+        f."name" as "fromTag",
+        t."name" as "toTag",
+        tot.type,
+        tot."createdAt"
+      FROM "TagsOnTags" tot
+      JOIN "Tag" f ON f."id" = tot."fromTagId"
+      JOIN "Tag" t ON t."id" = tot."toTagId"
+      WHERE tot.type IN ('Replace', 'Append')
+    `;
+    await redis.set(REDIS_KEYS.SYSTEM.TAG_RULES, JSON.stringify(rules), {
+      EX: SYSTEM_CACHE_EXPIRY,
+    });
+
+    log('got tag rules');
+    return rules;
+  },
+  SYSTEM_CACHE_INPROC_TTL_MS,
+  undefined,
+  { freeze: true }
+);
+
 export async function getTagRules() {
-  const cached = await redis.get(REDIS_KEYS.SYSTEM.TAG_RULES);
-  if (cached) return JSON.parse(cached) as TagRule[];
-
-  log('getting tag rules');
-  const rules = await dbWrite.$queryRaw<TagRule[]>`
-    SELECT
-      "fromTagId" as "fromId",
-      "toTagId" as "toId",
-      f."name" as "fromTag",
-      t."name" as "toTag",
-      tot.type,
-      tot."createdAt"
-    FROM "TagsOnTags" tot
-    JOIN "Tag" f ON f."id" = tot."fromTagId"
-    JOIN "Tag" t ON t."id" = tot."toTagId"
-    WHERE tot.type IN ('Replace', 'Append')
-  `;
-  await redis.set(REDIS_KEYS.SYSTEM.TAG_RULES, JSON.stringify(rules), {
-    EX: SYSTEM_CACHE_EXPIRY,
-  });
-
-  log('got tag rules');
-  return rules;
+  return getTagRulesMemo();
 }
 
+const getSystemTagsMemo = createTtlMemo<{ id: number; name: string }[]>(
+  async () => {
+    const cachedTags = await redis.get(REDIS_KEYS.SYSTEM.SYSTEM_TAGS);
+    if (cachedTags) return JSON.parse(cachedTags) as { id: number; name: string }[];
+
+    log('getting system tags');
+    const tags = await dbWrite.tag.findMany({
+      where: { type: TagType.System },
+      select: { id: true, name: true },
+    });
+    await redis.set(REDIS_KEYS.SYSTEM.SYSTEM_TAGS, JSON.stringify(tags), {
+      EX: SYSTEM_CACHE_EXPIRY,
+    });
+
+    log('got system tags');
+    return tags;
+  },
+  SYSTEM_CACHE_INPROC_TTL_MS,
+  undefined,
+  { freeze: true }
+);
+
 export async function getSystemTags() {
-  const cachedTags = await redis.get(REDIS_KEYS.SYSTEM.SYSTEM_TAGS);
-  if (cachedTags) return JSON.parse(cachedTags) as { id: number; name: string }[];
-
-  log('getting system tags');
-  const tags = await dbWrite.tag.findMany({
-    where: { type: TagType.System },
-    select: { id: true, name: true },
-  });
-  await redis.set(REDIS_KEYS.SYSTEM.SYSTEM_TAGS, JSON.stringify(tags), {
-    EX: SYSTEM_CACHE_EXPIRY,
-  });
-
-  log('got system tags');
-  return tags;
+  return getSystemTagsMemo();
 }
 
 export async function getReplacedTagIds(): Promise<number[]> {
@@ -219,32 +258,48 @@ const colorPriority = [
   'grey',
 ];
 
-export async function getCategoryTags(type: 'image' | 'model' | 'post' | 'article' | 'model3d') {
-  let categories: TypeCategory[] | undefined;
-  const categoriesCache = await redis.get(`${REDIS_KEYS.SYSTEM.CATEGORIES}:${type}`);
-  if (categoriesCache) categories = JSON.parse(categoriesCache);
+export type CategoryTagType = 'image' | 'model' | 'post' | 'article' | 'model3d';
 
-  if (!categories) {
-    const systemTags = await getSystemTags();
-    const categoryTag = systemTags.find((t) => t.name === `${type} category`);
-    if (!categoryTag) throw new Error(`${type} category tag not found`);
-    const categoriesRaw = await dbWrite.tag.findMany({
-      where: { fromTags: { some: { fromTagId: categoryTag.id } } },
-      select: { id: true, name: true, color: true, adminOnly: true },
-    });
-    categories = categoriesRaw
-      .map((c) => ({
-        id: c.id,
-        name: c.name,
-        adminOnly: c.adminOnly,
-        priority: indexOfOr(colorPriority, c.color ?? 'grey', colorPriority.length),
-      }))
-      .sort((a, b) => a.priority - b.priority);
-    if (categories.length)
-      await redis.set(`${REDIS_KEYS.SYSTEM.CATEGORIES}:${type}`, JSON.stringify(categories));
-  }
+// Keyed per category `type` (a fixed 5-value union — bounded, non-user). Each
+// type's value is global; the memo collapses the per-call redis GET + JSON.parse
+// into ~1 read / TTL / pod. CATEGORIES:<type> is redis.del-invalidated by tag
+// mutations (see the block comment above), so the memo adds at most
+// SYSTEM_CACHE_INPROC_TTL_MS of per-pod propagation delay after such a del.
+const getCategoryTagsMemo = createKeyedTtlMemo<TypeCategory[]>(
+  async (type) => {
+    let categories: TypeCategory[] | undefined;
+    const categoriesCache = await redis.get(`${REDIS_KEYS.SYSTEM.CATEGORIES}:${type}`);
+    if (categoriesCache) categories = JSON.parse(categoriesCache);
 
-  return categories;
+    if (!categories) {
+      const systemTags = await getSystemTags();
+      const categoryTag = systemTags.find((t) => t.name === `${type} category`);
+      if (!categoryTag) throw new Error(`${type} category tag not found`);
+      const categoriesRaw = await dbWrite.tag.findMany({
+        where: { fromTags: { some: { fromTagId: categoryTag.id } } },
+        select: { id: true, name: true, color: true, adminOnly: true },
+      });
+      categories = categoriesRaw
+        .map((c) => ({
+          id: c.id,
+          name: c.name,
+          adminOnly: c.adminOnly,
+          priority: indexOfOr(colorPriority, c.color ?? 'grey', colorPriority.length),
+        }))
+        .sort((a, b) => a.priority - b.priority);
+      if (categories.length)
+        await redis.set(`${REDIS_KEYS.SYSTEM.CATEGORIES}:${type}`, JSON.stringify(categories));
+    }
+
+    return categories;
+  },
+  SYSTEM_CACHE_INPROC_TTL_MS,
+  undefined,
+  { freeze: true }
+);
+
+export async function getCategoryTags(type: CategoryTagType) {
+  return getCategoryTagsMemo(type);
 }
 
 // export async function getTagsNeedingReview() {
@@ -331,9 +386,13 @@ export async function setLiveNow(isLive: boolean) {
   await redis.set(REDIS_KEYS.LIVE_NOW, isLive ? 'true' : 'false');
 }
 
-export async function getLiveNow() {
+const getLiveNowMemo = createTtlMemo<boolean>(async () => {
   const cachedLiveNow = await redis.get(REDIS_KEYS.LIVE_NOW);
   return cachedLiveNow === 'true';
+}, LIVE_NOW_INPROC_TTL_MS);
+
+export async function getLiveNow() {
+  return getLiveNowMemo();
 }
 
 // In-proc memo over the RAW sysRedis string only — the try/catch + JSON.parse

--- a/src/server/utils/__tests__/ttl-memoize.test.ts
+++ b/src/server/utils/__tests__/ttl-memoize.test.ts
@@ -209,4 +209,15 @@ describe('createKeyedTtlMemo', () => {
     expect(await memo('all')).toBe('all-3');
     expect(await memo('red')).toBe('red-2');
   });
+
+  it('freeze option is applied per key', async () => {
+    const clock = makeClock();
+    const memo = createKeyedTtlMemo<{ id: number }[]>(async () => [{ id: 1 }], 30_000, clock.now, {
+      freeze: true,
+    });
+
+    const arr = await memo('a');
+    expect(Object.isFrozen(arr)).toBe(true);
+    expect(() => arr.push({ id: 2 })).toThrow();
+  });
 });

--- a/src/server/utils/ttl-memoize.ts
+++ b/src/server/utils/ttl-memoize.ts
@@ -61,9 +61,10 @@ export function createTtlMemo<T>(
 
 // Keyed variant of createTtlMemo for a GLOBAL-per-key async fetcher — i.e. a
 // fetcher whose result depends ONLY on a small, bounded key (not on the
-// user/session), e.g. the per-domain "latest bug/changelog" timestamp. Each
-// distinct key gets its own independent single-slot TTL memo (same fail-open
-// semantics: only a resolved value is cached, a rejection propagates uncached).
+// user/session), e.g. the per-domain "latest bug/changelog" timestamp, a
+// category `type`, or a `DomainColor`. Each distinct key gets its own
+// independent single-slot TTL memo (same fail-open semantics: only a resolved
+// value is cached, a rejection propagates uncached).
 //
 // 🔴 The key space MUST be bounded (an enum, a domain list, …). This holds one
 // slot per distinct key forever, so a per-user / unbounded key would both leak


### PR DESCRIPTION
## What

Several tRPC reads return a value that is **identical for every user/request** and changes infrequently, yet re-fetch it from redis (`GET` + `JSON.parse`/msgpackr decode) on **every** call. This clones the already-shipped in-process TTL-memo pattern (`createTtlMemo`, as used by the `getModeratedTags` system-cache family) in front of those global reads, so repeated calls collapse to **~1 backing read per TTL per pod**.

## Memoized calls

| call | TTL | notes |
|---|---|---|
| `system-cache.getTagRules` | 30s | `redis.del`-invalidated by tag mutations (see below); backend-only |
| `system-cache.getSystemTags` | 30s | not del-invalidated |
| `system-cache.getCategoryTags(type)` | 30s | **keyed per category type** (`del`-invalidated per type) |
| `system-cache.getLiveNow` | 5s | global bool; client polls every ~5 min |
| `nowpayments.getSupportedCurrencies` | 60s | **success only** — an upstream-miss `[]` is not cached |
| `announcement` (`getAnnouncementsCached`) | 30s | **keyed per domain**; the per-user `targetAudience` + active-window filter stays **outside** the memo |

All memoized arrays use `{ freeze: true }` (all current consumers verified read-only) so an accidental future in-place mutation of the shared per-TTL array throws instead of silently corrupting it.

Adds `createKeyedTtlMemo` — a thin per-key fan-out over `createTtlMemo` (one independent single-slot memo per bounded, non-user key) for the type/domain-keyed cases.

## Behaviour: no normal-user change; a brief ≤30s mod/admin-facing flicker

This is **not** "zero behaviour change" — honest characterization:

- **No normal-end-user behaviour change.** All 6 memoized values already sit behind a longer client `staleTime` (~5 min), a longer redis TTL (3h/4h), an SSR seed, or are backend-only. 4 of the 6 are fully masked from any user-visible effect: `getTagRules`, `getSystemTags`, `getLiveNow`, `getSupportedCurrencies`.
- **What the per-pod in-proc memo does add** (upfront): each pod serves a value for ≤TTL then re-reads, with no background refresh — so within the TTL window, different pods can briefly serve different values (cross-pod inconsistency) after a change.
- **Two observable-but-negligible cases, both mod/admin-triggered:**
  - **Announcements** (`getCurrentAnnouncements`, 30s): right after a mod posts/edits/deletes an announcement, a refreshing user can see the banner appear-then-settle across pods for up to 30s. The mod's own management page (`getAnnouncementsPaged`, `moderatorProcedure`) is **not** memoized → reflects immediately. The per-user `targetAudience` + active-window (`startsAt ≤ now ≤ endsAt`) filter runs live per-request **outside** the memo, so no user is ever shown a wrong-audience or expired announcement — only new-announcement *appearance* is delayed ≤30s.
  - **Category tags** (`getCategoryTags`, 30s): after a mod edits a category, the browse category list can flip-flop for ≤30s.
- **Precedent:** this per-pod-TTL-staleness + brief cross-pod flicker is the exact behaviour of the already-shipped-in-prod `getModeratedTags` / `getClientConfigCached` in-proc memos this PR clones — it extends an accepted pattern, not a new standard.

### tag-rules / category del-invalidation

For the two `redis.del`-invalidated keys (`TAG_RULES`, `CATEGORIES:<type>`), a mod change previously propagated on the next call after the `del`; now a pod already holding the value serves it stale for up to the 30s TTL before re-reading. `TAG_RULES` is backend-only (no live request blocking), and the every-5-min `apply-tag-rules` batch job retroactively reconciles any image that missed a new rule during that window — so nothing is permanently mis-tagged. `CATEGORIES:<type>` staleness is the ≤30s browse-list flicker described above.

## Why it's safe

- **Global, verified.** Every memoized value is the same for all users. The announcement per-user filtering is applied in JS *after* the (global, per-domain) redis read, so only the global read is memoized.
- **Fail-open.** `createTtlMemo` only caches a *resolved* value — a rejected fetch propagates unchanged and is never cached, so a transient redis/upstream failure is never frozen in and the next call retries. `getSupportedCurrencies` throws on an upstream miss so its `[]` fallback isn't memoized (external `return []` behaviour preserved).
- **Per-pod, in-process.** Module-scope is fine because the values are global (not per-request). Returned arrays are `Object.freeze`d (all consumers verified read-only).
- **Off-switch:** revert the wrapper for any individual call.

### Excluded

`getSystemPermissions` — although global, on `main` its only callers are the two **read-modify-write** mutation helpers (`addSystemPermission` / `removeSystemPermission`); a memo there would risk a stale-read→overwrite and there is no hot read path to save, so it was intentionally left un-memoized.

## Tests

- `ttl-memoize.test.ts`: adds full `createKeyedTtlMemo` coverage (per-key hit/miss, independent TTL-expiry, fail-open, `clear(key)`/`clear()`, per-key freeze) alongside the existing `createTtlMemo` suite.
- Per-service wired tests (`system-cache`, `nowpayments`, `announcement`) assert call-collapsing within the TTL, per-key isolation, and fail-open (each re-imports the module for a fresh memo slate). TTL-expiry is proven deterministically at the utility level (the module-scope memos capture `Date.now` at load, so real-timer expiry isn't drivable in the wired tests — same reason the existing wired test only checks collapsing).
- 24 tests green.
