### PR TITLE
fix(model-wizard): stop the version wizard jumping to the post step mid-upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "model-share",
-  "version": "5.0.2151",
+  "version": "5.0.2152",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "scripts": {

--- a/src/components/Resource/Wizard/ModelVersionWizard.autoResume.browser.test.tsx
+++ b/src/components/Resource/Wizard/ModelVersionWizard.autoResume.browser.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { Router } from 'next/router';
+import { renderWithProviders } from '../../../../test/component-setup';
+
+/**
+ * Wizard-level regression for the post step stealing the user mid-upload: with
+ * several files on the upload step, the first to finish invalidates the version
+ * query, `hasFiles` flips, and an unguarded resume used to navigate to step 3
+ * while the rest were still transferring.
+ *
+ * Asserting on `router.replace` (rather than the hook) is the point — it's what
+ * catches the guard being dropped from the wizard itself.
+ */
+
+const versionQuery = vi.hoisted(() => ({ data: undefined as unknown, isInitialLoading: false }));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    modelVersion: {
+      getByIdForEdit: { useQuery: () => versionQuery },
+      publishPrivateModelVersion: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    useUtils: () => ({}),
+  },
+}));
+vi.mock('~/providers/FeatureFlagsProvider', () => ({ useFeatureFlags: () => ({}) }));
+
+// The wizard's step bodies pull the whole upload/post editor graph, none of which
+// this test drives.
+vi.mock('~/components/Resource/Files', () => ({
+  Files: () => <div data-testid="files" />,
+  UploadStepActions: () => <div />,
+}));
+vi.mock('~/components/Resource/FilesProvider', () => ({
+  FilesProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('~/components/Resource/Forms/ModelVersionUpsertForm', () => ({
+  ModelVersionUpsertForm: () => <div />,
+}));
+vi.mock('~/components/Resource/Forms/PostUpsertForm2', () => ({
+  PostUpsertForm2: () => <div data-testid="post-form" />,
+}));
+vi.mock('~/components/Resource/Forms/TrainingSelectFile', () => ({ default: () => <div /> }));
+vi.mock('~/store/s3-upload.store', () => ({
+  useS3UploadStore: () => ({ getStatus: () => ({ uploading: 0, error: 0, aborted: 0 }) }),
+}));
+
+import { ModelVersionWizard } from '~/components/Resource/Wizard/ModelVersionWizard';
+
+const MODEL_ID = 123;
+const VERSION_ID = 456;
+
+function makeVersion({ fileCount }: { fileCount: number }) {
+  return {
+    id: VERSION_ID,
+    name: 'v1',
+    files: Array.from({ length: fileCount }, (_, i) => ({ id: i + 1, name: `file-${i}.safetensors` })),
+    posts: [],
+    model: { id: MODEL_ID, name: 'Test model', user: { id: 1 } },
+  };
+}
+
+function setVersion(version: unknown) {
+  versionQuery.data = version;
+}
+
+const router = Router as unknown as {
+  replace: ReturnType<typeof vi.fn>;
+  query: Record<string, unknown>;
+  pathname: string;
+};
+
+beforeEach(() => {
+  router.replace.mockClear();
+  router.query = { id: String(MODEL_ID), versionId: String(VERSION_ID), step: '2' };
+  router.pathname = '/models/[id]/model-versions/[versionId]/wizard';
+  versionQuery.isInitialLoading = false;
+});
+
+describe('ModelVersionWizard auto-resume', () => {
+  test('resumes a file-less draft to the upload step, once', async () => {
+    setVersion(makeVersion({ fileCount: 0 }));
+    await renderWithProviders(<ModelVersionWizard />);
+
+    await vi.waitFor(() => expect(router.replace).toHaveBeenCalledTimes(1));
+    expect(router.replace.mock.calls[0][0]).toContain('step=2');
+  });
+
+  test('the first of several uploads finishing does NOT navigate to the post step', async () => {
+    setVersion(makeVersion({ fileCount: 0 }));
+    const { rerender } = await renderWithProviders(<ModelVersionWizard />);
+
+    await vi.waitFor(() => expect(router.replace).toHaveBeenCalledTimes(1));
+    expect(router.replace.mock.calls[0][0]).toContain('step=2');
+
+    // First upload lands → version query invalidated → refetch returns a file.
+    setVersion(makeVersion({ fileCount: 1 }));
+    await rerender(<ModelVersionWizard />);
+
+    await vi.waitFor(() => expect(router.replace).toHaveBeenCalledTimes(1));
+    expect(router.replace.mock.calls.some((call) => String(call[0]).includes('step=3'))).toBe(false);
+  });
+
+  test('a draft that already has files still resumes forward to the post step', async () => {
+    setVersion(makeVersion({ fileCount: 2 }));
+    await renderWithProviders(<ModelVersionWizard />);
+
+    await vi.waitFor(() => expect(router.replace).toHaveBeenCalledTimes(1));
+    expect(router.replace.mock.calls[0][0]).toContain('step=3');
+  });
+});

--- a/src/components/Resource/Wizard/ModelVersionWizard.tsx
+++ b/src/components/Resource/Wizard/ModelVersionWizard.tsx
@@ -325,11 +325,11 @@ export function ModelVersionWizard({ data, previousBaseModel }: Props) {
   const isTraining = modelVersion?.uploadType === ModelUploadType.Trained;
 
   useWizardAutoResume({
-    ready: !isNew && !isTraining && !isInitialLoading && !!modelVersion,
+    ready: !isNew && !isTraining && !!modelVersion,
     resolveStep: () => (!hasFiles && !skipFiles ? 2 : 3),
-    onResume: (step) => {
+    onResume: (targetStep) => {
       router
-        .replace(`/models/${id}/model-versions/${versionId}/wizard?step=${step}`, undefined, {
+        .replace(`/models/${id}/model-versions/${versionId}/wizard?step=${targetStep}`, undefined, {
           shallow: true,
         })
         .then();

--- a/src/components/Resource/Wizard/ModelVersionWizard.tsx
+++ b/src/components/Resource/Wizard/ModelVersionWizard.tsx
@@ -9,7 +9,7 @@ import { IconArrowLeft } from '@tabler/icons-react';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import type { NextRouter } from 'next/router';
 import { useRouter } from 'next/router';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { PageLoader } from '~/components/PageLoader/PageLoader';
 
@@ -18,6 +18,7 @@ import { FilesProvider } from '~/components/Resource/FilesProvider';
 import { ModelVersionUpsertForm } from '~/components/Resource/Forms/ModelVersionUpsertForm';
 import { PostUpsertForm2 } from '~/components/Resource/Forms/PostUpsertForm2';
 import TrainingSelectFile from '~/components/Resource/Forms/TrainingSelectFile';
+import { useWizardAutoResume } from '~/components/Resource/Wizard/useWizardAutoResume';
 import { useS3UploadStore } from '~/store/s3-upload.store';
 import type { ModelById, ModelVersionById } from '~/types/router';
 import { trpc } from '~/utils/trpc';
@@ -323,26 +324,17 @@ export function ModelVersionWizard({ data, previousBaseModel }: Props) {
   const postId = modelVersion?.posts?.filter((post) => post.userId === modelData?.user.id)?.[0]?.id;
   const isTraining = modelVersion?.uploadType === ModelUploadType.Trained;
 
-  useEffect(() => {
-    if (isTraining || isInitialLoading) return;
-
-    // redirect to correct step if missing values
-    if (!isNew) {
-      if (!hasFiles && !skipFiles)
-        router
-          .replace(`/models/${id}/model-versions/${versionId}/wizard?step=2`, undefined, {
-            shallow: true,
-          })
-          .then();
-      else
-        router
-          .replace(`/models/${id}/model-versions/${versionId}/wizard?step=3`, undefined, {
-            shallow: true,
-          })
-          .then();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasFiles, skipFiles, id, isNew, versionId]);
+  useWizardAutoResume({
+    ready: !isNew && !isTraining && !isInitialLoading && !!modelVersion,
+    resolveStep: () => (!hasFiles && !skipFiles ? 2 : 3),
+    onResume: (step) => {
+      router
+        .replace(`/models/${id}/model-versions/${versionId}/wizard?step=${step}`, undefined, {
+          shallow: true,
+        })
+        .then();
+    },
+  });
 
   return (
     <FilesProvider model={modelData} version={modelVersion}>

--- a/src/components/Resource/Wizard/ModelWizard.tsx
+++ b/src/components/Resource/Wizard/ModelWizard.tsx
@@ -489,7 +489,7 @@ export function ModelWizard() {
   };
 
   // File-less ExternalGeneration versions don't need the upload step. Hoisted so the
-  // CreateSteps stepper and the auto-redirect effect agree on the same step layout.
+  // CreateSteps stepper and the auto-resume hook agree on the same step layout.
   const skipFiles = modelVersion?.usageControl === ModelUsageControl.ExternalGeneration;
 
   useWizardAutoResume({
@@ -502,9 +502,9 @@ export function ModelWizard() {
       if (!hasFiles && !skipFiles) return 3;
       return 4;
     },
-    onResume: (step) => {
+    onResume: (targetStep) => {
       router
-        .replace(getWizardUrl({ id, step, templateId, bountyId, src }), undefined, {
+        .replace(getWizardUrl({ id, step: targetStep, templateId, bountyId, src }), undefined, {
           shallow: true,
         })
         .then();

--- a/src/components/Resource/Wizard/ModelWizard.tsx
+++ b/src/components/Resource/Wizard/ModelWizard.tsx
@@ -1,7 +1,7 @@
 import { Button, Group, LoadingOverlay, Popover, Stack, Stepper, Text, TextInput, Title } from '@mantine/core';
 import type { NextRouter } from 'next/router';
 import { useRouter } from 'next/router';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import * as z from 'zod';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { FeatureIntroductionHelpButton } from '~/components/FeatureIntroduction/FeatureIntroduction';
@@ -23,6 +23,7 @@ import { sanitizeDownloadFilename } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 import { isNumber } from '~/utils/type-guards';
 import { TemplateSelect } from './TemplateSelect';
+import { useWizardAutoResume } from './useWizardAutoResume';
 import { useWizardStepSave } from './useWizardStepSave';
 import { ReadOnlyAlert } from '~/components/ReadOnlyAlert/ReadOnlyAlert';
 
@@ -491,46 +492,24 @@ export function ModelWizard() {
   // CreateSteps stepper and the auto-redirect effect agree on the same step layout.
   const skipFiles = modelVersion?.usageControl === ModelUsageControl.ExternalGeneration;
 
-  // Only auto-resume to the furthest valid step ONCE, when the model first loads.
-  // Without this guard the effect re-runs on every `model` refetch — e.g. when a
-  // file upload completes and invalidates the model query — yanking the user
-  // forward to the next step. Forward navigation is now user-driven (Next button
-  // or clicking a reachable step indicator).
-  const autoResumedRef = useRef(false);
+  useWizardAutoResume({
+    ready: !isNew && !isTraining && !!model,
+    resolveStep: () => {
+      const hasVersions = !!model && model.modelVersions.length > 0;
+      const hasFiles = !!model && model.modelVersions.some((version) => version.files.length > 0);
 
-  useEffect(() => {
-    // redirect to correct step if missing values
-    if (!isNew) {
-      // don't redirect for trained type or if model is not loaded
-      if (isTraining || !model) return;
-      // resume only once per mount — never push the user forward mid-session
-      if (autoResumedRef.current) return;
-      autoResumedRef.current = true;
-
-      const hasVersions = model.modelVersions.length > 0;
-      const hasFiles = model.modelVersions.some((version) => version.files.length > 0);
-
-      if (!hasVersions)
-        router
-          .replace(getWizardUrl({ id, step: 2, templateId, bountyId, src }), undefined, {
-            shallow: true,
-          })
-          .then();
-      else if (!hasFiles && !skipFiles)
-        router
-          .replace(getWizardUrl({ id, step: 3, templateId, bountyId, src }), undefined, {
-            shallow: true,
-          })
-          .then();
-      else
-        router
-          .replace(getWizardUrl({ id, step: 4, templateId, bountyId, src }), undefined, {
-            shallow: true,
-          })
-          .then();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, isNew, model, modelVersion, templateId, bountyId, src]);
+      if (!hasVersions) return 2;
+      if (!hasFiles && !skipFiles) return 3;
+      return 4;
+    },
+    onResume: (step) => {
+      router
+        .replace(getWizardUrl({ id, step, templateId, bountyId, src }), undefined, {
+          shallow: true,
+        })
+        .then();
+    },
+  });
 
   const postId = modelVersion?.posts[0]?.id;
 

--- a/src/components/Resource/Wizard/useWizardAutoResume.browser.test.tsx
+++ b/src/components/Resource/Wizard/useWizardAutoResume.browser.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, test, vi } from 'vitest';
+import { useState } from 'react';
+import { renderWithProviders } from '../../../../test/component-setup';
+import { useWizardAutoResume } from '~/components/Resource/Wizard/useWizardAutoResume';
+
+/**
+ * Regression cover for the model-version wizard jumping to the post step as soon
+ * as the FIRST of several files finished uploading: that upload invalidates the
+ * version query, `hasFiles` flips, and an unguarded resume effect re-fired.
+ */
+
+function Harness({
+  initialReady,
+  onResume,
+}: {
+  initialReady: boolean;
+  onResume: (step: number) => void;
+}) {
+  const [ready, setReady] = useState(initialReady);
+  const [hasFiles, setHasFiles] = useState(false);
+
+  useWizardAutoResume({
+    ready,
+    resolveStep: () => (hasFiles ? 3 : 2),
+    onResume,
+  });
+
+  return (
+    <div>
+      <button data-testid="load" onClick={() => setReady(true)}>
+        load
+      </button>
+      <button data-testid="complete-upload" onClick={() => setHasFiles(true)}>
+        complete upload
+      </button>
+    </div>
+  );
+}
+
+function click(testId: string) {
+  const el = document.querySelector<HTMLButtonElement>(`[data-testid="${testId}"]`);
+  if (!el) throw new Error(`missing button: ${testId}`);
+  el.click();
+}
+
+describe('useWizardAutoResume', () => {
+  test('resumes once the data is ready', async () => {
+    const onResume = vi.fn();
+    await renderWithProviders(<Harness initialReady={true} onResume={onResume} />);
+
+    await vi.waitFor(() => expect(onResume).toHaveBeenCalledTimes(1));
+    expect(onResume).toHaveBeenCalledWith(2);
+  });
+
+  test('does not resume while the data is still loading', async () => {
+    const onResume = vi.fn();
+    await renderWithProviders(<Harness initialReady={false} onResume={onResume} />);
+
+    expect(onResume).not.toHaveBeenCalled();
+
+    click('load');
+    await vi.waitFor(() => expect(onResume).toHaveBeenCalledTimes(1));
+  });
+
+  test('a mid-session input change does NOT push the user forward again', async () => {
+    const onResume = vi.fn();
+    await renderWithProviders(<Harness initialReady={true} onResume={onResume} />);
+
+    await vi.waitFor(() => expect(onResume).toHaveBeenCalledTimes(1));
+    expect(onResume).toHaveBeenCalledWith(2);
+
+    // First of several uploads lands → version query invalidated → `hasFiles` flips.
+    click('complete-upload');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(onResume).not.toHaveBeenCalledWith(3);
+  });
+});

--- a/src/components/Resource/Wizard/useWizardAutoResume.browser.test.tsx
+++ b/src/components/Resource/Wizard/useWizardAutoResume.browser.test.tsx
@@ -1,12 +1,13 @@
 import { describe, expect, test, vi } from 'vitest';
 import { useState } from 'react';
+import { page } from 'vitest/browser';
 import { renderWithProviders } from '../../../../test/component-setup';
 import { useWizardAutoResume } from '~/components/Resource/Wizard/useWizardAutoResume';
 
 /**
- * Regression cover for the model-version wizard jumping to the post step as soon
- * as the FIRST of several files finished uploading: that upload invalidates the
- * version query, `hasFiles` flips, and an unguarded resume effect re-fired.
+ * Hook-level cover. The wizard-level regression for the reported bug (the post
+ * step stealing the user mid-upload) lives in
+ * `ModelVersionWizard.autoResume.browser.test.tsx`.
  */
 
 function Harness({
@@ -14,7 +15,7 @@ function Harness({
   onResume,
 }: {
   initialReady: boolean;
-  onResume: (step: number) => void;
+  onResume: (targetStep: number) => void;
 }) {
   const [ready, setReady] = useState(initialReady);
   const [hasFiles, setHasFiles] = useState(false);
@@ -27,6 +28,7 @@ function Harness({
 
   return (
     <div>
+      <span data-testid="has-files">{String(hasFiles)}</span>
       <button data-testid="load" onClick={() => setReady(true)}>
         load
       </button>
@@ -69,11 +71,9 @@ describe('useWizardAutoResume', () => {
     await vi.waitFor(() => expect(onResume).toHaveBeenCalledTimes(1));
     expect(onResume).toHaveBeenCalledWith(2);
 
-    // First of several uploads lands → version query invalidated → `hasFiles` flips.
     click('complete-upload');
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await expect.element(page.getByTestId('has-files')).toHaveTextContent('true');
 
     expect(onResume).toHaveBeenCalledTimes(1);
-    expect(onResume).not.toHaveBeenCalledWith(3);
   });
 });

--- a/src/components/Resource/Wizard/useWizardAutoResume.ts
+++ b/src/components/Resource/Wizard/useWizardAutoResume.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Resumes an existing draft at its furthest valid step ONCE, on first load.
+ *
+ * The resume inputs (has-a-version, has-files) are derived from queries that get
+ * invalidated mid-session — notably when a file upload completes. Re-running the
+ * resume on those changes yanks the user forward while their other files are
+ * still transferring, so forward navigation stays user-driven (Next button or a
+ * reachable step indicator) after this fires.
+ */
+export function useWizardAutoResume({
+  ready,
+  resolveStep,
+  onResume,
+}: {
+  ready: boolean;
+  resolveStep: () => number;
+  onResume: (step: number) => void;
+}) {
+  const resumedRef = useRef(false);
+  const resolveStepRef = useRef(resolveStep);
+  const onResumeRef = useRef(onResume);
+  resolveStepRef.current = resolveStep;
+  onResumeRef.current = onResume;
+
+  useEffect(() => {
+    if (!ready || resumedRef.current) return;
+    resumedRef.current = true;
+    onResumeRef.current(resolveStepRef.current());
+  }, [ready]);
+}

--- a/src/components/Resource/Wizard/useWizardAutoResume.ts
+++ b/src/components/Resource/Wizard/useWizardAutoResume.ts
@@ -1,13 +1,11 @@
 import { useEffect, useRef } from 'react';
 
 /**
- * Resumes an existing draft at its furthest valid step ONCE, on first load.
+ * Resumes a draft at its furthest valid step once, on first load.
  *
- * The resume inputs (has-a-version, has-files) are derived from queries that get
- * invalidated mid-session — notably when a file upload completes. Re-running the
- * resume on those changes yanks the user forward while their other files are
- * still transferring, so forward navigation stays user-driven (Next button or a
- * reachable step indicator) after this fires.
+ * `resolveStep`'s inputs come from queries that get invalidated mid-session (a
+ * completed file upload, say); re-resuming on those changes yanks the user
+ * forward mid-flow, so this fires exactly once per mount.
  */
 export function useWizardAutoResume({
   ready,
@@ -16,17 +14,13 @@ export function useWizardAutoResume({
 }: {
   ready: boolean;
   resolveStep: () => number;
-  onResume: (step: number) => void;
+  onResume: (targetStep: number) => void;
 }) {
   const resumedRef = useRef(false);
-  const resolveStepRef = useRef(resolveStep);
-  const onResumeRef = useRef(onResume);
-  resolveStepRef.current = resolveStep;
-  onResumeRef.current = onResume;
 
   useEffect(() => {
     if (!ready || resumedRef.current) return;
     resumedRef.current = true;
-    onResumeRef.current(resolveStepRef.current());
-  }, [ready]);
+    onResume(resolveStep());
+  }, [ready, resolveStep, onResume]);
 }


### PR DESCRIPTION
Fixes [868ke490b](https://app.clickup.com/t/8459928/868ke490b) — "Multi-model upload auto-advances to image step".

## The bug

Dropping several files on the version wizard's **Upload files** step: the *first* file to finish uploading navigated the user to the post/image step while the rest were still transferring.

`modelFile.create` → `queryUtils.modelVersion.getByIdForEdit.invalidate()` (`FilesProvider.tsx:495`) → refetch → `hasFiles` flips `false → true` → the auto-resume `useEffect` in `ModelVersionWizard` (which listed `hasFiles` in its deps and had no once-guard) re-fired → `router.replace(...wizard?step=3)`.

So "any one model finishes" in the report = any one *file* finishes.

## The fix

`ModelWizard` already had this exact fix — a local `autoResumedRef` latch from #2662. `ModelVersionWizard` was missed. That divergence *is* the bug, so rather than copy the latch a second time, both wizards now share `useWizardAutoResume`: resume to the furthest valid step once when data first loads, then leave forward navigation to the user (Next button or a reachable step indicator).

`ModelWizard`'s behavior is unchanged — same `isTraining`/`!model`/`skipFiles` conditions, same 2/3/4 ladder. Both call sites also shed their `eslint-disable react-hooks/exhaustive-deps`, which is what let the bug hide.

## Behavior change worth knowing

The version wizard no longer bounces you *back* to step 2 when you delete the last file. This matches `ModelWizard`'s already-shipped semantics; the post step renders unconditionally and publish is gated server-side, so nothing is bypassed.

## Tests

- `ModelVersionWizard.autoResume.browser.test.tsx` — mounts the wizard and asserts on `router.replace`. Verified red: reverting the wizard to the unguarded effect gives `expected "vi.fn()" to be called 1 times, but got 2 times`.
- `useWizardAutoResume.browser.test.tsx` — hook-level cover.

6/6 pass, `pnpm run typecheck` clean.

⚠️ The `component` vitest project is currently broken *locally* — `No loader is configured for ".node" files: .../sharp-darwin-arm64v8.node` during dep optimize. Pre-existing and unrelated (untouched browser tests fail identically; survives a `.vite` wipe + `pnpm install`), but **CI may hit the same wall**. I ran these tests via a temporary config scoping `optimizeDeps.entries` to the two files; that config is not committed.

## Not fixed here

The report also claims "going back to check a still-uploading model risks corrupting the upload." No code path supports that — `FilesProvider` wraps the whole stepper and uploads live in the global S3 store, so stepping back doesn't unmount or abort anything. Needs confirmation from MNeMiC (mnemic1) on whether a file actually went missing, or whether it was just the auto-advance being disorienting.

Separately noted during review, pre-existing: `ModelVersionMenu.tsx:263`'s "Add images" links to `?step=3`, but a file-less version resumes to step 2 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)