### PR TITLE
fix(creator-program): honor membership on any buzzType for shop access

### DIFF
--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -28,7 +28,7 @@ import {
   refundTransaction,
 } from '~/server/services/buzz.service';
 import { createNotification } from '~/server/services/notification.service';
-import { getUserSubscription } from '~/server/services/subscriptions.service';
+import { getHighestTierSubscription } from '~/server/services/subscriptions.service';
 import { payToTipaltiAccount } from '~/server/services/user-payment-configuration.service';
 import {
   bustFetchThroughCache,
@@ -242,11 +242,13 @@ export async function getCreatorRequirements(userId: number) {
 }
 
 // Whether a user currently holds a valid Creator Program membership — an active,
-// good-standing subscription on a supported tier. Delegates to
-// getUserSubscription (which already excludes canceled/expired/past-due/etc.) so
-// this stays in sync with how membership is determined everywhere else.
+// good-standing subscription on a supported tier. Uses getHighestTierSubscription
+// so it honors membership on ANY buzzType (yellow/green/blue paid + referral
+// grants), matching how session-user resolves tier. Checking a single buzzType
+// here would lock out .green/.red members and referral-granted members whose paid
+// sub isn't yellow.
 export async function hasValidCreatorMembership(userId: number) {
-  const subscription = await getUserSubscription({ userId });
+  const subscription = await getHighestTierSubscription(userId);
   const tier = subscription?.tier;
   return !!tier && tier !== 'free' && tier !== 'founder';
 }


### PR DESCRIPTION
## Problem

Reported via DM: a civitai.red creator (`SenatorMakenzie`) hit **"An active Creator Program membership is required. Renew your membership to use your shop."** when submitting a cosmetic — despite being an active Creator Program member.

`hasValidCreatorMembership` resolved membership via `getUserSubscription({ userId })`, which **defaults to `buzzType: 'yellow'`** (the .com paid sub). Memberships are multi-buzzType — paid subs use `yellow` (.com), `green` (.green), `blue` (.red), and referral grants use `buzzType: 'referral'` (see `docs/features/referral-program.md`). So any member whose active sub isn't yellow was gated out of the Creator Shop.

### Blast radius (prod, Creator Program members with an active/incomplete sub)

- 119 with a `yellow` sub → shop worked
- **250 with an active membership but no `yellow` sub → wrongly blocked**
  - green: bronze 191 / silver 36 / gold 33
  - referral: bronze 3 (incl. the reporter)

## Fix

Switch `hasValidCreatorMembership` to `getHighestTierSubscription`, which resolves the highest tier across **all** buzzTypes (matching how session-user derives `tier`). Founder stays excluded — it ranks below bronze in `constants.memberships.tierOrder`, so it can't mask a real tier. Referral grants count (product decision: they confer membership perks everywhere else, and they expire on their own via the status/period exclusion in `getAllUserSubscriptions`).

## Notes / out of scope

- **Shop dormancy on lapse** already works (`creator-shop.service.ts` shutters an enabled shop for the public when membership lapses; owner sees a renew prompt).
- **Banking** already requires an active, unexpired sub (`bankBuzz`), so lapsed members can't bank.
- Two pre-existing inconsistencies left for a follow-up: (1) the `CreatorProgram` onboarding bit is never cleared on lapse, so lapsed members stay on the program roster (`getCreatorProgramUsers`); (2) `bankBuzz`'s inline membership check doesn't exclude `founder`/`free`/`renewalEmailSent` the way the shop gate does.

## Test

- `creator-program.service.test.ts`: 34 pass
- typecheck: no new errors (pre-existing failures are stale generated Prisma client, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)