### PR TITLE
perf(image.getInfinite): strip 5 unread fields from the feed wire response

### DIFF
--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -2522,7 +2522,14 @@ export const getAllImagesIndex = async (
 
   return {
     nextCursor,
-    items: mergedData,
+    // Always-on wire trim on the DOMINANT tRPC Meili/BitDex feed path: the item
+    // literal above emits `scannedAt`/`mimeType`/`postTitle` as explicit `null`
+    // props (plus any of IMAGE_INFINITE_DROPPED_FIELDS carried on `...sr`), which
+    // still SERIALIZE even though the return type is narrowed to `Omit<...>` (a
+    // `const` object literal → no excess-property check strips them). Map through
+    // `stripImageForInfiniteWire` so they are actually removed from the payload,
+    // matching the DB `getAllImages` path. See `~/server/utils/image-infinite-wire.ts`.
+    items: mergedData.map(stripImageForInfiniteWire),
     ...(searchSource && { source: searchSource }),
   };
 };

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -69,6 +69,7 @@ import {
   registerCounterWithLabels,
 } from '~/server/prom/client';
 import { imageOnSiteSql, isImageMetaOnSite } from '~/server/utils/image-onsite';
+import { stripImageForInfiniteWire } from '~/server/utils/image-infinite-wire';
 import {
   getBaseModelFromResources,
   getUserFollows,
@@ -1210,6 +1211,11 @@ type GetAllImagesInput = GetInfiniteImagesOutput & {
   // correlation. Built upstream via buildSearchActor().
   actor?: string;
 };
+// Derived from `getAllImages`' return type, which applies `stripImageForInfiniteWire`
+// to each item — so this shape is already narrowed to
+// `Omit<..., IMAGE_INFINITE_DROPPED_FIELDS>`. Any consumer that reads a dropped field
+// (client component or internal server caller) is a compile error. See
+// `~/server/utils/image-infinite-wire.ts`.
 export type ImagesInfiniteModel = AsyncReturnType<typeof getAllImages>['items'][0];
 
 // Per-call ceiling for the image-feed raw query. The `civitai` postgres role
@@ -2172,7 +2178,11 @@ export const getAllImages = async (
 
   return {
     nextCursor,
-    items: images,
+    // Always-on wire trim: drop the grep-proven-unread fields no `image.getInfinite`
+    // consumer reads. Narrows `ImagesInfiniteModel` (defined from this return type) to
+    // `Omit<..., IMAGE_INFINITE_DROPPED_FIELDS>`, so tsc/`next build` flags any reader.
+    // See `~/server/utils/image-infinite-wire.ts` for the traced consumer graph.
+    items: images.map(stripImageForInfiniteWire),
   };
 };
 
@@ -3017,7 +3027,10 @@ export async function getImagesFromFeedSearch(
 
     return {
       nextCursor: feedResult.nextCursor,
-      items: transformedItems,
+      // Mirror the DB path's wire trim so both `image.getInfinite` backends ship the
+      // identical narrowed shape (drops any of IMAGE_INFINITE_DROPPED_FIELDS still
+      // carried on the ImageDocument rest).
+      items: transformedItems.map(stripImageForInfiniteWire),
     };
   } catch (err) {
     console.error('Error in getImagesFromFeedSearch:', err);

--- a/src/server/utils/__tests__/image-infinite-wire.test.ts
+++ b/src/server/utils/__tests__/image-infinite-wire.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import {
+  IMAGE_INFINITE_DROPPED_FIELDS,
+  stripImageForInfiniteWire,
+} from '~/server/utils/image-infinite-wire';
+
+// `image.getInfinite` (the /images feed) is the #1 procedure by server time; its
+// response is serialized synchronously with superjson on the event loop. This test
+// pins the wire contract of the always-on field trim: the exact dropped set, the
+// load-bearing retentions (fields that LOOK droppable but have a real consumer), and
+// non-mutation. Type-level proof that no consumer reads a dropped field lives in the
+// `next build` typecheck (the `ImagesInfiniteModel` narrowing), not here.
+
+// A representative per-image object carrying every field the DB path (`getAllImages`)
+// emits on the wire today (raw SQL SELECT + the item mapping).
+const makeImage = () => ({
+  // --- retained: rendered by the feed card / read by the seeded detail modal ---
+  id: 123,
+  url: 'abc.jpeg',
+  name: 'a render',
+  nsfwLevel: 1,
+  width: 832,
+  height: 1216,
+  hash: 'UBFO~q00',
+  hasMeta: true,
+  hasPositivePrompt: true,
+  onSite: false,
+  remixOfId: null,
+  type: 'image',
+  metadata: { width: 832, height: 1216 },
+  ingestion: 'Scanned',
+  blockedFor: null,
+  needsReview: null,
+  postId: 8000,
+  modelVersionId: 1500,
+  minor: false,
+  poi: false,
+  model3dId: null,
+  modelVersionIds: [1500],
+  modelVersionIdsManual: [],
+  publishedAt: new Date('2026-07-01T00:00:00.000Z'),
+  collectionItemStatus: null,
+  user: {
+    id: 500,
+    username: 'creator',
+    image: null,
+    deletedAt: null,
+    cosmetics: [],
+    profilePicture: null,
+  },
+  stats: { likeCountAllTime: 1, dislikeCountAllTime: 0 },
+  reactions: [],
+  cosmetic: null,
+  thumbnailUrl: undefined,
+  judgeScore: null,
+  // --- retained: hidden-prefs `images` filter iterates it (biggest field) ---
+  tagIds: [1, 2, 3, 4, 5],
+  // --- retained: read by the seeded ImageDetail2 modal (card never reads them) ---
+  createdAt: new Date('2026-07-01T00:00:00.000Z'),
+  sortAt: new Date('2026-07-01T00:00:00.000Z'),
+  // --- retained: typecheck found real readers (index: as-posts Newest sort;
+  //     availability: BidModelButton) — kept, not forced out ---
+  index: 0,
+  availability: 'Public',
+  // --- dropped: proven-unread across the whole ImagesInfiniteModel consumer graph ---
+  scannedAt: new Date('2026-07-01T00:00:00.000Z'),
+  mimeType: 'image/jpeg',
+  postTitle: 'my post',
+  hideMeta: false,
+  acceptableMinor: false,
+});
+
+describe('image-infinite-wire', () => {
+  describe('stripImageForInfiniteWire', () => {
+    it('drops exactly the declared unread fields', () => {
+      const out = stripImageForInfiniteWire(makeImage());
+      for (const field of IMAGE_INFINITE_DROPPED_FIELDS) {
+        expect(out).not.toHaveProperty(field);
+      }
+      // exactly these 7 and no others were removed
+      const removed = Object.keys(makeImage()).filter((k) => !(k in out));
+      expect(removed.sort()).toEqual([...IMAGE_INFINITE_DROPPED_FIELDS].sort());
+    });
+
+    it('keeps every field a consumer reads (card, hidden-prefs, seeded modal, OG)', () => {
+      const out = stripImageForInfiniteWire(makeImage());
+      for (const field of [
+        'id',
+        'url',
+        'name',
+        'nsfwLevel',
+        'width',
+        'height',
+        'hash',
+        'hasMeta',
+        'hasPositivePrompt',
+        'onSite',
+        'remixOfId',
+        'type',
+        'metadata',
+        'ingestion',
+        'blockedFor',
+        'needsReview',
+        'postId',
+        'modelVersionId',
+        'minor',
+        'poi',
+        'model3dId',
+        'modelVersionIds',
+        'modelVersionIdsManual',
+        'publishedAt',
+        'collectionItemStatus',
+        'user',
+        'stats',
+        'reactions',
+        'cosmetic',
+        'thumbnailUrl',
+        'judgeScore',
+      ]) {
+        expect(out).toHaveProperty(field);
+      }
+      // 🔴 the load-bearing retentions: look droppable but ARE read (out of scope)
+      expect(out).toHaveProperty('tagIds'); // client hidden-prefs filter
+      expect((out as { tagIds: number[] }).tagIds).toEqual([1, 2, 3, 4, 5]);
+      for (const field of ['createdAt', 'sortAt']) {
+        expect(out).toHaveProperty(field); // read by the seeded ImageDetail2 modal (LAZY)
+      }
+      // 🔴 kept because the typecheck found real readers (not drop-safe after all)
+      expect(out).toHaveProperty('index'); // as-posts ImageSort.Newest sort
+      expect(out).toHaveProperty('availability'); // BidModelButton
+      expect((out as { stats: Record<string, number> }).stats).toEqual({
+        likeCountAllTime: 1,
+        dislikeCountAllTime: 0,
+      });
+    });
+
+    it('does NOT mutate the source object', () => {
+      const source = makeImage();
+      const before = JSON.stringify(source);
+      const out = stripImageForInfiniteWire(source);
+      expect(JSON.stringify(source)).toBe(before);
+      expect(source).toHaveProperty('scannedAt');
+      expect(out).not.toBe(source);
+    });
+
+    it('is a no-op for keys absent on the object (DB/Meili union safety)', () => {
+      const out = stripImageForInfiniteWire({ id: 1, url: 'x', tagIds: [9] });
+      expect(out).toEqual({ id: 1, url: 'x', tagIds: [9] });
+    });
+  });
+});

--- a/src/server/utils/__tests__/image-infinite-wire.test.ts
+++ b/src/server/utils/__tests__/image-infinite-wire.test.ts
@@ -147,5 +147,28 @@ describe('image-infinite-wire', () => {
       const out = stripImageForInfiniteWire({ id: 1, url: 'x', tagIds: [9] });
       expect(out).toEqual({ id: 1, url: 'x', tagIds: [9] });
     });
+
+    it('removes the keys even when present as explicit null (the getAllImagesIndex shape)', () => {
+      // The Meili/BitDex tRPC path (`getAllImagesIndex`) builds each item as an
+      // object literal that sets `scannedAt`/`mimeType`/`postTitle` to `null`
+      // explicitly. Those props SERIALIZE unless removed. Assert the strip deletes
+      // the KEYS (not merely nulls them) so they leave the wire entirely.
+      const indexShaped = {
+        id: 7,
+        url: 'y.jpeg',
+        availability: 'Public', // kept (BidModelButton reads it)
+        index: 3, // kept (as-posts Newest sort reads it)
+        scannedAt: null,
+        mimeType: null,
+        postTitle: null,
+        hideMeta: false,
+        acceptableMinor: false,
+      };
+      const out = stripImageForInfiniteWire(indexShaped);
+      for (const field of IMAGE_INFINITE_DROPPED_FIELDS) {
+        expect(out).not.toHaveProperty(field); // key gone, not just null
+      }
+      expect(out).toEqual({ id: 7, url: 'y.jpeg', availability: 'Public', index: 3 });
+    });
   });
 });

