### PR TITLE
test: repair 5 baseline-broken unit suites on main (stale tests, no source regressions)

### DIFF
--- a/src/__tests__/pages/api/mod/adjust-tag-level.test.ts
+++ b/src/__tests__/pages/api/mod/adjust-tag-level.test.ts
@@ -23,10 +23,21 @@ vi.mock('~/server/db/db-helpers', async (importOriginal) => {
   return { ...actual, batchProcessor: vi.fn().mockResolvedValue(undefined) };
 });
 
-vi.mock('~/server/redis/client', () => ({
-  redis: {},
-  REDIS_KEYS: { CACHES: {} },
-}));
+vi.mock('~/server/redis/client', () => {
+  // Recursive key proxy: any nested key path resolves to a string, so
+  // module-eval-time dereferences like `REDIS_SYS_KEYS.NEW_ORDER.JUDGEMENTS.CORRECT`
+  // (used to build top-level counters in the transitively-imported new-order utils)
+  // don't throw. Mirrors the passing sibling orchestration sysredis-soft test.
+  const make = (): any => new Proxy(() => 'k', { get: () => make() });
+  return {
+    // The handler's bustGetTagsCache() → tag.service.bustCacheTag reads a tag's
+    // key-set via redis.sMembers then redis.del's each — provide benign no-op
+    // implementations so that (real, un-mocked) bust path completes.
+    redis: { sMembers: vi.fn().mockResolvedValue([]), del: vi.fn().mockResolvedValue(0) },
+    REDIS_KEYS: make(),
+    REDIS_SYS_KEYS: make(),
+  };
+});
 
 vi.mock('~/server/utils/endpoint-helpers', () => ({
   WebhookEndpoint: (handler: Function) => handler,
@@ -39,6 +50,11 @@ vi.mock('~/env/server', () => ({
       if (prop === 'IS_BUILD') return false;
       if (prop === 'LOGGING') return [];
       if (prop.endsWith('URL') || prop.endsWith('_URL') || prop.endsWith('ENDPOINT')) return 'http://localhost:3000';
+      // Numeric-config env vars (e.g. MEILI_CALL_CONCURRENCY) are consumed at
+      // module-eval time by pLimit()/limiter setup in the transitively-imported
+      // service graph and MUST be positive numbers — a string 'mock-value' throws
+      // ("Expected concurrency to be a number from 1 and up").
+      if (prop.endsWith('CONCURRENCY') || prop.endsWith('LIMIT') || prop.endsWith('TIMEOUT')) return 4;
       return 'mock-value';
     },
   }),

--- a/src/server/services/__tests__/block-registry.resolve-dev.test.ts
+++ b/src/server/services/__tests__/block-registry.resolve-dev.test.ts
@@ -155,15 +155,17 @@ describe('BlockRegistry.resolveDevPageBlockForAuthor', () => {
     mockDbRead.appBlock.findUnique.mockResolvedValue(null);
     mockDbRead.appBlockPublishRequest.findFirst.mockResolvedValue({
       submittedByUserId: 555,
-      // Includes page-forbidden + non-allowlisted scopes — the clamp must strip them.
+      // Includes a non-tunnel-allowlisted + an unknown scope — the clamp strips them.
       manifest: {
         scopes: ['ai:write:budgeted', 'buzz:read:self', 'social:tip:self', 'not:a:scope'],
       },
     });
     const res = await BlockRegistry.resolveDevPageBlockForAuthor('money-pending', 555);
-    // Clamp = TUNNEL allowlist − PAGE_FORBIDDEN, + force-granted user:read:self, sorted.
-    // buzz:read:self / social:tip:self are page-forbidden; not:a:scope is unknown.
-    expect(res?.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+    // Clamp = TUNNEL allowlist ∩ known − PAGE_FORBIDDEN, + force-granted user:read:self, sorted.
+    // PAGE_FORBIDDEN_SCOPES is now empty (#3103): buzz:read:self is a page-safe,
+    // low-sensitivity self-balance read and IS in the tunnel allowlist, so it
+    // survives. social:tip:self is NOT in the tunnel allowlist; not:a:scope is unknown.
+    expect(res?.scopes).toEqual(['ai:write:budgeted', 'buzz:read:self', 'user:read:self']);
     expect(res?.ephemeralSource).toBe('pending');
   });
 

--- a/src/server/services/__tests__/contest-entry-resource-gate.test.ts
+++ b/src/server/services/__tests__/contest-entry-resource-gate.test.ts
@@ -105,7 +105,17 @@ function wireChallengeFindFirst(opts: { hasResourceChallenge: boolean; hasFeeCha
     }
     if ('maxParticipants' in where) return null; // no participant cap configured
     if (where.source === 'User') {
-      return opts.hasFeeChallenge ? { id: 1, entryFee: 100, buzzType: 'yellow' } : null;
+      // The fee-challenge lookup (collection.service.ts) is distinguished by `entryFee`
+      // in its where clause; select: { id, entryFee, buzzType }.
+      if ('entryFee' in where) {
+        return opts.hasFeeChallenge ? { id: 1, entryFee: 100, buzzType: 'yellow' } : null;
+      }
+      // Otherwise this is the assertUserChallengeAcceptingEntries timing gate
+      // (challenge-entry-gate.ts), which runs BEFORE the resource gate and rejects
+      // unless the user challenge is Active. Return an Active challenge so execution
+      // reaches the resource gate under test. ('Active' is ChallengeStatus.Active —
+      // the same literal collection.service uses.)
+      return { status: 'Active' };
     }
     return null;
   });

--- a/src/server/services/__tests__/system-cache.sysredis-soft.test.ts
+++ b/src/server/services/__tests__/system-cache.sysredis-soft.test.ts
@@ -16,6 +16,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * `withSysReadDeadline(...)` wrap were removed the caller would hang and the
  * test would TIME OUT. A resolved-get mock would pass even without the wrap,
  * so it wouldn't guard the SLOW protection.
+ *
+ * NOTE: `getBrowsingSettingAddons` + `getLiveFeatureFlags` are fronted by a
+ * MODULE-SCOPE in-proc TTL memo (createTtlMemo, added in #3183). That single
+ * slot persists across tests within one module instance, so a prior happy-path
+ * read would otherwise bleed its cached value into the DOWN/SLOW fail-open
+ * assertions here. Each test therefore re-imports system-cache after
+ * `vi.resetModules()` to start from a FRESH (empty) memo slate — the same
+ * isolation pattern used by `system-cache.memoize.test.ts`. Because the source
+ * default constants are re-evaluated on that fresh import, the fail-open
+ * assertions compare with `toStrictEqual` (structural), not `toBe` (which would
+ * demand cross-module-instance reference identity that resetModules precludes).
  */
 
 const { mockGet, mockWithSysReadDeadline, mockLogSysRedisFailOpen } = vi.hoisted(() => ({
@@ -44,13 +55,14 @@ vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: mockLogSys
 // test touches the DB on these paths).
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 
-import {
-  getBrowsingSettingAddons,
-  getCreationBlockedTags,
-  getLiveFeatureFlags,
-} from '~/server/services/system-cache';
 import { DEFAULT_BROWSING_SETTINGS_ADDONS } from '~/shared/constants/browsing-settings-addons';
 import { DEFAULT_LIVE_FEATURE_FLAGS } from '~/server/common/constants';
+
+// Fresh module (fresh in-proc memos) per test — see file header note.
+async function loadSystemCache() {
+  vi.resetModules();
+  return import('~/server/services/system-cache');
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -59,6 +71,7 @@ beforeEach(() => {
 
 describe('getBrowsingSettingAddons — sysRedis soft-dependency', () => {
   it('happy path: returns the parsed cached value through withSysReadDeadline, no fail-open', async () => {
+    const { getBrowsingSettingAddons } = await loadSystemCache();
     const addons = [{ type: 'setting', nsfwLevels: [1], excludedFromDefaultBrowsingLevel: false }];
     mockGet.mockResolvedValue(JSON.stringify(addons));
 
@@ -70,11 +83,12 @@ describe('getBrowsingSettingAddons — sysRedis soft-dependency', () => {
   });
 
   it('DOWN: get throws → fails open to defaults, does not throw, logs read-degraded', async () => {
+    const { getBrowsingSettingAddons } = await loadSystemCache();
     mockGet.mockRejectedValue(new Error('sysRedis connection is down'));
 
     const result = await getBrowsingSettingAddons();
 
-    expect(result).toBe(DEFAULT_BROWSING_SETTINGS_ADDONS);
+    expect(result).toStrictEqual(DEFAULT_BROWSING_SETTINGS_ADDONS);
     expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
     const [subtype, fn] = mockLogSysRedisFailOpen.mock.calls[0];
     expect(subtype).toBe('read-degraded');
@@ -82,12 +96,13 @@ describe('getBrowsingSettingAddons — sysRedis soft-dependency', () => {
   });
 
   it('SLOW/half-open: get NEVER settles + deadline REJECTS → fails open (fail-on-revert)', async () => {
+    const { getBrowsingSettingAddons } = await loadSystemCache();
     mockGet.mockReturnValue(new Promise(() => undefined));
     mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
 
     const result = await getBrowsingSettingAddons();
 
-    expect(result).toBe(DEFAULT_BROWSING_SETTINGS_ADDONS);
+    expect(result).toStrictEqual(DEFAULT_BROWSING_SETTINGS_ADDONS);
     expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
     expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
     expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');
@@ -96,6 +111,7 @@ describe('getBrowsingSettingAddons — sysRedis soft-dependency', () => {
 
 describe('getCreationBlockedTags — sysRedis soft-dependency (adjacent sibling)', () => {
   it('happy path: returns the parsed+filtered blocked tags through withSysReadDeadline, no fail-open', async () => {
+    const { getCreationBlockedTags } = await loadSystemCache();
     const tags = [
       { id: 1, name: 'blocked-a' },
       { id: 2, name: 'blocked-b' },
@@ -110,6 +126,7 @@ describe('getCreationBlockedTags — sysRedis soft-dependency (adjacent sibling)
   });
 
   it('DOWN: get throws → fails open to empty list, does not throw, logs defaults-firing', async () => {
+    const { getCreationBlockedTags } = await loadSystemCache();
     mockGet.mockRejectedValue(new Error('ECONNREFUSED'));
 
     const result = await getCreationBlockedTags();
@@ -122,6 +139,7 @@ describe('getCreationBlockedTags — sysRedis soft-dependency (adjacent sibling)
   });
 
   it('SLOW/half-open: get NEVER settles + deadline REJECTS → fails open to empty (fail-on-revert)', async () => {
+    const { getCreationBlockedTags } = await loadSystemCache();
     mockGet.mockReturnValue(new Promise(() => undefined));
     mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
 
@@ -140,6 +158,7 @@ describe('getCreationBlockedTags — sysRedis soft-dependency (adjacent sibling)
 // parking ~11min.
 describe('getLiveFeatureFlags — sysRedis soft-dependency (STEP-6)', () => {
   it('happy path: returns the parsed cached value through withSysReadDeadline, no fail-open', async () => {
+    const { getLiveFeatureFlags } = await loadSystemCache();
     const flags = { ...DEFAULT_LIVE_FEATURE_FLAGS };
     mockGet.mockResolvedValue(JSON.stringify(flags));
 
@@ -151,11 +170,12 @@ describe('getLiveFeatureFlags — sysRedis soft-dependency (STEP-6)', () => {
   });
 
   it('DOWN: get throws → fails open to defaults, does not throw, logs read-degraded', async () => {
+    const { getLiveFeatureFlags } = await loadSystemCache();
     mockGet.mockRejectedValue(new Error('sysRedis connection is down'));
 
     const result = await getLiveFeatureFlags();
 
-    expect(result).toBe(DEFAULT_LIVE_FEATURE_FLAGS);
+    expect(result).toStrictEqual(DEFAULT_LIVE_FEATURE_FLAGS);
     expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
     const [subtype, fn] = mockLogSysRedisFailOpen.mock.calls[0];
     expect(subtype).toBe('read-degraded');
@@ -163,12 +183,13 @@ describe('getLiveFeatureFlags — sysRedis soft-dependency (STEP-6)', () => {
   });
 
   it('SLOW/half-open: get NEVER settles + deadline REJECTS → fails open to defaults (fail-on-revert)', async () => {
+    const { getLiveFeatureFlags } = await loadSystemCache();
     mockGet.mockReturnValue(new Promise(() => undefined));
     mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
 
     const result = await getLiveFeatureFlags();
 
-    expect(result).toBe(DEFAULT_LIVE_FEATURE_FLAGS);
+    expect(result).toStrictEqual(DEFAULT_LIVE_FEATURE_FLAGS);
     expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
     expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
     expect(mockLogSysRedisFailOpen.mock.calls[0][0]).toBe('read-degraded');

--- a/src/server/services/__tests__/tag.service.security.test.ts
+++ b/src/server/services/__tests__/tag.service.security.test.ts
@@ -19,7 +19,13 @@ vi.mock('~/server/redis/client', () => ({
   REDIS_KEYS: { SYSTEM: { TAG_RULES: 't', CATEGORIES: 'c' } },
   REDIS_SYS_KEYS: { SYSTEM: {} },
 }));
-vi.mock('~/server/redis/caches', () => ({ imageTagsCache: { bust: vi.fn() } }));
+vi.mock('~/server/redis/caches', () => ({
+  imageTagsCache: { bust: vi.fn() },
+  // tag.service now reads/busts the votable-tags cache (#3223) from add/remove/delete
+  // vote paths under test — provide fetch + bust so those paths don't hit an
+  // undefined cache export.
+  modelVotableTagsCache: { fetch: vi.fn().mockResolvedValue([]), bust: vi.fn() },
+}));
 vi.mock('~/server/services/system-cache', () => ({
   getCategoryTags: vi.fn(),
   getReplacedTagIds: vi.fn(),
@@ -31,7 +37,15 @@ vi.mock('~/server/services/user-preferences.service', () => ({
   HiddenModels: { refreshCache: vi.fn() },
   ImplicitHiddenImages: { refreshCache: vi.fn() },
 }));
-vi.mock('~/server/utils/cache-helpers', () => ({ fetchThroughCache: vi.fn() }));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  fetchThroughCache: vi.fn(),
+  // tag.service now builds a module-scope read-through cache at import time via
+  // `queryCache(dbRead, 'getTags', 'v1')` (#3239) — queryCache returns the cached
+  // query runner, so the mock returns a callable. bustCacheTag is used by the
+  // getTags cache-busting helper.
+  queryCache: vi.fn(() => vi.fn()),
+  bustCacheTag: vi.fn(),
+}));
 
 import { addTagVotes, removeTagVotes, deleteTags } from '../tag.service';
 


### PR DESCRIPTION
## Summary

This was a **real baseline break on `main`**: 5 unit suites fail on current HEAD (`12bb0b880f`), confirmed by running each. Every failure root-causes to a **stale test** that an intentional source change (mostly recent perf work) outgrew — **no source regressions were found, and no source files are changed**. All fixes are test-only.

Verified locally with vitest: **all 5 suites pass (46 tests)**.

## Per-suite root cause, verdict, and fix

### 1. `block-registry.resolve-dev.test.ts` — assertion divergence → **stale test**
`#3103` intentionally emptied `PAGE_FORBIDDEN_SCOPES` (`[]` now, documented in `slot-registry.ts`): `buzz:read:self` is a page-safe, low-sensitivity self-balance read and IS in `TUNNEL_HOST_MINT_SCOPE_ALLOWLIST`, so it survives the dev-tunnel scope clamp. `social:tip:self` is not in the tunnel allowlist; `not:a:scope` is unknown.
- **Before:** `expected [ 'ai:write:budgeted', …(2) ] to deeply equal [ 'ai:write:budgeted', …(1) ]`
- **Fix:** updated the (d2) expectation to `['ai:write:budgeted', 'buzz:read:self', 'user:read:self']` (+ comment).
- **After:** 26 passed.

### 2. `system-cache.sysredis-soft.test.ts` — **stale test** (isolation broken by `#3183`)
`#3183` (perf) added an in-proc `createTtlMemo` layer to `getBrowsingSettingAddons`/`getLiveFeatureFlags`. That single module-scope slot persists across tests, so the happy-path read's cached value bled into the following DOWN/SLOW fail-open assertions (fail-open never fired). Source is correct in production. `getCreationBlockedTags` (no memo) was unaffected — its 3 tests passed.
- **Before:** 4 failed — e.g. `expected [ { type: 'setting', … } ] to strictly equal [ { type: 'none', … } ]` (leftover happy-path value).
- **Fix:** adopted the codebase's existing memo-isolation pattern — `vi.resetModules()` + per-test dynamic `import` (identical to `system-cache.memoize.test.ts`) — and switched the defaults assertions from `toBe` to `toStrictEqual` (resetModules re-evaluates the source constants, so cross-instance reference identity is impossible; structural equality is the meaningful invariant).
- **After:** 9 passed.

### 3. `contest-entry-resource-gate.test.ts` — **stale test**
A new earlier gate `assertUserChallengeAcceptingEntries` (`challenge-entry-gate.ts`, called from `collection.service` **before** the resource gate under test) rejects unless the user challenge is `Active`. Its `challenge.findFirst({ where: { collectionId, source: User } })` collided with the test's dispatch `where.source === 'User'` branch, which returned the fee-challenge object (no `status`) → `status` undefined → the gate threw `"Challenge is starting shortly…"` before the resource gate ran.
- **Before:** 4 failed — `expected [Function] to throw error including 'This image does not use a required mo…' but got 'Challenge is starting shortly…'`.
- **Fix:** split the dispatch — the fee query (distinguished by `entryFee` in its `where`, per `collection.service.ts:1927`) is unchanged; the timing-gate query (`source: User`, no `entryFee`) now returns `{ status: 'Active' }` (the same `'Active'` literal `collection.service` uses), so execution reaches the resource gate.
- **After:** 4 passed.

### 4. `tag.service.security.test.ts` — **stale mocks**
`tag.service` added a top-level `queryCache(dbRead, 'getTags', 'v1')` (`#3239`) and `modelVotableTagsCache` usage (`#3223`); the test mocks weren't updated.
- **Before:** fails to collect — `No "queryCache" export is defined on the "~/server/utils/cache-helpers" mock`; then `No "modelVotableTagsCache" export is defined on the "~/server/redis/caches" mock`.
- **Fix:** added `queryCache`/`bustCacheTag` to the cache-helpers mock and `modelVotableTagsCache` to the caches mock, with benign defaults matching the real export shapes.
- **After:** 4 passed.

### 5. `adjust-tag-level.test.ts` — **stale mocks**
The transitively-imported graph (via `tag.service`) now dereferences `REDIS_SYS_KEYS`/`REDIS_KEYS` at module-eval (new-order counters, resource-data keys), requires a numeric `MEILI_CALL_CONCURRENCY` (`pLimit`), and the handler's new `bustGetTagsCache()` (`#3239`) calls `redis.sMembers`/`del`.
- **Before:** fails to collect — `No "REDIS_SYS_KEYS" export is defined on the "~/server/redis/client" mock` (the documented break), plus follow-on module-eval gaps once that's fixed.
- **Fix:** made `REDIS_KEYS`/`REDIS_SYS_KEYS` recursive key proxies (mirroring the passing orchestration sysredis-soft test), returned numbers for `*CONCURRENCY`/`*LIMIT`/`*TIMEOUT` env vars, and gave `redis` benign `sMembers`/`del` stubs.
- **After:** 3 passed.

## Regressions left for a human?

**None.** Every suite was a stale test outgrown by an intentional, well-documented source change (verified via `git log`/`git show` for each: `#3103`, `#3183`, the challenge-entry gate, `#3239`, `#3223`). I did not find a case where the source violated an invariant the test correctly encoded, so nothing is masked and nothing is left failing.

Note: local verification borrowed the Prisma client + `event-engine-common` from a sibling clone; the generic Prisma engine surfaces a `could not locate Query Engine for "linux-nixos"` warning on suite 5 — that is env-only (not a test/code failure) and the suite still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
