### PR TITLE
fix(storage): deregister file_locations on bulk model/version deletes

### DIFF
--- a/src/server/jobs/__tests__/remove-old-drafts.test.ts
+++ b/src/server/jobs/__tests__/remove-old-drafts.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockDbRead, mockDbWrite, mockDeregisterBatch, calls } = vi.hoisted(() => ({
+const { mockDbRead, mockDbWrite, mockDeregisterBatch, mockLogToAxiom, calls } = vi.hoisted(() => ({
   mockDbRead: { $queryRaw: vi.fn() },
   mockDbWrite: { $queryRaw: vi.fn(), $executeRaw: vi.fn() },
   mockDeregisterBatch: vi.fn(() => Promise.resolve({ deleted: 0 })),
+  // Tracked so we can assert the per-batch error path fired (the job's internal
+  // errorCount has no external surface other than this Axiom error log).
+  mockLogToAxiom: vi.fn(),
   // Ordered log of the side effects we care about, so we can assert the
   // versionId collection happens BEFORE the delete and deregister happens AFTER.
   calls: [] as string[],
@@ -11,7 +14,7 @@ const { mockDbRead, mockDbWrite, mockDeregisterBatch, calls } = vi.hoisted(() =>
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
 vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: mockDeregisterBatch }));
-vi.mock('~/server/logging/client', () => ({ logToAxiom: () => undefined }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
 vi.mock('~/utils/logging', () => ({ createLogger: () => () => undefined }));
 vi.mock('~/server/jobs/job', () => ({ createJob: (_n: string, _c: string, fn: unknown) => fn }));
 
@@ -66,5 +69,68 @@ describe('removeOldDrafts', () => {
 
     expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
     expect(mockDeregisterBatch).not.toHaveBeenCalled();
+  });
+
+  it('does not deregister a batch whose delete fails, counts the error, and continues', async () => {
+    // 11 models → two batches (BATCH_SIZE=10): [1..10] then [11].
+    const modelIds = Array.from({ length: 11 }, (_, i) => i + 1);
+    mockDbRead.$queryRaw.mockResolvedValue(modelIds.map((id) => ({ id })));
+
+    // Per-batch version lookup — return ids keyed off which batch is asked for.
+    mockDbWrite.$queryRaw.mockImplementation(async (_strings: unknown, batch: number[]) =>
+      batch.includes(1) ? [{ id: 100 }, { id: 101 }] : [{ id: 200 }]
+    );
+    // The DELETE FROM "Model" rejects for the FIRST batch only; the second succeeds.
+    mockDbWrite.$executeRaw.mockImplementation(async (_strings: unknown, batch: number[]) => {
+      if (batch.includes(1)) throw new Error('deadlock detected');
+      return 1;
+    });
+
+    // Job must not throw out — a failed batch is caught and the loop continues.
+    await expect(
+      (removeOldDrafts as unknown as () => Promise<void>)()
+    ).resolves.toBeUndefined();
+
+    // The failed batch's versions ([100, 101]) are NEVER deregistered — the delete
+    // never committed, so there are no orphaned file_locations to reap.
+    expect(mockDeregisterBatch).toHaveBeenCalledTimes(1);
+    expect(mockDeregisterBatch).toHaveBeenCalledWith([200]);
+    expect(mockDeregisterBatch).not.toHaveBeenCalledWith([100, 101]);
+
+    // errorCount increments → surfaced as the batch-failure Axiom error log.
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        name: 'remove-old-drafts',
+        message: 'Failed to remove batch of old draft models',
+      })
+    );
+  });
+
+  it('scopes each batch to its own version ids with no cross-batch bleed', async () => {
+    // 11 models → two batches (BATCH_SIZE=10): [1..10] then [11].
+    const modelIds = Array.from({ length: 11 }, (_, i) => i + 1);
+    mockDbRead.$queryRaw.mockResolvedValue(modelIds.map((id) => ({ id })));
+
+    // Each batch's ModelVersion SELECT returns a disjoint set of version ids.
+    mockDbWrite.$queryRaw.mockImplementation(async (_strings: unknown, batch: number[]) =>
+      batch.includes(1) ? [{ id: 1000 }, { id: 1001 }] : [{ id: 2000 }]
+    );
+    mockDbWrite.$executeRaw.mockResolvedValue(1);
+
+    await (removeOldDrafts as unknown as () => Promise<void>)();
+
+    // The version SELECT is scoped to exactly one batch of model ids per call.
+    const selectBatches = mockDbWrite.$queryRaw.mock.calls.map((c) => c[1] as number[]);
+    expect(selectBatches).toEqual([
+      Array.from({ length: 10 }, (_, i) => i + 1),
+      [11],
+    ]);
+
+    // Deregister runs once per batch, each with only that batch's version ids —
+    // no cross-batch bleed (batch 1's [1000,1001] and batch 2's [2000] never mix).
+    expect(mockDeregisterBatch).toHaveBeenCalledTimes(2);
+    expect(mockDeregisterBatch).toHaveBeenNthCalledWith(1, [1000, 1001]);
+    expect(mockDeregisterBatch).toHaveBeenNthCalledWith(2, [2000]);
   });
 });

--- a/src/server/jobs/__tests__/remove-old-drafts.test.ts
+++ b/src/server/jobs/__tests__/remove-old-drafts.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDbRead, mockDbWrite, mockDeregisterBatch, calls } = vi.hoisted(() => ({
+  mockDbRead: { $queryRaw: vi.fn() },
+  mockDbWrite: { $queryRaw: vi.fn(), $executeRaw: vi.fn() },
+  mockDeregisterBatch: vi.fn(() => Promise.resolve({ deleted: 0 })),
+  // Ordered log of the side effects we care about, so we can assert the
+  // versionId collection happens BEFORE the delete and deregister happens AFTER.
+  calls: [] as string[],
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: mockDeregisterBatch }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: () => undefined }));
+vi.mock('~/utils/logging', () => ({ createLogger: () => () => undefined }));
+vi.mock('~/server/jobs/job', () => ({ createJob: (_n: string, _c: string, fn: unknown) => fn }));
+
+import { removeOldDrafts } from '~/server/jobs/remove-old-drafts';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  calls.length = 0;
+});
+
+describe('removeOldDrafts', () => {
+  it('collects version ids pre-delete then deregisters them post-delete', async () => {
+    // Replica lookup: one old draft model (id 42).
+    mockDbRead.$queryRaw.mockResolvedValue([{ id: 42 }]);
+    // dbWrite.$queryRaw = the pre-delete version-id lookup.
+    mockDbWrite.$queryRaw.mockImplementation(async () => {
+      calls.push('collect-versions');
+      return [{ id: 100 }, { id: 101 }];
+    });
+    // dbWrite.$executeRaw = the cascade delete.
+    mockDbWrite.$executeRaw.mockImplementation(async () => {
+      calls.push('delete');
+      return 1;
+    });
+    mockDeregisterBatch.mockImplementation(async () => {
+      calls.push('deregister');
+      return { deleted: 2 };
+    });
+
+    await (removeOldDrafts as unknown as () => Promise<void>)();
+
+    // versionIds gathered before the delete, deregister runs after it.
+    expect(calls).toEqual(['collect-versions', 'delete', 'deregister']);
+    expect(mockDeregisterBatch).toHaveBeenCalledWith([100, 101]);
+  });
+
+  it('does not call deregister when a batch has no versions', async () => {
+    mockDbRead.$queryRaw.mockResolvedValue([{ id: 42 }]);
+    mockDbWrite.$queryRaw.mockResolvedValue([]); // no versions on the model
+    mockDbWrite.$executeRaw.mockResolvedValue(1);
+
+    await (removeOldDrafts as unknown as () => Promise<void>)();
+
+    expect(mockDbWrite.$executeRaw).toHaveBeenCalledTimes(1);
+    expect(mockDeregisterBatch).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there are no old drafts to remove', async () => {
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+
+    await (removeOldDrafts as unknown as () => Promise<void>)();
+
+    expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
+    expect(mockDeregisterBatch).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/jobs/remove-old-drafts.ts
+++ b/src/server/jobs/remove-old-drafts.ts
@@ -2,6 +2,7 @@ import { createLogger } from '~/utils/logging';
 import { createJob } from './job';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
+import { deregisterFileLocationsBatch } from '~/utils/storage-resolver';
 import { chunk } from 'lodash-es';
 
 const log = createLogger('remove-old-drafts');
@@ -38,11 +39,40 @@ export const removeOldDrafts = createJob('remove-old-drafts', '43 2 * * *', asyn
   const batches = chunk(modelIds, BATCH_SIZE);
   for (const batch of batches) {
     try {
+      // Collect the version ids BEFORE the cascade nukes the ModelVersion rows —
+      // once the Model delete cascades, this lookup returns nothing. These feed
+      // the post-delete storage-resolver deregister below.
+      const versionRows = await dbWrite.$queryRaw<{ id: number }[]>`
+        SELECT id FROM "ModelVersion" WHERE "modelId" = ANY(${batch})
+      `;
+      const versionIds = versionRows.map((v) => v.id);
+
       await dbWrite.$executeRaw`
         DELETE FROM "Model"
         WHERE id = ANY(${batch})
       `;
       deletedCount += batch.length;
+
+      // Post-delete: deregister storage-resolver file_locations for the reaped
+      // versions. The FK cascade removes ModelVersion/ModelFile rows but leaves
+      // file_locations behind — every leaked row keeps its backend object
+      // whitelisted against the dereference-quarantine sweep, a permanent orphan.
+      // Best-effort by contract (never throws); guard anyway so a future change
+      // can't turn a registry blip into a failed batch.
+      if (versionIds.length > 0) {
+        try {
+          await deregisterFileLocationsBatch(versionIds);
+        } catch (error) {
+          const e = error as Error;
+          logToAxiom({
+            type: 'error',
+            name: 'remove-old-drafts',
+            message: 'Failed to deregister file locations for removed draft versions',
+            error: e.message,
+            stack: e.stack,
+          });
+        }
+      }
     } catch (error) {
       const e = error as Error;
       errorCount += batch.length;

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -107,7 +107,7 @@ import { ingestModelById, updateModelLastVersionAt } from './model.service';
 import { markFileReplaced, filesForModelVersionCache } from './model-file.service';
 import { getBuzzTransactionSupportedAccountTypes } from '~/utils/buzz';
 import { deleteModelFileObjects } from '~/utils/s3-utils';
-import { deregisterFileLocations } from '~/utils/storage-resolver';
+import { deregisterFileLocations, deregisterFileLocationsBatch } from '~/utils/storage-resolver';
 import type { BaseModel, BaseModelGroup } from '~/shared/constants/basemodel.constants';
 import { getBaseModelsByGroup } from '~/shared/constants/basemodel.constants';
 import type { ImageMetadata } from '~/server/schema/media.schema';
@@ -2823,6 +2823,24 @@ export const mergeVersions = async ({
         error,
       });
     }
+  }
+
+  // Post-commit: deregister storage-resolver file_locations for the deleted
+  // source versions. Files were re-pointed to the target in step 2, but any
+  // file_locations rows keyed to a source version survive the cascade and keep
+  // their backend objects whitelisted against the dereference-quarantine sweep.
+  // Best-effort + never throws.
+  try {
+    await deregisterFileLocationsBatch(sourceVersionIds);
+  } catch (error) {
+    logToAxiom({
+      type: 'error',
+      name: 'model-version-merge-deregister-file-locations',
+      message: `Failed to deregister file locations for merged source versions ${sourceVersionIds.join(
+        ', '
+      )}`,
+      error,
+    });
   }
 };
 

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -107,7 +107,7 @@ import { ingestModelById, updateModelLastVersionAt } from './model.service';
 import { markFileReplaced, filesForModelVersionCache } from './model-file.service';
 import { getBuzzTransactionSupportedAccountTypes } from '~/utils/buzz';
 import { deleteModelFileObjects } from '~/utils/s3-utils';
-import { deregisterFileLocations, deregisterFileLocationsBatch } from '~/utils/storage-resolver';
+import { deregisterFileLocations } from '~/utils/storage-resolver';
 import type { BaseModel, BaseModelGroup } from '~/shared/constants/basemodel.constants';
 import { getBaseModelsByGroup } from '~/shared/constants/basemodel.constants';
 import type { ImageMetadata } from '~/server/schema/media.schema';
@@ -2823,24 +2823,6 @@ export const mergeVersions = async ({
         error,
       });
     }
-  }
-
-  // Post-commit: deregister storage-resolver file_locations for the deleted
-  // source versions. Files were re-pointed to the target in step 2, but any
-  // file_locations rows keyed to a source version survive the cascade and keep
-  // their backend objects whitelisted against the dereference-quarantine sweep.
-  // Best-effort + never throws.
-  try {
-    await deregisterFileLocationsBatch(sourceVersionIds);
-  } catch (error) {
-    logToAxiom({
-      type: 'error',
-      name: 'model-version-merge-deregister-file-locations',
-      message: `Failed to deregister file locations for merged source versions ${sourceVersionIds.join(
-        ', '
-      )}`,
-      error,
-    });
   }
 };
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -153,6 +153,7 @@ import { decreaseDate, isFutureDate } from '~/utils/date-helpers';
 import { prepareFile } from '~/utils/file-helpers';
 import { fromJson, toJson } from '~/utils/json-helpers';
 import { deleteModelFileObjects } from '~/utils/s3-utils';
+import { deregisterFileLocationsBatch } from '~/utils/storage-resolver';
 import { isDefined } from '~/utils/type-guards';
 import type {
   GetAssociatedResourcesInput,
@@ -1645,6 +1646,9 @@ export const permaDeleteModelById = async ({
 }) => {
   // Populated inside the tx so the snapshot is consistent with the cascade.
   let modelFileUrls: string[] = [];
+  // Version ids captured inside the tx (before the cascade removes them) so the
+  // post-commit storage-resolver deregister can reach every reaped version.
+  let versionIds: number[] = [];
 
   const deletionResult = await dbWrite.$transaction(
     async (tx) => {
@@ -1666,6 +1670,8 @@ export const permaDeleteModelById = async ({
         },
       });
       if (!model) return { deletedModel: null, imagesToDelete: [] };
+
+      versionIds = model.modelVersions.map(({ id }) => id);
 
       // Get posts to find associated images
       const posts = await tx.post.findMany({
@@ -1756,6 +1762,23 @@ export const permaDeleteModelById = async ({
           type: 'error',
           name: 'model-perma-delete-s3-objects',
           message: `Failed to delete S3 objects for model ${id}`,
+          error,
+        });
+      }
+    }
+    // Post-commit: deregister storage-resolver file_locations for every version
+    // this model owned. For a tiered file the real backend object is keyed by
+    // file_locations.path (not the stale ModelFile.url the S3 cleanup used), and
+    // the surviving row keeps that object whitelisted against the dereference-
+    // quarantine sweep — a permanent leak. Best-effort + never throws.
+    if (versionIds.length > 0) {
+      try {
+        await deregisterFileLocationsBatch(versionIds);
+      } catch (error) {
+        logToAxiom({
+          type: 'error',
+          name: 'model-perma-delete-deregister-file-locations',
+          message: `Failed to deregister file locations for model ${id}`,
           error,
         });
       }

--- a/src/utils/__tests__/storage-resolver.deregisterBatch.test.ts
+++ b/src/utils/__tests__/storage-resolver.deregisterBatch.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Concrete internal URL + token so the configured branch is reachable. Any field
+// we don't set falls back to the global env Proxy in src/__tests__/setup.ts.
+// vi.hoisted so the object exists before the hoisted vi.mock factory runs.
+const { envValues } = vi.hoisted(() => ({
+  envValues: {
+    STORAGE_RESOLVER_INTERNAL_URL: 'http://storage-resolver.internal',
+    STORAGE_RESOLVER_INTERNAL_TOKEN: 'test-token',
+  } as Record<string, unknown>,
+}));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy(envValues, {
+    get(target, prop: string) {
+      if (prop in target) return target[prop];
+      return undefined;
+    },
+  }),
+}));
+
+const { logToAxiom } = vi.hoisted(() => ({ logToAxiom: vi.fn(() => Promise.resolve()) }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom }));
+
+import { deregisterFileLocationsBatch } from '~/utils/storage-resolver';
+
+const okResponse = (body: unknown) => ({
+  ok: true,
+  status: 200,
+  json: () => Promise.resolve(body),
+  text: () => Promise.resolve(JSON.stringify(body)),
+});
+
+describe('deregisterFileLocationsBatch', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    logToAxiom.mockClear();
+    vi.stubGlobal('fetch', fetchMock);
+    // Restore the configured env for each test; individual tests may clear it.
+    envValues.STORAGE_RESOLVER_INTERNAL_URL = 'http://storage-resolver.internal';
+    envValues.STORAGE_RESOLVER_INTERNAL_TOKEN = 'test-token';
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('POSTs modelVersionIds with the bearer token and returns the deleted count', async () => {
+    fetchMock.mockResolvedValue(okResponse({ success: true, deleted: 4 }));
+
+    const result = await deregisterFileLocationsBatch([1, 2, 3]);
+
+    expect(result).toEqual({ deleted: 4 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('http://storage-resolver.internal/deregister');
+    expect((init as RequestInit).method).toBe('POST');
+    expect((init as any).headers.Authorization).toBe('Bearer test-token');
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({ modelVersionIds: [1, 2, 3] });
+    // Per-chunk unconditional abort so a hung resolver can't stall bulk cleanup.
+    expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('is a no-op returning null (and warns) when storage-resolver is not configured', async () => {
+    envValues.STORAGE_RESOLVER_INTERNAL_URL = undefined;
+    envValues.STORAGE_RESOLVER_INTERNAL_TOKEN = undefined;
+
+    const result = await deregisterFileLocationsBatch([1, 2, 3]);
+
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'deregister-file-locations-skipped', count: 3 })
+    );
+  });
+
+  it('de-dupes + drops non-positive ids and makes no call when nothing survives', async () => {
+    const result = await deregisterFileLocationsBatch([0, -1, -5]);
+
+    expect(result).toEqual({ deleted: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('de-dupes and drops non-positive ids before the request', async () => {
+    fetchMock.mockResolvedValue(okResponse({ success: true, deleted: 2 }));
+
+    const result = await deregisterFileLocationsBatch([1, 1, 2, 0, -3, 2]);
+
+    expect(result).toEqual({ deleted: 2 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string)).toEqual({
+      modelVersionIds: [1, 2],
+    });
+  });
+
+  it('chunks at 500 ids/request and sums deleted across chunks', async () => {
+    // 1200 unique ids → 3 chunks (500 + 500 + 200).
+    const ids = Array.from({ length: 1200 }, (_, i) => i + 1);
+    fetchMock
+      .mockResolvedValueOnce(okResponse({ success: true, deleted: 500 }))
+      .mockResolvedValueOnce(okResponse({ success: true, deleted: 500 }))
+      .mockResolvedValueOnce(okResponse({ success: true, deleted: 200 }));
+
+    const result = await deregisterFileLocationsBatch(ids);
+
+    expect(result).toEqual({ deleted: 1200 });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const chunkSizes = fetchMock.mock.calls.map(
+      ([, init]) => JSON.parse((init as RequestInit).body as string).modelVersionIds.length
+    );
+    expect(chunkSizes).toEqual([500, 500, 200]);
+  });
+
+  it('is best-effort per chunk: a non-OK chunk is logged + skipped, others proceed', async () => {
+    const ids = Array.from({ length: 1000 }, (_, i) => i + 1); // 2 chunks
+    fetchMock
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('boom'),
+        json: () => Promise.reject(new Error('not json')),
+      })
+      .mockResolvedValueOnce(okResponse({ success: true, deleted: 500 }));
+
+    const result = await deregisterFileLocationsBatch(ids);
+
+    // First chunk failed (counted 0), second succeeded — the loop never aborts.
+    expect(result).toEqual({ deleted: 500 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'deregister-file-locations-failed', status: 500 })
+    );
+  });
+
+  it('is best-effort per chunk: a thrown chunk is logged + skipped, others proceed', async () => {
+    const ids = Array.from({ length: 1000 }, (_, i) => i + 1); // 2 chunks
+    fetchMock
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValueOnce(okResponse({ success: true, deleted: 500 }));
+
+    const result = await deregisterFileLocationsBatch(ids);
+
+    expect(result).toEqual({ deleted: 500 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'deregister-file-locations-error' })
+    );
+  });
+
+  it('never throws when the request times out against a hung resolver', async () => {
+    fetchMock.mockRejectedValue(
+      new DOMException('The operation was aborted due to timeout', 'TimeoutError')
+    );
+
+    await expect(deregisterFileLocationsBatch([1, 2, 3])).resolves.toEqual({ deleted: 0 });
+    expect(logToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'deregister-file-locations-error' })
+    );
+  });
+});

