### PR TITLE
feat(apps-review): Phase 1 — flag-gated deep-linkable review PAGE (modal → page migration)

### DIFF
--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -209,7 +209,11 @@ export function OnsiteReviewModal({
 /** Static, per-request modal title (slug + version + a mode/first-version badge).
  *  Derived purely from `selection` — no transient state — so it lives on the
  *  stable shell, not the keyed body. */
-function OnsiteReviewModalTitle({ selection }: { selection: NonNullable<OnsiteReviewSelection> }) {
+export function OnsiteReviewModalTitle({
+  selection,
+}: {
+  selection: NonNullable<OnsiteReviewSelection>;
+}) {
   const { request, mode } = selection;
   const mds = (request.manifestDiffSummary ?? {}) as ManifestDiffSummary;
   return (
@@ -241,8 +245,17 @@ function OnsiteReviewModalTitle({ selection }: { selection: NonNullable<OnsiteRe
  * mutations. The parent keys this on `selection.request.id`, so all of that
  * state is fresh on every request switch — no manual reset needed, and the
  * `onSuccess → onClose` paths are safe because the next open remounts fresh.
+ *
+ * EXPORTED (with {@link OnsiteReviewModalTitle}) so the per-submission review
+ * PAGE (`/apps/review/<id>`, `appReviewPage` flag) can re-host the exact same
+ * body WITHOUT the `<Modal>` shell — the page passes a resolved `selection`, an
+ * `onClose` that redirects to the queue (Q6), and its own `busyRef`. Keep this
+ * server-graph-free and free of modal-only assumptions so the modal and page
+ * stay behaviour-identical (and so an off-site page could reuse the shared
+ * sub-sections later). The modal shell above remains the only caller that wraps
+ * it in `<Modal>`.
  */
-function OnsiteReviewModalBody({
+export function OnsiteReviewModalBody({
   selection,
   onClose,
   busyRef,

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -130,6 +130,20 @@ export default function ReviewQueuePage() {
     mode: TabValue;
   } | null>(null);
 
+  // DUAL-PATH row selection (Phase 1 of the review modal → page migration).
+  // Under the `appReviewPage` flag a row NAVIGATES to the deep-linkable detail
+  // page `/apps/review/<id>`; with the flag off it opens the modal exactly as
+  // before. Fully reversible: flip the flag off (or unset it) to restore the
+  // modal path with zero code change. The report/tabs redesign is Phase 2.
+  const linkToPage = !!features?.appReviewPage;
+  const openRequest = (request: AnyRequest, mode: TabValue) => {
+    if (linkToPage) {
+      void router.push(`/apps/review/${request.id}`);
+      return;
+    }
+    setSelected({ request, mode });
+  };
+
   if (!features?.appBlocks) return <NotFound />;
 
   return (
@@ -167,9 +181,7 @@ export default function ReviewQueuePage() {
           <Tabs.Panel value="pending" pt="md">
             {/* On-site (App Block) queue — deep code review (byte-unchanged). The
                 onsite iframe/preview review lives here and is KEPT as-is. */}
-            <PendingTab
-              onSelect={(r) => setSelected({ request: r, mode: 'pending' })}
-            />
+            <PendingTab onSelect={(r) => openRequest(r, 'pending')} />
             {/* Unified moderator LISTINGS MANAGEMENT table (W13 post-approval mgmt,
                 P2) — all statuses across both kinds, with per-row lifecycle actions.
                 REPLACES the flat off-site pending list (`OffsiteReviewQueue`): a
@@ -180,11 +192,11 @@ export default function ReviewQueuePage() {
           </Tabs.Panel>
 
           <Tabs.Panel value="approved" pt="md">
-            <ApprovedTab onSelect={(r) => setSelected({ request: r, mode: 'approved' })} />
+            <ApprovedTab onSelect={(r) => openRequest(r, 'approved')} />
           </Tabs.Panel>
 
           <Tabs.Panel value="rejected" pt="md">
-            <RejectedTab onSelect={(r) => setSelected({ request: r, mode: 'rejected' })} />
+            <RejectedTab onSelect={(r) => openRequest(r, 'rejected')} />
           </Tabs.Panel>
 
           <Tabs.Panel value="reports" pt="md">

--- a/src/pages/apps/review/[publishRequestId].tsx
+++ b/src/pages/apps/review/[publishRequestId].tsx
@@ -1,0 +1,156 @@
+import { Button, Center, Loader } from '@mantine/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useRef } from 'react';
+import { NotFound } from '~/components/AppLayout/NotFound';
+import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
+import {
+  OnsiteReviewModalBody,
+  OnsiteReviewModalTitle,
+  type AnyRequest,
+  type OnsiteReviewMode,
+} from '~/components/Apps/OnsiteReviewModal';
+import { Meta } from '~/components/Meta/Meta';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { isAppReviewer } from '~/shared/utils/app-blocks-access';
+import { getLoginLink } from '~/utils/login-helpers';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * PER-SUBMISSION REVIEW PAGE — `/apps/review/<publishRequestId>` (Phase 1 of the
+ * App Blocks review modal → page migration).
+ *
+ * A flag-gated (`appReviewPage`), deep-linkable, refresh-survivable FULL PAGE
+ * that RE-HOSTS the exact same on-site review body the `/apps/review` queue opens
+ * in a modal today — `OnsiteReviewModalBody`, rendered WITHOUT the `<Modal>`
+ * shell. The queue links here (flag-gated dual-path) instead of `setSelected`;
+ * with the flag off the queue keeps opening the modal, so this is fully
+ * reversible. The report/tabs redesign is intentionally deferred to Phase 2 — the
+ * report renders via the existing `AgentReviewPanel`/`ReportBody` as-is.
+ *
+ * GATE: mirrors `/apps/review` + `/apps/review/preview/<id>` — `features.appBlocks`
+ * required (else 404), PLUS `features.appReviewPage` (else 404, so the page is
+ * dark unless the flag resolves for the caller), login required (else redirect),
+ * moderator required via `isAppReviewer` (else 404). The id is resolved
+ * server-side (existence + reviewable status) so a missing / withdrawn request
+ * 404s and never leaks which. Fail-closed at every stage.
+ *
+ * The full request payload (manifest/diff/reviewer blobs, Dates) is fetched
+ * CLIENT-SIDE via `blocks.getPublishRequest` — kept off the SSR props so the big
+ * blobs don't inflate the HTML and Dates ride the tRPC/superjson path rather than
+ * being hand-serialized. The SSR resolver only carries the validated id.
+ */
+
+interface ReviewDetailPageProps {
+  publishRequestId: string;
+}
+
+export const getServerSideProps = createServerSideProps<ReviewDetailPageProps>({
+  useSession: true,
+  resolver: async ({ features, session, ctx }) => {
+    if (!features?.appBlocks) return { notFound: true };
+    // The page flag: dark unless it resolves for the caller. `['mod']` static
+    // fallback → mods pass on merge, non-mods fail closed even if they somehow
+    // reached here (belt with the isAppReviewer gate below).
+    if (!features?.appReviewPage) return { notFound: true };
+    if (!session?.user) {
+      return {
+        redirect: {
+          destination: getLoginLink({ returnUrl: ctx.resolvedUrl }),
+          permanent: false,
+        },
+      };
+    }
+    if (!isAppReviewer(session.user)) {
+      return { notFound: true };
+    }
+
+    const rawId = ctx.params?.publishRequestId;
+    const publishRequestId =
+      typeof rawId === 'string' ? rawId : Array.isArray(rawId) ? rawId[0] : '';
+    if (!publishRequestId) return { notFound: true };
+
+    // Fail-closed on a missing / withdrawn / superseded request (mirrors the
+    // preview route's `resolveReviewPreviewTarget`, but valid for
+    // pending/approved/rejected — the page shows history too).
+    const { resolveReviewRequestTarget } = await import(
+      '~/server/services/blocks/publish-request.service'
+    );
+    const target = await resolveReviewRequestTarget(publishRequestId);
+    if (!target) return { notFound: true };
+
+    return { props: { publishRequestId: target.id } };
+  },
+});
+
+export default function ReviewDetailPage({ publishRequestId }: ReviewDetailPageProps) {
+  const features = useFeatureFlags();
+  const router = useRouter();
+  // The page has no `<Modal>` shell, so `busyRef` (which the shell used to refuse
+  // an in-flight close) has no consumer here — a plain ref satisfies the body's
+  // contract. A route-leave busy-guard is a Phase 2 concern; Phase 1 keeps the
+  // body behaviour-identical.
+  const busyRef = useRef(false);
+
+  const query = trpc.blocks.getPublishRequest.useQuery(
+    { publishRequestId },
+    { enabled: !!features?.appBlocks && !!features?.appReviewPage, retry: false }
+  );
+
+  // Belt-and-suspenders client gate (the SSR resolver already fail-closed).
+  if (!features?.appBlocks || !features?.appReviewPage) return <NotFound />;
+
+  const selection =
+    query.data != null
+      ? {
+          request: query.data.request as unknown as AnyRequest,
+          mode: query.data.mode as OnsiteReviewMode,
+        }
+      : null;
+
+  return (
+    <>
+      <Meta title="App submission review — Civitai" deIndex />
+      <AppsPageLayout
+        size="xl"
+        title={selection ? <OnsiteReviewModalTitle selection={selection} /> : 'Submission review'}
+        actions={
+          <Button
+            component={Link}
+            href="/apps/review"
+            variant="default"
+            size="xs"
+            leftSection={<IconArrowLeft size={14} />}
+          >
+            Review queue
+          </Button>
+        }
+      >
+        {query.isLoading ? (
+          <Center py="xl">
+            <Loader size="sm" />
+          </Center>
+        ) : query.isError || !selection ? (
+          // A NOT_FOUND from the proc (deleted between SSR resolve and fetch) or
+          // any other error fails closed to the same not-found surface the SSR
+          // gate uses — never a half-rendered review.
+          <NotFound />
+        ) : (
+          <OnsiteReviewModalBody
+            // Route param remounts the page per submission (fresh approve/reject
+            // state); key parity with the modal for defensiveness.
+            key={selection.request.id}
+            selection={selection}
+            // Q6: after approve/reject, redirect to the queue (matches today's
+            // modal-close-then-invalidate — the mutation already invalidates the
+            // list queries, so the queue is fresh on arrival).
+            onClose={() => void router.push('/apps/review')}
+            busyRef={busyRef}
+          />
+        )}
+      </AppsPageLayout>
+    </>
+  );
+}

--- a/src/server/routers/__tests__/blocks.router.getPublishRequest.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getPublishRequest.test.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * REVIEW PAGE single-request read (PR #3298) — auth-surface coverage for the
+ * `blocks.getPublishRequest` proc through the REAL router (the modal→page
+ * migration's server entry point for `/apps/review/<publishRequestId>`).
+ *
+ * The proc stacks: `moderatorProcedure` (isAuthed → isMod) + `enforceAppBlocksFlag`
+ * + an in-handler `ctx.user?.isModerator` belt, then delegates to
+ * `getReviewRequestById` and maps a null result → NOT_FOUND (fail-closed;
+ * never leaks missing-vs-withdrawn). We prove, against the real middleware stack:
+ *   - a NON-moderator caller → rejected (FORBIDDEN, from `isMod`); service NOT reached.
+ *   - an ANONYMOUS caller → rejected (UNAUTHORIZED, from `isAuthed`); service NOT reached.
+ *   - a moderator (flag on) → reaches `getReviewRequestById(id)` and returns its result.
+ *   - a moderator, service returns null (missing / withdrawn / superseded) → NOT_FOUND.
+ *   - HONEST flag-off note: `getPublishRequest` is a QUERY, and `enforceAppBlocksFlag`
+ *     deliberately does NOT throw on a query when the flag is off — it passes through
+ *     (fail-open-EMPTY, `_appBlocksDisabled`). So for THIS read the moderator gate,
+ *     not the visibility flag, is the real guard: a mod with the flag off still
+ *     reaches the service. We assert that real behavior rather than a flag-off
+ *     rejection that queries never perform. (The mod segment of the live flag
+ *     resolves true for mods anyway, so no non-mod ever benefits from this.)
+ *
+ * Mock surface mirrors blocks.router.agentReview.test.ts so importing the router
+ * doesn't drag in the generated Prisma client.
+ */
+
+const {
+  mockIsAppBlocksEnabled,
+  mockIsReviewSandboxEnabled,
+  mockIsAgenticEnabled,
+  mockGetReviewRequestById,
+  mockPreviewRequest,
+  mockGetReviewStatus,
+  mockMintReviewBlockToken,
+  mockTeardownPreview,
+  mockListActivePreviews,
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockGetUserById,
+  mockGetUserBuzzAccounts,
+  mockLogToAxiom,
+  mockRedis,
+  mockSysRedis,
+  mockDbRead,
+} = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockIsReviewSandboxEnabled: vi.fn(),
+  mockIsAgenticEnabled: vi.fn(),
+  mockGetReviewRequestById: vi.fn(),
+  mockPreviewRequest: vi.fn(),
+  mockGetReviewStatus: vi.fn(),
+  mockMintReviewBlockToken: vi.fn(),
+  mockTeardownPreview: vi.fn(),
+  mockListActivePreviews: vi.fn(),
+  mockVerifyBlockToken: vi.fn(),
+  mockParseSubjectUserId: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockGetUserBuzzAccounts: vi.fn(),
+  mockLogToAxiom: vi.fn(async () => undefined),
+  mockRedis: { get: vi.fn(), set: vi.fn() },
+  mockSysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  mockDbRead: {
+    modelVersion: { findUnique: vi.fn() },
+    modelBlockInstall: { findUnique: vi.fn() },
+    model: { findUnique: vi.fn() },
+    appBlockPublishRequest: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksReviewSandboxEnabled: mockIsReviewSandboxEnabled,
+  isAppBlocksAgenticReviewEnabled: mockIsAgenticEnabled,
+}));
+// getPublishRequest dynamically imports getReviewRequestById from this module.
+vi.mock('~/server/services/blocks/publish-request.service', () => ({
+  getReviewRequestById: mockGetReviewRequestById,
+  previewRequest: mockPreviewRequest,
+  getReviewStatus: mockGetReviewStatus,
+  mintReviewBlockToken: mockMintReviewBlockToken,
+  teardownPreview: mockTeardownPreview,
+  listActiveReviewPreviews: mockListActivePreviews,
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...a: unknown[]) => mockParseSubjectUserId(...a),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
+  buildGenerationContext: vi.fn(),
+  createWorkflowStepsFromGraphInput: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(),
+}));
+vi.mock('~/server/services/user.service', () => ({
+  getUserById: (...a: unknown[]) => mockGetUserById(...a),
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: { modelBlockInstall: { findUnique: vi.fn() }, model: { findUnique: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>(
+    '@civitai/redis/client'
+  );
+  return { ...actual, redis: mockRedis, sysRedis: mockSysRedis };
+});
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getUserBuzzAccounts: (...a: unknown[]) => mockGetUserBuzzAccounts(...a),
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...a: unknown[]) => mockLogToAxiom(...a),
+}));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+// The app-blocks visibility flag resolves true for a moderator subject on the
+// live `app-blocks-enabled` flag (its `moderators` segment) — model that so the
+// mod path is exercised as it runs in prod.
+function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
+  return Promise.resolve(!!opts?.user?.isModerator);
+}
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: !!(user as { isModerator?: boolean })?.isModerator } as never,
+    track: undefined,
+  };
+}
+
+const modUser = { id: 1, isModerator: true, tier: 'free', username: 'mod' };
+const normalUser = { id: 2, isModerator: false, tier: 'free', username: 'user' };
+const PUBREQ = 'pubreq_0123456789ABCDEFGHJKMNPQRS';
+
+// The hydrated shape getReviewRequestById returns: { mode, request }, where
+// `request` carries the fields OnsiteReviewModalBody consumes on the page.
+const HYDRATED = {
+  mode: 'pending' as const,
+  request: {
+    id: PUBREQ,
+    slug: 'my-app',
+    version: '1.0.0',
+    approvalNotes: null,
+    rejectionReason: null,
+    reviewRepoUrl: 'https://forgejo.example/review/my-app',
+    pushCommitUrl: null,
+  },
+};
+
+beforeEach(() => {
+  mockIsAppBlocksEnabled.mockReset();
+  mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
+  mockGetReviewRequestById.mockReset();
+  mockGetReviewRequestById.mockResolvedValue(HYDRATED);
+});
+
+describe('blocks.getPublishRequest — mod-only review-page read', () => {
+  it('moderator + flag on: reaches getReviewRequestById(id) and returns the hydrated { mode, request }', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const res = await caller.getPublishRequest({ publishRequestId: PUBREQ });
+    expect(mockGetReviewRequestById).toHaveBeenCalledWith(PUBREQ);
+    expect(res.mode).toBe('pending');
+    expect(res.request).toMatchObject({ id: PUBREQ, slug: 'my-app' });
+  });
+
+  it('non-moderator: rejected (FORBIDDEN from isMod), service NOT reached', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(
+      caller.getPublishRequest({ publishRequestId: PUBREQ })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockGetReviewRequestById).not.toHaveBeenCalled();
+  });
+
+  it('anonymous: rejected (UNAUTHORIZED from isAuthed), service NOT reached', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(
+      caller.getPublishRequest({ publishRequestId: PUBREQ })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+    expect(mockGetReviewRequestById).not.toHaveBeenCalled();
+  });
+
+  it('moderator, service returns null (missing/withdrawn/superseded): NOT_FOUND (fail-closed, no leak of which)', async () => {
+    mockGetReviewRequestById.mockResolvedValue(null);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(
+      caller.getPublishRequest({ publishRequestId: PUBREQ })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    expect(mockGetReviewRequestById).toHaveBeenCalledWith(PUBREQ);
+  });
+
+  it('any rejection is a TRPCError (structured tRPC error, never a raw 500 leak)', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(
+      caller.getPublishRequest({ publishRequestId: PUBREQ })
+    ).rejects.toBeInstanceOf(TRPCError);
+  });
+
+  // HONEST flag-off behavior: enforceAppBlocksFlag is fail-open-EMPTY on queries
+  // (it returns next({ _appBlocksDisabled }) instead of throwing for type==='query').
+  // So a moderator with the visibility flag fully OFF still reaches the service —
+  // the moderator gate, not the flag, is what protects this read. We lock that in
+  // rather than asserting a flag-off rejection queries never perform.
+  it('moderator + app-blocks flag OFF (query fail-open-empty): NOT blocked by the flag — mod gate still reaches the service', async () => {
+    mockIsAppBlocksEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const res = await caller.getPublishRequest({ publishRequestId: PUBREQ });
+    expect(mockGetReviewRequestById).toHaveBeenCalledWith(PUBREQ);
+    expect(res.mode).toBe('pending');
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -58,6 +58,7 @@ import {
   agentReviewChatSchema,
   getAgentReviewSchema,
   getPublishRequestDiffSchema,
+  getPublishRequestSchema,
   getPublishRequestScreenshotsSchema,
   getReviewStatusSchema,
   listApprovedRequestsSchema,
@@ -1353,6 +1354,34 @@ export const blocksRouter = router({
         '~/server/services/blocks/publish-request.service'
       );
       return getPublishRequestDiff({ publishRequestId: input.publishRequestId });
+    }),
+
+  /**
+   * MOD-ONLY single-request fetch — powers the per-submission review PAGE
+   * (`/apps/review/<publishRequestId>`, `appReviewPage` flag). Returns the SAME
+   * hydrated request shape one item of `listPending/Approved/RejectedRequests`
+   * returns, plus the derived `mode`, so the extracted `OnsiteReviewModalBody`
+   * renders on the page identically to the modal path. A missing / withdrawn /
+   * superseded id → NOT_FOUND (fail-closed; never leaks which).
+   *
+   * Same auth shape as the other review reads: `moderatorProcedure` +
+   * `isModerator` belt + `enforceAppBlocksFlag` — no public path.
+   */
+  getPublishRequest: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(getPublishRequestSchema)
+    .query(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Mod review is restricted to civitai team');
+      }
+      const { getReviewRequestById } = await import(
+        '~/server/services/blocks/publish-request.service'
+      );
+      const result = await getReviewRequestById(input.publishRequestId);
+      if (!result) {
+        throw throwNotFoundError(`Publish request ${input.publishRequestId} not found`);
+      }
+      return result;
     }),
 
   /**

--- a/src/server/schema/blocks/publish-request.schema.ts
+++ b/src/server/schema/blocks/publish-request.schema.ts
@@ -131,6 +131,14 @@ export const getPublishRequestDiffSchema = z.object({
 
 export type GetPublishRequestDiffInput = z.infer<typeof getPublishRequestDiffSchema>;
 
+/** Input for the MOD-ONLY `blocks.getPublishRequest` — single-request fetch that
+ *  powers the per-submission review PAGE (`/apps/review/<publishRequestId>`). */
+export const getPublishRequestSchema = z.object({
+  publishRequestId: z.string().min(1).max(64),
+});
+
+export type GetPublishRequestInput = z.infer<typeof getPublishRequestSchema>;
+
 /** Input for the MOD-ONLY review-sandbox `blocks.previewRequest` /
  *  `blocks.getReviewStatus` (#2831). */
 export const previewRequestSchema = z.object({

--- a/src/server/services/blocks/__tests__/publish-request.reviewPage.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.reviewPage.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * REVIEW PAGE service-logic coverage (PR #3298) for
+ *   - resolveReviewRequestTarget  — the light SSR fail-close resolver
+ *     (`/apps/review/<publishRequestId>` getServerSideProps): status→mode or null.
+ *   - getReviewRequestById         — the full hydrated single-request fetch that
+ *     feeds OnsiteReviewModalBody on the page.
+ *
+ * Both perform NO authorization (the router's moderatorProcedure gates them) and
+ * both map a non-reviewable status → null via `reviewModeForStatus`
+ * (pending/approved/rejected → mode; withdrawn/superseded/anything-else → null).
+ * We prove:
+ *   - withdrawn → null (the 404 path; must not leak a withdrawn app's detail).
+ *   - pending / approved / rejected → { …, status|mode } with the correct mode.
+ *   - a non-existent id (findUnique → null) → null.
+ *   - getReviewRequestById returns a `request` carrying the fields the page body
+ *     consumes (id, slug, status-derived mode, approvalNotes/rejectionReason,
+ *     bundleSizeBytes as string, the Forgejo deep links) — shape-parity lock.
+ *
+ * dbRead + forgejo.service are dynamically imported by the service; we mock both
+ * (mirrors publish-request.reviewSandbox.test.ts) so no generated Prisma client
+ * or real Forgejo config is touched.
+ */
+
+const { mockDbRead, mockReviewRepoUrl, mockRepoCommitUrl } = vi.hoisted(() => ({
+  mockDbRead: {
+    appBlockPublishRequest: { findUnique: vi.fn() },
+  },
+  mockReviewRepoUrl: vi.fn((slug: string) => `https://forgejo.example/review/${slug}`),
+  mockRepoCommitUrl: vi.fn((slug: string, ref: string) => `https://forgejo.example/${slug}/commit/${ref}`),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: {} }));
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  reviewRepoUrl: mockReviewRepoUrl,
+  repoCommitUrl: mockRepoCommitUrl,
+}));
+
+import {
+  resolveReviewRequestTarget,
+  getReviewRequestById,
+} from '~/server/services/blocks/publish-request.service';
+
+// A full hydrated DB row shaped as getReviewRequestById's `select` returns it.
+function dbRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'pubreq_0123456789ABCDEFGHJKMNPQRS',
+    appBlockId: 'appblk_1',
+    slug: 'my-app',
+    version: '1.2.3',
+    status: 'pending',
+    submittedAt: new Date('2026-07-01T00:00:00Z'),
+    reviewedAt: null,
+    approvalNotes: null,
+    rejectionReason: null,
+    bundleSizeBytes: BigInt(4096),
+    bundleSha256: 'sha-abc',
+    manifest: { name: 'my-app' },
+    fileSummary: null,
+    manifestDiffSummary: null,
+    forgejoCommitSha: null,
+    submittedBy: { id: 7, username: 'author', image: null },
+    reviewedBy: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockDbRead.appBlockPublishRequest.findUnique.mockReset();
+  mockReviewRepoUrl.mockClear();
+  mockRepoCommitUrl.mockClear();
+});
+
+describe('resolveReviewRequestTarget — SSR status→mode fail-close', () => {
+  it('withdrawn → null (the 404 path; does not resolve a target)', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'pubreq_x',
+      status: 'withdrawn',
+    });
+    await expect(resolveReviewRequestTarget('pubreq_x')).resolves.toBeNull();
+  });
+
+  it('a superseded / unknown status → null', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'pubreq_x',
+      status: 'superseded',
+    });
+    await expect(resolveReviewRequestTarget('pubreq_x')).resolves.toBeNull();
+  });
+
+  it('non-existent id (findUnique → null) → null', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(null);
+    await expect(resolveReviewRequestTarget('pubreq_missing')).resolves.toBeNull();
+  });
+
+  it.each([
+    ['pending', 'pending'],
+    ['approved', 'approved'],
+    ['rejected', 'rejected'],
+  ])('%s → { id, status: %s } (correct mode)', async (dbStatus, expectedMode) => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'pubreq_ok',
+      status: dbStatus,
+    });
+    const res = await resolveReviewRequestTarget('pubreq_ok');
+    expect(res).toEqual({ id: 'pubreq_ok', status: expectedMode });
+  });
+});
+
+describe('getReviewRequestById — full hydrated single-request fetch', () => {
+  it('withdrawn → null (fail-closed; never hydrates a non-reviewable row)', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+      dbRow({ status: 'withdrawn' })
+    );
+    await expect(
+      getReviewRequestById('pubreq_0123456789ABCDEFGHJKMNPQRS')
+    ).resolves.toBeNull();
+  });
+
+  it('non-existent id (findUnique → null) → null', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(null);
+    await expect(getReviewRequestById('pubreq_missing')).resolves.toBeNull();
+  });
+
+  it.each([
+    ['pending', 'pending'],
+    ['approved', 'approved'],
+    ['rejected', 'rejected'],
+  ])('%s → { mode: %s, request } with the page-body fields (shape parity)', async (dbStatus, expectedMode) => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(dbRow({ status: dbStatus }));
+    const res = await getReviewRequestById('pubreq_0123456789ABCDEFGHJKMNPQRS');
+    expect(res).not.toBeNull();
+    expect(res!.mode).toBe(expectedMode);
+    // Shape-parity: the fields OnsiteReviewModalBody consumes on the page.
+    expect(res!.request).toMatchObject({
+      id: 'pubreq_0123456789ABCDEFGHJKMNPQRS',
+      slug: 'my-app',
+      version: '1.2.3',
+      approvalNotes: null,
+      rejectionReason: null,
+    });
+    // status is stripped from `request` (mode carries it) — mirrors the list builders.
+    expect((res!.request as Record<string, unknown>).status).toBeUndefined();
+    // bundle bigint is serialized to string for the tRPC/superjson path.
+    expect(res!.request.bundleSizeBytes).toBe('4096');
+    // Forgejo review-repo deep link is derived server-side from the slug.
+    expect(res!.request.reviewRepoUrl).toBe('https://forgejo.example/review/my-app');
+  });
+
+  it('a rejected detail carries the rejectionReason the history view renders', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+      dbRow({
+        status: 'rejected',
+        rejectionReason: 'uses a disallowed scope',
+        reviewedBy: { id: 9, username: 'reviewer', image: null },
+        reviewedAt: new Date('2026-07-02T00:00:00Z'),
+      })
+    );
+    const res = await getReviewRequestById('pubreq_0123456789ABCDEFGHJKMNPQRS');
+    expect(res!.mode).toBe('rejected');
+    expect(res!.request.rejectionReason).toBe('uses a disallowed scope');
+    expect(res!.request.reviewedBy).toMatchObject({ username: 'reviewer' });
+  });
+
+  it('pushCommitUrl is the canonical-commit link only for a push row (no bundle sha) with a forgejo sha', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+      dbRow({ status: 'approved', bundleSha256: null, forgejoCommitSha: 'deadbeef' })
+    );
+    const res = await getReviewRequestById('pubreq_0123456789ABCDEFGHJKMNPQRS');
+    expect(res!.request.pushCommitUrl).toBe('https://forgejo.example/my-app/commit/deadbeef');
+  });
+});

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -3229,6 +3229,110 @@ export async function resolveReviewPreviewTarget(
   return { id: row.id, slug: row.slug };
 }
 
