### PR TITLE
fix(challenge): raise text-scan recall from 10% to 90%

### DIFF
--- a/src/server/games/daily-challenge/__tests__/challenge-text-scan.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-text-scan.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHALLENGE_NSFW_SCORE_THRESHOLD,
+  isChallengeTextNsfw,
+} from '~/server/games/daily-challenge/challenge-text-scan';
+
+// Scores below are real XGuard output, captured by replaying every challenge in the corpus (214)
+// through the text scanner. Each case names the challenge it came from so the fixtures stay
+// traceable to the run that motivated the thresholds.
+const scores = (results: Record<string, number>) =>
+  Object.entries(results).map(([label, score]) => ({ label, score }));
+
+describe('isChallengeTextNsfw', () => {
+  it('flags a green challenge whose theme is overtly sexual (challenge 416)', () => {
+    // "cringe / sex / porn / penis" — shipped clean under nsfw@0.75, which is the bug.
+    expect(
+      isChallengeTextNsfw({ results: scores({ NSFW: 0.5663, Explicit: 0.6231, Suggestive: 0.7554 }) })
+    ).toBe(true);
+  });
+
+  it('flags on nsfw alone when explicit stays low (challenge 414, "furry butts")', () => {
+    expect(
+      isChallengeTextNsfw({ results: scores({ NSFW: 0.5721, Explicit: 0.3632, Suggestive: 0.8762 }) })
+    ).toBe(true);
+  });
+
+  it('leaves a benign challenge alone even when suggestive screams (challenge 400)', () => {
+    // "Grandpa Loves to RAVE!" — suggestive fires at 0.65 here, which is why it is not consulted.
+    expect(
+      isChallengeTextNsfw({ results: scores({ NSFW: 0.3358, Explicit: 0.3834, Suggestive: 0.6529 }) })
+    ).toBe(false);
+  });
+
+  it('ignores suggestive-only noise on plainly clean themes', () => {
+    // "Fractalize Worlds with Fractangles" / "Rainbow Unicorn" both trip suggestive.
+    expect(
+      isChallengeTextNsfw({ results: scores({ NSFW: 0.11, Explicit: 0.08, Suggestive: 0.507 }) })
+    ).toBe(false);
+  });
+
+  it('does not flag text with no adult content, whatever the challenge is rated', () => {
+    // Challenge 73 is rated XXX by a moderator, but its text is "broken hearts, wilted roses".
+    expect(
+      isChallengeTextNsfw({ results: scores({ NSFW: 0.284, Explicit: 0.2308, Suggestive: 0.5502 }) })
+    ).toBe(false);
+  });
+
+  it('treats a score exactly at the threshold as a flag', () => {
+    expect(
+      isChallengeTextNsfw({ results: scores({ NSFW: CHALLENGE_NSFW_SCORE_THRESHOLD }) })
+    ).toBe(true);
+  });
+
+  it('still escalates on a triggered label when scores are unavailable', () => {
+    // Defensive: the orchestrator already decided, so honour it even with no per-label scores.
+    expect(isChallengeTextNsfw({ results: [], triggeredLabels: ['NSFW'] })).toBe(true);
+    expect(isChallengeTextNsfw({ results: undefined, triggeredLabels: ['Explicit'] })).toBe(true);
+  });
+
+  it('ignores labels the challenge scan does not act on', () => {
+    expect(
+      isChallengeTextNsfw({ results: scores({ Celebrity: 0.99 }), triggeredLabels: ['Celebrity'] })
+    ).toBe(false);
+    // Suggestive triggering at the registry threshold must not escalate either.
+    expect(
+      isChallengeTextNsfw({ results: scores({ Suggestive: 0.99 }), triggeredLabels: ['Suggestive'] })
+    ).toBe(false);
+  });
+
+  it('returns false for missing or malformed output rather than throwing', () => {
+    expect(isChallengeTextNsfw({})).toBe(false);
+    expect(isChallengeTextNsfw({ results: null })).toBe(false);
+    expect(isChallengeTextNsfw({ results: [{ label: null, score: 0.99 }] })).toBe(false);
+    expect(isChallengeTextNsfw({ results: [{ label: 'NSFW', score: null }] })).toBe(false);
+  });
+});

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -33,12 +33,6 @@ import {
 // DB/Redis into client bundles)
 export { computeDynamicPool, distributePrizes } from './challenge-pool';
 
-// Labels requested for the challenge text scan. Only `nsfw` is currently reliable in XGuard, so we
-// scan for it alone; `suggestive`/`explicit` are omitted until they're trustworthy. Trade-off: nsfw's
-// 0.75 threshold misses borderline sexual text (a theme scoring ~0.68 slips through) — only clearly
-// NSFW text escalates for now. Any triggered label counts as NSFW downstream.
-export const CHALLENGE_MODERATION_LABELS = ['nsfw'] as const;
-
 // Author-supplied text sent to the text-moderation scan. Description is RTE HTML, so tags are
 // stripped.
 export function buildChallengeModerationText(challenge: {

--- a/src/server/games/daily-challenge/challenge-text-scan.ts
+++ b/src/server/games/daily-challenge/challenge-text-scan.ts
@@ -1,0 +1,44 @@
+// Which XGuard labels escalate a challenge, and the score at which they do.
+//
+// `nsfw` alone at its registry threshold of 0.75 caught 1 of 10 adult challenges when every
+// challenge in the corpus (214) was replayed through the scanner. Challenge text is a title and a
+// theme — keywords, never prose — and the NSFW policy asks for "explicit sexual content or graphic
+// sexual description", so bare topical text ("sex", "furry butts") lands at 0.55-0.73 and never
+// reaches 0.75. Adding `explicit` and scoring both at 0.5 took the same corpus to 9 of 10 with no
+// false positives.
+//
+// `suggestive` is deliberately excluded despite catching the tenth: it fires at 0.51-0.65 on
+// "Fractal Geometry", "Rainbow Unicorn" and "Psychedelic Dreams" — 40 false positives in that
+// backtest. It is fine for wildcard categories, where a trigger flips a boolean; here a trigger
+// voids a green challenge and refunds Buzz, so precision matters more.
+export const CHALLENGE_MODERATION_LABELS = ['nsfw', 'explicit'] as const;
+export const CHALLENGE_NSFW_SCORE_THRESHOLD = 0.5;
+
+const ESCALATING_LABELS: ReadonlySet<string> = new Set(CHALLENGE_MODERATION_LABELS);
+
+type ScanLabelResult = { label?: string | null; score?: number | null };
+
+/**
+ * Whether a challenge's scanned text counts as adult content.
+ *
+ * Scores are read directly rather than relying on the pipeline's `triggeredLabels`, because those
+ * are computed against the global per-label thresholds shared with articles and wildcard
+ * categories. Challenges need a stricter bar than the registry's 0.75 for `nsfw` without moving it
+ * for every other consumer.
+ */
+export function isChallengeTextNsfw({
+  results,
+  triggeredLabels = [],
+}: {
+  results?: ScanLabelResult[] | null;
+  triggeredLabels?: string[];
+}): boolean {
+  if (triggeredLabels.some((label) => ESCALATING_LABELS.has(label.toLowerCase()))) return true;
+
+  return (results ?? []).some(
+    (result) =>
+      !!result?.label &&
+      ESCALATING_LABELS.has(result.label.toLowerCase()) &&
+      (result.score ?? 0) >= CHALLENGE_NSFW_SCORE_THRESHOLD
+  );
+}

--- a/src/server/services/challenge-moderation.adapter.ts
+++ b/src/server/services/challenge-moderation.adapter.ts
@@ -3,10 +3,12 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import type { ModerationAdapter } from '~/server/services/entity-moderation.service';
 import { createNotification } from '~/server/services/notification.service';
 import { submitTextModeration } from '~/server/services/text-moderation.service';
+import { buildChallengeModerationText } from '~/server/games/daily-challenge/challenge-helpers';
 import {
-  buildChallengeModerationText,
   CHALLENGE_MODERATION_LABELS,
-} from '~/server/games/daily-challenge/challenge-helpers';
+  isChallengeTextNsfw,
+} from '~/server/games/daily-challenge/challenge-text-scan';
+import { logToAxiom } from '~/server/logging/client';
 import { parseChallengeMetadata } from '~/server/schema/challenge.schema';
 import { applyChallengeNsfwEscalation } from '~/server/games/daily-challenge/challenge-nsfw-escalation';
 import { ChallengeIngestionStatus } from '~/shared/utils/prisma/enums';
@@ -49,7 +51,7 @@ export const challengeModerationAdapter: ModerationAdapter = {
       priority: 'low',
     }),
 
-  applyResult: async ({ entityId, blocked, triggeredLabels }) => {
+  applyResult: async ({ entityId, blocked, triggeredLabels, output }) => {
     if (blocked) {
       const challenge = await dbRead.challenge.findUnique({
         where: { id: entityId },
@@ -77,8 +79,25 @@ export const challengeModerationAdapter: ModerationAdapter = {
       return;
     }
 
-    // Any of nsfw / suggestive / explicit crossing threshold escalates the challenge.
-    await applyChallengeNsfwEscalation({ entityId, isNsfw: triggeredLabels.length > 0 });
+    const isNsfw = isChallengeTextNsfw({ results: output?.results, triggeredLabels });
+
+    // A clean challenge scan otherwise leaves no trace anywhere, which is how a batch of
+    // under-flagged challenges went unnoticed until testers reported them. Log every verdict with
+    // the scores behind it so near-misses are queryable.
+    logToAxiom({
+      type: isNsfw ? 'warning' : 'info',
+      name: 'challenge-text-scan',
+      challengeId: entityId,
+      isNsfw,
+      scores: (output?.results ?? []).map((r) => ({
+        label: r.label,
+        score: r.score,
+        threshold: r.threshold,
+        topToken: r.topToken,
+      })),
+    });
+
+    await applyChallengeNsfwEscalation({ entityId, isNsfw });
   },
 
   // Terminal scan failure: mark retryable Error (the scan gate keeps the challenge hidden). The

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -4,7 +4,6 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { FLIPT_FEATURE_FLAGS, isFlipt } from '~/server/flipt/client';
 import { logToAxiom } from '~/server/logging/client';
 import {
-  CHALLENGE_MODERATION_LABELS,
   claimChallengeForCompletion,
   buildChallengeModerationText,
   closeChallengeCollection,
@@ -17,6 +16,7 @@ import {
 } from '~/server/games/daily-challenge/challenge-helpers';
 // Re-export getChallengeWinners so router can import from service (separation of concerns)
 export { getChallengeWinners } from '~/server/games/daily-challenge/challenge-helpers';
+import { CHALLENGE_MODERATION_LABELS } from '~/server/games/daily-challenge/challenge-text-scan';
 import {
   ChallengeParticipation,
   ChallengeSort,


### PR DESCRIPTION
## The bug

Testers reported that challenges aren't flagged NSFW based on their text. Challenge **416** — title `cringe`, theme `sex`, theme element `porn`, description `penis` — was created on the **green (SFW) domain** and passed its scan clean.

It isn't a plumbing failure. The scan ran and succeeded:

```json
// EntityModeration 481293
{ "blocked": false, "triggeredLabels": [],
  "results": [{ "label": "NSFW", "score": 0.5663, "threshold": 0.75 }] }
```

The model actually voted NSFW — its raw `topToken` is `x` — but at 57% confidence against a 75% bar, so `triggeredLabels` came back empty and `applyChallengeNsfwEscalation` ran with `isNsfw: false`.

## Why the score is low

- `nsfw` carries the **highest threshold in the entire text registry** (0.75). Every other label sits at 0.45–0.7.
- Its policy asks for *"explicit sexual content or graphic sexual description"*. Challenge text is a title and a theme — keywords, never prose — so the model hedges at 0.55–0.73 on plainly adult content. A graphic prose paragraph scores 0.9635 and triggers fine.
- `nsfw` was the **only** label we requested. `WildcardSetCategory` — the consumer that works well — requests eleven.

## Backtest

Every challenge in the corpus (**214**) was replayed through the scanner. Ground truth = moderator-assigned `nsfwLevel >= 4`, plus 416.

| Config | TP | FN | FP | Recall |
|---|---|---|---|---|
| **current** (`nsfw`@0.75) | 1 | 9 | 0 | **10%** |
| nsfw@0.5 | 7 | 3 | 2 | 70% |
| **this PR** (`nsfw`+`explicit`@0.5) | 9 | 1 | 2 | **90%** |
| + `suggestive` | 10 | 0 | **40** | 100% |

The remaining miss has **no adult content in its text** (rated XXX for its imagery: *"broken hearts, crying faces, wilted roses"*). The two "false positives" are yellow-domain challenges themed *Lust* (`flushed skin, sultry eyes, sweat`) and *Obsession* (`voyeurism, spying`) that a moderator left at PG-13 — under-labelled rather than wrong.

`suggestive` is deliberately excluded: it fires at 0.51–0.65 on *Fractal Geometry*, *Rainbow Unicorn* and *Psychedelic Dreams*. Fine for wildcards where a trigger flips a boolean; here it would void a green challenge and refund Buzz.

## The change

- `CHALLENGE_MODERATION_LABELS = ['nsfw', 'explicit']`, moved into a new pure `challenge-text-scan.ts` alongside the 0.5 threshold.
- Escalation reads per-label **scores** from the raw XGuard output — which `applyResult` already receives — instead of `triggeredLabels`. This keeps the stricter bar **local to challenges** rather than moving a threshold shared with articles and wildcard categories. **No policy change, no term list, no orchestrator change.**
- Logs every scan verdict with its scores. A clean scan previously wrote nothing anywhere, which is why this went unreported until testers hit it.

9 unit tests over the pure decision function, fixtures taken from real scanner output.

## Follow-ups (not in this PR)

- **Existing challenges need a re-scan** to pick up the new verdict — 416 and 414 at minimum. `submitTextModeration` already accepts `forceRescan` to bypass the `contentHash` dedup.
- **Articles have the identical defect** — `labels: ['nsfw']` at 0.75 (`article-moderation.adapter.ts:27`). Same failure mode, unmeasured.
- **Wildcards list `incest` as a hard-fail label, but no `Incest` label exists** in the text registry. Unknown labels are silently ignored, so that ToS condition has never been evaluated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)