--- a/src/utils/storage-resolver.ts
+++ b/src/utils/storage-resolver.ts
@@ -113,3 +113,89 @@ export async function deregisterFileLocations(
     return null;
   }
 }
+
+// Cap per request well under the resolver's own limit — one bulk delete (a
+// nightly draft-reap batch, a perma-delete, a merge) can carry far more ids than
+// a single request should. 500 keeps each POST small while collapsing thousands
+// of ids into a handful of round-trips.
+const DEREGISTER_BATCH_CHUNK_SIZE = 500;
+
+/**
+ * Batch variant of {@link deregisterFileLocations} for the BULK delete paths
+ * (remove-old-drafts cron, permaDeleteModelById, mergeVersions) that reap many
+ * versions at once. Same purpose and best-effort contract: it runs post-commit,
+ * NEVER throws into (or blocks) the delete, and returns `null` on a config skip.
+ *
+ * Semantics: de-dupes and drops non-positive ids, then POSTs the surviving ids
+ * in chunks of {@link DEREGISTER_BATCH_CHUNK_SIZE} to the same `/deregister`
+ * endpoint (which also accepts `{ modelVersionIds }`), summing `deleted` across
+ * chunks. A failed chunk is logged and skipped — it does NOT abort the rest, so
+ * one bad chunk can't leave the remaining versions' rows leaked.
+ */
+export async function deregisterFileLocationsBatch(
+  modelVersionIds: number[]
+): Promise<DeregisterFileLocationsResult | null> {
+  if (!env.STORAGE_RESOLVER_INTERNAL_URL || !env.STORAGE_RESOLVER_INTERNAL_TOKEN) {
+    // Not configured in this pod — nothing to deregister. Surface once to Axiom
+    // (a silently-skipped deregister re-grows the orphan backlog just like a
+    // thrown error would), then return.
+    logToAxiom({
+      type: 'warning',
+      name: 'deregister-file-locations-skipped',
+      reason: 'storage-resolver-not-configured',
+      count: modelVersionIds.length,
+    }).catch(() => undefined);
+    return null;
+  }
+
+  // De-dupe + drop non-positive ids. If nothing survives, there's no work — skip
+  // the network round-trip entirely and report a clean zero.
+  const ids = Array.from(new Set(modelVersionIds)).filter((id) => Number.isInteger(id) && id > 0);
+  if (ids.length === 0) return { deleted: 0 };
+
+  let deleted = 0;
+  for (let i = 0; i < ids.length; i += DEREGISTER_BATCH_CHUNK_SIZE) {
+    const chunkIds = ids.slice(i, i + DEREGISTER_BATCH_CHUNK_SIZE);
+    try {
+      const response = await fetch(`${env.STORAGE_RESOLVER_INTERNAL_URL}/deregister`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${env.STORAGE_RESOLVER_INTERNAL_TOKEN}`,
+        },
+        body: JSON.stringify({ modelVersionIds: chunkIds }),
+        // Per-chunk unconditional timeout — a hung resolver (accepts the socket,
+        // never replies) must not stall a bulk delete's post-commit cleanup.
+        signal: AbortSignal.timeout(30_000),
+      });
+
+      if (!response.ok) {
+        const text = await response.text().catch(() => 'unknown error');
+        logToAxiom({
+          type: 'error',
+          name: 'deregister-file-locations-failed',
+          count: chunkIds.length,
+          status: response.status,
+          message: text,
+        }).catch(() => undefined);
+        // Best-effort: skip this chunk, keep going with the rest.
+        continue;
+      }
+
+      const result = (await response.json().catch(() => null)) as {
+        deleted?: number;
+      } | null;
+      deleted += result?.deleted ?? 0;
+    } catch (error) {
+      logToAxiom({
+        type: 'error',
+        name: 'deregister-file-locations-error',
+        count: chunkIds.length,
+        error,
+      }).catch(() => undefined);
+      // Best-effort: a failed chunk is logged and skipped, never aborts the loop.
+    }
+  }
+
+  return { deleted };
+}

--- a/src/utils/storage-resolver.ts
+++ b/src/utils/storage-resolver.ts
@@ -115,14 +115,14 @@ export async function deregisterFileLocations(
 }
 
 // Cap per request well under the resolver's own limit — one bulk delete (a
-// nightly draft-reap batch, a perma-delete, a merge) can carry far more ids than
+// nightly draft-reap batch, a perma-delete) can carry far more ids than
 // a single request should. 500 keeps each POST small while collapsing thousands
 // of ids into a handful of round-trips.
 const DEREGISTER_BATCH_CHUNK_SIZE = 500;
 
 /**
  * Batch variant of {@link deregisterFileLocations} for the BULK delete paths
- * (remove-old-drafts cron, permaDeleteModelById, mergeVersions) that reap many
+ * (remove-old-drafts cron, permaDeleteModelById) that reap many
  * versions at once. Same purpose and best-effort contract: it runs post-commit,
  * NEVER throws into (or blocks) the delete, and returns `null` on a config skip.
  *


### PR DESCRIPTION
## Update (mergeVersions leg dropped)

Review found the `mergeVersions` leg unsafe, so it has been **removed** from this PR. `mergeVersions` **re-points** the source versions' files to the target version (they stay live) and only cascade-deletes stragglers — deregistering all `sourceVersionIds` would drop `file_locations` rows for bytes now live under the target version, causing a transient 404 on just-merged files. Only the two genuine whole-delete paths (`remove-old-drafts`, `permaDeleteModelById`) deregister here. A `mergeVersions`-specific follow-up can deregister only the files that are genuinely deleted (the cascade stragglers), not the re-pointed ones.

This PR now covers **two** delete paths (both true whole-model/whole-version deletes); `model-version.service.ts` is back to its `main` form (no diff).

---

## Problem

The storage-resolver `file_locations` catalog is accumulating orphan rows. Bulk delete paths remove `ModelVersion`/`ModelFile` records but never deregister the corresponding `file_locations` rows:

- **`remove-old-drafts` cron** (dominant source) — a nightly raw `DELETE FROM "Model"` FK-cascade that reaps abandoned training drafts. It cascades away ModelVersions/ModelFiles but leaves every reaped version's `file_locations` rows behind.
- **`permaDeleteModelById`** — admin/owner model perma-delete.

For a tiered file, `ModelFile.url` is a known-stale pointer (the tiering jobs move bytes between backends and update `file_locations.path`/`backend` without rewriting `ModelFile.url`), so the existing `ModelFile.url`-keyed cleanup misses the real object, and the surviving `file_locations` row keeps that object whitelisted against the dereference-quarantine sweep — a permanent leak. Only `deleteVersionById` deregisters today.

## Change

- **`src/utils/storage-resolver.ts`** — new `deregisterFileLocationsBatch(modelVersionIds)`, mirroring the existing single-version `deregisterFileLocations`:
  - Best-effort — never throws; every failure is caught + logged.
  - Config-gated on the storage-resolver URL/token (logs a skip + returns `null` when unconfigured).
  - De-dupes and drops non-positive ids; returns `{ deleted: 0 }` with no network call when nothing survives.
  - Chunks ids at 500/request, sums `deleted`, and a failed chunk is logged + skipped without aborting the rest.
- **`remove-old-drafts`** — per batch, collect the version ids *before* the cascade delete, then deregister them *after* the delete succeeds.
- **`permaDeleteModelById`** — capture the model's version ids in-transaction, deregister *post-commit*.

Both call sites run the deregister **post-commit**, **best-effort** (the util never throws into the delete), and **config-gated**. No bytes are deleted by these calls — deregistration just lets the existing (reversible) storage-orphan sweep reclaim the now catalog-gone objects.

## Tests

- `storage-resolver.deregisterBatch.test.ts` — config skip → null; happy path; chunking at 500 (1200 ids → 3 calls); de-dupe + non-positive filtering; per-chunk best-effort (non-OK and thrown chunks logged + skipped, others proceed); timeout never throws.
- `remove-old-drafts.test.ts` — version ids are collected pre-delete and deregister is invoked post-delete (asserted via call ordering); no deregister when a batch has no versions; no-op when there are no old drafts.

## Verification

- `npx tsc --noEmit`: none of the touched files produce any error (the only remaining errors are pre-existing "Cannot find module 'kysely'" in unrelated `packages/civitai-db*` workspace packages, an environment/install gap unrelated to this diff).
- `npx vitest run` on both new test files: all green (11 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