+/** The review-page modes a single request can be opened in. Mirrors the modal's
+ *  `mode` union minus `reports` (reports are off-site listings, not publish
+ *  requests). A row in any OTHER status (`withdrawn`, superseded) is not a
+ *  reviewable detail and resolves to `null`. */
+export type ReviewRequestMode = 'pending' | 'approved' | 'rejected';
+
+function reviewModeForStatus(status: string): ReviewRequestMode | null {
+  if (status === 'pending') return 'pending';
+  if (status === 'approved') return 'approved';
+  if (status === 'rejected') return 'rejected';
+  return null;
+}
+
+/**
+ * SSR fail-close resolver for the per-submission review PAGE
+ * (`/apps/review/<publishRequestId>`) — the page analogue of
+ * {@link resolveReviewPreviewTarget}, but valid for pending/approved/rejected
+ * (the page shows history too, not only the live-preview-able pending state).
+ *
+ * Returns `{ id, status }` ONLY for an existing request in a reviewable status;
+ * `null` for a missing / withdrawn / superseded row so the page's
+ * `getServerSideProps` 404s without leaking which. Cheap (id+status only) so the
+ * SSR gate stays light; the full request payload is fetched client-side via
+ * {@link getReviewRequestById} (keeps the big manifest/diff blobs off the SSR
+ * props, and Dates on the tRPC/superjson path instead of hand-serialized).
+ *
+ * NO AUTHORIZATION here (like `resolveReviewPreviewTarget`) — leaks a slug/status
+ * by id, so EVERY caller MUST already be moderator-gated (the page resolver runs
+ * `isAppReviewer` before calling).
+ */
+export async function resolveReviewRequestTarget(
+  publishRequestId: string
+): Promise<{ id: string; status: ReviewRequestMode } | null> {
+  const { dbRead } = await import('~/server/db/client');
+  const row = await dbRead.appBlockPublishRequest.findUnique({
+    where: { id: publishRequestId },
+    select: { id: true, status: true },
+  });
+  if (!row) return null;
+  const mode = reviewModeForStatus(row.status);
+  if (!mode) return null;
+  return { id: row.id, status: mode };
+}
+
+/**
+ * Single-request fetch for the review PAGE. Returns the SAME hydrated shape one
+ * item of `listPending/Approved/RejectedRequests` returns (so the extracted
+ * `OnsiteReviewModalBody` renders identically to the modal path), plus the
+ * derived `mode`. Includes the reviewer profile + approval-notes / rejection-
+ * reason so an approved/rejected detail shows the same read-only history the
+ * list tabs surface. Returns `null` for a missing / non-reviewable row.
+ *
+ * MOD-ONLY: like the list builders it performs no authorization — the router
+ * (`moderatorProcedure` + `enforceAppBlocksFlag`) gates it.
+ */
+export async function getReviewRequestById(publishRequestId: string): Promise<{
+  mode: ReviewRequestMode;
+  request: Record<string, unknown>;
+} | null> {
+  const [{ dbRead }, { reviewRepoUrl, repoCommitUrl }] = await Promise.all([
+    import('~/server/db/client'),
+    import('./forgejo.service'),
+  ]);
+  const r = await dbRead.appBlockPublishRequest.findUnique({
+    where: { id: publishRequestId },
+    select: {
+      id: true,
+      appBlockId: true,
+      slug: true,
+      version: true,
+      status: true,
+      submittedAt: true,
+      reviewedAt: true,
+      approvalNotes: true,
+      rejectionReason: true,
+      bundleSizeBytes: true,
+      bundleSha256: true,
+      manifest: true,
+      fileSummary: true,
+      manifestDiffSummary: true,
+      forgejoCommitSha: true,
+      submittedBy: { select: { id: true, username: true, image: true } },
+      reviewedBy: { select: { id: true, username: true, image: true } },
+    },
+  });
+  if (!r) return null;
+  const mode = reviewModeForStatus(r.status);
+  if (!mode) return null;
+
+  // Match the list builders' row mapping exactly (bundle bigint → string,
+  // Forgejo review-repo deep link, push-row canonical-commit link).
+  const { status, ...rest } = r;
+  const request = {
+    ...rest,
+    bundleSizeBytes: r.bundleSizeBytes.toString(),
+    reviewRepoUrl: reviewRepoUrl(r.slug),
+    pushCommitUrl:
+      !r.bundleSha256 && r.forgejoCommitSha
+        ? repoCommitUrl(r.slug, r.forgejoCommitSha)
+        : null,
+  };
+  return { mode, request };
+}
+
 export type MintReviewBlockTokenResult = {
   /** The signed, self-bound, scope-stripped block JWT for the review preview. */
   token: string;

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -425,6 +425,20 @@ const featureFlags = createFeatureFlags({
   // only on-switch + kill-switch. (Mirrors the `hiddenPrefsCompact` /
   // `genTabDeferView` `availability: []` precedent.)
   appBlocksAgenticReview: { availability: [], fliptKey: 'app-blocks-agentic-review' },
+  // App Blocks — dedicated per-submission REVIEW PAGE (`/apps/review/<id>`). A
+  // flag-gated, deep-linkable full page that re-hosts the existing on-site review
+  // body (today a modal on `/apps/review`) so mods can open, share, and refresh a
+  // single submission. `availability: ['mod']` (NOT `[]`): mods get the page the
+  // moment this ships — the page is a re-host of the already-live review UI (no
+  // new capability, no unapproved-code execution beyond what the modal already
+  // does), so dogfooding on merge is the intent. A non-mod still fails closed:
+  // 'mod' availability → static false for any non-mod segment AND the page's SSR
+  // gate additionally requires `isAppReviewer`. The Flipt `app-review-page` flag
+  // (created later) is the widen/kill lever; absent → this static mod-only default.
+  // Wired like `appBlocksAgenticReview` (client reads `features.appReviewPage`,
+  // the route SSR resolver reads the same resolved flag) but staged `['mod']`
+  // rather than `[]` because it's a re-host, not a brand-new dark capability.
+  appReviewPage: { availability: ['mod'], fliptKey: 'app-review-page' },
 });
 
 export const featureFlagKeys = Object.keys(featureFlags) as FeatureFlagKey[];

--- a/src/tests/pages/apps/review/review-detail-page-gate.test.ts
+++ b/src/tests/pages/apps/review/review-detail-page-gate.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * PER-SUBMISSION REVIEW PAGE SSR gate (`/apps/review/<publishRequestId>`).
+ *
+ * Mirrors `review-preview-page-gate.test.ts`: mock `createServerSideProps` to
+ * capture the resolver, then invoke it with a controlled `features`/`session`/
+ * `ctx`. The gate must mirror `/apps/review` PLUS the new `appReviewPage` flag —
+ * `appBlocks` off → 404, `appReviewPage` off → 404, no session → login redirect,
+ * non-moderator → 404, missing id → 404, missing/withdrawn request
+ * (`resolveReviewRequestTarget` → null) → 404, valid → typed props.
+ *
+ * Lives under `src/tests/` (NOT co-located under `src/pages/`) — Next treats
+ * every file under `pages/` as a route needing a default export.
+ */
+
+const { capturedResolver } = vi.hoisted(() => ({
+  capturedResolver: { fn: null as null | ((c: any) => Promise<any>) },
+}));
+
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: (opts: { resolver: (c: any) => Promise<any> }) => {
+    capturedResolver.fn = opts.resolver;
+    return async () => ({ props: {} });
+  },
+}));
+
+const { mockResolveReviewRequestTarget } = vi.hoisted(() => ({
+  mockResolveReviewRequestTarget: vi.fn<(...a: any[]) => Promise<any>>(),
+}));
+vi.mock('~/server/services/blocks/publish-request.service', () => ({
+  resolveReviewRequestTarget: mockResolveReviewRequestTarget,
+}));
+
+vi.mock('~/utils/login-helpers', () => ({
+  getLoginLink: ({ returnUrl }: { returnUrl: string }) => `/login?returnUrl=${returnUrl}`,
+}));
+
+// Stub the heavy client-only imports the page module pulls at top so importing
+// it in a node unit test doesn't drag a DOM in. The resolver (unit under test)
+// touches none of them. `isAppReviewer` is left REAL (pure predicate) so the
+// moderator gate is exercised for real.
+vi.mock('@mantine/core', () => ({
+  Button: () => null,
+  Center: () => null,
+  Loader: () => null,
+}));
+vi.mock('@tabler/icons-react', () => ({ IconArrowLeft: () => null }));
+vi.mock('next/link', () => ({ default: () => null }));
+vi.mock('~/components/AppLayout/NotFound', () => ({ NotFound: () => null }));
+vi.mock('~/components/Apps/AppsPageLayout', () => ({ AppsPageLayout: () => null }));
+vi.mock('~/components/Apps/OnsiteReviewModal', () => ({
+  OnsiteReviewModalBody: () => null,
+  OnsiteReviewModalTitle: () => null,
+}));
+vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true, appReviewPage: true }),
+}));
+vi.mock('~/utils/trpc', () => ({ trpc: { blocks: { getPublishRequest: { useQuery: () => ({}) } } } }));
+
+function makeCtx(
+  opts: {
+    appBlocks?: boolean;
+    appReviewPage?: boolean;
+    user?: { isModerator?: boolean } | null;
+    publishRequestId?: string | undefined;
+    resolvedUrl?: string;
+  } = {}
+) {
+  const {
+    appBlocks = true,
+    appReviewPage = true,
+    user = { isModerator: true } as { isModerator?: boolean } | null,
+    resolvedUrl = '/apps/review/pubreq_1',
+  } = opts;
+  // Read via `in` so an EXPLICIT `{ publishRequestId: undefined }` models a
+  // missing route param (a destructuring default would wrongly re-apply the id).
+  const publishRequestId = 'publishRequestId' in opts ? opts.publishRequestId : 'pubreq_1';
+  return {
+    features: { appBlocks, appReviewPage },
+    session: user ? { user } : null,
+    ctx: { params: { publishRequestId }, resolvedUrl },
+  };
+}
+
+async function loadResolver() {
+  await import('~/pages/apps/review/[publishRequestId]');
+  if (!capturedResolver.fn) throw new Error('resolver not captured');
+  return capturedResolver.fn;
+}
+
+describe('review detail page SSR — moderator + flag gate', () => {
+  beforeEach(() => {
+    // Only reset the service mock — NOT capturedResolver (ESM module cache means
+    // createServerSideProps captures the resolver on the FIRST import only).
+    mockResolveReviewRequestTarget.mockReset();
+  });
+
+  it('404s when the appBlocks flag is off', async () => {
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ appBlocks: false }));
+    expect(result).toEqual({ notFound: true });
+    expect(mockResolveReviewRequestTarget).not.toHaveBeenCalled();
+  });
+
+  it('404s when the appReviewPage flag is off (dark by default for a non-mod cohort)', async () => {
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ appReviewPage: false }));
+    expect(result).toEqual({ notFound: true });
+    expect(mockResolveReviewRequestTarget).not.toHaveBeenCalled();
+  });
+
+  it('redirects to login when there is no session', async () => {
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ user: null }));
+    expect(result.redirect?.destination).toContain('/login');
+    expect(result.redirect?.permanent).toBe(false);
+  });
+
+  it('404s for a logged-in NON-moderator', async () => {
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ user: { isModerator: false } }));
+    expect(result).toEqual({ notFound: true });
+    expect(mockResolveReviewRequestTarget).not.toHaveBeenCalled();
+  });
+
+  it('404s when the publishRequestId param is missing', async () => {
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ publishRequestId: undefined }));
+    expect(result).toEqual({ notFound: true });
+    expect(mockResolveReviewRequestTarget).not.toHaveBeenCalled();
+  });
+
+  it('404s when the request is missing / withdrawn (resolver returns null)', async () => {
+    mockResolveReviewRequestTarget.mockResolvedValue(null);
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ publishRequestId: 'pubreq_missing' }));
+    expect(result).toEqual({ notFound: true });
+    expect(mockResolveReviewRequestTarget).toHaveBeenCalledWith('pubreq_missing');
+  });
+
+  it('returns props with the resolved id for a valid moderator + reviewable request', async () => {
+    mockResolveReviewRequestTarget.mockResolvedValue({ id: 'pubreq_1', status: 'pending' });
+    const resolver = await loadResolver();
+    const result = await resolver(makeCtx({ publishRequestId: 'pubreq_1' }));
+    expect(result).toEqual({ props: { publishRequestId: 'pubreq_1' } });
+  });
+});

