### PR TITLE
fix(apps): collapse iframe + other-manifest-fields instead of hiding (follow-up to #3247)

### DIFF
--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -33,6 +33,9 @@ const ONSITE_PENDING = {
     scopes: ['user:read'],
     targets: [{ slotId: 'model.sidebar_top', priority: 10 }],
     iframe: { src: 'https://example.com/block', sandbox: 'allow-scripts' },
+    // An unexpected/novel top-level key — falls into the "Other manifest fields"
+    // disclosure so the mod can still inspect payloads the renderer doesn't model.
+    unexpectedTopLevelKey: { note: 'novel-payload' },
   },
   fileSummary: {
     files: [{ path: 'index.js', sha256: 'x', sizeBytes: 10 }],
@@ -183,6 +186,57 @@ describe('OnsiteReviewModal — onsite-specific contract', () => {
     // Both action entry points are present on a pending request.
     await expect.element(page.getByRole('button', { name: 'Approve + build' })).toBeInTheDocument();
     await expect.element(page.getByRole('button', { name: 'Reject…' })).toBeInTheDocument();
+  });
+
+  test('the iframe + other-manifest-fields sections render as collapsed-by-default disclosures the mod can expand', async () => {
+    renderWithProviders(
+      <OnsiteReviewModal selection={{ request: ONSITE_PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    // Both disclosure CONTROLS render — the moderator security signal (risky
+    // iframe sandbox flags; unexpected/novel manifest keys) is one click away,
+    // not lost. The fixture carries one iframe block + one unexpected top-level key.
+    const iframeCtrl = page.getByRole('button', { name: 'Iframe' });
+    const otherCtrl = page.getByRole('button', { name: 'Other manifest fields (1)' });
+    await expect.element(iframeCtrl).toBeInTheDocument();
+    await expect.element(otherCtrl).toBeInTheDocument();
+    // Default-CLOSED: both controls report aria-expanded="false". (Mantine keeps
+    // collapsed Accordion panel content MOUNTED but hidden, so the control's
+    // expanded-state is the deterministic default-closed signal, not DOM presence.)
+    await expect.element(iframeCtrl).toHaveAttribute('aria-expanded', 'false');
+    await expect.element(otherCtrl).toHaveAttribute('aria-expanded', 'false');
+    // Expanding the Iframe disclosure flips it open and reveals the sandbox flags
+    // (`allow-scripts` lives only inside the Iframe panel).
+    await iframeCtrl.click();
+    await expect.element(iframeCtrl).toHaveAttribute('aria-expanded', 'true');
+    await expect.element(page.getByText('allow-scripts')).toBeVisible();
+    // Expanding "Other manifest fields" reveals the raw JSON of the novel key.
+    await otherCtrl.click();
+    await expect.element(otherCtrl).toHaveAttribute('aria-expanded', 'true');
+    await expect.element(page.getByText(/novel-payload/)).toBeVisible();
+  });
+
+  test('a manifest with NO iframe config and no novel keys renders NO empty "Iframe"/"Other" disclosures', async () => {
+    // A block that only uses fully-handled inline fields — no iframe, no unexpected keys.
+    const nonIframe = {
+      ...ONSITE_PENDING,
+      id: 'onsite-req-noiframe',
+      slug: 'noiframe-block',
+      manifest: {
+        name: 'No Iframe Block',
+        blockId: 'blk_2',
+        version: '1.0.0',
+        scopes: ['user:read'],
+        targets: [{ slotId: 'model.sidebar_top', priority: 10 }],
+      },
+    };
+    renderWithProviders(
+      <OnsiteReviewModal selection={{ request: nonIframe, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    // The inline structured render still shows (scopes/targets).
+    await expect.element(page.getByText('model.sidebar_top')).toBeInTheDocument();
+    // Neither disclosure control renders — no empty "Iframe" or "Other" accordion.
+    expect(page.getByRole('button', { name: 'Iframe' }).elements()).toHaveLength(0);
+    expect(page.getByText(/^Other manifest fields/).elements()).toHaveLength(0);
   });
 });
 

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -1,4 +1,5 @@
 import {
+  Accordion,
   Alert,
   Badge,
   Button,
@@ -7,6 +8,7 @@ import {
   Group,
   Modal,
   NumberInput,
+  ScrollArea,
   Select,
   SimpleGrid,
   Stack,
@@ -29,7 +31,7 @@ import {
   IconWindow,
   IconX,
 } from '@tabler/icons-react';
-import { useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { ReviewBlockPreviewHost } from '~/components/Apps/ReviewBlockPreviewHost';
 import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
 import { useReviewPreview } from '~/components/Apps/useReviewPreview';
@@ -981,13 +983,85 @@ function CodeDiffPanel({
 // Structured manifest renderer (replaces the raw JSON dump)
 // ---------------------------------------------------------------------------
 
+/** Manifest top-level keys this renderer handles inline. Anything else falls
+ * into the "Other manifest fields" disclosure as raw JSON so reviewers can
+ * still see unexpected payloads. */
+const HANDLED_MANIFEST_KEYS = new Set([
+  '$schema',
+  'appId',
+  'blockId',
+  'version',
+  'name',
+  'description',
+  'type',
+  'minApiVersion',
+  'contentRating',
+  'renderMode',
+  'trustTier',
+  'scopes',
+  'targets',
+  'iframe',
+  'settings',
+]);
+
 function ManifestView({ manifest }: { manifest: Record<string, unknown> }) {
+  const otherKeys = useMemo(
+    () =>
+      Object.keys(manifest)
+        .filter((k) => !HANDLED_MANIFEST_KEYS.has(k))
+        .sort(),
+    [manifest]
+  );
+
+  const hasIframe = !!(manifest.iframe && typeof manifest.iframe === 'object');
+  const hasOther = otherKeys.length > 0;
+
   return (
     <Stack gap="sm">
       <ManifestIdentity manifest={manifest} />
       <ManifestScopes manifest={manifest} />
       <ManifestTargets manifest={manifest} />
       <ManifestSettings manifest={manifest} />
+      {/* Iframe + other-manifest-fields are collapsed-by-default disclosures:
+          the default view stays trimmed, but the moderator security signal
+          (risky iframe sandbox flags; unexpected/novel manifest keys) is one
+          click away. No defaultValue → every item starts closed. */}
+      {(hasIframe || hasOther) && (
+        <Accordion variant="contained" multiple={false}>
+          {hasIframe && (
+            <Accordion.Item value="iframe">
+              <Accordion.Control>
+                <Text size="sm" fw={500}>
+                  Iframe
+                </Text>
+              </Accordion.Control>
+              <Accordion.Panel>
+                <ManifestIframe manifest={manifest} />
+              </Accordion.Panel>
+            </Accordion.Item>
+          )}
+          {hasOther && (
+            <Accordion.Item value="other">
+              <Accordion.Control>
+                <Text size="sm" fw={500}>
+                  Other manifest fields ({otherKeys.length})
+                </Text>
+              </Accordion.Control>
+              <Accordion.Panel>
+                <ScrollArea h={200}>
+                  <Code block style={{ fontSize: 11, padding: 8 }}>
+                    {JSON.stringify(
+                      Object.fromEntries(otherKeys.map((k) => [k, manifest[k]])),
+                      null,
+                      2
+                    )}
+                  </Code>
+                </ScrollArea>
+              </Accordion.Panel>
+            </Accordion.Item>
+          )}
+        </Accordion>
+      )}
     </Stack>
   );
 }
@@ -1289,6 +1363,106 @@ function ManifestTargets({ manifest }: { manifest: Record<string, unknown> }) {
             );
           })}
         </Stack>
+      </Stack>
+    </Card>
+  );
+}
+
+function ManifestIframe({ manifest }: { manifest: Record<string, unknown> }) {
+  const iframe =
+    manifest.iframe && typeof manifest.iframe === 'object'
+      ? (manifest.iframe as Record<string, unknown>)
+      : null;
+  if (!iframe) return null;
+  const src = typeof iframe.src === 'string' ? iframe.src : null;
+  const sandbox = typeof iframe.sandbox === 'string' ? iframe.sandbox : null;
+  const minHeight = typeof iframe.minHeight === 'number' ? iframe.minHeight : null;
+  const maxHeight = typeof iframe.maxHeight === 'number' ? iframe.maxHeight : null;
+  const resizable = typeof iframe.resizable === 'boolean' ? iframe.resizable : null;
+
+  const sandboxFlags = sandbox ? sandbox.split(/\s+/).filter(Boolean) : [];
+
+  return (
+    <Card withBorder p="sm">
+      <Stack gap="xs">
+        <Group gap={6}>
+          <IconWindow size={14} />
+          <Text size="sm" fw={600}>
+            Iframe
+          </Text>
+        </Group>
+        {src && (
+          <Group gap={6} align="baseline">
+            <Text size="xs" c="dimmed" style={{ minWidth: 60 }}>
+              src
+            </Text>
+            <a href={src} target="_blank" rel="noopener" style={{ fontSize: 12 }}>
+              {src}
+            </a>
+          </Group>
+        )}
+        {sandboxFlags.length > 0 && (
+          <Group gap={6} align="baseline">
+            <Text size="xs" c="dimmed" style={{ minWidth: 60 }}>
+              sandbox
+            </Text>
+            <Group gap={4}>
+              {sandboxFlags.map((flag) => {
+                const risky =
+                  flag === 'allow-same-origin' ||
+                  flag === 'allow-top-navigation' ||
+                  flag === 'allow-popups-to-escape-sandbox';
+                return (
+                  <Tooltip
+                    key={flag}
+                    label={
+                      risky
+                        ? 'Higher-risk sandbox flag — review carefully.'
+                        : 'Standard sandbox flag.'
+                    }
+                  >
+                    <Badge
+                      size="xs"
+                      color={risky ? 'orange' : 'gray'}
+                      variant="light"
+                      leftSection={risky ? <IconShieldLock size={10} /> : undefined}
+                    >
+                      {flag}
+                    </Badge>
+                  </Tooltip>
+                );
+              })}
+            </Group>
+          </Group>
+        )}
+        {(minHeight !== null || maxHeight !== null || resizable !== null) && (
+          <Group gap={12}>
+            {minHeight !== null && (
+              <Text size="xs">
+                <Text component="span" size="xs" c="dimmed">
+                  min height:
+                </Text>{' '}
+                {minHeight}px
+              </Text>
+            )}
+            {maxHeight !== null && (
+              <Text size="xs">
+                <Text component="span" size="xs" c="dimmed">
+                  max height:
+                </Text>{' '}
+                {maxHeight}px
+              </Text>
+            )}
+            {resizable !== null && (
+              <Text size="xs">
+                <Text component="span" size="xs" c="dimmed">
+                  resizable:
+                </Text>{' '}
+                {resizable ? 'yes' : 'no'}
+              </Text>
+            )}
+          </Group>
+        )}
       </Stack>
     </Card>
   );


### PR DESCRIPTION
PR #3247 was squash-merged to `main` in its original "remove the sections" form due to a merge-timing race: the intended revision landed on the branch ~1 minute too late and never reached `main`.

This follow-up restores the intended UX: instead of **removing** the manifest **Iframe** card and the **Other manifest fields** block, present them as collapsed-by-default `Accordion` disclosures at the bottom of `ManifestView`.

- Default modal view stays trimmed (identity / scopes / targets / settings inline).
- Iframe + other-manifest-fields become default-closed disclosures — the mod security signal (risky iframe sandbox flags; unexpected/novel manifest keys) is one click away rather than lost.
- Items render only when their content exists (guarded on `manifest.iframe` being an object / `otherKeys.length > 0`) — no empty disclosures.
- Keeps the already-merged parts of #3247 (sha256 hidden, "View full source" relocated into Files).

Verification: `tsc --noEmit` clean; `OnsiteReviewModal.browser.test.tsx` 14/14 passing in Chromium (includes default-closed `aria-expanded` assertions + a negative no-disclosure case).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)