### PR TITLE
feat(app-blocks): flag + surface sensitive block scopes

### DIFF
--- a/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.browser.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * BlockConsentModal — the lazy-consent surface a logged-in viewer sees when a
+ * block requests consent-gated scopes it doesn't yet carry (REQUEST_CONSENT).
+ * This suite pins that SENSITIVE requested scopes are visually emphasised for
+ * the END USER (the reusable "Sensitive" indicator) while normal scopes are not.
+ *
+ * The modal reads its open/close props from `useDialogContext` and grants via
+ * `trpc.blocks.grantScopes` — both stubbed so the render stays network-free.
+ */
+
+vi.mock('~/components/Dialog/DialogProvider', () => ({
+  useDialogContext: () => ({ opened: true, onClose: vi.fn(), zIndex: 200 }),
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    blocks: {
+      grantScopes: {
+        useMutation: () => ({ mutate: vi.fn(), isPending: false }),
+      },
+    },
+  },
+}));
+
+const { default: BlockConsentModal } = await import('./BlockConsentModal');
+
+describe('BlockConsentModal — sensitive scope emphasis for the end user', () => {
+  test('a sensitive requested scope shows the "Sensitive" indicator; a normal one does not', async () => {
+    renderWithProviders(
+      <BlockConsentModal
+        appBlockId="app-1"
+        blockName="Tip Jar"
+        // one sensitive (spends Buzz) + one normal (reads username).
+        missingScopes={['social:tip:self', 'user:read:self']}
+        onGranted={vi.fn()}
+      />
+    );
+    // Friendly descriptions of both requested scopes render.
+    await expect.element(page.getByText('Post tips on behalf of the viewer')).toBeInTheDocument();
+    await expect
+      .element(page.getByText("Read the viewer's username and account status"))
+      .toBeInTheDocument();
+    // Exactly ONE sensitive badge — for the Buzz-spending scope only.
+    expect(page.getByTestId('sensitive-scope-badge').elements()).toHaveLength(1);
+    // The Allow action is present.
+    await expect.element(page.getByRole('button', { name: 'Allow' })).toBeInTheDocument();
+  });
+
+  test('renders no sensitive indicator when every requested scope is normal', async () => {
+    renderWithProviders(
+      <BlockConsentModal
+        appBlockId="app-2"
+        blockName="Model Viewer"
+        missingScopes={['models:read:self', 'user:read:self']}
+        onGranted={vi.fn()}
+      />
+    );
+    await expect
+      .element(page.getByText('Read the model on the page where the block is mounted'))
+      .toBeInTheDocument();
+    expect(page.getByTestId('sensitive-scope-badge').elements()).toHaveLength(0);
+  });
+});

--- a/src/components/AppBlocks/BlockConsentModal.tsx
+++ b/src/components/AppBlocks/BlockConsentModal.tsx
@@ -1,7 +1,9 @@
 import { Button, Group, List, Modal, Stack, Text, ThemeIcon } from '@mantine/core';
 import { IconShieldLock } from '@tabler/icons-react';
 import { useState } from 'react';
+import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
+import { isSensitiveBlockScope } from '~/shared/constants/block-scope.constants';
 import { SCOPE_DESCRIPTIONS } from '~/server/services/blocks/scope-descriptions.constants';
 import { trpc } from '~/utils/trpc';
 
