### PR TITLE
fix(collections): a write grant no longer authorizes deleting others' items

### DIFF
--- a/src/server/services/__tests__/collection-remove-item-authorization.service.test.ts
+++ b/src/server/services/__tests__/collection-remove-item-authorization.service.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `permissions.writeReview` is granted to every authenticated user on a `write: Review`
+// collection (and `permissions.write` likewise on `write: Public`), independent of ownership.
+// Removal must not accept those as authorization — a write grant lets you ADD an item, not
+// delete somebody else's.
+
+const { mockDbRead, mockDbWrite } = vi.hoisted(() => ({
+  mockDbRead: { $queryRaw: vi.fn() },
+  mockDbWrite: { $queryRaw: vi.fn() },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+
+const { removeCollectionItem } = await import('~/server/services/collection.service');
+
+const COLLECTION_ID = 10;
+const COLLECTION_OWNER_ID = 999;
+const ITEM_AUTHOR_ID = 777;
+const OUTSIDER_ID = 12_345;
+
+// First $queryRaw is the permission row (getUserCollectionPermissionsByIds), second is the
+// item-owner lookup.
+function arrangeCollection({
+  write,
+  contributorPermissions = null,
+}: {
+  write: 'Public' | 'Review' | 'Private';
+  contributorPermissions?: string[] | null;
+}) {
+  mockDbRead.$queryRaw.mockReset();
+  mockDbWrite.$queryRaw.mockReset();
+  mockDbRead.$queryRaw
+    .mockResolvedValueOnce([
+      {
+        id: COLLECTION_ID,
+        read: 'Public',
+        write,
+        userId: COLLECTION_OWNER_ID,
+        type: 'Image',
+        mode: 'Contest',
+        contributorPermissions,
+      },
+    ])
+    .mockResolvedValueOnce([{ userId: ITEM_AUTHOR_ID }]);
+  mockDbWrite.$queryRaw.mockResolvedValue(undefined);
+}
+
+function remove({ userId, isModerator = false }: { userId: number; isModerator?: boolean }) {
+  return removeCollectionItem({
+    collectionId: COLLECTION_ID,
+    itemId: 55,
+    userId,
+    isModerator,
+  } as never);
+}
+
+describe('removeCollectionItem authorization', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects an outsider on a write:Review collection', async () => {
+    arrangeCollection({ write: 'Review' });
+
+    await expect(remove({ userId: OUTSIDER_ID })).rejects.toThrow(/permission/i);
+    expect(mockDbWrite.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('rejects an outsider on a write:Public collection', async () => {
+    arrangeCollection({ write: 'Public' });
+
+    await expect(remove({ userId: OUTSIDER_ID })).rejects.toThrow(/permission/i);
+    expect(mockDbWrite.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('rejects a contributor holding only ADD on a write:Public collection', async () => {
+    arrangeCollection({ write: 'Public', contributorPermissions: ['ADD'] });
+
+    await expect(remove({ userId: OUTSIDER_ID })).rejects.toThrow(/permission/i);
+    expect(mockDbWrite.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('rejects an outsider on a write:Private collection', async () => {
+    arrangeCollection({ write: 'Private' });
+
+    await expect(remove({ userId: OUTSIDER_ID })).rejects.toThrow(/permission/i);
+    expect(mockDbWrite.$queryRaw).not.toHaveBeenCalled();
+  });
+
+  it('allows the item author to remove their own entry', async () => {
+    arrangeCollection({ write: 'Review' });
+
+    await expect(remove({ userId: ITEM_AUTHOR_ID })).resolves.toMatchObject({
+      collectionId: COLLECTION_ID,
+      itemId: 55,
+    });
+    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the collection owner to remove any entry', async () => {
+    arrangeCollection({ write: 'Review' });
+
+    await expect(remove({ userId: COLLECTION_OWNER_ID })).resolves.toBeTruthy();
+    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a moderator to remove any entry', async () => {
+    arrangeCollection({ write: 'Review' });
+
+    await expect(remove({ userId: OUTSIDER_ID, isModerator: true })).resolves.toBeTruthy();
+    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a contributor holding MANAGE to remove any entry', async () => {
+    arrangeCollection({ write: 'Review', contributorPermissions: ['MANAGE'] });
+
+    await expect(remove({ userId: OUTSIDER_ID })).resolves.toBeTruthy();
+    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -2811,13 +2811,10 @@ export const removeCollectionItem = async ({
 
   isOwner = item.userId === userId;
 
-  if (
-    !permissions.write &&
-    !permissions.writeReview &&
-    !isOwner &&
-    !permissions.manage &&
-    !isModerator
-  ) {
+  // Deliberately does NOT accept `permissions.write` / `permissions.writeReview`: both are granted
+  // to every authenticated user on a Public/Review-write collection regardless of ownership, so
+  // honoring them here let anyone delete anyone else's item. A write grant authorizes adding.
+  if (!isOwner && !permissions.manage && !isModerator) {
     throw throwAuthorizationError(
       'You do not have permission to remove items from this collection.'
     );


### PR DESCRIPTION
Follow-up to #3300, which found this while auditing challenge collection ownership but deliberately left it out of scope — it affects every Public/Review collection, not just challenges.

## The bug

`removeCollectionItem` (`collection.service.ts:2814`) guarded with:

```ts
if (!permissions.write && !permissions.writeReview && !isOwner && !permissions.manage && !isModerator)
  throw throwAuthorizationError(...)
```

`permissions.writeReview` is set in the `write === Review` branch at `collection.service.ts:261-265`, and `permissions.write` in the `write === Public` branch at `:255-259`. Both sit **above** the `if (!userId) return` at `:267` and never consult `collection.userId` — they're granted to every caller. Any one of them satisfies the OR-of-escapes, so the guard never tripped and the raw `DELETE FROM "CollectionItem"` at `:2826` ran.

Result: **any authenticated user could delete any other user's item from any `write: Public` or `write: Review` collection** — including challenge and contest entries. `isOwner` at `:2812` is recomputed as *item* authorship, so it never backstopped collection-level authorization.

Verified against the real function with only `~/server/db/client` mocked, caller = authenticated non-moderator, not the collection owner, not the item author:

| Collection `write` | Before | After |
|---|---|---|
| `Review` | DELETE ran | rejected |
| `Public` | DELETE ran | rejected |
| `Public` + contributor ADD | DELETE ran | rejected |
| `Private` (control) | rejected | rejected |

The `Private` control is what makes the result meaningful — flipping only the `write` column moved the same caller from rejected to deleting.

## Reachability

Not reachable by clicking: `Collection.tsx:147-150` and `:284-285` render the remove control only for collection-owner / item-owner / moderator / `manage`. Reachable by calling the `collection.removeFromCollection` tRPC mutation directly (`collection.router.ts:158`, a bare `protectedProcedure`; `removeCollectionItemHandler` adds no guard), or with an API key holding `CollectionsWrite`. That's why it hasn't been reported.

## The fix

Removal now requires item authorship, `manage` (collection owner or MANAGE contributor), or moderator — exactly what the UI already gates on. A write grant authorizes *adding* an item, not deleting someone else's.

**Behavior change to be aware of:** a contributor holding only `ADD`/`ADD_REVIEW` on a Public/Review collection can no longer delete other people's items. They can still remove their own, and MANAGE contributors are unaffected. No UI flow depended on the old behavior.

## Testing

New `src/server/services/__tests__/collection-remove-item-authorization.service.test.ts`, 8 cases — the 4 rejection paths above plus 4 that must keep working (item author, collection owner, moderator, MANAGE contributor). The 3 outsider cases fail on `main` and pass here.

Full `src/server/services/__tests__` suite: 1462 passed, 0 failed. `pnpm run typecheck` shows 7 pre-existing `Model.isOfficial` errors (stale generated Prisma client) present identically on clean `main`; this change adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)