### PR TITLE
Harden SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS env knob so a bad value can't crash app boot

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -126,6 +126,13 @@ NEXT_PUBLIC_SEARCH_CLIENT_KEY=meilisearch
 METRICS_SEARCH_HOST=http://localhost:7700
 METRICS_SEARCH_API_KEY=meilisearch
 
+# Debounce window (ms) for flushing model-metric-affected ids into the model
+# search-index update queue. Widening it collapses more of a hot model's repeated
+# metric changes into a single reindex (cost: metric/popularity staleness lags by
+# up to the window). Fail-soft: a bad value falls back to the 45m default. Requires
+# a restart/rollout to take effect. Default 45m.
+# SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS=2700000
+
 # Per-call Meilisearch timeout in ms. Calls wrapped via withMeili() fail fast
 # with MeiliCallTimeoutError once exceeded, instead of hanging until Traefik's
 # 30s router timeout fires.

--- a/src/env/__tests__/server-schema-model-metric-flush.test.ts
+++ b/src/env/__tests__/server-schema-model-metric-flush.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { serverSchema } from '~/env/server-schema';
+
+// Follow-up to #3243 — harden the SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS knob.
+// Before: z.coerce.number().int().positive().default(45m) — a 0/empty/float/garbage
+// value (e.g. a "disable debounce" attempt) failed validation, and because the whole
+// serverSchema throws on any invalid field (src/env/server.ts) that crashed the ENTIRE
+// app boot, not just search.
+// After:  .int().min(60_000).catch(45m) — any invalid/out-of-range/garbage value
+// falls back to the 45m default rather than throwing; valid in-range values pass through.
+const DEFAULT = 45 * 60 * 1000;
+const field = serverSchema.shape.SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS;
+
+describe('SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS env fail-soft', () => {
+  it('falls back to the default for empty/garbage/out-of-range values (never throws)', () => {
+    // '' and '0' coerce to 0 (a plausible "disable debounce" attempt); '1000.5' is a
+    // float; 'abc' is non-numeric; '30000' is below the 1-minute floor.
+    for (const bad of ['', '0', '-1', '1000.5', 'abc', '30000']) {
+      expect(() => field.parse(bad)).not.toThrow();
+      expect(field.parse(bad), `expected fallback for ${JSON.stringify(bad)}`).toBe(DEFAULT);
+    }
+  });
+
+  it('falls back to the default when undefined (missing)', () => {
+    expect(field.parse(undefined)).toBe(DEFAULT);
+  });
+
+  it('passes through valid in-range values', () => {
+    expect(field.parse('60000')).toBe(60000); // 1-minute floor inclusive
+    expect(field.parse('2700000')).toBe(DEFAULT); // 45m
+    expect(field.parse('5400000')).toBe(5400000); // 90m
+  });
+});

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -396,12 +396,24 @@ export const serverSchema = z
     // popularity-rank staleness on the search doc lags by up to the window
     // (genuine mutations still reindex immediately via the service layer).
     // Default 45m (3× the previous fixed 15m); tune down to react faster or up
-    // to shed more search-index write pressure.
+    // to shed more search-index write pressure. Changing it requires a pod
+    // restart/rollout to take effect (env is read once at module load — no live
+    // reconfiguration, though no image rebuild is needed).
+    // `.int().min(60_000).catch(45m)` fail-soft: this is a single, non-critical
+    // search-hygiene knob, but it is parsed as part of the whole-app serverSchema
+    // that throws on ANY invalid field (src/env/server.ts) — so a bad value here
+    // (0/empty/float/garbage — e.g. a "disable debounce" attempt) would crash the
+    // ENTIRE app boot, not just search. `.catch(...)` degrades any parse/validation
+    // failure to the safe 45m default instead of crashing; the `.min(60_000)`
+    // (1-minute) floor is documented intent — a sub-minute window is pointless
+    // (the processor only runs once per minute) and out-of-range/garbage values
+    // fall back to the default rather than throwing. Mirrors the
+    // EXTERNAL_MODERATION_TIMEOUT_MS clamp pattern below.
     SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS: z.coerce
       .number()
       .int()
