### PR TITLE
feat(app-blocks): app-chrome menu closes on iframe-click + "Recently run" section

### DIFF
--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 
 // AppBlockChrome now calls useCurrentUser() (moderator gate for the platform-nav
@@ -12,6 +12,11 @@ vi.mock('~/hooks/useCurrentUser', () => ({
 
 // eslint-disable-next-line import/first
 import { AppBlockChrome } from '~/components/AppBlocks/IframeHost';
+// eslint-disable-next-line import/first
+import {
+  clearRecentlyOpenedApps,
+  recordRecentlyOpenedApp,
+} from '~/components/Apps/recentlyOpenedAppsStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 // eslint-disable-next-line import/first
 import { renderWithProviders } from '../../../test/component-setup';
@@ -272,5 +277,132 @@ describe('AppBlockChrome run-page breadcrumb (Apps / <app name>)', () => {
     expect(text).not.toMatch(/[‮​]/);
     // The legible characters are preserved (control char became a space → collapsed).
     expect(text.replace(/\s+/g, '')).toBe('EvilAppName');
+  });
+});
+
+// "Recently run" section in the platform-nav ("Civitai Apps") dropdown — a
+// 1-click return to recently-run apps, sourced from the localStorage recents
+// store. Icon + name per entry, links to `/apps/run/<blockId>`, EXCLUDES the
+// current app, and the whole label+section is omitted when there are no other
+// recents. The store is real localStorage in browser mode, so seed it directly.
+describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => {
+  beforeEach(() => {
+    clearRecentlyOpenedApps();
+  });
+
+  // The platform-nav Menu mounts its dropdown lazily — open it first (its trigger
+  // is "Apps menu", distinct from the ⋯ "App menu").
+  async function openPlatformNav() {
+    await page.getByRole('button', { name: 'Apps menu' }).click();
+    await expect.element(page.getByRole('menuitem', { name: 'Apps home' })).toBeInTheDocument();
+  }
+
+  test('renders recents (icon + name), EXCLUDES the current app, links to /apps/run/<blockId>', async () => {
+    // Seed newest-last so the resulting order is [other, noicon, current].
+    recordRecentlyOpenedApp({ id: 'current', blockId: 'current-block', name: 'Current App' });
+    recordRecentlyOpenedApp({ id: 'noicon', blockId: 'noicon-block', name: 'No Icon App' });
+    recordRecentlyOpenedApp({
+      id: 'other',
+      blockId: 'other-block',
+      name: 'Other App',
+      iconUrl: 'https://cdn.example/icon.png',
+    });
+
+    renderWithProviders(
+      <AppBlockChrome
+        blockInstanceId="inst-recents"
+        appBlockId="current"
+        appName="Current App"
+        slotId="app.page"
+      />
+    );
+    await openPlatformNav();
+
+    // Section label present.
+    await expect.element(page.getByText('Recently run', { exact: true })).toBeInTheDocument();
+
+    // Rich entry: icon (Avatar <img>) + name, links to the run route.
+    const other = page.getByRole('menuitem', { name: 'Other App' }).element() as HTMLElement;
+    expect(other.getAttribute('href')).toBe('/apps/run/other-block');
+    const otherImg = other.querySelector('img');
+    expect(otherImg).not.toBeNull();
+    expect(otherImg?.getAttribute('src')).toBe('https://cdn.example/icon.png');
+
+    // Icon-less entry falls back to a generic app icon (an <svg>, no <img>).
+    const noicon = page.getByRole('menuitem', { name: 'No Icon App' }).element() as HTMLElement;
+    expect(noicon.getAttribute('href')).toBe('/apps/run/noicon-block');
+    expect(noicon.querySelector('img')).toBeNull();
+    expect(noicon.querySelector('svg')).not.toBeNull();
+
+    // The current app is EXCLUDED — no menuitem links to its run route.
+    const currentLinks = page
+      .getByRole('menuitem')
+      .all()
+      .map((el) => el.element().getAttribute('href'));
+    expect(currentLinks).not.toContain('/apps/run/current-block');
+  });
+
+  test('the whole "Recently run" section is ABSENT when there are no OTHER recents', async () => {
+    // Only the current app is a recent → nothing to offer after exclusion.
+    recordRecentlyOpenedApp({ id: 'solo', blockId: 'solo-block', name: 'Solo App' });
+
+    renderWithProviders(
+      <AppBlockChrome
+        blockInstanceId="inst-solo"
+        appBlockId="solo"
+        appName="Solo App"
+        slotId="app.page"
+      />
+    );
+    await openPlatformNav();
+
+    // Neither the label nor the section wrapper renders.
+    await expect.element(page.getByText('Recently run', { exact: true })).not.toBeInTheDocument();
+    await expect.element(page.getByTestId('app-recently-run')).not.toBeInTheDocument();
+  });
+
+  test('an EMPTY recents store renders no "Recently run" section', async () => {
+    renderWithProviders(
+      <AppBlockChrome
+        blockInstanceId="inst-empty"
+        appBlockId="anything"
+        appName="Anything"
+        slotId="app.page"
+      />
+    );
+    await openPlatformNav();
+    await expect.element(page.getByTestId('app-recently-run')).not.toBeInTheDocument();
+  });
+});
+
+// Iframe-aware close (the reported bug): the run page is dominated by a
+// cross-origin app iframe that SWALLOWS the click, so Mantine's default
+// outside-click close never sees the mousedown and the menu appears stuck open.
+// The controlled Menu closes on the window `blur` event, which DOES fire when
+// focus/pointer moves into the iframe.
+describe('AppBlockChrome platform-nav closes on window blur (iframe-aware)', () => {
+  beforeEach(() => {
+    clearRecentlyOpenedApps();
+  });
+
+  test('opening works, and a window blur (click into the app iframe) closes the menu', async () => {
+    renderWithProviders(
+      <AppBlockChrome blockInstanceId="inst-blur" appName="Any App" slotId="app.page" />
+    );
+
+    // Target toggles the menu open.
+    await page.getByRole('button', { name: 'Apps menu' }).click();
+    await expect.element(page.getByRole('menuitem', { name: 'Apps home' })).toBeInTheDocument();
+
+    // Simulate the click landing INSIDE the cross-origin iframe: the parent
+    // window loses focus → `blur`. The controlled menu must close.
+    window.dispatchEvent(new Event('blur'));
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Apps home' }))
+      .not.toBeInTheDocument();
+
+    // The target still opens the menu again after the blur-close (toggle intact).
+    await page.getByRole('button', { name: 'Apps menu' }).click();
+    await expect.element(page.getByRole('menuitem', { name: 'Apps home' })).toBeInTheDocument();
   });
 });

