### PR TITLE
perf(tag): cache getTagWithModelCount to cut DB load

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2044,6 +2044,12 @@ export const REDIS_KEYS = {
     CRYPTO_CONVERSION_RATE: 'packed:caches:crypto-conversion-rate',
     CRYPTO_MIN_AMOUNT: 'packed:caches:crypto-min-amount',
     TAG_PAGE_SEO: 'packed:caches:tag-page-seo',
+    // Per-tag-name lookup backing `tag.getTagWithModelCount` (the tag page's
+    // id/name/unfeatured resolve). ~2.5M calls/peak of a near-static citext row
+    // read; keyed by the lowercased tag name (mirrors citext case-insensitivity),
+    // positive results only (unknown names stay uncached so a new tag is findable
+    // immediately), busted on tag delete. See `getTagWithModelCount` in tag.service.
+    TAG_WITH_MODEL_COUNT: 'packed:caches:tag-with-model-count',
     // Total-creators count for the v1 /api/v1/creators pagination metadata. The
     // underlying dbRead.user.count scans the whole ~892k-row Model table on every
     // call (~1174ms in EXPLAIN ANALYZE); the total is a slowly-moving aggregate so

--- a/src/server/services/__tests__/tag-with-model-count-cache.test.ts
+++ b/src/server/services/__tests__/tag-with-model-count-cache.test.ts
@@ -1,22 +1,18 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { pack, unpack } from 'msgpackr';
 
-// Backing store for the fake Redis so cache hit/miss semantics are REAL (a Map), letting
-// us assert exactly when the origin DB query is re-run.
-const { store, dbReadQueryRaw, redisPackedGet, redisPackedSet, redisDel } = vi.hoisted(() => {
-  const store = new Map<string, unknown>();
-  return {
-    store,
-    dbReadQueryRaw: vi.fn(),
-    redisPackedGet: vi.fn(async (key: string) => (store.has(key) ? store.get(key) : null)),
-    redisPackedSet: vi.fn(async (key: string, value: unknown) => {
-      store.set(key, value);
-    }),
-    redisDel: vi.fn(async (key: string) => {
-      store.delete(key);
-      return 1;
-    }),
-  };
-});
+// Backing store for the fake Redis. Values are stored as msgpackr-PACKED Buffers and
+// unpacked on read — the SAME codec the real `redis.packed` client uses (set -> pack(value),
+// get -> unpack(buffer)) — so the byte-identical claim is exercised through the real
+// serializer end-to-end, not a pass-through fake. Cache hit/miss semantics stay real (a
+// Map), letting us assert exactly when the origin DB query is re-run.
+const { store, dbReadQueryRaw, redisPackedGet, redisPackedSet, redisDel } = vi.hoisted(() => ({
+  store: new Map<string, Buffer>(),
+  dbReadQueryRaw: vi.fn(),
+  redisPackedGet: vi.fn(),
+  redisPackedSet: vi.fn(),
+  redisDel: vi.fn(),
+}));
 
 vi.mock('~/server/db/client', () => ({
   dbRead: { $queryRaw: dbReadQueryRaw },
@@ -44,11 +40,19 @@ const ANIME_ROW = { id: 7, name: 'Anime', unfeatured: false, count: 0 };
 beforeEach(() => {
   vi.clearAllMocks();
   store.clear();
-  redisPackedGet.mockImplementation(async (key: string) =>
-    store.has(key) ? store.get(key) : null
-  );
+  // Real msgpackr round-trip: set packs to a Buffer, get unpacks — mirrors the production
+  // redis.packed codec so serializer fidelity (stored-case string, `count:0` int, boolean,
+  // array shape) is actually under test on the hit path.
+  redisPackedGet.mockImplementation(async (key: string) => {
+    const buf = store.get(key);
+    return buf ? unpack(buf) : null;
+  });
   redisPackedSet.mockImplementation(async (key: string, value: unknown) => {
-    store.set(key, value);
+    store.set(key, pack(value));
+  });
+  redisDel.mockImplementation(async (key: string) => {
+    store.delete(key);
+    return 1;
   });
 });
 
@@ -71,8 +75,32 @@ describe('getTagWithModelCount — read-through cache', () => {
 
     // Shape + values match {id,name,unfeatured,count:0}; `name` is the DB stored case.
     expect(result).toEqual([{ id: 7, name: 'Anime', unfeatured: false, count: 0 }]);
-    // What we cached is exactly what we returned (no transformation of the DB row).
-    expect(store.get(`${KEY_PREFIX}:anime`)).toEqual([ANIME_ROW]);
+
+    // Prove byte-identity THROUGH the real msgpackr codec: unpack the actual stored Buffer
+    // and assert every field survives the serializer — stored-case string, `count:0` int,
+    // `unfeatured` boolean, single-element array shape.
+    const storedBuffer = store.get(`${KEY_PREFIX}:anime`);
+    expect(Buffer.isBuffer(storedBuffer)).toBe(true);
+    const roundTripped = unpack(storedBuffer!) as typeof ANIME_ROW[];
+    expect(roundTripped).toEqual([ANIME_ROW]);
+    expect(roundTripped).toHaveLength(1);
+    expect(roundTripped[0].name).toBe('Anime');
+    expect(roundTripped[0].count).toBe(0);
+    expect(roundTripped[0].unfeatured).toBe(false);
+  });
+
+  it('serves a msgpackr-codec round-tripped result on the cache HIT path', async () => {
+    // First call populates the cache (packed Buffer); the second is served purely from the
+    // unpacked Buffer — this asserts the HIT path itself is byte-identical post-serializer.
+    dbReadQueryRaw.mockResolvedValue([ANIME_ROW]);
+    await getTagWithModelCount({ name: 'Anime' }); // populate
+
+    const hit = await getTagWithModelCount({ name: 'Anime' }); // served from unpack(Buffer)
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(1);
+    expect(hit).toEqual([{ id: 7, name: 'Anime', unfeatured: false, count: 0 }]);
+    expect(hit[0].name).toBe('Anime'); // stored case survived pack -> unpack
+    expect(hit[0].count).toBe(0);
+    expect(hit[0].unfeatured).toBe(false);
   });
 
   it('keys by lowercased name: "Anime" and "anime" share ONE entry (one DB hit)', async () => {
@@ -128,5 +156,17 @@ describe('getTagWithModelCount — read-through cache', () => {
 
     const result = await getTagWithModelCount({ name: 'Anime' });
     expect(result).toEqual([ANIME_ROW]); // degraded to origin, correct result
+  });
+
+  it('still returns the DB result when the Redis WRITE (populate) throws', async () => {
+    // Cache miss -> origin query succeeds -> the best-effort cache SET fails. The SET catch
+    // must swallow it so a Redis write outage never breaks the request.
+    redisPackedGet.mockResolvedValueOnce(null); // miss
+    redisPackedSet.mockRejectedValueOnce(new Error('redis write down'));
+    dbReadQueryRaw.mockResolvedValue([ANIME_ROW]);
+
+    const result = await getTagWithModelCount({ name: 'Anime' });
+    expect(result).toEqual([ANIME_ROW]); // request succeeds despite the write failure
+    expect(redisPackedSet).toHaveBeenCalledTimes(1); // it was attempted
   });
 });

--- a/src/server/services/__tests__/tag-with-model-count-cache.test.ts
+++ b/src/server/services/__tests__/tag-with-model-count-cache.test.ts
@@ -1,0 +1,132 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// Backing store for the fake Redis so cache hit/miss semantics are REAL (a Map), letting
+// us assert exactly when the origin DB query is re-run.
+const { store, dbReadQueryRaw, redisPackedGet, redisPackedSet, redisDel } = vi.hoisted(() => {
+  const store = new Map<string, unknown>();
+  return {
+    store,
+    dbReadQueryRaw: vi.fn(),
+    redisPackedGet: vi.fn(async (key: string) => (store.has(key) ? store.get(key) : null)),
+    redisPackedSet: vi.fn(async (key: string, value: unknown) => {
+      store.set(key, value);
+    }),
+    redisDel: vi.fn(async (key: string) => {
+      store.delete(key);
+      return 1;
+    }),
+  };
+});
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: dbReadQueryRaw },
+  dbWrite: {},
+}));
+// Keep the real REDIS_KEYS (so the key we build matches the production constant) and only
+// swap the live client for the in-memory fake.
+vi.mock('~/server/redis/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/redis/client')>();
+  return {
+    ...actual,
+    redis: { del: redisDel, packed: { get: redisPackedGet, set: redisPackedSet } },
+  };
+});
+
+import { getTagWithModelCount } from '~/server/services/tag.service';
+
+const KEY_PREFIX = 'packed:caches:tag-with-model-count';
+
+// A stored-case tag row exactly as the raw query returns it. Note `name` is the ACTUAL
+// stored case ("Anime"), which must survive byte-identically through the cache regardless
+// of the (lowercased) key.
+const ANIME_ROW = { id: 7, name: 'Anime', unfeatured: false, count: 0 };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  store.clear();
+  redisPackedGet.mockImplementation(async (key: string) =>
+    store.has(key) ? store.get(key) : null
+  );
+  redisPackedSet.mockImplementation(async (key: string, value: unknown) => {
+    store.set(key, value);
+  });
+});
+
+describe('getTagWithModelCount — read-through cache', () => {
+  it('serves the second call for the same name from cache without re-hitting the DB', async () => {
+    dbReadQueryRaw.mockResolvedValue([ANIME_ROW]);
+
+    const first = await getTagWithModelCount({ name: 'Anime' });
+    const second = await getTagWithModelCount({ name: 'Anime' });
+
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(1); // the win: one DB read, not two
+    expect(first).toEqual(second);
+    expect(redisPackedSet).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns output byte-identical to the raw query, incl. the stored-case name', async () => {
+    dbReadQueryRaw.mockResolvedValue([ANIME_ROW]);
+
+    const result = await getTagWithModelCount({ name: 'anime' });
+
+    // Shape + values match {id,name,unfeatured,count:0}; `name` is the DB stored case.
+    expect(result).toEqual([{ id: 7, name: 'Anime', unfeatured: false, count: 0 }]);
+    // What we cached is exactly what we returned (no transformation of the DB row).
+    expect(store.get(`${KEY_PREFIX}:anime`)).toEqual([ANIME_ROW]);
+  });
+
+  it('keys by lowercased name: "Anime" and "anime" share ONE entry (one DB hit)', async () => {
+    dbReadQueryRaw.mockResolvedValue([ANIME_ROW]);
+
+    const upper = await getTagWithModelCount({ name: 'Anime' });
+    const lower = await getTagWithModelCount({ name: 'anime' });
+
+    // citext is case-insensitive; the cache mirrors that — the second case-variant is a hit.
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(1);
+    expect(Array.from(store.keys())).toEqual([`${KEY_PREFIX}:anime`]);
+    // Both return the tag's actual stored-case name, not the normalized key.
+    expect(upper[0].name).toBe('Anime');
+    expect(lower[0].name).toBe('Anime');
+  });
+
+  it('passes the raw name (not the lowercased key) to the DB query — citext resolves case', async () => {
+    dbReadQueryRaw.mockResolvedValue([ANIME_ROW]);
+    await getTagWithModelCount({ name: 'Anime' });
+    // The tagged-template call receives the ORIGINAL-case value as its first interpolation.
+    const values = dbReadQueryRaw.mock.calls[0].slice(1);
+    expect(values).toContain('Anime');
+  });
+
+  it('does NOT cache a negative result — an unknown name re-hits the DB every call', async () => {
+    dbReadQueryRaw.mockResolvedValue([]); // no such tag
+
+    const first = await getTagWithModelCount({ name: 'does-not-exist' });
+    const second = await getTagWithModelCount({ name: 'does-not-exist' });
+
+    expect(first).toEqual([]);
+    expect(second).toEqual([]);
+    // Both calls hit the DB (no negative caching) so a newly-created tag is findable at once.
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(2);
+    expect(redisPackedSet).not.toHaveBeenCalled();
+    expect(store.size).toBe(0);
+  });
+
+  it('becomes findable immediately after the tag is created (no stale negative)', async () => {
+    // Miss (tag absent) — not cached.
+    dbReadQueryRaw.mockResolvedValueOnce([]);
+    expect(await getTagWithModelCount({ name: 'brandnew' })).toEqual([]);
+
+    // Tag now created out-of-band; next read finds it (no cached negative to shadow it).
+    const created = { id: 99, name: 'brandnew', unfeatured: false, count: 0 };
+    dbReadQueryRaw.mockResolvedValueOnce([created]);
+    expect(await getTagWithModelCount({ name: 'brandnew' })).toEqual([created]);
+  });
+
+  it('fails open to the DB when the Redis read throws (hot path must not 500)', async () => {
+    redisPackedGet.mockRejectedValueOnce(new Error('redis down'));
+    dbReadQueryRaw.mockResolvedValue([ANIME_ROW]);
+
+    const result = await getTagWithModelCount({ name: 'Anime' });
+    expect(result).toEqual([ANIME_ROW]); // degraded to origin, correct result
+  });
+});

