### PR TITLE
feat(app-blocks): per-engine budget ceilings for seamless-pano-360 customComfy recipe

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -4516,7 +4516,8 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
     return validClaims({
       ctx: { entityType: 'none', slotId: 'page' },
       appBlockId: 'apb_test',
-      buzzBudget: 500, // comfortably above the recipe ceiling (180) by default
+      // Comfortably above every per-engine ceiling (zimage 90 default … qwen 180 max).
+      buzzBudget: 500,
       ...over,
     });
   }
@@ -4601,19 +4602,22 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       happySubmit();
       const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
       expect(result.snapshot.workflowId).toBe('wf_cc_1');
-      // (2) per-user daily cap reserved the CEILING (180), not the 0 estimate.
+      // (2) per-user daily cap reserved the per-engine CEILING (zimage default =
+      // 90), not the 0 estimate.
       expect(mockSysRedis.incrBy).toHaveBeenCalledWith(
         expect.stringMatching(/^system:blocks:buzz-cap:42:/),
-        180
+        90
       );
       // (3) per-app aggregate cap reserved the CEILING.
-      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 180);
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 90);
+      // The submitted step's timeout matches the reserved ceiling (90s → 00:01:30).
+      expect(mockSubmitWorkflow.mock.calls[0][0].body.steps[0].timeout).toBe('00:01:30');
       // settle record persisted with BOTH reservation keys + the ceiling.
       expect(mockPersistCustomComfySettle).toHaveBeenCalledWith({
         workflowId: 'wf_cc_1',
         buzzCapKey: expect.stringMatching(/^system:blocks:buzz-cap:42:/),
         appSpendKey: 'system:blocks:app-spend-cap:apb_test:day',
-        ceiling: 180,
+        ceiling: 90,
       });
     });
 
@@ -4631,11 +4635,11 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
     });
 
     it('STATIC gate: recipe ceiling > buzzBudget → failed snapshot, NO reserve, NO submit', async () => {
-      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ buzzBudget: 50 })); // 180 > 50
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ buzzBudget: 50 })); // zimage 90 > 50
       happyCcResources();
       const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
       expect(result.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
-      expect(result.snapshot.error).toMatch(/ceiling 180 exceeds budget 50/);
+      expect(result.snapshot.error).toMatch(/ceiling 90 exceeds budget 50/);
       expect(mockSysRedis.incrBy).not.toHaveBeenCalled(); // never reserved
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });
@@ -4647,10 +4651,10 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
       expect(result.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
       expect(result.snapshot.error).toMatch(/daily Buzz cap/);
-      // refunded the reserved ceiling on the pinned key.
+      // refunded the reserved ceiling (zimage 90) on the pinned key.
       expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
         expect.stringMatching(/^system:blocks:buzz-cap:42:/),
-        180
+        90
       );
       expect(mockReserveAppSpend).not.toHaveBeenCalled(); // never reached the app cap
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
@@ -4668,10 +4672,10 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
       expect(result.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
       expect(result.snapshot.error).toMatch(/app daily spend cap/);
-      // per-user daily reservation rolled back.
+      // per-user daily reservation (zimage 90) rolled back.
       expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
         expect.stringMatching(/^system:blocks:buzz-cap:42:/),
-        180
+        90
       );
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });
@@ -4685,11 +4689,73 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       ).rejects.toThrow(/orchestrator down/);
       expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
         expect.stringMatching(/^system:blocks:buzz-cap:42:/),
-        180
+        90
       );
-      expect(mockRefundAppSpend).toHaveBeenCalledWith('system:blocks:app-spend-cap:apb_test:day', 180);
+      expect(mockRefundAppSpend).toHaveBeenCalledWith('system:blocks:app-spend-cap:apb_test:day', 90);
       // never persisted a settle record for a submit that threw.
       expect(mockPersistCustomComfySettle).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── v1.1: PER-ENGINE budget ceilings. A cheaper engine reserves/settles LESS
+  // cap AND gets a proportionally tighter step timeout (the timeout is the
+  // physical Buzz cap, so the reservation and the timeout MUST move together).
+  describe('submitWorkflow — per-engine budget ceilings (v1.1)', () => {
+    it('qwen-image reserves 180 on both caps and stamps a 00:03:00 timeout', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: ccBody({ params: { prompt: 'x', engine: 'qwen-image' } }),
+      });
+      expect(mockSysRedis.incrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        180
+      );
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 180);
+      expect(mockSubmitWorkflow.mock.calls[0][0].body.steps[0].timeout).toBe('00:03:00');
+      expect(mockPersistCustomComfySettle).toHaveBeenCalledWith(
+        expect.objectContaining({ ceiling: 180 })
+      );
+    });
+
+    it('flux2-klein reserves 120 and stamps a 00:02:00 timeout', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: ccBody({ params: { prompt: 'x', engine: 'flux2-klein' } }),
+      });
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 120);
+      expect(mockSubmitWorkflow.mock.calls[0][0].body.steps[0].timeout).toBe('00:02:00');
+    });
+
+    it('the concrete new behavior: at buzzBudget 100, cheap zimage (90) RUNS but qwen (180) is REJECTED', async () => {
+      // Under the old single-180 ceiling this budget gated out EVERY engine; now a
+      // cheaper engine runs under a budget the priciest still can't afford.
+      happyCcResources();
+      happySubmit();
+      // zimage ceiling 90 ≤ 100 → passes the static gate, reserves 90, submits.
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ buzzBudget: 100 }));
+      const okZimage = await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: ccBody({ params: { prompt: 'x', engine: 'zimage-turbo' } }),
+      });
+      expect(okZimage.snapshot.workflowId).toBe('wf_cc_1');
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 90);
+
+      // qwen ceiling 180 > 100 → rejected at the static gate, NO submit.
+      mockSubmitWorkflow.mockClear();
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ buzzBudget: 100 }));
+      const rejectedQwen = await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: ccBody({ params: { prompt: 'x', engine: 'qwen-image' } }),
+      });
+      expect(rejectedQwen.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
+      expect(rejectedQwen.snapshot.error).toMatch(/ceiling 180 exceeds budget 100/);
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });
   });
 
