### PR TITLE
feat(apps): agentic review modal UI + report rendering (P2, dark)

### DIFF
--- a/src/components/Apps/AgentReviewPanel.browser.test.tsx
+++ b/src/components/Apps/AgentReviewPanel.browser.test.tsx
@@ -27,6 +27,9 @@ const mocks = vi.hoisted(() => ({
   // Report row returned by getAgentReview (null = no report yet → Run button).
   agentReport: null as unknown,
   agentLoading: false,
+  // Consecutive failed-poll count surfaced by react-query (drives the ceiling).
+  agentFailureCount: 0,
+  refetch: vi.fn().mockResolvedValue(undefined),
   // getReviewStatus poll data for the sibling ReviewPreviewPanel (kept inert).
   reviewStatus: undefined as unknown,
   // Per-mutation error injected into the NEXT mutate() call's onError.
@@ -105,7 +108,13 @@ vi.mock('~/utils/trpc', () => {
         getAgentReview: {
           useQuery: (_input: unknown, opts: { refetchInterval?: (q: unknown) => unknown }) => {
             mocks.lastAgentOpts = opts;
-            return { data: mocks.agentReport, isLoading: mocks.agentLoading, error: null };
+            return {
+              data: mocks.agentReport,
+              isLoading: mocks.agentLoading,
+              error: null,
+              failureCount: mocks.agentFailureCount,
+              refetch: mocks.refetch,
+            };
           },
         },
         startAgentReview: { useMutation: mutation('startAgentReview') },
@@ -205,6 +214,8 @@ beforeEach(() => {
   mocks.flags = { appBlocks: true, appBlocksAgenticReview: true };
   mocks.agentReport = null;
   mocks.agentLoading = false;
+  mocks.agentFailureCount = 0;
+  mocks.refetch.mockClear();
   mocks.reviewStatus = undefined;
   mocks.mutationError = undefined;
   mocks.pending = false;
@@ -345,6 +356,37 @@ describe('AgentReviewPanel — lifecycle states', () => {
     renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
     await expect.element(page.getByText(/Review was torn down/)).toBeInTheDocument();
     await expect.element(page.getByRole('button', { name: 'Run again' })).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POLL CEILING — manual "Check again" fallback
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPanel — poll ceiling / manual refresh', () => {
+  test('a stuck `running` run past the error ceiling pauses auto-refresh and offers "Check again", which refetches', async () => {
+    // Still `running`, but the poll has been failing consecutively past the
+    // threshold → auto-refresh is paused (no spinner) and a manual affordance shows.
+    mocks.agentReport = { status: 'running' };
+    mocks.agentFailureCount = 3; // >= MAX_CONSECUTIVE_POLL_ERRORS
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+
+    await expect.element(page.getByText(/automatic updates paused/)).toBeInTheDocument();
+    // The spinning "Analyzing…" state is NOT shown while paused.
+    expect(page.getByText(/^Analyzing/).elements()).toHaveLength(0);
+
+    // Clicking "Check again" triggers a refetch (resuming the poll).
+    await page.getByRole('button', { name: 'Check again' }).click();
+    expect(mocks.refetch).toHaveBeenCalled();
+  });
+
+  test('a single transient poll failure does NOT pause — the spinner keeps showing', async () => {
+    mocks.agentReport = { status: 'running' };
+    mocks.agentFailureCount = 1; // 1 < MAX_CONSECUTIVE_POLL_ERRORS → keep polling
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+    await expect.element(page.getByText(/Analyzing/)).toBeInTheDocument();
+    expect(page.getByText(/automatic updates paused/).elements()).toHaveLength(0);
+    expect(page.getByRole('button', { name: 'Check again' }).elements()).toHaveLength(0);
   });
 });
 

--- a/src/components/Apps/AgentReviewPanel.browser.test.tsx
+++ b/src/components/Apps/AgentReviewPanel.browser.test.tsx
@@ -1,0 +1,456 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * AGENTIC MOD CODE-REVIEW panel (App Blocks P2) — browser-mode component tests.
+ *
+ * Covers:
+ *  - the render GATE (through OnsiteReviewModal): off when the client flag is
+ *    off, off for mode!=='pending', off for external/connect, ON for onsite
+ *    pending + flag on;
+ *  - the trigger (Run agentic review → startAgentReview) incl. the CONFLICT
+ *    "already running" path handled without crashing;
+ *  - the lifecycle states (running spinner + poll wiring, complete/cost-capped
+ *    render, failed + rerun, torn-down note);
+ *  - full report rendering (code findings, security findings, the three must-flag
+ *    callouts, the scope table incl. over-broad/under-declared, sensitive badge,
+ *    evidence file:line);
+ *  - defensive/empty rendering ("None found", no throw);
+ *  - the stored-XSS-at-render guard (adversarial markup renders as inert TEXT).
+ */
+
+const mocks = vi.hoisted(() => ({
+  // Client feature flags returned by the mocked provider (gate tests vary this).
+  flags: { appBlocks: true, appBlocksAgenticReview: true } as Record<string, boolean>,
+  // Report row returned by getAgentReview (null = no report yet → Run button).
+  agentReport: null as unknown,
+  agentLoading: false,
+  // getReviewStatus poll data for the sibling ReviewPreviewPanel (kept inert).
+  reviewStatus: undefined as unknown,
+  // Per-mutation error injected into the NEXT mutate() call's onError.
+  mutationError: undefined as { message: string; data?: { code?: string } } | undefined,
+  pending: false,
+  mutate: vi.fn(),
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  // Captures the options passed to getAgentReview.useQuery so poll wiring is asserted.
+  lastAgentOpts: undefined as { refetchInterval?: (q: unknown) => unknown } | undefined,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => mocks.flags,
+}));
+
+// Stub the review host bridge (only reached by the sibling live-preview branch).
+vi.mock('~/components/Apps/ReviewBlockPreviewHost', () => ({
+  ReviewBlockPreviewHost: () => <div data-testid="review-host-stub" />,
+}));
+
+const showError = vi.fn();
+const showSuccess = vi.fn();
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: (...a: unknown[]) => showSuccess(...a),
+  showErrorNotification: (...a: unknown[]) => showError(...a),
+}));
+
+vi.mock('~/utils/trpc', () => {
+  const mutation =
+    (name: string) =>
+    (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
+      mutate: (vars: unknown) => {
+        mocks.mutate(name, vars);
+        if (mocks.mutationError) opts?.onError?.(mocks.mutationError);
+        else void opts?.onSuccess?.();
+      },
+      mutateAsync: vi.fn(),
+      isPending: mocks.pending,
+    });
+  const inert = { invalidate: mocks.invalidate };
+  const utils = {
+    blocks: {
+      listPendingRequests: inert,
+      listApprovedRequests: inert,
+      listRejectedRequests: inert,
+      getReviewStatus: inert,
+      listActivePreviews: inert,
+      getAgentReview: inert,
+      getMarketplaceMeta: inert,
+      getFeaturedBlocks: inert,
+      listAvailable: inert,
+    },
+  };
+  return {
+    trpc: {
+      useUtils: () => utils,
+      blocks: {
+        approveRequest: { useMutation: mutation('approve') },
+        rejectRequest: { useMutation: mutation('reject') },
+        getReviewStatus: {
+          useQuery: () => ({ data: mocks.reviewStatus, isLoading: false, error: null }),
+        },
+        previewRequest: { useMutation: mutation('preview') },
+        teardownPreview: { useMutation: mutation('teardown') },
+        getPublishRequestScreenshots: {
+          useQuery: () => ({ data: { items: [] }, isLoading: false, error: null }),
+        },
+        getPublishRequestDiff: {
+          useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+        },
+        getMarketplaceMeta: {
+          useQuery: () => ({ data: undefined, isLoading: false, isError: false, error: null }),
+        },
+        setMarketplaceMeta: { useMutation: mutation('setMeta') },
+        // P2 additions.
+        getAgentReview: {
+          useQuery: (_input: unknown, opts: { refetchInterval?: (q: unknown) => unknown }) => {
+            mocks.lastAgentOpts = opts;
+            return { data: mocks.agentReport, isLoading: mocks.agentLoading, error: null };
+          },
+        },
+        startAgentReview: { useMutation: mutation('startAgentReview') },
+      },
+    },
+  };
+});
+
+const { AgentReviewPanel, AGENT_REVIEW_POLL_MS } = await import('./AgentReviewPanel');
+const { OnsiteReviewModal } = await import('./OnsiteReviewModal');
+
+const ONSITE_PENDING = {
+  id: 'onsite-req-1',
+  appBlockId: null as string | null,
+  slug: 'my-onsite-block',
+  version: '1.2.0',
+  submittedAt: new Date('2026-01-01T00:00:00Z'),
+  bundleSizeBytes: '2048',
+  bundleSha256: 'abcdef0123456789abcdef0123456789',
+  manifest: {
+    name: 'My Onsite Block',
+    blockId: 'blk_1',
+    version: '1.2.0',
+    scopes: ['user:read'],
+    targets: [{ slotId: 'model.sidebar_top', priority: 10 }],
+  },
+  fileSummary: { files: [], added: [], removed: [], changed: [] },
+  manifestDiffSummary: { kind: 'first-version', fields: ['name'] },
+  reviewRepoUrl: 'https://forgejo.example/repo',
+  pushCommitUrl: null as string | null,
+  submittedBy: { id: 7, username: 'dev-user', image: null },
+};
+
+const ONSITE_APPROVED = {
+  ...ONSITE_PENDING,
+  id: 'onsite-req-2',
+  reviewedAt: new Date('2026-01-02T00:00:00Z'),
+  approvalNotes: 'looks good',
+  reviewedBy: { id: 99, username: 'mod-user', image: null },
+};
+
+// A mis-routed external/connect request (out of P2 scope) — carries a manifest
+// kind marker (and, for belt, an oauthClientId).
+const EXTERNAL_PENDING = {
+  ...ONSITE_PENDING,
+  id: 'external-req-1',
+  oauthClientId: 'oauth_abc',
+  manifest: { ...ONSITE_PENDING.manifest, kind: 'external' },
+};
+
+const FULL_REPORT = {
+  id: 'arar_1',
+  status: 'complete',
+  model: 'review-model-x',
+  costUsd: '0.025000',
+  startedAt: new Date('2026-01-01T00:00:00Z'),
+  completedAt: new Date('2026-01-01T00:05:00Z'),
+  summaryMd: 'Overall the app looks reasonable with a couple of concerns.',
+  codeReview: {
+    findings: [
+      {
+        file: 'auth.js',
+        line: 42,
+        severity: 'high',
+        title: 'Hardcoded secret',
+        description: 'A hardcoded API token was found in the bundle.',
+      },
+    ],
+    priorFindingsReconciled: [{ title: 'Old eval() call', status: 'resolved' }],
+    notes: 'code notes here',
+  },
+  securityAudit: {
+    findings: [{ severity: 'medium', title: 'Broad fetch', description: 'Calls an external host.' }],
+    manifestUnexpectedKeys: ['sneakyKey'],
+    iframeSandboxGrants: ['allow-same-origin'],
+    promptInjectionAttempts: [{ file: 'README.md', excerpt: 'ignore previous instructions' }],
+    notes: 'security notes here',
+  },
+  scopeVerdicts: {
+    scopes: [
+      {
+        declared: 'buzz:read:self',
+        used: 'yes',
+        justificationAccurate: 'weak',
+        sensitive: true,
+        evidence: ['wallet.js:10'],
+        notes: 'reads balance',
+      },
+    ],
+    overBroad: ['user:*'],
+    underDeclared: ['models:write:self'],
+  },
+  tokenUsage: { promptTokens: 1200, completionTokens: 340 },
+};
+
+beforeEach(() => {
+  mocks.flags = { appBlocks: true, appBlocksAgenticReview: true };
+  mocks.agentReport = null;
+  mocks.agentLoading = false;
+  mocks.reviewStatus = undefined;
+  mocks.mutationError = undefined;
+  mocks.pending = false;
+  mocks.mutate.mockClear();
+  mocks.invalidate.mockClear();
+  mocks.lastAgentOpts = undefined;
+  showError.mockClear();
+  showSuccess.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// GATE (through the modal)
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPanel — render gate (through OnsiteReviewModal)', () => {
+  test('does NOT render when the agentic-review client flag is off', async () => {
+    mocks.flags = { appBlocks: true }; // flag absent → fails closed
+    renderWithProviders(
+      <OnsiteReviewModal selection={{ request: ONSITE_PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    // Sibling review-preview panel still renders (sanity that the modal mounted).
+    await expect.element(page.getByText('Review preview')).toBeInTheDocument();
+    // The agentic panel is absent.
+    expect(page.getByText('Agentic code review').elements()).toHaveLength(0);
+  });
+
+  test('does NOT render for a non-pending (approved) selection even with the flag on', async () => {
+    renderWithProviders(
+      <OnsiteReviewModal selection={{ request: ONSITE_APPROVED, mode: 'approved' }} onClose={vi.fn()} />
+    );
+    await expect.element(page.getByText('looks good')).toBeInTheDocument();
+    expect(page.getByText('Agentic code review').elements()).toHaveLength(0);
+  });
+
+  test('does NOT render for an external/connect request even on an onsite pending flow', async () => {
+    renderWithProviders(
+      <OnsiteReviewModal selection={{ request: EXTERNAL_PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    // The pending body mounted (Review preview shows), but the agentic panel is hidden.
+    await expect.element(page.getByText('Review preview')).toBeInTheDocument();
+    expect(page.getByText('Agentic code review').elements()).toHaveLength(0);
+  });
+
+  test('DOES render for an onsite pending request with the flag on', async () => {
+    renderWithProviders(
+      <OnsiteReviewModal selection={{ request: ONSITE_PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    await expect.element(page.getByText('Agentic code review')).toBeInTheDocument();
+    await expect
+      .element(page.getByRole('button', { name: 'Run agentic review' }))
+      .toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TRIGGER
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPanel — trigger', () => {
+  test('clicking "Run agentic review" fires startAgentReview with the request id', async () => {
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+    await page.getByRole('button', { name: 'Run agentic review' }).click();
+    expect(mocks.mutate).toHaveBeenCalledWith(
+      'startAgentReview',
+      expect.objectContaining({ publishRequestId: 'onsite-req-1' })
+    );
+    // Success path invalidates the read query (no error surfaced).
+    expect(showError).not.toHaveBeenCalled();
+    expect(mocks.invalidate).toHaveBeenCalled();
+  });
+
+  test('a CONFLICT "already running" error is handled gracefully (no error crash, refetches)', async () => {
+    mocks.mutationError = {
+      message: 'a review is already running for this request',
+      data: { code: 'CONFLICT' },
+    };
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+    await page.getByRole('button', { name: 'Run agentic review' }).click();
+    // No error notification (CONFLICT is expected), and the read query is refetched
+    // so the panel falls into the running state.
+    expect(showError).not.toHaveBeenCalled();
+    expect(showSuccess).toHaveBeenCalled();
+    expect(mocks.invalidate).toHaveBeenCalled();
+  });
+
+  test('a genuine error DOES surface via showErrorNotification', async () => {
+    mocks.mutationError = { message: 'boom', data: { code: 'BAD_REQUEST' } };
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+    await page.getByRole('button', { name: 'Run agentic review' }).click();
+    expect(showError).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Could not start agentic review' })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LIFECYCLE STATES
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPanel — lifecycle states', () => {
+  test('running: shows the spinner + "Analyzing…" and the poll is wired (stops on terminal)', async () => {
+    mocks.agentReport = { status: 'running' };
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+    await expect.element(page.getByText(/Analyzing/)).toBeInTheDocument();
+    // The run button is NOT shown while running.
+    expect(page.getByRole('button', { name: 'Run agentic review' }).elements()).toHaveLength(0);
+    // Poll wiring: refetchInterval polls while running, stops on every terminal state.
+    const ri = mocks.lastAgentOpts?.refetchInterval as (q: unknown) => unknown;
+    expect(ri({ state: { data: { status: 'running' } } })).toBe(AGENT_REVIEW_POLL_MS);
+    expect(ri({ state: { data: { status: 'complete' } } })).toBe(false);
+    expect(ri({ state: { data: { status: 'failed' } } })).toBe(false);
+    expect(ri({ state: { data: undefined } })).toBe(false);
+  });
+
+  test('complete: renders the report (advisory banner + a code finding)', async () => {
+    mocks.agentReport = FULL_REPORT;
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+    await expect.element(page.getByText(/Advisory only/)).toBeInTheDocument();
+    await expect.element(page.getByText('Hardcoded secret')).toBeInTheDocument();
+  });
+
+  test('cost-capped: renders the report with the cost-capped marker', async () => {
+    mocks.agentReport = { ...FULL_REPORT, status: 'cost-capped' };
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+    await expect.element(page.getByText(/Advisory only/)).toBeInTheDocument();
+    expect(page.getByText('cost-capped').elements().length).toBeGreaterThan(0);
+  });
+
+  test('failed: shows the error state + a "Run again" affordance', async () => {
+    mocks.agentReport = { status: 'failed', summaryMd: 'the model errored' };
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+    await expect.element(page.getByText(/agentic review failed/)).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Run again' })).toBeInTheDocument();
+  });
+
+  test('torn-down: shows the torn-down note + rerun', async () => {
+    mocks.agentReport = { status: 'torn-down' };
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+    await expect.element(page.getByText(/Review was torn down/)).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Run again' })).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FULL REPORT RENDERING
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPanel — report rendering', () => {
+  test('a fully-populated report renders code + security findings, the three must-flag callouts, and the scope table', async () => {
+    mocks.agentReport = FULL_REPORT;
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+
+    // Advisory banner (required).
+    await expect.element(page.getByText(/Advisory only/)).toBeInTheDocument();
+    // Header meta.
+    await expect.element(page.getByText('review-model-x')).toBeInTheDocument();
+    await expect.element(page.getByText('$0.0250')).toBeInTheDocument();
+
+    // Code review — file:line + severity + description + prior-version reconciliation.
+    await expect.element(page.getByText('Hardcoded secret')).toBeInTheDocument();
+    await expect.element(page.getByText('auth.js:42')).toBeInTheDocument();
+    await expect
+      .element(page.getByText('A hardcoded API token was found in the bundle.'))
+      .toBeInTheDocument();
+    await expect.element(page.getByText('Prior-version reconciliation')).toBeInTheDocument();
+    await expect.element(page.getByText('Old eval() call')).toBeInTheDocument();
+
+    // Security — the three MUST-FLAG callouts, rendered prominently.
+    await expect.element(page.getByText('Broad fetch')).toBeInTheDocument();
+    await expect.element(page.getByText('Unexpected manifest keys')).toBeInTheDocument();
+    await expect.element(page.getByText('sneakyKey')).toBeInTheDocument();
+    await expect.element(page.getByText('Risky iframe sandbox grants')).toBeInTheDocument();
+    await expect.element(page.getByText('allow-same-origin')).toBeInTheDocument();
+    await expect.element(page.getByText('Prompt-injection attempts')).toBeInTheDocument();
+    await expect.element(page.getByText('ignore previous instructions')).toBeInTheDocument();
+
+    // Scope verdicts table — one row + over-broad + under-declared + sensitive + evidence.
+    await expect.element(page.getByTestId('scope-verdicts-table')).toBeInTheDocument();
+    await expect.element(page.getByText('buzz:read:self')).toBeInTheDocument();
+    await expect.element(page.getByTestId('scope-sensitive-badge')).toBeInTheDocument();
+    await expect.element(page.getByText('wallet.js:10')).toBeInTheDocument();
+    await expect.element(page.getByText('Over-broad scopes')).toBeInTheDocument();
+    await expect.element(page.getByText('user:*')).toBeInTheDocument();
+    await expect.element(page.getByText('Under-declared scopes')).toBeInTheDocument();
+    await expect.element(page.getByText('models:write:self')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DEFENSIVE / EMPTY
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPanel — defensive / empty', () => {
+  test('a report with empty/missing sub-objects renders "None found" for each section without throwing', async () => {
+    mocks.agentReport = {
+      status: 'complete',
+      model: null,
+      costUsd: null,
+      codeReview: null,
+      securityAudit: undefined,
+      scopeVerdicts: {},
+    };
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+    // The report still renders (advisory banner) and the empty sections are tidy.
+    await expect.element(page.getByText(/Advisory only/)).toBeInTheDocument();
+    // Code + security findings both show "None found".
+    expect(page.getByText('None found').elements().length).toBeGreaterThanOrEqual(2);
+    // Scopes section shows its own empty label.
+    await expect.element(page.getByText('No scopes assessed')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SANITIZATION (stored-XSS-at-render guard)
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPanel — sanitization', () => {
+  test('adversarial HTML/script in finding text + summary renders as inert TEXT (no live DOM)', async () => {
+    const imgPayload = '<img src=x onerror="window.__xssFired=true">';
+    const scriptPayload = '<script>window.__xssScript=true</script>';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__xssFired = undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__xssScript = undefined;
+
+    mocks.agentReport = {
+      status: 'complete',
+      summaryMd: scriptPayload,
+      codeReview: { findings: [{ title: 'XSS attempt', description: imgPayload }] },
+      securityAudit: {},
+      scopeVerdicts: {},
+    };
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+
+    // The finding still renders (its title is present).
+    await expect.element(page.getByText('XSS attempt')).toBeInTheDocument();
+
+    // The raw markup is present as TEXT, not parsed into elements.
+    expect(document.body.textContent).toContain(imgPayload);
+    expect(document.body.textContent).toContain(scriptPayload);
+    // No injected <img> element was created from the payload, and no live <script>
+    // with the payload body executed.
+    expect(document.querySelectorAll('img').length).toBe(0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((window as any).__xssFired).toBeUndefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((window as any).__xssScript).toBeUndefined();
+  });
+});

--- a/src/components/Apps/AgentReviewPanel.tsx
+++ b/src/components/Apps/AgentReviewPanel.tsx
@@ -1,4 +1,5 @@
 import { Alert, Badge, Button, Card, Group, Loader, Stack, Table, Text, ThemeIcon } from '@mantine/core';
+import { useEffect, useRef } from 'react';
 import {
   IconAlertTriangle,
   IconCheck,
@@ -39,6 +40,39 @@ import { trpc } from '~/utils/trpc';
 
 /** Poll cadence while a run is in flight. */
 export const AGENT_REVIEW_POLL_MS = 4000;
+
+/**
+ * Stop polling after this many CONSECUTIVE failed poll requests. A single
+ * transient blip (< threshold) does NOT stop the poll — only a persistent
+ * error does. Guards against refetching every 4s forever if the read starts
+ * erroring mid-run.
+ */
+export const MAX_CONSECUTIVE_POLL_ERRORS = 3;
+
+/**
+ * Hard time ceiling for polling a single run — a review that outruns this is
+ * treated as stuck (a backend run wedged in `running` shouldn't poll forever).
+ */
+export const MAX_POLL_MS = 15 * 60 * 1000; // 15 min
+
+/**
+ * PURE poll-interval decision (unit-testable). Returns the 4s interval only
+ * while the run is genuinely in flight AND within both the error and time
+ * ceilings; otherwise `false` (stop). A single transient failure stays under
+ * the threshold and keeps polling; a persistent error or an over-long run
+ * stops it (surfaced in the UI as a manual "Check again" affordance).
+ */
+export function computeAgentReviewPollInterval(input: {
+  status: string | undefined; // last data status
+  consecutiveFailures: number; // query.state.fetchFailureCount
+  elapsedMs: number; // since polling started for this run
+}): number | false {
+  const { status, consecutiveFailures, elapsedMs } = input;
+  if (status !== 'running') return false;
+  if (consecutiveFailures >= MAX_CONSECUTIVE_POLL_ERRORS) return false;
+  if (elapsedMs >= MAX_POLL_MS) return false;
+  return AGENT_REVIEW_POLL_MS;
+}
 
 /**
  * Whether a review request is on-site (this panel's scope). External / OAuth-
@@ -166,16 +200,23 @@ export function AgentReviewPanel({
 }) {
   const utils = trpc.useUtils();
 
+  // When polling for the CURRENT run started (per-run, so the time ceiling is
+  // measured from the run, not from mount). Set when the report first becomes
+  // `running`; cleared on any terminal status; reset by the manual "Check again".
+  const pollStartedAt = useRef<number | null>(null);
+
   const reportQuery = trpc.blocks.getAgentReview.useQuery(
     { publishRequestId },
     {
       retry: false,
       // react-query v5: the callback receives the Query; poll only while running,
-      // stop on every terminal status (matches the useReviewPreview idiom).
-      refetchInterval: (query) => {
-        const status = query.state.data?.status;
-        return status === 'running' ? AGENT_REVIEW_POLL_MS : false;
-      },
+      // and only within the error + time ceilings (see computeAgentReviewPollInterval).
+      refetchInterval: (query) =>
+        computeAgentReviewPollInterval({
+          status: query.state.data?.status,
+          consecutiveFailures: query.state.fetchFailureCount ?? 0,
+          elapsedMs: pollStartedAt.current != null ? Date.now() - pollStartedAt.current : 0,
+        }),
     }
   );
 
@@ -206,6 +247,26 @@ export function AgentReviewPanel({
   const hasReport = status === 'complete' || status === 'cost-capped';
   const failed = status === 'failed';
   const tornDown = status === 'torn-down';
+
+  // Mark / clear the per-run poll start so the time ceiling is measured per-run.
+  useEffect(() => {
+    if (running) {
+      if (pollStartedAt.current == null) pollStartedAt.current = Date.now();
+    } else {
+      pollStartedAt.current = null;
+    }
+  }, [running]);
+
+  // Whether polling has STOPPED while the status is still non-terminal (hit the
+  // error or time ceiling). The panel then pauses auto-refresh and offers a
+  // manual "Check again" instead of spinning forever.
+  const pollPaused =
+    running &&
+    computeAgentReviewPollInterval({
+      status: status ?? undefined,
+      consecutiveFailures: reportQuery.failureCount ?? 0,
+      elapsedMs: pollStartedAt.current != null ? Date.now() - pollStartedAt.current : 0,
+    }) === false;
 
   const runButton = (label: string) => (
     <Button
@@ -252,12 +313,37 @@ export function AgentReviewPanel({
       ) : !report ? (
         <Group gap="xs">{runButton('Run agentic review')}</Group>
       ) : running ? (
-        <Group gap={6}>
-          <Loader size="sm" />
-          <Text size="sm" c="dimmed">
-            Analyzing…
-          </Text>
-        </Group>
+        pollPaused ? (
+          <Stack gap={6}>
+            <Group gap={6}>
+              <IconInfoCircle size={14} />
+              <Text size="sm" c="dimmed">
+                Still analyzing — automatic updates paused.
+              </Text>
+            </Group>
+            <Group gap="xs">
+              <Button
+                size="xs"
+                variant="light"
+                leftSection={<IconRefresh size={14} />}
+                onClick={() => {
+                  // Reset the per-run window and resume polling from this point.
+                  pollStartedAt.current = Date.now();
+                  void reportQuery.refetch();
+                }}
+              >
+                Check again
+              </Button>
+            </Group>
+          </Stack>
+        ) : (
+          <Group gap={6}>
+            <Loader size="sm" />
+            <Text size="sm" c="dimmed">
+              Analyzing…
+            </Text>
+          </Group>
+        )
       ) : failed ? (
         <Stack gap={6}>
           <Alert color="red" variant="light" icon={<IconX size={14} />}>

--- a/src/components/Apps/AgentReviewPanel.tsx
+++ b/src/components/Apps/AgentReviewPanel.tsx
@@ -1,0 +1,610 @@
+import { Alert, Badge, Button, Card, Group, Loader, Stack, Table, Text, ThemeIcon } from '@mantine/core';
+import {
+  IconAlertTriangle,
+  IconCheck,
+  IconCode,
+  IconInfoCircle,
+  IconKey,
+  IconRefresh,
+  IconRobot,
+  IconShieldLock,
+  IconX,
+} from '@tabler/icons-react';
+import {
+  fileLineLabel,
+  formatCostUsd,
+  parseAgentReport,
+  type AgentFinding,
+} from '~/components/Apps/agentReviewReport';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App Blocks — AGENTIC MOD CODE-REVIEW panel (P2). Rendered in the on-site review
+ * modal's PENDING flow, next to the Review-preview + Screenshots panels.
+ *
+ * DARK: the modal only mounts this when the `app-blocks-agentic-review` CLIENT
+ * feature flag is enabled (see the gate in OnsiteReviewModal). That flag has
+ * `availability: []` + a Flipt key that does NOT exist yet → it fails CLOSED →
+ * this panel never mounts on merge, and the sibling `blocks.getAgentReview` /
+ * `startAgentReview` procs reject (their own server-side flag gate). So the
+ * feature is inert end-to-end until the Flipt flag is created.
+ *
+ * ADVISORY ONLY: the report is generated from an UNTRUSTED bundle and is mod
+ * decision-SUPPORT, never a control. Every string here is rendered as inert TEXT
+ * (no `dangerouslySetInnerHTML`, no raw HTML) — that is the stored-XSS-at-render
+ * guard for adversarial LLM output. The Json columns are shape-validated through
+ * `parseAgentReport` (tolerant Zod) before render.
+ */
+
+/** Poll cadence while a run is in flight. */
+export const AGENT_REVIEW_POLL_MS = 4000;
+
+/**
+ * Whether a review request is on-site (this panel's scope). External / OAuth-
+ * connect requests are out of P2 scope — the on-site modal only ever holds
+ * on-site requests, but this stays defensive so a mis-routed external/connect
+ * request never surfaces the agentic panel. Pure + structural (no heuristic).
+ */
+export function isOnsiteReviewRequest(request: {
+  manifest?: unknown;
+  oauthClientId?: unknown;
+  externalUrl?: unknown;
+  kind?: unknown;
+}): boolean {
+  const r = request as Record<string, unknown>;
+  // Connect apps carry an oauthClientId; external-link apps carry an externalUrl.
+  if (typeof r.oauthClientId === 'string' && r.oauthClientId) return false;
+  if (typeof r.externalUrl === 'string' && r.externalUrl) return false;
+  const topKind = typeof r.kind === 'string' ? r.kind : null;
+  if (topKind && topKind !== 'onsite') return false;
+  const m = (request.manifest ?? {}) as Record<string, unknown>;
+  const mKind = typeof m.kind === 'string' ? m.kind : typeof m.type === 'string' ? m.type : null;
+  if (mKind === 'external' || mKind === 'external-link' || mKind === 'connect' || mKind === 'offsite')
+    return false;
+  return true;
+}
+
+function isAlreadyRunningError(e: { message?: string; data?: { code?: string } | null }): boolean {
+  // Robust to the proc preserving the service's CONFLICT code OR (belt) matching
+  // the "already running" message if a wrapper ever flattens the code.
+  return e?.data?.code === 'CONFLICT' || /already running/i.test(e?.message ?? '');
+}
+
+function severityColor(severity?: string): string {
+  switch ((severity ?? '').toLowerCase()) {
+    case 'critical':
+    case 'high':
+      return 'red';
+    case 'medium':
+    case 'moderate':
+      return 'orange';
+    case 'low':
+      return 'yellow';
+    default:
+      return 'gray';
+  }
+}
+
+function reconStatusColor(status?: string): string {
+  switch ((status ?? '').toLowerCase()) {
+    case 'resolved':
+      return 'green';
+    case 'regressed':
+      return 'red';
+    case 'still-present':
+      return 'orange';
+    default:
+      return 'gray';
+  }
+}
+
+function verdictColor(v?: string): string {
+  switch ((v ?? '').toLowerCase()) {
+    case 'yes':
+      return 'green';
+    case 'no':
+      return 'red';
+    case 'weak':
+    case 'unclear':
+      return 'orange';
+    default:
+      return 'gray';
+  }
+}
+
+/** A tidy "none found" for an empty section — never a blank/broken block. */
+function NoneFound({ label = 'None found' }: { label?: string }) {
+  return (
+    <Text size="xs" c="dimmed" fs="italic">
+      {label}
+    </Text>
+  );
+}
+
+function FindingsList({ findings }: { findings: AgentFinding[] }) {
+  if (findings.length === 0) return <NoneFound />;
+  return (
+    <Stack gap={6}>
+      {findings.map((f, i) => {
+        const loc = fileLineLabel(f.file, f.line);
+        return (
+          <Card key={i} withBorder padding="xs" radius="sm">
+            <Group gap={6} wrap="nowrap" align="center">
+              <Badge size="sm" variant="light" color={severityColor(f.severity)}>
+                {f.severity ?? 'info'}
+              </Badge>
+              {f.title && (
+                <Text size="sm" fw={600} style={{ wordBreak: 'break-word' }}>
+                  {f.title}
+                </Text>
+              )}
+            </Group>
+            {loc && (
+              <Text size="xs" c="dimmed" ff="monospace" style={{ wordBreak: 'break-all' }}>
+                {loc}
+              </Text>
+            )}
+            {f.description && (
+              <Text size="sm" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                {f.description}
+              </Text>
+            )}
+          </Card>
+        );
+      })}
+    </Stack>
+  );
+}
+
+export function AgentReviewPanel({
+  publishRequestId,
+  slug,
+}: {
+  publishRequestId: string;
+  slug: string;
+}) {
+  const utils = trpc.useUtils();
+
+  const reportQuery = trpc.blocks.getAgentReview.useQuery(
+    { publishRequestId },
+    {
+      retry: false,
+      // react-query v5: the callback receives the Query; poll only while running,
+      // stop on every terminal status (matches the useReviewPreview idiom).
+      refetchInterval: (query) => {
+        const status = query.state.data?.status;
+        return status === 'running' ? AGENT_REVIEW_POLL_MS : false;
+      },
+    }
+  );
+
+  const startMut = trpc.blocks.startAgentReview.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({ message: `Agentic review started for ${slug}.` });
+      await utils.blocks.getAgentReview.invalidate({ publishRequestId });
+    },
+    onError: (e) => {
+      // A CONFLICT ("a review is already running for this request") is EXPECTED
+      // when a run is already in flight — refetch so the panel falls into the
+      // running state instead of surfacing an error / crashing.
+      if (isAlreadyRunningError(e)) {
+        showSuccessNotification({ message: 'A review is already running for this request.' });
+        void utils.blocks.getAgentReview.invalidate({ publishRequestId });
+        return;
+      }
+      showErrorNotification({
+        title: 'Could not start agentic review',
+        error: new Error(e.message),
+      });
+    },
+  });
+
+  const report = reportQuery.data ?? null;
+  const status = report?.status ?? null;
+  const running = status === 'running';
+  const hasReport = status === 'complete' || status === 'cost-capped';
+  const failed = status === 'failed';
+  const tornDown = status === 'torn-down';
+
+  const runButton = (label: string) => (
+    <Button
+      size="xs"
+      variant="light"
+      leftSection={<IconRobot size={14} />}
+      loading={startMut.isPending}
+      disabled={startMut.isPending}
+      onClick={() => startMut.mutate({ publishRequestId })}
+    >
+      {label}
+    </Button>
+  );
+
+  return (
+    <Stack gap={6}>
+      <Group gap={6}>
+        <IconRobot size={14} />
+        <Text size="sm" fw={600}>
+          Agentic code review
+        </Text>
+        {status && (
+          <Badge
+            size="sm"
+            variant="light"
+            color={hasReport ? 'green' : failed ? 'red' : running ? 'blue' : 'gray'}
+          >
+            {status}
+          </Badge>
+        )}
+      </Group>
+      <Text size="xs" c="dimmed">
+        Dispatch an ephemeral, sandboxed agent to code-review + security-audit this
+        pending bundle. Advisory decision-support only.
+      </Text>
+
+      {reportQuery.isLoading ? (
+        <Group gap={6}>
+          <Loader size="xs" />
+          <Text size="xs" c="dimmed">
+            Loading review…
+          </Text>
+        </Group>
+      ) : !report ? (
+        <Group gap="xs">{runButton('Run agentic review')}</Group>
+      ) : running ? (
+        <Group gap={6}>
+          <Loader size="sm" />
+          <Text size="sm" c="dimmed">
+            Analyzing…
+          </Text>
+        </Group>
+      ) : failed ? (
+        <Stack gap={6}>
+          <Alert color="red" variant="light" icon={<IconX size={14} />}>
+            The agentic review failed.
+            {report.summaryMd ? ` ${report.summaryMd}` : ''}
+          </Alert>
+          <Group gap="xs">{runButton('Run again')}</Group>
+        </Stack>
+      ) : tornDown ? (
+        <Stack gap={6}>
+          <Text size="xs" c="dimmed">
+            Review was torn down.
+          </Text>
+          <Group gap="xs">{runButton('Run again')}</Group>
+        </Stack>
+      ) : hasReport ? (
+        <ReportBody report={report} costCapped={status === 'cost-capped'} />
+      ) : null}
+    </Stack>
+  );
+}
+
+function MetaLine({ label, value }: { label: string; value: string }) {
+  return (
+    <Text size="xs" c="dimmed">
+      <Text span fw={600}>
+        {label}:
+      </Text>{' '}
+      {value}
+    </Text>
+  );
+}
+
+function fmtDate(d: unknown): string | null {
+  if (d == null) return null;
+  const dt = d instanceof Date ? d : new Date(String(d));
+  return Number.isNaN(dt.getTime()) ? null : dt.toLocaleString();
+}
+
+function ReportBody({
+  report,
+  costCapped,
+}: {
+  report: {
+    status: string;
+    model?: string | null;
+    costUsd?: unknown;
+    startedAt?: unknown;
+    completedAt?: unknown;
+    summaryMd?: string | null;
+    codeReview?: unknown;
+    securityAudit?: unknown;
+    scopeVerdicts?: unknown;
+    tokenUsage?: unknown;
+  };
+  costCapped: boolean;
+}) {
+  const view = parseAgentReport(report);
+  const { codeReview, securityAudit, scopeVerdicts, tokenUsage } = view;
+
+  const cost = formatCostUsd(report.costUsd);
+  const started = fmtDate(report.startedAt);
+  const completed = fmtDate(report.completedAt);
+  const tokens =
+    tokenUsage.promptTokens != null || tokenUsage.completionTokens != null
+      ? `${tokenUsage.promptTokens ?? 0} in / ${tokenUsage.completionTokens ?? 0} out`
+      : null;
+
+  return (
+    <Stack gap="sm">
+      {/* Header meta */}
+      <Group gap={6}>
+        <Badge size="sm" variant="light" color={costCapped ? 'orange' : 'green'}>
+          {report.status}
+        </Badge>
+        {report.model && (
+          <Badge size="sm" variant="outline" color="gray">
+            {report.model}
+          </Badge>
+        )}
+      </Group>
+      <Group gap="md">
+        {cost && <MetaLine label="Cost" value={cost} />}
+        {tokens && <MetaLine label="Tokens" value={tokens} />}
+        {started && <MetaLine label="Started" value={started} />}
+        {completed && <MetaLine label="Completed" value={completed} />}
+      </Group>
+
+      {/* Advisory banner — REQUIRED. */}
+      <Alert color="yellow" variant="light" icon={<IconInfoCircle size={14} />}>
+        Advisory only — the moderator decision remains the control. This report is
+        generated from an untrusted bundle and may be manipulated.
+      </Alert>
+
+      {/* Summary — rendered as inert plain text (never markdown-as-HTML). */}
+      {report.summaryMd && (
+        <Stack gap={2}>
+          <Text size="sm" fw={600}>
+            Summary
+          </Text>
+          <Text size="sm" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {report.summaryMd}
+          </Text>
+        </Stack>
+      )}
+
+      {/* Code review */}
+      <Stack gap={4}>
+        <Group gap={6}>
+          <IconCode size={14} />
+          <Text size="sm" fw={600}>
+            Code review
+          </Text>
+          <Badge size="sm" variant="light" color="gray">
+            {codeReview.findings.length}
+          </Badge>
+        </Group>
+        <FindingsList findings={codeReview.findings} />
+        {codeReview.priorFindingsReconciled.length > 0 && (
+          <Card withBorder padding="xs" radius="sm">
+            <Text size="xs" fw={600}>
+              Prior-version reconciliation
+            </Text>
+            <Stack gap={2} mt={4}>
+              {codeReview.priorFindingsReconciled.map((p, i) => (
+                <Group key={i} gap={6} wrap="nowrap">
+                  <Badge size="xs" variant="light" color={reconStatusColor(p.status)}>
+                    {p.status ?? 'unknown'}
+                  </Badge>
+                  {p.title && (
+                    <Text size="xs" style={{ wordBreak: 'break-word' }}>
+                      {p.title}
+                    </Text>
+                  )}
+                </Group>
+              ))}
+            </Stack>
+          </Card>
+        )}
+        {codeReview.notes && (
+          <Text size="xs" c="dimmed" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {codeReview.notes}
+          </Text>
+        )}
+      </Stack>
+
+      {/* Security audit + the must-flag callouts */}
+      <Stack gap={4}>
+        <Group gap={6}>
+          <IconShieldLock size={14} />
+          <Text size="sm" fw={600}>
+            Security audit
+          </Text>
+          <Badge size="sm" variant="light" color="gray">
+            {securityAudit.findings.length}
+          </Badge>
+        </Group>
+        <FindingsList findings={securityAudit.findings} />
+
+        {/* MUST-FLAG callouts — surfaced prominently (they replace the manifest
+            signals collapsed out of the modal). */}
+        {securityAudit.manifestUnexpectedKeys.length > 0 && (
+          <Alert color="orange" variant="light" icon={<IconAlertTriangle size={14} />}>
+            <Text size="xs" fw={600}>
+              Unexpected manifest keys
+            </Text>
+            <Group gap={4} mt={4}>
+              {securityAudit.manifestUnexpectedKeys.map((k, i) => (
+                <Badge key={i} size="sm" variant="outline" color="orange" ff="monospace">
+                  {k}
+                </Badge>
+              ))}
+            </Group>
+          </Alert>
+        )}
+        {securityAudit.iframeSandboxGrants.length > 0 && (
+          <Alert color="orange" variant="light" icon={<IconAlertTriangle size={14} />}>
+            <Text size="xs" fw={600}>
+              Risky iframe sandbox grants
+            </Text>
+            <Group gap={4} mt={4}>
+              {securityAudit.iframeSandboxGrants.map((g, i) => (
+                <Badge key={i} size="sm" variant="outline" color="orange" ff="monospace">
+                  {g}
+                </Badge>
+              ))}
+            </Group>
+          </Alert>
+        )}
+        {securityAudit.promptInjectionAttempts.length > 0 && (
+          <Alert color="red" variant="light" icon={<IconAlertTriangle size={14} />}>
+            <Text size="xs" fw={600}>
+              Prompt-injection attempts
+            </Text>
+            <Stack gap={4} mt={4}>
+              {securityAudit.promptInjectionAttempts.map((p, i) => (
+                <Stack key={i} gap={0}>
+                  {p.file && (
+                    <Text size="xs" c="dimmed" ff="monospace" style={{ wordBreak: 'break-all' }}>
+                      {p.file}
+                    </Text>
+                  )}
+                  {p.excerpt && (
+                    <Text size="xs" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                      {p.excerpt}
+                    </Text>
+                  )}
+                </Stack>
+              ))}
+            </Stack>
+          </Alert>
+        )}
+        {securityAudit.notes && (
+          <Text size="xs" c="dimmed" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+            {securityAudit.notes}
+          </Text>
+        )}
+      </Stack>
+
+      {/* Scope verdicts */}
+      <Stack gap={4}>
+        <Group gap={6}>
+          <IconKey size={14} />
+          <Text size="sm" fw={600}>
+            Scope verdicts
+          </Text>
+          <Badge size="sm" variant="light" color="gray">
+            {scopeVerdicts.scopes.length}
+          </Badge>
+        </Group>
+        {scopeVerdicts.scopes.length === 0 ? (
+          <NoneFound label="No scopes assessed" />
+        ) : (
+          <Table striped withTableBorder withColumnBorders fz="xs" data-testid="scope-verdicts-table">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Scope</Table.Th>
+                <Table.Th>Used</Table.Th>
+                <Table.Th>Justified</Table.Th>
+                <Table.Th>Sensitive</Table.Th>
+                <Table.Th>Evidence</Table.Th>
+                <Table.Th>Notes</Table.Th>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {scopeVerdicts.scopes.map((s, i) => (
+                <Table.Tr key={i}>
+                  <Table.Td>
+                    <Text size="xs" ff="monospace" style={{ wordBreak: 'break-all' }}>
+                      {s.declared ?? '—'}
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge size="xs" variant="light" color={verdictColor(s.used)}>
+                      {s.used ?? '—'}
+                    </Badge>
+                  </Table.Td>
+                  <Table.Td>
+                    <Badge size="xs" variant="light" color={verdictColor(s.justificationAccurate)}>
+                      {s.justificationAccurate ?? '—'}
+                    </Badge>
+                  </Table.Td>
+                  <Table.Td>
+                    {s.sensitive ? (
+                      <Badge
+                        size="xs"
+                        variant="filled"
+                        color="red"
+                        data-testid="scope-sensitive-badge"
+                      >
+                        sensitive
+                      </Badge>
+                    ) : (
+                      <Text size="xs" c="dimmed">
+                        —
+                      </Text>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    {s.evidence.length === 0 ? (
+                      <Text size="xs" c="dimmed">
+                        —
+                      </Text>
+                    ) : (
+                      <Stack gap={0}>
+                        {s.evidence.map((e, j) => (
+                          <Text
+                            key={j}
+                            size="xs"
+                            ff="monospace"
+                            style={{ wordBreak: 'break-all' }}
+                          >
+                            {e}
+                          </Text>
+                        ))}
+                      </Stack>
+                    )}
+                  </Table.Td>
+                  <Table.Td>
+                    <Text size="xs" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                      {s.notes ?? '—'}
+                    </Text>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        )}
+
+        {scopeVerdicts.overBroad.length > 0 && (
+          <Alert color="orange" variant="light" icon={<IconAlertTriangle size={14} />}>
+            <Text size="xs" fw={600}>
+              Over-broad scopes
+            </Text>
+            <Group gap={4} mt={4}>
+              {scopeVerdicts.overBroad.map((k, i) => (
+                <Badge key={i} size="sm" variant="outline" color="orange" ff="monospace">
+                  {k}
+                </Badge>
+              ))}
+            </Group>
+          </Alert>
+        )}
+        {scopeVerdicts.underDeclared.length > 0 && (
+          <Alert color="orange" variant="light" icon={<IconAlertTriangle size={14} />}>
+            <Text size="xs" fw={600}>
+              Under-declared scopes
+            </Text>
+            <Group gap={4} mt={4}>
+              {scopeVerdicts.underDeclared.map((k, i) => (
+                <Badge key={i} size="sm" variant="outline" color="orange" ff="monospace">
+                  {k}
+                </Badge>
+              ))}
+            </Group>
+          </Alert>
+        )}
+      </Stack>
+
+      <Group gap={4}>
+        <ThemeIcon size="xs" variant="light" color="green" radius="xl">
+          <IconCheck size={10} />
+        </ThemeIcon>
+        <Text size="xs" c="dimmed">
+          Report is advisory. You retain the approve / reject decision.
+        </Text>
+      </Group>
+    </Stack>
+  );
+}

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -32,6 +32,7 @@ import {
   IconX,
 } from '@tabler/icons-react';
 import { useMemo, useRef, useState } from 'react';
+import { AgentReviewPanel, isOnsiteReviewRequest } from '~/components/Apps/AgentReviewPanel';
 import { ReviewBlockPreviewHost } from '~/components/Apps/ReviewBlockPreviewHost';
 import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
 import { useReviewPreview } from '~/components/Apps/useReviewPreview';
@@ -251,6 +252,7 @@ function OnsiteReviewModalBody({
   busyRef: { current: boolean };
 }) {
   const utils = trpc.useUtils();
+  const features = useFeatureFlags();
   const [approvalNotes, setApprovalNotes] = useState('');
   const [rejectionReason, setRejectionReason] = useState('');
   const [actionMode, setActionMode] = useState<'view' | 'reject'>('view');
@@ -375,6 +377,18 @@ function OnsiteReviewModalBody({
             mod-gated preview before approving. Pending requests only; dark
             unless the mod-only review-sandbox flag is enabled. */}
         {mode === 'pending' && <ReviewPreviewPanel publishRequestId={request.id} slug={request.slug} />}
+
+        {/* AGENTIC MOD CODE-REVIEW (App Blocks P2) — dispatch + poll + render an
+            agent code-review/security-audit report before approving. On-site
+            PENDING only, and DARK unless the mod-only `app-blocks-agentic-review`
+            CLIENT flag is enabled (fail-closed: absent Flipt flag → does not
+            render, so the panel is inert on merge). External/connect requests are
+            out of P2 scope — hidden. */}
+        {mode === 'pending' &&
+          !!features?.appBlocksAgenticReview &&
+          isOnsiteReviewRequest(request) && (
+            <AgentReviewPanel publishRequestId={request.id} slug={request.slug} />
+          )}
 
         {/* F-E E5 — publisher screenshot gallery review. Publisher-supplied
             images are an abuse vector → the mod sees them (here, derived from

--- a/src/components/Apps/__tests__/agentReviewPoll.test.ts
+++ b/src/components/Apps/__tests__/agentReviewPoll.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_REVIEW_POLL_MS,
+  MAX_CONSECUTIVE_POLL_ERRORS,
+  MAX_POLL_MS,
+  computeAgentReviewPollInterval,
+} from '~/components/Apps/AgentReviewPanel';
+
+/**
+ * PURE poll-interval decision for the agentic-review panel (P2). The panel polls
+ * `getAgentReview` every 4s while a run is `running`, but must NOT refetch forever
+ * if the poll starts erroring mid-run or a backend run wedges in `running`. This
+ * helper bounds the poll on BOTH an error ceiling and a time ceiling.
+ */
+
+describe('computeAgentReviewPollInterval', () => {
+  it('running + no failures + within the time cap → polls at 4000ms', () => {
+    expect(
+      computeAgentReviewPollInterval({ status: 'running', consecutiveFailures: 0, elapsedMs: 0 })
+    ).toBe(AGENT_REVIEW_POLL_MS);
+    expect(AGENT_REVIEW_POLL_MS).toBe(4000);
+  });
+
+  it('a SINGLE transient failure (1 < threshold) does NOT stop the poll', () => {
+    expect(
+      computeAgentReviewPollInterval({ status: 'running', consecutiveFailures: 1, elapsedMs: 0 })
+    ).toBe(AGENT_REVIEW_POLL_MS);
+    // Right up to (but below) the threshold it still polls.
+    expect(
+      computeAgentReviewPollInterval({
+        status: 'running',
+        consecutiveFailures: MAX_CONSECUTIVE_POLL_ERRORS - 1,
+        elapsedMs: 0,
+      })
+    ).toBe(AGENT_REVIEW_POLL_MS);
+  });
+
+  it('a PERSISTENT error (>= MAX_CONSECUTIVE_POLL_ERRORS) stops the poll → false', () => {
+    expect(
+      computeAgentReviewPollInterval({
+        status: 'running',
+        consecutiveFailures: MAX_CONSECUTIVE_POLL_ERRORS,
+        elapsedMs: 0,
+      })
+    ).toBe(false);
+    expect(
+      computeAgentReviewPollInterval({
+        status: 'running',
+        consecutiveFailures: MAX_CONSECUTIVE_POLL_ERRORS + 5,
+        elapsedMs: 0,
+      })
+    ).toBe(false);
+  });
+
+  it('an over-long run (elapsedMs >= MAX_POLL_MS) stops the poll → false', () => {
+    expect(
+      computeAgentReviewPollInterval({
+        status: 'running',
+        consecutiveFailures: 0,
+        elapsedMs: MAX_POLL_MS,
+      })
+    ).toBe(false);
+    expect(
+      computeAgentReviewPollInterval({
+        status: 'running',
+        consecutiveFailures: 0,
+        elapsedMs: MAX_POLL_MS + 1,
+      })
+    ).toBe(false);
+    // Just under the cap still polls.
+    expect(
+      computeAgentReviewPollInterval({
+        status: 'running',
+        consecutiveFailures: 0,
+        elapsedMs: MAX_POLL_MS - 1,
+      })
+    ).toBe(AGENT_REVIEW_POLL_MS);
+  });
+
+  it('any non-running status stops the poll → false', () => {
+    for (const status of ['complete', 'cost-capped', 'failed', 'torn-down', undefined]) {
+      expect(
+        computeAgentReviewPollInterval({ status, consecutiveFailures: 0, elapsedMs: 0 })
+      ).toBe(false);
+    }
+  });
+});

--- a/src/components/Apps/__tests__/agentReviewReport.test.ts
+++ b/src/components/Apps/__tests__/agentReviewReport.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import {
+  fileLineLabel,
+  formatCostUsd,
+  parseAgentReport,
+} from '~/components/Apps/agentReviewReport';
+
+/**
+ * Tolerant-parse contract for the adversarial LLM report columns (the
+ * sanitization BOUNDARY). Every field is `.catch()`-wrapped so a single
+ * malformed field never throws / blanks the report; unknown keys are stripped;
+ * missing sub-objects default to their empty shape.
+ */
+
+describe('parseAgentReport — tolerant shaping', () => {
+  it('a fully-populated report parses into typed view-models (unknown keys stripped)', () => {
+    const v = parseAgentReport({
+      codeReview: {
+        findings: [{ file: 'a.js', line: 3, severity: 'high', title: 'X', description: 'd', extra: 1 }],
+        priorFindingsReconciled: [{ title: 'old', status: 'resolved' }],
+        notes: 'n',
+        bogusTopKey: true,
+      },
+      securityAudit: {
+        findings: [{ severity: 'low' }],
+        manifestUnexpectedKeys: ['weird'],
+        iframeSandboxGrants: ['allow-same-origin'],
+        promptInjectionAttempts: [{ file: 'r.md', excerpt: 'ignore prev' }],
+        notes: 's',
+      },
+      scopeVerdicts: {
+        scopes: [
+          {
+            declared: 'buzz:read:self',
+            used: 'yes',
+            justificationAccurate: 'weak',
+            sensitive: true,
+            evidence: ['a.js:1'],
+            notes: 'ok',
+          },
+        ],
+        overBroad: ['user:*'],
+        underDeclared: ['models:write'],
+      },
+      tokenUsage: { promptTokens: 100, completionTokens: 20 },
+    });
+
+    expect(v.codeReview.findings).toHaveLength(1);
+    // Unknown `extra` key is stripped.
+    expect(v.codeReview.findings[0]).not.toHaveProperty('extra');
+    expect(v.codeReview.findings[0].severity).toBe('high');
+    expect(v.codeReview.priorFindingsReconciled[0].status).toBe('resolved');
+    expect(v.securityAudit.manifestUnexpectedKeys).toEqual(['weird']);
+    expect(v.securityAudit.iframeSandboxGrants).toEqual(['allow-same-origin']);
+    expect(v.securityAudit.promptInjectionAttempts[0].excerpt).toBe('ignore prev');
+    expect(v.scopeVerdicts.scopes[0].sensitive).toBe(true);
+    expect(v.scopeVerdicts.overBroad).toEqual(['user:*']);
+    expect(v.scopeVerdicts.underDeclared).toEqual(['models:write']);
+    expect(v.tokenUsage.promptTokens).toBe(100);
+  });
+
+  it('missing / null columns default to empty shapes (never throw)', () => {
+    const v = parseAgentReport({});
+    expect(v.codeReview.findings).toEqual([]);
+    expect(v.codeReview.priorFindingsReconciled).toEqual([]);
+    expect(v.securityAudit.findings).toEqual([]);
+    expect(v.securityAudit.manifestUnexpectedKeys).toEqual([]);
+    expect(v.securityAudit.iframeSandboxGrants).toEqual([]);
+    expect(v.securityAudit.promptInjectionAttempts).toEqual([]);
+    expect(v.scopeVerdicts.scopes).toEqual([]);
+    expect(v.scopeVerdicts.overBroad).toEqual([]);
+    expect(v.scopeVerdicts.underDeclared).toEqual([]);
+
+    const vn = parseAgentReport({
+      codeReview: null,
+      securityAudit: null,
+      scopeVerdicts: null,
+      tokenUsage: null,
+    });
+    expect(vn.codeReview.findings).toEqual([]);
+    expect(vn.scopeVerdicts.scopes).toEqual([]);
+  });
+
+  it('wrong-typed fields are treated as absent, not thrown', () => {
+    const v = parseAgentReport({
+      // findings is a string, severity is an object, evidence is a number
+      codeReview: { findings: 'not-an-array', notes: 42 },
+      securityAudit: { findings: [{ severity: { nested: true }, title: 5 }], iframeSandboxGrants: 'x' },
+      scopeVerdicts: { scopes: [{ declared: 'ok', evidence: 7, sensitive: 'yes' }] },
+      tokenUsage: { promptTokens: 'lots' },
+    });
+    expect(v.codeReview.findings).toEqual([]);
+    expect(v.codeReview.notes).toBeUndefined();
+    // The finding survives with only the well-typed absence; bad fields → undefined.
+    expect(v.securityAudit.findings[0].severity).toBeUndefined();
+    expect(v.securityAudit.findings[0].title).toBeUndefined();
+    expect(v.securityAudit.iframeSandboxGrants).toEqual([]);
+    expect(v.scopeVerdicts.scopes[0].declared).toBe('ok');
+    expect(v.scopeVerdicts.scopes[0].evidence).toEqual([]);
+    // 'yes' is not a boolean → sensitive falls back to undefined (falsy).
+    expect(v.scopeVerdicts.scopes[0].sensitive).toBeUndefined();
+    expect(v.tokenUsage.promptTokens).toBeUndefined();
+  });
+
+  it('parseAgentReport does NOT transform string content (render layer sanitizes)', () => {
+    const payload = '<img src=x onerror=alert(1)>';
+    const v = parseAgentReport({
+      codeReview: { findings: [{ description: payload }] },
+      securityAudit: {},
+      scopeVerdicts: {},
+    });
+    // The parser preserves the raw string verbatim — it guarantees SHAPE, not
+    // content escaping (the panel renders it as inert text, the real guard).
+    expect(v.codeReview.findings[0].description).toBe(payload);
+  });
+});
+
+describe('formatCostUsd', () => {
+  it('formats numbers, numeric strings, and Decimal-like objects', () => {
+    expect(formatCostUsd(0.01)).toBe('$0.0100');
+    expect(formatCostUsd('0.012345')).toBe('$0.0123');
+    expect(formatCostUsd({ toString: () => '0.5' })).toBe('$0.5000');
+  });
+  it('returns null for null/undefined/NaN', () => {
+    expect(formatCostUsd(null)).toBeNull();
+    expect(formatCostUsd(undefined)).toBeNull();
+    expect(formatCostUsd('not-a-number')).toBeNull();
+  });
+});
+
+describe('fileLineLabel', () => {
+  it('builds file:line, tolerates missing parts', () => {
+    expect(fileLineLabel('a.js', 3)).toBe('a.js:3');
+    expect(fileLineLabel('a.js', '10')).toBe('a.js:10');
+    expect(fileLineLabel('a.js')).toBe('a.js');
+    expect(fileLineLabel('a.js', '')).toBe('a.js');
+    expect(fileLineLabel(undefined, 3)).toBeNull();
+  });
+});

--- a/src/components/Apps/agentReviewReport.ts
+++ b/src/components/Apps/agentReviewReport.ts
@@ -1,0 +1,165 @@
+import { z } from 'zod';
+
+/**
+ * App Blocks — AGENTIC MOD CODE-REVIEW (P2) report view-model + parsing.
+ *
+ * THE SANITIZATION BOUNDARY. The `codeReview` / `securityAudit` / `scopeVerdicts`
+ * / `tokenUsage` columns are adversarial LLM output produced from an UNTRUSTED
+ * bundle: the analysed app author controls the code the agent reads, so the model
+ * text can carry markup, prompt-injection, or malformed shapes. Everything the
+ * UI renders flows through the tolerant Zod schemas below FIRST.
+ *
+ * Tolerance contract (why every field is `.catch()`-wrapped, never a bare parse):
+ *  - unknown/extra keys are STRIPPED (default Zod object behaviour),
+ *  - a missing field defaults to its empty value ([] / undefined),
+ *  - a WRONG-TYPED field (e.g. `severity` is an object, `findings` is a string)
+ *    is treated as absent instead of THROWING — a single malformed field must
+ *    never blank the whole report or crash the modal.
+ * The schemas do NOT sanitize the string CONTENT (that is impossible to do
+ * safely by transform) — they guarantee the shape. The panel renders every
+ * string as inert TEXT (never `dangerouslySetInnerHTML` / raw HTML), which is
+ * the actual stored-XSS-at-render guard.
+ */
+
+/** A string field that falls back to `undefined` on any non-string input. */
+const optString = z.string().optional().catch(undefined);
+/** A `file:line`-style line ref — number or string; anything else → undefined. */
+const optLine = z.union([z.number(), z.string()]).optional().catch(undefined);
+const optBool = z.boolean().optional().catch(undefined);
+/** A string array that falls back to `[]` on any non-array / wrong-element input. */
+const stringArray = z
+  .array(z.string())
+  .catch([])
+  // filter defends against a mixed array that partially coerces
+  .transform((a) => a.filter((s): s is string => typeof s === 'string'));
+
+// --- Code review -----------------------------------------------------------
+
+export const agentFindingSchema = z
+  .object({
+    file: optString,
+    line: optLine,
+    severity: optString,
+    title: optString,
+    description: optString,
+  })
+  .catch({});
+export type AgentFinding = z.infer<typeof agentFindingSchema>;
+
+export const priorFindingSchema = z
+  .object({
+    title: optString,
+    status: optString, // 'resolved' | 'still-present' | 'regressed' (rendered tolerantly)
+  })
+  .catch({});
+export type PriorFinding = z.infer<typeof priorFindingSchema>;
+
+export const codeReviewSchema = z
+  .object({
+    findings: z.array(agentFindingSchema).catch([]),
+    priorFindingsReconciled: z.array(priorFindingSchema).catch([]),
+    notes: optString,
+  })
+  .catch({ findings: [], priorFindingsReconciled: [], notes: undefined });
+export type CodeReviewView = z.infer<typeof codeReviewSchema>;
+
+// --- Security audit --------------------------------------------------------
+
+export const promptInjectionAttemptSchema = z
+  .object({
+    file: optString,
+    excerpt: optString,
+  })
+  .catch({});
+export type PromptInjectionAttempt = z.infer<typeof promptInjectionAttemptSchema>;
+
+export const securityAuditSchema = z
+  .object({
+    findings: z.array(agentFindingSchema).catch([]),
+    manifestUnexpectedKeys: stringArray,
+    iframeSandboxGrants: stringArray,
+    promptInjectionAttempts: z.array(promptInjectionAttemptSchema).catch([]),
+    notes: optString,
+  })
+  .catch({
+    findings: [],
+    manifestUnexpectedKeys: [],
+    iframeSandboxGrants: [],
+    promptInjectionAttempts: [],
+    notes: undefined,
+  });
+export type SecurityAuditView = z.infer<typeof securityAuditSchema>;
+
+// --- Scope verdicts --------------------------------------------------------
+
+export const scopeVerdictSchema = z
+  .object({
+    declared: optString,
+    kind: optString,
+    used: optString, // 'yes' | 'no' | 'unclear'
+    justificationAccurate: optString, // 'yes' | 'no' | 'weak'
+    sensitive: optBool,
+    evidence: stringArray,
+    notes: optString,
+  })
+  .catch({ evidence: [] });
+export type ScopeVerdict = z.infer<typeof scopeVerdictSchema>;
+
+export const scopeVerdictsSchema = z
+  .object({
+    scopes: z.array(scopeVerdictSchema).catch([]),
+    overBroad: stringArray,
+    underDeclared: stringArray,
+  })
+  .catch({ scopes: [], overBroad: [], underDeclared: [] });
+export type ScopeVerdictsView = z.infer<typeof scopeVerdictsSchema>;
+
+// --- Token usage -----------------------------------------------------------
+
+export const tokenUsageSchema = z
+  .object({
+    promptTokens: z.number().optional().catch(undefined),
+    completionTokens: z.number().optional().catch(undefined),
+  })
+  .catch({});
+export type TokenUsageView = z.infer<typeof tokenUsageSchema>;
+
+/** The fully-parsed, safe-to-render view-model of a report's structured fields. */
+export type AgentReportView = {
+  codeReview: CodeReviewView;
+  securityAudit: SecurityAuditView;
+  scopeVerdicts: ScopeVerdictsView;
+  tokenUsage: TokenUsageView;
+};
+
+/** Parse the adversarial Json columns of a report row into safe view-models. */
+export function parseAgentReport(report: {
+  codeReview?: unknown;
+  securityAudit?: unknown;
+  scopeVerdicts?: unknown;
+  tokenUsage?: unknown;
+}): AgentReportView {
+  return {
+    codeReview: codeReviewSchema.parse(report.codeReview),
+    securityAudit: securityAuditSchema.parse(report.securityAudit),
+    scopeVerdicts: scopeVerdictsSchema.parse(report.scopeVerdicts),
+    tokenUsage: tokenUsageSchema.parse(report.tokenUsage),
+  };
+}
+
+/**
+ * Render a `costUsd` value (Prisma Decimal over the wire, or a number/string in
+ * tests) as a `$x.xxxx` label — null/NaN → null (caller omits the line).
+ */
+export function formatCostUsd(costUsd: unknown): string | null {
+  if (costUsd == null) return null;
+  const n = typeof costUsd === 'number' ? costUsd : Number(String(costUsd));
+  if (!Number.isFinite(n)) return null;
+  return `$${n.toFixed(4)}`;
+}
+
+/** A `file:line` display string from a finding — tolerant of missing parts. */
+export function fileLineLabel(file?: string, line?: number | string): string | null {
+  if (!file) return null;
+  return line == null || line === '' ? file : `${file}:${line}`;
+}

--- a/src/server/routers/__tests__/blocks.router.agentReview.test.ts
+++ b/src/server/routers/__tests__/blocks.router.agentReview.test.ts
@@ -1,0 +1,274 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * AGENTIC MOD CODE-REVIEW (App Blocks P2) — gate coverage for the READ path
+ * blocks.getAgentReview (+ a CONFLICT-preservation check on startAgentReview)
+ * through the REAL router.
+ *
+ * getAgentReview stacks three gates: moderatorProcedure (isModerator),
+ * enforceAppBlocksFlag (the user-visibility flag), and the dedicated mod-only
+ * `app-blocks-agentic-review` flag. We prove:
+ *   - moderator + all flags on → reaches getAgentReport with the request id;
+ *     null passes through when the app has no report.
+ *   - non-moderator / anonymous → UNAUTHORIZED (service NOT reached).
+ *   - moderator but the agentic-review flag OFF → UNAUTHORIZED (DARK / fail-closed,
+ *     the as-merged posture since the Flipt flag does not exist yet).
+ *   - startAgentReview preserves the service's CONFLICT ("already running") code
+ *     instead of flattening it to BAD_REQUEST (the P2 panel keys on it).
+ *
+ * Mock surface mirrors blocks.router.reviewSandbox.test.ts so importing the
+ * router doesn't drag in the generated Prisma client.
+ */
+
+const {
+  mockIsAppBlocksEnabled,
+  mockIsReviewSandboxEnabled,
+  mockIsAgenticEnabled,
+  mockGetAgentReport,
+  mockStartAgentReview,
+  mockPreviewRequest,
+  mockGetReviewStatus,
+  mockMintReviewBlockToken,
+  mockTeardownPreview,
+  mockListActivePreviews,
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockGetUserById,
+  mockGetUserBuzzAccounts,
+  mockLogToAxiom,
+  mockRedis,
+  mockSysRedis,
+  mockDbRead,
+} = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockIsReviewSandboxEnabled: vi.fn(),
+  mockIsAgenticEnabled: vi.fn(),
+  mockGetAgentReport: vi.fn(),
+  mockStartAgentReview: vi.fn(),
+  mockPreviewRequest: vi.fn(),
+  mockGetReviewStatus: vi.fn(),
+  mockMintReviewBlockToken: vi.fn(),
+  mockTeardownPreview: vi.fn(),
+  mockListActivePreviews: vi.fn(),
+  mockVerifyBlockToken: vi.fn(),
+  mockParseSubjectUserId: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockGetUserBuzzAccounts: vi.fn(),
+  mockLogToAxiom: vi.fn(async () => undefined),
+  mockRedis: { get: vi.fn(), set: vi.fn() },
+  mockSysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  mockDbRead: {
+    modelVersion: { findUnique: vi.fn() },
+    modelBlockInstall: { findUnique: vi.fn() },
+    model: { findUnique: vi.fn() },
+    appBlockPublishRequest: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksReviewSandboxEnabled: mockIsReviewSandboxEnabled,
+  isAppBlocksAgenticReviewEnabled: mockIsAgenticEnabled,
+}));
+vi.mock('~/server/services/blocks/app-review-report.service', () => ({
+  getAgentReport: mockGetAgentReport,
+}));
+vi.mock('~/server/services/blocks/agent-review.service', () => ({
+  startAgentReview: mockStartAgentReview,
+}));
+vi.mock('~/server/services/blocks/publish-request.service', () => ({
+  previewRequest: mockPreviewRequest,
+  getReviewStatus: mockGetReviewStatus,
+  mintReviewBlockToken: mockMintReviewBlockToken,
+  teardownPreview: mockTeardownPreview,
+  listActiveReviewPreviews: mockListActivePreviews,
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...a: unknown[]) => mockParseSubjectUserId(...a),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
+  buildGenerationContext: vi.fn(),
+  createWorkflowStepsFromGraphInput: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(),
+}));
+vi.mock('~/server/services/user.service', () => ({
+  getUserById: (...a: unknown[]) => mockGetUserById(...a),
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>(
+    '@civitai/redis/client'
+  );
+  return { ...actual, redis: mockRedis, sysRedis: mockSysRedis };
+});
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: (...a: unknown[]) => mockGetUserBuzzAccounts(...a),
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...a: unknown[]) => mockLogToAxiom(...a),
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
+  return Promise.resolve(!!opts?.user?.isModerator);
+}
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: !!(user as { isModerator?: boolean })?.isModerator } as never,
+    track: undefined,
+  };
+}
+
+const modUser = { id: 1, isModerator: true, tier: 'free', username: 'mod' };
+const normalUser = { id: 2, isModerator: false, tier: 'free', username: 'user' };
+const PUBREQ = 'pubreq_0123456789ABCDEFGHJKMNPQRS';
+
+const REPORT = {
+  id: 'arar_1',
+  publishRequestId: PUBREQ,
+  slug: 'my-app',
+  kind: 'onsite',
+  version: '1.0.0',
+  status: 'complete',
+  model: 'test-model',
+  codeReview: { findings: [] },
+  securityAudit: { findings: [] },
+  scopeVerdicts: { scopes: [] },
+  summaryMd: 'ok',
+  costUsd: '0.010000',
+  tokenUsage: { promptTokens: 10, completionTokens: 5 },
+};
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset();
+  mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+  mockIsReviewSandboxEnabled.mockReset();
+  mockIsReviewSandboxEnabled.mockImplementation(fakePerUserFlag);
+  mockIsAgenticEnabled.mockReset();
+  mockIsAgenticEnabled.mockImplementation(fakePerUserFlag); // on for mods by default
+  mockGetAgentReport.mockReset();
+  mockGetAgentReport.mockResolvedValue(REPORT);
+  mockStartAgentReview.mockReset();
+  mockStartAgentReview.mockResolvedValue({ reportId: 'arar_1', status: 'running' });
+});
+
+describe('blocks.getAgentReview', () => {
+  it('moderator + flags on: reaches getAgentReport with the request id and returns the report', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const res = await caller.getAgentReview({ publishRequestId: PUBREQ });
+    expect(res?.status).toBe('complete');
+    expect(mockGetAgentReport).toHaveBeenCalledWith(PUBREQ);
+  });
+
+  it('moderator + flags on, no report: returns null', async () => {
+    mockGetAgentReport.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const res = await caller.getAgentReview({ publishRequestId: PUBREQ });
+    expect(res).toBeNull();
+    expect(mockGetAgentReport).toHaveBeenCalledWith(PUBREQ);
+  });
+
+  it('non-moderator: UNAUTHORIZED, service NOT reached', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(caller.getAgentReview({ publishRequestId: PUBREQ })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockGetAgentReport).not.toHaveBeenCalled();
+  });
+
+  it('anonymous: UNAUTHORIZED', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.getAgentReview({ publishRequestId: PUBREQ })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockGetAgentReport).not.toHaveBeenCalled();
+  });
+
+  it('moderator but the agentic-review flag OFF (flag-absent, fail-closed): UNAUTHORIZED (dark)', async () => {
+    mockIsAgenticEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(caller.getAgentReview({ publishRequestId: PUBREQ })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockGetAgentReport).not.toHaveBeenCalled();
+  });
+});
+
+describe('blocks.startAgentReview — CONFLICT preservation', () => {
+  it('moderator + flags on: reaches the service with the server-derived modUserId', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const res = await caller.startAgentReview({ publishRequestId: PUBREQ });
+    expect(res).toMatchObject({ status: 'running' });
+    expect(mockStartAgentReview).toHaveBeenCalledWith({ publishRequestId: PUBREQ, modUserId: 1 });
+  });
+
+  it('a service CONFLICT ("already running") is preserved as CONFLICT, not flattened to BAD_REQUEST', async () => {
+    mockStartAgentReview.mockRejectedValue(
+      new TRPCError({ code: 'CONFLICT', message: 'a review is already running for this request' })
+    );
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(caller.startAgentReview({ publishRequestId: PUBREQ })).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+  });
+
+  it('an opaque (non-TRPC) service error collapses to BAD_REQUEST', async () => {
+    mockStartAgentReview.mockRejectedValue(new Error('kaboom'));
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(caller.startAgentReview({ publishRequestId: PUBREQ })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+
+  it('moderator but the agentic-review flag OFF: UNAUTHORIZED, service NOT reached', async () => {
+    mockIsAgenticEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(caller.startAgentReview({ publishRequestId: PUBREQ })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockStartAgentReview).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -55,6 +55,7 @@ import {
   approveRequestSchema,
   backfillPublishRequestSchema,
   getMyPendingForSlugSchema,
+  getAgentReviewSchema,
   getPublishRequestDiffSchema,
   getPublishRequestScreenshotsSchema,
   getReviewStatusSchema,
@@ -1496,8 +1497,41 @@ export const blocksRouter = router({
           modUserId: ctx.user.id,
         });
       } catch (err) {
+        // Preserve a typed TRPCError's CODE (the service raises CONFLICT — "a
+        // review is already running" — which the P2 panel keys on to fall into
+        // the running state); only opaque errors collapse to BAD_REQUEST.
+        if (err instanceof TRPCError) throw err;
         throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
       }
+    }),
+
+  /**
+   * AGENTIC MOD CODE-REVIEW (App Blocks P2) — READ path. Returns the latest agent
+   * report row for a PENDING publish request (or null). This is the poll + render
+   * source for the `AgentReviewPanel` in the on-site review modal.
+   *
+   * Gated IDENTICALLY to startAgentReview (moderatorProcedure + the isModerator
+   * belt + enforceAppBlocksFlag + the dedicated mod-only `app-blocks-agentic-
+   * review` flag) so it ships DARK — the flag does not exist in Flipt yet, so
+   * isAppBlocksAgenticReviewEnabled fail-closes to false and this rejects.
+   */
+  getAgentReview: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(getAgentReviewSchema)
+    .query(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Agentic review is restricted to civitai team');
+      }
+      const { isAppBlocksAgenticReviewEnabled } = await import(
+        '~/server/services/app-blocks-flag'
+      );
+      if (!(await isAppBlocksAgenticReviewEnabled({ user: ctx.user }))) {
+        throw throwAuthorizationError('Agentic review is not enabled');
+      }
+      const { getAgentReport } = await import(
+        '~/server/services/blocks/app-review-report.service'
+      );
+      return getAgentReport(input.publishRequestId);
     }),
 
   /**

--- a/src/server/schema/blocks/publish-request.schema.ts
+++ b/src/server/schema/blocks/publish-request.schema.ts
@@ -163,6 +163,15 @@ export const startAgentReviewSchema = z.object({
 
 export type StartAgentReviewInput = z.infer<typeof startAgentReviewSchema>;
 
+/** Input for the MOD-ONLY agentic code-review READ path `blocks.getAgentReview`
+ *  (P2) — the poll + render source for the report of a PENDING request. Same
+ *  shape as previewRequest (the pending request id). */
+export const getAgentReviewSchema = z.object({
+  publishRequestId: z.string().min(1).max(64),
+});
+
+export type GetAgentReviewInput = z.infer<typeof getAgentReviewSchema>;
+
 export const teardownPreviewSchema = z.object({
   publishRequestId: z.string().min(1).max(64),
 });

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -402,6 +402,18 @@ const featureFlags = createFeatureFlags({
   // to mods + a curated cohort via the Flipt `app-blocks-author` flag (created
   // AFTER this merges: absent → static mod-only, identical to today).
   appBlocksAuthor: { availability: ['mod'], fliptKey: 'app-blocks-author' },
+  // App Blocks — AGENTIC MOD CODE-REVIEW panel (P2). CLIENT gate for the
+  // `AgentReviewPanel` in the on-site review modal. `availability: []` = DARK by
+  // default and FAILS CLOSED (empty availability → static eval false when Flipt
+  // is absent/down), so the panel does NOT render for ANYONE — mods included —
+  // until the Flipt `app-blocks-agentic-review` flag is created. This mirrors the
+  // server-side `isAppBlocksAgenticReviewEnabled` fail-closed gate on the
+  // `blocks.startAgentReview` / `getAgentReview` procs, so the whole feature is
+  // inert end-to-end on merge (NOT `['mod']`: that would render the panel for
+  // mods the moment this ships, before the flag exists). The Flipt key is the
+  // only on-switch + kill-switch. (Mirrors the `hiddenPrefsCompact` /
+  // `genTabDeferView` `availability: []` precedent.)
+  appBlocksAgenticReview: { availability: [], fliptKey: 'app-blocks-agentic-review' },
 });
 
 export const featureFlagKeys = Object.keys(featureFlags) as FeatureFlagKey[];


### PR DESCRIPTION
## App Blocks — agentic mod code-review, moderator UI (P2)

Additive. Ships **DARK** behind the `app-blocks-agentic-review` flag, which does
not exist yet, so it is **inert on merge**:

- **Client gate** — the new `appBlocksAgenticReview` feature flag has
  `availability: []` (+ a Flipt key), so it **fails closed for everyone (mods
  included)** until the flag is created (mirrors the `hiddenPrefsCompact` /
  `genTabDeferView` precedent). The panel does not render.
- **Server gate** — `blocks.getAgentReview` / `startAgentReview` stack
  `moderatorProcedure` + an `isModerator` belt + the app-blocks flag + the
  dedicated agentic-review flag. All fail closed → reject.

### What renders (when enabled)
`AgentReviewPanel` in the on-site review modal's **pending** flow, gated on the
client flag **and** `mode === 'pending'` **and** an on-site request
(external/connect are out of scope and hidden):

- **Run agentic review** → `startAgentReview`; the `CONFLICT` "already running"
  path is handled gracefully (refetch → running state, no crash).
- **States**: `running` → spinner + poll (`refetchInterval` stops on every
  terminal status); `complete` / `cost-capped` → report; `failed` → error +
  "Run again"; `torn-down` → note.
- **Report**: header (status/model/cost/tokens/dates), a required **advisory
  banner**, code-review findings + prior-version reconciliation, security
  findings + the three must-flag callouts (unexpected manifest keys / risky
  iframe sandbox grants / prompt-injection), and a scope-verdict table with
  over-broad / under-declared sections, a sensitive badge, and evidence
  file:line. Empty sections render a tidy "none found".

### Sanitization guard
The `codeReview` / `securityAudit` / `scopeVerdicts` / `tokenUsage` columns are
**adversarial LLM output** derived from an untrusted bundle. `agentReviewReport.ts`
is the boundary: tolerant Zod view-models (unknown keys stripped, missing →
empty, wrong-typed → absent, never throws). The panel renders every string as
**inert text** — no `dangerouslySetInnerHTML`, no raw HTML — which is the actual
stored-XSS-at-render guard (covered by a test that asserts `<img onerror>` /
`<script>` payloads do **not** become live DOM).

`startAgentReview` now preserves a typed `TRPCError`'s **code** (so the service's
`CONFLICT` survives instead of flattening to `BAD_REQUEST`); opaque errors still
collapse to `BAD_REQUEST`.

### Tests (complete coverage)
- `blocks.router.agentReview.test.ts` (9) — proc flag/mod/anon gating, null
  pass-through, `CONFLICT`-code preservation.
- `agentReviewReport.test.ts` (7) — tolerant parsing, wrong-typed/empty/null,
  content-not-transformed, helpers.
- `AgentReviewPanel.browser.test.tsx` (15, real Chromium) — render gate,
  trigger + CONFLICT, lifecycle + poll wiring, full report render,
  defensive/empty, and the adversarial-markup-as-inert-text guard.

Existing `OnsiteReviewModal.browser.test.tsx` (14) and
`blocks.router.reviewSandbox.test.ts` (17) stay green. `tsc --noEmit` clean for
touched files.

Chat is **P3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)