### PR TITLE
perf(tag): cache static votable-tags hierarchy to cut DB load

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2018,6 +2018,7 @@ export const REDIS_KEYS = {
     POST_STATS: 'packed:caches:post-stats',
     USER_FOLLOWS: 'packed:caches:user-follows',
     MODEL_TAGS: 'packed:caches:model-tags',
+    MODEL_VOTABLE_TAGS: 'packed:caches:model-votable-tags',
     IMAGE_TAGS: 'packed:caches:image-tags',
     MODEL_VERSION_RESOURCE_INFO: 'packed:caches:model-version-resource-info',
     TENSOR_METADATA: 'packed:caches:tensor-metadata',

--- a/src/server/jobs/__tests__/apply-tag-rules.test.ts
+++ b/src/server/jobs/__tests__/apply-tag-rules.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * apply-tag-rules is an automated 5-min job that adds/removes model tags directly on
+ * TagsOnModels. Because ModelTag gives every TagsOnModels row a base score of 5, both
+ * directions change a model's votable-tags list — so the job must bust
+ * modelVotableTagsCache for the affected models (else ≤TTL staleness after each run).
+ * This pins that contract.
+ */
+
+const { mockDbWrite, mockBust, mockGetTagRules } = vi.hoisted(() => ({
+  mockDbWrite: {
+    $queryRaw: vi.fn(),
+    $executeRaw: vi.fn().mockResolvedValue(undefined),
+  },
+  mockBust: vi.fn(),
+  mockGetTagRules: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
+vi.mock('~/server/redis/caches', () => ({ modelVotableTagsCache: { bust: mockBust } }));
+vi.mock('~/server/services/system-cache', () => ({ getTagRules: mockGetTagRules }));
+vi.mock('~/utils/logging', () => ({ createLogger: () => () => undefined }));
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (name: string, cron: string, fn: (e: unknown) => Promise<unknown>) => ({
+    name,
+    cron,
+    run: () => fn(undefined),
+  }),
+  getJobDate: vi.fn().mockResolvedValue([new Date(0), vi.fn()]),
+}));
+
+import { applyTagRules } from '~/server/jobs/apply-tag-rules';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbWrite.$executeRaw.mockResolvedValue(undefined);
+});
+
+describe('applyTagRules — votable-tags cache invalidation', () => {
+  it('busts the model cache for both inserted and deleted models on a Replace rule', async () => {
+    mockGetTagRules.mockResolvedValue([
+      { fromId: 1, toId: 2, fromTag: 'a', toTag: 'b', type: 'Replace', createdAt: new Date() },
+    ]);
+    // $queryRaw call order: MAX(image id), then appendTag models INSERT..RETURNING, then
+    // deleteTag models DELETE..RETURNING.
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([{ id: 100 }]) // MAX image id
+      .mockResolvedValueOnce([{ modelId: 7 }, { modelId: 9 }]) // inserted models
+      .mockResolvedValueOnce([{ modelId: 8 }]); // deleted models
+
+    await applyTagRules.run({});
+
+    expect(mockBust).toHaveBeenCalledWith([7, 9]);
+    expect(mockBust).toHaveBeenCalledWith([8]);
+    expect(mockBust).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not bust when an Append rule touches no models', async () => {
+    mockGetTagRules.mockResolvedValue([
+      { fromId: 1, toId: 2, fromTag: 'a', toTag: 'b', type: 'Append', createdAt: new Date() },
+    ]);
+    mockDbWrite.$queryRaw
+      .mockResolvedValueOnce([{ id: 100 }]) // MAX image id
+      .mockResolvedValueOnce([]); // inserted models — none
+
+    await applyTagRules.run({});
+
+    expect(mockBust).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/jobs/apply-tag-rules.ts
+++ b/src/server/jobs/apply-tag-rules.ts
@@ -2,6 +2,7 @@ import { createJob, getJobDate } from './job';
 import type { TagRule } from '~/server/services/system-cache';
 import { getTagRules } from '~/server/services/system-cache';
 import { dbWrite } from '~/server/db/client';
+import { modelVotableTagsCache } from '~/server/redis/caches';
 import { Prisma } from '@prisma/client';
 import { createLogger } from '~/utils/logging';
 
@@ -37,13 +38,18 @@ async function appendTag({ fromId, toId }: TagRule, maxImageId: number, since?: 
     : Prisma.empty;
 
   log('Updating models');
-  await dbWrite.$executeRaw`
+  // RETURNING the affected modelIds so we can bust their votable-tags cache — a newly
+  // applied TagsOnModels row is base score 5 in the ModelTag view → immediately votable.
+  const insertedModels = await dbWrite.$queryRaw<{ modelId: number }[]>`
     INSERT INTO "TagsOnModels"("modelId", "tagId")
     SELECT "modelId", ${fromId}
     FROM "TagsOnModels"
     WHERE "tagId" = ${toId} ${sinceClause}
-    ON CONFLICT ("modelId", "tagId") DO NOTHING;
+    ON CONFLICT ("modelId", "tagId") DO NOTHING
+    RETURNING "modelId";
   `;
+  if (insertedModels.length > 0)
+    await modelVotableTagsCache.bust(insertedModels.map((x) => x.modelId));
 
   log('Updating articles');
   await dbWrite.$executeRaw`
@@ -79,10 +85,15 @@ async function deleteTag({ toId }: TagRule, maxImageId: number, since?: Date) {
     : Prisma.empty;
 
   log('Deleting models');
-  await dbWrite.$executeRaw`
+  // RETURNING the affected modelIds so we can bust their votable-tags cache — removing
+  // the TagsOnModels row drops that tag from the model's votable list.
+  const deletedModels = await dbWrite.$queryRaw<{ modelId: number }[]>`
     DELETE FROM "TagsOnModels"
-    WHERE "tagId" = ${toId} ${sinceClause};
+    WHERE "tagId" = ${toId} ${sinceClause}
+    RETURNING "modelId";
   `;
+  if (deletedModels.length > 0)
+    await modelVotableTagsCache.bust(deletedModels.map((x) => x.modelId));
 
   log('Deleting articles');
   await dbWrite.$executeRaw`

--- a/src/server/redis/__tests__/model-votable-tags-cache.test.ts
+++ b/src/server/redis/__tests__/model-votable-tags-cache.test.ts
@@ -46,14 +46,24 @@ vi.mock('~/server/prom/client', () => ({
 
 import { createCachedObject } from '~/server/utils/cache-helpers';
 
-type ModelVotableTagsCacheItem = {
-  modelId: number;
-  tags: { tagId: number; tagName: string; tagType: string; score: number }[];
+type ModelTagComposite = {
+  tagId: number;
+  tagName: string;
+  tagType: string;
+  score: number;
+  upVotes: number;
+  downVotes: number;
 };
+type ModelVotableTagsCacheItem = { modelId: number; tags: ModelTagComposite[] };
 
 // db double: mirrors dbRead.modelTag.findMany({ where: { modelId: { in }, score: { gt: 0 } } }).
 const modelTagFindMany = vi.fn();
 
+// DIVERGENCE RISK: importing the real `modelVotableTagsCache` from caches.ts would drag in
+// its env/clickhouse/orchestrator import graph, so this replicates its lookupFn. Keep this a
+// FAITHFUL mirror of caches.ts `modelVotableTagsCache.lookupFn` — same select fields
+// (modelId + modelTagCompositeSelect: tagId/tagName/tagType/score/upVotes/downVotes), same
+// `orderBy: { score: 'desc' }`, same reduce/keying. If you change one, change both.
 function buildCache() {
   return createCachedObject<ModelVotableTagsCacheItem>({
     key: 'test:model-votable-tags' as never,
@@ -63,11 +73,21 @@ function buildCache() {
     lookupFn: async (ids) => {
       const modelTags = await modelTagFindMany({
         where: { modelId: { in: ids }, score: { gt: 0 } },
+        select: {
+          modelId: true,
+          tagId: true,
+          tagName: true,
+          tagType: true,
+          score: true,
+          upVotes: true,
+          downVotes: true,
+        },
+        orderBy: { score: 'desc' },
       });
-      return (modelTags as { modelId: number; [k: string]: unknown }[]).reduce((acc, tag) => {
+      return (modelTags as (ModelTagComposite & { modelId: number })[]).reduce((acc, tag) => {
         const { modelId, ...tagData } = tag;
         acc[modelId] ??= { modelId, tags: [] };
-        acc[modelId].tags.push(tagData as ModelVotableTagsCacheItem['tags'][number]);
+        acc[modelId].tags.push(tagData);
         return acc;
       }, {} as Record<number, ModelVotableTagsCacheItem>);
     },
@@ -86,10 +106,18 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe('modelVotableTagsCache dedup', () => {
+  const row = (modelId: number, tagId: number, tagName: string, score: number) => ({
+    modelId,
+    tagId,
+    tagName,
+    tagType: 'UserGenerated',
+    score,
+    upVotes: score,
+    downVotes: 0,
+  });
+
   it('hits the DB once, then serves the second fetch of the same model from cache', async () => {
-    modelTagFindMany.mockResolvedValue([
-      { modelId: 7, tagId: 304, tagName: 'nude', tagType: 'UserGenerated', score: 5 },
-    ]);
+    modelTagFindMany.mockResolvedValue([row(7, 304, 'nude', 5)]);
     const cache = buildCache();
 
     const first = await cache.fetch([7]);
@@ -97,24 +125,36 @@ describe('modelVotableTagsCache dedup', () => {
 
     // The expensive static read is issued exactly once across two fetches.
     expect(modelTagFindMany).toHaveBeenCalledTimes(1);
-    expect(first[7].tags.map((t) => t.tagId)).toEqual([304]);
-    expect(second[7].tags.map((t) => t.tagId)).toEqual([304]);
+    expect(first[7].tags).toEqual([
+      { tagId: 304, tagName: 'nude', tagType: 'UserGenerated', score: 5, upVotes: 5, downVotes: 0 },
+    ]);
+    expect(second[7].tags).toEqual(first[7].tags);
   });
 
   it('dedups duplicate ids within a single fetch and groups rows by modelId', async () => {
     modelTagFindMany.mockResolvedValue([
-      { modelId: 7, tagId: 304, tagName: 'nude', tagType: 'UserGenerated', score: 9 },
-      { modelId: 7, tagId: 5, tagName: 'anime', tagType: 'UserGenerated', score: 3 },
-      { modelId: 8, tagId: 6, tagName: 'realistic', tagType: 'UserGenerated', score: 1 },
+      row(7, 304, 'nude', 9),
+      row(7, 5, 'anime', 3),
+      row(8, 6, 'realistic', 1),
     ]);
     const cache = buildCache();
 
     const res = await cache.fetch([7, 7, 8]);
 
     expect(modelTagFindMany).toHaveBeenCalledTimes(1);
-    // Distinct ids only reach the DB lookup.
+    // Distinct ids only reach the DB lookup, with the full composite select + score-desc order.
     expect(modelTagFindMany).toHaveBeenCalledWith({
       where: { modelId: { in: [7, 8] }, score: { gt: 0 } },
+      select: {
+        modelId: true,
+        tagId: true,
+        tagName: true,
+        tagType: true,
+        score: true,
+        upVotes: true,
+        downVotes: true,
+      },
+      orderBy: { score: 'desc' },
     });
     expect(res[7].tags.map((t) => t.tagId).sort((a, b) => a - b)).toEqual([5, 304]);
     expect(res[8].tags.map((t) => t.tagId)).toEqual([6]);

--- a/src/server/redis/__tests__/model-votable-tags-cache.test.ts
+++ b/src/server/redis/__tests__/model-votable-tags-cache.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Dedup contract for the model votable-tags cache (the DB-load-reduction lever behind
+ * `tag.getVotableTags` on the model path).
+ *
+ * modelVotableTagsCache is a createCachedObject keyed by modelId. This test exercises the
+ * REAL cache mechanism against an in-memory packed-redis double + a mocked db, and pins
+ * the property the lever depends on: the static ModelTag-view read is cached, so a second
+ * fetch of the same modelId within the TTL does NOT re-issue the DB lookup. The lookupFn
+ * here is a byte-copy of modelVotableTagsCache's (caches.ts) — importing the real cache
+ * singleton would drag in caches.ts's whole env/clickhouse/orchestrator graph, so we assert
+ * the same reduce/keying logic against the same createCachedObject helper.
+ */
+
+// In-memory packed store so a cached value survives to the next fetch (real dedup).
+const store = new Map<string, unknown>();
+const mGetMock = vi.fn(async (keys: string[]) => keys.map((k) => store.get(k)));
+const setMock = vi.fn(async (key: string, value: unknown) => {
+  store.set(key, value);
+});
+const delMock = vi.fn(async () => undefined);
+const setNxMock = vi.fn().mockResolvedValue(true);
+
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: {
+      mGet: (...args: unknown[]) => mGetMock(...(args as [string[]])),
+      set: (...args: unknown[]) => setMock(...(args as [string, unknown])),
+    },
+    setNxKeepTtlWithEx: (...args: unknown[]) => setNxMock(...args),
+    del: (...args: unknown[]) => delMock(...args),
+  },
+  sysRedis: {},
+  REDIS_KEYS: { CACHE_LOCKS: 'caches:lock' },
+}));
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/prom/client', () => ({
+  cacheHitCounter: { inc: vi.fn() },
+  cacheMissCounter: { inc: vi.fn() },
+  cacheRevalidateCounter: { inc: vi.fn() },
+  cacheFailOpenDegradedCounter: { inc: vi.fn() },
+  cacheFailOpenOriginFetchCounter: { inc: vi.fn() },
+}));
+
+import { createCachedObject } from '~/server/utils/cache-helpers';
+
+type ModelVotableTagsCacheItem = {
+  modelId: number;
+  tags: { tagId: number; tagName: string; tagType: string; score: number }[];
+};
+
+// db double: mirrors dbRead.modelTag.findMany({ where: { modelId: { in }, score: { gt: 0 } } }).
+const modelTagFindMany = vi.fn();
+
+function buildCache() {
+  return createCachedObject<ModelVotableTagsCacheItem>({
+    key: 'test:model-votable-tags' as never,
+    idKey: 'modelId',
+    ttl: 3600,
+    staleWhileRevalidate: false,
+    lookupFn: async (ids) => {
+      const modelTags = await modelTagFindMany({
+        where: { modelId: { in: ids }, score: { gt: 0 } },
+      });
+      return (modelTags as { modelId: number; [k: string]: unknown }[]).reduce((acc, tag) => {
+        const { modelId, ...tagData } = tag;
+        acc[modelId] ??= { modelId, tags: [] };
+        acc[modelId].tags.push(tagData as ModelVotableTagsCacheItem['tags'][number]);
+        return acc;
+      }, {} as Record<number, ModelVotableTagsCacheItem>);
+    },
+  });
+}
+
+beforeEach(() => {
+  store.clear();
+  mGetMock.mockClear();
+  setMock.mockClear();
+  delMock.mockClear();
+  setNxMock.mockClear().mockResolvedValue(true);
+  modelTagFindMany.mockReset();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('modelVotableTagsCache dedup', () => {
+  it('hits the DB once, then serves the second fetch of the same model from cache', async () => {
+    modelTagFindMany.mockResolvedValue([
+      { modelId: 7, tagId: 304, tagName: 'nude', tagType: 'UserGenerated', score: 5 },
+    ]);
+    const cache = buildCache();
+
+    const first = await cache.fetch([7]);
+    const second = await cache.fetch([7]);
+
+    // The expensive static read is issued exactly once across two fetches.
+    expect(modelTagFindMany).toHaveBeenCalledTimes(1);
+    expect(first[7].tags.map((t) => t.tagId)).toEqual([304]);
+    expect(second[7].tags.map((t) => t.tagId)).toEqual([304]);
+  });
+
+  it('dedups duplicate ids within a single fetch and groups rows by modelId', async () => {
+    modelTagFindMany.mockResolvedValue([
+      { modelId: 7, tagId: 304, tagName: 'nude', tagType: 'UserGenerated', score: 9 },
+      { modelId: 7, tagId: 5, tagName: 'anime', tagType: 'UserGenerated', score: 3 },
+      { modelId: 8, tagId: 6, tagName: 'realistic', tagType: 'UserGenerated', score: 1 },
+    ]);
+    const cache = buildCache();
+
+    const res = await cache.fetch([7, 7, 8]);
+
+    expect(modelTagFindMany).toHaveBeenCalledTimes(1);
+    // Distinct ids only reach the DB lookup.
+    expect(modelTagFindMany).toHaveBeenCalledWith({
+      where: { modelId: { in: [7, 8] }, score: { gt: 0 } },
+    });
+    expect(res[7].tags.map((t) => t.tagId).sort((a, b) => a - b)).toEqual([5, 304]);
+    expect(res[8].tags.map((t) => t.tagId)).toEqual([6]);
+  });
+});

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -13,7 +13,12 @@ import type { ImageMetaProps } from '~/server/schema/image.schema';
 import type { ImageMetadata, VideoMetadata } from '~/server/schema/media.schema';
 import type { ContentDecorationCosmetic, WithClaimKey } from '~/server/selectors/cosmetic.selector';
 import type { ProfileImage } from '~/server/selectors/image.selector';
-import { type ImageTagComposite, imageTagCompositeSelect } from '~/server/selectors/tag.selector';
+import {
+  type ImageTagComposite,
+  imageTagCompositeSelect,
+  type ModelTagComposite,
+  modelTagCompositeSelect,
+} from '~/server/selectors/tag.selector';
 import type { EntityAccessDataType } from '~/server/services/common.service';
 import { getModelClient } from '~/server/services/orchestrator/models';
 import type { CachedObject } from '~/server/utils/cache-helpers';
@@ -1506,6 +1511,46 @@ export const imageTagsCache = createCachedObject<ImageTagsCacheItem>({
     }, {} as Record<number, ImageTagsCacheItem>);
 
     return result;
+  },
+});
+
+type ModelVotableTagsCacheItem = {
+  modelId: number;
+  tags: ModelTagComposite[];
+};
+
+// Caches the STATIC, user-independent portion of `tag.getVotableTags` for models:
+// the `ModelTag` composite-view read (tagId/tagName/tagType/score/upVotes/downVotes
+// for a model's score>0 tags). This is the mirror of `imageTagsCache` for the model
+// path — the image path was already cache-backed, the model path hit the DB on every
+// call. The per-user vote (`tag.vote`) is merged UNCACHED by getVotableTags from
+// `tagsOnModelsVote`, so no per-user data lives in this cache. Busted on model tag
+// votes (addTagVotes/removeTagVotes) exactly like imageTagsCache. 1h TTL / no SWR to
+// match imageTagsCache semantics; the model tag taxonomy is edit-rare so brief
+// cross-pod aggregate staleness within the TTL is imperceptible.
+export const modelVotableTagsCache = createCachedObject<ModelVotableTagsCacheItem>({
+  key: REDIS_KEYS.CACHES.MODEL_VOTABLE_TAGS,
+  idKey: 'modelId',
+  ttl: CacheTTL.hour,
+  staleWhileRevalidate: false,
+  lookupFn: async (ids, fromWrite) => {
+    const db = fromWrite ? dbWrite : dbRead;
+
+    const modelTags = await db.modelTag.findMany({
+      where: { modelId: { in: ids }, score: { gt: 0 } },
+      select: {
+        modelId: true,
+        ...modelTagCompositeSelect,
+      },
+      orderBy: { score: 'desc' },
+    });
+
+    return modelTags.reduce((acc, tag) => {
+      const { modelId, ...tagData } = tag;
+      acc[modelId] ??= { modelId, tags: [] };
+      acc[modelId].tags.push(tagData);
+      return acc;
+    }, {} as Record<number, ModelVotableTagsCacheItem>);
   },
 });
 

--- a/src/server/selectors/tag.selector.ts
+++ b/src/server/selectors/tag.selector.ts
@@ -24,6 +24,9 @@ export const modelTagCompositeSelect = Prisma.validator<Prisma.ModelTagSelect>()
   upVotes: true,
   downVotes: true,
 });
+export type ModelTagComposite = Prisma.ModelTagGetPayload<{
+  select: typeof modelTagCompositeSelect;
+}>;
 export const imageTagCompositeSelect = Prisma.validator<Prisma.ImageTagSelect>()({
   tagId: true,
   tagName: true,

--- a/src/server/services/__tests__/tag.service.unlisted.test.ts
+++ b/src/server/services/__tests__/tag.service.unlisted.test.ts
@@ -2,25 +2,37 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 const {
   imageTagsFetch,
+  imageTagsBust,
   tagCacheFetch,
   imageVotes,
   modelTagFindMany,
   modelVotes,
   modelVotableTagsFetch,
+  modelVotableTagsBust,
+  executeRaw,
+  dbWriteQueryRaw,
+  dbReadQueryRaw,
+  modelFindFirst,
 } = vi.hoisted(() => ({
   imageTagsFetch: vi.fn(),
+  imageTagsBust: vi.fn(),
   tagCacheFetch: vi.fn(),
   imageVotes: vi.fn().mockResolvedValue([]),
   modelTagFindMany: vi.fn(),
   modelVotes: vi.fn().mockResolvedValue([]),
   modelVotableTagsFetch: vi.fn(),
+  modelVotableTagsBust: vi.fn(),
+  executeRaw: vi.fn().mockResolvedValue(undefined),
+  dbWriteQueryRaw: vi.fn().mockResolvedValue([]),
+  dbReadQueryRaw: vi.fn().mockResolvedValue([{ count: 0 }]),
+  modelFindFirst: vi.fn().mockResolvedValue({ userId: 999 }),
 }));
 
 vi.mock('~/server/redis/caches', () => ({
-  imageTagsCache: { fetch: imageTagsFetch, bust: vi.fn() },
+  imageTagsCache: { fetch: imageTagsFetch, bust: imageTagsBust },
   // The model votable-tags cache now backs the static portion of the model path
   // (mirrors imageTagsCache for the image path).
-  modelVotableTagsCache: { fetch: modelVotableTagsFetch, bust: vi.fn() },
+  modelVotableTagsCache: { fetch: modelVotableTagsFetch, bust: modelVotableTagsBust },
   tagCache: { fetch: tagCacheFetch },
 }));
 vi.mock('~/server/db/client', () => ({
@@ -29,11 +41,31 @@ vi.mock('~/server/db/client', () => ({
     tagsOnModelsVote: { findMany: modelVotes },
     // Kept only to prove the model path NO LONGER reads the ModelTag view directly.
     modelTag: { findMany: modelTagFindMany },
+    model: { findFirst: modelFindFirst },
+    image: { findFirst: modelFindFirst },
+    $queryRaw: dbReadQueryRaw,
   },
-  dbWrite: {},
+  dbWrite: {
+    $executeRaw: executeRaw,
+    $queryRaw: dbWriteQueryRaw,
+  },
+}));
+// clearCache() fans out to the hidden-preferences caches — stub them so the vote
+// mutations don't reach real Redis/DB.
+vi.mock('~/server/services/user-preferences.service', () => ({
+  HiddenImages: { refreshCache: vi.fn() },
+  HiddenModels: { refreshCache: vi.fn() },
+  ImplicitHiddenImages: { refreshCache: vi.fn() },
 }));
 
-import { getVotableTags } from '~/server/services/tag.service';
+import {
+  addTagVotes,
+  addTags,
+  deleteTags,
+  disableTags,
+  getVotableTags,
+  removeTagVotes,
+} from '~/server/services/tag.service';
 
 const LOLI = 114467;
 const NUDE = 304;
@@ -193,5 +225,56 @@ describe('getVotableTags — image tags', () => {
   it('does not touch the model votable-tags cache', async () => {
     await getVotableTags({ type: 'image', id: 1, isModerator: false });
     expect(modelVotableTagsFetch).not.toHaveBeenCalled();
+  });
+});
+
+// The whole "always fresh / no behaviour change" (bucket-A) contract rests on busting
+// the model votable-tags cache on EVERY mutation that changes a model's score>0 ModelTag
+// rows. Pre-change the model path read the DB on every call, so a dropped bust is a NEW
+// ≤TTL staleness regression. These pin each bust so a refactor can't silently drop one.
+//
+// ModelTag view fact (containers/db/docker-init/02_all_dll.sql): each TagsOnModels row
+// contributes a BASE score of 5 (UNION with the vote sums), so an APPLIED tag is score>0
+// with no vote — hence addTags must bust, not just the vote paths.
+describe('getVotableTags — model votable-tags cache invalidation contract', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('addTagVotes(model) busts the model cache for the voted model', async () => {
+    await addTagVotes({ userId: 111, type: 'model', id: 42, tags: [304], vote: 1 });
+    expect(modelVotableTagsBust).toHaveBeenCalledWith(42);
+    expect(imageTagsBust).not.toHaveBeenCalled();
+  });
+
+  it('removeTagVotes(model) busts the model cache for the voted model', async () => {
+    await removeTagVotes({ userId: 111, type: 'model', id: 42, tags: [304] });
+    expect(modelVotableTagsBust).toHaveBeenCalledWith(42);
+    expect(imageTagsBust).not.toHaveBeenCalled();
+  });
+
+  it('addTags(model) busts the model cache for the applied modelIds (base score 5 → visible)', async () => {
+    await addTags({ tags: [304], entityIds: [7, 8], entityType: 'model' });
+    expect(modelVotableTagsBust).toHaveBeenCalledWith([7, 8]);
+  });
+
+  it('disableTags(model) busts the model cache for the affected modelIds', async () => {
+    await disableTags({ tags: [304], entityIds: [7, 8], entityType: 'model' });
+    expect(modelVotableTagsBust).toHaveBeenCalledWith([7, 8]);
+  });
+
+  it('deleteTags busts the model cache for models resolved from the ModelTag view', async () => {
+    // deleteTags reads affected images (1st $queryRaw) then affected models (2nd) before
+    // deleting the Tag row.
+    dbWriteQueryRaw.mockReset();
+    dbWriteQueryRaw
+      .mockResolvedValueOnce([]) // affected images
+      .mockResolvedValueOnce([{ modelId: 5 }, { modelId: 6 }]); // affected models
+    await deleteTags({ tags: [304] });
+    expect(modelVotableTagsBust).toHaveBeenCalledWith([5, 6]);
+  });
+
+  it('a vote on an IMAGE does not bust the model cache', async () => {
+    await addTagVotes({ userId: 111, type: 'image', id: 42, tags: [304], vote: 1 });
+    expect(modelVotableTagsBust).not.toHaveBeenCalled();
+    expect(imageTagsBust).toHaveBeenCalledWith(42);
   });
 });

--- a/src/server/services/__tests__/tag.service.unlisted.test.ts
+++ b/src/server/services/__tests__/tag.service.unlisted.test.ts
@@ -1,23 +1,33 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
-const { imageTagsFetch, tagCacheFetch, imageVotes, modelTagFindMany, modelVotes } = vi.hoisted(
-  () => ({
-    imageTagsFetch: vi.fn(),
-    tagCacheFetch: vi.fn(),
-    imageVotes: vi.fn().mockResolvedValue([]),
-    modelTagFindMany: vi.fn(),
-    modelVotes: vi.fn().mockResolvedValue([]),
-  })
-);
+const {
+  imageTagsFetch,
+  tagCacheFetch,
+  imageVotes,
+  modelTagFindMany,
+  modelVotes,
+  modelVotableTagsFetch,
+} = vi.hoisted(() => ({
+  imageTagsFetch: vi.fn(),
+  tagCacheFetch: vi.fn(),
+  imageVotes: vi.fn().mockResolvedValue([]),
+  modelTagFindMany: vi.fn(),
+  modelVotes: vi.fn().mockResolvedValue([]),
+  modelVotableTagsFetch: vi.fn(),
+}));
 
 vi.mock('~/server/redis/caches', () => ({
   imageTagsCache: { fetch: imageTagsFetch, bust: vi.fn() },
+  // The model votable-tags cache now backs the static portion of the model path
+  // (mirrors imageTagsCache for the image path).
+  modelVotableTagsCache: { fetch: modelVotableTagsFetch, bust: vi.fn() },
   tagCache: { fetch: tagCacheFetch },
 }));
 vi.mock('~/server/db/client', () => ({
   dbRead: {
     tagsOnImageVote: { findMany: imageVotes },
     tagsOnModelsVote: { findMany: modelVotes },
+    // Kept only to prove the model path NO LONGER reads the ModelTag view directly.
     modelTag: { findMany: modelTagFindMany },
   },
   dbWrite: {},
@@ -28,15 +38,21 @@ import { getVotableTags } from '~/server/services/tag.service';
 const LOLI = 114467;
 const NUDE = 304;
 
+// Shape of a cached ModelTag composite row (what modelVotableTagsCache stores).
 function modelTag(tagId: number, tagName: string) {
   return { tagId, tagName, tagType: 'UserGenerated', score: 5, upVotes: 5, downVotes: 0 };
+}
+
+// Prime the cache mock for model `id` with the given composite tags.
+function primeModelCache(id: number, tags: ReturnType<typeof modelTag>[]) {
+  modelVotableTagsFetch.mockResolvedValue({ [id]: { modelId: id, tags } });
 }
 
 describe('getVotableTags — model tags', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     modelVotes.mockResolvedValue([]);
-    modelTagFindMany.mockResolvedValue([modelTag(NUDE, 'nude'), modelTag(LOLI, 'loli')]);
+    primeModelCache(1, [modelTag(NUDE, 'nude'), modelTag(LOLI, 'loli')]);
     tagCacheFetch.mockResolvedValue({
       [NUDE]: { id: NUDE, name: 'nude', unlisted: undefined },
       [LOLI]: { id: LOLI, name: 'loli', unlisted: true },
@@ -57,16 +73,83 @@ describe('getVotableTags — model tags', () => {
   });
 
   it('leaves listed tags untouched', async () => {
-    modelTagFindMany.mockResolvedValue([modelTag(NUDE, 'nude')]);
+    primeModelCache(1, [modelTag(NUDE, 'nude')]);
     const tags = await getVotableTags({ type: 'model', id: 1, isModerator: false });
     expect(tags.map((t) => t.id)).toEqual([NUDE]);
   });
 
   it('does not hit the tag cache when there are no tags', async () => {
-    modelTagFindMany.mockResolvedValue([]);
+    primeModelCache(1, []);
     const tags = await getVotableTags({ type: 'model', id: 1, isModerator: false });
     expect(tags).toEqual([]);
     expect(tagCacheFetch).not.toHaveBeenCalled();
+  });
+
+  // The static (user-independent) hierarchy read is now served by the cache, NOT a
+  // direct DB read of the ModelTag view. This is the DB-load-reduction lever.
+  it('reads the static tags from the cache, never the ModelTag view directly', async () => {
+    await getVotableTags({ type: 'model', id: 1, isModerator: false });
+    expect(modelVotableTagsFetch).toHaveBeenCalledTimes(1);
+    expect(modelVotableTagsFetch).toHaveBeenCalledWith([1]);
+    expect(modelTagFindMany).not.toHaveBeenCalled();
+  });
+
+  // The output shape (fields + values) must be byte-identical to the pre-cache
+  // function: cached composite rows are mapped to the VotableTagModel shape.
+  it('produces the unchanged VotableTagModel shape from cached composite rows', async () => {
+    primeModelCache(1, [modelTag(NUDE, 'nude')]);
+    const tags = await getVotableTags({ type: 'model', id: 1, isModerator: true });
+    expect(tags).toEqual([
+      {
+        id: NUDE,
+        name: 'nude',
+        type: 'UserGenerated',
+        nsfwLevel: 0,
+        score: 5,
+        upVotes: 5,
+        downVotes: 0,
+      },
+    ]);
+  });
+
+  describe('per-user vote merge (no cross-user leakage)', () => {
+    beforeEach(() => {
+      // Same static tags for the model, cache shared across users.
+      primeModelCache(1, [modelTag(NUDE, 'nude')]);
+      tagCacheFetch.mockResolvedValue({ [NUDE]: { id: NUDE, name: 'nude' } });
+    });
+
+    it('merges each user OWN vote from their own tagsOnModelsVote read, uncached', async () => {
+      // User A upvoted; user B downvoted the SAME tag on the SAME model.
+      modelVotes.mockImplementation(async ({ where }: { where: { userId: number } }) => {
+        if (where.userId === 111) return [{ tagId: NUDE, vote: 1 }];
+        if (where.userId === 222) return [{ tagId: NUDE, vote: -1 }];
+        return [];
+      });
+
+      const aTags = await getVotableTags({ type: 'model', id: 1, userId: 111, isModerator: true });
+      const bTags = await getVotableTags({ type: 'model', id: 1, userId: 222, isModerator: true });
+
+      // Each user sees THEIR OWN vote — no bleed from the shared static cache.
+      expect(aTags.find((t) => t.id === NUDE)?.vote).toBe(1);
+      expect(bTags.find((t) => t.id === NUDE)?.vote).toBe(-1);
+
+      // The per-user vote read is scoped to that user + this model (uncached path).
+      expect(modelVotes).toHaveBeenNthCalledWith(1, {
+        where: { modelId: 1, userId: 111 },
+        select: { tagId: true, vote: true },
+      });
+      expect(modelVotes).toHaveBeenNthCalledWith(2, {
+        where: { modelId: 1, userId: 222 },
+        select: { tagId: true, vote: true },
+      });
+    });
+
+    it('an anonymous request never reads per-user votes', async () => {
+      const tags = await getVotableTags({ type: 'model', id: 1, isModerator: true });
+      expect(tags.find((t) => t.id === NUDE)?.vote).toBeUndefined();
+      expect(modelVotes).not.toHaveBeenCalled();
+    });
   });
 });
 
@@ -104,5 +187,11 @@ describe('getVotableTags — image tags', () => {
     const tags = await getVotableTags({ type: 'image', id: 1, isModerator: false });
     expect(tags.map((t) => t.id)).toEqual([NUDE]);
     expect(tagCacheFetch).not.toHaveBeenCalled();
+  });
+
+  // The image path must not touch the model cache.
+  it('does not touch the model votable-tags cache', async () => {
+    await getVotableTags({ type: 'image', id: 1, isModerator: false });
+    expect(modelVotableTagsFetch).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -42,6 +42,7 @@ import { withSpan } from '~/server/utils/otel-helpers';
 import {
   dataForModelsCache,
   modelTagCache,
+  modelVotableTagsCache,
   userBasicCache,
   userModelCountCache,
 } from '~/server/redis/caches';
@@ -1949,6 +1950,8 @@ export const upsertModel = async (
     }
 
     await modelTagCache.refresh(result.id);
+    // Model tag set changed → the votable-tags list (score>0 ModelTag rows) changed too.
+    await modelVotableTagsCache.bust(result.id);
     await preventReplicationLag('model', result.id);
     if (data.uploadType === ModelUploadType.Trained) {
       // getTrainingModelsByUserId filters by userId — flag that path so the
@@ -2044,6 +2047,7 @@ export const upsertModel = async (
     // Update search index if listing changes
     if (tagsOnModels || poiChanged || minorChanged) {
       await modelTagCache.refresh(result.id);
+      if (tagsOnModels) await modelVotableTagsCache.bust(result.id);
       await modelsSearchIndex.queueUpdate([{ id, action: SearchIndexUpdateQueueAction.Update }]);
     }
 
@@ -2904,6 +2908,8 @@ export const setModelsCategory = async ({
     `;
 
     await modelTagCache.refresh(modelIds);
+    // Applied tags land as score>0 ModelTag rows → refresh the votable-tags cache too.
+    await modelVotableTagsCache.bust(modelIds);
   } catch (error) {
     if (error instanceof TRPCError) throw error;
     throw throwDbError(error);

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -628,6 +628,10 @@ export const addTags = async ({ tags, entityIds, entityType, relationship }: Adj
       WHERE m."id" = ANY(${entityIds}::int[])
       ON CONFLICT DO NOTHING
     `);
+    // The ModelTag view gives every TagsOnModels row a base score of 5 (independent
+    // of votes), so a freshly-applied tag is immediately score>0 and would appear in
+    // getVotableTags — bust so the votable-tags cache reflects it within the TTL.
+    await modelVotableTagsCache.bust(entityIds);
   } else if (entityType === 'image') {
     const result = await dbWrite.$queryRaw<{ imageId: number; tagId: number }[]>(Prisma.sql`
       SELECT i."id" AS "imageId",  t."id" AS "tagId"
@@ -748,6 +752,9 @@ export const disableTags = async ({ tags, entityIds, entityType }: AdjustTagsSch
       WHERE "modelId" = ANY(${entityIds}::int[])
         AND ${tagIdMatch('tagId')}
     `);
+    // Precautionary: the ModelTag view does NOT currently filter on `disabled`, so this
+    // has no effect on getVotableTags output today — but bust to stay correct if the
+    // view ever starts honoring `disabled`, and to keep model mutations uniformly busting.
     await modelVotableTagsCache.bust(entityIds);
   } else if (entityType === 'image') {
     const toUpdate = await dbWrite.$queryRaw<{ imageId: number; tagId: number }[]>(Prisma.sql`
@@ -821,6 +828,17 @@ export const deleteTags = async ({ tags }: DeleteTagsSchema) => {
     )
   `);
 
+  // Get affected models before deletion — the ModelTag view JOINs Tag, so deleting the
+  // Tag row (cascading its TagsOnModels/TagsOnModelsVote rows) removes it from a model's
+  // votable list. Read the view directly (mirrors the ImageTag query above).
+  const affectedModels = await dbWrite.$queryRaw<{ modelId: number }[]>(Prisma.sql`
+    SELECT DISTINCT "modelId"
+    FROM "ModelTag"
+    WHERE "tagId" IN (
+      SELECT id FROM "Tag" WHERE ${tagMatch}
+    )
+  `);
+
   await dbWrite.$executeRaw(Prisma.sql`
     DELETE
     FROM "Tag"
@@ -831,6 +849,12 @@ export const deleteTags = async ({ tags }: DeleteTagsSchema) => {
   if (affectedImages.length > 0) {
     const imageIds = affectedImages.map((x) => x.imageId);
     await imageTagsCache.bust(imageIds);
+  }
+
+  // Bust cache for affected models
+  if (affectedModels.length > 0) {
+    const modelIds = affectedModels.map((x) => x.modelId);
+    await modelVotableTagsCache.bust(modelIds);
   }
 };
 

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -11,7 +11,11 @@ import {
 import { CacheTTL, constants } from '~/server/common/constants';
 import { NsfwLevel, TagSort } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
-import { imageTagsCache, tagCache as basicTagCache } from '~/server/redis/caches';
+import {
+  imageTagsCache,
+  modelVotableTagsCache,
+  tagCache as basicTagCache,
+} from '~/server/redis/caches';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import type {
   AdjustTagsSchema,
@@ -22,7 +26,6 @@ import type {
   GetVotableTagsSchema2,
   ModerateTagsSchema,
 } from '~/server/schema/tag.schema';
-import { modelTagCompositeSelect } from '~/server/selectors/tag.selector';
 import { getCategoryTags, getReplacedTagIds, getSystemTags } from '~/server/services/system-cache';
 import { upsertTagsOnImageNew } from '~/server/services/tagsOnImageNew.service';
 import {
@@ -349,12 +352,11 @@ export const getVotableTags = async ({
 }) => {
   let results: VotableTagModel[] = [];
   if (type === 'model') {
-    const tags = await dbRead.modelTag.findMany({
-      where: { modelId: id, score: { gt: 0 } },
-      select: modelTagCompositeSelect,
-      orderBy: { score: 'desc' },
-      // take,
-    });
+    // Static, user-independent read of the ModelTag composite view — cache-backed
+    // (mirrors the image path's imageTagsCache). The per-user vote is merged below,
+    // uncached, so nothing user-specific is cached here.
+    const cached = await modelVotableTagsCache.fetch([id]);
+    const tags = cached[id]?.tags ?? [];
     results.push(
       ...tags.map(({ tagId, tagName, tagType, ...tag }) => ({
         ...tag,
@@ -537,9 +539,11 @@ export const removeTagVotes = async ({ userId, type, id, tags }: TagVotingInput)
 
   await clearCache(userId, type);
 
-  // Bust image tags cache if voting on images
+  // Bust the votable-tags cache for the affected entity
   if (type === 'image') {
     await imageTagsCache.bust(id);
+  } else if (type === 'model') {
+    await modelVotableTagsCache.bust(id);
   }
 };
 
@@ -596,9 +600,11 @@ export const addTagVotes = async ({
     if (count > 0) await clearCache(userId, type); // Clear cache if it is
   }
 
-  // Bust image tags cache if voting on images
+  // Bust the votable-tags cache for the affected entity
   if (type === 'image') {
     await imageTagsCache.bust(id);
+  } else if (type === 'model') {
+    await modelVotableTagsCache.bust(id);
   }
 };
 // #endregion
@@ -742,6 +748,7 @@ export const disableTags = async ({ tags, entityIds, entityType }: AdjustTagsSch
       WHERE "modelId" = ANY(${entityIds}::int[])
         AND ${tagIdMatch('tagId')}
     `);
+    await modelVotableTagsCache.bust(entityIds);
   } else if (entityType === 'image') {
     const toUpdate = await dbWrite.$queryRaw<{ imageId: number; tagId: number }[]>(Prisma.sql`
       SELECT "imageId", "tagId"


### PR DESCRIPTION
## What

`tag.getVotableTags` (~34.6 calls/s at peak) is the single biggest DB total-exec-time consumer in a peak `pg_stat_statements` profile. Its **model path** read the `ModelTag` composite view (`dbRead.modelTag.findMany`) on **every call** — a user-INDEPENDENT, edit-rare static read — while the **image path was already cache-backed** by `imageTagsCache`.

This adds `modelVotableTagsCache` (a `createCachedObject` keyed by `modelId`, mirroring `imageTagsCache`) and routes the model path's static read through it.

## What's cached vs. per-user (byte-identical output)

- **Cached (static, user-independent):** the `ModelTag` composite rows for a model's `score > 0` tags — `tagId / tagName / tagType / score / upVotes / downVotes`. Keyed by `modelId`. This is exactly what `getVotableTags` mapped from `dbRead.modelTag.findMany`.
- **NOT cached (per-user):** the requesting user's own vote (`tag.vote`) is still merged **uncached** from `tagsOnModelsVote`, scoped to `{ modelId, userId }`. No user-specific data lives in the cache, so **no cross-user vote leakage** is possible and the response stays byte-identical per user.
- The `stripUnlistedTags` moderator filter and the final mapping are unchanged and run **after** the cache read, so output shape is identical.

## Invalidation / TTL

- **1h TTL, no SWR** — matches `imageTagsCache`'s existing semantics exactly.
- **`ModelTag.score` fact** (from the view DDL, `containers/db/docker-init/02_all_dll.sql`): `ModelTag` is a VIEW whose CTE gives **every `TagsOnModels` row a base `score = 5`** (UNION'd with the `TagsOnModelsVote` sums). So an **applied tag is `score > 0` with no vote** and appears in `getVotableTags` (which filters `score > 0`). Therefore applied-tag mutations — not just votes — must bust.
- **Busted on every mutation that changes a model's `score > 0` ModelTag rows** (the full `TagsOnModels`/`TagsOnModelsVote` writer surface was enumerated):
  - `tag.service`: `addTagVotes` / `removeTagVotes` (model), `addTags` (model — base-score-5), `deleteTags` (resolves affected models from the `ModelTag` view before the Tag delete cascades), `disableTags` (model — precautionary; the view doesn't currently filter `disabled`).
  - `model.service`: `upsertModel` (create + update-when-`tagsOnModels`) and `setModelsCategory`, co-located with the existing `modelTagCache.refresh` calls.
  - `jobs/apply-tag-rules` (automated 5-min job): the model `INSERT`/`DELETE INTO "TagsOnModels"` now `RETURNING "modelId"`, busting both the inserted (base-score-5 → newly votable) and deleted (no longer votable) model sets per rule.
- The requesting user always sees their own vote (uncached) and a freshly-busted aggregate after their own action; residual within-TTL staleness is only *other users'* votes on the same model — the identical freshness contract the image votable-tags path already runs in production.

## No flag gate

Follows the pure static read-through precedent (like `imageTagsCache`, which is unflagged). The cache stores only user-independent view data and is busted on the same mutations as the image path, so there's no residual per-user correctness risk needing a killswitch.

## Impact — cost/margin, not capacity

Bucket A (no behaviour change). The win is **DB total-exec-time / calls removed**, not pods. The DB runs at ~4% CPU, so this is a **pod-neutral cost/margin win, NOT a capacity win** — no pod-reduction is claimed.

## Tests

- Service test (`tag.service.unlisted.test.ts`): static read is served from the cache and **never** hits the `ModelTag` view directly; `VotableTagModel` output shape unchanged; two different users get their **own** votes (no cross-user leakage); anonymous requests read no per-user votes; image path untouched.
- **Invalidation-contract suite** (same file): pins that `addTagVotes` / `removeTagVotes` / `addTags` / `disableTags` (model) and `deleteTags` each call `modelVotableTagsCache.bust` with the right modelIds, and that an **image** vote does **not** bust the model cache — so a refactor can't silently drop a bust.
- **`apply-tag-rules` job test** (`jobs/__tests__/apply-tag-rules.test.ts`): a `Replace` rule busts both the inserted and deleted model sets; an `Append` rule touching no models busts nothing.
- Cache-mechanism test (`model-votable-tags-cache.test.ts`): a second `fetch` of the same model within the TTL does **not** re-hit the DB (mocked db, asserted call count); duplicate ids within a batch dedup and rows group by `modelId`; asserts the full composite `select` + `orderBy: score desc` reach the DB. (The lookupFn is a documented faithful mirror of `caches.ts` — importing the real singleton drags in its env/clickhouse graph.)
- `20/20` unit tests pass. Full `tsc --noEmit` (8 GB heap) completed clean (exit 0, 0 errors).

## Known limitation

`model.service.migrateResourceToCollection` (a rare admin/migration path) calls `tx.tagsOnModels.createMany` **inside a DB transaction** and is **not** busted. This is safe: it applies tags to **brand-new models it just created in the same tx**, whose ids can't have a pre-existing `modelVotableTagsCache` entry — the first `getVotableTags` read populates fresh — and doing a Redis write inside the DB transaction was not worth the contortion. Left documented rather than busted.

The rest of the `TagsOnModels`/`TagsOnModelsVote` writer surface (`tag.service` mutations, `model.service` `upsertModel`/`setModelsCategory`, and the `apply-tag-rules` job) is fully busted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
