### PR TITLE
feat(app-blocks): per-engine customComfy runtime/cost metric

### DIFF
--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -147,7 +147,20 @@ type Bundle = {
   requestsTotal: Counter<string>;
   requestDurationSeconds: Histogram<string>;
   rendersTotal: Counter<string>;
+  customComfyActualBuzz: Histogram<string>;
+  customComfyWallclockSeconds: Histogram<string>;
 };
+
+// ── customComfy per-engine runtime/cost buckets ──────────────────────────────
+// Sized for the 0–200 range that straddles the per-engine Buzz ceilings
+// (zimage 90 / flux2 150 / qwen 180) so the ceiling boundaries fall ON bucket
+// edges — a pre-GA `histogram_quantile` p95/p99 then reads directly against the
+// ceiling a gen is fighting.
+const CUSTOMCOMFY_BUZZ_BUCKETS = [10, 20, 30, 45, 60, 90, 120, 150, 180, 200];
+// Wall-clock (submit→terminal-observation) seconds — same ceiling landmarks plus
+// a couple of longer tails to catch a gen that queue-waits toward / past its
+// timeout (the clip-risk the metric exists to surface).
+const CUSTOMCOMFY_WALLCLOCK_BUCKETS = [5, 10, 20, 30, 45, 60, 90, 120, 150, 180, 200, 240];
 
 /**
  * Idempotent: safe to call on every request. Returns the metric instances
@@ -184,5 +197,81 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     ['app_block_id', 'slot_id', 'result', 'error_class']
   );
 
-  return { requestsTotal, requestDurationSeconds, rendersTotal };
+  // ── customComfy per-engine runtime/cost (App Blocks `customComfy` bridge) ────
+  // Instrument-ahead-of-demand for the pre-GA question "is flux2-klein's real p99
+  // approaching its 150-Buzz / 150s ceiling?". EMPTY until real customComfy volume
+  // accrues (DARK app code, mod-gated), by design.
+  //
+  // Cardinality: engine ∈ {zimage-turbo, flux2-klein, qwen-image} (3) × recipe ∈
+  // {seamless-pano-360} (1) → 4 series/histogram today; both labels are strict
+  // enums resolved server-side from the code-owned recipe registry (never client
+  // input), so they can't blow up regardless of the wire.
+  const customComfyActualBuzz = getOrCreateHistogram(
+    reg,
+    'civitai_app_block_customcomfy_actual_buzz',
+    // GPU-RUNTIME / billed Buzz (≈1 Buzz/GPU-second) — the settled `actual` cost, NOT
+    // wall-clock. Answers "how close to the per-engine ceiling is real spend".
+    'App Block customComfy settled GPU-runtime cost in billed Buzz (≈1 Buzz/GPU-second — NOT wall-clock) by engine and recipe',
+    ['engine', 'recipe'],
+    CUSTOMCOMFY_BUZZ_BUCKETS
+  );
+
+  const customComfyWallclockSeconds = getOrCreateHistogram(
+    reg,
+    'civitai_app_block_customcomfy_wallclock_seconds',
+    // WALL-CLOCK incl. GPU queue-wait: submit→terminal-observation seconds. The truer
+    // signal for the step-timeout clip risk (a fast gen hard-killed at the 150s
+    // wall-clock ceiling while its GPU runtime is well under). Bounded by the ~2s
+    // terminal-poll cadence + excludes the submit round-trip (see settle service).
+    'App Block customComfy wall-clock seconds from submit to terminal observation (incl. GPU queue-wait) by engine and recipe',
+    ['engine', 'recipe'],
+    CUSTOMCOMFY_WALLCLOCK_BUCKETS
+  );
+
+  return {
+    requestsTotal,
+    requestDurationSeconds,
+    rendersTotal,
+    customComfyActualBuzz,
+    customComfyWallclockSeconds,
+  };
+}
+
+/**
+ * Fail-soft emit of the settled GPU-runtime cost (billed `actual` Buzz) for one
+ * customComfy gen. Called from the settle service at terminal. A metrics error
+ * (registry/label) must NEVER perturb settle/refund correctness, so the whole
+ * emit is swallowed. Skips a non-positive/`NaN` actual (failed/no-op/0 gen).
+ */
+export function observeCustomComfyActualBuzz(
+  engine: string,
+  recipe: string,
+  actualBuzz: number
+): void {
+  try {
+    if (!Number.isFinite(actualBuzz) || actualBuzz <= 0) return;
+    const { customComfyActualBuzz } = ensureRegisterAppBlockRuntimeMetrics();
+    customComfyActualBuzz.observe({ engine, recipe }, actualBuzz);
+  } catch {
+    /* instrument-only — never let a metrics error touch the settle path */
+  }
+}
+
+/**
+ * Fail-soft emit of the submit→terminal-observation wall-clock (seconds, incl.
+ * GPU queue-wait) for one customComfy gen. Same never-throw contract as above.
+ * Skips a non-positive/`NaN` value.
+ */
+export function observeCustomComfyWallclockSeconds(
+  engine: string,
+  recipe: string,
+  seconds: number
+): void {
+  try {
+    if (!Number.isFinite(seconds) || seconds <= 0) return;
+    const { customComfyWallclockSeconds } = ensureRegisterAppBlockRuntimeMetrics();
+    customComfyWallclockSeconds.observe({ engine, recipe }, seconds);
+  } catch {
+    /* instrument-only — never let a metrics error touch the settle path */
+  }
 }

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -4612,12 +4612,16 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 90);
       // The submitted step's timeout matches the reserved ceiling (90s → 00:01:30).
       expect(mockSubmitWorkflow.mock.calls[0][0].body.steps[0].timeout).toBe('00:01:30');
