### PR TITLE
feat(apps): agentic review provisioning backend (P1, dark)

### DIFF
--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -2843,8 +2843,17 @@ model AppReviewAgentReport {
   // (on-site = AppBlockPublishRequest, connect = AppListingPublishRequest) so it
   // is stored as an indexed id, not a FK. Resolved by kind in the service.
   publishRequestId String    @map("publish_request_id")
-  // App identity — EXACTLY ONE is set: `appBlockId` for an on-site App Block,
-  // `oauthClientId` for an external / OAuth-connect app. Plain indexed columns.
+  // The STABLE app key (= blockId), present on EVERY publish request — including a
+  // first version, before any AppBlock row exists. Onsite reports are keyed by
+  // this (see the (slug, version) index); the prior-report chain is scoped by it.
+  slug             String
+  // Report origin: 'onsite' | 'external' (CHECK in the .sql). External/connect is
+  // a later phase; onsite reports write 'onsite'.
+  kind             String    @default("onsite")
+  // App identity — INFORMATIONAL, nullable. `appBlockId` populated when the
+  // on-site AppBlock already exists (else null, e.g. a first version); reserved
+  // `oauthClientId` for the external / OAuth-connect app. No exactly-one invariant
+  // any more — `slug` is the key (the app_key XOR CHECK was dropped).
   appBlockId       String?   @map("app_block_id")
   oauthClientId    String?   @map("oauth_client_id")
   // The reviewed bundle's version (semver) + integrity hash.
@@ -2875,11 +2884,14 @@ model AppReviewAgentReport {
   updatedAt        DateTime  @default(now()) @updatedAt @map("updated_at") @db.Timestamptz(6)
 
   // "latest prior complete report for this app older than version X" lookups,
-  // one index per app-key kind (on-site vs connect).
-  @@index([appBlockId, version], map: "app_review_agent_reports_app_block_version_idx")
-  @@index([oauthClientId, version], map: "app_review_agent_reports_oauth_client_version_idx")
+  // scoped by the stable slug key.
+  @@index([slug, version], map: "app_review_agent_reports_slug_version_idx")
   // By-review lookup (getAgentReport).
   @@index([publishRequestId], map: "app_review_agent_reports_publish_request_idx")
+  // NB: the status CHECK ('running'|'complete'|'failed'|'torn-down'|'cost-capped'),
+  // the kind CHECK ('onsite'|'external'), and the PARTIAL UNIQUE index on
+  // (publish_request_id) WHERE status='running' live ONLY in the migration .sql —
+  // Prisma cannot express CHECKs or partial-unique indexes.
   @@map("app_review_agent_reports")
 }
 

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -433,6 +433,8 @@ export type AppListingScreenshot = {
 export type AppReviewAgentReport = {
   id: string;
   publish_request_id: string;
+  slug: string;
+  kind: Generated<string>;
   app_block_id: string | null;
   oauth_client_id: string | null;
   version: string;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -2009,6 +2009,8 @@ export interface AppListingModerationEvent {
 export interface AppReviewAgentReport {
   id: string;
   publishRequestId: string;
+  slug: string;
+  kind: string;
   appBlockId: string | null;
   oauthClientId: string | null;
   version: string;

--- a/prisma/migrations/20260720130000_app_review_agent_report_slug_key/migration.sql
+++ b/prisma/migrations/20260720130000_app_review_agent_report_slug_key/migration.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- App Blocks — agentic mod code-review report: SLUG-KEYING correction (P1)
+-- ============================================================
+-- Follow-up to 20260720120000_app_review_agent_report. That table keyed a report
+-- to the app via app_block_id XOR oauth_client_id — but an on-site AppBlock row
+-- does not exist until the FIRST version is APPROVED, so a first-version onsite
+-- review had no key and could not be persisted. The stable identifier present on
+-- EVERY publish request (first version included) is the app SLUG (= blockId), so
+-- onsite reports are re-keyed by slug.
+--
+-- Changes (all additive / safe on the EXISTING, already-applied, EMPTY table):
+--   1. slug           TEXT NOT NULL          — the stable app key (blockId).
+--   2. kind           TEXT NOT NULL 'onsite' — 'onsite' | 'external' (CHECK).
+--   3. drop the app_key XOR CHECK — app_block_id / oauth_client_id become
+--      OPTIONAL informational columns (nullable, no exactly-one invariant).
+--   4. swap the (app_block_id, version) + (oauth_client_id, version) covering
+--      indexes for (slug, version) — the prior-report lookup now scopes by slug.
+--   5. status CHECK gains 'cost-capped' (the runner's cost-cap outcome is now
+--      persisted verbatim instead of being collapsed onto 'failed').
+--   6. a PARTIAL UNIQUE index on (publish_request_id) WHERE status='running' —
+--      makes a second concurrent `running` row for one request impossible at the
+--      DB (the double-provision backstop).
+--
+-- ⚠️ MANUAL APPLY — per datapacket-talos CLAUDE.md DB rule #8 the main civitai
+-- CNPG nvme0 DB does NOT auto-apply migrations (no prisma migrate deploy). This
+-- file is committed for HISTORY ONLY; a HUMAN applies the SQL below per
+-- environment (psql/retool). CI / deploy do NOT run it. Apply to BOTH:
+--   1. prod nvme0   (the live civitai DB)
+--   2. the dev clone
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS / DROP CONSTRAINT IF EXISTS / DROP INDEX
+-- IF EXISTS / CREATE [UNIQUE] INDEX IF NOT EXISTS + re-add-after-drop for CHECKs,
+-- so a manual re-run is a no-op. The table is brand-new + EMPTY, so adding a
+-- NOT NULL column with no default and building indexes take no meaningful lock —
+-- CONCURRENTLY is unnecessary (and cannot run in a txn).
+
+-- 1. slug — the stable app key (blockId), present on every publish request.
+ALTER TABLE "app_review_agent_reports"
+  ADD COLUMN IF NOT EXISTS "slug" TEXT NOT NULL;
+
+-- 2. kind — report origin. DEFAULT 'onsite' matches the Prisma @default and lets
+--    the (empty) table + any future onsite writer omit it. CHECK-constrained to
+--    the two supported kinds (external/connect is a later phase).
+ALTER TABLE "app_review_agent_reports"
+  ADD COLUMN IF NOT EXISTS "kind" TEXT NOT NULL DEFAULT 'onsite';
+ALTER TABLE "app_review_agent_reports"
+  DROP CONSTRAINT IF EXISTS "app_review_agent_reports_kind_check";
+ALTER TABLE "app_review_agent_reports"
+  ADD CONSTRAINT "app_review_agent_reports_kind_check"
+  CHECK ("kind" IN ('onsite', 'external'));
+
+-- 3. Drop the app-key XOR CHECK. app_block_id / oauth_client_id stay as nullable
+--    INFORMATIONAL columns (app_block_id populated when the AppBlock already
+--    exists, else null; oauth_client_id reserved for the external/connect flow).
+--    No exactly-one invariant any more — slug is the key.
+ALTER TABLE "app_review_agent_reports"
+  DROP CONSTRAINT IF EXISTS "app_review_agent_reports_app_key_xor";
+
+-- 4. Swap the per-app-key covering indexes for the slug-scoped one. The prior-
+--    report lookup narrows to one app by slug, then filters status='complete' and
+--    picks the semver-latest strictly-older version in-app.
+DROP INDEX IF EXISTS "app_review_agent_reports_app_block_version_idx";
+DROP INDEX IF EXISTS "app_review_agent_reports_oauth_client_version_idx";
+CREATE INDEX IF NOT EXISTS "app_review_agent_reports_slug_version_idx"
+  ON "app_review_agent_reports" ("slug", "version");
+
+-- 5. Status CHECK gains 'cost-capped' (persisted verbatim from the runner).
+ALTER TABLE "app_review_agent_reports"
+  DROP CONSTRAINT IF EXISTS "app_review_agent_reports_status_check";
+ALTER TABLE "app_review_agent_reports"
+  ADD CONSTRAINT "app_review_agent_reports_status_check"
+  CHECK ("status" IN ('running', 'complete', 'failed', 'torn-down', 'cost-capped'));
+
+-- 6. Partial UNIQUE index: at most ONE `running` report per publish request. The
+--    DB backstop for the double-provision guard — a concurrent second dispatch
+--    for the same request cannot insert a second running row. Non-running rows
+--    (complete/failed/torn-down/cost-capped) are unconstrained, so re-reviews and
+--    history accumulate freely.
+CREATE UNIQUE INDEX IF NOT EXISTS "app_review_agent_reports_running_pubreq_uq"
+  ON "app_review_agent_reports" ("publish_request_id")
+  WHERE "status" = 'running';

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -789,6 +789,14 @@ export const serverSchema = z
     // sync without spuriously failing a healthy preview. Tunable per-environment
     // without a code change. See waitForReviewHostReachable.
     REVIEW_HOST_REACHABLE_TIMEOUT_MS: z.coerce.number().int().min(1000).default(180000),
+    // AGENTIC MOD CODE-REVIEW (App Blocks P1). Per-review spend ceiling handed to
+    // the review agent pod as COST_CAP_USD — the runner self-aborts (status
+    // 'cost-capped') once its LLM spend crosses this. A STRING (envsubst-rendered
+    // straight into the pod env / the report cost accounting), default "2".
+    // Everything else the feature needs reuses existing config (APPS_KUBE_NAMESPACE
+    // for the provisioning Job, BUNDLE_S3_* for the presigned bundle, NEXTAUTH_URL
+    // for the callback base) — no parallel infra knobs.
+    AGENT_REVIEW_COST_CAP_USD: z.string().default('2'),
     // Base URL of the verify-runner screenshot service (warm Playwright Chromium)
     // used to autogenerate a marketplace screenshot for an approved App Block that
     // shipped no publisher screenshots. In-cluster service (devpod-devops ns), e.g.

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -797,6 +797,13 @@ export const serverSchema = z
     // for the provisioning Job, BUNDLE_S3_* for the presigned bundle, NEXTAUTH_URL
     // for the callback base) — no parallel infra knobs.
     AGENT_REVIEW_COST_CAP_USD: z.string().default('2'),
+    // AGENTIC MOD CODE-REVIEW (App Blocks P1) — CONTAINMENT. Base URL the review
+    // agent pod POSTs its report to. Set to the IN-CLUSTER civitai-web service URL
+    // (e.g. `http://<svc>.<ns>.svc.cluster.local`) so the adversarial report + the
+    // per-review bearer never traverse the public internet. Optional: when unset
+    // the callback falls back to NEXTAUTH_URL (the public origin) so the feature
+    // keeps working before infra sets the in-cluster value ahead of un-dark.
+    AGENT_REVIEW_CALLBACK_BASE_URL: z.string().optional(),
     // Base URL of the verify-runner screenshot service (warm Playwright Chromium)
     // used to autogenerate a marketplace screenshot for an approved App Block that
     // shipped no publisher screenshots. In-cluster service (devpod-devops ns), e.g.

--- a/src/pages/api/internal/blocks/agent-report-callback.ts
+++ b/src/pages/api/internal/blocks/agent-report-callback.ts
@@ -52,9 +52,10 @@ async function readRawBody(req: Readable): Promise<Buffer> {
 
 const PUBREQ_RE = /^pubreq_[0-9A-HJKMNP-TV-Z]{26}$/;
 
-/** Runner-reported statuses. `cost-capped` is a distinct runner outcome that
- *  maps onto the persisted `failed` status (the report table's CHECK allows only
- *  running|complete|failed|torn-down) — the cost-cap is noted in the summary. */
+/** Runner-reported statuses. All THREE are now valid persisted statuses (the
+ *  report table's CHECK allows running|complete|failed|torn-down|cost-capped), so
+ *  the runner's outcome — `cost-capped` included — is stored VERBATIM rather than
+ *  collapsed onto `failed`; a summary marker still flags the cost-cap for the UI. */
 const RUNNER_STATUSES = ['complete', 'failed', 'cost-capped'] as const;
 type RunnerStatus = (typeof RUNNER_STATUSES)[number];
 
@@ -77,10 +78,15 @@ function bearerFrom(header: unknown): string | null {
   return m ? m[1].trim() : null;
 }
 
-/** Map a runner status onto the persisted report status. Exported for the unit
- *  test that locks the cost-capped → failed collapse. */
-export function persistedStatusFor(runner: RunnerStatus): 'complete' | 'failed' {
-  return runner === 'complete' ? 'complete' : 'failed';
+/** Map a runner status onto the persisted report status — now an IDENTITY: every
+ *  runner status (complete|failed|cost-capped) is a valid persisted status, so
+ *  `cost-capped` is stored verbatim (no longer collapsed onto `failed`). Kept as
+ *  a named seam for the unit test + a single place to intercept if the persisted
+ *  set ever diverges from the runner set again. */
+export function persistedStatusFor(
+  runner: RunnerStatus
+): 'complete' | 'failed' | 'cost-capped' {
+  return runner;
 }
 
 /** Build the report UPDATE `data` from a validated body. Only provided fields are

--- a/src/pages/api/internal/blocks/agent-report-callback.ts
+++ b/src/pages/api/internal/blocks/agent-report-callback.ts
@@ -1,0 +1,197 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { Readable } from 'node:stream';
+import { withAxiom } from '@civitai/next-axiom';
+import { isAppBlocksPipelineEnabled } from '~/server/services/app-blocks-flag';
+import { verifyAgentCallbackToken } from '~/server/services/blocks/review-session';
+import { checkCallbackTimestamp } from './review-build-callback';
+
+/**
+ * POST /api/internal/blocks/agent-report-callback  (AGENTIC MOD CODE-REVIEW, P1)
+ *
+ * The ephemeral review agent pod → civitai-web, once it has produced its report
+ * (or definitively failed / hit the cost cap). Clones the review-build-callback
+ * shape:
+ *   1. Raw-body read with a small cap (bodyParser:false).
+ *   2. AUTH via the PER-REVIEW bearer bound to publishRequestId — NOT the shared
+ *      HMAC secret (that must never reach the agent pod).
+ *   3. Pipeline kill-switch (503 when the global flag is dark).
+ *   4. checkCallbackTimestamp replay-freshness window (enforce-if-present).
+ *   5. UPDATE the report row WHERE publishRequestId matches AND status is still
+ *      `running` (so a torn-down / decided review can't be overwritten — mirrors
+ *      the review-build-callback's previewNoLongerActive guard).
+ *
+ * DARK: gated by the same global `app-blocks-pipeline-enabled` kill-switch as the
+ * review-build path; with the feature's mod-visibility flag absent, no agent is
+ * ever provisioned to call this in the first place.
+ */
+
+// Bearer auth binds the caller; we still read the raw body ourselves to enforce
+// a hard size cap independent of Next's body parser.
+export const config = {
+  api: { bodyParser: false },
+};
+
+// Reports carry structured codeReview / securityAudit / scopeVerdicts JSON + a
+// markdown summary — larger than the 8KB build callback, but still bounded.
+const MAX_BODY_BYTES = 256 * 1024;
+const MAX_SUMMARY_CHARS = 100 * 1024;
+
+async function readRawBody(req: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buf = typeof chunk === 'string' ? Buffer.from(chunk) : (chunk as Buffer);
+    total += buf.length;
+    if (total > MAX_BODY_BYTES) {
+      throw new Error('payload too large');
+    }
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks);
+}
+
+const PUBREQ_RE = /^pubreq_[0-9A-HJKMNP-TV-Z]{26}$/;
+
+/** Runner-reported statuses. `cost-capped` is a distinct runner outcome that
+ *  maps onto the persisted `failed` status (the report table's CHECK allows only
+ *  running|complete|failed|torn-down) — the cost-cap is noted in the summary. */
+const RUNNER_STATUSES = ['complete', 'failed', 'cost-capped'] as const;
+type RunnerStatus = (typeof RUNNER_STATUSES)[number];
+
+type CallbackBody = {
+  publishRequestId?: string;
+  status?: string;
+  model?: unknown;
+  codeReview?: unknown;
+  securityAudit?: unknown;
+  scopeVerdicts?: unknown;
+  summaryMd?: unknown;
+  tokenUsage?: unknown;
+  costUsd?: unknown;
+  ts?: unknown;
+};
+
+function bearerFrom(header: unknown): string | null {
+  if (typeof header !== 'string') return null;
+  const m = header.match(/^Bearer\s+(.+)$/i);
+  return m ? m[1].trim() : null;
+}
+
+/** Map a runner status onto the persisted report status. Exported for the unit
+ *  test that locks the cost-capped → failed collapse. */
+export function persistedStatusFor(runner: RunnerStatus): 'complete' | 'failed' {
+  return runner === 'complete' ? 'complete' : 'failed';
+}
+
+/** Build the report UPDATE `data` from a validated body. Only provided fields are
+ *  set (undefined = leave existing). Pure + exported so the field mapping is
+ *  unit-tested without the DB. */
+export function buildReportUpdate(body: CallbackBody): Record<string, unknown> {
+  const runner = body.status as RunnerStatus;
+  const data: Record<string, unknown> = {
+    status: persistedStatusFor(runner),
+    completedAt: new Date(),
+  };
+  if (typeof body.model === 'string') data.model = body.model.slice(0, 200);
+  if (body.codeReview !== undefined && body.codeReview !== null) data.codeReview = body.codeReview;
+  if (body.securityAudit !== undefined && body.securityAudit !== null)
+    data.securityAudit = body.securityAudit;
+  if (body.scopeVerdicts !== undefined && body.scopeVerdicts !== null)
+    data.scopeVerdicts = body.scopeVerdicts;
+  if (body.tokenUsage !== undefined && body.tokenUsage !== null) data.tokenUsage = body.tokenUsage;
+  if (typeof body.costUsd === 'number' && Number.isFinite(body.costUsd) && body.costUsd >= 0)
+    data.costUsd = body.costUsd;
+
+  let summary = typeof body.summaryMd === 'string' ? body.summaryMd : '';
+  if (runner === 'cost-capped') {
+    // Preserve the cost-cap signal that the persisted `failed` status loses.
+    summary = `> ⚠️ Review stopped at the cost cap.\n\n${summary}`;
+  }
+  if (summary) data.summaryMd = summary.slice(0, MAX_SUMMARY_CHARS);
+
+  return data;
+}
+
+export default withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  let rawBody: Buffer;
+  try {
+    rawBody = await readRawBody(req);
+  } catch {
+    res.status(413).json({ error: 'Payload too large' });
+    return;
+  }
+
+  let body: CallbackBody;
+  try {
+    body = JSON.parse(rawBody.toString('utf8')) as CallbackBody;
+  } catch {
+    res.status(400).json({ error: 'Invalid JSON' });
+    return;
+  }
+
+  if (!body.publishRequestId || !PUBREQ_RE.test(body.publishRequestId)) {
+    res.status(400).json({ error: 'Invalid publishRequestId' });
+    return;
+  }
+
+  // AUTH: the per-review bearer bound to THIS publishRequestId. Never the shared
+  // HMAC secret.
+  const token = bearerFrom(req.headers['authorization']);
+  if (!verifyAgentCallbackToken(token, body.publishRequestId).ok) {
+    res.status(401).json({ error: 'Bad or missing bearer' });
+    return;
+  }
+
+  // Pipeline kill-switch — same global flag the build callbacks use.
+  if (!(await isAppBlocksPipelineEnabled())) {
+    res.status(503).json({ error: 'Apps are not enabled' });
+    return;
+  }
+
+  // Replay-freshness (enforce-if-present). The bearer's short TTL is the primary
+  // replay bound; this tightens it when the runner stamps a `ts`.
+  const tsCheck = checkCallbackTimestamp(body.ts);
+  if (!tsCheck.ok) {
+    res.status(401).json({ error: 'Stale or invalid timestamp' });
+    return;
+  }
+
+  if (!body.status || !RUNNER_STATUSES.includes(body.status as RunnerStatus)) {
+    res.status(400).json({ error: 'status must be one of complete|failed|cost-capped' });
+    return;
+  }
+
+  const data = buildReportUpdate(body);
+
+  // UPDATE the running report row for this review. `updateMany` + the
+  // status='running' guard means a torn-down / decided / already-reported review
+  // is a no-op (count 0) — never resurrected, never double-written.
+  let updated: number;
+  try {
+    const { dbWrite } = await import('~/server/db/client');
+    const result = await dbWrite.appReviewAgentReport.updateMany({
+      where: { publishRequestId: body.publishRequestId, status: 'running' },
+      data,
+    });
+    updated = result.count;
+  } catch (e) {
+    res.status(500).json({ error: 'Report write failed', detail: String(e).slice(0, 240) });
+    return;
+  }
+
+  if (updated === 0) {
+    res.status(200).json({
+      ok: true,
+      applied: false,
+      reason: 'no running report for this review (torn down, decided, or already reported)',
+    });
+    return;
+  }
+
+  res.status(200).json({ ok: true, applied: true });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -64,6 +64,7 @@ import {
   mintReviewBlockTokenSchema,
   previewRequestSchema,
   rejectRequestSchema,
+  startAgentReviewSchema,
   teardownPreviewSchema,
   withdrawRequestSchema,
 } from '~/server/schema/blocks/publish-request.schema';
@@ -1452,6 +1453,45 @@ export const blocksRouter = router({
         // The mod id is SERVER-derived (never client-supplied) so the token can
         // only ever be self-bound to the calling moderator.
         return await mintReviewBlockToken({
+          publishRequestId: input.publishRequestId,
+          modUserId: ctx.user.id,
+        });
+      } catch (err) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
+      }
+    }),
+
+  /**
+   * AGENTIC MOD CODE-REVIEW (App Blocks P1) — dispatch an ephemeral, sandboxed
+   * review agent for a PENDING publish request. Provisions the agent pod (pulls
+   * the reviewed bundle, produces a structured report, posts it back), torn down
+   * on the approve/reject decision.
+   *
+   * GATING: moderatorProcedure, NOT appDeveloperProcedure. The agent analyses an
+   * ADVERSARIAL bundle and produces mod decision-support; letting authors trigger
+   * reviews of their own apps is the wrong trust boundary, and every sibling
+   * review op (previewRequest / getReviewStatus / getPublishRequestDiff) is
+   * moderator-gated. The extra `app-blocks-agentic-review` flag check (on top of
+   * moderatorProcedure + the isModerator belt + enforceAppBlocksFlag) makes the
+   * whole feature ship DARK — the flag does not exist in Flipt yet, so
+   * isAppBlocksAgenticReviewEnabled fail-closes to false and this rejects.
+   */
+  startAgentReview: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(startAgentReviewSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Agentic review is restricted to civitai team');
+      }
+      const { isAppBlocksAgenticReviewEnabled } = await import(
+        '~/server/services/app-blocks-flag'
+      );
+      if (!(await isAppBlocksAgenticReviewEnabled({ user: ctx.user }))) {
+        throw throwAuthorizationError('Agentic review is not enabled');
+      }
+      const { startAgentReview } = await import('~/server/services/blocks/agent-review.service');
+      try {
+        return await startAgentReview({
           publishRequestId: input.publishRequestId,
           modUserId: ctx.user.id,
         });

--- a/src/server/schema/blocks/publish-request.schema.ts
+++ b/src/server/schema/blocks/publish-request.schema.ts
@@ -154,6 +154,15 @@ export const mintReviewBlockTokenSchema = z.object({
 
 export type MintReviewBlockTokenInput = z.infer<typeof mintReviewBlockTokenSchema>;
 
+/** Input for the MOD-ONLY agentic code-review `blocks.startAgentReview` (P1) —
+ *  dispatches an ephemeral review agent for a PENDING request. Same shape as
+ *  previewRequest (the pending request id). */
+export const startAgentReviewSchema = z.object({
+  publishRequestId: z.string().min(1).max(64),
+});
+
+export type StartAgentReviewInput = z.infer<typeof startAgentReviewSchema>;
+
 export const teardownPreviewSchema = z.object({
   publishRequestId: z.string().min(1).max(64),
 });

--- a/src/server/services/__tests__/app-blocks-flag.agentic-review.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.agentic-review.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionUser } from '~/types/session';
+
+/**
+ * AGENTIC MOD CODE-REVIEW (App Blocks P1) — flag-gate contract for
+ * `isAppBlocksAgenticReviewEnabled`. Mirrors the review-sandbox gate:
+ *   - a MODERATOR resolves ON only when the flag exists + its moderators segment
+ *     matches (threads the mod context in);
+ *   - a NON-MODERATOR and an ANONYMOUS caller resolve OFF (no widening);
+ *   - an ABSENT flag resolves OFF for everyone (fail-closed — the as-merged
+ *     state, since the flag does not exist in Flipt yet).
+ */
+
+const { mockIsFlipt } = vi.hoisted(() => ({ mockIsFlipt: vi.fn() }));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: mockIsFlipt }));
+
+import {
+  isAppBlocksAgenticReviewEnabled,
+  APP_BLOCKS_AGENTIC_REVIEW_FLAG,
+} from '../app-blocks-flag';
+
+// Faithful stand-in for the live flag rule: base OFF with a `moderators` segment
+// keyed on context.isModerator === 'true'. `flagExists` toggles the as-merged
+// (absent) state — an absent flag never evaluates true.
+const state = { flagExists: true };
+function fakeFlag(
+  flag: string,
+  _entityId = 'global',
+  context: Record<string, string> = {}
+): boolean {
+  if (!state.flagExists) return false;
+  if (flag !== APP_BLOCKS_AGENTIC_REVIEW_FLAG) return false;
+  return context.isModerator === 'true';
+}
+
+function makeUser(over: Partial<SessionUser> = {}): SessionUser {
+  return { id: 4242, username: 'u', isModerator: false, tier: 'free', ...over } as SessionUser;
+}
+
+beforeEach(() => {
+  state.flagExists = true;
+  mockIsFlipt.mockReset();
+  mockIsFlipt.mockImplementation(async (...args: Parameters<typeof fakeFlag>) => fakeFlag(...args));
+});
+
+describe('isAppBlocksAgenticReviewEnabled — fail-closed mod gate', () => {
+  it('resolves ON for a moderator when the flag exists (threads mod context)', async () => {
+    const user = makeUser({ isModerator: true });
+    await expect(isAppBlocksAgenticReviewEnabled({ user })).resolves.toBe(true);
+    expect(mockIsFlipt).toHaveBeenCalledWith(
+      APP_BLOCKS_AGENTIC_REVIEW_FLAG,
+      '4242',
+      expect.objectContaining({ isModerator: 'true' })
+    );
+  });
+
+  it('resolves OFF for a non-moderator user (no widening)', async () => {
+    await expect(isAppBlocksAgenticReviewEnabled({ user: makeUser() })).resolves.toBe(false);
+  });
+
+  it('resolves OFF for an anonymous caller (no user → global eval)', async () => {
+    await expect(isAppBlocksAgenticReviewEnabled()).resolves.toBe(false);
+    // The no-user path must NOT thread any context (a global eval that can never
+    // match the moderators segment).
+    expect(mockIsFlipt).toHaveBeenCalledWith(APP_BLOCKS_AGENTIC_REVIEW_FLAG);
+  });
+
+  it('resolves OFF for a moderator when the flag is ABSENT (as-merged dark state)', async () => {
+    state.flagExists = false;
+    await expect(
+      isAppBlocksAgenticReviewEnabled({ user: makeUser({ isModerator: true }) })
+    ).resolves.toBe(false);
+  });
+});

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -533,6 +533,48 @@ export async function isAppBlocksReviewSandboxEnabled(opts?: {
 }
 
 /**
+ * Dedicated mod-segmented flag for the AGENTIC MOD CODE-REVIEW (App Blocks P1).
+ *
+ * When a moderator reviews a PENDING publish request they can dispatch an
+ * ephemeral, sandboxed review agent that pulls the reviewed bundle, produces a
+ * structured code-review / security-audit / scope-verdict report, and reports it
+ * back — decision-support for the mod, torn down on the approve/reject decision.
+ *
+ * This is a USER-VISIBILITY gate (the `startAgentReview` tRPC procedure — the
+ * modal button + report rendering + chat are later phases), so — exactly like
+ * `app-blocks-review-sandbox-enabled` — it is mod-segmented and MUST be evaluated
+ * WITH the moderator's context. Create it in Flipt as base `enabled: false` with
+ * the SAME `moderators` segment the user-facing flag uses (`isModerator ==
+ * "true"`), so it can be scoped to a subset of mods during early dogfood.
+ *
+ * The machine-to-machine half (the report callback) has NO user context and
+ * additionally gates on the existing GLOBAL `app-blocks-pipeline-enabled`
+ * kill-switch — the same fail-safe as the review-sandbox build path.
+ *
+ * Fail-safe: the flag does NOT exist in Flipt yet (created only AFTER this
+ * merges) → `isFlipt` returns `false` → `startAgentReview` returns UNAUTHORIZED
+ * and no provisioning ever runs. So the as-merged behaviour is fully dark and
+ * cannot regress the gate open.
+ */
+export const APP_BLOCKS_AGENTIC_REVIEW_FLAG = 'app-blocks-agentic-review';
+
+/**
+ * Mod-segmented gate for the AGENTIC MOD CODE-REVIEW (App Blocks P1). Evaluated
+ * WITH the moderator's context (entityId = user id, context carries server-side
+ * `isModerator`) so the `moderators` segment can match — identical eval shape to
+ * `isAppBlocksReviewSandboxEnabled({ user })`. No user → preserves a global eval
+ * that can never match the segment (fail-closed), and an absent flag also
+ * evaluates false (fail-closed). See APP_BLOCKS_AGENTIC_REVIEW_FLAG.
+ */
+export async function isAppBlocksAgenticReviewEnabled(opts?: {
+  user?: SessionUser;
+}): Promise<boolean> {
+  if (!opts?.user) return isFlipt(APP_BLOCKS_AGENTIC_REVIEW_FLAG);
+  const user = opts.user;
+  return isFlipt(APP_BLOCKS_AGENTIC_REVIEW_FLAG, String(user.id), buildFliptContext(user));
+}
+
+/**
  * Dedicated fail-closed flag for App Blocks SHARED (app-global / cross-user)
  * storage — the FIRST surface that opens the per-app datastore to PUBLIC
  * cross-user writes (previously mod + app-dev-tester only). Mirrors

--- a/src/server/services/blocks/__tests__/agent-review.service.test.ts
+++ b/src/server/services/blocks/__tests__/agent-review.service.test.ts
@@ -21,6 +21,7 @@ const {
   mockEnv,
   mockFindUnique,
   mockAppBlockFindFirst,
+  mockReportFindFirst,
   mockCreate,
   mockUpdateMany,
   mockPresign,
@@ -33,9 +34,13 @@ const {
     APPS_KUBE_NAMESPACE: 'civitai-apps',
     APPS_DOMAIN: 'civit.ai',
     AGENT_REVIEW_COST_CAP_USD: '2',
+    NEXTAUTH_URL: 'https://civitai.com',
+    AGENT_REVIEW_CALLBACK_BASE_URL: undefined,
   } as Record<string, unknown>,
   mockFindUnique: vi.fn(),
   mockAppBlockFindFirst: vi.fn(async () => null as { id: string } | null),
+  // Double-provision pre-check: no running report by default.
+  mockReportFindFirst: vi.fn(async () => null as { id: string } | null),
   mockCreate: vi.fn(async () => undefined),
   mockUpdateMany: vi.fn(async () => ({ count: 1 })),
   mockPresign: vi.fn(async () => 'https://minio.internal/presigned?sig=x'),
@@ -51,6 +56,7 @@ vi.mock('~/server/db/client', () => ({
   dbRead: {
     appBlockPublishRequest: { findUnique: mockFindUnique },
     appBlock: { findFirst: mockAppBlockFindFirst },
+    appReviewAgentReport: { findFirst: mockReportFindFirst },
   },
   dbWrite: {
     appReviewAgentReport: { create: mockCreate, updateMany: mockUpdateMany },
@@ -128,8 +134,11 @@ beforeEach(() => {
   process.env.NEXTAUTH_URL = 'https://civitai.com';
   vi.clearAllMocks();
   mockAppBlockFindFirst.mockResolvedValue(null);
+  mockReportFindFirst.mockResolvedValue(null);
   mockGetPrior.mockResolvedValue(null);
   mockUpdateMany.mockResolvedValue({ count: 1 });
+  mockEnv.NEXTAUTH_URL = 'https://civitai.com';
+  mockEnv.AGENT_REVIEW_CALLBACK_BASE_URL = undefined;
   stubFetch();
 });
 afterEach(() => vi.unstubAllGlobals());
@@ -172,11 +181,14 @@ describe('startAgentReview — ZIP path', () => {
     expect(mockReconstruct).not.toHaveBeenCalled();
     expect(mockStage).not.toHaveBeenCalled();
 
-    // Running row keyed on appBlockId (XOR oauthClientId).
+    // Running row keyed on the stable slug (+ kind='onsite'); appBlockId is
+    // informational (resolved here), oauthClientId left null (out of P1 scope).
     const created = mockCreate.mock.calls[0][0].data;
     expect(created).toMatchObject({
       id: 'arar_TEST',
       publishRequestId: PUBREQ,
+      slug: 'my-app',
+      kind: 'onsite',
       appBlockId: 'ab_existing',
       version: '0.2.0',
       bundleSha256: SHA,
@@ -242,7 +254,7 @@ describe('startAgentReview — prior report', () => {
     const expectedB64 = Buffer.from(JSON.stringify(prior)).toString('base64');
     expect(jobEnv().PRIOR_REPORT_JSON_B64).toBe(expectedB64);
     expect(mockCreate.mock.calls[0][0].data.priorReportId).toBe('arar_prior');
-    expect(mockGetPrior).toHaveBeenCalledWith({ appBlockId: 'ab_existing', version: '0.2.0' });
+    expect(mockGetPrior).toHaveBeenCalledWith({ slug: 'my-app', version: '0.2.0' });
   });
 });
 
@@ -255,14 +267,18 @@ describe('startAgentReview — app-key resolution', () => {
     expect(mockCreate.mock.calls[0][0].data.appBlockId).toBe('ab_by_slug');
   });
 
-  it('fails closed on a first-version request (no appBlockId, no AppBlock)', async () => {
+  it('first-version review (no appBlockId, no AppBlock) PERSISTS keyed by slug, appBlockId null', async () => {
     mockFindUnique.mockResolvedValue(pendingRequest({ appBlockId: null }));
     mockAppBlockFindFirst.mockResolvedValue(null);
 
-    await expect(startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 })).rejects.toThrow(
-      /first-version/i
-    );
-    expect(mockCreate).not.toHaveBeenCalled();
+    const res = await startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 });
+    expect(res).toEqual({ reportId: 'arar_TEST', agentName: agentReviewName(PUBREQ) });
+
+    const created = mockCreate.mock.calls[0][0].data;
+    expect(created).toMatchObject({ slug: 'my-app', kind: 'onsite', appBlockId: null });
+    // Prior lookup + provisioning both proceed keyed by slug — no first-version throw.
+    expect(mockGetPrior).toHaveBeenCalledWith({ slug: 'my-app', version: '0.2.0' });
+    expect(calls.some((c) => c.method === 'POST')).toBe(true);
   });
 
   it('rejects a non-pending request', async () => {
@@ -276,6 +292,43 @@ describe('startAgentReview — app-key resolution', () => {
     mockFindUnique.mockResolvedValue(null);
     await expect(startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 })).rejects.toThrow(
       /not found/i
+    );
+  });
+});
+
+describe('startAgentReview — double-provision guard (audit #3)', () => {
+  it('refuses a second dispatch while a review is already running for the request', async () => {
+    mockFindUnique.mockResolvedValue(pendingRequest());
+    mockReportFindFirst.mockResolvedValue({ id: 'arar_running' });
+
+    await expect(startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 })).rejects.toThrow(
+      /already running/i
+    );
+    // No new row inserted, no Job provisioned.
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(calls.some((c) => c.method === 'POST')).toBe(false);
+    expect(mockReportFindFirst).toHaveBeenCalledWith({
+      where: { publishRequestId: PUBREQ, status: 'running' },
+      select: { id: true },
+    });
+  });
+});
+
+describe('startAgentReview — callback base URL (containment)', () => {
+  it('defaults CALLBACK_URL to NEXTAUTH_URL when AGENT_REVIEW_CALLBACK_BASE_URL is unset', async () => {
+    mockFindUnique.mockResolvedValue(pendingRequest());
+    await startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 });
+    expect(jobEnv().CALLBACK_URL).toBe(
+      'https://civitai.com/api/internal/blocks/agent-report-callback'
+    );
+  });
+
+  it('prefers the in-cluster AGENT_REVIEW_CALLBACK_BASE_URL when set (keeps report off the public internet)', async () => {
+    mockEnv.AGENT_REVIEW_CALLBACK_BASE_URL = 'http://web.internal.svc.cluster.local/';
+    mockFindUnique.mockResolvedValue(pendingRequest());
+    await startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 });
+    expect(jobEnv().CALLBACK_URL).toBe(
+      'http://web.internal.svc.cluster.local/api/internal/blocks/agent-report-callback'
     );
   });
 });

--- a/src/server/services/blocks/__tests__/agent-review.service.test.ts
+++ b/src/server/services/blocks/__tests__/agent-review.service.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * AGENTIC MOD CODE-REVIEW (App Blocks P1) — provisioning service.
+ *
+ * Covers startAgentReview end-to-end against mocked DB / S3 / k8s:
+ *   - ZIP path presigns the canonical bundleKey (no Forgejo reconstruct)
+ *   - PUSH path (bundleKey==='') reconstructs from Forgejo, STAGES it, presigns
+ *     the staged key
+ *   - prior-report lookup → base64 PRIOR_REPORT_JSON_B64 + priorReportId (empty
+ *     when there is no prior)
+ *   - the running report row is inserted with appBlockId (XOR oauthClientId)
+ *   - the provisioning Job carries EXACTLY the contract env vars
+ *   - idempotent pre-delete of the same-name apply Job before POST
+ *   - first-version (no app key) + non-pending → fail closed
+ *   - a provisioning failure flips the row to `failed`
+ * Plus deleteAgentReviewResources selector shape + buildAgentReviewApplyScript.
+ */
+
+const {
+  mockEnv,
+  mockFindUnique,
+  mockAppBlockFindFirst,
+  mockCreate,
+  mockUpdateMany,
+  mockPresign,
+  mockStage,
+  mockReconstruct,
+  mockGetPrior,
+  mockSign,
+} = vi.hoisted(() => ({
+  mockEnv: {
+    APPS_KUBE_NAMESPACE: 'civitai-apps',
+    APPS_DOMAIN: 'civit.ai',
+    AGENT_REVIEW_COST_CAP_USD: '2',
+  } as Record<string, unknown>,
+  mockFindUnique: vi.fn(),
+  mockAppBlockFindFirst: vi.fn(async () => null as { id: string } | null),
+  mockCreate: vi.fn(async () => undefined),
+  mockUpdateMany: vi.fn(async () => ({ count: 1 })),
+  mockPresign: vi.fn(async () => 'https://minio.internal/presigned?sig=x'),
+  mockStage: vi.fn(async () => undefined),
+  mockReconstruct: vi.fn(async () => Buffer.from('ZIPBYTES')),
+  mockGetPrior: vi.fn(async () => null as { id: string; version: string } | null),
+  mockSign: vi.fn(() => 'callback.token'),
+}));
+
+vi.mock('~/env/server', () => ({ env: mockEnv }));
+vi.mock('node:fs/promises', () => ({ readFile: vi.fn(async () => 'in-pod-token') }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    appBlockPublishRequest: { findUnique: mockFindUnique },
+    appBlock: { findFirst: mockAppBlockFindFirst },
+  },
+  dbWrite: {
+    appReviewAgentReport: { create: mockCreate, updateMany: mockUpdateMany },
+  },
+}));
+vi.mock('~/utils/bundle-s3', () => ({
+  presignBundleGet: mockPresign,
+  stageBundleObject: mockStage,
+  agentReviewBundleKey: (id: string, sha: string) => `agent-review/${id}-${sha}.zip`,
+}));
+vi.mock('~/server/services/blocks/publish-request.service', () => ({
+  reconstructBundleFromForgejo: mockReconstruct,
+}));
+vi.mock('~/server/services/blocks/app-review-report.service', () => ({
+  getPriorAgentReport: mockGetPrior,
+}));
+vi.mock('~/server/services/blocks/review-session', () => ({
+  signAgentCallbackToken: mockSign,
+}));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppReviewAgentReportId: () => 'arar_TEST',
+}));
+
+import {
+  startAgentReview,
+  deleteAgentReviewResources,
+  buildAgentReviewApplyScript,
+  agentReviewName,
+} from '~/server/services/blocks/agent-review.service';
+
+const PUBREQ = 'pubreq_0123456789ABCDEFGHJKMNPQRS';
+const SHA = 'f'.repeat(64);
+
+type Call = { url: string; method: string; body: any };
+let calls: Call[] = [];
+
+function stubFetch(postOk = true) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init: RequestInit) => {
+      calls.push({
+        url,
+        method: String(init.method),
+        body: init.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      if (init.method === 'POST') {
+        if (!postOk) {
+          return { ok: false, status: 500, statusText: 'err', text: async () => 'boom' } as unknown as Response;
+        }
+        return {
+          ok: true,
+          status: 201,
+          statusText: 'Created',
+          text: async () => JSON.stringify({ metadata: { name: 'agent-apply-job' } }),
+        } as unknown as Response;
+      }
+      if (init.method === 'GET' || init.method === undefined) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          text: async () => JSON.stringify({ items: [{ metadata: { name: 'review-agent-abc' } }] }),
+        } as unknown as Response;
+      }
+      // DELETE (pre-delete / teardown)
+      return { ok: true, status: 200, statusText: 'OK', text: async () => '' } as unknown as Response;
+    })
+  );
+}
+
+beforeEach(() => {
+  calls = [];
+  process.env.KUBERNETES_SERVICE_HOST = '10.0.0.1';
+  process.env.KUBERNETES_SERVICE_PORT = '443';
+  process.env.NEXTAUTH_URL = 'https://civitai.com';
+  vi.clearAllMocks();
+  mockAppBlockFindFirst.mockResolvedValue(null);
+  mockGetPrior.mockResolvedValue(null);
+  mockUpdateMany.mockResolvedValue({ count: 1 });
+  stubFetch();
+});
+afterEach(() => vi.unstubAllGlobals());
+
+const pendingRequest = (over: Record<string, unknown> = {}) => ({
+  id: PUBREQ,
+  slug: 'my-app',
+  version: '0.2.0',
+  bundleKey: `bundles/${SHA}.zip`,
+  bundleSha256: SHA,
+  appBlockId: 'ab_existing',
+  forgejoCommitSha: null,
+  status: 'pending',
+  ...over,
+});
+
+function postedJob() {
+  const post = calls.find((c) => c.method === 'POST');
+  expect(post).toBeDefined();
+  return post!.body;
+}
+function jobEnv() {
+  const env = postedJob().spec.template.spec.containers[0].env as Array<{
+    name: string;
+    value: string;
+  }>;
+  return Object.fromEntries(env.map((e) => [e.name, e.value]));
+}
+
+describe('startAgentReview — ZIP path', () => {
+  it('presigns the canonical bundleKey, inserts a running row, provisions the Job', async () => {
+    mockFindUnique.mockResolvedValue(pendingRequest());
+
+    const res = await startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 });
+
+    expect(res).toEqual({ reportId: 'arar_TEST', agentName: agentReviewName(PUBREQ) });
+
+    // Presigned the canonical bundle key — no Forgejo reconstruct/stage.
+    expect(mockPresign).toHaveBeenCalledWith(`bundles/${SHA}.zip`, expect.any(Number));
+    expect(mockReconstruct).not.toHaveBeenCalled();
+    expect(mockStage).not.toHaveBeenCalled();
+
+    // Running row keyed on appBlockId (XOR oauthClientId).
+    const created = mockCreate.mock.calls[0][0].data;
+    expect(created).toMatchObject({
+      id: 'arar_TEST',
+      publishRequestId: PUBREQ,
+      appBlockId: 'ab_existing',
+      version: '0.2.0',
+      bundleSha256: SHA,
+      status: 'running',
+      priorReportId: null,
+    });
+    expect(created.oauthClientId).toBeUndefined();
+
+    // Job carries EXACTLY the contract env vars.
+    const e = jobEnv();
+    expect(e).toEqual({
+      AGENT_NAME: agentReviewName(PUBREQ),
+      PUBLISH_REQUEST_ID: PUBREQ,
+      APP_SLUG: 'my-app',
+      BUNDLE_PRESIGNED_URL: 'https://minio.internal/presigned?sig=x',
+      CALLBACK_URL: 'https://civitai.com/api/internal/blocks/agent-report-callback',
+      CALLBACK_TOKEN: 'callback.token',
+      PRIOR_REPORT_JSON_B64: '',
+      COST_CAP_USD: '2',
+    });
+
+    // Job metadata labels for teardown selection.
+    expect(postedJob().metadata.labels['civitai.com/publish-request-id']).toBe(PUBREQ);
+  });
+
+  it('pre-deletes the same-name apply Job before POST (idempotency)', async () => {
+    mockFindUnique.mockResolvedValue(pendingRequest());
+    await startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 });
+
+    const jobName = `${agentReviewName(PUBREQ)}-apply`;
+    const del = calls.find((c) => c.method === 'DELETE' && c.url.includes(`/jobs/${jobName}`));
+    const post = calls.find((c) => c.method === 'POST');
+    expect(del).toBeDefined();
+    expect(post).toBeDefined();
+    // pre-delete precedes the create.
+    expect(calls.indexOf(del!)).toBeLessThan(calls.indexOf(post!));
+  });
+});
+
+describe('startAgentReview — PUSH (Forgejo) path', () => {
+  it('reconstructs from Forgejo, stages it, and presigns the staged key', async () => {
+    mockFindUnique.mockResolvedValue(
+      pendingRequest({ bundleKey: '', forgejoCommitSha: 'c'.repeat(40), appBlockId: 'ab_x' })
+    );
+
+    await startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 });
+
+    expect(mockReconstruct).toHaveBeenCalledWith('my-app', 'c'.repeat(40));
+    const stagedKey = `agent-review/${PUBREQ}-${SHA}.zip`;
+    expect(mockStage).toHaveBeenCalledWith(stagedKey, expect.any(Buffer));
+    expect(mockPresign).toHaveBeenCalledWith(stagedKey, expect.any(Number));
+  });
+});
+
+describe('startAgentReview — prior report', () => {
+  it('base64s the prior report JSON and links priorReportId', async () => {
+    mockFindUnique.mockResolvedValue(pendingRequest());
+    const prior = { id: 'arar_prior', version: '0.1.0' };
+    mockGetPrior.mockResolvedValue(prior);
+
+    await startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 });
+
+    const expectedB64 = Buffer.from(JSON.stringify(prior)).toString('base64');
+    expect(jobEnv().PRIOR_REPORT_JSON_B64).toBe(expectedB64);
+    expect(mockCreate.mock.calls[0][0].data.priorReportId).toBe('arar_prior');
+    expect(mockGetPrior).toHaveBeenCalledWith({ appBlockId: 'ab_existing', version: '0.2.0' });
+  });
+});
+
+describe('startAgentReview — app-key resolution', () => {
+  it('falls back to the AppBlock by slug when the request has no appBlockId', async () => {
+    mockFindUnique.mockResolvedValue(pendingRequest({ appBlockId: null }));
+    mockAppBlockFindFirst.mockResolvedValue({ id: 'ab_by_slug' });
+
+    await startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 });
+    expect(mockCreate.mock.calls[0][0].data.appBlockId).toBe('ab_by_slug');
+  });
+
+  it('fails closed on a first-version request (no appBlockId, no AppBlock)', async () => {
+    mockFindUnique.mockResolvedValue(pendingRequest({ appBlockId: null }));
+    mockAppBlockFindFirst.mockResolvedValue(null);
+
+    await expect(startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 })).rejects.toThrow(
+      /first-version/i
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-pending request', async () => {
+    mockFindUnique.mockResolvedValue(pendingRequest({ status: 'approved' }));
+    await expect(startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 })).rejects.toThrow(
+      /not pending/i
+    );
+  });
+
+  it('rejects a missing request', async () => {
+    mockFindUnique.mockResolvedValue(null);
+    await expect(startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 })).rejects.toThrow(
+      /not found/i
+    );
+  });
+});
+
+describe('startAgentReview — provisioning failure', () => {
+  it('flips the running row to failed when the Job POST fails', async () => {
+    mockFindUnique.mockResolvedValue(pendingRequest());
+    stubFetch(false); // POST returns non-ok → unwrap throws
+
+    await expect(startAgentReview({ publishRequestId: PUBREQ, modUserId: 7 })).rejects.toThrow();
+
+    // Row was inserted running, then flipped to failed.
+    expect(mockCreate).toHaveBeenCalled();
+    const upd = mockUpdateMany.mock.calls.at(-1)![0];
+    expect(upd.where).toMatchObject({ id: 'arar_TEST', status: 'running' });
+    expect(upd.data.status).toBe('failed');
+  });
+});
+
+describe('deleteAgentReviewResources', () => {
+  it('LISTs deployments + services by the review-agent selector then DELETEs by name', async () => {
+    await deleteAgentReviewResources({ slug: 'my-app', publishRequestId: PUBREQ });
+
+    const lists = calls.filter((c) => c.method === 'GET');
+    expect(lists.length).toBe(2);
+    for (const l of lists) {
+      expect(decodeURIComponent(l.url)).toContain(
+        `civitai.com/role=review-agent,civitai.com/publish-request-id=${PUBREQ}`
+      );
+    }
+    expect(lists.some((l) => l.url.includes('/deployments?'))).toBe(true);
+    expect(lists.some((l) => l.url.includes('/services?'))).toBe(true);
+
+    const deletes = calls.filter((c) => c.method === 'DELETE');
+    expect(deletes.length).toBe(2);
+    for (const d of deletes) {
+      expect(d.url).toContain('/review-agent-abc');
+      expect(d.url).not.toContain('labelSelector');
+    }
+  });
+
+  it('never throws when k8s is down (best-effort)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('k8s down');
+      })
+    );
+    await expect(
+      deleteAgentReviewResources({ slug: 'my-app', publishRequestId: PUBREQ })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('buildAgentReviewApplyScript', () => {
+  it('renders the review-agent template, applies it, and does NOT cat secrets', () => {
+    const script = buildAgentReviewApplyScript('civitai-apps');
+    expect(script).toContain('/templates/review-agent.yaml.tmpl');
+    expect(script).toContain('kubectl apply -f /tmp/rendered.yaml');
+    // The rendered manifest embeds the presigned URL + callback token — never cat
+    // it (match an actual `cat` command line, not the "Do NOT cat" comment).
+    expect(script).not.toContain('\ncat /tmp/rendered.yaml');
+    // envsubst fallback covers every contract var.
+    for (const v of [
+      'AGENT_NAME',
+      'PUBLISH_REQUEST_ID',
+      'APP_SLUG',
+      'BUNDLE_PRESIGNED_URL',
+      'CALLBACK_URL',
+      'CALLBACK_TOKEN',
+      'PRIOR_REPORT_JSON_B64',
+      'COST_CAP_USD',
+    ]) {
+      expect(script).toContain(v);
+    }
+  });
+});
+
+describe('agentReviewName', () => {
+  it('is DNS-label-safe and ≤63 chars', () => {
+    const name = agentReviewName(PUBREQ);
+    expect(name).toMatch(/^[a-z0-9-]+$/);
+    expect(name.length).toBeLessThanOrEqual(63);
+    expect(agentReviewName(PUBREQ)).toBe(name); // deterministic
+  });
+});

--- a/src/server/services/blocks/__tests__/app-review-report.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-review-report.service.test.ts
@@ -5,10 +5,10 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
  *
  * Covers the prior-report selection: picks the latest COMPLETE report strictly
  * semver-older than the version under review (semver, not lexical, ordering),
- * queries only status='complete' (so running/failed/torn-down are excluded at
- * the DB), respects the app key (appBlockId XOR oauthClientId), returns null
- * when there is no earlier report, and enforces the exactly-one-key + valid
- * semver invariants. Plus getAgentReport's by-review lookup.
+ * queries only status='complete' (so running/failed/torn-down/cost-capped are
+ * excluded at the DB), scopes to the stable `slug` key, returns null when there
+ * is no earlier report, and enforces the non-empty-slug + valid semver
+ * invariants. Plus getAgentReport's by-review lookup.
  */
 
 const { mockFindMany, mockFindFirst } = vi.hoisted(() => ({
@@ -53,25 +53,15 @@ describe('getPriorAgentReport', () => {
       report({ id: 'arar_c', version: '0.10.0' }),
     ]);
 
-    const prior = await getPriorAgentReport({ appBlockId: 'ab_x', version: '1.0.0' });
+    const prior = await getPriorAgentReport({ slug: 's_x', version: '1.0.0' });
     expect(prior?.id).toBe('arar_c');
   });
 
-  it('queries only status="complete" and scopes to the appBlockId key', async () => {
+  it('queries only status="complete" and scopes to the slug key', async () => {
     mockFindMany.mockResolvedValue([]);
-    await getPriorAgentReport({ appBlockId: 'ab_x', version: '2.0.0' });
+    await getPriorAgentReport({ slug: 's_x', version: '2.0.0' });
     expect(mockFindMany).toHaveBeenCalledWith({
-      where: { appBlockId: 'ab_x', status: 'complete' },
-      orderBy: { startedAt: 'desc' },
-      take: 100,
-    });
-  });
-
-  it('scopes to the oauthClientId key for a connect app', async () => {
-    mockFindMany.mockResolvedValue([]);
-    await getPriorAgentReport({ oauthClientId: 'oc_y', version: '2.0.0' });
-    expect(mockFindMany).toHaveBeenCalledWith({
-      where: { oauthClientId: 'oc_y', status: 'complete' },
+      where: { slug: 's_x', status: 'complete' },
       orderBy: { startedAt: 'desc' },
       take: 100,
     });
@@ -83,13 +73,13 @@ describe('getPriorAgentReport', () => {
       report({ id: 'arar_new', version: '1.1.0' }), // newer -> excluded
       report({ id: 'arar_old', version: '0.5.0' }), // older -> the answer
     ]);
-    const prior = await getPriorAgentReport({ appBlockId: 'ab_x', version: '1.0.0' });
+    const prior = await getPriorAgentReport({ slug: 's_x', version: '1.0.0' });
     expect(prior?.id).toBe('arar_old');
   });
 
   it('returns null when the app has no earlier complete report', async () => {
     mockFindMany.mockResolvedValue([report({ id: 'arar_only', version: '1.0.0' })]);
-    const prior = await getPriorAgentReport({ appBlockId: 'ab_x', version: '1.0.0' });
+    const prior = await getPriorAgentReport({ slug: 's_x', version: '1.0.0' });
     expect(prior).toBeNull();
   });
 
@@ -98,7 +88,7 @@ describe('getPriorAgentReport', () => {
       report({ id: 'arar_early', version: '0.9.0', startedAt: new Date('2026-01-01T00:00:00Z') }),
       report({ id: 'arar_late', version: '0.9.0', startedAt: new Date('2026-02-01T00:00:00Z') }),
     ]);
-    const prior = await getPriorAgentReport({ appBlockId: 'ab_x', version: '1.0.0' });
+    const prior = await getPriorAgentReport({ slug: 's_x', version: '1.0.0' });
     expect(prior?.id).toBe('arar_late');
   });
 
@@ -110,21 +100,20 @@ describe('getPriorAgentReport', () => {
       report({ id: 'arar_highest_semver', version: '0.10.0', startedAt: new Date('2026-01-01T00:00:00Z') }),
       report({ id: 'arar_mid', version: '0.9.0', startedAt: new Date('2026-02-01T00:00:00Z') }),
     ]);
-    const prior = await getPriorAgentReport({ appBlockId: 'ab_x', version: '1.0.0' });
+    const prior = await getPriorAgentReport({ slug: 's_x', version: '1.0.0' });
     expect(prior?.id).toBe('arar_highest_semver');
   });
 
