### PR TITLE
refactor(api): make articles/collections endpoints public-data-only + edge-cacheable (remove appBlocksAuthor gate)

### DIFF
--- a/src/pages/api/v1/articles/[id].ts
+++ b/src/pages/api/v1/articles/[id].ts
@@ -3,21 +3,23 @@ import type { Session } from '~/types/session';
 import * as z from 'zod';
 
 import { getArticleById } from '~/server/services/article.service';
-import { isAppBlocksAuthorEnabled } from '~/server/services/app-blocks-flag';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
 
 /**
- * GET /api/v1/articles/[id] — public article detail.
+ * GET /api/v1/articles/[id] — public, edge-cacheable article detail.
  *
  * Wraps the EXISTING `getArticleById` service (the same one `articleRouter.getById`
- * uses). Visibility is enforced server-side: for a non-moderator it matches
- * `(publishedAt IS NOT NULL AND status = Published AND ingestion = Scanned) OR
- * userId = <session user>`. So a draft / unpublished / not-yet-scanned article is
- * reachable ONLY by its owner (authenticated) or a moderator; everyone else gets a
- * 404. Ownership comes solely from the authenticated session — never a client
- * param. A private article a non-owner requests is INDISTINGUISHABLE from a
- * non-existent one (both 404), so this is not an existence oracle.
+ * — a public procedure — uses for anonymous website visitors). This endpoint
+ * evaluates as anonymous ALWAYS (no `userId`/`isModerator` passed), so the service
+ * matches `publishedAt IS NOT NULL AND status = Published AND ingestion = Scanned`
+ * for EVERY caller: a draft / unpublished / not-yet-scanned article is a 404 for
+ * everyone, authed or not. There is no owner self-view branch here, so the
+ * response is a pure function of the id (+ region) — byte-identical for an
+ * anonymous caller and any authenticated caller — which makes the
+ * `MixedAuthEndpoint` wrapper's `public, s-maxage=300` edge caching safe. A
+ * private article is INDISTINGUISHABLE from a non-existent one (both 404), so this
+ * is not an existence oracle.
  */
 
 // Bound the coerced id to Postgres int4 (mirrors models/[id].ts): a huge numeric
