### PR TITLE
perf(tag): cache getTags hierarchy to cut DB load

### DIFF
--- a/src/pages/api/mod/adjust-tag-level.ts
+++ b/src/pages/api/mod/adjust-tag-level.ts
@@ -8,6 +8,7 @@ import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 import { commaDelimitedStringArray } from '~/utils/zod-helpers';
 
 import { tagCache, tagCacheByName } from '~/server/redis/caches';
+import { bustGetTagsCache } from '~/server/services/tag.service';
 
 const schema = z.object({
   tags: commaDelimitedStringArray(),
@@ -34,6 +35,10 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
     await Promise.all([
       ...tags.map((tag) => tagCacheByName.bust(tag)),
       ...tagIds.map((id) => tagCache.bust(id)),
+      // A tag's `nsfwLevel`/`type` gate the cached `getTags` listings (the PG-only
+      // filter forced on no-query calls, the type filter, and the nsfwLevel rollup)
+      // — bust so a re-leveled tag is dropped from stale listings.
+      bustGetTagsCache(),
     ]);
   }
 

--- a/src/server/services/__tests__/get-tags-cache.test.ts
+++ b/src/server/services/__tests__/get-tags-cache.test.ts
@@ -1,0 +1,193 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { CacheTTL } from '~/server/common/constants';
+import { hashifyObject } from '~/utils/string-helpers';
+
+// Faithful in-test mirror of the real `queryCache` read-through (cache-helpers.ts):
+// a MISS runs `db.$queryRaw(query)` and stores the result keyed by the query hash; a
+// HIT returns the stored value WITHOUT touching the DB. This lets us assert both the
+// "cache hit skips DB" contract and the bounded-key routing purely from DB call counts.
+const {
+  dbReadQueryRaw,
+  dbWriteExecuteRaw,
+  dbWriteQueryRaw,
+  bustCacheTag,
+  cacheableStore,
+  cacheableOptions,
+  modelVotableTagsBust,
+  imageTagsBust,
+  upsertTagsOnImageNew,
+  getSystemTags,
+  getReplacedTagIds,
+  getCategoryTags,
+  redisDel,
+} = vi.hoisted(() => ({
+  dbReadQueryRaw: vi.fn(),
+  dbWriteExecuteRaw: vi.fn().mockResolvedValue(undefined),
+  dbWriteQueryRaw: vi.fn().mockResolvedValue([]),
+  bustCacheTag: vi.fn().mockResolvedValue(undefined),
+  cacheableStore: new Map<string, unknown>(),
+  cacheableOptions: [] as unknown[],
+  modelVotableTagsBust: vi.fn().mockResolvedValue(undefined),
+  imageTagsBust: vi.fn().mockResolvedValue(undefined),
+  upsertTagsOnImageNew: vi.fn().mockResolvedValue(undefined),
+  getSystemTags: vi.fn().mockResolvedValue([]),
+  getReplacedTagIds: vi.fn().mockResolvedValue([]),
+  getCategoryTags: vi.fn().mockResolvedValue([]),
+  redisDel: vi.fn().mockResolvedValue(1),
+}));
+
+vi.mock('~/server/utils/cache-helpers', () => ({
+  fetchThroughCache: vi.fn(),
+  bustCacheTag,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  queryCache: (db: any) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (query: any, options: any) => {
+      cacheableOptions.push(options);
+      const key = hashifyObject(query).toString();
+      if (cacheableStore.has(key)) return cacheableStore.get(key);
+      const result = await db.$queryRaw(query);
+      cacheableStore.set(key, result);
+      return result;
+    },
+}));
+
+vi.mock('~/server/services/system-cache', () => ({
+  getSystemTags,
+  getReplacedTagIds,
+  getCategoryTags,
+}));
+
+vi.mock('~/server/redis/caches', () => ({
+  imageTagsCache: { fetch: vi.fn(), bust: imageTagsBust },
+  modelVotableTagsCache: { fetch: vi.fn(), bust: modelVotableTagsBust },
+  tagCache: { fetch: vi.fn(), bust: vi.fn() },
+}));
+
+vi.mock('~/server/redis/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/redis/client')>();
+  return {
+    ...actual,
+    // Keep the real REDIS_KEYS; stub only the client so mutations never hit a connection.
+    redis: { del: redisDel, packed: { get: vi.fn(), set: vi.fn() } },
+  };
+});
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: dbReadQueryRaw },
+  dbWrite: { $executeRaw: dbWriteExecuteRaw, $queryRaw: dbWriteQueryRaw },
+}));
+
+vi.mock('~/server/services/tagsOnImageNew.service', () => ({
+  upsertTagsOnImageNew,
+}));
+
+vi.mock('~/server/services/user-preferences.service', () => ({
+  HiddenImages: { refreshCache: vi.fn() },
+  HiddenModels: { refreshCache: vi.fn() },
+  ImplicitHiddenImages: { refreshCache: vi.fn() },
+}));
+
+import { addTags, deleteTags, disableTags, getTags } from '~/server/services/tag.service';
+
+const ROWS = [
+  { id: 1, name: 'anime' },
+  { id: 2, name: 'nude' },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cacheableStore.clear();
+  cacheableOptions.length = 0;
+  dbReadQueryRaw.mockResolvedValue(ROWS);
+  dbWriteQueryRaw.mockResolvedValue([]);
+});
+
+describe('getTags — listing cache (bounded key space)', () => {
+  it('a no-query listing is served from cache on the second identical call (DB hit once)', async () => {
+    const first = await getTags({});
+    const second = await getTags({});
+
+    // The static hierarchy read hit the DB exactly once across two identical calls.
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(1);
+    // Cached output is byte-identical to the origin read.
+    expect(second).toEqual(first);
+  });
+
+  it('reads through the cache with the 1h TTL and the getTags bust tag', async () => {
+    await getTags({});
+    expect(cacheableOptions).toHaveLength(1);
+    expect(cacheableOptions[0]).toEqual({ ttl: CacheTTL.hour, tag: 'getTags' });
+  });
+
+  it('output shape matches the raw rows (models/isCategory/nsfwLevel stripped when absent)', async () => {
+    const { items } = await getTags({});
+    expect(items).toEqual([
+      { id: 1, name: 'anime' },
+      { id: 2, name: 'nude' },
+    ]);
+  });
+
+  it('BYPASSES the cache for a free-text query (unbounded key space) — DB hit every call', async () => {
+    await getTags({ query: 'anim' });
+    await getTags({ query: 'anim' });
+    // No memoization: each identical query call re-hits the DB directly.
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(2);
+    // The cache read-through was never invoked for a query call.
+    expect(cacheableOptions).toHaveLength(0);
+  });
+
+  it('BYPASSES the cache when a modelId filter is present', async () => {
+    await getTags({ modelId: 5 });
+    await getTags({ modelId: 5 });
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(2);
+    expect(cacheableOptions).toHaveLength(0);
+  });
+
+  it('BYPASSES the cache when excludedTagIds is present', async () => {
+    await getTags({ excludedTagIds: [7, 8] });
+    await getTags({ excludedTagIds: [7, 8] });
+    expect(dbReadQueryRaw).toHaveBeenCalledTimes(2);
+    expect(cacheableOptions).toHaveLength(0);
+  });
+
+  it('the cached (no-query) path produces the same items as the equivalent uncached read', async () => {
+    const cached = await getTags({});
+    // A query-param call takes the bypass branch but reads the same underlying rows.
+    const uncached = await getTags({ query: 'anime' });
+    expect(cached.items).toEqual(uncached.items);
+  });
+});
+
+describe('getTags — cache invalidation contract', () => {
+  it('addTags(entityType:tag) busts the getTags listing cache (TagsOnTags INSERT)', async () => {
+    await addTags({ tags: [1], entityIds: [2], entityType: 'tag', relationship: 'Parent' });
+    expect(bustCacheTag).toHaveBeenCalledWith('getTags');
+  });
+
+  it('disableTags(entityType:tag) busts the getTags listing cache (TagsOnTags DELETE)', async () => {
+    await disableTags({ tags: [1], entityIds: [2], entityType: 'tag' });
+    expect(bustCacheTag).toHaveBeenCalledWith('getTags');
+  });
+
+  it('deleteTags busts the getTags listing cache (Tag entity DELETE)', async () => {
+    dbWriteQueryRaw
+      .mockResolvedValueOnce([]) // affected images
+      .mockResolvedValueOnce([]) // affected models
+      .mockResolvedValueOnce([]); // affected tag names
+    await deleteTags({ tags: [1] });
+    expect(bustCacheTag).toHaveBeenCalledWith('getTags');
+  });
+
+  it('addTags(entityType:model) does NOT bust the getTags listing cache (TagsOnModels only)', async () => {
+    await addTags({ tags: [1], entityIds: [2], entityType: 'model' });
+    expect(modelVotableTagsBust).toHaveBeenCalledWith([2]);
+    expect(bustCacheTag).not.toHaveBeenCalledWith('getTags');
+  });
+
+  it('disableTags(entityType:image) does NOT bust the getTags listing cache (TagsOnImages only)', async () => {
+    dbWriteQueryRaw.mockResolvedValue([]); // TagsOnImageDetails select
+    await disableTags({ tags: [1], entityIds: [2], entityType: 'image' });
+    expect(bustCacheTag).not.toHaveBeenCalledWith('getTags');
+  });
+});

