### PR TITLE
fix(flipt-skill): speak Flipt v2, refuse writes, correct the token docs

### DIFF
--- a/.claude/skills/flipt/.env.example
+++ b/.claude/skills/flipt/.env.example
@@ -9,7 +9,7 @@ FLIPT_URL=https://flipt.civitai.com
 
 # Traefik ingress bypass header — NOT a Flipt credential and NOT read-only.
 # Flipt runs with authentication.required: false behind this, so anything that
-# reaches it has full API access, including the git-backed write path that can
+# reaches it has full API access, including a git-backed write path that may
 # push straight to civitai/flipt-state main. Treat as a live secret.
 # Change flags by PR to that repo, not through the API.
 FLIPT_API_TOKEN=your-bypass-header-here

--- a/.claude/skills/flipt/.env.example
+++ b/.claude/skills/flipt/.env.example
@@ -7,11 +7,17 @@
 # The base URL of your Flipt instance
 FLIPT_URL=https://flipt.civitai.com
 
-# Flipt API token
-# A token with read/write access to manage flags
-# For read-only operations, use the fetcher token
-# For write operations, you need an admin token
-FLIPT_API_TOKEN=your-api-token-here
+# Traefik ingress bypass header — NOT a Flipt credential and NOT read-only.
+# Flipt runs with authentication.required: false behind this, so anything that
+# reaches it has full API access, including the git-backed write path that can
+# push straight to civitai/flipt-state main. Treat as a live secret.
+# Change flags by PR to that repo, not through the API.
+FLIPT_API_TOKEN=your-bypass-header-here
+
+# Optional — skip runtime discovery of the environment / namespace.
+# Discovery picks the environment marked default:true, then its "default" namespace.
+# FLIPT_ENVIRONMENT=civitai-app
+# FLIPT_NAMESPACE=default
 
 # Git state repository (optional, for reference)
 # The repository where Flipt stores flag definitions

--- a/.claude/skills/flipt/SKILL.md
+++ b/.claude/skills/flipt/SKILL.md
@@ -31,9 +31,10 @@ so merge → visible takes up to ~30s).
 Writes are blocked by choice, not by capability. There is **no Flipt auth at
 all** — the `Authorization: Bearer` value in `.env` is a Traefik ingress bypass
 header, not a Flipt credential, and Flipt applies no authz behind it. The pod
-holds an SSH deploy key for `flipt-state`, so a v2 write against a git-backed
-environment can **commit and push to `main` directly**. That bypasses review on
-a file gating production behavior, which is why this skill refuses. Change flags
+holds an SSH deploy key for `flipt-state`, and v2's git-write model implies a
+write would **commit and push to `main` directly** — inferred from the manifest,
+not observed. A write path that *may* bypass review on a file gating production
+is reason enough to refuse either way, which is why this skill does. Change flags
 by PR to `civitai/flipt-state`.
 
 Treat that bearer value as a real secret: read it from env, never inline it, and

--- a/.claude/skills/flipt/SKILL.md
+++ b/.claude/skills/flipt/SKILL.md
@@ -21,13 +21,36 @@ node .claude/skills/flipt/flipt.mjs <command> [options]
 |---------|-------------|
 | `list` | List all flags |
 | `get <key>` | Get details for a specific flag |
-| `create <key>` | Create a new flag (boolean by default) |
-| `enable <key>` | Enable a flag (set to true) |
-| `disable <key>` | Disable a flag (set to false) |
-| `delete <key>` | Delete a flag (requires confirmation) |
-| `add-variant <flag> <variant>` | Add a variant to an existing flag |
-| `remove-variant <flag> <variant>` | Remove a variant from a flag |
-| `set-rollout <flag> <variant>` | Set rollout rule for a variant |
+| `create` / `enable` / `disable` / `delete` | Refuse with exit 2 and print the GitOps steps — see below |
+| `add-variant` / `remove-variant` / `set-rollout` | Same |
+
+**Reads work over the API; writes are deliberately refused.** This Flipt is
+**v2** (v2.10.0), GitOps-backed by `civitai/flipt-state` (`poll_interval: 30s`,
+so merge → visible takes up to ~30s).
+
+Writes are blocked by choice, not by capability. There is **no Flipt auth at
+all** — the `Authorization: Bearer` value in `.env` is a Traefik ingress bypass
+header, not a Flipt credential, and Flipt applies no authz behind it. The pod
+holds an SSH deploy key for `flipt-state`, so a v2 write against a git-backed
+environment can **commit and push to `main` directly**. That bypasses review on
+a file gating production behavior, which is why this skill refuses. Change flags
+by PR to `civitai/flipt-state`.
+
+Treat that bearer value as a real secret: read it from env, never inline it, and
+don't copy it into anything new.
+
+Flags live at `/api/v2/environments/{env}/namespaces/{ns}/resources/flipt.core.Flag`.
+The environment (`civitai-app`) and namespace (`default`) are discovered at
+runtime — the environment marked `default: true`, then its `default` namespace —
+so a second environment can't silently redirect reads. Override with
+`FLIPT_ENVIRONMENT` / `FLIPT_NAMESPACE` if ever needed.
+
+Responses carry a `revision` equal to the `flipt-state` commit SHA, which is the
+quickest way to confirm a flag change has actually synced:
+
+```bash
+node .claude/skills/flipt/flipt.mjs list --json | head -3   # revision == your commit
+```
 
 ### Options
 