-  it('throws when neither or both app keys are provided', async () => {
-    await expect(getPriorAgentReport({ version: '1.0.0' })).rejects.toThrow(/exactly one/);
-    await expect(
-      getPriorAgentReport({ appBlockId: 'ab_x', oauthClientId: 'oc_y', version: '1.0.0' })
-    ).rejects.toThrow(/exactly one/);
+  it('throws when the slug is empty', async () => {
+    await expect(getPriorAgentReport({ slug: '', version: '1.0.0' })).rejects.toThrow(
+      /non-empty slug/
+    );
     expect(mockFindMany).not.toHaveBeenCalled();
   });
 
   it('throws on an invalid semver version', async () => {
     await expect(
-      getPriorAgentReport({ appBlockId: 'ab_x', version: 'not-a-version' })
+      getPriorAgentReport({ slug: 's_x', version: 'not-a-version' })
     ).rejects.toThrow(/invalid semver/);
     expect(mockFindMany).not.toHaveBeenCalled();
   });

--- a/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
@@ -20,6 +20,8 @@ const {
   mockGetReviewHead,
   mockTriggerReviewBuild,
   mockDeleteReviewResources,
+  mockDeleteAgentReviewResources,
+  mockDeleteStagedBundle,
 } = vi.hoisted(() => ({
   mockDbRead: {
     appBlockPublishRequest: { findUnique: vi.fn(), findMany: vi.fn(async () => []) },
@@ -36,10 +38,14 @@ const {
     $transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb({})),
     appListing: { updateMany: vi.fn(async () => ({ count: 0 })) },
     appListingModerationEvent: { create: vi.fn(async () => ({})) },
+    // AGENTIC REVIEW (P1) — running-report flip target for teardownAgentReviewForRequest.
+    appReviewAgentReport: { updateMany: vi.fn(async () => ({ count: 1 })) },
   },
   mockGetReviewHead: vi.fn(async () => 'a'.repeat(40)),
   mockTriggerReviewBuild: vi.fn(async () => ({ name: 'review-pr-1' })),
   mockDeleteReviewResources: vi.fn(async () => undefined),
+  mockDeleteAgentReviewResources: vi.fn(async () => undefined),
+  mockDeleteStagedBundle: vi.fn(async () => undefined),
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
@@ -54,11 +60,19 @@ vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
   // pure helper used by previewRequest
   reviewHost: (sha: string, domain: string) => `review-${sha.slice(0, 16)}.${domain}`,
 }));
+// AGENTIC REVIEW (P1) — teardownAgentReviewForRequest dynamically imports these.
+vi.mock('~/server/services/blocks/agent-review.service', () => ({
+  deleteAgentReviewResources: mockDeleteAgentReviewResources,
+}));
+vi.mock('~/utils/bundle-s3', () => ({
+  deleteStagedBundle: mockDeleteStagedBundle,
+}));
 
 import {
   previewRequest,
   getReviewStatus,
   teardownReviewForRequest,
+  teardownAgentReviewForRequest,
   teardownPreview,
   countActiveReviewPreviews,
   listActiveReviewPreviews,
@@ -280,6 +294,39 @@ describe('teardownReviewForRequest', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// AGENTIC REVIEW (P1, audit #1/#2) — teardownAgentReviewForRequest is DECOUPLED
+// from the sandbox-preview teardown: it always deletes the agent k8s objects,
+// flips a running report row → torn-down, and cleans up the staged bundle,
+// regardless of whether a sandbox preview ever ran.
+// ---------------------------------------------------------------------------
+describe('teardownAgentReviewForRequest', () => {
+  beforeEach(() => {
+    mockDeleteAgentReviewResources.mockClear();
+    mockDeleteStagedBundle.mockClear();
+    mockDbWrite.appReviewAgentReport.updateMany.mockClear();
+    mockDbWrite.appReviewAgentReport.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it('deletes agent resources, flips the running report to torn-down, and cleans the staged bundle', async () => {
+    await teardownAgentReviewForRequest(PUBREQ);
+
+    expect(mockDeleteAgentReviewResources).toHaveBeenCalledWith(
+      expect.objectContaining({ publishRequestId: PUBREQ })
+    );
+    expect(mockDbWrite.appReviewAgentReport.updateMany).toHaveBeenCalledWith({
+      where: { publishRequestId: PUBREQ, status: 'running' },
+      data: { status: 'torn-down', completedAt: expect.any(Date) },
+    });
+    expect(mockDeleteStagedBundle).toHaveBeenCalledWith(PUBREQ);
+  });
+
+  it('never throws even if a step fails (best-effort)', async () => {
+    mockDbWrite.appReviewAgentReport.updateMany.mockRejectedValue(new Error('db down'));
+    await expect(teardownAgentReviewForRequest(PUBREQ)).resolves.toBeUndefined();
+  });
+});
+
 describe('withdrawRequest review teardown (#2831)', () => {
   const USER = 7;
   beforeEach(() => {
@@ -287,6 +334,7 @@ describe('withdrawRequest review teardown (#2831)', () => {
     mockDbWrite.appBlockPublishRequest.updateMany.mockReset();
     mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
     mockDeleteReviewResources.mockClear();
+    mockDeleteAgentReviewResources.mockClear();
   });
 
   it('tears down the review env when a previewed request is self-withdrawn', async () => {
@@ -319,7 +367,7 @@ describe('withdrawRequest review teardown (#2831)', () => {
     });
   });
 
-  it('does NOT tear down when no preview was started', async () => {
+  it('does NOT tear down the SANDBOX when no preview was started, but STILL tears down the agent (audit #1)', async () => {
     mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValueOnce({
       id: PUBREQ,
       status: 'pending',
@@ -330,7 +378,12 @@ describe('withdrawRequest review teardown (#2831)', () => {
     await withdrawRequest({ publishRequestId: PUBREQ, userId: USER });
     await new Promise((r) => setTimeout(r, 0));
 
+    // Sandbox teardown is preview-gated → skipped.
     expect(mockDeleteReviewResources).not.toHaveBeenCalled();
+    // Agent teardown is UNCONDITIONAL → fires even with no sandbox preview.
+    expect(mockDeleteAgentReviewResources).toHaveBeenCalledWith(
+      expect.objectContaining({ publishRequestId: PUBREQ })
+    );
   });
 });
 

--- a/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
@@ -38,8 +38,13 @@ const {
     $transaction: vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb({})),
     appListing: { updateMany: vi.fn(async () => ({ count: 0 })) },
     appListingModerationEvent: { create: vi.fn(async () => ({})) },
-    // AGENTIC REVIEW (P1) — running-report flip target for teardownAgentReviewForRequest.
-    appReviewAgentReport: { updateMany: vi.fn(async () => ({ count: 1 })) },
+    // AGENTIC REVIEW (P1) — teardownAgentReviewForRequest first probes findFirst
+    // (cheap indexed existence gate) then flips a running report → torn-down via
+    // updateMany. Default findFirst = a report exists (agent review ran).
+    appReviewAgentReport: {
+      findFirst: vi.fn(async () => ({ id: 'report_1' })),
+      updateMany: vi.fn(async () => ({ count: 1 })),
+    },
   },
   mockGetReviewHead: vi.fn(async () => 'a'.repeat(40)),
   mockTriggerReviewBuild: vi.fn(async () => ({ name: 'review-pr-1' })),
@@ -304,6 +309,8 @@ describe('teardownAgentReviewForRequest', () => {
   beforeEach(() => {
     mockDeleteAgentReviewResources.mockClear();
     mockDeleteStagedBundle.mockClear();
+    mockDbWrite.appReviewAgentReport.findFirst.mockClear();
+    mockDbWrite.appReviewAgentReport.findFirst.mockResolvedValue({ id: 'report_1' });
     mockDbWrite.appReviewAgentReport.updateMany.mockClear();
     mockDbWrite.appReviewAgentReport.updateMany.mockResolvedValue({ count: 1 });
   });
@@ -321,6 +328,23 @@ describe('teardownAgentReviewForRequest', () => {
     expect(mockDeleteStagedBundle).toHaveBeenCalledWith(PUBREQ);
   });
 
+  it('skips the k8s + MinIO teardown I/O when no agent review ran for the request', async () => {
+    // No report row for this request → the cheap indexed gate returns early,
+    // so the live approve/reject/withdraw path pays a single indexed read, not
+    // the k8s LIST+DELETE + MinIO LIST+DELETE round-trips.
+    mockDbWrite.appReviewAgentReport.findFirst.mockResolvedValue(null);
+
+    await expect(teardownAgentReviewForRequest(PUBREQ)).resolves.toBeUndefined();
+
+    expect(mockDbWrite.appReviewAgentReport.findFirst).toHaveBeenCalledWith({
+      where: { publishRequestId: PUBREQ },
+      select: { id: true },
+    });
+    expect(mockDeleteAgentReviewResources).not.toHaveBeenCalled();
+    expect(mockDbWrite.appReviewAgentReport.updateMany).not.toHaveBeenCalled();
+    expect(mockDeleteStagedBundle).not.toHaveBeenCalled();
+  });
+
   it('never throws even if a step fails (best-effort)', async () => {
     mockDbWrite.appReviewAgentReport.updateMany.mockRejectedValue(new Error('db down'));
     await expect(teardownAgentReviewForRequest(PUBREQ)).resolves.toBeUndefined();
@@ -335,6 +359,9 @@ describe('withdrawRequest review teardown (#2831)', () => {
     mockDbWrite.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
     mockDeleteReviewResources.mockClear();
     mockDeleteAgentReviewResources.mockClear();
+    // A report row exists → the agent teardown gate passes (a prior test may have
+    // flipped findFirst to null).
+    mockDbWrite.appReviewAgentReport.findFirst.mockResolvedValue({ id: 'report_1' });
   });
 
   it('tears down the review env when a previewed request is self-withdrawn', async () => {

--- a/src/server/services/blocks/__tests__/review-session.agentCallback.test.ts
+++ b/src/server/services/blocks/__tests__/review-session.agentCallback.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import {
+  signAgentCallbackToken,
+  verifyAgentCallbackToken,
+} from '~/server/services/blocks/review-session';
+
+/**
+ * AGENTIC MOD CODE-REVIEW (App Blocks P1) — unit coverage for the per-review
+ * callback bearer (bound to publishRequestId, domain-separated HMAC).
+ *
+ *   - sign → verify roundtrip (publishRequestId bound)
+ *   - rejects verification against a DIFFERENT publishRequestId (id binding)
+ *   - rejects a different secret / tampered sig (constant-time path)
+ *   - rejects an expired token
+ *   - rejects malformed input without throwing
+ *   - the `mr` entry token and this bearer do NOT cross-verify (domain sep)
+ */
+
+const SECRET = 'test-nextauth-secret-bbbbbbbbbbbbbbbbbbbb';
+const PUBREQ = 'pubreq_0123456789ABCDEFGHJKMNPQRS';
+
+describe('signAgentCallbackToken / verifyAgentCallbackToken', () => {
+  it('roundtrips: a fresh token verifies for the bound publishRequestId', () => {
+    const token = signAgentCallbackToken({ publishRequestId: PUBREQ, secret: SECRET });
+    expect(token).toMatch(/^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/);
+    expect(verifyAgentCallbackToken(token, PUBREQ, { secret: SECRET })).toEqual({
+      ok: true,
+      publishRequestId: PUBREQ,
+    });
+  });
+
+  it('rejects a token verified against a DIFFERENT publishRequestId (id binding)', () => {
+    const token = signAgentCallbackToken({ publishRequestId: PUBREQ, secret: SECRET });
+    expect(
+      verifyAgentCallbackToken(token, 'pubreq_ZZZZZZZZZZZZZZZZZZZZZZZZZZ', { secret: SECRET })
+    ).toEqual({ ok: false });
+  });
+
+  it('rejects a token signed with a different secret (sig mismatch)', () => {
+    const token = signAgentCallbackToken({ publishRequestId: PUBREQ, secret: 'other-secret' });
+    expect(verifyAgentCallbackToken(token, PUBREQ, { secret: SECRET })).toEqual({ ok: false });
+  });
+
+  it('rejects an expired token (ttl in the past)', () => {
+    const token = signAgentCallbackToken({
+      publishRequestId: PUBREQ,
+      secret: SECRET,
+      ttlSeconds: -1,
+    });
+    expect(verifyAgentCallbackToken(token, PUBREQ, { secret: SECRET })).toEqual({ ok: false });
+  });
+
+  it('never throws on malformed input → ok:false', () => {
+    for (const bad of [null, undefined, '', 'no-dot', '.', 'a.', '.b', 'not.base64!!']) {
+      expect(verifyAgentCallbackToken(bad as string, PUBREQ, { secret: SECRET }).ok).toBe(false);
+    }
+  });
+
+  it('rejects an empty expected id', () => {
+    const token = signAgentCallbackToken({ publishRequestId: PUBREQ, secret: SECRET });
+    expect(verifyAgentCallbackToken(token, '', { secret: SECRET }).ok).toBe(false);
+  });
+});

--- a/src/server/services/blocks/agent-review.service.ts
+++ b/src/server/services/blocks/agent-review.service.ts
@@ -1,0 +1,517 @@
+import { env } from '~/env/server';
+import {
+  getDp1Target,
+  k8sFetch,
+  unwrap,
+} from '~/server/services/blocks/apps-pipeline.service';
+
+/**
+ * AGENTIC MOD CODE-REVIEW (App Blocks P1) — provisioning lane.
+ *
+ * A moderator reviewing a PENDING publish request can dispatch an EPHEMERAL,
+ * sandboxed review agent. This service is the civitai side of that:
+ *   - `startAgentReview` gathers the reviewed bundle (presigned for in-cluster
+ *     pull), the prior-version report, mints a per-review callback bearer, writes
+ *     a `running` report row, and provisions a k8s apply Job that renders the
+ *     already-shipped `review-agent.yaml.tmpl` (from the `app-templates`
+ *     ConfigMap) via envsubst + `kubectl apply` — MIRRORING the review-sandbox
+ *     apply lane (`triggerApplyReview`) exactly.
+ *   - `deleteAgentReviewResources` tears the agent's k8s objects down by label
+ *     selector (best-effort, idempotent, never throws) — called from the shared
+ *     `teardownReviewForRequest` decision hook.
+ *
+ * DARK: `startAgentReview` is only reachable via a tRPC procedure gated on the
+ * `app-blocks-agentic-review` Flipt flag, which does not exist yet → the whole
+ * feature is inert on merge.
+ *
+ * Everything is a thin REST wrapper over the in-pod ServiceAccount k8s API (no
+ * kubernetes-client dependency), reusing `k8sFetch`/`getDp1Target` from the
+ * apps-pipeline service. Infra identifiers come from EXISTING env
+ * (`env.APPS_KUBE_NAMESPACE`) — none are hardcoded here.
+ */
+
+/** Presigned-bundle TTL. The agent pod's init curls it once, shortly after the
+ *  apply Job creates the Deployment; a few minutes covers image-pull + init. */
+export const AGENT_REVIEW_BUNDLE_PRESIGN_TTL_SECONDS = 15 * 60;
+
+/**
+ * Derive the DNS-label-safe agent object name from a publishRequestId. Must be
+ * ≤63 chars and match `[a-z0-9-]`. A short hex hash of the id keeps it stable
+ * (idempotent re-runs target the same objects) AND well under the label limit
+ * (`review-agent-` = 13 chars + 12 hex = 25). Exported so tests + teardown can
+ * derive the same name the apply Job renders.
+ */
+export function agentReviewName(publishRequestId: string): string {
+  // Lazy require: crypto is node-builtin, kept off the module top so this stays
+  // import-cheap for the (dark) importers.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { createHash } = require('crypto') as typeof import('crypto');
+  const hash = createHash('sha1').update(publishRequestId).digest('hex').slice(0, 12);
+  return `review-agent-${hash}`;
+}
+
+export type StartAgentReviewArgs = {
+  publishRequestId: string;
+  /** Calling moderator's id — recorded for audit; the agent produces mod
+   *  decision-support, so the trigger is always moderator-bound. */
+  modUserId: number;
+};
+
+export type StartAgentReviewResult = {
+  reportId: string;
+  agentName: string;
+};
+
+/**
+ * Dispatch an ephemeral review agent for a PENDING on-site publish request.
+ *
+ * Steps (mirroring the review-sandbox lane's shape):
+ *   a. Load the AppBlockPublishRequest (slug, bundle pointers, version, app key,
+ *      forgejo commit).
+ *   b. Resolve ONE presigned MinIO object the pod pulls: the canonical bundle
+ *      (`bundleKey`) if the ZIP was uploaded, else reconstruct-from-Forgejo and
+ *      stage it to a per-review key, then presign THAT. Either way the pod pulls
+ *      one read-only object and never talks to Forgejo.
+ *   c. Look up the prior-version report (base64 for the pod) so the agent can
+ *      diff against the last review.
+ *   d. Insert a `running` report row.
+ *   e. Mint the per-review callback bearer (bound to publishRequestId).
+ *   f. Provision the apply Job that envsubst-renders `review-agent.yaml.tmpl` +
+ *      `kubectl apply`s it.
+ *
+ * On a provisioning failure the just-inserted row is flipped to `failed` so it
+ * never lingers `running`.
+ */
+export async function startAgentReview(
+  args: StartAgentReviewArgs
+): Promise<StartAgentReviewResult> {
+  const { publishRequestId } = args;
+  const { dbRead, dbWrite } = await import('~/server/db/client');
+
+  // (a) Load the pending on-site publish request. The whole review lane
+  // (previewRequest / teardownReviewForRequest) targets AppBlockPublishRequest;
+  // this mirrors it. (The connect / AppListingPublishRequest → oauthClientId path
+  // is a separate flow, out of P1 scope — see the service docstring.)
+  const request = await dbRead.appBlockPublishRequest.findUnique({
+    where: { id: publishRequestId },
+    select: {
+      id: true,
+      slug: true,
+      version: true,
+      bundleKey: true,
+      bundleSha256: true,
+      appBlockId: true,
+      forgejoCommitSha: true,
+      status: true,
+    },
+  });
+  if (!request) throw new Error(`publish request ${publishRequestId} not found`);
+  if (request.status !== 'pending') {
+    throw new Error(
+      `publish request ${publishRequestId} is not pending (status=${request.status})`
+    );
+  }
+
+  // Resolve the on-site app key. An UPDATE carries appBlockId (or an AppBlock
+  // exists for the slug). A genuine FIRST version has neither (the AppBlock is
+  // created on approve) — and the report table's app_key XOR CHECK requires
+  // exactly one key, so a first-version review cannot be keyed yet. Fail closed
+  // with a clear message (see the P1 handoff — resolving first-version keying is
+  // a follow-up, e.g. relaxing the XOR to allow a slug key).
+  let appBlockId = request.appBlockId ?? null;
+  if (!appBlockId) {
+    const existing = await dbRead.appBlock.findFirst({
+      where: { blockId: request.slug },
+      select: { id: true },
+    });
+    appBlockId = existing?.id ?? null;
+  }
+  if (!appBlockId) {
+    throw new Error(
+      'agentic review needs an existing app version to key the report; first-version on-site reviews are not yet supported'
+    );
+  }
+
+  const sha = request.bundleSha256;
+
+  // (b) Resolve the ONE presigned object the pod pulls.
+  let bundleObjectKey: string;
+  if (request.bundleKey) {
+    // ZIP path: the canonical bundle object already exists — presign it directly.
+    bundleObjectKey = request.bundleKey;
+  } else if (request.forgejoCommitSha) {
+    // PUSH path (git-push origin, bundleKey===''): no ZIP was uploaded — the
+    // Forgejo repo at the reviewed sha IS the artifact. Reconstruct the exact
+    // reviewed bytes (deterministic; same helper approve uses) and STAGE them to
+    // a per-review MinIO key so the pod pulls one presigned object (never Forgejo).
+    const { reconstructBundleFromForgejo } = await import('./publish-request.service');
+    const { agentReviewBundleKey, stageBundleObject } = await import('~/utils/bundle-s3');
+    const buf = await reconstructBundleFromForgejo(request.slug, request.forgejoCommitSha);
+    bundleObjectKey = agentReviewBundleKey(publishRequestId, sha);
+    await stageBundleObject(bundleObjectKey, buf);
+  } else {
+    throw new Error(
+      `publish request ${publishRequestId} has neither a bundle nor a forgejo commit to review`
+    );
+  }
+  const { presignBundleGet } = await import('~/utils/bundle-s3');
+  const bundlePresignedUrl = await presignBundleGet(
+    bundleObjectKey,
+    AGENT_REVIEW_BUNDLE_PRESIGN_TTL_SECONDS
+  );
+
+  // (c) Prior-version report → base64 JSON for the pod (empty string if none).
+  const { getPriorAgentReport } = await import('./app-review-report.service');
+  const prior = await getPriorAgentReport({ appBlockId, version: request.version });
+  const priorReportJsonB64 = prior
+    ? Buffer.from(JSON.stringify(prior)).toString('base64')
+    : '';
+
+  // (d) Insert the running report row (appBlockId XOR oauthClientId — on-site =
+  // appBlockId set, oauthClientId left null).
+  const { newAppReviewAgentReportId } = await import('~/server/utils/app-block-ids');
+  const reportId = newAppReviewAgentReportId();
+  await dbWrite.appReviewAgentReport.create({
+    data: {
+      id: reportId,
+      publishRequestId,
+      appBlockId,
+      version: request.version,
+      bundleSha256: sha,
+      status: 'running',
+      startedAt: new Date(),
+      priorReportId: prior?.id ?? null,
+    },
+  });
+
+  // (e) Mint the per-review callback bearer bound to this publishRequestId. NOT
+  // the fleet-wide BLOCK_BUILD_CALLBACK_SECRET — that must never reach the agent
+  // pod. Short-TTL + review-scoped: a leaked token can only touch THIS report.
+  const { signAgentCallbackToken } = await import('./review-session');
+  const callbackToken = signAgentCallbackToken({ publishRequestId });
+  const callbackUrl = `${(process.env.NEXTAUTH_URL ?? '').replace(
+    /\/$/,
+    ''
+  )}/api/internal/blocks/agent-report-callback`;
+
+  const agentName = agentReviewName(publishRequestId);
+
+  // (f) Provision the apply Job. On failure, flip the row to failed so it never
+  // lingers `running`, then rethrow.
+  try {
+    await provisionAgentReviewJob({
+      agentName,
+      publishRequestId,
+      slug: request.slug,
+      bundlePresignedUrl,
+      callbackUrl,
+      callbackToken,
+      priorReportJsonB64,
+      costCapUsd: env.AGENT_REVIEW_COST_CAP_USD,
+    });
+  } catch (err) {
+    await dbWrite.appReviewAgentReport
+      .updateMany({
+        where: { id: reportId, status: 'running' },
+        data: {
+          status: 'failed',
+          summaryMd: `Provisioning failed: ${
+            err instanceof Error ? err.message : String(err)
+          }`.slice(0, 500),
+          completedAt: new Date(),
+        },
+      })
+      .catch(() => {
+        /* best-effort — the caller already sees the throw */
+      });
+    throw err;
+  }
+
+  return { reportId, agentName };
+}
+
+type ProvisionAgentReviewJobArgs = {
+  agentName: string;
+  publishRequestId: string;
+  slug: string;
+  bundlePresignedUrl: string;
+  callbackUrl: string;
+  callbackToken: string;
+  priorReportJsonB64: string;
+  costCapUsd: string;
+};
+
+/**
+ * Create the provisioning apply Job on dp-1's apps namespace. Mirrors
+ * `triggerApplyReview`: same in-pod SA k8s surface, same `apps-applier` SA + the
+ * same `app-templates` ConfigMap, but renders `review-agent.yaml.tmpl` with the
+ * agent-review contract vars and applies it. The rendered objects carry the
+ * template's labels (`civitai.com/role=review-agent`,
+ * `civitai.com/publish-request-id=<id>`, `civitai.com/app-slug=<slug>`,
+ * `review-mode=true`) — `deleteAgentReviewResources` sweeps on those.
+ *
+ * Exported so the orchestration test can lock the Job body + envsubst-var shape.
+ */
+export async function provisionAgentReviewJob(
+  args: ProvisionAgentReviewJobArgs
+): Promise<{ name: string }> {
+  const target = await getDp1Target();
+  const ns = env.APPS_KUBE_NAMESPACE;
+  const jobName = `${args.agentName}-apply`;
+
+  const job = {
+    apiVersion: 'batch/v1',
+    kind: 'Job',
+    metadata: {
+      name: jobName,
+      namespace: ns,
+      labels: {
+        app: jobName,
+        'civitai.com/role': 'apply-job',
+        'civitai.com/review-mode': 'true',
+        'civitai.com/app-slug': args.slug,
+        'civitai.com/publish-request-id': args.publishRequestId,
+      },
+    },
+    spec: {
+      backoffLimit: 2,
+      // 24h TTL backstop — the approve/reject decision (teardownReviewForRequest)
+      // tears the agent down; this only garbage-collects the apply Job itself.
+      ttlSecondsAfterFinished: 86400,
+      template: {
+        metadata: {
+          labels: {
+            'civitai.com/role': 'apply-job',
+            'civitai.com/review-mode': 'true',
+            'civitai.com/app-slug': args.slug,
+          },
+        },
+        spec: {
+          serviceAccountName: 'apps-applier',
+          restartPolicy: 'Never',
+          securityContext: {
+            runAsNonRoot: true,
+            runAsUser: 65532,
+            runAsGroup: 65532,
+            seccompProfile: { type: 'RuntimeDefault' },
+          },
+          containers: [
+            {
+              name: 'apply',
+              image: 'alpine/k8s:1.34.0',
+              imagePullPolicy: 'IfNotPresent',
+              // Contract vars the shipped review-agent.yaml.tmpl consumes.
+              // Object render vars + pod runtime env values (envsubst reads
+              // process env, which container env vars auto-export into).
+              // OPENROUTER_API_KEY is intentionally NOT passed — the pod reads it
+              // from a namespace Secret.
+              env: [
+                { name: 'AGENT_NAME', value: args.agentName },
+                { name: 'PUBLISH_REQUEST_ID', value: args.publishRequestId },
+                { name: 'APP_SLUG', value: args.slug },
+                { name: 'BUNDLE_PRESIGNED_URL', value: args.bundlePresignedUrl },
+                { name: 'CALLBACK_URL', value: args.callbackUrl },
+                { name: 'CALLBACK_TOKEN', value: args.callbackToken },
+                { name: 'PRIOR_REPORT_JSON_B64', value: args.priorReportJsonB64 },
+                { name: 'COST_CAP_USD', value: args.costCapUsd },
+              ],
+              securityContext: {
+                allowPrivilegeEscalation: false,
+                readOnlyRootFilesystem: true,
+                capabilities: { drop: ['ALL'] },
+              },
+              volumeMounts: [
+                { name: 'templates', mountPath: '/templates', readOnly: true },
+                { name: 'tmp', mountPath: '/tmp' },
+              ],
+              command: ['/bin/bash', '-c'],
+              args: [buildAgentReviewApplyScript(ns)],
+              resources: {
+                requests: { cpu: '50m', memory: '64Mi' },
+                limits: { cpu: '500m', memory: '256Mi' },
+              },
+            },
+          ],
+          volumes: [
+            { name: 'templates', configMap: { name: 'app-templates' } },
+            { name: 'tmp', emptyDir: { sizeLimit: '8Mi' } },
+          ],
+        },
+      },
+    },
+  };
+
+  // Idempotency: re-dispatching for the same request must restart cleanly —
+  // delete an existing same-name apply Job first (404 is fine). Mirrors the
+  // review lane. The rendered Deployment/Service are reconciled by `kubectl
+  // apply` inside the script.
+  await k8sFetch(
+    target,
+    `/apis/batch/v1/namespaces/${ns}/jobs/${jobName}?propagationPolicy=Background`,
+    { method: 'DELETE' }
+  ).then(async (r) => {
+    if (!r.ok && r.status !== 404) {
+      const body = await r.text().catch(() => '');
+      throw new Error(`pre-delete agent apply Job ${r.status}: ${body.slice(0, 240)}`);
+    }
+  });
+
+  const res = await k8sFetch(target, `/apis/batch/v1/namespaces/${ns}/jobs`, {
+    method: 'POST',
+    body: JSON.stringify(job),
+  });
+  const created = await unwrap<{ metadata: { name: string } }>(res);
+  return { name: created.metadata.name };
+}
+
+/**
+ * The apply script: envsubst-render `review-agent.yaml.tmpl` + `kubectl apply`.
+ *
+ * SECURITY: unlike the review-sandbox apply script, this deliberately does NOT
+ * `cat` the rendered manifest — it embeds the presigned bundle URL and the
+ * callback bearer, which must not land in the apply-Job logs. There is also no
+ * smoke test (the agent is not an HTTP block image; it pulls a bundle, analyses
+ * it, and POSTs a report). Exported for the orchestration test.
+ */
+export function buildAgentReviewApplyScript(ns: string): string {
+  return `#!/usr/bin/env bash
+set -euo pipefail
+
+# ---- Render the review-agent manifest from /templates/review-agent.yaml.tmpl --
+# envsubst only substitutes EXPORTED env vars; container env vars are already
+# exported into the process env, so AGENT_NAME / PUBLISH_REQUEST_ID / APP_SLUG /
+# BUNDLE_PRESIGNED_URL / CALLBACK_URL / CALLBACK_TOKEN / PRIOR_REPORT_JSON_B64 /
+# COST_CAP_USD all substitute.
+if command -v envsubst >/dev/null 2>&1; then
+  envsubst < /templates/review-agent.yaml.tmpl > /tmp/rendered.yaml
+else
+  sed -e "s|\\\${AGENT_NAME}|\${AGENT_NAME}|g" \\
+      -e "s|\\\${PUBLISH_REQUEST_ID}|\${PUBLISH_REQUEST_ID}|g" \\
+      -e "s|\\\${APP_SLUG}|\${APP_SLUG}|g" \\
+      -e "s|\\\${BUNDLE_PRESIGNED_URL}|\${BUNDLE_PRESIGNED_URL}|g" \\
+      -e "s|\\\${CALLBACK_URL}|\${CALLBACK_URL}|g" \\
+      -e "s|\\\${CALLBACK_TOKEN}|\${CALLBACK_TOKEN}|g" \\
+      -e "s|\\\${PRIOR_REPORT_JSON_B64}|\${PRIOR_REPORT_JSON_B64}|g" \\
+      -e "s|\\\${COST_CAP_USD}|\${COST_CAP_USD}|g" \\
+      /templates/review-agent.yaml.tmpl > /tmp/rendered.yaml
+fi
+
+# Do NOT cat /tmp/rendered.yaml — it contains the presigned URL + callback token.
+echo "agent-review: rendered review-agent.yaml.tmpl for \${AGENT_NAME} (publish-request \${PUBLISH_REQUEST_ID})"
+
+# ---- Apply the review-agent manifest into the namespace ---------------------
+kubectl apply -f /tmp/rendered.yaml
+echo "agent-review: applied objects for \${AGENT_NAME}"
+`;
+}
+
+/**
+ * Tear down an agent-review environment by label selector. Deletes the review-
+ * agent Deployment(s) + Service(s) for a publish request. Best-effort +
+ * idempotent: 404s are ignored, and a single failed resource type does not abort
+ * the rest. NEVER throws — called from the decision-path teardown hook.
+ *
+ * Selector: `civitai.com/role=review-agent,civitai.com/publish-request-id=<id>`.
+ * Scoped to the publish request AND the review-agent role, so it can only ever
+ * match this review's agent objects — never a live app (a live app carries no
+ * `review-agent` role) and never the review-SANDBOX preview (role=... not
+ * review-agent).
+ */
+export async function deleteAgentReviewResources(args: {
+  slug: string;
+  publishRequestId: string;
+}): Promise<void> {
+  let target: Awaited<ReturnType<typeof getDp1Target>>;
+  try {
+    target = await getDp1Target();
+  } catch (err) {
+    // Not in-cluster / no SA token — nothing to tear down. Best-effort: swallow.
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[agent-review] deleteAgentReviewResources: no k8s target: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+    return;
+  }
+  const ns = env.APPS_KUBE_NAMESPACE;
+  const selector = encodeURIComponent(
+    `civitai.com/role=review-agent,civitai.com/publish-request-id=${args.publishRequestId}`
+  );
+
+  // LIST-then-DELETE-by-name (NOT deletecollection) so the feature needs only the
+  // `list` + `delete` RBAC verbs — mirrors deleteReviewResources.
+  const kinds: Array<{
+    label: string;
+    listPath: string;
+    itemPath: (name: string) => string;
+  }> = [
+    {
+      label: 'deployments',
+      listPath: `/apis/apps/v1/namespaces/${ns}/deployments?labelSelector=${selector}`,
+      itemPath: (name) => `/apis/apps/v1/namespaces/${ns}/deployments/${name}`,
+    },
+    {
+      label: 'services',
+      listPath: `/api/v1/namespaces/${ns}/services?labelSelector=${selector}`,
+      itemPath: (name) => `/api/v1/namespaces/${ns}/services/${name}`,
+    },
+  ];
+
+  for (const k of kinds) {
+    try {
+      const listRes = await k8sFetch(target, k.listPath, { method: 'GET' });
+      if (!listRes.ok) {
+        if (listRes.status !== 404) {
+          const body = await listRes.text().catch(() => '');
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[agent-review] deleteAgentReviewResources list ${k.label} ${listRes.status}: ${body.slice(
+              0,
+              160
+            )}`
+          );
+        }
+        continue;
+      }
+      const list = await unwrap<{ items?: Array<{ metadata?: { name?: string } }> }>(listRes);
+      const names = (list?.items ?? [])
+        .map((it) => it?.metadata?.name)
+        .filter((n): n is string => typeof n === 'string' && n.length > 0);
+
+      for (const name of names) {
+        try {
+          const delRes = await k8sFetch(
+            target,
+            `${k.itemPath(name)}?propagationPolicy=Background`,
+            { method: 'DELETE' }
+          );
+          if (!delRes.ok && delRes.status !== 404) {
+            const body = await delRes.text().catch(() => '');
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[agent-review] deleteAgentReviewResources delete ${k.label}/${name} ${delRes.status}: ${body.slice(
+                0,
+                160
+              )}`
+            );
+          }
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[agent-review] deleteAgentReviewResources delete ${k.label}/${name} threw: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        }
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[agent-review] deleteAgentReviewResources ${k.label} threw: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+}

--- a/src/server/services/blocks/agent-review.service.ts
+++ b/src/server/services/blocks/agent-review.service.ts
@@ -1,3 +1,4 @@
+import { TRPCError } from '@trpc/server';
 import { env } from '~/env/server';
 import {
   getDp1Target,
@@ -112,12 +113,28 @@ export async function startAgentReview(
     );
   }
 
-  // Resolve the on-site app key. An UPDATE carries appBlockId (or an AppBlock
-  // exists for the slug). A genuine FIRST version has neither (the AppBlock is
-  // created on approve) — and the report table's app_key XOR CHECK requires
-  // exactly one key, so a first-version review cannot be keyed yet. Fail closed
-  // with a clear message (see the P1 handoff — resolving first-version keying is
-  // a follow-up, e.g. relaxing the XOR to allow a slug key).
+  // Double-provision guard (audit #3): refuse a second dispatch while a review is
+  // already `running` for this request. The partial-unique index
+  // (publish_request_id WHERE status='running') is the DB backstop; this is the
+  // friendly pre-check so the mod gets a clear error instead of a unique-violation.
+  const alreadyRunning = await dbRead.appReviewAgentReport.findFirst({
+    where: { publishRequestId, status: 'running' },
+    select: { id: true },
+  });
+  if (alreadyRunning) {
+    throw new TRPCError({
+      code: 'CONFLICT',
+      message: 'a review is already running for this request',
+    });
+  }
+
+  // Resolve the INFORMATIONAL on-site app key. The report is keyed by the stable
+  // `slug` (present on every request), so this is best-effort: an UPDATE carries
+  // appBlockId, or an AppBlock already exists for the slug; a genuine FIRST
+  // version has neither (the AppBlock is created on approve) → appBlockId stays
+  // null. First-version reviews now persist fine (keyed by slug). External /
+  // connect (oauthClientId) is out of P1 scope — TODO: a later phase keys those
+  // by oauthClientId + kind='external'.
   let appBlockId = request.appBlockId ?? null;
   if (!appBlockId) {
     const existing = await dbRead.appBlock.findFirst({
@@ -125,11 +142,6 @@ export async function startAgentReview(
       select: { id: true },
     });
     appBlockId = existing?.id ?? null;
-  }
-  if (!appBlockId) {
-    throw new Error(
-      'agentic review needs an existing app version to key the report; first-version on-site reviews are not yet supported'
-    );
   }
 
   const sha = request.bundleSha256;
@@ -161,20 +173,25 @@ export async function startAgentReview(
   );
 
   // (c) Prior-version report → base64 JSON for the pod (empty string if none).
+  // Keyed by the stable slug so the chain resolves for a first version too.
   const { getPriorAgentReport } = await import('./app-review-report.service');
-  const prior = await getPriorAgentReport({ appBlockId, version: request.version });
+  const prior = await getPriorAgentReport({ slug: request.slug, version: request.version });
   const priorReportJsonB64 = prior
     ? Buffer.from(JSON.stringify(prior)).toString('base64')
     : '';
 
-  // (d) Insert the running report row (appBlockId XOR oauthClientId — on-site =
-  // appBlockId set, oauthClientId left null).
+  // (d) Insert the running report row. Keyed by `slug` (+ kind='onsite'); the
+  // `appBlockId` column is informational (populated when resolvable, else null —
+  // first versions have none). oauthClientId is left null (external/connect is out
+  // of P1 scope).
   const { newAppReviewAgentReportId } = await import('~/server/utils/app-block-ids');
   const reportId = newAppReviewAgentReportId();
   await dbWrite.appReviewAgentReport.create({
     data: {
       id: reportId,
       publishRequestId,
+      slug: request.slug,
+      kind: 'onsite',
       appBlockId,
       version: request.version,
       bundleSha256: sha,
@@ -189,7 +206,13 @@ export async function startAgentReview(
   // pod. Short-TTL + review-scoped: a leaked token can only touch THIS report.
   const { signAgentCallbackToken } = await import('./review-session');
   const callbackToken = signAgentCallbackToken({ publishRequestId });
-  const callbackUrl = `${(process.env.NEXTAUTH_URL ?? '').replace(
+  // CONTAINMENT: prefer the IN-CLUSTER callback base (AGENT_REVIEW_CALLBACK_BASE_URL)
+  // so the adversarial report + the per-review bearer never leave the cluster onto
+  // the public internet. Falls back to the public NEXTAUTH_URL when the in-cluster
+  // env is unset (keeps working before infra sets it ahead of un-dark). Read from
+  // the VALIDATED env object, never process.env directly.
+  const callbackBase = env.AGENT_REVIEW_CALLBACK_BASE_URL ?? env.NEXTAUTH_URL ?? '';
+  const callbackUrl = `${callbackBase.replace(
     /\/$/,
     ''
   )}/api/internal/blocks/agent-report-callback`;
@@ -199,6 +222,11 @@ export async function startAgentReview(
   // (f) Provision the apply Job. On failure, flip the row to failed so it never
   // lingers `running`, then rethrow.
   try {
+    // COST CEILING (audit #5): enforcement is POD-SIDE only — the runner self-aborts
+    // (status 'cost-capped') once its LLM spend crosses COST_CAP_USD. There is NO
+    // civitai-side spend ceiling in P1 (no per-mod/day budget, no global cap): an
+    // accepted risk while the feature is DARK (mod-only, flag-gated), to revisit
+    // before widening.
     await provisionAgentReviewJob({
       agentName,
       publishRequestId,

--- a/src/server/services/blocks/app-review-report.service.ts
+++ b/src/server/services/blocks/app-review-report.service.ts
@@ -20,6 +20,10 @@ export const APP_REVIEW_AGENT_REPORT_STATUSES = [
   'complete',
   'failed',
   'torn-down',
+  // The runner's cost-cap outcome — persisted verbatim (the callback no longer
+  // collapses it onto `failed`). Like failed/torn-down it is NOT a valid prior
+  // link (only `complete` reports seed the diff chain).
+  'cost-capped',
 ] as const;
 export type AppReviewAgentReportStatus = (typeof APP_REVIEW_AGENT_REPORT_STATUSES)[number];
 
@@ -38,22 +42,23 @@ export async function getAgentReport(
 }
 
 export type GetPriorAgentReportArgs = {
-  appBlockId?: string | null;
-  oauthClientId?: string | null;
+  /** The stable app key (= blockId). Present on every publish request, so a
+   *  first-version review keys + chains correctly. */
+  slug: string;
   /** The version being reviewed now; the prior report must be strictly older. */
   version: string;
 };
 
 /**
- * The most recent `status='complete'` report for the SAME app (identified by
- * `appBlockId` XOR `oauthClientId`) whose version is strictly semver-OLDER than
- * `version` — i.e. the prior link in the chain the next review diffs against.
- * Returns null when the app has no earlier complete report.
+ * The most recent `status='complete'` report for the SAME app (identified by its
+ * stable `slug`) whose version is strictly semver-OLDER than `version` — i.e. the
+ * prior link in the chain the next review diffs against. Returns null when the
+ * app has no earlier complete report.
  *
  * "Most recent" is resolved on the VERSION axis (the greatest version still
  * older than the target), which is the authoritative ordering for the chain;
  * ties (same version re-reviewed) break on `startedAt` desc. The DB does NOT
- * drive this selection: the `(app_key, version)` index only narrows rows to one
+ * drive this selection: the `(slug, version)` index only narrows rows to one
  * app; `status='complete'` is a WHERE filter and the semver ordering is applied
  * IN-APP (the `version` column is lexically, not semver-, ordered, so the
  * ordering can't be pushed into SQL correctly). Only a handful of versions exist
@@ -63,25 +68,17 @@ export type GetPriorAgentReportArgs = {
 export async function getPriorAgentReport(
   args: GetPriorAgentReportArgs
 ): Promise<AppReviewAgentReport | null> {
-  const { appBlockId, oauthClientId, version } = args;
+  const { slug, version } = args;
 
-  const hasBlock = appBlockId != null && appBlockId !== '';
-  const hasClient = oauthClientId != null && oauthClientId !== '';
-  if (hasBlock === hasClient) {
-    // Fail fast on the "exactly one app key" invariant. The DB also enforces it
-    // via the app_key_xor CHECK on the table; this is the friendly caller-side
-    // guard so a bad arg errors here rather than at write time.
-    throw new Error(
-      'getPriorAgentReport requires exactly one of { appBlockId, oauthClientId }'
-    );
+  if (!slug) {
+    // Fail fast on a missing app key — a report cannot chain without one.
+    throw new Error('getPriorAgentReport requires a non-empty slug');
   }
   if (!semver.valid(version)) {
     throw new Error(`getPriorAgentReport: invalid semver version "${version}"`);
   }
 
-  const where = hasBlock
-    ? { appBlockId, status: 'complete' as const }
-    : { oauthClientId, status: 'complete' as const };
+  const where = { slug, status: 'complete' as const };
 
   // Recency-bounded superset of the semver answer: take the N most recently
   // started complete reports. The true semver-latest-older report is always

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1386,6 +1386,10 @@ export async function withdrawRequest(opts: {
     // the outcome. Gated on a preview actually having been started so the common
     // no-preview withdraw does zero extra k8s work.
     if (hadReviewPreview) void teardownReviewForRequest(publishRequestId);
+    // AGENTIC REVIEW (P1, audit #1) — tear down any review AGENT UNCONDITIONALLY:
+    // an agent can run without a sandbox preview, so this must not be gated on
+    // hadReviewPreview. Idempotent no-op when no agent was dispatched.
+    void teardownAgentReviewForRequest(publishRequestId);
     return;
   }
   if (count === 0) {
@@ -1402,6 +1406,8 @@ export async function withdrawRequest(opts: {
       // fire the review teardown (idempotent) in case THIS call observed a
       // preview but a concurrent withdraw committed first without tearing it down.
       if (hadReviewPreview) void teardownReviewForRequest(publishRequestId);
+      // AGENTIC REVIEW (P1, audit #1) — unconditional agent teardown (idempotent).
+      void teardownAgentReviewForRequest(publishRequestId);
       return;
     }
     // Raced into approved/rejected → the not-pending guarantee, now true under
@@ -2684,6 +2690,9 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   // deploy_state BEFORE markRequestDeployState flipped it to production
   // 'building'), so the common no-preview approve does zero extra DB/k8s work.
   if (hadReviewPreview) void teardownReviewForRequest(request.id);
+  // AGENTIC REVIEW (P1, audit #1) — tear down any review AGENT UNCONDITIONALLY
+  // (an agent can run without a sandbox preview). Idempotent no-op otherwise.
+  void teardownAgentReviewForRequest(request.id);
 
   // POST-COMMIT, best-effort — notify the submitting developer their block was
   // approved (and is now building/deploying). This runs AFTER the status flip to
@@ -3397,22 +3406,54 @@ export async function teardownReviewForRequest(publishRequestId: string): Promis
       sha: detail.sha ?? '',
       publishRequestId,
     });
-    // AGENTIC MOD CODE-REVIEW (P1) — also tear down any ephemeral review agent for
-    // this request (label-scoped, best-effort, never throws) and flip any still-
-    // running report row to `torn-down` so a late callback can't resurrect it (the
-    // callback's running-only guard then no-ops). Additive: does not touch the
-    // review-SANDBOX teardown above.
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[teardownReviewForRequest] best-effort teardown failed (id=${publishRequestId}): ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    );
+  }
+}
+
+/**
+ * AGENTIC MOD CODE-REVIEW (P1) — best-effort teardown of any ephemeral review
+ * AGENT for a publish request, DECOUPLED from the sandbox-preview teardown
+ * (audit #1). Called UNCONDITIONALLY on every approve/reject/withdraw — a review
+ * agent can be dispatched WITHOUT ever starting a sandbox preview, so gating this
+ * on `hadReviewPreview` (as the sandbox teardown is) would leak the agent's k8s
+ * objects + a `running` report row + the staged bundle whenever a mod ran only
+ * the agent. Idempotent + label/id-scoped, so it is a no-op when nothing matches.
+ *
+ * Three best-effort steps (order-independent; none throws into the decision path):
+ *   1. delete the review-agent Deployment(s)/Service(s) by label selector,
+ *   2. flip any still-`running` report row → `torn-down` so a late callback can't
+ *      resurrect it (the callback's running-only guard then no-ops),
+ *   3. delete the per-review staged bundle object(s) so staged ZIPs don't
+ *      accumulate (audit #2).
+ * NEVER throws — mirrors teardownReviewForRequest's best-effort contract.
+ */
+export async function teardownAgentReviewForRequest(publishRequestId: string): Promise<void> {
+  try {
+    // (1) agent k8s objects. deleteAgentReviewResources is itself best-effort +
+    // never-throws; its label selector is scoped to publishRequestId + the
+    // review-agent role, so it can only match this review's agent. `slug` is not
+    // part of that selector, so no publish-request lookup is needed here.
     const { deleteAgentReviewResources } = await import('./agent-review.service');
-    void deleteAgentReviewResources({ slug: row.slug, publishRequestId });
+    await deleteAgentReviewResources({ slug: '', publishRequestId });
+    // (2) flip any running report row → torn-down.
     const { dbWrite } = await import('~/server/db/client');
     await dbWrite.appReviewAgentReport.updateMany({
       where: { publishRequestId, status: 'running' },
       data: { status: 'torn-down', completedAt: new Date() },
     });
+    // (3) staged bundle cleanup (best-effort; also lifecycle-backstopped in infra).
+    const { deleteStagedBundle } = await import('~/utils/bundle-s3');
+    await deleteStagedBundle(publishRequestId);
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn(
-      `[teardownReviewForRequest] best-effort teardown failed (id=${publishRequestId}): ${
+      `[teardownAgentReviewForRequest] best-effort teardown failed (id=${publishRequestId}): ${
         err instanceof Error ? err.message : String(err)
       }`
     );
@@ -3817,6 +3858,9 @@ export async function rejectRequest(params: RejectRequestParams): Promise<void> 
   // must never affect the outcome. Gated on a preview actually having been
   // started so the common no-preview reject does zero extra work.
   if (hadReviewPreview) void teardownReviewForRequest(row.id);
+  // AGENTIC REVIEW (P1, audit #1) — tear down any review AGENT UNCONDITIONALLY
+  // (an agent can run without a sandbox preview). Idempotent no-op otherwise.
+  void teardownAgentReviewForRequest(row.id);
 
   // POST-COMMIT, best-effort — notify the submitting developer their block was NOT
   // approved, carrying the (already-trimmed) moderator reason so it shows inline on

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -3435,6 +3435,18 @@ export async function teardownReviewForRequest(publishRequestId: string): Promis
  */
 export async function teardownAgentReviewForRequest(publishRequestId: string): Promise<void> {
   try {
+    const { dbWrite } = await import('~/server/db/client');
+    // Cheap indexed gate: only pay the k8s + MinIO teardown I/O when an agent
+    // review actually ran for this request. Agent reviews are dark/rare, so for
+    // the many mod decisions that never trigger an agent this is a single
+    // indexed read (AppReviewAgentReport is indexed on publish_request_id), not
+    // two network round-trips (k8s LIST+DELETE + MinIO LIST+DELETE) on the live
+    // approve/reject/withdraw path.
+    const existing = await dbWrite.appReviewAgentReport.findFirst({
+      where: { publishRequestId },
+      select: { id: true },
+    });
+    if (!existing) return;
     // (1) agent k8s objects. deleteAgentReviewResources is itself best-effort +
     // never-throws; its label selector is scoped to publishRequestId + the
     // review-agent role, so it can only match this review's agent. `slug` is not
@@ -3442,7 +3454,6 @@ export async function teardownAgentReviewForRequest(publishRequestId: string): P
     const { deleteAgentReviewResources } = await import('./agent-review.service');
     await deleteAgentReviewResources({ slug: '', publishRequestId });
     // (2) flip any running report row → torn-down.
-    const { dbWrite } = await import('~/server/db/client');
     await dbWrite.appReviewAgentReport.updateMany({
       where: { publishRequestId, status: 'running' },
       data: { status: 'torn-down', completedAt: new Date() },

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -3397,6 +3397,18 @@ export async function teardownReviewForRequest(publishRequestId: string): Promis
       sha: detail.sha ?? '',
       publishRequestId,
     });
+    // AGENTIC MOD CODE-REVIEW (P1) — also tear down any ephemeral review agent for
+    // this request (label-scoped, best-effort, never throws) and flip any still-
+    // running report row to `torn-down` so a late callback can't resurrect it (the
+    // callback's running-only guard then no-ops). Additive: does not touch the
+    // review-SANDBOX teardown above.
+    const { deleteAgentReviewResources } = await import('./agent-review.service');
+    void deleteAgentReviewResources({ slug: row.slug, publishRequestId });
+    const { dbWrite } = await import('~/server/db/client');
+    await dbWrite.appReviewAgentReport.updateMany({
+      where: { publishRequestId, status: 'running' },
+      data: { status: 'torn-down', completedAt: new Date() },
+    });
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn(

--- a/src/server/services/blocks/review-session.ts
+++ b/src/server/services/blocks/review-session.ts
@@ -179,3 +179,129 @@ function resolveSecret(): string {
   if (!secret) throw new Error('NEXTAUTH_SECRET is not set');
   return secret;
 }
+
+// ---------------------------------------------------------------------------
+// AGENTIC MOD CODE-REVIEW (App Blocks P1) — per-review callback bearer token.
+//
+// The ephemeral review agent pod posts its report back to the internal
+// `agent-report-callback` route. It authenticates with a per-review bearer token
+// minted HERE and injected into the pod env (CALLBACK_TOKEN) — deliberately NOT
+// the fleet-wide `BLOCK_BUILD_CALLBACK_SECRET` (which must never leave civitai-web
+// onto an untrusted agent pod). The token is bound to the `publishRequestId` and
+// short-lived, so a leaked token can only touch THAT review's report and only for
+// the run window.
+//
+// Same construction as the `mr` entry token above (domain-separated HMAC over
+// NEXTAUTH_SECRET, compact `base64url(payload).base64url(sig)`), but a DISTINCT
+// domain prefix so the two signatures can never be confused, and it binds
+// `publishRequestId` (not a host + mod id).
+// ---------------------------------------------------------------------------
+
+/** Callback-token TTL. Bounds the whole agent run (bundle pull → analysis →
+ *  report POST). 30 min is a generous ceiling for a cost-capped single review. */
+export const AGENT_CALLBACK_TOKEN_TTL_SECONDS = 30 * 60;
+
+/** Domain-separation prefix for the agent report-callback bearer. Bump `v1` if
+ *  the payload shape changes. */
+const AGENT_CALLBACK_DOMAIN_PREFIX = 'agent-report:v1';
+
+type AgentCallbackPayload = {
+  /** publishRequestId the token authorizes a report write for. */
+  p: string;
+  /** Absolute expiry, unix seconds. */
+  exp: number;
+};
+
+/** The domain-separated string HMAC'd for the agent report-callback bearer. */
+function agentCallbackSigningString(payload: AgentCallbackPayload): string {
+  return `${AGENT_CALLBACK_DOMAIN_PREFIX}:${payload.p}:${payload.exp}`;
+}
+
+export type SignAgentCallbackTokenParams = {
+  publishRequestId: string;
+  /** Injected for testability; defaults to env.NEXTAUTH_SECRET. */
+  secret?: string;
+  /** Injected for testability; defaults to AGENT_CALLBACK_TOKEN_TTL_SECONDS. */
+  ttlSeconds?: number;
+};
+
+/**
+ * Mint a compact `base64url(payload).base64url(sig)` bearer bound to a
+ * publishRequestId, valid for `ttlSeconds` (default 30m). Injected into the
+ * review agent pod as CALLBACK_TOKEN.
+ */
+export function signAgentCallbackToken(params: SignAgentCallbackTokenParams): string {
+  const secret = params.secret ?? resolveSecret();
+  const ttl = params.ttlSeconds ?? AGENT_CALLBACK_TOKEN_TTL_SECONDS;
+  const payload: AgentCallbackPayload = {
+    p: params.publishRequestId,
+    exp: nowSec() + ttl,
+  };
+  const payloadB64 = base64url(JSON.stringify(payload));
+  const sigB64 = base64url(hmac(secret, agentCallbackSigningString(payload)));
+  return `${payloadB64}.${sigB64}`;
+}
+
+export type VerifyAgentCallbackTokenResult = {
+  ok: boolean;
+  publishRequestId?: string;
+};
+
+/**
+ * Verify an agent report-callback bearer against the expected publishRequestId.
+ * NEVER throws on malformed input — returns `{ ok:false }`. Checks: parseable
+ * payload + signature, constant-time HMAC match, not expired, and the bound
+ * `publishRequestId` equals `expectedPublishRequestId`.
+ */
+export function verifyAgentCallbackToken(
+  token: string | null | undefined,
+  expectedPublishRequestId: string,
+  opts?: { secret?: string }
+): VerifyAgentCallbackTokenResult {
+  const fail: VerifyAgentCallbackTokenResult = { ok: false };
+  if (!token || typeof token !== 'string') return fail;
+  if (!expectedPublishRequestId) return fail;
+
+  const dot = token.indexOf('.');
+  if (dot <= 0 || dot === token.length - 1) return fail;
+  const payloadB64 = token.slice(0, dot);
+  const sigB64 = token.slice(dot + 1);
+
+  let payload: AgentCallbackPayload;
+  try {
+    const parsed = JSON.parse(base64urlToBuffer(payloadB64).toString('utf8'));
+    if (
+      !parsed ||
+      typeof parsed !== 'object' ||
+      typeof parsed.p !== 'string' ||
+      typeof parsed.exp !== 'number'
+    ) {
+      return fail;
+    }
+    payload = parsed as AgentCallbackPayload;
+  } catch {
+    return fail;
+  }
+
+  let secret: string;
+  try {
+    secret = opts?.secret ?? resolveSecret();
+  } catch {
+    return fail;
+  }
+
+  const expectedSig = hmac(secret, agentCallbackSigningString(payload));
+  let providedSig: Buffer;
+  try {
+    providedSig = base64urlToBuffer(sigB64);
+  } catch {
+    return fail;
+  }
+  if (providedSig.length !== expectedSig.length) return fail;
+  if (!timingSafeEqual(providedSig, expectedSig)) return fail;
+
+  if (payload.exp <= nowSec()) return fail;
+  if (payload.p !== expectedPublishRequestId) return fail;
+
+  return { ok: true, publishRequestId: payload.p };
+}

--- a/src/tests/api/internal/blocks/agent-report-callback.test.ts
+++ b/src/tests/api/internal/blocks/agent-report-callback.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Readable } from 'node:stream';
+
+/**
+ * AGENTIC MOD CODE-REVIEW (App Blocks P1) — POST
+ * /api/internal/blocks/agent-report-callback:
+ *   - per-review BEARER auth (not the shared HMAC) — bad/missing → 401
+ *   - pipeline kill-switch → 503 (dark posture)
+ *   - checkCallbackTimestamp replay window (enforce-if-present)
+ *   - report shape validation + status mapping (cost-capped → failed)
+ *   - UPDATE guarded to status='running' — a torn-down/decided review is a no-op
+ */
+
+const { mockFlag, mockVerify, mockUpdateMany, mockTs } = vi.hoisted(() => ({
+  mockFlag: { enabled: true },
+  mockVerify: vi.fn(
+    (): { ok: boolean; publishRequestId?: string } => ({ ok: true, publishRequestId: 'x' })
+  ),
+  mockUpdateMany: vi.fn(async (_args: { where: unknown; data: any }) => ({ count: 1 })),
+  // Faithful ±300s stand-in for the reused checkCallbackTimestamp.
+  mockTs: vi.fn((ts: unknown) => {
+    if (ts === undefined || ts === null) return { ok: true };
+    if (typeof ts !== 'number' || !Number.isFinite(ts)) return { ok: false, reason: 'bad' };
+    return Math.abs(Math.floor(Date.now() / 1000) - ts) > 300
+      ? { ok: false, reason: 'skew' }
+      : { ok: true };
+  }),
+}));
+
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksPipelineEnabled: vi.fn(async () => mockFlag.enabled),
+}));
+vi.mock('~/server/services/blocks/review-session', () => ({
+  verifyAgentCallbackToken: mockVerify,
+}));
+vi.mock('~/pages/api/internal/blocks/review-build-callback', () => ({
+  checkCallbackTimestamp: mockTs,
+}));
+vi.mock('~/server/db/client', () => ({
+  dbWrite: { appReviewAgentReport: { updateMany: mockUpdateMany } },
+}));
+
+import handler, {
+  buildReportUpdate,
+  persistedStatusFor,
+} from '~/pages/api/internal/blocks/agent-report-callback';
+
+const PUBREQ = 'pubreq_0123456789ABCDEFGHJKMNPQRS';
+
+function makeReqRes(body: string, opts: { method?: string; auth?: string } = {}) {
+  const stream = Readable.from([Buffer.from(body)]) as unknown as NextApiRequest;
+  stream.method = opts.method ?? 'POST';
+  (stream as any).headers = { authorization: opts.auth ?? 'Bearer good.token' };
+  const res = {
+    statusCode: 0,
+    body: undefined as unknown,
+    setHeader() {},
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: unknown) {
+      this.body = payload;
+      return this;
+    },
+  };
+  return { req: stream, res: res as unknown as NextApiResponse & { statusCode: number; body: any } };
+}
+
+const goodBody = (over: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    publishRequestId: PUBREQ,
+    status: 'complete',
+    model: 'anthropic/claude',
+    codeReview: { findings: [] },
+    securityAudit: { high: 0 },
+    scopeVerdicts: { 'apps:storage': 'ok' },
+    summaryMd: '# Looks fine',
+    tokenUsage: { input: 10, output: 20 },
+    costUsd: 0.42,
+    ...over,
+  });
+
+beforeEach(() => {
+  mockFlag.enabled = true;
+  mockVerify.mockReturnValue({ ok: true, publishRequestId: PUBREQ });
+  mockUpdateMany.mockResolvedValue({ count: 1 });
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('persistedStatusFor / buildReportUpdate (pure)', () => {
+  it('maps complete→complete, failed→failed, cost-capped→failed', () => {
+    expect(persistedStatusFor('complete')).toBe('complete');
+    expect(persistedStatusFor('failed')).toBe('failed');
+    expect(persistedStatusFor('cost-capped')).toBe('failed');
+  });
+
+  it('writes the provided structured fields + costUsd', () => {
+    const data = buildReportUpdate(JSON.parse(goodBody()));
+    expect(data).toMatchObject({
+      status: 'complete',
+      model: 'anthropic/claude',
+      codeReview: { findings: [] },
+      securityAudit: { high: 0 },
+      scopeVerdicts: { 'apps:storage': 'ok' },
+      tokenUsage: { input: 10, output: 20 },
+      costUsd: 0.42,
+    });
+    expect(data.completedAt).toBeInstanceOf(Date);
+  });
+
+  it('prepends a cost-cap marker to the summary when cost-capped', () => {
+    const data = buildReportUpdate(JSON.parse(goodBody({ status: 'cost-capped' })));
+    expect(data.status).toBe('failed');
+    expect(String(data.summaryMd)).toContain('cost cap');
+  });
+
+  it('drops a non-finite / negative costUsd', () => {
+    expect(buildReportUpdate(JSON.parse(goodBody({ costUsd: -1 }))).costUsd).toBeUndefined();
+    expect(buildReportUpdate(JSON.parse(goodBody({ costUsd: 'nope' }))).costUsd).toBeUndefined();
+  });
+});
+
+describe('POST /api/internal/blocks/agent-report-callback', () => {
+  it('405 on non-POST', async () => {
+    const { req, res } = makeReqRes(goodBody(), { method: 'GET' });
+    await handler(req, res);
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('400 on invalid JSON', async () => {
+    const { req, res } = makeReqRes('{not json');
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('400 on an invalid publishRequestId', async () => {
+    const { req, res } = makeReqRes(goodBody({ publishRequestId: 'nope' }));
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('401 on a bad/missing bearer', async () => {
+    mockVerify.mockReturnValue({ ok: false });
+    const { req, res } = makeReqRes(goodBody(), { auth: 'Bearer wrong' });
+    await handler(req, res);
+    expect(res.statusCode).toBe(401);
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('verifies the bearer is bound to the body publishRequestId', async () => {
+    const { req, res } = makeReqRes(goodBody());
+    await handler(req, res);
+    expect(mockVerify).toHaveBeenCalledWith('good.token', PUBREQ);
+  });
+
+  it('503 under the pipeline kill-switch (dark)', async () => {
+    mockFlag.enabled = false;
+    const { req, res } = makeReqRes(goodBody());
+    await handler(req, res);
+    expect(res.statusCode).toBe(503);
+    expect(mockUpdateMany).not.toHaveBeenCalled();
+  });
+
+  it('401 on a stale timestamp', async () => {
+    const { req, res } = makeReqRes(goodBody({ ts: 1 }));
+    await handler(req, res);
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('400 on an unknown status', async () => {
+    const { req, res } = makeReqRes(goodBody({ status: 'weird' }));
+    await handler(req, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('200 applied:true — writes the report to the running row', async () => {
+    const { req, res } = makeReqRes(goodBody());
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, applied: true });
+    const args = mockUpdateMany.mock.calls[0][0];
+    expect(args.where).toEqual({ publishRequestId: PUBREQ, status: 'running' });
+    expect(args.data.status).toBe('complete');
+  });
+
+  it('200 applied:false when there is no running row (torn down / decided)', async () => {
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+    const { req, res } = makeReqRes(goodBody());
+    await handler(req, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, applied: false });
+  });
+});

--- a/src/tests/api/internal/blocks/agent-report-callback.test.ts
+++ b/src/tests/api/internal/blocks/agent-report-callback.test.ts
@@ -8,7 +8,7 @@ import { Readable } from 'node:stream';
  *   - per-review BEARER auth (not the shared HMAC) — bad/missing → 401
  *   - pipeline kill-switch → 503 (dark posture)
  *   - checkCallbackTimestamp replay window (enforce-if-present)
- *   - report shape validation + status mapping (cost-capped → failed)
+ *   - report shape validation + status passthrough (cost-capped persisted verbatim)
  *   - UPDATE guarded to status='running' — a torn-down/decided review is a no-op
  */
 
@@ -91,10 +91,10 @@ beforeEach(() => {
 afterEach(() => vi.clearAllMocks());
 
 describe('persistedStatusFor / buildReportUpdate (pure)', () => {
-  it('maps complete→complete, failed→failed, cost-capped→failed', () => {
+  it('persists every runner status verbatim (cost-capped no longer collapses to failed)', () => {
     expect(persistedStatusFor('complete')).toBe('complete');
     expect(persistedStatusFor('failed')).toBe('failed');
-    expect(persistedStatusFor('cost-capped')).toBe('failed');
+    expect(persistedStatusFor('cost-capped')).toBe('cost-capped');
   });
 
   it('writes the provided structured fields + costUsd', () => {
@@ -111,9 +111,9 @@ describe('persistedStatusFor / buildReportUpdate (pure)', () => {
     expect(data.completedAt).toBeInstanceOf(Date);
   });
 
-  it('prepends a cost-cap marker to the summary when cost-capped', () => {
+  it('persists cost-capped verbatim AND prepends a cost-cap marker to the summary', () => {
     const data = buildReportUpdate(JSON.parse(goodBody({ status: 'cost-capped' })));
-    expect(data.status).toBe('failed');
+    expect(data.status).toBe('cost-capped');
     expect(String(data.summaryMd)).toContain('cost cap');
   });
 

--- a/src/utils/bundle-s3.ts
+++ b/src/utils/bundle-s3.ts
@@ -1,4 +1,5 @@
-import { S3Client } from '@aws-sdk/client-s3';
+import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { env } from '~/env/server';
 
 /**
@@ -48,4 +49,50 @@ export function getBundleBucket(): string {
 /** Build the canonical S3 key for a bundle from its content SHA. */
 export function bundleKey(sha256: string): string {
   return `bundles/${sha256}.zip`;
+}
+
+/**
+ * Build the per-review staging key for a bundle reconstructed from Forgejo (the
+ * git-push publish path never uploads a ZIP, so there is no canonical
+ * `bundles/<sha>.zip` object to presign). Kept under a distinct `agent-review/`
+ * prefix so these transient staged objects are trivially lifecycle-expirable and
+ * never collide with the canonical bundle store.
+ */
+export function agentReviewBundleKey(publishRequestId: string, sha256: string): string {
+  return `agent-review/${publishRequestId}-${sha256}.zip`;
+}
+
+/**
+ * Stage a bundle ZIP into the bundle bucket at `key`. Used to persist a
+ * Forgejo-reconstructed bundle so the review agent pod can pull ONE presigned
+ * object (it never talks to Forgejo). Overwrites are fine — the key is content-
+ * addressed by (publishRequestId, sha).
+ */
+export async function stageBundleObject(
+  key: string,
+  body: Buffer,
+  contentType = 'application/zip'
+): Promise<void> {
+  const client = getBundleS3Client();
+  await client.send(
+    new PutObjectCommand({
+      Bucket: getBundleBucket(),
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+    })
+  );
+}
+
+/**
+ * Presign a read-only GET of a bundle object, valid for `ttlSeconds`. The URL is
+ * signed against the IN-CLUSTER MinIO endpoint (BUNDLE_S3_ENDPOINT, e.g.
+ * `http://minio.<ns>.svc.cluster.local`) so it is reachable from a pod's init
+ * curl; it is NOT a public URL. Short TTL bounds exposure of the presigned URL
+ * that is injected into the agent pod env.
+ */
+export async function presignBundleGet(key: string, ttlSeconds: number): Promise<string> {
+  const client = getBundleS3Client();
+  const cmd = new GetObjectCommand({ Bucket: getBundleBucket(), Key: key });
+  return getSignedUrl(client, cmd, { expiresIn: ttlSeconds });
 }

--- a/src/utils/bundle-s3.ts
+++ b/src/utils/bundle-s3.ts
@@ -51,48 +51,31 @@ export function bundleKey(sha256: string): string {
   return `bundles/${sha256}.zip`;
 }
 
-/**
- * Build the per-review staging key for a bundle reconstructed from Forgejo (the
- * git-push publish path never uploads a ZIP, so there is no canonical
- * `bundles/<sha>.zip` object to presign). Kept under a distinct `agent-review/`
- * prefix so these transient staged objects are trivially lifecycle-expirable and
- * never collide with the canonical bundle store.
- */
-export function agentReviewBundleKey(publishRequestId: string, sha256: string): string {
-  return `agent-review/${publishRequestId}-${sha256}.zip`;
+/** Derive a per-review staging key for agent-review bundles. */
+export function agentReviewBundleKey(publishRequestId: string, sha: string): string {
+  return `agent-reviews/${publishRequestId}/${sha}.zip`;
 }
 
-/**
- * Stage a bundle ZIP into the bundle bucket at `key`. Used to persist a
- * Forgejo-reconstructed bundle so the review agent pod can pull ONE presigned
- * object (it never talks to Forgejo). Overwrites are fine — the key is content-
- * addressed by (publishRequestId, sha).
- */
-export async function stageBundleObject(
-  key: string,
-  body: Buffer,
-  contentType = 'application/zip'
-): Promise<void> {
+/** Upload a buffer to the bundle store at the given key. */
+export async function stageBundleObject(key: string, buffer: Buffer): Promise<void> {
   const client = getBundleS3Client();
+  const bucket = getBundleBucket();
   await client.send(
     new PutObjectCommand({
-      Bucket: getBundleBucket(),
+      Bucket: bucket,
       Key: key,
-      Body: body,
-      ContentType: contentType,
+      Body: buffer,
     })
   );
 }
 
-/**
- * Presign a read-only GET of a bundle object, valid for `ttlSeconds`. The URL is
- * signed against the IN-CLUSTER MinIO endpoint (BUNDLE_S3_ENDPOINT, e.g.
- * `http://minio.<ns>.svc.cluster.local`) so it is reachable from a pod's init
- * curl; it is NOT a public URL. Short TTL bounds exposure of the presigned URL
- * that is injected into the agent pod env.
- */
+/** Sign a short-TTL read-only GET URL for a bundle object. */
 export async function presignBundleGet(key: string, ttlSeconds: number): Promise<string> {
   const client = getBundleS3Client();
-  const cmd = new GetObjectCommand({ Bucket: getBundleBucket(), Key: key });
-  return getSignedUrl(client, cmd, { expiresIn: ttlSeconds });
+  const bucket = getBundleBucket();
+  return getSignedUrl(
+    client,
+    new GetObjectCommand({ Bucket: bucket, Key: key }),
+    { expiresIn: ttlSeconds }
+  );
 }

--- a/src/utils/bundle-s3.ts
+++ b/src/utils/bundle-s3.ts
@@ -1,4 +1,10 @@
-import { GetObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import {
+  DeleteObjectCommand,
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { env } from '~/env/server';
 
@@ -67,6 +73,44 @@ export async function stageBundleObject(key: string, buffer: Buffer): Promise<vo
       Body: buffer,
     })
   );
+}
+
+/**
+ * Best-effort delete of the per-review staged bundle object(s) for a publish
+ * request. The git-push review path stages a Forgejo-reconstructed ZIP under
+ * `agent-reviews/<publishRequestId>/<sha>.zip` (see `agentReviewBundleKey`); on
+ * teardown we remove it so staged ZIPs don't accumulate. Keyed by the
+ * `agent-reviews/<publishRequestId>/` prefix (the sha isn't known at teardown,
+ * and a re-review could stage a second sha), so a LIST-then-DELETE sweeps every
+ * staged object for the request.
+ *
+ * NEVER throws — called from the best-effort decision-path teardown. A missing
+ * object / absent config / list error is swallowed (a MinIO bucket
+ * lifecycle-expiry rule on the `agent-reviews/` prefix is the intended infra
+ * backstop — a follow-up, not this PR — so a missed delete self-heals).
+ */
+export async function deleteStagedBundle(publishRequestId: string): Promise<void> {
+  if (!publishRequestId) return;
+  try {
+    const client = getBundleS3Client();
+    const bucket = getBundleBucket();
+    const prefix = `agent-reviews/${publishRequestId}/`;
+    const listed = await client.send(
+      new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix })
+    );
+    const keys = (listed.Contents ?? [])
+      .map((o) => o.Key)
+      .filter((k): k is string => typeof k === 'string' && k.length > 0);
+    for (const Key of keys) {
+      try {
+        await client.send(new DeleteObjectCommand({ Bucket: bucket, Key }));
+      } catch {
+        /* best-effort per-object — lifecycle-expiry backstops a missed delete */
+      }
+    }
+  } catch {
+    /* best-effort — never fail teardown on a staged-object cleanup error */
+  }
 }
 
 /** Sign a short-TTL read-only GET URL for a bundle object. */


### PR DESCRIPTION
## App Blocks agentic mod code-review — P1 provisioning backend (dark)

Builds the civitai side of the agentic review feature: provision an **ephemeral, sandboxed review agent** for a PENDING publish request, receive its structured report over an internal callback, and tear it down on the approve/reject decision. Builds on P0 (`AppReviewAgentReport` model + `getAgentReport` / `getPriorAgentReport`, already on `main`).

### Dark-behind-flag posture
- Gated on the mod-segmented `app-blocks-agentic-review` Flipt flag, evaluated **with** the moderator's context; fail-closed on no-user **and** on absent-flag.
- **The flag does not exist in Flipt yet** — so `isAppBlocksAgenticReviewEnabled` returns `false`, the `startAgentReview` procedure rejects, and nothing is ever provisioned. The whole feature is inert on merge and cannot regress the gate open.
- The machine-to-machine callback additionally honours the existing global pipeline kill-switch (503 when dark) — same fail-safe as the sibling review-build callback.
- Additive only; the existing review-sandbox lane is untouched (this is a parallel, clearly-labelled lane).

### Runtime contract satisfied
The provisioning code creates an apply Job that `envsubst`-renders the already-shipped agent template and applies it, substituting exactly:

| Var | Source |
|---|---|
| `AGENT_NAME` | DNS-label-safe name derived from the request id (≤63 chars, `[a-z0-9-]`) |
| `PUBLISH_REQUEST_ID` | the request id |
| `APP_SLUG` | app slug |
| `BUNDLE_PRESIGNED_URL` | short-TTL read-only GET, signed against the in-cluster object store (reachable from the pod's init curl) |
| `CALLBACK_URL` | internal `agent-report-callback` route on the same base the existing build callback uses |
| `CALLBACK_TOKEN` | per-review short-TTL bearer bound to the request id (**not** the fleet-wide callback secret) |
| `PRIOR_REPORT_JSON_B64` | base64 of the prior-version report JSON (empty when none) |
| `COST_CAP_USD` | per-review spend ceiling, default `"2"` |

The provider API key is **not** passed by civitai (the pod reads it from a namespace secret). Teardown selects the agent's objects by role + request-id label.

### What's here
- **Flag helper**, **provisioning service** (bundle presign / reconstruct-and-stage, prior-report lookup, running-row insert, apply Job, label-scoped teardown), **per-review callback bearer**, **report callback route** (bearer auth, kill-switch, replay window, running-only guarded write), **moderator-gated `startAgentReview` procedure**, and a decision-path teardown hook.
- **Gating is `moderatorProcedure`, not author-facing** — the agent analyses an adversarial bundle and produces mod decision-support; every sibling review op is moderator-gated.
- Unit tests for the flag fail-closed cases, the provisioning flow (ZIP vs reconstruct-from-source source branch, prior-report base64, row insert, Job env shape, idempotent pre-delete, fail-closed guards, provisioning-failure rollback), the callback (bearer accept/reject, kill-switch, running-only guard, field mapping), and the teardown selector.

### Verification
- `tsc --noEmit`: clean for all touched files (only pre-existing, unrelated environmental errors remain).
- 37 new unit tests pass; the 153 existing review-sandbox / orchestration / P0 tests still pass.
- Confirmed dark: flag absent → helper false → procedure rejects; callback 503s under the pipeline kill-switch.

### Follow-ups
- **UI (P2)** and **chat (P3)** are out of scope.
- First-version on-site reviews currently fail closed (a brand-new app has no stable app key yet, and the P0 report table requires exactly one key) — the realistic dogfood path (updates to existing apps) works; keying first-version reviews is a P0-schema follow-up.
- The report table's status set does not include a distinct cost-capped value, so a cost-capped run persists as `failed` with a note in the summary.
