### PR TITLE
feat(apps): OAuth-connect listing mod review — scope disclosure + sensitive-must-justify gate + connect-approval fix (PR3)

### DIFF
--- a/packages/civitai-auth/src/__tests__/connect-scope-review.test.ts
+++ b/packages/civitai-auth/src/__tests__/connect-scope-review.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
+  ALL_SCOPES,
   TokenScope,
   tokenScopeLabels,
   SCOPE_JUSTIFICATION_MAX_LENGTH,
+  SENSITIVE_TOKEN_SCOPES,
+  isSensitiveTokenScope,
   tokenScopeMaskToList,
   tokenScopeKeyByBit,
   connectScopesSubsetOfCeiling,
@@ -139,5 +142,99 @@ describe('validateConnectScopeJustifications', () => {
 
   it('SCOPE_JUSTIFICATION_MAX_LENGTH is 500 (shared bound)', () => {
     expect(SCOPE_JUSTIFICATION_MAX_LENGTH).toBe(500);
+  });
+});
+
+describe('SENSITIVE_TOKEN_SCOPES (OAuth sensitive taxonomy)', () => {
+  // The auditable expected set — money (BuzzRead/SocialTip + buzz-spending writes),
+  // private (UserRead), and every cross-user/account write+delete. Reads of public
+  // data and the opt-in App-Block scopes are NOT sensitive.
+  const EXPECTED_SENSITIVE =
+    TokenScope.UserRead |
+    TokenScope.UserWrite |
+    TokenScope.ModelsWrite |
+    TokenScope.ModelsDelete |
+    TokenScope.MediaWrite |
+    TokenScope.MediaDelete |
+    TokenScope.ArticlesWrite |
+    TokenScope.ArticlesDelete |
+    TokenScope.BountiesWrite |
+    TokenScope.BountiesDelete |
+    TokenScope.AIServicesWrite |
+    TokenScope.BuzzRead |
+    TokenScope.CollectionsWrite |
+    TokenScope.SocialWrite |
+    TokenScope.SocialTip |
+    TokenScope.NotificationsWrite |
+    TokenScope.VaultWrite;
+
+  it('is EXACTLY the expected sensitive bitmask', () => {
+    expect(SENSITIVE_TOKEN_SCOPES).toBe(EXPECTED_SENSITIVE);
+    // Spelled out as the set of enum-keys for a human to eyeball.
+    expect(tokenScopeMaskToList(SENSITIVE_TOKEN_SCOPES).map((s) => s.key)).toEqual([
+      'UserRead',
+      'UserWrite',
+      'ModelsWrite',
+      'ModelsDelete',
+      'MediaWrite',
+      'MediaDelete',
+      'ArticlesWrite',
+      'ArticlesDelete',
+      'BountiesWrite',
+      'BountiesDelete',
+      'AIServicesWrite',
+      'BuzzRead',
+      'CollectionsWrite',
+      'SocialWrite',
+      'SocialTip',
+      'NotificationsWrite',
+      'VaultWrite',
+    ]);
+  });
+
+  it('every set bit is a DEFINED single-bit TokenScope (⊆ ALL_SCOPES, none dangling)', () => {
+    // No bit outside the union of every defined scope bit.
+    expect(SENSITIVE_TOKEN_SCOPES & ~ALL_SCOPES).toBe(0);
+    // And each individual bit resolves to a real single-bit enum key.
+    for (const { bit, key } of tokenScopeMaskToList(SENSITIVE_TOKEN_SCOPES)) {
+      expect(tokenScopeKeyByBit(bit)).toBe(key);
+    }
+  });
+
+  it('EXCLUDES the public-read + opt-in App-Block scopes', () => {
+    for (const bit of [
+      TokenScope.ModelsRead,
+      TokenScope.MediaRead,
+      TokenScope.ArticlesRead,
+      TokenScope.BountiesRead,
+      TokenScope.AIServicesRead,
+      TokenScope.CollectionsRead,
+      TokenScope.NotificationsRead,
+      TokenScope.VaultRead,
+      TokenScope.AppBlocksSubmit,
+      TokenScope.AppBlocksDevTunnel,
+    ]) {
+      expect(SENSITIVE_TOKEN_SCOPES & bit).toBe(0);
+    }
+  });
+
+  it('isSensitiveTokenScope — single-bit spot checks', () => {
+    expect(isSensitiveTokenScope(TokenScope.ModelsWrite)).toBe(true);
+    expect(isSensitiveTokenScope(TokenScope.UserRead)).toBe(true);
+    expect(isSensitiveTokenScope(TokenScope.BuzzRead)).toBe(true);
+    expect(isSensitiveTokenScope(TokenScope.SocialTip)).toBe(true);
+    expect(isSensitiveTokenScope(TokenScope.ModelsRead)).toBe(false);
+    expect(isSensitiveTokenScope(TokenScope.MediaRead)).toBe(false);
+    expect(isSensitiveTokenScope(TokenScope.AppBlocksSubmit)).toBe(false);
+    expect(isSensitiveTokenScope(0)).toBe(false);
+  });
+
+  it('isSensitiveTokenScope — a mask is sensitive iff it intersects the set', () => {
+    // A read-only mask is not sensitive…
+    expect(isSensitiveTokenScope(TokenScope.ModelsRead | TokenScope.MediaRead)).toBe(false);
+    // …but add one sensitive bit and it is.
+    expect(
+      isSensitiveTokenScope(TokenScope.ModelsRead | TokenScope.ModelsWrite)
+    ).toBe(true);
   });
 });

--- a/packages/civitai-auth/src/token-scope.ts
+++ b/packages/civitai-auth/src/token-scope.ts
@@ -343,3 +343,54 @@ export function validateConnectScopeJustifications(
   }
   return errors;
 }
+
+/**
+ * The SENSITIVE OAuth-scope taxonomy — the mask of scope bits a moderator must
+ * scrutinise (and, for a connect listing, that MUST carry a per-scope
+ * justification before approval; see `approveExternalRequest`).
+ *
+ * Principle — a scope is sensitive when granting it lets an app touch MONEY, read
+ * PRIVATE/identity data, or WRITE data OTHER users see (cross-user side effects):
+ *  - money:      `BuzzRead` (balance/history) + `SocialTip` (spend on tips) — and
+ *                every `*Write` that implicitly spends Buzz (`AIServicesWrite`,
+ *                `BountiesWrite`).
+ *  - private:    `UserRead` (profile, settings & EMAIL / PII).
+ *  - cross-user / destructive: every `*Write` + `*Delete` (they create, mutate or
+ *                remove content others can see, or edit the user's own account).
+ *
+ * Written as an EXPLICIT named-bit OR (not a computed "everything but reads") so a
+ * moderator can eyeball exactly which permissions are flagged, and adding a new
+ * scope bit never silently folds it in. Deliberately EXCLUDES the read-only scopes
+ * that expose only public data (`ModelsRead`/`MediaRead`/`ArticlesRead`/
+ * `BountiesRead`/`AIServicesRead`/`CollectionsRead`/`NotificationsRead`/`VaultRead`)
+ * and the opt-in App-Block scopes (`AppBlocksSubmit`/`AppBlocksDevTunnel`, never
+ * part of a connect ceiling). `NotificationsWrite`/`VaultWrite` are included as
+ * account-mutating writes even though they are self-scoped.
+ */
+export const SENSITIVE_TOKEN_SCOPES: number =
+  TokenScope.UserRead | // private: profile, settings & email (PII)
+  TokenScope.UserWrite | // mutates the account
+  TokenScope.ModelsWrite |
+  TokenScope.ModelsDelete |
+  TokenScope.MediaWrite |
+  TokenScope.MediaDelete |
+  TokenScope.ArticlesWrite |
+  TokenScope.ArticlesDelete |
+  TokenScope.BountiesWrite | // buzz spend (bounty creation)
+  TokenScope.BountiesDelete |
+  TokenScope.AIServicesWrite | // buzz spend (generation/training)
+  TokenScope.BuzzRead | // money: balance & history
+  TokenScope.CollectionsWrite |
+  TokenScope.SocialWrite | // cross-user: follow/react/comment/review
+  TokenScope.SocialTip | // money: tip other users
+  TokenScope.NotificationsWrite |
+  TokenScope.VaultWrite;
+
+/**
+ * True iff `bit` carries ANY sensitive scope bit (see {@link SENSITIVE_TOKEN_SCOPES}).
+ * Works for a single scope bit OR a multi-bit mask — a mask is sensitive when it
+ * intersects the sensitive set at all.
+ */
+export function isSensitiveTokenScope(bit: number): boolean {
+  return (bit & SENSITIVE_TOKEN_SCOPES) !== 0;
+}

