### PR TITLE
fix(block): enforce user blocking on comment/reaction/review write paths

### DIFF
--- a/src/server/controllers/comment.controller.ts
+++ b/src/server/controllers/comment.controller.ts
@@ -23,6 +23,7 @@ import {
   updateCommentReportStatusByReason,
 } from '~/server/services/comment.service';
 import { createNotification } from '~/server/services/notification.service';
+import { throwIfBlockedByOwners } from '~/server/services/block-check.service';
 import { amIBlockedByUser } from '~/server/services/user.service';
 import {
   throwAuthorizationError,
@@ -103,6 +104,21 @@ export const upsertCommentHandler = async ({
     await throwOnBlockedLinkDomain(input.content);
     const { ownerId, locked } = ctx;
     const { modelId } = input;
+
+    if (!input.commentId && !ctx.user.isModerator) {
+      const parentAuthorId = input.parentId
+        ? (
+            await dbRead.comment.findUnique({
+              where: { id: input.parentId },
+              select: { userId: true },
+            })
+          )?.userId
+        : undefined;
+      await throwIfBlockedByOwners({
+        userId: ctx.user.id,
+        ownerIds: [ownerId, parentAuthorId],
+      });
+    }
 
     // Get model and at least 2 version to confirm access.
     // If model has 1 version, check access to that version. Otherwise, ignore.

--- a/src/server/controllers/commentv2.controller.ts
+++ b/src/server/controllers/commentv2.controller.ts
@@ -93,7 +93,11 @@ export const upsertCommentV2Handler = async ({
       }
     }
 
-    const result = await upsertComment({ ...input, userId: ctx.user.id });
+    const result = await upsertComment({
+      ...input,
+      userId: ctx.user.id,
+      isModerator: ctx.user.isModerator,
+    });
     if (!input.id) {
       if (type && type !== 'Article' && type !== 'Challenge') {
         await ctx.track.comment({

--- a/src/server/controllers/reaction.controller.ts
+++ b/src/server/controllers/reaction.controller.ts
@@ -21,6 +21,7 @@ import type { ReactionType } from '../clickhouse/client';
 import { dbRead } from '../db/client';
 import { toggleReaction } from './../services/reaction.service';
 import { hasEntityAccess } from '~/server/services/common.service';
+import { throwIfBlockedByEntityOwner } from '~/server/services/block-check.service';
 
 async function getTrackerEvent(input: ToggleReactionInput, result: 'removed' | 'created') {
   const shared = {
@@ -224,6 +225,13 @@ export const toggleReactionHandler = async ({
         }
       }
     }
+
+    await throwIfBlockedByEntityOwner({
+      userId: ctx.user.id,
+      entityType: input.entityType,
+      entityId: input.entityId,
+      isModerator: ctx.user.isModerator,
+    });
 
     const result = await toggleReaction({ ...input, userId: ctx.user.id });
     const trackerEvent = await getTrackerEvent(input, result);

--- a/src/server/controllers/reaction.controller.ts
+++ b/src/server/controllers/reaction.controller.ts
@@ -21,7 +21,6 @@ import type { ReactionType } from '../clickhouse/client';
 import { dbRead } from '../db/client';
 import { toggleReaction } from './../services/reaction.service';
 import { hasEntityAccess } from '~/server/services/common.service';
-import { throwIfBlockedByEntityOwner } from '~/server/services/block-check.service';
 
 async function getTrackerEvent(input: ToggleReactionInput, result: 'removed' | 'created') {
   const shared = {
@@ -226,14 +225,11 @@ export const toggleReactionHandler = async ({
       }
     }
 
-    await throwIfBlockedByEntityOwner({
+    const result = await toggleReaction({
+      ...input,
       userId: ctx.user.id,
-      entityType: input.entityType,
-      entityId: input.entityId,
       isModerator: ctx.user.isModerator,
     });
-
-    const result = await toggleReaction({ ...input, userId: ctx.user.id });
     const trackerEvent = await getTrackerEvent(input, result);
     if (trackerEvent) {
       await ctx.track

--- a/src/server/controllers/resourceReview.controller.ts
+++ b/src/server/controllers/resourceReview.controller.ts
@@ -42,7 +42,11 @@ export const upsertResourceReviewHandler = async ({
       throw throwAuthorizationError('You do not have access to this model version.');
     }
 
-    return await upsertResourceReview({ ...input, userId: ctx.user.id });
+    return await upsertResourceReview({
+      ...input,
+      userId: ctx.user.id,
+      isModerator: ctx.user.isModerator,
+    });
   } catch (error) {
     throw throwDbError(error);
   }

--- a/src/server/services/__tests__/block-check.service.test.ts
+++ b/src/server/services/__tests__/block-check.service.test.ts
@@ -25,6 +25,10 @@ const { mockDb, amIBlockedByUser } = vi.hoisted(() => ({
     comment: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     commentV2: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
     thread: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    model3D: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    model3DReview: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    comicChapter: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    comicProject: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
   },
 }));
 
@@ -110,6 +114,25 @@ describe('getBlockCheckOwnerIds — owner resolution per entity type', () => {
     expect(owners).toEqual(expect.arrayContaining([PARENT_AUTHOR, OWNER]));
   });
 
+  it('resolves the model3d owner', async () => {
+    mockDb.model3D.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    expect(await getBlockCheckOwnerIds({ entityType: 'model3d', entityId: 1 })).toEqual([OWNER]);
+  });
+
+  it('resolves the model3dReview owner', async () => {
+    mockDb.model3DReview.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    expect(await getBlockCheckOwnerIds({ entityType: 'model3dReview', entityId: 1 })).toEqual([
+      OWNER,
+    ]);
+  });
+
+  it('resolves the comicChapter owner via its project', async () => {
+    mockDb.comicChapter.findUnique.mockResolvedValueOnce({ project: { userId: OWNER } });
+    expect(await getBlockCheckOwnerIds({ entityType: 'comicChapter', entityId: 1 })).toEqual([
+      OWNER,
+    ]);
+  });
+
   it('returns [] for unowned/unknown entity types (no false blocks)', async () => {
     expect(await getBlockCheckOwnerIds({ entityType: 'appListing', entityId: 1 })).toEqual([]);
     expect(await getBlockCheckOwnerIds({ entityType: 'challenge', entityId: 1 })).toEqual([]);
@@ -129,6 +152,22 @@ describe('throwIfBlockedByEntityOwner — enforcement', () => {
       throwIfBlockedByEntityOwner({ userId: VIEWER, entityType: 'image', entityId: 1 })
     ).rejects.toThrow();
     expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: VIEWER, targetUserId: OWNER });
+  });
+
+  it('rejects a blocked user creating a model3d comment', async () => {
+    mockDb.model3D.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    amIBlockedByUser.mockResolvedValueOnce(true);
+    await expect(
+      throwIfBlockedByEntityOwner({ userId: VIEWER, entityType: 'model3d', entityId: 1 })
+    ).rejects.toThrow();
+  });
+
+  it('rejects a blocked user creating a comicChapter comment', async () => {
+    mockDb.comicChapter.findUnique.mockResolvedValueOnce({ project: { userId: OWNER } });
+    amIBlockedByUser.mockResolvedValueOnce(true);
+    await expect(
+      throwIfBlockedByEntityOwner({ userId: VIEWER, entityType: 'comicChapter', entityId: 1 })
+    ).rejects.toThrow();
   });
 
   it('does not throw when the acting user is NOT blocked', async () => {

--- a/src/server/services/__tests__/block-check.service.test.ts
+++ b/src/server/services/__tests__/block-check.service.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * User-blocking enforcement on write/interaction paths.
+ *
+ * Blocking used to be enforced read-side only (a blocked viewer 404s on the
+ * entity page), so a blocked user could still comment / reply / react / review
+ * the creator's content via direct tRPC/API calls. `throwIfBlockedByEntityOwner`
+ * closes that gap by resolving the content owner and throwing NotFound (mirroring
+ * the read handlers) when the acting user is blocked by that owner.
+ */
+
+const { mockDb, amIBlockedByUser } = vi.hoisted(() => ({
+  amIBlockedByUser: vi.fn(async (..._a: unknown[]): Promise<boolean> => false),
+  mockDb: {
+    image: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    post: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    article: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    model: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    resourceReview: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    question: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    answer: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    bounty: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    bountyEntry: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    comment: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    commentV2: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    thread: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser }));
+
+import {
+  getBlockCheckOwnerIds,
+  throwIfBlockedByEntityOwner,
+  throwIfBlockedByOwners,
+} from '~/server/services/block-check.service';
+
+const OWNER = 100;
+const VIEWER = 7;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  amIBlockedByUser.mockResolvedValue(false);
+});
+
+describe('getBlockCheckOwnerIds — owner resolution per entity type', () => {
+  it('resolves the image owner', async () => {
+    mockDb.image.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    expect(await getBlockCheckOwnerIds({ entityType: 'image', entityId: 1 })).toEqual([OWNER]);
+  });
+
+  it('resolves the post owner', async () => {
+    mockDb.post.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    expect(await getBlockCheckOwnerIds({ entityType: 'post', entityId: 1 })).toEqual([OWNER]);
+  });
+
+  it('resolves the model owner', async () => {
+    mockDb.model.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    expect(await getBlockCheckOwnerIds({ entityType: 'model', entityId: 1 })).toEqual([OWNER]);
+  });
+
+  it('resolves the resourceReview owner (review + resourceReview aliases)', async () => {
+    mockDb.resourceReview.findUnique.mockResolvedValue({ userId: OWNER });
+    expect(await getBlockCheckOwnerIds({ entityType: 'review', entityId: 1 })).toEqual([OWNER]);
+    expect(await getBlockCheckOwnerIds({ entityType: 'resourceReview', entityId: 1 })).toEqual([
+      OWNER,
+    ]);
+  });
+
+  it('resolves the legacy comment (commentOld) author', async () => {
+    mockDb.comment.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    expect(await getBlockCheckOwnerIds({ entityType: 'commentOld', entityId: 1 })).toEqual([OWNER]);
+  });
+
+  it('reply target (comment): resolves BOTH parent author and root content owner', async () => {
+    const PARENT_AUTHOR = 55;
+    mockDb.commentV2.findUnique.mockResolvedValueOnce({
+      userId: PARENT_AUTHOR,
+      thread: {
+        rootThreadId: 999,
+        imageId: null,
+        postId: null,
+        articleId: null,
+        modelId: null,
+        reviewId: null,
+        bountyId: null,
+        bountyEntryId: null,
+        questionId: null,
+        answerId: null,
+      },
+    });
+    // root thread hangs off an image owned by OWNER
+    mockDb.thread.findUnique.mockResolvedValueOnce({
+      rootThreadId: null,
+      imageId: 42,
+      postId: null,
+      articleId: null,
+      modelId: null,
+      reviewId: null,
+      bountyId: null,
+      bountyEntryId: null,
+      questionId: null,
+      answerId: null,
+    });
+    mockDb.image.findUnique.mockResolvedValueOnce({ userId: OWNER });
+
+    const owners = await getBlockCheckOwnerIds({ entityType: 'comment', entityId: 1 });
+    expect(owners).toEqual(expect.arrayContaining([PARENT_AUTHOR, OWNER]));
+  });
+
+  it('returns [] for unowned/unknown entity types (no false blocks)', async () => {
+    expect(await getBlockCheckOwnerIds({ entityType: 'appListing', entityId: 1 })).toEqual([]);
+    expect(await getBlockCheckOwnerIds({ entityType: 'challenge', entityId: 1 })).toEqual([]);
+  });
+
+  it('returns [] when the entity does not exist', async () => {
+    mockDb.image.findUnique.mockResolvedValueOnce(null);
+    expect(await getBlockCheckOwnerIds({ entityType: 'image', entityId: 1 })).toEqual([]);
+  });
+});
+
+describe('throwIfBlockedByEntityOwner — enforcement', () => {
+  it('throws NotFound when the acting user is blocked by the content owner', async () => {
+    mockDb.image.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    amIBlockedByUser.mockResolvedValueOnce(true);
+    await expect(
+      throwIfBlockedByEntityOwner({ userId: VIEWER, entityType: 'image', entityId: 1 })
+    ).rejects.toThrow();
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: VIEWER, targetUserId: OWNER });
+  });
+
+  it('does not throw when the acting user is NOT blocked', async () => {
+    mockDb.image.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    amIBlockedByUser.mockResolvedValue(false);
+    await expect(
+      throwIfBlockedByEntityOwner({ userId: VIEWER, entityType: 'image', entityId: 1 })
+    ).resolves.toBeUndefined();
+  });
+
+  it('never blocks the owner acting on their own content (owner === viewer)', async () => {
+    mockDb.image.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    await throwIfBlockedByEntityOwner({ userId: OWNER, entityType: 'image', entityId: 1 });
+    expect(amIBlockedByUser).not.toHaveBeenCalled();
+  });
+
+  it('exempts moderators even when blocked', async () => {
+    mockDb.image.findUnique.mockResolvedValueOnce({ userId: OWNER });
+    amIBlockedByUser.mockResolvedValue(true);
+    await expect(
+      throwIfBlockedByEntityOwner({
+        userId: VIEWER,
+        entityType: 'image',
+        entityId: 1,
+        isModerator: true,
+      })
+    ).resolves.toBeUndefined();
+    expect(amIBlockedByUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('throwIfBlockedByOwners — reply / legacy-comment helper', () => {
+  it('throws if blocked by ANY of the supplied owners (e.g. parent comment author)', async () => {
+    amIBlockedByUser.mockImplementation(async ({ targetUserId }: { targetUserId: number }) => {
+      return targetUserId === 55; // blocked by the parent comment author only
+    });
+    await expect(
+      throwIfBlockedByOwners({ userId: VIEWER, ownerIds: [OWNER, 55] })
+    ).rejects.toThrow();
+  });
+
+  it('skips null/undefined owner ids and passes when none block', async () => {
+    amIBlockedByUser.mockResolvedValue(false);
+    await expect(
+      throwIfBlockedByOwners({ userId: VIEWER, ownerIds: [OWNER, null, undefined] })
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/server/services/__tests__/commentsv2.appListing.service.test.ts
+++ b/src/server/services/__tests__/commentsv2.appListing.service.test.ts
@@ -52,6 +52,11 @@ vi.mock('~/server/services/blocklist.service', () => ({
 vi.mock('~/server/utils/otel-helpers', () => ({
   withSpan: (_name: string, fn: () => unknown) => fn(),
 }));
+// upsertComment now runs a block check; stub the block resolver's user lookup so
+// the heavy real user.service module isn't pulled into this unit test.
+vi.mock('~/server/services/user.service', () => ({
+  amIBlockedByUser: vi.fn(async () => false),
+}));
 
 import {
   getCommentCount,

--- a/src/server/services/__tests__/commentsv2.blockCheck.service.test.ts
+++ b/src/server/services/__tests__/commentsv2.blockCheck.service.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * upsertComment (CommentsV2 service) must enforce user-blocking on the CREATE
+ * branch only: a user blocked by the content owner can't add a comment, but
+ * editing an existing comment (`data.id` set) skips the check.
+ */
+
+const { db, amIBlockedByUser } = vi.hoisted(() => {
+  const amIBlockedByUser = vi.fn(async (..._a: unknown[]): Promise<boolean> => false);
+  const tx = {
+    thread: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 100, locked: false })),
+    },
+    commentV2: { create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 999 })) },
+  };
+  return {
+    db: {
+      tx,
+      image: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ userId: 100 })) },
+      thread: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+      commentV2: {
+        create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 999 })),
+        update: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 5 })),
+      },
+      $transaction: vi.fn(async (cb: (t: typeof tx) => Promise<unknown>) => cb(tx)),
+    },
+    amIBlockedByUser,
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: db, dbWrite: db }));
+vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser }));
+vi.mock('~/server/services/blocklist.service', () => ({
+  throwOnBlockedLinkDomain: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/utils/otel-helpers', () => ({
+  withSpan: (_name: string, fn: () => unknown) => fn(),
+}));
+
+import { upsertComment } from '../commentsv2.service';
+
+const baseCreate = {
+  userId: 7,
+  entityType: 'image',
+  entityId: 1,
+  content: 'hello',
+} as Parameters<typeof upsertComment>[0];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  amIBlockedByUser.mockResolvedValue(false);
+});
+
+describe('upsertComment — block enforcement on create', () => {
+  it('throws and never creates when the author is blocked by the content owner', async () => {
+    amIBlockedByUser.mockResolvedValueOnce(true);
+    await expect(upsertComment({ ...baseCreate })).rejects.toThrow();
+    expect(db.tx.commentV2.create).not.toHaveBeenCalled();
+  });
+
+  it('allows a non-blocked author to create', async () => {
+    await expect(upsertComment({ ...baseCreate })).resolves.toMatchObject({ id: 999 });
+    expect(amIBlockedByUser).toHaveBeenCalledWith({ userId: 7, targetUserId: 100 });
+    expect(db.tx.commentV2.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('exempts moderators from the block check', async () => {
+    amIBlockedByUser.mockResolvedValue(true);
+    await expect(
+      upsertComment({ ...baseCreate, isModerator: true } as Parameters<typeof upsertComment>[0])
+    ).resolves.toMatchObject({ id: 999 });
+    expect(amIBlockedByUser).not.toHaveBeenCalled();
+  });
+
+  it('skips the block check when editing an existing comment (data.id set)', async () => {
+    amIBlockedByUser.mockResolvedValue(true);
+    await expect(
+      upsertComment({ ...baseCreate, id: 5 } as Parameters<typeof upsertComment>[0])
+    ).resolves.toMatchObject({ id: 5 });
+    expect(amIBlockedByUser).not.toHaveBeenCalled();
+    expect(db.commentV2.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/__tests__/resourceReview.idempotent.service.test.ts
+++ b/src/server/services/__tests__/resourceReview.idempotent.service.test.ts
@@ -15,6 +15,8 @@ const { mockDb } = vi.hoisted(() => ({
     // createResourceReviewNotification (fired best-effort after the create
     // resolves) reads modelVersion; a null result makes it log+return cleanly.
     modelVersion: { findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null) },
+    // upsertResourceReview now runs a block check that resolves the model owner.
+    model: { findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ userId: 1 })) },
     imageResourceNew: { count: vi.fn(async (..._a: unknown[]): Promise<number> => 0) },
     resourceReview: {
       create: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({})),
@@ -53,7 +55,10 @@ vi.mock('~/server/services/user.service', () => ({
   getProfilePicturesForUsers: vi.fn(async () => ({})),
 }));
 
-import { createResourceReview, upsertResourceReview } from '~/server/services/resourceReview.service';
+import {
+  createResourceReview,
+  upsertResourceReview,
+} from '~/server/services/resourceReview.service';
 
 const p2002 = () =>
   new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {

--- a/src/server/services/block-check.service.ts
+++ b/src/server/services/block-check.service.ts
@@ -13,6 +13,10 @@ const threadContentSelect = {
   bountyEntryId: true,
   questionId: true,
   answerId: true,
+  model3dId: true,
+  model3dReviewId: true,
+  comicProjectId: true,
+  comicChapterPosition: true,
 } as const;
 
 type ThreadContent = {
@@ -26,6 +30,10 @@ type ThreadContent = {
   bountyEntryId: number | null;
   questionId: number | null;
   answerId: number | null;
+  model3dId: number | null;
+  model3dReviewId: number | null;
+  comicProjectId: number | null;
+  comicChapterPosition: number | null;
 };
 
 async function ownerOfThreadContent(thread: ThreadContent | null): Promise<number | undefined> {
@@ -77,6 +85,24 @@ async function ownerOfThreadContent(thread: ThreadContent | null): Promise<numbe
   if (thread.answerId)
     return (
       await dbRead.answer.findUnique({ where: { id: thread.answerId }, select: { userId: true } })
+    )?.userId;
+  if (thread.model3dId)
+    return (
+      await dbRead.model3D.findUnique({ where: { id: thread.model3dId }, select: { userId: true } })
+    )?.userId;
+  if (thread.model3dReviewId)
+    return (
+      await dbRead.model3DReview.findUnique({
+        where: { id: thread.model3dReviewId },
+        select: { userId: true },
+      })
+    )?.userId;
+  if (thread.comicProjectId)
+    return (
+      await dbRead.comicProject.findUnique({
+        where: { id: thread.comicProjectId },
+        select: { userId: true },
+      })
     )?.userId;
   return undefined;
 }
@@ -181,6 +207,27 @@ export async function getBlockCheckOwnerIds({
         select: { userId: true },
       });
       return r ? [r.userId] : [];
+    }
+    case 'model3d': {
+      const r = await dbRead.model3D.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      return r ? [r.userId] : [];
+    }
+    case 'model3dReview': {
+      const r = await dbRead.model3DReview.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      return r ? [r.userId] : [];
+    }
+    case 'comicChapter': {
+      const r = await dbRead.comicChapter.findUnique({
+        where: { id: entityId },
+        select: { project: { select: { userId: true } } },
+      });
+      return r?.project?.userId ? [r.project.userId] : [];
     }
     case 'comment':
       return ownersForCommentV2(entityId);

--- a/src/server/services/block-check.service.ts
+++ b/src/server/services/block-check.service.ts
@@ -1,0 +1,225 @@
+import { dbRead } from '~/server/db/client';
+import { amIBlockedByUser } from '~/server/services/user.service';
+import { throwNotFoundError } from '~/server/utils/errorHandling';
+
+const threadContentSelect = {
+  rootThreadId: true,
+  imageId: true,
+  postId: true,
+  articleId: true,
+  modelId: true,
+  reviewId: true,
+  bountyId: true,
+  bountyEntryId: true,
+  questionId: true,
+  answerId: true,
+} as const;
+
+type ThreadContent = {
+  rootThreadId: number | null;
+  imageId: number | null;
+  postId: number | null;
+  articleId: number | null;
+  modelId: number | null;
+  reviewId: number | null;
+  bountyId: number | null;
+  bountyEntryId: number | null;
+  questionId: number | null;
+  answerId: number | null;
+};
+
+async function ownerOfThreadContent(thread: ThreadContent | null): Promise<number | undefined> {
+  if (!thread) return undefined;
+  if (thread.imageId)
+    return (
+      await dbRead.image.findUnique({ where: { id: thread.imageId }, select: { userId: true } })
+    )?.userId;
+  if (thread.postId)
+    return (
+      await dbRead.post.findUnique({ where: { id: thread.postId }, select: { userId: true } })
+    )?.userId;
+  if (thread.articleId)
+    return (
+      await dbRead.article.findUnique({ where: { id: thread.articleId }, select: { userId: true } })
+    )?.userId;
+  if (thread.modelId)
+    return (
+      await dbRead.model.findUnique({ where: { id: thread.modelId }, select: { userId: true } })
+    )?.userId;
+  if (thread.reviewId)
+    return (
+      await dbRead.resourceReview.findUnique({
+        where: { id: thread.reviewId },
+        select: { userId: true },
+      })
+    )?.userId;
+  if (thread.bountyId)
+    return (
+      (await dbRead.bounty.findUnique({ where: { id: thread.bountyId }, select: { userId: true } }))
+        ?.userId ?? undefined
+    );
+  if (thread.bountyEntryId)
+    return (
+      (
+        await dbRead.bountyEntry.findUnique({
+          where: { id: thread.bountyEntryId },
+          select: { userId: true },
+        })
+      )?.userId ?? undefined
+    );
+  if (thread.questionId)
+    return (
+      await dbRead.question.findUnique({
+        where: { id: thread.questionId },
+        select: { userId: true },
+      })
+    )?.userId;
+  if (thread.answerId)
+    return (
+      await dbRead.answer.findUnique({ where: { id: thread.answerId }, select: { userId: true } })
+    )?.userId;
+  return undefined;
+}
+
+// For a CommentV2 reply target, block if blocked by the parent comment's author
+// OR by the owner of the root content the thread hangs off of.
+async function ownersForCommentV2(commentId: number): Promise<number[]> {
+  const comment = await dbRead.commentV2.findUnique({
+    where: { id: commentId },
+    select: { userId: true, thread: { select: threadContentSelect } },
+  });
+  if (!comment) return [];
+  const ids = new Set<number>([comment.userId]);
+  const thread = comment.thread;
+  if (thread) {
+    const rootContent = thread.rootThreadId
+      ? await dbRead.thread.findUnique({
+          where: { id: thread.rootThreadId },
+          select: threadContentSelect,
+        })
+      : thread;
+    const rootOwner = await ownerOfThreadContent(rootContent);
+    if (rootOwner) ids.add(rootOwner);
+  }
+  return [...ids];
+}
+
+// Resolves the content owner user id(s) relevant to an interaction on a given
+// entity, so we can enforce user-blocking on write paths (comment/reaction).
+export async function getBlockCheckOwnerIds({
+  entityType,
+  entityId,
+}: {
+  entityType: string;
+  entityId: number;
+}): Promise<number[]> {
+  switch (entityType) {
+    case 'image': {
+      const r = await dbRead.image.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      return r ? [r.userId] : [];
+    }
+    case 'post': {
+      const r = await dbRead.post.findUnique({ where: { id: entityId }, select: { userId: true } });
+      return r ? [r.userId] : [];
+    }
+    case 'article': {
+      const r = await dbRead.article.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      return r ? [r.userId] : [];
+    }
+    case 'model': {
+      const r = await dbRead.model.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      return r ? [r.userId] : [];
+    }
+    case 'review':
+    case 'resourceReview': {
+      const r = await dbRead.resourceReview.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      return r ? [r.userId] : [];
+    }
+    case 'question': {
+      const r = await dbRead.question.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      return r ? [r.userId] : [];
+    }
+    case 'answer': {
+      const r = await dbRead.answer.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      return r ? [r.userId] : [];
+    }
+    case 'bounty': {
+      const r = await dbRead.bounty.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      return r?.userId ? [r.userId] : [];
+    }
+    case 'bountyEntry': {
+      const r = await dbRead.bountyEntry.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      return r?.userId ? [r.userId] : [];
+    }
+    case 'commentOld': {
+      const r = await dbRead.comment.findUnique({
+        where: { id: entityId },
+        select: { userId: true },
+      });
+      return r ? [r.userId] : [];
+    }
+    case 'comment':
+      return ownersForCommentV2(entityId);
+    default:
+      return [];
+  }
+}
+
+export async function throwIfBlockedByOwners({
+  userId,
+  ownerIds,
+  isModerator,
+}: {
+  userId: number;
+  ownerIds: Array<number | null | undefined>;
+  isModerator?: boolean;
+}) {
+  if (isModerator) return;
+  for (const ownerId of ownerIds) {
+    if (!ownerId || ownerId === userId) continue;
+    const blocked = await amIBlockedByUser({ userId, targetUserId: ownerId });
+    if (blocked) throw throwNotFoundError();
+  }
+}
+
+// Throws NotFound (mirroring the read-side block enforcement) when `userId` is
+// blocked by the owner of the content they're trying to interact with.
+export async function throwIfBlockedByEntityOwner({
+  userId,
+  entityType,
+  entityId,
+  isModerator,
+}: {
+  userId: number;
+  entityType: string;
+  entityId: number;
+  isModerator?: boolean;
+}) {
+  if (isModerator) return;
+  const ownerIds = await getBlockCheckOwnerIds({ entityType, entityId });
+  await throwIfBlockedByOwners({ userId, ownerIds });
+}

--- a/src/server/services/commentsv2.service.ts
+++ b/src/server/services/commentsv2.service.ts
@@ -10,6 +10,7 @@ import type {
   GetCommentsInfiniteInput,
 } from './../schema/commentv2.schema';
 import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
+import { throwIfBlockedByEntityOwner } from '~/server/services/block-check.service';
 import type { NsfwLevel } from '~/server/common/enums';
 import { ThreadSort } from '~/server/common/enums';
 import { withSpan } from '~/server/utils/otel-helpers';
@@ -54,9 +55,11 @@ export const upsertComment = async ({
   entityType,
   entityId,
   parentThreadId,
+  isModerator,
   ...data
-}: UpsertCommentV2Input & { userId: number }) => {
+}: UpsertCommentV2Input & { userId: number; isModerator?: boolean }) => {
   await throwOnBlockedLinkDomain(data.content);
+  if (!data.id) await throwIfBlockedByEntityOwner({ userId, entityType, entityId, isModerator });
   // only check for threads on comment create
   let thread = await dbWrite.thread.findUnique({
     where: { [`${entityType}Id`]: entityId } as unknown as Prisma.ThreadWhereUniqueInput,
@@ -161,10 +164,7 @@ export async function bulkSetCommentV2TosViolation({
 
     await Promise.allSettled(
       reports.map((report) =>
-        reportAcceptedReward.apply(
-          { userId: report.userId, reportId: report.id },
-          { ip: actor.ip }
-        )
+        reportAcceptedReward.apply({ userId: report.userId, reportId: report.id }, { ip: actor.ip })
       )
     );
 

--- a/src/server/services/reaction.service.ts
+++ b/src/server/services/reaction.service.ts
@@ -10,13 +10,15 @@ import {
   questionMetrics,
 } from '~/server/metrics';
 import type { ReviewReactions } from '~/shared/utils/prisma/enums';
+import { throwIfBlockedByEntityOwner } from '~/server/services/block-check.service';
 
 export const toggleReaction = async ({
   entityType,
   entityId,
   userId,
   reaction,
-}: ToggleReactionInput & { userId: number }) => {
+  isModerator,
+}: ToggleReactionInput & { userId: number; isModerator?: boolean }) => {
   const existing = await getReaction({ entityType, entityId, userId, reaction });
   if (existing) {
     await deleteReaction({
@@ -28,6 +30,8 @@ export const toggleReaction = async ({
     });
     return 'removed';
   } else {
+    // Enforce on create only — a user blocked after reacting can still un-react.
+    await throwIfBlockedByEntityOwner({ userId, entityType, entityId, isModerator });
     await createReaction({ entityType, entityId, userId, reaction });
     return 'created';
   }

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -13,6 +13,7 @@ import {
 } from '~/server/selectors/resourceReview.selector';
 import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
+import { throwIfBlockedByEntityOwner } from '~/server/services/block-check.service';
 import { createNotification } from '~/server/services/notification.service';
 import {
   BlockedByUsers,
@@ -129,8 +130,7 @@ export const getResourceReviewsInfinite = async ({
   if (username) {
     const userFindArgs = { where: { username }, select: { id: true } };
     const targetUser =
-      (await dbRead.user.findUnique(userFindArgs)) ??
-      (await dbWrite.user.findUnique(userFindArgs));
+      (await dbRead.user.findUnique(userFindArgs)) ?? (await dbWrite.user.findUnique(userFindArgs));
 
     if (!targetUser) throw throwNotFoundError('User not found');
 
@@ -230,9 +230,7 @@ export const getRatingTotals = async ({ modelVersionId, modelId }: GetRatingTota
   const cacheable = queryCache(dbRead, 'getRatingTotals', 'v1');
   const result = await cacheable<GetRatingTotalsRow[]>(query, {
     ttl: CacheTTL.hour,
-    tag: modelVersionId
-      ? [`rating:modelVersion:${modelVersionId}`]
-      : [`rating:model:${modelId}`],
+    tag: modelVersionId ? [`rating:modelVersion:${modelVersionId}`] : [`rating:model:${modelId}`],
   });
 
   const transformed = result.reduce(
@@ -322,10 +320,17 @@ const createResourceReviewNotification = async ({
 
 export const upsertResourceReview = async ({
   userId,
+  isModerator,
   ...data
-}: UpsertResourceReviewInput & { userId: number }) => {
+}: UpsertResourceReviewInput & { userId: number; isModerator?: boolean }) => {
   if (data.details) await throwOnBlockedLinkDomain(data.details);
   if (!data.id) {
+    await throwIfBlockedByEntityOwner({
+      userId,
+      entityType: 'model',
+      entityId: data.modelId,
+      isModerator,
+    });
     const ret = await dbWrite.resourceReview
       .create({
         data: { ...data, userId, thread: { create: {} } },


### PR DESCRIPTION
## Problem

User blocking was enforced **read-side only** — an entity page 404s a blocked viewer — but the **write/interaction paths had no block check**. A user a creator has blocked could still comment, reply, react/vote, and review that creator's content via direct tRPC/API calls.

## Fix

New `src/server/services/block-check.service.ts` resolves the content **owner** per entity type and throws `NotFound` (mirroring the read-handler pattern, e.g. `model.controller.ts:187`) when the acting user is blocked by that owner. Enforced on **CREATE only** (edit/delete of one's own content is unaffected); moderators are exempt.

### Handlers gated
- **`upsertComment`** (`commentsv2.service.ts`) — enforced on the create branch (`!data.id`), so both `upsertCommentV2Handler` and API-token (SocialWrite) callers hitting the service directly are covered. `isModerator` threaded from `commentv2.controller.ts`.
- **`upsertCommentHandler`** (`comment.controller.ts`, legacy model comments) — checks the model owner (`ctx.ownerId`) plus the parent comment author for replies, on create (`!input.commentId`).
- **`toggleReactionHandler`** (`reaction.controller.ts`) — checks the reacted entity's owner before toggling.
- **`upsertResourceReview`** (`resourceReview.service.ts`) — checks the model owner on create; `isModerator` threaded from `resourceReview.controller.ts`.

### Owner resolution (`getBlockCheckOwnerIds`)
Handles `image`/`post`/`article`/`model`/`review`+`resourceReview`/`question`/`answer`/`bounty`/`bountyEntry`/`commentOld`. For CommentV2 **reply targets** (`entityType: 'comment'`) it resolves **both** the parent comment author **and** the root thread's content owner, so a blocked user can't reply inside a creator's thread. Unknown/unowned types (e.g. `challenge`, `appListing`) resolve to no owner and never false-block.

## Tests
- `block-check.service.test.ts` — owner resolution per entity type (incl. reply → parent author + root owner), enforcement (blocked throws, non-blocked passes, owner-acting-on-own-content and moderators exempt).
- `commentsv2.blockCheck.service.test.ts` — `upsertComment` throws and never creates when blocked, allows non-blocked, exempts moderators, and skips the check on edit.
- Updated `commentsv2.appListing` and `resourceReview.idempotent` test mocks for the new block-check lookups.

Full `pnpm typecheck` passes clean; new/affected unit tests pass.

> Note: sibling task 868keupaa ("downvote-then-block") edits the read/exclusion paths in some of the same files; this diff is scoped to the write/create handlers to minimize overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)