### PR TITLE
perf(search-index): env-configurable model-metric flush debounce (default 15m → 45m)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -386,6 +386,22 @@ export const serverSchema = z
     SEARCH_API_KEY: z.string().optional(),
     METRICS_SEARCH_HOST: z.url().optional(),
     METRICS_SEARCH_API_KEY: z.string().optional(),
+    // Debounce window (ms) for flushing model-metric-affected ids into the
+    // model search-index update queue. The model metric processor runs every
+    // minute and accumulates every model whose ModelVersionMetric.updatedAt
+    // changed into a Redis SET (dedup); it only drains that SET into the
+    // search-index queue once per window. Widening the window collapses more
+    // of a hot model's repeated metric changes into a single reindex, shrinking
+    // the burst the search backend has to drain at peak. Cost: metric-count /
+    // popularity-rank staleness on the search doc lags by up to the window
+    // (genuine mutations still reindex immediately via the service layer).
+    // Default 45m (3× the previous fixed 15m); tune down to react faster or up
+    // to shed more search-index write pressure.
+    SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(45 * 60 * 1000),
     // Per-call Meilisearch timeout in ms. Calls wrapped via withMeili() fail
     // fast with MeiliCallTimeoutError once exceeded, instead of hanging until
     // Traefik's 30s router timeout fires. Default tuned for the image feed

--- a/src/server/metrics/__tests__/model-metric-search-flush.test.ts
+++ b/src/server/metrics/__tests__/model-metric-search-flush.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldFlushMetricSearchIndex } from '~/server/metrics/model-metric-search-flush';
+
+/**
+ * Model-metric → search-index flush debounce.
+ *
+ * The processor accumulates affected model ids every minute and only drains
+ * them into the search-index queue once per `intervalMs`. `shouldFlushMetricSearchIndex`
+ * is the pure timing gate; a wider interval = more dedup = a smaller reindex
+ * burst, at the cost of the metric-doc lagging by up to the window.
+ */
+describe('shouldFlushMetricSearchIndex — debounce gate', () => {
+  const FIFTEEN_MIN = 15 * 60 * 1000;
+  const FORTY_FIVE_MIN = 45 * 60 * 1000;
+
+  it('does not flush before the interval has elapsed', () => {
+    const lastFlush = 1_000_000;
+    // one ms short of the window
+    expect(
+      shouldFlushMetricSearchIndex(lastFlush + FORTY_FIVE_MIN - 1, lastFlush, FORTY_FIVE_MIN)
+    ).toBe(false);
+  });
+
+  it('flushes exactly at the interval boundary', () => {
+    const lastFlush = 1_000_000;
+    expect(
+      shouldFlushMetricSearchIndex(lastFlush + FORTY_FIVE_MIN, lastFlush, FORTY_FIVE_MIN)
+    ).toBe(true);
+  });
+
+  it('flushes once the interval is exceeded', () => {
+    const lastFlush = 1_000_000;
+    expect(
+      shouldFlushMetricSearchIndex(lastFlush + FORTY_FIVE_MIN + 60_000, lastFlush, FORTY_FIVE_MIN)
+    ).toBe(true);
+  });
+
+  it('honors the configured interval — a wider window suppresses a flush that a narrower one would allow', () => {
+    const lastFlush = 1_000_000;
+    // 20 min after the last flush: past the old 15m window, still inside a 45m window.
+    const now = lastFlush + 20 * 60 * 1000;
+    expect(shouldFlushMetricSearchIndex(now, lastFlush, FIFTEEN_MIN)).toBe(true);
+    expect(shouldFlushMetricSearchIndex(now, lastFlush, FORTY_FIVE_MIN)).toBe(false);
+  });
+
+  it('flushes on a cold start (no prior flush recorded → lastFlush 0)', () => {
+    // Mirrors the processor mapping a missing MODEL_METRIC_LAST_FLUSH key to 0.
+    expect(shouldFlushMetricSearchIndex(Date.now(), 0, FORTY_FIVE_MIN)).toBe(true);
+  });
+});

--- a/src/server/metrics/model-metric-search-flush.ts
+++ b/src/server/metrics/model-metric-search-flush.ts
@@ -1,0 +1,23 @@
+/**
+ * Debounce decision for the model-metric → search-index flush.
+ *
+ * The model metric processor runs every minute and accumulates every model
+ * whose `ModelVersionMetric.updatedAt` changed into a Redis SET (dedup). Those
+ * ids are only flushed into the `models` search-index update queue on a
+ * debounce window: the wider the window, the more a hot model's repeated
+ * metric changes collapse into a single reindex, which shrinks the burst the
+ * single-node search backend has to drain.
+ *
+ * This decision is factored out as a pure function so the timing/dedup
+ * behaviour is unit-testable without Redis, env, or the search-index client.
+ * The window itself is env-configurable (see
+ * `SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS`) so ops can widen or narrow it
+ * at runtime without a redeploy.
+ */
+export function shouldFlushMetricSearchIndex(
+  now: number,
+  lastFlush: number,
+  intervalMs: number
+): boolean {
+  return now - lastFlush >= intervalMs;
+}

