### PR TITLE
security(app-blocks): remove 3 unenforced decorative block scopes + fix 2 audit-integrity issues

### DIFF
--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -69,12 +69,9 @@
         "type": "string",
         "enum": [
           "models:read:self",
-          "media:read:owned",
           "user:read:self",
           "ai:write:budgeted",
           "buzz:read:self",
-          "block:settings:read",
-          "block:settings:write",
           "social:tip:self",
           "apps:storage:read",
           "apps:storage:write",

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -1168,7 +1168,7 @@ function ManifestScopes({ manifest }: { manifest: Record<string, unknown> }) {
           <Tooltip
             multiline
             w={280}
-            label="Permissions the block requests. They are encoded as scopes in the app's signed block-token JWT (distinct from OAuth scopes) and enforced at token issuance."
+            label="Permissions the block requests. They are encoded as scopes in the app's signed block-token JWT (distinct from OAuth scopes) and enforced per-operation server-side: every capability re-verifies the token and checks the required scope before it runs."
           >
             <ThemeIcon size="xs" variant="subtle" color="gray">
               <IconInfoCircle size={13} />

--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -741,6 +741,12 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // 403ing the whole request. (Without this pre-filter, an unknown scope would
   // be flagged by `validateBlockScopesAgainstOauthClient` and hard-fail the
   // mint.) The capability-bearing (known) scopes are still fully gated below.
+  //
+  // INTENTIONAL: if the manifest declared ONLY removed/unknown scopes this
+  // filters to an EMPTY set and we go on to sign a valid ZERO-scope token (not
+  // an error). That is correct — the app simply has no capabilities, and every
+  // scope-gated endpoint fails closed at the deny-by-default runtime gate. A
+  // useless-but-valid token is the right graceful outcome, not a 403.
   const knownManifestScopes = rawManifestScopes.filter(isKnownBlockScope);
 
   const oauthAllowed = block.app?.allowedScopes ?? 0;

--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -55,7 +55,7 @@ import type { Logger } from '@civitai/next-axiom';
  * Token lifetime: 15 minutes. Rate limits: 120/min per IP, 60/min per (subject, instance).
  *
  * Anon viewers receive a token with `sub: "anon"`. Scopes requiring an
- * authenticated subject (buzz:read:self, social:tip:self, media:read:owned)
+ * authenticated subject (buzz:read:self, social:tip:self, user:read:self)
  * are rejected downstream by the block-scope middleware.
  *
  * CSRF posture: SAME-ORIGIN ONLY with EXACT host equality. The host page on
@@ -731,8 +731,20 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
         ) as string[])
       : [];
 
+  // Graceful deprecation: drop any scope that is no longer part of the known
+  // block-scope vocabulary BEFORE the OAuth / approved-snapshot gates below.
+  // A scope can become unknown when it is deprecated AFTER an app was approved
+  // (e.g. the removed decorative `media:read:owned` / `block:settings:*`). Such
+  // a scope carries no capability — the runtime gate (`enforceContextBinding`)
+  // rejects it and it is never signed into a token — so a legacy app that
+  // historically declared one must keep minting its OTHER scopes rather than
+  // 403ing the whole request. (Without this pre-filter, an unknown scope would
+  // be flagged by `validateBlockScopesAgainstOauthClient` and hard-fail the
+  // mint.) The capability-bearing (known) scopes are still fully gated below.
+  const knownManifestScopes = rawManifestScopes.filter(isKnownBlockScope);
+
   const oauthAllowed = block.app?.allowedScopes ?? 0;