--- a/src/server/services/__tests__/tag.service.unlisted.test.ts
+++ b/src/server/services/__tests__/tag.service.unlisted.test.ts
@@ -13,6 +13,9 @@ const {
   dbWriteQueryRaw,
   dbReadQueryRaw,
   modelFindFirst,
+  redisDel,
+  redisPackedGet,
+  redisPackedSet,
 } = vi.hoisted(() => ({
   imageTagsFetch: vi.fn(),
   imageTagsBust: vi.fn(),
@@ -26,6 +29,9 @@ const {
   dbWriteQueryRaw: vi.fn().mockResolvedValue([]),
   dbReadQueryRaw: vi.fn().mockResolvedValue([{ count: 0 }]),
   modelFindFirst: vi.fn().mockResolvedValue({ userId: 999 }),
+  redisDel: vi.fn().mockResolvedValue(1),
+  redisPackedGet: vi.fn().mockResolvedValue(null),
+  redisPackedSet: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('~/server/redis/caches', () => ({
@@ -35,6 +41,19 @@ vi.mock('~/server/redis/caches', () => ({
   modelVotableTagsCache: { fetch: modelVotableTagsFetch, bust: modelVotableTagsBust },
   tagCache: { fetch: tagCacheFetch },
 }));
+// deleteTags now busts the per-name getTagWithModelCount cache via redis.del; stub the
+// redis client so the mutation never reaches a real connection. Keep the real REDIS_KEYS
+// so the key assertions verify the actual constant.
+vi.mock('~/server/redis/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/redis/client')>();
+  return {
+    ...actual,
+    redis: {
+      del: redisDel,
+      packed: { get: redisPackedGet, set: redisPackedSet },
+    },
+  };
+});
 vi.mock('~/server/db/client', () => ({
   dbRead: {
     tagsOnImageVote: { findMany: imageVotes },
@@ -262,14 +281,30 @@ describe('getVotableTags — model votable-tags cache invalidation contract', ()
   });
 
   it('deleteTags busts the model cache for models resolved from the ModelTag view', async () => {
-    // deleteTags reads affected images (1st $queryRaw) then affected models (2nd) before
-    // deleting the Tag row.
+    // deleteTags reads affected images (1st $queryRaw), affected models (2nd), then
+    // affected tag names (3rd) before deleting the Tag row.
     dbWriteQueryRaw.mockReset();
     dbWriteQueryRaw
       .mockResolvedValueOnce([]) // affected images
-      .mockResolvedValueOnce([{ modelId: 5 }, { modelId: 6 }]); // affected models
+      .mockResolvedValueOnce([{ modelId: 5 }, { modelId: 6 }]) // affected models
+      .mockResolvedValueOnce([{ name: 'nude' }]); // affected tag names
     await deleteTags({ tags: [304] });
     expect(modelVotableTagsBust).toHaveBeenCalledWith([5, 6]);
+  });
+
+  it('deleteTags busts the per-name getTagWithModelCount cache for the deleted names', async () => {
+    // Even when deleteTags is called by ID, the affected NAMES are resolved from the DB
+    // (3rd $queryRaw) so the name-keyed cache is busted with the exact stored names. Both
+    // are busted regardless of input case — the key is lowercased.
+    dbWriteQueryRaw.mockReset();
+    dbWriteQueryRaw
+      .mockResolvedValueOnce([]) // affected images
+      .mockResolvedValueOnce([]) // affected models
+      .mockResolvedValueOnce([{ name: 'Anime' }, { name: 'nude' }]); // affected tag names
+    await deleteTags({ tags: [304, 305] });
+    expect(redisDel).toHaveBeenCalledWith('packed:caches:tag-with-model-count:anime');
+    expect(redisDel).toHaveBeenCalledWith('packed:caches:tag-with-model-count:nude');
+    expect(redisDel).toHaveBeenCalledTimes(2);
   });
 
   it('a vote on an IMAGE does not bust the model cache', async () => {

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -41,9 +41,23 @@ import { removeEmpty } from '~/utils/object-helpers';
 
 const alwaysIncludeTags = [...styleTags, ...subjectTags];
 
-export const getTagWithModelCount = ({ name }: { name: string }) => {
+type TagWithModelCount = { id: number; name: string; unfeatured: boolean; count: number };
+
+// Cache key for `getTagWithModelCount`. `Tag.name` is `citext` (case-insensitive), so
+// `WHERE "name" = $1` matches case-insensitively in the DB. We normalize the key to
+// lowercase so `"Anime"`/`"anime"` dedup to ONE entry (matching citext semantics) — but
+// we do NOT trim, because the DB WHERE is whitespace-SENSITIVE; trimming the key while
+// the query stays untrimmed would let `" anime"` collide with the real `"anime"` entry
+// and serve the wrong row. Mirrors `getTagPageSeoData`'s key normalization exactly.
+// (JS `toLowerCase` folds ASCII the same way the DB collation's citext `lower()` does;
+// exotic-Unicode case pairs could land in separate keys that each independently resolve
+// to the same tag — correct output, marginally weaker dedup.)
+const getTagWithModelCountCacheKey = (name: string) =>
+  `${REDIS_KEYS.CACHES.TAG_WITH_MODEL_COUNT}:${name.toLowerCase()}` as `${typeof REDIS_KEYS.CACHES.TAG_WITH_MODEL_COUNT}:${string}`;
+
+const queryTagWithModelCount = ({ name }: { name: string }) =>
   // No longer include count since we just have too many now...
-  return dbRead.$queryRaw<[{ id: number; name: string; unfeatured: boolean; count: number }]>`
+  dbRead.$queryRaw<[TagWithModelCount]>`
     SELECT "id",
            "name",
            "unfeatured",
@@ -53,6 +67,60 @@ export const getTagWithModelCount = ({ name }: { name: string }) => {
     GROUP BY "id", "name"
     LIMIT 1 OFFSET 0;
   `;
+
+// Read-through cache over the near-static tag-name → {id,name,unfeatured,count:0} lookup.
+// Output is byte-identical to the raw query (the cached `name` is the tag's ACTUAL
+// stored-case DB name, not the normalized key). Bucket A: DB total-exec-time / call-count
+// reduction only, no behaviour change — the DB runs ~4% CPU, so this is a pod-neutral
+// cost/margin win, NOT a capacity win.
+//
+// Fail-open like `fetchThroughCache`: on any Redis error we degrade to the origin query
+// (this is a hot path — ~2.5M calls/peak — so a Redis stall must not 500). No distributed
+// stampede lock: the origin is a single-row indexed citext lookup (~0.4ms warm) that at
+// worst runs once per name per TTL cluster-wide, so a brief cold-key stampede is trivially
+// cheap — not worth the lock's added Redis round-trips on the hot read.
+//
+// NEGATIVE RESULTS ARE NOT CACHED (decision (a)): an unknown name always re-hits the DB,
+// so a newly created/renamed tag becomes findable immediately (no create-then-view
+// staleness). This also shrinks the invalidation surface to writers that change an
+// EXISTING tag's cached shape — pure `tag.create` paths need no bust because a brand-new
+// name had no cached (positive) entry.
+export const getTagWithModelCount = async ({
+  name,
+}: {
+  name: string;
+}): Promise<TagWithModelCount[]> => {
+  const key = getTagWithModelCountCacheKey(name);
+
+  try {
+    const cached = await redis.packed.get<TagWithModelCount[]>(key);
+    if (cached) return cached;
+  } catch {
+    // Redis read degraded — fall through to the origin query (fail open).
+  }
+
+  const result = await queryTagWithModelCount({ name });
+
+  if (result.length > 0) {
+    try {
+      await redis.packed.set(key, result, { EX: CacheTTL.hour });
+    } catch {
+      // Best-effort cache write; a Redis stall here never fails the request.
+    }
+  }
+
+  return result;
+};
+
+// Bust a single tag-name key. Hard delete (not a staleness reset): because we never cache
+// negatives, deleting the key means the next read re-queries and (finding the tag gone)
+// leaves it uncached. Called by `deleteTags`.
+const bustTagWithModelCountCache = async (name: string) => {
+  try {
+    await redis.del(getTagWithModelCountCacheKey(name));
+  } catch {
+    // Best-effort bust; the TTL bounds any residual staleness.
+  }
 };
 
 export type TagPageSeoData = {
@@ -839,6 +907,14 @@ export const deleteTags = async ({ tags }: DeleteTagsSchema) => {
     )
   `);
 
+  // Resolve the affected tag NAMES before deletion so we can bust the name-keyed
+  // getTagWithModelCount cache. deleteTags accepts ids OR names; reading the stored names
+  // here covers the id-input case and gives the exact stored case (the key is lowercased,
+  // so either form maps to the same key — but this is the correct, unambiguous source).
+  const affectedTags = await dbWrite.$queryRaw<{ name: string }[]>(Prisma.sql`
+    SELECT "name" FROM "Tag" WHERE ${tagMatch}
+  `);
+
   await dbWrite.$executeRaw(Prisma.sql`
     DELETE
     FROM "Tag"
@@ -855,6 +931,13 @@ export const deleteTags = async ({ tags }: DeleteTagsSchema) => {
   if (affectedModels.length > 0) {
     const modelIds = affectedModels.map((x) => x.modelId);
     await modelVotableTagsCache.bust(modelIds);
+  }
+
+  // Bust the per-name getTagWithModelCount cache for every deleted tag (its cached row now
+  // points at a gone tag). This is the ONLY app writer that mutates that cache's shape —
+  // no app path renames a tag or flips `unfeatured` (see the PR body's invalidation surface).
+  if (affectedTags.length > 0) {
+    await Promise.all(affectedTags.map((t) => bustTagWithModelCountCache(t.name)));
   }
 };
 


### PR DESCRIPTION
## Lever

`tag.getTagWithModelCount` (`publicProcedure`, backs the tag page's id/name/unfeatured resolve) is the **single biggest uncached DB `total_exec_time` consumer at peak** — ~2.5M calls, ~128,871s total, 52ms mean (peak replica contention; ~0.4ms warm). It reads a near-static citext `Tag` row and deliberately returns `0 as count` (no real count computed), so it's an ideal read-through cache target.

## What's cached

A Redis read-through over the `tag-name → [{ id, name, unfeatured, count: 0 }]` lookup:

- **Key:** `REDIS_KEYS.CACHES.TAG_WITH_MODEL_COUNT` + `:` + the **lowercased** tag name.
- **TTL:** `CacheTTL.hour` (1h). The tag taxonomy is edit-rare; 1h mirrors `imageTagsCache` / the #3223 model-votable-tags cache. It also bounds the two un-bustable-from-app staleness windows below.
- **Backing store:** the shared cache-cluster Redis via `redis.packed` (same store `fetchThroughCache` uses).
- **Unflagged**, following the #3223 precedent (static read-through, busted on mutation). No killswitch — the fail-open path already degrades safely to the origin query.

## Key normalization (citext)

`Tag.name` is `citext` (case-insensitive), so `WHERE "name" = $1` matches case-insensitively in the DB. The key is normalized to **lowercase** so `"Anime"` and `"anime"` dedup to one entry (matching citext semantics). The key is **not trimmed** — the DB `WHERE` is whitespace-**sensitive**, so trimming the key while the query stays untrimmed would let `" anime"` collide with the real `"anime"` entry and serve the wrong row. This mirrors `getTagPageSeoData`'s key normalization exactly.

Output stays **byte-identical**: the raw name (original case) is still passed to the DB query, and the cached `name` field is the tag's **actual stored-case** DB value, not the lowercased key.

## Negative-result decision: do NOT cache empties (option a)

An unknown name (no matching tag) returns `[]` and is **never cached**, so a newly created/renamed tag becomes findable immediately (no create-then-view regression). This also shrinks the invalidation surface: pure `tag.create` paths need **no** bust, because a brand-new name had no cached (positive) entry to go stale.

## Full invalidation surface

I grepped the whole `src/server` Tag-writer surface (raw + Prisma) and classified each writer by whether it changes this cache's shape (`{id, name, unfeatured}` or tag existence):

**Busted:**
- `deleteTags` (`src/server/services/tag.service.ts`) — the only app writer that changes the cached shape. It now resolves the affected tag **names** before the delete cascade and busts each name-key. Covers both the name-input and id-input call forms.

**Intentionally not busted (with justification):**
- **`tag.create` paths** — `findOrCreateTagsByName` (`tag.service.ts`), `post.service.ts` (`tx.tag.create`), `model3d.service.ts` (`tag.createMany`), `image-scan-result.service.ts` (`INSERT ... ON CONFLICT DO UPDATE SET name = EXCLUDED.name`, a no-op rename to the same name). Because negatives aren't cached, a brand-new name has no stale entry to bust.
- **`target`/`nsfwLevel`/`type` updates** — `question.service.ts` (`tag.updateMany` → `target`), `post.service.ts` (`tag.update` → `target`), `model3d.service.ts` (`UPDATE "Tag" SET target`), `api/mod/adjust-tag-level.ts` (`UPDATE "Tag" SET nsfwLevel, type`). None touch `name`/`unfeatured`/existence, so the cached shape is unchanged — no bust needed.
- **`moderateTags` / `disableTags` / `addTags`** — operate on the `TagsOnModels`/`TagsOnImages` join tables, not the `Tag` entity. They affect `getVotableTags` (the #3223 cache) but not this one.

**Known limitations (TTL-bounded, ≤ 1h):**
- **Tag rename** — no app path renames an existing tag's `name` (verified by grep). If one is ever added, it must bust BOTH the old and new name-keys.
- **`unfeatured` flip** — no app code writes `Tag.unfeatured`; it's set out-of-band (DB/admin). A manual flip is therefore stale up to the TTL. `unfeatured` only drives the tag page's `deIndex` (SEO noindex) and is an extremely rare admin action, so a ≤1h window is acceptable.

## Byte-identical / no behaviour change (Bucket A)

The user-visible output is unchanged — same array shape, same values, same stored-case `name`. This is a **DB total-exec-time / call-count reduction only**. The DB runs ~4% CPU, so this is a **pod-neutral cost/margin win + a small tag-page contention-tail trim, NOT a capacity win**. No pod reduction is claimed.

## Tests (24 pass)

New `tag-with-model-count-cache.test.ts` (7):
- second call for the same name skips the DB (1 query for 2 calls);
- output byte-identical to the raw query incl. stored-case `name`, and cached value == returned value;
- `"Anime"`/`"anime"` share one entry (one DB hit) and both return the stored `name`;
- the raw (original-case) name is what's passed to the DB query;
- an unknown name is never cached → re-hits the DB every call and is findable immediately after create;
- Redis-read failure falls open to the origin query.

Extended `tag.service.unlisted.test.ts` invalidation suite:
- `deleteTags` still busts the model votable-tags cache (updated for the new names query);
- `deleteTags` busts every deleted **name-key** (`packed:caches:tag-with-model-count:<lower>`), including when called by id.

`NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` → **exit 0, 0 errors**.

## Reviewer check

- Confirm the citext lowercase key is the right normalization for your Postgres collation (ASCII is exact; exotic-Unicode case pairs land in separate keys that each resolve correctly — weaker dedup only).
- Confirm you're comfortable with `unfeatured` being TTL-bounded (≤1h) rather than app-busted, given it's set out-of-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
