### PR TITLE
fix(event-engine): drain outbox rows only after handlers succeed

### DIFF
--- a/apps/event-engine/src/handlers/outbox.ts
+++ b/apps/event-engine/src/handlers/outbox.ts
@@ -10,16 +10,23 @@ export const outboxHandler = createEventHandler<OutboxRecord>({
   tables: ['Outbox'],
   operations: ['create'],
   processor: async (ctx) => {
-    const { event, entityType, entityId, details } = ctx.record;
-    // Mark the outbox record as processed/deleted
-    await ctx.actions.outboxRemove(ctx.record.id);
+    const { id, event, entityType, entityId, details } = ctx.record;
 
     const handlers = getOutboxHandlers(entityType, event)
 
-    // Run all matching handlers
+    // Run every matching handler FIRST, then drain (below). If a handler throws
+    // we never reach outboxRemove, so the row survives: the Kafka message isn't
+    // committed and redelivers (at-least-once), and the OutboxPoller can reconcile
+    // the row as a backstop. Removing the row before the handlers ran would drop
+    // the work on any handler failure — including poison-skipped messages — with
+    // nothing left for the poller to retry. Handlers are idempotent, so
+    // re-running on redelivery is safe.
     for (const handler of handlers) {
       await handler.process({ ...ctx, event, entityType, entityId, details });
     }
+
+    // Drain only after every handler succeeded.
+    await ctx.actions.outboxRemove(id);
   },
   debug: (faker) => ({
     sample: () => ({


### PR DESCRIPTION
The fast-path outbox handler removed the row BEFORE running its handlers (delete-then-process), so any handler failure — including poison-skipped Kafka messages — dropped the work with no row left for the OutboxPoller to reconcile. That undermines the poller as a backstop: it can only reconcile rows that still exist.

Reorder to process-then-delete: run every matching handler first, and call outboxRemove only after they all succeed. On failure we throw before the delete, so the row survives — Kafka redelivers (at-least-once) and, once OUTBOX_POLL_ENABLED is on, the poller reconciles it too. Handlers are idempotent, so re-running on redelivery/poll is safe. This matches the process-then-delete ordering the OutboxPoller already uses.

Kept the throw (rather than swallow-and-leave) because the poller currently defaults OFF: swallowing would leave a failed row retried by neither Kafka nor the poller. Once the poller is reliably enabled, switching the fast path to swallow-and-leave (log + return, no rethrow) avoids head-of-line-blocking the Outbox partition during an outage — a worthwhile follow-up.