### PR TITLE
fix(app-blocks): dev-tunnel mint accepts an owned non-approved app (fixes "Couldn't authenticate this app")

### DIFF
--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -42,6 +42,7 @@ import {
 import {
   clampTunnelDeclaredScopes,
   FORCED_SFW_CEILING,
+  parseManifestBuzzBudget,
   resolveDevBuzzBudget,
   signDevScopedPageToken,
 } from '~/server/services/blocks/dev-scoped-mint.service';
@@ -468,6 +469,151 @@ async function tryDevTunnelScopedMint(args: {
   return 'handled';
 }
 
+/**
+ * PHASE 2 — App Dev Tunnel: OWNED, NON-APPROVED (real `apb_…`) SCOPED mint.
+ *
+ * The COMPANION to `tryDevTunnelScopedMint`, closing the SSR↔mint asymmetry for an
+ * app that HAS a real AppBlock row but is NOT `approved`. The SSR dev route
+ * (`resolveDevPageBlockForAuthor`) mounts an OWNED app at ANY status → the host
+ * requests a token for `page_<apb_…>`. But `resolvePageBlock` requires
+ * `status:'approved'`, and `tryDevTunnelScopedMint` only rescues the synthetic
+ * `ephemeral-*` namespace — so a previously-approved app that is now suspended /
+ * pending (re-submitted) / deprecated falls through BOTH branches to the bare 404,
+ * which the host renders as "Couldn't authenticate this app". This branch mints a
+ * SCOPED, forced-SFW, self-bound, budget-capped dev token for that case, reusing the
+ * IDENTICAL audited clamp + budget + sign belt as the ephemeral path.
+ *
+ * SECURITY INVARIANTS (ALL required — a failure of any → 'continue' → the SAME bare
+ * 404, no oracle, no mint):
+ *   1. OWNERSHIP — `resolveOwnedNonApprovedPageBlock` enforces `app.userId === caller`
+ *      IN the query. A non-owner requesting a suspended app's token gets the bare 404
+ *      (no cross-user mint, no existence oracle).
+ *   2. ACTIVE DEV TUNNEL — an ACTIVE `getActiveDevTunnel(caller, blockId)` is REQUIRED
+ *      (the SAME check the ephemeral/scoped mint uses). No active tunnel → 404. This is
+ *      NOT a general un-suspend: the app stays non-runnable publicly + without a tunnel.
+ *   3. FLAG-GATED — behind `app-blocks-enabled` (the outer handler's `appBlocks` gate),
+ *      `appBlocksAuthor`, AND the `app-blocks-dev-tunnel` kill-switch, all evaluated for
+ *      the caller. Any off → 404. (No `unsubmitted-spend` flag: unlike a never-reviewed
+ *      ephemeral app, this app's scopes ARE a prior moderator-approved snapshot.)
+ *   4. SELF-BOUND — the token `sub` is the caller (the owner), so at RUNTIME it spends
+ *      the caller's OWN Buzz under `assertViewerIsAppDeveloper(sub)` + the per-call /
+ *      per-session / per-day caps. Budget = the manifest `page.buzzBudgetPerGen` clamped
+ *      to the dev cap (default as the ephemeral path), forced-SFW.
+ *   5. SCOPES — sourced from the app's APPROVED SNAPSHOT (`approvedScopes`), NEVER the
+ *      raw/re-published manifest, then run through the SAME `clampTunnelDeclaredScopes`
+ *      belt (TUNNEL allowlist, no widening). No scope escalation.
+ *   6. NO PUBLIC-PATH BYPASS — this ONLY affects the dev-tunnel mint (gated on an active
+ *      tunnel for the caller). The public run-mint (`resolvePageBlock`) + SSR run page
+ *      still require `status:'approved'` and are untouched — a suspended app stays
+ *      non-runnable publicly.
+ *
+ * The token carries the app's REAL ids (unlike the synthetic ephemeral path), so the
+ * runtime spend-attribution row resolves the real OauthClient and lands as a
+ * `self_spend`-VOIDED row (spender == app owner) — no forged attribution, no bounty.
+ */
+async function tryDevTunnelOwnedNonApprovedMint(args: {
+  req: NextApiRequest & { log?: Logger };
+  res: NextApiResponse;
+  appBlockId: string;
+  blockInstanceId: string;
+  slotId: string;
+  sessionUser: SessionUser | undefined;
+  userId: number | null;
+}): Promise<'handled' | 'continue'> {
+  const { req, res, appBlockId, blockInstanceId, slotId, sessionUser, userId } = args;
+
+  // Cookie-authed author only. This branch is the REAL-id companion to
+  // tryDevTunnelScopedMint — the synthetic ephemeral namespace is handled THERE, so
+  // an `ephemeral-*` id is not ours.
+  if (userId == null || !sessionUser) return 'continue';
+  if (appBlockId.startsWith(EPHEMERAL_APP_ID_PREFIX)) return 'continue';
+  // The instance id is `page_<appBlockId>` by construction; a mismatch is not a
+  // legitimate dev mint.
+  if (blockInstanceId !== `${PAGE_INSTANCE_PREFIX}${appBlockId}`) return 'continue';
+  if (sessionUser.bannedAt) return 'continue';
+
+  // Author capability + dev-tunnel kill-switch (both fail-closed). Dynamic import so
+  // the flag module isn't eager-loaded on the prod-mint import path. NO
+  // unsubmitted-spend flag: the scope source is a prior moderator-approved snapshot,
+  // not a never-reviewed manifest.
+  const { isAppBlocksAuthorEnabled, isAppBlocksDevTunnelEnabled } = await import(
+    '~/server/services/app-blocks-flag'
+  );
+  if (!(await isAppBlocksAuthorEnabled({ user: sessionUser }))) return 'continue';
+  if (!(await isAppBlocksDevTunnelEnabled({ user: sessionUser }))) return 'continue';
+
+  // Soft-delete gate (M1 parity with the prod path + the ephemeral branch).
+  const userRow = await dbWrite.user.findUnique({
+    where: { id: userId },
+    select: { deletedAt: true, bannedAt: true },
+  });
+  if (!userRow || userRow.deletedAt || userRow.bannedAt) return 'continue';
+
+  // OWNERSHIP + NON-APPROVED resolve (any refusal → bare null → 404, no oracle). The
+  // resolver enforces `app.userId === caller` AND `status != approved` in the query.
+  const app = await BlockRegistry.resolveOwnedNonApprovedPageBlock(appBlockId, userId, {
+    db: 'write',
+  });
+  if (!app) return 'continue';
+
+  // Belt-and-suspenders: the page slot must be a real page slot.
+  if (!isPageSlot(slotId)) return 'continue';
+
+  // ACTIVE dev tunnel REQUIRED (invariant 2). NOT a general un-suspend: without an
+  // active tunnel for (caller, slug) this app cannot mint. Resolved server-side from
+  // (userId, blockId) — the SAME check the ephemeral/scoped mint + the runtime
+  // per-session spend backstop use.
+  const { getActiveDevTunnel } = await import('~/server/services/blocks/dev-tunnel.service');
+  const tunnel = await getActiveDevTunnel(userId, app.blockId);
+  if (!tunnel) return 'continue';
+
+  // SCOPE SOURCE = the app's APPROVED SNAPSHOT (moderator-reviewed, pinned) — NEVER
+  // the raw manifest. Clamped through the SAME tunnel belt as the ephemeral path
+  // (TUNNEL allowlist, no OAuth ceiling, no widening; force-adds user:read:self).
+  const granted = clampTunnelDeclaredScopes(app.approvedScopes);
+  // BUDGET = the manifest's page.buzzBudgetPerGen (clamped to the dev cap), defaulting
+  // as the ephemeral path when absent. Only meaningful if ai:write:budgeted survived.
+  const manifestBudget = parseManifestBuzzBudget(
+    (app.manifest as { page?: unknown }).page
+  );
+  const buzzBudget = resolveDevBuzzBudget(granted, undefined, manifestBudget);
+
+  // SIGN with the app's REAL ids (appId/appBlockId/blockId), the client's page
+  // instance id, self-bound sub, forced-SFW, dev-capped budget, dev:true (4h).
+  const result = await signDevScopedPageToken({
+    userId,
+    signBlockId: app.blockId,
+    signAppId: app.appId,
+    signAppBlockId: app.appBlockId,
+    blockInstanceId,
+    granted,
+    buzzBudget,
+  });
+
+  // MINT-TIME AUDIT (parity with the ephemeral branch): the forensic record of
+  // granting a (possibly spend-capable) dev token to a NON-approved owned app. Never
+  // the token itself.
+  req.log?.info('app-blocks.dev-tunnel.owned-nonapproved-mint', {
+    status: app.status,
+    userId,
+    slug: app.blockId,
+    sessionId: tunnel.sessionId,
+    scopes: granted,
+    spendGranted: granted.includes('ai:write:budgeted'),
+  });
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.status(200).json({
+    token: result.token,
+    expiresAt: result.expiresAt,
+    needsConsent: false,
+    missingScopes: [],
+    domain: null,
+    maxBrowsingLevel: FORCED_SFW_CEILING,
+  });
+  return 'handled';
+}
+
 export default withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   const cors = setSameOriginCors(req, res);
   if (cors === 'handled') return;
@@ -615,6 +761,22 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
         userId,
       });
       if (devMint === 'handled') return;