@@ -53,23 +76,9 @@ node .claude/skills/flipt/flipt.mjs list
 # Get a specific flag
 node .claude/skills/flipt/flipt.mjs get gift-card-vendor-waifu-way
 
-# Create a new flag (disabled by default)
-node .claude/skills/flipt/flipt.mjs create my-new-feature -d "Enable new feature for testing"
-
-# Create a flag that's enabled immediately
-node .claude/skills/flipt/flipt.mjs create my-feature --enabled -d "Already enabled feature"
-
-# Enable a flag
-node .claude/skills/flipt/flipt.mjs enable my-new-feature
-
-# Disable a flag
-node .claude/skills/flipt/flipt.mjs disable my-new-feature
-
-# Delete a flag (with confirmation)
-node .claude/skills/flipt/flipt.mjs delete old-flag
-
-# Delete without confirmation
-node .claude/skills/flipt/flipt.mjs delete old-flag --force
+# Creating / toggling a flag goes through GitOps — see below.
+# These commands exit 2 and print the steps:
+node .claude/skills/flipt/flipt.mjs disable my-feature
 
 # JSON output for scripting
 node .claude/skills/flipt/flipt.mjs list --json
@@ -116,7 +125,7 @@ flags:
 
 ## Safety Notes
 
-1. **API changes are temporary**: The Git repo is the source of truth
+1. **Do not write through the API**: it pushes an unreviewed commit to `flipt-state` main
 2. **Test before enabling**: Use segments for gradual rollout
 3. **Coordinate with team**: Others may be editing the same flags
 

--- a/.claude/skills/flipt/flipt.mjs
+++ b/.claude/skills/flipt/flipt.mjs
@@ -184,15 +184,18 @@ async function apiRequest(method, path, body = null) {
 }
 
 // Every write here previously POSTed to /api/v1/*, which does not exist on v2.
-// They are not repointed at v2 on purpose. There is no Flipt auth behind the
-// ingress, and a v2 write against a git-backed environment commits and pushes
-// to civitai/flipt-state main using the pod's deploy key — so a "quick toggle"
-// would silently land an unreviewed commit on a file gating production.
+// They are not repointed at v2 on purpose. Confirmed from the talos-infra
+// manifest: no Flipt auth behind the ingress, a git-backed environment, and an
+// SSH deploy key for civitai/flipt-state mounted into the pod. That a write
+// would commit to that repo follows from v2's git-write model — inferred, not
+// observed. A write path that MIGHT push an unreviewed commit to a file gating
+// production is reason enough to refuse either way.
 function refuseWrite(action, key) {
   console.error(`Cannot ${action} "${key}" through the API.`);
   console.error('');
-  console.error('civitai/flipt-state is the source of truth. An API write here would not');
-  console.error('fail — it would push an unreviewed commit to that repo. Open a PR instead.');
+  console.error('civitai/flipt-state is the source of truth, and this instance is git-backed');
+  console.error('with a deploy key — an API write may push an unreviewed commit there.');
+  console.error('Open a PR instead.');
   console.error('');
   console.error('  gh repo clone civitai/flipt-state /tmp/flipt-state');
   console.error('  # edit civitai-app/default/features.yaml');
@@ -496,7 +499,7 @@ Examples:
 
 Note: this Flipt is v2 and GitOps-backed. Reads (list/get) hit the API; every
 write command refuses and prints the civitai/flipt-state workflow instead.
-Writes are refused by choice, not capability — an API write would push an
+Writes are refused by choice, not capability — an API write may push an
 unreviewed commit straight to that repo's main.
 
 Env: FLIPT_URL, FLIPT_API_TOKEN. Optionally FLIPT_ENVIRONMENT / FLIPT_NAMESPACE

--- a/.claude/skills/flipt/flipt.mjs
+++ b/.claude/skills/flipt/flipt.mjs
@@ -123,6 +123,43 @@ for (let i = 0; i < args.length; i++) {
   }
 }
 
