### PR TITLE
fix(challenge): gate user-challenge entry on status=Active + guard cancel executor

### DIFF
--- a/src/server/games/daily-challenge/challenge-entry-gate.test.ts
+++ b/src/server/games/daily-challenge/challenge-entry-gate.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockFindFirst } = vi.hoisted(() => ({ mockFindFirst: vi.fn() }));
+vi.mock('~/server/db/client', () => ({ dbRead: { challenge: { findFirst: mockFindFirst } } }));
+
+const { assertUserChallengeAcceptingEntries } = await import('./challenge-entry-gate');
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('assertUserChallengeAcceptingEntries', () => {
+  it('rejects when the owning user challenge is Scheduled', async () => {
+    mockFindFirst.mockResolvedValue({ status: 'Scheduled' });
+    await expect(assertUserChallengeAcceptingEntries(55)).rejects.toThrow('starting shortly');
+  });
+
+  it('rejects for any non-Active status (e.g. Completing)', async () => {
+    mockFindFirst.mockResolvedValue({ status: 'Completing' });
+    await expect(assertUserChallengeAcceptingEntries(55)).rejects.toThrow('starting shortly');
+  });
+
+  it('accepts when the owning user challenge is Active', async () => {
+    mockFindFirst.mockResolvedValue({ status: 'Active' });
+    await expect(assertUserChallengeAcceptingEntries(55)).resolves.toBeUndefined();
+  });
+
+  it('no-ops when no user challenge owns the collection (daily/community contest)', async () => {
+    mockFindFirst.mockResolvedValue(null);
+    await expect(assertUserChallengeAcceptingEntries(55)).resolves.toBeUndefined();
+  });
+
+  it('scopes the lookup to source = User and selects only status', async () => {
+    mockFindFirst.mockResolvedValue(null);
+    await assertUserChallengeAcceptingEntries(55);
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: { collectionId: 55, source: 'User' },
+      select: { status: true },
+    });
+  });
+});

--- a/src/server/games/daily-challenge/challenge-entry-gate.ts
+++ b/src/server/games/daily-challenge/challenge-entry-gate.ts
@@ -1,0 +1,18 @@
+import { dbRead } from '~/server/db/client';
+import { ChallengeSource, ChallengeStatus } from '~/shared/utils/prisma/enums';
+import { throwBadRequestError } from '~/server/utils/errorHandling';
+
+// A user challenge accepts entries only once it is Active (⟹ Scanned ⟹ text frozen). While it is
+// still Scheduled the submission window may already be open, but the entry-fee charge silently
+// no-ops (it requires Active), so the entry would commit for free — and the still-mutable/rescannable
+// text could later flip NSFW and cancel the challenge out from under entrants. Reject until Active.
+// No-op for daily/system challenges and non-challenge contest collections (findFirst → null).
+export async function assertUserChallengeAcceptingEntries(collectionId: number): Promise<void> {
+  const userChallenge = await dbRead.challenge.findFirst({
+    where: { collectionId, source: ChallengeSource.User },
+    select: { status: true },
+  });
+  if (userChallenge && userChallenge.status !== ChallengeStatus.Active) {
+    throw throwBadRequestError('Challenge is starting shortly, please try again in a few minutes.');
+  }
+}