+      // PHASE 2 (owned non-approved) — a REAL `apb_…` page id the caller OWNS but
+      // that is NOT approved (suspended / pending / deprecated). Same audited belt,
+      // gated on an ACTIVE dev tunnel for the caller; any non-match → 'continue' →
+      // the SAME bare 404 (no oracle). Mutually exclusive with the ephemeral branch
+      // above (that one matches ONLY `ephemeral-*` ids; this one matches ONLY real
+      // ids), so exactly one can ever handle a given request.
+      const ownedMint = await tryDevTunnelOwnedNonApprovedMint({
+        req,
+        res,
+        appBlockId,
+        blockInstanceId,
+        slotId: slotContext.slotId,
+        sessionUser: session?.user,
+        userId,
+      });
+      if (ownedMint === 'handled') return;
       // Missing / not-approved / not-a-page app → 404 (never leaks which).
       res.status(404).json({ error: 'Page app not found' });
       return;

--- a/src/pages/apps/dev/[blockId].tsx
+++ b/src/pages/apps/dev/[blockId].tsx
@@ -206,6 +206,26 @@ export default function DevTunnelPage(props: DevTunnelProps) {
               the tunnel is bound to your account.
             </Alert>
           </Stack>
+        ) : error != null ? (
+          // DEV-ROUTE-SCOPED auth-failure copy. The dev tunnel mints a self-bound,
+          // forced-SFW token for the OWNER of an app at any status (approved,
+          // suspended, pending, deprecated). If the mint still fails here, the app
+          // isn't runnable in the tunnel — most likely it isn't yours or the tunnel
+          // dropped. This replaces the public host's generic "Couldn't authenticate
+          // this app" (which we deliberately do NOT change) with a message that
+          // makes sense for the dev route. Scoped to THIS route only.
+          <Stack p="md" gap="sm" style={{ maxWidth: 720, margin: '0 auto' }}>
+            <Title order={3}>Can’t run this app in the dev tunnel</Title>
+            <Alert color="red" variant="light">
+              We couldn’t mint a dev token for <Code>{blockId}</Code>. This app isn’t runnable in
+              the dev tunnel — it may be suspended, pending review, or not owned by your account.
+              If you just started the tunnel, reload the page.
+            </Alert>
+            <Text size="sm">
+              Restart your tunnel and reload if the problem persists:
+            </Text>
+            <Code block>civitai app dev:tunnel</Code>
+          </Stack>
         ) : (
           <PageBlockHost
             appBlockId={appBlockId}

--- a/src/server/services/__tests__/block-registry.resolve-owned-nonapproved.test.ts
+++ b/src/server/services/__tests__/block-registry.resolve-owned-nonapproved.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * APP DEV TUNNEL — BlockRegistry.resolveOwnedNonApprovedPageBlock.
+ *
+ * The DEV-TUNNEL-ONLY companion to resolvePageBlock. It resolves the caller's OWN
+ * page app when it is NOT approved (suspended / pending re-submitted / deprecated)
+ * so the owner can dogfood it in their own tunnel, while the PUBLIC run path stays
+ * approved-only. Pins:
+ *   - the query is OWNERSHIP-scoped (app.userId === caller) AND non-approved-only
+ *     (status != approved) — a foreign / missing / approved row → null (no oracle),
+ *   - scopes are sourced from the APPROVED SNAPSHOT column (approvedScopes),
+ *   - a non-page manifest → null,
+ *   - the manifest is surfaced (for the caller's page.buzzBudgetPerGen read).
+ */
+
+const { mockDbRead, mockDbWrite, mockRedis, mockSysRedis } = vi.hoisted(() => {
+  const dbRead = {
+    appBlock: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+  };
+  const dbWrite = {
+    appBlock: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+  };
+  const redis = {
+    packed: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) },
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 0),
+    scanIterator: async function* () {},
+  };
+  const sysRedis = { sMembers: vi.fn(async () => []) };
+  return { mockDbRead: dbRead, mockDbWrite: dbWrite, mockRedis: redis, mockSysRedis: sysRedis };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  sysRedis: mockSysRedis,
+  REDIS_KEYS: {
+    BLOCKS: { REGISTRY: 'r', TOKEN_RATE_LIMIT: 'rl', REVOKED_INSTANCE: 'rev' },
+  },
+  REDIS_SYS_KEYS: { BLOCKS: { EMERGENCY_KILL_LIST: 'kill' } },
+}));
+
+import { BlockRegistry } from '~/server/services/block-registry.service';
+
+const PAGE_MANIFEST = (overrides: Record<string, unknown> = {}) => ({
+  name: 'My App',
+  page: { path: '/', title: 'My App', buzzBudgetPerGen: 75 },
+  iframe: { src: 'https://my-app.civit.ai', sandbox: 'allow-scripts allow-forms' },
+  scopes: ['ai:write:budgeted', 'user:read:self'],
+  ...overrides,
+});
+
+/** A NON-approved AppBlock row as the resolveOwnedNonApprovedPageBlock select returns it. */
+function ownedRow(opts: {
+  status: string;
+  manifest?: Record<string, unknown>;
+  approvedScopes?: string[];
+}) {
+  return {
+    id: 'apb_real',
+    blockId: 'my-app',
+    appId: 'appblk-my-app',
+    status: opts.status,
+    manifest: opts.manifest ?? PAGE_MANIFEST(),
+    approvedScopes: opts.approvedScopes ?? ['ai:write:budgeted', 'user:read:self'],
+  };
+}
+
+describe('BlockRegistry.resolveOwnedNonApprovedPageBlock', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves an OWNED suspended page app, surfacing the approved snapshot + manifest', async () => {
+    mockDbWrite.appBlock.findFirst.mockResolvedValue(ownedRow({ status: 'suspended' }));
+    const res = await BlockRegistry.resolveOwnedNonApprovedPageBlock('apb_real', 42, {
+      db: 'write',
+    });
+    expect(res).not.toBeNull();
+    expect(res?.appBlockId).toBe('apb_real');
+    expect(res?.blockId).toBe('my-app');
+    expect(res?.appId).toBe('appblk-my-app');
+    expect(res?.status).toBe('suspended');
+    // Scope source is the approved-snapshot COLUMN, not the raw manifest.
+    expect(res?.approvedScopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+    // The manifest is surfaced so the caller can read page.buzzBudgetPerGen.
+    expect((res?.manifest.page as { buzzBudgetPerGen?: number })?.buzzBudgetPerGen).toBe(75);
+  });
+
+  it.each([['pending'], ['deprecated'], ['rejected']])(
+    'resolves an owned non-approved app in status %s',
+    async (status) => {
+      mockDbWrite.appBlock.findFirst.mockResolvedValue(ownedRow({ status }));
+      const res = await BlockRegistry.resolveOwnedNonApprovedPageBlock('apb_real', 42, {
+        db: 'write',
+      });
+      expect(res?.status).toBe(status);
+    }
+  );
+
+  it('scopes the query to OWNERSHIP (app.userId) AND non-approved (status != approved)', async () => {
+    mockDbWrite.appBlock.findFirst.mockResolvedValue(ownedRow({ status: 'suspended' }));
+    await BlockRegistry.resolveOwnedNonApprovedPageBlock('apb_real', 42, { db: 'write' });
+    const call = mockDbWrite.appBlock.findFirst.mock.calls.at(-1)?.[0] as {
+      where?: Record<string, unknown>;
+      select?: Record<string, unknown>;
+    };
+    expect(call?.where).toEqual({
+      id: 'apb_real',
+      app: { userId: 42 },
+      status: { not: 'approved' },
+    });
+    // The approved-snapshot column is actually read.
+    expect(call?.select?.approvedScopes).toBe(true);
+  });
+
+  it('returns null when the query finds no owned non-approved row (foreign / missing / approved)', async () => {
+    // A foreign-owned, missing, OR approved app all fall out of the ownership+status
+    // query as null — the caller renders the SAME bare 404 (no oracle).
+    mockDbWrite.appBlock.findFirst.mockResolvedValue(null);
+    const res = await BlockRegistry.resolveOwnedNonApprovedPageBlock('apb_real', 42, {
+      db: 'write',
+    });
+    expect(res).toBeNull();
+  });
+
+  it('returns null for a non-page manifest (no page descriptor)', async () => {
+    mockDbWrite.appBlock.findFirst.mockResolvedValue(
+      ownedRow({
+        status: 'suspended',
+        manifest: { name: 'x', iframe: { src: 'https://x.civit.ai' } },
+      })
+    );
+    const res = await BlockRegistry.resolveOwnedNonApprovedPageBlock('apb_real', 42, {
+      db: 'write',
+    });
+    expect(res).toBeNull();
+  });
+
+  it('returns null on empty inputs (no appBlockId / no userId) without a DB read', async () => {
+    expect(await BlockRegistry.resolveOwnedNonApprovedPageBlock('', 42)).toBeNull();
+    expect(await BlockRegistry.resolveOwnedNonApprovedPageBlock('apb_real', 0)).toBeNull();
+    expect(mockDbWrite.appBlock.findFirst).not.toHaveBeenCalled();
+    expect(mockDbRead.appBlock.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an EMPTY approved snapshot as [] (caller mints a read-only token)', async () => {
+    mockDbWrite.appBlock.findFirst.mockResolvedValue(
+      ownedRow({ status: 'suspended', approvedScopes: [] })
+    );
+    const res = await BlockRegistry.resolveOwnedNonApprovedPageBlock('apb_real', 42, {
+      db: 'write',
+    });
+    expect(res?.approvedScopes).toEqual([]);
+  });
+});

