### PR TITLE
feat(creator-shop): allow animated WebP cosmetics with auto-detection

### DIFF
--- a/src/components/CreatorShop/CreatorShopSubmitModal.tsx
+++ b/src/components/CreatorShop/CreatorShopSubmitModal.tsx
@@ -120,7 +120,7 @@ export function CreatorShopSubmitModal({ item }: { item?: CreatorShopManageItem 
             <Alert color="yellow" icon={<IconAlertTriangle size={18} />}>
               <Text size="xs">
                 All cosmetics must be <b>safe-for-work</b> and must not use{' '}
-                <b>copyrighted or trademarked material</b>{' '}you don&apos;t own. Submissions that
+                <b>copyrighted or trademarked material</b> you don&apos;t own. Submissions that
                 violate this will be rejected.
               </Text>
             </Alert>
@@ -169,13 +169,12 @@ export function CreatorShopSubmitModal({ item }: { item?: CreatorShopManageItem 
               minRows={2}
             />
 
-            {supportsAnimated && !artLocked && (
-              <Switch
-                checked={animated}
-                onChange={(e) => form.setAnimated(e.currentTarget.checked)}
-                label="Animated cosmetic"
-                description="Enable if your artwork is an animated PNG or WebP."
-              />
+            {supportsAnimated && !artLocked && animated && (
+              <Alert color="blue" icon={<IconInfoCircle size={18} />}>
+                <Text size="xs">
+                  Animated artwork detected — this cosmetic will play its animation.
+                </Text>
+              </Alert>
             )}
           </>
         )}

--- a/src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts
+++ b/src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts
@@ -18,6 +18,7 @@ import {
   CREATOR_SHOP_SUBMISSION_FEE,
 } from '~/server/schema/creator-shop.schema';
 import { CosmeticShopItemStatus, CosmeticSource, CosmeticType } from '~/shared/utils/prisma/enums';
+import { isAnimatedImage } from '~/utils/media-preprocessors/image.preprocessor';
 import { showErrorNotification } from '~/utils/notifications';
 
 // Owns the submit/edit form: local field state, the derived readiness/affordability
@@ -97,7 +98,8 @@ export function useSubmitCreatorShopForm({
     const result = await validateCosmeticImage(file, type, maxSize);
     setChecks(result.checks);
     if (!result.allRequiredPassed) return;
-    const uploaded = await uploadToCF(file);
+    const uploaded = await uploadToCF(file, undefined, { allowAnimatedWebP: supportsAnimated });
+    setAnimated(supportsAnimated && (await isAnimatedImage(file)));
     setImageId(uploaded.id);
   };
 

--- a/src/hooks/useCFImageUpload.tsx
+++ b/src/hooks/useCFImageUpload.tsx
@@ -28,7 +28,11 @@ type UploadResult = {
   type: MediaType;
 };
 
-type UploadToCF = (file: File, metadata?: Record<string, string>) => Promise<UploadResult>;
+type UploadToCF = (
+  file: File,
+  metadata?: Record<string, string>,
+  options?: { allowAnimatedWebP?: boolean }
+) => Promise<UploadResult>;
 
 type UseS3UploadTools = {
   uploadToCF: UploadToCF;
@@ -58,8 +62,10 @@ export const useCFImageUpload: UseCFImageUpload = () => {
   };
 
   // eslint-disable-next-line @typescript-eslint/no-shadow
-  const uploadToCF: UploadToCF = async (file, metadata = {}) => {
-    const imageData = await getDataFromFile(file, { allowAnimatedWebP: currentUser?.isModerator });
+  const uploadToCF: UploadToCF = async (file, metadata = {}, options) => {
+    const imageData = await getDataFromFile(file, {
+      allowAnimatedWebP: options?.allowAnimatedWebP ?? currentUser?.isModerator,
+    });
     if (!imageData) throw new Error('Failed to process file before upload');
 
     const filename = encodeURIComponent(file.name);

--- a/src/utils/media-preprocessors/image.preprocessor.ts
+++ b/src/utils/media-preprocessors/image.preprocessor.ts
@@ -33,11 +33,24 @@ export const auditImageMeta = async (meta: ImageMetaProps | undefined, nsfw: boo
   return { blockedFor: !auditResult?.success ? auditResult?.blockedFor : undefined };
 };
 
-async function isAnimatedWebP(file: File) {
-  const buffer = await file.slice(0, 4096).arrayBuffer(); // Read first few KB
-  const bytes = new Uint8Array(buffer);
+// latin1 so binary bytes map 1:1 and the ASCII chunk fourcc survives intact.
+async function scanHeader(file: File, marker: string) {
+  const buffer = await file.slice(0, 4096).arrayBuffer();
+  const str = new TextDecoder('latin1').decode(new Uint8Array(buffer));
+  return str.includes(marker);
+}
 
-  // Look for 'ANIM' chunk in WebP file
-  const str = new TextDecoder().decode(bytes);
-  return str.includes('ANIM');
+async function isAnimatedWebP(file: File) {
+  return scanHeader(file, 'ANIM');
+}
+
+// APNG advertises itself with an 'acTL' chunk that precedes the first frame.
+async function isAnimatedPng(file: File) {
+  return scanHeader(file, 'acTL');
+}
+
+export async function isAnimatedImage(file: File) {
+  if (file.type === 'image/webp') return isAnimatedWebP(file);
+  if (file.type === 'image/png' || file.type === 'image/apng') return isAnimatedPng(file);
+  return false;
 }


### PR DESCRIPTION
@
## What

Enables **animated WebP uploads** for Creator Shop cosmetic submissions, scoped to the cosmetic types that actually render animation (Badge, ProfileDecoration, ProfileBackground), and **auto-detects** animation instead of asking the creator to toggle a flag.

## Why

Our upload preprocessor rejects animated WebP by default (`Animated WebP files are not supported...`). Cosmetics are allowed to be animated, so creators were blocked. The preprocessor already supported an `allowAnimatedWebP` opt, but `useCFImageUpload` hardcoded it to `isModerator`, so non-mod creators couldn`t submit animated art.

## Changes

- **`image.preprocessor.ts`** — export `isAnimatedImage(file)` covering WebP (`ANIM`) and APNG (`acTL`) via a shared `latin1` header scan.
- **`useCFImageUpload.tsx`** — `uploadToCF` takes an optional `{ allowAnimatedWebP }`; falls back to the existing `isModerator` default when not passed. **No other call site changes behavior.**
- **`useSubmitCreatorShopForm.ts`** — passes `allowAnimatedWebP: supportsAnimated`, then auto-sets `animated` from `isAnimatedImage(file)` on drop.
- **`CreatorShopSubmitModal.tsx`** — manual "Animated cosmetic" toggle replaced with a read-only "animated detected" indicator.

## Blast radius

Every other `uploadToCF` caller passes no options → unchanged mod-only default. Non-animatable cosmetic types still reject animated WebP. Enforcement remains client-side, consistent with all existing format gating in the app (server issues a presigned PUT with no format checks either way — pre-existing).

## Test notes

- Typecheck of the 4 files is clean (unrelated pre-existing Prisma/`@civitai/client` errors elsewhere).
- Drop an animated WebP on a Badge submission → uploads, "animated detected" shows, cosmetic plays animation.
- Drop a static PNG → no indicator, `animated` stays false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@