--- a/src/tests/pages/apps/review/review-detail-page.browser.test.tsx
+++ b/src/tests/pages/apps/review/review-detail-page.browser.test.tsx
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../../test/component-setup';
+import { useRouter } from 'next/router';
+
+/**
+ * PER-SUBMISSION REVIEW PAGE — route-shell render test (browser mode).
+ *
+ * Complements the SSR-gate node test (`review-detail-page-gate.test.ts`): this
+ * drives the CLIENT shell of `/apps/review/<id>` and asserts the Phase-1 wiring —
+ * it reads the `publishRequestId` prop, fetches the request, re-hosts the
+ * extracted `OnsiteReviewModalBody` with the resolved `{ request, mode }`, wires
+ * the Q6 redirect-to-queue `onClose`, and fails closed (NotFound) when the flag
+ * is off / the fetch errors. The body itself is stubbed — its render is covered
+ * by `OnsiteReviewModal.browser.test.tsx` (behaviour-preserving extraction).
+ */
+
+const state = vi.hoisted(() => ({
+  // getPublishRequest.useQuery control object.
+  query: { data: undefined as unknown, isLoading: false, isError: false, error: null as unknown },
+  // Captured props the page passes to the (stubbed) review body.
+  bodyProps: { last: null as null | { selection: any; onClose: () => void } },
+  // Feature-flags the page sees (switchable per test).
+  flags: { appBlocks: true, appReviewPage: true } as Record<string, boolean>,
+}));
+
+// The page's `getServerSideProps` calls createServerSideProps at module top —
+// stub it so importing the page in a browser test doesn't pull the server graph.
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: () => async () => ({ props: {} }),
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => state.flags,
+}));
+
+// Stub the extracted body/title so we assert the SHELL wiring (props + gate),
+// not re-run the body's own covered behaviour.
+vi.mock('~/components/Apps/OnsiteReviewModal', () => ({
+  OnsiteReviewModalBody: (props: { selection: any; onClose: () => void }) => {
+    state.bodyProps.last = props;
+    return <div data-testid="review-body">body:{props.selection.request.id}:{props.selection.mode}</div>;
+  },
+  OnsiteReviewModalTitle: ({ selection }: { selection: any }) => (
+    <div data-testid="review-title">{selection.request.slug}</div>
+  ),
+}));
+
+// Pass-through layout so title/actions/children are all in the DOM.
+vi.mock('~/components/Apps/AppsPageLayout', () => ({
+  AppsPageLayout: ({ title, actions, children }: any) => (
+    <div data-testid="layout">
+      <div>{title}</div>
+      <div>{actions}</div>
+      <div>{children}</div>
+    </div>
+  ),
+}));
+
+vi.mock('~/components/AppLayout/NotFound', () => ({
+  NotFound: () => <div data-testid="not-found">Not found</div>,
+}));
+vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    blocks: {
+      getPublishRequest: { useQuery: () => state.query },
+    },
+  },
+}));
+
+const ReviewDetailPage = (await import('~/pages/apps/review/[publishRequestId]')).default;
+
+const REQUEST = {
+  id: 'pubreq_1',
+  slug: 'my-onsite-block',
+  version: '1.2.0',
+  submittedAt: new Date('2026-01-01T00:00:00Z'),
+  bundleSizeBytes: '2048',
+  submittedBy: { id: 7, username: 'dev-user', image: null },
+  manifest: {},
+  fileSummary: {},
+  manifestDiffSummary: { kind: 'first-version', fields: [] },
+  reviewRepoUrl: 'https://forgejo.example/repo',
+};
+
+beforeEach(() => {
+  state.query = { data: undefined, isLoading: false, isError: false, error: null };
+  state.bodyProps.last = null;
+  state.flags = { appBlocks: true, appReviewPage: true };
+});
+
+describe('ReviewDetailPage — route shell', () => {
+  test('renders the re-hosted review body with the resolved request + mode when the fetch resolves', async () => {
+    state.query = {
+      data: { mode: 'pending', request: REQUEST },
+      isLoading: false,
+      isError: false,
+      error: null,
+    };
+    renderWithProviders(<ReviewDetailPage publishRequestId="pubreq_1" />);
+
+    await expect.element(page.getByTestId('review-body')).toBeInTheDocument();
+    // The body received the resolved request id + mode (proves the shell threads
+    // the fetched `{ request, mode }` into the extracted body, not the modal).
+    await expect.element(page.getByTestId('review-body')).toHaveTextContent('body:pubreq_1:pending');
+    // The page header uses the shared modal title component.
+    await expect.element(page.getByTestId('review-title')).toHaveTextContent('my-onsite-block');
+    // No fail-closed surface on the happy path.
+    expect(page.getByTestId('not-found').elements()).toHaveLength(0);
+  });
+
+  test('shows a loader (no body, no NotFound) while the fetch is in flight', async () => {
+    state.query = { data: undefined, isLoading: true, isError: false, error: null };
+    renderWithProviders(<ReviewDetailPage publishRequestId="pubreq_1" />);
+    // Loading branch: neither the body nor the fail-closed surface is shown yet.
+    expect(page.getByTestId('review-body').elements()).toHaveLength(0);
+    expect(page.getByTestId('not-found').elements()).toHaveLength(0);
+  });
+
+  test('fails closed to NotFound (belt-and-suspenders) when the appReviewPage flag is off', async () => {
+    state.flags = { appBlocks: true, appReviewPage: false };
+    state.query = {
+      data: { mode: 'pending', request: REQUEST },
+      isLoading: false,
+      isError: false,
+      error: null,
+    };
+    renderWithProviders(<ReviewDetailPage publishRequestId="pubreq_1" />);
+    await expect.element(page.getByTestId('not-found')).toBeInTheDocument();
+    expect(page.getByTestId('review-body').elements()).toHaveLength(0);
+  });
+
+  test('fails closed to NotFound when the fetch errors (deleted between SSR resolve and fetch)', async () => {
+    state.query = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: { message: 'NOT_FOUND' },
+    };
+    renderWithProviders(<ReviewDetailPage publishRequestId="pubreq_gone" />);
+    await expect.element(page.getByTestId('not-found')).toBeInTheDocument();
+    expect(page.getByTestId('review-body').elements()).toHaveLength(0);
+  });
+
+  test('Q6: the body onClose redirects to the review queue', async () => {
+    state.query = {
+      data: { mode: 'pending', request: REQUEST },
+      isLoading: false,
+      isError: false,
+      error: null,
+    };
+    renderWithProviders(<ReviewDetailPage publishRequestId="pubreq_1" />);
+    await expect.element(page.getByTestId('review-body')).toBeInTheDocument();
+
+    // Fire the onClose the shell handed the body (what runs after approve/reject
+    // success) and assert it navigates back to the queue.
+    const push = vi.mocked((useRouter as any)()).push as ReturnType<typeof vi.fn>;
+    push.mockClear();
+    state.bodyProps.last?.onClose();
+    expect(push).toHaveBeenCalledWith('/apps/review');
+  });
+});