--- a/src/server/services/block-registry.service.ts
+++ b/src/server/services/block-registry.service.ts
@@ -413,6 +413,34 @@ export interface PageBlockResolution {
 }
 
 /**
+ * APP DEV TUNNEL — the shape resolved for an OWNED, NON-approved page app the
+ * author is dogfooding in their OWN dev tunnel (`resolveOwnedNonApprovedPageBlock`).
+ *
+ * This is the DEV-TUNNEL-ONLY companion to `resolvePageBlock` (which resolves ONLY
+ * `status:'approved'` apps for the PUBLIC run path). A previously-approved app that
+ * is now `suspended` / `pending` (re-submitted) / `deprecated` still owns a REAL
+ * `apb_` row + a moderator-reviewed `approvedScopes` snapshot, so its author can run
+ * it inside their own tunnel — but it stays NON-runnable publicly (`resolvePageBlock`
+ * still returns null for it). The mint sources scopes from `approvedScopes` (the
+ * pinned, mod-reviewed set — NEVER the raw manifest) and the per-gen budget from the
+ * manifest `page.buzzBudgetPerGen`.
+ */
+export interface OwnedNonApprovedPageBlockResolution {
+  /** The REAL AppBlock id (`apb_…`). */
+  appBlockId: string;
+  /** The app slug (== `block_id`), used to resolve the active dev tunnel. */
+  blockId: string;
+  /** The REAL OauthClient id (`appblk-…` / UUIDv4) — attribution resolves it. */
+  appId: string;
+  /** The app's current NON-approved status (suspended / pending / deprecated / …). */
+  status: string;
+  /** The moderator-reviewed approved-scope SNAPSHOT — the ONLY scope source. */
+  approvedScopes: string[];
+  /** The stored manifest — read for `page.buzzBudgetPerGen` only. */
+  manifest: Record<string, unknown>;
+}
+
+/**
  * W10 — the page block shape the SSR route consumes: just enough to render the
  * full-bleed IframeHost (iframe.src + sandbox + trust tier) and mint a token
  * (appBlockId). Public-display fields only; never the raw stored manifest.
@@ -1807,6 +1835,70 @@ export class BlockRegistry {
         app: ab.app ? { allowedScopes: ab.app.allowedScopes } : null,
         currentVersionDeployedAt: ab.currentVersionDeployedAt ?? null,
       },
+    };
+  }
+
+  /**
+   * APP DEV TUNNEL — resolve the caller's OWN, NON-approved page app by its REAL
+   * AppBlock id (`apb_…`), for the dev-tunnel block-token mint ONLY.
+   *
+   * WHY THIS EXISTS — `resolvePageBlock` requires `status:'approved'`, so a
+   * previously-approved page app that is now `suspended` / `pending` (re-submitted)
+   * / `deprecated` resolves to null there and the mint 404s ("Couldn't authenticate
+   * this app"), even though the SSR dev route (`resolveDevPageBlockForAuthor`)
+   * happily mounts it at ANY status. This closes that asymmetry for the DEV TUNNEL
+   * ONLY: the owner can dogfood their non-approved app in their OWN tunnel, while the
+   * PUBLIC run path (`resolvePageBlock`, `resolvePageBlockBySlug`) stays untouched —
+   * a suspended app remains NON-runnable publicly.
+   *
+   * CONTAINMENT (every gate here or at the caller, fail-closed):
+   *   - OWNERSHIP is enforced IN the query (`app.userId === userId`). A foreign or
+   *     missing app returns the SAME bare null (no ownership/existence oracle).
+   *   - status `!= 'approved'` is enforced in the query: an APPROVED app never
+   *     double-resolves through this branch (it mints via `resolvePageBlock`), and
+   *     this method is a NO-OP for the approved case.
+   *   - it MUST declare a page (`manifestDeclaresPage`) — a region/model-only app has
+   *     no full-page surface to mint for.
+   * The caller additionally gates on an ACTIVE dev tunnel + the author/dev-tunnel
+   * flags before it will sign anything (see `tryDevTunnelOwnedNonApprovedMint`).
+   *
+   * SCOPE SOURCE = `approvedScopes` (the moderator-reviewed snapshot pinned at the
+   * app's last approval) — NEVER the raw/re-published manifest, so a suspended app
+   * cannot widen its own scopes by editing its manifest. The caller clamps this
+   * through the SAME tunnel belt (`clampTunnelDeclaredScopes`) as the ephemeral path.
+   */
+  static async resolveOwnedNonApprovedPageBlock(
+    appBlockId: string,
+    userId: number,
+    opts?: { db?: 'read' | 'write' }
+  ): Promise<OwnedNonApprovedPageBlockResolution | null> {
+    if (!appBlockId || !userId) return null;
+    const db = opts?.db === 'read' ? dbRead : dbWrite;
+    const ab = await db.appBlock.findFirst({
+      // Ownership-scoped (app.userId === caller) AND non-approved only. A
+      // foreign/missing/approved row → null → the caller's bare 404 (no oracle).
+      where: { id: appBlockId, app: { userId }, status: { not: 'approved' } },
+      select: {
+        id: true,
+        blockId: true,
+        appId: true,
+        status: true,
+        manifest: true,
+        approvedScopes: true,
+      },
+    });
+    if (!ab) return null;
+    const manifest = (ab.manifest ?? {}) as Record<string, unknown>;
+    // A page app MUST declare a `page` block (mirrors resolvePageBlock) — otherwise
+    // there is no full-page surface to run.
+    if (!manifestDeclaresPage(manifest)) return null;
+    return {
+      appBlockId: ab.id,
+      blockId: ab.blockId,
+      appId: ab.appId,
+      status: ab.status,
+      approvedScopes: ab.approvedScopes ?? [],
+      manifest,
     };
   }
 

