### PR TITLE
feat(auth): mark NotificationsRead + VaultRead as sensitive OAuth scopes

### DIFF
--- a/packages/civitai-auth/src/__tests__/connect-scope-review.test.ts
+++ b/packages/civitai-auth/src/__tests__/connect-scope-review.test.ts
@@ -147,8 +147,9 @@ describe('validateConnectScopeJustifications', () => {
 
 describe('SENSITIVE_TOKEN_SCOPES (OAuth sensitive taxonomy)', () => {
   // The auditable expected set — money (BuzzRead/SocialTip + buzz-spending writes),
-  // private (UserRead), and every cross-user/account write+delete. Reads of public
-  // data and the opt-in App-Block scopes are NOT sensitive.
+  // private-data reads (UserRead PII, NotificationsRead, VaultRead), and every
+  // cross-user/account write+delete. Reads of PUBLIC data and the opt-in App-Block
+  // scopes are NOT sensitive.
   const EXPECTED_SENSITIVE =
     TokenScope.UserRead |
     TokenScope.UserWrite |
@@ -165,7 +166,9 @@ describe('SENSITIVE_TOKEN_SCOPES (OAuth sensitive taxonomy)', () => {
     TokenScope.CollectionsWrite |
     TokenScope.SocialWrite |
     TokenScope.SocialTip |
+    TokenScope.NotificationsRead |
     TokenScope.NotificationsWrite |
+    TokenScope.VaultRead |
     TokenScope.VaultWrite;
 
   it('is EXACTLY the expected sensitive bitmask', () => {
@@ -187,7 +190,9 @@ describe('SENSITIVE_TOKEN_SCOPES (OAuth sensitive taxonomy)', () => {
       'CollectionsWrite',
       'SocialWrite',
       'SocialTip',
+      'NotificationsRead',
       'NotificationsWrite',
+      'VaultRead',
       'VaultWrite',
     ]);
   });
@@ -202,6 +207,8 @@ describe('SENSITIVE_TOKEN_SCOPES (OAuth sensitive taxonomy)', () => {
   });
 
   it('EXCLUDES the public-read + opt-in App-Block scopes', () => {
+    // NotificationsRead/VaultRead are NO LONGER here — they are private-data reads
+    // and were promoted into SENSITIVE_TOKEN_SCOPES.
     for (const bit of [
       TokenScope.ModelsRead,
       TokenScope.MediaRead,
@@ -209,8 +216,6 @@ describe('SENSITIVE_TOKEN_SCOPES (OAuth sensitive taxonomy)', () => {
       TokenScope.BountiesRead,
       TokenScope.AIServicesRead,
       TokenScope.CollectionsRead,
-      TokenScope.NotificationsRead,
-      TokenScope.VaultRead,
       TokenScope.AppBlocksSubmit,
       TokenScope.AppBlocksDevTunnel,
     ]) {
@@ -223,6 +228,10 @@ describe('SENSITIVE_TOKEN_SCOPES (OAuth sensitive taxonomy)', () => {
     expect(isSensitiveTokenScope(TokenScope.UserRead)).toBe(true);
     expect(isSensitiveTokenScope(TokenScope.BuzzRead)).toBe(true);
     expect(isSensitiveTokenScope(TokenScope.SocialTip)).toBe(true);
+    // Private-data reads are sensitive.
+    expect(isSensitiveTokenScope(TokenScope.NotificationsRead)).toBe(true);
+    expect(isSensitiveTokenScope(TokenScope.VaultRead)).toBe(true);
+    // Public-data reads stay non-sensitive.
     expect(isSensitiveTokenScope(TokenScope.ModelsRead)).toBe(false);
     expect(isSensitiveTokenScope(TokenScope.MediaRead)).toBe(false);
     expect(isSensitiveTokenScope(TokenScope.AppBlocksSubmit)).toBe(false);

--- a/packages/civitai-auth/src/token-scope.ts
+++ b/packages/civitai-auth/src/token-scope.ts
@@ -354,18 +354,22 @@ export function validateConnectScopeJustifications(
  *  - money:      `BuzzRead` (balance/history) + `SocialTip` (spend on tips) — and
  *                every `*Write` that implicitly spends Buzz (`AIServicesWrite`,
  *                `BountiesWrite`).
- *  - private:    `UserRead` (profile, settings & EMAIL / PII).
+ *  - private:    `UserRead` (profile, settings & EMAIL / PII) + the private-data
+ *                reads `NotificationsRead` (a user's personal notifications) and
+ *                `VaultRead` (the user's PRIVATE model vault). Mirrors the App Blocks
+ *                sensitivity principle where private-data reads (e.g.
+ *                `collections:read:private`) are sensitive.
  *  - cross-user / destructive: every `*Write` + `*Delete` (they create, mutate or
  *                remove content others can see, or edit the user's own account).
  *
  * Written as an EXPLICIT named-bit OR (not a computed "everything but reads") so a
  * moderator can eyeball exactly which permissions are flagged, and adding a new
  * scope bit never silently folds it in. Deliberately EXCLUDES the read-only scopes
- * that expose only public data (`ModelsRead`/`MediaRead`/`ArticlesRead`/
- * `BountiesRead`/`AIServicesRead`/`CollectionsRead`/`NotificationsRead`/`VaultRead`)
- * and the opt-in App-Block scopes (`AppBlocksSubmit`/`AppBlocksDevTunnel`, never
- * part of a connect ceiling). `NotificationsWrite`/`VaultWrite` are included as
- * account-mutating writes even though they are self-scoped.
+ * that expose only PUBLIC data (`ModelsRead`/`MediaRead`/`ArticlesRead`/
+ * `BountiesRead`/`AIServicesRead`/`CollectionsRead`) and the opt-in App-Block
+ * scopes (`AppBlocksSubmit`/`AppBlocksDevTunnel`, never part of a connect ceiling).
+ * `NotificationsWrite`/`VaultWrite` are included as account-mutating writes even
+ * though they are self-scoped.
  */
 export const SENSITIVE_TOKEN_SCOPES: number =
   TokenScope.UserRead | // private: profile, settings & email (PII)
@@ -383,7 +387,9 @@ export const SENSITIVE_TOKEN_SCOPES: number =
   TokenScope.CollectionsWrite |
   TokenScope.SocialWrite | // cross-user: follow/react/comment/review
   TokenScope.SocialTip | // money: tip other users
+  TokenScope.NotificationsRead | // private: a user's personal notifications (mentions/alerts/transaction notices)
   TokenScope.NotificationsWrite |
+  TokenScope.VaultRead | // private: the user's PRIVATE model vault (what private models they've stored)
   TokenScope.VaultWrite;
 
 /**


### PR DESCRIPTION
## What

Adds `TokenScope.NotificationsRead` and `TokenScope.VaultRead` to the `SENSITIVE_TOKEN_SCOPES` bitmask in `packages/civitai-auth/src/token-scope.ts` (17 → **19 bits**), so both scopes require a per-scope justification at OAuth-connect listing approval and render in the "Sensitive permissions" group during mod review.

Both are **private-data reads**:
- `NotificationsRead` — a user's personal notifications (mentions / alerts / transaction notices).
- `VaultRead` — the user's **private** model vault (what private models they've stored).

This matches the App Blocks sensitivity principle where private-data reads (e.g. `collections:read:private`) are sensitive. `isSensitiveTokenScope` reads the constant, so the OAuth approval gate + review panel pick these up automatically — **no other code changes**.

## Tests

Updated `packages/civitai-auth/src/__tests__/connect-scope-review.test.ts`:
- `SENSITIVE_TOKEN_SCOPES` bitmask + enum-key list now include `NotificationsRead` + `VaultRead` (19 bits; value `33404635`).
- Both moved out of the public-read `EXCLUDES` set.
- Added `isSensitiveTokenScope(NotificationsRead)` / `isSensitiveTokenScope(VaultRead)` === `true` spot checks; `ModelsRead` stays `false`.
- The "every set bit is a defined single-bit TokenScope" guard still passes.

**Fails-before / passes-after** (proves the tests exercise the change): with the test edits applied but the source unchanged, 2 tests fail (`is EXACTLY the expected sensitive bitmask`: `22918875` vs expected `33404635`; `isSensitiveTokenScope single-bit spot checks`: `NotificationsRead` false→expected true). After the source edit, the full `@civitai/auth` suite is green (**231/231**).

Typecheck: `NODE_OPTIONS=--max_old_space_size=8192 tsc --noEmit` — **0 errors in the changed files** (0 delta).