@@ -30,16 +32,9 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
-  // App Blocks author-cohort gate — preview, cohort-only (mods + the
-  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → 403 with a clear
-  // preview message (invited-cohort DX: explain the restriction rather than an
-  // opaque 404), evaluated before the rate limit + service.
-  if (!(await isAppBlocksAuthorEnabled({ user }))) {
-    return res.status(403).json({
-      error: 'This API is in preview — access is restricted to Civitai moderators and app developers.',
-    });
-  }
-
+  // Conservative per-client rate limit (before the service call). Keys on
+  // CF-Connecting-IP / userId — guards only the cache-MISS path; the response
+  // body itself never varies by user.
   const rateLimit = await checkPublicApiRateLimit({ req, family: 'articles', userId: user?.id });
   if (!rateLimit.allowed) {
     res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
@@ -54,11 +49,10 @@ export default MixedAuthEndpoint(async function handler(
   const { id } = parsedParams.data;
 
   try {
-    const article = await getArticleById({
-      id,
-      userId: user?.id,
-      isModerator: user?.isModerator,
-    });
+    // Evaluate as anonymous — NEVER pass the session userId/isModerator. This
+    // pins published-only visibility for every caller (no owner-draft branch), so
+    // the response is caller-independent and edge-cacheable.
+    const article = await getArticleById({ id });
 
     // moderatorNsfwLevel is a moderator-only override the service includes for the
     // edit form; strip it so it never leaks through the public REST payload.

--- a/src/pages/api/v1/articles/[id].ts
+++ b/src/pages/api/v1/articles/[id].ts
@@ -5,6 +5,12 @@ import * as z from 'zod';
 import { getArticleById } from '~/server/services/article.service';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
+import {
+  publicBrowsingLevelsFlag,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
+import { Flags } from '~/shared/utils/flags';
+import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 
 /**
  * GET /api/v1/articles/[id] — public, edge-cacheable article detail.
@@ -20,6 +26,15 @@ import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
  * `MixedAuthEndpoint` wrapper's `public, s-maxage=300` edge caching safe. A
  * private article is INDISTINGUISHABLE from a non-existent one (both 404), so this
  * is not an existence oracle.
+ *
+ * Maturity: the cover image is clamped to the region-narrowed PUBLIC browsing
+ * ceiling (the SAME default the list endpoint uses, `publicBrowsingLevelsFlag`
+ * narrowed to `sfwBrowsingLevelsFlag` for restricted regions) — a cover above the
+ * ceiling is dropped so an anonymous SFW caller never receives mature cover art.
+ * `getArticleById` takes no browsing-level param, so the clamp is applied here as
+ * a post-service filter. It is derived ONLY from the region (`cf-ipcountry`) — it
+ * NEVER reads the caller's nsfw preference / browsingLevel cookie / session — so
+ * the response stays a pure function of id + region and remains edge-cacheable.
  */
 
 // Bound the coerced id to Postgres int4 (mirrors models/[id].ts): a huge numeric
@@ -48,6 +63,15 @@ export default MixedAuthEndpoint(async function handler(
 
   const { id } = parsedParams.data;
 
+  // Maturity/region ceiling — the SAME fixed PUBLIC default the list endpoint
+  // uses (articles/index.ts), narrowed to SFW for restricted regions. Region-
+  // derived ONLY (from `cf-ipcountry`); it NEVER reads the caller's nsfw
+  // preference/cookie/session, so the response stays a pure function of id +
+  // region and the `public` edge cache is leak-free.
+  const region = getRegion(req);
+  let browsingLevel = publicBrowsingLevelsFlag;
+  if (isRegionRestricted(region)) browsingLevel = sfwBrowsingLevelsFlag;
+
   try {
     // Evaluate as anonymous — NEVER pass the session userId/isModerator. This
     // pins published-only visibility for every caller (no owner-draft branch), so
@@ -57,6 +81,20 @@ export default MixedAuthEndpoint(async function handler(
     // moderatorNsfwLevel is a moderator-only override the service includes for the
     // edit form; strip it so it never leaks through the public REST payload.
     const { moderatorNsfwLevel, ...publicArticle } = article;
+
+    // Clamp the cover image to the region-narrowed public ceiling: drop a cover
+    // whose nsfwLevel is above the ceiling (mirroring the service's own
+    // "not viewable → coverImage: undefined" semantics) so an anon SFW caller
+    // never gets mature cover art. A level of 0 (unrated) is always allowed;
+    // otherwise it must intersect the clamped browsing level (the same bitwise
+    // test the list / collections endpoints use). Applied ONLY to a present
+    // cover, so an article with no viewable cover keeps its existing shape.
+    if (
+      publicArticle.coverImage?.nsfwLevel &&
+      !Flags.intersects(publicArticle.coverImage.nsfwLevel, browsingLevel)
+    ) {
+      publicArticle.coverImage = undefined;
+    }
 
     return res.status(200).json(publicArticle);
   } catch (e) {

--- a/src/pages/api/v1/articles/index.ts
+++ b/src/pages/api/v1/articles/index.ts
@@ -5,7 +5,6 @@ import * as z from 'zod';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { ArticleSort } from '~/server/common/enums';
 import { getArticles } from '~/server/services/article.service';
-import { isAppBlocksAuthorEnabled } from '~/server/services/app-blocks-flag';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { getNextPage } from '~/server/utils/pagination-helpers';
 import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
@@ -18,15 +17,19 @@ import { booleanString, commaDelimitedNumberArray } from '~/utils/zod-helpers';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 
 /**
- * GET /api/v1/articles — public list/search over articles.
+ * GET /api/v1/articles — public, edge-cacheable list/search over articles.
  *
  * Wraps the EXISTING `getArticles` service (the same function that powers the
- * website's article feed via `articleRouter.getInfinite`). Visibility is enforced
- * server-side by that service: for a non-owner / non-moderator caller it returns
- * ONLY `status = Published` + `ingestion = Scanned` articles and drops
- * `availability = Private` ones. This endpoint NEVER passes a client-supplied
- * userId — ownership is derived solely from the authenticated session (`user`),
- * so an unauthenticated caller can only ever see published, public articles.
+ * website's article feed via `articleRouter.getInfinite`). This endpoint serves
+ * PUBLIC data only: it ALWAYS evaluates as anonymous (`sessionUser: undefined`)
+ * and pins `forceHidePrivate: true`, so the article SET is a pure function of the
+ * URL (+ region) — an anonymous caller and any authenticated caller hitting the
+ * same URL get byte-identical data. That caller-independence is what makes the
+ * `MixedAuthEndpoint` wrapper's `public, s-maxage=300` edge caching safe (no
+ * cross-user leak). Nothing here widens or per-user-filters the result:
+ * `favorites`/`hidden` (own-engagement) and any owner self-view are NOT accepted.
+ * Visibility (published + scanned + non-private) is enforced server-side by the
+ * service for the anonymous evaluation.
  *
  * Pagination: composite keyset cursor (the article feed can't use offset paging —
  * ranked sorts need the `(sortValue, id)` tiebreaker). The opaque `cursor` string
@@ -41,11 +44,6 @@ export const config = {
   },
 };
 
-// favorites/hidden surface the CALLER's OWN engagement — meaningless (and gated
-// inside getArticles behind `if (sessionUser)`) without a session, so we 401 if
-// an unauthenticated caller requests them (mirrors models/index.ts).
-const authedOnlyOptions = ['favorites', 'hidden'] as const;
-
 const articlesEndpointSchema = z.object({
   limit: z.preprocess((val) => Number(val), z.number().min(1).max(100)).default(100),
   cursor: z.string().max(100).optional(),
@@ -53,8 +51,6 @@ const articlesEndpointSchema = z.object({
   sort: z.enum(ArticleSort).optional(),
   tags: commaDelimitedNumberArray().optional(),
   username: z.string().optional(),
-  favorites: booleanString().optional().default(false),
-  hidden: booleanString().optional().default(false),
   nsfw: booleanString().optional(),
 });
 
@@ -77,21 +73,9 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
-  // App Blocks author-cohort gate — this endpoint is a preview, reachable ONLY by
-  // the `appBlocksAuthor` cohort (mods via the static floor + the
-  // `app-blocks-author` Flipt cohort). Everyone else — INCLUDING anonymous (no
-  // user → not in cohort) — gets a 403 with a clear preview message: a deliberate
-  // DX choice for an invited cohort, so a caller who's been invited but isn't yet
-  // provisioned understands WHY they're blocked instead of hitting an opaque 404.
-  // Evaluated FIRST, before the rate limit + service, so no work leaks to a
-  // non-cohort caller.
-  if (!(await isAppBlocksAuthorEnabled({ user }))) {
-    return res.status(403).json({
-      error: 'This API is in preview — access is restricted to Civitai moderators and app developers.',
-    });
-  }
-
-  // Conservative per-client rate limit (before the expensive service call).
+  // Conservative per-client rate limit (before the expensive service call). The
+  // limiter keys on CF-Connecting-IP / userId — it only guards the cache-MISS
+  // path (varied-query scraping); the response body itself never varies by user.
   const rateLimit = await checkPublicApiRateLimit({ req, family: 'articles', userId: user?.id });
   if (!rateLimit.allowed) {
     res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
@@ -99,18 +83,16 @@ export default MixedAuthEndpoint(async function handler(
     return res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
   }
 
-  if (Object.keys(req.query).some((key) => (authedOnlyOptions as readonly string[]).includes(key)) && !user)
-    return res.status(401).json({ error: 'Unauthorized' });
-
   const parsedParams = articlesEndpointSchema.safeParse(req.query);
   if (!parsedParams.success) return res.status(400).json({ error: parsedParams.error });
 
-  const { limit, cursor, query, sort, tags, username, favorites, hidden, nsfw } = parsedParams.data;
+  const { limit, cursor, query, sort, tags, username, nsfw } = parsedParams.data;
 
   const parsedCursor = parseArticleCursor(cursor);
   if (parsedCursor === null) return res.status(400).json({ error: 'Invalid cursor' });
 
-  // Maturity/region ceiling — identical derivation to models/index.ts.
+  // Maturity/region ceiling — identical derivation to models/index.ts. This is
+  // the ONE legitimate response variation (region-derived); the CDN keys on it.
   const region = getRegion(req);
   let browsingLevel = !nsfw ? publicBrowsingLevelsFlag : allBrowsingLevelsFlag;
   if (isRegionRestricted(region)) browsingLevel = sfwBrowsingLevelsFlag;
@@ -122,8 +104,6 @@ export default MixedAuthEndpoint(async function handler(
       query,
       tags,
       username,
-      favorites,
-      hidden,
       // AllTime + published: getArticles requires a defined period/periodMode; this
       // pins the extra `publishedAt IS NOT NULL AND status = Published` guard on top
       // of the service's own non-owner visibility gate.
@@ -131,7 +111,11 @@ export default MixedAuthEndpoint(async function handler(
       periodMode: 'published',
       sort: sort ?? ArticleSort.Newest,
       browsingLevel,
-      sessionUser: user,
+      // Always evaluate as anonymous so the article SET is a pure function of the
+      // URL (+ region) — auth can never widen or per-user-filter it. Combined with
+      // `forceHidePrivate` this yields published + scanned + non-private for
+      // everyone, making the response safe to `public`-cache at the edge.
+      sessionUser: undefined,
       include: [],
       // Public scriptable surface: NEVER expand to `availability = Private`
       // articles, even when `?username=` is set (which normally lifts the

--- a/src/pages/api/v1/collections/[id].ts
+++ b/src/pages/api/v1/collections/[id].ts
@@ -7,7 +7,6 @@ import {
   getCollectionById,
   getUserCollectionPermissionsById,
 } from '~/server/services/collection.service';
-import { isAppBlocksAuthorEnabled } from '~/server/services/app-blocks-flag';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
 import {
@@ -19,16 +18,18 @@ import { CollectionReadConfiguration } from '~/shared/utils/prisma/enums';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 
 /**
- * GET /api/v1/collections/[id] — public collection detail.
+ * GET /api/v1/collections/[id] — public, edge-cacheable collection detail.
  *
  * VISIBILITY (existence-leak-safe): the read decision reuses the EXISTING
- * `getUserCollectionPermissionsById` (the same authority `getCollectionByIdHandler`
- * uses) — `read` is true for Public/Unlisted collections and for the
- * owner/contributor/moderator of a private one. A caller without read permission,
- * OR a non-existent collection, gets the SAME bare 404, so this is not a
- * private-collection existence oracle. `getCollectionById` itself does NO gating,
- * so this permission check is REQUIRED before calling it. Ownership comes solely
- * from the authenticated session — never a client param.
+ * `getUserCollectionPermissionsById`, evaluated as ANONYMOUS (no `userId`/
+ * `isModerator`), so `read` is true ONLY for a Public/Unlisted collection — for
+ * EVERY caller, authed or not. A private collection, OR a non-existent one, gets
+ * the SAME bare 404, so this is not a private-collection existence oracle. Because
+ * the permission decision never depends on WHO calls, the response is a pure
+ * function of the id (+ region) — byte-identical for anonymous and authenticated
+ * callers — which makes the `MixedAuthEndpoint` wrapper's `public, s-maxage=300`
+ * edge caching safe. `getCollectionById` itself does NO gating, so this permission
+ * check is REQUIRED before calling it.
  *
  * Maturity: the cover image is clamped to the region-narrowed browsing ceiling.
  */
@@ -40,16 +41,9 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
-  // App Blocks author-cohort gate — preview, cohort-only (mods + the
-  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → 403 with a clear
-  // preview message (invited-cohort DX: explain the restriction rather than an
-  // opaque 404), evaluated before the rate limit + service.
-  if (!(await isAppBlocksAuthorEnabled({ user }))) {
-    return res.status(403).json({
-      error: 'This API is in preview — access is restricted to Civitai moderators and app developers.',
-    });
-  }
-
+  // Conservative per-client rate limit (before the service call). Keys on
+  // CF-Connecting-IP / userId — guards only the cache-MISS path; the response
+  // body itself never varies by user.
   const rateLimit = await checkPublicApiRateLimit({ req, family: 'collections', userId: user?.id });
   if (!rateLimit.allowed) {
     res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
@@ -69,13 +63,11 @@ export default MixedAuthEndpoint(async function handler(
     : allBrowsingLevelsFlag;
 
   try {
-    // VISIBILITY gate. No read permission → 404 (indistinguishable from a
-    // non-existent collection — no existence oracle).
-    const permissions = await getUserCollectionPermissionsById({
-      id,
-      userId: user?.id,
-      isModerator: user?.isModerator,
-    });
+    // VISIBILITY gate, evaluated as ANONYMOUS — NEVER pass the session
+    // userId/isModerator. `read` is true only for Public/Unlisted, so a private
+    // collection → 404 for EVERY caller (indistinguishable from a non-existent
+    // one — no existence oracle), and the decision is caller-independent.
+    const permissions = await getUserCollectionPermissionsById({ id });
     if (!permissions.read) return res.status(404).json({ error: `No collection with id ${id}` });
 
     // getCollectionById throws NOT_FOUND when the row is gone → handleEndpointError

--- a/src/pages/api/v1/collections/[id].ts
+++ b/src/pages/api/v1/collections/[id].ts
@@ -10,7 +10,7 @@ import {
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
 import {
-  allBrowsingLevelsFlag,
+  publicBrowsingLevelsFlag,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 import { Flags } from '~/shared/utils/flags';
@@ -31,7 +31,14 @@ import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
  * edge caching safe. `getCollectionById` itself does NO gating, so this permission
  * check is REQUIRED before calling it.
  *
- * Maturity: the cover image is clamped to the region-narrowed browsing ceiling.
+ * Maturity: the cover image is clamped to the region-narrowed PUBLIC browsing
+ * ceiling — the SAME fixed default the list endpoint uses
+ * (`publicBrowsingLevelsFlag`, narrowed to `sfwBrowsingLevelsFlag` for restricted
+ * regions), NOT `allBrowsingLevels`. A cover above the ceiling is nulled so an
+ * anonymous SFW caller never receives mature cover art. The clamp is derived ONLY
+ * from the region (`cf-ipcountry`); it NEVER reads the caller's nsfw preference /
+ * browsingLevel cookie / session, so the response stays a pure function of id +
+ * region and the `public` edge cache is leak-free.
  */
 
 export const schema = z.object({ id: z.coerce.number().int().gt(0).lte(2147483647) });
@@ -57,10 +64,13 @@ export default MixedAuthEndpoint(async function handler(
 
   const { id } = parsedParams.data;
 
+  // Maturity/region ceiling — the SAME fixed PUBLIC default the list endpoint
+  // uses (collections/index.ts), narrowed to SFW for restricted regions. Region-
+  // derived ONLY (from `cf-ipcountry`); NEVER the caller's nsfw preference/cookie/
+  // session, so the response stays a pure function of id + region (edge-cacheable).
   const region = getRegion(req);
-  const browsingLevel = isRegionRestricted(region)
-    ? sfwBrowsingLevelsFlag
-    : allBrowsingLevelsFlag;
+  let browsingLevel = publicBrowsingLevelsFlag;
+  if (isRegionRestricted(region)) browsingLevel = sfwBrowsingLevelsFlag;
 
   try {
     // VISIBILITY gate, evaluated as ANONYMOUS — NEVER pass the session

--- a/src/pages/api/v1/collections/index.ts
+++ b/src/pages/api/v1/collections/index.ts
@@ -7,9 +7,7 @@ import { CollectionSort } from '~/server/common/enums';
 import {
   getAllCollections,
   getCollectionItemCount,
-  getUserCollectionsWithPermissions,
 } from '~/server/services/collection.service';
-import { isAppBlocksAuthorEnabled } from '~/server/services/app-blocks-flag';
 import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
 import { getNextPage } from '~/server/utils/pagination-helpers';
 import { checkPublicApiRateLimit } from '~/server/utils/public-api-rate-limit';
@@ -28,19 +26,21 @@ import { booleanString } from '~/utils/zod-helpers';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 
 /**
- * GET /api/v1/collections — public list/search over collections.
+ * GET /api/v1/collections — public, edge-cacheable list/search over collections.
  *
- * Two modes, both wrapping EXISTING services (no reimplemented business logic):
- *   - default (public): `getAllCollections`, whose privacy is PINNED to
- *     `[Public]` for any non-moderator caller (the service forces this itself),
- *     so an unauthenticated caller only ever sees Public collections.
- *   - `mine=true` (authenticated only → 401 otherwise): the caller's OWN
- *     collections via `getUserCollectionsWithPermissions`, keyed on the SESSION
- *     user id — never a client-supplied userId.
+ * Wraps the EXISTING `getAllCollections` service (no reimplemented business
+ * logic). This endpoint serves PUBLIC data only: privacy is pinned to `[Public]`
+ * AND the caller identity is dropped (`user: undefined`), so the service's own
+ * clamp forces Public UNCONDITIONALLY — an anonymous caller and any authenticated
+ * caller hitting the same URL get byte-identical data. That caller-independence is
+ * what makes the `MixedAuthEndpoint` wrapper's `public, s-maxage=300` edge caching
+ * safe (no cross-user leak). There is NO `mine=` mode here — own-collection
+ * discovery is inherently per-user (uncacheable + authoring), not public
+ * discovery. A private collection is therefore unreachable here.
  *
- * A private collection is therefore unreachable here for a non-owner. Maturity is
- * clamped to the region-narrowed browsing ceiling (a collection / cover above the
- * ceiling is dropped or its cover nulled), matching the other public endpoints.
+ * Maturity is clamped to the region-narrowed browsing ceiling (a collection /
+ * cover above the ceiling is dropped or its cover nulled), matching the other
+ * public endpoints — the one legitimate region-derived response variation.
  *
  * Envelope: `{ items, metadata: { nextCursor, nextPage } }` (keyset cursor on the
  * collection id, id DESC), consistent with the other public v1 endpoints.
@@ -57,7 +57,6 @@ const collectionsEndpointSchema = z.object({
   cursor: z.coerce.number().int().positive().optional(),
   query: z.string().trim().max(100).optional(),
   sort: z.enum(CollectionSort).optional(),
-  mine: booleanString().optional().default(false),
   nsfw: booleanString().optional(),
 });
 
@@ -86,16 +85,9 @@ export default MixedAuthEndpoint(async function handler(
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
-  // App Blocks author-cohort gate — preview, cohort-only (mods + the
-  // `app-blocks-author` Flipt cohort). Anonymous / non-cohort → 403 with a clear
-  // preview message (invited-cohort DX: explain the restriction rather than an
-  // opaque 404), evaluated before the rate limit + service.
-  if (!(await isAppBlocksAuthorEnabled({ user }))) {
-    return res.status(403).json({
-      error: 'This API is in preview — access is restricted to Civitai moderators and app developers.',
-    });
-  }
-
+  // Conservative per-client rate limit (before the expensive service call). The
+  // limiter keys on CF-Connecting-IP / userId — it only guards the cache-MISS
+  // path (varied-query scraping); the response body itself never varies by user.
   const rateLimit = await checkPublicApiRateLimit({ req, family: 'collections', userId: user?.id });
   if (!rateLimit.allowed) {
     res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
@@ -106,9 +98,7 @@ export default MixedAuthEndpoint(async function handler(
   const parsedParams = collectionsEndpointSchema.safeParse(req.query);
   if (!parsedParams.success) return res.status(400).json({ error: parsedParams.error });
 
-  const { limit, cursor, query, sort, mine, nsfw } = parsedParams.data;
-
-  if (mine && !user) return res.status(401).json({ error: 'Unauthorized' });
+  const { limit, cursor, query, sort, nsfw } = parsedParams.data;
 
   const region = getRegion(req);
   let browsingLevel = !nsfw ? publicBrowsingLevelsFlag : allBrowsingLevelsFlag;
@@ -122,58 +112,6 @@ export default MixedAuthEndpoint(async function handler(
       : null;
 
   try {
-    if (mine && user) {
-      // Own collections. The service returns the full owned set (no DB paging);
-      // apply the name filter + keyset (id DESC) slice in-memory. A user's own
-      // collection set is bounded.
-      const owned = await getUserCollectionsWithPermissions({
-        input: { userId: user.id, contributingOnly: true },
-      });
-
-      const needle = query?.toLowerCase();
-      const filtered = owned
-        .filter((c) => (needle ? c.name.toLowerCase().includes(needle) : true))
-        .filter((c) => (cursor ? c.id < cursor : true))
-        .sort((a, b) => b.id - a.id);
-
-      let page = filtered;
-      let nextCursor: number | undefined;
-      if (page.length > limit) {
-        page = page.slice(0, limit);
-        nextCursor = page[page.length - 1]?.id;
-      }
-
-      const ids = page.map((c) => c.id);
-      const countRows = await getCollectionItemCount({
-        collectionIds: ids,
-        status: CollectionItemStatus.ACCEPTED,
-      });
-      const countMap = new Map(countRows.map((c) => [c.id, Number(c.count)]));
-
-      const items: CollectionListItem[] = page.map((c) => ({
-        id: c.id,
-        name: c.name,
-        description: c.description ?? null,
-        type: c.type ?? null,
-        nsfwLevel: null,
-        read: c.read,
-        isPublic: c.read === CollectionReadConfiguration.Public,
-        itemCount: countMap.get(c.id) ?? 0,
-        coverImageUrl: coverUrl(
-          c.image
-            ? { url: c.image.url, type: c.image.type, nsfwLevel: c.image.nsfwLevel }
-            : null
-        ),
-        user: { id: user.id, username: user.username ?? null },
-      }));
-
-      const nextCursorStr = nextCursor !== undefined ? String(nextCursor) : undefined;
-      const { nextPage } = getNextPage({ req, nextCursor: nextCursorStr });
-      return res
-        .status(200)
-        .json({ items, metadata: { nextCursor: nextCursor ?? undefined, nextPage } });
-    }
-
     // Public discovery. The keyset cursor is id-based, which only tracks the
     // default `createdAt DESC` ordering. Under `sort=MostContributors`
     // `getAllCollections` orders by contributor `_count` — an id cursor there
@@ -202,7 +140,11 @@ export default MixedAuthEndpoint(async function handler(
         sort,
         privacy: [CollectionReadConfiguration.Public],
       },
-      user,
+      // Evaluate as anonymous — NEVER pass the session user. Combined with the
+      // explicit `privacy: [Public]`, the service's own clamp forces Public
+      // UNCONDITIONALLY (even the moderator override can't widen), so the result
+      // set is caller-independent and edge-cacheable.
+      user: undefined,
       select: {
         id: true,
         name: true,

--- a/src/tests/api/v1/articles/index.test.ts
+++ b/src/tests/api/v1/articles/index.test.ts
@@ -198,6 +198,8 @@ describe('GET /api/v1/articles (list)', () => {
 
     expect(res._getStatusCode()).toBe(429);
     expect(res._getHeader('Retry-After')).toBe('42');
+    // A 429 must NEVER be edge-cached (per-IP/per-user) — a cached public 429 would be served fleet-wide.
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
     expect(mockGetArticles).not.toHaveBeenCalled();
   });
 });
@@ -268,6 +270,7 @@ describe('GET /api/v1/articles/[id] (detail)', () => {
 
     expect(res._getStatusCode()).toBe(429);
     expect(res._getHeader('Retry-After')).toBe('10');
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
     expect(mockGetArticleById).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/api/v1/articles/index.test.ts
+++ b/src/tests/api/v1/articles/index.test.ts
@@ -4,14 +4,12 @@ import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 
-// Hoisted mocks for the wrapped service + the rate limiter + the author-cohort gate.
-const { mockGetArticles, mockGetArticleById, mockRateLimit, mockIsAppBlocksAuthorEnabled } =
-  vi.hoisted(() => ({
-    mockGetArticles: vi.fn(),
-    mockGetArticleById: vi.fn(),
-    mockRateLimit: vi.fn(),
-    mockIsAppBlocksAuthorEnabled: vi.fn(),
-  }));
+// Hoisted mocks for the wrapped service + the rate limiter.
+const { mockGetArticles, mockGetArticleById, mockRateLimit } = vi.hoisted(() => ({
+  mockGetArticles: vi.fn(),
+  mockGetArticleById: vi.fn(),
+  mockRateLimit: vi.fn(),
+}));
 
 vi.mock('~/server/services/article.service', () => ({
   getArticles: mockGetArticles,
@@ -20,13 +18,6 @@ vi.mock('~/server/services/article.service', () => ({
 
 vi.mock('~/server/utils/public-api-rate-limit', () => ({
   checkPublicApiRateLimit: mockRateLimit,
-}));
-
-// The App Blocks author-cohort gate — mock it so tests never touch real Flipt.
-// Default: in-cohort (true) so the existing happy-path assertions still exercise
-// the handler body; the dark-404 tests flip it to false.
-vi.mock('~/server/services/app-blocks-flag', () => ({
-  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
 }));
 
 // MixedAuthEndpoint → passthrough that injects the test session user (req.user).
@@ -113,64 +104,6 @@ function createMocks({
 beforeEach(() => {
   vi.clearAllMocks();
   mockRateLimit.mockResolvedValue({ allowed: true });
-  // Default: caller IS in the author cohort (mod / app-dev-tester) so the
-  // existing behavioural tests reach the handler body. Dark-404 tests override.
-  mockIsAppBlocksAuthorEnabled.mockResolvedValue(true);
-});
-
-const PREVIEW_MESSAGE =
-  'This API is in preview — access is restricted to Civitai moderators and app developers.';
-
-describe('GET /api/v1/articles — author-cohort gate (403 preview)', () => {
-  it('SECURITY: a non-cohort authed user gets a 403 + preview message and NEITHER the rate limiter NOR the service runs (list)', async () => {
-    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
-    const { req, res } = createMocks({ query: {}, user: { id: 7, isModerator: false } });
-
-    await listHandler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
-    expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: { id: 7, isModerator: false } });
-    expect(mockRateLimit).not.toHaveBeenCalled();
-    expect(mockGetArticles).not.toHaveBeenCalled();
-  });
-
-  it('SECURITY: an anonymous caller gets a 403 + preview message (list)', async () => {
-    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
-    const { req, res } = createMocks({ query: {} });
-
-    await listHandler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
-    expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: undefined });
-    expect(mockRateLimit).not.toHaveBeenCalled();
-    expect(mockGetArticles).not.toHaveBeenCalled();
-  });
-
-  it('SECURITY: a non-cohort authed user gets a 403 + preview message (detail)', async () => {
-    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
-    const { req, res } = createMocks({ query: { id: '3' }, user: { id: 7, isModerator: false } });
-
-    await detailHandler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
-    expect(mockRateLimit).not.toHaveBeenCalled();
-    expect(mockGetArticleById).not.toHaveBeenCalled();
-  });
-
-  it('SECURITY: an anonymous caller gets a 403 + preview message (detail)', async () => {
-    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
-    const { req, res } = createMocks({ query: { id: '3' } });
-
-    await detailHandler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
-    expect(mockRateLimit).not.toHaveBeenCalled();
-    expect(mockGetArticleById).not.toHaveBeenCalled();
-  });
 });
 
 describe('GET /api/v1/articles (list)', () => {
@@ -190,50 +123,62 @@ describe('GET /api/v1/articles (list)', () => {
     expect(body.metadata.nextPage).toContain('cursor=123.5%7C7');
   });
 
-  it('SECURITY: unauthenticated call passes sessionUser=undefined and NEVER a client-supplied userId (visibility delegated to the gated service)', async () => {
+  it('CACHEABILITY: the response is caller-independent — an authed caller gets byte-identical data to an anonymous caller for the same URL, and the service is called as anonymous in BOTH cases', async () => {
+    mockGetArticles.mockResolvedValue({
+      items: [{ id: 1, title: 'a' }],
+      nextCursor: undefined,
+    });
+
+    const anon = createMocks({ query: { limit: '5' } });
+    await listHandler(anon.req, anon.res);
+
+    const authed = createMocks({ query: { limit: '5' }, user: { id: 42, username: 'me', isModerator: true } });
+    await listHandler(authed.req, authed.res);
+
+    // Same URL → byte-identical response body regardless of caller identity.
+    expect(anon.res._getStatusCode()).toBe(200);
+    expect(authed.res._getStatusCode()).toBe(200);
+    expect(authed.res._getJSONData()).toEqual(anon.res._getJSONData());
+
+    // The service is invoked with identical, PURELY-PUBLIC args in both calls —
+    // no per-user widening (sessionUser is undefined even for the authed mod).
+    const anonArgs = mockGetArticles.mock.calls[0][0];
+    const authedArgs = mockGetArticles.mock.calls[1][0];
+    expect(anonArgs.sessionUser).toBeUndefined();
+    expect(authedArgs.sessionUser).toBeUndefined();
+    expect(authedArgs).toEqual(anonArgs);
+  });
+
+  it('SECURITY: passes sessionUser=undefined + forceHidePrivate=true and NEVER a client-supplied userId/favorites/hidden (visibility evaluated as anonymous)', async () => {
     mockGetArticles.mockResolvedValue({ items: [], nextCursor: undefined });
-    // A client tries to inject userId — the endpoint schema doesn't expose it.
-    const { req, res } = createMocks({ query: { userId: '5', userIds: '5,6' } });
+    // A client tries to inject per-user / owner-widening params — the endpoint
+    // schema doesn't expose any of them, so they can't reach the service.
+    const { req, res } = createMocks({
+      query: { userId: '5', userIds: '5,6', favorites: 'true', hidden: 'true', username: 'someUser' },
+      user: { id: 5, username: 'someUser' },
+    });
 
     await listHandler(req, res);
 
     expect(res._getStatusCode()).toBe(200);
     const args = mockGetArticles.mock.calls[0][0];
+    // Anonymous evaluation — no session identity flows to the service.
     expect(args.sessionUser).toBeUndefined();
     expect(args.userIds).toBeUndefined();
     expect(args.userId).toBeUndefined();
+    // Own-engagement filters are NOT accepted (removed from the public surface).
+    expect(args.favorites).toBeUndefined();
+    expect(args.hidden).toBeUndefined();
+    // Even with a username filter (which normally lifts the private-drop for an
+    // owner self-view), forceHidePrivate is pinned → availability=Private always
+    // dropped, for EVERY caller.
+    expect(args.username).toBe('someUser');
+    expect(args.forceHidePrivate).toBe(true);
     // Non-nsfw + non-restricted region → public browsing ceiling.
     expect(args.browsingLevel).toBe(publicBrowsingLevelsFlag);
     // published-only guard pinned on top of the service's own gate.
     expect(args.period).toBe('AllTime');
     expect(args.periodMode).toBe('published');
-    expect(args.favorites).toBe(false);
-    expect(args.hidden).toBe(false);
-  });
-
-  it('SECURITY: anon ?username=X forces forceHidePrivate=true so private-availability articles are never listed', async () => {
-    mockGetArticles.mockResolvedValue({ items: [], nextCursor: undefined });
-    const { req, res } = createMocks({ query: { username: 'someUser' } });
-
-    await listHandler(req, res);
-
-    expect(res._getStatusCode()).toBe(200);
-    const args = mockGetArticles.mock.calls[0][0];
-    // Even with a username filter (which normally lifts the private-drop for an
-    // owner self-view), the REST surface pins forceHidePrivate → the service
-    // ALWAYS drops availability=Private articles.
-    expect(args.username).toBe('someUser');
-    expect(args.forceHidePrivate).toBe(true);
-    expect(args.sessionUser).toBeUndefined();
-  });
-
-  it('401s when an unauthenticated caller requests favorites/hidden (own-engagement, authed-only)', async () => {
-    const { req, res } = createMocks({ query: { favorites: 'true' } });
-
-    await listHandler(req, res);
-
-    expect(res._getStatusCode()).toBe(401);
-    expect(mockGetArticles).not.toHaveBeenCalled();
   });
 
   it('400s on a malformed cursor', async () => {
@@ -253,20 +198,20 @@ describe('GET /api/v1/articles (list)', () => {
 
     expect(res._getStatusCode()).toBe(429);
     expect(res._getHeader('Retry-After')).toBe('42');
-    expect(res._getHeader('Cache-Control')).toBe('no-store');
     expect(mockGetArticles).not.toHaveBeenCalled();
   });
 });
 
 describe('GET /api/v1/articles/[id] (detail)', () => {
-  it('strips moderatorNsfwLevel and returns the article; passes session identity (undefined when unauthed)', async () => {
+  it('strips moderatorNsfwLevel and evaluates as anonymous (NEVER passes session userId/isModerator)', async () => {
     mockGetArticleById.mockResolvedValue({
       id: 3,
       title: 't',
       moderatorNsfwLevel: 8,
       nsfwLevel: 1,
     });
-    const { req, res } = createMocks({ query: { id: '3' } });
+    // Even an authed moderator caller must be evaluated as anonymous.
+    const { req, res } = createMocks({ query: { id: '3' }, user: { id: 9, isModerator: true } });
 
     await detailHandler(req, res);
 
@@ -274,11 +219,14 @@ describe('GET /api/v1/articles/[id] (detail)', () => {
     const body = res._getJSONData();
     expect(body).toEqual({ id: 3, title: 't', nsfwLevel: 1 });
     expect(body.moderatorNsfwLevel).toBeUndefined();
+    // No session identity reaches the service → published-only visibility for all.
     const args = mockGetArticleById.mock.calls[0][0];
-    expect(args).toMatchObject({ id: 3, userId: undefined, isModerator: undefined });
+    expect(args).toEqual({ id: 3 });
+    expect(args.userId).toBeUndefined();
+    expect(args.isModerator).toBeUndefined();
   });
 
-  it('SECURITY: a private/unpublished article (service throws NOT_FOUND for a non-owner) 404s', async () => {
+  it('SECURITY: a private/unpublished article (service throws NOT_FOUND) 404s for an anonymous caller', async () => {
     mockGetArticleById.mockRejectedValue(
       new TRPCError({ code: 'NOT_FOUND', message: 'No article with id 99' })
     );
@@ -287,6 +235,20 @@ describe('GET /api/v1/articles/[id] (detail)', () => {
     await detailHandler(req, res);
 
     expect(res._getStatusCode()).toBe(404);
+  });
+
+  it('SECURITY: a private/unpublished article 404s IDENTICALLY for an authed caller (no owner-draft branch)', async () => {
+    mockGetArticleById.mockRejectedValue(
+      new TRPCError({ code: 'NOT_FOUND', message: 'No article with id 99' })
+    );
+    // An authed user who might be the owner still gets a 404 — the endpoint never
+    // passes their identity, so the owner-draft self-view branch cannot fire.
+    const { req, res } = createMocks({ query: { id: '99' }, user: { id: 5, isModerator: false } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(404);
+    expect(mockGetArticleById.mock.calls[0][0]).toEqual({ id: 99 });
   });
 
   it('400s on a non-numeric / out-of-range id', async () => {

--- a/src/tests/api/v1/articles/index.test.ts
+++ b/src/tests/api/v1/articles/index.test.ts
@@ -3,13 +3,17 @@ import { TRPCError } from '@trpc/server';
 import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+import { NsfwLevel } from '~/server/common/enums';
 
-// Hoisted mocks for the wrapped service + the rate limiter.
-const { mockGetArticles, mockGetArticleById, mockRateLimit } = vi.hoisted(() => ({
-  mockGetArticles: vi.fn(),
-  mockGetArticleById: vi.fn(),
-  mockRateLimit: vi.fn(),
-}));
+// Hoisted mocks for the wrapped service + the rate limiter + the region helpers.
+const { mockGetArticles, mockGetArticleById, mockRateLimit, mockGetRegion, mockIsRegionRestricted } =
+  vi.hoisted(() => ({
+    mockGetArticles: vi.fn(),
+    mockGetArticleById: vi.fn(),
+    mockRateLimit: vi.fn(),
+    mockGetRegion: vi.fn(),
+    mockIsRegionRestricted: vi.fn(),
+  }));
 
 vi.mock('~/server/services/article.service', () => ({
   getArticles: mockGetArticles,
@@ -43,11 +47,12 @@ vi.mock('~/server/utils/endpoint-helpers', () => ({
   },
 }));
 
-// Region resolver kept deterministic (not restricted) so browsingLevel is the
-// public flag and assertions are stable.
+// Region resolver kept deterministic — the clamp is derived ONLY from these
+// helpers (never from the caller). Default: not restricted → the PUBLIC flag.
+// Individual tests flip `mockIsRegionRestricted` to exercise the SFW narrowing.
 vi.mock('~/server/utils/region-blocking', () => ({
-  getRegion: () => ({}),
-  isRegionRestricted: () => false,
+  getRegion: mockGetRegion,
+  isRegionRestricted: mockIsRegionRestricted,
 }));
 
 import listHandler from '~/pages/api/v1/articles/index';
@@ -104,6 +109,8 @@ function createMocks({
 beforeEach(() => {
   vi.clearAllMocks();
   mockRateLimit.mockResolvedValue({ allowed: true });
+  mockGetRegion.mockReturnValue({});
+  mockIsRegionRestricted.mockReturnValue(false);
 });
 
 describe('GET /api/v1/articles (list)', () => {
@@ -251,6 +258,85 @@ describe('GET /api/v1/articles/[id] (detail)', () => {
 
     expect(res._getStatusCode()).toBe(404);
     expect(mockGetArticleById.mock.calls[0][0]).toEqual({ id: 99 });
+  });
+
+  it('MATURITY: drops a cover image above the region-narrowed PUBLIC ceiling (mature cover never leaked to an anon SFW caller)', async () => {
+    mockGetArticleById.mockResolvedValue({
+      id: 3,
+      title: 't',
+      nsfwLevel: NsfwLevel.PG,
+      coverImage: { id: 1, url: 'k', nsfwLevel: NsfwLevel.R },
+    });
+    const { req, res } = createMocks({ query: { id: '3' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    // R does NOT intersect the PG-only public flag → cover dropped.
+    expect(res._getJSONData().coverImage).toBeUndefined();
+  });
+
+  it('MATURITY: preserves a cover within the public ceiling, and an unrated (0) cover is always allowed', async () => {
+    mockGetArticleById.mockResolvedValueOnce({
+      id: 3,
+      title: 't',
+      nsfwLevel: NsfwLevel.PG,
+      coverImage: { id: 1, url: 'k', nsfwLevel: NsfwLevel.PG },
+    });
+    const within = createMocks({ query: { id: '3' } });
+    await detailHandler(within.req, within.res);
+    expect(within.res._getJSONData().coverImage).toEqual({ id: 1, url: 'k', nsfwLevel: NsfwLevel.PG });
+
+    mockGetArticleById.mockResolvedValueOnce({
+      id: 4,
+      title: 't',
+      nsfwLevel: NsfwLevel.PG,
+      coverImage: { id: 2, url: 'k2', nsfwLevel: 0 },
+    });
+    const unrated = createMocks({ query: { id: '4' } });
+    await detailHandler(unrated.req, unrated.res);
+    expect(unrated.res._getJSONData().coverImage).toEqual({ id: 2, url: 'k2', nsfwLevel: 0 });
+  });
+
+  it('MATURITY/CACHEABILITY: the clamp reads NO per-user data — an authed (mod) caller gets byte-identical clamped output to an anon caller, and the service receives only { id } (no browsingLevel / userId)', async () => {
+    // Fresh object per call so a shallow-copy mutation can never bleed across calls.
+    mockGetArticleById.mockImplementation(async () => ({
+      id: 3,
+      title: 't',
+      nsfwLevel: NsfwLevel.PG,
+      coverImage: { id: 1, url: 'k', nsfwLevel: NsfwLevel.R },
+    }));
+
+    const anon = createMocks({ query: { id: '3' } });
+    await detailHandler(anon.req, anon.res);
+    const authed = createMocks({ query: { id: '3' }, user: { id: 42, isModerator: true } });
+    await detailHandler(authed.req, authed.res);
+
+    // Caller identity never feeds the clamp → identical output; mature cover
+    // dropped for BOTH (no per-user widening).
+    expect(authed.res._getJSONData()).toEqual(anon.res._getJSONData());
+    expect(anon.res._getJSONData().coverImage).toBeUndefined();
+    // Clamp is a POST-service filter → the service still gets just { id }.
+    expect(mockGetArticleById.mock.calls[0][0]).toEqual({ id: 3 });
+    expect(mockGetArticleById.mock.calls[1][0]).toEqual({ id: 3 });
+  });
+
+  it('MATURITY: the clamp is REGION-derived — a restricted region uses the SFW ceiling (PG-13 retained where the public default would drop it)', async () => {
+    mockIsRegionRestricted.mockReturnValue(true);
+    mockGetArticleById.mockResolvedValue({
+      id: 3,
+      title: 't',
+      nsfwLevel: NsfwLevel.PG,
+      coverImage: { id: 1, url: 'k', nsfwLevel: NsfwLevel.PG13 },
+    });
+    const { req, res } = createMocks({ query: { id: '3' } });
+
+    await detailHandler(req, res);
+
+    // Restricted → SFW ceiling (PG + PG-13) → the PG-13 cover is retained,
+    // proving the clamp tracks the region helper (not `allBrowsingLevels`, not a
+    // per-user value).
+    expect(res._getJSONData().coverImage).toMatchObject({ nsfwLevel: NsfwLevel.PG13 });
   });
 
   it('400s on a non-numeric / out-of-range id', async () => {

--- a/src/tests/api/v1/collections/index.test.ts
+++ b/src/tests/api/v1/collections/index.test.ts
@@ -3,6 +3,7 @@ import { TRPCError } from '@trpc/server';
 import { getHTTPStatusCodeFromError } from '@trpc/server/http';
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { CollectionReadConfiguration } from '~/shared/utils/prisma/enums';
+import { NsfwLevel } from '~/server/common/enums';
 
 const {
   mockGetAllCollections,
@@ -10,12 +11,16 @@ const {
   mockGetUserCollectionPermissionsById,
   mockGetCollectionById,
   mockRateLimit,
+  mockGetRegion,
+  mockIsRegionRestricted,
 } = vi.hoisted(() => ({
   mockGetAllCollections: vi.fn(),
   mockGetCollectionItemCount: vi.fn(),
   mockGetUserCollectionPermissionsById: vi.fn(),
   mockGetCollectionById: vi.fn(),
   mockRateLimit: vi.fn(),
+  mockGetRegion: vi.fn(),
+  mockIsRegionRestricted: vi.fn(),
 }));
 
 vi.mock('~/server/services/collection.service', () => ({
@@ -53,9 +58,12 @@ vi.mock('~/server/utils/endpoint-helpers', () => ({
   },
 }));
 
+// Region resolver kept deterministic — the maturity clamp is derived ONLY from
+// these helpers (never from the caller). Default: not restricted → PUBLIC flag.
+// Individual tests flip `mockIsRegionRestricted` to exercise the SFW narrowing.
 vi.mock('~/server/utils/region-blocking', () => ({
-  getRegion: () => ({}),
-  isRegionRestricted: () => false,
+  getRegion: mockGetRegion,
+  isRegionRestricted: mockIsRegionRestricted,
 }));
 
 import listHandler from '~/pages/api/v1/collections/index';
@@ -113,6 +121,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockRateLimit.mockResolvedValue({ allowed: true });
   mockGetCollectionItemCount.mockResolvedValue([]);
+  mockGetRegion.mockReturnValue({});
+  mockIsRegionRestricted.mockReturnValue(false);
 });
 
 describe('GET /api/v1/collections (list)', () => {
@@ -266,6 +276,92 @@ describe('GET /api/v1/collections/[id] (detail)', () => {
       user: { id: 2, username: 'bob' },
       tags: [{ id: 3, name: 'tag' }],
     });
+  });
+
+  it('MATURITY: nulls the cover URL when the cover is above the region-narrowed PUBLIC ceiling (mature cover never leaked; NOT allBrowsingLevels)', async () => {
+    mockGetUserCollectionPermissionsById.mockResolvedValue({
+      read: true,
+      write: false,
+      manage: false,
+    });
+    mockGetCollectionById.mockResolvedValue({
+      id: 55,
+      name: 'pub',
+      description: 'd',
+      type: 'Image',
+      nsfwLevel: NsfwLevel.R,
+      read: CollectionReadConfiguration.Public,
+      userId: 2,
+      user: { id: 2, username: 'bob' },
+      image: { url: 'img-key', type: 'image', nsfwLevel: NsfwLevel.R },
+      tags: [],
+    });
+    const { req, res } = createMocks({ query: { id: '55' } });
+
+    await detailHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    // R does NOT intersect the PG-only public flag → cover URL nulled. Under the
+    // old `allBrowsingLevels` clamp this R cover would have leaked.
+    expect(res._getJSONData().coverImageUrl).toBeNull();
+  });
+
+  it('MATURITY/CACHEABILITY: the clamp reads NO per-user data — an authed (mod) caller gets byte-identical clamped output to an anon caller', async () => {
+    mockGetUserCollectionPermissionsById.mockResolvedValue({
+      read: true,
+      write: false,
+      manage: false,
+    });
+    mockGetCollectionById.mockImplementation(async () => ({
+      id: 55,
+      name: 'pub',
+      description: 'd',
+      type: 'Image',
+      nsfwLevel: NsfwLevel.R,
+      read: CollectionReadConfiguration.Public,
+      userId: 2,
+      user: { id: 2, username: 'bob' },
+      image: { url: 'img-key', type: 'image', nsfwLevel: NsfwLevel.R },
+      tags: [],
+    }));
+
+    const anon = createMocks({ query: { id: '55' } });
+    await detailHandler(anon.req, anon.res);
+    const authed = createMocks({ query: { id: '55' }, user: { id: 7, isModerator: true } });
+    await detailHandler(authed.req, authed.res);
+
+    // Caller identity never feeds the clamp → identical output; mature cover
+    // nulled for BOTH.
+    expect(authed.res._getJSONData()).toEqual(anon.res._getJSONData());
+    expect(anon.res._getJSONData().coverImageUrl).toBeNull();
+  });
+
+  it('MATURITY: the clamp is REGION-derived — a restricted region uses the SFW ceiling (PG-13 cover retained where the public default would null it)', async () => {
+    mockIsRegionRestricted.mockReturnValue(true);
+    mockGetUserCollectionPermissionsById.mockResolvedValue({
+      read: true,
+      write: false,
+      manage: false,
+    });
+    mockGetCollectionById.mockResolvedValue({
+      id: 55,
+      name: 'pub',
+      description: 'd',
+      type: 'Image',
+      nsfwLevel: NsfwLevel.PG13,
+      read: CollectionReadConfiguration.Public,
+      userId: 2,
+      user: { id: 2, username: 'bob' },
+      image: { url: 'img-key', type: 'image', nsfwLevel: NsfwLevel.PG13 },
+      tags: [],
+    });
+    const { req, res } = createMocks({ query: { id: '55' } });
+
+    await detailHandler(req, res);
+
+    // Restricted → SFW ceiling (PG + PG-13) → the PG-13 cover survives, proving
+    // the clamp tracks the region helper (not a fixed max, not a per-user value).
+    expect(res._getJSONData().coverImageUrl).toBe('edge:img-key');
   });
 
   it('404s (via handleEndpointError) when the collection row is gone despite a permission grant', async () => {

--- a/src/tests/api/v1/collections/index.test.ts
+++ b/src/tests/api/v1/collections/index.test.ts
@@ -210,6 +210,8 @@ describe('GET /api/v1/collections (list)', () => {
 
     expect(res._getStatusCode()).toBe(429);
     expect(res._getHeader('Retry-After')).toBe('30');
+    // A 429 must NEVER be edge-cached (per-IP/per-user) — a cached public 429 would be served fleet-wide.
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
     expect(mockGetAllCollections).not.toHaveBeenCalled();
   });
 });
@@ -290,6 +292,7 @@ describe('GET /api/v1/collections/[id] (detail)', () => {
 
     expect(res._getStatusCode()).toBe(429);
     expect(res._getHeader('Retry-After')).toBe('15');
+    expect(res._getHeader('Cache-Control')).toBe('no-store');
     expect(mockGetUserCollectionPermissionsById).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/api/v1/collections/index.test.ts
+++ b/src/tests/api/v1/collections/index.test.ts
@@ -7,38 +7,26 @@ import { CollectionReadConfiguration } from '~/shared/utils/prisma/enums';
 const {
   mockGetAllCollections,
   mockGetCollectionItemCount,
-  mockGetUserCollectionsWithPermissions,
   mockGetUserCollectionPermissionsById,
   mockGetCollectionById,
   mockRateLimit,
-  mockIsAppBlocksAuthorEnabled,
 } = vi.hoisted(() => ({
   mockGetAllCollections: vi.fn(),
   mockGetCollectionItemCount: vi.fn(),
-  mockGetUserCollectionsWithPermissions: vi.fn(),
   mockGetUserCollectionPermissionsById: vi.fn(),
   mockGetCollectionById: vi.fn(),
   mockRateLimit: vi.fn(),
-  mockIsAppBlocksAuthorEnabled: vi.fn(),
 }));
 
 vi.mock('~/server/services/collection.service', () => ({
   getAllCollections: mockGetAllCollections,
   getCollectionItemCount: mockGetCollectionItemCount,
-  getUserCollectionsWithPermissions: mockGetUserCollectionsWithPermissions,
   getUserCollectionPermissionsById: mockGetUserCollectionPermissionsById,
   getCollectionById: mockGetCollectionById,
 }));
 
 vi.mock('~/server/utils/public-api-rate-limit', () => ({
   checkPublicApiRateLimit: mockRateLimit,
-}));
-
-// The App Blocks author-cohort gate — mock it so tests never touch real Flipt.
-// Default: in-cohort (true) so the existing happy-path assertions still exercise
-// the handler body; the dark-404 tests flip it to false.
-vi.mock('~/server/services/app-blocks-flag', () => ({
-  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
 }));
 
 vi.mock('~/client-utils/cf-images-utils', () => ({
@@ -125,68 +113,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockRateLimit.mockResolvedValue({ allowed: true });
   mockGetCollectionItemCount.mockResolvedValue([]);
-  // Default: caller IS in the author cohort (mod / app-dev-tester) so the
-  // existing behavioural tests reach the handler body. Dark-404 tests override.
-  mockIsAppBlocksAuthorEnabled.mockResolvedValue(true);
-});
-
-const PREVIEW_MESSAGE =
-  'This API is in preview — access is restricted to Civitai moderators and app developers.';
-
-describe('GET /api/v1/collections — author-cohort gate (403 preview)', () => {
-  it('SECURITY: a non-cohort authed user gets a 403 + preview message and NEITHER the rate limiter NOR the service runs (list)', async () => {
-    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
-    const { req, res } = createMocks({ query: {}, user: { id: 7, isModerator: false } });
-
-    await listHandler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
-    expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: { id: 7, isModerator: false } });
-    expect(mockRateLimit).not.toHaveBeenCalled();
-    expect(mockGetAllCollections).not.toHaveBeenCalled();
-  });
-
-  it('SECURITY: an anonymous caller gets a 403 + preview message (list)', async () => {
-    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
-    const { req, res } = createMocks({ query: {} });
-
-    await listHandler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
-    expect(mockIsAppBlocksAuthorEnabled).toHaveBeenCalledWith({ user: undefined });
-    expect(mockRateLimit).not.toHaveBeenCalled();
-    expect(mockGetAllCollections).not.toHaveBeenCalled();
-  });
-
-  it('SECURITY: a non-cohort authed user gets a 403 + preview message (detail)', async () => {
-    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
-    const { req, res } = createMocks({ query: { id: '55' }, user: { id: 7, isModerator: false } });
-
-    await detailHandler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
-    expect(mockRateLimit).not.toHaveBeenCalled();
-    expect(mockGetUserCollectionPermissionsById).not.toHaveBeenCalled();
-  });
-
-  it('SECURITY: an anonymous caller gets a 403 + preview message (detail)', async () => {
-    mockIsAppBlocksAuthorEnabled.mockResolvedValue(false);
-    const { req, res } = createMocks({ query: { id: '55' } });
-
-    await detailHandler(req, res);
-
-    expect(res._getStatusCode()).toBe(403);
-    expect(res._getJSONData()).toEqual({ error: PREVIEW_MESSAGE });
-    expect(mockRateLimit).not.toHaveBeenCalled();
-    expect(mockGetUserCollectionPermissionsById).not.toHaveBeenCalled();
-  });
 });
 
 describe('GET /api/v1/collections (list)', () => {
-  it('public mode: queries getAllCollections with privacy pinned to [Public] and returns the envelope', async () => {
+  it('queries getAllCollections with privacy pinned to [Public], evaluated as anonymous (user: undefined), and returns the envelope', async () => {
     mockGetAllCollections.mockResolvedValue([
       {
         id: 10,
@@ -206,49 +136,47 @@ describe('GET /api/v1/collections (list)', () => {
 
     expect(res._getStatusCode()).toBe(200);
     const args = mockGetAllCollections.mock.calls[0][0];
-    // SECURITY: privacy forced to Public (service also re-clamps for non-mods).
+    // SECURITY: privacy forced to Public AND no session user passed → the service
+    // clamps to Public unconditionally (even a mod override can't widen).
     expect(args.input.privacy).toEqual([CollectionReadConfiguration.Public]);
+    expect(args.user).toBeUndefined();
     const body = res._getJSONData();
     expect(body.items[0]).toMatchObject({ id: 10, name: 'c', isPublic: true });
     expect(body).toHaveProperty('metadata');
   });
 
-  it('SECURITY: mine=true requires auth → 401 when unauthenticated, and the service is not called', async () => {
-    const { req, res } = createMocks({ query: { mine: 'true' } });
-
-    await listHandler(req, res);
-
-    expect(res._getStatusCode()).toBe(401);
-    expect(mockGetUserCollectionsWithPermissions).not.toHaveBeenCalled();
-    expect(mockGetAllCollections).not.toHaveBeenCalled();
-  });
-
-  it('mine=true (authed): keys getUserCollectionsWithPermissions on the SESSION user id, never a client param', async () => {
-    mockGetUserCollectionsWithPermissions.mockResolvedValue([
+  it('CACHEABILITY: the response is caller-independent — an authed caller gets byte-identical data to an anonymous caller, and getAllCollections is called as anonymous (user: undefined) in BOTH cases', async () => {
+    mockGetAllCollections.mockResolvedValue([
       {
-        id: 20,
-        name: 'mine',
+        id: 10,
+        name: 'c',
         description: null,
-        read: CollectionReadConfiguration.Private,
+        read: CollectionReadConfiguration.Public,
         type: 'Image',
-        userId: 99,
-        image: undefined,
+        nsfwLevel: 1,
+        userId: 2,
+        user: { id: 2, username: 'bob' },
+        image: null,
       },
     ]);
-    const { req, res } = createMocks({
-      query: { mine: 'true', userId: '1' },
-      user: { id: 99, username: 'me' },
-    });
 
-    await listHandler(req, res);
+    const anon = createMocks({ query: { limit: '5' } });
+    await listHandler(anon.req, anon.res);
 
-    expect(res._getStatusCode()).toBe(200);
-    expect(mockGetUserCollectionsWithPermissions).toHaveBeenCalledWith({
-      input: { userId: 99, contributingOnly: true },
-    });
-    const body = res._getJSONData();
-    // Owner sees their OWN private collection in the mine listing.
-    expect(body.items[0]).toMatchObject({ id: 20, isPublic: false });
+    const authed = createMocks({ query: { limit: '5' }, user: { id: 42, username: 'me', isModerator: true } });
+    await listHandler(authed.req, authed.res);
+
+    expect(anon.res._getStatusCode()).toBe(200);
+    expect(authed.res._getStatusCode()).toBe(200);
+    // Same URL → byte-identical body regardless of caller identity.
+    expect(authed.res._getJSONData()).toEqual(anon.res._getJSONData());
+    // The service is invoked with identical, purely-public args (no session user)
+    // even for the authed moderator.
+    const anonArgs = mockGetAllCollections.mock.calls[0][0];
+    const authedArgs = mockGetAllCollections.mock.calls[1][0];
+    expect(anonArgs.user).toBeUndefined();
+    expect(authedArgs.user).toBeUndefined();
+    expect(authedArgs.input.privacy).toEqual([CollectionReadConfiguration.Public]);
   });
 
   it('PAGINATION: rejects a cursor combined with sort=Most Followers (id cursor is inconsistent with the contributor ordering)', async () => {
@@ -287,18 +215,21 @@ describe('GET /api/v1/collections (list)', () => {
 });
 
 describe('GET /api/v1/collections/[id] (detail)', () => {
-  it('SECURITY: no read permission → 404 and getCollectionById is NEVER called (private collection unreachable, no existence oracle)', async () => {
+  it('SECURITY: no read permission → 404 and getCollectionById is NEVER called (private collection unreachable, no existence oracle); permissions evaluated as anonymous', async () => {
     mockGetUserCollectionPermissionsById.mockResolvedValue({
       read: false,
       write: false,
       manage: false,
     });
-    const { req, res } = createMocks({ query: { id: '55' } });
+    // Even an authed caller is evaluated as anonymous — no owner/mod widening.
+    const { req, res } = createMocks({ query: { id: '55' }, user: { id: 7, isModerator: true } });
 
     await detailHandler(req, res);
 
     expect(res._getStatusCode()).toBe(404);
     expect(mockGetCollectionById).not.toHaveBeenCalled();
+    // Permission check never receives session identity.
+    expect(mockGetUserCollectionPermissionsById.mock.calls[0][0]).toEqual({ id: 55 });
   });
 
   it('returns the collection projection when read permission is granted', async () => {


### PR DESCRIPTION
## What

Make `GET /api/v1/articles[/{id}]` and `GET /api/v1/collections[/{id}]` **fully public + edge-cacheable**, exactly like the sibling `models`/`images`/`tags`/`creators` public endpoints. Removes the `appBlocksAuthor` cohort gate added in #3215.

## Why

#3215 gated these four endpoints behind the `appBlocksAuthor` cohort (403 for non-cohort/anon). But the underlying data is **already public** — published articles and public collections are served on the website and via public tRPC — so the flag protected nothing. Worse, gating made the response depend on the **caller's identity**, which is incompatible with edge caching: Cloudflare could cross-serve a cohort member's `403` to another caller, and a cached `200` could be served to anon. The gate created a leak surface without adding protection.

## The invariant (the whole point)

After this change the response body is a **pure function of the URL (+ region)** — it does **not** vary by caller identity or auth state. An anonymous caller and any authenticated caller hitting the same URL get **byte-identical** data. That is what makes `public, s-maxage=300` (set by `MixedAuthEndpoint`'s `addPublicCacheHeaders` for anonymous sessions) safe: no cross-user leak. `region` is the one legitimate response variation, identical to the existing public endpoints (the CDN already keys on it).

Every per-user path that could make the response caller-dependent was removed:

- **The flag gate** (the 403 denial + the `isAppBlocksAuthorEnabled` import) — deleted from all four handlers.
- **Articles list:** now evaluates as anonymous always (`sessionUser: undefined`) and keeps `forceHidePrivate: true`. The `favorites`/`hidden` own-engagement params (and their authed-only 401 branch) are removed from the schema entirely — a public cacheable list shows the same published+scanned articles to everyone.
- **Article detail:** the owner-can-see-own-draft branch is gone — the handler never passes `userId`/`isModerator`, so the service matches published + scanned only. A draft/unpublished/private article is a `404` for **everyone** (same path anonymous website visitors already use via the `getById` public procedure).
- **Collections list:** the `?mine=` mode (inherently per-user → uncacheable + authoring, not discovery) is removed. `getAllCollections` is now called with `user: undefined` **and** `privacy: [Public]`, so the service's own clamp forces Public unconditionally — even the moderator privacy-override can't widen it.
- **Collection detail:** `getUserCollectionPermissionsById` is evaluated as anonymous → `read` is true only for Public/Unlisted; a private collection → `404` for **everyone**, indistinguishable from a non-existent one (no existence oracle).

## Still enforced

- **Visibility still excludes private/unpublished for everyone.** Verified against the services: `getArticles` (anonymous + `forceHidePrivate`) yields published+scanned+non-private; `getArticleById` (no userId/isModerator) is published-only; `getAllCollections` clamps to `[Public]`; `getUserCollectionPermissionsById` (no userId) grants read only for Public/Unlisted. The security tests assert a private/unpublished item is `404`/excluded regardless of auth.
- **The rate limiter stays** (`public-api-rate-limit.ts`, CF-Connecting-IP / userId keyed). It now guards only the cache-**miss** path (varied-query scraping) — the right place for it. `429` responses set `Cache-Control: no-store`.
- `MixedAuthEndpoint` and its default cache behavior are unchanged — no `no-store` added to the success path.

## Supersedes #3215

This unbreaks the currently-cached-403 state on the next deploy: callers that were being served a cross-user `403` now get the public data.

## Tests

`src/tests/api/v1/{articles,collections}/index.test.ts` updated: flag-gate (403) tests removed; added caller-independence tests (anon vs authed → byte-identical body + service called with identical public args); kept/updated the visibility security tests (private/unpublished → 404 for everyone) and the rate-limit (429 + Retry-After) + cursor/envelope tests. Services + rate limiter are mocked (no real Flipt/Redis/DB). 19 tests green; `tsc --noEmit` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
