### PR TITLE
feat(apps): get-started Quickstart to bottom + collapse commands; nav "Apps Marketplace" → "Apps"

### DIFF
--- a/src/components/AppLayout/AppHeader/hooks.tsx
+++ b/src/components/AppLayout/AppHeader/hooks.tsx
@@ -186,13 +186,13 @@ export function useGetMenuItems(): UserMenuItemGroup[] {
         {
           // Mod-only App Blocks marketplace + in-page AppsSubNav hub (installed,
           // submit, my-submissions, revenue, review). Stays gated on `appBlocks`
-          // (mod-only today). Relabeled "Apps Marketplace" so it reads distinctly
-          // from the public "Build apps" entry above.
+          // (mod-only today). Labeled "Apps" so it reads distinctly from the
+          // public "Build apps" entry above.
           href: '/apps',
           visible: appsNav.marketplace,
           icon: IconPlugConnected,
           color: theme.colors.blue[getPrimaryShade(theme, colorScheme ?? 'dark')],
-          label: 'Apps Marketplace',
+          label: 'Apps',
           newUntil: new Date('2026-07-01'),
         },
       ],

--- a/src/components/Apps/GetStartedBody.browser.test.tsx
+++ b/src/components/Apps/GetStartedBody.browser.test.tsx
@@ -34,14 +34,44 @@ describe('GetStartedBody (public App builders landing)', () => {
     expect(page.getByRole('heading', { name: 'Publish' }).elements()).toHaveLength(0);
   });
 