--- a/src/server/utils/image-infinite-wire.ts
+++ b/src/server/utils/image-infinite-wire.ts
@@ -1,0 +1,82 @@
+/**
+ * Wire-shape trimming for `image.getInfinite` (the /images feed).
+ *
+ * `image.getInfinite` is a `heavyProcedure` and the #1 procedure by server time.
+ * Its response is serialized SYNCHRONOUSLY with superjson on the Node event loop —
+ * walking every field of every image (a page can carry ~100 images). Both server
+ * paths that back it — the DB path (`getAllImages`) and the Meili/BitDex path
+ * (`getAllImagesIndex`) — return the SAME `ImagesInfiniteModel` per-item shape.
+ * Cutting per-image fields that no consumer reads reduces both the byte size on
+ * the wire (~5–7% / ~11–14 KB per page) and the serialize walk (dropping the
+ * `scannedAt` Date removes one superjson Date node per image).
+ *
+ * The dropped fields below were confirmed unread across the ENTIRE consumer graph
+ * of `image.getInfinite`'s result:
+ *  - the feed card (`ImagesCard` / `Cards/ImageCard`) + its context menu,
+ *  - the hidden-preferences `images` filter (`useApplyHiddenPreferences`),
+ *  - the masonry grid + OG/SSR structured-data path,
+ *  - AND the image-detail modal seeded from the card (`ImageDetail2`), which reads
+ *    the SEEDED image objects directly (no refetch when the seed contains the
+ *    clicked id — `ImageDetailProvider` uses `initialImages` as-is), so its
+ *    read-set is load-bearing here and was traced explicitly.
+ *
+ * The correctness of "these are unread" is enforced by the compiler, not asserted:
+ * because `ImagesInfiniteModel` is defined from `getAllImages`' return type and the
+ * strip narrows that return to `Omit<..., IMAGE_INFINITE_DROPPED_FIELDS>`, ANY
+ * consumer (client component or internal server caller) that reads a dropped field
+ * becomes a `next build` type error. `image.getInfinite` OWNS this type (it is the
+ * type's origin), so — unlike the sibling as-posts trim, where the same unread
+ * fields had to be RETAINED because dropping them loosened a FOREIGN modal-seed
+ * type — here they are droppable.
+ *
+ * 🔴 KEPT deliberately (do NOT add these to the drop list) — they LOOK trimmable but
+ * have a non-obvious reader, so they are out of scope for this DROP-SAFE trim:
+ *  - `tagIds`  — the client hidden-preferences filter iterates it to drop
+ *    viewer-hidden images (`useApplyHiddenPreferences`). Largest per-image field;
+ *    dropping it breaks hidden-tag moderation for every viewer.
+ *  - `createdAt` / `sortAt` — read by the seeded `ImageDetail2` modal (OG structured
+ *    data + uploaded-date fallback) even though the card never reads them. LAZY, not
+ *    drop-safe.
+ *  - `stats.*` / `modelVersionId` / `modelVersionIds` — RISKY (same procedure serves
+ *    the model-gallery variant with different includes; `modelVersionIds` is read
+ *    there). Left untouched.
+ *  - `index` / `availability` — were in the original scoping's drop set, but the
+ *    typecheck surfaced real readers (`index`: the as-posts `ImageSort.Newest` sort;
+ *    `availability`: `BidModelButton`), so they were kept rather than forced out.
+ *    This is the `Omit`-narrowing safety net working as designed.
+ *
+ * Note `hideMeta` is only dropped from the WIRE — the server still derives `hasMeta`
+ * from it in SQL, and `hasMeta` (which consumers DO read) is unaffected.
+ */
+
+// The per-image keys dropped from the `image.getInfinite` wire. Exported so the
+// unit test can assert the strip drops EXACTLY this set (keeps the destructuring
+// below in sync). Every field is present on the wire today (raw SQL `SELECT` in
+// `getAllImages`) and proven-unread across the ENTIRE `ImagesInfiniteModel`
+// consumer graph BY THE COMPILER: narrowing the shared type surfaces any reader as
+// a `next build` error.
+//
+// 🔴 `index` and `availability` were in the original scoping's drop set but the
+// typecheck found real readers, so they are KEPT (not forced out):
+//  - `availability` — read by `BidModelButton` (`image.availability ?? Public`),
+//  - `index`        — read by the as-posts handler's `ImageSort.Newest` sort
+//                     (`images.sort((a, b) => (a.index ?? 0) - (b.index ?? 0))`),
+//                     which shares this type via `getAllImages`.
+export const IMAGE_INFINITE_DROPPED_FIELDS = [
+  'scannedAt',
+  'mimeType',
+  'postTitle',
+  'hideMeta',
+  'acceptableMinor',
+] as const;
+
+/**
+ * Return a shallow copy of `image` without the wire-dropped fields. Generic so it
+ * is type-safe across the DB/Meili result union (a key absent on one side is a
+ * no-op), and the narrowed `Omit<...>` return type makes tsc flag any future
+ * consumer that starts reading a dropped field. Does not mutate the input.
+ */
+export const stripImageForInfiniteWire = <T extends Record<string, unknown>>(image: T) => {
+  const { scannedAt, mimeType, postTitle, hideMeta, acceptableMinor, ...rest } = image;
+  return rest;
+};


