### PR TITLE
fix(app-blocks): markdown render + theme-aware bubbles in agent-review chat (Phase 0.1)

### DIFF
--- a/src/components/Apps/AgentReviewChat.browser.test.tsx
+++ b/src/components/Apps/AgentReviewChat.browser.test.tsx
@@ -37,6 +37,15 @@ vi.mock('~/utils/notifications', () => ({
   showErrorNotification: (...a: unknown[]) => showError(...a),
 }));
 
+// The agent bubble now renders through `CustomMarkdown`, which reads
+// `useCurrentUser()` (→ CivitaiSessionContext) for its link-rewrite. The
+// network-free scaffold has no session provider, so boundary-stub the hook (the
+// standard pattern in the sibling Apps tests). Null user is fine — CustomMarkdown
+// only uses `user?.id` (optional-chained).
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => null,
+}));
+
 vi.mock('~/utils/trpc', () => {
   const inert = { invalidate: mocks.invalidate };
   const utils = { blocks: { getAgentReview: inert } };
@@ -334,5 +343,88 @@ describe('AgentReviewChat — sanitization', () => {
     expect((window as any).__chatXssFired).toBeUndefined();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect((window as any).__chatXssScript).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MARKDOWN RENDERING (agent replies format markdown, not literal markup)
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewChat — markdown rendering', () => {
+  test('an assistant reply renders markdown (bold / inline code / list) as real HTML, not literal markup', async () => {
+    mocks.agentReport = COMPLETE_REPORT;
+    // A reply exercising three markdown constructs at once.
+    mocks.chatReply = 'Here is **bold text** and `inline code`.\n\n- first item\n- second item';
+    renderPanel();
+
+    await page.getByRole('textbox', { name: 'Ask the review agent' }).fill('format your answer');
+    await page.getByRole('button', { name: 'Send' }).click();
+
+    // Anchor on the mounted agent bubble before any sync DOM read (browser-mode
+    // render is async-committed).
+    const agentMsg = page.getByTestId('chat-agent-msg');
+    await expect.element(agentMsg).toBeInTheDocument();
+
+    // The markdown became actual HTML elements, scoped to the agent bubble.
+    const bubble = document.querySelector('[data-testid="chat-agent-msg"]') as HTMLElement;
+    expect(bubble.querySelector('strong')?.textContent).toBe('bold text');
+    expect(bubble.querySelector('code')?.textContent).toBe('inline code');
+    // The `- item` lines became a real bulleted list, not two literal dashes.
+    expect(bubble.querySelectorAll('li').length).toBe(2);
+
+    // The raw markdown SYNTAX is gone from the visible text — it was rendered,
+    // not shown verbatim (the pre-fix plain-<Text> behavior).
+    expect(bubble.textContent).not.toContain('**bold text**');
+    expect(bubble.textContent).not.toContain('`inline code`');
+  });
+
+  test('a user-typed message stays plain text (markdown NOT interpreted)', async () => {
+    mocks.agentReport = COMPLETE_REPORT;
+    renderPanel();
+
+    // User types markdown-ish syntax; it must render verbatim (no <strong>).
+    await page.getByRole('textbox', { name: 'Ask the review agent' }).fill('why **this** scope?');
+    await page.getByRole('button', { name: 'Send' }).click();
+
+    const userMsg = page.getByTestId('chat-user-msg');
+    await expect.element(userMsg).toBeInTheDocument();
+    const userBubble = document.querySelector('[data-testid="chat-user-msg"]') as HTMLElement;
+    // The literal `**` is preserved and NOT converted to a <strong>.
+    expect(userBubble.textContent).toContain('why **this** scope?');
+    expect(userBubble.querySelector('strong')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// THEME-AWARE BUBBLES (light-dark() surfaces, not a fixed light-mode color)
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewChat — theme-aware bubbles', () => {
+  test('bubbles use theme-driven light-dark() surfaces (dark-scheme token present), not a hardcoded hex', async () => {
+    mocks.agentReport = COMPLETE_REPORT;
+    renderPanel();
+
+    await page.getByRole('textbox', { name: 'Ask the review agent' }).fill('hello');
+    await page.getByRole('button', { name: 'Send' }).click();
+
+    const agentMsg = page.getByTestId('chat-agent-msg');
+    await expect.element(agentMsg).toBeInTheDocument();
+
+    const agentBubble = document.querySelector('[data-testid="chat-agent-msg"]') as HTMLElement;
+    const userBubble = document.querySelector('[data-testid="chat-user-msg"]') as HTMLElement;
+    const agentStyle = agentBubble.getAttribute('style') ?? '';
+    const userStyle = userBubble.getAttribute('style') ?? '';
+
+    // Agent bubble background flips with the color scheme via Mantine's
+    // light-dark() — the dark-scheme surface token is present, so it is NOT the
+    // old fixed light-mode `gray.1` that rendered near-white in dark mode.
+    expect(agentStyle).toContain('light-dark(');
+    expect(agentStyle).toContain('var(--mantine-color-dark-5)');
+    // No hardcoded hex color leaked into the bubble style.
+    expect(agentStyle).not.toMatch(/#[0-9a-fA-F]{3,6}/);
+
+    // User bubble is likewise theme-driven (filled blue accent, light-dark()).
+    expect(userStyle).toContain('light-dark(');
+    expect(userStyle).toContain('var(--mantine-color-blue');
   });
 });

--- a/src/components/Apps/AgentReviewChat.browser.test.tsx
+++ b/src/components/Apps/AgentReviewChat.browser.test.tsx
@@ -378,6 +378,33 @@ describe('AgentReviewChat — markdown rendering', () => {
     expect(bubble.textContent).not.toContain('`inline code`');
   });
 
+  test('markdown image syntax renders NO live <img> (adversarial external-fetch guard)', async () => {
+    mocks.agentReport = COMPLETE_REPORT;
+    // Native markdown image: `https` passes react-markdown's protocol filter, so
+    // WITHOUT `disallowedElements={['img']}` this renders a live <img> that fires
+    // an external fetch from the MODERATOR's browser (tracking pixel / IP+UA
+    // leak) on adversarial, prompt-injectable agent output. Must be dropped.
+    mocks.chatReply = 'Look here: ![tracking](https://example.com/pixel.png)';
+    renderPanel();
+
+    await page.getByRole('textbox', { name: 'Ask the review agent' }).fill('embed an image');
+    await page.getByRole('button', { name: 'Send' }).click();
+
+    const agentMsg = page.getByTestId('chat-agent-msg');
+    await expect.element(agentMsg).toBeInTheDocument();
+
+    // No <img> element anywhere — the image was dropped, so no external fetch.
+    expect(document.querySelectorAll('img').length).toBe(0);
+    const bubble = document.querySelector('[data-testid="chat-agent-msg"]') as HTMLElement;
+    expect(bubble.querySelector('img')).toBeNull();
+    // The surrounding prose still rendered (the reply wasn't blanked). Note:
+    // `disallowedElements` drops the node AND its children, so the image's alt
+    // text ("tracking") is removed too — better still, no attacker-controlled
+    // string is surfaced for the dropped image.
+    expect(bubble.textContent).toContain('Look here');
+    expect(bubble.textContent).not.toContain('tracking');
+  });
+
   test('a user-typed message stays plain text (markdown NOT interpreted)', async () => {
     mocks.agentReport = COMPLETE_REPORT;
     renderPanel();

--- a/src/components/Apps/AgentReviewChat.tsx
+++ b/src/components/Apps/AgentReviewChat.tsx
@@ -1,6 +1,7 @@
 import { Alert, Box, Button, Card, Group, Loader, ScrollArea, Stack, Text, Textarea } from '@mantine/core';
 import { useState } from 'react';
 import { IconMessageQuestion, IconSend, IconAlertTriangle } from '@tabler/icons-react';
+import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
 import { trpc } from '~/utils/trpc';
 
 /**
@@ -17,9 +18,12 @@ import { trpc } from '~/utils/trpc';
  * 30–90s) — a "thinking…" indicator covers the wait; streaming SSE is a follow-up.
  *
  * ADVISORY + ADVERSARIAL-SAFE: the reply is derived from an UNTRUSTED bundle, so
- * — exactly like the P2 report — every agent string is rendered as inert React
- * TEXT (no `dangerouslySetInnerHTML`, no HTML/markdown-with-raw-HTML). That is
- * the stored-XSS-at-render contract for adversarial LLM output.
+ * it is rendered through the shared `CustomMarkdown` (react-markdown) — which uses
+ * NO `rehype-raw` and NO `dangerouslySetInnerHTML`, so raw HTML embedded in
+ * adversarial agent output is escaped to inert text rather than parsed into live
+ * DOM. That preserves the stored-XSS-at-render contract for adversarial LLM output
+ * while letting normal markdown (bold, lists, code) format. User-typed messages
+ * stay plain inert text — only the agent's own replies carry markdown.
  */
 
 type ChatMessage = { role: 'user' | 'assistant'; content: string };
@@ -104,19 +108,53 @@ export function AgentReviewChat({ publishRequestId }: { publishRequestId: string
                       data-testid={isUser ? 'chat-user-msg' : 'chat-agent-msg'}
                       style={{
                         maxWidth: '85%',
+                        minWidth: 0,
                         borderRadius: 8,
                         padding: '6px 10px',
+                        // Keep markdown (long paths, urls, code) inside the bubble
+                        // rather than blowing past its max-width.
+                        overflowWrap: 'anywhere',
                       }}
-                      bg={isUser ? 'blue.6' : 'gray.1'}
+                      // Theme-aware bubble surface + text — matches the
+                      // `light-dark(...)` precedent in reviewDiffPanels.tsx. The old
+                      // fixed `gray.1` rendered a near-white agent bubble in dark
+                      // mode; these flip with the color scheme. User = filled accent.
+                      bg={
+                        isUser
+                          ? 'light-dark(var(--mantine-color-blue-6), var(--mantine-color-blue-8))'
+                          : 'light-dark(var(--mantine-color-gray-1), var(--mantine-color-dark-5))'
+                      }
+                      c={
+                        isUser
+                          ? 'white'
+                          : 'light-dark(var(--mantine-color-dark-9), var(--mantine-color-gray-0))'
+                      }
                     >
-                      {/* Inert TEXT — never HTML/markdown. Adversarial-safe. */}
-                      <Text
-                        size="sm"
-                        c={isUser ? 'white' : undefined}
-                        style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
-                      >
-                        {m.content}
-                      </Text>
+                      {isUser ? (
+                        // User-typed message — plain inert TEXT (no markdown),
+                        // matching the existing convention.
+                        <Text
+                          size="sm"
+                          style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}
+                        >
+                          {m.content}
+                        </Text>
+                      ) : (
+                        // Agent reply — markdown via the shared, XSS-safe
+                        // CustomMarkdown (react-markdown, NO rehype-raw / no
+                        // dangerouslySetInnerHTML): raw HTML in adversarial output is
+                        // escaped to inert text, normal markdown formats. `size="sm"`
+                        // sizing via the sm font-size var on the markdown container.
+                        <div
+                          className="markdown-content"
+                          style={{
+                            fontSize: 'var(--mantine-font-size-sm)',
+                            overflowWrap: 'anywhere',
+                          }}
+                        >
+                          <CustomMarkdown>{m.content}</CustomMarkdown>
+                        </div>
+                      )}
                     </Box>
                   </Group>
                 );

--- a/src/components/Apps/AgentReviewChat.tsx
+++ b/src/components/Apps/AgentReviewChat.tsx
@@ -145,6 +145,12 @@ export function AgentReviewChat({ publishRequestId }: { publishRequestId: string
                         // dangerouslySetInnerHTML): raw HTML in adversarial output is
                         // escaped to inert text, normal markdown formats. `size="sm"`
                         // sizing via the sm font-size var on the markdown container.
+                        // `disallowedElements={['img']}` drops markdown image syntax
+                        // (`![](https://…)`) — the agent bundle is adversarial and
+                        // prompt-injectable, and a rendered <img> would fire an
+                        // external fetch from the MODERATOR's browser (tracking
+                        // pixel / IP+UA leak). Links stay (protocol-sanitized +
+                        // click-gated).
                         <div
                           className="markdown-content"
                           style={{
@@ -152,7 +158,9 @@ export function AgentReviewChat({ publishRequestId }: { publishRequestId: string
                             overflowWrap: 'anywhere',
                           }}
                         >
-                          <CustomMarkdown>{m.content}</CustomMarkdown>
+                          <CustomMarkdown disallowedElements={['img']}>
+                            {m.content}
+                          </CustomMarkdown>
                         </div>
                       )}
                     </Box>


### PR DESCRIPTION
## Phase 0.1 — App Blocks agent-review chat: markdown render + theme-aware bubbles

Part of the App Blocks advisory-review page-migration plan (Phase 0.1 — quick-fix the current mods review modal, no flag). Scope is deliberately tight: **only** the in-modal agentic code-review chat (`AgentReviewChat.tsx`). Does not touch the scope-verdicts table or the summary/report sections (`AgentReviewPanel.tsx` / `ReportBody` are owned by a sibling PR).

### Fix 1 — markdown was not rendered
Chat messages rendered as plain-text Mantine `<Text>`, so an agent reply containing `**bold**`, lists, or `` `code` `` showed the raw markdown characters.

Agent replies now render through the repo's standard **`CustomMarkdown`** (`src/components/Markdown/CustomMarkdown.tsx`), matching the existing usage at `AppListingDetailBody.tsx` (wrapped in a `.markdown-content` container). User-typed messages stay plain text (existing convention).

**XSS contract preserved:** `CustomMarkdown` is `react-markdown` with **no `rehype-raw`** and no `dangerouslySetInnerHTML`, so raw HTML embedded in adversarial agent output is escaped to inert text, not parsed into live DOM. The load-bearing sanitization test (adversarial `<img onerror>` / `<script>` → inert text, zero `<img>`, no window side-effects) still passes unchanged. Markdown is kept inside the bubble width (`overflow-wrap: anywhere`), sized `sm` via the `--mantine-font-size-sm` var.

### Fix 2 — bubble colors clashed in dark mode
Bubbles used hardcoded Mantine scale tokens (`bg={isUser ? 'blue.6' : 'gray.1'}`). `gray.1` is a fixed light-mode token → the agent bubble rendered near-white in dark mode.

Replaced with theme-aware **`light-dark(...)`** surfaces + text colors, matching the established precedent in the sibling `reviewDiffPanels.tsx` (`light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6))`). Agent bubble flips to a `dark-5` surface in dark mode; user bubble stays a filled blue accent. No hardcoded hex.

### Tests
Extended `AgentReviewChat.browser.test.tsx` (Vitest browser-mode):
- **markdown render** — an assistant reply with `**bold**`, `` `inline code` ``, and a `- list` renders real `<strong>` / `<code>` / two `<li>` elements, and the literal `**`/`` ` `` syntax is absent from the visible text.
- **user stays plain** — a user message containing `**this**` renders verbatim with no `<strong>`.
- **theme-driven bubbles** — the bubble inline style contains `light-dark(` + the `var(--mantine-color-dark-5)` dark-scheme token and no hardcoded hex.
- Added the standard `useCurrentUser` boundary-stub (CustomMarkdown reads the session context, which the network-free scaffold doesn't provide) — same pattern as the sibling Apps tests.

All **14 tests pass** (11 pre-existing + 3 new). `tsc --noEmit` clean for the changed files (the only errors are the pre-existing missing-private-`event-engine-common`-submodule / unbuilt-`kysely`-workspace noise that resolves in CI).

**Rollback:** revert one component file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
