### PR TITLE
perf(auction): cache getAll to cut primary-DB load

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2055,6 +2055,16 @@ export const REDIS_KEYS = {
     // call (~1174ms in EXPLAIN ANALYZE); the total is a slowly-moving aggregate so
     // a few-minutes-stale value in totalItems/totalPages is harmless.
     CREATORS_COUNT: 'packed:caches:creators-count',
+    // The user-independent active-auction list backing `auction.getAll` (~21.8
+    // calls/s at peak, hitting the PRIMARY DB `dbWrite`). Output is a single global
+    // `{ id, auctionBase, lowestBidRequired }[]` with no per-user/ctx variance, so
+    // one global key serves everyone. Short TTL (30s), no bust: the set is time-
+    // windowed (startAt<=now<endAt, transitions bounded to <=30s) and the frequently-
+    // mutating input is bids (each shifts lowestBidRequired) — busting per-bid at
+    // ~21/s would defeat the cache, and a slightly-stale lowestBidRequired is display-
+    // only (bid submission re-validates the true minimum server-side). See
+    // `getAllAuctions` in auction.service.
+    ACTIVE_AUCTIONS: 'packed:caches:active-auctions',
   },
   RESEARCH: {
     RATINGS_COUNT: 'research:ratings-count',

--- a/src/server/services/__tests__/auction-getall-cache.test.ts
+++ b/src/server/services/__tests__/auction-getall-cache.test.ts
@@ -1,0 +1,201 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { pack, unpack } from 'msgpackr';
+
+// Backing store for the fake cache-cluster Redis. Values are stored as msgpackr-PACKED
+// Buffers and unpacked on read — the SAME codec the real `redis.packed` client uses
+// (set -> pack(value), get -> unpack(buffer)) — so the byte-identical claim is exercised
+// through the real serializer end-to-end, not a pass-through fake. Cache hit/miss
+// semantics stay real (a Map), letting us assert exactly when the origin DB query re-runs.
+const {
+  store,
+  auctionFindMany,
+  redisPackedGet,
+  redisPackedSet,
+  redisSetNxKeepTtlWithEx,
+  redisDel,
+} = vi.hoisted(() => ({
+  store: new Map<string, Buffer>(),
+  auctionFindMany: vi.fn(),
+  redisPackedGet: vi.fn(),
+  redisPackedSet: vi.fn(),
+  redisSetNxKeepTtlWithEx: vi.fn(),
+  redisDel: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  // `getAllAuctionsUncached` reads the PRIMARY DB (`dbWrite`) — that's the load this
+  // cache removes, so the win is asserted by counting calls to THIS mock.
+  dbWrite: { auction: { findMany: auctionFindMany } },
+  dbRead: {},
+}));
+
+// Cut the heavy sibling-service import graph (image.service pulls the event-engine-common
+// submodule; notification/signal pull their own env graphs). None are exercised by
+// getAllAuctions / getAllAuctionsUncached, so stubbing the used exports is safe and keeps
+// the test a focused unit of the cache path.
+vi.mock('~/server/services/image.service', () => ({ getImagesForModelVersionCache: vi.fn() }));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/utils/signal-client', () => ({ signalClient: { send: vi.fn(), topicSend: vi.fn() } }));
+// The fail-open logger pulls `safeError` from `~/server/logging/client`, which the global
+// test setup mocks only partially. Stub it to a no-op — we assert the fail-open BEHAVIOUR
+// (origin fetch still returns), not the log line.
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+
+// Keep the real REDIS_KEYS (so the key we build matches the production constant) and only
+// swap the live client for the in-memory fake. `fetchThroughCache` uses
+// `redis.packed.{get,set}`, `redis.setNxKeepTtlWithEx` (stampede lock), and `redis.del`.
+vi.mock('~/server/redis/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/redis/client')>();
+  return {
+    ...actual,
+    redis: {
+      packed: { get: redisPackedGet, set: redisPackedSet },
+      setNxKeepTtlWithEx: redisSetNxKeepTtlWithEx,
+      del: redisDel,
+    },
+  };
+});
+
+import {
+  getAllAuctions,
+  getAllAuctionsUncached,
+} from '~/server/services/auction.service';
+import { REDIS_KEYS } from '~/server/redis/client';
+
+const KEY = REDIS_KEYS.CACHES.ACTIVE_AUCTIONS; // 'packed:caches:active-auctions'
+
+// A representative active-auction row set exactly as `dbWrite.auction.findMany` returns
+// it (only the fields `getAllAuctionsUncached` / `prepareBids` read). `auctionBase` is an
+// opaque object passed straight through to the output — it must survive byte-identically
+// through the cache. Returned FRESH per call so the in-place `.sort()` in the origin can't
+// mutate a shared fixture across calls.
+const makeAuctionRows = () => [
+  {
+    id: 1,
+    minPrice: 100,
+    quantity: 1,
+    auctionBase: { id: 10, ecosystem: 'sd1', name: 'SD1' },
+    bids: [
+      { deleted: false, entityId: 5, amount: 150 },
+      { deleted: false, entityId: 6, amount: 120 },
+    ],
+  },
+  {
+    id: 2,
+    minPrice: 50,
+    quantity: 2,
+    auctionBase: { id: 20, ecosystem: 'sdxl', name: 'SDXL' },
+    bids: [{ deleted: false, entityId: 7, amount: 30 }],
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  store.clear();
+  auctionFindMany.mockImplementation(async () => makeAuctionRows());
+
+  // Real msgpackr round-trip: set packs the `{ data, cachedAt }` wrapper to a Buffer, get
+  // unpacks it — mirrors the production `redis.packed` codec so serializer fidelity is
+  // actually under test on the hit path.
+  redisPackedGet.mockImplementation(async (key: string) => {
+    const buf = store.get(key);
+    return buf ? unpack(buf) : null;
+  });
+  redisPackedSet.mockImplementation(async (key: string, value: unknown) => {
+    store.set(key, pack(value));
+  });
+  // Single-threaded test: the stampede lock is always free.
+  redisSetNxKeepTtlWithEx.mockResolvedValue(true);
+  redisDel.mockImplementation(async (key: string) => {
+    store.delete(key);
+    return 1;
+  });
+});
+
+describe('getAllAuctions — short-TTL read-through cache', () => {
+  it('serves the second call from cache without re-hitting the PRIMARY DB', async () => {
+    const first = await getAllAuctions();
+    const second = await getAllAuctions();
+
+    expect(auctionFindMany).toHaveBeenCalledTimes(1); // the win: one DB read, not two
+    expect(first).toEqual(second);
+    expect(redisPackedSet).toHaveBeenCalledTimes(1);
+    // One global key serves every caller — the payload has no per-user/ctx variance.
+    expect(redisPackedGet).toHaveBeenCalledWith(KEY, expect.anything());
+  });
+
+  it('returns output byte-identical to the uncached origin, through the real codec', async () => {
+    const cached = await getAllAuctions();
+    const uncached = await getAllAuctionsUncached();
+
+    // Same array shape + values (id / auctionBase passthrough / computed lowestBidRequired).
+    expect(cached).toEqual(uncached);
+    expect(cached).toEqual([
+      { id: 1, auctionBase: { id: 10, ecosystem: 'sd1', name: 'SD1' }, lowestBidRequired: 151 },
+      { id: 2, auctionBase: { id: 20, ecosystem: 'sdxl', name: 'SDXL' }, lowestBidRequired: 50 },
+    ]);
+
+    // Prove byte-identity THROUGH the real msgpackr codec: unpack the actual stored Buffer
+    // and assert every field survives the serializer (the `{data,cachedAt}` wrapper, the
+    // passthrough auctionBase object, the computed integer lowestBidRequired).
+    const buf = store.get(KEY);
+    expect(Buffer.isBuffer(buf)).toBe(true);
+    const wrapper = unpack(buf!) as { data: unknown; cachedAt: number };
+    expect(wrapper.data).toEqual(cached);
+    expect(typeof wrapper.cachedAt).toBe('number');
+  });
+
+  describe('TTL / staleness (30s)', () => {
+    beforeEach(() => vi.useFakeTimers());
+    afterEach(() => vi.useRealTimers());
+
+    it('serves the stale cached value within the TTL even after the DB changes', async () => {
+      const first = await getAllAuctions();
+      expect(first[0].lowestBidRequired).toBe(151);
+
+      // The DB now reflects a higher winning bid — but a cached read within 30s must NOT
+      // see it (this is the display-only staleness the cache trades for the load cut).
+      auctionFindMany.mockImplementation(async () => {
+        const rows = makeAuctionRows();
+        rows[0].bids.push({ deleted: false, entityId: 8, amount: 500 });
+        return rows;
+      });
+
+      vi.advanceTimersByTime(29_000); // < 30s TTL
+      const second = await getAllAuctions();
+
+      expect(second).toEqual(first); // still the stale value
+      expect(auctionFindMany).toHaveBeenCalledTimes(1); // DB not re-read
+    });
+
+    it('re-queries the DB once the TTL has elapsed', async () => {
+      await getAllAuctions();
+
+      auctionFindMany.mockImplementation(async () => {
+        const rows = makeAuctionRows();
+        rows[0].bids.push({ deleted: false, entityId: 8, amount: 500 });
+        return rows;
+      });
+
+      vi.advanceTimersByTime(31_000); // > 30s TTL
+      const afterExpiry = await getAllAuctions();
+
+      expect(auctionFindMany).toHaveBeenCalledTimes(2); // origin re-read after expiry
+      // entity8's 500 now wins -> lowestBidRequired = 501 (fresh value served).
+      expect(afterExpiry[0].lowestBidRequired).toBe(501);
+    });
+  });
+
+  it('fails OPEN to the origin on a Redis read error (no new failure mode)', async () => {
+    redisPackedGet.mockRejectedValueOnce(new Error('redis down'));
+
+    const result = await getAllAuctions();
+
+    // Degrades to a slow-but-correct origin fetch rather than throwing.
+    expect(auctionFindMany).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      { id: 1, auctionBase: { id: 10, ecosystem: 'sd1', name: 'SD1' }, lowestBidRequired: 151 },
+      { id: 2, auctionBase: { id: 20, ecosystem: 'sdxl', name: 'SDXL' }, lowestBidRequired: 50 },
+    ]);
+  });
+});

