### PR TITLE
harden(app-blocks): fail-soft wrap + wallclock bound + single-source engine for customComfy metrics

### DIFF
--- a/src/server/metrics/__tests__/app-block-runtime.metrics.test.ts
+++ b/src/server/metrics/__tests__/app-block-runtime.metrics.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import client from 'prom-client';
+
+/**
+ * Direct unit coverage for the two customComfy per-engine runtime/cost metric
+ * helpers (`observeCustomComfyActualBuzz` / `observeCustomComfyWallclockSeconds`).
+ *
+ * The settle-service test mocks these at the module boundary, so their OWN
+ * input-filtering + never-throw contract had no direct coverage. These tests
+ * exercise the REAL helpers against the REAL default prom-client registry (the
+ * same registry /api/metrics scrapes) and read the histogram back, so they pin:
+ *   - the `<= 0` / `NaN` drop (both helpers),
+ *   - the `> MAX_CUSTOMCOMFY_WALLCLOCK_SECONDS` drop (wall-clock only — Finding 2),
+ *   - a valid in-range value IS observed with the right {engine, recipe} labels,
+ *   - neither helper ever throws on bad input (the internal fail-soft catch).
+ */
+
+import {
+  MAX_CUSTOMCOMFY_WALLCLOCK_SECONDS,
+  observeCustomComfyActualBuzz,
+  observeCustomComfyWallclockSeconds,
+} from '~/server/metrics/app-block-runtime.metrics';
+
+type HistPoint = { metricName?: string; labels: Record<string, string>; value: number };
+
+/**
+ * Read back a single histogram aggregate (`_count` or `_sum`) for one
+ * {engine, recipe} label pair from the default registry. Returns 0 when the
+ * series doesn't exist yet — lets every assertion use a before/after DELTA so
+ * the tests are order-independent (the registry is process-global and other
+ * suites may have already observed samples).
+ */
+async function readHist(
+  name: string,
+  suffix: '_count' | '_sum',
+  engine: string,
+  recipe: string
+): Promise<number> {
+  const metric = client.register.getSingleMetric(name);
+  if (!metric) return 0;
+  const data = await (metric as { get(): Promise<{ values: HistPoint[] }> }).get();
+  const match = data.values.find(
+    (v) =>
+      v.metricName?.endsWith(suffix) &&
+      v.labels.engine === engine &&
+      v.labels.recipe === recipe
+  );
+  return match?.value ?? 0;
+}
+
+const ACTUAL_METRIC = 'civitai_app_block_customcomfy_actual_buzz';
+const WALLCLOCK_METRIC = 'civitai_app_block_customcomfy_wallclock_seconds';
+const RECIPE = 'seamless-pano-360';
+
+describe('observeCustomComfyActualBuzz', () => {
+  it('observes a valid value with the right engine/recipe labels', async () => {
+    const engine = 'zimage-turbo';
+    const beforeCount = await readHist(ACTUAL_METRIC, '_count', engine, RECIPE);
+    const beforeSum = await readHist(ACTUAL_METRIC, '_sum', engine, RECIPE);
+
+    observeCustomComfyActualBuzz(engine, RECIPE, 42);
+
+    expect(await readHist(ACTUAL_METRIC, '_count', engine, RECIPE)).toBe(beforeCount + 1);
+    expect(await readHist(ACTUAL_METRIC, '_sum', engine, RECIPE)).toBe(beforeSum + 42);
+  });
+
+  it('DROPS a zero / negative / NaN value (no sample recorded)', async () => {
+    const engine = 'flux2-klein';
+    const beforeCount = await readHist(ACTUAL_METRIC, '_count', engine, RECIPE);
+
+    observeCustomComfyActualBuzz(engine, RECIPE, 0);
+    observeCustomComfyActualBuzz(engine, RECIPE, -5);
+    observeCustomComfyActualBuzz(engine, RECIPE, Number.NaN);
+
+    expect(await readHist(ACTUAL_METRIC, '_count', engine, RECIPE)).toBe(beforeCount);
+  });
+
+  it('never throws on bad input', () => {
+    expect(() => observeCustomComfyActualBuzz('qwen-image', RECIPE, Infinity)).not.toThrow();
+    expect(() =>
+      observeCustomComfyActualBuzz('qwen-image', RECIPE, undefined as unknown as number)
+    ).not.toThrow();
+  });
+});
+
+describe('observeCustomComfyWallclockSeconds', () => {
+  it('observes an in-range value with the right engine/recipe labels', async () => {
+    const engine = 'zimage-turbo';
+    const beforeCount = await readHist(WALLCLOCK_METRIC, '_count', engine, RECIPE);
+    const beforeSum = await readHist(WALLCLOCK_METRIC, '_sum', engine, RECIPE);
+
+    observeCustomComfyWallclockSeconds(engine, RECIPE, 37);
+
+    expect(await readHist(WALLCLOCK_METRIC, '_count', engine, RECIPE)).toBe(beforeCount + 1);
+    expect(await readHist(WALLCLOCK_METRIC, '_sum', engine, RECIPE)).toBe(beforeSum + 37);
+  });
+
+  it('DROPS a zero / negative / NaN value', async () => {
+    const engine = 'flux2-klein';
+    const beforeCount = await readHist(WALLCLOCK_METRIC, '_count', engine, RECIPE);
+
+    observeCustomComfyWallclockSeconds(engine, RECIPE, 0);
+    observeCustomComfyWallclockSeconds(engine, RECIPE, -1);
+    observeCustomComfyWallclockSeconds(engine, RECIPE, Number.NaN);
+
+    expect(await readHist(WALLCLOCK_METRIC, '_count', engine, RECIPE)).toBe(beforeCount);
+  });
+
+  it('DROPS a value above MAX_CUSTOMCOMFY_WALLCLOCK_SECONDS (Finding 2 — junk delta)', async () => {
+    const engine = 'qwen-image';
+    const beforeCount = await readHist(WALLCLOCK_METRIC, '_count', engine, RECIPE);
+    const beforeSum = await readHist(WALLCLOCK_METRIC, '_sum', engine, RECIPE);
+
+    // A junk value from clock skew / stale submittedAt — dropped, not clamped, so
+    // it can't pollute `_sum` or the tail quantiles.
+    observeCustomComfyWallclockSeconds(engine, RECIPE, MAX_CUSTOMCOMFY_WALLCLOCK_SECONDS + 1);
+
+    expect(await readHist(WALLCLOCK_METRIC, '_count', engine, RECIPE)).toBe(beforeCount);
+    expect(await readHist(WALLCLOCK_METRIC, '_sum', engine, RECIPE)).toBe(beforeSum);
+  });
+
+  it('observes a value exactly at the MAX boundary (inclusive)', async () => {
+    const engine = 'qwen-image';
+    const beforeCount = await readHist(WALLCLOCK_METRIC, '_count', engine, RECIPE);
+
+    observeCustomComfyWallclockSeconds(engine, RECIPE, MAX_CUSTOMCOMFY_WALLCLOCK_SECONDS);
+
+    expect(await readHist(WALLCLOCK_METRIC, '_count', engine, RECIPE)).toBe(beforeCount + 1);
+  });
+
+  it('never throws on bad input', () => {
+    expect(() =>
+      observeCustomComfyWallclockSeconds('qwen-image', RECIPE, Infinity)
+    ).not.toThrow();
+    expect(() =>
+      observeCustomComfyWallclockSeconds('qwen-image', RECIPE, undefined as unknown as number)
+    ).not.toThrow();
+  });
+});

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -162,6 +162,17 @@ const CUSTOMCOMFY_BUZZ_BUCKETS = [10, 20, 30, 45, 60, 90, 120, 150, 180, 200];
 // timeout (the clip-risk the metric exists to surface).
 const CUSTOMCOMFY_WALLCLOCK_BUCKETS = [5, 10, 20, 30, 45, 60, 90, 120, 150, 180, 200, 240];
 