@@ -56,13 +58,19 @@ export default function BlockConsentModal({
           </Text>
         </Group>
         <List size="sm" spacing={4}>
-          {missingScopes.map((scope) => (
-            <List.Item key={scope}>
-              <Text component="span" fw={600}>
-                {SCOPE_DESCRIPTIONS[scope] ?? scope}
-              </Text>
-            </List.Item>
-          ))}
+          {missingScopes.map((scope) => {
+            const sensitive = isSensitiveBlockScope(scope);
+            return (
+              <List.Item key={scope}>
+                <Group component="span" gap="xs" wrap="nowrap" align="center">
+                  <Text component="span" fw={600} c={sensitive ? 'orange' : undefined}>
+                    {SCOPE_DESCRIPTIONS[scope] ?? scope}
+                  </Text>
+                  {sensitive && <SensitiveScopeBadge size="xs" />}
+                </Group>
+              </List.Item>
+            );
+          })}
         </List>
         {error ? (
           <Text size="xs" c="red">

--- a/src/components/Apps/BlockScopeList.browser.test.tsx
+++ b/src/components/Apps/BlockScopeList.browser.test.tsx
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { BlockScopeList } from './BlockScopeList';
+
+/**
+ * BlockScopeList — the shared block-scope disclosure list used by the
+ * install/manage modal AND the run-frame "Permissions & activity" drawer
+ * (AppPermissionsActivityDrawer renders granted scopes through this component).
+ * This pure-props browser test pins the SENSITIVE-scope emphasis for both
+ * surfaces at once: a sensitive granted scope gets the reusable "Sensitive"
+ * indicator, a normal one does not.
+ */
+describe('BlockScopeList — sensitive scope emphasis', () => {
+  test('flags a sensitive scope with the "Sensitive" badge and leaves a normal scope unbadged', async () => {
+    renderWithProviders(
+      <BlockScopeList scopes={['ai:write:budgeted', 'models:read:self']} />
+    );
+    // Both scopes render.
+    await expect.element(page.getByText('ai:write:budgeted')).toBeInTheDocument();
+    await expect.element(page.getByText('models:read:self')).toBeInTheDocument();
+    // Exactly ONE sensitive badge — for the sensitive scope only.
+    expect(page.getByTestId('sensitive-scope-badge').elements()).toHaveLength(1);
+  });
+
+  test('renders no sensitive badge when every granted scope is normal', async () => {
+    renderWithProviders(
+      <BlockScopeList scopes={['models:read:self', 'user:read:self']} />
+    );
+    await expect.element(page.getByText('user:read:self')).toBeInTheDocument();
+    expect(page.getByTestId('sensitive-scope-badge').elements()).toHaveLength(0);
+  });
+
+  test('renders the empty label with no badges when there are no scopes', async () => {
+    renderWithProviders(<BlockScopeList scopes={[]} emptyLabel="Nothing granted." />);
+    await expect.element(page.getByText('Nothing granted.')).toBeInTheDocument();
+    expect(page.getByTestId('sensitive-scope-badge').elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Apps/BlockScopeList.tsx
+++ b/src/components/Apps/BlockScopeList.tsx
@@ -1,4 +1,6 @@
 import { Badge, Group, Stack, Text } from '@mantine/core';
+import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
+import { isSensitiveBlockScope } from '~/shared/constants/block-scope.constants';
 import { SCOPE_DESCRIPTIONS } from '~/server/services/blocks/scope-descriptions.constants';
 
 /**
@@ -27,11 +29,13 @@ export function BlockScopeList({
     <Stack gap={4}>
       {scopes.map((scope) => {
         const desc = SCOPE_DESCRIPTIONS[scope];
+        const sensitive = isSensitiveBlockScope(scope);
         return (
           <Group key={scope} gap="xs" wrap="nowrap" align="flex-start">
-            <Badge size="sm" variant="light">
+            <Badge size="sm" variant="light" color={sensitive ? 'orange' : undefined}>
               {scope}
             </Badge>
+            {sensitive && <SensitiveScopeBadge size="sm" />}
             {desc ? (
               <Text size="xs" c="dimmed">
                 {desc}

--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -222,6 +222,61 @@ describe('OnsiteReviewModal — per-scope justifications shown to the mod', () =
   });
 });
 
+describe('OnsiteReviewModal — sensitive scopes are grouped + flagged for the mod', () => {
+  test('a mix of sensitive + normal scopes renders a "Sensitive permissions" group (first) and the normal "Permissions" group with per-group counts', async () => {
+    const withSensitive = {
+      ...ONSITE_PENDING,
+      id: 'onsite-req-sensitive',
+      slug: 'sensitive-block',
+      manifest: {
+        ...ONSITE_PENDING.manifest,
+        // 2 sensitive (spends/reads Buzz) + 1 normal.
+        scopes: ['ai:write:budgeted', 'buzz:read:self', 'models:read:self'],
+      },
+    };
+    renderWithProviders(
+      <OnsiteReviewModal
+        selection={{ request: withSensitive, mode: 'pending' }}
+        onClose={vi.fn()}
+      />
+    );
+    // Sensitive group header with the sensitive-only count.
+    await expect.element(page.getByText('Sensitive permissions (2)')).toBeInTheDocument();
+    // Normal group header counts ONLY the non-sensitive scopes.
+    await expect.element(page.getByText('Permissions (1)')).toBeInTheDocument();
+    // The sensitive scopes carry the reusable "Sensitive" indicator; the two
+    // sensitive scopes each get one badge (the normal scope does not).
+    expect(page.getByTestId('sensitive-scope-badge').elements()).toHaveLength(2);
+    // The sensitive + normal scope badges all render.
+    await expect.element(page.getByText('ai:write:budgeted')).toBeInTheDocument();
+    await expect.element(page.getByText('buzz:read:self')).toBeInTheDocument();
+    await expect.element(page.getByText('models:read:self')).toBeInTheDocument();
+  });
+
+  test('a manifest with ONLY normal scopes renders NO "Sensitive permissions" header', async () => {
+    const normalOnly = {
+      ...ONSITE_PENDING,
+      id: 'onsite-req-normal',
+      slug: 'normal-block',
+      manifest: {
+        ...ONSITE_PENDING.manifest,
+        scopes: ['models:read:self', 'user:read:self'],
+      },
+    };
+    renderWithProviders(
+      <OnsiteReviewModal
+        selection={{ request: normalOnly, mode: 'pending' }}
+        onClose={vi.fn()}
+      />
+    );
+    // The normal group still shows all of them.
+    await expect.element(page.getByText('Permissions (2)')).toBeInTheDocument();
+    // No sensitive header and no sensitive badge when nothing is sensitive.
+    expect(page.getByText(/Sensitive permissions/).elements()).toHaveLength(0);
+    expect(page.getByTestId('sensitive-scope-badge').elements()).toHaveLength(0);
+  });
+});
+
 describe('OnsiteReviewModal — live preview links to the full-page route (not the raw host)', () => {
   test('a live preview renders the "Open full-page preview" link (internal same-origin route, new tab) and NOT the old raw-host button', async () => {
     // Flip the shared getReviewStatus poll into the live state. previewUrl carries

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -33,6 +33,7 @@ import {
 } from '@tabler/icons-react';
 import { useMemo, useRef, useState } from 'react';
 import { ReviewBlockPreviewHost } from '~/components/Apps/ReviewBlockPreviewHost';
+import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
 import { useReviewPreview } from '~/components/Apps/useReviewPreview';
 import {
   FileDiffEntry,
@@ -46,6 +47,7 @@ import {
   reasonMeetsMin,
 } from '~/components/Apps/ReasonGatedActionModal';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { isSensitiveBlockScope } from '~/shared/constants/block-scope.constants';
 import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
 import {
   MARKETPLACE_CATEGORIES,
@@ -1143,6 +1145,52 @@ function trustColor(tier: string): string {
   }
 }
 
+function ManifestScopeRow({
+  scope,
+  justifications,
+}: {
+  scope: string;
+  justifications: Record<string, unknown>;
+}) {
+  const desc = SCOPE_DESCRIPTIONS[scope];
+  const known = !!desc;
+  const sensitive = isSensitiveBlockScope(scope);
+  const rawJustification = justifications[scope];
+  const justification =
+    typeof rawJustification === 'string' && rawJustification.trim().length > 0
+      ? rawJustification.trim()
+      : null;
+  return (
+    <Stack gap={2}>
+      <Group gap={8} align="flex-start" wrap="nowrap">
+        <Badge
+          variant={known ? 'light' : 'outline'}
+          color={known ? (sensitive ? 'orange' : 'blue') : 'red'}
+          style={{ fontFamily: 'ui-monospace, monospace' }}
+        >
+          {scope}
+        </Badge>
+        {sensitive && <SensitiveScopeBadge />}
+        <Text size="xs" c={known ? 'dimmed' : 'red'}>
+          {desc ?? 'Unknown scope — would fail at token issuance.'}
+        </Text>
+      </Group>
+      {justification ? (
+        <Text size="xs" c="dimmed" style={{ whiteSpace: 'pre-wrap' }}>
+          <Text span fw={600} c="dimmed">
+            Why:{' '}
+          </Text>
+          {justification}
+        </Text>
+      ) : (
+        <Text size="xs" c="dimmed" fs="italic">
+          No justification provided
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
 function ManifestScopes({ manifest }: { manifest: Record<string, unknown> }) {
   const scopes = Array.isArray(manifest.scopes)
     ? (manifest.scopes as unknown[]).filter((s): s is string => typeof s === 'string')
@@ -1157,69 +1205,87 @@ function ManifestScopes({ manifest }: { manifest: Record<string, unknown> }) {
     !Array.isArray(manifest.scopeJustifications)
       ? (manifest.scopeJustifications as Record<string, unknown>)
       : {};
+  // Split the declared scopes into a SENSITIVE group (elevated-risk — rendered
+  // first with warning emphasis) and the normal group. Each group keeps the
+  // existing "(N)" count semantics for its own members.
+  const sensitiveScopes = scopes.filter((s) => isSensitiveBlockScope(s));
+  const normalScopes = scopes.filter((s) => !isSensitiveBlockScope(s));
   return (
     <Card withBorder p="sm">
       <Stack gap="xs">
-        <Group gap={6}>
-          <IconKey size={14} />
-          <Text size="sm" fw={600}>
-            Permissions ({scopes.length})
-          </Text>
-          <Tooltip
-            multiline
-            w={280}
-            label="Permissions the block requests. They are encoded as scopes in the app's signed block-token JWT (distinct from OAuth scopes) and enforced per-operation server-side: every capability re-verifies the token and checks the required scope before it runs."
-          >
-            <ThemeIcon size="xs" variant="subtle" color="gray">
-              <IconInfoCircle size={13} />
-            </ThemeIcon>
-          </Tooltip>
-        </Group>
         {scopes.length === 0 ? (
-          <Text size="xs" c="dimmed" fs="italic">
-            No permissions requested — block can only consume host postMessage
-            data, no scope-gated platform APIs.
-          </Text>
+          <>
+            <Group gap={6}>
+              <IconKey size={14} />
+              <Text size="sm" fw={600}>
+                Permissions (0)
+              </Text>
+              <Tooltip
+                multiline
+                w={280}
+                label="Permissions the block requests. They are encoded as scopes in the app's signed block-token JWT (distinct from OAuth scopes) and enforced per-operation server-side: every capability re-verifies the token and checks the required scope before it runs."
+              >
+                <ThemeIcon size="xs" variant="subtle" color="gray">
+                  <IconInfoCircle size={13} />
+                </ThemeIcon>
+              </Tooltip>
+            </Group>
+            <Text size="xs" c="dimmed" fs="italic">
+              No permissions requested — block can only consume host postMessage
+              data, no scope-gated platform APIs.
+            </Text>
+          </>
         ) : (
-          <Stack gap={8}>
-            {scopes.map((s) => {
-              const desc = SCOPE_DESCRIPTIONS[s];
-              const known = !!desc;
-              const rawJustification = justifications[s];
-              const justification =
-                typeof rawJustification === 'string' && rawJustification.trim().length > 0
-                  ? rawJustification.trim()
-                  : null;
-              return (
-                <Stack key={s} gap={2}>
-                  <Group gap={8} align="flex-start" wrap="nowrap">
-                    <Badge
-                      variant={known ? 'light' : 'outline'}
-                      color={known ? 'blue' : 'red'}
-                      style={{ fontFamily: 'ui-monospace, monospace' }}
-                    >
-                      {s}
-                    </Badge>
-                    <Text size="xs" c={known ? 'dimmed' : 'red'}>
-                      {desc ?? 'Unknown scope — would fail at token issuance.'}
-                    </Text>
-                  </Group>
-                  {justification ? (
-                    <Text size="xs" c="dimmed" style={{ whiteSpace: 'pre-wrap' }}>
-                      <Text span fw={600} c="dimmed">
-                        Why:{' '}
-                      </Text>
-                      {justification}
-                    </Text>
-                  ) : (
-                    <Text size="xs" c="dimmed" fs="italic">
-                      No justification provided
-                    </Text>
-                  )}
-                </Stack>
-              );
-            })}
-          </Stack>
+          <>
+            {sensitiveScopes.length > 0 && (
+              <Stack gap={8}>
+                <Group gap={6}>
+                  <IconAlertTriangle size={14} color="var(--mantine-color-orange-6)" />
+                  <Text size="sm" fw={600} c="orange">
+                    Sensitive permissions ({sensitiveScopes.length})
+                  </Text>
+                  <Tooltip
+                    multiline
+                    w={280}
+                    label="Elevated-risk permissions — these let the app spend the viewer's Buzz, read the viewer's Buzz balance or private data, or write data other users see. Review the justification for each carefully."
+                  >
+                    <ThemeIcon size="xs" variant="subtle" color="orange">
+                      <IconInfoCircle size={13} />
+                    </ThemeIcon>
+                  </Tooltip>
+                </Group>
+                {sensitiveScopes.map((s) => (
+                  <ManifestScopeRow key={s} scope={s} justifications={justifications} />
+                ))}
+              </Stack>
+            )}
+            <Group gap={6}>
+              <IconKey size={14} />
+              <Text size="sm" fw={600}>
+                Permissions ({normalScopes.length})
+              </Text>
+              <Tooltip
+                multiline
+                w={280}
+                label="Permissions the block requests. They are encoded as scopes in the app's signed block-token JWT (distinct from OAuth scopes) and enforced per-operation server-side: every capability re-verifies the token and checks the required scope before it runs."
+              >
+                <ThemeIcon size="xs" variant="subtle" color="gray">
+                  <IconInfoCircle size={13} />
+                </ThemeIcon>
+              </Tooltip>
+            </Group>
+            {normalScopes.length === 0 ? (
+              <Text size="xs" c="dimmed" fs="italic">
+                No non-sensitive permissions requested.
+              </Text>
+            ) : (
+              <Stack gap={8}>
+                {normalScopes.map((s) => (
+                  <ManifestScopeRow key={s} scope={s} justifications={justifications} />
+                ))}
+              </Stack>
+            )}
+          </>
         )}
       </Stack>
     </Card>

--- a/src/components/Apps/SensitiveScopeBadge.tsx
+++ b/src/components/Apps/SensitiveScopeBadge.tsx
@@ -1,0 +1,30 @@
+import { Badge, type BadgeProps, Tooltip } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+
+/**
+ * Small reusable warning indicator rendered next to a SENSITIVE block scope
+ * (see `SENSITIVE_BLOCK_SCOPES` in block-scope.constants). Shared by the mod
+ * review modal, the consent/grant prompt, and the per-app "granted permissions"
+ * panels so the "this permission is elevated-risk" emphasis reads identically
+ * everywhere. Presentation only — it never affects whether a scope is granted.
+ */
+export function SensitiveScopeBadge({ size = 'sm', ...props }: Omit<BadgeProps, 'children'>) {
+  return (
+    <Tooltip
+      multiline
+      w={260}
+      label="Sensitive permission — this can spend your Buzz, read your private data, or write data other users see. Review it carefully."
+    >
+      <Badge
+        size={size}
+        color="orange"
+        variant="filled"
+        leftSection={<IconAlertTriangle size={11} />}
+        data-testid="sensitive-scope-badge"
+        {...props}
+      >
+        Sensitive
+      </Badge>
+    </Tooltip>
+  );
+}

--- a/src/shared/constants/__tests__/block-scope.constants.test.ts
+++ b/src/shared/constants/__tests__/block-scope.constants.test.ts
@@ -5,6 +5,8 @@ import {
   deriveOauthBitmaskFromBlockScopes,
   isAppBlockOauthClientId,
   isKnownBlockScope,
+  isSensitiveBlockScope,
+  SENSITIVE_BLOCK_SCOPES,
   SKIP_OAUTH_CHECK,
   validateBlockScopesAgainstOauthClient,
 } from '../block-scope.constants';
@@ -43,6 +45,51 @@ describe('block-scope.constants', () => {
   it('isKnownBlockScope rejects unknown strings', () => {
     expect(isKnownBlockScope('models:read:self')).toBe(true);
     expect(isKnownBlockScope('not:a:scope')).toBe(false);
+  });
+
+  describe('SENSITIVE_BLOCK_SCOPES / isSensitiveBlockScope', () => {
+    const EXPECTED_SENSITIVE = [
+      'ai:write:budgeted',
+      'social:tip:self',
+      'buzz:read:self',
+      'collections:read:private',
+      'apps:storage:shared:write',
+    ];
+
+    it('flags exactly the 5 designated sensitive scopes', () => {
+      expect([...SENSITIVE_BLOCK_SCOPES].sort()).toEqual([...EXPECTED_SENSITIVE].sort());
+      for (const scope of EXPECTED_SENSITIVE) {
+        expect(isSensitiveBlockScope(scope)).toBe(true);
+      }
+    });
+
+    it('does NOT flag normal (non-sensitive) known scopes', () => {
+      for (const scope of [
+        'models:read:self',
+        'user:read:self',
+        'apps:storage:read',
+        'apps:storage:write',
+        'apps:storage:shared:read',
+        'collections:read:self',
+        'collections:write:self',
+      ]) {
+        expect(isSensitiveBlockScope(scope)).toBe(false);
+      }
+    });
+
+    it('does NOT flag unknown / removed scopes', () => {
+      expect(isSensitiveBlockScope('not:a:scope')).toBe(false);
+      expect(isSensitiveBlockScope('media:read:owned')).toBe(false);
+    });
+
+    it('every sensitive scope is a currently-known scope (rename/removal guard)', () => {
+      // If a scope is renamed/removed from the enforcement map, this guard fails
+      // loudly so the sensitive set can never silently reference a dead scope.
+      for (const scope of SENSITIVE_BLOCK_SCOPES) {
+        expect(isKnownBlockScope(scope)).toBe(true);
+        expect(scope in BLOCK_SCOPE_TO_OAUTH_BIT).toBe(true);
+      }
+    });
   });
 
   describe('validateBlockScopesAgainstOauthClient', () => {

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -122,6 +122,40 @@ export function isKnownBlockScope(scope: string): scope is BlockScopeString {
 }
 
 /**
+ * SENSITIVE block scopes — the subset of the vocabulary that carries elevated
+ * privacy/financial risk to the VIEWER, and therefore warrants distinct,
+ * warning-styled emphasis wherever scopes are surfaced (the mod review modal,
+ * the consent/grant prompt, and the per-app "granted permissions" panels).
+ *
+ * A scope is sensitive when granting it lets the app do one of:
+ *   - spend the viewer's Buzz          (`ai:write:budgeted`, `social:tip:self`)
+ *   - read the viewer's Buzz balance   (`buzz:read:self`)
+ *   - read the viewer's PRIVATE data   (`collections:read:private`)
+ *   - write data OTHER users see       (`apps:storage:shared:write`)
+ *
+ * This is a PRESENTATION classification only — it changes how a scope is
+ * displayed, never whether it is granted/enforced (that stays with the
+ * server-side per-op gates + consent grant). Keeping it a set (not a per-scope
+ * flag on the map) keeps the enforcement map and the UI emphasis decoupled.
+ *
+ * INVARIANT (guarded by a test): every entry must be a currently-known scope in
+ * `BLOCK_SCOPE_TO_OAUTH_BIT`. If a scope is renamed/removed (as
+ * `media:read:owned` / `block:settings:*` were in #3212) it must be updated
+ * here too, so a sensitive scope can never silently drop out of the set.
+ */
+export const SENSITIVE_BLOCK_SCOPES: ReadonlySet<string> = new Set([
+  'ai:write:budgeted',
+  'social:tip:self',
+  'buzz:read:self',
+  'collections:read:private',
+  'apps:storage:shared:write',
+]);
+
+export function isSensitiveBlockScope(scope: string): boolean {
+  return SENSITIVE_BLOCK_SCOPES.has(scope);
+}
+
+/**
  * Validates that every requested block scope either declares no OAuth-bit
  * requirement (SKIP_OAUTH_CHECK) or has its OAuth bit set in the
  * OauthClient.allowedScopes bitmask.


### PR DESCRIPTION
## What

Adds a **sensitive scope** designation to App Blocks and surfaces it distinctly from normal scopes across both the moderator review flow and the user-facing consent / permissions surfaces.

Five scopes are flagged **SENSITIVE** — they let an app spend/read the viewer's Buzz, read the viewer's private data, or write data other users see:

| Scope | Why sensitive |
|---|---|
| `ai:write:budgeted` | spends the viewer's Buzz (budgeted generations) |
| `social:tip:self` | spends the viewer's Buzz (tips) |
| `buzz:read:self` | reads the viewer's Buzz balance |
| `collections:read:private` | reads the viewer's private collections |
| `apps:storage:shared:write` | writes data other users of the app see |

## Why

Not all block permissions carry the same risk. A moderator reviewing an app — and a user granting consent — should be able to tell at a glance which requested permissions touch money or private/cross-user data, versus benign read-only ones. This is a **presentation-layer** classification: it changes how a scope is displayed, never whether it is granted or enforced (that stays with the existing server-side per-op gates + consent grant).

## Changes

- **`block-scope.constants.ts`** — `SENSITIVE_BLOCK_SCOPES: ReadonlySet<string>` + `isSensitiveBlockScope(scope)`. A test guard asserts every sensitive scope is a currently-known scope in `BLOCK_SCOPE_TO_OAUTH_BIT`, so a renamed/removed scope (as `media:read:owned` / `block:settings:*` were in #3212) can't silently drop out of the set.
- **`SensitiveScopeBadge.tsx`** (new) — small reusable warning indicator (orange badge + `IconAlertTriangle` + explanatory tooltip), shared by every surface so the emphasis reads identically.
- **Mod review modal** (`OnsiteReviewModal` → `ManifestScopes`) — the scope list is split into a warning-styled **"Sensitive permissions (N)"** group rendered **first**, and the normal **"Permissions (N)"** group. Each scope keeps its badge + description + per-scope justification. Per-group counts; the sensitive header is hidden when there are no sensitive scopes (and vice-versa).
- **User consent + permissions surfaces**:
  - **`BlockConsentModal`** — the `REQUEST_CONSENT` grant prompt: sensitive requested-scope rows get the badge + orange emphasis (e.g. "Post tips on behalf of the viewer" is flagged).
  - **`BlockScopeList`** — the shared disclosure list used by both the install/manage modal **and** the run-frame `AppPermissionsActivityDrawer` ("granted permissions"), so flagging it once covers both user-facing surfaces.

## Tests

- **Constants** (`block-scope.constants.test.ts`, unit): `isSensitiveBlockScope` true for the 5 / false for normal + unknown + removed scopes; the exact-set assertion; the known-scope guard.
- **Review modal** (`OnsiteReviewModal.browser.test.tsx`): a mixed manifest renders "Sensitive permissions (2)" + "Permissions (1)" with the sensitive scopes badged; a normal-only manifest renders no sensitive header/badge.
- **Consent modal** (`BlockConsentModal.browser.test.tsx`, new): sensitive requested scope shows the indicator, normal one doesn't.
- **Scope list** (`BlockScopeList.browser.test.tsx`, new): sensitive granted scope badged, normal one not, empty state clean.

### Test evidence

- `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` — **0 errors in changed files**; total 17 = the pre-existing baseline (0 delta), all in unrelated files (`image.service.ts`, `flipt/client.ts`, `bitdex-stats.ts`, `civitai-db*`).
- `vitest run --project unit block-scope.constants.test.ts` — **21 passed**.
- `vitest run --project component` (OnsiteReviewModal + BlockScopeList + BlockConsentModal) — **17 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)