--- a/src/server/services/__tests__/tag.service.unlisted.test.ts
+++ b/src/server/services/__tests__/tag.service.unlisted.test.ts
@@ -16,6 +16,7 @@ const {
   redisDel,
   redisPackedGet,
   redisPackedSet,
+  bustCacheTagSpy,
 } = vi.hoisted(() => ({
   imageTagsFetch: vi.fn(),
   imageTagsBust: vi.fn(),
@@ -32,6 +33,14 @@ const {
   redisDel: vi.fn().mockResolvedValue(1),
   redisPackedGet: vi.fn().mockResolvedValue(null),
   redisPackedSet: vi.fn().mockResolvedValue(undefined),
+  bustCacheTagSpy: vi.fn().mockResolvedValue(undefined),
+}));
+
+// deleteTags now also busts the static getTags listing cache via bustCacheTag('getTags').
+// Spy only that helper; keep the rest of cache-helpers real so no other read-through breaks.
+vi.mock('~/server/utils/cache-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/server/utils/cache-helpers')>()),
+  bustCacheTag: bustCacheTagSpy,
 }));
 
 vi.mock('~/server/redis/caches', () => ({
@@ -311,5 +320,20 @@ describe('getVotableTags — model votable-tags cache invalidation contract', ()
     await addTagVotes({ userId: 111, type: 'image', id: 42, tags: [304], vote: 1 });
     expect(modelVotableTagsBust).not.toHaveBeenCalled();
     expect(imageTagsBust).toHaveBeenCalledWith(42);
+  });
+
+  it('deleteTags also busts the static getTags listing cache', async () => {
+    dbWriteQueryRaw.mockReset();
+    dbWriteQueryRaw
+      .mockResolvedValueOnce([]) // affected images
+      .mockResolvedValueOnce([]) // affected models
+      .mockResolvedValueOnce([]); // affected tag names
+    await deleteTags({ tags: [304] });
+    expect(bustCacheTagSpy).toHaveBeenCalledWith('getTags');
+  });
+
+  it('a model vote does NOT bust the getTags listing cache (join-table only)', async () => {
+    await addTagVotes({ userId: 111, type: 'model', id: 1, tags: [304], vote: 1 });
+    expect(bustCacheTagSpy).not.toHaveBeenCalledWith('getTags');
   });
 });

