### PR TITLE
fix(donation-goal): fail-open the EA-completion cache side-effects (double-donation guard)

### DIFF
--- a/src/server/services/__tests__/donation-goal.service.test.ts
+++ b/src/server/services/__tests__/donation-goal.service.test.ts
@@ -14,22 +14,33 @@ const { mockDbRead, mockDbWrite } = vi.hoisted(() => {
     mockDbWrite: { donationGoal: mk(), $queryRaw: vi.fn(), $executeRaw: vi.fn() },
   };
 });
-const { mockDonationGoalsBust, mockLogToAxiom } = vi.hoisted(() => ({
+const {
+  mockDonationGoalsBust,
+  mockLogToAxiom,
+  mockBustMvCache,
+  mockDataForModelsRefresh,
+  mockUpdateEaDeadline,
+} = vi.hoisted(() => ({
   mockDonationGoalsBust: vi.fn(),
   mockLogToAxiom: vi.fn(),
+  mockBustMvCache: vi.fn(),
+  mockDataForModelsRefresh: vi.fn(),
+  mockUpdateEaDeadline: vi.fn(),
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
 vi.mock('~/server/redis/caches', () => ({
-  dataForModelsCache: { refresh: vi.fn() },
+  dataForModelsCache: { refresh: mockDataForModelsRefresh },
   modelVersionPublicDonationGoalsCache: { bust: mockDonationGoalsBust },
 }));
 vi.mock('~/server/services/buzz.service', () => ({
   createMultiAccountBuzzTransaction: vi.fn(),
   refundMultiAccountTransaction: vi.fn(),
 }));
-vi.mock('~/server/services/model-version.service', () => ({ bustMvCache: vi.fn() }));
-vi.mock('~/server/services/model.service', () => ({ updateModelEarlyAccessDeadline: vi.fn() }));
+vi.mock('~/server/services/model-version.service', () => ({ bustMvCache: mockBustMvCache }));
+vi.mock('~/server/services/model.service', () => ({
+  updateModelEarlyAccessDeadline: mockUpdateEaDeadline,
+}));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
 
 import { checkDonationGoalComplete } from '~/server/services/donation-goal.service';
@@ -50,7 +61,29 @@ const goal = (over: Record<string, unknown> = {}) => ({
 beforeEach(() => {
   vi.clearAllMocks();
   mockLogToAxiom.mockResolvedValue(undefined);
+  mockUpdateEaDeadline.mockResolvedValue(undefined);
+  mockBustMvCache.mockResolvedValue(undefined);
+  mockDataForModelsRefresh.mockResolvedValue(undefined);
+  mockDonationGoalsBust.mockResolvedValue(undefined);
 });
+
+// Drives the early-access-completion branch: a met goal that is EA-tied and still within its
+// early-access window. `donationGoalById` (called inside checkDonationGoalComplete) does a
+// findUniqueOrThrow + $queryRaw for the total; the branch then updates the goal, reads the
+// modelVersion, runs the EA-deadline $executeRaw, and finally does the two cache side-effects.
+const primeEarlyAccessCompletion = () => {
+  mockDbWrite.donationGoal.findUniqueOrThrow.mockResolvedValueOnce(
+    goal({ isEarlyAccess: true, goalAmount: 1000 })
+  );
+  mockDbWrite.$queryRaw.mockResolvedValueOnce([{ total: 1500 }]); // >= goalAmount → met
+  mockDbWrite.donationGoal.update.mockResolvedValueOnce({});
+  mockDbRead.modelVersion.findUnique.mockResolvedValueOnce({
+    earlyAccessConfig: { timeframe: 7 },
+    earlyAccessEndsAt: new Date('2099-01-01T00:00:00.000Z'), // future → EA still applies
+    modelId: 2,
+  });
+  mockDbWrite.$executeRaw.mockResolvedValueOnce(1);
+};
 
 describe('checkDonationGoalComplete — public cache bust', () => {
   it('busts the public donation-goals cache keyed by modelVersionId after a donation', async () => {
@@ -89,5 +122,86 @@ describe('checkDonationGoalComplete — public cache bust', () => {
     expect(mockLogToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'donation-goal-public-cache-bust-failed' })
     );
+  });
+});
+
+describe('checkDonationGoalComplete — early-access-completion cache side-effects (double-donation guard)', () => {
+  it('runs both EA cache side-effects on completion', async () => {
+    primeEarlyAccessCompletion();
+
+    const result = await checkDonationGoalComplete({ donationGoalId: 10 });
+
+    expect(mockBustMvCache).toHaveBeenCalledWith(5, 2); // (modelVersionId, modelId)
+    expect(mockDataForModelsRefresh).toHaveBeenCalledWith(2);
+    expect(result).toMatchObject({ id: 10, total: 1500, active: false });
+  });
+
+  it('is FAIL-OPEN: a rejecting bustMvCache does NOT reject (never poisons the refund path)', async () => {
+    // bustMvCache does un-wrapped redis work; a transient blip here previously propagated into
+    // donateToGoal's catch → buzz refunded on a committed donation → donor retries → double
+    // donation. It must be swallowed and logged instead.
+    primeEarlyAccessCompletion();
+    mockBustMvCache.mockRejectedValueOnce(new Error('redis down'));
+
+    const result = await checkDonationGoalComplete({ donationGoalId: 10 });
+
+    expect(result).toMatchObject({ id: 10, total: 1500 });
+    expect(mockBustMvCache).toHaveBeenCalledWith(5, 2);
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'donation-goal-ea-cache-refresh-failed' })
+    );
+  });
+
+  it('is FAIL-OPEN: a rejecting dataForModelsCache.refresh does NOT reject', async () => {
+    primeEarlyAccessCompletion();
+    mockDataForModelsRefresh.mockRejectedValueOnce(new Error('redis down'));
+
+    const result = await checkDonationGoalComplete({ donationGoalId: 10 });
+
+    expect(result).toMatchObject({ id: 10, total: 1500 });
+    expect(mockDataForModelsRefresh).toHaveBeenCalledWith(2);
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'donation-goal-ea-cache-refresh-failed' })
+    );
+  });
+
+  it('does NOT swallow the goal-completion DB write ($executeRaw succeeds) — EA cache guard is scoped to the cache ops only', async () => {
+    // The donationGoal.update + $executeRaw EA-deadline writes are legitimate state changes and
+    // must remain OUTSIDE the fail-open guard so a real DB failure still surfaces (see below).
+    primeEarlyAccessCompletion();
+
+    await checkDonationGoalComplete({ donationGoalId: 10 });
+
+    expect(mockDbWrite.donationGoal.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 10 }, data: { active: false } })
+    );
+    expect(mockDbWrite.$executeRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('PROPAGATES a donationGoal.update DB failure (goal-completion write is NOT fail-open)', async () => {
+    // A genuine DB-write failure must still throw — silently dropping goal-completion would be
+    // its own bug, and this path is a legitimate error (distinct from the transient-cache class).
+    mockDbWrite.donationGoal.findUniqueOrThrow.mockResolvedValueOnce(
+      goal({ isEarlyAccess: true, goalAmount: 1000 })
+    );
+    mockDbWrite.$queryRaw.mockResolvedValueOnce([{ total: 1500 }]);
+    mockDbWrite.donationGoal.update.mockRejectedValueOnce(new Error('db write failed'));
+
+    await expect(checkDonationGoalComplete({ donationGoalId: 10 })).rejects.toThrow(
+      'db write failed'
+    );
+    // The cache guard never runs — the DB error short-circuits before the side-effects.
+    expect(mockBustMvCache).not.toHaveBeenCalled();
+  });
+
+  it('PROPAGATES an EA-deadline $executeRaw DB failure (EA-unlock write is NOT fail-open)', async () => {
+    primeEarlyAccessCompletion();
+    mockDbWrite.$executeRaw.mockReset();
+    mockDbWrite.$executeRaw.mockRejectedValueOnce(new Error('executeRaw failed'));
+
+    await expect(checkDonationGoalComplete({ donationGoalId: 10 })).rejects.toThrow(
+      'executeRaw failed'
+    );
+    expect(mockBustMvCache).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/donation-goal.service.ts
+++ b/src/server/services/donation-goal.service.ts
@@ -177,8 +177,27 @@ export const checkDonationGoalComplete = async ({ donationGoalId }: { donationGo
       });
 
       // Ensures user gets access to the resource after purchasing.
-      await bustMvCache(goal.modelVersionId, modelVersion.modelId);
-      await dataForModelsCache.refresh(modelVersion.modelId);
+      //
+      // MUST be fail-open (same reasoning as the public-cache bust below): both ops do
+      // un-wrapped redis/cache work that REJECTS on any transient redis error, and this runs
+      // INSIDE donateToGoal's try AFTER `donation.create` has already committed — that catch
+      // refunds the buzz and throws "Failed to create donation" on ANY throw. So a redis blip
+      // here must NEVER propagate, or the donor is refunded for a persisted donation and retries
+      // → double donation. On failure the caches just serve briefly-stale data, which is
+      // acceptable; the goal-completion + EA-unlock DB writes above have already committed.
+      try {
+        await bustMvCache(goal.modelVersionId, modelVersion.modelId);
+        await dataForModelsCache.refresh(modelVersion.modelId);
+      } catch (error) {
+        logToAxiom({
+          type: 'warning',
+          name: 'donation-goal-ea-cache-refresh-failed',
+          error,
+          donationGoalId,
+          modelVersionId: goal.modelVersionId,
+          modelId: modelVersion.modelId,
+        }).catch(() => undefined);
+      }
     }
   }
 


### PR DESCRIPTION
## The double-donation mechanism

`checkDonationGoalComplete` runs **inside** `donateToGoal`'s `try` block, AFTER `donation.create` has already committed the donation row. `donateToGoal`'s `catch` refunds the buzz and throws `"Failed to create donation"` on **any** error. So any throw from a post-commit operation inside `checkDonationGoalComplete` produces: donation row persists + buzz refunded + donor told it failed → **donor retries → double donation / double charge**.

This is the same class #3238 caught and fixed for the public-cache bust. This PR closes the two remaining un-guarded operations in the same function.

## What was guarded (2 ops)

In the early-access-completion branch (`if (goal.isEarlyAccess && goal.modelVersionId && isGoalMet)`), two non-critical redis/cache side-effects were un-guarded and reject on a transient redis error:

- `await bustMvCache(goal.modelVersionId, modelVersion.modelId)`
- `await dataForModelsCache.refresh(modelVersion.modelId)`

Both are now wrapped in a **fail-open try/catch that logs-and-continues** via `logToAxiom` (`name: 'donation-goal-ea-cache-refresh-failed'`), mirroring the #3238 public-cache-bust guard just below — including the trailing `.catch(() => undefined)` so the logger itself can't throw. On failure the caches serve briefly-stale data; the donation stands. (`updateModelEarlyAccessDeadline` already had its own `.catch`; the public-cache bust below was already guarded by #3238.)

## Why the DB writes are NOT guarded

The two `dbWrite` operations in this branch — `donationGoal.update` (marks the goal complete) and the `$executeRaw` EA-deadline update (unlocks early access) — are **legitimate state changes**, not fail-open candidates. A DB-write failure is a genuine error; silently dropping goal-completion / EA-unlock would be its own bug. They are deliberately left outside the guard so they still propagate. The double-donation risk being closed is specifically the **transient redis/cache** class.

## Structural-fix recommendation (follow-up, not this PR)

The deeper issue is that `checkDonationGoalComplete` runs inside `donateToGoal`'s refund-`try` at all — so even a *legitimate* post-commit DB-write failure (`donationGoal.update` / `$executeRaw`) still triggers a refund of a committed donation. A more robust long-term fix would move `checkDonationGoalComplete` **out** of the refund-`try` (the donation + buzz transaction are already durable at that point), so **no** post-commit side-effect — cache or DB — can refund a committed donation; a completion-side failure would then surface as an error without touching the money that already changed hands. That is a larger behavioral change and out of scope here; this PR does the proportionate, low-risk cache-fail-open fix matching #3238.

## Tests (9 pass: 3 pre-existing + 6 new)

- `bustMvCache` rejects → `checkDonationGoalComplete` still resolves, returns the goal, logs `donation-goal-ea-cache-refresh-failed`.
- `dataForModelsCache.refresh` rejects → same (resolves + logs).
- Both EA cache side-effects run on completion with the right args `(modelVersionId, modelId)` / `(modelId)`.
- The goal-completion DB write + `$executeRaw` still run (guard is scoped to cache ops only).
- `donationGoal.update` DB failure **propagates** (rejects) — completion write is NOT fail-open; cache guard never runs.
- `$executeRaw` EA-deadline DB failure **propagates** (rejects) — EA-unlock write is NOT fail-open.

## Verification

- `vitest run --project unit` on the suite: **9/9 pass**.
- `tsc --noEmit`: **zero new errors** vs `origin/main` (identical error set with the diff reverted).