+// Upper sanity bound on an observed wall-clock sample. The submit→terminal
+// wall-clock is `Date.now() - record.submittedAt`, a derived delta that a
+// clock skew, a stale/corrupt `submittedAt`, or a pathologically long
+// terminal-observation gap could inflate into a junk value far past any real
+// gen. The physical cap is the per-engine step timeout (≤180s today); 600s
+// (~10min) sits comfortably above any real queue-wait + exec for a 180s-max
+// step yet well past the 240s top bucket, so a legitimate slow gen is still
+// observed while a nonsense value is DROPPED (not clamped — a clamp would fold
+// junk onto the +Inf edge and pollute `_sum`/quantiles).
+export const MAX_CUSTOMCOMFY_WALLCLOCK_SECONDS = 600;
+
 /**
  * Idempotent: safe to call on every request. Returns the metric instances
  * (existing or newly created) from the default registry that /api/metrics
@@ -260,7 +271,10 @@ export function observeCustomComfyActualBuzz(
 /**
  * Fail-soft emit of the submit→terminal-observation wall-clock (seconds, incl.
  * GPU queue-wait) for one customComfy gen. Same never-throw contract as above.
- * Skips a non-positive/`NaN` value.
+ * DROPS (does not observe) a value that is non-positive/`NaN` OR above
+ * `MAX_CUSTOMCOMFY_WALLCLOCK_SECONDS` — a junk delta from clock skew / a stale
+ * `submittedAt` would otherwise pollute `_sum` and the tail quantiles. Dropping
+ * (not clamping) keeps the histogram honest.
  */
 export function observeCustomComfyWallclockSeconds(
   engine: string,
@@ -269,6 +283,7 @@ export function observeCustomComfyWallclockSeconds(
 ): void {
   try {
     if (!Number.isFinite(seconds) || seconds <= 0) return;
+    if (seconds > MAX_CUSTOMCOMFY_WALLCLOCK_SECONDS) return;
     const { customComfyWallclockSeconds } = ensureRegisterAppBlockRuntimeMetrics();
     customComfyWallclockSeconds.observe({ engine, recipe }, seconds);
   } catch {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5388,12 +5388,15 @@ async function submitCustomComfyWorkflow(opts: {
 
   // Resolve the engine + recipe id purely for per-engine settle-time
   // OBSERVABILITY (persisted in the settle record, read at terminal to emit
-  // `civitai_app_block_customcomfy_actual_buzz` / `_wallclock_seconds`). Mirrors
-  // the recipe's own `params.engine ?? default` resolution — `recipe.engines[0]`
-  // is the declared default (== DEFAULT_ENGINE for seamless-pano). Both labels are
-  // strict enums (engine ∈ 3, recipe ∈ 1) → cardinality-safe. Never affects spend.
-  const engine: string =
-    (params as { engine?: string }).engine ?? recipe.engines[0] ?? 'unknown';
+  // `civitai_app_block_customcomfy_actual_buzz` / `_wallclock_seconds`). Uses the
+  // recipe's OWN `resolveEngine` — the SAME resolution that drives the CHARGED
+  // ceiling (`budgetFor`) and the built graph — so the observed LABEL can never
+  // drift from what was actually charged/run (a latent mislabel for any future
+  // recipe whose `engines[0] !== its default`). Both labels are strict enums
+  // (engine ∈ 3, recipe ∈ 1) → cardinality-safe. Never affects spend. The
+  // `?? 'unknown'` stays as truly-unreachable defense (resolveEngine always
+  // returns a bounded engine id).
+  const engine: string = recipe.resolveEngine(params) ?? 'unknown';
   const recipeId: string = recipe.id;
 
   // (1) STATIC pre-submit gate — the post-paid analog of the txt2img whatIf

--- a/src/server/services/blocks/__tests__/custom-comfy-settle.service.test.ts
+++ b/src/server/services/blocks/__tests__/custom-comfy-settle.service.test.ts
@@ -341,5 +341,51 @@ describe('settleCustomComfySpend', () => {
       await settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 20 });
       expect(mockObserveActualBuzz).toHaveBeenCalledWith('zimage-turbo', 'unknown', 20);
     });
+
+    // ── Finding-1 regression guard: the MONEY path must survive a throwing emit.
+    // The two helpers each carry an internal try/catch, but the never-throw
+    // guarantee on the refund path must NOT depend on that never regressing —
+    // the settle service wraps the emit block in its OWN try/catch. This test
+    // makes the emit THROW and asserts the refund DECRBYs on ALL applicable keys
+    // still fire (settle completes, Buzz refunded). Without the service-level
+    // wrap this throw escapes before the `refund <= 0` check → the DECRBYs never
+    // run → RED. (A real fail-on-revert, not a tautology.)
+    it('still refunds ALL keys when the actual-Buzz emit THROWS (service-level fail-soft)', async () => {
+      mockObserveActualBuzz.mockImplementation(() => {
+        throw new Error('metrics registry exploded');
+      });
+      seedRecord({
+        appSpendKey: APP_KEY,
+        devSessionId: DEV_SESSION_ID,
+        ceiling: 180,
+        engine: 'qwen-image',
+        recipe: 'seamless-pano-360',
+        submittedAt: 1_700_000_000_000,
+      });
+      await expect(
+        settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 })
+      ).resolves.toBeUndefined(); // never throws into poll/cancel
+      // Every refund leg still fires with the correct over-reservation (180-30=150).
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
+      expect(mockRefundAppSpend).toHaveBeenCalledWith(APP_KEY, 150);
+      expect(mockRefundDevSessionBuzz).toHaveBeenCalledWith(DEV_SESSION_ID, 150);
+    });
+
+    it('still refunds when the WALL-CLOCK emit throws (the second emit is also guarded)', async () => {
+      mockObserveWallclock.mockImplementation(() => {
+        throw new Error('metrics registry exploded');
+      });
+      seedRecord({
+        ceiling: 180,
+        engine: 'qwen-image',
+        recipe: 'seamless-pano-360',
+        submittedAt: 1_700_000_000_000,
+      });
+      await expect(
+        settleCustomComfySpend({ workflowId: 'wf_1', actualCost: 30 })
+      ).resolves.toBeUndefined();
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(BUZZ_KEY, 150);
+      expect(mockRefundAppSpend).toHaveBeenCalledWith(APP_KEY, 150);
+    });
   });
 });