--- a/src/server/services/tag.service.ts
+++ b/src/server/services/tag.service.ts
@@ -36,10 +36,19 @@ import {
 import { getPagination, getPagingData } from '~/server/utils/pagination-helpers';
 import { Flags } from '~/shared/utils/flags';
 import { TagSource, TagTarget, TagType } from '~/shared/utils/prisma/enums';
-import { fetchThroughCache } from '~/server/utils/cache-helpers';
+import { bustCacheTag, fetchThroughCache, queryCache } from '~/server/utils/cache-helpers';
 import { removeEmpty } from '~/utils/object-helpers';
 
 const alwaysIncludeTags = [...styleTags, ...subjectTags];
+
+// Read-through cache for the static, user-independent `getTags` listing hierarchy
+// — the expensive `TagsOnTags EXISTS` isCategory + nsfwLevel-rollup subqueries that
+// dominate this procedure's DB total-exec-time. Keyed by a hash of the full query
+// SQL (so every param variation is a distinct key). Busted on every writer that
+// changes the `Tag` taxonomy or the `TagsOnTags` hierarchy (see `bustGetTagsCache`).
+export const GET_TAGS_CACHE_TAG = 'getTags';
+const getTagsListingCache = queryCache(dbRead, 'getTags', 'v1');
+export const bustGetTagsCache = () => bustCacheTag(GET_TAGS_CACHE_TAG);
 
 type TagWithModelCount = { id: number; name: string; unfeatured: boolean; count: number };
 
@@ -346,9 +355,9 @@ export const getTags = async ({
       t."nsfwLevel") "nsfwLevel"`
     : Prisma.sql``;
 
-  const tagsRaw = await dbRead.$queryRaw<
-    { id: number; name: string; isCategory?: boolean; nsfwLevel?: number }[]
-  >`
+  type TagsRawRow = { id: number; name: string; isCategory?: boolean; nsfwLevel?: number };
+
+  const tagsRawQuery = Prisma.sql`
     SELECT t."id",
            t."name"
            ${isCategory}
@@ -363,6 +372,26 @@ export const getTags = async ({
     ORDER BY ${Prisma.raw(orderBy)}
     LIMIT ${take} OFFSET ${skip}
   `;
+
+  // Cache only the bounded-key-space listings — the ~28 calls/s category/trending
+  // hierarchy reads that dominate this procedure. Bypass the cache for the
+  // high-cardinality dimensions so the Redis key space can't explode:
+  //   - `query`:          free-text `name LIKE` search — effectively unbounded.
+  //   - `modelId`:        per-model `TagsOnModels EXISTS` filter (huge id space, and
+  //                       would pull `TagsOnModels` into the invalidation surface).
+  //   - `excludedTagIds`: caller-supplied id arrays (rare admin/form paths).
+  // The cacheable path is user-INDEPENDENT: every input (incl. `includeAdminTags`,
+  // which toggles the `adminOnly = false` clause) is baked into `tagsRawQuery`, so
+  // the query hash IS the full param key — no per-user data, no admin-tag leak to
+  // non-admins. It depends only on `Tag` + `TagsOnTags` + `TagMetric`.
+  const cacheableListing = !query && !modelId && !(excludedTagIds && excludedTagIds.length);
+
+  const tagsRaw = cacheableListing
+    ? await getTagsListingCache<TagsRawRow[]>(tagsRawQuery, {
+        ttl: CacheTTL.hour,
+        tag: GET_TAGS_CACHE_TAG,
+      })
+    : await dbRead.$queryRaw<TagsRawRow[]>(tagsRawQuery);
 
   const models: Record<number, number[]> = {};
   // if (withModels) {
@@ -760,6 +789,10 @@ export const addTags = async ({ tags, entityIds, entityType, relationship }: Adj
         await redis.del(`${REDIS_KEYS.SYSTEM.CATEGORIES}:${tag.name.replace(' category', '')}`);
       } catch {}
     }
+
+    // Adding a TagsOnTags edge changes category membership + the nsfwLevel rollup
+    // that the cached `getTags` listings compute — bust the listing cache.
+    await bustGetTagsCache();
   }
 };
 
