### PR TITLE
fix(challenges): judge account owns challenge entry collections

### DIFF
--- a/src/server/games/daily-challenge/__tests__/challenge-collection-owner.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-collection-owner.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDbRead, mockGetChallengeConfig } = vi.hoisted(() => ({
+  mockDbRead: { challengeJudge: { findUnique: vi.fn() } },
+  mockGetChallengeConfig: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: {} }));
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getChallengeConfig: mockGetChallengeConfig,
+}));
+
+const { resolveChallengeCollectionOwnerId } = await import(
+  '~/server/games/daily-challenge/challenge-collection-owner'
+);
+
+describe('resolveChallengeCollectionOwnerId', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetChallengeConfig.mockResolvedValue({ defaultJudgeId: 7 });
+  });
+
+  it('returns the user account of the judge passed in', async () => {
+    mockDbRead.challengeJudge.findUnique.mockResolvedValue({ userId: 555 });
+
+    await expect(resolveChallengeCollectionOwnerId(3)).resolves.toBe(555);
+    expect(mockDbRead.challengeJudge.findUnique).toHaveBeenCalledWith({
+      where: { id: 3 },
+      select: { userId: true },
+    });
+  });
+
+  it('falls back to the configured default judge when none is passed', async () => {
+    mockDbRead.challengeJudge.findUnique.mockResolvedValue({ userId: 999 });
+
+    await expect(resolveChallengeCollectionOwnerId(null)).resolves.toBe(999);
+    expect(mockDbRead.challengeJudge.findUnique).toHaveBeenCalledWith({
+      where: { id: 7 },
+      select: { userId: true },
+    });
+  });
+
+  it('throws when neither a judge nor a default judge is configured', async () => {
+    mockGetChallengeConfig.mockResolvedValue({ defaultJudgeId: undefined });
+
+    await expect(resolveChallengeCollectionOwnerId(undefined)).rejects.toThrow(
+      /no challenge judge/i
+    );
+    expect(mockDbRead.challengeJudge.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('throws when the resolved judge does not exist', async () => {
+    mockDbRead.challengeJudge.findUnique.mockResolvedValue(null);
+
+    await expect(resolveChallengeCollectionOwnerId(42)).rejects.toThrow(/no challenge judge/i);
+  });
+});

--- a/src/server/games/daily-challenge/__tests__/challenge-collection-owner.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-collection-owner.test.ts
@@ -44,14 +44,16 @@ describe('resolveChallengeCollectionOwnerId', () => {
     mockGetChallengeConfig.mockResolvedValue({ defaultJudgeId: undefined });
 
     await expect(resolveChallengeCollectionOwnerId(undefined)).rejects.toThrow(
-      /no challenge judge/i
+      'No challenge judge is configured.'
     );
     expect(mockDbRead.challengeJudge.findUnique).not.toHaveBeenCalled();
   });
 
-  it('throws when the resolved judge does not exist', async () => {
+  it('throws naming the id when the resolved judge has no ChallengeJudge row', async () => {
     mockDbRead.challengeJudge.findUnique.mockResolvedValue(null);
 
-    await expect(resolveChallengeCollectionOwnerId(42)).rejects.toThrow(/no challenge judge/i);
+    await expect(resolveChallengeCollectionOwnerId(42)).rejects.toThrow(
+      'No challenge judge found for id 42.'
+    );
   });
 });

--- a/src/server/games/daily-challenge/challenge-collection-owner.ts
+++ b/src/server/games/daily-challenge/challenge-collection-owner.ts
@@ -1,0 +1,29 @@
+import { TRPCError } from '@trpc/server';
+import { dbRead } from '~/server/db/client';
+import { getChallengeConfig } from '~/server/games/daily-challenge/daily-challenge.utils';
+
+// Challenge entry collections are owned by the judge's account, never the creator's: collection
+// ownership grants unconditional `manage`, which would let a creator delete the collection,
+// hand-review entries past the safety checks, or rewrite the contest metadata.
+export async function resolveChallengeCollectionOwnerId(
+  judgeId?: number | null
+): Promise<number> {
+  const resolvedJudgeId = judgeId ?? (await getChallengeConfig()).defaultJudgeId;
+  if (!resolvedJudgeId)
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'No challenge judge is configured.',
+    });
+
+  const judge = await dbRead.challengeJudge.findUnique({
+    where: { id: resolvedJudgeId },
+    select: { userId: true },
+  });
+  if (!judge)
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'No challenge judge is configured.',
+    });
+
+  return judge.userId;
+}

