### PR TITLE
feat(api): public REST endpoints for articles + collections (conservative rate-limited)

### DIFF
--- a/src/pages/api/v1/articles/[id].ts
+++ b/src/pages/api/v1/articles/[id].ts
@@ -3,6 +3,7 @@ import type { Session } from '~/types/session';
 import * as z from 'zod';
 
 import { getArticleById } from '~/server/services/article.service';
+import { isAppBlocksAuthorEnabled } from '~/server/services/app-blocks-flag';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
 
@@ -29,6 +30,13 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
+  // App Blocks author-cohort gate — DARK preview, cohort-only (mods + the
+  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → bare 404 (no
+  // existence oracle), evaluated before the rate limit + service.
+  if (!(await isAppBlocksAuthorEnabled({ user }))) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+
   const rateLimit = await checkPublicApiRateLimit({ req, family: 'articles', userId: user?.id });
   if (!rateLimit.allowed) {
     res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));

--- a/src/pages/api/v1/articles/[id].ts
+++ b/src/pages/api/v1/articles/[id].ts
@@ -1,0 +1,62 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { Session } from '~/types/session';
+import * as z from 'zod';
+
+import { getArticleById } from '~/server/services/article.service';
+import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
+
+/**
+ * GET /api/v1/articles/[id] — public article detail.
+ *
+ * Wraps the EXISTING `getArticleById` service (the same one `articleRouter.getById`
+ * uses). Visibility is enforced server-side: for a non-moderator it matches
+ * `(publishedAt IS NOT NULL AND status = Published AND ingestion = Scanned) OR
+ * userId = <session user>`. So a draft / unpublished / not-yet-scanned article is
+ * reachable ONLY by its owner (authenticated) or a moderator; everyone else gets a
+ * 404. Ownership comes solely from the authenticated session — never a client
+ * param. A private article a non-owner requests is INDISTINGUISHABLE from a
+ * non-existent one (both 404), so this is not an existence oracle.
+ */
+
+// Bound the coerced id to Postgres int4 (mirrors models/[id].ts): a huge numeric
+// string would otherwise bind to the int4 `Article.id` and throw a raw PG range
+// 500. `.int().gt(0)` also rejects non-integer / non-positive ids.
+export const schema = z.object({ id: z.coerce.number().int().gt(0).lte(2147483647) });
+
+export default MixedAuthEndpoint(async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  user: Session['user'] | undefined
+) {
+  const rateLimit = await checkPublicApiRateLimit({ req, family: 'articles', userId: user?.id });
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.setHeader('Cache-Control', 'no-store');
+    return res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
+  }
+
+  const parsedParams = schema.safeParse(req.query);
+  if (!parsedParams.success)
+    return res.status(400).json({ error: z.prettifyError(parsedParams.error) ?? 'Invalid id' });
+
+  const { id } = parsedParams.data;
+
+  try {
+    const article = await getArticleById({
+      id,
+      userId: user?.id,
+      isModerator: user?.isModerator,
+    });
+
+    // moderatorNsfwLevel is a moderator-only override the service includes for the
+    // edit form; strip it so it never leaks through the public REST payload.
+    const { moderatorNsfwLevel, ...publicArticle } = article;
+
+    return res.status(200).json(publicArticle);
+  } catch (e) {
+    // getArticleById throws NOT_FOUND for a missing / non-visible article →
+    // handleEndpointError maps it to a 404.
+    return handleEndpointError(res, e);
+  }
+});

--- a/src/pages/api/v1/articles/[id].ts
+++ b/src/pages/api/v1/articles/[id].ts
@@ -30,11 +30,14 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
-  // App Blocks author-cohort gate — DARK preview, cohort-only (mods + the
-  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → bare 404 (no
-  // existence oracle), evaluated before the rate limit + service.
+  // App Blocks author-cohort gate — preview, cohort-only (mods + the
+  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → 403 with a clear
+  // preview message (invited-cohort DX: explain the restriction rather than an
+  // opaque 404), evaluated before the rate limit + service.
   if (!(await isAppBlocksAuthorEnabled({ user }))) {
-    return res.status(404).json({ error: 'Not found' });
+    return res.status(403).json({
+      error: 'This API is in preview — access is restricted to Civitai moderators and app developers.',
+    });
   }
 
   const rateLimit = await checkPublicApiRateLimit({ req, family: 'articles', userId: user?.id });

--- a/src/pages/api/v1/articles/index.ts
+++ b/src/pages/api/v1/articles/index.ts
@@ -1,0 +1,130 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { Session } from '~/types/session';
+import * as z from 'zod';
+
+import { MetricTimeframe } from '~/shared/utils/prisma/enums';
+import { ArticleSort } from '~/server/common/enums';
+import { getArticles } from '~/server/services/article.service';
+import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { getNextPage } from '~/server/utils/pagination-helpers';
+import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
+import {
+  allBrowsingLevelsFlag,
+  publicBrowsingLevelsFlag,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
+import { booleanString, commaDelimitedNumberArray } from '~/utils/zod-helpers';
+import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
+
+/**
+ * GET /api/v1/articles — public list/search over articles.
+ *
+ * Wraps the EXISTING `getArticles` service (the same function that powers the
+ * website's article feed via `articleRouter.getInfinite`). Visibility is enforced
+ * server-side by that service: for a non-owner / non-moderator caller it returns
+ * ONLY `status = Published` + `ingestion = Scanned` articles and drops
+ * `availability = Private` ones. This endpoint NEVER passes a client-supplied
+ * userId — ownership is derived solely from the authenticated session (`user`),
+ * so an unauthenticated caller can only ever see published, public articles.
+ *
+ * Pagination: composite keyset cursor (the article feed can't use offset paging —
+ * ranked sorts need the `(sortValue, id)` tiebreaker). The opaque `cursor` string
+ * is `"<v>|<id>"`; the response returns the next one plus a ready-made `nextPage`
+ * URL — matching the `{ items, metadata: { nextCursor, nextPage } }` envelope the
+ * other public v1 endpoints use.
+ */
+
+export const config = {
+  api: {
+    responseLimit: false,
+  },
+};
+
+// favorites/hidden surface the CALLER's OWN engagement — meaningless (and gated
+// inside getArticles behind `if (sessionUser)`) without a session, so we 401 if
+// an unauthenticated caller requests them (mirrors models/index.ts).
+const authedOnlyOptions = ['favorites', 'hidden'] as const;
+
+const articlesEndpointSchema = z.object({
+  limit: z.preprocess((val) => Number(val), z.number().min(1).max(100)).default(100),
+  cursor: z.string().max(100).optional(),
+  query: z.string().optional(),
+  sort: z.enum(ArticleSort).optional(),
+  tags: commaDelimitedNumberArray().optional(),
+  username: z.string().optional(),
+  favorites: booleanString().optional().default(false),
+  hidden: booleanString().optional().default(false),
+  nsfw: booleanString().optional(),
+});
+
+// Parse the opaque "<v>|<id>" REST cursor back into the service's composite
+// keyset cursor. `null` = malformed (→ clean 400); `undefined` = absent.
+function parseArticleCursor(
+  cursor: string | undefined
+): { v: number; id: number } | null | undefined {
+  if (!cursor) return undefined;
+  const parts = cursor.split('|');
+  if (parts.length !== 2) return null;
+  const v = Number(parts[0]);
+  const id = Number(parts[1]);
+  if (!Number.isFinite(v) || !Number.isInteger(id)) return null;
+  return { v, id };
+}
+
+export default MixedAuthEndpoint(async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  user: Session['user'] | undefined
+) {
+  // Conservative per-client rate limit (before the expensive service call).
+  const rateLimit = await checkPublicApiRateLimit({ req, family: 'articles', userId: user?.id });
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.setHeader('Cache-Control', 'no-store');
+    return res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
+  }
+
+  if (Object.keys(req.query).some((key) => (authedOnlyOptions as readonly string[]).includes(key)) && !user)
+    return res.status(401).json({ error: 'Unauthorized' });
+
+  const parsedParams = articlesEndpointSchema.safeParse(req.query);
+  if (!parsedParams.success) return res.status(400).json({ error: parsedParams.error });
+
+  const { limit, cursor, query, sort, tags, username, favorites, hidden, nsfw } = parsedParams.data;
+
+  const parsedCursor = parseArticleCursor(cursor);
+  if (parsedCursor === null) return res.status(400).json({ error: 'Invalid cursor' });
+
+  // Maturity/region ceiling — identical derivation to models/index.ts.
+  const region = getRegion(req);
+  let browsingLevel = !nsfw ? publicBrowsingLevelsFlag : allBrowsingLevelsFlag;
+  if (isRegionRestricted(region)) browsingLevel = sfwBrowsingLevelsFlag;
+
+  try {
+    const { items, nextCursor } = await getArticles({
+      limit,
+      cursor: parsedCursor,
+      query,
+      tags,
+      username,
+      favorites,
+      hidden,
+      // AllTime + published: getArticles requires a defined period/periodMode; this
+      // pins the extra `publishedAt IS NOT NULL AND status = Published` guard on top
+      // of the service's own non-owner visibility gate.
+      period: MetricTimeframe.AllTime,
+      periodMode: 'published',
+      sort: sort ?? ArticleSort.Newest,
+      browsingLevel,
+      sessionUser: user,
+      include: [],
+    });
+
+    const nextCursorStr = nextCursor ? `${nextCursor.v}|${nextCursor.id}` : undefined;
+    const { nextPage } = getNextPage({ req, nextCursor: nextCursorStr });
+
+    return res.status(200).json({ items, metadata: { nextCursor: nextCursorStr, nextPage } });
+  } catch (e) {
+    return handleEndpointError(res, e);
+  }
+});

--- a/src/pages/api/v1/articles/index.ts
+++ b/src/pages/api/v1/articles/index.ts
@@ -77,14 +77,18 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
-  // App Blocks author-cohort gate — this endpoint is a DARK preview, reachable
-  // ONLY by the `appBlocksAuthor` cohort (mods via the static floor + the
+  // App Blocks author-cohort gate — this endpoint is a preview, reachable ONLY by
+  // the `appBlocksAuthor` cohort (mods via the static floor + the
   // `app-blocks-author` Flipt cohort). Everyone else — INCLUDING anonymous (no
