### PR TITLE
perf(model-version): cache public donationGoals to cut DB load

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2019,6 +2019,7 @@ export const REDIS_KEYS = {
     USER_FOLLOWS: 'packed:caches:user-follows',
     MODEL_TAGS: 'packed:caches:model-tags',
     MODEL_VOTABLE_TAGS: 'packed:caches:model-votable-tags',
+    MODEL_VERSION_PUBLIC_DONATION_GOALS: 'packed:caches:model-version-public-donation-goals',
     IMAGE_TAGS: 'packed:caches:image-tags',
     MODEL_VERSION_RESOURCE_INFO: 'packed:caches:model-version-resource-info',
     TENSOR_METADATA: 'packed:caches:tensor-metadata',

--- a/src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts
+++ b/src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts
@@ -1,24 +1,22 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * Mechanism contract for `modelVersionPublicDonationGoalsCache` — the DB-load-reduction lever
- * behind `model-version.donationGoals` on the public path.
+ * Mechanism + lookup contract for `modelVersionPublicDonationGoalsCache` — the DB-load-reduction
+ * lever behind `model-version.donationGoals` on the public path.
  *
- * The cache is a `createCachedObject` keyed by modelVersionId with a 60s TTL and
- * `cacheNotFound: false`. This test exercises the REAL cache mechanism against an in-memory
- * packed-redis double + mocked db doubles and pins:
+ * This exercises the REAL lookupFn (`publicDonationGoalsLookupFn` from the light
+ * `donation-goals-cache` module — the exact function `caches.ts` wires into the cache) against
+ * an in-memory packed-redis double + mocked db doubles. No hand-copied mirror: if someone drops
+ * the security-relevant `active: true` public filter (the single guard keeping inactive/draft
+ * goals out of the shared public key), the `active: true` assertion below fails.
+ *
+ * Pins:
+ *   - the PUBLIC `active: true` goal filter is present on the real query (security invariant);
  *   - dedup/TTL: a second fetch of the same id within the TTL does NOT re-issue the DB lookup;
- *   - existence: an existing version with zero public goals yields an EMPTY entry (caller
- *     returns []), while a genuinely-missing version yields NO entry (caller 404s) and is NOT
- *     negatively cached (re-looked-up next time, per `cacheNotFound: false`);
- *   - the public early-access filter and the summed totals shape.
- *
- * DIVERGENCE RISK: importing the real `modelVersionPublicDonationGoalsCache` from caches.ts
- * would drag in its env/clickhouse/orchestrator import graph, so this replicates its lookupFn.
- * Keep this a FAITHFUL mirror of caches.ts `modelVersionPublicDonationGoalsCache.lookupFn` —
- * same existence + primary-fallback, same `active: true` public filter, same early-access
- * filter, same totals map, same "seed an empty entry per existing version". Change one, change
- * both.
+ *   - existence: an existing version with zero public goals yields an EMPTY entry (caller → []),
+ *     while a genuinely-missing version yields NO entry (caller → 404) and is NOT negatively
+ *     cached (re-looked-up next time, per `cacheNotFound: false`);
+ *   - the per-version early-access filter and the summed totals shape.
  */
 
 const store = new Map<string, unknown>();
@@ -41,7 +39,6 @@ vi.mock('~/server/redis/client', () => ({
   sysRedis: {},
   REDIS_KEYS: { CACHE_LOCKS: 'caches:lock' },
 }));
-
 vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
 vi.mock('~/server/prom/client', () => ({
   cacheHitCounter: { inc: vi.fn() },
@@ -49,83 +46,38 @@ vi.mock('~/server/prom/client', () => ({
   cacheRevalidateCounter: { inc: vi.fn() },
   cacheFailOpenDegradedCounter: { inc: vi.fn() },
   cacheFailOpenOriginFetchCounter: { inc: vi.fn() },
+  dbReadFallbackCounter: { inc: vi.fn() },
 }));
 
+const { mockDbRead, mockDbWrite } = vi.hoisted(() => {
+  const mk = () => ({
+    modelVersion: { findMany: vi.fn() },
+    donationGoal: { findMany: vi.fn() },
+    $queryRaw: vi.fn(),
+  });
+  return { mockDbRead: mk(), mockDbWrite: mk() };
+});
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+
 import { createCachedObject } from '~/server/utils/cache-helpers';
+import {
+  publicDonationGoalsLookupFn,
+  type ModelVersionPublicDonationGoalsCacheItem,
+} from '~/server/redis/donation-goals-cache';
 
-type GoalRow = {
-  id: number;
-  goalAmount: number;
-  title: string;
-  active: boolean;
-  isEarlyAccess: boolean;
-  userId: number;
-  createdAt: Date;
-  description: string | null;
-  modelVersionId: number | null;
-};
-type Item = { modelVersionId: number; goals: Array<Omit<GoalRow, 'modelVersionId'> & { total: number }> };
-
-// db doubles.
-const mvReadFindMany = vi.fn(); // dbRead.modelVersion.findMany
-const mvWriteFindMany = vi.fn(); // dbWrite.modelVersion.findMany (primary fallback)
-const dgFindMany = vi.fn(); // db.donationGoal.findMany
-const donationTotals = vi.fn(); // $queryRaw totals
-const fallbackInc = vi.fn();
-
-// FAITHFUL mirror of caches.ts `modelVersionPublicDonationGoalsCache.lookupFn`.
+// The REAL lookupFn, wired into createCachedObject exactly as caches.ts does.
 function buildCache() {
-  return createCachedObject<Item>({
+  return createCachedObject<ModelVersionPublicDonationGoalsCacheItem>({
     key: 'test:mv-public-donation-goals' as never,
     idKey: 'modelVersionId',
     ttl: 60,
     staleWhileRevalidate: false,
     cacheNotFound: false,
-    lookupFn: async (ids, fromWrite) => {
-      let versions: { id: number; earlyAccessEndsAt: Date | null }[] = await mvReadFindMany({
-        where: { id: { in: ids } },
-        select: { id: true, earlyAccessEndsAt: true },
-      });
-      if (!fromWrite && versions.length < ids.length) {
-        const found = new Set(versions.map((v) => v.id));
-        const missing = ids.filter((id) => !found.has(id));
-        if (missing.length > 0) {
-          fallbackInc();
-          const fromPrimary = await mvWriteFindMany({
-            where: { id: { in: missing } },
-            select: { id: true, earlyAccessEndsAt: true },
-          });
-          versions = versions.concat(fromPrimary);
-        }
-      }
-      if (versions.length === 0) return {};
-
-      const earlyAccessById = new Map(versions.map((v) => [v.id, v.earlyAccessEndsAt]));
-      const goals: GoalRow[] = await dgFindMany({
-        where: { modelVersionId: { in: versions.map((v) => v.id) }, active: true },
-      });
-
-      const totalByGoalId = new Map<number, number>();
-      const goalIds = goals.map((g) => g.id);
-      if (goalIds.length > 0) {
-        const totals: { donationGoalId: number; total: number }[] = await donationTotals(goalIds);
-        for (const t of totals) totalByGoalId.set(t.donationGoalId, t.total);
-      }
-
-      const result: Record<number, Item> = {};
-      for (const v of versions) result[v.id] = { modelVersionId: v.id, goals: [] };
-      for (const goal of goals) {
-        const { modelVersionId, ...rest } = goal;
-        if (modelVersionId == null) continue;
-        if (goal.isEarlyAccess && !earlyAccessById.get(modelVersionId)) continue;
-        result[modelVersionId].goals.push({ ...rest, total: totalByGoalId.get(goal.id) ?? 0 });
-      }
-      return result;
-    },
+    lookupFn: publicDonationGoalsLookupFn,
   });
 }
 
-const row = (over: Partial<GoalRow> = {}): GoalRow => ({
+const row = (over: Record<string, unknown> = {}) => ({
   id: 10,
   goalAmount: 1000,
   title: 'Goal',
@@ -144,27 +96,43 @@ beforeEach(() => {
   setMock.mockClear();
   delMock.mockClear();
   setNxMock.mockClear().mockResolvedValue(true);
-  mvReadFindMany.mockReset();
-  mvWriteFindMany.mockReset();
-  dgFindMany.mockReset();
-  donationTotals.mockReset();
-  fallbackInc.mockReset();
+  mockDbRead.modelVersion.findMany.mockReset();
+  mockDbRead.donationGoal.findMany.mockReset();
+  mockDbRead.$queryRaw.mockReset();
+  mockDbWrite.modelVersion.findMany.mockReset();
+  mockDbWrite.donationGoal.findMany.mockReset();
+  mockDbWrite.$queryRaw.mockReset();
 });
 
 afterEach(() => vi.restoreAllMocks());
 
+describe('publicDonationGoalsLookupFn — security invariant', () => {
+  it('queries donation goals with the PUBLIC active:true filter (keeps drafts out)', async () => {
+    mockDbRead.modelVersion.findMany.mockResolvedValue([{ id: 5, earlyAccessEndsAt: null }]);
+    mockDbRead.donationGoal.findMany.mockResolvedValue([row()]);
+    mockDbRead.$queryRaw.mockResolvedValue([{ donationGoalId: 10, total: 250 }]);
+
+    await publicDonationGoalsLookupFn([5]);
+
+    const call = mockDbRead.donationGoal.findMany.mock.calls[0][0];
+    // The one guard that keeps inactive/draft goals out of the shared public key.
+    expect(call.where.active).toBe(true);
+    expect(call.where.modelVersionId).toEqual({ in: [5] });
+  });
+});
+
 describe('modelVersionPublicDonationGoalsCache', () => {
   it('hits the DB once, then serves the second fetch of the same version from cache', async () => {
-    mvReadFindMany.mockResolvedValue([{ id: 5, earlyAccessEndsAt: null }]);
-    dgFindMany.mockResolvedValue([row()]);
-    donationTotals.mockResolvedValue([{ donationGoalId: 10, total: 250 }]);
+    mockDbRead.modelVersion.findMany.mockResolvedValue([{ id: 5, earlyAccessEndsAt: null }]);
+    mockDbRead.donationGoal.findMany.mockResolvedValue([row()]);
+    mockDbRead.$queryRaw.mockResolvedValue([{ donationGoalId: 10, total: 250 }]);
     const cache = buildCache();
 
     const first = await cache.fetch([5]);
     const second = await cache.fetch([5]);
 
-    expect(mvReadFindMany).toHaveBeenCalledTimes(1);
-    expect(dgFindMany).toHaveBeenCalledTimes(1);
+    expect(mockDbRead.modelVersion.findMany).toHaveBeenCalledTimes(1);
+    expect(mockDbRead.donationGoal.findMany).toHaveBeenCalledTimes(1);
     expect(first[5].goals).toEqual([
       {
         id: 10,
@@ -182,22 +150,21 @@ describe('modelVersionPublicDonationGoalsCache', () => {
   });
 
   it('caches an EMPTY entry for an existing version with no public goals (returns [], not 404)', async () => {
-    mvReadFindMany.mockResolvedValue([{ id: 8, earlyAccessEndsAt: null }]);
-    dgFindMany.mockResolvedValue([]);
+    mockDbRead.modelVersion.findMany.mockResolvedValue([{ id: 8, earlyAccessEndsAt: null }]);
+    mockDbRead.donationGoal.findMany.mockResolvedValue([]);
     const cache = buildCache();
 
     const first = await cache.fetch([8]);
     const second = await cache.fetch([8]);
 
     expect(first[8]).toEqual({ modelVersionId: 8, goals: [] });
-    // Positive (empty) entry is cached — no re-lookup on the second fetch.
-    expect(mvReadFindMany).toHaveBeenCalledTimes(1);
+    expect(mockDbRead.modelVersion.findMany).toHaveBeenCalledTimes(1); // positive entry cached
     expect(second[8].goals).toEqual([]);
   });
 
   it('yields NO entry for a missing version and does not negatively cache it (cacheNotFound: false)', async () => {
-    mvReadFindMany.mockResolvedValue([]); // replica miss
-    mvWriteFindMany.mockResolvedValue([]); // primary miss too → genuinely gone
+    mockDbRead.modelVersion.findMany.mockResolvedValue([]); // replica miss
+    mockDbWrite.modelVersion.findMany.mockResolvedValue([]); // primary miss too → genuinely gone
     const cache = buildCache();
 
     const first = await cache.fetch([999]);
@@ -205,26 +172,23 @@ describe('modelVersionPublicDonationGoalsCache', () => {
 
     expect(first[999]).toBeUndefined(); // caller maps absent entry → NOT_FOUND
     // Not negatively cached → the lookup (incl. primary fallback) re-runs each time.
-    expect(mvReadFindMany).toHaveBeenCalledTimes(2);
-    expect(mvWriteFindMany).toHaveBeenCalledTimes(2);
-    expect(fallbackInc).toHaveBeenCalledTimes(2);
+    expect(mockDbRead.modelVersion.findMany).toHaveBeenCalledTimes(2);
+    expect(mockDbWrite.modelVersion.findMany).toHaveBeenCalledTimes(2);
     expect(second[999]).toBeUndefined();
   });
 
   it('applies the public early-access filter per version', async () => {
-    // Version 5: no earlyAccessEndsAt → early-access goals are hidden.
-    // Version 9: earlyAccessEndsAt set → early-access goals are shown.
-    mvReadFindMany.mockResolvedValue([
-      { id: 5, earlyAccessEndsAt: null },
-      { id: 9, earlyAccessEndsAt: new Date('2099-01-01T00:00:00.000Z') },
+    mockDbRead.modelVersion.findMany.mockResolvedValue([
+      { id: 5, earlyAccessEndsAt: null }, // EA goals hidden
+      { id: 9, earlyAccessEndsAt: new Date('2099-01-01T00:00:00.000Z') }, // EA goals shown
     ]);
-    dgFindMany.mockResolvedValue([
+    mockDbRead.donationGoal.findMany.mockResolvedValue([
       row({ id: 10, isEarlyAccess: false, modelVersionId: 5 }),
       row({ id: 11, isEarlyAccess: true, modelVersionId: 5 }),
       row({ id: 20, isEarlyAccess: false, modelVersionId: 9 }),
       row({ id: 21, isEarlyAccess: true, modelVersionId: 9 }),
     ]);
-    donationTotals.mockResolvedValue([]); // all totals default to 0
+    mockDbRead.$queryRaw.mockResolvedValue([]); // all totals default to 0
     const cache = buildCache();
 
     const res = await cache.fetch([5, 9]);

--- a/src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts
+++ b/src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Mechanism contract for `modelVersionPublicDonationGoalsCache` — the DB-load-reduction lever
+ * behind `model-version.donationGoals` on the public path.
+ *
+ * The cache is a `createCachedObject` keyed by modelVersionId with a 60s TTL and
+ * `cacheNotFound: false`. This test exercises the REAL cache mechanism against an in-memory
+ * packed-redis double + mocked db doubles and pins:
+ *   - dedup/TTL: a second fetch of the same id within the TTL does NOT re-issue the DB lookup;
+ *   - existence: an existing version with zero public goals yields an EMPTY entry (caller
+ *     returns []), while a genuinely-missing version yields NO entry (caller 404s) and is NOT
+ *     negatively cached (re-looked-up next time, per `cacheNotFound: false`);
+ *   - the public early-access filter and the summed totals shape.
+ *
+ * DIVERGENCE RISK: importing the real `modelVersionPublicDonationGoalsCache` from caches.ts
+ * would drag in its env/clickhouse/orchestrator import graph, so this replicates its lookupFn.
+ * Keep this a FAITHFUL mirror of caches.ts `modelVersionPublicDonationGoalsCache.lookupFn` —
+ * same existence + primary-fallback, same `active: true` public filter, same early-access
+ * filter, same totals map, same "seed an empty entry per existing version". Change one, change
+ * both.
+ */
+
+const store = new Map<string, unknown>();
+const mGetMock = vi.fn(async (keys: string[]) => keys.map((k) => store.get(k)));
+const setMock = vi.fn(async (key: string, value: unknown) => {
+  store.set(key, value);
+});
+const delMock = vi.fn(async () => undefined);
+const setNxMock = vi.fn().mockResolvedValue(true);
+
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: {
+      mGet: (...args: unknown[]) => mGetMock(...(args as [string[]])),
+      set: (...args: unknown[]) => setMock(...(args as [string, unknown])),
+    },
+    setNxKeepTtlWithEx: (...args: unknown[]) => setNxMock(...args),
+    del: (...args: unknown[]) => delMock(...args),
+  },
+  sysRedis: {},
+  REDIS_KEYS: { CACHE_LOCKS: 'caches:lock' },
+}));
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/prom/client', () => ({
+  cacheHitCounter: { inc: vi.fn() },
+  cacheMissCounter: { inc: vi.fn() },
+  cacheRevalidateCounter: { inc: vi.fn() },
+  cacheFailOpenDegradedCounter: { inc: vi.fn() },
+  cacheFailOpenOriginFetchCounter: { inc: vi.fn() },
+}));
+
+import { createCachedObject } from '~/server/utils/cache-helpers';
+
+type GoalRow = {
+  id: number;
+  goalAmount: number;
+  title: string;
+  active: boolean;
+  isEarlyAccess: boolean;
+  userId: number;
+  createdAt: Date;
+  description: string | null;
+  modelVersionId: number | null;
+};
+type Item = { modelVersionId: number; goals: Array<Omit<GoalRow, 'modelVersionId'> & { total: number }> };
+
+// db doubles.
+const mvReadFindMany = vi.fn(); // dbRead.modelVersion.findMany
+const mvWriteFindMany = vi.fn(); // dbWrite.modelVersion.findMany (primary fallback)
+const dgFindMany = vi.fn(); // db.donationGoal.findMany
+const donationTotals = vi.fn(); // $queryRaw totals
+const fallbackInc = vi.fn();
+
+// FAITHFUL mirror of caches.ts `modelVersionPublicDonationGoalsCache.lookupFn`.
+function buildCache() {
+  return createCachedObject<Item>({
+    key: 'test:mv-public-donation-goals' as never,
+    idKey: 'modelVersionId',
+    ttl: 60,
+    staleWhileRevalidate: false,
+    cacheNotFound: false,
+    lookupFn: async (ids, fromWrite) => {
+      let versions: { id: number; earlyAccessEndsAt: Date | null }[] = await mvReadFindMany({
+        where: { id: { in: ids } },
+        select: { id: true, earlyAccessEndsAt: true },
+      });
+      if (!fromWrite && versions.length < ids.length) {
+        const found = new Set(versions.map((v) => v.id));
+        const missing = ids.filter((id) => !found.has(id));
+        if (missing.length > 0) {
+          fallbackInc();
+          const fromPrimary = await mvWriteFindMany({
+            where: { id: { in: missing } },
+            select: { id: true, earlyAccessEndsAt: true },
+          });
+          versions = versions.concat(fromPrimary);
+        }
+      }
+      if (versions.length === 0) return {};
+
+      const earlyAccessById = new Map(versions.map((v) => [v.id, v.earlyAccessEndsAt]));
+      const goals: GoalRow[] = await dgFindMany({
+        where: { modelVersionId: { in: versions.map((v) => v.id) }, active: true },
+      });
+
+      const totalByGoalId = new Map<number, number>();
+      const goalIds = goals.map((g) => g.id);
+      if (goalIds.length > 0) {
+        const totals: { donationGoalId: number; total: number }[] = await donationTotals(goalIds);
+        for (const t of totals) totalByGoalId.set(t.donationGoalId, t.total);
+      }
+
+      const result: Record<number, Item> = {};
+      for (const v of versions) result[v.id] = { modelVersionId: v.id, goals: [] };
+      for (const goal of goals) {
+        const { modelVersionId, ...rest } = goal;
+        if (modelVersionId == null) continue;
+        if (goal.isEarlyAccess && !earlyAccessById.get(modelVersionId)) continue;
+        result[modelVersionId].goals.push({ ...rest, total: totalByGoalId.get(goal.id) ?? 0 });
+      }
+      return result;
+    },
+  });
+}
+
+const row = (over: Partial<GoalRow> = {}): GoalRow => ({
+  id: 10,
+  goalAmount: 1000,
+  title: 'Goal',
+  active: true,
+  isEarlyAccess: false,
+  userId: 7,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  description: 'desc',
+  modelVersionId: 5,
+  ...over,
+});
+
+beforeEach(() => {
+  store.clear();
+  mGetMock.mockClear();
+  setMock.mockClear();
+  delMock.mockClear();
+  setNxMock.mockClear().mockResolvedValue(true);
+  mvReadFindMany.mockReset();
+  mvWriteFindMany.mockReset();
+  dgFindMany.mockReset();
+  donationTotals.mockReset();
+  fallbackInc.mockReset();
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('modelVersionPublicDonationGoalsCache', () => {
+  it('hits the DB once, then serves the second fetch of the same version from cache', async () => {
+    mvReadFindMany.mockResolvedValue([{ id: 5, earlyAccessEndsAt: null }]);
+    dgFindMany.mockResolvedValue([row()]);
+    donationTotals.mockResolvedValue([{ donationGoalId: 10, total: 250 }]);
+    const cache = buildCache();
+
+    const first = await cache.fetch([5]);
+    const second = await cache.fetch([5]);
+
+    expect(mvReadFindMany).toHaveBeenCalledTimes(1);
+    expect(dgFindMany).toHaveBeenCalledTimes(1);
+    expect(first[5].goals).toEqual([
+      {
+        id: 10,
+        goalAmount: 1000,
+        title: 'Goal',
+        active: true,
+        isEarlyAccess: false,
+        userId: 7,
+        createdAt: new Date('2026-01-01T00:00:00.000Z'),
+        description: 'desc',
+        total: 250,
+      },
+    ]);
+    expect(second[5].goals).toEqual(first[5].goals);
+  });
+
+  it('caches an EMPTY entry for an existing version with no public goals (returns [], not 404)', async () => {
+    mvReadFindMany.mockResolvedValue([{ id: 8, earlyAccessEndsAt: null }]);
+    dgFindMany.mockResolvedValue([]);
+    const cache = buildCache();
+
+    const first = await cache.fetch([8]);
+    const second = await cache.fetch([8]);
+
+    expect(first[8]).toEqual({ modelVersionId: 8, goals: [] });
+    // Positive (empty) entry is cached — no re-lookup on the second fetch.
+    expect(mvReadFindMany).toHaveBeenCalledTimes(1);
+    expect(second[8].goals).toEqual([]);
+  });
+
+  it('yields NO entry for a missing version and does not negatively cache it (cacheNotFound: false)', async () => {
+    mvReadFindMany.mockResolvedValue([]); // replica miss
+    mvWriteFindMany.mockResolvedValue([]); // primary miss too → genuinely gone
+    const cache = buildCache();
+
+    const first = await cache.fetch([999]);
+    const second = await cache.fetch([999]);
+
+    expect(first[999]).toBeUndefined(); // caller maps absent entry → NOT_FOUND
+    // Not negatively cached → the lookup (incl. primary fallback) re-runs each time.
+    expect(mvReadFindMany).toHaveBeenCalledTimes(2);
+    expect(mvWriteFindMany).toHaveBeenCalledTimes(2);
+    expect(fallbackInc).toHaveBeenCalledTimes(2);
+    expect(second[999]).toBeUndefined();
+  });
+
+  it('applies the public early-access filter per version', async () => {
+    // Version 5: no earlyAccessEndsAt → early-access goals are hidden.
+    // Version 9: earlyAccessEndsAt set → early-access goals are shown.
+    mvReadFindMany.mockResolvedValue([
+      { id: 5, earlyAccessEndsAt: null },
+      { id: 9, earlyAccessEndsAt: new Date('2099-01-01T00:00:00.000Z') },
+    ]);
+    dgFindMany.mockResolvedValue([
+      row({ id: 10, isEarlyAccess: false, modelVersionId: 5 }),
+      row({ id: 11, isEarlyAccess: true, modelVersionId: 5 }),
+      row({ id: 20, isEarlyAccess: false, modelVersionId: 9 }),
+      row({ id: 21, isEarlyAccess: true, modelVersionId: 9 }),
+    ]);
+    donationTotals.mockResolvedValue([]); // all totals default to 0
+    const cache = buildCache();
+
+    const res = await cache.fetch([5, 9]);
+
+    expect(res[5].goals.map((g) => g.id)).toEqual([10]); // EA goal 11 excluded
+    expect(res[9].goals.map((g) => g.id).sort((a, b) => a - b)).toEqual([20, 21]); // both shown
+    expect(res[5].goals[0].total).toBe(0); // no donation → 0
+  });
+});

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -9,7 +9,10 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { getDbWithoutLagBatch } from '~/server/db/db-lag-helpers';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { REDIS_KEYS, redis, type RedisKeyTemplateCache } from '~/server/redis/client';
-import { dbReadFallbackCounter } from '~/server/prom/client';
+import {
+  publicDonationGoalsLookupFn,
+  type ModelVersionPublicDonationGoalsCacheItem,
+} from '~/server/redis/donation-goals-cache';
 import type { ImageMetaProps } from '~/server/schema/image.schema';
 import type { ImageMetadata, VideoMetadata } from '~/server/schema/media.schema';
 import type { ContentDecorationCosmetic, WithClaimKey } from '~/server/selectors/cosmetic.selector';
@@ -1555,25 +1558,10 @@ export const modelVotableTagsCache = createCachedObject<ModelVotableTagsCacheIte
   },
 });
 
-// A single public (non-owner, non-moderator) donation goal, shaped byte-identically to
-// `modelVersionDonationGoals`' output element: the DonationGoal row fields it selects plus
-// the summed `total`. Privileged (owner/mod) responses can include unpublished/draft goals
-// and MUST NOT enter this shared cache — see `modelVersionDonationGoals` for the gate.
-export type ModelVersionPublicDonationGoal = {
-  id: number;
-  goalAmount: number;
-  title: string;
-  active: boolean;
-  isEarlyAccess: boolean;
-  userId: number;
-  createdAt: Date;
-  description: string | null;
-  total: number;
-};
-export type ModelVersionPublicDonationGoalsCacheItem = {
-  modelVersionId: number;
-  goals: ModelVersionPublicDonationGoal[];
-};
+export type {
+  ModelVersionPublicDonationGoal,
+  ModelVersionPublicDonationGoalsCacheItem,
+} from '~/server/redis/donation-goals-cache';
 
 /**
  * Read-through cache for the PUBLIC variant of a model version's donation goals, keyed by
@@ -1591,6 +1579,10 @@ export type ModelVersionPublicDonationGoalsCacheItem = {
  *
  * `cacheNotFound: false` — a missing version is never negative-cached, so the caller always
  * 404s fresh (matching the uncached read→primary-fallback→NOT_FOUND behavior).
+ *
+ * The lookupFn — including the security-relevant `active: true` public filter — lives in the
+ * light `donation-goals-cache` module so it can be tested against the REAL function (no mirror
+ * divergence).
  */
 export const modelVersionPublicDonationGoalsCache =
   createCachedObject<ModelVersionPublicDonationGoalsCacheItem>({
@@ -1599,84 +1591,7 @@ export const modelVersionPublicDonationGoalsCache =
     ttl: CacheTTL.xs,
     staleWhileRevalidate: false,
     cacheNotFound: false,
-    lookupFn: async (ids, fromWrite) => {
-      const versionSelect = { id: true, earlyAccessEndsAt: true } as const;
-
-      // Existence + earlyAccessEndsAt. Mirror the uncached path's replica→primary fallback:
-      // any id the replica misses is retried against the primary so replica lag on a
-      // just-created version does not read as NOT_FOUND.
-      let versions = await dbRead.modelVersion.findMany({
-        where: { id: { in: ids } },
-        select: versionSelect,
-      });
-      if (!fromWrite && versions.length < ids.length) {
-        const found = new Set(versions.map((v) => v.id));
-        const missing = ids.filter((id) => !found.has(id));
-        if (missing.length > 0) {
-          dbReadFallbackCounter.inc({
-            entity: 'modelVersion',
-            caller: 'modelVersionPublicDonationGoalsCache',
-          });
-          const fromPrimary = await dbWrite.modelVersion.findMany({
-            where: { id: { in: missing } },
-            select: versionSelect,
-          });
-          versions = versions.concat(fromPrimary);
-        }
-      }
-      if (versions.length === 0) return {};
-
-      const earlyAccessById = new Map(versions.map((v) => [v.id, v.earlyAccessEndsAt]));
-      const db = fromWrite ? dbWrite : dbRead;
-
-      // PUBLIC filter: only active goals (draft/inactive goals are owner/mod-only).
-      const goals = await db.donationGoal.findMany({
-        where: { modelVersionId: { in: versions.map((v) => v.id) }, active: true },
-        select: {
-          id: true,
-          goalAmount: true,
-          title: true,
-          active: true,
-          isEarlyAccess: true,
-          userId: true,
-          createdAt: true,
-          description: true,
-          modelVersionId: true,
-        },
-      });
-
-      const totalByGoalId = new Map<number, number>();
-      const goalIds = goals.map((g) => g.id);
-      if (goalIds.length > 0) {
-        const totals = await db.$queryRaw<{ donationGoalId: number; total: number }[]>`
-          SELECT
-            "donationGoalId",
-            SUM("amount")::int as total
-          FROM "Donation"
-          WHERE "donationGoalId" IN (${Prisma.join(goalIds)})
-          GROUP BY "donationGoalId"
-        `;
-        for (const t of totals) totalByGoalId.set(t.donationGoalId, t.total);
-      }
-
-      const result: Record<number, ModelVersionPublicDonationGoalsCacheItem> = {};
-      // Seed an entry for EVERY existing version (even with zero goals) so the caller can
-      // distinguish "exists, no goals" (return []) from "does not exist" (404). Missing
-      // versions get no entry.
-      for (const v of versions) result[v.id] = { modelVersionId: v.id, goals: [] };
-
-      for (const goal of goals) {
-        const { modelVersionId, ...rest } = goal;
-        if (modelVersionId == null) continue;
-        // Public early-access filter, byte-identical to the uncached query's
-        // `isEarlyAccess: version.earlyAccessEndsAt ? undefined : false`: early-access goals
-        // are only shown publicly while the version still has an earlyAccessEndsAt set.
-        if (goal.isEarlyAccess && !earlyAccessById.get(modelVersionId)) continue;
-        result[modelVersionId].goals.push({ ...rest, total: totalByGoalId.get(goal.id) ?? 0 });
-      }
-
-      return result;
-    },
+    lookupFn: publicDonationGoalsLookupFn,
   });
 
 type ModelTagCacheItem = {

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -9,6 +9,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { getDbWithoutLagBatch } from '~/server/db/db-lag-helpers';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { REDIS_KEYS, redis, type RedisKeyTemplateCache } from '~/server/redis/client';
+import { dbReadFallbackCounter } from '~/server/prom/client';
 import type { ImageMetaProps } from '~/server/schema/image.schema';
 import type { ImageMetadata, VideoMetadata } from '~/server/schema/media.schema';
 import type { ContentDecorationCosmetic, WithClaimKey } from '~/server/selectors/cosmetic.selector';
@@ -1553,6 +1554,130 @@ export const modelVotableTagsCache = createCachedObject<ModelVotableTagsCacheIte
     }, {} as Record<number, ModelVotableTagsCacheItem>);
   },
 });
+
+// A single public (non-owner, non-moderator) donation goal, shaped byte-identically to
+// `modelVersionDonationGoals`' output element: the DonationGoal row fields it selects plus
+// the summed `total`. Privileged (owner/mod) responses can include unpublished/draft goals
+// and MUST NOT enter this shared cache — see `modelVersionDonationGoals` for the gate.
+export type ModelVersionPublicDonationGoal = {
+  id: number;
+  goalAmount: number;
+  title: string;
+  active: boolean;
+  isEarlyAccess: boolean;
+  userId: number;
+  createdAt: Date;
+  description: string | null;
+  total: number;
+};
+export type ModelVersionPublicDonationGoalsCacheItem = {
+  modelVersionId: number;
+  goals: ModelVersionPublicDonationGoal[];
+};
+
+/**
+ * Read-through cache for the PUBLIC variant of a model version's donation goals, keyed by
+ * `modelVersionId`. The public variant is fully determined by the model version id (it does
+ * NOT vary by viewer), so a single shared entry is correct for every anonymous / non-owner /
+ * non-moderator caller. The privileged (owner/mod) variant — which additionally exposes
+ * inactive/draft goals — is computed fresh and NEVER routed through this cache (see
+ * `modelVersionDonationGoals`), so a draft-inclusive payload can never leak into the shared
+ * key and a cached public payload can never be served to a privileged viewer.
+ *
+ * TTL is short (CacheTTL.xs, 60s): a newly created goal or an updated donation total lags at
+ * most 60s, acceptable for a donation-progress display. Donation/goal-completion writes also
+ * bust the key eagerly (see `donation-goal.service.ts`), so the TTL only bounds the rare
+ * publish-time goal-create path.
+ *
+ * `cacheNotFound: false` — a missing version is never negative-cached, so the caller always
+ * 404s fresh (matching the uncached read→primary-fallback→NOT_FOUND behavior).
+ */
+export const modelVersionPublicDonationGoalsCache =
+  createCachedObject<ModelVersionPublicDonationGoalsCacheItem>({
+    key: REDIS_KEYS.CACHES.MODEL_VERSION_PUBLIC_DONATION_GOALS,
+    idKey: 'modelVersionId',
+    ttl: CacheTTL.xs,
+    staleWhileRevalidate: false,
+    cacheNotFound: false,
+    lookupFn: async (ids, fromWrite) => {
+      const versionSelect = { id: true, earlyAccessEndsAt: true } as const;
+
+      // Existence + earlyAccessEndsAt. Mirror the uncached path's replica→primary fallback:
+      // any id the replica misses is retried against the primary so replica lag on a
+      // just-created version does not read as NOT_FOUND.
+      let versions = await dbRead.modelVersion.findMany({
+        where: { id: { in: ids } },
+        select: versionSelect,
+      });
+      if (!fromWrite && versions.length < ids.length) {
+        const found = new Set(versions.map((v) => v.id));
+        const missing = ids.filter((id) => !found.has(id));
+        if (missing.length > 0) {
+          dbReadFallbackCounter.inc({
+            entity: 'modelVersion',
+            caller: 'modelVersionPublicDonationGoalsCache',
+          });
+          const fromPrimary = await dbWrite.modelVersion.findMany({
+            where: { id: { in: missing } },
+            select: versionSelect,
+          });
+          versions = versions.concat(fromPrimary);
+        }
+      }
+      if (versions.length === 0) return {};
+
+      const earlyAccessById = new Map(versions.map((v) => [v.id, v.earlyAccessEndsAt]));
+      const db = fromWrite ? dbWrite : dbRead;
+
+      // PUBLIC filter: only active goals (draft/inactive goals are owner/mod-only).
+      const goals = await db.donationGoal.findMany({
+        where: { modelVersionId: { in: versions.map((v) => v.id) }, active: true },
+        select: {
+          id: true,
+          goalAmount: true,
+          title: true,
+          active: true,
+          isEarlyAccess: true,
+          userId: true,
+          createdAt: true,
+          description: true,
+          modelVersionId: true,
+        },
+      });
+
+      const totalByGoalId = new Map<number, number>();
+      const goalIds = goals.map((g) => g.id);
+      if (goalIds.length > 0) {
+        const totals = await db.$queryRaw<{ donationGoalId: number; total: number }[]>`
+          SELECT
+            "donationGoalId",
+            SUM("amount")::int as total
+          FROM "Donation"
+          WHERE "donationGoalId" IN (${Prisma.join(goalIds)})
+          GROUP BY "donationGoalId"
+        `;
+        for (const t of totals) totalByGoalId.set(t.donationGoalId, t.total);
+      }
+
+      const result: Record<number, ModelVersionPublicDonationGoalsCacheItem> = {};
+      // Seed an entry for EVERY existing version (even with zero goals) so the caller can
+      // distinguish "exists, no goals" (return []) from "does not exist" (404). Missing
+      // versions get no entry.
+      for (const v of versions) result[v.id] = { modelVersionId: v.id, goals: [] };
+
+      for (const goal of goals) {
+        const { modelVersionId, ...rest } = goal;
+        if (modelVersionId == null) continue;
+        // Public early-access filter, byte-identical to the uncached query's
+        // `isEarlyAccess: version.earlyAccessEndsAt ? undefined : false`: early-access goals
+        // are only shown publicly while the version still has an earlyAccessEndsAt set.
+        if (goal.isEarlyAccess && !earlyAccessById.get(modelVersionId)) continue;
+        result[modelVersionId].goals.push({ ...rest, total: totalByGoalId.get(goal.id) ?? 0 });
+      }
+
+      return result;
+    },
+  });
 
 type ModelTagCacheItem = {
   modelId: number;

--- a/src/server/redis/donation-goals-cache.ts
+++ b/src/server/redis/donation-goals-cache.ts
@@ -1,0 +1,114 @@
+import { Prisma } from '@prisma/client';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { dbReadFallbackCounter } from '~/server/prom/client';
+
+// A single public (non-owner, non-moderator) donation goal, shaped byte-identically to
+// `modelVersionDonationGoals`' output element: the DonationGoal row fields it selects plus
+// the summed `total`. Privileged (owner/mod) responses can include unpublished/draft goals
+// and MUST NOT enter the shared public cache — see `modelVersionDonationGoals` for the gate.
+export type ModelVersionPublicDonationGoal = {
+  id: number;
+  goalAmount: number;
+  title: string;
+  active: boolean;
+  isEarlyAccess: boolean;
+  userId: number;
+  createdAt: Date;
+  description: string | null;
+  total: number;
+};
+export type ModelVersionPublicDonationGoalsCacheItem = {
+  modelVersionId: number;
+  goals: ModelVersionPublicDonationGoal[];
+};
+
+/**
+ * lookupFn for `modelVersionPublicDonationGoalsCache` (defined in `caches.ts`). Extracted into
+ * this light module (imports only db/prom/@prisma, NOT the caches.ts env/clickhouse/orchestrator
+ * graph) so the SECURITY-relevant `active: true` public filter — the single guard keeping
+ * inactive/draft goals out of the shared public key — can be tested against the REAL function
+ * the cache uses, with no hand-copied "mirror" that could silently diverge.
+ *
+ * Computes the PUBLIC variant for a set of model version ids: existence (with the same
+ * replica→primary fallback as the uncached read), the `active: true` goal filter, the
+ * per-version early-access filter, and the summed donation totals. Seeds an entry for every
+ * EXISTING version (even with zero goals) so the caller can tell "exists, no goals" (→ []) from
+ * "does not exist" (→ 404); missing versions get no entry.
+ */
+export const publicDonationGoalsLookupFn = async (
+  ids: number[],
+  fromWrite?: boolean
+): Promise<Record<number, ModelVersionPublicDonationGoalsCacheItem>> => {
+  const versionSelect = { id: true, earlyAccessEndsAt: true } as const;
+
+  let versions = await dbRead.modelVersion.findMany({
+    where: { id: { in: ids } },
+    select: versionSelect,
+  });
+  if (!fromWrite && versions.length < ids.length) {
+    const found = new Set(versions.map((v) => v.id));
+    const missing = ids.filter((id) => !found.has(id));
+    if (missing.length > 0) {
+      dbReadFallbackCounter.inc({
+        entity: 'modelVersion',
+        caller: 'modelVersionPublicDonationGoalsCache',
+      });
+      const fromPrimary = await dbWrite.modelVersion.findMany({
+        where: { id: { in: missing } },
+        select: versionSelect,
+      });
+      versions = versions.concat(fromPrimary);
+    }
+  }
+  if (versions.length === 0) return {};
+
+  const earlyAccessById = new Map(versions.map((v) => [v.id, v.earlyAccessEndsAt]));
+  const db = fromWrite ? dbWrite : dbRead;
+
+  // PUBLIC filter: only active goals (draft/inactive goals are owner/mod-only). This
+  // `active: true` is the one invariant that keeps drafts out of the shared public key — do
+  // NOT drop it. (`model-version.donation-goals-lookup.test.ts` asserts it.)
+  const goals = await db.donationGoal.findMany({
+    where: { modelVersionId: { in: versions.map((v) => v.id) }, active: true },
+    select: {
+      id: true,
+      goalAmount: true,
+      title: true,
+      active: true,
+      isEarlyAccess: true,
+      userId: true,
+      createdAt: true,
+      description: true,
+      modelVersionId: true,
+    },
+  });
+
+  const totalByGoalId = new Map<number, number>();
+  const goalIds = goals.map((g) => g.id);
+  if (goalIds.length > 0) {
+    const totals = await db.$queryRaw<{ donationGoalId: number; total: number }[]>`
+      SELECT
+        "donationGoalId",
+        SUM("amount")::int as total
+      FROM "Donation"
+      WHERE "donationGoalId" IN (${Prisma.join(goalIds)})
+      GROUP BY "donationGoalId"
+    `;
+    for (const t of totals) totalByGoalId.set(t.donationGoalId, t.total);
+  }
+
+  const result: Record<number, ModelVersionPublicDonationGoalsCacheItem> = {};
+  for (const v of versions) result[v.id] = { modelVersionId: v.id, goals: [] };
+
+  for (const goal of goals) {
+    const { modelVersionId, ...rest } = goal;
+    if (modelVersionId == null) continue;
+    // Public early-access filter, byte-identical to the uncached query's
+    // `isEarlyAccess: version.earlyAccessEndsAt ? undefined : false`: early-access goals are
+    // only shown publicly while the version still has an earlyAccessEndsAt set.
+    if (goal.isEarlyAccess && !earlyAccessById.get(modelVersionId)) continue;
+    result[modelVersionId].goals.push({ ...rest, total: totalByGoalId.get(goal.id) ?? 0 });
+  }
+
+  return result;
+};

--- a/src/server/services/__tests__/donation-goal.service.test.ts
+++ b/src/server/services/__tests__/donation-goal.service.test.ts
@@ -14,7 +14,10 @@ const { mockDbRead, mockDbWrite } = vi.hoisted(() => {
     mockDbWrite: { donationGoal: mk(), $queryRaw: vi.fn(), $executeRaw: vi.fn() },
   };
 });
-const { mockDonationGoalsBust } = vi.hoisted(() => ({ mockDonationGoalsBust: vi.fn() }));
+const { mockDonationGoalsBust, mockLogToAxiom } = vi.hoisted(() => ({
+  mockDonationGoalsBust: vi.fn(),
+  mockLogToAxiom: vi.fn(),
+}));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
 vi.mock('~/server/redis/caches', () => ({
@@ -27,6 +30,7 @@ vi.mock('~/server/services/buzz.service', () => ({
 }));
 vi.mock('~/server/services/model-version.service', () => ({ bustMvCache: vi.fn() }));
 vi.mock('~/server/services/model.service', () => ({ updateModelEarlyAccessDeadline: vi.fn() }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
 
 import { checkDonationGoalComplete } from '~/server/services/donation-goal.service';
 
@@ -45,6 +49,7 @@ const goal = (over: Record<string, unknown> = {}) => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockLogToAxiom.mockResolvedValue(undefined);
 });
 
 describe('checkDonationGoalComplete — public cache bust', () => {
@@ -66,5 +71,23 @@ describe('checkDonationGoalComplete — public cache bust', () => {
     await checkDonationGoalComplete({ donationGoalId: 10 });
 
     expect(mockDonationGoalsBust).not.toHaveBeenCalled();
+  });
+
+  it('is FAIL-OPEN: a rejecting bust does NOT reject (never poisons the donation/refund path)', async () => {
+    // A redis blip during the bust must not propagate — checkDonationGoalComplete runs inside
+    // donateToGoal's try after donation.create has committed; a throw there refunds the buzz and
+    // tells the donor it failed → they retry → double donation.
+    mockDbWrite.donationGoal.findUniqueOrThrow.mockResolvedValueOnce(goal());
+    mockDbWrite.$queryRaw.mockResolvedValueOnce([{ total: 100 }]);
+    mockDonationGoalsBust.mockRejectedValueOnce(new Error('redis down'));
+
+    const result = await checkDonationGoalComplete({ donationGoalId: 10 });
+
+    // Resolves normally with the goal (donation/total logic unaffected) and logs the failure.
+    expect(result).toMatchObject({ id: 10, total: 100 });
+    expect(mockDonationGoalsBust).toHaveBeenCalledWith(5);
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'donation-goal-public-cache-bust-failed' })
+    );
   });
 });

--- a/src/server/services/__tests__/donation-goal.service.test.ts
+++ b/src/server/services/__tests__/donation-goal.service.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `checkDonationGoalComplete` runs at the end of every donation (donateToGoal) and after an
+ * early-access completion — the write paths that change a goal's total (or flip it inactive).
+ * It must eagerly bust the public donation-goals cache so a donor sees the change before the
+ * 60s TTL, keyed by the goal's modelVersionId (and only when the goal is tied to a version).
+ */
+
+const { mockDbRead, mockDbWrite } = vi.hoisted(() => {
+  const mk = () => ({ findUnique: vi.fn(), findUniqueOrThrow: vi.fn(), update: vi.fn() });
+  return {
+    mockDbRead: { modelVersion: mk() },
+    mockDbWrite: { donationGoal: mk(), $queryRaw: vi.fn(), $executeRaw: vi.fn() },
+  };
+});
+const { mockDonationGoalsBust } = vi.hoisted(() => ({ mockDonationGoalsBust: vi.fn() }));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: { refresh: vi.fn() },
+  modelVersionPublicDonationGoalsCache: { bust: mockDonationGoalsBust },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  createMultiAccountBuzzTransaction: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
+vi.mock('~/server/services/model-version.service', () => ({ bustMvCache: vi.fn() }));
+vi.mock('~/server/services/model.service', () => ({ updateModelEarlyAccessDeadline: vi.fn() }));
+
+import { checkDonationGoalComplete } from '~/server/services/donation-goal.service';
+
+const goal = (over: Record<string, unknown> = {}) => ({
+  id: 10,
+  goalAmount: 1000,
+  title: 'Goal',
+  active: true,
+  isEarlyAccess: false,
+  userId: 7,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  modelVersionId: 5,
+  modelVersion: { model: { id: 2, nsfw: false } },
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('checkDonationGoalComplete — public cache bust', () => {
+  it('busts the public donation-goals cache keyed by modelVersionId after a donation', async () => {
+    mockDbWrite.donationGoal.findUniqueOrThrow.mockResolvedValueOnce(goal());
+    mockDbWrite.$queryRaw.mockResolvedValueOnce([{ total: 100 }]); // below goal → not met
+
+    await checkDonationGoalComplete({ donationGoalId: 10 });
+
+    expect(mockDonationGoalsBust).toHaveBeenCalledWith(5);
+  });
+
+  it('does not bust when the goal is not tied to a model version', async () => {
+    mockDbWrite.donationGoal.findUniqueOrThrow.mockResolvedValueOnce(
+      goal({ modelVersionId: null, modelVersion: null })
+    );
+    mockDbWrite.$queryRaw.mockResolvedValueOnce([{ total: 100 }]);
+
+    await checkDonationGoalComplete({ donationGoalId: 10 });
+
+    expect(mockDonationGoalsBust).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/model-version.donation-goals-cache.service.test.ts
+++ b/src/server/services/__tests__/model-version.donation-goals-cache.service.test.ts
@@ -1,0 +1,218 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Leak-safety + cache-routing contract for `modelVersionDonationGoals`.
+ *
+ * The response varies by viewer: an OWNER or MODERATOR (`canSeeAllGoals`) sees ALL goals
+ * including inactive/draft ones; the PUBLIC (anonymous / non-owner / non-moderator) viewer sees
+ * only active goals. The DB-load-reduction lever caches ONLY the public, viewer-independent
+ * variant keyed by modelVersionId. These tests pin the critical invariants:
+ *
+ *   (1) a public (cache-hit) read skips the per-viewer version + goals DB queries,
+ *   (2) an owner/moderator read NEVER reads from or writes to the public cache (no draft leak),
+ *   (3) two anonymous users — and a logged-in non-owner — share the SAME modelVersionId key and
+ *       get an identical payload (the key does not span the privilege dimension),
+ *   (4) the public payload is shape- and value-identical to the uncached privileged computation
+ *       for the same underlying goal row.
+ */
+
+const { mockDbRead, mockDbWrite } = vi.hoisted(() => {
+  const mk = () => ({
+    findFirst: vi.fn(),
+    findFirstOrThrow: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  });
+  const read = { modelVersion: mk(), donationGoal: mk(), model: mk(), $queryRaw: vi.fn() };
+  const write = { modelVersion: mk(), model: mk(), $queryRaw: vi.fn() };
+  return { mockDbRead: read, mockDbWrite: write };
+});
+
+const { mockCacheFetch, mockCacheBust } = vi.hoisted(() => ({
+  mockCacheFetch: vi.fn(),
+  mockCacheBust: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/prom/client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, dbReadFallbackCounter: { inc: vi.fn() } };
+});
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
+vi.mock('~/server/redis/caches', () => ({
+  modelVersionPublicDonationGoalsCache: { fetch: mockCacheFetch, bust: mockCacheBust },
+}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>(
+    '@civitai/redis/client'
+  );
+  return { ...actual, redis: { get: vi.fn(), set: vi.fn() }, sysRedis: { get: vi.fn() } };
+});
+vi.mock('~/server/redis/resource-data.redis', () => ({ resourceDataCache: {} }));
+vi.mock('~/server/search-index', () => ({}));
+vi.mock('~/server/services/auction.service', () => ({ deleteBidsForModelVersion: vi.fn() }));
+vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({}));
+vi.mock('~/server/services/common.service', () => ({ hasEntityAccess: vi.fn() }));
+vi.mock('~/server/services/donation-goal.service', () => ({ checkDonationGoalComplete: vi.fn() }));
+vi.mock('~/server/services/image.service', () => ({
+  imagesForModelVersionsCache: {},
+  uploadImageFromUrl: vi.fn(),
+}));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
+vi.mock('~/server/services/post.service', () => ({ addPostImage: vi.fn(), createPost: vi.fn() }));
+vi.mock('~/server/services/model.service', () => ({
+  ingestModelById: vi.fn(),
+  updateModelLastVersionAt: vi.fn(),
+}));
+vi.mock('~/server/services/model-file.service', () => ({ filesForModelVersionCache: {} }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+
+import { modelVersionDonationGoals } from '~/server/services/model-version.service';
+
+const CREATED_AT = new Date('2026-01-01T00:00:00.000Z');
+// A single active PUBLIC goal, already summed — the exact element shape the endpoint returns.
+const publicGoal = (over: Record<string, unknown> = {}) => ({
+  id: 10,
+  goalAmount: 1000,
+  title: 'Goal',
+  active: true,
+  isEarlyAccess: false,
+  userId: 7,
+  createdAt: CREATED_AT,
+  description: 'desc',
+  total: 250,
+  ...over,
+});
+// The DonationGoal row the privileged path reads (no `total` — that's summed separately).
+const goalRow = (over: Record<string, unknown> = {}) => ({
+  id: 10,
+  goalAmount: 1000,
+  title: 'Goal',
+  active: true,
+  isEarlyAccess: false,
+  userId: 7,
+  createdAt: CREATED_AT,
+  description: 'desc',
+  ...over,
+});
+const ownerVersion = (ownerId: number) => ({
+  id: 5,
+  modelId: 2,
+  earlyAccessEndsAt: null,
+  model: { userId: ownerId },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('modelVersionDonationGoals — public cache routing', () => {
+  it('(1) serves the public variant from the cache without any per-viewer DB read', async () => {
+    mockCacheFetch.mockResolvedValueOnce({ '5': { modelVersionId: 5, goals: [publicGoal()] } });
+
+    const res = await modelVersionDonationGoals({ id: 5 }); // anonymous
+
+    expect(res).toEqual([publicGoal()]);
+    expect(mockCacheFetch).toHaveBeenCalledWith([5]);
+    // The expensive per-viewer reads are elided on a public cache hit.
+    expect(mockDbRead.modelVersion.findFirstOrThrow).not.toHaveBeenCalled();
+    expect(mockDbRead.donationGoal.findMany).not.toHaveBeenCalled();
+    expect(mockDbRead.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('(1b) 404s a missing version on the public path (no cache entry → NOT_FOUND)', async () => {
+    mockCacheFetch.mockResolvedValueOnce({}); // lookupFn seeds no entry for a missing version
+
+    await expect(modelVersionDonationGoals({ id: 999 })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+});
+
+describe('modelVersionDonationGoals — privileged bypass (no draft-goal leak)', () => {
+  it('(2) an OWNER read is computed fresh and NEVER touches the public cache', async () => {
+    mockDbRead.modelVersion.findFirstOrThrow.mockResolvedValueOnce(ownerVersion(7));
+    // Owner sees ALL goals incl. a draft/inactive one that must never enter the shared cache.
+    mockDbRead.donationGoal.findMany.mockResolvedValueOnce([
+      goalRow(),
+      goalRow({ id: 11, active: false, title: 'Draft' }),
+    ]);
+    mockDbRead.$queryRaw.mockResolvedValueOnce([{ donationGoalId: 10, total: 250 }]);
+
+    const res = await modelVersionDonationGoals({ id: 5, userId: 7 }); // owner
+
+    // Leak axis: the privileged path must NOT read from or write to the shared public cache.
+    expect(mockCacheFetch).not.toHaveBeenCalled();
+    expect(mockCacheBust).not.toHaveBeenCalled();
+    // It reads ALL goals for the version (no active/isEarlyAccess restriction).
+    expect(mockDbRead.donationGoal.findMany).toHaveBeenCalledWith({
+      where: { modelVersionId: 5 },
+      select: {
+        id: true,
+        goalAmount: true,
+        title: true,
+        active: true,
+        isEarlyAccess: true,
+        userId: true,
+        createdAt: true,
+        description: true,
+      },
+    });
+    expect(res).toContainEqual(expect.objectContaining({ id: 11, active: false, title: 'Draft' }));
+  });
+
+  it('(2b) a MODERATOR (non-owner) read also bypasses the public cache', async () => {
+    mockDbRead.modelVersion.findFirstOrThrow.mockResolvedValueOnce(ownerVersion(7));
+    mockDbRead.donationGoal.findMany.mockResolvedValueOnce([goalRow({ active: false })]);
+    mockDbRead.$queryRaw.mockResolvedValueOnce([{ donationGoalId: 10, total: 250 }]);
+
+    const res = await modelVersionDonationGoals({ id: 5, userId: 999, isModerator: true });
+
+    expect(mockCacheFetch).not.toHaveBeenCalled();
+    expect(mockCacheBust).not.toHaveBeenCalled();
+    expect(res).toContainEqual(expect.objectContaining({ id: 10, active: false }));
+  });
+});
+
+describe('modelVersionDonationGoals — shared key does not span the privilege dimension', () => {
+  it('(3) two anon users AND a logged-in non-owner share the identical modelVersionId key', async () => {
+    const payload = { '5': { modelVersionId: 5, goals: [publicGoal()] } };
+    mockCacheFetch.mockResolvedValue(payload);
+    // Logged-in non-owner still resolves the owner (to confirm non-ownership) but then serves
+    // the SAME public cache — never the privileged fresh path.
+    mockDbRead.modelVersion.findFirstOrThrow.mockResolvedValue(ownerVersion(7));
+
+    const anon1 = await modelVersionDonationGoals({ id: 5 });
+    const anon2 = await modelVersionDonationGoals({ id: 5 });
+    const nonOwner = await modelVersionDonationGoals({ id: 5, userId: 999 });
+
+    expect(anon1).toEqual(anon2);
+    expect(nonOwner).toEqual(anon1);
+    // Every read used the SAME viewer-independent key [5] — no per-user dimension.
+    for (const call of mockCacheFetch.mock.calls) expect(call[0]).toEqual([5]);
+    // The public (non-owner) path never reads goals directly from the DB.
+    expect(mockDbRead.donationGoal.findMany).not.toHaveBeenCalled();
+    expect(mockDbRead.$queryRaw).not.toHaveBeenCalled();
+  });
+});
+
+describe('modelVersionDonationGoals — output shape identical to uncached', () => {
+  it('(4) the cached public element matches the fresh privileged element for the same goal', async () => {
+    // Public (cache) result for the shared active goal.
+    mockCacheFetch.mockResolvedValueOnce({ '5': { modelVersionId: 5, goals: [publicGoal()] } });
+    const [pub] = await modelVersionDonationGoals({ id: 5 }); // anonymous
+
+    // Uncached privileged result computed from the equivalent DB row + summed total.
+    mockDbRead.modelVersion.findFirstOrThrow.mockResolvedValueOnce(ownerVersion(7));
+    mockDbRead.donationGoal.findMany.mockResolvedValueOnce([goalRow()]);
+    mockDbRead.$queryRaw.mockResolvedValueOnce([{ donationGoalId: 10, total: 250 }]);
+    const [priv] = await modelVersionDonationGoals({ id: 5, isModerator: true });
+
+    expect(Object.keys(pub).sort()).toEqual(Object.keys(priv).sort());
+    expect(pub).toEqual(priv);
+    expect(pub.createdAt).toBeInstanceOf(Date); // Date type preserved (msgpack round-trip)
+  });
+});

--- a/src/server/services/__tests__/model-version.idempotent.service.test.ts
+++ b/src/server/services/__tests__/model-version.idempotent.service.test.ts
@@ -56,7 +56,10 @@ vi.mock('~/server/prom/client', async (importOriginal) => {
 
 // Keep the heavy service/search-index graph out of the test module graph.
 vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null }));
-vi.mock('~/server/redis/caches', () => ({}));
+vi.mock('~/server/redis/caches', () => ({
+  // Privileged (moderator) reads below never touch this cache; stub it so the import resolves.
+  modelVersionPublicDonationGoalsCache: { fetch: vi.fn(), bust: vi.fn() },
+}));
 vi.mock('~/server/redis/client', async () => {
   const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
   // The `redis`/`sysRedis` client instances live on the app shim, NOT the
@@ -103,14 +106,17 @@ beforeEach(() => {
 // ---------------------------------------------------------------------------
 // Fix 2 — modelVersionDonationGoals → 404 when truly not found
 // ---------------------------------------------------------------------------
-describe('modelVersionDonationGoals', () => {
+// The privileged (owner/moderator) path is uncached and still runs the findFirstOrThrow
+// read→primary-fallback→404 resolution. (The anonymous / non-owner public path is served from
+// the shared cache — covered in model-version.donation-goals-cache.service.test.ts.)
+describe('modelVersionDonationGoals (privileged path)', () => {
   it('throws NOT_FOUND (404) when the version is missing on both read and write', async () => {
     mockDbRead.modelVersion.findFirstOrThrow.mockRejectedValueOnce(p2025());
     mockDbWrite.modelVersion.findFirstOrThrow.mockRejectedValueOnce(p2025());
 
     let caught: unknown;
     try {
-      await modelVersionDonationGoals({ id: 999 });
+      await modelVersionDonationGoals({ id: 999, isModerator: true });
     } catch (e) {
       caught = e;
     }
@@ -128,7 +134,7 @@ describe('modelVersionDonationGoals', () => {
     });
     mockDbRead.donationGoal.findMany.mockResolvedValueOnce([]);
 
-    const result = await modelVersionDonationGoals({ id: 1 });
+    const result = await modelVersionDonationGoals({ id: 1, isModerator: true });
     expect(result).toEqual([]);
     expect(mockDbWrite.modelVersion.findFirstOrThrow).toHaveBeenCalledTimes(1);
   });

--- a/src/server/services/donation-goal.service.ts
+++ b/src/server/services/donation-goal.service.ts
@@ -9,6 +9,7 @@ import {
 } from '~/server/services/buzz.service';
 import { bustMvCache } from '~/server/services/model-version.service';
 import { updateModelEarlyAccessDeadline } from '~/server/services/model.service';
+import { logToAxiom } from '~/server/logging/client';
 
 export const donationGoalById = async ({
   id,
@@ -182,10 +183,28 @@ export const checkDonationGoalComplete = async ({ donationGoalId }: { donationGo
   }
 
   // Eagerly bust the public donation-goals cache so a donor sees the updated total (and any
-  // now-inactive completed goal) immediately rather than after the ≤60s TTL. This runs on
-  // every donation (donateToGoal → checkDonationGoalComplete) and on early-access completion.
+  // now-inactive completed goal) immediately rather than after the ≤60s TTL. Runs on every
+  // donation (donateToGoal → checkDonationGoalComplete) and on early-access completion.
+  //
+  // MUST be fail-open: `bust` does an un-wrapped `redis.packed.set` that REJECTS on any redis
+  // error, and this function runs INSIDE donateToGoal's try AFTER `donation.create` has already
+  // committed — that catch refunds the buzz and throws "Failed to create donation" on ANY
+  // throw. So a redis blip here must NEVER propagate, or the donor is refunded for a persisted
+  // donation and retries → double donation. On failure the cache just serves a ≤60s-stale
+  // total, which is acceptable. (Guarding here protects BOTH callers of
+  // checkDonationGoalComplete.)
   if (goal.modelVersionId != null) {
-    await modelVersionPublicDonationGoalsCache.bust(goal.modelVersionId);
+    try {
+      await modelVersionPublicDonationGoalsCache.bust(goal.modelVersionId);
+    } catch (error) {
+      logToAxiom({
+        type: 'warning',
+        name: 'donation-goal-public-cache-bust-failed',
+        error,
+        donationGoalId,
+        modelVersionId: goal.modelVersionId,
+      }).catch(() => undefined);
+    }
   }
 
   return goal;

--- a/src/server/services/donation-goal.service.ts
+++ b/src/server/services/donation-goal.service.ts
@@ -1,5 +1,5 @@
 import { dbRead, dbWrite } from '~/server/db/client';
-import { dataForModelsCache } from '~/server/redis/caches';
+import { dataForModelsCache, modelVersionPublicDonationGoalsCache } from '~/server/redis/caches';
 import type { GetByIdInput } from '~/server/schema/base.schema';
 import { TransactionType, type BuzzSpendType } from '~/shared/constants/buzz.constants';
 import type { DonateToGoalInput } from '~/server/schema/donation-goal.schema';
@@ -179,6 +179,13 @@ export const checkDonationGoalComplete = async ({ donationGoalId }: { donationGo
       await bustMvCache(goal.modelVersionId, modelVersion.modelId);
       await dataForModelsCache.refresh(modelVersion.modelId);
     }
+  }
+
+  // Eagerly bust the public donation-goals cache so a donor sees the updated total (and any
+  // now-inactive completed goal) immediately rather than after the ≤60s TTL. This runs on
+  // every donation (donateToGoal → checkDonationGoalComplete) and on early-access completion.
+  if (goal.modelVersionId != null) {
+    await modelVersionPublicDonationGoalsCache.bust(goal.modelVersionId);
   }
 
   return goal;

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -28,8 +28,10 @@ import { logToAxiom } from '~/server/logging/client';
 import {
   dataForModelsCache,
   modelVersionAccessCache,
+  modelVersionPublicDonationGoalsCache,
   modelVersionResourceCache,
 } from '~/server/redis/caches';
+import type { ModelVersionPublicDonationGoal } from '~/server/redis/caches';
 import type { RedisKeyTemplateCache } from '~/server/redis/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { resourceDataCache } from '~/server/redis/resource-data.redis';
@@ -1910,6 +1912,17 @@ export const earlyAccessPurchase = async ({
   }
 };
 
+// Serve the PUBLIC (viewer-independent) donation-goal variant from the shared, modelVersionId-
+// keyed cache. A missing entry means the version doesn't exist → 404, matching the uncached
+// read→primary-fallback→NOT_FOUND behavior (the cache's lookupFn does the same primary
+// fallback and only seeds entries for versions that exist).
+const getPublicDonationGoals = async (id: number): Promise<ModelVersionPublicDonationGoal[]> => {
+  const cached = await modelVersionPublicDonationGoalsCache.fetch([id]);
+  const entry = cached[id];
+  if (!entry) throw throwNotFoundError(`No model version with id ${id}`);
+  return entry.goals;
+};
+
 export const modelVersionDonationGoals = async ({
   id,
   userId,
@@ -1918,7 +1931,17 @@ export const modelVersionDonationGoals = async ({
   id: number;
   userId?: number;
   isModerator?: boolean;
-}) => {
+}): Promise<ModelVersionPublicDonationGoal[]> => {
+  // Fast path — a caller that can be NEITHER the owner NOR a moderator always receives the
+  // public variant, which does not vary by viewer. Serve it from the shared cache with no
+  // per-viewer DB read. (canSeeAllGoals below can only be true when userId === ownerId or
+  // isModerator, so this branch can never be a privileged caller.)
+  if (!isModerator && userId == null) {
+    return getPublicDonationGoals(id);
+  }
+
+  // The caller MIGHT be privileged (owner or moderator) — resolve the version to learn the
+  // owner and to 404 / fall back to the primary on replica lag.
   const donationFindArgs = {
     where: { id },
     select: {
@@ -1953,11 +1976,19 @@ export const modelVersionDonationGoals = async ({
 
   const canSeeAllGoals = userId === version.model.userId || isModerator;
 
+  // Logged-in but NOT the owner and NOT a moderator → still the public variant. Route through
+  // the same shared cache: it can only ever hold the public payload, so no privileged/draft
+  // data can leak in, and the expensive donationGoal.findMany + Donation SUM are elided.
+  if (!canSeeAllGoals) {
+    return getPublicDonationGoals(id);
+  }
+
+  // PRIVILEGED (owner or moderator): computed fresh and NEVER read from / written to the
+  // public cache. This variant may include inactive/draft goals (active/isEarlyAccess filters
+  // dropped), so it must never enter the shared key.
   const donationGoals = await dbRead.donationGoal.findMany({
     where: {
       modelVersionId: id,
-      active: canSeeAllGoals ? undefined : true,
-      isEarlyAccess: version.earlyAccessEndsAt || canSeeAllGoals ? undefined : false, // Avoids returning earlyAccessGoals for public models.
     },
     select: {
       id: true,


### PR DESCRIPTION
## Lever

`model-version.donationGoals` (`publicProcedure`, backs the donation-progress display on the model version page) is **uncached** and runs 2–3 DB queries per call — `modelVersion.findFirstOrThrow` + `donationGoal.findMany` + a `Donation` `SUM` — at ~31 calls/s peak, i.e. **~60–75 DB queries/s** removed at peak.

## The leak axis: public vs. privileged

The response **varies by viewer**:

- **Owner / moderator** (`canSeeAllGoals = userId === model.userId || isModerator`): sees **ALL** goals, including inactive/draft ones (`active`/`isEarlyAccess` filters dropped).
- **Public** (anonymous / logged-in non-owner / non-moderator): sees only `active: true` goals, plus a per-version early-access filter (`isEarlyAccess` goals shown only while the version still has `earlyAccessEndsAt` set).

The public variant is **fully determined by `modelVersionId`** (it does not vary by viewer), so a single shared cache entry is correct for every non-privileged caller. The privileged variant must **never** enter that shared key.

## What's cached + how the split prevents a leak

New `modelVersionPublicDonationGoalsCache` (`createCachedObject`, keyed by `modelVersionId`, **TTL 60s** (`CacheTTL.xs`), no SWR, `cacheNotFound: false`). Its `lookupFn` reproduces the **public** computation exactly: existence + `earlyAccessEndsAt` (with the same replica→primary fallback as the uncached read), the `active: true` filter, the per-version early-access filter, and the summed totals. It seeds an **empty** entry for every existing version (so "exists, no goals" → `[]`) and **no** entry for a missing version (→ 404).

`modelVersionDonationGoals` gates on the leak axis **before** touching the cache:

1. **Anonymous** (`!isModerator && userId == null`) — can be neither owner nor mod, so it's unconditionally public → served from the cache with **zero per-viewer DB reads** (full savings).
2. **Logged-in** — resolve the version to learn the owner (also the 404 / replica-lag path). If **not** owner and **not** mod → public → same shared cache (still elides the `donationGoal.findMany` + `Donation` `SUM`). If owner/mod → **privileged path computed fresh, never reads from or writes to the cache.**

So a cached public payload can never be served to a privileged viewer, and an owner's draft-inclusive payload can never be written into the shared key. (Mirrors #3223 keeping per-user data out of the shared cache.)

## TTL + bust

- **TTL 60s** bounds worst-case staleness of a donation total / a just-created goal — acceptable for a progress display.
- **Eager bust** on `checkDonationGoalComplete` (runs on **every** `donateToGoal` and on early-access completion), keyed by the goal's `modelVersionId` — so a donor sees the new total (and any now-inactive completed goal) immediately, not after the TTL.
- The rare **publish-time** early-access goal-create path is **not** busted and relies on the 60s TTL: it's a brand-new version nobody has a meaningful cached view of, and a ≤60s lag before a just-published goal appears is imperceptible.

## Byte-identity

The public cache element is byte-identical to the old uncached public output element (`{ id, goalAmount, title, active, isEarlyAccess, userId, createdAt, description, total }`). The early-access filter is reproduced 1:1 (`goal.isEarlyAccess && !earlyAccessEndsAt` → skip ≡ the old `isEarlyAccess: earlyAccessEndsAt ? undefined : false`). `createdAt` (Date) round-trips through the msgpack `packed` store as a Date, so tRPC/superjson serialization is unchanged. The privileged path is untouched (its `where` collapses to `{ modelVersionId }`, exactly what `canSeeAllGoals=true` produced before).

## Pod-neutral framing

Bucket A (no behaviour change): user-visible output unchanged, owner/mod path unchanged. This is a DB total-exec-time / call-count reduction (~60–75 q/s). The DB runs ~4% CPU, so it's a **pod-neutral cost/margin** win, **NOT** a capacity win.

## Tests (17, all green)

- `model-version-public-donation-goals-cache.test.ts` — real cache mechanism (byte-copied lookupFn): dedup/TTL (2nd fetch within TTL skips DB), existing-version-with-no-goals → empty entry (`[]`, not 404), missing version → **no** entry and **not** negatively cached (`cacheNotFound: false`), the public early-access filter.
- `model-version.donation-goals-cache.service.test.ts` — (1) public cache hit skips the version+goals DB reads; (2) owner **and** moderator reads never read/write the public cache (no draft leak) and return draft/inactive goals fresh; (3) two anon users + a logged-in non-owner share the identical `[id]` key and payload; (4) the cached public element is shape- and value-identical to the fresh privileged element; missing version → 404.
- `donation-goal.service.test.ts` — `checkDonationGoalComplete` busts keyed by `modelVersionId`, and does not bust when the goal has no version.
- Updated `model-version.idempotent.service.test.ts` — the findFirst→primary-fallback→404 tests now exercise the (still-uncached) privileged path.

`NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit`: no new errors in touched files (13 pre-existing errors, all from the un-checked-out `event-engine-common` submodule + its downstream `image.service.ts`, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