--- a/src/tests/api/v1/block-tokens/dev-tunnel-owned-nonapproved-mint.test.ts
+++ b/src/tests/api/v1/block-tokens/dev-tunnel-owned-nonapproved-mint.test.ts
@@ -1,0 +1,409 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+/**
+ * PHASE 2 — App Dev Tunnel OWNED, NON-APPROVED mint on POST /api/v1/block-tokens.
+ *
+ * Closes the SSR↔mint asymmetry: the SSR dev route mounts an OWNED app at ANY status
+ * (`resolveDevPageBlockForAuthor`), but the token mint's `resolvePageBlock` requires
+ * `status:'approved'` and `tryDevTunnelScopedMint` only rescues the synthetic
+ * `ephemeral-*` namespace — so a previously-approved app now suspended / pending /
+ * deprecated (a REAL `apb_…` id) fell through BOTH branches to the bare 404, which the
+ * host rendered as "Couldn't authenticate this app". This branch mints a SCOPED,
+ * forced-SFW, self-bound, budget-capped dev token for that case, gated on OWNERSHIP +
+ * an ACTIVE dev tunnel + the author/dev-tunnel flags, sourcing scopes from the app's
+ * APPROVED SNAPSHOT (never the raw manifest).
+ *
+ * Asserts the 6 security invariants + the full matrix:
+ *   ✅ owner + suspended/pending/deprecated + active tunnel + flags → self-bound mint,
+ *      scopes = clamped approved snapshot, budget from manifest, forced-SFW, dev:true,
+ *   ❌ non-owner (resolver → null) → the SAME bare 404, no mint, no oracle,
+ *   ❌ owner + no active tunnel → 404 (not a general un-suspend),
+ *   ❌ owner + dev-tunnel flag OFF → 404 (also proves the PUBLIC path stays 404),
+ *   ✅ scope clamp: apps:storage:* in the approved snapshot is STRIPPED,
+ *   ✅ approved app → handled by resolvePageBlock; this branch is never reached.
+ */
+
+const {
+  mockDbWrite,
+  mockRedis,
+  mockSession,
+  mockTokenService,
+  mockBlockRegistry,
+  mockFlags,
+  mockAppBlocksFlag,
+  mockDevTunnelService,
+} = vi.hoisted(() => {
+  const dbWrite = {
+    user: {
+      findUnique: vi.fn<(...args: any[]) => Promise<any>>(async () => ({
+        deletedAt: null,
+        bannedAt: null,
+      })),
+    },
+    appUserScopeGrant: { findUnique: vi.fn<(...args: any[]) => Promise<any>>(async () => null) },
+  };
+  const redis = {
+    incrBy: vi.fn(async () => 1),
+    expire: vi.fn(async () => true),
+    ttl: vi.fn(async () => 60),
+  };
+  const session = { value: null as any };
+  const tokenService = {
+    sign: vi.fn<(...args: any[]) => Promise<any>>(async () => ({
+      token: 'jwt.dev.signed',
+      expiresAt: '2099-01-01T00:00:00Z',
+      jti: 'j',
+    })),
+    checkRateLimit: vi.fn<(...args: any[]) => Promise<boolean>>(async () => true),
+  };
+  const blockRegistry = {
+    resolveBlockInstance: vi.fn<(...args: any[]) => Promise<any>>(),
+    // resolvePageBlock MISSES for a non-approved app → the dev branches run.
+    resolvePageBlock: vi.fn<(...args: any[]) => Promise<any>>(async () => null),
+    // Ephemeral branch resolver — never matches a real `apb_…` id, but the handler
+    // calls it only for the `ephemeral-*` namespace; default null keeps it inert.
+    resolveDevPageBlockForAuthor: vi.fn<(...args: any[]) => Promise<any>>(async () => null),
+    // The NEW owned-non-approved resolver.
+    resolveOwnedNonApprovedPageBlock: vi.fn<(...args: any[]) => Promise<any>>(async () => null),
+  };
+  const flags = {
+    getFeatureFlags: vi.fn(({ user }: { user?: { isModerator?: boolean } }) => ({
+      appBlocks: !!user?.isModerator,
+      appBlocksPages: !!user?.isModerator,
+    })),
+  };
+  const appBlocksFlag = {
+    isAppBlocksAuthorEnabled: vi.fn(async () => true),
+    isAppBlocksDevTunnelEnabled: vi.fn(async () => true),
+    isAppBlocksDevTunnelUnsubmittedSpendEnabled: vi.fn(async () => true),
+  };
+  const devTunnelService = {
+    getActiveDevTunnel: vi.fn<(...args: any[]) => Promise<any>>(async () => ({
+      sessionId: 'bki_testsession',
+      grantedScopes: [],
+    })),
+  };
+  return {
+    mockDbWrite: dbWrite,
+    mockRedis: redis,
+    mockSession: session,
+    mockTokenService: tokenService,
+    mockBlockRegistry: blockRegistry,
+    mockFlags: flags,
+    mockAppBlocksFlag: appBlocksFlag,
+    mockDevTunnelService: devTunnelService,
+  };
+});
+
+vi.mock('~/env/server', () => ({
+  env: {
+    NEXTAUTH_URL: 'https://civitai.com',
+    TRPC_ORIGINS: [],
+    BLOCK_TOKEN_PRIVATE_KEY: 'fake-private',
+    BLOCK_TOKEN_PUBLIC_KEY: 'fake-public',
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: unknown) => h }));
+vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
+vi.mock('~/server/auth/get-server-auth-session', () => ({
+  getServerAuthSession: vi.fn(async () => mockSession.value),
+}));
+vi.mock('~/server/services/block-token.service', () => ({ BlockTokenService: mockTokenService }));
+vi.mock('~/server/services/block-registry.service', () => ({ BlockRegistry: mockBlockRegistry }));
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'rl' } },
+}));
+vi.mock('~/server/utils/server-domain', () => ({
+  getAllServerHosts: () => ['civitai.com'],
+  getRequestDomainColor: () => undefined,
+  isHostForColor: () => false,
+  isMatureContentRating: () => false,
+}));
+vi.mock('~/server/services/feature-flags.service', () => mockFlags);
+vi.mock('~/server/services/app-blocks-flag', () => mockAppBlocksFlag);
+vi.mock('~/server/services/blocks/dev-tunnel.service', () => mockDevTunnelService);
+
+function makeReq(body: unknown): NextApiRequest & { log?: any } {
+  return {
+    method: 'POST',
+    headers: { origin: 'https://civitai.com' },
+    body,
+    socket: { remoteAddress: '127.0.0.1' },
+    query: {},
+  } as unknown as NextApiRequest;
+}
+
+function makeRes() {
+  const res = {
+    _status: 0,
+    _body: null as any,
+    _headers: {} as Record<string, string>,
+    setHeader: vi.fn(function (this: any, name: string, value: string) {
+      this._headers[name.toLowerCase()] = value;
+      return this;
+    }),
+    status: vi.fn(function (this: any, n: number) {
+      this._status = n;
+      return this;
+    }),
+    json: vi.fn(function (this: any, b: unknown) {
+      this._body = b;
+      return this;
+    }),
+    end: vi.fn(function (this: any) {
+      return this;
+    }),
+    send: vi.fn(function (this: any, b: unknown) {
+      this._body = b;
+      return this;
+    }),
+  };
+  return res as unknown as NextApiResponse & {
+    _status: number;
+    _body: any;
+    _headers: Record<string, string>;
+  };
+}
+
+const MOD = { user: { id: 4242, isModerator: true, bannedAt: null } };
+
+// The resolution BlockRegistry.resolveOwnedNonApprovedPageBlock returns for an OWNED,
+// non-approved page app: the REAL ids + the app's status + the moderator-reviewed
+// approved-scope SNAPSHOT + the manifest (for page.buzzBudgetPerGen).
+const OWNED_RESOLUTION = (extra?: Record<string, unknown>) => ({
+  appBlockId: 'apb_real',
+  blockId: 'my-app',
+  appId: 'appblk-my-app',
+  status: 'suspended',
+  approvedScopes: ['ai:write:budgeted', 'user:read:self'],
+  manifest: {
+    name: 'My App',
+    page: { path: '/', title: 'My App', buzzBudgetPerGen: 75 },
+    scopes: ['ai:write:budgeted', 'user:read:self'],
+  },
+  ...extra,
+});
+
+const DEV_BODY = (extra?: Record<string, unknown>) => ({
+  blockInstanceId: 'page_apb_real',
+  slotContext: { entityType: 'none', slotId: 'app.page' },
+  ...extra,
+});
+
+async function invoke(body: unknown) {
+  const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+  const res = makeRes();
+  await handler(makeReq(body), res);
+  return res;
+}
+
+describe('POST /api/v1/block-tokens — dev-tunnel OWNED non-approved mint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSession.value = MOD;
+    mockRedis.incrBy.mockResolvedValue(1);
+    mockRedis.ttl.mockResolvedValue(60);
+    mockTokenService.checkRateLimit.mockResolvedValue(true);
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue(null); // non-approved → miss
+    mockBlockRegistry.resolveDevPageBlockForAuthor.mockResolvedValue(null);
+    mockBlockRegistry.resolveOwnedNonApprovedPageBlock.mockResolvedValue(OWNED_RESOLUTION());
+    mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: null, bannedAt: null });
+    mockAppBlocksFlag.isAppBlocksAuthorEnabled.mockResolvedValue(true);
+    mockAppBlocksFlag.isAppBlocksDevTunnelEnabled.mockResolvedValue(true);
+    mockDevTunnelService.getActiveDevTunnel.mockResolvedValue({
+      sessionId: 'bki_testsession',
+      grantedScopes: [],
+    });
+  });
+
+  it('owner + SUSPENDED app + active tunnel + flags → mints a self-bound token (real ids, dev:true, forced-SFW)', async () => {
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(200);
+    expect(res._body.token).toBe('jwt.dev.signed');
+    expect(res._body.domain).toBeNull();
+    expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
+    const arg = mockTokenService.sign.mock.calls[0][0] as any;
+    // Scopes = clamped approved snapshot (user:read:self force-added; already present).
+    expect(arg.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+    // Self-bound to the OWNER; the app's REAL ids are signed (not synthetic).
+    expect(arg.userId).toBe(MOD.user.id);
+    expect(arg.appId).toBe('appblk-my-app');
+    expect(arg.appBlockId).toBe('apb_real');
+    expect(arg.blockId).toBe('my-app');
+    expect(arg.blockInstanceId).toBe('page_apb_real');
+    expect(arg.dev).toBe(true);
+    expect(arg.domain).toBeNull();
+    // Budget from the manifest page.buzzBudgetPerGen (75), clamped to the dev cap (250).
+    expect(arg.buzzBudget).toBe(75);
+    // Ownership resolve was called with the real id + caller + write db.
+    expect(mockBlockRegistry.resolveOwnedNonApprovedPageBlock).toHaveBeenCalledWith(
+      'apb_real',
+      MOD.user.id,
+      { db: 'write' }
+    );
+    // Active-tunnel check keyed on (userId, slug).
+    expect(mockDevTunnelService.getActiveDevTunnel).toHaveBeenCalledWith(MOD.user.id, 'my-app');
+  });
+
+  it.each([['pending'], ['deprecated']])(
+    'owner + %s app + active tunnel → mints via the SAME belt',
+    async (status) => {
+      mockBlockRegistry.resolveOwnedNonApprovedPageBlock.mockResolvedValue(
+        OWNED_RESOLUTION({ status })
+      );
+      const res = await invoke(DEV_BODY());
+      expect(res._status).toBe(200);
+      expect(mockTokenService.sign).toHaveBeenCalledTimes(1);
+      const arg = mockTokenService.sign.mock.calls[0][0] as any;
+      expect(arg.appBlockId).toBe('apb_real');
+      expect(arg.dev).toBe(true);
+    }
+  );
+
+  it('NON-OWNER (resolver → null) → the SAME bare 404, NO token, even with a tunnel + flags on', async () => {
+    // The resolver enforces ownership in the query; a non-owner gets null → 404. The
+    // active tunnel + flags are irrelevant — no cross-user mint, no existence oracle.
+    mockBlockRegistry.resolveOwnedNonApprovedPageBlock.mockResolvedValue(null);
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(404);
+    expect(res._body).toEqual({ error: 'Page app not found' });
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+    // Fail-closed before ever touching the tunnel (resolve gates first).
+    expect(mockDevTunnelService.getActiveDevTunnel).not.toHaveBeenCalled();
+  });
+
+  it('owner + suspended app but NO ACTIVE TUNNEL → 404 (not a general un-suspend)', async () => {
+    mockDevTunnelService.getActiveDevTunnel.mockResolvedValue(null);
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(404);
+    expect(res._body).toEqual({ error: 'Page app not found' });
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('owner + suspended app + dev-tunnel FLAG OFF → 404 (also proves the PUBLIC path stays 404 for a suspended app)', async () => {
+    mockAppBlocksFlag.isAppBlocksDevTunnelEnabled.mockResolvedValue(false);
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(404);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+    // Fail-closed BEFORE resolving ownership / touching the tunnel.
+    expect(mockBlockRegistry.resolveOwnedNonApprovedPageBlock).not.toHaveBeenCalled();
+    expect(mockDevTunnelService.getActiveDevTunnel).not.toHaveBeenCalled();
+  });
+
+  it('author capability OFF → 404, NO token', async () => {
+    mockAppBlocksFlag.isAppBlocksAuthorEnabled.mockResolvedValue(false);
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(404);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+    expect(mockBlockRegistry.resolveOwnedNonApprovedPageBlock).not.toHaveBeenCalled();
+  });
+
+  it('SCOPE CLAMP: apps:storage:* / social:tip:self in the approved snapshot are STRIPPED, no widening', async () => {
+    mockBlockRegistry.resolveOwnedNonApprovedPageBlock.mockResolvedValue(
+      OWNED_RESOLUTION({
+        approvedScopes: ['ai:write:budgeted', 'apps:storage:read', 'apps:storage:write', 'social:tip:self'],
+      })
+    );
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(200);
+    const arg = mockTokenService.sign.mock.calls[0][0] as any;
+    // ai:write:budgeted survives (tunnel allowlist), storage/tip stripped, self-read added.
+    expect(arg.scopes).toEqual(['ai:write:budgeted', 'user:read:self']);
+    expect(arg.scopes).not.toContain('apps:storage:read');
+    expect(arg.scopes).not.toContain('apps:storage:write');
+    expect(arg.scopes).not.toContain('social:tip:self');
+  });
+
+  it('an EMPTY approved snapshot → a valid READ-ONLY token (user:read:self only, no budget)', async () => {
+    mockBlockRegistry.resolveOwnedNonApprovedPageBlock.mockResolvedValue(
+      OWNED_RESOLUTION({ approvedScopes: [] })
+    );
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(200);
+    const arg = mockTokenService.sign.mock.calls[0][0] as any;
+    expect(arg.scopes).toEqual(['user:read:self']);
+    expect(arg.buzzBudget).toBeUndefined(); // no spend scope → no budget
+  });
+
+  it('a read-only approved snapshot (no ai:write:budgeted) mints no budget', async () => {
+    mockBlockRegistry.resolveOwnedNonApprovedPageBlock.mockResolvedValue(
+      OWNED_RESOLUTION({ approvedScopes: ['user:read:self', 'models:read:self'] })
+    );
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(200);
+    const arg = mockTokenService.sign.mock.calls[0][0] as any;
+    expect(arg.scopes).toEqual(['models:read:self', 'user:read:self']);
+    expect(arg.buzzBudget).toBeUndefined();
+  });
+
+  it('emits the app-blocks.dev-tunnel.owned-nonapproved-mint audit event, NEVER the token', async () => {
+    const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const { default: handler } = await import('~/pages/api/v1/block-tokens/index');
+    const req = makeReq(DEV_BODY()) as any;
+    req.log = log;
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(200);
+    expect(log.info).toHaveBeenCalledWith(
+      'app-blocks.dev-tunnel.owned-nonapproved-mint',
+      expect.objectContaining({
+        status: 'suspended',
+        userId: MOD.user.id,
+        slug: 'my-app',
+        sessionId: 'bki_testsession',
+        scopes: ['ai:write:budgeted', 'user:read:self'],
+        spendGranted: true,
+      })
+    );
+    const payload = log.info.mock.calls.find(
+      (c: any[]) => c[0] === 'app-blocks.dev-tunnel.owned-nonapproved-mint'
+    )![1];
+    expect(JSON.stringify(payload)).not.toContain('jwt.dev.signed');
+  });
+
+  it('a soft-deleted account never mints (M1 parity)', async () => {
+    mockDbWrite.user.findUnique.mockResolvedValue({ deletedAt: new Date(), bannedAt: null });
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(404);
+    expect(mockTokenService.sign).not.toHaveBeenCalled();
+  });
+
+  it('REGRESSION: an APPROVED app is handled by resolvePageBlock — this branch is never reached', async () => {
+    // resolvePageBlock succeeds for an approved app → the normal mint path runs and
+    // the owned-non-approved branch (and its resolver) is never touched.
+    mockBlockRegistry.resolvePageBlock.mockResolvedValue({
+      appBlock: {
+        id: 'apb_real',
+        blockId: 'my-app',
+        appId: 'appblk-my-app',
+        status: 'approved',
+        currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
+        manifest: { scopes: ['models:read:self'], page: { path: '/', title: 'My App' } },
+        approvedScopes: ['models:read:self'],
+        app: { allowedScopes: 4 /* ModelsRead */ },
+      },
+    });
+    mockDbWrite.appUserScopeGrant.findUnique.mockResolvedValue({
+      grantedScopes: ['models:read:self'],
+      revokedAt: null,
+    });
+    const res = await invoke(DEV_BODY());
+    expect(res._status).toBe(200);
+    // The non-approved branch never ran for an approved app.
+    expect(mockBlockRegistry.resolveOwnedNonApprovedPageBlock).not.toHaveBeenCalled();
+  });
+
+  it('an ephemeral-<slug> id is NOT handled by this branch (belongs to tryDevTunnelScopedMint)', async () => {
+    // A synthetic ephemeral id must never reach resolveOwnedNonApprovedPageBlock — the
+    // prefix gate hands it to the ephemeral branch instead. Here the ephemeral
+    // resolver returns null → 404, and the owned resolver is never called.
+    const res = await invoke({
+      blockInstanceId: 'page_ephemeral-my-app',
+      slotContext: { entityType: 'none', slotId: 'app.page' },
+    });
+    expect(res._status).toBe(404);
+    expect(mockBlockRegistry.resolveOwnedNonApprovedPageBlock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

The App Blocks **dev tunnel** had an SSR↔mint asymmetry. The SSR dev route (`/apps/dev/<blockId>`) resolves an **owned** app at **any** status (`BlockRegistry.resolveDevPageBlockForAuthor`) and mounts `<PageBlockHost>` with the real `appBlockId=apb_…`. But the token mint (`POST /api/v1/block-tokens`) required `status='approved'` (`resolvePageBlock`), and `tryDevTunnelScopedMint` only rescued the synthetic `ephemeral-*` namespace. So a **previously-approved page app that is now `suspended` / `pending` (re-submitted) / `deprecated`** — a real `apb_` id — fell through **both** mint branches to a bare `404 Page app not found`, which the host renders as **"Couldn't authenticate this app."** The owner could no longer dogfood their own app in their own dev tunnel.

(Pending-**never**-approved apps have no `apb_` row and already work via the ephemeral path — this only affected apps that were approved at least once.)

## Fix

Add a **dev-tunnel-only** branch — `tryDevTunnelOwnedNonApprovedMint` in the mint handler + `BlockRegistry.resolveOwnedNonApprovedPageBlock` — that mints a **scoped, forced-SFW, self-bound, budget-capped** dev token for that case, reusing the **identical audited belt** as the ephemeral path (`clampTunnelDeclaredScopes` / `resolveDevBuzzBudget` / `signDevScopedPageToken`, `TUNNEL_HOST_MINT_SCOPE_ALLOWLIST`). No new signing path.

### Security invariants (ALL required — any failure → the SAME bare 404, no oracle, no mint)

1. **Ownership** — the resolver enforces `app.userId === caller` **in the query**. A non-owner requesting a suspended app's token gets the bare 404 (no cross-user mint, no existence oracle).
2. **Active dev tunnel** — an ACTIVE `getActiveDevTunnel(caller, blockId)` is **required** (the same check the ephemeral/scoped mint uses). Not a general un-suspend.
3. **Flag-gated** — `app-blocks-enabled` + `appBlocksAuthor` + the `app-blocks-dev-tunnel` kill-switch, all evaluated for the caller. (No `unsubmitted-spend` flag: the scopes are a prior moderator-approved snapshot, not a never-reviewed manifest.)
4. **Self-bound** — token `sub` = the owner; at runtime it spends the owner's **own** Buzz under `assertViewerIsAppDeveloper(sub)` + per-call/session/day caps. Budget = the manifest `page.buzzBudgetPerGen`, clamped to the dev cap, forced-SFW.
5. **Scopes** — sourced from the app's **APPROVED SNAPSHOT** (`approvedScopes`), **never** the raw/re-published manifest, then tunnel-allowlist-clamped. No scope escalation.
6. **No public-path bypass** — the public run-mint (`resolvePageBlock`) + SSR run page (`resolvePageBlockBySlug`) still require `status='approved'` and are untouched. **A suspended app stays non-runnable publicly.**

The token carries the app's **real** ids, so runtime spend-attribution resolves the real OauthClient and lands as a `self_spend`-**voided** row (spender == owner) — no forged attribution, no bounty.

### Secondary

Clarifies the SSR dev-route auth-failure copy (scoped to `/apps/dev/<blockId>` only; the public host's "Couldn't authenticate this app" copy is unchanged).

## Tests

- `dev-tunnel-owned-nonapproved-mint.test.ts` — full matrix: owner + suspended/pending/deprecated + active tunnel → mint (real ids, `dev:true`, forced-SFW, budget from manifest); **non-owner → 404**; **no active tunnel → 404**; **flag off → 404** (also proves the public path stays 404 for a suspended app); **scope clamp** (`apps:storage:*` / `social:tip:self` stripped); empty snapshot → read-only; read-only snapshot → no budget; audit event fires (never the token); soft-deleted account → no mint; **approved app untouched** (handled by `resolvePageBlock`); **ephemeral path untouched**.
- `block-registry.resolve-owned-nonapproved.test.ts` — resolver unit tests (ownership+non-approved query shape, approved-snapshot sourcing, non-page → null, empty inputs → no DB read).
- The 7 owner-mint assertions were verified **red without the fix**.
- Existing block-registry / block-tokens / dev-tunnel-page suites all still pass (180 tests green across the related suites).

## Rollout

Dark / invite-gated (`app-blocks-dev-tunnel` base-off). Being a **money/auth-path token mint**, this warrants an adversarial `/audit-pr` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)