--- a/src/server/games/daily-challenge/challenge-nsfw-escalation.test.ts
+++ b/src/server/games/daily-challenge/challenge-nsfw-escalation.test.ts
@@ -1,23 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockDbRead, mockDbWrite, mockVoidChallenge, mockCreateNotification } = vi.hoisted(() => ({
-  mockDbRead: {
-    challenge: { findUnique: vi.fn() },
-    collection: { findUnique: vi.fn() },
-  },
-  mockDbWrite: {
-    challenge: { update: vi.fn() },
-    collection: { updateMany: vi.fn() },
-  },
-  mockVoidChallenge: vi.fn(),
-  mockCreateNotification: vi.fn(),
-}));
+const { mockDbRead, mockDbWrite, mockVoidChallenge, mockCreateNotification, mockLogToAxiom } =
+  vi.hoisted(() => ({
+    mockDbRead: {
+      challenge: { findUnique: vi.fn() },
+      collection: { findUnique: vi.fn() },
+    },
+    mockDbWrite: {
+      challenge: { update: vi.fn() },
+      collection: { updateMany: vi.fn() },
+    },
+    mockVoidChallenge: vi.fn(),
+    mockCreateNotification: vi.fn(),
+    mockLogToAxiom: vi.fn(),
+  }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
 vi.mock('~/server/services/challenge.service', () => ({ voidChallenge: mockVoidChallenge }));
 vi.mock('~/server/services/notification.service', () => ({
   createNotification: mockCreateNotification,
 }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
 
 const { applyChallengeNsfwEscalation } = await import('./challenge-nsfw-escalation');
 
@@ -31,6 +34,7 @@ function challenge(overrides: Record<string, unknown> = {}) {
     source: 'User',
     createdById: 7,
     collectionId: 55,
+    status: 'Scheduled',
     ...overrides,
   };
 }
@@ -42,6 +46,7 @@ beforeEach(() => {
   mockDbRead.collection.findUnique.mockResolvedValue({ metadata: { forcedBrowsingLevel: PG_PG13 } });
   mockVoidChallenge.mockResolvedValue({ success: true });
   mockCreateNotification.mockResolvedValue(undefined);
+  mockLogToAxiom.mockResolvedValue(undefined);
 });
 
 describe('applyChallengeNsfwEscalation', () => {
@@ -103,5 +108,19 @@ describe('applyChallengeNsfwEscalation', () => {
     await applyChallengeNsfwEscalation({ entityId: 404, isNsfw: true });
     expect(mockDbWrite.challenge.update).not.toHaveBeenCalled();
     expect(mockVoidChallenge).not.toHaveBeenCalled();
+  });
+
+  it('green user + nsfw while Active: hides via Blocked + alerts mods, no void, no refund, no cancel notif', async () => {
+    mockDbRead.challenge.findUnique.mockResolvedValue(challenge({ status: 'Active' }));
+
+    await applyChallengeNsfwEscalation({ entityId: 77, isNsfw: true });
+
+    expect(mockVoidChallenge).not.toHaveBeenCalled();
+    const data = mockDbWrite.challenge.update.mock.calls[0][0].data;
+    expect(data.ingestion).toBe('Blocked');
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'challenge-nsfw-escalation-held', challengeId: 77 })
+    );
   });
 });

--- a/src/server/games/daily-challenge/challenge-nsfw-escalation.test.ts
+++ b/src/server/games/daily-challenge/challenge-nsfw-escalation.test.ts
@@ -1,19 +1,26 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockDbRead, mockDbWrite, mockVoidChallenge, mockCreateNotification, mockLogToAxiom } =
-  vi.hoisted(() => ({
-    mockDbRead: {
-      challenge: { findUnique: vi.fn() },
-      collection: { findUnique: vi.fn() },
-    },
-    mockDbWrite: {
-      challenge: { update: vi.fn() },
-      collection: { updateMany: vi.fn() },
-    },
-    mockVoidChallenge: vi.fn(),
-    mockCreateNotification: vi.fn(),
-    mockLogToAxiom: vi.fn(),
-  }));
+const {
+  mockDbRead,
+  mockDbWrite,
+  mockVoidChallenge,
+  mockCreateNotification,
+  mockLogToAxiom,
+  mockCloseChallengeCollection,
+} = vi.hoisted(() => ({
+  mockDbRead: {
+    challenge: { findUnique: vi.fn() },
+    collection: { findUnique: vi.fn() },
+  },
+  mockDbWrite: {
+    challenge: { update: vi.fn() },
+    collection: { updateMany: vi.fn() },
+  },
+  mockVoidChallenge: vi.fn(),
+  mockCreateNotification: vi.fn(),
+  mockLogToAxiom: vi.fn(),
+  mockCloseChallengeCollection: vi.fn(),
+}));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
 vi.mock('~/server/services/challenge.service', () => ({ voidChallenge: mockVoidChallenge }));
