### PR TITLE
feat(apps): AppReviewAgentReport persistence (P0, dark/additive)

### DIFF
--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -2806,6 +2806,83 @@ model AppListingModerationEvent {
   @@map("app_listing_moderation_events")
 }
 
+/// App Blocks — agentic mod code-review report (P0 persistence layer).
+///
+/// One row per agent code-review of an app version, keyed to the app + version
+/// so the NEXT version's review can diff against the prior one (the
+/// `priorReportId` chain). Fronts BOTH on-site App Blocks (`appBlockId`) and
+/// external / OAuth-connect apps (`oauthClientId`) — EXACTLY ONE of those is set.
+///
+/// P0 = data model ONLY, fully DARK/INERT: NOTHING in the running image reads or
+/// writes this table (no router, no REST handler, no job) — it is additive and
+/// safe to apply ahead of the code that will populate it. Provisioning, the
+/// review UI, and the chat surface arrive in later phases.
+///
+/// Design notes:
+///   - `publishRequestId`, `appBlockId`, `oauthClientId` are PLAIN INDEXED ids,
+///     NOT Prisma relations. `publishRequestId` is dual-target by construction
+///     (an on-site review is an AppBlockPublishRequest `pubreq_<ULID>`; a
+///     connect review is an AppListingPublishRequest `alpr_<ULID>`), so it has
+///     no single clean FK — it is resolved in the service by kind. Keeping the
+///     app-key columns index-only (no back-relations on AppBlock/OauthClient)
+///     keeps this dark P0 a self-contained additive island; the `(key, version)`
+///     indexes drive the "latest prior report" lookup without relation traversal.
+///   - `status` is a checked string (running|complete|failed|torn-down); the
+///     CHECK lives ONLY in the migration .sql (Prisma can't express it), the
+///     canonical code set is APP_REVIEW_AGENT_REPORT_STATUSES in the service.
+///   - `costUsd` is Decimal(12,6): LLM costs are frequently sub-cent, so the
+///     repo's Decimal(10,2) money precision would round them away — 6 dp keeps
+///     per-review cost faithful. Deliberate deviation from the (10,2) precedent.
+///
+/// MANUAL-APPLY (datapacket-talos CLAUDE.md DB rule #8): the main civitai DB
+/// (CNPG nvme0) does NOT run prisma migrate deploy; the committed SQL is
+/// hand-applied per environment.
+model AppReviewAgentReport {
+  id               String    @id // arar_<ULID>
+  // The review (publish request) this report was generated for. Dual-target
+  // (on-site = AppBlockPublishRequest, connect = AppListingPublishRequest) so it
+  // is stored as an indexed id, not a FK. Resolved by kind in the service.
+  publishRequestId String    @map("publish_request_id")
+  // App identity — EXACTLY ONE is set: `appBlockId` for an on-site App Block,
+  // `oauthClientId` for an external / OAuth-connect app. Plain indexed columns.
+  appBlockId       String?   @map("app_block_id")
+  oauthClientId    String?   @map("oauth_client_id")
+  // The reviewed bundle's version (semver) + integrity hash.
+  version          String
+  bundleSha256     String    @map("bundle_sha256")
+  // Agent-run lifecycle: running|complete|failed|torn-down (CHECK in the .sql).
+  status           String    @default("running")
+  // The LLM that produced the review (NULL until the run reports one).
+  model            String?
+  startedAt        DateTime  @default(now()) @map("started_at") @db.Timestamptz(6)
+  completedAt      DateTime? @map("completed_at") @db.Timestamptz(6)
+  // Structured agent outputs (NULLABLE — populated as the run progresses).
+  codeReview       Json?     @map("code_review")
+  securityAudit    Json?     @map("security_audit")
+  scopeVerdicts    Json?     @map("scope_verdicts")
+  summaryMd        String?   @map("summary_md")
+  // The prior version's report in the chain (self-relation) — lets the next
+  // version diff against it. SetNull so deleting an older report does not
+  // cascade-delete its successors (the chain head is preserved).
+  priorReportId    String?               @map("prior_report_id")
+  priorReport      AppReviewAgentReport?  @relation("AppReviewAgentReportChain", fields: [priorReportId], references: [id], onDelete: SetNull)
+  nextReports      AppReviewAgentReport[] @relation("AppReviewAgentReportChain")
+  // LLM token accounting (provider-shaped Json) + total cost. See costUsd note
+  // in the model docstring for the Decimal(12,6) rationale.
+  tokenUsage       Json?     @map("token_usage")
+  costUsd          Decimal?  @map("cost_usd") @db.Decimal(12, 6)
+  createdAt        DateTime  @default(now()) @map("created_at") @db.Timestamptz(6)
+  updatedAt        DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
+
+  // "latest prior complete report for this app older than version X" lookups,
+  // one index per app-key kind (on-site vs connect).
+  @@index([appBlockId, version], map: "app_review_agent_reports_app_block_version_idx")
+  @@index([oauthClientId, version], map: "app_review_agent_reports_oauth_client_version_idx")
+  // By-review lookup (getAgentReport).
+  @@index([publishRequestId], map: "app_review_agent_reports_publish_request_idx")
+  @@map("app_review_agent_reports")
+}
+
 /// Per-block-instance, per-user settings (viewer preferences).
 /// FK CASCADE on subscription deletion and GDPR-user-delete.
 ///

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -430,6 +430,27 @@ export type AppListingScreenshot = {
   created_at: Generated<Timestamp>;
   updated_at: Generated<Timestamp>;
 };
