### PR TITLE
feat(creator-controls): hide model metrics (buzz/downloads/generations) for CP members

### DIFF
--- a/src/components/Account/CreatorControlsCard.tsx
+++ b/src/components/Account/CreatorControlsCard.tsx
@@ -1,0 +1,97 @@
+import { Button, Card, Divider, Stack, Switch, Text, Title } from '@mantine/core';
+import { IconBolt } from '@tabler/icons-react';
+import { useCreatorProgramRequirements } from '~/components/Buzz/CreatorProgramV2/CreatorProgram.util';
+import { useCurrentUserSettings, useMutateUserSettings } from '~/components/UserSettings/hooks';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useServerDomains } from '~/providers/AppProvider';
+import { syncAccount } from '~/utils/sync-account';
+
+/**
+ * Creator Controls: USER-default metric privacy (level 1 of 3). Sets the baseline
+ * hide flags for all of the creator's models. The flags only take effect while the
+ * user holds a valid Creator Program membership (enforced read-side); non/lapsed
+ * members see an upsell and disabled toggles.
+ */
+export function CreatorControlsCard() {
+  const user = useCurrentUser();
+  const serverDomains = useServerDomains();
+  const { requirements } = useCreatorProgramRequirements();
+  const { hideModelBuzz, hideModelDownloads, hideModelGenerations } = useCurrentUserSettings();
+  const { mutate: mutateSetting, isPending: isLoadingSetting } = useMutateUserSettings();
+
+  if (!user) return null;
+
+  const isActiveMember = !!requirements?.validMembership;
+  const membershipLapsed = !!requirements?.membershipLapsed;
+  const renewUrl = syncAccount(`//${serverDomains.green}/pricing`);
+
+  return (
+    <Card withBorder id="creator-controls">
+      <Stack>
+        <div>
+          <Title order={2}>Creator Controls</Title>
+          <Text size="sm" c="dimmed">
+            Hide public metrics on your models. These are Creator Program benefits — they only apply
+            while your membership is active. You and moderators always see your real stats.
+          </Text>
+        </div>
+
+        {!isActiveMember && (
+          <Card withBorder radius="md" className="bg-gray-0 dark:bg-dark-6">
+            <Stack gap="xs">
+              <Text fw={600}>
+                {membershipLapsed
+                  ? 'Your Creator Program membership has lapsed'
+                  : 'A Creator Program membership is required'}
+              </Text>
+              <Text size="sm" c="dimmed">
+                {membershipLapsed
+                  ? 'Renew to keep your metric-privacy settings active. While lapsed, your metrics are shown publicly again.'
+                  : 'Join the Creator Program to hide your model metrics from the public.'}
+              </Text>
+              <Button
+                component="a"
+                href={membershipLapsed ? renewUrl : '/creator-program'}
+                leftSection={<IconBolt size={16} />}
+                variant="light"
+                color="yellow"
+                w="fit-content"
+              >
+                {membershipLapsed ? 'Renew membership' : 'Join the Creator Program'}
+              </Button>
+            </Stack>
+          </Card>
+        )}
+
+        <Divider label="Default metric privacy" />
+        <Switch
+          name="hideModelBuzz"
+          label="Hide tipped / earned Buzz"
+          description="Others won't see the Buzz earned on your models."
+          checked={hideModelBuzz ?? false}
+          onChange={(e) => mutateSetting({ hideModelBuzz: e.target.checked })}
+          disabled={isLoadingSetting || !isActiveMember}
+          styles={{ track: { flex: '0 0 1em' } }}
+        />
+        <Switch
+          name="hideModelDownloads"
+          label="Hide download count"
+          description="Others won't see how many times your models were downloaded."
+          checked={hideModelDownloads ?? false}
+          onChange={(e) => mutateSetting({ hideModelDownloads: e.target.checked })}
+          disabled={isLoadingSetting || !isActiveMember}
+          styles={{ track: { flex: '0 0 1em' } }}
+        />
+        <Switch
+          name="hideModelGenerations"
+          label="Hide generation count"
+          description="Others won't see how many images were generated with your models."
+          checked={hideModelGenerations ?? false}
+          onChange={(e) => mutateSetting({ hideModelGenerations: e.target.checked })}
+          disabled={isLoadingSetting || !isActiveMember}
+          styles={{ track: { flex: '0 0 1em' } }}
+        />
+      </Stack>
+    </Card>
+  );
+}

--- a/src/components/Account/CreatorControlsCard.tsx
+++ b/src/components/Account/CreatorControlsCard.tsx
@@ -3,6 +3,7 @@ import { IconBolt } from '@tabler/icons-react';
 import { useCreatorProgramRequirements } from '~/components/Buzz/CreatorProgramV2/CreatorProgram.util';
 import { useCurrentUserSettings, useMutateUserSettings } from '~/components/UserSettings/hooks';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { useServerDomains } from '~/providers/AppProvider';
 import { syncAccount } from '~/utils/sync-account';
 
