### PR TITLE
Rate-limit the BitDex reemit job so it can't over-fire

### DIFF
--- a/packages/civitai-telemetry/src/client.ts
+++ b/packages/civitai-telemetry/src/client.ts
@@ -255,6 +255,10 @@ export const reemitRunDurationHistogram = registerHistogram({
   help: 'Wall-clock duration of the BitDex publish re-emitter INSERT...SELECT emit statement',
   buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
 });
+export const reemitSkippedRateLimitCounter = registerCounter({
+  name: 'reemit_skipped_rate_limit_total',
+  help: 'BitDex publish re-emitter fires skipped by the self rate-limit because too little time has passed since the last successful emit (external scheduler over-firing)',
+});
 
 // Creator compensation metrics
 export const creatorCompCreatorsPaidCounter = registerCounterWithLabels({

--- a/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
+++ b/src/server/jobs/__tests__/reemit-bitdex-ops.test.ts
@@ -1,17 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockDbWrite, mockIsFlipt, mockCounters, mockHistogram } = vi.hoisted(() => ({
-  mockDbWrite: { $queryRaw: vi.fn() },
-  mockIsFlipt: vi.fn(),
-  mockCounters: {
-    attempts: { inc: vi.fn() },
-    runs: { inc: vi.fn() },
-    errors: { inc: vi.fn() },
-    posts: { inc: vi.fn() },
-    images: { inc: vi.fn() },
-  },
-  mockHistogram: { observe: vi.fn() },
-}));
+const { mockDbWrite, mockIsFlipt, mockCounters, mockHistogram, mockGetJobDate, mockSetLastRun } =
+  vi.hoisted(() => ({
+    mockDbWrite: { $queryRaw: vi.fn() },
+    mockIsFlipt: vi.fn(),
+    mockCounters: {
+      attempts: { inc: vi.fn() },
+      runs: { inc: vi.fn() },
+      errors: { inc: vi.fn() },
+      posts: { inc: vi.fn() },
+      images: { inc: vi.fn() },
+      skipped: { inc: vi.fn() },
+    },
+    mockHistogram: { observe: vi.fn() },
+    mockSetLastRun: vi.fn(() => Promise.resolve()),
+    mockGetJobDate: vi.fn(),
+  }));
 
 vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
 vi.mock('~/server/flipt/client', () => ({
@@ -26,13 +30,19 @@ vi.mock('~/server/prom/client', () => ({
   reemitPostsScannedCounter: mockCounters.posts,
   reemitImagesEmittedCounter: mockCounters.images,
   reemitRunDurationHistogram: mockHistogram,
+  reemitSkippedRateLimitCounter: mockCounters.skipped,
 }));
-// createJob just returns the body fn so the test can invoke it directly.
-vi.mock('~/server/jobs/job', () => ({ createJob: (_n: string, _c: string, fn: unknown) => fn }));
+// createJob just returns the body fn so the test can invoke it directly; getJobDate
+// is mocked so each test can pin the stored last-run time and observe the writer.
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (_n: string, _c: string, fn: unknown) => fn,
+  getJobDate: mockGetJobDate,
+}));
 
 import {
   buildReemitQuery,
   getReemitConfig,
+  getReemitMinIntervalSecs,
   reemitBitdexOps,
 } from '~/server/jobs/reemit-bitdex-ops';
 
@@ -42,11 +52,16 @@ beforeEach(() => {
   vi.clearAllMocks();
   delete process.env.REEMIT_LOOKBACK_SECS;
   delete process.env.REEMIT_SETTLE_SECS;
+  delete process.env.REEMIT_MIN_INTERVAL_SECS;
+  // Default: last emit was long ago (epoch) so the rate-limit never trips unless a
+  // test explicitly pins a recent last-run time.
+  mockGetJobDate.mockResolvedValue([new Date(0), mockSetLastRun]);
 });
 
 afterEach(() => {
   delete process.env.REEMIT_LOOKBACK_SECS;
   delete process.env.REEMIT_SETTLE_SECS;
+  delete process.env.REEMIT_MIN_INTERVAL_SECS;
 });
 
 describe('buildReemitQuery', () => {
@@ -101,6 +116,22 @@ describe('getReemitConfig', () => {
   });
 });
 
+describe('getReemitMinIntervalSecs', () => {
+  it('defaults to 270s (just under the */5 cadence)', () => {
+    expect(getReemitMinIntervalSecs()).toBe(270);
+  });
+
+  it('honors a positive env override', () => {
+    process.env.REEMIT_MIN_INTERVAL_SECS = '120';
+    expect(getReemitMinIntervalSecs()).toBe(120);
+  });
+
+  it('falls back to the default on invalid / non-positive values', () => {
+    process.env.REEMIT_MIN_INTERVAL_SECS = '0';
+    expect(getReemitMinIntervalSecs()).toBe(270);
+  });
+});
+
 describe('reemitBitdexOps job body', () => {
   it('no-ops when the Flipt flag is OFF (default-off gate)', async () => {
     mockIsFlipt.mockResolvedValue(false);
@@ -112,6 +143,39 @@ describe('reemitBitdexOps job body', () => {
     expect(mockCounters.attempts.inc).not.toHaveBeenCalled();
     expect(mockCounters.runs.inc).not.toHaveBeenCalled();
     expect(mockCounters.errors.inc).not.toHaveBeenCalled();
+    // The rate-limit did not trip (last run was long ago) and, since nothing was
+    // emitted, the last-run marker is left untouched.
+    expect(mockCounters.skipped.inc).not.toHaveBeenCalled();
+    expect(mockSetLastRun).not.toHaveBeenCalled();
+  });
+
+  it('skips (rate-limited) when the last emit is inside the min interval', async () => {
+    // Last successful emit was 60s ago — well inside the 270s default interval.
+    mockGetJobDate.mockResolvedValue([new Date(Date.now() - 60_000), mockSetLastRun]);
+    mockIsFlipt.mockResolvedValue(true);
+
+    await runJob();
+
+    // Skipped before the flag was even read; nothing emitted, marker untouched.
+    expect(mockCounters.skipped.inc).toHaveBeenCalledTimes(1);
+    expect(mockIsFlipt).not.toHaveBeenCalled();
+    expect(mockDbWrite.$queryRaw).not.toHaveBeenCalled();
+    expect(mockCounters.attempts.inc).not.toHaveBeenCalled();
+    expect(mockSetLastRun).not.toHaveBeenCalled();
+  });
+
+  it('runs once the min interval has elapsed and advances the last-run marker', async () => {
+    // Last emit was 5 minutes ago — past the 270s interval.
+    mockGetJobDate.mockResolvedValue([new Date(Date.now() - 300_000), mockSetLastRun]);
+    mockIsFlipt.mockResolvedValue(true);
+    mockDbWrite.$queryRaw.mockResolvedValue([{ postsScanned: 3, imagesEmitted: 12 }]);
+
+    await runJob();
+
+    expect(mockCounters.skipped.inc).not.toHaveBeenCalled();
+    expect(mockDbWrite.$queryRaw).toHaveBeenCalledTimes(1);
+    // The window advances only after a successful emit.
+    expect(mockSetLastRun).toHaveBeenCalledTimes(1);
   });
 
   it('emits once and records metrics from the returned counts when ON', async () => {
@@ -128,6 +192,7 @@ describe('reemitBitdexOps job body', () => {
     expect(mockCounters.posts.inc).toHaveBeenCalledWith(3);
     expect(mockCounters.images.inc).toHaveBeenCalledWith(12);
     expect(mockHistogram.observe).toHaveBeenCalledTimes(1);
+    expect(mockSetLastRun).toHaveBeenCalledTimes(1);
     expect(result).toMatchObject({ postsScanned: 3, imagesEmitted: 12 });
   });
 
@@ -144,5 +209,7 @@ describe('reemitBitdexOps job body', () => {
     expect(mockCounters.errors.inc).toHaveBeenCalledTimes(1);
     expect(mockCounters.runs.inc).not.toHaveBeenCalled();
     expect(mockHistogram.observe).not.toHaveBeenCalled();
+    // A failed emit must NOT advance the rate-limit window — the next fire retries.
+    expect(mockSetLastRun).not.toHaveBeenCalled();
   });
 });

--- a/src/server/jobs/reemit-bitdex-ops.ts
+++ b/src/server/jobs/reemit-bitdex-ops.ts
@@ -9,8 +9,9 @@ import {
   reemitPostsScannedCounter,
   reemitRunDurationHistogram,
   reemitRunsCounter,
+  reemitSkippedRateLimitCounter,
 } from '~/server/prom/client';
-import { createJob } from './job';
+import { createJob, getJobDate } from './job';
 
 // BitDex publish re-emitter: a periodic job that re-asserts the per-image publish
 // values and ingested sortAt for every image whose parent Post was published in the
@@ -21,6 +22,18 @@ import { createJob } from './job';
 const DEFAULT_LOOKBACK_SECS = 15 * 60;
 const DEFAULT_SETTLE_SECS = 10; // must stay << lookback
 const CADENCE_CRON = '*/5 * * * *';
+
+// The job body is written for the */5 cadence above, but the external scheduler
+// currently fires it every 1-2 minutes. Each fire emits 600-1300 same-value ops
+// that BitDex has to churn through bucket-maintenance for, so an over-firing
+// scheduler amplifies load with no healing benefit. A little under the cron
+// period so a run that lands slightly early on the intended */5 tick still passes.
+const DEFAULT_MIN_INTERVAL_SECS = 270;
+
+// keyValue key holding the epoch-ms of the last successful emit. Shared across
+// pods (DB-backed), so the rate-limit spaces out emits fleet-wide, not per pod —
+// the cross-pod run lock only serializes concurrent runs, it does not space them.
+const REEMIT_LAST_RUN_KEY = 'reemit-bitdex-ops:last-run';
 
 function parsePositiveSecs(raw: string | undefined, fallback: number): number {
   const n = parseInt(raw ?? '', 10);
@@ -35,6 +48,12 @@ export function getReemitConfig(): ReemitConfig {
     lookbackSecs: parsePositiveSecs(process.env.REEMIT_LOOKBACK_SECS, DEFAULT_LOOKBACK_SECS),
     settleSecs: parsePositiveSecs(process.env.REEMIT_SETTLE_SECS, DEFAULT_SETTLE_SECS),
   };
+}
+
+// Kept separate from ReemitConfig so the SQL builder and its tests stay untouched;
+// this knob only gates whether the job runs, it is not part of the emit statement.
+export function getReemitMinIntervalSecs(): number {
+  return parsePositiveSecs(process.env.REEMIT_MIN_INTERVAL_SECS, DEFAULT_MIN_INTERVAL_SECS);
 }
 
 export type ReemitResult = { postsScanned: number; imagesEmitted: number };
@@ -87,6 +106,17 @@ export const reemitBitdexOps = createJob(
   'reemit-bitdex-ops',
   CADENCE_CRON,
   async () => {
+    // Self rate-limit, ahead of the flag check: an over-firing scheduler is
+    // wasteful whether or not the feature is on, and lastRun is only written
+    // after a successful emit — so the skip can only ever trip while enabled.
+    const minIntervalSecs = getReemitMinIntervalSecs();
+    const [lastRun, setLastRun] = await getJobDate(REEMIT_LAST_RUN_KEY);
+    const sinceLastRunSecs = (Date.now() - lastRun.getTime()) / 1000;
+    if (sinceLastRunSecs < minIntervalSecs) {
+      reemitSkippedRateLimitCounter?.inc();
+      return;
+    }
+
     // Default-off: registered and scheduled but no-ops until the flag is flipped on.
     const enabled = await isFlipt(FLIPT_FEATURE_FLAGS.BITDEX_PUBLISH_REEMITTER);
     if (!enabled) return;
@@ -106,6 +136,10 @@ export const reemitBitdexOps = createJob(
       throw e; // createJob logs job-error to Axiom and marks the run failed
     }
     const durationSec = (Date.now() - start) / 1000;
+
+    // Only a successful emit advances the rate-limit window: a failed run leaves
+    // lastRun untouched so the next fire can retry immediately instead of waiting.
+    await setLastRun();
 
     reemitRunsCounter?.inc();
     reemitPostsScannedCounter?.inc(postsScanned);


### PR DESCRIPTION
## What

Adds a self rate-limit to the `reemit-bitdex-ops` job so it emits at most once per ~4.5 minutes regardless of how often the scheduler fires it.

## Why

The job is written for a `*/5` cadence, but the external scheduler currently fires it every 1-2 minutes. Every fire emits 600-1300 same-value ops that BitDex then has to grind through bucket-maintenance for. When the values are already correct (the normal case) that heals nothing — it's pure load, and it's a confirmed production amplifier for the cache-shuffle symptom we've been chasing.

The existing cross-pod Redis run-lock only stops two runs from overlapping. It releases at the end of each run, so it does nothing to space runs out — back-to-back fires each grab the lock cleanly and emit.

## How

Before the flag check, the job now:

- reads the last successful-emit time from the shared `keyValue` store (the same `getJobDate` idiom other jobs use for cursors), and
- returns early if less than `REEMIT_MIN_INTERVAL_SECS` has passed (default **270s**, just under the `*/5` period, env-overridable).

Details:

- The marker is DB-backed, so the limit spaces emits across the whole fleet, not per pod.
- It advances **only after a successful emit**, so a failed run leaves the window open and the next fire retries immediately.
- A new `reemit_skipped_rate_limit_total` counter increments on each skipped fire, so the scheduler's over-firing stays visible in metrics.

## Tests

Extended the existing vitest suite: rate-limit skip path (within interval), normal run path (interval elapsed + marker advanced), the min-interval env override, and confirmation that a failed emit does not advance the marker. All 16 tests green.