-  // user → not in cohort) — gets a bare 404, indistinguishable from a
-  // non-existent route (no existence oracle). Evaluated FIRST, before the rate
-  // limit + service, so no work leaks to a non-cohort caller.
+  // user → not in cohort) — gets a 403 with a clear preview message: a deliberate
+  // DX choice for an invited cohort, so a caller who's been invited but isn't yet
+  // provisioned understands WHY they're blocked instead of hitting an opaque 404.
+  // Evaluated FIRST, before the rate limit + service, so no work leaks to a
+  // non-cohort caller.
   if (!(await isAppBlocksAuthorEnabled({ user }))) {
-    return res.status(404).json({ error: 'Not found' });
+    return res.status(403).json({
+      error: 'This API is in preview — access is restricted to Civitai moderators and app developers.',
+    });
   }
 
   // Conservative per-client rate limit (before the expensive service call).

--- a/src/pages/api/v1/articles/index.ts
+++ b/src/pages/api/v1/articles/index.ts
@@ -118,6 +118,10 @@ export default MixedAuthEndpoint(async function handler(
       browsingLevel,
       sessionUser: user,
       include: [],
+      // Public scriptable surface: NEVER expand to `availability = Private`
+      // articles, even when `?username=` is set (which normally lifts the
+      // private-drop for owner self-views). Conservative-by-default.
+      forceHidePrivate: true,
     });
 
     const nextCursorStr = nextCursor ? `${nextCursor.v}|${nextCursor.id}` : undefined;

--- a/src/pages/api/v1/articles/index.ts
+++ b/src/pages/api/v1/articles/index.ts
@@ -5,6 +5,7 @@ import * as z from 'zod';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { ArticleSort } from '~/server/common/enums';
 import { getArticles } from '~/server/services/article.service';
+import { isAppBlocksAuthorEnabled } from '~/server/services/app-blocks-flag';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { getNextPage } from '~/server/utils/pagination-helpers';
 import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
