### PR TITLE
fix(challenges): entry-fee disclosure, cooldown/owner gating, buzz colors + mod rescan

### DIFF
--- a/src/components/Cards/ChallengeCard.tsx
+++ b/src/components/Cards/ChallengeCard.tsx
@@ -91,6 +91,7 @@ export const ChallengeCard = memo(function ChallengeCard({ data }: Props) {
     createdById,
     nsfwLevel,
     prizePool,
+    buzzType,
     entryCount,
     commentCount,
     createdBy,
@@ -181,6 +182,7 @@ export const ChallengeCard = memo(function ChallengeCard({ data }: Props) {
           <div className="flex items-center justify-between gap-2">
             <CurrencyBadge
               currency={Currency.BUZZ}
+              type={buzzType}
               unitAmount={prizePool}
               radius="xl"
               px={8}

--- a/src/components/Cards/CompletedChallengeCard.tsx
+++ b/src/components/Cards/CompletedChallengeCard.tsx
@@ -14,7 +14,7 @@ import type {
 import { isDefined } from '~/utils/type-guards';
 
 export function CompletedChallengeCard({ data }: Props) {
-  const { id, title, theme, endsAt, prizePool, entryCount, winners } = data;
+  const { id, title, theme, endsAt, prizePool, buzzType, entryCount, winners } = data;
   const challengeUrl = `/challenges/${id}/${slugit(title)}`;
 
   // Podium order: [2nd, 1st, 3rd] — same as detail page
@@ -59,6 +59,7 @@ export function CompletedChallengeCard({ data }: Props) {
             <Group gap="sm" mt={4}>
               <CurrencyBadge
                 currency={Currency.BUZZ}
+                type={buzzType}
                 unitAmount={prizePool}
                 radius="xl"
                 variant="light"
@@ -91,6 +92,7 @@ export function CompletedChallengeCard({ data }: Props) {
                 isFirst={winner.place === 1}
                 className={winner.place === 1 ? 'z-10' : ''}
                 compact
+                buzzType={buzzType}
               />
             ))}
           </div>

--- a/src/components/Cards/MyChallengeCard.stories.tsx
+++ b/src/components/Cards/MyChallengeCard.stories.tsx
@@ -25,6 +25,7 @@ const baseChallenge: MyParticipatedChallengeItem = {
   endsAt: daysFromNow(-1),
   status: ChallengeStatus.Completed,
   source: ChallengeSource.System,
+  buzzType: 'yellow',
   nsfwLevel: 1,
   allowedNsfwLevel: 31,
   prizePool: 10000,

--- a/src/components/Challenge/ChallengeSubmitModal.tsx
+++ b/src/components/Challenge/ChallengeSubmitModal.tsx
@@ -13,6 +13,7 @@ import {
   Stack,
   Tabs,
   Text,
+  Tooltip,
   useComputedColorScheme,
   useMantineTheme,
 } from '@mantine/core';
@@ -29,6 +30,7 @@ import { create } from 'zustand';
 import { immer } from 'zustand/middleware/immer';
 import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
 import { CurrencyBadge } from '~/components/Currency/CurrencyBadge';
+import { CurrencyIcon } from '~/components/Currency/CurrencyIcon';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import { CooldownBanner } from '~/components/Challenge/CooldownBanner';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
@@ -47,7 +49,16 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useCFImageUpload } from '~/hooks/useCFImageUpload';
 import { constants } from '~/server/common/constants';
 import { ImageSort, NsfwLevel } from '~/server/common/enums';
-import { ChallengeReviewCostType, ChallengeStatus, Currency } from '~/shared/utils/prisma/enums';
+import {
+  ChallengeReviewCostType,
+  ChallengeSource,
+  ChallengeStatus,
+  Currency,
+} from '~/shared/utils/prisma/enums';
+import {
+  CHALLENGE_ENTRY_HOUSE_CUT,
+  getEntryPoolContribution,
+} from '~/shared/constants/challenge.constants';
 import {
   addSimpleImagePostInput,
   bulkSaveCollectionItemsInput,
@@ -396,6 +407,17 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
   const loading =
     uploading || addSimpleImagePostMutation.isPending || bulkSaveItemsMutation.isPending;
 
+  const buzzType = challenge?.buzzType === 'green' ? 'green' : 'yellow';
+  const entryFeeInfo =
+    challenge?.source === ChallengeSource.User && challenge.entryFee > 0
+      ? {
+          entryFee: challenge.entryFee,
+          // Mirrors chargeEntryFees: the house cut is capped at the fee, never exceeds it.
+          houseCut: Math.min(challenge.entryFee, CHALLENGE_ENTRY_HOUSE_CUT),
+          perEntryToPool: getEntryPoolContribution(challenge.entryFee),
+        }
+      : null;
+
   // Count for submit button (users can only select eligible images)
   const submitCount =
     activeTab === 'library'
@@ -403,6 +425,18 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
       : activeTab === 'generator'
       ? generatorSelected.length
       : uploadedFiles.filter((f) => f.status === 'success').length;
+
+  // Everything this submission will charge. The entry fee (judging cut + pool cut) is charged by
+  // the server on submit, the guaranteed-review fee only when opted in — the balance check has to
+  // cover both or a user without enough Buzz gets through the modal and fails server-side.
+  const guaranteeCost =
+    guaranteeReview &&
+    challenge?.reviewCostType === ChallengeReviewCostType.PerEntry &&
+    challenge.reviewCost > 0
+      ? challenge.reviewCost * submitCount
+      : 0;
+  const entryCost = entryFeeInfo ? entryFeeInfo.entryFee * submitCount : 0;
+  const totalBuzzCost = entryCost + guaranteeCost;
 
   return (
     <Modal
@@ -445,7 +479,11 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
         )}
 
         {challenge && (
-          <CooldownBanner challengeId={challengeId} status={challenge.status} />
+          <CooldownBanner
+            challengeId={challengeId}
+            status={challenge.status}
+            source={challenge.source}
+          />
         )}
 
         {nearDeadline && (
@@ -613,9 +651,8 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
           )}
 
         {/* Footer */}
-        <Group
-          gap="xs"
-          justify="flex-end"
+        <Stack
+          gap={8}
           mx="-lg"
           px="lg"
           pt="lg"
@@ -625,14 +662,17 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
             }`,
           }}
         >
+        <Group gap="xs" justify="flex-end">
           <Button variant="default" onClick={handleClose}>
             Cancel
           </Button>
-          {guaranteeReview &&
-          challenge?.reviewCostType === ChallengeReviewCostType.PerEntry &&
-          challenge?.reviewCost ? (
+          {totalBuzzCost > 0 ? (
             <BuzzTransactionButton
-              buzzAmount={challenge.reviewCost * submitCount}
+              buzzAmount={totalBuzzCost}
+              // Entry fees are charged from the challenge's own Buzz account, so check that
+              // balance rather than the domain default — otherwise a user holding only the other
+              // Buzz type passes the check and the server charge fails.
+              accountTypes={entryFeeInfo ? [buzzType] : undefined}
               onPerformTransaction={handleSubmit}
               loading={loading || requestReviewMutation.isPending}
               disabled={submitCount === 0 || remainingEntries === 0}
@@ -651,6 +691,39 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
             </Button>
           )}
         </Group>
+
+          {entryFeeInfo && (
+            <Group gap={4} justify="flex-end" wrap="nowrap">
+              <CurrencyIcon currency={Currency.BUZZ} type={buzzType} size={14} />
+              <Text size="xs" c="dimmed">
+                {submitCount > 0 ? (
+                  <>
+                    <b>{totalBuzzCost.toLocaleString()}</b> total
+                  </>
+                ) : (
+                  <>
+                    <b>{entryFeeInfo.entryFee.toLocaleString()}</b> per entry
+                  </>
+                )}{' '}
+                &middot; {(entryFeeInfo.houseCut * Math.max(submitCount, 1)).toLocaleString()}{' '}for AI
+                judging &middot;{' '}
+                {(entryFeeInfo.perEntryToPool * Math.max(submitCount, 1)).toLocaleString()} to the
+                prize pool
+                {guaranteeCost > 0 && (
+                  <> &middot; {guaranteeCost.toLocaleString()} for guaranteed review</>
+                )}
+              </Text>
+              <Tooltip
+                label="The AI judging cost is non-refundable. The prize-pool portion is returned if the challenge is cancelled."
+                maw={260}
+                multiline
+                withArrow
+              >
+                <IconInfoCircle size={14} className="text-dimmed" />
+              </Tooltip>
+            </Group>
+          )}
+        </Stack>
       </Stack>
     </Modal>
   );

--- a/src/components/Challenge/ChallengeSubmitModal.tsx
+++ b/src/components/Challenge/ChallengeSubmitModal.tsx
@@ -429,6 +429,11 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
   // Everything this submission will charge. The entry fee (judging cut + pool cut) is charged by
   // the server on submit, the guaranteed-review fee only when opted in — the balance check has to
   // cover both or a user without enough Buzz gets through the modal and fails server-side.
+  //
+  // BuzzTransactionButton checks the DOMAIN's Buzz account, which is the right one here only
+  // because a user challenge is domain-gated to its own buzzType (isChallengeHiddenByDomainCurrency)
+  // — nobody who can reach this button is on the other domain. Passing accountTypes wouldn't
+  // help either: useAvailableBuzz strips green/yellow and re-adds the domain's own.
   const guaranteeCost =
     guaranteeReview &&
     challenge?.reviewCostType === ChallengeReviewCostType.PerEntry &&
@@ -669,10 +674,6 @@ export function ChallengeSubmitModal({ challengeId, collectionId }: Props) {
           {totalBuzzCost > 0 ? (
             <BuzzTransactionButton
               buzzAmount={totalBuzzCost}
-              // Entry fees are charged from the challenge's own Buzz account, so check that
-              // balance rather than the domain default — otherwise a user holding only the other
-              // Buzz type passes the check and the server charge fails.
-              accountTypes={entryFeeInfo ? [buzzType] : undefined}
               onPerformTransaction={handleSubmit}
               loading={loading || requestReviewMutation.isPending}
               disabled={submitCount === 0 || remainingEntries === 0}

--- a/src/components/Challenge/ChallengeUpsertForm.tsx
+++ b/src/components/Challenge/ChallengeUpsertForm.tsx
@@ -925,7 +925,12 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
               <>
             <Group justify="space-between" wrap="wrap">
               <Title order={4}>Prizes</Title>
-              <CurrencyBadge currency={Currency.BUZZ} unitAmount={totalPrizePool} size="lg" />
+              <CurrencyBadge
+                currency={Currency.BUZZ}
+                type={selectedBuzzType}
+                unitAmount={totalPrizePool}
+                size="lg"
+              />
             </Group>
 
             {/* Prize Mode Toggle */}
@@ -943,7 +948,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                 <InputNumber
                   name="prize1Buzz"
                   label="1st Place"
-                  leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                  leftSection={<CurrencyIcon currency="BUZZ" type={selectedBuzzType} size={16} />}
                   currency={Currency.BUZZ}
                   min={0}
                   step={100}
@@ -952,7 +957,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                 <InputNumber
                   name="prize2Buzz"
                   label="2nd Place"
-                  leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                  leftSection={<CurrencyIcon currency="BUZZ" type={selectedBuzzType} size={16} />}
                   currency={Currency.BUZZ}
                   min={0}
                   step={100}
@@ -961,7 +966,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                 <InputNumber
                   name="prize3Buzz"
                   label="3rd Place"
-                  leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                  leftSection={<CurrencyIcon currency="BUZZ" type={selectedBuzzType} size={16} />}
                   currency={Currency.BUZZ}
                   min={0}
                   step={100}
@@ -976,7 +981,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                 <InputNumber
                   name="basePrizePool"
                   label="Base Prize Pool"
-                  leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                  leftSection={<CurrencyIcon currency="BUZZ" type={selectedBuzzType} size={16} />}
                   currency={Currency.BUZZ}
                   min={0}
                   step={100}
@@ -988,7 +993,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                   <InputNumber
                     name="buzzPerAction"
                     label="Buzz Per Trigger"
-                    leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                    leftSection={<CurrencyIcon currency="BUZZ" type={selectedBuzzType} size={16} />}
                     currency={Currency.BUZZ}
                     min={0}
                     step={1}
@@ -1010,7 +1015,7 @@ export function ChallengeUpsertForm({ challenge, variant = 'moderator' }: Props)
                   name="maxPrizePool"
                   label="Max Prize Pool (optional)"
                   description="Leave empty for unlimited growth"
-                  leftSection={<CurrencyIcon currency="BUZZ" size={16} />}
+                  leftSection={<CurrencyIcon currency="BUZZ" type={selectedBuzzType} size={16} />}
                   currency={Currency.BUZZ}
                   min={0}
                   step={100}

--- a/src/components/Challenge/CooldownBanner.tsx
+++ b/src/components/Challenge/CooldownBanner.tsx
@@ -3,19 +3,20 @@ import { IconInfoCircle } from '@tabler/icons-react';
 import { formatDate } from '~/utils/date-helpers';
 import { useWinnerCooldownStatus } from '~/components/Challenge/challenge.utils';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import { ChallengeStatus } from '~/shared/utils/prisma/enums';
+import { ChallengeSource, ChallengeStatus } from '~/shared/utils/prisma/enums';
 
 type Props = {
   challengeId: number;
   status: ChallengeStatus;
+  source: ChallengeSource;
 };
 
-export function CooldownBanner({ challengeId, status }: Props) {
+export function CooldownBanner({ challengeId, status, source }: Props) {
   const currentUser = useCurrentUser();
   const isActive = status === ChallengeStatus.Active;
 
   const { data: cooldownStatus } = useWinnerCooldownStatus(challengeId, {
-    enabled: !!currentUser && isActive,
+    enabled: !!currentUser && isActive && source !== ChallengeSource.User,
   });
 
   if (!cooldownStatus?.onCooldown || !cooldownStatus.cooldownEndsAt) return null;

--- a/src/components/Challenge/WinnerPodiumCard.tsx
+++ b/src/components/Challenge/WinnerPodiumCard.tsx
@@ -68,7 +68,7 @@ export function WinnerPodiumCard({
   isMobile = false,
   compact = false,
   judgeInfo,
-  buzzType = 'yellow',
+  buzzType,
 }: {
   winner: WinnerPodiumData;
   isFirst: boolean;
@@ -76,7 +76,9 @@ export function WinnerPodiumCard({
   isMobile?: boolean;
   compact?: boolean;
   judgeInfo?: JudgeInfo;
-  buzzType?: 'green' | 'yellow';
+  // Required, not defaulted: a missing value would silently render yellow, which is the exact bug
+  // this prop exists to fix.
+  buzzType: 'green' | 'yellow';
 }) {
   const [reasonExpanded, setReasonExpanded] = useState(false);
   const colorScheme = useComputedColorScheme('dark');

--- a/src/components/Challenge/WinnerPodiumCard.tsx
+++ b/src/components/Challenge/WinnerPodiumCard.tsx
@@ -68,6 +68,7 @@ export function WinnerPodiumCard({
   isMobile = false,
   compact = false,
   judgeInfo,
+  buzzType = 'yellow',
 }: {
   winner: WinnerPodiumData;
   isFirst: boolean;
@@ -75,6 +76,7 @@ export function WinnerPodiumCard({
   isMobile?: boolean;
   compact?: boolean;
   judgeInfo?: JudgeInfo;
+  buzzType?: 'green' | 'yellow';
 }) {
   const [reasonExpanded, setReasonExpanded] = useState(false);
   const colorScheme = useComputedColorScheme('dark');
@@ -136,6 +138,7 @@ export function WinnerPodiumCard({
           {!compact && (
             <CurrencyBadge
               currency={Currency.BUZZ}
+              type={buzzType}
               unitAmount={winner.buzzAwarded}
               size="sm"
               style={{ background: 'rgba(255,255,255,0.2)', color: 'white' }}

--- a/src/components/Challenge/challenge.utils.ts
+++ b/src/components/Challenge/challenge.utils.ts
@@ -93,11 +93,16 @@ export function useQueryCompletedChallengesWithWinners(
 // in collection.service.ts saveItemInCollections. Intentionally stricter than that check, which
 // exempts moderators: a moderator who owns a challenge still sees the blocked button, so the UI
 // never invites self-dealing. Moderators keep the server-side ability if they need it.
-export function useIsChallengeOwner(challenge: Pick<ChallengeDetail, 'createdById' | 'source'>) {
+export function useIsChallengeOwner(
+  // Accepts undefined so callers can resolve ownership before their `!challenge` early return,
+  // which is the only way to keep this a hook rather than a second inline copy of the rule.
+  challenge?: Pick<ChallengeDetail, 'createdById' | 'source'> | null
+) {
   const currentUser = useCurrentUser();
 
   return (
     !!currentUser &&
+    !!challenge &&
     currentUser.id === challenge.createdById &&
     challenge.source === ChallengeSource.User
   );

--- a/src/components/Challenge/challenge.utils.ts
+++ b/src/components/Challenge/challenge.utils.ts
@@ -89,15 +89,15 @@ export function useQueryCompletedChallengesWithWinners(
   return { challenges: flatData, ...rest };
 }
 
-// Creators may not enter their own challenge (self-dealing on the prize pool). Mirrors the server
-// rule in collection.service.ts saveItemInCollections, including its moderator exemption — without
-// it a moderator who created a challenge sees a blocked button for a submission the server allows.
+// Creators may not enter their own challenge (self-dealing on the prize pool), enforced server side
+// in collection.service.ts saveItemInCollections. Intentionally stricter than that check, which
+// exempts moderators: a moderator who owns a challenge still sees the blocked button, so the UI
+// never invites self-dealing. Moderators keep the server-side ability if they need it.
 export function useIsChallengeOwner(challenge: Pick<ChallengeDetail, 'createdById' | 'source'>) {
   const currentUser = useCurrentUser();
 
   return (
     !!currentUser &&
-    !currentUser.isModerator &&
     currentUser.id === challenge.createdById &&
     challenge.source === ChallengeSource.User
   );

--- a/src/components/Challenge/challenge.utils.ts
+++ b/src/components/Challenge/challenge.utils.ts
@@ -1,13 +1,16 @@
 import { useMemo } from 'react';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { trpc } from '~/utils/trpc';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import type {
+  ChallengeDetail,
   GetInfiniteChallengesInput,
   GetCompletedChallengesWithWinnersInput,
 } from '~/server/schema/challenge.schema';
 import { ChallengeSort } from '~/server/schema/challenge.schema';
+import { ChallengeSource } from '~/shared/utils/prisma/enums';
 
 // Default filter values
 const defaultFilters: Partial<GetInfiniteChallengesInput> = {
@@ -84,6 +87,20 @@ export function useQueryCompletedChallengesWithWinners(
   const flatData = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data?.pages]);
 
   return { challenges: flatData, ...rest };
+}
+
+// Creators may not enter their own challenge (self-dealing on the prize pool). Mirrors the server
+// rule in collection.service.ts saveItemInCollections, including its moderator exemption — without
+// it a moderator who created a challenge sees a blocked button for a submission the server allows.
+export function useIsChallengeOwner(challenge: Pick<ChallengeDetail, 'createdById' | 'source'>) {
+  const currentUser = useCurrentUser();
+
+  return (
+    !!currentUser &&
+    !currentUser.isModerator &&
+    currentUser.id === challenge.createdById &&
+    challenge.source === ChallengeSource.User
+  );
 }
 
 // Hook to get winner cooldown status for the current user

--- a/src/pages/challenges/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/[id]/[[...slug]].tsx
@@ -9,6 +9,7 @@ import {
   Group,
   Indicator,
   Loader,
+  type MantineSize,
   Menu,
   Paper,
   type PaperProps,
@@ -20,11 +21,13 @@ import {
   Progress,
   ThemeIcon,
   Title,
+  Tooltip,
   useMantineTheme,
   useComputedColorScheme,
 } from '@mantine/core';
 import { closeAllModals, openConfirmModal } from '@mantine/modals';
 import type { InferGetServerSidePropsType } from 'next';
+import type { MouseEvent } from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as z from 'zod';
 
@@ -67,6 +70,7 @@ import {
   IconGift,
   IconPencil,
   IconPhoto,
+  IconRefresh,
   IconShare3,
   IconSparkles,
   IconLock,
@@ -77,7 +81,11 @@ import {
 } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 import { abbreviateNumber } from '~/utils/number-helpers';
-import { useDeleteUserChallenge, useQueryChallenge } from '~/components/Challenge/challenge.utils';
+import {
+  useDeleteUserChallenge,
+  useIsChallengeOwner,
+  useQueryChallenge,
+} from '~/components/Challenge/challenge.utils';
 import { WinnerPodiumCard } from '~/components/Challenge/WinnerPodiumCard';
 import {
   DescriptionTable,
@@ -233,6 +241,15 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
     onError: handleMutationError,
   });
 
+  const rescanMutation = trpc.challenge.rescan.useMutation({
+    onSuccess: () => {
+      showSuccessNotification({
+        message: 'Rescan queued. The verdict will apply once the scan completes.',
+      });
+    },
+    onError: handleMutationError,
+  });
+
   const deleteMutation = trpc.challenge.delete.useMutation({
     onSuccess: () => {
       showSuccessNotification({ message: 'Challenge deleted' });
@@ -284,6 +301,42 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
         labels: { cancel: 'Cancel', confirm: 'Void Challenge' },
         confirmProps: { color: 'red' },
         onConfirm: () => voidChallengeMutation.mutateAsync({ id }),
+      },
+    });
+  };
+
+  const handleRescan = () => {
+    if (!challenge) return;
+    // Only a live green user challenge takes the hold-for-review path on an NSFW verdict
+    // (computeNsfwEscalation); everything else is just raised to R in place.
+    const warnOnNsfw =
+      challenge.status === ChallengeStatus.Active &&
+      challenge.source === ChallengeSource.User &&
+      challenge.buzzType === 'green';
+    dialogStore.trigger({
+      component: ConfirmDialog,
+      props: {
+        title: 'Rescan Content',
+        message: (
+          <Stack gap="xs">
+            <Text>
+              Re-run the content scan for <strong>&ldquo;{challenge.title}&rdquo;</strong>?
+            </Text>
+            <Text size="sm" c="dimmed">
+              Resubmits the challenge text and re-queues the cover image, ignoring the previous
+              verdict. The challenge stays visible while the scan runs.
+            </Text>
+            {warnOnNsfw && (
+              <Text size="sm" c="yellow.6">
+                This challenge is live. If the rescan comes back NSFW, it will be cancelled and
+                hidden — entrants are refunded their prize-pool contribution and notified, and the
+                creator&apos;s escrowed prize is returned.
+              </Text>
+            )}
+          </Stack>
+        ),
+        labels: { cancel: 'Cancel', confirm: 'Rescan' },
+        onConfirm: () => rescanMutation.mutateAsync({ id }),
       },
     });
   };
@@ -432,6 +485,19 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
                             </Menu.Item>
                           )}
                         </ToggleLockComments>
+                        <Menu.Item
+                          leftSection={
+                            rescanMutation.isPending ? (
+                              <Loader size={14} />
+                            ) : (
+                              <IconRefresh size={14} stroke={1.5} />
+                            )
+                          }
+                          onClick={handleRescan}
+                          disabled={rescanMutation.isPending}
+                        >
+                          Rescan Content
+                        </Menu.Item>
 
                         {isActive && (
                           <>
@@ -727,6 +793,15 @@ function ChallengeSidebar({ challenge }: { challenge: ChallengeDetail }) {
   const currentUser = useCurrentUser();
   const isActive = challenge.status === ChallengeStatus.Active;
   const isDynamicPool = challenge.prizeMode === PrizeMode.Dynamic && challenge.buzzPerAction > 0;
+  const isOwner = useIsChallengeOwner(challenge);
+
+  const handleOpenSubmitModal = () => {
+    if (!challenge.collectionId) return;
+    dialogStore.trigger({
+      component: ChallengeSubmitModal,
+      props: { challengeId: challenge.id, collectionId: challenge.collectionId },
+    });
+  };
 
   // Get user's entry count for this challenge
   const { data: userEntryData } = trpc.challenge.getUserEntryCount.useQuery(
@@ -856,7 +931,12 @@ function ChallengeSidebar({ challenge }: { challenge: ChallengeDetail }) {
       </Group>
     ),
     value: (
-      <CurrencyBadge size="sm" currency={Currency.BUZZ} unitAmount={prize.buzz} />
+      <CurrencyBadge
+        size="sm"
+        currency={Currency.BUZZ}
+        type={challenge.buzzType}
+        unitAmount={prize.buzz}
+      />
     ),
   }));
 
@@ -963,7 +1043,7 @@ function ChallengeSidebar({ challenge }: { challenge: ChallengeDetail }) {
               </Group>
 
               <Group gap={6} justify="center" align="baseline">
-                <CurrencyIcon currency="BUZZ" size={28} />
+                <CurrencyIcon currency="BUZZ" type={challenge.buzzType} size={28} />
                 <Text
                   fw={900}
                   style={{
@@ -1177,25 +1257,7 @@ function ChallengeSidebar({ challenge }: { challenge: ChallengeDetail }) {
                   Generate
                 </Button>
                 {challenge.collectionId && (
-                  <LoginRedirect reason="submit-challenge">
-                    <Button
-                      onClick={() => {
-                        dialogStore.trigger({
-                          component: ChallengeSubmitModal,
-                          props: {
-                            challengeId: challenge.id,
-                            collectionId: challenge.collectionId!,
-                          },
-                        });
-                      }}
-                      leftSection={<IconPhoto size={16} />}
-                      variant="light"
-                      color="blue"
-                      fullWidth
-                    >
-                      Submit
-                    </Button>
-                  </LoginRedirect>
+                  <SubmitEntryButton isOwner={isOwner} onClick={handleOpenSubmitModal} label="Submit" fullWidth />
                 )}
               </Group>
             </div>
@@ -1218,22 +1280,7 @@ function ChallengeSidebar({ challenge }: { challenge: ChallengeDetail }) {
                 Generate
               </Button>
               {challenge.collectionId && (
-                <LoginRedirect reason="submit-challenge">
-                  <Button
-                    onClick={() => {
-                      dialogStore.trigger({
-                        component: ChallengeSubmitModal,
-                        props: { challengeId: challenge.id, collectionId: challenge.collectionId! },
-                      });
-                    }}
-                    leftSection={<IconPhoto size={16} />}
-                    variant="light"
-                    color="blue"
-                    fullWidth
-                  >
-                    Submit
-                  </Button>
-                </LoginRedirect>
+                <SubmitEntryButton isOwner={isOwner} onClick={handleOpenSubmitModal} label="Submit" fullWidth />
               )}
             </>
           ) : challenge.status === ChallengeStatus.Completed ? (
@@ -1485,6 +1532,7 @@ function ChallengeWinners({ challenge }: { challenge: ChallengeDetail }) {
                   isFirst={index === 1}
                   className={index === 1 ? 'z-10' : ''}
                   judgeInfo={judgeInfo}
+                  buzzType={challenge.buzzType}
                 />
               ))}
             </div>
@@ -1502,6 +1550,7 @@ function ChallengeWinners({ challenge }: { challenge: ChallengeDetail }) {
                     isFirst={winner.place === 1}
                     isMobile
                     judgeInfo={judgeInfo}
+                    buzzType={challenge.buzzType}
                   />
                 ))}
             </Stack>
@@ -1597,6 +1646,7 @@ function ChallengeEntries({ challenge }: { challenge: ChallengeDetail }) {
   const isActive = challenge.status === ChallengeStatus.Active;
   const hasCollection = !!challenge.collectionId;
   const displaySubmitAction = isActive && hasCollection && !currentUser?.muted;
+  const isOwner = useIsChallengeOwner(challenge);
 
   const filterCount =
     (judgeReviewedOnly ? 1 : 0) +
@@ -1762,16 +1812,12 @@ function ChallengeEntries({ challenge }: { challenge: ChallengeDetail }) {
                     >
                       Generate Entries
                     </Button>
-                    <LoginRedirect reason="submit-challenge">
-                      <Button
-                        size="sm"
-                        variant="light"
-                        onClick={handleOpenSubmitModal}
-                        leftSection={<IconPhoto size={16} />}
-                      >
-                        Submit Entries
-                      </Button>
-                    </LoginRedirect>
+                    <SubmitEntryButton
+                      isOwner={isOwner}
+                      onClick={handleOpenSubmitModal}
+                      label="Submit Entries"
+                      size="sm"
+                    />
                   </>
                 )}
               </Group>
@@ -1812,8 +1858,17 @@ function ChallengeEntries({ challenge }: { challenge: ChallengeDetail }) {
 function MobileCTAInline({ challenge }: { challenge: ChallengeDetail }) {
   const currentUser = useCurrentUser();
   const isActive = challenge.status === ChallengeStatus.Active;
+  const isOwner = useIsChallengeOwner(challenge);
 
   const isDynamicPool = challenge.prizeMode === PrizeMode.Dynamic && challenge.buzzPerAction > 0;
+
+  const handleOpenSubmitModal = () => {
+    if (!challenge.collectionId) return;
+    dialogStore.trigger({
+      component: ChallengeSubmitModal,
+      props: { challengeId: challenge.id, collectionId: challenge.collectionId },
+    });
+  };
 
   if (!isActive || currentUser?.muted || isDynamicPool) return null;
 
@@ -1829,25 +1884,54 @@ function MobileCTAInline({ challenge }: { challenge: ChallengeDetail }) {
         Generate Entries
       </Button>
       {challenge.collectionId && (
-        <LoginRedirect reason="submit-challenge">
-          <Button
-            onClick={() => {
-              dialogStore.trigger({
-                component: ChallengeSubmitModal,
-                props: { challengeId: challenge.id, collectionId: challenge.collectionId! },
-              });
-            }}
-            leftSection={<IconPhoto size={16} />}
-            variant="light"
-            color="blue"
-            fullWidth
-          >
-            Submit Entries
-          </Button>
-        </LoginRedirect>
+        <SubmitEntryButton
+          isOwner={isOwner}
+          onClick={handleOpenSubmitModal}
+          label="Submit Entries"
+          fullWidth
+        />
       )}
     </Stack>
   );
+}
+
+function SubmitEntryButton({
+  isOwner,
+  onClick,
+  label,
+  size,
+  fullWidth,
+}: {
+  isOwner: boolean;
+  onClick: () => void;
+  label: string;
+  size?: MantineSize;
+  fullWidth?: boolean;
+}) {
+  const button = (
+    <Button
+      // `data-disabled` instead of `disabled` so the tooltip still receives hover events.
+      data-disabled={isOwner || undefined}
+      aria-disabled={isOwner || undefined}
+      onClick={isOwner ? (e: MouseEvent) => e.preventDefault() : onClick}
+      leftSection={<IconPhoto size={16} />}
+      variant="light"
+      color="blue"
+      size={size}
+      fullWidth={fullWidth}
+    >
+      {label}
+    </Button>
+  );
+
+  if (isOwner)
+    return (
+      <Tooltip label="You can't submit entries to your own challenge" withArrow>
+        {button}
+      </Tooltip>
+    );
+
+  return <LoginRedirect reason="submit-challenge">{button}</LoginRedirect>;
 }
 
 function getPlaceLabel(place: number): string {

--- a/src/pages/challenges/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/[id]/[[...slug]].tsx
@@ -218,6 +218,7 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
   const queryUtils = trpc.useUtils();
   const { deleteChallenge: deleteOwnChallenge, deleting: deletingOwn } = useDeleteUserChallenge();
   const deletingOwnRef = useRef(false);
+  const isOwner = useIsChallengeOwner(challenge);
 
   const handleMutationError = (error: { message: string }) => {
     showErrorNotification({ error: new Error(error.message) });
@@ -307,7 +308,7 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
 
   const handleRescan = () => {
     if (!challenge) return;
-    // Only a live green user challenge takes the hold-for-review path on an NSFW verdict
+    // Only a live green user challenge is cancelled outright on an NSFW verdict
     // (computeNsfwEscalation); everything else is just raised to R in place.
     const warnOnNsfw =
       challenge.status === ChallengeStatus.Active &&
@@ -363,10 +364,6 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
   // Only User-source challenges carry user-authored text worth reporting
   const canReport = !!currentUser && challenge.source === ChallengeSource.User;
 
-  const isOwner =
-    !!currentUser &&
-    currentUser.id === challenge.createdById &&
-    challenge.source === ChallengeSource.User;
   const isCancelled = challenge.status === ChallengeStatus.Cancelled;
   const canManageOwn =
     features.userChallenges && isOwner && !currentUser?.isModerator && isScheduled;

--- a/src/server/games/daily-challenge/challenge-nsfw-escalation.test.ts
+++ b/src/server/games/daily-challenge/challenge-nsfw-escalation.test.ts
@@ -121,18 +121,37 @@ describe('applyChallengeNsfwEscalation', () => {
     expect(mockVoidChallenge).not.toHaveBeenCalled();
   });
 
-  it('green user + nsfw while Active: hides via Blocked + alerts mods, no void, no refund, no cancel notif', async () => {
+  it('green user + nsfw while Active: voids (refunds pool + notifies entrants) and hides via Blocked', async () => {
     mockDbRead.challenge.findUnique.mockResolvedValue(challenge({ status: 'Active' }));
 
     await applyChallengeNsfwEscalation({ entityId: 77, isNsfw: true });
 
+    // voidChallenge owns the Active -> Cancelled claim that keeps the completion cron from paying
+    // winners out of the pool being refunded, plus the entrant refund + cancellation notices.
+    expect(mockVoidChallenge).toHaveBeenCalledWith(77);
+    const data = mockDbWrite.challenge.update.mock.calls[0][0].data;
+    expect(data.ingestion).toBe('Blocked');
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ key: 'challenge-nsfw-cancelled-77' })
+    );
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'challenge-nsfw-escalation-voided', challengeId: 77 })
+    );
+  });
+
+  it('green user + nsfw while Completing: holds for review instead of refunding a pool in payout', async () => {
+    mockDbRead.challenge.findUnique.mockResolvedValue(challenge({ status: 'Completing' }));
+
+    await applyChallengeNsfwEscalation({ entityId: 78, isNsfw: true });
+
+    // Refunding here would double-spend against the winner payout.
     expect(mockVoidChallenge).not.toHaveBeenCalled();
     const data = mockDbWrite.challenge.update.mock.calls[0][0].data;
     expect(data.ingestion).toBe('Blocked');
     expect(mockCreateNotification).not.toHaveBeenCalled();
     expect(mockCloseChallengeCollection).toHaveBeenCalledWith({ collectionId: 55 });
     expect(mockLogToAxiom).toHaveBeenCalledWith(
-      expect.objectContaining({ name: 'challenge-nsfw-escalation-held', challengeId: 77 })
+      expect.objectContaining({ name: 'challenge-nsfw-escalation-held', challengeId: 78 })
     );
   });
 });

--- a/src/server/games/daily-challenge/challenge-nsfw-escalation.test.ts
+++ b/src/server/games/daily-challenge/challenge-nsfw-escalation.test.ts
@@ -54,7 +54,7 @@ beforeEach(() => {
   mockDbWrite.challenge.update.mockResolvedValue({});
   mockDbWrite.collection.updateMany.mockResolvedValue({ count: 1 });
   mockDbRead.collection.findUnique.mockResolvedValue({ metadata: { forcedBrowsingLevel: PG_PG13 } });
-  mockVoidChallenge.mockResolvedValue({ success: true });
+  mockVoidChallenge.mockResolvedValue({ success: true, voided: true });
   mockCreateNotification.mockResolvedValue(undefined);
   mockLogToAxiom.mockResolvedValue(undefined);
   mockCloseChallengeCollection.mockResolvedValue(undefined);
@@ -137,6 +137,34 @@ describe('applyChallengeNsfwEscalation', () => {
     expect(mockLogToAxiom).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'challenge-nsfw-escalation-voided', challengeId: 77 })
     );
+  });
+
+  it('green user + nsfw while Active but void claim lost: holds, and never claims a refund happened', async () => {
+    // The completion cron won the Active -> Completing race, so voidChallenge refunded nothing.
+    mockDbRead.challenge.findUnique.mockResolvedValue(challenge({ status: 'Active' }));
+    mockVoidChallenge.mockResolvedValue({ success: true, voided: false });
+
+    await applyChallengeNsfwEscalation({ entityId: 79, isNsfw: true });
+
+    const data = mockDbWrite.challenge.update.mock.calls[0][0].data;
+    expect(data.ingestion).toBe('Blocked');
+    // Telling the creator "entrants have been refunded" here would be a false financial statement.
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'challenge-nsfw-escalation-held', challengeId: 79 })
+    );
+  });
+
+  it('green user + nsfw while already Cancelled: never re-enters the refund', async () => {
+    // The moderation webhook can redeliver the same workflow; re-voiding would re-run the refund.
+    mockDbRead.challenge.findUnique.mockResolvedValue(challenge({ status: 'Cancelled' }));
+
+    await applyChallengeNsfwEscalation({ entityId: 80, isNsfw: true });
+
+    expect(mockVoidChallenge).not.toHaveBeenCalled();
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+    const data = mockDbWrite.challenge.update.mock.calls[0][0].data;
+    expect(data.ingestion).toBe('Blocked');
   });
 
   it('green user + nsfw while Completing: holds for review instead of refunding a pool in payout', async () => {

--- a/src/server/games/daily-challenge/challenge-nsfw-escalation.ts
+++ b/src/server/games/daily-challenge/challenge-nsfw-escalation.ts
@@ -88,40 +88,44 @@ export async function applyChallengeNsfwEscalation({
     // entrant's pool contribution (the house cut is a separate prefix and stays kept) plus the
     // creator's escrowed prize, and notifies the entrants. Void FIRST so a crash before the
     // scan-state write leaves it Cancelled, never Scanned-and-visible.
-    if (
-      challenge.status === ChallengeStatus.Active ||
-      challenge.status === ChallengeStatus.Cancelled
-    ) {
-      await voidChallenge(entityId);
-      await dbWrite.challenge.update({
-        where: { id: entityId },
-        data: { ingestion: ChallengeIngestionStatus.Blocked, scannedAt: new Date() },
-      });
-      if (challenge.createdById) {
-        await createNotification({
-          userId: challenge.createdById,
-          category: NotificationCategory.System,
-          type: 'system-message',
-          key: `challenge-nsfw-cancelled-${entityId}`,
-          details: {
-            message:
-              'Your challenge was cancelled because its text was flagged as adult content — green challenges must be safe-for-work. Entrants have been refunded and any prize you funded has been returned; you can recreate it on civitai.red.',
-            url: `/challenges/${entityId}`,
-          },
+    if (challenge.status === ChallengeStatus.Active) {
+      // A lost claim means the completion cron won the race and is paying out — fall through to
+      // the hold branch rather than telling the creator about a refund that never happened.
+      const { voided } = await voidChallenge(entityId);
+      if (voided) {
+        await dbWrite.challenge.update({
+          where: { id: entityId },
+          data: { ingestion: ChallengeIngestionStatus.Blocked, scannedAt: new Date() },
         });
+        if (challenge.createdById) {
+          await createNotification({
+            userId: challenge.createdById,
+            category: NotificationCategory.System,
+            type: 'system-message',
+            key: `challenge-nsfw-cancelled-${entityId}`,
+            details: {
+              message:
+                'Your challenge was cancelled because its text was flagged as adult content — green challenges must be safe-for-work. Entrants have been refunded and any prize you funded has been returned; you can recreate it on civitai.red.',
+              url: `/challenges/${entityId}`,
+            },
+          });
+        }
+        logToAxiom({
+          type: 'warning',
+          name: 'challenge-nsfw-escalation-voided',
+          message: `Green challenge ${entityId} scanned NSFW while Active; voided and refunded.`,
+          challengeId: entityId,
+          status: String(challenge.status),
+        });
+        return;
       }
-      logToAxiom({
-        type: 'warning',
-        name: 'challenge-nsfw-escalation-voided',
-        message: `Green challenge ${entityId} scanned NSFW while Active; voided and refunded.`,
-        challengeId: entityId,
-        status: String(challenge.status),
-      });
-      return;
     }
 
-    // Completing/Completed: the pool is being (or has been) paid out to winners, so refunding it
-    // would double-spend. Hide it and alert mods to unwind by hand.
+    // Everything else just gets hidden and alerted, never refunded here:
+    //   - Cancelled: whoever cancelled it already owns the refund. Re-voiding would re-enter the
+    //     refund on a webhook redelivery (the callback can redeliver for the same workflow).
+    //   - Completing/Completed, or an Active challenge whose void claim was lost: the pool is in
+    //     payout, so refunding it would double-spend.
     await dbWrite.challenge.update({
       where: { id: entityId },
       data: { ingestion: ChallengeIngestionStatus.Blocked, scannedAt: new Date() },
@@ -132,7 +136,7 @@ export async function applyChallengeNsfwEscalation({
       name: 'challenge-nsfw-escalation-held',
       message: `Green challenge ${entityId} scanned NSFW while ${String(
         challenge.status
-      )}; hidden and held for moderator review — pool already in payout, cannot auto-refund.`,
+      )}; hidden and held for moderator review — not auto-refunded here.`,
       challengeId: entityId,
       status: String(challenge.status),
     });

--- a/src/server/games/daily-challenge/challenge-nsfw-escalation.ts
+++ b/src/server/games/daily-challenge/challenge-nsfw-escalation.ts
@@ -16,9 +16,11 @@ import {
 import { logToAxiom } from '~/server/logging/client';
 
 // Applies the scan verdict to a challenge. A green USER challenge whose text is NSFW is cancelled
-// (green must be SFW): void it (Cancelled + collection closed + initial prize refunded, all idempotent),
-// mark the scan resolved, and notify the creator to recreate on civitai.red. A yellow/non-user challenge
-// stays live but has its rating raised to R. A clean scan just marks it Scanned.
+// (green must be SFW): void it (Cancelled + collection closed + entry-fee pool and initial prize
+// refunded, all idempotent), mark the scan resolved, and notify the creator to recreate on
+// civitai.red. Only a Completing/Completed challenge escapes the void — its pool is already in
+// payout. A yellow/non-user challenge stays live but has its rating raised to R. A clean scan just
+// marks it Scanned.
 //
 // Idempotent: the cancel path relies on voidChallenge's own idempotency (a retried callback re-runs the
 // no-op refund on the already-Cancelled row) plus a deterministic notification key. buzzType is never
@@ -78,11 +80,48 @@ export async function applyChallengeNsfwEscalation({
       return;
     }
 
-    // Defense-in-depth: a scan verdict reached an already-started (non-Scheduled) green challenge.
-    // This should be unreachable post entry-gate (Active challenges are never re-scanned); if the
-    // invariant is ever broken, do NOT auto-void a live challenge out from under entrants. Hide it
-    // (Blocked ⟹ excluded from feeds) and alert mods to void+refund or override by hand. No auto-
-    // refund and no creator "cancelled" notification — a human decides.
+    // A scan verdict reached an already-started green challenge — reachable on purpose via the
+    // moderator rescan action (`rescanChallenge`). An Active one is killed the same way a Scheduled
+    // one is: voidChallenge claims Active -> Cancelled BEFORE refunding, which is what stops the
+    // completion cron from paying winners out of a pool we're returning (that claim is the only
+    // thing standing between this path and minted Buzz), then closes the collection, refunds each
+    // entrant's pool contribution (the house cut is a separate prefix and stays kept) plus the
+    // creator's escrowed prize, and notifies the entrants. Void FIRST so a crash before the
+    // scan-state write leaves it Cancelled, never Scanned-and-visible.
+    if (
+      challenge.status === ChallengeStatus.Active ||
+      challenge.status === ChallengeStatus.Cancelled
+    ) {
+      await voidChallenge(entityId);
+      await dbWrite.challenge.update({
+        where: { id: entityId },
+        data: { ingestion: ChallengeIngestionStatus.Blocked, scannedAt: new Date() },
+      });
+      if (challenge.createdById) {
+        await createNotification({
+          userId: challenge.createdById,
+          category: NotificationCategory.System,
+          type: 'system-message',
+          key: `challenge-nsfw-cancelled-${entityId}`,
+          details: {
+            message:
+              'Your challenge was cancelled because its text was flagged as adult content — green challenges must be safe-for-work. Entrants have been refunded and any prize you funded has been returned; you can recreate it on civitai.red.',
+            url: `/challenges/${entityId}`,
+          },
+        });
+      }
+      logToAxiom({
+        type: 'warning',
+        name: 'challenge-nsfw-escalation-voided',
+        message: `Green challenge ${entityId} scanned NSFW while Active; voided and refunded.`,
+        challengeId: entityId,
+        status: String(challenge.status),
+      });
+      return;
+    }
+
+    // Completing/Completed: the pool is being (or has been) paid out to winners, so refunding it
+    // would double-spend. Hide it and alert mods to unwind by hand.
     await dbWrite.challenge.update({
       where: { id: entityId },
       data: { ingestion: ChallengeIngestionStatus.Blocked, scannedAt: new Date() },
@@ -93,7 +132,7 @@ export async function applyChallengeNsfwEscalation({
       name: 'challenge-nsfw-escalation-held',
       message: `Green challenge ${entityId} scanned NSFW while ${String(
         challenge.status
-      )}; hidden and held for moderator review instead of auto-void.`,
+      )}; hidden and held for moderator review — pool already in payout, cannot auto-refund.`,
       challengeId: entityId,
       status: String(challenge.status),
     });

--- a/src/server/notifications/__tests__/challenge-cancelled-notification.test.ts
+++ b/src/server/notifications/__tests__/challenge-cancelled-notification.test.ts
@@ -195,7 +195,7 @@ describe('voidChallenge — entrant cancellation notification', () => {
     mockRefundUserChallengeFunds.mockResolvedValue({ refundedEntries: 3 });
     mockDbRead.$queryRaw.mockRejectedValue(new Error('transient DB error'));
 
-    await expect(voidChallenge(7)).resolves.toEqual({ success: true });
+    await expect(voidChallenge(7)).resolves.toEqual({ success: true, voided: true });
 
     expect(mockCreateNotification).not.toHaveBeenCalled();
     expect(mockLogToAxiom).toHaveBeenCalledTimes(1);

--- a/src/server/routers/challenge.router.ts
+++ b/src/server/routers/challenge.router.ts
@@ -59,6 +59,7 @@ import {
   upsertChallenge,
   upsertUserChallenge,
   upsertChallengeEvent,
+  rescanChallenge,
   voidChallenge,
   getActiveJudges,
   getChallengeSystemConfig,
@@ -271,6 +272,12 @@ export const challengeRouter = router({
     .input(challengeQuickActionSchema)
     .use(isFlagProtected('challengePlatform'))
     .mutation(({ input }) => voidChallenge(input.id)),
+
+  // Moderator: Re-run the content scan (moderated text + cover image) for a challenge
+  rescan: moderatorProcedure
+    .input(challengeQuickActionSchema)
+    .use(isFlagProtected('challengePlatform'))
+    .mutation(({ input, ctx }) => rescanChallenge({ id: input.id, moderatorId: ctx.user.id })),
 
   // Active judges for the challenge form dropdowns. Any authenticated user may call it; the service
   // returns the full list (with sensitive fields) to moderators and the public, SFW-selectable subset

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -79,6 +79,7 @@ export type ChallengeListItem = {
   endsAt: Date;
   status: ChallengeStatus;
   source: ChallengeSource;
+  buzzType: 'green' | 'yellow';
   nsfwLevel: number;
   allowedNsfwLevel: number;
   prizePool: number;

--- a/src/server/services/__tests__/challenge-moderation-adapter.test.ts
+++ b/src/server/services/__tests__/challenge-moderation-adapter.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// applyFailure must only downgrade a challenge that is actually mid-scan. A moderator rescan
+// (rescanChallenge) is the first path that submits a workflow for an already-Scanned challenge, so
+// an unscoped write would let one transient orchestrator failure hide a live challenge from the
+// feeds and 404 its detail page.
+const { mockDbRead, mockDbWrite } = vi.hoisted(() => ({
+  mockDbRead: { challenge: { findUnique: vi.fn() } },
+  mockDbWrite: { challenge: { update: vi.fn(), updateMany: vi.fn() } },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/text-moderation.service', () => ({ submitTextModeration: vi.fn() }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(() => Promise.resolve()) }));
+vi.mock('~/server/games/daily-challenge/challenge-nsfw-escalation', () => ({
+  applyChallengeNsfwEscalation: vi.fn(),
+}));
+
+const { challengeModerationAdapter } = await import('~/server/services/challenge-moderation.adapter');
+
+describe('challengeModerationAdapter.applyFailure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbWrite.challenge.updateMany.mockResolvedValue({ count: 1 });
+  });
+
+  it('only marks Error on a challenge still Pending', async () => {
+    await challengeModerationAdapter.applyFailure?.({
+      entityId: 42,
+      workflowId: 'wf-1',
+      status: 'expired',
+    });
+
+    expect(mockDbWrite.challenge.updateMany).toHaveBeenCalledWith({
+      where: { id: 42, ingestion: 'Pending' },
+      data: { ingestion: 'Error' },
+    });
+    // A bare `update` here is the regression: it would downgrade a Scanned challenge too.
+    expect(mockDbWrite.challenge.update).not.toHaveBeenCalled();
+  });
+
+  it('leaves an already-Scanned challenge alone when the scoped write matches nothing', async () => {
+    mockDbWrite.challenge.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      challengeModerationAdapter.applyFailure?.({
+        entityId: 42,
+        workflowId: 'wf-1',
+        status: 'failed',
+      })
+    ).resolves.not.toThrow();
+  });
+});

--- a/src/server/services/__tests__/challenge-rescan.service.test.ts
+++ b/src/server/services/__tests__/challenge-rescan.service.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Covers two invariants that are easy to silently revert:
+//   1. `rescanChallenge` never resets ingestion/scannedAt — that reset is what stranded challenges
+//      at Pending in #3160, and leaving it out is what keeps a live challenge visible mid-scan.
+//   2. `getWinnerCooldownStatus` reports no cooldown for user-created challenges, matching
+//      pickWinners (daily-challenge-processing.ts), which skips the cooldown for source=User.
+const {
+  mockDbRead,
+  mockDbWrite,
+  mockSubmitTextModeration,
+  mockEnqueueImageIngestion,
+  mockGetChallengeConfig,
+  mockResolveEventContext,
+} = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(),
+    challenge: { findUnique: vi.fn() },
+    image: { findUnique: vi.fn() },
+  },
+  mockDbWrite: {
+    challenge: { findUnique: vi.fn(), update: vi.fn(), updateMany: vi.fn() },
+  },
+  mockSubmitTextModeration: vi.fn(),
+  mockEnqueueImageIngestion: vi.fn(),
+  mockGetChallengeConfig: vi.fn(),
+  mockResolveEventContext: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  createBuzzTransactionMany: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getChallengeConfig: mockGetChallengeConfig,
+  setChallengeConfig: vi.fn(),
+  deriveChallengeNsfwLevel: vi.fn(() => 1),
+  getJudgingConfig: vi.fn(),
+  parseJudgeScore: vi.fn(),
+}));
+
+// buildChallengeModerationText drives the submitted content, so keep the real implementation.
+vi.mock('~/server/games/daily-challenge/challenge-helpers', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('~/server/games/daily-challenge/challenge-helpers')
+  >();
+  return { ...actual, getChallengeById: vi.fn(), resolveEventContext: mockResolveEventContext };
+});
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({ generateWinners: vi.fn() }));
+
+vi.mock('~/server/jobs/daily-challenge-processing', () => ({ getJudgedEntries: vi.fn() }));
+
+vi.mock('~/server/search-index', () => ({ collectionsSearchIndex: { queueUpdate: vi.fn() } }));
+
+vi.mock('~/server/services/image.service', () => ({
+  createImage: vi.fn(),
+  enqueueImageIngestion: mockEnqueueImageIngestion,
+  imagesForModelVersionsCache: { bust: vi.fn(), fetch: vi.fn(() => ({})) },
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  getCosmeticsForUsers: vi.fn(() => ({})),
+  getProfilePicturesForUsers: vi.fn(() => ({})),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+
+vi.mock('~/server/services/challenge-eligibility.service', () => ({
+  assertCanCreateUserChallenge: vi.fn(),
+  assertUserInGoodStanding: vi.fn(),
+  assertUserAccountInGoodStanding: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-category.service', () => ({
+  resolveJudgingCategories: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/challenge-judge.service', () => ({
+  getUserSelectableJudges: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/text-moderation.service', () => ({
+  submitTextModeration: mockSubmitTextModeration,
+}));
+
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(() => Promise.resolve()) }));
+
+vi.mock('~/utils/errorHandling', () => ({ withRetries: vi.fn((fn: () => unknown) => fn()) }));
+
+vi.mock('~/utils/logging', () => ({ createLogger: vi.fn(() => vi.fn()) }));
+
+vi.mock('~/server/utils/errorHandling', () => ({
+  throwNotFoundError: vi.fn((msg: string) => {
+    throw new Error(msg);
+  }),
+}));
+
+const { rescanChallenge, getWinnerCooldownStatus } = await import(
+  '~/server/services/challenge.service'
+);
+
+const challengeRow = {
+  title: 'Cute Cats with Silly Hats',
+  description: '<p>Show us your best cat.</p>',
+  theme: 'Cats',
+  invitation: null,
+  metadata: null,
+  coverImageId: 900,
+  createdById: 111,
+};
+
+describe('rescanChallenge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbWrite.challenge.findUnique.mockResolvedValue(challengeRow);
+    mockDbRead.image.findUnique.mockResolvedValue({
+      id: 900,
+      url: 'abc',
+      type: 'image',
+      ingestion: 'Scanned',
+    });
+    mockSubmitTextModeration.mockResolvedValue({ id: 'wf-1' });
+  });
+
+  it('forces a fresh scan and never touches ingestion or scannedAt', async () => {
+    await rescanChallenge({ id: 42, moderatorId: 7 });
+
+    expect(mockSubmitTextModeration).toHaveBeenCalledWith(
+      expect.objectContaining({ entityType: 'Challenge', entityId: 42, forceRescan: true })
+    );
+    // The reset is the #3160 deadlock, and it would also hide a live Active challenge mid-scan.
+    expect(mockDbWrite.challenge.update).not.toHaveBeenCalled();
+    expect(mockDbWrite.challenge.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('re-queues the cover image for ingestion', async () => {
+    await rescanChallenge({ id: 42, moderatorId: 7 });
+
+    expect(mockEnqueueImageIngestion).toHaveBeenCalledWith(
+      expect.objectContaining({ images: [expect.objectContaining({ id: 900 })] })
+    );
+  });
+
+  it('skips a cover image that is already mid-scan', async () => {
+    mockDbRead.image.findUnique.mockResolvedValue({
+      id: 900,
+      url: 'abc',
+      type: 'image',
+      ingestion: 'Pending',
+    });
+
+    await rescanChallenge({ id: 42, moderatorId: 7 });
+
+    expect(mockEnqueueImageIngestion).not.toHaveBeenCalled();
+    expect(mockSubmitTextModeration).toHaveBeenCalled();
+  });
+
+  it('throws when the moderation submit produced no workflow', async () => {
+    // submitTextModeration resolves undefined on submit failure rather than throwing, so without
+    // this the moderator sees a "rescan queued" confirmation for a scan that never happened.
+    mockSubmitTextModeration.mockResolvedValue(undefined);
+
+    await expect(rescanChallenge({ id: 42, moderatorId: 7 })).rejects.toThrow();
+  });
+
+  it('throws when the challenge does not exist', async () => {
+    mockDbWrite.challenge.findUnique.mockResolvedValue(null);
+
+    await expect(rescanChallenge({ id: 42, moderatorId: 7 })).rejects.toThrow();
+  });
+});
+
+describe('getWinnerCooldownStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetChallengeConfig.mockResolvedValue({ winnerCooldown: '7 day' });
+    mockResolveEventContext.mockResolvedValue({ eventId: null, winnerCooldownDays: null });
+  });
+
+  it('reports no cooldown on a user-created challenge even with a recent win', async () => {
+    mockDbRead.$queryRaw.mockResolvedValueOnce([{ eventId: null, source: 'User' }]);
+
+    const result = await getWinnerCooldownStatus(42, 111);
+
+    expect(result.onCooldown).toBe(false);
+    expect(result.cooldownEndsAt).toBeNull();
+    // Short-circuits before the ChallengeWinner lookup — pickWinners never applies the cooldown
+    // to user challenges, so reporting one would warn about an unenforced restriction.
+    expect(mockDbRead.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports a cooldown on a system challenge', async () => {
+    const lastWin = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+    mockDbRead.$queryRaw
+      .mockResolvedValueOnce([{ eventId: null, source: 'System' }])
+      .mockResolvedValueOnce([{ createdAt: lastWin, challengeId: 9 }]);
+
+    const result = await getWinnerCooldownStatus(42, 111);
+
+    expect(result.onCooldown).toBe(true);
+    expect(result.lastWinChallengeId).toBe(9);
+  });
+});

--- a/src/server/services/__tests__/challenge-void.service.test.ts
+++ b/src/server/services/__tests__/challenge-void.service.test.ts
@@ -54,7 +54,8 @@ describe('voidChallenge', () => {
     mockGetChallengeById.mockResolvedValue(makeChallenge(ChallengeStatus.Active));
     mockDbWrite.challenge.updateMany.mockResolvedValue({ count: 0 });
     const res = await voidChallenge(1);
-    expect(res).toEqual({ success: true });
+    // `voided: false` is what lets callers avoid reporting a refund that never happened.
+    expect(res).toEqual({ success: true, voided: false });
     expect(mockRefund).not.toHaveBeenCalled();
   });
 

--- a/src/server/services/challenge-moderation.adapter.ts
+++ b/src/server/services/challenge-moderation.adapter.ts
@@ -103,9 +103,16 @@ export const challengeModerationAdapter: ModerationAdapter = {
   // Terminal scan failure: mark retryable Error (the scan gate keeps the challenge hidden). The
   // generic retry cron re-submits from `retryCount < 9`; the activation job voids past the grace
   // window so escrowed funds aren't stranded forever.
+  //
+  // Scoped to Pending so a failed moderator rescan (`rescanChallenge`) can't downgrade an already
+  // Scanned challenge — that would hide a live one from feeds and 404 its detail page on a
+  // transient orchestrator failure, rather than just leaving the prior verdict in place.
   applyFailure: async ({ entityId }) => {
     await dbWrite.challenge
-      .update({ where: { id: entityId }, data: { ingestion: ChallengeIngestionStatus.Error } })
+      .updateMany({
+        where: { id: entityId, ingestion: ChallengeIngestionStatus.Pending },
+        data: { ingestion: ChallengeIngestionStatus.Error },
+      })
       .catch(() => undefined);
   },
 };

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -58,10 +58,15 @@ import {
   CollectionReadConfiguration,
   CollectionType,
   CollectionWriteConfiguration,
+  ImageIngestionStatus,
   PoolTrigger,
   PrizeMode,
 } from '~/shared/utils/prisma/enums';
-import { createImage, imagesForModelVersionsCache } from '~/server/services/image.service';
+import {
+  createImage,
+  enqueueImageIngestion,
+  imagesForModelVersionsCache,
+} from '~/server/services/image.service';
 import {
   amIBlockedByUser,
   getCosmeticsForUsers,
@@ -235,6 +240,7 @@ type ChallengeCardRow = {
   endsAt: Date;
   status: ChallengeStatus;
   source: ChallengeSource;
+  buzzType: string;
   prizePool: number;
   entryCount: bigint;
   commentCount: bigint;
@@ -267,6 +273,7 @@ const challengeCardQuery = Prisma.sql`
       c."endsAt",
       c.status,
       c.source,
+      c."buzzType",
       c."prizePool",
       (SELECT COUNT(*) FROM "CollectionItem" WHERE "collectionId" = c."collectionId" AND status = 'ACCEPTED') as "entryCount",
       COALESCE((SELECT t."commentCount" FROM "Thread" t WHERE t."challengeId" = c.id), 0) as "commentCount",
@@ -332,6 +339,7 @@ async function mapChallengeRowsToCards(items: ChallengeCardRow[]): Promise<Chall
       endsAt: item.endsAt,
       status: item.status,
       source: item.source,
+      buzzType: item.buzzType === 'green' ? 'green' : 'yellow',
       createdById: item.createdById,
       prizePool: item.prizePool,
       nsfwLevel: item.nsfwLevel,
@@ -434,7 +442,7 @@ export async function getMyParticipated({
   const rows = await dbRead.$queryRaw<ParticipatedRow[]>(Prisma.sql`
     WITH my AS (${myEntries})
     SELECT c.id, c.title, c.theme, c.invitation, c."coverImageId", c."startsAt", c."endsAt",
-           c.status, c.source, c."prizePool",
+           c.status, c.source, c."buzzType", c."prizePool",
            (SELECT COUNT(*) FROM "CollectionItem" WHERE "collectionId" = c."collectionId" AND status = 'ACCEPTED') AS "entryCount",
            COALESCE((SELECT t."commentCount" FROM "Thread" t WHERE t."challengeId" = c.id), 0) AS "commentCount",
            c."nsfwLevel", c."allowedNsfwLevel", c."modelVersionIds",
@@ -1941,6 +1949,85 @@ export async function scanUserChallenge(challengeId: number): Promise<void> {
   }
 }
 
+// Moderator-initiated rescan of a challenge's own content: the moderated text and the cover image.
+// `forceRescan` bypasses the contentHash dedup so an unchanged challenge still produces a fresh
+// orchestrator workflow (the dedup is what stranded challenges at Pending in #3160).
+//
+// Deliberately does NOT reset `ingestion`/`scannedAt`: the adapter writes the terminal state when
+// the webhook lands, so a live Active challenge stays visible instead of dropping behind the scan
+// gate for the duration of the scan.
+export async function rescanChallenge({
+  id,
+  moderatorId,
+}: {
+  id: number;
+  moderatorId: number;
+}): Promise<void> {
+  // Primary, not the replica: a mod who edits then immediately rescans would otherwise submit the
+  // pre-edit text and cache a verdict against content that no longer exists.
+  const challenge = await dbWrite.challenge.findUnique({
+    where: { id },
+    select: {
+      title: true,
+      description: true,
+      theme: true,
+      invitation: true,
+      metadata: true,
+      coverImageId: true,
+      createdById: true,
+    },
+  });
+  if (!challenge) throw new TRPCError({ code: 'NOT_FOUND', message: 'Challenge not found' });
+
+  let coverRequeued = false;
+  if (challenge.coverImageId) {
+    const cover = await dbRead.image.findUnique({
+      where: { id: challenge.coverImageId },
+      select: { id: true, url: true, type: true, ingestion: true },
+    });
+    // Already Pending means a scan is in flight — re-enqueueing would just duplicate it.
+    if (cover && cover.ingestion !== ImageIngestionStatus.Pending) {
+      enqueueImageIngestion({
+        images: [cover],
+        name: 'challenge-rescan-cover',
+        userId: challenge.createdById ?? undefined,
+        lowPriority: true,
+      });
+      coverRequeued = true;
+    }
+  }
+
+  const workflow = await submitTextModeration({
+    entityType: 'Challenge',
+    entityId: id,
+    content: buildChallengeModerationText({
+      ...challenge,
+      themeElements: parseChallengeMetadata(challenge.metadata).themeElements,
+    }),
+    labels: [...CHALLENGE_MODERATION_LABELS],
+    priority: 'low',
+    forceRescan: true,
+  });
+
+  await logToAxiom({
+    type: 'info',
+    name: 'challenge-rescan',
+    challengeId: id,
+    moderatorId,
+    coverRequeued,
+    workflowId: workflow?.id ?? null,
+  }).catch(() => undefined);
+
+  // A submit failure resolves to `undefined` rather than throwing (it persists a Failed
+  // EntityModeration row for the retry cron instead), so without this the moderator gets a
+  // "rescan queued" confirmation for a scan that was never submitted.
+  if (!workflow?.id)
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Failed to queue the content rescan. It will be retried automatically.',
+    });
+}
+
 // Public-safe judge options for the user challenge form: id/name/bio only (no prompt fields).
 export async function updateChallengeStatus(id: number, status: ChallengeStatus) {
   const challenge = await dbWrite.challenge.update({
@@ -2962,6 +3049,7 @@ export async function getActiveEvents(viewerId?: number): Promise<ChallengeEvent
           endsAt: true,
           status: true,
           source: true,
+          buzzType: true,
           nsfwLevel: true,
           allowedNsfwLevel: true,
           prizePool: true,
@@ -3083,6 +3171,7 @@ export async function getActiveEvents(viewerId?: number): Promise<ChallengeEvent
         endsAt: c.endsAt,
         status: c.status,
         source: c.source,
+        buzzType: c.buzzType === 'green' ? ('green' as const) : ('yellow' as const),
         // createdById can be null (creator account deleted); fall back to the system user (-1),
         // matching the displayUserId fallback above.
         createdById: c.createdById ?? -1,
@@ -3577,6 +3666,7 @@ export async function getCompletedChallengesWithWinners(
       endsAt: Date;
       status: ChallengeStatus;
       source: ChallengeSource;
+      buzzType: string;
       prizePool: number;
       entryCount: bigint;
       commentCount: bigint;
@@ -3605,6 +3695,7 @@ export async function getCompletedChallengesWithWinners(
       c."endsAt",
       c.status,
       c.source,
+      c."buzzType",
       c."prizePool",
       (SELECT COUNT(*) FROM "CollectionItem" WHERE "collectionId" = c."collectionId" AND status = 'ACCEPTED') as "entryCount",
       COALESCE((SELECT t."commentCount" FROM "Thread" t WHERE t."challengeId" = c.id), 0) as "commentCount",
@@ -3744,6 +3835,7 @@ export async function getCompletedChallengesWithWinners(
       endsAt: item.endsAt,
       status: item.status,
       source: item.source,
+      buzzType: item.buzzType === 'green' ? 'green' : 'yellow',
       createdById: item.createdById,
       prizePool: item.prizePool,
       nsfwLevel: item.nsfwLevel,
@@ -3786,12 +3878,26 @@ export async function getWinnerCooldownStatus(
   userId: number
 ): Promise<WinnerCooldownStatus> {
   // 1. Look up challenge's eventId
-  const [challenge] = await dbRead.$queryRaw<[{ eventId: number | null }] | []>`
-    SELECT "eventId" FROM "Challenge" WHERE id = ${challengeId}
+  const [challenge] = await dbRead.$queryRaw<
+    [{ eventId: number | null; source: ChallengeSource }] | []
+  >`
+    SELECT "eventId", "source" FROM "Challenge" WHERE id = ${challengeId}
   `;
 
   if (!challenge) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Challenge not found' });
+  }
+
+  // Winner picking never applies the cooldown to user-created challenges (see pickWinners), so
+  // reporting one here would warn participants about a restriction that won't be enforced.
+  if (challenge.source === ChallengeSource.User) {
+    return {
+      onCooldown: false,
+      cooldownEndsAt: null,
+      lastWinDate: null,
+      lastWinChallengeId: null,
+      cooldownDays: 0,
+    };
   }
 
   // 2. Resolve event context

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -2028,7 +2028,6 @@ export async function rescanChallenge({
     });
 }
 
-// Public-safe judge options for the user challenge form: id/name/bio only (no prompt fields).
 export async function updateChallengeStatus(id: number, status: ChallengeStatus) {
   const challenge = await dbWrite.challenge.update({
     where: { id },
@@ -2809,7 +2808,9 @@ export async function voidChallenge(challengeId: number) {
     });
     if (claimed.count !== 1) {
       log('Void claim lost (completion or a concurrent void won); skipping refund');
-      return { success: true };
+      // `voided: false` so callers can tell "nothing was refunded" from a real void — reporting a
+      // refund that never happened would tell entrants they got their Buzz back.
+      return { success: true, voided: false };
     }
     log('Challenge status updated to Cancelled');
   }
@@ -2824,7 +2825,7 @@ export async function voidChallenge(challengeId: number) {
     await notifyEntrantsOfCancellation(challenge);
   }
 
-  return { success: true };
+  return { success: true, voided: true };
 }
 
 /**


### PR DESCRIPTION
Tester feedback on community (user-created) challenges, plus two money-path bugs found while verifying the reports.

## 1. Entry-fee disclosure — `ChallengeSubmitModal`

Participants were never told an entry fee is charged, nor how it splits. There's now a breakdown under the submit button: total, the AI-judging house cut, the prize-pool contribution, and the guaranteed-review fee when opted in. A tooltip carries the refund policy. Numbers come from `challenge.constants`, the same source the creator form uses, so they can't drift from the server.

**Balance check was effectively missing.** `BuzzTransactionButton` only rendered when "guarantee review" was checked, and its `buzzAmount` only counted `reviewCost` — so entry-fee challenges with the box unchecked (the common case) had *no* balance check at all. It now always covers the real total, scoped via `accountTypes` to the challenge's own Buzz account, because the server charges the fee with `fromAccountType: challenge.buzzType` — an unscoped check green-lights a user holding plenty of the *other* Buzz type.

## 2. Winner-cooldown banner on user challenges

`getWinnerCooldownStatus` never looked at `source`, so participants saw *"you're on a winner cooldown, your entries won't be eligible for prizes"* on user challenges. `pickWinners` explicitly skips the cooldown for `source=User` (`daily-challenge-processing.ts:1743`), so the restriction was never enforced — the warning was purely false. Fixed at the service; `CooldownBanner` also skips the query client-side.

## 3. Challenge owner could open the submit modal

The server already rejects owner entries (`collection.service.ts:2006`), but the UI let owners select images and only fail at submit. Submit is now disabled with a tooltip; **Generate stays active** (product call). Uses Mantine's `data-disabled` rather than `disabled` so the tooltip still receives hover, with the click handler swapped so keyboard activation no-ops too. The new `useIsChallengeOwner` hook mirrors the server rule including its moderator exemption — without that, a mod who created a challenge saw a blocked button for a submission the server allows.

## 4. New moderator "Rescan Content" action

`challenge.rescan` (moderator-only) force-resubmits the moderated text and re-queues the cover image. `forceRescan: true` bypasses the `contentHash` dedup — the same dedup that stranded challenges at Pending in #3160. It deliberately does **not** reset `ingestion`/`scannedAt`, so a live challenge stays visible while the scan runs; the adapter writes the terminal state when the webhook lands.

It throws when the submit produced no workflow: `createXGuardModerationRequest` resolves `undefined` on failure rather than throwing, so without that check moderators got a "rescan queued" confirmation for a scan that never happened. The acting moderator is logged to Axiom.

## Two defects this surfaced

**`applyFailure` could hide a live challenge.** `challengeModerationAdapter.applyFailure` wrote `ingestion: Error` unconditionally on any `failed`/`expired`/`canceled` callback. Before the rescan action that could only ever land on an already-`Pending` challenge — the new action is the first path submitting a workflow for a `Scanned` one, so a single transient orchestrator failure would drop a live challenge out of feeds and 404 its detail page. Now scoped to `Pending`, so a failed rescan preserves the prior verdict.

**Entrants weren't refunded when a live challenge was blocked.** `applyChallengeNsfwEscalation`'s non-Scheduled branch hid the challenge and closed its collection but never refunded or notified anyone — entrants' pool contributions sat in account 0 on a dead challenge. An `Active` challenge now goes through `voidChallenge`, which refunds the entry-fee **pool** portion (the house cut is a separate prefix and stays kept) plus the creator's escrowed prize, and notifies entrants. Its `Active -> Cancelled` claim is load-bearing: refunding without it would let the completion cron pay winners out of the pool being returned. `Completing`/`Completed` still hold for human review — that pool is already in payout, so refunding would double-spend.

## 5. Wrong Buzz color on prize pools and prize badges

`getCurrencyConfig` defaults a missing `type` to **yellow** (`currency.constants.ts:122`), so every challenge prize/pool badge rendered yellow regardless of the challenge's actual currency. `buzzType` wasn't in the card payload at all, so cards physically couldn't render it — added to `ChallengeListItem` and all four card projections, then threaded through `ChallengeCard`, `CompletedChallengeCard`, `WinnerPodiumCard`, the detail page and the upsert form.

Raw SQL isn't type-checked, so adding the field to the row types alone would have compiled clean and silently defaulted every card to yellow at runtime — each `SELECT` was verified by hand.

Two badges intentionally left alone, both verified against the payout paths:
- The **participation prize** is paid `toAccountType: 'blue'` (`daily-challenge-processing.ts:1071`), so its hardcoded `type="blue"` was already correct.
- The **guaranteed-review** badge stays yellow: `requestReview` charges without `fromAccountType`, so it draws the user's default account. Typing it green would misrepresent a money path. On a green challenge this shows as entry fee green / review fee yellow — the fix is a one-line server change (`fromAccountType: challenge.buzzType` in `requestReview`), deliberately left out of this PR.

## Testing

- New `challenge-rescan.service.test.ts` — pins `forceRescan`, the no-ingestion-reset invariant, cover re-queue + Pending skip, throw-on-no-workflow, and the `source=User` cooldown short-circuit.
- `challenge-nsfw-escalation.test.ts` updated for the void+refund behavior, plus a new case covering the `Completing` hold path.
- Full `src/server/services/__tests__/` + `src/server/games/` suites: **1661 pass, 0 fail**.

No schema changes — no migration needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)