### PR TITLE
fix(api): match by-id model access to the site, stop over-gating the list

### DIFF
--- a/src/pages/api/v1/blocks/models.ts
+++ b/src/pages/api/v1/blocks/models.ts
@@ -156,6 +156,9 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
         cursor: !query ? cursor : undefined,
         query,
         searchIds,
+        // The public endpoint lets the addon policy decide, which leaves minor
+        // models visible under a SFW ceiling. Blocks stay strict on both axes.
+        disableMinor: true,
       },
       {
         // CLAMPED browsing level — never the client's. nsfwImagePassthrough is

--- a/src/pages/api/v1/models/[id].ts
+++ b/src/pages/api/v1/models/[id].ts
@@ -70,6 +70,11 @@ async function buildPublicModelResponse(
       periodMode: 'published',
       browsingLevel,
     },
+    // `browsingLevel` here is the ceiling this endpoint is allowed to serve, not
+    // a request for mature content, so the addon discovery rules must not fire —
+    // they 404 minor-flagged and child-tagged models that /models/{id} serves at
+    // the same id. POI still applies, matching the model page.
+    ignoreBrowsingAddons: true,
   });
   if (items.length === 0) return null;
 
@@ -77,76 +82,76 @@ async function buildPublicModelResponse(
 
   return {
     ...model,
-      mode: model.mode == null ? undefined : model.mode,
-      creator: user
-        ? {
-            username: user.username,
-            image: user.profilePicture
-              ? getEdgeUrl(user.profilePicture.url, {
-                  width: 96,
-                  name: user.username,
-                  type: user.profilePicture.type,
-                })
-              : user.image
-              ? getEdgeUrl(user.image, { width: 96, name: user.username })
-              : null,
-          }
-        : undefined,
-      tags: tagsOnModels.map(({ name }) => name),
-      modelVersions: modelVersions
-        .filter((x) => x.status === 'Published')
-        .map(({ images, files, ...version }) => {
-          const castedFiles = files as Array<
-            Omit<(typeof files)[number], 'metadata'> & { metadata: BasicFileMetadata }
-          >;
-          const primaryFile = getPrimaryFile(castedFiles);
-          if (!primaryFile) return null;
+    mode: model.mode == null ? undefined : model.mode,
+    creator: user
+      ? {
+          username: user.username,
+          image: user.profilePicture
+            ? getEdgeUrl(user.profilePicture.url, {
+                width: 96,
+                name: user.username,
+                type: user.profilePicture.type,
+              })
+            : user.image
+            ? getEdgeUrl(user.image, { width: 96, name: user.username })
+            : null,
+        }
+      : undefined,
+    tags: tagsOnModels.map(({ name }) => name),
+    modelVersions: modelVersions
+      .filter((x) => x.status === 'Published')
+      .map(({ images, files, ...version }) => {
+        const castedFiles = files as Array<
+          Omit<(typeof files)[number], 'metadata'> & { metadata: BasicFileMetadata }
+        >;
+        const primaryFile = getPrimaryFile(castedFiles);
+        if (!primaryFile) return null;
 
-          const includeDownloadUrl = model.mode !== ModelModifier.Archived;
-          const includeImages = model.mode !== ModelModifier.TakenDown;
+        const includeDownloadUrl = model.mode !== ModelModifier.Archived;
+        const includeImages = model.mode !== ModelModifier.TakenDown;
 
-          return removeEmpty({
-            ...version,
-            files: includeDownloadUrl
-              ? castedFiles
-                  .filter((file) => file.visibility === ModelFileVisibility.Public)
-                  .map(({ hashes, metadata, ...file }) => ({
-                    ...file,
-                    metadata: removeEmpty(metadata),
-                    name: safeDecodeURIComponent(
-                      getDownloadFilename({ model, modelVersion: version, file })
-                    ),
-                    hashes: hashesAsObject(hashes),
-                    downloadUrl: `${baseUrl}${createModelFileDownloadUrl({
-                      versionId: version.id,
-                      type: file.type,
-                      meta: metadata,
-                      primary: primaryFile.id === file.id,
-                    })}`,
-                    primary: primaryFile.id === file.id ? true : undefined,
-                    url: undefined,
-                    visibility: undefined,
-                  }))
-              : [],
-            images: includeImages
-              ? images.map(({ url, id, ...image }) => ({
-                  url: getEdgeUrl(url, {
-                    original: true,
-                    name: id.toString(),
-                    type: image.type,
-                  }),
-                  ...image,
+        return removeEmpty({
+          ...version,
+          files: includeDownloadUrl
+            ? castedFiles
+                .filter((file) => file.visibility === ModelFileVisibility.Public)
+                .map(({ hashes, metadata, ...file }) => ({
+                  ...file,
+                  metadata: removeEmpty(metadata),
+                  name: safeDecodeURIComponent(
+                    getDownloadFilename({ model, modelVersion: version, file })
+                  ),
+                  hashes: hashesAsObject(hashes),
+                  downloadUrl: `${baseUrl}${createModelFileDownloadUrl({
+                    versionId: version.id,
+                    type: file.type,
+                    meta: metadata,
+                    primary: primaryFile.id === file.id,
+                  })}`,
+                  primary: primaryFile.id === file.id ? true : undefined,
+                  url: undefined,
+                  visibility: undefined,
                 }))
-              : [],
-            downloadUrl: includeDownloadUrl
-              ? `${baseUrl}${createModelFileDownloadUrl({
-                  versionId: version.id,
-                  primary: true,
-                })}`
-              : undefined,
-          });
-        })
-        .filter((x) => x),
+            : [],
+          images: includeImages
+            ? images.map(({ url, id, ...image }) => ({
+                url: getEdgeUrl(url, {
+                  original: true,
+                  name: id.toString(),
+                  type: image.type,
+                }),
+                ...image,
+              }))
+            : [],
+          downloadUrl: includeDownloadUrl
+            ? `${baseUrl}${createModelFileDownloadUrl({
+                versionId: version.id,
+                primary: true,
+              })}`
+            : undefined,
+        });
+      })
+      .filter((x) => x),
   };
 }
 
@@ -189,8 +194,7 @@ const baseHandler = PublicEndpoint(async function handler(
     // full TTL when the build reads a lagging replica. 400 (bad id) is rejected
     // above the cache; 5xx throws out of buildPublicModelResponse and is never
     // stored.
-    if (body === null)
-      return res.status(404).json({ error: `No model with id ${id}` });
+    if (body === null) return res.status(404).json({ error: `No model with id ${id}` });
 
     return res.status(200).json(body);
   } catch (error) {

--- a/src/server/__tests__/blocked-browsing-tags.test.ts
+++ b/src/server/__tests__/blocked-browsing-tags.test.ts
@@ -6,6 +6,10 @@ import {
 } from '~/shared/constants/browsing-settings-addons';
 import { NsfwLevel } from '~/server/common/enums';
 import {
+  allBrowsingLevelsFlag,
+  publicBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
+import {
   enforceBlockedBrowsingTags,
   enforceBlockedBrowsingTagsForModels,
 } from '~/server/services/blocked-browsing-tags.service';
@@ -163,5 +167,47 @@ describe('enforceBlockedBrowsingTagsForModels', () => {
     const result = await enforceBlockedBrowsingTagsForModels(input, { id: 1 });
     expect(result.emptyResult).toBe(false);
     expect(input.excludedTagIds).toContain(5188);
+  });
+
+  // The exact two levels /api/v1/models derives from `?nsfw` (models/index.ts).
+  // /api/v1/models no longer passes disableMinor itself, so THIS is what decides
+  // whether the list hides minor models — assert the end state, not just that the
+  // endpoint forwards no opinion.
+  it('derives disableMinor from the browsing level the list endpoint passes', async () => {
+    const sfw = { browsingLevel: publicBrowsingLevelsFlag } as {
+      browsingLevel: number;
+      disableMinor?: boolean;
+    };
+    await enforceBlockedBrowsingTagsForModels(sfw, { id: 1 });
+    expect(sfw.disableMinor).toBe(false);
+
+    const nsfw = { browsingLevel: allBrowsingLevelsFlag } as {
+      browsingLevel: number;
+      disableMinor?: boolean;
+    };
+    await enforceBlockedBrowsingTagsForModels(nsfw, { id: 1 });
+    expect(nsfw.disableMinor).toBe(true);
+  });
+
+  it('ignoreBrowsingAddons drops the minor gate AND the tag union, but keeps disablePoi', async () => {
+    // Uniformity with /models/{id}: the site serves minor + child-tagged models
+    // at a direct id and 404s POI ones, so the by-id API must do the same.
+    const input = { browsingLevel: NsfwLevel.R } as {
+      browsingLevel: number;
+      disableMinor?: boolean;
+      disablePoi?: boolean;
+      excludedTagIds?: number[];
+    };
+    await enforceBlockedBrowsingTagsForModels(input, { id: 1 }, { ignoreBrowsingAddons: true });
+    expect(input.disableMinor).toBeUndefined();
+    expect(input.excludedTagIds).toBeUndefined();
+    expect(input.disablePoi).toBe(true);
+  });
+
+  it('ignoreBrowsingAddons never overrides caller-set values', async () => {
+    const input = { browsingLevel: NsfwLevel.PG, disableMinor: true, excludedTagIds: [42] };
+    await enforceBlockedBrowsingTagsForModels(input, { id: 1 }, { ignoreBrowsingAddons: true });
+    expect(input.disableMinor).toBe(true);
+    expect(input.excludedTagIds).toEqual([42]);
   });
 });

--- a/src/server/services/__tests__/model-search.minor-gate.test.ts
+++ b/src/server/services/__tests__/model-search.minor-gate.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `/api/v1/models` used to force `disableMinor: true` on every call, hiding
+ * minor-flagged models even from a plain SFW request. The gate now comes from
+ * the browsing-settings addons inside getModelsRaw, so the search service must
+ * forward NO opinion of its own — a hardcoded value here would shadow the live
+ * policy (and, since applyAddonExclusions ORs, could never be relaxed).
+ */
+
+const { mockGetModelsWithVersions } = vi.hoisted(() => ({
+  mockGetModelsWithVersions: vi.fn(),
+}));
+
+vi.mock('~/server/services/model.service', () => ({
+  getModelsWithVersions: mockGetModelsWithVersions,
+}));
+vi.mock('~/server/meilisearch/client', () => ({
+  searchClient: undefined,
+  withMeili: vi.fn(),
+  MeiliCallTimeoutError: class extends Error {},
+}));
+vi.mock('~/server/services/file.service', () => ({
+  getDownloadFilename: vi.fn(() => 'model.safetensors'),
+}));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/server/common/model-helpers', () => ({
+  createModelFileDownloadUrl: vi.fn(() => '/download'),
+}));
+
+async function forwardedInput(input: Record<string, unknown>) {
+  mockGetModelsWithVersions.mockResolvedValue({ items: [], nextCursor: undefined });
+  const { runModelSearch } = await import('~/server/services/model-search.service');
+  await runModelSearch(
+    { limit: 10, ...input } as Parameters<typeof runModelSearch>[0],
+    {
+      browsingLevel: 1,
+      nsfwImagePassthrough: false,
+      user: undefined,
+      baseUrlOrigin: 'https://civitai.com',
+    } as Parameters<typeof runModelSearch>[1]
+  );
+  return mockGetModelsWithVersions.mock.calls[0][0].input;
+}
+
+describe('runModelSearch — minor gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards no disableMinor of its own', async () => {
+    expect(await forwardedInput({})).not.toHaveProperty('disableMinor', true);
+  });
+
+  it('forwards a caller-set disableMinor (the block catalog stays strict)', async () => {
+    expect(await forwardedInput({ disableMinor: true })).toHaveProperty('disableMinor', true);
+  });
+
+  it('never forwards a browsingLevel from the input — the ctx value is the authority', async () => {
+    // browsingLevel now decides the minor gate as well as the level filter, and
+    // callers spread parsed query data into this input through a cast.
+    const input = await forwardedInput({ browsingLevel: 31 });
+    expect(input.browsingLevel).toBe(1);
+  });
+});

