### PR TITLE
fix(challenges): Challenges feedback round — personal row, merged page, filters, creator score

### DIFF
--- a/docs/features/challenge-platform.md
+++ b/docs/features/challenge-platform.md
@@ -55,7 +55,7 @@ Judging is category-driven for **all** sources (no feature flag): any challenge 
 **Client**
 - `src/components/Challenge/ChallengeUpsertForm.tsx` (unified create/edit, `variant` prop), `CategoryWeights.tsx`, `ChallengeContextMenu.tsx`, `ChallengeSubmitModal.tsx`, `challenge.utils.ts`.
 - `src/components/Cards/ChallengeCard.tsx`.
-- `src/pages/challenges/index.tsx` (feed + "My Challenges"), `src/pages/challenges/[id]/[[...slug]].tsx` (detail), `src/pages/challenges/[id]/edit.tsx`, `src/pages/challenges/create.tsx`, `src/pages/moderator/challenges.tsx`.
+- `src/pages/challenges/index.tsx` (feed + "Your Challenges" personal view), `src/pages/challenges/[id]/[[...slug]].tsx` (detail), `src/pages/challenges/[id]/edit.tsx`, `src/pages/challenges/create.tsx`, `src/pages/moderator/challenges.tsx`.
 
 **Config source**: `getChallengeConfig()` reads `REDIS_SYS_KEYS.DAILY_CHALLENGE.CONFIG` from sysRedis with a code-default fallback (fail-open). LLM prompt text comes from the `ChallengeType` table; judge personas from `ChallengeJudge`.
 
