### PR TITLE
feat(early-access): permanent pay-for-access foundation (schema + trigger + migration)

### DIFF
--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -1041,6 +1041,7 @@ model ModelVersion {
   nsfwLevel            Int               @default(0)
   earlyAccessEndsAt    DateTime?
   earlyAccessConfig    Json?
+  earlyAccessPermanent Boolean           @default(false)
   uploadType           ModelUploadType   @default(Created)
   usageControl         ModelUsageControl @default(Download)
   earlyAccessTimeFrame Int               @default(0)

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -2675,6 +2675,7 @@ export type ModelVersion = {
   nsfwLevel: Generated<number>;
   earlyAccessEndsAt: Timestamp | null;
   earlyAccessConfig: unknown | null;
+  earlyAccessPermanent: Generated<boolean>;
   uploadType: Generated<ModelUploadType>;
   usageControl: Generated<ModelUsageControl>;
   earlyAccessTimeFrame: Generated<number>;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -918,6 +918,7 @@ export interface ModelVersion {
   nsfwLevel: number;
   earlyAccessEndsAt: Date | null;
   earlyAccessConfig: JsonValue | null;
+  earlyAccessPermanent: boolean;
   uploadType: ModelUploadType;
   usageControl: ModelUsageControl;
   earlyAccessTimeFrame: number;

--- a/prisma/migrations/20260721120000_early_access_permanent/migration.sql
+++ b/prisma/migrations/20260721120000_early_access_permanent/migration.sql
@@ -1,8 +1,24 @@
+-- Permanent pay-for-access (CU 868ke4949).
+--
+-- SAFE TO RUN BEFORE THE CODE DEPLOY: purely additive. The new column defaults false, and the rewritten
+-- trigger only takes its new "permanent" branch when a version's earlyAccessConfig carries a `permanent`
+-- flag — which no existing row has and only the (not-yet-deployed) new code writes. So for every current
+-- row the trigger behaves exactly as before, and the running (old) code simply ignores the new column.
+
+-- 1. Additive column. NULL-safe: default false = no behavior change for existing rows.
+ALTER TABLE "ModelVersion"
+  ADD COLUMN IF NOT EXISTS "earlyAccessPermanent" boolean NOT NULL DEFAULT false;
+
+-- 2. Rewrite the early-access trigger with a highest-precedence "permanent" branch. A permanent version
+--    keeps earlyAccessEndsAt NULL (so the auto-expiry job — which filters earlyAccessEndsAt <= NOW() —
+--    never touches it) but stays availability = 'EarlyAccess' so every paywall still gates it. The
+--    "earlyAccessPermanent" column is derived here from the config flag (tracked even before publish, so a
+--    member can configure permanent access on an unpublished version). Behavior for non-permanent rows is
+--    unchanged. Permanent detection uses a text comparison (not ::boolean) so a malformed value can't abort
+--    the transaction.
 CREATE OR REPLACE FUNCTION early_access_ends_at()
 RETURNS TRIGGER AS $$
 DECLARE
-    -- Text comparison instead of a ::boolean cast, so a malformed value (only reachable via raw SQL — the tRPC
-    -- write path is zod-validated) can never raise and abort the enclosing publish/update transaction.
     is_permanent boolean := COALESCE(
         NEW."earlyAccessConfig" IS NOT NULL
         AND (NEW."earlyAccessConfig"->>'permanent') = 'true',
@@ -10,11 +26,6 @@ DECLARE
     );
 BEGIN
     IF is_permanent THEN
-        -- Permanent paid access (highest precedence): gated indefinitely. The column is tracked even before
-        -- publish, so a Creator-Program member can configure permanent access on an unpublished version and have
-        -- it counted/known immediately. Once published, keep "earlyAccessEndsAt" NULL (the auto-expiry job filters
-        -- "earlyAccessEndsAt" <= NOW(), so NULL excludes it) and "availability" = 'EarlyAccess' so every paywall
-        -- still gates it.
         IF NEW."publishedAt" IS NOT NULL THEN
             UPDATE "ModelVersion"
             SET "earlyAccessEndsAt" = NULL,
@@ -46,8 +57,7 @@ BEGIN
                 "earlyAccessPermanent" = false
             WHERE id = NEW.id;
         ELSE
-            -- Unpublished + not permanent: only clear a previously-set permanent flag (e.g. permanent -> off
-            -- before publish); otherwise leave the row untouched, matching the original no-op behavior.
+            -- Unpublished + not permanent: only clear a previously-set permanent flag; otherwise no-op.
             UPDATE "ModelVersion"
             SET "earlyAccessPermanent" = false
             WHERE id = NEW.id
@@ -58,7 +68,7 @@ BEGIN
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
----
+
 CREATE OR REPLACE TRIGGER trigger_early_access_ends_at
 AFTER INSERT OR UPDATE OF "earlyAccessConfig", "publishedAt" ON "ModelVersion"
 FOR EACH ROW

--- a/src/server/schema/model-version.schema.ts
+++ b/src/server/schema/model-version.schema.ts
@@ -363,6 +363,9 @@ export const MAX_LICENSING_FEE = 100;
 export type ModelVersionEarlyAccessConfig = z.infer<typeof modelVersionEarlyAccessConfigSchema>;
 export const modelVersionEarlyAccessConfigSchema = z.object({
   timeframe: z.number(),
+  // Permanent pay-for-access (CU 868ke4949): the gate never expires. Creator-Program-member-only; enforced
+  // at the write endpoint. `timeframe` is 0 for permanent (the trigger's permanent branch ignores it).
+  permanent: z.boolean().optional().default(false),
   chargeForDownload: z.boolean().default(false),
   downloadPrice: z.number().min(100).max(MAX_DONATION_GOAL).optional(),
   chargeForGeneration: z.boolean().default(false),


### PR DESCRIPTION
Foundation for gating a model version behind payment indefinitely (CU 868ke4949), extending the early-access system. Write-path enforcement + paywall sites land in follow-up commits.

- Add ModelVersion.earlyAccessPermanent (Boolean, default false) to schema.full.prisma; regenerate the slim schema, Prisma client, models.ts and Kysely types.
- Add `permanent` to the earlyAccessConfig zod schema.
- Rewrite the early_access trigger with a highest-precedence permanent branch: a permanent version keeps earlyAccessEndsAt NULL (so the auto-expiry job, which filters earlyAccessEndsAt <= NOW(), skips it) but stays availability = 'EarlyAccess' so paywalls still gate it. The column is derived from the config flag and tracked even before publish (a member can configure permanent access on an unpublished version). Permanent detection uses a text comparison (not ::boolean) so a malformed value can't abort the transaction.
- Migration 20260721120000_early_access_permanent: additive column + trigger rewrite. SAFE TO APPLY BEFORE THE CODE DEPLOY -- no existing row has the flag, so the new branch never fires and behavior is identical; old code ignores the new column. Apply manually (not via prisma migrate deploy).