### PR TITLE
fix(images): keep media-type scope when clearing feed filters

### DIFF
--- a/src/components/Image/Filters/MediaFiltersDropdown.tsx
+++ b/src/components/Image/Filters/MediaFiltersDropdown.tsx
@@ -18,6 +18,7 @@ import { PeriodFilter } from '~/components/Filters';
 import { FilterChip } from '~/components/Filters/FilterChip';
 import { StagedFiltersFooter } from '~/components/Filters/StagedFiltersFooter';
 import { useStagedFilters } from '~/components/Filters/useStagedFilters';
+import { getDefaultMediaTypes } from '~/components/Image/image.utils';
 import { TechniqueMultiSelect } from '~/components/Technique/TechniqueMultiSelect';
 import { ToolMultiSelect } from '~/components/Tool/ToolMultiSelect';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -108,9 +109,19 @@ export function MediaFiltersDropdown({
     // strips `?period=AllTime`, but the Zustand store needs `AllTime` so
     // `PeriodFilter` keeps rendering its chips (it returns null when period
     // is undefined).
+    //
+    // The store path also restores the feed's default media-type scope instead
+    // of clearing `types` outright — otherwise `removeEmpty` drops `types` and
+    // the /images feed starts serving videos too. The URL path keeps `types`
+    // undefined so it's stripped from the query string.
     if (onChange) onChange({ ...reset, period: undefined });
-    else setFilters({ ...reset, period: MetricTimeframe.AllTime });
-  }, [onChange, setFilters]);
+    else
+      setFilters({
+        ...reset,
+        types: getDefaultMediaTypes(filterType),
+        period: MetricTimeframe.AllTime,
+      });
+  }, [onChange, setFilters, filterType]);
 
   const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
     useStagedFilters({

--- a/src/components/Image/__tests__/media-filters-clear.test.ts
+++ b/src/components/Image/__tests__/media-filters-clear.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { getDefaultMediaTypes } from '~/components/Image/image.utils';
+import { MetricTimeframe, MediaType } from '~/shared/utils/prisma/enums';
+import { removeEmpty } from '~/utils/object-helpers';
+
+describe('getDefaultMediaTypes', () => {
+  it('scopes the images feed to image-only', () => {
+    expect(getDefaultMediaTypes('images')).toEqual([MediaType.image]);
+  });
+
+  it('scopes the videos feed to video-only', () => {
+    expect(getDefaultMediaTypes('videos')).toEqual([MediaType.video]);
+  });
+
+  it('leaves model-image feeds unscoped (all media types)', () => {
+    expect(getDefaultMediaTypes('modelImages')).toBeUndefined();
+  });
+});
+
+describe('clearing feed filters keeps the media-type scope', () => {
+  // Regression for the /images "Clear all filters" bug: the clear handler used
+  // to reset `types` to `undefined`, which `removeEmpty` strips from the stored
+  // filters, so the image.getInfinite payload lost its media-type scope and the
+  // feed served videos alongside images. Clearing must restore the feed default.
+  it('does not strip types from a cleared images payload', () => {
+    const cleared = removeEmpty({
+      types: getDefaultMediaTypes('images'),
+      period: MetricTimeframe.AllTime,
+    });
+    expect(cleared.types).toEqual([MediaType.image]);
+  });
+
+  it('does not strip types from a cleared videos payload', () => {
+    const cleared = removeEmpty({
+      types: getDefaultMediaTypes('videos'),
+      period: MetricTimeframe.AllTime,
+    });
+    expect(cleared.types).toEqual([MediaType.video]);
+  });
+});

--- a/src/components/Image/image.utils.ts
+++ b/src/components/Image/image.utils.ts
@@ -102,6 +102,18 @@ export const imagesQueryParamSchema = z
 
 export const useImageQueryParams = () => useZodRouteParams(imagesQueryParamSchema);
 
+// The media-type scope a feed falls back to when its filters are cleared.
+// `/images` shows images, `/videos` shows videos; model-image feeds stay
+// unscoped (all media types). Returning `undefined` here would let `removeEmpty`
+// drop `types` from the payload, so the feed would serve every media type.
+export const getDefaultMediaTypes = (
+  filterType: FilterKeys<'images' | 'videos' | 'modelImages'>
+): MediaType[] | undefined => {
+  if (filterType === 'images') return [MediaType.image];
+  if (filterType === 'videos') return [MediaType.video];
+  return undefined;
+};
+
 // could have userImages and userVideo
 export const useImageFilters = (type: FilterKeys<'images' | 'videos' | 'modelImages'>) => {
   const storeFilters = useFiltersContext((state) => state[type]);


### PR DESCRIPTION
## Problem
Clearing filters on `/images` served **videos mixed with images** (ClickUp [868kef5g3](https://app.clickup.com/t/8459928/868kef5g3)).

## Root cause
The `/images` feed has no media-type toggle (`hideMediaTypes`) — it relies entirely on the store default `types: [image]`. `MediaFiltersDropdown.handleClear` reset `types` to `undefined`; `removeEmpty` (store reducer + `useImageFilters`) strips `undefined` keys, so the `image.getInfinite` payload lost `types` entirely and the server returned **all** media types.

`/videos` dodged it only because the page re-injects `types: ['video']` as a prop override every render.

## Fix
Clearing now restores the feed's **default** media-type scope instead of dropping it:
- New pure helper `getDefaultMediaTypes(filterType)` in `image.utils.ts` — `images → [image]`, `videos → [video]`, `modelImages → all`.
- `handleClear` store branch sets `types: getDefaultMediaTypes(filterType)`. The URL/`onChange` branch is unchanged (`types: undefined` still strips it from the query string).

## No regression
Only the 3 store-path feeds change (`/images`, `/videos`, model-images). Every media-type-**visible** feed (Collection, UserMedia, Tool) uses the `onChange`/URL branch — untouched.

| Consumer | Path | filterType | Clear result |
|---|---|---|---|
| ImageFeedFilters (`/images`) | store | images | `[image]` |
| VideoFeedFilters (`/videos`) | store | videos | `[video]` |
| ImagesAsPostsInfinite | store | modelImages | all |
| ToolImageFeedFilters | URL | images | unchanged |
| UserMediaInfinite | URL | images/videos | unchanged |
| Collection | URL | images | unchanged |

## Tests
Added `src/components/Image/__tests__/media-filters-clear.test.ts` (5 tests) reproducing the `removeEmpty`-strips-`types` mechanic. Verified red before the fix, green after (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)