### PR TITLE
fix(event-engine): ship @clickhouse/client 1.12.x in the built image

### DIFF
--- a/apps/event-engine/Dockerfile
+++ b/apps/event-engine/Dockerfile
@@ -15,11 +15,11 @@ FROM node:22-alpine AS deps
 RUN apk add --no-cache libc6-compat && corepack enable && corepack prepare pnpm@10.28.1 --activate
 WORKDIR /app
 
-# Workspace manifests so the filtered frozen install AND `pnpm deploy` resolve. This app ITSELF depends on
+# Workspace manifests so the filtered frozen install resolves. This app ITSELF depends on
 # NO @civitai/* workspace packages (it vendors event-engine-common under src/common and ships its own
 # clients) — but the repo-root package.json (a workspace member via `.` in pnpm-workspace.yaml) declares
-# @civitai/{auth,buzz,shared}: workspace:*, and the prod-deps stage's `pnpm deploy --legacy` resolves the
-# root graph. Without packages/ present it fails ERR_PNPM_WORKSPACE_PKG_NOT_FOUND @civitai/auth (mirrors
+# @civitai/{auth,buzz,shared}: workspace:*, so the filtered frozen install below must see the workspace.
+# Without packages/ present it fails ERR_PNPM_WORKSPACE_PKG_NOT_FOUND @civitai/auth (mirrors
 # apps/orchestrator-gateway/Dockerfile). patches/ is required because the root declares pnpm.patchedDependencies.
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
 COPY patches ./patches
@@ -36,11 +36,22 @@ WORKDIR /app
 COPY apps/event-engine ./apps/event-engine
 RUN pnpm --filter @civitai/event-engine build
 
-##### prod-deps — pruned, flattened production node_modules #####################
+##### prod-deps — pruned, isolated production node_modules ######################
+# Deploy event-engine's OWN dependency closure (non-legacy). We must NOT use `--legacy`
+# here: legacy `pnpm deploy` builds a flat/hoisted tree from the WHOLE workspace graph and
+# hoists a single version of each package to the top level. The repo root (a workspace
+# member) declares `@clickhouse/client@^0.2.2`; event-engine declares `@clickhouse/client@^1.12.1`
+# (a major API break). Under `--legacy`, the root's 0.2.x won the hoist, so the built image
+# shipped `@clickhouse/client@0.2.x` at the top level even though event-engine's own manifest
+# pins ^1.12.1 — every ClickHouse insert then failed at runtime. Non-legacy deploy resolves
+# ONLY event-engine's closure and preserves per-package version isolation, so it links 1.12.x.
+# pnpm 10 gates non-legacy deploy behind `inject-workspace-packages` — event-engine depends on
+# NO @civitai/* workspace package, so injection is a no-op here; we just need the gate open.
 FROM deps AS prod-deps
 WORKDIR /app
 RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
-    pnpm --filter @civitai/event-engine deploy --prod --legacy --ignore-scripts /app/deploy
+    pnpm --filter @civitai/event-engine deploy --prod --ignore-scripts \
+    --config.inject-workspace-packages=true /app/deploy
 
 ##### runtime ###################################################################
 FROM node:22-alpine AS runtime


### PR DESCRIPTION
## Problem

`apps/event-engine` was just wired into the monorepo build. Its released image shipped **`@clickhouse/client@0.2.x`**, but the app code targets **`@clickhouse/client@^1.12.1`** — a major API break between `0.2.x` and `1.x`. Result: every ClickHouse metric-batch insert failed silently in prod (0 flushes, queue backing up), so the cutover was rolled back. The standalone predecessor built with `1.12.1` and worked — this is a lift-and-shift dependency-resolution regression.

## Root cause (the exact mechanism)

The lockfile is **correct**: the `apps/event-engine` importer resolves `@clickhouse/client` to `1.23.1` (satisfying `^1.12.1`), while the root importer resolves the main app's `^0.2.2` to `0.2.10`. Both versions coexist in `pnpm-lock.yaml` as they should.

The regression is in the **prod-deps stage's `pnpm deploy --legacy`**. Legacy deploy builds a **flat/hoisted** `node_modules` from the **whole workspace graph** and hoists a *single* version of each package to the top level. Because the repo root (a workspace member via `.`) declares `@clickhouse/client@^0.2.2`, the root's `0.2.10` **won the top-level hoist** — so event-engine's own direct dependency ended up symlinked to `0.2.10`, a version that does **not even satisfy** event-engine's own `^1.12.1` specifier.

Reproduced locally with the exact Dockerfile flow (pnpm 10.28.1):

```
# --legacy deploy tree:
node_modules/@clickhouse/client -> ../.pnpm/@clickhouse+client@0.2.10/...   # WRONG
# (the 1.23.1 copy exists in .pnpm but is not linked to the top level)
```

## Fix

Drop `--legacy` for **event-engine's** deploy only. Non-legacy `pnpm deploy` resolves **only event-engine's own dependency closure** and preserves per-package version isolation, so it links `1.12.x`. pnpm 10 gates non-legacy deploy behind `inject-workspace-packages`; event-engine depends on **no** `@civitai/*` workspace package, so injection is a no-op — we just open the gate via `--config.inject-workspace-packages=true`.

Single-file change (`apps/event-engine/Dockerfile`). The shared root `package.json` and `pnpm-lock.yaml` are **untouched**, so `auth` / `notifications` / `orchestrator-gateway` / `storage` / `creator-studio` (all still on `--legacy`, reading the same unchanged manifests) are unaffected. Bonus: the deploy tree shrinks from ~1585 spurious packages (the whole root graph) to event-engine's real ~103-package closure.

## Proof (before / after)

| | top-level `@clickhouse/client` |
|---|---|
| **before** (`--legacy`) | `0.2.10` ❌ (violates `^1.12.1`) |
| **after** (non-legacy) | `1.23.1` ✅ |

Truest end-to-end — full `docker build -f apps/event-engine/Dockerfile .` then run the built image:

```
$ docker run --rm --entrypoint node ee-test \
    -e "console.log(require('@clickhouse/client/package.json').version)"
1.23.1
# createClient is a function (1.x API); no 0.2.x present anywhere in the image
```