--- a/src/server/metrics/model.metrics.ts
+++ b/src/server/metrics/model.metrics.ts
@@ -1,8 +1,10 @@
 import dayjs from '~/shared/utils/dayjs';
 import { chunk } from 'lodash-es';
+import { env } from '~/env/server';
 import { PG_INT4_MAX, PG_INT4_MIN } from '~/server/common/constants';
 import { SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { templateHandler } from '~/server/db/db-helpers';
+import { shouldFlushMetricSearchIndex } from '~/server/metrics/model-metric-search-flush';
 import type { MetricProcessorRunContext } from '~/server/metrics/base.metrics';
 import { createMetricProcessor } from '~/server/metrics/base.metrics';
 import { executeRefresh } from '~/server/metrics/metric-helpers';
@@ -135,12 +137,21 @@ export const modelMetrics = createMetricProcessor({
       );
     }
 
-    const FLUSH_INTERVAL_MS = 15 * 60 * 1000;
+    // Debounce window for draining the accumulated ids into the search-index
+    // queue. Widening it collapses more of a hot model's repeated metric
+    // changes into a single reindex, shrinking the burst the search backend
+    // has to drain at peak. Env-configurable so ops can tune it at runtime
+    // without a redeploy (default 45m — 3× the previous fixed 15m). The only
+    // cost is metric-drift staleness on the search doc (download/generation
+    // counts and the popularity rank derived from them lag by up to the
+    // window); genuine mutations still reindex immediately via the untouched
+    // service-layer queueUpdate path.
+    const FLUSH_INTERVAL_MS = env.SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS;
     const lastFlushStr = await sysRedis.get(
       REDIS_SYS_KEYS.INDEX_UPDATES.MODEL_METRIC_LAST_FLUSH
     );
     const lastFlush = lastFlushStr ? new Date(lastFlushStr).getTime() : 0;
-    const shouldFlush = Date.now() - lastFlush >= FLUSH_INTERVAL_MS;
+    const shouldFlush = shouldFlushMetricSearchIndex(Date.now(), lastFlush, FLUSH_INTERVAL_MS);
 
     if (shouldFlush) {
       const pendingRaw = await sysRedis.sMembers(


### PR DESCRIPTION
## What

Make the model-metric → search-index flush debounce window **env-configurable** and raise the default from a fixed **15 minutes to 45 minutes**.

## Why

The model metric processor (`model.metrics.ts`) runs every minute and, as the existing code comment documents, accumulates *every* model whose `ModelVersionMetric.updatedAt` changed in that minute into a Redis SET — dominated by download/generation activity, a large fraction of which is not a user-visible mutation. Those ids are drained into the `models` search-index update queue on a debounce window.

The debounce is a dedup lever: a hot model whose metrics change many times inside the window gets reindexed **once** instead of N times. Widening the window collapses more of that repeated churn into a single reindex, which shrinks the search-index write burst the backend has to drain — reducing queue pressure and shed/timeout risk when search write volume outpaces what the index can absorb.

## Change

- New env var **`SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS`** (`z.coerce.number().int().positive()`, default `45 * 60 * 1000`) replaces the hardcoded `FLUSH_INTERVAL_MS = 15 * 60 * 1000`. Ops can widen it to shed more write pressure, or narrow it to react faster, at runtime with no redeploy.
- The debounce decision is extracted into a pure `shouldFlushMetricSearchIndex(now, lastFlush, intervalMs)` helper so the timing/dedup gate is unit-tested without Redis or env.

## Trade-off

The only cost is **metric-drift staleness on the search doc**: download/generation counts, and the popularity rank derived from them, lag by up to the window (now up to 45m vs 15m). This is bounded and cosmetic — **genuine mutations (publish, edit, tag changes) still reindex immediately** via the untouched service-layer `queueUpdate` path; only the passive metric-count refresh is debounced. Reversible: set the env var back to `900000` (15m) to restore prior behavior.

## Tests

Added `src/server/metrics/__tests__/model-metric-search-flush.test.ts` — 5 cases covering the debounce gate: no flush before the interval, flush at/after the boundary, cold-start (no prior flush) flushes, and that a wider configured window suppresses a flush a narrower one would allow. All pass under the `unit` project.

`npx tsc --noEmit` is clean for the changed files.
