### PR TITLE
feat(blocks): complete customComfy bridge v1 server feature (registry + router + timeout-cap budget belt)

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1703,6 +1703,21 @@ export const REDIS_SYS_KEYS = {
      * the approved/owned path is unaffected (only the ephemeral branch increments).
      */
     DEV_TUNNEL_EPHEMERAL_RATE_LIMIT: 'system:blocks:dev-tunnel-ephemeral-rate-limit',
+    /**
+     * App Blocks `customComfy` bridge — per-workflow SETTLE record so a
+     * post-paid customComfy job's terminal poll/cancel can refund the
+     * declared `maxBuzz` CEILING down to the workflow's REAL accrued cost
+     * against BOTH the per-user daily and per-app aggregate reservations.
+     * Keyed `${CUSTOM_COMFY_SETTLE}:<workflowId>`, JSON value
+     * `{ buzzCapKey, appSpendKey|null, ceiling }`, hard-TTL EX ~25h so it
+     * self-expires with the reservation window. Written at submit (after
+     * reserving the ceiling), consumed once via GET+DEL at the FIRST terminal
+     * observation (idempotent settle). On `sysRedis`, like the sibling BLOCKS
+     * caps/limiters. DEV/live-harness tokens still get a per-user daily
+     * reservation + settle; the per-app reservation (and its settle key) is
+     * absent for them (synthetic appBlockId), matching the txt2img caps.
+     */
+    CUSTOM_COMFY_SETTLE: 'system:blocks:custom-comfy-settle',
   },
   DOWNLOAD: {
     LIMITS: 'download:limits',

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -177,6 +177,19 @@ vi.mock('~/server/services/blocks/block-workflows.service', () => ({
   listMyBlockWorkflows: (...a: unknown[]) => mockListMyBlockWorkflows(...(a as [])),
   updateBlockWorkflowStatus: (...a: unknown[]) => mockUpdateBlockWorkflowStatus(...(a as [])),
 }));
+// customComfy post-paid SETTLE-TO-ACTUAL. `persistCustomComfySettle` is awaited in
+// the customComfy submit path; `settleCustomComfySpend` is called on the terminal
+// poll/cancel hook. Mock at the module boundary so we assert the exact
+// (server-derived) args the router passes; the service's refund logic is
+// unit-tested separately in custom-comfy-settle.service.test.ts.
+const { mockPersistCustomComfySettle, mockSettleCustomComfySpend } = vi.hoisted(() => ({
+  mockPersistCustomComfySettle: vi.fn(async () => undefined),
+  mockSettleCustomComfySpend: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/blocks/custom-comfy-settle.service', () => ({
+  persistCustomComfySettle: (...a: unknown[]) => mockPersistCustomComfySettle(...(a as [])),
+  settleCustomComfySpend: (...a: unknown[]) => mockSettleCustomComfySpend(...(a as [])),
+}));
 // submitWorkflow fires recordScopeInvocation (detached) which dynamic-imports the
 // REAL, heavy user-app-surface.service. That first-time real import serializes the
 // module runner and starves the sibling detached fire-and-forget writes (G6 queue),
@@ -478,6 +491,11 @@ beforeEach(() => {
   // G6 read-model flip: default to a resolved 1-row UPDATE. Tests exercising the
   // non-terminal (never-called) + best-effort (rejects) paths override this.
   mockUpdateBlockWorkflowStatus.mockResolvedValue(1);
+  // customComfy settle: default both to resolved no-ops (best-effort posture).
+  mockPersistCustomComfySettle.mockReset();
+  mockPersistCustomComfySettle.mockResolvedValue(undefined);
+  mockSettleCustomComfySpend.mockReset();
+  mockSettleCustomComfySpend.mockResolvedValue(undefined);
   // F4 defaults: no active dev tunnel (getActiveDevTunnel → null) so the dev
   // spend backstop is inert for every non-dev test. The F4 tests override these.
   mockGetActiveDevTunnel.mockResolvedValue(null);
@@ -4475,5 +4493,310 @@ describe('blocks.updateUserSettings — W13 action detail', () => {
       detail: { action: 'settings.update', outcome: 'ok' },
     });
     expect(auditArg.scope).not.toBe('block:settings:write');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App Blocks customComfy bridge (v1) — the SECURITY-CRITICAL post-paid path.
+// Covers every seam of plan §7 exercised at the ROUTER boundary: the page-only
+// guard, the entitlement gate over the recipe's pinned civitai versions, the
+// prompt audit on the new branch, and the §5.3 timeout-cap BUDGET BELT (static
+// maxBuzz<=buzzBudget gate, reserve-the-CEILING on both caps, refund-on-throw,
+// terminal settle). The settle refund arithmetic itself is unit-tested in
+// custom-comfy-settle.service.test.ts; here we assert the router CALLS it with
+// the correct server-derived args.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('customComfy bridge (submit/estimate/settle)', () => {
+  // The pinned 360Redmond LoRA versions the entitlement gate resolves (one per
+  // DiT engine of public model 118025 — see the recipe registry).
+  const CC_LORA_VERSION_IDS = [2702227, 2702222, 2702214];
+
+  // A PAGE token (ctx.entityType==='none') — customComfy recipes are page-only.
+  function ccPageClaims(over: Record<string, unknown> = {}) {
+    return validClaims({
+      ctx: { entityType: 'none', slotId: 'page' },
+      appBlockId: 'apb_test',
+      buzzBudget: 500, // comfortably above the recipe ceiling (180) by default
+      ...over,
+    });
+  }
+
+  function ccBody(over: Record<string, unknown> = {}) {
+    return {
+      kind: 'customComfy' as const,
+      recipe: 'seamless-pano-360',
+      params: { prompt: 'a sunset over mountains', engine: 'zimage-turbo' },
+      ...over,
+    };
+  }
+
+  // Resolve every pinned LoRA version as a published, generatable resource so the
+  // entitlement belt passes on the happy path. Tests override the canGenerate map.
+  function happyCcResources() {
+    happyUser(); // moderator subject for the developer gate + getBlockSessionUser
+    mockDbRead.modelVersion.findUnique.mockImplementation(async (args: { where: { id: number } }) => ({
+      id: args.where.id,
+      baseModel: 'Flux.1 D',
+      modelId: 118025,
+      status: 'Published',
+      availability: 'Public',
+      usageControl: 'Allow',
+      meta: {},
+      generationCoverage: { covered: true },
+      model: { id: 118025, type: 'LORA', userId: 999 },
+    }));
+    mockResolveCanGenerateForVersions.mockResolvedValue(
+      new Map(CC_LORA_VERSION_IDS.map((id) => [id, { canGenerate: true }]))
+    );
+  }
+
+  function happySubmit() {
+    mockSubmitWorkflow.mockResolvedValue({
+      id: 'wf_cc_1',
+      status: 'processing',
+      steps: [{ $type: 'customComfy', output: { blobs: [] } }],
+      cost: { total: 0 },
+    });
+  }
+
+  const caller = () => blocksRouter.createCaller(fakeCtx() as never);
+
+  describe('estimateWorkflow', () => {
+    it('returns the recipe per-engine DISPLAY estimate WITHOUT an orchestrator whatIf', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyUser();
+      const result = await caller().estimateWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(result.snapshot).toMatchObject({
+        workflowId: 'wf_estimate',
+        status: 'pending',
+        cost: { total: 20 }, // zimage-turbo display estimate
+      });
+      // No real orchestrator round-trip on a customComfy estimate.
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('reflects the selected engine in the estimate (qwen-image → 150)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyUser();
+      const result = await caller().estimateWorkflow({
+        blockToken: 'tok',
+        body: ccBody({ params: { prompt: 'x', engine: 'qwen-image' } }),
+      });
+      expect(result.snapshot.cost).toEqual({ total: 150 });
+    });
+
+    it('REJECTS a model token (customComfy is page-only)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims()); // model token (ctx.modelId)
+      happyUser();
+      await expect(
+        caller().estimateWorkflow({ blockToken: 'tok', body: ccBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+  });
+
+  describe('submitWorkflow — budget belt', () => {
+    it('happy path: reserves the CEILING on BOTH caps, submits the timeout step, persists the settle record', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(result.snapshot.workflowId).toBe('wf_cc_1');
+      // (2) per-user daily cap reserved the CEILING (180), not the 0 estimate.
+      expect(mockSysRedis.incrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        180
+      );
+      // (3) per-app aggregate cap reserved the CEILING.
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 180);
+      // settle record persisted with BOTH reservation keys + the ceiling.
+      expect(mockPersistCustomComfySettle).toHaveBeenCalledWith({
+        workflowId: 'wf_cc_1',
+        buzzCapKey: expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        appSpendKey: 'system:blocks:app-spend-cap:apb_test:day',
+        ceiling: 180,
+      });
+    });
+
+    it('tags reflect the recipe id + customComfy (never txt2img), preserving app-block provenance', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      const body = mockSubmitWorkflow.mock.calls[0][0].body;
+      expect(body.tags).toContain('customComfy');
+      expect(body.tags).toContain('seamless-pano-360');
+      expect(body.tags).toContain('app-block');
+      expect(body.tags).toContain('app-block:app_test'); // appBlockTag(appId) — subqueue read
+      expect(body.tags).not.toContain('txt2img');
+    });
+
+    it('STATIC gate: recipe ceiling > buzzBudget → failed snapshot, NO reserve, NO submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ buzzBudget: 50 })); // 180 > 50
+      happyCcResources();
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(result.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
+      expect(result.snapshot.error).toMatch(/ceiling 180 exceeds budget 50/);
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled(); // never reserved
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('daily-cap breach → failed snapshot + refund of the reserved CEILING, NO submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      mockSysRedis.incrBy.mockResolvedValue(60000); // reservation pushes over 50k cap
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(result.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
+      expect(result.snapshot.error).toMatch(/daily Buzz cap/);
+      // refunded the reserved ceiling on the pinned key.
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        180
+      );
+      expect(mockReserveAppSpend).not.toHaveBeenCalled(); // never reached the app cap
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('app-cap breach → failed snapshot + refund of the per-user CEILING reservation, NO submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      mockReserveAppSpend.mockResolvedValue({
+        allowed: false,
+        reason: 'daily',
+        dailyTotal: 9_999_999,
+        velocityCount: 1,
+      });
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(result.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
+      expect(result.snapshot.error).toMatch(/app daily spend cap/);
+      // per-user daily reservation rolled back.
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        180
+      );
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('refund-on-throw: a failing orchestrator submit refunds the CEILING on BOTH keys and re-throws', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: ccBody() })
+      ).rejects.toThrow(/orchestrator down/);
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        180
+      );
+      expect(mockRefundAppSpend).toHaveBeenCalledWith('system:blocks:app-spend-cap:apb_test:day', 180);
+      // never persisted a settle record for a submit that threw.
+      expect(mockPersistCustomComfySettle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('submitWorkflow — security seams', () => {
+    it('page-only guard: a MODEL token is rejected fail-closed BEFORE any spend', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 500 })); // model token
+      happyUser();
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: ccBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('entitlement gate: a gated/ungeneratable pinned version is rejected BEFORE submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      // One pinned version resolves to NOT generatable → assertViewerCanGeneratePageResources throws.
+      mockResolveCanGenerateForVersions.mockResolvedValue(
+        new Map([[CC_LORA_VERSION_IDS[0], { canGenerate: false }]])
+      );
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: ccBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled(); // no reservation before the gate
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('prompt audit runs on the customComfy branch (raw prompt + recipe negative) and blocks a flagged prompt', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      mockAuditPromptServer.mockRejectedValue(
+        new TRPCError({ code: 'BAD_REQUEST', message: 'prompt blocked' })
+      );
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: ccBody({ params: { prompt: 'disallowed content', engine: 'zimage-turbo' } }),
+        })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      // audited the RAW prompt + the recipe's negative, before any orchestrator call / spend.
+      expect(mockAuditPromptServer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: 'disallowed content',
+          negativePrompt: expect.stringContaining('ugly'),
+          userId: 42,
+        })
+      );
+      expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('unknown recipe id is rejected at the wire schema (never reaches the handler)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyUser();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: { kind: 'customComfy', recipe: 'not-a-recipe', params: { prompt: 'x' } } as never,
+        })
+      ).rejects.toBeTruthy();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('settle-to-actual on terminal poll/cancel', () => {
+    it('poll to a terminal status settles the workflow to its REAL accrued cost', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_cc_1',
+        status: 'succeeded',
+        cost: { total: 30 },
+        steps: [{ $type: 'customComfy', output: { blobs: [] } }],
+      });
+      await caller().pollWorkflow({ blockToken: 'tok', workflowId: 'wf_cc_1' });
+      expect(mockSettleCustomComfySpend).toHaveBeenCalledWith({
+        workflowId: 'wf_cc_1',
+        actualCost: 30,
+      });
+    });
+
+    it('does NOT settle on a non-terminal (processing) poll', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_cc_1',
+        status: 'processing',
+        cost: { total: 10 },
+        steps: [{ $type: 'customComfy', output: { blobs: [] } }],
+      });
+      await caller().pollWorkflow({ blockToken: 'tok', workflowId: 'wf_cc_1' });
+      expect(mockSettleCustomComfySpend).not.toHaveBeenCalled();
+    });
+
+    it('cancel bills accrued + settles the ceiling down to the accrued cost', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      mockCancelWorkflow.mockResolvedValue(undefined);
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_cc_1',
+        status: 'canceled',
+        cost: { total: 12 }, // accrued-so-far billed by the orchestrator on cancel
+        steps: [{ $type: 'customComfy', output: { blobs: [] } }],
+      });
+      await caller().cancelWorkflow({ blockToken: 'tok', workflowId: 'wf_cc_1' });
+      expect(mockSettleCustomComfySpend).toHaveBeenCalledWith({
+        workflowId: 'wf_cc_1',
+        actualCost: 12,
+      });
+    });
   });
 });

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -4693,6 +4693,102 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
     });
   });
 
+  // ── F4: dev-tunnel per-session spend backstop on the customComfy branch. Same
+  // semantics as the txt2img F4 backstop, but reserves the CEILING (recipe.maxBuzz)
+  // and is SETTLED at terminal (the session id rides the settle record), so it is
+  // safe to add over the post-paid path.
+  describe('submitWorkflow — dev-session backstop (F4)', () => {
+    it('a dev-token submit with an active tunnel reserves the CEILING on the session cap + persists the session id', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ dev: true }));
+      happyCcResources();
+      happySubmit();
+      mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 5000 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 180 });
+
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(result.snapshot.workflowId).toBe('wf_cc_1');
+      // Reserved the CEILING (180), not the 0 estimate, against the session cap.
+      expect(mockReserveDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 180, 5000);
+      // Dev token → NO per-app reserve, but the settle record carries the session
+      // id (so terminal settle refunds ceiling-actual on the session cap too).
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockPersistCustomComfySettle).toHaveBeenCalledWith({
+        workflowId: 'wf_cc_1',
+        buzzCapKey: expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        appSpendKey: null,
+        devSessionId: 'bki_dev',
+        ceiling: 180,
+      });
+    });
+
+    it('a NON-dev token WITH an active tunnel reserves BOTH the app cap and the session cap', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims()); // non-dev token
+      happyCcResources();
+      happySubmit();
+      mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 5000 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 180 });
+
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 180);
+      expect(mockReserveDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 180, 5000);
+      expect(mockPersistCustomComfySettle).toHaveBeenCalledWith({
+        workflowId: 'wf_cc_1',
+        buzzCapKey: expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        appSpendKey: 'system:blocks:app-spend-cap:apb_test:day',
+        devSessionId: 'bki_dev',
+        ceiling: 180,
+      });
+    });
+
+    it('over the session ceiling → failed snapshot + refund of the reserved CEILING, NO submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ dev: true }));
+      happyCcResources();
+      mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 100 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: false, total: 100 });
+
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(result.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
+      expect(result.snapshot.error).toMatch(/dev tunnel session Buzz cap reached/);
+      // The per-user daily CEILING reservation was rolled back.
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        180
+      );
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(mockPersistCustomComfySettle).not.toHaveBeenCalled();
+    });
+
+    it('refund-on-throw ALSO refunds the dev-session CEILING when the submit throws', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ dev: true }));
+      happyCcResources();
+      mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 5000 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 180 });
+      mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
+
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: ccBody() })
+      ).rejects.toThrow(/orchestrator down/);
+      // Daily + dev-session ceiling both refunded on the throw.
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        180
+      );
+      expect(mockRefundDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 180);
+      expect(mockPersistCustomComfySettle).not.toHaveBeenCalled();
+    });
+
+    it('is INERT for a normal (no-tunnel) submit — reserve never called, NO session id persisted', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      // default mockGetActiveDevTunnel → null
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(mockReserveDevSessionBuzz).not.toHaveBeenCalled();
+      const persistArg = mockPersistCustomComfySettle.mock.calls[0][0];
+      expect(persistArg).not.toHaveProperty('devSessionId');
+    });
+  });
+
   describe('submitWorkflow — security seams', () => {
     it('page-only guard: a MODEL token is rejected fail-closed BEFORE any spend', async () => {
       mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 500 })); // model token

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -68,6 +68,8 @@ import {
   withdrawRequestSchema,
 } from '~/server/schema/blocks/publish-request.schema';
 import { blockWorkflowBodySchema } from '~/server/schema/blocks/workflow.schema';
+import type { BlockWorkflowBody } from '~/server/schema/blocks/workflow.schema';
+import type { Context } from '~/server/createContext';
 import {
   allowMatureContentForCeiling,
   sfwBrowsingLevelsFlag,
@@ -100,13 +102,27 @@ import { getRequestDomainColor, isHostForColor } from '~/server/utils/server-dom
 import type { ResolveCanGenerateVersion } from '~/server/services/generation/generation.service';
 import {
   appBlockTag,
+  buildCustomComfyWorkflowInput,
   buildTextToImageInput,
+  createBlockCustomComfyStep,
   isPageLoraResource,
   projectAppWorkflow,
   resolveBlockVersionContext,
   resolvePageResourceContext,
   snapshotFromWorkflow,
 } from '~/server/services/blocks/workflow.service';
+// App Blocks customComfy bridge (v1). The recipe registry is the code-reviewed
+// trust root; the schema already gated `recipe` to a registered id, so `getRecipe`
+// never returns undefined for a schema-valid body (defensively re-checked).
+import { getRecipe, recipeCivitaiVersionIds } from '~/server/services/blocks/recipes';
+// Post-paid SETTLE-TO-ACTUAL for customComfy (plan §5.3). `persist*` is awaited in
+// submit (after reserving the ceiling); `settle*` is a best-effort call on the
+// terminal poll/cancel hook. Static import (both are light) — the heavy
+// refundAppSpend it may call is itself dynamic-imported inside the service.
+import {
+  persistCustomComfySettle,
+  settleCustomComfySpend,
+} from '~/server/services/blocks/custom-comfy-settle.service';
 // G8 — per-app aggregate spend/velocity cap. Type-only import (erased at
 // runtime): the cap functions themselves are dynamic-imported in the submit
 // path (mirrors recordSpendAttribution / the dev-tunnel backstop), so this adds
@@ -2589,6 +2605,16 @@ export const blocksRouter = router({
         } catch {
           /* best-effort: a read-model write failure never breaks the poll */
         }
+        // customComfy post-paid SETTLE-TO-ACTUAL (plan §5.3): refund the reserved
+        // CEILING down to the workflow's REAL accrued cost on BOTH reservation
+        // keys. Self-scoping + idempotent (a settle record exists ONLY for a
+        // customComfy submit and is consumed once via GET+DEL), and best-effort
+        // (never throws) — so it is safe to call for ANY terminal workflow; a
+        // txt2img / already-settled workflow simply no-ops.
+        await settleCustomComfySpend({
+          workflowId: input.workflowId,
+          actualCost: snapshot.cost?.total ?? 0,
+        });
       }
       return { snapshot };
     }),
