### PR TITLE
feat(apps): OAuth-connect listing submission + per-scope justification authoring (PR2)

### DIFF
--- a/src/components/Apps/ConnectSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ConnectSubmitForm.browser.test.tsx
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { TokenScope } from '../../shared/constants/token-scope.constants';
+
+/**
+ * W13 — /apps/submit "Connect an app" mode WIZARD. Browser-mode surface test
+ * (report-only in Tekton): the client picker lists the caller's own OAuth apps
+ * (app-block clients filtered out), picking one reveals a scope grid RESTRICTED to
+ * that client's allowedScopes (bits outside it are disabled), a justification
+ * textarea appears per checked scope, and Create-draft sends the right payload. The
+ * pure config (toggle/validate/payload shaping) is unit-tested in
+ * `__tests__/connectSubmitFormConfig.test.ts`.
+ */
+
+// Ceiling for the picked client: UserRead(1) | ModelsRead(4) = 5. ModelsWrite(8) is
+// OUTSIDE the ceiling → its checkbox must be disabled.
+const CEILING = TokenScope.UserRead | TokenScope.ModelsRead;
+
+const mocks = vi.hoisted(() => ({
+  mutate: vi.fn(),
+  clients: [] as Array<{ id: string; name: string; allowedScopes: number }>,
+}));
+
+vi.mock('~/utils/trpc', () => {
+  const mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
+  return {
+    trpc: {
+      oauthClient: {
+        getAll: {
+          useQuery: () => ({ data: mocks.clients, isLoading: false }),
+        },
+      },
+      appListings: {
+        submitConnectListing: {
+          useMutation: () => ({ mutate: mocks.mutate, mutateAsync: vi.fn(), isPending: false }),
+        },
+        persistAssetImage: { useMutation: mutation },
+        ingestAssetFromUrl: { useMutation: mutation },
+        setIcon: { useMutation: mutation },
+        setCover: { useMutation: mutation },
+        addScreenshot: { useMutation: mutation },
+      },
+    },
+  };
+});
+
+vi.mock('~/hooks/useCFImageUpload', () => ({
+  useCFImageUpload: () => ({
+    uploadToCF: vi.fn(),
+    files: [],
+    resetFiles: vi.fn(),
+    removeImage: vi.fn(),
+  }),
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+const { ConnectSubmitForm } = await import('./ConnectSubmitForm');
+
+beforeEach(() => {
+  mocks.mutate.mockClear();
+  mocks.clients = [
+    { id: 'oauth-client-1', name: 'My OAuth App', allowedScopes: CEILING },
+    // App-block clients must be filtered OUT of the picker.
+    { id: 'appblk-hidden', name: 'Block Client', allowedScopes: TokenScope.Full },
+  ];
+});
+
+describe('ConnectSubmitForm — wizard', () => {
+  test('restricts the scope grid to the selected client’s allowedScopes', async () => {
+    renderWithProviders(<ConnectSubmitForm />);
+    await page.getByTestId('apps-connect-client-select').click();
+    await page.getByRole('option', { name: 'My OAuth App' }).click();
+
+    // ModelsRead (bit 4) is in the ceiling → enabled; ModelsWrite (bit 8) is not → disabled.
+    await expect.element(page.getByTestId('apps-connect-scope-4')).not.toBeDisabled();
+    await expect.element(page.getByTestId('apps-connect-scope-8')).toBeDisabled();
+  });
+
+  test('a justification textarea appears per checked scope', async () => {
+    renderWithProviders(<ConnectSubmitForm />);
+    await page.getByTestId('apps-connect-client-select').click();
+    await page.getByRole('option', { name: 'My OAuth App' }).click();
+
+    // No justification textarea before any scope is checked.
+    expect(page.getByTestId('apps-connect-justification-4').elements()).toHaveLength(0);
+
+    await page.getByTestId('apps-connect-scope-4').click();
+    await expect.element(page.getByTestId('apps-connect-justification-4')).toBeInTheDocument();
+  });
+
+  test('Create-draft sends the connectClientId + requestedScopes + justifications', async () => {
+    renderWithProviders(<ConnectSubmitForm />);
+    await page.getByTestId('apps-connect-client-select').click();
+    await page.getByRole('option', { name: 'My OAuth App' }).click();
+    await page.getByTestId('apps-connect-scope-4').click();
+    await page.getByTestId('apps-connect-justification-4').fill('We download models.');
+    await page.getByTestId('apps-connect-wizard-next-client').click();
+
+    await page.getByTestId('apps-connect-submit-name').fill('My Connected App');
+    await page.getByTestId('apps-connect-submit-slug').fill('my-connected-app');
+    await page.getByTestId('apps-connect-submit-create').click();
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: 'my-connected-app',
+        name: 'My Connected App',
+        connectClientId: 'oauth-client-1',
+        requestedScopes: TokenScope.ModelsRead,
+        scopeJustifications: { ModelsRead: 'We download models.' },
+      })
+    );
+  });
+});