--- a/src/server/services/blocks/custom-comfy-settle.service.ts
+++ b/src/server/services/blocks/custom-comfy-settle.service.ts
@@ -180,24 +180,35 @@ export async function settleCustomComfySpend(input: {
   // ── Per-engine runtime/cost OBSERVABILITY (instrument-ahead-of-demand) ───────
   // Emitted BEFORE the refund early-return below so a job that spent the FULL
   // ceiling (actual >= ceiling → refund 0 → the ceiling-pressing case we most
-  // want to see) is still observed. Fail-soft in the metric helpers — a metrics
-  // error can never perturb the refund math that follows. Only for a record that
-  // carries the engine (every real customComfy submit going forward).
-  if (record.engine) {
-    const recipeLabel = record.recipe ?? 'unknown';
-    // GPU-runtime ≈ billed `actual` Buzz. Helper skips a 0/failed/no-op gen.
-    observeCustomComfyActualBuzz(record.engine, recipeLabel, actual);
-    // Wall-clock incl. queue: submit→THIS terminal observation. Emitted
-    // independently of `actual` so a job clipped at its timeout with ~0 accrued
-    // Buzz (the purest clip signal) is still captured. Helper skips a non-positive
-    // value.
-    if (typeof record.submittedAt === 'number') {
-      observeCustomComfyWallclockSeconds(
-        record.engine,
-        recipeLabel,
-        (Date.now() - record.submittedAt) / 1000
-      );
+  // want to see) is still observed. Only for a record that carries the engine
+  // (every real customComfy submit going forward).
+  //
+  // BELT-AND-SUSPENDERS FAIL-SOFT: the two helpers already each wrap their emit
+  // in an internal try/catch, so this is redundant TODAY — but the never-throw
+  // guarantee on the MONEY path (the refund + all three DECRBYs below) must NOT
+  // depend on that internal catch never regressing. Wrapping the whole emit block
+  // here makes the invariant structural at the call site: even if an emit throws
+  // (a future helper edit, a synchronous label-validation error, etc.), the
+  // `refund <= 0` check + every refund below still execute unchanged.
+  try {
+    if (record.engine) {
+      const recipeLabel = record.recipe ?? 'unknown';
+      // GPU-runtime ≈ billed `actual` Buzz. Helper skips a 0/failed/no-op gen.
+      observeCustomComfyActualBuzz(record.engine, recipeLabel, actual);
+      // Wall-clock incl. queue: submit→THIS terminal observation. Emitted
+      // independently of `actual` so a job clipped at its timeout with ~0 accrued
+      // Buzz (the purest clip signal) is still captured. Helper skips a non-positive
+      // value.
+      if (typeof record.submittedAt === 'number') {
+        observeCustomComfyWallclockSeconds(
+          record.engine,
+          recipeLabel,
+          (Date.now() - record.submittedAt) / 1000
+        );
+      }
     }
+  } catch {
+    /* instrument-only — a metrics emit error can NEVER perturb the refund below */
   }
 
   const refund = Math.max(0, ceiling - actual);

--- a/src/server/services/blocks/recipes/index.ts
+++ b/src/server/services/blocks/recipes/index.ts
@@ -102,6 +102,15 @@ export interface BlockRecipe<P = unknown> {
   /** Which engine variants this recipe exposes (drives which builder runs). */
   engines: readonly string[];
   /**
+   * The SINGLE source of truth for "which engine did this submit resolve to?"
+   * (`params.engine ?? <recipe default>`). The per-engine BUDGET (`budgetFor`),
+   * the built graph (`buildStep`), the display estimate (`estimateBuzz`) and the
+   * settle-time METRIC LABEL (blocks.router) MUST all agree on this one value —
+   * so they all derive it here rather than each re-spelling `params.engine ??
+   * engines[0]`. Returns a bounded engine id from `engines` (never client-raw).
+   */
+  resolveEngine(params: P): string;
+  /**
    * PURE builder: bounded params + resolved resources → the customComfy step
    * INPUT. Ported from panorama.ts; builds a ComfyGraph by OBJECT CONSTRUCTION
    * only (the prompt is a leaf string, never templated into the graph).

--- a/src/server/services/blocks/recipes/seamless-pano.recipe.ts
+++ b/src/server/services/blocks/recipes/seamless-pano.recipe.ts
@@ -28,6 +28,17 @@ export type SeamlessPanoEngine = (typeof SEAMLESS_PANO_ENGINES)[number];
 /** v1 default engine — cheapest/fastest (Z-Image Turbo, ~20 Buzz display estimate). */
 export const DEFAULT_ENGINE: SeamlessPanoEngine = 'zimage-turbo';
 
+/**
+ * The SINGLE resolution of "which engine did this submit pick" — `params.engine`
+ * or the recipe default. Every per-engine derivation (budget ceiling, built
+ * graph, display estimate, settle-time metric label) funnels through this so the
+ * CHARGED ceiling and the OBSERVED label can never drift. Returns a bounded
+ * `SeamlessPanoEngine` (params.engine is enum-validated by the schema).
+ */
+export function resolveEngine(params: SeamlessPanoParams): SeamlessPanoEngine {
+  return params.engine ?? DEFAULT_ENGINE;
+}
+
 // ── Prompt shaping ───────────────────────────────────────────────────────────
 // The block schema already caps prompt at 1500; we re-clamp here so the ported
 // builders stay byte-identical to the reference oracle for any input.
@@ -533,7 +544,7 @@ export function buildFlux2SeamlessGraph(params: SeamlessPanoParams): ComfyGraph 
  * changes if a future prepaid path registers it as a `$type:'comfy'` definition.
  */
 function buildStep(params: SeamlessPanoParams): CustomComfyStepInput {
-  const engine = params.engine ?? DEFAULT_ENGINE;
+  const engine = resolveEngine(params);
   const [resources, workflow] =
     engine === 'flux2-klein'
       ? ([[FLUX2_DIFFUSION_AIR, FLUX2_CLIP_AIR, FLUX2_VAE_AIR, FLUX2_LORA_AIR], buildFlux2SeamlessGraph(params)] as const)
@@ -550,6 +561,7 @@ export const seamlessPano360Recipe: BlockRecipe<SeamlessPanoParams> = {
   id: 'seamless-pano-360',
   paramSchema: seamlessPanoParamSchema,
   engines: SEAMLESS_PANO_ENGINES,
+  resolveEngine,
   buildStep,
   resourceAllowlist: {
     // No civitai checkpoint (DiT engines have no UNet checkpoint; pinned policy).
@@ -583,7 +595,7 @@ export const seamlessPano360Recipe: BlockRecipe<SeamlessPanoParams> = {
   budgetForEngine: (engine) =>
     BUDGET_BY_ENGINE[engine as SeamlessPanoEngine] ?? BUDGET_BY_ENGINE[DEFAULT_ENGINE],
   budgetFor: (params) =>
-    BUDGET_BY_ENGINE[params.engine ?? DEFAULT_ENGINE] ?? BUDGET_BY_ENGINE[DEFAULT_ENGINE],
-  estimateBuzz: (params) => ESTIMATE_BUZZ_BY_ENGINE[params.engine ?? DEFAULT_ENGINE],
+    BUDGET_BY_ENGINE[resolveEngine(params)] ?? BUDGET_BY_ENGINE[DEFAULT_ENGINE],
+  estimateBuzz: (params) => ESTIMATE_BUZZ_BY_ENGINE[resolveEngine(params)],
   negativePrompt: NEGATIVE_PROMPT,
 };


### PR DESCRIPTION
Follow-up to #3271 (per-engine customComfy runtime/cost metrics). Closes the audit findings on that already-merged PR.

**Scope:** DARK, mod-gated App Blocks `customComfy` settle/refund path. No behavior change — the metric emit stays strictly non-perturbing to the refund. Byte-identical charging/labels today; these are defensive/latent-bug fixes.

### Findings addressed

**Finding 1 (fail-soft on the money path).** `settleCustomComfySpend` now wraps the metric-emit block in its OWN `try/catch` in the service, so the never-throw guarantee on the refund path no longer depends solely on the two helpers' internal catch. Even if an emit throws, the `refund <= 0` check + all three DECRBY refunds (per-user daily, per-app aggregate, dev-session) still execute unchanged. Two new tests make the emit throw and assert every refund still fires — verified they go RED against the un-wrapped code path (real fail-on-revert guard, not a tautology).

**Finding 2 (upper bound on wall-clock — drop, don't clamp).** `observeCustomComfyWallclockSeconds` now DROPS a value above `MAX_CUSTOMCOMFY_WALLCLOCK_SECONDS = 600` (~10min, well above any real queue+exec for a 180s-max-timeout gen, past the 240s top bucket) in addition to the existing `<= 0` drop. Dropping (not clamping) avoids a junk observation polluting `_sum` / tail quantiles when clock skew or a stale `submittedAt` inflates the derived delta.

**Finding 3 (single source of truth for the resolved engine).** Added `resolveEngine(params)` to the `BlockRecipe` interface + seamless-pano impl (`params.engine ?? DEFAULT_ENGINE`). `budgetFor`, `estimateBuzz`, `buildStep` and the router's metric-label site all funnel through it, so the OBSERVED engine label and the CHARGED-ceiling derivation share one resolution. Byte-identical today (zimage default `== engines[0]`); fixes a latent mislabel for any future recipe whose `engines[0] != DEFAULT_ENGINE`. The `?? 'unknown'` fallback stays as truly-unreachable defense.

**Finding 6 (direct unit tests on the two helpers).** New `src/server/metrics/__tests__/app-block-runtime.metrics.test.ts` exercises the REAL helpers against the real prom-client registry: `<= 0` / `NaN` / `> MAX` drop, in-range observe with the right `{engine, recipe}` labels, exact-boundary inclusive, and never-throws on bad input.

(Finding 5 — dashboard `_count` note — is a separate one-line change in the ops repo, not this PR.)

### Verification
- `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` -> exit 0, 0 errors.
- `vitest run --project unit` on the three suites -> 253 passed (settle 25 incl. 2 new throw-tests, router-workflow 220 unchanged, new metrics helper 8).
- Finding-1 throw-tests confirmed RED against the un-wrapped code, GREEN with the wrap restored.

Generated with [Claude Code](https://claude.com/claude-code)