-      // settle record persisted with BOTH reservation keys + the ceiling.
+      // settle record persisted with BOTH reservation keys + the ceiling, plus the
+      // per-engine observability fields (engine/recipe/submittedAt — never affect spend).
       expect(mockPersistCustomComfySettle).toHaveBeenCalledWith({
         workflowId: 'wf_cc_1',
         buzzCapKey: expect.stringMatching(/^system:blocks:buzz-cap:42:/),
         appSpendKey: 'system:blocks:app-spend-cap:apb_test:day',
         ceiling: 90,
+        engine: 'zimage-turbo', // ccBody default engine (== recipe default)
+        recipe: 'seamless-pano-360',
+        submittedAt: expect.any(Number),
       });
     });
 
@@ -5016,6 +5020,9 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
         appSpendKey: null,
         devSessionId: 'bki_dev',
         ceiling: 90,
+        engine: 'zimage-turbo',
+        recipe: 'seamless-pano-360',
+        submittedAt: expect.any(Number),
       });
     });
 
@@ -5035,6 +5042,9 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
         appSpendKey: 'system:blocks:app-spend-cap:apb_test:day',
         devSessionId: 'bki_dev',
         ceiling: 90,
+        engine: 'zimage-turbo',
+        recipe: 'seamless-pano-360',
+        submittedAt: expect.any(Number),
       });
     });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5342,6 +5342,16 @@ async function submitCustomComfyWorkflow(opts: {
   // and the timeout stamped on the step MUST come from the same budget.
   const { maxBuzz: ceiling, stepTimeoutSeconds } = recipe.budgetFor(params);
 
+  // Resolve the engine + recipe id purely for per-engine settle-time
+  // OBSERVABILITY (persisted in the settle record, read at terminal to emit
+  // `civitai_app_block_customcomfy_actual_buzz` / `_wallclock_seconds`). Mirrors
+  // the recipe's own `params.engine ?? default` resolution — `recipe.engines[0]`
+  // is the declared default (== DEFAULT_ENGINE for seamless-pano). Both labels are
+  // strict enums (engine ∈ 3, recipe ∈ 1) → cardinality-safe. Never affects spend.
+  const engine: string =
+    (params as { engine?: string }).engine ?? recipe.engines[0] ?? 'unknown';
+  const recipeId: string = recipe.id;
+
   // (1) STATIC pre-submit gate — the post-paid analog of the txt2img whatIf
   // `cost > buzzBudget` gate. Because the timeout caps the job at `maxBuzz` and we
   // require `maxBuzz <= buzzBudget`, the per-call budget CANNOT be exceeded.
@@ -5467,6 +5477,10 @@ async function submitCustomComfyWorkflow(opts: {
   // `submitted` is a try-block `const` and is out of scope there. Mirrors the
   // txt2img path (~:3646).
   let realizedTransactions: Awaited<ReturnType<typeof submitWorkflow>>['transactions'];
+  // Captured just before the orchestrator submit → the server-side proxy for the
+  // job's submit instant, so the settle-time wall-clock metric measures
+  // submit→terminal-observation (incl. GPU queue-wait). Observability-only.
+  const submittedAt = Date.now();
   try {
     const stepInput = buildCustomComfyWorkflowInput(recipe, body.params, {});
     // Stamp the SAME per-engine timeout the ceiling above was reserved against —
@@ -5522,6 +5536,10 @@ async function submitCustomComfyWorkflow(opts: {
       appSpendKey: appSpendReserve?.key ?? null,
       ...(devSessionReserve ? { devSessionId: devSessionReserve.sessionId } : {}),
       ceiling,
+      // Observability-only (per-engine runtime/cost at settle) — never affects the refund.
+      engine,
+      recipe: recipeId,
+      submittedAt,
     });
     // G6 — persistent output queue (best-effort, non-dev). Same posture as
     // txt2img so a customComfy gen rebuilds in listMyWorkflows on reload.

--- a/src/server/services/blocks/__tests__/custom-comfy-settle.service.test.ts
+++ b/src/server/services/blocks/__tests__/custom-comfy-settle.service.test.ts
@@ -11,7 +11,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * assert the exact GET+DEL idempotency claim and the exact decrBy deltas.
  */
 
-const { mockSysRedis, mockRefundAppSpend, mockRefundDevSessionBuzz } = vi.hoisted(() => ({
+const {
+  mockSysRedis,
+  mockRefundAppSpend,
+  mockRefundDevSessionBuzz,
+  mockObserveActualBuzz,
+  mockObserveWallclock,
+} = vi.hoisted(() => ({
   mockSysRedis: {
     get: vi.fn(async () => null as string | null),
     set: vi.fn(async () => undefined),
@@ -23,6 +29,11 @@ const { mockSysRedis, mockRefundAppSpend, mockRefundDevSessionBuzz } = vi.hoiste
   // (heavy, k8s-client-pulling) dev-tunnel module at its boundary so the settle's
   // third refund is assertable without loading the real service.
   mockRefundDevSessionBuzz: vi.fn(async () => undefined),
+  // Per-engine observability emit — mocked at the metrics-module boundary so the
+  // settle's engine/recipe label + observed value are assertable without the real
+  // prom-client registry.
+  mockObserveActualBuzz: vi.fn(() => undefined),
+  mockObserveWallclock: vi.fn(() => undefined),
 }));
 
 vi.mock('~/server/redis/client', () => ({
@@ -34,6 +45,10 @@ vi.mock('~/server/services/blocks/app-spend-cap.service', () => ({
 }));
 vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
   refundDevSessionBuzz: (...a: unknown[]) => mockRefundDevSessionBuzz(...(a as [])),
+}));
+vi.mock('~/server/metrics/app-block-runtime.metrics', () => ({
+  observeCustomComfyActualBuzz: (...a: unknown[]) => mockObserveActualBuzz(...(a as [])),
+  observeCustomComfyWallclockSeconds: (...a: unknown[]) => mockObserveWallclock(...(a as [])),
 }));
 
 import {
@@ -53,6 +68,8 @@ beforeEach(() => {
     mockSysRedis.decrBy,
     mockRefundAppSpend,
     mockRefundDevSessionBuzz,
+    mockObserveActualBuzz,
+    mockObserveWallclock,
   ]) {
     fn.mockReset();
   }
@@ -73,6 +90,9 @@ function seedRecord(
     appSpendKey: string | null;
     devSessionId: string | null;
     ceiling: number;
+    engine: string;
+    recipe: string;
+    submittedAt: number;
   }> = {}
 ) {
   const record = { buzzCapKey: BUZZ_KEY, appSpendKey: APP_KEY, ceiling: 180, ...over };
@@ -91,8 +111,35 @@ describe('persistCustomComfySettle', () => {
     expect(mockSysRedis.set).toHaveBeenCalledTimes(1);
     const [key, value, opts] = mockSysRedis.set.mock.calls[0] as [string, string, { EX: number }];
     expect(key).toBe(`${SETTLE_PREFIX}:wf_1`);
-    expect(JSON.parse(value)).toEqual({ buzzCapKey: BUZZ_KEY, appSpendKey: APP_KEY, ceiling: 180 });
+    // submittedAt defaults to now() when the caller omits it (observability-only).
+    expect(JSON.parse(value)).toEqual({
+      buzzCapKey: BUZZ_KEY,
+      appSpendKey: APP_KEY,
+      ceiling: 180,
+      submittedAt: expect.any(Number),
+    });
     expect(opts.EX).toBe(25 * 60 * 60);
+  });
+
+  it('carries the engine + recipe + submittedAt when provided (per-engine observability)', async () => {
+    await persistCustomComfySettle({
+      workflowId: 'wf_1',
+      buzzCapKey: BUZZ_KEY,
+      appSpendKey: APP_KEY,
+      ceiling: 150,
+      engine: 'flux2-klein',
+      recipe: 'seamless-pano-360',
+      submittedAt: 1_700_000_000_000,
+    });
+    const [, value] = mockSysRedis.set.mock.calls[0] as [string, string, { EX: number }];
+    expect(JSON.parse(value)).toEqual({
+      buzzCapKey: BUZZ_KEY,
+      appSpendKey: APP_KEY,
+      ceiling: 150,
+      engine: 'flux2-klein',
+      recipe: 'seamless-pano-360',
+      submittedAt: 1_700_000_000_000,
+    });
   });
 
   it('F4: persists the dev-session id when a dev tunnel reserved the ceiling', async () => {
@@ -109,6 +156,7 @@ describe('persistCustomComfySettle', () => {
       appSpendKey: null,
       devSessionId: DEV_SESSION_ID,
       ceiling: 180,
+      submittedAt: expect.any(Number),
     });
   });
 
@@ -123,7 +171,12 @@ describe('persistCustomComfySettle', () => {
     const [, value] = mockSysRedis.set.mock.calls[0] as [string, string, { EX: number }];
     const parsed = JSON.parse(value);
     expect(parsed).not.toHaveProperty('devSessionId');
-    expect(parsed).toEqual({ buzzCapKey: BUZZ_KEY, appSpendKey: APP_KEY, ceiling: 180 });
+    expect(parsed).toEqual({
+      buzzCapKey: BUZZ_KEY,
+      appSpendKey: APP_KEY,
+      ceiling: 180,
+      submittedAt: expect.any(Number),
+    });
   });
 
   it('no-ops on an empty workflowId (never writes)', async () => {
@@ -236,5 +289,57 @@ describe('settleCustomComfySpend', () => {
     mockSysRedis.get.mockRejectedValue(new Error('redis down'));
     await expect(settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 })).resolves.toBeUndefined();
     expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
+  });
+
+  // ── Per-engine runtime/cost OBSERVABILITY (instrument-ahead-of-demand) ────────
+  describe('per-engine metric emit', () => {
+    it('observes the settled GPU-runtime (actual Buzz) + wall-clock with engine/recipe labels', async () => {
+      seedRecord({
+        ceiling: 150,
+        engine: 'flux2-klein',
+        recipe: 'seamless-pano-360',
+        submittedAt: 1_700_000_000_000,
+      });
+      await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 42 });
+      // GPU-runtime ≈ billed actual Buzz — the ceil'd `actual` (42), labeled by engine.
+      expect(mockObserveActualBuzz).toHaveBeenCalledWith('flux2-klein', 'seamless-pano-360', 42);
+      // Wall-clock incl. queue (submit→terminal observation) — a Number of seconds.
+      expect(mockObserveWallclock).toHaveBeenCalledWith(
+        'flux2-klein',
+        'seamless-pano-360',
+        expect.any(Number)
+      );
+    });
+
+    it('still observes actual Buzz when the job spent the FULL ceiling (emit precedes the refund early-return)', async () => {
+      seedRecord({ ceiling: 150, engine: 'flux2-klein', recipe: 'seamless-pano-360' });
+      await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 200 });
+      // refund is 0 (actual 200 >= ceiling 150) — but the ceiling-pressing case is
+      // exactly what we most want to see, so the emit must fire regardless.
+      expect(mockObserveActualBuzz).toHaveBeenCalledWith('flux2-klein', 'seamless-pano-360', 200);
+      expect(mockSysRedis.decrBy).not.toHaveBeenCalled(); // still no refund
+    });
+
+    it('emits actual Buzz but NOT wall-clock when the record has no submittedAt', async () => {
+      seedRecord({ ceiling: 90, engine: 'zimage-turbo', recipe: 'seamless-pano-360' });
+      await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 20 });
+      expect(mockObserveActualBuzz).toHaveBeenCalledWith('zimage-turbo', 'seamless-pano-360', 20);
+      expect(mockObserveWallclock).not.toHaveBeenCalled();
+    });
+
+    it('emits NEITHER metric for a legacy record with no engine (back-compat safe)', async () => {
+      seedRecord({ ceiling: 180 }); // pre-deploy record shape — no engine
+      await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 });
+      expect(mockObserveActualBuzz).not.toHaveBeenCalled();
+      expect(mockObserveWallclock).not.toHaveBeenCalled();
+      // …but the refund still happens (observability is orthogonal to settle).
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
+    });
+
+    it('a `recipe`-less record falls back to the "unknown" recipe label', async () => {
+      seedRecord({ ceiling: 90, engine: 'zimage-turbo' }); // engine but no recipe
+      await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 20 });
+      expect(mockObserveActualBuzz).toHaveBeenCalledWith('zimage-turbo', 'unknown', 20);
+    });
   });
 });