### PR DESCRIPTION
## What

`image.getInfinite` (the `/images` feed) is the highest server-time tRPC procedure, and its busiest cost is writing the response + serializing it **synchronously with superjson** on the event loop — walking every field of every image (a page carries ~100 images). This drops **5 per-image fields that no consumer of the feed reads** from the wire response:

```
scannedAt, mimeType, postTitle, hideMeta, acceptableMinor
```

Estimated **~4–6% smaller payload (~10–13 KB per 100-image page)** plus a small serialize-CPU win (dropping the `scannedAt` `Date` removes one superjson Date node per image on the DB path). It also shaves egress on the busiest image endpoint.

## How — the `Omit`-narrowing is the safety proof, not an assertion

A new always-on `stripImageForInfiniteWire` helper (`src/server/utils/image-infinite-wire.ts`, mirroring the sibling `stripImageForAsPostsWire` idiom) is applied at the return of **all three** functions that produce `ImagesInfiniteModel` items:

| Function | Path | Serves |
|---|---|---|
| `getAllImages` | DB | tRPC `image.getInfinite` (DB path) + REST fallback + as-posts |
| `getAllImagesIndex` | Meili/BitDex | **tRPC `image.getInfinite` — the dominant production feed path** (`image.controller.ts:331`) |
| `getImagesFromFeedSearch` | REST-only | `runImageSearch` / `/api/v1/images` search |