--- a/src/server/games/daily-challenge/challenge-collection-owner.ts
+++ b/src/server/games/daily-challenge/challenge-collection-owner.ts
@@ -22,7 +22,7 @@ export async function resolveChallengeCollectionOwnerId(
   if (!judge)
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
-      message: 'No challenge judge is configured.',
+      message: `No challenge judge found for id ${resolvedJudgeId}.`,
     });
 
   return judge.userId;

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -435,17 +435,24 @@ export type CreateChallengeInput = {
 export async function createChallengeCollection(input: {
   title: string;
   description?: string;
-  userId: number;
+  judgeId?: number | null;
   startsAt: Date;
   endsAt: Date;
   maxEntriesPerUser: number;
   allowedNsfwLevel?: number; // Bitwise NSFW levels (default 1 = PG only)
 }): Promise<number> {
+  // Dynamic import: this file -> challenge-collection-owner -> daily-challenge.utils imports
+  // closeChallengeCollection etc. back from this file, so a static import here is a require cycle.
+  const { resolveChallengeCollectionOwnerId } = await import(
+    '~/server/games/daily-challenge/challenge-collection-owner'
+  );
+  const userId = await resolveChallengeCollectionOwnerId(input.judgeId);
+
   const collection = await dbWrite.collection.create({
     data: {
       name: `Challenge: ${input.title}`,
       description: input.description || `Entries for challenge: ${input.title}`,
-      userId: input.userId,
+      userId,
       mode: CollectionMode.Contest,
       metadata: {
         maxItemsPerUser: input.maxEntriesPerUser,
@@ -702,7 +709,7 @@ export async function createChallengeWithCollection(
   const collectionId = await createChallengeCollection({
     title: input.title,
     description: input.description,
-    userId: input.createdById,
+    judgeId: input.judgeId,
     startsAt: input.startsAt,
     endsAt: input.endsAt,
     maxEntriesPerUser: input.maxEntriesPerUser ?? 20,

--- a/src/server/services/__tests__/challenge-collection-owner-wiring.service.test.ts
+++ b/src/server/services/__tests__/challenge-collection-owner-wiring.service.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// JUDGE_USER_ID/CREATOR_USER_ID must be defined inside vi.hoisted() itself: its callback runs
+// before any top-level `const` in this file initializes, so referencing an outer const here
+// throws a TDZ error ("Cannot access 'JUDGE_USER_ID' before initialization").
+const {
+  mockDbRead,
+  mockDbWrite,
+  mockTx,
+  mockCreateImage,
+  mockGetChallengeConfig,
+  JUDGE_USER_ID,
+  CREATOR_USER_ID,
+} = vi.hoisted(() => {
+  const JUDGE_USER_ID = 8_675_309;
+  const CREATOR_USER_ID = 42;
+  const tx = {
+    challenge: {
+      update: vi.fn().mockResolvedValue({ id: 1 }),
+      create: vi.fn().mockResolvedValue({ id: 2, collectionId: 10 }),
+    },
+    collection: {
+      create: vi.fn().mockResolvedValue({ id: 10 }),
+      update: vi.fn().mockResolvedValue({ id: 10 }),
+      findUnique: vi.fn().mockResolvedValue({ metadata: {} }),
+    },
+  };
+  return {
+    JUDGE_USER_ID,
+    CREATOR_USER_ID,
+    mockTx: tx,
+    mockDbRead: {
+      challenge: { findUnique: vi.fn() },
+      challengeJudge: { findUnique: vi.fn().mockResolvedValue({ userId: JUDGE_USER_ID }) },
+    },
+    mockDbWrite: { $transaction: vi.fn(async (cb: (tx: unknown) => unknown) => cb(tx)) },
+    mockCreateImage: vi.fn(),
+    mockGetChallengeConfig: vi.fn().mockResolvedValue({ defaultJudgeId: 1 }),
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+
+vi.mock('~/server/flipt/client', () => ({
+  FLIPT_FEATURE_FLAGS: {},
+  isFlipt: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  claimChallengeForCompletion: vi.fn(),
+  closeChallengeCollection: vi.fn(),
+  createChallengeWinner: vi.fn(),
+  getChallengeById: vi.fn(),
+  getChallengeWinners: vi.fn().mockResolvedValue([]),
+  getExistingWinnersForRetry: vi.fn().mockResolvedValue([]),
+  resolveEventContext: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getChallengeConfig: mockGetChallengeConfig,
+  setChallengeConfig: vi.fn(),
+  deriveChallengeNsfwLevel: vi.fn(() => 1),
+  getJudgingConfig: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  generateThemeElements: vi.fn().mockResolvedValue([]),
+  generateWinners: vi.fn(),
+}));
+
+vi.mock('~/server/jobs/daily-challenge-processing', () => ({ getJudgedEntries: vi.fn() }));
+vi.mock('~/server/search-index', () => ({ collectionsSearchIndex: { queueUpdate: vi.fn() } }));
+
+vi.mock('~/server/services/image.service', () => ({
+  createImage: mockCreateImage,
+  imagesForModelVersionsCache: { bust: vi.fn(), fetch: vi.fn(() => ({})) },
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  getCosmeticsForUsers: vi.fn(() => ({})),
+  getProfilePicturesForUsers: vi.fn(() => ({})),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  createBuzzTransactionMany: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-category.service', () => ({
+  resolveJudgingCategories: vi.fn().mockResolvedValue(null),
+}));
+
+const { upsertChallenge } = await import('~/server/services/challenge.service');
+
+const baseInput = {
+  title: 'Test challenge',
+  description: 'A description',
+  startsAt: new Date('2026-08-01T00:00:00Z'),
+  endsAt: new Date('2026-08-05T00:00:00Z'),
+  visibleAt: new Date('2026-07-29T00:00:00Z'),
+  coverImage: { id: 1 },
+  prizes: [],
+  userId: CREATOR_USER_ID,
+};
+
+describe('upsertChallenge (create) — collection ownership', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbRead.challengeJudge.findUnique.mockResolvedValue({ userId: JUDGE_USER_ID });
+    mockGetChallengeConfig.mockResolvedValue({ defaultJudgeId: 1 });
+    mockDbWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => unknown) => cb(mockTx));
+  });
+
+  it('assigns the entry collection to the judge account, not the caller', async () => {
+    await upsertChallenge({ ...baseInput, judgeId: 3 } as never);
+
+    expect(mockTx.collection.create).toHaveBeenCalledTimes(1);
+    const callArg = mockTx.collection.create.mock.calls[0][0];
+    expect(callArg.data.userId).toBe(JUDGE_USER_ID);
+    expect(callArg.data.userId).not.toBe(CREATOR_USER_ID);
+    expect(mockDbRead.challengeJudge.findUnique).toHaveBeenCalledWith({
+      where: { id: 3 },
+      select: { userId: true },
+    });
+  });
+
+  it('does not open a transaction when no judge can be resolved', async () => {
+    mockDbRead.challengeJudge.findUnique.mockResolvedValue(null);
+
+    await expect(upsertChallenge({ ...baseInput, judgeId: 3 } as never)).rejects.toThrow(
+      /no challenge judge/i
+    );
+    expect(mockDbWrite.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/challenge-collection-owner-wiring.service.test.ts
+++ b/src/server/services/__tests__/challenge-collection-owner-wiring.service.test.ts
@@ -32,6 +32,7 @@ const {
     mockDbRead: {
       challenge: { findUnique: vi.fn() },
       challengeJudge: { findUnique: vi.fn().mockResolvedValue({ userId: JUDGE_USER_ID }) },
+      image: { findFirst: vi.fn().mockResolvedValue({ id: 1 }) },
     },
     mockDbWrite: { $transaction: vi.fn(async (cb: (tx: unknown) => unknown) => cb(tx)) },
     mockCreateImage: vi.fn(),
@@ -94,7 +95,23 @@ vi.mock('~/server/services/challenge-category.service', () => ({
   resolveJudgingCategories: vi.fn().mockResolvedValue(null),
 }));
 
-const { upsertChallenge } = await import('~/server/services/challenge.service');
+vi.mock('~/server/services/challenge-eligibility.service', () => ({
+  assertCanCreateUserChallenge: vi.fn(),
+  assertUserInGoodStanding: vi.fn(),
+  assertUserAccountInGoodStanding: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-judge.service', () => ({
+  getUserSelectableJudges: vi.fn().mockResolvedValue([{ id: 3 }]),
+}));
+
+vi.mock('~/server/services/text-moderation.service', () => ({
+  submitTextModeration: vi.fn(),
+}));
+
+const { upsertChallenge, upsertUserChallenge } = await import(
+  '~/server/services/challenge.service'
+);
 
 const baseInput = {
   title: 'Test challenge',
@@ -134,6 +151,53 @@ describe('upsertChallenge (create) — collection ownership', () => {
     await expect(upsertChallenge({ ...baseInput, judgeId: 3 } as never)).rejects.toThrow(
       /no challenge judge/i
     );
+    expect(mockDbWrite.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe('upsertUserChallenge (create) — collection ownership', () => {
+  const userInput = {
+    title: 'User challenge',
+    description: 'A description',
+    startsAt: new Date(Date.now() + 48 * 60 * 60 * 1000),
+    endsAt: new Date(Date.now() + 96 * 60 * 60 * 1000),
+    coverImage: { id: 1 },
+    maxEntriesPerUser: 5,
+    entryFee: 0,
+    initialPrizeBuzz: 0,
+    judgeId: 3,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbRead.challengeJudge.findUnique.mockResolvedValue({ userId: JUDGE_USER_ID });
+    mockGetChallengeConfig.mockResolvedValue({ defaultJudgeId: 1 });
+    mockDbWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => unknown) => cb(mockTx));
+  });
+
+  it('assigns the entry collection to the judge account, not the creator', async () => {
+    await upsertUserChallenge({
+      ...userInput,
+      userId: CREATOR_USER_ID,
+      buzzType: 'yellow',
+    } as never);
+
+    expect(mockTx.collection.create).toHaveBeenCalledTimes(1);
+    const callArg = mockTx.collection.create.mock.calls[0][0];
+    expect(callArg.data.userId).toBe(JUDGE_USER_ID);
+    expect(callArg.data.userId).not.toBe(CREATOR_USER_ID);
+  });
+
+  it('does not open a transaction when no judge can be resolved', async () => {
+    mockDbRead.challengeJudge.findUnique.mockResolvedValue(null);
+
+    await expect(
+      upsertUserChallenge({
+        ...userInput,
+        userId: CREATOR_USER_ID,
+        buzzType: 'yellow',
+      } as never)
+    ).rejects.toThrow(/no challenge judge/i);
     expect(mockDbWrite.$transaction).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/__tests__/challenge-collection-permissions.service.test.ts
+++ b/src/server/services/__tests__/challenge-collection-permissions.service.test.ts
@@ -5,15 +5,20 @@ const CREATOR_USER_ID = 42;
 const COLLECTION_ID = 10;
 
 const { mockDbRead, mockDbWrite } = vi.hoisted(() => ({
-  mockDbRead: { $queryRaw: vi.fn() },
-  mockDbWrite: { collection: { findUnique: vi.fn() } },
+  mockDbRead: { $queryRaw: vi.fn(), collection: { findFirstOrThrow: vi.fn() } },
+  mockDbWrite: {
+    collection: { findUnique: vi.fn(), findFirstOrThrow: vi.fn(), delete: vi.fn() },
+  },
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
 
-const { getUserCollectionPermissionsById, updateCollectionItemsStatus } = await import(
-  '~/server/services/collection.service'
-);
+const {
+  getUserCollectionPermissionsById,
+  updateCollectionItemsStatus,
+  deleteCollectionById,
+  upsertCollection,
+} = await import('~/server/services/collection.service');
 
 // A challenge entry collection as created after this change: owned by the judge account,
 // publicly readable, entries land in review.
@@ -83,4 +88,29 @@ describe('challenge collection permissions', () => {
       } as never)
     ).rejects.toThrow(/permission/i);
   });
+
+  it('rejects the creator deleting the collection', async () => {
+    // deleteCollectionById scopes its own find by { id, userId } rather than going through
+    // getUserCollectionPermissionsById, so the creator's read just finds no matching row.
+    const notFound = new Error('No Collection found');
+    mockDbRead.collection.findFirstOrThrow.mockRejectedValue(notFound);
+    mockDbWrite.collection.findFirstOrThrow.mockRejectedValue(notFound);
+
+    await expect(
+      deleteCollectionById({ id: COLLECTION_ID, userId: CREATOR_USER_ID })
+    ).rejects.toThrow();
+    expect(mockDbWrite.collection.delete).not.toHaveBeenCalled();
+  });
+
+  it('rejects the creator editing collection settings', async () => {
+    await expect(
+      upsertCollection({
+        input: { id: COLLECTION_ID, userId: CREATOR_USER_ID, name: 'Renamed' } as never,
+      })
+    ).rejects.toThrow(/permission/i);
+  });
+
+  // removeCollectionItem is deliberately not covered here: its guard is satisfied by
+  // permissions.writeReview, which every authenticated user gets on a write: Review collection,
+  // so ownership never gated it — this change doesn't touch that exposure (tracked separately).
 });

--- a/src/server/services/__tests__/challenge-collection-permissions.service.test.ts
+++ b/src/server/services/__tests__/challenge-collection-permissions.service.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const JUDGE_USER_ID = 8_675_309;
+const CREATOR_USER_ID = 42;
+const COLLECTION_ID = 10;
+
+const { mockDbRead, mockDbWrite } = vi.hoisted(() => ({
+  mockDbRead: { $queryRaw: vi.fn() },
+  mockDbWrite: { collection: { findUnique: vi.fn() } },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+
+const { getUserCollectionPermissionsById, updateCollectionItemsStatus } = await import(
+  '~/server/services/collection.service'
+);
+
+// A challenge entry collection as created after this change: owned by the judge account,
+// publicly readable, entries land in review.
+function mockJudgeOwnedCollectionRow() {
+  mockDbRead.$queryRaw.mockResolvedValue([
+    {
+      id: COLLECTION_ID,
+      read: 'Public',
+      write: 'Review',
+      userId: JUDGE_USER_ID,
+      type: 'Image',
+      mode: 'Contest',
+      contributorPermissions: null,
+    },
+  ]);
+}
+
+describe('challenge collection permissions', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockJudgeOwnedCollectionRow();
+  });
+
+  it('gives the challenge creator no ownership and no manage rights', async () => {
+    const permissions = await getUserCollectionPermissionsById({
+      id: COLLECTION_ID,
+      userId: CREATOR_USER_ID,
+    });
+
+    expect(permissions.isOwner).toBe(false);
+    expect(permissions.manage).toBe(false);
+  });
+
+  it('still gives the judge account ownership', async () => {
+    const permissions = await getUserCollectionPermissionsById({
+      id: COLLECTION_ID,
+      userId: JUDGE_USER_ID,
+    });
+
+    expect(permissions.isOwner).toBe(true);
+    expect(permissions.manage).toBe(true);
+  });
+
+  it('still gives moderators manage rights', async () => {
+    const permissions = await getUserCollectionPermissionsById({
+      id: COLLECTION_ID,
+      userId: CREATOR_USER_ID,
+      isModerator: true,
+    });
+
+    expect(permissions.manage).toBe(true);
+  });
+
+  it('rejects the creator hand-reviewing entries', async () => {
+    mockDbWrite.collection.findUnique.mockResolvedValue({
+      id: COLLECTION_ID,
+      type: 'Image',
+      mode: 'Contest',
+      name: 'Challenge: Test',
+      metadata: {},
+    });
+
+    await expect(
+      updateCollectionItemsStatus({
+        input: { collectionId: COLLECTION_ID, collectionItemIds: [1], status: 'ACCEPTED' },
+        userId: CREATOR_USER_ID,
+      } as never)
+    ).rejects.toThrow(/permission/i);
+  });
+});

--- a/src/server/services/__tests__/challenge-upsert-mod-judging-categories.service.test.ts
+++ b/src/server/services/__tests__/challenge-upsert-mod-judging-categories.service.test.ts
@@ -26,7 +26,10 @@ const { mockDbRead, mockDbWrite, mockTx, mockCreateImage, mockGetChallengeConfig
     };
     return {
       mockTx: tx,
-      mockDbRead: { challenge: { findUnique: vi.fn() } },
+      mockDbRead: {
+        challenge: { findUnique: vi.fn() },
+        challengeJudge: { findUnique: vi.fn().mockResolvedValue({ userId: 1 }) },
+      },
       mockDbWrite: { $transaction: vi.fn(async (cb: (tx: unknown) => unknown) => cb(tx)) },
       mockCreateImage: vi.fn(),
       mockGetChallengeConfig: vi.fn().mockResolvedValue({ defaultJudgeId: 1 }),

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1831,12 +1831,14 @@ export async function upsertUserChallenge({
     return updated;
   }
 
+  const collectionOwnerId = await resolveChallengeCollectionOwnerId(judgeId);
+
   const created = await dbWrite.$transaction(async (tx) => {
     const collection = await tx.collection.create({
       data: {
         name: `Challenge: ${rest.title}`,
         description: rest.description || `Entries for challenge: ${rest.title}`,
-        userId,
+        userId: collectionOwnerId,
         mode: CollectionMode.Contest,
         write: CollectionWriteConfiguration.Review,
         read: CollectionReadConfiguration.Public,

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -16,6 +16,7 @@ import {
 } from '~/server/games/daily-challenge/challenge-helpers';
 // Re-export getChallengeWinners so router can import from service (separation of concerns)
 export { getChallengeWinners } from '~/server/games/daily-challenge/challenge-helpers';
+import { resolveChallengeCollectionOwnerId } from '~/server/games/daily-challenge/challenge-collection-owner';
 import { CHALLENGE_MODERATION_LABELS } from '~/server/games/daily-challenge/challenge-text-scan';
 import {
   ChallengeParticipation,
@@ -1483,6 +1484,8 @@ export async function upsertChallenge({
       ? await tryGenerateThemeElements(data.theme)
       : undefined;
 
+    const collectionOwnerId = await resolveChallengeCollectionOwnerId(judgeId);
+
     // Create new challenge with a Contest Collection for entries
     const challenge = await dbWrite.$transaction(async (tx) => {
       // First create the collection with proper Contest Mode settings
@@ -1490,7 +1493,7 @@ export async function upsertChallenge({
         data: {
           name: `Challenge: ${data.title}`,
           description: data.description || `Entries for challenge: ${data.title}`,
-          userId,
+          userId: collectionOwnerId,
           mode: CollectionMode.Contest,
           write: CollectionWriteConfiguration.Review,
           read: CollectionReadConfiguration.Public,

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -14,9 +14,9 @@ import {
   getExistingWinnersForRetry,
   resolveEventContext,
 } from '~/server/games/daily-challenge/challenge-helpers';
+import { resolveChallengeCollectionOwnerId } from '~/server/games/daily-challenge/challenge-collection-owner';
 // Re-export getChallengeWinners so router can import from service (separation of concerns)
 export { getChallengeWinners } from '~/server/games/daily-challenge/challenge-helpers';
-import { resolveChallengeCollectionOwnerId } from '~/server/games/daily-challenge/challenge-collection-owner';
 import { CHALLENGE_MODERATION_LABELS } from '~/server/games/daily-challenge/challenge-text-scan';
 import {
   ChallengeParticipation,
@@ -1315,6 +1315,10 @@ export async function upsertChallenge({
     });
   }
 
+  // Resolved before the cover image below: only the create path (no id) needs this, and a
+  // misconfigured judge must not leave an orphaned cover Image behind.
+  const collectionOwnerId = id ? undefined : await resolveChallengeCollectionOwnerId(judgeId);
+
   // Handle cover image - create Image record if needed (like Article does)
   let coverImageId: number;
   if (coverImage.id) {
@@ -1484,8 +1488,6 @@ export async function upsertChallenge({
       ? await tryGenerateThemeElements(data.theme)
       : undefined;
 
-    const collectionOwnerId = await resolveChallengeCollectionOwnerId(judgeId);
-
     // Create new challenge with a Contest Collection for entries
     const challenge = await dbWrite.$transaction(async (tx) => {
       // First create the collection with proper Contest Mode settings
@@ -1493,7 +1495,8 @@ export async function upsertChallenge({
         data: {
           name: `Challenge: ${data.title}`,
           description: data.description || `Entries for challenge: ${data.title}`,
-          userId: collectionOwnerId,
+          // Guaranteed set: this branch only runs when id is falsy (see resolution above).
+          userId: collectionOwnerId!,
           mode: CollectionMode.Contest,
           write: CollectionWriteConfiguration.Review,
           read: CollectionReadConfiguration.Public,
@@ -1639,6 +1642,10 @@ export async function upsertUserChallenge({
   // creator from editing their own challenge.
   if (!id) await assertCanCreateUserChallenge(userId);
   else await assertUserAccountInGoodStanding(userId);
+
+  // Resolved before the cover image below, for the same reason as the eligibility check above:
+  // a misconfigured judge must not leave an orphaned cover Image behind.
+  const collectionOwnerId = id ? undefined : await resolveChallengeCollectionOwnerId(judgeId);
 
   // Cover image: reuse an existing Image or create one from the upload (like the mod path).
   // A reused id must belong to the caller — otherwise anyone could surface another user's
@@ -1831,14 +1838,13 @@ export async function upsertUserChallenge({
     return updated;
   }
 
-  const collectionOwnerId = await resolveChallengeCollectionOwnerId(judgeId);
-
   const created = await dbWrite.$transaction(async (tx) => {
     const collection = await tx.collection.create({
       data: {
         name: `Challenge: ${rest.title}`,
         description: rest.description || `Entries for challenge: ${rest.title}`,
-        userId: collectionOwnerId,
+        // Guaranteed set: this branch only runs when id is falsy (see resolution above).
+        userId: collectionOwnerId!,
         mode: CollectionMode.Contest,
         write: CollectionWriteConfiguration.Review,
         read: CollectionReadConfiguration.Public,


### PR DESCRIPTION
Challenge creators owned the auto-created entry collection, and collection ownership grants unconditional `manage`. Testers hit this on community challenges: the creator could manage their own challenge's entries through the normal collection UI.

Concretely, that exposed:
- **Delete the collection** — `Challenge.collectionId` is `onDelete: SetNull`, so the challenge is orphaned and its escrowed prize pool stranded. Only `Bookmark` mode was guarded.
- **Hand-accept entries** — auto-review only rewrites `status = 'REVIEW'` rows (`challenge-rewards.ts:39-64`), so a manual `REVIEW → ACCEPTED` bypasses the isSafe / hasResource / isRecent checks entirely.
- **Hand-reject rivals** — excluded from judging and the entry prize, with no entry-fee refund.
- **Rewrite contest metadata** — including `forcedBrowsingLevel` (NSFW isolation) and `mode` (moving off `Contest` silently skips entry-fee charging, the entry gate, and entry prizes).
- **Grant a third party MANAGE** via collection contributors, and swap the collection cover.

## Fix

Entry collections are now assigned to the challenge judge's user account, matching how daily challenges have always worked (`daily-challenge-processing.ts:319`). Ownership resolves with the same fallback judging uses (`judgeId ?? config.defaultJudgeId` → `ChallengeJudge.userId`), and throws at creation if neither resolves — before any cover Image is created.

Because `manage`/`isOwner` derive solely from `userId === collection.userId`, every affected mutation now rejects the creator with no per-call-site guards and no UI changes. Moderators keep manage.

## Not fixed by this PR

`removeCollectionItem` is **not** closed by the ownership change. Its guard short-circuits on `permissions.writeReview`, which every authenticated user gets on a `write: Review` collection — ownership is irrelevant to that check. That is a pre-existing issue affecting all Public/Review collections, not just challenges, and is being handled separately. Not reachable from the UI (the remove control is owner/mod-gated client-side), but it is reachable via the tRPC endpoint.

Existing challenge collections are deliberately not backfilled — new challenges only.

## Notes for reviewers

- `collection.userId` pins the judge resolved at creation. `judgeId` stays editable on Scheduled challenges, so the owner is not guaranteed to be the judge that grades it. Harmless today — every judging write is raw SQL / direct Prisma with no permission check.
- These collections are `read: Public`, so they now accumulate on the judge account's public profile and in the collections search index rather than the creator's.
- `createChallengeWithCollection` / `createChallengeCollection` in `challenge-helpers.ts` have no callers, but the docstring advertises the former as preferred — routed through the same resolver so wiring it up later can't reintroduce the hole.

## Manual QA
- [ ] New user challenge: `Collection.userId` is the judge's user id, `Challenge.createdById` is still the creator
- [ ] Creator on `/collections/<id>`: no edit, delete, review tab, or contributor controls
- [ ] Collection absent from the creator's My Collections and AddToCollection modal
- [ ] Moderator on the same collection: manage controls still present
- [ ] Third-party entry submission still lands in `REVIEW`

🤖 Generated with [Claude Code](https://claude.com/claude-code)