### PR TITLE
fix(apps): XOR CHECK + bounded prior-report query for AppReviewAgentReport (follow-up to #3249)

### DIFF
--- a/prisma/migrations/20260720120000_app_review_agent_report/migration.sql
+++ b/prisma/migrations/20260720120000_app_review_agent_report/migration.sql
@@ -22,7 +22,9 @@
 -- Idempotent: IF NOT EXISTS guards on the table + every index so a manual re-run
 -- is a no-op. The table is brand-new + EMPTY, so plain CREATE INDEX takes no
 -- meaningful lock — CONCURRENTLY is unnecessary (and cannot run in a txn). The
--- string enum uses a CHECK constraint (mirrors the app_listings.status pattern).
+-- string enum uses a CHECK constraint (mirrors the app_listings.status pattern),
+-- and a second CHECK enforces the app-key XOR (exactly one of app_block_id /
+-- oauth_client_id set) at the DB.
 
 -- ------------------------------------------------------------
 -- app_review_agent_reports — per-review agent report, chained by version
@@ -35,8 +37,10 @@ CREATE TABLE IF NOT EXISTS "app_review_agent_reports" (
   -- a FK — resolved by kind in the service.
   "publish_request_id"  TEXT NOT NULL,
   -- App identity — EXACTLY ONE is set: app_block_id for an on-site App Block,
-  -- oauth_client_id for an external / OAuth-connect app. Plain indexed columns
-  -- (no FK) so this dark P0 stays a self-contained additive island.
+  -- oauth_client_id for an external / OAuth-connect app. The exactly-one
+  -- invariant is enforced by the app_key_xor CHECK below (not merely by the
+  -- reader). Plain indexed columns (no FK) so this dark P0 stays a
+  -- self-contained additive island.
   "app_block_id"        TEXT,
   "oauth_client_id"     TEXT,
   -- The reviewed bundle's version (semver) + integrity hash.
@@ -64,11 +68,18 @@ CREATE TABLE IF NOT EXISTS "app_review_agent_reports" (
   "updated_at"          TIMESTAMPTZ NOT NULL DEFAULT now(),
 
   CONSTRAINT "app_review_agent_reports_status_check"
-    CHECK ("status" IN ('running', 'complete', 'failed', 'torn-down'))
+    CHECK ("status" IN ('running', 'complete', 'failed', 'torn-down')),
+  -- App-key XOR: EXACTLY ONE of app_block_id / oauth_client_id is set. Enforced
+  -- at the DB (not just in the reader) so a future writer that sets BOTH is
+  -- rejected — otherwise a report would surface under two apps (cross-app leak).
+  -- Safe to add unconditionally: the table is brand-new + empty.
+  CONSTRAINT "app_review_agent_reports_app_key_xor"
+    CHECK (num_nonnulls("app_block_id", "oauth_client_id") = 1)
 );
 
--- "latest prior complete report for this app older than version X" lookups, one
--- index per app-key kind (on-site vs connect).
+-- Per-app-key covering index (on-site vs connect). Narrows the candidate set to
+-- one app; the reader still filters status='complete' and picks the semver-latest
+-- older version IN-APP (neither status nor semver ordering is expressed here).
 CREATE INDEX IF NOT EXISTS "app_review_agent_reports_app_block_version_idx"
   ON "app_review_agent_reports" ("app_block_id", "version");
 CREATE INDEX IF NOT EXISTS "app_review_agent_reports_oauth_client_version_idx"

--- a/src/server/services/blocks/__tests__/app-review-report.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-review-report.service.test.ts
@@ -62,6 +62,8 @@ describe('getPriorAgentReport', () => {
     await getPriorAgentReport({ appBlockId: 'ab_x', version: '2.0.0' });
     expect(mockFindMany).toHaveBeenCalledWith({
       where: { appBlockId: 'ab_x', status: 'complete' },
+      orderBy: { startedAt: 'desc' },
+      take: 100,
     });
   });
 
@@ -70,6 +72,8 @@ describe('getPriorAgentReport', () => {
     await getPriorAgentReport({ oauthClientId: 'oc_y', version: '2.0.0' });
     expect(mockFindMany).toHaveBeenCalledWith({
       where: { oauthClientId: 'oc_y', status: 'complete' },
+      orderBy: { startedAt: 'desc' },
+      take: 100,
     });
   });
 
@@ -96,6 +100,18 @@ describe('getPriorAgentReport', () => {
     ]);
     const prior = await getPriorAgentReport({ appBlockId: 'ab_x', version: '1.0.0' });
     expect(prior?.id).toBe('arar_late');
+  });
+
+  it('picks the semver-latest even when the recency-bounded fetch returns a different order', async () => {
+    // The query is bounded/ordered by startedAt desc; the in-app semver sort is
+    // authoritative, so the greatest older version wins regardless of fetch order.
+    mockFindMany.mockResolvedValue([
+      report({ id: 'arar_newest_started', version: '0.2.0', startedAt: new Date('2026-03-01T00:00:00Z') }),
+      report({ id: 'arar_highest_semver', version: '0.10.0', startedAt: new Date('2026-01-01T00:00:00Z') }),
+      report({ id: 'arar_mid', version: '0.9.0', startedAt: new Date('2026-02-01T00:00:00Z') }),
+    ]);
+    const prior = await getPriorAgentReport({ appBlockId: 'ab_x', version: '1.0.0' });
+    expect(prior?.id).toBe('arar_highest_semver');
   });
 
   it('throws when neither or both app keys are provided', async () => {

--- a/src/server/services/blocks/app-review-report.service.ts
+++ b/src/server/services/blocks/app-review-report.service.ts
@@ -52,10 +52,13 @@ export type GetPriorAgentReportArgs = {
  *
  * "Most recent" is resolved on the VERSION axis (the greatest version still
  * older than the target), which is the authoritative ordering for the chain;
- * ties (same version re-reviewed) break on `startedAt` desc. Only a handful of
- * versions exist per app, so the candidate set is fetched and compared in-app
- * (the `version` column is a lexical index — not semver-ordered — so the
- * ordering can't be pushed into SQL correctly).
+ * ties (same version re-reviewed) break on `startedAt` desc. The DB does NOT
+ * drive this selection: the `(app_key, version)` index only narrows rows to one
+ * app; `status='complete'` is a WHERE filter and the semver ordering is applied
+ * IN-APP (the `version` column is lexically, not semver-, ordered, so the
+ * ordering can't be pushed into SQL correctly). Only a handful of versions exist
+ * per app, and the fetch is recency-bounded (see the `take` below), so the
+ * candidate set stays small.
  */
 export async function getPriorAgentReport(
   args: GetPriorAgentReportArgs
@@ -65,7 +68,9 @@ export async function getPriorAgentReport(
   const hasBlock = appBlockId != null && appBlockId !== '';
   const hasClient = oauthClientId != null && oauthClientId !== '';
   if (hasBlock === hasClient) {
-    // Enforce the "exactly one app key" invariant the column pair encodes.
+    // Fail fast on the "exactly one app key" invariant. The DB also enforces it
+    // via the app_key_xor CHECK on the table; this is the friendly caller-side
+    // guard so a bad arg errors here rather than at write time.
     throw new Error(
       'getPriorAgentReport requires exactly one of { appBlockId, oauthClientId }'
     );
@@ -78,7 +83,16 @@ export async function getPriorAgentReport(
     ? { appBlockId, status: 'complete' as const }
     : { oauthClientId, status: 'complete' as const };
 
-  const candidates = await dbRead.appReviewAgentReport.findMany({ where });
+  // Recency-bounded superset of the semver answer: take the N most recently
+  // started complete reports. The true semver-latest-older report is always
+  // within the most-recent slice for any real app (only a handful of versions
+  // exist), so bounding by recency keeps the in-app semver sort below correct
+  // while capping the fetch for a pathologically re-reviewed app.
+  const candidates = await dbRead.appReviewAgentReport.findMany({
+    where,
+    orderBy: { startedAt: 'desc' },
+    take: 100,
+  });
 
   const prior = candidates
     // Only reports strictly older (by semver) than the version under review.


### PR DESCRIPTION
Follow-up to #3249 (`AppReviewAgentReport` P0 persistence, dark/additive).

#3249 was squash-merged to `main` **without this audit follow-up commit** — it was committed to the branch ~1 minute too late and got stranded off the squash. This PR recovers it (cherry-pick of the stranded tip commit onto fresh `origin/main`).

## What this adds

1. **DB-level XOR CHECK** — a named `CONSTRAINT "app_review_agent_reports_app_key_xor" CHECK (num_nonnulls("app_block_id","oauth_client_id") = 1)` inside the `CREATE TABLE`, so *exactly one* of `app_block_id` / `oauth_client_id` is set at the **DB**, not merely in the reader. Prevents a future writer that sets both from surfacing one report under two apps (cross-app leak). SQL-only — Prisma can't express a multi-column CHECK, so there is no `schema.full.prisma` change.
2. **Bounded prior-report query** — `getPriorAgentReport`'s `findMany` is now `orderBy: { startedAt: 'desc' }, take: 100`, a recency-bounded superset of the semver answer, so a pathologically re-reviewed app can't fetch an unbounded set. The in-app `semver.lt` filter + `rcompare` sort are unchanged, so the true semver-latest-older report is still selected.
3. **Comment corrections** — reconciles two overstated comments (the index does not "drive" the lookup — it only narrows to one app; the XOR invariant is now DB-enforced).
4. **Unit test** — asserts the recency-bounded fetch still yields the semver-latest prior regardless of `startedAt` fetch order.

## ⚠️ Migration apply note

The P0 migration `prisma/migrations/20260720120000_app_review_agent_report/` is **not yet hand-applied** (per the manual-apply DB rule, CNPG nvme0 does not run `prisma migrate deploy`). **Apply THIS final version — with the `app_key_xor` CHECK — to CNPG nvme0, not the #3249 original.** Editing the migration SQL in place is valid because it has not been applied to prod yet; the final applied version must include the CHECK.

Final migration SQL (the full file as it now stands on this branch):

```sql
-- ============================================================
-- App Blocks — agentic mod code-review report (P0 persistence layer)
-- ============================================================
-- Introduces app_review_agent_reports: one row per agent code-review of an app
-- version, keyed to the app (on-site app_blocks OR external OauthClient) + the
-- reviewed version, so the NEXT version's review can diff against the prior one
-- (the prior_report_id self-chain).
--
-- P0 = data model ONLY, fully DARK/INERT: NOTHING in the running image reads or
-- writes this table (no router, no REST handler, no job). It is additive and
-- read by nothing, so applying it ahead of / independent of the code that will
-- populate it is inert. Provisioning, the review UI, and the chat surface are
-- later phases.
--
-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
-- CNPG nvme0 DB does NOT auto-apply migrations (no prisma migrate deploy). This
-- file is committed for HISTORY ONLY; a HUMAN applies the SQL below per
-- environment (psql/retool). CI / deploy do NOT run it. Apply to BOTH:
--   1. prod nvme0   (the live civitai DB)
--   2. the dev clone
--
-- Idempotent: IF NOT EXISTS guards on the table + every index so a manual re-run
-- is a no-op. The table is brand-new + EMPTY, so plain CREATE INDEX takes no
-- meaningful lock — CONCURRENTLY is unnecessary (and cannot run in a txn). The
-- string enum uses a CHECK constraint (mirrors the app_listings.status pattern),
-- and a second CHECK enforces the app-key XOR (exactly one of app_block_id /
-- oauth_client_id set) at the DB.

-- ------------------------------------------------------------
-- app_review_agent_reports — per-review agent report, chained by version
-- ------------------------------------------------------------
CREATE TABLE IF NOT EXISTS "app_review_agent_reports" (
  "id"                  TEXT PRIMARY KEY,                       -- arar_<ULID>
  -- The review (publish request) this report was generated for. DUAL-TARGET by
  -- construction (on-site = app_block_publish_requests.id pubreq_<ULID>; connect
  -- = app_listing_publish_requests.id alpr_<ULID>), so it is an indexed id, NOT
  -- a FK — resolved by kind in the service.
  "publish_request_id"  TEXT NOT NULL,
  -- App identity — EXACTLY ONE is set: app_block_id for an on-site App Block,
  -- oauth_client_id for an external / OAuth-connect app. The exactly-one
  -- invariant is enforced by the app_key_xor CHECK below (not merely by the
  -- reader). Plain indexed columns (no FK) so this dark P0 stays a
  -- self-contained additive island.
  "app_block_id"        TEXT,
  "oauth_client_id"     TEXT,
  -- The reviewed bundle's version (semver) + integrity hash.
  "version"             TEXT NOT NULL,
  "bundle_sha256"       TEXT NOT NULL,
  -- Agent-run lifecycle. CHECK-constrained below.
  "status"              TEXT NOT NULL DEFAULT 'running',
  -- The LLM that produced the review (NULL until the run reports one).
  "model"               TEXT,
  "started_at"          TIMESTAMPTZ NOT NULL DEFAULT now(),
  "completed_at"        TIMESTAMPTZ,
  -- Structured agent outputs (NULLABLE — populated as the run progresses).
  "code_review"         JSONB,
  "security_audit"      JSONB,
  "scope_verdicts"      JSONB,
  "summary_md"          TEXT,
  -- The prior version's report in the chain (self-reference). SET NULL so
  -- deleting an older report does not cascade-delete its successors.
  "prior_report_id"     TEXT REFERENCES "app_review_agent_reports"("id") ON DELETE SET NULL,
  -- LLM token accounting + total cost. Decimal(12,6): LLM costs are frequently
  -- sub-cent, so the repo's (10,2) money precision would round them away.
  "token_usage"         JSONB,
  "cost_usd"            NUMERIC(12, 6),
  "created_at"          TIMESTAMPTZ NOT NULL DEFAULT now(),
  "updated_at"          TIMESTAMPTZ NOT NULL DEFAULT now(),

  CONSTRAINT "app_review_agent_reports_status_check"
    CHECK ("status" IN ('running', 'complete', 'failed', 'torn-down')),
  -- App-key XOR: EXACTLY ONE of app_block_id / oauth_client_id is set. Enforced
  -- at the DB (not just in the reader) so a future writer that sets BOTH is
  -- rejected — otherwise a report would surface under two apps (cross-app leak).
  -- Safe to add unconditionally: the table is brand-new + empty.
  CONSTRAINT "app_review_agent_reports_app_key_xor"
    CHECK (num_nonnulls("app_block_id", "oauth_client_id") = 1)
);

-- Per-app-key covering index (on-site vs connect). Narrows the candidate set to
-- one app; the reader still filters status='complete' and picks the semver-latest
-- older version IN-APP (neither status nor semver ordering is expressed here).
CREATE INDEX IF NOT EXISTS "app_review_agent_reports_app_block_version_idx"
  ON "app_review_agent_reports" ("app_block_id", "version");
CREATE INDEX IF NOT EXISTS "app_review_agent_reports_oauth_client_version_idx"
  ON "app_review_agent_reports" ("oauth_client_id", "version");
-- By-review lookup (getAgentReport).
CREATE INDEX IF NOT EXISTS "app_review_agent_reports_publish_request_idx"
  ON "app_review_agent_reports" ("publish_request_id");
```

## Verification

- `vitest run` on `app-review-report.service.test.ts` — **11/11 pass**.
- `tsc --noEmit` — clean for the touched service file (pre-existing unrelated `kysely` workspace-resolution + `event-engine-common` submodule errors remain, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