Because `ImagesInfiniteModel` is **derived from `getAllImages`' return type**, stripping there **narrows the shared type** to `Omit<..., IMAGE_INFINITE_DROPPED_FIELDS>`, so **any consumer — client component or internal server caller — that reads a dropped field becomes a `next build` type error**. "These fields are unused" is *enforced by the compiler*, not claimed.

### Why `getAllImagesIndex` needed an explicit runtime strip (not just the type narrowing)

`getAllImagesIndex` is already return-typed `Promise<AsyncReturnType<typeof getAllImages>>` (the narrowed `Omit<...>`), so **no consumer can READ** the 5 fields. But its item **object literal still SET them at runtime** — `scannedAt: null`, `mimeType: null`, `postTitle: null` (`image.service.ts:~2491`) — and a `const` object literal fires **no excess-property check**, so those props **serialized anyway**. Mapping `mergedData` through `stripImageForInfiniteWire` at the return actually removes them from the payload. This is the fix that lands the win on the **main production tRPC feed** (the first revision of this PR only stripped the DB path + the REST-only `getImagesFromFeedSearch`, missing the dominant Meili/BitDex path).

> 🔴 **The authoritative typecheck is the PR-preview `build-image` (`next build`).** Local `tsc` OOMs by default and vitest does not typecheck, so the full type graph — and therefore the no-hidden-reader guarantee — only fully proves out in the preview build. Please confirm `build-image` is green before merging; that green build *is* the whole safety argument for this change.