@@ -845,6 +878,10 @@ export const disableTags = async ({ tags, entityIds, entityType }: AdjustTagsSch
 
     // Bust cache for tag rules (since we can't easily check the type)
     await redis.del(REDIS_KEYS.SYSTEM.TAG_RULES);
+
+    // Removing a TagsOnTags edge changes category membership + the nsfwLevel rollup
+    // that the cached `getTags` listings compute — bust the listing cache.
+    await bustGetTagsCache();
   }
 };
 
@@ -939,6 +976,10 @@ export const deleteTags = async ({ tags }: DeleteTagsSchema) => {
   if (affectedTags.length > 0) {
     await Promise.all(affectedTags.map((t) => bustTagWithModelCountCache(t.name)));
   }
+
+  // Deleting a Tag removes it from the cached `getTags` listings (and cascades its
+  // TagsOnTags edges, changing category membership / nsfwLevel rollup) — bust.
+  await bustGetTagsCache();
 };
 
 // unused

--- a/src/tests/api/mod/adjust-tag-level.test.ts
+++ b/src/tests/api/mod/adjust-tag-level.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// adjust-tag-level UPDATEs a tag's nsfwLevel/type — a dimension the cached `getTags`
+// listings filter on — so it must bust the getTags listing cache alongside the
+// existing per-id / per-name tag caches. This drives the handler in isolation and
+// asserts the bust fires exactly when rows were actually updated.
+const { pgQuery, batchProcessor, tagBust, tagByNameBust, bustGetTagsCache } = vi.hoisted(() => ({
+  pgQuery: vi.fn(),
+  batchProcessor: vi.fn().mockResolvedValue(undefined),
+  tagBust: vi.fn().mockResolvedValue(undefined),
+  tagByNameBust: vi.fn().mockResolvedValue(undefined),
+  bustGetTagsCache: vi.fn().mockResolvedValue(undefined),
+}));
+
+// WebhookEndpoint is a passthrough wrapper in tests.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: any) => handler,
+}));
+vi.mock('~/server/db/pgDb', () => ({ pgDbWrite: { query: pgQuery } }));
+vi.mock('~/server/db/db-helpers', () => ({ batchProcessor }));
+vi.mock('~/server/redis/caches', () => ({
+  tagCache: { bust: tagBust },
+  tagCacheByName: { bust: tagByNameBust },
+}));
+// Stub tag.service so importing the handler doesn't pull the full server graph.
+vi.mock('~/server/services/tag.service', () => ({ bustGetTagsCache }));
+
+import handler from '~/pages/api/mod/adjust-tag-level';
+
+function createMocks(query: Record<string, string>) {
+  const req = { method: 'GET', query } as unknown as NextApiRequest;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as NextApiResponse;
+  return { req, res };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('adjust-tag-level — getTags cache invalidation', () => {
+  it('busts the getTags listing cache when tags were re-leveled', async () => {
+    pgQuery.mockResolvedValue({ rows: [{ id: 11 }, { id: 12 }] });
+    const { req, res } = createMocks({ tags: 'anime,nude', nsfwLevel: '1' });
+
+    await handler(req, res);
+
+    expect(bustGetTagsCache).toHaveBeenCalledTimes(1);
+    // The existing per-name / per-id busts still fire too.
+    expect(tagByNameBust).toHaveBeenCalled();
+    expect(tagBust).toHaveBeenCalled();
+  });
+
+  it('does NOT bust when no rows changed (no-op update)', async () => {
+    pgQuery.mockResolvedValue({ rows: [] });
+    const { req, res } = createMocks({ tags: 'anime', nsfwLevel: '1' });
+
+    await handler(req, res);
+
+    expect(bustGetTagsCache).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Lever

`getTags` (`src/server/services/tag.service.ts`, backing `tag.getAll` + `tag.getTrendingTags`) is the **2nd-biggest uncached DB `total_exec_time` consumer at peak** (~121,621s total, ~70–96ms mean, 1.7M calls; ~28.2 calls/s for `getAll`). The cost is the `isCategory` + nsfwLevel-rollup **`TagsOnTags EXISTS` subquery hierarchy** — a user-independent, edit-rare read of the global tag taxonomy. This adds a read-through cache over the bounded, hot listing calls (same series as #3223 / #3229).

## Static-vs-per-user analysis

`getTags` is **fully user-INDEPENDENT** — it references **no `userId`, no session, no `ctx`**. Every input is an explicit param: `take/skip, types, entityType, query, modelId, excludedTagIds, unlisted, categories, sort, withModels, includeAdminTags, nsfwLevel, include, moderation`. The only capability-flavored input is `includeAdminTags` (from `ctx.features.adminTags`), and it merely toggles the `t."adminOnly" = false` clause — so it is baked into the query SQL and becomes part of the cache key. **There is no per-user slice to split off**, and **no admin-tag leak to non-admins** is possible (admin vs non-admin produce different SQL → different keys).

Cache mechanism: the existing **`queryCache(dbRead, 'getTags', 'v1')`** read-through (`cache-helpers.ts`, same helper as `getRatingTotals` / `getPostsInfinite`). The cache key is a hash of the full compiled `Prisma.Sql` (all interpolated params + the `isCategory`/`isNsfwLevel`/`orderBy` fragments), so **byte-identical params map to one key automatically**. Output is byte-identical: on a miss it runs the exact same `dbRead.$queryRaw`; a hit returns the same rows, then the unchanged `.map(removeEmpty(...))` runs.

## How the key space is bounded

CRITICAL: cache **only when `!query && !modelId && !excludedTagIds?.length`** — the ~28 calls/s category/trending listings that dominate the 1.7M calls (`useCategoryTags`, the tag pickers' trending mode, `getTrendingTags`). The high-cardinality dimensions **bypass to the DB directly** (unchanged behavior) so Redis can't blow up:

- **`query`** — free-text `t."name" LIKE $1` search → effectively unbounded key space. Never cached. (The autocomplete callers, e.g. `VotableTagAdd`, are `enabled`-gated on typed input.)
- **`modelId`** — per-model `TagsOnModels EXISTS` filter → huge id space, and would pull `TagsOnModels` into the invalidation surface. Low-frequency modal/form callers only (`BlockModelTagsModal`, `GalleryModerationModal`, `ModelUpsertForm`).
- **`excludedTagIds`** — caller-supplied id arrays; rare admin/form paths.

The cached path therefore depends only on **`Tag` + `TagsOnTags` + `TagMetric`** (+ the already-separately-cached `system-cache` values, which are interpolated into the SQL and thus the key).

## TTL

`CacheTTL.hour` (1h), no SWR — matches `imageTagsCache` / the #3223 model-votable-tags cache / #3229. The taxonomy + hierarchy are edit-rare; 1h also bounds the TTL-bounded staleness windows below.

## Full invalidation surface

A single coarse tag (`bustGetTagsCache()` -> `bustCacheTag('getTags')`) flushes the whole namespace, since the key space spans many enum combos.

**Busted (writers that change the cached listings):**

- `addTags` (`entityType === 'tag'`) — `tag.service.ts:~792` — INSERT `TagsOnTags` (category membership / Parent / nsfwLevel rollup).
- `disableTags` (`entityType === 'tag'`) — `tag.service.ts:~881` — DELETE `TagsOnTags`.
- `deleteTags` — `tag.service.ts:~980` — DELETE `Tag` (listing existence; cascades its `TagsOnTags` edges).
- `adjust-tag-level` — `src/pages/api/mod/adjust-tag-level.ts:~38` — UPDATE `Tag` `nsfwLevel`/`type` (the PG-only filter forced on no-query calls, the type filter, and the base nsfwLevel used in the rollup). Busts only when rows actually changed.

**Intentionally NOT busted (justified):**

- **`TagMetric` writes (listing sort order)** — TTL-bounded <=1h. `TagMetric` is refreshed by a frequent metrics job; busting there would collapse the cache for mere ordering freshness, which is inherently slow-moving. (Mirrors #3229 TTL-bounding `unfeatured`.)
- **Tag `target` first-use writes** — `question.service` `upsertQuestion`, `post.service` `upsertTag`, `model3d.service` (all guarded to fire only the first time a tag gains an entity target). A tag newly gaining a `target` only surfaces in a **non-category, non-query** listing; the hot cached callers all pass `categories: true` (category dropdowns, which UGC tags aren't members of) or use `query` (bypassed). TTL-bounded <=1h.
- **New UGC-tag creation** — `findOrCreateTagsByName`, `post.service` `tx.tag.create`, `model3d.service` `tag.createMany`, `image-scan-result.service` `INSERT "Tag"`. A brand-new UGC tag has no `TagsOnTags`/category membership, so it only surfaces via `query` (bypassed) or after a mod categorizes it (which busts via `addTags(tag)`). Not busting keeps the cache effective against the high-frequency upload path.
- **Out-of-band `Tag` column edits (`adminOnly`, `unfeatured`, `unlisted`)** — these are cached WHERE-filter inputs with **no app-side writer** (set via retool / direct DB / job refresh only), so a change leaves the affected listing stale for <=1h. Same TTL-bounded class as above; **not a leak** — admin-vs-non-admin still key on different SQL via the `adminOnly = false` clause. (`unfeatured` also has no app writer per #3229's sweep; `unlisted` is a passed query param, but a direct flip of the stored column is out-of-band.)
- **`addTags`/`disableTags`/`moderateTags` (`model`/`image`/`article`)** and the **`apply-tag-rules` job** — write the `TagsOnModels`/`TagsOnImages`/`TagsOnArticle`/`TagsOnPost`/`TagsOnCollection` join tables, **not** `Tag`/`TagsOnTags`. They don't affect the non-`modelId` cached listing (they feed the image/model votable-tags caches, already wired).

## Byte-identical / pod-neutral (Bucket A)

No behaviour change: same array shape, same values, per-request identical output. This is a **DB total-exec-time / call-count reduction only**. The DB runs at ~4% CPU, so it's a **pod-neutral cost/margin win** (the 2nd-biggest DB consumer), **NOT a capacity win** — no pod reduction is claimed.

## Tests

New `get-tags-cache.test.ts` (12): cache-hit skips the DB (1 DB call across two identical no-query calls); read-through uses `CacheTTL.hour` + tag `getTags`; output shape unchanged; **bypass** proven for `query` / `modelId` / `excludedTagIds` (2 DB calls, cache never invoked); cached vs uncached items identical; and an assertion for **each** wired bust — `addTags(tag)` / `disableTags(tag)` / `deleteTags` bust `getTags`, while `addTags(model)` / `disableTags(image)` do **not**.

New `adjust-tag-level.test.ts` (2): busts `getTags` when rows were re-leveled; does **not** bust on a no-op update.

Extended `tag.service.unlisted.test.ts` (+2): `deleteTags` also busts the static listing cache; a model vote does not.

`33/33` pass. `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` -> **exit 0** (no `any` in production code).

## Known limitations

- The `queryCache` key is a 32-bit `hashify` of the compiled SQL — the house standard (`getRatingTotals`/`getPostsInfinite`); a hash collision would serve a wrong row. Inherited, not new.
- `TagMetric` ordering, `target` first-use, and new-UGC-tag visibility are TTL-bounded (<=1h) as detailed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
