### PR TITLE
fix(event-engine): COPY packages so pnpm deploy resolves root workspace deps

### DIFF
--- a/apps/event-engine/Dockerfile
+++ b/apps/event-engine/Dockerfile
@@ -15,11 +15,15 @@ FROM node:22-alpine AS deps
 RUN apk add --no-cache libc6-compat && corepack enable && corepack prepare pnpm@10.28.1 --activate
 WORKDIR /app
 
-# Workspace manifests so the filtered frozen install resolves. This app depends on NO @civitai/* workspace
-# packages yet (it vendors event-engine-common under src/common and ships its own clients), so it does not
-# need `COPY packages`. patches/ is required because the root declares pnpm.patchedDependencies.
+# Workspace manifests so the filtered frozen install AND `pnpm deploy` resolve. This app ITSELF depends on
+# NO @civitai/* workspace packages (it vendors event-engine-common under src/common and ships its own
+# clients) — but the repo-root package.json (a workspace member via `.` in pnpm-workspace.yaml) declares
+# @civitai/{auth,buzz,shared}: workspace:*, and the prod-deps stage's `pnpm deploy --legacy` resolves the
+# root graph. Without packages/ present it fails ERR_PNPM_WORKSPACE_PKG_NOT_FOUND @civitai/auth (mirrors
+# apps/orchestrator-gateway/Dockerfile). patches/ is required because the root declares pnpm.patchedDependencies.
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY patches ./patches
+COPY packages ./packages
 COPY apps/event-engine/package.json ./apps/event-engine/package.json
 
 # --ignore-scripts skips the root's `db:generate` (Prisma) — this consumer uses raw pg, not the Prisma client.


### PR DESCRIPTION
The first Tekton release build of `event-engine-v1.9.8` failed at the `prod-deps` stage:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  "@civitai/auth@workspace:*" is in the dependencies but no package named "@civitai/auth" is present in the workspace
```

Root cause: `pnpm --filter @civitai/event-engine deploy --prod --legacy` resolves the repo-root `package.json` graph (the root is a workspace member via `.` in `pnpm-workspace.yaml`), which declares `@civitai/{auth,buzz,shared}: workspace:*` (all under `packages/`). event-engine's Dockerfile omitted `COPY packages` on the assumption that the app itself has no `@civitai/*` deps — true for the app, but the deploy step still needs the root graph to resolve.

Fix: add `COPY packages ./packages` to the `deps` stage, exactly as `apps/orchestrator-gateway/Dockerfile` does. `deps`/`build` stages were already green; this unblocks `prod-deps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)