--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -373,6 +373,74 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
     await openPlatformNav();
     await expect.element(page.getByTestId('app-recently-run')).not.toBeInTheDocument();
   });
+
+  // Security-adjacent consistency: the persisted `name` is publisher-controlled
+  // (laundered through localStorage) — the SAME untrusted source the host trust
+  // label sanitizes. The recents item must route it through sanitizeAppChromeName
+  // too, so a bidi-override / zero-width / oversized name can't render raw in the
+  // dropdown. Mutation-sanity: dropping the sanitizer call (rendering `r.name`
+  // raw) fails the "dangerous chars stripped" assertions below.
+  test('a hostile persisted name is rendered SANITIZED (bidi/zero-width stripped) + length-bounded', async () => {
+    // RLO override + zero-width space + a long tail well past APP_CHROME_NAME_MAX
+    // (64). sanitizeAppChromeName strips the bidi/format chars and caps length.
+    const rawName = 'Evil‮Hack​App' + 'X'.repeat(200);
+    recordRecentlyOpenedApp({ id: 'hostile', blockId: 'hostile-block', name: rawName });
+
+    renderWithProviders(
+      <AppBlockChrome
+        blockInstanceId="inst-hostile"
+        appBlockId="viewer"
+        appName="Viewer App"
+        slotId="app.page"
+      />
+    );
+    await openPlatformNav();
+
+    // The item is present and still links to its run route (blockId unaffected).
+    const item = page.getByTestId('app-recently-run-item').element() as HTMLElement;
+    expect(item.getAttribute('href')).toBe('/apps/run/hostile-block');
+
+    const text = item.textContent ?? '';
+    // The bidi RLO override + zero-width space must NOT survive into the DOM.
+    expect(text).not.toMatch(/[‮​]/);
+    // The legible characters are preserved (format chars removed, not the letters).
+    expect(text).toContain('EvilHackApp');
+    // Length is bounded by the sanitizer (rawName was 200+ chars; the rendered
+    // string must be far shorter — proves the length cap ran, not just a CSS clamp).
+    expect(text.length).toBeLessThan(rawName.length);
+    expect(text.length).toBeLessThanOrEqual(70); // APP_CHROME_NAME_MAX (64) + ellipsis slack
+  });
+
+  // Freshness: the store is read on mount AND re-read every time the menu opens,
+  // so a within-session client-nav (open app A → open app B, no full reload)
+  // shows the CURRENT recents — not a snapshot frozen at first mount.
+  test('re-reads the recents store on menu OPEN (fresh within an SPA session)', async () => {
+    // Mount with an EMPTY store — first open shows no recents section.
+    renderWithProviders(
+      <AppBlockChrome
+        blockInstanceId="inst-fresh"
+        appBlockId="viewer"
+        appName="Viewer App"
+        slotId="app.page"
+      />
+    );
+    await openPlatformNav();
+    await expect.element(page.getByTestId('app-recently-run')).not.toBeInTheDocument();
+
+    // Close the menu (Escape), then a NEW app is recorded mid-session (simulating
+    // the viewer running another app via client-nav elsewhere in the SPA).
+    await page.getByRole('button', { name: 'Apps menu' }).click();
+    await expect
+      .element(page.getByRole('menuitem', { name: 'Apps home' }))
+      .not.toBeInTheDocument();
+    recordRecentlyOpenedApp({ id: 'fresh', blockId: 'fresh-block', name: 'Fresh App' });
+
+    // Re-open — the open-refresh read must surface the newly-recorded app.
+    await openPlatformNav();
+    await expect.element(page.getByTestId('app-recently-run')).toBeInTheDocument();
+    const item = page.getByRole('menuitem', { name: 'Fresh App' }).element() as HTMLElement;
+    expect(item.getAttribute('href')).toBe('/apps/run/fresh-block');
+  });
 });
 
 // Iframe-aware close (the reported bug): the run page is dominated by a

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -1,7 +1,7 @@
 import dynamic from 'next/dynamic';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import { ActionIcon, Box, Group, Menu, Text } from '@mantine/core';