-  test('shows the quickstart commands (brew install, scaffold, run)', async () => {
+  test('the Quickstart section renders BELOW the "What you get" content in DOM order', async () => {
     renderWithProviders(<GetStartedBody />);
-    // Copyable commands render prefixed with a shell prompt ("$ ").
+    const whatYouGet = page.getByRole('heading', { name: 'What you get' });
+    const quickstart = page.getByRole('heading', { name: 'Quickstart' });
+    await expect.element(whatYouGet).toBeInTheDocument();
+    await expect.element(quickstart).toBeInTheDocument();
+    // Quickstart moved to the bottom — its heading must FOLLOW the "What you get"
+    // heading in document order.
+    const position = whatYouGet.element().compareDocumentPosition(quickstart.element());
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  test('the quickstart commands are collapsed (not visible) by default', async () => {
+    renderWithProviders(<GetStartedBody />);
+    // The heading + subtitle lead; the commands sit inside a collapsed section
+    // fronted by a "Show commands" toggle.
+    await expect.element(page.getByRole('heading', { name: 'Quickstart' })).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Show commands' })).toBeInTheDocument();
+    // The commands live inside a Mantine <Collapse> which renders a height:0
+    // wrapper when closed — assert THAT region is not visible (the closed
+    // wrapper has a zero-height box). Asserting the inner <pre> directly is
+    // unreliable: the browser matcher ignores the wrapper's opacity:0 and the
+    // clipped child keeps its own bounding box.
+    await expect.element(page.getByTestId('quickstart-commands')).not.toBeVisible();
+  });
+
+  test('clicking "Show commands" reveals the quickstart commands (brew install, scaffold, run)', async () => {
+    renderWithProviders(<GetStartedBody />);
+    await page.getByRole('button', { name: 'Show commands' }).click();
+    // Toggle label flips once opened.
+    await expect.element(page.getByRole('button', { name: 'Hide commands' })).toBeInTheDocument();
+    await expect.element(page.getByTestId('quickstart-commands')).toBeVisible();
+    // Copyable commands render prefixed with a shell prompt ("$ "), now visible.
     for (const command of [CLI_INSTALL_BREW, CLI_CREATE_SAMPLE_COMMAND, CLI_RUN_COMMAND]) {
-      await expect.element(page.getByText(`$ ${command}`)).toBeInTheDocument();
+      await expect.element(page.getByText(`$ ${command}`)).toBeVisible();
     }
     // The Go install is shown inline (secondary option), not as a copyable block.
-    await expect.element(page.getByText(CLI_INSTALL_GO)).toBeInTheDocument();
+    await expect.element(page.getByText(CLI_INSTALL_GO)).toBeVisible();
   });
 
   test('the run command installs deps before dev:harness (the CLI does not auto-install)', () => {

--- a/src/components/Apps/GetStartedBody.tsx
+++ b/src/components/Apps/GetStartedBody.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Button,
   Code,
+  Collapse,
   CopyButton,
   Divider,
   Group,
@@ -14,9 +15,11 @@ import {
   ThemeIcon,
   Title,
 } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
 import {
   IconBrandGithub,
   IconCheck,
+  IconChevronDown,
   IconClipboard,
   IconDatabase,
   IconPalette,
@@ -86,6 +89,8 @@ function CopyableCommand({ command }: { command: string }) {
 }
 
 export function GetStartedBody() {
+  const [opened, { toggle }] = useDisclosure(false);
+
   return (
     <Stack gap="xl">
       {/* Banner — 3:2 hero image (public asset, no layout shift) */}
@@ -110,25 +115,6 @@ export function GetStartedBody() {
           models and generate with Buzz. You focus on creating; we handle the rest.
         </Text>
       </Stack>
-
-      {/* Quickstart — the whole point: copy 3 lines, you're running */}
-      <Stack gap="sm">
-        <Title order={2}>Quickstart</Title>
-        <Text size="sm" c="dimmed">
-          Create a local Civitai app in 3 steps with the{' '}
-          <Anchor href={CIVITAI_CLI_GITHUB_URL} target="_blank" rel="noopener noreferrer">
-            Civitai CLI
-          </Anchor>
-        </Text>
-        <CopyableCommand command={CLI_INSTALL_BREW} />
-        <Text size="xs" c="dimmed">
-          or: <Code>{CLI_INSTALL_GO}</Code>
-        </Text>
-        <CopyableCommand command={CLI_CREATE_SAMPLE_COMMAND} />
-        <CopyableCommand command={CLI_RUN_COMMAND} />
-      </Stack>
-
-      <Divider />
 
       {/* What you get — the platform leverage a dev gets, then the toolkit links */}
       <Stack gap="sm">
@@ -224,6 +210,48 @@ export function GetStartedBody() {
             @civitai/app-sdk
           </Button>
         </Group>
+      </Stack>
+
+      <Divider />
+
+      {/* Quickstart — copy 3 lines, you're running. Collapsed by default so the
+          "what you get" pitch leads; the commands are one click away. */}
+      <Stack gap="sm">
+        <Title order={2}>Quickstart</Title>
+        <Text size="sm" c="dimmed">
+          Create a local Civitai app in 3 steps with the{' '}
+          <Anchor href={CIVITAI_CLI_GITHUB_URL} target="_blank" rel="noopener noreferrer">
+            Civitai CLI
+          </Anchor>
+        </Text>
+        <Button
+          variant="subtle"
+          size="xs"
+          onClick={toggle}
+          aria-expanded={opened}
+          w="fit-content"
+          rightSection={
+            <IconChevronDown
+              size={16}
+              style={{
+                transform: opened ? 'rotate(180deg)' : undefined,
+                transition: 'transform 150ms ease',
+              }}
+            />
+          }
+        >
+          {opened ? 'Hide commands' : 'Show commands'}
+        </Button>
+        <Collapse in={opened} data-testid="quickstart-commands">
+          <Stack gap="sm">
+            <CopyableCommand command={CLI_INSTALL_BREW} />
+            <Text size="xs" c="dimmed">
+              or: <Code>{CLI_INSTALL_GO}</Code>
+            </Text>
+            <CopyableCommand command={CLI_CREATE_SAMPLE_COMMAND} />
+            <CopyableCommand command={CLI_RUN_COMMAND} />
+          </Stack>
+        </Collapse>
       </Stack>
     </Stack>
   );


### PR DESCRIPTION
## What

Two small App-platform UI polish changes for the "Build on Civitai" get-started funnel.

### 1. Get-started: lead with the pitch, tuck the commands away
`src/components/Apps/GetStartedBody.tsx`

- Moved the **Quickstart** block (heading + blurb + CLI command lines) from the middle of the page to the **bottom**, below the "What you get" section, with a `<Divider/>` separating them. The old divider that sat between Quickstart and "What you get" is removed.
- The Quickstart **heading + one-line blurb stay visible**, but the copyable CLI commands (`brew install`, the `go install` alt line, `civitai app create`, and the `cd … && npm install && npm run dev:harness` run step) now live inside a Mantine `<Collapse>` gated by a **"Show commands" / "Hide commands"** toggle with a rotating chevron. Default **closed** (`useDisclosure(false)`).
- Rationale: the "what you get" leverage pitch now leads; a dev who's ready to build is one click from the copy-paste steps. Component stays pure-presentational (no tRPC / network) so it keeps rendering in isolation in the browser component tests.

### 2. Nav rename: "Apps Marketplace" → "Apps"
`src/components/AppLayout/AppHeader/hooks.tsx`

- The mod-only `/apps` user-menu entry is relabeled **"Apps"**. The sibling public `/apps/get-started` **"Build apps"** entry is untouched — the two stay distinct (a moderator never sees two identical labels).

## Tests
`src/components/Apps/GetStartedBody.browser.test.tsx` (Vitest browser mode) updated/extended:

- Quickstart heading renders **below** the "What you get" content in DOM order (`compareDocumentPosition`).
- The commands region is **not visible by default** (asserted on the closed `<Collapse>` region — its wrapper is zero-height when closed; the browser matcher ignores the wrapper's opacity, so the region is the deterministic signal).
- Clicking **"Show commands"** flips the toggle to "Hide commands" and makes all three command lines (+ the inline `go install`) **visible**.

The `appsNavVisibility` unit suite only referenced "Apps Marketplace" in comments (no assertion), so no assertion change was needed there.

## Test evidence

- `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` → **exit 0** (clean; 0 errors — no delta).
- `vitest run --project component src/components/Apps/GetStartedBody.browser.test.tsx` → **10/10 passed**.
- `vitest run --project unit src/components/AppLayout/AppHeader/appsNavVisibility.test.ts` → **6/6 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