--- a/src/tests/pages/apps/review/review-queue-nav.browser.test.tsx
+++ b/src/tests/pages/apps/review/review-queue-nav.browser.test.tsx
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../../test/component-setup';
+import { useRouter } from 'next/router';
+
+/**
+ * REVIEW QUEUE dual-path row selection (Phase 1 migration) — browser mode.
+ *
+ * With the `appReviewPage` flag ON a row NAVIGATES to the deep-linkable detail
+ * page `/apps/review/<id>`; with the flag OFF it opens the modal exactly as
+ * before (the reversible dual-path). Asserts both branches on the pending queue.
+ *
+ * Heavy siblings (`AppListingsModerationTable`, `ActivePreviewsPanel`,
+ * `OffsiteReportsQueue`) + the review modal are stubbed so this isolates the
+ * QUEUE's selection behaviour; `formatBytes`/`formatDate` are kept REAL (via
+ * `importOriginal`) so the row renders faithfully.
+ */
+
+const state = vi.hoisted(() => ({
+  flags: { appBlocks: true, appReviewPage: true } as Record<string, boolean>,
+}));
+
+// Page's getServerSideProps calls createServerSideProps at module top — stub so
+// importing the page doesn't pull the server graph into the browser bundle.
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: () => async () => ({ props: {} }),
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => state.flags,
+}));
+
+// Stub the modal component (assert whether a selection opened it) but keep the
+// real byte/date formatters + request types the queue table depends on.
+vi.mock('~/components/Apps/OnsiteReviewModal', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/components/Apps/OnsiteReviewModal')>();
+  return {
+    ...actual,
+    OnsiteReviewModal: ({ selection }: { selection: { request: { slug: string } } | null }) =>
+      selection ? <div data-testid="modal-open">{selection.request.slug}</div> : null,
+  };
+});
+
+// Pass-through layout — the real one renders `AppsSubNav` → `useCurrentUser`,
+// which needs the CivitaiSession context this network-free test doesn't mount.
+vi.mock('~/components/Apps/AppsPageLayout', () => ({
+  AppsPageLayout: ({ children }: any) => <div>{children}</div>,
+}));
+vi.mock('~/components/Apps/AppListingsModerationTable', () => ({
+  AppListingsModerationTable: () => null,
+}));
+vi.mock('~/components/Apps/ActivePreviewsPanel', () => ({ ActivePreviewsPanel: () => null }));
+vi.mock('~/components/Apps/OffsiteReviewQueue', () => ({ OffsiteReportsQueue: () => null }));
+vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
+
+const PENDING = {
+  id: 'onsite-req-1',
+  appBlockId: null,
+  slug: 'my-onsite-block',
+  version: '1.2.0',
+  submittedAt: new Date('2026-01-01T00:00:00Z'),
+  bundleSizeBytes: '2048',
+  bundleSha256: 'abc',
+  manifest: {},
+  fileSummary: { files: [{ path: 'index.js', sha256: 'x', sizeBytes: 10 }], added: [], removed: [], changed: [] },
+  manifestDiffSummary: { kind: 'first-version', fields: [] },
+  reviewRepoUrl: 'https://forgejo.example/repo',
+  pushCommitUrl: null,
+  submittedBy: { id: 7, username: 'dev-user', image: null },
+};
+
+const inert = { invalidate: vi.fn() };
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    useUtils: () => ({ blocks: { listPendingRequests: inert, listApprovedRequests: inert, listRejectedRequests: inert } }),
+    blocks: {
+      listPendingRequests: {
+        useQuery: () => ({ data: { items: [PENDING] }, isLoading: false, isError: false, error: null }),
+      },
+      listApprovedRequests: {
+        useQuery: () => ({ data: { items: [] }, isLoading: false, isError: false, error: null }),
+      },
+      listRejectedRequests: {
+        useQuery: () => ({ data: { items: [] }, isLoading: false, isError: false, error: null }),
+      },
+    },
+  },
+}));
+
+const ReviewQueuePage = (await import('~/pages/apps/review')).default;
+
+function routerPush() {
+  return (useRouter() as unknown as { push: ReturnType<typeof vi.fn> }).push;
+}
+
+beforeEach(() => {
+  state.flags = { appBlocks: true, appReviewPage: true };
+  routerPush().mockClear();
+});
+
+describe('ReviewQueuePage — dual-path row selection', () => {
+  test('flag ON: clicking a pending row NAVIGATES to /apps/review/<id> (no modal)', async () => {
+    state.flags = { appBlocks: true, appReviewPage: true };
+    renderWithProviders(<ReviewQueuePage />);
+
+    const reviewBtn = page.getByRole('button', { name: 'Review' });
+    await expect.element(reviewBtn).toBeInTheDocument();
+    await userEvent.click(reviewBtn);
+
+    expect(routerPush()).toHaveBeenCalledWith('/apps/review/onsite-req-1');
+    // No modal opened on the page path.
+    expect(page.getByTestId('modal-open').elements()).toHaveLength(0);
+  });
+
+  test('flag OFF: clicking a pending row OPENS the modal (no navigation)', async () => {
+    state.flags = { appBlocks: true, appReviewPage: false };
+    renderWithProviders(<ReviewQueuePage />);
+
+    const reviewBtn = page.getByRole('button', { name: 'Review' });
+    await expect.element(reviewBtn).toBeInTheDocument();
+    await userEvent.click(reviewBtn);
+
+    // Modal opened with the selected request; NO navigation to the detail page.
+    await expect.element(page.getByTestId('modal-open')).toHaveTextContent('my-onsite-block');
+    expect(routerPush()).not.toHaveBeenCalledWith('/apps/review/onsite-req-1');
+  });
+});