--- a/src/components/Apps/ConnectSubmitForm.tsx
+++ b/src/components/Apps/ConnectSubmitForm.tsx
@@ -1,0 +1,526 @@
+import {
+  Alert,
+  Badge,
+  Button,
+  Checkbox,
+  Code,
+  Group,
+  Loader,
+  Select,
+  Stack,
+  Stepper,
+  Table,
+  Text,
+  TextInput,
+  Textarea,
+} from '@mantine/core';
+import {
+  IconAlertTriangle,
+  IconCheck,
+  IconExternalLink,
+  IconPlugConnected,
+} from '@tabler/icons-react';
+import Link from 'next/link';
+import { useMemo, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { ListingAssetStep } from '~/components/Apps/ListingAssetStep';
+import {
+  CONNECT_CATEGORY_OPTIONS,
+  CONNECT_CONTENT_RATING_OPTIONS,
+  CONNECT_SUBMIT_LIMITS,
+  emptyConnectSubmitForm,
+  isConnectClientStepComplete,
+  isConnectDetailsStepComplete,
+  scopeKeyForBit,
+  toSubmitConnectInput,
+  toggleScopeBit,
+  validateConnectSubmitForm,
+  type ConnectSubmitFormErrors,
+  type ConnectSubmitFormValues,
+} from '~/components/Apps/connectSubmitFormConfig';
+import type { MarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
+import type { OffsiteContentRating } from '~/server/schema/blocks/offsite-listing.schema';
+import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
+import {
+  tokenScopeGrid,
+  tokenScopeLabels,
+  tokenScopeMaskToList,
+} from '~/shared/constants/token-scope.constants';
+import { Flags } from '~/shared/utils/flags';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * /apps/submit — "Connect an app" mode body (W13, un-defers the OAuth-connect seam).
+ * A native publish-request flow that links a registered OAuth client the caller OWNS
+ * (design B1: creates a DRAFT listing + a pending request on submit), then reuses the
+ * standard asset step. The author picks one of their own OAuth apps, opts INTO the
+ * subset of that app's allowed scopes it will request (explicit opt-in from empty),
+ * and writes a short justification per requested scope.
+ *
+ * DISCLOSURE/REVIEW-ONLY: the requested-scope subset is stored + reviewed; it does
+ * NOT gate OAuth token issuance (the client's allowedScopes stays the runtime ceiling
+ * via the existing consent flow).
+ *
+ * The server (`submitConnectListing`) is the source of truth; the client mirror
+ * (`validateConnectSubmitForm`) only surfaces inline errors before the round-trip.
+ *
+ * DARK: reachable only behind `app-blocks-author` (the gSSP gate on /apps/submit is
+ * unchanged) — mirrors the External-link mode's gating.
+ */
+
+type Submitted = { listingId: string; publishRequestId: string; slug: string };
+
+const STEP_CLIENT = 0;
+const STEP_DETAILS = 1;
+const STEP_ASSETS = 2;
+
+export function ConnectSubmitForm() {
+  const [active, setActive] = useState<number>(STEP_CLIENT);
+  const [values, setValues] = useState<ConnectSubmitFormValues>(emptyConnectSubmitForm());
+  const [errors, setErrors] = useState<ConnectSubmitFormErrors>({});
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [submitted, setSubmitted] = useState<Submitted | null>(null);
+
+  const clientsQuery = trpc.oauthClient.getAll.useQuery(undefined, {
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  // The caller's OWN OAuth clients, EXCLUDING App-Block clients (managed by the App
+  // Blocks flow — never a hand-authored connect target). `getAll` is already scoped
+  // to the caller (`userId`), so this is the ownership filter + the app-block exclude.
+  const clients = useMemo(
+    () => (clientsQuery.data ?? []).filter((c) => !isAppBlockOauthClientId(c.id)),
+    [clientsQuery.data]
+  );
+
+  const selectedClient = useMemo(
+    () => clients.find((c) => c.id === values.connectClientId) ?? null,
+    [clients, values.connectClientId]
+  );
+  const allowedScopes = selectedClient?.allowedScopes ?? 0;
+
+  const submitMutation = trpc.appListings.submitConnectListing.useMutation({
+    onSuccess: (res: Submitted) => {
+      setSubmitted(res);
+      setServerError(null);
+      setActive(STEP_ASSETS);
+      showSuccessNotification({ message: 'Draft created. Add your assets to finish.' });
+    },
+    onError: (e: { message: string }) => {
+      setServerError(e.message);
+      showErrorNotification({ title: 'Could not create the listing', error: new Error(e.message) });
+    },
+  });
+
+  function setField<K extends keyof ConnectSubmitFormValues>(
+    key: K,
+    value: ConnectSubmitFormValues[K]
+  ) {
+    setValues((v) => ({ ...v, [key]: value }));
+  }
+
+  function handleSelectClient(clientId: string | null) {
+    // Changing the client resets the requested scopes + justifications — the new
+    // client has a DIFFERENT ceiling, so a carried-over mask could exceed it.
+    setValues((v) => ({
+      ...v,
+      connectClientId: clientId,
+      requestedScopes: 0,
+      scopeJustifications: {},
+    }));
+    setErrors((prev) => ({ ...prev, connectClientId: undefined, requestedScopes: undefined }));
+  }
+
+  function handleToggleScope(bit: number) {
+    setValues((v) => toggleScopeBit(v, bit));
+  }
+
+  function handleJustificationChange(key: string, text: string) {
+    setValues((v) => ({
+      ...v,
+      scopeJustifications: { ...v.scopeJustifications, [key]: text },
+    }));
+  }
+
+  function handleDetailsKeyDown(e: ReactKeyboardEvent<HTMLInputElement>) {
+    if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
+    e.preventDefault();
+    if (isConnectDetailsStepComplete(values, allowedScopes)) handleCreateDraft();
+  }
+
+  function handleAdvanceFromClient() {
+    if (!isConnectClientStepComplete(values, allowedScopes)) {
+      setErrors((prev) => ({
+        ...prev,
+        connectClientId: values.connectClientId ? undefined : 'Choose one of your OAuth apps.',
+      }));
+      return;
+    }
+    setErrors((prev) => ({ ...prev, connectClientId: undefined, requestedScopes: undefined }));
+    setActive(STEP_DETAILS);
+  }
+
+  function handleCreateDraft() {
+    const nextErrors = validateConnectSubmitForm(values, allowedScopes);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+    submitMutation.mutate(toSubmitConnectInput(values));
+  }
+
+  function handleStepClick(step: number) {
+    if (submitted) return;
+    if (step === STEP_CLIENT) setActive(STEP_CLIENT);
+    else if (step === STEP_DETAILS && isConnectClientStepComplete(values, allowedScopes)) {
+      setActive(STEP_DETAILS);
+    }
+  }
+
+  const busy = submitMutation.isPending;
+  const requestedScopeList = tokenScopeMaskToList(values.requestedScopes);
+
+  const clientOptions = clients.map((c) => ({ value: c.id, label: c.name }));
+
+  return (
+    <Stack gap="md" data-testid="apps-connect-submit-form">
+      <Alert
+        color="blue"
+        variant="light"
+        icon={<IconPlugConnected size={16} />}
+        title="Connect an app"
+      >
+        <Text size="sm">
+          Link one of your registered OAuth apps so users can grant it access. Disclose the scopes
+          your app requests and why — a moderator reviews it before it appears. This does not change
+          what your app can do: your OAuth client’s allowed scopes stay the limit.
+        </Text>
+      </Alert>
+
+      {serverError && (
+        <Alert
+          color="red"
+          variant="light"
+          icon={<IconAlertTriangle size={16} />}
+          title="Submission problem"
+        >
+          <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+            {serverError}
+          </Text>
+        </Alert>
+      )}
+
+      <Stepper active={active} onStepClick={handleStepClick} allowNextStepsSelect={false} size="sm">
+        <Stepper.Step
+          label="App & scopes"
+          description="Your OAuth app"
+          allowStepClick={!submitted}
+          data-testid="apps-connect-wizard-step-client"
+        >
+          <Stack gap="md" mt="md">
+            {clientsQuery.isLoading ? (
+              <Group gap={8} data-testid="apps-connect-clients-loading">
+                <Loader size={16} />
+                <Text size="sm" c="dimmed">
+                  Loading your OAuth apps…
+                </Text>
+              </Group>
+            ) : clients.length === 0 ? (
+              <Alert color="gray" variant="light" data-testid="apps-connect-no-clients">
+                <Text size="sm">
+                  You have no eligible OAuth apps. Register one in your account settings first, then
+                  come back to list it.
+                </Text>
+              </Alert>
+            ) : (
+              <>
+                <Select
+                  label="OAuth app"
+                  description="One of your registered OAuth clients. Users will grant this app access."
+                  placeholder="Choose an app"
+                  data={clientOptions}
+                  value={values.connectClientId}
+                  onChange={handleSelectClient}
+                  error={errors.connectClientId}
+                  disabled={busy}
+                  required
+                  data-testid="apps-connect-client-select"
+                />
+
+                {selectedClient && (
+                  <Stack gap="xs" data-testid="apps-connect-scope-grid">
+                    <div>
+                      <Text size="sm" fw={500}>
+                        Requested scopes
+                      </Text>
+                      <Text size="xs" c="dimmed">
+                        Check only the scopes your app needs. Scopes greyed out aren’t in this app’s
+                        allowed set.
+                      </Text>
+                    </div>
+                    <Table withTableBorder withColumnBorders>
+                      <Table.Thead>
+                        <Table.Tr>
+                          <Table.Th>Resource</Table.Th>
+                          <Table.Th style={{ textAlign: 'center', width: 70 }}>Read</Table.Th>
+                          <Table.Th style={{ textAlign: 'center', width: 70 }}>Write</Table.Th>
+                          <Table.Th style={{ textAlign: 'center', width: 70 }}>Delete</Table.Th>
+                        </Table.Tr>
+                      </Table.Thead>
+                      <Table.Tbody>
+                        {tokenScopeGrid.map((row) => (
+                          <Table.Tr key={row.label}>
+                            <Table.Td>
+                              <Text size="sm">{row.label}</Text>
+                            </Table.Td>
+                            {(['read', 'write', 'delete'] as const).map((col) => {
+                              const bit = (row as { read?: number; write?: number; delete?: number })[
+                                col
+                              ];
+                              const available = bit != null && Flags.hasFlag(allowedScopes, bit);
+                              return (
+                                <Table.Td key={col} style={{ textAlign: 'center' }}>
+                                  {bit != null ? (
+                                    <Checkbox
+                                      checked={Flags.hasFlag(values.requestedScopes, bit)}
+                                      onChange={() => handleToggleScope(bit)}
+                                      disabled={!available || busy}
+                                      styles={{ input: { cursor: available ? 'pointer' : 'not-allowed' } }}
+                                      data-testid={`apps-connect-scope-${bit}`}
+                                    />
+                                  ) : (
+                                    <Text size="xs" c="dimmed">
+                                      —
+                                    </Text>
+                                  )}
+                                </Table.Td>
+                              );
+                            })}
+                          </Table.Tr>
+                        ))}
+                      </Table.Tbody>
+                    </Table>
+                    {errors.requestedScopes && (
+                      <Text size="xs" c="red">
+                        {errors.requestedScopes}
+                      </Text>
+                    )}
+
+                    {requestedScopeList.length > 0 && (
+                      <Stack gap="sm" data-testid="apps-connect-justifications">
+                        <Text size="sm" fw={500}>
+                          Why do you need each scope? (optional, helps review)
+                        </Text>
+                        {requestedScopeList.map(({ bit, key, label }) => {
+                          const justificationKey = scopeKeyForBit(bit);
+                          const text = values.scopeJustifications[justificationKey] ?? '';
+                          return (
+                            <Textarea
+                              key={bit}
+                              label={label || tokenScopeLabels[bit] || key}
+                              placeholder="Explain why your app needs this scope…"
+                              autosize
+                              minRows={2}
+                              maxRows={4}
+                              value={text}
+                              onChange={(e) =>
+                                handleJustificationChange(justificationKey, e.currentTarget.value)
+                              }
+                              maxLength={CONNECT_SUBMIT_LIMITS.justificationMax}
+                              disabled={busy}
+                              description={`${text.length}/${CONNECT_SUBMIT_LIMITS.justificationMax}`}
+                              data-testid={`apps-connect-justification-${bit}`}
+                            />
+                          );
+                        })}
+                      </Stack>
+                    )}
+                  </Stack>
+                )}
+              </>
+            )}
+
+            <Group justify="space-between">
+              <Button variant="default" component={Link} href="/apps/my-submissions" disabled={busy}>
+                Cancel
+              </Button>
+              <Button
+                onClick={handleAdvanceFromClient}
+                disabled={busy || !isConnectClientStepComplete(values, allowedScopes)}
+                data-testid="apps-connect-wizard-next-client"
+              >
+                Next
+              </Button>
+            </Group>
+          </Stack>
+        </Stepper.Step>
+
+        <Stepper.Step
+          label="Details"
+          description="Name & metadata"
+          allowStepClick={!submitted && isConnectClientStepComplete(values, allowedScopes)}
+          data-testid="apps-connect-wizard-step-details"
+        >
+          <Stack gap="md" mt="md">
+            <TextInput
+              label="Name"
+              placeholder="My Connected App"
+              value={values.name}
+              onChange={(e) => setField('name', e.currentTarget.value)}
+              onKeyDown={handleDetailsKeyDown}
+              error={errors.name}
+              maxLength={CONNECT_SUBMIT_LIMITS.nameMax}
+              required
+              disabled={busy}
+              data-autofocus
+              data-testid="apps-connect-submit-name"
+            />
+
+            <TextInput
+              label="Slug"
+              description={`Your app's URL slug (${CONNECT_SUBMIT_LIMITS.slugMin}–${CONNECT_SUBMIT_LIMITS.slugMax} chars, lowercase a–z / 0–9 / hyphens).`}
+              placeholder="my-connected-app"
+              value={values.slug}
+              onChange={(e) => setField('slug', e.currentTarget.value)}
+              onKeyDown={handleDetailsKeyDown}
+              error={errors.slug}
+              maxLength={CONNECT_SUBMIT_LIMITS.slugMax}
+              required
+              disabled={busy}
+              data-testid="apps-connect-submit-slug"
+            />
+
+            <TextInput
+              label="Tagline"
+              description="A short one-liner (optional)."
+              value={values.tagline}
+              onChange={(e) => setField('tagline', e.currentTarget.value)}
+              onKeyDown={handleDetailsKeyDown}
+              error={errors.tagline}
+              maxLength={CONNECT_SUBMIT_LIMITS.taglineMax}
+              disabled={busy}
+            />
+
+            <Textarea
+              label="Description"
+              description="What the app does (optional)."
+              autosize
+              minRows={3}
+              maxRows={8}
+              value={values.description}
+              onChange={(e) => setField('description', e.currentTarget.value)}
+              error={errors.description}
+              maxLength={CONNECT_SUBMIT_LIMITS.descriptionMax}
+              disabled={busy}
+            />
+
+            <Group grow align="flex-start">
+              <Select
+                label="Category"
+                placeholder="No category"
+                data={CONNECT_CATEGORY_OPTIONS}
+                value={values.category}
+                onChange={(v: string | null) =>
+                  setField('category', (v as MarketplaceCategory) || null)
+                }
+                error={errors.category}
+                clearable
+                disabled={busy}
+              />
+              <Select
+                label="Content rating"
+                data={CONNECT_CONTENT_RATING_OPTIONS}
+                value={values.contentRating}
+                onChange={(v: string | null) =>
+                  setField('contentRating', (v as OffsiteContentRating) || 'g')
+                }
+                error={errors.contentRating}
+                allowDeselect={false}
+                disabled={busy}
+              />
+            </Group>
+
+            <Textarea
+              label="What is this app? (optional)"
+              description="A note for the reviewer — recorded on the request."
+              autosize
+              minRows={2}
+              maxRows={6}
+              value={values.changelog}
+              onChange={(e) => setField('changelog', e.currentTarget.value)}
+              error={errors.changelog}
+              maxLength={CONNECT_SUBMIT_LIMITS.changelogMax}
+              disabled={busy}
+            />
+
+            <Group justify="space-between">
+              <Button
+                variant="default"
+                onClick={() => setActive(STEP_CLIENT)}
+                disabled={busy}
+                data-testid="apps-connect-wizard-back-details"
+              >
+                Back
+              </Button>
+              <Button
+                onClick={handleCreateDraft}
+                loading={busy}
+                disabled={!isConnectDetailsStepComplete(values, allowedScopes)}
+                leftSection={<IconPlugConnected size={16} />}
+                data-testid="apps-connect-submit-create"
+              >
+                Create draft
+              </Button>
+            </Group>
+          </Stack>
+        </Stepper.Step>
+
+        <Stepper.Step
+          label="Assets"
+          description="Icon, cover, screenshots"
+          allowStepClick={false}
+          data-testid="apps-connect-wizard-step-assets"
+        >
+          <div data-testid="apps-connect-wizard-assets-panel">
+            {submitted ? (
+              <ListingAssetStep
+                listingId={submitted.listingId}
+                contentRating={values.contentRating}
+                suggestions={{}}
+                header={
+                  <Alert
+                    color="green"
+                    variant="light"
+                    icon={<IconCheck size={16} />}
+                    title="Draft created"
+                  >
+                    <Text size="sm">
+                      <Code>{submitted.slug}</Code> is a pending connect submission. Attach an icon, a
+                      cover and at least one screenshot below — a moderator can only approve an
+                      asset-complete listing. Content rating:{' '}
+                      <Badge size="xs">{values.contentRating}</Badge>
+                    </Text>
+                  </Alert>
+                }
+                footer={
+                  <Group justify="flex-end">
+                    <Button
+                      component={Link}
+                      href="/apps/my-submissions"
+                      rightSection={<IconExternalLink size={16} />}
+                    >
+                      View my submissions
+                    </Button>
+                  </Group>
+                }
+              />
+            ) : (
+              <Alert color="gray" variant="light" mt="md">
+                <Text size="sm">Create the draft on the previous step to add assets.</Text>
+              </Alert>
+            )}
+          </div>
+        </Stepper.Step>
+      </Stepper>
+    </Stack>
+  );
+}

--- a/src/components/Apps/SubmitModeSelector.tsx
+++ b/src/components/Apps/SubmitModeSelector.tsx
@@ -1,5 +1,5 @@
 import { Card, SimpleGrid, Stack, Text, ThemeIcon, UnstyledButton } from '@mantine/core';
-import { IconExternalLink, IconTerminal2 } from '@tabler/icons-react';
+import { IconExternalLink, IconPlugConnected, IconTerminal2 } from '@tabler/icons-react';
 import type { ReactNode } from 'react';
 
 /**
@@ -15,11 +15,11 @@ import type { ReactNode } from 'react';
  * The internal mode id keeps the historical `block` value for the on-platform
  * app — only the label/copy is "App"; the code id is never renamed.
  */
-export type SubmitMode = 'block' | 'external';
+export type SubmitMode = 'block' | 'external' | 'connect';
 
 export function SubmitModeSelector({ onSelect }: { onSelect: (mode: SubmitMode) => void }) {
   return (
-    <SimpleGrid cols={{ base: 1, xs: 2 }} spacing="md" data-testid="apps-submit-mode-selector">
+    <SimpleGrid cols={{ base: 1, xs: 3 }} spacing="md" data-testid="apps-submit-mode-selector">
       <ModeCard
         icon={<IconTerminal2 size={22} />}
         title="App"
@@ -33,6 +33,13 @@ export function SubmitModeSelector({ onSelect }: { onSelect: (mode: SubmitMode) 
         description="A marketplace card for an app hosted off-site. Users get a Visit ↗ button that opens your https link in a new tab — no bundle, no install."
         onSelect={() => onSelect('external')}
         testId="apps-submit-mode-card-external"
+      />
+      <ModeCard
+        icon={<IconPlugConnected size={22} />}
+        title="Connect an app"
+        description="Link your registered OAuth app so users can grant it access. Disclose the scopes your app requests and why — a moderator reviews before it appears."
+        onSelect={() => onSelect('connect')}
+        testId="apps-submit-mode-card-connect"
       />
     </SimpleGrid>
   );

--- a/src/components/Apps/__tests__/connectSubmitFormConfig.test.ts
+++ b/src/components/Apps/__tests__/connectSubmitFormConfig.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  emptyConnectSubmitForm,
+  isConnectClientStepComplete,
+  isConnectDetailsStepComplete,
+  toSubmitConnectInput,
+  toggleScopeBit,
+  validateConnectSubmitForm,
+  type ConnectSubmitFormValues,
+} from '~/components/Apps/connectSubmitFormConfig';
+import { SCOPE_JUSTIFICATION_MAX_LENGTH, TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * W13 OAuth-connect submit form CONFIG (client-side mirror) tests (PR2). Pure
+ * view-model — no DOM. Covers the scope toggle + prune, the subset gating, and the
+ * payload shaping (omit empty / non-requested justifications).
+ */
+
+const CEILING = TokenScope.UserRead | TokenScope.ModelsRead | TokenScope.ModelsWrite; // 13
+
+function full(overrides: Partial<ConnectSubmitFormValues> = {}): ConnectSubmitFormValues {
+  return {
+    ...emptyConnectSubmitForm(),
+    connectClientId: 'oauth-client-1',
+    slug: 'connect-app',
+    name: 'Connect App',
+    ...overrides,
+  };
+}
+
+describe('toggleScopeBit', () => {
+  it('sets and clears a bit', () => {
+    const on = toggleScopeBit(emptyConnectSubmitForm(), TokenScope.ModelsRead);
+    expect(on.requestedScopes).toBe(TokenScope.ModelsRead);
+    const off = toggleScopeBit(on, TokenScope.ModelsRead);
+    expect(off.requestedScopes).toBe(0);
+  });
+
+  it('prunes a justification when its scope is unchecked', () => {
+    let v = toggleScopeBit(emptyConnectSubmitForm(), TokenScope.ModelsRead);
+    v = { ...v, scopeJustifications: { ModelsRead: 'reason' } };
+    const cleared = toggleScopeBit(v, TokenScope.ModelsRead);
+    expect(cleared.requestedScopes).toBe(0);
+    expect(cleared.scopeJustifications).toEqual({});
+  });
+});
+
+describe('validateConnectSubmitForm', () => {
+  it('valid form has no errors', () => {
+    const v = full({ requestedScopes: TokenScope.ModelsRead });
+    expect(validateConnectSubmitForm(v, CEILING)).toEqual({});
+  });
+
+  it('flags a missing client', () => {
+    const v = full({ connectClientId: null });
+    expect(validateConnectSubmitForm(v, 0).connectClientId).toBeTruthy();
+  });
+
+  it('flags a requested scope outside the ceiling', () => {
+    const v = full({ requestedScopes: TokenScope.MediaWrite });
+    expect(validateConnectSubmitForm(v, CEILING).requestedScopes).toBeTruthy();
+  });
+
+  it('flags an over-long justification', () => {
+    const v = full({
+      requestedScopes: TokenScope.ModelsRead,
+      scopeJustifications: { ModelsRead: 'x'.repeat(SCOPE_JUSTIFICATION_MAX_LENGTH + 1) },
+    });
+    expect(validateConnectSubmitForm(v, CEILING).scopeJustifications).toBeTruthy();
+  });
+
+  it('flags a bad slug', () => {
+    const v = full({ slug: 'AB', requestedScopes: TokenScope.ModelsRead });
+    expect(validateConnectSubmitForm(v, CEILING).slug).toBeTruthy();
+  });
+});
+
+describe('step gates', () => {
+  it('client step complete needs a client + a valid subset', () => {
+    expect(isConnectClientStepComplete(full({ requestedScopes: TokenScope.ModelsRead }), CEILING)).toBe(
+      true
+    );
+    expect(isConnectClientStepComplete(full({ connectClientId: null }), 0)).toBe(false);
+    expect(
+      isConnectClientStepComplete(full({ requestedScopes: TokenScope.MediaWrite }), CEILING)
+    ).toBe(false);
+  });
+
+  it('details step complete needs the whole mirror valid', () => {
+    expect(
+      isConnectDetailsStepComplete(full({ requestedScopes: TokenScope.ModelsRead }), CEILING)
+    ).toBe(true);
+    expect(isConnectDetailsStepComplete(full({ name: '' }), CEILING)).toBe(false);
+  });
+});
+
+describe('toSubmitConnectInput', () => {
+  it('trims text + omits empty optionals', () => {
+    const v = full({
+      slug: ' connect-app ',
+      name: ' Connect App ',
+      requestedScopes: TokenScope.ModelsRead,
+      scopeJustifications: { ModelsRead: '  reason  ' },
+    });
+    const input = toSubmitConnectInput(v);
+    expect(input.slug).toBe('connect-app');
+    expect(input.name).toBe('Connect App');
+    expect(input.tagline).toBeUndefined();
+    expect(input.scopeJustifications).toEqual({ ModelsRead: 'reason' });
+  });
+
+  it('drops empty + non-requested justifications', () => {
+    const v = full({
+      requestedScopes: TokenScope.ModelsRead,
+      scopeJustifications: {
+        ModelsRead: '   ', // empty after trim → dropped
+        ModelsWrite: 'not requested', // scope not in mask → dropped
+      },
+    });
+    expect(toSubmitConnectInput(v).scopeJustifications).toEqual({});
+  });
+
+  it('keeps only requested + non-empty justifications', () => {
+    const v = full({
+      requestedScopes: TokenScope.ModelsRead | TokenScope.UserRead,
+      scopeJustifications: { ModelsRead: 'a', UserRead: '', ModelsWrite: 'x' },
+    });
+    expect(toSubmitConnectInput(v).scopeJustifications).toEqual({ ModelsRead: 'a' });
+  });
+});

--- a/src/components/Apps/connectSubmitFormConfig.ts
+++ b/src/components/Apps/connectSubmitFormConfig.ts
@@ -1,0 +1,241 @@
+import {
+  OFFSITE_CHANGELOG_MAX,
+  OFFSITE_CONTENT_RATINGS,
+  OFFSITE_DESCRIPTION_MAX,
+  OFFSITE_NAME_MAX,
+  OFFSITE_TAGLINE_MAX,
+  type OffsiteContentRating,
+} from '~/server/schema/blocks/offsite-listing.schema';
+import { SLUG_REGEX } from '~/server/schema/blocks/publish-request.schema';
+import {
+  MARKETPLACE_CATEGORIES,
+  isMarketplaceCategory,
+  type MarketplaceCategory,
+} from '~/server/services/blocks/marketplace-categories.constants';
+import {
+  SCOPE_JUSTIFICATION_MAX_LENGTH,
+  connectScopesSubsetOfCeiling,
+  tokenScopeKeyByBit,
+  tokenScopeMaskToList,
+} from '~/shared/constants/token-scope.constants';
+import { OFFSITE_SLUG_MAX, OFFSITE_SLUG_MIN } from '~/components/Apps/offsiteSubmitFormConfig';
+import { Flags } from '~/shared/utils/flags';
+
+/**
+ * App Store Listings (W13) — OAuth-CONNECT submit form field/validation config
+ * (PURE view-model). CLIENT-SIDE mirror of `submitConnectListingSchema` +
+ * `connectScopesSubsetOfCeiling` / `validateConnectScopeJustifications` so the
+ * `/apps/submit` "Connect an app" form surfaces inline errors BEFORE the round-trip.
+ * The SERVER stays the source of truth — the same `SLUG_REGEX`, `OFFSITE_*` bounds,
+ * category taxonomy and scope helpers are imported here (NOT re-declared) so this
+ * mirror can't drift from the contract.
+ *
+ * Extracted (no JSX) so the field bounds, the scope-subset gating and the payload
+ * shaping are unit-testable without mounting the form.
+ */
+
+export const CONNECT_SUBMIT_LIMITS = {
+  slugMin: OFFSITE_SLUG_MIN,
+  slugMax: OFFSITE_SLUG_MAX,
+  nameMax: OFFSITE_NAME_MAX,
+  taglineMax: OFFSITE_TAGLINE_MAX,
+  descriptionMax: OFFSITE_DESCRIPTION_MAX,
+  changelogMax: OFFSITE_CHANGELOG_MAX,
+  justificationMax: SCOPE_JUSTIFICATION_MAX_LENGTH,
+} as const;
+
+export type ConnectSubmitFormValues = {
+  /** The id of the caller's own OAuth client (chosen in the picker). */
+  connectClientId: string | null;
+  /** The disclosed requested-scope bitmask (⊆ the selected client's allowedScopes). */
+  requestedScopes: number;
+  /** enum-key → rationale (only checked scopes get an entry). */
+  scopeJustifications: Record<string, string>;
+  slug: string;
+  name: string;
+  tagline: string;
+  description: string;
+  category: MarketplaceCategory | null;
+  contentRating: OffsiteContentRating;
+  changelog: string;
+};
+
+export type ConnectSubmitFormErrors = Partial<
+  Record<keyof ConnectSubmitFormValues, string>
+>;
+
+/** Category `<Select>` data (value + human label). */
+export const CONNECT_CATEGORY_OPTIONS: Array<{ value: MarketplaceCategory; label: string }> =
+  MARKETPLACE_CATEGORIES.map((c) => ({
+    value: c,
+    label: c.charAt(0).toUpperCase() + c.slice(1),
+  }));
+
+/** Content-rating `<Select>` data. */
+export const CONNECT_CONTENT_RATING_OPTIONS: Array<{
+  value: OffsiteContentRating;
+  label: string;
+}> = OFFSITE_CONTENT_RATINGS.map((r) => ({ value: r, label: r.toUpperCase() }));
+
+/** Blank initial state — NO client, NO scopes checked (explicit opt-in from empty). */
+export function emptyConnectSubmitForm(): ConnectSubmitFormValues {
+  return {
+    connectClientId: null,
+    requestedScopes: 0,
+    scopeJustifications: {},
+    slug: '',
+    name: '',
+    tagline: '',
+    description: '',
+    category: null,
+    contentRating: 'g',
+    changelog: '',
+  };
+}
+
+/**
+ * Toggle a single scope bit in `requestedScopes`, pruning any justification whose
+ * scope is no longer requested (so the payload never carries a dangling rationale
+ * the server would reject). PURE.
+ */
+export function toggleScopeBit(
+  values: ConnectSubmitFormValues,
+  bit: number
+): ConnectSubmitFormValues {
+  const requestedScopes = Flags.hasFlag(values.requestedScopes, bit)
+    ? values.requestedScopes & ~bit
+    : values.requestedScopes | bit;
+  // Prune justifications for scopes no longer requested.
+  const requestedKeys = new Set(tokenScopeMaskToList(requestedScopes).map((s) => s.key));
+  const scopeJustifications: Record<string, string> = {};
+  for (const [key, text] of Object.entries(values.scopeJustifications)) {
+    if (requestedKeys.has(key)) scopeJustifications[key] = text;
+  }
+  return { ...values, requestedScopes, scopeJustifications };
+}
+
+/**
+ * Validate the form client-side, mirroring `submitConnectListingSchema` +
+ * `connectScopesSubsetOfCeiling`. `allowedScopes` is the selected client's ceiling
+ * (0 when no client picked). Returns a per-field error map (empty = valid).
+ */
+export function validateConnectSubmitForm(
+  values: ConnectSubmitFormValues,
+  allowedScopes: number
+): ConnectSubmitFormErrors {
+  const errors: ConnectSubmitFormErrors = {};
+
+  if (!values.connectClientId) {
+    errors.connectClientId = 'Choose one of your OAuth apps.';
+  }
+
+  if (!connectScopesSubsetOfCeiling(values.requestedScopes, allowedScopes)) {
+    errors.requestedScopes = 'A requested scope is not allowed by this OAuth app.';
+  }
+
+  for (const [, text] of Object.entries(values.scopeJustifications)) {
+    if (text.length > SCOPE_JUSTIFICATION_MAX_LENGTH) {
+      errors.scopeJustifications = `Each justification must be at most ${SCOPE_JUSTIFICATION_MAX_LENGTH} characters.`;
+      break;
+    }
+  }
+
+  const slug = values.slug.trim();
+  if (slug.length < OFFSITE_SLUG_MIN || slug.length > OFFSITE_SLUG_MAX) {
+    errors.slug = `Slug must be ${OFFSITE_SLUG_MIN}–${OFFSITE_SLUG_MAX} characters.`;
+  } else if (!SLUG_REGEX.test(slug)) {
+    errors.slug = 'Slug must be lowercase a–z / 0–9 / hyphens and start with a letter.';
+  }
+
+  const name = values.name.trim();
+  if (name.length < 1) {
+    errors.name = 'Name is required.';
+  } else if (name.length > OFFSITE_NAME_MAX) {
+    errors.name = `Name must be at most ${OFFSITE_NAME_MAX} characters.`;
+  }
+
+  if (values.tagline.length > OFFSITE_TAGLINE_MAX) {
+    errors.tagline = `Tagline must be at most ${OFFSITE_TAGLINE_MAX} characters.`;
+  }
+  if (values.description.length > OFFSITE_DESCRIPTION_MAX) {
+    errors.description = `Description must be at most ${OFFSITE_DESCRIPTION_MAX} characters.`;
+  }
+  if (values.changelog.length > OFFSITE_CHANGELOG_MAX) {
+    errors.changelog = `Changelog must be at most ${OFFSITE_CHANGELOG_MAX} characters.`;
+  }
+
+  if (values.category != null && !isMarketplaceCategory(values.category)) {
+    errors.category = 'Unknown category.';
+  }
+  if (!(OFFSITE_CONTENT_RATINGS as readonly string[]).includes(values.contentRating)) {
+    errors.contentRating = 'Unknown content rating.';
+  }
+
+  return errors;
+}
+
+/** The Step-0 (client + scopes) gate: a client is chosen and the subset is valid. */
+export function isConnectClientStepComplete(
+  values: ConnectSubmitFormValues,
+  allowedScopes: number
+): boolean {
+  return (
+    !!values.connectClientId &&
+    connectScopesSubsetOfCeiling(values.requestedScopes, allowedScopes) &&
+    Object.values(values.scopeJustifications).every(
+      (t) => t.length <= SCOPE_JUSTIFICATION_MAX_LENGTH
+    )
+  );
+}
+
+/** The Details-step gate: the whole client mirror validates. */
+export function isConnectDetailsStepComplete(
+  values: ConnectSubmitFormValues,
+  allowedScopes: number
+): boolean {
+  return Object.keys(validateConnectSubmitForm(values, allowedScopes)).length === 0;
+}
+
+/**
+ * Shape the form state into the `submitConnectListing` mutation input: trim the text
+ * fields, coerce empty optionals to `undefined`, and reduce `scopeJustifications` to
+ * ONLY the requested scopes with a non-empty (trimmed) rationale — so an unfilled
+ * textarea is omitted (the server accepts an empty map) and no dangling key is sent.
+ * PURE + unit-tested. `connectClientId` MUST be set (gated by the client step).
+ */
+export function toSubmitConnectInput(values: ConnectSubmitFormValues): {
+  slug: string;
+  name: string;
+  connectClientId: string;
+  requestedScopes: number;
+  scopeJustifications: Record<string, string>;
+  tagline?: string;
+  description?: string;
+  category?: MarketplaceCategory;
+  contentRating: OffsiteContentRating;
+  changelog?: string;
+} {
+  const requestedKeys = new Set(tokenScopeMaskToList(values.requestedScopes).map((s) => s.key));
+  const scopeJustifications: Record<string, string> = {};
+  for (const [key, text] of Object.entries(values.scopeJustifications)) {
+    const trimmed = text.trim();
+    if (trimmed.length > 0 && requestedKeys.has(key)) scopeJustifications[key] = trimmed;
+  }
+  return {
+    slug: values.slug.trim(),
+    name: values.name.trim(),
+    connectClientId: values.connectClientId ?? '',
+    requestedScopes: values.requestedScopes,
+    scopeJustifications,
+    tagline: values.tagline.trim() || undefined,
+    description: values.description.trim() || undefined,
+    category: values.category ?? undefined,
+    contentRating: values.contentRating,
+    changelog: values.changelog.trim() || undefined,
+  };
+}
+
+/** The enum-key for a scope bit (re-export for the form's justification map keys). */
+export function scopeKeyForBit(bit: number): string {
+  return tokenScopeKeyByBit(bit) ?? String(bit);
+}

--- a/src/pages/apps/submit.tsx
+++ b/src/pages/apps/submit.tsx
@@ -6,6 +6,7 @@ import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { AppsSubmitEditView } from '~/components/Apps/AppsSubmitEditView';
 import { CliSubmitCta } from '~/components/Apps/CliSubmitCta';
+import { ConnectSubmitForm } from '~/components/Apps/ConnectSubmitForm';
 import { ExternalSubmitForm } from '~/components/Apps/ExternalSubmitForm';
 import {
   SubmitModeSelector,
@@ -83,7 +84,15 @@ export default function SubmitAppPage() {
               every submission before it appears.
             </>
           ) : (
-            <>Submitting {mode === 'external' ? 'an External link' : 'an App'}.</>
+            <>
+              Submitting{' '}
+              {mode === 'external'
+                ? 'an External link'
+                : mode === 'connect'
+                ? 'a Connect app'
+                : 'an App'}
+              .
+            </>
           )
         }
       >
@@ -104,7 +113,13 @@ export default function SubmitAppPage() {
               </Group>
             </UnstyledButton>
 
-            {mode === 'external' ? <ExternalSubmitForm /> : <CliSubmitCta />}
+            {mode === 'external' ? (
+              <ExternalSubmitForm />
+            ) : mode === 'connect' ? (
+              <ConnectSubmitForm />
+            ) : (
+              <CliSubmitCta />
+            )}
           </Stack>
         )}
       </AppsPageLayout>

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -28,6 +28,7 @@ import {
   listOffsiteRequestsSchema,
   persistListingAssetImageSchema,
   rejectExternalRequestSchema,
+  submitConnectListingSchema,
   submitExternalListingSchema,
   submitListingRevisionSchema,
   updateListingSchema,
@@ -320,6 +321,32 @@ export const appListingsRouter = router({
         '~/server/services/blocks/offsite-listing.service'
       );
       return submitExternalListing({ input, userId: ctx.user.id });
+    }),
+
+  /**
+   * AUTHOR: submit an OAuth-CONNECT off-site app — link a registered OAuth client
+   * the caller OWNS (and that is NOT an App-Block client) so users can grant it
+   * access. Creates a DRAFT `AppListing(connectClientId set)` + a `pending` request
+   * (B1), carrying the DISCLOSED requested-scope subset (⊆ the client's
+   * `allowedScopes`) + per-scope justifications (review-only — does NOT gate token
+   * issuance). Owner-bound to the caller; the same `appDeveloperProcedure` author
+   * gate + submit-rate limit as the external path keeps it DARK until launch.
+   */
+  submitConnectListing: appDeveloperProcedure
+    .use(
+      rateLimit({
+        limit: 10,
+        period: 3600,
+        errorMessage: 'Too many submissions — slow down.',
+      })
+    )
+    .input(submitConnectListingSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { submitConnectListing } = await import(
+        '~/server/services/blocks/offsite-listing.service'
+      );
+      return submitConnectListing({ input, userId: ctx.user.id });
     }),
 
   /**

--- a/src/server/schema/blocks/__tests__/offsite-listing.connect.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/offsite-listing.connect.schema.test.ts
@@ -4,7 +4,11 @@ import {
   submitConnectListingSchema,
   updateListingPatchSchema,
 } from '~/server/schema/blocks/offsite-listing.schema';
-import { SCOPE_JUSTIFICATION_MAX_LENGTH } from '~/shared/constants/token-scope.constants';
+import {
+  ALL_SCOPES,
+  SCOPE_JUSTIFICATION_MAX_LENGTH,
+  TokenScope,
+} from '~/shared/constants/token-scope.constants';
 
 /**
  * W13 OAuth-connect submit + patch schema tests (PR2). The schema bounds the SHAPE
@@ -55,6 +59,41 @@ describe('submitConnectListingSchema', () => {
     );
   });
 
+  // int4-overflow hardening: a value beyond the full defined scope set must be
+  // rejected at the schema boundary (400), NOT survive the JS-ToInt32 subset check
+  // and 500 on the int4 INSERT. These FAIL without the `.max(ALL_SCOPES)` bound.
+  it.each([
+    ['2**32', 2 ** 32],
+    ['2**32 + a real bit', 2 ** 32 + TokenScope.ModelsRead],
+  ])('rejects an over-int4 requestedScopes (%s)', (_label, requestedScopes) => {
+    expect(
+      submitConnectListingSchema.safeParse({ ...valid, requestedScopes, scopeJustifications: {} })
+        .success
+    ).toBe(false);
+  });
+
+  it('accepts requestedScopes at exactly ALL_SCOPES (the max bound)', () => {
+    expect(
+      submitConnectListingSchema.safeParse({
+        ...valid,
+        requestedScopes: ALL_SCOPES,
+        scopeJustifications: {},
+      }).success
+    ).toBe(true);
+  });
+
+  it('accepts an app-block bit within ALL_SCOPES (Full would have been too strict)', () => {
+    // AppBlocksSubmit (bit 25) is EXCLUDED from TokenScope.Full but included in
+    // ALL_SCOPES — a client whose allowedScopes carries it can request it.
+    expect(
+      submitConnectListingSchema.safeParse({
+        ...valid,
+        requestedScopes: TokenScope.AppBlocksSubmit,
+        scopeJustifications: {},
+      }).success
+    ).toBe(true);
+  });
+
   it('rejects a justification value over the max length', () => {
     const parsed = submitConnectListingSchema.safeParse({
       ...valid,
@@ -88,5 +127,18 @@ describe('updateListingPatchSchema (connect fields)', () => {
         scopeJustifications: { ModelsRead: 'x'.repeat(SCOPE_JUSTIFICATION_MAX_LENGTH + 1) },
       }).success
     ).toBe(false);
+  });
+
+  it('rejects an over-int4 requestedScopes in a patch', () => {
+    expect(
+      updateListingPatchSchema.safeParse({ requestedScopes: 2 ** 32, scopeJustifications: {} })
+        .success
+    ).toBe(false);
+  });
+
+  it('accepts requestedScopes at ALL_SCOPES in a patch', () => {
+    expect(
+      updateListingPatchSchema.safeParse({ requestedScopes: ALL_SCOPES }).success
+    ).toBe(true);
   });
 });

--- a/src/server/schema/blocks/__tests__/offsite-listing.connect.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/offsite-listing.connect.schema.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  submitConnectListingSchema,
+  updateListingPatchSchema,
+} from '~/server/schema/blocks/offsite-listing.schema';
+import { SCOPE_JUSTIFICATION_MAX_LENGTH } from '~/shared/constants/token-scope.constants';
+
+/**
+ * W13 OAuth-connect submit + patch schema tests (PR2). The schema bounds the SHAPE
+ * (types + per-value lengths); the subset-of-ceiling + key/justification rules live
+ * in the service (they need the client's `allowedScopes`).
+ */
+
+const valid = {
+  slug: 'connect-app',
+  name: 'Connect App',
+  connectClientId: 'oauth-client-1',
+  requestedScopes: 4,
+  scopeJustifications: { ModelsRead: 'reason' },
+  contentRating: 'g' as const,
+};
+
+describe('submitConnectListingSchema', () => {
+  it('accepts a well-formed connect submission', () => {
+    const parsed = submitConnectListingSchema.parse(valid);
+    expect(parsed.connectClientId).toBe('oauth-client-1');
+    expect(parsed.requestedScopes).toBe(4);
+    expect(parsed.scopeJustifications).toEqual({ ModelsRead: 'reason' });
+  });
+
+  it('defaults contentRating to g when omitted', () => {
+    const { contentRating, ...rest } = valid;
+    expect(submitConnectListingSchema.parse(rest).contentRating).toBe('g');
+  });
+
+  it('accepts an empty justification map', () => {
+    expect(submitConnectListingSchema.parse({ ...valid, scopeJustifications: {} })).toBeTruthy();
+  });
+
+  it('rejects a missing connectClientId', () => {
+    const { connectClientId, ...rest } = valid;
+    expect(submitConnectListingSchema.safeParse(rest).success).toBe(false);
+  });
+
+  it('rejects a negative requestedScopes', () => {
+    expect(submitConnectListingSchema.safeParse({ ...valid, requestedScopes: -1 }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects a non-integer requestedScopes', () => {
+    expect(submitConnectListingSchema.safeParse({ ...valid, requestedScopes: 1.5 }).success).toBe(
+      false
+    );
+  });
+
+  it('rejects a justification value over the max length', () => {
+    const parsed = submitConnectListingSchema.safeParse({
+      ...valid,
+      scopeJustifications: { ModelsRead: 'x'.repeat(SCOPE_JUSTIFICATION_MAX_LENGTH + 1) },
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('accepts a justification value at exactly the max length', () => {
+    const parsed = submitConnectListingSchema.safeParse({
+      ...valid,
+      scopeJustifications: { ModelsRead: 'x'.repeat(SCOPE_JUSTIFICATION_MAX_LENGTH) },
+    });
+    expect(parsed.success).toBe(true);
+  });
+});
+
+describe('updateListingPatchSchema (connect fields)', () => {
+  it('accepts a scope-only patch', () => {
+    const parsed = updateListingPatchSchema.parse({
+      requestedScopes: 4,
+      scopeJustifications: { ModelsRead: 'reason' },
+    });
+    expect(parsed.requestedScopes).toBe(4);
+  });
+
+  it('rejects an over-long justification in a patch', () => {
+    expect(
+      updateListingPatchSchema.safeParse({
+        requestedScopes: 4,
+        scopeJustifications: { ModelsRead: 'x'.repeat(SCOPE_JUSTIFICATION_MAX_LENGTH + 1) },
+      }).success
+    ).toBe(false);
+  });
+});

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -11,7 +11,10 @@ import {
   OFFSITE_MOD_REASON_MIN,
 } from '~/server/schema/blocks/offsite-moderation.schema';
 import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
-import { SCOPE_JUSTIFICATION_MAX_LENGTH } from '~/shared/constants/token-scope.constants';
+import {
+  ALL_SCOPES,
+  SCOPE_JUSTIFICATION_MAX_LENGTH,
+} from '~/shared/constants/token-scope.constants';
 
 /**
  * App Store Listings (W13) — P3a OFF-SITE (external-link) submission schemas.
@@ -132,9 +135,17 @@ export const submitConnectListingSchema = z.object({
   slug: z.string().min(3).max(40).regex(SLUG_REGEX),
   name: z.string().min(1).max(OFFSITE_NAME_MAX),
   connectClientId: z.string().min(1).max(64),
-  // Non-negative bitmask; the subset-of-ceiling check lives in the service (needs
-  // the client's `allowedScopes`).
-  requestedScopes: z.number().int().nonnegative(),
+  // Non-negative bitmask, UPPER-BOUNDED at the full defined scope set (`ALL_SCOPES`,
+  // the OR of every TokenScope bit). Without the max, a crafted value beyond int4
+  // (e.g. 2**32, or 2**32 + a real bit) survives the subset check — JS bitwise ToInt32
+  // in `connectScopesSubsetOfCeiling` truncates it away — then the int4 INSERT raises
+  // Postgres 22003, which the service's P2002-only catch surfaces as a raw 500. The
+  // `.max` rejects it at the schema boundary (400) instead. `ALL_SCOPES` (not
+  // `TokenScope.Full`) is the correct ceiling: Full excludes the AppBlocksSubmit /
+  // AppBlocksDevTunnel bits, which a client's `allowedScopes` MAY legitimately carry,
+  // so bounding at Full could reject a valid subset. The per-client subset check still
+  // lives in the service (it needs the client's `allowedScopes`).
+  requestedScopes: z.number().int().nonnegative().max(ALL_SCOPES),
   // Per-value length bound only; full key/subset validation is in the service.
   scopeJustifications: z.record(z.string(), z.string().max(SCOPE_JUSTIFICATION_MAX_LENGTH)),
   tagline: z.string().max(OFFSITE_TAGLINE_MAX).optional(),
@@ -179,7 +190,9 @@ export const updateListingPatchSchema = z
     // as a pair: the SERVICE re-runs the subset-of-ceiling + justification checks
     // (needs the listing's client `allowedScopes`) and rejects justifications
     // without a `requestedScopes` mask, so a scope change re-enters mod review.
-    requestedScopes: z.number().int().nonnegative().optional(),
+    // Upper-bounded at `ALL_SCOPES` for the same int4-overflow reason as the submit
+    // schema (a value beyond int4 would 500 on the UPDATE, not 400 at the boundary).
+    requestedScopes: z.number().int().nonnegative().max(ALL_SCOPES).optional(),
     scopeJustifications: z
       .record(z.string(), z.string().max(SCOPE_JUSTIFICATION_MAX_LENGTH))
       .optional(),

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -11,6 +11,7 @@ import {
   OFFSITE_MOD_REASON_MIN,
 } from '~/server/schema/blocks/offsite-moderation.schema';
 import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
+import { SCOPE_JUSTIFICATION_MAX_LENGTH } from '~/shared/constants/token-scope.constants';
 
 /**
  * App Store Listings (W13) — P3a OFF-SITE (external-link) submission schemas.
@@ -109,6 +110,42 @@ export const submitExternalListingSchema = z
 
 export type SubmitExternalListingInput = z.infer<typeof submitExternalListingSchema>;
 
+/**
+ * Author submit input for an OAuth-CONNECT off-site listing (W13 — the un-deferred
+ * connect sub-kind). Mirrors {@link submitExternalListingSchema}'s display metadata
+ * (name/tagline/description/category/contentRating/changelog bounds) but DROPS
+ * `externalUrl` (a connect listing links to a registered OAuth client, not a URL)
+ * and adds:
+ *   - `connectClientId`  — the id of the caller's OWN OAuth client (ownership,
+ *     not-app-block, and the scope-ceiling checks are enforced in the SERVICE, which
+ *     has the client row; the schema only bounds the shape).
+ *   - `requestedScopes`  — a `TokenScope` bitmask the listing DISCLOSES it will
+ *     request (review-only; it does NOT gate token issuance — the client's
+ *     `allowedScopes` stays the runtime ceiling). The service asserts it is a subset
+ *     of the client's ceiling.
+ *   - `scopeJustifications` — `{ TokenScope-enum-key: rationale ≤SCOPE_JUSTIFICATION_MAX_LENGTH }`.
+ *     Per-value length is bounded here; the key-validity / keys-⊆-requested / non-empty
+ *     rules are enforced by the shared `validateConnectScopeJustifications` in the
+ *     service (single source with the App Blocks manifest validator).
+ */
+export const submitConnectListingSchema = z.object({
+  slug: z.string().min(3).max(40).regex(SLUG_REGEX),
+  name: z.string().min(1).max(OFFSITE_NAME_MAX),
+  connectClientId: z.string().min(1).max(64),
+  // Non-negative bitmask; the subset-of-ceiling check lives in the service (needs
+  // the client's `allowedScopes`).
+  requestedScopes: z.number().int().nonnegative(),
+  // Per-value length bound only; full key/subset validation is in the service.
+  scopeJustifications: z.record(z.string(), z.string().max(SCOPE_JUSTIFICATION_MAX_LENGTH)),
+  tagline: z.string().max(OFFSITE_TAGLINE_MAX).optional(),
+  description: z.string().max(OFFSITE_DESCRIPTION_MAX).optional(),
+  category: z.enum(MARKETPLACE_CATEGORIES).optional(),
+  contentRating: z.enum(OFFSITE_CONTENT_RATINGS).default('g'),
+  changelog: z.string().max(OFFSITE_CHANGELOG_MAX).optional(),
+});
+
+export type SubmitConnectListingInput = z.infer<typeof submitConnectListingSchema>;
+
 /** Withdraw one of the caller's own pending off-site requests (IDOR-checked in the service). */
 export const withdrawExternalRequestSchema = z.object({
   publishRequestId: z.string().min(1).max(64),
@@ -138,6 +175,14 @@ export const updateListingPatchSchema = z
     description: z.string().max(OFFSITE_DESCRIPTION_MAX).nullable().optional(),
     category: z.enum(MARKETPLACE_CATEGORIES).nullable().optional(),
     contentRating: z.enum(OFFSITE_CONTENT_RATINGS).optional(),
+    // OAuth-connect scope disclosure edit (connect sub-kind only). The two travel
+    // as a pair: the SERVICE re-runs the subset-of-ceiling + justification checks
+    // (needs the listing's client `allowedScopes`) and rejects justifications
+    // without a `requestedScopes` mask, so a scope change re-enters mod review.
+    requestedScopes: z.number().int().nonnegative().optional(),
+    scopeJustifications: z
+      .record(z.string(), z.string().max(SCOPE_JUSTIFICATION_MAX_LENGTH))
+      .optional(),
   })
   .refine((p) => Object.values(p).some((v) => v !== undefined), {
     message: 'patch must change at least one field',

--- a/src/server/services/blocks/__tests__/offsite-listing.connect.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.connect.service.test.ts
@@ -314,6 +314,21 @@ describe('updateListing (connect scope edit re-validation)', () => {
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
+  it('re-asserts client OWNERSHIP on edit: a client transferred to another user → FORBIDDEN, no shadow write', async () => {
+    // The listing is owned by CALLER, but the OAuth client now belongs to OTHER
+    // (transferred after submit). A scope edit must be refused before any shadow.
+    mockRead.appListing.findUnique.mockResolvedValue(approvedConnectListing);
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
+    await expect(
+      updateListing({
+        listingId: 'apl_live',
+        userId: CALLER,
+        patch: { requestedScopes: TokenScope.ModelsRead, scopeJustifications: {} },
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
   it('a valid scope change on an approved listing is MATERIAL → stages a shadow (requiresReview)', async () => {
     // loadOwnedEditableListing reads the live parent; beginListingRevision then
     // reads it again (approved, no existing shadow) and creates the shadow.

--- a/src/server/services/blocks/__tests__/offsite-listing.connect.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.connect.service.test.ts
@@ -1,0 +1,336 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildListingPatchData,
+  submitConnectListing,
+  updateListing,
+} from '~/server/services/blocks/offsite-listing.service';
+import type { SubmitConnectListingInput } from '~/server/schema/blocks/offsite-listing.schema';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * App Store Listings (W13) — OAuth-CONNECT submission SERVICE tests (PR2).
+ *
+ * Covers `submitConnectListing` (DRAFT AppListing + pending request in one tx with
+ * the connect fields; owner-binding; app-block-client exclude; scope subset +
+ * justification validation; slug/cap reuse) plus the edit path re-validation
+ * (`buildListingPatchData` + `updateListing`). DB deps are mocked — no real Prisma.
+ */
+
+const { mockRead, mockWrite, ids } = vi.hoisted(() => {
+  const makeClient = () => ({
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+      update: vi.fn(async (args: { data: unknown }) => args.data),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+    appBlock: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+    appListingScreenshot: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+    },
+    appListingPublishRequest: {
+      count: vi.fn(async (..._a: unknown[]) => 0),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+    },
+    oauthClient: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+  });
+  const mockRead = makeClient();
+  const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
+    $transaction: ReturnType<typeof vi.fn>;
+  };
+  mockWrite.$transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  return { mockRead, mockWrite, ids: { n: 0 } };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingId: () => `apl_test_${++ids.n}`,
+  newAppListingPublishRequestId: () => `alpr_test_${++ids.n}`,
+  newAppListingModerationEventId: () => `alme_test_${++ids.n}`,
+  newAppListingScreenshotId: () => `als_test_${++ids.n}`,
+  newUlid: () => `ulid_${++ids.n}`,
+}));
+
+const CALLER = 42;
+const OTHER = 99;
+const CLIENT_ID = 'oauth-client-1';
+// Ceiling: UserRead(1) | ModelsRead(4) | ModelsWrite(8) = 13.
+const CEILING = TokenScope.UserRead | TokenScope.ModelsRead | TokenScope.ModelsWrite;
+
+const baseInput: SubmitConnectListingInput = {
+  slug: 'connect-app',
+  name: 'Connect App',
+  connectClientId: CLIENT_ID,
+  requestedScopes: TokenScope.ModelsRead, // 4, ⊆ ceiling
+  scopeJustifications: { ModelsRead: 'We download models to run them.' },
+  contentRating: 'g',
+};
+
+function ownedClient(overrides: Partial<{ id: string; userId: number; allowedScopes: number }> = {}) {
+  return { id: CLIENT_ID, userId: CALLER, allowedScopes: CEILING, ...overrides };
+}
+
+beforeEach(() => {
+  ids.n = 0;
+  for (const c of [mockRead, mockWrite]) {
+    c.appListing.findUnique.mockReset().mockResolvedValue(null);
+    c.appListing.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    c.appListing.update.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    c.appListing.updateMany.mockReset().mockResolvedValue({ count: 1 });
+    c.appListing.findFirst.mockReset().mockResolvedValue(null);
+    c.appBlock.findFirst.mockReset().mockResolvedValue(null);
+    c.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
+    c.appListingScreenshot.createMany.mockReset().mockResolvedValue({ count: 0 });
+    c.appListingPublishRequest.count.mockReset().mockResolvedValue(0);
+    c.appListingPublishRequest.create
+      .mockReset()
+      .mockImplementation(async (a: { data: unknown }) => a.data);
+    c.oauthClient.findUnique.mockReset().mockResolvedValue(null);
+  }
+  mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient());
+  mockWrite.$transaction
+    .mockReset()
+    .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+});
+
+describe('submitConnectListing', () => {
+  it('happy path: creates a DRAFT connect AppListing + a pending request with the connect fields', async () => {
+    const res = await submitConnectListing({ input: baseInput, userId: CALLER });
+
+    expect(res.slug).toBe('connect-app');
+    expect(res.listingId).toMatch(/^apl_test_/);
+    expect(res.publishRequestId).toMatch(/^alpr_test_/);
+
+    const listingData = mockWrite.appListing.create.mock.calls[0][0].data as Record<string, unknown>;
+    expect(listingData).toMatchObject({
+      kind: 'offsite',
+      status: 'draft',
+      slug: 'connect-app',
+      externalUrl: null,
+      connectClientId: CLIENT_ID,
+      connectRequestedScopes: TokenScope.ModelsRead,
+      connectScopeJustifications: { ModelsRead: 'We download models to run them.' },
+      appBlockId: null,
+      userId: CALLER,
+    });
+
+    const reqData = mockWrite.appListingPublishRequest.create.mock.calls[0][0]
+      .data as Record<string, unknown>;
+    expect(reqData).toMatchObject({
+      kind: 'offsite',
+      status: 'pending',
+      slug: 'connect-app',
+      appListingId: res.listingId,
+      submittedByUserId: CALLER,
+    });
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('IDOR: the created rows carry the AUTHENTICATED caller as owner/submitter', async () => {
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
+    // caller OTHER owns the client → allowed; rows carry OTHER.
+    await submitConnectListing({ input: baseInput, userId: OTHER });
+    const listingData = mockWrite.appListing.create.mock.calls[0][0].data as { userId: number };
+    const reqData = mockWrite.appListingPublishRequest.create.mock.calls[0][0]
+      .data as { submittedByUserId: number };
+    expect(listingData.userId).toBe(OTHER);
+    expect(reqData.submittedByUserId).toBe(OTHER);
+  });
+
+  it('ownership failure: a client owned by someone else → FORBIDDEN, no write', async () => {
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
+    await expect(submitConnectListing({ input: baseInput, userId: CALLER })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('client not found → NOT_FOUND, no write', async () => {
+    mockRead.oauthClient.findUnique.mockResolvedValue(null);
+    await expect(submitConnectListing({ input: baseInput, userId: CALLER })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('app-block client → BAD_REQUEST (excluded up-front, no client lookup)', async () => {
+    await expect(
+      submitConnectListing({
+        input: { ...baseInput, connectClientId: 'appblk-abc123' },
+        userId: CALLER,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('App Block') });
+    expect(mockRead.oauthClient.findUnique).not.toHaveBeenCalled();
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('requestedScopes NOT ⊆ allowedScopes → BAD_REQUEST, no write', async () => {
+    await expect(
+      submitConnectListing({
+        input: {
+          ...baseInput,
+          // MediaWrite (64) is outside the ceiling (13).
+          requestedScopes: TokenScope.MediaWrite,
+          scopeJustifications: { MediaWrite: 'why' },
+        },
+        userId: CALLER,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('exceed') });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['unknown-scope key', { requestedScopes: TokenScope.ModelsRead, scopeJustifications: { NotAScope: 'x' } }],
+    [
+      'value > max length',
+      {
+        requestedScopes: TokenScope.ModelsRead,
+        scopeJustifications: { ModelsRead: 'x'.repeat(501) },
+      },
+    ],
+    [
+      'empty value',
+      { requestedScopes: TokenScope.ModelsRead, scopeJustifications: { ModelsRead: '' } },
+    ],
+    [
+      'key not among requested scopes',
+      {
+        requestedScopes: TokenScope.ModelsRead,
+        scopeJustifications: { ModelsWrite: 'not requested' },
+      },
+    ],
+  ])('bad justification (%s) → BAD_REQUEST, no write', async (_label, patch) => {
+    await expect(
+      submitConnectListing({ input: { ...baseInput, ...patch }, userId: CALLER })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('empty justification map ({}) is accepted (disclosure-only)', async () => {
+    await expect(
+      submitConnectListing({
+        input: { ...baseInput, scopeJustifications: {} },
+        userId: CALLER,
+      })
+    ).resolves.toMatchObject({ slug: 'connect-app' });
+  });
+
+  it('slug already taken → friendly BAD_REQUEST, no tx', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue({ id: 'apl_existing' });
+    await expect(submitConnectListing({ input: baseInput, userId: CALLER })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('already taken'),
+    });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('per-user pending cap → TOO_MANY_REQUESTS, no tx', async () => {
+    mockRead.appListingPublishRequest.count.mockResolvedValue(10);
+    await expect(submitConnectListing({ input: baseInput, userId: CALLER })).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildListingPatchData (connect scope edit)', () => {
+  it('valid scope patch writes connectRequestedScopes + connectScopeJustifications', () => {
+    const data = buildListingPatchData(
+      {
+        requestedScopes: TokenScope.ModelsRead,
+        scopeJustifications: { ModelsRead: 'reason' },
+      },
+      { connectAllowedScopes: CEILING }
+    );
+    expect(data.connectRequestedScopes).toBe(TokenScope.ModelsRead);
+    expect(data.connectScopeJustifications).toEqual({ ModelsRead: 'reason' });
+  });
+
+  it('scope patch with NO ceiling (non-connect listing) → BAD_REQUEST', () => {
+    expect(() =>
+      buildListingPatchData(
+        { requestedScopes: TokenScope.ModelsRead, scopeJustifications: {} },
+        { connectAllowedScopes: null }
+      )
+    ).toThrow(/no OAuth client/);
+  });
+
+  it('scopeJustifications without requestedScopes → BAD_REQUEST', () => {
+    expect(() =>
+      buildListingPatchData(
+        { scopeJustifications: { ModelsRead: 'reason' } },
+        { connectAllowedScopes: CEILING }
+      )
+    ).toThrow(/requestedScopes is required/);
+  });
+
+  it('scope patch exceeding the ceiling → BAD_REQUEST', () => {
+    expect(() =>
+      buildListingPatchData(
+        { requestedScopes: TokenScope.MediaWrite, scopeJustifications: {} },
+        { connectAllowedScopes: CEILING }
+      )
+    ).toThrow(/exceed/);
+  });
+});
+
+describe('updateListing (connect scope edit re-validation)', () => {
+  const approvedConnectListing = {
+    id: 'apl_live',
+    kind: 'offsite',
+    slug: 'connect-app',
+    status: 'approved',
+    userId: CALLER,
+    revisionOfId: null,
+    name: 'Connect App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: 'g',
+    externalUrl: null,
+    connectClientId: CLIENT_ID,
+    connectRequestedScopes: TokenScope.ModelsRead,
+    connectScopeJustifications: { ModelsRead: 'reason' },
+    iconId: 1,
+    coverId: 2,
+  };
+
+  it('re-validates the subset on edit: a scope change beyond the ceiling → error, no shadow write', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedConnectListing);
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient());
+    await expect(
+      updateListing({
+        listingId: 'apl_live',
+        userId: CALLER,
+        patch: { requestedScopes: TokenScope.MediaWrite, scopeJustifications: {} },
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('a valid scope change on an approved listing is MATERIAL → stages a shadow (requiresReview)', async () => {
+    // loadOwnedEditableListing reads the live parent; beginListingRevision then
+    // reads it again (approved, no existing shadow) and creates the shadow.
+    mockRead.appListing.findUnique.mockResolvedValue(approvedConnectListing);
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient());
+    mockRead.appListing.findFirst.mockResolvedValue(null); // no existing shadow
+    mockWrite.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' }); // winner re-read
+
+    const res = await updateListing({
+      listingId: 'apl_live',
+      userId: CALLER,
+      patch: {
+        requestedScopes: TokenScope.UserRead | TokenScope.ModelsRead,
+        scopeJustifications: { UserRead: 'profile', ModelsRead: 'reason' },
+      },
+    });
+    expect(res.requiresReview).toBe(true);
+    expect(res.shadowId).toBeTruthy();
+  });
+});

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -15,8 +15,14 @@ import {
   OFFSITE_REJECTION_REASON_MIN,
   type OffsiteContentRating,
   type PersistListingAssetImageInput,
+  type SubmitConnectListingInput,
   type SubmitExternalListingInput,
 } from '~/server/schema/blocks/offsite-listing.schema';
+import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
+import {
+  connectScopesSubsetOfCeiling,
+  validateConnectScopeJustifications,
+} from '~/shared/constants/token-scope.constants';
 import { assertListingAssetsComplete } from '~/server/services/blocks/app-listing-assets.service';
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
 import {
@@ -237,6 +243,199 @@ export async function submitExternalListing(opts: {
   } catch (err) {
     // Lost the check→create race (or a slug the pre-check missed): the
     // AppListing.slug @unique fires P2002. Collapse to the same friendly error.
+    if ((err as { code?: unknown })?.code === 'P2002') throw slugTakenError(slug);
+    throw err;
+  }
+
+  return { listingId, publishRequestId, slug };
+}
+
+// ---------------------------------------------------------------------------
+// submitConnectListing (author) — OAuth-connect sub-kind (un-defers the seam).
+// ---------------------------------------------------------------------------
+
+export type SubmitConnectListingResult = {
+  listingId: string;
+  publishRequestId: string;
+  slug: string;
+};
+
+/**
+ * Load the caller's OWN OAuth client and assert it is eligible to back a connect
+ * listing: it must EXIST, be OWNED by `userId` (IDOR), and NOT be an App-Block
+ * client (`isAppBlockOauthClientId` — those are managed by the App Blocks flow, not
+ * hand-listed). Returns the client's `allowedScopes` ceiling. A connect listing does
+ * NOT require the client to be `isVerified` (decision Q4). All failures are friendly
+ * TRPCErrors (parity with `submitExternalListing`'s validation style).
+ */
+async function loadConnectClientForListing(
+  connectClientId: string,
+  userId: number
+): Promise<{ id: string; allowedScopes: number }> {
+  // App-block clients are excluded up-front (cheap, no DB) — they are never a
+  // hand-authored connect target.
+  if (isAppBlockOauthClientId(connectClientId)) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'App Block OAuth clients cannot be listed as connect apps',
+    });
+  }
+  const client = await dbRead.oauthClient.findUnique({
+    where: { id: connectClientId },
+    select: { id: true, userId: true, allowedScopes: true },
+  });
+  if (!client) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'OAuth client not found' });
+  }
+  if (client.userId !== userId) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'you can only list an OAuth client you own',
+    });
+  }
+  return { id: client.id, allowedScopes: client.allowedScopes };
+}
+
+/**
+ * Assert a requested-scope mask + its per-scope justifications are valid against the
+ * client's `allowedScopes` ceiling: the mask must be a SUBSET of the ceiling
+ * ((requested & ~allowed) === 0) and the justifications must satisfy the shared
+ * `validateConnectScopeJustifications` (keys are valid single-bit TokenScope enum
+ * keys, keys ⊆ requested, values non-empty ≤ SCOPE_JUSTIFICATION_MAX_LENGTH). Throws
+ * a friendly BAD_REQUEST on the first failure. Used on submit AND on edit (defense
+ * in depth — these fns are exported + unit-tested directly).
+ */
+function assertConnectScopesValid(opts: {
+  requestedScopes: number;
+  scopeJustifications: Record<string, string>;
+  allowedScopes: number;
+}): void {
+  const { requestedScopes, scopeJustifications, allowedScopes } = opts;
+  if (!connectScopesSubsetOfCeiling(requestedScopes, allowedScopes)) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'requested scopes exceed the OAuth client’s allowed scopes',
+    });
+  }
+  const errors = validateConnectScopeJustifications(requestedScopes, scopeJustifications);
+  if (errors.length > 0) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: errors.join('; ') });
+  }
+}
+
+/**
+ * Create a DRAFT OAuth-CONNECT off-site listing + a pending publish request in one
+ * transaction — the connect analog of {@link submitExternalListing}. Same B1
+ * scaffold (draft listing for owner-gated asset CRUD, pending request, slug-squat
+ * pre-check + P2002 backstop, per-user pending cap) but the sub-kind carries a
+ * `connectClientId` (a client the caller OWNS + is NOT an App-Block client) and NO
+ * `externalUrl`, plus the DISCLOSED `connectRequestedScopes` subset (⊆ the client's
+ * `allowedScopes`) and per-scope `connectScopeJustifications`.
+ *
+ * Disclosure/review-only: `connectRequestedScopes` is STORED + reviewed; it does NOT
+ * gate OAuth token issuance (the client's `allowedScopes` remains the runtime ceiling
+ * via the existing consent flow).
+ *
+ * Owner-binding (IDOR) is identical to the external path — both `AppListing.userId`
+ * and `AppListingPublishRequest.submittedByUserId` come from the authenticated
+ * caller, and the client ownership is re-checked here.
+ */
+export async function submitConnectListing(opts: {
+  input: SubmitConnectListingInput;
+  userId: number;
+}): Promise<SubmitConnectListingResult> {
+  const { input, userId } = opts;
+
+  if (input.category != null && !isMarketplaceCategory(input.category)) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: `unknown category "${input.category}"` });
+  }
+  const contentRating = input.contentRating ?? 'g';
+  if (!(OFFSITE_CONTENT_RATINGS as readonly string[]).includes(contentRating)) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `unknown content rating "${contentRating}"`,
+    });
+  }
+
+  // Load + gate the OAuth client (exists / owned / not-app-block), then validate the
+  // requested-scope subset + justifications against the client's ceiling.
+  const client = await loadConnectClientForListing(input.connectClientId, userId);
+  assertConnectScopesValid({
+    requestedScopes: input.requestedScopes,
+    scopeJustifications: input.scopeJustifications,
+    allowedScopes: client.allowedScopes,
+  });
+
+  // Per-user pending-submission cap (shared with the external path — bounds standing
+  // orphan-draft accrual across BOTH offsite sub-kinds).
+  const pendingCount = await dbRead.appListingPublishRequest.count({
+    where: { submittedByUserId: userId, kind: 'offsite', status: 'pending' },
+  });
+  if (pendingCount >= MAX_PENDING_OFFSITE_SUBMISSIONS) {
+    throw new TRPCError({
+      code: 'TOO_MANY_REQUESTS',
+      message: `You have ${pendingCount} pending submissions (max ${MAX_PENDING_OFFSITE_SUBMISSIONS}). Withdraw one or wait for review before submitting another.`,
+    });
+  }
+
+  const slug = input.slug;
+
+  const existingListing = await dbRead.appListing.findUnique({
+    where: { slug },
+    select: { id: true },
+  });
+  if (existingListing) throw slugTakenError(slug);
+  const existingBlock = await dbRead.appBlock.findFirst({
+    where: { blockId: slug },
+    select: { id: true },
+  });
+  if (existingBlock) throw slugTakenError(slug);
+
+  const listingId = newAppListingId();
+  const publishRequestId = newAppListingPublishRequestId();
+
+  try {
+    await dbWrite.$transaction(async (tx) => {
+      const blockOnPrimary = await tx.appBlock.findFirst({
+        where: { blockId: slug },
+        select: { id: true },
+      });
+      if (blockOnPrimary) throw slugTakenError(slug);
+
+      await tx.appListing.create({
+        data: {
+          id: listingId,
+          kind: 'offsite',
+          status: 'draft',
+          slug,
+          name: input.name,
+          tagline: input.tagline ?? null,
+          description: input.description ?? null,
+          category: input.category ?? null,
+          contentRating,
+          // Connect sub-kind: no external URL; the app is a registered OAuth client.
+          externalUrl: null,
+          connectClientId: input.connectClientId,
+          // Disclosed, review-only scope subset + per-scope justifications.
+          connectRequestedScopes: input.requestedScopes,
+          connectScopeJustifications: input.scopeJustifications,
+          appBlockId: null,
+          userId,
+        },
+      });
+      await tx.appListingPublishRequest.create({
+        data: {
+          id: publishRequestId,
+          appListingId: listingId,
+          kind: 'offsite',
+          slug,
+          submittedByUserId: userId,
+          status: 'pending',
+          changelog: input.changelog ?? null,
+        },
+      });
+    });
+  } catch (err) {
     if ((err as { code?: unknown })?.code === 'P2002') throw slugTakenError(slug);
     throw err;
   }
@@ -475,7 +674,19 @@ const MATERIAL_PATCH_FIELDS = ['externalUrl', 'name', 'contentRating'] as const;
  * (an omitted field is left untouched; an explicit `null` clears a nullable one).
  * `externalUrl` is normalized to the validator's canonical form.
  */
-export function buildListingPatchData(patch: UpdateListingPatch): Prisma.AppListingUpdateInput {
+export function buildListingPatchData(
+  patch: UpdateListingPatch,
+  opts?: {
+    /**
+     * The connect client's `allowedScopes` ceiling (from the listing's
+     * `connectClientId`). REQUIRED when the patch touches `requestedScopes` /
+     * `scopeJustifications` — the caller (`updateListing`) resolves it once and
+     * passes it in. `null` means the listing has no connect client, so a scope edit
+     * is rejected.
+     */
+    connectAllowedScopes?: number | null;
+  }
+): Prisma.AppListingUpdateInput {
   const data: Prisma.AppListingUpdateInput = {};
   if (patch.externalUrl !== undefined) {
     const url = validateExternalUrl(patch.externalUrl);
@@ -500,6 +711,32 @@ export function buildListingPatchData(patch: UpdateListingPatch): Prisma.AppList
     }
     data.contentRating = patch.contentRating;
   }
+  // OAuth-connect scope disclosure edit. `requestedScopes` + `scopeJustifications`
+  // travel as a pair: justifications validate against the requested mask, so a
+  // justification-only edit (no mask) is rejected. Re-run the subset + justification
+  // checks against the listing's client ceiling (defense in depth — this fn is
+  // exported + unit-tested directly).
+  if (patch.requestedScopes !== undefined || patch.scopeJustifications !== undefined) {
+    if (patch.requestedScopes === undefined) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'requestedScopes is required when editing scope justifications',
+      });
+    }
+    if (opts?.connectAllowedScopes == null) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'this listing has no OAuth client, so it cannot request scopes',
+      });
+    }
+    assertConnectScopesValid({
+      requestedScopes: patch.requestedScopes,
+      scopeJustifications: patch.scopeJustifications ?? {},
+      allowedScopes: opts.connectAllowedScopes,
+    });
+    data.connectRequestedScopes = patch.requestedScopes;
+    data.connectScopeJustifications = patch.scopeJustifications ?? {};
+  }
   return data;
 }
 
@@ -511,7 +748,12 @@ export function buildListingPatchData(patch: UpdateListingPatch): Prisma.AppList
  */
 function patchHasMaterialChange(
   patch: UpdateListingPatch,
-  live: { externalUrl: string | null; name: string; contentRating: string | null }
+  live: {
+    externalUrl: string | null;
+    name: string;
+    contentRating: string | null;
+    connectRequestedScopes: number | null;
+  }
 ): boolean {
   for (const field of MATERIAL_PATCH_FIELDS) {
     const patched = patch[field];
@@ -525,6 +767,15 @@ function patchHasMaterialChange(
     }
     // name / contentRating: plain scalar inequality vs the live value.
     if (patched !== live[field]) return true;
+  }
+  // A change to the DISCLOSED OAuth scope subset is material — the mod approved a
+  // specific set of scopes, so a new set must re-enter review (the shadow carries the
+  // updated mask + justifications, re-validated in buildListingPatchData).
+  if (
+    patch.requestedScopes !== undefined &&
+    patch.requestedScopes !== (live.connectRequestedScopes ?? 0)
+  ) {
+    return true;
   }
   return false;
 }
@@ -557,6 +808,8 @@ type EditableListing = {
   contentRating: string | null;
   externalUrl: string | null;
   connectClientId: string | null;
+  connectRequestedScopes: number | null;
+  connectScopeJustifications: Prisma.JsonValue | null;
   iconId: number | null;
   coverId: number | null;
 };
@@ -575,6 +828,8 @@ const editableListingSelect = {
   contentRating: true,
   externalUrl: true,
   connectClientId: true,
+  connectRequestedScopes: true,
+  connectScopeJustifications: true,
   iconId: true,
   coverId: true,
 } as const;
@@ -619,6 +874,44 @@ export async function updateListing(opts: {
     );
   }
 
+  // If the patch touches the disclosed OAuth scopes, resolve the client's ceiling
+  // once (needed by buildListingPatchData's subset re-validation). A scope edit on a
+  // listing with no connect client → BAD_REQUEST.
+  const editsScopes =
+    patch.requestedScopes !== undefined || patch.scopeJustifications !== undefined;
+  let connectAllowedScopes: number | null = null;
+  if (editsScopes) {
+    if (listing.connectClientId == null) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'this listing has no OAuth client, so it cannot request scopes',
+      });
+    }
+    const client = await dbRead.oauthClient.findUnique({
+      where: { id: listing.connectClientId },
+      select: { allowedScopes: true },
+    });
+    if (!client) {
+      throw new TRPCError({ code: 'NOT_FOUND', message: 'OAuth client not found' });
+    }
+    connectAllowedScopes = client.allowedScopes;
+    // Validate the scope edit UP-FRONT (before any shadow is opened) so an invalid
+    // subset/justification rejects cleanly and never leaves an orphan shadow draft.
+    // `buildListingPatchData` re-validates as defense-in-depth for direct callers.
+    if (patch.requestedScopes === undefined) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'requestedScopes is required when editing scope justifications',
+      });
+    }
+    assertConnectScopesValid({
+      requestedScopes: patch.requestedScopes,
+      scopeJustifications: patch.scopeJustifications ?? {},
+      allowedScopes: connectAllowedScopes,
+    });
+  }
+  const patchOpts = { connectAllowedScopes };
+
   switch (listing.status) {
     case 'removed':
       throw new OffsiteRequestError(
@@ -636,7 +929,7 @@ export async function updateListing(opts: {
     case 'pending': {
       // Edit IN PLACE — no re-review. A pending listing's existing pending request
       // keeps reviewing the now-updated row (it references the row, not a snapshot).
-      const data = buildListingPatchData(patch);
+      const data = buildListingPatchData(patch, patchOpts);
       await dbWrite.appListing.update({ where: { id: listingId }, data });
       return { listingId, status: listing.status, requiresReview: false, shadowId: null };
     }
@@ -645,12 +938,13 @@ export async function updateListing(opts: {
         externalUrl: listing.externalUrl,
         name: listing.name,
         contentRating: listing.contentRating,
+        connectRequestedScopes: listing.connectRequestedScopes,
       });
       if (!material) {
         // TRIVIAL-only edit → apply to the LIVE row in place (no re-review). Any
         // material key present is byte-identical to the live value (material ===
         // false), so writing it is a harmless no-op.
-        const data = buildListingPatchData(patch);
+        const data = buildListingPatchData(patch, patchOpts);
         await dbWrite.appListing.update({ where: { id: listingId }, data });
         return { listingId, status: listing.status, requiresReview: false, shadowId: null };
       }
@@ -658,7 +952,7 @@ export async function updateListing(opts: {
       // FULL patch (material + trivial) is written to the shadow. Assets are edited
       // separately against the shadow id, then submitListingRevision re-reviews it.
       const { shadowId } = await beginListingRevision({ listingId, userId });
-      const data = buildListingPatchData(patch);
+      const data = buildListingPatchData(patch, patchOpts);
       await dbWrite.appListing.update({ where: { id: shadowId }, data });
       return { listingId, status: listing.status, requiresReview: true, shadowId };
     }
@@ -738,6 +1032,14 @@ export async function beginListingRevision(opts: {
           contentRating: parent.contentRating,
           externalUrl: parent.externalUrl,
           connectClientId: parent.connectClientId,
+          // Carry the disclosed OAuth scope subset + justifications onto the shadow so
+          // a revision that DOESN'T touch scopes preserves them (and one that does
+          // overwrites them via buildListingPatchData).
+          connectRequestedScopes: parent.connectRequestedScopes,
+          connectScopeJustifications:
+            parent.connectScopeJustifications === null
+              ? Prisma.DbNull
+              : (parent.connectScopeJustifications as Prisma.InputJsonValue),
           iconId: parent.iconId,
           coverId: parent.coverId,
           // A shadow has NO backing AppBlock (appBlockId is @unique — it stays on
@@ -1536,6 +1838,8 @@ async function applyApprovedRevision(opts: {
         contentRating: true,
         externalUrl: true,
         connectClientId: true,
+        connectRequestedScopes: true,
+        connectScopeJustifications: true,
         iconId: true,
         coverId: true,
       },
@@ -1602,6 +1906,13 @@ async function applyApprovedRevision(opts: {
         contentRating: finalRating,
         externalUrl: shadow.externalUrl,
         connectClientId: shadow.connectClientId,
+        // Apply the revision's disclosed OAuth scopes + justifications onto the live
+        // parent (a scope change is material, so the shadow carries the reviewed set).
+        connectRequestedScopes: shadow.connectRequestedScopes,
+        connectScopeJustifications:
+          shadow.connectScopeJustifications === null
+            ? Prisma.DbNull
+            : (shadow.connectScopeJustifications as Prisma.InputJsonValue),
         iconId: shadow.iconId,
         coverId: shadow.coverId,
       },

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -339,6 +339,12 @@ function assertConnectScopesValid(opts: {
  * Owner-binding (IDOR) is identical to the external path — both `AppListing.userId`
  * and `AppListingPublishRequest.submittedByUserId` come from the authenticated
  * caller, and the client ownership is re-checked here.
+ *
+ * NOTE: connect-listing mod APPROVAL is completed in PR3 (which owns the review
+ * side). Today `approveExternalRequest` / `applyApprovedRevision` re-validate the
+ * stored `externalUrl`, which is `null` for a connect listing — PR3 skips that URL
+ * re-validation for the connect sub-kind + adds the approve→live test. This submit
+ * path (PR2) deliberately does not touch the approve path.
  */
 export async function submitConnectListing(opts: {
   input: SubmitConnectListingInput;
@@ -889,10 +895,22 @@ export async function updateListing(opts: {
     }
     const client = await dbRead.oauthClient.findUnique({
       where: { id: listing.connectClientId },
-      select: { allowedScopes: true },
+      select: { userId: true, allowedScopes: true },
     });
     if (!client) {
       throw new TRPCError({ code: 'NOT_FOUND', message: 'OAuth client not found' });
+    }
+    // Defense in depth: re-assert the caller still OWNS the client (mirrors
+    // `loadConnectClientForListing`'s submit-time check). `connectClientId` is
+    // immutable on edit, so this is safe today — but if the client were transferred
+    // to another user after submit, the original listing owner must NOT be able to
+    // edit disclosed scopes against the new owner's ceiling. `userId` here is the
+    // authenticated caller (the listing was already owner-bound above).
+    if (client.userId !== userId) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'you can only list an OAuth client you own',
+      });
     }
     connectAllowedScopes = client.allowedScopes;
     // Validate the scope edit UP-FRONT (before any shadow is opened) so an invalid


### PR DESCRIPTION
**PR2 of the OAuth-connect app-listing scope-review plan.** Un-defers the connect-listing submission flow behind the app-blocks author gate, with per-scope justification authoring. **Disclosure/review-only** — no OAuth-issuance change. Validation reuses PR1's shared helpers.

## What this does
The only listing submission path today (`submitExternalListing`) hardcodes `connectClientId: null` — the OAuth-connect seam is inert. This PR builds the connect sub-kind: a dev links a registered OAuth app **they own**, opts into the subset of that app's `allowedScopes` it will request (explicit opt-in from empty), and writes a per-scope justification. A DRAFT `AppListing` + pending `AppListingPublishRequest` are created in one tx, mirroring the external flow.

**Disclosure/review-only (decided):** the requested-scope subset is STORED + reviewed; it does **not** gate OAuth token issuance — the client's `allowedScopes` remains the runtime ceiling via the existing consent flow. The `/authorize` scope param and consent policy are untouched.

## Changes
- **Submit mode** — `SubmitMode` union `+= 'connect'` + a "Connect an app" `SubmitModeCard`.
- **`ConnectSubmitForm`** (sibling of `ExternalSubmitForm`): OAuth client picker (`oauthClient.getAll`, filtered to the caller's own **non-app-block** clients), a scope-subset grid (`tokenScopeGrid` + `Flags.hasFlag`) **restricted to the selected client's `allowedScopes`** (others disabled, default none checked), and a justification `Textarea` (≤500, char counter) per checked scope.
- **Schema** `submitConnectListingSchema` — drops `externalUrl`; adds `connectClientId`, `requestedScopes` (int, non-negative), `scopeJustifications`. Reuses the name/tagline/description/category/contentRating bounds. Scope fields also threaded into `updateListingPatchSchema`.
- **Service** `submitConnectListing` — asserts caller **owns** the client, it's **not** an app-block client, `requestedScopes ⊆ allowedScopes`, and justifications validate; creates the DRAFT listing + pending request in one tx. `submitExternalListing` is unchanged.
- **Router** `appListings.submitConnectListing` (`appDeveloperProcedure` + submit-rate limit).
- **Edit/shadow** — `requestedScopes` + `scopeJustifications` threaded through `buildListingPatchData` (ceiling-aware re-validation, validated up-front so an invalid edit never orphans a shadow) + both shadow-revision copy sites; a scope change is material → re-enters review.

## Gating (dark)
The whole `/apps/submit` page is already gated by the `appBlocksAuthor` capability (Flipt `app-blocks-author`, static mod-only fallback) at the gSSP resolver, and the endpoint by `appDeveloperProcedure` — identical to the external mode. The connect mode/form/endpoint inherit that gate, so this is dark until launch. No new flag.

## Validation reuse (PR1)
`connectScopesSubsetOfCeiling`, `validateConnectScopeJustifications`, `tokenScopeMaskToList`, `tokenScopeKeyByBit`, `SCOPE_JUSTIFICATION_MAX_LENGTH` — all from `packages/civitai-auth/src/token-scope.ts`. The schema columns (`connect_requested_scopes`, `connect_scope_justifications`) and migration landed in PR1 (already applied to prod).

## Test evidence
- `tsc --noEmit` (`--max_old_space_size=8192`): **0 errors in changed files, 0 delta** vs the `main` baseline (17 pre-existing environmental module-resolution errors unchanged).
- Unit: `offsite-listing.connect.service` (19), `offsite-listing.connect.schema` (10), `connectSubmitFormConfig` (12) — **41 pass**. Existing `offsite-listing.service` (53) + `offsite-listing.schema` (27) still green.
- Component (browser): `ConnectSubmitForm.browser` (3) — scope grid restricts to `allowedScopes`, a justification textarea appears per checked scope, Create-draft sends the right payload. `SubmitModeSelector.browser` still green.

Service coverage includes: valid submission creates the DRAFT + pending request with the right connect fields; ownership failure → `FORBIDDEN`; app-block client → rejected; `requestedScopes` not ⊆ `allowedScopes` → rejected; bad justification (unknown-scope key / >500 / empty value / key-not-in-requested) → rejected; edit re-validates the subset.

> A sibling **PR3** will add the mod-review read path (`submissionSelect` + `ConnectScopesPanel`); this PR keeps its edits to the submit/service/schema/form side so PR3 stays separable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)