I did run a full local `tsc --noEmit` (raised heap) on the touched files — see the Verification section.

## Two fields were KEPT because the typecheck found real readers

The original scoping listed 7 candidates. Narrowing the shared type immediately surfaced two genuine readers, so those two were **left in rather than forced out**:

- **`index`** — the as-posts handler's `ImageSort.Newest` sort reads it (`images.sort((a, b) => (a.index ?? 0) - (b.index ?? 0))`), and it shares this type via `getAllImages`.
- **`availability`** — `BidModelButton` reads `image.availability ?? Public`.

This is exactly the `Omit`-narrowing net doing its job. The remaining 5 produced **zero** reader errors across the whole graph.

## Public-API safety

No breaking change to `/api/v1/images`: that endpoint reshapes its result through the `ShapedImage` whitelist (`getImagesFromSearch`), which never carried any of these 5 fields.

## Notes

- `hideMeta` is dropped from the **wire only** — the server still derives `hasMeta` from it in SQL, and `hasMeta` (which consumers *do* read) is unaffected.
- Not touched (out of scope, RISKY/LAZY): `tagIds` (hidden-prefs filter), `stats.*`, `modelVersionId`/`modelVersionIds`, `createdAt`/`sortAt`.

## Tests

`src/server/utils/__tests__/image-infinite-wire.test.ts` (5 cases) pins the exact dropped set, the load-bearing retentions (`tagIds`/`createdAt`/`sortAt`/`stats` + the kept `index`/`availability`), non-mutation, DB/Meili key-absence safety, and — for the `getAllImagesIndex` shape specifically — that explicit-`null` props have their **keys removed, not just nulled**. Passing locally.

## Verification done locally

- `vitest` on the new test — 5/5 pass.
- Full `tsc --noEmit` (raised heap) — the only errors in touched files are pre-existing `event-engine-common`/`kysely` submodule "cannot find module" noise (submodule not checked out locally; resolves in the preview build). Confirmed those pre-exist on `main` with the change stashed. The `getAllImagesIndex` strip added no new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)