### PR TITLE
fix(api): no-store on gated articles/collections endpoints (public cache cross-served the per-user gate)

### DIFF
--- a/src/pages/api/v1/articles/[id].ts
+++ b/src/pages/api/v1/articles/[id].ts
@@ -30,6 +30,15 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
+  // This response VARIES by user: the appBlocksAuthor cohort gate AND per-user
+  // visibility (owner/mod see draft/unpublished articles). It must NEVER be
+  // shared/edge-cached — unlike the fully-public models/images which are safely
+  // `public`-cached. Override the `public, s-maxage=…` header MixedAuthEndpoint sets
+  // for anonymous callers with `no-store` up front, so EVERY response path (403 gate,
+  // 429, 400, 200, 404) is uncacheable and Cloudflare can't cross-serve one user's
+  // response to another.
+  res.setHeader('Cache-Control', 'no-store');
+
   // App Blocks author-cohort gate — preview, cohort-only (mods + the
   // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → 403 with a clear
   // preview message (invited-cohort DX: explain the restriction rather than an

--- a/src/pages/api/v1/articles/index.ts
+++ b/src/pages/api/v1/articles/index.ts
@@ -77,6 +77,14 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
+  // This response VARIES by user: the appBlocksAuthor cohort gate AND per-user
+  // visibility (owner/mod see private articles). It must NEVER be shared/edge-cached —
+  // unlike the fully-public models/images which are safely `public`-cached. Override
+  // the `public, s-maxage=…` header MixedAuthEndpoint sets for anonymous callers with
+  // `no-store` up front, so EVERY response path (403 gate, 429, 400/401, 200) is
+  // uncacheable and Cloudflare can't cross-serve one user's response to another.
+  res.setHeader('Cache-Control', 'no-store');
+
   // App Blocks author-cohort gate — this endpoint is a preview, reachable ONLY by
   // the `appBlocksAuthor` cohort (mods via the static floor + the
   // `app-blocks-author` Flipt cohort). Everyone else — INCLUDING anonymous (no

--- a/src/pages/api/v1/collections/[id].ts
+++ b/src/pages/api/v1/collections/[id].ts
@@ -40,6 +40,15 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
+  // This response VARIES by user: the appBlocksAuthor cohort gate AND per-user
+  // visibility (owner/contributor/mod can read a private collection). It must NEVER be
+  // shared/edge-cached — unlike the fully-public models/images which are safely
+  // `public`-cached. Override the `public, s-maxage=…` header MixedAuthEndpoint sets
+  // for anonymous callers with `no-store` up front, so EVERY response path (403 gate,
+  // 429, 400, 200, 404) is uncacheable and Cloudflare can't cross-serve one user's
+  // response to another.
+  res.setHeader('Cache-Control', 'no-store');
+
   // App Blocks author-cohort gate — preview, cohort-only (mods + the
   // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → 403 with a clear
   // preview message (invited-cohort DX: explain the restriction rather than an

--- a/src/pages/api/v1/collections/index.ts
+++ b/src/pages/api/v1/collections/index.ts
@@ -86,6 +86,15 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
+  // This response VARIES by user: the appBlocksAuthor cohort gate AND per-user
+  // visibility (`mine=true` returns the caller's OWN collections). It must NEVER be
+  // shared/edge-cached — unlike the fully-public models/images which are safely
+  // `public`-cached. Override the `public, s-maxage=…` header MixedAuthEndpoint sets
+  // for anonymous callers with `no-store` up front, so EVERY response path (403 gate,
+  // 429, 400/401, 200) is uncacheable and Cloudflare can't cross-serve one user's
+  // response to another.
+  res.setHeader('Cache-Control', 'no-store');
+
   // App Blocks author-cohort gate — preview, cohort-only (mods + the
   // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → 403 with a clear
   // preview message (invited-cohort DX: explain the restriction rather than an

--- a/src/tests/api/v1/articles/index.test.ts
+++ b/src/tests/api/v1/articles/index.test.ts
@@ -173,6 +173,48 @@ describe('GET /api/v1/articles — author-cohort gate (403 preview)', () => {
   });
 });
 
