### PR TITLE
fix(apps): responsive scope-verdicts table in agent-review report

### DIFF
--- a/src/components/Apps/AgentReviewPanel.browser.test.tsx
+++ b/src/components/Apps/AgentReviewPanel.browser.test.tsx
@@ -50,6 +50,17 @@ vi.mock('~/components/Apps/ReviewBlockPreviewHost', () => ({
   ReviewBlockPreviewHost: () => <div data-testid="review-host-stub" />,
 }));
 
+// The scope-verdicts section renders responsively off `useMediaQuery` (table +
+// horizontal-scroll on desktop, stacked cards on narrow). The real viewport is
+// non-deterministic in browser mode, so we importActual @mantine/hooks and
+// override ONLY useMediaQuery — DEFAULT desktop (false); the narrow branch is
+// only reached after forcing it per test (the BaseModelInput/WorkflowInput
+// media-query pattern).
+vi.mock('@mantine/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@mantine/hooks')>('@mantine/hooks');
+  return { ...actual, useMediaQuery: vi.fn(() => false) };
+});
+
 const showError = vi.fn();
 const showSuccess = vi.fn();
 vi.mock('~/utils/notifications', () => ({
@@ -130,6 +141,10 @@ vi.mock('~/utils/trpc', () => {
 
 const { AgentReviewPanel, AGENT_REVIEW_POLL_MS } = await import('./AgentReviewPanel');
 const { OnsiteReviewModal } = await import('./OnsiteReviewModal');
+const { useMediaQuery } = await import('@mantine/hooks');
+const useMediaQueryMock = vi.mocked(useMediaQuery);
+/** Force the responsive branch: true = narrow/mobile (cards), false = desktop (table). */
+const setNarrow = (narrow: boolean) => useMediaQueryMock.mockReturnValue(narrow);
 
 const ONSITE_PENDING = {
   id: 'onsite-req-1',
@@ -229,6 +244,7 @@ beforeEach(() => {
   mocks.lastAgentOpts = undefined;
   showError.mockClear();
   showSuccess.mockClear();
+  setNarrow(false); // desktop (table + scroll-container) by default
 });
 
 // ---------------------------------------------------------------------------
@@ -437,6 +453,58 @@ describe('AgentReviewPanel — report rendering', () => {
     await expect.element(page.getByText('user:*')).toBeInTheDocument();
     await expect.element(page.getByText('Under-declared scopes')).toBeInTheDocument();
     await expect.element(page.getByText('models:write:self')).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RESPONSIVE SCOPE-VERDICTS (table + horizontal-scroll desktop / stacked cards)
+// ---------------------------------------------------------------------------
+
+describe('AgentReviewPanel — responsive scope verdicts', () => {
+  test('desktop: renders the verdicts table inside a horizontal-scroll container (not the card variant)', async () => {
+    setNarrow(false);
+    mocks.agentReport = FULL_REPORT;
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+
+    // The scroll container wraps the table so long scope/evidence columns scroll
+    // horizontally instead of squishing.
+    await expect.element(page.getByTestId('scope-verdicts-scroll')).toBeInTheDocument();
+    await expect.element(page.getByTestId('scope-verdicts-table')).toBeInTheDocument();
+    // The narrow stacked-card variant is NOT rendered on desktop.
+    expect(page.getByTestId('scope-verdicts-cards').elements()).toHaveLength(0);
+
+    // Same data — every scope row, the sensitive badge, and evidence still render.
+    await expect.element(page.getByText('buzz:read:self')).toBeInTheDocument();
+    await expect.element(page.getByTestId('scope-sensitive-badge')).toBeInTheDocument();
+    await expect.element(page.getByText('wallet.js:10')).toBeInTheDocument();
+  });
+
+  test('narrow/mobile: renders stacked per-scope cards instead of the table (same data)', async () => {
+    setNarrow(true);
+    mocks.agentReport = FULL_REPORT;
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+
+    // The card variant renders; the table + its scroll container do NOT.
+    await expect.element(page.getByTestId('scope-verdicts-cards')).toBeInTheDocument();
+    expect(page.getByTestId('scope-verdicts-table').elements()).toHaveLength(0);
+    expect(page.getByTestId('scope-verdicts-scroll').elements()).toHaveLength(0);
+
+    // The card layout carries the same label/value data — scope id, the sensitive
+    // badge, evidence, and the label rows.
+    await expect.element(page.getByText('buzz:read:self')).toBeInTheDocument();
+    await expect.element(page.getByTestId('scope-sensitive-badge')).toBeInTheDocument();
+    await expect.element(page.getByText('wallet.js:10')).toBeInTheDocument();
+    // The stacked-card label rows (present only in the card variant).
+    expect(page.getByText('Justified').elements().length).toBeGreaterThan(0);
+    expect(page.getByText('Evidence').elements().length).toBeGreaterThan(0);
+  });
+
+  test('narrow/mobile: empty scopes still shows the "No scopes assessed" empty state', async () => {
+    setNarrow(true);
+    mocks.agentReport = { ...FULL_REPORT, scopeVerdicts: { scopes: [], overBroad: [], underDeclared: [] } };
+    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
+    await expect.element(page.getByText('No scopes assessed')).toBeInTheDocument();
+    expect(page.getByTestId('scope-verdicts-cards').elements()).toHaveLength(0);
   });
 });
 

--- a/src/components/Apps/AgentReviewPanel.tsx
+++ b/src/components/Apps/AgentReviewPanel.tsx
@@ -1,5 +1,6 @@
 import { Alert, Badge, Button, Card, Group, Loader, Stack, Table, Text, ThemeIcon } from '@mantine/core';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, type ReactNode } from 'react';
+import { useMediaQuery } from '@mantine/hooks';
 import {
   IconAlertTriangle,
   IconCheck,
@@ -384,6 +385,18 @@ function MetaLine({ label, value }: { label: string; value: string }) {
   );
 }
 
+/** One label/value row inside a narrow-viewport scope card. */
+function ScopeCardRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <Group gap={6} wrap="nowrap" align="flex-start">
+      <Text size="xs" fw={600} c="dimmed" style={{ minWidth: 68, flexShrink: 0 }}>
+        {label}
+      </Text>
+      <div style={{ minWidth: 0, flex: 1 }}>{children}</div>
+    </Group>
+  );
+}
+
 function fmtDate(d: unknown): string | null {
   if (d == null) return null;
   const dt = d instanceof Date ? d : new Date(String(d));
@@ -410,6 +423,12 @@ function ReportBody({
 }) {
   const view = parseAgentReport(report);
   const { codeReview, securityAudit, scopeVerdicts, tokenUsage } = view;
+
+  // Responsive scope-verdicts layout: the 6-column verdicts table squishes at
+  // narrow widths (long monospace scope ids / evidence paths wrap char-by-char).
+  // Below `sm` we render each scope as a stacked label/value card instead; at
+  // wider widths the table scrolls horizontally rather than compressing.
+  const isNarrow = useMediaQuery('(max-width: 768px)');
 
   const cost = formatCostUsd(report.costUsd);
   const started = fmtDate(report.startedAt);
@@ -583,37 +602,29 @@ function ReportBody({
         </Group>
         {scopeVerdicts.scopes.length === 0 ? (
           <NoneFound label="No scopes assessed" />
-        ) : (
-          <Table striped withTableBorder withColumnBorders fz="xs" data-testid="scope-verdicts-table">
-            <Table.Thead>
-              <Table.Tr>
-                <Table.Th>Scope</Table.Th>
-                <Table.Th>Used</Table.Th>
-                <Table.Th>Justified</Table.Th>
-                <Table.Th>Sensitive</Table.Th>
-                <Table.Th>Evidence</Table.Th>
-                <Table.Th>Notes</Table.Th>
-              </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-              {scopeVerdicts.scopes.map((s, i) => (
-                <Table.Tr key={i}>
-                  <Table.Td>
+        ) : isNarrow ? (
+          // Narrow / mobile: stacked per-scope cards (label/value rows) — the
+          // 6-col table is unreadable below `sm`.
+          <Stack gap="xs" data-testid="scope-verdicts-cards">
+            {scopeVerdicts.scopes.map((s, i) => (
+              <Card key={i} withBorder padding="xs" radius="sm">
+                <Stack gap={4}>
+                  <ScopeCardRow label="Scope">
                     <Text size="xs" ff="monospace" style={{ wordBreak: 'break-all' }}>
                       {s.declared ?? '—'}
                     </Text>
-                  </Table.Td>
-                  <Table.Td>
+                  </ScopeCardRow>
+                  <ScopeCardRow label="Used">
                     <Badge size="xs" variant="light" color={verdictColor(s.used)}>
                       {s.used ?? '—'}
                     </Badge>
-                  </Table.Td>
-                  <Table.Td>
+                  </ScopeCardRow>
+                  <ScopeCardRow label="Justified">
                     <Badge size="xs" variant="light" color={verdictColor(s.justificationAccurate)}>
                       {s.justificationAccurate ?? '—'}
                     </Badge>
-                  </Table.Td>
-                  <Table.Td>
+                  </ScopeCardRow>
+                  <ScopeCardRow label="Sensitive">
                     {s.sensitive ? (
                       <Badge
                         size="xs"
@@ -628,8 +639,8 @@ function ReportBody({
                         —
                       </Text>
                     )}
-                  </Table.Td>
-                  <Table.Td>
+                  </ScopeCardRow>
+                  <ScopeCardRow label="Evidence">
                     {s.evidence.length === 0 ? (
                       <Text size="xs" c="dimmed">
                         —
@@ -637,27 +648,101 @@ function ReportBody({
                     ) : (
                       <Stack gap={0}>
                         {s.evidence.map((e, j) => (
-                          <Text
-                            key={j}
-                            size="xs"
-                            ff="monospace"
-                            style={{ wordBreak: 'break-all' }}
-                          >
+                          <Text key={j} size="xs" ff="monospace" style={{ wordBreak: 'break-all' }}>
                             {e}
                           </Text>
                         ))}
                       </Stack>
                     )}
-                  </Table.Td>
-                  <Table.Td>
+                  </ScopeCardRow>
+                  <ScopeCardRow label="Notes">
                     <Text size="xs" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
                       {s.notes ?? '—'}
                     </Text>
-                  </Table.Td>
+                  </ScopeCardRow>
+                </Stack>
+              </Card>
+            ))}
+          </Stack>
+        ) : (
+          // Wide: keep the table but let it scroll horizontally instead of
+          // squishing the monospace scope/evidence columns.
+          <Table.ScrollContainer minWidth={720} data-testid="scope-verdicts-scroll">
+            <Table striped withTableBorder withColumnBorders fz="xs" data-testid="scope-verdicts-table">
+              <Table.Thead>
+                <Table.Tr>
+                  <Table.Th>Scope</Table.Th>
+                  <Table.Th>Used</Table.Th>
+                  <Table.Th>Justified</Table.Th>
+                  <Table.Th>Sensitive</Table.Th>
+                  <Table.Th>Evidence</Table.Th>
+                  <Table.Th>Notes</Table.Th>
                 </Table.Tr>
-              ))}
-            </Table.Tbody>
-          </Table>
+              </Table.Thead>
+              <Table.Tbody>
+                {scopeVerdicts.scopes.map((s, i) => (
+                  <Table.Tr key={i}>
+                    <Table.Td>
+                      <Text size="xs" ff="monospace" style={{ wordBreak: 'break-all' }}>
+                        {s.declared ?? '—'}
+                      </Text>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge size="xs" variant="light" color={verdictColor(s.used)}>
+                        {s.used ?? '—'}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      <Badge size="xs" variant="light" color={verdictColor(s.justificationAccurate)}>
+                        {s.justificationAccurate ?? '—'}
+                      </Badge>
+                    </Table.Td>
+                    <Table.Td>
+                      {s.sensitive ? (
+                        <Badge
+                          size="xs"
+                          variant="filled"
+                          color="red"
+                          data-testid="scope-sensitive-badge"
+                        >
+                          sensitive
+                        </Badge>
+                      ) : (
+                        <Text size="xs" c="dimmed">
+                          —
+                        </Text>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      {s.evidence.length === 0 ? (
+                        <Text size="xs" c="dimmed">
+                          —
+                        </Text>
+                      ) : (
+                        <Stack gap={0}>
+                          {s.evidence.map((e, j) => (
+                            <Text
+                              key={j}
+                              size="xs"
+                              ff="monospace"
+                              style={{ wordBreak: 'break-all' }}
+                            >
+                              {e}
+                            </Text>
+                          ))}
+                        </Stack>
+                      )}
+                    </Table.Td>
+                    <Table.Td>
+                      <Text size="xs" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                        {s.notes ?? '—'}
+                      </Text>
+                    </Table.Td>
+                  </Table.Tr>
+                ))}
+              </Table.Tbody>
+            </Table>
+          </Table.ScrollContainer>
         )}
 
         {scopeVerdicts.overBroad.length > 0 && (


### PR DESCRIPTION
## What

Makes the App Blocks agent-review **scope-verdicts table** responsive. This table lives in `ReportBody` inside `AgentReviewPanel.tsx` (the `scopeVerdicts.scopes[]` render) — a 6-column Mantine `Table` (Scope / Used / Justified / Sensitive / Evidence / Notes) with **no scroll container**. Long monospace scope ids (`ai:write:budgeted`) and evidence paths (`wallet.js:10`) wrap char-by-char into tall thin columns and squish at narrow widths.

## The fix (presentation-only)

- **Wide viewport:** keep the table but wrap it in Mantine's `<Table.ScrollContainer minWidth={720}>` so it scrolls horizontally instead of compressing. Matches the existing repo pattern in `CreatorShop/Manage/ManageItemsTable.tsx`.
- **Narrow viewport (`<= 768px`, via `useMediaQuery`):** render each scope as a stacked label/value `<Card>` instead of table rows — the idiomatic `useMediaQuery('(max-width: 768px)')` desktop/mobile split already used by `BaseModelInput`/`WorkflowInput`.

Identical data and columns — nothing changes about what `ReportBody` reads from the report. The existing `scope-verdicts-table` / `scope-sensitive-badge` testids are preserved on the desktop branch; the narrow card variant carries `scope-sensitive-badge` too, plus new `scope-verdicts-scroll` (desktop) and `scope-verdicts-cards` (narrow) handles.

## Tests

Extends `AgentReviewPanel.browser.test.tsx` with the **media-query mock pattern** (first use in this corpus — `importActual('@mantine/hooks')` + override `useMediaQuery`, default desktop, forced per test). New assertions actually drive the responsive branch rather than just mounting:
- **desktop:** verdicts table renders inside the horizontal-scroll container (`scope-verdicts-scroll` + `scope-verdicts-table`); the card variant is absent; scope id / sensitive badge / evidence still render.
- **narrow/mobile:** stacked per-scope cards render (`scope-verdicts-cards`); the table + scroll container are absent; same data (scope id, sensitive badge, evidence, label rows) present.
- **narrow empty:** the `No scopes assessed` empty state still shows.

All 17 existing tests plus 3 new = **20 passing** (run against a system Chromium on NixOS).

## Scope

Tight — scope-verdicts table responsiveness only. Does **not** touch `AgentReviewChat.tsx` (sibling PR) or the summary/code-review/security-audit redesign (Phase 2). This is **Phase 0.2** of the App Blocks review-page migration.

## Rollback

Revert this one component file (+ its test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)