-      .positive()
-      .default(45 * 60 * 1000),
+      .min(60_000)
+      .catch(45 * 60 * 1000),
     // Per-call Meilisearch timeout in ms. Calls wrapped via withMeili() fail
     // fast with MeiliCallTimeoutError once exceeded, instead of hanging until
     // Traefik's 30s router timeout fires. Default tuned for the image feed

--- a/src/server/metrics/model.metrics.ts
+++ b/src/server/metrics/model.metrics.ts
@@ -140,8 +140,11 @@ export const modelMetrics = createMetricProcessor({
     // Debounce window for draining the accumulated ids into the search-index
     // queue. Widening it collapses more of a hot model's repeated metric
     // changes into a single reindex, shrinking the burst the search backend
-    // has to drain at peak. Env-configurable so ops can tune it at runtime
-    // without a redeploy (default 45m — 3× the previous fixed 15m). The only
+    // has to drain at peak. Env-configurable, but the value is read once at
+    // module load, so a change requires a pod restart/rollout to take effect
+    // (no image rebuild needed — it is NOT reconfigurable live). A bad value
+    // fails soft to the 45m default (see server-schema.ts) rather than crashing
+    // boot (default 45m — 3× the previous fixed 15m). The only
     // cost is metric-drift staleness on the search doc (download/generation
     // counts and the popularity rank derived from them lag by up to the
     // window); genuine mutations still reindex immediately via the untouched


### PR DESCRIPTION
Small follow-up to #3243 to harden the `SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS` env knob it added (the model-metric → search-index flush debounce). Two audit findings, plus a nit. No behavior change on the happy path.

## Finding 1 — a misconfigured value could crash the whole app boot
`src/env/server.ts` runs `serverSchema.safeParse(process.env)` once for the entire app and throws on **any** invalid field. This knob was pitched as ops-tunable, which invites a plausible "disable the debounce" attempt like setting it to `0` — or an empty string (`z.coerce` → `0`), a float, or any non-numeric value. Under the old `z.coerce.number().int().positive().default(45m)`, all of those **fail validation → the whole app fails to boot**, not just search.

**Fix:** make just this one field fail-soft.

```
-    SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS: z.coerce
-      .number()
-      .int()
-      .positive()
-      .default(45 * 60 * 1000),
+    SEARCH_INDEX_MODEL_METRIC_FLUSH_INTERVAL_MS: z.coerce
+      .number()
+      .int()
+      .min(60_000)
+      .catch(45 * 60 * 1000),
```

- `.catch(45m)` guarantees any parse/validation failure degrades to the safe default instead of throwing — so a bad value for this one var can never crash boot.
- `.min(60_000)` (a 1-minute floor) is documented intent, not a new throw path: `.catch` swallows out-of-range values back to the default too. A sub-minute window is pointless anyway (the processor only runs once per minute).

I did **not** touch the schema-wide throw-on-invalid behavior — that's the existing pattern for required config and is out of scope; only this single non-critical knob is made resilient.

**Convention:** `.catch()` is already the established fail-soft idiom in this schema — this mirrors `EXTERNAL_MODERATION_TIMEOUT_MS` (`z.coerce.number().int().min(100).max(60000).catch(5000)`, #2734), which exists for exactly this "a bad ops value must not crash boot / silently disable a subsystem" reason. So `.catch` fits the surrounding style rather than being out of place.

## Finding 2 — misleading "tunable at runtime" wording
A comment in `src/server/metrics/model.metrics.ts` said the knob is "Env-configurable so ops can tune it at runtime without a redeploy." `env` is a static snapshot read once at module load, so that's inaccurate — a change needs a **pod restart/rollout** to take effect (no image rebuild, but a restart). Reworded both the schema comment and the consumer comment to say so, so nobody expects live reconfiguration.

## Nit — `.env-example`
Added a commented entry next to its sibling `METRICS_SEARCH_HOST`, matching the file's convention.

## Test
Added `src/env/__tests__/server-schema-model-metric-flush.test.ts` (mirrors the existing `server-schema-moderation-timeout.test.ts`) asserting the field coerces `""`, `"0"`, `"-1"`, a float string, `"abc"`, and a below-floor value to the 45m default rather than throwing, and passes valid in-range values through.

```
✓ src/env/__tests__/server-schema-model-metric-flush.test.ts (3 tests)
✓ src/server/metrics/__tests__/model-metric-search-flush.test.ts (5 tests)  # #3243's, still green
```

Do not merge — opening for review.
