### PR TITLE
feat(oauth): record external OAuth API usage in the unified scope-usage audit

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260717000000_oauth_scope_usage_audit/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260717000000_oauth_scope_usage_audit/migration.sql
@@ -1,0 +1,39 @@
+-- Unified scope-usage audit — extend `block_scope_invocations` to ALSO record
+-- EXTERNAL OAuth API usage (standard OAuth access tokens), not just App-Block
+-- block-tokens. The two token populations exercise the SAME civitai scopes;
+-- this table becomes the single "which app used which scope, when" record for
+-- both, keyed on a `source` discriminator.
+--
+-- What this adds:
+--   * `oauth_client_id` (nullable TEXT) — the acting OauthClient (the app) for an
+--     external-OAuth invocation. Intentionally FK-LESS so the audit row SURVIVES
+--     deletion of the OauthClient it references (an audit trail must outlive the
+--     app). NULL for a block-token row (which uses `app_block_id`).
+--   * `source` (TEXT NOT NULL DEFAULT 'app-block') — discriminates 'app-block'
+--     (block-token) vs 'external-oauth' (OAuth access token) invocations. The
+--     DEFAULT backfills every existing row to 'app-block', so no block-token
+--     record changes meaning.
+--   * `block_instance_id` → NULLABLE — an external-OAuth row has no block instance
+--     (the acting app is a pure OauthClient with no App Block).
+--   * `bsi_oauth_client_invoked_idx` — supports a future per-OAuth-app activity
+--     read (oauth_client_id, invoked_at DESC), mirroring bsi_app_block_invoked_idx.
+--
+-- Additive + backward-compatible: nullable/defaulted columns, no data rewrite of
+-- existing semantics. Every existing row keeps app_block_id/block_instance_id and
+-- gets source = 'app-block'.
+--
+-- MANUAL APPLY ONLY: the main civitai DB (CNPG nvme0) does NOT auto-apply Prisma
+-- migrations. Apply this SQL by hand to the target env; _prisma_migrations is not
+-- the source of truth here. Safe to run in or out of a transaction — the ADD
+-- COLUMN ... DEFAULT is a metadata-only rewrite on modern Postgres, and dropping a
+-- NOT NULL is metadata-only.
+
+ALTER TABLE "block_scope_invocations"
+  ADD COLUMN IF NOT EXISTS "oauth_client_id" TEXT,
+  ADD COLUMN IF NOT EXISTS "source" TEXT NOT NULL DEFAULT 'app-block';
+
+ALTER TABLE "block_scope_invocations"
+  ALTER COLUMN "block_instance_id" DROP NOT NULL;
+
+CREATE INDEX IF NOT EXISTS "bsi_oauth_client_invoked_idx"
+  ON "block_scope_invocations" ("oauth_client_id", "invoked_at" DESC);

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -3202,7 +3202,21 @@ model BlockScopeInvocation {
   /// `local-<slug>` / `pending-<pubreqId>`) for a PRE-APPROVAL dev-tunnel spend —
   /// the forensic anchor when `appBlockId` is NULL. NULL for every approved-app row.
   syntheticAppId   String?  @map("synthetic_app_id")
-  blockInstanceId  String   @map("block_instance_id")
+  /// NULLABLE: an EXTERNAL OAuth invocation (`source = 'external-oauth'`) has no
+  /// block instance — the acting app is a pure OauthClient with no App Block. A
+  /// block-token row always sets this.
+  blockInstanceId  String?  @map("block_instance_id")
+  /// The acting OauthClient id for an EXTERNAL OAuth invocation (`source =
+  /// 'external-oauth'`) — the "which app" for external OAuth API usage, mirroring
+  /// what `appBlockId` is for a block-token row. NULL for a block-token row.
+  /// Intentionally FK-LESS text so the audit row SURVIVES deletion of the
+  /// OauthClient it references (an audit trail must outlive the app).
+  oauthClientId    String?  @map("oauth_client_id")
+  /// Discriminates the token population that made the call: `'app-block'` (an App
+  /// Block block-token, the historical default) vs `'external-oauth'` (a standard
+  /// external OAuth access token verified at `enforceTokenScope`). Additive:
+  /// existing rows backfill to `'app-block'`.
+  source           String   @default("app-block")
   scope            String
   endpoint         String
   statusCode       Int      @map("status_code") @db.SmallInt
@@ -3220,6 +3234,7 @@ model BlockScopeInvocation {
   @@index([userId, invokedAt(sort: Desc), id(sort: Desc)], map: "bsi_user_invoked_idx")
   @@index([appBlockId, invokedAt(sort: Desc)], map: "bsi_app_block_invoked_idx")
   @@index([syntheticAppId, invokedAt(sort: Desc)], map: "bsi_synthetic_app_invoked_idx")
+  @@index([oauthClientId, invokedAt(sort: Desc)], map: "bsi_oauth_client_invoked_idx")
   @@map("block_scope_invocations")
 }
 

--- a/src/server/services/blocks/__tests__/record-scope-invocation-oauth.test.ts
+++ b/src/server/services/blocks/__tests__/record-scope-invocation-oauth.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Unified scope-usage audit — `recordScopeInvocation` external-OAuth arm.
+ *
+ * An external OAuth access token's scope-gated call records into the SAME table
+ * as an App-Block block-token, tagged `source: 'external-oauth'` with the acting
+ * `oauthClientId` (and NO appBlockId / blockInstanceId — a pure OAuth app has no
+ * block). The existing block-token call site must stay byte-identical (no new
+ * keys; `source` falls to the DB default), so consumers of block rows are
+ * unaffected and there is no double-emit.
+ */
+
+const { mockDbWrite, mockLog } = vi.hoisted(() => ({
+  mockDbWrite: {
+    blockScopeInvocation: { create: vi.fn<(...args: any[]) => Promise<any>>() },
+  },
+  mockLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: mockDbWrite }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLog }));
+
+import { recordScopeInvocation } from '~/server/services/blocks/user-app-surface.service';
+
+describe('recordScopeInvocation — external OAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbWrite.blockScopeInvocation.create.mockResolvedValue({});
+  });
+
+  it('writes ONE external-oauth row: oauthClientId + source, no appBlock/blockInstance keys', async () => {
+    await recordScopeInvocation({
+      userId: 42,
+      oauthClientId: 'appblk-my-app',
+      scope: 'ModelsRead',
+      endpoint: 'model.getById',
+      statusCode: 200,
+      source: 'external-oauth',
+    });
+    expect(mockDbWrite.blockScopeInvocation.create).toHaveBeenCalledTimes(1);
+    const data = mockDbWrite.blockScopeInvocation.create.mock.calls[0][0].data;
+    expect(data).toMatchObject({
+      userId: 42,
+      oauthClientId: 'appblk-my-app',
+      source: 'external-oauth',
+      scope: 'ModelsRead',
+      endpoint: 'model.getById',
+      statusCode: 200,
+    });
+    // No block identifiers for a pure-OAuth invocation.
+    expect(data.appBlockId).toBeUndefined();
+    expect(data.blockInstanceId).toBeUndefined();
+    expect(data.syntheticAppId).toBeUndefined();
+    // Best-effort write succeeded → no failure log.
+    expect(mockLog).not.toHaveBeenCalled();
+  });
+
+  it('the block-token call site is byte-identical (no oauthClientId / source keys)', async () => {
+    await recordScopeInvocation({
+      userId: 42,
+      appBlockId: 'apb_1',
+      blockInstanceId: 'bki_1',
+      scope: 'user:read:self',
+      endpoint: '/api/v1/blocks/me',
+      statusCode: 200,
+    });
+    expect(mockDbWrite.blockScopeInvocation.create).toHaveBeenCalledWith({
+      data: {
+        userId: 42,
+        appBlockId: 'apb_1',
+        blockInstanceId: 'bki_1',
+        scope: 'user:read:self',
+        endpoint: '/api/v1/blocks/me',
+        statusCode: 200,
+      },
+    });
+  });
+
+  it('swallows a sink failure so the API call is never affected', async () => {
+    mockDbWrite.blockScopeInvocation.create.mockRejectedValueOnce(new Error('db down'));
+    await expect(
+      recordScopeInvocation({
+        userId: 42,
+        oauthClientId: 'appblk-my-app',
+        scope: 'ModelsRead',
+        endpoint: 'model.getById',
+        statusCode: 200,
+        source: 'external-oauth',
+      })
+    ).resolves.toBeUndefined();
+    // A non-dev, non-synthetic failure logs once and does not retry.
+    expect(mockDbWrite.blockScopeInvocation.create).toHaveBeenCalledTimes(1);
+    expect(mockLog).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/user-app-surface.orchestration.test.ts
@@ -464,6 +464,42 @@ describe('listMyScopeInvocations', () => {
     expect(arg.where).toEqual({ userId: 42, appBlockId: 'apb_target' });
   });
 
+  // Unified scope-usage audit: the GLOBAL feed (no appBlockId) must keep app-block
+  // AND pre-approval dev-tunnel SYNTHETIC rows (appBlockId null + syntheticAppId
+  // set) while excluding ONLY external-OAuth rows (appBlockId null + syntheticAppId
+  // null). It filters on the two PRE-EXISTING columns so the read is safe before
+  // the `source`/`oauth_client_id` migration is applied. This assertion FAILS under
+  // the earlier `appBlockId: { not: null }`-only filter, which silently dropped the
+  // dev's own synthetic rows.
+  it('global feed keeps app-block + synthetic rows, excludes only external-OAuth', async () => {
+    const { listMyScopeInvocations } = await import('../user-app-surface.service');
+    await listMyScopeInvocations({ userId: 42 });
+    const arg = mockDbRead.blockScopeInvocation.findMany.mock.calls[0][0];
+    expect(arg.where).toEqual({
+      userId: 42,
+      // app-block row (appBlockId set) → matched by predicate 1;
+      // synthetic dev-tunnel row (appBlockId null, syntheticAppId set) → predicate 2;
+      // external-OAuth row (both null) → matched by NEITHER, so excluded.
+      OR: [{ appBlockId: { not: null } }, { syntheticAppId: { not: null } }],
+    });
+    // Pre-migration safety: the read must NOT reference the new columns.
+    expect(JSON.stringify(arg.where)).not.toContain('source');
+    expect(JSON.stringify(arg.where)).not.toContain('oauthClientId');
+  });
+
+  it('global feed INCLUDES a synthetic dev-tunnel row (appBlockId null, syntheticAppId set)', async () => {
+    const { listMyScopeInvocations } = await import('../user-app-surface.service');
+    // A pre-approval dev-tunnel invocation: no AppBlock row, synthetic ref set.
+    mockDbRead.blockScopeInvocation.findMany.mockResolvedValue([
+      invocationRow({ id: 7n, appBlockId: null, appBlock: null, syntheticAppId: 'ephemeral-my-app' }),
+    ]);
+    const result = await listMyScopeInvocations({ userId: 42 });
+    // The mapper returns the row (does not crash on a null appBlockId) — it is
+    // present in the dev's own audit feed, restoring the pre-PR behaviour.
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].id).toBe('7');
+  });
+
   it('emits a nextCursor when the page is full and silently ignores a malformed inbound cursor', async () => {
     const { listMyScopeInvocations } = await import('../user-app-surface.service');
     // 1 more row than limit → hasNext + nextCursor is the last visible id.

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -393,15 +393,25 @@ export async function listMyScopeInvocations(opts: {
     // This is the BLOCK-token activity feed (/apps/installed). Unified scope-usage
     // audit: EXTERNAL-OAuth invocations now share this table but carry a NULL
     // `appBlockId` (+ `source = 'external-oauth'`); exclude them here so they don't
-    // leak into a block-semantic UI. Filtering on `app_block_id IS NOT NULL`
-    // (rather than `source`) references only the pre-existing column, so this is
-    // safe whether or not the `source` migration has been applied yet. External
-    // usage is captured in the table (queryable by `oauth_client_id`) for a future
-    // dedicated OAuth-app activity view. Cast: the `not: null` filter needs the
-    // nullable-`appBlockId` client type (CI-regenerated; may lag locally).
+    // leak into a block-semantic UI. But NOT every null-`appBlockId` row is
+    // external-OAuth: a PRE-APPROVAL App-Dev-Tunnel spend also writes `appBlockId:
+    // null` with `syntheticAppId` set (see the synthetic-retry path below) and MUST
+    // stay in the dev's own audit feed. So the GLOBAL feed keeps `app-block` AND
+    // synthetic rows and excludes only external-OAuth: `appBlockId IS NOT NULL OR
+    // syntheticAppId IS NOT NULL`. Both are PRE-EXISTING columns, so this read is
+    // safe whether or not the `source`/`oauth_client_id` migration has been applied
+    // (external-OAuth rows can't even exist pre-migration — they're naturally
+    // absent then, and `syntheticAppId IS NOT NULL` excludes exactly the
+    // external-OAuth population post-migration). Deliberately NOT filtering on the
+    // new `source`/`oauthClientId` columns keeps this pre-migration-safe. External
+    // usage is captured (queryable by `oauth_client_id`) for a future dedicated
+    // OAuth-app activity view. Cast: the nullable filters need the nullable-column
+    // client types (CI-regenerated; may lag locally).
     where: {
       userId: opts.userId,
-      ...(opts.appBlockId ? { appBlockId: opts.appBlockId } : { appBlockId: { not: null } }),
+      ...(opts.appBlockId
+        ? { appBlockId: opts.appBlockId }
+        : { OR: [{ appBlockId: { not: null } }, { syntheticAppId: { not: null } }] }),
     } as unknown as Prisma.BlockScopeInvocationWhereInput,
     orderBy: [{ invokedAt: 'desc' }, { id: 'desc' }],
     take: cappedLimit + 1,

--- a/src/server/services/blocks/user-app-surface.service.ts
+++ b/src/server/services/blocks/user-app-surface.service.ts
@@ -390,10 +390,19 @@ export async function listMyScopeInvocations(opts: {
     appBlock: { blockId: string; manifest: unknown } | null;
   };
   const rows = (await dbRead.blockScopeInvocation.findMany({
+    // This is the BLOCK-token activity feed (/apps/installed). Unified scope-usage
+    // audit: EXTERNAL-OAuth invocations now share this table but carry a NULL
+    // `appBlockId` (+ `source = 'external-oauth'`); exclude them here so they don't
+    // leak into a block-semantic UI. Filtering on `app_block_id IS NOT NULL`
+    // (rather than `source`) references only the pre-existing column, so this is
+    // safe whether or not the `source` migration has been applied yet. External
+    // usage is captured in the table (queryable by `oauth_client_id`) for a future
+    // dedicated OAuth-app activity view. Cast: the `not: null` filter needs the
+    // nullable-`appBlockId` client type (CI-regenerated; may lag locally).
     where: {
       userId: opts.userId,
-      ...(opts.appBlockId ? { appBlockId: opts.appBlockId } : {}),
-    },
+      ...(opts.appBlockId ? { appBlockId: opts.appBlockId } : { appBlockId: { not: null } }),
+    } as unknown as Prisma.BlockScopeInvocationWhereInput,
     orderBy: [{ invokedAt: 'desc' }, { id: 'desc' }],
     take: cappedLimit + 1,
     ...(cursorBigInt != null ? { cursor: { id: cursorBigInt }, skip: 1 } : {}),
@@ -451,8 +460,33 @@ export async function listMyScopeInvocations(opts: {
  */
 export async function recordScopeInvocation(opts: {
   userId: number;
-  appBlockId: string;
-  blockInstanceId: string;
+  /**
+   * The App Block whose block-token made the call. Present for an `'app-block'`
+   * invocation; OMITTED (undefined) for an `'external-oauth'` invocation, which
+   * has no App Block — the acting app is captured in `oauthClientId` instead.
+   */
+  appBlockId?: string;
+  /**
+   * The block instance. Present for an `'app-block'` invocation; OMITTED for an
+   * `'external-oauth'` invocation (a pure OauthClient has no block instance).
+   */
+  blockInstanceId?: string;
+  /**
+   * Unified scope-usage audit — the acting OauthClient id for an
+   * `'external-oauth'` invocation (an external OAuth access token verified at
+   * `enforceTokenScope`). This is the "which app" for external OAuth API usage,
+   * mirroring what `appBlockId` is for a block-token row. OMITTED for a
+   * block-token row.
+   */
+  oauthClientId?: string;
+  /**
+   * Which token population made the call: `'app-block'` (block-token — the
+   * default when omitted, preserving every existing block-token record) or
+   * `'external-oauth'` (a standard external OAuth access token). Consumers filter
+   * on this. Omitting it lets the DB column DEFAULT ('app-block') apply, so the
+   * existing block-token call sites write a byte-identical row.
+   */
+  source?: 'app-block' | 'external-oauth';
   scope: string;
   endpoint: string;
   statusCode: number;
@@ -486,19 +520,27 @@ export async function recordScopeInvocation(opts: {
     ? (opts.detail as unknown as Prisma.InputJsonValue)
     : undefined;
   try {
-    await dbWrite.blockScopeInvocation.create({
-      data: {
-        userId: opts.userId,
-        appBlockId: opts.appBlockId,
-        blockInstanceId: opts.blockInstanceId,
-        scope: opts.scope,
-        // Endpoint string is bounded by middleware-side normalisation but
-        // belt-and-braces clamp here so a runaway path can't blow the row.
-        endpoint: opts.endpoint.slice(0, 512),
-        statusCode: opts.statusCode,
-        ...(detailData !== undefined ? { detail: detailData } : {}),
-      },
-    });
+    // Build the row conditionally so an `'app-block'` call site writes a
+    // BYTE-IDENTICAL row to the pre-unification shape (no `oauthClientId` /
+    // `source` keys — `source` falls to the DB DEFAULT 'app-block'), while an
+    // `'external-oauth'` call site adds only the fields it carries. Bridge-cast
+    // once: the locally-generated Prisma client may pre-date the `oauth_client_id`
+    // / `source` columns (the NixOS dev env can't run `prisma generate`); CI
+    // regenerates from schema.full.prisma. Field names mirror the schema exactly.
+    const data = {
+      userId: opts.userId,
+      appBlockId: opts.appBlockId,
+      blockInstanceId: opts.blockInstanceId,
+      ...(opts.oauthClientId !== undefined ? { oauthClientId: opts.oauthClientId } : {}),
+      ...(opts.source !== undefined ? { source: opts.source } : {}),
+      scope: opts.scope,
+      // Endpoint string is bounded by middleware-side normalisation but
+      // belt-and-braces clamp here so a runaway path can't blow the row.
+      endpoint: opts.endpoint.slice(0, 512),
+      statusCode: opts.statusCode,
+      ...(detailData !== undefined ? { detail: detailData } : {}),
+    } as unknown as Parameters<typeof dbWrite.blockScopeInvocation.create>[0]['data'];
+    await dbWrite.blockScopeInvocation.create({ data });
   } catch (err) {
     // App Dev Tunnel Phase 2: a DEV token with a SYNTHETIC (non-resolving)
     // appBlockId FK-fails here. Retry with `appBlockId: null` + `syntheticAppId`
@@ -515,7 +557,7 @@ export async function recordScopeInvocation(opts: {
     // deleted between mint and spend — that FK-fails too, but it is NOT synthetic,
     // so it must keep the historical "log, no row" behaviour (never mislabelled
     // `synthetic_app_id = <real id>`). Only a genuine synthetic namespace retries.
-    if (opts.dev && isFkViolation && isSyntheticAppBlockId(opts.appBlockId)) {
+    if (opts.dev && isFkViolation && opts.appBlockId != null && isSyntheticAppBlockId(opts.appBlockId)) {
       try {
         // `appBlockId: null` + `syntheticAppId` require the schema change in this
         // PR (BlockScopeInvocation.appBlockId → nullable, + synthetic_app_id).

--- a/src/server/services/oauth/__tests__/enforce-token-scope.test.ts
+++ b/src/server/services/oauth/__tests__/enforce-token-scope.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * Middleware-level wiring for `enforceTokenScope` (the single OAuth
+ * scope-verification choke point). These lock the properties a refactor could
+ * silently break — that the audit emit is gated behind the deny throws, fires
+ * exactly once AFTER next() settles, and never fires for session / API-key auth.
+ *
+ * We exercise the extracted `runEnforceTokenScope` directly with a synthetic
+ * { ctx, meta, path, next } (mirroring middleware.trpc.test.ts), mocking the
+ * audit emit so we assert the wiring, not the sink.
+ */
+
+const { mockEmit } = vi.hoisted(() => ({ mockEmit: vi.fn() }));
+
+vi.mock('~/server/services/oauth/oauth-scope-audit', () => ({
+  maybeRecordOauthScopeUsage: mockEmit,
+}));
+
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { runEnforceTokenScope } from '~/server/services/oauth/enforce-token-scope';
+
+const OAUTH_CTX = {
+  tokenScope: TokenScope.Full,
+  apiKeyId: 5,
+  subject: { type: 'oauth' as const, id: 'appblk-my-app' },
+  user: { id: 42 },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('runEnforceTokenScope — deny paths emit nothing', () => {
+  it('blockApiKeys denies a token request BEFORE any emit (and never calls next)', async () => {
+    const next = vi.fn(async () => ({ ok: true }));
+    expect(() =>
+      runEnforceTokenScope({
+        ctx: OAUTH_CTX,
+        meta: { blockApiKeys: true },
+        path: 'buzz.tip',
+        next,
+      })
+    ).toThrow(TRPCError);
+    // If the emit were moved above the deny throw, this would fire → test fails.
+    expect(mockEmit).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('a scoped OAuth token missing the required bit is denied with no emit', async () => {
+    const next = vi.fn(async () => ({ ok: true }));
+    expect(() =>
+      runEnforceTokenScope({
+        ctx: { ...OAUTH_CTX, tokenScope: TokenScope.ModelsRead },
+        meta: { requiredScope: TokenScope.MediaWrite },
+        path: 'image.upload',
+        next,
+      })
+    ).toThrow(/required scope/i);
+    expect(mockEmit).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe('runEnforceTokenScope — authorized external OAuth emits exactly one row', () => {
+  it('records once (200) AFTER next() settles, with the right subject/scope/endpoint', async () => {
+    const order: string[] = [];
+    const next = vi.fn(async () => {
+      order.push('next');
+      return { ok: true };
+    });
+    mockEmit.mockImplementation(() => order.push('emit'));
+
+    await runEnforceTokenScope({
+      ctx: { ...OAUTH_CTX, tokenScope: TokenScope.ModelsRead },
+      meta: { requiredScope: TokenScope.ModelsRead },
+      path: 'model.getById',
+      next,
+    });
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    // Emitted AFTER the resolver ran.
+    expect(order).toEqual(['next', 'emit']);
+    expect(mockEmit).toHaveBeenCalledWith({
+      subject: { type: 'oauth', id: 'appblk-my-app' },
+      userId: 42,
+      scopeBit: TokenScope.ModelsRead,
+      endpoint: 'model.getById',
+      statusCode: 200,
+    });
+  });
+
+  it('a Full-scope OAuth token on an unannotated endpoint records scope=Full', async () => {
+    const next = vi.fn(async () => ({ ok: true }));
+    await runEnforceTokenScope({
+      ctx: OAUTH_CTX, // tokenScope Full, no requiredScope meta
+      meta: undefined,
+      path: 'account.getSettings',
+      next,
+    });
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    expect(mockEmit.mock.calls[0][0]).toMatchObject({ scopeBit: TokenScope.Full, statusCode: 200 });
+  });
+
+  it('a resolver ERROR (v11 { ok:false, error }) still emits exactly one row, mapped to the real status', async () => {
+    const next = vi.fn(async () => ({ ok: false, error: new TRPCError({ code: 'NOT_FOUND' }) }));
+    await runEnforceTokenScope({
+      ctx: { ...OAUTH_CTX, tokenScope: TokenScope.ModelsRead },
+      meta: { requiredScope: TokenScope.ModelsRead },
+      path: 'model.getById',
+      next,
+    });
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    expect(mockEmit.mock.calls[0][0].statusCode).toBe(404);
+  });
+
+  it('a genuine next() REJECTION still emits one row, then re-throws', async () => {
+    const boom = new TRPCError({ code: 'INTERNAL_SERVER_ERROR' });
+    const next = vi.fn(async () => {
+      throw boom;
+    });
+    await expect(
+      runEnforceTokenScope({
+        ctx: { ...OAUTH_CTX, tokenScope: TokenScope.ModelsRead },
+        meta: { requiredScope: TokenScope.ModelsRead },
+        path: 'model.getById',
+        next,
+      })
+    ).rejects.toBe(boom);
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    expect(mockEmit.mock.calls[0][0].statusCode).toBe(500);
+  });
+});
+
+describe('runEnforceTokenScope — non-OAuth auth emits nothing and takes the bare next()', () => {
+  it('a session request (no subject) records nothing and returns next() directly', async () => {
+    const sentinel = { ok: true, marker: 'bare' };
+    const next = vi.fn(async () => sentinel);
+    const result = await runEnforceTokenScope({
+      ctx: { tokenScope: TokenScope.Full, subject: undefined, user: { id: 42 } },
+      meta: { requiredScope: TokenScope.ModelsRead },
+      path: 'model.getById',
+      next,
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(mockEmit).not.toHaveBeenCalled();
+    // Bare path: the exact next() result propagates unchanged.
+    expect(result).toBe(sentinel);
+  });
+
+  it('a personal API key (subject.apiKey) records nothing', async () => {
+    const next = vi.fn(async () => ({ ok: true }));
+    await runEnforceTokenScope({
+      ctx: {
+        tokenScope: TokenScope.Full,
+        apiKeyId: 9,
+        subject: { type: 'apiKey', id: 9 },
+        user: { id: 42 },
+      },
+      meta: { requiredScope: TokenScope.ModelsRead },
+      path: 'model.getById',
+      next,
+    });
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/oauth/__tests__/oauth-scope-audit.test.ts
+++ b/src/server/services/oauth/__tests__/oauth-scope-audit.test.ts
@@ -122,8 +122,9 @@ describe('maybeRecordOauthScopeUsage', () => {
       })
     ).not.toThrow();
     await vi.waitFor(() => expect(mockRecordScopeInvocation).toHaveBeenCalledTimes(1));
-    // The rejection was swallowed — the unhandled-rejection guard below asserts
-    // no error escaped the fire-and-forget path.
+    // The sink was invoked with the external-oauth row and its rejection was
+    // swallowed by the helper's internal .catch (the synchronous call above
+    // already asserted it never threw).
     expect(mockRecordScopeInvocation.mock.calls[0][0]).toMatchObject({
       source: 'external-oauth',
       scope: 'full',

--- a/src/server/services/oauth/__tests__/oauth-scope-audit.test.ts
+++ b/src/server/services/oauth/__tests__/oauth-scope-audit.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Unified scope-usage audit — external-OAuth arm.
+ *
+ * `maybeRecordOauthScopeUsage` is the emit helper called from `enforceTokenScope`
+ * (the single OAuth scope-verification choke point). It must:
+ *   - record ONE `recordScopeInvocation` row for an external OAuth token, tagged
+ *     `source: 'external-oauth'` with the acting oauthClientId + mapped scope;
+ *   - emit NOTHING for a session (no subject) or a personal API key;
+ *   - never throw, even if the audit sink rejects (best-effort).
+ */
+
+const { mockRecordScopeInvocation } = vi.hoisted(() => ({
+  mockRecordScopeInvocation: vi.fn(async () => undefined),
+}));
+
+// The helper lazy-imports the service; mock it so no DB is touched.
+vi.mock('~/server/services/blocks/user-app-surface.service', () => ({
+  recordScopeInvocation: mockRecordScopeInvocation,
+}));
+
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import {
+  maybeRecordOauthScopeUsage,
+  tokenScopeToAuditName,
+} from '~/server/services/oauth/oauth-scope-audit';
+
+const OAUTH_SUBJECT = { type: 'oauth' as const, id: 'appblk-my-app' };
+const API_KEY_SUBJECT = { type: 'apiKey' as const, id: 7 };
+
+describe('tokenScopeToAuditName', () => {
+  it('maps a single known bit to its enum-key name', () => {
+    expect(tokenScopeToAuditName(TokenScope.ModelsRead)).toBe('ModelsRead');
+    expect(tokenScopeToAuditName(TokenScope.MediaRead)).toBe('MediaRead');
+    expect(tokenScopeToAuditName(TokenScope.SocialTip)).toBe('SocialTip');
+  });
+
+  it('maps the composite Full mask to "full"', () => {
+    expect(tokenScopeToAuditName(TokenScope.Full)).toBe('full');
+  });
+
+  it('falls back to scope:<bitmask> for an unknown / composite value (never throws)', () => {
+    // A value that is not a single defined bit and not Full.
+    const weird = TokenScope.ModelsRead | TokenScope.MediaRead;
+    expect(tokenScopeToAuditName(weird)).toBe(`scope:${weird}`);
+    expect(tokenScopeToAuditName(999999999)).toBe('scope:999999999');
+  });
+});
+
+describe('maybeRecordOauthScopeUsage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('records one external-oauth row with oauthClientId + mapped scope + source', async () => {
+    maybeRecordOauthScopeUsage({
+      subject: OAUTH_SUBJECT,
+      userId: 42,
+      scopeBit: TokenScope.ModelsRead,
+      endpoint: 'model.getById',
+      statusCode: 200,
+    });
+    await vi.waitFor(() => expect(mockRecordScopeInvocation).toHaveBeenCalledTimes(1));
+    expect(mockRecordScopeInvocation).toHaveBeenCalledWith({
+      userId: 42,
+      oauthClientId: 'appblk-my-app',
+      scope: 'ModelsRead',
+      endpoint: 'model.getById',
+      statusCode: 200,
+      source: 'external-oauth',
+    });
+  });
+
+  it('does NOT record for a personal API key subject', async () => {
+    maybeRecordOauthScopeUsage({
+      subject: API_KEY_SUBJECT,
+      userId: 42,
+      scopeBit: TokenScope.ModelsRead,
+      endpoint: 'model.getById',
+      statusCode: 200,
+    });
+    // Flush any pending microtasks; nothing should have been recorded.
+    await Promise.resolve();
+    expect(mockRecordScopeInvocation).not.toHaveBeenCalled();
+  });
+
+  it('does NOT record for a session (no subject)', async () => {
+    maybeRecordOauthScopeUsage({
+      subject: undefined,
+      userId: 42,
+      scopeBit: TokenScope.ModelsRead,
+      endpoint: 'model.getById',
+      statusCode: 200,
+    });
+    await Promise.resolve();
+    expect(mockRecordScopeInvocation).not.toHaveBeenCalled();
+  });
+
+  it('does NOT record when there is no userId', async () => {
+    maybeRecordOauthScopeUsage({
+      subject: OAUTH_SUBJECT,
+      userId: undefined,
+      scopeBit: TokenScope.ModelsRead,
+      endpoint: 'model.getById',
+      statusCode: 200,
+    });
+    await Promise.resolve();
+    expect(mockRecordScopeInvocation).not.toHaveBeenCalled();
+  });
+
+  it('is best-effort: a rejecting sink does not throw or surface', async () => {
+    mockRecordScopeInvocation.mockRejectedValueOnce(new Error('sink down'));
+    // Synchronous call must not throw.
+    expect(() =>
+      maybeRecordOauthScopeUsage({
+        subject: OAUTH_SUBJECT,
+        userId: 42,
+        scopeBit: TokenScope.Full,
+        endpoint: 'model.getById',
+        statusCode: 500,
+      })
+    ).not.toThrow();
+    await vi.waitFor(() => expect(mockRecordScopeInvocation).toHaveBeenCalledTimes(1));
+    // The rejection was swallowed — the unhandled-rejection guard below asserts
+    // no error escaped the fire-and-forget path.
+    expect(mockRecordScopeInvocation.mock.calls[0][0]).toMatchObject({
+      source: 'external-oauth',
+      scope: 'full',
+    });
+  });
+});

--- a/src/server/services/oauth/enforce-token-scope.ts
+++ b/src/server/services/oauth/enforce-token-scope.ts
@@ -1,0 +1,132 @@
+/**
+ * `enforceTokenScope` middleware body — extracted from `~/server/trpc` so the
+ * OAuth scope-verification + unified scope-usage audit wiring is unit-testable
+ * WITHOUT booting the full tRPC pipeline (prom-client / redis / serializer
+ * module-load side effects). `trpc.ts` wraps this in `t.middleware(...)`; this
+ * module stays light — its only heavy edge (the audit sink) is behind the
+ * lazy import inside `maybeRecordOauthScopeUsage`.
+ *
+ * Properties this locks (a refactor could otherwise silently break them):
+ *   - a scope-DENIED call throws BEFORE any emit → records nothing;
+ *   - an authorized EXTERNAL-OAuth call emits EXACTLY ONE row, AFTER `next()`
+ *     settles, with the real outcome status;
+ *   - a resolver error still emits exactly one row (then propagates);
+ *   - a session / personal-API-key call emits nothing and takes the bare
+ *     `next()` path (no extra async frame).
+ */
+
+import { TRPCError } from '@trpc/server';
+import { getHTTPStatusCodeFromError } from '@trpc/server/http';
+import { Flags } from '~/shared/utils/flags';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { maybeRecordOauthScopeUsage } from '~/server/services/oauth/oauth-scope-audit';
+
+/**
+ * Map a settled procedure outcome to an HTTP-ish status for the audit row.
+ * In tRPC v11 a downstream throw surfaces as a resolved `{ ok: false, error }`
+ * MiddlewareResult (not a rejection), so `error` is a `TRPCError` we can map to
+ * its real status (FORBIDDEN→403, NOT_FOUND→404, …); a genuine rejection (rare —
+ * an infra throw the pipeline didn't wrap) maps the thrown value the same way,
+ * defaulting to 500. Never throws.
+ */
+export function auditStatusFromError(error: unknown): number {
+  try {
+    if (error instanceof TRPCError) return getHTTPStatusCodeFromError(error);
+    const code = (error as { code?: unknown })?.code;
+    if (typeof code === 'string') {
+      return getHTTPStatusCodeFromError(new TRPCError({ code: code as TRPCError['code'] }));
+    }
+  } catch {
+    /* fall through */
+  }
+  return 500;
+}
+
+/**
+ * The `enforceTokenScope` middleware body. Generic over `next()`'s return so it
+ * stays transparent to tRPC's MiddlewareResult typing (same shape as
+ * `runRecordProcedureDuration`). `meta` is typed structurally (only the two
+ * fields read) to avoid a runtime import cycle with `~/server/trpc`.
+ */
+export function runEnforceTokenScope<T>(opts: {
+  ctx: {
+    tokenScope: number;
+    apiKeyId?: number | null;
+    subject?: { type: 'apiKey'; id: number } | { type: 'oauth'; id: string };
+    user?: { id: number } | null;
+  };
+  meta: { requiredScope?: number; blockApiKeys?: boolean } | undefined;
+  path: string;
+  next: () => Promise<T>;
+}): Promise<T> {
+  const { ctx, meta, path, next } = opts;
+
+  // blockApiKeys: deny any token-based request, regardless of scope. Session
+  // auth (apiKeyId === null) is unaffected. Thrown BEFORE any emit → a denied
+  // call records nothing.
+  if (meta?.blockApiKeys && ctx.apiKeyId != null) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'This action cannot be performed via API key or OAuth token.',
+    });
+  }
+
+  // The scope this call exercises — the declared requiredScope, or Full for an
+  // unannotated endpoint (which implicitly requires Full). Also the value the
+  // external-OAuth scope-usage audit records below.
+  const requiredScope = meta?.requiredScope ?? TokenScope.Full;
+
+  // Session auth (cookies) and full-access API keys pass through the scope check;
+  // a scoped token must carry the required bit. A scope-denied call throws HERE,
+  // before the emit block → it records nothing.
+  if (ctx.tokenScope !== TokenScope.Full) {
+    if (!Flags.hasFlag(ctx.tokenScope, requiredScope)) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Your API key does not have the required scope for this action',
+      });
+    }
+  }
+
+  // Unified scope-usage audit — external-OAuth arm. This is the single central
+  // choke point where an OAuth access token's scope is verified, so it's where
+  // external OAuth API usage is recorded (mirroring the block-token audit fired
+  // from block-scope.middleware). Only an external OAuth token reaches the sink
+  // (guarded inside maybeRecordOauthScopeUsage — session + personal-API-key
+  // requests emit nothing). Fire-and-forget, emitted AFTER the procedure settles
+  // so the status is real + EXACTLY one row per call. We wrap next() only for
+  // OAuth subjects so the (dominant) session path stays a bare `next()`.
+  if (ctx.subject?.type !== 'oauth' || ctx.user?.id == null) {
+    return next();
+  }
+  const subject = ctx.subject;
+  const userId = ctx.user.id;
+  return next().then(
+    (result) => {
+      // tRPC v11: a downstream throw resolves as { ok: false, error }, so derive
+      // the real status from the error; a success is 200.
+      const r = result as unknown as { ok?: boolean; error?: unknown };
+      const statusCode = r?.ok === false ? auditStatusFromError(r.error) : 200;
+      maybeRecordOauthScopeUsage({
+        subject,
+        userId,
+        scopeBit: requiredScope,
+        endpoint: path,
+        statusCode,
+      });
+      return result;
+    },
+    (err) => {
+      // A genuine rejection (infra throw the pipeline didn't wrap) — still record
+      // exactly one row, then re-throw so the error propagates unchanged.
+      maybeRecordOauthScopeUsage({
+        subject,
+        userId,
+        scopeBit: requiredScope,
+        endpoint: path,
+        statusCode: auditStatusFromError(err),
+      });
+      throw err;
+    }
+  );
+}

--- a/src/server/services/oauth/oauth-scope-audit.ts
+++ b/src/server/services/oauth/oauth-scope-audit.ts
@@ -1,0 +1,99 @@
+/**
+ * Unified scope-usage audit — the EXTERNAL-OAuth arm.
+ *
+ * App-Block block-tokens already record one `BlockScopeInvocation` row per
+ * scope-gated call (via `recordScopeInvocation`, fired from the block-scope
+ * middleware). External apps instead authenticate with a standard OAuth access
+ * token whose scope is verified ONCE, centrally, at the `enforceTokenScope`
+ * tRPC middleware (src/server/trpc.ts). That path never recorded an audit row,
+ * so external OAuth API usage was invisible to the scope-usage audit.
+ *
+ * This module closes that gap by emitting into the SAME sink + row shape as the
+ * block-token audit — `recordScopeInvocation`, tagged `source: 'external-oauth'`
+ * with the acting `oauthClientId` — so there is ONE "which app used which scope,
+ * when" record across both token populations (no divergent second format).
+ *
+ * Discipline mirrors the block path exactly:
+ *   - fire-and-forget: a failed audit write must NEVER fail or slow the API call;
+ *   - lazy import of the DB-backed service so this module (imported by the hot
+ *     `enforceTokenScope` middleware) stays free of eager Prisma/DB init;
+ *   - emitted from a SINGLE choke point (enforceTokenScope runs once per tRPC
+ *     procedure) so a call records exactly one row.
+ */
+
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * Reverse map: a single `TokenScope` bit → its stable machine name (the enum
+ * key, e.g. `ModelsRead`). Built from the enum so it can never drift behind a
+ * newly-added bit. Excludes the `None` (0) and `Full` (composite mask) entries —
+ * neither is a single capability bit.
+ */
+const SCOPE_NAME_BY_BIT: Record<number, string> = Object.entries(TokenScope).reduce(
+  (acc, [key, value]) => {
+    if (key === 'None' || key === 'Full') return acc;
+    if (typeof value === 'number' && value > 0) acc[value] = key;
+    return acc;
+  },
+  {} as Record<number, string>
+);
+
+/**
+ * Map a `TokenScope` bitmask (the value a procedure declares via
+ * `.meta({ requiredScope })`, or the implicit `Full` for an unannotated
+ * endpoint) to a readable, stable scope string for the audit row.
+ *
+ *   - `TokenScope.Full`         → `'full'`   (unannotated endpoint / full-access token)
+ *   - a single known bit         → its enum key, e.g. `'ModelsRead'`
+ *   - anything else (a composite / unknown value) → `'scope:<bitmask>'`
+ *     (never throws; the numeric value stays recoverable).
+ */
+export function tokenScopeToAuditName(bit: number): string {
+  if (bit === TokenScope.Full) return 'full';
+  return SCOPE_NAME_BY_BIT[bit] ?? `scope:${bit}`;
+}
+
+type RequestSubject =
+  | { type: 'apiKey'; id: number }
+  | { type: 'oauth'; id: string }
+  | undefined;
+
+/**
+ * Fire-and-forget: record ONE external-OAuth scope invocation, iff the request
+ * was authenticated by an external OAuth access token (`subject.type === 'oauth'`)
+ * and carries a user. A session/cookie request (`subject === undefined`) or a
+ * personal API key (`subject.type === 'apiKey'`) records nothing here — those are
+ * not external-app usage. Never throws; a failed audit write is swallowed.
+ */
+export function maybeRecordOauthScopeUsage(opts: {
+  subject: RequestSubject;
+  userId: number | undefined;
+  /** The `TokenScope` bit the call exercised (declared requiredScope, or Full). */
+  scopeBit: number;
+  /** The route — the tRPC procedure path (dotted name). */
+  endpoint: string;
+  statusCode: number;
+}): void {
+  if (opts.subject?.type !== 'oauth' || opts.userId == null) return;
+  const oauthClientId = opts.subject.id;
+  const userId = opts.userId;
+  const scope = tokenScopeToAuditName(opts.scopeBit);
+  const endpoint = opts.endpoint;
+  const statusCode = opts.statusCode;
+  // Lazy import so trpc.ts (which statically imports THIS module) doesn't eager
+  // load user-app-surface.service → dbWrite/Prisma init. Mirrors the block path.
+  void import('~/server/services/blocks/user-app-surface.service')
+    .then(({ recordScopeInvocation }) =>
+      recordScopeInvocation({
+        userId,
+        oauthClientId,
+        scope,
+        endpoint,
+        statusCode,
+        source: 'external-oauth',
+      })
+    )
+    .catch(() => {
+      /* best-effort — the audit pipeline must never affect the API call */
+    });
+}

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -31,8 +31,7 @@ import {
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 import { Flags } from '~/shared/utils/flags';
-import { TokenScope } from '~/shared/constants/token-scope.constants';
-import { maybeRecordOauthScopeUsage } from '~/server/services/oauth/oauth-scope-audit';
+import { runEnforceTokenScope } from '~/server/services/oauth/enforce-token-scope';
 import { parseVerifiedBotHeader, VERIFIED_BOT_HEADER } from '~/server/utils/bot-detection/header';
 import type { Context } from './createContext';
 
@@ -248,70 +247,12 @@ const applyDomainFeature = t.middleware(async (options) => {
  *   request regardless of scope. Used for buzz-spending operations that the
  *   orchestrator owns; tokens have no business spending buzz on Civitai's side.
  */
-const enforceTokenScope = t.middleware(({ ctx, meta, path, next }) => {
-  // blockApiKeys: deny any token-based request, regardless of scope. Session
-  // auth (apiKeyId === null) is unaffected.
-  if (meta?.blockApiKeys && ctx.apiKeyId != null) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'This action cannot be performed via API key or OAuth token.',
-    });
-  }
-
-  // The scope this call exercises — the declared requiredScope, or Full for an
-  // unannotated endpoint (which implicitly requires Full). Also the value the
-  // external-OAuth scope-usage audit records below.
-  const requiredScope = meta?.requiredScope ?? TokenScope.Full;
-
-  // Session auth (cookies) and full-access API keys pass through the scope check;
-  // a scoped token must carry the required bit.
-  if (ctx.tokenScope !== TokenScope.Full) {
-    if (!Flags.hasFlag(ctx.tokenScope, requiredScope)) {
-      throw new TRPCError({
-        code: 'FORBIDDEN',
-        message: 'Your API key does not have the required scope for this action',
-      });
-    }
-  }
-
-  // Unified scope-usage audit — external-OAuth arm. `enforceTokenScope` is the
-  // single central choke point where an OAuth access token's scope is verified,
-  // so it's where external OAuth API usage is recorded (mirroring the block-token
-  // audit fired from block-scope.middleware). Only an external OAuth token reaches
-  // the sink (guarded inside maybeRecordOauthScopeUsage — session + personal-API-
-  // key requests emit nothing). Fire-and-forget, and emitted AFTER the procedure
-  // settles so the recorded status reflects the real outcome + records EXACTLY one
-  // row per call. We wrap next() only for OAuth subjects so the (dominant) session
-  // path stays a bare `next()` with no extra async frame.
-  if (ctx.subject?.type !== 'oauth' || ctx.user?.id == null) {
-    return next();
-  }
-  const subject = ctx.subject;
-  const userId = ctx.user.id;
-  return next().then(
-    (result) => {
-      const ok = (result as unknown as { ok?: boolean })?.ok !== false;
-      maybeRecordOauthScopeUsage({
-        subject,
-        userId,
-        scopeBit: requiredScope,
-        endpoint: path,
-        statusCode: ok ? 200 : 400,
-      });
-      return result;
-    },
-    (err) => {
-      maybeRecordOauthScopeUsage({
-        subject,
-        userId,
-        scopeBit: requiredScope,
-        endpoint: path,
-        statusCode: 500,
-      });
-      throw err;
-    }
-  );
-});
+// `enforceTokenScope`'s body lives in a light standalone module so the OAuth
+// scope-verification + unified scope-usage audit wiring is unit-testable without
+// booting this heavy module. tRPC just wraps it.
+const enforceTokenScope = t.middleware(({ ctx, meta, path, next }) =>
+  runEnforceTokenScope({ ctx, meta, path, next })
+);
 
 // Time every procedure by path (full chain + resolver) so heavy-pool isolation
 // candidates can be ranked by P99 x rate — the criterion behind the image-feed

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -32,6 +32,7 @@ import {
 } from '~/shared/constants/browsingLevel.constants';
 import { Flags } from '~/shared/utils/flags';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { maybeRecordOauthScopeUsage } from '~/server/services/oauth/oauth-scope-audit';
 import { parseVerifiedBotHeader, VERIFIED_BOT_HEADER } from '~/server/utils/bot-detection/header';
 import type { Context } from './createContext';
 
@@ -247,7 +248,7 @@ const applyDomainFeature = t.middleware(async (options) => {
  *   request regardless of scope. Used for buzz-spending operations that the
  *   orchestrator owns; tokens have no business spending buzz on Civitai's side.
  */
-const enforceTokenScope = t.middleware(({ ctx, meta, next }) => {
+const enforceTokenScope = t.middleware(({ ctx, meta, path, next }) => {
   // blockApiKeys: deny any token-based request, regardless of scope. Session
   // auth (apiKeyId === null) is unaffected.
   if (meta?.blockApiKeys && ctx.apiKeyId != null) {
@@ -257,22 +258,59 @@ const enforceTokenScope = t.middleware(({ ctx, meta, next }) => {
     });
   }
 
-  // Session auth (cookies) and full-access API keys pass through scope check
-  if (ctx.tokenScope === TokenScope.Full) {
-    return next();
-  }
-
-  // Default unannotated endpoints to requiring Full scope
+  // The scope this call exercises — the declared requiredScope, or Full for an
+  // unannotated endpoint (which implicitly requires Full). Also the value the
+  // external-OAuth scope-usage audit records below.
   const requiredScope = meta?.requiredScope ?? TokenScope.Full;
 
-  if (!Flags.hasFlag(ctx.tokenScope, requiredScope)) {
-    throw new TRPCError({
-      code: 'FORBIDDEN',
-      message: 'Your API key does not have the required scope for this action',
-    });
+  // Session auth (cookies) and full-access API keys pass through the scope check;
+  // a scoped token must carry the required bit.
+  if (ctx.tokenScope !== TokenScope.Full) {
+    if (!Flags.hasFlag(ctx.tokenScope, requiredScope)) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Your API key does not have the required scope for this action',
+      });
+    }
   }
 
-  return next();
+  // Unified scope-usage audit — external-OAuth arm. `enforceTokenScope` is the
+  // single central choke point where an OAuth access token's scope is verified,
+  // so it's where external OAuth API usage is recorded (mirroring the block-token
+  // audit fired from block-scope.middleware). Only an external OAuth token reaches
+  // the sink (guarded inside maybeRecordOauthScopeUsage — session + personal-API-
+  // key requests emit nothing). Fire-and-forget, and emitted AFTER the procedure
+  // settles so the recorded status reflects the real outcome + records EXACTLY one
+  // row per call. We wrap next() only for OAuth subjects so the (dominant) session
+  // path stays a bare `next()` with no extra async frame.
+  if (ctx.subject?.type !== 'oauth' || ctx.user?.id == null) {
+    return next();
+  }
+  const subject = ctx.subject;
+  const userId = ctx.user.id;
+  return next().then(
+    (result) => {
+      const ok = (result as unknown as { ok?: boolean })?.ok !== false;
+      maybeRecordOauthScopeUsage({
+        subject,
+        userId,
+        scopeBit: requiredScope,
+        endpoint: path,
+        statusCode: ok ? 200 : 400,
+      });
+      return result;
+    },
+    (err) => {
+      maybeRecordOauthScopeUsage({
+        subject,
+        userId,
+        scopeBit: requiredScope,
+        endpoint: path,
+        statusCode: 500,
+      });
+      throw err;
+    }
+  );
 });
 
 // Time every procedure by path (full chain + resolver) so heavy-pool isolation


### PR DESCRIPTION
## What & why

App Blocks block-token calls already record a per-scope invocation row
(`recordScopeInvocation` → `block_scope_invocations`, surfaced in the app
Activity panel at `/apps/installed`). **External apps** authenticate with a
standard OAuth `authorization_code`/`refresh_token` access token whose scope is
verified centrally at the **`enforceTokenScope`** tRPC middleware
(`src/server/trpc.ts`) — a path that recorded **nothing**, so external OAuth API
usage was invisible to the scope-usage audit.

This makes `enforceTokenScope` — the single central point where an OAuth token's
scope is checked — emit into the **same sink and row shape** as the block-token
audit (no divergent second format), so there is **one "which app used which
scope, when" record across BOTH** token populations.

## Security / product level

- External OAuth API usage now flows into the same scope-usage audit as App
  Blocks: for every scope-gated tRPC call made by an external OAuth access token
  we record the acting **OAuth client (the app)**, the **scope** exercised, the
  **route**, the **user**, and **when** — the same forensic trail block-tokens
  already leave.
- **Additive `source` tag** distinguishes the two populations without a schema
  break: `source = 'app-block'` (default, existing block rows unchanged) vs
  `source = 'external-oauth'`. Block rows keep byte-identical write shape.
- **Non-blocking**: fire-and-forget with an internal try/catch — a failed or slow
  audit write can never fail or slow the API call. Emitted **after** the
  procedure settles so the recorded status reflects the real outcome, and
  **exactly one** row per call (the middleware runs once per procedure). Session
  and personal-API-key requests emit nothing (only external OAuth tokens do).

## Changes

- **Schema** (`schema.full.prisma` + manual-apply migration): `block_scope_invocations`
  gains nullable `oauth_client_id` (FK-less on purpose — an audit row must
  outlive the app it references), `source TEXT NOT NULL DEFAULT 'app-block'`
  (backfills existing rows), makes `block_instance_id` nullable, and adds
  `bsi_oauth_client_invoked_idx`. **Manual apply only** — the main civitai DB
  (CNPG nvme0) does not auto-apply Prisma migrations; until it is applied the
  external-oauth write simply logs-and-swallows (safe, non-blocking).
- `recordScopeInvocation`: `appBlockId`/`blockInstanceId` relaxed to optional,
  adds `oauthClientId` + `source`; an `'app-block'` call site writes a
  byte-identical row (conditional keys; `source` falls to the DB default).
- New `src/server/services/oauth/oauth-scope-audit.ts`: `maybeRecordOauthScopeUsage`
  (the guarded, lazy-import, fire-and-forget emit) + `tokenScopeToAuditName`
  (`TokenScope` bit → stable name; `Full` → `'full'`; unknown → `scope:<n>`).
- `enforceTokenScope`: capture the OAuth invocation after `next()` settles.

## Surfacing

The existing block Activity feed (`listMyScopeInvocations`) is **block-semantic**;
external-oauth rows are **excluded** from it (via `app_block_id IS NOT NULL`, which
references only the pre-existing column so it is safe whether or not the migration
has been applied). The **data is captured** (queryable by `oauth_client_id`); a
dedicated external-OAuth activity view (resolving `oauthClient.name`, badged by
`source`) is a **noted UI follow-up**, not built here to avoid scope creep.

## Tests

- `oauth-scope-audit.test.ts` (8): `tokenScopeToAuditName` mapping; an external
  OAuth call records **one** row with the right `oauthClientId` + scope +
  `source: 'external-oauth'`; a session / personal-API-key / no-user request
  records **nothing**; a rejecting sink never throws.
- `record-scope-invocation-oauth.test.ts` (3): the external-oauth create shape
  (oauthClientId + source, no block keys); the **block-token call site is
  byte-identical** (no new keys — no double-count / schema drift); a sink failure
  is swallowed.
- Existing block-path tests unchanged: `record-scope-invocation-synthetic` (7),
  `user-app-surface.orchestration` exact-shape assertion, `blocks.router.workflow`
  (185), `apps.router.storage` (31) all pass.

**Gates:** `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` → **0 errors**
(exit 0, project-wide). New + affected vitest suites → **all pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
