### PR TITLE
feat(challenges): block-user enforcement on user challenges

### DIFF
--- a/src/server/games/daily-challenge/challenge-entry-gate.ts
+++ b/src/server/games/daily-challenge/challenge-entry-gate.ts
@@ -7,11 +7,20 @@ import { throwBadRequestError } from '~/server/utils/errorHandling';
 // no-ops (it requires Active), so the entry would commit for free — and the still-mutable/rescannable
 // text could later flip NSFW and cancel the challenge out from under entrants. Reject until Active.
 // No-op for daily/system challenges and non-challenge contest collections (findFirst → null).
-export async function assertUserChallengeAcceptingEntries(collectionId: number): Promise<void> {
-  const userChallenge = await dbRead.challenge.findFirst({
-    where: { collectionId, source: ChallengeSource.User },
-    select: { status: true },
-  });
+export async function assertUserChallengeAcceptingEntries(
+  collectionId: number,
+  // Callers that already fetched the owning source=User challenge (e.g. the collection-entry
+  // validator) pass it here to skip a duplicate lookup: an object (or `null` for "no such
+  // challenge"). Omit to have this fetch it.
+  preloaded?: { status: ChallengeStatus } | null
+): Promise<void> {
+  const userChallenge =
+    preloaded !== undefined
+      ? preloaded
+      : await dbRead.challenge.findFirst({
+          where: { collectionId, source: ChallengeSource.User },
+          select: { status: true },
+        });
   if (userChallenge && userChallenge.status !== ChallengeStatus.Active) {
     throw throwBadRequestError('Challenge is starting shortly, please try again in a few minutes.');
   }

--- a/src/server/routers/challenge.router.ts
+++ b/src/server/routers/challenge.router.ts
@@ -316,7 +316,7 @@ export const challengeRouter = router({
   getActiveEvents: publicProcedure
     .meta({ requiredScope: TokenScope.MediaRead })
     .use(isFlagProtected('challengePlatform'))
-    .query(() => getActiveEvents()),
+    .query(({ ctx }) => getActiveEvents(ctx.user?.id)),
 
   // Public: Get single event by ID
   getEventById: publicProcedure

--- a/src/server/services/__tests__/challenge-detail-visibility.service.test.ts
+++ b/src/server/services/__tests__/challenge-detail-visibility.service.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // detail page of a user challenge regardless of its scan/POI/cover state (a stuck-Scheduled
 // challenge 404'd for mods because the scan gate only exempted the creator). The public gates
 // must keep applying to everyone else.
-const { mockDbRead, mockGetChallengeById } = vi.hoisted(() => ({
+const { mockDbRead, mockGetChallengeById, mockAmIBlockedByUser } = vi.hoisted(() => ({
   mockDbRead: {
     $queryRaw: vi.fn(),
     modelVersion: { findMany: vi.fn() },
@@ -13,6 +13,7 @@ const { mockDbRead, mockGetChallengeById } = vi.hoisted(() => ({
     collectionItem: { count: vi.fn() },
   },
   mockGetChallengeById: vi.fn(),
+  mockAmIBlockedByUser: vi.fn(),
 }));
 
 vi.mock('~/server/db/client', () => ({
@@ -64,6 +65,7 @@ vi.mock('~/server/services/image.service', () => ({
 vi.mock('~/server/services/user.service', () => ({
   getCosmeticsForUsers: vi.fn(() => ({})),
   getProfilePicturesForUsers: vi.fn(() => ({})),
+  amIBlockedByUser: mockAmIBlockedByUser,
 }));
 
 vi.mock('~/server/services/notification.service', () => ({
@@ -289,5 +291,43 @@ describe('getChallengeDetail — userChallenges flag gate', () => {
     );
 
     expect(await getChallengeDetail(400, RANDO_ID, false, false, false)).not.toBeNull();
+  });
+});
+
+describe('getChallengeDetail — creator block gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbRead.$queryRaw.mockResolvedValue([
+      { id: OWNER_ID, username: 'creator', image: null, deletedAt: null },
+    ]);
+  });
+
+  it('hides a user challenge from a viewer the creator has blocked', async () => {
+    mockGetChallengeById.mockResolvedValue(makeUserChallenge({ ingestion: 'Scanned' }));
+    mockAmIBlockedByUser.mockResolvedValue(true);
+    expect(await getChallengeDetail(400, RANDO_ID, false, false, true)).toBeNull();
+    expect(mockAmIBlockedByUser).toHaveBeenCalledWith({ userId: RANDO_ID, targetUserId: OWNER_ID });
+  });
+
+  it('still shows it to a viewer who is not blocked', async () => {
+    mockGetChallengeById.mockResolvedValue(makeUserChallenge({ ingestion: 'Scanned' }));
+    mockAmIBlockedByUser.mockResolvedValue(false);
+    expect(await getChallengeDetail(400, RANDO_ID, false, false, true)).not.toBeNull();
+  });
+
+  it('exempts moderators even when blocked', async () => {
+    mockGetChallengeById.mockResolvedValue(makeUserChallenge({ ingestion: 'Scanned' }));
+    mockAmIBlockedByUser.mockResolvedValue(true);
+    expect(await getChallengeDetail(400, MOD_ID, false, true, true)).not.toBeNull();
+    expect(mockAmIBlockedByUser).not.toHaveBeenCalled();
+  });
+
+  it('does not block-gate System (daily) challenges', async () => {
+    mockGetChallengeById.mockResolvedValue(
+      makeUserChallenge({ ingestion: 'Scanned', source: 'System', buzzType: 'yellow' })
+    );
+    mockAmIBlockedByUser.mockResolvedValue(true);
+    expect(await getChallengeDetail(400, RANDO_ID, false, false, true)).not.toBeNull();
+    expect(mockAmIBlockedByUser).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/challenge-feed-block-exclusion.service.test.ts
+++ b/src/server/services/__tests__/challenge-feed-block-exclusion.service.test.ts
@@ -1,0 +1,208 @@
+import type { Prisma } from '@prisma/client';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// getInfiniteChallenges: user challenges whose creator is in the viewer's block/hide set must be
+// dropped from the feed (parity with getChallengeDetail's creator-block gate, covered in
+// challenge-detail-visibility.service.test.ts). The predicate is only pushed onto the query when
+// the viewer's excluded-id set is non-empty, so we assert both that the predicate appears when it
+// should and that it's absent (not just empty) when it shouldn't.
+const {
+  mockDbRead,
+  mockHiddenUsersGetCached,
+  mockBlockedByUsersGetCached,
+  mockBlockedUsersGetCached,
+} = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(),
+    modelVersion: { findMany: vi.fn() },
+    image: { findUnique: vi.fn(), findFirst: vi.fn(), findMany: vi.fn(() => []) },
+    challenge: { findUnique: vi.fn() },
+    collectionItem: { count: vi.fn() },
+  },
+  mockHiddenUsersGetCached: vi.fn(() => [] as { id: number }[]),
+  mockBlockedByUsersGetCached: vi.fn(() => [] as { id: number }[]),
+  mockBlockedUsersGetCached: vi.fn(() => [] as { id: number }[]),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: {},
+}));
+
+vi.mock('~/server/services/user-preferences.service', () => ({
+  HiddenUsers: { getCached: mockHiddenUsersGetCached },
+  BlockedByUsers: { getCached: mockBlockedByUsersGetCached },
+  BlockedUsers: { getCached: mockBlockedUsersGetCached },
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  createBuzzTransactionMany: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getChallengeConfig: vi.fn(() => ({
+    reviewMeTagId: 301770,
+    judgedTagId: 299729,
+    maxScoredPerUser: 5,
+    reviewAmount: { min: 6, max: 12 },
+  })),
+  setChallengeConfig: vi.fn(),
+  deriveChallengeNsfwLevel: vi.fn(() => 1),
+  getJudgingConfig: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  getChallengeById: vi.fn(),
+  getChallengeWinners: vi.fn(() => []),
+  closeChallengeCollection: vi.fn(),
+  createChallengeWinner: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  generateWinners: vi.fn(),
+}));
+
+vi.mock('~/server/jobs/daily-challenge-processing', () => ({
+  getJudgedEntries: vi.fn(),
+}));
+
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+}));
+
+vi.mock('~/server/services/image.service', () => ({
+  createImage: vi.fn(),
+  imagesForModelVersionsCache: { bust: vi.fn(), fetch: vi.fn(() => ({})) },
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  getCosmeticsForUsers: vi.fn(() => ({})),
+  getProfilePicturesForUsers: vi.fn(() => ({})),
+  amIBlockedByUser: vi.fn(),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-eligibility.service', () => ({
+  assertCanCreateUserChallenge: vi.fn(),
+  assertUserInGoodStanding: vi.fn(),
+  assertUserAccountInGoodStanding: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-category.service', () => ({
+  resolveJudgingCategories: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/challenge-judge.service', () => ({
+  getUserSelectableJudges: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/text-moderation.service', () => ({
+  submitTextModeration: vi.fn(),
+}));
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn(),
+}));
+
+vi.mock('~/utils/errorHandling', () => ({
+  withRetries: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('~/utils/logging', () => ({
+  createLogger: vi.fn(() => vi.fn()),
+}));
+
+const { getInfiniteChallenges } = await import('~/server/services/challenge.service');
+
+// Duck-typed Prisma.Sql detection: the runtime `@prisma/client` package doesn't export the `Sql`
+// class itself (only the `Prisma.sql` tag function), so `instanceof Prisma.Sql` isn't available.
+// Every Sql fragment (plain or `Prisma.join`-composed) exposes an own `values`/`strings` array
+// plus a `.text` getter that already contains the FULLY FLATTENED, fully-composed SQL of any
+// nested fragments — so no manual recursion is needed once a fragment is identified.
+function isSqlLike(x: unknown): x is Prisma.Sql {
+  return (
+    typeof x === 'object' &&
+    x !== null &&
+    Array.isArray((x as { values?: unknown }).values) &&
+    Array.isArray((x as { strings?: unknown }).strings) &&
+    typeof (x as { text?: unknown }).text === 'string'
+  );
+}
+
+// Pulls the first `dbRead.$queryRaw` call's tagged-template args (stringsArray + interpolated
+// values — `challengeCardQuery`, `whereClause`, `orderByClause`, `limit + 1`), keeps only the
+// Prisma.Sql fragments, and flattens them into one SQL text + one bound-values list to assert on.
+function captureQuery() {
+  const call = mockDbRead.$queryRaw.mock.calls[0];
+  if (!call) throw new Error('dbRead.$queryRaw was not called');
+  const sqlFragments = call.filter(isSqlLike);
+  return {
+    text: sqlFragments.map((s) => s.text).join(' '),
+    values: sqlFragments.flatMap((s) => s.values),
+  };
+}
+
+const BLOCK_PREDICATE_MARKER = '!= ALL(';
+
+describe('getInfiniteChallenges — feed block/hide exclusion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+    mockDbRead.image.findMany.mockResolvedValue([]);
+    mockHiddenUsersGetCached.mockResolvedValue([]);
+    mockBlockedByUsersGetCached.mockResolvedValue([]);
+    mockBlockedUsersGetCached.mockResolvedValue([]);
+  });
+
+  it("excludes a blocked creator's user challenges", async () => {
+    mockBlockedByUsersGetCached.mockResolvedValue([{ id: 777 }]);
+
+    await getInfiniteChallenges({
+      limit: 20,
+      includeEnded: false,
+      excludeEventChallenges: false,
+      currentUserId: 5,
+      isGreen: false,
+      canAccessUserChallenges: true,
+    } as Parameters<typeof getInfiniteChallenges>[0]);
+
+    const { text, values } = captureQuery();
+    expect(text).toContain(BLOCK_PREDICATE_MARKER);
+    expect(values.some((v) => Array.isArray(v) && v.includes(777))).toBe(true);
+  });
+
+  it('adds no block predicate when the viewer has no blocks', async () => {
+    await getInfiniteChallenges({
+      limit: 20,
+      includeEnded: false,
+      excludeEventChallenges: false,
+      currentUserId: 5,
+      isGreen: false,
+      canAccessUserChallenges: true,
+    } as Parameters<typeof getInfiniteChallenges>[0]);
+
+    const { text } = captureQuery();
+    expect(text).not.toContain(BLOCK_PREDICATE_MARKER);
+  });
+
+  it('anonymous viewer adds no block predicate', async () => {
+    await getInfiniteChallenges({
+      limit: 20,
+      includeEnded: false,
+      excludeEventChallenges: false,
+      currentUserId: undefined,
+      isGreen: false,
+      canAccessUserChallenges: true,
+    } as Parameters<typeof getInfiniteChallenges>[0]);
+
+    const { text } = captureQuery();
+    expect(text).not.toContain(BLOCK_PREDICATE_MARKER);
+    expect(mockHiddenUsersGetCached).not.toHaveBeenCalled();
+    expect(mockBlockedByUsersGetCached).not.toHaveBeenCalled();
+    expect(mockBlockedUsersGetCached).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/collection.service.sysredis-soft.test.ts
+++ b/src/server/services/__tests__/collection.service.sysredis-soft.test.ts
@@ -70,6 +70,7 @@ vi.mock('~/server/services/model.service', () => ({ getModelsWithVersions: vi.fn
 vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
 vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
 vi.mock('~/server/services/post.service', () => ({ getPostsInfinite: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser: vi.fn(async () => false) }));
 
 import { getCollectionRandomSeed } from '~/server/services/collection.service';
 

--- a/src/server/services/__tests__/contest-entry-resource-gate.test.ts
+++ b/src/server/services/__tests__/contest-entry-resource-gate.test.ts
@@ -17,26 +17,39 @@ const REQUIRED_VERSION_ID = 111;
 const COLLECTION_ID = 100;
 const USER_ID = 5;
 const IMAGE_ID = 9001;
+const CREATOR_ID = 4242;
 
-const { mockChargeEntryFees, mockChallengeFindFirst, mockImageResourceNewFindMany, mockDbRead } =
-  vi.hoisted(() => {
-    const mockChargeEntryFees = vi.fn();
-    const mockChallengeFindFirst = vi.fn();
-    const mockImageResourceNewFindMany = vi.fn();
-    const mockDbRead = {
-      user: { findUnique: vi.fn() },
-      challenge: { findFirst: mockChallengeFindFirst },
-      collectionItem: { count: vi.fn(), findFirst: vi.fn() },
-      collection: { findMany: vi.fn() },
-      image: { findMany: vi.fn() },
-      article: { findMany: vi.fn() },
-      model: { findMany: vi.fn() },
-      post: { findMany: vi.fn() },
-      imageResourceNew: { findMany: mockImageResourceNewFindMany },
-      $queryRaw: vi.fn(),
-    };
-    return { mockChargeEntryFees, mockChallengeFindFirst, mockImageResourceNewFindMany, mockDbRead };
-  });
+const {
+  mockChargeEntryFees,
+  mockChallengeFindFirst,
+  mockImageResourceNewFindMany,
+  mockDbRead,
+  mockAmIBlockedByUser,
+} = vi.hoisted(() => {
+  const mockChargeEntryFees = vi.fn();
+  const mockChallengeFindFirst = vi.fn();
+  const mockImageResourceNewFindMany = vi.fn();
+  const mockAmIBlockedByUser = vi.fn(async () => false);
+  const mockDbRead = {
+    user: { findUnique: vi.fn() },
+    challenge: { findFirst: mockChallengeFindFirst },
+    collectionItem: { count: vi.fn(), findFirst: vi.fn() },
+    collection: { findMany: vi.fn() },
+    image: { findMany: vi.fn() },
+    article: { findMany: vi.fn() },
+    model: { findMany: vi.fn() },
+    post: { findMany: vi.fn() },
+    imageResourceNew: { findMany: mockImageResourceNewFindMany },
+    $queryRaw: vi.fn(),
+  };
+  return {
+    mockChargeEntryFees,
+    mockChallengeFindFirst,
+    mockImageResourceNewFindMany,
+    mockDbRead,
+    mockAmIBlockedByUser,
+  };
+});
 
 vi.mock('~/server/redis/client', () => {
   const make = (): any => new Proxy(() => 'k', { get: () => make() });
@@ -84,6 +97,7 @@ vi.mock('~/server/services/model.service', () => ({
   getModelsWithImagesAndModelVersions: vi.fn(),
 }));
 vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser: mockAmIBlockedByUser }));
 vi.mock('~/server/services/orchestrator/models', () => ({ bustOrchestratorModelCache: vi.fn() }));
 vi.mock('~/server/services/post.service', () => ({ getPostsInfinite: vi.fn() }));
 
@@ -115,7 +129,7 @@ function wireChallengeFindFirst(opts: { hasResourceChallenge: boolean; hasFeeCha
       // unless the user challenge is Active. Return an Active challenge so execution
       // reaches the resource gate under test. ('Active' is ChallengeStatus.Active —
       // the same literal collection.service uses.)
-      return { status: 'Active' };
+      return { status: 'Active', createdById: CREATOR_ID };
     }
     return null;
   });
@@ -209,5 +223,46 @@ describe('contest entry resource gate (Task 11)', () => {
     // Moderators are also exempt from the entry fee (chargeContestEntryFeesForCollection
     // no-ops for isModerator), so the fee charge is never invoked either.
     expect(mockChargeEntryFees).not.toHaveBeenCalled();
+  });
+});
+
+describe('validateContestCollectionEntry — creator block gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAmIBlockedByUser.mockResolvedValue(false);
+  });
+
+  it('rejects an entry from a viewer the creator has blocked, before charging', async () => {
+    wireChallengeFindFirst({ hasResourceChallenge: false, hasFeeChallenge: false });
+    mockDbRead.user.findUnique.mockResolvedValue({ id: USER_ID, meta: {} });
+    mockAmIBlockedByUser.mockResolvedValue(true);
+
+    await expect(
+      validateContestCollectionEntry({
+        collectionId: COLLECTION_ID,
+        userId: USER_ID,
+        imageIds: [IMAGE_ID],
+        canAccessUserChallenges: true,
+      })
+    ).rejects.toThrow('not available');
+
+    expect(mockAmIBlockedByUser).toHaveBeenCalledWith({ userId: USER_ID, targetUserId: CREATOR_ID });
+    expect(mockChargeEntryFees).not.toHaveBeenCalled();
+  });
+
+  it('lets an unblocked viewer proceed past the block gate', async () => {
+    wireChallengeFindFirst({ hasResourceChallenge: false, hasFeeChallenge: false });
+    mockDbRead.user.findUnique.mockResolvedValue({ id: USER_ID, meta: {} });
+    mockDbRead.$queryRaw.mockResolvedValue([]); // no already-judged image
+    mockAmIBlockedByUser.mockResolvedValue(false);
+
+    await expect(
+      validateContestCollectionEntry({
+        collectionId: COLLECTION_ID,
+        userId: USER_ID,
+        imageIds: [IMAGE_ID],
+        canAccessUserChallenges: true,
+      })
+    ).resolves.toBeUndefined();
   });
 });

--- a/src/server/services/__tests__/user-challenge-flag-gate.test.ts
+++ b/src/server/services/__tests__/user-challenge-flag-gate.test.ts
@@ -75,6 +75,7 @@ vi.mock('~/server/services/post.service', () => ({ getPostsInfinite: vi.fn() }))
 vi.mock('~/server/games/daily-challenge/challenge-funding', () => ({
   chargeEntryFees: mockChargeEntryFees,
 }));
+vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser: vi.fn(async () => false) }));
 
 const { validateContestCollectionEntry } = await import('~/server/services/collection.service');
 
@@ -84,7 +85,9 @@ function wireChallengeFindFirst({ userChallengeCollection }: { userChallengeColl
   mockChallengeFindFirst.mockImplementation(async ({ where }: { where: Record<string, unknown> }) => {
     const isFlagGateLookup =
       where.source === 'User' && !('entryFee' in where) && !('createdById' in where);
-    if (isFlagGateLookup) return userChallengeCollection ? { id: 1 } : null;
+    // status: 'Active' satisfies the assertUserChallengeAcceptingEntries timing gate (which shares
+    // this source-only lookup shape) so the flag-gate behavior under test is what actually decides.
+    if (isFlagGateLookup) return userChallengeCollection ? { id: 1, status: 'Active' } : null;
     return null; // every other challenge lookup: nothing configured
   });
 }

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -67,6 +67,12 @@ import {
   getCosmeticsForUsers,
   getProfilePicturesForUsers,
 } from '~/server/services/user.service';
+import { boundExcludedUserIds } from '~/server/utils/excluded-user-ids';
+import {
+  BlockedByUsers,
+  BlockedUsers,
+  HiddenUsers,
+} from '~/server/services/user-preferences.service';
 import { throwNotFoundError } from '~/server/utils/errorHandling';
 import { resolveJudgingCategories } from '~/server/services/challenge-category.service';
 import { getUserSelectableJudges } from '~/server/services/challenge-judge.service';
@@ -365,6 +371,23 @@ type ParticipatedRow = ChallengeCardRow & {
   myEnteredAt: Date;
 };
 
+// The viewer's bounded block/hide exclusion set (hidden ∪ blocked-by ∪ blocked), used to drop
+// user challenges whose creator is on it — parity with comment/review feeds. Empty for anon.
+// Ordering into boundExcludedUserIds is load-bearing (see its doc): hidden, blockedBy, blocked.
+async function getChallengeExcludedUserIds(viewerId?: number): Promise<number[]> {
+  if (!viewerId) return [];
+  const [hidden, blockedBy, blocked] = await Promise.all([
+    HiddenUsers.getCached({ userId: viewerId }),
+    BlockedByUsers.getCached({ userId: viewerId }),
+    BlockedUsers.getCached({ userId: viewerId }),
+  ]);
+  return boundExcludedUserIds(
+    hidden.map((u) => u.id),
+    blockedBy.map((u) => u.id),
+    blocked.map((u) => u.id)
+  );
+}
+
 /**
  * Challenges the current user has entered (CollectionItem) or won (ChallengeWinner), recent-first
  * by entry time. One row per challenge (their latest entry as the representative thumbnail).
@@ -398,6 +421,8 @@ export async function getMyParticipated({
     requested: undefined,
   });
 
+  const excludedUserIds = await getChallengeExcludedUserIds(userId);
+
   const rows = await dbRead.$queryRaw<ParticipatedRow[]>(Prisma.sql`
     WITH my AS (${myEntries})
     SELECT c.id, c.title, c.theme, c.invitation, c."coverImageId", c."startsAt", c."endsAt",
@@ -418,6 +443,11 @@ export async function getMyParticipated({
     LEFT JOIN "ChallengeWinner" cw ON cw."challengeId" = c.id AND cw."userId" = ${userId}
     WHERE c.status IN (${ChallengeStatus.Active}::"ChallengeStatus", ${ChallengeStatus.Completing}::"ChallengeStatus", ${ChallengeStatus.Completed}::"ChallengeStatus")
       AND (c.source <> ${ChallengeSource.User}::"ChallengeSource" OR c."buzzType" = ${domainCurrency} OR c."createdById" = ${userId})
+      ${
+        excludedUserIds.length > 0
+          ? Prisma.sql`AND (c.source <> ${ChallengeSource.User}::"ChallengeSource" OR c."createdById" != ALL(${excludedUserIds}::int[]))`
+          : Prisma.empty
+      }
       ${
         effectiveBrowsingLevel > 0
           ? Prisma.sql`AND (c."createdById" = ${userId} OR EXISTS (SELECT 1 FROM "Image" i WHERE i.id = COALESCE(my."myImageId", c."coverImageId") AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0))`
@@ -542,6 +572,15 @@ export async function getInfiniteChallenges(
       ? Prisma.sql`(c.source <> 'User'::"ChallengeSource" OR c."buzzType" = ${domainCurrency} OR c."createdById" = ${currentUserId})`
       : Prisma.sql`(c.source <> 'User'::"ChallengeSource" OR c."buzzType" = ${domainCurrency})`
   );
+
+  // Block/hide gate: drop user challenges whose creator the viewer has blocked/hidden (or who
+  // blocked the viewer) — parity with comment/review feeds. System/mod challenges are exempt.
+  const excludedUserIds = await getChallengeExcludedUserIds(currentUserId);
+  if (excludedUserIds.length > 0) {
+    conditions.push(
+      Prisma.sql`(c.source <> 'User'::"ChallengeSource" OR c."createdById" != ALL(${excludedUserIds}::int[]))`
+    );
+  }
 
   // Status filter (parameterized)
   if (status && status.length > 0) {
@@ -3472,6 +3511,14 @@ export async function getCompletedChallengesWithWinners(
       ? Prisma.sql`(c.source <> 'User'::"ChallengeSource" OR c."buzzType" = ${domainCurrency} OR c."createdById" = ${currentUserId})`
       : Prisma.sql`(c.source <> 'User'::"ChallengeSource" OR c."buzzType" = ${domainCurrency})`
   );
+
+  // Block/hide gate — parity with the feed. System/mod challenges exempt.
+  const excludedUserIds = await getChallengeExcludedUserIds(currentUserId);
+  if (excludedUserIds.length > 0) {
+    conditions.push(
+      Prisma.sql`(c.source <> 'User'::"ChallengeSource" OR c."createdById" != ALL(${excludedUserIds}::int[]))`
+    );
+  }
 
   // Content level filter — parity with the feed: exclude a challenge whose REAL cover image level
   // doesn't intersect the viewer's effective (green-capped) browsing level, rather than trusting

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -388,6 +388,14 @@ async function getChallengeExcludedUserIds(viewerId?: number): Promise<number[]>
   );
 }
 
+// Raw-SQL predicate (aliased `c`) dropping user challenges whose creator is in the viewer's
+// exclusion set; System/mod rows always pass via the source guard. Returns null when the set is
+// empty so callers can skip pushing it. Shared by the three raw feeds to keep the scoping in sync.
+function challengeCreatorBlockSql(excludedUserIds: number[]): Prisma.Sql | null {
+  if (excludedUserIds.length === 0) return null;
+  return Prisma.sql`(c.source <> ${ChallengeSource.User}::"ChallengeSource" OR c."createdById" != ALL(${excludedUserIds}::int[]))`;
+}
+
 /**
  * Challenges the current user has entered (CollectionItem) or won (ChallengeWinner), recent-first
  * by entry time. One row per challenge (their latest entry as the representative thumbnail).
@@ -421,7 +429,7 @@ export async function getMyParticipated({
     requested: undefined,
   });
 
-  const excludedUserIds = await getChallengeExcludedUserIds(userId);
+  const blockSql = challengeCreatorBlockSql(await getChallengeExcludedUserIds(userId));
 
   const rows = await dbRead.$queryRaw<ParticipatedRow[]>(Prisma.sql`
     WITH my AS (${myEntries})
@@ -443,11 +451,7 @@ export async function getMyParticipated({
     LEFT JOIN "ChallengeWinner" cw ON cw."challengeId" = c.id AND cw."userId" = ${userId}
     WHERE c.status IN (${ChallengeStatus.Active}::"ChallengeStatus", ${ChallengeStatus.Completing}::"ChallengeStatus", ${ChallengeStatus.Completed}::"ChallengeStatus")
       AND (c.source <> ${ChallengeSource.User}::"ChallengeSource" OR c."buzzType" = ${domainCurrency} OR c."createdById" = ${userId})
-      ${
-        excludedUserIds.length > 0
-          ? Prisma.sql`AND (c.source <> ${ChallengeSource.User}::"ChallengeSource" OR c."createdById" != ALL(${excludedUserIds}::int[]))`
-          : Prisma.empty
-      }
+      ${blockSql ? Prisma.sql`AND ${blockSql}` : Prisma.empty}
       ${
         effectiveBrowsingLevel > 0
           ? Prisma.sql`AND (c."createdById" = ${userId} OR EXISTS (SELECT 1 FROM "Image" i WHERE i.id = COALESCE(my."myImageId", c."coverImageId") AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0))`
@@ -575,12 +579,8 @@ export async function getInfiniteChallenges(
 
   // Block/hide gate: drop user challenges whose creator the viewer has blocked/hidden (or who
   // blocked the viewer) — parity with comment/review feeds. System/mod challenges are exempt.
-  const excludedUserIds = await getChallengeExcludedUserIds(currentUserId);
-  if (excludedUserIds.length > 0) {
-    conditions.push(
-      Prisma.sql`(c.source <> 'User'::"ChallengeSource" OR c."createdById" != ALL(${excludedUserIds}::int[]))`
-    );
-  }
+  const blockSql = challengeCreatorBlockSql(await getChallengeExcludedUserIds(currentUserId));
+  if (blockSql) conditions.push(blockSql);
 
   // Status filter (parameterized)
   if (status && status.length > 0) {
@@ -3524,12 +3524,8 @@ export async function getCompletedChallengesWithWinners(
   );
 
   // Block/hide gate — parity with the feed. System/mod challenges exempt.
-  const excludedUserIds = await getChallengeExcludedUserIds(currentUserId);
-  if (excludedUserIds.length > 0) {
-    conditions.push(
-      Prisma.sql`(c.source <> 'User'::"ChallengeSource" OR c."createdById" != ALL(${excludedUserIds}::int[]))`
-    );
-  }
+  const blockSql = challengeCreatorBlockSql(await getChallengeExcludedUserIds(currentUserId));
+  if (blockSql) conditions.push(blockSql);
 
   // Content level filter — parity with the feed: exclude a challenge whose REAL cover image level
   // doesn't intersect the viewer's effective (green-capped) browsing level, rather than trusting

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -62,7 +62,11 @@ import {
   PrizeMode,
 } from '~/shared/utils/prisma/enums';
 import { createImage, imagesForModelVersionsCache } from '~/server/services/image.service';
-import { getCosmeticsForUsers, getProfilePicturesForUsers } from '~/server/services/user.service';
+import {
+  amIBlockedByUser,
+  getCosmeticsForUsers,
+  getProfilePicturesForUsers,
+} from '~/server/services/user.service';
 import { throwNotFoundError } from '~/server/utils/errorHandling';
 import { resolveJudgingCategories } from '~/server/services/challenge-category.service';
 import { getUserSelectableJudges } from '~/server/services/challenge-judge.service';
@@ -1016,6 +1020,18 @@ export async function getChallengeDetail(
   // covers the direct-link case: the detail page's SSG prefetch and every client fetch go through
   // this function, so without the flag the page falls through to its not-found branch.
   if (challenge.source === ChallengeSource.User && !canAccessUserChallenges) return null;
+
+  // Block gate: a viewer the creator has blocked can't open the challenge — direct-link parity
+  // with model/article/post detail. Scoped to user challenges (System/mod challenges have no owner
+  // to block); moderators exempt. A creator viewing their own challenge is self-safe:
+  // amIBlockedByUser returns false when targetUserId === userId.
+  if (viewerId != null && isModerator !== true && challenge.source === ChallengeSource.User) {
+    const blocked = await amIBlockedByUser({
+      userId: viewerId,
+      targetUserId: challenge.createdById ?? undefined,
+    });
+    if (blocked) return null;
+  }
 
   // Visibility check: only show challenges that are visible to the public. The creator and
   // moderators may preview a not-yet-visible or Cancelled challenge, and are likewise exempt

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -2920,7 +2920,8 @@ async function getEventCoverImages(coverImageIds: (number | null)[]) {
  * Get active challenge events with their challenges.
  * Returns events where active=true and endDate >= now, ordered by startDate.
  */
-export async function getActiveEvents(): Promise<ChallengeEventListItem[]> {
+export async function getActiveEvents(viewerId?: number): Promise<ChallengeEventListItem[]> {
+  const excludedUserIds = await getChallengeExcludedUserIds(viewerId);
   const events = await dbRead.challengeEvent.findMany({
     where: {
       active: true,
@@ -2939,6 +2940,16 @@ export async function getActiveEvents(): Promise<ChallengeEventListItem[]> {
         where: {
           visibleAt: { lte: new Date() },
           status: { not: ChallengeStatus.Cancelled },
+          // Block/hide gate — drop user challenges whose creator the viewer blocked/hid.
+          // System/mod event challenges are exempt via the source OR-branch.
+          ...(excludedUserIds.length > 0
+            ? {
+                OR: [
+                  { source: { not: ChallengeSource.User } },
+                  { createdById: { notIn: excludedUserIds } },
+                ],
+              }
+            : {}),
         },
         orderBy: { startsAt: 'asc' },
         select: {

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -1988,20 +1988,24 @@ export const validateContestCollectionEntry = async ({
     throw throwBadRequestError('You are banned from participating in contests');
   }
 
+  // The source=User challenge (if any) that owns this collection. One lookup, reused by the flag
+  // gate, the block gate, and the accepting-entries timing gate below — System/Mod (daily) and
+  // community-contest collections have no such row, so this is null for them.
+  const userChallenge = await dbRead.challenge.findFirst({
+    where: { collectionId, source: ChallengeSource.User },
+    select: { id: true, createdById: true, status: true },
+  });
+
   // User-created challenges are still flag-gated, but entries reach this function through the
   // generic collection mutations, which carry no challenge-specific guard — so a direct link to
   // the challenge would otherwise be enough to submit. Scoped to source=User: ordinary contest
   // collections and System/Mod (daily) challenges are unaffected.
-  if (!canAccessUserChallenges) {
-    const gatedChallenge = await dbRead.challenge.findFirst({
-      where: { collectionId, source: ChallengeSource.User },
-      select: { id: true },
-    });
-    if (gatedChallenge)
-      throw throwAuthorizationError('This challenge is not currently available.');
-  }
+  if (!canAccessUserChallenges && userChallenge)
+    throw throwAuthorizationError('This challenge is not currently available.');
 
-  // Challenge creators may not enter their own challenge (self-dealing on the prize pool).
+  // Challenge creators may not enter their own challenge (self-dealing on the prize pool). Its own
+  // lookup: it filters on createdById across ANY source, so it also catches a System/Mod challenge
+  // the viewer created — which the source=User lookup above would miss.
   if (!isModerator) {
     const ownChallenge = await dbRead.challenge.findFirst({
       where: { collectionId, createdById: userId },
@@ -2014,18 +2018,12 @@ export const validateContestCollectionEntry = async ({
 
   // A viewer the challenge creator has blocked can't submit an entry — parity with the detail-page
   // block gate. Scoped to source=User (System/mod challenges have no owner); moderators exempt.
-  if (!isModerator) {
-    const userChallenge = await dbRead.challenge.findFirst({
-      where: { collectionId, source: ChallengeSource.User },
-      select: { createdById: true },
+  if (!isModerator && userChallenge) {
+    const blocked = await amIBlockedByUser({
+      userId,
+      targetUserId: userChallenge.createdById ?? undefined,
     });
-    if (userChallenge) {
-      const blocked = await amIBlockedByUser({
-        userId,
-        targetUserId: userChallenge.createdById ?? undefined,
-      });
-      if (blocked) throw throwBadRequestError('This challenge is not available.');
-    }
+    if (blocked) throw throwBadRequestError('This challenge is not available.');
   }
 
   // Block re-submitting an image a challenge judge has already scored. Removal
@@ -2058,7 +2056,7 @@ export const validateContestCollectionEntry = async ({
 
   // User challenges accept entries only once Active — makes the entry WRITE agree with the fee
   // CHARGE (which already requires Active). No-op for daily/system/community collections.
-  await assertUserChallengeAcceptingEntries(collectionId);
+  await assertUserChallengeAcceptingEntries(collectionId, userChallenge);
 
   if (!metadata) {
     return;

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -63,6 +63,7 @@ import { createNotification } from '~/server/services/notification.service';
 import { bustOrchestratorModelCache } from '~/server/services/orchestrator/models';
 import type { PostsInfiniteModel } from '~/server/services/post.service';
 import { getPostsInfinite } from '~/server/services/post.service';
+import { amIBlockedByUser } from '~/server/services/user.service';
 import {
   throwAuthorizationError,
   throwBadRequestError,
@@ -2008,6 +2009,22 @@ export const validateContestCollectionEntry = async ({
     });
     if (ownChallenge) {
       throw throwBadRequestError('You cannot submit entries to your own challenge.');
+    }
+  }
+
+  // A viewer the challenge creator has blocked can't submit an entry — parity with the detail-page
+  // block gate. Scoped to source=User (System/mod challenges have no owner); moderators exempt.
+  if (!isModerator) {
+    const userChallenge = await dbRead.challenge.findFirst({
+      where: { collectionId, source: ChallengeSource.User },
+      select: { createdById: true },
+    });
+    if (userChallenge) {
+      const blocked = await amIBlockedByUser({
+        userId,
+        targetUserId: userChallenge.createdById ?? undefined,
+      });
+      if (blocked) throw throwBadRequestError('This challenge is not available.');
     }
   }
 


### PR DESCRIPTION
## What

User-created challenges (`Challenge.source = 'User'`) had **zero** blocked-user enforcement, unlike every other user-owned entity (model/article/post/image/bounty). A user who blocked someone could still have that person open their challenge detail page, see their challenges in feeds, and submit entries. This closes that gap with parity to the existing conventions.

## Changes (all scoped to `source = 'User'`; System/Mod/daily challenges never filtered)

**Access guards** — `amIBlockedByUser` (blockedBy direction), moderators exempt, matching model/article/post:
- `getChallengeDetail` → returns `null` (→ not-found) when the viewer is blocked by the creator.
- `validateContestCollectionEntry` → throws **before any entry-fee charge** when a blocked viewer tries to submit.

**Feed/list exclusion** — `boundExcludedUserIds(hidden, blockedBy, blocked)` (all three directions), SQL `!= ALL(${ids}::int[])`, guarded on non-empty set:
- `getInfiniteChallenges`, `getCompletedChallengesWithWinners`, `getMyParticipated`, and `getActiveEvents` (nested challenges) drop challenges whose creator is in the viewer's exclusion set.
- Shared `getChallengeExcludedUserIds` helper.

## Out of scope (intentional)
- Winner-row stripping, removing/refunding existing entries, `getDailyChallenges` (System-only).

## Testing
- Detail block gate: blocked/unblocked/moderator/System cases.
- Entry guard: blocked → throws + fee never charged; unblocked → proceeds.
- Feed exclusion: `getInfiniteChallenges` drops a blocked creator's row via `!= ALL` with the blocked id in bind values; empty set adds no predicate; anon skips cache reads.
- 37/37 tests pass across all touched files.
- Also fixed a pre-existing stale-mock failure in `user-challenge-flag-gate.test.ts` (statusless mock made the `assertUserChallengeAcceptingEntries` timing gate reject; unrelated to blocking).

## Follow-ups (non-blocking, noted in final review)
- `getUpcomingThemes` lacks source/scan/block gating (pre-existing, broader; endpoint currently unrendered).
- `getChallengeEventById` challenge **count** not block-filtered (count only; content list is served by the gated feed).

Spec: `docs/superpowers/specs/2026-07-21-challenge-block-enforcement-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)