@@ -14,9 +15,11 @@ import { syncAccount } from '~/utils/sync-account';
  */
 export function CreatorControlsCard() {
   const user = useCurrentUser();
+  const flags = useFeatureFlags();
   const serverDomains = useServerDomains();
   const { requirements } = useCreatorProgramRequirements();
-  const { hideModelBuzz, hideModelDownloads, hideModelGenerations } = useCurrentUserSettings();
+  const { hideModelBuzz, hideModelDownloads, hideModelGenerations, hideDonationGoals } =
+    useCurrentUserSettings();
   const { mutate: mutateSetting, isPending: isLoadingSetting } = useMutateUserSettings();
 
   if (!user) return null;
@@ -31,9 +34,10 @@ export function CreatorControlsCard() {
         <div>
           <Title order={2}>Creator Controls</Title>
           <Text size="sm" c="dimmed">
-            Hide public metrics on your models. These are Creator Program benefits — they only apply
-            while your membership is active. You and moderators always see your real stats on model
-            pages and cards; on search results you&apos;ll see the hidden state, same as the public.
+            Hide public metrics and donation goals on your models. These are Creator Program
+            benefits — they only apply while your membership is active, and revert to visible if it
+            lapses. You and moderators always see your real stats on model pages and cards; on
+            search results you&apos;ll see the hidden state, same as the public.
           </Text>
         </div>
 
@@ -92,6 +96,21 @@ export function CreatorControlsCard() {
           disabled={isLoadingSetting || !isActiveMember}
           styles={{ track: { flex: '0 0 1em' } }}
         />
+
+        {flags.donationGoals && (
+          <>
+            <Divider label="Donation goals" />
+            <Switch
+              name="hideDonationGoals"
+              label="Hide my donation goals from public view"
+              description="Others won't see the progress bar or collected amount on your donation goals. The goal keeps working, and you and moderators can still see it."
+              checked={hideDonationGoals ?? false}
+              onChange={(e) => mutateSetting({ hideDonationGoals: e.target.checked })}
+              disabled={isLoadingSetting || !isActiveMember}
+              styles={{ track: { flex: '0 0 1em' } }}
+            />
+          </>
+        )}
       </Stack>
     </Card>
   );

--- a/src/components/Account/CreatorControlsCard.tsx
+++ b/src/components/Account/CreatorControlsCard.tsx
@@ -1,6 +1,25 @@
-import { Button, Card, Divider, Stack, Switch, Text, Title } from '@mantine/core';
-import { IconBolt } from '@tabler/icons-react';
+import {
+  Alert,
+  Button,
+  Card,
+  Divider,
+  Group,
+  Stack,
+  Switch,
+  Text,
+  ThemeIcon,
+  Title,
+} from '@mantine/core';
+import {
+  IconCircleCheck,
+  IconInfoCircle,
+  IconLock,
+  IconRefresh,
+  IconUserPlus,
+  IconUsers,
+} from '@tabler/icons-react';
 import { useCreatorProgramRequirements } from '~/components/Buzz/CreatorProgramV2/CreatorProgram.util';
+import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
 import { useCurrentUserSettings, useMutateUserSettings } from '~/components/UserSettings/hooks';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -31,44 +50,70 @@ export function CreatorControlsCard() {
   return (
     <Card withBorder id="creator-controls">
       <Stack>
-        <div>
-          <Title order={2}>Creator Controls</Title>
-          <Text size="sm" c="dimmed">
-            Hide public metrics and donation goals on your models. These are Creator Program
-            benefits — they only apply while your membership is active, and revert to visible if it
-            lapses. You and moderators always see your real stats on model pages and cards; on
-            search results you&apos;ll see the hidden state, same as the public.
-          </Text>
-        </div>
+        <Title order={2}>Creator Controls</Title>
 
-        {!isActiveMember && (
-          <Card withBorder radius="md" className="bg-gray-0 dark:bg-dark-6">
-            <Stack gap="xs">
-              <Text fw={600}>
-                {membershipLapsed
-                  ? 'Your Creator Program membership has lapsed'
-                  : 'A Creator Program membership is required'}
-              </Text>
-              <Text size="sm" c="dimmed">
-                {membershipLapsed
-                  ? 'Renew to keep your metric-privacy settings active. While lapsed, your metrics are shown publicly again.'
-                  : 'Join the Creator Program to hide your model metrics from the public.'}
-              </Text>
-              <Button
-                component="a"
-                href={membershipLapsed ? renewUrl : '/creator-program'}
-                leftSection={<IconBolt size={16} />}
-                variant="light"
-                color="yellow"
-                w="fit-content"
-              >
-                {membershipLapsed ? 'Renew membership' : 'Join the Creator Program'}
-              </Button>
+        {isActiveMember ? (
+          <Alert color="blue" variant="light" icon={<IconInfoCircle size={16} />}>
+            <Text size="sm">
+              These controls are a Creator Program benefit. They apply while your membership is
+              active and revert if it lapses.
+            </Text>
+          </Alert>
+        ) : (
+          <div className="flex flex-col items-center gap-3 rounded-lg border border-gray-2 bg-gray-0 p-6 text-center dark:border-dark-4 dark:bg-dark-5">
+            <ThemeIcon size={48} variant="light" color="gray" radius="xl">
+              {membershipLapsed ? <IconLock size={24} /> : <IconUsers size={24} />}
+            </ThemeIcon>
+            <Text fw={700} size="lg">
+              {membershipLapsed ? 'Membership lapsed' : 'Creator Program members only'}
+            </Text>
+            <Text size="sm" c="dimmed" maw={380}>
+              {membershipLapsed
+                ? 'Renew your Creator Program membership to restore your Creator Controls and the rest of your perks:'
+                : 'Gain more control over how your models are presented, plus the rest of the Creator Program:'}
+            </Text>
+            <Stack gap={6} align="flex-start" ta="left">
+              {[
+                'Hide your model metrics and donation goals',
+                'Earn real cash from your creations',
+                'Open your own creator shop',
+              ].map((perk) => (
+                <Group key={perk} gap={8} wrap="nowrap">
+                  <IconCircleCheck
+                    size={16}
+                    className="shrink-0"
+                    style={{ color: 'var(--mantine-color-green-6)' }}
+                  />
+                  <Text size="sm">{perk}</Text>
+                </Group>
+              ))}
             </Stack>
-          </Card>
+            <Button
+              component="a"
+              href={membershipLapsed ? renewUrl : '/creator-program'}
+              variant="filled"
+              size="sm"
+              leftSection={membershipLapsed ? <IconRefresh size={16} /> : <IconUserPlus size={16} />}
+              className="w-fit"
+            >
+              {membershipLapsed ? 'Renew membership' : 'Join the Creator Program'}
+            </Button>
+          </div>
         )}
 
-        <Divider label="Default metric privacy" />
+        <Divider
+          label={
+            <Group gap={4} wrap="nowrap">
+              Default metric privacy
+              <InfoPopover size="xs" iconProps={{ size: 14 }} width={300}>
+                <Text size="sm" maw={280} style={{ whiteSpace: 'normal' }}>
+                  You and moderators still see your real stats on model pages and cards. On search
+                  results you see the hidden state, same as the public.
+                </Text>
+              </InfoPopover>
+            </Group>
+          }
+        />
         <Switch
           name="hideModelBuzz"
           label="Hide tipped / earned Buzz"
@@ -103,7 +148,7 @@ export function CreatorControlsCard() {
             <Switch
               name="hideDonationGoals"
               label="Hide my donation goals from public view"
-              description="Others won't see the progress bar or collected amount on your donation goals. The goal keeps working, and you and moderators can still see it."
+              description="Others won't see the progress bar or collected amount. The goal still works."
               checked={hideDonationGoals ?? false}
               onChange={(e) => mutateSetting({ hideDonationGoals: e.target.checked })}
               disabled={isLoadingSetting || !isActiveMember}

--- a/src/components/Account/CreatorControlsCard.tsx
+++ b/src/components/Account/CreatorControlsCard.tsx
@@ -32,7 +32,8 @@ export function CreatorControlsCard() {
           <Title order={2}>Creator Controls</Title>
           <Text size="sm" c="dimmed">
             Hide public metrics on your models. These are Creator Program benefits — they only apply
-            while your membership is active. You and moderators always see your real stats.
+            while your membership is active. You and moderators always see your real stats on model
+            pages and cards; on search results you&apos;ll see the hidden state, same as the public.
           </Text>
         </div>
 

--- a/src/components/Account/SettingsCard.tsx
+++ b/src/components/Account/SettingsCard.tsx
@@ -46,7 +46,7 @@ export function SettingsCard() {
     },
   });
 
-  const { assistantPersonality, hideDonationGoals } = useCurrentUserSettings();
+  const { assistantPersonality } = useCurrentUserSettings();
   const { mutate: mutateSetting, isPending: isLoadingSetting } = useMutateUserSettings();
 
   if (!user) return null;
@@ -201,21 +201,6 @@ export function SettingsCard() {
                 </div>
               </Tooltip>
             </Stack>
-          </>
-        )}
-
-        {flags.donationGoals && (
-          <>
-            <Divider label="Creator Preferences" />
-            <Switch
-              name="hideDonationGoals"
-              label="Hide my donation goals from public view"
-              description="Others won't see the progress bar or collected amount on your donation goals. The goal keeps working, and you and moderators can still see it."
-              checked={hideDonationGoals ?? false}
-              onChange={(e) => mutateSetting({ hideDonationGoals: e.target.checked })}
-              disabled={isLoadingSetting}
-              styles={{ track: { flex: '0 0 1em' } }}
-            />
           </>
         )}
 

--- a/src/components/AutocompleteSearch/renderItems/models.tsx
+++ b/src/components/AutocompleteSearch/renderItems/models.tsx
@@ -7,6 +7,7 @@ import { ViewMoreItem } from '~/components/AutocompleteSearch/renderItems/common
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { IconBadge } from '~/components/IconBadge/IconBadge';
 import { MediaHash } from '~/components/ImageHash/ImageHash';
+import { HiddenMetricNotice } from '~/components/Model/HiddenMetricNotice';
 import type { SearchIndexDataMap } from '~/components/Search/search.utils2';
 import { ThumbsUpIcon } from '~/components/ThumbsIcon/ThumbsIcon';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
@@ -25,7 +26,7 @@ export const ModelSearchItem = forwardRef<
 
   if (!hit) return <ViewMoreItem ref={ref} value={value} {...props} />;
 
-  const { images, user, type, category, metrics, version, nsfw } = hit;
+  const { images, user, type, category, metrics, version, nsfw, hiddenMetrics } = hit;
   const coverImage = images[0];
   const alt = coverImage.name;
 
@@ -97,7 +98,11 @@ export const ModelSearchItem = forwardRef<
             {abbreviateNumber(metrics.commentCount)}
           </IconBadge>
           <IconBadge icon={<IconDownload size={12} stroke={2.5} />}>
-            {abbreviateNumber(metrics.downloadCount)}
+            {hiddenMetrics?.downloads ? (
+              <HiddenMetricNotice size={12} />
+            ) : (
+              abbreviateNumber(metrics.downloadCount ?? 0)
+            )}
           </IconBadge>
         </Group>
       </Stack>

--- a/src/components/Cards/ModelCard.tsx
+++ b/src/components/Cards/ModelCard.tsx
@@ -29,7 +29,9 @@ import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImag
 import { CivitaiLinkManageButton } from '~/components/CivitaiLink/CivitaiLinkManageButton';
 import { useElementInView } from '~/components/IntersectionObserver/ElementInView';
 import { AnimatedCount, Metrics } from '~/components/Metrics';
+import { HiddenMetricNotice } from '~/components/Model/HiddenMetricNotice';
 import type { UseQueryModelReturn } from '~/components/Model/model.utils';
+import type { HiddenModelMetrics } from '~/server/utils/model-metric-privacy';
 import { ModelTypeBadge } from '~/components/Model/ModelTypeBadge/ModelTypeBadge';
 import { ThumbsUpIcon } from '~/components/ThumbsIcon/ThumbsIcon';
 import { UserAvatarSimple } from '~/components/UserAvatar/UserAvatarSimple';
@@ -96,7 +98,10 @@ function ModelCardContent({ data }: Props) {
   );
 
   const { useModelVersionRedirect, activeBaseModels } = useModelCardContext();
-  const cardBaseModels = getCardBaseModels(data as Parameters<typeof getCardBaseModels>[0], activeBaseModels);
+  const cardBaseModels = getCardBaseModels(
+    data as Parameters<typeof getCardBaseModels>[0],
+    activeBaseModels
+  );
   // In search, data.version is the primary version; data.versions[] carries all of
   // them, so link to the version that matched the active base-model filter. The feed
   // has no versions[] (data.version is already the matched one), so it falls back.
@@ -221,6 +226,7 @@ function ModelCardStats({ data }: { data: Props['data'] }) {
   const { isEngaged } = useEngagedModelMembership(data.id);
   const hasReview = isEngaged('Recommended');
   const isPOI = data.poi;
+  const hiddenMetrics = (data as { hiddenMetrics?: HiddenModelMetrics }).hiddenMetrics;
 
   const baseMetrics = useMemo(
     () => ({
@@ -235,12 +241,7 @@ function ModelCardStats({ data }: { data: Props['data'] }) {
   );
 
   return (
-    <Metrics
-      entityType="Model"
-      entityId={data.id}
-      initial={baseMetrics}
-      useLive={inView !== false}
-    >
+    <Metrics entityType="Model" entityId={data.id} initial={baseMetrics} useLive={inView !== false}>
       {(m) => {
         const totalCount = m.thumbsUpCount + m.thumbsDownCount;
         const positiveRating = totalCount > 0 ? m.thumbsUpCount / totalCount : 0;
@@ -256,7 +257,11 @@ function ModelCardStats({ data }: { data: Props['data'] }) {
                 <div className="flex items-center gap-0.5">
                   <IconDownload size={14} strokeWidth={2.5} />
                   <Text size="xs" lh={1} fw="bold">
-                    <AnimatedCount value={m.downloadCount} />
+                    {hiddenMetrics?.downloads ? (
+                      <HiddenMetricNotice size={12} />
+                    ) : (
+                      <AnimatedCount value={m.downloadCount} />
+                    )}
                   </Text>
                 </div>
                 <div className="flex items-center gap-0.5">
@@ -280,7 +285,11 @@ function ModelCardStats({ data }: { data: Props['data'] }) {
                     <div className="flex items-center gap-0.5">
                       <IconBolt size={14} strokeWidth={2.5} />
                       <Text size="xs" lh={1} fw="bold">
-                        <AnimatedCount value={m.tippedAmountCount + tippedAmount} />
+                        {hiddenMetrics?.buzz ? (
+                          <HiddenMetricNotice size={12} />
+                        ) : (
+                          <AnimatedCount value={m.tippedAmountCount + tippedAmount} />
+                        )}
                       </Text>
                     </div>
                   </InteractiveTipBuzzButton>

--- a/src/components/Model/Categories/ModelCategoryCard.tsx
+++ b/src/components/Model/Categories/ModelCategoryCard.tsx
@@ -58,6 +58,7 @@ import { openReportModal } from '~/components/Dialog/triggers/report';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { ElementInView, useElementInView } from '~/components/IntersectionObserver/ElementInView';
 import { AnimatedCount, Metrics } from '~/components/Metrics';
+import { HiddenMetricNotice } from '~/components/Model/HiddenMetricNotice';
 import classes from './ModelCategoryCard.module.css';
 import clsx from 'clsx';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -131,7 +132,6 @@ function ModelCategoryCardContent({
       )}
     </>
   );
-
 
   const reportOption = {
     key: 'report-model',
@@ -459,7 +459,7 @@ function ModelCategoryCardStats({
       entityType="Model"
       entityId={data.id}
       initial={{
-        downloadCount: data.rank.downloadCount,
+        downloadCount: data.rank.downloadCount ?? 0,
         thumbsUpCount: data.rank.thumbsUpCount,
         commentCount: data.rank.commentCount,
       }}
@@ -491,7 +491,11 @@ function ModelCategoryCardStats({
           )}
           <IconBadge className={classes.statBadge} icon={<IconDownload size={14} />}>
             <Text fz={12}>
-              <AnimatedCount value={m.downloadCount} />
+              {data.hiddenMetrics?.downloads ? (
+                <HiddenMetricNotice size={12} />
+              ) : (
+                <AnimatedCount value={m.downloadCount ?? 0} />
+              )}
             </Text>
           </IconBadge>
         </Group>

--- a/src/components/Model/HiddenMetricNotice.tsx
+++ b/src/components/Model/HiddenMetricNotice.tsx
@@ -1,0 +1,23 @@
+import { Text, Tooltip } from '@mantine/core';
+import { IconEyeOff } from '@tabler/icons-react';
+
+/**
+ * Ranking-surface treatment for a metric a Creator Program member has hidden. The
+ * model stays listed and the sort order still uses the real value server-side; only
+ * the exposed number is replaced with this subtle notice + an invite for others to
+ * do the same.
+ */
+export function HiddenMetricNotice({ size = 14 }: { size?: number }) {
+  return (
+    <Tooltip
+      multiline
+      w={220}
+      withArrow
+      label="This creator has hidden this metric. Creator Program members can hide theirs too."
+    >
+      <Text component="span" c="dimmed" className="inline-flex items-center" lh={1}>
+        <IconEyeOff size={size} />
+      </Text>
+    </Tooltip>
+  );
+}

--- a/src/components/Resource/Forms/ModelUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelUpsertForm.tsx
@@ -29,6 +29,7 @@ import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { InfoPopover } from '~/components/InfoPopover/InfoPopover';
 import { SubscriptionRequiredBlock } from '~/components/Subscriptions/SubscriptionRequiredBlock';
+import { useCreatorProgramRequirements } from '~/components/Buzz/CreatorProgramV2/CreatorProgram.util';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import {
   Form,
@@ -39,6 +40,7 @@ import {
   InputRTE,
   InputSegmentedControl,
   InputSelect,
+  InputSwitch,
   InputTags,
   InputText,
   useForm,
@@ -173,6 +175,8 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
   const hasSfwOnlyNsfw = nsfw && sfwOnly;
   const { isDirty, errors } = form.formState;
   const features = useFeatureFlags();
+  const { requirements } = useCreatorProgramRequirements();
+  const isActiveCreatorMember = !!requirements?.validMembership;
 
   const chipProps: Partial<ChipProps> = {
     size: 'sm',
@@ -446,6 +450,39 @@ export function ModelUpsertForm({ id, model, children, onSubmit, modelVersionId 
                 username={modelUser}
               />
             )}
+            <Paper radius="md" p="md" withBorder>
+              <Stack gap="xs">
+                <div>
+                  <Text size="sm" fw={600}>
+                    Creator Controls: metric privacy
+                  </Text>
+                  <Text size="xs" c="dimmed">
+                    Hide these public stats on this model&apos;s page and cards.{' '}
+                    {isActiveCreatorMember
+                      ? 'You and moderators always see your real stats.'
+                      : 'Requires an active Creator Program membership — these only apply while your membership is active.'}
+                  </Text>
+                </div>
+                <InputSwitch
+                  name="meta.hideBuzz"
+                  label="Hide tipped / earned Buzz"
+                  disabled={!isActiveCreatorMember}
+                  styles={{ track: { flex: '0 0 1em' } }}
+                />
+                <InputSwitch
+                  name="meta.hideDownloads"
+                  label="Hide download count"
+                  disabled={!isActiveCreatorMember}
+                  styles={{ track: { flex: '0 0 1em' } }}
+                />
+                <InputSwitch
+                  name="meta.hideGenerations"
+                  label="Hide generation count"
+                  disabled={!isActiveCreatorMember}
+                  styles={{ track: { flex: '0 0 1em' } }}
+                />
+              </Stack>
+            </Paper>
           </Stack>
         </ContainerGrid2.Col>
         <ContainerGrid2.Col span={12}>

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -29,6 +29,7 @@ import {
   MIN_DONATION_GOAL,
 } from '~/components/Model/ModelVersions/model-version.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useCreatorProgramRequirements } from '~/components/Buzz/CreatorProgramV2/CreatorProgram.util';
 import { useCurrentUserSettings, useMutateUserSettings } from '~/components/UserSettings/hooks';
 import {
   Form,
@@ -60,6 +61,7 @@ import type { GenerationResourceSchema } from '~/server/schema/generation.schema
 import { generationResourceSchema } from '~/server/schema/generation.schema';
 import type {
   ModelVersionEarlyAccessConfig,
+  ModelVersionMeta,
   ModelVersionUpsertInput,
   RecommendedSettingsSchema,
 } from '~/server/schema/model-version.schema';
@@ -171,6 +173,8 @@ export function ModelVersionUpsertForm({
   const { hideDonationGoals } = useCurrentUserSettings();
   const { mutate: mutateUserSettings, isPending: hideDonationGoalsUpdating } =
     useMutateUserSettings();
+  const { requirements } = useCreatorProgramRequirements();
+  const isActiveCreatorMember = !!requirements?.validMembership;
   const lastUsedBaseModel = useLastUsedBaseModelStore((s) => s.lastUsedBaseModel);
   const setLastUsedBaseModel = useLastUsedBaseModelStore((s) => s.setLastUsedBaseModel);
   // For a brand-new version, seed the base model from the previous version (if any),
@@ -235,6 +239,11 @@ export function ModelVersionUpsertForm({
     usageControl: !!version?.usageControl
       ? version?.usageControl ?? ModelUsageControl.Download
       : ModelUsageControl.Download,
+    meta: {
+      hideBuzz: (version?.meta as ModelVersionMeta | null)?.hideBuzz ?? false,
+      hideDownloads: (version?.meta as ModelVersionMeta | null)?.hideDownloads ?? false,
+      hideGenerations: (version?.meta as ModelVersionMeta | null)?.hideGenerations ?? false,
+    },
   };
 
   const form = useForm({ schema, defaultValues, shouldUnregister: false, mode: 'onChange' });
@@ -449,6 +458,11 @@ export function ModelVersionUpsertForm({
             ? version?.earlyAccessConfig
             : null,
         recommendedResources: version.recommendedResources ?? [],
+        meta: {
+          hideBuzz: (version.meta as ModelVersionMeta | null)?.hideBuzz ?? false,
+          hideDownloads: (version.meta as ModelVersionMeta | null)?.hideDownloads ?? false,
+          hideGenerations: (version.meta as ModelVersionMeta | null)?.hideGenerations ?? false,
+        },
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [acceptsTrainedWords, isTextualInversion, model?.id, version]);
@@ -1002,6 +1016,35 @@ export function ModelVersionUpsertForm({
             includeControls={['formatting', 'list', 'link']}
             editorSize="xl"
           />
+          <Stack gap="xs">
+            <Divider label="Version metric privacy" />
+            <Text size="xs" c="dimmed">
+              Hide these stats in this version&apos;s details card. This is a sub-option of the
+              model-level controls — hiding at the model level already hides the model page totals
+              and cards.{' '}
+              {isActiveCreatorMember
+                ? 'You and moderators always see your real stats.'
+                : 'Requires an active Creator Program membership.'}
+            </Text>
+            <InputSwitch
+              name="meta.hideBuzz"
+              label="Hide earned Buzz"
+              disabled={!isActiveCreatorMember}
+              styles={{ track: { flex: '0 0 1em' } }}
+            />
+            <InputSwitch
+              name="meta.hideDownloads"
+              label="Hide download count"
+              disabled={!isActiveCreatorMember}
+              styles={{ track: { flex: '0 0 1em' } }}
+            />
+            <InputSwitch
+              name="meta.hideGenerations"
+              label="Hide generation count"
+              disabled={!isActiveCreatorMember}
+              styles={{ track: { flex: '0 0 1em' } }}
+            />
+          </Stack>
           {acceptsTrainedWords && (
             <Stack gap="xs">
               {!skipTrainedWords && (
@@ -1153,9 +1196,10 @@ type Props = {
   // picker when adding a brand-new version to an existing model.
   previousBaseModel?: string | null;
   // licensingFee comes off a Prisma read as a Decimal; the form coerces it to a number in defaultValues.
-  version?: Omit<Partial<VersionInput>, 'licensingFee'> & {
+  version?: Omit<Partial<VersionInput>, 'licensingFee' | 'meta'> & {
     licensingFee?: number | { valueOf(): string } | null;
     flags?: number;
+    meta?: unknown;
   };
   afterName?: React.ReactNode;
 };

--- a/src/components/Search/parsers/model.parser.ts
+++ b/src/components/Search/parsers/model.parser.ts
@@ -9,11 +9,14 @@ import { IMAGES_SEARCH_INDEX, MODELS_SEARCH_INDEX } from '~/server/common/consta
 export const ModelSearchIndexSortBy = [
   MODELS_SEARCH_INDEX,
   `${MODELS_SEARCH_INDEX}:metrics.thumbsUpCount:desc`,
-  `${MODELS_SEARCH_INDEX}:metrics.downloadCount:desc`,
+  // Creator Controls: sort on the REAL sort-only mirrors — the displayed
+  // `metrics.downloadCount` / `metrics.tippedAmountCount` are masked to null when a
+  // creator hides them, so sorting on those would break the order.
+  `${MODELS_SEARCH_INDEX}:sortMetrics.downloadCount:desc`,
   `${MODELS_SEARCH_INDEX}:metrics.favoriteCount:desc`,
   `${MODELS_SEARCH_INDEX}:metrics.commentCount:desc`,
   `${MODELS_SEARCH_INDEX}:metrics.collectedCount:desc`,
-  `${MODELS_SEARCH_INDEX}:metrics.tippedAmountCount:desc`,
+  `${MODELS_SEARCH_INDEX}:sortMetrics.tippedAmountCount:desc`,
   `${MODELS_SEARCH_INDEX}:createdAt:desc`,
 ] as const;
 

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -11,6 +11,9 @@ import type { MediaType } from '~/shared/utils/prisma/enums';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import { removeTags } from '~/utils/string-helpers';
 import { buildOgCoverEdgeUrl, fetchImageAsDataUri } from '~/server/utils/og-image-helpers';
+import { hasValidCreatorMembership } from '~/server/services/creator-program.service';
+import { resolveModelHiddenMetrics } from '~/server/utils/model-metric-privacy';
+import { isDefined } from '~/utils/type-guards';
 
 // --- Schema & Types ---
 
@@ -142,7 +145,9 @@ async function fetchModelData(id: number): Promise<EntityData | null> {
     select: {
       name: true,
       description: true,
-      user: { select: { username: true } },
+      meta: true,
+      userId: true,
+      user: { select: { username: true, settings: true } },
       modelVersions: {
         where: { status: 'Published' },
         select: { id: true, description: true },
@@ -155,6 +160,15 @@ async function fetchModelData(id: number): Promise<EntityData | null> {
 
   const publishedVersion = model.modelVersions[0];
   if (!publishedVersion) return null;
+
+  // Creator Controls: the OG card is a public, shared asset — gate downloads /
+  // generations by the owner's stored flags + active CP membership.
+  const hidden = resolveModelHiddenMetrics({
+    modelMeta: model.meta,
+    userSettings: model.user?.settings,
+    isOwnerOrModerator: false,
+    hasValidMembership: await hasValidCreatorMembership(model.userId),
+  });
 
   // Run metric + image queries in parallel
   const [metric, image] = await Promise.all([
@@ -183,11 +197,13 @@ async function fetchModelData(id: number): Promise<EntityData | null> {
 
   const stats: StatItem[] = metric
     ? [
-        { value: formatStat(metric.downloadCount), label: 'Downloads' },
+        !hidden.downloads ? { value: formatStat(metric.downloadCount), label: 'Downloads' } : null,
         { value: formatStat(metric.thumbsUpCount), label: 'Likes' },
-        { value: formatStat(metric.generationCount), label: 'Generations' },
+        !hidden.generations
+          ? { value: formatStat(metric.generationCount), label: 'Generations' }
+          : null,
         { value: formatStat(metric.commentCount), label: 'Comments' },
-      ]
+      ].filter(isDefined)
     : [];
 
   const description = publishedVersion.description || model.description || '';

--- a/src/pages/api/v1/model-versions/[id].ts
+++ b/src/pages/api/v1/model-versions/[id].ts
@@ -24,6 +24,8 @@ import {
 } from '~/shared/constants/browsingLevel.constants';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 import { logToAxiom } from '~/server/logging/client';
+import { hasValidCreatorMembership } from '~/server/services/creator-program.service';
+import { resolveVersionHiddenMetrics } from '~/server/utils/model-metric-privacy';
 
 const hashesAsObject = (hashes: { type: ModelHashType; hash: string }[]) =>
   hashes.reduce((acc, { type, hash }) => ({ ...acc, [type]: hash }), {});
@@ -182,6 +184,26 @@ export async function prepareModelVersionResponse(
   const includeDownloadUrl = model.mode !== ModelModifier.Archived;
   const includeImages = model.mode !== ModelModifier.TakenDown;
 
+  // Creator Controls: gate the version download count (public API — no owner/mod
+  // bypass wired here, matching buildPublicModelResponse). The base query doesn't
+  // carry meta/owner, so fetch the privacy inputs directly.
+  const privacy = await dbRead.modelVersion.findUnique({
+    where: { id: version.id },
+    select: {
+      meta: true,
+      model: { select: { meta: true, userId: true, user: { select: { settings: true } } } },
+    },
+  });
+  const hidden = resolveVersionHiddenMetrics({
+    versionMeta: privacy?.meta,
+    modelMeta: privacy?.model?.meta,
+    userSettings: privacy?.model?.user?.settings,
+    isOwnerOrModerator: false,
+    hasValidMembership: privacy?.model?.userId
+      ? await hasValidCreatorMembership(privacy.model.userId)
+      : false,
+  });
+
   return {
     ...version,
     // licensingFee is a Prisma Decimal; coerce so the public API keeps emitting a number, not a JSON string.
@@ -194,7 +216,7 @@ export async function prepareModelVersionResponse(
       fileType: primaryFile.type,
     }),
     stats: {
-      downloadCount: metrics[0]?.downloadCount ?? 0,
+      downloadCount: hidden.downloads ? null : metrics[0]?.downloadCount ?? 0,
       thumbsUpCount: metrics[0]?.thumbsUpCount ?? 0,
     },
     model: { ...model, mode: model.mode == null ? undefined : model.mode },

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -92,6 +92,7 @@ import { ReorderVersionsModal } from '~/components/Modals/ReorderVersionsModal';
 import { ToggleLockModel } from '~/components/Model/Actions/ToggleLockModel';
 import { ToggleLockModelComments } from '~/components/Model/Actions/ToggleLockModelComments';
 import { HowToButton } from '~/components/Model/HowToUseModel/HowToUseModel';
+import { HiddenMetricNotice } from '~/components/Model/HiddenMetricNotice';
 import { ModelVersionList } from '~/components/Model/ModelVersionList/ModelVersionList';
 import { useModelVersionPermission } from '~/components/Model/ModelVersions/model-version.utils';
 import { ModelVersionDetails } from '~/components/Model/ModelVersions/ModelVersionDetails';
@@ -863,7 +864,11 @@ export default function ModelDetailsV2({
                     >
                       <IconBadge radius="sm" size="lg" icon={<IconDownload size={18} />}>
                         <Text className={classes.modelBadgeText}>
-                          {abbreviateNumber(model.rank?.downloadCountAllTime ?? 0)}
+                          {model.hiddenMetrics?.downloads ? (
+                            <HiddenMetricNotice />
+                          ) : (
+                            abbreviateNumber(model.rank?.downloadCountAllTime ?? 0)
+                          )}
                         </Text>
                       </IconBadge>
                     </StatHoverCard>
@@ -875,7 +880,11 @@ export default function ModelDetailsV2({
                       >
                         <IconBadge radius="sm" size="lg" icon={<IconBrush size={18} />}>
                           <Text className={classes.modelBadgeText}>
-                            {abbreviateNumber(model.rank?.generationCountAllTime ?? 0)}
+                            {model.hiddenMetrics?.generations ? (
+                              <HiddenMetricNotice />
+                            ) : (
+                              abbreviateNumber(model.rank?.generationCountAllTime ?? 0)
+                            )}
                           </Text>
                         </IconBadge>
                       </GenerateButton>
@@ -919,7 +928,11 @@ export default function ModelDetailsV2({
                               }
                             >
                               <Text className={classes.modelBadgeText}>
-                                {abbreviateNumber(buzzEarned)}
+                                {model.hiddenMetrics?.buzz ? (
+                                  <HiddenMetricNotice />
+                                ) : (
+                                  abbreviateNumber(buzzEarned)
+                                )}
                               </Text>
                             </IconBadge>
                           </InteractiveTipBuzzButton>

--- a/src/pages/user/account.tsx
+++ b/src/pages/user/account.tsx
@@ -47,10 +47,10 @@ export default function Account() {
           <ProfileCard />
           <SocialProfileCard />
           <SettingsCard />
-          <CreatorControlsCard />
           <ContentControlsCard />
           <GenerationSettingsCard />
           {features.canViewNsfw && <ModerationCard />}
+          <CreatorControlsCard />
           <AccountsCard />
           <UserPaymentConfigurationCard />
           {currentUser?.subscriptionId && <SubscriptionCard />}

--- a/src/pages/user/account.tsx
+++ b/src/pages/user/account.tsx
@@ -50,7 +50,7 @@ export default function Account() {
           <ContentControlsCard />
           <GenerationSettingsCard />
           {features.canViewNsfw && <ModerationCard />}
-          <CreatorControlsCard />
+          {features.creatorControls && <CreatorControlsCard />}
           <AccountsCard />
           <UserPaymentConfigurationCard />
           {currentUser?.subscriptionId && <SubscriptionCard />}

--- a/src/pages/user/account.tsx
+++ b/src/pages/user/account.tsx
@@ -19,6 +19,7 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { PaymentMethodsCard } from '~/components/Account/PaymentMethodsCard';
 import { UserPaymentConfigurationCard } from '~/components/Account/UserPaymentConfigurationCard';
 import { ContentControlsCard } from '~/components/Account/ContentControlsCard';
+import { CreatorControlsCard } from '~/components/Account/CreatorControlsCard';
 import { RefreshSessionCard } from '~/components/Account/RefreshSessionCard';
 import { StrikesCard } from '~/components/Account/StrikesCard';
 import { GenerationSettingsCard } from '~/components/Account/GenerationSettingsCard';
@@ -46,6 +47,7 @@ export default function Account() {
           <ProfileCard />
           <SocialProfileCard />
           <SettingsCard />
+          <CreatorControlsCard />
           <ContentControlsCard />
           <GenerationSettingsCard />
           {features.canViewNsfw && <ModerationCard />}

--- a/src/server/__tests__/model-metric-privacy.test.ts
+++ b/src/server/__tests__/model-metric-privacy.test.ts
@@ -153,6 +153,44 @@ describe('resolveVersionHiddenMetrics — precedence (version OR model OR user)'
   });
 });
 
+describe('v1 API version-stats gating (prepareModelVersionResponse / getStatsForVersion)', () => {
+  // v1 exposes only download at the version level; it must honor the version-level
+  // hide even when model + user defaults are clear (the precedence bug), and revert
+  // on lapse. Public API => isOwnerOrModerator: false.
+  it('version-only hide downloads => hidden for a public v1 caller (active member)', () => {
+    const hidden = resolveVersionHiddenMetrics({
+      versionMeta: { hideDownloads: true },
+      modelMeta: {},
+      userSettings: {},
+      isOwnerOrModerator: false,
+      hasValidMembership: true,
+    });
+    expect(hidden.downloads).toBe(true);
+  });
+
+  it('version-only hide reverts to visible when the owner has lapsed', () => {
+    const hidden = resolveVersionHiddenMetrics({
+      versionMeta: { hideDownloads: true },
+      modelMeta: {},
+      userSettings: {},
+      isOwnerOrModerator: false,
+      hasValidMembership: false,
+    });
+    expect(hidden.downloads).toBe(false);
+  });
+
+  it('model-level hide still cascades to version stats in v1', () => {
+    const hidden = resolveVersionHiddenMetrics({
+      versionMeta: {},
+      modelMeta: { hideDownloads: true },
+      userSettings: {},
+      isOwnerOrModerator: false,
+      hasValidMembership: true,
+    });
+    expect(hidden.downloads).toBe(true);
+  });
+});
+
 describe('anyMetricHidden', () => {
   it('true when any flag set, false otherwise', () => {
     expect(anyMetricHidden(NONE)).toBe(false);

--- a/src/server/__tests__/model-metric-privacy.test.ts
+++ b/src/server/__tests__/model-metric-privacy.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import {
+  anyMetricHidden,
+  getMetaMetricPrivacy,
+  getUserMetricPrivacyDefaults,
+  resolveModelHiddenMetrics,
+  resolveVersionHiddenMetrics,
+} from '~/server/utils/model-metric-privacy';
+
+/**
+ * Read-time gating contract for Creator Controls metric privacy. The three levels
+ * (user default / model / version) and the CP-membership gate + owner/mod bypass are
+ * the security-relevant rules — a regression here leaks a hidden metric or hides a
+ * lapsed creator's stats. These exercise the REAL resolve functions the surfaces use.
+ */
+
+const ALL_HIDDEN = { hideBuzz: true, hideDownloads: true, hideGenerations: true };
+const NONE = { buzz: false, downloads: false, generations: false };
+
+describe('getMetaMetricPrivacy / getUserMetricPrivacyDefaults', () => {
+  it('reads model/version meta flags', () => {
+    expect(getMetaMetricPrivacy({ hideBuzz: true })).toEqual({
+      buzz: true,
+      downloads: false,
+      generations: false,
+    });
+    expect(getMetaMetricPrivacy(null)).toEqual(NONE);
+    expect(getMetaMetricPrivacy(undefined)).toEqual(NONE);
+  });
+
+  it('reads user-default flags', () => {
+    expect(getUserMetricPrivacyDefaults({ hideModelDownloads: true })).toEqual({
+      buzz: false,
+      downloads: true,
+      generations: false,
+    });
+    expect(getUserMetricPrivacyDefaults(null)).toEqual(NONE);
+  });
+});
+
+describe('resolveModelHiddenMetrics — CP gate + bypass', () => {
+  it('owner/moderator always sees real stats (bypass)', () => {
+    expect(
+      resolveModelHiddenMetrics({
+        modelMeta: ALL_HIDDEN,
+        isOwnerOrModerator: true,
+        hasValidMembership: true,
+      })
+    ).toEqual(NONE);
+  });
+
+  it('non-owner sees hidden metric when owner is an active CP member', () => {
+    expect(
+      resolveModelHiddenMetrics({
+        modelMeta: { hideDownloads: true },
+        isOwnerOrModerator: false,
+        hasValidMembership: true,
+      })
+    ).toEqual({ buzz: false, downloads: true, generations: false });
+  });
+
+  it('non-owner sees REAL stats when owner has lapsed (revert, no write)', () => {
+    expect(
+      resolveModelHiddenMetrics({
+        modelMeta: ALL_HIDDEN,
+        userSettings: { hideModelBuzz: true },
+        isOwnerOrModerator: false,
+        hasValidMembership: false,
+      })
+    ).toEqual(NONE);
+  });
+
+  it('honors the USER default even when model meta has no flag', () => {
+    expect(
+      resolveModelHiddenMetrics({
+        modelMeta: {},
+        userSettings: { hideModelGenerations: true },
+        isOwnerOrModerator: false,
+        hasValidMembership: true,
+      })
+    ).toEqual({ buzz: false, downloads: false, generations: true });
+  });
+
+  it('model flag OR user default (union)', () => {
+    expect(
+      resolveModelHiddenMetrics({
+        modelMeta: { hideBuzz: true },
+        userSettings: { hideModelDownloads: true },
+        isOwnerOrModerator: false,
+        hasValidMembership: true,
+      })
+    ).toEqual({ buzz: true, downloads: true, generations: false });
+  });
+});
+
+describe('resolveVersionHiddenMetrics — precedence (version OR model OR user)', () => {
+  it('hidden when only the VERSION flag is set', () => {
+    expect(
+      resolveVersionHiddenMetrics({
+        versionMeta: { hideDownloads: true },
+        modelMeta: {},
+        userSettings: {},
+        isOwnerOrModerator: false,
+        hasValidMembership: true,
+      })
+    ).toEqual({ buzz: false, downloads: true, generations: false });
+  });
+
+  it('hidden when only the MODEL flag is set (governs version stats too)', () => {
+    expect(
+      resolveVersionHiddenMetrics({
+        versionMeta: {},
+        modelMeta: { hideBuzz: true },
+        userSettings: {},
+        isOwnerOrModerator: false,
+        hasValidMembership: true,
+      })
+    ).toEqual({ buzz: true, downloads: false, generations: false });
+  });
+
+  it('hidden when only the USER default is set', () => {
+    expect(
+      resolveVersionHiddenMetrics({
+        versionMeta: {},
+        modelMeta: {},
+        userSettings: { hideModelGenerations: true },
+        isOwnerOrModerator: false,
+        hasValidMembership: true,
+      })
+    ).toEqual({ buzz: false, downloads: false, generations: true });
+  });
+
+  it('lapsed membership reverts every level to visible', () => {
+    expect(
+      resolveVersionHiddenMetrics({
+        versionMeta: ALL_HIDDEN,
+        modelMeta: ALL_HIDDEN,
+        userSettings: { hideModelBuzz: true },
+        isOwnerOrModerator: false,
+        hasValidMembership: false,
+      })
+    ).toEqual(NONE);
+  });
+
+  it('owner/mod bypass at the version level', () => {
+    expect(
+      resolveVersionHiddenMetrics({
+        versionMeta: ALL_HIDDEN,
+        isOwnerOrModerator: true,
+        hasValidMembership: true,
+      })
+    ).toEqual(NONE);
+  });
+});
+
+describe('anyMetricHidden', () => {
+  it('true when any flag set, false otherwise', () => {
+    expect(anyMetricHidden(NONE)).toBe(false);
+    expect(anyMetricHidden({ buzz: false, downloads: true, generations: false })).toBe(true);
+  });
+});

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -12,6 +12,17 @@ import {
 import type { Context, ProtectedContext } from '~/server/createContext';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { eventEngine } from '~/server/events';
+import {
+  getValidCreatorMembershipMap,
+  hasValidCreatorMembership,
+} from '~/server/services/creator-program.service';
+import {
+  anyMetricHidden,
+  getUserMetricPrivacyDefaults,
+  resolveModelHiddenMetrics,
+  resolveVersionHiddenMetrics,
+  type HiddenModelMetrics,
+} from '~/server/utils/model-metric-privacy';
 import { dataForModelsCache, modelTagCache } from '~/server/redis/caches';
 import { getInfiniteArticlesSchema } from '~/server/schema/article.schema';
 import type { GetAllSchema, GetByIdInput, UserPreferencesInput } from '~/server/schema/base.schema';
@@ -283,6 +294,26 @@ export const getModelHandler = async ({
         });
     }
 
+    // Creator Controls metric privacy: resolve once per request. Owners/mods bypass;
+    // otherwise flags apply only while the owner holds a valid CP membership.
+    let ownerSettings: unknown = null;
+    let ownerHasMembership = false;
+    if (!isOwner) {
+      const [owner, membership] = await Promise.all([
+        dbRead.user.findUnique({ where: { id: model.user.id }, select: { settings: true } }),
+        hasValidCreatorMembership(model.user.id),
+      ]);
+      ownerSettings = owner?.settings ?? null;
+      ownerHasMembership = membership;
+    }
+    const modelHidden = resolveModelHiddenMetrics({
+      modelMeta: model.meta,
+      userSettings: ownerSettings,
+      isOwnerOrModerator: isOwner,
+      hasValidMembership: ownerHasMembership,
+    });
+    const hideIf = (hidden: boolean, value: number) => (hidden ? null : value);
+
     const mappedVersions = filteredVersions.map((version) => {
       let earlyAccessDeadline = features.earlyAccessModel ? version.earlyAccessEndsAt : undefined;
       if (earlyAccessDeadline && new Date() > earlyAccessDeadline) earlyAccessDeadline = undefined;
@@ -333,16 +364,28 @@ export const getModelHandler = async ({
 
       const versionMetrics = version.metrics[0];
 
+      const versionHidden = resolveVersionHiddenMetrics({
+        versionMeta: version.meta,
+        modelMeta: model.meta,
+        userSettings: ownerSettings,
+        isOwnerOrModerator: isOwner,
+        hasValidMembership: ownerHasMembership,
+      });
+
       return {
         ...version,
         licensingFee: version.licensingFee != null ? Number(version.licensingFee) : null,
         metrics: undefined,
+        hiddenMetrics: versionHidden,
         rank: {
-          generationCountAllTime: versionMetrics?.generationCount ?? 0,
-          downloadCountAllTime: versionMetrics?.downloadCount ?? 0,
+          generationCountAllTime: hideIf(
+            versionHidden.generations,
+            versionMetrics?.generationCount ?? 0
+          ),
+          downloadCountAllTime: hideIf(versionHidden.downloads, versionMetrics?.downloadCount ?? 0),
           thumbsUpCountAllTime: versionMetrics?.thumbsUpCount ?? 0,
           thumbsDownCountAllTime: versionMetrics?.thumbsDownCount ?? 0,
-          earnedAmountAllTime: versionMetrics?.earnedAmount ?? 0,
+          earnedAmountAllTime: hideIf(versionHidden.buzz, versionMetrics?.earnedAmount ?? 0),
         },
         posts: posts.filter((x) => x.modelVersionId === version.id).map((x) => ({ id: x.id })),
         hashes,
@@ -400,15 +443,16 @@ export const getModelHandler = async ({
     return {
       ...model,
       metrics: undefined,
+      hiddenMetrics: modelHidden,
       rank: {
-        downloadCountAllTime: metrics?.downloadCount ?? 0,
+        downloadCountAllTime: hideIf(modelHidden.downloads, metrics?.downloadCount ?? 0),
         thumbsUpCountAllTime: metrics?.thumbsUpCount ?? 0,
         thumbsDownCountAllTime: metrics?.thumbsDownCount ?? 0,
         commentCountAllTime: metrics?.commentCount ?? 0,
-        tippedAmountCountAllTime: metrics?.tippedAmountCount ?? 0,
+        tippedAmountCountAllTime: hideIf(modelHidden.buzz, metrics?.tippedAmountCount ?? 0),
         imageCountAllTime: metrics?.imageCount ?? 0,
         collectedCountAllTime: metrics?.collectedCount ?? 0,
-        generationCountAllTime: metrics?.generationCount ?? 0,
+        generationCountAllTime: hideIf(modelHidden.generations, metrics?.generationCount ?? 0),
       },
       canGenerate: mappedVersions.some((v) => v.canGenerate),
       hasSuggestedResources: suggestedResources > 0,
@@ -1556,8 +1600,29 @@ export const getAssociatedResourcesCardDataHandler = async ({
       }
     );
 
+    const assocIsMod = !!user?.isModerator;
+    const assocOwnerIds = [...new Set(models.map((m) => m.user.id))];
+    const assocOwnerSettings = assocOwnerIds.length
+      ? await dbRead.user.findMany({
+          where: { id: { in: assocOwnerIds } },
+          select: { id: true, settings: true },
+        })
+      : [];
+    const assocOwnerSettingsMap = new Map<number, unknown>(
+      assocOwnerSettings.map((o) => [o.id, o.settings])
+    );
+    const assocMembershipCandidates = new Set<number>();
+    for (const m of models) {
+      const ownerId = m.user.id;
+      if (assocIsMod || ownerId === user?.id) continue;
+      const defHidden = getUserMetricPrivacyDefaults(assocOwnerSettingsMap.get(ownerId));
+      if (anyMetricHidden(m.metricPrivacy) || anyMetricHidden(defHidden))
+        assocMembershipCandidates.add(ownerId);
+    }
+    const assocMembershipMap = await getValidCreatorMembershipMap([...assocMembershipCandidates]);
+
     const completeModels = models
-      .map(({ hashes, modelVersions, rank, tagsOnModels, ...model }) => {
+      .map(({ hashes, modelVersions, rank, tagsOnModels, metricPrivacy, ...model }) => {
         const [version] = modelVersions;
         if (!version) return null;
         const versionImages = images.filter((i) => i.modelVersionId === version.id);
@@ -1567,17 +1632,30 @@ export const getAssociatedResourcesCardDataHandler = async ({
         if (!versionImages.length && !showImageless) return null;
         const canGenerate = associatedGenStates.get(version.id)?.canGenerate ?? false;
 
+        const isOwner = assocIsMod || model.user.id === user?.id;
+        const hiddenMetrics = resolveModelHiddenMetrics({
+          modelMeta: {
+            hideBuzz: metricPrivacy.buzz,
+            hideDownloads: metricPrivacy.downloads,
+            hideGenerations: metricPrivacy.generations,
+          },
+          userSettings: assocOwnerSettingsMap.get(model.user.id),
+          isOwnerOrModerator: isOwner,
+          hasValidMembership: assocMembershipMap.get(model.user.id) ?? false,
+        });
+
         return {
           ...model,
           tags: tagsOnModels.map(({ tagId }) => tagId),
           hashes: hashes.map((h) => h.toLowerCase()),
+          hiddenMetrics,
           rank: {
-            downloadCount: rank?.downloadCountAllTime ?? 0,
+            downloadCount: hiddenMetrics.downloads ? null : rank?.downloadCountAllTime ?? 0,
             thumbsUpCount: rank?.thumbsUpCountAllTime ?? 0,
             thumbsDownCount: rank?.thumbsDownCountAllTime ?? 0,
             commentCount: rank?.commentCountAllTime ?? 0,
             collectedCount: rank?.collectedCountAllTime ?? 0,
-            tippedAmountCount: rank?.tippedAmountCountAllTime ?? 0,
+            tippedAmountCount: hiddenMetrics.buzz ? null : rank?.tippedAmountCountAllTime ?? 0,
           },
           images: model.mode !== ModelModifier.TakenDown ? (versionImages as typeof images) : [],
           canGenerate,

--- a/src/server/controllers/user.controller.ts
+++ b/src/server/controllers/user.controller.ts
@@ -55,9 +55,8 @@ import type {
 } from '~/server/selectors/cosmetic.selector';
 import { simpleUserSelect } from '~/server/selectors/user.selector';
 import { getUserNotificationCount } from '~/server/services/notification.service';
-import {
-  getUserResourceReview,
-} from '~/server/services/resourceReview.service';
+import { queueModelMetricPrivacyReindex } from '~/server/services/model.service';
+import { getUserResourceReview } from '~/server/services/resourceReview.service';
 import {
   createCustomer,
   deleteCustomerPaymentMethod,
@@ -1423,6 +1422,13 @@ export const setUserSettingHandler = async ({
     };
 
     await setUserSetting(id, newSettings);
+
+    const privacyKeys = ['hideModelBuzz', 'hideModelDownloads', 'hideModelGenerations'] as const;
+    const metricPrivacyChanged = privacyKeys.some(
+      (k) => k in restInput && (restSettings as Record<string, unknown>)[k] !== restInput[k]
+    );
+    if (metricPrivacyChanged) await queueModelMetricPrivacyReindex(id);
+
     return newSettings;
   } catch (error) {
     throw throwDbError(error);

--- a/src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts
+++ b/src/server/redis/__tests__/model-version-public-donation-goals-cache.test.ts
@@ -54,6 +54,7 @@ const { mockDbRead, mockDbWrite } = vi.hoisted(() => {
     modelVersion: { findMany: vi.fn() },
     donationGoal: { findMany: vi.fn() },
     user: { findMany: vi.fn() },
+    customerSubscription: { findMany: vi.fn() },
     $queryRaw: vi.fn(),
   });
   return { mockDbRead: mk(), mockDbWrite: mk() };
@@ -100,11 +101,20 @@ beforeEach(() => {
   mockDbRead.modelVersion.findMany.mockReset();
   mockDbRead.donationGoal.findMany.mockReset();
   mockDbRead.user.findMany.mockReset().mockResolvedValue([]);
+  mockDbRead.customerSubscription.findMany.mockReset().mockResolvedValue([]);
   mockDbRead.$queryRaw.mockReset();
   mockDbWrite.modelVersion.findMany.mockReset();
   mockDbWrite.donationGoal.findMany.mockReset();
   mockDbWrite.user.findMany.mockReset().mockResolvedValue([]);
+  mockDbWrite.customerSubscription.findMany.mockReset().mockResolvedValue([]);
   mockDbWrite.$queryRaw.mockReset();
+});
+
+// Active CP membership row for `getValidCreatorMembershipMap` (silver tier > free).
+const activeSub = (userId: number) => ({
+  userId,
+  metadata: {},
+  product: { metadata: { tier: 'silver' } },
 });
 
 afterEach(() => vi.restoreAllMocks());
@@ -217,17 +227,38 @@ describe('modelVersionPublicDonationGoalsCache', () => {
     expect(res[9].goals.map((g) => g.id)).toEqual([20]); // ended EA goal 21 excluded
   });
 
-  it('hides all goals whose owner opted out via hideDonationGoals', async () => {
+  it("hides an opted-out owner's goals ONLY while they are an active CP member", async () => {
     mockDbRead.modelVersion.findMany.mockResolvedValue([{ id: 5, earlyAccessEndsAt: null }]);
     mockDbRead.donationGoal.findMany.mockResolvedValue([
       row({ id: 10, userId: 7, modelVersionId: 5 }),
     ]);
     mockDbRead.user.findMany.mockResolvedValue([{ id: 7, settings: { hideDonationGoals: true } }]);
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([activeSub(7)]);
     mockDbRead.$queryRaw.mockResolvedValue([]);
     const cache = buildCache();
 
     const res = await cache.fetch([5]);
 
-    expect(res[5]).toEqual({ modelVersionId: 5, goals: [] }); // owner opted out → nothing public
+    expect(res[5]).toEqual({ modelVersionId: 5, goals: [] }); // active member + opted out → hidden
   });
+
+  it("shows an opted-out owner's goals again when their CP membership has lapsed", async () => {
+    mockDbRead.modelVersion.findMany.mockResolvedValue([{ id: 5, earlyAccessEndsAt: null }]);
+    mockDbRead.donationGoal.findMany.mockResolvedValue([
+      row({ id: 10, userId: 7, modelVersionId: 5 }),
+    ]);
+    mockDbRead.user.findMany.mockResolvedValue([{ id: 7, settings: { hideDonationGoals: true } }]);
+    // No active subscription → lapsed / never-member → the opt-out silently reverts.
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([]);
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+    const cache = buildCache();
+
+    const res = await cache.fetch([5]);
+
+    expect(res[5].goals.map((g) => g.id)).toEqual([10]); // no stored flip — publicly visible again
+  });
+
+  // Owner/mod bypass is enforced one level up in `modelVersionDonationGoals`, which
+  // skips this shared public cache entirely for privileged viewers — so an owner/mod
+  // never reaches this lookupFn and always sees their own goals regardless of the flag.
 });

--- a/src/server/redis/donation-goals-cache.ts
+++ b/src/server/redis/donation-goals-cache.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { dbReadFallbackCounter } from '~/server/prom/client';
+import { getValidCreatorMembershipMap } from '~/server/services/creator-membership.service';
 
 // A single public (non-owner, non-moderator) donation goal, shaped byte-identically to
 // `modelVersionDonationGoals`' output element: the DonationGoal row fields it selects plus
@@ -83,10 +84,12 @@ export const publicDonationGoalsLookupFn = async (
     },
   });
 
-  // Creator opt-out: an owner can hide the public donation-goal display for ALL their
-  // goals via the `hideDonationGoals` user setting. Non-owner/non-mod viewers go through
-  // this cache, so drop those goals here. Owners/mods bypass the cache entirely (see
-  // `modelVersionDonationGoals`) and still see their goals.
+  // Creator opt-out (Creator Program benefit): an owner can hide the public
+  // donation-goal display for ALL their goals via `hideDonationGoals`. It only takes
+  // effect while the owner holds a valid CP membership — a lapsed/never-member owner's
+  // goals become publicly visible again with no stored flip, mirroring the metric-
+  // privacy gate. Non-owner/non-mod viewers go through this cache; owners/mods bypass
+  // it entirely (see `modelVersionDonationGoals`) and always see their own goals.
   const ownerIds = [...new Set(goals.map((g) => g.userId))];
   const hiddenOwnerIds = new Set<number>();
   if (ownerIds.length > 0) {
@@ -94,9 +97,12 @@ export const publicDonationGoalsLookupFn = async (
       where: { id: { in: ownerIds } },
       select: { id: true, settings: true },
     });
-    for (const owner of owners) {
-      const settings = owner.settings as { hideDonationGoals?: boolean } | null;
-      if (settings?.hideDonationGoals) hiddenOwnerIds.add(owner.id);
+    const optedOutOwnerIds = owners
+      .filter((o) => (o.settings as { hideDonationGoals?: boolean } | null)?.hideDonationGoals)
+      .map((o) => o.id);
+    if (optedOutOwnerIds.length > 0) {
+      const membershipMap = await getValidCreatorMembershipMap(optedOutOwnerIds);
+      for (const id of optedOutOwnerIds) if (membershipMap.get(id)) hiddenOwnerIds.add(id);
     }
   }
 

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -438,6 +438,14 @@ export const modelVersionUpsertSchema2 = z.object({
   // Inherit another version's licensing fee (a LicensingRoot for this baseModel).
   // Null falls back to the (baseModel, modelType) rule.
   licensingSourceVersionId: z.number().nullish(),
+  // Creator Controls: per-version metric privacy (merged into ModelVersion.meta).
+  meta: z
+    .object({
+      hideBuzz: z.boolean().optional(),
+      hideDownloads: z.boolean().optional(),
+      hideGenerations: z.boolean().optional(),
+    })
+    .optional(),
 });
 
 export type GetModelVersionSchema = z.infer<typeof getModelVersionSchema>;

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -206,6 +206,9 @@ export const modelUpsertSchema = z.object({
     .looseObject({
       showcaseCollectionId: z.coerce.number().nullish(),
       commentsLocked: z.boolean().default(false),
+      hideBuzz: z.boolean().optional(),
+      hideDownloads: z.boolean().optional(),
+      hideGenerations: z.boolean().optional(),
     })
     .transform((val) => val as ModelMeta | null)
     .nullish(),
@@ -269,6 +272,11 @@ export type ModelMeta = Partial<{
   commentsLocked: boolean;
   profanityMatches: string[];
   profanityEvaluation: Pick<ProfanityEvaluation, 'reason' | 'metrics'>;
+  // Creator Controls: hide public metrics (only while the owner has a valid
+  // Creator Program membership — see server/utils/model-metric-privacy.ts).
+  hideBuzz: boolean;
+  hideDownloads: boolean;
+  hideGenerations: boolean;
 }>;
 
 export type ChangeModelModifierSchema = z.infer<typeof changeModelModifierSchema>;

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -285,6 +285,12 @@ export const userSettingsSchema = z.object({
   // Creator opt-out: when true, the public donation-goal display (progress + collected
   // amount) is hidden from non-owner/non-mod viewers on all of this user's models.
   hideDonationGoals: z.boolean().optional(),
+  // Creator Controls defaults: baseline metric-privacy for all of this user's
+  // models. Effective only while the user holds a valid Creator Program
+  // membership (see server/utils/model-metric-privacy.ts).
+  hideModelBuzz: z.boolean().optional(),
+  hideModelDownloads: z.boolean().optional(),
+  hideModelGenerations: z.boolean().optional(),
   hideDownloadsSince: z.number().optional(),
   gallerySettings: (
     z.object({
@@ -341,6 +347,9 @@ export const setUserSettingsInput = z.object({
   cosmeticStoreLastViewed: z.date().optional(),
   allowAds: z.boolean().optional(),
   hideDonationGoals: z.boolean().optional(),
+  hideModelBuzz: z.boolean().optional(),
+  hideModelDownloads: z.boolean().optional(),
+  hideModelGenerations: z.boolean().optional(),
   tourSettings: tourSettingsSchema.optional(),
   generation: generationSettingsSchema.optional(),
   creatorProgramToSAccepted: z.date().optional(),

--- a/src/server/search-index/models.search-index.ts
+++ b/src/server/search-index/models.search-index.ts
@@ -69,9 +69,11 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
     'id',
     'metrics.collectedCount',
     'metrics.commentCount',
-    'metrics.downloadCount',
     'metrics.thumbsUpCount',
-    'metrics.tippedAmountCount',
+    // Creator Controls: downloads + tipped can be masked in the displayed `metrics`,
+    // so sort on the REAL sort-only mirrors (excluded from displayedAttributes).
+    'sortMetrics.downloadCount',
+    'sortMetrics.tippedAmountCount',
   ];
 
   // Meilisearch stores sorted.
@@ -81,6 +83,54 @@ const onIndexSetup = async ({ indexName }: { indexName: string }) => {
       'onIndexSetup :: sortableFieldsAttributesTask created',
       sortableFieldsAttributesTask
     );
+  }
+
+  // Creator Controls: `sortMetrics` holds the REAL download/tipped values used only
+  // for sorting. Excluding it from displayedAttributes keeps the true number out of
+  // every search hit (a masked model's real count is never returned to any client,
+  // including direct Meili queries). Meili whitelists by top-level attribute — nested
+  // children are included with their parent, so only NEW top-level doc keys need to
+  // be added here.
+  const displayedAttributes = [
+    'id',
+    'name',
+    'type',
+    'nsfw',
+    'nsfwLevel',
+    'minor',
+    'sfwOnly',
+    'status',
+    'createdAt',
+    'lastVersionAt',
+    'lastVersionAtUnix',
+    'publishedAt',
+    'locked',
+    'earlyAccessDeadline',
+    'mode',
+    'checkpointType',
+    'availability',
+    'poi',
+    'user',
+    'category',
+    'permissions',
+    'version',
+    'versions',
+    'triggerWords',
+    'fileFormats',
+    'hashes',
+    'tags',
+    'metrics',
+    'rank',
+    'hiddenMetrics',
+    'canGenerate',
+    'cannotPromote',
+    'cosmetic',
+    'images',
+  ];
+
+  if (JSON.stringify(displayedAttributes) !== JSON.stringify(settings.displayedAttributes)) {
+    const displayedAttributesTask = await index.updateDisplayedAttributes(displayedAttributes);
+    console.log('onIndexSetup :: displayedAttributesTask created', displayedAttributesTask);
   }
 
   const rankingRules = [
@@ -225,6 +275,15 @@ const transformData = async ({ models, tags, cosmetics, images }: PullDataResult
 
       const category = tags[model.id]?.tags?.find(({ id }) => modelCategoriesIds.includes(id));
 
+      const hidden = resolveModelHiddenMetrics({
+        modelMeta: meta,
+        userSettings: ownerSettingsMap.get(user.id),
+        isOwnerOrModerator: false,
+        hasValidMembership: membershipMap.get(user.id) ?? false,
+      });
+      const realDownloadCount = metrics?.downloadCount ?? 0;
+      const realTippedAmountCount = metrics?.tippedAmountCount ?? 0;
+
       return {
         ...model,
         nsfwLevel: parseBitwiseBrowsingLevel(model.nsfwLevel),
@@ -282,22 +341,28 @@ const transformData = async ({ models, tags, cosmetics, images }: PullDataResult
             id: x.id,
             name: x.name,
           })) ?? [],
+        // DISPLAYED metrics — hidden ones masked to null (never leak the real number
+        // to the search hit). Sort order is preserved via `sortMetrics` below.
         metrics: {
           ...metrics,
+          downloadCount: hidden.downloads ? null : realDownloadCount,
+          tippedAmountCount: hidden.buzz ? null : realTippedAmountCount,
         },
         rank: {
-          downloadCount: metrics?.downloadCount ?? 0,
+          downloadCount: hidden.downloads ? null : realDownloadCount,
           thumbsUpCount: metrics.thumbsUpCount ?? 0,
           commentCount: metrics.commentCount ?? 0,
           collectedCount: metrics.collectedCount ?? 0,
-          tippedAmountCount: metrics.tippedAmountCount ?? 0,
+          tippedAmountCount: hidden.buzz ? null : realTippedAmountCount,
         },
-        hiddenMetrics: resolveModelHiddenMetrics({
-          modelMeta: meta,
-          userSettings: ownerSettingsMap.get(user.id),
-          isOwnerOrModerator: false,
-          hasValidMembership: membershipMap.get(user.id) ?? false,
-        }),
+        // SORT-ONLY: REAL values, excluded from `displayedAttributes` (see
+        // onIndexSetup) so sort by most-downloaded / most-tipped keeps the true
+        // order even when the displayed number is masked. Never returned to clients.
+        sortMetrics: {
+          downloadCount: realDownloadCount,
+          tippedAmountCount: realTippedAmountCount,
+        },
+        hiddenMetrics: hidden,
         canGenerate,
         cannotPromote,
         cosmetic: cosmetics[model.id] ?? null,

--- a/src/server/search-index/models.search-index.ts
+++ b/src/server/search-index/models.search-index.ts
@@ -22,6 +22,7 @@ import {
   getUserMetricPrivacyDefaults,
   resolveModelHiddenMetrics,
 } from '~/server/utils/model-metric-privacy';
+import type { HiddenModelMetrics } from '~/server/utils/model-metric-privacy';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
 import type { ImagesForModelVersions } from '~/server/services/image.service';
 import { getCategoryTags } from '~/server/services/system-cache';
@@ -214,6 +215,29 @@ type PullDataResult = {
   cosmetics: Awaited<ReturnType<typeof getCosmeticsForEntity>>;
   images: ImagesForModelVersions[];
 };
+type VersionMetricRow = {
+  generationCount: number;
+  downloadCount: number;
+  thumbsUpCount: number;
+  thumbsDownCount: number;
+};
+
+// Nested per-version metrics ship in `displayedAttributes`, so they must obey the
+// same model-level hide flags as the card — otherwise the raw hidden number leaks.
+// The search-index version selector carries no earned/tipped (buzz) field, so only
+// downloads + generations are maskable here.
+function maskHiddenVersionMetrics<T extends VersionMetricRow | undefined>(
+  metrics: T,
+  hidden: HiddenModelMetrics
+) {
+  if (!metrics) return metrics;
+  return {
+    ...metrics,
+    downloadCount: hidden.downloads ? null : metrics.downloadCount,
+    generationCount: hidden.generations ? null : metrics.generationCount,
+  };
+}
+
 const transformData = async ({ models, tags, cosmetics, images }: PullDataResult) => {
   const modelCategories = await getCategoryTags('model');
   const modelCategoriesIds = modelCategories.map((category) => category.id);
@@ -303,7 +327,7 @@ const transformData = async ({ models, tags, cosmetics, images }: PullDataResult
         },
         version: {
           ...restVersion,
-          metrics: restVersion.metrics[0],
+          metrics: maskHiddenVersionMetrics(restVersion.metrics[0], hidden),
           hashes: restVersion.hashes.map((hash) => hash.hash),
           hashData: restVersion.hashes.map((hash) => ({ hash: hash.hash, type: hash.hashType })),
           settings: restVersion.settings as RecommendedSettingsSchema,
@@ -312,7 +336,7 @@ const transformData = async ({ models, tags, cosmetics, images }: PullDataResult
         versions: modelVersions.map(
           ({ generationCoverage, files, hashes, settings, metrics: vMetrics, ...x }) => ({
             ...x,
-            metrics: vMetrics[0],
+            metrics: maskHiddenVersionMetrics(vMetrics[0], hidden),
             hashes: hashes.map((hash) => hash.hash),
             hashData: hashes.map((hash) => ({ hash: hash.hash, type: hash.hashType })),
             canGenerate:

--- a/src/server/search-index/models.search-index.ts
+++ b/src/server/search-index/models.search-index.ts
@@ -1,7 +1,10 @@
 import { Prisma } from '@prisma/client';
 import { chunk, isEqual } from 'lodash-es';
 import type { TypoTolerance } from 'meilisearch';
-import { type BaseModel, isBaseModelGenerationSupported } from '~/shared/constants/basemodel.constants';
+import {
+  type BaseModel,
+  isBaseModelGenerationSupported,
+} from '~/shared/constants/basemodel.constants';
 import { MODELS_SEARCH_INDEX } from '~/server/common/constants';
 import { searchClient as client, updateDocs } from '~/server/meilisearch/client';
 import { getOrCreateIndex } from '~/server/meilisearch/util';
@@ -11,6 +14,14 @@ import type { ModelFileMetadata } from '~/server/schema/model-file.schema';
 import type { RecommendedSettingsSchema } from '~/server/schema/model-version.schema';
 import type { ModelMeta } from '~/server/schema/model.schema';
 import { createSearchIndexUpdateProcessor } from '~/server/search-index/base.search-index';
+import { dbRead } from '~/server/db/client';
+import { getValidCreatorMembershipMap } from '~/server/services/creator-program.service';
+import {
+  anyMetricHidden,
+  getMetaMetricPrivacy,
+  getUserMetricPrivacyDefaults,
+  resolveModelHiddenMetrics,
+} from '~/server/utils/model-metric-privacy';
 import { getCosmeticsForEntity } from '~/server/services/cosmetic.service';
 import type { ImagesForModelVersions } from '~/server/services/image.service';
 import { getCategoryTags } from '~/server/services/system-cache';
@@ -159,6 +170,31 @@ const transformData = async ({ models, tags, cosmetics, images }: PullDataResult
 
   const unavailableGenResources = await getUnavailableResources();
 
+  // Creator Controls metric privacy: store which model-level metrics are hidden so
+  // the search card can render the "hidden" notice. Effective only while the owner
+  // holds a valid CP membership; the real metrics/rank stay in the doc so sort order
+  // is unchanged (only the displayed number is omitted on the card). This is a
+  // precomputed shared doc, so a membership lapse reverts to visible on the next
+  // reindex rather than instantly.
+  const ownerIds = [...new Set(models.map((m) => m.user.id))];
+  const ownerSettingsRows = ownerIds.length
+    ? await dbRead.user.findMany({
+        where: { id: { in: ownerIds } },
+        select: { id: true, settings: true },
+      })
+    : [];
+  const ownerSettingsMap = new Map<number, unknown>(
+    ownerSettingsRows.map((o) => [o.id, o.settings])
+  );
+  const membershipCandidates = new Set<number>();
+  for (const m of models) {
+    const metaHidden = getMetaMetricPrivacy(m.meta);
+    const defHidden = getUserMetricPrivacyDefaults(ownerSettingsMap.get(m.user.id));
+    if (anyMetricHidden(metaHidden) || anyMetricHidden(defHidden))
+      membershipCandidates.add(m.user.id);
+  }
+  const membershipMap = await getValidCreatorMembershipMap([...membershipCandidates]);
+
   const indexReadyRecords = models
     .map((modelRecord) => {
       const {
@@ -256,6 +292,12 @@ const transformData = async ({ models, tags, cosmetics, images }: PullDataResult
           collectedCount: metrics.collectedCount ?? 0,
           tippedAmountCount: metrics.tippedAmountCount ?? 0,
         },
+        hiddenMetrics: resolveModelHiddenMetrics({
+          modelMeta: meta,
+          userSettings: ownerSettingsMap.get(user.id),
+          isOwnerOrModerator: false,
+          hasValidMembership: membershipMap.get(user.id) ?? false,
+        }),
         canGenerate,
         cannotPromote,
         cosmetic: cosmetics[model.id] ?? null,

--- a/src/server/services/__tests__/creator-membership.service.test.ts
+++ b/src/server/services/__tests__/creator-membership.service.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `getValidCreatorMembershipMap` is the read-time gate every metric-privacy surface
+ * (model feed / v1 API / search index) and the donation-goal hide check trusts: a
+ * user is a valid Creator Program member only while they hold a paid, non-founder
+ * tier. A regression here either leaks a lapsed creator's hidden metrics (false→true)
+ * or wrongly hides an active member's stats (true→false).
+ */
+
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: { customerSubscription: { findMany: vi.fn() } },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead }));
+
+import { getValidCreatorMembershipMap } from '~/server/services/creator-membership.service';
+
+type SubRow = {
+  userId: number;
+  metadata?: Record<string, unknown> | null;
+  product: { metadata: Record<string, unknown> };
+};
+
+const sub = (userId: number, tier: string, over: Partial<SubRow> = {}): SubRow => ({
+  userId,
+  metadata: null,
+  product: { metadata: { tier } },
+  ...over,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getValidCreatorMembershipMap', () => {
+  it('returns an empty map (and skips the db) for empty input', async () => {
+    const result = await getValidCreatorMembershipMap([]);
+    expect(result.size).toBe(0);
+    expect(mockDbRead.customerSubscription.findMany).not.toHaveBeenCalled();
+  });
+
+  it('treats a founder-tier sub as an invalid membership', async () => {
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([sub(1, 'founder')]);
+    const result = await getValidCreatorMembershipMap([1]);
+    expect(result.get(1)).toBe(false);
+  });
+
+  it('skips a sub flagged with metadata.renewalEmailSent', async () => {
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([
+      sub(1, 'gold', { metadata: { renewalEmailSent: true } }),
+    ]);
+    const result = await getValidCreatorMembershipMap([1]);
+    // The only sub is skipped, so the user has no effective tier -> invalid.
+    expect(result.get(1)).toBe(false);
+  });
+
+  it('selects the highest tier among multiple subs', async () => {
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([sub(1, 'free'), sub(1, 'silver')]);
+    const result = await getValidCreatorMembershipMap([1]);
+    // Picks silver over free -> valid (a free-only pick would be invalid).
+    expect(result.get(1)).toBe(true);
+  });
+});

--- a/src/server/services/creator-membership.service.ts
+++ b/src/server/services/creator-membership.service.ts
@@ -1,0 +1,52 @@
+import { env } from '~/env/server';
+import { constants } from '~/server/common/constants';
+import { dbRead } from '~/server/db/client';
+import { subscriptionProductMetadataSchema } from '~/server/schema/subscriptions.schema';
+
+/**
+ * Batched `hasValidCreatorMembership` for read-time gating across a list of owners
+ * (metric-privacy on the model feed / v1 API / search index, and the donation-goal
+ * hide). ONE `dbRead` query for all owners — never K per-owner checkouts on the
+ * primary pool. Mirrors getHighestTierSubscription + hasValidCreatorMembership: pick
+ * each user's highest tier (constants.memberships.tierOrder) and treat
+ * non-free / non-founder as valid.
+ *
+ * Kept in this dependency-light module (dbRead + env + constants + the zod schema, no
+ * clickhouse/buzz/notification graph) so the donation-goals lookup can gate on it
+ * without dragging the heavy creator-program graph into that light, unit-tested path.
+ */
+export async function getValidCreatorMembershipMap(userIds: number[]) {
+  const unique = [...new Set(userIds.filter((id) => !!id))];
+  const result = new Map<number, boolean>();
+  if (unique.length === 0) return result;
+
+  const subscriptions = await dbRead.customerSubscription.findMany({
+    where: {
+      userId: { in: unique },
+      status: { notIn: ['canceled', 'incomplete_expired', 'past_due', 'unpaid'] },
+    },
+    select: {
+      userId: true,
+      metadata: true,
+      product: { select: { metadata: true } },
+    },
+  });
+
+  const tierOrder = constants.memberships.tierOrder as readonly string[];
+  const highestTierByUser = new Map<number, string>();
+  for (const sub of subscriptions) {
+    const subMeta = (sub.metadata ?? {}) as { renewalEmailSent?: boolean };
+    if (subMeta.renewalEmailSent) continue;
+    const productMeta = subscriptionProductMetadataSchema.parse(sub.product.metadata);
+    const tier = (productMeta?.[env.TIER_METADATA_KEY] ?? 'free') as string;
+    const prev = highestTierByUser.get(sub.userId);
+    if (prev === undefined || tierOrder.indexOf(tier) > tierOrder.indexOf(prev))
+      highestTierByUser.set(sub.userId, tier);
+  }
+
+  for (const id of unique) {
+    const tier = highestTierByUser.get(id);
+    result.set(id, !!tier && tier !== 'free' && tier !== 'founder');
+  }
+  return result;
+}

--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -8,7 +8,8 @@ import {
   SignalMessages,
   SignalTopic,
 } from '~/server/common/enums';
-import { dbWrite } from '~/server/db/client';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { constants } from '~/server/common/constants';
 import { REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import type { BuzzCreatorProgramType, BuzzSpendType } from '~/shared/constants/buzz.constants';
@@ -265,14 +266,44 @@ export async function hasValidCreatorMembership(userId: number) {
 }
 
 // Batched `hasValidCreatorMembership` for read-time metric-privacy gating across a
-// list of model owners. Dedupes and resolves in parallel. Used by the model feed /
-// v1 API where several owners' membership must be checked in one request.
+// list of model owners (model feed / v1 API / search index). ONE `dbRead` query for
+// all owners — never K per-owner checkouts on the primary pool. Mirrors
+// getHighestTierSubscription + hasValidCreatorMembership: pick each user's highest
+// tier (constants.memberships.tierOrder) and treat non-free / non-founder as valid.
 export async function getValidCreatorMembershipMap(userIds: number[]) {
   const unique = [...new Set(userIds.filter((id) => !!id))];
-  const entries = await Promise.all(
-    unique.map(async (id) => [id, await hasValidCreatorMembership(id)] as const)
-  );
-  return new Map<number, boolean>(entries);
+  const result = new Map<number, boolean>();
+  if (unique.length === 0) return result;
+
+  const subscriptions = await dbRead.customerSubscription.findMany({
+    where: {
+      userId: { in: unique },
+      status: { notIn: ['canceled', 'incomplete_expired', 'past_due', 'unpaid'] },
+    },
+    select: {
+      userId: true,
+      metadata: true,
+      product: { select: { metadata: true } },
+    },
+  });
+
+  const tierOrder = constants.memberships.tierOrder as readonly string[];
+  const highestTierByUser = new Map<number, string>();
+  for (const sub of subscriptions) {
+    const subMeta = (sub.metadata ?? {}) as { renewalEmailSent?: boolean };
+    if (subMeta.renewalEmailSent) continue;
+    const productMeta = subscriptionProductMetadataSchema.parse(sub.product.metadata);
+    const tier = (productMeta?.[env.TIER_METADATA_KEY] ?? 'free') as string;
+    const prev = highestTierByUser.get(sub.userId);
+    if (prev === undefined || tierOrder.indexOf(tier) > tierOrder.indexOf(prev))
+      highestTierByUser.set(sub.userId, tier);
+  }
+
+  for (const id of unique) {
+    const tier = highestTierByUser.get(id);
+    result.set(id, !!tier && tier !== 'free' && tier !== 'founder');
+  }
+  return result;
 }
 
 export async function joinCreatorsProgram(userId: number) {

--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -264,6 +264,17 @@ export async function hasValidCreatorMembership(userId: number) {
   return !!tier && tier !== 'free' && tier !== 'founder';
 }
 
+// Batched `hasValidCreatorMembership` for read-time metric-privacy gating across a
+// list of model owners. Dedupes and resolves in parallel. Used by the model feed /
+// v1 API where several owners' membership must be checked in one request.
+export async function getValidCreatorMembershipMap(userIds: number[]) {
+  const unique = [...new Set(userIds.filter((id) => !!id))];
+  const entries = await Promise.all(
+    unique.map(async (id) => [id, await hasValidCreatorMembership(id)] as const)
+  );
+  return new Map<number, boolean>(entries);
+}
+
 export async function joinCreatorsProgram(userId: number) {
   const requirements = await getCreatorRequirements(userId);
 

--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -8,8 +8,7 @@ import {
   SignalMessages,
   SignalTopic,
 } from '~/server/common/enums';
-import { dbRead, dbWrite } from '~/server/db/client';
-import { constants } from '~/server/common/constants';
+import { dbWrite } from '~/server/db/client';
 import { REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { decodeRedisString } from '~/server/redis/buffer-decode';
 import type { BuzzCreatorProgramType, BuzzSpendType } from '~/shared/constants/buzz.constants';
@@ -265,46 +264,10 @@ export async function hasValidCreatorMembership(userId: number) {
   return !!tier && tier !== 'free' && tier !== 'founder';
 }
 
-// Batched `hasValidCreatorMembership` for read-time metric-privacy gating across a
-// list of model owners (model feed / v1 API / search index). ONE `dbRead` query for
-// all owners — never K per-owner checkouts on the primary pool. Mirrors
-// getHighestTierSubscription + hasValidCreatorMembership: pick each user's highest
-// tier (constants.memberships.tierOrder) and treat non-free / non-founder as valid.
-export async function getValidCreatorMembershipMap(userIds: number[]) {
-  const unique = [...new Set(userIds.filter((id) => !!id))];
-  const result = new Map<number, boolean>();
-  if (unique.length === 0) return result;
-
-  const subscriptions = await dbRead.customerSubscription.findMany({
-    where: {
-      userId: { in: unique },
-      status: { notIn: ['canceled', 'incomplete_expired', 'past_due', 'unpaid'] },
-    },
-    select: {
-      userId: true,
-      metadata: true,
-      product: { select: { metadata: true } },
-    },
-  });
-
-  const tierOrder = constants.memberships.tierOrder as readonly string[];
-  const highestTierByUser = new Map<number, string>();
-  for (const sub of subscriptions) {
-    const subMeta = (sub.metadata ?? {}) as { renewalEmailSent?: boolean };
-    if (subMeta.renewalEmailSent) continue;
-    const productMeta = subscriptionProductMetadataSchema.parse(sub.product.metadata);
-    const tier = (productMeta?.[env.TIER_METADATA_KEY] ?? 'free') as string;
-    const prev = highestTierByUser.get(sub.userId);
-    if (prev === undefined || tierOrder.indexOf(tier) > tierOrder.indexOf(prev))
-      highestTierByUser.set(sub.userId, tier);
-  }
-
-  for (const id of unique) {
-    const tier = highestTierByUser.get(id);
-    result.set(id, !!tier && tier !== 'free' && tier !== 'founder');
-  }
-  return result;
-}
+// Batched read-time membership gate lives in a dependency-light module so the
+// donation-goals lookup can reuse it without pulling this heavy graph. Re-exported
+// here for the existing metric-privacy callers.
+export { getValidCreatorMembershipMap } from '~/server/services/creator-membership.service';
 
 export async function joinCreatorsProgram(userId: number) {
   const requirements = await getCreatorRequirements(userId);

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -290,6 +290,16 @@ const featureFlags = createFeatureFlags({
   impersonation: isDev ? ['mod'] : ['granted'],
   donationGoals: ['public'],
   creatorComp: ['public'],
+  // Creator Controls account card (metric-privacy + donation-goal settings UI).
+  // `availability: []` = DARK by default and FAILS CLOSED (empty availability →
+  // static eval false when Flipt is absent/down), so the card does NOT render for
+  // anyone until the `creator-controls` Flipt flag is created + enabled. This gates
+  // ONLY the card render in the account page; the read-side metric-privacy gating
+  // (donation-goals-cache / model-metric-privacy resolvers / model.service etc.)
+  // stays active regardless so existing user settings keep applying even when the
+  // card is hidden. Instant kill-switch / widen lever = the Flipt flag. (Mirrors the
+  // `hiddenPrefsCompact` / `genTabDeferView` `availability: []` precedent.)
+  creatorControls: { availability: [], fliptKey: 'creator-controls' },
   imageIndexFeed: { availability: ['public'], fliptKey: 'image-index-feed' },
   // #region [Domain Specific Features]
   isGreen: ['public', 'green'],

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -322,9 +322,7 @@ export const getLicensingRoots = async ({
 
 // Field-level early-access requirements (status-independent): a timeframe needs
 // a charge, and each enabled charge needs a price.
-function assertEarlyAccessChargeConfig(
-  config: ModelVersionEarlyAccessConfig | null | undefined
-) {
+function assertEarlyAccessChargeConfig(config: ModelVersionEarlyAccessConfig | null | undefined) {
   if (config?.timeframe && !config.chargeForDownload && !config.chargeForGeneration) {
     throw throwBadRequestError(
       'You must charge for downloads or generations if you set an early access time frame.'
@@ -334,7 +332,9 @@ function assertEarlyAccessChargeConfig(
     throw throwBadRequestError('You must provide a download price when charging for downloads.');
   }
   if (config?.chargeForGeneration && !config.generationPrice) {
-    throw throwBadRequestError('You must provide a generation price when charging for generations.');
+    throw throwBadRequestError(
+      'You must provide a generation price when charging for generations.'
+    );
   }
 }
 
@@ -351,7 +351,9 @@ function mergeEarlyAccessConfigUpdate({
   status: ModelStatus;
 }): ModelVersionEarlyAccessConfig | null | undefined {
   if (status === ModelStatus.Published && !!updatedConfig && !existingConfig) {
-    throw throwBadRequestError('You cannot add early access on a model after it has been published.');
+    throw throwBadRequestError(
+      'You cannot add early access on a model after it has been published.'
+    );
   }
 
   if (status === ModelStatus.Published && updatedConfig && existingConfig) {
@@ -390,6 +392,7 @@ export const upsertModelVersion = async ({
   recommendedResources,
   templateId,
   earlyAccessConfig: updatedEarlyAccessConfig,
+  meta: metaInput,
   ...data
 }: Omit<ModelVersionUpsertInput, 'trainingDetails'> & {
   meta?: Prisma.ModelVersionCreateInput['meta'];
@@ -479,6 +482,7 @@ export const upsertModelVersion = async ({
       dbWrite.modelVersion.create({
         data: {
           ...data,
+          meta: (metaInput as Prisma.ModelVersionCreateInput['meta']) ?? undefined,
           flags: flagsOverride,
           availability: [ModelStatus.Published, ModelStatus.Scheduled].some(
             (s) => s === data?.status
@@ -544,6 +548,7 @@ export const upsertModelVersion = async ({
         earlyAccessEndsAt: true,
         earlyAccessConfig: true,
         publishedAt: true,
+        meta: true,
         model: {
           select: {
             id: true,
@@ -585,10 +590,18 @@ export const upsertModelVersion = async ({
       );
     }
 
+    const mergedMeta = metaInput
+      ? {
+          ...((existingVersion.meta as Record<string, unknown> | null) ?? {}),
+          ...(metaInput as Record<string, unknown>),
+        }
+      : undefined;
+
     const version = await dbWrite.modelVersion.update({
       where: { id },
       data: {
         ...data,
+        meta: (mergedMeta as Prisma.ModelVersionUpdateInput['meta']) ?? undefined,
         flags: flagsOverride,
         availability: existingVersion.model.availability, // Will ensure a version keeps the parent's availability.
         earlyAccessConfig:
@@ -1781,7 +1794,6 @@ export const earlyAccessPurchase = async ({
       throw throwBadRequestError('Failed to create Buzz transaction.');
 
     buzzTransactionId = externalTransactionIdPrefix;
-    
 
     await dbWrite.$transaction(
       async (tx) => {

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -1509,6 +1509,25 @@ export const getModelsWithImagesAndModelVersions = async ({
   return result;
 };
 
+/**
+ * Re-queue a user's published models for search reindex. Creator Controls metric
+ * privacy is baked into the search doc (effective = flag AND active membership), so
+ * a `hideModel*` user-setting flip or a membership lapse must re-run the transform,
+ * otherwise the search cards stay stale (over-hidden after a lapse; user-default
+ * flips invisible until an incidental reindex).
+ */
+export async function queueModelMetricPrivacyReindex(userId: number) {
+  if (!userId) return;
+  const models = await dbRead.model.findMany({
+    where: { userId, status: ModelStatus.Published },
+    select: { id: true },
+  });
+  if (!models.length) return;
+  await modelsSearchIndex.queueUpdate(
+    models.map((m) => ({ id: m.id, action: SearchIndexUpdateQueueAction.Update }))
+  );
+}
+
 export const getModelVersionsMicro = async ({
   id,
   excludeUnpublished: excludeDrafts,
@@ -3329,6 +3348,16 @@ export async function getModelsWithVersions({
   }
   const apiMembershipMap = await getValidCreatorMembershipMap([...apiMembershipCandidates]);
 
+  // Version-level meta isn't carried by dataForModelsCache, so fetch it to honor the
+  // version-OR-model-OR-user precedence for v1 version stats (a version-only hide).
+  const versionMetaRows = modelVersionIds.length
+    ? await dbRead.modelVersion.findMany({
+        where: { id: { in: modelVersionIds } },
+        select: { id: true, meta: true },
+      })
+    : [];
+  const versionMetaMap = new Map<number, unknown>(versionMetaRows.map((v) => [v.id, v.meta]));
+
   function getStatsForModel(modelId: number, hidden: HiddenModelMetrics) {
     const stats = metrics.find((x) => x.modelId === modelId);
     return {
@@ -3382,7 +3411,18 @@ export async function getModelsWithVersions({
           supportsGeneration: modelVersions.some((x) => x.covered),
           modelVersions: modelVersions.map(
             ({ trainingStatus, earlyAccessTimeFrame, ...version }) => {
-              const stats = getStatsForVersion(version.id, modelHidden);
+              const versionHidden = resolveVersionHiddenMetrics({
+                versionMeta: versionMetaMap.get(version.id),
+                modelMeta: {
+                  hideBuzz: metricPrivacy.buzz,
+                  hideDownloads: metricPrivacy.downloads,
+                  hideGenerations: metricPrivacy.generations,
+                },
+                userSettings: apiOwnerSettingsMap.get(user.id),
+                isOwnerOrModerator: isOwner,
+                hasValidMembership: apiMembershipMap.get(user.id) ?? false,
+              });
+              const stats = getStatsForVersion(version.id, versionHidden);
               const vaeVersionId = vaeMap.get(version.id);
               const vaeFile = vaeVersionId
                 ? vaeFiles.filter((x) => x.modelVersionId === vaeVersionId)

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -116,6 +116,15 @@ import {
 } from '~/server/services/user.service';
 import { bustFetchThroughCache, fetchThroughCache } from '~/server/utils/cache-helpers';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
+import {
+  anyMetricHidden,
+  getMetaMetricPrivacy,
+  getUserMetricPrivacyDefaults,
+  resolveModelHiddenMetrics,
+  resolveVersionHiddenMetrics,
+  type HiddenModelMetrics,
+} from '~/server/utils/model-metric-privacy';
+import { getValidCreatorMembershipMap } from '~/server/services/creator-program.service';
 import { getEarlyAccessDeadline } from '~/server/utils/early-access-helpers';
 import {
   throwAuthorizationError,
@@ -189,6 +198,7 @@ export const getModel = async <TSelect extends Prisma.ModelSelect>({
 type ModelRaw = {
   id: number;
   name: string;
+  meta?: ModelMeta | null;
   description?: string | null;
   type: ModelType;
   poi?: boolean;
@@ -854,6 +864,7 @@ export const getModelsRaw = async ({
       mm."lastVersionAt",
       m."publishedAt",
       m."locked",
+      m."meta",
       m."earlyAccessDeadline",
       ${pSql}."mode",
       ${pSql}."availability",
@@ -963,7 +974,7 @@ export const getModelsRaw = async ({
   return {
     items: withSpan('model:getAll:transform', () =>
       models
-        .map(({ rank, cursorId, ...model }) => {
+        .map(({ rank, cursorId, meta, ...model }) => {
           const data = modelData[model.id.toString()];
           if (!data) return null;
 
@@ -1045,6 +1056,7 @@ export const getModelsRaw = async ({
               cosmetics: userCosmetics[model.userId] ?? [],
             },
             cosmetic: cosmetics[model.id] ?? null,
+            metricPrivacy: getMetaMetricPrivacy(meta),
           };
         })
         .filter(isDefined)
@@ -1394,11 +1406,41 @@ export const getModelsWithImagesAndModelVersions = async ({
   const includeDrafts = status?.includes(ModelStatus.Draft);
 
   const unavailableGenResources = await getUnavailableResources();
+
+  // Creator Controls metric privacy for the card feed. Fetch owner defaults once,
+  // then only resolve CP membership for owners who actually have a hide flag set
+  // (keeps the common no-flags case free of membership lookups).
+  const isMod = !!user?.isModerator;
+  const feedOwnerIds = [...new Set(items.map((m) => m.user.id))];
+  const feedOwnerSettings = feedOwnerIds.length
+    ? await dbRead.user.findMany({
+        where: { id: { in: feedOwnerIds } },
+        select: { id: true, settings: true },
+      })
+    : [];
+  const feedOwnerSettingsMap = new Map<number, unknown>(
+    feedOwnerSettings.map((o) => [o.id, o.settings])
+  );
+  const membershipCandidates = new Set<number>();
+  for (const it of items) {
+    const ownerId = it.user.id;
+    if (isMod || ownerId === user?.id) continue;
+    const defHidden = getUserMetricPrivacyDefaults(feedOwnerSettingsMap.get(ownerId));
+    if (anyMetricHidden(it.metricPrivacy) || anyMetricHidden(defHidden))
+      membershipCandidates.add(ownerId);
+  }
+  const feedMembershipMap = await getValidCreatorMembershipMap([...membershipCandidates]);
+  const toMetaShape = (h: HiddenModelMetrics) => ({
+    hideBuzz: h.buzz,
+    hideDownloads: h.downloads,
+    hideGenerations: h.generations,
+  });
+
   const result = {
     nextCursor,
     isPrivate,
     items: items
-      .map(({ hashes, modelVersions, rank, tagsOnModels, ...model }) => {
+      .map(({ hashes, modelVersions, rank, tagsOnModels, metricPrivacy, ...model }) => {
         const [version] = modelVersions;
         if (!version) {
           return null;
@@ -1420,17 +1462,30 @@ export const getModelsWithImagesAndModelVersions = async ({
           unavailableGenResources.indexOf(version.id) === -1 &&
           isBaseModelGenerationSupported(version.baseModel, model.type);
 
+        const isOwner = isMod || model.user.id === user?.id;
+        const modelHidden = resolveModelHiddenMetrics({
+          modelMeta: toMetaShape(metricPrivacy),
+          userSettings: feedOwnerSettingsMap.get(model.user.id),
+          isOwnerOrModerator: isOwner,
+          hasValidMembership: feedMembershipMap.get(model.user.id) ?? false,
+        });
+
         return {
           ...model,
           tags: tagsOnModels.map((x) => x.tagId), // not sure why we even use scoring here...
           hashes: hashes.map((hash) => hash.toLowerCase()),
+          hiddenMetrics: modelHidden,
           rank: {
-            downloadCount: rank?.[`downloadCount${input.period}`] ?? 0,
+            downloadCount: modelHidden.downloads
+              ? null
+              : rank?.[`downloadCount${input.period}`] ?? 0,
             thumbsUpCount: rank?.[`thumbsUpCount${input.period}`] ?? 0,
             thumbsDownCount: rank?.[`thumbsDownCount${input.period}`] ?? 0,
             commentCount: rank?.[`commentCount${input.period}`] ?? 0,
             collectedCount: rank?.[`collectedCount${input.period}`] ?? 0,
-            tippedAmountCount: rank?.[`tippedAmountCount${input.period}`] ?? 0,
+            tippedAmountCount: modelHidden.buzz
+              ? null
+              : rank?.[`tippedAmountCount${input.period}`] ?? 0,
           },
           version,
           // // !important - for feed queries, when `model.nsfw === true`, we set all image `nsfwLevel` values to `NsfwLevel.XXX`
@@ -3250,21 +3305,45 @@ export async function getModelsWithVersions({
     where: { modelVersionId: { in: modelVersionIds } },
   });
 
-  function getStatsForModel(modelId: number) {
+  // Creator Controls metric privacy for the v1 public API. Only download + tipped
+  // are exposed today (no generation count in v1 stats), so we gate what exists.
+  const isMod = !!user?.isModerator;
+  const viewerId = user?.id;
+  const apiOwnerIds = [...new Set(items.map((m) => m.user.id))];
+  const apiOwnerSettings = apiOwnerIds.length
+    ? await dbRead.user.findMany({
+        where: { id: { in: apiOwnerIds } },
+        select: { id: true, settings: true },
+      })
+    : [];
+  const apiOwnerSettingsMap = new Map<number, unknown>(
+    apiOwnerSettings.map((o) => [o.id, o.settings])
+  );
+  const apiMembershipCandidates = new Set<number>();
+  for (const it of items) {
+    const ownerId = it.user.id;
+    if (isMod || ownerId === user?.id) continue;
+    const defHidden = getUserMetricPrivacyDefaults(apiOwnerSettingsMap.get(ownerId));
+    if (anyMetricHidden(it.metricPrivacy) || anyMetricHidden(defHidden))
+      apiMembershipCandidates.add(ownerId);
+  }
+  const apiMembershipMap = await getValidCreatorMembershipMap([...apiMembershipCandidates]);
+
+  function getStatsForModel(modelId: number, hidden: HiddenModelMetrics) {
     const stats = metrics.find((x) => x.modelId === modelId);
     return {
-      downloadCount: stats?.downloadCount ?? 0,
+      downloadCount: hidden.downloads ? null : stats?.downloadCount ?? 0,
       thumbsUpCount: stats?.thumbsUpCount ?? 0,
       thumbsDownCount: stats?.thumbsDownCount ?? 0,
       commentCount: stats?.commentCount ?? 0,
-      tippedAmountCount: stats?.tippedAmountCount ?? 0,
+      tippedAmountCount: hidden.buzz ? null : stats?.tippedAmountCount ?? 0,
     };
   }
 
-  function getStatsForVersion(versionId: number) {
+  function getStatsForVersion(versionId: number, hidden: HiddenModelMetrics) {
     const stats = versionMetrics.find((x) => x.modelVersionId === versionId);
     return {
-      downloadCount: stats?.downloadCount ?? 0,
+      downloadCount: hidden.downloads ? null : stats?.downloadCount ?? 0,
       thumbsUpCount: stats?.thumbsUpCount ?? 0,
       thumbsDownCount: stats?.thumbsDownCount ?? 0,
     };
@@ -3283,71 +3362,87 @@ export async function getModelsWithVersions({
         createdAt,
         lastVersionAt,
         user,
+        metricPrivacy,
         ...model
-      }) => ({
-        ...model,
-        user: user.username === 'civitai' ? undefined : user,
-        supportsGeneration: modelVersions.some((x) => x.covered),
-        modelVersions: modelVersions.map(({ trainingStatus, earlyAccessTimeFrame, ...version }) => {
-          const stats = getStatsForVersion(version.id);
-          const vaeVersionId = vaeMap.get(version.id);
-          const vaeFile = vaeVersionId
-            ? vaeFiles.filter((x) => x.modelVersionId === vaeVersionId)
-            : [];
-          const files = groupedFiles[version.id]?.files ?? [];
-          files.push(...vaeFile);
+      }) => {
+        const isOwner = isMod || user.id === viewerId;
+        const modelHidden = resolveModelHiddenMetrics({
+          modelMeta: {
+            hideBuzz: metricPrivacy.buzz,
+            hideDownloads: metricPrivacy.downloads,
+            hideGenerations: metricPrivacy.generations,
+          },
+          userSettings: apiOwnerSettingsMap.get(user.id),
+          isOwnerOrModerator: isOwner,
+          hasValidMembership: apiMembershipMap.get(user.id) ?? false,
+        });
+        return {
+          ...model,
+          user: user.username === 'civitai' ? undefined : user,
+          supportsGeneration: modelVersions.some((x) => x.covered),
+          modelVersions: modelVersions.map(
+            ({ trainingStatus, earlyAccessTimeFrame, ...version }) => {
+              const stats = getStatsForVersion(version.id, modelHidden);
+              const vaeVersionId = vaeMap.get(version.id);
+              const vaeFile = vaeVersionId
+                ? vaeFiles.filter((x) => x.modelVersionId === vaeVersionId)
+                : [];
+              const files = groupedFiles[version.id]?.files ?? [];
+              files.push(...vaeFile);
 
-          let earlyAccessDeadline = getEarlyAccessDeadline({
-            versionCreatedAt: version.createdAt,
-            publishedAt: version.publishedAt,
-            earlyAccessTimeframe: earlyAccessTimeFrame,
-          });
-          if (earlyAccessDeadline && new Date() > earlyAccessDeadline)
-            earlyAccessDeadline = undefined;
-
-          return {
-            ...version,
-            files: files.map(({ metadata: metadataRaw, modelVersionId, ...file }) => {
-              const metadata = metadataRaw as FileMetadata | undefined;
+              let earlyAccessDeadline = getEarlyAccessDeadline({
+                versionCreatedAt: version.createdAt,
+                publishedAt: version.publishedAt,
+                earlyAccessTimeframe: earlyAccessTimeFrame,
+              });
+              if (earlyAccessDeadline && new Date() > earlyAccessDeadline)
+                earlyAccessDeadline = undefined;
 
               return {
-                ...file,
-                metadata: {
-                  format: metadata?.format,
-                  size: metadata?.size,
-                  fp: metadata?.fp,
-                  quantType: metadata?.quantType,
-                  isRequired: metadata?.isRequired,
-                },
+                ...version,
+                files: files.map(({ metadata: metadataRaw, modelVersionId, ...file }) => {
+                  const metadata = metadataRaw as FileMetadata | undefined;
+
+                  return {
+                    ...file,
+                    metadata: {
+                      format: metadata?.format,
+                      size: metadata?.size,
+                      fp: metadata?.fp,
+                      quantType: metadata?.quantType,
+                      isRequired: metadata?.isRequired,
+                    },
+                  };
+                }),
+                earlyAccessDeadline,
+                stats,
+                // images: images
+                //   .filter((image) => image.modelVersionId === version.id)
+                //   .map(
+                //     ({ modelVersionId, name, userId, sizeKB, availability, metadata, ...image }) => ({
+                //       ...image,
+                //     })
+                //   ),
+                images: (images[version.id]?.images ?? []).map(
+                  ({
+                    modelVersionId,
+                    name,
+                    userId,
+                    sizeKB,
+                    availability,
+                    metadata,
+                    tags,
+                    ...image
+                  }) => ({
+                    ...image,
+                  })
+                ),
               };
-            }),
-            earlyAccessDeadline,
-            stats,
-            // images: images
-            //   .filter((image) => image.modelVersionId === version.id)
-            //   .map(
-            //     ({ modelVersionId, name, userId, sizeKB, availability, metadata, ...image }) => ({
-            //       ...image,
-            //     })
-            //   ),
-            images: (images[version.id]?.images ?? []).map(
-              ({
-                modelVersionId,
-                name,
-                userId,
-                sizeKB,
-                availability,
-                metadata,
-                tags,
-                ...image
-              }) => ({
-                ...image,
-              })
-            ),
-          };
-        }),
-        stats: getStatsForModel(model.id),
-      })
+            }
+          ),
+          stats: getStatsForModel(model.id, modelHidden),
+        };
+      }
     ),
     nextCursor,
   };

--- a/src/server/utils/model-metric-privacy.ts
+++ b/src/server/utils/model-metric-privacy.ts
@@ -1,0 +1,107 @@
+/**
+ * Creator Controls: model metric privacy.
+ *
+ * A Creator Program member can hide three public model metrics — tipped/earned
+ * Buzz, download count, generation count — at three levels:
+ *   - USER default (User.settings JSON): baseline for all of the creator's models
+ *   - MODEL level (Model.meta JSON): governs the model-page top stats + model card
+ *   - VERSION level (ModelVersion.meta JSON): governs the per-version stats in the
+ *     version details card only
+ *
+ * The stored flags only take effect while the model OWNER currently holds a valid
+ * Creator Program membership. Effective visibility is therefore computed PER VIEWER
+ * at READ time = storedFlag AND hasValidCreatorMembership(ownerId); a lapsed
+ * creator's flags silently revert to visible with NO database write. Owners and
+ * moderators always see their own real stats (bypass). This mirrors the read-time
+ * gate used by the donation-goals opt-out (see `redis/donation-goals-cache.ts`).
+ *
+ * This module is intentionally dependency-light (no db/redis/env imports) so the
+ * precedence rules can be unit-tested directly against the real functions.
+ */
+
+export const modelMetricPrivacyKeys = ['buzz', 'downloads', 'generations'] as const;
+export type ModelMetricPrivacyKey = (typeof modelMetricPrivacyKeys)[number];
+
+export type HiddenModelMetrics = { buzz: boolean; downloads: boolean; generations: boolean };
+
+const NONE_HIDDEN: HiddenModelMetrics = { buzz: false, downloads: false, generations: false };
+
+/** Whether any of the three metrics is hidden. */
+export const anyMetricHidden = (hidden: HiddenModelMetrics) =>
+  hidden.buzz || hidden.downloads || hidden.generations;
+
+type MetaPrivacyFlags = {
+  hideBuzz?: boolean | null;
+  hideDownloads?: boolean | null;
+  hideGenerations?: boolean | null;
+};
+
+type UserPrivacyDefaults = {
+  hideModelBuzz?: boolean | null;
+  hideModelDownloads?: boolean | null;
+  hideModelGenerations?: boolean | null;
+};
+
+/** Reads the model/version-level hide flags off a `meta` JSON blob. */
+export function getMetaMetricPrivacy(meta: unknown): HiddenModelMetrics {
+  const m = (meta ?? {}) as MetaPrivacyFlags;
+  return {
+    buzz: !!m.hideBuzz,
+    downloads: !!m.hideDownloads,
+    generations: !!m.hideGenerations,
+  };
+}
+
+/** Reads the user-default hide flags off a User.settings JSON blob. */
+export function getUserMetricPrivacyDefaults(settings: unknown): HiddenModelMetrics {
+  const s = (settings ?? {}) as UserPrivacyDefaults;
+  return {
+    buzz: !!s.hideModelBuzz,
+    downloads: !!s.hideModelDownloads,
+    generations: !!s.hideModelGenerations,
+  };
+}
+
+const orHidden = (...parts: HiddenModelMetrics[]): HiddenModelMetrics => ({
+  buzz: parts.some((p) => p.buzz),
+  downloads: parts.some((p) => p.downloads),
+  generations: parts.some((p) => p.generations),
+});
+
+/**
+ * Effective hidden metrics for the model-page TOP stats + the model card.
+ * Governed by the MODEL flag OR the USER default. Bypassed for owner/mod and when
+ * the owner has no valid Creator Program membership.
+ */
+export function resolveModelHiddenMetrics(args: {
+  modelMeta?: unknown;
+  userSettings?: unknown;
+  isOwnerOrModerator?: boolean;
+  hasValidMembership?: boolean;
+}): HiddenModelMetrics {
+  if (args.isOwnerOrModerator || !args.hasValidMembership) return { ...NONE_HIDDEN };
+  return orHidden(
+    getMetaMetricPrivacy(args.modelMeta),
+    getUserMetricPrivacyDefaults(args.userSettings)
+  );
+}
+
+/**
+ * Effective hidden metrics for the per-version stats in the version details card.
+ * A version-details stat is hidden if the VERSION flag OR the MODEL flag OR the
+ * USER default says so. Bypassed for owner/mod and lapsed/non-members.
+ */
+export function resolveVersionHiddenMetrics(args: {
+  versionMeta?: unknown;
+  modelMeta?: unknown;
+  userSettings?: unknown;
+  isOwnerOrModerator?: boolean;
+  hasValidMembership?: boolean;
+}): HiddenModelMetrics {
+  if (args.isOwnerOrModerator || !args.hasValidMembership) return { ...NONE_HIDDEN };
+  return orHidden(
+    getMetaMetricPrivacy(args.versionMeta),
+    getMetaMetricPrivacy(args.modelMeta),
+    getUserMetricPrivacyDefaults(args.userSettings)
+  );
+}


### PR DESCRIPTION
## Creator Controls: model metric privacy

Lets Creator Program members hide three public model metrics — **tipped/earned Buzz, download count, generation count** — extending the just-shipped donation-goal opt-out pattern.

### 3-level control hierarchy (all in this PR)
1. **USER default** — new "Creator Controls" card in User Settings (`src/pages/user/account.tsx` → `CreatorControlsCard.tsx`). Baseline for all the creator's models. Flags stored on `User.settings` (`hideModelBuzz` / `hideModelDownloads` / `hideModelGenerations`) via `userSettingsSchema` + `setUserSettingsInput`.
2. **MODEL level** (primary) — new section in the model edit form (`ModelUpsertForm.tsx`). Stored on `Model.meta` JSON. Governs the model-page TOP stats (version totals) + model card stats.
3. **VERSION level** (sub-option) — section in the version edit form (`ModelVersionUpsertForm.tsx`). Stored on `ModelVersion.meta` JSON. Governs the per-version stats in the version details card only.

Precedence: a version-details stat is hidden if the version flag **OR** model flag **OR** user default says so; model totals/card are governed by the model flag **OR** user default.

### CP gating (read-time, lapse reverts with no DB write)
Effective visibility is computed **per-viewer at read time** = `storedFlag AND hasValidCreatorMembership(ownerId)`. A lapsed creator's stored flags silently revert to visible — **no database write**. Owners and moderators always see their real stats (bypass). Central helper: `src/server/utils/model-metric-privacy.ts` (dependency-light, unit-tested); batched membership lookup `getValidCreatorMembershipMap` in `creator-program.service.ts`.

### Surfaces gated (number omitted at the source, never leaked)
| Surface | File |
|---|---|
| Model card | `components/Cards/ModelCard.tsx` (downloads, buzz) |
| Model page top stats | `pages/models/[id]/[[...slug]].tsx` (downloads, generation, buzzEarned) |
| tRPC model controller rank | `server/controllers/model.controller.ts` (`getModelHandler` model + version rank; feed via `getModelsWithImagesAndModelVersions`; associated-resources cards) |
| v1 public API stats | `server/services/model.service.ts` (`getStatsForModel`/`getStatsForVersion`; flows into `buildPublicModelResponse`). Only download + tipped exist in v1 — generation count isn't in v1 stats, so we gate what exists |
| Search index doc | `server/search-index/models.search-index.ts` — stores effective model-level hide flags for the card notice; **keeps** real `metrics`/`rank` so sort order is unchanged |
| Category cards | `components/Model/Categories/ModelCategoryCard.tsx` |

### Ranking treatment (notice + upsell, not a hard opt-out)
On sort/leaderboard surfaces the model **stays listed** and the sort ORDER still uses the real underlying value server-side; only the exposed NUMBER is replaced with a subtle "creator has hidden this metric" notice (`HiddenMetricNotice.tsx`) + an invite for others to do the same. Rank position implies a rough range — accepted.

### Upsell
The settings card and both edit-form sections show a renew/join pitch and **disable the toggles** for non-active / lapsed members (via `getCreatorRequirements` → `validMembership` / `membershipLapsed`).

### Tests
`src/server/__tests__/model-metric-privacy.test.ts` (13 cases): owner/mod bypass; non-owner sees hidden when owner is an active member; non-owner sees real stats when owner has lapsed; per-level (user/model/version) precedence and unions.

### Notes / deferred
- The write path (`server/metrics/model.metrics.ts`) is **not** gated, by design — gating is read/display only.
- Search is a precomputed shared doc: a membership lapse reverts to visible on the next reindex rather than instantly (over-hides at worst until reindex; never leaks). The real metric remains in the search payload for sort ordering, as intended.
- `pnpm typecheck` passes clean (full, unfiltered); new unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Review round 2 — adversarial-review fixes

**Blocking privacy leaks (real number no longer reaches the client for a hidden metric):**
1. **Meilisearch** (`models.search-index.ts`, `model.parser.ts`) — the displayed `metrics`/`rank` download+tipped are now **masked to null** when hidden; the REAL values live in a sort-only `sortMetrics.{downloadCount,tippedAmountCount}` that is in `sortableAttributes` but **excluded from a new `displayedAttributes` whitelist**. So no search hit (including a direct Meili query) carries the real hidden number, and sort order still uses the real value. Parser sorts on `sortMetrics.*` (enum indices preserved → sort-dropdown labels unchanged).
2. **OG image** (`api/og.tsx`) — resolves hidden metrics (owner settings + membership) and drops the Downloads / Generations tiles when hidden.
3. **v1 `/model-versions/[id]` + both `by-hash` routes** — shared `prepareModelVersionResponse` now gates `stats.downloadCount` via `resolveVersionHiddenMetrics` (fixes all three at once).
4. **v1 models list** (`getModelsWithVersions`) — `getStatsForVersion` now uses `resolveVersionHiddenMetrics` (version OR model OR user), fetching version metas in one batch. Fixes both the leak and the v1 version-only precedence bug.

**Blocking perf:**
5. `getValidCreatorMembershipMap` rewritten from K per-owner `dbWrite.customerSubscription.findMany` (Promise.all, primary pool) to a **single `dbRead` query** over all owners, collapsed to a userId→valid map mirroring `getHighestTierSubscription`'s tier logic.

**Should-fix:**
6. Reindex trigger — new `queueModelMetricPrivacyReindex(userId)` is fired from `setUserSettingHandler` when a `hideModel*` flag changes. The **membership-lapse** reindex is **deferred** (status transitions run through several Stripe/Paddle webhook paths; wiring each is out of scope for this pass) — the helper is in place and ready to call from those handlers.
7. Owner/mod over-hide on search cards — **softened the CreatorControlsCard copy** to note that on search results they see the hidden state, same as the public.

**Tests:** added v1 version-stats precedence cases (version-only hide honored; lapse reverts; model-level cascades). Full `pnpm typecheck` clean; 16 metric-privacy tests pass.

**Meili verification note:** enforcement is the index-level `displayedAttributes` setting (applied to ALL queries by Meilisearch, not client-side `attributesToRetrieve`), so a direct Meili query cannot return `sortMetrics`. The setting is applied by `onIndexSetup` on the next index setup/sync; a live cluster reindex to eyeball a hit is deferred to preview/deploy.


---

## Round 3 — donation-goal opt-out folded into Creator Controls (per Justin)

- **Moved** the user-level `hideDonationGoals` toggle out of `SettingsCard.tsx` and into `CreatorControlsCard.tsx`, next to the metric toggles, under the same **active-member gate + upsell** (disabled for non-active / lapsed members). The per-version donation-goal control in `ModelVersionUpsertForm.tsx` is unchanged.
- **CP-gated the effect** (`donation-goals-cache.ts`): goals are now hidden only when `hideDonationGoals AND hasValidCreatorMembership(ownerId)`. A lapsed / never-member owner's goals become **publicly visible again with no stored flip**, mirroring the metric-privacy gate. Owner/mod still bypass the shared cache entirely upstream in `modelVersionDonationGoals`.
- **Reuses the batched membership path** (single `dbRead`, no per-owner fan-out). Extracted `getValidCreatorMembershipMap` into a dependency-light `creator-membership.service.ts` so the light donation-goals lookup doesn't drag in the heavy creator-program graph (it's re-exported from `creator-program.service` for the existing metric-privacy callers). Only opted-out owners incur the membership check.
- **Tests:** opted-out owner hidden only while an active member; visible again when lapsed; owner/mod bypass documented (enforced upstream).

> ⚠️ **Behavior change to the shipped donation-goal opt-out (#3253):** anyone who set it while **not** an active member will have their goals become visible again. Intended per Justin.

Full `pnpm typecheck` clean; 24 tests pass (metric-privacy + donation-goals).
