### PR TITLE
fix(support): let /bugs work on civitai.red instead of bouncing to .com

### DIFF
--- a/ops/cloudflare/civitai-red-redirects.json
+++ b/ops/cloudflare/civitai-red-redirects.json
@@ -4,7 +4,7 @@
   "rules": [
     {
       "description": "support-portal bounce (.red -> .com session-sync trampoline)",
-      "expression": "(http.request.uri.path eq \"/bugs\" or http.request.uri.path eq \"/canny/bugs\" or http.request.uri.path eq \"/support-portal\")",
+      "expression": "(http.request.uri.path eq \"/support-portal\")",
       "action": "redirect",
       "action_parameters": {
         "from_value": {


### PR DESCRIPTION
## Problem
On **civitai.red**, `/bugs` redirects to civitai.com and forces a second sign-in.

Root cause is a **Cloudflare edge rule** (`ops/cloudflare/civitai-red-redirects.json`), not app code. It intercepts `/bugs`, `/canny/bugs`, `/support-portal` on the `.red` zone and 302s them to `https://civitai.com/support?sync-account=red&sync-redirect=<path>`, which:
- runs the `.com` domain-sync (`useDomainSync`) → a cross-domain auth round-trip that surfaces as a sign-in, since the `.red` session cookie isn't valid on `.com`;
- passes `sync-redirect=/bugs`, but **nothing reads `sync-redirect`** — so users land on `/support` and never reach the Freshdesk portal.

## Change
Drop `/bugs` and `/canny/bugs` from the edge rule. They then fall through to the existing Next.js redirect (`next.config.mjs`), which hands off to the **same Freshworks SSO** URL that `.com` uses — no `.com` trampoline, no domain-sync leg, no dead `sync-redirect`. `/support-portal` is left on the trampoline for now (separate call).

## ⚠️ Required follow-ups (this PR alone does not fully ship it)
1. **Live Cloudflare zone:** this file is the checked-in copy. The live `civitai.red` dynamic-redirect rule must be updated to match (via the `cloudflare` skill / zone). Until then, prod behavior is unchanged.
2. **Freshworks SSO leg:** the Freshworks provider authenticates against the `.com` IdP endpoint (`/api/auth/freshdesk`). A `.red`-only session may still not resolve there and could re-prompt. Either point the Freshworks tenant SSO at a host that resolves the shared hub session (or make it host-relative), or confirm the hub session is silently resolvable at `civitai.com/api/auth/freshdesk` for a user who signed in on `.red`. Needs a quick verify before calling this fully fixed.

## Verify (after the live zone rule is updated)
- On civitai.red, hit `/bugs` → should reach the Freshdesk/Freshworks support flow on the current domain without bouncing to civitai.com or forcing a re-login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)