### PR TITLE
feat(moderation): mod-only Moderation card on model page

### DIFF
--- a/src/components/Model/ModelVersions/ModelModerationCard.tsx
+++ b/src/components/Model/ModelVersions/ModelModerationCard.tsx
@@ -1,0 +1,188 @@
+import {
+  Accordion,
+  Badge,
+  Code,
+  Group,
+  Loader,
+  Stack,
+  Text,
+  useComputedColorScheme,
+} from '@mantine/core';
+import { useLocalStorage } from '@mantine/hooks';
+import { IconShieldCheck, IconShieldHalfFilled } from '@tabler/icons-react';
+import type { ReactNode } from 'react';
+import { formatDate } from '~/utils/date-helpers';
+import { trpc } from '~/utils/trpc';
+import classes from './ModelVersionDetails.module.scss';
+
+// Mod-only at-a-glance moderation status for a model. Surfaces automated state
+// (minor/POI/nsfw flags, locked properties, profanity lock, unpublish/takedown)
+// that mods otherwise can't see since they bypass the enforcement filters.
+// Collapsible + persisted, styled to match the version-details card.
+export function ModelModerationCard({ modelId }: { modelId: number }) {
+  const colorScheme = useComputedColorScheme('dark');
+  const { data, isLoading } = trpc.moderator.models.getModerationDetail.useQuery({ id: modelId });
+  const [open, setOpen] = useLocalStorage<string[]>({
+    key: 'model-moderation-card',
+    defaultValue: [],
+  });
+
+  const flags: { label: string; color: string }[] = [];
+  if (data?.minor) flags.push({ label: 'Minor', color: 'red' });
+  if (data?.poi) flags.push({ label: 'POI', color: 'grape' });
+  if (data?.nsfw) flags.push({ label: 'NSFW', color: 'red' });
+  if (data?.needsReview) flags.push({ label: 'Needs review', color: 'yellow' });
+  if (data?.cannotPublish) flags.push({ label: 'Cannot publish', color: 'orange' });
+  if (data?.cannotPromote) flags.push({ label: 'Promo banned', color: 'orange' });
+  if (data?.commentsLocked) flags.push({ label: 'Comments locked', color: 'gray' });
+
+  const locked = data?.lockedProperties ?? [];
+  const hasFooter = !!(
+    data?.profanity ||
+    data?.unpublishedAt ||
+    data?.takenDownAt ||
+    data?.deletedAt
+  );
+  const rows: { key: string; badges: ReactNode }[] = [];
+  if (flags.length)
+    rows.push({
+      key: 'Flags',
+      badges: flags.map((f) => (
+        <Badge key={f.label} size="sm" radius="xl" color={f.color} variant="light">
+          {f.label}
+        </Badge>
+      )),
+    });
+  if (locked.length)
+    rows.push({
+      key: 'Locked',
+      badges: locked.map((p) => (
+        <Badge key={p} size="sm" radius="xl" color="orange" variant="light">
+          {p}
+        </Badge>
+      )),
+    });
+
+  const isEmpty = !isLoading && !!data && rows.length === 0 && !hasFooter;
+  const notableCount =
+    flags.length +
+    locked.length +
+    (data?.profanity ? 1 : 0) +
+    (data?.unpublishedAt ? 1 : 0) +
+    (data?.takenDownAt ? 1 : 0) +
+    (data?.deletedAt ? 1 : 0);
+
+  return (
+    <Accordion
+      variant="separated"
+      multiple
+      value={open}
+      onChange={setOpen}
+      styles={(theme) => ({
+        content: { padding: 0 },
+        label: { padding: 0 },
+        item: {
+          overflow: 'hidden',
+          borderColor: colorScheme === 'dark' ? theme.colors.dark[4] : theme.colors.gray[3],
+          boxShadow: theme.shadows.sm,
+        },
+        control: { padding: theme.spacing.sm, gap: theme.spacing.md },
+      })}
+    >
+      <Accordion.Item value="moderation">
+        <Accordion.Control>
+          <Group justify="space-between" gap="xs" wrap="nowrap">
+            <Group gap={6} wrap="nowrap">
+              <IconShieldHalfFilled size={16} />
+              Moderation
+              {notableCount > 0 && (
+                <Badge size="sm" variant="filled" color="orange">
+                  {notableCount}
+                </Badge>
+              )}
+            </Group>
+            <Badge size="sm" variant="light" color="blue">
+              mods only
+            </Badge>
+          </Group>
+        </Accordion.Control>
+        <Accordion.Panel>
+          {isLoading || !data ? (
+            <Group justify="center" py="sm">
+              <Loader size="sm" />
+            </Group>
+          ) : isEmpty ? (
+            <Group justify="center" gap={8} py="lg">
+              <IconShieldCheck size={18} style={{ color: 'var(--mantine-color-green-6)' }} />
+              <Text size="sm" c="dimmed">
+                No moderation flags on this model
+              </Text>
+            </Group>
+          ) : (
+            <>
+              {rows.length > 0 && (
+                <Stack gap={0} className={classes.detailsPanel}>
+                  {rows.map((r, i) => {
+                    const isLast = i === rows.length - 1 && !hasFooter;
+                    return (
+                      <div
+                        key={r.key}
+                        className={isLast ? classes.detailRowPlain : classes.detailRow}
+                      >
+                        <span className={classes.detailLabel}>{r.key}</span>
+                        <Group gap={4}>{r.badges}</Group>
+                      </div>
+                    );
+                  })}
+                </Stack>
+              )}
+
+              {hasFooter && (
+                <Stack gap={6} px="md" py="sm">
+                  {data.profanity && (
+                    <Stack gap={4}>
+                      <Text size="xs" fw={600} c="orange">
+                        Auto-flagged by profanity filter
+                      </Text>
+                      <Group gap={4}>
+                        {data.profanity.matches.map((m, i) => (
+                          <Code key={i}>{m}</Code>
+                        ))}
+                      </Group>
+                      {data.profanity.metrics && (
+                        <Text size="xs">
+                          {data.profanity.metrics.matchCount} matches in{' '}
+                          {data.profanity.metrics.totalWords} words (
+                          {(data.profanity.metrics.density * 100).toFixed(2)}%)
+                        </Text>
+                      )}
+                      <Text size="xs" c="dimmed">
+                        From lock time — may be stale; re-save to re-run the current filter.
+                      </Text>
+                    </Stack>
+                  )}
+                  {data.unpublishedAt && (
+                    <Text size="xs">
+                      Unpublished {formatDate(data.unpublishedAt)}
+                      {data.unpublishedReason ? ` — ${data.unpublishedReason}` : ''}
+                    </Text>
+                  )}
+                  {data.takenDownAt && (
+                    <Text size="xs" c="red">
+                      Taken down {formatDate(data.takenDownAt)}
+                    </Text>
+                  )}
+                  {data.deletedAt && (
+                    <Text size="xs" c="red">
+                      Deleted {formatDate(data.deletedAt)}
+                    </Text>
+                  )}
+                </Stack>
+              )}
+            </>
+          )}
+        </Accordion.Panel>
+      </Accordion.Item>
+    </Accordion>
+  );
+}

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -83,6 +83,7 @@ import { ModelFileAlert } from '~/components/Model/ModelFileAlert/ModelFileAlert
 import { ModelHash } from '~/components/Model/ModelHash/ModelHash';
 import { ModelURN, URNExplanation } from '~/components/Model/ModelURN/ModelURN';
 import { DownloadVariantDropdown } from '~/components/Model/ModelVersions/DownloadVariantDropdown';
