### PR TITLE
feat(comments): let model owners pin comments on the model page

### DIFF
--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -3445,6 +3445,7 @@ model Comment {
   modelId      Int
   locked       Boolean? @default(false)
   hidden       Boolean? @default(false)
+  pinnedAt     DateTime?
 
   comments  Comment[]         @relation("ParentComments")
   reactions CommentReaction[]

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -1845,6 +1845,7 @@ export type Comment = {
   modelId: number;
   locked: Generated<boolean | null>;
   hidden: Generated<boolean | null>;
+  pinnedAt: Timestamp | null;
 };
 export type CommentReaction = {
   id: Generated<number>;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -2277,6 +2277,7 @@ export interface Comment {
   modelId: number;
   locked: boolean | null;
   hidden: boolean | null;
+  pinnedAt: Date | null;
   comments?: Comment[];
   reactions?: CommentReaction[];
   reports?: CommentReport[];

--- a/prisma/migrations/20260721160807_add_comment_pinned_at/migration.sql
+++ b/prisma/migrations/20260721160807_add_comment_pinned_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN "pinnedAt" TIMESTAMP(3);

--- a/src/components/Model/ModelDiscussion/CommentDiscussionItem.tsx
+++ b/src/components/Model/ModelDiscussion/CommentDiscussionItem.tsx
@@ -1,6 +1,11 @@
 import { Badge, Button, Card, Group, Text, ThemeIcon, Tooltip } from '@mantine/core';
 import type { ReviewReactions } from '~/shared/utils/prisma/enums';
-import { IconExclamationCircle, IconLock, IconMessageCircle2 } from '@tabler/icons-react';
+import {
+  IconExclamationCircle,
+  IconLock,
+  IconMessageCircle2,
+  IconPinned,
+} from '@tabler/icons-react';
 
 import { ContentClamp } from '~/components/ContentClamp/ContentClamp';
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
@@ -90,7 +95,16 @@ export function CommentDiscussionItem({ data: comment, modelUserId }: Props) {
           withUsername
           linkToProfile
         />
-        <CommentDiscussionMenu comment={comment} hideLockOption modelUserId={modelUserId} />
+        <Group gap={4} wrap="nowrap">
+          {comment.pinnedAt && (
+            <Tooltip label="Pinned">
+              <ThemeIcon size="sm" color="orange">
+                <IconPinned size={16} stroke={2} />
+              </ThemeIcon>
+            </Tooltip>
+          )}
+          <CommentDiscussionMenu comment={comment} hideLockOption modelUserId={modelUserId} />
+        </Group>
       </Group>
 
       <ContentClamp maxHeight={100}>

--- a/src/components/Model/ModelDiscussion/CommentDiscussionMenu.tsx
+++ b/src/components/Model/ModelDiscussion/CommentDiscussionMenu.tsx
@@ -11,6 +11,8 @@ import {
   IconLock,
   IconLockOpen,
   IconBan,
+  IconPinned,
+  IconPinnedOff,
 } from '@tabler/icons-react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { triggerRoutedDialog } from '~/components/Dialog/RoutedDialogLink';
@@ -158,6 +160,34 @@ export function CommentDiscussionMenu({
     toggleHideCommentMutation.mutate({ id: comment.id });
   };
 
+  const togglePinCommentMutation = trpc.comment.togglePin.useMutation({
+    async onMutate({ id }) {
+      await queryUtils.comment.getById.cancel();
+
+      const prevComment = queryUtils.comment.getById.getData({ id });
+      if (prevComment)
+        queryUtils.comment.getById.setData({ id }, () => ({
+          ...prevComment,
+          pinnedAt: prevComment.pinnedAt ? null : new Date(),
+        }));
+
+      return { prevComment };
+    },
+    async onSuccess() {
+      await queryUtils.comment.getAll.invalidate();
+    },
+    onError(error, vars, context) {
+      showErrorNotification({
+        title: 'Could not pin comment',
+        error: new Error(error.message),
+      });
+      queryUtils.comment.getById.setData({ id: vars.id }, context?.prevComment);
+    },
+  });
+  const handleTogglePinComment = () => {
+    togglePinCommentMutation.mutate({ id: comment.id });
+  };
+
   return (
     <Menu position="bottom-end" withinPortal {...props}>
       <Menu.Target>
@@ -215,6 +245,20 @@ export function CommentDiscussionMenu({
             {comment.hidden ? 'Unhide comment' : 'Hide comment'}
           </Menu.Item>
         )}
+        {(isModelOwner || isMod) && (
+          <Menu.Item
+            leftSection={
+              comment.pinnedAt ? (
+                <IconPinnedOff size={14} stroke={1.5} />
+              ) : (
+                <IconPinned size={14} stroke={1.5} />
+              )
+            }
+            onClick={handleTogglePinComment}
+          >
+            {comment.pinnedAt ? 'Unpin comment' : 'Pin comment'}
+          </Menu.Item>
+        )}
         {isMod && (
           <Menu.Item leftSection={<IconBan size={14} stroke={1.5} />} onClick={handleTosViolation}>
             Remove as TOS Violation
@@ -242,7 +286,7 @@ export function CommentDiscussionMenu({
 }
 
 type Props = MenuProps & {
-  comment: Pick<CommentGetAllItem, 'id' | 'user' | 'locked' | 'hidden' | 'modelId'>;
+  comment: Pick<CommentGetAllItem, 'id' | 'user' | 'locked' | 'hidden' | 'modelId' | 'pinnedAt'>;
   size?: MantineSpacing;
   hideLockOption?: boolean;
   modelUserId?: number;

--- a/src/server/controllers/comment.controller.ts
+++ b/src/server/controllers/comment.controller.ts
@@ -18,7 +18,9 @@ import {
   getCommentById,
   getCommentReactions,
   getComments,
+  getPinnedComments,
   toggleHideComment,
+  togglePinComment,
   updateCommentById,
   updateCommentReportStatusByReason,
 } from '~/server/services/comment.service';
@@ -50,8 +52,20 @@ export const getCommentsInfiniteHandler = async ({
     select: getAllCommentsSelect,
   });
 
-  const commentIds = comments.map((c) => c.id);
-  if (commentIds.length === 0) return { comments: [], nextCursor: undefined };
+  let nextCursor: number | undefined;
+  if (comments.length > input.limit) {
+    const nextItem = comments.pop();
+    nextCursor = nextItem?.id;
+  }
+
+  // Pinned comments surface at the top of the first page only.
+  const pinnedComments = !input.cursor
+    ? await getPinnedComments({ input, user, select: getAllCommentsSelect })
+    : [];
+
+  const allComments = [...pinnedComments, ...comments];
+  const commentIds = allComments.map((c) => c.id);
+  if (commentIds.length === 0) return { comments: [], nextCursor };
 
   const counts = await dbRead.$queryRaw<{ id: number; count: number }[]>`
     SELECT
@@ -63,15 +77,9 @@ export const getCommentsInfiniteHandler = async ({
   `;
   const countsMap = Object.fromEntries(counts.map((c) => [c.id, Number(c.count)]));
 
-  let nextCursor: number | undefined;
-  if (comments.length > input.limit) {
-    const nextItem = comments.pop();
-    nextCursor = nextItem?.id;
-  }
-
   return {
     nextCursor,
-    comments: comments.map((c) => ({
+    comments: allComments.map((c) => ({
       ...c,
       _count: { comments: countsMap[c.id] ?? 0 },
     })),
@@ -172,6 +180,24 @@ export const toggleHideCommentHandler = async ({
 }) => {
   try {
     await toggleHideComment({
+      ...input,
+      userId: ctx.user.id,
+      isModerator: ctx.user.isModerator ?? false,
+    });
+  } catch (error) {
+    throw throwDbError(error);
+  }
+};
+
+export const togglePinCommentHandler = async ({
+  input,
+  ctx,
+}: {
+  input: GetByIdInput;
+  ctx: ProtectedContext;
+}) => {
+  try {
+    await togglePinComment({
       ...input,
       userId: ctx.user.id,
       isModerator: ctx.user.isModerator ?? false,

--- a/src/server/routers/comment.router.ts
+++ b/src/server/routers/comment.router.ts
@@ -9,6 +9,7 @@ import {
   getCommentsInfiniteHandler,
   setTosViolationHandler,
   toggleHideCommentHandler,
+  togglePinCommentHandler,
   toggleLockHandler,
   upsertCommentHandler,
 } from '~/server/controllers/comment.controller';
@@ -138,6 +139,10 @@ export const commentRouter = router({
     .meta({ requiredScope: TokenScope.SocialWrite })
     .input(getByIdSchema)
     .mutation(toggleHideCommentHandler),
+  togglePin: protectedProcedure
+    .meta({ requiredScope: TokenScope.SocialWrite })
+    .input(getByIdSchema)
+    .mutation(togglePinCommentHandler),
   toggleLock: protectedProcedure
     .meta({ requiredScope: TokenScope.SocialWrite })
     .input(getByIdSchema)

--- a/src/server/selectors/comment.selector.ts
+++ b/src/server/selectors/comment.selector.ts
@@ -13,6 +13,7 @@ export const commentDetailSelect = Prisma.validator<Prisma.CommentSelect>()({
   locked: true,
   tosViolation: true,
   hidden: true,
+  pinnedAt: true,
   user: {
     select: userWithCosmeticsSelect,
   },

--- a/src/server/services/comment.service.ts
+++ b/src/server/services/comment.service.ts
@@ -224,7 +224,7 @@ export const togglePinComment = async ({
   userId,
   isModerator,
 }: GetByIdInput & { userId: number; isModerator: boolean }) => {
-  const AND = [Prisma.sql`c.id = ${id}`];
+  const AND = [Prisma.sql`c.id = ${id}`, Prisma.sql`c."parentId" IS NULL`];
   // Only the model owner or a moderator can pin a comment
   if (!isModerator) AND.push(Prisma.sql`m."userId" = ${userId}`);
 

--- a/src/server/services/comment.service.ts
+++ b/src/server/services/comment.service.ts
@@ -72,6 +72,7 @@ export const getComments = async <TSelect extends Prisma.CommentSelect>({
       parentId: { equals: null },
       tosViolation: !isMod ? false : undefined,
       hidden,
+      pinnedAt: null,
       // OR: [
       //   {
       //     userId: { not: user?.id },
@@ -90,6 +91,38 @@ export const getComments = async <TSelect extends Prisma.CommentSelect>({
   });
 
   return comments;
+};
+
+export const getPinnedComments = async <TSelect extends Prisma.CommentSelect>({
+  input: { modelId, userId, filterBy, hidden = false },
+  select,
+  user,
+}: {
+  input: GetAllCommentsSchema;
+  select: TSelect;
+  user?: SessionUser;
+}) => {
+  const isMod = user?.isModerator ?? false;
+  if (filterBy?.includes(ReviewFilter.IncludesImages)) return [];
+
+  const hiddenUsers = (await HiddenUsers.getCached({ userId: user?.id })).map((x) => x.id);
+  const blockedByUsers = (await BlockedByUsers.getCached({ userId: user?.id })).map((x) => x.id);
+  const blockedUsers = (await BlockedUsers.getCached({ userId: user?.id })).map((x) => x.id);
+  const excludedUserIds = boundExcludedUserIds(hiddenUsers, blockedByUsers, blockedUsers);
+
+  const db = await getDbWithoutLag('commentModel', modelId);
+  return db.comment.findMany({
+    where: {
+      modelId,
+      userId: userId ? userId : excludedUserIds.length ? { notIn: excludedUserIds } : undefined,
+      parentId: { equals: null },
+      tosViolation: !isMod ? false : undefined,
+      hidden,
+      pinnedAt: { not: null },
+    },
+    orderBy: { pinnedAt: 'desc' },
+    select,
+  });
 };
 
 export const getCommentById = <TSelect extends Prisma.CommentSelect>({
@@ -186,6 +219,32 @@ export const toggleHideComment = async ({
   await preventReplicationLag('commentModel', comment.modelId);
 };
 
+export const togglePinComment = async ({
+  id,
+  userId,
+  isModerator,
+}: GetByIdInput & { userId: number; isModerator: boolean }) => {
+  const AND = [Prisma.sql`c.id = ${id}`];
+  // Only the model owner or a moderator can pin a comment
+  if (!isModerator) AND.push(Prisma.sql`m."userId" = ${userId}`);
+
+  const [comment] = await dbWrite.$queryRaw<{ pinnedAt: Date | null; modelId: number }[]>`
+    SELECT
+      c."pinnedAt", c."modelId"
+    FROM "Comment" c
+    JOIN "Model" m ON m.id = c."modelId"
+    WHERE ${Prisma.join(AND, ' AND ')}
+  `;
+
+  if (!comment) throw throwNotFoundError(`You don't have permission to pin this comment`);
+
+  await dbWrite.comment.updateMany({
+    where: { id },
+    data: { pinnedAt: comment.pinnedAt ? null : new Date() },
+  });
+  await preventReplicationLag('commentModel', comment.modelId);
+};
+
 export const deleteCommentById = async ({ id }: GetByIdInput) => {
   const { modelId, model } =
     (await dbWrite.comment.findUnique({
@@ -270,10 +329,7 @@ export async function bulkSetCommentTosViolation({
 
     await Promise.allSettled(
       reports.map((report) =>
-        reportAcceptedReward.apply(
-          { userId: report.userId, reportId: report.id },
-          { ip: actor.ip }
-        )
+        reportAcceptedReward.apply({ userId: report.userId, reportId: report.id }, { ip: actor.ip })
       )
     );
 
@@ -302,7 +358,9 @@ export async function bulkDeleteComments({ ids }: { ids: number[] }) {
   });
   const result = await dbWrite.comment.deleteMany({ where: { id: { in: ids } } });
 
-  const modelIds = Array.from(new Set(affected.map((c) => c.modelId).filter((v): v is number => !!v)));
+  const modelIds = Array.from(
+    new Set(affected.map((c) => c.modelId).filter((v): v is number => !!v))
+  );
   const userIds = Array.from(
     new Set(affected.map((c) => c.model?.userId).filter((v): v is number => !!v))
   );


### PR DESCRIPTION
## What

Lets a **model owner (creator) or moderator** pin/unpin comments on the model page (`/models/[id]`) so important comments surface at the top.

## Why this is a separate PR from #3286

The model page renders the **LEGACY** comment system (`trpc.comment.*` → `Comment` table → `ModelDiscussionV2` / `CommentDiscussionItem`), **not** CommentsV2. #3286 wired pinning into CommentsV2 (`commentv2.*`), which does not drive the model page. This PR adds pinning to the legacy path so it actually works there. No CommentsV2 files are touched.

## Changes

**DB migration** — `prisma/migrations/20260721160807_add_comment_pinned_at/migration.sql`:
```sql
ALTER TABLE "Comment" ADD COLUMN "pinnedAt" TIMESTAMP(3);
```
Added `pinnedAt DateTime?` to the legacy `Comment` model in `packages/civitai-db-schema/prisma/schema.full.prisma` (authoritative schema) and regenerated the Prisma client + kysely/interface types.

⚠️ **Migration must be applied MANUALLY** to preview/prod (this repo does not use `prisma migrate deploy`).

**Server**
- `comment.service.ts`: new `togglePinComment` mirroring `toggleHideComment`, but auth is **model-owner-OR-moderator only** — the non-mod clause is just `m."userId" = <userId>` (no comment-author clause, so a random commenter cannot pin their own comment). Enforced server-side via the raw `Comment`→`Model` join, same as hide.
- `comment.service.ts`: pinned-first ordering. New `getPinnedComments` (where `pinnedAt IS NOT NULL`, `ORDER BY pinnedAt DESC`, same modelId/filters/excluded-users). `getComments` now always excludes pinned (`pinnedAt: null`), matching how CommentsV2 excludes pinned from its regular query.
- `comment.controller.ts`: `getCommentsInfiniteHandler` computes the regular-comment cursor **first** (unchanged +1 sentinel logic), then on the **first page only** (`!input.cursor`) fetches pinned and **prepends** them. Cursor pagination is unaffected: pinned are never counted toward the limit/sentinel, and subsequent pages don't refetch them. Added `togglePinCommentHandler`.
- `comment.router.ts`: `togglePin` procedure (`protectedProcedure`, `SocialWrite` scope, `getByIdSchema`), mirroring `toggleHide`.
- `comment.selector.ts`: added `pinnedAt` to `commentDetailSelect` so it flows to both `getAll` (indicator) and `getById` (menu optimistic update).

**Client**
- `CommentDiscussionMenu.tsx`: `togglePin` mutation (optimistic on `getById` + invalidate `comment.getAll`) and a Pin/Unpin `Menu.Item` gated `(isModelOwner || isMod)`, using `IconPinned` / `IconPinnedOff`.
- `CommentDiscussionItem.tsx`: orange `IconPinned` ThemeIcon indicator next to the menu when `pinnedAt` is set (mirrors the CommentsV2 indicator).

## Pinned-first ordering (cursor caveat)

Pinned comments appear only at the top of the **first page**; they are excluded from the regular query on every page, so they never duplicate and never consume the cursor's `limit+1` sentinel. `nextCursor` is derived solely from regular comments, so pagination behavior is identical to before.

## Verification

- `pnpm run typecheck` — passes.
- Regenerated types confirmed: `Comment.pinnedAt` present in `packages/civitai-db-schema/src/models.ts` and `.../src/kysely/types.ts`.
- Prettier clean on all changed source files.
- Not verified at runtime (no DB with the column applied); migration is intentionally unapplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