--- a/src/server/services/blocked-browsing-tags.service.ts
+++ b/src/server/services/blocked-browsing-tags.service.ts
@@ -18,12 +18,29 @@ type AddonTarget = {
 
 type Viewer = { id?: number; username?: string | null; isModerator?: boolean };
 
+export type EnforcementOptions = {
+  /**
+   * Drop the addon-derived DISCOVERY exclusions (`disableMinor` + the tag
+   * union). The addon rules read `browsingLevel` as viewer intent, which only
+   * holds for a feed; a lookup by id passes a permission CEILING
+   * (allBrowsingLevelsFlag), so they fire on every such call and 404 content the
+   * site itself serves at the same id — `getModel` applies none of this
+   * (model.service.ts). `disablePoi` deliberately survives: the model page 404s
+   * POI models too, so keeping it is what makes the two paths agree.
+   * Caller-set values still stand — this only drops the implicit ones.
+   */
+  ignoreBrowsingAddons?: boolean;
+};
+
 function applyAddonExclusions(
   input: AddonTarget,
   resolved: ResolvedBrowsingSettingsAddons,
-  viewer: Viewer
+  viewer: Viewer,
+  opts?: EnforcementOptions
 ) {
   input.disablePoi = input.disablePoi || resolved.disablePoi;
+  if (opts?.ignoreBrowsingAddons) return;
+
   input.disableMinor = input.disableMinor || resolved.disableMinor;
 
   const isOwnScoped =
@@ -90,7 +107,8 @@ export async function enforceBlockedBrowsingTags(
  */
 export async function enforceBlockedBrowsingTagsForModels(
   input: AddonTarget & { tag?: string; tagname?: string },
-  viewer: Viewer
+  viewer: Viewer,
+  opts?: EnforcementOptions
 ): Promise<{ emptyResult: boolean }> {
   const { blocked, resolved } = await loadBlockedBrowsingContext(input.browsingLevel, viewer);
 
@@ -103,6 +121,6 @@ export async function enforceBlockedBrowsingTagsForModels(
   )
     return { emptyResult: true };
 
-  applyAddonExclusions(input, resolved, viewer);
+  applyAddonExclusions(input, resolved, viewer, opts);
   return { emptyResult: false };
 }

--- a/src/server/services/model-search.service.ts
+++ b/src/server/services/model-search.service.ts
@@ -182,8 +182,12 @@ export async function runModelSearch(
     primaryFileOnly,
     collectionId,
     searchIds,
+    // Dropped, never forwarded: the ctx value is the only authority. The input
+    // type excludes it, but callers spread parsed query data in through a cast,
+    // and `browsingLevel` now decides the minor gate as well as the level filter.
+    browsingLevel: _clientBrowsingLevel,
     ...data
-  } = input;
+  } = input as typeof input & { browsingLevel?: number };
 
   const { items, nextCursor } = await getModelsWithVersions({
     // Cast: callers supply a partial of GetAllModelsOutput (the public endpoint
@@ -200,8 +204,10 @@ export async function runModelSearch(
       cursor: !query ? cursor : undefined,
       ids: query ? searchIds ?? [] : queryIds,
       collectionId,
+      // No `disableMinor` here on purpose: getModelsRaw resolves it from the live
+      // browsing-settings addons against `browsingLevel`, so it turns on for
+      // ?nsfw=true and stays off for the default SFW request.
       disablePoi: true,
-      disableMinor: true,
     } as Parameters<typeof getModelsWithVersions>[0]['input'],
     user,
   });

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -252,6 +252,7 @@ export const getModelsRaw = async ({
   input,
   include,
   user: sessionUser,
+  ignoreBrowsingAddons,
   _forceBaseModelMetrics,
 }: {
   input: Omit<GetAllModelsOutput, 'limit' | 'page'> & {
@@ -260,14 +261,25 @@ export const getModelsRaw = async ({
   };
   include?: Array<'details' | 'cosmetics'>;
   user?: { id: number; isModerator?: boolean; username?: string };
+  /**
+   * Drop the addon-derived discovery exclusions — for by-id lookups, whose
+   * `browsingLevel` is a permission ceiling rather than viewer intent.
+   * Deliberately a sibling of `input` (not a field on it) so it can never arrive
+   * from parsed query params.
+   */
+  ignoreBrowsingAddons?: boolean;
   /** For testing only: force the ModelBaseModelMetric query path regardless of feature flag */
   _forceBaseModelMetrics?: boolean;
 }) => {
-  const blockedEnforcement = await enforceBlockedBrowsingTagsForModels(input, {
-    id: sessionUser?.id,
-    username: sessionUser?.username,
-    isModerator: sessionUser?.isModerator,
-  });
+  const blockedEnforcement = await enforceBlockedBrowsingTagsForModels(
+    input,
+    {
+      id: sessionUser?.id,
+      username: sessionUser?.username,
+      isModerator: sessionUser?.isModerator,
+    },
+    { ignoreBrowsingAddons }
+  );
   if (blockedEnforcement.emptyResult) return { items: [], isPrivate: false };
 
   const {
@@ -3174,6 +3186,7 @@ export async function toggleCheckpointCoverage({ id, versionId }: ToggleCheckpoi
 export async function getModelsWithVersions({
   input,
   user,
+  ignoreBrowsingAddons,
 }: {
   input: GetAllModelsOutput & { take?: number; skip?: number };
   user?: {
@@ -3182,11 +3195,14 @@ export async function getModelsWithVersions({
     username?: string;
     filePreferences?: UserFilePreferences;
   };
+  /** See `getModelsRaw` — by-id lookups opt out of the addon discovery gates. */
+  ignoreBrowsingAddons?: boolean;
 }) {
   const { items, nextCursor } = await getModelsRaw({
     input,
     user,
     include: ['details'],
+    ignoreBrowsingAddons,
   });
 
   const modelVersionIds = items.flatMap(({ modelVersions }) => modelVersions.map(({ id }) => id));

--- a/src/tests/api/v1/blocks/models-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/models-endpoint.test.ts
@@ -124,7 +124,12 @@ async function invoke(query: Record<string, unknown>) {
   // Import after mocks are registered.
   const mod = await import('~/pages/api/v1/blocks/models');
   const handler = mod.default as (req: NextApiRequest, res: NextApiResponse) => Promise<void>;
-  const req = { method: 'GET', query, headers: {}, url: '/api/v1/blocks/models' } as unknown as NextApiRequest;
+  const req = {
+    method: 'GET',
+    query,
+    headers: {},
+    url: '/api/v1/blocks/models',
+  } as unknown as NextApiRequest;
   const res = fakeRes();
   await handler(req, res);
   return res;
@@ -206,6 +211,16 @@ describe('/api/v1/blocks/models — authoritative clamp wiring', () => {
     expect(input).not.toHaveProperty('nsfw');
     expect(input).not.toHaveProperty('browsingLevel');
     expect(input).not.toHaveProperty('someJunk');
+  });
+
+  it('forces disableMinor on the search input, even under a SFW ceiling', async () => {
+    // The public endpoint lets the addon policy decide, and that rule only fires
+    // above R — so a SFW-clamped block would otherwise start listing minor models.
+    claimsBox.claims = fakeClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag, domain: 'green' });
+    await invoke({});
+
+    const [input] = mockRunModelSearch.mock.calls[0];
+    expect(input.disableMinor).toBe(true);
   });
 
   it('forwards the selector params (query/types/baseModels/sort/limit)', async () => {

--- a/src/tests/api/v1/models/id-origin-cache.test.ts
+++ b/src/tests/api/v1/models/id-origin-cache.test.ts
@@ -115,7 +115,9 @@ vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => 
 vi.mock('~/server/common/model-helpers', () => ({
   createModelFileDownloadUrl: () => '/download',
 }));
-vi.mock('~/server/services/file.service', () => ({ getDownloadFilename: () => 'file.safetensors' }));
+vi.mock('~/server/services/file.service', () => ({
+  getDownloadFilename: () => 'file.safetensors',
+}));
 vi.mock('~/server/utils/model-helpers', () => ({ getPrimaryFile: (files: any[]) => files[0] }));
 vi.mock('~/server/utils/url-helpers', () => ({ getBaseUrl: () => 'https://civitai.com' }));
 
@@ -378,5 +380,15 @@ describe('GET /api/v1/models/[id] — origin-side response cache', () => {
     expect(res.body.name).not.toBe('STALE');
     expect(res.body.id).toBe(123);
     expect(mockGetModelsWithVersions).toHaveBeenCalledTimes(1);
+  });
+
+  it('(i) opts out of the addon discovery gates — a by-id fetch is not a request for NSFW', async () => {
+    // browsingLevel here is the ceiling the endpoint may serve, so the addon
+    // rules (disableMinor + child-ish excludedTagIds above R) would otherwise
+    // fire on EVERY call and 404 models that /models/{id} serves at the same id.
+    await invoke({ id: '123' });
+    expect(mockGetModelsWithVersions.mock.calls[0][0]).toMatchObject({
+      ignoreBrowsingAddons: true,
+    });
   });
 });


### PR DESCRIPTION
Closes ClickUp 868kdwgpa. Support ref: Freshdesk #69443.

## Policy being enforced
Minor-flagged models are hidden **only when the request is asking for NSFW content**. Canonical encoding is the browsing-settings addon rule `{ type:'some', nsfwLevels:[R,X,XXX], disableMinor:true }` (verified identical in live prod sysRedis).

Corollary the team agreed on: **if you can reach a thing directly on the site, you should be able to reach it directly on the API.** The browsing-settings addons are *browse/discovery* policy — they don't belong on a direct by-id resource fetch.

## The bug, both directions
- **Over-restrictive:** `/api/v1/models` hardcoded `disableMinor: true` (`model-search.service.ts`), hiding minor models even on plain SFW requests.
- **Misfiring on by-id:** `getModelsRaw` derives `disableMinor` from `input.browsingLevel` via `applyAddonExclusions`. `/api/v1/models/{id}` passes `allBrowsingLevelsFlag` — a *permission ceiling*, not NSFW intent — so the rule fired and minor models 404'd. That's the inconsistency an external developer reported (`/api/v1/models/{id}` 404 vs `/api/v1/model-versions/{id}` 200).

## Changes
- `model-search.service.ts` — delete the hardcoded `disableMinor: true`; the resolver already derives it. List now: no `?nsfw` → minor visible; `?nsfw=true` → minor hidden.
- `blocked-browsing-tags.service.ts` — new `EnforcementOptions.ignoreBrowsingAddons`; when set, skips the `disableMinor` line **and** the `excludedTagIds` union. `disablePoi` is applied *before* the early return, so it still applies.
- `model.service.ts` / `getModelsWithVersions` — thread the flag as a **sibling of `input`** (structurally unreachable from request data, not merely unreachable by convention).
- `api/v1/models/[id].ts` — set `ignoreBrowsingAddons: true`.
- `api/v1/blocks/models.ts` — pass `disableMinor: true` so the blocks catalog stays strict.
- Hardening: `runModelSearch` now destructures `browsingLevel` out of `data` so the ctx value is the sole authority (the minor gate is a function of it; a future `z.coerce` would otherwise make it client-controllable).

## Resulting by-id parity with the site
| | Site `/models/{id}` | API `/api/v1/models/{id}` |
|---|---|---|
| `minor` | visible | **visible** |
| child-ish tags (`child`, `toddler`, …) | visible | **visible** |
| `poi` | 404 | **404** |
| availability / status / deleted / blocked-by-user | gated | gated |

## Deliberately out of scope
- `/api/v1/model-versions/{id}` and by-hash routes — unchanged; they use raw SQL that never touches the resolver and already 200.
- `/api/v1/images` (`disableMinor` there maps to `Image.minor` — intentional).
- The `minor: true` value returned by `mini`/generation endpoints.
- The API being *more permissive* than the site on mature content (anonymous gets X/XXX by id with no login gate) — known, deliberately left; blast radius is every integration reading mature models by id.
- Unrated (`nsfwLevel = 0`) 404s on API vs an "unrated" placeholder on site.

## Verification
- 43 tests pass across the four touched test files, including: the resolver end-to-end (PG → `disableMinor` false, R/X/XXX → true), the widened guard (minor + tags skipped, **POI still applied**), caller-set values surviving the guard, and the SFW-clamped blocks case still forwarding `disableMinor: true`.
- Prettier clean. Typecheck delta vs main is unrelated to these files.
- Adversarial review: **SHIP**, no blocker — confirmed `ignoreBrowsingAddons` is not settable from query/body/JWT (zod strips unknowns; it's not on `input`).

> **Reviewer note:** `[id].ts` shows ~142 changed lines but only ~6 are functional — that file was already prettier-dirty on `main` and the required prettier run reformatted it. Review with `git diff -w`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)