### PR TITLE
feat(profile): responsive density for the profile nav bar

### DIFF
--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -123,7 +123,7 @@ export function MainContent({
 } & ScrollAreaProps) {
   return scrollable ? (
     <ScrollArea {...props}>
-      <main className="flex-1">
+      <main className="min-w-0 flex-1">
         {subNav && (
           <SubNav>
             <RewardsBonusBanner />

--- a/src/components/HomeContentToggle/HomeStyleSegmentedControl.module.css
+++ b/src/components/HomeContentToggle/HomeStyleSegmentedControl.module.css
@@ -109,9 +109,12 @@
   transition-delay: 500ms;
 }
 
-/* Active pill shows its label permanently, no delay. */
+/* Active pill shows its label permanently; keyboard focus reveals it too (no
+   delay) so a tabbing user isn't left on an unlabeled icon. */
 .container[data-density='2'] .pill[data-active] .tabLabel,
-.container[data-density='3'] .pill[data-active] .tabLabel {
+.container[data-density='3'] .pill[data-active] .tabLabel,
+.container[data-density='2'] .pill:focus-visible .tabLabel,
+.container[data-density='3'] .pill:focus-visible .tabLabel {
   grid-template-columns: 1fr;
   margin-inline-start: 6px;
 }
@@ -133,7 +136,9 @@
 .container[data-density='2'] .pill:not(:has(.tabCount)):hover .tabLabel,
 .container[data-density='3'] .pill:not(:has(.tabCount)):hover .tabLabel,
 .container[data-density='2'] .pill:not(:has(.tabCount))[data-active] .tabLabel,
-.container[data-density='3'] .pill:not(:has(.tabCount))[data-active] .tabLabel {
+.container[data-density='3'] .pill:not(:has(.tabCount))[data-active] .tabLabel,
+.container[data-density='2'] .pill:not(:has(.tabCount)):focus-visible .tabLabel,
+.container[data-density='3'] .pill:not(:has(.tabCount)):focus-visible .tabLabel {
   margin-inline-end: 4px;
 }
 
@@ -146,7 +151,9 @@
   display: inline-flex;
 }
 
-/* Shop tab accent — mirrors the primary subnav's shop highlight. */
+/* Shop tab accent — mirrors HomeContentToggle.module.css `.tabHighlight`. Kept
+   in sync by hand: this bundler's CSS modules reject `composes` here, and a
+   global utility isn't worth the churn for one accent. */
 .tabHighlight {
   background-color: light-dark(
     alpha(var(--mantine-color-yellow-3), 0.3),

--- a/src/components/HomeContentToggle/HomeStyleSegmentedControl.module.css
+++ b/src/components/HomeContentToggle/HomeStyleSegmentedControl.module.css
@@ -1,9 +1,8 @@
 .container {
   position: relative;
-  /* Inset lives on the non-scrolling container so it always holds, unlike
-     padding inside the scroll area which slides out of view. Matches the
-     primary subnav's px-2 py-1. */
-  padding-inline: 8px;
+  /* Vertical inset matches the primary subnav's py-1. Horizontal inset lives on
+     the scroll area (below) so scrolled items bleed to the physical edge instead
+     of being clipped short by container padding. */
   padding-block: 4px;
 
   &:hover {
@@ -21,6 +20,9 @@
   align-items: center;
   gap: 4px;
   max-width: 100%;
+  /* First/last pills rest inset from the edges, but scroll flush to them so
+     partially-scrolled pills bleed to the edge rather than looking truncated. */
+  padding-inline: 8px;
   overflow-x: auto;
   overflow-y: hidden;
 

--- a/src/components/HomeContentToggle/HomeStyleSegmentedControl.module.css
+++ b/src/components/HomeContentToggle/HomeStyleSegmentedControl.module.css
@@ -1,52 +1,151 @@
-.label {
-  padding: 6px 10px;
-}
-
 .container {
   position: relative;
+  /* Inset lives on the non-scrolling container so it always holds, unlike
+     padding inside the scroll area which slides out of view. Matches the
+     primary subnav's px-2 py-1. */
+  padding-inline: 8px;
+  padding-block: 4px;
 
   &:hover {
-    .scrollArea {
-      &::-webkit-scrollbar {
-        opacity: 1;
-      }
-
-      &::-webkit-scrollbar-thumb {
-        background-color: light-dark(
-          alpha(var(--mantine-color-black), 0.5),
-          alpha(var(--mantine-color-white), 0.5)
-        );
-      }
+    .root::-webkit-scrollbar-thumb {
+      background-color: light-dark(
+        alpha(var(--mantine-color-black), 0.5),
+        alpha(var(--mantine-color-white), 0.5)
+      );
     }
   }
 }
 
 .root {
-  overflow: auto;
-  scroll-snap-type: x mandatory;
-  background-color: transparent;
-  gap: 8px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
   max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
 
   &::-webkit-scrollbar {
     background: transparent;
-    opacity: 0;
     height: 8px;
   }
 
   &::-webkit-scrollbar-thumb {
     border-radius: 4px;
+    background-color: transparent;
   }
 }
 
-.control {
-  border: none !important;
+.pill {
+  flex: none;
 }
 
-/* Mirrors the main content-nav's Shop tab highlight (HomeContentToggle.module.css). */
+/* Mantine wins the var battle here, so pin the badge font + padding hard. The
+   count would otherwise inherit the pill's `text-base`. min-width = height keeps
+   a single-digit count a circle; symmetric padding lets multi-digit grow. */
+.tabCount {
+  --badge-fz: 11px;
+  --badge-height: 18px;
+  min-width: 18px !important;
+  height: 18px !important;
+  padding-inline: 4px !important;
+  font-size: 11px !important;
+  font-weight: 600;
+  /* Mantine's Badge forces `cursor: default`; let clicks + the link's pointer
+     cursor pass through to the pill instead. */
+  pointer-events: none;
+}
+
+.tabCount :global(.mantine-Badge-label) {
+  font-size: 11px !important;
+}
+
+/* Compact (density >= 2): floor each pill's width to its height (h-8 = 32px) so
+   an icon-only pill renders as a circle; icon + stat pills grow past it. */
+.container[data-density='2'] .pill,
+.container[data-density='3'] .pill {
+  min-width: 32px;
+}
+
+/* Keep a persistent chip background on non-active pills so the icon + stat read
+   as one grouped, clickable unit. At full size the row only chips on hover
+   (Mantine `default` variant), matching the primary subnav; shop keeps its own
+   highlight. */
+.container[data-density='2'] .pill:not([data-active]):not(.tabHighlight),
+.container[data-density='3'] .pill:not([data-active]):not(.tabHighlight) {
+  background-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+}
+
+/* Level 2/3: collapse the label to zero width, reveal it on hover (or when
+   active) with the grid 0fr -> 1fr trick. It animates to the exact content
+   width — no guessed max-width, no jank — and the count slides right as it opens. */
+/* Compact spacing runs on animated margins (not flex gap) so a collapsed label
+   leaves no dead space and the lone icon stays perfectly centered. */
+.container[data-density='2'] .tabLabel,
+.container[data-density='3'] .tabLabel {
+  display: grid;
+  grid-template-columns: 0fr;
+  margin-inline-start: 0;
+  transition: grid-template-columns 160ms ease, margin 160ms ease;
+}
+
+.container[data-density='2'] .tabLabelInner,
+.container[data-density='3'] .tabLabelInner {
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  /* Padding gives descenders (the g in "Images") room inside the overflow clip;
+     the negative margin cancels the added height so vertical centering holds. */
+  padding-block: 2px;
+  margin-block: -2px;
+}
+
+/* Hover reveal — delayed so a quick pass-over doesn't twitch it open. */
+.container[data-density='2'] .pill:hover .tabLabel,
+.container[data-density='3'] .pill:hover .tabLabel {
+  grid-template-columns: 1fr;
+  margin-inline-start: 6px;
+  transition-delay: 500ms;
+}
+
+/* Active pill shows its label permanently, no delay. */
+.container[data-density='2'] .pill[data-active] .tabLabel,
+.container[data-density='3'] .pill[data-active] .tabLabel {
+  grid-template-columns: 1fr;
+  margin-inline-start: 6px;
+}
+
+/* Space the count off the icon/label when it's shown in compact. */
+.container[data-density='2'] .tabCount,
+.container[data-density='3'] .pill[data-active] .tabCount {
+  margin-inline-start: 4px;
+}
+
+/* Stat-less pills (Overview, Shop) have no trailing badge, so their label butts
+   up against the right edge — add a little breathing room after it. Scoped to
+   the revealed/full states so collapsed compact circles stay round. */
+.container[data-density='0'] .pill:not(:has(.tabCount)) .tabLabel,
+.container[data-density='1'] .pill:not(:has(.tabCount)) .tabLabel {
+  margin-inline-end: 3px;
+}
+
+.container[data-density='2'] .pill:not(:has(.tabCount)):hover .tabLabel,
+.container[data-density='3'] .pill:not(:has(.tabCount)):hover .tabLabel,
+.container[data-density='2'] .pill:not(:has(.tabCount))[data-active] .tabLabel,
+.container[data-density='3'] .pill:not(:has(.tabCount))[data-active] .tabLabel {
+  margin-inline-end: 4px;
+}
+
+/* Level 3: also drop counts, leaving icon-only. Active pill keeps its count. */
+.container[data-density='3'] .tabCount {
+  display: none;
+}
+
+.container[data-density='3'] .pill[data-active] .tabCount {
+  display: inline-flex;
+}
+
+/* Shop tab accent — mirrors the primary subnav's shop highlight. */
 .tabHighlight {
-  padding: 4px 12px;
-  border-radius: var(--mantine-radius-xl);
   background-color: light-dark(
     alpha(var(--mantine-color-yellow-3), 0.3),
     alpha(var(--mantine-color-yellow-3), 0.1)
@@ -61,32 +160,7 @@
   background-position: -300% 50%;
   background-repeat: no-repeat;
   color: light-dark(var(--mantine-color-yellow-8), var(--mantine-color-yellow-3));
-  /* `button-highlight` is a global keyframes (src/styles/globals.css); it stays
-     global because no local @keyframes of that name exists in this module. */
+  /* `button-highlight` is a global keyframes (src/styles/globals.css). */
   animation: button-highlight 5s linear infinite;
   will-change: background-position;
-
-  /* The label carries `text-black dark:text-white`, and the icon inherits the
-     control's color — force both to the yellow accent. */
-  :global(.text-black) {
-    color: light-dark(var(--mantine-color-yellow-8), var(--mantine-color-yellow-3)) !important;
-  }
-
-  svg {
-    color: light-dark(var(--mantine-color-yellow-8), var(--mantine-color-yellow-3)) !important;
-    /* The profile nav passes an explicit `color` to the icon, which tabler
-       renders as a `stroke="#fff"` attribute — override the stroke too. */
-    stroke: light-dark(var(--mantine-color-yellow-8), var(--mantine-color-yellow-3)) !important;
-  }
-
-  /* Collapse the 30px icon box to an inline glyph so the pill matches the main
-     nav's compact size + tight icon-to-label spacing. */
-  :global(.mantine-ThemeIcon-root) {
-    width: auto !important;
-    height: auto !important;
-    min-width: 0 !important;
-    min-height: 0 !important;
-    padding: 0 !important;
-    background: transparent !important;
-  }
 }

--- a/src/components/HomeContentToggle/HomeStyleSegmentedControl.tsx
+++ b/src/components/HomeContentToggle/HomeStyleSegmentedControl.tsx
@@ -2,7 +2,8 @@ import { Badge, Button, Loader } from '@mantine/core';
 import { useIsomorphicEffect } from '@mantine/hooks';
 import type { IconProps } from '@tabler/icons-react';
 import clsx from 'clsx';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { useEffect, useReducer, useRef, useState } from 'react';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 
 import classes from './HomeStyleSegmentedControl.module.css';
@@ -14,10 +15,11 @@ import classes from './HomeStyleSegmentedControl.module.css';
 const MAX_DENSITY = 3;
 
 export function HomeStyleSegmentedControl({ data, value: activePath, loading }: Props) {
-  const containerRef = React.useRef<HTMLDivElement>(null);
-  const rootRef = React.useRef<HTMLDivElement>(null);
-  const [density, setDensity] = React.useState(0);
-  const [measureNonce, bumpMeasure] = React.useReducer((x: number) => x + 1, 0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const lastWidthRef = useRef(0);
+  const [density, setDensity] = useState(0);
+  const [measureNonce, bumpMeasure] = useReducer((x: number) => x + 1, 0);
 
   const compact = density >= 2;
 
@@ -25,11 +27,16 @@ export function HomeStyleSegmentedControl({ data, value: activePath, loading }: 
     ([, value]) => value.disabled === undefined || value.disabled === false
   );
 
-  // Reset to comfy on any width change, then the walk-down effect re-tightens.
-  React.useEffect(() => {
+  // Reset to comfy on width change, then the walk-down effect re-tightens. Guard
+  // on width only: a height delta (the horizontal scrollbar appearing/vanishing
+  // as density changes) would otherwise refire the observer and oscillate.
+  useEffect(() => {
     const el = containerRef.current;
     if (!el || typeof ResizeObserver === 'undefined') return;
-    const ro = new ResizeObserver(() => {
+    const ro = new ResizeObserver((roEntries) => {
+      const width = roEntries[0]?.contentRect.width ?? 0;
+      if (width === lastWidthRef.current) return;
+      lastWidthRef.current = width;
       setDensity(0);
       bumpMeasure();
     });
@@ -98,7 +105,7 @@ export function HomeStyleSegmentedControl({ data, value: activePath, loading }: 
 
 export type DataItem = {
   url: string;
-  icon: (props?: IconProps) => React.ReactNode;
+  icon: (props?: IconProps) => ReactNode;
   disabled?: boolean;
   count?: number;
   label?: string;

--- a/src/components/HomeContentToggle/HomeStyleSegmentedControl.tsx
+++ b/src/components/HomeContentToggle/HomeStyleSegmentedControl.tsx
@@ -1,72 +1,97 @@
-import type { SegmentedControlItem, SegmentedControlProps } from '@mantine/core';
-import {
-  Anchor,
-  Badge,
-  Group,
-  Loader,
-  SegmentedControl,
-  Text,
-  ThemeIcon,
-  useComputedColorScheme,
-  useMantineTheme,
-} from '@mantine/core';
+import { Badge, Button, Loader } from '@mantine/core';
+import { useIsomorphicEffect } from '@mantine/hooks';
 import type { IconProps } from '@tabler/icons-react';
+import clsx from 'clsx';
 import React from 'react';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 
 import classes from './HomeStyleSegmentedControl.module.css';
 
-export function HomeStyleSegmentedControl({
-  data,
-  value: activePath,
-  onChange,
-  size,
-  loading,
-  ...props
-}: Props) {
-  const theme = useMantineTheme();
-  const colorScheme = useComputedColorScheme('dark');
-  const options: SegmentedControlItem[] = Object.entries(data).map(([key, value]) => ({
-    label: (
-      <Link legacyBehavior href={value.url} passHref>
-        <Anchor td="none" variant="text">
-          <Group align="center" gap={8} wrap="nowrap" className={value.className}>
-            <ThemeIcon
-              size={30}
-              color={activePath === key ? theme.colors.dark[7] : 'transparent'}
-              p={6}
-            >
-              {value.icon({
-                color:
-                  colorScheme === 'dark' || activePath === key ? theme.white : theme.colors.dark[7],
-              })}
-            </ThemeIcon>
-            <Text size="sm" tt="capitalize" className="text-black dark:text-white" inline>
-              {value.label ?? key}
-            </Text>
-            {value.count != null && (
-              <Badge classNames={{ label: 'overflow-visible' }}>
-                {loading ? <Loader size="xs" type="dots" /> : value.count.toLocaleString()}
-              </Badge>
-            )}
-          </Group>
-        </Anchor>
-      </Link>
-    ),
-    value: key,
-    disabled: value.disabled,
-  }));
+// Progressive density: 0 = comfy, 1 = tight padding, 2 = icon + count (labels
+// dropped), 3 = icon only. The active tab always keeps its full label + count.
+// Beyond 3 the row falls back to horizontal scroll. Built to mirror the primary
+// subnav (HomeContentToggle) — rounded pill buttons, chip-on-hover at full size.
+const MAX_DENSITY = 3;
+
+export function HomeStyleSegmentedControl({ data, value: activePath, loading }: Props) {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const rootRef = React.useRef<HTMLDivElement>(null);
+  const [density, setDensity] = React.useState(0);
+  const [measureNonce, bumpMeasure] = React.useReducer((x: number) => x + 1, 0);
+
+  const compact = density >= 2;
+
+  const entries = Object.entries(data).filter(
+    ([, value]) => value.disabled === undefined || value.disabled === false
+  );
+
+  // Reset to comfy on any width change, then the walk-down effect re-tightens.
+  React.useEffect(() => {
+    const el = containerRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => {
+      setDensity(0);
+      bumpMeasure();
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Step down one density level while the row overflows. Runs pre-paint so the
+  // intermediate levels never flash. Self-terminating: stops once it fits or
+  // hits MAX_DENSITY, after which overflow-x:auto scrolls the rest.
+  useIsomorphicEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+    if (density < MAX_DENSITY && root.scrollWidth > root.clientWidth + 1) {
+      setDensity((d) => d + 1);
+    }
+  }, [density, measureNonce, loading, entries.length]);
 
   return (
-    <div className={classes.container}>
-      <SegmentedControl
-        {...props}
-        size="md"
-        classNames={classes}
-        value={activePath}
-        data={options.filter((item) => item.disabled === undefined || item.disabled === false)}
-        withItemsBorders={false}
-      />
+    <div ref={containerRef} className={classes.container} data-density={density}>
+      <div ref={rootRef} className={clsx(classes.root, 'text-black dark:text-white')}>
+        {entries.map(([key, value]) => {
+          const active = activePath === key;
+          return (
+            <Button
+              key={key}
+              component={Link}
+              href={value.url}
+              variant="default"
+              data-active={active || undefined}
+              className={clsx(
+                classes.pill,
+                'h-8 overflow-visible rounded-full border-none',
+                compact ? 'px-2' : 'py-2 pl-3 pr-4',
+                active && 'bg-gray-4 dark:bg-dark-4',
+                value.className
+              )}
+              classNames={{
+                label: clsx(
+                  'flex items-center overflow-visible capitalize',
+                  compact ? 'justify-center' : 'gap-2'
+                ),
+              }}
+            >
+              {value.icon({ size: 16 })}
+              <span className={clsx('text-base font-medium capitalize', classes.tabLabel)}>
+                <span className={classes.tabLabelInner}>{value.label ?? key}</span>
+              </span>
+              {value.count != null && (
+                <Badge
+                  size="sm"
+                  radius="xl"
+                  className={classes.tabCount}
+                  classNames={{ label: 'overflow-visible' }}
+                >
+                  {loading ? <Loader size="xs" type="dots" /> : value.count.toLocaleString()}
+                </Badge>
+              )}
+            </Button>
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -80,9 +105,7 @@ export type DataItem = {
   className?: string;
 };
 type Props = {
-  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   value: string;
-  onChange?: (item: DataItem) => void;
   loading?: boolean;
   data: Record<string, DataItem>;
-} & Omit<SegmentedControlProps, 'data' | 'value' | 'onChange'>;
+};


### PR DESCRIPTION
## Problem

The user profile tab bar (Overview / Models / Posts / Images / …) overflowed on narrow screens and got **clipped instead of scrolling** — the scroll container sat in a flex column with default `min-width: auto`, so it refused to shrink below the tabs' full content width and an ancestor `overflow-hidden` cut it off. From a Discord report (MNeMiC): the feature row doesn't fit even at 16:9.

## Approach

Rebuilt the bar to **progressively degrade** with available width instead of wrapping (which would make the bar taller) — matching the primary subnav's look.

**Density ladder** (a `ResizeObserver` picks the least-degraded level that fits, pre-paint so nothing flashes):

| Level | Inactive pills | Active pill |
|-------|----------------|-------------|
| 0 comfy | icon + label + stat | same |
| 1 tight | icon + label + stat (tighter) | same |
| 2 | icon + stat | icon + label + stat |
| 3 | icon only | icon + label + stat |
| — | overflow → horizontal scroll | |

- **Rebuilt `HomeStyleSegmentedControl`** from a Mantine `SegmentedControl` to a rounded **pill-button row** (same `variant="default"` pills as the primary subnav). This removes the segmented-control double selection box, the rounded-square icon background, and the shop double-chip, and makes it consistent with the rest of the site.
- **Compact pills are centered circles**; hovering reveals the label via a CSS grid `0fr → 1fr` animation (animates to exact content width — no jank), with a **500ms open delay** and instant close. The stat slides right as the label opens.
- **Root-cause fix:** `min-w-0` on the scrollable `<main>` so the content column can shrink below its content width (this is what unblocks both scrolling and the density measurement).

## Detail fixes
- Count badge font + padding force-pinned (Mantine was overriding the CSS vars); single-digit stats render as circles.
- Badge `pointer-events: none` so the link's pointer cursor + clicks pass through (was showing the default cursor over the stat).
- Trailing space after labels on stat-less pills (Overview, Shop) via `:has(.tabCount)`.
- Edge/vertical padding on the row to match the primary subnav's `px-2 py-1`; descender clip on "Images" fixed.

## Scope / risk
- `HomeStyleSegmentedControl` is used **only** by `ProfileNavigation`.
- The one shared change is `min-w-0` on the scrollable `<main>` in `AppLayout` — standard, lets content columns shrink to the viewport; watch for any feed that relied on forcing page width (none expected).

## Test
- `pnpm typecheck` ✅, `pnpm lint` ✅, prettier ✅.
- Verified on the dev server at multiple widths (full → tight → icon+stat → icon-only → scroll).
- Note: could not self-verify via CDP screenshots (debug port was unavailable during the session); reviewed live on HMR by the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)