@@ -76,6 +77,16 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
+  // App Blocks author-cohort gate — this endpoint is a DARK preview, reachable
+  // ONLY by the `appBlocksAuthor` cohort (mods via the static floor + the
+  // `app-blocks-author` Flipt cohort). Everyone else — INCLUDING anonymous (no
+  // user → not in cohort) — gets a bare 404, indistinguishable from a
+  // non-existent route (no existence oracle). Evaluated FIRST, before the rate
+  // limit + service, so no work leaks to a non-cohort caller.
+  if (!(await isAppBlocksAuthorEnabled({ user }))) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+
   // Conservative per-client rate limit (before the expensive service call).
   const rateLimit = await checkPublicApiRateLimit({ req, family: 'articles', userId: user?.id });
   if (!rateLimit.allowed) {

--- a/src/pages/api/v1/collections/[id].ts
+++ b/src/pages/api/v1/collections/[id].ts
@@ -7,6 +7,7 @@ import {
   getCollectionById,
   getUserCollectionPermissionsById,
 } from '~/server/services/collection.service';
+import { isAppBlocksAuthorEnabled } from '~/server/services/app-blocks-flag';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
 import {
@@ -39,6 +40,13 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
+  // App Blocks author-cohort gate — DARK preview, cohort-only (mods + the
+  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → bare 404 (no
+  // existence oracle), evaluated before the rate limit + service.
+  if (!(await isAppBlocksAuthorEnabled({ user }))) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+
   const rateLimit = await checkPublicApiRateLimit({ req, family: 'collections', userId: user?.id });
   if (!rateLimit.allowed) {
     res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));

--- a/src/pages/api/v1/collections/[id].ts
+++ b/src/pages/api/v1/collections/[id].ts
@@ -40,11 +40,14 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
-  // App Blocks author-cohort gate — DARK preview, cohort-only (mods + the
-  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → bare 404 (no
-  // existence oracle), evaluated before the rate limit + service.
+  // App Blocks author-cohort gate — preview, cohort-only (mods + the
+  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → 403 with a clear
+  // preview message (invited-cohort DX: explain the restriction rather than an
+  // opaque 404), evaluated before the rate limit + service.
   if (!(await isAppBlocksAuthorEnabled({ user }))) {
-    return res.status(404).json({ error: 'Not found' });
+    return res.status(403).json({
+      error: 'This API is in preview — access is restricted to Civitai moderators and app developers.',
+    });
   }
 
   const rateLimit = await checkPublicApiRateLimit({ req, family: 'collections', userId: user?.id });

--- a/src/pages/api/v1/collections/[id].ts
+++ b/src/pages/api/v1/collections/[id].ts
@@ -1,0 +1,102 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { Session } from '~/types/session';
+import * as z from 'zod';
+
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import {
+  getCollectionById,
+  getUserCollectionPermissionsById,
+} from '~/server/services/collection.service';
+import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
+import {
+  allBrowsingLevelsFlag,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
+import { Flags } from '~/shared/utils/flags';
+import { CollectionReadConfiguration } from '~/shared/utils/prisma/enums';
+import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
+
+/**
+ * GET /api/v1/collections/[id] — public collection detail.
+ *
+ * VISIBILITY (existence-leak-safe): the read decision reuses the EXISTING
+ * `getUserCollectionPermissionsById` (the same authority `getCollectionByIdHandler`
+ * uses) — `read` is true for Public/Unlisted collections and for the
+ * owner/contributor/moderator of a private one. A caller without read permission,
+ * OR a non-existent collection, gets the SAME bare 404, so this is not a
+ * private-collection existence oracle. `getCollectionById` itself does NO gating,
+ * so this permission check is REQUIRED before calling it. Ownership comes solely
+ * from the authenticated session — never a client param.
+ *
+ * Maturity: the cover image is clamped to the region-narrowed browsing ceiling.
+ */
+
+export const schema = z.object({ id: z.coerce.number().int().gt(0).lte(2147483647) });
+
+export default MixedAuthEndpoint(async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  user: Session['user'] | undefined
+) {
+  const rateLimit = await checkPublicApiRateLimit({ req, family: 'collections', userId: user?.id });
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.setHeader('Cache-Control', 'no-store');
+    return res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
+  }
+
+  const parsedParams = schema.safeParse(req.query);
+  if (!parsedParams.success)
+    return res.status(400).json({ error: z.prettifyError(parsedParams.error) ?? 'Invalid id' });
+
+  const { id } = parsedParams.data;
+
+  const region = getRegion(req);
+  const browsingLevel = isRegionRestricted(region)
+    ? sfwBrowsingLevelsFlag
+    : allBrowsingLevelsFlag;
+
+  try {
+    // VISIBILITY gate. No read permission → 404 (indistinguishable from a
+    // non-existent collection — no existence oracle).
+    const permissions = await getUserCollectionPermissionsById({
+      id,
+      userId: user?.id,
+      isModerator: user?.isModerator,
+    });
+    if (!permissions.read) return res.status(404).json({ error: `No collection with id ${id}` });
+
+    // getCollectionById throws NOT_FOUND when the row is gone → handleEndpointError
+    // maps it to the same 404.
+    const collection = await getCollectionById({ input: { id } });
+
+    const coverWithinCeiling =
+      !!collection.image?.url &&
+      (!collection.image.nsfwLevel ||
+        Flags.intersects(collection.image.nsfwLevel, browsingLevel));
+
+    return res.status(200).json({
+      id: collection.id,
+      name: collection.name,
+      description: collection.description ?? null,
+      type: collection.type ?? null,
+      nsfwLevel: collection.nsfwLevel ?? null,
+      read: collection.read,
+      isPublic: collection.read === CollectionReadConfiguration.Public,
+      coverImageUrl:
+        coverWithinCeiling && collection.image?.url
+          ? getEdgeUrl(collection.image.url, {
+              width: 450,
+              type: collection.image.type ?? undefined,
+            })
+          : null,
+      user: collection.user
+        ? { id: collection.user.id, username: collection.user.username ?? null }
+        : { id: collection.userId, username: null },
+      tags: collection.tags?.map((t) => ({ id: t.id, name: t.name })) ?? [],
+    });
+  } catch (e) {
+    return handleEndpointError(res, e);
+  }
+});

--- a/src/pages/api/v1/collections/index.ts
+++ b/src/pages/api/v1/collections/index.ts
@@ -9,6 +9,7 @@ import {
   getCollectionItemCount,
   getUserCollectionsWithPermissions,
 } from '~/server/services/collection.service';
+import { isAppBlocksAuthorEnabled } from '~/server/services/app-blocks-flag';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { getNextPage } from '~/server/utils/pagination-helpers';
 import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
@@ -85,6 +86,13 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
+  // App Blocks author-cohort gate — DARK preview, cohort-only (mods + the
+  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → bare 404 (no
+  // existence oracle), evaluated before the rate limit + service.
+  if (!(await isAppBlocksAuthorEnabled({ user }))) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+
   const rateLimit = await checkPublicApiRateLimit({ req, family: 'collections', userId: user?.id });
   if (!rateLimit.allowed) {
     res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));

--- a/src/pages/api/v1/collections/index.ts
+++ b/src/pages/api/v1/collections/index.ts
@@ -1,0 +1,235 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { Session } from '~/types/session';
+import * as z from 'zod';
+
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { CollectionSort } from '~/server/common/enums';
+import {
+  getAllCollections,
+  getCollectionItemCount,
+  getUserCollectionsWithPermissions,
+} from '~/server/services/collection.service';
+import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { getNextPage } from '~/server/utils/pagination-helpers';
+import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
+import {
+  allBrowsingLevelsFlag,
+  publicBrowsingLevelsFlag,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
+import { Flags } from '~/shared/utils/flags';
+import {
+  CollectionItemStatus,
+  CollectionReadConfiguration,
+  MediaType,
+} from '~/shared/utils/prisma/enums';
+import { booleanString } from '~/utils/zod-helpers';
+import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
+
+/**
+ * GET /api/v1/collections — public list/search over collections.
+ *
+ * Two modes, both wrapping EXISTING services (no reimplemented business logic):
+ *   - default (public): `getAllCollections`, whose privacy is PINNED to
+ *     `[Public]` for any non-moderator caller (the service forces this itself),
+ *     so an unauthenticated caller only ever sees Public collections.
+ *   - `mine=true` (authenticated only → 401 otherwise): the caller's OWN
+ *     collections via `getUserCollectionsWithPermissions`, keyed on the SESSION
+ *     user id — never a client-supplied userId.
+ *
+ * A private collection is therefore unreachable here for a non-owner. Maturity is
+ * clamped to the region-narrowed browsing ceiling (a collection / cover above the
+ * ceiling is dropped or its cover nulled), matching the other public endpoints.
+ *
+ * Envelope: `{ items, metadata: { nextCursor, nextPage } }` (keyset cursor on the
+ * collection id, id DESC), consistent with the other public v1 endpoints.
+ */
+
+export const config = {
+  api: {
+    responseLimit: false,
+  },
+};
+
+const collectionsEndpointSchema = z.object({
+  limit: z.preprocess((val) => Number(val), z.number().min(1).max(100)).default(100),
+  cursor: z.coerce.number().int().positive().optional(),
+  query: z.string().trim().max(100).optional(),
+  sort: z.enum(CollectionSort).optional(),
+  mine: booleanString().optional().default(false),
+  nsfw: booleanString().optional(),
+});
+
+// A level of 0 (unrated) is always allowed; otherwise it must intersect the
+// clamped browsing level (identical bitwise test the feed / block endpoints use).
+function withinCeiling(nsfwLevel: number | null | undefined, browsingLevel: number): boolean {
+  if (!nsfwLevel) return true;
+  return Flags.intersects(nsfwLevel, browsingLevel);
+}
+
+type CollectionListItem = {
+  id: number;
+  name: string;
+  description: string | null;
+  type: string | null;
+  nsfwLevel: number | null;
+  read: CollectionReadConfiguration;
+  isPublic: boolean;
+  itemCount: number;
+  coverImageUrl: string | null;
+  user: { id: number | null; username: string | null };
+};
+
+export default MixedAuthEndpoint(async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse,
+  user: Session['user'] | undefined
+) {
+  const rateLimit = await checkPublicApiRateLimit({ req, family: 'collections', userId: user?.id });
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.setHeader('Cache-Control', 'no-store');
+    return res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
+  }
+
+  const parsedParams = collectionsEndpointSchema.safeParse(req.query);
+  if (!parsedParams.success) return res.status(400).json({ error: parsedParams.error });
+
+  const { limit, cursor, query, sort, mine, nsfw } = parsedParams.data;
+
+  if (mine && !user) return res.status(401).json({ error: 'Unauthorized' });
+
+  const region = getRegion(req);
+  let browsingLevel = !nsfw ? publicBrowsingLevelsFlag : allBrowsingLevelsFlag;
+  if (isRegionRestricted(region)) browsingLevel = sfwBrowsingLevelsFlag;
+
+  const coverUrl = (
+    image: { url: string; type: MediaType | null; nsfwLevel: number | null } | null | undefined
+  ): string | null =>
+    image?.url && withinCeiling(image.nsfwLevel, browsingLevel)
+      ? getEdgeUrl(image.url, { width: 450, type: image.type ?? undefined })
+      : null;
+
+  try {
+    if (mine && user) {
+      // Own collections. The service returns the full owned set (no DB paging);
+      // apply the name filter + keyset (id DESC) slice in-memory. A user's own
+      // collection set is bounded.
+      const owned = await getUserCollectionsWithPermissions({
+        input: { userId: user.id, contributingOnly: true },
+      });
+
+      const needle = query?.toLowerCase();
+      const filtered = owned
+        .filter((c) => (needle ? c.name.toLowerCase().includes(needle) : true))
+        .filter((c) => (cursor ? c.id < cursor : true))
+        .sort((a, b) => b.id - a.id);
+
+      let page = filtered;
+      let nextCursor: number | undefined;
+      if (page.length > limit) {
+        page = page.slice(0, limit);
+        nextCursor = page[page.length - 1]?.id;
+      }
+
+      const ids = page.map((c) => c.id);
+      const countRows = await getCollectionItemCount({
+        collectionIds: ids,
+        status: CollectionItemStatus.ACCEPTED,
+      });
+      const countMap = new Map(countRows.map((c) => [c.id, Number(c.count)]));
+
+      const items: CollectionListItem[] = page.map((c) => ({
+        id: c.id,
+        name: c.name,
+        description: c.description ?? null,
+        type: c.type ?? null,
+        nsfwLevel: null,
+        read: c.read,
+        isPublic: c.read === CollectionReadConfiguration.Public,
+        itemCount: countMap.get(c.id) ?? 0,
+        coverImageUrl: coverUrl(
+          c.image
+            ? { url: c.image.url, type: c.image.type, nsfwLevel: c.image.nsfwLevel }
+            : null
+        ),
+        user: { id: user.id, username: user.username ?? null },
+      }));
+
+      const nextCursorStr = nextCursor !== undefined ? String(nextCursor) : undefined;
+      const { nextPage } = getNextPage({ req, nextCursor: nextCursorStr });
+      return res
+        .status(200)
+        .json({ items, metadata: { nextCursor: nextCursor ?? undefined, nextPage } });
+    }
+
+    // Public discovery. Over-fetch so the maturity clamp can't under-fill the page
+    // and terminate pagination early; walk (createdAt DESC) rows collecting visible
+    // ones until the page is full, then resume the keyset from the first fetched row
+    // we did NOT consume (getAllCollections' cursor is inclusive).
+    const OVERFETCH = limit * 4 + 1;
+    const rows = await getAllCollections({
+      input: {
+        limit: OVERFETCH,
+        cursor,
+        query,
+        sort,
+        privacy: [CollectionReadConfiguration.Public],
+      },
+      user,
+      select: {
+        id: true,
+        name: true,
+        description: true,
+        read: true,
+        type: true,
+        nsfwLevel: true,
+        userId: true,
+        user: { select: { id: true, username: true } },
+        image: { select: { url: true, type: true, nsfwLevel: true } },
+      },
+    });
+
+    const visible: typeof rows = [];
+    let firstUnconsumedId: number | undefined;
+    for (let i = 0; i < rows.length; i++) {
+      if (visible.length >= limit) {
+        firstUnconsumedId = rows[i].id;
+        break;
+      }
+      if (withinCeiling(rows[i].nsfwLevel ?? 0, browsingLevel)) visible.push(rows[i]);
+    }
+
+    let nextCursor: number | undefined;
+    if (firstUnconsumedId !== undefined) nextCursor = firstUnconsumedId;
+    else if (rows.length === OVERFETCH) nextCursor = rows[rows.length - 1]?.id;
+
+    const ids = visible.map((c) => c.id);
+    const countRows = await getCollectionItemCount({
+      collectionIds: ids,
+      status: CollectionItemStatus.ACCEPTED,
+    });
+    const countMap = new Map(countRows.map((c) => [c.id, Number(c.count)]));
+
+    const items: CollectionListItem[] = visible.map((c) => ({
+      id: c.id,
+      name: c.name,
+      description: c.description ?? null,
+      type: c.type ?? null,
+      nsfwLevel: c.nsfwLevel ?? null,
+      read: c.read,
+      isPublic: c.read === CollectionReadConfiguration.Public,
+      itemCount: countMap.get(c.id) ?? 0,
+      coverImageUrl: coverUrl(c.image),
+      user: { id: c.user?.id ?? c.userId ?? null, username: c.user?.username ?? null },
+    }));
+
+    const nextCursorStr = nextCursor !== undefined ? String(nextCursor) : undefined;
+    const { nextPage } = getNextPage({ req, nextCursor: nextCursorStr });
+    return res
+      .status(200)
+      .json({ items, metadata: { nextCursor: nextCursor ?? undefined, nextPage } });
+  } catch (e) {
+    return handleEndpointError(res, e);
+  }
+});

--- a/src/pages/api/v1/collections/index.ts
+++ b/src/pages/api/v1/collections/index.ts
@@ -86,11 +86,14 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
-  // App Blocks author-cohort gate — DARK preview, cohort-only (mods + the
-  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → bare 404 (no
-  // existence oracle), evaluated before the rate limit + service.
+  // App Blocks author-cohort gate — preview, cohort-only (mods + the
+  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → 403 with a clear
+  // preview message (invited-cohort DX: explain the restriction rather than an
+  // opaque 404), evaluated before the rate limit + service.
   if (!(await isAppBlocksAuthorEnabled({ user }))) {
-    return res.status(404).json({ error: 'Not found' });
+    return res.status(403).json({
+      error: 'This API is in preview — access is restricted to Civitai moderators and app developers.',
+    });
   }
 
   const rateLimit = await checkPublicApiRateLimit({ req, family: 'collections', userId: user?.id });

--- a/src/pages/api/v1/collections/index.ts
+++ b/src/pages/api/v1/collections/index.ts
@@ -163,10 +163,25 @@ export default MixedAuthEndpoint(async function handler(
         .json({ items, metadata: { nextCursor: nextCursor ?? undefined, nextPage } });
     }
 
-    // Public discovery. Over-fetch so the maturity clamp can't under-fill the page
-    // and terminate pagination early; walk (createdAt DESC) rows collecting visible
-    // ones until the page is full, then resume the keyset from the first fetched row
-    // we did NOT consume (getAllCollections' cursor is inclusive).
+    // Public discovery. The keyset cursor is id-based, which only tracks the
+    // default `createdAt DESC` ordering. Under `sort=MostContributors`
+    // `getAllCollections` orders by contributor `_count` — an id cursor there
+    // positions Prisma at an arbitrary point in that ordering, silently
+    // skipping/duplicating rows across pages. Rather than return corrupt pages,
+    // reject the unsupported combination explicitly. (First-page reads with
+    // `MostContributors` and NO cursor are still fine.)
+    if (sort === CollectionSort.MostContributors && cursor !== undefined) {
+      return res.status(400).json({
+        error:
+          'Cursor pagination is only supported for the default (Newest) sort. ' +
+          'Omit `sort=Most Followers` when paginating with a cursor, or request the first page without a cursor.',
+      });
+    }
+
+    // Over-fetch so the maturity clamp can't under-fill the page and terminate
+    // pagination early; walk (createdAt DESC) rows collecting visible ones until
+    // the page is full, then resume the keyset from the first fetched row we did
+    // NOT consume (getAllCollections' cursor is inclusive).
     const OVERFETCH = limit * 4 + 1;
     const rows = await getAllCollections({
       input: {

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -174,9 +174,16 @@ export const getArticles = async ({
   pending,
   browsingLevel,
   include,
+  forceHidePrivate,
 }: GetInfiniteArticlesSchema & {
   sessionUser?: { id: number; isModerator?: boolean; username?: string };
   include?: Array<'cosmetics'>;
+  // When true, `availability = Private` articles are ALWAYS dropped, even when a
+  // `username`/`collectionId`/etc. filter is set (which normally expands the result
+  // set to include the caller's private articles). Used by the public REST surface
+  // so an anonymous `?username=X` request can never surface a user's private
+  // articles. Defaults to false → the website/tRPC path is unchanged.
+  forceHidePrivate?: boolean;
 }) => {
   const userId = sessionUser?.id;
   const isModerator = sessionUser?.isModerator ?? false;
@@ -188,7 +195,8 @@ export const getArticles = async ({
       !!sessionUser?.username &&
       postgresSlugify(sessionUser.username) === postgresSlugify(username);
     const hidePrivateArticles =
-      !ids && !username && !collectionId && !followed && !hidden && !favorites && !userIds;
+      forceHidePrivate ||
+      (!ids && !username && !collectionId && !followed && !hidden && !favorites && !userIds);
 
     const AND: Prisma.Sql[] = [];
 

--- a/src/server/utils/__tests__/public-api-rate-limit.test.ts
+++ b/src/server/utils/__tests__/public-api-rate-limit.test.ts
@@ -1,0 +1,146 @@
+import type { NextApiRequest } from 'next';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit coverage for the public REST articles/collections rate limiter
+ * (checkPublicApiRateLimit + resolveClientIp). The security-relevant contract:
+ * the unauthenticated bucket is keyed on the Cloudflare-trusted
+ * `CF-Connecting-IP` header (not the client-spoofable raw `X-Forwarded-For`
+ * chain), so a caller can't rotate XFF to escape their per-IP window. The authed
+ * bucket is keyed on the userId regardless of any header.
+ *
+ * The redis cache client is mocked so no real connection is constructed.
+ */
+
+const { mockRedis } = vi.hoisted(() => ({
+  mockRedis: {
+    incrBy: vi.fn(),
+    expire: vi.fn(),
+    ttl: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+}));
+
+import {
+  checkPublicApiRateLimit,
+  resolveClientIp,
+  PUBLIC_API_RATE_LIMIT_AUTH_MAX,
+  PUBLIC_API_RATE_LIMIT_UNAUTH_MAX,
+} from '../public-api-rate-limit';
+
+function reqWith(headers: Record<string, string | string[]>): NextApiRequest {
+  return { headers } as unknown as NextApiRequest;
+}
+
+// The key redis.incrBy was called with (the full bucket key).
+function lastKey(): string {
+  const calls = mockRedis.incrBy.mock.calls;
+  return calls[calls.length - 1][0] as string;
+}
+
+describe('resolveClientIp', () => {
+  it('prefers CF-Connecting-IP over X-Forwarded-For', () => {
+    const ip = resolveClientIp(
+      reqWith({ 'cf-connecting-ip': '203.0.113.7', 'x-forwarded-for': '1.2.3.4' })
+    );
+    expect(ip).toBe('203.0.113.7');
+  });
+
+  it('takes the first element when cf-connecting-ip is an array + trims whitespace', () => {
+    const ip = resolveClientIp(reqWith({ 'cf-connecting-ip': [' 203.0.113.9 ', '5.5.5.5'] }));
+    expect(ip).toBe('203.0.113.9');
+  });
+
+  it('falls back to X-Forwarded-For when there is no CF header (non-CF / local)', () => {
+    const ip = resolveClientIp(reqWith({ 'x-forwarded-for': '198.51.100.1' }));
+    expect(ip).toBe('198.51.100.1');
+  });
+});
+
+describe('checkPublicApiRateLimit', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRedis.incrBy.mockResolvedValue(1);
+    mockRedis.expire.mockResolvedValue(true);
+    mockRedis.ttl.mockResolvedValue(60);
+  });
+
+  it('unauth: keys the bucket on CF-Connecting-IP, not the raw XFF', async () => {
+    await checkPublicApiRateLimit({
+      req: reqWith({ 'cf-connecting-ip': '203.0.113.7', 'x-forwarded-for': '1.2.3.4' }),
+      family: 'articles',
+    });
+    const key = lastKey();
+    expect(key).toContain('ip:203.0.113.7');
+    expect(key).not.toContain('1.2.3.4');
+  });
+
+  it('SECURITY: two requests with different injected XFF but the SAME CF-Connecting-IP share one bucket', async () => {
+    await checkPublicApiRateLimit({
+      req: reqWith({ 'cf-connecting-ip': '203.0.113.7', 'x-forwarded-for': '10.0.0.1' }),
+      family: 'articles',
+    });
+    const keyA = lastKey();
+    await checkPublicApiRateLimit({
+      req: reqWith({ 'cf-connecting-ip': '203.0.113.7', 'x-forwarded-for': '10.0.0.99' }),
+      family: 'articles',
+    });
+    const keyB = lastKey();
+    expect(keyA).toBe(keyB);
+  });
+
+  it('each family gets its own bucket for the same client IP', async () => {
+    const headers = { 'cf-connecting-ip': '203.0.113.7' };
+    await checkPublicApiRateLimit({ req: reqWith(headers), family: 'articles' });
+    const articlesKey = lastKey();
+    await checkPublicApiRateLimit({ req: reqWith(headers), family: 'collections' });
+    const collectionsKey = lastKey();
+    expect(articlesKey).not.toBe(collectionsKey);
+    expect(articlesKey).toContain('articles');
+    expect(collectionsKey).toContain('collections');
+  });
+
+  it('authed: keys on the userId and ignores the client IP header entirely', async () => {
+    await checkPublicApiRateLimit({
+      req: reqWith({ 'cf-connecting-ip': '203.0.113.7' }),
+      family: 'articles',
+      userId: 42,
+    });
+    const key = lastKey();
+    expect(key).toContain('user:42');
+    expect(key).not.toContain('203.0.113.7');
+  });
+
+  it('over the ceiling → not allowed + Retry-After = live TTL', async () => {
+    mockRedis.incrBy.mockResolvedValue(PUBLIC_API_RATE_LIMIT_UNAUTH_MAX + 1);
+    mockRedis.ttl.mockResolvedValue(9);
+    const res = await checkPublicApiRateLimit({
+      req: reqWith({ 'cf-connecting-ip': '203.0.113.7' }),
+      family: 'articles',
+    });
+    expect(res).toEqual({ allowed: false, retryAfterSeconds: 9 });
+  });
+
+  it('authed callers get the higher ceiling (still allowed at the unauth max + 1)', async () => {
+    mockRedis.incrBy.mockResolvedValue(PUBLIC_API_RATE_LIMIT_UNAUTH_MAX + 1);
+    const res = await checkPublicApiRateLimit({
+      req: reqWith({ 'cf-connecting-ip': '203.0.113.7' }),
+      family: 'articles',
+      userId: 42,
+    });
+    expect(PUBLIC_API_RATE_LIMIT_AUTH_MAX).toBeGreaterThan(PUBLIC_API_RATE_LIMIT_UNAUTH_MAX);
+    expect(res).toEqual({ allowed: true });
+  });
+
+  it('redis error → FAIL OPEN (allowed)', async () => {
+    mockRedis.incrBy.mockRejectedValue(new Error('redis down'));
+    const res = await checkPublicApiRateLimit({
+      req: reqWith({ 'cf-connecting-ip': '203.0.113.7' }),
+      family: 'articles',
+    });
+    expect(res).toEqual({ allowed: true });
+  });
+});

--- a/src/server/utils/public-api-rate-limit.ts
+++ b/src/server/utils/public-api-rate-limit.ts
@@ -1,0 +1,112 @@
+import type { NextApiRequest } from 'next';
+import requestIp from 'request-ip';
+import { redis } from '~/server/redis/client';
+
+/**
+ * Conservative per-client fixed-window rate limit for the PUBLIC REST endpoints
+ * that expose articles + collections (`/api/v1/articles[/:id]`,
+ * `/api/v1/collections[/:id]`).
+ *
+ * WHY: these routes make articles/collections publicly REST-accessible for the
+ * first time — a brand-new origin-exposure surface. The pre-existing public
+ * endpoints (models/images) ship with NO per-endpoint ceiling; for a NEW surface
+ * we start deliberately CAUTIOUS (easy to loosen later once real traffic shape is
+ * known) so a scraper can't shift unbounded catalog cost onto the origin.
+ *
+ * PATTERN: the established fixed-window limiter — INCR + EXPIRE on the `redis`
+ * cache client — byte-identical in shape to `checkBlockCatalogRateLimit` /
+ * `checkSharedAppendRateLimit` / `BlockTokenService.checkRateLimit`.
+ *
+ * KEY: keyed on the CLIENT IP for unauthenticated callers, and on the USER ID for
+ * authenticated callers (who get a higher bucket — a logged-in integration is a
+ * known principal, not anonymous scraper traffic). The `family` segment
+ * (`articles` | `collections`) gives each endpoint-family its OWN independent
+ * bucket, so hammering articles never consumes a caller's collections budget.
+ *
+ * FAIL-OPEN: any redis error/timeout returns `allowed:true` — a read endpoint
+ * must never hard-fail a public GET because the limiter's redis blipped. Mirrors
+ * every sibling limiter. (The abuse ceiling is defence-in-depth, not the
+ * authorization boundary — visibility gating is enforced independently in each
+ * handler.)
+ */
+
+// CONSERVATIVE ceilings (named constants → trivially tunable). Chosen strict on
+// purpose for a fresh public surface:
+//   - Unauthenticated: 60 requests / minute / IP. A human browsing paginated
+//     articles/collections issues at most a handful of requests per page view;
+//     60/min (1/s sustained) is generous for that yet hard-caps a scraper walking
+//     the catalog from a single IP.
+//   - Authenticated: 120 requests / minute / user. A logged-in integration (e.g.
+//     the CLI) gets 2× headroom for legitimate batch reads while still bounded.
+// Both are easy to raise once real traffic is observed; err strict first.
+export const PUBLIC_API_RATE_LIMIT_UNAUTH_MAX = 60;
+export const PUBLIC_API_RATE_LIMIT_AUTH_MAX = 120;
+export const PUBLIC_API_RATE_LIMIT_WINDOW_SECONDS = 60;
+
+// Distinct top-level namespace so these buckets never contend with any other
+// limiter's keys.
+const KEY_PREFIX = 'public-api:rate-limit';
+
+export type PublicApiRateLimitFamily = 'articles' | 'collections';
+
+export type PublicApiRateLimitResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number };
+
+function resolveClientIp(req: NextApiRequest): string {
+  return requestIp.getClientIp(req) ?? 'unknown';
+}
+
+async function checkFixedWindow(
+  key: string,
+  max: number,
+  windowSeconds: number
+): Promise<PublicApiRateLimitResult> {
+  try {
+    const count = await redis.incrBy(key as never, 1);
+    if (count === 1) {
+      await redis.expire(key as never, windowSeconds);
+    } else {
+      // Re-assert a lost TTL (a crash between INCR and EXPIRE would otherwise
+      // strand a TTL-less key → permanent lock). Same mitigation the sibling
+      // limiters use.
+      const ttl = await redis.ttl(key as never);
+      if (ttl < 0) await redis.expire(key as never, windowSeconds);
+    }
+
+    if (count <= max) return { allowed: true };
+
+    let retryAfter = await redis.ttl(key as never);
+    if (!Number.isFinite(retryAfter) || retryAfter < 1) retryAfter = windowSeconds;
+    return { allowed: false, retryAfterSeconds: retryAfter };
+  } catch {
+    // Fail open — a redis incident must never break a public read.
+    return { allowed: true };
+  }
+}
+
+/**
+ * Records one request against the caller's per-family window and reports whether
+ * it is within the conservative ceiling.
+ *
+ * @param req    the incoming request (client IP is resolved from it for the
+ *   unauthenticated bucket via the same `request-ip` resolver createContext uses).
+ * @param family `articles` | `collections` — independent bucket per family.
+ * @param userId the authenticated user id when present; keys the (higher) authed
+ *   bucket. `undefined` → the per-IP unauthenticated bucket.
+ */
+export async function checkPublicApiRateLimit({
+  req,
+  family,
+  userId,
+}: {
+  req: NextApiRequest;
+  family: PublicApiRateLimitFamily;
+  userId?: number;
+}): Promise<PublicApiRateLimitResult> {
+  const authed = typeof userId === 'number';
+  const max = authed ? PUBLIC_API_RATE_LIMIT_AUTH_MAX : PUBLIC_API_RATE_LIMIT_UNAUTH_MAX;
+  const bucket = authed ? `user:${userId}` : `ip:${resolveClientIp(req)}`;
+  const key = `${KEY_PREFIX}:${family}:${bucket}`;
+  return checkFixedWindow(key, max, PUBLIC_API_RATE_LIMIT_WINDOW_SECONDS);
+}

--- a/src/server/utils/public-api-rate-limit.ts
+++ b/src/server/utils/public-api-rate-limit.ts
@@ -53,7 +53,23 @@ export type PublicApiRateLimitResult =
   | { allowed: true }
   | { allowed: false; retryAfterSeconds: number };
 
-function resolveClientIp(req: NextApiRequest): string {
+/**
+ * Resolve the rate-limit client IP.
+ *
+ * PREFER Cloudflare's `CF-Connecting-IP` (Next lowercases header keys →
+ * `cf-connecting-ip`): CF sets it to the real client IP and — unlike the raw
+ * `X-Forwarded-For` chain — a caller CANNOT spoof it through Cloudflare, so it
+ * can't be rotated to escape the per-IP bucket. Fall back to
+ * `requestIp.getClientIp` (which reads XFF/socket) only for non-CF / local
+ * requests that never traversed Cloudflare. Same header the bot-detection
+ * middleware and region-blocking trust.
+ *
+ * Exported for unit testing.
+ */
+export function resolveClientIp(req: NextApiRequest): string {
+  const cfip = req.headers['cf-connecting-ip'];
+  const cf = Array.isArray(cfip) ? cfip[0] : cfip;
+  if (cf && cf.trim()) return cf.trim();
   return requestIp.getClientIp(req) ?? 'unknown';
 }
 

--- a/src/tests/api/v1/articles/index.test.ts
+++ b/src/tests/api/v1/articles/index.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import { getHTTPStatusCodeFromError } from '@trpc/server/http';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+
+// Hoisted mocks for the wrapped service + the rate limiter.
+const { mockGetArticles, mockGetArticleById, mockRateLimit } = vi.hoisted(() => ({
+  mockGetArticles: vi.fn(),
+  mockGetArticleById: vi.fn(),
+  mockRateLimit: vi.fn(),
+}));
+
+vi.mock('~/server/services/article.service', () => ({
+  getArticles: mockGetArticles,
+  getArticleById: mockGetArticleById,
+}));
+
+vi.mock('~/server/utils/public-api-rate-limit', () => ({
+  checkPublicApiRateLimit: mockRateLimit,
+}));
+
+// MixedAuthEndpoint → passthrough that injects the test session user (req.user).
+// handleEndpointError → faithful minimal reimplementation (TRPCError → mapped
+// HTTP status), so a NOT_FOUND from the service becomes a 404.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  MixedAuthEndpoint:
+    (handler: any) =>
+    (req: any, res: any) =>
+      handler(req, res, req.user),
+  handleEndpointError: (res: any, e: any) => {
+    if (e instanceof TRPCError) {
+      const status = getHTTPStatusCodeFromError(e);
+      let body: unknown;
+      try {
+        body = JSON.parse(e.message);
+      } catch {
+        body = { message: e.message };
+      }
+      return res.status(status).json(body);
+    }
+    return res.status(500).json({ message: 'error', error: (e as Error).message });
+  },
+}));
+
+// Region resolver kept deterministic (not restricted) so browsingLevel is the
+// public flag and assertions are stable.
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => ({}),
+  isRegionRestricted: () => false,
+}));
+
+import listHandler from '~/pages/api/v1/articles/index';
+import detailHandler from '~/pages/api/v1/articles/[id]';
+
+function createMocks({
+  query = {},
+  user,
+}: {
+  query?: Record<string, string | string[]>;
+  user?: { id: number; isModerator?: boolean; username?: string };
+}) {
+  let statusCode = 200;
+  let payload: any = undefined;
+  const headers: Record<string, string> = {};
+
+  const req = {
+    method: 'GET',
+    headers: {},
+    url: '/api/v1/articles',
+    query,
+    user,
+  } as unknown as NextApiRequest & { user?: any };
+
+  const res = {
+    headersSent: false,
+    setHeader(name: string, value: string) {
+      headers[name.toLowerCase()] = value;
+      return res;
+    },
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(body: any) {
+      payload = body;
+      return res;
+    },
+    end() {
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+    _getHeader: (name: string) => headers[name.toLowerCase()],
+  } as unknown as NextApiResponse & {
+    _getStatusCode: () => number;
+    _getJSONData: () => any;
+    _getHeader: (name: string) => string | undefined;
+  };
+
+  return { req, res };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRateLimit.mockResolvedValue({ allowed: true });
+});
+
+describe('GET /api/v1/articles (list)', () => {
+  it('returns the { items, metadata } envelope and serializes the composite cursor', async () => {
+    mockGetArticles.mockResolvedValue({
+      items: [{ id: 1, title: 'a' }],
+      nextCursor: { v: 123.5, id: 7 },
+    });
+    const { req, res } = createMocks({ query: { limit: '2' } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const body = res._getJSONData();
+    expect(body.items).toEqual([{ id: 1, title: 'a' }]);
+    expect(body.metadata.nextCursor).toBe('123.5|7');
+    expect(body.metadata.nextPage).toContain('cursor=123.5%7C7');
+  });
+
+  it('SECURITY: unauthenticated call passes sessionUser=undefined and NEVER a client-supplied userId (visibility delegated to the gated service)', async () => {
+    mockGetArticles.mockResolvedValue({ items: [], nextCursor: undefined });
+    // A client tries to inject userId — the endpoint schema doesn't expose it.
+    const { req, res } = createMocks({ query: { userId: '5', userIds: '5,6' } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const args = mockGetArticles.mock.calls[0][0];
+    expect(args.sessionUser).toBeUndefined();
+    expect(args.userIds).toBeUndefined();
+    expect(args.userId).toBeUndefined();
+    // Non-nsfw + non-restricted region → public browsing ceiling.
+    expect(args.browsingLevel).toBe(publicBrowsingLevelsFlag);
+    // published-only guard pinned on top of the service's own gate.
+    expect(args.period).toBe('AllTime');
+    expect(args.periodMode).toBe('published');
+    expect(args.favorites).toBe(false);
+    expect(args.hidden).toBe(false);
+  });
+
+  it('401s when an unauthenticated caller requests favorites/hidden (own-engagement, authed-only)', async () => {
+    const { req, res } = createMocks({ query: { favorites: 'true' } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(mockGetArticles).not.toHaveBeenCalled();
+  });
+
+  it('400s on a malformed cursor', async () => {
+    const { req, res } = createMocks({ query: { cursor: 'not-a-cursor' } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockGetArticles).not.toHaveBeenCalled();
+  });
+
+  it('RATE LIMIT: returns 429 + Retry-After and skips the service when the limiter denies', async () => {
+    mockRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 42 });
+    const { req, res } = createMocks({ query: {} });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(429);
+    expect(res._getHeader('Retry-After')).toBe('42');
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+    expect(mockGetArticles).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/v1/articles/[id] (detail)', () => {
+  it('strips moderatorNsfwLevel and returns the article; passes session identity (undefined when unauthed)', async () => {
+    mockGetArticleById.mockResolvedValue({
+      id: 3,
+      title: 't',
+      moderatorNsfwLevel: 8,
+      nsfwLevel: 1,
+    });
+    const { req, res } = createMocks({ query: { id: '3' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const body = res._getJSONData();
+    expect(body).toEqual({ id: 3, title: 't', nsfwLevel: 1 });
+    expect(body.moderatorNsfwLevel).toBeUndefined();
+    const args = mockGetArticleById.mock.calls[0][0];
+    expect(args).toMatchObject({ id: 3, userId: undefined, isModerator: undefined });
+  });
+
+  it('SECURITY: a private/unpublished article (service throws NOT_FOUND for a non-owner) 404s', async () => {
+    mockGetArticleById.mockRejectedValue(
+      new TRPCError({ code: 'NOT_FOUND', message: 'No article with id 99' })
+    );
+    const { req, res } = createMocks({ query: { id: '99' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it('400s on a non-numeric / out-of-range id', async () => {
+    const { req, res } = createMocks({ query: { id: '99999999999999999999' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockGetArticleById).not.toHaveBeenCalled();
+  });
+
+  it('RATE LIMIT: 429 + Retry-After, service skipped', async () => {
+    mockRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 10 });
+    const { req, res } = createMocks({ query: { id: '3' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(429);
+    expect(res._getHeader('Retry-After')).toBe('10');
+    expect(mockGetArticleById).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/api/v1/articles/index.test.ts
+++ b/src/tests/api/v1/articles/index.test.ts
@@ -4,12 +4,14 @@ import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 
-// Hoisted mocks for the wrapped service + the rate limiter.
-const { mockGetArticles, mockGetArticleById, mockRateLimit } = vi.hoisted(() => ({
-  mockGetArticles: vi.fn(),
-  mockGetArticleById: vi.fn(),
-  mockRateLimit: vi.fn(),
-}));
+// Hoisted mocks for the wrapped service + the rate limiter + the author-cohort gate.
+const { mockGetArticles, mockGetArticleById, mockRateLimit, mockIsAppBlocksAuthorEnabled } =
+  vi.hoisted(() => ({
+    mockGetArticles: vi.fn(),
+    mockGetArticleById: vi.fn(),
+    mockRateLimit: vi.fn(),
+    mockIsAppBlocksAuthorEnabled: vi.fn(),
+  }));
 
 vi.mock('~/server/services/article.service', () => ({
   getArticles: mockGetArticles,
@@ -18,6 +20,13 @@ vi.mock('~/server/services/article.service', () => ({
 
 vi.mock('~/server/utils/public-api-rate-limit', () => ({
   checkPublicApiRateLimit: mockRateLimit,
+}));
+
+// The App Blocks author-cohort gate — mock it so tests never touch real Flipt.
+// Default: in-cohort (true) so the existing happy-path assertions still exercise
+// the handler body; the dark-404 tests flip it to false.
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
 }));
 
 // MixedAuthEndpoint → passthrough that injects the test session user (req.user).
@@ -104,6 +113,60 @@ function createMocks({
 beforeEach(() => {
   vi.clearAllMocks();
   mockRateLimit.mockResolvedValue({ allowed: true });
+  // Default: caller IS in the author cohort (mod / app-dev-tester) so the
+  // existing behavioural tests reach the handler body. Dark-404 tests override.
+  mockIsAppBlocksAuthorEnabled.mockResolvedValue(true);
+});
+
+describe('GET /api/v1/articles — author-cohort gate (dark 404)', () => {
+  it('SECURITY: a non-cohort authed user gets a bare 404 and NEITHER the rate limiter NOR the service runs (list)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: {}, user: { id: 7, isModerator: false } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: { id: 7, isModerator: false } });
+    expect(mockRateLimit).not.toHaveBeenCalled();
+    expect(mockGetArticles).not.toHaveBeenCalled();
+  });
+
+  it('SECURITY: an anonymous caller gets a bare 404 (list)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: {} });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: undefined });
+    expect(mockRateLimit).not.toHaveBeenCalled();
+    expect(mockGetArticles).not.toHaveBeenCalled();
+  });
+
+  it('SECURITY: a non-cohort authed user gets a bare 404 (detail)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: { id: '3' }, user: { id: 7, isModerator: false } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(mockRateLimit).not.toHaveBeenCalled();
+    expect(mockGetArticleById).not.toHaveBeenCalled();
+  });
+
+  it('SECURITY: an anonymous caller gets a bare 404 (detail)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: { id: '3' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(mockRateLimit).not.toHaveBeenCalled();
+    expect(mockGetArticleById).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /api/v1/articles (list)', () => {

--- a/src/tests/api/v1/articles/index.test.ts
+++ b/src/tests/api/v1/articles/index.test.ts
@@ -144,6 +144,22 @@ describe('GET /api/v1/articles (list)', () => {
     expect(args.hidden).toBe(false);
   });
 
+  it('SECURITY: anon ?username=X forces forceHidePrivate=true so private-availability articles are never listed', async () => {
+    mockGetArticles.mockResolvedValue({ items: [], nextCursor: undefined });
+    const { req, res } = createMocks({ query: { username: 'someUser' } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const args = mockGetArticles.mock.calls[0][0];
+    // Even with a username filter (which normally lifts the private-drop for an
+    // owner self-view), the REST surface pins forceHidePrivate → the service
+    // ALWAYS drops availability=Private articles.
+    expect(args.username).toBe('someUser');
+    expect(args.forceHidePrivate).toBe(true);
+    expect(args.sessionUser).toBeUndefined();
+  });
+
   it('401s when an unauthenticated caller requests favorites/hidden (own-engagement, authed-only)', async () => {
     const { req, res } = createMocks({ query: { favorites: 'true' } });
 

--- a/src/tests/api/v1/articles/index.test.ts
+++ b/src/tests/api/v1/articles/index.test.ts
@@ -118,52 +118,56 @@ beforeEach(() => {
   mockIsAppBlocksAuthorEnabled.mockResolvedValue(true);
 });
 
-describe('GET /api/v1/articles — author-cohort gate (dark 404)', () => {
-  it('SECURITY: a non-cohort authed user gets a bare 404 and NEITHER the rate limiter NOR the service runs (list)', async () => {
+const PREVIEW_MESSAGE =
+  'This API is in preview — access is restricted to Civitai moderators and app developers.';
+
+describe('GET /api/v1/articles — author-cohort gate (403 preview)', () => {
+  it('SECURITY: a non-cohort authed user gets a 403 + preview message and NEITHER the rate limiter NOR the service runs (list)', async () => {
     mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
     const { req, res } = createMocks({ query: {}, user: { id: 7, isModerator: false } });
 
     await listHandler(req, res);
 
-    expect(res._getStatusCode()).toBe(404);
-    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
     expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: { id: 7, isModerator: false } });
     expect(mockRateLimit).not.toHaveBeenCalled();
     expect(mockGetArticles).not.toHaveBeenCalled();
   });
 
-  it('SECURITY: an anonymous caller gets a bare 404 (list)', async () => {
+  it('SECURITY: an anonymous caller gets a 403 + preview message (list)', async () => {
     mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
     const { req, res } = createMocks({ query: {} });
 
     await listHandler(req, res);
 
-    expect(res._getStatusCode()).toBe(404);
-    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
     expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: undefined });
     expect(mockRateLimit).not.toHaveBeenCalled();
     expect(mockGetArticles).not.toHaveBeenCalled();
   });
 
-  it('SECURITY: a non-cohort authed user gets a bare 404 (detail)', async () => {
+  it('SECURITY: a non-cohort authed user gets a 403 + preview message (detail)', async () => {
     mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
     const { req, res } = createMocks({ query: { id: '3' }, user: { id: 7, isModerator: false } });
 
     await detailHandler(req, res);
 
-    expect(res._getStatusCode()).toBe(404);
-    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
     expect(mockRateLimit).not.toHaveBeenCalled();
     expect(mockGetArticleById).not.toHaveBeenCalled();
   });
 
-  it('SECURITY: an anonymous caller gets a bare 404 (detail)', async () => {
+  it('SECURITY: an anonymous caller gets a 403 + preview message (detail)', async () => {
     mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
     const { req, res } = createMocks({ query: { id: '3' } });
 
     await detailHandler(req, res);
 
-    expect(res._getStatusCode()).toBe(404);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
     expect(mockRateLimit).not.toHaveBeenCalled();
     expect(mockGetArticleById).not.toHaveBeenCalled();
   });

--- a/src/tests/api/v1/collections/index.test.ts
+++ b/src/tests/api/v1/collections/index.test.ts
@@ -184,6 +184,29 @@ describe('GET /api/v1/collections (list)', () => {
     expect(body.items[0]).toMatchObject({ id: 20, isPublic: false });
   });
 
+  it('PAGINATION: rejects a cursor combined with sort=Most Followers (id cursor is inconsistent with the contributor ordering)', async () => {
+    const { req, res } = createMocks({
+      query: { sort: 'Most Followers', cursor: '10' },
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(400);
+    expect(mockGetAllCollections).not.toHaveBeenCalled();
+    expect(res._getJSONData().error).toMatch(/cursor/i);
+  });
+
+  it('PAGINATION: sort=Most Followers WITHOUT a cursor (first page) is allowed', async () => {
+    mockGetAllCollections.mockResolvedValue([]);
+    const { req, res } = createMocks({ query: { sort: 'Most Followers' } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockGetAllCollections).toHaveBeenCalled();
+    expect(mockGetAllCollections.mock.calls[0][0].input.sort).toBe('Most Followers');
+  });
+
   it('RATE LIMIT: 429 + Retry-After, no service call', async () => {
     mockRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 30 });
     const { req, res } = createMocks({ query: {} });

--- a/src/tests/api/v1/collections/index.test.ts
+++ b/src/tests/api/v1/collections/index.test.ts
@@ -130,52 +130,56 @@ beforeEach(() => {
   mockIsAppBlocksAuthorEnabled.mockResolvedValue(true);
 });
 
-describe('GET /api/v1/collections — author-cohort gate (dark 404)', () => {
-  it('SECURITY: a non-cohort authed user gets a bare 404 and NEITHER the rate limiter NOR the service runs (list)', async () => {
+const PREVIEW_MESSAGE =
+  'This API is in preview — access is restricted to Civitai moderators and app developers.';
+
+describe('GET /api/v1/collections — author-cohort gate (403 preview)', () => {
+  it('SECURITY: a non-cohort authed user gets a 403 + preview message and NEITHER the rate limiter NOR the service runs (list)', async () => {
     mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
     const { req, res } = createMocks({ query: {}, user: { id: 7, isModerator: false } });
 
     await listHandler(req, res);
 
-    expect(res._getStatusCode()).toBe(404);
-    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
     expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: { id: 7, isModerator: false } });
     expect(mockRateLimit).not.toHaveBeenCalled();
     expect(mockGetAllCollections).not.toHaveBeenCalled();
   });
 
-  it('SECURITY: an anonymous caller gets a bare 404 (list)', async () => {
+  it('SECURITY: an anonymous caller gets a 403 + preview message (list)', async () => {
     mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
     const { req, res } = createMocks({ query: {} });
 
     await listHandler(req, res);
 
-    expect(res._getStatusCode()).toBe(404);
-    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
     expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: undefined });
     expect(mockRateLimit).not.toHaveBeenCalled();
     expect(mockGetAllCollections).not.toHaveBeenCalled();
   });
 
-  it('SECURITY: a non-cohort authed user gets a bare 404 (detail)', async () => {
+  it('SECURITY: a non-cohort authed user gets a 403 + preview message (detail)', async () => {
     mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
     const { req, res } = createMocks({ query: { id: '55' }, user: { id: 7, isModerator: false } });
 
     await detailHandler(req, res);
 
-    expect(res._getStatusCode()).toBe(404);
-    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
     expect(mockRateLimit).not.toHaveBeenCalled();
     expect(mockGetUserCollectionPermissionsById).not.toHaveBeenCalled();
   });
 
-  it('SECURITY: an anonymous caller gets a bare 404 (detail)', async () => {
+  it('SECURITY: an anonymous caller gets a 403 + preview message (detail)', async () => {
     mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
     const { req, res } = createMocks({ query: { id: '55' } });
 
     await detailHandler(req, res);
 
-    expect(res._getStatusCode()).toBe(404);
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
     expect(mockRateLimit).not.toHaveBeenCalled();
     expect(mockGetUserCollectionPermissionsById).not.toHaveBeenCalled();
   });

--- a/src/tests/api/v1/collections/index.test.ts
+++ b/src/tests/api/v1/collections/index.test.ts
@@ -11,6 +11,7 @@ const {
   mockGetUserCollectionPermissionsById,
   mockGetCollectionById,
   mockRateLimit,
+  mockIsAppBlocksAuthorEnabled,
 } = vi.hoisted(() => ({
   mockGetAllCollections: vi.fn(),
   mockGetCollectionItemCount: vi.fn(),
@@ -18,6 +19,7 @@ const {
   mockGetUserCollectionPermissionsById: vi.fn(),
   mockGetCollectionById: vi.fn(),
   mockRateLimit: vi.fn(),
+  mockIsAppBlocksAuthorEnabled: vi.fn(),
 }));
 
 vi.mock('~/server/services/collection.service', () => ({
@@ -30,6 +32,13 @@ vi.mock('~/server/services/collection.service', () => ({
 
 vi.mock('~/server/utils/public-api-rate-limit', () => ({
   checkPublicApiRateLimit: mockRateLimit,
+}));
+
+// The App Blocks author-cohort gate — mock it so tests never touch real Flipt.
+// Default: in-cohort (true) so the existing happy-path assertions still exercise
+// the handler body; the dark-404 tests flip it to false.
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
 }));
 
 vi.mock('~/client-utils/cf-images-utils', () => ({
@@ -116,6 +125,60 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockRateLimit.mockResolvedValue({ allowed: true });
   mockGetCollectionItemCount.mockResolvedValue([]);
+  // Default: caller IS in the author cohort (mod / app-dev-tester) so the
+  // existing behavioural tests reach the handler body. Dark-404 tests override.
+  mockIsAppBlocksAuthorEnabled.mockResolvedValue(true);
+});
+
+describe('GET /api/v1/collections — author-cohort gate (dark 404)', () => {
+  it('SECURITY: a non-cohort authed user gets a bare 404 and NEITHER the rate limiter NOR the service runs (list)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: {}, user: { id: 7, isModerator: false } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: { id: 7, isModerator: false } });
+    expect(mockRateLimit).not.toHaveBeenCalled();
+    expect(mockGetAllCollections).not.toHaveBeenCalled();
+  });
+
+  it('SECURITY: an anonymous caller gets a bare 404 (list)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: {} });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: undefined });
+    expect(mockRateLimit).not.toHaveBeenCalled();
+    expect(mockGetAllCollections).not.toHaveBeenCalled();
+  });
+
+  it('SECURITY: a non-cohort authed user gets a bare 404 (detail)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: { id: '55' }, user: { id: 7, isModerator: false } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(res._getJSONData()).toEqual({ error: 'Not found' });
+    expect(mockRateLimit).not.toHaveBeenCalled();
+    expect(mockGetUserCollectionPermissionsById).not.toHaveBeenCalled();
+  });
+
+  it('SECURITY: an anonymous caller gets a bare 404 (detail)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: { id: '55' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(mockRateLimit).not.toHaveBeenCalled();
+    expect(mockGetUserCollectionPermissionsById).not.toHaveBeenCalled();
+  });
 });
 
 describe('GET /api/v1/collections (list)', () => {

--- a/src/tests/api/v1/collections/index.test.ts
+++ b/src/tests/api/v1/collections/index.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { TRPCError } from '@trpc/server';
+import { getHTTPStatusCodeFromError } from '@trpc/server/http';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { CollectionReadConfiguration } from '~/shared/utils/prisma/enums';
+
+const {
+  mockGetAllCollections,
+  mockGetCollectionItemCount,
+  mockGetUserCollectionsWithPermissions,
+  mockGetUserCollectionPermissionsById,
+  mockGetCollectionById,
+  mockRateLimit,
+} = vi.hoisted(() => ({
+  mockGetAllCollections: vi.fn(),
+  mockGetCollectionItemCount: vi.fn(),
+  mockGetUserCollectionsWithPermissions: vi.fn(),
+  mockGetUserCollectionPermissionsById: vi.fn(),
+  mockGetCollectionById: vi.fn(),
+  mockRateLimit: vi.fn(),
+}));
+
+vi.mock('~/server/services/collection.service', () => ({
+  getAllCollections: mockGetAllCollections,
+  getCollectionItemCount: mockGetCollectionItemCount,
+  getUserCollectionsWithPermissions: mockGetUserCollectionsWithPermissions,
+  getUserCollectionPermissionsById: mockGetUserCollectionPermissionsById,
+  getCollectionById: mockGetCollectionById,
+}));
+
+vi.mock('~/server/utils/public-api-rate-limit', () => ({
+  checkPublicApiRateLimit: mockRateLimit,
+}));
+
+vi.mock('~/client-utils/cf-images-utils', () => ({
+  getEdgeUrl: (url: string) => `edge:${url}`,
+}));
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  MixedAuthEndpoint:
+    (handler: any) =>
+    (req: any, res: any) =>
+      handler(req, res, req.user),
+  handleEndpointError: (res: any, e: any) => {
+    if (e instanceof TRPCError) {
+      const status = getHTTPStatusCodeFromError(e);
+      let body: unknown;
+      try {
+        body = JSON.parse(e.message);
+      } catch {
+        body = { message: e.message };
+      }
+      return res.status(status).json(body);
+    }
+    return res.status(500).json({ message: 'error', error: (e as Error).message });
+  },
+}));
+
+vi.mock('~/server/utils/region-blocking', () => ({
+  getRegion: () => ({}),
+  isRegionRestricted: () => false,
+}));
+
+import listHandler from '~/pages/api/v1/collections/index';
+import detailHandler from '~/pages/api/v1/collections/[id]';
+
+function createMocks({
+  query = {},
+  user,
+}: {
+  query?: Record<string, string | string[]>;
+  user?: { id: number; isModerator?: boolean; username?: string };
+}) {
+  let statusCode = 200;
+  let payload: any = undefined;
+  const headers: Record<string, string> = {};
+
+  const req = {
+    method: 'GET',
+    headers: {},
+    url: '/api/v1/collections',
+    query,
+    user,
+  } as unknown as NextApiRequest & { user?: any };
+
+  const res = {
+    headersSent: false,
+    setHeader(name: string, value: string) {
+      headers[name.toLowerCase()] = value;
+      return res;
+    },
+    status(code: number) {
+      statusCode = code;
+      return res;
+    },
+    json(body: any) {
+      payload = body;
+      return res;
+    },
+    end() {
+      return res;
+    },
+    _getStatusCode: () => statusCode,
+    _getJSONData: () => payload,
+    _getHeader: (name: string) => headers[name.toLowerCase()],
+  } as unknown as NextApiResponse & {
+    _getStatusCode: () => number;
+    _getJSONData: () => any;
+    _getHeader: (name: string) => string | undefined;
+  };
+
+  return { req, res };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRateLimit.mockResolvedValue({ allowed: true });
+  mockGetCollectionItemCount.mockResolvedValue([]);
+});
+
+describe('GET /api/v1/collections (list)', () => {
+  it('public mode: queries getAllCollections with privacy pinned to [Public] and returns the envelope', async () => {
+    mockGetAllCollections.mockResolvedValue([
+      {
+        id: 10,
+        name: 'c',
+        description: null,
+        read: CollectionReadConfiguration.Public,
+        type: 'Image',
+        nsfwLevel: 1,
+        userId: 2,
+        user: { id: 2, username: 'bob' },
+        image: null,
+      },
+    ]);
+    const { req, res } = createMocks({ query: { limit: '5' } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const args = mockGetAllCollections.mock.calls[0][0];
+    // SECURITY: privacy forced to Public (service also re-clamps for non-mods).
+    expect(args.input.privacy).toEqual([CollectionReadConfiguration.Public]);
+    const body = res._getJSONData();
+    expect(body.items[0]).toMatchObject({ id: 10, name: 'c', isPublic: true });
+    expect(body).toHaveProperty('metadata');
+  });
+
+  it('SECURITY: mine=true requires auth → 401 when unauthenticated, and the service is not called', async () => {
+    const { req, res } = createMocks({ query: { mine: 'true' } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(401);
+    expect(mockGetUserCollectionsWithPermissions).not.toHaveBeenCalled();
+    expect(mockGetAllCollections).not.toHaveBeenCalled();
+  });
+
+  it('mine=true (authed): keys getUserCollectionsWithPermissions on the SESSION user id, never a client param', async () => {
+    mockGetUserCollectionsWithPermissions.mockResolvedValue([
+      {
+        id: 20,
+        name: 'mine',
+        description: null,
+        read: CollectionReadConfiguration.Private,
+        type: 'Image',
+        userId: 99,
+        image: undefined,
+      },
+    ]);
+    const { req, res } = createMocks({
+      query: { mine: 'true', userId: '1' },
+      user: { id: 99, username: 'me' },
+    });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockGetUserCollectionsWithPermissions).toHaveBeenCalledWith({
+      input: { userId: 99, contributingOnly: true },
+    });
+    const body = res._getJSONData();
+    // Owner sees their OWN private collection in the mine listing.
+    expect(body.items[0]).toMatchObject({ id: 20, isPublic: false });
+  });
+
+  it('RATE LIMIT: 429 + Retry-After, no service call', async () => {
+    mockRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 30 });
+    const { req, res } = createMocks({ query: {} });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(429);
+    expect(res._getHeader('Retry-After')).toBe('30');
+    expect(mockGetAllCollections).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/v1/collections/[id] (detail)', () => {
+  it('SECURITY: no read permission → 404 and getCollectionById is NEVER called (private collection unreachable, no existence oracle)', async () => {
+    mockGetUserCollectionPermissionsById.mockResolvedValue({
+      read: false,
+      write: false,
+      manage: false,
+    });
+    const { req, res } = createMocks({ query: { id: '55' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(mockGetCollectionById).not.toHaveBeenCalled();
+  });
+
+  it('returns the collection projection when read permission is granted', async () => {
+    mockGetUserCollectionPermissionsById.mockResolvedValue({
+      read: true,
+      write: false,
+      manage: false,
+    });
+    mockGetCollectionById.mockResolvedValue({
+      id: 55,
+      name: 'pub',
+      description: 'd',
+      type: 'Image',
+      nsfwLevel: 1,
+      read: CollectionReadConfiguration.Public,
+      userId: 2,
+      user: { id: 2, username: 'bob' },
+      image: { url: 'img-key', type: 'image', nsfwLevel: 1 },
+      tags: [{ id: 3, name: 'tag', filterableOnly: false }],
+    });
+    const { req, res } = createMocks({ query: { id: '55' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    const body = res._getJSONData();
+    expect(body).toMatchObject({
+      id: 55,
+      name: 'pub',
+      isPublic: true,
+      coverImageUrl: 'edge:img-key',
+      user: { id: 2, username: 'bob' },
+      tags: [{ id: 3, name: 'tag' }],
+    });
+  });
+
+  it('404s (via handleEndpointError) when the collection row is gone despite a permission grant', async () => {
+    mockGetUserCollectionPermissionsById.mockResolvedValue({
+      read: true,
+      write: false,
+      manage: false,
+    });
+    mockGetCollectionById.mockRejectedValue(
+      new TRPCError({ code: 'NOT_FOUND', message: 'No collection with id 55' })
+    );
+    const { req, res } = createMocks({ query: { id: '55' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+  });
+
+  it('RATE LIMIT: 429 + Retry-After, no permission/service call', async () => {
+    mockRateLimit.mockResolvedValue({ allowed: false, retryAfterSeconds: 15 });
+    const { req, res } = createMocks({ query: { id: '55' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(429);
+    expect(res._getHeader('Retry-After')).toBe('15');
+    expect(mockGetUserCollectionPermissionsById).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds four REST endpoints for **articles** and **collections**, closing the Phase-2 CLI gap (models/images/tags/creators/users already have public REST; articles + collections did not). Each endpoint **wraps the existing service layer** (the same functions the website's tRPC routers use) — no business logic is reimplemented.

> **⚠️ Gated preview — NO LONGER public/anonymous.** These four endpoints are now gated behind the **`appBlocksAuthor`** cohort (moderators + the `app-dev-testers` Flipt cohort), the same authoring cohort the App Blocks v1 endpoints use. Every non-cohort caller — **including anonymous** — gets a **`403 { error: 'This API is in preview — access is restricted to Civitai moderators and app developers.' }`**. This is a deliberate DX choice for an *invited* cohort: rather than a dark 404 that hides the endpoint's existence, the 403 reveals that the API exists but explains WHY the caller is restricted — so someone who's been invited but isn't yet provisioned into the cohort understands the situation instead of chasing a phantom "not found". The gate is evaluated FIRST in each handler, before the rate limit + service, via `isAppBlocksAuthorEnabled({ user })` (async; mod static-floor OR the `app-blocks-author` Flipt cohort). Ownership/user always comes from the authenticated session (`MixedAuthEndpoint`'s optional user), never a client param.
>
> **Consumer note:** the `civitai` CLI must be **logged in as a cohort member** (a moderator / app-author OAuth session) to reach these — an anonymous or ordinary-user call gets the 403 preview message. Widen later by widening the `app-blocks-author` Flipt flag, not by editing these handlers.

| Endpoint | Wraps | Shape |
|---|---|---|
| `GET /api/v1/articles` | `getArticles` | `{ items, metadata: { nextCursor, nextPage } }` (composite keyset cursor) |
| `GET /api/v1/articles/{id}` | `getArticleById` | article object (moderator-only fields stripped) |
| `GET /api/v1/collections` | `getAllCollections` (public) / `getUserCollectionsWithPermissions` (`?mine=true`) | `{ items, metadata: { nextCursor, nextPage } }` (keyset cursor on id) |
| `GET /api/v1/collections/{id}` | `getUserCollectionPermissionsById` + `getCollectionById` | collection projection |

All four use `MixedAuthEndpoint` and match the `{ items, metadata }` envelope + `limit`/`cursor` param style of the existing `models` endpoint.

## Cohort gate + visibility (defense in depth)

The `appBlocksAuthor` gate is the OUTER boundary — but the per-resource visibility gates below are retained UNCHANGED behind it, so even a cohort member only ever sees what the service layer would show their session. Read-only over existing data — **no DB migration**.

- **Articles list** — passes the session user through to `getArticles` unchanged and never a client-supplied userId. For a non-owner/non-moderator the service returns only `status = Published` + `ingestion = Scanned` and drops `availability = Private` (`forceHidePrivate: true` pins this even with `?username=`). `favorites`/`hidden` (own-engagement) are authenticated-only → 401.
- **Article detail** — `getArticleById` gates non-moderators to `(published + scanned) OR owner`; a draft/unpublished article 404s for a non-owner (indistinguishable from non-existent). `moderatorNsfwLevel` is stripped from the response.
- **Collections list** — `getAllCollections` pins privacy to `[Public]` for any non-moderator (the service re-clamps too). `?mine=true` is authenticated-only (401 otherwise) and keys `getUserCollectionsWithPermissions` on the **session** user id, never a client param.
- **Collection detail** — reuses `getUserCollectionPermissionsById` for the read decision (the same authority `getCollectionByIdHandler` uses); no read permission → the same bare 404 as a non-existent collection (no existence oracle). `getCollectionById` does no gating on its own, so this check is mandatory before it's called.
- **Maturity/region** — all four derive the browsing-level ceiling the same way the existing public endpoints do (region-restricted → SFW) and clamp covers / drop over-ceiling collections accordingly.

## Conservative rate limiting

Helper `src/server/utils/public-api-rate-limit.ts`, modeled on the existing block-catalog / shared-storage fixed-window limiters (same Redis `INCR`+`EXPIRE` shape, same **fail-open** posture — a Redis blip must never hard-fail a GET). Runs AFTER the cohort gate, so a non-cohort caller never even reaches the limiter.

- **Keying:** now that every caller is authenticated (the cohort gate rejects anon), the limiter keys on **user id**; the client-**IP** path (CF-Connecting-IP-derived) remains for defense but is effectively unreachable.
- **Limits (named, tunable constants at the top of the helper):**
  - Unauthenticated: **60 req/min per IP** (path now unreachable behind the gate).
  - Authenticated: **120 req/min per user** — 2× headroom for legitimate batch reads (e.g. the CLI).
- On exceed: **429** with a `Retry-After` header (+ `Cache-Control: no-store` so the edge can't cache the throttle response). Applied before the expensive service call.

## Tests

`src/tests/api/v1/{articles,collections}/index.test.ts` (28 tests, under `src/tests/**` so they don't break `next build`):
- the **author-cohort gate**: a non-cohort authed user AND an anonymous caller each get a **403 carrying the preview message**, with neither the rate limiter nor the service invoked (the flag helper `isAppBlocksAuthorEnabled` is mocked — no real Flipt); the happy-path suites now mock the flag ON (in-cohort) so they exercise the handler body,
- envelope + cursor serialization, the visibility gate (a private/unpublished item 404s / is excluded for a non-owner; collection detail never calls `getCollectionById` without read permission), the authenticated-only params (401), and the rate-limit path (429 + `Retry-After`, service skipped).

`tsc --noEmit`: the changed files are clean (the only errors in the run are pre-existing `Cannot find module` noise from an un-checked-out submodule in the isolated worktree, plus downstream implicit-`any` in an untouched file — none in this PR's files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
