### PR TITLE
perf(image-delivery): cache url→metadata lookup

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2081,6 +2081,14 @@ export const REDIS_KEYS = {
     // only (bid submission re-validates the true minimum server-side). See
     // `getAllAuctions` in auction.service.
     ACTIVE_AUCTIONS: 'packed:caches:active-auctions',
+    // url -> {id, url, hideMeta} lookup backing the internal image-delivery endpoint
+    // (`/api/internal/image-delivery/[id]`, ~9.2 req/s at peak). The near-immutable
+    // `Image WHERE url = $1` single-row read is the highest-volume DB query in the
+    // profile. Keyed by the EXACT url (case/whitespace-sensitive — the WHERE key is not
+    // normalized), positive results only (an unknown url stays uncached so a newly
+    // registered image resolves immediately), busted when `hideMeta` flips in
+    // updatePostImage. See `getCachedImageDeliveryMetadata` in image-delivery.service.
+    IMAGE_DELIVERY_METADATA: 'packed:caches:image-delivery-metadata',
   },
   RESEARCH: {
     RATINGS_COUNT: 'research:ratings-count',

--- a/src/pages/api/internal/image-delivery/[id].ts
+++ b/src/pages/api/internal/image-delivery/[id].ts
@@ -1,16 +1,11 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
 
-import { dbRead, dbWrite } from '~/server/db/client';
-import { dbReadFallbackCounter, registerCounterWithLabels } from '~/server/prom/client';
+import { registerCounterWithLabels } from '~/server/prom/client';
+import { getCachedImageDeliveryMetadata } from '~/server/services/image-delivery.service';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 const schema = z.object({ id: z.string() });
-type ImageRow = {
-  id: number;
-  url: string;
-  hideMeta: boolean;
-};
 
 const imageDeliveryRequestCounter = registerCounterWithLabels({
   name: 'image_delivery_request_total',
@@ -27,28 +22,9 @@ export default WebhookEndpoint(async function handler(req: NextApiRequest, res: 
 
   const { id } = results.data;
 
-  const query = () => dbRead.$queryRaw<ImageRow[]>`
-    SELECT
-      id,
-      url,
-      "hideMeta"
-    FROM "Image"
-    WHERE url = ${id}
-    LIMIT 1
-  `;
-
-  const [image] = await query().catch(() => {
-    dbReadFallbackCounter.inc({ entity: 'image', caller: 'imageDelivery' });
-    return dbWrite.$queryRaw<ImageRow[]>`
-      SELECT
-        id,
-        url,
-        "hideMeta"
-      FROM "Image"
-      WHERE url = ${id}
-      LIMIT 1
-    `;
-  });
+  // `id` is the image url (the raw query keys on `WHERE url = $1`). Read-through Redis cache
+  // fronts the near-immutable url -> {id, url, hideMeta} lookup; fails open to the DB.
+  const image = await getCachedImageDeliveryMetadata(id);
 
   if (!image) {
     imageDeliveryRequestCounter.inc({ status: 'not_found' });

--- a/src/server/services/__tests__/image-delivery-metadata-cache.test.ts
+++ b/src/server/services/__tests__/image-delivery-metadata-cache.test.ts
@@ -1,0 +1,221 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { pack, unpack } from 'msgpackr';
+
+// Backing store for the fake Redis. Values are stored as msgpackr-PACKED Buffers and
+// unpacked on read — the SAME codec the real `redis.packed` client uses (set -> pack(value),
+// get -> unpack(buffer)) — so the byte-identical claim is exercised through the real
+// serializer end-to-end, not a pass-through fake. Cache hit/miss semantics stay real (a Map),
+// letting us assert exactly when the origin DB query is re-run.
+const { store, dbReadQueryRaw, dbWriteQueryRaw, redisPackedGet, redisPackedSet, redisDel } =
+  vi.hoisted(() => ({
+    store: new Map<string, Buffer>(),
+    dbReadQueryRaw: vi.fn(),
+    dbWriteQueryRaw: vi.fn(),
+    redisPackedGet: vi.fn(),
+    redisPackedSet: vi.fn(),
+    redisDel: vi.fn(),
+  }));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: dbReadQueryRaw },
+  dbWrite: { $queryRaw: dbWriteQueryRaw },
+}));
+// Keep the real REDIS_KEYS (so the key we build matches the production constant) and only
+// swap the live client for the in-memory fake.
+vi.mock('~/server/redis/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/redis/client')>();
+  return {
+    ...actual,
+    redis: { del: redisDel, packed: { get: redisPackedGet, set: redisPackedSet } },
+  };
+});
+
+import {
+  getCachedImageDeliveryMetadata,
+  bustImageDeliveryMetadataCache,
+} from '~/server/services/image-delivery.service';
+import { CacheTTL } from '~/server/common/constants';
+
+const KEY_PREFIX = 'packed:caches:image-delivery-metadata';
+
+// A row exactly as the raw `Image WHERE url = $1` query returns it.
+const URL = 'abc123/def456.jpeg';
+const IMAGE_ROW = { id: 42, url: URL, hideMeta: false };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  store.clear();
+  // Real msgpackr round-trip: set packs to a Buffer, get unpacks — mirrors the production
+  // redis.packed codec so serializer fidelity (number id, string url, boolean hideMeta) is
+  // actually under test on the hit path.
+  redisPackedGet.mockImplementation(async (key: string) => {
+    const buf = store.get(key);
+    return buf ? unpack(buf) : null;
+  });
+  redisPackedSet.mockImplementation(async (key: string, value: unknown) => {
+    store.set(key, pack(value));
+  });
+  redisDel.mockImplementation(async (key: string) => {
+    store.delete(key);
+    return 1;
+  });
+});
+
+describe('getCachedImageDeliveryMetadata — read-through cache', () => {
+  it('serves the second call for the same url from cache without re-hitting the DB', async () => {
+    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+
+    const first = await getCachedImageDeliveryMetadata(URL);
+    const second = await getCachedImageDeliveryMetadata(URL);
+
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(1); // the win: one DB read, not two
+    expect(first).toEqual(second);
+    expect(redisPackedSet).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns output byte-identical to the raw query', async () => {
+    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+
+    const result = await getCachedImageDeliveryMetadata(URL);
+    expect(result).toEqual({ id: 42, url: URL, hideMeta: false });
+
+    // Prove byte-identity THROUGH the real msgpackr codec: unpack the actual stored Buffer
+    // and assert every field survives the serializer — number id, string url, boolean.
+    const storedBuffer = store.get(`${KEY_PREFIX}:${URL}`);
+    expect(Buffer.isBuffer(storedBuffer)).toBe(true);
+    const roundTripped = unpack(storedBuffer!) as typeof IMAGE_ROW;
+    expect(roundTripped).toEqual(IMAGE_ROW);
+    expect(roundTripped.id).toBe(42);
+    expect(roundTripped.url).toBe(URL);
+    expect(roundTripped.hideMeta).toBe(false);
+  });
+
+  it('serves a msgpackr-codec round-tripped result on the cache HIT path', async () => {
+    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    await getCachedImageDeliveryMetadata(URL); // populate
+
+    const hit = await getCachedImageDeliveryMetadata(URL); // served from unpack(Buffer)
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(1);
+    expect(hit).toEqual({ id: 42, url: URL, hideMeta: false });
+    expect(hit?.hideMeta).toBe(false);
+  });
+
+  it('preserves hideMeta:true through the codec on the hit path', async () => {
+    const hidden = { id: 7, url: 'hidden/img.png', hideMeta: true };
+    dbReadQueryRaw.mockResolvedValue([hidden]);
+
+    await getCachedImageDeliveryMetadata(hidden.url); // populate
+    const hit = await getCachedImageDeliveryMetadata(hidden.url);
+
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(1);
+    expect(hit).toEqual(hidden);
+    expect(hit?.hideMeta).toBe(true); // boolean true survived pack -> unpack
+  });
+
+  it('keys by the EXACT url — a case/whitespace variant is a MISS (no collision)', async () => {
+    dbReadQueryRaw.mockResolvedValueOnce([IMAGE_ROW]);
+    await getCachedImageDeliveryMetadata(URL);
+
+    // An uppercased variant must NOT resolve to the same cached row (url WHERE is
+    // case-sensitive, unlike citext) — it re-hits the DB with its own row.
+    const variantRow = { id: 99, url: URL.toUpperCase(), hideMeta: false };
+    dbReadQueryRaw.mockResolvedValueOnce([variantRow]);
+    const variant = await getCachedImageDeliveryMetadata(URL.toUpperCase());
+
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(2); // no collision — separate DB read
+    expect(variant).toEqual(variantRow);
+    expect(new Set(store.keys())).toEqual(
+      new Set([`${KEY_PREFIX}:${URL}`, `${KEY_PREFIX}:${URL.toUpperCase()}`])
+    );
+  });
+
+  it('passes the exact url to the DB query as the WHERE value', async () => {
+    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    await getCachedImageDeliveryMetadata(URL);
+    const values = dbReadQueryRaw.mock.calls[0].slice(1);
+    expect(values).toContain(URL);
+  });
+
+  it('sets the cache entry with the short TTL', async () => {
+    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    await getCachedImageDeliveryMetadata(URL);
+    expect(redisPackedSet).toHaveBeenCalledWith(`${KEY_PREFIX}:${URL}`, IMAGE_ROW, {
+      EX: CacheTTL.sm,
+    });
+  });
+
+  it('does NOT cache a negative result — an unknown url re-hits the DB every call', async () => {
+    dbReadQueryRaw.mockResolvedValue([]); // no such image
+
+    const first = await getCachedImageDeliveryMetadata('missing/url.jpg');
+    const second = await getCachedImageDeliveryMetadata('missing/url.jpg');
+
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    // Both calls hit the DB (no negative caching) so a newly-registered image is findable.
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(2);
+    expect(redisPackedSet).not.toHaveBeenCalled();
+    expect(store.size).toBe(0);
+  });
+
+  it('becomes findable immediately after the image is registered (no stale negative)', async () => {
+    dbReadQueryRaw.mockResolvedValueOnce([]); // miss — not cached
+    expect(await getCachedImageDeliveryMetadata('brandnew/img.png')).toBeNull();
+
+    const created = { id: 555, url: 'brandnew/img.png', hideMeta: false };
+    dbReadQueryRaw.mockResolvedValueOnce([created]);
+    expect(await getCachedImageDeliveryMetadata('brandnew/img.png')).toEqual(created);
+  });
+
+  it('fails open to dbRead when the Redis read throws (hot path must not 500)', async () => {
+    redisPackedGet.mockRejectedValueOnce(new Error('redis down'));
+    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+
+    const result = await getCachedImageDeliveryMetadata(URL);
+    expect(result).toEqual(IMAGE_ROW); // degraded to origin, correct result
+  });
+
+  it('still returns the DB result when the Redis WRITE (populate) throws', async () => {
+    redisPackedGet.mockResolvedValueOnce(null); // miss
+    redisPackedSet.mockRejectedValueOnce(new Error('redis write down'));
+    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+
+    const result = await getCachedImageDeliveryMetadata(URL);
+    expect(result).toEqual(IMAGE_ROW); // request succeeds despite the write failure
+    expect(redisPackedSet).toHaveBeenCalledTimes(1); // it was attempted
+  });
+
+  it('falls over to dbWrite (primary) when the read replica query rejects', async () => {
+    redisPackedGet.mockResolvedValue(null); // cache miss
+    dbReadQueryRaw.mockRejectedValueOnce(new Error('replica error'));
+    dbWriteQueryRaw.mockResolvedValueOnce([IMAGE_ROW]);
+
+    const result = await getCachedImageDeliveryMetadata(URL);
+    expect(result).toEqual(IMAGE_ROW); // primary fallback resolved
+    expect(dbWriteQueryRaw).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('bustImageDeliveryMetadataCache', () => {
+  it('deletes the exact url key so the next read re-queries', async () => {
+    dbReadQueryRaw.mockResolvedValue([IMAGE_ROW]);
+    await getCachedImageDeliveryMetadata(URL); // populate
+    expect(store.has(`${KEY_PREFIX}:${URL}`)).toBe(true);
+
+    await bustImageDeliveryMetadataCache(URL);
+    expect(redisDel).toHaveBeenCalledWith(`${KEY_PREFIX}:${URL}`);
+    expect(store.has(`${KEY_PREFIX}:${URL}`)).toBe(false);
+
+    // Next read re-hits the DB (fresh row) rather than serving the busted entry.
+    const fresh = { id: 42, url: URL, hideMeta: true };
+    dbReadQueryRaw.mockResolvedValue([fresh]);
+    const after = await getCachedImageDeliveryMetadata(URL);
+    expect(after).toEqual(fresh);
+    expect(after?.hideMeta).toBe(true); // the flipped value is now served
+  });
+
+  it('swallows a Redis del error (best-effort bust never throws)', async () => {
+    redisDel.mockRejectedValueOnce(new Error('redis down'));
+    await expect(bustImageDeliveryMetadataCache(URL)).resolves.toBeUndefined();
+  });
+});

--- a/src/server/services/__tests__/update-post-image-hidemeta-bust.test.ts
+++ b/src/server/services/__tests__/update-post-image-hidemeta-bust.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Wiring test for the image-delivery metadata cache bust in `updatePostImage`.
+ *
+ * The bust FUNCTION is unit-tested in isolation (image-delivery-metadata-cache.test.ts);
+ * this asserts the PRIVACY WIRING — that `updatePostImage` actually calls the bust on a
+ * `hideMeta` change, in BOTH directions, and does NOT call it when hideMeta is unchanged
+ * or omitted. That both-direction guarantee is the entire privacy argument: the adjacent
+ * `purgeResizeCache` guard only fires on hide (`image.hideMeta &&`), so a future edit that
+ * copies that guard onto the bust would silently stop busting on `true -> false` and stay
+ * green without this test.
+ *
+ * post.service sits at the top of the service dependency graph, so the module-load scaffold
+ * below mocks every sibling-service + infra import it pulls, mirroring
+ * contest-entry-resource-gate.test.ts's approach (redis/db/kysely short-circuits) — the
+ * minimal set needed to import post.service without kysely/@civitai/db or the heavy
+ * image.service graph.
+ */
+
+const IMAGE_ID = 9001;
+const IMAGE_URL = 'abc123/def456.jpeg';
+const USER_ID = 5;
+
+const { mockFindUniqueOrThrow, mockImageUpdate, mockBustImageDeliveryMetadataCache } = vi.hoisted(
+  () => ({
+    mockFindUniqueOrThrow: vi.fn(),
+    mockImageUpdate: vi.fn(),
+    mockBustImageDeliveryMetadataCache: vi.fn(),
+  })
+);
+
+// --- infra scaffold (mirrors contest-entry-resource-gate.test.ts) ---------------------
+vi.mock('~/server/redis/client', () => {
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  const keyProxy = make();
+  return {
+    redis: { get: vi.fn(), set: vi.fn(), del: vi.fn(), packed: { get: vi.fn(), set: vi.fn() } },
+    sysRedis: { get: vi.fn(), set: vi.fn() },
+    REDIS_KEYS: keyProxy,
+    REDIS_SYS_KEYS: keyProxy,
+    REDIS_SUB_KEYS: keyProxy,
+    withSysReadDeadline: vi.fn((p) => p),
+  };
+});
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('@civitai/db', () => ({
+  createLagTracker: vi.fn(() => ({})),
+  loadDbEnv: vi.fn(() => ({})),
+}));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {} }));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  getDbWithoutLag: vi.fn(),
+  preventReplicationLag: vi.fn(),
+  preventReplicationLagBatch: vi.fn(),
+}));
+vi.mock('~/server/search-index', () => ({}));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: {} }));
+
+// dbWrite is the only DB surface updatePostImage touches (findUniqueOrThrow + update).
+vi.mock('~/server/db/client', () => ({
+  dbRead: {},
+  dbWrite: { image: { findUniqueOrThrow: mockFindUniqueOrThrow, update: mockImageUpdate } },
+}));
+
+// Every cache post.service imports — each a stub whose methods are no-op vi.fns. (Named
+// exports must be statically present for ESM import binding; a Proxy has no own keys.)
+vi.mock('~/server/redis/caches', () => {
+  const cacheStub = () => ({
+    refresh: vi.fn().mockResolvedValue(undefined),
+    bust: vi.fn().mockResolvedValue(undefined),
+    fetch: vi.fn(),
+    refreshMany: vi.fn(),
+  });
+  return {
+    imageMetaCache: cacheStub(),
+    imageResourcesCache: cacheStub(),
+    modelVersionAccessCache: cacheStub(),
+    postStatCache: cacheStub(),
+    thumbnailCache: cacheStub(),
+    imageMetadataCache: cacheStub(),
+    userBasicCache: cacheStub(),
+    userImageVideoCountCaches: cacheStub(),
+    userPostCountCache: cacheStub(),
+  };
+});
+
+// The heavy image.service graph — replaced wholesale with the named exports post.service
+// imports. `purgeResizeCache` is spied so we can assert the hide-only path independently.
+vi.mock('~/server/services/image.service', () => ({
+  createImage: vi.fn(),
+  createImageResources: vi.fn(),
+  deleteImageFromS3: vi.fn(),
+  deleteImagesForModelVersionCache: vi.fn(),
+  getImagesForPosts: vi.fn(),
+  imagesForModelVersionsCache: { refresh: vi.fn() },
+  enqueueImageIngestion: vi.fn(),
+  invalidateManyImageExistence: vi.fn(),
+  purgeImageGenerationDataCache: vi.fn(),
+  purgeResizeCache: vi.fn().mockResolvedValue(undefined),
+  queueImageSearchIndexUpdate: vi.fn(),
+}));
+
+// The unit under scrutiny: spy the bust so we can assert exactly when/whether it fires.
+vi.mock('~/server/services/image-delivery.service', () => ({
+  bustImageDeliveryMetadataCache: mockBustImageDeliveryMetadataCache.mockResolvedValue(undefined),
+}));
+
+// Other sibling services post.service imports — mocked so their graphs aren't evaluated.
+vi.mock('~/server/services/collection.service', () => ({
+  getCollectionById: vi.fn(),
+  getUserCollectionPermissionsById: vi.fn(),
+  removeEntityFromAllCollections: vi.fn(),
+}));
+vi.mock('~/server/services/cosmetic.service', () => ({ getCosmeticsForEntity: vi.fn() }));
+vi.mock('~/server/services/post-collection-visibility', () => ({ canViewCollectionPost: vi.fn() }));
+vi.mock('~/server/services/tag.service', () => ({
+  findOrCreateTagsByName: vi.fn(),
+  getVotableImageTags: vi.fn(),
+}));
+vi.mock('~/server/services/technique.service', () => ({ getTechniqueByName: vi.fn() }));
+vi.mock('~/server/services/tool.service', () => ({
+  getToolByAlias: vi.fn(),
+  getToolByDomain: vi.fn(),
+  getToolByName: vi.fn(),
+}));
+vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));
+
+// isValidAIGeneration is called before shouldIngest; keep it deterministic. shouldIngest is
+// forced false via currentImage.blockedFor below, so its value doesn't affect the bust path.
+vi.mock('~/utils/image-utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/utils/image-utils')>();
+  return { ...actual, isValidAIGeneration: vi.fn(() => true) };
+});
+
+const { updatePostImage } = await import('~/server/services/post.service');
+
+const KEY_URL = IMAGE_URL;
+
+// Build a currentImage row. blockedFor is anything BUT AiNotVerified so shouldIngest=false
+// (no enqueueImageIngestion side effect on this path).
+function wireCurrentImage(hideMeta: boolean) {
+  mockFindUniqueOrThrow.mockResolvedValue({
+    hideMeta,
+    ingestion: 'Scanned',
+    blockedFor: null,
+    metadata: {},
+    nsfwLevel: 1,
+  });
+  mockImageUpdate.mockResolvedValue({ id: IMAGE_ID, url: IMAGE_URL, userId: USER_ID });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBustImageDeliveryMetadataCache.mockResolvedValue(undefined);
+});
+
+describe('updatePostImage — image-delivery metadata cache bust wiring', () => {
+  it('busts on a false -> true hideMeta flip (privacy-sensitive direction)', async () => {
+    wireCurrentImage(false); // stored hideMeta = false
+
+    await updatePostImage({ id: IMAGE_ID, hideMeta: true } as any); // flip to true
+
+    expect(mockBustImageDeliveryMetadataCache).toHaveBeenCalledTimes(1);
+    expect(mockBustImageDeliveryMetadataCache).toHaveBeenCalledWith(KEY_URL);
+  });
+
+  it('ALSO busts on a true -> false hideMeta flip (both-direction guarantee)', async () => {
+    wireCurrentImage(true); // stored hideMeta = true
+
+    await updatePostImage({ id: IMAGE_ID, hideMeta: false } as any); // flip to false (reveal)
+
+    // This is the case the adjacent purgeResizeCache guard MISSES — the bust must still fire.
+    expect(mockBustImageDeliveryMetadataCache).toHaveBeenCalledTimes(1);
+    expect(mockBustImageDeliveryMetadataCache).toHaveBeenCalledWith(KEY_URL);
+  });
+
+  it('does NOT bust when hideMeta is unchanged (same value passed)', async () => {
+    wireCurrentImage(false); // stored hideMeta = false
+
+    await updatePostImage({ id: IMAGE_ID, hideMeta: false } as any); // no change
+
+    expect(mockBustImageDeliveryMetadataCache).not.toHaveBeenCalled();
+  });
+
+  it('does NOT bust when hideMeta is omitted from the update', async () => {
+    wireCurrentImage(false); // stored hideMeta = false
+
+    await updatePostImage({ id: IMAGE_ID } as any); // hideMeta not part of the update
+
+    expect(mockBustImageDeliveryMetadataCache).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/image-delivery.service.ts
+++ b/src/server/services/image-delivery.service.ts
@@ -1,0 +1,106 @@
+import { CacheTTL } from '~/server/common/constants';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { dbReadFallbackCounter } from '~/server/prom/client';
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+
+// The row shape returned by the internal image-delivery endpoint. `hideMeta` gates whether
+// the delivery/resize path embeds the image's generation metadata (EXIF) in the served
+// bytes — it controls METADATA VISIBILITY, not access to the image itself.
+export type ImageDeliveryMetadata = { id: number; url: string; hideMeta: boolean };
+
+// Cache key for the `url -> {id, url, hideMeta}` lookup. The origin query is
+// `WHERE url = $1`, which is CASE- and WHITESPACE-SENSITIVE, so — unlike the citext tag
+// cache — the key must be the EXACT url string, never lowercased or trimmed. Trimming or
+// case-folding here would let a different url collide onto another image's cached row and
+// serve the wrong { id, hideMeta }.
+const getImageDeliveryMetadataCacheKey = (url: string) =>
+  `${REDIS_KEYS.CACHES.IMAGE_DELIVERY_METADATA}:${url}` as `${typeof REDIS_KEYS.CACHES.IMAGE_DELIVERY_METADATA}:${string}`;
+
+// Origin read: the single-row `Image WHERE url = $1` lookup, with the endpoint's existing
+// dbRead -> dbWrite (primary) fallback preserved so a read-replica error still resolves.
+const queryImageDeliveryMetadata = async (url: string): Promise<ImageDeliveryMetadata | null> => {
+  const [image] = await dbRead
+    .$queryRaw<ImageDeliveryMetadata[]>`
+      SELECT
+        id,
+        url,
+        "hideMeta"
+      FROM "Image"
+      WHERE url = ${url}
+      LIMIT 1
+    `
+    .catch(() => {
+      dbReadFallbackCounter.inc({ entity: 'image', caller: 'imageDelivery' });
+      return dbWrite.$queryRaw<ImageDeliveryMetadata[]>`
+        SELECT
+          id,
+          url,
+          "hideMeta"
+        FROM "Image"
+        WHERE url = ${url}
+        LIMIT 1
+      `;
+    });
+
+  return image ?? null;
+};
+
+// Read-through cache over the near-immutable url -> {id, url, hideMeta} lookup — the hot
+// caller of the highest-volume DB query in the profile (`Image WHERE url = $1`). Output is
+// byte-identical to the raw query. Bucket A: DB total-exec-time / call-count reduction only,
+// no behaviour change — the DB runs ~4% CPU, so this is a pod-neutral cost/margin win, NOT a
+// capacity win. This offloads ONLY the image-delivery endpoint's calls; the same query has
+// other callers (feed hydration, scanning) that are untouched.
+//
+// Fail-open like `fetchThroughCache`: on any Redis error we degrade to the origin query
+// (this is a hot path — ~9.2 req/s at peak — so a Redis stall must not 500). No distributed
+// stampede lock: the origin is a single-row indexed lookup that at worst runs once per url
+// per TTL, so a brief cold-key stampede is trivially cheap — not worth the lock's extra
+// Redis round-trips on the hot read (mirrors `getTagWithModelCount`).
+//
+// NEGATIVE RESULTS ARE NOT CACHED: an unknown url always re-hits the DB, so a newly
+// registered image resolves immediately (no register-then-deliver staleness). This also
+// shrinks invalidation to writers that change an EXISTING image's cached shape.
+//
+// STALENESS: `hideMeta` can flip. The privacy-sensitive direction (false -> true, the owner
+// hiding their prompt) is busted explicitly in `updatePostImage` (co-located with its
+// existing `purgeResizeCache`), so an app-path flip takes effect at once. An out-of-band
+// flip (mod tooling / direct DB) lags at most TTL; because the delivered image BYTES are
+// still separately purged/CDN-managed and this value only gates embedded-metadata
+// visibility, a bounded ≤TTL window is acceptable. TTL is deliberately short (3 min) to keep
+// that window tight.
+export const getCachedImageDeliveryMetadata = async (
+  url: string
+): Promise<ImageDeliveryMetadata | null> => {
+  const key = getImageDeliveryMetadataCacheKey(url);
+
+  try {
+    const cached = await redis.packed.get<ImageDeliveryMetadata>(key);
+    if (cached) return cached;
+  } catch {
+    // Redis read degraded — fall through to the origin query (fail open).
+  }
+
+  const result = await queryImageDeliveryMetadata(url);
+
+  if (result) {
+    try {
+      await redis.packed.set(key, result, { EX: CacheTTL.sm });
+    } catch {
+      // Best-effort cache write; a Redis stall here never fails the request.
+    }
+  }
+
+  return result;
+};
+
+// Bust a single url key. Hard delete (not a staleness reset): because we never cache
+// negatives, deleting the key means the next read re-queries and re-populates the fresh row.
+// Called by `updatePostImage` when `hideMeta` changes.
+export const bustImageDeliveryMetadataCache = async (url: string) => {
+  try {
+    await redis.del(getImageDeliveryMetadataCacheKey(url));
+  } catch {
+    // Best-effort bust; the TTL bounds any residual staleness.
+  }
+};

--- a/src/server/services/post.service.ts
+++ b/src/server/services/post.service.ts
@@ -54,6 +54,7 @@ import {
   purgeResizeCache,
   queueImageSearchIndexUpdate,
 } from '~/server/services/image.service';
+import { bustImageDeliveryMetadataCache } from '~/server/services/image-delivery.service';
 import { findOrCreateTagsByName, getVotableImageTags } from '~/server/services/tag.service';
 import { getTechniqueByName } from '~/server/services/technique.service';
 import { getToolByAlias, getToolByDomain, getToolByName } from '~/server/services/tool.service';
@@ -1380,6 +1381,14 @@ export const updatePostImage = async (image: UpdatePostImageInput) => {
   ];
   if (image.hideMeta && currentImage && currentImage.hideMeta !== image.hideMeta) {
     cacheRefreshPromises.push(purgeResizeCache({ url: result.url }));
+  }
+  // Bust the image-delivery metadata cache on ANY hideMeta change (both directions): that
+  // cache serves { hideMeta } to the delivery/resize path, and a stale value would keep
+  // embedding (or keep stripping) generation metadata for up to its TTL. The privacy-
+  // sensitive direction (false -> true) is the reason this bust is explicit rather than
+  // TTL-bounded.
+  if (image.hideMeta !== undefined && currentImage && currentImage.hideMeta !== image.hideMeta) {
+    cacheRefreshPromises.push(bustImageDeliveryMetadataCache(result.url));
   }
   await Promise.all(cacheRefreshPromises);
 


### PR DESCRIPTION
## Lever

`GET /api/internal/image-delivery/[id]` runs, on **every request (~9.2 req/s at peak)**, one uncached raw `SELECT id, url, "hideMeta" FROM "Image" WHERE url = $1 LIMIT 1`. That `Image WHERE url = $1` single-row lookup is the **highest-volume DB query in the profile (~788M cumulative calls)**, and this endpoint is its hot caller. This adds a Redis read-through in front of it.

## Mechanism / TTL / key

- **Read-through** over the `url -> {id, url, hideMeta}` lookup via `redis.packed` (same store `fetchThroughCache` uses), in a new `image-delivery.service.ts`. Mirrors the `getTagWithModelCount` (#3229) precedent exactly: `redis.packed.get` -> on miss run the origin query -> `redis.packed.set`.
- **Key:** `REDIS_KEYS.CACHES.IMAGE_DELIVERY_METADATA` + `:` + the **exact url string**. Unlike the citext tag cache, the origin `WHERE url = $1` is **case- and whitespace-SENSITIVE**, so the key is the raw url — **never** lowercased or trimmed. Normalizing would let a different url collide onto another image's cached `{ id, hideMeta }` and serve the wrong row. (A test asserts an uppercased variant is a MISS, not a collision.)
- **TTL:** `CacheTTL.sm` = **180s (3 min)**. Deliberately short (vs. the tag cache's 1h) to bound `hideMeta` staleness tight — see below.
- **Fail-open:** any Redis error (read or write) degrades to the origin query; the DB `dbRead -> dbWrite` primary fallback is preserved. A Redis stall on this hot path must never 500. No distributed stampede lock — the origin is a single-row indexed lookup, so a brief cold-key stampede is trivially cheap (mirrors #3229's reasoning).
- **No flag gate**, following the #3229 static-read-through precedent (fail-open already degrades safely).

## Negative-result decision: do NOT cache empties

An unknown url returns `null` and is **never cached**, so a newly registered image resolves immediately (no register-then-deliver staleness), and the invalidation surface shrinks to writers that change an **existing** image's cached shape.

## hideMeta staleness argument

`hideMeta` on this delivery path gates whether the delivery/resize worker **embeds the image's generation metadata (EXIF) in the served bytes** — it controls **metadata visibility, not access to the image bytes themselves** (confirmed: `updatePostImage` calls `purgeResizeCache` on a `hideMeta` flip, re-deriving the served variant with metadata stripped).

- The **privacy-sensitive direction** (`false -> true`, an owner hiding their prompt) is **busted explicitly** in `updatePostImage`, co-located with the existing `purgeResizeCache` call, on **any** `hideMeta` change. So an app-path flip takes effect at once — no ≤TTL leak window.
- An **out-of-band** flip (mod tooling / direct DB) lags at most **TTL (≤3 min)**. Because the delivered bytes are separately purged/CDN-managed and the cached value only gates embedded-metadata visibility, a bounded ≤3-min window is acceptable.
- **Image delete** similarly lags ≤TTL for a positive cached entry (delivery of a deleted image's url), self-healing at TTL; the bytes are separately purged.

## Scope honesty

This caches **only the image-delivery endpoint's calls** (~9.2/s -> ~795k/day offloaded). The same `Image WHERE url = $1` query has **other callers** (feed hydration, scanning) that are **not touched** here — this does **not** eliminate all ~788M cumulative calls, only the image-delivery slice.

## Cost framing: pod-neutral, NOT capacity

Bucket A. The DB runs ~4% CPU, so this is a **pod-neutral cost/margin** win (less DB total-exec-time / fewer calls), **not** a capacity win. Output is **byte-identical** to the uncached response (status, headers, body).

## Tests

New `image-delivery-metadata-cache.test.ts` (14 tests, mirroring #3229's msgpackr-round-trip rig — real `pack`/`unpack` codec, real Map hit/miss): cache-hit skips DB, byte-identical output through the real codec (incl. `hideMeta:true`), exact-url keying (no collision), exact url passed to the WHERE, short-TTL set, negative results not cached + immediately findable, fail-open on Redis read error, request still succeeds on Redis write error, dbRead->dbWrite primary fallback, and bust (deletes the exact key + swallows del errors).

`tsc --noEmit`: clean on all touched files (the only remaining errors are pre-existing `kysely` module-resolution in untouched `packages/civitai-db*`, an environmental workspace-node_modules artifact). No `any` introduced.
