### PR TITLE
fix(posts): stop deleteModelById leaving live publishedAt on unpublished posts

### DIFF
--- a/src/components/Post/Detail/PostDetail.tsx
+++ b/src/components/Post/Detail/PostDetail.tsx
@@ -211,8 +211,8 @@ export function PostDetailContent({ postId }: Props) {
                   )}
                   <Text size="sm">
                     This post is hidden from the public because its parent model or version was
-                    unpublished. Republish the parent to bring this post back — the original
-                    publish date will be preserved.
+                    unpublished. Republish the parent to bring this post back — the original publish
+                    date will be preserved.
                   </Text>
                   {post.parentModelId && post.modelVersionId && (
                     <Text size="sm">
@@ -416,8 +416,8 @@ export function PostDetailContent({ postId }: Props) {
             {!imagesLoading && !unfilteredImages?.length ? (
               hasActiveContentFilter ? (
                 <Alert color="yellow">
-                  No images visible at your current browsing settings. Some images in this post may
-                  be hidden because they are tagged as minor or depict real people.
+                  No images in this post are visible with your current browsing and content
+                  settings.
                 </Alert>
               ) : (
                 <Alert>Unable to load images</Alert>

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1561,8 +1561,10 @@ export const deleteModelById = async ({
         UPDATE "Post"
         SET "metadata" = "metadata" || jsonb_build_object(
           'unpublishedAt', ${new Date().toISOString()},
-          'unpublishedBy', ${userId}
-                                       )
+          'unpublishedBy', ${userId},
+          'prevPublishedAt', "publishedAt"
+                                       ),
+            "publishedAt" = NULL
         WHERE
             "publishedAt" IS NOT NULL
         AND "userId" = ${model.userId}


### PR DESCRIPTION
## Problem

Image posts could be **invisible to regular users while visible to mods and the post owner**. Root cause: a post that reads as *published* (`publishedAt` set, non-null, in the past) while its `metadata` still carries an `unpublishedAt` stamp. The DB image feed filter (`image.service.ts` `getAllImages`) drops any such post for non-owners:

```js
if (isModerator) return true;                       // mods bypass
if ((!x.publishedAt || x.publishedAt > now || !!x.unpublishedAt) && x.userId !== userId)
  return false;                                     // everyone else dropped by !!unpublishedAt
```

## Cause

`deleteModelById` stamped `metadata.unpublishedAt`/`unpublishedBy` on attached posts **but left `publishedAt` set and never stashed `prevPublishedAt`** — unlike every sibling unpublish path (`unpublishModelById`, version unpublish in `model-version.service.ts`, moderation in `user.service.ts`), all of which set `publishedAt = NULL` and stash `prevPublishedAt`. So `deleteModelById` was the sole path producing the "published + stamped" state going forward. (Legacy occurrences also came from the pre-#2458 owner edit-page republish loophole, already fixed.)

## Fix

- `deleteModelById`: null `publishedAt` + stash `prevPublishedAt`, matching the other unpublish paths. Keeps `publishedAt` the source of truth and makes delete → restore symmetric (restore reads back the stash).
- Reword the post empty-state alert that falsely blamed content "tagged as minor or depict real people" for *any* empty result.

## Not included
- No change to the feed filter (`!!unpublishedAt` gate stays) — nulling `publishedAt` at the source is the correct fix and avoids un-hiding genuinely-removed content.
- A one-time prod data cleanup of 229 currently-live posts stuck with a stale stamp (incl. the reported post) was applied separately, scoped to model-live posts only; deleted/orphaned posts left hidden.

## Verification
- Typecheck ✅, prettier ✅.
- Verified live against the reported post: after clearing its stale stamp, an impersonated non-mod user goes from 0 → all 6 images, alert gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)