### PR TITLE
docs(app-blocks): refresh dev-token money-path comments + document approvedScopes invariant (#3285 follow-up)

### DIFF
--- a/src/pages/api/v1/block-tokens/index.ts
+++ b/src/pages/api/v1/block-tokens/index.ts
@@ -483,6 +483,17 @@ async function tryDevTunnelScopedMint(args: {
  * SCOPED, forced-SFW, self-bound, budget-capped dev token for that case, reusing the
  * IDENTICAL audited clamp + budget + sign belt as the ephemeral path.
  *
+ * PRODUCT INTENT (confirmed — this is NOT a suspension bypass or a bug): a suspended
+ * (or pending / deprecated) app is DELIBERATELY still runnable by its OWNER, in the
+ * owner's OWN dev tunnel ONLY — never publicly. Suspension blocks the PUBLIC listing +
+ * public run, NOT the owner's own dev-tunnel dogfood: the owner must be able to keep
+ * iterating on / diagnosing a suspended app to get it back into review. The action is
+ * fully contained — self-bound (owner spends only their own Buzz), forced-SFW,
+ * dev-budget-capped, tunnel- AND flag-gated, NON-public, with no cross-user spend and no
+ * bounty attribution (the runtime row self-voids), and scope power bounded to the prior
+ * moderator-`approvedScopes` snapshot (never the re-published manifest). A future
+ * reader/moderator should NOT mistake this for a suspension escape hatch.
+ *
  * SECURITY INVARIANTS (ALL required — a failure of any → 'continue' → the SAME bare
  * 404, no oracle, no mint):
  *   1. OWNERSHIP — `resolveOwnedNonApprovedPageBlock` enforces `app.userId === caller`
@@ -570,6 +581,16 @@ async function tryDevTunnelOwnedNonApprovedMint(args: {
   // SCOPE SOURCE = the app's APPROVED SNAPSHOT (moderator-reviewed, pinned) — NEVER
   // the raw manifest. Clamped through the SAME tunnel belt as the ephemeral path
   // (TUNNEL allowlist, no OAuth ceiling, no widening; force-adds user:read:self).
+  //
+  // 🔴 LOAD-BEARING INVARIANT — the spend safety of this whole branch rests on:
+  //   `approvedScopes` is non-empty  ⟹  the app was moderator-approved at some point.
+  // `approvedScopes` is written ONLY by the mod-approval flow (it snapshots the scopes a
+  // moderator signed off on). A NEVER-approved app therefore has `approvedScopes = []`,
+  // and `clampTunnelDeclaredScopes([])` cannot invent `ai:write:budgeted` — so its dev
+  // token is READ-ONLY and can spend NOTHING. That is the only thing stopping this branch
+  // from minting a spend-capable token for an app no moderator ever vetted. Any future
+  // code that writes `approvedScopes` OUTSIDE the mod-approval flow (e.g. copying the raw
+  // manifest scopes into it) would silently break dev-tunnel spend safety here.
   const granted = clampTunnelDeclaredScopes(app.approvedScopes);
   // BUDGET = the manifest's page.buzzBudgetPerGen (clamped to the dev cap), defaulting
   // as the ephemeral path when absent. Only meaningful if ai:write:budgeted survived.

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -773,10 +773,13 @@ export function withBlockScope(
     // `app_block_id` cardinality: a normal (approved/pre-approval) token carries
     // a real FK appBlockId bounded to the approved-app set. A DEV token
     // (`claims.dev === true`, the same discriminator the max-age cap + audit path
-    // use) carries a CALLER-CONSTRUCTED, synthetic, non-resolving appBlockId (see
-    // dev-scoped-mint.service) — an unbounded label vector even though minting is
-    // mod/dev-cohort gated. Bucket ALL dev tokens to the single stable label
-    // 'dev' so that vector is closed while real per-app attribution is preserved.
+    // use) carries EITHER a CALLER-CONSTRUCTED, synthetic, non-resolving appBlockId
+    // (see dev-scoped-mint.service) OR — since #3285 — a real `apb_` id for an owner
+    // dev-tunnelling their OWN suspended/pending/deprecated app; the synthetic case
+    // makes this an unbounded label vector even though minting is mod/dev-cohort
+    // gated. Bucket ALL dev tokens (real-id or synthetic) to the single stable
+    // label 'dev' so that vector is closed while real per-app attribution is
+    // preserved for non-dev tokens.
     const appBlockIdLabel = claims.dev === true ? 'dev' : claims.appBlockId;
     const metricStart = process.hrtime.bigint();
     let metricRecorded = false;
@@ -930,8 +933,11 @@ export function withBlockScope(
               statusCode: res.statusCode,
               ...(actionDetail ? { detail: actionDetail } : {}),
               // Phase 2: a dev token MAY carry a synthetic non-FK appBlockId (a
-              // pre-approval dev-tunnel app) — let the audit write persist it via
-              // the nullable-appBlockId path instead of FK-failing + swallowing.
+              // pre-approval dev-tunnel app) OR — since #3285 — a real `apb_` id
+              // (an owner dev-tunnelling their own suspended/pending/deprecated
+              // app). Passing `dev` lets the audit write persist a synthetic id via
+              // the nullable-appBlockId path instead of FK-failing + swallowing; a
+              // real id persists normally.
               dev: claims.dev === true,
             })
           )

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3657,10 +3657,16 @@ export const blocksRouter = router({
       // reject fail-safe (NO spend).
       //
       // EXCLUSION: skipped for DEV/live-harness tokens (`claims.dev === true`),
-      // which carry a synthetic non-FK appBlockId and already have the
-      // per-session dev-tunnel spend backstop below — so a dev iterating locally
-      // is never clamped by the aggregate cap (matches recordSpendAttribution
-      // being inert for a synthetic appId).
+      // which carry EITHER a synthetic non-FK appBlockId (ephemeral / pre-approval
+      // apps) OR — since #3285 — a real `apb_` id for an owner dev-tunnelling their
+      // OWN suspended/pending/deprecated app. The G8 skip is still safe in both
+      // cases because a dev token is SELF-BOUND: only the owner can spend, and only
+      // their own Buzz, still bounded by the per-user daily cap above + the
+      // per-session dev-tunnel spend backstop below — so a dev iterating locally is
+      // never clamped by the aggregate (anti-Sybil) cap, which exists to bound
+      // MANY viewers funnelling through one PUBLIC app (impossible for a self-bound
+      // dev token). For the synthetic-id case this also matches recordSpendAttribution
+      // being inert for a non-FK appId.
       let appSpendReserve: { key: AppSpendDailyKey; cost: number } | null = null;
       if (claims.dev !== true) {
         const { reserveAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1992,6 +1992,12 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
     typeof request.deployState === 'string' && request.deployState.startsWith('preview-');
 
   const manifest = request.manifest as Record<string, unknown>;
+  // `manifestScopes` is written to `AppBlock.approvedScopes` on the three approve paths
+  // below (create / P2002-retry / subsequent-version). 🔴 This mod-approval flow is the
+  // ONLY place that writes `approvedScopes` — a load-bearing invariant the dev-tunnel
+  // owned-non-approved mint relies on (block-tokens/index.ts): a NEVER-approved app has
+  // `approvedScopes = []` ⟹ its dev token is read-only + cannot spend. Writing
+  // `approvedScopes` anywhere OUTSIDE this approval flow would break that safety.
   const manifestScopes = Array.isArray(manifest.scopes) ? (manifest.scopes as string[]) : [];
   const manifestContentRating =
     typeof manifest.contentRating === 'string' ? manifest.contentRating : 'g';


### PR DESCRIPTION
Comment/doc-only follow-up closing the 🟢 findings from the #3285 audit (the dev-tunnel owned-non-approved mint, already merged). **No behavior change.**

#3285 made a `dev:true` block token able to carry a REAL `apb_` FK id (for an owner dev-tunnelling their own suspended/pending/deprecated app) — previously `dev:true` only ever carried a synthetic non-FK id. That's safe (audit-confirmed: self-spend voids, the G8 skip is fine because the token is self-bound), but it invalidated some comments documenting the safety premise, and it rested on an undocumented invariant. This refreshes the docs so a future maintainer reasoning about money-path safety isn't misled.

## Findings closed

**#1 — stale-comment refresh** (comments now documented a now-false "synthetic only" premise):
- `src/server/routers/blocks.router.ts` — the **G8 per-app-cap skip** for `dev:true`: now notes the token may carry a synthetic id (ephemeral) OR an owned-non-approved real `apb_` id, and that the skip stays safe because the token is SELF-BOUND (owner-only spend, still bounded by per-user daily cap + per-dev-session backstop).
- `src/server/middleware/block-scope.middleware.ts` — the dev-token **metric bucketing** premise AND the **audit-write** `dev` comment: same refresh (synthetic OR owned-non-approved real id; all dev tokens still bucket to the `'dev'` metric label).

**#2 — capture confirmed product intent** (`tryDevTunnelOwnedNonApprovedMint` docblock, `block-tokens/index.ts`): a suspended/pending/deprecated app is DELIBERATELY runnable by its owner, in their own dev tunnel only — fully contained (self-bound, forced-SFW, dev-budget-capped, tunnel+flag-gated, non-public, no cross-user spend/bounty, scope power bounded to the prior `approvedScopes` snapshot). Suspension blocks PUBLIC listing/run, NOT the owner's own dev-tunnel dogfood — so a future reader/mod doesn't mistake it for a bug or suspension bypass.

**#3 — document the load-bearing invariant**: spend capability in this branch rests entirely on **`approvedScopes` non-empty ⟹ the app was mod-approved at some point** (a never-approved app has `approvedScopes = []` → read-only token, no `ai:write:budgeted`). Documented at the CONSUMPTION site (`block-tokens/index.ts`, where `clampTunnelDeclaredScopes(app.approvedScopes)` runs) and the sole WRITE site (`approveRequest` in `publish-request.service.ts`), noting that any future code writing `approvedScopes` outside the mod-approval flow would break dev-tunnel spend safety.

Comment-only — no runtime assertion added: a post-clamp `scopes ⊆ allowlist` assert would be tautological since `clampTunnelDeclaredScopes` already enforces the allowlist.

## Verification
- `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` — **zero errors in the 4 changed files**. The remaining repo-wide errors are pre-existing/environmental (Challenge Prisma-drift, plus `event-engine-common`/`kysely` module-not-found from the local sandbox's uncheckedout submodule + unsymlinked per-package deps); the pr-preview is the authoritative typecheck. Comment-only changes cannot introduce type errors.
- Both #3285 suites green: `dev-tunnel-owned-nonapproved-mint.test.ts` (14) + `block-registry.resolve-owned-nonapproved.test.ts` (9) = **23 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)