@@ -21,6 +28,9 @@ vi.mock('~/server/services/notification.service', () => ({
   createNotification: mockCreateNotification,
 }));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  closeChallengeCollection: mockCloseChallengeCollection,
+}));
 
 const { applyChallengeNsfwEscalation } = await import('./challenge-nsfw-escalation');
 
@@ -47,6 +57,7 @@ beforeEach(() => {
   mockVoidChallenge.mockResolvedValue({ success: true });
   mockCreateNotification.mockResolvedValue(undefined);
   mockLogToAxiom.mockResolvedValue(undefined);
+  mockCloseChallengeCollection.mockResolvedValue(undefined);
 });
 
 describe('applyChallengeNsfwEscalation', () => {
@@ -119,6 +130,7 @@ describe('applyChallengeNsfwEscalation', () => {
     const data = mockDbWrite.challenge.update.mock.calls[0][0].data;
     expect(data.ingestion).toBe('Blocked');
     expect(mockCreateNotification).not.toHaveBeenCalled();
+    expect(mockCloseChallengeCollection).toHaveBeenCalledWith({ collectionId: 55 });
     expect(mockLogToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'challenge-nsfw-escalation-held', challengeId: 77 })
     );

--- a/src/server/games/daily-challenge/challenge-nsfw-escalation.ts
+++ b/src/server/games/daily-challenge/challenge-nsfw-escalation.ts
@@ -7,7 +7,12 @@ import {
 import { createNotification } from '~/server/services/notification.service';
 import { voidChallenge } from '~/server/services/challenge.service';
 import type { CollectionMetadataSchema } from '~/server/schema/collection.schema';
-import { ChallengeIngestionStatus, ChallengeSource } from '~/shared/utils/prisma/enums';
+import {
+  ChallengeIngestionStatus,
+  ChallengeSource,
+  ChallengeStatus,
+} from '~/shared/utils/prisma/enums';
+import { logToAxiom } from '~/server/logging/client';
 
 // Applies the scan verdict to a challenge. A green USER challenge whose text is NSFW is cancelled
 // (green must be SFW): void it (Cancelled + collection closed + initial prize refunded, all idempotent),
@@ -32,6 +37,7 @@ export async function applyChallengeNsfwEscalation({
       source: true,
       createdById: true,
       collectionId: true,
+      status: true,
     },
   });
   if (!challenge) return;
@@ -45,27 +51,50 @@ export async function applyChallengeNsfwEscalation({
   });
 
   if (escalation.cancel) {
-    // Void FIRST (Cancelled + collection closed + prize refunded, idempotent) so a crash before the
-    // scan-state write leaves the challenge Cancelled/hidden — never a Scanned-and-therefore-visible
-    // green NSFW challenge. Then resolve the moderation state.
-    await voidChallenge(entityId);
+    // Only auto-void a challenge that has NOT started. A Scheduled green challenge is entry-free
+    // (entry gate) — or holds only legacy pre-gate free entries — so voiding it (Cancelled +
+    // collection closed + prize refunded, all idempotent) is always safe. Void FIRST so a crash
+    // before the scan-state write leaves it Cancelled/hidden, never Scanned-and-visible.
+    if (challenge.status === ChallengeStatus.Scheduled) {
+      await voidChallenge(entityId);
+      await dbWrite.challenge.update({
+        where: { id: entityId },
+        data: { ingestion: ChallengeIngestionStatus.Scanned, scannedAt: new Date() },
+      });
+      if (challenge.createdById) {
+        await createNotification({
+          userId: challenge.createdById,
+          category: NotificationCategory.System,
+          type: 'system-message',
+          key: `challenge-nsfw-cancelled-${entityId}`,
+          details: {
+            message:
+              'Your challenge was cancelled because its text was flagged as adult content — green challenges must be safe-for-work. Any prize you funded has been refunded; you can recreate it on civitai.red.',
+            url: `/challenges/${entityId}`,
+          },
+        });
+      }
+      return;
+    }
+
+    // Defense-in-depth: a scan verdict reached an already-started (non-Scheduled) green challenge.
+    // This should be unreachable post entry-gate (Active challenges are never re-scanned); if the
+    // invariant is ever broken, do NOT auto-void a live challenge out from under entrants. Hide it
+    // (Blocked ⟹ excluded from feeds) and alert mods to void+refund or override by hand. No auto-
+    // refund and no creator "cancelled" notification — a human decides.
     await dbWrite.challenge.update({
       where: { id: entityId },
-      data: { ingestion: ChallengeIngestionStatus.Scanned, scannedAt: new Date() },
+      data: { ingestion: ChallengeIngestionStatus.Blocked, scannedAt: new Date() },
     });
-    if (challenge.createdById) {
-      await createNotification({
-        userId: challenge.createdById,
-        category: NotificationCategory.System,
-        type: 'system-message',
-        key: `challenge-nsfw-cancelled-${entityId}`,
-        details: {
-          message:
-            'Your challenge was cancelled because its text was flagged as adult content — green challenges must be safe-for-work. Any prize you funded has been refunded; you can recreate it on civitai.red.',
-          url: `/challenges/${entityId}`,
-        },
-      });
-    }
+    logToAxiom({
+      type: 'error',
+      name: 'challenge-nsfw-escalation-held',
+      message: `Green challenge ${entityId} scanned NSFW while ${String(
+        challenge.status
+      )}; hidden and held for moderator review instead of auto-void.`,
+      challengeId: entityId,
+      status: String(challenge.status),
+    });
     return;
   }
 

--- a/src/server/games/daily-challenge/challenge-nsfw-escalation.ts
+++ b/src/server/games/daily-challenge/challenge-nsfw-escalation.ts
@@ -6,6 +6,7 @@ import {
 } from '~/server/games/daily-challenge/challenge-currency';
 import { createNotification } from '~/server/services/notification.service';
 import { voidChallenge } from '~/server/services/challenge.service';
+import { closeChallengeCollection } from './challenge-helpers';
 import type { CollectionMetadataSchema } from '~/server/schema/collection.schema';
 import {
   ChallengeIngestionStatus,
@@ -86,6 +87,7 @@ export async function applyChallengeNsfwEscalation({
       where: { id: entityId },
       data: { ingestion: ChallengeIngestionStatus.Blocked, scannedAt: new Date() },
     });
+    await closeChallengeCollection({ collectionId: challenge.collectionId });
     logToAxiom({
       type: 'error',
       name: 'challenge-nsfw-escalation-held',

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -85,6 +85,7 @@ import {
   TagTarget,
 } from '~/shared/utils/prisma/enums';
 import { isDefined } from '~/utils/type-guards';
+import { assertUserChallengeAcceptingEntries } from '~/server/games/daily-challenge/challenge-entry-gate';
 
 export type CollectionContributorPermissionFlags = {
   collectionId: number;
@@ -2040,6 +2041,10 @@ export const validateContestCollectionEntry = async ({
       throw throwBadRequestError(`You have reached the maximum number of items in collection`);
     }
   }
+
+  // User challenges accept entries only once Active — makes the entry WRITE agree with the fee
+  // CHARGE (which already requires Active). No-op for daily/system/community collections.
+  await assertUserChallengeAcceptingEntries(collectionId);
 
   if (
     (metadata.submissionStartDate && new Date(metadata.submissionStartDate) > new Date()) ||

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -2015,6 +2015,10 @@ export const validateContestCollectionEntry = async ({
     }
   }
 
+  // User challenges accept entries only once Active — makes the entry WRITE agree with the fee
+  // CHARGE (which already requires Active). No-op for daily/system/community collections.
+  await assertUserChallengeAcceptingEntries(collectionId);
+
   if (!metadata) {
     return;
   }
@@ -2041,10 +2045,6 @@ export const validateContestCollectionEntry = async ({
       throw throwBadRequestError(`You have reached the maximum number of items in collection`);
     }
   }
-
-  // User challenges accept entries only once Active — makes the entry WRITE agree with the fee
-  // CHARGE (which already requires Active). No-op for daily/system/community collections.
-  await assertUserChallengeAcceptingEntries(collectionId);
 
   if (
     (metadata.submissionStartDate && new Date(metadata.submissionStartDate) > new Date()) ||


### PR DESCRIPTION
## Problem

User-created challenges could lose entries and leak free entries via two decoupling gaps found in an audit of the NSFW-escalation code on `main`:

- **Free pre-`Active` entries.** The contest submission window is purely time-based `[startsAt, endsAt]` and doesn't check `challenge.status`. Activation is a separate hourly cron requiring `ingestion = Scanned`, so there's a window (up to ~1h happy-path, indefinite while `Pending`/`Error`) where a challenge is `Scheduled` but already accepting entries. The fee charge requires `status:'Active'`, so a `Scheduled` entry commits **for free**.
- **Scan-cancel of a started challenge.** A green challenge whose text is scanned NSFW is auto-voided (Cancelled + collection closed + refunds). Because entries could exist while `Scheduled` (still re-scannable), a challenge people had already entered could vanish on them.

Spec: `docs/superpowers/specs/2026-07-18-challenge-entry-active-gate-design.md`
Plan: `docs/superpowers/plans/2026-07-20-challenge-entry-active-gate.md`

## Invariant established

> A user challenge holds entries **only after** it is `Active` (⟹ `Scanned` ⟹ text frozen).

An `Active` challenge is never re-scanned, so no entried challenge is ever scan-cancelled, and the free-entry leak disappears.

## Changes

1. **Entry gate** — new `src/server/games/daily-challenge/challenge-entry-gate.ts` → `assertUserChallengeAcceptingEntries(collectionId)`, wired into `validateContestCollectionEntry` (the single chokepoint both write paths funnel through). Rejects entries to a `source = User` challenge that isn't yet `Active` with "Challenge is starting shortly, please try again in a few minutes." Scoped to `source = User` (no-op for daily/system/community contests); applies to free **and** paid challenges, and to moderators. Placed before the metadata early-return so a future caller can't bypass it.

2. **Cancel-executor guard (defense-in-depth)** — `applyChallengeNsfwEscalation` now only auto-voids a `Scheduled` challenge. If a scan verdict ever reaches an already-started (`Active`+) challenge (a should-never-happen, invariant-broken case), it hides the challenge (`ingestion = Blocked`), **closes the entry collection** so no further non-refundable entries accrue, and alerts mods via `logToAxiom` — instead of auto-voiding a live challenge out from under entrants. No auto-void, no auto-refund; a human decides.

### Design note
The guard's hold branch fires only when `status !== Scheduled` (a `Scheduled` challenge always auto-voids, entried-or-not — its entries are legacy pre-gate free entries, safe to refund). This intentionally supersedes the spec's original "Scheduled+entried → hold" branch, which would have been auto-voided anyway by the activation job's void-on-`Blocked`+`Scheduled` path.

## Testing

- `challenge-entry-gate.test.ts` — 5 cases (Scheduled/non-Active reject, Active accept, no-user-challenge no-op, `source=User`/select shape).
- `challenge-nsfw-escalation.test.ts` — Scheduled auto-void preserved; new `Active`-hold case asserts no void, `ingestion=Blocked`, collection closed, no creator notif, mod alert fired.
- Both files: 10/10 pass.

## Deploy notes

- Public challenges are Flipt-gated (`CHALLENGE_PLATFORM_ENABLED`); no new flag.
- **No schema migration.**
- Existing `Scheduled` user challenges holding pre-gate (free) entries will have **further** entries rejected until they activate — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)