+import { ActionIcon, Avatar, Box, Group, Menu, Text } from '@mantine/core';
 import {
   IconApps,
   IconDots,
@@ -12,6 +12,10 @@ import {
   IconUpload,
 } from '@tabler/icons-react';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
+import {
+  getRecentlyOpenedApps,
+  type RecentApp,
+} from '~/components/Apps/recentlyOpenedAppsStore';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { AppPermissionsActivityDrawer } from './AppPermissionsActivityDrawer';
@@ -82,6 +86,12 @@ const TOKEN_WAIT_TIMEOUT_MS = 15_000;
 // A malicious or buggy block sending {height: 1e9} on RESIZE_IFRAME would
 // otherwise OOM the tab. 8000px is well above any legitimate block.
 const HARD_HEIGHT_CEILING = 8_000;
+
+// Max "Recently run" entries shown in the app-chrome platform-nav dropdown.
+// Kept short so the compact menu doesn't grow unbounded (the store itself caps
+// at MAX_RECENTS; this is the additional display cap after excluding the
+// current app).
+const RECENTLY_RUN_LIMIT = 5;
 
 type Status = 'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token';
 
@@ -177,6 +187,35 @@ export function AppBlockChrome({
   // Per-app "Permissions & activity" drawer open state (only reachable when
   // appBlockId was threaded through).
   const [permsOpen, setPermsOpen] = useState(false);
+
+  // The platform-nav ("Civitai Apps") Menu is CONTROLLED so we can close it when
+  // the user clicks INTO the cross-origin app iframe. Mantine's default
+  // outside-click close CAN'T detect that: the iframe swallows the mousedown, so
+  // the parent document never sees it and Mantine can't tell the click was
+  // "outside" the dropdown — the menu appears stuck open (the reported bug).
+  // The fix is iframe-aware: while the menu is open, listen for the window
+  // `blur` event, which DOES fire when focus/pointer moves into a cross-origin
+  // iframe, and close on it. Normal same-document outside-clicks + item-clicks
+  // still close via Mantine's untouched defaults (closeOnClickOutside /
+  // closeOnItemClick).
+  const [menuOpened, setMenuOpened] = useState(false);
+  useEffect(() => {
+    if (!menuOpened) return;
+    const onBlur = () => setMenuOpened(false);
+    window.addEventListener('blur', onBlur);
+    return () => window.removeEventListener('blur', onBlur);
+  }, [menuOpened]);
+
+  // Recently-run apps (client-only personalisation from localStorage). Seeded
+  // empty so SSR + the first client render match (no hydration mismatch); the
+  // real list loads in an effect after mount. Excludes the app currently being
+  // viewed (matched by appBlockId — the store's stable id) and is capped to a
+  // short list for the compact dropdown.
+  const [recents, setRecents] = useState<RecentApp[]>([]);
+  useEffect(() => {
+    setRecents(getRecentlyOpenedApps());
+  }, []);
+  const recentApps = recents.filter((r) => r.id !== appBlockId).slice(0, RECENTLY_RUN_LIMIT);
   // The full-page run surface (`app.page`) has no model-page slot to hide the
   // block from — the page IS the block — so suppress the "Hide" item there.
   const isPage = slotId != null && isPageSlot(slotId);
@@ -231,7 +270,13 @@ export function AppBlockChrome({
             (role="img" + aria-label "App") — required so a bare tabler <svg>'s
             label is announced; on the fallback the visible "App" Text carries
             provenance instead, so the icon is marked decorative there. */}
-        <Menu position="bottom-start" shadow="md" width={200}>
+        <Menu
+          position="bottom-start"
+          shadow="md"
+          width={200}
+          opened={menuOpened}
+          onChange={setMenuOpened}
+        >
           <Menu.Target>
             <ActionIcon
               variant="subtle"
@@ -281,6 +326,35 @@ export function AppBlockChrome({
               >
                 Review
               </Menu.Item>
+            )}
+            {/* "Recently run" — a 1-click return to apps the viewer recently ran,
+                sourced from the client-only localStorage recents store (read
+                after mount so SSR + first client render match). Excludes the app
+                currently being viewed and the whole label+section is omitted when
+                there's nothing else to show (a first-time / single-app viewer).
+                Each item shows the app icon (persisted `iconUrl`, else a generic
+                app icon) + name, linking to the full-page run route. */}
+            {recentApps.length > 0 && (
+              <div data-testid="app-recently-run">
+                <Menu.Label>Recently run</Menu.Label>
+                {recentApps.map((r) => (
+                  <Menu.Item
+                    key={r.id}
+                    component={Link}
+                    href={`/apps/run/${r.blockId}`}
+                    data-testid="app-recently-run-item"
+                    leftSection={
+                      r.iconUrl ? (
+                        <Avatar src={r.iconUrl} size={16} radius="sm" alt="" />
+                      ) : (
+                        <IconApps size={14} stroke={1.5} />
+                      )
+                    }
+                  >
+                    {r.name ?? r.blockId}
+                  </Menu.Item>
+                ))}
+              </div>
             )}
           </Menu.Dropdown>
         </Menu>

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -208,14 +208,25 @@ export function AppBlockChrome({
 
   // Recently-run apps (client-only personalisation from localStorage). Seeded
   // empty so SSR + the first client render match (no hydration mismatch); the
-  // real list loads in an effect after mount. Excludes the app currently being
-  // viewed (matched by appBlockId — the store's stable id) and is capped to a
-  // short list for the compact dropdown.
+  // real list loads in an effect after mount AND is refreshed every time the
+  // menu opens (see handleMenuChange) so a within-session client-nav
+  // (app A → app B) shows the CURRENT list, not the list as of first mount.
+  // Excludes the app currently being viewed (matched by appBlockId — the store's
+  // stable id) and is capped to a short list for the compact dropdown.
   const [recents, setRecents] = useState<RecentApp[]>([]);
   useEffect(() => {
     setRecents(getRecentlyOpenedApps());
   }, []);
   const recentApps = recents.filter((r) => r.id !== appBlockId).slice(0, RECENTLY_RUN_LIMIT);
+
+  // Controlled-Menu change handler: mirror the open state AND re-read the recents
+  // store on the transition to open, so the "Recently run" list is fresh within
+  // an SPA session. Still SSR-safe — the read only happens on a user-driven open
+  // (never during render) and getRecentlyOpenedApps() self-guards `isClient`.
+  const handleMenuChange = useCallback((opened: boolean) => {
+    setMenuOpened(opened);
+    if (opened) setRecents(getRecentlyOpenedApps());
+  }, []);
   // The full-page run surface (`app.page`) has no model-page slot to hide the
   // block from — the page IS the block — so suppress the "Hide" item there.
   const isPage = slotId != null && isPageSlot(slotId);
@@ -275,7 +286,7 @@ export function AppBlockChrome({
           shadow="md"
           width={200}
           opened={menuOpened}
-          onChange={setMenuOpened}
+          onChange={handleMenuChange}
         >
           <Menu.Target>
             <ActionIcon
@@ -351,7 +362,17 @@ export function AppBlockChrome({
                       )
                     }
                   >
-                    {r.name ?? r.blockId}
+                    {/* The persisted `name` is the SAME publisher-controlled string
+                        the trust label above laundered through localStorage — so
+                        route it through the identical sanitizer (strips bidi
+                        RLO/LRO overrides, zero-width/format + control chars, caps
+                        Zalgo combining runs, bounds length). `||` (not `??`) so an
+                        empty/whitespace sanitized result falls back to the blockId
+                        handle. `lineClamp={1}` keeps a pathologically long name
+                        from blowing out the width={200} dropdown. */}
+                    <Text size="sm" lineClamp={1}>
+                      {sanitizeAppChromeName(r.name) || r.blockId}
+                    </Text>
                   </Menu.Item>
                 ))}
               </div>

--- a/src/components/Apps/MarketplaceBody.tsx
+++ b/src/components/Apps/MarketplaceBody.tsx
@@ -228,7 +228,19 @@ export function MarketplaceBody() {
   //    never fires the install `onOpen`. The store dedups, so an app opened via
   //    both paths is recorded once.
   function recordRecent(block: AvailableBlock) {
-    setRecents(recordRecentlyOpenedApp({ id: block.id, blockId: block.blockId }));
+    // Enrich the recents entry with the block's name + cover image when they're
+    // already on hand (they are, on the AvailableBlock) so the shared app-chrome
+    // "Recently run" menu can render icon + name without a re-fetch. Both are
+    // optional in the store, so a null coverUrl/appName just falls back to the
+    // generic icon / blockId handle.
+    setRecents(
+      recordRecentlyOpenedApp({
+        id: block.id,
+        blockId: block.blockId,
+        name: block.appName ?? undefined,
+        iconUrl: block.coverUrl ?? undefined,
+      })
+    );
   }
 
   function handleOpen(block: AvailableBlock) {

--- a/src/components/Apps/recentlyOpenedAppsStore.ts
+++ b/src/components/Apps/recentlyOpenedAppsStore.ts
@@ -26,10 +26,19 @@ export const MAX_RECENTS = 8;
 
 /** One recorded recently-opened app. `id` is the app block id (the stable key
  *  used for de-dup); `blockId` is the human/slug handle kept for display +
- *  re-resolution against the listing. */
+ *  re-resolution against the listing (and the `/apps/run/<blockId>` link).
+ *
+ *  `name` + `iconUrl` are OPTIONAL display enrichments so a consumer (the shared
+ *  app-chrome "Recently run" menu) can render icon + name WITHOUT re-fetching the
+ *  listing. They are optional on purpose: entries persisted before this field
+ *  existed are `{id, blockId}`-only and MUST still parse (backward-compatible),
+ *  and a caller that doesn't readily have the name/icon simply omits them (the
+ *  UI falls back to a generic icon / the blockId handle). */
 export type RecentApp = {
   id: string;
   blockId: string;
+  name?: string;
+  iconUrl?: string;
 };
 
 function isClient(): boolean {
@@ -48,7 +57,17 @@ function coerce(raw: unknown): RecentApp[] {
       typeof (item as RecentApp).id === 'string' &&
       typeof (item as RecentApp).blockId === 'string'
     ) {
-      out.push({ id: (item as RecentApp).id, blockId: (item as RecentApp).blockId });
+      const entry: RecentApp = {
+        id: (item as RecentApp).id,
+        blockId: (item as RecentApp).blockId,
+      };
+      // Carry the OPTIONAL display enrichments through only when present AND a
+      // string — a legacy `{id,blockId}`-only entry, or a hand-edited blob with
+      // a wrong-typed name/iconUrl, degrades to "no enrichment" (never crashes).
+      const { name, iconUrl } = item as RecentApp;
+      if (typeof name === 'string') entry.name = name;
+      if (typeof iconUrl === 'string') entry.iconUrl = iconUrl;
+      out.push(entry);
     }
   }
   return out;

--- a/src/components/Apps/recents-helper.browser.test.tsx
+++ b/src/components/Apps/recents-helper.browser.test.tsx
@@ -76,4 +76,52 @@ describe('recentlyOpenedApps helper', () => {
     );
     expect(getRecentlyOpenedApps()).toEqual([{ id: 'ok', blockId: 'b-ok' }]);
   });
+
+  // Display-enrichment fields (name/iconUrl) — round-trip + backward-compat.
+  test('name + iconUrl are persisted and round-tripped', () => {
+    recordRecentlyOpenedApp({
+      id: 'rich',
+      blockId: 'block-rich',
+      name: 'Background Remover',
+      iconUrl: 'https://cdn.example/icon.png',
+    });
+    expect(getRecentlyOpenedApps()).toEqual([
+      {
+        id: 'rich',
+        blockId: 'block-rich',
+        name: 'Background Remover',
+        iconUrl: 'https://cdn.example/icon.png',
+      },
+    ]);
+  });
+
+  test('a legacy {id,blockId}-only stored entry still parses (backward-compat)', () => {
+    // Simulate an entry written BEFORE name/iconUrl existed — it must survive a
+    // read unchanged (no name/iconUrl keys invented), proving the widened type
+    // is backward-compatible with already-persisted data.
+    window.localStorage.setItem(
+      RECENTLY_OPENED_APPS_KEY,
+      JSON.stringify([{ id: 'legacy', blockId: 'block-legacy' }])
+    );
+    const list = getRecentlyOpenedApps();
+    expect(list).toEqual([{ id: 'legacy', blockId: 'block-legacy' }]);
+    expect(list[0]).not.toHaveProperty('name');
+    expect(list[0]).not.toHaveProperty('iconUrl');
+  });
+
+  test('wrong-typed name/iconUrl are dropped, id/blockId still parse (fail-soft)', () => {
+    window.localStorage.setItem(
+      RECENTLY_OPENED_APPS_KEY,
+      JSON.stringify([{ id: 'x', blockId: 'b-x', name: 42, iconUrl: { bad: true } }])
+    );
+    expect(getRecentlyOpenedApps()).toEqual([{ id: 'x', blockId: 'b-x' }]);
+  });
+
+  test('re-recording upgrades a legacy entry to the richer shape (dedup keeps newest)', () => {
+    recordRecentlyOpenedApp({ id: 'up', blockId: 'block-up' });
+    recordRecentlyOpenedApp({ id: 'up', blockId: 'block-up', name: 'Upgraded', iconUrl: 'i.png' });
+    const list = getRecentlyOpenedApps();
+    expect(list).toHaveLength(1);
+    expect(list[0]).toEqual({ id: 'up', blockId: 'block-up', name: 'Upgraded', iconUrl: 'i.png' });
+  });
 });

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -1,6 +1,7 @@
 import { Box, useComputedColorScheme } from '@mantine/core';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { recordRecentlyOpenedApp } from '~/components/Apps/recentlyOpenedAppsStore';
 import { Meta } from '~/components/Meta/Meta';
 import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
 import { useBlockToken } from '~/components/AppBlocks/useBlockToken';
@@ -94,6 +95,17 @@ export default function AppPage(props: PageProps) {
   const currentUser = useCurrentUser();
   const colorScheme = useComputedColorScheme('dark');
   const theme: 'light' | 'dark' = colorScheme === 'dark' ? 'dark' : 'light';
+
+  // Record this ACTUAL run in the client-only recents store (localStorage), so
+  // the shared app-chrome "Recently run" menu can offer a 1-click return. Keyed
+  // by appBlockId (the store's stable de-dup id); `blockId` backs the
+  // `/apps/run/<blockId>` link and `name` is the display label. No icon URL is
+  // plumbed to this SSR page (PageProps carries none), so `iconUrl` is omitted —
+  // the menu falls back to a generic app icon. Fires once per mount; the store
+  // dedups so revisiting just moves the entry to the front.
+  useEffect(() => {
+    recordRecentlyOpenedApp({ id: appBlockId, blockId, name: appName });
+  }, [appBlockId, blockId, appName]);
 
   // Synthetic page instance id — the mint resolves `page_<appBlockId>` directly
   // from the approved AppBlock (no install row).


### PR DESCRIPTION
## What & why

Two related product changes to the **shared app-chrome menu** — the trust bar the host renders around every app block. It shows on **both** the full-page run frame (`/apps/run/<slug>`) and the `model.sidebar_top` slot embed, so both changes apply to both surfaces.

### 1. The menu now closes when you click into the app

The "Civitai Apps" dropdown didn't close on an outside click on the run page. Root cause: the run surface is dominated by a **cross-origin app iframe that swallows the click** — the parent document never sees the mousedown, so the menu's default outside-click detection can't tell the click was "outside" and the menu stayed open.

The fix is iframe-aware: the menu is now controlled and, while open, also closes on the window `blur` event (which *does* fire when focus/pointer moves into a cross-origin iframe). Normal same-document outside-clicks and item-clicks still close it exactly as before.

### 2. A "Recently run" section for 1-click return

The menu now lists the apps you recently ran (**icon + name**), each a direct link back to `/apps/run/<blockId>`. It's localStorage-backed (client-only personalisation — never read on the server), records **actual runs** on the run page, and:

- **excludes the app you're currently viewing**,
- shows up to 5, newest-first,
- is **hidden entirely** when you have no other recent apps (new / single-app viewer),
- falls back to a generic app icon when no icon URL was captured.

Marketplace-opened apps are also enriched with name + cover image so they show richly here too.

## Notes

- The recents store's `RecentApp` gains **optional** `name`/`iconUrl` fields — backward-compatible: entries persisted as `{id, blockId}` still parse unchanged.
- No icon URL is plumbed to the SSR run page (its props carry none), so run-page-recorded entries omit `iconUrl` and fall back to the generic icon rather than adding heavy SSR plumbing. Marketplace entries (which already have the cover image on hand) persist the real icon.

## Test evidence

New + affected tests, all green (vitest browser mode, `--project component`):

- **Store** (`recents-helper.browser.test.tsx`, 11 tests): `name`/`iconUrl` persisted + round-tripped; a legacy `{id,blockId}`-only entry still parses; wrong-typed enrichment dropped fail-soft; re-record upgrades a legacy entry; cap/dedup/order preserved.
- **Chrome menu** (`AppBlockChrome.browser.test.tsx`, 18 tests): "Recently run" renders icon + name, **excludes the current app**, links to `/apps/run/<blockId>`, generic-icon fallback when no `iconUrl`, and the section is **absent** when there are no other recents; the menu **closes on window `blur`** while open and the target still re-opens it.
- **No regressions**: `AppBlockChromePlatformNav` (6), `IframeHost` (5), `PageBlockHost` (25), `MarketplaceBody` (9), `RecentlyOpenedApps` (2) — all pass.

```
recents-helper.browser.test.tsx   11 passed
AppBlockChrome.browser.test.tsx   18 passed
+ adjacent: 47 passed
```

Typecheck: `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` -> 17 errors, all pre-existing environmental (kysely / event-engine-common module resolution, image.service implicit-any) -- **0 in any changed file, 0 delta** vs the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
