### PR TITLE
fix(app-blocks): customComfy submits write durable audit + attribution; dev-token defaults budget to manifest

### DIFF
--- a/src/pages/api/v1/blocks/dev-token.ts
+++ b/src/pages/api/v1/blocks/dev-token.ts
@@ -12,6 +12,7 @@ import {
   clampDevScopes,
   DEV_TOKEN_SCOPE_ALLOWLIST,
   FORCED_SFW_CEILING,
+  parseManifestBuzzBudget,
   resolveDevBuzzBudget,
   signDevScopedPageToken,
 } from '~/server/services/blocks/dev-scoped-mint.service';
@@ -491,6 +492,13 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
     signAppId: string;
     signAppBlockId: string;
     blockInstanceId: string;
+    // The RESOLVED app manifest's declared `page.buzzBudgetPerGen`, used as the
+    // DEFAULT dev-token budget (step 8) when the caller passed no explicit
+    // `buzzBudget`. Set on the approved + pending modes (a manifest is
+    // resolvable); UNDEFINED on the ephemeral no-row mode (no server manifest →
+    // resolveDevBuzzBudget falls back to DEV_BUZZ_BUDGET_DEFAULT). Clamped to
+    // DEV_BUZZ_BUDGET_CAP by resolveDevBuzzBudget regardless.
+    manifestBudgetDefault?: number;
   };
   let resolved: Resolved | null = null;
   // Set ONLY on the local-manifest (pending) path so the structured mint-audit
@@ -550,6 +558,11 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
       // lifetime — otherwise a dev revocation (or a 4h marker) would bleed into
       // production page tokens for the SAME app (collision on `page_<appBlockId>`).
       blockInstanceId: `${PAGE_INSTANCE_PREFIX}${block.id}`,
+      // DEV budget default = the APPROVED manifest's declared per-gen budget so
+      // an app whose `page.buzzBudgetPerGen` exceeds the flat 50 default is
+      // dev-testable without a manual `buzzBudget` request. Clamped to
+      // DEV_BUZZ_BUDGET_CAP by resolveDevBuzzBudget; undefined → the flat default.
+      manifestBudgetDefault: parseManifestBuzzBudget(manifest.page),
     };
   } else if (slug) {
     // 6b. LOCAL-MANIFEST path (Phase 4). Reached ONLY when no owned approved row
@@ -627,6 +640,14 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
         // Stable, BlockRevocation-checkable synthetic instance id derived from the
         // publish-request id (no AppBlock.id to key on).
         blockInstanceId: `${PAGE_INSTANCE_PREFIX}pubreq_${pending.id}`,
+        // DEV budget default = the PENDING request's UN-REVIEWED manifest
+        // `page.buzzBudgetPerGen`. This is a developer-controlled value, but it
+        // only raises the per-call BUDGET (never a spend AUTHORITY): spend is
+        // still bounded by DEV_BUZZ_BUDGET_CAP (the clamp in resolveDevBuzzBudget),
+        // the per-user daily cap, the dev-session cap, and the 7f AIServicesWrite
+        // bearer gate. Mirrors the approved path so a pending recipe with a >50
+        // budget is dev-testable pre-approval without a manual `buzzBudget`.
+        manifestBudgetDefault: parseManifestBuzzBudget(manifest.page),
       };
     } else if (block == null) {
       // 6c. NO-ROW (local-manifest) path (Phase 4 — deferred mode). Reached ONLY
@@ -673,6 +694,16 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
         signAppBlockId: `page_local_${slug}`,
         // Stable, BlockRevocation-checkable synthetic instance id.
         blockInstanceId: `${PAGE_INSTANCE_PREFIX}local_${slug}`,
+        // TODO(ephemeral dev budget): the no-row mode has NO server manifest to
+        // read `page.buzzBudgetPerGen` from — the manifest lives only in the
+        // dev's LOCAL `block.manifest.json`, which the CLI does not send on this
+        // path (only `scopes`/`buzzBudget` cross the wire). So the dev default
+        // stays the flat DEV_BUZZ_BUDGET_DEFAULT here; a dev iterating on a
+        // brand-new (unsubmitted) app whose recipe ceiling exceeds 50 must pass
+        // an explicit `buzzBudget` in the request body (still clamped to
+        // DEV_BUZZ_BUDGET_CAP). To auto-default this mode, the CLI would need to
+        // send the local manifest's `page.buzzBudgetPerGen` in the body — deferred.
+        manifestBudgetDefault: undefined,
       };
     }
   }