### PR DESCRIPTION
## What this is

**Phase 1** (foundation) of the App Blocks moderator review-page migration: a **flag-gated, deep-linkable full page** that RE-HOSTS the existing on-site review body. This is intentionally **not** the tabs/report redesign — the report renders via the existing `AgentReviewPanel`/`ReportBody` as-is. The redesign is **Phase 2**.

Fully reversible dual-path: with the flag off, the queue keeps opening today's modal.

## What's in it

**1. Flag** — `appReviewPage: { availability: ['mod'], fliptKey: 'app-review-page' }` in `feature-flags.service.ts`. Mods get the page on merge (it's a re-host of already-live review UI, not a new dark capability), so we dogfood immediately; a non-mod fails closed (`['mod']` → static false for any non-mod segment, **plus** the page's `isAppReviewer` SSR gate). Wired like `appBlocksAgenticReview` (client reads `features.appReviewPage`; the SSR resolver reads the same resolved flag). The Flipt `app-review-page` flag (created later) is the widen/kill lever.

**2. Route** `src/pages/apps/review/[publishRequestId].tsx` — mirrors the existing preview route's three-stage fail-closed SSR gate (`appBlocks` → `appReviewPage` → session→login → `isAppReviewer` → resolve id) + `deIndex`. The full request is fetched **client-side** via a new `blocks.getPublishRequest` proc; SSR carries only the validated id (keeps the big manifest/diff blobs off the HTML and Dates on the tRPC/superjson path). Renders the **extracted** `OnsiteReviewModalBody` WITHOUT the `<Modal>` shell; after approve/reject it redirects to `/apps/review` (Q6 — matches today's modal-close-then-invalidate). Missing/withdrawn id → NotFound at both SSR and client.

