### PR TITLE
feat(app-listings): W13 OAuth-connect scope-review dark groundwork (schema + pure helpers/validator)

### DIFF
--- a/packages/civitai-auth/src/__tests__/connect-scope-review.test.ts
+++ b/packages/civitai-auth/src/__tests__/connect-scope-review.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TokenScope,
+  tokenScopeLabels,
+  SCOPE_JUSTIFICATION_MAX_LENGTH,
+  tokenScopeMaskToList,
+  tokenScopeKeyByBit,
+  connectScopesSubsetOfCeiling,
+  validateConnectScopeJustifications,
+} from '../token-scope';
+
+describe('tokenScopeKeyByBit', () => {
+  it('maps a single bit to its enum-key', () => {
+    expect(tokenScopeKeyByBit(TokenScope.ModelsRead)).toBe('ModelsRead');
+    expect(tokenScopeKeyByBit(TokenScope.UserRead)).toBe('UserRead');
+    expect(tokenScopeKeyByBit(TokenScope.AppBlocksDevTunnel)).toBe('AppBlocksDevTunnel');
+  });
+
+  it('returns undefined for an unknown / non-single bit', () => {
+    expect(tokenScopeKeyByBit(0)).toBeUndefined(); // None sentinel
+    expect(tokenScopeKeyByBit(TokenScope.Full)).toBeUndefined(); // aggregate, not a single bit
+    expect(tokenScopeKeyByBit(1 << 30)).toBeUndefined(); // undefined bit
+    expect(tokenScopeKeyByBit(TokenScope.UserRead | TokenScope.ModelsRead)).toBeUndefined(); // multi-bit
+  });
+});
+
+describe('tokenScopeMaskToList', () => {
+  it('empty mask (0) yields no scopes', () => {
+    expect(tokenScopeMaskToList(0)).toEqual([]);
+  });
+
+  it('single-bit mask yields that scope with bit/key/label', () => {
+    expect(tokenScopeMaskToList(TokenScope.ModelsRead)).toEqual([
+      {
+        bit: TokenScope.ModelsRead,
+        key: 'ModelsRead',
+        label: tokenScopeLabels[TokenScope.ModelsRead],
+      },
+    ]);
+  });
+
+  it('multi-bit mask yields every set scope, sorted by bit ascending', () => {
+    const mask = TokenScope.MediaWrite | TokenScope.UserRead | TokenScope.ModelsRead;
+    const list = tokenScopeMaskToList(mask);
+    expect(list.map((s) => s.key)).toEqual(['UserRead', 'ModelsRead', 'MediaWrite']);
+    for (const s of list) {
+      expect(tokenScopeKeyByBit(s.bit)).toBe(s.key);
+      expect(s.label).toBe(tokenScopeLabels[s.bit]);
+    }
+  });
+
+  it('ignores bits not set in the mask (aggregate Full stays fully expanded)', () => {
+    const list = tokenScopeMaskToList(TokenScope.Full);
+    // Full is the OR of bits 0..24 → 25 single-bit scopes, none of them the two
+    // opt-in bits (AppBlocksSubmit / AppBlocksDevTunnel) which are excluded.
+    expect(list).toHaveLength(25);
+    expect(list.some((s) => s.key === 'AppBlocksSubmit')).toBe(false);
+    expect(list.some((s) => s.key === 'AppBlocksDevTunnel')).toBe(false);
+  });
+});
+
+describe('connectScopesSubsetOfCeiling', () => {
+  it('true when requested is a subset of the ceiling', () => {
+    const ceiling = TokenScope.UserRead | TokenScope.ModelsRead | TokenScope.MediaRead;
+    expect(connectScopesSubsetOfCeiling(0, ceiling)).toBe(true);
+    expect(connectScopesSubsetOfCeiling(TokenScope.ModelsRead, ceiling)).toBe(true);
+    expect(connectScopesSubsetOfCeiling(ceiling, ceiling)).toBe(true);
+  });
+
+  it('false when requested carries a bit outside the ceiling', () => {
+    const ceiling = TokenScope.UserRead | TokenScope.ModelsRead;
+    expect(
+      connectScopesSubsetOfCeiling(TokenScope.ModelsRead | TokenScope.ModelsWrite, ceiling)
+    ).toBe(false);
+    expect(connectScopesSubsetOfCeiling(TokenScope.MediaDelete, ceiling)).toBe(false);
+  });
+});
+
+describe('validateConnectScopeJustifications', () => {
+  const requested = TokenScope.ModelsRead | TokenScope.MediaWrite;
+
+  it('no errors when every key is a requested scope with a non-empty ≤500 value', () => {
+    expect(
+      validateConnectScopeJustifications(requested, {
+        ModelsRead: 'We read models to render the gallery.',
+        MediaWrite: 'We publish generated images on the user behalf.',
+      })
+    ).toEqual([]);
+  });
+
+  it('empty justifications ({}) is valid', () => {
+    expect(validateConnectScopeJustifications(requested, {})).toEqual([]);
+  });
+
+  it('rejects an unknown / invalid scope key', () => {
+    const errors = validateConnectScopeJustifications(requested, {
+      NotAScope: 'x',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('NotAScope');
+    expect(errors[0]).toContain('not a valid scope');
+  });
+
+  it('rejects an aggregate/sentinel key (Full / None)', () => {
+    expect(validateConnectScopeJustifications(requested, { Full: 'x' })).toEqual([
+      'scopeJustifications references "Full" which is not a valid scope',
+    ]);
+    expect(validateConnectScopeJustifications(requested, { None: 'x' })).toEqual([
+      'scopeJustifications references "None" which is not a valid scope',
+    ]);
+  });
+
+  it('rejects a valid scope key that is not among the requested scopes', () => {
+    const errors = validateConnectScopeJustifications(requested, {
+      ModelsDelete: 'We need to delete models.',
+    });
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('ModelsDelete');
+    expect(errors[0]).toContain('not among the requested scopes');
+  });
+
+  it('rejects an empty value', () => {
+    const errors = validateConnectScopeJustifications(requested, { ModelsRead: '' });
+    expect(errors).toEqual(['scopeJustifications["ModelsRead"] must be a non-empty string']);
+  });
+
+  it('rejects a value longer than SCOPE_JUSTIFICATION_MAX_LENGTH', () => {
+    const tooLong = 'a'.repeat(SCOPE_JUSTIFICATION_MAX_LENGTH + 1);
+    const errors = validateConnectScopeJustifications(requested, { ModelsRead: tooLong });
+    expect(errors).toEqual([
+      `scopeJustifications["ModelsRead"] must be ≤${SCOPE_JUSTIFICATION_MAX_LENGTH} chars`,
+    ]);
+  });
+
+  it('accepts a value exactly at the length bound', () => {
+    const atBound = 'a'.repeat(SCOPE_JUSTIFICATION_MAX_LENGTH);
+    expect(validateConnectScopeJustifications(requested, { ModelsRead: atBound })).toEqual([]);
+  });
+
+  it('SCOPE_JUSTIFICATION_MAX_LENGTH is 500 (shared bound)', () => {
+    expect(SCOPE_JUSTIFICATION_MAX_LENGTH).toBe(500);
+  });
+});

--- a/packages/civitai-auth/src/token-scope.ts
+++ b/packages/civitai-auth/src/token-scope.ts
@@ -237,3 +237,109 @@ export function getScopeLabel(tokenScope: number | null | undefined): string {
   if (tokenScope === TokenScopePresets.AIServices) return 'AI Services';
   return 'Custom';
 }
+
+// ---------------------------------------------------------------------------
+// OAuth-connect scope review (W13) — shared, pure helpers + validator.
+//
+// Dark groundwork: nothing references these at runtime yet. They back the
+// per-scope justification/review that the OAuth-connect app-listing authoring
+// (PR2) and mod-review (PR3) flows will use. Kept here — next to the scope
+// vocab — so the bitmask, the justification-key mapping, and the length bound
+// have a SINGLE source of truth. Still env/DOM-free and client-safe.
+// ---------------------------------------------------------------------------
+
+/**
+ * Max length of a single per-scope justification string. SINGLE SOURCE — the
+ * App Blocks manifest validator (`block-manifest-validator.service.ts`) and the
+ * OAuth-connect validator below both import this so the bound can never drift.
+ * Also mirrors the published App Block manifest schema's
+ * `scopeJustifications.additionalProperties.maxLength`.
+ */
+export const SCOPE_JUSTIFICATION_MAX_LENGTH = 500;
+
+/**
+ * Every SINGLE-BIT scope in the enum, as `{ bit, key }`, sorted by bit ascending.
+ * Excludes the aggregate/sentinel members `None` (0) and `Full` (an OR of many
+ * bits) via the power-of-two test — so it can never accidentally list a
+ * composite value, and never drifts behind a newly-added bit.
+ */
+const TOKEN_SCOPE_BITS: { bit: number; key: string }[] = Object.entries(TokenScope)
+  .filter(([, value]) => value !== 0 && (value & (value - 1)) === 0) // power of two
+  .map(([key, value]) => ({ bit: value as number, key }))
+  .sort((a, b) => a.bit - b.bit);
+
+/** bit → enum-key reverse lookup for the single-bit scopes. */
+const BIT_TO_SCOPE_KEY: Map<number, string> = new Map(
+  TOKEN_SCOPE_BITS.map(({ bit, key }) => [bit, key])
+);
+
+/** The enum-key (e.g. "ModelsRead") for a single scope bit, or undefined if the
+ * value is not a defined single-bit scope. */
+export function tokenScopeKeyByBit(bit: number): string | undefined {
+  return BIT_TO_SCOPE_KEY.get(bit);
+}
+
+/**
+ * Expand a tokenScope bitmask into the set of scopes it carries, each as
+ * `{ bit, key, label }` (label from `tokenScopeLabels`, '' if none), sorted by
+ * bit ascending. Mirrors `Flags.hasFlag(mask, bit)` with an inlined bit test so
+ * this stays a dependency-free leaf module. Empty mask (0) ⇒ [].
+ */
+export function tokenScopeMaskToList(
+  mask: number
+): { bit: number; key: string; label: string }[] {
+  return TOKEN_SCOPE_BITS.filter(({ bit }) => (mask & bit) === bit).map(({ bit, key }) => ({
+    bit,
+    key,
+    label: tokenScopeLabels[bit] ?? '',
+  }));
+}
+
+/**
+ * True iff `requested` is a subset of the `allowedScopes` ceiling — i.e. carries
+ * no bit outside it. `(requested & ~allowedScopes) === 0`.
+ */
+export function connectScopesSubsetOfCeiling(requested: number, allowedScopes: number): boolean {
+  return (requested & ~allowedScopes) === 0;
+}
+
+/**
+ * Validate an OAuth-connect listing's per-scope justifications against its
+ * requested-scope mask. Returns an array of human-readable error strings (empty
+ * ⇒ valid). Mirrors the App Blocks manifest justification loop
+ * (`block-manifest-validator.service.ts`): every key must be a valid single-bit
+ * `TokenScope` enum-key, every key's bit must be set in `requestedScopes` (keys
+ * ⊆ requested), and every value must be a non-empty string
+ * ≤ SCOPE_JUSTIFICATION_MAX_LENGTH. An empty map (`{}`) is valid — this only
+ * CAPTURES the dev's stated rationale, it does not verify it. Justifications for
+ * scopes NOT requested are rejected so no dangling rationale reaches the mod.
+ */
+export function validateConnectScopeJustifications(
+  requestedScopes: number,
+  justifications: Record<string, string>
+): string[] {
+  const errors: string[] = [];
+  for (const [key, value] of Object.entries(justifications)) {
+    const bit = (TokenScope as Record<string, number>)[key];
+    // Unknown key, or an aggregate/sentinel member (None/Full) that is not a
+    // single justifiable scope.
+    if (bit === undefined || bit === 0 || (bit & (bit - 1)) !== 0) {
+      errors.push(`scopeJustifications references "${key}" which is not a valid scope`);
+      continue;
+    }
+    if ((requestedScopes & bit) !== bit) {
+      errors.push(
+        `scopeJustifications["${key}"] is not among the requested scopes`
+      );
+      continue;
+    }
+    if (typeof value !== 'string' || value.length === 0) {
+      errors.push(`scopeJustifications["${key}"] must be a non-empty string`);
+    } else if (value.length > SCOPE_JUSTIFICATION_MAX_LENGTH) {
+      errors.push(
+        `scopeJustifications["${key}"] must be ≤${SCOPE_JUSTIFICATION_MAX_LENGTH} chars`
+      );
+    }
+  }
+  return errors;
+}

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -2538,6 +2538,15 @@ model AppListing {
   // Off-site OAuth-connect client (Connect CTA). NULL for on-site/external-link.
   connectClientId String?      @map("connect_client_id")
   connectClient   OauthClient? @relation(fields: [connectClientId], references: [id], onDelete: SetNull)
+  // W13 OAuth-connect scope review (DARK — additive, nullable; nothing reads
+  // these yet). `connectRequestedScopes` = the TokenScope bitmask the listing
+  // requests, always a subset ⊆ `connectClient.allowedScopes` (the per-client
+  // ceiling). `connectScopeJustifications` = a JSON object keyed by TokenScope
+  // enum-key STRING (e.g. "ModelsRead") → the dev's rationale (≤500 chars,
+  // SCOPE_JUSTIFICATION_MAX_LENGTH). Both NULL for external-link / on-site
+  // listings (only OAuth-connect listings carry them).
+  connectRequestedScopes     Int?  @map("connect_requested_scopes")
+  connectScopeJustifications Json? @map("connect_scope_justifications")
   // 1:1 backing AppBlock (UNIQUE) + idempotency key. Set for EVERY backfilled
   // row — on-site AND the #2821 off-site rows (both come from an AppBlock). It is
   // NOT a kind discriminator: discriminate on `kind`, never on appBlockId nullness.

--- a/prisma/migrations/20260717120000_w13_connect_scope_review/migration.sql
+++ b/prisma/migrations/20260717120000_w13_connect_scope_review/migration.sql
@@ -1,0 +1,31 @@
+-- ============================================================
+-- W13 — OAuth-connect app-listing scope review + per-scope justifications
+-- ============================================================
+-- See claudedocs/oauth-app-scope-review-plan-2026-07-17.md (§1). PR1 (dark
+-- groundwork): additive schema only — nothing reads these columns yet. PR2
+-- (dev authoring) and PR3 (mod review) will write/read them.
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
+-- CNPG nvme0 DB does NOT auto-apply migrations. This file is committed for
+-- history; a HUMAN applies the SQL below per environment (psql/retool). CI /
+-- deploy does NOT run it.
+--
+-- ⚠️ MUST BE APPLIED BEFORE THE PR2/PR3 CODE GOES LIVE: the authoring service
+-- and the mod-review submissionSelect will SELECT/INSERT these columns. If that
+-- code ships before the columns exist, those queries 500 (same missing-column
+-- constraint as E5's `screenshots` / E3's `category`). PR1 itself references
+-- nothing, so it is safe to deploy ahead of this apply — but PR2/PR3 are NOT.
+-- Apply this first.
+--
+-- ADDITIVE + NON-BREAKING + IDEMPOTENT:
+--   - Two nullable columns; existing rows and existing INSERTs (which never
+--     mention them) are unaffected. Both default to NULL:
+--       * connect_requested_scopes  = "no scope review" (external-link/on-site)
+--       * connect_scope_justifications = "no justifications"
+--   - `IF NOT EXISTS` so re-applying is a no-op.
+--   - No index needed: read only on the single-row listing/review paths (keyed
+--     on the PK), never filtered/sorted on.
+
+ALTER TABLE "app_listings"
+  ADD COLUMN IF NOT EXISTS "connect_requested_scopes" integer,
+  ADD COLUMN IF NOT EXISTS "connect_scope_justifications" jsonb;

--- a/src/server/services/block-manifest-validator.service.ts
+++ b/src/server/services/block-manifest-validator.service.ts
@@ -12,6 +12,9 @@ import {
 // imported by `ManifestEditForm.tsx`). `safe-fetch.ts` imports the same helpers,
 // so the manifest validator and the fetch-time guard share ONE source of truth.
 import { isPublicHttpsUrl } from '~/server/utils/ssrf-hostname';
+// Single source for the per-scope justification length bound — shared with the
+// OAuth-connect scope-review validator in @civitai/auth so the two can't drift.
+import { SCOPE_JUSTIFICATION_MAX_LENGTH } from '@civitai/auth/token-scope';
 
 type ValidationResult = { valid: true } | { valid: false; errors: string[] };
 
@@ -138,9 +141,10 @@ const SHELL_METACHAR_RE = /[;|&$`<>(){}\\!*?\[\]'"\n\r]/;
 
 // Max length of a single per-scope justification string (scopeJustifications
 // map value). Bounded so a malicious/careless manifest can't bloat the stored
-// blob or the mod-review render. Single-sourced with the published schema's
-// scopeJustifications.additionalProperties.maxLength.
-export const SCOPE_JUSTIFICATION_MAX_LENGTH = 500;
+// blob or the mod-review render. LIFTED to @civitai/auth/token-scope (imported
+// above) so the App Blocks manifest path and the OAuth-connect scope-review
+// path share ONE literal; re-exported here to keep existing importers stable.
+export { SCOPE_JUSTIFICATION_MAX_LENGTH };
 
 // Min/max for the iframe height envelope. The host clamps incoming
 // RESIZE_IFRAME to these bounds, but rejecting absurd values at


### PR DESCRIPTION
## What this is — dark groundwork (PR1 of the W13 OAuth-connect scope-review feature)

Additive schema + pure helpers/validator for per-scope review of **OAuth-connect** app listings. **Everything here is DARK — nothing references these at runtime yet.** No behavior change, no wiring into any flow. Dev authoring (PR2) and mod review (PR3) land in later PRs. Low risk / additive only.

Design: `oauth-app-scope-review-plan-2026-07-17.md` (§1, §2, §5).

## Changes
- **Schema** — two ADDITIVE, nullable columns on `AppListing`:
  - `connectRequestedScopes Int?` — the requested `TokenScope` bitmask, always a subset ⊆ `connectClient.allowedScopes` (the per-client ceiling).
  - `connectScopeJustifications Json?` — object keyed by `TokenScope` enum-key string (e.g. `"ModelsRead"`) → rationale (≤500 chars).
  - Both `NULL` for external-link / on-site listings (only OAuth-connect listings carry them).
- **Pure helpers** in `@civitai/auth/token-scope` (env/DOM-free, client-safe):
  - `tokenScopeMaskToList(mask)` → `{ bit, key, label }[]` for each set scope.
  - `tokenScopeKeyByBit(bit)` → enum-key for a single bit (or `undefined`).
  - `connectScopesSubsetOfCeiling(requested, allowedScopes)` = `(requested & ~allowedScopes) === 0`.
  - `validateConnectScopeJustifications(requestedScopes, justifications)` → `string[]` errors, mirroring the App Blocks manifest justification loop.
- **Single-source constant** — lifted `SCOPE_JUSTIFICATION_MAX_LENGTH` (500) into `@civitai/auth/token-scope`; `block-manifest-validator.service.ts` now re-exports it instead of declaring its own literal (no duplicated value across the two validator paths).
- **Tests** — 17 new unit tests for the helpers + validator.

## 🔴 Migration is HUMAN-APPLIED — apply to CNPG nvme0 BEFORE PR2/PR3 deploy
Per the DB rule, the main civitai CNPG nvme0 DB does **not** auto-apply migrations. `prisma/migrations/20260717120000_w13_connect_scope_review/migration.sql` is committed **for history only** — a human applies it per environment (psql/retool); CI/deploy does NOT run it. PR1 itself references nothing, so it is safe to deploy ahead of the apply — but **PR2/PR3 read/write these columns and will 500 (missing-column) if they ship before the columns exist.** Apply this first:

```sql
ALTER TABLE "app_listings"
  ADD COLUMN IF NOT EXISTS "connect_requested_scopes" integer,
  ADD COLUMN IF NOT EXISTS "connect_scope_justifications" jsonb;
```
Additive + non-breaking + idempotent (`IF NOT EXISTS`); existing rows/INSERTs unaffected (default NULL).

## Test evidence
- `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` → **exit 0, 0 errors** (0-delta vs baseline; no errors in changed files).
- `@civitai/auth` unit tests: **25 passed** (17 new `connect-scope-review.test.ts` + 8 existing `token-scope.test.ts`).
- Affected block-validator tests: **139 passed** (`block-manifest-validator.service.test.ts` 134 incl. the shared-constant path + `blocks.router.updateManifest.scopeJustifications.test.ts` 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