+export type AppReviewAgentReport = {
+  id: string;
+  publish_request_id: string;
+  app_block_id: string | null;
+  oauth_client_id: string | null;
+  version: string;
+  bundle_sha256: string;
+  status: Generated<string>;
+  model: string | null;
+  started_at: Generated<Timestamp>;
+  completed_at: Timestamp | null;
+  code_review: unknown | null;
+  security_audit: unknown | null;
+  scope_verdicts: unknown | null;
+  summary_md: string | null;
+  prior_report_id: string | null;
+  token_usage: unknown | null;
+  cost_usd: string | null;
+  created_at: Generated<Timestamp>;
+  updated_at: Generated<Timestamp>;
+};
 export type AppUserScopeGrant = {
   id: string;
   user_id: number;
@@ -3848,6 +3869,7 @@ export type DB = {
   app_listing_reviews: AppListingReview;
   app_listing_screenshots: AppListingScreenshot;
   app_listings: AppListing;
+  app_review_agent_reports: AppReviewAgentReport;
   app_user_scope_grants: AppUserScopeGrant;
   Appeal: Appeal;
   Article: Article;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -2006,6 +2006,30 @@ export interface AppListingModerationEvent {
   createdAt: Date;
 }
 
+export interface AppReviewAgentReport {
+  id: string;
+  publishRequestId: string;
+  appBlockId: string | null;
+  oauthClientId: string | null;
+  version: string;
+  bundleSha256: string;
+  status: string;
+  model: string | null;
+  startedAt: Date;
+  completedAt: Date | null;
+  codeReview: JsonValue | null;
+  securityAudit: JsonValue | null;
+  scopeVerdicts: JsonValue | null;
+  summaryMd: string | null;
+  priorReportId: string | null;
+  priorReport?: AppReviewAgentReport | null;
+  nextReports?: AppReviewAgentReport[];
+  tokenUsage: JsonValue | null;
+  costUsd: Decimal | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface BlockUserSettings {
   blockInstanceId: string;
   subscription?: BlockUserSubscription;

--- a/prisma/migrations/20260720120000_app_review_agent_report/migration.sql
+++ b/prisma/migrations/20260720120000_app_review_agent_report/migration.sql
@@ -1,0 +1,78 @@
+-- ============================================================
+-- App Blocks — agentic mod code-review report (P0 persistence layer)
+-- ============================================================
+-- Introduces app_review_agent_reports: one row per agent code-review of an app
+-- version, keyed to the app (on-site app_blocks OR external OauthClient) + the
+-- reviewed version, so the NEXT version's review can diff against the prior one
+-- (the prior_report_id self-chain).
+--
+-- P0 = data model ONLY, fully DARK/INERT: NOTHING in the running image reads or
+-- writes this table (no router, no REST handler, no job). It is additive and
+-- read by nothing, so applying it ahead of / independent of the code that will
+-- populate it is inert. Provisioning, the review UI, and the chat surface are
+-- later phases.
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
+-- CNPG nvme0 DB does NOT auto-apply migrations (no prisma migrate deploy). This
+-- file is committed for HISTORY ONLY; a HUMAN applies the SQL below per
+-- environment (psql/retool). CI / deploy do NOT run it. Apply to BOTH:
+--   1. prod nvme0   (the live civitai DB)
+--   2. the dev clone
+--
+-- Idempotent: IF NOT EXISTS guards on the table + every index so a manual re-run
+-- is a no-op. The table is brand-new + EMPTY, so plain CREATE INDEX takes no
+-- meaningful lock — CONCURRENTLY is unnecessary (and cannot run in a txn). The
+-- string enum uses a CHECK constraint (mirrors the app_listings.status pattern).
+
+-- ------------------------------------------------------------
+-- app_review_agent_reports — per-review agent report, chained by version
+-- ------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS "app_review_agent_reports" (
+  "id"                  TEXT PRIMARY KEY,                       -- arar_<ULID>
+  -- The review (publish request) this report was generated for. DUAL-TARGET by
+  -- construction (on-site = app_block_publish_requests.id pubreq_<ULID>; connect
+  -- = app_listing_publish_requests.id alpr_<ULID>), so it is an indexed id, NOT
+  -- a FK — resolved by kind in the service.
+  "publish_request_id"  TEXT NOT NULL,
+  -- App identity — EXACTLY ONE is set: app_block_id for an on-site App Block,
+  -- oauth_client_id for an external / OAuth-connect app. Plain indexed columns
+  -- (no FK) so this dark P0 stays a self-contained additive island.
+  "app_block_id"        TEXT,
+  "oauth_client_id"     TEXT,
+  -- The reviewed bundle's version (semver) + integrity hash.
+  "version"             TEXT NOT NULL,
+  "bundle_sha256"       TEXT NOT NULL,
+  -- Agent-run lifecycle. CHECK-constrained below.
+  "status"              TEXT NOT NULL DEFAULT 'running',
+  -- The LLM that produced the review (NULL until the run reports one).
+  "model"               TEXT,
+  "started_at"          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "completed_at"        TIMESTAMPTZ,
+  -- Structured agent outputs (NULLABLE — populated as the run progresses).
+  "code_review"         JSONB,
+  "security_audit"      JSONB,
+  "scope_verdicts"      JSONB,
+  "summary_md"          TEXT,
+  -- The prior version's report in the chain (self-reference). SET NULL so
+  -- deleting an older report does not cascade-delete its successors.
+  "prior_report_id"     TEXT REFERENCES "app_review_agent_reports"("id") ON DELETE SET NULL,
+  -- LLM token accounting + total cost. Decimal(12,6): LLM costs are frequently
+  -- sub-cent, so the repo's (10,2) money precision would round them away.
+  "token_usage"         JSONB,
+  "cost_usd"            NUMERIC(12, 6),
+  "created_at"          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  "updated_at"          TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT "app_review_agent_reports_status_check"
+    CHECK ("status" IN ('running', 'complete', 'failed', 'torn-down'))
+);
+
+-- "latest prior complete report for this app older than version X" lookups, one
+-- index per app-key kind (on-site vs connect).
+CREATE INDEX IF NOT EXISTS "app_review_agent_reports_app_block_version_idx"
+  ON "app_review_agent_reports" ("app_block_id", "version");
+CREATE INDEX IF NOT EXISTS "app_review_agent_reports_oauth_client_version_idx"
+  ON "app_review_agent_reports" ("oauth_client_id", "version");
+-- By-review lookup (getAgentReport).
+CREATE INDEX IF NOT EXISTS "app_review_agent_reports_publish_request_idx"
+  ON "app_review_agent_reports" ("publish_request_id");

--- a/src/server/services/blocks/__tests__/app-review-report.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-review-report.service.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+/**
+ * App Blocks agentic mod code-review report — P0 lookup layer (DARK).
+ *
+ * Covers the prior-report selection: picks the latest COMPLETE report strictly
+ * semver-older than the version under review (semver, not lexical, ordering),
+ * queries only status='complete' (so running/failed/torn-down are excluded at
+ * the DB), respects the app key (appBlockId XOR oauthClientId), returns null
+ * when there is no earlier report, and enforces the exactly-one-key + valid
+ * semver invariants. Plus getAgentReport's by-review lookup.
+ */
+
+const { mockFindMany, mockFindFirst } = vi.hoisted(() => ({
+  mockFindMany: vi.fn(),
+  mockFindFirst: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    appReviewAgentReport: { findMany: mockFindMany, findFirst: mockFindFirst },
+  },
+}));
+
+import {
+  getAgentReport,
+  getPriorAgentReport,
+} from '../app-review-report.service';
+
+// Minimal row factory — only the fields the selection logic reads.
+const report = (over: {
+  id: string;
+  version: string;
+  startedAt?: Date;
+  status?: string;
+}) => ({
+  id: over.id,
+  version: over.version,
+  status: over.status ?? 'complete',
+  startedAt: over.startedAt ?? new Date('2026-01-01T00:00:00Z'),
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getPriorAgentReport', () => {
+  it('picks the latest complete report strictly older than the target (semver, not lexical)', async () => {
+    // Lexical order would wrongly pick 0.9.0 over 0.10.0 — semver must pick 0.10.0.
+    mockFindMany.mockResolvedValue([
+      report({ id: 'arar_a', version: '0.1.0' }),
+      report({ id: 'arar_b', version: '0.9.0' }),
+      report({ id: 'arar_c', version: '0.10.0' }),
+    ]);
+
+    const prior = await getPriorAgentReport({ appBlockId: 'ab_x', version: '1.0.0' });
+    expect(prior?.id).toBe('arar_c');
+  });
+
+  it('queries only status="complete" and scopes to the appBlockId key', async () => {
+    mockFindMany.mockResolvedValue([]);
+    await getPriorAgentReport({ appBlockId: 'ab_x', version: '2.0.0' });
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { appBlockId: 'ab_x', status: 'complete' },
+    });
+  });
+
+  it('scopes to the oauthClientId key for a connect app', async () => {
+    mockFindMany.mockResolvedValue([]);
+    await getPriorAgentReport({ oauthClientId: 'oc_y', version: '2.0.0' });
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: { oauthClientId: 'oc_y', status: 'complete' },
+    });
+  });
+
+  it('excludes the same version and any newer version', async () => {
+    mockFindMany.mockResolvedValue([
+      report({ id: 'arar_eq', version: '1.0.0' }), // equal -> excluded
+      report({ id: 'arar_new', version: '1.1.0' }), // newer -> excluded
+      report({ id: 'arar_old', version: '0.5.0' }), // older -> the answer
+    ]);
+    const prior = await getPriorAgentReport({ appBlockId: 'ab_x', version: '1.0.0' });
+    expect(prior?.id).toBe('arar_old');
+  });
+
+  it('returns null when the app has no earlier complete report', async () => {
+    mockFindMany.mockResolvedValue([report({ id: 'arar_only', version: '1.0.0' })]);
+    const prior = await getPriorAgentReport({ appBlockId: 'ab_x', version: '1.0.0' });
+    expect(prior).toBeNull();
+  });
+
+  it('breaks a same-version tie on startedAt desc', async () => {
+    mockFindMany.mockResolvedValue([
+      report({ id: 'arar_early', version: '0.9.0', startedAt: new Date('2026-01-01T00:00:00Z') }),
+      report({ id: 'arar_late', version: '0.9.0', startedAt: new Date('2026-02-01T00:00:00Z') }),
+    ]);
+    const prior = await getPriorAgentReport({ appBlockId: 'ab_x', version: '1.0.0' });
+    expect(prior?.id).toBe('arar_late');
+  });
+
+  it('throws when neither or both app keys are provided', async () => {
+    await expect(getPriorAgentReport({ version: '1.0.0' })).rejects.toThrow(/exactly one/);
+    await expect(
+      getPriorAgentReport({ appBlockId: 'ab_x', oauthClientId: 'oc_y', version: '1.0.0' })
+    ).rejects.toThrow(/exactly one/);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+
+  it('throws on an invalid semver version', async () => {
+    await expect(
+      getPriorAgentReport({ appBlockId: 'ab_x', version: 'not-a-version' })
+    ).rejects.toThrow(/invalid semver/);
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('getAgentReport', () => {
+  it('returns the most-recently-started report for a review', async () => {
+    mockFindFirst.mockResolvedValue({ id: 'arar_z' });
+    const r = await getAgentReport('pubreq_1');
+    expect(r).toEqual({ id: 'arar_z' });
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: { publishRequestId: 'pubreq_1' },
+      orderBy: { startedAt: 'desc' },
+    });
+  });
+
+  it('returns null for an empty id without querying', async () => {
+    const r = await getAgentReport('');
+    expect(r).toBeNull();
+    expect(mockFindFirst).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/app-review-report.service.ts
+++ b/src/server/services/blocks/app-review-report.service.ts
@@ -1,0 +1,97 @@
+import semver from 'semver';
+import type { AppReviewAgentReport } from '@prisma/client';
+import { dbRead } from '~/server/db/client';
+
+// App Blocks — agentic mod code-review report (P0 read/lookup layer).
+//
+// DARK/INERT: these are plain service functions read by NOTHING in the running
+// image — no tRPC router, no REST handler, no job calls them in P0. They exist so
+// the later provisioning / UI / chat phases have a stable read seam. Applying the
+// migration + shipping this file is therefore a no-op at runtime.
+
+/**
+ * Canonical agent-run lifecycle. Mirrored by the CHECK constraint in the
+ * migration .sql (Prisma can't express a CHECK). `complete` is the only status
+ * whose report is a valid "prior" link — a `running`/`failed`/`torn-down` report
+ * is never used as the diff base.
+ */
+export const APP_REVIEW_AGENT_REPORT_STATUSES = [
+  'running',
+  'complete',
+  'failed',
+  'torn-down',
+] as const;
+export type AppReviewAgentReportStatus = (typeof APP_REVIEW_AGENT_REPORT_STATUSES)[number];
+
+/**
+ * The agent report for a given review (publish request), or null. If a review
+ * was re-run and has more than one report, the most recently started one wins.
+ */
+export async function getAgentReport(
+  publishRequestId: string
+): Promise<AppReviewAgentReport | null> {
+  if (!publishRequestId) return null;
+  return dbRead.appReviewAgentReport.findFirst({
+    where: { publishRequestId },
+    orderBy: { startedAt: 'desc' },
+  });
+}
+
+export type GetPriorAgentReportArgs = {
+  appBlockId?: string | null;
+  oauthClientId?: string | null;
+  /** The version being reviewed now; the prior report must be strictly older. */
+  version: string;
+};
+
+/**
+ * The most recent `status='complete'` report for the SAME app (identified by
+ * `appBlockId` XOR `oauthClientId`) whose version is strictly semver-OLDER than
+ * `version` — i.e. the prior link in the chain the next review diffs against.
+ * Returns null when the app has no earlier complete report.
+ *
+ * "Most recent" is resolved on the VERSION axis (the greatest version still
+ * older than the target), which is the authoritative ordering for the chain;
+ * ties (same version re-reviewed) break on `startedAt` desc. Only a handful of
+ * versions exist per app, so the candidate set is fetched and compared in-app
+ * (the `version` column is a lexical index — not semver-ordered — so the
+ * ordering can't be pushed into SQL correctly).
+ */
+export async function getPriorAgentReport(
+  args: GetPriorAgentReportArgs
+): Promise<AppReviewAgentReport | null> {
+  const { appBlockId, oauthClientId, version } = args;
+
+  const hasBlock = appBlockId != null && appBlockId !== '';
+  const hasClient = oauthClientId != null && oauthClientId !== '';
+  if (hasBlock === hasClient) {
+    // Enforce the "exactly one app key" invariant the column pair encodes.
+    throw new Error(
+      'getPriorAgentReport requires exactly one of { appBlockId, oauthClientId }'
+    );
+  }
+  if (!semver.valid(version)) {
+    throw new Error(`getPriorAgentReport: invalid semver version "${version}"`);
+  }
+
+  const where = hasBlock
+    ? { appBlockId, status: 'complete' as const }
+    : { oauthClientId, status: 'complete' as const };
+
+  const candidates = await dbRead.appReviewAgentReport.findMany({ where });
+
+  const prior = candidates
+    // Only reports strictly older (by semver) than the version under review.
+    .filter((r) => {
+      const v = semver.valid(r.version);
+      return v != null && semver.lt(v, version);
+    })
+    // Greatest version first; same-version re-reviews break on startedAt desc.
+    .sort((a, b) => {
+      const byVersion = semver.rcompare(a.version, b.version);
+      if (byVersion !== 0) return byVersion;
+      return b.startedAt.getTime() - a.startedAt.getTime();
+    });
+
+  return prior[0] ?? null;
+}

--- a/src/server/utils/app-block-ids.ts
+++ b/src/server/utils/app-block-ids.ts
@@ -128,3 +128,8 @@ export function newAppListingReportId(): string {
 export function newAppListingModerationEventId(): string {
   return `alme_${newUlid()}`;
 }
+
+// App Blocks — agentic mod code-review report (P0). Dark/additive.
+export function newAppReviewAgentReportId(): string {
+  return `arar_${newUlid()}`;
+}


### PR DESCRIPTION
## What

P0 persistence layer for the App Blocks **agentic mod code-review** feature: a new `AppReviewAgentReport` model + table storing one agent report per app version, plus a dark read/lookup service. Provisioning, the review UI, and the chat surface come in later phases.

A report is keyed to the app (**exactly one** of `appBlockId` for an on-site App Block, or `oauthClientId` for an external / OAuth-connect app) + the reviewed `version`, and chains to the prior version's report via `priorReportId` so the next version's review can diff against it.

## Dark / inert — no readers

This PR is **additive and fully DARK**. Nothing in the running image reads or writes the new table:

- No tRPC router, REST handler, or job references the service.
- The service (`getAgentReport`, `getPriorAgentReport`) is a plain, **uncalled** read seam for later phases.
- Grep confirms zero live callers.

So applying the migration ahead of / independent of the code deploy cannot cause a runtime error.

## Design notes

- `publishRequestId` / `appBlockId` / `oauthClientId` are **plain indexed ids, not FK relations**. `publishRequestId` is dual-target by construction (on-site review = `AppBlockPublishRequest` `pubreq_<ULID>`; connect review = `AppListingPublishRequest` `alpr_<ULID>`), so it has no single clean FK — it is resolved by kind in the service. Keeping the app-key columns index-only keeps this P0 a self-contained additive island; the `(key, version)` indexes drive the "latest prior report" lookup.
- `status` is a checked string (`running|complete|failed|torn-down`); the CHECK lives in the migration SQL (Prisma can't express it), the canonical code set is `APP_REVIEW_AGENT_REPORT_STATUSES`.
- `priorReportId` is a self-relation with `ON DELETE SET NULL` (deleting an older report doesn't cascade-delete its successors).
- `costUsd` is `Decimal(12,6)` — a deliberate deviation from the repo's `Decimal(10,2)` money precision, because LLM costs are frequently sub-cent and 2 dp would round them away.
- Follows the W13 App Store Listings conventions (prefixed-ULID id `arar_<ULID>`, `@map` snake_case, `Timestamptz(6)`, `IF NOT EXISTS` idempotent migration, CHECK-constrained enums). Generated artifacts (`src/models.ts`, `src/kysely/types.ts`) regenerated from the schema.

## Verification

- `tsc --noEmit`: clean for all files in this PR (the only errors on the tree are pre-existing and unrelated — a `kysely` module-resolution issue in the sibling `civitai-db` package + a few app files).
- New unit tests: **10/10 pass** (semver-correct prior selection incl. `0.10.0` > `0.9.0`, complete-only filtering, app-key scoping, same-version tie-break, null-when-none, and the exactly-one-key / valid-semver invariants).

## ⚠️ Migration is applied BY HAND — not by CI/deploy

Per repo policy the main civitai database does **not** auto-apply migrations. The SQL below is committed for history only; **a human applies it by hand per environment**. It is additive and safe to run on a live DB (`CREATE TABLE` + `CREATE INDEX`, all `IF NOT EXISTS`, no destructive statements).

```sql
-- ============================================================
-- App Blocks — agentic mod code-review report (P0 persistence layer)
-- ============================================================
CREATE TABLE IF NOT EXISTS "app_review_agent_reports" (
  "id"                  TEXT PRIMARY KEY,                       -- arar_<ULID>
  -- Dual-target review id (on-site pubreq_<ULID> / connect alpr_<ULID>), indexed, not a FK.
  "publish_request_id"  TEXT NOT NULL,
  -- App identity — EXACTLY ONE is set (on-site app block vs connect client). Indexed, no FK.
  "app_block_id"        TEXT,
  "oauth_client_id"     TEXT,
  "version"             TEXT NOT NULL,
  "bundle_sha256"       TEXT NOT NULL,
  "status"              TEXT NOT NULL DEFAULT 'running',
  "model"               TEXT,
  "started_at"          TIMESTAMPTZ NOT NULL DEFAULT now(),
  "completed_at"        TIMESTAMPTZ,
  "code_review"         JSONB,
  "security_audit"      JSONB,
  "scope_verdicts"      JSONB,
  "summary_md"          TEXT,
  -- Prior version's report (self-reference). SET NULL so deleting an older report
  -- does not cascade-delete its successors.
  "prior_report_id"     TEXT REFERENCES "app_review_agent_reports"("id") ON DELETE SET NULL,
  -- Decimal(12,6): LLM costs are frequently sub-cent.
  "token_usage"         JSONB,
  "cost_usd"            NUMERIC(12, 6),
  "created_at"          TIMESTAMPTZ NOT NULL DEFAULT now(),
  "updated_at"          TIMESTAMPTZ NOT NULL DEFAULT now(),

  CONSTRAINT "app_review_agent_reports_status_check"
    CHECK ("status" IN ('running', 'complete', 'failed', 'torn-down'))
);

CREATE INDEX IF NOT EXISTS "app_review_agent_reports_app_block_version_idx"
  ON "app_review_agent_reports" ("app_block_id", "version");
CREATE INDEX IF NOT EXISTS "app_review_agent_reports_oauth_client_version_idx"
  ON "app_review_agent_reports" ("oauth_client_id", "version");
CREATE INDEX IF NOT EXISTS "app_review_agent_reports_publish_request_idx"
  ON "app_review_agent_reports" ("publish_request_id");
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