--- a/src/components/Apps/ConnectScopesPanel.browser.test.tsx
+++ b/src/components/Apps/ConnectScopesPanel.browser.test.tsx
@@ -1,0 +1,174 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * PR3 — OAuth-connect mod review UI. Two seams:
+ *  1. `ConnectScopesPanel` (pure props): the requested-scope disclosure a moderator
+ *     reviews — scope keys + descriptions + per-scope justifications, with SENSITIVE
+ *     scopes flagged in a distinct group and a "No justification provided" fallback.
+ *  2. `OffsiteReviewModal` conditional: the panel is rendered ONLY for a CONNECT
+ *     listing (`connectClientId != null`), never for an external-link listing.
+ */
+
+// --- trpc / providers mocked for the OffsiteReviewModal conditional tests. The
+// pure-props ConnectScopesPanel tests below don't touch these. ---
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true }),
+}));
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+vi.mock('~/utils/trpc', () => {
+  const mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
+  return {
+    trpc: {
+      useUtils: () => ({
+        appListings: {
+          listPendingRequests: { invalidate: vi.fn() },
+          listApprovedRequests: { invalidate: vi.fn() },
+          listRejectedRequests: { invalidate: vi.fn() },
+        },
+      }),
+      appListings: {
+        getAssets: {
+          useQuery: () => ({
+            data: {
+              listingId: 'listing-c',
+              iconId: 10,
+              coverId: 11,
+              iconNsfwLevel: 1,
+              coverNsfwLevel: 1,
+              screenshots: [{ imageId: 12, nsfwLevel: 1 }],
+            },
+            isLoading: false,
+            error: null,
+          }),
+        },
+        approveExternalRequest: { useMutation: mutation },
+        rejectExternalRequest: { useMutation: mutation },
+      },
+    },
+  };
+});
+
+const { ConnectScopesPanel } = await import('./ConnectScopesPanel');
+const { OffsiteReviewModal } = await import('./OffsiteReviewQueue');
+
+// ModelsWrite (sensitive, justified) + ModelsRead (normal, UNjustified → fallback).
+const REQUESTED = TokenScope.ModelsWrite | TokenScope.ModelsRead;
+const JUSTIFICATIONS = { ModelsWrite: 'We publish edited models on the user behalf.' };
+
+describe('ConnectScopesPanel — pure props', () => {
+  test('renders each scope key + its description + the justification', async () => {
+    renderWithProviders(
+      <ConnectScopesPanel
+        connectClientName="Acme OAuth App"
+        requestedScopes={REQUESTED}
+        justifications={JUSTIFICATIONS}
+      />
+    );
+    // Both scope keys render.
+    await expect.element(page.getByText('ModelsWrite')).toBeInTheDocument();
+    await expect.element(page.getByText('ModelsRead')).toBeInTheDocument();
+    // The human-readable description (from tokenScopeLabels) renders.
+    await expect.element(page.getByText('Upload & edit models')).toBeInTheDocument();
+    // The client name renders.
+    await expect.element(page.getByText('Client: Acme OAuth App')).toBeInTheDocument();
+    // The justification renders next to its scope.
+    await expect
+      .element(page.getByText('We publish edited models on the user behalf.'))
+      .toBeInTheDocument();
+  });
+
+  test('a SENSITIVE scope appears in the sensitive group with the Sensitive badge', async () => {
+    renderWithProviders(
+      <ConnectScopesPanel requestedScopes={REQUESTED} justifications={JUSTIFICATIONS} />
+    );
+    // The sensitive group is present…
+    await expect.element(page.getByTestId('connect-scopes-sensitive-group')).toBeInTheDocument();
+    // …and carries exactly ONE sensitive badge (ModelsWrite; ModelsRead is normal).
+    expect(page.getByTestId('sensitive-scope-badge').elements()).toHaveLength(1);
+    // ModelsWrite (sensitive) is inside the sensitive group.
+    const group = page.getByTestId('connect-scopes-sensitive-group');
+    await expect.element(group.getByText('ModelsWrite')).toBeInTheDocument();
+  });
+
+  test('an unjustified scope shows the "No justification provided" fallback', async () => {
+    renderWithProviders(
+      <ConnectScopesPanel requestedScopes={REQUESTED} justifications={JUSTIFICATIONS} />
+    );
+    // ModelsRead has no justification → the muted fallback shows exactly once.
+    await expect.element(page.getByText('No justification provided')).toBeInTheDocument();
+    expect(page.getByText('No justification provided').elements()).toHaveLength(1);
+  });
+
+  test('empty justifications → every scope shows the fallback', async () => {
+    renderWithProviders(<ConnectScopesPanel requestedScopes={REQUESTED} justifications={null} />);
+    // Await the render before the synchronous count.
+    await expect.element(page.getByText('No justification provided').first()).toBeInTheDocument();
+    expect(page.getByText('No justification provided').elements()).toHaveLength(2);
+  });
+});
+
+// A pending row feeding OffsiteReviewModal. Overridable per-test for the
+// connect vs external-link conditional.
+function makeRow(appListing: Record<string, unknown>) {
+  return {
+    id: 'req-c',
+    appListingId: 'listing-c',
+    slug: 'connect-app',
+    status: 'pending',
+    submittedAt: new Date('2026-01-01T00:00:00Z'),
+    changelog: null,
+    appListing,
+    submittedBy: { id: 42, username: 'dev', image: null },
+  } as never;
+}
+
+describe('OffsiteReviewModal — ConnectScopesPanel conditional', () => {
+  test('renders the ConnectScopesPanel for a CONNECT listing (connectClientId set)', async () => {
+    renderWithProviders(
+      <OffsiteReviewModal
+        request={makeRow({
+          name: 'Connect App',
+          externalUrl: null,
+          category: 'utility',
+          contentRating: 'g',
+          connectClientId: 'client-1',
+          connectRequestedScopes: REQUESTED,
+          connectScopeJustifications: JUSTIFICATIONS,
+          connectClient: { name: 'Acme OAuth App' },
+        })}
+        onClose={() => undefined}
+      />
+    );
+    await expect.element(page.getByTestId('connect-scopes-panel')).toBeInTheDocument();
+    await expect.element(page.getByText('ModelsWrite')).toBeInTheDocument();
+  });
+
+  test('does NOT render the ConnectScopesPanel for an external-link listing (connectClientId null)', async () => {
+    renderWithProviders(
+      <OffsiteReviewModal
+        request={makeRow({
+          name: 'External App',
+          externalUrl: 'https://example.com/app',
+          category: 'utility',
+          contentRating: 'g',
+          connectClientId: null,
+          connectRequestedScopes: null,
+          connectScopeJustifications: null,
+          connectClient: null,
+        })}
+        onClose={() => undefined}
+      />
+    );
+    // The external URL confirms the modal mounted…
+    await expect.element(page.getByText('https://example.com/app')).toBeInTheDocument();
+    // …but the connect scope panel is absent.
+    expect(page.getByTestId('connect-scopes-panel').elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Apps/ConnectScopesPanel.tsx
+++ b/src/components/Apps/ConnectScopesPanel.tsx
@@ -1,0 +1,170 @@
+import { Card, Group, Stack, Text, ThemeIcon, Tooltip } from '@mantine/core';
+import { IconAlertTriangle, IconInfoCircle, IconKey } from '@tabler/icons-react';
+import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
+import {
+  isSensitiveTokenScope,
+  tokenScopeMaskToList,
+} from '~/shared/constants/token-scope.constants';
+
+/**
+ * ConnectScopesPanel — the OAuth-CONNECT analog of `ManifestScopes`
+ * (OnsiteReviewModal). Renders, for a mod reviewing an OFF-SITE connect listing,
+ * the OAuth scopes the external app requests + the author's per-scope
+ * justification. SENSITIVE scopes (money / private data / cross-user writes — see
+ * `SENSITIVE_TOKEN_SCOPES`) render FIRST in a distinct warning-styled group, reusing
+ * the shared `SensitiveScopeBadge` so the "elevated-risk" emphasis reads identically
+ * to the on-site block review.
+ *
+ * Display-only: this surface DISPLAYS the developer's stated rationale; it never
+ * grants a scope. The server enforces the sensitive-must-justify approval gate
+ * (`approveExternalRequest`). The requested-scope bitmask is expanded via
+ * `tokenScopeMaskToList` (bit/key/label, sorted by bit); the justification map is
+ * keyed by the TokenScope enum-key.
+ */
+export function ConnectScopesPanel({
+  connectClientName,
+  requestedScopes,
+  justifications,
+}: {
+  connectClientName?: string | null;
+  /** The disclosed TokenScope bitmask the listing requests. */
+  requestedScopes: number;
+  /** Per-scope rationale keyed by TokenScope enum-key (e.g. `{ ModelsWrite: '…' }`). */
+  justifications?: Record<string, string> | null;
+}) {
+  const scopes = tokenScopeMaskToList(requestedScopes);
+  const sensitiveScopes = scopes.filter((s) => isSensitiveTokenScope(s.bit));
+  const normalScopes = scopes.filter((s) => !isSensitiveTokenScope(s.bit));
+
+  return (
+    <Card withBorder p="sm" data-testid="connect-scopes-panel">
+      <Stack gap="xs">
+        <Group gap={6}>
+          <IconKey size={14} />
+          <Text size="sm" fw={600}>
+            Requested OAuth permissions ({scopes.length})
+          </Text>
+          <Tooltip
+            multiline
+            w={300}
+            label="The account permissions this external app asks to be granted when a user connects it. They are bounded by the OAuth client's allowed-scope ceiling; the per-scope note is the developer's stated reason and is not verified by the platform."
+          >
+            <ThemeIcon size="xs" variant="subtle" color="gray">
+              <IconInfoCircle size={13} />
+            </ThemeIcon>
+          </Tooltip>
+        </Group>
+        {connectClientName && (
+          <Text size="xs" c="dimmed">
+            Client: {connectClientName}
+          </Text>
+        )}
+
+        {scopes.length === 0 ? (
+          <Text size="xs" c="dimmed" fs="italic">
+            No permissions requested — the app connects without account access.
+          </Text>
+        ) : (
+          <>
+            {sensitiveScopes.length > 0 && (
+              <Stack gap={8} data-testid="connect-scopes-sensitive-group">
+                <Group gap={6}>
+                  <IconAlertTriangle size={14} color="var(--mantine-color-orange-6)" />
+                  <Text size="sm" fw={600} c="orange">
+                    Sensitive permissions ({sensitiveScopes.length})
+                  </Text>
+                  <Tooltip
+                    multiline
+                    w={280}
+                    label="Elevated-risk permissions — these let the app spend the user's Buzz, read the user's balance or private data (incl. email), or write data other users see. Review each justification carefully; approval is blocked unless every one is justified."
+                  >
+                    <ThemeIcon size="xs" variant="subtle" color="orange">
+                      <IconInfoCircle size={13} />
+                    </ThemeIcon>
+                  </Tooltip>
+                </Group>
+                {sensitiveScopes.map((s) => (
+                  <ConnectScopeRow
+                    key={s.bit}
+                    scopeKey={s.key}
+                    label={s.label}
+                    sensitive
+                    justifications={justifications}
+                  />
+                ))}
+              </Stack>
+            )}
+
+            <Group gap={6}>
+              <IconKey size={14} />
+              <Text size="sm" fw={600}>
+                Permissions ({normalScopes.length})
+              </Text>
+            </Group>
+            {normalScopes.length === 0 ? (
+              <Text size="xs" c="dimmed" fs="italic">
+                No non-sensitive permissions requested.
+              </Text>
+            ) : (
+              <Stack gap={8} data-testid="connect-scopes-normal-group">
+                {normalScopes.map((s) => (
+                  <ConnectScopeRow
+                    key={s.bit}
+                    scopeKey={s.key}
+                    label={s.label}
+                    justifications={justifications}
+                  />
+                ))}
+              </Stack>
+            )}
+          </>
+        )}
+      </Stack>
+    </Card>
+  );
+}
+
+function ConnectScopeRow({
+  scopeKey,
+  label,
+  sensitive = false,
+  justifications,
+}: {
+  scopeKey: string;
+  label: string;
+  sensitive?: boolean;
+  justifications?: Record<string, string> | null;
+}) {
+  const raw = justifications?.[scopeKey];
+  const justification = typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : null;
+  return (
+    <Stack gap={2} data-testid={`connect-scope-row-${scopeKey}`}>
+      <Group gap={8} align="flex-start" wrap="nowrap">
+        <ThemeIcon size="xs" variant="subtle" color={sensitive ? 'orange' : 'blue'}>
+          <IconKey size={12} />
+        </ThemeIcon>
+        <Text size="sm" fw={600} style={{ fontFamily: 'ui-monospace, monospace' }}>
+          {scopeKey}
+        </Text>
+        {sensitive && <SensitiveScopeBadge />}
+        {label && (
+          <Text size="xs" c="dimmed">
+            {label}
+          </Text>
+        )}
+      </Group>
+      {justification ? (
+        <Text size="xs" c="dimmed" style={{ whiteSpace: 'pre-wrap' }}>
+          <Text span fw={600} c="dimmed">
+            Why:{' '}
+          </Text>
+          {justification}
+        </Text>
+      ) : (
+        <Text size="xs" c="dimmed" fs="italic">
+          No justification provided
+        </Text>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -38,6 +38,7 @@ import {
   reasonMeetsMin,
 } from '~/components/Apps/ReasonGatedActionModal';
 import { getOffsiteReviewChecklist } from '~/components/Apps/offsiteReviewChecklist';
+import { ConnectScopesPanel } from '~/components/Apps/ConnectScopesPanel';
 import { getReportReasonLabel } from '~/components/Apps/appListingReportView';
 import {
   isDestructiveAction,
@@ -87,6 +88,14 @@ export type OffsitePendingRow = {
     externalUrl: string | null;
     category: string | null;
     contentRating: string | null;
+    // OAuth-CONNECT sub-kind (PR3). `connectClientId` is the discriminator: when set,
+    // the row is a connect listing and the review modal renders the requested-scope
+    // panel + the sensitive-justification checklist item. Null for an external-link
+    // listing. `connectScopeJustifications` is keyed by TokenScope enum-key.
+    connectClientId?: string | null;
+    connectRequestedScopes?: number | null;
+    connectScopeJustifications?: Record<string, string> | null;
+    connectClient?: { name: string | null } | null;
   } | null;
   submittedBy: OffsiteUser | null;
 };
@@ -325,6 +334,11 @@ export function OffsiteReviewModal({
     nsfwLevelFromContentRating(derivedRating) > nsfwLevelFromContentRating(declaredRating);
   const selectedRating: OffsiteContentRating = ratingOverride ?? derivedRating;
 
+  // OAuth-CONNECT sub-kind (PR3): render the requested-scope panel + the sensitive-
+  // justification checklist item only when the listing is a connect listing.
+  const connectClientId = request.appListing?.connectClientId ?? null;
+  const isConnect = connectClientId != null;
+
   const checklist = getOffsiteReviewChecklist({
     name: request.appListing?.name,
     externalUrl: request.appListing?.externalUrl,
@@ -333,6 +347,9 @@ export function OffsiteReviewModal({
     screenshotCount,
     category: request.appListing?.category,
     description: null,
+    connectClientId,
+    connectRequestedScopes: request.appListing?.connectRequestedScopes ?? null,
+    connectScopeJustifications: request.appListing?.connectScopeJustifications ?? null,
   });
 
   const assetsIncomplete = !assetsQuery.isLoading && (!hasIcon || !hasCover || screenshotCount < 1);
@@ -451,6 +468,14 @@ export function OffsiteReviewModal({
             )}
           </Stack>
         </Card>
+
+        {isConnect && (
+          <ConnectScopesPanel
+            connectClientName={request.appListing?.connectClient?.name ?? null}
+            requestedScopes={request.appListing?.connectRequestedScopes ?? 0}
+            justifications={request.appListing?.connectScopeJustifications ?? null}
+          />
+        )}
 
         <Stack gap={4}>
           <Text size="sm" fw={600}>

--- a/src/components/Apps/__tests__/offsiteReviewChecklist.test.ts
+++ b/src/components/Apps/__tests__/offsiteReviewChecklist.test.ts
@@ -3,8 +3,10 @@ import {
   getOffsiteReviewChecklist,
   getOnsiteReviewChecklist,
   getReviewChecklist,
+  unjustifiedSensitiveScopeKeys,
   type OffsiteChecklistData,
 } from '../offsiteReviewChecklist';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 /**
  * W13 P3a — kind-aware mod-review checklist view-model.
@@ -102,5 +104,74 @@ describe('getOffsiteReviewChecklist — auto-derived statuses', () => {
     );
     expect(byId.name).toBe('warn');
     expect(byId['url-https']).toBe('warn');
+  });
+});
+
+describe('getOffsiteReviewChecklist — connect sensitive-scope item (PR3)', () => {
+  const connectBase: OffsiteChecklistData = {
+    ...complete,
+    connectClientId: 'client-1',
+    connectRequestedScopes: TokenScope.ModelsWrite | TokenScope.ModelsRead, // one sensitive, one read
+  };
+
+  it('non-connect listing (no connectClientId) has NO sensitive-scope item', () => {
+    const ids = getOffsiteReviewChecklist(complete).map((i) => i.id);
+    expect(ids).not.toContain('connect-sensitive-scopes');
+  });
+
+  it('connect listing with an UNjustified sensitive scope → item present and WARN', () => {
+    const item = getOffsiteReviewChecklist({
+      ...connectBase,
+      connectScopeJustifications: {}, // ModelsWrite is sensitive + unjustified
+    }).find((i) => i.id === 'connect-sensitive-scopes');
+    expect(item?.status).toBe('warn');
+    expect(item?.hint).toContain('ModelsWrite');
+  });
+
+  it('connect listing with every sensitive scope justified → item OK', () => {
+    const item = getOffsiteReviewChecklist({
+      ...connectBase,
+      connectScopeJustifications: { ModelsWrite: 'We edit models for the user.' },
+    }).find((i) => i.id === 'connect-sensitive-scopes');
+    expect(item?.status).toBe('ok');
+  });
+
+  it('a NON-sensitive unjustified scope does not warn (item is OK)', () => {
+    // Only ModelsRead requested (non-sensitive) → nothing to justify.
+    const item = getOffsiteReviewChecklist({
+      ...connectBase,
+      connectRequestedScopes: TokenScope.ModelsRead,
+      connectScopeJustifications: {},
+    }).find((i) => i.id === 'connect-sensitive-scopes');
+    expect(item?.status).toBe('ok');
+  });
+});
+
+describe('unjustifiedSensitiveScopeKeys', () => {
+  it('returns the enum-keys of sensitive requested scopes lacking a non-empty justification', () => {
+    expect(
+      unjustifiedSensitiveScopeKeys({
+        connectRequestedScopes: TokenScope.ModelsWrite | TokenScope.MediaWrite,
+        connectScopeJustifications: { ModelsWrite: 'ok' }, // MediaWrite missing
+      })
+    ).toEqual(['MediaWrite']);
+  });
+
+  it('empty when no sensitive scope is requested', () => {
+    expect(
+      unjustifiedSensitiveScopeKeys({
+        connectRequestedScopes: TokenScope.ModelsRead,
+        connectScopeJustifications: {},
+      })
+    ).toEqual([]);
+  });
+
+  it('whitespace-only justification counts as missing', () => {
+    expect(
+      unjustifiedSensitiveScopeKeys({
+        connectRequestedScopes: TokenScope.ModelsWrite,
+        connectScopeJustifications: { ModelsWrite: '   ' },
+      })
+    ).toEqual(['ModelsWrite']);
   });
 });

--- a/src/components/Apps/offsiteReviewChecklist.ts
+++ b/src/components/Apps/offsiteReviewChecklist.ts
@@ -1,4 +1,8 @@
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
+import {
+  SENSITIVE_TOKEN_SCOPES,
+  tokenScopeMaskToList,
+} from '~/shared/constants/token-scope.constants';
 
 /**
  * App Store Listings (W13) — P3a kind-aware mod-review checklist (PURE view-model).
@@ -39,7 +43,33 @@ export type OffsiteChecklistData = {
   screenshotCount: number;
   category: string | null | undefined;
   description: string | null | undefined;
+  // OAuth-CONNECT sub-kind (PR3): present only for a connect listing. When
+  // `connectClientId` is set the checklist adds a "sensitive scopes justified" item
+  // that WARNS if any sensitive requested scope lacks a non-empty justification.
+  connectClientId?: string | null;
+  connectRequestedScopes?: number | null;
+  connectScopeJustifications?: Record<string, string> | null;
 };
+
+/**
+ * The enum-keys of the SENSITIVE requested scopes that have NO non-empty
+ * justification (used by the checklist + a shared surface for the mod UI). Empty
+ * for a non-connect listing or when every sensitive scope is justified.
+ */
+export function unjustifiedSensitiveScopeKeys(data: {
+  connectRequestedScopes?: number | null;
+  connectScopeJustifications?: Record<string, string> | null;
+}): string[] {
+  const sensitiveRequested = (data.connectRequestedScopes ?? 0) & SENSITIVE_TOKEN_SCOPES;
+  if (sensitiveRequested === 0) return [];
+  const justifications = data.connectScopeJustifications ?? {};
+  return tokenScopeMaskToList(sensitiveRequested)
+    .filter(({ key }) => {
+      const raw = justifications[key];
+      return !(typeof raw === 'string' && raw.trim().length > 0);
+    })
+    .map(({ key }) => key);
+}
 
 /**
  * The deep ON-SITE (App Block) review checklist. These items are STATIC reminders
@@ -92,6 +122,8 @@ export function getOffsiteReviewChecklist(data: OffsiteChecklistData): ReviewChe
   const namePresent = typeof data.name === 'string' && data.name.trim().length > 0;
   const urlValid = validateExternalUrl(data.externalUrl).ok;
   const screenshotOk = data.screenshotCount >= 1;
+  const isConnect = data.connectClientId != null;
+  const unjustifiedSensitive = isConnect ? unjustifiedSensitiveScopeKeys(data) : [];
   return [
     {
       id: 'name',
@@ -135,6 +167,21 @@ export function getOffsiteReviewChecklist(data: OffsiteChecklistData): ReviewChe
       hint: 'The declared category matches what the app actually does.',
       status: 'todo',
     },
+    // CONNECT sub-kind only (PR3): warn when a sensitive requested scope has no
+    // justification. Auto-`warn` if any is missing, `ok` when all are justified.
+    ...(isConnect
+      ? [
+          {
+            id: 'connect-sensitive-scopes',
+            label: 'Sensitive permissions justified',
+            hint:
+              unjustifiedSensitive.length > 0
+                ? `Missing a justification for: ${unjustifiedSensitive.join(', ')}. Approval is blocked until every sensitive scope is justified.`
+                : 'Every requested sensitive permission (money / private data / cross-user writes) carries a justification.',
+            status: unjustifiedSensitive.length > 0 ? ('warn' as const) : ('ok' as const),
+          },
+        ]
+      : []),
   ];
 }
 

--- a/src/server/services/blocks/__tests__/offsite-listing.connect.approve.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.connect.approve.service.test.ts
@@ -60,6 +60,9 @@ const CLIENT_ID = 'oauth-client-1';
 // A sensitive scope (ModelsWrite) + a normal read (ModelsRead).
 const REQUESTED = TokenScope.ModelsWrite | TokenScope.ModelsRead;
 const JUSTIFIED = { ModelsWrite: 'We edit models on the user behalf.' };
+// A generous client ceiling (⊇ any scope these tests request) unless a test overrides it.
+const CEILING =
+  TokenScope.ModelsWrite | TokenScope.ModelsRead | TokenScope.MediaWrite | TokenScope.MediaRead;
 
 beforeEach(() => {
   for (const c of [mockRead, mockWrite]) {
@@ -88,6 +91,11 @@ beforeEach(() => {
 function stageConnectApprove(overrides: {
   requestedScopes?: number;
   justifications?: Record<string, string>;
+  /** In-tx (PRIMARY) row overrides — defaults mirror the replica row. Lets a test
+   * diverge the primary from the replica to exercise the in-tx TOCTOU re-gate. */
+  primaryRequestedScopes?: number;
+  primaryJustifications?: Record<string, string>;
+  primaryAllowedScopes?: number;
 } = {}) {
   mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
     id: 'alpr_c',
@@ -96,6 +104,8 @@ function stageConnectApprove(overrides: {
     slug: 'connect-app',
     appListingId: 'apl_c',
   });
+  const requestedScopes = overrides.requestedScopes ?? REQUESTED;
+  const justifications = overrides.justifications ?? JUSTIFIED;
   const listing = {
     id: 'apl_c',
     status: 'draft',
@@ -104,18 +114,24 @@ function stageConnectApprove(overrides: {
     coverId: 2,
     revisionOfId: null,
     connectClientId: CLIENT_ID,
-    connectRequestedScopes: overrides.requestedScopes ?? REQUESTED,
-    connectScopeJustifications: overrides.justifications ?? JUSTIFIED,
+    connectRequestedScopes: requestedScopes,
+    connectScopeJustifications: justifications,
     userId: CALLER,
     name: 'Connect App',
     slug: 'connect-app',
   };
   mockRead.appListing.findUnique.mockResolvedValue(listing);
+  // The in-tx (PRIMARY) re-read: carries the reviewed scope disclosure + the client
+  // ceiling so the AUTHORITATIVE connect gates run row-consistent with the flip. By
+  // default it mirrors the replica; a TOCTOU test overrides the `primary*` fields.
   mockWrite.appListing.findUnique.mockResolvedValue({
     externalUrl: null,
     iconId: 1,
     coverId: 2,
     connectClientId: CLIENT_ID,
+    connectRequestedScopes: overrides.primaryRequestedScopes ?? requestedScopes,
+    connectScopeJustifications: overrides.primaryJustifications ?? justifications,
+    connectClient: { allowedScopes: overrides.primaryAllowedScopes ?? CEILING },
   });
 }
 
@@ -227,7 +243,11 @@ describe('approveExternalRequest — CONNECT revision copies updated scopes to l
 });
 
 describe('approveExternalRequest — sensitive-must-justify gate', () => {
-  it('a SENSITIVE requested scope with NO justification → BAD_REQUEST (no tx opened)', async () => {
+  it('PRE-TX FAST-FAIL: a SENSITIVE requested scope with NO justification (replica) → BAD_REQUEST before the tx opens', async () => {
+    // The replica row ALREADY shows the unjustified sensitive scope, so the pre-tx
+    // fail-fast rejects it without opening the tx. This documents the CHEAP fast-fail;
+    // the AUTHORITATIVE gate (row-consistent, race-safe) is exercised by the in-tx
+    // TOCTOU test below where the replica is benign but the primary is broadened.
     stageConnectApprove({ requestedScopes: REQUESTED, justifications: {} }); // ModelsWrite unjustified
     await expect(
       approveExternalRequest({ publishRequestId: 'alpr_c', reviewerUserId: MOD })
@@ -235,7 +255,7 @@ describe('approveExternalRequest — sensitive-must-justify gate', () => {
       code: 'BAD_REQUEST',
       message: expect.stringContaining('ModelsWrite'),
     });
-    // The gate runs BEFORE the tx — nothing was flipped.
+    // The fast-fail runs BEFORE the tx — nothing was flipped.
     expect(mockWrite.$transaction).not.toHaveBeenCalled();
     expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
   });
@@ -254,5 +274,121 @@ describe('approveExternalRequest — sensitive-must-justify gate', () => {
       approveExternalRequest({ publishRequestId: 'alpr_c', reviewerUserId: MOD })
     ).resolves.toMatchObject({ publishRequestId: 'alpr_c', listingId: 'apl_c' });
     expect(mockWrite.appListing.updateMany).toHaveBeenCalled();
+  });
+});
+
+describe('approveExternalRequest — AUTHORITATIVE in-tx connect re-gate (TOCTOU)', () => {
+  it('🔴 TOCTOU: replica is benign (ModelsRead only) but the PRIMARY was broadened to an unjustified sensitive scope → REJECT inside the tx, NO flip', async () => {
+    // The owner submitted requesting only a non-sensitive scope (pre-tx replica gate
+    // passes), then RACED an in-place edit broadening `connectRequestedScopes` to a
+    // sensitive bit with an empty justification map AFTER the mod's pre-tx check but
+    // BEFORE the flip. The authoritative in-tx re-read must catch it and roll back.
+    stageConnectApprove({
+      requestedScopes: TokenScope.ModelsRead, // replica: benign, gate passes
+      justifications: {},
+      primaryRequestedScopes: TokenScope.ModelsWrite | TokenScope.ModelsRead, // primary: broadened
+      primaryJustifications: {}, // ...with NO justification for the sensitive bit
+    });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_c', reviewerUserId: MOD })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('ModelsWrite'),
+    });
+    // We DID open the tx (the authoritative gate runs inside it) but bailed BEFORE any
+    // flip — neither the request nor the listing status changed, and no live copy wrote.
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    // Owner is NOT notified of a live app that never went live.
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+
+  it('in-tx subset-of-ceiling: the PRIMARY row requests a scope NOT in the client ceiling → REJECT inside the tx, NO flip', async () => {
+    // Guards a client whose `allowedScopes` SHRANK after submit: the requested mask is
+    // a SUPERSET of the (now-smaller) ceiling. Sensitive scopes are all justified, so
+    // this is caught only by the subset re-assert, not the justify gate.
+    stageConnectApprove({
+      requestedScopes: TokenScope.ModelsWrite | TokenScope.ModelsRead,
+      justifications: JUSTIFIED,
+      primaryRequestedScopes: TokenScope.ModelsWrite | TokenScope.ModelsRead,
+      primaryJustifications: JUSTIFIED,
+      primaryAllowedScopes: TokenScope.ModelsRead, // ceiling shrank — ModelsWrite no longer allowed
+    });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_c', reviewerUserId: MOD })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('exceed'),
+    });
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('approveExternalRequest — external-link revision still validates its URL', () => {
+  it('a connect-LESS revision with a bad stored externalUrl still throws BAD_REQUEST on approve (in-tx URL gate)', async () => {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_r',
+      status: 'pending',
+      kind: 'offsite',
+      slug: 'parent-slug',
+      appListingId: 'apl_shadow',
+    });
+    // Replica: the shadow (revisionOfId set) routes into applyApprovedRevision; the
+    // parent is still approved.
+    mockRead.appListing.findUnique.mockImplementation(async (args: { where: { id: string } }) => {
+      if (args.where.id === 'apl_shadow') {
+        return {
+          id: 'apl_shadow',
+          status: 'draft',
+          externalUrl: 'http://insecure.example.com', // non-https stored URL
+          iconId: 1,
+          coverId: 2,
+          revisionOfId: 'apl_parent',
+          connectClientId: null, // external-link revision (no connect)
+          connectRequestedScopes: null,
+          connectScopeJustifications: null,
+          userId: CALLER,
+          name: 'Link App',
+          slug: 'parent-slug',
+        };
+      }
+      if (args.where.id === 'apl_parent') {
+        return { id: 'apl_parent', slug: 'parent-slug', status: 'approved' };
+      }
+      return null;
+    });
+    // In-tx (PRIMARY) shadow re-read carries the same bad URL, connectClientId null.
+    mockWrite.appListing.findUnique.mockImplementation(async (args: { where: { id: string } }) => {
+      if (args.where.id === 'apl_shadow') {
+        return {
+          id: 'apl_shadow',
+          status: 'draft',
+          revisionOfId: 'apl_parent',
+          name: 'Link App',
+          tagline: null,
+          description: null,
+          category: 'utility',
+          contentRating: 'g',
+          externalUrl: 'http://insecure.example.com',
+          connectClientId: null,
+          connectRequestedScopes: null,
+          connectScopeJustifications: null,
+          iconId: 1,
+          coverId: 2,
+        };
+      }
+      return null;
+    });
+
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_r', reviewerUserId: MOD })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('externalUrl'),
+    });
+    // Rolled back before the parent copy.
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.connect.approve.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.connect.approve.service.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { approveExternalRequest } from '~/server/services/blocks/offsite-listing.service';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+/**
+ * App Store Listings (W13) — OAuth-CONNECT APPROVE service tests (PR3).
+ *
+ * Covers the two gaps PR3 closes for connect (OAuth) listings:
+ *   1. approve→live: a connect listing (externalUrl = null) is approvable — the
+ *      `validateExternalUrl` gate is SKIPPED for the connect sub-kind — and a connect
+ *      REVISION copies its (updated) scopes onto the live parent.
+ *   2. sensitive-must-justify: approving a connect listing where a SENSITIVE requested
+ *      scope has no justification is rejected `BAD_REQUEST`; all-justified approves; a
+ *      non-sensitive missing justification does NOT block.
+ *
+ * External-link (non-connect) URL validation is proven UNWEAKENED by the sibling
+ * `offsite-listing.service.test.ts` ("a non-https stored value BLOCKS approve").
+ * DB deps are mocked — no real Prisma.
+ */
+
+const { mockRead, mockWrite } = vi.hoisted(() => {
+  const makeClient = () => ({
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      update: vi.fn(async (args: { data: unknown }) => args.data),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appListingScreenshot: {
+      count: vi.fn(async (..._a: unknown[]) => 0),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+    },
+    image: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+    appListingPublishRequest: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+  });
+  const mockRead = makeClient();
+  const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
+    $transaction: ReturnType<typeof vi.fn>;
+  };
+  mockWrite.$transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  return { mockRead, mockWrite };
+});
+
+const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn(async () => undefined) }));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/services/blocks/app-listing-notify', () => ({
+  notifyAppListingOwner: mockNotify,
+}));
+
+const MOD = 7;
+const CALLER = 42;
+const CLIENT_ID = 'oauth-client-1';
+// A sensitive scope (ModelsWrite) + a normal read (ModelsRead).
+const REQUESTED = TokenScope.ModelsWrite | TokenScope.ModelsRead;
+const JUSTIFIED = { ModelsWrite: 'We edit models on the user behalf.' };
+
+beforeEach(() => {
+  for (const c of [mockRead, mockWrite]) {
+    c.appListing.findUnique.mockReset().mockResolvedValue(null);
+    c.appListing.update.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    c.appListing.updateMany.mockReset().mockResolvedValue({ count: 1 });
+    c.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
+    c.appListingScreenshot.count.mockReset().mockResolvedValue(1);
+    c.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
+    c.appListingScreenshot.deleteMany.mockReset().mockResolvedValue({ count: 0 });
+    c.appListingScreenshot.updateMany.mockReset().mockResolvedValue({ count: 0 });
+    c.image.findMany.mockReset().mockResolvedValue([]);
+    c.appListingPublishRequest.findUnique.mockReset().mockResolvedValue(null);
+    c.appListingPublishRequest.updateMany.mockReset().mockResolvedValue({ count: 1 });
+  }
+  mockWrite.$transaction
+    .mockReset()
+    .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  mockNotify.mockReset().mockResolvedValue(undefined);
+});
+
+/**
+ * Stage a first-time CONNECT approve: a pending connect request → a DRAFT connect
+ * listing (externalUrl null, revisionOfId null), on both the replica + primary.
+ */
+function stageConnectApprove(overrides: {
+  requestedScopes?: number;
+  justifications?: Record<string, string>;
+} = {}) {
+  mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+    id: 'alpr_c',
+    status: 'pending',
+    kind: 'offsite',
+    slug: 'connect-app',
+    appListingId: 'apl_c',
+  });
+  const listing = {
+    id: 'apl_c',
+    status: 'draft',
+    externalUrl: null, // CONNECT: no external URL by construction
+    iconId: 1,
+    coverId: 2,
+    revisionOfId: null,
+    connectClientId: CLIENT_ID,
+    connectRequestedScopes: overrides.requestedScopes ?? REQUESTED,
+    connectScopeJustifications: overrides.justifications ?? JUSTIFIED,
+    userId: CALLER,
+    name: 'Connect App',
+    slug: 'connect-app',
+  };
+  mockRead.appListing.findUnique.mockResolvedValue(listing);
+  mockWrite.appListing.findUnique.mockResolvedValue({
+    externalUrl: null,
+    iconId: 1,
+    coverId: 2,
+    connectClientId: CLIENT_ID,
+  });
+}
+
+describe('approveExternalRequest — CONNECT approve→live (validateExternalUrl skip)', () => {
+  it('approves a connect listing with a NULL externalUrl (URL gate skipped) → draft→approved', async () => {
+    stageConnectApprove();
+    const res = await approveExternalRequest({ publishRequestId: 'alpr_c', reviewerUserId: MOD });
+    expect(res).toEqual({ publishRequestId: 'alpr_c', listingId: 'apl_c', slug: 'connect-app' });
+    // The listing flip fired (draft/pending → approved) — proves approve reached the
+    // flip rather than throwing on the null URL.
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
+      where: { id: 'apl_c', status: { in: ['draft', 'pending'] } },
+      data: { status: 'approved', contentRating: 'g' },
+    });
+    // Owner notified their app went live.
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'app-listing-approved', userId: CALLER })
+    );
+  });
+
+  it('the LIVE connect listing carries the reviewed scopes (flip does not clobber the connect fields)', async () => {
+    stageConnectApprove();
+    await approveExternalRequest({ publishRequestId: 'alpr_c', reviewerUserId: MOD });
+    // The first-time flip only sets status + contentRating; it never rewrites the
+    // connect fields, so the reviewed connectClientId/scopes/justifications persist
+    // on the same (now-approved) row.
+    const flip = mockWrite.appListing.updateMany.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(flip.data).toEqual({ status: 'approved', contentRating: 'g' });
+    expect(flip.data).not.toHaveProperty('connectRequestedScopes');
+  });
+});
+
+describe('approveExternalRequest — CONNECT revision copies updated scopes to live', () => {
+  it('a connect REVISION approve copies connectClientId/scopes/justifications onto the live parent', async () => {
+    const UPDATED = TokenScope.ModelsWrite | TokenScope.MediaWrite; // scope change
+    const UPDATED_JUST = {
+      ModelsWrite: 'still editing models',
+      MediaWrite: 'now also publishing media',
+    };
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_r',
+      status: 'pending',
+      kind: 'offsite',
+      slug: 'parent-slug',
+      appListingId: 'apl_shadow',
+    });
+    // approveExternalRequest reads the SHADOW (revisionOfId set) on the replica →
+    // routes into applyApprovedRevision; applyApprovedRevision then reads the PARENT.
+    mockRead.appListing.findUnique.mockImplementation(async (args: { where: { id: string } }) => {
+      if (args.where.id === 'apl_shadow') {
+        return {
+          id: 'apl_shadow',
+          status: 'draft',
+          externalUrl: null,
+          iconId: 1,
+          coverId: 2,
+          revisionOfId: 'apl_parent',
+          connectClientId: CLIENT_ID,
+          connectRequestedScopes: UPDATED,
+          connectScopeJustifications: UPDATED_JUST,
+          userId: CALLER,
+          name: 'Connect App',
+          slug: 'parent-slug',
+        };
+      }
+      if (args.where.id === 'apl_parent') {
+        return { id: 'apl_parent', slug: 'parent-slug', status: 'approved' };
+      }
+      return null;
+    });
+    // The in-tx (PRIMARY) shadow re-read.
+    mockWrite.appListing.findUnique.mockImplementation(async (args: { where: { id: string } }) => {
+      if (args.where.id === 'apl_shadow') {
+        return {
+          id: 'apl_shadow',
+          status: 'draft',
+          revisionOfId: 'apl_parent',
+          name: 'Connect App',
+          tagline: null,
+          description: null,
+          category: 'utility',
+          contentRating: 'g',
+          externalUrl: null,
+          connectClientId: CLIENT_ID,
+          connectRequestedScopes: UPDATED,
+          connectScopeJustifications: UPDATED_JUST,
+          iconId: 1,
+          coverId: 2,
+        };
+      }
+      return null;
+    });
+
+    const res = await approveExternalRequest({ publishRequestId: 'alpr_r', reviewerUserId: MOD });
+    expect(res).toEqual({ publishRequestId: 'alpr_r', listingId: 'apl_parent', slug: 'parent-slug' });
+
+    // The copy onto the LIVE parent carries the UPDATED connect scopes.
+    const copy = mockWrite.appListing.update.mock.calls[0][0] as {
+      where: { id: string };
+      data: Record<string, unknown>;
+    };
+    expect(copy.where).toEqual({ id: 'apl_parent' });
+    expect(copy.data).toMatchObject({
+      connectClientId: CLIENT_ID,
+      connectRequestedScopes: UPDATED,
+      connectScopeJustifications: UPDATED_JUST,
+    });
+  });
+});
+
+describe('approveExternalRequest — sensitive-must-justify gate', () => {
+  it('a SENSITIVE requested scope with NO justification → BAD_REQUEST (no tx opened)', async () => {
+    stageConnectApprove({ requestedScopes: REQUESTED, justifications: {} }); // ModelsWrite unjustified
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_c', reviewerUserId: MOD })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('ModelsWrite'),
+    });
+    // The gate runs BEFORE the tx — nothing was flipped.
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('all sensitive scopes justified → approves', async () => {
+    stageConnectApprove({ requestedScopes: REQUESTED, justifications: JUSTIFIED });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_c', reviewerUserId: MOD })
+    ).resolves.toMatchObject({ publishRequestId: 'alpr_c', listingId: 'apl_c' });
+  });
+
+  it('a NON-sensitive requested scope missing a justification does NOT block approval', async () => {
+    // Only ModelsRead (non-sensitive) requested, with an empty justification map.
+    stageConnectApprove({ requestedScopes: TokenScope.ModelsRead, justifications: {} });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_c', reviewerUserId: MOD })
+    ).resolves.toMatchObject({ publishRequestId: 'alpr_c', listingId: 'apl_c' });
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -642,7 +642,18 @@ describe('approveExternalRequest', () => {
       where: { id: 'apl_1' },
       // `connectClientId` was added to the in-tx re-read so the URL gate can be
       // skipped for a connect listing (PR3); external-link listings still validate.
-      select: { externalUrl: true, iconId: true, coverId: true, connectClientId: true },
+      // The reviewed scope disclosure + client ceiling are ALSO re-read on the primary
+      // so the sensitive-must-justify + subset-of-ceiling gates are authoritative
+      // (race-safe) rather than pre-tx-replica-only.
+      select: {
+        externalUrl: true,
+        iconId: true,
+        coverId: true,
+        connectClientId: true,
+        connectRequestedScopes: true,
+        connectScopeJustifications: true,
+        connectClient: { select: { allowedScopes: true } },
+      },
     });
     expect(mockWrite.appListingScreenshot.count).toHaveBeenCalledWith({
       where: { appListingId: 'apl_1', imageId: { not: null } },

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -640,7 +640,9 @@ describe('approveExternalRequest', () => {
     // through the PRIMARY client (`tx` === mockWrite) inside the transaction.
     expect(mockWrite.appListing.findUnique).toHaveBeenCalledWith({
       where: { id: 'apl_1' },
-      select: { externalUrl: true, iconId: true, coverId: true },
+      // `connectClientId` was added to the in-tx re-read so the URL gate can be
+      // skipped for a connect listing (PR3); external-link listings still validate.
+      select: { externalUrl: true, iconId: true, coverId: true, connectClientId: true },
     });
     expect(mockWrite.appListingScreenshot.count).toHaveBeenCalledWith({
       where: { appListingId: 'apl_1', imageId: { not: null } },

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1545,9 +1545,15 @@ async function resolveApprovalContentRating(
  * `SENSITIVE_TOKEN_SCOPES` (money / private / cross-user writes) is the flagged set;
  * a non-sensitive requested scope need not be justified. No-op for an external-link
  * listing (`connectClientId == null`) or a connect listing requesting no sensitive
- * scope. Throws `BAD_REQUEST` listing the offending scope keys otherwise. Read-only
- * — call it BEFORE opening the approve tx (the connect fields are immutable across
- * the approve flow, so a pre-tx check is row-consistent enough).
+ * scope. Throws `BAD_REQUEST` listing the offending scope keys otherwise. Read-only.
+ *
+ * 🔴 The connect fields are NOT immutable across the approve flow — an owner can edit
+ * `connectRequestedScopes`/`connectScopeJustifications` in place while the request
+ * sits draft/pending. A pre-tx call on the replica is therefore only a FAST-FAIL; the
+ * AUTHORITATIVE gate runs on the in-tx re-read of the row (row-consistent with the
+ * status flip) so a concurrent scope-broadening can't slip an unjustified sensitive
+ * scope past a mod approval (TOCTOU). Both the first-time approve and the revision
+ * approve paths re-invoke this on their in-tx `tx`-read row before flipping status.
  */
 function assertConnectSensitiveScopesJustified(listing: {
   connectClientId: string | null;
@@ -1740,7 +1746,18 @@ export async function approveExternalRequest(opts: {
     // any failure rolls the whole tx back BEFORE anything is flipped.
     const primaryListing = await tx.appListing.findUnique({
       where: { id: appListingId },
-      select: { externalUrl: true, iconId: true, coverId: true, connectClientId: true },
+      select: {
+        externalUrl: true,
+        iconId: true,
+        coverId: true,
+        connectClientId: true,
+        // Connect sub-kind (PR3): re-read the reviewed scope disclosure on the PRIMARY
+        // so the sensitive-must-justify + subset-of-ceiling gates below are authoritative
+        // (row-consistent with the flip), not merely checked pre-tx on the replica.
+        connectRequestedScopes: true,
+        connectScopeJustifications: true,
+        connectClient: { select: { allowedScopes: true } },
+      },
     });
     if (!primaryListing) {
       throw new OffsiteRequestError('NOT_FOUND', `draft listing ${appListingId} not found`);
@@ -1761,6 +1778,34 @@ export async function approveExternalRequest(opts: {
         throw new TRPCError({
           code: 'BAD_REQUEST',
           message: `stored externalUrl is invalid and cannot be approved: ${primaryUrl.error}`,
+        });
+      }
+    }
+
+    // AUTHORITATIVE connect-scope gate — re-run on the PRIMARY read (row-consistent
+    // with the flip). The pre-tx gate in (4b) is a REPLICA fail-fast: the connect
+    // fields are owner-editable in-place while the request sits pending (draft/pending
+    // in-place edit), so an owner could broaden `connectRequestedScopes` to sensitive
+    // bits (with an empty justification map) AFTER the mod's pre-tx gate passed but
+    // BEFORE this flip — a mod-approved listing would then go live with unjustified
+    // sensitive scopes. Re-asserting on the in-tx row closes that TOCTOU. Mirrors the
+    // revision path's in-tx re-gate. Only for connect listings (`connectClientId`
+    // non-null here; external-link listings carry no scopes).
+    if (primaryListing.connectClientId != null) {
+      assertConnectSensitiveScopesJustified({
+        connectClientId: primaryListing.connectClientId,
+        connectRequestedScopes: primaryListing.connectRequestedScopes,
+        connectScopeJustifications: primaryListing.connectScopeJustifications,
+      });
+      // Also re-assert subset-of-ceiling on the primary: guards a client whose
+      // `allowedScopes` SHRANK after submit (the pre-tx subset check happened at
+      // submit/edit time). A connect listing always has a `connectClient` row here
+      // (FK-backed by the non-null `connectClientId`); treat a null ceiling as 0.
+      const allowedScopes = primaryListing.connectClient?.allowedScopes ?? 0;
+      if (!connectScopesSubsetOfCeiling(primaryListing.connectRequestedScopes ?? 0, allowedScopes)) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'requested scopes exceed the OAuth client’s allowed scopes',
         });
       }
     }

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -22,6 +22,8 @@ import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constant
 import {
   connectScopesSubsetOfCeiling,
   validateConnectScopeJustifications,
+  SENSITIVE_TOKEN_SCOPES,
+  tokenScopeMaskToList,
 } from '~/shared/constants/token-scope.constants';
 import { assertListingAssetsComplete } from '~/server/services/blocks/app-listing-assets.service';
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
@@ -1538,6 +1540,46 @@ async function resolveApprovalContentRating(
 }
 
 /**
+ * Approval gate for OAuth-CONNECT listings (PR3): every SENSITIVE requested scope
+ * MUST carry a non-empty per-scope justification before the listing can go live.
+ * `SENSITIVE_TOKEN_SCOPES` (money / private / cross-user writes) is the flagged set;
+ * a non-sensitive requested scope need not be justified. No-op for an external-link
+ * listing (`connectClientId == null`) or a connect listing requesting no sensitive
+ * scope. Throws `BAD_REQUEST` listing the offending scope keys otherwise. Read-only
+ * — call it BEFORE opening the approve tx (the connect fields are immutable across
+ * the approve flow, so a pre-tx check is row-consistent enough).
+ */
+function assertConnectSensitiveScopesJustified(listing: {
+  connectClientId: string | null;
+  connectRequestedScopes: number | null;
+  connectScopeJustifications: Prisma.JsonValue | null;
+}): void {
+  if (listing.connectClientId == null) return; // external-link listing — no scopes.
+  const sensitiveRequested = (listing.connectRequestedScopes ?? 0) & SENSITIVE_TOKEN_SCOPES;
+  if (sensitiveRequested === 0) return; // nothing sensitive requested.
+  const justifications =
+    listing.connectScopeJustifications &&
+    typeof listing.connectScopeJustifications === 'object' &&
+    !Array.isArray(listing.connectScopeJustifications)
+      ? (listing.connectScopeJustifications as Record<string, unknown>)
+      : {};
+  // Each sensitive requested bit is keyed by its TokenScope enum-key (same mapping
+  // the author-side justification map uses).
+  const missing = tokenScopeMaskToList(sensitiveRequested)
+    .filter(({ key }) => {
+      const raw = justifications[key];
+      return !(typeof raw === 'string' && raw.trim().length > 0);
+    })
+    .map(({ key }) => key);
+  if (missing.length > 0) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `sensitive scope(s) require a justification before approval: ${missing.join(', ')}`,
+    });
+  }
+}
+
+/**
  * MOD approve of a pending off-site request. Loads the request + its draft
  * `AppListing`, asserts `pending`, and enforces two gates BEFORE any mutation:
  *
@@ -1620,6 +1662,12 @@ export async function approveExternalRequest(opts: {
       iconId: true,
       coverId: true,
       revisionOfId: true,
+      // Connect sub-kind (PR3): the discriminator + the reviewed scope disclosure —
+      // used to SKIP the external-URL gate (connect listings store `externalUrl:null`)
+      // and to enforce the sensitive-must-justify approval gate.
+      connectClientId: true,
+      connectRequestedScopes: true,
+      connectScopeJustifications: true,
       // Owner (for the post-commit "approved" owner notification) + name (message).
       userId: true,
       name: true,
@@ -1659,14 +1707,25 @@ export async function approveExternalRequest(opts: {
 
   // (4) Defense-in-depth: re-validate the STORED externalUrl before it can reach
   // the store (mirrors submit + the read-path `safeExternalUrl`). Also re-checked
-  // on the primary inside the tx.
-  const url = validateExternalUrl(listing.externalUrl);
-  if (!url.ok) {
-    throw new TRPCError({
-      code: 'BAD_REQUEST',
-      message: `stored externalUrl is invalid and cannot be approved: ${url.error}`,
-    });
+  // on the primary inside the tx. SKIPPED for a CONNECT listing (PR3): a connect
+  // listing has NO external URL (`externalUrl: null` by construction — the app is a
+  // registered OAuth client, not an off-site link), so the URL gate does not apply;
+  // running it unconditionally is exactly the PR2 audit gap that made connect
+  // listings unapprovable. External-link listings still require a valid https URL.
+  const isConnectListing = listing.connectClientId != null;
+  if (!isConnectListing) {
+    const url = validateExternalUrl(listing.externalUrl);
+    if (!url.ok) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: `stored externalUrl is invalid and cannot be approved: ${url.error}`,
+      });
+    }
   }
+
+  // (4b) Connect sub-kind approval gate (PR3): every SENSITIVE requested scope must
+  // carry a non-empty justification before the app goes live. No-op for external-link.
+  assertConnectSensitiveScopesJustified(listing);
 
   // (5) One transaction: RE-ASSERT the asset gate on the PRIMARY (row-consistent
   // with the flip) + guarded request flip + guarded listing flip + supersede.
@@ -1681,7 +1740,7 @@ export async function approveExternalRequest(opts: {
     // any failure rolls the whole tx back BEFORE anything is flipped.
     const primaryListing = await tx.appListing.findUnique({
       where: { id: appListingId },
-      select: { externalUrl: true, iconId: true, coverId: true },
+      select: { externalUrl: true, iconId: true, coverId: true, connectClientId: true },
     });
     if (!primaryListing) {
       throw new OffsiteRequestError('NOT_FOUND', `draft listing ${appListingId} not found`);
@@ -1694,12 +1753,16 @@ export async function approveExternalRequest(opts: {
       coverId: primaryListing.coverId,
       screenshotCount: primaryScreenshotCount,
     });
-    const primaryUrl = validateExternalUrl(primaryListing.externalUrl);
-    if (!primaryUrl.ok) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: `stored externalUrl is invalid and cannot be approved: ${primaryUrl.error}`,
-      });
+    // Skip the external-URL gate for a connect listing (no URL by construction);
+    // external-link listings still require a valid stored https URL. See step (4).
+    if (primaryListing.connectClientId == null) {
+      const primaryUrl = validateExternalUrl(primaryListing.externalUrl);
+      if (!primaryUrl.ok) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `stored externalUrl is invalid and cannot be approved: ${primaryUrl.error}`,
+        });
+      }
     }
 
     const req = await tx.appListingPublishRequest.updateMany({
@@ -1876,13 +1939,25 @@ async function applyApprovedRevision(opts: {
       coverId: shadow.coverId,
       screenshotCount,
     });
-    const url = validateExternalUrl(shadow.externalUrl);
-    if (!url.ok) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: `stored externalUrl is invalid and cannot be approved: ${url.error}`,
-      });
+    // Skip the external-URL gate for a CONNECT revision (no URL by construction);
+    // external-link revisions still require a valid stored https URL. See the
+    // first-time approve path (step 4) for the same PR3 rationale.
+    if (shadow.connectClientId == null) {
+      const url = validateExternalUrl(shadow.externalUrl);
+      if (!url.ok) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: `stored externalUrl is invalid and cannot be approved: ${url.error}`,
+        });
+      }
     }
+    // Connect approval gate (PR3): the revision carries the (possibly UPDATED) scope
+    // set that will go live — every sensitive requested scope must be justified.
+    assertConnectSensitiveScopesJustified({
+      connectClientId: shadow.connectClientId,
+      connectRequestedScopes: shadow.connectRequestedScopes,
+      connectScopeJustifications: shadow.connectScopeJustifications,
+    });
 
     // (2) Flip the request pending→approved AND re-point it at the PARENT.
     const req = await tx.appListingPublishRequest.updateMany({
@@ -2136,6 +2211,17 @@ const submissionSelect = {
       category: true,
       contentRating: true,
       revisionOfId: true,
+      // OAuth-connect sub-kind (PR3 mod review): the requested-scope disclosure the
+      // moderator reviews. `connectClientId` is the discriminator (null ⇒ an
+      // external-link listing; the mod UI renders the scope panel only when set);
+      // `connectRequestedScopes` is the disclosed bitmask, `connectScopeJustifications`
+      // the per-scope rationale map. `connectClient.{name,allowedScopes}` gives the
+      // reviewed client's display name + its scope CEILING for context. All
+      // additive/PII-safe — the external-link queues just carry nulls.
+      connectClientId: true,
+      connectRequestedScopes: true,
+      connectScopeJustifications: true,
+      connectClient: { select: { name: true, allowedScopes: true } },
       // The listing's TRUE lifecycle status (`draft|pending|approved|rejected|
       // removed`) — DISTINCT from the publish-REQUEST `status`. An owner unpublish
       // / mod delist flips `AppListing.status` approved → removed WITHOUT touching


### PR DESCRIPTION
## PR3 — OAuth-connect listing mod review (+ approve gap fix)

Final piece of the OAuth-connect app-listing scope-review feature. **PR1 (#3217)** + **PR2 (#3218)** are merged; this PR completes the arc: a moderator reviewing an off-site **connect** listing now sees the OAuth scopes the external app requests + the author's per-scope justifications (sensitive-flagged), a **sensitive-must-justify** approval gate is enforced server-side, and the PR2 gap that made connect listings **unapprovable** is fixed so a reviewed connect listing can go live.

Dark behind the existing App Blocks feature gates.

### What changed
1. **OAuth sensitive taxonomy** (`packages/civitai-auth/src/token-scope.ts`, pure/client-safe): `SENSITIVE_TOKEN_SCOPES` (explicit named-bit OR — auditable) + `isSensitiveTokenScope(bit)`.
2. **Read path**: `submissionSelect` (offsite-listing.service) carries `connectClientId` / `connectRequestedScopes` / `connectScopeJustifications` + nested `connectClient { name, allowedScopes }` → flows through `listPendingRequests` to the review queue.
3. **Mod review UI**: new `ConnectScopesPanel` (OAuth analog of `ManifestScopes`) — sensitive scopes render first in a warning group reusing the shared `SensitiveScopeBadge`; per-scope "Why: …" with a muted "No justification provided" fallback. Rendered in `OffsiteReviewModal` **only** when `connectClientId != null`.
4. **Checklist**: warns when any sensitive requested scope lacks a non-empty justification.
5. **Approval gate**: `approveExternalRequest` requires every **sensitive** requested scope (`connectRequestedScopes & SENSITIVE_TOKEN_SCOPES`) to carry a non-empty justification → `BAD_REQUEST` otherwise. Non-sensitive scopes need no justification.
6. **🔴 Connect-approval gap fix (PR2 audit 🟡-1)**: `approveExternalRequest` + `applyApprovedRevision` called `validateExternalUrl(externalUrl)` unconditionally; connect listings store `externalUrl: null`, so approve threw `BAD_REQUEST`. The URL gate now **skips** when `connectClientId != null` (discriminator used elsewhere in the file). **External-link listings still require a valid https `externalUrl`** — that path is unchanged.

### SENSITIVE_TOKEN_SCOPES (for the reviewer to eyeball)
`UserRead · UserWrite · ModelsWrite · ModelsDelete · MediaWrite · MediaDelete · ArticlesWrite · ArticlesDelete · BountiesWrite · BountiesDelete · AIServicesWrite · BuzzRead · CollectionsWrite · SocialWrite · SocialTip · NotificationsWrite · VaultWrite`

Principle: money (`BuzzRead`, `SocialTip`, buzz-spending writes), private/identity (`UserRead` — profile/settings/**email**), and every cross-user/account `*Write`/`*Delete`. Excludes all public-read scopes and the opt-in `AppBlocksSubmit`/`AppBlocksDevTunnel`.

### Test evidence
- **civitai-auth package**: 30 pass (incl. new `SENSITIVE_TOKEN_SCOPES` exact-set / subset-of-`ALL_SCOPES` / `isSensitiveTokenScope` spot-checks).
- **unit (server + checklist)**: 93 pass — connect approve→live (URL gate skipped, draft→approved), connect **revision** copies updated scopes to the live parent, sensitive-must-justify (missing → `BAD_REQUEST`; all-justified → approves; non-sensitive missing → does **not** block), checklist item, PR2 connect tests still green.
- **component (browser, Chromium)**: 17 pass — `ConnectScopesPanel` renders scopes + descriptions + justifications, sensitive group + badge, "No justification provided" fallback; `OffsiteReviewModal` renders the panel for a connect listing and **not** for an external-link listing.
- **tsc** (`tsc --noEmit`): **0 errors** project-wide (0 in changed files, 0 delta vs `origin/main`).

**Revert experiments (proving the gaps are closed):**
- Forcing the `validateExternalUrl` gate to run for connect (revert the skip) → the connect approve→live test **FAILS** (`BAD_REQUEST` on the null URL). Restored → passes.
- Disabling the sensitive-justify throw (revert the gate) → the sensitive-must-justify test **FAILS** (approve resolves instead of rejecting). Restored → passes.

**External-link validation unweakened**: proven by the existing `offsite-listing.service.test.ts` › *"re-validates the STORED externalUrl — a non-https stored value BLOCKS approve"* (a non-connect listing with `http://…` still throws `BAD_REQUEST`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)