--- a/src/server/services/auction.service.ts
+++ b/src/server/services/auction.service.ts
@@ -5,6 +5,8 @@ import { getModelTypesForAuction, miscAuctionName } from '~/components/Auction/a
 import { NotificationCategory, SignalMessages, SignalTopic } from '~/server/common/enums';
 import { dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
+import { REDIS_KEYS } from '~/server/redis/client';
+import { fetchThroughCache } from '~/server/utils/cache-helpers';
 import type {
   DetailsCanceledBid,
   DetailsDroppedOutAuction,
@@ -87,7 +89,12 @@ type AuctionSelectType = Prisma.AuctionGetPayload<typeof auctionValidator>;
 
 export type GetAllAuctionsReturn = AsyncReturnType<typeof getAllAuctions>;
 
-export async function getAllAuctions() {
+// The origin (uncached) fetch: reads the active-auction set from the PRIMARY DB
+// (`dbWrite`) and reduces each to `{ id, auctionBase, lowestBidRequired }`. The
+// output is fully user-independent (no `ctx`/`userId`) — the requiredScope on the
+// router gates ACCESS, not the payload — so a single global cache entry is correct
+// for every caller. Kept as a separate export so tests can assert cache-hit skips it.
+export async function getAllAuctionsUncached() {
   const now = new Date();
 
   const aData = await dbWrite.auction.findMany({
@@ -125,6 +132,25 @@ export async function getAllAuctions() {
       auctionBase: ad.auctionBase,
       lowestBidRequired,
     };
+  });
+}
+
+// Short-TTL (30s) read-through over the user-independent active-auction list to cut
+// load on the PRIMARY DB (`getAllAuctionsUncached` reads `dbWrite`), which
+// `auction.getAll` hits ~21.8x/s at peak. Output is byte-identical to the uncached
+// path; the only delta is up-to-30s staleness. That is safe here:
+//   - the active set is time-windowed (startAt<=now<endAt); a <=30s lag in an
+//     auction appearing/disappearing is imperceptible, and
+//   - `lowestBidRequired` is a DISPLAY hint — bid submission re-validates the true
+//     minimum server-side (`createBid`), so a slightly-stale value can't let an
+//     under-minimum bid through.
+// No bust: the frequently-mutating input is bids (~21/s), so busting per-bid would
+// defeat the cache; auction create/close happens in the daily `handle-auctions` job
+// and is already bounded by the 30s TTL. `fetchThroughCache` fails OPEN to the origin
+// on a Redis error, so this never adds a failure mode over the uncached path.
+export async function getAllAuctions() {
+  return fetchThroughCache(REDIS_KEYS.CACHES.ACTIVE_AUCTIONS, getAllAuctionsUncached, {
+    ttl: 30,
   });
 }
 


### PR DESCRIPTION
## Lever

`auction.getAll` (`publicProcedure` → `getAllAuctions`, ~21.8 calls/s at peak) ran **uncached** against the **PRIMARY DB** (`dbWrite.auction.findMany`) on every call. Its output is a single global `{ id, auctionBase, lowestBidRequired }[]` with **no per-user/ctx variance** (the `requiredScope` gates ACCESS, not the payload), so it's an ideal read-through cache target.

## STEP 0 — the commented-out `edgeCacheIt`

`auction.router.ts` carries a `// .use(edgeCacheIt({ ttl: CacheTTL.hour }))` line. I traced its history (`git log -p -S edgeCacheIt`): it has been **commented-out since the file was first created** (Feb 2025, "all the auction things!") — it was **never enabled and never disabled**, i.e. there is **no correctness reason on record** for keeping edge-cache off; it's a leftover placeholder.

That line is a **public CDN edge-cache** anyway (a different mechanism), and it's left untouched here. This PR adds a **server-side** short-TTL read-through, which is safe independent of the edge-cache question: I confirmed the payload has no per-user/ctx variance (the function takes no args and reads no `ctx`), so one global entry is correct for every caller.

## Mechanism / TTL

A 30s `fetchThroughCache` under a new global key `REDIS_KEYS.CACHES.ACTIVE_AUCTIONS` (`packed:caches:active-auctions`). The origin fetch is factored out as `getAllAuctionsUncached` (exported so tests can assert a cache hit skips it).

- **Short TTL (30s), no bust.** The frequently-mutating input is **bids** (each shifts `lowestBidRequired`), so busting per-bid at ~21/s would defeat the cache. Auction create/close happens in the daily `handle-auctions` job and is already bounded by the 30s TTL. A short TTL is the right trade here vs. full invalidation.
- **Fails OPEN.** `fetchThroughCache` degrades to a slow-but-correct origin fetch on a Redis error, so this adds **no new failure mode** over the uncached path.

## Byte-identical / staleness (Bucket A)

Output is **byte-identical** to the uncached path. The only delta is **≤30s staleness**, and it's **display-only**:

- The active set is **time-windowed** (`startAt <= now < endAt`); a ≤30s lag in an auction appearing/disappearing is imperceptible.
- `lowestBidRequired` is a **UI hint**, not a server-side gate. `createBid` re-reads the auction fresh from the DB (`dbWrite.auction.findFirst`) and validates amount / model-version / balance independently of any cached display value; winner determination is computed server-side from fresh bids. So a slightly-stale `lowestBidRequired` cannot let an invalid bid through — it can only make the UI's suggested minimum momentarily off.

## Impact — cost/margin, not capacity

The win is **PRIMARY-DB `total_exec_time` / call-count removed**, not pods. The DB runs at ~4% CPU, so this is a **pod-neutral cost/margin win, NOT a capacity win** — no pod reduction is claimed.

## Tests (5 pass)

New `src/server/services/__tests__/auction-getall-cache.test.ts` (fake cache-cluster Redis backed by the **real msgpackr codec**, so byte-identity is exercised end-to-end):

- second call served from cache **without re-hitting the PRIMARY DB** (1 `findMany` for 2 calls); one global key serves every caller;
- output **byte-identical** to `getAllAuctionsUncached`, proven by unpacking the actual stored Buffer through the real codec;
- **staleness within TTL** — a DB change is NOT seen within 30s (stale value served, DB not re-read);
- **TTL expiry** — the origin is re-queried once >30s elapses and the fresh value is served;
- **fail-open** — a Redis read error degrades to the origin fetch (correct output, no throw).

`NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` → **exit 0, 0 errors**. No `any` introduced.

## Caveat

30s of `lowestBidRequired` display staleness is the only behavioural delta (argued display-only above). If a future path ever needs the auction list fresh-to-the-second on the server, this cache would need a bust hook — none exists today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