+import { ModelModerationCard } from '~/components/Model/ModelVersions/ModelModerationCard';
 import { ModelTensorMetadata } from '~/components/Model/ModelVersions/ModelTensorMetadata';
 import { ModelVersionPopularity } from '~/components/Model/ModelVersions/ModelVersionPopularity';
 import { ModelVersionReview } from '~/components/Model/ModelVersions/ModelVersionReview';
@@ -364,8 +365,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
     staleTime: 60 * 1000, // 1 minute - avoid refetching on every model view
   });
   const isNotificationOn =
-    (followingUsers.includes(model.user.id) || isModelEngaged('Notify')) &&
-    !isModelEngaged('Mute');
+    (followingUsers.includes(model.user.id) || isModelEngaged('Notify')) && !isModelEngaged('Mute');
   const toggleNotifyModelMutation = trpc.user.toggleNotifyModel.useMutation({
     onMutate() {
       // Optimistic store update + snapshot for rollback.
@@ -878,6 +878,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                   </div>
                 </Stack>
               </Card>
+              {user?.isModerator && <ModelModerationCard modelId={model.id} />}
               {/* Component-only model message */}
               {isComponentOnlyModel && (
                 <AlertWithIcon
@@ -1400,7 +1401,9 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                       <span className={classes.detailLabel}>Generation License Fee</span>
                       <Group gap={4} wrap="nowrap">
                         <CurrencyIcon currency="BUZZ" size={16} />
-                        <Text size="sm">{numberWithCommas(Number(version.licensingFee))} / image</Text>
+                        <Text size="sm">
+                          {numberWithCommas(Number(version.licensingFee))} / image
+                        </Text>
                         <Popover
                           width={260}
                           shadow="md"

--- a/src/server/routers/moderator/index.ts
+++ b/src/server/routers/moderator/index.ts
@@ -28,6 +28,7 @@ import {
 import { getImagesModRules } from '~/server/services/image.service';
 import { getFlaggedModels, resolveFlaggedModel } from '~/server/services/model-flag.service';
 import {
+  getModelModerationDetail,
   getModelModRules,
   getTrainingModelsForModerators,
   transferModelOwnership,
@@ -57,6 +58,9 @@ export const modRouter = router({
     transferOwnership: moderatorProcedure
       .input(transferModelOwnershipSchema)
       .mutation(({ input, ctx }) => transferModelOwnership({ ...input, modUserId: ctx.user.id })),
+    getModerationDetail: moderatorProcedure
+      .input(getByIdSchema)
+      .query(({ input }) => getModelModerationDetail(input)),
   }),
   modelVersions: router({
     query: moderatorProcedure

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -3701,6 +3701,61 @@ export async function bustFeaturedModelsCache() {
   await bustFetchThroughCache(REDIS_KEYS.CACHES.FEATURED_MODELS);
 }
 
+// Mod-only read of a model's moderation state — surfaces why a model is
+// locked / marked nsfw / hidden so mods can self-triage instead of escalating
+// (auto-actions like the profanity nsfw-lock are otherwise invisible to them).
+export async function getModelModerationDetail({ id }: { id: number }) {
+  const model = await dbRead.model.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      name: true,
+      nsfw: true,
+      nsfwLevel: true,
+      status: true,
+      availability: true,
+      minor: true,
+      poi: true,
+      lockedProperties: true,
+      deletedAt: true,
+      deletedBy: true,
+      meta: true,
+    },
+  });
+  if (!model) throw throwNotFoundError(`No model with id ${id}`);
+
+  const meta = (model.meta ?? {}) as ModelMeta;
+  return {
+    id: model.id,
+    name: model.name,
+    nsfw: model.nsfw,
+    nsfwLevel: model.nsfwLevel,
+    status: model.status,
+    availability: model.availability,
+    minor: model.minor,
+    poi: model.poi,
+    lockedProperties: model.lockedProperties ?? [],
+    cannotPromote: meta.cannotPromote ?? false,
+    cannotPublish: meta.cannotPublish ?? false,
+    commentsLocked: meta.commentsLocked ?? false,
+    deletedAt: model.deletedAt,
+    deletedBy: model.deletedBy,
+    profanity: meta.profanityMatches?.length
+      ? {
+          matches: meta.profanityMatches,
+          reason: meta.profanityEvaluation?.reason ?? null,
+          metrics: meta.profanityEvaluation?.metrics ?? null,
+        }
+      : null,
+    unpublishedAt: meta.unpublishedAt ?? null,
+    unpublishedBy: meta.unpublishedBy ?? null,
+    unpublishedReason: meta.unpublishedReason ?? null,
+    takenDownAt: meta.takenDownAt ?? null,
+    takenDownBy: meta.takenDownBy ?? null,
+    needsReview: meta.needsReview ?? false,
+  };
+}
+
 export async function getModelModRules() {
   const modRules = await fetchThroughCache(
     REDIS_KEYS.CACHES.MOD_RULES.MODELS,


### PR DESCRIPTION
## Why

Origin: ClickUp 868kdbmmv / Freshdesk #68397. A mod reported a model gallery as blank-for-users but it looked fine to her — because **mods bypass the enforcement filters**, so an auto-nsfw-locked or unpublish-stamped model reads as normal to a mod and gets escalated as a bug. The underlying data bugs were fixed separately (#3219, the stale `unpublishedAt` cleanup); this PR closes the **visibility** gap so mods can self-triage.

## What

A mod-only **Moderation** card in the model sidebar (under the action card, above download):

- **Server:** `moderator.models.getModerationDetail` (mod-gated) returns `minor`/`poi`/`nsfw`, `needsReview`, `cannotPublish`/`cannotPromote`/`commentsLocked`, `lockedProperties`, the profanity auto-eval (`matches`/`reason`/`metrics`), and unpublish/takedown/delete records.
- **Client:** a collapsible + persisted card (matches the version-details card via the shared `detailsPanel`/`detailRow` classes). Shows **Flags** and **Locked** rows only when populated, a readable **profanity footer**, and a clean **empty state** ("No moderation flags on this model") when nothing's flagged. Header shows a count badge so state is visible even collapsed.

Read-only; no behavior change for non-mods (card renders only when `user.isModerator`).

## Verification
- Typecheck ✅, prettier ✅.
- Driven live in the dev server against prod data: locked model (`2043774`) shows Flags/Locked/profanity; unlocked (`2058901`) shows just the profanity footer; a clean model shows the empty state.

## Not included (follow-ups)
- The 61-model stale-profanity-lock unlock sweep (separate remediation, dry-run done: 61 of 68 clear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)