### PR TITLE
perf(redis): opt-in per-pod L1 in front of near-static feed-hydration caches

### DIFF
--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -1300,12 +1300,11 @@ export const imageMetaCache = createCachedObject<ImageWithMeta>({
   // working set into misses and stampede dbRead.
   ttl: CacheTTL.hour * 4,
   staleWhileRevalidateTtl: CacheTTL.hour,
-  // L1: generation meta behind a 4h Redis TTL, refresh-only on image edit/delete.
-  // Shortest L1 TTL of the set (10s) because `hideMeta` toggles the prompt to NULL —
-  // a ≤10s cross-pod lag on hide taking effect, on data that was already public.
-  // max 5000: `meta` is the heaviest per-entity value (~2.8KB/key), keep it small.
-  localTtl: 10,
-  localMax: 5000,
+  // NO per-pod L1 here (deliberate): `meta` is gated on `hideMeta`, and when an owner
+  // flips hideMeta false→true the write path calls imageMetaCache.refresh() (meta→NULL).
+  // A per-pod L1 can't observe that cross-pod refresh, so other viewers' pods would keep
+  // serving the old prompt for up to localTtl — a prompt-exposure window on a PRIVACY
+  // control. Not worth it; also the heaviest value, so its exclusion frees the most heap.
 });
 
 type ImageWithMetadata = {

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -64,6 +64,7 @@ export const tagIdsForImagesCache = createCachedObject<{
   // edit by ≤15s. Not a visibility gate (feed SQL enforces that). Hot-image set.
   localTtl: 15,
   localMax: 10000,
+  localMaxBytes: 6 * 1024 * 1024, // hard heap cap ~6MB (tag-id arrays are small)
   async lookupFn(imageId, fromWrite) {
     const imageIds = Array.isArray(imageId) ? imageId : [imageId];
     const db = fromWrite ? dbWrite : dbRead;
@@ -356,6 +357,7 @@ export const userBasicCache = createCachedObject<UserBasicLookup>({
   // cross-pod delay on a rename/avatar/soft-delete propagating — imperceptible.
   localTtl: 30,
   localMax: 10000,
+  localMaxBytes: 4 * 1024 * 1024, // hard heap cap ~4MB (tiny records)
 });
 
 type ModelVersionAccessCache = EntityAccessDataType & { publishedAt: Date; status: ModelStatus };
@@ -1516,6 +1518,7 @@ export const imageTagsCache = createCachedObject<ImageTagsCacheItem>({
   // hidden-tag filtering, not a hard visibility gate. max 5000: ~4.2KB/key, heavy.
   localTtl: 15,
   localMax: 5000,
+  localMaxBytes: 16 * 1024 * 1024, // hard heap cap ~16MB (heaviest remaining value)
   lookupFn: async (ids, fromWrite) => {
     const db = fromWrite ? dbWrite : dbRead;
 
@@ -1683,8 +1686,14 @@ export const imageResourcesCache = createCachedObject<ImageResourcesCacheItem>({
   // L1: which models an image used — attribution metadata, refresh-only on resource
   // edits, 8h Redis TTL. A 30s per-pod L1 only delays a cross-pod resource edit by
   // ≤30s. Not sensitive / not a visibility gate.
+  //
+  // Per-pod L1 total HARD heap ceiling across the 4 enabled caches (localMaxBytes):
+  //   userBasic 4MB + imageResources 12MB + tagIdsForImages 6MB + imageTags 16MB
+  //   = 38MB/pod — well under the heap-headroom alert; byte-bounded so a per-value
+  //   size spike can never blow the cap (deterministic, deploy fleet-wide safely).
   localTtl: 30,
   localMax: 10000,
+  localMaxBytes: 12 * 1024 * 1024, // hard heap cap ~12MB
   lookupFn: async (ids, fromWrite) => {
     const imageIds = Array.isArray(ids) ? ids : [ids];
     if (imageIds.length === 0) return {};

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -59,6 +59,11 @@ export const tagIdsForImagesCache = createCachedObject<{
   // unaffected (they revalidate at the 8h logical boundary either way).
   ttl: CacheTTL.hour * 8,
   staleWhileRevalidateTtl: CacheTTL.hour,
+  // L1: image tag-ids are near-static display metadata (busted on scan/tag edits);
+  // an 8h Redis TTL dwarfs a 15s per-pod L1, which only delays a cross-pod tag
+  // edit by ≤15s. Not a visibility gate (feed SQL enforces that). Hot-image set.
+  localTtl: 15,
+  localMax: 10000,
   async lookupFn(imageId, fromWrite) {
     const imageIds = Array.isArray(imageId) ? imageId : [imageId];
     const db = fromWrite ? dbWrite : dbRead;
@@ -345,6 +350,12 @@ export const userBasicCache = createCachedObject<UserBasicLookup>({
     return Object.fromEntries(userBasicData.map((x) => [x.id, x]));
   },
   ttl: CacheTTL.day,
+  // L1: username/avatar/deletedAt are cosmetic near-static fields with a 1-day Redis
+  // TTL and refresh-only invalidation (deleteBasicDataForUser). A 30s per-pod L1 is
+  // strictly fresher than what Redis already serves; the only effect is a ≤30s
+  // cross-pod delay on a rename/avatar/soft-delete propagating — imperceptible.
+  localTtl: 30,
+  localMax: 10000,
 });
 
 type ModelVersionAccessCache = EntityAccessDataType & { publishedAt: Date; status: ModelStatus };
@@ -1289,6 +1300,12 @@ export const imageMetaCache = createCachedObject<ImageWithMeta>({
   // working set into misses and stampede dbRead.
   ttl: CacheTTL.hour * 4,
   staleWhileRevalidateTtl: CacheTTL.hour,
+  // L1: generation meta behind a 4h Redis TTL, refresh-only on image edit/delete.
+  // Shortest L1 TTL of the set (10s) because `hideMeta` toggles the prompt to NULL —
+  // a ≤10s cross-pod lag on hide taking effect, on data that was already public.
+  // max 5000: `meta` is the heaviest per-entity value (~2.8KB/key), keep it small.
+  localTtl: 10,
+  localMax: 5000,
 });
 
 type ImageWithMetadata = {
@@ -1495,6 +1512,11 @@ export const imageTagsCache = createCachedObject<ImageTagsCacheItem>({
   // before reuse. SWR off → effective Redis EX = 1h. (2026-06-09 redis usage audit)
   ttl: CacheTTL.hour,
   staleWhileRevalidate: false,
+  // L1: votable-tag composites (busted on tag votes/edits). 1h Redis TTL vs a 15s
+  // per-pod L1 → ≤15s cross-pod delay on a tag vote/edit. Display metadata + soft
+  // hidden-tag filtering, not a hard visibility gate. max 5000: ~4.2KB/key, heavy.
+  localTtl: 15,
+  localMax: 5000,
   lookupFn: async (ids, fromWrite) => {
     const db = fromWrite ? dbWrite : dbRead;
 
@@ -1659,6 +1681,11 @@ export const imageResourcesCache = createCachedObject<ImageResourcesCacheItem>({
   // the day TTL resided for 48h, generous for a sub-average-hit cache.
   // Effective Redis EX = 16h. (2026-06-09 redis usage audit)
   ttl: CacheTTL.hour * 8,
+  // L1: which models an image used — attribution metadata, refresh-only on resource
+  // edits, 8h Redis TTL. A 30s per-pod L1 only delays a cross-pod resource edit by
+  // ≤30s. Not sensitive / not a visibility gate.
+  localTtl: 30,
+  localMax: 10000,
   lookupFn: async (ids, fromWrite) => {
     const imageIds = Array.isArray(ids) ? ids : [ids];
     if (imageIds.length === 0) return {};

--- a/src/server/utils/__tests__/cache-helpers-l1.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-l1.test.ts
@@ -187,6 +187,59 @@ describe('createCachedArray L1 — byte-identical + TTL + bounded', () => {
     expect(lookupFn).toHaveBeenCalledTimes(1);
   });
 
+  it('is BYTE-bounded: exceeding localMaxBytes evicts LRU to keep the heap footprint capped', async () => {
+    // Values ~2.1KB each (1000-char name). Budget 5000 bytes → ~2 fit; the entry
+    // cap (localMax) is high so the BYTE cap is the binding constraint.
+    const big = 'x'.repeat(1000);
+    const lookupFn = vi.fn(
+      async (ids: number[]) =>
+        Object.fromEntries(ids.map((id) => [id, { id, name: `${big}-${id}` }])) as Record<string, Row>
+    );
+    const cache = createCachedArray<Row>({
+      key: 'test:l1bytes' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 60,
+      localMax: 10000, // high — byte cap binds first
+      localMaxBytes: 5000,
+    });
+
+    await cache.fetch([1]); // L1 ~2.1KB
+    await cache.fetch([2]); // L1 ~4.2KB
+    await cache.fetch([3]); // would be ~6.3KB > 5000 → evicts LRU (id 1) to fit
+    mGetMock.mockClear().mockResolvedValue([]);
+    lookupFn.mockClear();
+
+    await cache.fetch([1]); // id 1 was byte-evicted → must re-fetch
+    expect(mGetMock).toHaveBeenCalledTimes(1);
+    expect(lookupFn).toHaveBeenCalledWith([1]);
+
+    await cache.fetch([3]); // id 3 still resident → served from L1 (no new origin call)
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('never stores a single value larger than localMaxBytes (falls through to Redis, no throw)', async () => {
+    const huge = 'y'.repeat(10000); // ~20KB, larger than the 4KB budget
+    const lookupFn = vi.fn(
+      async (ids: number[]) =>
+        Object.fromEntries(ids.map((id) => [id, { id, name: `${huge}-${id}` }])) as Record<string, Row>
+    );
+    const cache = createCachedArray<Row>({
+      key: 'test:l1huge' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 60,
+      localMaxBytes: 4000,
+    });
+
+    const first = await cache.fetch([1]); // stored? no — value > budget
+    expect(first[0].name).toBe(`${huge}-1`); // still returned correctly
+    mGetMock.mockClear().mockResolvedValue([]);
+
+    await cache.fetch([1]); // not in L1 → back to Redis (no crash)
+    expect(mGetMock).toHaveBeenCalledTimes(1);
+  });
+
   it('is bounded: exceeding localMax evicts the LRU entry (no unbounded growth)', async () => {
     const lookupFn = makeLookup();
     const cache = createCachedArray<Row>({

--- a/src/server/utils/__tests__/cache-helpers-l1.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-l1.test.ts
@@ -279,6 +279,71 @@ describe('createCachedArray L1 — shared-instance isolation', () => {
   });
 });
 
+describe('createCachedArray L1 — mirrors the Redis-write skip (dontCache/debounce)', () => {
+  it('does NOT L1-cache a freshly-busted (debounce) id so the debounce/replica-lag guard survives', async () => {
+    // Redis returns a debounce marker with a RECENT cachedAt → the id is treated as
+    // `dontCache` (within debounceTime): served from origin (dbRead) but deliberately
+    // NOT written back to Redis. The L1 must skip it too, else it would pin the
+    // possibly replica-lagged read for localTtl.
+    mGetMock.mockResolvedValue([{ id: 1, debounce: true, cachedAt: new Date() }]);
+    const lookupFn = makeLookup();
+    const cache = createCachedArray<Row>({
+      key: 'test:l1debounce' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 60,
+    });
+
+    const first = await cache.fetch([1]);
+    expect(first).toEqual([{ id: 1, name: 'db-1' }]); // served from origin
+    mGetMock.mockClear();
+
+    // Not pinned in L1 → the next read still consults Redis (would be an L1 hit if we
+    // had wrongly cached the debounced value).
+    await cache.fetch([1]);
+    expect(mGetMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createCachedArray L1 — self-pod invalidation', () => {
+  it('bust() drops the id from THIS pod L1 (no self-pod stale serve)', async () => {
+    const lookupFn = makeLookup();
+    const cache = createCachedArray<Row>({
+      key: 'test:l1bust' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 60,
+    });
+
+    await cache.fetch([1]); // warm L1
+    mGetMock.mockClear().mockResolvedValue([]);
+    lookupFn.mockClear();
+
+    await cache.bust(1); // must delete id 1 from L1 (bust == invalidate when SWR on)
+
+    mGetMock.mockClear().mockResolvedValue([]);
+    await cache.fetch([1]); // L1 was dropped → back to Redis
+    expect(mGetMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('refresh() drops the id from THIS pod L1', async () => {
+    const lookupFn = makeLookup();
+    const cache = createCachedArray<Row>({
+      key: 'test:l1refresh' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 60,
+    });
+
+    await cache.fetch([1]); // warm L1
+    await cache.refresh(1); // re-fetches primary + drops L1
+
+    mGetMock.mockClear().mockResolvedValue([]);
+    await cache.fetch([1]);
+    expect(mGetMock).toHaveBeenCalledTimes(1); // served from Redis, not stale L1
+  });
+});
+
 describe('createCachedObject L1 — keyed Record served from L1', () => {
   it('returns the same keyed Record whether served from Redis or L1', async () => {
     const lookupFn = makeLookup();

--- a/src/server/utils/__tests__/cache-helpers-l1.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-l1.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for the opt-in per-pod L1 cache in createCachedArray / createCachedObject.
+ *
+ * Background: on the image-feed hydration path `redis.packed.mGet` decomposes into
+ * per-id GETs (no cross-slot MGET), so N images fan out to N Redis commands, each
+ * routed through cluster-routing-retry individually — the dominant driver of
+ * api-heavy's Redis command volume + cluster-slot churn. The `localTtl` opt-in adds a
+ * bounded in-process LRU in front of the Redis per-id cache: an L1 hit skips the
+ * ENTIRE Redis fan-out for that id.
+ *
+ * These tests pin the contract:
+ *  - an L1 hit does NOT touch Redis (mGet) or the origin (lookupFn);
+ *  - an L1 miss falls through to the existing Redis path and backfills L1;
+ *  - the L1 value is byte-identical to the Redis path's return;
+ *  - the TTL expires and re-fetches;
+ *  - the LRU is bounded (evicts, no unbounded growth);
+ *  - `notFound` ids are never L1-cached (positive-only — no stale-miss pinning);
+ *  - a cache WITHOUT `localTtl` is untouched (no L1 layer at all);
+ *  - a caller mutating its returned object cannot corrupt the shared L1 instance;
+ *  - the lruCache hit/miss counters are emitted for measurability.
+ *
+ * The redis client + prom counters are mocked (mirrors cache-helpers-failopen.test.ts)
+ * so we can assert exactly which layer served each id.
+ */
+
+const mGetMock = vi.fn();
+const setMock = vi.fn().mockResolvedValue(undefined);
+const setNxMock = vi.fn().mockResolvedValue(true);
+const delMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: {
+      mGet: (...args: unknown[]) => mGetMock(...args),
+      set: (...args: unknown[]) => setMock(...args),
+    },
+    setNxKeepTtlWithEx: (...args: unknown[]) => setNxMock(...args),
+    del: (...args: unknown[]) => delMock(...args),
+  },
+  sysRedis: {},
+  REDIS_KEYS: { CACHE_LOCKS: 'caches:lock', TAG: 'caches:tag' },
+}));
+
+vi.mock('~/server/redis/fail-open-log', () => ({
+  logSysRedisFailOpen: vi.fn(),
+}));
+
+// vi.hoisted so the inc spies exist before the (hoisted) vi.mock factory references
+// them — lets us assert the lruCache hit/miss observability wiring.
+const { hitInc, missInc } = vi.hoisted(() => ({
+  hitInc: vi.fn(),
+  missInc: vi.fn(),
+}));
+vi.mock('~/server/prom/client', () => ({
+  cacheHitCounter: { inc: hitInc },
+  cacheMissCounter: { inc: missInc },
+  cacheRevalidateCounter: { inc: vi.fn() },
+  cacheFailOpenDegradedCounter: { inc: vi.fn() },
+  cacheFailOpenOriginFetchCounter: { inc: vi.fn() },
+}));
+
+import { createCachedArray, createCachedObject } from '~/server/utils/cache-helpers';
+
+type Row = { id: number; name: string };
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// Count how many lruCache-typed hits/misses were recorded (across all calls).
+const lruHits = () =>
+  hitInc.mock.calls
+    .filter((c) => (c[0] as { cache_type?: string })?.cache_type === 'lruCache')
+    .reduce((s, c) => s + ((c[1] as number) ?? 1), 0);
+const lruMisses = () =>
+  missInc.mock.calls
+    .filter((c) => (c[0] as { cache_type?: string })?.cache_type === 'lruCache')
+    .reduce((s, c) => s + ((c[1] as number) ?? 1), 0);
+
+beforeEach(() => {
+  // Empty read → every id is a Redis miss; lookupFn (origin) fills it, then it is
+  // written back (setMock) and backfilled into L1.
+  mGetMock.mockReset().mockResolvedValue([]);
+  setMock.mockClear().mockResolvedValue(undefined);
+  setNxMock.mockClear().mockResolvedValue(true);
+  delMock.mockClear().mockResolvedValue(undefined);
+  hitInc.mockClear();
+  missInc.mockClear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const makeLookup = () =>
+  vi.fn(
+    async (ids: number[]) =>
+      Object.fromEntries(ids.map((id) => [id, { id, name: `db-${id}` }])) as Record<string, Row>
+  );
+
+describe('createCachedArray L1 — hit skips the Redis fan-out', () => {
+  it('serves a warmed id from L1 without calling mGet or lookupFn', async () => {
+    const lookupFn = makeLookup();
+    const cache = createCachedArray<Row>({
+      key: 'test:l1hit' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 5,
+    });
+
+    // Warm: first fetch is a full miss → Redis read + origin + backfill L1.
+    const first = await cache.fetch([1]);
+    expect(mGetMock).toHaveBeenCalledTimes(1);
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+    expect(first).toEqual([{ id: 1, name: 'db-1' }]);
+
+    mGetMock.mockClear();
+    lookupFn.mockClear();
+
+    // Warm hit: neither Redis nor the origin is touched.
+    const second = await cache.fetch([1]);
+    expect(mGetMock).not.toHaveBeenCalled();
+    expect(lookupFn).not.toHaveBeenCalled();
+    expect(second).toEqual([{ id: 1, name: 'db-1' }]);
+    expect(lruHits()).toBeGreaterThanOrEqual(1);
+  });
+
+  it('only the L1-miss ids reach Redis on a partial hit; result merges both', async () => {
+    const lookupFn = makeLookup();
+    const cache = createCachedArray<Row>({
+      key: 'test:l1partial' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 5,
+    });
+
+    await cache.fetch([1]); // warm id 1 into L1
+    mGetMock.mockClear();
+    lookupFn.mockClear();
+
+    const result = await cache.fetch([1, 2]); // 1 = L1 hit, 2 = miss
+    // Redis + origin saw ONLY the miss (id 2), never the warmed id 1.
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+    expect(lookupFn).toHaveBeenCalledWith([2]);
+    const mGetKeys = (mGetMock.mock.calls[0]?.[0] as string[]) ?? [];
+    expect(mGetKeys).toEqual(['test:l1partial:2']);
+    expect(result.map((r) => r.id).sort((a, b) => a - b)).toEqual([1, 2]);
+    expect(result.find((r) => r.id === 1)?.name).toBe('db-1');
+    expect(result.find((r) => r.id === 2)?.name).toBe('db-2');
+  });
+});
+
+describe('createCachedArray L1 — byte-identical + TTL + bounded', () => {
+  it('the L1 value is byte-identical to the Redis-path return', async () => {
+    const lookupFn = makeLookup();
+    const cache = createCachedArray<Row>({
+      key: 'test:l1identical' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 5,
+    });
+
+    const fromRedisPath = await cache.fetch([42]);
+    const fromL1 = await cache.fetch([42]);
+    expect(fromL1).toEqual(fromRedisPath);
+    // No internal bookkeeping (cachedAt) leaks into the L1-served value.
+    expect(fromL1[0]).not.toHaveProperty('cachedAt');
+  });
+
+  it('re-fetches after the L1 TTL expires', async () => {
+    const lookupFn = makeLookup();
+    const cache = createCachedArray<Row>({
+      key: 'test:l1ttl' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 0.05, // 50ms
+    });
+
+    await cache.fetch([1]); // warm
+    mGetMock.mockClear();
+    lookupFn.mockClear();
+
+    await sleep(80); // let the L1 entry expire
+
+    await cache.fetch([1]); // expired → falls through to Redis again
+    expect(mGetMock).toHaveBeenCalledTimes(1);
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('is bounded: exceeding localMax evicts the LRU entry (no unbounded growth)', async () => {
+    const lookupFn = makeLookup();
+    const cache = createCachedArray<Row>({
+      key: 'test:l1bound' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 60,
+      localMax: 2,
+    });
+
+    await cache.fetch([1]); // L1: {1}
+    await cache.fetch([2]); // L1: {1,2}
+    await cache.fetch([3]); // L1: {2,3} — id 1 evicted (max 2)
+    mGetMock.mockClear();
+    lookupFn.mockClear();
+
+    await cache.fetch([1]); // evicted → must re-fetch from Redis/origin
+    expect(mGetMock).toHaveBeenCalledTimes(1);
+    expect(lookupFn).toHaveBeenCalledWith([1]);
+
+    await cache.fetch([3]); // still resident → served from L1
+    // (id 3 fetch above must NOT have added a second origin call for id 3)
+    expect(lookupFn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createCachedArray L1 — positive-only (no negative pinning)', () => {
+  it('never L1-caches a notFound id; it re-checks Redis each time', async () => {
+    // id 2 never has a DB row → notFound. mGet stays empty (no positive redis entry).
+    const lookupFn = vi.fn(async (ids: number[]) =>
+      Object.fromEntries(
+        ids.filter((id) => id !== 2).map((id) => [id, { id, name: `db-${id}` }])
+      ) as Record<string, Row>
+    );
+    const cache = createCachedArray<Row>({
+      key: 'test:l1nf' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 60,
+    });
+
+    const first = await cache.fetch([2]);
+    expect(first).toEqual([]); // notFound → omitted
+    mGetMock.mockClear();
+
+    // Because the negative was NOT pinned in L1, the id still consults Redis — so a
+    // later create (once the Redis notFound marker clears) resolves without waiting
+    // out an L1 TTL.
+    await cache.fetch([2]);
+    expect(mGetMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('createCachedArray — WITHOUT localTtl (excluded caches, e.g. metrics)', () => {
+  it('never installs an L1 layer: every fetch hits Redis, no lruCache metrics', async () => {
+    const lookupFn = makeLookup();
+    const cache = createCachedArray<Row>({
+      key: 'test:nol1' as never,
+      idKey: 'id',
+      lookupFn,
+      // no localTtl
+    });
+
+    await cache.fetch([1]);
+    await cache.fetch([1]); // would be an L1 hit IF L1 existed
+    expect(mGetMock).toHaveBeenCalledTimes(2); // both went to Redis
+    expect(lruHits()).toBe(0);
+    expect(lruMisses()).toBe(0);
+  });
+});
+
+describe('createCachedArray L1 — shared-instance isolation', () => {
+  it('a caller mutating its returned object does not corrupt the L1 copy', async () => {
+    const lookupFn = makeLookup();
+    const cache = createCachedArray<Row>({
+      key: 'test:l1iso' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 60,
+    });
+
+    const first = await cache.fetch([1]);
+    first[0].name = 'MUTATED'; // caller mutates its copy
+    mGetMock.mockClear();
+    lookupFn.mockClear();
+
+    const second = await cache.fetch([1]); // served from L1
+    expect(mGetMock).not.toHaveBeenCalled(); // still an L1 hit
+    expect(second[0].name).toBe('db-1'); // NOT corrupted by the earlier mutation
+  });
+});
+
+describe('createCachedObject L1 — keyed Record served from L1', () => {
+  it('returns the same keyed Record whether served from Redis or L1', async () => {
+    const lookupFn = makeLookup();
+    const cache = createCachedObject<Row>({
+      key: 'test:l1obj' as never,
+      idKey: 'id',
+      lookupFn,
+      localTtl: 60,
+    });
+
+    const fromRedis = await cache.fetch([1, 2]);
+    mGetMock.mockClear();
+    lookupFn.mockClear();
+
+    const fromL1 = await cache.fetch([1, 2]);
+    expect(mGetMock).not.toHaveBeenCalled();
+    expect(fromL1).toEqual(fromRedis);
+    expect(Object.keys(fromL1).sort()).toEqual(['1', '2']);
+    expect(fromL1['2'].name).toBe('db-2');
+  });
+});

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -23,6 +23,7 @@ function getCacheClient(target: CacheTarget = 'main'): any {
   return target === 'sys' ? sysRedis : redis;
 }
 import { sleep } from '~/server/utils/concurrency-helpers';
+import { createLruCache } from '~/server/utils/lru-cache';
 import { createLogger } from '~/utils/logging';
 import { hashifyObject } from '~/utils/string-helpers';
 import { isDefined } from '~/utils/type-guards';
@@ -127,6 +128,27 @@ type CachedLookupOptions<T extends object> = {
   // true. Shorten it to cut resident memory for caches whose stale tail is far
   // larger than the sub-second revalidation actually needs.
   staleWhileRevalidateTtl?: number;
+  // --- In-process (per-pod) L1 cache in front of the Redis per-id cache -------
+  // Opt-in. When `localTtl` (SECONDS) is set, resolved per-id values are also
+  // held in a bounded per-pod LRU. An L1 hit skips the ENTIRE Redis GET fan-out
+  // for that id — the win on the hot image-feed hydration path where
+  // redis.packed.mGet decomposes into per-id GETs (no MGET across cluster slots),
+  // so N images = N GETs, each routed through cluster-routing-retry individually.
+  //
+  // 🔴 CORRECTNESS: the L1 is per-pod and CANNOT see a cross-pod `bust`/`refresh`
+  // of the Redis entry, so a mutation propagates with up to `localTtl` extra
+  // staleness on pods holding an L1 copy. Enable ONLY on near-static per-entity
+  // caches whose Redis TTL already tolerates far more staleness than `localTtl`
+  // adds, AND that do not gate content visibility / auth (those are enforced by
+  // the feed SQL, not these hydration caches). Keep `localTtl` SHORT (5–30s) and
+  // strictly < the Redis `ttl`. Only positive results are L1-cached (matching the
+  // Redis layer's positive-only return): a notFound id is never L1-cached, so a
+  // just-created entity still resolves as soon as the Redis notFound marker
+  // clears — the L1 never pins a negative.
+  localTtl?: number;
+  // Max entries in the per-pod L1 LRU (default 10000). Bounds memory; cold ids
+  // evict LRU-first and simply fall through to Redis (same as no L1).
+  localMax?: number;
 };
 /**
  * Physical Redis EX (seconds) for a cached entry. The logical freshness window
@@ -185,7 +207,40 @@ export function createCachedArray<T extends object>({
   dontCacheFn,
   staleWhileRevalidate = true,
   staleWhileRevalidateTtl,
+  localTtl,
+  localMax = 10000,
 }: CachedLookupOptions<T>) {
+  // Per-pod L1 in front of the Redis per-id cache (opt-in via localTtl). Holds the
+  // FINAL resolved per-id value — post-appendFn, cachedAt stripped — so an L1 hit is
+  // byte-identical to what the Redis path returns and needs no further decoration.
+  // Built on the shared createLruCache util; we drive it with get/set (not its
+  // wrapping .fetch) because our access pattern is a batch mGet, not a per-id fetch.
+  // The fetchFn is unused (loud if ever hit).
+  const localCache =
+    localTtl && localTtl > 0
+      ? createLruCache<number, T>({
+          name: `${key}:l1`,
+          max: localMax,
+          ttl: localTtl * 1000,
+          keyFn: (id) => String(id),
+          fetchFn: () => {
+            throw new Error(`createCachedArray L1 fetchFn must not be called [${key}]`);
+          },
+        })
+      : null;
+
+  // Store a SHALLOW CLONE in L1 (and hand out shallow clones on read) so a caller
+  // mutating its returned object cannot corrupt the single shared L1 instance — the
+  // same isolation the degraded path documents (its appendFns reassign/delete
+  // top-level fields; shallow is enough). The healthy Redis path is naturally immune
+  // (each request decodes its own objects from msgpack); this restores that for L1.
+  function backfillLocal(items: T[]) {
+    if (!localCache) return;
+    for (const x of items) {
+      const id = x[idKey] as unknown as number;
+      if (id !== undefined && id !== null) localCache.set(id, { ...x });
+    }
+  }
   // Degraded origin (DB) fetch used when a CLUSTER Redis read rejects. Returns the SAME shape
   // as the healthy `fetch` (decorated by appendFn, cachedAt stripped) but reads nothing from
   // and writes nothing to Redis. DB load is bounded by the per-id single-flight above; a
@@ -254,7 +309,28 @@ export function createCachedArray<T extends object>({
 
   async function fetch(ids: number[]) {
     if (!ids.length) return [] as T[];
-    const distinctIds = [...new Set(ids)];
+    let distinctIds = [...new Set(ids)];
+
+    // --- L1 (per-pod) read -------------------------------------------------------
+    // Serve hot ids from the in-process LRU and drop them from the Redis fan-out.
+    // Only the L1 MISSES flow into the existing Redis path below (via `distinctIds`),
+    // so a full L1 hit returns without a single Redis command.
+    const l1Hits: T[] = [];
+    if (localCache) {
+      const l1Misses: number[] = [];
+      for (const id of distinctIds) {
+        const hit = localCache.get(id);
+        if (hit !== undefined) l1Hits.push({ ...hit });
+        else l1Misses.push(id);
+      }
+      if (l1Hits.length)
+        cacheHitCounter.inc({ cache_name: key, cache_type: 'lruCache' }, l1Hits.length);
+      if (l1Misses.length)
+        cacheMissCounter.inc({ cache_name: key, cache_type: 'lruCache' }, l1Misses.length);
+      if (l1Misses.length === 0) return l1Hits;
+      distinctIds = l1Misses;
+    }
+
     const results = new Set<T>();
     const cacheResults: T[] = [];
     try {
@@ -274,7 +350,11 @@ export function createCachedArray<T extends object>({
         key,
         ids: distinctIds.length,
       });
-      return fetchFromOriginDegraded(distinctIds);
+      const degraded = await fetchFromOriginDegraded(distinctIds);
+      // Backfill L1 even during a Redis wedge (short TTL; helps bound the DB herd)
+      // and merge any ids we already served from L1 before the read failed.
+      backfillLocal(degraded);
+      return localCache ? [...l1Hits, ...degraded] : degraded;
     }
     const cacheArray = cacheResults.filter((x) => x !== null) as T[];
     const cache = Object.fromEntries(cacheArray.map((x) => [x[idKey], x]));
@@ -429,11 +509,17 @@ export function createCachedArray<T extends object>({
 
     if (appendFn) await appendFn(results);
 
-    return [...results].map((x) => {
+    const final = [...results].map((x) => {
       // Remove cachedAt from result since this is an internal value
       if ('cachedAt' in x) delete x.cachedAt;
       return x;
     });
+
+    // Backfill L1 with the FINAL shape (post-appendFn, cachedAt stripped) so a later
+    // L1 hit is byte-identical to this return, then prepend the ids already served
+    // from L1 above. When there is no L1, l1Hits is empty and we return `final` as-is.
+    backfillLocal(final);
+    return localCache ? [...l1Hits, ...final] : final;
   }
 
   async function bust(id: number | number[], options: { debounceTime?: number } = {}) {

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -234,12 +234,28 @@ export function createCachedArray<T extends object>({
   // same isolation the degraded path documents (its appendFns reassign/delete
   // top-level fields; shallow is enough). The healthy Redis path is naturally immune
   // (each request decodes its own objects from msgpack); this restores that for L1.
-  function backfillLocal(items: T[]) {
+  // 🔴 INVARIANT: shallow only protects TOP-LEVEL fields — nested refs (e.g. `tags`,
+  // `meta`) are shared with the L1 copy, so consumers MUST treat returned values as
+  // read-only for nested fields (all current consumers map into new objects rather
+  // than mutating in place). `skip` lets a caller withhold ids the Redis layer itself
+  // deliberately did NOT cache (dontCache debounce window / dontCacheFn), so L1 never
+  // pins a value Redis chose not to persist (e.g. a replica-lagged debounced read).
+  function backfillLocal(items: T[], skip?: (x: T) => boolean) {
     if (!localCache) return;
     for (const x of items) {
+      if (skip?.(x)) continue;
       const id = x[idKey] as unknown as number;
       if (id !== undefined && id !== null) localCache.set(id, { ...x });
     }
+  }
+
+  // Drop these ids from THIS pod's L1 on a local bust/refresh/invalidate. Does NOT
+  // fix cross-pod staleness (inherent + accepted for the near-static caches L1 is
+  // enabled on) — it closes the self-pod window where the pod that just processed a
+  // mutation would otherwise keep serving its own pre-mutation L1 copy for localTtl.
+  function dropLocal(ids: number[]) {
+    if (!localCache) return;
+    for (const id of ids) localCache.delete(id);
   }
   // Degraded origin (DB) fetch used when a CLUSTER Redis read rejects. Returns the SAME shape
   // as the healthy `fetch` (decorated by appendFn, cachedAt stripped) but reads nothing from
@@ -352,8 +368,9 @@ export function createCachedArray<T extends object>({
       });
       const degraded = await fetchFromOriginDegraded(distinctIds);
       // Backfill L1 even during a Redis wedge (short TTL; helps bound the DB herd)
-      // and merge any ids we already served from L1 before the read failed.
-      backfillLocal(degraded);
+      // and merge any ids we already served from L1 before the read failed. Honor
+      // dontCacheFn (dontCache is a Redis-hit concept, not reachable on this path).
+      backfillLocal(degraded, dontCacheFn ? (x) => !!dontCacheFn(x) : undefined);
       return localCache ? [...l1Hits, ...degraded] : degraded;
     }
     const cacheArray = cacheResults.filter((x) => x !== null) as T[];
@@ -518,13 +535,19 @@ export function createCachedArray<T extends object>({
     // Backfill L1 with the FINAL shape (post-appendFn, cachedAt stripped) so a later
     // L1 hit is byte-identical to this return, then prepend the ids already served
     // from L1 above. When there is no L1, l1Hits is empty and we return `final` as-is.
-    backfillLocal(final);
+    // Skip exactly what the Redis write skipped: dontCache (freshly-busted debounce
+    // window — value came from dbRead and may be replica-lagged) and dontCacheFn.
+    backfillLocal(
+      final,
+      (x) => dontCache.has(x[idKey] as unknown as number) || !!dontCacheFn?.(x)
+    );
     return localCache ? [...l1Hits, ...final] : final;
   }
 
   async function bust(id: number | number[], options: { debounceTime?: number } = {}) {
     const ids = Array.isArray(id) ? id : [id];
     if (ids.length === 0) return;
+    dropLocal(ids);
 
     await Promise.all(
       ids.map((id) =>
@@ -543,6 +566,7 @@ export function createCachedArray<T extends object>({
   async function invalidate(id: number | number[], options: { debounceTime?: number } = {}) {
     const ids = Array.isArray(id) ? id : [id];
     if (ids.length === 0) return;
+    dropLocal(ids);
 
     const cacheResults: T[] = [];
     for (const batch of chunk(ids, 200)) {
@@ -578,6 +602,7 @@ export function createCachedArray<T extends object>({
 
   async function refresh(id: number | number[]) {
     const ids = Array.isArray(id) ? id : [id];
+    dropLocal(ids);
 
     try {
       const results = await lookupFn(ids, true);
@@ -615,6 +640,7 @@ export function createCachedArray<T extends object>({
   }
 
   async function flush() {
+    localCache?.clear();
     await clearCacheByPattern(`${key}:*`);
   }
 

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -146,9 +146,16 @@ type CachedLookupOptions<T extends object> = {
   // just-created entity still resolves as soon as the Redis notFound marker
   // clears — the L1 never pins a negative.
   localTtl?: number;
-  // Max entries in the per-pod L1 LRU (default 10000). Bounds memory; cold ids
+  // Belt-and-suspenders ENTRY cap for the per-pod L1 LRU (default 10000). Cold ids
   // evict LRU-first and simply fall through to Redis (same as no L1).
   localMax?: number;
+  // 🔴 HARD HEAP CAP: byte budget for this cache's per-pod L1 (deterministic — the
+  // LRU evicts to keep total retained-byte estimate ≤ localMaxBytes, on top of
+  // localMax). Set this on every L1-enabled cache so the pod's total L1 footprint
+  // is bounded regardless of per-value size spikes (this pool is heap-OOM
+  // sensitive). A single value larger than the budget is simply not stored (falls
+  // through to Redis) — never an error. Sizes estimated via roughSizeOf.
+  localMaxBytes?: number;
 };
 /**
  * Physical Redis EX (seconds) for a cached entry. The logical freshness window
@@ -209,6 +216,7 @@ export function createCachedArray<T extends object>({
   staleWhileRevalidateTtl,
   localTtl,
   localMax = 10000,
+  localMaxBytes,
 }: CachedLookupOptions<T>) {
   // Per-pod L1 in front of the Redis per-id cache (opt-in via localTtl). Holds the
   // FINAL resolved per-id value — post-appendFn, cachedAt stripped — so an L1 hit is
@@ -221,6 +229,9 @@ export function createCachedArray<T extends object>({
       ? createLruCache<number, T>({
           name: `${key}:l1`,
           max: localMax,
+          // Deterministic byte cap (roughSizeOf estimator) so the pod's total L1
+          // heap footprint is bounded regardless of per-value size spikes.
+          maxSize: localMaxBytes,
           ttl: localTtl * 1000,
           keyFn: (id) => String(id),
           fetchFn: () => {

--- a/src/server/utils/lru-cache.ts
+++ b/src/server/utils/lru-cache.ts
@@ -13,9 +13,37 @@ import { cacheHitCounter, cacheMissCounter } from '~/server/prom/client';
 const DEFAULT_MAX_SIZE = 1000;
 const DEFAULT_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
+/**
+ * Pragmatic retained-bytes estimator for a decoded JS value. Uses the UTF-16
+ * JSON length (`* 2`) plus a small fixed per-entry overhead, clamped to ≥1 (a
+ * `sizeCalculation` return of 0 is rejected by lru-cache). It runs on each `set`
+ * (miss-fill, not on hits), so it stays cheap; it is an ESTIMATE for bounding
+ * heap, not an exact `retainedSize`. Callers can override via `sizeCalculation`.
+ */
+export function roughSizeOf(value: unknown): number {
+  let json: string;
+  try {
+    json = JSON.stringify(value) ?? '';
+  } catch {
+    json = ''; // circular/unserializable → fall back to the fixed overhead
+  }
+  return Math.max(1, json.length * 2 + 64);
+}
+
 export type LruCacheOptions<K, V extends {}> = {
-  /** Maximum number of items in cache (default: 1000) */
+  /** Maximum number of items in cache (default: 1000). Belt-and-suspenders entry cap. */
   max?: number;
+  /**
+   * Optional byte budget for the cache. When set, the LRU evicts to keep the sum
+   * of entry sizes ≤ maxSize (a deterministic heap cap), in ADDITION to `max`.
+   * Requires a `sizeCalculation` (defaults to `roughSizeOf`).
+   */
+  maxSize?: number;
+  /**
+   * Per-value size estimator used when `maxSize` is set. Runs on each `set`
+   * (miss-fill). Defaults to `roughSizeOf`. Must return a positive integer.
+   */
+  sizeCalculation?: (value: V, key: string) => number;
   /** TTL in milliseconds (default: 5 minutes). Set to 0 for no TTL. */
   ttl?: number;
   /** Name for metrics tracking */
@@ -46,11 +74,22 @@ export type LruCacheOptions<K, V extends {}> = {
  * ```
  */
 export function createLruCache<K, V extends {}>(options: LruCacheOptions<K, V>) {
-  const { max = DEFAULT_MAX_SIZE, ttl = DEFAULT_TTL_MS, name, keyFn, fetchFn } = options;
+  const { max = DEFAULT_MAX_SIZE, maxSize, sizeCalculation, ttl = DEFAULT_TTL_MS, name, keyFn, fetchFn } =
+    options;
 
   const cache = new LRUCache<string, V>({
     max,
     ttl: ttl > 0 ? ttl : undefined,
+    // Byte cap (deterministic heap bound), enabled only when maxSize is set —
+    // lru-cache requires a sizeCalculation whenever maxSize is present. Clamp the
+    // estimator to a positive integer (0 is rejected).
+    ...(maxSize
+      ? {
+          maxSize,
+          sizeCalculation: (value: V, key: string) =>
+            Math.max(1, Math.round((sizeCalculation ?? roughSizeOf)(value, key))),
+        }
+      : {}),
   });
 
   return {


### PR DESCRIPTION
## What

Adds an **opt-in per-process (per-pod) L1 cache** in front of the Redis per-id
cache used by the image-feed hydration path.

`redis.packed.mGet` decomposes into `Promise.all(keys.map(get))` (to avoid
`CROSSSLOT` on the cluster), so hydrating a feed page fans out to one Redis
`GET` **per image per cache**, each going through the cluster-routing-retry
layer individually. Pipelining hides round-trip latency but not command count.
An L1 hit skips the entire per-id `GET` fan-out for a hot id.

## How

New opt-in options on `createCachedArray` / `createCachedObject`
(`src/server/utils/cache-helpers.ts`):

- `localTtl` (seconds) — enables a bounded in-process LRU (built on the existing
  `createLruCache` util). Unset = no L1 layer at all (zero behaviour change).
- `localMax` — LRU **entry** cap (default 10000, belt-and-suspenders).
- `localMaxBytes` — LRU **byte** budget → deterministic heap cap. The LRU evicts
  to keep the retained-byte estimate ≤ budget; a single value larger than the
  budget is simply not stored (falls through to Redis), never an error.

`createLruCache` was extended to accept `maxSize` + `sizeCalculation`
(lru-cache@11 supports `max` and `maxSize` together). Default estimator
`roughSizeOf(v) ≈ JSON.stringify(v).length * 2` (UTF-16) + fixed overhead; it
runs on `set` (miss-fill) only, so it stays cheap.

Design guarantees:

- **Byte-identical output** — the L1 stores the *final* per-id value
  (post-`appendFn`, `cachedAt` stripped), so an L1 hit returns exactly what the
  Redis path returns.
- **Per-id, not per-request** — hits accrue across requests; only L1-miss ids
  flow into the existing Redis path, which then backfills L1.
- **Positive-only** — a `notFound` id is never L1-cached (no stale-miss pinning).
- **Mirrors the Redis-write skip** — the backfill withholds ids the Redis layer
  itself did not persist (`dontCache` debounce window / `dontCacheFn`), so a
  freshly-busted id read from `dbRead` (possibly replica-lagged) is not pinned.
- **Self-pod invalidation** — `bust`/`invalidate`/`refresh` delete the id from
  this pod's L1 (`flush` clears it), so the pod that processed a mutation never
  serves its own pre-mutation copy. (Cross-pod staleness is inherent + accepted.)
- **Shared-instance isolation** — shallow clones in and out; top-level mutation
  can't corrupt the cached instance. Consumers treat returned values as
  read-only for nested fields (all current consumers map into new objects).
- **Fail-open preserved** — a Redis read reject still degrades to the origin,
  merges any already-served L1 hits, and backfills.
- **Observability** — `cacheHitCounter` / `cacheMissCounter` with
  `cache_type="lruCache"` → L1 hit-rate measurable per cache.

## Where it's enabled

Only on always-on, **near-static** per-entity caches whose Redis TTL already
tolerates far more staleness than the short L1 adds, and that attach *display
metadata* to already-eligible feed images (visibility/moderation is enforced by
the feed query, not these caches):

| cache | fields | localTtl | localMaxBytes | Redis TTL | invalidation |
|---|---|---|---|---|---|
| `userBasicCache` | `{id, username, image, deletedAt}` | 30s | 4 MB | 1 day | refresh-only |
| `imageResourcesCache` | model attribution | 30s | 12 MB | 8h | refresh-only |
| `tagIdsForImagesCache` | tag ids | 15s | 6 MB | 8h | bust/refresh |
| `imageTagsCache` | votable-tag composites | 15s | 16 MB | 1h | bust |

### Deliberately NOT enabled

- **`imageMetaCache` — excluded for privacy.** Its value (generation prompt/
  params) is gated on `hideMeta`; flipping `hideMeta` false→true calls
  `imageMetaCache.refresh()` (meta→NULL), which a per-pod L1 can't observe → an
  exposure window on a privacy control. Also the heaviest value.
- **image-metrics cache** — volatile like/comment/collect counts.

## Trade-off (called out)

The L1 is per-pod and cannot see a cross-pod `bust`/`refresh`, so a mutation
propagates with up to `localTtl` extra staleness on pods **other than** the one
that processed it (self-pod invalidation handles the processing pod). Acceptable
because these 4 caches are near-static, their Redis TTLs already tolerate much
larger windows, and none is a visibility/auth gate.

## Deploy plan

The L1 is now **byte-bounded to a hard ≈38 MB/pod total** (4 + 12 + 6 + 16 MB,
`localMaxBytes` per cache) — well under the heap-headroom alert, and a per-value
size spike can't blow the cap (deterministic). Safe to **deploy fleet-wide**
(the L1 is in-code, not flag-gated, and the cache instances are shared across
pools, so a one-pod bake isn't possible anyway). Still watch per-pod heap RSS +
the headroom alert through the first traffic peak, and confirm the
`cache_type="lruCache"` hit-rate + the drop in per-id Redis GET volume.

## Testing

- `cache-helpers-l1.test.ts` (14 tests): L1 hit skips Redis+origin; partial hit
  routes only misses to Redis; byte-identical to the Redis path; TTL expiry
  re-fetches; entry-count eviction; **byte-cap eviction keeps the footprint
  bounded**; **a single value over budget is not stored + falls through (no
  throw)**; `notFound` never pinned; a cache without `localTtl` is untouched;
  mutation isolation; `dontCache`/debounce id not L1-pinned; `bust`/`refresh`
  self-pod L1 drop; `createCachedObject` keyed-Record parity.
- Existing `cache-helpers.test.ts` + `cache-helpers-failopen.test.ts` green.
- `tsc --noEmit` clean.