**3. Single-request fetch** — new `getReviewRequestById` + `resolveReviewRequestTarget` service fns (mirroring `resolveReviewPreviewTarget`, but valid for pending/approved/rejected) returning the **same hydrated shape as one list item** so the body renders identically. New mod-gated `blocks.getPublishRequest` proc (`moderatorProcedure` + `enforceAppBlocksFlag`, same auth shape as the other review reads).

**4. Queue dual-path** (`src/pages/apps/review.tsx`) — under `appReviewPage`, a row NAVIGATES to `/apps/review/<id>`; with the flag off it opens the modal exactly as before.

## How the extraction was done (behaviour-preserving)

`OnsiteReviewModalBody` and `OnsiteReviewModalTitle` were **already separate components** inside `OnsiteReviewModal.tsx` — the modal shell (`<Modal opened onClose>`) just mounts the body keyed on the request id. Phase 1 only **exports** those two functions; the modal shell, its `busyRef` close-guard, and every section are unchanged. The page passes a resolved `selection`, an `onClose` that redirects to the queue, and its own `busyRef`. The existing 14 `OnsiteReviewModal.browser.test.tsx` tests **still pass**, confirming the modal path is untouched. Section boundaries were kept offsite-reusable per Q7 — no modal-only assumptions were baked into the shared body.

