### PR TITLE
fix(block): let creators see/report a blocker's engagement on their own content

### DIFF
--- a/src/server/controllers/commentv2.controller.ts
+++ b/src/server/controllers/commentv2.controller.ts
@@ -28,6 +28,7 @@ import {
   getCommentCount,
   getCommentsThreadDetails2,
   getCommentsInfinite,
+  isViewerContentOwner,
   toggleHideComment,
   toggleLockCommentsThread,
   upsertComment,
@@ -167,10 +168,21 @@ export const getCommentsThreadDetailsHandler = async ({
       (x) => x.id
     );
     const blockedUsers = (await BlockedUsers.getCached({ userId: ctx.user?.id })).map((x) => x.id);
+    // On the owner's own content, don't hide a blocker's engagement from them (they must still
+    // be able to see + report it) — drop blockedByUsers only in that case; keep the anti-
+    // harassment exclusion for every non-owner viewer.
+    const isContentOwner = await isViewerContentOwner({
+      entityType: input.entityType,
+      entityId: input.entityId,
+      userId: ctx.user?.id,
+      blockedByUsers,
+    });
     // De-dupe + cap so the downstream `notIn` / raw `NOT IN` stays under the Postgres
     // bind-param limit (heavily-blocked viewer otherwise → P2029 → 500). Ordering is a
     // load-bearing safety priority — see boundExcludedUserIds.
-    const excludedUserIds = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers);
+    const excludedUserIds = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers, {
+      isContentOwner,
+    });
 
     return await getCommentsThreadDetails2({ ...input, excludedUserIds });
   } catch (error) {
@@ -255,10 +267,21 @@ export const getCommentsInfiniteHandler = async ({
       (x) => x.id
     );
     const blockedUsers = (await BlockedUsers.getCached({ userId: ctx.user?.id })).map((x) => x.id);
+    // On the owner's own content, don't hide a blocker's engagement from them (they must still
+    // be able to see + report it) — drop blockedByUsers only in that case; keep the anti-
+    // harassment exclusion for every non-owner viewer.
+    const isContentOwner = await isViewerContentOwner({
+      entityType: input.entityType,
+      entityId: input.entityId,
+      userId: ctx.user?.id,
+      blockedByUsers,
+    });
     // De-dupe + cap so the downstream `notIn` / raw `NOT IN` stays under the Postgres
     // bind-param limit (heavily-blocked viewer otherwise → P2029 → 500). Ordering is a
     // load-bearing safety priority — see boundExcludedUserIds.
-    const excludedUserIds = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers);
+    const excludedUserIds = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers, {
+      isContentOwner,
+    });
 
     return await getCommentsInfinite({ ...input, excludedUserIds });
   } catch (error) {

--- a/src/server/services/__tests__/commentsv2-owner.test.ts
+++ b/src/server/services/__tests__/commentsv2-owner.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { findUnique } = vi.hoisted(() => ({ findUnique: vi.fn() }));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    image: { findUnique },
+    post: { findUnique },
+    model: { findUnique },
+    article: { findUnique },
+    bounty: { findUnique },
+    bountyEntry: { findUnique },
+    resourceReview: { findUnique },
+    commentV2: { findUnique },
+    question: { findUnique },
+    answer: { findUnique },
+    challenge: { findUnique },
+    comicChapter: { findUnique },
+  },
+  dbWrite: {},
+}));
+
+import { getThreadEntityOwnerId, isViewerContentOwner } from '../commentsv2.service';
+
+describe('getThreadEntityOwnerId', () => {
+  beforeEach(() => findUnique.mockReset());
+
+  it('resolves the owner via userId for standard entity types', async () => {
+    findUnique.mockResolvedValueOnce({ userId: 99 });
+    await expect(getThreadEntityOwnerId({ entityType: 'image', entityId: 1 })).resolves.toBe(99);
+  });
+
+  it('resolves the challenge owner via createdById', async () => {
+    findUnique.mockResolvedValueOnce({ createdById: 7 });
+    await expect(getThreadEntityOwnerId({ entityType: 'challenge', entityId: 1 })).resolves.toBe(7);
+  });
+
+  it('resolves the comicChapter owner via the parent project', async () => {
+    findUnique.mockResolvedValueOnce({ project: { userId: 12 } });
+    await expect(getThreadEntityOwnerId({ entityType: 'comicChapter', entityId: 1 })).resolves.toBe(
+      12
+    );
+  });
+
+  it('returns null for entity types we cannot cheaply resolve', async () => {
+    await expect(
+      getThreadEntityOwnerId({ entityType: 'model3d', entityId: 1 })
+    ).resolves.toBeNull();
+    expect(findUnique).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the entity is missing', async () => {
+    findUnique.mockResolvedValueOnce(null);
+    await expect(getThreadEntityOwnerId({ entityType: 'post', entityId: 1 })).resolves.toBeNull();
+  });
+});
+
+describe('isViewerContentOwner', () => {
+  beforeEach(() => findUnique.mockReset());
+
+  it('is true when the viewer owns the content a blocker engaged with', async () => {
+    // Blocker 42 downvoted/commented then blocked the owner (id 5).
+    findUnique.mockResolvedValueOnce({ userId: 5 });
+    await expect(
+      isViewerContentOwner({
+        entityType: 'image',
+        entityId: 1,
+        userId: 5,
+        blockedByUsers: [42],
+      })
+    ).resolves.toBe(true);
+  });
+
+  it('is false for a non-owner viewer (keeps blocker excluded)', async () => {
+    findUnique.mockResolvedValueOnce({ userId: 5 });
+    await expect(
+      isViewerContentOwner({
+        entityType: 'image',
+        entityId: 1,
+        userId: 999,
+        blockedByUsers: [42],
+      })
+    ).resolves.toBe(false);
+  });
+
+  it('skips the lookup entirely when the viewer has no blocked-by list', async () => {
+    await expect(
+      isViewerContentOwner({ entityType: 'image', entityId: 1, userId: 5, blockedByUsers: [] })
+    ).resolves.toBe(false);
+    expect(findUnique).not.toHaveBeenCalled();
+  });
+
+  it('skips the lookup for an anonymous viewer', async () => {
+    await expect(
+      isViewerContentOwner({
+        entityType: 'image',
+        entityId: 1,
+        userId: undefined,
+        blockedByUsers: [42],
+      })
+    ).resolves.toBe(false);
+    expect(findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/comment.service.ts
+++ b/src/server/services/comment.service.ts
@@ -53,11 +53,25 @@ export const getComments = async <TSelect extends Prisma.CommentSelect>({
   const hiddenUsers = (await HiddenUsers.getCached({ userId: user?.id })).map((x) => x.id);
   const blockedByUsers = (await BlockedByUsers.getCached({ userId: user?.id })).map((x) => x.id);
   const blockedUsers = (await BlockedUsers.getCached({ userId: user?.id })).map((x) => x.id);
+  // If the viewer owns the model, don't hide a blocker's comments from them (the owner must
+  // still see + report engagement on their own content) — drop blockedByUsers only then; keep
+  // the anti-harassment exclusion for every non-owner viewer. Skip the lookup unless the
+  // viewer actually has a blocked-by list, since that's the only case it can change anything.
+  let isContentOwner = false;
+  if (user?.id && blockedByUsers.length) {
+    const model = await dbRead.model.findUnique({
+      where: { id: modelId },
+      select: { userId: true },
+    });
+    isContentOwner = model?.userId === user.id;
+  }
   // De-dupe + cap the exclusion list so the `userId: { notIn: [...] }` negation below stays
   // under the Postgres bind-parameter limit (a heavily-blocked viewer's combined list can
   // otherwise overflow → Prisma P2029 → 500). Ordering is a load-bearing safety priority —
   // see boundExcludedUserIds.
-  const excludedUserIds = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers);
+  const excludedUserIds = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers, {
+    isContentOwner,
+  });
 
   if (filterBy?.includes(ReviewFilter.IncludesImages)) return [];
 
@@ -270,10 +284,7 @@ export async function bulkSetCommentTosViolation({
 
     await Promise.allSettled(
       reports.map((report) =>
-        reportAcceptedReward.apply(
-          { userId: report.userId, reportId: report.id },
-          { ip: actor.ip }
-        )
+        reportAcceptedReward.apply({ userId: report.userId, reportId: report.id }, { ip: actor.ip })
       )
     );
 
@@ -302,7 +313,9 @@ export async function bulkDeleteComments({ ids }: { ids: number[] }) {
   });
   const result = await dbWrite.comment.deleteMany({ where: { id: { in: ids } } });
 
-  const modelIds = Array.from(new Set(affected.map((c) => c.modelId).filter((v): v is number => !!v)));
+  const modelIds = Array.from(
+    new Set(affected.map((c) => c.modelId).filter((v): v is number => !!v))
+  );
   const userIds = Array.from(
     new Set(affected.map((c) => c.model?.userId).filter((v): v is number => !!v))
   );

--- a/src/server/services/commentsv2.service.ts
+++ b/src/server/services/commentsv2.service.ts
@@ -49,6 +49,104 @@ export async function getJudgeCommentForImage({
   return result[0]?.content ?? null;
 }
 
+/**
+ * Resolve the owner (creator) userId of the entity a comment thread hangs off of, so callers
+ * can tell whether the current viewer is looking at engagement on their OWN content. Returns
+ * null for entity types we can't cheaply resolve — callers treat that as "not the owner",
+ * which keeps the anti-harassment `blockedByUsers` exclusion in place (the safe default).
+ */
+export async function getThreadEntityOwnerId({
+  entityType,
+  entityId,
+}: {
+  entityType: CommentConnectorInput['entityType'];
+  entityId: number;
+}): Promise<number | null> {
+  const findUserId = async (row: Promise<{ userId: number | null } | null>) =>
+    (await row)?.userId ?? null;
+
+  switch (entityType) {
+    case 'image':
+      return findUserId(
+        dbRead.image.findUnique({ where: { id: entityId }, select: { userId: true } })
+      );
+    case 'post':
+      return findUserId(
+        dbRead.post.findUnique({ where: { id: entityId }, select: { userId: true } })
+      );
+    case 'model':
+      return findUserId(
+        dbRead.model.findUnique({ where: { id: entityId }, select: { userId: true } })
+      );
+    case 'article':
+      return findUserId(
+        dbRead.article.findUnique({ where: { id: entityId }, select: { userId: true } })
+      );
+    case 'bounty':
+      return findUserId(
+        dbRead.bounty.findUnique({ where: { id: entityId }, select: { userId: true } })
+      );
+    case 'bountyEntry':
+      return findUserId(
+        dbRead.bountyEntry.findUnique({ where: { id: entityId }, select: { userId: true } })
+      );
+    case 'review':
+      return findUserId(
+        dbRead.resourceReview.findUnique({ where: { id: entityId }, select: { userId: true } })
+      );
+    case 'comment':
+      return findUserId(
+        dbRead.commentV2.findUnique({ where: { id: entityId }, select: { userId: true } })
+      );
+    case 'question':
+      return findUserId(
+        dbRead.question.findUnique({ where: { id: entityId }, select: { userId: true } })
+      );
+    case 'answer':
+      return findUserId(
+        dbRead.answer.findUnique({ where: { id: entityId }, select: { userId: true } })
+      );
+    case 'challenge': {
+      const row = await dbRead.challenge.findUnique({
+        where: { id: entityId },
+        select: { createdById: true },
+      });
+      return row?.createdById ?? null;
+    }
+    case 'comicChapter': {
+      const row = await dbRead.comicChapter.findUnique({
+        where: { id: entityId },
+        select: { project: { select: { userId: true } } },
+      });
+      return row?.project?.userId ?? null;
+    }
+    default:
+      return null;
+  }
+}
+
+/**
+ * Whether `userId` owns the entity this comment thread hangs off of. Skips the lookup unless a
+ * viewer is present AND has a non-empty blocked-by list — dropping `blockedByUsers` only
+ * matters (and only for the owner) in that case, so the extra query stays off the hot path for
+ * everyone else.
+ */
+export async function isViewerContentOwner({
+  entityType,
+  entityId,
+  userId,
+  blockedByUsers,
+}: {
+  entityType: CommentConnectorInput['entityType'];
+  entityId: number;
+  userId?: number;
+  blockedByUsers: number[];
+}): Promise<boolean> {
+  if (!userId || !blockedByUsers.length) return false;
+  const ownerId = await getThreadEntityOwnerId({ entityType, entityId });
+  return ownerId === userId;
+}
+
 export const upsertComment = async ({
   userId,
   entityType,
@@ -161,10 +259,7 @@ export async function bulkSetCommentV2TosViolation({
 
     await Promise.allSettled(
       reports.map((report) =>
-        reportAcceptedReward.apply(
-          { userId: report.userId, reportId: report.id },
-          { ip: actor.ip }
-        )
+        reportAcceptedReward.apply({ userId: report.userId, reportId: report.id }, { ip: actor.ip })
       )
     );
 

--- a/src/server/services/resourceReview.service.ts
+++ b/src/server/services/resourceReview.service.ts
@@ -129,8 +129,7 @@ export const getResourceReviewsInfinite = async ({
   if (username) {
     const userFindArgs = { where: { username }, select: { id: true } };
     const targetUser =
-      (await dbRead.user.findUnique(userFindArgs)) ??
-      (await dbWrite.user.findUnique(userFindArgs));
+      (await dbRead.user.findUnique(userFindArgs)) ?? (await dbWrite.user.findUnique(userFindArgs));
 
     if (!targetUser) throw throwNotFoundError('User not found');
 
@@ -230,9 +229,7 @@ export const getRatingTotals = async ({ modelVersionId, modelId }: GetRatingTota
   const cacheable = queryCache(dbRead, 'getRatingTotals', 'v1');
   const result = await cacheable<GetRatingTotalsRow[]>(query, {
     ttl: CacheTTL.hour,
-    tag: modelVersionId
-      ? [`rating:modelVersion:${modelVersionId}`]
-      : [`rating:model:${modelId}`],
+    tag: modelVersionId ? [`rating:modelVersion:${modelVersionId}`] : [`rating:model:${modelId}`],
   });
 
   const transformed = result.reduce(
@@ -500,10 +497,23 @@ export const getPagedResourceReviews = async ({
   // the raw NOT IN below (P2029). Same fix + safety-priority order as the comment
   // surfaces; see boundExcludedUserIds.
   const [hiddenUsers, blockedByUsers, blockedUsers] = excludedUsers;
+  // If the viewer owns the model these reviews are on, don't hide a blocker's review/thumb
+  // from them (the owner must still see + report engagement on their own content) — drop
+  // blockedByUsers only then; keep the anti-harassment exclusion for every non-owner viewer.
+  // Skip the lookup unless the viewer has a blocked-by list, the only case it changes anything.
+  let isContentOwner = false;
+  if (userId && blockedByUsers.length) {
+    const modelVersion = await dbRead.modelVersion.findUnique({
+      where: { id: modelVersionId },
+      select: { model: { select: { userId: true } } },
+    });
+    isContentOwner = modelVersion?.model?.userId === userId;
+  }
   const excludedUserIds = boundExcludedUserIds(
     hiddenUsers.map((u) => u.id),
     blockedByUsers.map((u) => u.id),
-    blockedUsers.map((u) => u.id)
+    blockedUsers.map((u) => u.id),
+    { isContentOwner }
   );
   if (excludedUserIds.length) {
     AND.push(Prisma.sql`rr."userId" != ALL(${excludedUserIds}::int[])`);

--- a/src/server/utils/__tests__/excluded-user-ids.test.ts
+++ b/src/server/utils/__tests__/excluded-user-ids.test.ts
@@ -60,4 +60,34 @@ describe('boundExcludedUserIds', () => {
   it('handles empty inputs', () => {
     expect(boundExcludedUserIds([], [], [])).toEqual([]);
   });
+
+  describe('isContentOwner (viewer looking at engagement on their OWN content)', () => {
+    // A blocker (user 42) left a comment/review/downvote on the owner's content, then blocked
+    // the owner. `42` therefore lands in the owner's blockedByUsers list.
+    const blocker = 42;
+
+    it('non-owner viewer still has the blocker excluded (anti-harassment stays)', () => {
+      const result = boundExcludedUserIds([], [blocker], []);
+      expect(result).toContain(blocker);
+    });
+
+    it("owner sees the blocker's engagement on their own content (blockedByUsers dropped)", () => {
+      const result = boundExcludedUserIds([], [blocker], [], { isContentOwner: true });
+      expect(result).not.toContain(blocker);
+    });
+
+    it('owner still excludes people on their OWN hidden/blocked lists', () => {
+      // hidden(7) + own-block(8) must survive; only the involuntary blocked-by(42) is dropped.
+      const result = boundExcludedUserIds([7], [blocker], [8], { isContentOwner: true });
+      expect(result).toContain(7);
+      expect(result).toContain(8);
+      expect(result).not.toContain(blocker);
+    });
+
+    it('isContentOwner: false behaves identically to omitting the option', () => {
+      expect(boundExcludedUserIds([1], [2], [3], { isContentOwner: false })).toEqual(
+        boundExcludedUserIds([1], [2], [3])
+      );
+    });
+  });
 });

--- a/src/server/utils/excluded-user-ids.ts
+++ b/src/server/utils/excluded-user-ids.ts
@@ -31,13 +31,23 @@ export const MAX_EXCLUDED_USER_IDS = 30000;
  * few comments through — far preferable to a hard 500 that breaks the surface entirely, and
  * deliberately preferred over leaking the involuntary blocked-by list. A future refactor
  * MUST NOT silently reorder these spreads.
+ *
+ * `isContentOwner`: set ONLY on surfaces where the viewer is the owner of the content being
+ * engaged with (a creator looking at comments/reviews/reactions on their OWN model, image,
+ * post, etc.). There we DROP `blockedByUsers`: the involuntary "someone blocked me" list
+ * otherwise lets a downvoter/commenter hide their trail on the owner's own content simply by
+ * blocking the owner — and stops the owner from seeing or reporting it. Everywhere else
+ * (viewer is NOT the owner) `blockedByUsers` stays, preserving the anti-harassment guarantee
+ * that a harasser who blocked the viewer cannot resurface to them.
  */
 export function boundExcludedUserIds(
   hiddenUsers: number[],
   blockedByUsers: number[],
-  blockedUsers: number[]
+  blockedUsers: number[],
+  options?: { isContentOwner?: boolean }
 ): number[] {
-  return [...new Set([...hiddenUsers, ...blockedByUsers, ...blockedUsers])].slice(
+  const involuntaryBlockedBy = options?.isContentOwner ? [] : blockedByUsers;
+  return [...new Set([...hiddenUsers, ...involuntaryBlockedBy, ...blockedUsers])].slice(
     0,
     MAX_EXCLUDED_USER_IDS
   );


### PR DESCRIPTION
## The gap

When user B blocks creator A, B's prior comments / reviews / downvotes disappeared from A's view of A's **own** content, and A could no longer report them. A's content-filter exclusion list merges `blockedByUsers` (everyone who blocked A) into the `notIn` / `NOT IN` filter via `boundExcludedUserIds`. That `blockedByUsers` exclusion is deliberate anti-harassment (a harasser who blocked you can't resurface to you) — but on a creator's **own** content it backfired: a downvoter/commenter could hide their trail simply by blocking the creator.

## The fix

Added an `isContentOwner` option to `boundExcludedUserIds` (`src/server/utils/excluded-user-ids.ts`) that drops `blockedByUsers` **only** when the viewer is the owner of the content being engaged with. The viewer's own lists (`hiddenUsers` + `blockedUsers`) are always kept, and the P2029 bind-param cap/ordering safety is untouched.

Anti-harassment stays intact for **every non-owner viewer** — `blockedByUsers` is only dropped in the owner-viewing-own-content case.

## Surfaces fixed (read/list/exclusion paths only)

- **CommentV2** thread details + `getInfinite` (`commentv2.controller.ts`) — new `getThreadEntityOwnerId` / `isViewerContentOwner` resolver in `commentsv2.service.ts` maps each thread's entity (image, post, model, article, bounty, review, comment, question, answer, challenge, comicChapter, …) to its owner.
- **Legacy model comments** — `comment.service.getComments` (owner = model owner).
- **Model reviews/thumbs** — `resourceReview.service.getPagedResourceReviews` (owner = model owner via modelVersion).

The owner lookup is **skipped entirely** unless the viewer actually has a non-empty blocked-by list, so the extra query stays off the hot path for anonymous and unblocked viewers. Entity types we can't cheaply resolve fall back to "not owner" (keeps `blockedByUsers` — the safe default).

Scope is kept to read/exclusion paths only, to avoid conflicting with the sibling "enforce blocking on writes" PR (task 868keup9w). `bounty.controller` / `user.controller` were left as-is (not owner-viewing-own surfaces).

## Tests

- `boundExcludedUserIds`: owner sees a blocker's comment/review/downvote (blocker dropped); non-owner viewer still excludes the blocker; owner still excludes their own hidden/blocked lists.
- `isViewerContentOwner` / `getThreadEntityOwnerId`: owner detection across entity types (incl. challenge `createdById`, comicChapter via project), and the skip-guard (no lookup when the viewer has no blocked-by list or is anonymous).

`pnpm typecheck` is clean for all changed files (remaining errors in the run are pre-existing, in untouched `packages/civitai-db` / `challenge.service.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)