### PR TITLE
feat(donation-goals): let creators hide public collected amount

### DIFF
--- a/src/components/Account/SettingsCard.tsx
+++ b/src/components/Account/SettingsCard.tsx
@@ -46,7 +46,7 @@ export function SettingsCard() {
     },
   });
 
-  const { assistantPersonality } = useCurrentUserSettings();
+  const { assistantPersonality, hideDonationGoals } = useCurrentUserSettings();
   const { mutate: mutateSetting, isPending: isLoadingSetting } = useMutateUserSettings();
 
   if (!user) return null;
@@ -201,6 +201,21 @@ export function SettingsCard() {
                 </div>
               </Tooltip>
             </Stack>
+          </>
+        )}
+
+        {flags.donationGoals && (
+          <>
+            <Divider label="Creator Preferences" />
+            <Switch
+              name="hideDonationGoals"
+              label="Hide my donation goals from public view"
+              description="Others won't see the progress bar or collected amount on your donation goals. The goal keeps working, and you and moderators can still see it."
+              checked={hideDonationGoals ?? false}
+              onChange={(e) => mutateSetting({ hideDonationGoals: e.target.checked })}
+              disabled={isLoadingSetting}
+              styles={{ track: { flex: '0 0 1em' } }}
+            />
           </>
         )}
 

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -29,6 +29,7 @@ import {
   MIN_DONATION_GOAL,
 } from '~/components/Model/ModelVersions/model-version.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useCurrentUserSettings, useMutateUserSettings } from '~/components/UserSettings/hooks';
 import {
   Form,
   InputCreatableMultiSelect,
@@ -164,6 +165,9 @@ export function ModelVersionUpsertForm({
   const router = useRouter();
   const queryUtils = trpc.useUtils();
   const currentUser = useCurrentUser();
+  const { hideDonationGoals } = useCurrentUserSettings();
+  const { mutate: mutateUserSettings, isPending: hideDonationGoalsUpdating } =
+    useMutateUserSettings();
   const colorScheme = useComputedColorScheme('dark');
   const theme = useMantineTheme();
 
@@ -264,7 +268,9 @@ export function ModelVersionUpsertForm({
   );
   const defaultLicensingSourceId = licensingRootsData?.defaultVersionId ?? null;
   // A version that is itself a licensing root is the source, so it doesn't pick a parent.
-  const currentIsLicensingRoot = (licensingRootsData?.roots ?? []).some((r) => r.id === version?.id);
+  const currentIsLicensingRoot = (licensingRootsData?.roots ?? []).some(
+    (r) => r.id === version?.id
+  );
   // Versions flagged NotDerivative (e.g. API-only official checkpoints) aren't
   // fine-tunes, so the form doesn't require/auto-select a parent for them. They
   // can still set their own licensing fee via the fee field above.
@@ -827,6 +833,15 @@ export function ModelVersionUpsertForm({
                                     !!version?.earlyAccessConfig?.donationGoalId ||
                                     isEarlyAccessOver
                                   }
+                                />
+                                <Switch
+                                  label="Hide donation goals from public view"
+                                  description="Others won't see the progress bar or collected amount. The goal still works, and you and moderators can still see it. This applies to all of your donation goals."
+                                  checked={hideDonationGoals ?? false}
+                                  onChange={(e) =>
+                                    mutateUserSettings({ hideDonationGoals: e.target.checked })
+                                  }
+                                  disabled={hideDonationGoalsUpdating}
                                 />
                               </Stack>
                             </Card.Section>

--- a/src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts
+++ b/src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts
@@ -53,6 +53,7 @@ const { mockDbRead, mockDbWrite } = vi.hoisted(() => {
   const mk = () => ({
     modelVersion: { findMany: vi.fn() },
     donationGoal: { findMany: vi.fn() },
+    user: { findMany: vi.fn() },
     $queryRaw: vi.fn(),
   });
   return { mockDbRead: mk(), mockDbWrite: mk() };
@@ -98,9 +99,11 @@ beforeEach(() => {
   setNxMock.mockClear().mockResolvedValue(true);
   mockDbRead.modelVersion.findMany.mockReset();
   mockDbRead.donationGoal.findMany.mockReset();
+  mockDbRead.user.findMany.mockReset().mockResolvedValue([]);
   mockDbRead.$queryRaw.mockReset();
   mockDbWrite.modelVersion.findMany.mockReset();
   mockDbWrite.donationGoal.findMany.mockReset();
+  mockDbWrite.user.findMany.mockReset().mockResolvedValue([]);
   mockDbWrite.$queryRaw.mockReset();
 });
 
@@ -196,5 +199,35 @@ describe('modelVersionPublicDonationGoalsCache', () => {
     expect(res[5].goals.map((g) => g.id)).toEqual([10]); // EA goal 11 excluded
     expect(res[9].goals.map((g) => g.id).sort((a, b) => a - b)).toEqual([20, 21]); // both shown
     expect(res[5].goals[0].total).toBe(0); // no donation → 0
+  });
+
+  it('hides an early-access goal once the early-access window has ended (past date)', async () => {
+    mockDbRead.modelVersion.findMany.mockResolvedValue([
+      { id: 9, earlyAccessEndsAt: new Date('2000-01-01T00:00:00.000Z') }, // EA already ended
+    ]);
+    mockDbRead.donationGoal.findMany.mockResolvedValue([
+      row({ id: 20, isEarlyAccess: false, modelVersionId: 9 }),
+      row({ id: 21, isEarlyAccess: true, modelVersionId: 9 }),
+    ]);
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+    const cache = buildCache();
+
+    const res = await cache.fetch([9]);
+
+    expect(res[9].goals.map((g) => g.id)).toEqual([20]); // ended EA goal 21 excluded
+  });
+
+  it('hides all goals whose owner opted out via hideDonationGoals', async () => {
+    mockDbRead.modelVersion.findMany.mockResolvedValue([{ id: 5, earlyAccessEndsAt: null }]);
+    mockDbRead.donationGoal.findMany.mockResolvedValue([
+      row({ id: 10, userId: 7, modelVersionId: 5 }),
+    ]);
+    mockDbRead.user.findMany.mockResolvedValue([{ id: 7, settings: { hideDonationGoals: true } }]);
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+    const cache = buildCache();
+
+    const res = await cache.fetch([5]);
+
+    expect(res[5]).toEqual({ modelVersionId: 5, goals: [] }); // owner opted out → nothing public
   });
 });

--- a/src/server/redis/donation-goals-cache.ts
+++ b/src/server/redis/donation-goals-cache.ts
@@ -83,6 +83,23 @@ export const publicDonationGoalsLookupFn = async (
     },
   });
 
+  // Creator opt-out: an owner can hide the public donation-goal display for ALL their
+  // goals via the `hideDonationGoals` user setting. Non-owner/non-mod viewers go through
+  // this cache, so drop those goals here. Owners/mods bypass the cache entirely (see
+  // `modelVersionDonationGoals`) and still see their goals.
+  const ownerIds = [...new Set(goals.map((g) => g.userId))];
+  const hiddenOwnerIds = new Set<number>();
+  if (ownerIds.length > 0) {
+    const owners = await db.user.findMany({
+      where: { id: { in: ownerIds } },
+      select: { id: true, settings: true },
+    });
+    for (const owner of owners) {
+      const settings = owner.settings as { hideDonationGoals?: boolean } | null;
+      if (settings?.hideDonationGoals) hiddenOwnerIds.add(owner.id);
+    }
+  }
+
   const totalByGoalId = new Map<number, number>();
   const goalIds = goals.map((g) => g.id);
   if (goalIds.length > 0) {
@@ -100,13 +117,17 @@ export const publicDonationGoalsLookupFn = async (
   const result: Record<number, ModelVersionPublicDonationGoalsCacheItem> = {};
   for (const v of versions) result[v.id] = { modelVersionId: v.id, goals: [] };
 
+  const now = new Date();
   for (const goal of goals) {
     const { modelVersionId, ...rest } = goal;
     if (modelVersionId == null) continue;
-    // Public early-access filter, byte-identical to the uncached query's
-    // `isEarlyAccess: version.earlyAccessEndsAt ? undefined : false`: early-access goals are
-    // only shown publicly while the version still has an earlyAccessEndsAt set.
-    if (goal.isEarlyAccess && !earlyAccessById.get(modelVersionId)) continue;
+    if (hiddenOwnerIds.has(goal.userId)) continue;
+    // Public early-access filter: an early-access goal is shown publicly only while the
+    // version's early-access window is still open. Once it has ended (missing or past
+    // `earlyAccessEndsAt`) the goal is hidden from the public — the goal itself keeps
+    // working; owners/mods still see it via the uncached privileged path.
+    const earlyAccessEndsAt = earlyAccessById.get(modelVersionId);
+    if (goal.isEarlyAccess && (!earlyAccessEndsAt || earlyAccessEndsAt <= now)) continue;
     result[modelVersionId].goals.push({ ...rest, total: totalByGoalId.get(goal.id) ?? 0 });
   }
 

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -282,6 +282,9 @@ export const userSettingsSchema = z.object({
   cosmeticStoreLastViewed: z.coerce.date().nullish(),
   allowAds: z.boolean().optional(),
   disableHidden: z.boolean().optional(),
+  // Creator opt-out: when true, the public donation-goal display (progress + collected
+  // amount) is hidden from non-owner/non-mod viewers on all of this user's models.
+  hideDonationGoals: z.boolean().optional(),
   hideDownloadsSince: z.number().optional(),
   gallerySettings: (
     z.object({
@@ -337,6 +340,7 @@ export const setUserSettingsInput = z.object({
   creatorsProgramCodeOfConductAccepted: z.date().optional(),
   cosmeticStoreLastViewed: z.date().optional(),
   allowAds: z.boolean().optional(),
+  hideDonationGoals: z.boolean().optional(),
   tourSettings: tourSettingsSchema.optional(),
   generation: generationSettingsSchema.optional(),
   creatorProgramToSAccepted: z.date().optional(),


### PR DESCRIPTION
## What & why

Creator feedback (MNeMiC): the donation-goal progress bar publicly exposes how much a creator has collected/earned, which is especially unwanted on models whose Early Access has already ended. This lets creators opt out of that public display while the donation goal keeps working (it still triggers the EA unlock).

## Changes

1. **Per-account opt-out** — new `hideDonationGoals` user setting. When ON, non-owner/non-mod viewers see none of the creator's donation-goal displays. Owners and moderators still see them.
2. **Auto-hide ended goals** — an early-access donation goal is now hidden from the public once its early-access window has ended (missing or past `earlyAccessEndsAt`), not just when the field is cleared.
3. **Two entry points for the toggle**:
   - Account settings → Creator Preferences (feature-gated behind `donationGoals`).
   - The model-version Early Access config, right where the donation goal is set (reflects/writes the same per-account setting).

## Implementation notes

- Both filters live in `publicDonationGoalsLookupFn` (the lookup behind `modelVersionPublicDonationGoalsCache`), which serves only the public (non-owner, non-mod) variant. The privileged owner/mod path is uncached and unchanged, so creators and mods still see everything, and the goal + its EA-unlock trigger are untouched.
- No DB migration — reuses the JSON `User.settings` column. Change visibility is bounded by the cache's existing 60s (`CacheTTL.xs`) TTL, so no extra cache-busting was added.
- Added unit tests for the owner opt-out and the ended-EA hide; existing cache tests updated for the new owner-settings lookup. `pnpm typecheck` and the affected vitest files pass.

## How to verify

- As a creator, toggle "Hide my donation goals from public view" in Account settings (or in the model-version Early Access config). View one of your models in an incognito/logged-out window: the "Support this model" donation-goal block should disappear; as the owner or a moderator it still shows.
- Set/keep an early-access donation goal and let (or set) its early-access window to the past: the goal stops showing publicly (within ~60s of cache TTL) while remaining visible to owner/mods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