## Deferred to Phase 2 (NOT in this PR)

Tabbed report sections, the wall-of-text report redesign, `summaryMd`→markdown, and the deep a11y pass (focus-to-main, `aria-live`, sticky action bar).

## Tests & gates (honest results)

- **`tsc --noEmit`**: 0 errors reference any changed/new file. The 26 pre-existing errors are the known environmental ones (`kysely` workspace pkg uninstalled, `event-engine-common` submodule not checked out, and the `isOfficial`/stale-Prisma-client from the just-merged #3297) — none in this change.
- **SSR gate** (`review-detail-page-gate.test.ts`, unit): **7/7 pass** — appBlocks-off / appReviewPage-off / no-session / non-mod / missing-id / resolver-null all 404 (or login-redirect); valid mod → props.
- **Route shell** (`review-detail-page.browser.test.tsx`, browser): **5/5 pass** — renders the re-hosted body with the resolved `{request, mode}`, loader while fetching, NotFound on flag-off and on fetch error, and the Q6 onClose→`/apps/review` redirect.
- **Queue dual-path** (`review-queue-nav.browser.test.tsx`, browser): **2/2 pass** — flag ON → navigates to `/apps/review/<id>` (no modal); flag OFF → opens the modal (no nav).
- **Regression**: existing `OnsiteReviewModal.browser.test.tsx` **14/14 pass** unchanged. Full combined run of all three browser files: **21/21 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)