-  const scopeCheck = validateBlockScopesAgainstOauthClient(rawManifestScopes, oauthAllowed);
+  const scopeCheck = validateBlockScopesAgainstOauthClient(knownManifestScopes, oauthAllowed);
   if (!scopeCheck.valid) {
     res.status(403).json({
       error: 'block manifest carries scopes outside the OAuth client allowlist',
@@ -744,13 +756,16 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // H-2: intersect requested scopes with the approved-scope snapshot. An
   // approved manifest re-published with added scopes already loses approval
   // (status → 'pending', filtered above), but the approved_scopes column is
-  // the authoritative pinning. Empty array = fail-closed.
+  // the authoritative pinning. Empty array = fail-closed. Checked on the
+  // known-scope subset — an unknown scope was dropped above (capability-less),
+  // so an anti-swap check on it would only mislead; a KNOWN scope added outside
+  // the approved snapshot is still caught here.
   const approvedScopes = new Set(block.approvedScopes ?? []);
   if (approvedScopes.size === 0) {
     res.status(403).json({ error: 'block has no approved scopes' });
     return;
   }
-  const outsideApproved = rawManifestScopes.filter((s) => !approvedScopes.has(s));
+  const outsideApproved = knownManifestScopes.filter((s) => !approvedScopes.has(s));
   if (outsideApproved.length > 0) {
     res.status(403).json({
       error: 'block manifest carries scopes outside the approved snapshot',
@@ -758,7 +773,7 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     });
     return;
   }
-  const requestedScopes = rawManifestScopes.filter(isKnownBlockScope);
+  const requestedScopes = knownManifestScopes;
 
   // W10 PAGE HARD RULE (belt over the manifest + approved-scope intersection):
   // a page (kind==='page', entity=none) is viewer-scoped with no model entity
@@ -809,7 +824,7 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
   // anon-safe scope subset rather than a 403. The anon-safe subset is the
   // manifest scopes with every consent-gated scope STRIPPED — which is exactly
   // every `:self` / owned / money / tip scope (`user:read:self`,
-  // `buzz:read:self`, `media:read:owned`, `social:tip:self`,
+  // `buzz:read:self`, `social:tip:self`,
   // `ai:write:budgeted`, `models:read:self`, …). `consentGatedScopes` is the
   // single source of truth for "requires a per-user grant"; an anon viewer has
   // no grant and never can, so the entire consent-gated set is withheld.
@@ -836,10 +851,12 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
     needsConsent = false;
   }
 
-  // C8: settings scopes are publisher-only. Caller must be the install's
-  // installedByUserId. When the publisher's account has been deleted,
-  // installedByUserId is NULL (SET NULL FK) → this check fails for everyone,
-  // which is the correct fail-closed behavior — the model owner can uninstall.
+  // C8 (now INERT — retained as fail-safe): settings scopes were publisher-only,
+  // requiring caller == install.installedByUserId. `block:settings:*` has since
+  // been removed from the known block-scope vocabulary, so it is filtered out of
+  // `manifestScopes` above (never known) and this branch can no longer fire. Kept
+  // as harmless defense-in-depth so re-introducing a settings scope re-arms the
+  // installer gate rather than silently minting it. (See block-scope.constants.ts.)
   const wantsSettingsScope = manifestScopes.some(
     (s) => s === 'block:settings:read' || s === 'block:settings:write'
   );

--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -72,7 +72,7 @@ type AxiomAPIRequest = NextApiRequest & { log: Logger };
  *    PAGE_FORBIDDEN_SCOPES; spend is the dev's OWN budget-capped Buzz against the
  *    untouched per-user daily cap; the runtime spend belt still asserts
  *    moderator pre-GA. The R1-escalation test proves an escalated manifest scope
- *    (`social:tip:self`, `block:settings:write`, an unknown/mature scope) is
+ *    (`social:tip:self`, an unknown/removed/mature scope) is
  *    STRIPPED, never minted.
  *
  *    APPID MISATTRIBUTION (audit S1 — FIXED): the pending path mints a SYNTHETIC

--- a/src/server/middleware/__tests__/block-scope.middleware.test.ts
+++ b/src/server/middleware/__tests__/block-scope.middleware.test.ts
@@ -87,15 +87,22 @@ describe('enforceContextBinding', () => {
     expect(() => enforceContextBinding(authed, fakeReq({}))).not.toThrow();
   });
 
-  it('block:settings:* binds to blockInstanceId in query', () => {
-    const claims = fakeClaims({ scopes: ['block:settings:read'], blockInstanceId: 'bki_A' });
-    expect(() =>
-      enforceContextBinding(claims, fakeReq({ blockInstanceId: 'bki_A' }))
-    ).not.toThrow();
-    expect(() =>
-      enforceContextBinding(claims, fakeReq({ blockInstanceId: 'bki_B' }))
-    ).toThrow();
-    expect(() => enforceContextBinding(claims, fakeReq({}))).toThrow();
+  it('rejects the removed decorative scopes (no longer known → deny-by-default)', () => {
+    // media:read:owned / block:settings:read / block:settings:write were removed
+    // from the known vocabulary (decorative — no runtime capability checked them).
+    // A token still carrying one is now an UNKNOWN scope → denied at the runtime
+    // gate before any binding case runs, EVEN for an authenticated subject with a
+    // matching blockInstanceId (which used to satisfy the old block:settings case).
+    for (const removed of ['media:read:owned', 'block:settings:read', 'block:settings:write']) {
+      const claims = fakeClaims({
+        sub: 'user:42',
+        scopes: [removed],
+        blockInstanceId: 'bki_A',
+      });
+      expect(() =>
+        enforceContextBinding(claims, fakeReq({ blockInstanceId: 'bki_A' }))
+      ).toThrow();
+    }
   });
 
   it('rejects unknown scopes outright (deny-by-default at runtime)', () => {

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -588,12 +588,10 @@ function readBoundQueryString(req: NextApiRequest, name: string): string | undef
  * Enforces context binding per scope type. Each scope can require
  * additional request-shape checks beyond having-the-scope:
  *   - models:read:self   → query.id ≡ claims.ctx.modelId (integer match)
- *   - media:read:owned   → claims.sub != 'anon'
  *   - buzz:read:self     → claims.sub != 'anon'
  *   - social:tip:self    → claims.sub != 'anon'
  *   - user:read:self     → claims.sub != 'anon'
  *   - ai:write:budgeted  → claims.buzzBudget > 0
- *   - block:settings:*   → query.blockInstanceId ≡ claims.blockInstanceId
  *
  * Throws ForbiddenError on mismatch.
  */
@@ -633,12 +631,11 @@ export function enforceContextBinding(
         }
         break;
       }
-      case 'media:read:owned':
       case 'buzz:read:self':
       case 'social:tip:self':
       case 'user:read:self': {
         // Every :self scope requires an authenticated subject — there's no
-        // anonymous "self" to read/own/tip. user:read:self joined this set
+        // anonymous "self" to read/tip. user:read:self joined this set
         // when /api/v1/blocks/me switched off buzz:read:self (audit I3).
         if (claims.sub === 'anon') {
           throw forbidden(`${scope} requires authenticated subject`);
@@ -648,14 +645,6 @@ export function enforceContextBinding(
       case 'ai:write:budgeted': {
         if (typeof claims.buzzBudget !== 'number' || claims.buzzBudget <= 0) {
           throw forbidden('ai:write:budgeted requires positive buzzBudget claim');
-        }
-        break;
-      }
-      case 'block:settings:read':
-      case 'block:settings:write': {
-        const requested = readBoundQueryString(req, 'blockInstanceId');
-        if (!requested || requested !== claims.blockInstanceId) {
-          throw forbidden(`${scope} bound to different blockInstanceId`);
         }
         break;
       }

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -4464,10 +4464,16 @@ describe('blocks.updateUserSettings — W13 action detail', () => {
     expect(BlockRegistry.upsertUserSettings).toHaveBeenCalled();
 
     await vi.waitFor(() => expect(vi.mocked(recordScopeInvocation)).toHaveBeenCalled());
-    expect(vi.mocked(recordScopeInvocation).mock.calls[0][0]).toMatchObject({
-      scope: 'block:settings:write',
+    // The audit row must NOT assert `block:settings:write` — that scope was
+    // decorative/unenforced (never checked here) and has been removed. The row
+    // labels the action itself (matching `endpoint`) instead of lying about a
+    // token scope that was never verified.
+    const auditArg = vi.mocked(recordScopeInvocation).mock.calls[0][0];
+    expect(auditArg).toMatchObject({
+      scope: 'user-settings:write',
       endpoint: 'user-settings:write',
       detail: { action: 'settings.update', outcome: 'ok' },
     });
+    expect(auditArg.scope).not.toBe('block:settings:write');
   });
 });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -4303,7 +4303,12 @@ export const blocksRouter = router({
           userId,
           appBlockId: claims.appBlockId,
           blockInstanceId: claims.blockInstanceId,
-          scope: 'block:settings:write',
+          // This write is authorized by valid-token + app-developer + installer
+          // resolution above — NOT by a token block-scope. The audit row must not
+          // assert a scope that was never checked, so it labels the ACTION itself
+          // (matching `endpoint`) rather than claiming a `block:settings:write`
+          // scope (that scope was decorative/unenforced and has been removed).
+          scope: 'user-settings:write',
           endpoint: 'user-settings:write',
           statusCode: 200,
           // W13 richer detail — structured code for the render-time sentence.

--- a/src/server/services/__tests__/block-manifest-validator.service.test.ts
+++ b/src/server/services/__tests__/block-manifest-validator.service.test.ts
@@ -245,6 +245,26 @@ describe('BlockManifestValidator', () => {
     }
   });
 
+  // Deprecation: the removed decorative scopes are now UNKNOWN, so a NEW/edited
+  // manifest declaring one is rejected at registration/edit time (intended — an
+  // existing approved app that historically declared one degrades gracefully at
+  // MINT instead; see the block-tokens mint graceful-drop test).
+  it.each([['media:read:owned'], ['block:settings:read'], ['block:settings:write']])(
+    'rejects a manifest declaring the removed decorative scope %s',
+    (removed) => {
+      const manifest = { ...VALID_MANIFEST, scopes: [removed] };
+      const result = BlockManifestValidator.validate(manifest, TokenScope.Full);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(
+          result.errors.some(
+            (e) => e.includes('not a known block scope') && e.includes(removed)
+          )
+        ).toBe(true);
+      }
+    }
+  );
+
   it('accepts the known SKIP_OAUTH_CHECK scope apps:storage:read', () => {
     // apps:storage:read maps to SKIP_OAUTH_CHECK, so it passes the OAuth-bit gate
     // regardless of the client bitmask — but it must still be a KNOWN scope.

--- a/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
@@ -49,13 +49,13 @@ const AI_WRITE_BIT = 1 << 15;
 
 const FULL_SOURCE = [
   'models:read:self',
-  'media:read:owned',
+  'media:read:owned', // REMOVED decorative scope — now unknown → always stripped
   'ai:write:budgeted',
   'apps:storage:read',
   'apps:storage:write',
   'social:tip:self', // money-OUT — in NO allowlist, always stripped
   'buzz:read:self', // own-ledger READ — in both dev allowlists, NOT the review one
-  'block:settings:read', // not in either dev allowlist
+  'block:settings:read', // REMOVED decorative scope — now unknown → always stripped
   'totally:fake:scope', // unknown
 ];
 
@@ -70,7 +70,6 @@ describe('clampDevScopes', () => {
     expect(granted).toEqual([
       'ai:write:budgeted',
       'buzz:read:self',
-      'media:read:owned',
       'models:read:self',
       'user:read:self',
     ]);
@@ -80,6 +79,9 @@ describe('clampDevScopes', () => {
     // buzz:read:self (own-ledger read) survives; social:tip:self (money OUT) never does.
     expect(granted).toContain('buzz:read:self');
     expect(granted).not.toContain('social:tip:self');
+    // Removed decorative scopes are unknown → stripped by step (a) of the clamp.
+    expect(granted).not.toContain('media:read:owned');
+    expect(granted).not.toContain('block:settings:read');
   });
 
   it('DEV (bearer) allowlist KEEPS apps:storage:* — the tunnel-vs-bearer difference is exactly storage', () => {
@@ -203,7 +205,7 @@ describe('clampDevScopes — REVIEW_MINT_SCOPE_ALLOWLIST (mod review sandbox #28
   // + shared storage, private collections, real-money tip, and financial read.
   const MALICIOUS_MANIFEST_SCOPES = [
     'models:read:self',
-    'media:read:owned',
+    'media:read:owned', // removed decorative scope — unknown → stripped
     'collections:read:self',
     'ai:write:budgeted',
     'apps:storage:read',
@@ -226,12 +228,12 @@ describe('clampDevScopes — REVIEW_MINT_SCOPE_ALLOWLIST (mod review sandbox #28
     // ONLY the render-only survivors (+ the unconditional user:read:self grant).
     expect(granted).toEqual([
       'collections:read:self',
-      'media:read:owned',
       'models:read:self',
       'user:read:self',
     ]);
     // None of the withheld scopes can EVER reach the review JWT.
     for (const withheld of [
+      'media:read:owned', // removed decorative scope — unknown → stripped
       'ai:write:budgeted',
       'apps:storage:read',
       'apps:storage:write',

--- a/src/server/services/blocks/__tests__/publish-request.mintReviewToken.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.mintReviewToken.test.ts
@@ -106,11 +106,11 @@ describe('mintReviewBlockToken', () => {
     const scopes = arg.scopes as string[];
     expect(scopes).toEqual([
       'collections:read:self',
-      'media:read:owned',
       'models:read:self',
       'user:read:self',
     ]);
     for (const withheld of [
+      'media:read:owned', // removed decorative scope — unknown → stripped
       'ai:write:budgeted',
       'apps:storage:read',
       'apps:storage:write',

--- a/src/server/services/blocks/__tests__/scope-grant.service.test.ts
+++ b/src/server/services/blocks/__tests__/scope-grant.service.test.ts
@@ -8,7 +8,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
  *   - recordScopeGrant: additive (existing grants persist), un-revokes,
  *     idempotent on the (user, app_block) unique index, P2002-race-safe
  *   - partitionByConsent: granted scopes sign; ungranted withheld; exempt
- *     scopes (block:settings:*, apps:storage:*) always sign
+ *     scopes (apps:storage:*, models:read:self, collections:read:self/write:self)
+ *     always sign
  */
 
 const { mockDb } = vi.hoisted(() => {
@@ -136,18 +137,33 @@ describe('scope-grant.service', () => {
       expect(missing).toEqual(['ai:write:budgeted']);
     });
 
-    it('always signs consent-exempt scopes (block:settings:*, apps:storage:*, models:read:self)', async () => {
+    it('always signs consent-exempt scopes (apps:storage:*, models:read:self)', async () => {
       const { partitionByConsent } = await import('../scope-grant.service');
       const { signable, missing } = partitionByConsent(
-        ['block:settings:read', 'apps:storage:write', 'models:read:self'],
+        ['apps:storage:read', 'apps:storage:write', 'models:read:self'],
         new Set() // user granted nothing
       );
       // models:read:self is consent-exempt (allow-by-default, 01ea90441), so all
-      // three sign with no grant and nothing is withheld.
+      // three sign with no grant and nothing is withheld. (block:settings:* was
+      // removed from the exempt set alongside the scope's removal from the registry.)
       expect(new Set(signable)).toEqual(
-        new Set(['block:settings:read', 'apps:storage:write', 'models:read:self'])
+        new Set(['apps:storage:read', 'apps:storage:write', 'models:read:self'])
       );
       expect(missing).toEqual([]);
+    });
+
+    it('does NOT exempt the removed block:settings:* scopes (footgun guard)', async () => {
+      // block:settings:read/write were dropped from CONSENT_EXEMPT_SCOPES when the
+      // scopes were removed from the registry. If either is ever re-added to the
+      // registry it must NOT be silently consent-exempt — it must flow through the
+      // gate (→ `missing`) unless an explicit grant/exemption decision is made.
+      const { partitionByConsent } = await import('../scope-grant.service');
+      const { signable, missing } = partitionByConsent(
+        ['block:settings:read', 'block:settings:write'],
+        new Set() // user granted nothing
+      );
+      expect(signable).toEqual([]);
+      expect(new Set(missing)).toEqual(new Set(['block:settings:read', 'block:settings:write']));
     });
 
     it('signs the SHARED storage scopes WITHOUT any grant (governed by resolveSharedContext, not consent)', async () => {
@@ -182,12 +198,11 @@ describe('scope-grant.service', () => {
     it('drops the consent-exempt scopes so the implicit grant only stores gated ones', async () => {
       const { consentGatedScopes } = await import('../scope-grant.service');
       // models:read:self is consent-exempt (01ea90441), so it's dropped here
-      // alongside block:settings:* / apps:storage:* — only ai:write:budgeted is
-      // gated and kept.
+      // alongside apps:storage:* — only ai:write:budgeted is gated and kept.
       expect(
         consentGatedScopes([
           'models:read:self',
-          'block:settings:read',
+          'apps:storage:write',
           'apps:storage:read',
           'ai:write:budgeted',
         ])

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -55,13 +55,11 @@ export const FORCED_SFW_CEILING = domainBrowsingCeiling(null);
 /**
  * The BEARER dev-token allowlist (scope doc §4.1): read/catalog scopes + the page
  * spend scope + per-app storage. Used by `/api/v1/blocks/dev-token` only.
- * DELIBERATELY EXCLUDES `social:tip:self` (real money OUT) and
- * `block:settings:read` / `block:settings:write` (installer-only). A requested /
+ * DELIBERATELY EXCLUDES `social:tip:self` (real money OUT). A requested /
  * approved scope outside this set is STRIPPED (defense-in-depth).
  */
 export const DEV_TOKEN_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
   'models:read:self',
-  'media:read:owned',
   'user:read:self',
   'ai:write:budgeted',
   'apps:storage:read',
@@ -110,7 +108,6 @@ export const DEV_TOKEN_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
  */
 export const TUNNEL_HOST_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
   'models:read:self',
-  'media:read:owned',
   'user:read:self',
   'ai:write:budgeted',
   // collections:* — INCLUDED here too (see DEV_TOKEN_SCOPE_ALLOWLIST rationale):
@@ -136,7 +133,6 @@ export const TUNNEL_HOST_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<str
  *
  * KEEP (render-only survivors, all self-bound reads):
  *   - `models:read:self`   the caller's own models (self-bound)
- *   - `media:read:owned`   the caller's own media
  *   - `user:read:self`     the caller's own identity (also force-granted post-clamp)
  *   - `collections:read:self` own-PUBLIC + any PUBLIC collection (no per-app namespace)
  *
@@ -159,7 +155,6 @@ export const TUNNEL_HOST_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<str
  */
 export const REVIEW_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
   'models:read:self',
-  'media:read:owned',
   'user:read:self',
   'collections:read:self',
 ]);
@@ -169,8 +164,8 @@ export const REVIEW_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>(
  * Start from `scopeSource` (the app's approved snapshot, an owned pending request's
  * un-reviewed `manifest.scopes`, or the caller's self-declared body scopes) and:
  *   a) keep only KNOWN block scopes,
- *   b) keep only scopes within `allowlist` (excludes social:tip:self +
- *      block:settings:* always; for the tunnel allowlist also apps:storage:*),
+ *   b) keep only scopes within `allowlist` (excludes social:tip:self always;
+ *      for the tunnel allowlist also apps:storage:*),
  *   c) keep only scopes within the app's OAuth ceiling (approved path only —
  *      `oauthAllowed !== null`); OMITTED for a pending / no-row / ephemeral app
  *      (no OauthClient — passing 0 would WRONGLY strip every non-skip scope),

--- a/src/server/services/blocks/scope-descriptions.constants.ts
+++ b/src/server/services/blocks/scope-descriptions.constants.ts
@@ -20,12 +20,9 @@
 export const SCOPE_DESCRIPTIONS: Record<string, string> = {
   'user:read:self': "Read the viewer's username and account status",
   'models:read:self': 'Read the model on the page where the block is mounted',
-  'media:read:owned': "Read the viewer's own uploaded media",
   'buzz:read:self': "Read the viewer's Buzz balance",
   'ai:write:budgeted': 'Submit generations with a per-call Buzz cap',
   'social:tip:self': 'Post tips on behalf of the viewer',
-  'block:settings:read': "Read this block's per-install settings",
-  'block:settings:write': "Update this block's per-install settings",
   'apps:storage:read': "Read this app's private per-install data store",
   'apps:storage:write': "Write to this app's private per-install data store",
   'apps:storage:shared:read': "Read this app's shared, community-wide data (e.g. everyone's posts + vote counts)",

--- a/src/server/services/blocks/scope-grant.service.ts
+++ b/src/server/services/blocks/scope-grant.service.ts
@@ -114,12 +114,11 @@ export async function recordScopeGrant(opts: {
  * granted scopes, returning the granted subset to sign + the withheld scopes
  * the host must re-consent for.
  *
- * `block:settings:*` and `apps:storage:*` (per-user KV) are intentionally NOT
- * consent-gated here — they are publisher-only / ambient-but-otherwise-gated
- * scopes that have their own issuance-time checks (caller-is-installer,
- * resolveStorageContext). Subjecting them to per-user consent would make the
- * publisher re-consent to their own block's settings on every version bump for
- * no security gain. The remaining user-resource scopes (media/user/ai/buzz/
+ * `apps:storage:*` (per-user KV) is intentionally NOT consent-gated here — it is
+ * an ambient-but-otherwise-gated scope with its own issuance-time / per-op check
+ * (resolveStorageContext). Subjecting it to per-user consent would make the
+ * publisher re-consent to their own block's storage on every version bump for
+ * no security gain. The remaining user-resource scopes (user/ai/buzz/
  * social, models:write) flow through the consent gate.
  *
  * `apps:storage:shared:read` / `apps:storage:shared:write` (the SHARED, app-
@@ -166,8 +165,11 @@ export async function recordScopeGrant(opts: {
  * exemption above: read:self always mints; read:private mints only after consent.)
  */
 const CONSENT_EXEMPT_SCOPES = new Set([
-  'block:settings:read',
-  'block:settings:write',
+  // NOTE: block:settings:* is intentionally ABSENT — those scopes were removed
+  // from the block-scope registry (decorative/unenforced). Do NOT re-add them
+  // here: if a settings scope is ever reintroduced it must be reintroduced WITH
+  // an explicit consent decision, not silently exempted (a stale exempt entry
+  // would mint it consent-free the moment it re-entered the registry).
   'apps:storage:read',
   'apps:storage:write',
   // SHARED (cross-user) storage — governed by resolveSharedContext's server-side

--- a/src/shared/constants/__tests__/block-scope.constants.test.ts
+++ b/src/shared/constants/__tests__/block-scope.constants.test.ts
@@ -14,8 +14,7 @@ describe('block-scope.constants', () => {
   it('maps known scopes to the right bits', () => {
     expect(BLOCK_SCOPE_TO_OAUTH_BIT['models:read:self']).toBe(TokenScope.ModelsRead);
     expect(BLOCK_SCOPE_TO_OAUTH_BIT['ai:write:budgeted']).toBe(TokenScope.AIServicesWrite);
-    // settings + storage scopes intentionally have no OAuth bit (SKIP sentinel).
-    expect(BLOCK_SCOPE_TO_OAUTH_BIT['block:settings:read']).toBe(SKIP_OAUTH_CHECK);
+    // storage scopes intentionally have no OAuth bit (SKIP sentinel).
     expect(BLOCK_SCOPE_TO_OAUTH_BIT['apps:storage:read']).toBe(SKIP_OAUTH_CHECK);
     expect(BLOCK_SCOPE_TO_OAUTH_BIT['apps:storage:write']).toBe(SKIP_OAUTH_CHECK);
   });
@@ -27,6 +26,20 @@ describe('block-scope.constants', () => {
     expect(isKnownBlockScope('apps:storage:write')).toBe(true);
   });
 
+  it('the removed decorative scopes are no longer known (deprecated)', () => {
+    // media:read:owned / block:settings:read / block:settings:write were
+    // declared/validated/mintable but had NO runtime capability that checked
+    // them (purely decorative), so they were removed from the vocabulary. A
+    // manifest declaring them now fails validation, and a token carrying one is
+    // denied at the runtime gate — see the middleware + validator tests.
+    expect(isKnownBlockScope('media:read:owned')).toBe(false);
+    expect(isKnownBlockScope('block:settings:read')).toBe(false);
+    expect(isKnownBlockScope('block:settings:write')).toBe(false);
+    expect('media:read:owned' in BLOCK_SCOPE_TO_OAUTH_BIT).toBe(false);
+    expect('block:settings:read' in BLOCK_SCOPE_TO_OAUTH_BIT).toBe(false);
+    expect('block:settings:write' in BLOCK_SCOPE_TO_OAUTH_BIT).toBe(false);
+  });
+
   it('isKnownBlockScope rejects unknown strings', () => {
     expect(isKnownBlockScope('models:read:self')).toBe(true);
     expect(isKnownBlockScope('not:a:scope')).toBe(false);
@@ -34,9 +47,9 @@ describe('block-scope.constants', () => {
 
   describe('validateBlockScopesAgainstOauthClient', () => {
     it('passes when every requested scope has its bit', () => {
-      const allowed = TokenScope.ModelsRead | TokenScope.MediaRead;
+      const allowed = TokenScope.ModelsRead | TokenScope.UserRead;
       const result = validateBlockScopesAgainstOauthClient(
-        ['models:read:self', 'media:read:owned'],
+        ['models:read:self', 'user:read:self'],
         allowed
       );
       expect(result.valid).toBe(true);
@@ -55,8 +68,20 @@ describe('block-scope.constants', () => {
     });
 
     it('accepts no-bit scopes regardless of bitmask', () => {
-      const result = validateBlockScopesAgainstOauthClient(['block:settings:read'], 0);
+      const result = validateBlockScopesAgainstOauthClient(['apps:storage:read'], 0);
       expect(result.valid).toBe(true);
+    });
+
+    it('rejects the removed decorative scopes as unknown', () => {
+      for (const removed of [
+        'media:read:owned',
+        'block:settings:read',
+        'block:settings:write',
+      ]) {
+        const result = validateBlockScopesAgainstOauthClient([removed], TokenScope.Full);
+        expect(result.valid).toBe(false);
+        expect(result.rejectedScopes).toEqual([removed]);
+      }
     });
 
     it('rejects unknown scopes outright', () => {
@@ -99,10 +124,10 @@ describe('block-scope.constants', () => {
     });
 
     it('SKIP_OAUTH_CHECK scopes contribute no bits', () => {
-      // block:settings:* + apps:storage:* are gated elsewhere, not via the bit.
+      // apps:storage:* are gated elsewhere (per-op server-side), not via the bit.
       expect(
         deriveOauthBitmaskFromBlockScopes([
-          'block:settings:read',
+          'apps:storage:read',
           'apps:storage:write',
         ])
       ).toBe(0);

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -11,15 +11,15 @@
  *      to defend against post-approval manifest swaps (audit H-1 + C2).
  *
  * Block JWT scopes are a different concept from the underlying OAuth bits:
- * they're per-block-instance and short-lived (15min / 5min for settings).
- * The OAuth bit on the publisher's app is the policy ceiling. A scope
- * with `SKIP_OAUTH_CHECK` (e.g. block:settings:*) gates elsewhere — see
- * the issuance-time caller-is-installer check.
+ * they're per-block-instance and short-lived (15min). The OAuth bit on the
+ * publisher's app is the policy ceiling. A scope with `SKIP_OAUTH_CHECK`
+ * (e.g. apps:storage:*) gates elsewhere — see the per-op server-side checks
+ * (resolveStorageContext / resolveSharedContext).
  *
  * Forward-extensibility contract:
  *   - New block scopes MUST be added here with their OAuth-bit relationship.
  *   - A scope that intentionally has no bitmask requirement (e.g.
- *     block:settings:*) uses the `SKIP_OAUTH_CHECK` sentinel — NOT a 0
+ *     apps:storage:*) uses the `SKIP_OAUTH_CHECK` sentinel — NOT a 0
  *     value. The sentinel is explicit so a future maintainer doesn't
  *     accidentally type 0 and get OAuth-allowlist bypass by surprise.
  */
@@ -29,7 +29,7 @@ import { TokenScope } from './token-scope.constants';
 /**
  * Sentinel value for scopes that intentionally do not require an OAuth-bitmask
  * bit. The validator treats this as "approval gate elsewhere" (e.g. the
- * issuance-time caller-is-installer check for block:settings:*).
+ * per-op server-side checks for apps:storage:*).
  */
 export const SKIP_OAUTH_CHECK = Symbol('SKIP_OAUTH_CHECK');
 export type ScopeBitmaskRequirement = number | typeof SKIP_OAUTH_CHECK;
@@ -45,14 +45,22 @@ export const BLOCK_SCOPE_TO_OAUTH_BIT: Record<string, ScopeBitmaskRequirement> =
   // declarable+grantable scope added friction (Go CLI manifest validator + each
   // app's OauthClient.allowedScopes bit) with no security value, since the
   // catalog is strictly MORE restricted than the public /api/v1/models.
-  'media:read:owned': TokenScope.MediaRead,
+  // NOTE: there is intentionally NO `media:read:owned` block scope. It was
+  // declared/validated/mintable but had NO runtime consumer that ever checked
+  // it (no block-token endpoint gated on it), so it was purely decorative and
+  // was removed as part of the "every declared block scope is actually
+  // enforced" hygiene pass. The underlying OAuth `TokenScope.MediaRead` bit is
+  // UNCHANGED — it still backs ~80 tRPC media routes (image/post/comment/…) via
+  // `requiredScope`; it simply no longer maps to a block scope.
   'user:read:self': TokenScope.UserRead,
   'ai:write:budgeted': TokenScope.AIServicesWrite,
   'buzz:read:self': TokenScope.BuzzRead,
-  // block:settings:* relies on the issuance-time caller-is-installer gate
-  // (audit C8) instead of an OAuth bit. SKIP_OAUTH_CHECK makes that explicit.
-  'block:settings:read': SKIP_OAUTH_CHECK,
-  'block:settings:write': SKIP_OAUTH_CHECK,
+  // NOTE: there is intentionally NO `block:settings:read` / `block:settings:write`
+  // block scope. Both were declared/validated/mintable but NO runtime capability
+  // ever verified them (the per-install settings read/write paths authorize on
+  // valid-token + app-developer + installer-resolution, not on a token scope), so
+  // they were purely decorative and were removed in the same hygiene pass. There is
+  // no OAuth bit to orphan — they used SKIP_OAUTH_CHECK, not a TokenScope bit.
   'social:tip:self': TokenScope.SocialTip,
   // apps:storage:* — the W4 KV datastore. There is no OAuth bitmask bit for
   // per-app storage (it never touches the user's civitai resources via the
@@ -169,7 +177,7 @@ export function isAppBlockOauthClientId(clientId: string | null | undefined): bo
  * inert (any manifest scope was always within the all-bits ceiling).
  *
  * The bitmask is the OR of the OAuth bits each known scope maps to. Scopes
- * with `SKIP_OAUTH_CHECK` (block:settings:*, apps:storage:*) and unknown
+ * with `SKIP_OAUTH_CHECK` (apps:storage:*) and unknown
  * scopes contribute nothing — they are gated by other mechanisms, not the
  * OAuth bitmask. Result is therefore the *intersection* of the manifest with
  * the OAuth-eligible scope set, exactly what the validator / token-mint path

--- a/src/tests/api/v1/block-tokens/index.test.ts
+++ b/src/tests/api/v1/block-tokens/index.test.ts
@@ -332,45 +332,33 @@ describe('POST /api/v1/block-tokens', () => {
     expect(mockTokenService.sign).not.toHaveBeenCalled();
   });
 
-  it('C8: block:settings:* tokens require caller == installer', async () => {
+  it('graceful drop: a removed/unknown scope in the approved snapshot does NOT 403 — it is dropped and the other scopes still mint', async () => {
+    // A legacy app approved BEFORE `block:settings:*` (and `media:read:owned`)
+    // were removed from the block-scope vocabulary still has them in its stored
+    // manifest + approved snapshot. Removing them from the known set must NOT
+    // break its mint: the now-unknown scope is dropped (it carried no capability)
+    // and the app keeps minting its remaining enforced scope.
     mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
       ...RESOLVED_INSTALL,
       appBlock: {
         ...RESOLVED_INSTALL.appBlock,
-        manifest: { scopes: ['block:settings:read'] },
-        approvedScopes: ['block:settings:read'],
+        manifest: { scopes: ['models:read:self', 'block:settings:read'] },
+        approvedScopes: ['models:read:self', 'block:settings:read'],
+        app: { allowedScopes: 4 /* ModelsRead bit set */ },
       },
     });
-    // Mod-but-not-installer: passes the Phase-2 isModerator mint-gate so the
-    // assertion exercises the installer check (caller 999 != installer 42),
-    // not the upstream mod-gate.
-    mockSession.value = { user: { id: 999, bannedAt: null, isModerator: true } } as never; // not the installer (42)
-    mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: null, bannedAt: null });
-    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
-    const res = makeRes();
-    await handler(makeReq({ origin: 'https://civitai.com', body: validBody() }), res);
-    expect(res._status).toBe(403);
-    expect((res._body as { error: string }).error).toMatch(/installer/);
-    expect(mockTokenService.sign).not.toHaveBeenCalled();
-  });
-
-  it('C8: block:settings:* tokens succeed when caller == installer', async () => {
-    mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
-      ...RESOLVED_INSTALL,
-      appBlock: {
-        ...RESOLVED_INSTALL.appBlock,
-        manifest: { scopes: ['block:settings:read'] },
-        approvedScopes: ['block:settings:read'],
-      },
-    });
-    // == installedByUserId; mod gate satisfied (App Blocks is mod-only today).
     mockSession.value = { user: { id: 42, bannedAt: null, isModerator: true } } as never;
     mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: null, bannedAt: null });
     const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
     const res = makeRes();
     await handler(makeReq({ origin: 'https://civitai.com', body: validBody() }), res);
+    // NOT a 403 — the removed scope is dropped gracefully rather than rejected.
     expect(res._status).toBe(200);
-    expect(mockTokenService.sign).toHaveBeenCalled();
+    const signArgs = mockTokenService.sign.mock.calls.at(-1)?.[0] as { scopes: string[] };
+    // models:read:self is consent-exempt (allow-by-default) so it signs; the
+    // removed block:settings:read is omitted from the JWT entirely.
+    expect(signArgs.scopes).toEqual(['models:read:self']);
+    expect(signArgs.scopes).not.toContain('block:settings:read');
   });
 
   it('scope allowlist: rejects when manifest carries scopes the OauthClient doesnt allow', async () => {
@@ -564,14 +552,14 @@ describe('POST /api/v1/block-tokens', () => {
     expect(new Set(body.missingScopes)).toEqual(new Set(['buzz:read:self']));
   });
 
-  it('A6: consent-exempt scopes (block:settings:*) sign even with no grant', async () => {
+  it('A6: consent-exempt scopes (apps:storage:*) sign even with no grant', async () => {
     mockSession.value = { user: { id: 42, bannedAt: null, isModerator: true } } as never;
     mockBlockRegistry.resolveBlockInstance.mockResolvedValue({
       ...RESOLVED_INSTALL,
       appBlock: {
         ...RESOLVED_INSTALL.appBlock,
-        manifest: { scopes: ['block:settings:read'] },
-        approvedScopes: ['block:settings:read'],
+        manifest: { scopes: ['apps:storage:read'] },
+        approvedScopes: ['apps:storage:read'],
         app: { allowedScopes: 4 },
       },
     });
@@ -581,7 +569,7 @@ describe('POST /api/v1/block-tokens', () => {
     await handler(makeReq({ origin: 'https://civitai.com', body: validBody() }), res);
     expect(res._status).toBe(200);
     const signArgs = mockTokenService.sign.mock.calls.at(-1)?.[0] as { scopes: string[] };
-    expect(signArgs.scopes).toEqual(['block:settings:read']);
+    expect(signArgs.scopes).toEqual(['apps:storage:read']);
     const body = res._body as { needsConsent: boolean };
     expect(body.needsConsent).toBe(false);
   });


### PR DESCRIPTION
## What / why

Security-hygiene pass on App Block scopes. Three scopes were **declared, validated, mapped, and mintable but never enforced by any runtime capability** — purely decorative:

- `media:read:owned`
- `block:settings:read`
- `block:settings:write`

None was an exploitable bypass (their "capabilities" were never wired as block-token endpoints), but the mod-review UI implied they were enforced and one audit-log path asserted an unchecked scope. After this change **every remaining declared block scope is one that is actually enforced per-operation server-side.**

## Changes

**Remove the 3 scopes**
- Drop the entries from `BLOCK_SCOPE_TO_OAUTH_BIT` (the authoritative registry) + `SCOPE_DESCRIPTIONS` (mod-review / installed UI) + the `scopes` enum in `public/schemas/app-block/v1.json` (order preserved so the schema⇄registry drift-guard stays green).
- Because `isKnownBlockScope` derives from the registry, a **new/edited** manifest declaring one of these is now rejected as unknown (intended deprecation), and the `enforceContextBinding` runtime cases become unreachable — removed (deny-by-default `default` retained). `media:read:owned` also dropped from the dev / tunnel / mod-review mint allowlists.
- **No OAuth bit orphaned:** `TokenScope.MediaRead` is unchanged and still backs ~80 tRPC media routes via `requiredScope`; it simply no longer maps to a block scope. The settings scopes used `SKIP_OAUTH_CHECK`, not a bit.

**Fix audit-log that asserted an unchecked scope**
- `updateUserSettings` logged the invocation as `scope: 'block:settings:write'` although the token was **never checked** for it (the write is gated by valid-token + app-developer + installer resolution). Relabel the audit row to `user-settings:write` (matching `endpoint`) so it stops asserting a scope that was never verified. No new enforcement gate added.

**Fix misleading mod-review tooltip**
- Was "…enforced at token issuance." Corrected to state scopes are enforced **per-operation server-side** — every capability re-verifies the token and checks the required scope before it runs.

## Legacy apps degrade gracefully (no break)

An already-approved app whose stored manifest / approved snapshot lists a removed scope must not break. The mint path (`POST /api/v1/block-tokens`) previously ran the OAuth-ceiling check on the **raw** manifest scopes, so a now-unknown scope would have **403'd the entire mint**. Fixed: filter to known scopes **before** the OAuth + approved-snapshot gates — the removed scope is dropped (it carried no capability and is never signed into the JWT) and the app keeps minting its remaining scopes. Capability-bearing (known) scopes are still fully gated (OAuth ceiling + approved snapshot + per-user consent).

Code path for a legacy app that declared, e.g., `models:read:self` + `block:settings:read`: `rawManifestScopes → filter(isKnownBlockScope) → ['models:read:self']` → OAuth/approved checks pass → JWT signed with `['models:read:self']`, `block:settings:read` omitted, HTTP 200 (no 403).

## Test evidence (all green)

- **Validator:** each removed scope is now rejected as unknown; the remaining 12 scopes still validate.
- **Mint graceful-drop:** an app whose approved snapshot lists a removed scope mints **200** and omits it from the JWT while other scopes still mint (does not throw/403).
- **Audit-log:** `updateUserSettings` no longer emits `block:settings:write` (asserts `user-settings:write`).
- **Runtime gate:** `enforceContextBinding` denies the removed scopes (deny-by-default), even for an authed subject that used to satisfy the old `block:settings` binding.
- Scope-set / schema-drift / dev-mint allowlist / review-mint snapshots updated intentionally.

```
block-scope.constants.test.ts ........... 17 passed
block-scope.schema-drift.test.ts .........  3 passed
block-manifest-validator.service.test.ts  134 passed (+3 removed-scope cases)
block-scope.middleware.test.ts .......... 32 passed
dev-scoped-mint.service.test.ts ......... 17 passed
publish-request.mintReviewToken.test.ts ..  4 passed
block-tokens/index.test.ts .............. 30 passed (incl. graceful-drop)
blocks.router.workflow.test.ts .......... 185 passed (incl. audit-log)
block-token.service.test.ts ............. 18 passed
scope-grant / dev-token / updateManifest* / collections-scope-plumbing — passed
```

`tsc --noEmit`: 0 errors in changed files (the only reported error is a pre-existing, unrelated environmental `@types/react-dom/test-utils` resolution in `useTrackEvent.wiring.test.ts`, untouched here).

## Follow-up (out of scope, non-blocking)

- The `scopes` list in `public/schemas/app-block/v1.json` changed, so the **Go CLI's vendored copy of the schema** (and any app-sdk byte-mirror) should be re-vendored to match. The in-repo schema⇄registry drift-guard covers this repo only.
- A few now-**inert** references to the removed scopes remain as harmless defense-in-depth / backward-compatible display maps (the mint installer-gate, the settings-token TTL branch, and the historical audit/activity label maps). They can never fire in production (the scopes are filtered upstream) and are annotated as such; removing them is optional cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