@@ -4810,7 +4876,7 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
     it('over-budget static gate returns BEFORE submit → NO scope-invocation, NO attribution', async () => {
       vi.mocked(recordScopeInvocation).mockClear();
       mockRecordSpendAttribution.mockClear();
-      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ buzzBudget: 50 })); // 180 > 50
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ buzzBudget: 50 })); // zimage 90 > 50
       happyCcResources();
       const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
       expect(result.snapshot.status).toBe('failed');
@@ -4844,12 +4910,12 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       happyCcResources();
       happySubmit();
       mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 5000 });
-      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 180 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 90 });
 
       const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
       expect(result.snapshot.workflowId).toBe('wf_cc_1');
-      // Reserved the CEILING (180), not the 0 estimate, against the session cap.
-      expect(mockReserveDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 180, 5000);
+      // Reserved the CEILING (zimage default = 90), not the 0 estimate, against the session cap.
+      expect(mockReserveDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 90, 5000);
       // Dev token → NO per-app reserve, but the settle record carries the session
       // id (so terminal settle refunds ceiling-actual on the session cap too).
       expect(mockReserveAppSpend).not.toHaveBeenCalled();
@@ -4858,7 +4924,7 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
         buzzCapKey: expect.stringMatching(/^system:blocks:buzz-cap:42:/),
         appSpendKey: null,
         devSessionId: 'bki_dev',
-        ceiling: 180,
+        ceiling: 90,
       });
     });
 
@@ -4867,17 +4933,17 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       happyCcResources();
       happySubmit();
       mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 5000 });
-      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 180 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 90 });
 
       await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
-      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 180);
-      expect(mockReserveDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 180, 5000);
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 90);
+      expect(mockReserveDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 90, 5000);
       expect(mockPersistCustomComfySettle).toHaveBeenCalledWith({
         workflowId: 'wf_cc_1',
         buzzCapKey: expect.stringMatching(/^system:blocks:buzz-cap:42:/),
         appSpendKey: 'system:blocks:app-spend-cap:apb_test:day',
         devSessionId: 'bki_dev',
-        ceiling: 180,
+        ceiling: 90,
       });
     });
 
@@ -4890,10 +4956,10 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       const result = await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
       expect(result.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
       expect(result.snapshot.error).toMatch(/dev tunnel session Buzz cap reached/);
-      // The per-user daily CEILING reservation was rolled back.
+      // The per-user daily CEILING (zimage 90) reservation was rolled back.
       expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
         expect.stringMatching(/^system:blocks:buzz-cap:42:/),
-        180
+        90
       );
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
       expect(mockPersistCustomComfySettle).not.toHaveBeenCalled();
@@ -4903,18 +4969,18 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ dev: true }));
       happyCcResources();
       mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 5000 });
-      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 180 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 90 });
       mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
 
       await expect(
         caller().submitWorkflow({ blockToken: 'tok', body: ccBody() })
       ).rejects.toThrow(/orchestrator down/);
-      // Daily + dev-session ceiling both refunded on the throw.
+      // Daily + dev-session ceiling (zimage 90) both refunded on the throw.
       expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
         expect.stringMatching(/^system:blocks:buzz-cap:42:/),
-        180
+        90
       );
-      expect(mockRefundDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 180);
+      expect(mockRefundDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 90);
       expect(mockPersistCustomComfySettle).not.toHaveBeenCalled();
     });
 

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -4720,7 +4720,7 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       );
     });
 