+// Flipt v2 addresses flags as resources under an environment + namespace, and
+// this instance is GitOps-backed (flags live in civitai/flipt-state). The v1
+// /api/v1/flags endpoints this skill used to call 404 on v2.
+let _context = null;
+
+async function fliptContext() {
+  if (_context) return _context;
+
+  const envKey = process.env.FLIPT_ENVIRONMENT;
+  const nsKey = process.env.FLIPT_NAMESPACE;
+  if (envKey && nsKey) return (_context = { envKey, nsKey });
+
+  // Discovered rather than hardcoded so a second environment can't silently
+  // send every read to the wrong place.
+  const { environments = [] } = await apiRequest('GET', '/api/v2/environments');
+  const env =
+    environments.find((e) => e.key === envKey) ??
+    environments.find((e) => e.default) ??
+    environments[0];
+  if (!env) throw new Error('No Flipt environments available');
+
+  const { items = [] } = await apiRequest(
+    'GET',
+    `/api/v2/environments/${env.key}/namespaces`
+  );
+  const ns = items.find((n) => n.key === nsKey) ?? items.find((n) => n.key === 'default') ?? items[0];
+  if (!ns) throw new Error(`No namespaces in Flipt environment "${env.key}"`);
+
+  return (_context = { envKey: env.key, nsKey: ns.key });
+}
+
+async function flagsPath(key) {
+  const { envKey, nsKey } = await fliptContext();
+  const base = `/api/v2/environments/${envKey}/namespaces/${nsKey}/resources/flipt.core.Flag`;
+  return key ? `${base}/${encodeURIComponent(key)}` : base;
+}
+
 async function apiRequest(method, path, body = null) {
   const url = `${FLIPT_URL}${path}`;
   const options = {
@@ -146,8 +183,33 @@ async function apiRequest(method, path, body = null) {
   return data;
 }
 
+// Every write here previously POSTed to /api/v1/*, which does not exist on v2.
+// They are not repointed at v2 on purpose. There is no Flipt auth behind the
+// ingress, and a v2 write against a git-backed environment commits and pushes
+// to civitai/flipt-state main using the pod's deploy key — so a "quick toggle"
+// would silently land an unreviewed commit on a file gating production.
+function refuseWrite(action, key) {
+  console.error(`Cannot ${action} "${key}" through the API.`);
+  console.error('');
+  console.error('civitai/flipt-state is the source of truth. An API write here would not');
+  console.error('fail — it would push an unreviewed commit to that repo. Open a PR instead.');
+  console.error('');
+  console.error('  gh repo clone civitai/flipt-state /tmp/flipt-state');
+  console.error('  # edit civitai-app/default/features.yaml');
+  console.error('  cd /tmp/flipt-state && git add -A && git commit && git push');
+  console.error('');
+  console.error('Flag entry format:');
+  console.error('  - key: my-flag');
+  console.error('    name: my-flag');
+  console.error('    type: BOOLEAN_FLAG_TYPE');
+  console.error('    description: what it controls');
+  console.error('    enabled: false');
+  process.exit(2);
+}
+
 async function listFlags() {
-  const data = await apiRequest('GET', '/api/v1/flags');
+  const { resources = [], revision } = await apiRequest('GET', await flagsPath());
+  const data = { flags: resources.map((r) => r.payload), revision };
 
   if (jsonOutput) {
     console.log(JSON.stringify(data, null, 2));
@@ -171,13 +233,13 @@ async function listFlags() {
 }
 
 async function getFlag(key) {
-  // Flipt API doesn't support individual flag lookup well, so filter from list
-  const allFlags = await apiRequest('GET', '/api/v1/flags');
-  const data = allFlags.flags?.find(f => f.key === key);
-
-  if (!data) {
+  let data;
+  try {
+    ({ resource: { payload: data } = {} } = await apiRequest('GET', await flagsPath(key)));
+  } catch (err) {
     throw new Error(`Flag not found: ${key}`);
   }
+  if (!data) throw new Error(`Flag not found: ${key}`);
 
   if (jsonOutput) {
     console.log(JSON.stringify(data, null, 2));
@@ -230,6 +292,7 @@ async function getFlag(key) {
 }
 
 async function createFlag(key, desc, isEnabled) {
+  refuseWrite('create', key);
   const flagType = isVariant ? 'VARIANT_FLAG_TYPE' : 'BOOLEAN_FLAG_TYPE';
   try {
     const data = await apiRequest('POST', '/api/v1/flags', {
@@ -288,6 +351,7 @@ ${variantYaml}
 }
 
 async function addVariant(flagKey, variantKey) {
+  refuseWrite('add a variant to', flagKey);
   const data = await apiRequest('POST', `/api/v1/flags/${flagKey}/variants`, { key: variantKey, default: false });
   if (jsonOutput) { console.log(JSON.stringify(data, null, 2)); return; }
   console.log(`✓ Added variant "${variantKey}" to flag: ${flagKey}`);
@@ -295,6 +359,7 @@ async function addVariant(flagKey, variantKey) {
 }
 
 async function removeVariant(flagKey, variantKey) {
+  refuseWrite('remove a variant from', flagKey);
   const allFlags = await apiRequest('GET', '/api/v1/flags');
   const flag = allFlags.flags?.find(f => f.key === flagKey);
   if (!flag) throw new Error(`Flag not found: ${flagKey}`);
@@ -308,6 +373,7 @@ async function removeVariant(flagKey, variantKey) {
 }
 
 async function setRollout(flagKey, variantKey) {
+  refuseWrite('set a rollout on', flagKey);
   const allFlags = await apiRequest('GET', '/api/v1/flags');
   const flag = allFlags.flags?.find(f => f.key === flagKey);
   if (!flag) throw new Error(`Flag not found: ${flagKey}`);
@@ -326,6 +392,7 @@ async function setRollout(flagKey, variantKey) {
 }
 
 async function updateFlag(key, isEnabled) {
+  refuseWrite('update', key);
   // First verify the flag exists
   const allFlags = await apiRequest('GET', '/api/v1/flags');
   const current = allFlags.flags?.find(f => f.key === key);
@@ -364,6 +431,7 @@ async function updateFlag(key, isEnabled) {
 }
 
 async function deleteFlag(key) {
+  refuseWrite('delete', key);
   if (!force) {
     console.error(`Warning: This will delete flag "${key}"`);
     console.error('Use --force to skip this confirmation');
@@ -426,8 +494,14 @@ Examples:
   node .claude/skills/flipt/flipt.mjs set-rollout my-feature 2 --rollout 100
   node .claude/skills/flipt/flipt.mjs add-variant my-feature 3
 
-Note: Write operations require an admin token. If you have a read-only token,
-use the GitOps workflow by editing the civitai/flipt-state repository.`);
+Note: this Flipt is v2 and GitOps-backed. Reads (list/get) hit the API; every
+write command refuses and prints the civitai/flipt-state workflow instead.
+Writes are refused by choice, not capability — an API write would push an
+unreviewed commit straight to that repo's main.
+
+Env: FLIPT_URL, FLIPT_API_TOKEN. Optionally FLIPT_ENVIRONMENT / FLIPT_NAMESPACE
+to skip auto-discovery (defaults to the environment marked default, namespace
+"default").`);
 }
 
 async function main() {


### PR DESCRIPTION
The `flipt` skill was speaking v1 to a v2 server, so every read 404'd — `list` and `get` failed against flags that plainly existed, and the CLI reported `environment: "" not found`. Found while trying to verify the `buzz-transaction-export` kill switch from #3255.

## Reads

v2 addresses flags as resources under an environment and namespace:

```
/api/v2/environments/{env}/namespaces/{ns}/resources/flipt.core.Flag[/{key}]
```

Both are **discovered at runtime** (environment marked `default: true`, then its `default` namespace) rather than hardcoded — in v2 the routing key is `environments.<key>.name`, not the YAML map key, and the two are kept in sync by hand, so discovery is safer than pinning. `FLIPT_ENVIRONMENT` / `FLIPT_NAMESPACE` override. Nothing is pinned to a 2.10-exact shape, since Flux lands patch releases automatically within 12h.

Responses carry a `revision` equal to the `flipt-state` commit SHA — the quickest way to confirm a flag change has actually synced (~30s poll interval).

## Writes are refused, deliberately

Not repointed at v2. **Confirmed** from the talos-infra manifest: there is no Flipt auth behind the ingress, the environment is git-backed, and an SSH deploy key for `civitai/flipt-state` is mounted into the pod. **Inferred, not observed:** that a v2 write therefore commits and pushes to that repo's `main`. That follows from v2's documented git-write model, but nobody has watched it happen and we're not going to find out against production.

The guard holds under either reading — a write path that *may* land an unreviewed commit on a file gating production behavior is reason enough to refuse. Write commands exit 2 and print the PR workflow.

## Docs

`.env.example` described `FLIPT_API_TOKEN` as a "read-only fetcher token" that "cannot create/modify" flags. It is neither: it's a Traefik ingress bypass header, and Flipt applies no authz behind it. Both halves were wrong in the dangerous direction, so the comments now say what it actually is and that it should be treated as a live secret.

## Testing

```
get buzz-transaction-export  -> renders, exit 0
list                         -> 94 flags, exit 0
list --json                  -> revision matches the flipt-state SHA
get <nonexistent>            -> "Flag not found", exit 1
disable <flag>               -> refuses with GitOps steps, exit 2 (no API call made)
node --check                 -> clean
```

No writes were issued against production Flipt at any point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)