### PR TITLE
fix(pricing): SSR-prefetch membership plans to remove loading flash

### DIFF
--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -17,6 +17,27 @@ import { useBuzzCurrencyConfig } from '~/components/Currency/useCurrencyConfig';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { Button, Stack, Text, ThemeIcon, Title } from '@mantine/core';
 import { IconArrowRight, IconPepper } from '@tabler/icons-react';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { PaymentProvider } from '~/shared/utils/prisma/enums';
+
+export const getServerSideProps = createServerSideProps({
+  useSSG: true,
+  useSession: true,
+  resolver: async ({ ssg, features }) => {
+    // Only the green environment renders the MembershipPlans view, which otherwise
+    // flashes a client-side loading state while it fetches plans. Prefetch that same
+    // query (interval 'month', green buzz) so the plans are present on first paint.
+    if (features?.isGreen && ssg) {
+      await ssg.subscriptions.getPlans.prefetch({
+        interval: 'month',
+        buzzType: 'green',
+        paymentProvider: features.disablePayments
+          ? PaymentProvider.Civitai
+          : PaymentProvider.Stripe,
+      });
+    }
+  },
+});
 
 export default function Pricing() {
   const router = useRouter();


### PR DESCRIPTION
## Problem
On the green pricing page (`/pricing`, civitai.com), the membership plans render behind a client-side loading state. During that fetch the "Unrestricted content creation has moved to civitai.red" banner shows on its own, so the page briefly looks broken / like it's just telling you to go back to red.

## Fix
Added `getServerSideProps` that prefetches `subscriptions.getPlans` (the same query the client fires on first render) so the plan cards are present on first paint — no loader flash under the banner.

- Only prefetches on the green environment (`features.isGreen`) — every non-green path returns early and never renders `MembershipPlans`, so nothing to prefetch there.
- Prefetch input matches the client's first-render query key exactly (`interval: 'month'`, `buzzType: 'green'`, provider `Stripe`/`Civitai` per `disablePayments`) so hydration hits the cache.
- `getPlans` is a `publicProcedure`, so SSR prefetch works without auth. Banner markup untouched.

## Verify
- `/pricing` on green, throttled hard refresh → plan cards present in server-rendered HTML, no `<Loader />` flash.
- Non-green domains unchanged (prefetch skipped via the `isGreen` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)