@@ -2688,7 +2714,17 @@ export const blocksRouter = router({
       const token = await getOrchestratorToken(userId, ctx);
       await cancelWorkflow({ workflowId: input.workflowId, token });
       const workflow = await getWorkflow({ token, path: { workflowId: input.workflowId } });
-      return { snapshot: snapshotFromWorkflow(workflow) };
+      const snapshot = snapshotFromWorkflow(workflow);
+      // customComfy post-paid SETTLE (plan §5.3): a mid-run cancel BILLS the
+      // accrued cost (orchestrator-side, non-refundable), so settle refunds the
+      // reserved CEILING down to that accrued `cost.total` on BOTH reservation
+      // keys. Self-scoping + idempotent + best-effort — a txt2img / non-customComfy
+      // cancel has no settle record and no-ops.
+      await settleCustomComfySpend({
+        workflowId: input.workflowId,
+        actualCost: snapshot.cost?.total ?? 0,
+      });
+      return { snapshot };
     }),
 
   /**
@@ -3102,6 +3138,13 @@ export const blocksRouter = router({
       if (!claims.scopes.includes('ai:write:budgeted')) {
         throw new TRPCError({ code: 'FORBIDDEN', message: 'block lacks ai:write:budgeted scope' });
       }
+      // App Blocks customComfy bridge (v1): a fixed server-authored recipe has no
+      // whatIf-able cost, so estimate returns the recipe's per-engine DISPLAY
+      // estimate. The textToImage path below stays byte-identical (we only ADD a
+      // branch). Everything customComfy-specific lives in the helper.
+      if (input.body.kind === 'customComfy') {
+        return await estimateCustomComfyWorkflow({ claims, body: input.body });
+      }
       // Context binding. A MODEL token pins `ctx.modelId`; the body must match
       // it. A PAGE token (ctx.entityType==='none') has NO model binding — it
       // lets the viewer pick a model, so the modelId match is SKIPPED and
@@ -3262,6 +3305,20 @@ export const blocksRouter = router({
       if (typeof claims.buzzBudget !== 'number' || claims.buzzBudget <= 0) {
         throw new TRPCError({ code: 'FORBIDDEN', message: 'block token missing budget' });
       }
+      // App Blocks customComfy bridge (v1) — the SECURITY-CRITICAL post-paid
+      // path. Branch to the dedicated handler (page-only guard + entitlement +
+      // prompt audit + the §5.3 timeout-cap budget belt). The textToImage path
+      // below stays byte-identical (we only ADD a branch); after this early
+      // return `input.body` narrows to the textToImage member for the rest.
+      if (input.body.kind === 'customComfy') {
+        return await submitCustomComfyWorkflow({ ctx, claims, body: input.body });
+      }
+      // `input.body` is now the textToImage member. Capture it so the narrowing
+      // survives into the fire-and-forget spend-attribution CLOSURE below (TS
+      // drops discriminated-union property narrowing at nested-function
+      // boundaries — the synchronous txt2img code keeps using `input.body`
+      // byte-identically; only the closure reads this alias).
+      const textToImageBody = input.body;
       // Context binding. MODEL token → body.modelId must match ctx.modelId.
       // PAGE token (ctx.entityType==='none') → no model binding; skip the match
       // and enforce the pre-spend availability gate after the version read
@@ -3858,7 +3915,7 @@ export const blocksRouter = router({
             // behalf of. Passed through OPAQUE — the service resolves the author
             // SERVER-SIDE from the app's own shared storage (never trusts the
             // client). Omitted → unchanged app-owner-only attribution.
-            sharedContentKey: input.body.sharedContentKey ?? null,
+            sharedContentKey: textToImageBody.sharedContentKey ?? null,
           });
         })().catch(() => {
           /* best-effort: a failed attribution write never breaks submit */