--- a/src/server/services/blocks/custom-comfy-settle.service.ts
+++ b/src/server/services/blocks/custom-comfy-settle.service.ts
@@ -1,3 +1,7 @@
+import {
+  observeCustomComfyActualBuzz,
+  observeCustomComfyWallclockSeconds,
+} from '~/server/metrics/app-block-runtime.metrics';
 import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import type { AppSpendDailyKey } from '~/server/services/blocks/app-spend-cap.service';
 
@@ -61,6 +65,23 @@ type SettleRecord = {
   devSessionId?: string | null;
   /** The declared per-job ceiling that was reserved (recipe.maxBuzz). */
   ceiling: number;
+  /**
+   * The resolved per-engine id (`params.engine ?? recipe default`) and the recipe
+   * id, both known at submit. Carried purely for per-engine runtime/cost
+   * OBSERVABILITY at settle (`civitai_app_block_customcomfy_actual_buzz` /
+   * `_wallclock_seconds`) — they never affect the refund math. Optional so a
+   * pre-deploy record (or any future non-engine settle) still settles cleanly;
+   * the metric emit self-skips when `engine` is absent.
+   */
+  engine?: string;
+  recipe?: string;
+  /**
+   * Server wall-clock (ms epoch) captured at submit. Enables the cheap
+   * submit→terminal-observation WALL-CLOCK metric (`_wallclock_seconds`) — the
+   * truer signal for the step-timeout clip risk (incl. GPU queue-wait). Optional
+   * for the same back-compat reason; the wall-clock emit self-skips when absent.
+   */
+  submittedAt?: number;
 };
 
 /**
@@ -78,13 +99,32 @@ export async function persistCustomComfySettle(input: {
   appSpendKey: string | null;
   devSessionId?: string | null;
   ceiling: number;
+  /** Resolved engine + recipe id, for per-engine settle-time observability. */
+  engine?: string;
+  recipe?: string;
+  /** Submit ms-epoch, for the wall-clock metric. Defaults to now if omitted. */
+  submittedAt?: number;
 }): Promise<void> {
-  const { workflowId, buzzCapKey, appSpendKey, devSessionId = null, ceiling } = input;
+  const {
+    workflowId,
+    buzzCapKey,
+    appSpendKey,
+    devSessionId = null,
+    ceiling,
+    engine,
+    recipe,
+    submittedAt = Date.now(),
+  } = input;
   if (!workflowId) return;
   const record: SettleRecord = { buzzCapKey, appSpendKey, ceiling };
   // Include the dev-session id ONLY when present, so a non-dev submit persists the
   // exact record shape it did before F4 (the dev-session refund leg then no-ops).
   if (devSessionId) record.devSessionId = devSessionId;
+  // Observability-only fields (never affect the refund). Present for every real
+  // customComfy submit going forward; absent-safe at settle.
+  if (engine) record.engine = engine;
+  if (recipe) record.recipe = recipe;
+  if (Number.isFinite(submittedAt)) record.submittedAt = submittedAt;
   try {
     await sysRedis.set(settleKey(workflowId), JSON.stringify(record), {
       EX: SETTLE_TTL_SECONDS,
@@ -136,6 +176,30 @@ export async function settleCustomComfySpend(input: {
 
   const ceiling = Math.ceil(record.ceiling ?? 0);
   const actual = Math.ceil(Number.isFinite(actualCost) ? Math.max(0, actualCost) : 0);
+
+  // ── Per-engine runtime/cost OBSERVABILITY (instrument-ahead-of-demand) ───────
+  // Emitted BEFORE the refund early-return below so a job that spent the FULL
+  // ceiling (actual >= ceiling → refund 0 → the ceiling-pressing case we most
+  // want to see) is still observed. Fail-soft in the metric helpers — a metrics
+  // error can never perturb the refund math that follows. Only for a record that
+  // carries the engine (every real customComfy submit going forward).
+  if (record.engine) {
+    const recipeLabel = record.recipe ?? 'unknown';
+    // GPU-runtime ≈ billed `actual` Buzz. Helper skips a 0/failed/no-op gen.
+    observeCustomComfyActualBuzz(record.engine, recipeLabel, actual);
+    // Wall-clock incl. queue: submit→THIS terminal observation. Emitted
+    // independently of `actual` so a job clipped at its timeout with ~0 accrued
+    // Buzz (the purest clip signal) is still captured. Helper skips a non-positive
+    // value.
+    if (typeof record.submittedAt === 'number') {
+      observeCustomComfyWallclockSeconds(
+        record.engine,
+        recipeLabel,
+        (Date.now() - record.submittedAt) / 1000
+      );
+    }
+  }
+
   const refund = Math.max(0, ceiling - actual);
   if (refund <= 0) return; // nothing to give back (job spent the full ceiling)
 


### PR DESCRIPTION
## Goal

Instrument the App Blocks `customComfy` settle path with **per-engine runtime/cost observability** so the pre-GA question — *is `flux2-klein`'s real p99 approaching its 150-Buzz / 150s ceiling?* — has real data as usage accrues. This is **instrument-ahead-of-demand**: `customComfy` is DARK app code (mod-gated behind the App Blocks flag) with near-zero traffic today, so the metric will be **EMPTY until real volume accrues** — the point is to have it in place, not to read it now.

## The GPU-runtime vs wall-clock distinction (captured BOTH)

The pre-GA risk is that the orchestrator step `timeout` (`job.ExpireAt`) may count GPU **queue-wait**, so a fast gen could be hard-killed at 150s **wall-clock** even though its GPU **runtime** (the billed `actual` Buzz) is well under 150. Two distinct signals — labeled accurately, not conflated:

- **`civitai_app_block_customcomfy_actual_buzz`** `{engine, recipe}` — the settled **GPU-runtime cost in billed `actual` Buzz** (≈1 Buzz/GPU-second). Answers "how close to the ceiling is real spend." Cheap (already computed at settle). Buckets `[10,20,30,45,60,90,120,150,180,200]` straddle the per-engine ceilings (zimage 90 / flux2 150 / qwen 180).
- **`civitai_app_block_customcomfy_wallclock_seconds`** `{engine, recipe}` — **wall-clock incl. GPU queue-wait**, the truer signal for the clip risk. Captured cheaply by persisting a submit timestamp in the settle record and diffing at the terminal observation.

### Residual gap (wall-clock)

The wall-clock is measured **server-side from just-before-submit to the block's terminal-POLL observation**, not the orchestrator's exact terminal transition. So it:
- is bounded above by the block's ~2s terminal-poll cadence (cancel path observes immediately),
- excludes the `submitWorkflow` round-trip (timestamp captured just before it), and
- is subject to sub-second cross-pod clock skew.

For the "does the 150s timeout clip a queued-but-fast gen" question this is close enough (±~2s on a 150s budget) and it captures the **purest** clip case: wall-clock is emitted independently of `actual`, so a gen killed at its timeout with ~0 accrued Buzz still shows ~150s wall-clock. The exact GPU queue-vs-run split lives only in the orchestrator trace and is **not** captured here.

## Implementation

- Thread the resolved `engine` (`params.engine ?? recipe.engines[0]`, the declared default — cardinality-safe enum) + `recipe.id` + a submit `submittedAt` through the `SettleRecord` (written at submit in `submitCustomComfyWorkflow`, read at the first terminal settle).
- Emit both histograms in `settleCustomComfySpend`, **before** the `refund <= 0` early-return, so a full-ceiling-spend gen (the ceiling-pressing case we most want) is still observed.
- **Fail-soft**: the emit helpers swallow all errors — a metrics failure can never perturb settle/refund correctness. The new record fields are optional/absent-safe (a legacy pre-deploy record emits nothing).

## Cardinality

`engine ∈ {zimage-turbo, flux2-klein, qwen-image}` (3) × `recipe ∈ {seamless-pano-360}` (1) → 4 series per histogram today. Both labels are strict enums resolved server-side from the code-owned recipe registry (never client input).

## Behavior change

**None.** DARK app code; the metric is pure observability and the emit is orthogonal to (and fail-soft around) the spend/refund path.

## Tests

Extended `custom-comfy-settle.service.test.ts` (record now carries `engine`/`recipe`/`submittedAt`; settle emits the histograms with the right engine label + observed value, incl. the emit-before-refund-early-return and back-compat legacy-record cases) and updated `blocks.router.workflow.test.ts` persist assertions. **243 passed** (settle 23, router workflow 220); `tsc --noEmit` exit 0. Not verified against live traffic (none yet — see instrument-ahead-of-demand above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
