### PR TITLE
perf(creator-controls): flag-gate read-time metric-privacy resolution (default ON)

### DIFF
--- a/src/server/__tests__/model-metric-privacy.test.ts
+++ b/src/server/__tests__/model-metric-privacy.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   anyMetricHidden,
+  gateHiddenMetrics,
   getMetaMetricPrivacy,
   getUserMetricPrivacyDefaults,
+  noHiddenMetrics,
   resolveModelHiddenMetrics,
   resolveVersionHiddenMetrics,
 } from '~/server/utils/model-metric-privacy';
@@ -195,5 +197,60 @@ describe('anyMetricHidden', () => {
   it('true when any flag set, false otherwise', () => {
     expect(anyMetricHidden(NONE)).toBe(false);
     expect(anyMetricHidden({ buzz: false, downloads: true, generations: false })).toBe(true);
+  });
+});
+
+describe('noHiddenMetrics', () => {
+  it('returns an all-visible result', () => {
+    expect(noHiddenMetrics()).toEqual(NONE);
+  });
+
+  it('returns a FRESH object each call (no shared mutable ref)', () => {
+    const a = noHiddenMetrics();
+    const b = noHiddenMetrics();
+    expect(a).not.toBe(b);
+    a.downloads = true; // mutating one must not affect the other
+    expect(b.downloads).toBe(false);
+  });
+});
+
+/**
+ * Read-time flag gate (`modelMetricPrivacyReadtime`). This is the choke-point every
+ * gated surface (getModel / associated-resources / browse feed) uses to select
+ * between running #3266's metric-privacy resolution (flag ON) and skipping it
+ * entirely (flag OFF). ON must be byte-identical to calling the resolver directly;
+ * OFF must NOT invoke the resolver and must emit raw (all-visible) metrics.
+ */
+describe('gateHiddenMetrics — read-time flag gate', () => {
+  it('ON: runs the resolver and returns its result unchanged (current behaviour)', () => {
+    const resolve = vi.fn(() =>
+      resolveModelHiddenMetrics({
+        modelMeta: { hideDownloads: true },
+        isOwnerOrModerator: false,
+        hasValidMembership: true,
+      })
+    );
+    const result = gateHiddenMetrics(true, resolve);
+    expect(resolve).toHaveBeenCalledTimes(1); // resolution IS invoked when ON
+    expect(result).toEqual({ buzz: false, downloads: true, generations: false });
+  });
+
+  it('OFF: does NOT invoke the resolver and returns raw all-visible metrics', () => {
+    const resolve = vi.fn(() =>
+      resolveModelHiddenMetrics({
+        modelMeta: ALL_HIDDEN, // would hide everything if it ran
+        isOwnerOrModerator: false,
+        hasValidMembership: true,
+      })
+    );
+    const result = gateHiddenMetrics(false, resolve);
+    expect(resolve).not.toHaveBeenCalled(); // the whole resolution is skipped
+    expect(result).toEqual(NONE); // raw metrics — nothing hidden (pre-#3266)
+  });
+
+  it('OFF path returns a fresh object (parity with the resolver contract)', () => {
+    const a = gateHiddenMetrics(false, () => noHiddenMetrics());
+    const b = gateHiddenMetrics(false, () => noHiddenMetrics());
+    expect(a).not.toBe(b);
   });
 });

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -18,6 +18,7 @@ import {
 } from '~/server/services/creator-program.service';
 import {
   anyMetricHidden,
+  gateHiddenMetrics,
   getUserMetricPrivacyDefaults,
   resolveModelHiddenMetrics,
   resolveVersionHiddenMetrics,
@@ -296,9 +297,13 @@ export const getModelHandler = async ({
 
     // Creator Controls metric privacy: resolve once per request. Owners/mods bypass;
     // otherwise flags apply only while the owner holds a valid CP membership.
+    // Flag-gated (#3266 A/B): when `modelMetricPrivacyReadtime` is OFF, skip the
+    // owner-settings + membership lookups AND the resolvers entirely and emit raw
+    // metrics. Evaluated ONCE per request off the memoized per-request flag object.
+    const metricPrivacyEnabled = !!features.modelMetricPrivacyReadtime;
     let ownerSettings: unknown = null;
     let ownerHasMembership = false;
-    if (!isOwner) {
+    if (metricPrivacyEnabled && !isOwner) {
       const [owner, membership] = await Promise.all([
         dbRead.user.findUnique({ where: { id: model.user.id }, select: { settings: true } }),
         hasValidCreatorMembership(model.user.id),
@@ -306,12 +311,14 @@ export const getModelHandler = async ({
       ownerSettings = owner?.settings ?? null;
       ownerHasMembership = membership;
     }
-    const modelHidden = resolveModelHiddenMetrics({
-      modelMeta: model.meta,
-      userSettings: ownerSettings,
-      isOwnerOrModerator: isOwner,
-      hasValidMembership: ownerHasMembership,
-    });
+    const modelHidden = gateHiddenMetrics(metricPrivacyEnabled, () =>
+      resolveModelHiddenMetrics({
+        modelMeta: model.meta,
+        userSettings: ownerSettings,
+        isOwnerOrModerator: isOwner,
+        hasValidMembership: ownerHasMembership,
+      })
+    );
     const hideIf = (hidden: boolean, value: number) => (hidden ? null : value);
 
     const mappedVersions = filteredVersions.map((version) => {
@@ -367,13 +374,15 @@ export const getModelHandler = async ({
 
       const versionMetrics = version.metrics[0];
 
-      const versionHidden = resolveVersionHiddenMetrics({
-        versionMeta: version.meta,
-        modelMeta: model.meta,
-        userSettings: ownerSettings,
-        isOwnerOrModerator: isOwner,
-        hasValidMembership: ownerHasMembership,
-      });
+      const versionHidden = gateHiddenMetrics(metricPrivacyEnabled, () =>
+        resolveVersionHiddenMetrics({
+          versionMeta: version.meta,
+          modelMeta: model.meta,
+          userSettings: ownerSettings,
+          isOwnerOrModerator: isOwner,
+          hasValidMembership: ownerHasMembership,
+        })
+      );
 
       return {
         ...version,
@@ -501,6 +510,9 @@ export const getModelsInfiniteHandler = async ({
     // applies either way (see model-getall-images).
     const slim = ctx.features.getAllModelImagesSlim;
     const imagesPerModel = slim ? GET_ALL_IMAGES_PER_MODEL_SLIM : GET_ALL_IMAGES_PER_MODEL;
+    // Flag-gated (#3266 A/B): pass the once-per-request `modelMetricPrivacyReadtime`
+    // value so the feed-hydration path skips the metric-privacy resolution when OFF.
+    const metricPrivacyEnabled = !!ctx.features.modelMetricPrivacyReadtime;
     const results: Awaited<ReturnType<typeof getModelsWithImagesAndModelVersions>>['items'] = [];
     while (results.length < (input.limit ?? 100) && loopCount < 3) {
       const result = await getModelsWithImagesAndModelVersions({
@@ -508,6 +520,7 @@ export const getModelsInfiniteHandler = async ({
         user: ctx.user,
         imagesPerModel,
         biasImageSlice: slim,
+        metricPrivacyEnabled,
       });
       if (result.isPrivate) isPrivate = true;
       results.push(...result.items);
@@ -1603,26 +1616,34 @@ export const getAssociatedResourcesCardDataHandler = async ({
       }
     );
 
+    // Flag-gated (#3266 A/B): when `modelMetricPrivacyReadtime` is OFF, skip the
+    // batched owner-settings query + `getValidCreatorMembershipMap` and emit raw
+    // metrics. Evaluated once per request off the memoized per-request flag object.
+    const metricPrivacyEnabled = !!ctx.features.modelMetricPrivacyReadtime;
     const assocIsMod = !!user?.isModerator;
-    const assocOwnerIds = [...new Set(models.map((m) => m.user.id))];
-    const assocOwnerSettings = assocOwnerIds.length
-      ? await dbRead.user.findMany({
-          where: { id: { in: assocOwnerIds } },
-          select: { id: true, settings: true },
-        })
-      : [];
-    const assocOwnerSettingsMap = new Map<number, unknown>(
-      assocOwnerSettings.map((o) => [o.id, o.settings])
-    );
-    const assocMembershipCandidates = new Set<number>();
-    for (const m of models) {
-      const ownerId = m.user.id;
-      if (assocIsMod || ownerId === user?.id) continue;
-      const defHidden = getUserMetricPrivacyDefaults(assocOwnerSettingsMap.get(ownerId));
-      if (anyMetricHidden(m.metricPrivacy) || anyMetricHidden(defHidden))
-        assocMembershipCandidates.add(ownerId);
+    let assocOwnerSettingsMap = new Map<number, unknown>();
+    let assocMembershipMap = new Map<number, boolean>();
+    if (metricPrivacyEnabled) {
+      const assocOwnerIds = [...new Set(models.map((m) => m.user.id))];
+      const assocOwnerSettings = assocOwnerIds.length
+        ? await dbRead.user.findMany({
+            where: { id: { in: assocOwnerIds } },
+            select: { id: true, settings: true },
+          })
+        : [];
+      assocOwnerSettingsMap = new Map<number, unknown>(
+        assocOwnerSettings.map((o) => [o.id, o.settings])
+      );
+      const assocMembershipCandidates = new Set<number>();
+      for (const m of models) {
+        const ownerId = m.user.id;
+        if (assocIsMod || ownerId === user?.id) continue;
+        const defHidden = getUserMetricPrivacyDefaults(assocOwnerSettingsMap.get(ownerId));
+        if (anyMetricHidden(m.metricPrivacy) || anyMetricHidden(defHidden))
+          assocMembershipCandidates.add(ownerId);
+      }
+      assocMembershipMap = await getValidCreatorMembershipMap([...assocMembershipCandidates]);
     }
-    const assocMembershipMap = await getValidCreatorMembershipMap([...assocMembershipCandidates]);
 
     const completeModels = models
       .map(({ hashes, modelVersions, rank, tagsOnModels, metricPrivacy, ...model }) => {
@@ -1636,16 +1657,18 @@ export const getAssociatedResourcesCardDataHandler = async ({
         const canGenerate = associatedGenStates.get(version.id)?.canGenerate ?? false;
 
         const isOwner = assocIsMod || model.user.id === user?.id;
-        const hiddenMetrics = resolveModelHiddenMetrics({
-          modelMeta: {
-            hideBuzz: metricPrivacy.buzz,
-            hideDownloads: metricPrivacy.downloads,
-            hideGenerations: metricPrivacy.generations,
-          },
-          userSettings: assocOwnerSettingsMap.get(model.user.id),
-          isOwnerOrModerator: isOwner,
-          hasValidMembership: assocMembershipMap.get(model.user.id) ?? false,
-        });
+        const hiddenMetrics = gateHiddenMetrics(metricPrivacyEnabled, () =>
+          resolveModelHiddenMetrics({
+            modelMeta: {
+              hideBuzz: metricPrivacy.buzz,
+              hideDownloads: metricPrivacy.downloads,
+              hideGenerations: metricPrivacy.generations,
+            },
+            userSettings: assocOwnerSettingsMap.get(model.user.id),
+            isOwnerOrModerator: isOwner,
+            hasValidMembership: assocMembershipMap.get(model.user.id) ?? false,
+          })
+        );
 
         return {
           ...model,

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -300,6 +300,23 @@ const featureFlags = createFeatureFlags({
   // card is hidden. Instant kill-switch / widen lever = the Flipt flag. (Mirrors the
   // `hiddenPrefsCompact` / `genTabDeferView` `availability: []` precedent.)
   creatorControls: { availability: [], fliptKey: 'creator-controls' },
+  // Read-time gate for the Creator-Controls metric-privacy RESOLUTION (#3266): the
+  // per-request synchronous work that hides a CP member's model/version metrics —
+  // the batched `getValidCreatorMembershipMap` (a `subscriptionProductMetadataSchema`
+  // Zod parse per subscription), the owner-settings lookups, and the per-item
+  // `resolveModel/VersionHiddenMetrics`. Default ON: `availability: ['public']` keeps
+  // it enabled for everyone AND fails OPEN (ON) when Flipt is absent/down, so merging
+  // + releasing is a pure no-op — the privacy feature keeps working exactly as today.
+  // Flipt is authoritative when the `model-metric-privacy-readtime` flag exists:
+  // flipping it OFF makes every gated read path SKIP that work entirely and return the
+  // RAW (pre-#3266) metrics, for a controlled A/B of its request-path cost. OFF briefly
+  // re-exposes CP members' hidden metrics for the test window (accepted, keep it short).
+  // NOT `[]`: that would fail CLOSED and default the feature off. (Mirrors the
+  // `challengePlatform` / `animaControlnet` `['public']` + fliptKey fail-open precedent.)
+  modelMetricPrivacyReadtime: {
+    availability: ['public'],
+    fliptKey: 'model-metric-privacy-readtime',
+  },
   imageIndexFeed: { availability: ['public'], fliptKey: 'image-index-feed' },
   // #region [Domain Specific Features]
   isGreen: ['public', 'green'],

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -119,6 +119,7 @@ import { bustFetchThroughCache, fetchThroughCache } from '~/server/utils/cache-h
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import {
   anyMetricHidden,
+  gateHiddenMetrics,
   getMetaMetricPrivacy,
   getUserMetricPrivacyDefaults,
   resolveModelHiddenMetrics,
@@ -1343,11 +1344,18 @@ export const getModelsWithImagesAndModelVersions = async ({
   // When true (flag-ON browse feed only) pick the nsfw-biased coverage slice instead
   // of the naive first-`imagesPerModel`, so reducing the count adds ~zero feed drops.
   biasImageSlice = false,
+  // Read-time Creator-Controls metric-privacy gate (#3266 A/B). DEFAULTS TRUE so
+  // callers that don't thread it (home blocks, collections) keep today's behavior;
+  // the browse-feed controller passes the once-per-request `modelMetricPrivacyReadtime`
+  // flag. When false, the per-request owner-settings + membership work below is
+  // skipped and raw metrics are emitted (pre-#3266 visibility).
+  metricPrivacyEnabled = true,
 }: {
   input: GetAllModelsOutput;
   user?: SessionUser;
   imagesPerModel?: number;
   biasImageSlice?: boolean;
+  metricPrivacyEnabled?: boolean;
 }) => {
   input.limit = input.limit ?? 100;
 
@@ -1411,26 +1419,33 @@ export const getModelsWithImagesAndModelVersions = async ({
   // Creator Controls metric privacy for the card feed. Fetch owner defaults once,
   // then only resolve CP membership for owners who actually have a hide flag set
   // (keeps the common no-flags case free of membership lookups).
+  // Flag-gated (#3266 A/B): when `metricPrivacyEnabled` is false the whole batched
+  // owner-settings + `getValidCreatorMembershipMap` block is skipped and raw metrics
+  // are emitted (pre-#3266 visibility).
   const isMod = !!user?.isModerator;
-  const feedOwnerIds = [...new Set(items.map((m) => m.user.id))];
-  const feedOwnerSettings = feedOwnerIds.length
-    ? await dbRead.user.findMany({
-        where: { id: { in: feedOwnerIds } },
-        select: { id: true, settings: true },
-      })
-    : [];
-  const feedOwnerSettingsMap = new Map<number, unknown>(
-    feedOwnerSettings.map((o) => [o.id, o.settings])
-  );
-  const membershipCandidates = new Set<number>();
-  for (const it of items) {
-    const ownerId = it.user.id;
-    if (isMod || ownerId === user?.id) continue;
-    const defHidden = getUserMetricPrivacyDefaults(feedOwnerSettingsMap.get(ownerId));
-    if (anyMetricHidden(it.metricPrivacy) || anyMetricHidden(defHidden))
-      membershipCandidates.add(ownerId);
+  let feedOwnerSettingsMap = new Map<number, unknown>();
+  let feedMembershipMap = new Map<number, boolean>();
+  if (metricPrivacyEnabled) {
+    const feedOwnerIds = [...new Set(items.map((m) => m.user.id))];
+    const feedOwnerSettings = feedOwnerIds.length
+      ? await dbRead.user.findMany({
+          where: { id: { in: feedOwnerIds } },
+          select: { id: true, settings: true },
+        })
+      : [];
+    feedOwnerSettingsMap = new Map<number, unknown>(
+      feedOwnerSettings.map((o) => [o.id, o.settings])
+    );
+    const membershipCandidates = new Set<number>();
+    for (const it of items) {
+      const ownerId = it.user.id;
+      if (isMod || ownerId === user?.id) continue;
+      const defHidden = getUserMetricPrivacyDefaults(feedOwnerSettingsMap.get(ownerId));
+      if (anyMetricHidden(it.metricPrivacy) || anyMetricHidden(defHidden))
+        membershipCandidates.add(ownerId);
+    }
+    feedMembershipMap = await getValidCreatorMembershipMap([...membershipCandidates]);
   }
-  const feedMembershipMap = await getValidCreatorMembershipMap([...membershipCandidates]);
   const toMetaShape = (h: HiddenModelMetrics) => ({
     hideBuzz: h.buzz,
     hideDownloads: h.downloads,
@@ -1464,12 +1479,14 @@ export const getModelsWithImagesAndModelVersions = async ({
           isBaseModelGenerationSupported(version.baseModel, model.type);
 
         const isOwner = isMod || model.user.id === user?.id;
-        const modelHidden = resolveModelHiddenMetrics({
-          modelMeta: toMetaShape(metricPrivacy),
-          userSettings: feedOwnerSettingsMap.get(model.user.id),
-          isOwnerOrModerator: isOwner,
-          hasValidMembership: feedMembershipMap.get(model.user.id) ?? false,
-        });
+        const modelHidden = gateHiddenMetrics(metricPrivacyEnabled, () =>
+          resolveModelHiddenMetrics({
+            modelMeta: toMetaShape(metricPrivacy),
+            userSettings: feedOwnerSettingsMap.get(model.user.id),
+            isOwnerOrModerator: isOwner,
+            hasValidMembership: feedMembershipMap.get(model.user.id) ?? false,
+          })
+        );
 
         return {
           ...model,

--- a/src/server/utils/model-metric-privacy.ts
+++ b/src/server/utils/model-metric-privacy.ts
@@ -26,6 +26,40 @@ export type HiddenModelMetrics = { buzz: boolean; downloads: boolean; generation
 
 const NONE_HIDDEN: HiddenModelMetrics = { buzz: false, downloads: false, generations: false };
 
+/**
+ * A fresh, fully-visible ("nothing hidden") result. Returned by the read-time gate
+ * (`gateHiddenMetrics`) when the `modelMetricPrivacyReadtime` flag is OFF, so a
+ * gated surface emits its RAW metrics without running any membership / resolver
+ * work. Always a NEW object (never the shared `NONE_HIDDEN` ref) to match the
+ * fresh-object contract of `resolveModel/VersionHiddenMetrics`.
+ */
+export const noHiddenMetrics = (): HiddenModelMetrics => ({
+  buzz: false,
+  downloads: false,
+  generations: false,
+});
+
+/**
+ * Read-time flag gate for the Creator-Controls metric-privacy resolution.
+ *
+ * When `enabled` is true the caller's `resolve` thunk runs and its result is
+ * returned UNCHANGED (byte-identical to calling the resolver directly). When
+ * `enabled` is false the thunk is NOT invoked at all — no resolver, and (because
+ * the caller only builds the resolver's inputs inside a matching `if (enabled)`
+ * guard) none of the batched membership / owner-settings lookups either — and a
+ * fresh all-visible result is returned (raw metrics, i.e. pre-#3266 visibility).
+ *
+ * This is the single choke-point that lets `modelMetricPrivacyReadtime` be flipped
+ * OFF to skip #3266's added synchronous read-time work for a controlled A/B.
+ */
+export function gateHiddenMetrics(
+  enabled: boolean,
+  resolve: () => HiddenModelMetrics
+): HiddenModelMetrics {
+  if (!enabled) return noHiddenMetrics();
+  return resolve();
+}
+
 /** Whether any of the three metrics is hidden. */
 export const anyMetricHidden = (hidden: HiddenModelMetrics) =>
   hidden.buzz || hidden.downloads || hidden.generations;


### PR DESCRIPTION
## What

Puts the **read-time Creator-Controls metric-privacy resolution added in #3266**
behind a new Flipt feature flag, **`modelMetricPrivacyReadtime`** (Flipt key
`model-metric-privacy-readtime`), so we can measure that resolution's
request-path cost with a clean on/off A/B.

**Default ON — merging + releasing is a pure no-op.** The privacy feature keeps
working exactly as it does today until someone flips the Flipt flag off.

## Why

#3266 added synchronous work to model hydration on read: a batched
`getValidCreatorMembershipMap` (which runs a `subscriptionProductMetadataSchema`
Zod parse per subscription), per-non-owner `hasValidCreatorMembership`, owner-
settings lookups, and per-item `resolveModel/VersionHiddenMetrics`. Because that
cost is spread across hydration rather than isolated in one frame, a profiler
can't cleanly attribute it. A flag that toggles the whole resolution on/off lets
us A/B the request-path cost directly and either confirm or exonerate it.

## Design

- **Flag:** `modelMetricPrivacyReadtime: { availability: ['public'], fliptKey:
  'model-metric-privacy-readtime' }`.
  - `['public']` = enabled for everyone **and fails OPEN (ON)** when Flipt is
    absent/down, so this is a no-op on merge/release (mirrors the
    `challengePlatform` / `animaControlnet` fail-open precedent — *not* the
    fail-closed `[]` pattern).
  - Flipt is authoritative when the `model-metric-privacy-readtime` flag exists;
    flipping it off is the only thing that changes behaviour.
- **Evaluated once per request** off the memoized per-request feature-flag object
  (`ctx.features` / threaded boolean). No per-model/version/owner flag lookups.
- **ON** → every gated path runs the existing resolution unchanged (byte-identical
  output).
- **OFF** → the batched membership map, the Zod parses, the owner-settings
  queries, `hasValidCreatorMembership`, and the per-item resolvers are **skipped
  entirely**; the gated paths return the raw (pre-#3266) metrics.
- **Central choke-point:** `gateHiddenMetrics(enabled, resolve)` in
  `utils/model-metric-privacy.ts` — returns the resolver result when ON, a fresh
  all-visible result (`noHiddenMetrics()`) when OFF.

## Gated read paths

| Path | File |
|---|---|
| `getModelHandler` (`model.getById`) | `server/controllers/model.controller.ts` |
| `getAssociatedResourcesCardDataHandler` | `server/controllers/model.controller.ts` |
| browse feed `getModelsWithImagesAndModelVersions` (`model.getAll`) | `server/services/model.service.ts` (threaded from `getModelsInfiniteHandler`) |

The feed helper takes a `metricPrivacyEnabled` param that **defaults to `true`**,
so its other callers (home blocks, collections) keep today's behaviour; only the
browse-feed controller threads the flag.

**Not gated (deliberately, see below):** the v1 REST model/version routes and the
OG-image endpoint (edge/origin response-cached, so the resolution is amortised and
not instantly reversible), the donation-goals cache lookup (a *shared* public
cache — a per-request flag can't coherently gate shared cached state without
changing the cache key), and the search-index build (write-time, not a read path).
These can be added if the A/B on the paths above is inconclusive.

## Tests

Unit tests in `server/__tests__/model-metric-privacy.test.ts` (mirrors the
existing style):

- `noHiddenMetrics()` returns an all-visible, freshly-allocated result.
- `gateHiddenMetrics` **ON** → invokes the resolver and returns its result
  (metrics hidden per current behaviour).
- `gateHiddenMetrics` **OFF** → resolver is **not** invoked (spy asserts it) and
  raw all-visible metrics are returned.

## Behaviour trade

Flipping the flag OFF briefly re-exposes Creator-Program members' hidden metrics
for the measurement window. That is the accepted, instantly-reversible trade for a
clean A/B — keep the OFF window short.

## Notes

- Do **not** merge — this is a measurement/review artifact.
- No caches, batching, or schema were changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
