### PR TITLE
feat(jobs): BitDex publish re-emitter safety-net job (reemit-bitdex-ops)

### DIFF
--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -227,6 +227,31 @@ export const imagesFeedWithoutIndexCounter = registerCounter({
   help: 'Number of times getInfiniteImagesHandler is called with useIndex=false or undefined',
 });
 
+// BitDex publish re-emitter job (reemit-bitdex-ops). The job re-asserts the
+// per-image publish + sortAt ops for recently-published posts so a dropped/
+// missed BitDex write self-heals within one lookback window. `runs` is the
+// liveness signal; `images_emitted / runs` tracks emission volume against the
+// sizing estimate and alarms on a rate spike or stuck cursor; the duration
+// histogram guards against the single INSERT...SELECT becoming slow/lock-heavy.
+// See docs/design/publish-reemitter.md §6.3 (in the bitdex-v2 repo).
+export const reemitRunsCounter = registerCounter({
+  name: 'reemit_runs_total',
+  help: 'BitDex publish re-emitter runs that executed the emit (past the enabled gate)',
+});
+export const reemitPostsScannedCounter = registerCounter({
+  name: 'reemit_posts_scanned_total',
+  help: 'Distinct posts scanned by the BitDex publish re-emitter across all runs',
+});
+export const reemitImagesEmittedCounter = registerCounter({
+  name: 'reemit_images_emitted_total',
+  help: 'BitdexOps rows (per-image ops) written by the BitDex publish re-emitter across all runs',
+});
+export const reemitRunDurationHistogram = registerHistogram({
+  name: 'reemit_run_duration_seconds',
+  help: 'Wall-clock duration of the BitDex publish re-emitter INSERT...SELECT emit statement',
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+});
+
 // Creator compensation metrics
 export const creatorCompCreatorsPaidCounter = registerCounterWithLabels({
   name: 'creator_comp_creators_paid_total',

--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -234,9 +234,17 @@ export const imagesFeedWithoutIndexCounter = registerCounter({
 // sizing estimate and alarms on a rate spike or stuck cursor; the duration
 // histogram guards against the single INSERT...SELECT becoming slow/lock-heavy.
 // See docs/design/publish-reemitter.md §6.3 (in the bitdex-v2 repo).
+export const reemitAttemptsCounter = registerCounter({
+  name: 'reemit_attempts_total',
+  help: 'BitDex publish re-emitter runs that passed the enabled gate and attempted the emit (incremented before the emit — counts erroring runs too)',
+});
 export const reemitRunsCounter = registerCounter({
   name: 'reemit_runs_total',
-  help: 'BitDex publish re-emitter runs that executed the emit (past the enabled gate)',
+  help: 'BitDex publish re-emitter runs that emitted SUCCESSFULLY (success-only; compare to reemit_attempts_total for the error rate)',
+});
+export const reemitErrorsCounter = registerCounter({
+  name: 'reemit_errors_total',
+  help: 'BitDex publish re-emitter emits that threw (e.g. a missing shared PG function) before rethrowing',
 });
 export const reemitPostsScannedCounter = registerCounter({
   name: 'reemit_posts_scanned_total',

--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -227,13 +227,9 @@ export const imagesFeedWithoutIndexCounter = registerCounter({
   help: 'Number of times getInfiniteImagesHandler is called with useIndex=false or undefined',
 });
 
-// BitDex publish re-emitter job (reemit-bitdex-ops). The job re-asserts the
-// per-image publish + sortAt ops for recently-published posts so a dropped/
-// missed BitDex write self-heals within one lookback window. `runs` is the
-// liveness signal; `images_emitted / runs` tracks emission volume against the
-// sizing estimate and alarms on a rate spike or stuck cursor; the duration
-// histogram guards against the single INSERT...SELECT becoming slow/lock-heavy.
-// See docs/design/publish-reemitter.md §6.3 (in the bitdex-v2 repo).
+// Metrics for the BitDex publish re-emitter job (reemit-bitdex-ops): runs is the
+// liveness signal, images_emitted/runs tracks emission volume, and the duration
+// histogram guards the emit statement against getting slow.
 export const reemitAttemptsCounter = registerCounter({
   name: 'reemit_attempts_total',
   help: 'BitDex publish re-emitter runs that passed the enabled gate and attempted the emit (incremented before the emit — counts erroring runs too)',

--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -75,6 +75,7 @@ import { reconcileWildcardSetsJob } from '~/server/jobs/reconcile-wildcard-sets'
 import { pushDiscordMetadata } from '~/server/jobs/push-discord-metadata';
 import { refreshAuctionCache } from '~/server/jobs/refresh-auction-cache';
 import { refreshFeaturedCollectionsEligibility } from '~/server/jobs/refresh-featured-collections-eligibility';
+import { reemitBitdexOps } from '~/server/jobs/reemit-bitdex-ops';
 import { removeOldDrafts } from '~/server/jobs/remove-old-drafts';
 import { reindexRecentScheduledImages } from '~/server/jobs/reindex-recent-scheduled-images';
 import { resetToDraftWithoutRequirements } from '~/server/jobs/reset-to-draft-without-requirements';
@@ -115,6 +116,7 @@ export const jobs: Job[] = [
   deliverPurchasedCosmetics,
   deliverLeaderboardCosmetics,
   reindexRecentScheduledImages,
+  reemitBitdexOps,
   pushDiscordMetadata,
   applyVotedTags,
   removeOldDrafts,

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -43,10 +43,8 @@ export enum FLIPT_FEATURE_FLAGS {
   ENHANCED_COMPATIBILITY_SDCPP = 'enhanced-compatibility-sdcpp',
   IMAGE_INDEX_FEED = 'image-index-feed',
   BITDEX_IMAGE_SEARCH = 'bitdex-image-search',
-  // Gates the reemit-bitdex-ops job (the BitDex publish re-emitter safety net).
-  // DEFAULT-OFF: the job is registered/scheduled but no-ops every run until this
-  // flag is flipped ON for the W4 shadow window — flipping needs no redeploy.
-  // See docs/design/publish-reemitter.md (bitdex-v2 repo).
+  // Gates the reemit-bitdex-ops job (BitDex publish re-emitter). Default-off: the
+  // job is registered but no-ops until this flag is flipped on.
   BITDEX_PUBLISH_REEMITTER = 'bitdex-publish-reemitter',
   // Routes ImageResourceNew reads to the writer (primary) instead of the read
   // replica while the DataPacket replica is missing historical backfill rows

--- a/src/server/flipt/client.ts
+++ b/src/server/flipt/client.ts
@@ -43,6 +43,11 @@ export enum FLIPT_FEATURE_FLAGS {
   ENHANCED_COMPATIBILITY_SDCPP = 'enhanced-compatibility-sdcpp',
   IMAGE_INDEX_FEED = 'image-index-feed',
   BITDEX_IMAGE_SEARCH = 'bitdex-image-search',
+  // Gates the reemit-bitdex-ops job (the BitDex publish re-emitter safety net).
+  // DEFAULT-OFF: the job is registered/scheduled but no-ops every run until this
+  // flag is flipped ON for the W4 shadow window — flipping needs no redeploy.
+  // See docs/design/publish-reemitter.md (bitdex-v2 repo).
+  BITDEX_PUBLISH_REEMITTER = 'bitdex-publish-reemitter',
   // Routes ImageResourceNew reads to the writer (primary) instead of the read
   // replica while the DataPacket replica is missing historical backfill rows
   // for imageId < ~110M. Flip off once backfill is complete.

--- a/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
+++ b/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDbWrite, mockIsFlipt, mockCounters, mockHistogram } = vi.hoisted(() => ({
+  mockDbWrite: { $queryRaw: vi.fn() },
+  mockIsFlipt: vi.fn(),
+  mockCounters: {
+    runs: { inc: vi.fn() },
+    posts: { inc: vi.fn() },
+    images: { inc: vi.fn() },
+  },
+  mockHistogram: { observe: vi.fn() },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
+vi.mock('~/server/flipt/client', () => ({
+  isFlipt: mockIsFlipt,
+  FLIPT_FEATURE_FLAGS: { BITDEX_PUBLISH_REEMITTER: 'bitdex-publish-reemitter' },
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(() => Promise.resolve()) }));
+vi.mock('~/server/prom/client', () => ({
+  reemitRunsCounter: mockCounters.runs,
+  reemitPostsScannedCounter: mockCounters.posts,
+  reemitImagesEmittedCounter: mockCounters.images,
+  reemitRunDurationHistogram: mockHistogram,
+}));
+// createJob just returns the body fn so the test can invoke it directly.
+vi.mock('~/server/jobs/job', () => ({ createJob: (_n: string, _c: string, fn: unknown) => fn }));
+
+import {
+  buildReemitQuery,
+  getReemitConfig,
+  reemitBitdexOps,
+} from '~/server/jobs/reemit-bitdex-ops';
+
+const runJob = reemitBitdexOps as unknown as () => Promise<unknown>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.REEMIT_LOOKBACK_SECS;
+  delete process.env.REEMIT_SETTLE_SECS;
+});
+
+afterEach(() => {
+  delete process.env.REEMIT_LOOKBACK_SECS;
+  delete process.env.REEMIT_SETTLE_SECS;
+});
+
+describe('buildReemitQuery — the fence + belt', () => {
+  const sql = () => buildReemitQuery({ lookbackSecs: 900, settleSecs: 10 }).sql;
+
+  it('calls BOTH shared PG functions and concatenates them (shape parity)', () => {
+    // Op shape must come from the shared functions, never be re-spelled here.
+    expect(sql()).toContain('bitdex_post_fanout_ops(p)');
+    expect(sql()).toContain('bitdex_image_sortat_ops(i)');
+    expect(sql()).toMatch(/bitdex_post_fanout_ops\(p\)\s*\|\|\s*bitdex_image_sortat_ops\(i\)/);
+  });
+
+  it('is a single INSERT ... SELECT emission (the [PR-M3] fence)', () => {
+    const text = sql();
+    // Exactly one INSERT — a per-row emit loop would reintroduce the ghost race.
+    expect(text.match(/INSERT INTO "BitdexOps"/g)).toHaveLength(1);
+    expect(text).toContain('INSERT INTO "BitdexOps" (entity_id, ops)');
+  });
+
+  it('excludes still-scheduled (future) posts via publishedAt <= now()', () => {
+    expect(sql()).toContain('"publishedAt" <= now()');
+    expect(sql()).toContain('"publishedAt" >= now() -');
+  });
+
+  it('applies the settle belt on updatedAt', () => {
+    expect(sql()).toContain('"updatedAt"  <  now() - make_interval');
+  });
+
+  it('parameterizes lookback and settle (no literal injection)', () => {
+    const query = buildReemitQuery({ lookbackSecs: 900, settleSecs: 10 });
+    expect(query.values).toEqual([900, 10]);
+    // The seconds are placeholders, not baked into the text.
+    expect(query.sql).not.toContain('900');
+  });
+});
+
+describe('getReemitConfig', () => {
+  it('defaults to 15m lookback / 10s settle', () => {
+    expect(getReemitConfig()).toEqual({ lookbackSecs: 900, settleSecs: 10 });
+  });
+
+  it('honors positive env overrides', () => {
+    process.env.REEMIT_LOOKBACK_SECS = '1800';
+    process.env.REEMIT_SETTLE_SECS = '30';
+    expect(getReemitConfig()).toEqual({ lookbackSecs: 1800, settleSecs: 30 });
+  });
+
+  it('falls back to defaults on invalid / non-positive values', () => {
+    process.env.REEMIT_LOOKBACK_SECS = 'nope';
+    process.env.REEMIT_SETTLE_SECS = '0';
+    expect(getReemitConfig()).toEqual({ lookbackSecs: 900, settleSecs: 10 });
+  });
+});
+
+describe('reemitBitdexOps job body', () => {
+  it('no-ops when the Flipt flag is OFF (default-off gate)', async () => {
+    mockIsFlipt.mockResolvedValue(false);
+
+    await runJob();
+
+    expect(mockDbWrite.$queryRaw).not.toHaveBeenCalled();
+    expect(mockCounters.runs.inc).not.toHaveBeenCalled();
+  });
+
+  it('emits once and records metrics from the returned counts when ON', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw.mockResolvedValue([{ postsScanned: 3, imagesEmitted: 12 }]);
+
+    const result = await runJob();
+
+    // Single statement — exactly one query executed.
+    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(mockCounters.runs.inc).toHaveBeenCalledTimes(1);
+    expect(mockCounters.posts.inc).toHaveBeenCalledWith(3);
+    expect(mockCounters.images.inc).toHaveBeenCalledWith(12);
+    expect(mockHistogram.observe).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({ postsScanned: 3, imagesEmitted: 12 });
+  });
+
+  it('propagates a PG error (e.g. missing shared function) instead of swallowing it', async () => {
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw.mockRejectedValue(
+      new Error('function bitdex_post_fanout_ops(post) does not exist')
+    );
+
+    await expect(runJob()).rejects.toThrow(/does not exist/);
+    expect(mockCounters.runs.inc).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
+++ b/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
@@ -4,7 +4,9 @@ const { mockDbWrite, mockIsFlipt, mockCounters, mockHistogram } = vi.hoisted(() 
   mockDbWrite: { $queryRaw: vi.fn() },
   mockIsFlipt: vi.fn(),
   mockCounters: {
+    attempts: { inc: vi.fn() },
     runs: { inc: vi.fn() },
+    errors: { inc: vi.fn() },
     posts: { inc: vi.fn() },
     images: { inc: vi.fn() },
   },
@@ -18,7 +20,9 @@ vi.mock('~/server/flipt/client', () => ({
 }));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(() => Promise.resolve()) }));
 vi.mock('~/server/prom/client', () => ({
+  reemitAttemptsCounter: mockCounters.attempts,
   reemitRunsCounter: mockCounters.runs,
+  reemitErrorsCounter: mockCounters.errors,
   reemitPostsScannedCounter: mockCounters.posts,
   reemitImagesEmittedCounter: mockCounters.images,
   reemitRunDurationHistogram: mockHistogram,
@@ -104,7 +108,10 @@ describe('reemitBitdexOps job body', () => {
     await runJob();
 
     expect(mockDbWrite.$queryRaw).not.toHaveBeenCalled();
+    // No attempt is counted when the gate is off — attempts_total stays flat.
+    expect(mockCounters.attempts.inc).not.toHaveBeenCalled();
     expect(mockCounters.runs.inc).not.toHaveBeenCalled();
+    expect(mockCounters.errors.inc).not.toHaveBeenCalled();
   });
 
   it('emits once and records metrics from the returned counts when ON', async () => {
@@ -115,20 +122,27 @@ describe('reemitBitdexOps job body', () => {
 
     // Single statement — exactly one query executed.
     expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(mockCounters.attempts.inc).toHaveBeenCalledTimes(1);
     expect(mockCounters.runs.inc).toHaveBeenCalledTimes(1);
+    expect(mockCounters.errors.inc).not.toHaveBeenCalled();
     expect(mockCounters.posts.inc).toHaveBeenCalledWith(3);
     expect(mockCounters.images.inc).toHaveBeenCalledWith(12);
     expect(mockHistogram.observe).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({ postsScanned: 3, imagesEmitted: 12 });
   });
 
-  it('propagates a PG error (e.g. missing shared function) instead of swallowing it', async () => {
+  it('counts the attempt + error but NOT a run, and rethrows, on a PG error', async () => {
     mockIsFlipt.mockResolvedValue(true);
     mockDbWrite.$queryRaw.mockRejectedValue(
       new Error('function bitdex_post_fanout_ops(post) does not exist')
     );
 
     await expect(runJob()).rejects.toThrow(/does not exist/);
+    // The attempt is counted (before the emit) so a failing run still moves a
+    // counter; the error counter fires; runs_total stays flat (success-only).
+    expect(mockCounters.attempts.inc).toHaveBeenCalledTimes(1);
+    expect(mockCounters.errors.inc).toHaveBeenCalledTimes(1);
     expect(mockCounters.runs.inc).not.toHaveBeenCalled();
+    expect(mockHistogram.observe).not.toHaveBeenCalled();
   });
 });

--- a/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
+++ b/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
@@ -49,7 +49,7 @@ afterEach(() => {
   delete process.env.REEMIT_SETTLE_SECS;
 });
 
-describe('buildReemitQuery — the fence + belt', () => {
+describe('buildReemitQuery', () => {
   const sql = () => buildReemitQuery({ lookbackSecs: 900, settleSecs: 10 }).sql;
 
   it('calls BOTH shared PG functions and concatenates them (shape parity)', () => {
@@ -59,7 +59,7 @@ describe('buildReemitQuery — the fence + belt', () => {
     expect(sql()).toMatch(/bitdex_post_fanout_ops\(p\)\s*\|\|\s*bitdex_image_sortat_ops\(i\)/);
   });
 
-  it('is a single INSERT ... SELECT emission (the [PR-M3] fence)', () => {
+  it('is a single INSERT ... SELECT emission', () => {
     const text = sql();
     // Exactly one INSERT — a per-row emit loop would reintroduce the ghost race.
     expect(text.match(/INSERT INTO "BitdexOps"/g)).toHaveLength(1);

--- a/src/server/jobs/reemit-bitdex-ops.ts
+++ b/src/server/jobs/reemit-bitdex-ops.ts
@@ -1,0 +1,142 @@
+import { Prisma } from '@prisma/client';
+import { dbWrite } from '~/server/db/client';
+import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
+import { logToAxiom } from '~/server/logging/client';
+import {
+  reemitImagesEmittedCounter,
+  reemitPostsScannedCounter,
+  reemitRunDurationHistogram,
+  reemitRunsCounter,
+} from '~/server/prom/client';
+import { createJob } from './job';
+
+// BitDex publish re-emitter — the safety net under engine-driven activation.
+//
+// Every <cadence> it re-asserts, for every image whose parent Post was published
+// in the trailing <lookback> window, the per-image publish values AND the ingested
+// sortAt, by calling the SAME two shared PG functions the W1-1 sync triggers call
+// (bitdex_post_fanout_ops + bitdex_image_sortat_ops). When BitDex already holds the
+// right values the ops are no-ops (the >=99% success case); when a write was missed
+// (dropped op / activation miss / reschedule straggler / silent sortAt recompute
+// failure) the re-emit heals it from PG's authoritative values within one window.
+//
+// Correctness rests on TWO structural properties — do not weaken either:
+//   1. SINGLE-STATEMENT emission (§3.1, the [PR-M3] fence). The INSERT and its
+//      selection share one MVCC snapshot and the BitdexOps BIGSERIAL id is
+//      allocated inside that statement, which is what keeps a concurrent unpublish
+//      from being re-ordered into a ghost re-publish. Splitting this into a
+//      per-row emit loop takes a fresh snapshot per row and REINTRODUCES the ghost.
+//   2. Shape parity via the SHARED functions. The re-emit's op shape cannot drift
+//      from the triggers' because it calls the identical functions; that is what
+//      preserves the "no-op = success" signal. Never re-spell the op JSON here.
+//
+// See docs/design/publish-reemitter.md (bitdex-v2 repo) for the full argument.
+
+const DEFAULT_LOOKBACK_SECS = 15 * 60; // §4: dominates poller/WAL lag by >10x.
+const DEFAULT_SETTLE_SECS = 10; // §3.3: unpublish-race belt; must be << lookback.
+const CADENCE_CRON = '*/5 * * * *'; // §6.1: cadence < lookback → ~3 heal attempts.
+
+function parsePositiveSecs(raw: string | undefined, fallback: number): number {
+  const n = parseInt(raw ?? '', 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export type ReemitConfig = { lookbackSecs: number; settleSecs: number };
+
+// Config knobs (§8 item 6). Env-overridable so the window can be retuned without a
+// code change; the enable/disable switch is the Flipt flag (no redeploy needed).
+export function getReemitConfig(): ReemitConfig {
+  return {
+    lookbackSecs: parsePositiveSecs(process.env.REEMIT_LOOKBACK_SECS, DEFAULT_LOOKBACK_SECS),
+    settleSecs: parsePositiveSecs(process.env.REEMIT_SETTLE_SECS, DEFAULT_SETTLE_SECS),
+  };
+}
+
+export type ReemitResult = { postsScanned: number; imagesEmitted: number };
+
+// The emit is one data-modifying-CTE statement (fence property #1): `scanned`,
+// the INSERT, and the count read all execute under a single snapshot. The counts
+// are read via RETURNING/aggregate in the SAME statement so posts_scanned is
+// honest (no second snapshot) — it is still one statement, so the fence holds.
+//
+//   - publishedAt <= now()  → excludes still-scheduled (future) posts; a scheduled
+//     post enters the window only once its clock passes, which is exactly when a
+//     missed activation needs healing.
+//   - updatedAt < now() - settle → the settle belt: a post being (un)published
+//     right now has a fresh updatedAt and is skipped until it settles, so the
+//     re-emit and a live publish/unpublish op never coexist in a processable window.
+export function buildReemitQuery({ lookbackSecs, settleSecs }: ReemitConfig): Prisma.Sql {
+  return Prisma.sql`
+    WITH scanned AS (
+      SELECT
+        p.id AS post_id,
+        i.id AS image_id,
+        bitdex_post_fanout_ops(p) || bitdex_image_sortat_ops(i) AS ops
+      FROM "Post" p
+      JOIN "Image" i ON i."postId" = p.id
+      WHERE p."publishedAt" >= now() - make_interval(secs => ${lookbackSecs})
+        AND p."publishedAt" <= now()
+        AND p."updatedAt"  <  now() - make_interval(secs => ${settleSecs})
+    ),
+    ins AS (
+      INSERT INTO "BitdexOps" (entity_id, ops)
+      SELECT image_id, ops FROM scanned
+      RETURNING entity_id
+    )
+    SELECT
+      (SELECT count(*) FROM ins)::int AS "imagesEmitted",
+      (SELECT count(DISTINCT post_id) FROM scanned)::int AS "postsScanned"
+  `;
+}
+
+// Run the emit. Any PG error — notably a MISSING bitdex_post_fanout_ops /
+// bitdex_image_sortat_ops (the functions are created by the sync-trigger deploy,
+// not here) — propagates out of $queryRaw and is NOT swallowed, so createJob's
+// wrapper logs a `job-error` to Axiom and marks the run failed. Loud, never silent.
+export async function runReemit(config: ReemitConfig): Promise<ReemitResult> {
+  const rows = await dbWrite.$queryRaw<ReemitResult[]>(buildReemitQuery(config));
+  const row = rows[0];
+  return {
+    postsScanned: row?.postsScanned ?? 0,
+    imagesEmitted: row?.imagesEmitted ?? 0,
+  };
+}
+
+export const reemitBitdexOps = createJob(
+  'reemit-bitdex-ops',
+  CADENCE_CRON,
+  async () => {
+    // DEFAULT-OFF gate. Registered + scheduled but no-ops every run until the flag
+    // is flipped ON for the W4 shadow window. An unknown/undefined flag → false.
+    const enabled = await isFlipt(FLIPT_FEATURE_FLAGS.BITDEX_PUBLISH_REEMITTER);
+    if (!enabled) return;
+
+    const config = getReemitConfig();
+    const start = Date.now();
+    const { postsScanned, imagesEmitted } = await runReemit(config);
+    const durationSec = (Date.now() - start) / 1000;
+
+    reemitRunsCounter?.inc();
+    reemitPostsScannedCounter?.inc(postsScanned);
+    reemitImagesEmittedCounter?.inc(imagesEmitted);
+    reemitRunDurationHistogram?.observe(durationSec);
+
+    logToAxiom(
+      {
+        type: 'job',
+        name: 'reemit-bitdex-ops',
+        message: 'reemit-complete',
+        postsScanned,
+        imagesEmitted,
+        durationSec,
+        lookbackSecs: config.lookbackSecs,
+        settleSecs: config.settleSecs,
+      },
+      'webhooks'
+    ).catch(() => undefined);
+
+    return { postsScanned, imagesEmitted, durationSec };
+  },
+  // Cheap statement; keep the single-runner lock short.
+  { lockExpiration: 5 * 60 }
+);

--- a/src/server/jobs/reemit-bitdex-ops.ts
+++ b/src/server/jobs/reemit-bitdex-ops.ts
@@ -12,31 +12,15 @@ import {
 } from '~/server/prom/client';
 import { createJob } from './job';
 
-// BitDex publish re-emitter — the safety net under engine-driven activation.
-//
-// Every <cadence> it re-asserts, for every image whose parent Post was published
-// in the trailing <lookback> window, the per-image publish values AND the ingested
-// sortAt, by calling the SAME two shared PG functions the W1-1 sync triggers call
-// (bitdex_post_fanout_ops + bitdex_image_sortat_ops). When BitDex already holds the
-// right values the ops are no-ops (the >=99% success case); when a write was missed
-// (dropped op / activation miss / reschedule straggler / silent sortAt recompute
-// failure) the re-emit heals it from PG's authoritative values within one window.
-//
-// Correctness rests on TWO structural properties — do not weaken either:
-//   1. SINGLE-STATEMENT emission (§3.1, the [PR-M3] fence). The INSERT and its
-//      selection share one MVCC snapshot and the BitdexOps BIGSERIAL id is
-//      allocated inside that statement, which is what keeps a concurrent unpublish
-//      from being re-ordered into a ghost re-publish. Splitting this into a
-//      per-row emit loop takes a fresh snapshot per row and REINTRODUCES the ghost.
-//   2. Shape parity via the SHARED functions. The re-emit's op shape cannot drift
-//      from the triggers' because it calls the identical functions; that is what
-//      preserves the "no-op = success" signal. Never re-spell the op JSON here.
-//
-// See docs/design/publish-reemitter.md (bitdex-v2 repo) for the full argument.
+// BitDex publish re-emitter: a periodic job that re-asserts the per-image publish
+// values and ingested sortAt for every image whose parent Post was published in the
+// trailing lookback window, by calling the same two shared PG functions the sync
+// triggers use. When BitDex already holds the right values the ops are no-ops; when
+// a write was missed, the re-emit heals it from PG within one window.
 
-const DEFAULT_LOOKBACK_SECS = 15 * 60; // §4: dominates poller/WAL lag by >10x.
-const DEFAULT_SETTLE_SECS = 10; // §3.3: unpublish-race belt; must be << lookback.
-const CADENCE_CRON = '*/5 * * * *'; // §6.1: cadence < lookback → ~3 heal attempts.
+const DEFAULT_LOOKBACK_SECS = 15 * 60;
+const DEFAULT_SETTLE_SECS = 10; // must stay << lookback
+const CADENCE_CRON = '*/5 * * * *';
 
 function parsePositiveSecs(raw: string | undefined, fallback: number): number {
   const n = parseInt(raw ?? '', 10);
@@ -45,8 +29,7 @@ function parsePositiveSecs(raw: string | undefined, fallback: number): number {
 
 export type ReemitConfig = { lookbackSecs: number; settleSecs: number };
 
-// Config knobs (§8 item 6). Env-overridable so the window can be retuned without a
-// code change; the enable/disable switch is the Flipt flag (no redeploy needed).
+// Env-overridable so the window can be retuned without a redeploy.
 export function getReemitConfig(): ReemitConfig {
   return {
     lookbackSecs: parsePositiveSecs(process.env.REEMIT_LOOKBACK_SECS, DEFAULT_LOOKBACK_SECS),
@@ -56,17 +39,14 @@ export function getReemitConfig(): ReemitConfig {
 
 export type ReemitResult = { postsScanned: number; imagesEmitted: number };
 
-// The emit is one data-modifying-CTE statement (fence property #1): `scanned`,
-// the INSERT, and the count read all execute under a single snapshot. The counts
-// are read via RETURNING/aggregate in the SAME statement so posts_scanned is
-// honest (no second snapshot) — it is still one statement, so the fence holds.
+// This must stay a single data-modifying-CTE statement: the scan, the INSERT, and
+// the count all run under one snapshot, and the BitdexOps id is allocated inside the
+// INSERT. Splitting it into a per-row emit loop takes a fresh snapshot per row and
+// lets a concurrent unpublish be re-ordered into a ghost re-publish.
 //
-//   - publishedAt <= now()  → excludes still-scheduled (future) posts; a scheduled
-//     post enters the window only once its clock passes, which is exactly when a
-//     missed activation needs healing.
-//   - updatedAt < now() - settle → the settle belt: a post being (un)published
-//     right now has a fresh updatedAt and is skipped until it settles, so the
-//     re-emit and a live publish/unpublish op never coexist in a processable window.
+// The updatedAt < now() - settle clause skips a post that is being (un)published
+// right now (fresh updatedAt) until it settles, so a re-emit never coexists with a
+// live publish/unpublish op.
 export function buildReemitQuery({ lookbackSecs, settleSecs }: ReemitConfig): Prisma.Sql {
   return Prisma.sql`
     WITH scanned AS (
@@ -91,10 +71,9 @@ export function buildReemitQuery({ lookbackSecs, settleSecs }: ReemitConfig): Pr
   `;
 }
 
-// Run the emit. Any PG error — notably a MISSING bitdex_post_fanout_ops /
-// bitdex_image_sortat_ops (the functions are created by the sync-trigger deploy,
-// not here) — propagates out of $queryRaw and is NOT swallowed, so createJob's
-// wrapper logs a `job-error` to Axiom and marks the run failed. Loud, never silent.
+// bitdex_post_fanout_ops / bitdex_image_sortat_ops are created by the sync-trigger
+// deploy, not this repo. A missing function propagates out of $queryRaw rather than
+// being swallowed, so the run fails loudly instead of silently healing nothing.
 export async function runReemit(config: ReemitConfig): Promise<ReemitResult> {
   const rows = await dbWrite.$queryRaw<ReemitResult[]>(buildReemitQuery(config));
   const row = rows[0];
@@ -108,15 +87,12 @@ export const reemitBitdexOps = createJob(
   'reemit-bitdex-ops',
   CADENCE_CRON,
   async () => {
-    // DEFAULT-OFF gate. Registered + scheduled but no-ops every run until the flag
-    // is flipped ON for the W4 shadow window. An unknown/undefined flag → false.
+    // Default-off: registered and scheduled but no-ops until the flag is flipped on.
     const enabled = await isFlipt(FLIPT_FEATURE_FLAGS.BITDEX_PUBLISH_REEMITTER);
     if (!enabled) return;
 
-    // Count the ATTEMPT before the emit — so a run that fails (e.g. a missing
-    // shared PG function) still moves a counter. runs_total stays success-only, so
-    // attempts - runs = the error count and the W4 "counter increments" check can't
-    // be ambiguous between flag-off / erroring / not-scheduled.
+    // Count the attempt before the emit so a failing run still moves a counter;
+    // runs_total stays success-only (attempts - runs = the error count).
     reemitAttemptsCounter?.inc();
 
     const config = getReemitConfig();
@@ -127,7 +103,7 @@ export const reemitBitdexOps = createJob(
       ({ postsScanned, imagesEmitted } = await runReemit(config));
     } catch (e) {
       reemitErrorsCounter?.inc();
-      throw e; // createJob's wrapper logs job-error to Axiom + marks the run failed.
+      throw e; // createJob logs job-error to Axiom and marks the run failed
     }
     const durationSec = (Date.now() - start) / 1000;
 

--- a/src/server/jobs/reemit-bitdex-ops.ts
+++ b/src/server/jobs/reemit-bitdex-ops.ts
@@ -3,6 +3,8 @@ import { dbWrite } from '~/server/db/client';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { logToAxiom } from '~/server/logging/client';
 import {
+  reemitAttemptsCounter,
+  reemitErrorsCounter,
   reemitImagesEmittedCounter,
   reemitPostsScannedCounter,
   reemitRunDurationHistogram,
@@ -111,9 +113,22 @@ export const reemitBitdexOps = createJob(
     const enabled = await isFlipt(FLIPT_FEATURE_FLAGS.BITDEX_PUBLISH_REEMITTER);
     if (!enabled) return;
 
+    // Count the ATTEMPT before the emit — so a run that fails (e.g. a missing
+    // shared PG function) still moves a counter. runs_total stays success-only, so
+    // attempts - runs = the error count and the W4 "counter increments" check can't
+    // be ambiguous between flag-off / erroring / not-scheduled.
+    reemitAttemptsCounter?.inc();
+
     const config = getReemitConfig();
     const start = Date.now();
-    const { postsScanned, imagesEmitted } = await runReemit(config);
+    let postsScanned: number;
+    let imagesEmitted: number;
+    try {
+      ({ postsScanned, imagesEmitted } = await runReemit(config));
+    } catch (e) {
+      reemitErrorsCounter?.inc();
+      throw e; // createJob's wrapper logs job-error to Axiom + marks the run failed.
+    }
     const durationSec = (Date.now() - start) / 1000;
 
     reemitRunsCounter?.inc();


### PR DESCRIPTION
## What

Adds the **BitDex publish re-emitter** — a periodic safety-net job that re-asserts, for every image whose parent Post published in the trailing lookback window, the per-image publish values (`publishedAt`, `availability`, `postedToId`) **and** the ingested `sortAt`. It emits ops by calling the **same two shared PG functions the sync triggers call** — `bitdex_post_fanout_ops(p) || bitdex_image_sortat_ops(i)` — so its op shape cannot drift from the triggers'. When BitDex already holds the right values the ops are no-ops (the ≥99% success case); when a write was missed (dropped op, activation miss, reschedule straggler, or a silently-failed `sortAt` recompute) the re-emit heals it from PG's authoritative values within one window.

Implements W1-3 of **`docs/design/publish-reemitter.md`** (in the bitdex-v2 repo — final, reviewed, on `main`).

## How it's built

- `src/server/jobs/reemit-bitdex-ops.ts` — `createJob('reemit-bitdex-ops', '*/5 * * * *', …)`, registered in the jobs array in `src/pages/api/webhooks/run-jobs/[[...run]].ts`. Inherits the app's **cross-pod Redis lock**, which is the single-runner guard the re-emitter needs — no `pg_try_advisory_lock` in the body.
- Emission is a **data-modifying-CTE single statement** run via `dbWrite.$queryRaw`. `INSERT INTO "BitdexOps" (entity_id, ops) SELECT … RETURNING …` shares one MVCC snapshot with the count read, so `posts_scanned` is honest without a second snapshot.

## The fence + belt (why single-statement is load-bearing)

Design §3. Two independent protections against a concurrent-unpublish **ghost re-publish**:

1. **Single-statement emission [PR-M3].** The `INSERT … SELECT` and its selection share one snapshot, and the `BitdexOps` BIGSERIAL id is allocated *inside* that statement. That matches id-allocation order to the snapshot the values were read under, so the ops_poller's gap-hold machinery always delivers a concurrent unpublish to the engine *after* the re-emit — last-committer-wins, which is correct. A per-row emit loop takes a fresh snapshot per row and **reintroduces the ghost**, so this is a hard requirement, not a style choice (enforced by a unit test asserting exactly one `INSERT`).
2. **Settle belt.** `AND p."updatedAt" < now() - :settle` (default 10s) excludes posts being (un)published *right now*, so the re-emit and a live publish/unpublish op never coexist in a processable window — holds even if the poller's gap machinery ever regresses.

`publishedAt <= now()` excludes still-scheduled (future) posts; a scheduled post enters the window only once its clock passes — exactly when a missed activation needs healing.

## Gating & enable-plan

- **DEFAULT-OFF** behind the Flipt flag `bitdex-publish-reemitter` (added to `FLIPT_FEATURE_FLAGS`). The job body checks the flag first and no-ops every run until it's flipped ON. Flipping the flag needs **no redeploy** (matches the `hot-path-fetch-timeouts` default-off precedent).
- **Registered ≠ running.** A newly-added `createJob` only starts firing once the **external scheduler picks up its cron from `/api/internal/get-jobs`**. Registering it in the array is necessary but not sufficient.
- **Plan:** merge with the flag OFF → confirm the scheduler picked up the cron → flip `bitdex-publish-reemitter` ON for the W4 shadow window → watch `reemit_runs_total` increment. Before enabling, calibrate `lookback` against real `bitdex_sync_v2_lag` / WAL-reader-lag P99 and replace the design's volume estimate with a measured prod publish rate (design §4, §6.2 — follow-ups, not blockers for this PR).

## Config knobs

- `REEMIT_LOOKBACK_SECS` (default 900) and `REEMIT_SETTLE_SECS` (default 10) — env overrides, retune the window without a code change.
- Cadence is the cron literal `*/5 * * * *` (overlap factor 3 → ~3 heal attempts before a stuck slot ages out).

## Metrics (design §6.3 + review NIT-1)

- `reemit_attempts_total` — incremented **before** the emit, right after the enabled gate. Counts erroring runs too, so it moves on every run that passed the flag.
- `reemit_runs_total` — **success-only** (help text says so). `attempts - runs` = the error count.
- `reemit_errors_total` — incremented in the `catch` before rethrow (e.g. a missing shared PG function).
- `reemit_posts_scanned_total`, `reemit_images_emitted_total` — volume; `images_emitted / runs` alarms on a rate spike or stuck cursor.
- `reemit_run_duration_seconds` — histogram; guards the emit becoming slow/lock-heavy.

The attempt/error split (NIT-1) removes the W4 ambiguity: a flat `reemit_runs_total` alone can't distinguish flag-off vs erroring vs not-scheduled — now `attempts` moving with `runs` flat and `errors` climbing pinpoints an erroring run. All added to the `@civitai/telemetry` client, re-exported through `~/server/prom/client`.

## Loud failure

The two PG functions are created by the sync-trigger deploy (2026-07-17), **not** here. A missing function (or any PG error) propagates out of `$queryRaw` un-swallowed → `createJob`'s wrapper logs a `job-error` to Axiom and marks the run failed. Never a silent no-op.

## Tests

`src/server/jobs/__tests__/reemit-bitdex-ops.test.ts` (vitest, 11 tests, all passing): asserts the query text carries the fence (exactly one `INSERT`, `publishedAt <= now()`), the belt (`updatedAt < now() - make_interval`), calls **both** shared functions with `||`, and parameterizes the intervals (no literal injection); config parsing (defaults, env override, invalid/non-positive fallback); the flag gate no-ops when OFF and doesn't touch the DB; metric wiring from the returned counts; and error propagation on a simulated missing-function failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