@@ -225,7 +225,7 @@ Creators can **view / edit / delete their own `User` challenges only while `Sche
 - `deleteUserChallenge({ id, userId })` — `protectedProcedure`, both flags; guards owner + `source=User` + `Scheduled` + 0 entries, then `deleteChallenge` (refunds escrowed prize, cascades). Delete re-reads status so it **fails safe** if it races activation (blocks on `Active`); full idempotency under concurrent delete is an open verification item **(deferred)**.
 - `getUserChallengeForEdit({ id, userId })` — owner-gated edit payload.
 - `getInfiniteChallenges`/`getChallengeDetail` expose top-level **`createdById`** (the field all owner checks use).
-- Client: `useDeleteUserChallenge()`, `ChallengeContextMenu` (owner Edit/Delete, self-gating), owner menu on `ChallengeCard` + detail; edit route `/challenges/[id]/edit` (`variant="user"`, standing-only); "My Challenges" mode at `/challenges?engagement=created` (creator exempt from scan gate, `visibleAt=now()`); nav link in the user dropdown.
+- Client: `useDeleteUserChallenge()`, `ChallengeContextMenu` (owner Edit/Delete, self-gating), owner menu on `ChallengeCard` + detail; edit route `/challenges/[id]/edit` (`variant="user"`, standing-only, creator exempt from scan gate, `visibleAt=now()`). The two personal engagement views are merged into one **"Your Challenges"** page (`/challenges?engagement=participated|created`) with a Participated | Created control plus a status control; Created defaults to Scheduled. The horizontal `YourChallengesRow` on `/challenges` covers both entered and created challenges (`getMyChallenges`; `MyChallengeResult` gains a `hosting` member with its own badge and "Manage"/"View results" CTA), and its "See all" link routes to whichever tab the row's contents match. Community Challenges' participation filter has a "Hosting" option (`ChallengeParticipation.Created`). The user-dropdown nav link reads "Your Challenges".
 
 ---
 

--- a/src/components/Account/StrikesCard.tsx
+++ b/src/components/Account/StrikesCard.tsx
@@ -7,17 +7,19 @@ import { getDisplayName } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 import { UserScoreDisplay } from './UserScoreDisplay';
 
-// The strike email links to `/user/account#strikes`. This card sits near the
-// bottom of the page and only renders its `id` once data loads, so the browser's
-// native hash scroll fires too early. A stable callback ref scrolls the card into
-// view the moment its node mounts (post-load). `scroll-margin-top` (globals.css
-// `[id]`) clears the fixed header. Module-level so its identity stays stable —
-// an inline ref would re-run on every render.
-function scrollToStrikesIfHashed(node: HTMLDivElement | null) {
-  if (node && typeof window !== 'undefined' && window.location.hash === '#strikes') {
-    node.scrollIntoView({ block: 'start' });
-  }
+// The strike email links to `/user/account#strikes`, and the challenge/creator-program eligibility
+// rows link to `#creator-score`. Both targets only render their `id` once data loads, so the
+// browser's native hash scroll fires too early. Module-level so the ref identity stays stable.
+function scrollIfHashed(hash: string) {
+  return (node: HTMLElement | null) => {
+    if (node && typeof window !== 'undefined' && window.location.hash === hash) {
+      node.scrollIntoView({ block: 'start' });
+    }
+  };
 }
+
+const scrollToStrikes = scrollIfHashed('#strikes');
+const scrollToCreatorScore = scrollIfHashed('#creator-score');
 
 export function StrikesCard() {
   const currentUser = useCurrentUser();
@@ -44,7 +46,7 @@ export function StrikesCard() {
   const strikes = strikesData?.strikes ?? [];
 
   return (
-    <Card withBorder id="strikes" ref={scrollToStrikesIfHashed}>
+    <Card withBorder id="strikes" ref={scrollToStrikes}>
       <Stack gap="lg">
         {/* Header — the standing badge now lives beside the Strikes subheading below,
             since it's derived purely from strike points, not the Creator Score. Keeping
@@ -53,8 +55,9 @@ export function StrikesCard() {
 
         <Divider />
 
-        {/* User Score Section */}
-        <UserScoreDisplay scores={scores} />
+        <div id="creator-score" ref={scrollToCreatorScore}>
+          <UserScoreDisplay scores={scores} />
+        </div>
 
         <Divider />
 

--- a/src/components/AppLayout/AppHeader/hooks.tsx
+++ b/src/components/AppLayout/AppHeader/hooks.tsx
@@ -144,7 +144,7 @@ export function useGetMenuItems(): UserMenuItemGroup[] {
           visible: features.challengePlatform && features.userChallenges,
           icon: IconTrophy,
           color: theme.colors.pink[getPrimaryShade(theme, colorScheme ?? 'dark')],
-          label: 'My Challenges',
+          label: 'Your Challenges',
           newUntil: new Date('2026-08-15'),
         },
         {

--- a/src/components/Buzz/CreatorProgramV2/CreatorProgramV2.modals.tsx
+++ b/src/components/Buzz/CreatorProgramV2/CreatorProgramV2.modals.tsx
@@ -233,29 +233,6 @@ export const openExtractionFeeModal = () => {
   });
 };
 
-export const openCreatorScoreModal = () => {
-  dialogStore.trigger({
-    component: AlertDialog,
-    props: {
-      title: 'What is your Creator Score?',
-      type: 'info',
-      icon: null,
-      children: ({ handleClose }) => (
-        <div className="flex flex-col justify-center gap-4">
-          <p>
-            Creator Score is a value we calculate based on your participation in the Civitai
-            community, including your activity and how others engage with the content and models you
-            create.
-          </p>
-          <Button className="mt-2" onClick={handleClose}>
-            Close
-          </Button>
-        </div>
-      ),
-    },
-  });
-};
-
 export const CreatorProgramCapsInfo = ({ onUpgrade }: { onUpgrade?: () => void }) => {
   const { banked, isLoading } = useBankedBuzz();
 

--- a/src/components/Buzz/CreatorProgramV2/CreatorProgramV2.tsx
+++ b/src/components/Buzz/CreatorProgramV2/CreatorProgramV2.tsx
@@ -46,7 +46,6 @@ import {
 import {
   CreatorProgramCapsInfoModal,
   openCompensationPoolModal,
-  openCreatorScoreModal,
   openEarningEstimateModal,
   openExtractionFeeModal,
   openPhasesModal,
@@ -354,20 +353,17 @@ const JoinCreatorProgramCard = () => {
               requirements?.score.min ?? 10000
             )}`}
             content={
-              <>
-                <p className="my-0">
-                  Your current{' '}
-                  <Anchor
-                    onClick={() => {
-                      openCreatorScoreModal();
-                    }}
-                    inherit
-                  >
-                    Creator Score
-                  </Anchor>{' '}
-                  is {abbreviateNumber(requirements?.score.current ?? 0)}.
-                </p>
-              </>
+              <p className="my-0">
+                Your current{' '}
+                <Anchor component={NextLink} href="/user/account#creator-score" inherit>
+                  Creator Score
+                </Anchor>{' '}
+                is{' '}
+                <Anchor component={NextLink} href="/user/account#creator-score" inherit>
+                  {abbreviateNumber(requirements?.score.current ?? 0)}
+                </Anchor>
+                .
+              </p>
             }
           />
           <CreatorProgramRequirement

--- a/src/components/Cards/MyChallengeCard.stories.tsx
+++ b/src/components/Cards/MyChallengeCard.stories.tsx
@@ -1,5 +1,5 @@
 import { ChallengeSource, ChallengeStatus, MediaType } from '~/shared/utils/prisma/enums';
-import type { MyParticipatedChallengeItem } from '~/server/schema/challenge.schema';
+import type { MyChallengeItem } from '~/server/schema/challenge.schema';
 import { MyChallengeCard } from './MyChallengeCard';
 
 const now = new Date();
@@ -15,7 +15,7 @@ const baseImage = {
   type: MediaType.image,
 };
 
-const baseChallenge: MyParticipatedChallengeItem = {
+const baseChallenge: MyChallengeItem = {
   id: 101,
   title: 'Cybernetic Dreams',
   theme: 'Neon-soaked futures',
@@ -46,10 +46,10 @@ const baseChallenge: MyParticipatedChallengeItem = {
   myPlace: null,
   myResult: 'entered',
   isLive: false,
-  myEnteredAt: daysFromNow(-5),
+  myActivityAt: daysFromNow(-5),
 };
 
-const wrap = (data: MyParticipatedChallengeItem) => (
+const wrap = (data: MyChallengeItem) => (
   <div style={{ width: 320 }}>
     <MyChallengeCard data={data} />
   </div>

--- a/src/components/Cards/MyChallengeCard.stories.tsx
+++ b/src/components/Cards/MyChallengeCard.stories.tsx
@@ -42,7 +42,6 @@ const baseChallenge: MyChallengeItem = {
     cosmetics: null,
     deletedAt: null,
   },
-  myEntryImage: baseImage,
   myPlace: null,
   myResult: 'entered',
   isLive: false,
@@ -103,7 +102,6 @@ export const HostingScheduled = () =>
     myPlace: null,
     myResult: 'hosting',
     isLive: false,
-    myEntryImage: null,
     startsAt: daysFromNow(2),
     endsAt: daysFromNow(9),
   });
@@ -116,7 +114,6 @@ export const HostingLive = () =>
     myPlace: null,
     myResult: 'hosting',
     isLive: true,
-    myEntryImage: null,
     startsAt: daysFromNow(-2),
     endsAt: daysFromNow(3),
   });

--- a/src/components/Cards/MyChallengeCard.stories.tsx
+++ b/src/components/Cards/MyChallengeCard.stories.tsx
@@ -94,3 +94,29 @@ export const EnteredEnded = () =>
     myResult: 'entered',
     isLive: false,
   });
+
+/** Hosting state: scheduled, not yet started — grape crown badge, "Starts …" chip, "Manage" CTA */
+export const HostingScheduled = () =>
+  wrap({
+    ...baseChallenge,
+    status: ChallengeStatus.Scheduled,
+    myPlace: null,
+    myResult: 'hosting',
+    isLive: false,
+    myEntryImage: null,
+    startsAt: daysFromNow(2),
+    endsAt: daysFromNow(9),
+  });
+
+/** Hosting state: live — grape crown badge, "… left · Live" chip, "View entries" CTA */
+export const HostingLive = () =>
+  wrap({
+    ...baseChallenge,
+    status: ChallengeStatus.Active,
+    myPlace: null,
+    myResult: 'hosting',
+    isLive: true,
+    myEntryImage: null,
+    startsAt: daysFromNow(-2),
+    endsAt: daysFromNow(3),
+  });

--- a/src/components/Cards/MyChallengeCard.tsx
+++ b/src/components/Cards/MyChallengeCard.tsx
@@ -15,7 +15,11 @@ import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImag
 import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import { NextLink } from '~/components/NextLink/NextLink';
 import { slugit } from '~/utils/string-helpers';
-import { getMyChallengeBadge, getMyChallengeCta } from './myChallengeCard.utils';
+import {
+  getMyChallengeBadge,
+  getMyChallengeCta,
+  getMyChallengeCtaHref,
+} from './myChallengeCard.utils';
 import type { MyChallengeItem } from '~/server/schema/challenge.schema';
 import { ChallengeStatus } from '~/shared/utils/prisma/enums';
 
@@ -38,30 +42,14 @@ const badgeStyles = {
 } as const;
 
 export const MyChallengeCard = memo(function MyChallengeCard({ data }: { data: MyChallengeItem }) {
-  const {
-    id,
-    title,
-    theme,
-    coverImage,
-    myEntryImage,
-    myResult,
-    myPlace,
-    isLive,
-    status,
-    startsAt,
-    endsAt,
-  } = data;
+  const { id, title, theme, coverImage, myResult, myPlace, isLive, status, startsAt, endsAt } =
+    data;
   const badge = getMyChallengeBadge(myResult, myPlace);
   const cta = getMyChallengeCta(myResult, isLive, status);
   const BadgeIcon = badgeIcons[badge.icon];
   const badgeStyle = badgeStyles[badge.color];
   const challengeHref = `/challenges/${id}/${slugit(title)}`;
-  const ctaHref =
-    cta.kind === 'entry' && myEntryImage
-      ? `/images/${myEntryImage.id}`
-      : cta.kind === 'manage'
-      ? `/challenges/${id}/edit`
-      : challengeHref;
+  const ctaHref = getMyChallengeCtaHref(cta.kind, { id, title });
 
   const image = coverImage
     ? {

--- a/src/components/Cards/MyChallengeCard.tsx
+++ b/src/components/Cards/MyChallengeCard.tsx
@@ -5,6 +5,7 @@ import {
   IconMedal,
   IconHourglass,
   IconCheck,
+  IconCrown,
   IconArrowRight,
   IconPlus,
 } from '@tabler/icons-react';
@@ -15,13 +16,15 @@ import { DaysFromNow } from '~/components/Dates/DaysFromNow';
 import { NextLink } from '~/components/NextLink/NextLink';
 import { slugit } from '~/utils/string-helpers';
 import { getMyChallengeBadge, getMyChallengeCta } from './myChallengeCard.utils';
-import type { MyParticipatedChallengeItem } from '~/server/schema/challenge.schema';
+import type { MyChallengeItem } from '~/server/schema/challenge.schema';
+import { ChallengeStatus } from '~/shared/utils/prisma/enums';
 
 const badgeIcons = {
   trophy: IconTrophy,
   medal: IconMedal,
   hourglass: IconHourglass,
   check: IconCheck,
+  crown: IconCrown,
 } as const;
 
 // Per-result badge palette (matches designs/challenges-feed.pen v4). Gold uses dark content for
@@ -31,33 +34,44 @@ const badgeStyles = {
   dark: { bg: 'var(--mantine-color-gray-8)', fg: '#ffffff' },
   blue: { bg: 'var(--mantine-color-blue-6)', fg: '#ffffff' },
   green: { bg: 'var(--mantine-color-green-8)', fg: '#ffffff' },
+  grape: { bg: 'var(--mantine-color-grape-6)', fg: '#ffffff' },
 } as const;
 
-export const MyChallengeCard = memo(function MyChallengeCard({
-  data,
-}: {
-  data: MyParticipatedChallengeItem;
-}) {
-  const { id, title, theme, myEntryImage, myResult, myPlace, isLive, endsAt } = data;
+export const MyChallengeCard = memo(function MyChallengeCard({ data }: { data: MyChallengeItem }) {
+  const {
+    id,
+    title,
+    theme,
+    coverImage,
+    myEntryImage,
+    myResult,
+    myPlace,
+    isLive,
+    status,
+    startsAt,
+    endsAt,
+  } = data;
   const badge = getMyChallengeBadge(myResult, myPlace);
-  const cta = getMyChallengeCta(myResult, isLive);
+  const cta = getMyChallengeCta(myResult, isLive, status);
   const BadgeIcon = badgeIcons[badge.icon];
   const badgeStyle = badgeStyles[badge.color];
   const challengeHref = `/challenges/${id}/${slugit(title)}`;
-  // "View entry" goes straight to the user's own image; everything else (results, and the
-  // submit flow "Add another entry" opens from) lives on the challenge page.
   const ctaHref =
-    cta.kind === 'entry' && myEntryImage ? `/images/${myEntryImage.id}` : challengeHref;
+    cta.kind === 'entry' && myEntryImage
+      ? `/images/${myEntryImage.id}`
+      : cta.kind === 'manage'
+      ? `/challenges/${id}/edit`
+      : challengeHref;
 
-  const image = myEntryImage
+  const image = coverImage
     ? {
-        id: myEntryImage.id,
-        url: myEntryImage.url,
-        type: myEntryImage.type,
-        width: myEntryImage.width ?? 512,
-        height: myEntryImage.height ?? 512,
-        nsfwLevel: myEntryImage.nsfwLevel,
-        hash: myEntryImage.hash,
+        id: coverImage.id,
+        url: coverImage.url,
+        type: coverImage.type,
+        width: coverImage.width ?? 512,
+        height: coverImage.height ?? 512,
+        nsfwLevel: coverImage.nsfwLevel,
+        hash: coverImage.hash,
         metadata: null,
       }
     : undefined;
@@ -91,7 +105,11 @@ export const MyChallengeCard = memo(function MyChallengeCard({
             style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
           >
             <Text size="xs" fw={600} c="gray.2">
-              {isLive ? (
+              {status === ChallengeStatus.Scheduled ? (
+                <>
+                  Starts <DaysFromNow date={startsAt} />
+                </>
+              ) : isLive ? (
                 <>
                   <DaysFromNow date={endsAt} withoutSuffix /> left · Live
                 </>

--- a/src/components/Cards/MyChallengeCard.tsx
+++ b/src/components/Cards/MyChallengeCard.tsx
@@ -113,9 +113,11 @@ export const MyChallengeCard = memo(function MyChallengeCard({ data }: { data: M
                 <>
                   <DaysFromNow date={endsAt} withoutSuffix /> left · Live
                 </>
-              ) : myResult === 'judging' ? (
+              ) : status === ChallengeStatus.Completing ? (
                 // No judging deadline is exposed, and "Ended 3h ago" next to a Judging badge
-                // reads as a contradiction, so state the phase instead of a date.
+                // reads as a contradiction, so state the phase instead of a date. Gated on status
+                // rather than myResult: a hosting creator's result is always 'hosting', never
+                // 'judging', but they're in the same phase as an entrant here.
                 'Judging'
               ) : (
                 <>

--- a/src/components/Cards/myChallengeCard.utils.test.ts
+++ b/src/components/Cards/myChallengeCard.utils.test.ts
@@ -38,8 +38,12 @@ describe('getMyChallengeCtaHref', () => {
 
   it('manage skips the deep link and goes to the edit page', () =>
     expect(getMyChallengeCtaHref('manage', challenge)).toBe('/challenges/42/edit'));
-  it('results anchors to the entries gallery', () =>
+  it('results anchors to the winners podium', () =>
     expect(getMyChallengeCtaHref('results', challenge)).toBe(
+      '/challenges/42/crystal-caverns#winners'
+    ));
+  it('entries anchors to the entries gallery', () =>
+    expect(getMyChallengeCtaHref('entries', challenge)).toBe(
       '/challenges/42/crystal-caverns#entries'
     ));
   it('entry anchors to the entries gallery filtered to the viewer', () =>
@@ -86,7 +90,7 @@ describe('hosting', () => {
 
   test('a live hosted challenge offers View entries', () => {
     expect(getMyChallengeCta('hosting', true, ChallengeStatus.Active)).toEqual({
-      kind: 'results',
+      kind: 'entries',
       label: 'View entries',
       filled: 'white',
     });
@@ -94,7 +98,7 @@ describe('hosting', () => {
 
   test('a hosted challenge being judged offers View entries, not View results', () => {
     expect(getMyChallengeCta('hosting', false, ChallengeStatus.Completing)).toEqual({
-      kind: 'results',
+      kind: 'entries',
       label: 'View entries',
       filled: 'white',
     });

--- a/src/components/Cards/myChallengeCard.utils.test.ts
+++ b/src/components/Cards/myChallengeCard.utils.test.ts
@@ -69,6 +69,14 @@ describe('hosting', () => {
     });
   });
 
+  test('a hosted challenge being judged offers View entries, not View results', () => {
+    expect(getMyChallengeCta('hosting', false, ChallengeStatus.Completing)).toEqual({
+      kind: 'results',
+      label: 'View entries',
+      filled: 'white',
+    });
+  });
+
   test('a finished hosted challenge offers View results', () => {
     expect(getMyChallengeCta('hosting', false, ChallengeStatus.Completed)).toEqual({
       kind: 'results',

--- a/src/components/Cards/myChallengeCard.utils.test.ts
+++ b/src/components/Cards/myChallengeCard.utils.test.ts
@@ -1,27 +1,28 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, test, expect } from 'vitest';
 import { getMyChallengeCta, getMyChallengeBadge } from './myChallengeCard.utils';
+import { ChallengeStatus } from '~/shared/utils/prisma/enums';
 
 describe('getMyChallengeCta', () => {
   it('won => View results (white)', () =>
-    expect(getMyChallengeCta('won', false)).toEqual({
+    expect(getMyChallengeCta('won', false, ChallengeStatus.Completed)).toEqual({
       kind: 'results',
       label: 'View results',
       filled: 'white',
     }));
   it('judging => View entry (white)', () =>
-    expect(getMyChallengeCta('judging', false)).toEqual({
+    expect(getMyChallengeCta('judging', false, ChallengeStatus.Completed)).toEqual({
       kind: 'entry',
       label: 'View entry',
       filled: 'white',
     }));
   it('entered + live => Add another entry (blue)', () =>
-    expect(getMyChallengeCta('entered', true)).toEqual({
+    expect(getMyChallengeCta('entered', true, ChallengeStatus.Active)).toEqual({
       kind: 'add',
       label: 'Add another entry',
       filled: 'blue',
     }));
   it('entered + not live => View results (white)', () =>
-    expect(getMyChallengeCta('entered', false)).toEqual({
+    expect(getMyChallengeCta('entered', false, ChallengeStatus.Completed)).toEqual({
       kind: 'results',
       label: 'View results',
       filled: 'white',
@@ -41,4 +42,38 @@ describe('getMyChallengeBadge', () => {
       color: 'gold',
       icon: 'trophy',
     }));
+});
+
+describe('hosting', () => {
+  test('badge is a grape crown', () => {
+    expect(getMyChallengeBadge('hosting', null)).toEqual({
+      label: 'Hosting',
+      color: 'grape',
+      icon: 'crown',
+    });
+  });
+
+  test('a scheduled hosted challenge offers Manage', () => {
+    expect(getMyChallengeCta('hosting', false, ChallengeStatus.Scheduled)).toEqual({
+      kind: 'manage',
+      label: 'Manage',
+      filled: 'white',
+    });
+  });
+
+  test('a live hosted challenge offers View entries', () => {
+    expect(getMyChallengeCta('hosting', true, ChallengeStatus.Active)).toEqual({
+      kind: 'results',
+      label: 'View entries',
+      filled: 'white',
+    });
+  });
+
+  test('a finished hosted challenge offers View results', () => {
+    expect(getMyChallengeCta('hosting', false, ChallengeStatus.Completed)).toEqual({
+      kind: 'results',
+      label: 'View results',
+      filled: 'white',
+    });
+  });
 });

--- a/src/components/Cards/myChallengeCard.utils.test.ts
+++ b/src/components/Cards/myChallengeCard.utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, test, expect } from 'vitest';
-import { getMyChallengeCta, getMyChallengeBadge } from './myChallengeCard.utils';
+import {
+  getMyChallengeCta,
+  getMyChallengeBadge,
+  getMyChallengeCtaHref,
+} from './myChallengeCard.utils';
 import { ChallengeStatus } from '~/shared/utils/prisma/enums';
 
 describe('getMyChallengeCta', () => {
@@ -27,6 +31,25 @@ describe('getMyChallengeCta', () => {
       label: 'View results',
       filled: 'white',
     }));
+});
+
+describe('getMyChallengeCtaHref', () => {
+  const challenge = { id: 42, title: 'Crystal Caverns' };
+
+  it('manage skips the deep link and goes to the edit page', () =>
+    expect(getMyChallengeCtaHref('manage', challenge)).toBe('/challenges/42/edit'));
+  it('results anchors to the entries gallery', () =>
+    expect(getMyChallengeCtaHref('results', challenge)).toBe(
+      '/challenges/42/crystal-caverns#entries'
+    ));
+  it('entry anchors to the entries gallery filtered to the viewer', () =>
+    expect(getMyChallengeCtaHref('entry', challenge)).toBe(
+      '/challenges/42/crystal-caverns?mine=1#entries'
+    ));
+  it('add opens the submit modal on arrival', () =>
+    expect(getMyChallengeCtaHref('add', challenge)).toBe(
+      '/challenges/42/crystal-caverns?submit=1#entries'
+    ));
 });
 
 describe('getMyChallengeBadge', () => {

--- a/src/components/Cards/myChallengeCard.utils.ts
+++ b/src/components/Cards/myChallengeCard.utils.ts
@@ -1,11 +1,19 @@
+import { ChallengeStatus } from '~/shared/utils/prisma/enums';
 import type { MyChallengeResult } from '~/server/schema/challenge.schema';
 
-export type MyChallengeCtaKind = 'results' | 'entry' | 'add';
+export type MyChallengeCtaKind = 'results' | 'entry' | 'add' | 'manage';
 
 export function getMyChallengeCta(
   result: MyChallengeResult,
-  isLive: boolean
+  isLive: boolean,
+  status: ChallengeStatus
 ): { kind: MyChallengeCtaKind; label: string; filled: 'white' | 'blue' } {
+  if (result === 'hosting') {
+    // Before it starts, the only useful action is editing it — after that, looking at it.
+    if (status === ChallengeStatus.Scheduled)
+      return { kind: 'manage', label: 'Manage', filled: 'white' };
+    return { kind: 'results', label: isLive ? 'View entries' : 'View results', filled: 'white' };
+  }
   if (result === 'judging') return { kind: 'entry', label: 'View entry', filled: 'white' };
   if (result === 'entered' && isLive)
     return { kind: 'add', label: 'Add another entry', filled: 'blue' };
@@ -15,8 +23,14 @@ export function getMyChallengeCta(
 export function getMyChallengeBadge(
   result: MyChallengeResult,
   myPlace: number | null
-): { label: string; color: 'gold' | 'dark' | 'blue' | 'green'; icon: 'trophy' | 'medal' | 'hourglass' | 'check' } {
+): {
+  label: string;
+  color: 'gold' | 'dark' | 'blue' | 'green' | 'grape';
+  icon: 'trophy' | 'medal' | 'hourglass' | 'check' | 'crown';
+} {
   switch (result) {
+    case 'hosting':
+      return { label: 'Hosting', color: 'grape', icon: 'crown' };
     case 'won':
       return { label: 'Won', color: 'gold', icon: 'trophy' };
     case 'placed':

--- a/src/components/Cards/myChallengeCard.utils.ts
+++ b/src/components/Cards/myChallengeCard.utils.ts
@@ -2,10 +2,11 @@ import { ChallengeStatus } from '~/shared/utils/prisma/enums';
 import type { MyChallengeResult } from '~/server/schema/challenge.schema';
 import { slugit } from '~/utils/string-helpers';
 
-export type MyChallengeCtaKind = 'results' | 'entry' | 'add' | 'manage';
+export type MyChallengeCtaKind = 'results' | 'entries' | 'entry' | 'add' | 'manage';
 
-// The detail page reads `#entries` to scroll, `?mine=1` to seed the My Entries filter, and
-// `?submit=1` to open the submit modal on arrival.
+// Detail-page deep-link targets. `results` lands on the winners podium (`#winners`), the others
+// on the entries gallery (`#entries`); `?mine=1` seeds the My Entries filter and `?submit=1`
+// opens the submit modal on arrival.
 export function getMyChallengeCtaHref(
   kind: MyChallengeCtaKind,
   { id, title }: { id: number; title: string }
@@ -14,6 +15,7 @@ export function getMyChallengeCtaHref(
   const href = `/challenges/${id}/${slugit(title)}`;
   if (kind === 'entry') return `${href}?mine=1#entries`;
   if (kind === 'add') return `${href}?submit=1#entries`;
+  if (kind === 'results') return `${href}#winners`;
   return `${href}#entries`;
 }
 
@@ -23,14 +25,14 @@ export function getMyChallengeCta(
   status: ChallengeStatus
 ): { kind: MyChallengeCtaKind; label: string; filled: 'white' | 'blue' } {
   if (result === 'hosting') {
-    // Before it starts, the only useful action is editing it — after that, looking at it.
+    // Before it starts, the only useful action is editing it — after that, looking at it. While
+    // it's live or judging there are no winners yet, so point at the entries; once completed the
+    // "results" are the winners podium.
     if (status === ChallengeStatus.Scheduled)
       return { kind: 'manage', label: 'Manage', filled: 'white' };
-    return {
-      kind: 'results',
-      label: isLive || status === ChallengeStatus.Completing ? 'View entries' : 'View results',
-      filled: 'white',
-    };
+    if (isLive || status === ChallengeStatus.Completing)
+      return { kind: 'entries', label: 'View entries', filled: 'white' };
+    return { kind: 'results', label: 'View results', filled: 'white' };
   }
   if (result === 'judging') return { kind: 'entry', label: 'View entry', filled: 'white' };
   if (result === 'entered' && isLive)

--- a/src/components/Cards/myChallengeCard.utils.ts
+++ b/src/components/Cards/myChallengeCard.utils.ts
@@ -1,7 +1,21 @@
 import { ChallengeStatus } from '~/shared/utils/prisma/enums';
 import type { MyChallengeResult } from '~/server/schema/challenge.schema';
+import { slugit } from '~/utils/string-helpers';
 
 export type MyChallengeCtaKind = 'results' | 'entry' | 'add' | 'manage';
+
+// The detail page reads `#entries` to scroll, `?mine=1` to seed the My Entries filter, and
+// `?submit=1` to open the submit modal on arrival.
+export function getMyChallengeCtaHref(
+  kind: MyChallengeCtaKind,
+  { id, title }: { id: number; title: string }
+) {
+  if (kind === 'manage') return `/challenges/${id}/edit`;
+  const href = `/challenges/${id}/${slugit(title)}`;
+  if (kind === 'entry') return `${href}?mine=1#entries`;
+  if (kind === 'add') return `${href}?submit=1#entries`;
+  return `${href}#entries`;
+}
 
 export function getMyChallengeCta(
   result: MyChallengeResult,

--- a/src/components/Cards/myChallengeCard.utils.ts
+++ b/src/components/Cards/myChallengeCard.utils.ts
@@ -12,7 +12,11 @@ export function getMyChallengeCta(
     // Before it starts, the only useful action is editing it — after that, looking at it.
     if (status === ChallengeStatus.Scheduled)
       return { kind: 'manage', label: 'Manage', filled: 'white' };
-    return { kind: 'results', label: isLive ? 'View entries' : 'View results', filled: 'white' };
+    return {
+      kind: 'results',
+      label: isLive || status === ChallengeStatus.Completing ? 'View entries' : 'View results',
+      filled: 'white',
+    };
   }
   if (result === 'judging') return { kind: 'entry', label: 'View entry', filled: 'white' };
   if (result === 'entered' && isLive)

--- a/src/components/Challenge/ChallengeCreateRequirements.tsx
+++ b/src/components/Challenge/ChallengeCreateRequirements.tsx
@@ -1,7 +1,7 @@
 import { Anchor, Divider, Paper, Stack, Text } from '@mantine/core';
 import { IconCircleCheck, IconCircleX } from '@tabler/icons-react';
 import type { ReactNode } from 'react';
-import { openCreatorScoreModal } from '~/components/Buzz/CreatorProgramV2/CreatorProgramV2.modals';
+import { NextLink } from '~/components/NextLink/NextLink';
 import type { RouterOutput } from '~/types/router';
 import { abbreviateNumber } from '~/utils/number-helpers';
 
@@ -16,10 +16,14 @@ function renderRequirement(req: Requirement): { title: string; content: ReactNod
         content: (
           <Text size="sm" c="dimmed">
             Your current{' '}
-            <Anchor inherit onClick={() => openCreatorScoreModal()}>
+            <Anchor component={NextLink} href="/user/account#creator-score" inherit>
               Creator Score
             </Anchor>{' '}
-            is {abbreviateNumber(req.current)}.
+            is{' '}
+            <Anchor component={NextLink} href="/user/account#creator-score" inherit>
+              {abbreviateNumber(req.current)}
+            </Anchor>
+            .
           </Text>
         ),
       };

--- a/src/components/Challenge/ChallengeCreateRequirements.tsx
+++ b/src/components/Challenge/ChallengeCreateRequirements.tsx
@@ -1,7 +1,9 @@
-import { Anchor, Divider, Paper, Stack, Text } from '@mantine/core';
-import { IconCircleCheck, IconCircleX } from '@tabler/icons-react';
+import { Anchor, Button, Divider, Modal, Stack, Text } from '@mantine/core';
+import { IconArrowLeft, IconCircleCheck, IconCircleX } from '@tabler/icons-react';
+import { useRouter } from 'next/router';
 import type { ReactNode } from 'react';
 import { NextLink } from '~/components/NextLink/NextLink';
+import { useHasClientHistory } from '~/store/ClientHistoryStore';
 import type { RouterOutput } from '~/types/router';
 import { abbreviateNumber } from '~/utils/number-helpers';
 
@@ -85,18 +87,29 @@ function RequirementRow({ req }: { req: Requirement }) {
 }
 
 export function ChallengeCreateRequirements({ eligibility }: { eligibility: Eligibility }) {
+  const router = useRouter();
+  const hasHistory = useHasClientHistory();
+
+  const handleGoBack = () => {
+    if (hasHistory) router.back();
+    else router.push('/challenges');
+  };
+
   return (
-    <Paper withBorder p="lg" radius="md">
+    <Modal
+      opened
+      onClose={handleGoBack}
+      withCloseButton={false}
+      closeOnClickOutside={false}
+      closeOnEscape={false}
+      title="Requirements to create a challenge"
+      centered
+    >
       <Stack gap="md">
-        <div>
-          <Text fw={700} size="lg">
-            Requirements to create a challenge
-          </Text>
-          <Text size="sm" c="dimmed">
-            You don&apos;t meet all the requirements to create a challenge yet. Once every item below
-            is met, you&apos;ll be able to create one.
-          </Text>
-        </div>
+        <Text size="sm" c="dimmed">
+          You don&apos;t meet all the requirements to create a challenge yet. Once every item below
+          is met, you&apos;ll be able to create one.
+        </Text>
         <Divider />
         <Stack gap="md">
           {eligibility.requirements
@@ -108,7 +121,10 @@ export function ChallengeCreateRequirements({ eligibility }: { eligibility: Elig
               <RequirementRow key={req.key} req={req} />
             ))}
         </Stack>
+        <Button onClick={handleGoBack} leftSection={<IconArrowLeft size={16} />} fullWidth>
+          Go back
+        </Button>
       </Stack>
-    </Paper>
+    </Modal>
   );
 }

--- a/src/components/Challenge/Infinite/ChallengeFiltersDropdown.tsx
+++ b/src/components/Challenge/Infinite/ChallengeFiltersDropdown.tsx
@@ -21,6 +21,9 @@ const participationFilters = [
   { value: ChallengeParticipation.Entered, label: 'Entered' },
   { value: ChallengeParticipation.NotEntered, label: 'Not Entered' },
   { value: ChallengeParticipation.Won, label: 'Won' },
+  // "Created" is the ownership axis on the Your Challenges page; "Hosting" here keeps the two
+  // surfaces from meaning different things by the same word. The stored value stays `created`.
+  { value: ChallengeParticipation.Created, label: 'Hosting' },
 ];
 
 const defaultStatus = ['active', 'upcoming'];
@@ -38,7 +41,8 @@ export function parseParticipationQuery(
   if (
     value === ChallengeParticipation.Entered ||
     value === ChallengeParticipation.NotEntered ||
-    value === ChallengeParticipation.Won
+    value === ChallengeParticipation.Won ||
+    value === ChallengeParticipation.Created
   )
     return value;
   return undefined;
@@ -154,7 +158,7 @@ export function ChallengeFiltersDropdown() {
 
       {currentUser && (
         <Stack gap={0}>
-          <Divider label="My Challenges" className="text-sm font-bold" mb={4} />
+          <Divider label="Challenge Participation" className="text-sm font-bold" mb={4} />
           <Chip.Group
             value={mergedFilters.participation ?? ''}
             onChange={handleParticipationChange}

--- a/src/components/Challenge/Infinite/challengeFilters.test.ts
+++ b/src/components/Challenge/Infinite/challengeFilters.test.ts
@@ -1,16 +1,18 @@
 import { describe, expect, test } from 'vitest';
 import { parseParticipationQuery } from '~/components/Challenge/Infinite/ChallengeFiltersDropdown';
-import { ChallengeParticipation } from '~/server/schema/challenge.schema';
 
+// Asserts against wire-format literals rather than `ChallengeParticipation.*`. Comparing the
+// parser's output to the same const the parser reads makes both sides collapse together when a
+// key is removed, so the test passes on a regression it exists to catch.
 describe('parseParticipationQuery', () => {
   test('accepts created', () => {
-    expect(parseParticipationQuery('created')).toBe(ChallengeParticipation.Created);
+    expect(parseParticipationQuery('created')).toBe('created');
   });
 
   test('accepts the pre-existing values', () => {
-    expect(parseParticipationQuery('entered')).toBe(ChallengeParticipation.Entered);
-    expect(parseParticipationQuery('not_entered')).toBe(ChallengeParticipation.NotEntered);
-    expect(parseParticipationQuery('won')).toBe(ChallengeParticipation.Won);
+    expect(parseParticipationQuery('entered')).toBe('entered');
+    expect(parseParticipationQuery('not_entered')).toBe('not_entered');
+    expect(parseParticipationQuery('won')).toBe('won');
   });
 
   test('rejects anything else', () => {
@@ -19,6 +21,6 @@ describe('parseParticipationQuery', () => {
   });
 
   test('takes the first value of an array', () => {
-    expect(parseParticipationQuery(['created', 'won'])).toBe(ChallengeParticipation.Created);
+    expect(parseParticipationQuery(['created', 'won'])).toBe('created');
   });
 });

--- a/src/components/Challenge/Infinite/challengeFilters.test.ts
+++ b/src/components/Challenge/Infinite/challengeFilters.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'vitest';
+import { parseParticipationQuery } from '~/components/Challenge/Infinite/ChallengeFiltersDropdown';
+import { ChallengeParticipation } from '~/server/schema/challenge.schema';
+
+describe('parseParticipationQuery', () => {
+  test('accepts created', () => {
+    expect(parseParticipationQuery('created')).toBe(ChallengeParticipation.Created);
+  });
+
+  test('accepts the pre-existing values', () => {
+    expect(parseParticipationQuery('entered')).toBe(ChallengeParticipation.Entered);
+    expect(parseParticipationQuery('not_entered')).toBe(ChallengeParticipation.NotEntered);
+    expect(parseParticipationQuery('won')).toBe(ChallengeParticipation.Won);
+  });
+
+  test('rejects anything else', () => {
+    expect(parseParticipationQuery('bogus')).toBeUndefined();
+    expect(parseParticipationQuery(undefined)).toBeUndefined();
+  });
+
+  test('takes the first value of an array', () => {
+    expect(parseParticipationQuery(['created', 'won'])).toBe(ChallengeParticipation.Created);
+  });
+});

--- a/src/components/Challenge/YourChallengesRow.tsx
+++ b/src/components/Challenge/YourChallengesRow.tsx
@@ -54,7 +54,11 @@ export function YourChallengesRow() {
           {headerLeft}
           <Button
             component={Link}
-            href="/challenges?engagement=participated"
+            href={
+              filtered.every((c) => c.myResult === 'hosting')
+                ? '/challenges?engagement=created'
+                : '/challenges?engagement=participated'
+            }
             variant="subtle"
             size="compact-sm"
             rightSection={<IconChevronRight size={16} />}

--- a/src/components/Challenge/YourChallengesRow.tsx
+++ b/src/components/Challenge/YourChallengesRow.tsx
@@ -9,10 +9,10 @@ import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { trpc } from '~/utils/trpc';
 
 /**
- * Horizontal row of the current user's recently participated-in challenges, including its own
+ * Horizontal row of the current user's own challenges — entered or created — including its own
  * section header so the whole section disappears when there's nothing to show. Renders nothing
- * while logged out, while fetching, or when the user has no entries — most users have no entries,
- * so a skeleton band here would flash a titled personal section at them and then remove it.
+ * while logged out, while fetching, or when the user has none: most users have none, so a
+ * skeleton band here would flash a titled personal section at them and then remove it.
  */
 export function YourChallengesRow() {
   const currentUser = useCurrentUser();
@@ -20,7 +20,7 @@ export function YourChallengesRow() {
     data: challenges,
     isLoading,
     isRefetching,
-  } = trpc.challenge.getMyParticipated.useQuery(
+  } = trpc.challenge.getMyChallenges.useQuery(
     { limit: 6 },
     { enabled: !!currentUser, trpc: { context: { skipBatch: true } } }
   );
@@ -37,7 +37,7 @@ export function YourChallengesRow() {
       <div>
         <Title order={3}>Your Challenges</Title>
         <Text size="xs" c="dimmed">
-          Challenges you&apos;ve recently entered
+          Challenges you&apos;ve entered or created
         </Text>
       </div>
     </Group>

--- a/src/components/Challenge/__tests__/YourChallengesRow.browser.test.tsx
+++ b/src/components/Challenge/__tests__/YourChallengesRow.browser.test.tsx
@@ -72,8 +72,8 @@ describe('YourChallengesRow', () => {
   test('renders the header, See all link, and a card per challenge', async () => {
     mocks.useQuery.mockReturnValue(
       queryResult([
-        { id: 7, title: 'Neon Cats' },
-        { id: 8, title: 'Foggy Forests' },
+        { id: 7, title: 'Neon Cats', myResult: 'entered' },
+        { id: 8, title: 'Foggy Forests', myResult: 'hosting' },
       ])
     );
     await renderWithProviders(<YourChallengesRow />);
@@ -83,6 +83,19 @@ describe('YourChallengesRow', () => {
     await expect
       .element(page.getByRole('link', { name: /see all/i }))
       .toHaveAttribute('href', '/challenges?engagement=participated');
+  });
+
+  test('See all links to Created when the row is entirely hosted challenges', async () => {
+    mocks.useQuery.mockReturnValue(
+      queryResult([
+        { id: 7, title: 'Neon Cats', myResult: 'hosting' },
+        { id: 8, title: 'Foggy Forests', myResult: 'hosting' },
+      ])
+    );
+    await renderWithProviders(<YourChallengesRow />);
+    await expect
+      .element(page.getByRole('link', { name: /see all/i }))
+      .toHaveAttribute('href', '/challenges?engagement=created');
   });
 
   test('the subtitle covers both entered and created challenges', async () => {

--- a/src/components/Challenge/__tests__/YourChallengesRow.browser.test.tsx
+++ b/src/components/Challenge/__tests__/YourChallengesRow.browser.test.tsx
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('~/utils/trpc', () => ({
-  trpc: { challenge: { getMyParticipated: { useQuery: mocks.useQuery } } },
+  trpc: { challenge: { getMyChallenges: { useQuery: mocks.useQuery } } },
 }));
 
 vi.mock('~/hooks/useCurrentUser', () => ({
@@ -83,5 +83,13 @@ describe('YourChallengesRow', () => {
     await expect
       .element(page.getByRole('link', { name: /see all/i }))
       .toHaveAttribute('href', '/challenges?engagement=participated');
+  });
+
+  test('the subtitle covers both entered and created challenges', async () => {
+    mocks.useQuery.mockReturnValue(queryResult([{ id: 7, title: 'Neon Cats' }]));
+    await renderWithProviders(<YourChallengesRow />);
+    await expect
+      .element(page.getByText("Challenges you've entered or created"))
+      .toBeInTheDocument();
   });
 });

--- a/src/components/Challenge/__tests__/YourChallengesRow.browser.test.tsx
+++ b/src/components/Challenge/__tests__/YourChallengesRow.browser.test.tsx
@@ -5,7 +5,7 @@ import { page } from 'vitest/browser';
 import { renderWithProviders } from '../../../../test/component-setup';
 
 // The band is personal: it must be completely absent (no header, no skeleton) for
-// logged-out users, while the query is in flight, and when the user has no entries —
+// logged-out users, while the query is in flight, and when the user has no challenges —
 // otherwise a titled "Your Challenges" band flashes at every first-time visitor.
 
 const mocks = vi.hoisted(() => ({
@@ -63,13 +63,13 @@ describe('YourChallengesRow', () => {
     await expect.element(page.getByText('Your Challenges')).not.toBeInTheDocument();
   });
 
-  test('renders nothing when the user has no entries', async () => {
+  test('renders nothing when the user has no challenges', async () => {
     mocks.useQuery.mockReturnValue(queryResult([]));
     await renderWithProviders(<YourChallengesRow />);
     await expect.element(page.getByText('Your Challenges')).not.toBeInTheDocument();
   });
 
-  test('renders the header, See all link, and a card per entry', async () => {
+  test('renders the header, See all link, and a card per challenge', async () => {
     mocks.useQuery.mockReturnValue(
       queryResult([
         { id: 7, title: 'Neon Cats' },

--- a/src/components/HiddenPreferences/__tests__/useApplyHiddenPreferences.test.ts
+++ b/src/components/HiddenPreferences/__tests__/useApplyHiddenPreferences.test.ts
@@ -314,3 +314,49 @@ describe("seed ('posts') ↔ tail ('images') filter parity — no reappear-via-t
     expect(runImages([tailOnly]).items.map((i) => i.id)).toEqual([12]);
   });
 });
+
+// ============================================================================
+// `case 'challenges'` branch — `isOwner` must key off `createdById` (the real
+// creator), not `createdBy.id` (the judge assigned to non-`User`-source
+// challenges, e.g. CivBot). A challenge failing every other gate must still
+// survive when the viewer is its real creator.
+// ============================================================================
+
+const makeChallenge = (o: { createdById: number; createdBy?: { id: number } }) => ({
+  id: nextId++,
+  nsfwLevel: 0,
+  allowedNsfwLevel: 0, // 0 never intersects a nonzero browsingLevel — fails that gate
+  coverImage: null, // also fails the cover-image gate
+  createdById: o.createdById,
+  createdBy: o.createdBy,
+});
+
+const runChallenges = (data: ReturnType<typeof makeChallenge>[], currentUserId: number) =>
+  filterPreferences({
+    type: 'challenges',
+    data,
+    hiddenPreferences: emptyPrefs(),
+    browsingLevel: BROWSING_LEVEL,
+    currentUser: { id: currentUserId } as never,
+    canViewNsfw: true,
+  });
+
+describe("filterPreferences — 'challenges' isOwner keys off createdById, not the judge's createdBy.id", () => {
+  it('keeps a challenge the viewer created, even though it fails the browsing-level/cover-image gates', () => {
+    // createdById is the real creator (the viewer); createdBy.id simulates a judge (e.g.
+    // CivBot) assigned to a non-`User`-source challenge — a different id entirely.
+    const own = makeChallenge({ createdById: 1, createdBy: { id: 999 } });
+
+    const { items } = runChallenges([own], 1);
+
+    expect(items.map((c) => c.id)).toEqual([own.id]);
+  });
+
+  it('drops a challenge that fails the gates when the viewer did not create it', () => {
+    const other = makeChallenge({ createdById: 2, createdBy: { id: 2 } });
+
+    const { items } = runChallenges([other], 1);
+
+    expect(items).toEqual([]);
+  });
+});

--- a/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
+++ b/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
@@ -711,7 +711,9 @@ export function filterPreferences<
       return { items: comics, hidden };
     case 'challenges':
       const challenges = value.filter((challenge) => {
-        const isOwner = challenge.createdBy.id === currentUser?.id;
+        // `createdBy.id` displays the judge (e.g. CivBot) when one is assigned, not the real
+        // creator — use `createdById` for the ownership exemption.
+        const isOwner = challenge.createdById === currentUser?.id;
         if (isOwner || isModerator) return true;
 
         // Content allowed by the challenge must intersect the user's browsing level
@@ -912,7 +914,7 @@ type BaseChallenge = {
   nsfwLevel: number;
   allowedNsfwLevel: number;
   coverImage: { id: number; nsfwLevel: number } | null;
-  createdBy: { id: number };
+  createdById: number;
 };
 
 type BaseModel3D = {

--- a/src/pages/challenges/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/[id]/[[...slug]].tsx
@@ -210,6 +210,29 @@ export const getServerSideProps = createServerSideProps({
   },
 });
 
+// The hero, prize and judge panels above the entries section keep resolving after the challenge
+// query does, so a single scroll lands short of the section. Re-pin on a short interval, and stop
+// the moment the reader takes over. Returns an abort fn so the caller can cancel on unmount; the
+// AbortController's signal also tears down all three listeners in one shot on any exit path.
+function scrollToEntries() {
+  const deadline = Date.now() + 1500;
+  const controller = new AbortController();
+  const { signal } = controller;
+  const events = ['wheel', 'touchmove', 'keydown'] as const;
+  events.forEach((e) =>
+    window.addEventListener(e, () => controller.abort(), { passive: true, signal })
+  );
+
+  const pin = () => {
+    if (signal.aborted) return;
+    document.getElementById('entries')?.scrollIntoView();
+    if (Date.now() < deadline) setTimeout(pin, 250);
+    else controller.abort();
+  };
+  requestAnimationFrame(pin);
+  return () => controller.abort();
+}
+
 function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { data: challenge, isLoading } = useQueryChallenge(id);
   const currentUser = useCurrentUser();
@@ -218,6 +241,7 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
   const queryUtils = trpc.useUtils();
   const { deleteChallenge: deleteOwnChallenge, deleting: deletingOwn } = useDeleteUserChallenge();
   const deletingOwnRef = useRef(false);
+  const deepLinkHandledFor = useRef<number>();
   const isOwner = useIsChallengeOwner(challenge);
 
   const handleMutationError = (error: { message: string }) => {
@@ -354,6 +378,39 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
       },
     });
   };
+
+  // Deep links from the "Your Challenges" cards: `#entries` scrolls to the gallery, `?submit=1`
+  // opens the submit modal. Both wait on `challenge` — the entries section mounts with the query,
+  // long after the browser would have tried its own hash scroll (and it scrolls an inner
+  // `.scroll-area` container, not the window). `submit` is stripped before the modal opens so a
+  // refresh or back-nav doesn't re-trigger it.
+  useEffect(() => {
+    // Scoped to the loaded challenge id, not a one-shot bool: Next reuses this component across
+    // detail→detail navigations, so a boolean guard would swallow a deep link on the second one.
+    if (!challenge || deepLinkHandledFor.current === challenge.id) return;
+    deepLinkHandledFor.current = challenge.id;
+
+    const wantsSubmit = !!router.query.submit;
+    if (wantsSubmit) {
+      const { submit, ...query } = router.query;
+      router.replace({ pathname: router.pathname, query }, undefined, { shallow: true });
+    }
+
+    const abortScroll =
+      router.asPath.split('#')[1] === 'entries' ? scrollToEntries() : undefined;
+
+    const canSubmit =
+      challenge.status === ChallengeStatus.Active &&
+      !!challenge.collectionId &&
+      !currentUser?.muted;
+    if (wantsSubmit && canSubmit && challenge.collectionId)
+      dialogStore.trigger({
+        component: ChallengeSubmitModal,
+        props: { challengeId: challenge.id, collectionId: challenge.collectionId },
+      });
+
+    return abortScroll;
+  }, [challenge, router, currentUser?.muted]);
 
   if (isLoading) return <PageLoader />;
   if (!challenge) return <NotFound />;
@@ -1635,8 +1692,11 @@ function ChallengeEntries({ challenge }: { challenge: ChallengeDetail }) {
   // the domain rule, so the toggle would be a no-op for them.
   const showPG13Toggle = domainColor === 'green' && !!currentUser;
 
+  const router = useRouter();
+
   const [judgeReviewedOnly, setJudgeReviewedOnly] = useState(false);
-  const [myEntriesOnly, setMyEntriesOnly] = useState(false);
+  // Seeded from `?mine=1` so the Your Challenges "View entry" CTA lands on the user's own entries.
+  const [myEntriesOnly, setMyEntriesOnly] = useState(() => !!router.query.mine);
   const [pendingReviewOnly, setPendingReviewOnly] = useState(false);
   const [includePG13, setIncludePG13] = useState(false);
   const [opened, setOpened] = useState(false);
@@ -1781,6 +1841,7 @@ function ChallengeEntries({ challenge }: { challenge: ChallengeDetail }) {
   return (
     <Container
       fluid
+      id="entries"
       my="md"
       style={{
         background: colorScheme === 'dark' ? theme.colors.dark[6] : theme.colors.gray[1],

--- a/src/pages/challenges/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/[id]/[[...slug]].tsx
@@ -210,11 +210,13 @@ export const getServerSideProps = createServerSideProps({
   },
 });
 
-// The hero, prize and judge panels above the entries section keep resolving after the challenge
-// query does, so a single scroll lands short of the section. Re-pin on a short interval, and stop
-// the moment the reader takes over. Returns an abort fn so the caller can cancel on unmount; the
-// AbortController's signal also tears down all three listeners in one shot on any exit path.
-function scrollToEntries() {
+// The hero, prize and judge panels above the target section keep resolving after the challenge
+// query does, so a single scroll lands short. Re-pin on a short interval to the first of `ids`
+// present in the DOM (winners → entries fallback, since a completed challenge that never picked
+// winners has no podium), and stop the moment the reader takes over. Returns an abort fn so the
+// caller can cancel on unmount; the AbortController's signal also tears down all three listeners
+// in one shot on any exit path.
+function scrollToHash(ids: string[]) {
   const deadline = Date.now() + 1500;
   const controller = new AbortController();
   const { signal } = controller;
@@ -225,13 +227,20 @@ function scrollToEntries() {
 
   const pin = () => {
     if (signal.aborted) return;
-    document.getElementById('entries')?.scrollIntoView();
+    const target = ids.map((id) => document.getElementById(id)).find(Boolean);
+    target?.scrollIntoView();
     if (Date.now() < deadline) setTimeout(pin, 250);
     else controller.abort();
   };
   requestAnimationFrame(pin);
   return () => controller.abort();
 }
+
+// Deep-link anchors → ordered scroll targets (first present wins).
+const DEEP_LINK_TARGETS: Record<string, string[]> = {
+  entries: ['entries'],
+  winners: ['winners', 'entries'],
+};
 
 function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServerSideProps>) {
   const { data: challenge, isLoading } = useQueryChallenge(id);
@@ -379,11 +388,11 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
     });
   };
 
-  // Deep links from the "Your Challenges" cards: `#entries` scrolls to the gallery, `?submit=1`
-  // opens the submit modal. Both wait on `challenge` — the entries section mounts with the query,
-  // long after the browser would have tried its own hash scroll (and it scrolls an inner
-  // `.scroll-area` container, not the window). `submit` is stripped before the modal opens so a
-  // refresh or back-nav doesn't re-trigger it.
+  // Deep links from the "Your Challenges" cards: `#entries`/`#winners` scroll to that section,
+  // `?submit=1` opens the submit modal. All wait on `challenge` — the target section mounts with
+  // the query, long after the browser would have tried its own hash scroll (and it scrolls an
+  // inner `.scroll-area` container, not the window). `submit` is stripped before the modal opens
+  // so a refresh or back-nav doesn't re-trigger it.
   useEffect(() => {
     // Scoped to the loaded challenge id, not a one-shot bool: Next reuses this component across
     // detail→detail navigations, so a boolean guard would swallow a deep link on the second one.
@@ -396,8 +405,8 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
       router.replace({ pathname: router.pathname, query }, undefined, { shallow: true });
     }
 
-    const abortScroll =
-      router.asPath.split('#')[1] === 'entries' ? scrollToEntries() : undefined;
+    const targets = DEEP_LINK_TARGETS[router.asPath.split('#')[1]];
+    const abortScroll = targets ? scrollToHash(targets) : undefined;
 
     const canSubmit =
       challenge.status === ChallengeStatus.Active &&
@@ -1552,6 +1561,7 @@ function ChallengeWinners({ challenge }: { challenge: ChallengeDetail }) {
 
   return (
     <div
+      id="winners"
       className="relative overflow-hidden py-12"
       style={{
         background: isDark

--- a/src/pages/challenges/create.tsx
+++ b/src/pages/challenges/create.tsx
@@ -21,8 +21,8 @@ export default function CreateUserChallengePage() {
     );
   }
 
-  // On a query error `eligibility` stays undefined and we fall through to the form; the create
-  // mutation still enforces the gate, degrading to the existing error-on-submit behavior.
+  // On a query error `eligibility` stays undefined and no gate renders; the create mutation still
+  // enforces it, degrading to the existing error-on-submit behavior.
   return (
     <>
       <Meta title="Create a Challenge" deIndex />
@@ -31,10 +31,13 @@ export default function CreateUserChallengePage() {
           <Center py="xl">
             <Loader />
           </Center>
-        ) : eligibility && !eligibility.canCreate ? (
-          <ChallengeCreateRequirements eligibility={eligibility} />
         ) : (
-          <ChallengeUpsertForm variant="user" />
+          <>
+            <ChallengeUpsertForm variant="user" />
+            {eligibility && !eligibility.canCreate && (
+              <ChallengeCreateRequirements eligibility={eligibility} />
+            )}
+          </>
         )}
       </Container>
     </>

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -93,7 +93,12 @@ function ChallengesPage() {
   const rawEngagement = router.query.engagement;
   const isPersonalView = rawEngagement === 'created' || rawEngagement === 'participated';
   const engagement: Engagement = rawEngagement === 'created' ? 'created' : 'participated';
-  const [statusSelection, setStatusSelection] = useState<MyChallengeStatus>('Active');
+  // Creators arrive from the header menu to check on what they've queued up, so Created opens on
+  // Scheduled; entrants care about what's running. Initial value only — the clamp below governs
+  // after that.
+  const [statusSelection, setStatusSelection] = useState<MyChallengeStatus>(
+    rawEngagement === 'created' ? 'Scheduled' : 'Active'
+  );
   const allowedStatuses = engagementStatuses[engagement];
   const myStatus = allowedStatuses.includes(statusSelection)
     ? statusSelection
@@ -110,6 +115,11 @@ function ChallengesPage() {
   if (isPersonalView) {
     if (!currentUser) return <NotFound />;
     if (engagement === 'created' && !features.userChallenges) return <NotFound />;
+
+    const engagementOptions = [
+      { label: 'Participated', value: 'participated' },
+      ...(features.userChallenges ? [{ label: 'Created', value: 'created' }] : []),
+    ];
 
     const personalFilters: Partial<GetInfiniteChallengesInput> =
       engagement === 'created'
@@ -134,18 +144,17 @@ function ChallengesPage() {
               {createChallengeButton}
             </Group>
             <Group justify="space-between" w="100%" wrap="wrap" gap="sm">
-              <SegmentedControl
-                classNames={styles}
-                transitionDuration={0}
-                radius="xl"
-                data={[
-                  { label: 'Participated', value: 'participated' },
-                  ...(features.userChallenges ? [{ label: 'Created', value: 'created' }] : []),
-                ]}
-                value={engagement}
-                onChange={handleEngagementChange}
-                withItemsBorders={false}
-              />
+              {engagementOptions.length > 1 && (
+                <SegmentedControl
+                  classNames={styles}
+                  transitionDuration={0}
+                  radius="xl"
+                  data={engagementOptions}
+                  value={engagement}
+                  onChange={handleEngagementChange}
+                  withItemsBorders={false}
+                />
+              )}
               <SegmentedControl
                 classNames={styles}
                 transitionDuration={0}

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -91,15 +91,15 @@ function ChallengesPage() {
   const participation = parseParticipationQuery(router.query.participation);
 
   const rawEngagement = router.query.engagement;
-  const isPersonalView = rawEngagement != null;
+  const isPersonalView = rawEngagement === 'created' || rawEngagement === 'participated';
   const engagement: Engagement = rawEngagement === 'created' ? 'created' : 'participated';
-  const [myStatus, setMyStatus] = useState<MyChallengeStatus>('Active');
+  const [statusSelection, setStatusSelection] = useState<MyChallengeStatus>('Active');
+  const allowedStatuses = engagementStatuses[engagement];
+  const myStatus = allowedStatuses.includes(statusSelection)
+    ? statusSelection
+    : allowedStatuses[0];
 
   const handleEngagementChange = (next: string) => {
-    // Status sets differ per engagement — carry the selection over only when it's still valid,
-    // otherwise fall back to the first option so the feed can't query an impossible combination.
-    const allowed = engagementStatuses[next as Engagement];
-    if (!allowed.includes(myStatus)) setMyStatus(allowed[0]);
     router.replace(
       { pathname: '/challenges', query: { ...router.query, engagement: next } },
       undefined,
@@ -125,8 +125,6 @@ function ChallengesPage() {
                 <LegacyActionIcon
                   component={Link}
                   href="/challenges"
-                  variant="subtle"
-                  color="gray"
                   aria-label="Back to challenges"
                 >
                   <IconArrowLeft size={20} />
@@ -142,7 +140,7 @@ function ChallengesPage() {
                 radius="xl"
                 data={[
                   { label: 'Participated', value: 'participated' },
-                  { label: 'Created', value: 'created' },
+                  ...(features.userChallenges ? [{ label: 'Created', value: 'created' }] : []),
                 ]}
                 value={engagement}
                 onChange={handleEngagementChange}
@@ -152,9 +150,9 @@ function ChallengesPage() {
                 classNames={styles}
                 transitionDuration={0}
                 radius="xl"
-                data={engagementStatuses[engagement]}
+                data={allowedStatuses}
                 value={myStatus}
-                onChange={(v) => setMyStatus(v as MyChallengeStatus)}
+                onChange={(v) => setStatusSelection(v as MyChallengeStatus)}
                 withItemsBorders={false}
               />
             </Group>

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -195,7 +195,7 @@ function ChallengesPage() {
       <div className={styles.sections}>
         <FeaturedChallengeEvents />
 
-        <YourChallengesRow />
+        {features.userChallenges && <YourChallengesRow />}
 
         <DailyChallengesSection />
 

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 import { Stack, Title, Group, Button, SegmentedControl } from '@mantine/core';
 import { IconTrophy, IconUsers, IconArrowLeft } from '@tabler/icons-react';
 import Link from 'next/link';
@@ -101,13 +101,13 @@ function ChallengesPage() {
   // /challenges and /challenges?engagement=* are the same page with no route key, so switching
   // engagement via a link (header menu, the in-page control) doesn't remount — reset the status
   // explicitly rather than relying on the initializer above, which only runs once per mount.
-  const prevEngagement = useRef(rawEngagement);
-  useEffect(() => {
-    if (prevEngagement.current !== rawEngagement) {
-      setStatusSelection(rawEngagement === 'created' ? 'Scheduled' : 'Active');
-      prevEngagement.current = rawEngagement;
-    }
-  }, [rawEngagement]);
+  // Render-phase adjustment (not an effect) so the stale status is never committed/painted, and
+  // ChallengesInfinite never mounts with it — see https://react.dev/learn/you-might-not-need-an-effect.
+  const [prevEngagement, setPrevEngagement] = useState(rawEngagement);
+  if (prevEngagement !== rawEngagement) {
+    setPrevEngagement(rawEngagement);
+    setStatusSelection(rawEngagement === 'created' ? 'Scheduled' : 'Active');
+  }
   const allowedStatuses = engagementStatuses[engagement];
   const myStatus = allowedStatuses.includes(statusSelection)
     ? statusSelection

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -200,6 +200,7 @@ function ChallengesPage() {
                   <Title order={3}>Community Challenges</Title>
                 </Group>
                 <Group gap="sm" wrap="wrap" ml="auto">
+                  {createChallengeButton}
                   <ChallengeFeedFilters />
                 </Group>
               </Group>

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Stack, Title, Group, Button, SegmentedControl } from '@mantine/core';
 import { IconTrophy, IconUsers, IconArrowLeft } from '@tabler/icons-react';
 import Link from 'next/link';
@@ -94,11 +94,20 @@ function ChallengesPage() {
   const isPersonalView = rawEngagement === 'created' || rawEngagement === 'participated';
   const engagement: Engagement = rawEngagement === 'created' ? 'created' : 'participated';
   // Creators arrive from the header menu to check on what they've queued up, so Created opens on
-  // Scheduled; entrants care about what's running. Initial value only — the clamp below governs
-  // after that.
+  // Scheduled; entrants care about what's running.
   const [statusSelection, setStatusSelection] = useState<MyChallengeStatus>(
     rawEngagement === 'created' ? 'Scheduled' : 'Active'
   );
+  // /challenges and /challenges?engagement=* are the same page with no route key, so switching
+  // engagement via a link (header menu, the in-page control) doesn't remount — reset the status
+  // explicitly rather than relying on the initializer above, which only runs once per mount.
+  const prevEngagement = useRef(rawEngagement);
+  useEffect(() => {
+    if (prevEngagement.current !== rawEngagement) {
+      setStatusSelection(rawEngagement === 'created' ? 'Scheduled' : 'Active');
+      prevEngagement.current = rawEngagement;
+    }
+  }, [rawEngagement]);
   const allowedStatuses = engagementStatuses[engagement];
   const myStatus = allowedStatuses.includes(statusSelection)
     ? statusSelection

--- a/src/pages/challenges/index.tsx
+++ b/src/pages/challenges/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Stack, Title, Group, Button, SegmentedControl } from '@mantine/core';
-import { IconTrophy, IconUsers } from '@tabler/icons-react';
+import { IconTrophy, IconUsers, IconArrowLeft } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { FeedLayout } from '~/components/AppLayout/FeedLayout';
@@ -12,6 +12,7 @@ import { FeaturedChallengeEvents } from '~/components/Challenge/FeaturedChalleng
 import { SectionBand } from '~/components/Challenge/SectionBand';
 import { YourChallengesRow } from '~/components/Challenge/YourChallengesRow';
 import { ChallengeFeedFilters } from '~/components/Filters/FeedFilters/ChallengeFeedFilters';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { Meta } from '~/components/Meta/Meta';
 import {
@@ -40,6 +41,24 @@ const statusMap: Record<string, ChallengeStatus> = {
 };
 
 type MyChallengeStatus = 'Scheduled' | 'Active' | 'Completed' | 'Cancelled';
+type Engagement = 'participated' | 'created';
+
+const engagementStatuses: Record<Engagement, MyChallengeStatus[]> = {
+  // You can't enter a challenge that hasn't started, and a cancelled one you entered is a refund,
+  // not a thing to browse — so Participated gets a narrower set than Created.
+  participated: ['Active', 'Completed'],
+  created: ['Scheduled', 'Active', 'Completed', 'Cancelled'],
+};
+
+const myStatusFilters: Record<MyChallengeStatus, Partial<GetInfiniteChallengesInput>> = {
+  Scheduled: { status: [ChallengeStatus.Scheduled], includeEnded: false },
+  Active: { status: [ChallengeStatus.Active], includeEnded: false },
+  Completed: {
+    status: [ChallengeStatus.Completing, ChallengeStatus.Completed],
+    includeEnded: true,
+  },
+  Cancelled: { status: [ChallengeStatus.Cancelled], includeEnded: true },
+};
 
 function ChallengesPage() {
   const router = useRouter();
@@ -71,82 +90,78 @@ function ChallengesPage() {
   const includeEnded = statusFilters.includes('completed');
   const participation = parseParticipationQuery(router.query.participation);
 
-  const mine = router.query.engagement === 'created';
-  const [myStatus, setMyStatus] = useState<MyChallengeStatus>('Scheduled');
+  const rawEngagement = router.query.engagement;
+  const isPersonalView = rawEngagement != null;
+  const engagement: Engagement = rawEngagement === 'created' ? 'created' : 'participated';
+  const [myStatus, setMyStatus] = useState<MyChallengeStatus>('Active');
 
-  const myStatusFilters: Record<MyChallengeStatus, Partial<GetInfiniteChallengesInput>> = {
-    Scheduled: { status: [ChallengeStatus.Scheduled], includeEnded: false },
-    Active: { status: [ChallengeStatus.Active], includeEnded: false },
-    Completed: { status: [ChallengeStatus.Completed], includeEnded: true },
-    Cancelled: { status: [ChallengeStatus.Cancelled], includeEnded: true },
+  const handleEngagementChange = (next: string) => {
+    // Status sets differ per engagement — carry the selection over only when it's still valid,
+    // otherwise fall back to the first option so the feed can't query an impossible combination.
+    const allowed = engagementStatuses[next as Engagement];
+    if (!allowed.includes(myStatus)) setMyStatus(allowed[0]);
+    router.replace(
+      { pathname: '/challenges', query: { ...router.query, engagement: next } },
+      undefined,
+      { shallow: true }
+    );
   };
 
-  const participated = router.query.engagement === 'participated';
-  const [participatedStatus, setParticipatedStatus] = useState<'Active' | 'Completed'>('Active');
-  const participatedStatusFilters: Record<string, Partial<GetInfiniteChallengesInput>> = {
-    Active: { status: [ChallengeStatus.Active], includeEnded: false },
-    Completed: {
-      status: [ChallengeStatus.Completing, ChallengeStatus.Completed],
-      includeEnded: true,
-    },
-  };
+  if (isPersonalView) {
+    if (!currentUser) return <NotFound />;
+    if (engagement === 'created' && !features.userChallenges) return <NotFound />;
 
-  if (mine) {
-    if (!currentUser || !features.userChallenges) return <NotFound />;
+    const personalFilters: Partial<GetInfiniteChallengesInput> =
+      engagement === 'created'
+        ? { userId: currentUser.id, source: [ChallengeSource.User], excludeEventChallenges: true }
+        : { participation: ChallengeParticipation.Entered };
+
     return (
       <MasonryContainer>
         <Stack gap="xs">
-          <Stack gap="xl" align="flex-start">
+          <Stack gap="xl" align="flex-start" w="100%">
             <Group justify="space-between" w="100%" wrap="nowrap" gap="sm">
-              <Title>My Challenges</Title>
+              <Group gap="sm" wrap="nowrap">
+                <LegacyActionIcon
+                  component={Link}
+                  href="/challenges"
+                  variant="subtle"
+                  color="gray"
+                  aria-label="Back to challenges"
+                >
+                  <IconArrowLeft size={20} />
+                </LegacyActionIcon>
+                <Title>Your Challenges</Title>
+              </Group>
               {createChallengeButton}
             </Group>
-            <SegmentedControl
-              classNames={styles}
-              transitionDuration={0}
-              radius="xl"
-              data={['Scheduled', 'Active', 'Completed', 'Cancelled']}
-              value={myStatus}
-              onChange={(v) => setMyStatus(v as MyChallengeStatus)}
-              withItemsBorders={false}
-            />
+            <Group justify="space-between" w="100%" wrap="wrap" gap="sm">
+              <SegmentedControl
+                classNames={styles}
+                transitionDuration={0}
+                radius="xl"
+                data={[
+                  { label: 'Participated', value: 'participated' },
+                  { label: 'Created', value: 'created' },
+                ]}
+                value={engagement}
+                onChange={handleEngagementChange}
+                withItemsBorders={false}
+              />
+              <SegmentedControl
+                classNames={styles}
+                transitionDuration={0}
+                radius="xl"
+                data={engagementStatuses[engagement]}
+                value={myStatus}
+                onChange={(v) => setMyStatus(v as MyChallengeStatus)}
+                withItemsBorders={false}
+              />
+            </Group>
           </Stack>
           <ChallengesInfinite
-            filters={{
-              userId: currentUser.id,
-              source: [ChallengeSource.User],
-              excludeEventChallenges: true,
-              ...myStatusFilters[myStatus],
-            }}
-            emptyAction={createChallengeButton}
-          />
-        </Stack>
-      </MasonryContainer>
-    );
-  }
-
-  if (participated) {
-    if (!currentUser) return <NotFound />;
-    return (
-      <MasonryContainer>
-        <Stack gap="xs">
-          <Stack gap="xl" align="flex-start">
-            <Title>Challenges You&apos;ve Entered</Title>
-            <SegmentedControl
-              classNames={styles}
-              transitionDuration={0}
-              radius="xl"
-              data={['Active', 'Completed']}
-              value={participatedStatus}
-              onChange={(v) => setParticipatedStatus(v as 'Active' | 'Completed')}
-              withItemsBorders={false}
-            />
-          </Stack>
-          <ChallengesInfinite
-            filters={{
-              participation: ChallengeParticipation.Entered,
-              ...participatedStatusFilters[participatedStatus],
-            }}
+            filters={{ ...personalFilters, ...myStatusFilters[myStatus] }}
+            emptyAction={engagement === 'created' ? createChallengeButton : undefined}
           />
         </Stack>
       </MasonryContainer>

--- a/src/pages/challenges/winners.tsx
+++ b/src/pages/challenges/winners.tsx
@@ -6,6 +6,7 @@ import { CompletedChallengesInfinite } from '~/components/Challenge/Infinite/Com
 import { MasonryContainer } from '~/components/MasonryColumns/MasonryContainer';
 import { Meta } from '~/components/Meta/Meta';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { ChallengeSource } from '~/shared/utils/prisma/enums';
 
 export const getServerSideProps = createServerSideProps({
   resolver: async ({ features }) => {
@@ -38,7 +39,7 @@ function PreviousWinnersPage() {
             </div>
           </Group>
 
-          <CompletedChallengesInfinite />
+          <CompletedChallengesInfinite filters={{ source: [ChallengeSource.System] }} />
         </Stack>
       </MasonryContainer>
     </>

--- a/src/pages/creator-program/index.tsx
+++ b/src/pages/creator-program/index.tsx
@@ -47,10 +47,7 @@ import {
   usePrevMonthStats,
 } from '~/components/Buzz/CreatorProgramV2/CreatorProgram.util';
 import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
-import {
-  CreatorProgramCapsInfo,
-  openCreatorScoreModal,
-} from '~/components/Buzz/CreatorProgramV2/CreatorProgramV2.modals';
+import { CreatorProgramCapsInfo } from '~/components/Buzz/CreatorProgramV2/CreatorProgramV2.modals';
 import { getCreatorProgramAvailability } from '~/server/utils/creator-program.utils';
 import { Flags } from '~/shared/utils/flags';
 import { OnboardingSteps } from '~/server/common/enums';
@@ -437,14 +434,14 @@ const JoinSection = ({ applyFormUrl }: { applyFormUrl: string }) => {
                     content={
                       <p className="my-0">
                         Your current{' '}
-                        <Anchor
-                          onClick={() => {
-                            openCreatorScoreModal();
-                          }}
-                        >
+                        <Anchor component={NextLink} href="/user/account#creator-score">
                           Creator Score
                         </Anchor>{' '}
-                        is {abbreviateNumber(requirements?.score.current ?? 0)}.
+                        is{' '}
+                        <Anchor component={NextLink} href="/user/account#creator-score">
+                          {abbreviateNumber(requirements?.score.current ?? 0)}
+                        </Anchor>
+                        .
                       </p>
                     }
                   />

--- a/src/server/games/daily-challenge/__tests__/challenge-degenerate-winners.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-degenerate-winners.test.ts
@@ -141,6 +141,7 @@ vi.mock('~/server/games/daily-challenge/challenge-funding', () => ({
   refundUserChallengeFunds: mockRefundUserChallengeFunds,
   buildWinnerPayoutTransactions: vi.fn().mockReturnValue([]),
   getChallengeBuzzType: vi.fn().mockResolvedValue('user'),
+  reportPoolFundingShortfall: vi.fn(),
 }));
 
 vi.mock('~/utils/logging', () => ({

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-mapping.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-mapping.test.ts
@@ -146,6 +146,7 @@ vi.mock('~/server/games/daily-challenge/challenge-funding', () => ({
   refundUserChallengeFunds: mockRefundUserChallengeFunds,
   buildWinnerPayoutTransactions: vi.fn().mockReturnValue([]),
   getChallengeBuzzType: vi.fn().mockResolvedValue('user'),
+  reportPoolFundingShortfall: vi.fn(),
 }));
 
 vi.mock('~/utils/logging', () => ({

--- a/src/server/games/daily-challenge/challenge-funding.test.ts
+++ b/src/server/games/daily-challenge/challenge-funding.test.ts
@@ -15,6 +15,7 @@ const {
   mockRefundTransaction,
   mockChallengeUpdate,
   mockChallengeFindUnique,
+  mockCollectionItemCount,
   mockLogToAxiom,
 } = vi.hoisted(() => ({
   mockCreateBuzzTransaction: vi.fn(),
@@ -24,11 +25,15 @@ const {
   mockRefundTransaction: vi.fn(),
   mockChallengeUpdate: vi.fn(),
   mockChallengeFindUnique: vi.fn(),
+  mockCollectionItemCount: vi.fn(),
   mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('~/server/db/client', () => ({
-  dbRead: { challenge: { findUnique: mockChallengeFindUnique } },
+  dbRead: {
+    challenge: { findUnique: mockChallengeFindUnique },
+    collectionItem: { count: mockCollectionItemCount },
+  },
   dbWrite: { challenge: { update: mockChallengeUpdate } },
 }));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
@@ -40,8 +45,13 @@ vi.mock('~/server/services/buzz.service', () => ({
   refundTransaction: mockRefundTransaction,
 }));
 
-const { chargeEntryFees, chargeInitialPrize, refundUserChallengeFunds, buildWinnerPayoutTransactions } =
-  await import('./challenge-funding');
+const {
+  chargeEntryFees,
+  chargeInitialPrize,
+  refundUserChallengeFunds,
+  buildWinnerPayoutTransactions,
+  reportPoolFundingShortfall,
+} = await import('./challenge-funding');
 const { CHALLENGE_ENTRY_HOUSE_CUT, getEntryPoolContribution } = await import(
   '~/shared/constants/challenge.constants'
 );
@@ -385,5 +395,80 @@ describe('refundUserChallengeFunds — void refunds pool legs only', () => {
     );
 
     await expect(refundUserChallengeFunds(CHALLENGE_ID)).rejects.toThrow('boom');
+  });
+});
+
+// The pool only grows through paid entry legs, so an entry that lands in the collection without
+// one (a fee-exempt submission, a rolled-back charge that left the row behind) silently shrinks
+// every winner's payout. Completion must flag that gap rather than pay out quietly.
+describe('reportPoolFundingShortfall', () => {
+  const COLLECTION_ID = 3030;
+
+  const wireChallenge = (overrides: Record<string, unknown> = {}) =>
+    mockChallengeFindUnique.mockResolvedValue({
+      source: ChallengeSource.User,
+      entryFee: ENTRY_FEE,
+      basePrizePool: 0,
+      prizePool: 0,
+      ...overrides,
+    });
+
+  it('warns when the collected pool is below what the accepted entries imply', async () => {
+    wireChallenge();
+    mockCollectionItemCount.mockResolvedValue(2);
+
+    await reportPoolFundingShortfall({ challengeId: CHALLENGE_ID, collectionId: COLLECTION_ID });
+
+    const expectedPool = getEntryPoolContribution(ENTRY_FEE) * 2;
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'warning',
+        name: 'challenge-pool-funding-shortfall',
+        challengeId: CHALLENGE_ID,
+        entryCount: 2,
+        prizePool: 0,
+        expectedPool,
+        shortfall: expectedPool,
+      })
+    );
+  });
+
+  it('counts the escrowed initial prize as funding, not as a shortfall', async () => {
+    wireChallenge({ basePrizePool: 500, prizePool: 500 + getEntryPoolContribution(ENTRY_FEE) });
+    mockCollectionItemCount.mockResolvedValue(1);
+
+    await reportPoolFundingShortfall({ challengeId: CHALLENGE_ID, collectionId: COLLECTION_ID });
+
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+
+  // Removed/rejected entries keep their (never-refunded) fee in the pool, so a pool above the
+  // accepted-entry total is expected — not a shortfall.
+  it('stays quiet when the pool exceeds the accepted-entry total', async () => {
+    wireChallenge({ prizePool: getEntryPoolContribution(ENTRY_FEE) * 5 });
+    mockCollectionItemCount.mockResolvedValue(1);
+
+    await reportPoolFundingShortfall({ challengeId: CHALLENGE_ID, collectionId: COLLECTION_ID });
+
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('ignores challenges that charge no entry fee, and non-user challenges', async () => {
+    mockCollectionItemCount.mockResolvedValue(3);
+
+    wireChallenge({ entryFee: 0 });
+    await reportPoolFundingShortfall({ challengeId: CHALLENGE_ID, collectionId: COLLECTION_ID });
+
+    wireChallenge({ source: ChallengeSource.System });
+    await reportPoolFundingShortfall({ challengeId: CHALLENGE_ID, collectionId: COLLECTION_ID });
+
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('no-ops for a challenge without a collection', async () => {
+    await reportPoolFundingShortfall({ challengeId: CHALLENGE_ID, collectionId: null });
+
+    expect(mockChallengeFindUnique).not.toHaveBeenCalled();
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
   });
 });

--- a/src/server/games/daily-challenge/challenge-funding.ts
+++ b/src/server/games/daily-challenge/challenge-funding.ts
@@ -43,7 +43,7 @@ import {
   CHALLENGE_ENTRY_HOUSE_CUT,
   getEntryPoolContribution,
 } from '~/shared/constants/challenge.constants';
-import { ChallengeSource } from '~/shared/utils/prisma/enums';
+import { ChallengeSource, CollectionItemStatus } from '~/shared/utils/prisma/enums';
 import { createLogger } from '~/utils/logging';
 
 const log = createLogger('challenge-funding', 'yellow');
@@ -296,6 +296,48 @@ export async function refundUserChallengeFunds(challengeId: number) {
     `Refunded ${refundedEntries} entry-fee pool contributions + initial prize for cancelled challenge ${challengeId}`
   );
   return { refundedEntries };
+}
+
+/**
+ * Alert when a completing user challenge holds less Buzz than its accepted entries imply. An
+ * entry that reached the collection without a paid pool leg still competes for the prizes, so
+ * the shortfall silently shrinks every winner's payout (challenge 413 completed with 2 entries
+ * and a pool of 0, paying its winners nothing). Never throws — reporting only.
+ */
+export async function reportPoolFundingShortfall({
+  challengeId,
+  collectionId,
+}: {
+  challengeId: number;
+  collectionId: number | null;
+}) {
+  if (!collectionId) return;
+
+  const challenge = await dbRead.challenge.findUnique({
+    where: { id: challengeId },
+    select: { source: true, entryFee: true, basePrizePool: true, prizePool: true },
+  });
+  if (!challenge || challenge.source !== ChallengeSource.User || challenge.entryFee <= 0) return;
+
+  const entryCount = await dbRead.collectionItem.count({
+    where: { collectionId, status: CollectionItemStatus.ACCEPTED },
+  });
+  const expectedPool =
+    challenge.basePrizePool + getEntryPoolContribution(challenge.entryFee) * entryCount;
+  const shortfall = expectedPool - challenge.prizePool;
+  if (shortfall <= 0) return;
+
+  await logToAxiom({
+    type: 'warning',
+    name: 'challenge-pool-funding-shortfall',
+    message: 'Challenge completing with a prize pool below what its accepted entries imply',
+    challengeId,
+    entryCount,
+    entryFee: challenge.entryFee,
+    prizePool: challenge.prizePool,
+    expectedPool,
+    shortfall,
+  }).catch(() => {});
 }
 
 /** Build the winner-prize transactions for a challenge, paid in its stored currency. Pure. */

--- a/src/server/jobs/__tests__/daily-challenge-processing.judging-categories.test.ts
+++ b/src/server/jobs/__tests__/daily-challenge-processing.judging-categories.test.ts
@@ -150,6 +150,7 @@ vi.mock('~/server/games/daily-challenge/challenge-funding', () => ({
   refundUserChallengeFunds: mockRefundUserChallengeFunds,
   getChallengeBuzzType: vi.fn(async () => 'yellow'),
   buildWinnerPayoutTransactions: vi.fn(() => []),
+  reportPoolFundingShortfall: vi.fn(),
 }));
 
 vi.mock('~/utils/logging', () => ({

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -80,6 +80,7 @@ import {
   refundUserChallengeFunds,
   buildWinnerPayoutTransactions,
   getChallengeBuzzType,
+  reportPoolFundingShortfall,
 } from '~/server/games/daily-challenge/challenge-funding';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import {
@@ -1313,6 +1314,11 @@ export async function pickWinnersForChallenge(
             prizes: finalPrizes,
           });
         }
+
+        await reportPoolFundingShortfall({
+          challengeId: currentChallenge.challengeId,
+          collectionId: currentChallenge.collectionId,
+        });
       }
 
       // 3. Get judged entries + LLM judgment

--- a/src/server/notifications/__tests__/challenge-cancelled-notification.test.ts
+++ b/src/server/notifications/__tests__/challenge-cancelled-notification.test.ts
@@ -95,6 +95,7 @@ vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
 vi.mock('~/server/games/daily-challenge/challenge-funding', () => ({
   chargeInitialPrize: vi.fn(),
   refundUserChallengeFunds: mockRefundUserChallengeFunds,
+  reportPoolFundingShortfall: vi.fn(),
 }));
 vi.mock('~/server/services/notification.service', () => ({
   createNotification: mockCreateNotification,

--- a/src/server/notifications/__tests__/challenge-winner-notification.test.ts
+++ b/src/server/notifications/__tests__/challenge-winner-notification.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { challengeNotifications } from '~/server/notifications/challenge.notifications';
+
+// A user challenge whose pool was never funded still picks winners, so the prize can legitimately
+// be 0 (challenge 413). The notification must not congratulate the winner on 0 Buzz.
+describe('challenge-winner notification message', () => {
+  const def = challengeNotifications['challenge-winner'];
+
+  it('names the prize when there is one', () => {
+    const msg = def.prepareMessage({
+      details: { challengeId: 7, challengeName: 'Neon Dreams', position: 1, prize: 1500 },
+    });
+
+    expect(msg!.message).toContain('1st');
+    expect(msg!.message).toContain('1,500 Buzz');
+    expect(msg!.url).toBe('/challenges/7');
+  });
+
+  it('drops the Buzz claim entirely when the prize is 0', () => {
+    const msg = def.prepareMessage({
+      details: { challengeId: 413, challengeName: 'Cute Cats with Silly Hats', position: 2, prize: 0 },
+    });
+
+    expect(msg!.message).toContain('2nd');
+    expect(msg!.message).toContain('Cute Cats with Silly Hats');
+    expect(msg!.message).not.toMatch(/Buzz/);
+    expect(msg!.message).not.toMatch(/won/);
+  });
+});

--- a/src/server/notifications/challenge.notifications.ts
+++ b/src/server/notifications/challenge.notifications.ts
@@ -8,9 +8,12 @@ export const challengeNotifications = createNotificationProcessor({
     category: NotificationCategory.System,
     toggleable: false,
     prepareMessage: ({ details }) => ({
+      // A user challenge whose pool was never funded pays 0 — don't congratulate them on winning it.
       message: `You placed ${asOrdinal(details.position)} in the "${
         details.challengeName
-      }" challenge! You've won ${numberWithCommas(details.prize)} Buzz.`,
+      }" challenge!${
+        details.prize > 0 ? ` You've won ${numberWithCommas(details.prize)} Buzz.` : ''
+      }`,
       url: `/challenges/${details.challengeId}`,
     }),
   },

--- a/src/server/routers/challenge.router.ts
+++ b/src/server/routers/challenge.router.ts
@@ -7,7 +7,7 @@ import {
   getCompletedChallengesWithWinnersSchema,
   getInfiniteChallengesSchema,
   getModeratorChallengesSchema,
-  getMyParticipatedSchema,
+  getMyChallengesSchema,
   getUpcomingThemesSchema,
   getUserEntryCountSchema,
   getUserUnjudgedEntriesSchema,
@@ -49,7 +49,7 @@ import {
   getDailyChallenges,
   getInfiniteChallenges,
   getModeratorChallenges,
-  getMyParticipated,
+  getMyChallenges,
   getUpcomingThemes,
   getUserChallengeForEdit,
   getUserEntryCount,
@@ -102,13 +102,13 @@ export const challengeRouter = router({
     .use(isFlagProtected('challengePlatform'))
     .query(() => getDailyChallenges()),
 
-  // Current user's recently participated-in challenges (entered or won), recent-first.
-  getMyParticipated: protectedProcedure
+  // Current user's own challenges — entered or created — most-recent-activity first.
+  getMyChallenges: protectedProcedure
     .meta({ requiredScope: TokenScope.MediaRead })
-    .input(getMyParticipatedSchema)
+    .input(getMyChallengesSchema)
     .use(isFlagProtected('challengePlatform'))
     .query(({ input, ctx }) =>
-      getMyParticipated({ ...input, userId: ctx.user.id, isGreen: ctx.features.isGreen })
+      getMyChallenges({ ...input, userId: ctx.user.id, isGreen: ctx.features.isGreen })
     ),
 
   // Get single challenge by ID (public — sensitive fields stripped)

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -279,6 +279,7 @@ export const ChallengeParticipation = {
   Entered: 'entered',
   NotEntered: 'not_entered',
   Won: 'won',
+  Created: 'created',
 } as const;
 export type ChallengeParticipation =
   (typeof ChallengeParticipation)[keyof typeof ChallengeParticipation];
@@ -308,6 +309,7 @@ export const getInfiniteChallengesSchema = z.object({
       ChallengeParticipation.Entered,
       ChallengeParticipation.NotEntered,
       ChallengeParticipation.Won,
+      ChallengeParticipation.Created,
     ])
     .optional(),
   includeEnded: z.boolean().default(false),

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -29,7 +29,7 @@ import type { JudgeScore } from '~/server/games/daily-challenge/daily-challenge.
 
 // Lives here rather than in the service util that derives it: the util and the client-side card
 // helpers both need it, and services depend on schema, never the reverse.
-export type MyChallengeResult = 'won' | 'placed' | 'judging' | 'entered';
+export type MyChallengeResult = 'won' | 'placed' | 'judging' | 'entered' | 'hosting';
 
 // Cover image type for challenges (compatible with ImageGuard2)
 export type ChallengeCoverImage = {
@@ -99,18 +99,19 @@ export type ChallengeListItem = {
   };
 };
 
-// Recently participated-in challenges for the current user (Challenges Center "My Participated" row)
-export const getMyParticipatedSchema = z.object({
+// The viewer's own challenges — entered or created — for the Challenges Center "Your Challenges" row.
+export const getMyChallengesSchema = z.object({
   limit: z.number().min(1).max(20).default(6),
 });
-export type GetMyParticipatedInput = z.infer<typeof getMyParticipatedSchema>;
+export type GetMyChallengesInput = z.infer<typeof getMyChallengesSchema>;
 
-export type MyParticipatedChallengeItem = ChallengeListItem & {
+export type MyChallengeItem = ChallengeListItem & {
   myEntryImage: ChallengeListItem['coverImage'];
   myPlace: number | null;
   myResult: MyChallengeResult;
   isLive: boolean;
-  myEnteredAt: Date;
+  // Entry time for challenges you entered; creation time for ones you host.
+  myActivityAt: Date;
 };
 
 // Completion summary stored in Challenge.metadata when winners are picked

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -106,7 +106,6 @@ export const getMyChallengesSchema = z.object({
 export type GetMyChallengesInput = z.infer<typeof getMyChallengesSchema>;
 
 export type MyChallengeItem = ChallengeListItem & {
-  myEntryImage: ChallengeListItem['coverImage'];
   myPlace: number | null;
   myResult: MyChallengeResult;
   isLive: boolean;
@@ -603,6 +602,7 @@ export const getCompletedChallengesWithWinnersSchema = z.object({
   eventId: z.number().optional(),
   browsingLevel: z.number().optional(),
   query: z.string().optional(),
+  source: z.enum(ChallengeSource).array().optional(),
 });
 
 // --- Winner Cooldown ---

--- a/src/server/services/__tests__/challenge-judging-categories-gate.service.test.ts
+++ b/src/server/services/__tests__/challenge-judging-categories-gate.service.test.ts
@@ -92,6 +92,7 @@ vi.mock('~/server/jobs/daily-challenge-processing', () => ({
 vi.mock('~/server/games/daily-challenge/challenge-funding', () => ({
   chargeInitialPrize: vi.fn(),
   refundUserChallengeFunds: mockRefundUserChallengeFunds,
+  reportPoolFundingShortfall: vi.fn(),
 }));
 
 vi.mock('~/server/services/buzz.service', () => ({

--- a/src/server/services/__tests__/challenge-my-challenges-scope.service.test.ts
+++ b/src/server/services/__tests__/challenge-my-challenges-scope.service.test.ts
@@ -1,0 +1,163 @@
+import type { Prisma } from '@prisma/client';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// getMyChallenges: pins the WHERE-clause grouping between the "entered" branch (my CTE) and the
+// "created" branch (creator id + source = User). Flattening that OR — even by accident while
+// editing a neighboring predicate (block exclusion, domain currency, browsing level all live in
+// this same WHERE) — would readmit Mod/System-sourced challenges through the creator branch with
+// no visible symptom besides a dead "Manage" link for the moderators who created them (see
+// challenge.service.ts:454's isCreator scoping). Mocking shape mirrors
+// challenge-feed-block-exclusion.service.test.ts.
+const {
+  mockDbRead,
+  mockHiddenUsersGetCached,
+  mockBlockedByUsersGetCached,
+  mockBlockedUsersGetCached,
+} = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(),
+    modelVersion: { findMany: vi.fn() },
+    image: { findUnique: vi.fn(), findFirst: vi.fn(), findMany: vi.fn(() => []) },
+    challenge: { findUnique: vi.fn() },
+    collectionItem: { count: vi.fn() },
+  },
+  mockHiddenUsersGetCached: vi.fn(() => [] as { id: number }[]),
+  mockBlockedByUsersGetCached: vi.fn(() => [] as { id: number }[]),
+  mockBlockedUsersGetCached: vi.fn(() => [] as { id: number }[]),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: {},
+}));
+
+vi.mock('~/server/services/user-preferences.service', () => ({
+  HiddenUsers: { getCached: mockHiddenUsersGetCached },
+  BlockedByUsers: { getCached: mockBlockedByUsersGetCached },
+  BlockedUsers: { getCached: mockBlockedUsersGetCached },
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  createBuzzTransactionMany: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getChallengeConfig: vi.fn(() => ({
+    reviewMeTagId: 301770,
+    judgedTagId: 299729,
+    maxScoredPerUser: 5,
+    reviewAmount: { min: 6, max: 12 },
+  })),
+  setChallengeConfig: vi.fn(),
+  deriveChallengeNsfwLevel: vi.fn(() => 1),
+  getJudgingConfig: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  getChallengeById: vi.fn(),
+  getChallengeWinners: vi.fn(() => []),
+  closeChallengeCollection: vi.fn(),
+  createChallengeWinner: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  generateWinners: vi.fn(),
+}));
+
+vi.mock('~/server/jobs/daily-challenge-processing', () => ({
+  getJudgedEntries: vi.fn(),
+}));
+
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+}));
+
+vi.mock('~/server/services/image.service', () => ({
+  createImage: vi.fn(),
+  imagesForModelVersionsCache: { bust: vi.fn(), fetch: vi.fn(() => ({})) },
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  getCosmeticsForUsers: vi.fn(() => ({})),
+  getProfilePicturesForUsers: vi.fn(() => ({})),
+  amIBlockedByUser: vi.fn(),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-eligibility.service', () => ({
+  assertCanCreateUserChallenge: vi.fn(),
+  assertUserInGoodStanding: vi.fn(),
+  assertUserAccountInGoodStanding: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-category.service', () => ({
+  resolveJudgingCategories: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/challenge-judge.service', () => ({
+  getUserSelectableJudges: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/text-moderation.service', () => ({
+  submitTextModeration: vi.fn(),
+}));
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn(),
+}));
+
+vi.mock('~/utils/errorHandling', () => ({
+  withRetries: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('~/utils/logging', () => ({
+  createLogger: vi.fn(() => vi.fn()),
+}));
+
+const { getMyChallenges } = await import('~/server/services/challenge.service');
+
+// Duck-typed Prisma.Sql detection — see challenge-feed-block-exclusion.service.test.ts for why
+// `instanceof Prisma.Sql` isn't available at runtime.
+function isSqlLike(x: unknown): x is Prisma.Sql {
+  return (
+    typeof x === 'object' &&
+    x !== null &&
+    Array.isArray((x as { values?: unknown }).values) &&
+    Array.isArray((x as { strings?: unknown }).strings) &&
+    typeof (x as { text?: unknown }).text === 'string'
+  );
+}
+
+function capturedSql(): string {
+  const call = mockDbRead.$queryRaw.mock.calls[0];
+  if (!call) throw new Error('dbRead.$queryRaw was not called');
+  return call
+    .filter(isSqlLike)
+    .map((s) => s.text)
+    .join(' ');
+}
+
+describe('getMyChallenges — WHERE-clause scope and grouping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+    mockHiddenUsersGetCached.mockResolvedValue([]);
+    mockBlockedByUsersGetCached.mockResolvedValue([]);
+    mockBlockedUsersGetCached.mockResolvedValue([]);
+  });
+
+  it('scopes the created-by branch to User-sourced challenges, grouped under the same OR as the entered branch', async () => {
+    await getMyChallenges({ userId: 42, limit: 6, isGreen: false });
+
+    const text = capturedSql().replace(/\$\d+/g, '$?').replace(/\s+/g, ' ');
+    expect(text).toContain('OR (c."createdById" = $? AND c.source = $?::"ChallengeSource")');
+    // The grouping is what matters: flattening this OR (dropping the inner parens) would let a
+    // Mod/System-sourced challenge with a viewer CollectionItem satisfy the WHERE via the creator
+    // clause without the source guard, which is exactly the silent-failure mode this pins.
+    expect(text).toContain('WHERE (my."collectionId" IS NOT NULL OR (');
+  });
+});

--- a/src/server/services/__tests__/contest-entry-resource-gate.test.ts
+++ b/src/server/services/__tests__/contest-entry-resource-gate.test.ts
@@ -220,9 +220,28 @@ describe('contest entry resource gate (Task 11)', () => {
     ).resolves.toBeUndefined();
 
     expect(mockImageResourceNewFindMany).not.toHaveBeenCalled();
-    // Moderators are also exempt from the entry fee (chargeContestEntryFeesForCollection
-    // no-ops for isModerator), so the fee charge is never invoked either.
-    expect(mockChargeEntryFees).not.toHaveBeenCalled();
+  });
+
+  it('charges moderators the entry fee — the resource-gate bypass is not a fee exemption', async () => {
+    wireChallengeFindFirst({ hasResourceChallenge: false, hasFeeChallenge: true });
+
+    await expect(
+      validateContestCollectionEntry({
+        collectionId: COLLECTION_ID,
+        userId: USER_ID,
+        canAccessUserChallenges: true,
+        isModerator: true,
+        imageIds: [IMAGE_ID],
+        metadata: {},
+      })
+    ).resolves.toBeUndefined();
+
+    // A fee-exempt entry still competes for the prizes, so it would pay out from a pool it
+    // never funded (challenge 413: 2 mod entries, prizePool 0).
+    expect(mockChargeEntryFees).toHaveBeenCalledTimes(1);
+    expect(mockChargeEntryFees).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: USER_ID, imageIds: [IMAGE_ID], entryFee: 100 })
+    );
   });
 });
 

--- a/src/server/services/challenge-participation.enrich.test.ts
+++ b/src/server/services/challenge-participation.enrich.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { ChallengeStatus, ChallengeSource } from '~/shared/utils/prisma/enums';
-import { enrichParticipatedCards } from './challenge-participation.util';
+import {
+  deriveMyChallengeResult,
+  enrichMyChallengeCards,
+} from './challenge-participation.util';
 
 const baseCard = {
   id: 10,
@@ -24,68 +27,96 @@ const baseCard = {
 } as any;
 const img = { id: 99, url: 'u', nsfwLevel: 1, hash: 'h', width: 512, height: 512, type: 'image' as const };
 
-describe('enrichParticipatedCards', () => {
-  it('attaches entry image, place, derived result, entered-at', () => {
-    const [out] = enrichParticipatedCards(
+describe('enrichMyChallengeCards', () => {
+  it('attaches entry image, place, derived result, activity-at', () => {
+    const [out] = enrichMyChallengeCards(
       [baseCard],
-      [{ id: 10, myImageId: 99, myPlace: 1, myEnteredAt: new Date('2026-01-03') }],
+      [{ id: 10, myImageId: 99, myPlace: 1, myActivityAt: new Date('2026-01-03'), isCreator: false }],
       [img]
     );
     expect(out.myEntryImage?.id).toBe(99);
     expect(out.myPlace).toBe(1);
     expect(out.myResult).toBe('won');
     expect(out.isLive).toBe(false);
-    expect(out.myEnteredAt).toEqual(new Date('2026-01-03'));
+    expect(out.myActivityAt).toEqual(new Date('2026-01-03'));
   });
-  it('falls back to challenge cover when entry image missing', () => {
-    const withCover = { ...baseCard, coverImage: { ...img, id: 7 } };
-    const [out] = enrichParticipatedCards(
-      [withCover],
-      [{ id: 10, myImageId: null, myPlace: null, myEnteredAt: new Date('2026-01-03') }],
+  it('leaves myEntryImage null when the entry image is missing', () => {
+    const cover = { ...img, id: 7 };
+    const [out] = enrichMyChallengeCards(
+      [{ ...baseCard, coverImage: cover }],
+      [{ id: 10, myImageId: null, myPlace: null, myActivityAt: new Date('2026-01-03'), isCreator: false }],
       []
     );
-    expect(out.myEntryImage?.id).toBe(7); // fell back to challenge cover
+    expect(out.myEntryImage).toBeNull();
+    expect(out.coverImage).toEqual(cover);
     expect(out.myResult).toBe('entered');
   });
 });
 
-// `useApplyHiddenPreferences({ type: 'challenges' })` gates each row on `coverImage.nsfwLevel` and
-// drops anything with no cover at all — but the card renders `myEntryImage`. Keeping `coverImage`
-// pointed at the image actually rendered makes the generic filter judge what the user will see.
-describe('enrichParticipatedCards — coverImage tracks the rendered thumbnail', () => {
-  const spicyEntry = { ...img, id: 1234, nsfwLevel: 8 };
+describe('enrichMyChallengeCards — the card renders the challenge cover', () => {
+  const cover = { id: 1, url: 'cover', nsfwLevel: 1, hash: null, width: 10, height: 10, type: 'image' as const };
+  const entry = { id: 2, url: 'entry', nsfwLevel: 1, hash: null, width: 10, height: 10, type: 'image' as const };
 
-  it('sets coverImage to the entry image so the hidden-preferences filter gates on it', () => {
-    const [out] = enrichParticipatedCards(
-      [{ ...baseCard, coverImage: { ...img, id: 7, nsfwLevel: 1 } }],
-      [{ id: 10, myImageId: spicyEntry.id, myPlace: null, myEnteredAt: new Date('2026-01-03') }],
-      [spicyEntry]
-    );
-
-    expect(out.myEntryImage).toEqual(spicyEntry);
-    expect(out.coverImage).toEqual(spicyEntry);
-  });
-
-  it('keeps a cover-less challenge visible when the user has an entry image', () => {
-    const [out] = enrichParticipatedCards(
-      [{ ...baseCard, coverImage: null }],
-      [{ id: 10, myImageId: img.id, myPlace: null, myEnteredAt: new Date('2026-01-03') }],
-      [img]
-    );
-
-    // Without this the filter sees `coverImage: null` and hides a challenge the user entered.
-    expect(out.coverImage).toEqual(img);
-  });
-
-  it('falls back to the challenge cover when there is no entry image', () => {
-    const cover = { ...img, id: 7 };
-    const [out] = enrichParticipatedCards(
+  it('coverImage stays the challenge cover even when an entry image exists', () => {
+    const [out] = enrichMyChallengeCards(
       [{ ...baseCard, coverImage: cover }],
-      [{ id: 10, myImageId: null, myPlace: null, myEnteredAt: new Date('2026-01-03') }],
+      [{ id: baseCard.id, myImageId: 2, myPlace: null, myActivityAt: new Date(), isCreator: false }],
+      [entry]
+    );
+    expect(out.coverImage).toEqual(cover);
+  });
+
+  it('myEntryImage is the entry image, for the View entry link', () => {
+    const [out] = enrichMyChallengeCards(
+      [{ ...baseCard, coverImage: cover }],
+      [{ id: baseCard.id, myImageId: 2, myPlace: null, myActivityAt: new Date(), isCreator: false }],
+      [entry]
+    );
+    expect(out.myEntryImage).toEqual(entry);
+  });
+
+  it('a hosted challenge has no entry image', () => {
+    const [out] = enrichMyChallengeCards(
+      [{ ...baseCard, coverImage: cover }],
+      [{ id: baseCard.id, myImageId: null, myPlace: null, myActivityAt: new Date(), isCreator: true }],
       []
     );
-
+    expect(out.myEntryImage).toBeNull();
     expect(out.coverImage).toEqual(cover);
-    expect(out.myEntryImage).toEqual(cover);
+    expect(out.myResult).toBe('hosting');
+  });
+});
+
+describe('deriveMyChallengeResult — hosting', () => {
+  it('a creator gets hosting regardless of status', () => {
+    expect(
+      deriveMyChallengeResult({
+        status: ChallengeStatus.Scheduled,
+        myPlace: null,
+        isCreator: true,
+      })
+    ).toEqual({ result: 'hosting', isLive: false });
+  });
+
+  it('a live hosted challenge is marked live', () => {
+    expect(
+      deriveMyChallengeResult({ status: ChallengeStatus.Active, myPlace: null, isCreator: true })
+    ).toEqual({ result: 'hosting', isLive: true });
+  });
+
+  it('a completed hosted challenge is hosting, not entered', () => {
+    expect(
+      deriveMyChallengeResult({
+        status: ChallengeStatus.Completed,
+        myPlace: null,
+        isCreator: true,
+      })
+    ).toEqual({ result: 'hosting', isLive: false });
+  });
+
+  it('a non-creator entrant is unaffected', () => {
+    expect(
+      deriveMyChallengeResult({ status: ChallengeStatus.Active, myPlace: null, isCreator: false })
+    ).toEqual({ result: 'entered', isLive: true });
   });
 });

--- a/src/server/services/challenge-participation.enrich.test.ts
+++ b/src/server/services/challenge-participation.enrich.test.ts
@@ -25,63 +25,37 @@ const baseCard = {
   modelVersionIds: [],
   createdBy: { id: 1, username: 'CivBot', image: null, profilePicture: null, cosmetics: null, deletedAt: null },
 } as any;
-const img = { id: 99, url: 'u', nsfwLevel: 1, hash: 'h', width: 512, height: 512, type: 'image' as const };
 
 describe('enrichMyChallengeCards', () => {
-  it('attaches entry image, place, derived result, activity-at', () => {
+  it('attaches place, derived result, activity-at', () => {
     const [out] = enrichMyChallengeCards(
       [baseCard],
-      [{ id: 10, myImageId: 99, myPlace: 1, myActivityAt: new Date('2026-01-03'), isCreator: false }],
-      [img]
+      [{ id: 10, myPlace: 1, myActivityAt: new Date('2026-01-03'), isCreator: false }]
     );
-    expect(out.myEntryImage?.id).toBe(99);
     expect(out.myPlace).toBe(1);
     expect(out.myResult).toBe('won');
     expect(out.isLive).toBe(false);
     expect(out.myActivityAt).toEqual(new Date('2026-01-03'));
   });
-  it('leaves myEntryImage null when the entry image is missing', () => {
-    const cover = { ...img, id: 7 };
-    const [out] = enrichMyChallengeCards(
-      [{ ...baseCard, coverImage: cover }],
-      [{ id: 10, myImageId: null, myPlace: null, myActivityAt: new Date('2026-01-03'), isCreator: false }],
-      []
-    );
-    expect(out.myEntryImage).toBeNull();
-    expect(out.coverImage).toEqual(cover);
-    expect(out.myResult).toBe('entered');
-  });
 });
 
 describe('enrichMyChallengeCards — the card renders the challenge cover', () => {
   const cover = { id: 1, url: 'cover', nsfwLevel: 1, hash: null, width: 10, height: 10, type: 'image' as const };
-  const entry = { id: 2, url: 'entry', nsfwLevel: 1, hash: null, width: 10, height: 10, type: 'image' as const };
 
-  it('coverImage stays the challenge cover even when an entry image exists', () => {
+  it('coverImage stays the challenge cover', () => {
     const [out] = enrichMyChallengeCards(
       [{ ...baseCard, coverImage: cover }],
-      [{ id: baseCard.id, myImageId: 2, myPlace: null, myActivityAt: new Date(), isCreator: false }],
-      [entry]
+      [{ id: baseCard.id, myPlace: null, myActivityAt: new Date(), isCreator: false }]
     );
     expect(out.coverImage).toEqual(cover);
+    expect(out.myResult).toBe('entered');
   });
 
-  it('myEntryImage is the entry image, for the View entry link', () => {
+  it('a creator gets the hosting result', () => {
     const [out] = enrichMyChallengeCards(
       [{ ...baseCard, coverImage: cover }],
-      [{ id: baseCard.id, myImageId: 2, myPlace: null, myActivityAt: new Date(), isCreator: false }],
-      [entry]
+      [{ id: baseCard.id, myPlace: null, myActivityAt: new Date(), isCreator: true }]
     );
-    expect(out.myEntryImage).toEqual(entry);
-  });
-
-  it('a hosted challenge has no entry image', () => {
-    const [out] = enrichMyChallengeCards(
-      [{ ...baseCard, coverImage: cover }],
-      [{ id: baseCard.id, myImageId: null, myPlace: null, myActivityAt: new Date(), isCreator: true }],
-      []
-    );
-    expect(out.myEntryImage).toBeNull();
     expect(out.coverImage).toEqual(cover);
     expect(out.myResult).toBe('hosting');
   });

--- a/src/server/services/challenge-participation.util.test.ts
+++ b/src/server/services/challenge-participation.util.test.ts
@@ -4,23 +4,23 @@ import { deriveMyChallengeResult } from './challenge-participation.util';
 
 describe('deriveMyChallengeResult', () => {
   it('completed + place 1 => won', () => {
-    expect(deriveMyChallengeResult({ status: ChallengeStatus.Completed, myPlace: 1 }))
+    expect(deriveMyChallengeResult({ status: ChallengeStatus.Completed, myPlace: 1, isCreator: false }))
       .toEqual({ result: 'won', isLive: false });
   });
   it('completed + place 2 => placed', () => {
-    expect(deriveMyChallengeResult({ status: ChallengeStatus.Completed, myPlace: 2 }))
+    expect(deriveMyChallengeResult({ status: ChallengeStatus.Completed, myPlace: 2, isCreator: false }))
       .toEqual({ result: 'placed', isLive: false });
   });
   it('completed + no placement => entered', () => {
-    expect(deriveMyChallengeResult({ status: ChallengeStatus.Completed, myPlace: null }))
+    expect(deriveMyChallengeResult({ status: ChallengeStatus.Completed, myPlace: null, isCreator: false }))
       .toEqual({ result: 'entered', isLive: false });
   });
   it('completing => judging', () => {
-    expect(deriveMyChallengeResult({ status: ChallengeStatus.Completing, myPlace: null }))
+    expect(deriveMyChallengeResult({ status: ChallengeStatus.Completing, myPlace: null, isCreator: false }))
       .toEqual({ result: 'judging', isLive: false });
   });
   it('active => entered + live', () => {
-    expect(deriveMyChallengeResult({ status: ChallengeStatus.Active, myPlace: null }))
+    expect(deriveMyChallengeResult({ status: ChallengeStatus.Active, myPlace: null, isCreator: false }))
       .toEqual({ result: 'entered', isLive: true });
   });
 });

--- a/src/server/services/challenge-participation.util.ts
+++ b/src/server/services/challenge-participation.util.ts
@@ -2,48 +2,59 @@ import { ChallengeStatus } from '~/shared/utils/prisma/enums';
 import type {
   ChallengeListItem,
   MyChallengeResult,
-  MyParticipatedChallengeItem,
+  MyChallengeItem,
 } from '~/server/schema/challenge.schema';
 
 export function deriveMyChallengeResult(input: {
   status: ChallengeStatus;
   myPlace: number | null;
+  isCreator: boolean;
 }): { result: MyChallengeResult; isLive: boolean } {
-  const { status, myPlace } = input;
+  const { status, myPlace, isCreator } = input;
+  // Creating and entering are mutually exclusive (self-entry is blocked), so ownership wins
+  // outright rather than being reconciled with a placement.
+  if (isCreator) return { result: 'hosting', isLive: status === ChallengeStatus.Active };
   if (status === ChallengeStatus.Completed) {
     if (myPlace === 1) return { result: 'won', isLive: false };
     if (myPlace != null && myPlace > 1) return { result: 'placed', isLive: false };
     return { result: 'entered', isLive: false };
   }
   if (status === ChallengeStatus.Completing) return { result: 'judging', isLive: false };
-  // Active (or any other state a user could have entered)
   return { result: 'entered', isLive: status === ChallengeStatus.Active };
 }
 
-// Pure: zip base cards + raw my-fields + hydrated entry images into MyParticipatedChallengeItem.
+// Pure: zip base cards + raw my-fields + hydrated entry images into MyChallengeItem.
 // Rows/baseCards are index-aligned (mapChallengeRowsToCards preserves input order). Lives here
 // (not challenge.service.ts) so it stays unit-testable without pulling in that ~8K-line module.
-export function enrichParticipatedCards(
+export function enrichMyChallengeCards(
   baseCards: ChallengeListItem[],
-  rows: { id: number; myImageId: number | null; myPlace: number | null; myEnteredAt: Date }[],
+  rows: {
+    id: number;
+    myImageId: number | null;
+    myPlace: number | null;
+    myActivityAt: Date;
+    isCreator: boolean;
+  }[],
   entryImages: Array<NonNullable<ChallengeListItem['coverImage']>>
-): MyParticipatedChallengeItem[] {
+): MyChallengeItem[] {
   return baseCards.map((card, i) => {
     const row = rows[i];
     const entryImg = row.myImageId ? entryImages.find((img) => img.id === row.myImageId) : null;
-    const { result, isLive } = deriveMyChallengeResult({ status: card.status, myPlace: row.myPlace });
-    const thumbnail = entryImg ?? card.coverImage ?? null;
+    const { result, isLive } = deriveMyChallengeResult({
+      status: card.status,
+      myPlace: row.myPlace,
+      isCreator: row.isCreator,
+    });
     return {
       ...card,
-      // The consumer runs these through `useApplyHiddenPreferences({ type: 'challenges' })`, whose
-      // gate reads `coverImage.nsfwLevel` and drops rows with no cover — while the card renders
-      // `myEntryImage`. Point both at the same image so the filter judges what is actually shown.
-      coverImage: thumbnail,
-      myEntryImage: thumbnail,
+      // The card renders the challenge cover, and the consumer's
+      // useApplyHiddenPreferences({ type: 'challenges' }) gate reads coverImage.nsfwLevel — so
+      // both must be the cover. myEntryImage exists solely for the "View entry" link target.
+      myEntryImage: entryImg ?? null,
       myPlace: row.myPlace,
       myResult: result,
       isLive,
-      myEnteredAt: row.myEnteredAt,
+      myActivityAt: row.myActivityAt,
     };
   });
 }

--- a/src/server/services/challenge-participation.util.ts
+++ b/src/server/services/challenge-participation.util.ts
@@ -24,23 +24,20 @@ export function deriveMyChallengeResult(input: {
   return { result: 'entered', isLive: status === ChallengeStatus.Active };
 }
 
-// Pure: zip base cards + raw my-fields + hydrated entry images into MyChallengeItem.
+// Pure: zip base cards + raw my-fields into MyChallengeItem.
 // Rows/baseCards are index-aligned (mapChallengeRowsToCards preserves input order). Lives here
 // (not challenge.service.ts) so it stays unit-testable without pulling in that ~8K-line module.
 export function enrichMyChallengeCards(
   baseCards: ChallengeListItem[],
   rows: {
     id: number;
-    myImageId: number | null;
     myPlace: number | null;
     myActivityAt: Date;
     isCreator: boolean;
-  }[],
-  entryImages: Array<NonNullable<ChallengeListItem['coverImage']>>
+  }[]
 ): MyChallengeItem[] {
   return baseCards.map((card, i) => {
     const row = rows[i];
-    const entryImg = row.myImageId ? entryImages.find((img) => img.id === row.myImageId) : null;
     const { result, isLive } = deriveMyChallengeResult({
       status: card.status,
       myPlace: row.myPlace,
@@ -48,10 +45,6 @@ export function enrichMyChallengeCards(
     });
     return {
       ...card,
-      // The card renders the challenge cover, and the consumer's
-      // useApplyHiddenPreferences({ type: 'challenges' }) gate reads coverImage.nsfwLevel — so
-      // both must be the cover. myEntryImage exists solely for the "View entry" link target.
-      myEntryImage: entryImg ?? null,
       myPlace: row.myPlace,
       myResult: result,
       isLive,

--- a/src/server/services/challenge-participation.util.ts
+++ b/src/server/services/challenge-participation.util.ts
@@ -11,8 +11,9 @@ export function deriveMyChallengeResult(input: {
   isCreator: boolean;
 }): { result: MyChallengeResult; isLive: boolean } {
   const { status, myPlace, isCreator } = input;
-  // Creating and entering are mutually exclusive (self-entry is blocked), so ownership wins
-  // outright rather than being reconciled with a placement.
+  // Creating and entering are mutually exclusive for regular users (self-entry is blocked), but
+  // moderators are exempt from that guard (collection.service.ts) — a moderator who places in
+  // their own challenge still shows hosting, not won, since ownership wins outright here.
   if (isCreator) return { result: 'hosting', isLive: status === ChallengeStatus.Active };
   if (status === ChallengeStatus.Completed) {
     if (myPlace === 1) return { result: 'won', isLive: false };

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -451,7 +451,7 @@ export async function getMyChallenges({
            u.username AS "creatorUsername", u.image AS "creatorImage", u."deletedAt" AS "creatorDeletedAt",
            cj."userId" AS "judgeUserId", ju.username AS "judgeUsername", ju.image AS "judgeImage", ju."deletedAt" AS "judgeDeletedAt",
            my."myImageId", cw."place" AS "myPlace",
-           (c."createdById" = ${userId}) AS "isCreator",
+           (c."createdById" = ${userId} AND c.source = ${ChallengeSource.User}::"ChallengeSource") AS "isCreator",
            COALESCE(my."myEnteredAt", c."createdAt") AS "myActivityAt"
     FROM "Challenge" c
     LEFT JOIN my ON my."collectionId" = c."collectionId"

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -697,6 +697,9 @@ export async function getInfiniteChallenges(
           )`
         );
         break;
+      case ChallengeParticipation.Created:
+        conditions.push(Prisma.sql`c."createdById" = ${currentUserId}`);
+        break;
     }
   }
 

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -34,9 +34,9 @@ import {
   type GetInfiniteChallengesInput,
   type GetModeratorChallengesInput,
   type GetChallengeEventsInput,
-  type GetMyParticipatedInput,
+  type GetMyChallengesInput,
   type ImageEligibilityResult,
-  type MyParticipatedChallengeItem,
+  type MyChallengeItem,
   type UpcomingTheme,
   type UpsertChallengeInput,
   type UserChallengeUpsertInput,
@@ -87,7 +87,7 @@ import {
   assertUserAccountInGoodStanding,
 } from '~/server/services/challenge-eligibility.service';
 import { submitTextModeration } from '~/server/services/text-moderation.service';
-import { enrichParticipatedCards } from '~/server/services/challenge-participation.util';
+import { enrichMyChallengeCards } from '~/server/services/challenge-participation.util';
 import {
   getEffectiveBrowsingLevel,
   isChallengeHiddenByCoverScan,
@@ -372,12 +372,13 @@ async function mapChallengeRowsToCards(items: ChallengeCardRow[]): Promise<Chall
   });
 }
 
-// Raw row shape for getMyParticipated: the shared card projection plus the viewer's own
-// entry/placement fields from the `my` CTE.
-type ParticipatedRow = ChallengeCardRow & {
+// Raw row shape for getMyChallenges: the shared card projection plus the viewer's own
+// entry/placement fields from the `my` CTE, and whether the viewer created it.
+type MyChallengeRow = ChallengeCardRow & {
   myImageId: number | null;
   myPlace: number | null;
-  myEnteredAt: Date;
+  myActivityAt: Date;
+  isCreator: boolean;
 };
 
 // The viewer's bounded block/hide exclusion set (hidden ∪ blocked-by ∪ blocked), used to drop
@@ -406,16 +407,14 @@ function challengeCreatorBlockSql(excludedUserIds: number[]): Prisma.Sql | null 
 }
 
 /**
- * Challenges the current user has entered (CollectionItem) or won (ChallengeWinner), recent-first
- * by entry time. One row per challenge (their latest entry as the representative thumbnail).
+ * The viewer's own challenges: ones they entered (CollectionItem) and ones they created,
+ * most-recent-activity first. One row per challenge.
  */
-export async function getMyParticipated({
+export async function getMyChallenges({
   userId,
   limit,
   isGreen,
-}: GetMyParticipatedInput & { userId: number; isGreen: boolean }): Promise<
-  MyParticipatedChallengeItem[]
-> {
+}: GetMyChallengesInput & { userId: number; isGreen: boolean }): Promise<MyChallengeItem[]> {
   const myEntries = Prisma.sql`
     SELECT
       ci."collectionId" AS "collectionId",
@@ -429,8 +428,8 @@ export async function getMyParticipated({
   // Domain + NSFW gating mirrors getInfiniteChallenges (deriveDomainCurrency / getEffectiveBrowsingLevel)
   // rather than a flat `nsfwLevel = 1` check — a yellow-domain user challenge must stay off the
   // green site, and the SFW cap must be bitwise-checked, not equality-checked. Both gates exempt
-  // the viewer's own creations. The browsing-level check reads the entry image (COALESCE to the
-  // challenge cover when absent) since that's the thumbnail this card actually renders.
+  // the viewer's own creations. The level check reads the challenge cover, which is what the card
+  // renders.
   const domainCurrency = deriveDomainCurrency(isGreen);
   const effectiveBrowsingLevel = getEffectiveBrowsingLevel({
     isGreen,
@@ -440,7 +439,7 @@ export async function getMyParticipated({
 
   const blockSql = challengeCreatorBlockSql(await getChallengeExcludedUserIds(userId));
 
-  const rows = await dbRead.$queryRaw<ParticipatedRow[]>(Prisma.sql`
+  const rows = await dbRead.$queryRaw<MyChallengeRow[]>(Prisma.sql`
     WITH my AS (${myEntries})
     SELECT c.id, c.title, c.theme, c.invitation, c."coverImageId", c."startsAt", c."endsAt",
            c.status, c.source, c."buzzType", c."prizePool",
@@ -451,22 +450,25 @@ export async function getMyParticipated({
            c."collectionId", c."createdById",
            u.username AS "creatorUsername", u.image AS "creatorImage", u."deletedAt" AS "creatorDeletedAt",
            cj."userId" AS "judgeUserId", ju.username AS "judgeUsername", ju.image AS "judgeImage", ju."deletedAt" AS "judgeDeletedAt",
-           my."myImageId", my."myEnteredAt", cw."place" AS "myPlace"
+           my."myImageId", cw."place" AS "myPlace",
+           (c."createdById" = ${userId}) AS "isCreator",
+           COALESCE(my."myEnteredAt", c."createdAt") AS "myActivityAt"
     FROM "Challenge" c
-    JOIN my ON my."collectionId" = c."collectionId"
+    LEFT JOIN my ON my."collectionId" = c."collectionId"
     JOIN "User" u ON u.id = c."createdById"
     LEFT JOIN "ChallengeJudge" cj ON cj.id = c."judgeId"
     LEFT JOIN "User" ju ON ju.id = cj."userId"
     LEFT JOIN "ChallengeWinner" cw ON cw."challengeId" = c.id AND cw."userId" = ${userId}
-    WHERE c.status IN (${ChallengeStatus.Active}::"ChallengeStatus", ${ChallengeStatus.Completing}::"ChallengeStatus", ${ChallengeStatus.Completed}::"ChallengeStatus")
+    WHERE (my."collectionId" IS NOT NULL OR c."createdById" = ${userId})
+      AND c.status IN (${ChallengeStatus.Scheduled}::"ChallengeStatus", ${ChallengeStatus.Active}::"ChallengeStatus", ${ChallengeStatus.Completing}::"ChallengeStatus", ${ChallengeStatus.Completed}::"ChallengeStatus")
       AND (c.source <> ${ChallengeSource.User}::"ChallengeSource" OR c."buzzType" = ${domainCurrency} OR c."createdById" = ${userId})
       ${blockSql ? Prisma.sql`AND ${blockSql}` : Prisma.empty}
       ${
         effectiveBrowsingLevel > 0
-          ? Prisma.sql`AND (c."createdById" = ${userId} OR EXISTS (SELECT 1 FROM "Image" i WHERE i.id = COALESCE(my."myImageId", c."coverImageId") AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0))`
+          ? Prisma.sql`AND (c."createdById" = ${userId} OR EXISTS (SELECT 1 FROM "Image" i WHERE i.id = c."coverImageId" AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0))`
           : Prisma.empty
       }
-    ORDER BY my."myEnteredAt" DESC
+    ORDER BY COALESCE(my."myEnteredAt", c."createdAt") DESC
     LIMIT ${limit}`);
 
   if (!rows.length) return [];
@@ -477,9 +479,15 @@ export async function getMyParticipated({
     ? await dbRead.image.findMany({ where: { id: { in: entryImageIds } }, select: imageSelect })
     : [];
 
-  return enrichParticipatedCards(
+  return enrichMyChallengeCards(
     baseCards,
-    rows.map((r) => ({ id: r.id, myImageId: r.myImageId, myPlace: r.myPlace, myEnteredAt: r.myEnteredAt })),
+    rows.map((r) => ({
+      id: r.id,
+      myImageId: r.myImageId,
+      myPlace: r.myPlace,
+      myActivityAt: r.myActivityAt,
+      isCreator: r.isCreator,
+    })),
     entryImages.map((img) => ({
       id: img.id,
       url: img.url,

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -98,6 +98,7 @@ import {
   buildWinnerPayoutTransactions,
   chargeInitialPrize,
   refundUserChallengeFunds,
+  reportPoolFundingShortfall,
 } from '~/server/games/daily-challenge/challenge-funding';
 import {
   deriveDomainCurrency,
@@ -375,7 +376,6 @@ async function mapChallengeRowsToCards(items: ChallengeCardRow[]): Promise<Chall
 // Raw row shape for getMyChallenges: the shared card projection plus the viewer's own
 // entry/placement fields from the `my` CTE, and whether the viewer created it.
 type MyChallengeRow = ChallengeCardRow & {
-  myImageId: number | null;
   myPlace: number | null;
   myActivityAt: Date;
   isCreator: boolean;
@@ -418,8 +418,7 @@ export async function getMyChallenges({
   const myEntries = Prisma.sql`
     SELECT
       ci."collectionId" AS "collectionId",
-      MAX(ci."createdAt") AS "myEnteredAt",
-      (ARRAY_AGG(ci."imageId" ORDER BY ci."createdAt" DESC))[1] AS "myImageId"
+      MAX(ci."createdAt") AS "myEnteredAt"
     FROM "CollectionItem" ci
     WHERE ci."addedById" = ${userId}
       AND ci.status IN (${CollectionItemStatus.ACCEPTED}::"CollectionItemStatus", ${CollectionItemStatus.REVIEW}::"CollectionItemStatus")
@@ -450,7 +449,7 @@ export async function getMyChallenges({
            c."collectionId", c."createdById",
            u.username AS "creatorUsername", u.image AS "creatorImage", u."deletedAt" AS "creatorDeletedAt",
            cj."userId" AS "judgeUserId", ju.username AS "judgeUsername", ju.image AS "judgeImage", ju."deletedAt" AS "judgeDeletedAt",
-           my."myImageId", cw."place" AS "myPlace",
+           cw."place" AS "myPlace",
            (c."createdById" = ${userId} AND c.source = ${ChallengeSource.User}::"ChallengeSource") AS "isCreator",
            COALESCE(my."myEnteredAt", c."createdAt") AS "myActivityAt"
     FROM "Challenge" c
@@ -475,28 +474,14 @@ export async function getMyChallenges({
   if (!rows.length) return [];
 
   const baseCards = await mapChallengeRowsToCards(rows);
-  const entryImageIds = rows.map((r) => r.myImageId).filter((id): id is number => !!id);
-  const entryImages = entryImageIds.length
-    ? await dbRead.image.findMany({ where: { id: { in: entryImageIds } }, select: imageSelect })
-    : [];
 
   return enrichMyChallengeCards(
     baseCards,
     rows.map((r) => ({
       id: r.id,
-      myImageId: r.myImageId,
       myPlace: r.myPlace,
       myActivityAt: r.myActivityAt,
       isCreator: r.isCreator,
-    })),
-    entryImages.map((img) => ({
-      id: img.id,
-      url: img.url,
-      nsfwLevel: img.nsfwLevel,
-      hash: img.hash,
-      width: img.width,
-      height: img.height,
-      type: img.type,
     }))
   );
 }
@@ -2472,6 +2457,8 @@ export async function endChallengeAndPickWinners(challengeId: number) {
           prizes: finalPrizes,
         });
       }
+
+      await reportPoolFundingShortfall({ challengeId, collectionId: challenge.collectionId });
     }
 
     // Check if winners already exist from a previous (failed) run.
@@ -3614,7 +3601,7 @@ export async function playgroundPickWinners(input: PlaygroundPickWinnersInput) {
 export async function getCompletedChallengesWithWinners(
   input: GetCompletedChallengesWithWinnersInput & { isGreen?: boolean; currentUserId?: number }
 ) {
-  const { cursor, limit, eventId, browsingLevel, query, isGreen, currentUserId } = input;
+  const { cursor, limit, eventId, browsingLevel, query, source, isGreen, currentUserId } = input;
 
   // Phase 1: Query completed challenges with cursor pagination
   const conditions: Prisma.Sql[] = [
@@ -3625,6 +3612,14 @@ export async function getCompletedChallengesWithWinners(
 
   if (eventId) {
     conditions.push(Prisma.sql`c."eventId" = ${eventId}`);
+  }
+
+  if (source?.length) {
+    conditions.push(
+      Prisma.sql`c.source IN (${Prisma.join(
+        source.map((s) => Prisma.sql`${s}::"ChallengeSource"`)
+      )})`
+    );
   }
 
   // Domain-currency gate — parity with the feed: a user challenge only appears on its own domain

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -459,7 +459,8 @@ export async function getMyChallenges({
     LEFT JOIN "ChallengeJudge" cj ON cj.id = c."judgeId"
     LEFT JOIN "User" ju ON ju.id = cj."userId"
     LEFT JOIN "ChallengeWinner" cw ON cw."challengeId" = c.id AND cw."userId" = ${userId}
-    WHERE (my."collectionId" IS NOT NULL OR c."createdById" = ${userId})
+    WHERE (my."collectionId" IS NOT NULL
+           OR (c."createdById" = ${userId} AND c.source = ${ChallengeSource.User}::"ChallengeSource"))
       AND c.status IN (${ChallengeStatus.Scheduled}::"ChallengeStatus", ${ChallengeStatus.Active}::"ChallengeStatus", ${ChallengeStatus.Completing}::"ChallengeStatus", ${ChallengeStatus.Completed}::"ChallengeStatus")
       AND (c.source <> ${ChallengeSource.User}::"ChallengeSource" OR c."buzzType" = ${domainCurrency} OR c."createdById" = ${userId})
       ${blockSql ? Prisma.sql`AND ${blockSql}` : Prisma.empty}

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -1916,22 +1916,24 @@ export function getContributorCount({ collectionIds: ids }: { collectionIds: num
 }
 
 // Charge the active user-challenge entry fee for `imageIds` on this collection, if any.
-// Idempotent per (challenge, image) — see chargeEntryFees. No-op for moderators, empty input,
-// or collections without an Active fee challenge. Returns the paid/unpaid partition when a
-// charge ran; entry fees are NEVER refunded (see challenge-funding.ts), so callers must
-// commit only `paidImageIds` — an unpaid image self-heals if the user retries.
+// Idempotent per (challenge, image) — see chargeEntryFees. No-op for empty input or collections
+// without an Active fee challenge. Returns the paid/unpaid partition when a charge ran; entry
+// fees are NEVER refunded (see challenge-funding.ts), so callers must commit only
+// `paidImageIds` — an unpaid image self-heals if the user retries.
+//
+// Moderators are charged like everyone else: a fee-exempt entry is still eligible to win, so it
+// would pay out from a pool it never funded (challenge 413 completed with 2 mod entries and a
+// prizePool of 0).
 const chargeContestEntryFeesForCollection = async ({
   collectionId,
   userId,
   imageIds,
-  isModerator,
 }: {
   collectionId: number;
   userId: number;
   imageIds: number[];
-  isModerator?: boolean;
 }) => {
-  if (isModerator || imageIds.length === 0) return undefined;
+  if (imageIds.length === 0) return undefined;
   const feeChallenge = await dbRead.challenge.findFirst({
     where: { collectionId, source: 'User', entryFee: { gt: 0 }, status: 'Active' },
     select: { id: true, entryFee: true, buzzType: true },
@@ -2278,7 +2280,6 @@ export const validateContestCollectionEntry = async ({
       collectionId,
       userId,
       imageIds,
-      isModerator,
     });
     if (chargeResult && chargeResult.unpaidImageIds.length > 0) {
       // Nothing was written yet, so aborting strands no entry. Any legs that DID charge stay
@@ -2557,7 +2558,6 @@ export const bulkSaveItems = async ({
         collectionId,
         userId,
         imageIds: chargeImageIds,
-        isModerator,
       });
     } catch (e) {
       // Transport/service failure — per-image payment state is unknown, so remove every row

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -95,6 +95,12 @@ export default defineConfig({
         // the optimize pass happen BEFORE the run starts, so there's no mid-run reload.
         optimizeDeps: {
           include: ['next/router', 'vitest-browser-react', 'react/jsx-dev-runtime', 'react/jsx-runtime'],
+          // Vite's cold-scan crawls the whole `src` tree for bare imports, including server-only
+          // files that `await import('sharp')` (e.g. app-listing-assets.service.ts). esbuild can't
+          // pre-bundle sharp's native binding (a template-literal `require` of a `.node` file) and
+          // fails the whole component project with "No loader is configured for '.node' files" —
+          // unrelated to whatever test you actually ran. Exclude it; no component test needs it.
+          exclude: ['sharp'],
         },
         test: {
           name: 'component',

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -95,11 +95,16 @@ export default defineConfig({
         // the optimize pass happen BEFORE the run starts, so there's no mid-run reload.
         optimizeDeps: {
           include: ['next/router', 'vitest-browser-react', 'react/jsx-dev-runtime', 'react/jsx-runtime'],
-          // Vite's cold-scan crawls the whole `src` tree for bare imports, including server-only
-          // files that `await import('sharp')` (e.g. app-listing-assets.service.ts). esbuild can't
-          // pre-bundle sharp's native binding (a template-literal `require` of a `.node` file) and
-          // fails the whole component project with "No loader is configured for '.node' files" —
-          // unrelated to whatever test you actually ran. Exclude it; no component test needs it.
+          // `@vitest/browser` seeds optimizeDeps.entries from EVERY `*.browser.test.tsx` file
+          // (globTestFiles), not just the one you ran. The review app-listing browser tests
+          // (src/tests/pages/apps/review/review-{detail-page,queue-nav}.browser.test.tsx, from
+          // #3298 on main) `await import('~/pages/apps/review/[publishRequestId]')`, which pulls
+          // in `createServerSideProps` -> `appRouter` -> app-listing-assets.service.ts's
+          // `await import('sharp')`. Those tests `vi.mock` `server-side-helpers` so `sharp` is
+          // never evaluated at runtime — but esbuild's static scan follows the import anyway and
+          // can't pre-bundle sharp's native binding (a template-literal `require` of a `.node`
+          // file), failing the whole component project with "No loader is configured for '.node'
+          // files" regardless of which test you targeted. Exclude it; no component test needs it.
           exclude: ['sharp'],
         },
         test: {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -98,8 +98,8 @@ export default defineConfig({
           // `@vitest/browser` seeds optimizeDeps.entries from EVERY `*.browser.test.tsx` file
           // (globTestFiles), not just the one you ran. The review app-listing browser tests
           // (src/tests/pages/apps/review/review-{detail-page,queue-nav}.browser.test.tsx, from
-          // #3298 on main) `await import('~/pages/apps/review/[publishRequestId]')`, which pulls
-          // in `createServerSideProps` -> `appRouter` -> app-listing-assets.service.ts's
+          // #3298 on main) each import their page, which pulls in `createServerSideProps` ->
+          // `appRouter` -> app-listing-assets.service.ts's
           // `await import('sharp')`. Those tests `vi.mock` `server-side-helpers` so `sharp` is
           // never evaluated at runtime — but esbuild's static scan follows the import anyway and
           // can't pre-bundle sharp's native binding (a template-literal `require` of a `.node`


### PR DESCRIPTION
Implements items 1–5 of the 2026-07-22 walkthrough feedback on user challenges.

## What changed

**"Your Challenges" row now covers what you host, and shows the challenge**
The row only ever showed challenges you *entered*, using your own entry image as the card art. It now also returns challenges you *created*, and renders the challenge cover instead. `getMyParticipated` → `getMyChallenges` (widened SQL, `Scheduled` admitted, creator branch scoped to `source = 'User'`), `MyParticipatedChallengeItem` → `MyChallengeItem`, `myEnteredAt` → `myActivityAt`. New `hosting` state on `MyChallengeResult` with a crown badge and a status-dependent CTA — Scheduled → Manage, Active/judging → View entries, Completed → View results. Also fixes an upcoming challenge rendering "Ended in 5 days".

**One "Your Challenges" page instead of two**
`?engagement=created` ("My Challenges") and `?engagement=participated` ("Challenges You've Entered") were sibling early-return branches with different titles and no way between them. Now one page: Participated | Created on the left, status on the right, back arrow to `/challenges`. Status is clamped to the selected engagement on render, so no navigation path can query an impossible combination. Created opens on Scheduled, Participated on Active. The header menu item is relabelled to match.

**"Hosting" participation filter**
The filter group claimed "My Challenges" over options describing participation. Relabelled "Challenge Participation", plus a fourth option (enum `created`, shown as "Hosting").

**Create button on the Community Challenges header**
The only path to creating a challenge was the global Create menu, which opens the generator on click and is hover-only on mobile.

**Creator Score points at the real explanation**
All three callers now link to `/user/account#creator-score` — the card that already shows the total, the category breakdown, and per-category tooltips — and the one-paragraph modal is deleted. `StrikesCard`'s hash-scroll ref is generalized to serve both anchors; `#strikes` (used by strike emails) is unchanged and regression-checked.

**Unrelated but included:** `optimizeDeps.exclude: ['sharp']` on the component test project. Without it every `*.browser.test.tsx` fails on a cold dep cache — `@vitest/browser` seeds `optimizeDeps.entries` from *all* browser test files, and the review-app page tests added in #3298 drag `createServerSideProps` → `appRouter` → `sharp`'s native binding into esbuild's scan. This is a `main` regression; the branch just unblocks it.

## Not included

- **Prize pool not rendering on a Dynamic challenge** — investigated and deliberately dropped. The hypothesis was `buzzPerAction = 0` making `isDynamicPool` false; production has 24 Dynamic challenges and **none** with `buzzPerAction = 0`, and the challenge it was seen on was created locally through the testing API on an unreachable database. Needs a reproducing challenge id before a fix is worth shipping.
- **NSFW verdict → currency switch** — held by decision; `challenge-nsfw-escalation.ts` and friends are untouched.

## Verification

- `pnpm run typecheck` clean.
- `pnpm run test:unit:run` — 610 files, 7930 passed, 0 failed.
- `pnpm run test:component` — 712 passed, 12 failed, all in `PageBlockHost*` (AppBlocks). Pre-existing on `main`: that test's trpc mock lacks `publishGenerationOutputs`/`getImagesByIds`, which `PageBlockHost.tsx` began calling in ace6dcc25b.
- `pnpm run lint` crashes with an ESLint config `Converting circular structure to JSON` error — reproduced identically on `main`.
- Browser-verified: engagement/status interactions including browser-Back and refresh; the Create button at desktop and 360px; the Hosting filter (returned exactly the one Active/Scheduled challenge the DB says that user created); both `#creator-score` and `#strikes` cold-load hash scrolls.

## Known, pre-existing, not addressed here

Clicking an already-checked participation chip does not deselect it — radio semantics mean no `onChange` fires, so the toggle-off branch in `ChallengeFiltersDropdown` is dead in practice. This affects all four options equally, including ones that shipped long ago. "Clear all filters" is the working escape hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)