### PR TITLE
feat(app-blocks): starter-comfy-txt2img recipe (cheap customComfy scaffold sample)

### DIFF
--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -213,10 +213,13 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
   // approaching its 150-Buzz / 150s ceiling?". EMPTY until real customComfy volume
   // accrues (DARK app code, mod-gated), by design.
   //
-  // Cardinality: engine ∈ {zimage-turbo, flux2-klein, qwen-image} (3) × recipe ∈
-  // {seamless-pano-360} (1) → 4 series/histogram today; both labels are strict
-  // enums resolved server-side from the code-owned recipe registry (never client
-  // input), so they can't blow up regardless of the wire.
+  // Cardinality: one `engine` label per recipe's engine(s) + one `recipe` label per
+  // registered recipe — both small server-side enums drawn from the code-owned recipe
+  // registry (never client input). Today that spans e.g. seamless-pano-360's engines
+  // {zimage-turbo, flux2-klein, qwen-image} plus starter-comfy-txt2img's {default}, so
+  // the series count grows by a handful with each new recipe/engine — always trivially
+  // bounded regardless of the wire (labels are free-form + fail-soft, but the values
+  // are enum-resolved from the registry, so they can't blow up).
   const customComfyActualBuzz = getOrCreateHistogram(
     reg,
     'civitai_app_block_customcomfy_actual_buzz',

--- a/src/server/services/blocks/recipes/__tests__/starter-comfy-txt2img.recipe.test.ts
+++ b/src/server/services/blocks/recipes/__tests__/starter-comfy-txt2img.recipe.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  STARTER_BUDGET,
+  STARTER_CFG,
+  STARTER_COMFY_ENGINES,
+  STARTER_ESTIMATE_BUZZ,
+  STARTER_HEIGHT,
+  STARTER_SHIFT,
+  STARTER_STEPS,
+  STARTER_WIDTH,
+  buildStarterTxt2imgGraph,
+  starterComfyParamSchema,
+  starterComfyTxt2imgRecipe,
+  type StarterComfyParams,
+} from '../starter-comfy-txt2img.recipe';
+import {
+  NEGATIVE_PROMPT,
+  PROMPT_MAX,
+  ZIMAGE_CLIP_AIR,
+  ZIMAGE_DIFFUSION_AIR,
+  ZIMAGE_VAE_AIR,
+} from '../seamless-pano.recipe';
+import {
+  REGISTERED_RECIPE_IDS,
+  getRecipe,
+  recipeCivitaiVersionIds,
+  type ComfyGraph,
+  type CustomComfyStepInput,
+} from '../index';
+
+const params = (prompt: string, seed?: number): StarterComfyParams => ({
+  prompt,
+  ...(seed !== undefined ? { seed } : {}),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GOLDEN-GRAPH — the minimal single-step Z-Image txt2img topology. A builder that
+// drifts (wrong link ref, class_type, or widget) fails here.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('buildStarterTxt2imgGraph (golden: minimal Z-Image txt2img)', () => {
+  const graph = buildStarterTxt2imgGraph(params('an icy lake', 42));
+
+  it('loads the Z-Image split model set: UNET, aura-flow shift, lumina2 clip, vae', () => {
+    expect(graph['1']).toEqual({
+      class_type: 'UNETLoader',
+      inputs: { unet_name: ZIMAGE_DIFFUSION_AIR, weight_dtype: 'default' },
+    });
+    expect(graph['2']).toEqual({
+      class_type: 'ModelSamplingAuraFlow',
+      inputs: { model: ['1', 0], shift: STARTER_SHIFT },
+    });
+    expect(graph['3'].inputs).toMatchObject({ clip_name: ZIMAGE_CLIP_AIR, type: 'lumina2' });
+    expect(graph['6'].inputs.vae_name).toBe(ZIMAGE_VAE_AIR);
+  });
+
+  it('has NO LoRA node — a plain single-step graph (no LoraLoaderModelOnly)', () => {
+    const classes = Object.values(graph).map((n) => n.class_type);
+    expect(classes).not.toContain('LoraLoaderModelOnly');
+  });
+
+  it('turbo sampling: 8 steps, cfg 1, euler/simple, single 1024×1024 latent', () => {
+    expect(graph['7']).toEqual({
+      class_type: 'EmptySD3LatentImage',
+      inputs: { width: STARTER_WIDTH, height: STARTER_HEIGHT, batch_size: 1 },
+    });
+    expect(STARTER_WIDTH).toBe(1024);
+    expect(STARTER_HEIGHT).toBe(1024);
+    expect(graph['8'].inputs).toMatchObject({
+      model: ['2', 0],
+      positive: ['4', 0],
+      negative: ['5', 0],
+      latent_image: ['7', 0],
+      seed: 42,
+      steps: STARTER_STEPS,
+      cfg: STARTER_CFG,
+      sampler_name: 'euler',
+      scheduler: 'simple',
+      denoise: 1.0,
+    });
+  });
+
+  it('the prompt is a LEAF string on the positive CLIPTextEncode; negative is inert (cfg 1)', () => {
+    expect(graph['4']).toEqual({
+      class_type: 'CLIPTextEncode',
+      inputs: { clip: ['3', 0], text: 'an icy lake' },
+    });
+    expect(graph['5'].inputs.text).toBe('');
+  });
+
+  it('decodes and saves — the terminal nodes wire straight through', () => {
+    expect(graph['9']).toEqual({
+      class_type: 'VAEDecode',
+      inputs: { samples: ['8', 0], vae: ['6', 0] },
+    });
+    expect(graph['10']).toMatchObject({ class_type: 'SaveImage', inputs: { images: ['9', 0] } });
+    // Exactly 10 nodes — the minimal graph, no seam-heal / roll nodes.
+    expect(Object.keys(graph)).toHaveLength(10);
+  });
+
+  it('randomizes the seed when omitted', () => {
+    const g = buildStarterTxt2imgGraph(params('a lake'));
+    const seed = g['8'].inputs.seed as number;
+    expect(Number.isInteger(seed)).toBe(true);
+    expect(seed).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Injection safety — a prompt with graph-hostile bytes yields a STRUCTURALLY
+// identical graph (object construction; prompt is a leaf). Plan §7-3.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('prompt injection safety', () => {
+  const MALICIOUS = 'a lake", "class_type": "Evil"}, "999": {{ </script> \\   end';
+  const structure = (g: ComfyGraph) =>
+    Object.fromEntries(Object.entries(g).map(([id, n]) => [id, n.class_type]));
+
+  it('hostile prompt does not perturb graph topology, lands as a leaf', () => {
+    const benign = buildStarterTxt2imgGraph(params('a lake', 7));
+    const hostile = buildStarterTxt2imgGraph(params(MALICIOUS, 7));
+    expect(structure(hostile)).toEqual(structure(benign));
+    expect(hostile['4'].inputs.text).toBe(MALICIOUS);
+    // Survives a JSON round-trip as a single escaped string value — never structure.
+    const revived = JSON.parse(JSON.stringify(hostile)) as ComfyGraph;
+    expect(structure(revived)).toEqual(structure(benign));
+    expect(revived['4'].inputs.text).toBe(MALICIOUS);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildStep — resources + trace (no engine axis).
+// ─────────────────────────────────────────────────────────────────────────────
+describe('recipe.buildStep', () => {
+  const build = (p: StarterComfyParams): CustomComfyStepInput =>
+    starterComfyTxt2imgRecipe.buildStep(p, {});
+
+  it('emits ONLY the three huggingface AIRs (no LoRA) + the binary trace', () => {
+    const step = build(params('a lake', 1));
+    expect(step.trace).toBe('binary');
+    expect(step.resources).toEqual([ZIMAGE_DIFFUSION_AIR, ZIMAGE_CLIP_AIR, ZIMAGE_VAE_AIR]);
+    expect(step.workflow['1'].class_type).toBe('UNETLoader');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Param schema — bounded + strict, no engine, no checkpoint.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('starterComfyParamSchema', () => {
+  it('accepts the bounded shape', () => {
+    expect(
+      starterComfyParamSchema.safeParse({ prompt: 'x', seed: 5, accountType: 'blue' }).success
+    ).toBe(true);
+  });
+  it('rejects a prompt over the cap', () => {
+    expect(starterComfyParamSchema.safeParse({ prompt: 'x'.repeat(PROMPT_MAX + 1) }).success).toBe(
+      false
+    );
+  });
+  it('rejects an engine field (single fixed graph — .strict())', () => {
+    expect(starterComfyParamSchema.safeParse({ prompt: 'x', engine: 'zimage-turbo' }).success).toBe(
+      false
+    );
+  });
+  it('rejects a checkpoint field (pinned policy — .strict())', () => {
+    expect(
+      starterComfyParamSchema.safeParse({ prompt: 'x', checkpoint: { modelId: 1, versionId: 2 } })
+        .success
+    ).toBe(false);
+  });
+  it('coerces a string seed and tolerates null', () => {
+    expect(starterComfyParamSchema.parse({ prompt: 'x', seed: '9' }).seed).toBe(9);
+    expect(starterComfyParamSchema.parse({ prompt: 'x', seed: null }).seed).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Recipe contract + registry wiring.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('starterComfyTxt2imgRecipe contract', () => {
+  it('is registered under its id and reachable via getRecipe', () => {
+    expect(REGISTERED_RECIPE_IDS).toContain('starter-comfy-txt2img');
+    expect(getRecipe('starter-comfy-txt2img')).toBe(starterComfyTxt2imgRecipe);
+  });
+
+  it('exposes a single nominal engine and resolves to it for any params', () => {
+    expect(STARTER_COMFY_ENGINES).toEqual(['default']);
+    expect(starterComfyTxt2imgRecipe.resolveEngine(params('x'))).toBe('default');
+    expect(starterComfyTxt2imgRecipe.resolveEngine(params('y', 7))).toBe('default');
+  });
+
+  it('honors the post-paid ceiling contract: maxBuzz === ceil(stepTimeoutSeconds) === 30', () => {
+    expect(STARTER_BUDGET).toEqual({ stepTimeoutSeconds: 30, maxBuzz: 30 });
+    expect(STARTER_BUDGET.maxBuzz).toBe(Math.ceil(STARTER_BUDGET.stepTimeoutSeconds));
+  });
+
+  it('budgetFor / budgetForEngine both return the ceiling-30 budget', () => {
+    expect(starterComfyTxt2imgRecipe.budgetFor(params('x'))).toEqual({
+      maxBuzz: 30,
+      stepTimeoutSeconds: 30,
+    });
+    expect(starterComfyTxt2imgRecipe.budgetForEngine('default')).toEqual({
+      maxBuzz: 30,
+      stepTimeoutSeconds: 30,
+    });
+  });
+
+  it('pins NO civitai resources → recipeCivitaiVersionIds is empty (entitlement gate skipped)', () => {
+    expect(starterComfyTxt2imgRecipe.checkpointPolicy).toBe('pinned');
+    expect(starterComfyTxt2imgRecipe.resourceAllowlist.checkpoints).toBeUndefined();
+    expect(starterComfyTxt2imgRecipe.resourceAllowlist.loras).toBeUndefined();
+    expect(recipeCivitaiVersionIds(starterComfyTxt2imgRecipe)).toEqual([]);
+  });
+
+  it('surfaces the fixed display estimate and a sensible negative prompt', () => {
+    expect(starterComfyTxt2imgRecipe.estimateBuzz(params('x'))).toBe(STARTER_ESTIMATE_BUZZ);
+    expect(STARTER_ESTIMATE_BUZZ).toBe(15);
+    expect(starterComfyTxt2imgRecipe.negativePrompt).toBe(NEGATIVE_PROMPT);
+  });
+});

--- a/src/server/services/blocks/recipes/__tests__/starter-comfy-txt2img.recipe.test.ts
+++ b/src/server/services/blocks/recipes/__tests__/starter-comfy-txt2img.recipe.test.ts
@@ -2,12 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   STARTER_BUDGET,
-  STARTER_CFG,
   STARTER_COMFY_ENGINES,
   STARTER_ESTIMATE_BUZZ,
   STARTER_HEIGHT,
-  STARTER_SHIFT,
-  STARTER_STEPS,
   STARTER_WIDTH,
   buildStarterTxt2imgGraph,
   starterComfyParamSchema,
@@ -48,7 +45,7 @@ describe('buildStarterTxt2imgGraph (golden: minimal Z-Image txt2img)', () => {
     });
     expect(graph['2']).toEqual({
       class_type: 'ModelSamplingAuraFlow',
-      inputs: { model: ['1', 0], shift: STARTER_SHIFT },
+      inputs: { model: ['1', 0], shift: 3.0 }, // STARTER_SHIFT — pinned literal so drift fails here
     });
     expect(graph['3'].inputs).toMatchObject({ clip_name: ZIMAGE_CLIP_AIR, type: 'lumina2' });
     expect(graph['6'].inputs.vae_name).toBe(ZIMAGE_VAE_AIR);
@@ -72,8 +69,8 @@ describe('buildStarterTxt2imgGraph (golden: minimal Z-Image txt2img)', () => {
       negative: ['5', 0],
       latent_image: ['7', 0],
       seed: 42,
-      steps: STARTER_STEPS,
-      cfg: STARTER_CFG,
+      steps: 8, // STARTER_STEPS — pinned literal (turbo step count) so a constant drift fails here
+      cfg: 1, // STARTER_CFG — pinned literal (guidance off) so a constant drift fails here
       sampler_name: 'euler',
       scheduler: 'simple',
       denoise: 1.0,

--- a/src/server/services/blocks/recipes/index.ts
+++ b/src/server/services/blocks/recipes/index.ts
@@ -1,5 +1,6 @@
 import type * as z from 'zod';
 import { seamlessPano360Recipe } from './seamless-pano.recipe';
+import { starterComfyTxt2imgRecipe } from './starter-comfy-txt2img.recipe';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // App Blocks `customComfy` recipe registry.
@@ -154,6 +155,10 @@ export type AnyBlockRecipe = BlockRecipe<any>;
 // The registry object. Its keys ARE the source of truth for the schema enum.
 const recipeRegistry = {
   'seamless-pano-360': seamlessPano360Recipe,
+  // Recipe #2 — the CLI scaffold's demoable starter: a minimal single-step Z-Image
+  // txt2img, no civitai resources (no entitlement gate), ceiling 30. See
+  // starter-comfy-txt2img.recipe.ts.
+  'starter-comfy-txt2img': starterComfyTxt2imgRecipe,
 };
 
 export type RegisteredRecipeId = keyof typeof recipeRegistry & string;

--- a/src/server/services/blocks/recipes/index.ts
+++ b/src/server/services/blocks/recipes/index.ts
@@ -79,6 +79,12 @@ export type RecipeCivitaiResource = {
 // verified Public / Published / non-early-access / non-Private — safe under this
 // invariant.
 //
+// #2 (`starter-comfy-txt2img`): pins NO civitai resources at all — its only model
+// weights are huggingface staticAirs, never a civitai `modelVersionId`. So
+// `recipeCivitaiVersionIds(recipe)` returns `[]` and the entitlement gate has
+// nothing to check → it's skipped entirely, and the recipe is safe by construction
+// (there is no pinned civitai version that could bypass the belt).
+//
 // This is a DOC-INVARIANT, enforced by CODE REVIEW of each new recipe PR — NOT a
 // module-load DB check (there is no DB in this module; the registry loads at
 // import time, before any request context). A robust router-side early-access /

--- a/src/server/services/blocks/recipes/starter-comfy-txt2img.recipe.ts
+++ b/src/server/services/blocks/recipes/starter-comfy-txt2img.recipe.ts
@@ -1,0 +1,213 @@
+import * as z from 'zod';
+import { buzzSpendTypes } from '~/shared/constants/buzz.constants';
+import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
+import type { BlockRecipe, ComfyGraph, CustomComfyStepInput } from './index';
+import {
+  NEGATIVE_PROMPT,
+  PROMPT_MAX,
+  ZIMAGE_CLIP_AIR,
+  ZIMAGE_DIFFUSION_AIR,
+  ZIMAGE_VAE_AIR,
+} from './seamless-pano.recipe';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// starter-comfy-txt2img — recipe #2 for the App Blocks `customComfy` bridge.
+//
+// The DEMOABLE STARTER: the recipe the CLI scaffold's default `customComfy` sample
+// invokes. Deliberately the CHEAPEST viable graph — a minimal single-step Z-Image
+// (DiT) txt2img producing one 1024×1024 image — so a new app author sees the
+// customComfy plumbing end-to-end (recipe id on the wire → server-authored graph →
+// post-paid budget belt → orchestrator) with the least moving parts. Real recipes
+// (seamless-pano-360, future ones) do things `kind:textToImage` cannot; this one
+// exists to show the WIRING, not a sophisticated workflow.
+//
+// 🔴 NO civitai-pinned resources. It pins ONLY huggingface `staticAirs` (the same
+// Z-Image diffusion/clip/vae AIRs seamless-pano reuses) — no `loras`, no
+// `checkpoints`. So `recipeCivitaiVersionIds(recipe)` returns `[]` and the router's
+// entitlement-gate loop (resolveCanGenerateForVersions over pinned versions) is
+// skipped entirely: the simplest, safest starter, sidestepping the early-access /
+// Private invariant (index.ts RESOURCE INVARIANT) by construction. `checkpointPolicy:
+// 'pinned'` (no user-picked checkpoint).
+//
+// Like every recipe module here: server-authored, code-reviewed, NEVER
+// runtime/DB-editable. The iframe sends `{ recipe:'starter-comfy-txt2img', params }`
+// and the server owns the graph in full. The prompt is ALWAYS a leaf string value
+// (object construction only — never string-templated into graph topology; the
+// injection-safety invariant, plan §7-3).
+//
+// DARK: customComfy is behind the mod-gated app-blocks flag. Adding this recipe
+// only widens the wire schema's `recipe` enum (derived from REGISTERED_RECIPE_IDS).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Single nominal engine — this recipe has ONE fixed graph (no engine axis, unlike
+ * seamless-pano's DiT variants), so `engines` is a single sentinel. Every
+ * per-engine derivation (budget ceiling, built graph, display estimate, settle
+ * label) funnels through `resolveEngine` → this value, per the #3273 pattern.
+ */
+export const STARTER_COMFY_ENGINES = ['default'] as const;
+export type StarterComfyEngine = (typeof STARTER_COMFY_ENGINES)[number];
+export const STARTER_COMFY_DEFAULT_ENGINE: StarterComfyEngine = 'default';
+
+// ── Graph tunables (Z-Image Turbo, mirrors the spine workers' own builder) ────
+// A plain 1024×1024 image — no panorama canvas, no LoRA, no seam-heal pass.
+export const STARTER_WIDTH = 1024;
+export const STARTER_HEIGHT = 1024;
+export const STARTER_STEPS = 8;
+export const STARTER_CFG = 1; // turbo: guidance off, so the negative encode is inert.
+export const STARTER_SHIFT = 3.0;
+export const STARTER_SAMPLER = 'euler';
+export const STARTER_SCHEDULER = 'simple';
+
+/** Fixed display estimate (post-paid has no exact pre-price — display only). A cheap Z-Image turbo gen runs in seconds. */
+export const STARTER_ESTIMATE_BUZZ = 15;
+
+// ── POST-PAID BUDGET (single engine) ──────────────────────────────────────────
+// `maxBuzz` MUST equal `ceil(stepTimeoutSeconds × 1)` (asserted at registry load):
+// the step `timeout` is the PHYSICAL cap (~1 Buzz/GPU-second). A cheap single-step
+// Z-Image turbo gen finishes in seconds, so 30 is generous headroom while keeping a
+// tight blast-radius ceiling. The router reserves this ceiling on every cap and
+// settles-to-actual.
+export const STARTER_BUDGET: { stepTimeoutSeconds: number; maxBuzz: number } = {
+  stepTimeoutSeconds: 30,
+  maxBuzz: 30,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Param schema — .strict(), no `engine` field (single fixed graph), no checkpoint
+// (pinned policy). Mirrors seamless-pano's schema MINUS the engine axis. The
+// account-type enum comes from the SAME source of truth (buzzSpendTypes) the block
+// schema's `blockAccountTypeSchema` uses — imported directly (not from
+// workflow.schema) to avoid a workflow.schema ⇄ recipes import cycle.
+// ─────────────────────────────────────────────────────────────────────────────
+export const starterComfyParamSchema = z
+  .object({
+    prompt: z.string().max(PROMPT_MAX),
+    seed: z.coerce.number().int().nullish(),
+    accountType: z.enum(buzzSpendTypes as [BuzzSpendType, ...BuzzSpendType[]]).optional(),
+  })
+  .strict();
+
+export type StarterComfyParams = z.infer<typeof starterComfyParamSchema>;
+
+/**
+ * The single resolution of "which engine did this submit pick". A one-engine recipe
+ * always resolves to the sentinel — kept as a method (not a constant) so the budget,
+ * graph, estimate and settle-label all derive the engine the SAME way seamless-pano
+ * does, so the CHARGED ceiling and the OBSERVED label can never drift.
+ */
+export function resolveEngine(_params: StarterComfyParams): StarterComfyEngine {
+  return STARTER_COMFY_DEFAULT_ENGINE;
+}
+
+function resolveSeed(seed: number | null | undefined): number {
+  return seed ?? Math.floor(Math.random() * 2_147_483_647);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Graph builder — object construction only. The prompt is ALWAYS a leaf string
+// value; there is NO string-templating of the graph structure (injection-safe by
+// construction, plan §7-3). Simplest viable Z-Image txt2img: diffusion loader →
+// aura-flow shift → clip → pos/neg encode → vae → empty latent → KSampler → decode
+// → save.
+// ─────────────────────────────────────────────────────────────────────────────
+export function buildStarterTxt2imgGraph(params: StarterComfyParams): ComfyGraph {
+  const seed = resolveSeed(params.seed);
+
+  return {
+    '1': {
+      class_type: 'UNETLoader',
+      inputs: { unet_name: ZIMAGE_DIFFUSION_AIR, weight_dtype: 'default' },
+    },
+    '2': {
+      class_type: 'ModelSamplingAuraFlow',
+      inputs: { model: ['1', 0], shift: STARTER_SHIFT },
+    },
+    '3': {
+      class_type: 'CLIPLoader',
+      inputs: { clip_name: ZIMAGE_CLIP_AIR, type: 'lumina2', device: 'default' },
+    },
+    '4': {
+      // Positive prompt — the raw user prompt as a LEAF string value.
+      class_type: 'CLIPTextEncode',
+      inputs: { clip: ['3', 0], text: params.prompt },
+    },
+    '5': {
+      // Negative — inert at cfg 1 (guidance off), wired for graph completeness.
+      class_type: 'CLIPTextEncode',
+      inputs: { clip: ['3', 0], text: '' },
+    },
+    '6': {
+      class_type: 'VAELoader',
+      inputs: { vae_name: ZIMAGE_VAE_AIR },
+    },
+    '7': {
+      class_type: 'EmptySD3LatentImage',
+      inputs: { width: STARTER_WIDTH, height: STARTER_HEIGHT, batch_size: 1 },
+    },
+    '8': {
+      class_type: 'KSampler',
+      inputs: {
+        model: ['2', 0],
+        positive: ['4', 0],
+        negative: ['5', 0],
+        latent_image: ['7', 0],
+        seed,
+        steps: STARTER_STEPS,
+        cfg: STARTER_CFG,
+        sampler_name: STARTER_SAMPLER,
+        scheduler: STARTER_SCHEDULER,
+        denoise: 1.0,
+      },
+    },
+    '9': {
+      class_type: 'VAEDecode',
+      inputs: { samples: ['8', 0], vae: ['6', 0] },
+    },
+    '10': {
+      class_type: 'SaveImage',
+      inputs: { images: ['9', 0], filename_prefix: 'starter' },
+    },
+  };
+}
+
+/**
+ * The reusable graph-construction step. Returns the `customComfy` step INPUT
+ * (`{ resources, trace, workflow }`). Only huggingface `staticAirs` — no gated
+ * civitai versions, so the router's entitlement loop is skipped. Deliberately
+ * separable from the `$type:'customComfy'` step wrapper so ONLY the wrapper (not
+ * this graph) changes if a future prepaid path registers it as `$type:'comfy'`.
+ */
+function buildStep(params: StarterComfyParams): CustomComfyStepInput {
+  return {
+    resources: [ZIMAGE_DIFFUSION_AIR, ZIMAGE_CLIP_AIR, ZIMAGE_VAE_AIR],
+    trace: 'binary',
+    workflow: buildStarterTxt2imgGraph(params),
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The recipe definition.
+// ─────────────────────────────────────────────────────────────────────────────
+export const starterComfyTxt2imgRecipe: BlockRecipe<StarterComfyParams> = {
+  id: 'starter-comfy-txt2img',
+  paramSchema: starterComfyParamSchema,
+  engines: STARTER_COMFY_ENGINES,
+  resolveEngine,
+  buildStep,
+  resourceAllowlist: {
+    // NO civitai resources (no checkpoints, no loras). Only huggingface AIRs —
+    // exempt-by-construction (code-reviewed) → recipeCivitaiVersionIds() === [] →
+    // the router's entitlement gate loop is skipped for this recipe.
+    staticAirs: [ZIMAGE_DIFFUSION_AIR, ZIMAGE_CLIP_AIR, ZIMAGE_VAE_AIR],
+  },
+  checkpointPolicy: 'pinned',
+  // Single-engine post-paid budget: maxBuzz === ceil(stepTimeoutSeconds) (30 === 30),
+  // asserted per-engine at registry load. See STARTER_BUDGET.
+  budgetForEngine: () => STARTER_BUDGET,
+  budgetFor: () => STARTER_BUDGET,
+  estimateBuzz: () => STARTER_ESTIMATE_BUZZ,
+  // Read by the router's prompt audit (a server-owned graph earns no moderation
+  // bypass). The graph itself keeps the negative encode inert (cfg 1).
+  negativePrompt: NEGATIVE_PROMPT,
+};


### PR DESCRIPTION
## What

Registers a second App Blocks `customComfy` recipe — **`starter-comfy-txt2img`** — the demoable recipe the CLI's default scaffold sample invokes. It shows the customComfy plumbing end-to-end (recipe id on the wire → server-authored graph → post-paid budget belt → orchestrator) with the fewest moving parts. Real recipes do things `kind:textToImage` can't; this one exists to show the WIRING.

## The recipe

- **Graph:** the simplest viable single-step **Z-Image (DiT) txt2img** — diffusion loader → aura-flow shift → CLIP → pos/neg encode → VAE → empty latent → KSampler → VAE-decode → SaveImage. A plain single **1024×1024** image: no LoRA, no panorama canvas, no seam-heal pass. The prompt is always a **leaf string** (object construction only — injection-safe, never templated into topology).
- 🔴 **No civitai-pinned resources.** Only huggingface `staticAirs` (the Z-Image diffusion/clip/vae AIRs reused from `seamless-pano`) — no `loras`, no `checkpoints`. So `recipeCivitaiVersionIds(recipe)` returns `[]` and the router's entitlement-gate loop is **skipped entirely**, sidestepping the early-access / Private invariant by construction. `checkpointPolicy: 'pinned'`.
- **Engine / budget:** single nominal engine `'default'`; post-paid **ceiling 30** (`maxBuzz === ceil(stepTimeoutSeconds) === 30`, enforced at registry load), reusing the audited per-engine budget belt. A cheap Z-Image turbo gen runs in seconds, so 30 is generous headroom. Display estimate 15.
- **Params (`.strict()`):** `{ prompt: string(≤1500), seed?, accountType? }` — seamless-pano's shape **minus the engine axis** (single fixed graph).
- Registered in `recipeRegistry`, which widens the wire schema's `recipe` enum (`REGISTERED_RECIPE_IDS`) automatically. The `kind` (`customComfy`) and the SDK are untouched.

## Tests

- Golden-graph test for `buildStep` / the graph builder: node structure, prompt-as-leaf, injection safety, no-LoRA, exactly 10 nodes.
- Registry/contract test: `getRecipe` resolves, `REGISTERED_RECIPE_IDS` includes it, `budgetFor`/`budgetForEngine`/`resolveEngine` return the expected values, `recipeCivitaiVersionIds` is `[]`, `.strict()` schema rejects `engine`/`checkpoint`.
- Re-ran `blocks.router.workflow` (220), `custom-comfy-settle.service` (25), `workflow.schema` (21), `seamless-pano.recipe` (30) — widening the enum breaks nothing.

## Safety

**DARK** — customComfy is behind the mod-gated app-blocks flag. Pure app logic; no infra internals.

## Verification

- `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` → exit 0.
- vitest (node `unit` project): starter recipe 19 ✓, seamless-pano 30 ✓, blocks.router.workflow 220 ✓, custom-comfy-settle 25 ✓, workflow.schema 21 ✓.
- Not exercised: no live generation (recipe is DARK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)