### PR TITLE
fix(creator-shop): toast on cosmetic upload failure

### DIFF
--- a/src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts
+++ b/src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts
@@ -103,12 +103,15 @@ export function useSubmitCreatorShopForm({
       setAnimated(supportsAnimated && (await isAnimatedImage(file)));
       setImageId(uploaded.id);
     } catch (error) {
-      // Without this the failure only hit the console and the creator was left
-      // staring at a preview that never finished uploading.
-      showErrorNotification({
-        title: 'Upload failed',
-        error: error instanceof Error ? error : new Error('Could not upload your artwork'),
-      });
+      // Clear the stuck tracked file so `uploading` flips back to false —
+      // otherwise the preview spins forever and Replace stays disabled. Keeps
+      // localUrl so the creator still sees their pick and can re-drop.
+      resetFiles();
+      const err = error instanceof Error ? error : new Error('Could not upload your artwork');
+      // getDataFromFile already toasts its own preprocess failures (then returns
+      // null → this generic throw), so don't double-notify for those.
+      if (err.message !== 'Failed to process file before upload')
+        showErrorNotification({ title: 'Upload failed', error: err });
     }
   };
 

--- a/src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts
+++ b/src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts
@@ -98,9 +98,18 @@ export function useSubmitCreatorShopForm({
     const result = await validateCosmeticImage(file, type, maxSize);
     setChecks(result.checks);
     if (!result.allRequiredPassed) return;
-    const uploaded = await uploadToCF(file, undefined, { allowAnimatedWebP: supportsAnimated });
-    setAnimated(supportsAnimated && (await isAnimatedImage(file)));
-    setImageId(uploaded.id);
+    try {
+      const uploaded = await uploadToCF(file, undefined, { allowAnimatedWebP: supportsAnimated });
+      setAnimated(supportsAnimated && (await isAnimatedImage(file)));
+      setImageId(uploaded.id);
+    } catch (error) {
+      // Without this the failure only hit the console and the creator was left
+      // staring at a preview that never finished uploading.
+      showErrorNotification({
+        title: 'Upload failed',
+        error: error instanceof Error ? error : new Error('Could not upload your artwork'),
+      });
+    }
   };
 
   const handleReplace = () => {
@@ -185,7 +194,6 @@ export function useSubmitCreatorShopForm({
     buzzType,
     setBuzzType,
     animated,
-    setAnimated,
     sellableByOthers,
     setSellableByOthers,
     sellerShare,


### PR DESCRIPTION
## What

Follow-up to #3230. Two small hardening cleanups in the Creator Shop submit form:

1. **Toast on upload failure.** A failed artwork upload in `handleDrop` only hit the console (`console.error` inside `uploadToCF`), so the creator was left staring at a preview that never finished uploading with no idea why. Wrapped the upload in `try/catch` and surface a `showErrorNotification` toast.
2. **Dead code.** Removed the now-unused `setAnimated` from the hook's returned API — orphaned when the manual animated toggle was replaced by auto-detection in #3230.

## Notes

- `showErrorNotification` was already imported in the form; no new deps.
- Covers every rejection path through `uploadToCF`: preprocess/audit failures, the image-upload API error, and xhr network/abort errors.
- Typecheck of the touched file is clean.

## Test

- Force an upload failure (offline, or reject the PUT) while submitting a cosmetic → a red "Upload failed" toast appears instead of silent console-only failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
