### PR TITLE
fix(deps): scope fast-xml-parser override off the AWS SDK (unbreak S3 error parsing)

### DIFF
--- a/package.json
+++ b/package.json
@@ -399,6 +399,7 @@
       "vite": "6.4.3",
       "protobufjs@7": "^7.5.6",
       "fast-xml-parser": "^5.9.3",
+      "@aws-sdk/core>fast-xml-parser": "5.2.5",
       "axios": "^1.16.0",
       "undici@6": "^6.27.0",
       "tar-fs@2": "^2.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   vite: 6.4.3
   protobufjs@7: ^7.5.6
   fast-xml-parser: ^5.9.3
+  '@aws-sdk/core>fast-xml-parser': 5.2.5
   axios: ^1.16.0
   undici@6: ^6.27.0
   tar-fs@2: ^2.1.5
@@ -7252,6 +7253,10 @@ packages:
     resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
     hasBin: true
 
+  fast-xml-parser@5.2.5:
+    resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
+    hasBin: true
+
   fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
@@ -12336,7 +12341,7 @@ snapshots:
       '@smithy/util-body-length-browser': 4.0.0
       '@smithy/util-middleware': 4.0.5
       '@smithy/util-utf8': 4.0.0
-      fast-xml-parser: 5.10.1
+      fast-xml-parser: 5.2.5
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.862.0':
@@ -19017,6 +19022,10 @@ snapshots:
       path-expression-matcher: 1.6.2
       strnum: 2.4.1
       xml-naming: 0.3.0
+
+  fast-xml-parser@5.2.5:
+    dependencies:
+      strnum: 2.4.1
 
   fastest-levenshtein@1.0.16: {}
 


### PR DESCRIPTION
## Regression

The CVE PR added a **blanket** `pnpm.overrides` entry `"fast-xml-parser": "^5.9.3"`. pnpm applies a bare override to *every* transitive copy in the tree, so it forced **`@aws-sdk/core@3.862.0`**'s own fast-xml-parser up to **5.10.1**.

`@aws-sdk/core@3.862.0` declares and is tested against **fast-xml-parser `5.2.5`** (not 4.x — it is a 5.x-era SDK). fast-xml-parser 5.10.1 changed parse/validation behavior enough that the SDK's `parseXmlErrorBody` now **throws `"char '4' is not expected:1:1"`** when handed an S3 **error** response, instead of surfacing the real error.

**Live symptom:** `purge-resize-cache` failing ~92×/10min across pods (fail-soft — no user 5xx, but it masks the real S3 error on every S3 error path and is a latent risk).

## Fix — scope the override off the AWS SDK

pnpm parent-qualified override so **only** the AWS SDK's copy pins back to its tested version, while the general CVE override stays for the other consumer:

```json
"fast-xml-parser": "^5.9.3",
"@aws-sdk/core>fast-xml-parser": "5.2.5",
```

Consumers of fast-xml-parser in the tree (grepped the lockfile — these are the **only** two, and among `@aws-sdk/*` / `@smithy/*` **only `@aws-sdk/core` declares it**, so a single qualifier is sufficient):

| Consumer | declares | before (blanket) | after (scoped) |
|---|---|---|---|
| `@aws-sdk/core@3.862.0` | `5.2.5` | 5.10.1 ❌ broke `parseXmlErrorBody` | **5.2.5** ✅ |
| `@civitai/cybertipline-tools@0.1.0` | `5.2.5` | 5.10.1 (CVE patch) | 5.10.1 (CVE patch kept) |

## Direct usage / CVE applicability

`git grep "fast-xml-parser\|XMLParser\|XMLBuilder" src/` → **civitai/civitai has NO direct fast-xml-parser usage.** Both consumers are transitive and parse **semi-trusted** XML (AWS/S3 API responses, and NCMEC CyberTipline API responses) — not arbitrary user-supplied XML. The CVE (untrusted-XML DoS/pollution class) is therefore of low applicability to our actual usage; the general override is kept as defense-in-depth on the non-AWS consumer only. The AWS SDK's copy parses AWS-origin XML and stays on the version AWS ships and tests, which is the safe choice.

## Verification

- **Lockfile (authoritative):** `@aws-sdk/core@3.862.0 -> fast-xml-parser 5.2.5` (before: `5.10.1`). On-disk `node_modules/.pnpm/@aws-sdk+core@3.862.0*/.../fast-xml-parser/package.json` = `5.2.5`. This is the key assertion — the resize-purge crash is gone once the SDK is back on 5.2.5.
- **tsc:** `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` → 13 pre-existing `event-engine-common` submodule-absent errors (the known 13-17 baseline), **ZERO new** errors. Diff touches only `package.json` + `pnpm-lock.yaml`; no TS source and no type civitai imports changes.
- The preview build can't easily trigger a real S3 error, so the lockfile assertion above is the authoritative check. Prod confirmation: `purge-resize-cache` fast-xml-parser errors should stop after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
