### PR TITLE
feat(challenges): event banner carousel, dedicated event pages + event-page redesign

### DIFF
--- a/designs/challenges-feed.pen
+++ b/designs/challenges-feed.pen
@@ -8992,6 +8992,2281 @@
           ]
         }
       ]
+    },
+    {
+      "type": "frame",
+      "id": "k6ltm",
+      "x": 5330,
+      "y": 0,
+      "name": "Event Detail — Desktop",
+      "clip": true,
+      "width": 1280,
+      "fill": "$bg-page",
+      "layout": "vertical",
+      "children": [
+        {
+          "id": "GCmuK",
+          "type": "ref",
+          "ref": "k3m5y3",
+          "name": "TopNav",
+          "width": "fill_container"
+        },
+        {
+          "type": "frame",
+          "id": "b8PJaC",
+          "name": "Hero",
+          "clip": true,
+          "width": "fill_container",
+          "height": 340,
+          "fill": [
+            {
+              "type": "gradient",
+              "gradientType": "linear",
+              "enabled": true,
+              "rotation": 120,
+              "size": {
+                "height": 1
+              },
+              "colors": [
+                {
+                  "color": "#0f4a32",
+                  "position": 0
+                },
+                {
+                  "color": "#123f2a",
+                  "position": 0.5
+                },
+                {
+                  "color": "#0a2a1c",
+                  "position": 1
+                }
+              ]
+            },
+            {
+              "type": "gradient",
+              "gradientType": "linear",
+              "enabled": true,
+              "rotation": 180,
+              "size": {
+                "height": 1
+              },
+              "colors": [
+                {
+                  "color": "#00000000",
+                  "position": 0
+                },
+                {
+                  "color": "#00000044",
+                  "position": 0.55
+                },
+                {
+                  "color": "#000000aa",
+                  "position": 1
+                }
+              ]
+            }
+          ],
+          "layout": "vertical",
+          "padding": [
+            24,
+            40
+          ],
+          "justifyContent": "space_between",
+          "children": [
+            {
+              "type": "frame",
+              "id": "n0HFc",
+              "name": "HeroTop",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Q5xvi",
+                  "name": "Back",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "iK3fb",
+                      "name": "BackIcon",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "arrow-left",
+                      "library": "lucide",
+                      "fill": "#a6f0c6"
+                    },
+                    {
+                      "type": "text",
+                      "id": "pMfyg",
+                      "name": "BackText",
+                      "fill": "#a6f0c6",
+                      "content": "All Challenges",
+                      "fontFamily": "$font",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ZeMI7",
+                  "name": "Share",
+                  "fill": "#ffffff1a",
+                  "cornerRadius": "$radius-sm",
+                  "stroke": "#ffffff33",
+                  "strokeWidth": 1,
+                  "gap": 6,
+                  "padding": [
+                    8,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "E6qD4",
+                      "name": "ShareIcon",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "share-2",
+                      "library": "lucide",
+                      "fill": "#ffffff"
+                    },
+                    {
+                      "type": "text",
+                      "id": "d83a72",
+                      "name": "ShareText",
+                      "fill": "#ffffff",
+                      "content": "Share",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Vamxp",
+              "name": "HeroBottom",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "end",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "uJC43",
+                  "name": "Content",
+                  "layout": "vertical",
+                  "gap": 10,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "orW5L",
+                      "name": "StatusRow",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "t6ysvQ",
+                          "name": "StatusPill",
+                          "fill": "#2f9e4433",
+                          "cornerRadius": 100,
+                          "stroke": "#2f9e4466",
+                          "strokeWidth": 1,
+                          "gap": 6,
+                          "padding": [
+                            5,
+                            10
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "Dv3k4",
+                              "name": "Dot",
+                              "fill": "#40c057",
+                              "width": 8,
+                              "height": 8
+                            },
+                            {
+                              "type": "text",
+                              "id": "nVSUs",
+                              "name": "PillText",
+                              "fill": "#69db7c",
+                              "content": "Active Event",
+                              "fontFamily": "$font",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "MiOej",
+                          "name": "EndsIn",
+                          "fill": "#ffffffcc",
+                          "content": "Ends in 9 days",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "YdLoD",
+                      "name": "Title",
+                      "fill": "#ffffff",
+                      "content": "Creator Showcase",
+                      "fontFamily": "$font",
+                      "fontSize": 40,
+                      "fontWeight": "800"
+                    },
+                    {
+                      "type": "text",
+                      "id": "N4RHUQ",
+                      "name": "Dates",
+                      "fill": "#ffffffb3",
+                      "content": "Jul 1 – Aug 3, 2026   ·   Featured event spotlighting standout creators",
+                      "fontFamily": "$font",
+                      "fontSize": 15,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "o16x8",
+                  "name": "Prize",
+                  "layout": "vertical",
+                  "gap": 3,
+                  "alignItems": "end",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "VCDE5",
+                      "name": "PrizeLabel",
+                      "fill": "#ffffff99",
+                      "content": "TOTAL PRIZE POOL",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "700",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XeRO8",
+                      "name": "PrizeVal",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "kspB6",
+                          "name": "Bolt",
+                          "width": 28,
+                          "height": 28,
+                          "icon": "zap",
+                          "library": "lucide",
+                          "fill": "$buzz"
+                        },
+                        {
+                          "type": "text",
+                          "id": "us6tu",
+                          "name": "PrizeNum",
+                          "fill": "$buzz",
+                          "content": "250,000",
+                          "fontFamily": "$font",
+                          "fontSize": 38,
+                          "fontWeight": "800"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "G9Olx",
+                      "name": "PrizeSub",
+                      "fill": "#ffffff99",
+                      "content": "across 6 challenges",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "qvJr8",
+          "name": "StatsStrip",
+          "width": "fill_container",
+          "gap": 16,
+          "padding": [
+            24,
+            40,
+            4,
+            40
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "no7KU",
+              "name": "Challenges",
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius-card",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "gap": 12,
+              "padding": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "t0vqqS",
+                  "name": "Icon",
+                  "width": 40,
+                  "height": 40,
+                  "fill": "#16324f",
+                  "cornerRadius": "$radius-sm",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "d4C3kz",
+                      "name": "I",
+                      "width": 20,
+                      "height": 20,
+                      "icon": "swords",
+                      "library": "lucide",
+                      "fill": "$blue"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ZVfM0",
+                  "name": "Txt",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "pzjK3",
+                      "name": "Val",
+                      "fill": "$text",
+                      "content": "6",
+                      "fontFamily": "$font",
+                      "fontSize": 20,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "d5jRz",
+                      "name": "Lbl",
+                      "fill": "$text-dim",
+                      "content": "Challenges",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "tb4hw",
+              "name": "Submissions",
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius-card",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "gap": 12,
+              "padding": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Q5UNL",
+                  "name": "Icon",
+                  "width": 40,
+                  "height": 40,
+                  "fill": "#2a1c38",
+                  "cornerRadius": "$radius-sm",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "NA1Ej",
+                      "name": "I",
+                      "width": 20,
+                      "height": 20,
+                      "icon": "image",
+                      "library": "lucide",
+                      "fill": "$grape"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "D8ALSA",
+                  "name": "Txt",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "k7oVR",
+                      "name": "Val",
+                      "fill": "$text",
+                      "content": "1,240",
+                      "fontFamily": "$font",
+                      "fontSize": 20,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "yTfQj",
+                      "name": "Lbl",
+                      "fill": "$text-dim",
+                      "content": "Submissions",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ajER3",
+              "name": "Participants",
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius-card",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "gap": 12,
+              "padding": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "T37C2",
+                  "name": "Icon",
+                  "width": 40,
+                  "height": 40,
+                  "fill": "#15321f",
+                  "cornerRadius": "$radius-sm",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "ZlnQ3",
+                      "name": "I",
+                      "width": 20,
+                      "height": 20,
+                      "icon": "users",
+                      "library": "lucide",
+                      "fill": "#40c057"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "X0cN2",
+                  "name": "Txt",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "DCcdp",
+                      "name": "Val",
+                      "fill": "$text",
+                      "content": "860",
+                      "fontFamily": "$font",
+                      "fontSize": 20,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "lBYcT",
+                      "name": "Lbl",
+                      "fill": "$text-dim",
+                      "content": "Participants",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sstpL",
+              "name": "Time left",
+              "width": "fill_container",
+              "fill": "$surface",
+              "cornerRadius": "$radius-card",
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "gap": 12,
+              "padding": 16,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "sbPHO",
+                  "name": "Icon",
+                  "width": 40,
+                  "height": 40,
+                  "fill": "#352c12",
+                  "cornerRadius": "$radius-sm",
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "DLDLO",
+                      "name": "I",
+                      "width": 20,
+                      "height": 20,
+                      "icon": "hourglass",
+                      "library": "lucide",
+                      "fill": "$buzz"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "P3nEH7",
+                  "name": "Txt",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Oehvu",
+                      "name": "Val",
+                      "fill": "$text",
+                      "content": "9 days",
+                      "fontFamily": "$font",
+                      "fontSize": 20,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "CPBJH",
+                      "name": "Lbl",
+                      "fill": "$text-dim",
+                      "content": "Time left",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "LRQ5j",
+          "name": "Body",
+          "width": "fill_container",
+          "gap": 24,
+          "padding": [
+            20,
+            40,
+            44,
+            40
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "F8AzuG",
+              "name": "Left",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 18,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "k04a67",
+                  "name": "SectionHeader",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "SXXMy",
+                      "name": "HL",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "WIOd1",
+                          "name": "H",
+                          "fill": "$text",
+                          "content": "Challenges",
+                          "fontFamily": "$font",
+                          "fontSize": 22,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "wgAi9",
+                          "name": "CountPill",
+                          "fill": "$surface-2",
+                          "cornerRadius": 100,
+                          "padding": [
+                            3,
+                            9
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "P7Cfnt",
+                              "name": "C",
+                              "fill": "$text-dim",
+                              "content": "6",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dVLOp",
+                      "name": "Sort",
+                      "fill": "$surface",
+                      "cornerRadius": "$radius-sm",
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "isRjo",
+                          "name": "SortT",
+                          "fill": "$text-dim",
+                          "content": "Newest",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "mznXq",
+                          "name": "SortI",
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevron-down",
+                          "library": "lucide",
+                          "fill": "$text-dim"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "x81KDU",
+                  "name": "GRow0",
+                  "width": "fill_container",
+                  "gap": 18,
+                  "children": [
+                    {
+                      "id": "kF25d",
+                      "type": "ref",
+                      "ref": "E0RTe",
+                      "name": "GC00",
+                      "width": "fill_container"
+                    },
+                    {
+                      "id": "o2ejnx",
+                      "type": "ref",
+                      "ref": "E0RTe",
+                      "name": "GC01",
+                      "width": "fill_container"
+                    },
+                    {
+                      "id": "WSwwG",
+                      "type": "ref",
+                      "ref": "E0RTe",
+                      "name": "GC02",
+                      "width": "fill_container"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "STUnq",
+                  "name": "GRow1",
+                  "width": "fill_container",
+                  "gap": 18,
+                  "children": [
+                    {
+                      "id": "p9JZo",
+                      "type": "ref",
+                      "ref": "E0RTe",
+                      "name": "GC10",
+                      "width": "fill_container"
+                    },
+                    {
+                      "id": "Sd3sg",
+                      "type": "ref",
+                      "ref": "E0RTe",
+                      "name": "GC11",
+                      "width": "fill_container"
+                    },
+                    {
+                      "id": "AnicS",
+                      "type": "ref",
+                      "ref": "E0RTe",
+                      "name": "GC12",
+                      "width": "fill_container"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zAqu1",
+              "name": "AboutRail",
+              "width": 300,
+              "layout": "vertical",
+              "gap": 16,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "l94rt",
+                  "name": "AboutCard",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": "$radius-card",
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "layout": "vertical",
+                  "gap": 14,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "y6gm3",
+                      "name": "AboutTitle",
+                      "fill": "$text",
+                      "content": "About this event",
+                      "fontFamily": "$font",
+                      "fontSize": 15,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "w30K5",
+                      "name": "AboutDesc",
+                      "fill": "$text-dim",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "A month-long spotlight on standout creators. Enter any of the featured challenges to earn Buzz, badges, and a shot at the grand prize.",
+                      "lineHeight": 1.5,
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "l80MOz",
+                      "name": "Div1",
+                      "fill": "$border",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bExHZ",
+                      "name": "Starts",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "SkQyg",
+                          "name": "L",
+                          "fill": "$text-dim",
+                          "content": "Starts",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "kYBdV",
+                          "name": "V",
+                          "fill": "$text",
+                          "content": "Jul 1, 2026",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "d3zyv",
+                      "name": "Ends",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "TWTvo",
+                          "name": "L",
+                          "fill": "$text-dim",
+                          "content": "Ends",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "kuOHB",
+                          "name": "V",
+                          "fill": "$text",
+                          "content": "Aug 3, 2026",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "upA82",
+                      "name": "Format",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "rUwNd",
+                          "name": "L",
+                          "fill": "$text-dim",
+                          "content": "Format",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ejDkb",
+                          "name": "V",
+                          "fill": "$text",
+                          "content": "Open · SFW",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "q5t1i",
+                      "name": "Eligibility",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "CaUhK",
+                          "name": "L",
+                          "fill": "$text-dim",
+                          "content": "Eligibility",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "N3qTu",
+                          "name": "V",
+                          "fill": "$text",
+                          "content": "All members",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "M7Q3cr",
+                      "name": "Cooldown",
+                      "width": "fill_container",
+                      "justifyContent": "space_between",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Q1v1GU",
+                          "name": "L",
+                          "fill": "$text-dim",
+                          "content": "Winner cooldown",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "A8l2MN",
+                          "name": "V",
+                          "fill": "$text",
+                          "content": "7 days",
+                          "fontFamily": "$font",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HLPmP",
+                  "name": "JudgesCard",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": "$radius-card",
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": 20,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "OyYO7",
+                      "name": "JudgesTitle",
+                      "fill": "$text",
+                      "content": "Judged by",
+                      "fontFamily": "$font",
+                      "fontSize": 15,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HjX45",
+                      "name": "CivBot",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "p4wnv",
+                          "name": "Av",
+                          "fill": "#4263eb",
+                          "width": 34,
+                          "height": 34
+                        },
+                        {
+                          "type": "frame",
+                          "id": "dRrZ1",
+                          "name": "T",
+                          "layout": "vertical",
+                          "gap": 1,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "DxWG7",
+                              "name": "N",
+                              "fill": "$text",
+                              "content": "CivBot",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "dpfYD",
+                              "name": "R",
+                              "fill": "$text-dim",
+                              "content": "AI Judge",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "RWP7R",
+                      "name": "CivChan",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "kNPAa",
+                          "name": "Av",
+                          "fill": "#e8590c",
+                          "width": 34,
+                          "height": 34
+                        },
+                        {
+                          "type": "frame",
+                          "id": "h2L0qD",
+                          "name": "T",
+                          "layout": "vertical",
+                          "gap": 1,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "vmPm9",
+                              "name": "N",
+                              "fill": "$text",
+                              "content": "CivChan",
+                              "fontFamily": "$font",
+                              "fontSize": 13,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "h24PVw",
+                              "name": "R",
+                              "fill": "$text-dim",
+                              "content": "AI Judge",
+                              "fontFamily": "$font",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "sTw3I",
+      "x": 6690,
+      "y": 0,
+      "name": "Event Detail — Mobile",
+      "clip": true,
+      "width": 390,
+      "fill": "$bg-page",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "e2dhQw",
+          "name": "TopBar",
+          "width": "fill_container",
+          "height": 52,
+          "fill": "$bg-header",
+          "padding": [
+            0,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "LKe3S",
+              "name": "Logo",
+              "fill": "$text",
+              "content": "CIVITAI",
+              "fontFamily": "$font",
+              "fontSize": 18,
+              "fontWeight": "800"
+            },
+            {
+              "type": "frame",
+              "id": "q2Rhm",
+              "name": "R",
+              "gap": 14,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "i22Uv",
+                  "name": "Search",
+                  "width": 20,
+                  "height": 20,
+                  "icon": "search",
+                  "library": "lucide",
+                  "fill": "$text-dim"
+                },
+                {
+                  "type": "icon",
+                  "id": "L5iuA",
+                  "name": "Menu",
+                  "width": 22,
+                  "height": 22,
+                  "icon": "menu",
+                  "library": "lucide",
+                  "fill": "$text"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ZYw1Y",
+          "name": "Hero",
+          "clip": true,
+          "width": "fill_container",
+          "fill": [
+            {
+              "type": "gradient",
+              "gradientType": "linear",
+              "enabled": true,
+              "rotation": 120,
+              "size": {
+                "height": 1
+              },
+              "colors": [
+                {
+                  "color": "#0f4a32",
+                  "position": 0
+                },
+                {
+                  "color": "#0c3423",
+                  "position": 1
+                }
+              ]
+            },
+            {
+              "type": "gradient",
+              "gradientType": "linear",
+              "enabled": true,
+              "rotation": 180,
+              "size": {
+                "height": 1
+              },
+              "colors": [
+                {
+                  "color": "#00000000",
+                  "position": 0
+                },
+                {
+                  "color": "#00000066",
+                  "position": 1
+                }
+              ]
+            }
+          ],
+          "layout": "vertical",
+          "gap": 12,
+          "padding": [
+            16,
+            16,
+            20,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "UmQ8F",
+              "name": "HeroTop",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "GMw0y",
+                  "name": "Back",
+                  "gap": 6,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "RzVv5",
+                      "name": "BI",
+                      "width": 15,
+                      "height": 15,
+                      "icon": "arrow-left",
+                      "library": "lucide",
+                      "fill": "#a6f0c6"
+                    },
+                    {
+                      "type": "text",
+                      "id": "COT2h",
+                      "name": "BT",
+                      "fill": "#a6f0c6",
+                      "content": "All Challenges",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HB3Qx",
+                  "name": "Details",
+                  "fill": "#ffffff1a",
+                  "cornerRadius": "$radius-sm",
+                  "stroke": "#ffffff33",
+                  "strokeWidth": 1,
+                  "gap": 6,
+                  "padding": [
+                    6,
+                    12
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "efpFj",
+                      "name": "DI",
+                      "width": 14,
+                      "height": 14,
+                      "icon": "info",
+                      "library": "lucide",
+                      "fill": "#ffffff"
+                    },
+                    {
+                      "type": "text",
+                      "id": "dFxpP",
+                      "name": "DT",
+                      "fill": "#ffffff",
+                      "content": "Details",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "lle8D",
+              "name": "StatusRow",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ziNpr",
+                  "name": "Pill",
+                  "fill": "#2f9e4433",
+                  "cornerRadius": 100,
+                  "stroke": "#2f9e4466",
+                  "strokeWidth": 1,
+                  "gap": 6,
+                  "padding": [
+                    4,
+                    9
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "ellipse",
+                      "id": "OrCdS",
+                      "name": "D",
+                      "fill": "#40c057",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "text",
+                      "id": "l2C8n",
+                      "name": "PT",
+                      "fill": "#69db7c",
+                      "content": "Active",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "600"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "aUmwK",
+                  "name": "Ends",
+                  "fill": "#ffffffcc",
+                  "content": "Ends in 9 days",
+                  "fontFamily": "$font",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "BN7hD",
+              "name": "Title",
+              "fill": "#ffffff",
+              "content": "Creator Showcase",
+              "fontFamily": "$font",
+              "fontSize": 27,
+              "fontWeight": "800"
+            },
+            {
+              "type": "text",
+              "id": "vTwzP",
+              "name": "Desc",
+              "fill": "#ffffffb3",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Featured event spotlighting standout creators",
+              "fontFamily": "$font",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "t1lTcs",
+              "name": "PrizeInline",
+              "fill": "#00000040",
+              "cornerRadius": "$radius-sm",
+              "stroke": "#ffffff1a",
+              "strokeWidth": 1,
+              "gap": 6,
+              "padding": [
+                8,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "I0TWc",
+                  "name": "Z",
+                  "width": 18,
+                  "height": 18,
+                  "icon": "zap",
+                  "library": "lucide",
+                  "fill": "$buzz"
+                },
+                {
+                  "type": "text",
+                  "id": "mod70",
+                  "name": "PN",
+                  "fill": "$buzz",
+                  "content": "250,000",
+                  "fontFamily": "$font",
+                  "fontSize": 18,
+                  "fontWeight": "800"
+                },
+                {
+                  "type": "text",
+                  "id": "Knbsn",
+                  "name": "PL",
+                  "fill": "#ffffff99",
+                  "content": "prize pool",
+                  "fontFamily": "$font",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dylgX",
+          "name": "Stats",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 10,
+          "padding": [
+            16,
+            16,
+            4,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "dUDtv",
+              "name": "R1",
+              "width": "fill_container",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "lPAyw",
+                  "name": "Challenges",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": "$radius-card",
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "gap": 10,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "pLM94",
+                      "name": "Ic",
+                      "width": 32,
+                      "height": 32,
+                      "fill": "#16324f",
+                      "cornerRadius": "$radius-sm",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "mf6eq",
+                          "name": "I",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "swords",
+                          "library": "lucide",
+                          "fill": "$blue"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "za030",
+                      "name": "T",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dzInB",
+                          "name": "V",
+                          "fill": "$text",
+                          "content": "6",
+                          "fontFamily": "$font",
+                          "fontSize": 16,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "VpHqM",
+                          "name": "L",
+                          "fill": "$text-dim",
+                          "content": "Challenges",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jwjgQ",
+                  "name": "Submissions",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": "$radius-card",
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "gap": 10,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "EQwuC",
+                      "name": "Ic",
+                      "width": 32,
+                      "height": 32,
+                      "fill": "#2a1c38",
+                      "cornerRadius": "$radius-sm",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "vgYze",
+                          "name": "I",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "image",
+                          "library": "lucide",
+                          "fill": "$grape"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yEJTf",
+                      "name": "T",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "p6Rf6",
+                          "name": "V",
+                          "fill": "$text",
+                          "content": "1,240",
+                          "fontFamily": "$font",
+                          "fontSize": 16,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ZQnpl",
+                          "name": "L",
+                          "fill": "$text-dim",
+                          "content": "Submissions",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sKHZp",
+              "name": "R2",
+              "width": "fill_container",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "JudP1",
+                  "name": "Participants",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": "$radius-card",
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "gap": 10,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "QkITL",
+                      "name": "Ic",
+                      "width": 32,
+                      "height": 32,
+                      "fill": "#15321f",
+                      "cornerRadius": "$radius-sm",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "Q2u50J",
+                          "name": "I",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "users",
+                          "library": "lucide",
+                          "fill": "#40c057"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CsXfb",
+                      "name": "T",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "XJB5l",
+                          "name": "V",
+                          "fill": "$text",
+                          "content": "860",
+                          "fontFamily": "$font",
+                          "fontSize": 16,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "L0F7J",
+                          "name": "L",
+                          "fill": "$text-dim",
+                          "content": "Participants",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jYgdN",
+                  "name": "Time left",
+                  "width": "fill_container",
+                  "fill": "$surface",
+                  "cornerRadius": "$radius-card",
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "gap": 10,
+                  "padding": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "aFV7W",
+                      "name": "Ic",
+                      "width": 32,
+                      "height": 32,
+                      "fill": "#352c12",
+                      "cornerRadius": "$radius-sm",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "o7mHv4",
+                          "name": "I",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "hourglass",
+                          "library": "lucide",
+                          "fill": "$buzz"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZRd5f",
+                      "name": "T",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "g2bZaJ",
+                          "name": "V",
+                          "fill": "$text",
+                          "content": "9 days",
+                          "fontFamily": "$font",
+                          "fontSize": 16,
+                          "fontWeight": "700"
+                        },
+                        {
+                          "type": "text",
+                          "id": "H1RDv",
+                          "name": "L",
+                          "fill": "$text-dim",
+                          "content": "Time left",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "d1OnTn",
+          "name": "ChallengesSection",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 14,
+          "padding": [
+            16,
+            16,
+            8,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "MiAEZ",
+              "name": "Header",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "yLq6E",
+                  "name": "HL",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "zPEmI",
+                      "name": "H",
+                      "fill": "$text",
+                      "content": "Challenges",
+                      "fontFamily": "$font",
+                      "fontSize": 18,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "sRQXk",
+                      "name": "CP",
+                      "fill": "$surface-2",
+                      "cornerRadius": 100,
+                      "padding": [
+                        2,
+                        8
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "bhcii",
+                          "name": "C",
+                          "fill": "$text-dim",
+                          "content": "6",
+                          "fontFamily": "$font",
+                          "fontSize": 12,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "AdsmS",
+                  "name": "Sort",
+                  "fill": "$surface",
+                  "cornerRadius": "$radius-sm",
+                  "stroke": "$border",
+                  "strokeWidth": 1,
+                  "gap": 6,
+                  "padding": [
+                    6,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "r4nmGv",
+                      "name": "ST",
+                      "fill": "$text-dim",
+                      "content": "Newest",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "uJWb4",
+                      "name": "SI",
+                      "width": 13,
+                      "height": 13,
+                      "icon": "chevron-down",
+                      "library": "lucide",
+                      "fill": "$text-dim"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "id": "WypsT",
+              "type": "ref",
+              "ref": "E0RTe",
+              "name": "MCard0",
+              "width": "fill_container"
+            },
+            {
+              "id": "jvnC8",
+              "type": "ref",
+              "ref": "E0RTe",
+              "name": "MCard1",
+              "width": "fill_container"
+            },
+            {
+              "id": "eqAF7",
+              "type": "ref",
+              "ref": "E0RTe",
+              "name": "MCard2",
+              "width": "fill_container"
+            },
+            {
+              "id": "SW1s5",
+              "type": "ref",
+              "ref": "E0RTe",
+              "name": "MCard3",
+              "width": "fill_container"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "cYSzB",
+      "x": 7160,
+      "y": 0,
+      "name": "Event Details — Modal (Mobile)",
+      "clip": true,
+      "width": 390,
+      "fill": "$bg-page",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "pB159",
+          "name": "Header",
+          "width": "fill_container",
+          "height": 56,
+          "fill": "$bg-header",
+          "stroke": "$border",
+          "strokeWidth": {
+            "bottom": 1
+          },
+          "padding": [
+            0,
+            16
+          ],
+          "justifyContent": "space_between",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "P9wvR3",
+              "name": "T",
+              "fill": "$text",
+              "content": "About this event",
+              "fontFamily": "$font",
+              "fontSize": 16,
+              "fontWeight": "700"
+            },
+            {
+              "type": "icon",
+              "id": "l59X3W",
+              "name": "X",
+              "width": 22,
+              "height": 22,
+              "icon": "x",
+              "library": "lucide",
+              "fill": "$text-dim"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "ukfSl",
+          "name": "Body",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 16,
+          "padding": 16,
+          "children": [
+            {
+              "type": "frame",
+              "id": "NMNYw",
+              "name": "EventHead",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 8,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "PQZiB",
+                  "name": "SR",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ecYyn",
+                      "name": "Pill",
+                      "fill": "#2f9e4426",
+                      "cornerRadius": 100,
+                      "stroke": "#2f9e4455",
+                      "strokeWidth": 1,
+                      "gap": 6,
+                      "padding": [
+                        4,
+                        9
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "oomyC",
+                          "name": "D",
+                          "fill": "#40c057",
+                          "width": 7,
+                          "height": 7
+                        },
+                        {
+                          "type": "text",
+                          "id": "X8SW8",
+                          "name": "PT",
+                          "fill": "#69db7c",
+                          "content": "Active",
+                          "fontFamily": "$font",
+                          "fontSize": 11,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "u2BeV",
+                      "name": "Dt",
+                      "fill": "$text-dim",
+                      "content": "Jul 1 – Aug 3, 2026",
+                      "fontFamily": "$font",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "hboE8",
+                  "name": "Ttl",
+                  "fill": "$text",
+                  "content": "Creator Showcase",
+                  "fontFamily": "$font",
+                  "fontSize": 22,
+                  "fontWeight": "800"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "g2S8QS",
+              "name": "Desc",
+              "fill": "$text-dim",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "A month-long spotlight on standout creators. Enter any featured challenge to earn Buzz, badges, and a shot at the grand prize.",
+              "lineHeight": 1.55,
+              "fontFamily": "$font",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "rectangle",
+              "id": "BbzDh",
+              "name": "Div",
+              "fill": "$border",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "r6Si1",
+              "name": "Starts",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "G3nuW3",
+                  "name": "L",
+                  "fill": "$text-dim",
+                  "content": "Starts",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "G595FM",
+                  "name": "V",
+                  "fill": "$text",
+                  "content": "Jul 1, 2026",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "pZBwH",
+              "name": "Ends",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "gvq3B",
+                  "name": "L",
+                  "fill": "$text-dim",
+                  "content": "Ends",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "efz6m",
+                  "name": "V",
+                  "fill": "$text",
+                  "content": "Aug 3, 2026",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "S1tlnx",
+              "name": "Format",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "lxcCS",
+                  "name": "L",
+                  "fill": "$text-dim",
+                  "content": "Format",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "huYpA",
+                  "name": "V",
+                  "fill": "$text",
+                  "content": "Open · SFW",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "NxCJr",
+              "name": "Eligibility",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "KzK9W",
+                  "name": "L",
+                  "fill": "$text-dim",
+                  "content": "Eligibility",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "gLUp6",
+                  "name": "V",
+                  "fill": "$text",
+                  "content": "All members",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "WwGhC",
+              "name": "Winner cooldown",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "qVtLI",
+                  "name": "L",
+                  "fill": "$text-dim",
+                  "content": "Winner cooldown",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "UXLYs",
+                  "name": "V",
+                  "fill": "$text",
+                  "content": "7 days",
+                  "fontFamily": "$font",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "JnKv0",
+              "name": "Div2",
+              "fill": "$border",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "text",
+              "id": "tbmDP",
+              "name": "JT",
+              "fill": "$text",
+              "content": "Judged by",
+              "fontFamily": "$font",
+              "fontSize": 14,
+              "fontWeight": "700"
+            },
+            {
+              "type": "frame",
+              "id": "zwiss",
+              "name": "CivBot",
+              "width": "fill_container",
+              "gap": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "DZide",
+                  "name": "Av",
+                  "fill": "#4263eb",
+                  "width": 34,
+                  "height": 34
+                },
+                {
+                  "type": "frame",
+                  "id": "OcrL5",
+                  "name": "T",
+                  "layout": "vertical",
+                  "gap": 1,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "jg5ly",
+                      "name": "N",
+                      "fill": "$text",
+                      "content": "CivBot",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "DyeM2",
+                      "name": "R",
+                      "fill": "$text-dim",
+                      "content": "AI Judge",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yBj8U",
+              "name": "CivChan",
+              "width": "fill_container",
+              "gap": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "Fx6wz",
+                  "name": "Av",
+                  "fill": "#e8590c",
+                  "width": 34,
+                  "height": 34
+                },
+                {
+                  "type": "frame",
+                  "id": "VKKg1",
+                  "name": "T",
+                  "layout": "vertical",
+                  "gap": 1,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "r3mUL",
+                      "name": "N",
+                      "fill": "$text",
+                      "content": "CivChan",
+                      "fontFamily": "$font",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "oSbZ1",
+                      "name": "R",
+                      "fill": "$text-dim",
+                      "content": "AI Judge",
+                      "fontFamily": "$font",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "variables": {

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -1740,6 +1740,7 @@ model Image {
   comicProjectHero        ComicProject[]         @relation("comicProjectHero")
   challengesCover     Challenge[]           @relation("ChallengeCoverImage")
   challengeWins       ChallengeWinner[]
+  challengeEventCovers ChallengeEvent[]     @relation("ChallengeEventCover")
   model3dThumbnails   Model3D[]             @relation("model3dThumbnail")
   model3dSources      Model3D[]             @relation("model3dSource")
   appListingIcons        AppListing[]           @relation("AppListingIcon")
@@ -5456,6 +5457,8 @@ model ChallengeEvent {
   endDate            DateTime
   active             Boolean  @default(true)
   winnerCooldownDays Int?
+  coverImageId       Int?
+  coverImage         Image?   @relation("ChallengeEventCover", fields: [coverImageId], references: [id], onDelete: SetNull)
   createdById        Int?
   createdBy          User?    @relation(fields: [createdById], references: [id], onDelete: SetNull)
   createdAt          DateTime @default(now())

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -346,6 +346,8 @@ export type AppListing = {
   content_rating: string | null;
   external_url: string | null;
   connect_client_id: string | null;
+  connect_requested_scopes: number | null;
+  connect_scope_justifications: unknown | null;
   app_block_id: string | null;
   revision_of_id: string | null;
   featured: Generated<boolean>;
@@ -775,7 +777,27 @@ export type BlockScopeInvocation = {
    * the forensic anchor when `appBlockId` is NULL. NULL for every approved-app row.
    */
   synthetic_app_id: string | null;
-  block_instance_id: string;
+  /**
+   * NULLABLE: an EXTERNAL OAuth invocation (`source = 'external-oauth'`) has no
+   * block instance — the acting app is a pure OauthClient with no App Block. A
+   * block-token row always sets this.
+   */
+  block_instance_id: string | null;
+  /**
+   * The acting OauthClient id for an EXTERNAL OAuth invocation (`source =
+   * 'external-oauth'`) — the "which app" for external OAuth API usage, mirroring
+   * what `appBlockId` is for a block-token row. NULL for a block-token row.
+   * Intentionally FK-LESS text so the audit row SURVIVES deletion of the
+   * OauthClient it references (an audit trail must outlive the app).
+   */
+  oauth_client_id: string | null;
+  /**
+   * Discriminates the token population that made the call: `'app-block'` (an App
+   * Block block-token, the historical default) vs `'external-oauth'` (a standard
+   * external OAuth access token verified at `enforceTokenScope`). Additive:
+   * existing rows backfill to `'app-block'`.
+   */
+  source: Generated<string>;
   scope: string;
   endpoint: string;
   status_code: number;
@@ -1362,6 +1384,7 @@ export type ChallengeEvent = {
   endDate: Timestamp;
   active: Generated<boolean>;
   winnerCooldownDays: number | null;
+  coverImageId: number | null;
   createdById: number | null;
   createdAt: Generated<Timestamp>;
   updatedAt: Timestamp;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -1406,6 +1406,7 @@ export interface Image {
   comicProjectHero?: ComicProject[];
   challengesCover?: Challenge[];
   challengeWins?: ChallengeWinner[];
+  challengeEventCovers?: ChallengeEvent[];
   model3dThumbnails?: Model3D[];
   model3dSources?: Model3D[];
   appListingIcons?: AppListing[];
@@ -1890,6 +1891,8 @@ export interface AppListing {
   externalUrl: string | null;
   connectClientId: string | null;
   connectClient?: OauthClient | null;
+  connectRequestedScopes: number | null;
+  connectScopeJustifications: JsonValue | null;
   appBlockId: string | null;
   appBlock?: AppBlock | null;
   revisionOfId: string | null;
@@ -2169,7 +2172,9 @@ export interface BlockScopeInvocation {
   appBlockId: string | null;
   appBlock?: AppBlock | null;
   syntheticAppId: string | null;
-  blockInstanceId: string;
+  blockInstanceId: string | null;
+  oauthClientId: string | null;
+  source: string;
   scope: string;
   endpoint: string;
   statusCode: number;
@@ -3714,6 +3719,8 @@ export interface ChallengeEvent {
   endDate: Date;
   active: boolean;
   winnerCooldownDays: number | null;
+  coverImageId: number | null;
+  coverImage?: Image | null;
   createdById: number | null;
   createdBy?: User | null;
   createdAt: Date;

--- a/prisma/migrations/20260720120000_challenge_event_cover_image/migration.sql
+++ b/prisma/migrations/20260720120000_challenge_event_cover_image/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "ChallengeEvent" ADD COLUMN "coverImageId" INTEGER;
+ALTER TABLE "ChallengeEvent"
+  ADD CONSTRAINT "ChallengeEvent_coverImageId_fkey"
+  FOREIGN KEY ("coverImageId") REFERENCES "Image"("id")
+  ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20260720120000_challenge_event_cover_image/migration.sql
+++ b/prisma/migrations/20260720120000_challenge_event_cover_image/migration.sql
@@ -1,5 +1,7 @@
+BEGIN;
 ALTER TABLE "ChallengeEvent" ADD COLUMN "coverImageId" INTEGER;
 ALTER TABLE "ChallengeEvent"
   ADD CONSTRAINT "ChallengeEvent_coverImageId_fkey"
   FOREIGN KEY ("coverImageId") REFERENCES "Image"("id")
   ON DELETE SET NULL ON UPDATE CASCADE;
+COMMIT;

--- a/src/components/Challenge/EventBannerCard.tsx
+++ b/src/components/Challenge/EventBannerCard.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import type { ChallengeEventListItem } from '~/server/schema/challenge.schema';
 import { formatDate } from '~/utils/date-helpers';
+import { slugit } from '~/utils/string-helpers';
 
 // Dark gradient-stop tints per `titleColor`. Hardcoded hex (Tailwind's stock `900` shade for
 // each name) rather than `from-{color}-900` utility classes: this project's tailwind.config.js
@@ -61,7 +62,7 @@ export function EventBannerCard({
   const className = 'relative flex h-40 w-full overflow-hidden rounded-lg no-underline sm:h-48';
 
   return (
-    <Link href={`/challenges/events/${event.id}`} className={className}>
+    <Link href={`/challenges/events/${event.id}/${slugit(event.title)}`} className={className}>
       {content}
     </Link>
   );

--- a/src/components/Challenge/EventBannerCard.tsx
+++ b/src/components/Challenge/EventBannerCard.tsx
@@ -22,16 +22,24 @@ const gradientByTitleColor: Record<string, string> = {
 };
 const DEFAULT_GRADIENT = 'from-dark-9/80';
 
-export function EventBannerCard({ event }: { event: ChallengeEventListItem }) {
+export function EventBannerCard({
+  event,
+  // The dedicated event page (`/challenges/events/[id]`) reuses this same card for its hero:
+  // `linkable={false}` there avoids a self-link, and `count` overrides `event.challenges.length`
+  // since `getEventById` always returns an empty `challenges` array (the grid loads separately).
+  linkable = true,
+  count: countOverride,
+}: {
+  event: ChallengeEventListItem;
+  linkable?: boolean;
+  count?: number;
+}) {
   const gradient =
     (event.titleColor && gradientByTitleColor[event.titleColor]) ?? DEFAULT_GRADIENT;
-  const count = event.challenges.length;
+  const count = countOverride ?? event.challenges.length;
 
-  return (
-    <Link
-      href={`/challenges/events/${event.id}`}
-      className="relative flex h-40 w-full overflow-hidden rounded-lg no-underline sm:h-48"
-    >
+  const content = (
+    <>
       {event.coverImage && (
         <EdgeMedia
           src={event.coverImage.url}
@@ -50,10 +58,22 @@ export function EventBannerCard({ event }: { event: ChallengeEventListItem }) {
         <Title order={2} c="white" className="drop-shadow">
           {event.title}
         </Title>
-        <Text size="sm" c="white" className="flex items-center gap-1 opacity-90">
-          Explore Event <IconArrowRight size={16} />
-        </Text>
+        {linkable && (
+          <Text size="sm" c="white" className="flex items-center gap-1 opacity-90">
+            Explore Event <IconArrowRight size={16} />
+          </Text>
+        )}
       </div>
+    </>
+  );
+
+  const className = 'relative flex h-40 w-full overflow-hidden rounded-lg no-underline sm:h-48';
+
+  if (!linkable) return <div className={className}>{content}</div>;
+
+  return (
+    <Link href={`/challenges/events/${event.id}`} className={className}>
+      {content}
     </Link>
   );
 }

--- a/src/components/Challenge/EventBannerCard.tsx
+++ b/src/components/Challenge/EventBannerCard.tsx
@@ -1,0 +1,59 @@
+import { Text, Title } from '@mantine/core';
+import { IconArrowRight } from '@tabler/icons-react';
+import clsx from 'clsx';
+import Link from 'next/link';
+import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
+import type { ChallengeEventListItem } from '~/server/schema/challenge.schema';
+import { formatDate } from '~/utils/date-helpers';
+
+// Dark gradient-stop tints per `titleColor`. Hardcoded hex (Tailwind's stock `900` shade for
+// each name) rather than `from-{color}-900` utility classes: this project's tailwind.config.js
+// overrides blue/red/orange/yellow/green with Mantine's 0-9 shade scale, so a `-900` suffix on
+// those colors doesn't exist and would silently emit no background. Arbitrary-value classes
+// (`from-[#hex]`) sidestep the theme override entirely.
+const gradientByTitleColor: Record<string, string> = {
+  blue: 'from-[#1e3a8a]/80',
+  purple: 'from-[#581c87]/80',
+  red: 'from-[#7f1d1d]/80',
+  orange: 'from-[#7c2d12]/80',
+  yellow: 'from-[#713f12]/80',
+  green: 'from-[#14532d]/80',
+  pink: 'from-[#831843]/80',
+};
+const DEFAULT_GRADIENT = 'from-dark-9/80';
+
+export function EventBannerCard({ event }: { event: ChallengeEventListItem }) {
+  const gradient =
+    (event.titleColor && gradientByTitleColor[event.titleColor]) ?? DEFAULT_GRADIENT;
+  const count = event.challenges.length;
+
+  return (
+    <Link
+      href={`/challenges/events/${event.id}`}
+      className="relative flex h-40 w-full overflow-hidden rounded-lg no-underline sm:h-48"
+    >
+      {event.coverImage && (
+        <EdgeMedia
+          src={event.coverImage.url}
+          type={event.coverImage.type}
+          width={1600}
+          className="absolute inset-0 size-full object-cover"
+          alt={event.title}
+        />
+      )}
+      <div className={clsx('absolute inset-0 bg-gradient-to-r to-transparent', gradient)} />
+      <div className="relative z-10 flex flex-col justify-end gap-1 p-5">
+        <Text size="xs" c="white" className="opacity-80">
+          {formatDate(event.startDate)} – {formatDate(event.endDate)} · {count}{' '}
+          {count === 1 ? 'challenge' : 'challenges'}
+        </Text>
+        <Title order={2} c="white" className="drop-shadow">
+          {event.title}
+        </Title>
+        <Text size="sm" c="white" className="flex items-center gap-1 opacity-90">
+          Explore Event <IconArrowRight size={16} />
+        </Text>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/Challenge/EventBannerCard.tsx
+++ b/src/components/Challenge/EventBannerCard.tsx
@@ -46,7 +46,7 @@ export function EventBannerCard({
           type={event.coverImage.type}
           width={1600}
           className="absolute inset-0 size-full object-cover"
-          alt={event.title}
+          alt=""
         />
       )}
       <div className={clsx('absolute inset-0 bg-gradient-to-r to-transparent', gradient)} />

--- a/src/components/Challenge/EventBannerCard.tsx
+++ b/src/components/Challenge/EventBannerCard.tsx
@@ -24,19 +24,12 @@ const DEFAULT_GRADIENT = 'from-dark-9/80';
 
 export function EventBannerCard({
   event,
-  // The dedicated event page (`/challenges/events/[id]`) reuses this same card for its hero:
-  // `linkable={false}` there avoids a self-link, and `count` overrides `event.challenges.length`
-  // since `getEventById` always returns an empty `challenges` array (the grid loads separately).
-  linkable = true,
-  count: countOverride,
 }: {
   event: ChallengeEventListItem;
-  linkable?: boolean;
-  count?: number;
 }) {
   const gradient =
     (event.titleColor && gradientByTitleColor[event.titleColor]) ?? DEFAULT_GRADIENT;
-  const count = countOverride ?? event.challenges.length;
+  const count = event.challenges.length;
 
   const content = (
     <>
@@ -58,18 +51,14 @@ export function EventBannerCard({
         <Title order={2} c="white" className="drop-shadow">
           {event.title}
         </Title>
-        {linkable && (
-          <Text size="sm" c="white" className="flex items-center gap-1 opacity-90">
-            Explore Event <IconArrowRight size={16} />
-          </Text>
-        )}
+        <Text size="sm" c="white" className="flex items-center gap-1 opacity-90">
+          Explore Event <IconArrowRight size={16} />
+        </Text>
       </div>
     </>
   );
 
   const className = 'relative flex h-40 w-full overflow-hidden rounded-lg no-underline sm:h-48';
-
-  if (!linkable) return <div className={className}>{content}</div>;
 
   return (
     <Link href={`/challenges/events/${event.id}`} className={className}>

--- a/src/components/Challenge/EventHero.tsx
+++ b/src/components/Challenge/EventHero.tsx
@@ -1,0 +1,91 @@
+import { Text, Title } from '@mantine/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import clsx from 'clsx';
+import Link from 'next/link';
+import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
+import type { ChallengeEventListItem } from '~/server/schema/challenge.schema';
+import { daysFromNow, formatDate } from '~/utils/date-helpers';
+
+// Hardcoded hex (Tailwind's stock `900` shade) — this project's tailwind.config.js remaps
+// blue/red/orange/yellow/green to Mantine's 0-9 scale, so `-900` utility classes don't exist.
+// Matches EventBannerCard's approach.
+const gradientByTitleColor: Record<string, string> = {
+  blue: 'from-[#1e3a8a]',
+  purple: 'from-[#581c87]',
+  red: 'from-[#7f1d1d]',
+  orange: 'from-[#7c2d12]',
+  yellow: 'from-[#713f12]',
+  green: 'from-[#14532d]',
+  pink: 'from-[#831843]',
+};
+const DEFAULT_GRADIENT = 'from-dark-9';
+
+type EventHeroData = ChallengeEventListItem & { challengeCount: number; active: boolean };
+
+export function EventHero({ event }: { event: EventHeroData }) {
+  const gradient =
+    (event.titleColor && gradientByTitleColor[event.titleColor]) ?? DEFAULT_GRADIENT;
+  const isActive = event.active && new Date(event.endDate) >= new Date();
+  const count = event.challengeCount;
+
+  return (
+    <div className="relative flex min-h-[220px] w-full flex-col justify-between overflow-hidden rounded-lg p-5 sm:min-h-[280px] sm:p-8">
+      {event.coverImage && (
+        <EdgeMedia
+          src={event.coverImage.url}
+          type={event.coverImage.type}
+          width={1600}
+          className="absolute inset-0 size-full object-cover"
+          alt=""
+        />
+      )}
+      <div className={clsx('absolute inset-0 bg-gradient-to-br to-black/60', gradient)} />
+      <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent" />
+
+      <Link
+        href="/challenges"
+        className="relative z-10 flex w-fit items-center gap-1 text-sm font-semibold text-white/90 no-underline hover:text-white"
+      >
+        <IconArrowLeft size={16} /> Back
+      </Link>
+
+      <div className="relative z-10 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-end">
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={clsx(
+                'flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold',
+                isActive ? 'bg-[#40c057]/20 text-[#69db7c]' : 'bg-white/10 text-white/70'
+              )}
+            >
+              <span
+                className={clsx('size-2 rounded-full', isActive ? 'bg-[#40c057]' : 'bg-white/40')}
+              />
+              {isActive ? 'Active Event' : 'Event Ended'}
+            </span>
+            <Text size="sm" c="white" className="opacity-80">
+              {isActive ? `Ends ${daysFromNow(event.endDate)}` : `Ended ${daysFromNow(event.endDate)}`}
+            </Text>
+          </div>
+          <Title order={1} c="white" className="text-2xl drop-shadow sm:text-4xl">
+            {event.title}
+          </Title>
+          <Text c="white" className="opacity-80">
+            {formatDate(event.startDate)} – {formatDate(event.endDate)}
+          </Text>
+          {event.description && (
+            <Text c="white" className="max-w-2xl opacity-75" lineClamp={2}>
+              {event.description}
+            </Text>
+          )}
+        </div>
+        <div className="flex shrink-0 flex-col items-start sm:items-end">
+          <Text className="text-4xl font-extrabold text-white drop-shadow">{count}</Text>
+          <Text size="sm" c="white" className="opacity-70">
+            {count === 1 ? 'Challenge' : 'Challenges'}
+          </Text>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Challenge/EventHero.tsx
+++ b/src/components/Challenge/EventHero.tsx
@@ -25,8 +25,16 @@ type EventHeroData = ChallengeEventListItem & { challengeCount: number; active: 
 export function EventHero({ event }: { event: EventHeroData }) {
   const gradient =
     (event.titleColor && gradientByTitleColor[event.titleColor]) ?? DEFAULT_GRADIENT;
-  const isActive = event.active && new Date(event.endDate) >= new Date();
+  const ended = new Date(event.endDate) < new Date();
+  const isActive = event.active && !ended;
   const count = event.challengeCount;
+  // Key the relative-time line on the actual end date (not `active`), so a mod-deactivated event
+  // whose end date is still in the future doesn't render "Event Ended · Ends in 9 days".
+  const timeLabel = isActive
+    ? `Ends ${daysFromNow(event.endDate)}`
+    : ended
+    ? `Ended ${daysFromNow(event.endDate)}`
+    : null;
 
   return (
     <div className="relative flex min-h-[220px] w-full flex-col justify-between overflow-hidden rounded-lg p-5 sm:min-h-[280px] sm:p-8">
@@ -63,9 +71,11 @@ export function EventHero({ event }: { event: EventHeroData }) {
               />
               {isActive ? 'Active Event' : 'Event Ended'}
             </span>
-            <Text size="sm" c="white" className="opacity-80">
-              {isActive ? `Ends ${daysFromNow(event.endDate)}` : `Ended ${daysFromNow(event.endDate)}`}
-            </Text>
+            {timeLabel && (
+              <Text size="sm" c="white" className="opacity-80">
+                {timeLabel}
+              </Text>
+            )}
           </div>
           <Title order={1} c="white" className="text-2xl drop-shadow sm:text-4xl">
             {event.title}

--- a/src/components/Challenge/EventHero.tsx
+++ b/src/components/Challenge/EventHero.tsx
@@ -46,7 +46,7 @@ export function EventHero({ event }: { event: EventHeroData }) {
         href="/challenges"
         className="relative z-10 flex w-fit items-center gap-1 text-sm font-semibold text-white/90 no-underline hover:text-white"
       >
-        <IconArrowLeft size={16} /> Back
+        <IconArrowLeft size={16} /> All Challenges
       </Link>
 
       <div className="relative z-10 flex flex-col items-start justify-between gap-4 sm:flex-row sm:items-end">

--- a/src/components/Challenge/FeaturedChallengeEvents.tsx
+++ b/src/components/Challenge/FeaturedChallengeEvents.tsx
@@ -1,22 +1,10 @@
 import { useMemo } from 'react';
-import clsx from 'clsx';
-import { Stack, Title } from '@mantine/core';
-import { ChallengeCard } from '~/components/Cards/ChallengeCard';
 import { ChallengeCardSkeletonRow } from '~/components/Challenge/ChallengeCardSkeletonRow';
+import { EventBannerCard } from '~/components/Challenge/EventBannerCard';
 import { SectionBand } from '~/components/Challenge/SectionBand';
-import { TwScrollX } from '~/components/TwScrollX/TwScrollX';
+import { Embla } from '~/components/EmblaCarousel/EmblaCarousel';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
 import { trpc } from '~/utils/trpc';
-
-const eventTitleColors: Record<string, string> = {
-  blue: 'text-blue-400',
-  purple: 'text-purple-400',
-  red: 'text-red-400',
-  orange: 'text-orange-400',
-  yellow: 'text-yellow-400',
-  green: 'text-green-400',
-  pink: 'text-pink-400',
-};
 
 export function FeaturedChallengeEvents() {
   const {
@@ -47,7 +35,7 @@ export function FeaturedChallengeEvents() {
           ...event,
           challenges: event.challenges.filter((c) => filteredIds.has(c.id)),
         }))
-        .filter((e) => e.challenges.length > 0),
+        .filter((e) => e.challenges.length > 0) ?? [],
     [events, filteredIds]
   );
 
@@ -58,29 +46,28 @@ export function FeaturedChallengeEvents() {
       </SectionBand>
     );
 
-  if (!visibleEvents || visibleEvents.length === 0) return null;
+  if (visibleEvents.length === 0) return null;
+
+  if (visibleEvents.length === 1)
+    return (
+      <SectionBand>
+        <EventBannerCard event={visibleEvents[0]} />
+      </SectionBand>
+    );
 
   return (
     <SectionBand>
-      <Stack gap="md">
-        {visibleEvents.map((event) => (
-          <Stack key={event.id} gap="xs">
-            <Title
-              order={3}
-              className={clsx(event.titleColor && eventTitleColors[event.titleColor])}
-            >
-              {event.title}
-            </Title>
-            <TwScrollX className="flex gap-4">
-              {event.challenges.map((challenge) => (
-                <div key={challenge.id} className="w-[320px] shrink-0">
-                  <ChallengeCard data={challenge} />
-                </div>
-              ))}
-            </TwScrollX>
-          </Stack>
-        ))}
-      </Stack>
+      <Embla loop withIndicators>
+        <Embla.Viewport>
+          <Embla.Container className="-ml-4 flex">
+            {visibleEvents.map((event, index) => (
+              <Embla.Slide key={event.id} index={index} className="flex-[0_0_100%] pl-4">
+                <EventBannerCard event={event} />
+              </Embla.Slide>
+            ))}
+          </Embla.Container>
+        </Embla.Viewport>
+      </Embla>
     </SectionBand>
   );
 }

--- a/src/components/Challenge/SectionBand.tsx
+++ b/src/components/Challenge/SectionBand.tsx
@@ -2,7 +2,9 @@ import type { ReactNode } from 'react';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 
 // Full-bleed section band: the outer div spans full content width; the inner MasonryContainer
-// re-centers content to the max column width (homepage HomeBlockWrapper shape).
+// re-centers content to the max column width (homepage HomeBlockWrapper shape). The alternating
+// band background is painted by the parent container (see index.module.css `.sections`), mirroring
+// the home page's home-block treatment — no per-band prop needed.
 export function SectionBand({ children }: { children: ReactNode }) {
   return (
     <div>

--- a/src/components/Challenge/__tests__/EventBannerCard.browser.test.tsx
+++ b/src/components/Challenge/__tests__/EventBannerCard.browser.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+import { EventBannerCard } from '~/components/Challenge/EventBannerCard';
+import type { ChallengeEventListItem } from '~/server/schema/challenge.schema';
+
+const event = {
+  id: 42,
+  title: 'Civitai Summer Art Festival',
+  description: 'Compete all summer',
+  titleColor: 'purple',
+  startDate: new Date('2026-07-01'),
+  endDate: new Date('2026-08-31'),
+  coverImage: null,
+  challenges: [{ id: 1 }, { id: 2 }, { id: 3 }] as unknown as ChallengeEventListItem['challenges'],
+} satisfies ChallengeEventListItem;
+
+describe('EventBannerCard', () => {
+  test('renders the title and links to the event page', async () => {
+    renderWithProviders(<EventBannerCard event={event} />);
+    await expect.element(page.getByText('Civitai Summer Art Festival')).toBeInTheDocument();
+    await expect.element(page.getByRole('link')).toHaveAttribute('href', '/challenges/events/42');
+  });
+
+  test('shows the challenge count', async () => {
+    renderWithProviders(<EventBannerCard event={event} />);
+    await expect.element(page.getByText(/3 challenges/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/Challenge/__tests__/EventBannerCard.browser.test.tsx
+++ b/src/components/Challenge/__tests__/EventBannerCard.browser.test.tsx
@@ -20,7 +20,9 @@ describe('EventBannerCard', () => {
   test('renders the title and links to the event page', async () => {
     renderWithProviders(<EventBannerCard event={event} />);
     await expect.element(page.getByText('Civitai Summer Art Festival')).toBeInTheDocument();
-    await expect.element(page.getByRole('link')).toHaveAttribute('href', '/challenges/events/42');
+    await expect
+      .element(page.getByRole('link'))
+      .toHaveAttribute('href', '/challenges/events/42/civitai-summer-art-festival');
   });
 
   test('shows the challenge count', async () => {

--- a/src/components/Challenge/__tests__/EventHero.browser.test.tsx
+++ b/src/components/Challenge/__tests__/EventHero.browser.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+import { page } from 'vitest/browser';
+import { renderWithProviders } from '../../../../test/component-setup';
+import { EventHero } from '~/components/Challenge/EventHero';
+
+const base = {
+  id: 7,
+  title: 'Creator Showcase',
+  description: 'Featured event spotlighting standout creators',
+  titleColor: 'green',
+  startDate: new Date('2026-07-01'),
+  coverImage: null,
+  challenges: [],
+  challengeCount: 6,
+} as any;
+
+const future = new Date(Date.now() + 9 * 24 * 60 * 60 * 1000);
+const past = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000);
+
+describe('EventHero', () => {
+  test('renders title, challenge-count label, and a back link to /challenges', async () => {
+    renderWithProviders(<EventHero event={{ ...base, active: true, endDate: future }} />);
+    await expect.element(page.getByText('Creator Showcase')).toBeInTheDocument();
+    await expect.element(page.getByText('Challenges')).toBeInTheDocument();
+    await expect.element(page.getByRole('link')).toHaveAttribute('href', '/challenges');
+  });
+
+  test('shows Active Event for a live event', async () => {
+    renderWithProviders(<EventHero event={{ ...base, active: true, endDate: future }} />);
+    await expect.element(page.getByText('Active Event')).toBeInTheDocument();
+  });
+
+  test('shows Event Ended for a past event', async () => {
+    renderWithProviders(<EventHero event={{ ...base, active: true, endDate: past }} />);
+    await expect.element(page.getByText('Event Ended')).toBeInTheDocument();
+  });
+});

--- a/src/components/Challenge/__tests__/EventHero.browser.test.tsx
+++ b/src/components/Challenge/__tests__/EventHero.browser.test.tsx
@@ -21,7 +21,7 @@ describe('EventHero', () => {
   test('renders title, challenge-count label, and a back link to /challenges', async () => {
     renderWithProviders(<EventHero event={{ ...base, active: true, endDate: future }} />);
     await expect.element(page.getByText('Creator Showcase')).toBeInTheDocument();
-    await expect.element(page.getByText('Challenges')).toBeInTheDocument();
+    await expect.element(page.getByText('Challenges', { exact: true })).toBeInTheDocument();
     await expect.element(page.getByRole('link')).toHaveAttribute('href', '/challenges');
   });
 

--- a/src/pages/challenges/events/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/events/[id]/[[...slug]].tsx
@@ -1,0 +1,63 @@
+import { Stack, Title, Text, Button } from '@mantine/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { FeedLayout } from '~/components/AppLayout/FeedLayout';
+import { NotFound } from '~/components/AppLayout/NotFound';
+import { Page } from '~/components/AppLayout/Page';
+import { ChallengesInfinite } from '~/components/Challenge/Infinite/ChallengesInfinite';
+import { EventBannerCard } from '~/components/Challenge/EventBannerCard';
+import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
+import { Meta } from '~/components/Meta/Meta';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { trpc } from '~/utils/trpc';
+
+export const getServerSideProps = createServerSideProps({
+  resolver: async ({ features }) => {
+    if (!features?.challengePlatform) return { notFound: true };
+    return { props: {} };
+  },
+});
+
+function ChallengeEventPage() {
+  const router = useRouter();
+  const id = Number(router.query.id);
+  const { data: event, isLoading } = trpc.challenge.getEventById.useQuery(
+    { id },
+    { enabled: !Number.isNaN(id) }
+  );
+
+  if (!isLoading && !event) return <NotFound />;
+
+  return (
+    <>
+      <Meta
+        title={event ? `${event.title} | Civitai Challenges` : 'Challenge Event | Civitai'}
+        description={event?.description ?? undefined}
+        canonical={`/challenges/events/${id}`}
+      />
+      <MasonryContainer>
+        <Stack gap="lg">
+          <Button
+            component={Link}
+            href="/challenges"
+            variant="subtle"
+            size="compact-sm"
+            leftSection={<IconArrowLeft size={16} />}
+            className="self-start"
+          >
+            All Challenges
+          </Button>
+          {event && (
+            <EventBannerCard event={event} linkable={false} count={event.challengeCount} />
+          )}
+          {event?.description && <Text c="dimmed">{event.description}</Text>}
+          <Title order={3}>Challenges</Title>
+          {!Number.isNaN(id) && <ChallengesInfinite filters={{ challengeEventId: id }} />}
+        </Stack>
+      </MasonryContainer>
+    </>
+  );
+}
+
+export default Page(ChallengeEventPage, { InnerLayout: FeedLayout, announcements: true });

--- a/src/pages/challenges/events/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/events/[id]/[[...slug]].tsx
@@ -53,7 +53,9 @@ function ChallengeEventPage() {
           )}
           {event?.description && <Text c="dimmed">{event.description}</Text>}
           <Title order={3}>Challenges</Title>
-          {!Number.isNaN(id) && <ChallengesInfinite filters={{ challengeEventId: id }} />}
+          {!Number.isNaN(id) && (
+            <ChallengesInfinite filters={{ challengeEventId: id, includeEnded: true }} />
+          )}
         </Stack>
       </MasonryContainer>
     </>

--- a/src/pages/challenges/events/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/events/[id]/[[...slug]].tsx
@@ -1,12 +1,10 @@
-import { Stack, Title, Text, Button } from '@mantine/core';
-import { IconArrowLeft } from '@tabler/icons-react';
-import Link from 'next/link';
+import { Stack, Title } from '@mantine/core';
 import { useRouter } from 'next/router';
 import { FeedLayout } from '~/components/AppLayout/FeedLayout';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { Page } from '~/components/AppLayout/Page';
 import { ChallengesInfinite } from '~/components/Challenge/Infinite/ChallengesInfinite';
-import { EventBannerCard } from '~/components/Challenge/EventBannerCard';
+import { EventHero } from '~/components/Challenge/EventHero';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { Meta } from '~/components/Meta/Meta';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -38,20 +36,7 @@ function ChallengeEventPage() {
       />
       <MasonryContainer>
         <Stack gap="lg">
-          <Button
-            component={Link}
-            href="/challenges"
-            variant="subtle"
-            size="compact-sm"
-            leftSection={<IconArrowLeft size={16} />}
-            className="self-start"
-          >
-            All Challenges
-          </Button>
-          {event && (
-            <EventBannerCard event={event} linkable={false} count={event.challengeCount} />
-          )}
-          {event?.description && <Text c="dimmed">{event.description}</Text>}
+          {event && <EventHero event={event} />}
           <Title order={3}>Challenges</Title>
           {!Number.isNaN(id) && (
             <ChallengesInfinite filters={{ challengeEventId: id, includeEnded: true }} />

--- a/src/pages/challenges/events/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/events/[id]/[[...slug]].tsx
@@ -1,5 +1,6 @@
 import { Stack, Title } from '@mantine/core';
 import { useRouter } from 'next/router';
+import { z } from 'zod';
 import { FeedLayout } from '~/components/AppLayout/FeedLayout';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { Page } from '~/components/AppLayout/Page';
@@ -8,12 +9,47 @@ import { EventHero } from '~/components/Challenge/EventHero';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { Meta } from '~/components/Meta/Meta';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { removeEmpty } from '~/utils/object-helpers';
+import { buildPassthroughQuery } from '~/utils/query-string-helpers';
+import { slugit } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 
+const querySchema = z.object({
+  id: z.coerce.number(),
+  slug: z.array(z.string()).optional(),
+});
+
 export const getServerSideProps = createServerSideProps({
-  resolver: async ({ features }) => {
+  useSSG: true,
+  resolver: async ({ ctx, ssg, features }) => {
     if (!features?.challengePlatform) return { notFound: true };
-    return { props: {} };
+
+    const result = querySchema.safeParse(ctx.query);
+    if (!result.success) return { notFound: true };
+
+    if (ssg) {
+      const event = await ssg.challenge.getEventById
+        .fetch({ id: result.data.id })
+        .catch(() => null);
+
+      // Redirect to the canonical slug URL when it's missing or incorrect. Skip when the
+      // canonical slug is empty (see the challenge detail page for the redirect-loop rationale).
+      if (event) {
+        const correctSlug = slugit(event.title);
+        const currentSlug = result.data.slug?.join('/');
+        if (correctSlug && currentSlug !== correctSlug) {
+          const queryString = buildPassthroughQuery(ctx.query);
+          return {
+            redirect: {
+              destination: `/challenges/events/${result.data.id}/${correctSlug}${queryString}`,
+              permanent: false,
+            },
+          };
+        }
+      }
+    }
+
+    return { props: removeEmpty(result.data) };
   },
 });
 
@@ -32,7 +68,9 @@ function ChallengeEventPage() {
       <Meta
         title={event ? `${event.title} | Civitai Challenges` : 'Challenge Event | Civitai'}
         description={event?.description ?? undefined}
-        canonical={`/challenges/events/${id}`}
+        canonical={
+          event ? `/challenges/events/${id}/${slugit(event.title)}` : `/challenges/events/${id}`
+        }
       />
       <MasonryContainer>
         <Stack gap="lg">

--- a/src/pages/challenges/events/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/events/[id]/[[...slug]].tsx
@@ -37,7 +37,7 @@ function ChallengeEventPage() {
       <MasonryContainer>
         <Stack gap="lg">
           {event && <EventHero event={event} />}
-          <Title order={3}>Challenges</Title>
+          <Title order={2}>Challenges</Title>
           {!Number.isNaN(id) && (
             <ChallengesInfinite filters={{ challengeEventId: id, includeEnded: true }} />
           )}

--- a/src/pages/challenges/index.module.css
+++ b/src/pages/challenges/index.module.css
@@ -33,3 +33,17 @@
 .control {
   border: none !important;
 }
+
+/* Alternating full-bleed band background, painted purely in CSS on the parent (mirrors the home
+   page's `.container` home-block treatment). -12px cancels the shared SubNav wrapper's mb-3 so the
+   first band sits flush under the subnav. */
+.sections {
+  margin-top: -12px;
+
+  & > *:nth-of-type(even) {
+    background: light-dark(
+      color-mix(in srgb, var(--mantine-color-gray-0), black 1%),
+      var(--mantine-color-dark-8)
+    );
+  }
+}

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -158,9 +158,7 @@ function ChallengesPage() {
         canonical="/challenges"
       />
 
-      {/* -mt-3 cancels the shared SubNav wrapper's mb-3 so the first band sits flush under the
-          subnav (SubNav in AppLayout.tsx). */}
-      <div className="-mt-3">
+      <div className={styles.sections}>
         <FeaturedChallengeEvents />
 
       <YourChallengesRow />

--- a/src/pages/moderator/challenges/events.tsx
+++ b/src/pages/moderator/challenges/events.tsx
@@ -33,6 +33,7 @@ import {
   InputDateTimePicker,
   InputSelect,
   InputNumber,
+  InputSimpleImageUpload,
   InputSwitch,
   InputText,
   InputTextArea,
@@ -77,6 +78,7 @@ const eventFormSchema = z.object({
   endDate: z.date({ error: 'End date is required' }),
   active: z.boolean().default(false),
   winnerCooldownDays: z.number().int().min(0).max(365).nullable().optional(),
+  coverImage: z.object({ id: z.number(), url: z.string() }).passthrough().nullable().optional(),
 });
 
 type ChallengeEventItem = {
@@ -88,6 +90,7 @@ type ChallengeEventItem = {
   endDate: Date;
   active: boolean;
   winnerCooldownDays: number | null;
+  coverImage: { id: number; url: string } | null;
   _count: { challenges: number };
 };
 
@@ -116,6 +119,7 @@ function EventFormModal({
       endDate: event?.endDate ? toDisplayUTC(event.endDate) : defaultEndDate,
       active: event?.active ?? false,
       winnerCooldownDays: event?.winnerCooldownDays ?? null,
+      coverImage: event?.coverImage ?? null,
     },
   });
 
@@ -152,6 +156,7 @@ function EventFormModal({
       endDate,
       active: data.active,
       winnerCooldownDays: data.winnerCooldownDays ?? null,
+      coverImage: data.coverImage ?? null,
     });
   };
 
@@ -212,6 +217,12 @@ function EventFormModal({
             min={0}
             max={365}
             clearable
+          />
+          <InputSimpleImageUpload
+            name="coverImage"
+            label="Cover Image"
+            description="Wide banner shown on the challenges page. Suggested 1600x600."
+            withNsfwLevel={false}
           />
           <Group justify="flex-end">
             <Button variant="default" onClick={onClose}>

--- a/src/pages/moderator/challenges/events.tsx
+++ b/src/pages/moderator/challenges/events.tsx
@@ -78,7 +78,11 @@ const eventFormSchema = z.object({
   endDate: z.date({ error: 'End date is required' }),
   active: z.boolean().default(false),
   winnerCooldownDays: z.number().int().min(0).max(365).nullable().optional(),
-  coverImage: z.object({ id: z.number(), url: z.string() }).passthrough().nullable().optional(),
+  coverImage: z
+    .object({ id: z.number().optional(), url: z.string() })
+    .passthrough()
+    .nullable()
+    .optional(),
 });
 
 type ChallengeEventItem = {
@@ -90,7 +94,7 @@ type ChallengeEventItem = {
   endDate: Date;
   active: boolean;
   winnerCooldownDays: number | null;
-  coverImage: { id: number; url: string } | null;
+  coverImage: { id?: number; url: string } | null;
   _count: { challenges: number };
 };
 

--- a/src/server/routers/challenge.router.ts
+++ b/src/server/routers/challenge.router.ts
@@ -40,6 +40,7 @@ import {
   deleteUserChallenge,
   endChallengeAndPickWinners,
   getActiveEvents,
+  getChallengeEventById,
   getChallengeDetail,
   getChallengeForEdit,
   getChallengeEvents,
@@ -303,6 +304,13 @@ export const challengeRouter = router({
     .meta({ requiredScope: TokenScope.MediaRead })
     .use(isFlagProtected('challengePlatform'))
     .query(() => getActiveEvents()),
+
+  // Public: Get single event by ID
+  getEventById: publicProcedure
+    .meta({ requiredScope: TokenScope.MediaRead })
+    .input(z.object({ id: z.number() }))
+    .use(isFlagProtected('challengePlatform'))
+    .query(({ input }) => getChallengeEventById(input.id)),
 
   // Moderator: Get all challenge events
   getEvents: moderatorProcedure

--- a/src/server/schema/__tests__/challenge-event-schema.test.ts
+++ b/src/server/schema/__tests__/challenge-event-schema.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  upsertChallengeEventSchema,
+  getInfiniteChallengesSchema,
+} from '~/server/schema/challenge.schema';
+
+describe('challenge event schema', () => {
+  const base = {
+    title: 'Summer Fest',
+    startDate: new Date('2026-07-01'),
+    endDate: new Date('2026-08-31'),
+  };
+
+  it('accepts an optional coverImage object', () => {
+    const parsed = upsertChallengeEventSchema.parse({
+      ...base,
+      coverImage: { id: 123, url: '123e4567-e89b-12d3-a456-426614174000', nsfwLevel: 1 },
+    });
+    expect(parsed.coverImage?.id).toBe(123);
+  });
+
+  it('accepts a null coverImage', () => {
+    const parsed = upsertChallengeEventSchema.parse({ ...base, coverImage: null });
+    expect(parsed.coverImage).toBeNull();
+  });
+
+  it('parses without coverImage', () => {
+    const parsed = upsertChallengeEventSchema.parse(base);
+    expect(parsed.coverImage).toBeUndefined();
+  });
+
+  it('accepts challengeEventId on the infinite challenges filter', () => {
+    const parsed = getInfiniteChallengesSchema.parse({ challengeEventId: 42 });
+    expect(parsed.challengeEventId).toBe(42);
+  });
+});

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -307,6 +307,7 @@ export const getInfiniteChallengesSchema = z.object({
     .optional(),
   includeEnded: z.boolean().default(false),
   excludeEventChallenges: z.boolean().default(false),
+  challengeEventId: z.number().optional(),
   browsingLevel: z.number().optional(),
   limit: z.coerce.number().min(1).max(100).default(20),
 });
@@ -619,6 +620,7 @@ export type ChallengeEventListItem = {
   title: string;
   description: string | null;
   titleColor: string | null;
+  coverImage: ChallengeCoverImage | null;
   startDate: Date;
   endDate: Date;
   challenges: ChallengeListItem[];
@@ -645,6 +647,7 @@ export const upsertChallengeEventBaseSchema = z.object({
   endDate: z.date(),
   active: z.boolean().default(true),
   winnerCooldownDays: z.number().int().min(0).max(365).nullable().optional(),
+  coverImage: imageSchema.nullable().optional(),
 });
 
 export const upsertChallengeEventSchema = upsertChallengeEventBaseSchema.refine(

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -3092,7 +3092,7 @@ export async function upsertChallengeEvent({
   userId,
   ...input
 }: UpsertChallengeEventInput & { userId: number }) {
-  const { id, ...data } = input;
+  const { id, coverImage, ...data } = input;
 
   if (data.endDate <= data.startDate) {
     throw new TRPCError({
@@ -3101,17 +3101,24 @@ export async function upsertChallengeEvent({
     });
   }
 
+  let coverImageId: number | null | undefined;
+  if (coverImage === null) coverImageId = null;
+  else if (coverImage) {
+    coverImageId = coverImage.id ?? (await createImage({ ...coverImage, userId })).id;
+  }
+
   return dbWrite.$transaction(async (tx) => {
     if (id) {
       return tx.challengeEvent.update({
         where: { id },
-        data,
+        data: { ...data, ...(coverImageId !== undefined ? { coverImageId } : {}) },
       });
     }
 
     return tx.challengeEvent.create({
       data: {
         ...data,
+        coverImageId: coverImageId ?? null,
         createdById: userId,
       },
     });

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -475,6 +475,7 @@ export async function getInfiniteChallenges(
     participation,
     includeEnded,
     excludeEventChallenges,
+    challengeEventId,
     browsingLevel,
     limit,
     cursor,
@@ -568,6 +569,11 @@ export async function getInfiniteChallenges(
   // Exclude challenges that belong to an event (shown in featured section instead)
   if (excludeEventChallenges) {
     conditions.push(Prisma.sql`c."eventId" IS NULL`);
+  }
+
+  // Scope to a single event's challenges (e.g. an event's own challenges page)
+  if (challengeEventId) {
+    conditions.push(Prisma.sql`c."eventId" = ${challengeEventId}`);
   }
 
   // Content level filter — models-style: exclude a challenge outright when its REAL cover image

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -22,6 +22,7 @@ import {
   ChallengeSort,
   challengeJudgingCategoriesSchema,
   parseChallengeMetadata,
+  type ChallengeCoverImage,
   type ChallengeDetail,
   type ChallengeDetailForEdit,
   type ChallengeEventListItem,
@@ -2802,6 +2803,30 @@ export async function updateChallengeSystemConfig(input: UpdateChallengeConfigIn
 
 // --- Challenge Events ---
 
+// Batch-map event coverImageIds to the ChallengeCoverImage shape (mirrors the challenge-cover
+// mapping in mapChallengeRowsToCards above so both produce identical shapes).
+async function getEventCoverImages(coverImageIds: (number | null)[]) {
+  const ids = coverImageIds.filter(isDefined);
+  if (ids.length === 0) return new Map<number, ChallengeCoverImage>();
+  const images = await dbRead.image.findMany({
+    where: { id: { in: ids } },
+    select: imageSelect,
+  });
+  const map = new Map<number, ChallengeCoverImage>();
+  for (const img of images) {
+    map.set(img.id, {
+      id: img.id,
+      url: img.url,
+      nsfwLevel: img.nsfwLevel,
+      hash: img.hash,
+      width: img.width,
+      height: img.height,
+      type: img.type,
+    });
+  }
+  return map;
+}
+
 /**
  * Get active challenge events with their challenges.
  * Returns events where active=true and endDate >= now, ordered by startDate.
@@ -2820,6 +2845,7 @@ export async function getActiveEvents(): Promise<ChallengeEventListItem[]> {
       titleColor: true,
       startDate: true,
       endDate: true,
+      coverImageId: true,
       challenges: {
         where: {
           visibleAt: { lte: new Date() },
@@ -2848,10 +2874,16 @@ export async function getActiveEvents(): Promise<ChallengeEventListItem[]> {
     },
   });
 
+  const eventCoverMap = await getEventCoverImages(events.map((e) => e.coverImageId));
+
   // Batch-enrich all challenges across all events
   const allChallenges = events.flatMap((e) => e.challenges);
   if (allChallenges.length === 0) {
-    return events.map((e) => ({ ...e, challenges: [] }));
+    return events.map((e) => ({
+      ...e,
+      coverImage: e.coverImageId ? eventCoverMap.get(e.coverImageId) ?? null : null,
+      challenges: [],
+    }));
   }
 
   // Get judge user IDs for challenges that have judges
@@ -2931,6 +2963,7 @@ export async function getActiveEvents(): Promise<ChallengeEventListItem[]> {
     titleColor: event.titleColor,
     startDate: event.startDate,
     endDate: event.endDate,
+    coverImage: event.coverImageId ? eventCoverMap.get(event.coverImageId) ?? null : null,
     challenges: event.challenges.map((c) => {
       // createdById can be null (creator account deleted); fall back to the system user (-1).
       const displayUserId = displayUidFor({
@@ -2982,6 +3015,51 @@ export async function getActiveEvents(): Promise<ChallengeEventListItem[]> {
       };
     }),
   }));
+}
+
+/**
+ * Get a single challenge event by id, with its cover image and currently-visible challenge count.
+ * The `challenges` array is always empty — the grid loads separately via an infinite query.
+ */
+export async function getChallengeEventById(
+  id: number
+): Promise<ChallengeEventListItem & { challengeCount: number }> {
+  const event = await dbRead.challengeEvent.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      titleColor: true,
+      startDate: true,
+      endDate: true,
+      coverImageId: true,
+      _count: {
+        select: {
+          challenges: {
+            where: {
+              visibleAt: { lte: new Date() },
+              status: { not: ChallengeStatus.Cancelled },
+            },
+          },
+        },
+      },
+    },
+  });
+  if (!event) throw throwNotFoundError('Challenge event not found');
+
+  const coverMap = await getEventCoverImages([event.coverImageId]);
+  return {
+    id: event.id,
+    title: event.title,
+    description: event.description,
+    titleColor: event.titleColor,
+    startDate: event.startDate,
+    endDate: event.endDate,
+    coverImage: event.coverImageId ? coverMap.get(event.coverImageId) ?? null : null,
+    challenges: [],
+    challengeCount: event._count.challenges,
+  };
 }
 
 /**

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -3073,7 +3073,7 @@ export async function getChallengeEventById(
  */
 export async function getChallengeEvents(input: GetChallengeEventsInput) {
   const where = input.activeOnly ? { active: true, endDate: { gte: new Date() } } : {};
-  return dbRead.challengeEvent.findMany({
+  const events = await dbRead.challengeEvent.findMany({
     where,
     orderBy: { startDate: 'desc' },
     select: {
@@ -3086,9 +3086,16 @@ export async function getChallengeEvents(input: GetChallengeEventsInput) {
       active: true,
       winnerCooldownDays: true,
       createdAt: true,
+      coverImageId: true,
       _count: { select: { challenges: true } },
     },
   });
+
+  const coverMap = await getEventCoverImages(events.map((e) => e.coverImageId));
+  return events.map(({ coverImageId, ...e }) => ({
+    ...e,
+    coverImage: coverImageId ? coverMap.get(coverImageId) ?? null : null,
+  }));
 }
 
 /**

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -3029,7 +3029,7 @@ export async function getActiveEvents(): Promise<ChallengeEventListItem[]> {
  */
 export async function getChallengeEventById(
   id: number
-): Promise<ChallengeEventListItem & { challengeCount: number }> {
+): Promise<ChallengeEventListItem & { challengeCount: number; active: boolean }> {
   const event = await dbRead.challengeEvent.findUnique({
     where: { id },
     select: {
@@ -3040,6 +3040,7 @@ export async function getChallengeEventById(
       startDate: true,
       endDate: true,
       coverImageId: true,
+      active: true,
       _count: {
         select: {
           challenges: {
@@ -3065,6 +3066,7 @@ export async function getChallengeEventById(
     coverImage: event.coverImageId ? coverMap.get(event.coverImageId) ?? null : null,
     challenges: [],
     challengeCount: event._count.challenges,
+    active: event.active,
   };
 }
 

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -2879,9 +2879,9 @@ export async function getActiveEvents(): Promise<ChallengeEventListItem[]> {
   // Batch-enrich all challenges across all events
   const allChallenges = events.flatMap((e) => e.challenges);
   if (allChallenges.length === 0) {
-    return events.map((e) => ({
+    return events.map(({ coverImageId, ...e }) => ({
       ...e,
-      coverImage: e.coverImageId ? eventCoverMap.get(e.coverImageId) ?? null : null,
+      coverImage: coverImageId ? eventCoverMap.get(coverImageId) ?? null : null,
       challenges: [],
     }));
   }


### PR DESCRIPTION
## Summary

Adds **challenge events** to the Challenges Center and a redesigned dedicated event page. Two chunks:

**1. Event banners + dedicated event pages** (`coverImageId` feature)
- `/challenges` renders active events as a wide **banner carousel** (`Embla`, >1 event) instead of stacked per-event scroll rows that shoved the Daily/Community bands down.
- New **`/challenges/events/[id]/[[...slug]]`** page listing an event's challenges via `ChallengesInfinite` (new `challengeEventId` filter).
- New `ChallengeEvent.coverImageId` (FK → `Image`, `onDelete: SetNull`) + moderator cover upload in the event form.
- `getEventById` (public), event cover enrichment, `challengeEventId` infinite filter.

**2. Event page redesign v1** (`EventHero`)
- Replaces the thin reused-banner hero with a purpose-built **`EventHero`**: cover/`titleColor`-gradient background, back link, Active/Ended status pill, title, date range, description, and a **challenge-count focal** — fixing the empty-hero problem. Responsive (desktop content-left / count-right → mobile stacked).
- `getChallengeEventById` gains `active` for the status pill. Removed now-unused `EventBannerCard` `linkable`/`count` props.

## ⚠️ Manual migration required

`prisma/migrations/20260720120000_challenge_event_cover_image/migration.sql` adds `ChallengeEvent.coverImageId` (nullable INT + FK). Per repo policy it is **not** auto-applied — a human must run it against **preview / staging / prod**. **Already applied to the dev DB.** Until applied per-env, `getActiveEvents`/`getChallengeEvents`/`getChallengeEventById` (which now `SELECT coverImageId`) error at runtime.

## Testing / verification

- Full-branch `pnpm run typecheck` exit 0; component browser tests pass (`EventHero` 3/3, `EventBannerCard` 2/2, schema/challenge tests).
- Every task individually spec+quality reviewed; two whole-branch reviews (event-banners + redesign) → no Critical/Important; minors fixed.
- Verified live as a mod against the dev DB: `/challenges` carousel, `/challenges/events/7` (2 challenges, desktop), `/challenges/events/8` (1 challenge → singular "Challenge"), and mobile viewport stack.

## Notes
- Base branch is **`feat/challenges-center-redesign`** (the Challenges Center integration branch), not `main`.
- Deferred to a later phase: event stats (prize pool, submissions, participants), About/Judges rail, mobile details modal, grid sort control. Design frames for those live in `designs/challenges-feed.pen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