@@ -5053,6 +5110,289 @@ async function getBlockSessionUser(userId: number): Promise<SessionUser> {
   return row as unknown as SessionUser;
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// App Blocks `customComfy` bridge (v1) — estimate + submit handlers.
+//
+// A `customComfy` body carries `{ kind, recipe, params }` — NO model binding,
+// NO whatIf-able cost (post-paid customComfy whatIfs to 0). These two handlers
+// are the second `kind` branch off estimateWorkflow / submitWorkflow; the
+// textToImage path stays byte-identical (the procs branch, they don't rewrite).
+// The load-bearing addition is the POST-PAID BUDGET BELT (plan §5.3): a static
+// `maxBuzz <= buzzBudget` gate + reserve-the-CEILING + settle-to-actual, since
+// the step `timeout` (stamped by createBlockCustomComfyStep) is the ONLY
+// deterministic per-job Buzz bound the orchestrator offers.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type BlockClaims = NonNullable<Awaited<ReturnType<typeof verifyBlockToken>>>;
+type CustomComfyBody = Extract<BlockWorkflowBody, { kind: 'customComfy' }>;
+
+/**
+ * Resolve the recipe from the (schema-gated) `recipe` id. The wire schema's
+ * `z.enum(REGISTERED_RECIPE_IDS)` already rejected any unregistered id at the
+ * union, so this never returns undefined for a schema-valid body — the guard is
+ * defense-in-depth against a registry/schema desync. Fail closed.
+ */
+function resolveCustomComfyRecipe(body: CustomComfyBody) {
+  const recipe = getRecipe(body.recipe);
+  if (!recipe) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'unknown recipe' });
+  }
+  return recipe;
+}
+
+/**
+ * customComfy ESTIMATE (plan §4). Do NOT run a real whatIf (returns 0 for
+ * customComfy) — return the recipe's honest per-engine DISPLAY estimate. Same
+ * page-only + developer gates as submit, so a model token / non-developer can't
+ * even probe estimates. Fail-closed on an out-of-bounds param (ZodError).
+ */
+async function estimateCustomComfyWorkflow(opts: { claims: BlockClaims; body: CustomComfyBody }) {
+  const { claims, body } = opts;
+  // Page-only: a fixed server-authored recipe belongs to the page path (mirrors
+  // the model-token sourceImage/additionalResources rejection in the txt2img
+  // branch). Defense-in-depth even on estimate.
+  if (!isPageToken(claims)) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'customComfy recipes are page-only' });
+  }
+  const userId = parseSubjectUserId(claims.sub);
+  if (userId == null) {
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'estimate requires authenticated viewer' });
+  }
+  await assertAppBlocksEnabledForTokenUser(userId);
+  await assertViewerIsAppDeveloper(userId);
+  const recipe = resolveCustomComfyRecipe(body);
+  // Parse through the recipe's OWN `.strict()` schema so the engine (which drives
+  // the per-engine display estimate) is validated/bounded; an invalid param
+  // throws a ZodError → BAD_REQUEST, exactly as submit fails closed.
+  const params = recipe.paramSchema.parse(body.params);
+  return {
+    snapshot: {
+      // Non-empty sentinel: the SDK's inbound validator drops empty-workflowId
+      // snapshots. The block treats estimate as a cost quote and never polls it.
+      workflowId: 'wf_estimate',
+      status: 'pending' as const,
+      cost: { total: recipe.estimateBuzz(params) },
+    },
+  };
+}
+
+/**
+ * customComfy SUBMIT (plan §4 + §5.3 — the crux). Order: page-only guard →
+ * developer gates → per-recipe param parse → entitlement gate over the recipe's
+ * pinned civitai versions → prompt audit → post-paid budget belt (static gate +
+ * reserve-the-ceiling on both caps) → build+submit the timeout-stamped step →
+ * persist the settle record. Over-cap / rejections return a failed-shape
+ * snapshot (recoverable by the block); a throw AFTER reserving refunds the
+ * ceiling on both keys.
+ */
+async function submitCustomComfyWorkflow(opts: {
+  ctx: Context;
+  claims: BlockClaims;
+  body: CustomComfyBody;
+}) {
+  const { ctx, claims, body } = opts;
+
+  // ── Page-only guard (mirror the model-token sourceImage rejection ~:3294).
+  if (!isPageToken(claims)) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'customComfy recipes are page-only' });
+  }
+  // The outer proc already gated this, but re-narrow here (defense-in-depth) so
+  // `buzzBudget` is a positive number the static gate can compare against.
+  if (typeof claims.buzzBudget !== 'number' || claims.buzzBudget <= 0) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'block token missing budget' });
+  }
+  const userId = parseSubjectUserId(claims.sub);
+  if (userId == null) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'workflow submit requires authenticated viewer',
+    });
+  }
+  await assertAppBlocksEnabledForTokenUser(userId);
+  await assertViewerIsAppDeveloper(userId);
+
+  const recipe = resolveCustomComfyRecipe(body);
+  // The recipe's OWN `.strict()` schema is the real param contract (the wire
+  // schema only gated `recipe`); an invalid param throws → fail-closed.
+  const params = recipe.paramSchema.parse(body.params);
+
+  const user = await getBlockSessionUser(userId);
+  const { allowMatureContent, isGreen } = resolveBlockMaturity(claims);
+  // Honor a money-page account pick (preferred-first, domain-clamped) as txt2img;
+  // absent → Auto.
+  const currencies = resolveBlockCurrenciesForAccount(isGreen, params.accountType);
+
+  // ── Entitlement gate (plan §6). A raw customComfy step submits its `resources`
+  // AIR array DIRECTLY, bypassing the generation-graph path's automatic
+  // resolveCanGenerateForVersions. Run the SAME belt the txt2img page branch uses
+  // over EVERY civitai version the recipe pins (v1 = fixed public LoRAs) BEFORE
+  // emitting the step — so the code-reviewed registry can't be quietly edited to
+  // point at a gated / early-access / Private / unpublished version without the
+  // belt catching it. The huggingface staticAirs carry no civitai entitlement
+  // (exempt-by-construction). checkpointPolicy:'pinned' → no user checkpoint in v1.
+  const versionIds = recipeCivitaiVersionIds(recipe);
+  if (versionIds.length > 0) {
+    const gates: ReturnType<typeof buildGateVersion>[] = [];
+    for (const versionId of versionIds) {
+      const resolvedVersion = await resolvePageResourceContext(versionId);
+      gates.push(buildGateVersion(resolvedVersion.gate));
+    }
+    await assertViewerCanGeneratePageResources({
+      gates,
+      viewer: { id: userId, isModerator: !!user.isModerator },
+      sfwOnly: allowMatureContent === false,
+      wildcardsEnabled: !!ctx.features.wildcards,
+    });
+  }
+
+  const token = await getOrchestratorToken(userId, ctx);
+
+  // ── Prompt audit (plan §7 seam 3). A server-owned graph earns NO moderation
+  // bypass — audit the RAW prompt (the recipe appends its trigger-word prefix +
+  // quality suffix only INSIDE the builder, AFTER this read) with the
+  // domain-derived isGreen strictness, exactly like txt2img, before any
+  // orchestrator call.
+  await auditPromptServer({
+    prompt: params.prompt,
+    negativePrompt: recipe.negativePrompt,
+    userId,
+    isGreen,
+    isModerator: !!user.isModerator,
+  });
+
+  // ── Post-paid budget belt (plan §5.3 — THE crux) ─────────────────────────
+  // `ceiling === recipe.maxBuzz === ceil(stepTimeoutSeconds)` (enforced at
+  // registry load): the step `timeout` physically caps the job at this many Buzz.
+  const ceiling = recipe.maxBuzz;
+
+  // (1) STATIC pre-submit gate — the post-paid analog of the txt2img whatIf
+  // `cost > buzzBudget` gate. Because the timeout caps the job at `maxBuzz` and we
+  // require `maxBuzz <= buzzBudget`, the per-call budget CANNOT be exceeded.
+  // Deterministic, no orchestrator round-trip.
+  if (ceiling > claims.buzzBudget) {
+    return {
+      snapshot: {
+        workflowId: 'failed',
+        status: 'failed' as const,
+        cost: { total: ceiling },
+        error: `insufficient buzz budget: recipe ceiling ${ceiling} exceeds budget ${claims.buzzBudget}`,
+      },
+    };
+  }
+
+  // (2) Reserve the CEILING (not the 0 estimate) against the per-user daily cap so
+  // post-paid spend can't slip past the 50k/day ceiling counted at ~0.
+  const { total, key: buzzCapKey } = await reserveBlockBuzzSpend(userId, ceiling);
+  if (total > BLOCK_BUZZ_CAP_PER_DAY) {
+    await refundBlockBuzzSpend(buzzCapKey, ceiling);
+    return {
+      snapshot: {
+        workflowId: 'failed',
+        status: 'failed' as const,
+        cost: { total: ceiling },
+        error:
+          `daily Buzz cap reached: ${total - Math.ceil(ceiling)} already spent today ` +
+          `across your installed apps, this generation may cost up to ${ceiling}, ` +
+          `daily cap is ${BLOCK_BUZZ_CAP_PER_DAY}`,
+      },
+    };
+  }
+
+  // (3) Reserve the CEILING against the per-app aggregate cap (G8). Skipped for
+  // DEV tokens (synthetic non-FK appBlockId) — matching the txt2img caps.
+  let appSpendReserve: { key: AppSpendDailyKey; cost: number } | null = null;
+  if (claims.dev !== true) {
+    const { reserveAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
+    const appSpend = await reserveAppSpend(claims.appBlockId, ceiling);
+    if (!appSpend.allowed) {
+      // Roll back the per-user reservation so a rejected submit doesn't burn the
+      // viewer's own daily ceiling for a spend that never happened.
+      await refundBlockBuzzSpend(buzzCapKey, ceiling);
+      return {
+        snapshot: {
+          workflowId: 'failed',
+          status: 'failed' as const,
+          cost: { total: ceiling },
+          error:
+            appSpend.reason === 'velocity'
+              ? 'app generation rate limit reached: this app has run too many generations in a short window — please retry shortly'
+              : appSpend.reason === 'unavailable'
+              ? 'generation temporarily unavailable — please retry shortly'
+              : 'app daily spend cap reached: this app has hit its aggregate daily generation-spend ceiling — please try again later',
+        },
+      };
+    }
+    if (appSpend.dailyKey) appSpendReserve = { key: appSpend.dailyKey, cost: ceiling };
+  }
+
+  // ── Build + submit. `createBlockCustomComfyStep` stamps the recipe's aggressive
+  // `timeout` — the physical Buzz ceiling. On ANY throw AFTER reserving, refund
+  // the CEILING (not 0) on both keys and re-throw (refund-on-throw, plan §7).
+  let snapshot: ReturnType<typeof snapshotFromWorkflow>;
+  try {
+    const stepInput = buildCustomComfyWorkflowInput(recipe, body.params, {});
+    const step = createBlockCustomComfyStep(recipe, stepInput);
+    // Parameterized tags: emit the recipe id + 'customComfy' (NOT 'txt2img'),
+    // preserving the `app-block:*` provenance tags the subqueue read depends on.
+    const tags = buildWorkflowTags(claims, recipe.id, 'customComfy');
+    const submitted = await submitWorkflow({
+      token,
+      body: {
+        steps: [step],
+        tags,
+        currencies,
+        // Authoritative maturity clamp on the real submit — token-claim derived.
+        ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
+      },
+    });
+    snapshot = snapshotFromWorkflow(submitted);
+  } catch (e) {
+    await refundBlockBuzzSpend(buzzCapKey, ceiling);
+    if (appSpendReserve) {
+      const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
+      await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
+    }
+    throw e;
+  }
+
+  // ── Persist the settle record (AWAITED — see custom-comfy-settle.service). The
+  // terminal poll/cancel hook reads it and refunds `ceiling - actual` on BOTH
+  // keys. Only for a REAL orchestrator id (never the failed/whatif sentinels).
+  if (
+    snapshot.workflowId &&
+    snapshot.workflowId !== 'failed' &&
+    snapshot.workflowId !== 'whatif'
+  ) {
+    await persistCustomComfySettle({
+      workflowId: snapshot.workflowId,
+      buzzCapKey,
+      appSpendKey: appSpendReserve?.key ?? null,
+      ceiling,
+    });
+    // G6 — persistent output queue (best-effort, non-dev). Same posture as
+    // txt2img so a customComfy gen rebuilds in listMyWorkflows on reload.
+    if (claims.dev !== true) {
+      const realWorkflowId = snapshot.workflowId;
+      void (async () => {
+        const { upsertBlockWorkflowOnSubmit } = await import(
+          '~/server/services/blocks/block-workflows.service'
+        );
+        await upsertBlockWorkflowOnSubmit({
+          workflowId: realWorkflowId,
+          appBlockId: claims.appBlockId,
+          blockInstanceId: claims.blockInstanceId,
+          userId,
+          status: snapshot.status,
+        });
+      })().catch(() => {
+        /* best-effort: a failed queue write never breaks (or slows) submit */
+      });
+    }
+  }
+
+  return { snapshot };
+}
+
 /**
  * Workflow tags drive orchestrator-side filtering, billing attribution, and
  * the "submitted via app block" audit trail. Mirrors what createTextToImage
@@ -5061,12 +5401,19 @@ async function getBlockSessionUser(userId: number): Promise<SessionUser> {
  */
 function buildWorkflowTags(
   claims: { blockId: string; blockInstanceId: string; appId: string },
-  baseModel: string
+  baseModel: string,
+  // The workflow-TYPE tag (orchestrator-side filtering / billing attribution).
+  // Defaults to 'txt2img' so every existing txt2img call site (2-arg) emits the
+  // BYTE-IDENTICAL tag set it did before. The customComfy branch passes the
+  // recipe id here (with `baseModel` also the recipe id) so a customComfy job is
+  // NOT mislabeled 'txt2img' — while the `app-block:*` provenance tags below are
+  // preserved verbatim, so the per-app subqueue read (appBlockTag) is unaffected.
+  workflowType: string = 'txt2img'
 ): string[] {
   return [
     WORKFLOW_TAGS.GENERATION,
     WORKFLOW_TAGS.IMAGE,
-    'txt2img',
+    workflowType,
     baseModel,
     'app-block',
     // Per-app subqueue tag — the SAME helper `blocks.queryAppWorkflows` filters

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5325,9 +5325,65 @@ async function submitCustomComfyWorkflow(opts: {
     if (appSpend.dailyKey) appSpendReserve = { key: appSpend.dailyKey, cost: ceiling };
   }
 
+  // ── (4) APP DEV TUNNEL per-session spend backstop (F4) — mirror the txt2img
+  // path (~:3596). When the caller has an ACTIVE dev tunnel for THIS block, bound
+  // cumulative spend within that ONE dev session (a backstop OVER the per-call
+  // budget + the per-user daily cap + the per-app cap) so a runaway LOCAL submit
+  // loop can't drain Buzz. Resolved SERVER-SIDE from (userId, blockId) — a single
+  // Redis GET that misses (and no-ops) for every non-dev submit. Same fail-open
+  // LOOKUP / fail-closed ENFORCEMENT posture as txt2img (safe because the
+  // fail-closed daily-cap reserve above has already run and throws on any Redis
+  // error before this lookup executes).
+  //
+  // UNLIKE txt2img (which reserves the whatIf estimate PERMANENTLY), customComfy
+  // is post-paid: this reservation is the CEILING and is SETTLED (ceiling-actual
+  // refunded) at terminal alongside the daily + app keys — so its session id is
+  // persisted in the settle record below. This is what makes adding the third
+  // reservation safe (it can't over-count the session for the 25h TTL).
+  let devSessionReserve: { sessionId: string; cost: number } | null = null;
+  {
+    const { getActiveDevTunnel, reserveDevSessionBuzz } = await import(
+      '~/server/services/blocks/dev-tunnel.service'
+    );
+    const devTunnel = await getActiveDevTunnel(userId, claims.blockId).catch(() => null);
+    if (devTunnel) {
+      const reserved = await reserveDevSessionBuzz(
+        devTunnel.sessionId,
+        ceiling,
+        devTunnel.spendCapBuzz
+      );
+      if (!reserved.allowed) {
+        // Over the session ceiling → refund the per-user daily reservation made
+        // above (the session reserve rolled ITSELF back on deny) and the G8
+        // per-app reservation (present only for non-dev tokens; a token with
+        // `dev !== true` can still have an active dev tunnel). Then fail-snapshot.
+        await refundBlockBuzzSpend(buzzCapKey, ceiling);
+        if (appSpendReserve) {
+          const { refundAppSpend } = await import(
+            '~/server/services/blocks/app-spend-cap.service'
+          );
+          await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
+        }
+        return {
+          snapshot: {
+            workflowId: 'failed',
+            status: 'failed' as const,
+            cost: { total: ceiling },
+            error:
+              `dev tunnel session Buzz cap reached: ${reserved.total} already spent ` +
+              `this dev session, this generation may cost up to ${Math.ceil(ceiling)}, ` +
+              `session cap is ${devTunnel.spendCapBuzz}`,
+          },
+        };
+      }
+      devSessionReserve = { sessionId: devTunnel.sessionId, cost: Math.ceil(ceiling) };
+    }
+  }
+
   // ── Build + submit. `createBlockCustomComfyStep` stamps the recipe's aggressive
   // `timeout` — the physical Buzz ceiling. On ANY throw AFTER reserving, refund
-  // the CEILING (not 0) on both keys and re-throw (refund-on-throw, plan §7).
+  // the CEILING (not 0) on ALL reservation keys and re-throw (refund-on-throw,
+  // plan §7).
   let snapshot: ReturnType<typeof snapshotFromWorkflow>;
   try {
     const stepInput = buildCustomComfyWorkflowInput(recipe, body.params, {});
@@ -5352,12 +5408,24 @@ async function submitCustomComfyWorkflow(opts: {
       const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
       await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
     }
+    // F4 — mirror the daily/app refund for the dev-session reservation so a failed
+    // submit doesn't permanently burn the session ceiling. Best-effort; present
+    // only when an active dev tunnel was reserved above.
+    if (devSessionReserve) {
+      const { refundDevSessionBuzz } = await import(
+        '~/server/services/blocks/dev-tunnel.service'
+      );
+      await refundDevSessionBuzz(devSessionReserve.sessionId, devSessionReserve.cost);
+    }
     throw e;
   }
 
   // ── Persist the settle record (AWAITED — see custom-comfy-settle.service). The
-  // terminal poll/cancel hook reads it and refunds `ceiling - actual` on BOTH
-  // keys. Only for a REAL orchestrator id (never the failed/whatif sentinels).
+  // terminal poll/cancel hook reads it and refunds `ceiling - actual` on the
+  // per-user daily + per-app + (when present) dev-session keys. Only for a REAL
+  // orchestrator id (never the failed/whatif sentinels). The dev-session id is
+  // included ONLY when a dev tunnel was reserved above (spread) — so a non-dev
+  // submit persists the SAME record shape it did before (settle no-ops that leg).
   if (
     snapshot.workflowId &&
     snapshot.workflowId !== 'failed' &&
@@ -5367,6 +5435,7 @@ async function submitCustomComfyWorkflow(opts: {
       workflowId: snapshot.workflowId,
       buzzCapKey,
       appSpendKey: appSpendReserve?.key ?? null,
+      ...(devSessionReserve ? { devSessionId: devSessionReserve.sessionId } : {}),
       ceiling,
     });
     // G6 — persistent output queue (best-effort, non-dev). Same posture as

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -1,6 +1,7 @@
 import * as z from 'zod';
 import { buzzSpendTypes } from '~/shared/constants/buzz.constants';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
+import { REGISTERED_RECIPE_IDS } from '~/server/services/blocks/recipes';
 
 // The spendable buzz account types a viewer may pick for a (money) page block.
 // Reuse the authoritative `buzzSpendTypes` (blue/green/yellow — `red` is
@@ -21,6 +22,24 @@ const blockAccountTypeSchema = z.enum(buzzSpendTypes as [BuzzSpendType, ...BuzzS
 // as a NEW discriminated-union `kind` here, which must also (a) extend the
 // discriminator in blocks.router workflow procedures, (b) be exposed by
 // @civitai/app-sdk's useBuzzWorkflow contract.
+//
+// `customComfy` is the second `kind` (App Blocks customComfy bridge, v1). Unlike
+// `textToImage` (which maps a bounded body onto a generation GRAPH the server
+// builds), a `customComfy` body carries only a server-side `recipe` id + opaque
+// `params` — the server owns the ComfyUI graph in full (a fixed, code-reviewed
+// recipe from `~/server/services/blocks/recipes`). The wire schema does only the
+// COARSE fail-closed gate here: `recipe` MUST be a registered id
+// (REGISTERED_RECIPE_IDS, derived from the recipe registry keys) and `params` is
+// an opaque record; the per-recipe `.strict()` param schema is applied in the
+// TRANSLATOR (workflow.service `buildCustomComfyWorkflowInput`), not here, so the
+// wire surface stays recipe-agnostic. Mirrors `@civitai/app-sdk`'s
+// `WorkflowBodyCustomComfy` (civitai-app-starters PR #171) — keep the two in
+// lockstep.
+//
+// INERT/DARK: blocks.router still handles ONLY `textToImage` — the submit /
+// estimate branch on `kind==='customComfy'` (+ the post-paid budget belt) is the
+// separate PR6. This member only widens the accepted wire shape; no live code
+// path reads it yet.
 //
 // Caps are intentionally tighter than the platform-wide generateImageSchema —
 // blocks run in untrusted iframes and the token issuer caps per-call buzz at
@@ -164,8 +183,28 @@ const blockTextToImageBodySchema = z.object({
   }),
 });
 
+// App Blocks customComfy bridge (v1). Coarse fail-closed wire gate only:
+//  - `recipe` MUST be a REGISTERED recipe id (derived from the recipe registry
+//    keys) — an unregistered id is rejected at the union, before any translator
+//    or orchestrator call.
+//  - `params` is an opaque `Record<string, unknown>` here; the per-recipe
+//    `.strict()` param schema (prompt/seed/engine/accountType bounds) is applied
+//    in the translator (`buildCustomComfyWorkflowInput`), which is the single
+//    place a recipe's real param contract lives.
+//  - `.strict()` rejects any extra top-level field on the body.
+export const blockCustomComfyBodySchema = z
+  .object({
+    kind: z.literal('customComfy'),
+    recipe: z.enum(REGISTERED_RECIPE_IDS),
+    params: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
 export type BlockWorkflowBody = z.infer<typeof blockWorkflowBodySchema>;
-export const blockWorkflowBodySchema = z.discriminatedUnion('kind', [blockTextToImageBodySchema]);
+export const blockWorkflowBodySchema = z.discriminatedUnion('kind', [
+  blockTextToImageBodySchema,
+  blockCustomComfyBodySchema,
+]);
 
 // Mirrors BlockWorkflowSnapshot in @civitai/app-sdk's blocks/types.ts.
 // Keep field names in lockstep — this is the wire contract the iframe consumes.

--- a/src/server/services/blocks/__tests__/custom-comfy-settle.service.test.ts
+++ b/src/server/services/blocks/__tests__/custom-comfy-settle.service.test.ts
@@ -11,7 +11,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * assert the exact GET+DEL idempotency claim and the exact decrBy deltas.
  */
 
-const { mockSysRedis, mockRefundAppSpend } = vi.hoisted(() => ({
+const { mockSysRedis, mockRefundAppSpend, mockRefundDevSessionBuzz } = vi.hoisted(() => ({
   mockSysRedis: {
     get: vi.fn(async () => null as string | null),
     set: vi.fn(async () => undefined),
@@ -19,6 +19,10 @@ const { mockSysRedis, mockRefundAppSpend } = vi.hoisted(() => ({
     decrBy: vi.fn(async () => 0),
   },
   mockRefundAppSpend: vi.fn(async () => undefined),
+  // F4 — the dev-session refund leg dynamic-imports refundDevSessionBuzz. Mock the
+  // (heavy, k8s-client-pulling) dev-tunnel module at its boundary so the settle's
+  // third refund is assertable without loading the real service.
+  mockRefundDevSessionBuzz: vi.fn(async () => undefined),
 }));
 
 vi.mock('~/server/redis/client', () => ({
@@ -27,6 +31,9 @@ vi.mock('~/server/redis/client', () => ({
 }));
 vi.mock('~/server/services/blocks/app-spend-cap.service', () => ({
   refundAppSpend: (...a: unknown[]) => mockRefundAppSpend(...(a as [])),
+}));
+vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
+  refundDevSessionBuzz: (...a: unknown[]) => mockRefundDevSessionBuzz(...(a as [])),
 }));
 
 import {
@@ -45,6 +52,7 @@ beforeEach(() => {
     mockSysRedis.del,
     mockSysRedis.decrBy,
     mockRefundAppSpend,
+    mockRefundDevSessionBuzz,
   ]) {
     fn.mockReset();
   }
@@ -54,9 +62,19 @@ beforeEach(() => {
   mockSysRedis.del.mockResolvedValue(1);
   mockSysRedis.decrBy.mockResolvedValue(0);
   mockRefundAppSpend.mockResolvedValue(undefined);
+  mockRefundDevSessionBuzz.mockResolvedValue(undefined);
 });
 
-function seedRecord(over: Partial<{ buzzCapKey: string; appSpendKey: string | null; ceiling: number }> = {}) {
+const DEV_SESSION_ID = 'bki_dev_session';
+
+function seedRecord(
+  over: Partial<{
+    buzzCapKey: string;
+    appSpendKey: string | null;
+    devSessionId: string | null;
+    ceiling: number;
+  }> = {}
+) {
   const record = { buzzCapKey: BUZZ_KEY, appSpendKey: APP_KEY, ceiling: 180, ...over };
   mockSysRedis.get.mockResolvedValue(JSON.stringify(record));
   return record;
@@ -75,6 +93,37 @@ describe('persistCustomComfySettle', () => {
     expect(key).toBe(`${SETTLE_PREFIX}:wf_1`);
     expect(JSON.parse(value)).toEqual({ buzzCapKey: BUZZ_KEY, appSpendKey: APP_KEY, ceiling: 180 });
     expect(opts.EX).toBe(25 * 60 * 60);
+  });
+
+  it('F4: persists the dev-session id when a dev tunnel reserved the ceiling', async () => {
+    await persistCustomComfySettle({
+      workflowId: 'wf_1',
+      buzzCapKey: BUZZ_KEY,
+      appSpendKey: null, // dev token → no per-app reserve
+      devSessionId: DEV_SESSION_ID,
+      ceiling: 180,
+    });
+    const [, value] = mockSysRedis.set.mock.calls[0] as [string, string, { EX: number }];
+    expect(JSON.parse(value)).toEqual({
+      buzzCapKey: BUZZ_KEY,
+      appSpendKey: null,
+      devSessionId: DEV_SESSION_ID,
+      ceiling: 180,
+    });
+  });
+
+  it('F4: a non-dev submit persists the SAME record shape as before (NO devSessionId field)', async () => {
+    await persistCustomComfySettle({
+      workflowId: 'wf_1',
+      buzzCapKey: BUZZ_KEY,
+      appSpendKey: APP_KEY,
+      // devSessionId omitted → non-dev submit
+      ceiling: 180,
+    });
+    const [, value] = mockSysRedis.set.mock.calls[0] as [string, string, { EX: number }];
+    const parsed = JSON.parse(value);
+    expect(parsed).not.toHaveProperty('devSessionId');
+    expect(parsed).toEqual({ buzzCapKey: BUZZ_KEY, appSpendKey: APP_KEY, ceiling: 180 });
   });
 
   it('no-ops on an empty workflowId (never writes)', async () => {
@@ -147,6 +196,40 @@ describe('settleCustomComfySpend', () => {
     await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
     expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
     expect(mockRefundAppSpend).not.toHaveBeenCalled();
+  });
+
+  it('F4: refunds `ceiling - actual` on the dev-session cap too when a devSessionId is present', async () => {
+    seedRecord({ appSpendKey: null, devSessionId: DEV_SESSION_ID, ceiling: 180 });
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
+    // Same over-reservation (180 - 30 = 150) refunded on the per-user daily key…
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
+    // …and on the dev-tunnel SESSION cap (by session id — refundDevSessionBuzz
+    // derives the spend key itself).
+    expect(mockRefundDevSessionBuzz).toHaveBeenCalledWith(DEV_SESSION_ID, 150);
+    // dev token → no per-app leg.
+    expect(mockRefundAppSpend).not.toHaveBeenCalled();
+  });
+
+  it('F4: refunds all THREE keys for a non-dev submit that also had an active dev tunnel', async () => {
+    seedRecord({ devSessionId: DEV_SESSION_ID, ceiling: 180 });
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
+    expect(mockRefundAppSpend).toHaveBeenCalledWith(APP_KEY, 150);
+    expect(mockRefundDevSessionBuzz).toHaveBeenCalledWith(DEV_SESSION_ID, 150);
+  });
+
+  it('F4: a record WITHOUT a devSessionId (non-dev submit) never touches the dev-session cap', async () => {
+    seedRecord({ ceiling: 180 }); // no devSessionId
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
+    expect(mockRefundAppSpend).toHaveBeenCalledWith(APP_KEY, 150);
+    expect(mockRefundDevSessionBuzz).not.toHaveBeenCalled();
+  });
+
+  it('F4: a full-ceiling spend refunds NOTHING on the dev-session cap either', async () => {
+    seedRecord({ devSessionId: DEV_SESSION_ID, ceiling: 180 });
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 200 });
+    expect(mockRefundDevSessionBuzz).not.toHaveBeenCalled();
   });
 
   it('never throws when the GET fails (leaves the ceiling reserved — stricter)', async () => {

--- a/src/server/services/blocks/__tests__/custom-comfy-settle.service.test.ts
+++ b/src/server/services/blocks/__tests__/custom-comfy-settle.service.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Unit coverage for the customComfy post-paid SETTLE-TO-ACTUAL service (plan
+ * §5.3). This is the security-critical accounting that keeps the per-user daily
+ * + per-app aggregate caps honest against a post-paid job whose real cost is only
+ * known at terminal: reserve the CEILING at submit, refund `ceiling - actual` on
+ * BOTH keys exactly once at the first terminal observation.
+ *
+ * The refund path is exercised against a fake sysRedis (get/set/del/decrBy) so we
+ * assert the exact GET+DEL idempotency claim and the exact decrBy deltas.
+ */
+
+const { mockSysRedis, mockRefundAppSpend } = vi.hoisted(() => ({
+  mockSysRedis: {
+    get: vi.fn(async () => null as string | null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 1),
+    decrBy: vi.fn(async () => 0),
+  },
+  mockRefundAppSpend: vi.fn(async () => undefined),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: mockSysRedis,
+  REDIS_SYS_KEYS: { BLOCKS: { CUSTOM_COMFY_SETTLE: 'system:blocks:custom-comfy-settle' } },
+}));
+vi.mock('~/server/services/blocks/app-spend-cap.service', () => ({
+  refundAppSpend: (...a: unknown[]) => mockRefundAppSpend(...(a as [])),
+}));
+
+import {
+  persistCustomComfySettle,
+  settleCustomComfySpend,
+} from '~/server/services/blocks/custom-comfy-settle.service';
+
+const SETTLE_PREFIX = 'system:blocks:custom-comfy-settle';
+const BUZZ_KEY = 'system:blocks:buzz-cap:42:2026-07-17';
+const APP_KEY = 'system:blocks:app-spend-cap:app_test:2026-07-17';
+
+beforeEach(() => {
+  for (const fn of [
+    mockSysRedis.get,
+    mockSysRedis.set,
+    mockSysRedis.del,
+    mockSysRedis.decrBy,
+    mockRefundAppSpend,
+  ]) {
+    fn.mockReset();
+  }
+  // Sensible defaults: empty store, DEL claims 1 (we win).
+  mockSysRedis.get.mockResolvedValue(null);
+  mockSysRedis.set.mockResolvedValue(undefined);
+  mockSysRedis.del.mockResolvedValue(1);
+  mockSysRedis.decrBy.mockResolvedValue(0);
+  mockRefundAppSpend.mockResolvedValue(undefined);
+});
+
+function seedRecord(over: Partial<{ buzzCapKey: string; appSpendKey: string | null; ceiling: number }> = {}) {
+  const record = { buzzCapKey: BUZZ_KEY, appSpendKey: APP_KEY, ceiling: 180, ...over };
+  mockSysRedis.get.mockResolvedValue(JSON.stringify(record));
+  return record;
+}
+
+describe('persistCustomComfySettle', () => {
+  it('writes the record keyed by workflowId with a ~25h TTL', async () => {
+    await persistCustomComfySettle({
+      workflowId: 'wf_1',
+      buzzCapKey: BUZZ_KEY,
+      appSpendKey: APP_KEY,
+      ceiling: 180,
+    });
+    expect(mockSysRedis.set).toHaveBeenCalledTimes(1);
+    const [key, value, opts] = mockSysRedis.set.mock.calls[0] as [string, string, { EX: number }];
+    expect(key).toBe(`${SETTLE_PREFIX}:wf_1`);
+    expect(JSON.parse(value)).toEqual({ buzzCapKey: BUZZ_KEY, appSpendKey: APP_KEY, ceiling: 180 });
+    expect(opts.EX).toBe(25 * 60 * 60);
+  });
+
+  it('no-ops on an empty workflowId (never writes)', async () => {
+    await persistCustomComfySettle({ workflowId: '', buzzCapKey: BUZZ_KEY, appSpendKey: null, ceiling: 180 });
+    expect(mockSysRedis.set).not.toHaveBeenCalled();
+  });
+
+  it('swallows a Redis error (best-effort, degrades to reserve-without-settle)', async () => {
+    mockSysRedis.set.mockRejectedValue(new Error('redis down'));
+    await expect(
+      persistCustomComfySettle({ workflowId: 'wf_1', buzzCapKey: BUZZ_KEY, appSpendKey: null, ceiling: 180 })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('settleCustomComfySpend', () => {
+  it('refunds `ceiling - actual` on BOTH keys and consumes the record (GET+DEL)', async () => {
+    seedRecord({ ceiling: 180 });
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
+    // GET then DEL of the settle key (the atomic single-shot claim).
+    expect(mockSysRedis.get).toHaveBeenCalledWith(`${SETTLE_PREFIX}:wf_1`);
+    expect(mockSysRedis.del).toHaveBeenCalledWith(`${SETTLE_PREFIX}:wf_1`);
+    // Refund the over-reservation (180 - 30 = 150) on the per-user daily key…
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
+    // …and the per-app aggregate key.
+    expect(mockRefundAppSpend).toHaveBeenCalledWith(APP_KEY, 150);
+  });
+
+  it('is IDEMPOTENT — a second terminal observation (DEL===0) refunds nothing', async () => {
+    seedRecord({ ceiling: 180 });
+    mockSysRedis.del.mockResolvedValue(0); // someone else already claimed it
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
+    expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
+    expect(mockRefundAppSpend).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when there is no record (txt2img / non-customComfy workflow)', async () => {
+    mockSysRedis.get.mockResolvedValue(null);
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
+    expect(mockSysRedis.del).not.toHaveBeenCalled();
+    expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
+    expect(mockRefundAppSpend).not.toHaveBeenCalled();
+  });
+
+  it('refunds NOTHING when the job spent the full ceiling (actual >= ceiling)', async () => {
+    seedRecord({ ceiling: 180 });
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 200 });
+    expect(mockSysRedis.del).toHaveBeenCalledWith(`${SETTLE_PREFIX}:wf_1`); // still consumed
+    expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
+    expect(mockRefundAppSpend).not.toHaveBeenCalled();
+  });
+
+  it('refunds the FULL ceiling on a missing/zero actual (e.g. cancel before any accrual)', async () => {
+    seedRecord({ ceiling: 180 });
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 0 });
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 180);
+    expect(mockRefundAppSpend).toHaveBeenCalledWith(APP_KEY, 180);
+  });
+
+  it('ceils a fractional actual so the remaining reservation is never understated', async () => {
+    seedRecord({ ceiling: 180 });
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30.4 });
+    // ceil(30.4)=31 stays reserved → refund 180-31 = 149.
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 149);
+    expect(mockRefundAppSpend).toHaveBeenCalledWith(APP_KEY, 149);
+  });
+
+  it('skips the per-app refund for a dev token (appSpendKey null) but still refunds the daily key', async () => {
+    seedRecord({ appSpendKey: null, ceiling: 180 });
+    await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
+    expect(mockRefundAppSpend).not.toHaveBeenCalled();
+  });
+
+  it('never throws when the GET fails (leaves the ceiling reserved — stricter)', async () => {
+    mockSysRedis.get.mockRejectedValue(new Error('redis down'));
+    await expect(settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 })).resolves.toBeUndefined();
+    expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -18,9 +18,12 @@ vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead }));
 
 import {
   appBlockTag,
+  buildCustomComfyWorkflowInput,
   buildImageWorkflowInput,
   buildTextToImageInput,
+  BLOCK_CUSTOM_COMFY_STEP_NAME,
   BLOCK_IMAGE_WORKFLOW_TYPES,
+  createBlockCustomComfyStep,
   isPageLoraResource,
   projectAppWorkflow,
   resolveBlockImageWorkflowType,
@@ -29,6 +32,7 @@ import {
   snapshotFromWorkflow,
 } from '../workflow.service';
 import { blockWorkflowBodySchema } from '~/server/schema/blocks/workflow.schema';
+import { getRecipe, REGISTERED_RECIPE_IDS } from '../recipes';
 // REAL param-building path (no mocks): the generation graph validator and the
 // step-metadata snapshot fn are the exact functions the orchestrator's
 // `createWorkflowStepsFromGraph` runs to derive `workflowMetadata.params`. Both
@@ -1421,5 +1425,138 @@ describe('blockWorkflowBodySchema sourceImage bound (SSRF / arbitrary-URL guard)
         sourceImage: { url: 'https://image.civitai.com/a.jpeg', width: 99999, height: 1024 },
       }).success
     ).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// customComfy bridge (App Blocks customComfy bridge, v1) — INERT building blocks.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('blockWorkflowBodySchema: customComfy member', () => {
+  it('accepts a registered recipe with opaque params', () => {
+    const r = blockWorkflowBodySchema.safeParse({
+      kind: 'customComfy',
+      recipe: REGISTERED_RECIPE_IDS[0],
+      params: { prompt: 'an icy lake', engine: 'zimage-turbo' },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects an unregistered recipe id at the wire schema (fail-closed)', () => {
+    const r = blockWorkflowBodySchema.safeParse({
+      kind: 'customComfy',
+      recipe: 'not-a-real-recipe',
+      params: {},
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects an extra top-level field (.strict())', () => {
+    const r = blockWorkflowBodySchema.safeParse({
+      kind: 'customComfy',
+      recipe: REGISTERED_RECIPE_IDS[0],
+      params: {},
+      sneaky: 1,
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('still parses an existing textToImage body (union widened, not replaced)', () => {
+    const r = blockWorkflowBodySchema.safeParse({
+      kind: 'textToImage',
+      modelId: 1,
+      modelVersionId: 2,
+      params: { prompt: 'hi' },
+    });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('buildCustomComfyWorkflowInput (translator)', () => {
+  const recipe = getRecipe('seamless-pano-360')!;
+
+  it('applies the recipe param schema then runs its pure builder', () => {
+    const input = buildCustomComfyWorkflowInput(recipe, { prompt: 'a lake', seed: 1, engine: 'zimage-turbo' });
+    expect(input.trace).toBe('binary');
+    expect(input.resources[0]).toContain('z_image_turbo');
+    expect(input.workflow['1'].class_type).toBe('UNETLoader');
+    // seed threaded into the KSampler leaf
+    expect(input.workflow['9'].inputs).toMatchObject({ seed: 1 });
+  });
+
+  it('throws (fail-closed) on an out-of-bounds param the coarse wire schema let through', () => {
+    // `params: Record<string,unknown>` would accept these; the recipe schema rejects them.
+    expect(() => buildCustomComfyWorkflowInput(recipe, { prompt: 'x'.repeat(2000) })).toThrow();
+    expect(() => buildCustomComfyWorkflowInput(recipe, { prompt: 'x', engine: 'sdxl' })).toThrow();
+    expect(() => buildCustomComfyWorkflowInput(recipe, { prompt: 'x', checkpoint: {} })).toThrow();
+  });
+});
+
+describe('createBlockCustomComfyStep (step wrapper)', () => {
+  const recipe = getRecipe('seamless-pano-360')!;
+
+  it('wraps the input as a customComfy step and stamps the recipe timeout (HH:MM:SS)', () => {
+    const input = buildCustomComfyWorkflowInput(recipe, { prompt: 'a lake', seed: 1 });
+    const step = createBlockCustomComfyStep(recipe, input);
+    expect(step.$type).toBe('customComfy');
+    expect(step.name).toBe(BLOCK_CUSTOM_COMFY_STEP_NAME);
+    // 180s ceiling → 00:03:00 (NOT the reference's loose 01:00:00).
+    expect(step.timeout).toBe('00:03:00');
+    expect(step.input).toBe(input);
+  });
+});
+
+describe('snapshotFromWorkflow: customComfy blobs', () => {
+  it('surfaces available blob urls from a customComfy step (output.blobs, not .images)', () => {
+    const wf = fakeWorkflow({
+      status: 'succeeded',
+      steps: [
+        {
+          $type: 'customComfy',
+          name: 'block-custom-comfy',
+          status: 'succeeded',
+          metadata: {},
+          output: {
+            blobs: [
+              { id: 'p1', type: 'image', url: 'https://cdn/pano.png', available: true },
+              { id: 'p2', type: 'image', url: 'https://pending/', available: false },
+            ],
+          },
+        },
+      ],
+    });
+    const snap = snapshotFromWorkflow(wf as never);
+    expect(snap.imageUrls).toEqual(['https://cdn/pano.png']);
+  });
+});
+
+describe('projectAppWorkflow: customComfy blobs', () => {
+  it('projects blobs to images (null width/height, nsfwLevel mapped from rating)', () => {
+    const wf = fakeWorkflow({
+      id: 'wf_cc',
+      createdAt: '2026-07-17T00:00:00.000Z',
+      status: 'succeeded',
+      cost: { total: 47 },
+      steps: [
+        {
+          $type: 'customComfy',
+          name: 'block-custom-comfy',
+          status: 'succeeded',
+          metadata: {},
+          output: {
+            blobs: [
+              { id: 'p1', type: 'image', url: 'https://cdn/pano.png', available: true, nsfwLevel: 'pg' },
+              { id: 'p2', type: 'image', url: 'https://blocked/', available: false },
+            ],
+          },
+        },
+      ],
+    });
+    expect(projectAppWorkflow(wf as never)).toEqual({
+      workflowId: 'wf_cc',
+      status: 'succeeded',
+      images: [{ url: 'https://cdn/pano.png', width: null, height: null, nsfwLevel: 1 }],
+      cost: 47,
+      createdAt: '2026-07-17T00:00:00.000Z',
+    });
   });
 });

--- a/src/server/services/blocks/custom-comfy-settle.service.ts
+++ b/src/server/services/blocks/custom-comfy-settle.service.ts
@@ -1,0 +1,142 @@
+import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import type { AppSpendDailyKey } from '~/server/services/blocks/app-spend-cap.service';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App Blocks `customComfy` bridge — post-paid SETTLE-TO-ACTUAL (plan §5.3).
+//
+// A post-paid `$type:'customComfy'` job whatIfs to 0, so the router reserves the
+// recipe's declared `maxBuzz` CEILING against the per-user daily cap
+// (`reserveBlockBuzzSpend`) and the per-app aggregate cap (`reserveAppSpend`) at
+// submit — keeping those caps honest against a spend the orchestrator only
+// realizes at runtime. When the job reaches a TERMINAL status (observed by
+// `pollWorkflow` / `cancelWorkflow`) we refund the over-reservation
+// (`ceiling - actual`) back to BOTH reservation counters, so the caps converge on
+// the REAL accrued cost.
+//
+// This module owns the small durable link between the two: a per-workflow Redis
+// record of the exact reservation keys + the ceiling, written at submit and
+// consumed EXACTLY ONCE (GET+DEL) at the first terminal observation. The GET+DEL
+// is the idempotency guard — a block polls to terminal repeatedly, and cancel +
+// a trailing poll can both observe terminal, but only the caller that wins the
+// DEL performs the refund.
+//
+// FAIL-SAFE in both directions:
+//   - a lost PERSIST degrades to reserve-without-settle: the caps over-count by
+//     `ceiling - actual` for the ~25h TTL (the documented R5 fallback) — STRICTER,
+//     never looser.
+//   - a lost/failed SETTLE leaves the ceiling reserved (same over-count) — again
+//     the safe direction for an abuse cap.
+// Neither ever throws into the poll/cancel/ submit response path.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Same 25h window as the reservation counters (BLOCK_BUZZ_CAP_TTL_SECONDS /
+// DAILY_CAP_TTL_SECONDS): comfortably covers a UTC-day window plus clock skew, so
+// the settle record outlives the reservation it must unwind even across midnight.
+const SETTLE_TTL_SECONDS = 25 * 60 * 60;
+
+// The per-user daily buzz-cap key the router reserved against. It is a branded
+// `${BUZZ_CAP}:${string}` at the router; persisted/read here as a plain string
+// and cast back at DECRBY time (the value round-trips the exact key that was
+// reserved, so the cast is sound — same key, same window).
+type BuzzCapKey = `${typeof REDIS_SYS_KEYS.BLOCKS.BUZZ_CAP}:${string}`;
+
+function settleKey(workflowId: string): `${typeof REDIS_SYS_KEYS.BLOCKS.CUSTOM_COMFY_SETTLE}:${string}` {
+  return `${REDIS_SYS_KEYS.BLOCKS.CUSTOM_COMFY_SETTLE}:${workflowId}`;
+}
+
+type SettleRecord = {
+  /** The per-user daily buzz-cap Redis key the ceiling was reserved against. */
+  buzzCapKey: string;
+  /** The per-app aggregate daily key; null for dev tokens (no per-app reserve). */
+  appSpendKey: string | null;
+  /** The declared per-job ceiling that was reserved (recipe.maxBuzz). */
+  ceiling: number;
+};
+
+/**
+ * Persist the settle record at submit, AFTER the ceiling has been reserved
+ * against both caps. Awaited (not fire-and-forget) so the record is durably
+ * written before the router hands the workflowId back to the block — otherwise a
+ * very fast terminal poll could race the write and miss the settle. Best-effort:
+ * a Redis error is swallowed (degrades to reserve-without-settle, the R5
+ * fallback), NEVER thrown into the submit response.
+ */
+export async function persistCustomComfySettle(input: {
+  workflowId: string;
+  buzzCapKey: string;
+  appSpendKey: string | null;
+  ceiling: number;
+}): Promise<void> {
+  const { workflowId, buzzCapKey, appSpendKey, ceiling } = input;
+  if (!workflowId) return;
+  const record: SettleRecord = { buzzCapKey, appSpendKey, ceiling };
+  try {
+    await sysRedis.set(settleKey(workflowId), JSON.stringify(record), {
+      EX: SETTLE_TTL_SECONDS,
+    });
+  } catch {
+    /* best-effort — a lost persist over-counts the caps (stricter), never looser */
+  }
+}
+
+/**
+ * Settle a customComfy workflow to its REAL accrued cost on the FIRST terminal
+ * observation. Reads + atomically claims the settle record (GET then DEL, gated
+ * on DEL===1 so only one caller refunds), then refunds `ceiling - actual` to
+ * BOTH the per-user daily cap and the per-app aggregate cap.
+ *
+ * Idempotent + self-scoping: a record exists ONLY for a customComfy submit and is
+ * deleted on the first successful claim, so this can be called unconditionally on
+ * ANY block workflow's terminal poll/cancel — a txt2img workflow (no record) or a
+ * second terminal observation (already claimed) simply no-ops.
+ *
+ * `actualCost` is the workflow's realized `cost.total` (accrued Buzz). The refund
+ * is clamped to `[0, ceiling]`: an `actual >= ceiling` refunds nothing (the full
+ * ceiling stays counted), a missing/zero `actual` refunds the whole ceiling. Both
+ * DECRBYs are best-effort; a lost refund over-counts (stricter cap). Never throws.
+ */
+export async function settleCustomComfySpend(input: {
+  workflowId: string;
+  actualCost: number;
+}): Promise<void> {
+  const { workflowId, actualCost } = input;
+  if (!workflowId) return;
+  const key = settleKey(workflowId);
+
+  let record: SettleRecord;
+  try {
+    const raw = await sysRedis.get<string>(key);
+    if (!raw) return; // not a customComfy workflow, or already settled
+    // Atomically claim: DEL returns 1 iff WE removed it. A concurrent terminal
+    // observation (cancel + trailing poll) that already claimed it returns 0 →
+    // we must NOT double-refund.
+    const removed = await sysRedis.del(key);
+    if (removed !== 1) return;
+    record = JSON.parse(raw) as SettleRecord;
+  } catch {
+    // A GET/DEL error → leave the record (if any) in place; the ceiling stays
+    // reserved (stricter cap). Never throw into poll/cancel.
+    return;
+  }
+
+  const ceiling = Math.ceil(record.ceiling ?? 0);
+  const actual = Math.ceil(Number.isFinite(actualCost) ? Math.max(0, actualCost) : 0);
+  const refund = Math.max(0, ceiling - actual);
+  if (refund <= 0) return; // nothing to give back (job spent the full ceiling)
+
+  // Per-user daily cap: DECRBY the over-reservation on the EXACT key reserved
+  // (mirrors refundBlockBuzzSpend — pin the key so a midnight-UTC settle can't
+  // decrement the next day's window).
+  if (record.buzzCapKey) {
+    await sysRedis.decrBy(record.buzzCapKey as BuzzCapKey, refund).catch(() => {
+      /* best-effort — a lost refund over-counts (stricter cap) */
+    });
+  }
+
+  // Per-app aggregate cap: reuse the service's own pinned-key refund. Absent for
+  // dev tokens (no per-app reservation was made).
+  if (record.appSpendKey) {
+    const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
+    await refundAppSpend(record.appSpendKey as AppSpendDailyKey, refund);
+  }
+}

--- a/src/server/services/blocks/custom-comfy-settle.service.ts
+++ b/src/server/services/blocks/custom-comfy-settle.service.ts
@@ -10,8 +10,9 @@ import type { AppSpendDailyKey } from '~/server/services/blocks/app-spend-cap.se
 // submit — keeping those caps honest against a spend the orchestrator only
 // realizes at runtime. When the job reaches a TERMINAL status (observed by
 // `pollWorkflow` / `cancelWorkflow`) we refund the over-reservation
-// (`ceiling - actual`) back to BOTH reservation counters, so the caps converge on
-// the REAL accrued cost.
+// (`ceiling - actual`) back to EACH reservation counter (per-user daily, per-app
+// aggregate, and — when the submit came from an active on-site dev tunnel — the
+// per-dev-session cap), so every cap converges on the REAL accrued cost.
 //
 // This module owns the small durable link between the two: a per-workflow Redis
 // record of the exact reservation keys + the ceiling, written at submit and
@@ -49,13 +50,23 @@ type SettleRecord = {
   buzzCapKey: string;
   /** The per-app aggregate daily key; null for dev tokens (no per-app reserve). */
   appSpendKey: string | null;
+  /**
+   * The dev-tunnel SESSION id the ceiling was ALSO reserved against, when the
+   * submit came from an active on-site dev tunnel (F4). Absent for every non-dev
+   * submit — so the dev-session refund leg no-ops (a plain reserve-without-a-third
+   * key, byte-identical to the pre-F4 record). Stored as the opaque `bki_<ulid>`
+   * session id (not a raw Redis key) so the settle reuses `refundDevSessionBuzz`,
+   * which derives the session spend key itself.
+   */
+  devSessionId?: string | null;
   /** The declared per-job ceiling that was reserved (recipe.maxBuzz). */
   ceiling: number;
 };
 
 /**
  * Persist the settle record at submit, AFTER the ceiling has been reserved
- * against both caps. Awaited (not fire-and-forget) so the record is durably
+ * against the caps (per-user daily + per-app + optional dev-session). Awaited
+ * (not fire-and-forget) so the record is durably
  * written before the router hands the workflowId back to the block — otherwise a
  * very fast terminal poll could race the write and miss the settle. Best-effort:
  * a Redis error is swallowed (degrades to reserve-without-settle, the R5
@@ -65,11 +76,15 @@ export async function persistCustomComfySettle(input: {
   workflowId: string;
   buzzCapKey: string;
   appSpendKey: string | null;
+  devSessionId?: string | null;
   ceiling: number;
 }): Promise<void> {
-  const { workflowId, buzzCapKey, appSpendKey, ceiling } = input;
+  const { workflowId, buzzCapKey, appSpendKey, devSessionId = null, ceiling } = input;
   if (!workflowId) return;
   const record: SettleRecord = { buzzCapKey, appSpendKey, ceiling };
+  // Include the dev-session id ONLY when present, so a non-dev submit persists the
+  // exact record shape it did before F4 (the dev-session refund leg then no-ops).
+  if (devSessionId) record.devSessionId = devSessionId;
   try {
     await sysRedis.set(settleKey(workflowId), JSON.stringify(record), {
       EX: SETTLE_TTL_SECONDS,
@@ -138,5 +153,15 @@ export async function settleCustomComfySpend(input: {
   if (record.appSpendKey) {
     const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
     await refundAppSpend(record.appSpendKey as AppSpendDailyKey, refund);
+  }
+
+  // Dev-tunnel SESSION cap (F4): present ONLY when the submit came from an active
+  // on-site dev tunnel, which reserved the same CEILING against the per-session
+  // cumulative cap. Refund the SAME over-reservation there so the session cap
+  // converges on the real accrued cost like the other two. `refundDevSessionBuzz`
+  // is itself best-effort (a lost refund over-counts — stricter) and never throws.
+  if (record.devSessionId) {
+    const { refundDevSessionBuzz } = await import('~/server/services/blocks/dev-tunnel.service');
+    await refundDevSessionBuzz(record.devSessionId, refund);
   }
 }

--- a/src/server/services/blocks/recipes/__tests__/seamless-pano.recipe.test.ts
+++ b/src/server/services/blocks/recipes/__tests__/seamless-pano.recipe.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ESTIMATE_BUZZ_BY_ENGINE,
+  FLUX2_CFG,
+  FLUX2_CLIP_AIR,
+  FLUX2_DIFFUSION_AIR,
+  FLUX2_LORA_AIR,
+  FLUX2_LORA_VERSION_ID,
+  FLUX2_STEPS,
+  FLUX2_TRIGGER_WORDS,
+  FLUX2_VAE_AIR,
+  NEGATIVE_PROMPT,
+  PANO_HEIGHT,
+  PANO_WIDTH,
+  PROMPT_MAX,
+  QWEN_CLIP_AIR,
+  QWEN_DIFFUSION_AIR,
+  QWEN_LORA_AIR,
+  QWEN_LORA_VERSION_ID,
+  QWEN_TRIGGER_WORDS,
+  QWEN_VAE_AIR,
+  SEAM_BAND_PX,
+  SEAM_DENOISE,
+  SEAM_FEATHER_PX,
+  SEAM_STEPS,
+  ZIMAGE_CLIP_AIR,
+  ZIMAGE_DIFFUSION_AIR,
+  ZIMAGE_LORA_AIR,
+  ZIMAGE_LORA_VERSION_ID,
+  ZIMAGE_TRIGGER_WORDS,
+  ZIMAGE_VAE_AIR,
+  buildFlux2SeamlessGraph,
+  buildQwenSeamlessGraph,
+  buildZimageSeamlessGraph,
+  seamlessPano360Recipe,
+  seamlessPanoParamSchema,
+  type SeamlessPanoParams,
+} from '../seamless-pano.recipe';
+import {
+  REGISTERED_RECIPE_IDS,
+  getRecipe,
+  recipeCivitaiVersionIds,
+  type ComfyGraph,
+  type CustomComfyStepInput,
+} from '../index';
+
+// The recipe builders take the recipe's OWN param type. These helpers mirror the
+// reference oracle's `buildPanoBody(prompt, seed, _, { engine })` fixtures.
+const params = (prompt: string, seed?: number, engine?: SeamlessPanoParams['engine']): SeamlessPanoParams => ({
+  prompt,
+  ...(seed !== undefined ? { seed } : {}),
+  ...(engine ? { engine } : {}),
+});
+
+const QUALITY_TAIL = ', ultra detailed, masterpiece, best quality';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GOLDEN-GRAPH ORACLE — the assertions below are ported byte-for-byte from
+// Koen's `panorama.test.ts`. A ported builder that drifts from the reference
+// graph (a wrong link ref, class_type, or widget) fails here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('buildZimageSeamlessGraph (golden: Z-Image DiT engine)', () => {
+  const graph = buildZimageSeamlessGraph(params('an icy lake', 42, 'zimage-turbo'));
+
+  it('mirrors the worker Z-Image recipe: split loaders, lumina2 clip, shift 3', () => {
+    expect(graph['1']).toEqual({
+      class_type: 'UNETLoader',
+      inputs: { unet_name: ZIMAGE_DIFFUSION_AIR, weight_dtype: 'default' },
+    });
+    expect(graph['2'].class_type).toBe('LoraLoaderModelOnly');
+    expect(graph['2'].inputs.lora_name).toBe(ZIMAGE_LORA_AIR);
+    expect(graph['3']).toEqual({
+      class_type: 'ModelSamplingAuraFlow',
+      inputs: { model: ['2', 0], shift: 3.0 },
+    });
+    expect(graph['4'].inputs).toMatchObject({ clip_name: ZIMAGE_CLIP_AIR, type: 'lumina2' });
+    expect(graph['7'].inputs.vae_name).toBe(ZIMAGE_VAE_AIR);
+    expect(graph['8'].class_type).toBe('EmptySD3LatentImage');
+  });
+
+  it('turbo sampling: 8 steps, cfg 1, euler/simple, inert negative', () => {
+    expect(graph['9'].inputs).toMatchObject({
+      seed: 42,
+      steps: 8,
+      cfg: 1,
+      sampler_name: 'euler',
+      scheduler: 'simple',
+      denoise: 1.0,
+    });
+    expect(graph['5'].inputs.text).toBe(ZIMAGE_TRIGGER_WORDS + 'an icy lake' + QUALITY_TAIL);
+    expect(graph['6'].inputs.text).toBe('');
+  });
+
+  it('rolls 50% via crop+stitch with the halves swapped (seam to center)', () => {
+    const half = PANO_WIDTH / 2;
+    expect(graph['11'].inputs).toMatchObject({ image: ['10', 0], x: 0, width: half });
+    expect(graph['12'].inputs).toMatchObject({ image: ['10', 0], x: half, width: half });
+    expect(graph['13'].class_type).toBe('ImageStitch');
+    expect(graph['13'].inputs.image1).toEqual(['12', 0]);
+    expect(graph['13'].inputs.image2).toEqual(['11', 0]);
+    expect(graph['13'].inputs.direction).toBe('right');
+  });
+
+  it('builds a centered feathered band mask', () => {
+    expect(graph['14'].inputs).toMatchObject({ value: 0, width: PANO_WIDTH, height: PANO_HEIGHT });
+    expect(graph['15'].inputs).toMatchObject({ value: 1, width: SEAM_BAND_PX });
+    expect(graph['16'].inputs).toMatchObject({ x: (PANO_WIDTH - SEAM_BAND_PX) / 2, operation: 'add' });
+    expect(graph['17'].inputs).toMatchObject({ left: SEAM_FEATHER_PX, right: SEAM_FEATHER_PX });
+  });
+
+  it('heals the band with a partial-denoise pass and rolls back', () => {
+    expect(graph['18']).toEqual({
+      class_type: 'VAEEncode',
+      inputs: { pixels: ['13', 0], vae: ['7', 0] },
+    });
+    expect(graph['19']).toEqual({
+      class_type: 'SetLatentNoiseMask',
+      inputs: { samples: ['18', 0], mask: ['17', 0] },
+    });
+    expect(graph['20'].inputs).toMatchObject({
+      latent_image: ['19', 0],
+      denoise: SEAM_DENOISE,
+      seed: 43,
+      cfg: 1,
+    });
+    expect(graph['21'].inputs.samples).toEqual(['20', 0]);
+    expect(graph['22'].inputs.image).toEqual(['21', 0]);
+    expect(graph['24'].inputs.image1).toEqual(['23', 0]);
+    expect(graph['25']).toMatchObject({ class_type: 'SaveImage', inputs: { images: ['24', 0] } });
+  });
+
+  it('randomizes the seed when omitted', () => {
+    const g = buildZimageSeamlessGraph(params('a lake', undefined, 'zimage-turbo'));
+    const seed = g['9'].inputs.seed as number;
+    expect(Number.isInteger(seed)).toBe(true);
+    expect(seed).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('buildQwenSeamlessGraph (golden: Qwen DiT engine)', () => {
+  const graph = buildQwenSeamlessGraph(params('an icy lake', 42, 'qwen-image'));
+
+  it('loads the prod-warm 2512 GGUF with the sdpa attention override', () => {
+    expect(graph['1'].class_type).toBe('GGUFLoaderKJ');
+    expect(graph['1'].inputs).toMatchObject({ model_name: QWEN_DIFFUSION_AIR, attention_override: 'sdpa' });
+    expect(graph['2'].inputs.lora_name).toBe(QWEN_LORA_AIR);
+    expect(graph['3'].inputs).toMatchObject({ shift: 3.1 });
+    expect(graph['4'].inputs).toMatchObject({ clip_name: QWEN_CLIP_AIR, type: 'qwen_image' });
+    expect(graph['7'].inputs.vae_name).toBe(QWEN_VAE_AIR);
+  });
+
+  it('quality sampling: 20 steps, cfg 2.5, ACTIVE negative prompt', () => {
+    expect(graph['9'].inputs).toMatchObject({
+      seed: 42,
+      steps: 20,
+      cfg: 2.5,
+      sampler_name: 'euler',
+      scheduler: 'simple',
+    });
+    expect(graph['5'].inputs.text).toBe(QWEN_TRIGGER_WORDS + 'an icy lake' + QUALITY_TAIL);
+    expect(graph['6'].inputs.text).toBe(NEGATIVE_PROMPT);
+    expect(graph['20'].inputs).toMatchObject({ cfg: 2.5, denoise: SEAM_DENOISE, seed: 43 });
+  });
+
+  it('shares the exact roll/mask/heal node shape with Z-Image (loader aside)', () => {
+    const zimage = buildZimageSeamlessGraph(params('an icy lake', 42, 'zimage-turbo'));
+    expect(Object.keys(graph)).toEqual(Object.keys(zimage));
+    for (const id of Object.keys(graph)) {
+      if (id === '1') continue;
+      expect(graph[id].class_type).toBe(zimage[id].class_type);
+    }
+  });
+});
+
+describe('buildFlux2SeamlessGraph (golden: Flux2 Klein engine)', () => {
+  const graph = buildFlux2SeamlessGraph(params('an icy lake', 42, 'flux2-klein'));
+
+  it('loads the prod 9b-kv model set with the flux2 clip type', () => {
+    expect(graph['1']).toEqual({
+      class_type: 'UNETLoader',
+      inputs: { unet_name: FLUX2_DIFFUSION_AIR, weight_dtype: 'default' },
+    });
+    expect(graph['2'].inputs.lora_name).toBe(FLUX2_LORA_AIR);
+    expect(graph['3'].inputs).toMatchObject({ clip_name: FLUX2_CLIP_AIR, type: 'flux2' });
+    expect(graph['6'].inputs.vae_name).toBe(FLUX2_VAE_AIR);
+    expect(graph['7'].class_type).toBe('EmptyFlux2LatentImage');
+    expect(graph['4'].inputs.text).toBe(FLUX2_TRIGGER_WORDS + 'an icy lake' + QUALITY_TAIL);
+    expect(graph['5'].inputs.text).toBe(NEGATIVE_PROMPT);
+  });
+
+  it('samples with the fleet stack: Flux2Scheduler + CFGGuider + SamplerCustomAdvanced', () => {
+    expect(graph['8']).toEqual({
+      class_type: 'Flux2Scheduler',
+      inputs: { steps: FLUX2_STEPS, width: PANO_WIDTH, height: PANO_HEIGHT },
+    });
+    expect(graph['9']).toEqual({
+      class_type: 'CFGGuider',
+      inputs: { model: ['2', 0], positive: ['4', 0], negative: ['5', 0], cfg: FLUX2_CFG },
+    });
+    expect(graph['10'].inputs.noise_seed).toBe(42);
+    expect(graph['12']).toEqual({
+      class_type: 'SamplerCustomAdvanced',
+      inputs: { noise: ['10', 0], guider: ['9', 0], sampler: ['11', 0], sigmas: ['8', 0], latent_image: ['7', 0] },
+    });
+    expect(graph['13'].inputs).toEqual({ samples: ['12', 0], vae: ['6', 0] });
+  });
+
+  it('seam pass takes its partial denoise from SplitSigmasDenoise low_sigmas', () => {
+    expect(graph['23'].inputs).toMatchObject({ steps: SEAM_STEPS });
+    expect(graph['24']).toEqual({
+      class_type: 'SplitSigmasDenoise',
+      inputs: { sigmas: ['23', 0], denoise: SEAM_DENOISE },
+    });
+    expect(graph['25'].inputs.noise_seed).toBe(43);
+    expect(graph['26'].inputs).toEqual({
+      noise: ['25', 0],
+      guider: ['9', 0],
+      sampler: ['11', 0],
+      sigmas: ['24', 1],
+      latent_image: ['22', 0],
+    });
+  });
+
+  it('rolls, masks, heals, rolls back, and saves', () => {
+    const half = PANO_WIDTH / 2;
+    expect(graph['14'].inputs).toMatchObject({ image: ['13', 0], x: 0, width: half });
+    expect(graph['15'].inputs).toMatchObject({ image: ['13', 0], x: half, width: half });
+    expect(graph['16'].inputs.image1).toEqual(['15', 0]);
+    expect(graph['21'].inputs).toEqual({ pixels: ['16', 0], vae: ['6', 0] });
+    expect(graph['22'].inputs).toEqual({ samples: ['21', 0], mask: ['20', 0] });
+    expect(graph['31']).toMatchObject({ class_type: 'SaveImage', inputs: { images: ['30', 0] } });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Injection safety — a prompt with graph-hostile bytes yields a STRUCTURALLY
+// identical graph (object construction; prompt is a leaf). Plan §7-3.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('prompt injection safety', () => {
+  const MALICIOUS = 'a lake", "class_type": "Evil"}, "999": {{ </script> \\   end';
+
+  const structure = (g: ComfyGraph) => Object.fromEntries(Object.entries(g).map(([id, n]) => [id, n.class_type]));
+
+  it.each(['zimage-turbo', 'qwen-image', 'flux2-klein'] as const)(
+    '%s: hostile prompt does not perturb graph topology, lands as a leaf',
+    (engine) => {
+      const build =
+        engine === 'flux2-klein'
+          ? buildFlux2SeamlessGraph
+          : engine === 'qwen-image'
+          ? buildQwenSeamlessGraph
+          : buildZimageSeamlessGraph;
+      const benign = build(params('a lake', 7, engine));
+      const hostile = build(params(MALICIOUS, 7, engine));
+      // The positive-prompt CLIPTextEncode node differs by engine (flux2 wires
+      // positive at node 4, the KSampler-shaped engines at node 5).
+      const positive = engine === 'flux2-klein' ? '4' : '5';
+
+      // Same node ids + class_types → identical topology.
+      expect(structure(hostile)).toEqual(structure(benign));
+      // The prompt text node differs ONLY in its leaf `text` value.
+      expect(hostile[positive].inputs.text).toContain(MALICIOUS);
+      expect(hostile[positive].inputs.text).not.toBe(benign[positive].inputs.text);
+      // The malicious bytes never become graph structure — they survive a JSON
+      // round-trip as a single string value, escaped.
+      const revived = JSON.parse(JSON.stringify(hostile)) as ComfyGraph;
+      expect(structure(revived)).toEqual(structure(benign));
+      expect(revived[positive].inputs.text).toContain(MALICIOUS);
+    }
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildStep — engine dispatch + resource ordering (mirrors buildDitSeamlessTemplate).
+// ─────────────────────────────────────────────────────────────────────────────
+describe('recipe.buildStep (engine → resources + graph)', () => {
+  const build = (p: SeamlessPanoParams): CustomComfyStepInput => seamlessPano360Recipe.buildStep(p, {});
+
+  it('defaults to zimage-turbo when engine is omitted', () => {
+    const step = build(params('a lake', 1));
+    expect(step.trace).toBe('binary');
+    expect(step.resources).toEqual([ZIMAGE_DIFFUSION_AIR, ZIMAGE_CLIP_AIR, ZIMAGE_VAE_AIR, ZIMAGE_LORA_AIR]);
+    expect(step.workflow['1'].class_type).toBe('UNETLoader');
+  });
+
+  it('qwen-image: the four Qwen AIRs + GGUF loader', () => {
+    const step = build(params('a lake', 1, 'qwen-image'));
+    expect(step.resources).toEqual([QWEN_DIFFUSION_AIR, QWEN_CLIP_AIR, QWEN_VAE_AIR, QWEN_LORA_AIR]);
+    expect(step.workflow['1'].class_type).toBe('GGUFLoaderKJ');
+  });
+
+  it('flux2-klein: the four Klein AIRs + fleet sampler stack', () => {
+    const step = build(params('a lake', 1, 'flux2-klein'));
+    expect(step.resources).toEqual([FLUX2_DIFFUSION_AIR, FLUX2_CLIP_AIR, FLUX2_VAE_AIR, FLUX2_LORA_AIR]);
+    expect(step.workflow['9'].class_type).toBe('CFGGuider');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Param schema — bounded + strict, no checkpoint (pinned policy).
+// ─────────────────────────────────────────────────────────────────────────────
+describe('seamlessPanoParamSchema', () => {
+  it('accepts the bounded shape', () => {
+    const r = seamlessPanoParamSchema.safeParse({ prompt: 'x', seed: 5, engine: 'qwen-image', accountType: 'blue' });
+    expect(r.success).toBe(true);
+  });
+  it('rejects a prompt over the cap', () => {
+    expect(seamlessPanoParamSchema.safeParse({ prompt: 'x'.repeat(PROMPT_MAX + 1) }).success).toBe(false);
+  });
+  it('rejects an unknown engine', () => {
+    expect(seamlessPanoParamSchema.safeParse({ prompt: 'x', engine: 'sdxl' }).success).toBe(false);
+  });
+  it('rejects a checkpoint field (v1 pinned policy — .strict())', () => {
+    expect(seamlessPanoParamSchema.safeParse({ prompt: 'x', checkpoint: { modelId: 1, versionId: 2 } }).success).toBe(
+      false
+    );
+  });
+  it('coerces a string seed and tolerates null', () => {
+    expect(seamlessPanoParamSchema.parse({ prompt: 'x', seed: '9' }).seed).toBe(9);
+    expect(seamlessPanoParamSchema.parse({ prompt: 'x', seed: null }).seed).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Recipe contract + registry wiring.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('seamlessPano360Recipe contract', () => {
+  it('is registered under its id and reachable via getRecipe', () => {
+    expect(REGISTERED_RECIPE_IDS).toContain('seamless-pano-360');
+    expect(getRecipe('seamless-pano-360')).toBe(seamlessPano360Recipe);
+    expect(getRecipe('not-a-recipe')).toBeUndefined();
+  });
+
+  it('declares the post-paid ceiling contract: maxBuzz == ceil(stepTimeoutSeconds)', () => {
+    expect(seamlessPano360Recipe.stepTimeoutSeconds).toBe(180);
+    expect(seamlessPano360Recipe.maxBuzz).toBe(Math.ceil(seamlessPano360Recipe.stepTimeoutSeconds));
+  });
+
+  it('is pinned (no user checkpoint) and pins the three 360Redmond LoRA versions', () => {
+    expect(seamlessPano360Recipe.checkpointPolicy).toBe('pinned');
+    expect(seamlessPano360Recipe.resourceAllowlist.checkpoints).toBeUndefined();
+    expect(recipeCivitaiVersionIds(seamlessPano360Recipe).sort()).toEqual(
+      [ZIMAGE_LORA_VERSION_ID, QWEN_LORA_VERSION_ID, FLUX2_LORA_VERSION_ID].sort()
+    );
+  });
+
+  it('surfaces per-engine display estimates', () => {
+    expect(seamlessPano360Recipe.estimateBuzz(params('x'))).toBe(ESTIMATE_BUZZ_BY_ENGINE['zimage-turbo']);
+    expect(seamlessPano360Recipe.estimateBuzz(params('x', undefined, 'qwen-image'))).toBe(150);
+    expect(seamlessPano360Recipe.estimateBuzz(params('x', undefined, 'flux2-klein'))).toBe(45);
+  });
+});

--- a/src/server/services/blocks/recipes/index.ts
+++ b/src/server/services/blocks/recipes/index.ts
@@ -55,6 +55,41 @@ export type RecipeCivitaiResource = {
   baseModelGroup?: string;
 };
 
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 RESOURCE INVARIANT (read before pinning ANY civitai model version below)
+//
+// A customComfy recipe MAY ONLY pin FULLY-PUBLIC, Published, NON-early-access,
+// NON-Private model versions in its `resourceAllowlist` (checkpoints + loras).
+//
+// WHY this is a hard invariant and not just a preference: a raw customComfy step
+// submits its `input.resources` AIR array DIRECTLY to the orchestrator, which
+// BYPASSES `getGenerationResourceData`'s early-access / Private belt — that belt
+// only runs over generation-GRAPH steps (textToImage/comfy), never over a
+// hand-authored customComfy `resources` array. The router-side gate the belt
+// leans on (`resolveCanGenerateForVersions` → `assertViewerCanGeneratePageResources`
+// in blocks.router.ts `submitCustomComfyWorkflow`) covers baseline generatability
+// (usageControl / covered / NSFW-tier) but does NOT currently cover early-access
+// `hasAccess` NOR Private-model subscription entitlement. So a pinned early-access
+// or Private version would run for viewers who have NOT paid for / been granted it
+// — an entitlement bypass. Keep every pinned version Public + Published +
+// non-early-access until that gate exists.
+//
+// v1 (`seamless-pano-360`): the pinned 360Redmond LoRA versions (model 118025) are
+// verified Public / Published / non-early-access / non-Private — safe under this
+// invariant.
+//
+// This is a DOC-INVARIANT, enforced by CODE REVIEW of each new recipe PR — NOT a
+// module-load DB check (there is no DB in this module; the registry loads at
+// import time, before any request context). A robust router-side early-access /
+// Private / hasAccess gate for customComfy-resolved versions is separate pre-GA
+// hardening.
+//
+// TODO(app-blocks customComfy pre-GA): add an early-access `hasAccess` +
+// Private-subscription entitlement gate over `recipeCivitaiVersionIds(recipe)` in
+// `submitCustomComfyWorkflow` (blocks.router.ts) so the invariant is ENFORCED at
+// submit, not merely asserted by review — then this comment can relax to "prefer".
+// ─────────────────────────────────────────────────────────────────────────────
+
 /**
  * The recipe contract (server-side, NEVER on the wire). `P` is the recipe's
  * bounded param type (inferred from `paramSchema`).

--- a/src/server/services/blocks/recipes/index.ts
+++ b/src/server/services/blocks/recipes/index.ts
@@ -1,0 +1,146 @@
+import type * as z from 'zod';
+import { seamlessPano360Recipe } from './seamless-pano.recipe';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App Blocks `customComfy` recipe registry.
+//
+// A recipe bundles a fixed, server-authored ComfyUI graph builder with a bounded
+// param schema, a fixed resource/AIR allowlist, a checkpoint policy, and — the
+// load-bearing addition for the post-paid path — a declared `maxBuzz` ceiling
+// backed by an aggressive step `timeout`. It is a CODE-REVIEWED, in-repo artifact
+// (never runtime/DB-editable): the registry is the trust root (plan §3, §7).
+//
+// The block schema's `recipe` enum is DERIVED from this registry's keys
+// (`REGISTERED_RECIPE_IDS`), so an unregistered recipe id fails closed at the
+// wire schema. Adding a recipe = one small reviewed civitai PR: write a
+// `<name>.recipe.ts`, register it below, add golden-graph tests. The `kind`
+// (`customComfy`) and the SDK are untouched — only the recipe id enum widens.
+//
+// INERT/DARK: nothing here is wired into the live blocks.router submit/estimate
+// path yet — PR6 (router + post-paid budget belt) is what will call `getRecipe`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A ComfyUI /prompt graph node: class_type + inputs, link refs `['id', slot]`. */
+export type ComfyGraphNode = { class_type: string; inputs: Record<string, unknown> };
+/** A ComfyUI /prompt graph: node-id keyed. */
+export type ComfyGraph = Record<string, ComfyGraphNode>;
+
+/**
+ * The `$type:'customComfy'` step INPUT payload (`CustomComfyInput` in
+ * @civitai/client): the AIR resource list + the raw graph + the trace mode. This
+ * is the reusable graph-construction output — a future prepaid `$type:'comfy'`
+ * path would wrap the SAME input differently, so keep it free of any
+ * customComfy-step envelope concern.
+ */
+export type CustomComfyStepInput = {
+  resources: string[];
+  trace: 'binary';
+  workflow: ComfyGraph;
+};
+
+/**
+ * Resolved, entitlement-verified resources handed to a recipe's `buildStep`.
+ * v1 (pinned policy) carries nothing — the recipe's graph uses fixed public
+ * constants. A future user-picked-checkpoint policy would resolve the picked
+ * checkpoint's AIR here AFTER the entitlement belt has run over it.
+ */
+export type ResolvedRecipeResources = {
+  checkpointAir?: string;
+};
+
+/** A recipe-pinned civitai resource (checkpoint/LoRA) the entitlement belt gates. */
+export type RecipeCivitaiResource = {
+  modelId?: number;
+  modelVersionId: number;
+  baseModelGroup?: string;
+};
+
+/**
+ * The recipe contract (server-side, NEVER on the wire). `P` is the recipe's
+ * bounded param type (inferred from `paramSchema`).
+ */
+export interface BlockRecipe<P = unknown> {
+  /** Stable id; the schema's `recipe` enum is derived from the registry keys. */
+  id: string;
+  /** Bounded, `.strict()` Zod schema for the recipe's params. */
+  paramSchema: z.ZodType<P>;
+  /** Which engine variants this recipe exposes (drives which builder runs). */
+  engines: readonly string[];
+  /**
+   * PURE builder: bounded params + resolved resources → the customComfy step
+   * INPUT. Ported from panorama.ts; builds a ComfyGraph by OBJECT CONSTRUCTION
+   * only (the prompt is a leaf string, never templated into the graph).
+   */
+  buildStep(params: P, resolved: ResolvedRecipeResources): CustomComfyStepInput;
+  /** Every resource the recipe can reference, by role. v1 = fixed public models. */
+  resourceAllowlist: {
+    checkpoints?: RecipeCivitaiResource[];
+    loras?: RecipeCivitaiResource[];
+    /** huggingface AIRs the DiT engines pin (not gated civitai versions). */
+    staticAirs: string[];
+  };
+  /** v1: 'pinned' (no user checkpoint). Follow-up: 'userPickedSdxl'. */
+  checkpointPolicy: 'pinned' | 'userPickedSdxl';
+  /** Hard per-job Buzz ceiling — MUST equal ceil(stepTimeoutSeconds × 1). */
+  maxBuzz: number;
+  /** The aggressive step timeout (seconds) that ENFORCES `maxBuzz` (plan §5). */
+  stepTimeoutSeconds: number;
+  /** Display-only estimate for estimateWorkflow (post-paid has no exact price). */
+  estimateBuzz(params: P): number;
+  /** Recipe-level negative prompt (the prompt-audit re-point reads this in PR6). */
+  negativePrompt: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyBlockRecipe = BlockRecipe<any>;
+
+// The registry object. Its keys ARE the source of truth for the schema enum.
+const recipeRegistry = {
+  'seamless-pano-360': seamlessPano360Recipe,
+};
+
+export type RegisteredRecipeId = keyof typeof recipeRegistry & string;
+
+/**
+ * The registered recipe ids, derived from the registry keys. Consumed by
+ * `workflow.schema`'s `blockCustomComfyBodySchema` as the fail-closed `recipe`
+ * enum (an unregistered id is rejected at the union). Typed as a non-empty tuple
+ * so `z.enum` accepts it.
+ */
+export const REGISTERED_RECIPE_IDS = Object.keys(recipeRegistry) as [
+  RegisteredRecipeId,
+  ...RegisteredRecipeId[]
+];
+
+/** Resolve a recipe by id. Returns `undefined` for an unregistered id. */
+export function getRecipe(id: string): AnyBlockRecipe | undefined {
+  return (recipeRegistry as Record<string, AnyBlockRecipe>)[id];
+}
+
+/**
+ * The civitai model-version ids a recipe pins (checkpoints + LoRAs). PR6's router
+ * passes these through `resolveCanGenerateForVersions` /
+ * `assertViewerCanGeneratePageResources` (blocks.router.ts) BEFORE emitting the
+ * step — so the registry can't be quietly edited to point at a gated /
+ * early-access / Private resource without the entitlement belt catching it. The
+ * huggingface `staticAirs` are exempt-by-construction (no civitai entitlement).
+ */
+export function recipeCivitaiVersionIds(recipe: AnyBlockRecipe): number[] {
+  const { checkpoints = [], loras = [] } = recipe.resourceAllowlist;
+  return [...checkpoints, ...loras].map((r) => r.modelVersionId);
+}
+
+// Fail-fast the `maxBuzz == ceil(stepTimeoutSeconds)` invariant at module load —
+// the safety argument (plan §5.4) depends on the step timeout physically capping
+// the job at `maxBuzz`, so a recipe that declares a looser `maxBuzz` than its
+// timeout enforces (or a tighter one it can't guarantee) is a build-time error,
+// not a runtime surprise.
+for (const [id, recipe] of Object.entries(recipeRegistry)) {
+  const enforced = Math.ceil(recipe.stepTimeoutSeconds);
+  if (recipe.maxBuzz !== enforced) {
+    throw new Error(
+      `recipe '${id}': maxBuzz (${recipe.maxBuzz}) must equal ceil(stepTimeoutSeconds) (${enforced}) — ` +
+        'the step timeout is the physical Buzz ceiling (plan §5).'
+    );
+  }
+}

--- a/src/server/services/blocks/recipes/seamless-pano.recipe.ts
+++ b/src/server/services/blocks/recipes/seamless-pano.recipe.ts
@@ -1,0 +1,557 @@
+import * as z from 'zod';
+import { buzzSpendTypes } from '~/shared/constants/buzz.constants';
+import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
+import type { BlockRecipe, ComfyGraph, CustomComfyStepInput } from './index';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// seamless-pano-360 — recipe #1 for the App Blocks `customComfy` bridge.
+//
+// Ported VERBATIM (by object construction) from the reference DEV app's
+// `panorama.ts` graph builders (Koen's civitai-app-model-benchmarking). This is
+// the server-authored, code-reviewed ComfyUI recipe — NEVER runtime/DB-editable.
+// The iframe never sends a graph; it sends `{ recipe:'seamless-pano-360', params }`
+// and the server owns the graph in full.
+//
+// v1 scope = the DiT engines only (Z-Image Turbo / Flux2 Klein / Qwen Image),
+// each ONE `$type:'customComfy'` step with all stock/baked nodes — no nodepack
+// snapshot, no layer-AIR cache. The SDXL conv-wrap engine (the nodepack-snapshot
+// path) is deferred (plan R4).
+//
+// INERT/DARK: nothing in this module is wired into the live blocks.router submit
+// / estimate path yet. PR6 (router + post-paid budget belt) is what calls it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The DiT engine variants this recipe exposes (v1 = DiT only, no SDXL). */
+export const SEAMLESS_PANO_ENGINES = ['zimage-turbo', 'flux2-klein', 'qwen-image'] as const;
+export type SeamlessPanoEngine = (typeof SEAMLESS_PANO_ENGINES)[number];
+
+/** v1 default engine — cheapest/fastest (Z-Image Turbo, ~20 Buzz display estimate). */
+export const DEFAULT_ENGINE: SeamlessPanoEngine = 'zimage-turbo';
+
+// ── Prompt shaping ───────────────────────────────────────────────────────────
+// The block schema already caps prompt at 1500; we re-clamp here so the ported
+// builders stay byte-identical to the reference oracle for any input.
+export const PROMPT_MAX = 1500;
+export const PROMPT_SUFFIX = ', ultra detailed, masterpiece, best quality';
+export const NEGATIVE_PROMPT =
+  'ugly, blurry, low quality, watermark, jpeg artifacts, deformed, text, border, frame';
+
+export function clampPrompt(raw: string): string {
+  return raw.trim().slice(0, PROMPT_MAX);
+}
+
+/**
+ * Each DiT LoRA variant publishes differently-cased/ordered trigger words. The
+ * trigger-word prefix + quality suffix are appended AFTER the raw prompt is read
+ * — the prompt-audit (PR6) reads `params.prompt` (the raw leaf), never this
+ * decorated string, and the prompt is ALWAYS a leaf string value in the graph
+ * (object construction), so it can never perturb graph topology (plan §7-3).
+ */
+export function ditPositivePrompt(triggerWords: string, scene: string): string {
+  return triggerWords + clampPrompt(scene) + PROMPT_SUFFIX;
+}
+
+// ── Recipe-pinned civitai LoRA (360Redmond, per-engine DiT variants) ─────────
+// All three are versions of the SAME public model (118025); pinned by the
+// registry, entitlement-checked by PR6 against `resolveCanGenerateForVersions`.
+export const LORA_MODEL_ID = 118025;
+
+// ── Z-Image Turbo — model set mirrors the spine workers' own Z-Image builders ─
+export const ZIMAGE_DIFFUSION_AIR =
+  'urn:air:zimageturbo:diffusion_model:huggingface:Comfy-Org/z_image_turbo@main/split_files/diffusion_models/z_image_turbo_bf16.safetensors';
+export const ZIMAGE_CLIP_AIR =
+  'urn:air:qwen:clip:huggingface:Comfy-Org/z_image_turbo@main/split_files/text_encoders/qwen_3_4b_fp8_mixed.safetensors';
+export const ZIMAGE_VAE_AIR =
+  'urn:air:flux1:vae:huggingface:black-forest-labs/FLUX.1-dev@main/ae.safetensors';
+// Ecosystem must be `zimageturbo` (the version's canonical AIR per the civitai
+// API) — `zimage:lora` fails resource resolution on the workers.
+export const ZIMAGE_LORA_VERSION_ID = 2702227;
+export const ZIMAGE_LORA_AIR = `urn:air:zimageturbo:lora:civitai:${LORA_MODEL_ID}@${ZIMAGE_LORA_VERSION_ID}`;
+export const ZIMAGE_LORA_STRENGTH = 1.0;
+export const ZIMAGE_TRIGGER_WORDS = '360 view, 360, ';
+
+export const ZIMAGE_SHIFT = 3.0;
+export const ZIMAGE_STEPS = 8;
+export const ZIMAGE_CFG = 1;
+export const ZIMAGE_SAMPLER = 'euler';
+export const ZIMAGE_SCHEDULER = 'simple';
+
+// ── Qwen Image — the prod-warm 2512 GGUF (sage attention corrupts it) ────────
+export const QWEN_DIFFUSION_AIR =
+  'urn:air:qwen:diffusion_model:huggingface:unsloth/Qwen-Image-2512-GGUF@main/qwen-image-2512-Q5_K_M.gguf';
+export const QWEN_CLIP_AIR =
+  'urn:air:qwen:clip:huggingface:Comfy-Org/Qwen-Image_ComfyUI@main/split_files/text_encoders/qwen_2.5_vl_7b_fp8_scaled.safetensors';
+export const QWEN_VAE_AIR =
+  'urn:air:qwen:vae:huggingface:Comfy-Org/Qwen-Image_ComfyUI@main/split_files/vae/qwen_image_vae.safetensors';
+export const QWEN_LORA_VERSION_ID = 2702222;
+export const QWEN_LORA_AIR = `urn:air:qwen:lora:civitai:${LORA_MODEL_ID}@${QWEN_LORA_VERSION_ID}`;
+export const QWEN_LORA_STRENGTH = 1.0;
+export const QWEN_TRIGGER_WORDS = '360 VIEW, 360, ';
+
+export const QWEN_STEPS = 20;
+export const QWEN_CFG = 2.5;
+export const QWEN_SHIFT = 3.1;
+
+// ── Flux2 Klein 9B — prod's ComfyUI variant ("9b-kv") ────────────────────────
+export const FLUX2_DIFFUSION_AIR =
+  'urn:air:flux2:diffusion_model:huggingface:black-forest-labs/FLUX.2-klein-9b-kv-fp8@main/flux-2-klein-9b-kv-fp8.safetensors';
+export const FLUX2_CLIP_AIR =
+  'urn:air:flux2:text_encoders:huggingface:Comfy-Org/vae-text-encorder-for-flux-klein-9b@main/split_files/text_encoders/qwen_3_8b_fp8mixed.safetensors';
+export const FLUX2_VAE_AIR =
+  'urn:air:flux2:vae:huggingface:Comfy-Org/vae-text-encorder-for-flux-klein-9b@main/split_files/vae/flux2-vae.safetensors';
+export const FLUX2_LORA_VERSION_ID = 2702214;
+export const FLUX2_LORA_AIR = `urn:air:flux2:lora:civitai:${LORA_MODEL_ID}@${FLUX2_LORA_VERSION_ID}`;
+export const FLUX2_LORA_STRENGTH = 1.0;
+export const FLUX2_TRIGGER_WORDS = '360 View, 360, ';
+
+// Klein is step-distilled but NOT guidance-distilled — cfg 5 is real guidance,
+// so the negative prompt is active.
+export const FLUX2_STEPS = 8;
+export const FLUX2_CFG = 5;
+
+// ── Canvas + seam-heal tunables ──────────────────────────────────────────────
+// 2:1 equirectangular. 2048 is also the block bridge's DIM_MAX.
+export const PANO_WIDTH = 2048;
+export const PANO_HEIGHT = 1024;
+const HALF_W = PANO_WIDTH / 2;
+
+// Seam-heal tunables. Denoise below 0.7 leaves the seam line partially intact;
+// the wide feather blends the repaint in.
+export const SEAM_BAND_PX = 320;
+export const SEAM_FEATHER_PX = 128;
+export const SEAM_DENOISE = 0.7;
+export const SEAM_STEPS = 8;
+
+/** Per-engine display estimate (post-paid has no exact pre-price — display only). */
+export const ESTIMATE_BUZZ_BY_ENGINE: Record<SeamlessPanoEngine, number> = {
+  'zimage-turbo': 20,
+  'flux2-klein': 45,
+  'qwen-image': 150,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Param schema — .strict(), no checkpoint (v1 pinned policy).
+// Mirrors the reference PanoBody minus the user-picked SDXL checkpoint.
+// Account-type enum is built from the SAME source of truth (buzzSpendTypes) the
+// block schema's `blockAccountTypeSchema` uses — imported directly (not from
+// workflow.schema) to avoid a workflow.schema ⇄ recipes import cycle.
+// ─────────────────────────────────────────────────────────────────────────────
+export const seamlessPanoParamSchema = z
+  .object({
+    prompt: z.string().max(PROMPT_MAX),
+    seed: z.coerce.number().int().nullish(),
+    engine: z.enum(SEAMLESS_PANO_ENGINES).optional(),
+    accountType: z
+      .enum(buzzSpendTypes as [BuzzSpendType, ...BuzzSpendType[]])
+      .optional(),
+  })
+  .strict();
+
+export type SeamlessPanoParams = z.infer<typeof seamlessPanoParamSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Graph builders — ported verbatim from panorama.ts (object construction only).
+// The prompt is always a leaf string value; there is NO string-templating of the
+// graph structure (injection-safe by construction).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function resolveSeed(seed: number | null | undefined): number {
+  return seed ?? Math.floor(Math.random() * 2_147_483_647);
+}
+
+/** Everything that differs between the KSampler-shaped DiT engines. */
+export interface DitEngineSpec {
+  diffusionAir: string;
+  /** The whole diffusion-loader node — engines differ in loader class too. */
+  loader: { class_type: string; inputs: Record<string, unknown> };
+  clipAir: string;
+  clipType: string;
+  vaeAir: string;
+  loraAir: string;
+  loraStrength: number;
+  triggerWords: string;
+  shift: number;
+  steps: number;
+  cfg: number;
+  /** '' when cfg is 1 (guidance off — the encode is wired but inert). */
+  negativePrompt: string;
+}
+
+export const ZIMAGE_SPEC: DitEngineSpec = {
+  diffusionAir: ZIMAGE_DIFFUSION_AIR,
+  loader: {
+    class_type: 'UNETLoader',
+    inputs: { unet_name: ZIMAGE_DIFFUSION_AIR, weight_dtype: 'default' },
+  },
+  clipAir: ZIMAGE_CLIP_AIR,
+  clipType: 'lumina2',
+  vaeAir: ZIMAGE_VAE_AIR,
+  loraAir: ZIMAGE_LORA_AIR,
+  loraStrength: ZIMAGE_LORA_STRENGTH,
+  triggerWords: ZIMAGE_TRIGGER_WORDS,
+  shift: ZIMAGE_SHIFT,
+  steps: ZIMAGE_STEPS,
+  cfg: ZIMAGE_CFG,
+  negativePrompt: '',
+};
+
+export const QWEN_SPEC: DitEngineSpec = {
+  diffusionAir: QWEN_DIFFUSION_AIR,
+  // The fleet launches ComfyUI with --use-sage-attention, which silently
+  // corrupts the attention mask Qwen passes — GGUFLoaderKJ's `sdpa` override
+  // forces pytorch attention.
+  loader: {
+    class_type: 'GGUFLoaderKJ',
+    inputs: {
+      model_name: QWEN_DIFFUSION_AIR,
+      extra_model_name: 'none',
+      dequant_dtype: 'default',
+      patch_dtype: 'default',
+      patch_on_device: false,
+      enable_fp16_accumulation: false,
+      attention_override: 'sdpa',
+    },
+  },
+  clipAir: QWEN_CLIP_AIR,
+  clipType: 'qwen_image',
+  vaeAir: QWEN_VAE_AIR,
+  loraAir: QWEN_LORA_AIR,
+  loraStrength: QWEN_LORA_STRENGTH,
+  triggerWords: QWEN_TRIGGER_WORDS,
+  shift: QWEN_SHIFT,
+  steps: QWEN_STEPS,
+  cfg: QWEN_CFG,
+  negativePrompt: NEGATIVE_PROMPT,
+};
+
+/**
+ * 50% horizontal roll: id: left crop, id+1: right crop, id+2: [R|L] stitch.
+ * ComfyUI has no roll node; crop+stitch is an involution, so applying it again
+ * rolls back.
+ */
+function rollNodes(id: number, image: [string, number]): ComfyGraph {
+  return {
+    [`${id}`]: {
+      class_type: 'ImageCrop',
+      inputs: { image, width: HALF_W, height: PANO_HEIGHT, x: 0, y: 0 },
+    },
+    [`${id + 1}`]: {
+      class_type: 'ImageCrop',
+      inputs: { image, width: HALF_W, height: PANO_HEIGHT, x: HALF_W, y: 0 },
+    },
+    [`${id + 2}`]: {
+      class_type: 'ImageStitch',
+      inputs: {
+        image1: [`${id + 1}`, 0],
+        image2: [`${id}`, 0],
+        direction: 'right',
+        match_image_size: true,
+        spacing_width: 0,
+        spacing_color: 'white',
+      },
+    },
+  };
+}
+
+/** Feathered band mask over the centered seam: ids id..id+3, output at id+3. */
+function bandMaskNodes(id: number): ComfyGraph {
+  return {
+    [`${id}`]: {
+      class_type: 'SolidMask',
+      inputs: { value: 0, width: PANO_WIDTH, height: PANO_HEIGHT },
+    },
+    [`${id + 1}`]: {
+      class_type: 'SolidMask',
+      inputs: { value: 1, width: SEAM_BAND_PX, height: PANO_HEIGHT },
+    },
+    [`${id + 2}`]: {
+      class_type: 'MaskComposite',
+      inputs: {
+        destination: [`${id}`, 0],
+        source: [`${id + 1}`, 0],
+        x: (PANO_WIDTH - SEAM_BAND_PX) / 2,
+        y: 0,
+        operation: 'add',
+      },
+    },
+    [`${id + 3}`]: {
+      class_type: 'FeatherMask',
+      inputs: {
+        mask: [`${id + 2}`, 0],
+        left: SEAM_FEATHER_PX,
+        top: 0,
+        right: SEAM_FEATHER_PX,
+        bottom: 0,
+      },
+    },
+  };
+}
+
+/** Z-Image + Qwen share one KSampler-shaped graph (loader aside). */
+export function buildDitSeamlessGraph(spec: DitEngineSpec, params: SeamlessPanoParams): ComfyGraph {
+  const seed = resolveSeed(params.seed);
+
+  return {
+    '1': spec.loader,
+    '2': {
+      class_type: 'LoraLoaderModelOnly',
+      inputs: { model: ['1', 0], lora_name: spec.loraAir, strength_model: spec.loraStrength },
+    },
+    '3': {
+      class_type: 'ModelSamplingAuraFlow',
+      inputs: { model: ['2', 0], shift: spec.shift },
+    },
+    '4': {
+      class_type: 'CLIPLoader',
+      inputs: { clip_name: spec.clipAir, type: spec.clipType, device: 'default' },
+    },
+    '5': {
+      class_type: 'CLIPTextEncode',
+      inputs: { clip: ['4', 0], text: ditPositivePrompt(spec.triggerWords, params.prompt) },
+    },
+    '6': {
+      class_type: 'CLIPTextEncode',
+      inputs: { clip: ['4', 0], text: spec.negativePrompt },
+    },
+    '7': {
+      class_type: 'VAELoader',
+      inputs: { vae_name: spec.vaeAir },
+    },
+    '8': {
+      class_type: 'EmptySD3LatentImage',
+      inputs: { width: PANO_WIDTH, height: PANO_HEIGHT, batch_size: 1 },
+    },
+    '9': {
+      class_type: 'KSampler',
+      inputs: {
+        model: ['3', 0],
+        positive: ['5', 0],
+        negative: ['6', 0],
+        latent_image: ['8', 0],
+        seed,
+        steps: spec.steps,
+        cfg: spec.cfg,
+        sampler_name: ZIMAGE_SAMPLER,
+        scheduler: ZIMAGE_SCHEDULER,
+        denoise: 1.0,
+      },
+    },
+    '10': {
+      class_type: 'VAEDecode',
+      inputs: { samples: ['9', 0], vae: ['7', 0] },
+    },
+    ...rollNodes(11, ['10', 0]),
+    ...bandMaskNodes(14),
+    '18': {
+      class_type: 'VAEEncode',
+      inputs: { pixels: ['13', 0], vae: ['7', 0] },
+    },
+    '19': {
+      class_type: 'SetLatentNoiseMask',
+      inputs: { samples: ['18', 0], mask: ['17', 0] },
+    },
+    '20': {
+      class_type: 'KSampler',
+      inputs: {
+        model: ['3', 0],
+        positive: ['5', 0],
+        negative: ['6', 0],
+        latent_image: ['19', 0],
+        seed: seed + 1,
+        steps: SEAM_STEPS,
+        cfg: spec.cfg,
+        sampler_name: ZIMAGE_SAMPLER,
+        scheduler: ZIMAGE_SCHEDULER,
+        denoise: SEAM_DENOISE,
+      },
+    },
+    '21': {
+      class_type: 'VAEDecode',
+      inputs: { samples: ['20', 0], vae: ['7', 0] },
+    },
+    ...rollNodes(22, ['21', 0]),
+    '25': {
+      class_type: 'SaveImage',
+      inputs: { images: ['24', 0], filename_prefix: 'panorama' },
+    },
+  };
+}
+
+export function buildZimageSeamlessGraph(params: SeamlessPanoParams): ComfyGraph {
+  return buildDitSeamlessGraph(ZIMAGE_SPEC, params);
+}
+
+export function buildQwenSeamlessGraph(params: SeamlessPanoParams): ComfyGraph {
+  return buildDitSeamlessGraph(QWEN_SPEC, params);
+}
+
+/**
+ * Klein via the fleet's sampler stack. The seam pass gets its partial denoise
+ * from SplitSigmasDenoise's low_sigmas (output 1): SamplerCustomAdvanced scales
+ * its noise to the first sigma given, exactly like KSampler denoise<1.
+ */
+export function buildFlux2SeamlessGraph(params: SeamlessPanoParams): ComfyGraph {
+  const seed = resolveSeed(params.seed);
+
+  return {
+    '1': {
+      class_type: 'UNETLoader',
+      inputs: { unet_name: FLUX2_DIFFUSION_AIR, weight_dtype: 'default' },
+    },
+    '2': {
+      class_type: 'LoraLoaderModelOnly',
+      inputs: { model: ['1', 0], lora_name: FLUX2_LORA_AIR, strength_model: FLUX2_LORA_STRENGTH },
+    },
+    '3': {
+      class_type: 'CLIPLoader',
+      inputs: { clip_name: FLUX2_CLIP_AIR, type: 'flux2', device: 'default' },
+    },
+    '4': {
+      class_type: 'CLIPTextEncode',
+      inputs: { clip: ['3', 0], text: ditPositivePrompt(FLUX2_TRIGGER_WORDS, params.prompt) },
+    },
+    '5': {
+      class_type: 'CLIPTextEncode',
+      inputs: { clip: ['3', 0], text: NEGATIVE_PROMPT },
+    },
+    '6': {
+      class_type: 'VAELoader',
+      inputs: { vae_name: FLUX2_VAE_AIR },
+    },
+    '7': {
+      class_type: 'EmptyFlux2LatentImage',
+      inputs: { width: PANO_WIDTH, height: PANO_HEIGHT, batch_size: 1 },
+    },
+    '8': {
+      class_type: 'Flux2Scheduler',
+      inputs: { steps: FLUX2_STEPS, width: PANO_WIDTH, height: PANO_HEIGHT },
+    },
+    '9': {
+      class_type: 'CFGGuider',
+      inputs: { model: ['2', 0], positive: ['4', 0], negative: ['5', 0], cfg: FLUX2_CFG },
+    },
+    '10': {
+      class_type: 'RandomNoise',
+      inputs: { noise_seed: seed },
+    },
+    '11': {
+      class_type: 'KSamplerSelect',
+      inputs: { sampler_name: ZIMAGE_SAMPLER },
+    },
+    '12': {
+      class_type: 'SamplerCustomAdvanced',
+      inputs: {
+        noise: ['10', 0],
+        guider: ['9', 0],
+        sampler: ['11', 0],
+        sigmas: ['8', 0],
+        latent_image: ['7', 0],
+      },
+    },
+    '13': {
+      class_type: 'VAEDecode',
+      inputs: { samples: ['12', 0], vae: ['6', 0] },
+    },
+    ...rollNodes(14, ['13', 0]),
+    ...bandMaskNodes(17),
+    '21': {
+      class_type: 'VAEEncode',
+      inputs: { pixels: ['16', 0], vae: ['6', 0] },
+    },
+    '22': {
+      class_type: 'SetLatentNoiseMask',
+      inputs: { samples: ['21', 0], mask: ['20', 0] },
+    },
+    '23': {
+      class_type: 'Flux2Scheduler',
+      inputs: { steps: SEAM_STEPS, width: PANO_WIDTH, height: PANO_HEIGHT },
+    },
+    '24': {
+      class_type: 'SplitSigmasDenoise',
+      inputs: { sigmas: ['23', 0], denoise: SEAM_DENOISE },
+    },
+    '25': {
+      class_type: 'RandomNoise',
+      inputs: { noise_seed: seed + 1 },
+    },
+    '26': {
+      class_type: 'SamplerCustomAdvanced',
+      inputs: {
+        noise: ['25', 0],
+        guider: ['9', 0],
+        sampler: ['11', 0],
+        sigmas: ['24', 1],
+        latent_image: ['22', 0],
+      },
+    },
+    '27': {
+      class_type: 'VAEDecode',
+      inputs: { samples: ['26', 0], vae: ['6', 0] },
+    },
+    ...rollNodes(28, ['27', 0]),
+    '31': {
+      class_type: 'SaveImage',
+      inputs: { images: ['30', 0], filename_prefix: 'panorama' },
+    },
+  };
+}
+
+/**
+ * The reusable graph-construction step. Selects the engine's resource AIRs +
+ * ComfyUI graph and returns the `customComfy` step INPUT (`{ resources, trace,
+ * workflow }`). Deliberately separable from the `$type:'customComfy'` step
+ * wrapper (`createBlockCustomComfyStep`) so ONLY the wrapper — not this graph —
+ * changes if a future prepaid path registers it as a `$type:'comfy'` definition.
+ */
+function buildStep(params: SeamlessPanoParams): CustomComfyStepInput {
+  const engine = params.engine ?? DEFAULT_ENGINE;
+  const [resources, workflow] =
+    engine === 'flux2-klein'
+      ? ([[FLUX2_DIFFUSION_AIR, FLUX2_CLIP_AIR, FLUX2_VAE_AIR, FLUX2_LORA_AIR], buildFlux2SeamlessGraph(params)] as const)
+      : engine === 'qwen-image'
+      ? ([[QWEN_DIFFUSION_AIR, QWEN_CLIP_AIR, QWEN_VAE_AIR, QWEN_LORA_AIR], buildQwenSeamlessGraph(params)] as const)
+      : ([[ZIMAGE_DIFFUSION_AIR, ZIMAGE_CLIP_AIR, ZIMAGE_VAE_AIR, ZIMAGE_LORA_AIR], buildZimageSeamlessGraph(params)] as const);
+  return { resources: [...resources], trace: 'binary', workflow };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The recipe definition.
+// ─────────────────────────────────────────────────────────────────────────────
+export const seamlessPano360Recipe: BlockRecipe<SeamlessPanoParams> = {
+  id: 'seamless-pano-360',
+  paramSchema: seamlessPanoParamSchema,
+  engines: SEAMLESS_PANO_ENGINES,
+  buildStep,
+  resourceAllowlist: {
+    // No civitai checkpoint (DiT engines have no UNet checkpoint; pinned policy).
+    // The per-engine 360Redmond LoRA versions ARE gated civitai versions — PR6
+    // runs `resolveCanGenerateForVersions` over these before submit.
+    loras: [
+      { modelId: LORA_MODEL_ID, modelVersionId: ZIMAGE_LORA_VERSION_ID },
+      { modelId: LORA_MODEL_ID, modelVersionId: QWEN_LORA_VERSION_ID },
+      { modelId: LORA_MODEL_ID, modelVersionId: FLUX2_LORA_VERSION_ID },
+    ],
+    // The diffusion/clip/vae AIRs are huggingface AIRs (not gated civitai
+    // versions) — recipe constants, exempt-by-construction (code-reviewed).
+    staticAirs: [
+      ZIMAGE_DIFFUSION_AIR,
+      ZIMAGE_CLIP_AIR,
+      ZIMAGE_VAE_AIR,
+      QWEN_DIFFUSION_AIR,
+      QWEN_CLIP_AIR,
+      QWEN_VAE_AIR,
+      FLUX2_DIFFUSION_AIR,
+      FLUX2_CLIP_AIR,
+      FLUX2_VAE_AIR,
+    ],
+  },
+  checkpointPolicy: 'pinned',
+  // THE post-paid budget contract (plan §5): `maxBuzz` MUST equal
+  // ceil(stepTimeoutSeconds × 1). A DiT panorama renders in well under a minute;
+  // 180s is a deliberately tight blast-radius ceiling (vs the reference's loose
+  // 3600s). The step `timeout` physically caps the job at `maxBuzz` Buzz.
+  stepTimeoutSeconds: 180,
+  maxBuzz: 180,
+  estimateBuzz: (params) => ESTIMATE_BUZZ_BY_ENGINE[params.engine ?? DEFAULT_ENGINE],
+  negativePrompt: NEGATIVE_PROMPT,
+};

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server';
-import type { Workflow, WorkflowStatus } from '@civitai/client';
+import type { CustomComfyStepTemplate, Workflow, WorkflowStatus } from '@civitai/client';
+import type { AnyBlockRecipe, CustomComfyStepInput, ResolvedRecipeResources } from './recipes';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { dbRead } from '~/server/db/client';
 import { nsfwLevelFromContentRating } from '~/shared/constants/browsingLevel.constants';
@@ -36,6 +37,20 @@ export function snapshotFromWorkflow(workflow: Workflow): BlockWorkflowSnapshot 
   const status = ORCH_STATUS_MAP[workflow.status] ?? 'pending';
   const imageUrls: string[] = [];
   for (const step of workflow.steps ?? []) {
+    // A `customComfy` step (App Blocks customComfy bridge) surfaces its outputs
+    // as `output.blobs` (CustomComfyOutput), NOT `output.images` — so it needs
+    // its own extraction, otherwise its rendered panorama is silently dropped.
+    if (step.$type === 'customComfy') {
+      const blobs = (
+        step as unknown as { output?: { blobs?: Array<{ url?: string | null; available?: boolean }> } }
+      ).output?.blobs;
+      for (const blob of blobs ?? []) {
+        if (blob.available && typeof blob.url === 'string' && blob.url.length > 0) {
+          imageUrls.push(blob.url);
+        }
+      }
+      continue;
+    }
     if (step.$type !== 'textToImage' && step.$type !== 'imageGen' && step.$type !== 'comfy') {
       continue;
     }
@@ -128,6 +143,32 @@ export function projectAppWorkflow(workflow: Workflow): AppWorkflow {
   const status = ORCH_STATUS_MAP[workflow.status] ?? 'pending';
   const images: AppWorkflowImage[] = [];
   for (const step of workflow.steps ?? []) {
+    // A `customComfy` step surfaces its outputs as `output.blobs`
+    // (CustomComfyOutput) — no width/height, `nsfwLevel` is the same string
+    // rating the image steps carry. Extract it here so the app subqueue read
+    // picks up recipe-generated images (mirrors the snapshotFromWorkflow branch).
+    if (step.$type === 'customComfy') {
+      const blobs = (
+        step as unknown as {
+          output?: {
+            blobs?: Array<{ url?: string | null; available?: boolean; nsfwLevel?: string | null }>;
+          };
+        }
+      ).output?.blobs;
+      for (const blob of blobs ?? []) {
+        if (!blob.available || typeof blob.url !== 'string' || blob.url.length === 0) continue;
+        images.push({
+          url: blob.url,
+          width: null,
+          height: null,
+          nsfwLevel:
+            blob.nsfwLevel && blob.nsfwLevel !== 'na'
+              ? nsfwLevelFromContentRating(blob.nsfwLevel)
+              : null,
+        });
+      }
+      continue;
+    }
     if (step.$type !== 'textToImage' && step.$type !== 'imageGen' && step.$type !== 'comfy') {
       continue;
     }
@@ -587,3 +628,70 @@ export function buildImageWorkflowInput(
 // `buildTextToImageInput`; it is now the IMAGE-class builder (txt2img when the
 // body has no source image — byte-identical to before — img2img when it does).
 export const buildTextToImageInput = buildImageWorkflowInput;
+
+// ── customComfy translator + step builder (App Blocks customComfy bridge, v1) ─
+// INERT/DARK: neither function is called by the live blocks.router yet. The
+// router still handles ONLY `textToImage`; PR6 branches submit/estimate on
+// `kind==='customComfy'` and calls these two, wrapped in the post-paid budget
+// belt. Added here now so PR6 is a thin wiring change over reviewed building
+// blocks.
+
+/**
+ * Translate a validated `customComfy` body into the reusable customComfy step
+ * INPUT (`{ resources, trace, workflow }`). The wire schema only did the coarse
+ * gate (`recipe` ∈ registry, `params` an opaque record); this applies the
+ * recipe's OWN `.strict()` param schema (the real prompt/seed/engine/accountType
+ * bounds) and then runs the recipe's PURE graph builder.
+ *
+ * The returned input is intentionally reusable for a future prepaid
+ * `$type:'comfy'` registered-definition path — only the step WRAPPER
+ * (`createBlockCustomComfyStep`) is customComfy-specific, so the graph
+ * construction never has to change if the step type later does.
+ */
+export function buildCustomComfyWorkflowInput(
+  recipe: AnyBlockRecipe,
+  rawParams: unknown,
+  resolved: ResolvedRecipeResources = {}
+): CustomComfyStepInput {
+  // `.parse` throws a ZodError on an out-of-bounds param (e.g. prompt > 1500,
+  // unknown engine, extra field) — the router (PR6) maps it to a BAD_REQUEST /
+  // failed-snapshot, fail-closed. The coarse wire gate never validated these.
+  const params = recipe.paramSchema.parse(rawParams);
+  return recipe.buildStep(params, resolved);
+}
+
+/** The step name every block customComfy step carries (queue provenance). */
+export const BLOCK_CUSTOM_COMFY_STEP_NAME = 'block-custom-comfy';
+
+// Format a whole-second timeout as the orchestrator's `HH:MM:SS` step-timeout
+// string (WorkflowStep.timeout). 180 → '00:03:00'.
+function formatStepTimeout(totalSeconds: number): string {
+  const s = Math.max(0, Math.ceil(totalSeconds));
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${pad(Math.floor(s / 3600))}:${pad(Math.floor((s % 3600) / 60))}:${pad(s % 60)}`;
+}
+
+/**
+ * Wrap a recipe's customComfy step input into the `$type:'customComfy'` step,
+ * STAMPING the recipe's aggressive `stepTimeoutSeconds` as the step `timeout`
+ * (formatted `HH:MM:SS`). That timeout is the ONLY deterministic per-job Buzz
+ * bound the orchestrator offers: at `job.ExpireAt` the job is canceled and
+ * billed for measured runtime, so worst-case Buzz = `ceil(timeout_s × 1)` =
+ * `recipe.maxBuzz` (plan §5). This is what makes the post-paid path bounded.
+ *
+ * Sibling of `createBlockTextToImageStep` (blocks.router.ts) — but a customComfy
+ * step is built by DIRECT object construction (the recipe's graph), NOT through
+ * the generation-graph pipeline, so it needs none of that helper's
+ * `createWorkflowStepsFromGraphInput` machinery.
+ */
+export function createBlockCustomComfyStep(
+  recipe: AnyBlockRecipe,
+  input: CustomComfyStepInput
+): CustomComfyStepTemplate {
+  return {
+    $type: 'customComfy',
+    name: BLOCK_CUSTOM_COMFY_STEP_NAME,
+    timeout: formatStepTimeout(recipe.stepTimeoutSeconds),
+    input,
+  };
+}


### PR DESCRIPTION
## What

The **complete App Blocks `customComfy` bridge v1 server feature** — a bounded, server-authored ComfyUI recipe run end-to-end through the four existing block-bridge procedures, reusing the post-paid `$type:'customComfy'` orchestrator submit. The iframe sends only `{ kind:'customComfy', recipe, params }`; the civitai server owns the graph in full.

This PR now spans plan **PR2+PR3** (schema + recipe registry + graph translator + snapshot support — the inert building blocks) **and PR5+PR6** (router wiring + the **timeout-cap post-paid budget belt** — the security-critical crux), landed onto the one branch so the v1 server spine is reviewable as a whole.

**Stays DARK.** The four block-token procs are already `assertViewerIsAppDeveloper` / `assertAppBlocksEnabledForTokenUser`-gated, so recipe submissions are developer/mod-gated until GA — the empty-but-panorama recipe registry is itself the gate. No worker-image baking, no `$type:'comfy'` registration, no per-invocation orchestrator token — v1 stays **post-paid**.

## Building blocks (PR2+PR3)

- **Schema** (`workflow.schema.ts`): `blockCustomComfyBodySchema = { kind:'customComfy', recipe ∈ REGISTERED_RECIPE_IDS, params: z.record(...) }.strict()`; `blockWorkflowBodySchema` widened to a `discriminatedUnion('kind', [...])`. `recipe` is a coarse fail-closed gate; the per-recipe `.strict()` param schema is applied in the translator.
- **Recipe registry** (`src/server/services/blocks/recipes/`): the `BlockRecipe` interface + registry, `REGISTERED_RECIPE_IDS` derived from registry keys, and a fail-fast `maxBuzz == ceil(stepTimeoutSeconds)` invariant checked at module load. `seamless-pano-360` is recipe #1 (DiT engines `zimage-turbo` / `flux2-klein` / `qwen-image`), ported verbatim from `panorama.ts` as pure object-construction builders. Pinned checkpoint policy, `stepTimeoutSeconds = 180` → `maxBuzz = 180` (a deliberately tight blast-radius ceiling — the step `timeout` is the only deterministic per-job Buzz bound).
- **Translator + step builder** (`workflow.service.ts`): `buildCustomComfyWorkflowInput` + `createBlockCustomComfyStep` (stamps the recipe timeout as `HH:MM:SS`), kept cleanly separable from the step wrapper so a future prepaid `$type:'comfy'` path changes only the wrapper.
- **Snapshot support**: `snapshotFromWorkflow` + `projectAppWorkflow` read `output.blobs` for a `customComfy` step.

## Router wiring + budget belt (PR5+PR6 — this update)

- **`estimateWorkflow`** branches on `kind==='customComfy'`: returns the recipe's per-engine **DISPLAY estimate** (no real whatIf — a post-paid customComfy whatIfs to 0), behind the same page-only + developer gates as submit.
- **`submitWorkflow`** branches to a dedicated handler, in order:
  1. **Page-only guard** — a MODEL-bound token is rejected fail-closed (a fixed recipe is page-path only).
  2. **Entitlement gate** — `resolveCanGenerateForVersions` / `assertViewerCanGeneratePageResources` over **every** civitai version the recipe pins (v1 = fixed public LoRAs), before the step is emitted, so the code-reviewed registry can't be quietly edited to point at a gated / early-access / Private / unpublished version without the belt catching it.
  3. **Prompt audit** — `auditPromptServer` over the **raw** prompt + the recipe negative, with the domain `isGreen` strictness, before any orchestrator call. A server-owned graph earns **no** moderation bypass; the trigger-word prefix/suffix are appended only inside the builder, after the audit reads the raw prompt.
  4. **Timeout-cap budget belt** — the crux (plan §5.3): a **static `recipe.maxBuzz > buzzBudget` gate** (deterministic, no orchestrator round-trip — the step `timeout` physically caps the job at `maxBuzz` Buzz, and `maxBuzz ≤ buzzBudget` ⇒ the per-call budget can't be exceeded); **reserve the CEILING** (`maxBuzz`, not the 0 estimate) against both the per-user 50k/day cap and the per-app G8 aggregate cap (over-cap → refund + failed-snapshot); **refund-on-throw** for the ceiling; build the step with the recipe `timeout` and submit.
- **Settle-to-actual** — a per-workflow Redis settle record (`{buzzCapKey, appSpendKey, ceiling}`, 25h TTL) is persisted at submit; the terminal-status hook in `pollWorkflow` / `cancelWorkflow` reads it once (GET+DEL idempotency) and refunds `ceiling − accrued` on **both** reservation keys. Cancel bills accrued + settles.
- **Tags** parameterized to emit the recipe id + `'customComfy'` (not hardcoded `'txt2img'`), preserving the `app-block:*` provenance tags the subqueue read depends on.

## `textToImage` unchanged

The `textToImage` request-handling behavior is byte-unchanged (branch, don't rewrite) — verified by all **185 existing txt2img workflow tests** still green. The only non-additive edits are behavior-preserving: the `buildWorkflowTags` `workflowType` param (defaults to `'txt2img'` ⇒ identical output for 2-arg calls) and a narrowing alias for the spend-attribution closure (same object; forced by the discriminated-union type).

## Safety / injection

The prompt is always a **leaf string value**; the graph is assembled by object construction (no string-templating of graph structure). Golden tests include an injection test — a prompt with `"` / `{{` / `</` yields a structurally-identical graph per engine.

## Tests

- Golden-graph oracle (byte-equivalent graphs per DiT engine), injection safety, param-schema bounds, registry + `maxBuzz` contract, schema union.
- **16 router seams**: page-only guard, entitlement, prompt audit, static gate, daily/app-cap breach + refund, refund-on-throw, tags, terminal poll/cancel settle, estimate.
- **11 settle-service unit tests**: GET+DEL idempotency + refund arithmetic on both keys.
- Locally (node-only vitest): all touched suites green; **full `tsc --noEmit` clean**. Per the repo gotcha, the **pr-preview typecheck/build is the authoritative gate** and must go green before merge. A comprehensive `/audit-pr` will run over the three seams (post-paid budget / AIR-entitlement / prompt-graph injection) before merge.

Plan: `claudedocs/app-blocks-customcomfy-bridge-v1-impl-plan-2026-07-17.md` (§4, §5, §6, §7, §8 PR5+PR6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