@@ -725,7 +756,12 @@ export default withAxiom(async (req: AxiomAPIRequest, res: NextApiResponse) => {
   });
 
   // 8. BUDGET CAP — only meaningful when ai:write:budgeted survived the clamp.
-  const buzzBudget = resolveDevBuzzBudget(granted, requestedBudget);
+  // DEFAULT to the resolved app manifest's `page.buzzBudgetPerGen` (approved +
+  // pending modes) so an app/recipe whose per-gen budget exceeds the flat 50
+  // default is dev-testable WITHOUT a manual `buzzBudget` request; an explicit
+  // caller `requestedBudget` still wins, and DEV_BUZZ_BUDGET_CAP still clamps.
+  // The ephemeral no-row mode carries no manifest default → the flat fallback.
+  const buzzBudget = resolveDevBuzzBudget(granted, requestedBudget, resolved.manifestBudgetDefault);
 
   // 8b. PENDING-PATH MINT AUDIT (FIX 🟡-1). The pending (local-manifest) path is
   // the ONLY mint without durable, queryable audit rows: recordSpendAttribution

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -4693,6 +4693,147 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
     });
   });
 
+  // ── Durable audit + attribution (dogfood follow-up). Before this fix a
+  // successful customComfy generation billed real Buzz but wrote NO
+  // block_scope_invocations row (per-user activity trail) and NO
+  // block_spend_attribution row (author-bounty basis) — the branch early-returned
+  // before both writes. Parity with the txt2img path.
+  describe('submitWorkflow — durable audit + attribution', () => {
+    it('writes a block_scope_invocations row mirroring txt2img (scope + workflow:submit endpoint + ok detail)', async () => {
+      vi.mocked(recordScopeInvocation).mockClear();
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      await vi.waitFor(() => expect(vi.mocked(recordScopeInvocation)).toHaveBeenCalled());
+      expect(vi.mocked(recordScopeInvocation).mock.calls[0][0]).toMatchObject({
+        userId: 42, // from claims.sub
+        appBlockId: 'apb_test',
+        blockInstanceId: 'bki_test',
+        scope: 'ai:write:budgeted',
+        endpoint: 'workflow:submit:wf_cc_1',
+        statusCode: 200,
+        detail: { action: 'workflow.submit', outcome: 'ok' },
+        dev: false, // non-dev page token
+      });
+    });
+
+    it('routes the dev/ephemeral synthetic-app case via dev:true (service writes appBlockId:null + synthetic_app_id)', async () => {
+      // A dev token carries a SYNTHETIC non-FK appBlockId (a pre-approval app has
+      // no AppBlock row). The router passes `dev:true` + the synthetic id so
+      // recordScopeInvocation's FK-fallback persists the row with synthetic_app_id.
+      vi.mocked(recordScopeInvocation).mockClear();
+      mockVerifyBlockToken.mockResolvedValue(
+        ccPageClaims({ dev: true, appBlockId: 'ephemeral-my-recipe' })
+      );
+      happyCcResources();
+      happySubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      await vi.waitFor(() => expect(vi.mocked(recordScopeInvocation)).toHaveBeenCalled());
+      expect(vi.mocked(recordScopeInvocation).mock.calls[0][0]).toMatchObject({
+        appBlockId: 'ephemeral-my-recipe',
+        scope: 'ai:write:budgeted',
+        dev: true,
+      });
+    });
+
+    it('writes a block_spend_attribution TRACK-row with SERVER-DERIVED args (free-floor buzzType, null modelId + sharedContentKey)', async () => {
+      mockRecordSpendAttribution.mockClear();
+      mockVerifyBlockToken.mockResolvedValue(
+        ccPageClaims({
+          appId: 'app_from_token',
+          appBlockId: 'apb_from_token',
+          blockInstanceId: 'bki_from_token',
+        })
+      );
+      happyCcResources();
+      happySubmit(); // no transactions surfaced → conservative free floor (blue)
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      await vi.waitFor(() => expect(mockRecordSpendAttribution).toHaveBeenCalledTimes(1));
+      expect(mockRecordSpendAttribution.mock.calls[0][0]).toMatchObject({
+        userId: 42,
+        appId: 'app_from_token',
+        appBlockId: 'apb_from_token',
+        blockInstanceId: 'bki_from_token',
+        workflowId: 'wf_cc_1',
+        buzzType: 'blue', // free-first floor when no paid debit is surfaced → 0 payout
+        modelId: null, // recipe-based, no single user-picked model
+        sharedContentKey: null, // customComfy body has no sharedContentKey field
+      });
+    });
+
+    it('derives the PAID currency basis (green debit) off the REALIZED transactions', async () => {
+      mockRecordSpendAttribution.mockClear();
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      // Orchestrator surfaces a realized green (payout-eligible) debit.
+      mockSubmitWorkflow.mockResolvedValue({
+        id: 'wf_cc_paid',
+        status: 'processing',
+        steps: [{ $type: 'customComfy', output: { blobs: [] } }],
+        cost: { total: 120 },
+        transactions: { list: [{ type: 'debit', amount: 120, accountType: 'green' }] },
+      });
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      await vi.waitFor(() => expect(mockRecordSpendAttribution).toHaveBeenCalledTimes(1));
+      expect(mockRecordSpendAttribution.mock.calls[0][0]).toMatchObject({
+        buzzType: 'green',
+        buzzAmount: 120,
+        workflowId: 'wf_cc_paid',
+      });
+    });
+
+    it('nets a same-workflow refund out of the paid basis (debit 120 − credit 20 = 100)', async () => {
+      mockRecordSpendAttribution.mockClear();
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      mockSubmitWorkflow.mockResolvedValue({
+        id: 'wf_cc_net',
+        status: 'processing',
+        steps: [{ $type: 'customComfy', output: { blobs: [] } }],
+        cost: { total: 120 },
+        transactions: {
+          list: [
+            { type: 'debit', amount: 120, accountType: 'green' },
+            { type: 'credit', amount: 20, accountType: 'green' },
+          ],
+        },
+      });
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      await vi.waitFor(() => expect(mockRecordSpendAttribution).toHaveBeenCalledTimes(1));
+      expect(mockRecordSpendAttribution.mock.calls[0][0]).toMatchObject({
+        buzzType: 'green',
+        buzzAmount: 100,
+      });
+    });
+
+    it('over-budget static gate returns BEFORE submit → NO scope-invocation, NO attribution', async () => {
+      vi.mocked(recordScopeInvocation).mockClear();
+      mockRecordSpendAttribution.mockClear();
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ buzzBudget: 50 })); // 180 > 50
+      happyCcResources();
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(result.snapshot.status).toBe('failed');
+      // Flush any detached microtasks the happy path would have scheduled.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(vi.mocked(recordScopeInvocation)).not.toHaveBeenCalled();
+      expect(mockRecordSpendAttribution).not.toHaveBeenCalled();
+    });
+
+    it('an attribution write failure NEVER breaks the submit (fire-and-forget)', async () => {
+      mockRecordSpendAttribution.mockClear();
+      mockRecordSpendAttribution.mockRejectedValue(new Error('attribution db down'));
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      // The already-billed submit still returns its snapshot.
+      expect(result.snapshot.workflowId).toBe('wf_cc_1');
+      await vi.waitFor(() => expect(mockRecordSpendAttribution).toHaveBeenCalledTimes(1));
+    });
+  });
+
   // ── F4: dev-tunnel per-session spend backstop on the customComfy branch. Same
   // semantics as the txt2img F4 backstop, but reserves the CEILING (recipe.maxBuzz)
   // and is SETTLED at terminal (the session id rides the settle record), so it is

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5385,6 +5385,11 @@ async function submitCustomComfyWorkflow(opts: {
   // the CEILING (not 0) on ALL reservation keys and re-throw (refund-on-throw,
   // plan §7).
   let snapshot: ReturnType<typeof snapshotFromWorkflow>;
+  // Hoisted out of the try so the post-submit spend-attribution closure (which
+  // runs AFTER the try/catch) can read the REALIZED per-account debit —
+  // `submitted` is a try-block `const` and is out of scope there. Mirrors the
+  // txt2img path (~:3646).
+  let realizedTransactions: Awaited<ReturnType<typeof submitWorkflow>>['transactions'];
   try {
     const stepInput = buildCustomComfyWorkflowInput(recipe, body.params, {});
     const step = createBlockCustomComfyStep(recipe, stepInput);
@@ -5402,6 +5407,7 @@ async function submitCustomComfyWorkflow(opts: {
       },
     });
     snapshot = snapshotFromWorkflow(submitted);
+    realizedTransactions = submitted.transactions;
   } catch (e) {
     await refundBlockBuzzSpend(buzzCapKey, ceiling);
     if (appSpendReserve) {
@@ -5459,7 +5465,149 @@ async function submitCustomComfyWorkflow(opts: {
     }
   }
 
+  // ── Durable audit + attribution (parity with the txt2img path ~:3725,3810).
+  // The customComfy branch early-returned before these writes, so a successful
+  // recipe generation billed real Buzz but left NO durable trail: no
+  // per-user activity row (block_scope_invocations) and no author-bounty basis
+  // (block_spend_attribution). Both are ADDED here, server-derived from the
+  // VERIFIED token claims (never client input), fire-and-forget with each
+  // write's OWN try/catch so an audit failure can never add latency to — or
+  // break — the already-billed submit response.
+
+  // (1) block_scope_invocations — the per-user activity-feed row ("this app ran
+  // a workflow on your behalf"). Fires UNCONDITIONALLY after the submit returns
+  // (even a non-throwing 'failed' snapshot logs, mapped to a 500-ish code),
+  // mirroring the txt2img call. The dev/ephemeral synthetic-app case (a
+  // PRE-APPROVAL app carries a synthetic non-FK `appBlockId`) is handled INSIDE
+  // recordScopeInvocation: `dev` routes the FK-failing insert to the
+  // `appBlockId: null` + `synthetic_app_id` retry so the row persists.
+  {
+    const invocationCost = snapshot.cost?.total ?? ceiling;
+    void (async () => {
+      const { recordScopeInvocation } = await import(
+        '~/server/services/blocks/user-app-surface.service'
+      );
+      await recordScopeInvocation({
+        userId,
+        appBlockId: claims.appBlockId,
+        blockInstanceId: claims.blockInstanceId,
+        scope: 'ai:write:budgeted',
+        endpoint: `workflow:submit:${snapshot.workflowId || 'pending'}`,
+        statusCode: snapshot.status === 'failed' ? 500 : 200,
+        detail: {
+          action: 'workflow.submit',
+          amount:
+            typeof invocationCost === 'number' ? -Math.abs(invocationCost) : undefined,
+          outcome: snapshot.status === 'failed' ? 'failed' : 'ok',
+        },
+        // Dev token → route a synthetic non-FK appBlockId to the nullable-appBlockId
+        // + synthetic_app_id path so the pre-approval audit row persists.
+        dev: claims.dev === true,
+      });
+    })().catch(() => {
+      /* swallowed inside helper */
+    });
+  }
+
+  // (2) block_spend_attribution — the author-bounty spend basis (TRACK-ONLY,
+  // status='tracked' / rate_card_version='unrated' / share=0 today; the payout
+  // rail backpays later). One row per generation that spends the viewer's Buzz,
+  // server-derived from the verified block-JWT (appId/appBlockId/blockInstanceId
+  // from the token, spender from `sub`, author looked up from the app's
+  // OauthClient) — no client-supplied attribution, so it is forge-safe.
+  // Idempotent on (workflowId, appBlockId), so a re-poll/retry can't
+  // double-attribute. Reuses the SAME service the txt2img path uses; the
+  // payout-safe currency basis (paid green/yellow vs free blue) is derived off
+  // the REALIZED per-account debit so a future non-zero share only ever accrues
+  // off the user's PAID portion. For a synthetic/ephemeral appId the OauthClient
+  // lookup misses and the write is inert (caught below), matching txt2img.
+  // customComfy carries no `sharedContentKey` (its wire body is
+  // recipe+params `.strict()`), so the base track-row is written without it.
+  //
+  // Only on a REAL workflow id + non-failed status (a failed/whatif sentinel has
+  // no generation to attribute), mirroring the txt2img guard.
+  const spendWorkflowId = snapshot.workflowId;
+  if (spendWorkflowId && spendWorkflowId !== 'failed' && snapshot.status !== 'failed') {
+    void (async () => {
+      const { recordSpendAttribution } = await import(
+        '~/server/services/blocks/buzz-attribution.service'
+      );
+      const { buzzType, buzzAmount } = deriveBlockSpendBasis(
+        realizedTransactions,
+        isGreen,
+        // Fall back to the realized snapshot cost (then the reserved ceiling)
+        // when no paid debit is surfaced — the conservative FREE floor, which
+        // isPayoutEligibleBuzz EXCLUDES → zero bounty (anti-farming preserved).
+        snapshot.cost?.total ?? ceiling
+      );
+      await recordSpendAttribution({
+        userId,
+        buzzAmount,
+        buzzType,
+        workflowId: spendWorkflowId,
+        appId: claims.appId,
+        appBlockId: claims.appBlockId,
+        blockInstanceId: claims.blockInstanceId,
+        // customComfy is recipe-based (no single user-picked model to attribute).
+        modelId: null,
+        // customComfy has no sharedContentKey field (recipe+params only) → omit.
+        sharedContentKey: null,
+      });
+    })().catch(() => {
+      /* best-effort: a failed attribution write never breaks submit */
+    });
+  }
+
   return { snapshot };
+}
+
+/**
+ * Derive the PAYOUT-SAFE currency basis (buzzType + buzzAmount) for a block
+ * spend-attribution row off the orchestrator's REALIZED per-account
+ * transactions. Mirrors the inline txt2img derivation (~:3871) so a customComfy
+ * generation attributes on the SAME rule without touching that byte-frozen path:
+ *
+ *  - A generation can split across FREE (blue) and PAID (green/yellow) Buzz. The
+ *    orchestrator drains blue FIRST, so `transactions.list` carries one entry
+ *    per charge with `type` (debit/credit), `amount`, and `accountType`.
+ *  - ONLY the paid portion earns — filter to payout-eligible (green/yellow)
+ *    entries, NET debits against same-workflow credits (partial refund /
+ *    correction), and stamp that paid account + net-paid amount.
+ *  - When NO net paid debit is present (blue-only, cache-hit/0-cost, or a
+ *    snapshot returned WITHOUT transactions) fall back to the conservative FREE
+ *    floor (blue + `fallbackCost`), which `isPayoutEligibleBuzz` EXCLUDES → zero
+ *    bounty. Free-Buzz spend can never accrue a bounty; an absent debit never pays.
+ *  - Defensive: if BOTH green and yellow appear (the contract offers only
+ *    ['blue', green|yellow], so at most one paid account is touched today) we
+ *    refuse to conflate them and fall back to the blue floor.
+ *
+ * Forge-safe: `realizedTransactions` is the orchestrator's authoritative
+ * response, never client input.
+ */
+function deriveBlockSpendBasis(
+  realizedTransactions: Awaited<ReturnType<typeof submitWorkflow>>['transactions'],
+  isGreen: boolean,
+  fallbackCost: number
+): { buzzType: BuzzSpendType; buzzAmount: number } {
+  const paidEntries = (realizedTransactions?.list ?? []).filter((t) =>
+    isPayoutEligibleBuzz(t.accountType)
+  );
+  const distinctPaidTypes = new Set(paidEntries.map((t) => t.accountType));
+  const netPaidAmount =
+    distinctPaidTypes.size > 1
+      ? 0
+      : paidEntries.reduce(
+          (sum, t) =>
+            sum + (t.type === 'debit' ? Math.abs(t.amount ?? 0) : -Math.abs(t.amount ?? 0)),
+          0
+        );
+  const hasPaidDebit = distinctPaidTypes.size === 1 && netPaidAmount > 0;
+  const paidType = hasPaidDebit ? (paidEntries[0].accountType as BuzzSpendType) : undefined;
+  // paidType is set iff hasPaidDebit; otherwise the conservative free floor
+  // (getBlockAllowedAccountTypes[0] === 'blue' in both maturity branches).
+  const buzzType: BuzzSpendType = paidType ?? getBlockAllowedAccountTypes(isGreen)[0];
+  const buzzAmount = hasPaidDebit ? netPaidAmount : Math.ceil(fallbackCost);
+  return { buzzType, buzzAmount };
 }
 
 /**

--- a/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
@@ -36,6 +36,7 @@ import {
   DEV_BUZZ_BUDGET_DEFAULT,
   DEV_TOKEN_SCOPE_ALLOWLIST,
   FORCED_SFW_CEILING,
+  parseManifestBuzzBudget,
   resolveDevBuzzBudget,
   REVIEW_MINT_SCOPE_ALLOWLIST,
   signDevScopedPageToken,
@@ -280,9 +281,58 @@ describe('resolveDevBuzzBudget', () => {
     expect(resolveDevBuzzBudget(['ai:write:budgeted'], 100000)).toBe(DEV_BUZZ_BUDGET_CAP);
     expect(resolveDevBuzzBudget(['ai:write:budgeted'], 10)).toBe(10);
   });
-  it('defaults to DEV_BUZZ_BUDGET_DEFAULT when no budget is requested', () => {
+  it('defaults to DEV_BUZZ_BUDGET_DEFAULT when no budget is requested AND no manifest default', () => {
     expect(resolveDevBuzzBudget(['ai:write:budgeted'])).toBe(DEV_BUZZ_BUDGET_DEFAULT);
   });
+
+  // Fix 2 (dogfood follow-up): a recipe/app whose manifest budget exceeds the flat
+  // 50 default must be dev-testable without a manual budget request.
+  it('DEFAULTS to the resolved app manifest budget when present (no explicit request)', () => {
+    // manifest page.buzzBudgetPerGen = 180 (> the flat 50 default) → 180.
+    expect(resolveDevBuzzBudget(['ai:write:budgeted'], undefined, 180)).toBe(180);
+  });
+  it('clamps a manifest default above the CAP to DEV_BUZZ_BUDGET_CAP', () => {
+    expect(resolveDevBuzzBudget(['ai:write:budgeted'], undefined, 100000)).toBe(
+      DEV_BUZZ_BUDGET_CAP
+    );
+  });
+  it('an EXPLICIT requested budget still wins over the manifest default', () => {
+    // requestedBudget (30) takes precedence over the manifest default (180).
+    expect(resolveDevBuzzBudget(['ai:write:budgeted'], 30, 180)).toBe(30);
+  });
+  it('falls back to the flat default when the manifest default is absent (ephemeral no-row mode)', () => {
+    expect(resolveDevBuzzBudget(['ai:write:budgeted'], undefined, undefined)).toBe(
+      DEV_BUZZ_BUDGET_DEFAULT
+    );
+  });
+  it('never mints a budget when ai:write:budgeted was not granted, even with a manifest default', () => {
+    expect(resolveDevBuzzBudget(['user:read:self'], undefined, 180)).toBeUndefined();
+  });
+});
+
+describe('parseManifestBuzzBudget', () => {
+  it('returns the positive-integer page.buzzBudgetPerGen', () => {
+    expect(parseManifestBuzzBudget({ path: '/', buzzBudgetPerGen: 180 })).toBe(180);
+  });
+  it('returns undefined when the field is absent (→ caller uses the flat default)', () => {
+    expect(parseManifestBuzzBudget({ path: '/', title: 'X' })).toBeUndefined();
+  });
+  it.each([
+    ['fractional', 12.5],
+    ['zero', 0],
+    ['negative', -10],
+    ['NaN', Number.NaN],
+    ['Infinity', Number.POSITIVE_INFINITY],
+    ['string', '180' as unknown as number],
+  ])('ignores a %s budget (→ undefined, never flowed through)', (_label, value) => {
+    expect(parseManifestBuzzBudget({ buzzBudgetPerGen: value })).toBeUndefined();
+  });
+  it.each([[null], [undefined], ['not-an-object'], [[1, 2, 3]]])(
+    'returns undefined for a non-object page (%s)',
+    (page) => {
+      expect(parseManifestBuzzBudget(page)).toBeUndefined();
+    }
+  );
 });
 
 describe('signDevScopedPageToken', () => {

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -248,16 +248,50 @@ export function clampTunnelDeclaredScopes(scopeSource: string[]): string[] {
 }
 
 /**
+ * Extract a resolvable manifest page's declared per-generation Buzz budget
+ * (`page.buzzBudgetPerGen`) for use as the DEV-token DEFAULT budget. Returns the
+ * positive integer when the manifest declares a valid one, else `undefined` (the
+ * caller then falls back to `DEV_BUZZ_BUDGET_DEFAULT`). Mirrors the host-mint's
+ * manifest-budget read (`block-tokens/index.ts`): a fractional / NaN / Infinity /
+ * non-positive / non-number value is IGNORED (→ undefined), never flowed through
+ * as a budget. `resolveDevBuzzBudget` still clamps the result to
+ * `DEV_BUZZ_BUDGET_CAP`, so a manifest can raise the dev default UP TO the cap but
+ * never past it. Accepts the raw `manifest.page` value (already narrowed to a
+ * non-null object by the dev-token endpoint's page-block gate, but re-guarded
+ * here so this is safe to call on any input).
+ */
+export function parseManifestBuzzBudget(page: unknown): number | undefined {
+  if (typeof page !== 'object' || page === null || Array.isArray(page)) return undefined;
+  const raw = (page as { buzzBudgetPerGen?: unknown }).buzzBudgetPerGen;
+  return typeof raw === 'number' && Number.isInteger(raw) && raw > 0 ? raw : undefined;
+}
+
+/**
  * BUDGET CAP (dev-token.ts step 8). Only meaningful when `ai:write:budgeted`
- * survived the clamp. Clamp the requested budget (or the default) to the LOWER dev
- * cap; `undefined` when no spend scope was granted.
+ * survived the clamp. Resolve the effective per-call budget and clamp it to the
+ * dev cap; `undefined` when no spend scope was granted.
+ *
+ * Precedence: an EXPLICIT caller-supplied `requestedBudget` (the CLI/body can
+ * always ask for a specific budget) > the RESOLVED app manifest's
+ * `page.buzzBudgetPerGen` (`manifestDefaultBudget`, present for the approved +
+ * pending modes where a manifest is resolvable) > `DEV_BUZZ_BUDGET_DEFAULT` (the
+ * flat platform floor, used only for the ephemeral no-row mode). The
+ * `DEV_BUZZ_BUDGET_CAP` hard ceiling clamps the final value in EVERY case, so a
+ * manifest can only ever raise the dev default UP TO the cap. This is what lets a
+ * recipe/app whose `page.buzzBudgetPerGen` exceeds 50 be dev-tested without a
+ * manual `buzzBudget` request (the flat-50 default previously rejected it with
+ * `ceiling N exceeds budget 50`).
  */
 export function resolveDevBuzzBudget(
   granted: string[],
-  requestedBudget?: number
+  requestedBudget?: number,
+  manifestDefaultBudget?: number
 ): number | undefined {
   return granted.includes('ai:write:budgeted')
-    ? Math.min(requestedBudget ?? DEV_BUZZ_BUDGET_DEFAULT, DEV_BUZZ_BUDGET_CAP)
+    ? Math.min(
+        requestedBudget ?? manifestDefaultBudget ?? DEV_BUZZ_BUDGET_DEFAULT,
+        DEV_BUZZ_BUDGET_CAP
+      )
     : undefined;
 }
 

--- a/src/tests/api/v1/blocks/dev-token.test.ts
+++ b/src/tests/api/v1/blocks/dev-token.test.ts
@@ -637,6 +637,69 @@ describe('POST /api/v1/blocks/dev-token', () => {
     expect(mockSign.mock.calls[0][0].buzzBudget).toBe(250); // DEV_BUZZ_BUDGET_CAP
   });
 
+  // Fix 2 (dogfood follow-up): the dev-token default budget now comes from the
+  // resolved app manifest's `page.buzzBudgetPerGen`, so a recipe/app whose budget
+  // exceeds the flat 50 default is dev-testable WITHOUT a manual buzzBudget.
+  it('DEFAULTS the budget to the APPROVED manifest page.buzzBudgetPerGen when no explicit request', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(
+      pageApp({ manifest: { page: { title: 'X', buzzBudgetPerGen: 180 } } })
+    );
+    const { req, res } = authPost({ appBlockId: 'apb_abc' }); // NO buzzBudget
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign.mock.calls[0][0].buzzBudget).toBe(180);
+  });
+
+  it('clamps an over-cap manifest budget to the dev cap (manifest 5000 → 250)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(
+      pageApp({ manifest: { page: { title: 'X', buzzBudgetPerGen: 5000 } } })
+    );
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign.mock.calls[0][0].buzzBudget).toBe(250); // DEV_BUZZ_BUDGET_CAP
+  });
+
+  it('an EXPLICIT requested budget still wins over the manifest default', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockAppBlockFindUnique.mockResolvedValueOnce(
+      pageApp({ manifest: { page: { title: 'X', buzzBudgetPerGen: 180 } } })
+    );
+    const { req, res } = authPost({ appBlockId: 'apb_abc', buzzBudget: 30 });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign.mock.calls[0][0].buzzBudget).toBe(30);
+  });
+
+  it('falls back to the flat default (50) when the approved manifest omits buzzBudgetPerGen', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    // Default pageApp() manifest has no buzzBudgetPerGen.
+    const { req, res } = authPost({ appBlockId: 'apb_abc' });
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign.mock.calls[0][0].buzzBudget).toBe(50);
+  });
+
+  it('DEFAULTS the budget to the PENDING manifest page.buzzBudgetPerGen (local-manifest mode)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION); // personal key w/ AIServicesWrite
+    // No approved row → pending path; pending manifest declares a >50 budget.
+    mockAppBlockFindUnique.mockResolvedValueOnce(null);
+    mockPublishRequestFindFirst.mockResolvedValueOnce(
+      pendingRequest({
+        manifest: {
+          page: { title: 'X', buzzBudgetPerGen: 200 },
+          scopes: ['ai:write:budgeted', 'user:read:self'],
+        },
+      })
+    );
+    const { req, res } = authPost({ slug: 'my-pending-app' }); // NO buzzBudget
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    expect(mockSign.mock.calls[0][0].buzzBudget).toBe(200);
+  });
+
   it('omits buzzBudget when ai:write:budgeted is not granted', async () => {
     mockGetSession.mockResolvedValueOnce(MOD_SESSION);
     mockAppBlockFindUnique.mockResolvedValueOnce(


### PR DESCRIPTION
## What

Two follow-up fixes to the App Blocks **customComfy** bridge, both surfaced by a live dogfood of #3228 (now on `main`).

### Fix 1 (primary — GA-gate audit gap): customComfy submits wrote no durable audit/attribution rows

The dogfood confirmed a successful customComfy generation billed real Buzz but wrote **no `block_scope_invocations` row** and **no `block_spend_attribution` row** — the `submitCustomComfyWorkflow` handler early-returned before both writes (the txt2img path writes both). Added to the customComfy branch, mirroring txt2img and reusing the same services:

- **`block_scope_invocations`** — the per-user activity-feed row. Fires after the orchestrator submit returns (`scope: 'ai:write:budgeted'`, `endpoint: workflow:submit:<id>`, spend detail, status-mapped code). The dev/ephemeral **synthetic-app** case (a pre-approval app carries a synthetic non-FK `appBlockId`) is handled by passing `dev: true`, so `recordScopeInvocation`'s FK-fallback persists `app_block_id NULL` + `synthetic_app_id`.
- **`block_spend_attribution`** — the author-bounty basis the PR6 author left out of scope. One **track-only** row per generation (`status='tracked'` / `rate_card_version='unrated'` / share 0), server-derived from the verified block-JWT (forge-safe), idempotent on `(workflow_id, app_block_id)`. The payout-safe currency basis (paid green/yellow vs free-first blue floor) is derived off the **realized** per-account debit via a new `deriveBlockSpendBasis` helper, so a future non-zero share only ever accrues off the user's paid portion. customComfy carries no `sharedContentKey` (its wire body is recipe+params `.strict()`), so the base track-row is written without it.

Both are fire-and-forget with their own try/catch. **The txt2img path is byte-unchanged** (additions only — verified: zero deleted lines in `blocks.router.ts`).

### Fix 2 (secondary — DX): dev-token default budget ignored the app's manifest budget

`resolveDevBuzzBudget` defaulted to a flat `DEV_BUZZ_BUDGET_DEFAULT = 50`, so a recipe/app whose manifest `page.buzzBudgetPerGen` exceeds 50 couldn't be dev-tested via dev-token/dev-tunnel without a manual budget request (the dogfood hit `ceiling 180 exceeds budget 50`).

The dev-token mint now **defaults the budget to the resolved app manifest's `page.buzzBudgetPerGen`** (clamped to `DEV_BUZZ_BUDGET_CAP = 250`) when a manifest is resolvable, via a new `parseManifestBuzzBudget` helper threaded through the endpoint's `resolved` object. Precedence: explicit caller `buzzBudget` > manifest `page.buzzBudgetPerGen` > flat `DEV_BUZZ_BUDGET_DEFAULT`. The `DEV_BUZZ_BUDGET_CAP` hard ceiling still clamps in every case.

**Mint-mode handling:**
- **Approved** mode — reads `page.buzzBudgetPerGen` from the approved `AppBlock.manifest`.
- **Pending** mode — reads it from the caller-owned pending request's un-reviewed manifest (raises the per-call budget only; spend authority is still bounded by the cap, the per-user daily cap, the dev-session cap, and the 7f `AIServicesWrite` bearer gate).
- **Ephemeral no-row** mode — no server manifest exists (the local `block.manifest.json` isn't sent on this path), so it keeps the flat default with a clear `TODO` to thread the CLI-sent manifest budget. Callers can still pass `buzzBudget` explicitly.

## Tests

- `blocks.router.workflow.test.ts` — a customComfy submit writes a `block_scope_invocations` row (incl. the dev `synthetic_app_id` case) + a `block_spend_attribution` track-row; paid-debit and net-refund currency-basis derivation; over-budget early-return writes neither; a failing attribution write never breaks submit.
- `dev-scoped-mint.service.test.ts` — `resolveDevBuzzBudget` defaults to the manifest budget (clamped), explicit request wins, falls back to 50 when absent; `parseManifestBuzzBudget` accepts a positive integer and rejects fractional/zero/negative/NaN/Infinity/non-object.
- `dev-token.test.ts` (endpoint) — approved + pending manifest budgets flow through and clamp; explicit request wins; omitted budget falls back to 50.

Touched suites pass: **213 + 34 + 81**. Full `NODE_OPTIONS=--max_old_space_size=8192 tsc --noEmit` runs clean (**0 errors**). The **pr-preview typecheck is the authoritative gate**.

## Notes

- Both issues were **dogfood-caught** against #3228.
- Do not merge yet — awaiting the pr-preview typecheck + review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
