### PR TITLE
feat(models): smarter base model picker defaults + type-to-search

### DIFF
--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -51,8 +51,10 @@ import {
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
 import {
   baseModelSupportsClipSkip,
+  defaultBaseModel,
   getActiveBaseModels,
 } from '~/shared/constants/basemodel.constants';
+import { useLastUsedBaseModelStore } from '~/store/last-used-base-model.store';
 import type { GenerationResourceSchema } from '~/server/schema/generation.schema';
 import { generationResourceSchema } from '~/server/schema/generation.schema';
 import type {
@@ -156,6 +158,7 @@ export function ModelVersionUpsertForm({
   id,
   model,
   version,
+  previousBaseModel,
   children,
   onSubmit,
   afterName,
@@ -164,6 +167,12 @@ export function ModelVersionUpsertForm({
   const router = useRouter();
   const queryUtils = trpc.useUtils();
   const currentUser = useCurrentUser();
+  const lastUsedBaseModel = useLastUsedBaseModelStore((s) => s.lastUsedBaseModel);
+  const setLastUsedBaseModel = useLastUsedBaseModelStore((s) => s.setLastUsedBaseModel);
+  // For a brand-new version, seed the base model from the previous version (if any),
+  // then the user's last-used selection, then the global default.
+  const initialBaseModel =
+    version?.baseModel ?? previousBaseModel ?? lastUsedBaseModel ?? defaultBaseModel;
   const colorScheme = useComputedColorScheme('dark');
   const theme = useMantineTheme();
 
@@ -187,7 +196,7 @@ export function ModelVersionUpsertForm({
   const defaultValues: Schema = {
     ...version,
     name: version?.name ?? 'v1.0',
-    baseModel: version?.baseModel ?? 'SD 1.5',
+    baseModel: initialBaseModel,
     baseModelType: hasBaseModelType ? version?.baseModelType ?? 'Standard' : undefined,
     trainedWords: version?.trainedWords ?? [],
     skipTrainedWords: acceptsTrainedWords
@@ -228,7 +237,7 @@ export function ModelVersionUpsertForm({
 
   const skipTrainedWords = !isTextualInversion && (form.watch('skipTrainedWords') ?? false);
   const trainedWords = form.watch('trainedWords') ?? [];
-  const baseModel = form.watch('baseModel') ?? 'SD 1.5';
+  const baseModel = form.watch('baseModel') ?? initialBaseModel;
   // Non-commercial base models (e.g. Ideogram) can't be monetized — hide the
   // licensing-fee and early-access controls for these versions.
   const isNonCommercial = isNonCommercialBaseModel(baseModel);
@@ -353,6 +362,8 @@ export function ModelVersionUpsertForm({
       });
       return;
     }
+
+    if (data.baseModel) setLastUsedBaseModel(data.baseModel);
 
     const schemaResult = querySchema.safeParse(router.query);
     const templateId = schemaResult.success ? schemaResult.data.templateId : undefined;
@@ -900,6 +911,9 @@ export function ModelVersionUpsertForm({
               allowDeselect={false}
               withAsterisk
               searchable
+              // Select the current value on focus so the user can click and immediately
+              // type to filter (e.g. "wan") instead of clearing the field first.
+              onFocus={(e) => e.currentTarget.select()}
             />
             {hasBaseModelType && (
               <InputSelect
@@ -1120,6 +1134,9 @@ type Props = {
   onSubmit: (version?: ModelVersionUpsertInput) => void;
   children: (data: { loading: boolean; canSave: boolean }) => React.ReactNode;
   model?: Partial<ModelUpsertInput & { publishedAt: Date | null }>;
+  // Base model of the model's most recent existing version; used to default the
+  // picker when adding a brand-new version to an existing model.
+  previousBaseModel?: string | null;
   // licensingFee comes off a Prisma read as a Decimal; the form coerces it to a number in defaultValues.
   version?: Omit<Partial<VersionInput>, 'licensingFee'> & {
     licensingFee?: number | { valueOf(): string } | null;

--- a/src/components/Resource/Wizard/ModelVersionWizard.tsx
+++ b/src/components/Resource/Wizard/ModelVersionWizard.tsx
@@ -34,6 +34,7 @@ const CreateSteps = ({
   versionId,
   modelData,
   modelVersion,
+  previousBaseModel,
   goBack,
   goNext,
   router,
@@ -44,6 +45,7 @@ const CreateSteps = ({
   versionId?: string | string[];
   modelData?: ModelVersionById['model'];
   modelVersion?: ModelVersionById;
+  previousBaseModel?: string | null;
   goBack: () => void;
   goNext: () => void;
   router: NextRouter;
@@ -85,6 +87,7 @@ const CreateSteps = ({
             id={formId}
             model={modelData}
             version={modelVersion}
+            previousBaseModel={previousBaseModel}
             onSubmit={withSavedNav((result) => {
               const skipFiles = result?.usageControl === ModelUsageControl.ExternalGeneration;
               const nextStep = skipFiles ? 3 : 2;
@@ -274,7 +277,7 @@ const TrainSteps = ({
   );
 };
 
-export function ModelVersionWizard({ data }: Props) {
+export function ModelVersionWizard({ data, previousBaseModel }: Props) {
   const router = useRouter();
 
   const { id, versionId } = router.query;
@@ -386,6 +389,7 @@ export function ModelVersionWizard({ data }: Props) {
           versionId={versionId}
           modelData={modelData}
           modelVersion={modelVersion}
+          previousBaseModel={previousBaseModel}
           goBack={goBack}
           goNext={goNext}
           router={router}
@@ -399,4 +403,5 @@ export function ModelVersionWizard({ data }: Props) {
 
 type Props = {
   data?: ModelById;
+  previousBaseModel?: string | null;
 };

--- a/src/pages/models/[id]/model-versions/create.tsx
+++ b/src/pages/models/[id]/model-versions/create.tsx
@@ -39,12 +39,19 @@ export const getServerSideProps = createServerSideProps({
         },
       };
 
-    return { props: { modelId, model } };
+    const latestVersion = await dbRead.modelVersion.findFirst({
+      where: { modelId },
+      orderBy: { index: 'desc' },
+      select: { baseModel: true },
+    });
+
+    return { props: { modelId, model, previousBaseModel: latestVersion?.baseModel ?? null } };
   },
 });
 
 export default function NewModelVersion({
   model,
+  previousBaseModel,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
-  return <ModelVersionWizard data={model as any} />;
+  return <ModelVersionWizard data={model as any} previousBaseModel={previousBaseModel} />;
 }

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -4358,6 +4358,12 @@ export const baseModelGroups: string[] = [...new Set(ecosystems.map((x) => x.key
  */
 export const activeBaseModels: string[] = getActiveBaseModels().map((x) => x.name);
 
+/**
+ * Default base model for brand-new models/versions that have no prior context
+ * (no previous version, no remembered last-used selection).
+ */
+export const defaultBaseModel: BaseModel = 'Anima';
+
 // -----------------------------------------------------------------------------
 // Constant Exports
 // -----------------------------------------------------------------------------

--- a/src/store/last-used-base-model.store.ts
+++ b/src/store/last-used-base-model.store.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+
+interface LastUsedBaseModelStore {
+  lastUsedBaseModel?: string;
+  setLastUsedBaseModel: (baseModel: string) => void;
+}
+
+export const useLastUsedBaseModelStore = create<LastUsedBaseModelStore>()(
+  persist(
+    (set) => ({
+      lastUsedBaseModel: undefined,
+      setLastUsedBaseModel: (baseModel) => set({ lastUsedBaseModel: baseModel }),
+    }),
+    {
+      name: 'last-used-base-model',
+      storage: createJSONStorage(() => localStorage),
+      version: 1,
+    }
+  )
+);
+
+export const lastUsedBaseModelStore = {
+  get: () => useLastUsedBaseModelStore.getState().lastUsedBaseModel,
+  set: (baseModel: string) => useLastUsedBaseModelStore.getState().setLastUsedBaseModel(baseModel),
+};


### PR DESCRIPTION
## What
Improves the Base Model picker in the model-version upload/edit form, from creator feedback that the picker defaults poorly and is clumsy to search.

1. **Default SD 1.5 → Anima.** New models/versions with no prior context now default to `Anima` (a new `defaultBaseModel` constant) instead of the long-stale `SD 1.5`.
2. **Default to the previous version's base model.** Adding a new version to an existing model now seeds the picker from that model's most recent version. Resolution order: `version.baseModel ?? previousBaseModel ?? lastUsedBaseModel ?? defaultBaseModel`. A brand-new model falls back to the user's last-used selection (new persisted zustand store), then Anima.
3. **Type-to-search.** The control now selects its current value on focus, so you can click and immediately type (e.g. "wan") to filter instead of clearing the field first; arrow-select works.

## Files
- `src/shared/constants/basemodel.constants.ts` — `defaultBaseModel = 'Anima'`
- `src/store/last-used-base-model.store.ts` — new persisted last-used store
- `src/components/Resource/Forms/ModelVersionUpsertForm.tsx` — default logic, last-used persistence, `onFocus` select
- `src/pages/models/[id]/model-versions/create.tsx` — sources previous version's base model in `getServerSideProps`
- `src/components/Resource/Wizard/ModelVersionWizard.tsx` — threads `previousBaseModel` through

## Verify
- `/models/create` → defaults to Anima (or your last-used).
- `/models/[id]/model-versions/create` → defaults to the model's most recent version base model.
- Click the Base Model field, type "wan" → filters instantly without manual clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)