-    it('flux2-klein reserves 120 and stamps a 00:02:00 timeout', async () => {
+    it('flux2-klein reserves 150 and stamps a 00:02:30 timeout', async () => {
       mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
       happyCcResources();
       happySubmit();
@@ -4728,8 +4728,99 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
         blockToken: 'tok',
         body: ccBody({ params: { prompt: 'x', engine: 'flux2-klein' } }),
       });
-      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 120);
-      expect(mockSubmitWorkflow.mock.calls[0][0].body.steps[0].timeout).toBe('00:02:00');
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 150);
+      expect(mockSubmitWorkflow.mock.calls[0][0].body.steps[0].timeout).toBe('00:02:30');
+    });
+
+    // ── Per-engine reserve↔refund SYMMETRY. The refund/rollback tests in the
+    // budget-belt block above only exercise the DEFAULT engine (zimage 90); these
+    // prove a NON-default engine refunds ITS OWN ceiling (qwen 180 / flux2 150),
+    // not the flat 90 — so a cheaper engine can never over-refund and a pricier
+    // one can never under-refund on a deny/throw.
+    it('SYMMETRY: a qwen-image daily-cap breach refunds ITS ceiling (180, not 90) on the pinned key', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      mockSysRedis.incrBy.mockResolvedValue(60000); // reservation pushes over 50k cap
+      const result = await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: ccBody({ params: { prompt: 'x', engine: 'qwen-image' } }),
+      });
+      expect(result.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
+      // The reserved qwen ceiling (180) is refunded — NOT the default 90.
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        180
+      );
+      expect(mockSysRedis.decrBy).not.toHaveBeenCalledWith(expect.anything(), 90);
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('SYMMETRY: a flux2-klein app-cap breach refunds ITS ceiling (150) on the per-user key', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      mockReserveAppSpend.mockResolvedValue({
+        allowed: false,
+        reason: 'daily',
+        dailyTotal: 9_999_999,
+        velocityCount: 1,
+      });
+      const result = await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: ccBody({ params: { prompt: 'x', engine: 'flux2-klein' } }),
+      });
+      expect(result.snapshot).toMatchObject({ workflowId: 'failed', status: 'failed' });
+      // The per-user reservation rolled back at flux2's ceiling (150), not 90.
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        150
+      );
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('SYMMETRY: a qwen-image refund-on-throw refunds ITS ceiling (180) on BOTH caps', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: ccBody({ params: { prompt: 'x', engine: 'qwen-image' } }),
+        })
+      ).rejects.toThrow(/orchestrator down/);
+      // BOTH the per-user daily cap and the per-app aggregate cap refund 180.
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        180
+      );
+      expect(mockRefundAppSpend).toHaveBeenCalledWith(
+        'system:blocks:app-spend-cap:apb_test:day',
+        180
+      );
+      expect(mockPersistCustomComfySettle).not.toHaveBeenCalled();
+    });
+
+    // ── Graph-engine ↔ stamped-timeout end-to-end. Within ONE submit, prove the
+    // engine that drove the BUILT customComfy graph is the SAME engine that drove
+    // the STAMPED step timeout — i.e. the reservation/timeout can't be stamped for
+    // one engine while the graph is another's (safe-by-construction, now asserted).
+    it('END-TO-END: a qwen submit stamps 00:03:00 AND the emitted step input is qwen’s graph + resources', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: ccBody({ params: { prompt: 'x', engine: 'qwen-image' } }),
+      });
+      const step = mockSubmitWorkflow.mock.calls[0][0].body.steps[0];
+      // Stamped timeout = qwen's ceiling (180s).
+      expect(step.timeout).toBe('00:03:00');
+      // The SAME submit's built graph is qwen's — the GGUF loader is qwen-specific
+      // (zimage/flux2 use UNETLoader), and a qwen resource AIR is in the step input.
+      expect(step.input.workflow['1'].class_type).toBe('GGUFLoaderKJ');
+      expect((step.input.resources as string[]).some((r) => r.includes('Qwen-Image'))).toBe(true);
+      // And it is NOT zimage's graph/resources (guards against a mismatched pairing).
+      expect((step.input.resources as string[]).some((r) => r.includes('z_image_turbo'))).toBe(false);
     });
 
     it('the concrete new behavior: at buzzBudget 100, cheap zimage (90) RUNS but qwen (180) is REJECTED', async () => {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5301,9 +5301,12 @@ async function submitCustomComfyWorkflow(opts: {
   });
 
   // ── Post-paid budget belt (plan §5.3 — THE crux) ─────────────────────────
-  // `ceiling === recipe.maxBuzz === ceil(stepTimeoutSeconds)` (enforced at
-  // registry load): the step `timeout` physically caps the job at this many Buzz.
-  const ceiling = recipe.maxBuzz;
+  // v1.1: the budget is PER ENGINE — resolve BOTH the ceiling AND the matching
+  // step timeout from the parsed params. `ceiling === maxBuzz === ceil(
+  // stepTimeoutSeconds)` (enforced per-engine at registry load): the step
+  // `timeout` physically caps the job at this many Buzz, so the reservation below
+  // and the timeout stamped on the step MUST come from the same budget.
+  const { maxBuzz: ceiling, stepTimeoutSeconds } = recipe.budgetFor(params);
 
   // (1) STATIC pre-submit gate — the post-paid analog of the txt2img whatIf
   // `cost > buzzBudget` gate. Because the timeout caps the job at `maxBuzz` and we
@@ -5420,7 +5423,7 @@ async function submitCustomComfyWorkflow(opts: {
     }
   }
 
-  // ── Build + submit. `createBlockCustomComfyStep` stamps the recipe's aggressive
+  // ── Build + submit. `createBlockCustomComfyStep` stamps the resolved per-engine
   // `timeout` — the physical Buzz ceiling. On ANY throw AFTER reserving, refund
   // the CEILING (not 0) on ALL reservation keys and re-throw (refund-on-throw,
   // plan §7).
@@ -5432,7 +5435,9 @@ async function submitCustomComfyWorkflow(opts: {
   let realizedTransactions: Awaited<ReturnType<typeof submitWorkflow>>['transactions'];
   try {
     const stepInput = buildCustomComfyWorkflowInput(recipe, body.params, {});
-    const step = createBlockCustomComfyStep(recipe, stepInput);
+    // Stamp the SAME per-engine timeout the ceiling above was reserved against —
+    // the timeout is the physical cap for that reservation (v1.1).
+    const step = createBlockCustomComfyStep(stepInput, stepTimeoutSeconds);
     // Parameterized tags: emit the recipe id + 'customComfy' (NOT 'txt2img'),
     // preserving the `app-block:*` provenance tags the subqueue read depends on.
     const tags = buildWorkflowTags(claims, recipe.id, 'customComfy');

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -1506,7 +1506,7 @@ describe('createBlockCustomComfyStep (step wrapper)', () => {
     expect(step.input).toBe(input);
   });
 
-  it('formats the timeout per engine: zimage 90s → 00:01:30, flux2 120s → 00:02:00', () => {
+  it('formats the timeout per engine: zimage 90s → 00:01:30, flux2 150s → 00:02:30', () => {
     const input = buildCustomComfyWorkflowInput(recipe, { prompt: 'a lake', seed: 1 });
     expect(
       createBlockCustomComfyStep(input, recipe.budgetFor({ prompt: 'a lake', engine: 'zimage-turbo' }).stepTimeoutSeconds)
@@ -1515,7 +1515,7 @@ describe('createBlockCustomComfyStep (step wrapper)', () => {
     expect(
       createBlockCustomComfyStep(input, recipe.budgetFor({ prompt: 'a lake', engine: 'flux2-klein' }).stepTimeoutSeconds)
         .timeout
-    ).toBe('00:02:00');
+    ).toBe('00:02:30');
   });
 });
 

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -1494,14 +1494,28 @@ describe('buildCustomComfyWorkflowInput (translator)', () => {
 describe('createBlockCustomComfyStep (step wrapper)', () => {
   const recipe = getRecipe('seamless-pano-360')!;
 
-  it('wraps the input as a customComfy step and stamps the recipe timeout (HH:MM:SS)', () => {
+  it('wraps the input as a customComfy step and stamps the resolved per-engine timeout (HH:MM:SS)', () => {
     const input = buildCustomComfyWorkflowInput(recipe, { prompt: 'a lake', seed: 1 });
-    const step = createBlockCustomComfyStep(recipe, input);
+    // v1.1: the caller resolves the timeout from the params' budget and threads it.
+    const { stepTimeoutSeconds } = recipe.budgetFor({ prompt: 'a lake', engine: 'qwen-image' });
+    const step = createBlockCustomComfyStep(input, stepTimeoutSeconds);
     expect(step.$type).toBe('customComfy');
     expect(step.name).toBe(BLOCK_CUSTOM_COMFY_STEP_NAME);
-    // 180s ceiling → 00:03:00 (NOT the reference's loose 01:00:00).
+    // qwen 180s ceiling → 00:03:00 (NOT the reference's loose 01:00:00).
     expect(step.timeout).toBe('00:03:00');
     expect(step.input).toBe(input);
+  });
+
+  it('formats the timeout per engine: zimage 90s → 00:01:30, flux2 120s → 00:02:00', () => {
+    const input = buildCustomComfyWorkflowInput(recipe, { prompt: 'a lake', seed: 1 });
+    expect(
+      createBlockCustomComfyStep(input, recipe.budgetFor({ prompt: 'a lake', engine: 'zimage-turbo' }).stepTimeoutSeconds)
+        .timeout
+    ).toBe('00:01:30');
+    expect(
+      createBlockCustomComfyStep(input, recipe.budgetFor({ prompt: 'a lake', engine: 'flux2-klein' }).stepTimeoutSeconds)
+        .timeout
+    ).toBe('00:02:00');
   });
 });
 

--- a/src/server/services/blocks/recipes/__tests__/seamless-pano.recipe.test.ts
+++ b/src/server/services/blocks/recipes/__tests__/seamless-pano.recipe.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  BUDGET_BY_ENGINE,
   ESTIMATE_BUZZ_BY_ENGINE,
   FLUX2_CFG,
   FLUX2_CLIP_AIR,
@@ -20,6 +21,7 @@ import {
   QWEN_LORA_VERSION_ID,
   QWEN_TRIGGER_WORDS,
   QWEN_VAE_AIR,
+  SEAMLESS_PANO_ENGINES,
   SEAM_BAND_PX,
   SEAM_DENOISE,
   SEAM_FEATHER_PX,
@@ -333,9 +335,46 @@ describe('seamlessPano360Recipe contract', () => {
     expect(getRecipe('not-a-recipe')).toBeUndefined();
   });
 
-  it('declares the post-paid ceiling contract: maxBuzz == ceil(stepTimeoutSeconds)', () => {
-    expect(seamlessPano360Recipe.stepTimeoutSeconds).toBe(180);
-    expect(seamlessPano360Recipe.maxBuzz).toBe(Math.ceil(seamlessPano360Recipe.stepTimeoutSeconds));
+  it('declares the per-engine post-paid ceiling contract: maxBuzz == ceil(stepTimeoutSeconds) for EVERY engine', () => {
+    // v1.1: the timeout==ceiling invariant now holds PER ENGINE (the module-load
+    // loop in index.ts asserts this too — re-assert it here as the recipe's own
+    // contract test so a bad table entry fails loudly in the recipe suite).
+    for (const engine of SEAMLESS_PANO_ENGINES) {
+      const budget = BUDGET_BY_ENGINE[engine];
+      expect(budget.maxBuzz).toBe(Math.ceil(budget.stepTimeoutSeconds));
+    }
+  });
+
+  it('resolves the per-engine budget from params (zimage 90 / flux2 120 / qwen 180), default → zimage 90', () => {
+    expect(seamlessPano360Recipe.budgetFor(params('x', undefined, 'zimage-turbo'))).toEqual({
+      maxBuzz: 90,
+      stepTimeoutSeconds: 90,
+    });
+    expect(seamlessPano360Recipe.budgetFor(params('x', undefined, 'flux2-klein'))).toEqual({
+      maxBuzz: 120,
+      stepTimeoutSeconds: 120,
+    });
+    expect(seamlessPano360Recipe.budgetFor(params('x', undefined, 'qwen-image'))).toEqual({
+      maxBuzz: 180,
+      stepTimeoutSeconds: 180,
+    });
+    // No engine → the DEFAULT_ENGINE (zimage) budget.
+    expect(seamlessPano360Recipe.budgetFor(params('x'))).toEqual({
+      maxBuzz: 90,
+      stepTimeoutSeconds: 90,
+    });
+  });
+
+  it('budgetForEngine matches budgetFor and drives the module-load per-engine invariant', () => {
+    expect(seamlessPano360Recipe.budgetForEngine('qwen-image')).toEqual({
+      maxBuzz: 180,
+      stepTimeoutSeconds: 180,
+    });
+    // An unknown engine falls back to the default engine's budget (defensive; the
+    // .strict() schema already rejects unknown engines before this is reached).
+    expect(seamlessPano360Recipe.budgetForEngine('not-an-engine')).toEqual(
+      BUDGET_BY_ENGINE['zimage-turbo']
+    );
   });
 
   it('is pinned (no user checkpoint) and pins the three 360Redmond LoRA versions', () => {

--- a/src/server/services/blocks/recipes/__tests__/seamless-pano.recipe.test.ts
+++ b/src/server/services/blocks/recipes/__tests__/seamless-pano.recipe.test.ts
@@ -345,14 +345,14 @@ describe('seamlessPano360Recipe contract', () => {
     }
   });
 
-  it('resolves the per-engine budget from params (zimage 90 / flux2 120 / qwen 180), default → zimage 90', () => {
+  it('resolves the per-engine budget from params (zimage 90 / flux2 150 / qwen 180), default → zimage 90', () => {
     expect(seamlessPano360Recipe.budgetFor(params('x', undefined, 'zimage-turbo'))).toEqual({
       maxBuzz: 90,
       stepTimeoutSeconds: 90,
     });
     expect(seamlessPano360Recipe.budgetFor(params('x', undefined, 'flux2-klein'))).toEqual({
-      maxBuzz: 120,
-      stepTimeoutSeconds: 120,
+      maxBuzz: 150,
+      stepTimeoutSeconds: 150,
     });
     expect(seamlessPano360Recipe.budgetFor(params('x', undefined, 'qwen-image'))).toEqual({
       maxBuzz: 180,

--- a/src/server/services/blocks/recipes/index.ts
+++ b/src/server/services/blocks/recipes/index.ts
@@ -116,10 +116,23 @@ export interface BlockRecipe<P = unknown> {
   };
   /** v1: 'pinned' (no user checkpoint). Follow-up: 'userPickedSdxl'. */
   checkpointPolicy: 'pinned' | 'userPickedSdxl';
-  /** Hard per-job Buzz ceiling — MUST equal ceil(stepTimeoutSeconds × 1). */
-  maxBuzz: number;
-  /** The aggressive step timeout (seconds) that ENFORCES `maxBuzz` (plan §5). */
-  stepTimeoutSeconds: number;
+  /**
+   * Per-ENGINE post-paid budget for the given params (v1.1). `maxBuzz` is the hard
+   * per-job Buzz ceiling and MUST equal `ceil(stepTimeoutSeconds × 1)` — the
+   * aggressive step `timeout` is the PHYSICAL cap (~1 Buzz/GPU-second), so a lower
+   * `maxBuzz` REQUIRES a proportionally lower `stepTimeoutSeconds` (a lower
+   * reservation under the same timeout would let the job outspend the reservation
+   * and under-count real spend, defeating the cap). The router reserves this
+   * `maxBuzz` against every cap and settles-to-actual (plan §5).
+   */
+  budgetFor(params: P): { maxBuzz: number; stepTimeoutSeconds: number };
+  /**
+   * The same per-engine budget keyed directly by engine id — used by the
+   * module-load invariant loop (which enumerates `engines`, not full params) and
+   * anywhere only the engine is in hand. Same `maxBuzz === ceil(stepTimeoutSeconds)`
+   * contract per engine.
+   */
+  budgetForEngine(engine: string): { maxBuzz: number; stepTimeoutSeconds: number };
   /** Display-only estimate for estimateWorkflow (post-paid has no exact price). */
   estimateBuzz(params: P): number;
   /** Recipe-level negative prompt (the prompt-audit re-point reads this in PR6). */
@@ -165,17 +178,22 @@ export function recipeCivitaiVersionIds(recipe: AnyBlockRecipe): number[] {
   return [...checkpoints, ...loras].map((r) => r.modelVersionId);
 }
 
-// Fail-fast the `maxBuzz == ceil(stepTimeoutSeconds)` invariant at module load —
-// the safety argument (plan §5.4) depends on the step timeout physically capping
-// the job at `maxBuzz`, so a recipe that declares a looser `maxBuzz` than its
-// timeout enforces (or a tighter one it can't guarantee) is a build-time error,
-// not a runtime surprise.
+// Fail-fast the per-engine `maxBuzz == ceil(stepTimeoutSeconds)` invariant at
+// module load — the safety argument (plan §5.4) depends on the step timeout
+// physically capping the job at `maxBuzz`, so a recipe that declares (for ANY
+// engine) a looser `maxBuzz` than its timeout enforces (or a tighter one it can't
+// guarantee) is a build-time error, not a runtime surprise. v1.1: the budget is
+// per-engine, so assert it for EACH of the recipe's engines.
 for (const [id, recipe] of Object.entries(recipeRegistry)) {
-  const enforced = Math.ceil(recipe.stepTimeoutSeconds);
-  if (recipe.maxBuzz !== enforced) {
-    throw new Error(
-      `recipe '${id}': maxBuzz (${recipe.maxBuzz}) must equal ceil(stepTimeoutSeconds) (${enforced}) — ` +
-        'the step timeout is the physical Buzz ceiling (plan §5).'
-    );
+  for (const engine of recipe.engines) {
+    const budget = recipe.budgetForEngine(engine);
+    const enforced = Math.ceil(budget.stepTimeoutSeconds);
+    if (budget.maxBuzz !== enforced) {
+      throw new Error(
+        `recipe '${id}' engine '${engine}': maxBuzz (${budget.maxBuzz}) must equal ` +
+          `ceil(stepTimeoutSeconds) (${enforced}) — the step timeout is the physical ` +
+          'Buzz ceiling (plan §5).'
+      );
+    }
   }
 }

--- a/src/server/services/blocks/recipes/seamless-pano.recipe.ts
+++ b/src/server/services/blocks/recipes/seamless-pano.recipe.ts
@@ -129,6 +129,31 @@ export const ESTIMATE_BUZZ_BY_ENGINE: Record<SeamlessPanoEngine, number> = {
   'qwen-image': 150,
 };
 
+// ── Per-engine POST-PAID BUDGET (v1.1) ───────────────────────────────────────
+// The hard per-job Buzz ceiling, sized PER ENGINE. `maxBuzz` MUST equal
+// `ceil(stepTimeoutSeconds × 1)` for EACH entry (asserted at registry load) —
+// the step `timeout` is the PHYSICAL cap (~1 Buzz/GPU-second), so a lower
+// reservation without a matching lower timeout would let the job run past what
+// was reserved and under-count spend. The router reserves `maxBuzz` against every
+// cap and settles-to-actual, so a cheaper engine reserves (and settles) less cap.
+//
+// The three timeout numbers are the ONE reviewer judgment call here (a `timeout`
+// is a HARD kill on a slow gen, so headroom over typical runtime matters):
+//   • qwen-image  180s — UNCHANGED from the single-ceiling v1 (zero regression on
+//                        the priciest engine; ~150 Buzz display estimate).
+//   • zimage-turbo 90s — ≈ 4× the 21-Buzz dogfood-measured actual.
+//   • flux2-klein 120s — ≈ 2.7× its 45-Buzz display estimate.
+// All tunable in this one obvious table. The MAX entry (180) still holds the
+// app-manifest invariant `page.buzzBudgetPerGen (200) ≥ recipe ceiling`.
+export const BUDGET_BY_ENGINE: Record<
+  SeamlessPanoEngine,
+  { stepTimeoutSeconds: number; maxBuzz: number }
+> = {
+  'zimage-turbo': { stepTimeoutSeconds: 90, maxBuzz: 90 },
+  'flux2-klein': { stepTimeoutSeconds: 120, maxBuzz: 120 },
+  'qwen-image': { stepTimeoutSeconds: 180, maxBuzz: 180 },
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Param schema — .strict(), no checkpoint (v1 pinned policy).
 // Mirrors the reference PanoBody minus the user-picked SDXL checkpoint.
@@ -546,12 +571,15 @@ export const seamlessPano360Recipe: BlockRecipe<SeamlessPanoParams> = {
     ],
   },
   checkpointPolicy: 'pinned',
-  // THE post-paid budget contract (plan §5): `maxBuzz` MUST equal
-  // ceil(stepTimeoutSeconds × 1). A DiT panorama renders in well under a minute;
-  // 180s is a deliberately tight blast-radius ceiling (vs the reference's loose
-  // 3600s). The step `timeout` physically caps the job at `maxBuzz` Buzz.
-  stepTimeoutSeconds: 180,
-  maxBuzz: 180,
+  // THE post-paid budget contract (plan §5), now PER ENGINE (v1.1): `maxBuzz` MUST
+  // equal ceil(stepTimeoutSeconds × 1) for the resolved engine. A DiT panorama
+  // renders in well under a minute; each timeout is a deliberately tight
+  // blast-radius ceiling (vs the reference's loose 3600s). The step `timeout`
+  // physically caps the job at `maxBuzz` Buzz. See BUDGET_BY_ENGINE above.
+  budgetForEngine: (engine) =>
+    BUDGET_BY_ENGINE[engine as SeamlessPanoEngine] ?? BUDGET_BY_ENGINE[DEFAULT_ENGINE],
+  budgetFor: (params) =>
+    BUDGET_BY_ENGINE[params.engine ?? DEFAULT_ENGINE] ?? BUDGET_BY_ENGINE[DEFAULT_ENGINE],
   estimateBuzz: (params) => ESTIMATE_BUZZ_BY_ENGINE[params.engine ?? DEFAULT_ENGINE],
   negativePrompt: NEGATIVE_PROMPT,
 };

--- a/src/server/services/blocks/recipes/seamless-pano.recipe.ts
+++ b/src/server/services/blocks/recipes/seamless-pano.recipe.ts
@@ -142,7 +142,11 @@ export const ESTIMATE_BUZZ_BY_ENGINE: Record<SeamlessPanoEngine, number> = {
 //   • qwen-image  180s — UNCHANGED from the single-ceiling v1 (zero regression on
 //                        the priciest engine; ~150 Buzz display estimate).
 //   • zimage-turbo 90s — ≈ 4× the 21-Buzz dogfood-measured actual.
-//   • flux2-klein 120s — ≈ 2.7× its 45-Buzz display estimate.
+//   • flux2-klein 150s — ≈ 3.3× its 45-Buzz DISPLAY ESTIMATE. flux2's runtime is
+//                        characterized only by that estimate (no dogfood-measured
+//                        actual like zimage's 21), so 150 gives more margin against
+//                        a hard-kill of a legit gen than 120 did, while still
+//                        cutting over-reservation from the flat 180.
 // All tunable in this one obvious table. The MAX entry (180) still holds the
 // app-manifest invariant `page.buzzBudgetPerGen (200) ≥ recipe ceiling`.
 export const BUDGET_BY_ENGINE: Record<
@@ -150,7 +154,7 @@ export const BUDGET_BY_ENGINE: Record<
   { stepTimeoutSeconds: number; maxBuzz: number }
 > = {
   'zimage-turbo': { stepTimeoutSeconds: 90, maxBuzz: 90 },
-  'flux2-klein': { stepTimeoutSeconds: 120, maxBuzz: 120 },
+  'flux2-klein': { stepTimeoutSeconds: 150, maxBuzz: 150 },
   'qwen-image': { stepTimeoutSeconds: 180, maxBuzz: 180 },
 };
 

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -673,11 +673,14 @@ function formatStepTimeout(totalSeconds: number): string {
 
 /**
  * Wrap a recipe's customComfy step input into the `$type:'customComfy'` step,
- * STAMPING the recipe's aggressive `stepTimeoutSeconds` as the step `timeout`
+ * STAMPING the resolved per-engine `stepTimeoutSeconds` as the step `timeout`
  * (formatted `HH:MM:SS`). That timeout is the ONLY deterministic per-job Buzz
  * bound the orchestrator offers: at `job.ExpireAt` the job is canceled and
  * billed for measured runtime, so worst-case Buzz = `ceil(timeout_s × 1)` =
- * `recipe.maxBuzz` (plan §5). This is what makes the post-paid path bounded.
+ * the engine's `maxBuzz` (plan §5). This is what makes the post-paid path
+ * bounded. v1.1: the timeout is PER ENGINE, so the caller resolves it from the
+ * params (`recipe.budgetFor(params).stepTimeoutSeconds`) and threads it in — the
+ * `maxBuzz` reserved against the caps and this timeout MUST move together.
  *
  * Sibling of `createBlockTextToImageStep` (blocks.router.ts) — but a customComfy
  * step is built by DIRECT object construction (the recipe's graph), NOT through
@@ -685,13 +688,13 @@ function formatStepTimeout(totalSeconds: number): string {
  * `createWorkflowStepsFromGraphInput` machinery.
  */
 export function createBlockCustomComfyStep(
-  recipe: AnyBlockRecipe,
-  input: CustomComfyStepInput
+  input: CustomComfyStepInput,
+  stepTimeoutSeconds: number
 ): CustomComfyStepTemplate {
   return {
     $type: 'customComfy',
     name: BLOCK_CUSTOM_COMFY_STEP_NAME,
-    timeout: formatStepTimeout(recipe.stepTimeoutSeconds),
+    timeout: formatStepTimeout(stepTimeoutSeconds),
     input,
   };
 }


### PR DESCRIPTION
## Per-engine budget ceilings for the `seamless-pano-360` customComfy recipe (v1.1)

### The problem
The App Blocks `customComfy` bridge uses a POST-PAID budget model: a recipe declares a single `maxBuzz` ceiling that MUST equal `ceil(stepTimeoutSeconds)` — the orchestrator step `timeout` physically caps spend at ~1 Buzz/GPU-second, so the timeout *is* the ceiling. At submit the router reserves the CEILING against every cap (per-user daily, per-app aggregate, dev-session) and settles-to-actual at terminal.

`seamless-pano-360` declared ONE ceiling (`stepTimeoutSeconds:180 / maxBuzz:180`), sized for the priciest engine (qwen, ~150 display estimate). A cheap Z-Image gen (dogfood-measured actual ≈ 21 Buzz) still reserved **180** against all three caps and then settled back — correct, but it needlessly consumes cap headroom that gates *other* generations (the per-user 50k/day cap, the per-app cap, the dev-session cap all hold the ceiling until settle).

### The change
Make the ceiling **per engine**.

Because the step `timeout` is the PHYSICAL cap, a lower `maxBuzz` **requires** a proportionally lower `stepTimeoutSeconds` — a lower reservation under the same 180s timeout would let the job run to 180 Buzz while only reserving less, under-counting real spend and defeating the cap. So the two always move together, from a single table:

```ts
export const BUDGET_BY_ENGINE = {
  'zimage-turbo': { stepTimeoutSeconds: 90,  maxBuzz: 90  },
  'flux2-klein':  { stepTimeoutSeconds: 150, maxBuzz: 150 },
  'qwen-image':   { stepTimeoutSeconds: 180, maxBuzz: 180 },
};
```

- `BlockRecipe` interface: the two scalars (`maxBuzz` / `stepTimeoutSeconds`) are replaced by `budgetFor(params)` and `budgetForEngine(engine)`, each returning `{ maxBuzz, stepTimeoutSeconds }`.
- The module-load invariant now asserts `maxBuzz === ceil(stepTimeoutSeconds)` for **each** of a recipe's engines (was a single scalar check).
- The router resolves `const { maxBuzz: ceiling, stepTimeoutSeconds } = recipe.budgetFor(params)` and threads the per-engine timeout into `createBlockCustomComfyStep(input, stepTimeoutSeconds)` (which dropped its now-unused `recipe` param). Everything downstream already keyed off `ceiling`.
- `estimateBuzz` (already per-engine, display-only) is unchanged.

### Concrete behavior change
Each engine now reserves and settles less cap the cheaper it is. The new observable behavior: at a budget of 100, a **zimage** gen (ceiling 90) now RUNS, while **qwen** (ceiling 180) is still rejected at the static gate (`recipe ceiling 180 exceeds budget 100`) — under the old single-180 ceiling that budget gated out *every* engine.

### 🔴 The one reviewer judgment call
The three timeout numbers. A `timeout` is a HARD kill on a slow generation, so headroom over typical runtime matters:
- **qwen-image 180s — UNCHANGED** → zero regression on the priciest engine.
- **zimage-turbo 90s** ≈ 4× the 21-Buzz dogfood-measured actual.
- **flux2-klein 150s** ≈ 3.3× its 45-Buzz DISPLAY ESTIMATE. flux2's runtime is characterized only by that estimate — there is **no** dogfood-measured actual like zimage's 21 — so 150 buys more margin against a hard-kill of a legit gen than 120 did, while still cutting over-reservation from the flat 180. (This is the audit's 🟡 follow-up; bumped 120 → 150.)

All tunable in the one obvious `BUDGET_BY_ENGINE` table. The MAX entry (180) still satisfies the app-manifest invariant `page.buzzBudgetPerGen (200) ≥ recipe ceiling`, so **no app-side change** is needed.

### Scope / safety
`customComfy` is DARK — behind the mod-gated App Blocks flag — so this rides the next release cut with no user-visible surface until the flag opens.

### Tests / verification
- `npx tsc --noEmit` (8 GiB heap): clean, 0 errors.
- Affected unit suites all green: recipe (30), workflow.service (98), custom-comfy-settle (17), blocks.router.workflow (220).
- Coverage: per-engine `budgetFor`/`budgetForEngine` resolution + default-engine fallback; per-engine module-load invariant; `createBlockCustomComfyStep` timeout formatting per engine (00:01:30 / 00:02:30 / 00:03:00); router submits proving per-engine reserve amounts + stamped step timeout differ (zimage 90/00:01:30 vs flux2 150/00:02:30 vs qwen 180/00:03:00); and the budget-100 zimage-runs / qwen-rejected behavior.

### Follow-up commit (audit findings addressed)
- **🟡 flux2 ceiling 120 → 150** — see the judgment-call note above.
- **🟢 per-engine reserve↔refund symmetry** — the earlier refund/rollback tests only proved the default engine's 90 refunds. Added coverage that a NON-default engine refunds ITS OWN ceiling: a qwen daily-cap breach refunds **180** (not 90), a flux2 app-cap breach refunds **150**, and a qwen refund-on-throw refunds **180** on BOTH caps.
- **🟢 graph-engine ↔ stamped-timeout end-to-end** — added an assertion that within ONE submit the engine driving the BUILT customComfy graph is the same engine driving the STAMPED timeout: a qwen submit stamps `00:03:00` AND its emitted step input is qwen's graph (`GGUFLoaderKJ` loader + qwen resource AIRs, not zimage's). Closes the "safe by construction but unasserted" gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
