### PR TITLE
chore(storage): sync package.json to 0.0.1 (matches deployed bootstrap image)

### DIFF
--- a/apps/storage/package.json
+++ b/apps/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civitai/storage-app",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": true,
   "type": "module",
   "main": "./dist/server.js",


### PR DESCRIPTION
## What

Bump `apps/storage/package.json` version from `0.0.0` to `0.0.1`. One-line change, nothing else.

## Why

`civitai-storage` was bootstrap-deployed from image tag `storage-v0.0.1`, but `apps/storage/package.json` on `main` is still `0.0.0`. The first `pnpm release:storage` runs `npm version patch` (0.0.0 → 0.0.1) then `git tag storage-v0.0.1` — which would **fail**, because the `storage-v0.0.1` tag already exists from the bootstrap.

Reconciling `main` to `0.0.1` means the next release patches `0.0.1 → 0.0.2` and tags `storage-v0.0.2` cleanly, with no tag collision.

## Risk

None. Version-only metadata bump on a `private` package; no runtime or build behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)