+describe('CACHE: gated responses must be no-store (never edge-cached/cross-served)', () => {
+  it('403 gate denial sets Cache-Control: no-store (list)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: {} });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+  });
+
+  it('200 success sets Cache-Control: no-store (list)', async () => {
+    mockGetArticles.mockResolvedValue({ items: [{ id: 1 }], nextCursor: undefined });
+    const { req, res } = createMocks({ query: {}, user: { id: 7, isModerator: true } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+  });
+
+  it('403 gate denial sets Cache-Control: no-store (detail)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: { id: '3' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+  });
+
+  it('200 success sets Cache-Control: no-store (detail)', async () => {
+    mockGetArticleById.mockResolvedValue({ id: 3, title: 't', moderatorNsfwLevel: 8, nsfwLevel: 1 });
+    const { req, res } = createMocks({ query: { id: '3' }, user: { id: 7, isModerator: true } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+  });
+});
+
 describe('GET /api/v1/articles (list)', () => {
   it('returns the { items, metadata } envelope and serializes the composite cursor', async () => {
     mockGetArticles.mockResolvedValue({

--- a/src/tests/api/v1/collections/index.test.ts
+++ b/src/tests/api/v1/collections/index.test.ts
@@ -185,6 +185,60 @@ describe('GET /api/v1/collections — author-cohort gate (403 preview)', () => {
   });
 });
 
+describe('CACHE: gated responses must be no-store (never edge-cached/cross-served)', () => {
+  it('403 gate denial sets Cache-Control: no-store (list)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: {} });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+  });
+
+  it('200 success sets Cache-Control: no-store (list)', async () => {
+    mockGetAllCollections.mockResolvedValue([]);
+    const { req, res } = createMocks({ query: {}, user: { id: 7, isModerator: true } });
+
+    await listHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+  });
+
+  it('403 gate denial sets Cache-Control: no-store (detail)', async () => {
+    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const { req, res } = createMocks({ query: { id: '55' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(403);
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+  });
+
+  it('200 success sets Cache-Control: no-store (detail)', async () => {
+    mockGetUserCollectionPermissionsById.mockResolvedValue({ read: true, write: false, manage: false });
+    mockGetCollectionById.mockResolvedValue({
+      id: 55,
+      name: 'pub',
+      description: 'd',
+      type: 'Image',
+      nsfwLevel: 1,
+      read: CollectionReadConfiguration.Public,
+      userId: 2,
+      user: { id: 2, username: 'bob' },
+      image: null,
+      tags: [],
+    });
+    const { req, res } = createMocks({ query: { id: '55' }, user: { id: 7, isModerator: true } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
+  });
+});
+
 describe('GET /api/v1/collections (list)', () => {
   it('public mode: queries getAllCollections with privacy pinned to [Public] and returns the envelope', async () => {
     mockGetAllCollections.mockResolvedValue([


### PR DESCRIPTION
## The bug (verified live on prod)

PR #3215 added the gated public REST endpoints `GET /api/v1/articles[/{id}]` and `/api/v1/collections[/{id}]`. They are gated behind the `appBlocksAuthor` cohort (403 for anon/non-cohort, 200 with per-user-visible data for cohort members). But they inherit `Cache-Control: public, s-maxage=300` from the `MixedAuthEndpoint` wrapper (which sets it for anonymous callers), so Cloudflare edge-caches a per-user response and cross-serves it:

- The cached anonymous **403** is served to authed cohort members too, so **no cohort member can reach the endpoint** (verified live: a moderator token received the cached 403).
- Latent **leak**: if an authed **200** (gated data) caches first for a URL, CF serves it to anonymous callers.

These responses **vary by user** (cohort gate + per-user visibility), so they must never be shared/edge-cached.

## The fix

Set `Cache-Control: no-store` as the first statement in each of the 4 handlers, overriding the `public, s-maxage=…` default `MixedAuthEndpoint` sets. Placing it up front makes **every** response path uncacheable — the 403 gate denial, the 429 rate-limit (already no-store, unchanged), the 400/401 validation paths, and the 200/404 service paths. The override is set inside the handler, which runs after `MixedAuthEndpoint`'s `addPublicCacheHeaders`, so it wins cleanly (headers aren't flushed until `res.json`/`res.end`).

A comment on each handler explains these endpoints are per-user-gated (cohort + per-user visibility) and so must not be shared-cached — unlike the fully-public models/images endpoints, which are safely `public`-cached. This matches the existing override precedent in `src/pages/api/v1/models/index.ts` (the transient-503 no-store override).

## Tests

Extended `src/tests/api/v1/{articles,collections}/index.test.ts` with cache-header assertions covering **both** the gate-403 path and the success-200 path (list + detail) on all 4 endpoints. All 36 tests green. `tsc --noEmit` clean on the changed files.

## Rollout note

After deploy, existing cached entries expire within the 300s `s-maxage` window on their own. A Cloudflare cache purge of `/api/v1/articles*` and `/api/v1/collections*` clears them immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
